### PR TITLE
Instrument cap hits and subscription lifecycle in PostHog

### DIFF
--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { stripe } from "@/app/api/stripe";
 import { workos } from "@/app/api/workos";
 import { ConvexHttpClient } from "convex/browser";
@@ -11,7 +11,30 @@ import {
   initProratedBucket,
   clearOrgRemovedUsage,
 } from "@/lib/rate-limit";
+import { phLogger } from "@/lib/posthog/server";
 import type { SubscriptionTier } from "@/types";
+
+// Linear ranking used to label tier transitions as upgrade/downgrade. Team is
+// pinned at the top because moves between team and individual plans are rare
+// and analysts can re-bucket from `from_tier`/`to_tier` if needed.
+const TIER_ORDER: readonly SubscriptionTier[] = [
+  "free",
+  "pro",
+  "pro-plus",
+  "ultra",
+  "team",
+];
+
+function tierDirection(
+  from: SubscriptionTier | null,
+  to: SubscriptionTier | null,
+): "upgrade" | "downgrade" | "lateral" {
+  const fi = from ? TIER_ORDER.indexOf(from) : -1;
+  const ti = to ? TIER_ORDER.indexOf(to) : -1;
+  if (ti > fi) return "upgrade";
+  if (ti < fi) return "downgrade";
+  return "lateral";
+}
 
 const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
