### PR TITLE
fix: use dvh instead of vh for Safari viewport height

### DIFF
--- a/app/(chat)/layout.tsx
+++ b/app/(chat)/layout.tsx
@@ -5,7 +5,7 @@ import { ChatLayout } from "@/app/components/ChatLayout";
 import Loading from "@/components/ui/loading";
 
 const fullWidthShell = (
-  <div className="h-screen min-h-0 flex flex-col bg-background overflow-hidden">
+  <div className="h-dvh min-h-0 flex flex-col bg-background overflow-hidden">
     <div className="flex-1 flex items-center justify-center min-h-0">
       <Loading />
     </div>
@@ -26,12 +26,12 @@ export default function ChatRouteLayout({
     <>
       <AuthLoading>{fullWidthShell}</AuthLoading>
       <Unauthenticated>
-        <div className="h-screen min-h-0 flex flex-col bg-background overflow-hidden">
+        <div className="h-dvh min-h-0 flex flex-col bg-background overflow-hidden">
           {children}
         </div>
       </Unauthenticated>
       <Authenticated>
-        <div className="h-screen min-h-0 flex flex-col bg-background overflow-hidden">
+        <div className="h-dvh min-h-0 flex flex-col bg-background overflow-hidden">
           <ChatLayout>{children}</ChatLayout>
         </div>
       </Authenticated>


### PR DESCRIPTION
Safari's 100vh includes the area behind the address bar/toolbar,
causing the page to be taller than the visible viewport and creating
unwanted scrolling. Replace h-screen (100vh) with h-dvh (100dvh) which
dynamically adjusts to the actual visible viewport height.

https://claude.ai/code/session_01QiaTPCdjEJde7nE4Pn7pqQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced the chat interface to display more reliably on mobile devices by improving how the layout dynamically adapts to changing screen conditions, particularly when browser controls and toolbars appear or disappear, ensuring the chat window always remains properly visible, fully functional, and easily accessible for uninterrupted conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->