### PR TITLE
fix: credit extra-usage balance on checkout return

### DIFF
--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -10,6 +10,7 @@ import PricingDialog from "../components/PricingDialog";
 import TeamPricingDialog from "../components/TeamPricingDialog";
 import { TeamWelcomeDialog } from "../components/TeamDialogs";
 import MigratePentestgptDialog from "../components/MigratePentestgptDialog";
+import { ExtraUsagePurchaseToast } from "../components/extra-usage";
 import { usePricingDialog } from "../hooks/usePricingDialog";
 import { useGlobalState } from "../contexts/GlobalState";
 import { usePentestgptMigration } from "../hooks/usePentestgptMigration";
@@ -149,6 +150,7 @@ export default function Page() {
     <>
       <Authenticated>
         <AuthenticatedContent />
+        <ExtraUsagePurchaseToast />
         <PricingDialog isOpen={showPricing} onClose={handleClosePricing} />
         <TeamPricingDialog
           isOpen={teamPricingDialogOpen}

--- a/app/api/extra-usage/confirm/route.ts
+++ b/app/api/extra-usage/confirm/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { stripe } from "@/app/api/stripe";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "@/convex/_generated/api";
+
+const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+
+/**
+ * GET /api/extra-usage/confirm?session_id=cs_xxx
+ *
+ * Landing endpoint after Stripe Checkout completes. Verifies the session
+ * directly with Stripe and credits the user's balance synchronously so they
+ * see the new balance immediately on return. The async webhook at
+ * /api/extra-usage/webhook remains the safety net for cases where the user
+ * closes the tab before this route runs — both paths share a session-scoped
+ * idempotency key (`cs_<session_id>`), so whichever commits first wins.
+ */
+export async function GET(req: NextRequest) {
+  const sessionId = req.nextUrl.searchParams.get("session_id");
+  const origin = req.nextUrl.origin;
+
+  if (!sessionId || !sessionId.startsWith("cs_")) {
+    return NextResponse.redirect(origin, { status: 303 });
+  }
+
+  try {
+    const session = await stripe.checkout.sessions.retrieve(sessionId);
+
+    if (session.metadata?.type !== "extra_usage_purchase") {
+      return NextResponse.redirect(origin, { status: 303 });
+    }
+
+    const userId = session.metadata.userId;
+    const amountDollars = session.metadata.amountDollars
+      ? parseFloat(session.metadata.amountDollars)
+      : parseInt(session.metadata.amountCents ?? "0", 10) / 100;
+
+    if (!userId || isNaN(amountDollars) || amountDollars <= 0) {
+      console.error(
+        "[Extra Usage Confirm] Invalid metadata on session:",
+        session.id,
+      );
+      return NextResponse.redirect(origin, { status: 303 });
+    }
+
+    const redirectUrl = new URL(origin);
+    redirectUrl.searchParams.set("extra-usage-purchased", "true");
+    redirectUrl.searchParams.set("amount", String(amountDollars));
+
+    // Async payment methods (e.g. bank debits) finalize later — webhook will
+    // credit when Stripe sends `checkout.session.async_payment_succeeded` or
+    // an eventual `checkout.session.completed` with `payment_status: paid`.
+    if (session.payment_status !== "paid") {
+      redirectUrl.searchParams.set("extra-usage-pending", "true");
+      return NextResponse.redirect(redirectUrl, { status: 303 });
+    }
+
+    await convex.mutation(api.extraUsage.addCredits, {
+      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+      userId,
+      amountDollars,
+      idempotencyKey: `cs_${session.id}`,
+    });
+
+    return NextResponse.redirect(redirectUrl, { status: 303 });
+  } catch (err) {
+    console.error("[Extra Usage Confirm] Failed to confirm session:", err);
+    // Webhook is the safety net — don't block the user on confirm failures.
+    const fallback = new URL(origin);
+    fallback.searchParams.set("extra-usage-purchased", "true");
+    return NextResponse.redirect(fallback, { status: 303 });
+  }
+}

--- a/app/api/extra-usage/webhook/route.ts
+++ b/app/api/extra-usage/webhook/route.ts
@@ -75,13 +75,16 @@ export async function POST(req: NextRequest) {
         );
       }
 
