### PR TITLE
fix: consume free user rate limit only on successful chat response

### DIFF
--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -29,6 +29,7 @@ import { isSelectedModel } from "@/types";
 import { getBaseTodosForRequest } from "@/lib/utils/todo-utils";
 import {
   checkRateLimit,
+  consumeFreeUserRateLimit,
   deductUsage,
   UsageRefundTracker,
 } from "@/lib/rate-limit";
@@ -531,6 +532,7 @@ export const createChatHandler = (
           let accumulatedOutputTokens = 0;
           let accumulatedProviderCost = 0;
           let hasDeductedUsage = false;
+          let hasConsumedFreeRateLimit = false;
 
           // Helper to deduct accumulated usage (called from multiple exit points)
           const deductAccumulatedUsage = async () => {
@@ -550,6 +552,18 @@ export const createChatHandler = (
                 selectedModel,
               );
             }
+          };
+
+          // Consume free user sliding-window rate limit once on success (only for ask + free)
+          const consumeFreeRateLimitIfApplicable = async () => {
+            if (
+              hasConsumedFreeRateLimit ||
+              mode !== "ask" ||
+              subscription !== "free"
+            )
+              return;
+            hasConsumedFreeRateLimit = true;
+            await consumeFreeUserRateLimit(userId);
           };
 
           // Helper to create streamText with a given model (reused for retry)
@@ -940,6 +954,7 @@ export const createChatHandler = (
 
                           // Deduct accumulated usage (includes both original + retry streams)
                           await deductAccumulatedUsage();
+                          await consumeFreeRateLimitIfApplicable();
                         },
                         sendReasoning: true,
                       }),
@@ -1211,6 +1226,7 @@ export const createChatHandler = (
                 }
 
                 await deductAccumulatedUsage();
+                await consumeFreeRateLimitIfApplicable();
               },
               sendReasoning: true,
             }),

