### PR TITLE
fix(chat): strip image attachments from history for free users

### DIFF
--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -58,6 +58,7 @@ import {
 } from "@/lib/api/chat-logger";
 import {
   countFileAttachments,
+  stripImageAttachments,
   sendRateLimitWarnings,
   buildProviderOptions,
   isXaiSafetyError,
@@ -249,18 +250,22 @@ export const createChatHandler = (
         selectedModelOverride,
       );
 
-      const { truncatedMessages, chat, isNewChat, fileTokens } =
-        await getMessagesByChatId({
-          chatId,
-          userId,
-          subscription,
-          newMessages: messages,
-          regenerate,
-          isTemporary: temporary,
-          mode,
-          maxMode: maxModeEnabled,
-          modelName: resolvedModelName,
-        });
+      const fetched = await getMessagesByChatId({
+        chatId,
+        userId,
+        subscription,
+        newMessages: messages,
+        regenerate,
+        isTemporary: temporary,
+        mode,
+        maxMode: maxModeEnabled,
+        modelName: resolvedModelName,
+      });
+      const { chat, isNewChat, fileTokens } = fetched;
+      const truncatedMessages =
+        subscription === "free"
+          ? stripImageAttachments(fetched.truncatedMessages)
+          : fetched.truncatedMessages;
 
       const baseTodos: Todo[] = getBaseTodosForRequest(
         (chat?.todos as unknown as Todo[]) || [],

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -69,6 +69,35 @@ export function countFileAttachments(
 }
 
 /**
+ * Remove image file parts from messages. Used for free-tier users continuing
+ * chats that already contain images uploaded while paid. Messages that would
+ * end up empty get a text placeholder so turn structure stays intact.
+ */
+export function stripImageAttachments<
+  T extends { parts?: Array<{ type?: string; mediaType?: string }> },
+>(messages: T[]): T[] {
+  return messages.map((msg) => {
+    if (!msg.parts) return msg;
+    const filtered = msg.parts.filter(
+      (p) => !(p.type === "file" && (p.mediaType ?? "").startsWith("image/")),
+    );
+    if (filtered.length === msg.parts.length) return msg;
+    return {
+      ...msg,
+      parts:
+        filtered.length > 0
+          ? filtered
+          : [
+              {
+                type: "text",
+                text: "[Image attachment hidden — image attachments are a paid-plan feature and aren't available on the free plan.]",
+              },
+            ],
+    } as T;
+  });
+}
+
+/**
  * Send rate limit warnings based on subscription and rate limit info
  */
 export function sendRateLimitWarnings(


### PR DESCRIPTION
## Summary
- Strip image file parts from `truncatedMessages` for free-tier users in the chat handler, so a downgraded (paid → free) user can continue chats whose history contains images without sending them to a free-tier provider that may not support vision.
- Replace any message that becomes empty after stripping with a text placeholder explaining the image was hidden because attachments are a paid-plan feature, keeping user/assistant turn structure intact.
- New helper `stripImageAttachments` in `lib/api/chat-stream-helpers.ts` next to existing `countFileAttachments` / `hasFileAttachments`.

## Test plan
- [ ] As a free user, send a chat in a thread that has prior image messages → request succeeds, model receives placeholder text instead of image parts
- [ ] As a paid user, send a chat with images → unchanged behavior, images still sent
- [ ] As a free user, send a thread where every prior turn was image-only → no provider "empty parts" error; placeholder is present
- [ ] Existing tests pass (`pnpm typecheck` + `pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Free-tier users now have image attachments hidden in conversations, with a placeholder message displayed instead. Paid subscribers retain full access to image attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->