### PR TITLE
[codex] Repair Anthropic history before fallback

### DIFF
--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -17,8 +17,7 @@ jest.mock("@/lib/logger", () => ({
 }));
 
 // Slugs the test asserts against. These match the registry in lib/ai/providers.ts.
-// If the registry slug for a model changes, update both places intentionally —
-// that's the point of this test.
+// If the registry slug for a model changes, update both places intentionally.
 const KIMI_SLUG = "moonshotai/kimi-k2.6:exacto";
 
 describe("buildProviderOptions fallback chain", () => {
@@ -34,6 +33,14 @@ describe("buildProviderOptions fallback chain", () => {
     const opts = buildProviderOptions(false, "user-1", "model-sonnet-4.6");
     expect(opts.openrouter).toMatchObject({
       models: [KIMI_SLUG],
+      user: "user-1",
+    });
+  });
+
+  it("keeps fallback for free auto agent model", () => {
+    const opts = buildProviderOptions(false, "user-1", "agent-model-free");
+    expect(opts.openrouter).toMatchObject({
+      models: ["x-ai/grok-4.3"],
       user: "user-1",
     });
   });

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -17,6 +17,7 @@ import {
   convertToModelMessages,
   stepCountIs,
   streamText,
+  type ModelMessage,
   type UIMessage,
   type UIMessageStreamWriter,
   type ToolSet,
@@ -47,9 +48,11 @@ import {
 } from "@/lib/chat/doom-loop-detection";
 import {
   filterEmptyAssistantMessages,
+  repairAnthropicModelMessagesWithTelemetry,
   pruneToolOutputs,
   pruneModelMessages,
 } from "@/lib/chat/compaction/prune-tool-outputs";
+import { isAnthropicModel } from "@/lib/ai/providers";
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { getMaxTokensForSubscription } from "@/lib/token-utils";
 import { SUMMARIZATION_THRESHOLD_PERCENTAGE } from "@/lib/chat/summarization/constants";
@@ -164,12 +167,29 @@ export async function createAgentStream(
 ) {
   const requestedLanguageModel = ctx.trackedProvider.languageModel(modelName);
   const requestedSlug = requestedLanguageModel.modelId;
+  const prepareProviderMessages = (
+    messages: ModelMessage[],
+  ): ModelMessage[] => {
+    const nonEmptyMessages = filterEmptyAssistantMessages(messages);
+    if (!isAnthropicModel(modelName)) return nonEmptyMessages;
+
+    const repair = repairAnthropicModelMessagesWithTelemetry(nonEmptyMessages);
+    if (repair.action !== "none") {
+      ctx.chatLogger?.recordAnthropicPromptRepair({
+        action: repair.action,
+        reason: repair.reason,
+        trailingAssistantContentTypes: repair.trailingAssistantContentTypes,
+        model: modelName,
+      });
+    }
+    return repair.messages as ModelMessage[];
+  };
 
   return streamText({
     model: requestedLanguageModel,
     maxOutputTokens: 30000,
     system: buildSystemPrompt(ctx.currentSystemPrompt, modelName),
-    messages: filterEmptyAssistantMessages(
+    messages: prepareProviderMessages(
       await convertToModelMessages(state.finalMessages),
     ),
     tools: ctx.tools,
@@ -228,7 +248,7 @@ export async function createAgentStream(
               state.ctxUsage = result.contextUsage;
             }
             return {
-              messages: filterEmptyAssistantMessages(
+              messages: prepareProviderMessages(
                 await convertToModelMessages(result.summarizedMessages),
               ),
             };
@@ -269,8 +289,11 @@ export async function createAgentStream(
         }
 
         return {
-          messages: filterEmptyAssistantMessages(
-            addCacheBreakpointToLastUserMessage(updatedMessages, modelName),
+          messages: prepareProviderMessages(
+            addCacheBreakpointToLastUserMessage(
+              updatedMessages,
+              modelName,
+            ) as ModelMessage[],
           ) as typeof messages,
         };
       } catch (error) {
@@ -365,12 +388,21 @@ export async function createAgentStream(
       state.streamUsage = usage as Record<string, unknown>;
       state.responseModel = response?.modelId;
 
+      const fallbackSlugs = getFallbackSlugs(modelName);
       logOpenRouterFallbackIfFired({
-        fallbackSlugs: getFallbackSlugs(modelName),
+        fallbackSlugs,
         requestedSlug,
         responseModel: state.responseModel,
         chatId: ctx.chatId,
       });
+      if (state.responseModel && fallbackSlugs.includes(state.responseModel)) {
+        ctx.chatLogger?.recordModelFallback({
+          requested: requestedSlug,
+          served: state.responseModel,
+          chain: fallbackSlugs,
+          model: modelName,
+        });
+      }
       ctx.chatLogger?.setStreamResponse(state.responseModel, state.streamUsage);
 
       await ptySessionManager

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -204,6 +204,58 @@ export function createChatLogger(config: ChatLoggerConfig) {
     },
 
     /**
+     * Record Anthropic prompt repair before provider call.
+     */
+    recordAnthropicPromptRepair(repair: {
+      action: "appended_continue" | "trimmed";
+      reason:
+        | "useful_assistant_tail"
+        | "no_useful_content"
+        | "dangling_tool_call";
+      trailingAssistantContentTypes?: string[];
+      model: string;
+    }) {
+      builder.recordAnthropicPromptRepair(repair);
+      phLogger.event("anthropic_prompt_repaired", {
+        userId,
+        chat_id: config.chatId,
+        endpoint: config.endpoint,
+        mode,
+        subscription,
+        model: repair.model,
+        action: repair.action,
+        reason: repair.reason,
+        trailing_assistant_content_types: repair.trailingAssistantContentTypes,
+      });
+    },
+
+    /**
+     * Record that OpenRouter served a configured fallback model.
+     */
+    recordModelFallback(fallback: {
+      requested: string | undefined;
+      served: string;
+      chain: string[];
+      model: string;
+    }) {
+      builder.recordModelFallback({
+        served: fallback.served,
+        chain: fallback.chain,
+      });
+      phLogger.event("model_fallback_served", {
+        userId,
+        chat_id: config.chatId,
+        endpoint: config.endpoint,
+        mode,
+        subscription,
+        configured_model: fallback.model,
+        requested_model: fallback.requested,
+        served_model: fallback.served,
+        fallback_chain: fallback.chain,
+      });
+    },
+
+    /**
      * Set cache metrics for the wide event
      */
     setCacheMetrics(metrics: {

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -447,9 +447,9 @@ export class SummarizationTracker {
  * stream, OpenRouter rolls forward through this list and bills at the served
  * model's rate (response.modelId reflects what actually ran).
  *
- * Chain ordering: prefer a same-provider fallback first to preserve context
- * window and behavior, then cross to a different provider so an Anthropic
- * outage that takes down Opus and Sonnet together still has somewhere to go.
+ * Claude chats are repaired for Anthropic-compatible message shapes before
+ * this fallback can fire. If Opus/Sonnet still fails due to provider-side
+ * issues, Kimi preserves agent availability.
  *
  * Keys and values are registry names (see lib/ai/providers.ts) — the actual
  * OpenRouter slugs are resolved at request-build time so this stays in sync

--- a/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
+++ b/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
@@ -4,6 +4,7 @@ import {
   pruneToolOutputs,
   pruneModelMessages,
   filterEmptyAssistantMessages,
+  repairAnthropicModelMessages,
 } from "../prune-tool-outputs";
 
 // Helper to create a UIMessage with tool parts
@@ -1218,5 +1219,78 @@ describe("filterEmptyAssistantMessages", () => {
     expect(result[1]).toEqual(messages[1]); // assistant with tool-call kept
     expect(result[2]).toEqual(messages[2]); // tool result kept
     expect(result[3]).toEqual(messages[4]); // final assistant kept
+  });
+});
+
+describe("repairAnthropicModelMessages", () => {
+  it("preserves useful trailing assistant text by appending a user continuation", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "build this" }] },
+      { role: "assistant", content: [{ type: "text", text: "half answer" }] },
+    ];
+
+    expect(repairAnthropicModelMessages(messages)).toEqual([
+      ...messages,
+      {
+        role: "user",
+        content:
+          "Continue from the previous assistant message. Do not repeat completed work.",
+      },
+    ]);
+  });
+
+  it("trims a trailing assistant with no useful provider-visible content", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "build this" }] },
+      {
+        role: "assistant",
+        content: [{ type: "reasoning", text: "thinking..." }],
+      },
+    ];
+
+    expect(repairAnthropicModelMessages(messages)).toEqual([messages[0]]);
+  });
+
+  it("trims a trailing assistant with a dangling tool call", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "read the file" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "tc1", toolName: "read", args: {} },
+        ],
+      },
+    ];
+
+    expect(repairAnthropicModelMessages(messages)).toEqual([messages[0]]);
+  });
+
+  it("leaves conversations ending in user or tool messages unchanged", () => {
+    const userEnding = [
+      { role: "assistant", content: [{ type: "text", text: "done" }] },
+      { role: "user", content: [{ type: "text", text: "continue" }] },
+    ];
+    const toolEnding = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "tc1", toolName: "read", args: {} },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: "read",
+            output: "contents",
+          },
+        ],
+      },
+    ];
+
+    expect(repairAnthropicModelMessages(userEnding)).toBe(userEnding);
+    expect(repairAnthropicModelMessages(toolEnding)).toBe(toolEnding);
   });
 });

