### PR TITLE
Set Safari-shaped userAgent so prod desktop streams trigger.dev

### DIFF
--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -23,6 +23,7 @@
         "center": true,
         "decorations": true,
         "transparent": false,
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15 HackerAI-Desktop/1.0",
         "theme": "Dark",
         "dragDropEnabled": false
       }


### PR DESCRIPTION
## Summary

#452 removed the custom \`HackerAI-Desktop/1.0\` userAgent expecting WKWebView's default UA to behave like Safari. It doesn't — the WKWebView default UA on macOS is:

\`\`\`
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)
\`\`\`

with no \`Version/X\` or \`Safari/X\` suffix. Cloudflare in front of api.trigger.dev classifies that as a non-browser client and downgrades the SSE response, so v0.0.43 still batched agent-long output until run completion.

Verified by running \`pnpm tauri dev --config '{...userAgent...}'\` against hackerai.co:

- Default WKWebView UA → batched until end
- Safari UA only → streams live
- Safari UA + \`HackerAI-Desktop/1.0\` suffix → streams live (trailing token doesn't change Cloudflare's classification)

Set a full Safari UA with the \`HackerAI-Desktop/1.0\` suffix retained so server logs can still grep desktop users out of regular Safari traffic.

## Trade-offs (worth flagging)

- macOS-shaped UA on all platforms today. Windows/Linux builds aren't reported broken, and addressing them properly is a separate change using \`tauri.windows.conf.json\` / \`tauri.linux.conf.json\`.
- Version strings (\`Version/17.6 Safari/605.1.15\`) will look dated eventually. Cloudflare's classifier matches loosely so this isn't urgent.

## Test plan

- [x] Local repro: \`pnpm tauri dev --config '{\"build\":{\"devUrl\":\"https://hackerai.co\"},\"app\":{\"windows\":[{\"title\":\"HackerAI\",\"width\":1280,\"height\":800,\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15 HackerAI-Desktop/1.0\"}]}}'\` → streams live, window opens at full size.
- [ ] After merge + v0.0.44 release: install, run an agent-long query, confirm reasoning + text tokens stream live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
  * Updated desktop application user agent identifier.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/453)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->