### PR TITLE
Route web agent runs through Trigger.dev for all tiers

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -32,6 +32,7 @@ import {
   fetchAgentLongStream,
   resumeAgentLongStream,
 } from "@/lib/chat/agent-long-transport";
+import { isTauriEnvironment } from "@/app/hooks/useTauri";
 import { stripAgentLongHeartbeatPartsFromMessages } from "@/lib/chat/agent-long-heartbeat";
 import { toast } from "sonner";
 import type { Todo, ChatMessage, ChatMode } from "@/types";
@@ -342,9 +343,10 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       api: "/api/chat",
       fetch: async (input, init) => {
         const mode = chatModeRef.current;
-        const isFreeAgent =
-          mode === "agent" && subscriptionRef.current === "free";
-        if (isFreeAgent) {
+        const useTriggerAgent =
+          mode === "agent" &&
+          (!isTauriEnvironment() || subscriptionRef.current === "free");
+        if (useTriggerAgent) {
           // useChat reuses this fetch for both POST sendMessages and GET
           // reconnectToStream — dispatch on method.
           if (init?.method === "GET") {
@@ -377,10 +379,11 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       prepareReconnectToStreamRequest: ({ id, api }) => {
         // Use the agent-long resume endpoint when there is a stored trigger run
         // (covers legacy "agent-long" chats normalised to "agent" on load) OR
-        // when the current user is a free user in agent mode.
-        const isFreeAgent =
-          chatModeRef.current === "agent" && subscriptionRef.current === "free";
-        if (isFreeAgent || !!activeTriggerRunRef.current) {
+        // when the current run is using Trigger.dev for agent mode.
+        const useTriggerAgent =
+          chatModeRef.current === "agent" &&
+          (!isTauriEnvironment() || subscriptionRef.current === "free");
+        if (useTriggerAgent || !!activeTriggerRunRef.current) {
           return {
             api: `/api/agent-long/resume?chatId=${encodeURIComponent(id)}`,
           };


### PR DESCRIPTION
## Summary
- Web users on agent mode now use the `agent-long` Trigger.dev endpoint for both free and paid tiers (previously only free).
- Desktop (Tauri) keeps the prior gating: only free users hit Trigger.dev; paid desktop users continue to call `/api/agent` directly.
- Renames the local guard from `isFreeAgent` to `useTriggerAgent` to reflect the new combined tier + environment condition.

## Test plan
- [x] Web, free user, agent mode → request goes to `/api/agent-long` and resumes via `/api/agent-long/resume`.
- [x] Web, paid user, agent mode → request goes to `/api/agent-long` and resumes via `/api/agent-long/resume`.
- [ ] Desktop, free user, agent mode → still uses `/api/agent-long`.
- [x] Desktop, paid user, agent mode → uses `/api/agent` and standard reconnect URL.
- [x] Non-agent modes are unaffected on both web and desktop.
- [x] Legacy `agent-long` chats still resume correctly via the stored `active_trigger_run_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved agent-mode request selection across different environments.
  * Enhanced stream reconnection handling with better trigger condition logic.

* **Chores**
  * Updated transport request logic for agent-mode operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/455)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->