### PR TITLE
fix: assistant file display in temporary chats

### DIFF
--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -31,6 +31,7 @@ import {
   extractWebSourcesFromMessage,
 } from "@/lib/utils/message-utils";
 import type { ChatStatus, ChatMessage } from "@/types";
+import type { FileDetails } from "@/types/file";
 import { toast } from "sonner";
 import { FileSearch } from "lucide-react";
 
@@ -54,6 +55,7 @@ interface MessagesProps {
   loadMore?: (numItems: number) => void;
   isSwitchingChats?: boolean;
   isTemporaryChat?: boolean;
+  tempChatFileDetails?: Map<string, FileDetails[]>;
   finishReason?: string;
   uploadStatus?: { message: string; isUploading: boolean } | null;
   mode?: "ask" | "agent";
@@ -78,6 +80,7 @@ export const Messages = ({
   loadMore,
   isSwitchingChats,
   isTemporaryChat,
+  tempChatFileDetails,
   finishReason,
   uploadStatus,
   mode,
@@ -291,12 +294,19 @@ export const Messages = ({
               status === "streaming" &&
               !messageHasTextContent;
 
+            // Merge fileDetails from parallel state for temporary chats
+            const effectiveFileDetails = !isUser
+              ? message.fileDetails ||
+                tempChatFileDetails?.get(message.id) ||
+                undefined
+              : undefined;
+
             // Get saved files for assistant messages (include files with url, storageId, or s3Key)
             const savedFiles =
               !isUser &&
               (isLastAssistantMessage ? status !== "streaming" : true) &&
-              message.fileDetails
-                ? message.fileDetails.filter(
+              effectiveFileDetails
+                ? effectiveFileDetails.filter(
                     (f) => f.url || f.storageId || f.s3Key,
                   )
                 : [];

--- a/convex/s3Utils.ts
+++ b/convex/s3Utils.ts
@@ -47,11 +47,11 @@ export function getS3Client(): S3Client {
 export function generateS3Key(userId: string, fileName: string): string {
   const timestamp = Date.now();
   const uuid = uuidv4();
-  
+
   // Extract file extension, default to empty string if none
   const lastDotIndex = fileName.lastIndexOf(".");
   const extension = lastDotIndex !== -1 ? fileName.substring(lastDotIndex) : "";
-  
+
   return `${S3_USER_FILES_PREFIX}/${userId}/${timestamp}-${uuid}${extension}`;
 }
 

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -1,6 +1,7 @@
 import { UIMessage } from "ai";
 import { z } from "zod";
 import { Id } from "@/convex/_generated/dataModel";
+import type { FileDetails } from "./file";
 
 export type ChatMode = "agent" | "ask";
 
@@ -81,14 +82,7 @@ export const messageMetadataSchema = z.object({
 export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
 
 export type ChatMessage = UIMessage<MessageMetadata> & {
-  fileDetails?: Array<{
-    fileId: Id<"files">;
-    name: string;
-    mediaType?: string;
-    url?: string | null;
-    storageId?: string;
-    s3Key?: string;
-  }>;
+  fileDetails?: FileDetails[];
   sourceMessageId?: string;
 };
 

--- a/types/file.ts
+++ b/types/file.ts
@@ -79,3 +79,13 @@ export interface ProcessFileOptions {
   prepend?: string; // For markdown files
   fileName?: string; // For file type detection (e.g., .doc vs .docx)
 }
+
+// File details type for assistant-generated files in messages
+export interface FileDetails {
+  fileId: Id<"files">;
+  name: string;
+  mediaType?: string;
+  url?: string | null;
+  storageId?: string;
+  s3Key?: string;
+}


### PR DESCRIPTION
## Problem

Assistant-generated files (from sandbox/terminal) were not displaying in temporary chats, despite working correctly in regular chats.

## Root Cause

Temporary chats bypass database persistence for privacy, but the file display mechanism depended on database-sourced `fileDetails`. Custom stream data needs to be stored outside the AI SDK's message state to persist through the streaming lifecycle.

## Solution

Implemented **parallel state storage** for temporary chat file metadata:

1. **Backend**: Stream file metadata via custom `data-file-metadata` event  
2. **Frontend**: Store metadata in separate `Map` state  
3. **Render**: Merge file metadata from database or parallel state

## Implementation

### Backend (`lib/api/chat-handler.ts`)
- Fetch file metadata in batch for temporary chats
- Stream via custom `data-file-metadata` event in `onFinish` callback

### Frontend (`app/components/chat.tsx`)
- Add `tempChatFileDetails` Map state for temporary chat file metadata
- Handle `data-file-metadata` event to populate the Map

### Render (`app/components/Messages.tsx`)
- Merge fileDetails from database (regular chats) OR parallel state (temp chats)
- Display files with `url`, `storageId`, or `s3Key`

### Supporting Changes
- **convex/fileStorage.ts**: Added `getFileMetadataByFileIds` query
- **types/file.ts**: Created shared `FileDetails` interface
- **types/chat.ts**: Used shared type for consistency

## Why Parallel State?

The AI SDK manages message state internally through its streaming lifecycle. To ensure custom data persists throughout this process, we store it separately and merge during render. This keeps concerns separated - the AI SDK handles messages, our state handles supplemental metadata.

## Testing

- ✅ Files display correctly in temporary chats
- ✅ Regular chats still work (database-backed fileDetails)  
- ✅ All tests passing (108 passed)
- ✅ ESLint & TypeScript checks passing

## Technical Notes

**Stream Lifecycle:**
1. `execute` callback runs → creates stream
2. AI model generates response  
3. `onFinish` callback runs → fetches file metadata → sends custom event
4. Frontend receives event → stores in parallel Map
5. Component renders → merges data from Map

This pattern ensures data persistence regardless of the AI SDK's internal state management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced file metadata handling for temporary chats, enabling proper file details retrieval in non-user conversations.
  * Implemented batch file metadata fetching for improved performance and reliability.

* **Improvements**
  * Optimized file information lookup across chat types with fallback support for temporary chat file data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->