### PR TITLE
fix: use platform-aware shell syntax in local sandbox client on Windows

### DIFF
--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -361,8 +361,12 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
     return `'${path.replace(/'/g, "'\\''")}'`;
   }
 
-  // Max chunk size ~500KB base64 to stay under size limits
+  // Max chunk size ~500KB base64 to stay under size limits (bash path)
   private static readonly MAX_CHUNK_SIZE = 500 * 1024;
+
+  // cmd.exe has an ~8191 character command line limit. Reserve room for
+  // `echo `, redirect operator, and file path — keep data under 7000 chars.
+  private static readonly MAX_CMD_CHUNK_SIZE = 7000;
 
   /** Extract parent directory from a path, handling both `/` and `\` separators. */
   private static parentDir(path: string): string {
@@ -564,15 +568,12 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
           ? contentStr
           : Buffer.from(contentStr).toString("base64");
 
-        // Chunk if needed
+        // Chunk to stay within cmd.exe's ~8191 char command line limit.
+        const chunkSize = CentrifugoSandbox.MAX_CMD_CHUNK_SIZE;
         const chunks: string[] = [];
-        if (b64.length > CentrifugoSandbox.MAX_CHUNK_SIZE) {
-          for (
-            let i = 0;
-            i < b64.length;
-            i += CentrifugoSandbox.MAX_CHUNK_SIZE
-          ) {
-            chunks.push(b64.slice(i, i + CentrifugoSandbox.MAX_CHUNK_SIZE));
+        if (b64.length > chunkSize) {
+          for (let i = 0; i < b64.length; i += chunkSize) {
+            chunks.push(b64.slice(i, i + chunkSize));
           }
         } else {
           chunks.push(b64);

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -418,13 +418,30 @@ class LocalSandboxClient {
     try {
       let fullCommand = command;
 
+      // Detect whether the default shell is cmd.exe so we emit the
+      // correct syntax for cd and environment variable injection.
+      const shellBase =
+        DEFAULT_SHELL.shell
+          .toLowerCase()
+          .replace(/\\/g, "/")
+          .split("/")
+          .pop() ?? "";
+      const useCmd = shellBase === "cmd" || shellBase === "cmd.exe";
+
       if (cwd && cwd.trim() !== "") {
-        fullCommand = `cd "${cwd}" 2>/dev/null && ${fullCommand}`;
+        fullCommand = useCmd
+          ? `cd /d "${cwd}" && ${fullCommand}`
+          : `cd "${cwd}" 2>/dev/null && ${fullCommand}`;
       }
 
       if (env) {
         const envString = Object.entries(env)
           .map(([k, v]) => {
+            if (useCmd) {
+              // cmd.exe: use `set` with no trailing space inside quotes
+              const escaped = v.replace(/"/g, '""');
+              return `set "${k}=${escaped}"`;
+            }
             const escaped = v
               .replace(/\\/g, "\\\\")
               .replace(/"/g, '\\"')
@@ -432,8 +449,10 @@ class LocalSandboxClient {
               .replace(/`/g, "\\`");
             return `export ${k}="${escaped}"`;
           })
-          .join("; ");
-        fullCommand = `${envString}; ${fullCommand}`;
+          .join(useCmd ? " && " : "; ");
+        fullCommand = useCmd
+          ? `${envString} && ${fullCommand}`
+          : `${envString}; ${fullCommand}`;
       }
 
       if (background) {

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -439,7 +439,7 @@ class LocalSandboxClient {
           .map(([k, v]) => {
             if (useCmd) {
               // cmd.exe: use `set` with no trailing space inside quotes
-              const escaped = v.replace(/"/g, '""');
+              const escaped = v.replace(/%/g, "%%").replace(/"/g, '""');
               return `set "${k}=${escaped}"`;
             }
             const escaped = v


### PR DESCRIPTION
## Summary
- **Local client env vars**: `handleCommand()` in `packages/local/src/index.ts` unconditionally used bash `export VAR="val"` and `cd ... 2>/dev/null` syntax. On Windows without git-bash (cmd.exe fallback), every command with env vars failed with `'export' is not recognized`. Now detects cmd.exe and uses `set "VAR=val"` + `cd /d "dir"` instead.
- **File write chunk size**: The cmd.exe file write path in `centrifugo-sandbox.ts` used 500KB chunks in `echo` commands — 84x larger than cmd.exe's ~8191 char command line limit. Added `MAX_CMD_CHUNK_SIZE = 7000` for the cmd.exe path.

Follows up on the `augmentCommandPath` fix already merged to main (commit 2e6f06b).

## Test plan
- [x] TypeScript type check passes
- [x] All 817 tests pass
- [ ] On Windows without git-bash: verify `set` syntax is used for env vars, `cd /d` for directory changes
- [ ] On Windows without git-bash: verify file writes work for files > 8KB (triggers chunking)
- [ ] On Linux/Mac: verify bash syntax (`export`, `cd ... 2>/dev/null`) is still used (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows cmd.exe execution: working directory changes and environment variable injection now follow cmd syntax to run reliably.
  * Fixed command-line length handling for cmd.exe by implementing appropriate chunking to avoid exceeding cmd limits.
  * Enhanced shell compatibility: non-cmd shells retain existing POSIX behavior while cmd-specific behavior is applied where needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->