### PR TITLE
fix(agent-long): use sandbox for file uploads instead of AI context

### DIFF
--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -88,6 +88,7 @@ const collectFilesToProcess = (
 
       const shouldProcess =
         mode === "agent" ||
+        mode === "agent-long" ||
         part.mediaType === "application/pdf" ||
         isMediaFile(part.mediaType);
 
@@ -185,7 +186,7 @@ const applyModeSpecificTransforms = async (
 ) => {
   const fileIds = extractAllFileIdsFromMessages(messages);
 
-  if (mode === "agent") {
+  if (mode === "agent" || mode === "agent-long") {
     collectSandboxFiles(messages, sandboxFiles, uploadBasePath);
     removeNonMediaFileParts(messages);
   } else {
@@ -205,7 +206,7 @@ const applyModeSpecificTransforms = async (
  *
  * Transforms file parts based on chat mode:
  * - **Ask mode**: Converts non-media files to document content, keeps images/PDFs as file parts
- * - **Agent mode**: Prepares all files for sandbox upload, keeps only images as file parts
+ * - **Agent / Agent-long mode**: Prepares all files for sandbox upload, keeps only images as file parts
  *
  * Processing steps:
  * 1. Generates fresh URLs for files (prevents expiration)
@@ -213,10 +214,10 @@ const applyModeSpecificTransforms = async (
  * 3. Detects media files (images/PDFs)
  * 4. Applies mode-specific transforms:
  *    - Ask: Injects document content for text files, removes audio
- *    - Agent: Collects files for sandbox, adds attachment tags, removes non-images
+ *    - Agent/Agent-long: Collects files for sandbox, adds attachment tags, removes non-images
  *
  * @param messages - Messages to process
- * @param mode - Chat mode ("ask" or "agent")
+ * @param mode - Chat mode ("ask", "agent", or "agent-long")
  * @param uploadBasePath - Override for agent mode (/home/user/upload or /tmp/hackerai-upload for local dangerous)
  * @returns Processed messages with file metadata and sandbox files for upload
  */


### PR DESCRIPTION
## Summary
Align agent-long file handling with agent mode so uploaded files go to the sandbox instead of being injected into the AI prompt.

## Problem
Agent-long was treating files like ask mode: document content was injected into the prompt for the AI to consume. This differed from agent mode, where files are uploaded to the sandbox and the agent accesses them via tools.

## Solution
- Treat agent-long the same as agent in `applyModeSpecificTransforms`: collect files for sandbox upload and remove non-media file parts from messages
- Include agent-long in `collectFilesToProcess` so all file types get URLs for sandbox download
- Agent-long now uploads files to the sandbox; the agent uses terminal/file tools to read them

## Benefits
- Consistent behavior between agent and agent-long modes
- Supports larger files without token limits
- Enables tool-based file analysis (grep, cat, etc.) in agent-long runs

---
<p><a href="https://cursor.com/agents?id=bc-2e61fb72-83f5-4dc8-ac4d-12faae507e96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e61fb72-83f5-4dc8-ac4d-12faae507e96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

