### PR TITLE
fix(callback): preserve authkit's PKCE delete on post-login redirect

### DIFF
--- a/app/callback/route.ts
+++ b/app/callback/route.ts
@@ -8,6 +8,11 @@ const isValidLocalPath = (path: string): boolean => {
   );
 };
 
+const PKCE_COOKIE_PREFIX = "wos-auth-verifier";
+
+const hasPkceCookie = (request: NextRequest): boolean =>
+  request.cookies.getAll().some((c) => c.name.startsWith(PKCE_COOKIE_PREFIX));
+
 type RecoveryBucket =
   | "state_mismatch"
   | "verifier_missing"
@@ -38,9 +43,7 @@ const buildRecoveryResponse = async (
 ): Promise<Response> => {
   const cookieStore = await cookies();
   const redirectPath = cookieStore.get("post_login_redirect")?.value;
-  const hasVerifierCookie = request.cookies
-    .getAll()
-    .some((c) => c.name.startsWith("wos-auth-verifier"));
+  const hasVerifierCookie = hasPkceCookie(request);
   if (redirectPath) {
     cookieStore.delete({ name: "post_login_redirect", path: "/" });
   }
@@ -63,12 +66,14 @@ const buildRecoveryResponse = async (
     secFetchSite: request.headers.get("sec-fetch-site"),
   };
 
+  // Distinct prefix from authkit's own `[AuthKit callback error]` so log
+  // aggregators don't double-count and so we can grep this wrapper separately.
   if (bucket === "unknown") {
-    console.error("[AuthKit callback error]", error, logPayload);
+    console.error("[callback] unrecoverable", error, logPayload);
     return NextResponse.redirect(new URL("/auth-error?code=500", request.url));
   }
 
-  console.warn("[AuthKit callback recovery]", logPayload);
+  console.warn("[callback] recovering", logPayload);
 
   // Only verifier_missing with the cookie still present indicates genuine
   // corruption/tampering worth surfacing as an error. Everything else →
@@ -103,26 +108,47 @@ const authHandler = handleAuth({
 });
 
 export async function GET(request: NextRequest) {
+  // Short-circuit the single most common recoverable case — no PKCE cookie
+  // at all (stale/abandoned flow, prefetch, ITP) — before authkit runs, so
+  // authkit's unconditional `[AuthKit callback error]` console.error doesn't
+  // fire. Kept intentionally minimal so it doesn't couple to authkit internals.
+  if (!hasPkceCookie(request)) {
+    return buildRecoveryResponse(
+      request,
+      new Error(
+        "Auth cookie missing — cannot verify OAuth state. Ensure Set-Cookie headers are propagated on redirects.",
+      ),
+    );
+  }
+
   const cookieStore = await cookies();
   const redirectPath = cookieStore.get("post_login_redirect")?.value;
 
-  let response: Response;
+  let response: NextResponse;
   try {
-    response = await authHandler(request);
+    response = (await authHandler(request)) as NextResponse;
   } catch (error) {
     // Defensive: handleAuth shouldn't throw when onError is provided, but if
     // it ever does, fall back to the same recovery pipeline.
     return buildRecoveryResponse(request, error);
   }
 
-  // On success, honor post_login_redirect.
+  // On success, honor post_login_redirect by MUTATING the existing response's
+  // Location header rather than building a new one. Rebuilding drops the
+  // Set-Cookie headers authkit attached to expire the PKCE verifier, leaving
+  // the cookie in the browser — which then causes `invalid_grant` on any
+  // subsequent hit of the callback URL (refresh, back button, prefetcher).
   if (
     redirectPath &&
     isValidLocalPath(redirectPath) &&
     [302, 307].includes(response.status)
   ) {
     cookieStore.delete({ name: "post_login_redirect", path: "/" });
-    return NextResponse.redirect(new URL(redirectPath, request.url));
+    response.headers.set(
+      "location",
+      new URL(redirectPath, request.url).toString(),
+    );
+    return response;
   }
 
   if (response.status >= 400) {

--- a/app/callback/route.ts
+++ b/app/callback/route.ts
@@ -133,21 +133,21 @@ export async function GET(request: NextRequest) {
     return buildRecoveryResponse(request, error);
   }
 
-  // On success, honor post_login_redirect by MUTATING the existing response's
-  // Location header rather than building a new one. Rebuilding drops the
-  // Set-Cookie headers authkit attached to expire the PKCE verifier, leaving
-  // the cookie in the browser — which then causes `invalid_grant` on any
-  // subsequent hit of the callback URL (refresh, back button, prefetcher).
-  if (
-    redirectPath &&
-    isValidLocalPath(redirectPath) &&
-    [302, 307].includes(response.status)
-  ) {
+  // On a successful redirect response, always clear post_login_redirect so a
+  // stale/malformed value can't survive and re-trigger the check on every
+  // subsequent callback. Only rewrite the Location header if the value is a
+  // safe local path. MUTATE authkit's response rather than building a new one
+  // — rebuilding drops the Set-Cookie headers authkit attached to expire the
+  // PKCE verifier, which causes `invalid_grant` on any subsequent hit of the
+  // callback URL (refresh, back button, prefetcher).
+  if (redirectPath && [302, 307].includes(response.status)) {
     cookieStore.delete({ name: "post_login_redirect", path: "/" });
-    response.headers.set(
-      "location",
-      new URL(redirectPath, request.url).toString(),
-    );
+    if (isValidLocalPath(redirectPath)) {
+      response.headers.set(
+        "location",
+        new URL(redirectPath, request.url).toString(),
+      );
+    }
     return response;
   }
 


### PR DESCRIPTION
## Why

Prod is seeing a real spike in \`OauthException: invalid_grant — code already exchanged\` logs, plus an increase in \`[AuthKit callback error]\` noise overall, since #389.

### Bug #1 (real): PKCE verifier isn't deleted after success → \`invalid_grant\`

Our \`/callback\` wrapper replaced authkit's success response with a fresh \`NextResponse.redirect\` when a \`post_login_redirect\` cookie was set:

\`\`\`ts
return NextResponse.redirect(new URL(redirectPath, request.url));
\`\`\`

authkit's own response carries \`Set-Cookie: wos-auth-verifier-<hash>=; Expires=epoch\` to delete the PKCE verifier after a successful exchange ([authkit-callback-route.js#L78](https://github.com/workos/authkit-nextjs/blob/main/src/authkit-callback-route.ts)). Rebuilding the response dropped that header. The cookie stayed in the browser, and any refresh / back button / prefetcher hit on the callback URL ran authkit again with the same \`code\`, which WorkOS rejected with \`invalid_grant\`.

Fix: **mutate the Location header** on authkit's existing response instead of rebuilding it.

### Bug #2 (noise): double-logged errors

Our recovery uses \`console.error('[AuthKit callback error]', ...)\` for \`bucket: 'unknown'\` failures. authkit already logs under the same prefix. Every unknown-bucket failure showed up twice in the dashboard.

Renamed our wrapper's prefixes to \`[callback] unrecoverable\` / \`[callback] recovering\` so aggregators can distinguish.

### Bug #3 (noise): \`[AuthKit callback error]\` spam for stale flows

authkit's \`handleAuth\` logs at error severity unconditionally, including for the common \`cookie_missing\` case (user abandoned the flow, prefetcher hit \`/callback\`, cookie aged out). The previous preflight suppressed these before the v4 upgrade; when we deleted the preflight those logs came back.

Added a **minimal** preflight: one line checking \`wos-auth-verifier*\` cookie presence. No sealed-data inspection, no cookie-name algorithm coupling — just presence. If no cookie → go straight to recovery.

## Test plan
- [x] \`pnpm typecheck\`, \`pnpm lint\`, \`pnpm test\` (797/797)
- [ ] Deploy → confirm \`invalid_grant\` rate drops toward zero
- [ ] Confirm \`[AuthKit callback error]\` rate drops (should now only fire for \`verifier_missing\` / \`state_mismatch\` / genuine unknowns, not \`cookie_missing\`)
- [ ] Exercise \`/login?intent=pricing\` and \`/login?confirm-migrate-pentestgpt=true\` end-to-end — landing page should still honor both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented loss of PKCE/verifier cookie during authentication redirects to avoid intermittent login failures.
  * Added early detection and clearer error response when required auth cookies are missing.
  * Ensured post-login redirect is reliably cleared after successful callbacks to avoid stale redirect loops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->