--- a/lib/chat/compaction/prune-tool-outputs.ts
+++ b/lib/chat/compaction/prune-tool-outputs.ts
@@ -496,3 +496,129 @@ export function filterEmptyAssistantMessages<T extends Record<string, unknown>>(
     });
   });
 }
+
+const ANTHROPIC_CONTINUE_MESSAGE = {
+  role: "user",
+  content:
+    "Continue from the previous assistant message. Do not repeat completed work.",
+} as const;
+
+export type PromptMessage = Record<string, unknown> & {
+  role?: unknown;
+  content?: unknown;
+};
+
+export type AnthropicPromptRepairAction =
+  | "none"
+  | "appended_continue"
+  | "trimmed";
+
+export type AnthropicPromptRepairReason =
+  | "not_trailing_assistant"
+  | "useful_assistant_tail"
+  | "no_useful_content"
+  | "dangling_tool_call";
+
+export type AppliedAnthropicPromptRepairReason = Exclude<
+  AnthropicPromptRepairReason,
+  "not_trailing_assistant"
+>;
+
+export interface AppliedAnthropicPromptRepair {
+  messages: PromptMessage[];
+  action: Exclude<AnthropicPromptRepairAction, "none">;
+  reason: AppliedAnthropicPromptRepairReason;
+  trailingAssistantContentTypes?: string[];
+}
+
+export interface NoAnthropicPromptRepair {
+  messages: PromptMessage[];
+  action: "none";
+  reason: "not_trailing_assistant";
+}
+
+export type AnthropicPromptRepairTelemetry =
+  | AppliedAnthropicPromptRepair
+  | NoAnthropicPromptRepair;
+
+const getContentTypes = (content: unknown): string[] | undefined => {
+  if (typeof content === "string") return ["text"];
+  if (!Array.isArray(content)) return undefined;
+  return content
+    .map((part: any) => part?.type)
+    .filter((type: unknown): type is string => typeof type === "string");
+};
+
+const hasDanglingAssistantToolCall = (content: unknown): boolean => {
+  if (!Array.isArray(content)) return false;
+  return content.some((part: any) => part?.type === "tool-call");
+};
+
+const hasUsefulAssistantContent = (content: unknown): boolean => {
+  if (typeof content === "string") return content.trim().length > 0;
+  if (!Array.isArray(content)) return content != null;
+
+  return content.some((part: any) => {
+    if (part?.type === "text") return !!part.text?.trim();
+    if (part?.type === "reasoning" || part?.type === "redacted-reasoning") {
+      return false;
+    }
+    if (part?.type === "tool-call") return false;
+    return true;
+  });
+};
+
+/**
+ * Anthropic treats a final assistant message in the prompt as an assistant
+ * prefill. Claude Opus 4.6 / Sonnet 4.6 reject prefill, so before calling an
+ * Anthropic model we ensure the prompt does not end with assistant content.
+ *
+ * When the trailing assistant message has useful non-tool context, preserve it
+ * and append a provider-only user continuation. If it is empty/reasoning-only
+ * or contains a dangling tool call, trim it to avoid follow-up provider errors.
+ */
+export function repairAnthropicModelMessagesWithTelemetry(
+  messages: PromptMessage[],
+): AnthropicPromptRepairTelemetry {
+  const lastMessage = messages.at(-1);
+  if (lastMessage?.role !== "assistant") {
+    return {
+      messages,
+      action: "none",
+      reason: "not_trailing_assistant",
+    };
+  }
+
+  const trailingAssistantContentTypes = getContentTypes(lastMessage.content);
+
+  if (hasDanglingAssistantToolCall(lastMessage.content)) {
+    return {
+      messages: messages.slice(0, -1),
+      action: "trimmed",
+      reason: "dangling_tool_call",
+      trailingAssistantContentTypes,
+    };
+  }
+
+  if (hasUsefulAssistantContent(lastMessage.content)) {
+    return {
+      messages: [...messages, ANTHROPIC_CONTINUE_MESSAGE],
+      action: "appended_continue",
+      reason: "useful_assistant_tail",
+      trailingAssistantContentTypes,
+    };
+  }
+
+  return {
+    messages: messages.slice(0, -1),
+    action: "trimmed",
+    reason: "no_useful_content",
+    trailingAssistantContentTypes,
+  };
+}
+
+export function repairAnthropicModelMessages(
+  messages: PromptMessage[],
+): PromptMessage[] {
+  return repairAnthropicModelMessagesWithTelemetry(messages).messages;
+}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -66,6 +66,20 @@ export interface ChatWideEvent {
   model?: {
     configured: string;
     actual?: string;
+    fallback_triggered?: boolean;
+    fallback_chain?: string[];
+  };
+
+  prompt_repair?: {
+    anthropic?: {
+      count: number;
+      last_action: "appended_continue" | "trimmed";
+      last_reason:
+        | "useful_assistant_tail"
+        | "no_useful_content"
+        | "dangling_tool_call";
+      last_content_types?: string[];
+    };
   };
 
   // Stream execution
@@ -182,6 +196,7 @@ export class WideEventBuilder {
   private event: Partial<ChatWideEvent>;
   private toolCalls: Array<{ name: string; sandbox_type?: string }> = [];
   private streamStartTime?: number;
+  private anthropicPromptRepairCount = 0;
 
   constructor(
     requestId: string,
@@ -301,6 +316,43 @@ export class WideEventBuilder {
     } else {
       this.event.model = { configured: actual, actual };
     }
+    return this;
+  }
+
+  /**
+   * Record that OpenRouter served a configured fallback model.
+   */
+  recordModelFallback(fallback: { served: string; chain: string[] }): this {
+    if (!this.event.model) {
+      this.event.model = { configured: fallback.served };
+    }
+    this.event.model.actual = fallback.served;
+    this.event.model.fallback_triggered = true;
+    this.event.model.fallback_chain = fallback.chain;
+    return this;
+  }
+
+  /**
+   * Record Anthropic prompt repairs that prevent unsupported assistant prefill.
+   */
+  recordAnthropicPromptRepair(repair: {
+    action: "appended_continue" | "trimmed";
+    reason:
+      | "useful_assistant_tail"
+      | "no_useful_content"
+      | "dangling_tool_call";
+    trailingAssistantContentTypes?: string[];
+  }): this {
+    this.anthropicPromptRepairCount += 1;
+    this.event.prompt_repair = {
+      ...this.event.prompt_repair,
+      anthropic: {
+        count: this.anthropicPromptRepairCount,
+        last_action: repair.action,
+        last_reason: repair.reason,
+        last_content_types: repair.trailingAssistantContentTypes,
+      },
+    };
     return this;
   }
 


### PR DESCRIPTION
## Summary
- Repair Anthropic model messages before provider calls so Claude Opus/Sonnet do not receive unsupported assistant-prefill shaped prompts
- Preserve useful trailing assistant context by appending a provider-only user continuation message; trim empty/reasoning-only or dangling-tool-call tails
- Keep the existing Kimi fallback for Opus/Sonnet after the repaired Claude attempt
- Add observability to measure repair frequency and fallback frequency

## Root Cause
Claude Opus 4.6 and Sonnet 4.6 can reject prompts that end with an assistant message because Anthropic treats that shape as assistant prefill. OpenRouter can then fall through to the configured Kimi fallback, making users feel their selected Opus model was ignored.

## Observability
- Wide chat events now include `prompt_repair.anthropic` with repair count, last action, last reason, and trailing assistant content types
- Wide chat events now mark `model.fallback_triggered` and `model.fallback_chain` when OpenRouter serves a configured fallback
- PostHog emits `anthropic_prompt_repaired` and `model_fallback_served` so we can compare repair volume against remaining Kimi fallbacks over time

## Validation
- pnpm test -- lib/chat/compaction/__tests__/prune-tool-outputs.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts --runInBand
- pnpm typecheck
- Full pre-commit hook: prettier, eslint --fix, pnpm typecheck, pnpm test (75 suites / 1042 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of assistant-tail endings to avoid provider errors and remove dangling tool/reasoning content
  * Refined fallback logic so agent availability is preserved when a primary provider fails

* **New Features**
  * Automatic prompt-repair that appends continuation prompts or trims problematic assistant tails
  * Logging of prompt-repair and model-fallback events for observability

* **Tests**
  * Added tests covering prompt repairs and fallback preservation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->