### PR TITLE
Debug: log agent-long Convex URL and listConnections result

### DIFF
--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -46,6 +46,7 @@ export class HybridSandboxManager implements SandboxManager {
   private currentConnectionId: string | null = null;
   private currentConnectionName: string | null = null;
   private convex: ConvexHttpClient;
+  private convexUrl: string;
   private pendingFallbackInfo: SandboxFallbackInfo | null = null;
   private healthFailureCount = 0;
   private sandboxUnavailable = false;
@@ -64,7 +65,13 @@ export class HybridSandboxManager implements SandboxManager {
     if (!convexUrl) {
       throw new Error("NEXT_PUBLIC_CONVEX_URL environment variable is not set");
     }
+    this.convexUrl = convexUrl;
     this.convex = new ConvexHttpClient(convexUrl);
+    console.log("[agent-long-convex-debug] HybridSandboxManager constructed", {
+      userID,
+      sandboxPreference,
+      capturedConvexUrl: convexUrl,
+    });
   }
 
   recordHealthFailure(): boolean {
@@ -191,9 +198,19 @@ export class HybridSandboxManager implements SandboxManager {
           userId: this.userID,
         },
       );
+      console.log("[agent-long-convex-debug] listConnections result", {
+        userID: this.userID,
+        queriedConvexUrl: this.convexUrl,
+        connectionCount: connections.length,
+        connectionIds: connections.map((c) => c.connectionId),
+      });
       return connections;
     } catch (error) {
-      console.error(`[${this.userID}] Failed to list connections:`, error);
+      console.error("[agent-long-convex-debug] listConnections error", {
+        userID: this.userID,
+        queriedConvexUrl: this.convexUrl,
+        error: error instanceof Error ? error.message : String(error),
+      });
       return [];
     }
   }

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -233,8 +233,18 @@ export const agentLongTask = task({
     // Point the Convex client at the correct per-branch preview deployment.
     // NEXT_PUBLIC_CONVEX_URL in Trigger.dev's env vars only reflects the
     // main deployment; preview branches each have their own Convex URL.
+    console.log("[agent-long-convex-debug] task start", {
+      chatId: payload.chatId,
+      userId: payload.userId,
+      envNextPublicConvexUrl: process.env.NEXT_PUBLIC_CONVEX_URL,
+      payloadConvexUrl: payload.convexUrl,
+      sandboxPreference: payload.sandboxPreference,
+    });
     if (payload.convexUrl) {
       setConvexUrl(payload.convexUrl);
+      console.log("[agent-long-convex-debug] setConvexUrl applied", {
+        appliedUrl: payload.convexUrl,
+      });
     }
 
     const {


### PR DESCRIPTION
## Summary

- Adds prefixed `[agent-long-convex-debug]` logs at three points so we can confirm (or rule out) the Convex URL mismatch hypothesis when agent-long tools come back with blank output on trigger.dev cloud.
- Logs only; no behavior change. Plan to revert once we have the data.

## Logs added

- `trigger/agent-long.ts`: `process.env.NEXT_PUBLIC_CONVEX_URL` and `payload.convexUrl` at task start, plus confirmation when `setConvexUrl()` runs.
- `HybridSandboxManager` constructor: `capturedConvexUrl` (the value the sandbox-lookup client is bound to for its lifetime — the one we suspect is stale).
- `HybridSandboxManager.listConnections()`: connection count + connectionIds on success, error message on failure, alongside the URL queried.

## How to read the output

Deploy this branch, trigger an agent-long run with the desktop sandbox connected, then grep trigger.dev logs for `agent-long-convex-debug`. Expected lines:

1. `task start` — compare `envNextPublicConvexUrl` vs `payloadConvexUrl`. If they differ, that's the smoking gun.
2. `setConvexUrl applied` — confirms the override ran.
3. `HybridSandboxManager constructed` — `capturedConvexUrl` is what the lookup actually queries.
4. `listConnections result` — `connectionCount: 0` confirms the wrong-deployment theory; non-zero but tools still blank means the bug is elsewhere.

## Test plan

- [ ] Deploy preview, trigger agent-long with desktop sandbox, capture the four log lines.
- [ ] Repeat on production deploy.
- [ ] Revert this branch once we've used the data to land a real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced internal logging and debugging capabilities for improved system monitoring and troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/445)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->