### PR TITLE
[codex] Fix generated file sharing OOM

### DIFF
--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -1027,6 +1027,7 @@ export const saveSandboxGeneratedFile = action({
     }
 
     try {
+      const fileUrl = await generateS3DownloadUrl(args.s3Key);
       const fileId = (await ctx.runMutation(internal.fileStorage.saveFileToDb, {
         s3Key: args.s3Key,
         userId: args.userId,
@@ -1037,7 +1038,7 @@ export const saveSandboxGeneratedFile = action({
       })) as Id<"files">;
 
       return {
-        url: await generateS3DownloadUrl(args.s3Key),
+        url: fileUrl,
         fileId,
         tokens: 0,
       };

--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -35,6 +35,7 @@ import {
   MAX_IMAGE_SIZE,
 } from "../lib/utils/file-utils";
 import { FILE_TOKEN_PERCENT, MAX_TOKENS_PAID } from "../lib/token-utils";
+import { MAX_GENERATED_FILE_SIZE_BYTES } from "../lib/constants/s3";
 
 // Maximum file size: 20 MB (enforced regardless of skipTokenValidation)
 const MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024;
@@ -956,5 +957,114 @@ export const saveFile = action({
       fileId,
       tokens: tokenSize,
     };
+  },
+});
+
+/**
+ * Save metadata for an assistant-generated sandbox artifact.
+ *
+ * These files are download-only artifacts produced by tools like
+ * get_terminal_files, not prompt attachments. Avoid fetching or parsing the
+ * object here so large generated archives do not consume Convex memory.
+ */
+export const saveSandboxGeneratedFile = action({
+  args: {
+    s3Key: v.string(),
+    name: v.string(),
+    mediaType: v.string(),
+    size: v.number(),
+    serviceKey: v.string(),
+    userId: v.string(),
+  },
+  returns: v.object({
+    url: v.string(),
+    fileId: v.id("files"),
+    tokens: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    await checkFileUploadRateLimit(args.userId, false);
+
+    const cleanupUploadedObject = async (stage: string) => {
+      try {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.s3Cleanup.deleteS3ObjectAction,
+          {
+            s3Key: args.s3Key,
+          },
+        );
+      } catch (deleteError) {
+        convexLogger.warn("file_upload_storage_cleanup_failed", {
+          userId: args.userId,
+          fileName: args.name,
+          stage,
+          s3Key: args.s3Key,
+          error:
+            deleteError instanceof Error
+              ? { name: deleteError.name, message: deleteError.message }
+              : String(deleteError),
+        });
+      }
+    };
+
+    if (args.size > MAX_GENERATED_FILE_SIZE_BYTES) {
+      convexLogger.warn("sandbox_generated_file_too_large", {
+        event: "sandbox_generated_file_too_large",
+        service: "convex-file-actions",
+        user_id: args.userId,
+        file_name: args.name,
+        media_type: args.mediaType,
+        size_bytes: args.size,
+        limit_bytes: MAX_GENERATED_FILE_SIZE_BYTES,
+      });
+      await cleanupUploadedObject("oversized_generated_artifact");
+      throw new ConvexError({
+        code: "GENERATED_FILE_SIZE_EXCEEDED",
+        message: `File "${args.name}" exceeds the maximum generated file size limit of ${MAX_GENERATED_FILE_SIZE_BYTES / (1024 * 1024)} MB. Current size: ${(args.size / (1024 * 1024)).toFixed(2)} MB`,
+      });
+    }
+
+    try {
+      const fileId = (await ctx.runMutation(internal.fileStorage.saveFileToDb, {
+        s3Key: args.s3Key,
+        userId: args.userId,
+        name: args.name,
+        mediaType: args.mediaType,
+        size: args.size,
+        fileTokenSize: 0,
+      })) as Id<"files">;
+
+      return {
+        url: await generateS3DownloadUrl(args.s3Key),
+        fileId,
+        tokens: 0,
+      };
+    } catch (error) {
+      convexLogger.error("sandbox_generated_file_metadata_save_failed", {
+        event: "sandbox_generated_file_metadata_save_failed",
+        service: "convex-file-actions",
+        user_id: args.userId,
+        file_name: args.name,
+        media_type: args.mediaType,
+        size_bytes: args.size,
+        error:
+          error instanceof Error
+            ? { name: error.name, message: error.message }
+            : String(error),
+      });
+      await cleanupUploadedObject("generated_artifact_save_failed");
+
+      if (error instanceof ConvexError) {
+        throw error;
+      }
+      throw new ConvexError({
+        code: "GENERATED_FILE_SAVE_FAILED",
+        message: `Failed to save generated file ${args.name}: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`,
+      });
+    }
   },
 });

--- a/lib/ai/tools/get-terminal-files.ts
+++ b/lib/ai/tools/get-terminal-files.ts
@@ -13,6 +13,7 @@ Usage:
 - Use this tool when the user requests files or needs to download results from the sandbox
 - Provide full file paths (e.g., /home/user/output.txt, /home/user/scan-results.xml)
 - Files are automatically uploaded and made available for download
+- Files larger than 250 MB cannot be shared; reduce, split, or exclude bulky generated/dependency directories before sharing
 - Use this after generating reports, saving scan results, or creating any files the user needs to access
 - Multiple files can be shared in a single call`,
     inputSchema: z.object({
@@ -81,7 +82,6 @@ Usage:
                 sandbox,
                 userId: context.userID,
                 fullPath: filePath,
-                skipTokenValidation: true, // Skip token limits for assistant-generated files
               });
 
               context.fileAccumulator.add({

--- a/lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts
@@ -161,6 +161,28 @@ describe("uploadSandboxFileToConvex", () => {
     });
   });
 
+  test("derives the file name from Windows-style paths", async () => {
+    const sandbox = makeSandbox(1234);
+
+    await uploadSandboxFileToConvex({
+      sandbox: sandbox as any,
+      userId: "u1",
+      fullPath: "C:\\Users\\user\\report.txt",
+    });
+
+    expect(mockGenerateS3UploadUrl).toHaveBeenCalledWith(
+      "report.txt",
+      "application/octet-stream",
+      "u1",
+    );
+    expect(mockConvexAction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        name: "report.txt",
+      }),
+    );
+  });
+
   test("uploads allowed E2B files from the sandbox without downloading into memory", async () => {
     const sandbox = makeSandbox(4321, true);
 

--- a/lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts
@@ -1,0 +1,190 @@
+jest.mock("server-only", () => ({}), { virtual: true });
+
+jest.mock("@/convex/s3Utils", () => ({
+  generateS3UploadUrl: jest.fn(),
+}));
+
+jest.mock("@/lib/db/convex-client", () => ({
+  getConvexClient: jest.fn(),
+}));
+
+import { generateS3UploadUrl } from "@/convex/s3Utils";
+import { getConvexClient } from "@/lib/db/convex-client";
+import {
+  MAX_FILE_SIZE_BYTES,
+  MAX_GENERATED_FILE_SIZE_BYTES,
+} from "@/lib/constants/s3";
+import { uploadSandboxFileToConvex } from "../sandbox-file-uploader";
+
+const mockGenerateS3UploadUrl = generateS3UploadUrl as jest.MockedFunction<
+  typeof generateS3UploadUrl
+>;
+const mockGetConvexClient = getConvexClient as jest.MockedFunction<
+  typeof getConvexClient
+>;
+let mockConvexAction: jest.Mock;
+let consoleWarnSpy: jest.SpyInstance;
+let consoleErrorSpy: jest.SpyInstance;
+
+function makeSandbox(size: number, e2b = false) {
+  return {
+    ...(e2b ? {} : { sandboxKind: "centrifugo" as const }),
+    commands: {
+      run: jest.fn(async (command: string) => {
+        if (command.startsWith("stat ")) {
+          return { stdout: String(size), stderr: "", exitCode: 0 };
+        }
+        if (command.includes("curl -fsSL -X PUT")) {
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }
+        return { stdout: "", stderr: "unexpected command", exitCode: 1 };
+      }),
+    },
+    files: {
+      uploadToUrl: jest.fn(async () => undefined),
+    },
+    downloadUrl: jest.fn(async () => "https://sandbox.example/file"),
+  };
+}
+
+describe("uploadSandboxFileToConvex", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    process.env.NEXT_PUBLIC_CONVEX_URL = "https://convex.example";
+    process.env.CONVEX_SERVICE_ROLE_KEY = "service-key";
+    mockGenerateS3UploadUrl.mockResolvedValue({
+      uploadUrl: "https://s3.example/upload",
+      s3Key: "users/u1/file.txt",
+    });
+    mockConvexAction = jest.fn(async () => ({
+      url: "https://s3.example/download",
+      fileId: "file_123",
+      tokens: 0,
+    }));
+    mockGetConvexClient.mockReturnValue({
+      action: mockConvexAction,
+    } as any);
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("rejects oversized Centrifugo files before uploading to S3", async () => {
+    const sandbox = makeSandbox(MAX_GENERATED_FILE_SIZE_BYTES + 1);
+
+    await expect(
+      uploadSandboxFileToConvex({
+        sandbox: sandbox as any,
+        userId: "u1",
+        fullPath: "/home/user/large.tar.gz",
+      }),
+    ).rejects.toThrow(/exceeds the maximum generated file size limit/);
+
+    expect(sandbox.files.uploadToUrl).not.toHaveBeenCalled();
+    expect(mockGenerateS3UploadUrl).not.toHaveBeenCalled();
+    expect(mockGetConvexClient).not.toHaveBeenCalled();
+    expect(mockConvexAction).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"event":"sandbox_generated_file_too_large"'),
+    );
+  });
+
+  test("rejects oversized E2B files before uploading to S3", async () => {
+    const sandbox = makeSandbox(MAX_GENERATED_FILE_SIZE_BYTES + 1, true);
+
+    await expect(
+      uploadSandboxFileToConvex({
+        sandbox: sandbox as any,
+        userId: "u1",
+        fullPath: "/home/user/large.tar.gz",
+      }),
+    ).rejects.toThrow(/exceeds the maximum generated file size limit/);
+
+    expect(sandbox.commands.run).toHaveBeenCalledTimes(1);
+    expect(sandbox.downloadUrl).not.toHaveBeenCalled();
+    expect(mockGenerateS3UploadUrl).not.toHaveBeenCalled();
+    expect(mockGetConvexClient).not.toHaveBeenCalled();
+  });
+
+  test("allows generated artifacts above the user upload limit", async () => {
+    const sandbox = makeSandbox(MAX_FILE_SIZE_BYTES + 1);
+
+    await uploadSandboxFileToConvex({
+      sandbox: sandbox as any,
+      userId: "u1",
+      fullPath: "/home/user/archive.tar.gz",
+    });
+
+    expect(sandbox.files.uploadToUrl).toHaveBeenCalled();
+    expect(mockConvexAction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        name: "archive.tar.gz",
+        size: MAX_FILE_SIZE_BYTES + 1,
+      }),
+    );
+  });
+
+  test("uploads allowed Centrifugo files using the preflight size", async () => {
+    const sandbox = makeSandbox(1234);
+
+    const saved = await uploadSandboxFileToConvex({
+      sandbox: sandbox as any,
+      userId: "u1",
+      fullPath: "/home/user/report.txt",
+    });
+
+    expect(sandbox.files.uploadToUrl).toHaveBeenCalledWith(
+      "/home/user/report.txt",
+      "https://s3.example/upload",
+      "application/octet-stream",
+    );
+    expect(mockConvexAction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        name: "report.txt",
+        size: 1234,
+        s3Key: "users/u1/file.txt",
+      }),
+    );
+    expect(saved).toMatchObject({
+      name: "report.txt",
+      s3Key: "users/u1/file.txt",
+    });
+  });
+
+  test("uploads allowed E2B files from the sandbox without downloading into memory", async () => {
+    const sandbox = makeSandbox(4321, true);
+
+    await uploadSandboxFileToConvex({
+      sandbox: sandbox as any,
+      userId: "u1",
+      fullPath: "/home/user/archive.tar.gz",
+    });
+
+    expect(sandbox.downloadUrl).not.toHaveBeenCalled();
+    expect(sandbox.files.uploadToUrl).not.toHaveBeenCalled();
+    expect(sandbox.commands.run).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("curl -fsSL -X PUT"),
+      expect.objectContaining({
+        envVars: { UPLOAD_URL: "https://s3.example/upload" },
+      }),
+    );
+    expect(mockConvexAction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        name: "archive.tar.gz",
+        size: 4321,
+      }),
+    );
+  });
+});

--- a/lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts
@@ -196,11 +196,16 @@ describe("uploadSandboxFileToConvex", () => {
     expect(sandbox.files.uploadToUrl).not.toHaveBeenCalled();
     expect(sandbox.commands.run).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining("curl -fsSL -X PUT"),
+      expect.stringContaining(
+        "curl -fsSL -X PUT -H 'Content-Type: application/octet-stream'",
+      ),
       expect.objectContaining({
-        envVars: { UPLOAD_URL: "https://s3.example/upload" },
+        timeoutMs: expect.any(Number),
       }),
     );
+    const uploadCommand = (sandbox.commands.run as jest.Mock).mock.calls[1][0];
+    expect(uploadCommand).toContain("'https://s3.example/upload'");
+    expect(uploadCommand).not.toContain("UPLOAD_URL");
     expect(mockConvexAction).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/lib/ai/tools/utils/sandbox-file-uploader.ts
+++ b/lib/ai/tools/utils/sandbox-file-uploader.ts
@@ -100,6 +100,10 @@ function errorToLog(error: unknown) {
   return { message: String(error) };
 }
 
+function getFileNameFromPath(fullPath: string): string {
+  return fullPath.split(/[/\\]/).pop() || "file";
+}
+
 async function uploadGeneratedFileFromSandboxToUrl(args: {
   sandbox: AnySandbox;
   fullPath: string;
@@ -172,7 +176,7 @@ export async function uploadSandboxFileToConvex(args: {
 
   const { sandbox, userId, fullPath } = args;
   const mediaType = DEFAULT_MEDIA_TYPE;
-  const name = fullPath.split("/").pop() || "file";
+  const name = getFileNameFromPath(fullPath);
   const fileSize = await getSandboxFileSize(sandbox, fullPath);
   if (fileSize > MAX_GENERATED_FILE_SIZE_BYTES) {
     logger.warn("sandbox_generated_file_too_large", {

--- a/lib/ai/tools/utils/sandbox-file-uploader.ts
+++ b/lib/ai/tools/utils/sandbox-file-uploader.ts
@@ -7,8 +7,13 @@ import type { AnySandbox } from "@/types";
 import { isE2BSandbox } from "./sandbox-types";
 import { generateS3UploadUrl } from "@/convex/s3Utils";
 import { getConvexClient } from "@/lib/db/convex-client";
+import { MAX_GENERATED_FILE_SIZE_BYTES } from "@/lib/constants/s3";
+import { logger } from "@/lib/logger";
 
 const DEFAULT_MEDIA_TYPE = "application/octet-stream";
+const MAX_GENERATED_FILE_SIZE_MB =
+  MAX_GENERATED_FILE_SIZE_BYTES / (1024 * 1024);
+const SANDBOX_UPLOAD_TIMEOUT_MS = 5 * 60 * 1000;
 
 export type UploadedFileInfo = {
   url: string;
@@ -36,11 +41,121 @@ function extractErrorMessage(error: unknown): string {
   return "An unexpected error occurred";
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+async function getSandboxFileSize(
+  sandbox: AnySandbox,
+  fullPath: string,
+): Promise<number> {
+  const quotedPath = shellQuote(fullPath);
+  const statResult = await sandbox.commands.run(
+    `stat -c%s ${quotedPath} 2>/dev/null || stat -f%z ${quotedPath} 2>/dev/null`,
+    { displayName: "" } as { displayName?: string },
+  );
+
+  let fileSize = parseInt(statResult.stdout.trim(), 10);
+  if (!isNaN(fileSize) && statResult.exitCode === 0) {
+    return fileSize;
+  }
+
+  // Windows cmd.exe fallback: %~zI expands to the file size.
+  const escapedForCmd = fullPath.replace(/"/g, '\\"');
+  const winResult = await sandbox.commands.run(
+    `for %I in ("${escapedForCmd}") do @echo %~zI`,
+    { displayName: "" } as { displayName?: string },
+  );
+  fileSize = parseInt(winResult.stdout.trim(), 10);
+  if (!isNaN(fileSize) && winResult.exitCode === 0) {
+    return fileSize;
+  }
+
+  throw new Error(
+    `Failed to get file size for ${fullPath}: ${
+      statResult.stderr || winResult.stderr || "stat command failed"
+    }`,
+  );
+}
+
+function assertSandboxFileSizeAllowed(fileName: string, size: number): void {
+  if (size <= MAX_GENERATED_FILE_SIZE_BYTES) return;
+
+  throw new Error(
+    `File "${fileName}" exceeds the maximum generated file size limit of ${MAX_GENERATED_FILE_SIZE_MB} MB. Current size: ${(size / (1024 * 1024)).toFixed(2)} MB`,
+  );
+}
+
+function getSandboxLogType(sandbox: AnySandbox): "e2b" | "centrifugo" {
+  return isE2BSandbox(sandbox) ? "e2b" : "centrifugo";
+}
+
+function errorToLog(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+    };
+  }
+  return { message: String(error) };
+}
+
+async function uploadGeneratedFileFromSandboxToUrl(args: {
+  sandbox: AnySandbox;
+  fullPath: string;
+  uploadUrl: string;
+  mediaType: string;
+}): Promise<void> {
+  const { sandbox, fullPath, uploadUrl, mediaType } = args;
+
+  if (!isE2BSandbox(sandbox) && sandbox.files?.uploadToUrl) {
+    await sandbox.files.uploadToUrl(fullPath, uploadUrl, mediaType);
+    return;
+  }
+
+  let result: Awaited<ReturnType<typeof sandbox.commands.run>>;
+  try {
+    result = await sandbox.commands.run(
+      `curl -fsSL -X PUT -H "Content-Type: ${mediaType.replace(/"/g, '\\"')}" --data-binary @${shellQuote(fullPath)} "$UPLOAD_URL"`,
+      {
+        timeoutMs: SANDBOX_UPLOAD_TIMEOUT_MS,
+        envVars: { UPLOAD_URL: uploadUrl },
+      } as { timeoutMs?: number; envVars?: Record<string, string> },
+    );
+  } catch (error) {
+    logger.error(
+      "sandbox_generated_file_upload_failed",
+      error instanceof Error ? error : undefined,
+      {
+        event: "sandbox_generated_file_upload_failed",
+        service: "chat-handler",
+        sandbox_type: getSandboxLogType(sandbox),
+        media_type: mediaType,
+        error: errorToLog(error),
+      },
+    );
+    throw error;
+  }
+
+  if (result.exitCode !== 0) {
+    logger.error("sandbox_generated_file_upload_failed", undefined, {
+      event: "sandbox_generated_file_upload_failed",
+      service: "chat-handler",
+      sandbox_type: getSandboxLogType(sandbox),
+      media_type: mediaType,
+      exit_code: result.exitCode,
+      stderr: result.stderr?.slice(0, 500),
+    });
+    throw new Error(
+      `Failed to upload file ${fullPath}: ${result.stderr || result.stdout || "upload command failed"}`,
+    );
+  }
+}
+
 export async function uploadSandboxFileToConvex(args: {
   sandbox: AnySandbox;
   userId: string;
   fullPath: string;
-  skipTokenValidation?: boolean;
 }): Promise<UploadedFileInfo> {
   if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
     throw new Error(
@@ -56,116 +171,49 @@ export async function uploadSandboxFileToConvex(args: {
   }
 
   const { sandbox, userId, fullPath } = args;
-  const convex = getConvexClient();
-
   const mediaType = DEFAULT_MEDIA_TYPE;
   const name = fullPath.split("/").pop() || "file";
-
-  // For CentrifugoSandbox, always upload directly from sandbox to S3
-  // This avoids data corruption and size limits when piping through Convex commands
-  if (!isE2BSandbox(sandbox) && sandbox.files?.uploadToUrl) {
-    const { uploadUrl, s3Key } = await generateS3UploadUrl(
-      name,
-      mediaType,
-      userId,
-    );
-
-    // Upload directly from sandbox to S3
-    await sandbox.files.uploadToUrl(fullPath, uploadUrl, mediaType);
-
-    // Get file size — try POSIX stat first, then Windows cmd.exe fallback
-    // Linux: stat -c%s, macOS: stat -f%z, Windows: for %~z
-    const statResult = await sandbox.commands.run(
-      `stat -c%s "${fullPath}" 2>/dev/null || stat -f%z "${fullPath}" 2>/dev/null`,
-      { displayName: "" } as { displayName?: string },
-    );
-    let fileSize = parseInt(statResult.stdout.trim(), 10);
-    if (isNaN(fileSize) || statResult.exitCode !== 0) {
-      // Windows cmd.exe fallback: %~zI expands to the file size
-      const winResult = await sandbox.commands.run(
-        `for %I in ("${fullPath}") do @echo %~zI`,
-        { displayName: "" } as { displayName?: string },
-      );
-      fileSize = parseInt(winResult.stdout.trim(), 10);
-      if (isNaN(fileSize) || winResult.exitCode !== 0) {
-        throw new Error(
-          `Failed to get file size for ${fullPath}: ${statResult.stderr || winResult.stderr || "stat command failed"}`,
-        );
-      }
-    }
-
-    try {
-      const saved = await convex.action(api.fileActions.saveFile, {
-        s3Key,
-        name,
-        mediaType,
-        size: fileSize,
-        serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
-        userId,
-        skipTokenValidation: args.skipTokenValidation,
-      });
-
-      return {
-        ...saved,
-        name,
-        mediaType,
-        s3Key,
-      } as UploadedFileInfo;
-    } catch (error) {
-      throw new Error(extractErrorMessage(error));
-    }
-  }
-
-  // E2B Sandbox: use downloadUrl to fetch file, then upload to storage
-  let blob: Blob;
-
-  if (isE2BSandbox(sandbox)) {
-    const downloadUrl = await sandbox.downloadUrl(fullPath, {
-      useSignatureExpiration: 30_000, // 30 seconds
+  const fileSize = await getSandboxFileSize(sandbox, fullPath);
+  if (fileSize > MAX_GENERATED_FILE_SIZE_BYTES) {
+    logger.warn("sandbox_generated_file_too_large", {
+      event: "sandbox_generated_file_too_large",
+      service: "chat-handler",
+      user_id: userId,
+      file_name: name,
+      media_type: mediaType,
+      size_bytes: fileSize,
+      limit_bytes: MAX_GENERATED_FILE_SIZE_BYTES,
+      sandbox_type: getSandboxLogType(sandbox),
     });
-
-    const fileRes = await fetch(downloadUrl);
-    if (!fileRes.ok) {
-      throw new Error(
-        `Failed to download ${fullPath}: ${fileRes.status} ${fileRes.statusText}`,
-      );
-    }
-
-    blob = await fileRes.blob();
-  } else {
-    // Fallback for unknown sandbox types
-    throw new Error("Unsupported sandbox type for file upload");
   }
+  assertSandboxFileSizeAllowed(name, fileSize);
+  const convex = getConvexClient();
 
-  // S3 upload path
   const { uploadUrl, s3Key } = await generateS3UploadUrl(
     name,
     mediaType,
     userId,
   );
 
-  const uploadRes = await fetch(uploadUrl, {
-    method: "PUT",
-    headers: { "Content-Type": mediaType },
-    body: blob,
+  await uploadGeneratedFileFromSandboxToUrl({
+    sandbox,
+    fullPath,
+    uploadUrl,
+    mediaType,
   });
 
-  if (!uploadRes.ok) {
-    throw new Error(
-      `S3 upload failed for ${fullPath}: ${uploadRes.status} ${uploadRes.statusText}`,
-    );
-  }
-
   try {
-    const saved = await convex.action(api.fileActions.saveFile, {
-      s3Key,
-      name,
-      mediaType,
-      size: blob.size,
-      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
-      userId,
-      skipTokenValidation: args.skipTokenValidation,
-    });
+    const saved = await convex.action(
+      api.fileActions.saveSandboxGeneratedFile,
+      {
+        s3Key,
+        name,
+        mediaType,
+        size: fileSize,
+        serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+        userId,
+      },
+    );
 
     return {
       ...saved,
@@ -174,6 +222,20 @@ export async function uploadSandboxFileToConvex(args: {
       s3Key,
     } as UploadedFileInfo;
   } catch (error) {
+    logger.error(
+      "sandbox_generated_file_metadata_save_failed",
+      error instanceof Error ? error : undefined,
+      {
+        event: "sandbox_generated_file_metadata_save_failed",
+        service: "chat-handler",
+        user_id: userId,
+        file_name: name,
+        media_type: mediaType,
+        size_bytes: fileSize,
+        sandbox_type: getSandboxLogType(sandbox),
+        error: errorToLog(error),
+      },
+    );
     // Re-throw with properly extracted error message
     throw new Error(extractErrorMessage(error));
   }

--- a/lib/ai/tools/utils/sandbox-file-uploader.ts
+++ b/lib/ai/tools/utils/sandbox-file-uploader.ts
@@ -92,9 +92,23 @@ function getSandboxLogType(sandbox: AnySandbox): "e2b" | "centrifugo" {
 
 function errorToLog(error: unknown) {
   if (error instanceof Error) {
+    const commandError = error as Error & {
+      exitCode?: unknown;
+      stdout?: unknown;
+      stderr?: unknown;
+    };
     return {
       name: error.name,
       message: error.message,
+      ...(typeof commandError.exitCode === "number"
+        ? { exit_code: commandError.exitCode }
+        : {}),
+      ...(typeof commandError.stderr === "string" && commandError.stderr
+        ? { stderr: commandError.stderr.slice(0, 500) }
+        : {}),
+      ...(typeof commandError.stdout === "string" && commandError.stdout
+        ? { stdout: commandError.stdout.slice(0, 500) }
+        : {}),
     };
   }
   return { message: String(error) };
@@ -120,11 +134,10 @@ async function uploadGeneratedFileFromSandboxToUrl(args: {
   let result: Awaited<ReturnType<typeof sandbox.commands.run>>;
   try {
     result = await sandbox.commands.run(
-      `curl -fsSL -X PUT -H "Content-Type: ${mediaType.replace(/"/g, '\\"')}" --data-binary @${shellQuote(fullPath)} "$UPLOAD_URL"`,
+      `curl -fsSL -X PUT -H ${shellQuote(`Content-Type: ${mediaType}`)} --data-binary @${shellQuote(fullPath)} ${shellQuote(uploadUrl)}`,
       {
         timeoutMs: SANDBOX_UPLOAD_TIMEOUT_MS,
-        envVars: { UPLOAD_URL: uploadUrl },
-      } as { timeoutMs?: number; envVars?: Record<string, string> },
+      } as { timeoutMs?: number },
     );
   } catch (error) {
     logger.error(

--- a/lib/constants/s3.ts
+++ b/lib/constants/s3.ts
@@ -19,5 +19,8 @@ export const getS3UrlExpirationBufferSeconds = (): number => {
 // Maximum file size (20 MB)
 export const MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024;
 
+// Maximum assistant-generated downloadable artifact size (250 MB)
+export const MAX_GENERATED_FILE_SIZE_BYTES = 250 * 1024 * 1024;
+
 // S3 key prefix for user files
 export const S3_USER_FILES_PREFIX = "users";


### PR DESCRIPTION
## Summary

Fixes an OOM-prone generated file sharing path used by `get_terminal_files`, especially in Trigger.dev agent runs when users request large generated artifacts such as project archives.

## What Changed

- Added a separate 250 MB limit for assistant-generated downloadable artifacts while preserving the existing 20 MB limit for user-uploaded files.
- Preflights sandbox file size with `stat` before upload work begins.
- Uploads generated files from the sandbox directly to S3 instead of downloading them into app memory.
- Adds a Convex metadata-only save action for generated artifacts so Convex does not fetch or parse large blobs.
- Adds structured logs for oversized generated artifacts, sandbox upload failures, and metadata save failures.
- Adds regression tests covering oversized files, generated files above the normal upload limit, Centrifugo upload, and E2B upload without `downloadUrl()`.

## Root Cause

The old E2B path downloaded sandbox files into a server-side `Blob`, then Convex fetched and processed the file again through the normal upload action. Large generated archives could multiply memory usage and terminate Trigger.dev runs with `Run was terminated due to running out of memory`.

## Validation

- `pnpm test -- lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts --runInBand`
- `pnpm typecheck`
- Commit hook ran full Jest suite: 76 suites / 1047 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assistant-generated files can be uploaded directly from sandboxes, saved, and downloaded via a returned URL.

* **Bug Fixes**
  * Enforced a 250 MB size limit for generated artifacts and added best-effort cleanup on oversize.
  * Token validation is now required for assistant-generated uploads; improved sandbox-side upload flow and Windows path handling.

* **Tests**
  * Expanded tests covering upload flows, size gating, path handling, and error paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->