### PR TITLE
fix(sandbox): record disconnect reason+time so refresh errors are diagnosable

### DIFF
--- a/app/api/sandbox/presence/route.ts
+++ b/app/api/sandbox/presence/route.ts
@@ -4,6 +4,7 @@ import { getUserID } from "@/lib/auth/get-user-id";
 import { generateCentrifugoToken } from "@/lib/centrifugo/jwt";
 import { ConvexHttpClient } from "convex/browser";
 import { api } from "@/convex/_generated/api";
+import { phLogger } from "@/lib/posthog/server";
 
 interface CentrifugoPresenceClient {
   client: string;
@@ -128,11 +129,22 @@ export async function GET(request: NextRequest) {
         ),
       );
       results.forEach((result, i) => {
+        const conn = stale[i];
         if (result.status === "rejected") {
-          console.error(
-            `Failed to disconnect stale connection ${stale[i].connectionId}:`,
-            result.reason,
-          );
+          phLogger.error("sandbox_presence_sweep_disconnect_failed", {
+            userId,
+            connectionId: conn.connectionId,
+            isDesktop: conn.isDesktop,
+            msSinceLastSeen: now - conn.lastSeen,
+            error: result.reason,
+          });
+        } else {
+          phLogger.warn("sandbox_presence_sweep_disconnect", {
+            userId,
+            connectionId: conn.connectionId,
+            isDesktop: conn.isDesktop,
+            msSinceLastSeen: now - conn.lastSeen,
+          });
         }
       });
     }

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -1,9 +1,29 @@
 import { Centrifuge, type Subscription } from "centrifuge";
+import posthog from "posthog-js";
 import {
   sandboxChannel,
   type SandboxMessage,
   type CommandMessage,
 } from "@/lib/centrifugo/types";
