### PR TITLE
fix(FilePartRenderer): prevent image flicker by stabilizing file identifier tracking

### DIFF
--- a/app/components/FilePartRenderer.tsx
+++ b/app/components/FilePartRenderer.tsx
@@ -40,12 +40,19 @@ const FilePartRendererComponent = ({
   useEffect(() => {
     // Create stable identifier for this file
     const currentFileIdentifier = part.fileId || part.storageId || part.url;
+    const fileIdentifierChanged = prevFileIdentifierRef.current !== currentFileIdentifier;
 
     // Only reset state if the file identifier has actually changed (prevents image flicker during streaming)
-    if (prevFileIdentifierRef.current !== currentFileIdentifier) {
+    if (fileIdentifierChanged) {
       setFileUrl(null);
       setUrlError(null);
       prevFileIdentifierRef.current = currentFileIdentifier;
+    }
+
+    // Skip fetching if we already have a valid URL and the file hasn't changed
+    // This prevents unnecessary fetches during streaming that cause scroll glitches
+    if (!fileIdentifierChanged && fileUrl && !urlError) {
+      return;
     }
 
     async function fetchUrl() {
@@ -135,6 +142,8 @@ const FilePartRendererComponent = ({
     getFileUrlAction,
     convex,
     fileUrlCache,
+    fileUrl,
+    urlError,
   ]);
 
   const handleDownload = useCallback(async (url: string, fileName: string) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file rendering stability during streaming by avoiding unnecessary URL resets unless the file identifier changes, preventing UI flicker.
  * Skipped redundant eager fetches when a valid URL is already present, reducing needless network requests and smoothing playback experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->