### PR TITLE
fix: keep chat input above mobile keyboard and stop focus zoom

### DIFF
--- a/app/(chat)/layout.tsx
+++ b/app/(chat)/layout.tsx
@@ -3,14 +3,10 @@
 import { Authenticated, Unauthenticated, AuthLoading } from "convex/react";
 import { ChatLayout } from "@/app/components/ChatLayout";
 import Loading from "@/components/ui/loading";
+import { useVisualViewportHeight } from "@/app/hooks/useVisualViewportHeight";
 
-const fullWidthShell = (
-  <div className="h-dvh min-h-0 flex flex-col bg-background overflow-hidden">
-    <div className="flex-1 flex items-center justify-center min-h-0">
-      <Loading />
-    </div>
-  </div>
-);
+const shellClass =
+  "h-[var(--vvh,100dvh)] min-h-0 flex flex-col bg-background overflow-hidden";
 
 /**
  * Shared layout for / and /c/[id]. Renders the Chat Sidebar only when authenticated
@@ -22,16 +18,22 @@ export default function ChatRouteLayout({
 }: {
   children: React.ReactNode;
 }) {
+  useVisualViewportHeight();
+
   return (
     <>
-      <AuthLoading>{fullWidthShell}</AuthLoading>
-      <Unauthenticated>
-        <div className="h-dvh min-h-0 flex flex-col bg-background overflow-hidden">
-          {children}
+      <AuthLoading>
+        <div className={shellClass}>
+          <div className="flex-1 flex items-center justify-center min-h-0">
+            <Loading />
+          </div>
         </div>
+      </AuthLoading>
+      <Unauthenticated>
+        <div className={shellClass}>{children}</div>
       </Unauthenticated>
       <Authenticated>
-        <div className="h-dvh min-h-0 flex flex-col bg-background overflow-hidden">
+        <div className={shellClass}>
           <ChatLayout>{children}</ChatLayout>
         </div>
       </Authenticated>

--- a/app/components/ChatInput/ChatInputTextarea.tsx
+++ b/app/components/ChatInput/ChatInputTextarea.tsx
@@ -117,7 +117,7 @@ export function ChatInputTextarea({
             ? "Hack, test, secure anything"
             : "Ask, learn, brainstorm"
         }
-        className="flex rounded-md border-input focus-visible:outline-none focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 overflow-hidden flex-1 bg-transparent p-0 pt-[1px] border-0 focus-visible:ring-0 focus-visible:ring-offset-0 w-full placeholder:text-muted-foreground text-[15px] shadow-none resize-none min-h-[28px]"
+        className="flex rounded-md border-input focus-visible:outline-none focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 overflow-hidden flex-1 bg-transparent p-0 pt-[1px] border-0 focus-visible:ring-0 focus-visible:ring-offset-0 w-full placeholder:text-muted-foreground text-base md:text-[15px] shadow-none resize-none min-h-[28px]"
         minRows={minRows}
         autoFocus
         disabled={disabled}

--- a/app/hooks/useVisualViewportHeight.ts
+++ b/app/hooks/useVisualViewportHeight.ts
@@ -3,7 +3,9 @@ import { useEffect } from "react";
 /**
  * Tracks window.visualViewport.height as the CSS variable --vvh on
  * documentElement so layouts can shrink above the mobile keyboard on iOS
- * Safari, where interactive-widget=resizes-content is not supported.
+ * Safari, where interactive-widget=resizes-content is not supported. Also
+ * pins html/body so the browser's scroll-into-view on focus can't push
+ * the page above the viewport on Chromium Android.
  */
 export function useVisualViewportHeight() {
   useEffect(() => {
@@ -11,6 +13,15 @@ export function useVisualViewportHeight() {
     if (!vv) return;
 
     const root = document.documentElement;
+    const body = document.body;
+    const prevRootOverflow = root.style.overflow;
+    const prevBodyOverflow = body.style.overflow;
+    const prevOverscroll = body.style.overscrollBehavior;
+
+    root.style.overflow = "hidden";
+    body.style.overflow = "hidden";
+    body.style.overscrollBehavior = "none";
+
     const update = () => {
       root.style.setProperty("--vvh", `${vv.height}px`);
     };
@@ -23,6 +34,9 @@ export function useVisualViewportHeight() {
       vv.removeEventListener("resize", update);
       vv.removeEventListener("scroll", update);
       root.style.removeProperty("--vvh");
+      root.style.overflow = prevRootOverflow;
+      body.style.overflow = prevBodyOverflow;
+      body.style.overscrollBehavior = prevOverscroll;
     };
   }, []);
 }

--- a/app/hooks/useVisualViewportHeight.ts
+++ b/app/hooks/useVisualViewportHeight.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+
+/**
+ * Tracks window.visualViewport.height as the CSS variable --vvh on
+ * documentElement so layouts can shrink above the mobile keyboard on iOS
+ * Safari, where interactive-widget=resizes-content is not supported.
+ */
+export function useVisualViewportHeight() {
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    const root = document.documentElement;
+    const update = () => {
+      root.style.setProperty("--vvh", `${vv.height}px`);
+    };
+
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+      root.style.removeProperty("--vvh");
+    };
+  }, []);
+}

