### PR TITLE
fix: polyfill Promise.try for pdfjs-serverless in Convex Node runtime

### DIFF
--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -1,5 +1,16 @@
 "use node";
 
+// Polyfill Promise.try for the Convex Node runtime (not yet available there).
+// pdfjs-serverless >=0.7.0 uses Promise.try and crashes without this.
+if (typeof (Promise as unknown as { try?: unknown }).try !== "function") {
+  (Promise as unknown as { try: unknown }).try = function <T>(
+    fn: (...args: unknown[]) => T | PromiseLike<T>,
+    ...args: unknown[]
+  ): Promise<T> {
+    return new Promise<T>((resolve) => resolve(fn(...args)));
+  };
+}
+
 import { action } from "./_generated/server";
 import { v, ConvexError } from "convex/values";
 import { countTokens } from "gpt-tokenizer";


### PR DESCRIPTION
## Summary
- PDF uploads were failing with `Uncaught unhandledRejection: Promise.try is not a function` in the `fileActions:saveFile` Convex action.
- Root cause: `pdfjs-serverless` >=0.7.0 uses `Promise.try`, which is not yet available in Convex's Node runtime.
- Fix: polyfill `Promise.try` at the top of [convex/fileActions.ts](convex/fileActions.ts) so PDF processing works without downgrading the library (downgrading would require jumping from 1.2.2 → 0.6.0, spanning ~2 years of fixes).

Identified via Axiom query on `data.function.request_id` — failure was a runtime crash, not a business-logic rejection, so paid users with small PDFs were still blocked.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 817 tests pass
- [ ] Deploy to Convex prod and upload a PDF to confirm the error is gone
- [ ] Re-run Axiom query in 24h to confirm `Promise.try is not a function` no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added compatibility improvements to ensure Promise.try functionality is available across all runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->