### PR TITLE
fix(convex): retain legacy byok field on usage_logs schema

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -241,6 +241,10 @@ export default defineSchema({
     cost_dollars: v.number(),
     // True when Max mode was active for this request (larger context window).
     max_mode: v.optional(v.boolean()),
+    // Legacy BYOK flag retained on historical rows. The feature was removed
+    // and nothing reads or writes this anymore — kept in the schema so old
+    // rows still pass validation.
+    byok: v.optional(v.boolean()),
   })
     .index("by_user", ["user_id"])
     .index("by_user_and_model", ["user_id", "model"]),


### PR DESCRIPTION
## Summary
- Re-adds `byok: v.optional(v.boolean())` to the `usage_logs` table only.
- The BYOK feature was fully removed in #409, but historical rows on `usage_logs` still carry `byok: true/false`. The cleanup migration (`clearByokFromUsageLogs`) didn't drain the table because the cursor wasn't advanced on follow-up runs, so the deploy now fails schema validation.
- `user_customization.byok_enabled` was successfully drained by `clearByokEnabledFlag` (small table, single batch covered every row), so that field stays out of the schema.

## Why not drain and remove?
`usage_logs` is large and append-only; running the migration to completion would be operationally messy. Nothing in the application reads or writes `byok` anymore — keeping it as an optional schema field permanently is one line, zero risk, and unblocks deploys immediately.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` — 812 passed
- [ ] Vercel deploy reaches the Convex push step without schema validation error
- [ ] Existing `usage_logs` rows with `byok` set load fine in the usage dashboard (no UI references `byok` anymore, so it's just dead bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for new optional tracking attributes in usage logs to enable enhanced data collection
  * Improved backward compatibility to ensure existing historical data records remain valid and accessible without requiring migration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->