--- a/app/hooks/useVisualViewportHeight.ts
+++ b/app/hooks/useVisualViewportHeight.ts
@@ -26,13 +26,29 @@ export function useVisualViewportHeight() {
       root.style.setProperty("--vvh", `${vv.height}px`);
     };
 
+    // Some Chromium Android builds don't fire visualViewport.resize when the
+    // keyboard closes via blur, so re-read on the next frame after focusout
+    // and on window resize.
+    let raf = 0;
+    const updateNextFrame = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(update);
+    };
+
     update();
     vv.addEventListener("resize", update);
     vv.addEventListener("scroll", update);
+    window.addEventListener("resize", update);
+    window.addEventListener("orientationchange", updateNextFrame);
+    document.addEventListener("focusout", updateNextFrame);
 
     return () => {
+      cancelAnimationFrame(raf);
       vv.removeEventListener("resize", update);
       vv.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+      window.removeEventListener("orientationchange", updateNextFrame);
+      document.removeEventListener("focusout", updateNextFrame);
       root.style.removeProperty("--vvh");
       root.style.overflow = prevRootOverflow;
       body.style.overflow = prevBodyOverflow;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -113,7 +113,7 @@ export default function RootLayout({
       <head>
         <meta
           name="viewport"
-          content="width=device-width, initial-scale=1, viewport-fit=cover"
+          content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"
         />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
       </head>


### PR DESCRIPTION
## Summary

Mobile chat experience fixes — on iOS Safari and Chromium Android, the chat shell didn't shrink above the keyboard, the page would overscroll at the top, and focusing the textarea zoomed the page in.

- **Viewport meta**: add `interactive-widget=resizes-content` so Chrome/Firefox resize the layout viewport when the keyboard opens ([app/layout.tsx](app/layout.tsx))
- **VisualViewport tracking**: new `useVisualViewportHeight` hook sets `--vvh` to `window.visualViewport.height` so iOS Safari (which ignores the meta tag) also gets a shell that hugs the visible area ([app/hooks/useVisualViewportHeight.ts](app/hooks/useVisualViewportHeight.ts))
- **Scroll lock**: while the chat layout is mounted, pin `html`/`body` `overflow: hidden` + `overscroll-behavior: none` so Chromium's scroll-into-view can't push the page above the viewport on focus ([app/(chat)/layout.tsx](app/(chat)/layout.tsx))
- **No focus zoom**: bump the chat textarea from 15px to 16px on mobile (keeps 15px on desktop via `md:text-[15px]`) so Safari/Chrome don't auto-zoom ([app/components/ChatInput/ChatInputTextarea.tsx](app/components/ChatInput/ChatInputTextarea.tsx))

## Test plan

- [ ] iOS Safari: open a chat, focus input → keyboard slides up, input stays visible above it, page does not scroll, no zoom
- [ ] iOS Chrome/Brave (WebKit): same checks
- [ ] Android Chrome: same checks
- [ ] Android Brave: focus input → no extra top overscroll, input pinned above keyboard
- [ ] Desktop Chrome/Safari: chat layout unchanged, textarea still 15px
- [ ] Non-chat routes (`/download`, auth screens): normal scrolling still works (hook only mounts under `app/(chat)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved viewport-height handling so the UI adapts smoothly to visual viewport changes (reducing layout jumps from virtual keyboards and resizes).
  * Loading, authenticated, and unauthenticated shells now follow updated viewport sizing for a more consistent layout across devices.
  * Chat input text uses responsive typography for clearer, better-scaled text across screen sizes.

* **Chores**
  * Updated viewport meta to better support interactive widgets during viewport changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->