### PR TITLE
fix(caido): defer proxy setup to first proxy-tool call on local sandboxes

### DIFF
--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -44,13 +44,13 @@ export const createRunTerminalCmd = (context: ToolContext) => {
   const userGuardrailConfig = parseGuardrailConfig(guardrailsConfig);
   const effectiveGuardrails = getEffectiveGuardrails(userGuardrailConfig);
 
-  // Caido proxy env vars — injected into every command on non-E2B sandboxes when enabled.
-  // Permanently disabled on first setup failure (e.g. Windows sandbox) to avoid
-  // retrying and logging warnings on every subsequent command.
+  // Caido proxy is set up eagerly only on E2B sandboxes (controlled image where
+  // capturing all agent HTTP traffic is the point). On local sandboxes the proxy
+  // is lazy: it spins up only when the agent reaches for a proxy tool, so plain
+  // terminal commands don't pay the install/start cost or route through Caido.
+  // Permanently disabled on first setup failure to avoid retrying every command.
   const caidoConfig = getCaidoConfig(caidoPort);
-  let caidoEnvVars = caidoEnabled
-    ? buildCaidoProxyEnvVars(caidoConfig)
-    : undefined;
+  let caidoSetupDisabled = false;
 
   return tool({
     description: `Execute a command on behalf of the user.
@@ -256,17 +256,24 @@ If you are generating files:
 
         async function executeCommand(sandboxInstance: typeof sandbox) {
           // Ensure Caido proxy is running + authenticated before commands route through it.
+          // Only eager on E2B; local sandboxes defer setup to proxy tool invocations.
           // This is a no-op after the first successful call (cached per session).
           // If setup fails, permanently disable proxy env vars for all future commands.
-          if (caidoEnvVars) {
+          let caidoEnvVars: Record<string, string> | undefined;
+          if (
+            caidoEnabled &&
+            isE2BSandbox(sandboxInstance) &&
+            !caidoSetupDisabled
+          ) {
             try {
               await ensureCaido(context);
+              caidoEnvVars = buildCaidoProxyEnvVars(caidoConfig);
             } catch (e) {
               console.warn(
                 "[Terminal Command] Caido setup failed, disabling proxy env vars:",
                 e instanceof Error ? e.message : e,
               );
-              caidoEnvVars = undefined;
+              caidoSetupDisabled = true;
             }
           }
 


### PR DESCRIPTION
## Summary
- On local (non-E2B) sandboxes, `ensureCaido` and `HTTP_PROXY` env-var injection no longer run for every terminal command.
- Caido now starts lazily on the first proxy-tool call (`list_requests`, `send_request`, etc.) via the existing guards in `runGql` / `executeProxiedRequest`.
- E2B behavior unchanged — controlled image still captures the agent's HTTP traffic eagerly. The "permanently disable on first failure" guard is preserved for that path.

## Why
Previously every terminal command on a local sandbox triggered the `caido-cli` install/auth/project-create script and injected `HTTP_PROXY`, even when the agent never used a proxy tool. That added noise (e.g. the `/etc/profile.d/caido.sh` write failing on systems without that dir), slowed first-command cold-start, and silently routed the user's shell traffic through Caido on a machine they didn't ask to be intercepted.

For local mode the cleaner mental model is: `run_terminal_cmd` = raw exec, proxy tools = explicit "capture this for analysis." Pentesters who want full agent-traffic capture locally can point the agent at their own already-running Caido/Burp via env.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — all 812 tests pass (incl. all 20 `proxy-manager.test.ts` cases)
- [ ] Manual: in local sandbox with `caido_enabled=true`, run a terminal command (e.g. `ls`) and confirm no `install_caido_cli` script output, no `caido-cli` process started.
- [ ] Manual: in same session, invoke a proxy tool (e.g. `list_requests`) and confirm Caido spins up on first call, returns results, and subsequent calls hit the fast path.
- [ ] Manual: on E2B sandbox with `caido_enabled=true`, confirm first terminal command still triggers eager Caido setup and `curl` traffic shows up under `list_requests` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Caido proxy initialization to be more selective and resilient, with better handling of setup failures to prevent repeated errors in subsequent terminal commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->