### PR TITLE
fix: clear todos when switching to chat without todos

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -505,6 +505,8 @@ export const Chat = ({
       })();
 
       setTodos(nextTodos);
+    } else {
+      setTodos([]);
     }
     // Server has responded for this chat id; stop suppressing not-found state
     setAwaitingServerChat(false);


### PR DESCRIPTION
## Summary
- **Root cause:** `chatData.todos` is optional in the Convex schema, so it's `undefined` for chats that never had todos. The existing code only called `setTodos()` when `chatData.todos` was truthy, leaving the previous chat's todos in global state.
- **Fix:** Added an `else` branch to clear todos (`setTodos([])`) when `chatData.todos` is undefined.

## Test plan
- [x] Open Chat A that has todos (agent mode, ask it to create a plan)
- [x] Switch to Chat B that has no todos — verify todos panel disappears
- [x] Switch back to Chat A — verify todos are restored
- [x] Create a new chat — verify no todos leak from previous chat
- [x] Run existing tests: `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where todo items could incorrectly persist when loading a chat without associated tasks. Todo lists are now properly cleared when switching between conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->