### PR TITLE
feat: add GPT-5.5 and remove Opus 4.6

### DIFF
--- a/app/components/ModelSelector/CostIndicator.tsx
+++ b/app/components/ModelSelector/CostIndicator.tsx
@@ -10,9 +10,9 @@ const MODEL_COST_TIER: Record<string, CostTier> = {
   "gemini-3-flash": "low",
   "grok-4.1": "low",
   "sonnet-4.6": "high",
-  "opus-4.6": "very-high",
   "opus-4.7": "very-high",
   "gpt-5.4": "high",
+  "gpt-5.5": "very-high",
   "kimi-k2.6": "medium",
 };
 

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -14,18 +14,23 @@ export const ASK_MODEL_OPTIONS: ModelOption[] = [
   { id: "gemini-3-flash", label: "Gemini 3 Flash" },
   { id: "grok-4.1", label: "Grok 4.1" },
   { id: "gpt-5.4", label: "GPT-5.4", censored: true },
+  { id: "gpt-5.5", label: "GPT-5.5", censored: true },
   { id: "sonnet-4.6", label: "Claude Sonnet 4.6", censored: true },
-  { id: "opus-4.6", label: "Claude Opus 4.6", censored: true },
   { id: "opus-4.7", label: "Claude Opus 4.7", censored: true },
 ];
 
 export const AGENT_MODEL_OPTIONS: ModelOption[] = [
   { id: "kimi-k2.6", label: "Kimi K2.6", thinking: true },
   { id: "grok-4.1", label: "Grok 4.1", thinking: true },
-  { id: "gpt-5.4", label: "GPT-5.4", censored: true },
-  { id: "sonnet-4.6", label: "Claude Sonnet 4.6", censored: true },
-  { id: "opus-4.6", label: "Claude Opus 4.6", censored: true },
-  { id: "opus-4.7", label: "Claude Opus 4.7", censored: true },
+  { id: "gpt-5.4", label: "GPT-5.4", thinking: true, censored: true },
+  { id: "gpt-5.5", label: "GPT-5.5", thinking: true, censored: true },
+  {
+    id: "sonnet-4.6",
+    label: "Claude Sonnet 4.6",
+    thinking: true,
+    censored: true,
+  },
+  { id: "opus-4.7", label: "Claude Opus 4.7", thinking: true, censored: true },
 ];
 
 // export const CODEX_LOCAL_OPTIONS: ModelOption[] = [

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -45,9 +45,9 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "model-sonnet-4.6": or("anthropic/claude-sonnet-4-6"),
     "model-grok-4.1": or("x-ai/grok-4.1-fast"),
     "model-gemini-3-flash": or("google/gemini-3-flash-preview"),
-    "model-opus-4.6": or("anthropic/claude-opus-4-6"),
     "model-opus-4.7": or("anthropic/claude-opus-4-7"),
     "model-gpt-5.4": or("openai/gpt-5.4"),
+    "model-gpt-5.5": or("openai/gpt-5.5"),
     "model-kimi-k2.6": or("moonshotai/kimi-k2.6:exacto"),
     "fallback-agent-model": or("x-ai/grok-4.1-fast"),
     "fallback-ask-model": or("x-ai/grok-4.1-fast"),
@@ -67,9 +67,9 @@ export const modelCutoffDates: Record<ModelName, string> &
   "model-sonnet-4.6": "May 2025",
   "model-grok-4.1": "November 2024",
   "model-gemini-3-flash": "January 2025",
-  "model-opus-4.6": "May 2025",
   "model-opus-4.7": "January 2026",
   "model-gpt-5.4": "August 2025",
+  "model-gpt-5.5": "August 2025",
   "model-kimi-k2.6": "April 2024",
   "fallback-agent-model": "January 2025",
   "fallback-ask-model": "January 2025",
@@ -86,9 +86,9 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-sonnet-4.6": "Anthropic Claude Sonnet 4.6",
   "model-grok-4.1": "xAI Grok 4.1 Fast",
   "model-gemini-3-flash": "Google Gemini 3 Flash",
-  "model-opus-4.6": "Anthropic Claude Opus 4.6",
   "model-opus-4.7": "Anthropic Claude Opus 4.7",
   "model-gpt-5.4": "OpenAI GPT-5.4",
