### PR TITLE
feat: stream file creation content in sidebar immediately

### DIFF
--- a/lib/utils/sidebar-utils.ts
+++ b/lib/utils/sidebar-utils.ts
@@ -227,6 +227,27 @@ export function extractSidebarContentFromMessage(
       });
     }
 
+    // File write/append streaming - extract during input-streaming/input-available
+    // so sidebar auto-follow works for file creation (like terminals)
+    if (
+      part.type === "tool-file" &&
+      (part.state === "input-streaming" || part.state === "input-available")
+    ) {
+      const fileInput = part.input;
+      if (fileInput?.path) {
+        const fileAction = fileInput.action as string;
+        if (fileAction === "write" || fileAction === "append") {
+          contentList.push({
+            path: fileInput.path,
+            content: fileInput.text || "",
+            action: fileAction === "write" ? "creating" : "appending",
+            toolCallId: part.toolCallId || "",
+            isExecuting: true,
+          });
+        }
+      }
+    }
+
     // File Operations - only extract when output is available
     // This ensures content is ready when auto-following
     if (


### PR DESCRIPTION
Previously, file write/append operations were only extracted into toolExecutions at output-available state, so the sidebar auto-follow never triggered during streaming. Users had to manually click the tool block to view file content being written.

Now file write/append ops are extracted during input-streaming and input-available states (matching terminal behavior), and a resolvedFile pattern keeps content and metadata updating live as tokens arrive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time sidebar updates now display live file operations and modifications as they occur during execution.
  * Sidebar auto-follow now tracks file creation and append operations during streaming scenarios.

* **Bug Fixes**
  * Improved file content display to reflect current operation state instead of stale data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->