### PR TITLE
fix(sandbox): preserve PATH for login-shell command exec

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -156,6 +156,10 @@ RUN useradd --create-home --shell /bin/bash user && \
 
 WORKDIR /home/user
 
+# Ensure Go bin paths are in PATH for login shells (su - user, bash -l)
+RUN printf 'export PATH=/home/user/.local/bin:/usr/local/go/bin:/home/user/go/bin:$PATH\n' \
+    > /etc/profile.d/00-hackerai-path.sh && chmod 644 /etc/profile.d/00-hackerai-path.sh
+
 # ============================================================================
 # Python Packages for Document Generation & Security Tools
 # ============================================================================


### PR DESCRIPTION
## Summary

- E2B-spawned commands run via a login shell (with `user: "root"`, see [lib/ai/tools/utils/sandbox-command-options.ts:65-68](lib/ai/tools/utils/sandbox-command-options.ts#L65-L68)). Login shells source `/etc/profile`, which resets `PATH` from `/etc/login.defs` and clobbers the Dockerfile's `ENV PATH`. Result: tools installed under `/home/user/go/bin` (katana, cvemap, interactsh-client) became invisible at runtime even though the build-time `which katana` validation passed.
- Adds `/etc/profile.d/00-hackerai-path.sh` so login shells re-prepend `/home/user/.local/bin`, `/usr/local/go/bin`, and `/home/user/go/bin` before any user command runs.
- Local (Centrifugo) sandboxes were already covered by `augmentCommandPath` in [lib/ai/tools/utils/sandbox-command-options.ts:23-33](lib/ai/tools/utils/sandbox-command-options.ts#L23-L33), so this only changes E2B behavior.

## Test plan

- [ ] Rebuild the sandbox image
- [ ] Spawn an E2B sandbox and run `katana --version` (and `cvemap`, `interactsh-client`) without an absolute path — should resolve
- [ ] Confirm `which katana` still works during build (existing validation step)
- [ ] Spot-check `docker run -it ... /bin/bash` (manual launch) — PATH should be unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker environment configuration to ensure proper PATH setup for interactive shell sessions, making system and local binaries more accessible within the container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->