+
+interface ConnectionTerminatedDetails {
+  code?: string;
+  message?: string;
+  connectionId?: string;
+  clientVersion?: string;
+  status?: string;
+  disconnectReason?: string | null;
+  msSinceDisconnected?: number | null;
+  msSinceLastHeartbeat?: number;
+  msSinceCreated?: number;
+}
+
+function readErrorData(error: unknown): ConnectionTerminatedDetails {
+  if (!error || typeof error !== "object") return {};
+  const data = (error as { data?: unknown }).data;
+  if (!data || typeof data !== "object") return {};
+  return data as ConnectionTerminatedDetails;
+}
 
 interface StreamChunk {
   type: "stdout" | "stderr" | "exit" | "error";
@@ -92,17 +112,29 @@ export class DesktopSandboxBridge {
           return result.centrifugoToken;
         } catch (error) {
           if (isConnectionTerminatedByServer(error)) {
-            const data =
-              (error as { data?: { code?: string; message?: string } }).data ??
-              {};
+            const data = readErrorData(error);
+            const eventProps = {
+              connectionId: this.connectionId,
+              clientSurface: "desktop_bridge",
+              code: data.code ?? null,
+              message: data.message ?? null,
+              serverConnectionId: data.connectionId ?? null,
+              serverClientVersion: data.clientVersion ?? null,
+              serverStatus: data.status ?? null,
+              disconnectReason: data.disconnectReason ?? null,
+              msSinceDisconnected: data.msSinceDisconnected ?? null,
+              msSinceLastHeartbeat: data.msSinceLastHeartbeat ?? null,
+              msSinceCreated: data.msSinceCreated ?? null,
+            };
             console.warn(
               "[DesktopSandboxBridge] Centrifugo refresh aborted — server reports connection terminated; stopping client to break retry loop",
-              {
-                connectionId: this.connectionId,
-                code: data.code,
-                message: data.message,
-              },
+              eventProps,
             );
+            try {
+              posthog.capture("sandbox_connection_terminated", eventProps);
+            } catch {
+              // posthog not initialized for this user
+            }
             const client = this.client;
             this.client = null;
             this.connectionId = null;

--- a/convex/localSandbox.ts
+++ b/convex/localSandbox.ts
@@ -160,10 +160,14 @@ export const regenerateToken = mutation({
       });
     }
 
-    // Disconnect all existing connections for this user
+    // Disconnect existing *connected* rows. Skip already-disconnected rows so
+    // we don't clobber their original disconnect_reason/disconnected_at —
+    // those are the diagnostic signal we're trying to preserve.
     const connections = await ctx.db
       .query("local_sandbox_connections")
-      .withIndex("by_user_id", (q) => q.eq("user_id", userId))
+      .withIndex("by_user_and_status", (q) =>
+        q.eq("user_id", userId).eq("status", "connected"),
+      )
       .collect();
 
     const now = Date.now();
@@ -331,7 +335,11 @@ export const disconnect = mutation({
       .withIndex("by_connection_id", (q) => q.eq("connection_id", connectionId))
       .first();
 
-    if (connection && connection.user_id === tokenResult.userId) {
+    if (
+      connection &&
+      connection.user_id === tokenResult.userId &&
+      connection.status === "connected"
+    ) {
       await ctx.db.patch(connection._id, {
         status: "disconnected",
         disconnected_at: Date.now(),
@@ -506,11 +514,13 @@ export const disconnectDesktop = mutation({
       return { success: false };
     }
 
-    await ctx.db.patch(connection._id, {
-      status: "disconnected",
-      disconnected_at: Date.now(),
-      disconnect_reason: "desktop_disconnect",
-    });
+    if (connection.status === "connected") {
+      await ctx.db.patch(connection._id, {
+        status: "disconnected",
+        disconnected_at: Date.now(),
+        disconnect_reason: "desktop_disconnect",
+      });
+    }
 
     return { success: true };
   },

--- a/convex/localSandbox.ts
+++ b/convex/localSandbox.ts
@@ -166,9 +166,12 @@ export const regenerateToken = mutation({
       .withIndex("by_user_id", (q) => q.eq("user_id", userId))
       .collect();
 
+    const now = Date.now();
     for (const connection of connections) {
       await ctx.db.patch(connection._id, {
         status: "disconnected",
+        disconnected_at: now,
+        disconnect_reason: "token_regenerated",
       });
     }
 
@@ -283,9 +286,19 @@ export const refreshCentrifugoToken = mutation({
     }
 
     if (connection.status !== "connected") {
+      const now = Date.now();
       throw new ConvexError({
         code: "BAD_REQUEST",
         message: "Connection is not active",
+        connectionId: connection.connection_id,
+        clientVersion: connection.client_version,
+        status: connection.status,
+        disconnectReason: connection.disconnect_reason ?? null,
+        msSinceDisconnected: connection.disconnected_at
+          ? now - connection.disconnected_at
+          : null,
+        msSinceLastHeartbeat: now - connection.last_heartbeat,
+        msSinceCreated: now - connection.created_at,
       });
     }
 
@@ -321,6 +334,8 @@ export const disconnect = mutation({
     if (connection && connection.user_id === tokenResult.userId) {
       await ctx.db.patch(connection._id, {
         status: "disconnected",
+        disconnected_at: Date.now(),
+        disconnect_reason: "client_disconnect",
       });
     }
 
@@ -363,9 +378,14 @@ export const connectDesktop = mutation({
         q.eq("user_id", userId).eq("status", "connected"),
       )
       .collect();
+    const now = Date.now();
     for (const conn of existingDesktop) {
       if (conn.client_version === "desktop") {
-        await ctx.db.patch(conn._id, { status: "disconnected" });
+        await ctx.db.patch(conn._id, {
+          status: "disconnected",
+          disconnected_at: now,
+          disconnect_reason: "desktop_kicked_by_new_session",
+        });
       }
     }
 
@@ -436,9 +456,19 @@ export const refreshCentrifugoTokenDesktop = mutation({
     }
 
     if (connection.status !== "connected") {
+      const now = Date.now();
       throw new ConvexError({
         code: "BAD_REQUEST",
         message: "Connection is not active",
+        connectionId: connection.connection_id,
+        clientVersion: connection.client_version,
+        status: connection.status,
+        disconnectReason: connection.disconnect_reason ?? null,
+        msSinceDisconnected: connection.disconnected_at
+          ? now - connection.disconnected_at
+          : null,
+        msSinceLastHeartbeat: now - connection.last_heartbeat,
+        msSinceCreated: now - connection.created_at,
       });
     }
 
@@ -478,6 +508,8 @@ export const disconnectDesktop = mutation({
 
     await ctx.db.patch(connection._id, {
       status: "disconnected",
+      disconnected_at: Date.now(),
+      disconnect_reason: "desktop_disconnect",
     });
 
     return { success: true };
@@ -501,7 +533,11 @@ export const disconnectByBackend = mutation({
       .first();
 
     if (connection && connection.status === "connected") {
-      await ctx.db.patch(connection._id, { status: "disconnected" });
+      await ctx.db.patch(connection._id, {
+        status: "disconnected",
+        disconnected_at: Date.now(),
+        disconnect_reason: "presence_sweep",
+      });
     }
 
     return { success: true };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -222,6 +222,19 @@ export default defineSchema({
     last_heartbeat: v.number(),
     status: v.union(v.literal("connected"), v.literal("disconnected")),
     created_at: v.number(),
+    // Set whenever status flips to "disconnected" so refresh-time errors can
+    // report the cause (presence sweep, token regen, desktop kick, etc.) and
+    // the lag between disconnect and the failed refresh attempt.
+    disconnected_at: v.optional(v.number()),
+    disconnect_reason: v.optional(
+      v.union(
+        v.literal("client_disconnect"),
+        v.literal("desktop_disconnect"),
+        v.literal("desktop_kicked_by_new_session"),
+        v.literal("token_regenerated"),
+        v.literal("presence_sweep"),
+      ),
+    ),
   })
     .index("by_user_id", ["user_id"])
     .index("by_connection_id", ["connection_id"])

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -343,20 +343,45 @@ class LocalSandboxClient {
         } catch (error) {
           if (isConnectionTerminatedByServer(error)) {
             const data =
-              (error as { data?: { code?: string; message?: string } }).data ??
-              {};
+              (
+                error as {
+                  data?: {
+                    code?: string;
+                    message?: string;
+                    disconnectReason?: string | null;
+                    msSinceDisconnected?: number | null;
+                    msSinceLastHeartbeat?: number;
+                    msSinceCreated?: number;
+                  };
+                }
+              ).data ?? {};
             console.error(
               chalk.red(
                 `\n❌ Connection terminated by server (${data.code ?? "unknown"}: ${data.message ?? "unknown"})`,
               ),
             );
+            const reasonHint =
+              data.disconnectReason === "token_regenerated"
+                ? "Your token was regenerated; rerun with the new token."
+                : data.disconnectReason === "presence_sweep"
+                  ? "Server presence sweep marked this connection stale."
+                  : data.disconnectReason === "desktop_kicked_by_new_session"
+                    ? "A new desktop session took over."
+                    : data.disconnectReason === "client_disconnect" ||
+                        data.disconnectReason === "desktop_disconnect"
+                      ? "This connection was explicitly disconnected."
+                      : "Likely causes: token regenerated, or disconnected from another session.";
+            console.error(chalk.yellow(reasonHint));
             console.error(
-              chalk.yellow(
-                "Likely causes: token was regenerated, or this connection was disconnected from another session.",
+              chalk.gray(
+                JSON.stringify({
+                  connectionId: this.connectionId ?? "unknown",
+                  disconnectReason: data.disconnectReason ?? null,
+                  msSinceDisconnected: data.msSinceDisconnected ?? null,
+                  msSinceLastHeartbeat: data.msSinceLastHeartbeat ?? null,
+                  msSinceCreated: data.msSinceCreated ?? null,
+                }),
               ),
-            );
-            console.error(
-              chalk.gray(`Connection ID: ${this.connectionId ?? "unknown"}`),
             );
             // Stop the Centrifuge retry loop and exit. cleanup() synchronously
             // calls centrifuge.disconnect() before any awaits, so by the time


### PR DESCRIPTION
## Summary

- "Connection is not active" errors from `refreshCentrifugoToken` / `refreshCentrifugoTokenDesktop` keep recurring after PR #408 (presence race) and #415 (retry-loop suppression). The thrown error was identical regardless of which of five paths flipped `status` to `disconnected`, and carried no timestamps — so we couldn't distinguish a stale client from a presence-sweep race from a token regen.
- Add `disconnect_reason` and `disconnected_at` to `local_sandbox_connections`, stamp them on every status flip, and surface them in the thrown ConvexError so each failure self-describes.
- Wire PostHog capture on the presence sweep (server) and desktop bridge (browser); structured stderr on the CLI.

## What changed

- **Schema** (`convex/schema.ts`): two optional fields on `local_sandbox_connections` — additive, no migration.
- **Convex disconnect paths** (`convex/localSandbox.ts`): every site that flips status now writes a reason — `regenerateToken` → `token_regenerated`, `disconnect` → `client_disconnect`, `connectDesktop` multi-tab kick → `desktop_kicked_by_new_session`, `disconnectDesktop` → `desktop_disconnect`, `disconnectByBackend` → `presence_sweep`.
- **Refresh handlers**: both `BAD_REQUEST: Connection is not active` throws now carry `connectionId`, `clientVersion`, `status`, `disconnectReason`, `msSinceDisconnected`, `msSinceLastHeartbeat`, `msSinceCreated` in the ConvexError data field.
- **Presence sweep** (`app/api/sandbox/presence/route.ts`): `phLogger.warn`/`error` for each disconnect attempt with `userId`, `connectionId`, `isDesktop`, `msSinceLastSeen`.
- **Desktop bridge** (`app/services/desktop-sandbox-bridge.ts`): `posthog.capture("sandbox_connection_terminated", …)` with the full enriched payload.
- **CLI** (`packages/local/src/index.ts`): reason-specific human hint + structured JSON line on terminated connections.

## What this gets you

When the next "Connection is not active" event fires, the payload tells you (a) which of the five paths flipped the row, (b) how many ms ago, and (c) the heartbeat lag. That's enough to distinguish the four hypotheses we've been chasing — and to spot a sixth path none of the prior fixes covered (`disconnectReason: null`).

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (812/812 passing)
- [x] `npx tsc --noEmit -p packages/local/tsconfig.json`
- [ ] After deploy: confirm a `sandbox_connection_terminated` event lands in PostHog with non-null `disconnectReason` for at least one organic occurrence
- [ ] After deploy: pick one PostHog event and verify `msSinceDisconnected` < `PRESENCE_GRACE_MS` (30s) means presence-sweep race; > 30s means stale-client retry that #415 should have suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for connection termination and token-refresh failures with richer diagnostic details and clearer human-readable hints.

* **Chores**
  * Enhanced disconnect tracking: connections now record disconnect reason and timestamp, and telemetry/events include richer connection metadata to aid diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->