-      // Add credits to user's balance (idempotent - uses Stripe event ID for deduplication)
+      // Add credits to user's balance. Idempotency key is scoped to the Checkout
+      // Session so this path and the post-checkout confirm redirect (which uses
+      // the same key) can race without double-crediting.
       try {
         const result = await convex.mutation(api.extraUsage.addCredits, {
           serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
           userId,
           amountDollars,
-          idempotencyKey: event.id, // Stripe event ID is stable across retries
+          idempotencyKey: `cs_${session.id}`,
+          legacyIdempotencyKey: event.id, // Guards retries of pre-deploy webhooks that stored `evt_<id>`
         });
 
         if (result.alreadyProcessed) {

--- a/app/components/extra-usage/ExtraUsagePurchaseToast.tsx
+++ b/app/components/extra-usage/ExtraUsagePurchaseToast.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+/**
+ * Shows a sonner toast after a user returns from Stripe Checkout for extra
+ * usage credits. The confirm route (/api/extra-usage/confirm) redirects here
+ * with ?extra-usage-purchased=true&amount=<dollars>. Async payment methods
+ * land with ?extra-usage-pending=true while the webhook completes the credit.
+ *
+ * Strips the params from the URL after firing so a reload doesn't re-show it.
+ * Reads directly from window.location to match the existing page pattern and
+ * avoid forcing a Suspense boundary via next/navigation's useSearchParams.
+ */
+export function ExtraUsagePurchaseToast() {
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (firedRef.current) return;
+
+    const url = new URL(window.location.href);
+    if (url.searchParams.get("extra-usage-purchased") !== "true") return;
+
+    firedRef.current = true;
+
+    const pending = url.searchParams.get("extra-usage-pending") === "true";
+    const amountRaw = url.searchParams.get("amount");
+    const amount = amountRaw ? Number(amountRaw) : NaN;
+    const amountLabel =
+      Number.isFinite(amount) && amount > 0 ? `$${amount}` : null;
+
+    if (pending) {
+      toast.info("Payment received", {
+        description: amountLabel
+          ? `${amountLabel} in credits will be added once your payment finalizes.`
+          : "Your credits will be added once your payment finalizes.",
+      });
+    } else {
+      toast.success("Payment successful", {
+        description: amountLabel
+          ? `Added ${amountLabel} in extra usage credits.`
+          : "Extra usage credits added to your balance.",
+      });
+    }
+
+    url.searchParams.delete("extra-usage-purchased");
+    url.searchParams.delete("extra-usage-pending");
+    url.searchParams.delete("amount");
+    window.history.replaceState({}, "", url.pathname + url.search + url.hash);
+  }, []);
+
+  return null;
+}

--- a/app/components/extra-usage/ExtraUsagePurchaseToast.tsx
+++ b/app/components/extra-usage/ExtraUsagePurchaseToast.tsx
@@ -47,7 +47,13 @@ export function ExtraUsagePurchaseToast() {
     url.searchParams.delete("extra-usage-purchased");
     url.searchParams.delete("extra-usage-pending");
     url.searchParams.delete("amount");
-    window.history.replaceState({}, "", url.pathname + url.search + url.hash);
+    // Preserve Next.js App Router's internal history state (routing tree,
+    // scroll restoration) — passing {} would clobber it.
+    window.history.replaceState(
+      window.history.state,
+      "",
+      url.pathname + url.search + url.hash,
+    );
   }, []);
 
   return null;

--- a/app/components/extra-usage/index.ts
+++ b/app/components/extra-usage/index.ts
@@ -2,3 +2,4 @@ export { TurnOffExtraUsageDialog } from "./TurnOffExtraUsageDialog";
 export { BuyExtraUsageDialog } from "./BuyExtraUsageDialog";
 export { AdjustSpendingLimitDialog } from "./AdjustSpendingLimitDialog";
 export { AutoReloadDialog } from "./AutoReloadDialog";
