### PR TITLE
Fix Windows desktop-build: unused imports in platform.rs

### DIFF
--- a/packages/desktop/src-tauri/src/platform.rs
+++ b/packages/desktop/src-tauri/src/platform.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 /// Check if a path is executable (Unix: has execute permission).
 #[cfg(not(windows))]
 fn is_executable(path: &std::path::Path) -> bool {
@@ -139,8 +137,8 @@ pub fn build_command(
             // Rust's std `Command::arg` applies on Windows. Use `raw_arg`
             // to pass the command line through verbatim, wrapped in the
             // outer quotes that `cmd /C` expects, so embedded quoted paths
-            // like `"C:\temp\foo"` survive intact.
-            use std::os::windows::process::CommandExt;
+            // like `"C:\temp\foo"` survive intact. tokio's Command exposes
+            // raw_arg natively on Windows, no CommandExt import needed.
             cmd.arg(config.flag);
             cmd.raw_arg(format!("\"{}\"", command));
         } else {
@@ -177,6 +175,7 @@ pub fn build_command(
 pub async fn graceful_kill(child: &mut tokio::process::Child) {
     #[cfg(unix)]
     {
+        use std::time::Duration;
         if let Some(pid) = child.id() {
             // Send SIGTERM first for graceful shutdown
             unsafe {


### PR DESCRIPTION
## Summary

Follow-up to #449 — these two platform.rs fixes were authored on the same branch but a race between my second push and the squash merge left them out of the merged commit. Windows desktop-build is still failing under \`RUSTFLAGS=-D warnings\`:

\`\`\`
error: unused import: \`std::time::Duration\`
  --> src\\platform.rs:1:5
error: unused import: \`std::os::windows::process::CommandExt\`
  --> src\\platform.rs:143:17
\`\`\`

- \`Duration\` is only referenced inside \`graceful_kill\`'s \`#[cfg(unix)]\` branch; moved the import there.
- \`CommandExt\` was imported for \`raw_arg\`, but \`tokio::process::Command\` exposes \`raw_arg\` natively on Windows — the trait import was redundant (which is why the compiler flagged it as unused).

## Test plan

- [x] \`RUSTFLAGS=\"-D warnings\" cargo check --release\` clean on macOS (unix path).
- [ ] After merge, Windows-x64 + all other matrix entries should clear \`cargo build\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)