### PR TITLE
fix(auth): handle callback errors gracefully with dedicated error page

### DIFF
--- a/app/auth-error/page.tsx
+++ b/app/auth-error/page.tsx
@@ -1,0 +1,106 @@
+import { AlertCircle, RefreshCw, Home } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+type ErrorCode = "429" | "401" | "403" | "500" | "502" | "503" | "504";
+
+const ERROR_MESSAGES: Record<
+  ErrorCode,
+  { title: string; description: string }
+> = {
+  "429": {
+    title: "Too Many Requests",
+    description:
+      "Too many login attempts. Please wait a moment before trying again.",
+  },
+  "401": {
+    title: "Session Expired",
+    description:
+      "Your session has expired or the login link is no longer valid. Please sign in again.",
+  },
+  "403": {
+    title: "Access Denied",
+    description:
+      "You don't have permission to access this resource. Please sign in with a different account.",
+  },
+  "500": {
+    title: "Authentication Failed",
+    description: "Something went wrong during sign in. Please try again.",
+  },
+  "502": {
+    title: "Service Unavailable",
+    description:
+      "Our authentication service is temporarily unavailable. Please try again in a few minutes.",
+  },
+  "503": {
+    title: "Service Unavailable",
+    description:
+      "Our authentication service is temporarily unavailable. Please try again in a few minutes.",
+  },
+  "504": {
+    title: "Request Timeout",
+    description:
+      "The authentication request timed out. Please check your connection and try again.",
+  },
+};
+
+const DEFAULT_ERROR = {
+  title: "Authentication Error",
+  description: "An unexpected error occurred during sign in. Please try again.",
+};
+
+type SearchParams = Promise<{ code?: string }>;
+
+export default async function AuthErrorPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const { code } = await searchParams;
+  const errorInfo = ERROR_MESSAGES[code as ErrorCode] ?? DEFAULT_ERROR;
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+            <AlertCircle className="h-6 w-6 text-destructive" />
+          </div>
+          <CardTitle className="text-xl">{errorInfo.title}</CardTitle>
+          <CardDescription className="mt-2">
+            {errorInfo.description}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {code && (
+            <p className="text-center text-xs text-muted-foreground">
+              Error code: {code}
+            </p>
+          )}
+        </CardContent>
+        <CardFooter className="flex flex-col gap-3 sm:flex-row w-full">
+          <Button asChild className="flex-1 min-w-0">
+            <a href="/login">
+              <RefreshCw className="h-4 w-4" />
+              Try Again
+            </a>
+          </Button>
+          <Button asChild variant="outline" className="flex-1 min-w-0">
+            <Link href="/">
+              <Home className="h-4 w-4" />
+              Go Home
+            </Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/app/callback/route.ts
+++ b/app/callback/route.ts
@@ -16,26 +16,24 @@ export async function GET(request: NextRequest) {
 
   if (redirectPath) cookieStore.delete("post_login_redirect");
 
-  try {
-    const response = await authHandler(request);
+  // Authkit returns error responses instead of throwing, so we check status codes
+  const response = await authHandler(request);
 
-    if (
-      redirectPath &&
-      isValidLocalPath(redirectPath) &&
-      [302, 307].includes(response.status)
-    ) {
-      return NextResponse.redirect(new URL(redirectPath, request.url));
-    }
-
-    return response;
-  } catch (error) {
-    const errorMessage = String(error);
-    if (
-      errorMessage.includes("invalid_grant") ||
-      errorMessage.includes("InvalidCharacterError")
-    ) {
-      return NextResponse.redirect(new URL("/", request.url));
-    }
-    throw error;
+  if (
+    redirectPath &&
+    isValidLocalPath(redirectPath) &&
+    [302, 307].includes(response.status)
+  ) {
+    return NextResponse.redirect(new URL(redirectPath, request.url));
   }
+
+  if (response.status >= 400) {
+    const body = await response.json().catch(() => null);
+    console.warn("Authkit returned an error code", response.status, body);
+    return NextResponse.redirect(
+      new URL(`/auth-error?code=${response.status}`, request.url),
+    );
+  }
+
+  return response;
 }


### PR DESCRIPTION
- Check response status codes instead of relying on try/catch (Authkit returns error responses, doesn't throw)
- Add /auth-error page with contextual error messages
- Show user-friendly messages for 429, 401, 403, 500, 502-504
- Provide "Try Again" and "Go Home" actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated authentication error page that displays when login encounters issues, providing error details and options to retry or return home.

* **Bug Fixes**
  * Enhanced error handling during authentication to properly display user-friendly messages and guide users to recovery actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->