### PR TITLE
fix: PKCE cookie drop in /login breaks all logins after workos v4 bump

### DIFF
--- a/app/login/route.ts
+++ b/app/login/route.ts
@@ -1,4 +1,5 @@
-import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import { getSignInUrl } from "@workos-inc/authkit-nextjs";
 
 const ALLOWED_INTENTS: Record<string, string> = {
@@ -11,11 +12,7 @@ export async function GET(request: Request) {
   const intent = url.searchParams.get("intent");
   const confirmMigrate = url.searchParams.get("confirm-migrate-pentestgpt");
 
-  const authorizationUrl = await getSignInUrl();
-  const response = NextResponse.redirect(authorizationUrl);
-
-  let redirectPath = null;
-
+  let redirectPath: string | null = null;
   if (intent && ALLOWED_INTENTS[intent]) {
     redirectPath = ALLOWED_INTENTS[intent];
   } else if (confirmMigrate === "true") {
@@ -23,7 +20,8 @@ export async function GET(request: Request) {
   }
 
   if (redirectPath) {
-    response.cookies.set("post_login_redirect", redirectPath, {
+    const cookieStore = await cookies();
+    cookieStore.set("post_login_redirect", redirectPath, {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
@@ -32,5 +30,9 @@ export async function GET(request: Request) {
     });
   }
 
-  return response;
+  // AuthKit v4 sets the PKCE verifier via `cookies().set()` inside getSignInUrl.
+  // Must use next/navigation's redirect() so Next flushes those cookie mutations
+  // onto the outgoing response — a manual NextResponse.redirect() would drop them.
+  const authorizationUrl = await getSignInUrl();
+  redirect(authorizationUrl);
 }


### PR DESCRIPTION
## Hotfix — prod is currently broken on \`/login\`

#389 bumped \`@workos-inc/authkit-nextjs\` to v4. In v4, \`getSignInUrl()\` sets the PKCE verifier cookie internally via Next's async \`cookies()\` store — previously the caller did it explicitly.

Our \`app/login/route.ts\` builds its own \`NextResponse.redirect(authorizationUrl)\`. Manually-constructed \`NextResponse\` objects don't merge mutations made via \`cookies().set()\` — those only attach to the framework's implicit response. So the PKCE cookie is silently dropped at \`/login\`, the browser sends WorkOS an auth request with no verifier, Google bounces back to \`/callback\` without the cookie, and the callback recovery redirects to \`/login\` → loop.

Observed in prod logs:

\`\`\`
[AuthKit callback error] Error: Auth cookie missing — cannot verify OAuth state.
[AuthKit callback recovery] { bucket: 'cookie_missing', hasVerifierCookie: false, ... }
\`\`\`

\`/signup\` was unaffected because it already uses \`redirect()\` from \`next/navigation\` (which cooperates with the cookie store).

## Fix

Mirror \`/signup\`: mutate \`cookies()\` then call \`redirect()\` from \`next/navigation\`. Next flushes cookie mutations onto the redirect response.

## Test plan
- [x] \`pnpm typecheck\`, \`pnpm lint\`, \`pnpm test\` (797/797)
- [ ] Merge → deploy → verify \`/login\` → Google → \`/callback\` completes
- [ ] Verify intent-based post-login redirects (\`/login?intent=pricing\`) still land correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal authentication redirect mechanism and cookie handling for enhanced reliability and performance during login flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->