### PR TITLE
Remove custom userAgent so prod desktop streams trigger.dev realtime

### DIFF
--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -23,7 +23,6 @@
         "center": true,
         "decorations": true,
         "transparent": false,
-        "userAgent": "HackerAI-Desktop/1.0",
         "theme": "Dark",
         "dragDropEnabled": false
       }


### PR DESCRIPTION
## Summary

v0.0.42 desktop binary couldn't stream agent-long tokens from api.trigger.dev — output appeared in one batch when the run finished. \`pnpm run desktop:dev\` and Safari both worked correctly with the same backend.

Root cause is **not** CSP (already verified: \`strings\` on the installed v0.0.42 binary shows \`api.trigger.dev\` is in \`connect-src\`). It's the custom \`userAgent: \"HackerAI-Desktop/1.0\"\` set only in [tauri.conf.json](packages/desktop/src-tauri/tauri.conf.json). trigger.dev's edge (Cloudflare) treats non-browser UAs as transformable — buffering / compressing / disabling chunked transfer — which defeats the SDK's SSE delivery.

[tauri.dev.conf.json](packages/desktop/src-tauri/tauri.dev.conf.json) doesn't override userAgent → dev builds use the platform's default WebKit UA → matches Safari → streams fine. Dropping the override aligns prod with dev.

If we want to keep app branding in server logs later, we can append \`HackerAI-Desktop/X\` *after* a real Safari UA string (not replace it). For now the simplest fix is to remove the override.

## Test plan

- [ ] After this lands and a new desktop release ships (v0.0.43+), reinstall, run an agent-long query, confirm reasoning + text tokens stream live.
- [ ] Verify dev mode (\`pnpm run desktop:dev\`) still streams (no change to dev config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated desktop application configuration by removing the custom user agent setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->