### PR TITLE
chore: remove free-agent request logging

### DIFF
--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -50,7 +50,6 @@ import { countTokens } from "gpt-tokenizer";
 import { ChatSDKError } from "@/lib/errors";
 import PostHogClient from "@/app/posthog";
 import {
-  captureFreeAgentRequest,
   captureToolCalls,
   createChatLogger,
   shutdownPostHog,
@@ -1136,25 +1135,6 @@ export const createChatHandler = (
                             userId,
                             mode,
                           });
-                          if (mode === "agent" && subscription === "free") {
-                            captureFreeAgentRequest({
-                              posthog,
-                              chatLogger,
-                              userId,
-                              estimatedInputTokens,
-                              selectedModel,
-                              selectedModelOverride,
-                              configuredModelId,
-                              responseModel,
-                              usageTracker,
-                              finishReason: streamFinishReason,
-                              wasAborted: retryAborted,
-                              wasPreemptiveTimeout: false,
-                              hadSummarization: hasSummarized(),
-                              isTemporary: !!temporary,
-                              isRegenerate: !!regenerate,
-                            });
-                          }
                           shutdownPostHog(posthog);
                           chatLogger!.emitSuccess({
                             finishReason: streamFinishReason,
@@ -1340,25 +1320,6 @@ export const createChatHandler = (
                   cacheWriteTokens: usageTracker.cacheWriteTokens,
                 });
                 captureToolCalls({ posthog, chatLogger, userId, mode });
-                if (mode === "agent" && subscription === "free") {
-                  captureFreeAgentRequest({
-                    posthog,
-                    chatLogger,
-                    userId,
-                    estimatedInputTokens,
-                    selectedModel,
-                    selectedModelOverride,
-                    configuredModelId,
-                    responseModel,
-                    usageTracker,
-                    finishReason: streamFinishReason,
-                    wasAborted: isAborted,
-                    wasPreemptiveTimeout: isPreemptiveAbort,
-                    hadSummarization: hasSummarized(),
-                    isTemporary: !!temporary,
-                    isRegenerate: !!regenerate,
-                  });
-                }
                 shutdownPostHog(posthog);
                 chatLogger!.emitSuccess({
                   finishReason: streamFinishReason,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -13,7 +13,6 @@ import {
 } from "@/lib/logger";
 import type { ChatMode, ExtraUsageConfig } from "@/types";
 import type { ChatSDKError } from "@/lib/errors";
-import type { UsageTracker } from "@/lib/usage-tracker";
 import type { PostHog } from "posthog-node";
 import { after } from "next/server";
 
@@ -257,80 +256,6 @@ export function captureToolCalls({
       },
     });
   }
-}
-
-export function captureFreeAgentRequest({
-  posthog,
-  chatLogger,
-  userId,
-  estimatedInputTokens,
-  selectedModel,
-  selectedModelOverride,
-  configuredModelId,
-  responseModel,
-  usageTracker,
-  finishReason,
-  wasAborted,
-  wasPreemptiveTimeout,
-  hadSummarization,
-  isTemporary,
-  isRegenerate,
-}: {
-  posthog: PostHog | null;
-  chatLogger: ChatLogger | undefined;
-  userId: string;
-  estimatedInputTokens: number;
-  selectedModel: string;
-  selectedModelOverride?: string;
-  configuredModelId: string;
-  responseModel?: string;
-  usageTracker: UsageTracker;
-  finishReason?: string;
-  wasAborted: boolean;
-  wasPreemptiveTimeout: boolean;
-  hadSummarization: boolean;
-  isTemporary: boolean;
-  isRegenerate: boolean;
-}) {
-  if (!posthog) return;
-
-  const resolvedModel = usageTracker.resolveModelName({
-    selectedModelOverride,
-    responseModel,
-    configuredModelId,
-    selectedModel,
-  });
-
-  posthog.capture({
-    distinctId: userId,
-    event: "free_agent_request_completed",
-    properties: {
-      estimatedInputTokens,
-      inputTokens: usageTracker.inputTokens,
-      outputTokens: usageTracker.outputTokens,
-      totalTokens:
-        usageTracker.totalTokens ||
-        usageTracker.inputTokens + usageTracker.outputTokens,
-      cacheReadTokens: usageTracker.cacheReadTokens || undefined,
-      cacheWriteTokens: usageTracker.cacheWriteTokens || undefined,
-      providerCostDollars: usageTracker.providerCost || undefined,
-      modelCostDollars: usageTracker.computeModelCostDollars(selectedModel),
-      nonModelCostDollars: usageTracker.nonModelCost || undefined,
-      totalCostDollars: usageTracker.computeCostDollars(selectedModel),
-      selectedModel,
-      selectedModelOverride: selectedModelOverride ?? "auto",
-      configuredModelId,
-      responseModel,
-      resolvedModel,
-      toolCallCount: chatLogger?.getToolCalls().length ?? 0,
-      finishReason,
-      wasAborted,
-      wasPreemptiveTimeout,
-      hadSummarization,
-      isTemporary,
-      isRegenerate,
-    },
-  });
 }
 
 export function shutdownPostHog(posthog: PostHog | null) {


### PR DESCRIPTION
Drop captureFreeAgentRequest and its two call sites now that the free-agent local sandbox experiment has concluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal analytics tracking for free-plan agent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->