### PR TITLE
feat: add doom loop detection for agent tool calls

### DIFF
--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -15,7 +15,13 @@ import {
   elapsedTimeExceeds,
   PREEMPTIVE_TIMEOUT_FINISH_REASON,
   AGENT_MAX_STREAM_DURATION_MS,
+  doomLoopDetected,
+  DOOM_LOOP_FINISH_REASON,
 } from "@/lib/chat/stop-conditions";
+import {
+  detectDoomLoop,
+  generateDoomLoopNudge,
+} from "@/lib/chat/doom-loop-detection";
 import { createTools } from "@/lib/ai/tools";
 import { generateTitleFromUserMessageWithWriter } from "@/lib/actions";
 import { getUserIDAndPro } from "@/lib/auth/get-user-id";
@@ -600,6 +606,7 @@ export const createChatHandler = (
           const hasSummarized = () => summarizationTracker.hasSummarized;
           let stoppedDueToTokenExhaustion = false;
           let stoppedDueToPreemptiveTimeout = false;
+          let stoppedDueToDoomLoop = false;
           let lastStepInputTokens = 0;
           const isReasoningModel = isAgentMode(mode);
 
@@ -769,10 +776,31 @@ export const createChatHandler = (
                       (lastStep as { toolResults?: unknown[] }).toolResults) ||
                     [];
 
-                  const updatedMessages = await applyPrepareStepReminders(
+                  let updatedMessages = await applyPrepareStepReminders(
                     currentMessages,
                     { toolResults, noteInjectionOpts },
                   );
+
+                  // Doom loop detection: inject nudge as trailing user message
+                  const loopCheck = detectDoomLoop(
+                    steps as unknown as Parameters<typeof detectDoomLoop>[0],
+                  );
+                  if (loopCheck.severity !== "none") {
+                    console.log(
+                      `[doom-loop] severity=${loopCheck.severity} tools=${loopCheck.toolNames.join(",")} count=${loopCheck.consecutiveCount} step=${steps.length}`,
+                    );
+
+                    if (loopCheck.severity === "warning") {
+                      const nudge = generateDoomLoopNudge(loopCheck);
+                      console.log(
+                        `[doom-loop] Injecting nudge as last user message`,
+                      );
+                      updatedMessages = [
+                        ...updatedMessages,
+                        { role: "user", content: nudge },
+                      ] as typeof updatedMessages;
+                    }
+                  }
 
                   return {
                     messages: filterEmptyAssistantMessages(
@@ -823,6 +851,11 @@ export const createChatHandler = (
                         stoppedDueToPreemptiveTimeout = true;
                       },
                     }),
+                    doomLoopDetected({
+                      onFired: () => {
+                        stoppedDueToDoomLoop = true;
+                      },
+                    }),
                   ]
                 : stepCountIs(getMaxStepsForUser(mode, subscription)),
               onChunk: async (chunk) => {
@@ -859,6 +892,8 @@ export const createChatHandler = (
                   streamFinishReason = PREEMPTIVE_TIMEOUT_FINISH_REASON;
                 } else if (stoppedDueToTokenExhaustion) {
                   streamFinishReason = TOKEN_EXHAUSTION_FINISH_REASON;
+                } else if (stoppedDueToDoomLoop) {
+                  streamFinishReason = DOOM_LOOP_FINISH_REASON;
                 } else {
                   streamFinishReason = finishReason;
                 }
@@ -921,6 +956,7 @@ export const createChatHandler = (
               lastStepInputTokens = 0;
               stoppedDueToTokenExhaustion = false;
               stoppedDueToPreemptiveTimeout = false;
+              stoppedDueToDoomLoop = false;
               preFallbackCacheRead = usageTracker.cacheReadTokens;
               preFallbackCacheWrite = usageTracker.cacheWriteTokens;
               result = await createStream(fallbackModel);
@@ -966,6 +1002,7 @@ export const createChatHandler = (
                     lastStepInputTokens = 0;
                     stoppedDueToTokenExhaustion = false;
                     stoppedDueToPreemptiveTimeout = false;
+                    stoppedDueToDoomLoop = false;
                     const fallbackStartTime = Date.now();
 
                     const retryResult = await createStream(fallbackModel);
@@ -1147,6 +1184,7 @@ export const createChatHandler = (
                             !retryAborted &&
                             !stoppedDueToPreemptiveTimeout &&
                             !stoppedDueToTokenExhaustion &&
+                            !stoppedDueToDoomLoop &&
                             streamFinishReason === "stop";
                           await deductAccumulatedUsage(isFallbackClean);
                         },
@@ -1446,6 +1484,7 @@ export const createChatHandler = (
                   !isAborted &&
                   !stoppedDueToPreemptiveTimeout &&
                   !stoppedDueToTokenExhaustion &&
+                  !stoppedDueToDoomLoop &&
                   streamFinishReason === "stop";
                 await deductAccumulatedUsage(isCleanCompletion);
               },

--- a/lib/chat/__tests__/doom-loop-detection.test.ts
+++ b/lib/chat/__tests__/doom-loop-detection.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  createStepFingerprint,
+  detectDoomLoop,
+  generateDoomLoopNudge,
+  DOOM_LOOP_WARNING_THRESHOLD,
+  DOOM_LOOP_HALT_THRESHOLD,
+} from "../doom-loop-detection";
+
+function makeStep(toolCalls: Array<{ toolName: string; input: unknown }>) {
+  return { toolCalls };
+}
+
+describe("createStepFingerprint", () => {
+  it("returns sentinel for steps with no tool calls", () => {
+    expect(createStepFingerprint(makeStep([]))).toBe("__no_tools__");
+  });
+
+  it("returns consistent fingerprint for same tool call", () => {
+    const step = makeStep([{ toolName: "file", input: { path: "/a.txt" } }]);
+    expect(createStepFingerprint(step)).toBe(createStepFingerprint(step));
+  });
+
+  it("sorts tool calls by name for deterministic fingerprint", () => {
+    const step1 = makeStep([
+      { toolName: "b_tool", input: {} },
+      { toolName: "a_tool", input: {} },
+    ]);
+    const step2 = makeStep([
+      { toolName: "a_tool", input: {} },
+      { toolName: "b_tool", input: {} },
+    ]);
+    expect(createStepFingerprint(step1)).toBe(createStepFingerprint(step2));
+  });
+
+  it("different args produce different fingerprints", () => {
+    const step1 = makeStep([{ toolName: "file", input: { path: "/a.txt" } }]);
+    const step2 = makeStep([{ toolName: "file", input: { path: "/b.txt" } }]);
+    expect(createStepFingerprint(step1)).not.toBe(createStepFingerprint(step2));
+  });
+
+  it("ignores brief field when fingerprinting", () => {
+    const step1 = makeStep([
+      {
+        toolName: "file",
+        input: { action: "read", path: "/a.txt", brief: "Read the file" },
+      },
+    ]);
+    const step2 = makeStep([
+      {
+        toolName: "file",
+        input: {
+          action: "read",
+          path: "/a.txt",
+          brief: "Retry reading the file",
+        },
+      },
+    ]);
+    expect(createStepFingerprint(step1)).toBe(createStepFingerprint(step2));
+  });
+
+  it("ignores explanation field when fingerprinting", () => {
+    const step1 = makeStep([
+      {
+        toolName: "run_terminal_cmd",
+        input: { command: "ls", explanation: "List files" },
+      },
+    ]);
+    const step2 = makeStep([
+      {
+        toolName: "run_terminal_cmd",
+        input: { command: "ls", explanation: "Trying again to list" },
+      },
+    ]);
+    expect(createStepFingerprint(step1)).toBe(createStepFingerprint(step2));
+  });
+});
+
+describe("detectDoomLoop", () => {
+  it("returns none for empty steps", () => {
+    expect(detectDoomLoop([])).toEqual({
+      severity: "none",
+      toolNames: [],
+      consecutiveCount: 0,
+    });
+  });
+
+  it("returns none for fewer steps than warning threshold", () => {
+    const step = makeStep([{ toolName: "file", input: { path: "/a.txt" } }]);
+    const steps = Array(DOOM_LOOP_WARNING_THRESHOLD - 1).fill(step);
+    expect(detectDoomLoop(steps).severity).toBe("none");
+  });
+
+  it("returns warning at exactly warning threshold identical steps", () => {
+    const step = makeStep([{ toolName: "file", input: { path: "/a.txt" } }]);
+    const steps = Array(DOOM_LOOP_WARNING_THRESHOLD).fill(step);
+    const result = detectDoomLoop(steps);
+    expect(result.severity).toBe("warning");
+    expect(result.toolNames).toEqual(["file"]);
+    expect(result.consecutiveCount).toBe(DOOM_LOOP_WARNING_THRESHOLD);
+  });
+
+  it("returns warning between warning and halt thresholds", () => {
+    const step = makeStep([
+      { toolName: "run_terminal_cmd", input: { command: "ls" } },
+    ]);
+    const steps = Array(DOOM_LOOP_HALT_THRESHOLD - 1).fill(step);
+    const result = detectDoomLoop(steps);
+    expect(result.severity).toBe("warning");
+    expect(result.consecutiveCount).toBe(DOOM_LOOP_HALT_THRESHOLD - 1);
+  });
+
+  it("returns halt at exactly halt threshold identical steps", () => {
+    const step = makeStep([{ toolName: "file", input: { path: "/a.txt" } }]);
+    const steps = Array(DOOM_LOOP_HALT_THRESHOLD).fill(step);
+    const result = detectDoomLoop(steps);
+    expect(result.severity).toBe("halt");
+    expect(result.consecutiveCount).toBe(DOOM_LOOP_HALT_THRESHOLD);
+  });
+
+  it("returns halt above halt threshold", () => {
+    const step = makeStep([{ toolName: "file", input: { path: "/a.txt" } }]);
+    const steps = Array(DOOM_LOOP_HALT_THRESHOLD + 3).fill(step);
+    const result = detectDoomLoop(steps);
+    expect(result.severity).toBe("halt");
+  });
+
+  it("returns none when chain is broken by a different tool call", () => {
+    const stepA = makeStep([{ toolName: "file", input: { path: "/a.txt" } }]);
+    const stepB = makeStep([
+      { toolName: "run_terminal_cmd", input: { command: "pwd" } },
+    ]);
+    // A, A, B, A, A — only 2 trailing identical
+    const steps = [stepA, stepA, stepB, stepA, stepA];
+    expect(detectDoomLoop(steps).severity).toBe("none");
+  });
+
+  it("returns none when chain is broken by a no-tool step", () => {
+    const step = makeStep([{ toolName: "file", input: { path: "/a.txt" } }]);
+    const noToolStep = makeStep([]);
+    // 3 identical, then no-tool, then 2 identical — trailing count is 2
+    const steps = [step, step, step, noToolStep, step, step];
+    expect(detectDoomLoop(steps).severity).toBe("none");
+  });
+
+  it("returns none when same tool has different args each time", () => {
+    const steps = Array.from({ length: 5 }, (_, i) =>
+      makeStep([{ toolName: "file", input: { path: `/file${i}.txt` } }]),
+    );
+    expect(detectDoomLoop(steps).severity).toBe("none");
+  });
+
+  it("detects loop when only brief/explanation differs between calls", () => {
+    const steps = [
+      makeStep([
+        {
+          toolName: "file",
+          input: {
+            action: "read",
+            path: "/home/user/.credentials/api_key.txt",
+            brief: "Read the API key file as requested",
+          },
+        },
+      ]),
+      makeStep([
+        {
+          toolName: "file",
+          input: {
+            action: "read",
+            path: "/home/user/.credentials/api_key.txt",
+            brief: "Retry reading the API key file",
+          },
+        },
+      ]),
+      makeStep([
+        {
+          toolName: "file",
+          input: {
+            action: "read",
+            path: "/home/user/.credentials/api_key.txt",
+            brief: "Third attempt to read the API key file",
+          },
+        },
+      ]),
+    ];
+    const result = detectDoomLoop(steps);
+    expect(result.severity).toBe("warning");
+    expect(result.toolNames).toEqual(["file"]);
+    expect(result.consecutiveCount).toBe(3);
+  });
+
+  it("handles steps with multiple tool calls", () => {
+    const step = makeStep([
+      { toolName: "file", input: { path: "/a.txt" } },
+      { toolName: "run_terminal_cmd", input: { command: "ls" } },
+    ]);
+    const steps = Array(DOOM_LOOP_WARNING_THRESHOLD).fill(step);
+    const result = detectDoomLoop(steps);
+    expect(result.severity).toBe("warning");
+    expect(result.toolNames).toContain("file");
+    expect(result.toolNames).toContain("run_terminal_cmd");
+  });
+});
+
+describe("generateDoomLoopNudge", () => {
+  it("includes tool name and count", () => {
+    const nudge = generateDoomLoopNudge({
+      severity: "warning",
+      toolNames: ["file"],
+      consecutiveCount: 3,
+    });
+    expect(nudge).toContain("file");
+    expect(nudge).toContain("3 times");
+    expect(nudge).toContain("[LOOP DETECTED]");
+  });
+
+  it("includes multiple tool names", () => {
+    const nudge = generateDoomLoopNudge({
+      severity: "warning",
+      toolNames: ["file", "run_terminal_cmd"],
+      consecutiveCount: 4,
+    });
+    expect(nudge).toContain("file");
+    expect(nudge).toContain("run_terminal_cmd");
+    expect(nudge).toContain("4 times");
+  });
+});

--- a/lib/chat/doom-loop-detection.ts
+++ b/lib/chat/doom-loop-detection.ts
@@ -1,0 +1,128 @@
+/**
+ * Doom Loop Detection
+ *
+ * Detects when the AI agent is stuck in a loop, repeatedly calling the same
+ * tool(s) with identical arguments. Inspired by OpenCode's doom loop detection
+ * (sst/opencode PR #3445).
+ *
+ * Two-tier response:
+ * - Warning (3 consecutive identical steps): inject a nudge as a user message
+ * - Halt (5 consecutive identical steps): stop generation entirely
+ */
+
+export const DOOM_LOOP_WARNING_THRESHOLD = 3;
+export const DOOM_LOOP_HALT_THRESHOLD = 5;
+
+export type DoomLoopSeverity = "none" | "warning" | "halt";
+
+export interface DoomLoopResult {
+  severity: DoomLoopSeverity;
+  toolNames: string[];
+  consecutiveCount: number;
+}
+
+interface MinimalToolCall {
+  toolName: string;
+  input?: unknown;
+}
+
+export interface MinimalStep {
+  toolCalls: MinimalToolCall[];
+}
+
+// Fields in tool inputs that are cosmetic descriptions (change each call even
+// when the functional arguments are identical). Stripped before fingerprinting.
+const COSMETIC_INPUT_FIELDS = new Set(["brief", "explanation"]);
+
+function stripCosmeticFields(input: unknown): unknown {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return input;
+  }
+  const entries = Object.entries(input as Record<string, unknown>).filter(
+    ([key]) => !COSMETIC_INPUT_FIELDS.has(key),
+  );
+  return Object.fromEntries(entries);
+}
+
+/**
+ * Creates a deterministic fingerprint for a step's tool calls.
+ * Steps with no tool calls return a sentinel that breaks any loop chain.
+ * Strips cosmetic fields (brief, explanation) that change per-call.
+ */
+export function createStepFingerprint(step: MinimalStep): string {
+  if (!step.toolCalls || step.toolCalls.length === 0) {
+    return "__no_tools__";
+  }
+
+  const sorted = [...step.toolCalls]
+    .map((tc) => ({
+      toolName: tc.toolName,
+      input: stripCosmeticFields(tc.input),
+    }))
+    .sort((a, b) => a.toolName.localeCompare(b.toolName));
+
+  return JSON.stringify(sorted);
+}
+
+/**
+ * Detects doom loops by counting trailing identical step fingerprints.
+ */
+export function detectDoomLoop(steps: MinimalStep[]): DoomLoopResult {
+  const none: DoomLoopResult = {
+    severity: "none",
+    toolNames: [],
+    consecutiveCount: 0,
+  };
+
+  if (steps.length < DOOM_LOOP_WARNING_THRESHOLD) {
+    return none;
+  }
+
+  // Get fingerprint of the last step
+  const lastStep = steps[steps.length - 1];
+  const lastFingerprint = createStepFingerprint(lastStep);
+
+  // No-tool steps can't form a doom loop
+  if (lastFingerprint === "__no_tools__") {
+    return none;
+  }
+
+  // Count how many trailing steps share the same fingerprint
+  let count = 1;
+  for (let i = steps.length - 2; i >= 0; i--) {
+    if (createStepFingerprint(steps[i]) === lastFingerprint) {
+      count++;
+    } else {
+      break;
+    }
+  }
+
+  if (count < DOOM_LOOP_WARNING_THRESHOLD) {
+    return none;
+  }
+
+  const toolNames = [...new Set(lastStep.toolCalls.map((tc) => tc.toolName))];
+
+  return {
+    severity: count >= DOOM_LOOP_HALT_THRESHOLD ? "halt" : "warning",
+    toolNames,
+    consecutiveCount: count,
+  };
+}
+
+/**
+ * Generates a nudge message to inject as a trailing user message when a doom
+ * loop is detected. The message guides the model to break out of the loop.
+ */
+export function generateDoomLoopNudge(result: DoomLoopResult): string {
+  const toolList = result.toolNames.join(", ");
+
+  return (
+    `[LOOP DETECTED] You have called ${toolList} ${result.consecutiveCount} times in a row with identical arguments. ` +
+    `You are stuck in a loop and not making progress. You MUST try a DIFFERENT approach:\n` +
+    `- If a command or tool keeps failing, read the error carefully and adjust your strategy\n` +
+    `- Try different parameters, a different tool, or a different method entirely\n` +
+    `- If you cannot make progress, explain what you've tried and ask the user for guidance\n` +
+    `Do NOT repeat the same tool call again.`
+  );
+}

--- a/lib/chat/stop-conditions.ts
+++ b/lib/chat/stop-conditions.ts
@@ -1,4 +1,8 @@
 import type { StopCondition } from "ai";
+import {
+  detectDoomLoop,
+  type MinimalStep,
+} from "@/lib/chat/doom-loop-detection";
 
 export const TOKEN_EXHAUSTION_FINISH_REASON = "context-limit";
 
@@ -32,5 +36,20 @@ export function elapsedTimeExceeds(state: {
     const shouldStop = elapsed >= state.maxDurationMs;
     if (shouldStop) state.onFired();
     return shouldStop;
+  };
+}
+
+export const DOOM_LOOP_FINISH_REASON = "doom-loop";
+
+export function doomLoopDetected(state: {
+  onFired: () => void;
+}): StopCondition<any> {
+  return ({ steps }) => {
+    const result = detectDoomLoop(steps as unknown as MinimalStep[]);
+    if (result.severity === "halt") {
+      state.onFired();
+      return true;
+    }
+    return false;
   };
 }


### PR DESCRIPTION
Detect when the AI agent is stuck calling the same tool with identical arguments. Inspired by OpenCode's doom loop detection (sst/opencode PR #3445).

Two-tier response:
- Warning (3 consecutive identical steps): inject a nudge as a trailing user message telling the model to try a different approach
- Halt (5 consecutive identical steps): stop generation with finish reason "doom-loop"

Cosmetic tool input fields (brief, explanation) are stripped before fingerprinting so description changes don't mask identical calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented doom-loop detection to prevent AI agents from becoming stuck in repetitive patterns. The system now warns after detecting 3 consecutive identical actions and halts execution after 5 consecutive identical actions.
  * Added automatic guidance nudges to redirect agent behavior when repetitive patterns are detected.

* **Tests**
  * Added comprehensive tests validating doom-loop detection and guidance message generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->