### PR TITLE
fix: scroll to bottom when sending a message while scrolled up

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -746,6 +746,16 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
   const handleScrollToBottom = () => scrollToBottom({ force: true });
 
+  const handleSubmitWithScroll = useCallback(
+    (e: React.FormEvent) => {
+      if (!isAtBottom) {
+        scrollToBottom({ force: true });
+      }
+      handleSubmit(e);
+    },
+    [isAtBottom, scrollToBottom, handleSubmit],
+  );
+
   // Rate limit warning dismiss handler
   const handleDismissRateLimitWarning = () => {
     setRateLimitWarning(null);
@@ -871,7 +881,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
                       {!isMobile && (
                         <div className="w-full">
                           <ChatInput
-                            onSubmit={handleSubmit}
+                            onSubmit={handleSubmitWithScroll}
                             onStop={handleStop}
                             onSendNow={handleSendNow}
                             status={displayStatus}
@@ -905,7 +915,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
               {(hasMessages || isExistingChat || isMobile) &&
                 !isChatNotFound && (
                   <ChatInput
-                    onSubmit={handleSubmit}
+                    onSubmit={handleSubmitWithScroll}
                     onStop={handleStop}
                     onSendNow={handleSendNow}
                     status={displayStatus}


### PR DESCRIPTION
Call scrollToBottom({ force: true }) before handleSubmit when the user is scrolled up. This synchronously sets isAtBottom = true and starts a smooth animation, so the library's own ResizeObserver picks up the new content height naturally — no custom observer or ref signal needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat auto-scrolling behavior to ensure the message list scrolls to the bottom when submitting new messages, enhancing visibility across desktop and mobile interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->