### PR TITLE
Show tool error in sidebar terminal output

### DIFF
--- a/lib/ai/tools/interact-terminal-session.ts
+++ b/lib/ai/tools/interact-terminal-session.ts
@@ -349,5 +349,22 @@ export const createInteractTerminalSession = (context: ToolContext) => {
 
       return errorResult(`Unknown action: ${action}`);
     },
+    // Strip rawSnapshot from the model's view: the agent only needs the
+    // cleaned `output` plus structural fields. rawSnapshot stays in the
+    // persisted tool result so the sidebar's xterm renderer can replay it.
+    toModelOutput({ output }) {
+      if (typeof output !== "object" || output === null) {
+        return { type: "text", value: String(output ?? "") };
+      }
+      const result = (output as { result?: unknown }).result;
+      if (typeof result !== "object" || result === null) {
+        return { type: "text", value: JSON.stringify(output) };
+      }
+      const { rawSnapshot: _rawSnapshot, ...rest } = result as Record<
+        string,
+        unknown
+      >;
+      return { type: "text", value: JSON.stringify({ result: rest }) };
+    },
   });
 };

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -784,5 +784,24 @@ In using these tools, adhere to the following guidelines:
         return error as CommandExitError;
       }
     },
+    // For interactive PTY results, strip rawSnapshot from what the model
+    // sees — the agent only needs the cleaned `output` plus structural
+    // fields. rawSnapshot stays in the persisted tool result so the
+    // sidebar's xterm renderer can replay it. No-op for non-interactive
+    // results, which never include rawSnapshot.
+    toModelOutput({ output }) {
+      if (typeof output !== "object" || output === null) {
+        return { type: "text", value: String(output ?? "") };
+      }
+      const result = (output as { result?: unknown }).result;
+      if (typeof result !== "object" || result === null) {
+        return { type: "text", value: JSON.stringify(output) };
+      }
+      const { rawSnapshot: _rawSnapshot, ...rest } = result as Record<
+        string,
+        unknown
+      >;
+      return { type: "text", value: JSON.stringify({ result: rest }) };
+    },
   });
 };

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -279,10 +279,18 @@ function removeDuplicateToolParts(messages: UIMessage[]): UIMessage[] {
 }
 
 /**
- * Strips originalContent and modifiedContent from file tool outputs to reduce payload size.
- * Also strips original and modified from update_note tool outputs.
- * These are persisted for UI but shouldn't be sent to the model
- * (toModelOutput handles what the model sees, but we also strip it here as a safeguard).
+ * Strips bulky UI-only fields from historical tool outputs before they're
+ * fed back into the model context.
+ *
+ * Tools' own `toModelOutput` handles the current step's result, but
+ * `convertToModelMessages` is called here without the tools registry, so
+ * `toModelOutput` is bypassed for past results — we strip explicitly.
+ *
+ * - `tool-file` (read/edit/append): drops originalContent / modifiedContent
+ * - `tool-update_note`: drops original / modified diff data
+ * - `tool-run_terminal_cmd` / `tool-interact_terminal_session`: drops
+ *   rawSnapshot (raw ANSI byte buffer used only by the sidebar's xterm
+ *   renderer; the model already has `output` and `sessionSnapshot`).
  */
 function stripOriginalContentFromMessages(messages: UIMessage[]): UIMessage[] {
   return messages.map((message) => {
@@ -322,6 +330,25 @@ function stripOriginalContentFromMessages(messages: UIMessage[]): UIMessage[] {
         return {
           ...part,
           output: restOutput,
+        };
+      }
+
+      // Process PTY tool parts to strip rawSnapshot. Output shape is
+      // `{ result: { output, sessionSnapshot, rawSnapshot, ... } }`.
+      if (
+        (part.type === "tool-run_terminal_cmd" ||
+          part.type === "tool-interact_terminal_session") &&
+        typeof part.output === "object" &&
+        part.output !== null &&
+        typeof (part.output as any).result === "object" &&
+        (part.output as any).result !== null &&
+        "rawSnapshot" in (part.output as any).result
+      ) {
+        hasChanges = true;
+        const { rawSnapshot, ...restResult } = (part.output as any).result;
+        return {
+          ...part,
+          output: { ...part.output, result: restResult },
         };
       }
 

--- a/lib/utils/sidebar-utils.ts
+++ b/lib/utils/sidebar-utils.ts
@@ -167,6 +167,10 @@ export function extractSidebarContentFromMessage(
       // sessionSnapshot is cleaned via xterm headless - prefer it when available.
       // For streaming, show live output for responsiveness.
       const sessionSnapshot = result?.sessionSnapshot || "";
+      // Surface tool-level errors as the displayed output so e.g. action=view
+      // on a killed session shows "Session ... not found." in the sidebar
+      // instead of an empty panel — same pattern as `getShellOutput`.
+      const resultError = typeof result?.error === "string" ? result.error : "";
       const finalOutput =
         // Prefer cleaned sessionSnapshot when available (works for all action types)
         sessionSnapshot ||
@@ -176,6 +180,7 @@ export function extractSidebarContentFromMessage(
         output ||
         streamingOutput ||
         part.output?.output ||
+        resultError ||
         "";
 
       // Only feed rawBytes (→ xterm renderer) for interactive PTY contexts.


### PR DESCRIPTION
When the agent calls action=view on a killed shell, the tool returns { result: { output: "", error: "Session ... not found." } }. The sidebar's live extraction path didn't fall back to result.error, so the panel rendered as empty. Append result.error to the finalOutput fallback chain — same pattern getShellOutput already uses on the non-live path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar now shows meaningful terminal error messages (e.g., when sessions are unavailable) instead of empty panels.

* **Improvements**
  * Terminal output shared with the assistant/model is streamlined to remove large internal snapshots, reducing noise in replies and history while keeping full details available to the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->