### PR TITLE
fix(logging): partial outcome on provider error + per-attempt capture

### DIFF
--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -21,7 +21,10 @@ import type { ChatSDKError } from "@/lib/errors";
 import type { PostHog } from "posthog-node";
 import { after } from "next/server";
 import { phLogger } from "@/lib/posthog/server";
-import { extractErrorDetails } from "@/lib/utils/error-utils";
+import {
+  extractErrorDetails,
+  extractRetryAttempts,
+} from "@/lib/utils/error-utils";
 
 export interface ChatLoggerConfig {
   chatId: string;
@@ -194,6 +197,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
       },
     ) {
       const details = extractErrorDetails(error);
+      const attempts = extractRetryAttempts(error);
 
       logger.error(
         "Provider streaming error",
@@ -203,6 +207,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
           endpoint: config.endpoint,
           ...context,
           ...details,
+          ...(attempts && { provider_attempts: attempts }),
         },
       );
 
@@ -212,6 +217,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
         endpoint: config.endpoint,
         ...context,
         ...details,
+        ...(attempts && { provider_attempts: attempts }),
       });
 
       builder.markProviderError({
@@ -220,6 +226,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
         reason: (error as { reason?: string })?.reason,
         message: details.errorMessage as string | undefined,
         retriable: details.isRetryable as boolean | undefined,
+        attempts,
       });
     },
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -139,8 +139,10 @@ export interface ChatWideEvent {
   // Tool execution
   tool_call_count?: number;
 
-  // Outcome
-  outcome: "success" | "error" | "aborted";
+  // Outcome. `partial` means the request returned 200 but the provider stream
+  // errored — either we recovered via fallback or we sent an error chunk to
+  // the client. Distinguishing this from `success` keeps dashboards honest.
+  outcome: "success" | "partial" | "error" | "aborted";
   status_code: number;
 
   // Error details (if any)
@@ -161,6 +163,15 @@ export interface ChatWideEvent {
     reason?: string;
     message?: string;
     retriable?: boolean;
+    // Per-attempt breakdown when the SDK retried internally. Each entry is one
+    // upstream call. Lets you tell consistent-500 from a mixed cascade and
+    // gives you provider request IDs to file support tickets with.
+    attempts?: Array<{
+      status_code?: number;
+      message: string;
+      error_name?: string;
+      request_id?: string;
+    }>;
   };
 }
 
@@ -445,10 +456,12 @@ export class WideEventBuilder {
   }
 
   /**
-   * Set successful outcome
+   * Set successful outcome. Downgrades to `partial` when the provider stream
+   * errored mid-flight, so dashboards/alerts don't treat broken responses as
+   * clean successes.
    */
   setSuccess(): this {
-    this.event.outcome = "success";
+    this.event.outcome = this.event.had_provider_error ? "partial" : "success";
     this.event.status_code = 200;
     return this;
   }
@@ -472,6 +485,7 @@ export class WideEventBuilder {
     reason?: string;
     message?: string;
     retriable?: boolean;
+    attempts?: NonNullable<ChatWideEvent["provider_error"]>["attempts"];
   }): this {
     this.event.had_provider_error = true;
     this.event.provider_error = {
@@ -480,6 +494,7 @@ export class WideEventBuilder {
       reason: details.reason,
       message: details.message,
       retriable: details.retriable,
+      attempts: details.attempts,
     };
     return this;
   }

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -113,6 +113,73 @@ export const extractErrorDetails = (
   return details;
 };
 
+export interface ProviderAttempt {
+  status_code?: number;
+  message: string;
+  error_name?: string;
+  request_id?: string;
+}
+
+const REQUEST_ID_HEADERS = [
+  "request-id",
+  "x-request-id",
+  "cf-ray",
+  "x-amzn-requestid",
+];
+
+const extractRequestId = (error: unknown): string | undefined => {
+  if (!error || typeof error !== "object") return undefined;
+  const headers = (error as { responseHeaders?: Record<string, unknown> })
+    .responseHeaders;
+  if (!headers || typeof headers !== "object") return undefined;
+  const lower: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    lower[k.toLowerCase()] = v;
+  }
+  for (const key of REQUEST_ID_HEADERS) {
+    const value = lower[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+};
+
+const toAttempt = (error: unknown): ProviderAttempt => {
+  const anyError = (error ?? {}) as Record<string, unknown>;
+  const statusCode =
+    typeof anyError.statusCode === "number"
+      ? anyError.statusCode
+      : typeof anyError.status === "number"
+        ? anyError.status
+        : undefined;
+  const errorName =
+    error instanceof Error
+      ? error.name
+      : typeof anyError.name === "string"
+        ? (anyError.name as string)
+        : undefined;
+  return {
+    status_code: statusCode,
+    message: getErrorMessage(error),
+    error_name: errorName,
+    request_id: extractRequestId(error),
+  };
+};
+
+/**
+ * Decompose an AI SDK `RetryError` (or anything with an `errors[]` array of
+ * attempt errors) into per-attempt records. Returns undefined when the error
+ * does not carry attempt history, so callers can fall back to single-error
+ * logging.
+ */
+export const extractRetryAttempts = (
+  error: unknown,
+): ProviderAttempt[] | undefined => {
+  if (!error || typeof error !== "object") return undefined;
+  const errors = (error as { errors?: unknown }).errors;
+  if (!Array.isArray(errors) || errors.length === 0) return undefined;
+  return errors.map(toAttempt);
+};
+
 /**
  * Converts a provider error into a user-friendly message.
  *


### PR DESCRIPTION
## Summary
- A 200 response whose provider stream errored mid-flight was being logged as `outcome: "success"` because `had_provider_error` did not affect the classifier. Add a new `partial` outcome and downgrade in `setSuccess` when the flag is set, so dashboards stop treating broken responses as clean successes.
- Decompose AI SDK `RetryError.errors[]` into a per-attempt array on the wide event and structured log line. Each entry carries `status_code`, `message`, `error_name`, and the upstream `request_id` (extracted from `request-id` / `x-request-id` / `cf-ray` / `x-amzn-requestid`). Lets us tell a consistent 500 from a mixed cascade and follow up with the provider.

## Motivation
Triggered by a real prod failure: a 227k-token Sonnet 4.6 request returned `AI_RetryError: Failed after 3 attempts. Last error: Internal Server Error` but the wide event still recorded `outcome: "success"`, `had_provider_error: true`. Two visible symptoms — misleading success metric and no per-attempt detail to diagnose with.

## Changes
- [lib/logger.ts](lib/logger.ts) — extend outcome union with `"partial"`; `setSuccess()` checks `had_provider_error`; extend `provider_error.attempts` schema.
- [lib/utils/error-utils.ts](lib/utils/error-utils.ts) — new `extractRetryAttempts(error)` helper + request-id header extraction.
- [lib/api/chat-logger.ts](lib/api/chat-logger.ts) — pass `attempts` into both `logger.error` / `phLogger.error` and `markProviderError`.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (887 tests)
- [ ] Spot-check production wide events after deploy to confirm the next provider failure shows `outcome: "partial"` and a populated `provider_error.attempts` array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error logging with per-attempt retry details including status codes, error names, and request identifiers for better diagnostics.
  * Added "partial" outcome status to complement existing success, error, and aborted states for more granular event tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->