### PR TITLE
Tighten agent-long Stop button and submit feedback

### DIFF
--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -117,7 +117,7 @@ export const Messages = ({
   const shouldShowLoadingDots = useMemo(() => {
     // Show dots while resuming an interrupted stream until the first chunk arrives
     if (isAutoResuming) return true;
-    if (status !== "streaming") return false;
+    if (status !== "streaming" && status !== "submitted") return false;
     if (summarizationStatus?.status === "started") return false;
     if (uploadStatus?.isUploading) return false;
 

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -3,6 +3,7 @@ import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useGlobalState } from "../contexts/GlobalState";
 import { useLatestRef } from "@/app/hooks/useLatestRef";
+import { isTauriEnvironment } from "@/app/hooks/useTauri";
 import type { ChatMessage, ChatStatus } from "@/types";
 import { Id } from "@/convex/_generated/dataModel";
 import {
@@ -97,6 +98,25 @@ export const useChatHandlers = ({
     api.tempStreams.cancelTempStreamFromClient,
   );
 
+  // Mirrors the routing rule in app/components/chat.tsx: web users in agent
+  // mode (and Tauri free users) run on Trigger.dev. Persistent chats only —
+  // temporary chats use the legacy Redis pub/sub cancel path.
+  const shouldCancelTriggerRun = () =>
+    chatModeRef.current === "agent" &&
+    !temporaryChatsEnabledRef.current &&
+    (!isTauriEnvironment() || subscriptionRef.current === "free");
+
+  const cancelTriggerRun = () => {
+    if (!shouldCancelTriggerRun()) return;
+    fetch("/api/agent-long/cancel", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chatId }),
+    }).catch((error) => {
+      console.error("Failed to cancel trigger.dev run:", error);
+    });
+  };
+
   /**
    * Helper to stop an active stream, normalize messages, and persist state.
    * Returns the normalized messages array.
@@ -190,6 +210,10 @@ export const useChatHandlers = ({
         } else if (queueBehavior === "stop-and-send") {
           // Immediately stop current stream and send right away
           stop();
+
+          // Cancel the trigger.dev run for agent-long streams so the prior
+          // run stops burning compute instead of finishing in the background.
+          cancelTriggerRun();
 
           // Cancel the stream in database and save current message state
           if (!temporaryChatsEnabledRef.current) {
@@ -312,24 +336,13 @@ export const useChatHandlers = ({
     // Clear any active status indicators immediately
     onStopCallback?.();
 
+    // Fire the trigger.dev cancel in parallel with stopActiveStream so the
+    // Trigger.dev API round-trip overlaps the Convex cancel/save instead of
+    // sequencing after it.
+    cancelTriggerRun();
+
     try {
       await stopActiveStream();
-      // For agent-long, also tell the server to cancel the trigger.dev run.
-      // Fire-and-forget — server-side cancel is idempotent and the client
-      // abort already disconnected the realtime stream.
-      if (
-        chatModeRef.current === "agent" &&
-        subscriptionRef.current === "free" &&
-        !temporaryChatsEnabledRef.current
-      ) {
-        fetch("/api/agent-long/cancel", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ chatId }),
-        }).catch((error) => {
-          console.error("Failed to cancel trigger.dev run:", error);
-        });
-      }
     } catch (error) {
       console.error("Error in handleStop:", error);
     }

--- a/lib/chat/agent-long-transport.ts
+++ b/lib/chat/agent-long-transport.ts
@@ -48,10 +48,10 @@ const TERMINAL_RUN_STATUSES = new Set([
 // always closes and useChat exits streaming state.
 const STREAM_TIMEOUT_MS = 30_000;
 
-const buildSSEResponseFromRun = ({
-  runId,
-  publicAccessToken,
-}: RunHandle): Response => {
+const buildSSEResponseFromRun = (
+  { runId, publicAccessToken }: RunHandle,
+  signal?: AbortSignal,
+): Response => {
   const encoder = new TextEncoder();
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
@@ -75,6 +75,13 @@ const buildSSEResponseFromRun = ({
       // Timeout guard: if the subscription hangs (e.g. task failed before
       // registering the stream), force-close after STREAM_TIMEOUT_MS.
       const timeoutId = setTimeout(sendAbortAndClose, STREAM_TIMEOUT_MS);
+
+      // Short-circuit if the consumer already aborted before we got here.
+      if (signal?.aborted) {
+        clearTimeout(timeoutId);
+        sendAbortAndClose();
+        return;
+      }
 
       try {
         const { runs, auth } = await import("@trigger.dev/sdk");
@@ -122,9 +129,29 @@ const buildSSEResponseFromRun = ({
             batchedDeltaCount = 0;
           };
 
+          // Race subscription.next() against the consumer's abort signal so
+          // Stop closes the local stream in one tick, even when the LLM is
+          // mid-step and no chunks are flowing.
+          const iter = subscription[Symbol.asyncIterator]();
+          const abortSentinel = Symbol("aborted");
+          const abortPromise = new Promise<typeof abortSentinel>((resolve) => {
+            if (!signal) return; // never resolves — Promise.race ignores it
+            const onAbort = () => resolve(abortSentinel);
+            signal.addEventListener("abort", onAbort, { once: true });
+          });
+
           let sawTerminalChunk = false;
+          let userAborted = false;
           let firstEventReceived = false;
-          for await (const part of subscription) {
+          while (true) {
+            const next = await Promise.race([iter.next(), abortPromise]);
+            if (next === abortSentinel) {
+              userAborted = true;
+              break;
+            }
+            if (next.done) break;
+            const part = next.value;
+
             // Disarm the "no first event" timeout once the subscription is
             // proven live. Without this, a run longer than STREAM_TIMEOUT_MS
             // would have its stream force-closed mid-execution.
@@ -217,6 +244,12 @@ const buildSSEResponseFromRun = ({
           // Flush any deltas that didn't trigger a count- or timer-based flush.
           flushDeltaBuffers();
 
+          if (userAborted) {
+            // Release the trigger.dev subscription so it doesn't keep
+            // streaming chunks into a dead controller.
+            await iter.return?.(undefined).catch(() => undefined);
+          }
+
           if (!sawTerminalChunk) {
             // Subscription ended without a terminal UI chunk — run crashed,
             // was canceled, or failed before registering the stream.
@@ -249,7 +282,7 @@ export const fetchAgentLongStream = async (
   if (!startResponse.ok) return startResponse;
 
   const handle: RunHandle = await startResponse.json();
-  return buildSSEResponseFromRun(handle);
+  return buildSSEResponseFromRun(handle, init?.signal ?? undefined);
 };
 
 export const resumeAgentLongStream = async (
@@ -267,5 +300,5 @@ export const resumeAgentLongStream = async (
   if (!response.ok) return response;
 
   const handle: RunHandle = await response.json();
-  return buildSSEResponseFromRun(handle);
+  return buildSSEResponseFromRun(handle, init?.signal ?? undefined);
 };


### PR DESCRIPTION
## Summary
- **Make agent-long Stop close the stream instantly.** The custom SSE stream in `lib/chat/agent-long-transport.ts` ignored `init.signal`, so `useChat.stop()` couldn't break out of the trigger.dev subscription's `for-await` loop until the next chunk arrived (5–10s while the LLM was mid-step). Thread the signal through and race `iter.next()` against an abort promise so the local stream flushes, releases the iterator, and sends the SSE `abort` frame in one tick.
- **Cancel the trigger.dev run for every routed user.** The `/api/agent-long/cancel` call in `useChatHandlers` was guarded on `subscription === "free"`, but #455 routed all web agent runs through trigger.dev. Replace the guard with the same `useTriggerAgent` rule as `app/components/chat.tsx`, and fire the cancel in parallel with `stopActiveStream` so the RPC overlaps the Convex cancel/save. Same fix applied to the `stop-and-send` branch in `handleSubmit`.
- **Show loading dots while the agent run is being kicked off.** Trigger.dev cold starts left the UI blank between submit and the first chunk; treat `submitted` the same as `streaming` for the dots indicator.

## Test plan
- [ ] As a **paid** web user in agent mode, send a prompt that runs tools for a while, then click Stop mid-step — text stops appearing within ~1 frame and the run shows `CANCELED` on the Trigger.dev dashboard within 1–3s.
- [ ] As a **free** web user, same flow — instant stop, cancel endpoint still hit.
- [ ] In a **temporary** chat, Stop still works and doesn't call `/api/agent-long/cancel` (uses the legacy Redis pub/sub cancel path).
- [ ] Click Stop while the model is "thinking" (no chunks flowing) — stream closes immediately instead of waiting for the next chunk.
- [ ] Reload mid-stream (resume path) and click Stop after reconnection — `resumeAgentLongStream` honors the abort signal.
- [ ] On submit, the typing dots appear before the first chunk lands (cold-start case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Loading indicators now display during message submission, not just active streaming
  * Improved message stream cancellation and cleanup operations
  * Enhanced robustness of streaming with better handling of cancellation signals

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/460)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->