### PR TITLE
[codex] Add worked-for UI and context indicator controls

### DIFF
--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -19,10 +19,7 @@ import { NULL_THREAD_DRAFT_ID } from "@/lib/utils/client-storage";
 import { SandboxSelector } from "../SandboxSelector";
 import { ChatInputTextarea } from "./ChatInputTextarea";
 import { ChatInputToolbar } from "./ChatInputToolbar";
-import {
-  ContextUsageIndicator,
-  type ContextUsageData,
-} from "../ContextUsageIndicator";
+import { type ContextUsageData } from "../ContextUsageIndicator";
 import { useIsMobile } from "@/hooks/use-mobile";
 
 interface ChatInputProps {
@@ -95,9 +92,7 @@ export const ChatInput = ({
 
   const isGenerating = status === "submitted" || status === "streaming";
   const showContextIndicator =
-    !isMobile &&
-    (subscription !== "free" || isAgentMode(chatMode)) &&
-    !!contextUsage;
+    (subscription !== "free" || isAgentMode(chatMode)) && !!contextUsage;
   const isAgent = isAgentMode(chatMode);
 
   const draftId = isNewChat ? "new" : chatId || NULL_THREAD_DRAFT_ID;
@@ -241,8 +236,9 @@ export const ChatInput = ({
             input={input}
             uploadedFiles={uploadedFiles}
             chatMode={chatMode}
-            contextUsage={!isAgent ? contextUsage : undefined}
-            showContextIndicator={!isAgent && showContextIndicator}
+            contextUsage={contextUsage}
+            showContextIndicator={showContextIndicator}
+            contextUsageVariant={isMobile ? "compact-popover" : "tooltip"}
           />
         </div>
 
@@ -259,11 +255,6 @@ export const ChatInput = ({
               value={sandboxPreference}
               onChange={setSandboxPreference}
             />
-            {showContextIndicator && contextUsage && (
-              <div className="ml-auto">
-                <ContextUsageIndicator {...contextUsage} />
-              </div>
-            )}
           </div>
         )}
 

--- a/app/components/ChatInput/ChatInputToolbar.tsx
+++ b/app/components/ChatInput/ChatInputToolbar.tsx
@@ -17,12 +17,14 @@ export interface ChatInputToolbarProps extends SubmitStopButtonProps {
   onAttachClick: () => void;
   contextUsage?: ContextUsageData;
   showContextIndicator?: boolean;
+  contextUsageVariant?: "tooltip" | "compact-popover";
 }
 
 export function ChatInputToolbar({
   onAttachClick,
   contextUsage,
   showContextIndicator = false,
+  contextUsageVariant = "tooltip",
   chatMode,
   ...submitStopProps
 }: ChatInputToolbarProps) {
@@ -41,7 +43,10 @@ export function ChatInputToolbar({
       />
       <div className="ml-auto shrink-0 flex items-center gap-2.5">
         {showContextIndicator && contextUsage && (
-          <ContextUsageIndicator {...contextUsage} />
+          <ContextUsageIndicator
+            {...contextUsage}
+            variant={contextUsageVariant}
+          />
         )}
         <SubmitStopButton {...submitStopProps} chatMode={chatMode} />
       </div>

--- a/app/components/ContextUsageIndicator.tsx
+++ b/app/components/ContextUsageIndicator.tsx
@@ -5,10 +5,20 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { forwardRef, type ComponentPropsWithoutRef } from "react";
 
 export interface ContextUsageData {
   usedTokens: number;
   maxTokens: number;
+}
+
+interface ContextUsageIndicatorProps extends ContextUsageData {
+  variant?: "tooltip" | "compact-popover";
 }
 
 function formatTokenCount(n: number): string {
@@ -24,56 +34,124 @@ function formatTokenCount(n: number): string {
   return String(n);
 }
 
+function formatExactTokenCount(n: number): string {
+  return Math.round(n).toLocaleString();
+}
+
 const CIRCLE_SIZE = 16;
 const STROKE_WIDTH = 2.5;
 const RADIUS = (CIRCLE_SIZE - STROKE_WIDTH) / 2;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
+function ContextUsageCircle({ dashOffset }: { dashOffset: number }) {
+  return (
+    <svg
+      width={CIRCLE_SIZE}
+      height={CIRCLE_SIZE}
+      viewBox={`0 0 ${CIRCLE_SIZE} ${CIRCLE_SIZE}`}
+      className="shrink-0 -rotate-90"
+      data-testid="context-usage-circle"
+    >
+      <circle
+        cx={CIRCLE_SIZE / 2}
+        cy={CIRCLE_SIZE / 2}
+        r={RADIUS}
+        fill="none"
+        className="stroke-muted"
+        strokeWidth={STROKE_WIDTH}
+      />
+      <circle
+        cx={CIRCLE_SIZE / 2}
+        cy={CIRCLE_SIZE / 2}
+        r={RADIUS}
+        fill="none"
+        className="transition-all duration-300 stroke-foreground"
+        strokeWidth={STROKE_WIDTH}
+        strokeDasharray={CIRCUMFERENCE}
+        strokeDashoffset={dashOffset}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+const ContextUsageHoverTrigger = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div"> & ContextUsageData & { dashOffset: number }
+>(({ usedTokens, maxTokens, dashOffset, ...props }, ref) => (
+  <div
+    ref={ref}
+    className="flex items-center h-7 px-1 cursor-default"
+    aria-label={`Context usage: ${formatTokenCount(usedTokens)} of ${formatTokenCount(maxTokens)} tokens`}
+    data-testid="context-usage-indicator"
+    {...props}
+  >
+    <ContextUsageCircle dashOffset={dashOffset} />
+  </div>
+));
+ContextUsageHoverTrigger.displayName = "ContextUsageHoverTrigger";
+
+const ContextUsageButtonTrigger = forwardRef<
+  HTMLButtonElement,
+  ComponentPropsWithoutRef<"button"> & ContextUsageData & { dashOffset: number }
+>(({ usedTokens, maxTokens, dashOffset, ...props }, ref) => (
+  <button
+    ref={ref}
+    type="button"
+    className="flex items-center justify-center h-7 w-7 cursor-pointer rounded-full p-0 text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+    aria-label={`Context usage: ${formatTokenCount(usedTokens)} of ${formatTokenCount(maxTokens)} tokens`}
+    data-testid="context-usage-indicator"
+    {...props}
+  >
+    <ContextUsageCircle dashOffset={dashOffset} />
+  </button>
+));
+ContextUsageButtonTrigger.displayName = "ContextUsageButtonTrigger";
+
 export const ContextUsageIndicator = ({
   usedTokens,
   maxTokens,
-}: ContextUsageData) => {
+  variant = "tooltip",
+}: ContextUsageIndicatorProps) => {
   if (usedTokens === 0 || maxTokens === 0) return null;
   const percent = Math.min((usedTokens / maxTokens) * 100, 100);
   const remaining = Math.max(0, 100 - Math.round(percent));
   const dashOffset = CIRCUMFERENCE - (percent / 100) * CIRCUMFERENCE;
 
+  if (variant === "compact-popover") {
+    return (
+      <Popover>
+        <PopoverTrigger asChild>
+          <ContextUsageButtonTrigger
+            usedTokens={usedTokens}
+            maxTokens={maxTokens}
+            dashOffset={dashOffset}
+          />
+        </PopoverTrigger>
+        <PopoverContent
+          side="top"
+          align="end"
+          sideOffset={8}
+          className="w-auto max-w-[240px] px-3 py-2.5 text-center"
+        >
+          <div className="font-medium text-xs">Context window:</div>
+          <div className="text-xs tabular-nums">
+            {remaining}% left ({formatExactTokenCount(usedTokens)} used /{" "}
+            {formatExactTokenCount(maxTokens)})
+          </div>
+        </PopoverContent>
+      </Popover>
+    );
+  }
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <div
-          className="flex items-center h-7 px-1 cursor-default"
-          aria-label={`Context usage: ${formatTokenCount(usedTokens)} of ${formatTokenCount(maxTokens)} tokens`}
-          data-testid="context-usage-indicator"
-        >
-          <svg
-            width={CIRCLE_SIZE}
-            height={CIRCLE_SIZE}
-            viewBox={`0 0 ${CIRCLE_SIZE} ${CIRCLE_SIZE}`}
-            className="shrink-0 -rotate-90"
-            data-testid="context-usage-circle"
-          >
-            <circle
-              cx={CIRCLE_SIZE / 2}
-              cy={CIRCLE_SIZE / 2}
-              r={RADIUS}
-              fill="none"
-              className="stroke-muted"
-              strokeWidth={STROKE_WIDTH}
-            />
-            <circle
-              cx={CIRCLE_SIZE / 2}
-              cy={CIRCLE_SIZE / 2}
-              r={RADIUS}
-              fill="none"
-              className="transition-all duration-300 stroke-foreground"
-              strokeWidth={STROKE_WIDTH}
-              strokeDasharray={CIRCUMFERENCE}
-              strokeDashoffset={dashOffset}
-              strokeLinecap="round"
-            />
-          </svg>
-        </div>
+        <ContextUsageHoverTrigger
+          usedTokens={usedTokens}
+          maxTokens={maxTokens}
+          dashOffset={dashOffset}
+        />
       </TooltipTrigger>
       <TooltipContent
         side="top"

--- a/app/components/ContextUsageIndicator.tsx
+++ b/app/components/ContextUsageIndicator.tsx
@@ -81,7 +81,8 @@ const ContextUsageHoverTrigger = forwardRef<
 >(({ usedTokens, maxTokens, dashOffset, ...props }, ref) => (
   <div
     ref={ref}
-    className="flex items-center h-7 px-1 cursor-default"
+    tabIndex={0}
+    className="flex items-center h-7 px-1 cursor-default rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
     aria-label={`Context usage: ${formatTokenCount(usedTokens)} of ${formatTokenCount(maxTokens)} tokens`}
     data-testid="context-usage-indicator"
     {...props}

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -1,4 +1,11 @@
-import { memo, useMemo, useCallback, Fragment } from "react";
+import {
+  memo,
+  useMemo,
+  useCallback,
+  useEffect,
+  useState,
+  Fragment,
+} from "react";
 import { MessageActions } from "./MessageActions";
 import { MessagePartHandler } from "./MessagePartHandler";
 import { FilePartRenderer } from "./FilePartRenderer";
@@ -7,12 +14,18 @@ import { FeedbackInput } from "./FeedbackInput";
 import { BranchIndicator } from "./BranchIndicator";
 import { FinishReasonNotice } from "./FinishReasonNotice";
 import { Shimmer } from "@/components/ai-elements/shimmer";
+import {
+  WorkedFor,
+  WorkedForContent,
+  WorkedForTrigger,
+} from "@/components/ai-elements/worked-for";
 import { FileSearch, WandSparkles } from "lucide-react";
 import {
   extractMessageText,
   hasTextContent,
   extractWebSourcesFromMessage,
 } from "@/lib/utils/message-utils";
+import { isAgentMode } from "@/lib/utils/mode-helpers";
 import type { ChatStatus, ChatMessage, ChatMode } from "@/types";
 import type { FileDetails } from "@/types/file";
 
@@ -69,6 +82,7 @@ function areMessageItemPropsEqual(
   if (prev.lastAssistantMessageIndex !== next.lastAssistantMessageIndex)
     return false;
   if (prev.finishReason !== next.finishReason) return false;
+  if (prev.mode !== next.mode) return false;
   if (prev.showingLoadingIndicator !== next.showingLoadingIndicator)
     return false;
   if (prev.summarizationStatus?.status !== next.summarizationStatus?.status)
@@ -84,6 +98,21 @@ function areMessageItemPropsEqual(
     const prevLastPart = prev.message.parts[prev.message.parts.length - 1];
     const nextLastPart = next.message.parts[next.message.parts.length - 1];
     if (prevLastPart !== nextLastPart) return false;
+    // generationTimeMs arrives in message-metadata after the last text-delta;
+    // parts may be unchanged but metadata needs to trigger a re-render so the
+    // "Worked for X" pill shows the duration.
+    if (prev.message.metadata?.mode !== next.message.metadata?.mode)
+      return false;
+    if (
+      prev.message.metadata?.generationStartedAt !==
+      next.message.metadata?.generationStartedAt
+    )
+      return false;
+    if (
+      prev.message.metadata?.generationTimeMs !==
+      next.message.metadata?.generationTimeMs
+    )
+      return false;
   }
 
   return true;
@@ -148,11 +177,70 @@ export const MessageItem = memo(function MessageItem({
   );
 
   // Memoize part filtering - only recompute when parts change
-  const { fileParts, nonFileParts } = useMemo(() => {
-    const files = message.parts.filter((part) => part.type === "file");
-    const nonFiles = message.parts.filter((part) => part.type !== "file");
-    return { fileParts: files, nonFileParts: nonFiles };
-  }, [message.parts]);
+  const { fileParts, nonFileParts, workParts, trailingTextParts } =
+    useMemo(() => {
+      const files = message.parts.filter((part) => part.type === "file");
+      const nonFiles = message.parts.filter((part) => part.type !== "file");
+      // Find the trailing run of contiguous text parts at the end of nonFiles.
+      // Everything before it counts as "work" (reasoning, tool calls, data,
+      // intermediate text). This split powers the Codex-style collapse:
+      // the work is hidden behind a "Worked for X" pill, the final text stays
+      // visible below.
+      let trailingStart = nonFiles.length;
+      for (let i = nonFiles.length - 1; i >= 0; i--) {
+        if ((nonFiles[i] as { type?: string }).type === "text") {
+          trailingStart = i;
+        } else {
+          break;
+        }
+      }
+      return {
+        fileParts: files,
+        nonFileParts: nonFiles,
+        workParts: nonFiles.slice(0, trailingStart),
+        trailingTextParts: nonFiles.slice(trailingStart),
+      };
+    }, [message.parts]);
+
+  const isStreamingThisMessage =
+    message.role === "assistant" &&
+    isLastAssistantMessage &&
+    effectiveStatus === "streaming";
+
+  const generationTimeMs =
+    typeof message.metadata?.generationTimeMs === "number"
+      ? message.metadata.generationTimeMs
+      : undefined;
+  const generationStartedAt =
+    typeof message.metadata?.generationStartedAt === "number"
+      ? message.metadata.generationStartedAt
+      : undefined;
+  const [streamedMessageId, setStreamedMessageId] = useState<string | null>(
+    null,
+  );
+  useEffect(() => {
+    if (!isStreamingThisMessage) return;
+
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) {
+        setStreamedMessageId(message.id);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isStreamingThisMessage, message.id]);
+  const isAwaitingGenerationTime =
+    message.role === "assistant" &&
+    isLastAssistantMessage &&
+    effectiveStatus === "ready" &&
+    streamedMessageId === message.id &&
+    generationTimeMs === undefined;
+  const shouldShowWorkingTimer =
+    isStreamingThisMessage || isAwaitingGenerationTime;
+  const shouldUseWorkedFor = message.metadata?.mode === "agent";
 
   // Pre-compute terminal output by toolCallId so TerminalToolHandler doesn't filter all parts per instance
   const terminalOutputByToolCallId = useMemo(() => {
@@ -182,6 +270,22 @@ export const MessageItem = memo(function MessageItem({
     if (isUser || !effectiveFileDetails) return [];
     return effectiveFileDetails.filter((f) => f.url || f.storageId || f.s3Key);
   }, [isUser, effectiveFileDetails]);
+
+  const renderAssistantPart = (
+    part: ChatMessage["parts"][number],
+    partIndex: number,
+  ) => (
+    <MessagePartHandler
+      key={`${message.id}-${partIndex}`}
+      message={message}
+      part={part}
+      partIndex={partIndex}
+      status={effectiveStatus}
+      isLastMessage={isLastMessage}
+      terminalOutputByToolCallId={terminalOutputByToolCallId}
+      sharedFileDetails={effectiveFileDetails}
+    />
+  );
 
   const shouldShowBranchIndicator = Boolean(
     branchedFromChatId &&
@@ -307,9 +411,8 @@ export const MessageItem = memo(function MessageItem({
                       />
                     ))}
                   </div>
-                ) : (
-                  // For assistant messages, render all parts in original order
-                  message.parts.map((part, partIndex) => (
+                ) : !shouldUseWorkedFor ? (
+                  nonFileParts.map((part, partIndex) => (
                     <MessagePartHandler
                       key={`${message.id}-${partIndex}`}
                       message={message}
@@ -321,6 +424,71 @@ export const MessageItem = memo(function MessageItem({
                       sharedFileDetails={effectiveFileDetails}
                     />
                   ))
+                ) : shouldShowWorkingTimer ? (
+                  <>
+                    {workParts.length > 0 && (
+                      <WorkedFor key="working" hasWork defaultOpen>
+                        <WorkedForTrigger
+                          isTiming
+                          startedAt={generationStartedAt}
+                        />
+                        <WorkedForContent>
+                          {workParts.map(renderAssistantPart)}
+                        </WorkedForContent>
+                      </WorkedFor>
+                    )}
+                    {trailingTextParts.length > 0 && (
+                      <div
+                        className={
+                          workParts.length > 0 ? "mt-4 space-y-3" : "space-y-3"
+                        }
+                      >
+                        {trailingTextParts.map((part, partIndex) =>
+                          renderAssistantPart(
+                            part,
+                            workParts.length + partIndex,
+                          ),
+                        )}
+                      </div>
+                    )}
+                  </>
+                ) : trailingTextParts.length === 0 ? (
+                  // No final text output (e.g. run ended mid-tool or was
+                  // aborted before a summary). Don't hide the work behind a
+                  // "Worked for" pill — that would leave the user with an
+                  // empty-looking message. Render the parts inline.
+                  nonFileParts.map((part, partIndex) => (
+                    <MessagePartHandler
+                      key={`${message.id}-${partIndex}`}
+                      message={message}
+                      part={part}
+                      partIndex={partIndex}
+                      status={effectiveStatus}
+                      isLastMessage={isLastMessage}
+                      terminalOutputByToolCallId={terminalOutputByToolCallId}
+                      sharedFileDetails={effectiveFileDetails}
+                    />
+                  ))
+                ) : (
+                  <>
+                    {workParts.length > 0 && (
+                      <WorkedFor key="worked" hasWork>
+                        <WorkedForTrigger durationMs={generationTimeMs} />
+                        <WorkedForContent lazy>
+                          {() => workParts.map(renderAssistantPart)}
+                        </WorkedForContent>
+                      </WorkedFor>
+                    )}
+                    <div
+                      className={
+                        workParts.length > 0 ? "mt-4 space-y-3" : "space-y-3"
+                      }
+                    >
+                      {trailingTextParts.map((part, partIndex) =>
+                        renderAssistantPart(part, workParts.length + partIndex),
+                      )}
+                    </div>
+                  </>
                 )}
               </div>
             )}

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -1,11 +1,4 @@
-import {
-  memo,
-  useMemo,
-  useCallback,
-  useEffect,
-  useState,
-  Fragment,
-} from "react";
+import { memo, useMemo, useCallback, Fragment } from "react";
 import { MessageActions } from "./MessageActions";
 import { MessagePartHandler } from "./MessagePartHandler";
 import { FilePartRenderer } from "./FilePartRenderer";
@@ -13,6 +6,7 @@ import { MessageEditor, EditableFile } from "./MessageEditor";
 import { FeedbackInput } from "./FeedbackInput";
 import { BranchIndicator } from "./BranchIndicator";
 import { FinishReasonNotice } from "./FinishReasonNotice";
+import { splitWorkedForParts } from "./worked-for-parts";
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import {
   WorkedFor,
@@ -177,30 +171,10 @@ export const MessageItem = memo(function MessageItem({
   );
 
   // Memoize part filtering - only recompute when parts change
-  const { fileParts, nonFileParts, workParts, trailingTextParts } =
-    useMemo(() => {
-      const files = message.parts.filter((part) => part.type === "file");
-      const nonFiles = message.parts.filter((part) => part.type !== "file");
-      // Find the trailing run of contiguous text parts at the end of nonFiles.
-      // Everything before it counts as "work" (reasoning, tool calls, data,
-      // intermediate text). This split powers the Codex-style collapse:
-      // the work is hidden behind a "Worked for X" pill, the final text stays
-      // visible below.
-      let trailingStart = nonFiles.length;
-      for (let i = nonFiles.length - 1; i >= 0; i--) {
-        if ((nonFiles[i] as { type?: string }).type === "text") {
-          trailingStart = i;
-        } else {
-          break;
-        }
-      }
-      return {
-        fileParts: files,
-        nonFileParts: nonFiles,
-        workParts: nonFiles.slice(0, trailingStart),
-        trailingTextParts: nonFiles.slice(trailingStart),
-      };
-    }, [message.parts]);
+  const { fileParts, nonFileParts, workParts, trailingTextParts } = useMemo(
+    () => splitWorkedForParts(message.parts),
+    [message.parts],
+  );
 
   const isStreamingThisMessage =
     message.role === "assistant" &&
@@ -215,31 +189,7 @@ export const MessageItem = memo(function MessageItem({
     typeof message.metadata?.generationStartedAt === "number"
       ? message.metadata.generationStartedAt
       : undefined;
-  const [streamedMessageId, setStreamedMessageId] = useState<string | null>(
-    null,
-  );
-  useEffect(() => {
-    if (!isStreamingThisMessage) return;
-
-    let cancelled = false;
-    queueMicrotask(() => {
-      if (!cancelled) {
-        setStreamedMessageId(message.id);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isStreamingThisMessage, message.id]);
-  const isAwaitingGenerationTime =
-    message.role === "assistant" &&
-    isLastAssistantMessage &&
-    effectiveStatus === "ready" &&
-    streamedMessageId === message.id &&
-    generationTimeMs === undefined;
-  const shouldShowWorkingTimer =
-    isStreamingThisMessage || isAwaitingGenerationTime;
+  const shouldShowWorkingTimer = isStreamingThisMessage;
   const shouldUseWorkedFor = message.metadata?.mode === "agent";
 
   // Pre-compute terminal output by toolCallId so TerminalToolHandler doesn't filter all parts per instance
@@ -325,14 +275,13 @@ export const MessageItem = memo(function MessageItem({
   // Memoize editable files for MessageEditor
   const editableFiles = useMemo(() => {
     return fileParts
-      .filter((part) => part.type === "file" && (part as any).fileId)
+      .filter((part) => part.fileId)
       .map((part) => {
-        const filePart = part as any;
         return {
-          fileId: filePart.fileId as string,
-          name: filePart.name || filePart.filename || "File",
-          mediaType: filePart.mediaType,
-          url: filePart.url || getCachedUrl(filePart.fileId as string),
+          fileId: part.fileId as string,
+          name: part.name || part.filename || "File",
+          mediaType: part.mediaType,
+          url: part.url || getCachedUrl(part.fileId as string),
         } as EditableFile;
       });
   }, [fileParts, getCachedUrl]);
@@ -427,7 +376,12 @@ export const MessageItem = memo(function MessageItem({
                 ) : shouldShowWorkingTimer ? (
                   <>
                     {workParts.length > 0 && (
-                      <WorkedFor key="working" hasWork defaultOpen>
+                      <WorkedFor
+                        key="work"
+                        hasWork
+                        defaultOpen
+                        isTiming={shouldShowWorkingTimer}
+                      >
                         <WorkedForTrigger
                           isTiming
                           startedAt={generationStartedAt}
@@ -453,10 +407,8 @@ export const MessageItem = memo(function MessageItem({
                     )}
                   </>
                 ) : trailingTextParts.length === 0 ? (
-                  // No final text output (e.g. run ended mid-tool or was
-                  // aborted before a summary). Don't hide the work behind a
-                  // "Worked for" pill — that would leave the user with an
-                  // empty-looking message. Render the parts inline.
+                  // If a run stops before producing final text, keep the work
+                  // visible inline instead of leaving only a collapsed header.
                   nonFileParts.map((part, partIndex) => (
                     <MessagePartHandler
                       key={`${message.id}-${partIndex}`}
@@ -472,22 +424,31 @@ export const MessageItem = memo(function MessageItem({
                 ) : (
                   <>
                     {workParts.length > 0 && (
-                      <WorkedFor key="worked" hasWork>
+                      <WorkedFor
+                        key="work"
+                        hasWork
+                        isTiming={shouldShowWorkingTimer}
+                      >
                         <WorkedForTrigger durationMs={generationTimeMs} />
-                        <WorkedForContent lazy>
+                        <WorkedForContent>
                           {() => workParts.map(renderAssistantPart)}
                         </WorkedForContent>
                       </WorkedFor>
                     )}
-                    <div
-                      className={
-                        workParts.length > 0 ? "mt-4 space-y-3" : "space-y-3"
-                      }
-                    >
-                      {trailingTextParts.map((part, partIndex) =>
-                        renderAssistantPart(part, workParts.length + partIndex),
-                      )}
-                    </div>
+                    {trailingTextParts.length > 0 && (
+                      <div
+                        className={
+                          workParts.length > 0 ? "mt-4 space-y-3" : "space-y-3"
+                        }
+                      >
+                        {trailingTextParts.map((part, partIndex) =>
+                          renderAssistantPart(
+                            part,
+                            workParts.length + partIndex,
+                          ),
+                        )}
+                      </div>
+                    )}
                   </>
                 )}
               </div>

--- a/app/components/__tests__/ContextUsageIndicator.test.tsx
+++ b/app/components/__tests__/ContextUsageIndicator.test.tsx
@@ -29,6 +29,13 @@ describe("ContextUsageIndicator", () => {
       const indicator = screen.getByTestId("context-usage-indicator");
       expect(indicator.tagName).toBe("DIV");
     });
+
+    it("keeps the passive desktop target keyboard-focusable", () => {
+      render(<ContextUsageIndicator {...defaultProps} />);
+      const indicator = screen.getByTestId("context-usage-indicator");
+
+      expect(indicator).toHaveAttribute("tabIndex", "0");
+    });
   });
 
   describe("Zero tokens state", () => {

--- a/app/components/__tests__/ContextUsageIndicator.test.tsx
+++ b/app/components/__tests__/ContextUsageIndicator.test.tsx
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom";
 import { describe, it, expect } from "@jest/globals";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ContextUsageIndicator } from "../ContextUsageIndicator";
 
 describe("ContextUsageIndicator", () => {
@@ -22,6 +23,12 @@ describe("ContextUsageIndicator", () => {
       const indicator = screen.getByTestId("context-usage-indicator");
       expect(indicator.textContent).toBe("");
     });
+
+    it("uses a passive hover target by default", () => {
+      render(<ContextUsageIndicator {...defaultProps} />);
+      const indicator = screen.getByTestId("context-usage-indicator");
+      expect(indicator.tagName).toBe("DIV");
+    });
   });
 
   describe("Zero tokens state", () => {
@@ -41,6 +48,27 @@ describe("ContextUsageIndicator", () => {
         "aria-label",
         "Context usage: 8.0k of 100k tokens",
       );
+    });
+  });
+
+  describe("Compact popover", () => {
+    it("opens a short mobile-friendly message on click", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <ContextUsageIndicator
+          usedTokens={189833}
+          maxTokens={258000}
+          variant="compact-popover"
+        />,
+      );
+
+      await user.click(screen.getByTestId("context-usage-indicator"));
+
+      expect(screen.getByText("Context window:")).toBeInTheDocument();
+      expect(
+        screen.getByText("26% left (189,833 used / 258,000)"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/app/components/__tests__/MessageItem.worked-for.test.tsx
+++ b/app/components/__tests__/MessageItem.worked-for.test.tsx
@@ -117,6 +117,66 @@ describe("MessageItem WorkedFor rendering", () => {
     expect(screen.getByText("final answer")).toBeInTheDocument();
   });
 
+  it("renders stopped agent work inline when there is no final text", () => {
+    renderMessageItem({
+      mode: "agent",
+      message: {
+        ...assistantMessage,
+        parts: [
+          {
+            type: "tool-shell",
+            input: "ran command",
+            state: "output-available",
+          },
+        ],
+        metadata: {
+          mode: "agent",
+          generationStartedAt: 1_000,
+          generationTimeMs: 2_500,
+        },
+      } as unknown as ChatMessage,
+      status: "ready",
+    });
+
+    expect(screen.queryByRole("button", { name: /worked for/i })).toBeNull();
+    expect(screen.getByText("ran command")).toBeInTheDocument();
+  });
+
+  it("keeps regenerated final text visible when stream metadata trails it", () => {
+    renderMessageItem({
+      mode: "agent",
+      message: {
+        ...assistantMessage,
+        parts: [
+          {
+            type: "tool-shell",
+            input: "ran command",
+            state: "output-available",
+          },
+          {
+            type: "text",
+            text: "regenerated final answer",
+          },
+          {
+            type: "data-context-usage",
+            data: {},
+          },
+        ],
+        metadata: {
+          mode: "agent",
+          generationTimeMs: 1_500,
+        },
+      } as unknown as ChatMessage,
+      status: "ready",
+    });
+
+    expect(
+      screen.getByRole("button", { name: /worked for 2s/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("ran command")).not.toBeInTheDocument();
+    expect(screen.getByText("regenerated final answer")).toBeInTheDocument();
+  });
+
   it("keeps saved message mode stable when the current picker mode changes", () => {
     const { rerender } = renderMessageItem({ mode: "ask" });
 

--- a/app/components/__tests__/MessageItem.worked-for.test.tsx
+++ b/app/components/__tests__/MessageItem.worked-for.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen } from "@testing-library/react";
+import { MessageItem } from "../MessageItem";
+import type { ChatMessage, ChatMode, ChatStatus } from "@/types";
+
+jest.mock("../MessagePartHandler", () => ({
+  MessagePartHandler: ({ part }: { part: any }) => (
+    <div data-testid={`part-${part.type}`}>
+      {part.text ?? part.input ?? part.type}
+    </div>
+  ),
+}));
+
+jest.mock("../MessageActions", () => ({
+  MessageActions: () => <div data-testid="message-actions" />,
+}));
+
+jest.mock("../FilePartRenderer", () => ({
+  FilePartRenderer: () => <div data-testid="file-part" />,
+}));
+
+jest.mock("../MessageEditor", () => ({
+  MessageEditor: () => <div data-testid="message-editor" />,
+}));
+
+jest.mock("../FeedbackInput", () => ({
+  FeedbackInput: () => <div data-testid="feedback-input" />,
+}));
+
+jest.mock("../BranchIndicator", () => ({
+  BranchIndicator: () => <div data-testid="branch-indicator" />,
+}));
+
+jest.mock("../FinishReasonNotice", () => ({
+  FinishReasonNotice: () => null,
+}));
+
+const assistantMessage = {
+  id: "assistant-1",
+  role: "assistant",
+  parts: [
+    {
+      type: "tool-shell",
+      input: "ran command",
+      state: "output-available",
+    },
+    {
+      type: "text",
+      text: "final answer",
+    },
+  ],
+  metadata: {
+    mode: "agent",
+    generationTimeMs: 1_500,
+  },
+} as unknown as ChatMessage;
+
+const renderMessageItem = ({
+  mode,
+  message = assistantMessage,
+  status = "ready",
+}: {
+  mode: ChatMode;
+  message?: ChatMessage;
+  status?: ChatStatus;
+}) =>
+  render(
+    <MessageItem
+      message={message}
+      index={0}
+      messagesLength={1}
+      lastAssistantMessageIndex={0}
+      status={status}
+      isHovered={false}
+      isEditing={false}
+      feedbackInputMessageId={null}
+      mode={mode}
+      branchBoundaryIndex={undefined}
+      onMouseEnter={jest.fn()}
+      onMouseLeave={jest.fn()}
+      onStartEdit={jest.fn()}
+      onSaveEdit={jest.fn()}
+      onCancelEdit={jest.fn()}
+      onRegenerate={jest.fn()}
+      onFeedback={jest.fn()}
+      onFeedbackSubmit={jest.fn()}
+      onFeedbackCancel={jest.fn()}
+      onShowAllFiles={jest.fn()}
+      getCachedUrl={jest.fn()}
+    />,
+  );
+
+describe("MessageItem WorkedFor rendering", () => {
+  it("renders work inline for messages generated in ask mode", () => {
+    renderMessageItem({
+      mode: "agent",
+      message: {
+        ...assistantMessage,
+        metadata: {
+          mode: "ask",
+          generationTimeMs: 1_500,
+        },
+      } as ChatMessage,
+    });
+
+    expect(screen.queryByText(/worked for/i)).not.toBeInTheDocument();
+    expect(screen.getByText("ran command")).toBeInTheDocument();
+    expect(screen.getByText("final answer")).toBeInTheDocument();
+  });
+
+  it("shows Worked for for messages generated in agent mode", () => {
+    renderMessageItem({ mode: "ask" });
+
+    expect(
+      screen.getByRole("button", { name: /worked for 2s/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("ran command")).not.toBeInTheDocument();
+    expect(screen.getByText("final answer")).toBeInTheDocument();
+  });
+
+  it("keeps saved message mode stable when the current picker mode changes", () => {
+    const { rerender } = renderMessageItem({ mode: "ask" });
+
+    expect(
+      screen.getByRole("button", { name: /worked for 2s/i }),
+    ).toBeInTheDocument();
+
+    rerender(
+      <MessageItem
+        message={assistantMessage}
+        index={0}
+        messagesLength={1}
+        lastAssistantMessageIndex={0}
+        status="ready"
+        isHovered={false}
+        isEditing={false}
+        feedbackInputMessageId={null}
+        mode="agent"
+        branchBoundaryIndex={undefined}
+        onMouseEnter={jest.fn()}
+        onMouseLeave={jest.fn()}
+        onStartEdit={jest.fn()}
+        onSaveEdit={jest.fn()}
+        onCancelEdit={jest.fn()}
+        onRegenerate={jest.fn()}
+        onFeedback={jest.fn()}
+        onFeedbackSubmit={jest.fn()}
+        onFeedbackCancel={jest.fn()}
+        onShowAllFiles={jest.fn()}
+        getCachedUrl={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /worked for 2s/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("ran command")).not.toBeInTheDocument();
+    expect(screen.getByText("final answer")).toBeInTheDocument();
+  });
+
+  it("renders legacy messages without saved mode inline", () => {
+    renderMessageItem({
+      mode: "agent",
+      message: {
+        ...assistantMessage,
+        metadata: {
+          generationTimeMs: 1_500,
+        },
+      } as ChatMessage,
+    });
+
+    expect(screen.queryByText(/worked for/i)).not.toBeInTheDocument();
+    expect(screen.getByText("ran command")).toBeInTheDocument();
+  });
+});

--- a/app/components/__tests__/worked-for-parts.test.ts
+++ b/app/components/__tests__/worked-for-parts.test.ts
@@ -1,0 +1,70 @@
+import { splitWorkedForParts } from "../worked-for-parts";
+import type { ChatMessage } from "@/types";
+
+const part = (
+  type: string,
+  extra: Record<string, unknown> = {},
+): ChatMessage["parts"][number] =>
+  ({
+    type,
+    ...extra,
+  }) as ChatMessage["parts"][number];
+
+describe("splitWorkedForParts", () => {
+  it("keeps tool work collapsed and trailing answer text visible", () => {
+    const tool = part("tool-shell", { input: "ran command" });
+    const text = part("text", { text: "final answer" });
+
+    const result = splitWorkedForParts([tool, text]);
+
+    expect(result.fileParts).toEqual([]);
+    expect(result.nonFileParts).toEqual([tool, text]);
+    expect(result.workParts).toEqual([tool]);
+    expect(result.trailingTextParts).toEqual([text]);
+  });
+
+  it("treats stopped tool-only messages as work with no visible answer", () => {
+    const tool = part("tool-shell", { input: "ran command" });
+
+    const result = splitWorkedForParts([tool]);
+
+    expect(result.workParts).toEqual([tool]);
+    expect(result.trailingTextParts).toEqual([]);
+  });
+
+  it("ignores trailing stream metadata after regenerated answer text", () => {
+    const tool = part("tool-shell", { input: "ran command" });
+    const text = part("text", { text: "regenerated final answer" });
+    const metadata = part("data-context-usage", { data: {} });
+
+    const result = splitWorkedForParts([tool, text, metadata]);
+
+    expect(result.workParts).toEqual([tool]);
+    expect(result.trailingTextParts).toEqual([text]);
+  });
+
+  it("does not ignore rendered data-terminal parts at the tail", () => {
+    const text = part("text", { text: "intermediate text" });
+    const terminal = part("data-terminal", {
+      data: { terminal: "output", toolCallId: "tool-1" },
+    });
+
+    const result = splitWorkedForParts([text, terminal]);
+
+    expect(result.workParts).toEqual([text, terminal]);
+    expect(result.trailingTextParts).toEqual([]);
+  });
+
+  it("separates file parts from worked-for parts", () => {
+    const file = part("file", { url: "https://example.com/file.txt" });
+    const tool = part("tool-shell", { input: "ran command" });
+    const text = part("text", { text: "final answer" });
+
+    const result = splitWorkedForParts([file, tool, text]);
+
+    expect(result.fileParts).toEqual([file]);
+    expect(result.nonFileParts).toEqual([tool, text]);
+    expect(result.workParts).toEqual([tool]);
+    expect(result.trailingTextParts).toEqual([text]);
+  });
+});

--- a/app/components/worked-for-parts.ts
+++ b/app/components/worked-for-parts.ts
@@ -1,0 +1,62 @@
+import type { ChatMessage } from "@/types";
+import type { FilePart } from "@/types/file";
+
+type MessagePart = ChatMessage["parts"][number];
+
+const TRAILING_METADATA_PART_TYPES = new Set([
+  "data-agent-heartbeat",
+  "data-appendMessage",
+  "data-auto-continue",
+  "data-context-usage",
+  "data-diff",
+  "data-file-metadata",
+  "data-rate-limit-warning",
+  "data-sandbox-fallback",
+  "data-title",
+  "data-upload-status",
+  "finish-step",
+  "step-start",
+]);
+
+export type WorkedForParts = {
+  fileParts: FilePart[];
+  nonFileParts: MessagePart[];
+  workParts: MessagePart[];
+  trailingTextParts: MessagePart[];
+};
+
+const isTrailingMetadataPart = (part: MessagePart) => {
+  const type = (part as { type?: string }).type;
+  return !!type && TRAILING_METADATA_PART_TYPES.has(type);
+};
+
+export function splitWorkedForParts(
+  parts: ChatMessage["parts"],
+): WorkedForParts {
+  const fileParts = parts.filter((part) => part.type === "file") as FilePart[];
+  const nonFileParts = parts.filter((part) => part.type !== "file");
+
+  let trailingEnd = nonFileParts.length;
+  while (
+    trailingEnd > 0 &&
+    isTrailingMetadataPart(nonFileParts[trailingEnd - 1])
+  ) {
+    trailingEnd -= 1;
+  }
+
+  let trailingStart = trailingEnd;
+  for (let i = trailingEnd - 1; i >= 0; i--) {
+    if ((nonFileParts[i] as { type?: string }).type === "text") {
+      trailingStart = i;
+    } else {
+      break;
+    }
+  }
+
+  return {
+    fileParts,
+    nonFileParts,
+    workParts: nonFileParts.slice(0, trailingStart),
+    trailingTextParts: nonFileParts.slice(trailingStart, trailingEnd),
+  };
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -253,7 +253,7 @@
 }
 
 .worked-for-content[data-state="closed"] {
-  animation: worked-for-content-close 220ms cubic-bezier(0.16, 1, 0.3, 1);
+  animation: worked-for-content-close 360ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -210,10 +210,58 @@
   }
 }
 
+@keyframes worked-for-content-open {
+  from {
+    height: 0;
+    opacity: 0;
+    transform: translateY(-0.375rem);
+  }
+  to {
+    height: var(--radix-collapsible-content-height);
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes worked-for-content-close {
+  from {
+    height: var(--radix-collapsible-content-height);
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    height: 0;
+    opacity: 0;
+    transform: translateY(-0.375rem);
+  }
+}
+
 .animate-text-shimmer {
   animation-name: text-shimmer;
   animation-iteration-count: infinite;
   animation-timing-function: linear;
+}
+
+.worked-for-content {
+  overflow: hidden;
+  transform-origin: top;
+  will-change: height, opacity, transform;
+}
+
+.worked-for-content[data-state="open"] {
+  animation: worked-for-content-open 260ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.worked-for-content[data-state="closed"] {
+  animation: worked-for-content-close 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .worked-for-content[data-state="open"],
+  .worked-for-content[data-state="closed"] {
+    animation-duration: 1ms;
+    transform: none;
+  }
 }
 
 /* Scrollbar Styles */

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -135,14 +135,43 @@ export const useChatHandlers = ({
     const { messages: normalizedMessages, hasChanges } =
       normalizeMessages(messages);
 
+    const stopTime = Date.now();
+    const normalizedLastMessage =
+      normalizedMessages[normalizedMessages.length - 1];
+    const generationStartedAt =
+      typeof normalizedLastMessage?.metadata?.generationStartedAt === "number"
+        ? normalizedLastMessage.metadata.generationStartedAt
+        : undefined;
+    const generationTimeMs =
+      generationStartedAt !== undefined
+        ? Math.max(0, stopTime - generationStartedAt)
+        : undefined;
+    const stoppedMessages =
+      normalizedLastMessage?.role === "assistant" &&
+      generationTimeMs !== undefined
+        ? [
+            ...normalizedMessages.slice(0, -1),
+            {
+              ...normalizedLastMessage,
+              metadata: {
+                ...normalizedLastMessage.metadata,
+                mode:
+                  normalizedLastMessage.metadata?.mode ?? chatModeRef.current,
+                generationStartedAt,
+                generationTimeMs,
+              },
+            },
+          ]
+        : normalizedMessages;
+
     // Update local state if changes were made
-    if (hasChanges) {
-      setMessages(normalizedMessages);
+    if (hasChanges || stoppedMessages !== normalizedMessages) {
+      setMessages(stoppedMessages);
     }
 
     if (!temporaryChatsEnabledRef.current) {
       // Run cancel and save in parallel - they're independent operations
-      const lastMessage = normalizedMessages[normalizedMessages.length - 1];
+      const lastMessage = stoppedMessages[stoppedMessages.length - 1];
       const savePromise =
         !options?.skipSave && lastMessage?.role === "assistant"
           ? saveAssistantMessage({
@@ -150,6 +179,9 @@ export const useChatHandlers = ({
               chatId,
               role: lastMessage.role,
               parts: lastMessage.parts,
+              mode: lastMessage.metadata?.mode ?? chatModeRef.current,
+              generationStartedAt,
+              generationTimeMs,
             }).catch((error) => {
               console.error("Failed to save message on stop:", error);
             })

--- a/app/hooks/useMessageScroll.ts
+++ b/app/hooks/useMessageScroll.ts
@@ -1,5 +1,6 @@
 import { useStickToBottom } from "use-stick-to-bottom";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
+import { STICKY_BOTTOM_ESCAPE_EVENT } from "@/lib/utils/scroll-events";
 
 export const useMessageScroll = () => {
   const stickToBottom = useStickToBottom({
@@ -28,6 +29,30 @@ export const useMessageScroll = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [stickToBottom.scrollToBottom, stickToBottom.scrollRef],
   );
+
+  useEffect(() => {
+    const scrollContainer = stickToBottom.scrollRef.current;
+    window.addEventListener(
+      STICKY_BOTTOM_ESCAPE_EVENT,
+      stickToBottom.stopScroll,
+    );
+
+    scrollContainer?.addEventListener(
+      STICKY_BOTTOM_ESCAPE_EVENT,
+      stickToBottom.stopScroll,
+    );
+
+    return () => {
+      window.removeEventListener(
+        STICKY_BOTTOM_ESCAPE_EVENT,
+        stickToBottom.stopScroll,
+      );
+      scrollContainer?.removeEventListener(
+        STICKY_BOTTOM_ESCAPE_EVENT,
+        stickToBottom.stopScroll,
+      );
+    };
+  }, [stickToBottom.scrollRef, stickToBottom.stopScroll]);
 
   return {
     scrollRef: stickToBottom.scrollRef,

--- a/components/ai-elements/__tests__/worked-for.test.tsx
+++ b/components/ai-elements/__tests__/worked-for.test.tsx
@@ -112,6 +112,37 @@ describe("WorkedFor", () => {
     expect(screen.getByText("Hidden work")).toBeVisible();
   });
 
+  it("auto-collapses when timing finishes", () => {
+    const { rerender } = render(
+      <WorkedFor hasWork isTiming>
+        <WorkedForTrigger isTiming />
+        <WorkedForContent>Hidden work</WorkedForContent>
+      </WorkedFor>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /working for 1s/i }),
+    ).toBeDisabled();
+    expect(screen.getByText("Hidden work")).toBeVisible();
+
+    rerender(
+      <WorkedFor hasWork isTiming={false}>
+        <WorkedForTrigger durationMs={1_000} />
+        <WorkedForContent>Hidden work</WorkedForContent>
+      </WorkedFor>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /worked for 1s/i }),
+    ).not.toBeDisabled();
+    const hiddenWork = screen.queryByText("Hidden work");
+    if (hiddenWork) {
+      expect(hiddenWork).not.toBeVisible();
+    } else {
+      expect(hiddenWork).not.toBeInTheDocument();
+    }
+  });
+
   it("does not render lazy content until opened", () => {
     const renderContent = jest.fn(() => "Hidden work");
 

--- a/components/ai-elements/__tests__/worked-for.test.tsx
+++ b/components/ai-elements/__tests__/worked-for.test.tsx
@@ -5,6 +5,51 @@ import {
   WorkedForTrigger,
   formatDuration,
 } from "../worked-for";
+import { STICKY_BOTTOM_ESCAPE_EVENT } from "@/lib/utils/scroll-events";
+
+function renderScrollableWorkedFor({
+  scrollTop = 260,
+  scrollHeight = 1_200,
+  clientHeight = 200,
+}: {
+  scrollTop?: number;
+  scrollHeight?: number;
+  clientHeight?: number;
+} = {}) {
+  render(
+    <div data-testid="scroll-container">
+      <div style={{ height: 400 }} />
+      <WorkedFor hasWork>
+        <WorkedForTrigger durationMs={1_000} />
+        <WorkedForContent>
+          <div style={{ height: 800 }}>Hidden work</div>
+        </WorkedForContent>
+      </WorkedFor>
+    </div>,
+  );
+
+  const scrollContainer = screen.getByTestId("scroll-container");
+  Object.defineProperties(scrollContainer, {
+    clientHeight: { configurable: true, value: clientHeight },
+    scrollHeight: { configurable: true, value: scrollHeight },
+  });
+  Object.defineProperty(scrollContainer, "scrollTop", {
+    configurable: true,
+    writable: true,
+    value: scrollTop,
+  });
+  Object.defineProperty(scrollContainer, "scrollLeft", {
+    configurable: true,
+    writable: true,
+    value: 0,
+  });
+  const trigger = screen.getByRole("button", { name: /worked for 1s/i });
+  const getComputedStyleSpy = jest
+    .spyOn(window, "getComputedStyle")
+    .mockReturnValue({ overflowY: "auto" } as CSSStyleDeclaration);
+
+  return { scrollContainer, trigger, getComputedStyleSpy };
+}
 
 describe("formatDuration", () => {
   it("rounds sub-second durations up to 1s", () => {
@@ -113,6 +158,7 @@ describe("WorkedFor", () => {
   });
 
   it("auto-collapses when timing finishes", () => {
+    jest.useFakeTimers();
     const { rerender } = render(
       <WorkedFor hasWork isTiming>
         <WorkedForTrigger isTiming />
@@ -135,12 +181,20 @@ describe("WorkedFor", () => {
     expect(
       screen.getByRole("button", { name: /worked for 1s/i }),
     ).not.toBeDisabled();
+
+    expect(screen.getByText("Hidden work")).toBeVisible();
+
+    act(() => {
+      jest.advanceTimersByTime(700);
+    });
+
     const hiddenWork = screen.queryByText("Hidden work");
     if (hiddenWork) {
       expect(hiddenWork).not.toBeVisible();
     } else {
       expect(hiddenWork).not.toBeInTheDocument();
     }
+    jest.useRealTimers();
   });
 
   it("does not render lazy content until opened", () => {
@@ -173,37 +227,8 @@ describe("WorkedFor", () => {
         return 1;
       });
 
-    render(
-      <div data-testid="scroll-container">
-        <div style={{ height: 400 }} />
-        <WorkedFor hasWork>
-          <WorkedForTrigger durationMs={1_000} />
-          <WorkedForContent>
-            <div style={{ height: 800 }}>Hidden work</div>
-          </WorkedForContent>
-        </WorkedFor>
-      </div>,
-    );
-
-    const scrollContainer = screen.getByTestId("scroll-container");
-    Object.defineProperties(scrollContainer, {
-      clientHeight: { configurable: true, value: 200 },
-      scrollHeight: { configurable: true, value: 1_200 },
-    });
-    Object.defineProperty(scrollContainer, "scrollTop", {
-      configurable: true,
-      writable: true,
-      value: 260,
-    });
-    Object.defineProperty(scrollContainer, "scrollLeft", {
-      configurable: true,
-      writable: true,
-      value: 0,
-    });
-    const trigger = screen.getByRole("button", { name: /worked for 1s/i });
-    const getComputedStyleSpy = jest
-      .spyOn(window, "getComputedStyle")
-      .mockReturnValue({ overflowY: "auto" } as CSSStyleDeclaration);
+    const { scrollContainer, trigger, getComputedStyleSpy } =
+      renderScrollableWorkedFor();
     fireEvent.pointerDown(trigger);
     scrollContainer.scrollTop = 900;
 
@@ -212,6 +237,85 @@ describe("WorkedFor", () => {
     });
 
     expect(scrollContainer.scrollTop).toBe(260);
+    getComputedStyleSpy.mockRestore();
+    requestAnimationFrameSpy.mockRestore();
+    dateNowSpy.mockRestore();
+  });
+
+  it("keeps restoring longer when opening from the bottom of the scroll container", () => {
+    let now = 0;
+    let frameCount = 0;
+    const dateNowSpy = jest.spyOn(Date, "now").mockImplementation(() => now);
+
+    const escapeStickyBottomListener = jest.fn();
+    const windowEscapeStickyBottomListener = jest.fn();
+    const { scrollContainer, trigger, getComputedStyleSpy } =
+      renderScrollableWorkedFor({ scrollTop: 1_000 });
+    scrollContainer.addEventListener(
+      STICKY_BOTTOM_ESCAPE_EVENT,
+      escapeStickyBottomListener,
+    );
+    window.addEventListener(
+      STICKY_BOTTOM_ESCAPE_EVENT,
+      windowEscapeStickyBottomListener,
+    );
+    const requestAnimationFrameSpy = jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        frameCount += 1;
+        now += 500;
+        scrollContainer.scrollTop = 1_500;
+        callback(now);
+        return frameCount;
+      });
+
+    fireEvent.pointerDown(trigger);
+
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    expect(scrollContainer.scrollTop).toBe(1_000);
+    expect(frameCount).toBe(3);
+    expect(escapeStickyBottomListener).toHaveBeenCalled();
+    expect(windowEscapeStickyBottomListener).toHaveBeenCalled();
+
+    scrollContainer.removeEventListener(
+      STICKY_BOTTOM_ESCAPE_EVENT,
+      escapeStickyBottomListener,
+    );
+    window.removeEventListener(
+      STICKY_BOTTOM_ESCAPE_EVENT,
+      windowEscapeStickyBottomListener,
+    );
+    getComputedStyleSpy.mockRestore();
+    requestAnimationFrameSpy.mockRestore();
+    dateNowSpy.mockRestore();
+  });
+
+  it("captures the pre-open scroll position from touch interactions", () => {
+    let now = 0;
+    const dateNowSpy = jest.spyOn(Date, "now").mockImplementation(() => now);
+    const requestAnimationFrameSpy = jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        now += 500;
+        callback(now);
+        return 1;
+      });
+
+    const { scrollContainer, trigger, getComputedStyleSpy } =
+      renderScrollableWorkedFor({ scrollTop: 1_000 });
+
+    fireEvent.touchStart(trigger);
+    scrollContainer.scrollTop = 1_500;
+
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    expect(scrollContainer.scrollTop).toBe(1_000);
+
     getComputedStyleSpy.mockRestore();
     requestAnimationFrameSpy.mockRestore();
     dateNowSpy.mockRestore();

--- a/components/ai-elements/__tests__/worked-for.test.tsx
+++ b/components/ai-elements/__tests__/worked-for.test.tsx
@@ -1,0 +1,188 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+  WorkedFor,
+  WorkedForContent,
+  WorkedForTrigger,
+  formatDuration,
+} from "../worked-for";
+
+describe("formatDuration", () => {
+  it("rounds sub-second durations up to 1s", () => {
+    expect(formatDuration(0)).toBe("1s");
+    expect(formatDuration(1)).toBe("1s");
+    expect(formatDuration(499)).toBe("1s");
+    expect(formatDuration(999)).toBe("1s");
+  });
+
+  it("formats sub-minute durations as seconds", () => {
+    expect(formatDuration(1_000)).toBe("1s");
+    expect(formatDuration(23_400)).toBe("23s");
+    expect(formatDuration(59_400)).toBe("59s");
+  });
+
+  it("formats >=1m durations as minutes and seconds", () => {
+    expect(formatDuration(60_000)).toBe("1m 0s");
+    expect(formatDuration(96_000)).toBe("1m 36s");
+    expect(formatDuration(120_000)).toBe("2m 0s");
+    expect(formatDuration(3_661_000)).toBe("61m 1s");
+  });
+
+  it("guards against non-finite or negative inputs", () => {
+    expect(formatDuration(Number.NaN)).toBe("1s");
+    expect(formatDuration(Number.POSITIVE_INFINITY)).toBe("1s");
+    expect(formatDuration(-500)).toBe("1s");
+  });
+});
+
+describe("WorkedFor", () => {
+  it("shows a live working timer while timing", () => {
+    jest.useFakeTimers();
+    let now = 0;
+    const dateNowSpy = jest.spyOn(Date, "now").mockImplementation(() => now);
+
+    render(
+      <WorkedFor hasWork defaultOpen>
+        <WorkedForTrigger isTiming />
+        <WorkedForContent>Hidden work</WorkedForContent>
+      </WorkedFor>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /working for 1s/i }),
+    ).toBeInTheDocument();
+
+    act(() => {
+      now = 23_400;
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(
+      screen.getByRole("button", { name: /working for 23s/i }),
+    ).toBeInTheDocument();
+
+    dateNowSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it("uses a persisted start timestamp for the live timer", () => {
+    jest.useFakeTimers();
+    let now = 30_000;
+    const dateNowSpy = jest.spyOn(Date, "now").mockImplementation(() => now);
+
+    render(
+      <WorkedFor hasWork defaultOpen>
+        <WorkedForTrigger isTiming startedAt={5_000} />
+        <WorkedForContent>Hidden work</WorkedForContent>
+      </WorkedFor>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /working for 25s/i }),
+    ).toBeInTheDocument();
+
+    act(() => {
+      now = 42_000;
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(
+      screen.getByRole("button", { name: /working for 37s/i }),
+    ).toBeInTheDocument();
+
+    dateNowSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it("does not allow collapsing or show a chevron while timing", () => {
+    const { container } = render(
+      <WorkedFor hasWork defaultOpen>
+        <WorkedForTrigger isTiming />
+        <WorkedForContent>Hidden work</WorkedForContent>
+      </WorkedFor>,
+    );
+
+    const trigger = screen.getByRole("button", { name: /working for 1s/i });
+
+    expect(trigger).toBeDisabled();
+    expect(container.querySelector("svg")).not.toBeInTheDocument();
+    expect(screen.getByText("Hidden work")).toBeVisible();
+
+    fireEvent.click(trigger);
+
+    expect(screen.getByText("Hidden work")).toBeVisible();
+  });
+
+  it("does not render lazy content until opened", () => {
+    const renderContent = jest.fn(() => "Hidden work");
+
+    render(
+      <WorkedFor hasWork>
+        <WorkedForTrigger durationMs={1_000} />
+        <WorkedForContent lazy>{renderContent}</WorkedForContent>
+      </WorkedFor>,
+    );
+
+    expect(renderContent).not.toHaveBeenCalled();
+    expect(screen.queryByText("Hidden work")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /worked for 1s/i }));
+
+    expect(renderContent).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Hidden work")).toBeVisible();
+  });
+
+  it("keeps the nearest scroll container at the same position when toggled", () => {
+    let now = 0;
+    const dateNowSpy = jest.spyOn(Date, "now").mockImplementation(() => now);
+    const requestAnimationFrameSpy = jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        now += 500;
+        callback(now);
+        return 1;
+      });
+
+    render(
+      <div data-testid="scroll-container">
+        <div style={{ height: 400 }} />
+        <WorkedFor hasWork>
+          <WorkedForTrigger durationMs={1_000} />
+          <WorkedForContent>
+            <div style={{ height: 800 }}>Hidden work</div>
+          </WorkedForContent>
+        </WorkedFor>
+      </div>,
+    );
+
+    const scrollContainer = screen.getByTestId("scroll-container");
+    Object.defineProperties(scrollContainer, {
+      clientHeight: { configurable: true, value: 200 },
+      scrollHeight: { configurable: true, value: 1_200 },
+    });
+    Object.defineProperty(scrollContainer, "scrollTop", {
+      configurable: true,
+      writable: true,
+      value: 260,
+    });
+    Object.defineProperty(scrollContainer, "scrollLeft", {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+    const trigger = screen.getByRole("button", { name: /worked for 1s/i });
+    const getComputedStyleSpy = jest
+      .spyOn(window, "getComputedStyle")
+      .mockReturnValue({ overflowY: "auto" } as CSSStyleDeclaration);
+    fireEvent.pointerDown(trigger);
+    scrollContainer.scrollTop = 900;
+
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    expect(scrollContainer.scrollTop).toBe(260);
+    getComputedStyleSpy.mockRestore();
+    requestAnimationFrameSpy.mockRestore();
+    dateNowSpy.mockRestore();
+  });
+});

--- a/components/ai-elements/worked-for.tsx
+++ b/components/ai-elements/worked-for.tsx
@@ -6,6 +6,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { STICKY_BOTTOM_ESCAPE_EVENT } from "@/lib/utils/scroll-events";
 import { cn } from "@/lib/utils";
 import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
 import {
@@ -57,6 +58,7 @@ type ScrollSnapshot = {
   element: HTMLElement;
   scrollLeft: number;
   scrollTop: number;
+  wasAtBottom: boolean;
 };
 
 const getScrollableAncestor = (element: HTMLElement): HTMLElement | null => {
@@ -79,6 +81,22 @@ const getScrollableAncestor = (element: HTMLElement): HTMLElement | null => {
 };
 
 const now = () => Date.now();
+const AUTO_COLLAPSE_DELAY_MS = 700;
+const SCROLL_RESTORE_MS = 450;
+const BOTTOM_SCROLL_RESTORE_MS = 1_100;
+// Mobile browser chrome and smooth resize timing can make "at bottom" read
+// slightly off even when the user is visually anchored at the bottom.
+const BOTTOM_SCROLL_THRESHOLD_PX = 96;
+
+const escapeStickyBottom = (snapshot: ScrollSnapshot) => {
+  if (!snapshot.wasAtBottom) return;
+
+  window.dispatchEvent(new CustomEvent(STICKY_BOTTOM_ESCAPE_EVENT));
+
+  snapshot.element.dispatchEvent(
+    new CustomEvent(STICKY_BOTTOM_ESCAPE_EVENT, { bubbles: true }),
+  );
+};
 
 export function WorkedFor({
   className,
@@ -98,6 +116,14 @@ export function WorkedFor({
   const scrollSnapshotRef = useRef<ScrollSnapshot | null>(null);
   const restoreTokenRef = useRef(0);
   const wasTimingRef = useRef(isTiming);
+  const autoCollapseTimeoutRef = useRef<number | null>(null);
+
+  const clearAutoCollapseTimeout = useCallback(() => {
+    if (autoCollapseTimeoutRef.current === null) return;
+
+    window.clearTimeout(autoCollapseTimeoutRef.current);
+    autoCollapseTimeoutRef.current = null;
+  }, []);
 
   const captureScrollPosition = useCallback((target: EventTarget | null) => {
     if (!(target instanceof HTMLElement)) return;
@@ -110,6 +136,11 @@ export function WorkedFor({
       element: scrollElement,
       scrollLeft: scrollElement.scrollLeft,
       scrollTop: scrollElement.scrollTop,
+      wasAtBottom:
+        scrollElement.scrollHeight -
+          scrollElement.scrollTop -
+          scrollElement.clientHeight <=
+        BOTTOM_SCROLL_THRESHOLD_PX,
     };
   }, []);
 
@@ -120,6 +151,9 @@ export function WorkedFor({
     const token = restoreTokenRef.current + 1;
     restoreTokenRef.current = token;
     const start = now();
+    const restoreForMs = snapshot.wasAtBottom
+      ? BOTTOM_SCROLL_RESTORE_MS
+      : SCROLL_RESTORE_MS;
     const cancelRestore = () => {
       restoreTokenRef.current += 1;
       scrollSnapshotRef.current = null;
@@ -140,7 +174,7 @@ export function WorkedFor({
       snapshot.element.scrollTop = snapshot.scrollTop;
       snapshot.element.scrollLeft = snapshot.scrollLeft;
 
-      if (now() - start < 450) {
+      if (now() - start < restoreForMs) {
         requestAnimationFrame(restore);
         return;
       }
@@ -156,23 +190,35 @@ export function WorkedFor({
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
+      const snapshot = scrollSnapshotRef.current;
+      clearAutoCollapseTimeout();
+      if (nextOpen && snapshot) {
+        escapeStickyBottom(snapshot);
+      }
       setIsOpen(nextOpen);
       restoreCapturedScrollPosition();
     },
-    [restoreCapturedScrollPosition, setIsOpen],
+    [clearAutoCollapseTimeout, restoreCapturedScrollPosition, setIsOpen],
   );
 
   useEffect(() => {
     const wasTiming = wasTimingRef.current;
 
     if (isTiming) {
+      clearAutoCollapseTimeout();
       setIsOpen(true);
     } else if (wasTiming) {
-      setIsOpen(false);
+      clearAutoCollapseTimeout();
+      autoCollapseTimeoutRef.current = window.setTimeout(() => {
+        autoCollapseTimeoutRef.current = null;
+        setIsOpen(false);
+      }, AUTO_COLLAPSE_DELAY_MS);
     }
 
     wasTimingRef.current = isTiming;
-  }, [isTiming, setIsOpen]);
+  }, [clearAutoCollapseTimeout, isTiming, setIsOpen]);
+
+  useEffect(() => clearAutoCollapseTimeout, [clearAutoCollapseTimeout]);
 
   const contextValue = useMemo(
     () => ({
@@ -216,6 +262,7 @@ export function WorkedForTrigger({
   onClick,
   onKeyDown,
   onPointerDown,
+  onTouchStart,
   ...props
 }: WorkedForTriggerProps) {
   const { isOpen, hasWork, captureScrollPosition } = useWorkedFor();
@@ -264,6 +311,12 @@ export function WorkedForTrigger({
       captureScrollPosition(event.currentTarget);
     }
   };
+  const handleTouchStart: WorkedForTriggerProps["onTouchStart"] = (event) => {
+    onTouchStart?.(event);
+    if (!event.defaultPrevented && canToggle) {
+      captureScrollPosition(event.currentTarget);
+    }
+  };
   const handleKeyDown: WorkedForTriggerProps["onKeyDown"] = (event) => {
     onKeyDown?.(event);
     if (
@@ -293,6 +346,7 @@ export function WorkedForTrigger({
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       onPointerDown={handlePointerDown}
+      onTouchStart={handleTouchStart}
       {...props}
     >
       <span>{text}</span>

--- a/components/ai-elements/worked-for.tsx
+++ b/components/ai-elements/worked-for.tsx
@@ -50,6 +50,7 @@ export const useWorkedFor = () => {
 
 export type WorkedForProps = ComponentProps<typeof Collapsible> & {
   hasWork: boolean;
+  isTiming?: boolean;
 };
 
 type ScrollSnapshot = {
@@ -82,6 +83,7 @@ const now = () => Date.now();
 export function WorkedFor({
   className,
   hasWork,
+  isTiming = false,
   open,
   defaultOpen = false,
   onOpenChange,
@@ -95,6 +97,7 @@ export function WorkedFor({
   });
   const scrollSnapshotRef = useRef<ScrollSnapshot | null>(null);
   const restoreTokenRef = useRef(0);
+  const wasTimingRef = useRef(isTiming);
 
   const captureScrollPosition = useCallback((target: EventTarget | null) => {
     if (!(target instanceof HTMLElement)) return;
@@ -158,6 +161,18 @@ export function WorkedFor({
     },
     [restoreCapturedScrollPosition, setIsOpen],
   );
+
+  useEffect(() => {
+    const wasTiming = wasTimingRef.current;
+
+    if (isTiming) {
+      setIsOpen(true);
+    } else if (wasTiming) {
+      setIsOpen(false);
+    }
+
+    wasTimingRef.current = isTiming;
+  }, [isTiming, setIsOpen]);
 
   const contextValue = useMemo(
     () => ({
@@ -270,8 +285,8 @@ export function WorkedForTrigger({
     <CollapsibleTrigger
       disabled={!canToggle}
       className={cn(
-        "flex items-center gap-2 text-foreground text-sm transition-opacity border-b border-border pb-3 w-full",
-        canToggle && "hover:opacity-80",
+        "flex items-center gap-2 text-muted-foreground text-sm transition-colors border-b border-border pb-3 w-full",
+        canToggle && "hover:text-foreground",
         !canToggle && "cursor-default",
         className,
       )}
@@ -310,13 +325,7 @@ export function WorkedForContent({
 
   return (
     <CollapsibleContent
-      className={cn(
-        "mt-2 space-y-3",
-        "data-[state=closed]:animate-out data-[state=open]:animate-in",
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-        "data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2",
-        className,
-      )}
+      className={cn("worked-for-content mt-2 space-y-3", className)}
       {...props}
     >
       {shouldRenderChildren

--- a/components/ai-elements/worked-for.tsx
+++ b/components/ai-elements/worked-for.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { ComponentProps, ReactNode } from "react";
+
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "1s";
+  if (ms < 60_000) {
+    const seconds = Math.max(1, Math.round(ms / 1000));
+    return `${seconds}s`;
+  }
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${seconds}s`;
+}
+
+type WorkedForContextValue = {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  captureScrollPosition: (target: EventTarget | null) => void;
+  hasWork: boolean;
+};
+
+const WorkedForContext = createContext<WorkedForContextValue | null>(null);
+
+export const useWorkedFor = () => {
+  const context = useContext(WorkedForContext);
+  if (!context) {
+    throw new Error("WorkedFor components must be used within WorkedFor");
+  }
+  return context;
+};
+
+export type WorkedForProps = ComponentProps<typeof Collapsible> & {
+  hasWork: boolean;
+};
+
+type ScrollSnapshot = {
+  element: HTMLElement;
+  scrollLeft: number;
+  scrollTop: number;
+};
+
+const getScrollableAncestor = (element: HTMLElement): HTMLElement | null => {
+  let parent = element.parentElement;
+
+  while (parent) {
+    const { overflowY } = window.getComputedStyle(parent);
+    const canScroll =
+      (overflowY === "auto" ||
+        overflowY === "scroll" ||
+        overflowY === "overlay") &&
+      parent.scrollHeight > parent.clientHeight;
+
+    if (canScroll) return parent;
+    parent = parent.parentElement;
+  }
+
+  const scrollingElement = document.scrollingElement;
+  return scrollingElement instanceof HTMLElement ? scrollingElement : null;
+};
+
+const now = () => Date.now();
+
+export function WorkedFor({
+  className,
+  hasWork,
+  open,
+  defaultOpen = false,
+  onOpenChange,
+  children,
+  ...props
+}: WorkedForProps) {
+  const [isOpen, setIsOpen] = useControllableState({
+    prop: open,
+    defaultProp: defaultOpen,
+    onChange: onOpenChange,
+  });
+  const scrollSnapshotRef = useRef<ScrollSnapshot | null>(null);
+  const restoreTokenRef = useRef(0);
+
+  const captureScrollPosition = useCallback((target: EventTarget | null) => {
+    if (!(target instanceof HTMLElement)) return;
+
+    const scrollElement = getScrollableAncestor(target);
+    if (!scrollElement) return;
+    if (scrollSnapshotRef.current?.element === scrollElement) return;
+
+    scrollSnapshotRef.current = {
+      element: scrollElement,
+      scrollLeft: scrollElement.scrollLeft,
+      scrollTop: scrollElement.scrollTop,
+    };
+  }, []);
+
+  const restoreCapturedScrollPosition = useCallback(() => {
+    const snapshot = scrollSnapshotRef.current;
+    if (!snapshot) return;
+
+    const token = restoreTokenRef.current + 1;
+    restoreTokenRef.current = token;
+    const start = now();
+    const cancelRestore = () => {
+      restoreTokenRef.current += 1;
+      scrollSnapshotRef.current = null;
+      snapshot.element.removeEventListener("wheel", cancelRestore);
+      snapshot.element.removeEventListener("touchstart", cancelRestore);
+      window.removeEventListener("keydown", cancelRestore);
+    };
+
+    snapshot.element.addEventListener("wheel", cancelRestore, { once: true });
+    snapshot.element.addEventListener("touchstart", cancelRestore, {
+      once: true,
+    });
+    window.addEventListener("keydown", cancelRestore, { once: true });
+
+    const restore = () => {
+      if (restoreTokenRef.current !== token) return;
+
+      snapshot.element.scrollTop = snapshot.scrollTop;
+      snapshot.element.scrollLeft = snapshot.scrollLeft;
+
+      if (now() - start < 450) {
+        requestAnimationFrame(restore);
+        return;
+      }
+
+      snapshot.element.removeEventListener("wheel", cancelRestore);
+      snapshot.element.removeEventListener("touchstart", cancelRestore);
+      window.removeEventListener("keydown", cancelRestore);
+      scrollSnapshotRef.current = null;
+    };
+
+    requestAnimationFrame(restore);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setIsOpen(nextOpen);
+      restoreCapturedScrollPosition();
+    },
+    [restoreCapturedScrollPosition, setIsOpen],
+  );
+
+  const contextValue = useMemo(
+    () => ({
+      isOpen: !!isOpen,
+      setIsOpen: handleOpenChange,
+      captureScrollPosition,
+      hasWork,
+    }),
+    [isOpen, handleOpenChange, captureScrollPosition, hasWork],
+  );
+
+  return (
+    <WorkedForContext.Provider value={contextValue}>
+      <Collapsible
+        open={hasWork ? !!isOpen : false}
+        onOpenChange={hasWork ? handleOpenChange : undefined}
+        className={cn("not-prose w-full space-y-2", className)}
+        {...props}
+      >
+        {children}
+      </Collapsible>
+    </WorkedForContext.Provider>
+  );
+}
+
+export type WorkedForTriggerProps = ComponentProps<
+  typeof CollapsibleTrigger
+> & {
+  durationMs?: number;
+  startedAt?: number;
+  label?: ReactNode;
+  isTiming?: boolean;
+};
+
+export function WorkedForTrigger({
+  className,
+  durationMs,
+  startedAt,
+  isTiming = false,
+  label,
+  onClick,
+  onKeyDown,
+  onPointerDown,
+  ...props
+}: WorkedForTriggerProps) {
+  const { isOpen, hasWork, captureScrollPosition } = useWorkedFor();
+  const timingStartedAtRef = useRef<number | null>(null);
+  const getElapsedMs = useCallback(() => {
+    if (typeof startedAt !== "number" || !Number.isFinite(startedAt)) {
+      return 0;
+    }
+
+    return Math.max(0, Date.now() - startedAt);
+  }, [startedAt]);
+  const [elapsedMs, setElapsedMs] = useState(() => getElapsedMs());
+  useEffect(() => {
+    if (!isTiming) {
+      timingStartedAtRef.current = null;
+      return;
+    }
+
+    timingStartedAtRef.current =
+      typeof startedAt === "number" && Number.isFinite(startedAt)
+        ? startedAt
+        : (timingStartedAtRef.current ?? Date.now());
+
+    const updateElapsed = () => {
+      setElapsedMs(
+        Math.max(0, Date.now() - (timingStartedAtRef.current ?? Date.now())),
+      );
+    };
+
+    updateElapsed();
+    const intervalId = window.setInterval(updateElapsed, 1000);
+    return () => window.clearInterval(intervalId);
+  }, [isTiming, startedAt]);
+
+  const text =
+    label ??
+    (isTiming
+      ? `Working for ${formatDuration(elapsedMs)}`
+      : typeof durationMs === "number" && durationMs > 0
+        ? `Worked for ${formatDuration(durationMs)}`
+        : "Worked");
+  const canToggle = hasWork && !isTiming;
+  const handlePointerDown: WorkedForTriggerProps["onPointerDown"] = (event) => {
+    onPointerDown?.(event);
+    if (!event.defaultPrevented && canToggle) {
+      captureScrollPosition(event.currentTarget);
+    }
+  };
+  const handleKeyDown: WorkedForTriggerProps["onKeyDown"] = (event) => {
+    onKeyDown?.(event);
+    if (
+      !event.defaultPrevented &&
+      canToggle &&
+      (event.key === "Enter" || event.key === " ")
+    ) {
+      captureScrollPosition(event.currentTarget);
+    }
+  };
+  const handleClick: WorkedForTriggerProps["onClick"] = (event) => {
+    onClick?.(event);
+    if (!event.defaultPrevented && canToggle) {
+      captureScrollPosition(event.currentTarget);
+    }
+  };
+
+  return (
+    <CollapsibleTrigger
+      disabled={!canToggle}
+      className={cn(
+        "flex items-center gap-2 text-foreground text-sm transition-opacity border-b border-border pb-3 w-full",
+        canToggle && "hover:opacity-80",
+        !canToggle && "cursor-default",
+        className,
+      )}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      onPointerDown={handlePointerDown}
+      {...props}
+    >
+      <span>{text}</span>
+      {canToggle &&
+        (isOpen ? (
+          <ChevronDownIcon className="size-4" />
+        ) : (
+          <ChevronRightIcon className="size-4" />
+        ))}
+    </CollapsibleTrigger>
+  );
+}
+
+export type WorkedForContentProps = Omit<
+  ComponentProps<typeof CollapsibleContent>,
+  "children"
+> & {
+  children: ReactNode | (() => ReactNode);
+  lazy?: boolean;
+};
+
+export function WorkedForContent({
+  className,
+  children,
+  lazy = false,
+  ...props
+}: WorkedForContentProps) {
+  const { isOpen } = useWorkedFor();
+  const shouldRenderChildren = !lazy || isOpen;
+
+  return (
+    <CollapsibleContent
+      className={cn(
+        "mt-2 space-y-3",
+        "data-[state=closed]:animate-out data-[state=open]:animate-in",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2",
+        className,
+      )}
+      {...props}
+    >
+      {shouldRenderChildren
+        ? typeof children === "function"
+          ? children()
+          : children
+        : null}
+    </CollapsibleContent>
+  );
+}
+
+WorkedFor.displayName = "WorkedFor";
+WorkedForTrigger.displayName = "WorkedForTrigger";
+WorkedForContent.displayName = "WorkedForContent";

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -251,12 +251,15 @@ export const saveMessage = mutation({
           patch.mode = args.mode;
         }
         if (
-          args.generationStartedAt &&
-          !existingMessage.generation_started_at
+          typeof args.generationStartedAt === "number" &&
+          typeof existingMessage.generation_started_at !== "number"
         ) {
           patch.generation_started_at = args.generationStartedAt;
         }
-        if (args.generationTimeMs && !existingMessage.generation_time_ms) {
+        if (
+          typeof args.generationTimeMs === "number" &&
+          typeof existingMessage.generation_time_ms !== "number"
+        ) {
           patch.generation_time_ms = args.generationTimeMs;
         }
         if (args.finishReason && !existingMessage.finish_reason) {

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -183,6 +183,8 @@ export const saveMessage = mutation({
     parts: v.array(v.any()),
     fileIds: v.optional(v.array(v.id("files"))),
     model: v.optional(v.string()),
+    mode: v.optional(v.union(v.literal("agent"), v.literal("ask"))),
+    generationStartedAt: v.optional(v.number()),
     generationTimeMs: v.optional(v.number()),
     finishReason: v.optional(v.string()),
     usage: v.optional(v.any()),
@@ -245,6 +247,15 @@ export const saveMessage = mutation({
         if (args.model && !existingMessage.model) {
           patch.model = args.model;
         }
+        if (args.mode && !existingMessage.mode) {
+          patch.mode = args.mode;
+        }
+        if (
+          args.generationStartedAt &&
+          !existingMessage.generation_started_at
+        ) {
+          patch.generation_started_at = args.generationStartedAt;
+        }
         if (args.generationTimeMs && !existingMessage.generation_time_ms) {
           patch.generation_time_ms = args.generationTimeMs;
         }
@@ -294,6 +305,8 @@ export const saveMessage = mutation({
         file_ids: args.fileIds,
         update_time: Date.now(),
         model: args.model,
+        mode: args.mode,
+        generation_started_at: args.generationStartedAt,
         generation_time_ms: args.generationTimeMs,
         finish_reason: args.finishReason,
         usage: args.usage,
@@ -356,6 +369,9 @@ export const getMessagesByChatId = query({
           }),
           v.null(),
         ),
+        generation_time_ms: v.optional(v.number()),
+        generation_started_at: v.optional(v.number()),
+        mode: v.optional(v.union(v.literal("agent"), v.literal("ask"))),
         fileDetails: v.optional(
           v.array(
             v.object({
@@ -468,6 +484,9 @@ export const getMessagesByChatId = query({
           parts: message.parts,
           source_message_id: message.source_message_id,
           feedback,
+          mode: message.mode,
+          generation_started_at: message.generation_started_at,
+          generation_time_ms: message.generation_time_ms,
           fileDetails,
         });
       }
@@ -522,6 +541,8 @@ export const saveAssistantMessage = mutation({
     ),
     parts: v.array(v.any()),
     model: v.optional(v.string()),
+    mode: v.optional(v.union(v.literal("agent"), v.literal("ask"))),
+    generationStartedAt: v.optional(v.number()),
     generationTimeMs: v.optional(v.number()),
     finishReason: v.optional(v.string()),
     usage: v.optional(v.any()),
@@ -569,6 +590,8 @@ export const saveAssistantMessage = mutation({
         content: content || undefined,
         update_time: Date.now(),
         model: args.model,
+        mode: args.mode,
+        generation_started_at: args.generationStartedAt,
         generation_time_ms: args.generationTimeMs,
         finish_reason: args.finishReason,
         usage: args.usage,
@@ -728,6 +751,13 @@ export const getLastAssistantMessage = query({
       id: v.string(),
       role: v.literal("assistant"),
       parts: v.array(v.any()),
+      metadata: v.optional(
+        v.object({
+          generationStartedAt: v.optional(v.number()),
+          generationTimeMs: v.optional(v.number()),
+          mode: v.optional(v.union(v.literal("agent"), v.literal("ask"))),
+        }),
+      ),
     }),
     v.null(),
   ),
@@ -756,6 +786,20 @@ export const getLastAssistantMessage = query({
         id: message.id,
         role: message.role,
         parts: message.parts,
+        metadata:
+          message.mode ||
+          typeof message.generation_started_at === "number" ||
+          typeof message.generation_time_ms === "number"
+            ? {
+                ...(message.mode ? { mode: message.mode } : {}),
+                ...(typeof message.generation_started_at === "number"
+                  ? { generationStartedAt: message.generation_started_at }
+                  : {}),
+                ...(typeof message.generation_time_ms === "number"
+                  ? { generationTimeMs: message.generation_time_ms }
+                  : {}),
+              }
+            : undefined,
       };
     } catch (error) {
       console.error("Failed to get last assistant message:", error);
@@ -1120,6 +1164,8 @@ export const branchChat = mutation({
           source_message_id: msg.id,
           update_time: Date.now(),
           model: msg.model,
+          mode: msg.mode,
+          generation_started_at: msg.generation_started_at,
           generation_time_ms: msg.generation_time_ms,
           finish_reason: msg.finish_reason,
           usage: msg.usage,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -81,6 +81,8 @@ export default defineSchema({
     source_message_id: v.optional(v.string()),
     update_time: v.number(),
     model: v.optional(v.string()),
+    mode: v.optional(v.union(v.literal("agent"), v.literal("ask"))),
+    generation_started_at: v.optional(v.number()),
     generation_time_ms: v.optional(v.number()),
     finish_reason: v.optional(v.string()),
     usage: v.optional(v.any()),

--- a/convex/sharedChats.ts
+++ b/convex/sharedChats.ts
@@ -328,6 +328,8 @@ export const forkSharedChat = mutation({
         source_message_id: msg.id,
         update_time: Date.now(),
         model: msg.model,
+        mode: msg.mode,
+        generation_started_at: msg.generation_started_at,
         generation_time_ms: msg.generation_time_ms,
         finish_reason: msg.finish_reason,
         usage: msg.usage,

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -63,6 +63,27 @@ describe("utils", () => {
       expect(result[0].metadata).toBeUndefined();
     });
 
+    it("should convert generation timing metadata", () => {
+      const messages: MessageRecord[] = [
+        {
+          id: "msg1",
+          role: "assistant",
+          parts: [{ type: "text", text: "Done" }],
+          mode: "agent",
+          generation_started_at: 1_000,
+          generation_time_ms: 2_500,
+        },
+      ];
+
+      const result = convertToUIMessages(messages);
+
+      expect(result[0].metadata).toEqual({
+        mode: "agent",
+        generationStartedAt: 1_000,
+        generationTimeMs: 2_500,
+      });
+    });
+
     it("should handle messages with file details", () => {
       const messages: MessageRecord[] = [
         {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -691,6 +691,19 @@ export const createChatHandler = (
           writer.merge(
             result.toUIMessageStream({
               generateMessageId: () => assistantMessageId,
+              messageMetadata: ({ part }) => {
+                if (part.type === "start") {
+                  return { mode, generationStartedAt: streamStartTime };
+                }
+
+                if (part.type === "finish") {
+                  return {
+                    mode,
+                    generationStartedAt: streamStartTime,
+                    generationTimeMs: Date.now() - streamStartTime,
+                  };
+                }
+              },
               onFinish: async ({ messages, isAborted }) => {
                 // Check if stream finished with only step-start (indicates incomplete response)
                 const lastAssistantMessage = messages
@@ -742,6 +755,22 @@ export const createChatHandler = (
                     writer.merge(
                       retryResult.toUIMessageStream({
                         generateMessageId: () => retryMessageId,
+                        messageMetadata: ({ part }) => {
+                          if (part.type === "start") {
+                            return {
+                              mode,
+                              generationStartedAt: fallbackStartTime,
+                            };
+                          }
+
+                          if (part.type === "finish") {
+                            return {
+                              mode,
+                              generationStartedAt: fallbackStartTime,
+                              generationTimeMs: Date.now() - fallbackStartTime,
+                            };
+                          }
+                        },
                         onFinish: async ({
                           messages: retryMessages,
                           isAborted: retryAborted,
@@ -835,6 +864,8 @@ export const createChatHandler = (
                                 extraFileIds: newFileIds,
                                 usage: state.streamUsage,
                                 model: state.responseModel,
+                                mode,
+                                generationStartedAt: fallbackStartTime,
                                 generationTimeMs:
                                   Date.now() - fallbackStartTime,
                                 finishReason: state.streamFinishReason,
@@ -1097,6 +1128,11 @@ export const createChatHandler = (
                       message: processedMessage,
                       extraFileIds: newFileIds,
                       model: state.responseModel || configuredModelId,
+                      mode,
+                      generationStartedAt:
+                        processedMessage.role === "assistant"
+                          ? streamStartTime
+                          : undefined,
                       generationTimeMs: Date.now() - streamStartTime,
                       finishReason: state.streamFinishReason,
                       usage: resolvedUsage ?? state.streamUsage,

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -21,6 +21,7 @@ import type { Id } from "@/convex/_generated/dataModel";
 import { v4 as uuidv4 } from "uuid";
 import { AGENT_RESUME_PREAMBLE } from "@/lib/chat/summarization/prompts";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
+import type { ChatMode } from "@/types/chat";
 
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 
@@ -64,6 +65,8 @@ export async function saveMessage({
   message,
   extraFileIds,
   model,
+  mode,
+  generationStartedAt,
   generationTimeMs,
   finishReason,
   usage,
@@ -79,6 +82,8 @@ export async function saveMessage({
   };
   extraFileIds?: Array<Id<"files">>;
   model?: string;
+  mode?: ChatMode;
+  generationStartedAt?: number;
   generationTimeMs?: number;
   finishReason?: string;
   usage?: Record<string, unknown>;
@@ -108,6 +113,8 @@ export async function saveMessage({
       parts: fixedParts,
       fileIds: mergedFileIds.length > 0 ? (mergedFileIds as any) : undefined,
       model,
+      mode,
+      generationStartedAt,
       generationTimeMs,
       finishReason,
       usage,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,7 +1,7 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { ChatSDKError, ErrorCode } from "./errors";
-import { ChatMessage } from "@/types/chat";
+import { ChatMessage, type ChatMode } from "@/types/chat";
 import { UIMessagePart } from "ai";
 import { Id } from "@/convex/_generated/dataModel";
 
@@ -13,6 +13,9 @@ export interface MessageRecord {
   feedback?: {
     feedbackType: "positive" | "negative";
   } | null;
+  mode?: ChatMode;
+  generation_started_at?: number;
+  generation_time_ms?: number;
   fileDetails?: Array<{
     fileId: Id<"files">;
     name: string;
@@ -60,9 +63,24 @@ export function convertToUIMessages(messages: MessageRecord[]): ChatMessage[] {
       return part;
     }),
     sourceMessageId: message.source_message_id,
-    metadata: message.feedback
-      ? { feedbackType: message.feedback.feedbackType }
-      : undefined,
+    metadata:
+      message.feedback ||
+      message.mode ||
+      typeof message.generation_started_at === "number" ||
+      typeof message.generation_time_ms === "number"
+        ? {
+            ...(message.feedback
+              ? { feedbackType: message.feedback.feedbackType }
+              : {}),
+            ...(message.mode ? { mode: message.mode } : {}),
+            ...(typeof message.generation_started_at === "number"
+              ? { generationStartedAt: message.generation_started_at }
+              : {}),
+            ...(typeof message.generation_time_ms === "number"
+              ? { generationTimeMs: message.generation_time_ms }
+              : {}),
+          }
+        : undefined,
     fileDetails: message.fileDetails,
   }));
 }

--- a/lib/utils/scroll-events.ts
+++ b/lib/utils/scroll-events.ts
@@ -1,0 +1,1 @@
+export const STICKY_BOTTOM_ESCAPE_EVENT = "hackerai:escape-sticky-bottom";

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -808,6 +808,19 @@ export const agentLongTask = task({
               result.toUIMessageStream({
                 generateMessageId: () => assistantMessageId,
                 sendReasoning: true,
+                messageMetadata: ({ part }) => {
+                  if (part.type === "start") {
+                    return { mode, generationStartedAt: streamStartTime };
+                  }
+
+                  if (part.type === "finish") {
+                    return {
+                      mode,
+                      generationStartedAt: streamStartTime,
+                      generationTimeMs: Date.now() - streamStartTime,
+                    };
+                  }
+                },
                 onFinish: async ({ messages: finishedMessages, isAborted }) => {
                   // Retry with fallback if stream only produced step-start (incomplete response)
                   const lastAssistantMessage = finishedMessages
@@ -847,6 +860,23 @@ export const agentLongTask = task({
                         retryResult.toUIMessageStream({
                           generateMessageId: () => retryMessageId,
                           sendReasoning: true,
+                          messageMetadata: ({ part }) => {
+                            if (part.type === "start") {
+                              return {
+                                mode,
+                                generationStartedAt: fallbackStartTime,
+                              };
+                            }
+
+                            if (part.type === "finish") {
+                              return {
+                                mode,
+                                generationStartedAt: fallbackStartTime,
+                                generationTimeMs:
+                                  Date.now() - fallbackStartTime,
+                              };
+                            }
+                          },
                           onFinish: async ({
                             messages: retryMessages,
                             isAborted: retryAborted,
@@ -914,6 +944,8 @@ export const agentLongTask = task({
                               const newFileIds = accumulatedFiles.map(
                                 (f) => f.fileId,
                               );
+                              const fallbackGenerationTimeMs =
+                                Date.now() - fallbackStartTime;
                               for (const msg of retryMessages) {
                                 if (msg.role !== "assistant") continue;
                                 const processed = stripAgentLongHeartbeatParts(
@@ -928,11 +960,20 @@ export const agentLongTask = task({
                                   extraFileIds: newFileIds,
                                   usage: state.streamUsage,
                                   model: state.responseModel,
-                                  generationTimeMs:
-                                    Date.now() - fallbackStartTime,
+                                  mode,
+                                  generationStartedAt: fallbackStartTime,
+                                  generationTimeMs: fallbackGenerationTimeMs,
                                   finishReason: state.streamFinishReason,
                                 });
                               }
+                              writer.write({
+                                type: "message-metadata",
+                                messageMetadata: {
+                                  mode,
+                                  generationStartedAt: fallbackStartTime,
+                                  generationTimeMs: fallbackGenerationTimeMs,
+                                },
+                              });
                               sendFileMetadataToStream(accumulatedFiles);
                             }
                             await deductAccumulatedUsage();
@@ -1040,6 +1081,8 @@ export const agentLongTask = task({
                       return;
                     }
 
+                    const finalGenerationTimeMs = Date.now() - streamStartTime;
+                    let savedAssistantMessage = false;
                     for (const message of finishedMessages) {
                       const processed = stripAgentLongHeartbeatParts(
                         summarizationTracker.processMessageForSave(message),
@@ -1056,7 +1099,12 @@ export const agentLongTask = task({
                         message: processed,
                         extraFileIds: newFileIds,
                         model: state.responseModel || configuredModelId,
-                        generationTimeMs: Date.now() - streamStartTime,
+                        mode,
+                        generationStartedAt:
+                          processed.role === "assistant"
+                            ? streamStartTime
+                            : undefined,
+                        generationTimeMs: finalGenerationTimeMs,
                         finishReason: state.streamFinishReason,
                         usage: resolvedUsage ?? state.streamUsage,
                         updateOnly:
@@ -1067,6 +1115,20 @@ export const agentLongTask = task({
                           isAutoContinue && processed.role === "user"
                             ? true
                             : undefined,
+                      });
+                      if (processed.role === "assistant") {
+                        savedAssistantMessage = true;
+                      }
+                    }
+
+                    if (savedAssistantMessage) {
+                      writer.write({
+                        type: "message-metadata",
+                        messageMetadata: {
+                          mode,
+                          generationStartedAt: streamStartTime,
+                          generationTimeMs: finalGenerationTimeMs,
+                        },
                       });
                     }
 

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -284,6 +284,9 @@ export type ChatStatus = "submitted" | "streaming" | "ready" | "error";
 export const messageMetadataSchema = z.object({
   feedbackType: z.enum(["positive", "negative"]).optional(),
   isAutoContinue: z.boolean().optional(),
+  mode: z.enum(["agent", "ask"]).optional(),
+  generationStartedAt: z.number().optional(),
+  generationTimeMs: z.number().optional(),
 });
 
 export type MessageMetadata = z.infer<typeof messageMetadataSchema>;


### PR DESCRIPTION
## Summary

Adds the agent-only `Worked for` message treatment and updates the chat input context indicator so context usage is visible from the composer on desktop and mobile.

## What changed

- Added a reusable `WorkedFor` collapsible UI element with live and completed timing states.
- Renders `Worked for` only for assistant messages generated in Agent mode.
- Persists per-message mode plus generation start/end timing through Convex, DB actions, stream metadata, replay, and UI message conversion.
- Keeps legacy messages without saved mode inline to avoid changing old Ask conversations.
- Moves the context usage circle into the chat input toolbar next to the submit/stop button.
- Keeps desktop context usage hover-only, while mobile uses a tappable compact popover with shorter remaining-context copy.
- Adds focused tests for timer behavior, Ask/Agent rendering, legacy inline behavior, metadata conversion, and the context indicator variants.

## Impact

Agent responses can hide work/tool output behind a stable `Worked for` section, while Ask responses and legacy messages remain inline. Users can also inspect remaining context directly from the chat composer, including on mobile.

## Validation

- Pre-commit hook passed on `f00e8eec`:
  - `pnpm typecheck`
  - `pnpm test` (68 suites, 985 tests)
- Focused checks also passed earlier:
  - `pnpm jest app/components/__tests__/ContextUsageIndicator.test.tsx --runInBand`
  - `pnpm exec tsc --noEmit --pretty false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible "Worked for" UI with live timer, preserved scroll behavior, lazy content, and reduced-motion support.
  * Assistant messages split into work/file/trailing sections so worked-for displays only appropriate content.
  * Operation mode (agent vs ask) and generation timing are persisted; context usage indicator gains a compact popover and can appear on mobile.

* **Bug Fixes**
  * Stable rendering: saved mode/timing reliably control worked-for visibility and trailing text display across rerenders.

* **Tests**
  * Expanded coverage for partitioning, worked-for behavior/timing, formatting, and metadata mapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->