### PR TITLE
fix: reduce card-testing false positives on 3DS-authenticated users

### DIFF
--- a/app/api/fraud/webhook/route.ts
+++ b/app/api/fraud/webhook/route.ts
@@ -222,12 +222,19 @@ async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<void> {
 /** Decline codes that warrant an immediate block — no threshold needed. */
 const IMMEDIATE_BLOCK_CODES = new Set(["stolen_card", "fraudulent"]);
 
-/** Decline codes from legitimate financial issues — don't count toward fraud. */
+/** Decline codes from legitimate financial issues — don't count toward fraud.
+ *  do_not_honor and generic_decline are the bank's catch-all "we won't tell you
+ *  why" codes — commonly returned for legit users hitting the bank's own risk
+ *  rules (new merchant, velocity limits, temporary holds). Real card-testers
+ *  produce structural signals (incorrect_number, card diversity) that are still
+ *  tracked. */
 const IGNORED_CODES = new Set([
   "insufficient_funds",
   "expired_card",
   "processing_error",
   "reenter_transaction",
+  "do_not_honor",
+  "generic_decline",
 ]);
 
 /** 24 hours in milliseconds — accounts newer than this get a lower block threshold. */
@@ -259,6 +266,36 @@ async function extractCardFingerprint(
   }
 
   return null;
+}
+
+/**
+ * Check whether the payment was authenticated via 3D Secure.
+ *
+ * 3DS "authenticated" (or "exempted") means the cardholder proved identity
+ * with the issuing bank — card-testers can't pass this because they don't
+ * control the cardholder's banking app. A subsequent decline on an
+ * authenticated payment is almost always the bank's own risk rules rejecting
+ * a legitimate user, not card testing.
+ */
+async function wasAuthenticatedVia3DS(
+  paymentIntent: Stripe.PaymentIntent,
+): Promise<boolean> {
+  const chargeRef = paymentIntent.latest_charge;
+  if (!chargeRef) return false;
+
+  let charge: Stripe.Charge;
+  if (typeof chargeRef === "string") {
+    try {
+      charge = await stripe.charges.retrieve(chargeRef);
+    } catch {
+      return false;
+    }
+  } else {
+    charge = chargeRef;
+  }
+
+  const result = charge.payment_method_details?.card?.three_d_secure?.result;
+  return result === "authenticated" || result === "exempted";
 }
 
 /**
@@ -365,6 +402,16 @@ async function handlePaymentFailed(
 
   // Skip tracking for legitimate financial failures
   if (IGNORED_CODES.has(declineCode)) {
+    return;
+  }
+
+  // Skip tracking when the cardholder already authenticated via 3DS on this
+  // attempt — they proved identity with the issuing bank, so any subsequent
+  // decline is the bank's risk decision, not card testing.
+  if (await wasAuthenticatedVia3DS(paymentIntent)) {
+    console.log(
+      `[Fraud Webhook] Skipping fraud tracking for 3DS-authenticated failure ${paymentIntent.id} (customer ${customerId}, decline=${declineCode})`,
+    );
     return;
   }
 

--- a/convex/__tests__/fraudTracking.test.ts
+++ b/convex/__tests__/fraudTracking.test.ts
@@ -500,6 +500,97 @@ describe("recordPaymentFailure", () => {
     expect(r3.failureCount).toBe(3);
   });
 
+  it("does NOT stack weight from repeated retries of the same card", async () => {
+    // Legit user hitting do_not_honor on the same card 4x — with fingerprint
+    // dedup, weighted score = max(weight) = 2, not 8. Does not block even
+    // on the new-account lower threshold of 3.
+    const now = Date.now();
+    const entries = [
+      makeEntry({
+        timestamp: now - 4000,
+        declineCode: "incorrect_number",
+        fingerprint: "fp_same",
+        weight: 2,
+      }),
+      makeEntry({
+        timestamp: now - 3000,
+        declineCode: "incorrect_number",
+        fingerprint: "fp_same",
+        weight: 2,
+      }),
+      makeEntry({
+        timestamp: now - 2000,
+        declineCode: "incorrect_number",
+        fingerprint: "fp_same",
+        weight: 2,
+      }),
+    ];
+    const existing = makeRecord({}, entries);
+    const { ctx } = makeCtx(existing);
+
+    const result = await recordPaymentFailure.handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      stripeCustomerId: CUSTOMER_ID,
+      declineCode: "incorrect_number",
+      cardFingerprint: "fp_same",
+      isNewAccount: true,
+    });
+
+    expect(result.shouldBlock).toBe(false);
+  });
+
+  it("still blocks on distinct-fingerprint test across cards", async () => {
+    // Card-tester using 3 different cards — fingerprint dedup shouldn't save
+    // them; Signal 2 (distinct_cards) fires at 3 fingerprints.
+    const now = Date.now();
+    const entries = [
+      makeEntry({ timestamp: now - 2000, fingerprint: "fp_a", weight: 1 }),
+      makeEntry({ timestamp: now - 1000, fingerprint: "fp_b", weight: 1 }),
+    ];
+    const existing = makeRecord({}, entries);
+    const { ctx } = makeCtx(existing);
+
+    const result = await recordPaymentFailure.handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      stripeCustomerId: CUSTOMER_ID,
+      declineCode: "card_declined",
+      cardFingerprint: "fp_c",
+    });
+
+    expect(result.shouldBlock).toBe(true);
+    expect(result.blockReason).toContain("distinct_cards");
+  });
+
+  it("null-fingerprint entries still count individually in weighted score", async () => {
+    // Can't bypass detection by stripping fingerprint data.
+    const now = Date.now();
+    const entries = [
+      makeEntry({
+        timestamp: now - 2000,
+        declineCode: "incorrect_number",
+        fingerprint: null,
+        weight: 2,
+      }),
+      makeEntry({
+        timestamp: now - 1000,
+        declineCode: "incorrect_number",
+        fingerprint: null,
+        weight: 2,
+      }),
+    ];
+    const existing = makeRecord({}, entries);
+    const { ctx } = makeCtx(existing);
+
+    const result = await recordPaymentFailure.handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      stripeCustomerId: CUSTOMER_ID,
+      declineCode: "incorrect_number", // 2 + 2 + 2 = 6 >= 5
+    });
+
+    expect(result.shouldBlock).toBe(true);
+    expect(result.blockReason).toContain("weighted_score");
+  });
+
   it("legitimate user: 2 card_declined failures do not trigger block", async () => {
     const { ctx: ctx1 } = makeCtx(null);
     const r1 = await recordPaymentFailure.handler(ctx1, {

--- a/convex/fraudTracking.ts
+++ b/convex/fraudTracking.ts
@@ -86,8 +86,26 @@ function evaluateWindow(
   const windowStart = now - WINDOW_MS;
   const recent = entries.filter((e) => e.timestamp >= windowStart);
 
-  // Signal 1: Weighted score
-  const score = recent.reduce((sum, e) => sum + e.weight, 0);
+  // Signal 1: Weighted score — dedupe by fingerprint so that a legit user
+  // retrying the same card (bank throwing do_not_honor, etc.) doesn't stack
+  // weight. Card-testers iterate cards, which is already caught by Signal 2
+  // (distinct fingerprints). Entries without a fingerprint still count
+  // individually so detection can't be bypassed by stripping card data.
+  const bestPerFingerprint = new Map<string, FailureEntry>();
+  const noFingerprint: FailureEntry[] = [];
+  for (const e of recent) {
+    if (e.fingerprint) {
+      const existing = bestPerFingerprint.get(e.fingerprint);
+      if (!existing || e.weight > existing.weight) {
+        bestPerFingerprint.set(e.fingerprint, e);
+      }
+    } else {
+      noFingerprint.push(e);
+    }
+  }
+  const score =
+    [...bestPerFingerprint.values()].reduce((sum, e) => sum + e.weight, 0) +
+    noFingerprint.reduce((sum, e) => sum + e.weight, 0);
   if (score >= threshold) {
     return {
       shouldBlock: true,


### PR DESCRIPTION
## Summary

Legit users hitting the bank's `do_not_honor` decline were being auto-blocked as card-testers after 3 retries on a new account (screenshot case: 3DS authenticated successfully, then bank returned `do_not_honor`, customer retried, hit `weighted_score:3.0>=3` block).

Three-layer fix, defense in depth:

- **Treat `do_not_honor` + `generic_decline` as `IGNORED_CODES`** — these are the bank's catch-all "we won't tell you why" declines, commonly returned for legit users hitting bank-side risk rules (new merchant, velocity limits, temporary holds). Structural card-testing signals like `incorrect_number` are still tracked.
- **Skip fraud tracking when the cardholder passed 3DS on the attempt.** Card-testers can't pass 3DS — they don't control the cardholder's banking/auth app. `three_d_secure.result` of `authenticated` or `exempted` on the charge is a strong legitimacy signal.
- **Dedupe the weighted score by card fingerprint.** A legit user retrying the same card no longer stacks weight. Card-testing across distinct cards is still caught by the existing distinct-fingerprints signal (Signal 2). Null-fingerprint entries still count individually so detection can't be bypassed by stripping card data.

Any one of these would have saved the user in the screenshot — all three in place for resilience.

## Test plan

- [x] `convex/__tests__/fraudTracking.test.ts` — 3 new tests + 22 existing, all pass
  - `does NOT stack weight from repeated retries of the same card`
  - `still blocks on distinct-fingerprint test across cards`
  - `null-fingerprint entries still count individually in weighted score`
- [x] Full suite: 821 tests pass, typecheck clean
- [ ] Manual: in Stripe test mode, trigger 3 `do_not_honor` declines on the same card from a new account — verify customer is NOT blocked
- [ ] Manual: trigger `stolen_card` immediate-block decline — verify customer IS blocked (regression)
- [ ] Manual: trigger 3 distinct-fingerprint declines in 10 min — verify `distinct_cards:3` still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic exemption for payments authenticated through 3D Secure verification.

* **Bug Fixes**
  * Corrected fraud detection scoring to count each unique payment method only once across multiple attempts.
  * Expanded recognition of legitimate payment decline codes to reduce false fraud alerts.

* **Tests**
  * Added comprehensive test coverage for fraud detection edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->