### PR TITLE
feat(models): add Grok 4.3 for agent mode alongside Grok 4.1 for ask

### DIFF
--- a/app/components/ModelSelector/CostIndicator.tsx
+++ b/app/components/ModelSelector/CostIndicator.tsx
@@ -9,6 +9,7 @@ type CostTier = "low" | "medium" | "high" | "very-high" | "free";
 const MODEL_COST_TIER: Record<string, CostTier> = {
   "gemini-3-flash": "low",
   "grok-4.1": "low",
+  "grok-4.3": "low",
   "sonnet-4.6": "high",
   "opus-4.7": "very-high",
   "kimi-k2.6": "medium",

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -19,7 +19,7 @@ export const ASK_MODEL_OPTIONS: ModelOption[] = [
 
 export const AGENT_MODEL_OPTIONS: ModelOption[] = [
   { id: "kimi-k2.6", label: "Kimi K2.6", thinking: true },
-  { id: "grok-4.1", label: "Grok 4.1", thinking: true },
+  { id: "grok-4.3", label: "Grok 4.3", thinking: true },
   {
     id: "sonnet-4.6",
     label: "Claude Sonnet 4.6",

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -44,10 +44,11 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "agent-model-free": or("deepseek/deepseek-v4-flash"),
     "model-sonnet-4.6": or("anthropic/claude-sonnet-4-6"),
     "model-grok-4.1": or("x-ai/grok-4.1-fast"),
+    "model-grok-4.3": or("x-ai/grok-4.3"),
     "model-gemini-3-flash": or("google/gemini-3-flash-preview"),
     "model-opus-4.7": or("anthropic/claude-opus-4-7"),
     "model-kimi-k2.6": or("moonshotai/kimi-k2.6:exacto"),
-    "fallback-agent-model": or("x-ai/grok-4.1-fast"),
+    "fallback-agent-model": or("x-ai/grok-4.3"),
     "fallback-ask-model": or("x-ai/grok-4.1-fast"),
     "title-generator-model": or("x-ai/grok-4.1-fast"),
   }) as Record<string, any>;
@@ -64,6 +65,7 @@ export const modelCutoffDates: Record<ModelName, string> &
   "agent-model-free": "May 2025",
   "model-sonnet-4.6": "May 2025",
   "model-grok-4.1": "November 2024",
+  "model-grok-4.3": "November 2024",
   "model-gemini-3-flash": "January 2025",
   "model-opus-4.7": "January 2026",
   "model-kimi-k2.6": "April 2024",
@@ -81,6 +83,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "agent-model-free": "Auto, an intelligent model router built by HackerAI",
   "model-sonnet-4.6": "Anthropic Claude Sonnet 4.6",
   "model-grok-4.1": "xAI Grok 4.1 Fast",
+  "model-grok-4.3": "xAI Grok 4.3",
   "model-gemini-3-flash": "Google Gemini 3 Flash",
   "model-opus-4.7": "Anthropic Claude Opus 4.7",
   "model-kimi-k2.6": "Moonshot Kimi K2.6",
@@ -104,12 +107,13 @@ export const MODEL_CONTEXT_WINDOWS: Record<ModelName, number> &
   "agent-model-free": 262_144, // resolves to Kimi K2.6
   "model-sonnet-4.6": 1_000_000, // Claude Sonnet 4.6 with 1M context beta
   "model-grok-4.1": 2_000_000, // Grok 4.1 Fast
+  "model-grok-4.3": 1_000_000, // Grok 4.3
   "model-gemini-3-flash": 1_048_576, // Gemini 3 Flash
   "model-opus-4.7": 1_000_000, // Claude Opus 4.7 with 1M context beta
   "model-kimi-k2.6": 262_144, // Kimi K2.6
-  "fallback-agent-model": 2_000_000,
-  "fallback-ask-model": 2_000_000,
-  "title-generator-model": 2_000_000,
+  "fallback-agent-model": 1_000_000, // Grok 4.3
+  "fallback-ask-model": 2_000_000, // Grok 4.1 Fast
+  "title-generator-model": 2_000_000, // Grok 4.1 Fast
   "model-codex-local": 400_000,
 };
 

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -180,7 +180,7 @@ describe("selectModel", () => {
   // Agent mode allows model override for paid users
   describe("model override in agent mode", () => {
     it("should use allowed model override for paid users in agent mode", () => {
-      expect(selectModel("agent", "pro", "grok-4.1")).toBe("model-grok-4.1");
+      expect(selectModel("agent", "pro", "grok-4.3")).toBe("model-grok-4.3");
       expect(selectModel("agent", "pro", "gemini-3-flash")).toBe(
         "model-gemini-3-flash",
       );

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -328,6 +328,15 @@ describe("token-bucket", () => {
       );
     });
 
+    it("should use Grok 4.3 pricing ($1.25/$2.50)", () => {
+      expect(calculateTokenCost(1_000_000, "input", "model-grok-4.3")).toBe(
+        15000,
+      );
+      expect(calculateTokenCost(1_000_000, "output", "model-grok-4.3")).toBe(
+        30000,
+      );
+    });
+
     it("expensive models should deplete budget faster", () => {
       const monthlyBudget = getBudgetLimits("pro").monthly;
       // Typical conversation: 2000 input + 500 output tokens

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -18,6 +18,7 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   default: { input: 0.5, output: 3.0 },
   "model-sonnet-4.6": { input: 3.0, output: 15.0 },
   "model-grok-4.1": { input: 0.2, output: 0.5 },
+  "model-grok-4.3": { input: 1.25, output: 2.5 },
   "model-gemini-3-flash": { input: 0.5, output: 3.0 },
   "model-opus-4.7": { input: 5.0, output: 25.0 },
   // "agent-model", "agent-model-free", and "model-kimi-k2.6" all route to

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -15,6 +15,7 @@ export type SelectedModel =
   | "auto"
   | "sonnet-4.6"
   | "grok-4.1"
+  | "grok-4.3"
   | "gemini-3-flash"
   | "opus-4.7"
   | "kimi-k2.6";
@@ -25,6 +26,7 @@ export const SELECTABLE_MODELS: readonly SelectedModel[] = [
   "auto",
   "sonnet-4.6",
   "grok-4.1",
+  "grok-4.3",
   "gemini-3-flash",
   "opus-4.7",
   "kimi-k2.6",


### PR DESCRIPTION
## Summary

- Add Grok 4.3 (`x-ai/grok-4.3`) as a new selectable model for **agent mode** (reasoning required).
- Keep Grok 4.1 Fast (`x-ai/grok-4.1-fast`) as the selectable model for **ask mode** (no reasoning).
- Route `fallback-agent-model` to Grok 4.3, `fallback-ask-model` and `title-generator-model` to Grok 4.1 Fast.
- Wire pricing ($1.25 in / $2.50 out per 1M for 4.3, ≤200K tier), display name, cutoff date, and 1M context window for the new model.

## Slot routing

| Slot | Model |
|---|---|
| Ask-mode selectable | Grok 4.1 Fast |
| Agent-mode selectable | Grok 4.3 |
| `fallback-ask-model` | Grok 4.1 Fast |
| `fallback-agent-model` | Grok 4.3 |
| `title-generator-model` | Grok 4.1 Fast |

## Notes / follow-ups

- Grok 4.3 OpenRouter pricing is tiered (≤200K vs >200K) but `MODEL_PRICING_MAP` only supports a flat rate — used the ≤200K tier.
- Reasoning is required for Grok 4.3 but is **not yet enforced** here. If the API rejects calls without `reasoning`, we'll need a `providerOptions` toggle (or a fetch shim like the Kimi one in [lib/ai/providers.ts](lib/ai/providers.ts)) wherever `model-grok-4.3` is invoked.
- Cutoff date for Grok 4.3 is set to "November 2024" as a placeholder — update if xAI documents a different value.

## Test plan

- [x] `pnpm test` — 813 tests pass (including new Grok 4.3 pricing case)
- [x] `pnpm tsc --noEmit` — clean
- [ ] Manually open ask-mode model selector → confirm "Grok 4.1" appears
- [ ] Manually open agent-mode model selector → confirm "Grok 4.3" appears with thinking badge
- [ ] Send a message with Grok 4.3 selected and verify the request lands on `x-ai/grok-4.3` in OpenRouter logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grok 4.3 model is now available for selection with updated cost tier mapping and per-token pricing configuration.
  * Default fallback model has been updated to Grok 4.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->