### PR TITLE
[codex] Auto-select Agent mode for local connections

### DIFF
--- a/app/components/RemoteControlTab.tsx
+++ b/app/components/RemoteControlTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Button } from "@/components/ui/button";
@@ -18,12 +18,17 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { runCommand, convexUrlFlag } from "@/lib/utils/sandbox-command";
+import { useGlobalState } from "@/app/contexts/GlobalState";
+import type {
+  ChatMode,
+  SandboxPreference,
+  SelectedModel,
+  SubscriptionTier,
+} from "@/types/chat";
 
 interface LocalConnection {
   connectionId: string;
   name: string;
-  mode: "docker" | "dangerous";
-  containerId?: string;
   osInfo?: {
     platform: string;
     arch: string;
@@ -31,6 +36,7 @@ interface LocalConnection {
     hostname: string;
   };
   lastSeen: number;
+  isDesktop: boolean;
 }
 
 interface CommandBlockProps {
@@ -80,14 +86,115 @@ const CommandBlock = ({
   </div>
 );
 
+interface UseAutoSelectNewRemoteConnectionArgs {
+  connections: LocalConnection[] | undefined;
+  chatMode: ChatMode;
+  setChatMode: (mode: ChatMode) => void;
+  subscription: SubscriptionTier;
+  sandboxPreference: SandboxPreference;
+  setSandboxPreference: (preference: SandboxPreference) => void;
+  selectedModel: SelectedModel;
+  setSelectedModel: (model: SelectedModel) => void;
+  temporaryChatsEnabled: boolean;
+}
+
+function useAutoSelectNewRemoteConnection({
+  connections,
+  chatMode,
+  setChatMode,
+  subscription,
+  sandboxPreference,
+  setSandboxPreference,
+  selectedModel,
+  setSelectedModel,
+  temporaryChatsEnabled,
+}: UseAutoSelectNewRemoteConnectionArgs) {
+  const previousRemoteConnectionIdsRef = useRef<Set<string> | null>(null);
+
+  useEffect(() => {
+    if (connections === undefined) return;
+
+    const remoteConnections = connections.filter((conn) => !conn.isDesktop);
+    const currentIds = new Set(
+      remoteConnections.map((conn) => conn.connectionId),
+    );
+    const previousIds = previousRemoteConnectionIdsRef.current;
+    previousRemoteConnectionIdsRef.current = currentIds;
+
+    // Treat the first loaded query result as baseline so existing connections
+    // do not hijack the user's saved mode on settings open or page load.
+    if (previousIds === null) return;
+
+    const newConnection = remoteConnections.find(
+      (conn) => !previousIds.has(conn.connectionId),
+    );
+    if (!newConnection) return;
+
+    if (sandboxPreference !== newConnection.connectionId) {
+      setSandboxPreference(newConnection.connectionId);
+    }
+
+    if (temporaryChatsEnabled) {
+      toast.info("Local sandbox connected", {
+        description: "Turn off temporary chat to use Agent mode.",
+      });
+      return;
+    }
+
+    if (subscription === "free" && selectedModel !== "auto") {
+      setSelectedModel("auto");
+    }
+
+    if (chatMode !== "agent") {
+      setChatMode("agent");
+      toast.success("Local sandbox connected. Switched to Agent mode.");
+    } else {
+      toast.success("Local sandbox connected.");
+    }
+  }, [
+    chatMode,
+    connections,
+    sandboxPreference,
+    selectedModel,
+    setChatMode,
+    setSandboxPreference,
+    setSelectedModel,
+    subscription,
+    temporaryChatsEnabled,
+  ]);
+}
+
 const RemoteControlTab = () => {
   const [showToken, setShowToken] = useState(false);
   const [token, setToken] = useState<string | null>(null);
   const [isLoadingToken, setIsLoadingToken] = useState(false);
 
+  const {
+    chatMode,
+    setChatMode,
+    subscription,
+    sandboxPreference,
+    setSandboxPreference,
+    selectedModel,
+    setSelectedModel,
+    temporaryChatsEnabled,
+  } = useGlobalState();
+
   const connections = useQuery(api.localSandbox.listConnections);
   const tokenResult = useMutation(api.localSandbox.getToken);
   const regenerateToken = useMutation(api.localSandbox.regenerateToken);
+
+  useAutoSelectNewRemoteConnection({
+    chatMode,
+    connections,
+    sandboxPreference,
+    selectedModel,
+    setChatMode,
+    setSandboxPreference,
+    setSelectedModel,
+    subscription,
+    temporaryChatsEnabled,
+  });
 
   const handleGetToken = async () => {
     setIsLoadingToken(true);

--- a/app/components/__tests__/RemoteControlTab.test.tsx
+++ b/app/components/__tests__/RemoteControlTab.test.tsx
@@ -1,0 +1,126 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+type MockConnection = {
+  connectionId: string;
+  name: string;
+  osInfo?: {
+    platform: string;
+    arch: string;
+    release: string;
+    hostname: string;
+  };
+  lastSeen: number;
+  isDesktop: boolean;
+};
+
+let mockConnections: MockConnection[] | undefined;
+let mockChatMode: "ask" | "agent";
+let mockSubscription: "free" | "pro";
+let mockSandboxPreference: string;
+let mockSelectedModel: "auto" | "hackerai-standard" | "hackerai-pro";
+let mockTemporaryChatsEnabled: boolean;
+
+const mockSetChatMode = jest.fn((mode: "ask" | "agent") => {
+  mockChatMode = mode;
+});
+const mockSetSandboxPreference = jest.fn((preference: string) => {
+  mockSandboxPreference = preference;
+});
+const mockSetSelectedModel = jest.fn(
+  (model: "auto" | "hackerai-standard" | "hackerai-pro") => {
+    mockSelectedModel = model;
+  },
+);
+
+jest.mock("convex/react", () => ({
+  useQuery: jest.fn(() => mockConnections),
+  useMutation: jest.fn(() => jest.fn()),
+}));
+
+jest.mock("@/app/contexts/GlobalState", () => ({
+  useGlobalState: () => ({
+    chatMode: mockChatMode,
+    setChatMode: mockSetChatMode,
+    subscription: mockSubscription,
+    sandboxPreference: mockSandboxPreference,
+    setSandboxPreference: mockSetSandboxPreference,
+    selectedModel: mockSelectedModel,
+    setSelectedModel: mockSetSelectedModel,
+    temporaryChatsEnabled: mockTemporaryChatsEnabled,
+  }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const { RemoteControlTab } = jest.requireActual<
+  typeof import("../RemoteControlTab")
+>("../RemoteControlTab");
+const { toast } = jest.requireMock<typeof import("sonner")>("sonner");
+
+const remoteConnection: MockConnection = {
+  connectionId: "conn-remote-1",
+  name: "My Machine",
+  osInfo: {
+    platform: "darwin",
+    arch: "arm64",
+    release: "25.0.0",
+    hostname: "devbox",
+  },
+  lastSeen: 123,
+  isDesktop: false,
+};
+
+describe("RemoteControlTab", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnections = [];
+    mockChatMode = "ask";
+    mockSubscription = "free";
+    mockSandboxPreference = "e2b";
+    mockSelectedModel = "hackerai-pro";
+    mockTemporaryChatsEnabled = false;
+  });
+
+  it("selects agent mode with the new local connection after an empty baseline", async () => {
+    const { rerender } = render(<RemoteControlTab />);
+
+    expect(mockSetChatMode).not.toHaveBeenCalled();
+    expect(screen.getByText("No active connections")).toBeInTheDocument();
+
+    mockConnections = [remoteConnection];
+    rerender(<RemoteControlTab />);
+
+    await waitFor(() => {
+      expect(mockSetSandboxPreference).toHaveBeenCalledWith("conn-remote-1");
+    });
+    expect(mockSetSelectedModel).toHaveBeenCalledWith("auto");
+    expect(mockSetChatMode).toHaveBeenCalledWith("agent");
+    expect(toast.success).toHaveBeenCalledWith(
+      "Local sandbox connected. Switched to Agent mode.",
+    );
+  });
+
+  it("does not switch modes when an existing connection appears on initial query load", async () => {
+    mockConnections = undefined;
+    const { rerender } = render(<RemoteControlTab />);
+
+    mockConnections = [remoteConnection];
+    rerender(<RemoteControlTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText("devbox")).toBeInTheDocument();
+    });
+    expect(mockSetSandboxPreference).not.toHaveBeenCalled();
+    expect(mockSetSelectedModel).not.toHaveBeenCalled();
+    expect(mockSetChatMode).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Auto-selects a newly connected remote/local sandbox from the Remote Control settings tab.
- Switches users from Ask mode to Agent mode when that new local connection appears.
- Keeps the first loaded connection list as a baseline so existing connections do not unexpectedly change saved mode.
- Adds focused coverage for the auto-switch path and the initial-load guard.

## Why

New users connecting a local machine through settings were still left in Ask mode, which made Agent mode harder to discover after setup completed.

## Validation

- `pnpm test -- app/components/__tests__/RemoteControlTab.test.tsx --runInBand`
- `pnpm exec eslint app/components/RemoteControlTab.tsx app/components/__tests__/RemoteControlTab.test.tsx`
- `pnpm exec prettier --check app/components/RemoteControlTab.tsx app/components/__tests__/RemoteControlTab.test.tsx`
- `pnpm typecheck`
- Commit hook also ran full `pnpm typecheck` and full `pnpm test` successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote connections now automatically detected, with chat mode and sandbox preferences configured accordingly.
  * Added toast notifications to inform users when new remote connections are detected and configured.
  * Improved connection identification to distinguish between local and remote systems.

* **Tests**
  * Added test suite for remote connection handling and automatic configuration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/454)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->