### PR TITLE
[codex] Fix desktop terminal stop cancellation

### DIFF
--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -3,6 +3,7 @@ import posthog from "posthog-js";
 import {
   sandboxChannel,
   type SandboxMessage,
+  type CommandCancelMessage,
   type CommandMessage,
   type PtyCreateMessage,
   type PtyInputMessage,
@@ -81,6 +82,7 @@ export class DesktopSandboxBridge {
   private client: Centrifuge | null = null;
   private subscription: Subscription | null = null;
   private connectionId: string | null = null;
+  private activeCommands = new Set<string>();
   private config: DesktopBridgeConfig;
 
   constructor(config: DesktopBridgeConfig) {
@@ -203,6 +205,17 @@ export class DesktopSandboxBridge {
           });
           break;
 
+        case "command_cancel":
+          this.handleCommandCancel(message as CommandCancelMessage).catch(
+            (err) => {
+              console.error(
+                "[DesktopSandboxBridge] Command cancel failed:",
+                err,
+              );
+            },
+          );
+          break;
+
         case "pty_create":
           this.handlePtyCreate(message as PtyCreateMessage).catch((err) => {
             console.error("[DesktopSandboxBridge] PTY create failed:", err);
@@ -317,6 +330,7 @@ export class DesktopSandboxBridge {
 
   private async handleCommand(command: CommandMessage): Promise<void> {
     const { commandId } = command;
+    this.activeCommands.add(commandId);
 
     try {
       const { invoke, Channel } = await import("@tauri-apps/api/core");
@@ -327,6 +341,7 @@ export class DesktopSandboxBridge {
       };
 
       await invoke("execute_stream_command", {
+        commandId,
         command: command.command,
         cwd: command.cwd,
         env: command.env,
@@ -339,7 +354,19 @@ export class DesktopSandboxBridge {
         commandId,
         message: error instanceof Error ? error.message : String(error),
       });
+    } finally {
+      this.activeCommands.delete(commandId);
     }
+  }
+
+  private async handleCommandCancel(
+    command: CommandCancelMessage,
+  ): Promise<void> {
+    if (!this.activeCommands.has(command.commandId)) return;
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("cancel_stream_command", {
+      commandId: command.commandId,
+    });
   }
 
   private async forwardChunk(

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -479,6 +479,21 @@ In using these tools, adhere to the following guidelines:
               // from the killed process might trigger retries
               resolved = true;
 
+              if (isCentrifugoSandbox(sandboxInstance)) {
+                const result = handler ? handler.getResult() : { output: "" };
+                if (handler) {
+                  handler.cleanup();
+                }
+                resolve({
+                  result: {
+                    output: result.output,
+                    exitCode: 130,
+                    error: "Command execution aborted by user",
+                  },
+                });
+                return;
+              }
+
               // Try to get PID from execution object first (cheap, no shell call)
               if (!processId && execution && (execution as any)?.pid) {
                 processId = (execution as any).pid;
@@ -592,6 +607,9 @@ In using these tools, adhere to the following guidelines:
                   },
               caidoEnvVars,
             );
+            const runOptions = isCentrifugoSandbox(sandboxInstance)
+              ? { ...commonOptions, signal: abortSignal }
+              : commonOptions;
 
             // Determine if an error is a permanent command failure (don't retry)
             // vs a transient sandbox issue (do retry)
@@ -642,7 +660,7 @@ In using these tools, adhere to the following guidelines:
                     const result = await sandboxInstance.commands.run(
                       effectiveCommand,
                       {
-                        ...commonOptions,
+                        ...runOptions,
                         background: true,
                       },
                     );
@@ -665,10 +683,7 @@ In using these tools, adhere to the following guidelines:
                 )
               : retryWithBackoff(
                   () =>
-                    sandboxInstance.commands.run(
-                      effectiveCommand,
-                      commonOptions,
-                    ),
+                    sandboxInstance.commands.run(effectiveCommand, runOptions),
                   {
                     maxRetries: 6,
                     baseDelayMs: 500,

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -253,6 +253,58 @@ describe("CentrifugoSandbox", () => {
       expect(sub.unsubscribe).toHaveBeenCalled();
       expect(client.disconnect).toHaveBeenCalled();
     });
+
+    it("publishes command_cancel when aborted while command publish is in flight", async () => {
+      const sandbox = createSandbox();
+      const abortController = new AbortController();
+
+      const { promise } = startCommand(sandbox, "sleep 999", {
+        timeoutMs: 5000,
+        signal: abortController.signal,
+      });
+
+      await jest.advanceTimersByTimeAsync(0);
+
+      const sub = mockSubscriptions[0];
+      let resolveCommandPublish!: () => void;
+      sub.publish = jest.fn((msg: { type: string }) => {
+        if (msg.type === "command") {
+          return new Promise<void>((resolve) => {
+            resolveCommandPublish = resolve;
+          });
+        }
+        return Promise.resolve();
+      });
+
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(sub.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "command",
+          commandId: FIXED_UUID,
+        }),
+      );
+
+      abortController.abort();
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(sub.publish).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "command_cancel" }),
+      );
+
+      resolveCommandPublish();
+      await jest.advanceTimersByTimeAsync(0);
+
+      await expect(promise).resolves.toMatchObject({
+        exitCode: 130,
+      });
+      expect(sub.publish).toHaveBeenCalledWith({
+        type: "command_cancel",
+        commandId: FIXED_UUID,
+        targetConnectionId: "conn-1",
+      });
+    });
   });
 
   describe("commands.run error message", () => {

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -214,6 +214,47 @@ describe("CentrifugoSandbox", () => {
     });
   });
 
