### PR TITLE
feat(fraud): restore EFW + dispute webhook handlers

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -116,6 +116,7 @@ E2B_TEMPLATE=terminal-agent-sandbox
 # ⚠️ IMPORTANT: If using Stripe, also add these to Convex Dashboard → Environment Variables
 # STRIPE_API_KEY=sk_test_
 # STRIPE_EXTRA_USAGE_WEBHOOK_SECRET=
+# STRIPE_FRAUD_WEBHOOK_SECRET=
 # STRIPE_SUBSCRIPTION_WEBHOOK_SECRET=
 
 # =============================================================================

--- a/app/api/fraud/webhook/route.ts
+++ b/app/api/fraud/webhook/route.ts
@@ -22,8 +22,17 @@ function isTerminalStripeError(err: unknown): boolean {
   );
 }
 
-/** Cancel all active Stripe subscriptions for a customer. */
-async function cancelAllSubscriptions(customerId: string): Promise<void> {
+/**
+ * Cancel Stripe subscriptions that existed at the time of the originating
+ * fraud event. Subs created after `asOfUnix` are skipped: they're a different
+ * customer action (e.g. a re-subscribe after a non-fraudulent dispute) and
+ * must not be affected by a webhook replay. This is what makes the handler
+ * safe to re-run against drifted Stripe state.
+ */
+async function cancelAllSubscriptions(
+  customerId: string,
+  asOfUnix: number,
+): Promise<void> {
   const subs = await stripe.subscriptions.list({
     customer: customerId,
     status: "all",
@@ -31,6 +40,12 @@ async function cancelAllSubscriptions(customerId: string): Promise<void> {
   });
 
   for (const sub of subs.data) {
+    if (sub.created > asOfUnix) {
+      console.log(
+        `[Fraud Webhook] Cancel skipped for subscription ${sub.id}: created ${sub.created} > event ${asOfUnix} (post-event)`,
+      );
+      continue;
+    }
     try {
       await stripe.subscriptions.cancel(sub.id as string);
     } catch (err) {
@@ -49,14 +64,27 @@ async function cancelAllSubscriptions(customerId: string): Promise<void> {
   }
 }
 
-/** Detach all payment methods from a customer to prevent future charges. */
-async function detachAllPaymentMethods(customerId: string): Promise<void> {
+/**
+ * Detach payment methods that existed at the time of the originating fraud
+ * event. Payment methods added after `asOfUnix` are skipped — same reasoning
+ * as cancelAllSubscriptions: a replay must not reach into post-event state.
+ */
+async function detachAllPaymentMethods(
+  customerId: string,
+  asOfUnix: number,
+): Promise<void> {
   const paymentMethods = await stripe.paymentMethods.list({
     customer: customerId,
     limit: 100,
   });
 
   for (const pm of paymentMethods.data) {
+    if (pm.created > asOfUnix) {
+      console.log(
+        `[Fraud Webhook] Detach skipped for payment method ${pm.id}: created ${pm.created} > event ${asOfUnix} (post-event)`,
+      );
+      continue;
+    }
     try {
       await stripe.paymentMethods.detach(pm.id);
     } catch (err) {
@@ -176,9 +204,10 @@ async function blockFraudulentUser(
   customerId: string,
   chargeId: string | null,
   reason: string,
+  asOfUnix: number,
 ): Promise<void> {
-  await cancelAllSubscriptions(customerId);
-  await detachAllPaymentMethods(customerId);
+  await cancelAllSubscriptions(customerId, asOfUnix);
+  await detachAllPaymentMethods(customerId, asOfUnix);
   await markCustomerBlocked(customerId, reason);
   if (chargeId) {
     await reportChargeFraudulent(chargeId);
@@ -230,6 +259,7 @@ async function handleEarlyFraudWarning(
       customerId,
       chargeId,
       `early_fraud_warning:${warning.fraud_type}`,
+      warning.created,
     );
   }
 }
@@ -274,6 +304,7 @@ async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<void> {
       customerId,
       chargeId,
       `dispute_fraudulent:${dispute.id}`,
+      dispute.created,
     );
   } else {
     // Non-fraudulent dispute (unrecognized, duplicate, product issue, etc.).
@@ -282,8 +313,8 @@ async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<void> {
     // again. Stop all future charges on this card: cancel subscriptions
     // AND detach payment methods. Don't mark blocked — the customer can
     // still re-subscribe with a different card if they want to continue.
-    await cancelAllSubscriptions(customerId);
-    await detachAllPaymentMethods(customerId);
+    await cancelAllSubscriptions(customerId, dispute.created);
+    await detachAllPaymentMethods(customerId, dispute.created);
     console.log(
       `[Fraud Webhook] Cancelled subscriptions and detached payment methods for customer ${customerId} (non-fraudulent dispute ${dispute.id}, reason: ${dispute.reason})`,
     );
@@ -391,8 +422,12 @@ export async function POST(req: NextRequest) {
   }
 
   // Finalize the claim. If this write itself fails, log and continue:
-  // a duplicate Stripe retry would re-run the (now individually idempotent)
-  // handler operations, so the missed finalize is recoverable.
+  // a duplicate Stripe retry would re-run the handler operations, but the
+  // handlers filter Stripe state by the originating event's `created`
+  // timestamp (see cancelAllSubscriptions / detachAllPaymentMethods), so a
+  // replay can only act on subs/payment methods that already existed when
+  // the fraud signal arrived. Replacement subs and new cards added after
+  // the event are skipped.
   try {
     await convex.mutation(api.extraUsage.finalizeWebhookProcessing, {
       serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,

--- a/app/api/fraud/webhook/route.ts
+++ b/app/api/fraud/webhook/route.ts
@@ -266,14 +266,15 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // Atomic idempotency claim — marks the event immediately to prevent
-  // concurrent deliveries from both passing the check (TOCTOU race).
-  // Stripe operations below are idempotent, so duplicate runs are safe
-  // if the claim write succeeds but processing partially fails.
+  // Idempotency check — check only, mark after successful handling.
+  // Marking before the handler runs would cause Stripe retries to be
+  // skipped if the handler partially fails (e.g., markCustomerBlocked
+  // throws), leaving the block flow permanently incomplete.
   try {
     const result = await convex.mutation(api.extraUsage.checkAndMarkWebhook, {
       serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
       eventId: event.id,
+      checkOnly: true,
     });
 
     if (result.alreadyProcessed) {
@@ -290,18 +291,42 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // Handle events
-  switch (event.type) {
-    case "radar.early_fraud_warning.created": {
-      await handleEarlyFraudWarning(
-        event.data.object as Stripe.Radar.EarlyFraudWarning,
-      );
-      break;
+  // Handle events. If the handler throws, return 500 WITHOUT marking the
+  // event as processed so Stripe retries the delivery.
+  try {
+    switch (event.type) {
+      case "radar.early_fraud_warning.created": {
+        await handleEarlyFraudWarning(
+          event.data.object as Stripe.Radar.EarlyFraudWarning,
+        );
+        break;
+      }
+      case "charge.dispute.created": {
+        await handleDisputeCreated(event.data.object as Stripe.Dispute);
+        break;
+      }
     }
-    case "charge.dispute.created": {
-      await handleDisputeCreated(event.data.object as Stripe.Dispute);
-      break;
-    }
+  } catch (error) {
+    console.error(
+      `[Fraud Webhook] Handler failed for event ${event.id} (${event.type}):`,
+      error,
+    );
+    return NextResponse.json({ error: "Handler failed" }, { status: 500 });
+  }
+
+  // Mark as processed only after successful handling.
+  try {
+    await convex.mutation(api.extraUsage.checkAndMarkWebhook, {
+      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+      eventId: event.id,
+    });
+  } catch (error) {
+    // Log but don't fail — the event was already handled successfully.
+    // A duplicate retry would re-run idempotent Stripe operations.
+    console.error(
+      `[Fraud Webhook] Failed to mark event ${event.id} as processed:`,
+      error,
+    );
   }
 
   return NextResponse.json({ received: true });

--- a/app/api/fraud/webhook/route.ts
+++ b/app/api/fraud/webhook/route.ts
@@ -77,6 +77,55 @@ async function reportChargeFraudulent(chargeId: string): Promise<void> {
   }
 }
 
+/**
+ * Refund a charge for an early fraud warning.
+ *
+ * Uses an idempotency key derived from the EFW ID so that webhook retries
+ * (or TOCTOU duplicate deliveries) collapse onto a single refund instead
+ * of erroring with `charge_already_refunded`.
+ *
+ * Terminal failures (`charge_already_refunded`, `charge_disputed`,
+ * `charge_pending`) are logged and treated as success: there is nothing
+ * to retry. All other errors bubble so the webhook returns 500 and Stripe
+ * retries the delivery — silently swallowing transient errors here would
+ * defeat the entire point of the EFW path (refund proactively to avoid
+ * the dispute fee + ratio impact).
+ */
+async function refundChargeForEFW(
+  chargeId: string,
+  efwId: string,
+): Promise<void> {
+  try {
+    await stripe.refunds.create(
+      { charge: chargeId, reason: "fraudulent" },
+      { idempotencyKey: `efw-refund:${efwId}` },
+    );
+    console.log(
+      `[Fraud Webhook] Refunded charge ${chargeId} (early fraud warning ${efwId})`,
+    );
+  } catch (err) {
+    if (err instanceof Stripe.errors.StripeError) {
+      const code = err.code;
+      if (
+        code === "charge_already_refunded" ||
+        code === "charge_disputed" ||
+        code === "charge_pending"
+      ) {
+        console.log(
+          `[Fraud Webhook] Refund skipped for ${chargeId} (EFW ${efwId}): ${code}`,
+        );
+        return;
+      }
+    }
+    // Transient or unexpected — bubble so Stripe retries the webhook.
+    console.error(
+      `[Fraud Webhook] Refund failed for ${chargeId} (EFW ${efwId}):`,
+      err,
+    );
+    throw err;
+  }
+}
+
 /** Resolve Stripe customer ID from a charge. */
 function getCustomerIdFromCharge(charge: Stripe.Charge): string | null {
   return typeof charge.customer === "string"
@@ -146,18 +195,8 @@ async function handleEarlyFraudWarning(
   const charge = await stripe.charges.retrieve(chargeId);
   const customerId = getCustomerIdFromCharge(charge);
 
-  // Refund the charge immediately
-  try {
-    await stripe.refunds.create({
-      charge: chargeId,
-      reason: "fraudulent",
-    });
-    console.log(
-      `[Fraud Webhook] Refunded charge ${chargeId} (early fraud warning)`,
-    );
-  } catch (err) {
-    console.warn(`[Fraud Webhook] Could not refund charge ${chargeId}:`, err);
-  }
+  // Refund first. Throws on transient errors so Stripe retries the webhook.
+  await refundChargeForEFW(chargeId, warning.id);
 
   // Block the user
   if (customerId) {
@@ -266,33 +305,38 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // Idempotency check — check only, mark after successful handling.
-  // Marking before the handler runs would cause Stripe retries to be
-  // skipped if the handler partially fails (e.g., markCustomerBlocked
-  // throws), leaving the block flow permanently incomplete.
+  // Atomic claim — eliminates the TOCTOU window where two concurrent
+  // deliveries of the same event.id could both pass a read-then-write
+  // pre-check and both run side effects. claimWebhookProcessing inserts
+  // a `pending` row in a single transaction; only one caller wins.
+  // Stale `pending` claims (>10 min) are reclaimable so a crashed first
+  // attempt doesn't permanently block Stripe's retries.
+  let claimState: "acquired" | "already_processed" | "claim_held";
   try {
-    const result = await convex.mutation(api.extraUsage.checkAndMarkWebhook, {
-      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
-      eventId: event.id,
-      checkOnly: true,
-    });
-
-    if (result.alreadyProcessed) {
-      console.log(
-        `[Fraud Webhook] Event ${event.id} already processed, skipping`,
-      );
-      return NextResponse.json({ received: true });
-    }
+    const result = await convex.mutation(
+      api.extraUsage.claimWebhookProcessing,
+      {
+        serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+        eventId: event.id,
+      },
+    );
+    claimState = result.state;
   } catch (error) {
-    console.error("[Fraud Webhook] Idempotency check failed:", error);
+    console.error("[Fraud Webhook] Claim failed:", error);
     return NextResponse.json(
-      { error: "Failed to check idempotency" },
+      { error: "Failed to claim webhook" },
       { status: 500 },
     );
   }
 
-  // Handle events. If the handler throws, return 500 WITHOUT marking the
-  // event as processed so Stripe retries the delivery.
+  if (claimState !== "acquired") {
+    console.log(`[Fraud Webhook] Event ${event.id} ${claimState}, skipping`);
+    return NextResponse.json({ received: true });
+  }
+
+  // Handle events. If the handler throws, return 500 WITHOUT finalizing —
+  // the `pending` claim will become reclaimable after STALE_CLAIM_MS so a
+  // future Stripe retry can drive completion.
   try {
     switch (event.type) {
       case "radar.early_fraud_warning.created": {
@@ -314,17 +358,17 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Handler failed" }, { status: 500 });
   }
 
-  // Mark as processed only after successful handling.
+  // Finalize the claim. If this write itself fails, log and continue:
+  // a duplicate Stripe retry would re-run the (now individually idempotent)
+  // handler operations, so the missed finalize is recoverable.
   try {
-    await convex.mutation(api.extraUsage.checkAndMarkWebhook, {
+    await convex.mutation(api.extraUsage.finalizeWebhookProcessing, {
       serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
       eventId: event.id,
     });
   } catch (error) {
-    // Log but don't fail — the event was already handled successfully.
-    // A duplicate retry would re-run idempotent Stripe operations.
     console.error(
-      `[Fraud Webhook] Failed to mark event ${event.id} as processed:`,
+      `[Fraud Webhook] Failed to finalize event ${event.id}:`,
       error,
     );
   }

--- a/app/api/fraud/webhook/route.ts
+++ b/app/api/fraud/webhook/route.ts
@@ -10,6 +10,18 @@ const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 // Helpers
 // =============================================================================
 
+/**
+ * True if a Stripe error means "the resource is already in the desired
+ * end-state" — already cancelled, already detached, or no longer exists.
+ * These are safe to swallow on retry; anything else (network, rate limit,
+ * 5xx) is transient and must bubble so Stripe retries the webhook.
+ */
+function isTerminalStripeError(err: unknown): boolean {
+  return (
+    err instanceof Stripe.errors.StripeError && err.code === "resource_missing"
+  );
+}
+
 /** Cancel all active Stripe subscriptions for a customer. */
 async function cancelAllSubscriptions(customerId: string): Promise<void> {
   const subs = await stripe.subscriptions.list({
@@ -22,10 +34,17 @@ async function cancelAllSubscriptions(customerId: string): Promise<void> {
     try {
       await stripe.subscriptions.cancel(sub.id as string);
     } catch (err) {
-      console.warn(
+      if (isTerminalStripeError(err)) {
+        console.log(
+          `[Fraud Webhook] Cancel skipped for subscription ${sub.id}: resource_missing`,
+        );
+        continue;
+      }
+      console.error(
         `[Fraud Webhook] Failed to cancel subscription ${sub.id}:`,
         err,
       );
+      throw err;
     }
   }
 }
@@ -41,10 +60,17 @@ async function detachAllPaymentMethods(customerId: string): Promise<void> {
     try {
       await stripe.paymentMethods.detach(pm.id);
     } catch (err) {
-      console.warn(
+      if (isTerminalStripeError(err)) {
+        console.log(
+          `[Fraud Webhook] Detach skipped for payment method ${pm.id}: resource_missing`,
+        );
+        continue;
+      }
+      console.error(
         `[Fraud Webhook] Failed to detach payment method ${pm.id}:`,
         err,
       );
+      throw err;
     }
   }
 }

--- a/app/api/fraud/webhook/route.ts
+++ b/app/api/fraud/webhook/route.ts
@@ -1,0 +1,308 @@
+import { NextRequest, NextResponse } from "next/server";
+import { stripe } from "@/app/api/stripe";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "@/convex/_generated/api";
+import Stripe from "stripe";
+
+const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Cancel all active Stripe subscriptions for a customer. */
+async function cancelAllSubscriptions(customerId: string): Promise<void> {
+  const subs = await stripe.subscriptions.list({
+    customer: customerId,
+    status: "all",
+    limit: 100,
+  });
+
+  for (const sub of subs.data) {
+    try {
+      await stripe.subscriptions.cancel(sub.id as string);
+    } catch (err) {
+      console.warn(
+        `[Fraud Webhook] Failed to cancel subscription ${sub.id}:`,
+        err,
+      );
+    }
+  }
+}
+
+/** Detach all payment methods from a customer to prevent future charges. */
+async function detachAllPaymentMethods(customerId: string): Promise<void> {
+  const paymentMethods = await stripe.paymentMethods.list({
+    customer: customerId,
+    limit: 100,
+  });
+
+  for (const pm of paymentMethods.data) {
+    try {
+      await stripe.paymentMethods.detach(pm.id);
+    } catch (err) {
+      console.warn(
+        `[Fraud Webhook] Failed to detach payment method ${pm.id}:`,
+        err,
+      );
+    }
+  }
+}
+
+/** Mark the Stripe customer as blocked via metadata. */
+async function markCustomerBlocked(
+  customerId: string,
+  reason: string,
+): Promise<void> {
+  await stripe.customers.update(customerId, {
+    metadata: {
+      blocked: "true",
+      blocked_at: new Date().toISOString(),
+      blocked_reason: reason,
+    },
+  });
+}
+
+/** Report a charge as fraudulent — feeds Stripe Radar's ML models. */
+async function reportChargeFraudulent(chargeId: string): Promise<void> {
+  try {
+    await stripe.charges.update(chargeId, {
+      fraud_details: { user_report: "fraudulent" },
+    });
+  } catch (err) {
+    console.warn(
+      `[Fraud Webhook] Failed to report charge ${chargeId} as fraudulent:`,
+      err,
+    );
+  }
+}
+
+/** Resolve Stripe customer ID from a charge. */
+function getCustomerIdFromCharge(charge: Stripe.Charge): string | null {
+  return typeof charge.customer === "string"
+    ? charge.customer
+    : (charge.customer?.id ?? null);
+}
+
+/**
+ * Block a fraudulent user without deleting anything.
+ *
+ * - Cancel all subscriptions (stops billing)
+ * - Detach all payment methods (prevents future charges)
+ * - Mark customer as blocked (metadata flag)
+ * - Report charge as fraudulent (feeds Radar ML) — skipped when no charge
+ *
+ * The Stripe customer and WorkOS account are preserved for:
+ * - Dispute evidence (up to 120 days later)
+ * - Pattern analysis (identifying fraud rings)
+ * - Radar block list data (card fingerprints, email)
+ */
+async function blockFraudulentUser(
+  customerId: string,
+  chargeId: string | null,
+  reason: string,
+): Promise<void> {
+  await cancelAllSubscriptions(customerId);
+  await detachAllPaymentMethods(customerId);
+  await markCustomerBlocked(customerId, reason);
+  if (chargeId) {
+    await reportChargeFraudulent(chargeId);
+  }
+
+  console.log(
+    `[Fraud Webhook] Blocked customer ${customerId}: subscriptions cancelled, payment methods detached, marked as blocked (${reason})`,
+  );
+}
+
+// =============================================================================
+// Event Handlers
+// =============================================================================
+
+/**
+ * Handle radar.early_fraud_warning.created
+ *
+ * Auto-refund the charge and block the user. ~80% of early fraud warnings
+ * become full disputes if not acted on. A proactive refund avoids the $15
+ * dispute fee and doesn't count against the dispute ratio.
+ */
+async function handleEarlyFraudWarning(
+  warning: Stripe.Radar.EarlyFraudWarning,
+): Promise<void> {
+  const chargeId =
+    typeof warning.charge === "string" ? warning.charge : warning.charge?.id;
+
+  if (!chargeId) {
+    console.error(
+      "[Fraud Webhook] Early fraud warning missing charge ID:",
+      warning.id,
+    );
+    return;
+  }
+
+  console.log(
+    `[Fraud Webhook] Early fraud warning for charge ${chargeId}, reason: ${warning.fraud_type}`,
+  );
+
+  const charge = await stripe.charges.retrieve(chargeId);
+  const customerId = getCustomerIdFromCharge(charge);
+
+  // Refund the charge immediately
+  try {
+    await stripe.refunds.create({
+      charge: chargeId,
+      reason: "fraudulent",
+    });
+    console.log(
+      `[Fraud Webhook] Refunded charge ${chargeId} (early fraud warning)`,
+    );
+  } catch (err) {
+    console.warn(`[Fraud Webhook] Could not refund charge ${chargeId}:`, err);
+  }
+
+  // Block the user
+  if (customerId) {
+    await blockFraudulentUser(
+      customerId,
+      chargeId,
+      `early_fraud_warning:${warning.fraud_type}`,
+    );
+  }
+}
+
+/**
+ * Handle charge.dispute.created
+ *
+ * Fraudulent disputes: block the user (cancel subs, detach cards, flag).
+ * Non-fraudulent disputes (unrecognized, duplicate, etc.): cancel subscription
+ * only — the customer may be legitimate and confused.
+ *
+ * No refund call: when a dispute is created, Stripe automatically debits the
+ * disputed amount (plus a non-refundable dispute fee) from the merchant
+ * balance. Calling stripe.refunds.create here would error with
+ * "charge_disputed" / double-refund. The disputed funds are returned to the
+ * cardholder by their issuer, not by us.
+ */
+async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<void> {
+  const chargeId =
+    typeof dispute.charge === "string" ? dispute.charge : dispute.charge?.id;
+  const isFraudulent = dispute.reason === "fraudulent";
+
+  console.log(
+    `[Fraud Webhook] Dispute created: ${dispute.id}, reason: ${dispute.reason}, fraudulent: ${isFraudulent}, amount: $${(dispute.amount / 100).toFixed(2)}, charge: ${chargeId}`,
+  );
+
+  if (!chargeId) return;
+
+  const charge = await stripe.charges.retrieve(chargeId);
+  const customerId = getCustomerIdFromCharge(charge);
+
+  if (!customerId) {
+    console.error(
+      `[Fraud Webhook] Could not resolve customer for dispute ${dispute.id}`,
+    );
+    return;
+  }
+
+  if (isFraudulent) {
+    // Stolen card — block fully but preserve everything for evidence
+    await blockFraudulentUser(
+      customerId,
+      chargeId,
+      `dispute_fraudulent:${dispute.id}`,
+    );
+  } else {
+    // Legitimate customer confused about the charge — just stop billing
+    await cancelAllSubscriptions(customerId);
+    console.log(
+      `[Fraud Webhook] Cancelled subscriptions for customer ${customerId} (non-fraudulent dispute ${dispute.id}, reason: ${dispute.reason})`,
+    );
+  }
+}
+
+// =============================================================================
+// Webhook Endpoint
+// =============================================================================
+
+/**
+ * POST /api/fraud/webhook
+ * Handles Stripe fraud-related events: early fraud warnings and disputes.
+ *
+ * Configure in Stripe Dashboard:
+ * - Endpoint URL: https://your-domain.com/api/fraud/webhook
+ * - Events: radar.early_fraud_warning.created, charge.dispute.created
+ */
+export async function POST(req: NextRequest) {
+  const body = await req.text();
+  const signature = req.headers.get("stripe-signature");
+
+  if (!signature) {
+    console.error("[Fraud Webhook] Missing stripe-signature header");
+    return NextResponse.json(
+      { error: "Missing stripe-signature header" },
+      { status: 400 },
+    );
+  }
+
+  const webhookSecret = process.env.STRIPE_FRAUD_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    console.error(
+      "[Fraud Webhook] STRIPE_FRAUD_WEBHOOK_SECRET is not configured",
+    );
+    return NextResponse.json(
+      { error: "Webhook secret not configured" },
+      { status: 500 },
+    );
+  }
+
+  let event: Stripe.Event;
+
+  try {
+    event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
+  } catch (err) {
+    console.error("[Fraud Webhook] Signature verification failed:", err);
+    return NextResponse.json(
+      { error: "Webhook signature verification failed" },
+      { status: 400 },
+    );
+  }
+
+  // Atomic idempotency claim — marks the event immediately to prevent
+  // concurrent deliveries from both passing the check (TOCTOU race).
+  // Stripe operations below are idempotent, so duplicate runs are safe
+  // if the claim write succeeds but processing partially fails.
+  try {
+    const result = await convex.mutation(api.extraUsage.checkAndMarkWebhook, {
+      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+      eventId: event.id,
+    });
+
+    if (result.alreadyProcessed) {
+      console.log(
+        `[Fraud Webhook] Event ${event.id} already processed, skipping`,
+      );
+      return NextResponse.json({ received: true });
+    }
+  } catch (error) {
+    console.error("[Fraud Webhook] Idempotency check failed:", error);
+    return NextResponse.json(
+      { error: "Failed to check idempotency" },
+      { status: 500 },
+    );
+  }
+
+  // Handle events
+  switch (event.type) {
+    case "radar.early_fraud_warning.created": {
+      await handleEarlyFraudWarning(
+        event.data.object as Stripe.Radar.EarlyFraudWarning,
+      );
+      break;
+    }
+    case "charge.dispute.created": {
+      await handleDisputeCreated(event.data.object as Stripe.Dispute);
+      break;
+    }
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/app/api/fraud/webhook/route.ts
+++ b/app/api/fraud/webhook/route.ts
@@ -250,10 +250,16 @@ async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<void> {
       `dispute_fraudulent:${dispute.id}`,
     );
   } else {
-    // Legitimate customer confused about the charge — just stop billing
+    // Non-fraudulent dispute (unrecognized, duplicate, product issue, etc.).
+    // The customer may be legitimate but a chargeback still costs us the
+    // dispute fee + ratio impact, and the disputed card is likely to file
+    // again. Stop all future charges on this card: cancel subscriptions
+    // AND detach payment methods. Don't mark blocked — the customer can
+    // still re-subscribe with a different card if they want to continue.
     await cancelAllSubscriptions(customerId);
+    await detachAllPaymentMethods(customerId);
     console.log(
-      `[Fraud Webhook] Cancelled subscriptions for customer ${customerId} (non-fraudulent dispute ${dispute.id}, reason: ${dispute.reason})`,
+      `[Fraud Webhook] Cancelled subscriptions and detached payment methods for customer ${customerId} (non-fraudulent dispute ${dispute.id}, reason: ${dispute.reason})`,
     );
   }
 }

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -2,6 +2,7 @@ import { stripe } from "../stripe";
 import { workos } from "../workos";
 import { getUserID } from "@/lib/auth/get-user-id";
 import { NextRequest, NextResponse } from "next/server";
+import { getSuspensionMessage } from "@/lib/suspensionMessage";
 
 export const POST = async (req: NextRequest) => {
   try {
@@ -116,6 +117,18 @@ export const POST = async (req: NextRequest) => {
     );
 
     if (matchingCustomer) {
+      // Reject blocked customers (flagged by fraud webhook)
+      if (matchingCustomer.metadata.blocked === "true") {
+        return NextResponse.json(
+          {
+            error: getSuspensionMessage(
+              matchingCustomer.metadata.blocked_reason,
+            ),
+          },
+          { status: 403 },
+        );
+      }
+
       customer = matchingCustomer;
     }
 

--- a/app/api/subscription-details/route.ts
+++ b/app/api/subscription-details/route.ts
@@ -3,6 +3,7 @@ import { workos } from "../workos";
 import { getUserID } from "@/lib/auth/get-user-id";
 import { NextRequest, NextResponse } from "next/server";
 import { SubscriptionTier } from "@/types/chat";
+import { getSuspensionMessage } from "@/lib/suspensionMessage";
 
 export const POST = async (req: NextRequest) => {
   try {
@@ -46,6 +47,16 @@ export const POST = async (req: NextRequest) => {
       return NextResponse.json(
         { error: "No Stripe customer found" },
         { status: 404 },
+      );
+    }
+
+    // Reject blocked customers (flagged by fraud webhook)
+    if (matchingCustomer.metadata.blocked === "true") {
+      return NextResponse.json(
+        {
+          error: getSuspensionMessage(matchingCustomer.metadata.blocked_reason),
+        },
+        { status: 403 },
       );
     }
 

--- a/convex/__tests__/webhookClaim.test.ts
+++ b/convex/__tests__/webhookClaim.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+jest.mock("../_generated/server", () => ({
+  mutation: jest.fn((config: any) => config),
+  internalMutation: jest.fn((config: any) => config),
+  query: jest.fn((config: any) => config),
+  internalQuery: jest.fn((config: any) => config),
+}));
+jest.mock("convex/values", () => ({
+  v: {
+    id: jest.fn(() => "id"),
+    null: jest.fn(() => "null"),
+    string: jest.fn(() => "string"),
+    number: jest.fn(() => "number"),
+    optional: jest.fn(() => "optional"),
+    object: jest.fn(() => "object"),
+    union: jest.fn(() => "union"),
+    array: jest.fn(() => "array"),
+    boolean: jest.fn(() => "boolean"),
+    literal: jest.fn(() => "literal"),
+    any: jest.fn(() => "any"),
+  },
+  ConvexError: class ConvexError extends Error {
+    data: any;
+    constructor(data: any) {
+      super(typeof data === "string" ? data : data.message);
+      this.data = data;
+      this.name = "ConvexError";
+    }
+  },
+}));
+jest.mock("../lib/utils", () => ({
+  validateServiceKey: jest.fn(),
+}));
+jest.mock("../lib/logger", () => ({
+  convexLogger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const SERVICE_KEY = "test-service-key";
+process.env.CONVEX_SERVICE_ROLE_KEY = SERVICE_KEY;
+
+const STALE_CLAIM_MS = 10 * 60 * 1000;
+const EVENT_ID = "evt_test_123";
+
+type Row = {
+  _id: string;
+  event_id: string;
+  processed_at: number;
+  status?: "pending" | "completed";
+  claimed_at?: number;
+};
+
+function makeMockCtx(initialRows: Row[] = []) {
+  const rows = [...initialRows];
+
+  const queryChain = (eventId: string) => ({
+    first: async () => rows.find((r) => r.event_id === eventId) ?? null,
+  });
+
+  const ctx: any = {
+    db: {
+      query: jest.fn(() => ({
+        withIndex: jest.fn((_indexName: string, predicate: any) => {
+          let captured: string | null = null;
+          predicate({
+            eq: (_field: string, value: string) => {
+              captured = value;
+              return {};
+            },
+          });
+          return queryChain(captured ?? "");
+        }),
+      })),
+      insert: jest.fn(async (_table: string, doc: Omit<Row, "_id">) => {
+        const newRow: Row = { _id: `id-${rows.length + 1}`, ...doc };
+        rows.push(newRow);
+        return newRow._id;
+      }),
+      patch: jest.fn(async (id: string, patch: Partial<Row>) => {
+        const row = rows.find((r) => r._id === id);
+        if (!row) throw new Error(`row ${id} not found`);
+        Object.assign(row, patch);
+      }),
+    },
+  };
+
+  return { ctx, rows };
+}
+
+async function callClaim(ctx: any) {
+  const { claimWebhookProcessing } = await import("../extraUsage");
+  return (claimWebhookProcessing as any).handler(ctx, {
+    serviceKey: SERVICE_KEY,
+    eventId: EVENT_ID,
+  });
+}
+
+async function callFinalize(ctx: any) {
+  const { finalizeWebhookProcessing } = await import("../extraUsage");
+  return (finalizeWebhookProcessing as any).handler(ctx, {
+    serviceKey: SERVICE_KEY,
+    eventId: EVENT_ID,
+  });
+}
+
+describe("claimWebhookProcessing", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, "now").mockReturnValue(1_000_000);
+  });
+
+  it("inserts a pending row and acquires the claim when no row exists", async () => {
+    const { ctx, rows } = makeMockCtx();
+
+    const result = await callClaim(ctx);
+
+    expect(result).toEqual({ state: "acquired" });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      event_id: EVENT_ID,
+      status: "pending",
+      claimed_at: 1_000_000,
+      processed_at: 1_000_000,
+    });
+  });
+
+  it("returns already_processed when the row is completed", async () => {
+    const { ctx, rows } = makeMockCtx([
+      {
+        _id: "id-1",
+        event_id: EVENT_ID,
+        processed_at: 500,
+        status: "completed",
+      },
+    ]);
+
+    const result = await callClaim(ctx);
+
+    expect(result).toEqual({ state: "already_processed" });
+    expect(rows).toHaveLength(1);
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it("treats legacy rows without status as completed (back-compat)", async () => {
+    const { ctx } = makeMockCtx([
+      { _id: "id-1", event_id: EVENT_ID, processed_at: 500 },
+    ]);
+
+    const result = await callClaim(ctx);
+
+    expect(result).toEqual({ state: "already_processed" });
+  });
+
+  it("returns claim_held when a recent pending claim exists", async () => {
+    const recentClaimAt = 1_000_000 - 30_000;
+    const { ctx, rows } = makeMockCtx([
+      {
+        _id: "id-1",
+        event_id: EVENT_ID,
+        processed_at: recentClaimAt,
+        status: "pending",
+        claimed_at: recentClaimAt,
+      },
+    ]);
+
+    const result = await callClaim(ctx);
+
+    expect(result).toEqual({ state: "claim_held" });
+    expect(rows[0].claimed_at).toBe(recentClaimAt);
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it("takes over a stale pending claim and re-acquires it", async () => {
+    const staleClaimAt = 1_000_000 - STALE_CLAIM_MS - 1;
+    const { ctx, rows } = makeMockCtx([
+      {
+        _id: "id-1",
+        event_id: EVENT_ID,
+        processed_at: staleClaimAt,
+        status: "pending",
+        claimed_at: staleClaimAt,
+      },
+    ]);
+
+    const result = await callClaim(ctx);
+
+    expect(result).toEqual({ state: "acquired" });
+    expect(ctx.db.patch).toHaveBeenCalledWith("id-1", {
+      status: "pending",
+      claimed_at: 1_000_000,
+    });
+    expect(rows[0].claimed_at).toBe(1_000_000);
+  });
+
+  it("reclaims a pending claim exactly at the stale boundary", async () => {
+    const boundaryClaimAt = 1_000_000 - STALE_CLAIM_MS;
+    const { ctx } = makeMockCtx([
+      {
+        _id: "id-1",
+        event_id: EVENT_ID,
+        processed_at: boundaryClaimAt,
+        status: "pending",
+        claimed_at: boundaryClaimAt,
+      },
+    ]);
+
+    const result = await callClaim(ctx);
+
+    // `now - claimedAt < STALE_CLAIM_MS` is false at equality → reclaimable.
+    expect(result).toEqual({ state: "acquired" });
+  });
+
+  it("treats a pending claim 1ms before the stale boundary as still held", async () => {
+    const justBeforeBoundary = 1_000_000 - (STALE_CLAIM_MS - 1);
+    const { ctx } = makeMockCtx([
+      {
+        _id: "id-1",
+        event_id: EVENT_ID,
+        processed_at: justBeforeBoundary,
+        status: "pending",
+        claimed_at: justBeforeBoundary,
+      },
+    ]);
+
+    const result = await callClaim(ctx);
+
+    expect(result).toEqual({ state: "claim_held" });
+  });
+
+  it("falls back to processed_at when claimed_at is missing on a pending row", async () => {
+    const oldProcessedAt = 1_000_000 - STALE_CLAIM_MS - 1_000;
+    const { ctx } = makeMockCtx([
+      {
+        _id: "id-1",
+        event_id: EVENT_ID,
+        processed_at: oldProcessedAt,
+        status: "pending",
+      },
+    ]);
+
+    const result = await callClaim(ctx);
+
+    expect(result).toEqual({ state: "acquired" });
+  });
+});
+
+describe("finalizeWebhookProcessing", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, "now").mockReturnValue(2_000_000);
+  });
+
+  it("transitions a pending row to completed", async () => {
+    const { ctx, rows } = makeMockCtx([
+      {
+        _id: "id-1",
+        event_id: EVENT_ID,
+        processed_at: 1_000_000,
+        status: "pending",
+        claimed_at: 1_000_000,
+      },
+    ]);
+
+    const result = await callFinalize(ctx);
+
+    expect(result).toBeNull();
+    expect(rows[0]).toMatchObject({
+      status: "completed",
+      processed_at: 2_000_000,
+    });
+  });
+
+  it("is idempotent — re-finalizing a completed row stays completed", async () => {
+    const { ctx, rows } = makeMockCtx([
+      {
+        _id: "id-1",
+        event_id: EVENT_ID,
+        processed_at: 1_500_000,
+        status: "completed",
+      },
+    ]);
+
+    await callFinalize(ctx);
+
+    expect(rows[0].status).toBe("completed");
+    expect(rows[0].processed_at).toBe(2_000_000);
+  });
+
+  it("is a no-op when the row is missing (defensive)", async () => {
+    const { ctx } = makeMockCtx();
+
+    const result = await callFinalize(ctx);
+
+    expect(result).toBeNull();
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+});

--- a/convex/__tests__/webhookClaim.test.ts
+++ b/convex/__tests__/webhookClaim.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
 
 jest.mock("../_generated/server", () => ({
   mutation: jest.fn((config: any) => config),
@@ -59,6 +66,16 @@ function makeMockCtx(initialRows: Row[] = []) {
 
   const queryChain = (eventId: string) => ({
     first: async () => rows.find((r) => r.event_id === eventId) ?? null,
+    unique: async () => {
+      const matches = rows.filter((r) => r.event_id === eventId);
+      if (matches.length === 0) return null;
+      if (matches.length > 1) {
+        throw new Error(
+          `Expected exactly one row for event_id=${eventId}, found ${matches.length}`,
+        );
+      }
+      return matches[0];
+    },
   });
 
   const ctx: any = {
@@ -111,6 +128,10 @@ describe("claimWebhookProcessing", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(Date, "now").mockReturnValue(1_000_000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("inserts a pending row and acquires the claim when no row exists", async () => {
@@ -252,6 +273,10 @@ describe("finalizeWebhookProcessing", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(Date, "now").mockReturnValue(2_000_000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("transitions a pending row to completed", async () => {

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -152,10 +152,124 @@ export const checkAndMarkWebhook = mutation({
       await ctx.db.insert("processed_webhooks", {
         event_id: args.eventId,
         processed_at: Date.now(),
+        status: "completed",
       });
     }
 
     return { alreadyProcessed: false };
+  },
+});
+
+/**
+ * How long a `pending` claim is honored before it can be taken over by a
+ * retrying delivery. Sized larger than any reasonable handler runtime so a
+ * still-running first attempt is not pre-empted, but small enough that a
+ * crashed first attempt unblocks the next Stripe webhook retry within the
+ * same retry window (Stripe backs off exponentially over hours).
+ */
+const STALE_CLAIM_MS = 10 * 60 * 1000;
+
+/**
+ * Atomic claim for webhook processing.
+ *
+ * Replaces the read-then-write `checkAndMarkWebhook(checkOnly: true)` pattern,
+ * which was a TOCTOU pair: two concurrent deliveries of the same event could
+ * both pass the pre-check and both run side effects before either landed the
+ * mark.
+ *
+ * Returns one of three states atomically:
+ *   - "acquired"          : caller now owns the claim; run handler then call
+ *                           finalizeWebhookProcessing on success
+ *   - "already_processed" : event was finalized previously; skip with 200
+ *   - "claim_held"        : another worker is currently processing this event;
+ *                           skip with 200 (the holder will finalize, or its
+ *                           claim will expire and a future retry takes over)
+ *
+ * If a `pending` row's claim is older than STALE_CLAIM_MS, this mutation
+ * reclaims it and returns "acquired" — this is what allows Stripe webhook
+ * retries to recover after a handler crash.
+ */
+export const claimWebhookProcessing = mutation({
+  args: {
+    serviceKey: v.string(),
+    eventId: v.string(),
+  },
+  returns: v.object({
+    state: v.union(
+      v.literal("acquired"),
+      v.literal("already_processed"),
+      v.literal("claim_held"),
+    ),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("processed_webhooks")
+      .withIndex("by_event_id", (q) => q.eq("event_id", args.eventId))
+      .first();
+
+    if (!existing) {
+      await ctx.db.insert("processed_webhooks", {
+        event_id: args.eventId,
+        processed_at: now,
+        status: "pending",
+        claimed_at: now,
+      });
+      return { state: "acquired" as const };
+    }
+
+    // Legacy rows without status were inserted under the older "mark on entry"
+    // semantics for events whose lifecycle has already concluded.
+    const status = existing.status ?? "completed";
+
+    if (status === "completed") {
+      return { state: "already_processed" as const };
+    }
+
+    const claimedAt = existing.claimed_at ?? existing.processed_at;
+    if (now - claimedAt < STALE_CLAIM_MS) {
+      return { state: "claim_held" as const };
+    }
+
+    // Stale claim — take it over so Stripe's retry can drive completion.
+    await ctx.db.patch(existing._id, {
+      status: "pending",
+      claimed_at: now,
+    });
+    return { state: "acquired" as const };
+  },
+});
+
+/**
+ * Mark a previously-claimed webhook as completed.
+ *
+ * Idempotent: re-finalizing an already-completed event is a no-op. Missing
+ * rows are also tolerated (the row should always exist when called immediately
+ * after a successful claim, but we don't fail the request if it doesn't).
+ */
+export const finalizeWebhookProcessing = mutation({
+  args: {
+    serviceKey: v.string(),
+    eventId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const existing = await ctx.db
+      .query("processed_webhooks")
+      .withIndex("by_event_id", (q) => q.eq("event_id", args.eventId))
+      .first();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        status: "completed",
+        processed_at: Date.now(),
+      });
+    }
+    return null;
   },
 });
 

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -139,10 +139,12 @@ export const checkAndMarkWebhook = mutation({
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
 
+    // .unique() throws if duplicates exist, surfacing any state-machine
+    // invariant break instead of silently masking it.
     const existing = await ctx.db
       .query("processed_webhooks")
       .withIndex("by_event_id", (q) => q.eq("event_id", args.eventId))
-      .first();
+      .unique();
 
     if (existing) {
       return { alreadyProcessed: true };
@@ -205,10 +207,12 @@ export const claimWebhookProcessing = mutation({
     validateServiceKey(args.serviceKey);
 
     const now = Date.now();
+    // .unique() throws if duplicates exist, surfacing any state-machine
+    // invariant break instead of silently masking it.
     const existing = await ctx.db
       .query("processed_webhooks")
       .withIndex("by_event_id", (q) => q.eq("event_id", args.eventId))
-      .first();
+      .unique();
 
     if (!existing) {
       await ctx.db.insert("processed_webhooks", {
@@ -258,10 +262,12 @@ export const finalizeWebhookProcessing = mutation({
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
 
+    // .unique() throws if duplicates exist, surfacing any state-machine
+    // invariant break instead of silently masking it.
     const existing = await ctx.db
       .query("processed_webhooks")
       .withIndex("by_event_id", (q) => q.eq("event_id", args.eventId))
-      .first();
+      .unique();
 
     if (existing) {
       await ctx.db.patch(existing._id, {

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -541,57 +541,68 @@ export const deductWithAutoReload = action({
         autoReloadResult = { success: false, reason: "no_stripe_customer" };
       } else {
         try {
-          // Get default payment method
-          const paymentMethodId =
-            await getDefaultPaymentMethodId(stripeCustomerId);
-          if (!paymentMethodId) {
-            autoReloadResult = {
-              success: false,
-              reason: "no_default_payment_method",
-            };
-          } else {
-            // Calculate how much to charge to reach target balance
-            // reloadAmount is the TARGET balance, not the amount to add
-            const currentBalanceDollars = settings.balanceDollars;
-            const targetBalanceDollars = reloadAmount;
-            const amountToCharge = Math.max(
-              0,
-              targetBalanceDollars - currentBalanceDollars,
-            );
+          // Check if customer is blocked (fraud flagged) before attempting charge
+          const customerObj =
+            await getStripe().customers.retrieve(stripeCustomerId);
+          const isBlocked =
+            !customerObj.deleted &&
+            (customerObj as Stripe.Customer).metadata?.blocked === "true";
 
-            // Minimum charge of $1 to avoid tiny transactions
-            const MIN_CHARGE_DOLLARS = 1;
-            if (amountToCharge < MIN_CHARGE_DOLLARS) {
+          if (isBlocked) {
+            autoReloadResult = { success: false, reason: "customer_blocked" };
+          } else {
+            // Get default payment method
+            const paymentMethodId =
+              await getDefaultPaymentMethodId(stripeCustomerId);
+            if (!paymentMethodId) {
               autoReloadResult = {
                 success: false,
-                reason: "amount_to_charge_below_minimum",
+                reason: "no_default_payment_method",
               };
             } else {
-              // Create payment (Stripe uses cents)
-              const amountToChargeCents = Math.round(amountToCharge * 100);
-              const paymentResult = await createAutoReloadPayment(
-                stripeCustomerId,
-                paymentMethodId,
-                amountToChargeCents,
-                args.userId,
+              // Calculate how much to charge to reach target balance
+              // reloadAmount is the TARGET balance, not the amount to add
+              const currentBalanceDollars = settings.balanceDollars;
+              const targetBalanceDollars = reloadAmount;
+              const amountToCharge = Math.max(
+                0,
+                targetBalanceDollars - currentBalanceDollars,
               );
 
-              if (paymentResult.success) {
-                // Add credits (dollars -> points conversion happens in mutation)
-                await ctx.runMutation(api.extraUsage.addCredits, {
-                  serviceKey: args.serviceKey,
-                  userId: args.userId,
-                  amountDollars: amountToCharge,
-                });
-                autoReloadResult = {
-                  success: true,
-                  chargedAmountDollars: amountToCharge,
-                };
-              } else {
+              // Minimum charge of $1 to avoid tiny transactions
+              const MIN_CHARGE_DOLLARS = 1;
+              if (amountToCharge < MIN_CHARGE_DOLLARS) {
                 autoReloadResult = {
                   success: false,
-                  reason: paymentResult.error || "payment_failed",
+                  reason: "amount_to_charge_below_minimum",
                 };
+              } else {
+                // Create payment (Stripe uses cents)
+                const amountToChargeCents = Math.round(amountToCharge * 100);
+                const paymentResult = await createAutoReloadPayment(
+                  stripeCustomerId,
+                  paymentMethodId,
+                  amountToChargeCents,
+                  args.userId,
+                );
+
+                if (paymentResult.success) {
+                  // Add credits (dollars -> points conversion happens in mutation)
+                  await ctx.runMutation(api.extraUsage.addCredits, {
+                    serviceKey: args.serviceKey,
+                    userId: args.userId,
+                    amountDollars: amountToCharge,
+                  });
+                  autoReloadResult = {
+                    success: true,
+                    chargedAmountDollars: amountToCharge,
+                  };
+                } else {
+                  autoReloadResult = {
+                    success: false,
+                    reason: paymentResult.error || "payment_failed",
+                  };
+                }
               }
             }
           }
@@ -607,12 +618,14 @@ export const deductWithAutoReload = action({
     // Record outcome of auto-reload attempt for failure tracking / auto-disable.
     // Only count *real charge outcomes*: a successful charge, or a charge that
     // was actually attempted and declined by Stripe. Pre-charge configuration
-    // / lookup problems (no_stripe_customer, no_default_payment_method,
-    // stripe_lookup_failed, amount_to_charge_below_minimum) must NOT increment
-    // the consecutive failure counter — they aren't card declines and shouldn't
-    // auto-disable auto-reload.
+    // / lookup problems (no_stripe_customer, customer_blocked,
+    // no_default_payment_method, stripe_lookup_failed,
+    // amount_to_charge_below_minimum) must NOT increment the consecutive
+    // failure counter — they aren't card declines and shouldn't auto-disable
+    // auto-reload.
     const PRE_CHARGE_REASONS = new Set([
       "no_stripe_customer",
+      "customer_blocked",
       "no_default_payment_method",
       "stripe_lookup_failed",
       "amount_to_charge_below_minimum",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -253,5 +253,11 @@ export default defineSchema({
   processed_webhooks: defineTable({
     event_id: v.string(),
     processed_at: v.number(),
+    // State-machine fields for atomic claim/finalize. Optional for
+    // backwards compatibility — legacy rows (no status) are treated as
+    // completed since they were inserted under the old "mark on entry"
+    // semantics for events whose lifecycle has already concluded.
+    status: v.optional(v.union(v.literal("pending"), v.literal("completed"))),
+    claimed_at: v.optional(v.number()),
   }).index("by_event_id", ["event_id"]),
 });

--- a/lib/__tests__/suspensionMessage.test.ts
+++ b/lib/__tests__/suspensionMessage.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "@jest/globals";
+import { getSuspensionMessage } from "../suspensionMessage";
+
+const SUPPORT_URL = "https://help.hackerai.co/";
+
+describe("getSuspensionMessage", () => {
+  it("uses the EFW label for early_fraud_warning reasons", () => {
+    const msg = getSuspensionMessage("early_fraud_warning:fraudulent");
+    expect(msg).toContain("a fraud warning from your card issuer");
+    expect(msg).toContain(SUPPORT_URL);
+  });
+
+  it("uses the dispute label for dispute_fraudulent reasons", () => {
+    const msg = getSuspensionMessage("dispute_fraudulent:dp_123");
+    expect(msg).toContain("a fraudulent payment dispute (chargeback)");
+    expect(msg).toContain(SUPPORT_URL);
+  });
+
+  it("falls back to the generic label when the reason is missing", () => {
+    expect(getSuspensionMessage(undefined)).toContain("suspicious activity");
+    expect(getSuspensionMessage(null)).toContain("suspicious activity");
+    expect(getSuspensionMessage("")).toContain("suspicious activity");
+  });
+
+  it("falls back to the generic label for unknown categories", () => {
+    expect(getSuspensionMessage("card_testing_detected:foo")).toContain(
+      "suspicious activity",
+    );
+    expect(getSuspensionMessage("immediate_block:stolen_card")).toContain(
+      "suspicious activity",
+    );
+    expect(getSuspensionMessage("totally_unknown")).toContain(
+      "suspicious activity",
+    );
+  });
+
+  it("does not leak detection internals after the colon", () => {
+    const msg = getSuspensionMessage("early_fraud_warning:fraudulent");
+    expect(msg).not.toContain("fraudulent");
+    expect(msg).not.toContain("early_fraud_warning");
+  });
+});

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/types";
 import { createRedisClient, formatTimeRemaining } from "./redis";
 import { deductFromBalance, refundToBalance } from "@/lib/extra-usage";
+import { getSuspensionMessage } from "@/lib/suspensionMessage";
 
 // =============================================================================
 // Configuration
@@ -281,7 +282,13 @@ export const checkTokenBucketLimit = async (
           ) {
             const reason =
               deductResult.autoReloadResult.reason ?? "payment_failed";
-            const msg = `Auto-reload couldn't charge your card (${reason}). Update your payment method in Settings, then try again.`;
+            // Suspended customers (flagged by the fraud webhook) short-circuit
+            // before any charge attempt. Render the suspension message instead
+            // of the "update your payment method" copy — they can't fix it.
+            const msg =
+              reason === "customer_blocked"
+                ? getSuspensionMessage(null)
+                : `Auto-reload couldn't charge your card (${reason}). Update your payment method in Settings, then try again.`;
             throw new ChatSDKError("rate_limit:chat", msg, {
               resetTimestamp: monthlyCheck.reset,
               subscription,

--- a/lib/suspensionMessage.ts
+++ b/lib/suspensionMessage.ts
@@ -1,0 +1,30 @@
+/**
+ * Build a user-facing suspension message from a Stripe customer's
+ * `blocked_reason` metadata (set by the fraud webhook).
+ *
+ * The raw reason categories come from app/api/fraud/webhook/route.ts:
+ *   - early_fraud_warning:<fraud_type>
+ *   - dispute_fraudulent:<dispute_id>
+ *
+ * Specific fraud signals are intentionally not exposed to avoid tipping
+ * off bad actors about how detection works.
+ */
+export function getSuspensionMessage(blockedReason?: string | null): string {
+  const reasonLabel = mapBlockedReasonToLabel(blockedReason);
+  return `Your account has been suspended due to ${reasonLabel}. Please contact support via chat at https://help.hackerai.co/ if you believe this is a mistake.`;
+}
+
+function mapBlockedReasonToLabel(blockedReason?: string | null): string {
+  if (!blockedReason) return "suspicious activity";
+
+  const category = blockedReason.split(":")[0];
+
+  switch (category) {
+    case "early_fraud_warning":
+      return "a fraud warning from your card issuer";
+    case "dispute_fraudulent":
+      return "a fraudulent payment dispute (chargeback)";
+    default:
+      return "suspicious activity";
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,6 +10,7 @@ const UNAUTHENTICATED_PATHS = new Set([
   "/api/clear-auth-cookies",
   "/api/auth/desktop-callback",
   "/api/extra-usage/webhook",
+  "/api/fraud/webhook",
   "/api/subscription/webhook",
   "/callback",
   "/desktop-login",


### PR DESCRIPTION
## Summary

Partial revert of #383 (a3103207). Brings back only the **dispute** and **early-fraud-warning** paths; the card-testing detector and its Convex `payment_failure_tracking` table stay deleted.

- Recreate `/api/fraud/webhook` with handlers for `radar.early_fraud_warning.created` and `charge.dispute.created`. EFW path refunds the charge proactively (~80% of EFWs become disputes if not acted on, plus avoids the $15 dispute fee and ratio impact). Dispute path deliberately does **not** refund — Stripe auto-debits the disputed amount, and `refunds.create` on a disputed charge would 400 with `charge_disputed`. The asymmetry is documented inline.
- Re-enforce `metadata.blocked === "true"` in `app/api/subscribe`, `app/api/subscription-details`, and `convex/extraUsageActions.ts` auto-reload — so a flagged customer can't re-subscribe with a new card. `customer_blocked` is back in `PRE_CHARGE_REASONS` so it doesn't trip the consecutive-failure auto-disable.
- Restore `lib/suspensionMessage.ts` trimmed to the two reason categories the current webhook produces (`early_fraud_warning`, `dispute_fraudulent`); unknown reasons fall through to a generic label, which both handles legacy customer metadata and avoids leaking detection internals.
- Add unit tests for `suspensionMessage` covering label mapping and the no-leak invariant.
- Re-add `/api/fraud/webhook` to the middleware allowlist and `STRIPE_FRAUD_WEBHOOK_SECRET` to `.env.local.example`.

## Deliberately not restored

- `payment_intent.payment_failed` handling and the multi-signal card-testing detector (3DS bypass detection, decline-code scoring, fingerprint diversity, account-age weighting).
- `convex/fraudTracking.ts` and the `payment_failure_tracking` schema.
- The `convex/__tests__/fraudTracking.test.ts` suite (738 lines) — it only covered the deleted Convex logic, not the webhook handlers.
- `isCustomerSuspicious` pre-check call sites in subscribe / subscription-details.

## External setup required

- **Stripe Dashboard**: create a webhook endpoint at `https://<domain>/api/fraud/webhook` listening to exactly `radar.early_fraud_warning.created` and `charge.dispute.created`. Copy the signing secret.
- **Env**: set `STRIPE_FRAUD_WEBHOOK_SECRET` in local `.env.local`, Vercel production, and Vercel preview.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 801 tests pass (5 new tests in `lib/__tests__/suspensionMessage.test.ts`)
- [x] `pnpm lint` — 0 errors on touched files
- [ ] In Stripe test mode, trigger `radar.early_fraud_warning.created` via CLI; verify charge is refunded, subscriptions cancelled, payment methods detached, customer metadata `blocked=true`, and charge marked fraudulent
- [ ] In Stripe test mode, trigger `charge.dispute.created` with `reason=fraudulent`; verify same block actions but **no** refund call (would error)
- [ ] In Stripe test mode, trigger `charge.dispute.created` with `reason=unrecognized`; verify subscriptions cancelled but customer not blocked
- [ ] After a customer has `metadata.blocked=true`, hit `/api/subscribe`, `/api/subscription-details`, and trigger an auto-reload — all three should reject with the suspension message / `customer_blocked` reason
- [ ] Verify `customer_blocked` does not increment the consecutive-failure counter on auto-reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fraud webhook to process Stripe events and block affected accounts.
  * Added user-facing suspension messages for blocked customers.

* **Behavior Changes**
  * Blocked customers are prevented from creating subscriptions and from auto-reload charges; suspension messaging surfaced in relevant flows.

* **Tests**
  * Added tests for suspension message mapping and webhook claim/finalization behavior.

* **Chores**
  * Added environment variable entry for the fraud webhook secret.

* **Middleware**
  * Whitelisted the fraud webhook path as unauthenticated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->