### PR TITLE
feat: enable message queuing in ask mode

### DIFF
--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -150,8 +150,7 @@ export const ChatInput = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const canSubmit =
-      (status === "ready" ||
-        (status === "streaming" && isAgentMode(chatMode))) &&
+      (status === "ready" || status === "streaming") &&
       !isUploadingFiles &&
       (input.trim() || uploadedFiles.length > 0);
 
@@ -176,7 +175,7 @@ export const ChatInput = ({
 
         <TodoPanel status={status} />
 
-        {messageQueue.length > 0 && chatMode === "agent" && (
+        {messageQueue.length > 0 && (
           <QueuedMessagesPanel
             messages={messageQueue}
             onSendNow={onSendNow}

--- a/app/components/RateLimitWarning.tsx
+++ b/app/components/RateLimitWarning.tsx
@@ -71,7 +71,7 @@ const getMessage = (data: RateLimitWarningData, timeString: string): string => {
   if (data.warningType === "sliding-window") {
     return data.remaining === 0
       ? `You've used all your daily responses. Daily responses reset at midnight UTC.`
-      : `You have ${data.remaining} daily ${data.remaining === 1 ? "response" : "responses"} remaining. Daily responses reset at midnight UTC.`;
+      : `You have ${data.remaining} daily ${data.remaining === 1 ? "response" : "responses"} remaining today.`;
   }
 
   if (data.warningType === "extra-usage-active") {

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -970,13 +970,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     messageQueueRef.current = messageQueue;
   }, [messageQueue]);
 
-  // Clear queue when switching from Agent to Ask mode
-  useEffect(() => {
-    if (chatMode === "ask" && messageQueueRef.current.length > 0) {
-      clearQueue();
-    }
-  }, [chatMode, clearQueue]);
-
   // Clear queue when navigating to a different chat
   useEffect(() => {
     return () => {
@@ -1002,7 +995,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       !isProcessingQueue &&
       !isSendingNowRef.current &&
       !hasManuallyStoppedRef.current &&
-      chatMode === "agent" &&
       queueBehavior === "queue"
     ) {
       setIsProcessingQueue(true);
@@ -1039,7 +1031,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     status,
     messageQueue.length,
     isProcessingQueue,
-    chatMode,
     dequeueNext,
     sendMessage,
     queueBehavior,

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -179,7 +179,7 @@ export const useChatHandlers = ({
     const hasValidFiles = uploadedFiles.some((f) => f.uploaded && f.url);
     if (input.trim() || hasValidFiles) {
       // If streaming in Agent mode, check queue behavior
-      if (status === "streaming" && chatMode === "agent") {
+      if (status === "streaming") {
         const validFiles = uploadedFiles.filter(
           (file) => file.uploaded && file.url && file.fileId,
         );

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -118,7 +118,7 @@ const saveTranscriptToSandbox = async (
         await new Promise((resolve) => setTimeout(resolve, 1000));
         continue;
       }
-      console.error("[Summarization] Failed to save transcript:", error);
+      console.warn("[Summarization] Failed to save transcript:", error);
       return null;
     }
   }


### PR DESCRIPTION
## Summary
- Remove agent-only restrictions on message queuing so users can queue messages and use stop-and-send while streaming in ask mode
- Remove the effect that cleared the queue when switching from agent to ask mode
- Allow the `QueuedMessagesPanel` to render in all chat modes
- Simplify daily usage warning to show "remaining today" instead of reset time details

## Test plan
- [x] Start a chat in ask mode, send a message, and while streaming type another message — verify it gets queued
- [x] Verify the queued messages panel appears in ask mode
- [x] Switch queue behavior to "stop-and-send" and verify it stops the current stream and sends immediately in ask mode
- [x] Verify agent mode queuing still works as before
- [x] Verify queue is cleared when navigating to a different chat
- [x] Verify daily usage warning shows "X remaining today" without reset time info

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message queuing now works consistently across all chat modes.
  * Queued messages panel displays whenever messages are pending.

* **Bug Fixes**
  * Message submission and queue processing during streaming behave consistently regardless of the active chat mode.
  * Queued messages are no longer cleared when switching chat modes.

* **Style**
  * Rate limit warning now says “remaining today.”

* **Chores**
  * Transcript save failures are logged less prominently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->