### PR TITLE
fix(agent): switch agent models from AI gateway to OpenRouter

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -46,9 +46,6 @@ AWS_S3_BUCKET_NAME=
 # OpenRouter - Get key at: https://openrouter.ai/
 OPENROUTER_API_KEY=
 
-# AI Gateway - Get key at: https://vercel.com/ai-gateway
-AI_GATEWAY_API_KEY=
-
 # OpenAI - Get key at: https://platform.openai.com/
 OPENAI_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ You'll need the following accounts:
 **Required:**
 
 - [OpenRouter](https://openrouter.ai/) - AI model provider
-- [AI GATEWAY](https://vercel.com/ai-gateway) - AI model provider
 - [OpenAI](https://platform.openai.com/) - AI model provider
 - [XAI](https://x.ai/) - AI model provider for agent mode
 - [E2B](https://e2b.dev/) - Sandbox environment for secure code execution in agent mode

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -3,7 +3,6 @@ import { xai } from "@ai-sdk/xai";
 import { withTracing } from "@posthog/ai";
 import PostHogClient from "@/app/posthog";
 import type { SubscriptionTier } from "@/types";
-import { gateway } from "ai";
 import { openrouter } from "@openrouter/ai-sdk-provider";
 
 const baseProviders = {
@@ -11,8 +10,8 @@ const baseProviders = {
   "ask-model-free": xai("grok-4-1-fast-non-reasoning"),
   "ask-vision-model": openrouter("google/gemini-3-flash-preview"),
   "ask-vision-model-for-pdfs": openrouter("google/gemini-3-flash-preview"),
-  "agent-model": gateway("google/gemini-3-flash"),
-  "agent-vision-model": gateway("google/gemini-3-flash"),
+  "agent-model": openrouter("google/gemini-3-flash-preview"),
+  "agent-vision-model": openrouter("google/gemini-3-flash-preview"),
   "title-generator-model": xai("grok-4-1-fast-non-reasoning"),
   "summarization-model": openrouter("google/gemini-3-flash-preview"),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Replace AI gateway with OpenRouter for agent-model and agent-vision-model to resolve GatewayInternalServerError thought_signature errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed AI Gateway configuration and API key requirements from environment setup files, streamlining the initial setup process
  * Updated AI model provider backends to use OpenRouter as the service provider, completely replacing the previous gateway integration
* **Documentation**
  * Updated setup documentation to reflect the new provider configuration; removed AI Gateway from the list of required external accounts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->