### PR TITLE
fix: refund on stream errors, correct Kimi pricing, drop primary leg on fallback

### DIFF
--- a/app/api/delete-account/route.ts
+++ b/app/api/delete-account/route.ts
@@ -3,6 +3,7 @@ import { stripe } from "../stripe";
 import { workos } from "../workos";
 import { getUserIDWithFreshLogin } from "@/lib/auth/get-user-id";
 import { clearByokApiKey } from "@/lib/auth/byok";
+import { deleteUserRateLimitKeys } from "@/lib/rate-limit/token-bucket";
 import { ChatSDKError } from "@/lib/errors";
 
 export const POST = async (req: NextRequest) => {
@@ -94,15 +95,24 @@ export const POST = async (req: NextRequest) => {
       }),
     );
 
-    // Remove any stored BYOK OpenRouter key from WorkOS Vault. Best-effort:
-    // WorkOS user deletion proceeds even if vault cleanup fails so the account
-    // is not left in a half-deleted state.
-    await clearByokApiKey(userId).catch((err) => {
-      console.warn(
-        "Failed to clear BYOK vault entry during account deletion:",
-        err,
-      );
-    });
+    // Remove any stored BYOK OpenRouter key from WorkOS Vault and purge
+    // Redis rate-limit keys in parallel. Both are best-effort: WorkOS user
+    // deletion proceeds even if either fails so the account is not left in
+    // a half-deleted state.
+    await Promise.all([
+      clearByokApiKey(userId).catch((err) => {
+        console.warn(
+          "Failed to clear BYOK vault entry during account deletion:",
+          err,
+        );
+      }),
+      deleteUserRateLimitKeys(userId).catch((err) => {
+        console.warn(
+          "Failed to clear Redis rate-limit keys during account deletion:",
+          err,
+        );
+      }),
+    ]);
 
     // Finally, delete the WorkOS user
     await workos.userManagement.deleteUser(userId);

--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -205,6 +205,19 @@ describe("UsageTracker", () => {
 
       expect(tracker.computeCostDollars("model-default")).toBe(0.85);
     });
+
+    it("should use token-based model cost + nonModelCost when modelProviderCost is 0 but providerCost is positive from sandbox/tool spend (post-resetModelLeg scenario)", () => {
+      // Simulate the state after resetModelLeg() has stripped the primary
+      // leg's model cost and the fallback leg ran without reporting raw.cost.
+      tracker.accumulateStep({ inputTokens: 1_000_000, outputTokens: 0 });
+      tracker.providerCost = 0.25; // nonModelCost baked in
+      tracker.nonModelCost = 0.25;
+      // modelProviderCost stays 0 because the fallback provider didn't emit cost.
+
+      // Must include BOTH the token-based model cost (0.60) AND the sandbox
+      // spend (0.25). The old implementation returned just providerCost = 0.25.
+      expect(tracker.computeCostDollars("model-default")).toBe(0.85);
+    });
   });
 
   describe("resolveUsageType", () => {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -993,7 +993,12 @@ export const createChatHandler = (
                     ...extractErrorDetails(error),
                   });
                 }
-                // No refund on streaming errors - usage is still charged
+                // Refund the upfront deduction only when the provider errored
+                // before producing any tokens. If hasUsage is true, the real
+                // cost will still be reconciled by deductAccumulatedUsage().
+                if (!usageTracker.hasUsage) {
+                  await usageRefundTracker.refund();
+                }
               },
             });
 
