### PR TITLE
Default to agent mode when a local sandbox is connected

### DIFF
--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -115,16 +115,15 @@ export const ChatInput = ({
     prevHasLocalSandboxRef.current = hasLocalSandbox;
 
     if (!isFreeAgent) return;
-    // Only show toast on actual disconnect (true → false), not on
-    // initial mount or logout where hasLocalSandbox starts as false.
-    if (!hasLocalSandbox) {
+    // Only force-switch on a real disconnect (true → false). On initial mount the
+    // Convex query is still loading and hasLocalSandbox is transiently false —
+    // flipping mode here would clobber the saved "agent" preference.
+    if (!hasLocalSandbox && wasConnected) {
       setChatMode("ask");
-      if (wasConnected) {
-        toast.info("Local sandbox disconnected. Switched to Ask mode.", {
-          description: "Reconnect your sandbox to use Agent mode.",
-          duration: 5000,
-        });
-      }
+      toast.info("Local sandbox disconnected. Switched to Ask mode.", {
+        description: "Reconnect your sandbox to use Agent mode.",
+        duration: 5000,
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFreeAgent, hasLocalSandbox]);

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -18,7 +18,6 @@ import {
   type QueuedMessage,
   type QueueBehavior,
   type SandboxPreference,
-  isChatMode,
 } from "@/types/chat";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import type { Todo } from "@/types";
@@ -174,11 +173,12 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   const prevIsMobile = useRef(isMobile);
   const [input, setInput] = useState("");
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFileState[]>([]);
-  const [chatMode, setChatMode] = useState<ChatMode>(() => {
-    const saved = readChatMode();
-    if (!isChatMode(saved)) return "ask";
-    return saved;
-  });
+  const [chatMode, setChatMode] = useState<ChatMode>(
+    () => readChatMode() ?? "ask",
+  );
+  // Whether a saved preference existed at mount — gates the auto-agent default below.
+  const [hadSavedChatModePref] = useState(() => readChatMode() !== null);
+  const autoAgentModeAppliedRef = useRef(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sidebarContent, setSidebarContent] = useState<SidebarContent | null>(
     null,
@@ -252,6 +252,16 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
       if (firstDesktop) return "desktop";
       return null;
     }, [desktopBridgeActive, localConnections]);
+
+  // First-time agent default when a local sandbox is available; never overrides a saved choice.
+  useEffect(() => {
+    if (autoAgentModeAppliedRef.current) return;
+    if (hadSavedChatModePref) return;
+    if (!hasLocalSandbox) return;
+    autoAgentModeAppliedRef.current = true;
+    setChatMode("agent");
+    toast("Agent mode enabled — local machine connected");
+  }, [hasLocalSandbox, hadSavedChatModePref]);
 
   // Persist queue behavior to localStorage
   useEffect(() => {

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -184,8 +184,15 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     null,
   );
 
-  // Persist chat mode preference to localStorage on change
+  // Persist chat mode preference to localStorage on change.
+  // Skip the initial-mount write so the fallback "ask" doesn't get committed
+  // before the auto-agent-mode effect (below) has a chance to fire.
+  const isInitialChatModePersistRef = useRef(true);
   useEffect(() => {
+    if (isInitialChatModePersistRef.current) {
+      isInitialChatModePersistRef.current = false;
+      return;
+    }
     writeChatMode(chatMode);
   }, [chatMode]);
 


### PR DESCRIPTION
## Summary
- New users with a local sandbox (Tauri desktop bridge or a remote connection registered via `localSandbox.listConnections`) are auto-switched from "ask" to "agent" on first mount.
- A one-time toast ("Agent mode enabled — local machine connected") surfaces the switch so the change doesn't feel like silent state mutation.
- An explicit prior preference in `localStorage` (including a user who deliberately picked "ask") is always respected, and the auto-switch is guarded by a ref so it never fires twice or overrides a mid-session manual change.

## Test plan
- [ ] Fresh profile / `localStorage.removeItem("chat_mode")` with a local connection running → app opens in **Agent** mode and the toast appears.
- [ ] Fresh profile with no local connection → app opens in **Ask** mode (no toast); connecting a machine mid-session flips to Agent once and only once.
- [ ] Existing user with `chat_mode = "ask"` saved → stays in Ask even when a local connection is present.
- [ ] Auto-switched user toggles back to Ask manually → stays in Ask for the rest of the session and on next reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App can automatically enable agent mode when a local sandbox becomes available and no saved chat-mode preference exists; users see a notification when this auto-activation runs.

* **Bug Fixes**
  * Prevents spurious mode switches and notifications on transient/initial sandbox connection states so mode only changes on real disconnects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/442)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->