### PR TITLE
Share Convex client across Trigger.dev task so payload URL flips every caller

### DIFF
--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -8,7 +8,7 @@ import type {
 import { CentrifugoSandbox, type CentrifugoConfig } from "./centrifugo-sandbox";
 import { isCentrifugoSandbox, type ConnectionInfo } from "./sandbox-types";
 import { ensureSandboxConnection } from "./sandbox";
-import { ConvexHttpClient } from "convex/browser";
+import { getConvexClient } from "@/lib/db/convex-client";
 import { api } from "@/convex/_generated/api";
 import { SANDBOX_ENVIRONMENT_TOOLS } from "./sandbox-tools";
 import { getPlatformDisplayName } from "./platform-utils";
@@ -45,7 +45,6 @@ export class HybridSandboxManager implements SandboxManager {
   private isLocal = false;
   private currentConnectionId: string | null = null;
   private currentConnectionName: string | null = null;
-  private convex: ConvexHttpClient;
   private pendingFallbackInfo: SandboxFallbackInfo | null = null;
   private healthFailureCount = 0;
   private sandboxUnavailable = false;
@@ -60,11 +59,6 @@ export class HybridSandboxManager implements SandboxManager {
     private onBoot?: (info: SandboxBootInfo) => void,
   ) {
     this.sandbox = initialSandbox || null;
-    const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
-    if (!convexUrl) {
-      throw new Error("NEXT_PUBLIC_CONVEX_URL environment variable is not set");
-    }
-    this.convex = new ConvexHttpClient(convexUrl);
   }
 
   recordHealthFailure(): boolean {
@@ -184,7 +178,7 @@ export class HybridSandboxManager implements SandboxManager {
    */
   async listConnections(): Promise<ConnectionInfo[]> {
     try {
-      const connections = await this.convex.query(
+      const connections = await getConvexClient().query(
         api.localSandbox.listConnectionsForBackend,
         {
           serviceKey: this.serviceKey,

--- a/lib/ai/tools/utils/sandbox-file-uploader.ts
+++ b/lib/ai/tools/utils/sandbox-file-uploader.ts
@@ -1,12 +1,12 @@
 import "server-only";
 
-import { ConvexHttpClient } from "convex/browser";
 import { ConvexError } from "convex/values";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
 import type { AnySandbox } from "@/types";
 import { isE2BSandbox } from "./sandbox-types";
 import { generateS3UploadUrl } from "@/convex/s3Utils";
+import { getConvexClient } from "@/lib/db/convex-client";
 
 const DEFAULT_MEDIA_TYPE = "application/octet-stream";
 
@@ -20,14 +20,6 @@ export type UploadedFileInfo = {
   s3Key?: string;
   storageId?: Id<"_storage">;
 };
-
-let convexClient: ConvexHttpClient | null = null;
-function getConvexClient(): ConvexHttpClient {
-  if (!convexClient) {
-    convexClient = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
-  }
-  return convexClient;
-}
 
 /**
  * Extract error message from ConvexError or regular Error

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { api } from "@/convex/_generated/api";
 import { ChatSDKError } from "../errors";
-import { ConvexHttpClient } from "convex/browser";
+import { getConvexClient, setConvexUrl } from "./convex-client";
 import { UIMessage, UIMessagePart } from "ai";
 import { extractFileIdsFromParts } from "@/lib/utils/file-token-utils";
 import {
@@ -22,18 +22,13 @@ import { v4 as uuidv4 } from "uuid";
 import { AGENT_RESUME_PREAMBLE } from "@/lib/chat/summarization/prompts";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 
-let convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL ?? "");
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 
-// Called by Trigger.dev tasks to point at the correct per-branch preview deployment.
-// Each task run is an isolated worker process so mutation is safe.
-export function setConvexUrl(url: string) {
-  convex = new ConvexHttpClient(url);
-}
+export { setConvexUrl };
 
 export async function getChatById({ id }: { id: string }) {
   try {
-    const selectedChat = await convex.query(api.chats.getChatById, {
+    const selectedChat = await getConvexClient().query(api.chats.getChatById, {
       serviceKey,
       id,
     });
@@ -53,7 +48,7 @@ export async function saveChat({
   title: string;
 }) {
   try {
-    return await convex.mutation(api.chats.saveChat, {
+    return await getConvexClient().mutation(api.chats.saveChat, {
       serviceKey,
       id,
       userId,
@@ -104,7 +99,7 @@ export async function saveMessage({
       ...((extraFileIds || []).filter(Boolean) as string[]),
     ];
 
-    return await convex.mutation(api.messages.saveMessage, {
+    return await getConvexClient().mutation(api.messages.saveMessage, {
       serviceKey,
       id: message.id,
       chatId,
@@ -213,7 +208,7 @@ export async function updateChat({
   selectedModel?: string;
 }) {
   try {
-    return await convex.mutation(api.chats.updateChat, {
+    return await getConvexClient().mutation(api.chats.updateChat, {
       serviceKey,
       chatId,
       title,
@@ -282,12 +277,15 @@ export async function getMessagesByChatId({
             page: UIMessage[];
             isDone: boolean;
             continueCursor: string | null;
-          } = await convex.query(api.messages.getMessagesPageForBackend, {
-            serviceKey,
-            chatId,
-            userId,
-            paginationOpts: { numItems: PAGE_SIZE, cursor },
-          });
+          } = await getConvexClient().query(
+            api.messages.getMessagesPageForBackend,
+            {
+              serviceKey,
+              chatId,
+              userId,
+              paginationOpts: { numItems: PAGE_SIZE, cursor },
+            },
+          );
           const { page, isDone, continueCursor: nextCursor } = pageResult;
 
           fetchedDesc = fetchedDesc.concat(page);
@@ -503,7 +501,7 @@ export async function getMessagesByChatId({
 
 export async function getUserCustomization({ userId }: { userId: string }) {
   try {
-    const userCustomization = await convex.query(
+    const userCustomization = await getConvexClient().query(
       api.userCustomization.getUserCustomizationForBackend,
       {
         serviceKey,
@@ -527,7 +525,7 @@ export async function setActiveTriggerRun({
   expectedRunId?: string;
 }) {
   try {
-    await convex.mutation(api.chats.setActiveTriggerRun, {
+    await getConvexClient().mutation(api.chats.setActiveTriggerRun, {
       serviceKey,
       chatId,
       triggerRunId,
@@ -543,7 +541,7 @@ export async function setActiveTriggerRun({
 
 export async function getActiveTriggerRun({ chatId }: { chatId: string }) {
   try {
-    return await convex.query(api.chats.getActiveTriggerRun, {
+    return await getConvexClient().query(api.chats.getActiveTriggerRun, {
       serviceKey,
       chatId,
     });
@@ -560,7 +558,7 @@ export async function startStream({
   streamId: string;
 }) {
   try {
-    await convex.mutation(api.chatStreams.startStream, {
+    await getConvexClient().mutation(api.chatStreams.startStream, {
       serviceKey,
       chatId,
       streamId,
@@ -573,7 +571,7 @@ export async function startStream({
 
 export async function prepareForNewStream({ chatId }: { chatId: string }) {
   try {
-    await convex.mutation(api.chatStreams.prepareForNewStream, {
+    await getConvexClient().mutation(api.chatStreams.prepareForNewStream, {
       serviceKey,
       chatId,
     });
@@ -588,10 +586,13 @@ export async function prepareForNewStream({ chatId }: { chatId: string }) {
 
 export async function getCancellationStatus({ chatId }: { chatId: string }) {
   try {
-    const status = await convex.query(api.chatStreams.getCancellationStatus, {
-      serviceKey,
-      chatId,
-    });
+    const status = await getConvexClient().query(
+      api.chatStreams.getCancellationStatus,
+      {
+        serviceKey,
+        chatId,
+      },
+    );
     return status;
   } catch (error) {
     // Silently return null on error for cancellation checks
@@ -608,7 +609,7 @@ export async function startTempStream({
   userId: string;
 }) {
   try {
-    await convex.mutation(api.tempStreams.startTempStream, {
+    await getConvexClient().mutation(api.tempStreams.startTempStream, {
       serviceKey,
       chatId,
       userId,
@@ -624,10 +625,13 @@ export async function getTempCancellationStatus({
   chatId: string;
 }) {
   try {
-    return await convex.query(api.tempStreams.getTempCancellationStatus, {
-      serviceKey,
-      chatId,
-    });
+    return await getConvexClient().query(
+      api.tempStreams.getTempCancellationStatus,
+      {
+        serviceKey,
+        chatId,
+      },
+    );
   } catch (error) {
     return null;
   }
@@ -639,10 +643,13 @@ export async function deleteTempStreamForBackend({
   chatId: string;
 }) {
   try {
-    await convex.mutation(api.tempStreams.deleteTempStreamForBackend, {
-      serviceKey,
-      chatId,
-    });
+    await getConvexClient().mutation(
+      api.tempStreams.deleteTempStreamForBackend,
+      {
+        serviceKey,
+        chatId,
+      },
+    );
   } catch (error) {
     // Best-effort cleanup
   }
@@ -658,7 +665,7 @@ export async function saveChatSummary({
   summaryUpToMessageId: string;
 }) {
   try {
-    await convex.mutation(api.chats.saveLatestSummary, {
+    await getConvexClient().mutation(api.chats.saveLatestSummary, {
       serviceKey,
       chatId,
       summaryText,
@@ -687,10 +694,13 @@ export async function saveChatSummary({
 
 export async function getLatestSummary({ chatId }: { chatId: string }) {
   try {
-    const summary = await convex.query(api.chats.getLatestSummaryForBackend, {
-      serviceKey,
-      chatId,
-    });
+    const summary = await getConvexClient().query(
+      api.chats.getLatestSummaryForBackend,
+      {
+        serviceKey,
+        chatId,
+      },
+    );
     return summary;
   } catch (error) {
     console.error("[DB Actions] Failed to get latest summary:", error);
@@ -716,14 +726,17 @@ export async function createNote({
   tags?: string[];
 }) {
   try {
-    const result = await convex.mutation(api.notes.createNoteForBackend, {
-      serviceKey,
-      userId,
-      title,
-      content,
-      category,
-      tags,
-    });
+    const result = await getConvexClient().mutation(
+      api.notes.createNoteForBackend,
+      {
+        serviceKey,
+        userId,
+        title,
+        content,
+        category,
+        tags,
+      },
+    );
     return result;
   } catch (error) {
     throw new ChatSDKError(
@@ -745,13 +758,16 @@ export async function listNotes({
   search?: string;
 }) {
   try {
-    const result = await convex.query(api.notes.listNotesForBackend, {
-      serviceKey,
-      userId,
-      category,
-      tags,
-      search,
-    });
+    const result = await getConvexClient().query(
+      api.notes.listNotesForBackend,
+      {
+        serviceKey,
+        userId,
+        category,
+        tags,
+        search,
+      },
+    );
     return result;
   } catch (error) {
     throw new ChatSDKError(
@@ -775,14 +791,17 @@ export async function updateNote({
   tags?: string[];
 }) {
   try {
-    const result = await convex.mutation(api.notes.updateNoteForBackend, {
-      serviceKey,
-      userId,
-      noteId,
-      title,
-      content,
-      tags,
-    });
+    const result = await getConvexClient().mutation(
+      api.notes.updateNoteForBackend,
+      {
+        serviceKey,
+        userId,
+        noteId,
+        title,
+        content,
+        tags,
+      },
+    );
     return result;
   } catch (error) {
     throw new ChatSDKError(
@@ -800,11 +819,14 @@ export async function deleteNote({
   noteId: string;
 }) {
   try {
-    const result = await convex.mutation(api.notes.deleteNoteForBackend, {
-      serviceKey,
-      userId,
-      noteId,
-    });
+    const result = await getConvexClient().mutation(
+      api.notes.deleteNoteForBackend,
+      {
+        serviceKey,
+        userId,
+        noteId,
+      },
+    );
     return result;
   } catch (error) {
     throw new ChatSDKError(
@@ -822,7 +844,7 @@ export async function getNotes({
   subscription: SubscriptionTier;
 }) {
   try {
-    const notes = await convex.query(api.notes.getNotesForBackend, {
+    const notes = await getConvexClient().query(api.notes.getNotesForBackend, {
       serviceKey,
       userId,
       subscription,
@@ -856,7 +878,7 @@ export async function logUsageRecord({
   costDollars: number;
 }) {
   try {
-    await convex.mutation(api.usageLogs.logUsage, {
+    await getConvexClient().mutation(api.usageLogs.logUsage, {
       serviceKey,
       user_id: userId,
       model,

--- a/lib/db/convex-client.ts
+++ b/lib/db/convex-client.ts
@@ -1,0 +1,32 @@
+import { ConvexHttpClient } from "convex/browser";
+
+// Shared singleton so Trigger.dev's setConvexUrl() override reaches every
+// caller. Lazy-init the client so this module is safe to import from code
+// paths that Convex's deploy bundler analyzes (e.g.
+// convex/rateLimitStatus → lib/rate-limit/token-bucket → lib/extra-usage);
+// constructing ConvexHttpClient eagerly with the empty URL the analyzer
+// sees would fail validation and break `convex deploy`.
+
+let client: ConvexHttpClient | null = null;
+let overrideUrl: string | undefined;
+
+export function getConvexClient(): ConvexHttpClient {
+  if (!client) {
+    const url = overrideUrl ?? process.env.NEXT_PUBLIC_CONVEX_URL;
+    if (!url) {
+      throw new Error("NEXT_PUBLIC_CONVEX_URL is not set");
+    }
+    client = new ConvexHttpClient(url);
+  }
+  return client;
+}
+
+// Called by Trigger.dev tasks to point at the correct per-branch preview
+// deployment. The Trigger.dev process's NEXT_PUBLIC_CONVEX_URL only reflects
+// what the dashboard has configured, so the route forwards the right URL via
+// the task payload and the task calls this. Each Trigger.dev run is an
+// isolated worker process so mutation is safe.
+export function setConvexUrl(url: string) {
+  overrideUrl = url;
+  client = new ConvexHttpClient(url);
+}

--- a/lib/extra-usage.ts
+++ b/lib/extra-usage.ts
@@ -1,5 +1,5 @@
 import { POINTS_PER_DOLLAR } from "@/lib/rate-limit/token-bucket";
-import { ConvexHttpClient } from "convex/browser";
+import { getConvexClient } from "@/lib/db/convex-client";
 import { api } from "@/convex/_generated/api";
 
 /** Extra usage pricing multiplier */
@@ -49,7 +49,7 @@ export async function getExtraUsageBalance(
   userId: string,
 ): Promise<ExtraUsageBalance | null> {
   try {
-    const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+    const convex = getConvexClient();
     const settings = await convex.query(
       api.extraUsage.getExtraUsageBalanceForBackend,
       {
@@ -110,7 +110,7 @@ export async function refundToBalance(
   }
 
   try {
-    const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+    const convex = getConvexClient();
 
     const result = await convex.mutation(api.extraUsage.refundPoints, {
       serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
@@ -157,7 +157,7 @@ export async function deductFromBalance(
   }
 
   try {
-    const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+    const convex = getConvexClient();
 
     // Use the Convex action that handles deduction + auto-reload internally
     // Pass points directly to avoid precision loss from dollar conversion

--- a/lib/utils/file-token-utils.ts
+++ b/lib/utils/file-token-utils.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { api } from "@/convex/_generated/api";
-import { ConvexHttpClient } from "convex/browser";
+import { getConvexClient } from "@/lib/db/convex-client";
 import { UIMessagePart, UIMessage } from "ai";
 import { Id } from "@/convex/_generated/dataModel";
 import {
@@ -10,8 +10,6 @@ import {
 } from "@/lib/token-utils";
 import type { SubscriptionTier } from "@/types";
 import type { FileMessagePart } from "@/types/file";
-
-const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
 /**
  * Type guard to check if a message part is a file part
@@ -40,10 +38,13 @@ export const getFileTokensByIds = async (
   if (!fileIds.length) return {};
 
   try {
-    const tokens = await convex.query(api.fileStorage.getFileTokensByFileIds, {
-      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
-      fileIds,
-    });
+    const tokens = await getConvexClient().query(
+      api.fileStorage.getFileTokensByFileIds,
+      {
+        serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+        fileIds,
+      },
+    );
 
     return Object.fromEntries(
       fileIds.map((id, i) => [id, tokens[i] || 0]),

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { api } from "@/convex/_generated/api";
-import { ConvexHttpClient } from "convex/browser";
+import { getConvexClient } from "@/lib/db/convex-client";
 import { UIMessage } from "ai";
 import type { ChatMode, FileContent } from "@/types";
 import { Id } from "@/convex/_generated/dataModel";
@@ -12,7 +12,6 @@ import { extractAllFileIdsFromMessages, isFilePart } from "./file-token-utils";
 import { getMaxFileTokens } from "../token-utils";
 import type { SubscriptionTier } from "@/types";
 
-const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 
 const containsPdfAttachments = (messages: UIMessage[]): boolean =>
@@ -135,10 +134,13 @@ const fetchFileUrls = async (fileIds: string[]): Promise<(string | null)[]> => {
   if (!fileIds.length) return [];
 
   try {
-    return await convex.action(api.s3Actions.getFileUrlsByFileIdsAction, {
-      serviceKey,
-      fileIds: fileIds as Id<"files">[],
-    });
+    return await getConvexClient().action(
+      api.s3Actions.getFileUrlsByFileIdsAction,
+      {
+        serviceKey,
+        fileIds: fileIds as Id<"files">[],
+      },
+    );
   } catch (error) {
     console.error("Failed to fetch file URLs:", {
       error: error instanceof Error ? error.message : String(error),
@@ -345,7 +347,7 @@ const addDocumentContentToMessages = async (
   if (!fileIds.length || !messages.length) return;
 
   try {
-    const fileContents = await convex.query(
+    const fileContents = await getConvexClient().query(
       api.fileStorage.getFileContentByFileIds,
       { serviceKey, fileIds },
     );

--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -8,7 +8,10 @@ if (process.env.NODE_ENV !== "production") {
 
 export default defineConfig({
   project: process.env.TRIGGER_PROJECT_ID!,
-  runtime: "node",
+  // centrifuge-js relies on globalThis.WebSocket, which is only stable on
+  // Node 22+. The default "node" runtime is older and would throw
+  // "WebSocket constructor not found" when CentrifugoSandbox connects.
+  runtime: "node-22",
   logLevel: "log",
   // Up to one hour per agent-long run.
   maxDuration: 3600,


### PR DESCRIPTION
## Summary

Logs from #445 confirmed the diagnosis exactly:

\`\`\`
[agent-long-convex-debug] task start
  envNextPublicConvexUrl: 'https://diligent-blackbird-710.convex.cloud'
  payloadConvexUrl:       'https://descriptive-boar-542.convex.cloud'

[agent-long-convex-debug] setConvexUrl applied
  appliedUrl: 'https://descriptive-boar-542.convex.cloud'

[agent-long-convex-debug] HybridSandboxManager constructed
  capturedConvexUrl: 'https://diligent-blackbird-710.convex.cloud'   ← stale

[agent-long-convex-debug] listConnections result
  queriedConvexUrl: 'https://diligent-blackbird-710.convex.cloud'
  connectionCount: 0
\`\`\`

Tool output came back as \`{"type":"tool-output-available", ..., "output":{}}\`.

\`setConvexUrl()\` only flipped \`actions.ts\`'s local closure. \`HybridSandboxManager\`, \`file-token-utils\`, \`file-transform-utils\`, \`sandbox-file-uploader\`, and \`extra-usage\` each kept their own \`ConvexHttpClient\` bound to whatever the Trigger.dev process loaded at module init, which doesn't match the per-branch URL the route forwards.

## Fix

- Centralize the client in \`lib/db/convex-client.ts\` and route every caller through \`getConvexClient()\` so \`setConvexUrl(payload.convexUrl)\` flips them all.
- \`actions.ts\` re-exports \`setConvexUrl\` so \`trigger/agent-long.ts\`'s existing import keeps working.
- Lazy-init the client (no eager \`new ConvexHttpClient\` at module load) and skip \`import \"server-only\"\`. Convex's deploy bundler reaches this file via \`convex/rateLimitStatus → lib/rate-limit/token-bucket → lib/extra-usage\`; eager construction with the analyzer's empty \`NEXT_PUBLIC_CONVEX_URL\` fails validation in convex 1.37+, and \`server-only\` is unresolvable in that bundle context. Lazy + no server-only keeps \`convex deploy\` clean.
- Route handlers under \`app/api/*\` keep their own clients — they run in Next.js where the env is already correct.

## Why my last attempt broke

The previous PR (#444, closed) added \`import \"server-only\"\` to the shared module, which got pulled into the Convex deploy bundle via the rate-limit chain and broke \`convex deploy\`. This time I verified locally that \`npx convex codegen\` succeeds.

## Test plan

- [x] \`npx convex codegen\` runs without \`InvalidModules\`.
- [x] \`tsc --noEmit\` and \`jest\` pass.
- [ ] Deploy to preview, trigger agent-long with desktop sandbox connected, verify tool output renders and \`listConnections result\` shows the right URL + non-zero connectionCount.
- [ ] Repeat on production deploy.
- [ ] Close PR #445 (debug logs) once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized database client usage across the app by introducing a shared client helper, simplifying how services obtain the remote data client.

* **Chores**
  * Updated runtime to Node 22 to ensure stable WebSocket support for sandboxed/runtime tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/446)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->