### PR TITLE
fix: improve agent stream resilience and desktop sandbox reliability

### DIFF
--- a/app/api/chat/[id]/stream/route.ts
+++ b/app/api/chat/[id]/stream/route.ts
@@ -68,9 +68,14 @@ export async function GET(
   });
 
   if (recentStreamId) {
-    const stream = await streamContext.resumableStream(recentStreamId, () =>
-      emptyDataStream.pipeThrough(new JsonToSseTransformStream()),
-    );
+    let stream: ReadableStream | null = null;
+    try {
+      stream = await streamContext.resumableStream(recentStreamId, () =>
+        emptyDataStream.pipeThrough(new JsonToSseTransformStream()),
+      );
+    } catch {
+      // Producer is gone (ack timeout) — fall through to replay fallback
+    }
 
     if (stream) {
       const abortController = new AbortController();

--- a/app/components/AgentsTab.tsx
+++ b/app/components/AgentsTab.tsx
@@ -175,6 +175,54 @@ const AgentsTab = () => {
             aria-label="Toggle Caido proxy"
           />
         </div>
+        {(userCustomization?.caido_enabled ?? false) && (
+          <div className="flex items-center justify-between py-3 border-b pl-4">
+            <div className="flex-1 pr-4">
+              <Label
+                htmlFor="caido-port"
+                className="font-medium cursor-pointer"
+              >
+                Custom Port
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                Connect to your own Caido instance (local sandbox only). Leave
+                empty for default (48080).
+              </p>
+            </div>
+            <input
+              id="caido-port"
+              type="number"
+              min={1}
+              max={65535}
+              placeholder="48080"
+              className="w-24 rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+              defaultValue={userCustomization?.caido_port ?? ""}
+              onBlur={async (e) => {
+                const raw = e.target.value.trim();
+                const port = raw ? Number(raw) : 0;
+                if (raw && (isNaN(port) || port < 1 || port > 65535)) {
+                  toast.error("Port must be between 1 and 65535");
+                  return;
+                }
+                try {
+                  await saveCustomization({ caido_port: port || undefined });
+                  toast.success(
+                    port
+                      ? `Caido port set to ${port}`
+                      : "Caido port reset to default",
+                  );
+                } catch {
+                  toast.error("Failed to update Caido port");
+                }
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  (e.target as HTMLInputElement).blur();
+                }
+              }}
+            />
+          </div>
+        )}
       </div>
 
       {/* Queue Messages - Only show for Pro/Ultra/Team users */}

--- a/app/components/AgentsTab.tsx
+++ b/app/components/AgentsTab.tsx
@@ -200,8 +200,14 @@ const AgentsTab = () => {
               onBlur={async (e) => {
                 const raw = e.target.value.trim();
                 const port = raw ? Number(raw) : 0;
-                if (raw && (isNaN(port) || port < 1 || port > 65535)) {
-                  toast.error("Port must be between 1 and 65535");
+                if (
+                  raw &&
+                  (isNaN(port) ||
+                    !Number.isInteger(port) ||
+                    port < 1 ||
+                    port > 65535)
+                ) {
+                  toast.error("Port must be an integer between 1 and 65535");
                   return;
                 }
                 try {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -126,6 +126,7 @@ export default defineSchema({
     include_memory_entries: v.optional(v.boolean()),
     guardrails_config: v.optional(v.string()),
     caido_enabled: v.optional(v.boolean()),
+    caido_port: v.optional(v.number()),
     extra_usage_enabled: v.optional(v.boolean()),
     max_mode_enabled: v.optional(v.boolean()),
   }).index("by_user_id", ["user_id"]),

--- a/convex/userCustomization.ts
+++ b/convex/userCustomization.ts
@@ -73,6 +73,19 @@ export const saveUserCustomization = mutation({
       });
     }
 
+    if (
+      args.caido_port !== undefined &&
+      args.caido_port !== 0 &&
+      (!Number.isInteger(args.caido_port) ||
+        args.caido_port < 1 ||
+        args.caido_port > 65535)
+    ) {
+      throw new ConvexError({
+        code: "VALIDATION_ERROR",
+        message: "Caido port must be an integer between 1 and 65535",
+      });
+    }
+
     try {
       // Check if user already has customization data
       const existing = await ctx.db
@@ -100,7 +113,7 @@ export const saveUserCustomization = mutation({
         if (args.caido_enabled !== undefined)
           patch.caido_enabled = args.caido_enabled;
         if (args.caido_port !== undefined)
-          patch.caido_port = args.caido_port || undefined;
+          patch.caido_port = args.caido_port ? args.caido_port : undefined;
         if (args.extra_usage_enabled !== undefined)
           patch.extra_usage_enabled = args.extra_usage_enabled;
         if (args.max_mode_enabled !== undefined)
@@ -119,7 +132,7 @@ export const saveUserCustomization = mutation({
           include_memory_entries: args.include_memory_entries ?? true,
           guardrails_config: args.guardrails_config?.trim() || undefined,
           caido_enabled: args.caido_enabled ?? false,
-          caido_port: args.caido_port || undefined,
+          caido_port: args.caido_port ? args.caido_port : undefined,
           extra_usage_enabled: args.extra_usage_enabled ?? false,
           max_mode_enabled: args.max_mode_enabled ?? false,
           updated_at: Date.now(),

--- a/convex/userCustomization.ts
+++ b/convex/userCustomization.ts
@@ -15,6 +15,7 @@ export const saveUserCustomization = mutation({
     include_memory_entries: v.optional(v.boolean()),
     guardrails_config: v.optional(v.string()),
     caido_enabled: v.optional(v.boolean()),
+    caido_port: v.optional(v.number()),
     extra_usage_enabled: v.optional(v.boolean()),
     max_mode_enabled: v.optional(v.boolean()),
   },
@@ -98,6 +99,8 @@ export const saveUserCustomization = mutation({
           patch.guardrails_config = args.guardrails_config.trim() || undefined;
         if (args.caido_enabled !== undefined)
           patch.caido_enabled = args.caido_enabled;
+        if (args.caido_port !== undefined)
+          patch.caido_port = args.caido_port || undefined;
         if (args.extra_usage_enabled !== undefined)
           patch.extra_usage_enabled = args.extra_usage_enabled;
         if (args.max_mode_enabled !== undefined)
@@ -116,6 +119,7 @@ export const saveUserCustomization = mutation({
           include_memory_entries: args.include_memory_entries ?? true,
           guardrails_config: args.guardrails_config?.trim() || undefined,
           caido_enabled: args.caido_enabled ?? false,
+          caido_port: args.caido_port || undefined,
           extra_usage_enabled: args.extra_usage_enabled ?? false,
           max_mode_enabled: args.max_mode_enabled ?? false,
           updated_at: Date.now(),
@@ -153,6 +157,7 @@ export const getUserCustomization = query({
       include_memory_entries: v.boolean(),
       guardrails_config: v.optional(v.string()),
       caido_enabled: v.boolean(),
+      caido_port: v.optional(v.number()),
       extra_usage_enabled: v.boolean(),
       max_mode_enabled: v.boolean(),
       updated_at: v.number(),
@@ -183,6 +188,7 @@ export const getUserCustomization = query({
         include_memory_entries: customization.include_memory_entries ?? true,
         guardrails_config: customization.guardrails_config,
         caido_enabled: customization.caido_enabled ?? false,
+        caido_port: customization.caido_port,
         extra_usage_enabled: customization.extra_usage_enabled ?? false,
         max_mode_enabled: customization.max_mode_enabled ?? false,
         updated_at: customization.updated_at,
@@ -213,6 +219,7 @@ export const getUserCustomizationForBackend = query({
       include_memory_entries: v.boolean(),
       guardrails_config: v.optional(v.string()),
       caido_enabled: v.boolean(),
+      caido_port: v.optional(v.number()),
       extra_usage_enabled: v.boolean(),
       max_mode_enabled: v.boolean(),
       updated_at: v.number(),
@@ -240,6 +247,7 @@ export const getUserCustomizationForBackend = query({
         include_memory_entries: customization.include_memory_entries ?? true,
         guardrails_config: customization.guardrails_config,
         caido_enabled: customization.caido_enabled ?? false,
+        caido_port: customization.caido_port,
         extra_usage_enabled: customization.extra_usage_enabled ?? false,
         max_mode_enabled: customization.max_mode_enabled ?? false,
         updated_at: customization.updated_at,

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -60,6 +60,7 @@ export const createTools = (
   serviceKey?: string,
   guardrailsConfig?: string,
   caidoEnabled: boolean = false,
+  caidoPort?: number,
   appendMetadataStream?: AppendMetadataStreamFn,
   onToolCost?: (costDollars: number) => void,
   subscription?: SubscriptionTier,
@@ -121,6 +122,7 @@ export const createTools = (
     isE2BSandbox,
     guardrailsConfig,
     caidoEnabled,
+    caidoPort,
     appendMetadataStream,
     onToolCost,
   };

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -15,13 +15,16 @@ import {
   getSandboxDiagnostics,
 } from "./utils/sandbox-health";
 import { isE2BSandbox } from "./utils/sandbox-types";
-import { buildSandboxCommandOptions } from "./utils/sandbox-command-options";
+import {
+  buildSandboxCommandOptions,
+  augmentCommandPath,
+} from "./utils/sandbox-command-options";
 import {
   parseGuardrailConfig,
   getEffectiveGuardrails,
   checkCommandGuardrails,
 } from "./utils/guardrails";
-import { CAIDO_DEFAULTS, buildCaidoProxyEnvVars } from "./utils/caido-proxy";
+import { getCaidoConfig, buildCaidoProxyEnvVars } from "./utils/caido-proxy";
 import { ensureCaido } from "./utils/proxy-manager";
 
 const DEFAULT_STREAM_TIMEOUT_SECONDS = 60;
@@ -34,6 +37,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
     backgroundProcessTracker,
     guardrailsConfig,
     caidoEnabled,
+    caidoPort,
   } = context;
 
   // Parse user guardrail configuration and get effective guardrails
@@ -43,8 +47,9 @@ export const createRunTerminalCmd = (context: ToolContext) => {
   // Caido proxy env vars — injected into every command on non-E2B sandboxes when enabled.
   // Permanently disabled on first setup failure (e.g. Windows sandbox) to avoid
   // retrying and logging warnings on every subsequent command.
+  const caidoConfig = getCaidoConfig(caidoPort);
   let caidoEnvVars = caidoEnabled
-    ? buildCaidoProxyEnvVars(CAIDO_DEFAULTS)
+    ? buildCaidoProxyEnvVars(caidoConfig)
     : undefined;
 
   return tool({
@@ -437,6 +442,14 @@ If you are generating files:
               return false;
             };
 
+            // Augment PATH for local sandboxes so user-installed tools
+            // (e.g. ~/go/bin/waybackurls) are found without full paths.
+            // Keep the original `command` for PID discovery (findProcessPid).
+            const effectiveCommand = augmentCommandPath(
+              command,
+              sandboxInstance,
+            );
+
             // Execute command with retry logic for transient failures
             // Sandbox readiness already checked, so these retries handle race conditions
             // Retries: 6 attempts with exponential backoff (500ms, 1s, 2s, 4s, 8s, 16s) + jitter (±50ms)
@@ -448,10 +461,13 @@ If you are generating files:
             }> = is_background
               ? retryWithBackoff(
                   async () => {
-                    const result = await sandboxInstance.commands.run(command, {
-                      ...commonOptions,
-                      background: true,
-                    });
+                    const result = await sandboxInstance.commands.run(
+                      effectiveCommand,
+                      {
+                        ...commonOptions,
+                        background: true,
+                      },
+                    );
                     // Normalize the result to include exitCode
                     return {
                       stdout: result.stdout,
@@ -470,7 +486,11 @@ If you are generating files:
                   },
                 )
               : retryWithBackoff(
-                  () => sandboxInstance.commands.run(command, commonOptions),
+                  () =>
+                    sandboxInstance.commands.run(
+                      effectiveCommand,
+                      commonOptions,
+                    ),
                   {
                     maxRetries: 6,
                     baseDelayMs: 500,

--- a/lib/ai/tools/utils/caido-proxy.ts
+++ b/lib/ai/tools/utils/caido-proxy.ts
@@ -3,8 +3,19 @@ export const CAIDO_DEFAULTS = {
   port: 48080,
 } as const;
 
+/** Resolve Caido config: use custom port if provided, otherwise defaults. */
+export function getCaidoConfig(caidoPort?: number): {
+  host: string;
+  port: number;
+} {
+  return {
+    host: CAIDO_DEFAULTS.host,
+    port: caidoPort || CAIDO_DEFAULTS.port,
+  };
+}
+
 export function buildCaidoProxyEnvVars(
-  config: typeof CAIDO_DEFAULTS = CAIDO_DEFAULTS,
+  config: { host: string; port: number } = CAIDO_DEFAULTS,
 ): Record<string, string> {
   const proxyUrl = `http://${config.host}:${config.port}`;
   return {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -310,7 +310,17 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
                 cleanup();
                 reject(
                   new Error(
-                    `Failed to publish command: ${err instanceof Error ? err.message : JSON.stringify(err)}`,
+                    `Failed to publish command: ${
+                      err instanceof Error
+                        ? err.message
+                        : (() => {
+                            try {
+                              return JSON.stringify(err);
+                            } catch {
+                              return String(err);
+                            }
+                          })()
+                    }`,
                   ),
                 );
               }

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -310,7 +310,7 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
                 cleanup();
                 reject(
                   new Error(
-                    `Failed to publish command: ${err instanceof Error ? err.message : String(err)}`,
+                    `Failed to publish command: ${err instanceof Error ? err.message : JSON.stringify(err)}`,
                   ),
                 );
               }

--- a/lib/ai/tools/utils/proxy-manager.ts
+++ b/lib/ai/tools/utils/proxy-manager.ts
@@ -7,7 +7,7 @@
  */
 
 import type { ToolContext } from "@/types";
-import { CAIDO_DEFAULTS } from "./caido-proxy";
+import { CAIDO_DEFAULTS, getCaidoConfig } from "./caido-proxy";
 import { buildSandboxCommandOptions } from "./sandbox-command-options";
 import { isCentrifugoSandbox } from "./sandbox-types";
 import { truncateContent, TRUNCATION_MESSAGE } from "@/lib/token-utils";
@@ -45,6 +45,20 @@ export function isCaidoBroken(text: string): boolean {
 async function invalidateAndKillCaido(context: ToolContext): Promise<void> {
   caidoLock.delete(context.sandboxManager);
   cachedCaidoToken = null;
+
+  // When using a custom port, the user manages their own Caido instance —
+  // only clear the lock and token, don't kill their process.
+  if (context.caidoPort) {
+    try {
+      const { sandbox } = await context.sandboxManager.getSandbox();
+      const options = buildSandboxCommandOptions(sandbox);
+      await sandbox.commands.run(`rm -f ${CAIDO_TOKEN_FILE}`, options);
+    } catch {
+      /* best effort */
+    }
+    return;
+  }
+
   try {
     const { sandbox } = await context.sandboxManager.getSandbox();
     const options = buildSandboxCommandOptions(sandbox);
@@ -112,11 +126,86 @@ export async function ensureCaido(context: ToolContext): Promise<void> {
   }
 }
 
+/**
+ * Fast path for user-managed Caido instances (custom port).
+ * Only health-checks and authenticates — never installs or starts Caido.
+ */
+async function doEnsureExternalCaido(
+  sandbox: {
+    commands: {
+      run: (
+        cmd: string,
+        opts: Record<string, unknown>,
+      ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+    };
+    getHost: (port: number) => string;
+  },
+  config: { host: string; port: number },
+  options: Record<string, unknown>,
+): Promise<void> {
+  const baseUrl = `http://${config.host}:${config.port}`;
+
+  // Health check — is the user's Caido reachable?
+  const healthCheck =
+    `curl -s --noproxy '*' -o /dev/null -w "%{http_code}" -X POST "${baseUrl}/graphql"` +
+    ` -H "Content-Type: application/json" -d '{"query":"{ __typename }"}' --max-time 5 2>/dev/null`;
+
+  const healthResult = await sandbox.commands.run(healthCheck, {
+    ...options,
+    timeoutMs: 10000,
+  });
+  const status = healthResult.stdout.trim();
+
+  if (status !== "200" && status !== "400") {
+    throw new Error(
+      `Could not connect to your Caido instance on port ${config.port}. ` +
+        `Ensure Caido is running and listening on ${baseUrl}. ` +
+        `Got HTTP status: ${status || "no response"}.`,
+    );
+  }
+
+  // Authenticate as guest if we don't have a cached token
+  if (!cachedCaidoToken) {
+    const authBody = JSON.stringify({
+      query: "mutation LoginAsGuest { loginAsGuest { token { accessToken } } }",
+    });
+    const authB64 = Buffer.from(authBody).toString("base64");
+    const authResult = await sandbox.commands.run(
+      `echo '${authB64}' | base64 -d | curl -sL --noproxy '*' -X POST "${baseUrl}/graphql" ` +
+        `-H "Content-Type: application/json" --max-time 10 --data @-`,
+      { ...options, timeoutMs: 15000 },
+    );
+    const token = authResult.stdout.match(/"accessToken":"([^"]+)"/)?.[1];
+    if (!token) {
+      throw new Error(
+        `Could not authenticate with Caido on port ${config.port}. ` +
+          `Ensure Caido is running with --allow-guests.`,
+      );
+    }
+    cachedCaidoToken = token;
+    const tokenB64 = Buffer.from(token).toString("base64");
+    await sandbox.commands.run(
+      `echo '${tokenB64}' | base64 -d > ${CAIDO_TOKEN_FILE}`,
+      options,
+    );
+  }
+
+  console.log(
+    `[Caido] Connected to user's existing Caido on port ${config.port}`,
+  );
+}
+
 async function doEnsureCaido(context: ToolContext): Promise<void> {
   const { sandbox } = await context.sandboxManager.getSandbox();
-  const config = CAIDO_DEFAULTS;
+  const config = getCaidoConfig(context.caidoPort);
   const baseUrl = `http://${config.host}:${config.port}`;
   const options = buildSandboxCommandOptions(sandbox);
+
+  // External Caido fast path: when the user specified a custom port, they manage
+  // their own Caido instance. Skip install/start — only health-check + authenticate.
+  if (context.caidoPort) {
+    return doEnsureExternalCaido(sandbox, config, options);
+  }
 
   const authB64 = Buffer.from(
     JSON.stringify({

--- a/lib/ai/tools/utils/sandbox-command-options.ts
+++ b/lib/ai/tools/utils/sandbox-command-options.ts
@@ -4,6 +4,31 @@ import { isE2BSandbox } from "./sandbox-types";
 export const MAX_COMMAND_EXECUTION_TIME = 10 * 60 * 1000; // 10 minutes
 
 /**
+ * Common directories where user-installed CLI tools live (Go, Rust, Homebrew, etc.).
+ * Shell-expanded at runtime via `$HOME`.
+ */
+const LOCAL_EXTRA_PATH_DIRS = [
+  "$HOME/go/bin",
+  "$HOME/.local/bin",
+  "$HOME/.cargo/bin",
+  "/usr/local/bin",
+  "/opt/homebrew/bin",
+  "/usr/local/go/bin",
+].join(":");
+
+/**
+ * Prepend common tool directories to PATH for local (non-E2B) sandboxes.
+ * E2B sandboxes have their own pre-configured PATH and are left untouched.
+ */
+export function augmentCommandPath(
+  command: string,
+  sandbox: AnySandbox,
+): string {
+  if (isE2BSandbox(sandbox)) return command;
+  return `export PATH="${LOCAL_EXTRA_PATH_DIRS}:$PATH" && ${command}`;
+}
+
+/**
  * Build command options for sandbox execution.
  *
  * E2B sandbox requires user: "root" and cwd: "/home/user" for network tools

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -942,7 +942,7 @@ export const createChatHandler = (
                   lastAssistantMessage.parts[0]?.type === "step-start";
 
                 if (hasOnlyStepStart) {
-                  nextJsAxiomLogger.error(
+                  nextJsAxiomLogger.warn(
                     "Stream finished incomplete - triggering fallback",
                     {
                       chatId,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -464,6 +464,7 @@ export const createChatHandler = (
             process.env.CONVEX_SERVICE_ROLE_KEY,
             userCustomization?.guardrails_config,
             userCustomization?.caido_enabled ?? false,
+            userCustomization?.caido_port,
             undefined, // appendMetadataStream
             (costDollars: number) => {
               usageTracker.providerCost += costDollars;

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -103,9 +103,13 @@ const saveTranscriptToSandbox = async (
 
       return path;
     } catch (error) {
-      const isPublishError =
-        error instanceof Error && error.message.includes("Failed to publish");
-      if (isPublishError && attempt < maxRetries) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      const isPublishError = errorMsg.includes("Failed to publish");
+      const isUnrecoverable =
+        errorMsg.includes("connection closed") ||
+        errorMsg.includes("connection lost") ||
+        errorMsg.includes("program not found");
+      if (isPublishError && !isUnrecoverable && attempt < maxRetries) {
         console.warn(
           `[Summarization] Transcript save failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying...`,
           error,

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -71,39 +71,54 @@ const saveTranscriptToSandbox = async (
   sandbox: AnySandbox,
   modelMessages?: ModelMessage[],
 ): Promise<string | null> => {
-  try {
-    const transcriptId = uuidv4();
-    const dir = isE2BSandbox(sandbox)
-      ? "/home/user/agent-transcripts"
-      : "/tmp/agent-transcripts";
-    const path = `${dir}/${transcriptId}.json`;
+  const maxRetries = 2;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const transcriptId = uuidv4();
+      const dir = isE2BSandbox(sandbox)
+        ? "/home/user/agent-transcripts"
+        : "/tmp/agent-transcripts";
+      const path = `${dir}/${transcriptId}.json`;
 
-    // E2B needs an explicit mkdir since its files.write doesn't create parents.
-    // CentrifugoSandbox's files.write already calls ensureDirectory internally
-    // with proper Windows path/shell handling, so skip the raw mkdir for it.
-    if (isE2BSandbox(sandbox)) {
-      await sandbox.commands.run(`mkdir -p ${dir}`, { timeoutMs: 5000 });
+      // E2B needs an explicit mkdir since its files.write doesn't create parents.
+      // CentrifugoSandbox's files.write already calls ensureDirectory internally
+      // with proper Windows path/shell handling, so skip the raw mkdir for it.
+      if (isE2BSandbox(sandbox)) {
+        await sandbox.commands.run(`mkdir -p ${dir}`, { timeoutMs: 5000 });
+      }
+
+      // Save as structured JSON — model messages (mid-stream, with separate
+      // tool-call/tool-result parts) when available, otherwise UI messages
+      const content = JSON.stringify(modelMessages ?? messages, null, 2);
+      if (isE2BSandbox(sandbox)) {
+        // E2B uploads via HTTP — no shell argument limits, string is fine
+        await sandbox.files.write(path, content);
+      } else {
+        // ConvexSandbox/TauriSandbox: pass as ArrayBuffer to trigger binary
+        // chunking in ConvexSandbox, avoiding shell argument size limits that
+        // occur when large strings are embedded in heredoc commands.
+        const buf = new TextEncoder().encode(content);
+        await sandbox.files.write(path, buf.buffer as ArrayBuffer);
+      }
+
+      return path;
+    } catch (error) {
+      const isPublishError =
+        error instanceof Error && error.message.includes("Failed to publish");
+      if (isPublishError && attempt < maxRetries) {
+        console.warn(
+          `[Summarization] Transcript save failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying...`,
+          error,
+        );
+        // Brief delay before retry to allow connection recovery
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        continue;
+      }
+      console.error("[Summarization] Failed to save transcript:", error);
+      return null;
     }
-
-    // Save as structured JSON — model messages (mid-stream, with separate
-    // tool-call/tool-result parts) when available, otherwise UI messages
-    const content = JSON.stringify(modelMessages ?? messages, null, 2);
-    if (isE2BSandbox(sandbox)) {
-      // E2B uploads via HTTP — no shell argument limits, string is fine
-      await sandbox.files.write(path, content);
-    } else {
-      // ConvexSandbox/TauriSandbox: pass as ArrayBuffer to trigger binary
-      // chunking in ConvexSandbox, avoiding shell argument size limits that
-      // occur when large strings are embedded in heredoc commands.
-      const buf = new TextEncoder().encode(content);
-      await sandbox.files.write(path, buf.buffer as ArrayBuffer);
-    }
-
-    return path;
-  } catch (error) {
-    console.error("[Summarization] Failed to save transcript:", error);
-    return null;
   }
+  return null;
 };
 
 export const checkAndSummarizeIfNeeded = async (

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -90,6 +90,7 @@ before coming back to the user.\n"
 const getProxySection = (
   caidoEnabled: boolean,
   isLocalSandbox: boolean,
+  caidoPort?: number,
 ): string => {
   if (!caidoEnabled) {
     return `<proxy_interception>
@@ -97,10 +98,13 @@ Caido proxy is DISABLED by the user. Proxy tools (list_requests, send_request, e
 All HTTP requests from terminal commands go directly to the target without interception.
 </proxy_interception>`;
   }
+  const effectivePort = caidoPort || 48080;
   const uiLine = isLocalSandbox
-    ? `- The user can view captured traffic in Caido's UI at http://127.0.0.1:48080 (local sandbox only).`
+    ? `- The user can view captured traffic in Caido's UI at http://127.0.0.1:${effectivePort} (local sandbox only).`
     : `- The Caido proxy UI is NOT accessible to users in this environment. NEVER share any proxy URL, sandbox URL, or Caido URL. Users interact with proxy data exclusively through the proxy tools.`;
-  const runningLine = `Caido CLI — a modern web security proxy — starts automatically when proxy tools are first used. Once started, it intercepts all HTTP/HTTPS traffic.`;
+  const runningLine = caidoPort
+    ? `Connected to the user's existing Caido instance on port ${caidoPort}. Do NOT attempt to install or start Caido — the user manages it themselves.`
+    : `Caido CLI — a modern web security proxy — starts automatically when proxy tools are first used. Once started, it intercepts all HTTP/HTTPS traffic.`;
   return `<proxy_interception>
 ${runningLine}
 - Use proxy tools (list_requests, view_request, send_request, scope_rules, list_sitemap, view_sitemap_entry) to inspect, replay, and modify captured traffic.
@@ -113,6 +117,7 @@ ${uiLine}
 
 const getDefaultSandboxEnvironmentSection = (
   caidoEnabled: boolean,
+  caidoPort?: number,
 ): string => `<sandbox_environment>
 IMPORTANT: All tools operate in an isolated sandbox environment that is individual to each user. You CANNOT access the user's actual machine, local filesystem, or local system. Tools can ONLY interact with the sandbox environment described below.
 
@@ -135,13 +140,14 @@ Development Environment:
 
 ${PREINSTALLED_PENTESTING_TOOLS}
 
-${getProxySection(caidoEnabled, false)}
+${getProxySection(caidoEnabled, false, caidoPort)}
 </sandbox_environment>`;
 
 const getAgentModeSection = (
   mode: ChatMode,
   sandboxContext?: string | null,
   caidoEnabled: boolean = false,
+  caidoPort?: number,
 ): string => {
   const agentSpecificNote =
     mode === "agent"
@@ -241,7 +247,7 @@ When running security scans:
 - Chain scan results intelligently — use output from reconnaissance to inform targeted exploitation
 </scan_methodology>
 
-${sandboxContext ? sandboxContext + "\n\n" + getProxySection(caidoEnabled, true) : getDefaultSandboxEnvironmentSection(caidoEnabled)}
+${sandboxContext ? sandboxContext + "\n\n" + getProxySection(caidoEnabled, true, caidoPort) : getDefaultSandboxEnvironmentSection(caidoEnabled, caidoPort)}
 
 ${getProductQuestionsSection()}
 
@@ -364,7 +370,10 @@ The current date is ${currentDateTime}.`;
     sections.push(getAskModeSection(modelName, subscription, isTemporary));
   } else {
     const caidoEnabled = userCustomization?.caido_enabled ?? false;
-    sections.push(getAgentModeSection(mode, sandboxContext, caidoEnabled));
+    const caidoPort = userCustomization?.caido_port;
+    sections.push(
+      getAgentModeSection(mode, sandboxContext, caidoEnabled, caidoPort),
+    );
   }
 
   sections.push(getSecurityInstructions());

--- a/packages/desktop/src-tauri/src/platform.rs
+++ b/packages/desktop/src-tauri/src/platform.rs
@@ -40,7 +40,21 @@ pub fn get_shell_config() -> ShellConfig {
     {
         static USER_SHELL: std::sync::OnceLock<String> = std::sync::OnceLock::new();
         let shell = USER_SHELL.get_or_init(|| {
-            std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
+            use std::path::Path;
+            let candidates = [
+                std::env::var("SHELL").ok(),
+                Some("/bin/sh".to_string()),
+                Some("/bin/bash".to_string()),
+                Some("/usr/bin/sh".to_string()),
+                Some("/usr/bin/bash".to_string()),
+            ];
+            for candidate in candidates.into_iter().flatten() {
+                if Path::new(&candidate).exists() {
+                    return candidate;
+                }
+            }
+            // Last resort — hope the OS can resolve "sh" via PATH
+            "sh".to_string()
         });
         ShellConfig {
             shell: shell.clone(),

--- a/packages/desktop/src-tauri/src/platform.rs
+++ b/packages/desktop/src-tauri/src/platform.rs
@@ -1,5 +1,14 @@
 use std::time::Duration;
 
+/// Check if a path is executable (Unix: has execute permission).
+#[cfg(not(windows))]
+fn is_executable(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.metadata()
+        .map(|m| m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
 /// Shell configuration for cross-platform command execution.
 pub struct ShellConfig {
     pub shell: String,
@@ -49,7 +58,8 @@ pub fn get_shell_config() -> ShellConfig {
                 Some("/usr/bin/bash".to_string()),
             ];
             for candidate in candidates.into_iter().flatten() {
-                if Path::new(&candidate).exists() {
+                let p = Path::new(&candidate);
+                if p.is_file() && is_executable(p) {
                     return candidate;
                 }
             }

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -64,6 +64,8 @@ export interface ToolContext {
   guardrailsConfig?: string;
   /** Whether the Caido proxy is enabled (default true). When false, proxy tools are hidden and HTTP_PROXY env vars are not injected. */
   caidoEnabled: boolean;
+  /** Custom Caido port for local sandbox users with an existing instance (default: 48080). */
+  caidoPort?: number;
   /** When set, run_terminal_cmd awaits this for each terminal chunk so the run yields and metadata delivery can happen in real time. */
   appendMetadataStream?: AppendMetadataStreamFn;
   /** Callback to report additional tool costs (in dollars) that should be added to the request's total cost. */

--- a/types/user.ts
+++ b/types/user.ts
@@ -6,6 +6,8 @@ export interface UserCustomization {
   readonly additional_info?: string;
   readonly include_memory_entries?: boolean;
   readonly caido_enabled?: boolean;
+  /** Custom Caido port for local sandbox users with an existing Caido instance (default: 48080). */
+  readonly caido_port?: number;
   readonly updated_at: number;
   readonly extra_usage_enabled?: boolean;
   readonly max_mode_enabled?: boolean;


### PR DESCRIPTION
## Summary
- **Centrifugo publish error diagnostics**: `String(err)` → `JSON.stringify(err)` so publish rejections log useful details instead of `[object Object]`
- **Transcript save retry**: up to 2 retries with 1s delay for Centrifugo publish failures during summarization, covering stale connections on long-running desktop agent sessions
- **Desktop shell fallback (Unix)**: verify `$SHELL` binary exists before spawning; fall back through `/bin/sh` → `/bin/bash` → `/usr/bin/sh` → `/usr/bin/bash` → `sh` to fix "program not found" errors on systems with missing or misconfigured shells
- **Resumable stream ack timeout**: catch producer-gone timeout in stream resume so the replay fallback kicks in instead of crashing
- **Incomplete stream log level**: downgrade "Stream finished incomplete" from error to warn since the fallback handles it gracefully

## Test plan
- [x] `cargo check` passes for desktop crate
- [x] `tsc --noEmit` passes
- [x] All 798 tests pass
- [ ] Verify transcript save succeeds on desktop sandbox after long-running agent session
- [ ] Verify desktop app launches correctly on Linux with non-standard `$SHELL`
- [ ] Verify stream resume falls back to replay when producer is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Custom Port" setting for Caido with UI to set/reset port; app reflects custom port in agent/sandbox prompts.
  * Option to connect to an existing external Caido instance (uses configured port, skips local install/start).

* **Bug Fixes**
  * Graceful fallback when resumable chat streams fail.
  * Transcript save now retries transient publish failures.
  * Improved error serialization for publish failures.

* **Chores**
  * Lowered log severity for a known incomplete-output condition.
  * Better shell detection and PATH augmentation for local command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->