### PR TITLE
fix(logging): destructure streamText onError to prevent prompt leak

### DIFF
--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -944,8 +944,11 @@ export const createChatHandler = (
                 // Update logger with model and usage
                 chatLogger!.setStreamResponse(responseModel, streamUsage);
               },
-              onError: async (error) => {
-                // Suppress xAI safety check errors from logging (they're expected for certain content)
+              onError: async ({ error }) => {
+                // streamText wraps errors in `{ error }` events. Without this
+                // destructure, the wrapper object reaches getErrorMessage which
+                // JSON.stringifies it and leaks requestBodyValues (system prompt,
+                // user messages) into logs.
                 if (!isXaiSafetyError(error)) {
                   chatLogger?.recordProviderError(error, {
                     mode,


### PR DESCRIPTION
## Summary

The AI SDK's `streamText.onError` callback receives an event object `{ error }`, **not the error directly**. We were passing the entire wrapper to `recordProviderError`, which:

1. Failed `error instanceof Error` — so `extractErrorDetails` stamped `errorName: "UnknownError"`.
2. Fell through `getErrorMessage`'s final branch (`JSON.stringify(err)`), which serialized the *whole event object* — including `requestBodyValues.messages` (system prompt + every user message) — into the structured error log.

**Sample of what was being logged** (content redacted):

```json
{
  "level": "error",
  "message": "Provider streaming error",
  "errorName": "UnknownError",
  "errorMessage": "{\"error\":{\"name\":\"AI_APICallError\",\"requestBodyValues\":{\"messages\":[{\"role\":\"system\",\"content\":[{\"type\":\"text\",\"text\":\"You are HackerAI...\"}]},{\"role\":\"user\",\"content\":\"...\"}]}}}"
}
```

## Why this got noticed now

The leak existed in `phLogger.error("Provider streaming error", { error, ...extractErrorDetails(error) })` for as long as that handler has existed — PostHog was already receiving the same data on every provider stream error.

PR #416 made it visible in Vercel terminal logs because `logger.error` uses `console.error(JSON.stringify(...))` which recurses without depth limit. The previous bare `console.error("Error:", err)` used `util.inspect` with default depth=2 and collapsed `requestBodyValues` to `[Object]` — leak hidden in the terminal but still flowing to PostHog.

## Recommended follow-up (not in this PR)

Audit PostHog `\$exception` events for `errorMessage` containing `requestBodyValues` and consider purging the affected window. Retention will eventually clear them, but if compliance requires it, do it explicitly.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 812/812 passing
- [ ] Trigger a provider error in staging (bad model id) and confirm:
  - [ ] Vercel runtime log shows `errorName: "AI_RetryError"` (not `"UnknownError"`)
  - [ ] `errorMessage` is the short text (e.g., `"Failed after 3 attempts. Last error: Internal Server Error"`) — not a JSON dump
  - [ ] No `requestBodyValues` or `messages` content anywhere in the log payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed error handling in chat API to prevent sensitive user information (prompts, messages) from being inadvertently included in error logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->