### PR TITLE
Use actions-rust-lang/setup-rust-toolchain for desktop build CI

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -133,9 +133,13 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          targets: ${{ matrix.target }}
+          toolchain: stable
+          target: ${{ matrix.target }}
+          # Skip the action's built-in cache; swatinem/rust-cache below is
+          # already scoped to packages/desktop/src-tauri and covers it.
+          cache: false
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2


### PR DESCRIPTION
macos-latest moved to Apple Silicon, and dtolnay/rust-toolchain@stable's PATH injection has been flaky on that image: cargo on PATH ends up resolving to rustup-init (the installer shim Homebrew puts at the front of PATH), so `pnpm tauri build` fails with:

  failed to run 'cargo metadata' command to get workspace directory:
  failed to run command cargo metadata: error: unexpected argument
  'metadata' found
  Usage: rustup-init[EXE] [OPTIONS]

actions-rust-lang/setup-rust-toolchain@v1 handles PATH ordering on the Apple Silicon runner correctly. Disable its built-in cache since the existing swatinem/rust-cache@v2 step is already scoped to packages/desktop/src-tauri.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build infrastructure for improved toolchain management and caching efficiency.

---

**Note:** This is an internal maintenance update with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/448)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->