### PR TITLE
fix: enable file drag-and-drop in Tauri desktop app

### DIFF
--- a/.cursor/rules/convex_rules.mdc
+++ b/.cursor/rules/convex_rules.mdc
@@ -169,9 +169,9 @@ Note: `paginationOpts` is an object with the following properties:
 - `numItems`: the maximum number of documents to return (the validator is `v.number()`)
 - `cursor`: the cursor to use to fetch the next page of documents (the validator is `v.union(v.string(), v.null())`)
 - A query that ends in `.paginate()` returns an object that has the following properties:
-                            - page (contains an array of documents that you fetches)
-                            - isDone (a boolean that represents whether or not this is the last page of documents)
-                            - continueCursor (a string that represents the cursor to use to fetch the next page of documents)
+- page (contains an array of documents that you fetches)
+- isDone (a boolean that represents whether or not this is the last page of documents)
+- continueCursor (a string that represents the cursor to use to fetch the next page of documents)
 
 
 ## Validator guidelines
@@ -290,7 +290,7 @@ export default crons;
 - The `ctx.storage.getUrl()` method returns a signed URL for a given file. It returns `null` if the file doesn't exist.
 - Do NOT use the deprecated `ctx.storage.getMetadata` call for loading a file's metadata.
 
-                    Instead, query the `_storage` system table. For example, you can use `ctx.db.system.get` to get an `Id<"_storage">`.
+Instead, query the `_storage` system table. For example, you can use `ctx.db.system.get` to get an `Id<"_storage">`.
 ```
 import { query } from "./_generated/server";
 import { Id } from "./_generated/dataModel";
@@ -702,4 +702,3 @@ export default function App() {
   return <div>Hello World</div>;
 }
 ```
-

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -24,7 +24,8 @@
         "decorations": true,
         "transparent": false,
         "userAgent": "HackerAI-Desktop/1.0",
-        "theme": "Dark"
+        "theme": "Dark",
+        "dragDropEnabled": false
       }
     ],
     "security": {


### PR DESCRIPTION
## Summary
- Disabled Tauri's native drag-drop interception (`dragDropEnabled: false`) so HTML5 drag-drop events pass through to the webview
- The web app's existing `useDocumentDragAndDrop` + `useFileUpload` hooks now work in the desktop app just like in a browser
- Single-line config change — no Rust code, no JS code, no new dependencies

## Test plan
- [x] Run the Tauri dev app: `pnpm dev` in `packages/desktop/`
- [x] Navigate to a chat page
- [x] Drag a file from desktop/Finder onto the app window — drag overlay should appear
- [x] Drop the file — file should upload via the existing S3 pipeline
- [x] Test with multiple file types: image (PNG/JPG), PDF, TXT, CSV
- [x] Test dropping multiple files at once (max 5)
- [x] Test on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Drag-and-drop functionality has been disabled in the desktop application window.

* **Chores**
  * Updated documentation formatting in project guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->