### PR TITLE
fix(stream): clear stale active_stream_id and skip dead resumes

### DIFF
--- a/app/api/chat/[id]/stream/route.ts
+++ b/app/api/chat/[id]/stream/route.ts
@@ -67,117 +67,172 @@ export async function GET(
     execute: () => {},
   });
 
+  // Best-effort cleanup of a stale `active_stream_id`. Called whenever we
+  // detect the producer is dead so subsequent reconnects skip straight to
+  // replay instead of hitting the ack-timeout (~5s) again.
+  const clearStaleActiveStream = async () => {
+    try {
+      await convex.mutation(api.chatStreams.prepareForNewStream, {
+        serviceKey,
+        chatId,
+      });
+    } catch {
+      // Best-effort — the next reconnect will re-attempt cleanup.
+    }
+  };
+
   if (recentStreamId) {
     let stream: ReadableStream | null = null;
+    let resumableThrew = false;
     try {
       stream = await streamContext.resumableStream(recentStreamId, () =>
         emptyDataStream.pipeThrough(new JsonToSseTransformStream()),
       );
     } catch {
       // Producer is gone (ack timeout) — fall through to replay fallback
+      resumableThrew = true;
+    }
+
+    if (resumableThrew) {
+      await clearStaleActiveStream();
     }
 
     if (stream) {
-      const abortController = new AbortController();
-
-      // Set up pre-emptive timeout before Vercel's hard 800s limit
-      const preemptiveTimeout = createPreemptiveTimeout({
-        chatId,
-        endpoint: "/api/chat/[id]/stream",
-        abortController,
-      });
-
-      // Abort on client disconnect (tab close, network error, etc.)
-      req.signal.addEventListener("abort", () => abortController.abort(), {
-        once: true,
-      });
-
-      // Abort on explicit stop button click (via Redis pub/sub or polling)
-      const cancellationSubscriber = await createCancellationSubscriber({
-        chatId,
-        isTemporary,
-        abortController,
-        onStop: () => {},
-      });
-
       const reader = stream.getReader();
 
-      const abortableStream = new ReadableStream({
-        async pull(controller) {
-          try {
-            // Create a promise that rejects on abort
-            const abortPromise = new Promise<never>((_, reject) => {
-              if (abortController.signal.aborted) {
-                reject(new DOMException("Aborted", "AbortError"));
+      // Peek the first chunk. When `active_stream_id` is still set in DB but
+      // the resumable buffer is empty (producer finished and the buffer
+      // expired), `resumableStream` invokes the no-op fallback, which emits
+      // only the SSE `[DONE]` terminator. Returning that to the client renders
+      // an empty assistant message — fall through to the replay branch instead.
+      const first = await reader.read();
+      const firstText = first.done
+        ? ""
+        : typeof first.value === "string"
+          ? first.value
+          : new TextDecoder().decode(first.value as Uint8Array);
+      const isNoopStream =
+        first.done || /^\s*data:\s*\[DONE\]\s*$/m.test(firstText.trim());
+
+      if (isNoopStream) {
+        reader.releaseLock();
+        try {
+          await stream.cancel();
+        } catch {
+          // ignore — falling through to replay
+        }
+        await clearStaleActiveStream();
+      } else {
+        const abortController = new AbortController();
+
+        // Set up pre-emptive timeout before Vercel's hard 800s limit
+        const preemptiveTimeout = createPreemptiveTimeout({
+          chatId,
+          endpoint: "/api/chat/[id]/stream",
+          abortController,
+        });
+
+        // Abort on client disconnect (tab close, network error, etc.)
+        req.signal.addEventListener("abort", () => abortController.abort(), {
+          once: true,
+        });
+
+        // Abort on explicit stop button click (via Redis pub/sub or polling)
+        const cancellationSubscriber = await createCancellationSubscriber({
+          chatId,
+          isTemporary,
+          abortController,
+          onStop: () => {},
+        });
+
+        let pendingFirstDelivered = false;
+
+        const abortableStream = new ReadableStream({
+          async pull(controller) {
+            try {
+              if (!pendingFirstDelivered) {
+                pendingFirstDelivered = true;
+                controller.enqueue(first.value);
                 return;
               }
-              abortController.signal.addEventListener(
-                "abort",
-                () => reject(new DOMException("Aborted", "AbortError")),
-                { once: true },
-              );
-            });
 
-            // Race between read and abort
-            const { done, value } = await Promise.race([
-              reader.read(),
-              abortPromise,
-            ]);
-
-            if (done) {
-              preemptiveTimeout.clear();
-              controller.close();
-            } else {
-              controller.enqueue(value);
-            }
-          } catch (error) {
-            const isPreemptive = preemptiveTimeout.isPreemptive();
-            const triggerTime = preemptiveTimeout.getTriggerTime();
-            const cleanupStart = Date.now();
-
-            if (isPreemptive) {
-              nextJsAxiomLogger.info("Stream route preemptive abort caught", {
-                chatId,
-                timeSinceTriggerMs: triggerTime
-                  ? cleanupStart - triggerTime
-                  : null,
-              });
-            }
-
-            preemptiveTimeout.clear();
-
-            if (error instanceof DOMException && error.name === "AbortError") {
-              if (isPreemptive) {
-                nextJsAxiomLogger.info(
-                  "Stream route closing controller after abort",
-                  {
-                    chatId,
-                    cleanupDurationMs: Date.now() - cleanupStart,
-                  },
+              // Create a promise that rejects on abort
+              const abortPromise = new Promise<never>((_, reject) => {
+                if (abortController.signal.aborted) {
+                  reject(new DOMException("Aborted", "AbortError"));
+                  return;
+                }
+                abortController.signal.addEventListener(
+                  "abort",
+                  () => reject(new DOMException("Aborted", "AbortError")),
+                  { once: true },
                 );
-                await nextJsAxiomLogger.flush();
-              }
-              controller.close();
-            } else {
-              controller.error(error);
-            }
-          }
-        },
-        cancel() {
-          const isPreemptive = preemptiveTimeout.isPreemptive();
-          if (isPreemptive) {
-            nextJsAxiomLogger.info("Stream route cancel called", { chatId });
-          }
-          preemptiveTimeout.clear();
-          reader.cancel();
-          cancellationSubscriber.stop();
-          if (isPreemptive) {
-            nextJsAxiomLogger.flush();
-          }
-        },
-      });
+              });
 
-      return new Response(abortableStream, { status: 200 });
+              // Race between read and abort
+              const { done, value } = await Promise.race([
+                reader.read(),
+                abortPromise,
+              ]);
+
+              if (done) {
+                preemptiveTimeout.clear();
+                controller.close();
+              } else {
+                controller.enqueue(value);
+              }
+            } catch (error) {
+              const isPreemptive = preemptiveTimeout.isPreemptive();
+              const triggerTime = preemptiveTimeout.getTriggerTime();
+              const cleanupStart = Date.now();
+
+              if (isPreemptive) {
+                nextJsAxiomLogger.info("Stream route preemptive abort caught", {
+                  chatId,
+                  timeSinceTriggerMs: triggerTime
+                    ? cleanupStart - triggerTime
+                    : null,
+                });
+              }
+
+              preemptiveTimeout.clear();
+
+              if (
+                error instanceof DOMException &&
+                error.name === "AbortError"
+              ) {
+                if (isPreemptive) {
+                  nextJsAxiomLogger.info(
+                    "Stream route closing controller after abort",
+                    {
+                      chatId,
+                      cleanupDurationMs: Date.now() - cleanupStart,
+                    },
+                  );
+                  await nextJsAxiomLogger.flush();
+                }
+                controller.close();
+              } else {
+                controller.error(error);
+              }
+            }
+          },
+          cancel() {
+            const isPreemptive = preemptiveTimeout.isPreemptive();
+            if (isPreemptive) {
+              nextJsAxiomLogger.info("Stream route cancel called", { chatId });
+            }
+            preemptiveTimeout.clear();
+            reader.cancel();
+            cancellationSubscriber.stop();
+            if (isPreemptive) {
+              nextJsAxiomLogger.flush();
+            }
+          },
+        });
+
+        return new Response(abortableStream, { status: 200 });
+      }
     }
   }
 
@@ -193,6 +248,12 @@ export async function GET(
     );
 
     if (!mostRecentMessage) {
+      // Producer is dead and there's nothing to replay — clear the stale
+      // active_stream_id so the chat isn't stuck in a "resuming" state on
+      // every page load.
+      if (recentStreamId) {
+        await clearStaleActiveStream();
+      }
       return new Response(
         emptyDataStream.pipeThrough(new JsonToSseTransformStream()),
         { status: 200 },
@@ -213,7 +274,7 @@ export async function GET(
       restoredStream.pipeThrough(new JsonToSseTransformStream()),
       { status: 200 },
     );
-  } catch (error) {
+  } catch {
     return new Response(
       emptyDataStream.pipeThrough(new JsonToSseTransformStream()),
       { status: 200 },

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -145,6 +145,7 @@ function StreamEffects({
   sandboxPreference,
   selectedModel,
   resetRef,
+  hasActiveStream,
 }: {
   autoResume: boolean;
   serverMessages: ChatMessage[];
@@ -162,12 +163,14 @@ function StreamEffects({
   sandboxPreference: string;
   selectedModel: string;
   resetRef: RefObject<(() => void) | null>;
+  hasActiveStream: boolean | undefined;
 }) {
   useAutoResume({
     autoResume,
     initialMessages: serverMessages,
     resumeStream,
     setMessages,
+    hasActiveStream,
   });
 
   const { resetAutoContinueCount } = useAutoContinue({
@@ -1159,6 +1162,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
         sandboxPreference={sandboxPreference}
         selectedModel={selectedModel}
         resetRef={resetAutoContinueRef}
+        hasActiveStream={
+          chatData === undefined ? undefined : !!chatData?.active_stream_id
+        }
       />
       <div className="flex min-h-0 flex-1 w-full flex-col bg-background overflow-hidden">
         <div className="flex min-h-0 flex-1 min-w-0 relative">

--- a/app/hooks/useAutoResume.ts
+++ b/app/hooks/useAutoResume.ts
@@ -13,6 +13,11 @@ export interface UseAutoResumeParams {
   initialMessages: ChatMessage[];
   resumeStream: UseChatHelpers<ChatMessage>["resumeStream"];
   setMessages: UseChatHelpers<ChatMessage>["setMessages"];
+  // Tri-state: undefined = chat data still loading (wait), true = server is
+  // actively producing (resume), false = no active stream (don't resume —
+  // the user message went unanswered, but resuming would just GET an empty
+  // SSE and waste a round-trip).
+  hasActiveStream: boolean | undefined;
 }
 
 export function useAutoResume({
@@ -20,6 +25,7 @@ export function useAutoResume({
   initialMessages,
   resumeStream,
   setMessages,
+  hasActiveStream,
 }: UseAutoResumeParams) {
   const { dataStream } = useDataStreamState();
   const { setIsAutoResuming } = useDataStreamDispatch();
@@ -28,6 +34,10 @@ export function useAutoResume({
   useEffect(() => {
     if (!autoResume || hasAutoResumedRef.current) return;
     if (initialMessages.length === 0) return;
+    // Wait for chat data to load, then only resume when the server says
+    // it's actively producing a response.
+    if (hasActiveStream === undefined) return;
+    if (!hasActiveStream) return;
 
     const mostRecentMessage = initialMessages.at(-1);
 
@@ -37,7 +47,7 @@ export function useAutoResume({
       resumeStream();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoResume, initialMessages.length > 0]);
+  }, [autoResume, initialMessages.length > 0, hasActiveStream]);
 
   useEffect(() => {
     if (!dataStream) return;


### PR DESCRIPTION
## Summary

- When a stream's producer dies before saving an assistant message (ack timeout or empty resumable buffer), `active_stream_id` was left set on the chat. Every reconnect paid the full ack-timeout (~5s) before falling through to replay, and the client kept auto-resuming forever because `useAutoResume` only checked the last message role.
- **Server**: clear `active_stream_id` in all dead-stream branches (ack timeout, no-op `[DONE]`-only stream, empty replay) and peek the resumable stream's first chunk so a `[DONE]`-only fallback gets routed into replay instead of returned to the client.
- **Client**: gate `useAutoResume` on `chatData.active_stream_id` (tri-state: `undefined` while loading, `true` to resume, `false` to skip) so the auto-resume `GET /api/chat/[id]/stream` only fires when the server is actively producing.

## Test plan

- [ ] Reload a chat where the user's last message went unanswered — confirm no `GET /api/chat/[id]/stream` is fired (was firing on every reload before)
- [ ] Mid-stream tab close + reopen during an actively producing chat — confirm resume still works and content streams in
- [ ] Server-side: trigger an ack-timeout case once, confirm `active_stream_id` is cleared in Convex on the next reconnect
- [ ] `npm run typecheck`
- [ ] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted or stale streaming connections to prevent empty assistant messages
  * Enhanced reconnection logic to better detect when the server is actively producing output
  * Auto-resume now correctly accounts for server state before attempting to reconnect

<!-- end of auto-generated comment: release notes by coderabbit.ai -->