### PR TITLE
feat: show mobile app install flow on /download for iOS and Android

### DIFF
--- a/app/components/SidebarUserNav.tsx
+++ b/app/components/SidebarUserNav.tsx
@@ -445,14 +445,12 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
             <span>Settings</span>
           </DropdownMenuItem>
 
-          {!isMobile && (
-            <DropdownMenuItem asChild className="py-1.5">
-              <Link href="/download">
-                <Download className="mr-2 h-4 w-4 text-foreground" />
-                <span>Download App</span>
-              </Link>
-            </DropdownMenuItem>
-          )}
+          <DropdownMenuItem asChild className="py-1.5">
+            <Link href="/download">
+              <Download className="mr-2 h-4 w-4 text-foreground" />
+              <span>{isMobile ? "Install App" : "Download App"}</span>
+            </Link>
+          </DropdownMenuItem>
 
           <DropdownMenuSeparator />
 

--- a/app/download/DownloadPageContent.tsx
+++ b/app/download/DownloadPageContent.tsx
@@ -57,49 +57,51 @@ function DownloadContent() {
 
         <DownloadSection />
 
-        <div className="rounded-md border bg-card p-6 shadow-lg">
-          <h2 className="mb-4 text-xl font-semibold text-card-foreground">
-            Desktop Downloads
-          </h2>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <DownloadCard
-              title="macOS"
-              subtitle="Universal (Intel & Apple Silicon)"
-              href={downloadLinks.macos}
-              icon={<AppleIcon />}
-            />
-            <DownloadCard
-              title="Windows"
-              subtitle="64-bit"
-              href={downloadLinks.windows}
-              icon={<WindowsIcon />}
-            />
-            <DownloadCard
-              title="Linux"
-              subtitle="x64 (.deb)"
-              href={downloadLinks.linuxDeb}
-              icon={<LinuxIcon />}
-            />
-            <DownloadCard
-              title="Linux"
-              subtitle="ARM64 (.deb)"
-              href={downloadLinks.linuxArm64Deb}
-              icon={<LinuxIcon />}
-            />
-            <DownloadCard
-              title="Linux"
-              subtitle="x64 (.AppImage)"
-              href={downloadLinks.linuxAppImage}
-              icon={<LinuxIcon />}
-            />
-            <DownloadCard
-              title="Linux"
-              subtitle="ARM64 (.AppImage)"
-              href={downloadLinks.linuxArm64AppImage}
-              icon={<LinuxIcon />}
-            />
+        {!isMobile && (
+          <div className="rounded-md border bg-card p-6 shadow-lg">
+            <h2 className="mb-4 text-xl font-semibold text-card-foreground">
+              Desktop Downloads
+            </h2>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <DownloadCard
+                title="macOS"
+                subtitle="Universal (Intel & Apple Silicon)"
+                href={downloadLinks.macos}
+                icon={<AppleIcon />}
+              />
+              <DownloadCard
+                title="Windows"
+                subtitle="64-bit"
+                href={downloadLinks.windows}
+                icon={<WindowsIcon />}
+              />
+              <DownloadCard
+                title="Linux"
+                subtitle="x64 (.deb)"
+                href={downloadLinks.linuxDeb}
+                icon={<LinuxIcon />}
+              />
+              <DownloadCard
+                title="Linux"
+                subtitle="ARM64 (.deb)"
+                href={downloadLinks.linuxArm64Deb}
+                icon={<LinuxIcon />}
+              />
+              <DownloadCard
+                title="Linux"
+                subtitle="x64 (.AppImage)"
+                href={downloadLinks.linuxAppImage}
+                icon={<LinuxIcon />}
+              />
+              <DownloadCard
+                title="Linux"
+                subtitle="ARM64 (.AppImage)"
+                href={downloadLinks.linuxArm64AppImage}
+                icon={<LinuxIcon />}
+              />
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/app/download/DownloadPageContent.tsx
+++ b/app/download/DownloadPageContent.tsx
@@ -6,7 +6,7 @@ import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Header from "@/app/components/Header";
 import { HackerAISVG } from "@/components/icons/hackerai-svg";
-import { DownloadSection } from "./DownloadSection";
+import { DownloadSection, useDetectedPlatform } from "./DownloadSection";
 import { downloadLinks } from "./constants";
 import { AppleIcon, WindowsIcon, LinuxIcon } from "./icons";
 
@@ -37,15 +37,21 @@ function AuthenticatedHeader() {
 }
 
 function DownloadContent() {
+  const detected = useDetectedPlatform();
+  const isMobile =
+    detected?.platform === "ios" || detected?.platform === "android";
+
   return (
     <div className="px-4 py-8 pb-16 md:px-0">
       <div className="container mx-auto max-w-3xl space-y-8">
         <div className="text-center">
           <h1 className="mb-4 text-4xl font-bold text-card-foreground">
-            Download HackerAI
+            {isMobile ? "Install HackerAI" : "Download HackerAI"}
           </h1>
           <p className="text-lg text-muted-foreground">
-            Get the desktop app for the best experience
+            {isMobile
+              ? "Add the app to your home screen"
+              : "Get the desktop app for the best experience"}
           </p>
         </div>
 
@@ -53,7 +59,7 @@ function DownloadContent() {
 
         <div className="rounded-md border bg-card p-6 shadow-lg">
           <h2 className="mb-4 text-xl font-semibold text-card-foreground">
-            All Downloads
+            Desktop Downloads
           </h2>
           <div className="grid gap-4 sm:grid-cols-2">
             <DownloadCard

--- a/app/download/DownloadSection.tsx
+++ b/app/download/DownloadSection.tsx
@@ -213,12 +213,17 @@ function MobileInstallCard({ detected }: { detected: DetectedPlatform }) {
 
   const handleInstallClick = async () => {
     if (!deferredPrompt) return;
-    await deferredPrompt.prompt();
-    const choice = await deferredPrompt.userChoice;
-    if (choice.outcome === "accepted") {
-      setInstalled(true);
+    try {
+      await deferredPrompt.prompt();
+      const choice = await deferredPrompt.userChoice;
+      if (choice.outcome === "accepted") {
+        setInstalled(true);
+      }
+    } catch {
+      // Prompt already shown or blocked by the browser — fall back to manual steps.
+    } finally {
+      setDeferredPrompt(null);
     }
-    setDeferredPrompt(null);
   };
 
   return (

--- a/app/download/DownloadSection.tsx
+++ b/app/download/DownloadSection.tsx
@@ -1,29 +1,64 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { Button } from "@/components/ui/button";
 import { downloadLinks } from "./constants";
 import {
   AppleIcon,
   WindowsIcon,
   LinuxIcon,
+  AndroidIcon,
   DeviceIcon,
   DownloadIcon,
 } from "./icons";
 
-type Platform = "macos" | "windows" | "linux" | "unknown";
+type Platform = "macos" | "windows" | "linux" | "ios" | "android" | "unknown";
 type LinuxArch = "x64" | "arm64";
+type Browser = "safari" | "chrome" | "firefox" | "samsung" | "other";
 
 export interface DetectedPlatform {
   platform: Platform;
   linuxArch?: LinuxArch;
+  browser?: Browser;
   displayName: string;
   downloadUrl: string;
+}
+
+function detectBrowser(ua: string): Browser {
+  if (/samsungbrowser/.test(ua)) return "samsung";
+  if (/firefox|fxios/.test(ua)) return "firefox";
+  if (/safari/.test(ua) && !/crios|fxios|edgios|chrome|android/.test(ua)) {
+    return "safari";
+  }
+  if (/chrome|crios/.test(ua) && !/edg|opr/.test(ua)) return "chrome";
+  return "other";
 }
 
 export function detectPlatform(): DetectedPlatform {
   const userAgent = navigator.userAgent.toLowerCase();
   const platform = navigator.platform?.toLowerCase() || "";
+  const browser = detectBrowser(userAgent);
+
+  const isIpadOS =
+    navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
+
+  if (/iphone|ipad|ipod/.test(userAgent) || isIpadOS) {
+    return {
+      platform: "ios",
+      browser,
+      displayName: "iOS",
+      downloadUrl: "",
+    };
+  }
+
+  if (/android/.test(userAgent)) {
+    return {
+      platform: "android",
+      browser,
+      displayName: "Android",
+      downloadUrl: "",
+    };
+  }
 
   if (
     userAgent.includes("mac") ||
@@ -32,6 +67,7 @@ export function detectPlatform(): DetectedPlatform {
   ) {
     return {
       platform: "macos",
+      browser,
       displayName: "macOS",
       downloadUrl: downloadLinks.macos,
     };
@@ -40,6 +76,7 @@ export function detectPlatform(): DetectedPlatform {
   if (userAgent.includes("win") || platform.includes("win")) {
     return {
       platform: "windows",
+      browser,
       displayName: "Windows",
       downloadUrl: downloadLinks.windows,
     };
@@ -60,6 +97,7 @@ export function detectPlatform(): DetectedPlatform {
       return {
         platform: "linux",
         linuxArch: "arm64",
+        browser,
         displayName: "Linux (ARM64)",
         downloadUrl: downloadLinks.linuxArm64Deb,
       };
@@ -68,6 +106,7 @@ export function detectPlatform(): DetectedPlatform {
     return {
       platform: "linux",
       linuxArch: "x64",
+      browser,
       displayName: "Linux",
       downloadUrl: downloadLinks.linuxDeb,
     };
@@ -75,6 +114,7 @@ export function detectPlatform(): DetectedPlatform {
 
   return {
     platform: "unknown",
+    browser,
     displayName: "your platform",
     downloadUrl: downloadLinks.macos,
   };
@@ -98,7 +138,7 @@ function subscribe() {
   return () => {};
 }
 
-function useDetectedPlatform(): DetectedPlatform | null {
+export function useDetectedPlatform(): DetectedPlatform | null {
   return useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
 }
 
@@ -111,6 +151,10 @@ export function DownloadSection() {
         <div className="h-20 animate-pulse rounded bg-muted" />
       </div>
     );
+  }
+
+  if (detected.platform === "ios" || detected.platform === "android") {
+    return <MobileInstallCard detected={detected} />;
   }
 
   return (
@@ -135,6 +179,170 @@ export function DownloadSection() {
   );
 }
 
+type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+};
+
+function MobileInstallCard({ detected }: { detected: DetectedPlatform }) {
+  const [deferredPrompt, setDeferredPrompt] =
+    useState<BeforeInstallPromptEvent | null>(null);
+  const [installed, setInstalled] = useState(false);
+
+  useEffect(() => {
+    if (detected.platform !== "android") return;
+
+    const handleBeforeInstall = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+    };
+
+    const handleAppInstalled = () => {
+      setDeferredPrompt(null);
+      setInstalled(true);
+    };
+
+    window.addEventListener("beforeinstallprompt", handleBeforeInstall);
+    window.addEventListener("appinstalled", handleAppInstalled);
+
+    return () => {
+      window.removeEventListener("beforeinstallprompt", handleBeforeInstall);
+      window.removeEventListener("appinstalled", handleAppInstalled);
+    };
+  }, [detected.platform]);
+
+  const handleInstallClick = async () => {
+    if (!deferredPrompt) return;
+    await deferredPrompt.prompt();
+    const choice = await deferredPrompt.userChoice;
+    if (choice.outcome === "accepted") {
+      setInstalled(true);
+    }
+    setDeferredPrompt(null);
+  };
+
+  return (
+    <div className="rounded-md border bg-card p-8 shadow-lg">
+      <div className="mb-6 text-center">
+        <MobilePlatformIcon platform={detected.platform} />
+        <h2 className="mt-4 text-2xl font-semibold text-card-foreground">
+          Install Mobile App
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Install HackerAI on your {detected.displayName} device
+        </p>
+      </div>
+
+      {installed && (
+        <div className="mb-4 rounded-md border border-green-500/30 bg-green-500/10 p-4 text-center text-sm text-green-600 dark:text-green-400">
+          Installed! Open HackerAI from your home screen.
+        </div>
+      )}
+
+      {!installed && deferredPrompt && (
+        <>
+          <Button
+            size="lg"
+            className="mb-4 w-full text-lg"
+            onClick={handleInstallClick}
+          >
+            <DownloadIcon />
+            Install HackerAI
+          </Button>
+          <div className="mb-4 flex items-center gap-3 text-xs text-muted-foreground">
+            <div className="h-px flex-1 bg-border" />
+            <span>Or install manually</span>
+            <div className="h-px flex-1 bg-border" />
+          </div>
+        </>
+      )}
+
+      {!installed && <InstallInstructions detected={detected} />}
+    </div>
+  );
+}
+
+function InstallInstructions({ detected }: { detected: DetectedPlatform }) {
+  if (detected.platform === "ios") {
+    if (detected.browser !== "safari") {
+      return (
+        <div className="rounded-md border bg-background p-4 text-sm text-muted-foreground">
+          <p className="mb-2 font-medium text-card-foreground">
+            Installing on iOS requires Safari
+          </p>
+          <p>Open this page in Safari to add HackerAI to your home screen.</p>
+        </div>
+      );
+    }
+
+    return (
+      <StepsList
+        steps={[
+          <>
+            Tap the <strong>Share</strong> button at the bottom of Safari (the
+            square with an arrow pointing up).
+          </>,
+          <>
+            Scroll down and tap <strong>Add to Home Screen</strong>.
+          </>,
+          <>
+            Tap <strong>Add</strong> in the top right corner.
+          </>,
+        ]}
+      />
+    );
+  }
+
+  // Android
+  if (detected.browser === "firefox") {
+    return (
+      <StepsList
+        steps={[
+          <>
+            Tap the <strong>menu</strong> (⋮).
+          </>,
+          <>
+            Tap <strong>Install</strong> (or <strong>Add to Home Screen</strong>
+            ).
+          </>,
+        ]}
+      />
+    );
+  }
+
+  return (
+    <StepsList
+      steps={[
+        <>
+          Tap the <strong>menu</strong> (⋮) in the top right.
+        </>,
+        <>
+          Tap <strong>Install app</strong> (or{" "}
+          <strong>Add to Home screen</strong>).
+        </>,
+        <>
+          Tap <strong>Install</strong>.
+        </>,
+      ]}
+    />
+  );
+}
+
+function StepsList({ steps }: { steps: React.ReactNode[] }) {
+  return (
+    <ol className="space-y-3">
+      {steps.map((step, i) => (
+        <li key={i} className="flex gap-3 text-sm text-card-foreground">
+          <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
+            {i + 1}
+          </span>
+          <span className="pt-0.5">{step}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
 function PlatformIcon({ platform }: { platform: Platform }) {
   const className = "mx-auto h-16 w-16 text-muted-foreground";
 
@@ -145,6 +353,19 @@ function PlatformIcon({ platform }: { platform: Platform }) {
       return <WindowsIcon className={className} />;
     case "linux":
       return <LinuxIcon className={className} />;
+    default:
+      return <DeviceIcon className={className} />;
+  }
+}
+
+function MobilePlatformIcon({ platform }: { platform: Platform }) {
+  const className = "mx-auto h-16 w-16 text-muted-foreground";
+
+  switch (platform) {
+    case "ios":
+      return <AppleIcon className={className} />;
+    case "android":
+      return <AndroidIcon className={className} />;
     default:
       return <DeviceIcon className={className} />;
   }

--- a/app/download/DownloadSection.tsx
+++ b/app/download/DownloadSection.tsx
@@ -314,14 +314,14 @@ function InstallInstructions({ detected }: { detected: DetectedPlatform }) {
     <StepsList
       steps={[
         <>
-          Tap the <strong>menu</strong> (⋮) in the top right.
+          Tap the <strong>menu</strong> button (three dots in the top right)
         </>,
         <>
-          Tap <strong>Install app</strong> (or{" "}
-          <strong>Add to Home screen</strong>).
+          Tap <strong>Install app</strong> or{" "}
+          <strong>Add to Home screen</strong>
         </>,
         <>
-          Tap <strong>Install</strong>.
+          Tap <strong>Install</strong> to confirm
         </>,
       ]}
     />

--- a/app/download/icons/AndroidIcon.tsx
+++ b/app/download/icons/AndroidIcon.tsx
@@ -1,0 +1,14 @@
+export function AndroidIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+    >
+      <path d="M17.6 9.48l1.84-3.18a.4.4 0 0 0-.15-.54.4.4 0 0 0-.54.15l-1.86 3.22A11.4 11.4 0 0 0 12 8a11.4 11.4 0 0 0-4.9 1.13L5.25 5.91a.4.4 0 0 0-.54-.15.4.4 0 0 0-.15.54l1.84 3.18A10.3 10.3 0 0 0 1 18h22a10.3 10.3 0 0 0-5.4-8.52zM7 15.25a1.25 1.25 0 1 1 0-2.5 1.25 1.25 0 0 1 0 2.5zm10 0a1.25 1.25 0 1 1 0-2.5 1.25 1.25 0 0 1 0 2.5z" />
+    </svg>
+  );
+}

--- a/app/download/icons/index.ts
+++ b/app/download/icons/index.ts
@@ -1,5 +1,6 @@
 export { AppleIcon } from "./AppleIcon";
 export { WindowsIcon } from "./WindowsIcon";
 export { LinuxIcon } from "./LinuxIcon";
+export { AndroidIcon } from "./AndroidIcon";
 export { DeviceIcon } from "./DeviceIcon";
 export { DownloadIcon } from "./DownloadIcon";

--- a/app/download/page.tsx
+++ b/app/download/page.tsx
@@ -4,18 +4,18 @@ import { DownloadPageContent } from "./DownloadPageContent";
 export const metadata: Metadata = {
   title: "Download | HackerAI",
   description:
-    "Download HackerAI desktop app for macOS, Windows, and Linux. AI-powered penetration testing at your fingertips.",
+    "Download HackerAI for macOS, Windows, Linux, iOS, and Android. AI-powered penetration testing at your fingertips.",
   openGraph: {
-    title: "Download HackerAI Desktop",
+    title: "Download HackerAI",
     description:
-      "Download HackerAI desktop app for macOS, Windows, and Linux. AI-powered penetration testing at your fingertips.",
+      "Download HackerAI for macOS, Windows, Linux, iOS, and Android. AI-powered penetration testing at your fingertips.",
     type: "website",
   },
   twitter: {
     card: "summary",
-    title: "Download HackerAI Desktop",
+    title: "Download HackerAI",
     description:
-      "Download HackerAI desktop app for macOS, Windows, and Linux. AI-powered penetration testing at your fingertips.",
+      "Download HackerAI for macOS, Windows, Linux, iOS, and Android. AI-powered penetration testing at your fingertips.",
   },
 };
 


### PR DESCRIPTION
## Summary
- Replace the desktop-only download card with an **Install Mobile App** card when the visitor is on iOS or Android (including iPadOS, which reports a Mac UA but is distinguished via `navigator.maxTouchPoints`).
- Capture `beforeinstallprompt` on Android Chrome/Samsung/Edge for a one-tap Install button; show "Installed!" state on `appinstalled`.
- Show browser-specific Add-to-Home-Screen steps:
  - iOS Safari → Share button → Add to Home Screen → Add
  - iOS non-Safari → "open in Safari to install" fallback
  - Android Chrome → menu (⋮) → Install app → Install
  - Android Firefox → menu (⋮) → Install
- Keep the desktop download grid visible on mobile (renamed to "Desktop Downloads") so users can still grab the desktop installer.
- Broaden route metadata description to include iOS and Android.

No service worker or UA-parsing dependency added — the existing `public/manifest.json` is already PWA-valid, so Add-to-Home-Screen and `beforeinstallprompt` work out of the box.

## Test plan
- [ ] iOS Safari (iPhone and iPad): visit `/download`, see the three Safari share-sheet steps, install, verify standalone launch.
- [ ] iOS Chrome: see the "open in Safari" fallback.
- [ ] Android Chrome over HTTPS: verify Install button appears (may need `chrome://flags/#bypass-app-banner-engagement-checks`), installs cleanly, "Installed!" state renders.
- [ ] Android Firefox: only manual steps visible (no `beforeinstallprompt`).
- [ ] Desktop macOS / Windows / Linux: existing download UX unchanged.
- [ ] `pnpm typecheck` and `pnpm test` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS and Android support with platform-aware install flows, mobile-specific headings, and an install card on mobile while desktop retains download panels.
  * Added an Android icon for the mobile install UI.
* **Documentation**
  * Updated download page metadata to include iOS and Android.
* **UX**
  * Sidebar download/install menu now always visible with context-aware label ("Install App" vs "Download App").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->