### PR TITLE
Remove MAX Mode + fix E2B PTY per-RPC deadline

### DIFF
--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -42,8 +42,6 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { useState } from "react";
-import { useQuery, useMutation } from "convex/react";
-import { api } from "@/convex/_generated/api";
 import { isCodexLocal, type ChatMode, type SelectedModel } from "@/types/chat";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import { useGlobalState } from "@/app/contexts/GlobalState";
@@ -389,8 +387,6 @@ const ModelOptionList = ({
   isAuto,
   isFreeUser,
   isTauri = false,
-  isMaxMode,
-  onMaxModeToggle,
   onAutoToggle,
   onSelect,
   onClose,
@@ -402,8 +398,6 @@ const ModelOptionList = ({
   isAuto: boolean;
   isFreeUser: boolean;
   isTauri?: boolean;
-  isMaxMode: boolean;
-  onMaxModeToggle: (checked: boolean) => void;
   onAutoToggle: (checked: boolean) => void;
   onSelect: (option: ModelOption) => void;
   onClose: () => void;
@@ -500,38 +494,6 @@ const ModelOptionList = ({
             />
           </>
         )}
-
-        {!isFreeUser && (
-          <>
-            <div className="my-1 border-b border-border/50" />
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div>
-                  <SwitchRow
-                    label="MAX Mode"
-                    checked={isMaxMode}
-                    onToggle={onMaxModeToggle}
-                    ariaLabel="Toggle max mode"
-                    mobile={mobile}
-                  />
-                </div>
-              </TooltipTrigger>
-              <TooltipContent
-                side="right"
-                sideOffset={12}
-                className="bg-popover text-popover-foreground border border-border shadow-lg rounded-xl px-4 py-3 max-w-[240px] [&_svg]:!hidden"
-              >
-                <p className="text-sm font-semibold text-foreground leading-snug">
-                  MAX Mode
-                </p>
-                <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
-                  Use the selected model&apos;s full native context window (up
-                  to 1M+ tokens) instead of the default 200k.
-                </p>
-              </TooltipContent>
-            </Tooltip>
-          </>
-        )}
       </>
     )}
   </div>
@@ -556,22 +518,6 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
   const isAuto = value === "auto";
   const isFreeUser = subscription === "free";
 
-  const userCustomization = useQuery(
-    api.userCustomization.getUserCustomization,
-    isFreeUser ? "skip" : {},
-  );
-  const saveCustomization = useMutation(
-    api.userCustomization.saveUserCustomization,
-  );
-  const isMaxMode = userCustomization?.max_mode_enabled ?? false;
-
-  const handleMaxModeToggle = async (checked: boolean) => {
-    try {
-      await saveCustomization({ max_mode_enabled: checked });
-    } catch {
-      // Silent; toggle will revert on next query refresh
-    }
-  };
   const options = isAgentMode(mode) ? AGENT_MODEL_OPTIONS : ASK_MODEL_OPTIONS;
   const codexOptions = CODEX_LOCAL_OPTIONS;
   const allOptions = [...options, ...codexOptions];
@@ -743,8 +689,6 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
               isAuto={isAuto}
               isFreeUser={isFreeUser}
               isTauri={isTauri}
-              isMaxMode={isMaxMode}
-              onMaxModeToggle={handleMaxModeToggle}
               onAutoToggle={handleAutoToggle}
               onSelect={handleModelSelect}
               onClose={() => setOpen(false)}
@@ -769,8 +713,6 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
             isAuto={isAuto}
             isFreeUser={isFreeUser}
             isTauri={isTauri}
-            isMaxMode={isMaxMode}
-            onMaxModeToggle={handleMaxModeToggle}
             onAutoToggle={handleAutoToggle}
             onSelect={handleModelSelect}
             onClose={() => setOpen(false)}

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -449,12 +449,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
             ) {
               const maxTokens = getMaxTokensForSubscription(
                 subscriptionRef.current,
-                {
-                  maxMode:
-                    userCustomizationRef.current?.max_mode_enabled ?? false,
-                  modelName: selectedModelRef.current ?? undefined,
-                  mode: chatModeRef.current as "ask" | "agent",
-                },
+                { mode: chatModeRef.current as "ask" | "agent" },
               );
               const context = serializeConversation(currentMessages, maxTokens);
               if (context) {

--- a/app/components/usage/UsageLogsTable.tsx
+++ b/app/components/usage/UsageLogsTable.tsx
@@ -115,7 +115,6 @@ const UsageLogsTable = () => {
       "Date",
       "Type",
       "Model",
-      "MAX Mode",
       "Cache Read",
       "Cache Write",
       "Input",
@@ -127,7 +126,6 @@ const UsageLogsTable = () => {
       new Date(log._creationTime).toISOString(),
       log.type === "included" ? "Included" : "Extra Usage",
       log.model,
-      log.max_mode ? "Yes" : "No",
       (log.cache_read_tokens ?? 0).toString(),
       (log.cache_write_tokens ?? 0).toString(),
       log.input_tokens.toString(),
@@ -283,23 +281,7 @@ const UsageLogsTable = () => {
                     {log.type === "included" ? "Included" : "Extra"}
                   </td>
                   <td className="px-3 py-2.5 text-muted-foreground whitespace-nowrap">
-                    <div className="flex items-center gap-1.5">
-                      <span>{log.model}</span>
-                      {log.max_mode && (
-                        <div className="flex h-[14px] items-center gap-1.5 rounded border border-white/10 px-1 py-0 flex-shrink-0">
-                          <span
-                            className="text-xs font-bold uppercase"
-                            style={{
-                              background:
-                                "linear-gradient(to right, rgb(129, 161, 193), rgb(125, 124, 155)) text",
-                              WebkitTextFillColor: "transparent",
-                            }}
-                          >
-                            Max
-                          </span>
-                        </div>
-                      )}
-                    </div>
+                    {log.model}
                   </td>
                   <td className="px-3 py-2.5 text-right tabular-nums text-muted-foreground">
                     <TokenBreakdownTooltip

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -128,6 +128,9 @@ export default defineSchema({
     caido_enabled: v.optional(v.boolean()),
     caido_port: v.optional(v.number()),
     extra_usage_enabled: v.optional(v.boolean()),
+    // Legacy MAX Mode flag retained on historical rows. The feature was
+    // removed and nothing reads or writes this anymore — kept in the schema
+    // so old rows still pass validation.
     max_mode_enabled: v.optional(v.boolean()),
   }).index("by_user_id", ["user_id"]),
 
@@ -252,7 +255,9 @@ export default defineSchema({
     cache_write_tokens: v.optional(v.number()),
     total_tokens: v.number(),
     cost_dollars: v.number(),
-    // True when Max mode was active for this request (larger context window).
+    // Legacy MAX Mode flag retained on historical rows. The feature was
+    // removed and nothing reads or writes this anymore — kept in the schema
+    // so old rows still pass validation.
     max_mode: v.optional(v.boolean()),
     // Legacy BYOK flag retained on historical rows. The feature was removed
     // and nothing reads or writes this anymore — kept in the schema so old

--- a/convex/usageLogs.ts
+++ b/convex/usageLogs.ts
@@ -28,7 +28,6 @@ export const logUsage = mutation({
     cache_write_tokens: v.optional(v.number()),
     total_tokens: v.number(),
     cost_dollars: v.number(),
-    max_mode: v.optional(v.boolean()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -44,7 +43,6 @@ export const logUsage = mutation({
       cache_write_tokens: args.cache_write_tokens,
       total_tokens: args.total_tokens,
       cost_dollars: args.cost_dollars,
-      max_mode: args.max_mode,
     });
 
     return null;
@@ -135,7 +133,6 @@ export const getUserUsageLogs = query({
         cache_write_tokens: log.cache_write_tokens,
         total_tokens: log.total_tokens,
         cost_dollars: log.cost_dollars,
-        max_mode: !!log.max_mode,
       })),
     };
   },

--- a/convex/userCustomization.ts
+++ b/convex/userCustomization.ts
@@ -17,7 +17,6 @@ export const saveUserCustomization = mutation({
     caido_enabled: v.optional(v.boolean()),
     caido_port: v.optional(v.number()),
     extra_usage_enabled: v.optional(v.boolean()),
-    max_mode_enabled: v.optional(v.boolean()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -116,8 +115,6 @@ export const saveUserCustomization = mutation({
           patch.caido_port = args.caido_port ? args.caido_port : undefined;
         if (args.extra_usage_enabled !== undefined)
           patch.extra_usage_enabled = args.extra_usage_enabled;
-        if (args.max_mode_enabled !== undefined)
-          patch.max_mode_enabled = args.max_mode_enabled;
 
         await ctx.db.patch(existing._id, patch);
       } else {
@@ -134,7 +131,6 @@ export const saveUserCustomization = mutation({
           caido_enabled: args.caido_enabled,
           caido_port: args.caido_port ? args.caido_port : undefined,
           extra_usage_enabled: args.extra_usage_enabled ?? false,
-          max_mode_enabled: args.max_mode_enabled ?? false,
           updated_at: Date.now(),
         });
       }
@@ -172,7 +168,6 @@ export const getUserCustomization = query({
       caido_enabled: v.boolean(),
       caido_port: v.optional(v.number()),
       extra_usage_enabled: v.boolean(),
-      max_mode_enabled: v.boolean(),
       updated_at: v.number(),
     }),
   ),
@@ -203,7 +198,6 @@ export const getUserCustomization = query({
         caido_enabled: customization.caido_enabled ?? false,
         caido_port: customization.caido_port,
         extra_usage_enabled: customization.extra_usage_enabled ?? false,
-        max_mode_enabled: customization.max_mode_enabled ?? false,
         updated_at: customization.updated_at,
       };
     } catch (error) {
@@ -234,7 +228,6 @@ export const getUserCustomizationForBackend = query({
       caido_enabled: v.boolean(),
       caido_port: v.optional(v.number()),
       extra_usage_enabled: v.boolean(),
-      max_mode_enabled: v.boolean(),
       updated_at: v.number(),
     }),
   ),
@@ -262,7 +255,6 @@ export const getUserCustomizationForBackend = query({
         caido_enabled: customization.caido_enabled ?? false,
         caido_port: customization.caido_port,
         extra_usage_enabled: customization.extra_usage_enabled ?? false,
-        max_mode_enabled: customization.max_mode_enabled ?? false,
         updated_at: customization.updated_at,
       };
     } catch (error) {

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -94,33 +94,6 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-codex-local": "OpenAI Codex (Your Account)",
 };
 
-/**
- * Maximum context window (in tokens) per model, as advertised by the provider.
- * Used when "MAX Mode" is enabled to unlock the model's full native context.
- * Sourced from OpenRouter model pages.
- */
-export const MODEL_CONTEXT_WINDOWS: Record<ModelName, number> &
-  Record<string, number> = {
-  "ask-model": 1_048_576, // resolves to Gemini 3 Flash
-  "ask-model-free": 2_000_000, // resolves to Grok 4.1 Fast
-  "agent-model": 262_144, // resolves to Kimi K2.5
-  "agent-model-free": 262_144, // resolves to Kimi K2.6
-  "model-sonnet-4.6": 1_000_000, // Claude Sonnet 4.6 with 1M context beta
-  "model-grok-4.1": 2_000_000, // Grok 4.1 Fast
-  "model-grok-4.3": 1_000_000, // Grok 4.3
-  "model-gemini-3-flash": 1_048_576, // Gemini 3 Flash
-  "model-opus-4.6": 1_000_000, // Claude Opus 4.6 with 1M context
-  "model-kimi-k2.6": 262_144, // Kimi K2.6
-  "fallback-agent-model": 1_000_000, // Grok 4.3
-  "fallback-ask-model": 2_000_000, // Grok 4.1 Fast
-  "title-generator-model": 2_000_000, // Grok 4.1 Fast
-  "model-codex-local": 400_000,
-};
-
-export const getModelContextWindow = (modelName: string): number => {
-  return MODEL_CONTEXT_WINDOWS[modelName] ?? 200_000;
-};
-
 export const getModelDisplayName = (modelName: ModelName): string => {
   return modelDisplayNames[modelName];
 };

--- a/lib/ai/tools/utils/e2b-pty-adapter.ts
+++ b/lib/ai/tools/utils/e2b-pty-adapter.ts
@@ -22,11 +22,14 @@ interface E2BPtyCreateOpts {
   onData: PtyDataCb;
   cwd?: string;
   envs?: Record<string, string>;
+  timeoutMs?: number;
 }
 
 interface E2BCommandHandle {
   readonly pid: number;
-  wait(): Promise<{ exitCode: number | null | undefined }>;
+  wait(opts?: {
+    timeoutMs?: number;
+  }): Promise<{ exitCode: number | null | undefined }>;
 }
 
 interface E2BPtyModule {
@@ -63,6 +66,12 @@ export interface CreatePtyOptions {
 
 const LOG_PREFIX = "[e2b-pty-adapter]";
 
+// Disable the SDK's per-RPC deadline. Lifetime is owned by PtySessionManager
+// (idle + max-lifetime timers). Without this, the default RPC timeout (~60s)
+// rejects pty.create / handle.wait while the process is still healthy in the
+// sandbox, leaving the manager to mark the session as exitedNaturally.
+const PTY_NO_TIMEOUT_MS = 0;
+
 export async function createE2BPtyHandle(
   sandbox: Sandbox,
   opts: CreatePtyOptions,
@@ -89,6 +98,7 @@ export async function createE2BPtyHandle(
     cwd: opts.cwd,
     envs: opts.envs,
     onData,
+    timeoutMs: PTY_NO_TIMEOUT_MS,
   });
 
   const pid = handle.pid;
@@ -98,7 +108,7 @@ export async function createE2BPtyHandle(
   // {exitCode: null} with a structured log — the error is surfaced, not
   // swallowed silently.
   const exited: Promise<{ exitCode: number | null }> = handle
-    .wait()
+    .wait({ timeoutMs: PTY_NO_TIMEOUT_MS })
     .then((result) => ({
       exitCode: typeof result?.exitCode === "number" ? result.exitCode : null,
     }))

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -235,20 +235,7 @@ export const createChatHandler = (
         });
       }
 
-      // Fetch user customization early so max_mode_enabled can influence
-      // context truncation (before messages are fetched from DB).
       const userCustomization = await getUserCustomization({ userId });
-
-      // MAX Mode only applies when a specific model is selected — not in Auto.
-      const isAutoModelSelection =
-        !selectedModelOverride || selectedModelOverride === "auto";
-      const maxModeEnabled =
-        !isAutoModelSelection && (userCustomization?.max_mode_enabled ?? false);
-      const resolvedModelName = selectModel(
-        mode,
-        subscription,
-        selectedModelOverride,
-      );
 
       const fetched = await getMessagesByChatId({
         chatId,
@@ -258,8 +245,6 @@ export const createChatHandler = (
         regenerate,
         isTemporary: temporary,
         mode,
-        maxMode: maxModeEnabled,
-        modelName: resolvedModelName,
       });
       const { chat, isNewChat, fileTokens } = fetched;
       const truncatedMessages =
@@ -596,11 +581,7 @@ export const createChatHandler = (
           const contextUsageOn = isContextUsageEnabled(subscription, mode);
           const ctxSystemTokens = contextUsageOn ? systemPromptTokens : 0;
           const ctxMaxTokens = contextUsageOn
-            ? getMaxTokensForSubscription(subscription, {
-                maxMode: maxModeEnabled,
-                modelName: selectedModel,
-                mode,
-              })
+            ? getMaxTokensForSubscription(subscription, { mode })
             : 0;
           let ctxUsage = contextUsageOn
             ? computeContextUsage(
@@ -721,7 +702,6 @@ export const createChatHandler = (
               responseModel,
               configuredModelId,
               rateLimitInfo,
-              maxMode: maxModeEnabled,
             });
           };
 
@@ -740,11 +720,8 @@ export const createChatHandler = (
                 try {
                   const stepNumber = steps.length;
                   const threshold = Math.floor(
-                    getMaxTokensForSubscription(subscription, {
-                      maxMode: maxModeEnabled,
-                      modelName: selectedModel,
-                      mode,
-                    }) * SUMMARIZATION_THRESHOLD_PERCENTAGE,
+                    getMaxTokensForSubscription(subscription, { mode }) *
+                      SUMMARIZATION_THRESHOLD_PERCENTAGE,
                   );
 
                   // Prune old tool outputs to stay within rolling token budget
@@ -880,11 +857,8 @@ export const createChatHandler = (
                     stepCountIs(getMaxStepsForUser(mode, subscription)),
                     tokenExhaustedAfterSummarization({
                       threshold: Math.floor(
-                        getMaxTokensForSubscription(subscription, {
-                          maxMode: maxModeEnabled,
-                          modelName: selectedModel,
-                          mode,
-                        }) * SUMMARIZATION_THRESHOLD_PERCENTAGE,
+                        getMaxTokensForSubscription(subscription, { mode }) *
+                          SUMMARIZATION_THRESHOLD_PERCENTAGE,
                       ),
                       getLastStepInputTokens: () => lastStepInputTokens,
                       getHasSummarized: hasSummarized,

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -233,8 +233,6 @@ export async function getMessagesByChatId({
   subscription,
   isTemporary,
   mode,
-  maxMode,
-  modelName,
 }: {
   chatId: string;
   userId: string;
@@ -243,8 +241,6 @@ export async function getMessagesByChatId({
   regenerate?: boolean;
   isTemporary?: boolean;
   mode?: "ask" | "agent";
-  maxMode?: boolean;
-  modelName?: string;
 }) {
   // For temporary chats, skip database operations
   let chat = undefined;
@@ -310,8 +306,6 @@ export async function getMessagesByChatId({
           }
 
           const maxTokens = getMaxTokensForSubscription(subscription, {
-            maxMode,
-            modelName,
             mode,
           });
           const truncatedMessages = truncateMessagesToTokenLimit(
@@ -389,8 +383,6 @@ export async function getMessagesByChatId({
 
             // Re-truncate real messages to leave room for the summary message
             const maxTokens = getMaxTokensForSubscription(subscription, {
-              maxMode,
-              modelName,
               mode,
             });
             const summaryTokens = countMessagesTokens(
@@ -459,8 +451,6 @@ export async function getMessagesByChatId({
     allMessages,
     subscription,
     mode === "agent", // Skip file tokens for agent mode (files go to sandbox)
-    maxMode,
-    modelName,
   );
   const truncatedMessages = truncateResult.messages;
   const fileTokens = truncateResult.fileTokens;
@@ -471,8 +461,6 @@ export async function getMessagesByChatId({
       const fileIds = extractAllFileIdsFromMessages(allMessages);
       const fileTokens = await getFileTokensByIds(fileIds as any);
       const maxTokens = getMaxTokensForSubscription(subscription, {
-        maxMode,
-        modelName,
         mode,
       });
       const totalTokensBefore = countMessagesTokens(allMessages, fileTokens);
@@ -930,7 +918,6 @@ export async function logUsageRecord({
   cacheReadTokens,
   cacheWriteTokens,
   costDollars,
-  maxMode,
 }: {
   userId: string;
   model: string;
@@ -941,7 +928,6 @@ export async function logUsageRecord({
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
   costDollars: number;
-  maxMode?: boolean;
 }) {
   try {
     await convex.mutation(api.usageLogs.logUsage, {
@@ -955,7 +941,6 @@ export async function logUsageRecord({
       cache_write_tokens: cacheWriteTokens,
       total_tokens: totalTokens,
       cost_dollars: costDollars,
-      max_mode: maxMode,
     });
   } catch (error) {
     console.error("Failed to log usage record:", {

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -451,6 +451,7 @@ export async function getMessagesByChatId({
     allMessages,
     subscription,
     mode === "agent", // Skip file tokens for agent mode (files go to sandbox)
+    mode,
   );
   const truncatedMessages = truncateResult.messages;
   const fileTokens = truncateResult.fileTokens;

--- a/lib/token-utils.ts
+++ b/lib/token-utils.ts
@@ -2,7 +2,6 @@ import { UIMessage, UIMessagePart } from "ai";
 import { countTokens, encode, decode } from "gpt-tokenizer";
 import type { SubscriptionTier } from "@/types";
 import type { Id } from "@/convex/_generated/dataModel";
-import { getModelContextWindow } from "@/lib/ai/providers";
 
 export const MAX_TOKENS_FREE = 32000;
 export const MAX_TOKENS_PAID = 200000;
@@ -12,24 +11,12 @@ export const MAX_TOKENS_PAID = 200000;
  */
 export const FILE_TOKEN_PERCENT = 0.5;
 
-/**
- * Returns the context token budget for a user.
- *
- * When `maxMode` is enabled for a paid user, we unlock the selected model's
- * full native context window (via MODEL_CONTEXT_WINDOWS). Otherwise we use
- * the conservative default (200k paid / 32k free) so token accounting,
- * pricing, and cache behavior stay predictable for typical conversations.
- * Free agent users get the same 200k budget as paid users.
- */
 export const getMaxTokensForSubscription = (
   subscription: SubscriptionTier,
-  opts?: { maxMode?: boolean; modelName?: string; mode?: "ask" | "agent" },
+  opts?: { mode?: "ask" | "agent" },
 ): number => {
   if (subscription === "free") {
     return opts?.mode === "agent" ? MAX_TOKENS_PAID : MAX_TOKENS_FREE;
-  }
-  if (opts?.maxMode && opts.modelName) {
-    return Math.max(MAX_TOKENS_PAID, getModelContextWindow(opts.modelName));
   }
   return MAX_TOKENS_PAID;
 };
@@ -40,7 +27,7 @@ export const getMaxTokensForSubscription = (
  */
 export const getMaxFileTokens = (
   subscription: SubscriptionTier,
-  opts?: { maxMode?: boolean; modelName?: string; mode?: "ask" | "agent" },
+  opts?: { mode?: "ask" | "agent" },
 ): number => {
   return Math.floor(
     getMaxTokensForSubscription(subscription, opts) * FILE_TOKEN_PERCENT,

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -145,7 +145,6 @@ export class UsageTracker {
     responseModel,
     configuredModelId,
     rateLimitInfo,
-    maxMode,
   }: {
     userId: string;
     selectedModel: string;
@@ -153,7 +152,6 @@ export class UsageTracker {
     responseModel?: string;
     configuredModelId: string;
     rateLimitInfo: RateLimitInfo;
-    maxMode?: boolean;
   }) {
     logUsageRecord({
       userId,
@@ -170,7 +168,6 @@ export class UsageTracker {
       cacheReadTokens: this.cacheReadTokens || undefined,
       cacheWriteTokens: this.cacheWriteTokens || undefined,
       costDollars: this.computeCostDollars(selectedModel),
-      maxMode,
     });
   }
 }

--- a/lib/utils/file-token-utils.ts
+++ b/lib/utils/file-token-utils.ts
@@ -78,16 +78,11 @@ export const truncateMessagesWithFileTokens = async (
   messages: UIMessage[],
   subscription: SubscriptionTier = "pro",
   skipFileTokens: boolean = false,
-  maxMode?: boolean,
-  modelName?: string,
 ): Promise<{
   messages: UIMessage[];
   fileTokens: Record<Id<"files">, number>;
 }> => {
-  const maxTokens = getMaxTokensForSubscription(subscription, {
-    maxMode,
-    modelName,
-  });
+  const maxTokens = getMaxTokensForSubscription(subscription);
   const fileTokens = skipFileTokens
     ? {}
     : await getFileTokensByIds(extractAllFileIdsFromMessages(messages));

--- a/lib/utils/file-token-utils.ts
+++ b/lib/utils/file-token-utils.ts
@@ -78,11 +78,12 @@ export const truncateMessagesWithFileTokens = async (
   messages: UIMessage[],
   subscription: SubscriptionTier = "pro",
   skipFileTokens: boolean = false,
+  mode?: "ask" | "agent",
 ): Promise<{
   messages: UIMessage[];
   fileTokens: Record<Id<"files">, number>;
 }> => {
-  const maxTokens = getMaxTokensForSubscription(subscription);
+  const maxTokens = getMaxTokensForSubscription(subscription, { mode });
   const fileTokens = skipFileTokens
     ? {}
     : await getFileTokensByIds(extractAllFileIdsFromMessages(messages));

--- a/types/user.ts
+++ b/types/user.ts
@@ -10,7 +10,6 @@ export interface UserCustomization {
   readonly caido_port?: number;
   readonly updated_at: number;
   readonly extra_usage_enabled?: boolean;
-  readonly max_mode_enabled?: boolean;
 }
 
 export type PersonalityType = "cynic" | "robot" | "listener" | "nerd";


### PR DESCRIPTION
## Summary

Two unrelated changes on this daily branch:

### `cc573ae8` — refactor: remove MAX Mode feature
- Drops the user-facing toggle, `userCustomization.max_mode_enabled` field, request plumbing, and the `usage_logs.max_mode` column from the live code paths.
- Schema retains `max_mode_enabled` / `max_mode` as **optional** so historical Convex rows still validate (mirrors the existing `byok` deprecation pattern).
- Touches: `ModelSelector.tsx`, `chat.tsx`, `UsageLogsTable.tsx`, `convex/schema.ts`, `convex/usageLogs.ts`, `convex/userCustomization.ts`, `lib/ai/providers.ts`, `lib/api/chat-handler.ts`, `lib/db/actions.ts`, `lib/token-utils.ts`, `lib/usage-tracker.ts`, `lib/utils/file-token-utils.ts`, `types/user.ts`.

### `7be29e3c` — fix(pty): disable per-RPC timeout on E2B pty.create/wait
- `createE2BPtyHandle` was calling `pty.create()` and `handle.wait()` without `timeoutMs`, so the E2B SDK's default per-RPC deadline (~60s) rejected long-running PTYs with `[deadline_exceeded]` while the process was still healthy in the sandbox.
- Side effect: `PtySessionManager` would then mark the session as `exitedNaturally` and stop streaming output despite the process still running.
- Fix: pass `timeoutMs: 0` to both calls; lifetime ownership stays with `PtySessionManager` (idle + max-lifetime timers).
- Touches only `lib/ai/tools/utils/e2b-pty-adapter.ts` (+12/-2). Note: this PR does **not** address the secondary `kill failed ... sandbox was not found` errors — that requires a separate look at sandbox lifetime vs. session lifetime.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 887/887 tests pass (incl. `e2b-pty-adapter.test.ts`, `pty-session-manager.test.ts`, `chat-handler-pty-cleanup.test.ts`)
- [ ] Manually verify a long-running PTY session (>60s, e.g. `sleep 120` + observe output) no longer logs `pty wait() rejected ... [deadline_exceeded]`
- [ ] Smoke-test that historical usage_logs rows with `max_mode` still load in the usage table without schema errors
- [ ] Confirm new chats no longer surface a MAX Mode toggle anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Caido configuration options (enable/disable and port).
  * Added extra usage tracking option in customization.

* **Removed Features**
  * Removed MAX Mode toggle from model selector and related settings.
  * Removed MAX Mode column and CSV field from usage logs and exports.
  * Stopped recording MAX Mode in usage logs.

* **Improvements**
  * Simplified token limit calculations to use subscription tier and chat mode only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->