### PR TITLE
[codex] Align desktop Tauri API version

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -12,7 +12,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.9.1",
+    "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-deep-link": "^2.4.6",
     "@tauri-apps/plugin-os": "^2.3.2",
     "@tauri-apps/plugin-process": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,8 +392,8 @@ importers:
   packages/desktop:
     dependencies:
       "@tauri-apps/api":
-        specifier: ^2.9.1
-        version: 2.9.1
+        specifier: ^2.11.0
+        version: 2.11.0
       "@tauri-apps/plugin-deep-link":
         specifier: ^2.4.6
         version: 2.4.6


### PR DESCRIPTION
## Summary

Fixes the desktop release build failure on `main` by aligning the desktop workspace's `@tauri-apps/api` version with the Rust `tauri` crate minor version.

## Root Cause

The `Build Desktop App` workflow failed on every platform at the `Build Tauri app` step before compilation. The Tauri CLI reported:

```text
Found version mismatched Tauri packages:
tauri (v2.11.1) : @tauri-apps/api (v2.9.1)
```

`packages/desktop/package.json` still requested `@tauri-apps/api ^2.9.1`, while `packages/desktop/src-tauri/Cargo.lock` resolved Rust `tauri` to `2.11.1`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --dir packages/desktop tauri info` reports `tauri 2.11.1` and `@tauri-apps/api 2.11.0`
- `APP_URL=https://hackerai.co pnpm --dir packages/desktop tauri build --target x86_64-apple-darwin --debug` passed the Tauri version gate and only stopped because the local machine is missing the `x86_64-apple-darwin` Rust target
- `cargo check` in `packages/desktop/src-tauri`
- `pnpm --dir packages/desktop tauri build --debug` built the local debug app/bundles and only stopped at the expected local signing-key step (`TAURI_SIGNING_PRIVATE_KEY` not set)
- Commit hook passed full `tsc --noEmit` and Jest (`72` suites, `1010` tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to latest compatible versions for improved stability and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->