### PR TITLE
refactor: simplify mobile install flow; hide sidebar entry when standalone

### DIFF
--- a/app/components/SidebarUserNav.tsx
+++ b/app/components/SidebarUserNav.tsx
@@ -21,6 +21,7 @@ import Link from "next/link";
 import { useGlobalState } from "@/app/contexts/GlobalState";
 import { redirectToPricing } from "../hooks/usePricingDialog";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useIsStandalone } from "@/hooks/use-is-standalone";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -116,6 +117,7 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
   const [isLoadingUsage, setIsLoadingUsage] = useState(false);
   const [usageFetchFailed, setUsageFetchFailed] = useState(false);
   const isMobile = useIsMobile();
+  const isStandalone = useIsStandalone();
   const isPaidUser = subscription !== "free";
 
   const getAgentRateLimitStatus = useAction(
@@ -445,12 +447,14 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
             <span>Settings</span>
           </DropdownMenuItem>
 
-          <DropdownMenuItem asChild className="py-1.5">
-            <Link href="/download">
-              <Download className="mr-2 h-4 w-4 text-foreground" />
-              <span>{isMobile ? "Install App" : "Download App"}</span>
-            </Link>
-          </DropdownMenuItem>
+          {!isStandalone && (
+            <DropdownMenuItem asChild className="py-1.5">
+              <Link href="/download">
+                <Download className="mr-2 h-4 w-4 text-foreground" />
+                <span>{isMobile ? "Install App" : "Download App"}</span>
+              </Link>
+            </DropdownMenuItem>
+          )}
 
           <DropdownMenuSeparator />
 

--- a/app/download/DownloadSection.tsx
+++ b/app/download/DownloadSection.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useSyncExternalStore } from "react";
 import { Button } from "@/components/ui/button";
