### PR TITLE
fix: skip raw mkdir for CentrifugoSandbox transcript save on Windows

### DIFF
--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -78,7 +78,12 @@ const saveTranscriptToSandbox = async (
       : "/tmp/agent-transcripts";
     const path = `${dir}/${transcriptId}.json`;
 
-    await sandbox.commands.run(`mkdir -p ${dir}`, { timeoutMs: 5000 });
+    // E2B needs an explicit mkdir since its files.write doesn't create parents.
+    // CentrifugoSandbox's files.write already calls ensureDirectory internally
+    // with proper Windows path/shell handling, so skip the raw mkdir for it.
+    if (isE2BSandbox(sandbox)) {
+      await sandbox.commands.run(`mkdir -p ${dir}`, { timeoutMs: 5000 });
+    }
 
     // Save as structured JSON — model messages (mid-stream, with separate
     // tool-call/tool-result parts) when available, otherwise UI messages


### PR DESCRIPTION
The summarization transcript save was running `mkdir -p /tmp/agent-transcripts` directly via shell command, which fails on Windows remote sandboxes (invalid path and cmd.exe syntax). CentrifugoSandbox's files.write already handles directory creation internally with proper Windows path/shell detection, so only E2B sandboxes need the explicit mkdir.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transcript file handling to ensure transcripts are reliably saved across different sandbox configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->