### PR TITLE
fix(logging): structured provider error logs with had_provider_error flag

### DIFF
--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -947,19 +947,12 @@ export const createChatHandler = (
               onError: async (error) => {
                 // Suppress xAI safety check errors from logging (they're expected for certain content)
                 if (!isXaiSafetyError(error)) {
-                  console.error("Error:", error);
-
-                  // Capture provider errors with request context
-                  phLogger.error("Provider streaming error", {
-                    error,
-                    chatId,
-                    endpoint,
+                  chatLogger?.recordProviderError(error, {
                     mode,
                     model: selectedModel,
                     userId,
                     subscription,
                     isTemporary: temporary,
-                    ...extractErrorDetails(error),
                   });
                 }
                 // Refund the upfront deduction only when the provider errored

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -20,6 +20,8 @@ import type {
 import type { ChatSDKError } from "@/lib/errors";
 import type { PostHog } from "posthog-node";
 import { after } from "next/server";
+import { phLogger } from "@/lib/posthog/server";
+import { extractErrorDetails } from "@/lib/utils/error-utils";
 
 export interface ChatLoggerConfig {
   chatId: string;
@@ -171,6 +173,54 @@ export function createChatLogger(config: ChatLoggerConfig) {
       cacheWriteTokens: number;
     }) {
       builder.setCacheMetrics(metrics);
+    },
+
+    /**
+     * Record a provider streaming error. Fans out to:
+     *   - Vercel runtime logs (structured JSON via logger.error)
+     *   - PostHog exception capture (phLogger.error)
+     *   - The wide event (had_provider_error + provider_error fields)
+     *
+     * Does NOT change outcome — emitSuccess/emitChatError still decides that.
+     */
+    recordProviderError(
+      error: unknown,
+      context: {
+        mode?: string;
+        model?: string;
+        userId?: string;
+        subscription?: string;
+        isTemporary?: boolean;
+      },
+    ) {
+      const details = extractErrorDetails(error);
+
+      logger.error(
+        "Provider streaming error",
+        error instanceof Error ? error : undefined,
+        {
+          chat_id: config.chatId,
+          endpoint: config.endpoint,
+          ...context,
+          ...details,
+        },
+      );
+
+      phLogger.error("Provider streaming error", {
+        error,
+        chatId: config.chatId,
+        endpoint: config.endpoint,
+        ...context,
+        ...details,
+      });
+
+      builder.markProviderError({
+        statusCode: details.statusCode as number | undefined,
+        url: details.providerUrl as string | undefined,
+        reason: (error as { reason?: string })?.reason,
+        message: details.errorMessage as string | undefined,
+        retriable: details.isRetryable as boolean | undefined,
+      });
     },
 
     /**

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -150,6 +150,18 @@ export interface ChatWideEvent {
     message: string;
     retriable: boolean;
   };
+
+  // True when the provider stream errored (e.g., AI_RetryError) but the
+  // request still resolved end-to-end — distinguishes a clean success from
+  // one where the model leg died and we recovered (fallback, partial output).
+  had_provider_error?: boolean;
+  provider_error?: {
+    status_code?: number;
+    url?: string;
+    reason?: string;
+    message?: string;
+    retriable?: boolean;
+  };
 }
 
 /**
@@ -447,6 +459,28 @@ export class WideEventBuilder {
   setAborted(): this {
     this.event.outcome = "aborted";
     this.event.status_code = 200;
+    return this;
+  }
+
+  /**
+   * Mark that a provider error fired during the stream. Does not change
+   * outcome — call setSuccess/setError separately based on overall result.
+   */
+  markProviderError(details: {
+    statusCode?: number;
+    url?: string;
+    reason?: string;
+    message?: string;
+    retriable?: boolean;
+  }): this {
+    this.event.had_provider_error = true;
+    this.event.provider_error = {
+      status_code: details.statusCode,
+      url: details.url,
+      reason: details.reason,
+      message: details.message,
+      retriable: details.retriable,
+    };
     return this;
   }
 


### PR DESCRIPTION
## Summary

- Fixes a logging gap where `onError` from `streamText` dumped a raw `console.error("Error:", error)` with a minified stack and no request correlation, while `emitSuccess` later stamped `outcome: "success"` even though the model leg had failed (e.g., AI_RetryError on OpenRouter 500s).
- Adds `recordProviderError` on the chat-logger that fans out to **all three** sinks in one call: structured Vercel runtime log (via `logger.error` JSON), PostHog exception capture (via `phLogger.error`), and the wide event.
- Adds `had_provider_error` + `provider_error` fields to `ChatWideEvent` so a single filter distinguishes clean successes from ones where the provider died but the request still resolved.

## Why

When OpenRouter burped a string of 500s, the prod terminal showed an unattributed `Error: { error: AI_RetryError ... __03xztdy._.js:79:5400 }` blob followed 89ms later by a `"outcome":"success"` wide event for the same chat — and there was no shared `chat_id` or `request_id` between them. After this PR, both lines are structured JSON keyed on `chat_id`/`endpoint`, and the wide event carries `had_provider_error: true, provider_error: { status_code: 500, url, reason: "maxRetriesExceeded", ... }`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 812/812 passing
- [ ] Trigger a provider error in staging (e.g., bad model id) and confirm:
  - [ ] Vercel runtime log is JSON with `chat_id`, `endpoint`, `errorMessage`, `statusCode`, `providerUrl`
  - [ ] PostHog still receives the exception
  - [ ] Wide event for the same request shows `had_provider_error: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored provider streaming error handling to use structured, unified error tracking with enhanced telemetry for improved visibility into request execution and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->