### PR TITLE
fix: re-arm sticky scroll on new user message

### DIFF
--- a/app/components/CodeHighlight.tsx
+++ b/app/components/CodeHighlight.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { useState, useMemo } from "react";
+import { memo, useState, useMemo } from "react";
 import ShikiHighlighter, { isInlineCode, type Element } from "react-shiki";
 import { CodeActionButtons } from "@/components/ui/code-action-buttons";
 import { isLanguageSupported, ShikiErrorBoundary } from "@/lib/utils/shiki";
@@ -10,7 +10,7 @@ interface CodeHighlightProps {
   node?: Element | undefined;
 }
 
-export const CodeHighlight = ({
+const CodeHighlightImpl = ({
   className,
   children,
   node,
@@ -110,3 +110,9 @@ export const CodeHighlight = ({
     </code>
   );
 };
+
+// Memoize so finished code blocks don't re-highlight when sibling markdown
+// re-renders during streaming. Streaming code blocks still update because
+// `children` (the text) changes each token; Shiki's `delay={150}` throttles
+// the actual tokenization on top of that.
+export const CodeHighlight = memo(CodeHighlightImpl);

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -964,21 +964,22 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     }
   }, [messages.length, scrollToBottom, isExistingChat]);
 
-  // Re-arm sticky scroll whenever a new user message is appended. Stop+send
-  // flows (Send Now, stop-and-send) mutate the DOM mid-stream which knocks
-  // use-stick-to-bottom out of "at bottom" state, so we force-scroll on the
-  // new user message to resume following the next generation.
-  const prevMessagesLenRef = useRef(messages.length);
+  // Re-arm sticky scroll whenever a new user message is appended at the tail.
+  // Stop+send flows (Send Now, stop-and-send) mutate the DOM mid-stream which
+  // knocks use-stick-to-bottom out of "at bottom" state, so we force-scroll on
+  // the new user message to resume following the next generation. Keyed on
+  // tail-id (not length) so pagination prepends don't trigger a scroll jump.
+  const prevLastIdRef = useRef<string | undefined>(
+    messages[messages.length - 1]?.id,
+  );
   useEffect(() => {
-    const prev = prevMessagesLenRef.current;
-    prevMessagesLenRef.current = messages.length;
-    if (
-      messages.length > prev &&
-      messages[messages.length - 1]?.role === "user"
-    ) {
+    const last = messages[messages.length - 1];
+    const prevLastId = prevLastIdRef.current;
+    prevLastIdRef.current = last?.id;
+    if (last && last.id !== prevLastId && last.role === "user") {
       scrollToBottom({ force: true });
     }
-  }, [messages.length, messages, scrollToBottom]);
+  }, [messages, scrollToBottom]);
 
   // Keep a ref to the latest messageQueue to avoid stale closures
   const messageQueueRef = useRef(messageQueue);

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -964,6 +964,22 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     }
   }, [messages.length, scrollToBottom, isExistingChat]);
 
