### PR TITLE
Warn base Pro users before selecting HackerAI Max

### DIFF
--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -20,6 +20,16 @@ import {
 } from "@/components/ui/tooltip";
 import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { useState } from "react";
 import type { ChatMode, SelectedModel } from "@/types/chat";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
@@ -33,6 +43,10 @@ import {
   getDefaultModelForMode,
   type ModelOption,
 } from "./ModelSelector/constants";
+import {
+  dismissProMaxUsageNotice,
+  isProMaxUsageNoticeDismissed,
+} from "@/lib/utils/pro-max-notice-cookie";
 
 // ── Shared sub-components ──────────────────────────────────────────
 
@@ -318,11 +332,15 @@ const ModelOptionList = ({
 
 export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
+  const [pendingProMaxNotice, setPendingProMaxNotice] =
+    useState<ModelOption | null>(null);
   const { subscription } = useGlobalState();
   const isMobile = useIsMobile();
 
   const isAuto = value === "auto";
   const isFreeUser = subscription === "free";
+  /** Base Pro tier: Max is flagged as unusually heavy usage vs higher plans. */
+  const isBaseProTier = subscription === "pro";
 
   const options = isAgentMode(mode) ? AGENT_MODEL_OPTIONS : ASK_MODEL_OPTIONS;
 
@@ -348,6 +366,11 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
     onChange(checked ? "auto" : getDefaultModelForMode(mode));
   };
 
+  const applyModelChoice = (option: ModelOption) => {
+    onChange(option.id);
+    setOpen(false);
+  };
+
   const handleModelSelect = (option: ModelOption) => {
     if (isFreeUser) {
       window.location.hash = "pricing";
@@ -355,8 +378,27 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
       return;
     }
 
-    onChange(option.id);
-    setOpen(false);
+    if (
+      isBaseProTier &&
+      option.id === "hackerai-max" &&
+      !isProMaxUsageNoticeDismissed()
+    ) {
+      setPendingProMaxNotice(option);
+      return;
+    }
+
+    applyModelChoice(option);
+  };
+
+  const handleDismissProMaxNotice = () => {
+    setPendingProMaxNotice(null);
+  };
+
+  const handleConfirmProMax = () => {
+    if (!pendingProMaxNotice) return;
+    dismissProMaxUsageNotice();
+    applyModelChoice(pendingProMaxNotice);
+    setPendingProMaxNotice(null);
   };
 
   const trigger = (
@@ -373,10 +415,38 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
     </Button>
   );
 
+  const maxUsageNoticeDialog = (
+    <AlertDialog
+      open={pendingProMaxNotice !== null}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) handleDismissProMaxNotice();
+      }}
+    >
+      <AlertDialogContent className="sm:max-w-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Higher usage</AlertDialogTitle>
+          <AlertDialogDescription className="text-left">
+            HackerAI Max uses quota much faster than Standard or Pro. One long
+            task can use much of what&apos;s included on Pro.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={handleDismissProMaxNotice}>
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirmProMax}>
+            Continue
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+
   if (isMobile) {
     return (
       <>
         {trigger}
+        {maxUsageNoticeDialog}
         <Sheet open={open} onOpenChange={setOpen}>
           <SheetContent
             side="bottom"
@@ -406,20 +476,23 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-      <PopoverContent className="w-[270px] p-1.5 rounded-xl" align="start">
-        <ModelOptionList
-          options={options}
-          value={effectiveValue}
-          isAuto={isAuto}
-          isFreeUser={isFreeUser}
-          mode={mode}
-          onAutoToggle={handleAutoToggle}
-          onSelect={handleModelSelect}
-          onClose={() => setOpen(false)}
-        />
-      </PopoverContent>
-    </Popover>
+    <>
+      {maxUsageNoticeDialog}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+        <PopoverContent className="w-[270px] p-1.5 rounded-xl" align="start">
+          <ModelOptionList
+            options={options}
+            value={effectiveValue}
+            isAuto={isAuto}
+            isFreeUser={isFreeUser}
+            mode={mode}
+            onAutoToggle={handleAutoToggle}
+            onSelect={handleModelSelect}
+            onClose={() => setOpen(false)}
+          />
+        </PopoverContent>
+      </Popover>
+    </>
   );
 }