+import { useIsStandalone } from "@/hooks/use-is-standalone";
 import { downloadLinks } from "./constants";
 import {
   AppleIcon,
@@ -14,30 +15,17 @@ import {
 
 type Platform = "macos" | "windows" | "linux" | "ios" | "android" | "unknown";
 type LinuxArch = "x64" | "arm64";
-type Browser = "safari" | "chrome" | "firefox" | "samsung" | "other";
 
 export interface DetectedPlatform {
   platform: Platform;
   linuxArch?: LinuxArch;
-  browser?: Browser;
   displayName: string;
   downloadUrl: string;
-}
-
-function detectBrowser(ua: string): Browser {
-  if (/samsungbrowser/.test(ua)) return "samsung";
-  if (/firefox|fxios/.test(ua)) return "firefox";
-  if (/safari/.test(ua) && !/crios|fxios|edgios|chrome|android/.test(ua)) {
-    return "safari";
-  }
-  if (/chrome|crios/.test(ua) && !/edg|opr/.test(ua)) return "chrome";
-  return "other";
 }
 
 export function detectPlatform(): DetectedPlatform {
   const userAgent = navigator.userAgent.toLowerCase();
   const platform = navigator.platform?.toLowerCase() || "";
-  const browser = detectBrowser(userAgent);
 
   const isIpadOS =
     navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
@@ -45,7 +33,6 @@ export function detectPlatform(): DetectedPlatform {
   if (/iphone|ipad|ipod/.test(userAgent) || isIpadOS) {
     return {
       platform: "ios",
-      browser,
       displayName: "iOS",
       downloadUrl: "",
     };
@@ -54,7 +41,6 @@ export function detectPlatform(): DetectedPlatform {
   if (/android/.test(userAgent)) {
     return {
       platform: "android",
-      browser,
       displayName: "Android",
       downloadUrl: "",
     };
@@ -67,7 +53,6 @@ export function detectPlatform(): DetectedPlatform {
   ) {
     return {
       platform: "macos",
-      browser,
       displayName: "macOS",
       downloadUrl: downloadLinks.macos,
     };
@@ -76,7 +61,6 @@ export function detectPlatform(): DetectedPlatform {
   if (userAgent.includes("win") || platform.includes("win")) {
     return {
       platform: "windows",
-      browser,
       displayName: "Windows",
       downloadUrl: downloadLinks.windows,
     };
@@ -97,7 +81,6 @@ export function detectPlatform(): DetectedPlatform {
       return {
         platform: "linux",
         linuxArch: "arm64",
-        browser,
         displayName: "Linux (ARM64)",
         downloadUrl: downloadLinks.linuxArm64Deb,
       };
@@ -106,7 +89,6 @@ export function detectPlatform(): DetectedPlatform {
     return {
       platform: "linux",
       linuxArch: "x64",
-      browser,
       displayName: "Linux",
       downloadUrl: downloadLinks.linuxDeb,
     };
@@ -114,7 +96,6 @@ export function detectPlatform(): DetectedPlatform {
 
   return {
     platform: "unknown",
-    browser,
     displayName: "your platform",
     downloadUrl: downloadLinks.macos,
   };
@@ -188,6 +169,7 @@ function MobileInstallCard({ detected }: { detected: DetectedPlatform }) {
   const [deferredPrompt, setDeferredPrompt] =
     useState<BeforeInstallPromptEvent | null>(null);
   const [installed, setInstalled] = useState(false);
+  const isStandalone = useIsStandalone();
 
   useEffect(() => {
     if (detected.platform !== "android") return;
@@ -226,6 +208,20 @@ function MobileInstallCard({ detected }: { detected: DetectedPlatform }) {
     }
   };
 
+  if (isStandalone) {
+    return (
+      <div className="rounded-md border bg-card p-8 text-center shadow-lg">
+        <MobilePlatformIcon platform={detected.platform} />
+        <h2 className="mt-4 text-2xl font-semibold text-card-foreground">
+          HackerAI is installed
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          You&apos;re already running HackerAI as an installed app.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="rounded-md border bg-card p-8 shadow-lg">
       <div className="mb-6 text-center">
@@ -262,53 +258,26 @@ function MobileInstallCard({ detected }: { detected: DetectedPlatform }) {
         </>
       )}
 
-      {!installed && <InstallInstructions detected={detected} />}
+      {!installed && <InstallInstructions platform={detected.platform} />}
     </div>
   );
 }
 
-function InstallInstructions({ detected }: { detected: DetectedPlatform }) {
-  if (detected.platform === "ios") {
-    if (detected.browser !== "safari") {
-      return (
-        <div className="rounded-md border bg-background p-4 text-sm text-muted-foreground">
-          <p className="mb-2 font-medium text-card-foreground">
-            Installing on iOS requires Safari
-          </p>
-          <p>Open this page in Safari to add HackerAI to your home screen.</p>
-        </div>
-      );
-    }
-
+function InstallInstructions({ platform }: { platform: Platform }) {
+  if (platform === "ios") {
     return (
       <StepsList
         steps={[
           <>
-            Tap the <strong>Share</strong> button at the bottom of Safari (the
-            square with an arrow pointing up).
+            Tap the <strong>Share</strong> button (the square with an arrow
+            pointing up). You may need to tap the three dots (⋯) menu first to
+            reveal it.
           </>,
           <>
             Scroll down and tap <strong>Add to Home Screen</strong>.
           </>,
           <>
             Tap <strong>Add</strong> in the top right corner.
-          </>,
-        ]}
-      />
-    );
-  }
-
-  // Android
-  if (detected.browser === "firefox") {
-    return (
-      <StepsList
-        steps={[
-          <>
-            Tap the <strong>menu</strong> (⋮).
-          </>,
-          <>
-            Tap <strong>Install</strong> (or <strong>Add to Home Screen</strong>
-            ).
           </>,
         ]}
       />

--- a/hooks/use-is-standalone.ts
+++ b/hooks/use-is-standalone.ts
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+export function useIsStandalone() {
+  const [isStandalone, setIsStandalone] = React.useState(false);
+
+  React.useEffect(() => {
+    const mql = window.matchMedia("(display-mode: standalone)");
+    const iosStandalone =
+      (window.navigator as Navigator & { standalone?: boolean }).standalone ===
+      true;
+
+    const update = () => setIsStandalone(mql.matches || iosStandalone);
+    update();
+
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+
+  return isStandalone;
+}


### PR DESCRIPTION
Follow-up to #380. Two small improvements on top of the now-merged mobile install feature.

## Summary
- **Drop per-browser UA sniffing.** iOS is WebKit-forced by Apple, so all iOS browsers use the same "tap Share → Add to Home Screen" flow; Android Chrome/Samsung/Edge all use the same three-dot-menu flow. The `browser` field, `detectBrowser()` helper, and Firefox-specific Android branch are removed (~30 lines deleted).
- **Add shared `useIsStandalone` hook** ([hooks/use-is-standalone.ts](hooks/use-is-standalone.ts)) wrapping `matchMedia("(display-mode: standalone)")` plus iOS Safari's legacy `navigator.standalone`.
- **Hide the sidebar "Install App" / "Download App" entry** when the user is already inside the installed PWA — avoids surfacing a useless menu item.
- **Short-circuit the /download mobile card** to an "already installed" state for the rare case someone reaches the page via bookmark or URL from inside the installed app.

## Test plan
- [ ] Browser on mobile: sidebar still shows "Install App" / "Download App", /download shows install steps.
- [ ] Installed PWA on mobile (open app from home screen): sidebar entry is hidden. If /download is opened directly, it shows "HackerAI is installed".
- [ ] Desktop browser: unchanged behavior.
- [ ] `pnpm typecheck` and `pnpm test` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detection for when HackerAI is installed as a standalone app on your device.
  * "Download App" option now appears only when the app is not yet installed.
  * When the app is already installed, a confirmation message displays instead of installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->