### PR TITLE
fix: apply token exhaustion stop condition to ask mode

### DIFF
--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -609,18 +609,16 @@ export const createChatHandler = (
                 subscription,
               ),
               experimental_transform: smoothStream({ chunking: "word" }),
-              stopWhen: isAgentMode(mode)
-                ? [
-                    stepCountIs(getMaxStepsForUser(mode, subscription)),
-                    tokenExhaustedAfterSummarization({
-                      getLastStepInputTokens: () => lastStepInputTokens,
-                      getHasSummarized: () => hasSummarized,
-                      onFired: () => {
-                        stoppedDueToTokenExhaustion = true;
-                      },
-                    }),
-                  ]
-                : stepCountIs(getMaxStepsForUser(mode, subscription)),
+              stopWhen: [
+                stepCountIs(getMaxStepsForUser(mode, subscription)),
+                tokenExhaustedAfterSummarization({
+                  getLastStepInputTokens: () => lastStepInputTokens,
+                  getHasSummarized: () => hasSummarized,
+                  onFired: () => {
+                    stoppedDueToTokenExhaustion = true;
+                  },
+                }),
+              ],
               onChunk: async (chunk) => {
                 if (chunk.chunk.type === "tool-call") {
                   const sandboxType = sandboxManager.getSandboxType(


### PR DESCRIPTION
Ask mode previously only had a step count limit, with no
tokenExhaustedAfterSummarization check. This meant ask mode could
silently exceed the 128K token limit during multi-step runs, causing
the provider to reject the request. Now both agent and ask modes
share the same two stop conditions (step count + token exhaustion).

https://claude.ai/code/session_01371Shymg5bEto7y8d1tL3V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token exhaustion handling in chat conversations by ensuring consistent enforcement across all interaction modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->