--- a/lib/utils/__tests__/pro-max-notice-cookie.test.ts
+++ b/lib/utils/__tests__/pro-max-notice-cookie.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "@jest/globals";
+import { isProMaxUsageNoticeDismissedFromCookieHeader } from "../pro-max-notice-cookie";
+
+describe("pro-max-notice-cookie", () => {
+  describe("isProMaxUsageNoticeDismissedFromCookieHeader", () => {
+    it("returns false when empty", () => {
+      expect(isProMaxUsageNoticeDismissedFromCookieHeader("")).toBe(false);
+    });
+
+    it("returns true when the ack cookie appears first", () => {
+      expect(
+        isProMaxUsageNoticeDismissedFromCookieHeader(
+          "hackerai_pro_max_usage_ack=1",
+        ),
+      ).toBe(true);
+    });
+
+    it("returns true when the ack cookie follows another cookie", () => {
+      expect(
+        isProMaxUsageNoticeDismissedFromCookieHeader(
+          "sidebar=open; hackerai_pro_max_usage_ack=1",
+        ),
+      ).toBe(true);
+    });
+
+    it("does not match a prefixed cookie name substring", () => {
+      expect(
+        isProMaxUsageNoticeDismissedFromCookieHeader(
+          "evil_hackerai_pro_max_usage_ack=1",
+        ),
+      ).toBe(false);
+    });
+
+    it("requires value 1", () => {
+      expect(
+        isProMaxUsageNoticeDismissedFromCookieHeader(
+          "hackerai_pro_max_usage_ack=0",
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/lib/utils/pro-max-notice-cookie.ts
+++ b/lib/utils/pro-max-notice-cookie.ts
@@ -1,0 +1,22 @@
+const COOKIE_NAME = "hackerai_pro_max_usage_ack";
+
+/** Long-lived dismissal; informational only (not auth). */
+const MAX_AGE_SEC = 60 * 60 * 24 * 365 * 5;
+
+/**
+ * Parses a `document.cookie`-style header so logic is testable without DOM.
+ */
+export const isProMaxUsageNoticeDismissedFromCookieHeader = (
+  cookieHeader: string,
+): boolean =>
+  new RegExp(`(?:^|;\\s*)${COOKIE_NAME}=1(?:;|$)`).test(cookieHeader);
+
+export const isProMaxUsageNoticeDismissed = (): boolean => {
+  if (typeof document === "undefined") return false;
+  return isProMaxUsageNoticeDismissedFromCookieHeader(document.cookie);
+};
+
+export const dismissProMaxUsageNotice = (): void => {
+  if (typeof document === "undefined") return;
+  document.cookie = `${COOKIE_NAME}=1; path=/; max-age=${MAX_AGE_SEC}; SameSite=Lax`;
+};


### PR DESCRIPTION
## Summary
- Show a short `AlertDialog` the first time a base **Pro** user picks **HackerAI Max** in the model selector, warning that quota can be consumed quickly and a single long task may use most of what's included on Pro.
- Persist dismissal in a long-lived first-party cookie (`hackerai_pro_max_usage_ack=1`, `path=/`, `SameSite=Lax`, ~5y) so the dialog appears at most once per browser.
- Higher tiers (Pro Plus, Ultra, Team) and free users are unaffected.
- Cookie helpers extracted to `lib/utils/pro-max-notice-cookie.ts` with a pure header-parsing helper for tests.

## Files
- `app/components/ModelSelector.tsx` — intercept Max selection on base Pro, render the dialog, gate on the cookie.
- `lib/utils/pro-max-notice-cookie.ts` — `isProMaxUsageNoticeDismissed`, `dismissProMaxUsageNotice`, plus a header-parsing helper for tests.
- `lib/utils/__tests__/pro-max-notice-cookie.test.ts` — covers empty header, first/other position, prefix collision, wrong value.

## Test plan
- [x] `pnpm test` — full suite passes locally (940 tests).
- [ ] Manual: as a **Pro** user, open the model selector → pick **HackerAI Max** → confirm dialog appears, **Cancel** keeps current model and dialog reappears next time, **Continue** selects Max and dialog never appears again on that browser.
- [ ] Manual: as **Pro Plus / Ultra / Team / free**, picking Max behaves exactly as before (no dialog).
- [ ] Manual: clearing site cookies brings the notice back.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pro users will now see a usage notice dialog when selecting the premium model tier. The dialog can be confirmed or dismissed, and won't reappear after dismissal.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/438)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->