### PR TITLE
[codex] Add user suspension guard

### DIFF
--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -5,6 +5,7 @@ import { geolocation } from "@vercel/functions";
 import type { UIMessage } from "ai";
 
 import { getUserIDAndPro } from "@/lib/auth/get-user-id";
+import { assertUserCanMakeCostIncurringRequest } from "@/lib/suspensions";
 import {
   getChatById,
   handleInitialChatAndUserMessage,
@@ -43,6 +44,7 @@ export async function POST(req: NextRequest) {
       coerceSelectedModel(rawSelectedModel ?? null) ?? undefined;
 
     const { userId, subscription, organizationId } = await getUserIDAndPro(req);
+    await assertUserCanMakeCostIncurringRequest(userId);
     const userLocation = geolocation(req);
 
     assertFreeAgentGates({

--- a/app/api/fraud/webhook/route.ts
+++ b/app/api/fraud/webhook/route.ts
@@ -3,8 +3,14 @@ import { stripe } from "@/app/api/stripe";
 import { ConvexHttpClient } from "convex/browser";
 import { api } from "@/convex/_generated/api";
 import Stripe from "stripe";
+import { resolveUserIdsFromCustomer as resolveStripeCustomerUsers } from "@/lib/billing/resolve-customer-users";
 
 const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+
+type SuspensionCategory =
+  | "early_fraud_warning"
+  | "dispute_fraudulent"
+  | "dispute_billing_hold";
 
 // =============================================================================
 // Helpers
@@ -187,6 +193,41 @@ function getCustomerIdFromCharge(charge: Stripe.Charge): string | null {
     : (charge.customer?.id ?? null);
 }
 
+const resolveUserIdsFromCustomer = (customerId: string) =>
+  resolveStripeCustomerUsers(customerId, "Fraud Webhook");
+
+async function suspendCustomerUsers({
+  customerId,
+  category,
+  sourceId,
+  sourceReason,
+  chargeId,
+  sourceCreatedUnix,
+}: {
+  customerId: string;
+  category: SuspensionCategory;
+  sourceId: string;
+  sourceReason?: string;
+  chargeId?: string | null;
+  sourceCreatedUnix: number;
+}): Promise<void> {
+  const { userIds, orgId } = await resolveUserIdsFromCustomer(customerId);
+
+  for (const userId of userIds) {
+    await convex.mutation(api.userSuspensions.upsertActive, {
+      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+      userId,
+      category,
+      sourceId,
+      sourceReason,
+      stripeCustomerId: customerId,
+      stripeChargeId: chargeId ?? undefined,
+      workosOrganizationId: orgId ?? undefined,
+      sourceCreatedAt: sourceCreatedUnix * 1000,
+    });
+  }
+}
+
 /**
  * Block a fraudulent user without deleting anything.
  *
@@ -203,18 +244,31 @@ function getCustomerIdFromCharge(charge: Stripe.Charge): string | null {
 async function blockFraudulentUser(
   customerId: string,
   chargeId: string | null,
-  reason: string,
+  metadataReason: string,
+  suspension: {
+    category: SuspensionCategory;
+    sourceId: string;
+    sourceReason?: string;
+  },
   asOfUnix: number,
 ): Promise<void> {
   await cancelAllSubscriptions(customerId, asOfUnix);
   await detachAllPaymentMethods(customerId, asOfUnix);
-  await markCustomerBlocked(customerId, reason);
+  await markCustomerBlocked(customerId, metadataReason);
   if (chargeId) {
     await reportChargeFraudulent(chargeId);
   }
+  await suspendCustomerUsers({
+    customerId,
+    category: suspension.category,
+    sourceId: suspension.sourceId,
+    sourceReason: suspension.sourceReason,
+    chargeId,
+    sourceCreatedUnix: asOfUnix,
+  });
 
   console.log(
-    `[Fraud Webhook] Blocked customer ${customerId}: subscriptions cancelled, payment methods detached, marked as blocked (${reason})`,
+    `[Fraud Webhook] Blocked customer ${customerId}: subscriptions cancelled, payment methods detached, marked as blocked (${metadataReason})`,
   );
 }
 
@@ -259,6 +313,11 @@ async function handleEarlyFraudWarning(
       customerId,
       chargeId,
       `early_fraud_warning:${warning.fraud_type}`,
+      {
+        category: "early_fraud_warning",
+        sourceId: warning.id,
+        sourceReason: warning.fraud_type,
+      },
       warning.created,
     );
   }
@@ -268,8 +327,9 @@ async function handleEarlyFraudWarning(
  * Handle charge.dispute.created
  *
  * Fraudulent disputes: block the user (cancel subs, detach cards, flag).
- * Non-fraudulent disputes (unrecognized, duplicate, etc.): cancel subscription
- * only — the customer may be legitimate and confused.
+ * Non-fraudulent disputes (unrecognized, duplicate, etc.): cancel subscription,
+ * detach payment methods, and pause cost-incurring usage. The customer may be
+ * legitimate and confused, so we don't mark the Stripe customer as blocked.
  *
  * No refund call: when a dispute is created, Stripe automatically debits the
  * disputed amount (plus a non-refundable dispute fee) from the merchant
@@ -304,6 +364,11 @@ async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<void> {
       customerId,
       chargeId,
       `dispute_fraudulent:${dispute.id}`,
+      {
+        category: "dispute_fraudulent",
+        sourceId: dispute.id,
+        sourceReason: dispute.reason,
+      },
       dispute.created,
     );
   } else {
@@ -312,9 +377,18 @@ async function handleDisputeCreated(dispute: Stripe.Dispute): Promise<void> {
     // dispute fee + ratio impact, and the disputed card is likely to file
     // again. Stop all future charges on this card: cancel subscriptions
     // AND detach payment methods. Don't mark blocked — the customer can
-    // still re-subscribe with a different card if they want to continue.
+    // still re-subscribe with a different card, while app usage remains paused
+    // until support resolves the suspension.
     await cancelAllSubscriptions(customerId, dispute.created);
     await detachAllPaymentMethods(customerId, dispute.created);
+    await suspendCustomerUsers({
+      customerId,
+      category: "dispute_billing_hold",
+      sourceId: dispute.id,
+      sourceReason: dispute.reason,
+      chargeId,
+      sourceCreatedUnix: dispute.created,
+    });
     console.log(
       `[Fraud Webhook] Cancelled subscriptions and detached payment methods for customer ${customerId} (non-fraudulent dispute ${dispute.id}, reason: ${dispute.reason})`,
     );

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse, after } from "next/server";
 import { stripe } from "@/app/api/stripe";
-import { workos } from "@/app/api/workos";
 import { ConvexHttpClient } from "convex/browser";
 import { api } from "@/convex/_generated/api";
 import Stripe from "stripe";
@@ -12,6 +11,7 @@ import {
   clearOrgRemovedUsage,
 } from "@/lib/rate-limit";
 import { phLogger } from "@/lib/posthog/server";
+import { resolveUserIdsFromCustomer as resolveStripeCustomerUsers } from "@/lib/billing/resolve-customer-users";
 import type { SubscriptionTier } from "@/types";
 
 // Linear ranking used to label tier transitions as upgrade/downgrade. Team is
@@ -55,46 +55,8 @@ function planLookupKeyToTier(lookupKey: string): SubscriptionTier | null {
 // Helpers
 // =============================================================================
 
-/** Resolve all active WorkOS user IDs and org ID from a Stripe customer ID. */
-async function resolveUserIdsFromCustomer(
-  customerId: string,
-): Promise<{ userIds: string[]; orgId: string | null }> {
-  try {
-    const customerData = await stripe.customers.retrieve(customerId);
-    if (customerData.deleted) return { userIds: [], orgId: null };
-
-    const customer = customerData as Stripe.Customer;
-    const orgId = customer.metadata?.workOSOrganizationId ?? null;
-    if (!orgId) {
-      console.error(
-        `[Subscription Webhook] Customer ${customerId} missing workOSOrganizationId metadata`,
-      );
-      return { userIds: [], orgId: null };
-    }
-
-    const memberships = await workos.userManagement.listOrganizationMemberships(
-      {
-        organizationId: orgId,
-        statuses: ["active"],
-      },
-    );
-
-    if (!memberships.data || memberships.data.length === 0) {
-      console.error(
-        `[Subscription Webhook] No active memberships for org ${orgId}`,
-      );
-      return { userIds: [], orgId };
-    }
-
-    return { userIds: memberships.data.map((m) => m.userId), orgId };
-  } catch (error) {
-    console.error(
-      `[Subscription Webhook] Failed to resolve users for customer ${customerId}:`,
-      error,
-    );
-    return { userIds: [], orgId: null };
-  }
-}
+const resolveUserIdsFromCustomer = (customerId: string) =>
+  resolveStripeCustomerUsers(customerId, "Subscription Webhook");
 
 /** Infer subscription tier from a Stripe product name (fallback when lookup_key is missing). */
 function tierFromProductName(name: string): SubscriptionTier | null {

--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -118,7 +118,11 @@ export const MessageErrorState = ({
                 variant="default"
                 size="sm"
                 onClick={() =>
-                  window.open("https://help.hackerai.co/", "_blank")
+                  window.open(
+                    "https://help.hackerai.co/",
+                    "_blank",
+                    "noopener,noreferrer",
+                  )
                 }
               >
                 Contact Support
@@ -146,7 +150,11 @@ export const MessageErrorState = ({
                 variant="default"
                 size="sm"
                 onClick={() =>
-                  window.open("https://help.hackerai.co/", "_blank")
+                  window.open(
+                    "https://help.hackerai.co/",
+                    "_blank",
+                    "noopener,noreferrer",
+                  )
                 }
               >
                 Contact Support

--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -68,6 +68,7 @@ export const MessageErrorState = ({
     subscription === "pro" ||
     subscription === "pro-plus";
   const isTrustCapExceeded = metadata?.trustCapExceeded === true;
+  const isSuspensionError = metadata?.suspensionCategory !== undefined;
 
   return (
     <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3">
@@ -140,14 +141,28 @@ export const MessageErrorState = ({
           </>
         ) : (
           <>
-            {canReconnect && (
-              <Button variant="default" size="sm" onClick={onReconnect}>
-                Reconnect
+            {isSuspensionError ? (
+              <Button
+                variant="default"
+                size="sm"
+                onClick={() =>
+                  window.open("https://help.hackerai.co/", "_blank")
+                }
+              >
+                Contact Support
               </Button>
+            ) : (
+              <>
+                {canReconnect && (
+                  <Button variant="default" size="sm" onClick={onReconnect}>
+                    Reconnect
+                  </Button>
+                )}
+                <Button variant="destructive" size="sm" onClick={onRetry}>
+                  Retry
+                </Button>
+              </>
             )}
-            <Button variant="destructive" size="sm" onClick={onRetry}>
-              Retry
-            </Button>
           </>
         )}
       </div>

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -605,7 +605,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       setAwaitingServerChat(false);
       dispatchStreaming({ type: "RESET_ON_FINISH" });
       if (error instanceof ChatSDKError && error.type !== "rate_limit") {
-        toast.error(error.message);
+        toast.error(
+          typeof error.cause === "string" ? error.cause : error.message,
+        );
       }
     },
   });

--- a/convex/__tests__/userSuspensions.test.ts
+++ b/convex/__tests__/userSuspensions.test.ts
@@ -60,26 +60,38 @@ function makeMockCtx(initialRows: SuspensionRow[] = []) {
       ([field, value]) => row[field as keyof SuspensionRow] === value,
     );
 
+  const withIndex = jest.fn((_indexName: string, predicate: any) => {
+    const filters: Record<string, unknown> = {};
+    const q = {
+      eq: jest.fn((field: string, value: unknown) => {
+        filters[field] = value;
+        return q;
+      }),
+    };
+    predicate(q);
+
+    const filteredRows = () =>
+      rows.filter((row) => matchesFilters(row, filters));
+
+    return {
+      order: jest.fn((direction: "asc" | "desc") => ({
+        first: async () => {
+          const sorted = [...filteredRows()].sort(
+            (a, b) => (a.source_created_at ?? 0) - (b.source_created_at ?? 0),
+          );
+          if (direction === "desc") sorted.reverse();
+          return sorted[0] ?? null;
+        },
+      })),
+      first: async () => filteredRows()[0] ?? null,
+    };
+  });
+
   const ctx: any = {
+    __withIndex: withIndex,
     db: {
       query: jest.fn(() => ({
-        withIndex: jest.fn((_indexName: string, predicate: any) => {
-          const filters: Record<string, unknown> = {};
-          const q = {
-            eq: jest.fn((field: string, value: unknown) => {
-              filters[field] = value;
-              return q;
-            }),
-          };
-          predicate(q);
-
-          return {
-            collect: async () =>
-              rows.filter((row) => matchesFilters(row, filters)),
-            first: async () =>
-              rows.find((row) => matchesFilters(row, filters)) ?? null,
-          };
-        }),
+        withIndex,
       })),
       insert: jest.fn(
         async (_table: string, doc: Omit<SuspensionRow, "_id">) => {
@@ -222,6 +234,10 @@ describe("userSuspensions", () => {
     });
 
     expect(result.source_id).toBe("dp_newer");
+    expect(ctx.__withIndex).toHaveBeenCalledWith(
+      "by_user_status_source_created",
+      expect.any(Function),
+    );
   });
 
   it("resolves by source so the suspension is no longer active", async () => {

--- a/convex/__tests__/userSuspensions.test.ts
+++ b/convex/__tests__/userSuspensions.test.ts
@@ -1,0 +1,265 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+
+jest.mock("../_generated/server", () => ({
+  mutation: jest.fn((config: any) => config),
+  query: jest.fn((config: any) => config),
+}));
+
+jest.mock("convex/values", () => ({
+  v: {
+    string: jest.fn(() => "string"),
+    number: jest.fn(() => "number"),
+    optional: jest.fn(() => "optional"),
+    union: jest.fn(() => "union"),
+    literal: jest.fn(() => "literal"),
+  },
+}));
+
+jest.mock("../lib/utils", () => ({
+  validateServiceKey: jest.fn(),
+}));
+
+const SERVICE_KEY = "test-service-key";
+
+type SuspensionRow = {
+  _id: string;
+  user_id: string;
+  status: "active" | "resolved";
+  category:
+    | "early_fraud_warning"
+    | "dispute_fraudulent"
+    | "dispute_billing_hold";
+  source: "stripe";
+  source_id: string;
+  source_reason?: string;
+  stripe_customer_id: string;
+  stripe_charge_id?: string;
+  workos_organization_id?: string;
+  created_at: number;
+  updated_at: number;
+  source_created_at?: number;
+  resolved_at?: number;
+  resolved_reason?: string;
+};
+
+function makeMockCtx(initialRows: SuspensionRow[] = []) {
+  const rows = [...initialRows];
+
+  const matchesFilters = (
+    row: SuspensionRow,
+    filters: Record<string, unknown>,
+  ) =>
+    Object.entries(filters).every(
+      ([field, value]) => row[field as keyof SuspensionRow] === value,
+    );
+
+  const ctx: any = {
+    db: {
+      query: jest.fn(() => ({
+        withIndex: jest.fn((_indexName: string, predicate: any) => {
+          const filters: Record<string, unknown> = {};
+          const q = {
+            eq: jest.fn((field: string, value: unknown) => {
+              filters[field] = value;
+              return q;
+            }),
+          };
+          predicate(q);
+
+          return {
+            collect: async () =>
+              rows.filter((row) => matchesFilters(row, filters)),
+            first: async () =>
+              rows.find((row) => matchesFilters(row, filters)) ?? null,
+          };
+        }),
+      })),
+      insert: jest.fn(
+        async (_table: string, doc: Omit<SuspensionRow, "_id">) => {
+          const row: SuspensionRow = { _id: `id-${rows.length + 1}`, ...doc };
+          rows.push(row);
+          return row._id;
+        },
+      ),
+      patch: jest.fn(async (id: string, patch: Partial<SuspensionRow>) => {
+        const row = rows.find((r) => r._id === id);
+        if (!row) throw new Error(`row ${id} not found`);
+        Object.assign(row, patch);
+      }),
+    },
+  };
+
+  return { ctx, rows };
+}
+
+const baseArgs = {
+  serviceKey: SERVICE_KEY,
+  userId: "user_123",
+  category: "dispute_fraudulent" as const,
+  sourceId: "dp_123",
+  sourceReason: "fraudulent",
+  stripeCustomerId: "cus_123",
+  stripeChargeId: "ch_123",
+  workosOrganizationId: "org_123",
+  sourceCreatedAt: 1_000,
+};
+
+describe("userSuspensions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, "now").mockReturnValue(10_000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("creates an active suspension", async () => {
+    const { upsertActive } = await import("../userSuspensions");
+    const { ctx, rows } = makeMockCtx();
+
+    const id = await (upsertActive as any).handler(ctx, baseArgs);
+
+    expect(id).toBe("id-1");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      user_id: "user_123",
+      status: "active",
+      category: "dispute_fraudulent",
+      source: "stripe",
+      source_id: "dp_123",
+      stripe_customer_id: "cus_123",
+      created_at: 10_000,
+      updated_at: 10_000,
+      source_created_at: 1_000,
+    });
+  });
+
+  it("updates an existing suspension for the same user and source", async () => {
+    const { upsertActive } = await import("../userSuspensions");
+    const { ctx, rows } = makeMockCtx([
+      {
+        _id: "id-1",
+        user_id: "user_123",
+        status: "resolved",
+        category: "early_fraud_warning",
+        source: "stripe",
+        source_id: "dp_123",
+        stripe_customer_id: "cus_old",
+        created_at: 5_000,
+        updated_at: 5_000,
+        resolved_at: 8_000,
+        resolved_reason: "manual",
+      },
+    ]);
+
+    const id = await (upsertActive as any).handler(ctx, baseArgs);
+
+    expect(id).toBe("id-1");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      status: "active",
+      category: "dispute_fraudulent",
+      stripe_customer_id: "cus_123",
+      created_at: 5_000,
+      updated_at: 10_000,
+      resolved_at: undefined,
+      resolved_reason: undefined,
+    });
+  });
+
+  it("returns the newest active suspension for a user", async () => {
+    const { getActiveByUser } = await import("../userSuspensions");
+    const { ctx } = makeMockCtx([
+      {
+        _id: "id-1",
+        user_id: "user_123",
+        status: "active",
+        category: "early_fraud_warning",
+        source: "stripe",
+        source_id: "issfr_older",
+        stripe_customer_id: "cus_123",
+        created_at: 1_000,
+        updated_at: 1_000,
+        source_created_at: 1_000,
+      },
+      {
+        _id: "id-2",
+        user_id: "user_123",
+        status: "resolved",
+        category: "dispute_fraudulent",
+        source: "stripe",
+        source_id: "dp_resolved",
+        stripe_customer_id: "cus_123",
+        created_at: 5_000,
+        updated_at: 5_000,
+        source_created_at: 5_000,
+      },
+      {
+        _id: "id-3",
+        user_id: "user_123",
+        status: "active",
+        category: "dispute_billing_hold",
+        source: "stripe",
+        source_id: "dp_newer",
+        stripe_customer_id: "cus_123",
+        created_at: 2_000,
+        updated_at: 2_000,
+        source_created_at: 9_000,
+      },
+    ]);
+
+    const result = await (getActiveByUser as any).handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      userId: "user_123",
+    });
+
+    expect(result.source_id).toBe("dp_newer");
+  });
+
+  it("resolves by source so the suspension is no longer active", async () => {
+    const { resolveBySource, getActiveByUser } =
+      await import("../userSuspensions");
+    const { ctx, rows } = makeMockCtx([
+      {
+        _id: "id-1",
+        user_id: "user_123",
+        status: "active",
+        category: "dispute_billing_hold",
+        source: "stripe",
+        source_id: "dp_123",
+        stripe_customer_id: "cus_123",
+        created_at: 1_000,
+        updated_at: 1_000,
+      },
+    ]);
+
+    const result = await (resolveBySource as any).handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      userId: "user_123",
+      sourceId: "dp_123",
+      resolvedReason: "support_review",
+    });
+
+    expect(result).toEqual({ resolved: true });
+    expect(rows[0]).toMatchObject({
+      status: "resolved",
+      resolved_at: 10_000,
+      resolved_reason: "support_review",
+      updated_at: 10_000,
+    });
+
+    const active = await (getActiveByUser as any).handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      userId: "user_123",
+    });
+    expect(active).toBeNull();
+  });
+});

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -33,6 +33,7 @@ import type * as tempStreams from "../tempStreams.js";
 import type * as usageLogs from "../usageLogs.js";
 import type * as userCustomization from "../userCustomization.js";
 import type * as userDeletion from "../userDeletion.js";
+import type * as userSuspensions from "../userSuspensions.js";
 
 import type {
   ApiFromModules,
@@ -66,6 +67,7 @@ declare const fullApi: ApiFromModules<{
   usageLogs: typeof usageLogs;
   userCustomization: typeof userCustomization;
   userDeletion: typeof userDeletion;
+  userSuspensions: typeof userSuspensions;
 }>;
 
 /**

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -182,6 +182,11 @@ export default defineSchema({
     resolved_reason: v.optional(v.string()),
   })
     .index("by_user_and_status", ["user_id", "status"])
+    .index("by_user_status_source_created", [
+      "user_id",
+      "status",
+      "source_created_at",
+    ])
     .index("by_user_and_source", ["user_id", "source_id"])
     .index("by_customer_and_status", ["stripe_customer_id", "status"]),
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -161,6 +161,30 @@ export default defineSchema({
     updated_at: v.number(),
   }).index("by_user_id", ["user_id"]),
 
+  user_suspensions: defineTable({
+    user_id: v.string(),
+    status: v.union(v.literal("active"), v.literal("resolved")),
+    category: v.union(
+      v.literal("early_fraud_warning"),
+      v.literal("dispute_fraudulent"),
+      v.literal("dispute_billing_hold"),
+    ),
+    source: v.literal("stripe"),
+    source_id: v.string(),
+    source_reason: v.optional(v.string()),
+    stripe_customer_id: v.string(),
+    stripe_charge_id: v.optional(v.string()),
+    workos_organization_id: v.optional(v.string()),
+    created_at: v.number(),
+    updated_at: v.number(),
+    source_created_at: v.optional(v.number()),
+    resolved_at: v.optional(v.number()),
+    resolved_reason: v.optional(v.string()),
+  })
+    .index("by_user_and_status", ["user_id", "status"])
+    .index("by_user_and_source", ["user_id", "source_id"])
+    .index("by_customer_and_status", ["stripe_customer_id", "status"]),
+
   memories: defineTable({
     user_id: v.string(),
     memory_id: v.string(),

--- a/convex/userSuspensions.ts
+++ b/convex/userSuspensions.ts
@@ -1,0 +1,116 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { validateServiceKey } from "./lib/utils";
+
+const suspensionCategoryValidator = v.union(
+  v.literal("early_fraud_warning"),
+  v.literal("dispute_fraudulent"),
+  v.literal("dispute_billing_hold"),
+);
+
+export const getActiveByUser = query({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const suspensions = await ctx.db
+      .query("user_suspensions")
+      .withIndex("by_user_and_status", (q) =>
+        q.eq("user_id", args.userId).eq("status", "active"),
+      )
+      .collect();
+
+    return (
+      suspensions.sort(
+        (a, b) =>
+          (b.source_created_at ?? b.created_at) -
+          (a.source_created_at ?? a.created_at),
+      )[0] ?? null
+    );
+  },
+});
+
+export const upsertActive = mutation({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+    category: suspensionCategoryValidator,
+    sourceId: v.string(),
+    sourceReason: v.optional(v.string()),
+    stripeCustomerId: v.string(),
+    stripeChargeId: v.optional(v.string()),
+    workosOrganizationId: v.optional(v.string()),
+    sourceCreatedAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("user_suspensions")
+      .withIndex("by_user_and_source", (q) =>
+        q.eq("user_id", args.userId).eq("source_id", args.sourceId),
+      )
+      .first();
+
+    const fields = {
+      status: "active" as const,
+      category: args.category,
+      source: "stripe" as const,
+      source_id: args.sourceId,
+      source_reason: args.sourceReason,
+      stripe_customer_id: args.stripeCustomerId,
+      stripe_charge_id: args.stripeChargeId,
+      workos_organization_id: args.workosOrganizationId,
+      updated_at: now,
+      source_created_at: args.sourceCreatedAt,
+      resolved_at: undefined,
+      resolved_reason: undefined,
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, fields);
+      return existing._id;
+    }
+
+    return await ctx.db.insert("user_suspensions", {
+      ...fields,
+      user_id: args.userId,
+      created_at: now,
+    });
+  },
+});
+
+export const resolveBySource = mutation({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+    sourceId: v.string(),
+    resolvedReason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const suspension = await ctx.db
+      .query("user_suspensions")
+      .withIndex("by_user_and_source", (q) =>
+        q.eq("user_id", args.userId).eq("source_id", args.sourceId),
+      )
+      .first();
+
+    if (!suspension) return { resolved: false };
+
+    const now = Date.now();
+    await ctx.db.patch(suspension._id, {
+      status: "resolved",
+      resolved_at: now,
+      resolved_reason: args.resolvedReason,
+      updated_at: now,
+    });
+
+    return { resolved: true };
+  },
+});

--- a/convex/userSuspensions.ts
+++ b/convex/userSuspensions.ts
@@ -16,20 +16,13 @@ export const getActiveByUser = query({
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
 
-    const suspensions = await ctx.db
+    return await ctx.db
       .query("user_suspensions")
-      .withIndex("by_user_and_status", (q) =>
+      .withIndex("by_user_status_source_created", (q) =>
         q.eq("user_id", args.userId).eq("status", "active"),
       )
-      .collect();
-
-    return (
-      suspensions.sort(
-        (a, b) =>
-          (b.source_created_at ?? b.created_at) -
-          (a.source_created_at ?? a.created_at),
-      )[0] ?? null
-    );
+      .order("desc")
+      .first();
   },
 });
 
@@ -66,7 +59,7 @@ export const upsertActive = mutation({
       stripe_charge_id: args.stripeChargeId,
       workos_organization_id: args.workosOrganizationId,
       updated_at: now,
-      source_created_at: args.sourceCreatedAt,
+      source_created_at: args.sourceCreatedAt ?? now,
       resolved_at: undefined,
       resolved_reason: undefined,
     };

--- a/lib/__tests__/resolve-customer-users.test.ts
+++ b/lib/__tests__/resolve-customer-users.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+const mockRetrieveCustomer = jest.fn();
+const mockListMemberships = jest.fn();
+
+jest.mock("@/app/api/stripe", () => ({
+  stripe: {
+    customers: {
+      retrieve: mockRetrieveCustomer,
+    },
+  },
+}));
+
+jest.mock("@/app/api/workos", () => ({
+  workos: {
+    userManagement: {
+      listOrganizationMemberships: mockListMemberships,
+    },
+  },
+}));
+
+describe("resolveUserIdsFromCustomer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("uses WorkOS autoPagination so all active org members are returned", async () => {
+    mockRetrieveCustomer.mockResolvedValueOnce({
+      deleted: false,
+      metadata: { workOSOrganizationId: "org_123" },
+    } as never);
+    mockListMemberships.mockResolvedValueOnce({
+      data: [{ userId: "user_first_page" }],
+      autoPagination: jest
+        .fn()
+        .mockResolvedValue([
+          { userId: "user_first_page" },
+          { userId: "user_second_page" },
+        ]),
+    } as never);
+
+    const { resolveUserIdsFromCustomer } =
+      await import("../billing/resolve-customer-users");
+
+    const result = await resolveUserIdsFromCustomer("cus_123", "Test Webhook");
+
+    expect(mockListMemberships).toHaveBeenCalledWith({
+      organizationId: "org_123",
+      statuses: ["active"],
+    });
+    expect(result).toEqual({
+      userIds: ["user_first_page", "user_second_page"],
+      orgId: "org_123",
+    });
+  });
+
+  it("returns no users when the customer has no WorkOS organization metadata", async () => {
+    mockRetrieveCustomer.mockResolvedValueOnce({
+      deleted: false,
+      metadata: {},
+    } as never);
+
+    const { resolveUserIdsFromCustomer } =
+      await import("../billing/resolve-customer-users");
+
+    const result = await resolveUserIdsFromCustomer("cus_123", "Test Webhook");
+
+    expect(result).toEqual({ userIds: [], orgId: null });
+    expect(mockListMemberships).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/resolve-customer-users.test.ts
+++ b/lib/__tests__/resolve-customer-users.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
 
 const mockRetrieveCustomer = jest.fn();
 const mockListMemberships = jest.fn();
@@ -23,6 +30,10 @@ describe("resolveUserIdsFromCustomer", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("uses WorkOS autoPagination so all active org members are returned", async () => {

--- a/lib/__tests__/suspensionMessage.test.ts
+++ b/lib/__tests__/suspensionMessage.test.ts
@@ -16,6 +16,12 @@ describe("getSuspensionMessage", () => {
     expect(msg).toContain(SUPPORT_URL);
   });
 
+  it("uses the billing hold label for disputed-payment holds", () => {
+    const msg = getSuspensionMessage("dispute_billing_hold:dp_123");
+    expect(msg).toContain("a payment dispute under review");
+    expect(msg).toContain(SUPPORT_URL);
+  });
+
   it("falls back to the generic label when the reason is missing", () => {
     expect(getSuspensionMessage(undefined)).toContain("suspicious activity");
     expect(getSuspensionMessage(null)).toContain("suspicious activity");

--- a/lib/__tests__/suspensions.test.ts
+++ b/lib/__tests__/suspensions.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { ChatSDKError } from "../errors";
+
+const mockQuery = jest.fn();
+
+jest.mock("server-only", () => ({}), { virtual: true });
+
+jest.mock("@/convex/_generated/api", () => ({
+  api: {
+    userSuspensions: {
+      getActiveByUser: "getActiveByUser",
+    },
+  },
+}));
+
+jest.mock("@/lib/db/convex-client", () => ({
+  getConvexClient: () => ({
+    query: mockQuery,
+  }),
+}));
+
+process.env.CONVEX_SERVICE_ROLE_KEY = "test-service-key";
+
+describe("suspensions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("allows cost-incurring requests when no active suspension exists", async () => {
+    mockQuery.mockResolvedValueOnce(null as never);
+    const { assertUserCanMakeCostIncurringRequest } =
+      await import("../suspensions");
+
+    await expect(
+      assertUserCanMakeCostIncurringRequest("user_123"),
+    ).resolves.toBeUndefined();
+
+    expect(mockQuery).toHaveBeenCalledWith("getActiveByUser", {
+      serviceKey: "test-service-key",
+      userId: "user_123",
+    });
+  });
+
+  it("blocks cost-incurring requests for active suspensions", async () => {
+    mockQuery.mockResolvedValueOnce({
+      user_id: "user_123",
+      status: "active",
+      category: "dispute_fraudulent",
+      source: "stripe",
+      source_id: "dp_123",
+    } as never);
+    const { assertUserCanMakeCostIncurringRequest } =
+      await import("../suspensions");
+
+    await expect(
+      assertUserCanMakeCostIncurringRequest("user_123"),
+    ).rejects.toMatchObject({
+      type: "forbidden",
+      surface: "chat",
+      statusCode: 403,
+      cause: expect.stringContaining("fraudulent payment dispute"),
+      metadata: {
+        suspensionCategory: "dispute_fraudulent",
+        suspensionSource: "stripe",
+      },
+    });
+  });
+
+  it("does not leak raw source IDs in the user-facing block message", async () => {
+    mockQuery.mockResolvedValueOnce({
+      user_id: "user_123",
+      status: "active",
+      category: "dispute_billing_hold",
+      source: "stripe",
+      source_id: "dp_secret",
+    } as never);
+    const { assertUserCanMakeCostIncurringRequest } =
+      await import("../suspensions");
+
+    try {
+      await assertUserCanMakeCostIncurringRequest("user_123");
+      expect.fail("Expected suspension guard to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ChatSDKError);
+      expect((error as ChatSDKError).cause).toContain(
+        "payment dispute under review",
+      );
+      expect((error as ChatSDKError).cause).not.toContain("dp_secret");
+    }
+  });
+});

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -12,6 +12,7 @@ import { createTools } from "@/lib/ai/tools";
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { generateTitleFromUserMessageWithWriter } from "@/lib/actions";
 import { getUserIDAndPro } from "@/lib/auth/get-user-id";
+import { assertUserCanMakeCostIncurringRequest } from "@/lib/suspensions";
 import type {
   ChatMode,
   Todo,
@@ -162,6 +163,7 @@ export const createChatHandler = (
 
       const { userId, subscription, organizationId } =
         await getUserIDAndPro(req);
+      await assertUserCanMakeCostIncurringRequest(userId);
       usageRefundTracker.setUser(userId, subscription);
       const userLocation = geolocation(req);
 

--- a/lib/billing/resolve-customer-users.ts
+++ b/lib/billing/resolve-customer-users.ts
@@ -26,12 +26,15 @@ export async function resolveUserIdsFromCustomer(
       },
     );
 
-    if (!memberships.data || memberships.data.length === 0) {
+    const allMemberships = await memberships.autoPagination();
+    const userIds = allMemberships.map((membership) => membership.userId);
+
+    if (userIds.length === 0) {
       console.error(`[${logPrefix}] No active memberships for org ${orgId}`);
       return { userIds: [], orgId };
     }
 
-    return { userIds: memberships.data.map((m) => m.userId), orgId };
+    return { userIds, orgId };
   } catch (error) {
     console.error(
       `[${logPrefix}] Failed to resolve users for customer ${customerId}:`,

--- a/lib/billing/resolve-customer-users.ts
+++ b/lib/billing/resolve-customer-users.ts
@@ -1,0 +1,42 @@
+import { stripe } from "@/app/api/stripe";
+import { workos } from "@/app/api/workos";
+import Stripe from "stripe";
+
+export async function resolveUserIdsFromCustomer(
+  customerId: string,
+  logPrefix: string,
+): Promise<{ userIds: string[]; orgId: string | null }> {
+  try {
+    const customerData = await stripe.customers.retrieve(customerId);
+    if (customerData.deleted) return { userIds: [], orgId: null };
+
+    const customer = customerData as Stripe.Customer;
+    const orgId = customer.metadata?.workOSOrganizationId ?? null;
+    if (!orgId) {
+      console.error(
+        `[${logPrefix}] Customer ${customerId} missing workOSOrganizationId metadata`,
+      );
+      return { userIds: [], orgId: null };
+    }
+
+    const memberships = await workos.userManagement.listOrganizationMemberships(
+      {
+        organizationId: orgId,
+        statuses: ["active"],
+      },
+    );
+
+    if (!memberships.data || memberships.data.length === 0) {
+      console.error(`[${logPrefix}] No active memberships for org ${orgId}`);
+      return { userIds: [], orgId };
+    }
+
+    return { userIds: memberships.data.map((m) => m.userId), orgId };
+  } catch (error) {
+    console.error(
+      `[${logPrefix}] Failed to resolve users for customer ${customerId}:`,
+      error,
+    );
+    return { userIds: [], orgId: null };
+  }
+}

--- a/lib/suspensionMessage.ts
+++ b/lib/suspensionMessage.ts
@@ -5,6 +5,7 @@
  * The raw reason categories come from app/api/fraud/webhook/route.ts:
  *   - early_fraud_warning:<fraud_type>
  *   - dispute_fraudulent:<dispute_id>
+ *   - dispute_billing_hold:<dispute_id>
  *
  * Specific fraud signals are intentionally not exposed to avoid tipping
  * off bad actors about how detection works.
@@ -24,6 +25,8 @@ function mapBlockedReasonToLabel(blockedReason?: string | null): string {
       return "a fraud warning from your card issuer";
     case "dispute_fraudulent":
       return "a fraudulent payment dispute (chargeback)";
+    case "dispute_billing_hold":
+      return "a payment dispute under review";
     default:
       return "suspicious activity";
   }

--- a/lib/suspensions.ts
+++ b/lib/suspensions.ts
@@ -1,0 +1,29 @@
+import "server-only";
+
+import { api } from "@/convex/_generated/api";
+import { ChatSDKError } from "@/lib/errors";
+import { getConvexClient } from "@/lib/db/convex-client";
+import { getSuspensionMessage } from "@/lib/suspensionMessage";
+
+const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
+
+export async function getActiveSuspensionForUser(userId: string) {
+  return await getConvexClient().query(api.userSuspensions.getActiveByUser, {
+    serviceKey,
+    userId,
+  });
+}
+
+export async function assertUserCanMakeCostIncurringRequest(userId: string) {
+  const suspension = await getActiveSuspensionForUser(userId);
+  if (!suspension) return;
+
+  throw new ChatSDKError(
+    "forbidden:chat",
+    getSuspensionMessage(`${suspension.category}:${suspension.source_id}`),
+    {
+      suspensionCategory: suspension.category,
+      suspensionSource: suspension.source,
+    },
+  );
+}

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -44,6 +44,7 @@ import {
   deductUsage,
   UsageRefundTracker,
 } from "@/lib/rate-limit";
+import { assertUserCanMakeCostIncurringRequest } from "@/lib/suspensions";
 import {
   saveMessage,
   updateChat,
@@ -482,6 +483,8 @@ export const agentLongTask = task({
           return getUserFriendlyProviderError(error);
         },
         execute: async ({ writer }) => {
+          await assertUserCanMakeCostIncurringRequest(userId);
+
           extraUsageConfig = await buildExtraUsageConfig({
             userId,
             subscription,


### PR DESCRIPTION
## Summary

Adds a first-class Convex-backed suspension guard for payment risk events and wires it into chat and agent request entry points.

## Changes

- Add `user_suspensions` schema and Convex mutations/queries for active and resolved suspension state.
- Persist fraud/dispute webhook outcomes into Convex suspension records.
- Block cost-incurring chat, agent, and agent-long requests when an active suspension exists.
- Extract shared Stripe customer to WorkOS user resolution for billing webhooks.
- Rename dispute hold state to `dispute_billing_hold` so the category describes app policy rather than raw Stripe reason.
- Add direct tests for suspension messages, Convex suspension behavior, and the server guard.

## Impact

Users with active fraud warnings, fraudulent disputes, or disputed-payment billing holds are blocked before model work starts, including when they would otherwise appear as free users. Billing/support paths can still use Stripe metadata and Convex state to understand why an account is held.

## Validation

- Pre-commit hook ran `tsc --noEmit`
- Pre-commit hook ran full Jest suite: 67 suites, 969 tests passed
- Focused suspension tests passed before commit
- Focused ESLint and Prettier checks passed on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user suspension records and automatic gating that blocks cost-incurring actions for suspended users.
  * Improved billing-to-user resolution for webhooks.

* **UI**
  * Suspensions show a single "Contact Support" action; error UI now favors informative cause text when present.

* **Tests**
  * Added tests for suspension lifecycle, webhook behavior, billing resolution, and request-blocking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->