### PR TITLE
[codex] Fix desktop command bridge ACL

### DIFF
--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -335,7 +335,8 @@ describe("forwardChunk", () => {
     await startBridgeAndForwardChunks([{ type: "exit" }]);
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("exit chunk missing exitCode"),
+      "[desktop-bridge]",
+      expect.stringContaining("desktop_stream_exit_code_missing"),
     );
     warnSpy.mockRestore();
   });

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -349,10 +349,20 @@ export class DesktopSandboxBridge {
         onEvent: channel,
       });
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(
+        "[desktop-bridge]",
+        JSON.stringify({
+          event: "desktop_stream_command_failed",
+          service: "desktop_bridge",
+          command_id: commandId,
+          message,
+        }),
+      );
       await this.publishResult({
         type: "error",
         commandId,
-        message: error instanceof Error ? error.message : String(error),
+        message,
       });
     } finally {
       this.activeCommands.delete(commandId);
@@ -395,7 +405,12 @@ export class DesktopSandboxBridge {
       case "exit":
         if (chunk.exitCode === undefined) {
           console.warn(
-            `[desktop-bridge] exit chunk missing exitCode for command ${commandId}, defaulting to -1`,
+            "[desktop-bridge]",
+            JSON.stringify({
+              event: "desktop_stream_exit_code_missing",
+              service: "desktop_bridge",
+              command_id: commandId,
+            }),
           );
         }
         await this.publishResult({
@@ -405,6 +420,15 @@ export class DesktopSandboxBridge {
         });
         break;
       case "error":
+        console.error(
+          "[desktop-bridge]",
+          JSON.stringify({
+            event: "desktop_stream_error_chunk_received",
+            service: "desktop_bridge",
+            command_id: commandId,
+            message: chunk.message || "Unknown error",
+          }),
+        );
         await this.publishResult({
           type: "error",
           commandId,

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -713,6 +713,9 @@ In using these tools, adhere to the following guidelines:
                   const finalResult = handler
                     ? handler.getResult(processId ?? undefined)
                     : { output: "" };
+                  const sandboxOutput = [exec.stdout, exec.stderr]
+                    .filter(Boolean)
+                    .join("\n");
 
                   // Track background processes with their output files
                   if (is_background && processId) {
@@ -729,7 +732,8 @@ In using these tools, adhere to the following guidelines:
                   }
 
                   // Save full output to file when truncated (show path at top so AI sees it first)
-                  let outputWithSaveInfo = finalResult.output || "";
+                  let outputWithSaveInfo =
+                    finalResult.output || sandboxOutput || "";
                   if (!is_background && handler) {
                     const saveMsg = await saveTruncatedOutput({
                       handler,
@@ -750,6 +754,10 @@ In using these tools, adhere to the following guidelines:
                       : {
                           exitCode: exec.exitCode ?? 0,
                           output: outputWithSaveInfo,
+                          error:
+                            exec.exitCode === -1 && exec.stderr
+                              ? exec.stderr
+                              : undefined,
                         },
                   });
                 }

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -329,11 +329,25 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
               });
               break;
             case "error":
+              console.warn(
+                "[local-command]",
+                JSON.stringify({
+                  event: "local_command_error_received",
+                  service: "web",
+                  command_id: commandId,
+                  connection_id: this.connectionInfo.connectionId,
+                  stdout_length: stdout.length,
+                  stderr_length: stderr.length,
+                  message: message.message,
+                }),
+              );
               settled = true;
               cleanup();
               resolve({
                 stdout,
-                stderr: stderr + message.message,
+                stderr: stderr
+                  ? `${stderr}\n${message.message}`
+                  : message.message,
                 exitCode: -1,
               });
               break;

--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -15,6 +15,7 @@
         { "path": "https://**", "scheme": "https" }
       ]
     },
+    "allow-desktop-command-bridge",
     "os:default",
     "process:default",
     "updater:default",

--- a/packages/desktop/src-tauri/permissions/desktop-command-bridge.toml
+++ b/packages/desktop/src-tauri/permissions/desktop-command-bridge.toml
@@ -1,0 +1,14 @@
+[[permission]]
+identifier = "allow-desktop-command-bridge"
+description = "Allows the desktop webview to reach the local command bridge."
+commands.allow = [
+  "get_dev_auth_port",
+  "get_cmd_server_info",
+  "execute_command",
+  "execute_stream_command",
+  "cancel_stream_command",
+  "execute_pty_create",
+  "execute_pty_input",
+  "execute_pty_resize",
+  "execute_pty_kill",
+]


### PR DESCRIPTION
## Summary
- surface desktop bridge command errors instead of returning empty `exitCode: -1` results
- add the Tauri app permission that allows the remote desktop webview to call the local command bridge IPC commands
- keep stream, cancel, and PTY command paths covered by the desktop capability

## Root cause
Production desktop was loading the app from `https://hackerai.co`, and Tauri rejected custom IPC commands like `execute_stream_command` and `execute_pty_create` because the default capability only had plugin permissions. Dev worked because the local/dev origin was looser. The prod trace confirmed this with `execute_stream_command not allowed by ACL`.

## Verification
- `pnpm test -- app/services/__tests__/desktop-sandbox-bridge.test.ts --runInBand`
- `pnpm test -- lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts --runInBand`
- `pnpm test -- lib/ai/tools/__tests__/run-terminal-cmd.test.ts --runInBand`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec tsc --noEmit` via commit hook
- `pnpm test` via commit hook
- `cargo check` in `packages/desktop/src-tauri`
