### PR TITLE
test: use URL-based selectors in pinned chat e2e tests

### DIFF
--- a/e2e/page-objects/SidebarComponent.ts
+++ b/e2e/page-objects/SidebarComponent.ts
@@ -232,4 +232,29 @@ export class SidebarComponent {
       timeout,
     });
   }
+
+  /**
+   * Open the chat options dropdown menu for a chat by URL.
+   * Extracts the chat ID from the URL and uses openChatOptionsById.
+   */
+  async openChatOptionsByUrl(url: string): Promise<void> {
+    const chatId = new URL(url).pathname.replace(/^\/c\//, "");
+    await this.openChatOptionsById(chatId);
+  }
+
+  /**
+   * Pin a chat by URL: open its options menu and click Pin.
+   */
+  async clickPinByUrl(url: string): Promise<void> {
+    await this.openChatOptionsByUrl(url);
+    await this.page.getByRole("menuitem", { name: "Pin" }).click();
+  }
+
+  /**
+   * Unpin a chat by URL: open its options menu and click Unpin.
+   */
+  async clickUnpinByUrl(url: string): Promise<void> {
+    await this.openChatOptionsByUrl(url);
+    await this.page.getByRole("menuitem", { name: "Unpin" }).click();
+  }
 }


### PR DESCRIPTION
- Add SidebarComponent helpers: openChatOptionsByUrl, clickPinByUrl, clickUnpinByUrl
- Add getOrderedChatUrls() in spec to get sidebar order by chat URL
- Switch pinned tests from title-based to URL-based selection for stability (titles can duplicate or change; URLs/IDs are unique and stable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced the reliability and stability of tests for the chat pinning feature through improved identification methods that provide more consistent test execution.
  * Strengthened the testing infrastructure with new helper functions designed to support better test coverage for chat organization and management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->