### PR TITLE
[codex] Track agent-long errors in Trigger.dev

### DIFF
--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -70,22 +70,38 @@ export async function POST(req: NextRequest) {
       });
     }
 
-    const handle = await tasks.trigger<typeof agentLongTask>("agent-long", {
-      chatId,
-      userId,
-      subscription,
-      organizationId,
-      messages,
-      baseTodos: Array.isArray(todos) ? todos : [],
-      sandboxPreference,
-      selectedModel: selectedModelOverride,
-      userLocation,
-      temporary,
-      isAutoContinue,
-      regenerate,
-      isNewChat,
-      convexUrl: process.env.NEXT_PUBLIC_CONVEX_URL,
-    });
+    const triggerTags = [`user_${userId}`, `chat_${chatId}`];
+    if (subscription !== "free") triggerTags.push(`sub_${subscription}`);
+
+    const handle = await tasks.trigger<typeof agentLongTask>(
+      "agent-long",
+      {
+        chatId,
+        userId,
+        subscription,
+        organizationId,
+        messages,
+        baseTodos: Array.isArray(todos) ? todos : [],
+        sandboxPreference,
+        selectedModel: selectedModelOverride,
+        userLocation,
+        temporary,
+        isAutoContinue,
+        regenerate,
+        isNewChat,
+        convexUrl: process.env.NEXT_PUBLIC_CONVEX_URL,
+      },
+      {
+        tags: triggerTags,
+        metadata: {
+          status: "queued",
+          chatId,
+          userId,
+          subscription,
+          loginRequired: false,
+        },
+      },
+    );
 
     if (!temporary) {
       await setActiveTriggerRun({ chatId, triggerRunId: handle.id });

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -31,6 +31,16 @@ const resumeSrc = fs.readFileSync(
   "utf8",
 );
 
+const routeSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../../app/api/agent-long/route.ts"),
+  "utf8",
+);
+
+const taskSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../../trigger/agent-long.ts"),
+  "utf8",
+);
+
 describe("agent-long-transport — STREAM_TIMEOUT_MS guard", () => {
   test("STREAM_TIMEOUT_MS is set to 30 seconds", () => {
     expect(transportSrc).toMatch(/STREAM_TIMEOUT_MS\s*=\s*30[_,]?000/);
@@ -89,5 +99,32 @@ describe("agent-long resume route — 204 on terminal + self-heal on 404", () =>
 
   test("returns 204 when no active run ID is stored", () => {
     expect(resumeSrc).toMatch(/status:\s*204/);
+  });
+});
+
+describe("agent-long task — Trigger.dev dashboard error visibility", () => {
+  test("runs are triggered with filterable queued metadata and tags", () => {
+    expect(routeSrc).toMatch(/tags:\s*triggerTags/);
+    expect(routeSrc).toMatch(/metadata:\s*{/);
+    expect(routeSrc).toMatch(/status:\s*"queued"/);
+    expect(routeSrc).toMatch(/loginRequired:\s*false/);
+  });
+
+  test("stream errors are rethrown after the UI error chunk is flushed", () => {
+    const waitIdx = taskSrc.indexOf("await waitUntilComplete()");
+    const streamErrorIdx = taskSrc.indexOf("if (streamError)", waitIdx);
+    const throwIdx = taskSrc.indexOf("throw streamError", streamErrorIdx);
+    expect(waitIdx).toBeGreaterThan(-1);
+    expect(streamErrorIdx).toBeGreaterThan(waitIdx);
+    expect(throwIdx).toBeGreaterThan(streamErrorIdx);
+  });
+
+  test("task catch records structured metadata for dashboard filtering", () => {
+    expect(taskSrc).toMatch(/recordAgentLongFailureForDashboard/);
+    expect(taskSrc).toMatch(/errorCategory/);
+    expect(taskSrc).toMatch(/loginRequired/);
+    expect(taskSrc).toMatch(/login_required/);
+    expect(taskSrc).toMatch(/error_\$\{summary\.category\}/);
+    expect(taskSrc).toMatch(/metadata\.flush\(\)/);
   });
 });

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1,4 +1,9 @@
-import { task, tags, metadata } from "@trigger.dev/sdk";
+import {
+  task,
+  tags,
+  metadata,
+  logger as triggerLogger,
+} from "@trigger.dev/sdk";
 import { agentUiStream } from "./streams";
 import {
   createUIMessageStream,
@@ -93,6 +98,89 @@ import {
 const AGENT_LONG_MAX_DURATION_MS = 58 * 60 * 1000;
 
 type AgentLongUiStreamPart = Parameters<UIMessageStreamWriter["write"]>[0];
+
+const MAX_TRIGGER_ERROR_MESSAGE_LENGTH = 500;
+
+const truncateForTriggerMetadata = (value: string) =>
+  value.length > MAX_TRIGGER_ERROR_MESSAGE_LENGTH
+    ? `${value.slice(0, MAX_TRIGGER_ERROR_MESSAGE_LENGTH)}...`
+    : value;
+
+const sanitizeTriggerTagValue = (value: string) =>
+  value.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 80);
+
+const classifyAgentLongError = (error: unknown) => {
+  const details = extractErrorDetails(error);
+  const errorMessage = truncateForTriggerMetadata(
+    typeof details.errorMessage === "string"
+      ? details.errorMessage
+      : "Unknown error occurred",
+  );
+
+  if (error instanceof ChatSDKError) {
+    const code = `${error.type}:${error.surface}`;
+    return {
+      category: error.type === "unauthorized" ? "login_required" : "chat_error",
+      code,
+      name: "ChatSDKError",
+      message: errorMessage,
+      loginRequired: error.type === "unauthorized",
+      statusCode: error.statusCode,
+    };
+  }
+
+  return {
+    category: isProviderApiError(error) ? "provider_error" : "unexpected_error",
+    code: typeof details.errorCode === "string" ? details.errorCode : undefined,
+    name:
+      typeof details.errorName === "string"
+        ? details.errorName
+        : "UnknownError",
+    message: errorMessage,
+    loginRequired: false,
+    statusCode:
+      typeof details.statusCode === "number" ? details.statusCode : undefined,
+  };
+};
+
+const recordAgentLongFailureForDashboard = async (
+  error: unknown,
+  context: {
+    chatId: string;
+    userId: string;
+    runId: string;
+    phase: "setup" | "streaming";
+  },
+) => {
+  const summary = classifyAgentLongError(error);
+  metadata
+    .set("status", "failed")
+    .set("errorCategory", summary.category)
+    .set("errorName", summary.name)
+    .set("errorMessage", summary.message)
+    .set("loginRequired", summary.loginRequired)
+    .set("failedPhase", context.phase)
+    .set("failedAt", new Date().toISOString());
+
+  if (summary.code) metadata.set("errorCode", summary.code);
+  if (summary.statusCode) metadata.set("errorStatusCode", summary.statusCode);
+
+  const errorTags = [`error_${summary.category}`];
+  if (summary.code) {
+    errorTags.push(`error_code_${sanitizeTriggerTagValue(summary.code)}`);
+  }
+  await tags.add(errorTags);
+
+  triggerLogger.error("[agent-long] run failed", {
+    chatId: context.chatId,
+    userId: context.userId,
+    runId: context.runId,
+    phase: context.phase,
+    ...summary,
+  });
+
+  await metadata.flush();
+};
 
 const withAgentLongStreamHeartbeat = (
   source: ReadableStream<AgentLongUiStreamPart>,
@@ -382,8 +470,10 @@ export const agentLongTask = task({
       let rateLimitInfo: RateLimitInfo;
       let extraUsageConfig: Awaited<ReturnType<typeof buildExtraUsageConfig>>;
 
+      let streamError: unknown;
       const uiStream = createUIMessageStream({
         onError: (error) => {
+          streamError ??= error;
           if (error instanceof ChatSDKError) {
             return typeof error.cause === "string"
               ? error.cause
@@ -1017,10 +1107,25 @@ export const agentLongTask = task({
       streamPiped = true;
       await waitUntilComplete();
 
+      if (streamError) {
+        throw streamError;
+      }
+
       metadata.set("status", "done");
       await phLogger.flush().catch(() => {});
     } catch (error) {
-      metadata.set("status", "failed");
+      await recordAgentLongFailureForDashboard(error, {
+        chatId,
+        userId,
+        runId: ctx.run.id,
+        phase: streamPiped ? "streaming" : "setup",
+      }).catch((metadataError) => {
+        metadata.set("status", "failed");
+        console.error(
+          "[agent-long] failed to record run error metadata:",
+          metadataError,
+        );
+      });
       await usageRefundTracker.refund().catch(() => {});
       if (error instanceof ChatSDKError) {
         chatLogger?.emitChatError(error);


### PR DESCRIPTION
## Summary

- Add Trigger.dev queued metadata and searchable tags when starting `agent-long` runs.
- Record structured failure metadata for agent-long runs, including login-required, chat, provider, and unexpected error categories.
- Preserve the user-facing AI SDK error chunk, then rethrow stream failures so Trigger.dev marks the run as failed in the dashboard.
- Add contract coverage for the dashboard observability guarantees.

## Why

The AI SDK UI stream can convert thrown agent errors into client-visible `error` chunks, which keeps the user experience intact but can make the Trigger.dev run look successful. This change keeps the friendly frontend error behavior while making failed agent runs obvious and filterable in Trigger.dev.

## Validation

- `pnpm typecheck`
- `pnpm jest lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- Commit hook: `pnpm typecheck`
- Commit hook: `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error handling and metadata tracking for tasks, including improved error classification and dashboard visibility
  * Task triggering now includes enriched metadata and tagging for better tracking and filtering

* **Tests**
  * Added comprehensive test coverage for error handling and dashboard error metadata recording

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/458)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->