### PR TITLE
[codex] Handle PostHog error noise

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1086,11 +1086,15 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const handleBranchMessage = async (messageId: string) => {
     try {
       const newChatId = await branchChatMutation({ messageId });
+      if (!newChatId) {
+        toast.error("That message is no longer available to branch.");
+        return;
+      }
       initializeChat(newChatId);
       router.push(`/c/${newChatId}`);
     } catch (error) {
       console.error("Failed to branch chat:", error);
-      throw error;
+      toast.error("Failed to branch chat. Please try again.");
     }
   };
 

--- a/app/hooks/useFeedback.ts
+++ b/app/hooks/useFeedback.ts
@@ -34,10 +34,15 @@ export const useFeedback = ({ messages, setMessages }: UseFeedbackProps) => {
 
         // For positive feedback, save immediately
         try {
-          await createFeedback({
+          const feedbackId = await createFeedback({
             feedback_type: "positive",
             message_id: messageId,
           });
+
+          if (!feedbackId) {
+            toast.error("That message is no longer available.");
+            return;
+          }
 
           // Update local message state and merge metadata
           setMessages(
@@ -74,10 +79,15 @@ export const useFeedback = ({ messages, setMessages }: UseFeedbackProps) => {
 
         // Save negative feedback immediately without details and show input
         try {
-          await createFeedback({
+          const feedbackId = await createFeedback({
             feedback_type: "negative",
             message_id: messageId,
           });
+
+          if (!feedbackId) {
+            toast.error("That message is no longer available.");
+            return;
+          }
 
           // Update local message state and merge metadata
           setMessages(
@@ -117,11 +127,17 @@ export const useFeedback = ({ messages, setMessages }: UseFeedbackProps) => {
 
       try {
         // Update the existing negative feedback with details
-        await createFeedback({
+        const feedbackId = await createFeedback({
           feedback_type: "negative",
           feedback_details: details,
           message_id: feedbackInputMessageId,
         });
+
+        if (!feedbackId) {
+          toast.error("That message is no longer available.");
+          setFeedbackInputMessageId(null);
+          return;
+        }
 
         // Local state already shows negative feedback, just hide the input
         setFeedbackInputMessageId(null);

--- a/convex/__tests__/fileStorage.delete.test.ts
+++ b/convex/__tests__/fileStorage.delete.test.ts
@@ -119,14 +119,14 @@ describe("fileStorage - deleteFile", () => {
       expect(mockCtx.db.delete).not.toHaveBeenCalled();
     });
 
-    it("should throw error if file not found", async () => {
+    it("should no-op if file not found", async () => {
       mockCtx.db.get.mockResolvedValue(null);
 
       const { deleteFile } = await import("../fileStorage");
 
       await expect(
         deleteFile.handler(mockCtx, { fileId: testFileId }),
-      ).rejects.toThrow("File not found");
+      ).resolves.toBeNull();
 
       expect(mockCtx.db.delete).not.toHaveBeenCalled();
     });

--- a/convex/chatStreams.ts
+++ b/convex/chatStreams.ts
@@ -2,6 +2,7 @@ import { query, mutation } from "./_generated/server";
 import { v, ConvexError } from "convex/values";
 import { internal } from "./_generated/api";
 import { validateServiceKey } from "./lib/utils";
+import { convexLogger } from "./lib/logger";
 
 /**
  * Start a stream by setting active_stream_id and clearing canceled_at (backend only)
@@ -24,7 +25,11 @@ export const startStream = mutation({
       .first();
 
     if (!chat) {
-      throw new Error("Chat not found");
+      convexLogger.warn("chat_stream_start_chat_missing", {
+        chat_id: args.chatId,
+        stream_id: args.streamId,
+      });
+      return null;
     }
 
     await ctx.db.patch(chat._id, {
@@ -57,7 +62,10 @@ export const prepareForNewStream = mutation({
       .first();
 
     if (!chat) {
-      throw new Error("Chat not found");
+      convexLogger.warn("chat_stream_prepare_chat_missing", {
+        chat_id: args.chatId,
+      });
+      return null;
     }
 
     // Only patch if either field needs to be cleared.

--- a/convex/feedback.ts
+++ b/convex/feedback.ts
@@ -1,5 +1,6 @@
 import { mutation } from "./_generated/server";
 import { v, ConvexError } from "convex/values";
+import { convexLogger } from "./lib/logger";
 
 export const createFeedback = mutation({
   args: {
@@ -7,7 +8,7 @@ export const createFeedback = mutation({
     feedback_details: v.optional(v.string()),
     message_id: v.string(),
   },
-  returns: v.id("feedback"),
+  returns: v.union(v.id("feedback"), v.null()),
   handler: async (ctx, args) => {
     const user = await ctx.auth.getUserIdentity();
 
@@ -25,11 +26,16 @@ export const createFeedback = mutation({
       .unique();
 
     if (!message) {
-      throw new ConvexError({
-        code: "MESSAGE_NOT_FOUND",
-        message: "Message not found",
+      convexLogger.warn("feedback_message_missing", {
+        user_id: user.subject,
+        message_id: args.message_id,
       });
+      return null;
     } else if (message.user_id !== user.subject) {
+      convexLogger.warn("feedback_message_access_denied", {
+        user_id: user.subject,
+        message_id: args.message_id,
+      });
       throw new ConvexError({
         code: "ACCESS_DENIED",
         message:

--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -30,7 +30,10 @@ import type {
 } from "../types/file";
 import { Id } from "./_generated/dataModel";
 import { validateServiceKey } from "./lib/utils";
-import { isSupportedImageMediaType } from "../lib/utils/file-utils";
+import {
+  isSupportedImageMediaType,
+  MAX_IMAGE_SIZE,
+} from "../lib/utils/file-utils";
 import { FILE_TOKEN_PERCENT, MAX_TOKENS_PAID } from "../lib/token-utils";
 
 // Maximum file size: 20 MB (enforced regardless of skipTokenValidation)
@@ -712,6 +715,39 @@ export const saveFile = action({
       throw new ConvexError({
         code: "FILE_SIZE_EXCEEDED",
         message: `File "${args.name}" exceeds the maximum file size limit of 20 MB. Current size: ${(args.size / (1024 * 1024)).toFixed(2)} MB`,
+      });
+    }
+
+    if (
+      isSupportedImageMediaType(args.mediaType) &&
+      args.size > MAX_IMAGE_SIZE
+    ) {
+      try {
+        if (args.s3Key) {
+          await ctx.scheduler.runAfter(
+            0,
+            internal.s3Cleanup.deleteS3ObjectAction,
+            { s3Key: args.s3Key },
+          );
+        } else if (args.storageId) {
+          await ctx.storage.delete(args.storageId);
+        }
+      } catch (deleteError) {
+        convexLogger.warn("file_upload_storage_cleanup_failed", {
+          userId: actingUserId,
+          fileName: args.name,
+          stage: "oversized_image",
+          s3Key: args.s3Key,
+          storageId: args.storageId,
+          error:
+            deleteError instanceof Error
+              ? { name: deleteError.name, message: deleteError.message }
+              : String(deleteError),
+        });
+      }
+      throw new ConvexError({
+        code: "IMAGE_SIZE_EXCEEDED",
+        message: `Image "${args.name}" exceeds the maximum image size limit of ${MAX_IMAGE_SIZE / (1024 * 1024)} MB. Current size: ${(args.size / (1024 * 1024)).toFixed(2)} MB`,
       });
     }
 

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -10,6 +10,7 @@ import { validateServiceKey } from "./lib/utils";
 import { internal } from "./_generated/api";
 import { isSupportedImageMediaType } from "../lib/utils/file-utils";
 import { fileCountAggregate } from "./fileAggregate";
+import { convexLogger } from "./lib/logger";
 
 // Maximum storage per user: 10 GB
 const MAX_STORAGE_BYTES = 10 * 1024 * 1024 * 1024; // 10737418240 bytes
@@ -32,30 +33,35 @@ export const getFileDownloadUrl = query({
       });
     }
 
-    try {
-      // Direct lookup by storage_id using index
-      const file = await ctx.db
-        .query("files")
-        .withIndex("by_storage_id", (q) =>
-          q.eq("storage_id", args.storageId as Id<"_storage">),
-        )
-        .first();
+    // Direct lookup by storage_id using index
+    const file = await ctx.db
+      .query("files")
+      .withIndex("by_storage_id", (q) =>
+        q.eq("storage_id", args.storageId as Id<"_storage">),
+      )
+      .first();
 
-      // Verify file exists and belongs to user
-      if (!file || file.user_id !== user.subject) {
-        throw new ConvexError({
-          code: "FILE_NOT_FOUND",
-          message: "File not found",
-        });
-      }
-
-      // Generate and return signed URL
-      const url = await ctx.storage.getUrl(args.storageId);
-      return url;
-    } catch (error) {
-      console.error("Failed to get file download URL:", error);
-      throw error;
+    // Stale message/file UI can outlive deleted storage rows. Treat missing as
+    // an unavailable URL instead of a Convex exception.
+    if (!file) {
+      convexLogger.warn("file_download_url_missing_file", {
+        user_id: user.subject,
+        storage_id: args.storageId,
+      });
+      return null;
     }
+
+    if (file.user_id !== user.subject) {
+      convexLogger.warn("file_download_url_access_denied", {
+        user_id: user.subject,
+        file_id: file._id,
+        storage_id: args.storageId,
+      });
+      return null;
+    }
+
+    // Generate and return signed URL
+    return await ctx.storage.getUrl(args.storageId);
   },
 });
 
@@ -81,10 +87,11 @@ export const deleteFile = mutation({
     const file = await ctx.db.get(args.fileId);
 
     if (!file) {
-      throw new ConvexError({
-        code: "FILE_NOT_FOUND",
-        message: "File not found",
+      convexLogger.warn("file_delete_missing_file", {
+        user_id: user.subject,
+        file_id: args.fileId,
       });
+      return null;
     }
 
     if (file.user_id !== user.subject) {

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -5,6 +5,7 @@ import { Id } from "./_generated/dataModel";
 import { paginationOptsValidator } from "convex/server";
 import { validateServiceKey, copyChatSummary } from "./lib/utils";
 import { fileCountAggregate } from "./fileAggregate";
+import { convexLogger } from "./lib/logger";
 
 /**
  * Extract text content from message parts for search and display
@@ -1038,7 +1039,7 @@ export const branchChat = mutation({
   args: {
     messageId: v.string(),
   },
-  returns: v.string(),
+  returns: v.union(v.string(), v.null()),
   handler: async (ctx, args) => {
     const user = await ctx.auth.getUserIdentity();
 
@@ -1053,11 +1054,19 @@ export const branchChat = mutation({
         .first();
 
       if (!message) {
-        throw new Error("Message not found");
+        convexLogger.warn("branch_chat_message_missing", {
+          user_id: user.subject,
+          message_id: args.messageId,
+        });
+        return null;
       }
 
       if (message.user_id !== user.subject) {
-        throw new Error("Unauthorized: Message does not belong to user");
+        convexLogger.warn("branch_chat_message_access_denied", {
+          user_id: user.subject,
+          message_id: args.messageId,
+        });
+        return null;
       }
 
       const chatExists: boolean = await ctx.runQuery(
@@ -1069,7 +1078,12 @@ export const branchChat = mutation({
       );
 
       if (!chatExists) {
-        throw new Error("Chat not found");
+        convexLogger.warn("branch_chat_chat_missing_or_denied", {
+          user_id: user.subject,
+          message_id: args.messageId,
+          chat_id: message.chat_id,
+        });
+        return null;
       }
 
       // Get original chat to copy title
@@ -1079,7 +1093,12 @@ export const branchChat = mutation({
         .first();
 
       if (!originalChat) {
-        throw new Error("Original chat not found");
+        convexLogger.warn("branch_chat_original_chat_missing", {
+          user_id: user.subject,
+          message_id: args.messageId,
+          chat_id: message.chat_id,
+        });
+        return null;
       }
 
       // Get all messages up to and including this message using index range

--- a/convex/sharedChats.ts
+++ b/convex/sharedChats.ts
@@ -1,6 +1,7 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
 import { copyChatSummary } from "./lib/utils";
+import { convexLogger } from "./lib/logger";
 
 /**
  * Share a chat by creating a public share link.
@@ -28,10 +29,19 @@ export const shareChat = mutation({
       .first();
 
     if (!chat) {
+      convexLogger.warn("share_chat_missing", {
+        user_id: identity.subject,
+        chat_id: args.chatId,
+      });
       throw new Error("Chat not found");
     }
 
     if (chat.user_id !== identity.subject) {
+      convexLogger.warn("share_chat_access_denied", {
+        user_id: identity.subject,
+        chat_id: args.chatId,
+        owner_user_id: chat.user_id,
+      });
       throw new Error("Unauthorized: Chat does not belong to user");
     }
 
@@ -97,15 +107,28 @@ export const updateShareDate = mutation({
       .first();
 
     if (!chat) {
+      convexLogger.warn("share_update_chat_missing", {
+        user_id: identity.subject,
+        chat_id: args.chatId,
+      });
       throw new Error("Chat not found");
     }
 
     if (chat.user_id !== identity.subject) {
+      convexLogger.warn("share_update_access_denied", {
+        user_id: identity.subject,
+        chat_id: args.chatId,
+        owner_user_id: chat.user_id,
+      });
       throw new Error("Unauthorized: Chat does not belong to user");
     }
 
     // Can only update if chat is already shared
     if (!chat.share_id || !chat.share_date) {
+      convexLogger.warn("share_update_not_shared", {
+        user_id: identity.subject,
+        chat_id: args.chatId,
+      });
       throw new Error(
         "Chat is not shared - use shareChat to create a share first",
       );
@@ -147,10 +170,19 @@ export const unshareChat = mutation({
       .first();
 
     if (!chat) {
+      convexLogger.warn("share_unshare_chat_missing", {
+        user_id: identity.subject,
+        chat_id: args.chatId,
+      });
       throw new Error("Chat not found");
     }
 
     if (chat.user_id !== identity.subject) {
+      convexLogger.warn("share_unshare_access_denied", {
+        user_id: identity.subject,
+        chat_id: args.chatId,
+        owner_user_id: chat.user_id,
+      });
       throw new Error("Unauthorized: Chat does not belong to user");
     }
 

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -67,6 +67,32 @@ export interface StreamResult {
   hadSummarization: boolean;
 }
 
+function providerErrorCategory(details: Record<string, unknown>): string {
+  const statusCode =
+    typeof details.statusCode === "number" ? details.statusCode : undefined;
+  if (statusCode === 429) return "rate_limited";
+  if (statusCode != null && statusCode >= 500) return "provider_5xx";
+  if (statusCode != null && statusCode >= 400) return "provider_4xx";
+
+  const message =
+    typeof details.errorMessage === "string" ? details.errorMessage : "";
+  if (/terminated|aborted|abort/i.test(message)) return "stream_terminated";
+  if (/timeout|timed out/i.test(message)) return "timeout";
+  return "unknown";
+}
+
+function posthogProviderException(
+  error: unknown,
+  details: Record<string, unknown>,
+): Error {
+  if (error instanceof Error) return error;
+  const message =
+    typeof details.errorMessage === "string" && details.errorMessage.length > 0
+      ? details.errorMessage
+      : "Provider streaming error";
+  return new Error(message);
+}
+
 /**
  * Creates a chat logger instance for tracking wide events
  */
@@ -208,6 +234,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
     ) {
       const details = extractErrorDetails(error);
       const attempts = extractRetryAttempts(error);
+      const category = providerErrorCategory(details);
 
       logger.error(
         "Provider streaming error",
@@ -215,6 +242,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
         {
           chat_id: config.chatId,
           endpoint: config.endpoint,
+          provider_error_category: category,
           ...context,
           ...details,
           ...(attempts && { provider_attempts: attempts }),
@@ -222,9 +250,10 @@ export function createChatLogger(config: ChatLoggerConfig) {
       );
 
       phLogger.error("Provider streaming error", {
-        error,
+        error: posthogProviderException(error, details),
         chatId: config.chatId,
         endpoint: config.endpoint,
+        providerErrorCategory: category,
         ...context,
         ...details,
         ...(attempts && { provider_attempts: attempts }),

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -11,8 +11,10 @@ import { collectSandboxFiles } from "./sandbox-file-utils";
 import { extractAllFileIdsFromMessages, isFilePart } from "./file-token-utils";
 import { getMaxFileTokens } from "../token-utils";
 import type { SubscriptionTier } from "@/types";
+import { logger } from "@/lib/logger";
 
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
+const MAX_PROVIDER_IMAGE_DOWNLOAD_SIZE = 30 * 1024 * 1024;
 
 const containsPdfAttachments = (messages: UIMessage[]): boolean =>
   messages.some((msg: any) =>
@@ -54,6 +56,34 @@ const convertUrlToBase64DataUrl = async (
   }
 };
 
+const probeContentLength = async (url: string): Promise<number | null> => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+  try {
+    const response = await fetch(url, {
+      method: "HEAD",
+      signal: controller.signal,
+    });
+    if (!response.ok) return null;
+    const length = response.headers.get("content-length");
+    if (!length) return null;
+    const parsed = Number(length);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};
+
+const imageOmittedText = (
+  name: unknown,
+  sizeBytes: number,
+  limitBytes: number,
+) =>
+  `[Image "${typeof name === "string" && name.length > 0 ? name : "unnamed"}" omitted: ${(sizeBytes / (1024 * 1024)).toFixed(1)} MB exceeds the ${limitBytes / (1024 * 1024)} MB per-image limit]`;
+
 /**
  * Replace image file parts whose declared size exceeds Anthropic's 5 MiB
  * per-image limit with a short text note. Without this, the model call fails
@@ -72,10 +102,13 @@ const replaceOversizedImageParts = (messages: UIMessage[]) => {
       ) {
         return part;
       }
-      const sizeMb = ((part as any).size / (1024 * 1024)).toFixed(1);
       return {
         type: "text",
-        text: `[Image "${(part as any).name ?? "unnamed"}" omitted: ${sizeMb} MB exceeds the ${MAX_IMAGE_SIZE / (1024 * 1024)} MB per-image limit]`,
+        text: imageOmittedText(
+          (part as any).name,
+          (part as any).size,
+          MAX_IMAGE_SIZE,
+        ),
       };
     });
   });
@@ -175,7 +208,7 @@ const applyUrlsToFileParts = async (
     }
   });
 
-  for (const [_, file] of filesToProcess) {
+  for (const [fileId, file] of filesToProcess) {
     if (!file.url) continue;
 
     // Only convert PDFs to base64 in "ask" mode for inline viewing.
@@ -187,9 +220,59 @@ const applyUrlsToFileParts = async (
           )
         : file.url;
 
+    const firstPart = file.positions.length
+      ? (messages[file.positions[0].messageIndex].parts![
+          file.positions[0].partIndex
+        ] as any)
+      : null;
+    const isSupportedImage = isSupportedImageMediaType(file.mediaType ?? "");
+    const probedImageSize =
+      isSupportedImage && typeof firstPart?.size !== "number"
+        ? await probeContentLength(file.url)
+        : null;
+    const effectiveImageSize =
+      typeof firstPart?.size === "number" ? firstPart.size : probedImageSize;
+    const imageLimit =
+      effectiveImageSize != null &&
+      effectiveImageSize > MAX_PROVIDER_IMAGE_DOWNLOAD_SIZE
+        ? MAX_PROVIDER_IMAGE_DOWNLOAD_SIZE
+        : MAX_IMAGE_SIZE;
+    const shouldOmitImage =
+      isSupportedImage &&
+      effectiveImageSize != null &&
+      effectiveImageSize > imageLimit;
+
+    if (shouldOmitImage) {
+      logger.warn("image_attachment_omitted_before_provider_call", {
+        event: "image_attachment_omitted_before_provider_call",
+        service: "chat-handler",
+        file_id: fileId,
+        media_type: file.mediaType,
+        size_bytes: effectiveImageSize,
+        limit_bytes: imageLimit,
+        size_source:
+          typeof firstPart?.size === "number"
+            ? "message_part"
+            : "content_length",
+        mode,
+      });
+    }
+
     file.positions.forEach(({ messageIndex, partIndex }) => {
       const filePart = messages[messageIndex].parts![partIndex] as any;
-      if (filePart.type === "file") filePart.url = finalUrl;
+      if (filePart.type !== "file") return;
+      if (shouldOmitImage) {
+        messages[messageIndex].parts![partIndex] = {
+          type: "text",
+          text: imageOmittedText(
+            filePart.name,
+            effectiveImageSize!,
+            imageLimit,
+          ),
+        };
+      } else {
+        filePart.url = finalUrl;
+      }
     });
   }
 };


### PR DESCRIPTION
## Summary

This PR cleans up the highest-volume PostHog error groups from the recent review pass.

- Converts stale message/file races into graceful no-ops with user-facing toasts where appropriate.
- Adds structured Convex warnings for ambiguous authorization and missing-resource cases so future incidents have useful IDs and ownership context.
- Rejects or omits oversized image attachments before provider calls to avoid provider download-size failures.
- Adds provider error categorization so streaming failures are easier to group by rate limit, provider 4xx/5xx, timeout, or stream termination.

## Root Cause

Several expected lifecycle races were being thrown as hard Convex/client errors: deleted files referenced by stale UI, feedback/branch operations against missing messages, and backend stream setup after chat deletion. Provider/image failures also lacked enough preflight checks and structured grouping.

## Validation

- `pnpm test -- convex/__tests__/fileStorage.delete.test.ts convex/__tests__/messages.hidden.test.ts lib/chat/__tests__/chat-processor.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- Commit hook: `tsc --noEmit` and full `jest` suite, 72 suites / 1010 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Chat branching and feedback operations now gracefully handle missing messages with clear error notifications instead of crashing.
  * Added stricter image upload size validation to prevent oversized images.
  * Improved error handling for file operations and chat actions.

* **Improvements**
  * Enhanced error logging and diagnostic tracking for better system reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->