### PR TITLE
fix(chat): add diagnostic logging for Vercel timeout investigation

### DIFF
--- a/lib/utils/stream-cancellation.ts
+++ b/lib/utils/stream-cancellation.ts
@@ -216,10 +216,32 @@ export const createPreemptiveTimeout = ({
 
   let isPreemptive = false;
   let triggerTime: number | null = null;
+  let currentPhase = "initializing";
+
+  // Diagnostic timeout: fires 10s before Vercel hard timeout to log what's blocking
+  const diagnosticTime = (maxDuration - 10) * 1000;
+  const diagnosticTimeoutId = setTimeout(() => {
+    const now = Date.now();
+    logger.warn("Diagnostic: 10s before Vercel timeout", {
+      chatId,
+      endpoint,
+      maxDuration,
+      elapsedMs: now - startTime,
+      currentPhase,
+      preemptiveTriggered: isPreemptive,
+      preemptiveTriggerTime: triggerTime
+        ? new Date(triggerTime).toISOString()
+        : null,
+      timeSincePreemptiveMs: triggerTime ? now - triggerTime : null,
+    });
+    // Flush immediately to ensure this log is captured before Vercel kills the process
+    logger.flush();
+  }, diagnosticTime);
 
   const timeoutId = setTimeout(() => {
     triggerTime = Date.now();
     isPreemptive = true;
+    currentPhase = "preemptive_triggered";
 
     logger.info("Preemptive timeout triggered", {
       chatId,
@@ -230,15 +252,26 @@ export const createPreemptiveTimeout = ({
       elapsedMs: triggerTime - startTime,
       triggerTime: new Date(triggerTime).toISOString(),
     });
+    // Flush immediately to ensure this log is captured
+    logger.flush();
 
     abortController.abort();
   }, maxStreamTime);
 
   return {
     timeoutId,
-    clear: () => clearTimeout(timeoutId),
+    clear: () => {
+      clearTimeout(timeoutId);
+      clearTimeout(diagnosticTimeoutId);
+    },
+    clearPreemptiveOnly: () => {
+      clearTimeout(timeoutId);
+    },
     isPreemptive: () => isPreemptive,
     getTriggerTime: () => triggerTime,
     getStartTime: () => startTime,
+    setPhase: (phase: string) => {
+      currentPhase = phase;
+    },
   };
 };


### PR DESCRIPTION
## Summary
- Add diagnostic timeout that fires 10s before Vercel hard timeout to capture what phase the request is stuck in
- Add phase tracking throughout request lifecycle (streaming, onFinish steps)
- Add `clearPreemptiveOnly()` to keep diagnostic timeout alive during onFinish cleanup
- Add immediate log flush after preemptive timeout trigger to ensure capture before process termination

Extracted from #208 to keep the summarization PR focused.

## Test plan
- [ ] Deploy to staging and trigger a long-running chat request
- [ ] Verify diagnostic logs appear in Axiom when request approaches Vercel timeout
- [ ] Verify phase tracking correctly reflects the current lifecycle stage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery mechanisms in streaming operations.

* **Performance & Stability**
  * Enhanced timeout management for more reliable chat functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->