+export { ExtraUsagePurchaseToast } from "./ExtraUsagePurchaseToast";

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -172,7 +172,8 @@ export const addCredits = mutation({
     serviceKey: v.string(),
     userId: v.string(),
     amountDollars: v.number(),
-    idempotencyKey: v.optional(v.string()), // Stripe event ID for webhook deduplication
+    idempotencyKey: v.optional(v.string()), // Primary dedup key (session-scoped: `cs_<id>`)
+    legacyIdempotencyKey: v.optional(v.string()), // Stripe event ID — checked only to guard pre-deploy webhook retries
   },
   returns: v.object({
     newBalance: v.number(), // Returns dollars
@@ -181,11 +182,15 @@ export const addCredits = mutation({
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
 
-    // Idempotency: skip if already processed (prevents double-credit on webhook retries)
-    if (args.idempotencyKey) {
+    // Idempotency: skip if already processed (prevents double-credit on webhook retries
+    // and across both the post-checkout confirm path and the async webhook path)
+    const dedupKeys = [args.idempotencyKey, args.legacyIdempotencyKey].filter(
+      (k): k is string => typeof k === "string" && k.length > 0,
+    );
+    for (const key of dedupKeys) {
       const existing = await ctx.db
         .query("processed_webhooks")
-        .withIndex("by_event_id", (q) => q.eq("event_id", args.idempotencyKey!))
+        .withIndex("by_event_id", (q) => q.eq("event_id", key))
         .first();
 
       if (existing) {

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -352,7 +352,7 @@ export const createPurchaseSession = action({
           userId: identity.subject,
           amountDollars: String(args.amountDollars),
         },
-        success_url: `${args.baseUrl}?extra-usage-purchased=true&amount=${args.amountDollars}`,
+        success_url: `${args.baseUrl}/api/extra-usage/confirm?session_id={CHECKOUT_SESSION_ID}`,
         cancel_url: args.baseUrl,
       });
 


### PR DESCRIPTION
## Summary

- Manual extra-usage purchases previously depended on the async Stripe webhook alone, so any delay in webhook delivery left users seeing a stale balance — matching the recurring complaint "I paid but my account hasn't been updated," which "fixes itself" once the webhook eventually arrives.
- Adds `/api/extra-usage/confirm`, the new Checkout `success_url` target, which retrieves the session from Stripe server-side, verifies `payment_status === "paid"`, and credits the balance synchronously before the user lands back on the app.
- Webhook at `/api/extra-usage/webhook` stays as the closed-tab safety net. Both paths share a session-scoped idempotency key (`cs_<session_id>`) so whichever commits first wins. Webhook also passes its previous `event.id` key as `legacyIdempotencyKey` to guard retries of any pre-deploy deliveries recorded under the old key.

## Known gap (intentional, not in this PR)

If both the confirm route AND the webhook fail, the purchase is lost silently. A reconciliation cron (scan recent `checkout.session.completed` sessions vs. `processed_webhooks`) would close that gap as a follow-up. Not shipped here to keep this PR focused on the user-visible complaint.

## Test plan

- [ ] Buy extra usage with a test card — balance should update immediately on return, before the webhook fires.
- [ ] Simulate the webhook arriving before the redirect (e.g. via Stripe CLI replay); confirm route should no-op via idempotency and not double-credit.
- [ ] Simulate the confirm route failing (temporary network error); webhook should still credit once.
- [ ] Close the Checkout tab before returning; webhook alone should credit the balance.
- [ ] Async payment method (if enabled): redirect lands with `extra-usage-pending=true`; webhook credits once Stripe finalizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated confirmation endpoint after checkout to validate payment and apply purchased credits.
  * In-app toast notifications that report successful or pending credit application and remove URL flags after display.

* **Bug Fixes**
  * Improved duplicate-prevention for crediting using a checkout-scoped deduplication key with legacy fallback.
  * Safer handling of pending payments to defer crediting until final confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->