@@ -291,7 +314,7 @@ async function handleSubscriptionUpdated(
 
   if (!customerId) return;
 
-  const { userIds } = await resolveUserIdsFromCustomer(customerId);
+  const { userIds, orgId } = await resolveUserIdsFromCustomer(customerId);
   if (userIds.length === 0) {
     console.error(
       `[Subscription Webhook] subscription.updated: could not resolve users for customer ${customerId}`,
@@ -303,6 +326,18 @@ async function handleSubscriptionUpdated(
     `[Subscription Webhook] subscription.updated: tier change ${previousTier} → ${currentTier} for ${userIds.length} user(s)`,
   );
 
+  const direction = tierDirection(previousTier, currentTier);
+  for (const uid of userIds) {
+    phLogger.event("subscription_changed", {
+      userId: uid,
+      from_tier: previousTier,
+      to_tier: currentTier,
+      direction,
+      org_id: orgId,
+      $set: { subscription_tier: currentTier ?? "free" },
+    });
+  }
+
   // Stash remaining credits from old tier before deleting, then reset old buckets
   if (previousTier) {
     await Promise.all(
@@ -311,6 +346,44 @@ async function handleSubscriptionUpdated(
     await Promise.all(
       userIds.map((uid) => resetRateLimitBuckets(uid, previousTier)),
     );
+  }
+}
+
+/** Handle customer.subscription.deleted — emit churn analytics for the lapsed paid users. */
+async function handleSubscriptionDeleted(
+  subscription: Stripe.Subscription,
+): Promise<void> {
+  const customerId =
+    typeof subscription.customer === "string"
+      ? subscription.customer
+      : subscription.customer?.id;
+  if (!customerId) return;
+
+  const lookupKey = subscription.items?.data[0]?.price?.lookup_key ?? null;
+  const tier = lookupKey ? planLookupKeyToTier(lookupKey) : null;
+
+  const { userIds, orgId } = await resolveUserIdsFromCustomer(customerId);
+  if (userIds.length === 0) {
+    console.error(
+      `[Subscription Webhook] subscription.deleted: could not resolve users for customer ${customerId}`,
+    );
+    return;
+  }
+
+  const cancellationReason = subscription.cancellation_details?.reason ?? null;
+
+  console.log(
+    `[Subscription Webhook] subscription.deleted: tier ${tier ?? "unknown"} cancelled for ${userIds.length} user(s) (reason: ${cancellationReason ?? "none"})`,
+  );
+
+  for (const uid of userIds) {
+    phLogger.event("subscription_cancelled", {
+      userId: uid,
+      tier,
+      org_id: orgId,
+      cancellation_reason: cancellationReason,
+      $set: { subscription_tier: "free" },
+    });
   }
 }
 
@@ -324,7 +397,7 @@ async function handleSubscriptionUpdated(
  *
  * Configure in Stripe Dashboard:
  * - Endpoint URL: https://your-domain.com/api/subscription/webhook
- * - Events: invoice.paid, customer.subscription.updated
+ * - Events: invoice.paid, customer.subscription.updated, customer.subscription.deleted
  */
 export async function POST(req: NextRequest) {
   const body = await req.text();
@@ -399,7 +472,15 @@ export async function POST(req: NextRequest) {
       );
       break;
     }
+    case "customer.subscription.deleted": {
+      await handleSubscriptionDeleted(event.data.object as Stripe.Subscription);
+      break;
+    }
   }
+
+  // Flush queued PostHog events after the response is sent. Webhook handlers
+  // terminate quickly enough that buffered events would otherwise be dropped.
+  after(() => phLogger.flush());
 
   // Mark as processed after successful handling
   try {

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -334,7 +334,11 @@ async function handleSubscriptionUpdated(
       to_tier: currentTier,
       direction,
       org_id: orgId,
-      $set: { subscription_tier: currentTier ?? "free" },
+      // Only update the person property when we resolved the new tier. A null
+      // currentTier means Stripe's lookup_key + product fallbacks both failed,
+      // and coercing to "free" would silently move possibly-paid users out of
+      // the paid cohort.
+      ...(currentTier && { $set: { subscription_tier: currentTier } }),
     });
   }
 

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -73,11 +73,20 @@ export interface StreamResult {
 export function createChatLogger(config: ChatLoggerConfig) {
   const builder = createWideEventBuilder(config.chatId, config.endpoint);
 
+  // Cache identity/context fields so emitChatError can fire discrete PostHog
+  // events (e.g. monthly_cap_hit) without forcing the call site to thread
+  // them through. Populated by the corresponding setX methods below.
+  let userId: string | undefined;
+  let subscription: string | undefined;
+  let mode: ChatMode | undefined;
+  let monthlyRemainingPercent: number | undefined;
+
   return {
     /**
      * Set initial request details
      */
     setRequestDetails(details: RequestDetails) {
+      mode = details.mode;
       builder.setRequestDetails(details);
     },
 
@@ -85,6 +94,8 @@ export function createChatLogger(config: ChatLoggerConfig) {
      * Set user context
      */
     setUser(user: UserContext) {
+      userId = user.id;
+      subscription = user.subscription;
       builder.setUser(user);
     },
 
@@ -103,15 +114,14 @@ export function createChatLogger(config: ChatLoggerConfig) {
       context: RateLimitContext,
       extraUsageConfig?: ExtraUsageConfig,
     ) {
+      monthlyRemainingPercent = context.monthly
+        ? Math.round((context.monthly.remaining / context.monthly.limit) * 100)
+        : undefined;
       builder.setExtraUsage(extraUsageConfig);
       builder.setRateLimit({
         pointsDeducted: context.pointsDeducted,
         extraUsagePointsDeducted: context.extraUsagePointsDeducted,
-        monthlyRemainingPercent: context.monthly
-          ? Math.round(
-              (context.monthly.remaining / context.monthly.limit) * 100,
-            )
-          : undefined,
+        monthlyRemainingPercent,
         freeRemaining:
           context.subscription === "free" ? context.remaining : undefined,
       });
@@ -255,6 +265,31 @@ export function createChatLogger(config: ChatLoggerConfig) {
         retriable: error.type === "rate_limit",
       });
       logger.info(builder.build());
+
+      // Fire a discrete PostHog event when a paid user is blocked at the
+      // monthly cap. Used to size the cap-hit cohort and correlate against
+      // subscription_changed / subscription_cancelled events.
+      if (
+        error.type === "rate_limit" &&
+        subscription &&
+        subscription !== "free"
+      ) {
+        const capReason =
+          (error.metadata?.capReason as string | undefined) ?? "unknown";
+        phLogger.event("monthly_cap_hit", {
+          userId,
+          subscription,
+          mode,
+          cap_reason: capReason,
+          monthly_remaining_percent: monthlyRemainingPercent,
+          chat_id: config.chatId,
+          endpoint: config.endpoint,
+          $set: {
+            subscription_tier: subscription,
+            last_cap_hit_at: new Date().toISOString(),
+          },
+        });
+      }
     },
 
     /**

--- a/lib/posthog/server.ts
+++ b/lib/posthog/server.ts
@@ -15,6 +15,11 @@ type LogFields = Record<string, unknown> & {
   error?: unknown;
 };
 
+type EventFields = Record<string, unknown> & {
+  userId?: string;
+  $set?: Record<string, unknown>;
+};
+
 function distinctIdFor(userId: unknown): string {
   return typeof userId === "string" && userId.length > 0 ? userId : "system";
 }
@@ -71,6 +76,21 @@ export const phLogger = {
       });
     } catch (telemetryError) {
       console.log(message, { ...fields, telemetryError });
+    }
+  },
+
+  event(name: string, fields: EventFields = {}) {
+    const client = getClient();
+    if (!client) return;
+    try {
+      const { userId, $set, ...rest } = fields;
+      client.capture({
+        distinctId: distinctIdFor(userId),
+        event: name,
+        properties: { ...rest, ...($set && { $set }) },
+      });
+    } catch {
+      // best-effort
     }
   },
 

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -257,6 +257,7 @@ export const checkTokenBucketLimit = async (
               resetTimestamp: monthlyCheck.reset,
               subscription,
               trustCapExceeded: true,
+              capReason: "trust_cap",
             });
           }
 
@@ -265,6 +266,7 @@ export const checkTokenBucketLimit = async (
             throw new ChatSDKError("rate_limit:chat", msg, {
               resetTimestamp: monthlyCheck.reset,
               subscription,
+              capReason: "extra_usage_cap",
             });
           }
 
@@ -292,6 +294,7 @@ export const checkTokenBucketLimit = async (
               subscription,
               autoReloadFailed: true,
               autoReloadFailureReason: reason,
+              capReason: "auto_reload_failed",
             });
           }
 
@@ -299,6 +302,7 @@ export const checkTokenBucketLimit = async (
           throw new ChatSDKError("rate_limit:chat", msg, {
             resetTimestamp: monthlyCheck.reset,
             subscription,
+            capReason: "monthly_exhausted",
           });
         }
 
@@ -307,7 +311,11 @@ export const checkTokenBucketLimit = async (
         throw new ChatSDKError(
           "rate_limit:chat",
           "Extra usage billing is temporarily unavailable. Please try again in a few moments.",
-          { resetTimestamp: monthlyCheck.reset, subscription },
+          {
+            resetTimestamp: monthlyCheck.reset,
+            subscription,
+            capReason: "billing_unavailable",
+          },
         );
       }
 
@@ -317,6 +325,7 @@ export const checkTokenBucketLimit = async (
       throw new ChatSDKError("rate_limit:chat", msg, {
         resetTimestamp: monthlyCheck.reset,
         subscription,
+        capReason: "monthly_exhausted",
       });
     }
 


### PR DESCRIPTION
## Summary

Adds PostHog instrumentation so we can size the monthly-cap-hit cohort and correlate it with upgrades and churn — input data needed to decide whether to build a post-cap daily allowance for paid users.

- New `monthly_cap_hit` event fires from `chat-logger.emitChatError` whenever a paid user is blocked at the cap. Tagged with `cap_reason` (`monthly_exhausted`, `extra_usage_cap`, `trust_cap`, `auto_reload_failed`, `billing_unavailable`), request `mode` (ask/agent), `monthly_remaining_percent`, and `chat_id`.
- New `subscription_changed` event fires per affected user from `customer.subscription.updated`, with `from_tier`, `to_tier`, and `direction` (upgrade/downgrade/lateral).
- New `subscription_cancelled` event fires from a new `customer.subscription.deleted` handler. **Stripe Dashboard endpoint must be subscribed to this event** — events that aren't enabled never reach the handler.
- `subscription_tier` and `last_cap_hit_at` are set as PostHog person properties via `$set` so cohorts can filter active paid users without a separate `identify` call.
- Adds a `phLogger.event(name, fields)` helper for discrete events (separate from the existing `info`/`warn`/`error` log channel) and an `after(() => phLogger.flush())` in the webhook so events ship before the function terminates.

The cap is a single shared bucket across ASK and AGENT modes — there isn't an ASK-only cap. Filtering by `mode = "ask"` in PostHog gets the closest answer to "ASK cap hits".

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all four touched files
- [x] Full Jest suite (935 tests) green via the lint-staged pre-commit hook
- [ ] Verify `monthly_cap_hit` lands in PostHog Live Events with the expected `cap_reason` and `mode` (force a cap by lowering a test paid user's monthly limit, fire requests in both modes)
- [ ] `stripe trigger customer.subscription.updated` with a tier change → `subscription_changed` lands with correct `direction`
- [ ] Enable `customer.subscription.deleted` on the Stripe webhook endpoint, then `stripe trigger customer.subscription.deleted` → `subscription_cancelled` lands and `subscription_tier` flips to `free`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate limit errors now include specific cap reasons for usage cap hits.
  * Subscription tier changes and cancellations are tracked with analytics (including upgrade/downgrade/lateral classification).
  * Chat error logging now emits targeted monthly-cap-hit analytics and updates subscription-related properties.
  * Analytics client extended to record arbitrary events with optional property updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/436)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->