### PR TITLE
[codex] fix reasoning overflow

### DIFF
--- a/__mocks__/react-shiki.tsx
+++ b/__mocks__/react-shiki.tsx
@@ -5,4 +5,6 @@ export const ShikiCode = ({ children }: { children?: React.ReactNode }) => {
   return <code data-testid="shiki-code">{children}</code>;
 };
 
+export const isInlineCode = () => false;
+
 export default ShikiCode;

--- a/app/components/CodeHighlight.tsx
+++ b/app/components/CodeHighlight.tsx
@@ -103,7 +103,7 @@ const CodeHighlightImpl = ({
     </div>
   ) : (
     <code
-      className="bg-muted text-muted-foreground px-1.5 py-0.5 rounded text-sm font-mono"
+      className="bg-muted text-muted-foreground px-1.5 py-0.5 rounded text-sm font-mono whitespace-pre-wrap break-words [overflow-wrap:anywhere]"
       {...props}
     >
       {children}

--- a/app/components/__tests__/CodeHighlight.test.tsx
+++ b/app/components/__tests__/CodeHighlight.test.tsx
@@ -1,0 +1,28 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { CodeHighlight } from "../CodeHighlight";
+
+jest.mock("react-shiki", () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) => {
+    const React = require("react");
+    return React.createElement("div", null, children);
+  },
+  isInlineCode: () => true,
+}));
+
+describe("CodeHighlight", () => {
+  it("wraps long inline code tokens instead of forcing horizontal scrolling", () => {
+    render(
+      <CodeHighlight node={{ type: "element", tagName: "code" } as any}>
+        53‡‡†305))6*;4826)4‡.)4‡);806*;48†8¶60))85
+      </CodeHighlight>,
+    );
+
+    const code = screen.getByText(/53‡‡†305/);
+
+    expect(code).toHaveClass("whitespace-pre-wrap");
+    expect(code).toHaveClass("break-words");
+    expect(code).toHaveClass("[overflow-wrap:anywhere]");
+  });
+});

--- a/components/ai-elements/__tests__/reasoning.test.tsx
+++ b/components/ai-elements/__tests__/reasoning.test.tsx
@@ -1,0 +1,25 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { Reasoning, ReasoningContent, ReasoningTrigger } from "../reasoning";
+
+describe("Reasoning", () => {
+  it("prevents long formatted reasoning text from creating page-width overflow", () => {
+    render(
+      <Reasoning open>
+        <ReasoningTrigger />
+        <ReasoningContent>
+          <p>
+            So using that, we can reverse-engineer:{" "}
+            <code>53‡‡†305))6*;4826)4‡.)4‡);806*;48†8¶60))85</code>
+          </p>
+        </ReasoningContent>
+      </Reasoning>,
+    );
+
+    const content = screen.getByText(/So using that/).closest("[data-state]");
+
+    expect(content).toHaveClass("overflow-x-hidden");
+    expect(content).toHaveClass("break-words");
+    expect(content).toHaveClass("[overflow-wrap:anywhere]");
+  });
+});

--- a/components/ai-elements/reasoning.tsx
+++ b/components/ai-elements/reasoning.tsx
@@ -60,7 +60,10 @@ export function Reasoning({
       <Collapsible
         open={isOpen}
         onOpenChange={setIsOpen}
-        className={cn("not-prose w-full space-y-2", className)}
+        className={cn(
+          "not-prose w-full min-w-0 max-w-full space-y-2",
+          className,
+        )}
         {...props}
       >
         {children}
@@ -133,7 +136,9 @@ export function ReasoningContent({
     <CollapsibleContent
       ref={contentRef}
       className={cn(
-        "mt-2 space-y-3 text-muted-foreground max-h-60 overflow-y-auto",
+        "mt-2 space-y-3 text-muted-foreground max-h-60 min-w-0 max-w-full overflow-x-hidden overflow-y-auto break-words",
+        "[overflow-wrap:anywhere]",
+        "[&_pre]:max-w-full [&_pre]:overflow-x-auto",
         "data-[state=closed]:animate-out data-[state=open]:animate-in",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         "data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2",


### PR DESCRIPTION
## Summary

Fixes horizontal page overflow when reasoning blocks contain long formatted inline text, such as cipher strings rendered as inline markdown code.

## Root Cause

Reasoning content only constrained vertical overflow. Long unbroken inline code tokens could remain unbreakable, forcing the reasoning block and chat viewport wider than the mobile screen.

## Changes

- Constrain reasoning blocks with `min-w-0`, `max-w-full`, and hidden horizontal overflow.
- Allow reasoning text to emergency-wrap with `overflow-wrap:anywhere`.
- Allow inline code tokens to wrap while preserving fenced code block horizontal scrolling.
- Add regression tests for reasoning overflow and inline code wrapping.

## Validation

- `pnpm jest components/ai-elements/__tests__/reasoning.test.tsx app/components/__tests__/CodeHighlight.test.tsx --runInBand`
- `pnpm exec eslint components/ai-elements/reasoning.tsx components/ai-elements/__tests__/reasoning.test.tsx app/components/CodeHighlight.tsx app/components/__tests__/CodeHighlight.test.tsx __mocks__/react-shiki.tsx`
- `pnpm tsc --noEmit --pretty false`
- Pre-commit hook: `tsc --noEmit` and full `jest` suite, 78 suites / 1050 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced inline code rendering with improved text wrapping and overflow handling to maintain proper layouts.
  * Improved reasoning components with better text wrapping, word breaking, and horizontal scroll management for long content.

* **Tests**
  * Added test coverage for inline code wrapping behavior.
  * Added test coverage for reasoning component overflow handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->