### PR TITLE
Fix desktop-build dead-code/unused-import errors under -D warnings

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -616,6 +616,11 @@ async fn execute_stream_command(
 
 /// Start a local HTTP server for dev mode auth callbacks.
 /// This replaces deep links which don't work in `tauri dev` on macOS.
+/// Only compiled in debug builds — matches the cfg-gated call site at the
+/// bottom of `run()`. Without this gate, release builds error out with
+/// `dead_code` under `actions-rust-lang/setup-rust-toolchain@v1`'s
+/// `RUSTFLAGS=-D warnings`.
+#[cfg(debug_assertions)]
 async fn start_dev_auth_server(app_handle: tauri::AppHandle) {
     let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
         Ok(l) => l,


### PR DESCRIPTION
## Summary

\`actions-rust-lang/setup-rust-toolchain@v1\` (introduced in #448) sets \`RUSTFLAGS=-D warnings\` by default, which exposed pre-existing dead-code / unused-import issues that \`dtolnay/rust-toolchain\` had let through silently. Three fixes in two files, all minimal and platform-correct:

### \`packages/desktop/src-tauri/src/lib.rs\`

\`start_dev_auth_server\`'s call site at [lib.rs:1044-1047](packages/desktop/src-tauri/src/lib.rs#L1044) is already gated with \`#[cfg(debug_assertions)]\`. The function *definition* wasn't — so in release builds it was unreferenced. Add the same cfg to the definition.

### \`packages/desktop/src-tauri/src/platform.rs\`

Two unused imports on the Windows target:

- \`use std::time::Duration;\` at file scope, only consumed by \`graceful_kill\`'s \`#[cfg(unix)]\` arm. Moved into that arm.
- \`use std::os::windows::process::CommandExt;\` inside the Windows path, imported for \`raw_arg\`. \`tokio::process::Command\` exposes \`raw_arg\` natively on Windows, so the trait import is redundant — removed.

## Failing run

https://github.com/hackerai-tech/hackerai/actions/runs/25888225402 — every matrix entry died on one of these warnings.

## Test plan

- [x] \`RUSTFLAGS=\"-D warnings\" cargo check --release\` from \`packages/desktop/src-tauri\` runs clean on macOS (covers unix code paths).
- [ ] After merge, watch the next desktop-build run; all five matrix jobs should clear \`cargo build\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)