### PR TITLE
feat: enable notes for free users in agent mode

### DIFF
--- a/app/components/PersonalizationTab.tsx
+++ b/app/components/PersonalizationTab.tsx
@@ -50,8 +50,8 @@ const PersonalizationTab = ({
         </div>
       </div>
 
-      {/* Notes Section (formerly Memory Section) - hidden for free users */}
-      {subscription && subscription !== "free" && (
+      {/* Notes Section (formerly Memory Section) */}
+      {subscription && (
         <div>
           <h3 className="text-lg font-medium mb-4 pb-2 border-b">Notes</h3>
           <div className="space-y-4">

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -322,7 +322,7 @@ export const createChatHandler = (
       }
 
       const memoryEnabled =
-        subscription !== "free" &&
+        (subscription !== "free" || isAgentMode(mode)) &&
         (userCustomization?.include_memory_entries ?? true);
 
       // Agent mode and paid ask mode: check rate limit with model-specific pricing after knowing the model

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -344,7 +344,7 @@ export const systemPrompt = async (
   sandboxContext?: string | null,
 ): Promise<string> => {
   const shouldIncludeNotes =
-    subscription !== "free" &&
+    (subscription !== "free" || mode === "agent") &&
     (userCustomization?.include_memory_entries ?? true);
 
   const personalityInstructions = getPersonalityInstructions(
@@ -383,7 +383,9 @@ The current date is ${currentDateTime}.`;
   // Notes are injected via <system-reminder> in messages to keep the system prompt
   // stable for prompt caching. Only include the static "disabled" message here.
   if (!shouldIncludeNotes) {
-    sections.push(getNotesDisabledMessage(subscription === "free"));
+    sections.push(
+      getNotesDisabledMessage(subscription === "free" && mode !== "agent"),
+    );
   }
 
   // Add personality instructions at the end


### PR DESCRIPTION
## Summary
- Extend `memoryEnabled` and `shouldIncludeNotes` so free users get the notes tools and injected notes section while in agent mode (ask mode still paid-only).
- Surface the Notes section in Settings → Personalization for free users so they can toggle and manage notes.
- Keep the "upgrade to unlock" disabled-notes prompt limited to free users in ask mode; free agent users with notes toggled off get the standard "go to Settings" message.

## Test plan
- [ ] As a free user in agent mode, confirm `create_note` / `list_notes` / `update_note` / `delete_note` work and stored notes appear in subsequent turns
- [ ] As a free user in ask mode, confirm notes remain disabled and the upgrade prompt still fires if the model is asked to save
- [ ] Settings → Personalization shows the Notes section with working enable toggle and Manage button for a free account
- [ ] Paid user behavior (both modes) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notes and Memory features can now be used by free users in agent mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->