--- a/lib/rate-limit/__tests__/index.test.ts
+++ b/lib/rate-limit/__tests__/index.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 
 describe("checkRateLimit", () => {
   const mockLimitFn = jest.fn();
+  const mockGetRemainingFn = jest.fn();
   const mockCheckTokenBucketLimit = jest.fn();
   const mockCreateRedisClient = jest.fn();
   const mockFormatTimeRemaining = jest.fn();
@@ -17,10 +18,14 @@ describe("checkRateLimit", () => {
     jest.resetModules();
     jest.clearAllMocks();
 
-    // Default mock responses
+    // Default mock responses (free user check uses getRemaining)
     mockLimitFn.mockResolvedValue({
       success: true,
       remaining: 5,
+      reset: Date.now() + 3600000,
+    });
+    mockGetRemainingFn.mockResolvedValue({
+      remaining: 6,
       reset: Date.now() + 3600000,
     });
 
@@ -40,6 +45,7 @@ describe("checkRateLimit", () => {
     jest.isolateModules(() => {
       const MockRatelimit = jest.fn().mockImplementation(() => ({
         limit: mockLimitFn,
+        getRemaining: mockGetRemainingFn,
       }));
       (MockRatelimit as any).slidingWindow = jest.fn().mockReturnValue({});
 
@@ -89,7 +95,7 @@ describe("checkRateLimit", () => {
 
       const result = await checkRateLimit("user-123", "ask", "free", 0);
 
-      expect(mockLimitFn).toHaveBeenCalled();
+      expect(mockGetRemainingFn).toHaveBeenCalled();
       expect(mockCheckTokenBucketLimit).not.toHaveBeenCalled();
       expect(result.remaining).toBe(5);
     });
@@ -111,8 +117,7 @@ describe("checkRateLimit", () => {
       const { checkRateLimit } = getIsolatedModule();
 
       mockCreateRedisClient.mockReturnValue({});
-      mockLimitFn.mockResolvedValue({
-        success: false,
+      mockGetRemainingFn.mockResolvedValue({
         remaining: 0,
         reset: Date.now() + 3600000,
       });

--- a/lib/rate-limit/__tests__/sliding-window.test.ts
+++ b/lib/rate-limit/__tests__/sliding-window.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 
 describe("sliding-window", () => {
   const mockLimitFn = jest.fn();
+  const mockGetRemainingFn = jest.fn();
   const mockCreateRedisClient = jest.fn();
   const mockFormatTimeRemaining = jest.fn();
 
@@ -14,10 +15,14 @@ describe("sliding-window", () => {
     jest.resetModules();
     jest.clearAllMocks();
 
-    // Default mock responses
+    // Default mock responses (check uses getRemaining; consume uses limit)
     mockLimitFn.mockResolvedValue({
       success: true,
       remaining: 5,
+      reset: Date.now() + 3600000,
+    });
+    mockGetRemainingFn.mockResolvedValue({
+      remaining: 6,
       reset: Date.now() + 3600000,
     });
 
@@ -30,6 +35,7 @@ describe("sliding-window", () => {
     jest.isolateModules(() => {
       const MockRatelimit = jest.fn().mockImplementation(() => ({
         limit: mockLimitFn,
+        getRemaining: mockGetRemainingFn,
       }));
       (MockRatelimit as any).slidingWindow = jest.fn().mockReturnValue({});
 
@@ -69,7 +75,7 @@ describe("sliding-window", () => {
 
       const result = await checkFreeUserRateLimit("user-123");
 
-      expect(mockLimitFn).toHaveBeenCalled();
+      expect(mockGetRemainingFn).toHaveBeenCalled();
       expect(result.remaining).toBe(5);
     });
 
@@ -77,8 +83,7 @@ describe("sliding-window", () => {
       const { checkFreeUserRateLimit } = getIsolatedModule();
 
       mockCreateRedisClient.mockReturnValue({});
-      mockLimitFn.mockResolvedValue({
-        success: false,
+      mockGetRemainingFn.mockResolvedValue({
         remaining: 0,
         reset: Date.now() + 3600000,
       });
@@ -96,8 +101,7 @@ describe("sliding-window", () => {
       const { checkFreeUserRateLimit } = getIsolatedModule();
 
       mockCreateRedisClient.mockReturnValue({});
-      mockLimitFn.mockResolvedValue({
-        success: false,
+      mockGetRemainingFn.mockResolvedValue({
         remaining: 0,
         reset: Date.now() + 3600000,
       });
@@ -115,7 +119,9 @@ describe("sliding-window", () => {
       const { checkFreeUserRateLimit } = getIsolatedModule();
 
       mockCreateRedisClient.mockReturnValue({});
-      mockLimitFn.mockRejectedValue(new Error("Redis connection failed"));
+      mockGetRemainingFn.mockRejectedValue(
+        new Error("Redis connection failed"),
+      );
 
       try {
         await checkFreeUserRateLimit("user-123");

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -36,7 +36,10 @@ export {
 } from "./token-bucket";
 
 // Re-export sliding window functions
-export { checkFreeUserRateLimit } from "./sliding-window";
+export {
+  checkFreeUserRateLimit,
+  consumeFreeUserRateLimit,
+} from "./sliding-window";
 
 // Re-export utilities
 export { createRedisClient, formatTimeRemaining } from "./redis";

--- a/lib/rate-limit/sliding-window.ts
+++ b/lib/rate-limit/sliding-window.ts
@@ -11,8 +11,8 @@ import type { RateLimitInfo } from "@/types";
 import { createRedisClient, formatTimeRemaining } from "./redis";
 
 /**
- * Check rate limit for free users using sliding window.
- * Simple request counting within a 5-hour rolling window.
+ * Check rate limit for free users using sliding window (without consuming).
+ * Uses getRemaining so the request is only consumed on success via consumeFreeUserRateLimit.
  */
 export const checkFreeUserRateLimit = async (
   userId: string,
@@ -36,9 +36,9 @@ export const checkFreeUserRateLimit = async (
     });
 
     const rateLimitKey = `${userId}:free`;
-    const { success, reset, remaining } = await ratelimit.limit(rateLimitKey);
+    const { remaining, reset } = await ratelimit.getRemaining(rateLimitKey);
 
-    if (!success) {
+    if (remaining <= 0) {
       const timeString = formatTimeRemaining(new Date(reset));
       throw new ChatSDKError(
         "rate_limit:chat",
@@ -46,8 +46,9 @@ export const checkFreeUserRateLimit = async (
       );
     }
 
+    // Return remaining - 1 so UI shows count after this request would be consumed on success
     return {
-      remaining,
+      remaining: remaining - 1,
       resetTime: new Date(reset),
       limit: requestLimit,
     };
@@ -56,6 +57,37 @@ export const checkFreeUserRateLimit = async (
     throw new ChatSDKError(
       "rate_limit:chat",
       `Rate limiting service unavailable: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+};
+
+/**
+ * Consume one request from the free user sliding window. Call only after a successful AI response.
+ * Fire-and-forget: errors are logged but not thrown.
+ */
+export const consumeFreeUserRateLimit = async (
+  userId: string,
+): Promise<void> => {
+  const redis = createRedisClient();
+  if (!redis) {
+    return;
+  }
+
+  const requestLimit = parseInt(process.env.FREE_RATE_LIMIT_REQUESTS || "10");
+  const ratelimit = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(requestLimit, "5 h"),
+    prefix: "free_limit",
+  });
+
+  const rateLimitKey = `${userId}:free`;
+  try {
+    await ratelimit.limit(rateLimitKey);
+  } catch (error) {
+    // Log but don't throw - response was already served
+    console.warn(
+      "Free user rate limit consume failed:",
+      error instanceof Error ? error.message : String(error),
     );
   }
 };


### PR DESCRIPTION
- Use getRemaining() for checkFreeUserRateLimit so the request is not consumed until the response succeeds; return remaining - 1 for UI
- Add consumeFreeUserRateLimit() to call limit() after success (fire-and-forget)
- Chat handler calls consumeFreeUserRateLimit once on stream completion for ask + free users, so failed or aborted requests no longer count
- Update rate-limit tests to mock getRemaining for check path

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rate limit enforcement for free users in ask mode to properly track and consume quota per request, ensuring accurate usage accounting across successful completions and fallback scenarios.

* **Tests**
  * Updated test coverage to reflect revised rate limit checking mechanism for free user scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->