+  "model-gpt-5.5": "OpenAI GPT-5.5",
   "model-kimi-k2.6": "Moonshot Kimi K2.6",
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
   "fallback-ask-model": "Auto, an intelligent model router built by HackerAI",
@@ -111,9 +111,9 @@ export const MODEL_CONTEXT_WINDOWS: Record<ModelName, number> &
   "model-sonnet-4.6": 1_000_000, // Claude Sonnet 4.6 with 1M context beta
   "model-grok-4.1": 2_000_000, // Grok 4.1 Fast
   "model-gemini-3-flash": 1_048_576, // Gemini 3 Flash
-  "model-opus-4.6": 1_000_000, // Claude Opus 4.6 with 1M context beta
   "model-opus-4.7": 1_000_000, // Claude Opus 4.7 with 1M context beta
   "model-gpt-5.4": 1_050_000, // GPT-5.4 (922k input + 128k output)
+  "model-gpt-5.5": 1_050_000, // GPT-5.5 (922k input + 128k output)
   "model-kimi-k2.6": 262_144, // Kimi K2.6
   "fallback-agent-model": 2_000_000,
   "fallback-ask-model": 2_000_000,

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -192,10 +192,6 @@ describe("selectModel", () => {
       );
     });
 
-    it("should allow Opus 4.6 in agent mode for paid users", () => {
-      expect(selectModel("agent", "pro", "opus-4.6")).toBe("model-opus-4.6");
-    });
-
     it("should default to agent-model when no model selected", () => {
       expect(selectModel("agent", "pro")).toBe("agent-model");
       expect(selectModel("agent", "pro", "auto")).toBe("agent-model");

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -18,9 +18,9 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   "model-sonnet-4.6": { input: 3.0, output: 15.0 },
   "model-grok-4.1": { input: 0.2, output: 0.5 },
   "model-gemini-3-flash": { input: 0.5, output: 3.0 },
-  "model-opus-4.6": { input: 5.0, output: 25.0 },
   "model-opus-4.7": { input: 5.0, output: 25.0 },
   "model-gpt-5.4": { input: 2.5, output: 15.0 },
+  "model-gpt-5.5": { input: 5.0, output: 30.0 },
   // "agent-model", "agent-model-free", and "model-kimi-k2.6" all route to
   // moonshotai/kimi-k2.6:exacto via lib/ai/providers.ts. Rates from Moonshot AI
   // direct provider (int4): $0.95 in / $4.00 out per 1M tokens. Cache-read

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -16,9 +16,9 @@ export type SelectedModel =
   | "sonnet-4.6"
   | "grok-4.1"
   | "gemini-3-flash"
-  | "opus-4.6"
   | "opus-4.7"
   | "gpt-5.4"
+  | "gpt-5.5"
   | "kimi-k2.6";
 // | "codex-local"
 // | `codex-local:${string}`;
@@ -28,9 +28,9 @@ export const SELECTABLE_MODELS: readonly SelectedModel[] = [
   "sonnet-4.6",
   "grok-4.1",
   "gemini-3-flash",
-  "opus-4.6",
   "opus-4.7",
   "gpt-5.4",
+  "gpt-5.5",
   "kimi-k2.6",
   // "codex-local",
 ];


### PR DESCRIPTION
## Summary
- Add OpenAI GPT-5.5 to ask and agent model selectors (OpenRouter pricing: \$5 in / \$30 out per 1M; `very-high` cost tier)
- Remove Claude Opus 4.6 from selectors, provider map, pricing, context windows, and tests
- Mark censored agent-mode models (gpt-5.4, gpt-5.5, sonnet-4.6, opus-4.7) as `thinking: true` so both badges render

## Test plan
- [x] `tsc --noEmit` passes
- [x] `jest` — 796/796 pass
- [ ] Open the chat UI and verify GPT-5.5 appears in both Ask and Agent selectors with `$$$+` (very-high) cost indicator and both thinking + censored badges in Agent mode
- [ ] Verify Opus 4.6 no longer appears in either selector
- [ ] Send a paid-tier message with GPT-5.5 selected and confirm it routes to `openai/gpt-5.5` via OpenRouter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GPT-5.5 model with extended reasoning capabilities.
  * Thinking mode now enabled for GPT-5.4, GPT-5.5, Sonnet-4.6, and Opus-4.7.

* **Chores**
  * Removed Opus-4.6 model from available options.
  * Updated model metadata including context window sizes and knowledge cutoff dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->