### PR TITLE
chore(models): remove GPT-5.5 model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You'll need the following accounts:
 **Required:**
 
 - [OpenRouter](https://openrouter.ai/) - AI model provider
-- [OpenAI](https://platform.openai.com/) - AI model provider
+- [OpenAI](https://platform.openai.com/) - Content moderation
 - [E2B](https://e2b.dev/) - Sandbox environment for secure code execution in agent mode
 - [Convex](https://www.convex.dev/) - Database and backend
 - [WorkOS](https://workos.com/) - Authentication and user management

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -471,8 +471,8 @@ const ModelOptionList = ({
                   Access the top AI models
                 </p>
                 <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
-                  Access the latest AI models from OpenAI, Anthropic (Claude)
-                  and more by{" "}
+                  Access the latest AI models from Anthropic (Claude), Google
+                  (Gemini), xAI (Grok) and more by{" "}
                   <a
                     href="#pricing"
                     onClick={() => onClose()}

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -508,7 +508,7 @@ const ModelOptionList = ({
               <TooltipTrigger asChild>
                 <div>
                   <SwitchRow
-                    label="Max Mode"
+                    label="MAX Mode"
                     checked={isMaxMode}
                     onToggle={onMaxModeToggle}
                     ariaLabel="Toggle max mode"
@@ -522,7 +522,7 @@ const ModelOptionList = ({
                 className="bg-popover text-popover-foreground border border-border shadow-lg rounded-xl px-4 py-3 max-w-[240px] [&_svg]:!hidden"
               >
                 <p className="text-sm font-semibold text-foreground leading-snug">
-                  Max Mode
+                  MAX Mode
                 </p>
                 <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
                   Use the selected model&apos;s full native context window (up

--- a/app/components/ModelSelector/CostIndicator.tsx
+++ b/app/components/ModelSelector/CostIndicator.tsx
@@ -11,7 +11,6 @@ const MODEL_COST_TIER: Record<string, CostTier> = {
   "grok-4.1": "low",
   "sonnet-4.6": "high",
   "opus-4.7": "very-high",
-  "gpt-5.5": "very-high",
   "kimi-k2.6": "medium",
 };
 

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -13,7 +13,6 @@ export interface ModelOption {
 export const ASK_MODEL_OPTIONS: ModelOption[] = [
   { id: "gemini-3-flash", label: "Gemini 3 Flash" },
   { id: "grok-4.1", label: "Grok 4.1" },
-  { id: "gpt-5.5", label: "GPT-5.5", censored: true },
   { id: "sonnet-4.6", label: "Claude Sonnet 4.6", censored: true },
   { id: "opus-4.7", label: "Claude Opus 4.7", censored: true },
 ];
@@ -21,7 +20,6 @@ export const ASK_MODEL_OPTIONS: ModelOption[] = [
 export const AGENT_MODEL_OPTIONS: ModelOption[] = [
   { id: "kimi-k2.6", label: "Kimi K2.6", thinking: true },
   { id: "grok-4.1", label: "Grok 4.1", thinking: true },
-  { id: "gpt-5.5", label: "GPT-5.5", thinking: true, censored: true },
   {
     id: "sonnet-4.6",
     label: "Claude Sonnet 4.6",

--- a/app/components/usage/UsageLogsTable.tsx
+++ b/app/components/usage/UsageLogsTable.tsx
@@ -115,7 +115,7 @@ const UsageLogsTable = () => {
       "Date",
       "Type",
       "Model",
-      "Max Mode",
+      "MAX Mode",
       "Cache Read",
       "Cache Write",
       "Input",

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -46,7 +46,6 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "model-grok-4.1": or("x-ai/grok-4.1-fast"),
     "model-gemini-3-flash": or("google/gemini-3-flash-preview"),
     "model-opus-4.7": or("anthropic/claude-opus-4-7"),
-    "model-gpt-5.5": or("openai/gpt-5.5"),
     "model-kimi-k2.6": or("moonshotai/kimi-k2.6:exacto"),
     "fallback-agent-model": or("x-ai/grok-4.1-fast"),
     "fallback-ask-model": or("x-ai/grok-4.1-fast"),
@@ -67,7 +66,6 @@ export const modelCutoffDates: Record<ModelName, string> &
   "model-grok-4.1": "November 2024",
   "model-gemini-3-flash": "January 2025",
   "model-opus-4.7": "January 2026",
-  "model-gpt-5.5": "August 2025",
   "model-kimi-k2.6": "April 2024",
   "fallback-agent-model": "January 2025",
   "fallback-ask-model": "January 2025",
@@ -85,7 +83,6 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-grok-4.1": "xAI Grok 4.1 Fast",
   "model-gemini-3-flash": "Google Gemini 3 Flash",
   "model-opus-4.7": "Anthropic Claude Opus 4.7",
-  "model-gpt-5.5": "OpenAI GPT-5.5",
   "model-kimi-k2.6": "Moonshot Kimi K2.6",
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
   "fallback-ask-model": "Auto, an intelligent model router built by HackerAI",
@@ -109,7 +106,6 @@ export const MODEL_CONTEXT_WINDOWS: Record<ModelName, number> &
   "model-grok-4.1": 2_000_000, // Grok 4.1 Fast
   "model-gemini-3-flash": 1_048_576, // Gemini 3 Flash
   "model-opus-4.7": 1_000_000, // Claude Opus 4.7 with 1M context beta
-  "model-gpt-5.5": 1_050_000, // GPT-5.5 (922k input + 128k output)
   "model-kimi-k2.6": 262_144, // Kimi K2.6
   "fallback-agent-model": 2_000_000,
   "fallback-ask-model": 2_000_000,

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -93,7 +93,7 @@ export const modelDisplayNames: Record<ModelName, string> &
 
 /**
  * Maximum context window (in tokens) per model, as advertised by the provider.
- * Used when "Max Mode" is enabled to unlock the model's full native context.
+ * Used when "MAX Mode" is enabled to unlock the model's full native context.
  * Sourced from OpenRouter model pages.
  */
 export const MODEL_CONTEXT_WINDOWS: Record<ModelName, number> &

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -235,7 +235,7 @@ export const createChatHandler = (
       // context truncation (before messages are fetched from DB).
       const userCustomization = await getUserCustomization({ userId });
 
-      // Max Mode only applies when a specific model is selected — not in Auto.
+      // MAX Mode only applies when a specific model is selected — not in Auto.
       const isAutoModelSelection =
         !selectedModelOverride || selectedModelOverride === "auto";
       const maxModeEnabled =

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -20,7 +20,6 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   "model-grok-4.1": { input: 0.2, output: 0.5 },
   "model-gemini-3-flash": { input: 0.5, output: 3.0 },
   "model-opus-4.7": { input: 5.0, output: 25.0 },
-  "model-gpt-5.5": { input: 5.0, output: 30.0 },
   // "agent-model", "agent-model-free", and "model-kimi-k2.6" all route to
   // moonshotai/kimi-k2.6:exacto via lib/ai/providers.ts. Rates from Moonshot AI
   // direct provider (int4): $0.95 in / $4.00 out per 1M tokens. Cache-read

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -17,7 +17,6 @@ export type SelectedModel =
   | "grok-4.1"
   | "gemini-3-flash"
   | "opus-4.7"
-  | "gpt-5.5"
   | "kimi-k2.6";
 // | "codex-local"
 // | `codex-local:${string}`;
@@ -28,7 +27,6 @@ export const SELECTABLE_MODELS: readonly SelectedModel[] = [
   "grok-4.1",
   "gemini-3-flash",
   "opus-4.7",
-  "gpt-5.5",
   "kimi-k2.6",
   // "codex-local",
 ];
@@ -40,7 +38,7 @@ export function isCodexLocal(model: string | null): boolean {
   );
 }
 
-/** Extract the Codex sub-model (e.g., "gpt-5.5" from "codex-local:gpt-5.5") */
+/** Extract the Codex sub-model (e.g., "gpt-5.3" from "codex-local:gpt-5.3") */
 export function getCodexSubModel(model: string): string | undefined {
   if (model.startsWith("codex-local:")) {
     return model.slice("codex-local:".length);


### PR DESCRIPTION
## Summary

- Removes GPT-5.5 from the model selector, provider map, cutoff dates, display names, context windows, and rate-limit pricing.
- Updates user-facing copy so OpenAI is no longer listed as a chat-model provider — the README now labels it as "Content moderation" (its only remaining use), and the upsell tooltip in the model selector now lists Anthropic / Google / xAI instead.

## Test plan

- [ ] `pnpm typecheck` passes (already verified by pre-commit hook)
- [ ] `pnpm test` passes (already verified — 812/812)
- [ ] Open the model selector and confirm GPT-5.5 no longer appears in either Ask or Agent options
- [ ] Confirm Codex (local-provider) entries and the OpenAI moderation flow are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified OpenAI account usage as for content moderation in prerequisites.

* **Changes**
  * Removed gpt-5.5 from selectable models and provider listings.
  * Updated provider tooltip to list Google (Gemini) and xAI (Grok) instead of OpenAI.
  * Normalized "MAX Mode" capitalization in UI and CSV exports.
  * Adjusted cost-tier display for the removed model (affects $ indicator and tooltip).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->