+  // Re-arm sticky scroll whenever a new user message is appended. Stop+send
+  // flows (Send Now, stop-and-send) mutate the DOM mid-stream which knocks
+  // use-stick-to-bottom out of "at bottom" state, so we force-scroll on the
+  // new user message to resume following the next generation.
+  const prevMessagesLenRef = useRef(messages.length);
+  useEffect(() => {
+    const prev = prevMessagesLenRef.current;
+    prevMessagesLenRef.current = messages.length;
+    if (
+      messages.length > prev &&
+      messages[messages.length - 1]?.role === "user"
+    ) {
+      scrollToBottom({ force: true });
+    }
+  }, [messages.length, messages, scrollToBottom]);
+
   // Keep a ref to the latest messageQueue to avoid stale closures
   const messageQueueRef = useRef(messageQueue);
   useEffect(() => {

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -651,11 +651,16 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       if (toolCall.toolName === "todo_write" && toolCall.input) {
         const todoInput = toolCall.input as { merge?: boolean; todos: Todo[] };
         if (!todoInput.todos) return;
-        // Determine last assistant message id to stamp/replace
-        const lastAssistant = [...messages]
-          .reverse()
-          .find((m) => m.role === "assistant");
-        const lastAssistantId = lastAssistant?.id;
+        // Determine last assistant message id to stamp/replace.
+        // Read via ref to avoid closing over the streaming messages array.
+        const currentMessages = messagesRef.current;
+        let lastAssistantId: string | undefined;
+        for (let i = currentMessages.length - 1; i >= 0; i--) {
+          if (currentMessages[i].role === "assistant") {
+            lastAssistantId = currentMessages[i].id;
+            break;
+          }
+        }
 
         const treatAsMerge = shouldTreatAsMerge(
           todoInput.merge,
@@ -681,7 +686,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       // in-memory messages with fresh objects (causes flicker/scroll jump).
       if (isCodexLocal(selectedModelRef.current)) {
         codexSyncSuppressedUntilRef.current = Date.now() + 2000;
-        persistCodexMessages(messages);
+        persistCodexMessages(messagesRef.current);
         return;
       }
 

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -969,17 +969,17 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   // knocks use-stick-to-bottom out of "at bottom" state, so we force-scroll on
   // the new user message to resume following the next generation. Keyed on
   // tail-id (not length) so pagination prepends don't trigger a scroll jump.
-  const prevLastIdRef = useRef<string | undefined>(
-    messages[messages.length - 1]?.id,
-  );
+  const lastMessage = messages[messages.length - 1];
+  const lastId = lastMessage?.id;
+  const lastRole = lastMessage?.role;
+  const prevLastIdRef = useRef<string | undefined>(lastId);
   useEffect(() => {
-    const last = messages[messages.length - 1];
     const prevLastId = prevLastIdRef.current;
-    prevLastIdRef.current = last?.id;
-    if (last && last.id !== prevLastId && last.role === "user") {
+    prevLastIdRef.current = lastId;
+    if (lastId && lastId !== prevLastId && lastRole === "user") {
       scrollToBottom({ force: true });
     }
-  }, [messages, scrollToBottom]);
+  }, [lastId, lastRole, scrollToBottom]);
 
   // Keep a ref to the latest messageQueue to avoid stale closures
   const messageQueueRef = useLatestRef(messageQueue);

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -982,18 +982,17 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   }, [messages, scrollToBottom]);
 
   // Keep a ref to the latest messageQueue to avoid stale closures
-  const messageQueueRef = useRef(messageQueue);
-  useEffect(() => {
-    messageQueueRef.current = messageQueue;
-  }, [messageQueue]);
+  const messageQueueRef = useLatestRef(messageQueue);
 
-  // Clear queue when navigating to a different chat
+  // Clear queue when navigating to a different chat.
+  // Intentionally reads messageQueueRef at cleanup time (latest value).
   useEffect(() => {
     return () => {
       if (messageQueueRef.current.length > 0) {
         clearQueue();
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chatId, clearQueue]);
 
   // Document-level drag and drop listeners encapsulated in a hook
@@ -1033,7 +1032,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
           },
           {
             body: {
-              mode: chatMode,
+              mode: chatModeRef.current,
               todos: todosRef.current,
               temporary: temporaryChatsEnabledRef.current,
               sandboxPreference: sandboxPreferenceRef.current,


### PR DESCRIPTION
## Summary
- Send Now (queued message) and stop-and-send flows knock `use-stick-to-bottom` out of its "at bottom" state because `stopActiveStream()` aborts the stream and calls `setMessages(normalizedMessages)`, mutating the DOM mid-stream. The next generation then streams without auto-following.
- Fix: in `chat.tsx`, add an effect that force-scrolls to bottom whenever a new user message is appended. One declarative point covers Send Now, stop-and-send, and auto-send-after-fork.
- Refactor (`a70765eb`): the queue auto-send effect now reads `chatMode` via `chatModeRef.current` so a mode switch mid-flight doesn't dispatch with a stale value, and the manual `messageQueueRef` sync effect is replaced with `useLatestRef` for consistency with the other refs in the component.
- Perf (`6629b2d6`): the re-arm effect now depends on the tail message's `id`/`role` primitives instead of the `messages` array reference, so it stops firing on every streamed assistant token.
- Perf (`37fb82e4`): drop streaming-array closures in `useChat` callbacks and memoize `CodeHighlight`.
  - `onToolCall` and `onFinish`/codex-persist read `messagesRef.current` instead of capturing `messages`. Also replaces `[...messages].reverse().find()` with a backwards loop (no array clone) when stamping todos onto the last assistant message.
  - `CodeHighlight` wrapped in `React.memo` so finished code blocks stop re-rendering when sibling markdown updates mid-stream. Streaming blocks still update via `children`; Shiki's `delay={150}` throttles the actual tokenization on top of that.

## Test plan
- [ ] Start a long generation, type another prompt, hit Enter with `stop-and-send` queue mode → new generation auto-scrolls.
- [ ] Start a long generation, queue a message, click Send Now on the queued item → new generation auto-scrolls.
- [ ] Normal first send in a fresh chat still follows the assistant output.
- [ ] Existing-chat initial load still scrolls to bottom once (the older `hasScrolledToBottomRef` effect is unchanged).
- [ ] Pagination prepending older messages does NOT trigger a scroll-to-bottom.
- [ ] Queue a message in `ask` mode while streaming, switch to `agent` mid-stream → queued message dispatches to `/api/agent` (latest mode) when the stream ends.
- [ ] Navigate to a different chat with messages still queued → queue is cleared.
- [ ] React DevTools Profiler: re-arm effect fires once per appended message during streaming, not per token.
- [ ] Stream a response that calls `todo_write` mid-stream → todos stamp onto the correct assistant message and update as expected.
- [ ] Stream a long response containing multiple fenced code blocks → finished blocks should not re-highlight on every token (visible in Profiler as fewer `CodeHighlight` renders); the actively-streaming block still updates.
- [ ] Codex local model: finish a stream → messages persist to Convex correctly (the `onFinish` path now reads via ref).

## Follow-ups (not in this PR)
- `ComputerSidebar` re-renders per token because `useSidebarNavigation` re-derives `toolExecutions` from a new `messages` reference each token. A naive `React.memo` is unsafe — the AI SDK streams tool outputs by mutating existing parts, so `messages.length` alone would freeze terminal/file output. A structural-fingerprint comparator (or memoizing `extractAllSidebarContent` differently) needs its own design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat auto-scroll: reliably scrolls to the bottom for new user messages while avoiding jumps when older messages are loaded or paginated.
  * More reliable message sending and queue handling: queued sends now use the current chat mode and the latest queue state to prevent stale or missed send attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->