+  describe("commands.run cancellation", () => {
+    it("publishes command_cancel and resolves with exitCode 130 when aborted", async () => {
+      const sandbox = createSandbox();
+      const abortController = new AbortController();
+
+      const { promise } = startCommand(sandbox, "sleep 999", {
+        timeoutMs: 5000,
+        signal: abortController.signal,
+      });
+
+      await jest.advanceTimersByTimeAsync(0);
+
+      const sub = mockSubscriptions[0];
+      const client = mockClients[0];
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(sub.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "command",
+          commandId: FIXED_UUID,
+          command: "sleep 999",
+        }),
+      );
+
+      abortController.abort();
+      await jest.advanceTimersByTimeAsync(0);
+
+      await expect(promise).resolves.toMatchObject({
+        exitCode: 130,
+      });
+      expect(sub.publish).toHaveBeenCalledWith({
+        type: "command_cancel",
+        commandId: FIXED_UUID,
+        targetConnectionId: "conn-1",
+      });
+      expect(sub.unsubscribe).toHaveBeenCalled();
+      expect(client.disconnect).toHaveBeenCalled();
+    });
+  });
+
   describe("commands.run error message", () => {
     it("resolves with exitCode -1 when type is error", async () => {
       const sandbox = createSandbox();

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -13,6 +13,7 @@ import { validateDownloadUrl } from "./path-validation";
 
 const VALID_MESSAGE_TYPES = new Set([
   "command",
+  "command_cancel",
   "stdout",
   "stderr",
   "exit",
@@ -62,6 +63,8 @@ function parseSandboxMessage(data: unknown): CommandResponseMessage | null {
         console.warn("Invalid command message: missing command", msg);
         return null;
       }
+      break;
+    case "command_cancel":
       break;
   }
 
@@ -163,6 +166,7 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
         onStdout?: (data: string) => void;
         onStderr?: (data: string) => void;
         displayName?: string;
+        signal?: AbortSignal;
       },
     ): Promise<{
       stdout: string;
@@ -190,6 +194,7 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
         let settled = false;
         let timeoutId: NodeJS.Timeout | undefined;
         let subscription: Subscription | undefined;
+        let publishedCommand = false;
 
         const maxWaitTime = timeout + 5000; // Add 5s buffer for network
 
@@ -222,7 +227,49 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
           if (idx !== -1) {
             this.activeClients.splice(idx, 1);
           }
+          opts?.signal?.removeEventListener("abort", handleAbort);
         };
+
+        const resolveCanceled = () => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          resolve({
+            stdout,
+            stderr,
+            exitCode: 130,
+          });
+        };
+
+        const publishCancel = () => {
+          if (settled) return;
+          if (!publishedCommand || !subscription) {
+            resolveCanceled();
+            return;
+          }
+
+          subscription
+            .publish({
+              type: "command_cancel",
+              commandId,
+              targetConnectionId: this.connectionInfo.connectionId,
+            })
+            .catch(() => {
+              // The run is being aborted already; resolve locally even if the
+              // remote relay disappeared before it accepted the cancel message.
+            })
+            .finally(resolveCanceled);
+        };
+
+        const handleAbort = () => {
+          publishCancel();
+        };
+
+        if (opts?.signal?.aborted) {
+          resolveCanceled();
+          return;
+        }
+        opts?.signal?.addEventListener("abort", handleAbort, { once: true });
 
         // Set up timeout
         timeoutId = setTimeout(() => {
@@ -319,6 +366,10 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
             .publish(commandMessage)
             .then(() => {
               tPublished = Date.now();
+              publishedCommand = true;
+              if (opts?.signal?.aborted) {
+                publishCancel();
+              }
             })
             .catch((err: unknown) => {
               if (!settled) {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -195,6 +195,9 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
         let timeoutId: NodeJS.Timeout | undefined;
         let subscription: Subscription | undefined;
         let publishedCommand = false;
+        let commandPublishInFlight = false;
+        let cancelRequested = false;
+        let cancelPublishStarted = false;
 
         const maxWaitTime = timeout + 5000; // Add 5s buffer for network
 
@@ -243,10 +246,14 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
 
         const publishCancel = () => {
           if (settled) return;
+          cancelRequested = true;
           if (!publishedCommand || !subscription) {
+            if (commandPublishInFlight) return;
             resolveCanceled();
             return;
           }
+          if (cancelPublishStarted) return;
+          cancelPublishStarted = true;
 
           subscription
             .publish({
@@ -349,6 +356,7 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
         // "subscribed" fires after the server confirms the subscription,
         // ensuring we receive messages published to the channel.
         subscription.on("subscribed", () => {
+          if (settled) return;
           tSubscribed = Date.now();
           const commandMessage: CommandMessage = {
             type: "command",
@@ -362,16 +370,23 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
             targetConnectionId: this.connectionInfo.connectionId,
           };
 
+          commandPublishInFlight = true;
           subscription!
             .publish(commandMessage)
             .then(() => {
+              commandPublishInFlight = false;
               tPublished = Date.now();
               publishedCommand = true;
-              if (opts?.signal?.aborted) {
+              if (cancelRequested || opts?.signal?.aborted) {
                 publishCancel();
               }
             })
             .catch((err: unknown) => {
+              commandPublishInFlight = false;
+              if (cancelRequested || opts?.signal?.aborted) {
+                resolveCanceled();
+                return;
+              }
               if (!settled) {
                 settled = true;
                 cleanup();

--- a/lib/ai/tools/utils/sandbox-types.ts
+++ b/lib/ai/tools/utils/sandbox-types.ts
@@ -57,6 +57,7 @@ export interface CommonSandboxInterface {
         background?: boolean;
         onStdout?: (data: string) => void;
         onStderr?: (data: string) => void;
+        signal?: AbortSignal;
       },
     ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
   };

--- a/lib/centrifugo/types.ts
+++ b/lib/centrifugo/types.ts
@@ -10,6 +10,12 @@ export interface CommandMessage {
   targetConnectionId?: string;
 }
 
+export interface CommandCancelMessage {
+  type: "command_cancel";
+  commandId: string;
+  targetConnectionId?: string;
+}
+
 export interface StdoutMessage {
   type: "stdout";
   commandId: string;
@@ -98,6 +104,7 @@ export interface PtyErrorMessage {
 /** Command-only response subset — used by one-shot command execution. */
 export type CommandResponseMessage =
   | CommandMessage
+  | CommandCancelMessage
   | StdoutMessage
   | StderrMessage
   | ExitMessage

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -78,6 +78,8 @@ async fn wait_with_output_or_kill_on_timeout(
         .stderr
         .take()
         .ok_or_else(|| "Failed to capture stderr".to_string())?;
+    let child_pid = child.id();
+    let started_at = tokio::time::Instant::now();
 
     let stdout_task = tokio::spawn(async move {
         let mut output = Vec::new();
@@ -103,13 +105,40 @@ async fn wait_with_output_or_kill_on_timeout(
         }
     };
 
-    let stdout = match stdout_task.await {
-        Ok(Ok(output)) => output,
-        _ => Vec::new(),
+    let stdout_abort = stdout_task.abort_handle();
+    let stderr_abort = stderr_task.abort_handle();
+    let remaining = timeout
+        .checked_sub(started_at.elapsed())
+        .unwrap_or_else(|| Duration::from_millis(0));
+    let drain_timeout = if remaining.is_zero() {
+        Duration::from_millis(1)
+    } else {
+        remaining
     };
-    let stderr = match stderr_task.await {
-        Ok(Ok(output)) => output,
-        _ => Vec::new(),
+
+    let drain_result = tokio::time::timeout(drain_timeout, async {
+        let stdout = match stdout_task.await {
+            Ok(Ok(output)) => output,
+            _ => Vec::new(),
+        };
+        let stderr = match stderr_task.await {
+            Ok(Ok(output)) => output,
+            _ => Vec::new(),
+        };
+        (stdout, stderr)
+    })
+    .await;
+
+    let (stdout, stderr) = match drain_result {
+        Ok(output) => output,
+        Err(_) => {
+            if let Some(pid) = child_pid {
+                platform::cancel_process_tree(pid).await;
+            }
+            stdout_abort.abort();
+            stderr_abort.abort();
+            return Err(format!("Command timed out after {}ms", timeout_ms));
+        }
     };
 
     Ok(std::process::Output {

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -65,6 +65,60 @@ struct ExecResponse {
     exit_code: i32,
 }
 
+async fn wait_with_output_or_kill_on_timeout(
+    mut child: tokio::process::Child,
+    timeout: Duration,
+    timeout_ms: u64,
+) -> Result<std::process::Output, String> {
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Failed to capture stdout".to_string())?;
+    let mut stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Failed to capture stderr".to_string())?;
+
+    let stdout_task = tokio::spawn(async move {
+        let mut output = Vec::new();
+        stdout.read_to_end(&mut output).await.map(|_| output)
+    });
+    let stderr_task = tokio::spawn(async move {
+        let mut output = Vec::new();
+        stderr.read_to_end(&mut output).await.map(|_| output)
+    });
+
+    let status = match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(Ok(status)) => status,
+        Ok(Err(e)) => {
+            stdout_task.abort();
+            stderr_task.abort();
+            return Err(format!("Process error: {}", e));
+        }
+        Err(_) => {
+            platform::graceful_kill(&mut child).await;
+            stdout_task.abort();
+            stderr_task.abort();
+            return Err(format!("Command timed out after {}ms", timeout_ms));
+        }
+    };
+
+    let stdout = match stdout_task.await {
+        Ok(Ok(output)) => output,
+        _ => Vec::new(),
+    };
+    let stderr = match stderr_task.await {
+        Ok(Ok(output)) => output,
+        _ => Vec::new(),
+    };
+
+    Ok(std::process::Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
 #[derive(Deserialize)]
 struct FileReadRequest {
     path: String,
@@ -303,11 +357,7 @@ async fn handle_execute(body: &str) -> Result<String, String> {
     let child = cmd.spawn().map_err(|e| format!("Failed to spawn: {}", e))?;
 
     let timeout = Duration::from_millis(req.timeout_ms);
-    let output = match tokio::time::timeout(timeout, child.wait_with_output()).await {
-        Ok(Ok(output)) => output,
-        Ok(Err(e)) => return Err(format!("Process error: {}", e)),
-        Err(_) => return Err(format!("Command timed out after {}ms", req.timeout_ms)),
-    };
+    let output = wait_with_output_or_kill_on_timeout(child, timeout, req.timeout_ms).await?;
 
     // Truncate output to 1MB to prevent huge responses
     const MAX_OUTPUT: usize = 1024 * 1024;
@@ -526,11 +576,8 @@ async fn execute_command(
     let mut cmd = platform::build_command(&command, cwd.as_deref(), env.as_ref());
     let child = cmd.spawn().map_err(|e| format!("Failed to spawn: {}", e))?;
     let timeout = Duration::from_millis(timeout_ms.unwrap_or(30000));
-    let output = match tokio::time::timeout(timeout, child.wait_with_output()).await {
-        Ok(Ok(output)) => output,
-        Ok(Err(e)) => return Err(format!("Process error: {}", e)),
-        Err(_) => return Err(format!("Command timed out after {}ms", timeout_ms.unwrap_or(30000))),
-    };
+    let timeout_ms = timeout_ms.unwrap_or(30000);
+    let output = wait_with_output_or_kill_on_timeout(child, timeout, timeout_ms).await?;
     const MAX_OUTPUT: usize = 1024 * 1024;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -514,6 +514,8 @@ enum StreamEvent {
     Error { message: String },
 }
 
+type StreamCommandState = std::sync::Arc<std::sync::Mutex<HashMap<String, u32>>>;
+
 #[tauri::command]
 async fn execute_command(
     command: String,
@@ -551,6 +553,8 @@ async fn execute_command(
 
 #[tauri::command]
 async fn execute_stream_command(
+    state: tauri::State<'_, StreamCommandState>,
+    command_id: String,
     command: String,
     cwd: Option<String>,
     env: Option<HashMap<String, String>>,
@@ -559,6 +563,11 @@ async fn execute_stream_command(
 ) -> Result<(), String> {
     let mut cmd = platform::build_command(&command, cwd.as_deref(), env.as_ref());
     let mut child = cmd.spawn().map_err(|e| format!("Failed to spawn: {}", e))?;
+    if let Some(pid) = child.id() {
+        if let Ok(mut commands) = state.lock() {
+            commands.insert(command_id.clone(), pid);
+        }
+    }
     let timeout = Duration::from_millis(timeout_ms.unwrap_or(30000));
     let mut stdout = child.stdout.take().unwrap();
     let mut stderr = child.stderr.take().unwrap();
@@ -611,7 +620,29 @@ async fn execute_stream_command(
             let _ = on_event.send(StreamEvent::Error { message: format!("Command timed out after {}ms", timeout_ms.unwrap_or(30000)) });
         }
     }
+    if let Ok(mut commands) = state.lock() {
+        commands.remove(&command_id);
+    }
     Ok(())
+}
+
+#[tauri::command]
+async fn cancel_stream_command(
+    state: tauri::State<'_, StreamCommandState>,
+    command_id: String,
+) -> Result<bool, String> {
+    let pid = state
+        .lock()
+        .map_err(|_| "stream command state lock poisoned".to_string())?
+        .get(&command_id)
+        .copied();
+
+    if let Some(pid) = pid {
+        platform::cancel_process_tree(pid).await;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
 }
 
 /// Start a local HTTP server for dev mode auth callbacks.
@@ -993,7 +1024,7 @@ async fn execute_pty_kill(
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![get_dev_auth_port, get_cmd_server_info, execute_command, execute_stream_command, execute_pty_create, execute_pty_input, execute_pty_resize, execute_pty_kill])
+        .invoke_handler(tauri::generate_handler![get_dev_auth_port, get_cmd_server_info, execute_command, execute_stream_command, cancel_stream_command, execute_pty_create, execute_pty_input, execute_pty_resize, execute_pty_kill])
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_shell::init())
@@ -1018,6 +1049,7 @@ pub fn run() {
             }
         }))
         .manage(std::sync::Arc::new(std::sync::Mutex::new(pty::PtyManager::new())) as PtyState)
+        .manage(std::sync::Arc::new(std::sync::Mutex::new(HashMap::<String, u32>::new())) as StreamCommandState)
         .setup(|app| {
             #[cfg(desktop)]
             {

--- a/packages/desktop/src-tauri/src/platform.rs
+++ b/packages/desktop/src-tauri/src/platform.rs
@@ -149,6 +149,14 @@ pub fn build_command(
     #[cfg(not(windows))]
     {
         cmd.arg(config.flag).arg(command);
+        unsafe {
+            cmd.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
     }
 
     if let Some(cwd) = cwd {
@@ -178,14 +186,13 @@ pub async fn graceful_kill(child: &mut tokio::process::Child) {
         use std::time::Duration;
         if let Some(pid) = child.id() {
             // Send SIGTERM first for graceful shutdown
-            unsafe {
-                libc::kill(pid as libc::pid_t, libc::SIGTERM);
-            }
+            terminate_process_group(pid, libc::SIGTERM);
             // Wait up to 2 seconds for the process to exit
             match tokio::time::timeout(Duration::from_secs(2), child.wait()).await {
                 Ok(_) => return,
                 Err(_) => {
                     // Process didn't exit in time, escalate to SIGKILL
+                    terminate_process_group(pid, libc::SIGKILL);
                     let _ = child.kill().await;
                 }
             }
@@ -202,4 +209,35 @@ pub async fn graceful_kill(child: &mut tokio::process::Child) {
 
     // Reap the process to avoid zombies
     let _ = child.wait().await;
+}
+
+#[cfg(unix)]
+fn terminate_process_group(pid: u32, signal: libc::c_int) {
+    let pid = pid as libc::pid_t;
+    unsafe {
+        // build_command places each command in a fresh session, making the
+        // child pid also the process-group id. Kill the group so pipelines and
+        // shell grandchildren stop together.
+        if libc::kill(-pid, signal) == -1 {
+            let _ = libc::kill(pid, signal);
+        }
+    }
+}
+
+/// Best-effort external cancellation for a streaming command by process id.
+pub async fn cancel_process_tree(pid: u32) {
+    #[cfg(unix)]
+    {
+        terminate_process_group(pid, libc::SIGTERM);
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        terminate_process_group(pid, libc::SIGKILL);
+    }
+
+    #[cfg(windows)]
+    {
+        let _ = tokio::process::Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .output()
+            .await;
+    }
 }

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -780,6 +780,16 @@ class LocalSandboxClient {
     }, 1000).unref();
   }
 
+  private terminateActiveStreamCommands(): void {
+    for (const [commandId, proc] of this.activeStreamCommands) {
+      console.log(
+        chalk.yellow(`[CMD] Terminating active command ${commandId}`),
+      );
+      this.terminateProcessTree(proc);
+    }
+    this.activeStreamCommands.clear();
+  }
+
   private async streamCommand(
     commandId: string,
     fullCommand: string,
@@ -906,6 +916,7 @@ class LocalSandboxClient {
 
       proc.on("error", (error) => {
         if (timeoutId) clearTimeout(timeoutId);
+        this.activeStreamCommands.delete(commandId);
         this.publishToChannel({
           type: "error",
           commandId,
@@ -1050,6 +1061,9 @@ class LocalSandboxClient {
 
     // Stop all PTY sessions
     this.processRunner.stopAll();
+
+    // Stop all active streamed commands before dropping the realtime connection.
+    this.terminateActiveStreamCommands();
 
     // Disconnect Centrifugo
     if (this.subscription) {

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -185,6 +185,12 @@ interface CentrifugoCommandMessage {
   targetConnectionId?: string;
 }
 
+interface CentrifugoCommandCancelMessage {
+  type: "command_cancel";
+  commandId: string;
+  targetConnectionId?: string;
+}
+
 interface CentrifugoStdoutMessage {
   type: "stdout";
   commandId: string;
@@ -340,6 +346,7 @@ class LocalSandboxClient {
   private lastActivityTime: number;
   private idleCheckInterval?: NodeJS.Timeout;
   private processRunner: ProcessRunner;
+  private activeStreamCommands: Map<string, ChildProcess> = new Map();
 
   constructor(private config: Config) {
     this.convexHttp = new ConvexHttpClient(config.convexUrl);
@@ -544,6 +551,7 @@ class LocalSandboxClient {
 
       const message = ctx.data as
         | CentrifugoCommandMessage
+        | CentrifugoCommandCancelMessage
         | CentrifugoPtyIncomingMessage;
 
       // Gate on targetConnectionId for all message types that carry it
@@ -564,6 +572,10 @@ class LocalSandboxClient {
               console.error(chalk.red(`Error handling command: ${errorMsg}`));
             },
           );
+          break;
+
+        case "command_cancel":
+          this.handleCommandCancel(message as CentrifugoCommandCancelMessage);
           break;
 
         case "pty_create":
@@ -727,6 +739,47 @@ class LocalSandboxClient {
     }
   }
 
+  private handleCommandCancel(msg: CentrifugoCommandCancelMessage): void {
+    const proc = this.activeStreamCommands.get(msg.commandId);
+    if (!proc) {
+      return;
+    }
+    this.terminateProcessTree(proc);
+  }
+
+  private terminateProcessTree(proc: ChildProcess): void {
+    const pid = proc.pid;
+    if (!pid) {
+      proc.kill("SIGKILL");
+      return;
+    }
+
+    if (os.platform() === "win32") {
+      spawn("taskkill", ["/PID", String(pid), "/T", "/F"], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+      return;
+    }
+
+    try {
+      process.kill(-pid, "SIGTERM");
+    } catch {
+      proc.kill("SIGTERM");
+    }
+
+    setTimeout(() => {
+      if (proc.exitCode !== null || proc.signalCode !== null) {
+        return;
+      }
+      try {
+        process.kill(-pid, "SIGKILL");
+      } catch {
+        proc.kill("SIGKILL");
+      }
+    }, 1000).unref();
+  }
+
   private async streamCommand(
     commandId: string,
     fullCommand: string,
@@ -748,18 +801,15 @@ class LocalSandboxClient {
       );
       const proc = spawn(DEFAULT_SHELL.shell, spawnSpec.args, {
         stdio: ["ignore", "pipe", "pipe"],
+        detached: os.platform() !== "win32",
         ...spawnSpec.options,
       });
+      this.activeStreamCommands.set(commandId, proc);
 
       if (commandTimeout > 0) {
         timeoutId = setTimeout(() => {
           killed = true;
-          proc.kill("SIGTERM");
-          setTimeout(() => {
-            if (!proc.killed) {
-              proc.kill("SIGKILL");
-            }
-          }, 2000);
+          this.terminateProcessTree(proc);
         }, commandTimeout);
       }
 
@@ -798,6 +848,7 @@ class LocalSandboxClient {
 
       proc.on("close", (code) => {
         if (timeoutId) clearTimeout(timeoutId);
+        this.activeStreamCommands.delete(commandId);
 
         const duration = Date.now() - startTime;
         const exitCode = killed ? 124 : (code ?? 1);


### PR DESCRIPTION
## Summary

Fixes the Stop path for desktop/free-plan local terminal runs by relaying command cancellation through the local command bridge and killing the active streaming process group.

## What changed

- Added a `command_cancel` relay message for local Centrifugo commands.
- Passed the abort signal from `run_terminal_cmd` into the local sandbox command path.
- Updated the desktop bridge to handle `command_cancel` and call a new Tauri `cancel_stream_command` command.
- Tracked active streaming commands by `commandId` in Tauri and killed the process group so shell pipelines stop as a unit.
- Added matching process-tree cancellation behavior to the standalone local sandbox client.
- Added regression coverage for publishing `command_cancel` on Centrifugo abort.

## Root cause

Desktop/free-plan local runs were relying on fragile process discovery for cancellation. That could leave parts of a shell pipeline running after Stop was pressed.

## Validation

- `pnpm test -- lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts --runInBand`
- `pnpm test -- lib/ai/tools/__tests__/run-terminal-cmd.test.ts --runInBand`
- `pnpm exec tsc --noEmit --pretty false`
- `cargo check` in `packages/desktop/src-tauri`
- Commit hook also completed repo typecheck and Jest before committing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command cancellation for streaming terminal commands — users can abort running commands across platforms; aborted runs now consistently resolve with exit code 130.
  * Abort signals are respected for remote sandbox runs, and streaming commands are cleaned up reliably on timeout or cancel.

* **Tests**
  * Added automated tests covering command cancellation and abort race conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->