@@ -1033,6 +1038,10 @@ export const createChatHandler = (
               stoppedDueToDoomLoop = false;
               preFallbackCacheRead = usageTracker.cacheReadTokens;
               preFallbackCacheWrite = usageTracker.cacheWriteTokens;
+              // Discard the failed primary leg's model usage so the user is
+              // only billed for the fallback. Non-model spend (sandbox/tools)
+              // is preserved.
+              usageTracker.resetModelLeg();
               result = await createStream(fallbackModel);
             } else {
               throw error;
@@ -1078,6 +1087,11 @@ export const createChatHandler = (
                     stoppedDueToPreemptiveTimeout = false;
                     stoppedDueToDoomLoop = false;
                     const fallbackStartTime = Date.now();
+
+                    // Discard the failed primary leg's model usage so the
+                    // user is only billed for the fallback. Non-model spend
+                    // (sandbox/tools) is preserved.
+                    usageTracker.resetModelLeg();
 
                     const retryResult = await createStream(fallbackModel);
                     const retryMessageId = generateId();
@@ -1587,7 +1601,10 @@ export const createChatHandler = (
       // Clear timeout if error occurs before onFinish
       preemptiveTimeout?.clear();
 
-      // No refund on errors - usage is still charged
+      // Refund the upfront deduction when the request fails before any tokens
+      // were consumed. refund() is idempotent and only fires if deductions were
+      // recorded and nothing has been refunded yet.
+      await usageRefundTracker.refund();
 
       // Handle ChatSDKErrors (including authentication errors)
       if (error instanceof ChatSDKError) {

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -21,6 +21,13 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   "model-opus-4.6": { input: 5.0, output: 25.0 },
   "model-opus-4.7": { input: 5.0, output: 25.0 },
   "model-gpt-5.4": { input: 2.5, output: 15.0 },
+  // "agent-model", "agent-model-free", and "model-kimi-k2.6" all route to
+  // moonshotai/kimi-k2.6:exacto via lib/ai/providers.ts. Rates from Moonshot AI
+  // direct provider (int4): $0.95 in / $4.00 out per 1M tokens. Cache-read
+  // discount ($0.16/M) applies when provider cost is available via usage.raw.cost.
+  "agent-model": { input: 0.95, output: 4.0 },
+  "agent-model-free": { input: 0.95, output: 4.0 },
+  "model-kimi-k2.6": { input: 0.95, output: 4.0 },
 };
 
 const getModelPricing = (modelName?: string) =>
@@ -471,6 +478,32 @@ export const resetRateLimitBuckets = async (
   subscription: SubscriptionTier,
 ): Promise<void> => {
   await initProratedBucket(userId, subscription, 1.0, 0);
+};
+
+/**
+ * Delete all Redis keys associated with a user. Called during account deletion
+ * so orphaned buckets, stashes, and sliding-window counters are purged
+ * immediately rather than waiting on the 30-day TTL. Best-effort — returns
+ * the number of keys deleted, never throws.
+ */
+export const deleteUserRateLimitKeys = async (
+  userId: string,
+): Promise<number> => {
+  const redis = createRedisClient();
+  if (!redis) return 0;
+
+  try {
+    const keys = await redis.keys(`*${userId}*`);
+    if (!keys || keys.length === 0) return 0;
+    await Promise.all(keys.map((key) => redis.del(key)));
+    return keys.length;
+  } catch (error) {
+    console.error(
+      `[deleteUserRateLimitKeys] Failed for user ${userId}:`,
+      error,
+    );
+    return 0;
+  }
 };
 
 // =============================================================================

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -481,10 +481,21 @@ export const resetRateLimitBuckets = async (
 };
 
 /**
- * Delete all Redis keys associated with a user. Called during account deletion
- * so orphaned buckets, stashes, and sliding-window counters are purged
+ * Delete Redis keys associated with a user across every rate-limit namespace
+ * written by this codebase. Called during account deletion so orphaned
+ * buckets, stashes, sliding-window counters, and seat-debt flags are purged
  * immediately rather than waiting on the 30-day TTL. Best-effort — returns
  * the number of keys deleted, never throws.
+ *
+ * Namespaces (keep in sync with key builders in this file and sliding-window.ts):
+ *   - usage:monthly:<userId>:*       — monthly token bucket (any tier)
+ *   - upgrade:carryover:<userId>     — upgrade proration stash
+ *   - free_limit:<userId>:*          — free-tier ask sliding window
+ *   - free_agent_limit:<userId>:*    — free-tier agent sliding window
+ *   - team:debt_applied:*:<userId>   — seat-debt idempotency flag (org-scoped)
+ *
+ * Deliberately NOT included: team:removed_usage:<orgId> (org counter, not
+ * user-scoped) and any extra-usage balance records (stored in Convex, not Redis).
  */
 export const deleteUserRateLimitKeys = async (
   userId: string,
@@ -492,9 +503,20 @@ export const deleteUserRateLimitKeys = async (
   const redis = createRedisClient();
   if (!redis) return 0;
 
+  const patterns = [
+    `usage:monthly:${userId}:*`,
+    `upgrade:carryover:${userId}`,
+    `free_limit:${userId}:*`,
+    `free_agent_limit:${userId}:*`,
+    `team:debt_applied:*:${userId}`,
+  ];
+
   try {
-    const keys = await redis.keys(`*${userId}*`);
-    if (!keys || keys.length === 0) return 0;
+    const keyBatches = await Promise.all(
+      patterns.map((pattern) => redis.keys(pattern)),
+    );
+    const keys = Array.from(new Set(keyBatches.flat()));
+    if (keys.length === 0) return 0;
     await Promise.all(keys.map((key) => redis.del(key)));
     return keys.length;
   } catch (error) {

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -34,6 +34,25 @@ export class UsageTracker {
   /** Output tokens from summarization (not from assistant responses) */
   summarizationOutputTokens = 0;
 
+  /**
+   * Discard the model leg's accumulated usage before a fallback retry runs.
+   * Keeps nonModelCost (sandbox/tool spend already incurred) and summarization
+   * output tokens, so the final deduction only bills the fallback model.
+   */
+  resetModelLeg() {
+    this.providerCost -= this.modelProviderCost;
+    this.modelProviderCost = 0;
+    this.inputTokens = 0;
+    // Preserve summarization's contribution to outputTokens so the
+    // streamOutputTokens getter (outputTokens - summarizationOutputTokens)
+    // never goes negative.
+    this.outputTokens = this.summarizationOutputTokens;
+    this.totalTokens = this.outputTokens;
+    this.lastStepInputTokens = 0;
+    this.cacheReadTokens = 0;
+    this.cacheWriteTokens = 0;
+  }
+
   accumulateStep(usage: StepUsage) {
     this.inputTokens += usage.inputTokens || 0;
     this.outputTokens += usage.outputTokens || 0;

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -91,7 +91,13 @@ export class UsageTracker {
   }
 
   computeModelCostDollars(selectedModel: string): number {
-    if (this.providerCost > 0) return this.providerCost;
+    // Use authoritative per-step provider cost only when the model itself
+    // reported one via raw.cost (tracked in modelProviderCost). providerCost
+    // also includes sandbox/tool spend and summarization cost, so subtract
+    // nonModelCost to isolate the model portion.
+    if (this.modelProviderCost > 0) {
+      return this.providerCost - this.nonModelCost;
+    }
     return (
       (calculateTokenCost(this.inputTokens, "input", selectedModel) +
         calculateTokenCost(this.outputTokens, "output", selectedModel)) /
@@ -100,7 +106,11 @@ export class UsageTracker {
   }
 
   computeCostDollars(selectedModel: string): number {
-    if (this.providerCost > 0) return this.providerCost;
+    // Mirror deductUsage's gate: providerCost is only authoritative for the
+    // total when modelProviderCost > 0. After resetModelLeg() (fallback retry)
+    // providerCost can be positive from nonModelCost alone, which would
+    // underreport the fallback's model tokens if we used it directly.
+    if (this.modelProviderCost > 0) return this.providerCost;
     return this.computeModelCostDollars(selectedModel) + this.nonModelCost;
   }
 


### PR DESCRIPTION
## Summary

Users reported two recurring billing pains:

1. **Balance drains on failed requests** — the upfront `checkRateLimit` deduction was never refunded when a request errored before producing tokens. The `UsageRefundTracker.refund()` machinery already existed; it just wasn't called.
2. **Kimi K2.6 felt disproportionately expensive** — Kimi had no pricing entry, so upfront estimates used the `default` rate ($0.50/$3.00) and the post-stream reconciliation then charged a large overage. On top of that, when Kimi fell back to Grok, both legs' tokens were combined and billed, so users paid for a Kimi attempt they never saw plus the fallback that actually answered.

### Changes

- **Refund on failure** (`lib/api/chat-handler.ts`) — `usageRefundTracker.refund()` now runs in the outer `catch` and in `streamText`'s `onError`. The `onError` refund is gated on `!usageTracker.hasUsage` so real token cost is still reconciled via `deductAccumulatedUsage` when tokens were actually produced. `refund()` is idempotent so the two sites can't double-refund.
- **Kimi K2.6 pricing** (`lib/rate-limit/token-bucket.ts`) — added Moonshot direct rates ($0.95 in / $4.00 out per 1M tokens) under `agent-model`, `agent-model-free`, and `model-kimi-k2.6`. All three route to `moonshotai/kimi-k2.6:exacto` in [lib/ai/providers.ts](lib/ai/providers.ts). Cache-read discount ($0.16/M) still applies automatically via `usage.raw.cost` when the provider reports it.
- **Stop Kimi fallback double-billing** (`lib/usage-tracker.ts` + `lib/api/chat-handler.ts`) — new `UsageTracker.resetModelLeg()` discards `modelProviderCost` and the primary leg's token counts right before the fallback retry runs. Non-model spend (`nonModelCost` — E2B sandbox, tool costs already incurred) and `summarizationOutputTokens` are preserved so the `streamOutputTokens` getter stays non-negative. Wired into both retry sites in `chat-handler.ts`: the immediate retry after `createStream` throws, and the "step-start only" retry inside `onFinish`.
- **Account-deletion rate-limit cleanup** (`app/api/delete-account/route.ts` + `lib/rate-limit/token-bucket.ts`) — new `deleteUserRateLimitKeys(userId)` purges `*${userId}*` Redis keys so orphaned buckets, upgrade-carryover stashes, and sliding-window counters don't linger for the full 30-day TTL after the WorkOS user is deleted. Best-effort, runs in parallel with BYOK vault cleanup.

## Test plan

- [ ] Force a pre-stream `ChatSDKError` (e.g. throw after `checkRateLimit`). Verify `HGET usage:monthly:<uid>:pro tokens` returns to its pre-call value and any `extra_usage` deduction is reversed.
- [ ] Run a stream that produces ~100 output tokens then throws mid-stream. Verify **no** refund fires (because `hasUsage === true`) and normal `deductAccumulatedUsage` still runs.
- [ ] Force the primary Kimi provider to return a 502 after emitting some reasoning tokens. Confirm via Axiom that `deductUsage` only bills the fallback leg's tokens — not the Kimi primary's.
- [ ] Send a simple Kimi turn with a known input size. Upfront `pointsDeducted` should match `ceil(tokens / 1e6 * 0.95 * 10_000 * 1.2)`. Post-stream overage should be minimal (< a few percent).
- [ ] Run one turn each on Sonnet 4.6 and Grok 4.1 — confirm their billing is unchanged.
- [ ] Delete a test account and inspect Redis (`KEYS *<userId>*`) — should return 0 keys after the POST completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account deletion now more thoroughly cleans up associated rate-limit and related data.
  * Streaming errors and fallback retries now refund only when appropriate and reconcile usage/costs more accurately.
  * Pricing rates updated for additional model variants.

* **Tests**
  * Added a unit test covering post-retry usage/cost accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->