### PR TITLE
fix: skip bash PATH augmentation on Windows local sandboxes

### DIFF
--- a/lib/ai/tools/utils/sandbox-command-options.ts
+++ b/lib/ai/tools/utils/sandbox-command-options.ts
@@ -1,5 +1,5 @@
 import type { AnySandbox } from "@/types";
-import { isE2BSandbox } from "./sandbox-types";
+import { isCentrifugoSandbox, isE2BSandbox } from "./sandbox-types";
 
 export const MAX_COMMAND_EXECUTION_TIME = 10 * 60 * 1000; // 10 minutes
 
@@ -25,6 +25,10 @@ export function augmentCommandPath(
   sandbox: AnySandbox,
 ): string {
   if (isE2BSandbox(sandbox)) return command;
+  // Windows local sandboxes use cmd.exe or git-bash — Unix PATH dirs
+  // ($HOME/go/bin, /opt/homebrew/bin, etc.) don't apply, and `export`
+  // syntax would break cmd.exe entirely.
+  if (isCentrifugoSandbox(sandbox) && sandbox.isWindows()) return command;
   return `export PATH="${LOCAL_EXTRA_PATH_DIRS}:$PATH" && ${command}`;
 }
 


### PR DESCRIPTION
augmentCommandPath() unconditionally prepended `export PATH="..."` to every command on local sandboxes. Since `export` is bash syntax, this broke all command execution on Windows cmd.exe with "'export' is not recognized as an internal or external command". File writes also failed as a downstream consequence since sandbox.files.write() runs shell commands internally.

Skip PATH augmentation on Windows entirely — the Unix-style dirs ($HOME/go/bin, /opt/homebrew/bin, etc.) don't exist on Windows anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command execution on Windows for Centrifugo sandboxes. Removed unnecessary Unix-style path exports that were being prepended to commands, ensuring proper command handling on Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->