### PR TITLE
feat(todos): mirror panel into computer sidebar + sidebar mid-stream fix

### DIFF
--- a/app/components/ComputerSidebar.tsx
+++ b/app/components/ComputerSidebar.tsx
@@ -753,7 +753,7 @@ export const ComputerSidebarBase: React.FC<ComputerSidebarProps> = ({
                 <div></div>
               </div>
             </div>
-            <TodoPanel status={status ?? "ready"} placement="sidebar" />
+            <TodoPanel status={status} placement="sidebar" />
           </div>
         </div>
       </div>

--- a/app/components/ComputerSidebar.tsx
+++ b/app/components/ComputerSidebar.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/types/chat";
 import type { Id } from "@/convex/_generated/dataModel";
 import { FilePartRenderer } from "./FilePartRenderer";
+import { TodoPanel } from "./TodoPanel";
 import {
   getCategoryColor,
   getLanguageFromPath,
@@ -752,6 +753,7 @@ export const ComputerSidebarBase: React.FC<ComputerSidebarProps> = ({
                 <div></div>
               </div>
             </div>
+            <TodoPanel status={status ?? "ready"} placement="sidebar" />
           </div>
         </div>
       </div>

--- a/app/components/TodoPanel.tsx
+++ b/app/components/TodoPanel.tsx
@@ -104,13 +104,18 @@ export const TodoPanel = ({ status, placement = "chat" }: TodoPanelProps) => {
     ? `${currentTodoIndex + 1} / ${stats.total}`
     : null;
 
-  const containerClassName =
+  const panelClassName =
     placement === "sidebar"
-      ? "mt-3 rounded-[16px] shadow-[0px_4px_32px_0px_rgba(0,0,0,0.04)] border border-black/8 dark:border-border bg-input-chat"
+      ? "rounded-[16px] shadow-[0px_4px_32px_0px_rgba(0,0,0,0.04)] border border-black/8 dark:border-border bg-input-chat overflow-hidden"
       : "mx-4 rounded-[22px_22px_0px_0px] shadow-[0px_12px_32px_0px_rgba(0,0,0,0.02)] border border-black/8 dark:border-border border-b-0 bg-input-chat";
 
-  return (
-    <div className={containerClassName}>
+  const listMaxHeightClass =
+    placement === "sidebar"
+      ? "max-h-[min(calc(100vh-360px),400px)]"
+      : "max-h-[200px]";
+
+  const panel = (
+    <div className={panelClassName}>
       {/* Header */}
       <button
         onClick={handleToggleExpand}
@@ -149,7 +154,9 @@ export const TodoPanel = ({ status, placement = "chat" }: TodoPanelProps) => {
 
       {/* Todo List - Collapsible */}
       {isExpanded && (
-        <div className="border-t border-border px-4 py-3 space-y-2 max-h-[200px] overflow-y-auto">
+        <div
+          className={`border-t border-border px-4 py-3 space-y-2 overflow-y-auto ${listMaxHeightClass}`}
+        >
           {uniqueTodos.map((todo) => (
             <SharedTodoItem key={todo.id} todo={todo} isPaused={isPaused} />
           ))}
@@ -157,4 +164,17 @@ export const TodoPanel = ({ status, placement = "chat" }: TodoPanelProps) => {
       )}
     </div>
   );
+
+  // In the computer sidebar, anchor the panel to the bottom of a fixed-height
+  // placeholder so the expanded list overlays the timeline above it instead of
+  // pushing the timeline up.
+  if (placement === "sidebar") {
+    return (
+      <div className="relative z-50 mt-3 min-h-[40px]">
+        <div className="absolute bottom-0 left-0 right-0">{panel}</div>
+      </div>
+    );
+  }
+
+  return panel;
 };

--- a/app/components/TodoPanel.tsx
+++ b/app/components/TodoPanel.tsx
@@ -1,19 +1,23 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import type { ChatStatus } from "@/types";
 import { useGlobalState } from "@/app/contexts/GlobalState";
-import { SharedTodoItem } from "@/components/ui/shared-todo-item";
+import {
+  SharedTodoItem,
+  getStatusIcon,
+} from "@/components/ui/shared-todo-item";
 import { getTodoStats } from "@/lib/utils/todo-utils";
 
 interface TodoPanelProps {
   status: ChatStatus;
+  placement?: "chat" | "sidebar";
 }
 
-export const TodoPanel = ({ status }: TodoPanelProps) => {
+export const TodoPanel = ({ status, placement = "chat" }: TodoPanelProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const { todos, setIsTodoPanelExpanded } = useGlobalState();
+  const { todos, setIsTodoPanelExpanded, sidebarOpen } = useGlobalState();
 
   // Deduplicate todos by id (keep last occurrence, consistent with backend)
   const uniqueTodos = Array.from(
@@ -51,53 +55,103 @@ export const TodoPanel = ({ status }: TodoPanelProps) => {
     return null;
   }
 
+  if (placement === "chat" && sidebarOpen) {
+    return null;
+  }
+
+  if (placement === "sidebar" && !sidebarOpen) {
+    return null;
+  }
+
   const handleToggleExpand = () => {
     setIsExpanded(!isExpanded);
   };
 
-  const getHeaderText = () => {
-    if (stats.done === 0) {
-      return `${stats.total} To-dos`;
+  // Find the "current" todo: prefer in-progress, otherwise the most recent
+  // completed/cancelled action. Pending-only is handled with a count fallback.
+  const currentTodoIndex = (() => {
+    const inProgressIdx = uniqueTodos.findIndex(
+      (t) => t.status === "in_progress",
+    );
+    if (inProgressIdx !== -1) return inProgressIdx;
+    for (let i = uniqueTodos.length - 1; i >= 0; i--) {
+      const s = uniqueTodos[i].status;
+      if (s === "completed" || s === "cancelled") return i;
     }
-    return `${stats.done} of ${stats.total} To-dos`;
-  };
+    return -1;
+  })();
+
+  const currentTodo =
+    currentTodoIndex !== -1 ? uniqueTodos[currentTodoIndex] : undefined;
+
+  // When the chat is idle but a todo is still in_progress, the user manually
+  // stopped the agent — surface the in_progress todo as paused.
+  const isPaused = status === "ready" && stats.inProgress > 0;
+  const currentTodoDisplayStatus =
+    currentTodo && isPaused && currentTodo.status === "in_progress"
+      ? "paused"
+      : currentTodo?.status;
+
+  const headerText = isExpanded
+    ? "Task progress"
+    : currentTodo
+      ? currentTodo.content
+      : stats.done === 0
+        ? `${stats.total} To-dos`
+        : `${stats.done} of ${stats.total} To-dos`;
+
+  const headerCounter = currentTodo
+    ? `${currentTodoIndex + 1} / ${stats.total}`
+    : null;
+
+  const containerClassName =
+    placement === "sidebar"
+      ? "mt-3 rounded-[16px] shadow-[0px_4px_32px_0px_rgba(0,0,0,0.04)] border border-black/8 dark:border-border bg-input-chat"
+      : "mx-4 rounded-[22px_22px_0px_0px] shadow-[0px_12px_32px_0px_rgba(0,0,0,0.02)] border border-black/8 dark:border-border border-b-0 bg-input-chat";
 
   return (
-    <div className="mx-4 rounded-[22px_22px_0px_0px] shadow-[0px_12px_32px_0px_rgba(0,0,0,0.02)] border border-black/8 dark:border-border border-b-0 bg-input-chat">
+    <div className={containerClassName}>
       {/* Header */}
-      <div
-        className={`flex items-center px-4 transition-all duration-300 py-2`}
+      <button
+        onClick={handleToggleExpand}
+        className="flex items-center w-full gap-2 pl-3 pr-4 py-2 hover:opacity-80 transition-opacity cursor-pointer focus:outline-none"
+        aria-label={isExpanded ? "Collapse todos" : "Expand todos"}
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleToggleExpand();
+          }
+        }}
       >
-        <button
-          onClick={handleToggleExpand}
-          className="flex items-center gap-2 hover:opacity-80 transition-opacity cursor-pointer focus:outline-none rounded-md p-1 -m-1 flex-1"
-          aria-label={isExpanded ? "Collapse todos" : "Expand todos"}
-          tabIndex={0}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              handleToggleExpand();
-            }
-          }}
+        {!isExpanded && currentTodo && currentTodoDisplayStatus ? (
+          <span className="flex-shrink-0">
+            {getStatusIcon(currentTodoDisplayStatus)}
+          </span>
+        ) : null}
+        <h3
+          className="text-muted-foreground text-sm font-medium truncate text-left flex-1 min-w-0"
+          title={headerText}
         >
-          {isExpanded ? (
-            <ChevronDown className="w-4 h-4 text-muted-foreground" />
-          ) : (
-            <ChevronRight className="w-4 h-4 text-muted-foreground" />
-          )}
-          <div className="flex items-center gap-2">
-            <h3 className="text-muted-foreground text-sm font-medium">
-              {getHeaderText()}
-            </h3>
-          </div>
-        </button>
-      </div>
+          {headerText}
+        </h3>
+        {headerCounter && (
+          <span className="text-xs text-muted-foreground flex-shrink-0">
+            {headerCounter}
+          </span>
+        )}
+        {isExpanded ? (
+          <ChevronDown className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+        ) : (
+          <ChevronUp className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+        )}
+      </button>
 
       {/* Todo List - Collapsible */}
       {isExpanded && (
         <div className="border-t border-border px-4 py-3 space-y-2 max-h-[200px] overflow-y-auto">
           {uniqueTodos.map((todo) => (
-            <SharedTodoItem key={todo.id} todo={todo} />
+            <SharedTodoItem key={todo.id} todo={todo} isPaused={isPaused} />
           ))}
         </div>
       )}

--- a/app/components/TodoPanel.tsx
+++ b/app/components/TodoPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import type { ChatStatus } from "@/types";
 import { useGlobalState } from "@/app/contexts/GlobalState";
@@ -11,13 +11,17 @@ import {
 import { getTodoStats } from "@/lib/utils/todo-utils";
 
 interface TodoPanelProps {
-  status: ChatStatus;
+  status?: ChatStatus;
   placement?: "chat" | "sidebar";
 }
 
 export const TodoPanel = ({ status, placement = "chat" }: TodoPanelProps) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const { todos, setIsTodoPanelExpanded, sidebarOpen } = useGlobalState();
+  const {
+    todos,
+    isTodoPanelExpanded: isExpanded,
+    setIsTodoPanelExpanded,
+    sidebarOpen,
+  } = useGlobalState();
 
   // Deduplicate todos by id (keep last occurrence, consistent with backend)
   const uniqueTodos = Array.from(
@@ -28,14 +32,6 @@ export const TodoPanel = ({ status, placement = "chat" }: TodoPanelProps) => {
 
   // Don't show panel if no todos exist
   const hasTodos = uniqueTodos.length > 0;
-
-  // Reflect expansion to global state
-  useEffect(() => {
-    setIsTodoPanelExpanded(isExpanded);
-    return () => {
-      setIsTodoPanelExpanded(false);
-    };
-  }, [isExpanded, setIsTodoPanelExpanded]);
 
   // Show panel only when there are active todos (hide when all are finished)
   const hasActiveTodos = stats.inProgress > 0 || stats.pending > 0;
@@ -64,7 +60,7 @@ export const TodoPanel = ({ status, placement = "chat" }: TodoPanelProps) => {
   }
 
   const handleToggleExpand = () => {
-    setIsExpanded(!isExpanded);
+    setIsTodoPanelExpanded(!isExpanded);
   };
 
   // Find the "current" todo: prefer in-progress, otherwise the most recent
@@ -121,13 +117,6 @@ export const TodoPanel = ({ status, placement = "chat" }: TodoPanelProps) => {
         onClick={handleToggleExpand}
         className="flex items-center w-full gap-2 pl-3 pr-4 py-2 hover:opacity-80 transition-opacity cursor-pointer focus:outline-none"
         aria-label={isExpanded ? "Collapse todos" : "Expand todos"}
-        tabIndex={0}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            handleToggleExpand();
-          }
-        }}
       >
         {!isExpanded && currentTodo && currentTodoDisplayStatus ? (
           <span className="flex-shrink-0">

--- a/app/components/TodoPanel.tsx
+++ b/app/components/TodoPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import type { ChatStatus } from "@/types";
 import { useGlobalState } from "@/app/contexts/GlobalState";
@@ -115,7 +115,7 @@ export const TodoPanel = ({ status, placement = "chat" }: TodoPanelProps) => {
       {/* Header */}
       <button
         onClick={handleToggleExpand}
-        className="flex items-center w-full gap-2 pl-3 pr-4 py-2 hover:opacity-80 transition-opacity cursor-pointer focus:outline-none"
+        className="flex items-center w-full gap-2 pl-3 pr-4 py-2 hover:opacity-80 transition-opacity cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         aria-label={isExpanded ? "Collapse todos" : "Expand todos"}
       >
         {!isExpanded && currentTodo && currentTodoDisplayStatus ? (

--- a/components/ui/shared-todo-item.tsx
+++ b/components/ui/shared-todo-item.tsx
@@ -1,18 +1,27 @@
 import React from "react";
-import { CircleCheck, Circle, CircleArrowRight, X } from "lucide-react";
+import {
+  CircleCheck,
+  Clock,
+  CircleArrowRight,
+  CirclePause,
+  X,
+} from "lucide-react";
 import type { Todo } from "@/types";
+
+export type TodoDisplayStatus = Todo["status"] | "paused";
 
 export const STATUS_ICONS = {
   completed: <CircleCheck className="w-4 h-4 text-foreground" />,
   in_progress: <CircleArrowRight className="w-4 h-4 text-foreground" />,
+  paused: <CirclePause className="w-4 h-4 text-muted-foreground" />,
   cancelled: <X className="w-4 h-4 text-muted-foreground" />,
-  pending: <Circle className="w-4 h-4 text-muted-foreground" />,
+  pending: <Clock className="w-4 h-4 text-muted-foreground" />,
 } as const;
 
-export const getStatusIcon = (status: Todo["status"]) =>
+export const getStatusIcon = (status: TodoDisplayStatus) =>
   STATUS_ICONS[status] || STATUS_ICONS.pending;
 
-export const getTextStyles = (status: Todo["status"]) => {
+export const getTextStyles = (status: TodoDisplayStatus) => {
   if (status === "completed") {
     return "line-through opacity-75 text-foreground";
   }
@@ -22,19 +31,23 @@ export const getTextStyles = (status: Todo["status"]) => {
   return "text-muted-foreground";
 };
 
-export const SharedTodoItem = React.memo(({ todo }: { todo: Todo }) => {
-  return (
-    <div
-      data-testid="todo-item"
-      data-status={todo.status}
-      className="flex items-center gap-3 py-1"
-    >
-      <div className="flex-shrink-0">{getStatusIcon(todo.status)}</div>
-      <span className={`text-sm ${getTextStyles(todo.status)}`}>
-        {todo.content}
-      </span>
-    </div>
-  );
-});
+export const SharedTodoItem = React.memo(
+  ({ todo, isPaused = false }: { todo: Todo; isPaused?: boolean }) => {
+    const displayStatus: TodoDisplayStatus =
+      isPaused && todo.status === "in_progress" ? "paused" : todo.status;
+    return (
+      <div
+        data-testid="todo-item"
+        data-status={displayStatus}
+        className="flex items-center gap-3 py-1"
+      >
+        <div className="flex-shrink-0">{getStatusIcon(displayStatus)}</div>
+        <span className={`text-sm ${getTextStyles(displayStatus)}`}>
+          {todo.content}
+        </span>
+      </div>
+    );
+  },
+);
 
 SharedTodoItem.displayName = "SharedTodoItem";

--- a/lib/utils/sidebar-utils.ts
+++ b/lib/utils/sidebar-utils.ts
@@ -96,7 +96,13 @@ export function extractSidebarContentFromMessage(
 
   message.parts.forEach((part) => {
     // Terminal (including Codex local commands)
-    if (part.type === "tool-run_terminal_cmd" && part.input?.command) {
+    // Skip during input-streaming so partial JSON-parsed inputs don't trigger
+    // sidebar auto-follow before the command is finalized.
+    if (
+      part.type === "tool-run_terminal_cmd" &&
+      part.input?.command &&
+      part.state !== "input-streaming"
+    ) {
       const command = part.input.command;
 
       // Get streaming output from data-terminal parts
@@ -205,10 +211,15 @@ export function extractSidebarContentFromMessage(
     }
 
     // Shell tool (new interactive PTY-based shell)
-    if (part.type === "tool-shell" && part.input) {
+    // Skip during input-streaming so partial JSON-parsed inputs don't trigger
+    // sidebar auto-follow before the command is finalized.
+    if (
+      part.type === "tool-shell" &&
+      part.input &&
+      part.state !== "input-streaming"
+    ) {
       const command = part.input.command || part.input.brief || "";
 
-      // Skip if no command/brief available yet (input still streaming)
       if (!command) return;
 
       // Get streaming output from data-terminal parts
@@ -233,7 +244,13 @@ export function extractSidebarContentFromMessage(
     }
 
     // HTTP Request
-    if (part.type === "tool-http_request" && part.input?.url) {
+    // Skip during input-streaming so partial JSON-parsed inputs don't trigger
+    // sidebar auto-follow before the request is finalized.
+    if (
+      part.type === "tool-http_request" &&
+      part.input?.url &&
+      part.state !== "input-streaming"
+    ) {
       const method = part.input.method || "GET";
       const url = part.input.url;
       const command = `${method} ${url}`;
@@ -540,7 +557,12 @@ export function extractSidebarContentFromMessage(
     }
 
     // Shared files (get_terminal_files)
-    if (part.type === "tool-get_terminal_files") {
+    // Skip during input-streaming so partial JSON-parsed inputs don't trigger
+    // sidebar auto-follow before the file list is finalized.
+    if (
+      part.type === "tool-get_terminal_files" &&
+      part.state !== "input-streaming"
+    ) {
       const requestedPaths: string[] = part.input?.files || [];
 
       // Seed from persisted message.fileDetails so sidebar shows files after reload
@@ -572,7 +594,12 @@ export function extractSidebarContentFromMessage(
       "tool-view_sitemap_entry",
     ];
 
-    if (proxyToolTypes.includes(part.type)) {
+    // Skip during input-streaming so partial JSON-parsed inputs don't trigger
+    // sidebar auto-follow before the proxy action is finalized.
+    if (
+      proxyToolTypes.includes(part.type) &&
+      part.state !== "input-streaming"
+    ) {
       const toolName = part.type.replace("tool-", "");
       const proxyInput = part.input || {};
       const cmdParts: string[] = [toolName];
@@ -616,7 +643,12 @@ export function extractSidebarContentFromMessage(
       "tool-delete_note",
     ];
 
-    if (notesToolTypes.includes(part.type)) {
+    // Skip during input-streaming so partial JSON-parsed inputs don't trigger
+    // sidebar auto-follow before the notes action is finalized.
+    if (
+      notesToolTypes.includes(part.type) &&
+      part.state !== "input-streaming"
+    ) {
       const toolName = part.type.replace("tool-", "") as
         | "create_note"
         | "list_notes"

--- a/lib/utils/sidebar-utils.ts
+++ b/lib/utils/sidebar-utils.ts
@@ -60,6 +60,12 @@ export interface Message {
   [key: string]: any;
 }
 
+// Tool types that intentionally render during input-streaming for progressive UI
+// (e.g. file write/append showing content as the LLM generates it). All other
+// tool types are held back until input-available — see the gate inside the
+// per-part forEach below.
+const STREAMS_DURING_INPUT = new Set<string>(["tool-file"]);
+
 /**
  * Extract sidebar content from a single message. Exported for incremental processing
  * (e.g. only reprocess the last message during streaming).
@@ -95,14 +101,22 @@ export function extractSidebarContentFromMessage(
   });
 
   message.parts.forEach((part) => {
-    // Terminal (including Codex local commands)
-    // Skip during input-streaming so partial JSON-parsed inputs don't trigger
-    // sidebar auto-follow before the command is finalized.
+    // Hold tool entries back until the LLM finishes generating tool input.
+    // The AI SDK populates `part.input` from partial JSON during input-streaming,
+    // which would otherwise push entries into contentList and trigger sidebar
+    // auto-follow mid-stream. Tools listed in STREAMS_DURING_INPUT opt out for
+    // progressive UI (e.g. file write/append showing content as it's generated).
     if (
-      part.type === "tool-run_terminal_cmd" &&
-      part.input?.command &&
-      part.state !== "input-streaming"
+      part.state === "input-streaming" &&
+      typeof part.type === "string" &&
+      part.type.startsWith("tool-") &&
+      !STREAMS_DURING_INPUT.has(part.type)
     ) {
+      return;
+    }
+
+    // Terminal (including Codex local commands)
+    if (part.type === "tool-run_terminal_cmd" && part.input?.command) {
       const command = part.input.command;
 
       // Get streaming output from data-terminal parts
@@ -211,15 +225,10 @@ export function extractSidebarContentFromMessage(
     }
 
     // Shell tool (new interactive PTY-based shell)
-    // Skip during input-streaming so partial JSON-parsed inputs don't trigger
-    // sidebar auto-follow before the command is finalized.
-    if (
-      part.type === "tool-shell" &&
-      part.input &&
-      part.state !== "input-streaming"
-    ) {
+    if (part.type === "tool-shell" && part.input) {
       const command = part.input.command || part.input.brief || "";
 
+      // Skip if no command/brief available yet
       if (!command) return;
 
       // Get streaming output from data-terminal parts
@@ -244,13 +253,7 @@ export function extractSidebarContentFromMessage(
     }
 
     // HTTP Request
-    // Skip during input-streaming so partial JSON-parsed inputs don't trigger
-    // sidebar auto-follow before the request is finalized.
-    if (
-      part.type === "tool-http_request" &&
-      part.input?.url &&
-      part.state !== "input-streaming"
-    ) {
+    if (part.type === "tool-http_request" && part.input?.url) {
       const method = part.input.method || "GET";
       const url = part.input.url;
       const command = `${method} ${url}`;
@@ -557,12 +560,7 @@ export function extractSidebarContentFromMessage(
     }
 
     // Shared files (get_terminal_files)
-    // Skip during input-streaming so partial JSON-parsed inputs don't trigger
-    // sidebar auto-follow before the file list is finalized.
-    if (
-      part.type === "tool-get_terminal_files" &&
-      part.state !== "input-streaming"
-    ) {
+    if (part.type === "tool-get_terminal_files") {
       const requestedPaths: string[] = part.input?.files || [];
 
       // Seed from persisted message.fileDetails so sidebar shows files after reload
@@ -594,12 +592,7 @@ export function extractSidebarContentFromMessage(
       "tool-view_sitemap_entry",
     ];
 
-    // Skip during input-streaming so partial JSON-parsed inputs don't trigger
-    // sidebar auto-follow before the proxy action is finalized.
-    if (
-      proxyToolTypes.includes(part.type) &&
-      part.state !== "input-streaming"
-    ) {
+    if (proxyToolTypes.includes(part.type)) {
       const toolName = part.type.replace("tool-", "");
       const proxyInput = part.input || {};
       const cmdParts: string[] = [toolName];
@@ -643,12 +636,7 @@ export function extractSidebarContentFromMessage(
       "tool-delete_note",
     ];
 
-    // Skip during input-streaming so partial JSON-parsed inputs don't trigger
-    // sidebar auto-follow before the notes action is finalized.
-    if (
-      notesToolTypes.includes(part.type) &&
-      part.state !== "input-streaming"
-    ) {
+    if (notesToolTypes.includes(part.type)) {
       const toolName = part.type.replace("tool-", "") as
         | "create_note"
         | "list_notes"


### PR DESCRIPTION
## Summary

Two related sidebar/todo improvements bundled on this branch:

- **`002544c8` feat(todos): mirror todo panel into computer sidebar with current-action header**
  - When the computer sidebar is open, render `TodoPanel` at the bottom of the sidebar column (and hide the chat-input copy) so it doesn't compete with the active tool view.
  - Header now shows the current in-progress (or most-recent done) todo's content with a status icon and a `position / total` counter; switches to `Task progress` when expanded.
  - Added a paused display state for `in_progress` todos when the chat is idle (i.e. user manually stopped) — purely a UI derivation, no schema change.
  - Replaced the empty pending circle with a clock icon.

- **`3f488786` fix(sidebar): hold tool entries until input-available to stop mid-stream auto-follow**
  - The AI SDK populates `part.input` from partial JSON during `input-streaming`, so terminal/shell/http/proxy/notes/`get_terminal_files` entries were pushed into the sidebar `contentList` mid-stream, causing Auto Mode to snap to a half-formed command.
  - Centralized the gate via a `STREAMS_DURING_INPUT` allowlist — only `tool-file` opts in for progressive write/append rendering; everything else waits for `input-available`.

## Test plan

- [ ] Open a chat with the computer sidebar **closed** — TodoPanel still appears above the chat input as before.
- [ ] Open the computer sidebar — TodoPanel disappears from above the input and reappears at the bottom of the sidebar column.
- [ ] With an `in_progress` todo, hit the stop button — the todo's icon switches to a pause icon (in both header and expanded list); pending todos show a clock icon.
- [ ] Expand the panel — header shows `Task progress`; collapsed shows the current action's content + `position / total`.
- [ ] Run a long terminal/shell/http command — sidebar in Auto Mode no longer snaps to a partial command; it follows once input is finalized.
- [ ] File write/append still streams progressively into the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Todo panel can be placed in the sidebar (or chat) and overlays surrounding content when expanded.

* **Improvements**
  * Collapsed header shows the current todo with a concise current/total counter; expanded view shows task progress.
  * In-progress items can display a clearer paused state and updated status icons/visuals.
  * Sidebar content updates are gated during streaming to avoid premature/ mid-stream refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->