### PR TITLE
fix: align mid-cycle upgrade bucket reset with Stripe billing period

### DIFF
--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -213,7 +213,13 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
 
       await Promise.all(
         tierChangeUsers.map(({ uid, stash }) =>
-          initProratedBucket(uid, tier, proratedRatio, stash!.consumed),
+          initProratedBucket(
+            uid,
+            tier,
+            proratedRatio,
+            stash!.consumed,
+            periodEnd,
+          ),
         ),
       );
 

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -625,12 +625,18 @@ export const calculateProratedCredits = (
  *
  * @param consumedCredits - Credits already consumed from the old tier this cycle.
  *   Deducted from the prorated allocation so users can't "double-dip".
+ * @param periodEndSeconds - Optional Stripe `current_period_end` (unix seconds).
+ *   When supplied, the bucket's internal `refilledAt` is rewritten so Upstash's
+ *   reported reset (`refilledAt + 30 d`) lands on the actual invoice date
+ *   instead of 30 days from now. Matters for mid-cycle upgrades, where the
+ *   remaining cycle is shorter than 30 days.
  */
 export const initProratedBucket = async (
   userId: string,
   newTier: SubscriptionTier,
   proratedRatio: number,
   consumedCredits: number = 0,
+  periodEndSeconds?: number,
 ): Promise<void> => {
   const redis = createRedisClient();
   if (!redis) return;
@@ -656,6 +662,21 @@ export const initProratedBucket = async (
     // Burn excess to bring bucket down to prorated level
     if (burnAmount > 0) {
       await monthly.limiter.limit(monthly.key, { rate: burnAmount });
+    }
+
+    // Align the UI-facing reset time with Stripe's billing cycle. Upstash's
+    // token bucket computes reset as `refilledAt + interval`; our interval is
+    // hardcoded to 30 d, so setting `refilledAt = periodEnd - 30 d` makes the
+    // reported reset land exactly on the next invoice date. `refilledAt` is
+    // an internal field of @upstash/ratelimit — re-verify on SDK upgrades.
+    if (
+      periodEndSeconds &&
+      Number.isFinite(periodEndSeconds) &&
+      periodEndSeconds > 0
+    ) {
+      const targetRefilledAtMs =
+        (periodEndSeconds - THIRTY_DAYS_SECONDS) * 1000;
+      await redis.hset(monthlyKey, { refilledAt: targetRefilledAtMs });
     }
 
     // Align TTL to 30 days from now


### PR DESCRIPTION
On mid-cycle upgrades, the new token bucket was created with refilledAt=now, so Upstash's reported reset (refilledAt + 30d) drifted past the actual Stripe invoice date — users saw "resets in ~30 days" instead of the real ~N days until renewal. Override refilledAt to (periodEnd - 30d) so the reported reset lands on the next invoice date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected rate-limit bucket reset timing for mid-cycle subscription tier changes to synchronize with Stripe billing cycle end dates rather than defaulting to 30 days from initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->