### PR TITLE
Install rustup manually on macOS to bypass rustup-init shim

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -132,7 +132,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      - name: Install Rust stable
+      - name: Install Rust stable (Linux, Windows)
+        if: matrix.platform != 'macos-latest'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
@@ -140,6 +141,24 @@ jobs:
           # Skip the action's built-in cache; swatinem/rust-cache below is
           # already scoped to packages/desktop/src-tauri and covers it.
           cache: false
+
+      - name: Install Rust stable (macOS — bypass rustup-init shim)
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        run: |
+          # The standard rust-toolchain actions short-circuit on
+          # `command -v rustup`, but the GitHub-hosted macOS runner ships a
+          # `rustup-init` shim aliased as `rustup`/`cargo`, fooling that
+          # heuristic. The action then skips installing the real toolchain
+          # and `cargo metadata` invokes the shim, which doesn't know
+          # `metadata` and dies with rustup-init's usage screen. Install
+          # rustup directly to bypass the broken detection.
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL \
+            https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          "$HOME/.cargo/bin/rustup" target add "${{ matrix.target }}"
+          "$HOME/.cargo/bin/cargo" --version
+          "$HOME/.cargo/bin/rustc" --version
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

The macos-latest Apple-Silicon runner image ships a \`rustup-init\` shim aliased as \`rustup\` / \`cargo\` / etc. Both \`dtolnay/rust-toolchain\` and \`actions-rust-lang/setup-rust-toolchain\` (which #448 switched to) gate their install logic on \`command -v rustup\`: if rustup is found, skip install. The shim satisfies that check, so the real toolchain never gets installed, and \`cargo metadata\` later invokes the shim:

\`\`\`
failed to run 'cargo metadata' command to get workspace directory:
failed to run command cargo metadata: error: unexpected argument 'metadata' found
Usage: rustup-init[EXE] [OPTIONS]
\`\`\`

The bug is intermittent because not every \`macos-latest\` runner image variant has the shim — some runs pass, others (like this one) fail at exactly this step.

Fix: bypass the heuristic on macOS by installing rustup directly via the upstream shell installer, set \`~/.cargo/bin\` on \`GITHUB_PATH\` explicitly, and add the target. Linux + Windows keep \`actions-rust-lang/setup-rust-toolchain@v1\` where the detection works correctly.

## Test plan

- [ ] After merge, watch the next desktop-build run; macOS-arm64 and macOS-x64 should both clear the Rust install step deterministically.
- [ ] Linux-x64, Linux-arm64, Windows-x64 should still pass (no change to their setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved desktop build reliability on macOS by optimizing the build environment setup process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/451)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->