### PR TITLE
Allow trigger.dev realtime endpoints in desktop CSP

### DIFF
--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' http://localhost:* https://hackerai.co https://*.hackerai.co https://*.convex.cloud https://*.convex.dev https://auth.hackerai.co https://api.workos.com; script-src 'self' 'unsafe-inline' http://localhost:* https://hackerai.co https://*.hackerai.co https://*.convex.cloud; style-src 'self' 'unsafe-inline' http://localhost:* https://hackerai.co https://*.hackerai.co; img-src 'self' data: https: blob:; font-src 'self' data: https:; connect-src 'self' http://localhost:* ws://localhost:* http://127.0.0.1:* https://hackerai.co https://*.hackerai.co wss://*.hackerai.co https://*.convex.cloud wss://*.convex.cloud https://auth.hackerai.co https://api.workos.com https://*.posthog.com https://*.stripe.com; frame-src 'self' https://*.stripe.com; media-src 'self' blob:;"
+      "csp": "default-src 'self' http://localhost:* https://hackerai.co https://*.hackerai.co https://*.convex.cloud https://*.convex.dev https://auth.hackerai.co https://api.workos.com; script-src 'self' 'unsafe-inline' http://localhost:* https://hackerai.co https://*.hackerai.co https://*.convex.cloud; style-src 'self' 'unsafe-inline' http://localhost:* https://hackerai.co https://*.hackerai.co; img-src 'self' data: https: blob:; font-src 'self' data: https:; connect-src 'self' http://localhost:* ws://localhost:* http://127.0.0.1:* https://hackerai.co https://*.hackerai.co wss://*.hackerai.co https://*.convex.cloud wss://*.convex.cloud https://auth.hackerai.co https://api.workos.com https://*.posthog.com https://*.stripe.com https://api.trigger.dev https://*.trigger.dev wss://*.trigger.dev; frame-src 'self' https://*.stripe.com; media-src 'self' blob:;"
     }
   },
   "bundle": {

--- a/packages/desktop/src-tauri/tauri.dev.conf.json
+++ b/packages/desktop/src-tauri/tauri.dev.conf.json
@@ -5,7 +5,7 @@
   },
   "app": {
     "security": {
-      "csp": "default-src 'self' http://localhost:3000 https://hackerai.co https://*.hackerai.co https://*.convex.cloud https://*.convex.dev https://auth.hackerai.co https://api.workos.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:3000 https://hackerai.co https://*.hackerai.co https://*.convex.cloud; style-src 'self' 'unsafe-inline' http://localhost:3000 https://hackerai.co https://*.hackerai.co; img-src 'self' data: https: http: blob:; font-src 'self' data: https: http:; connect-src 'self' http://localhost:3000 ws://localhost:3000 https://hackerai.co https://*.hackerai.co https://*.convex.cloud wss://*.convex.cloud https://auth.hackerai.co https://api.workos.com https://*.posthog.com https://*.stripe.com; frame-src 'self' https://*.stripe.com; media-src 'self' blob:;"
+      "csp": "default-src 'self' http://localhost:3000 https://hackerai.co https://*.hackerai.co https://*.convex.cloud https://*.convex.dev https://auth.hackerai.co https://api.workos.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:3000 https://hackerai.co https://*.hackerai.co https://*.convex.cloud; style-src 'self' 'unsafe-inline' http://localhost:3000 https://hackerai.co https://*.hackerai.co; img-src 'self' data: https: http: blob:; font-src 'self' data: https: http:; connect-src 'self' http://localhost:3000 ws://localhost:3000 https://hackerai.co https://*.hackerai.co https://*.convex.cloud wss://*.convex.cloud https://auth.hackerai.co https://api.workos.com https://*.posthog.com https://*.stripe.com https://api.trigger.dev https://*.trigger.dev wss://*.trigger.dev; frame-src 'self' https://*.stripe.com; media-src 'self' blob:;"
     }
   }
 }


### PR DESCRIPTION
## Summary

Agent-long token streaming was batching at end-of-run inside the Tauri desktop app while working fine in Safari. Confirmed via the same prod URL: live streaming in Safari, batched in the desktop app.

Root cause: the Tauri-injected CSP in both `tauri.conf.json` and `tauri.dev.conf.json` was missing `api.trigger.dev` under `connect-src`. The chat transport opens `runs.subscribeToRun().withStreams()` which connects to `https://api.trigger.dev/realtime/v1/runs/...?live=true&log=full&...` — that request was being blocked / forced into a non-streaming fallback by the webview's content policy.

Adds three entries to `connect-src` in both files:

- `https://api.trigger.dev` — current realtime/REST host
- `https://*.trigger.dev` — covers regional/sub-domain endpoints
- `wss://*.trigger.dev` — covers any WebSocket transport the SDK may upgrade to

No `tauri-plugin-http` is in `Cargo.toml`, so no capability/scope change is needed — `window.fetch` from inside the webview is what carries the stream.

## Test plan

- [ ] Rebuild desktop app (`pnpm tauri build` or run via `pnpm tauri dev` from `packages/desktop/`).
- [ ] Open an agent-long chat, run a slow tool (e.g. `ping -c 4 hackerone.com`).
- [ ] Reasoning + text-delta tokens should appear progressively, matching Safari behavior.
- [ ] No CSP violations in the WKWebView devtools console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security configuration for the desktop application to support connections to additional service endpoints.
  * Enhanced development environment configuration for expanded service integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/447)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->