### PR TITLE
fix(billing): prevent subscription loss on failed upgrade payment

### DIFF
--- a/app/api/subscription-details/route.ts
+++ b/app/api/subscription-details/route.ts
@@ -223,6 +223,7 @@ export const POST = async (req: NextRequest) => {
               ],
               proration_behavior: "always_invoice",
               proration_date: Math.floor(Date.now() / 1000),
+              payment_behavior: "pending_if_incomplete",
             },
           );
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:e2e:users:delete": "npx tsx scripts/create-test-users.ts delete",
     "test:e2e:users:reset-passwords": "npx tsx scripts/create-test-users.ts reset-passwords",
     "rate-limit:reset": "npx tsx scripts/reset-rate-limit.ts",
+    "stripe:attach-failing-card": "npx tsx scripts/attach-failing-card.ts",
     "prepare": "husky",
     "s3:validate": "npx ts-node scripts/validate-s3-security.ts",
     "e2b:build:dev": "npx tsx e2b/build.dev.ts",

--- a/scripts/attach-failing-card.ts
+++ b/scripts/attach-failing-card.ts
@@ -1,0 +1,118 @@
+/**
+ * Attach Failing Card Script
+ *
+ * This script attaches a Stripe test card that will FAIL when charged to a customer.
+ * It's used for testing payment failure scenarios during subscription upgrades.
+ *
+ * How it works:
+ * 1. Finds the Stripe customer by email
+ * 2. Removes ALL existing payment methods (so there's no fallback)
+ * 3. Attaches tok_visa_chargeCustomerFail - a special Stripe test token
+ * 4. Sets it as the default payment method
+ *
+ * The tok_visa_chargeCustomerFail token behavior:
+ * - Attaches to customer successfully
+ * - Passes initial validation
+ * - FAILS when an actual charge is attempted
+ *
+ * Use case:
+ * Test that subscription upgrades with `payment_behavior: "pending_if_incomplete"`
+ * correctly keep the user on their current plan when payment fails, rather than
+ * leaving them in a broken state.
+ *
+ * Usage:
+ *   pnpm stripe:attach-failing-card <customer-email>
+ *
+ * Example:
+ *   pnpm stripe:attach-failing-card pro1@hackerai.com
+ *
+ * After running:
+ *   1. Log in as the user in the app
+ *   2. Try to upgrade (e.g., Pro → Ultra)
+ *   3. Payment should fail and user should remain on their current plan
+ *
+ * @see https://docs.stripe.com/testing#cards - Stripe test tokens documentation
+ */
+
+import Stripe from "stripe";
+import * as dotenv from "dotenv";
+import * as path from "path";
+import chalk from "chalk";
+
+dotenv.config({ path: path.join(process.cwd(), ".env.local") });
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  typescript: true,
+});
+
+async function attachFailingCard(customerEmail: string) {
+  console.log(
+    chalk.bold.blue(`\n🔧 Attaching failing card to ${customerEmail}\n`),
+  );
+
+  // 1. Find customer
+  const customers = await stripe.customers.list({
+    email: customerEmail,
+    limit: 1,
+  });
+  if (customers.data.length === 0) {
+    console.log(chalk.red("❌ Customer not found"));
+    return;
+  }
+  const customer = customers.data[0];
+  console.log(chalk.green(`✓ Found customer: ${customer.id}`));
+
+  // 2. Remove all existing payment methods
+  console.log(chalk.cyan("\n📝 Removing existing payment methods..."));
+  const existingPMs = await stripe.paymentMethods.list({
+    customer: customer.id,
+    type: "card",
+  });
+  for (const pm of existingPMs.data) {
+    await stripe.paymentMethods.detach(pm.id);
+    console.log(chalk.gray(`   Removed: ${pm.id}`));
+  }
+  console.log(chalk.green(`✓ Removed ${existingPMs.data.length} existing payment method(s)`));
+
+  // 3. Attach tok_visa_chargeCustomerFail - attaches OK but fails on charge
+  console.log(chalk.cyan("\n📝 Attaching test card that will fail on charge..."));
+
+  const paymentMethod = await stripe.paymentMethods.create({
+    type: "card",
+    card: { token: "tok_visa_chargeCustomerFail" },
+  });
+
+  await stripe.paymentMethods.attach(paymentMethod.id, {
+    customer: customer.id,
+  });
+
+  await stripe.customers.update(customer.id, {
+    invoice_settings: { default_payment_method: paymentMethod.id },
+  });
+
+  console.log(chalk.green(`✓ Attached payment method: ${paymentMethod.id}`));
+  console.log(chalk.green(`✓ Set as default (only) payment method`));
+
+  console.log(chalk.bold.yellow("\n⚠️  This card will FAIL when charged!"));
+  console.log(chalk.gray("   Token: tok_visa_chargeCustomerFail"));
+  console.log(chalk.gray("   Behavior: Attaches OK, fails when customer is charged"));
+
+  console.log(chalk.bold.green("\n✨ Done! Now try upgrading in the UI.\n"));
+}
+
+// Get email from command line
+const email = process.argv[2];
+if (!email) {
+  console.log(
+    chalk.red("Usage: npx tsx scripts/attach-failing-card.ts <customer-email>"),
+  );
+  console.log(
+    chalk.gray("Example: npx tsx scripts/attach-failing-card.ts pro1@hackerai.com"),
+  );
+  process.exit(1);
+}
+
+attachFailingCard(email).catch((error) => {
+  console.error(chalk.red("\n❌ Fatal error:"), error);
+  process.exit(1);
+});


### PR DESCRIPTION
Add `payment_behavior: "pending_if_incomplete"` to subscription updates to ensure users keep their current plan when upgrade payment fails.

Also includes:
- Add attach-failing-card.ts script for testing payment failures
- Add stripe:attach-failing-card npm script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line utility for managing Stripe test payment methods to enable payment failure testing scenarios
* **Improvements**
  * Subscription updates now support pending payment flows, improving handling of incomplete transactions requiring additional customer action

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->