### PR TITLE
fix: enable agent mode reconnection by relaxing useAutoResume condition

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -404,11 +404,10 @@ export const Chat = ({
       : undefined;
 
   // Auto-resume controlled by prop; default to true when a specific chat id is present, false on "/"
-  // Disable for agent-long: resuming hits AI SDK /api/chat, not Trigger.dev, and can block sync
-  // Use serverMode (from DB) instead of chatMode (from GlobalState) to avoid stale state from previous chat
+  // Disable only for agent-long: resuming hits AI SDK /api/chat, not Trigger.dev, and can block sync
+  // Enable when serverMode is undefined (old chats, or before chatData loads) so agent mode can reconnect
   useAutoResume({
-    autoResume:
-      autoResume && serverMode !== undefined && serverMode !== "agent-long",
+    autoResume: autoResume && serverMode !== "agent-long",
     initialMessages,
     resumeStream,
     setMessages,


### PR DESCRIPTION
Previously required serverMode !== undefined, which blocked reconnection when:
- chatData hadn't loaded yet
- older chats without default_model_slug

Now only disables for agent-long (Trigger.dev path). Agent mode uses the same resumable stream as ask mode (/api/chat + active_stream_id).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-resume behavior in chats, now enabling it in more scenarios including legacy chats and during chat data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->