### PR TITLE
[codex] Add DB persistence diagnostics

### DIFF
--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -18,6 +18,56 @@ const extractTextFromParts = (parts: any[]): string => {
     .trim();
 };
 
+const getJsonSize = (value: unknown): number => {
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return 0;
+  }
+};
+
+const getMessageSaveDiagnostics = (parts: any[]) => {
+  const partTypes: Record<string, number> = {};
+  let largestPartType = "unknown";
+  let largestPartSize = 0;
+  let textChars = 0;
+  let reasoningChars = 0;
+  let toolPartCount = 0;
+  let dataPartCount = 0;
+
+  for (const part of parts) {
+    const type = typeof part?.type === "string" ? part.type : "unknown";
+    partTypes[type] = (partTypes[type] ?? 0) + 1;
+
+    const partSize = getJsonSize(part);
+    if (partSize > largestPartSize) {
+      largestPartType = type;
+      largestPartSize = partSize;
+    }
+
+    if (type === "text" && typeof part.text === "string") {
+      textChars += part.text.length;
+    }
+    if (type === "reasoning" && typeof part.text === "string") {
+      reasoningChars += part.text.length;
+    }
+    if (type.startsWith("tool-") || type === "dynamic-tool") toolPartCount++;
+    if (type.startsWith("data-")) dataPartCount++;
+  }
+
+  return {
+    part_count: parts.length,
+    parts_json_chars: getJsonSize(parts),
+    part_types: partTypes,
+    largest_part_type: largestPartType,
+    largest_part_json_chars: largestPartSize,
+    text_chars: textChars,
+    reasoning_chars: reasoningChars,
+    tool_part_count: toolPartCount,
+    data_part_count: dataPartCount,
+  };
+};
+
 /**
  * Helper function to check if deleted messages invalidate the chat summary
  * Clears latest_summary_id if the summary's cutoff message was deleted
@@ -342,7 +392,28 @@ export const saveMessage = mutation({
 
       return null;
     } catch (error) {
-      console.error("Failed to save message:", error);
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "convex_message_save_failed",
+          service: "convex",
+          timestamp: new Date().toISOString(),
+          db_operation: "messages.saveMessage",
+          chat_id: args.chatId,
+          user_id: args.userId,
+          message_id: args.id,
+          message_role: args.role,
+          mode: args.mode,
+          model: args.model,
+          finish_reason: args.finishReason,
+          update_only: args.updateOnly === true,
+          hidden: args.isHidden === true,
+          file_count: args.fileIds?.length ?? 0,
+          error_name: error instanceof Error ? error.name : typeof error,
+          error_message: error instanceof Error ? error.message : String(error),
+          ...getMessageSaveDiagnostics(args.parts),
+        }),
+      );
       throw new Error("Failed to save message");
     }
   },

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -93,6 +93,9 @@ function posthogProviderException(
   return new Error(message);
 }
 
+const truncateLogString = (value: string, maxLength = 500): string =>
+  value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+
 /**
  * Creates a chat logger instance for tracking wide events
  */
@@ -338,12 +341,19 @@ export function createChatLogger(config: ChatLoggerConfig) {
      * Finalize and emit error event for ChatSDKError
      */
     emitChatError(error: ChatSDKError) {
+      const cause =
+        typeof error.cause === "string"
+          ? truncateLogString(error.cause)
+          : undefined;
+
       builder.setError({
         type: "ChatSDKError",
         code: `${error.type}:${error.surface}`,
         message: error.message,
+        cause,
         statusCode: error.statusCode,
         retriable: error.type === "rate_limit",
+        metadata: error.metadata,
       });
       logger.info(builder.build());
 

--- a/lib/db/__tests__/message-persistence-diagnostics.test.ts
+++ b/lib/db/__tests__/message-persistence-diagnostics.test.ts
@@ -31,5 +31,6 @@ describe("getMessagePersistenceDiagnostics", () => {
     expect(serialized).not.toContain("hello secret text");
     expect(serialized).not.toContain("private chain");
     expect(serialized).not.toContain("secret output");
+    expect(serialized).not.toContain("secret stream");
   });
 });

--- a/lib/db/__tests__/message-persistence-diagnostics.test.ts
+++ b/lib/db/__tests__/message-persistence-diagnostics.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "@jest/globals";
+import { getMessagePersistenceDiagnostics } from "../message-persistence-diagnostics";
+
+describe("getMessagePersistenceDiagnostics", () => {
+  it("summarizes message parts without exposing part content", () => {
+    const diagnostics = getMessagePersistenceDiagnostics([
+      { type: "text", text: "hello secret text" } as any,
+      { type: "reasoning", text: "private chain" } as any,
+      {
+        type: "tool-run_terminal_cmd",
+        state: "output-available",
+        input: { command: "cat secret.txt" },
+        output: { result: { output: "secret output" } },
+      } as any,
+      { type: "data-terminal", data: { terminal: "secret stream" } } as any,
+    ]);
+
+    expect(diagnostics.part_count).toBe(4);
+    expect(diagnostics.part_types).toEqual({
+      text: 1,
+      reasoning: 1,
+      "tool-run_terminal_cmd": 1,
+      "data-terminal": 1,
+    });
+    expect(diagnostics.tool_part_count).toBe(1);
+    expect(diagnostics.data_part_count).toBe(1);
+    expect(diagnostics.text_chars).toBe("hello secret text".length);
+    expect(diagnostics.reasoning_chars).toBe("private chain".length);
+
+    const serialized = JSON.stringify(diagnostics);
+    expect(serialized).not.toContain("hello secret text");
+    expect(serialized).not.toContain("private chain");
+    expect(serialized).not.toContain("secret output");
+  });
+});

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -142,13 +142,15 @@ export async function saveMessage({
   updateOnly?: boolean;
   isHidden?: boolean;
 }) {
-  // Fix incomplete tool invocations for assistant messages (from interrupted streams)
-  const fixedParts =
-    message.role === "assistant"
-      ? fixIncompleteMessageParts(message.parts)
-      : message.parts;
+  let fixedParts = message.parts;
 
   try {
+    // Fix incomplete tool invocations for assistant messages (from interrupted streams)
+    fixedParts =
+      message.role === "assistant"
+        ? fixIncompleteMessageParts(message.parts)
+        : message.parts;
+
     // Extract file IDs from file parts
     const fileIds = extractFileIdsFromParts(fixedParts);
     const mergedFileIds = [

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -22,10 +22,58 @@ import { v4 as uuidv4 } from "uuid";
 import { AGENT_RESUME_PREAMBLE } from "@/lib/chat/summarization/prompts";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import type { ChatMode } from "@/types/chat";
+import { getMessagePersistenceDiagnostics } from "./message-persistence-diagnostics";
 
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
+const MAX_DATABASE_ERROR_MESSAGE_LENGTH = 500;
 
 export { setConvexUrl };
+
+const stringifyError = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+};
+
+const truncateDiagnosticString = (value: string): string =>
+  value.length > MAX_DATABASE_ERROR_MESSAGE_LENGTH
+    ? `${value.slice(0, MAX_DATABASE_ERROR_MESSAGE_LENGTH)}...`
+    : value;
+
+const databaseError = (
+  operation: string,
+  error: unknown,
+  metadata: Record<string, unknown> = {},
+) => {
+  const dbErrorName = error instanceof Error ? error.name : typeof error;
+  const dbErrorMessage = truncateDiagnosticString(stringifyError(error));
+  const diagnosticMetadata = {
+    db_operation: operation,
+    db_error_name: dbErrorName,
+    db_error_message: dbErrorMessage,
+    ...metadata,
+  };
+
+  console.error(
+    JSON.stringify({
+      level: "error",
+      event: "database_operation_failed",
+      service: "chat-handler",
+      timestamp: new Date().toISOString(),
+      ...diagnosticMetadata,
+    }),
+  );
+
+  return new ChatSDKError(
+    "bad_request:database",
+    `Database operation failed: ${operation}: ${dbErrorMessage}`,
+    diagnosticMetadata,
+  );
+};
 
 export async function getChatById({ id }: { id: string }) {
   try {
@@ -35,7 +83,7 @@ export async function getChatById({ id }: { id: string }) {
     });
     return selectedChat;
   } catch (error) {
-    throw new ChatSDKError("bad_request:database", "Failed to get chat by id");
+    throw databaseError("chats.getChatById", error, { chat_id: id });
   }
 }
 
@@ -56,7 +104,11 @@ export async function saveChat({
       title,
     });
   } catch (error) {
-    throw new ChatSDKError("bad_request:database", "Failed to save chat");
+    throw databaseError("chats.saveChat", error, {
+      chat_id: id,
+      user_id: userId,
+      title_length: title.length,
+    });
   }
 }
 export async function saveMessage({
@@ -90,13 +142,13 @@ export async function saveMessage({
   updateOnly?: boolean;
   isHidden?: boolean;
 }) {
-  try {
-    // Fix incomplete tool invocations for assistant messages (from interrupted streams)
-    const fixedParts =
-      message.role === "assistant"
-        ? fixIncompleteMessageParts(message.parts)
-        : message.parts;
+  // Fix incomplete tool invocations for assistant messages (from interrupted streams)
+  const fixedParts =
+    message.role === "assistant"
+      ? fixIncompleteMessageParts(message.parts)
+      : message.parts;
 
+  try {
     // Extract file IDs from file parts
     const fileIds = extractFileIdsFromParts(fixedParts);
     const mergedFileIds = [
@@ -122,7 +174,20 @@ export async function saveMessage({
       isHidden,
     });
   } catch (error) {
-    throw new ChatSDKError("bad_request:database", "Failed to save message");
+    throw databaseError("messages.saveMessage", error, {
+      chat_id: chatId,
+      user_id: userId,
+      message_id: message.id,
+      message_role: message.role,
+      mode,
+      model,
+      finish_reason: finishReason,
+      update_only: updateOnly === true,
+      hidden: isHidden === true,
+      extra_file_count: extraFileIds?.length ?? 0,
+      usage_keys: usage ? Object.keys(usage).sort() : undefined,
+      ...getMessagePersistenceDiagnostics(fixedParts),
+    });
   }
 }
 

--- a/lib/db/message-persistence-diagnostics.ts
+++ b/lib/db/message-persistence-diagnostics.ts
@@ -1,0 +1,75 @@
+import type { UIMessagePart } from "ai";
+
+const UNKNOWN_PART_TYPE = "unknown";
+
+const getByteLength = (value: unknown): number => {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), "utf-8");
+  } catch {
+    return 0;
+  }
+};
+
+const getPartType = (part: unknown): string => {
+  if (!part || typeof part !== "object") return UNKNOWN_PART_TYPE;
+  const type = (part as { type?: unknown }).type;
+  return typeof type === "string" && type.length > 0 ? type : UNKNOWN_PART_TYPE;
+};
+
+export function getMessagePersistenceDiagnostics(
+  parts: UIMessagePart<any, any>[],
+) {
+  const partTypes: Record<string, number> = {};
+  let largestPartType = UNKNOWN_PART_TYPE;
+  let largestPartSizeBytes = 0;
+  let textChars = 0;
+  let reasoningChars = 0;
+  let toolPartCount = 0;
+  let dataPartCount = 0;
+  let stepStartCount = 0;
+
+  for (const part of parts) {
+    const partType = getPartType(part);
+    partTypes[partType] = (partTypes[partType] ?? 0) + 1;
+
+    const partSizeBytes = getByteLength(part);
+    if (partSizeBytes > largestPartSizeBytes) {
+      largestPartType = partType;
+      largestPartSizeBytes = partSizeBytes;
+    }
+
+    if (partType === "text") {
+      const text = (part as { text?: unknown }).text;
+      if (typeof text === "string") textChars += text.length;
+    } else if (partType === "reasoning") {
+      const text = (part as { text?: unknown }).text;
+      if (typeof text === "string") reasoningChars += text.length;
+    } else if (partType === "step-start") {
+      stepStartCount++;
+    }
+
+    if (partType.startsWith("tool-") || partType === "dynamic-tool") {
+      toolPartCount++;
+    }
+    if (partType.startsWith("data-")) {
+      dataPartCount++;
+    }
+  }
+
+  const partsSizeBytes = getByteLength(parts);
+
+  return {
+    part_count: parts.length,
+    parts_size_bytes: partsSizeBytes,
+    parts_size_kb: Math.round(partsSizeBytes / 1024),
+    part_types: partTypes,
+    largest_part_type: largestPartType,
+    largest_part_size_bytes: largestPartSizeBytes,
+    largest_part_size_kb: Math.round(largestPartSizeBytes / 1024),
+    text_chars: textChars,
+    reasoning_chars: reasoningChars,
+    tool_part_count: toolPartCount,
+    data_part_count: dataPartCount,
+    step_start_count: stepStartCount,
+  };
+}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -164,7 +164,9 @@ export interface ChatWideEvent {
     type: string;
     code?: string;
     message: string;
+    cause?: string;
     retriable: boolean;
+    metadata?: Record<string, unknown>;
   };
 
   // True when the provider stream errored (e.g., AI_RetryError) but the
@@ -558,8 +560,10 @@ export class WideEventBuilder {
     type: string;
     code?: string;
     message: string;
+    cause?: string;
     statusCode: number;
     retriable?: boolean;
+    metadata?: Record<string, unknown>;
   }): this {
     this.event.outcome = "error";
     this.event.status_code = error.statusCode;
@@ -567,7 +571,9 @@ export class WideEventBuilder {
       type: error.type,
       code: error.code,
       message: error.message,
+      cause: error.cause,
       retriable: error.retriable ?? false,
+      metadata: error.metadata,
     };
     return this;
   }

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -110,11 +110,47 @@ const truncateForTriggerMetadata = (value: string) =>
 const sanitizeTriggerTagValue = (value: string) =>
   value.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 80);
 
+const getStringMetadata = (
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+) => {
+  const value = metadata?.[key];
+  return typeof value === "string" ? value : undefined;
+};
+
+const getNumberMetadata = (
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+) => {
+  const value = metadata?.[key];
+  return typeof value === "number" ? value : undefined;
+};
+
 const OPERATIONAL_RATE_LIMIT_CAUSE_PATTERNS = [
   /rate limiting service .*not configured/i,
   /rate limiting service unavailable/i,
   /extra usage billing is temporarily unavailable/i,
 ];
+
+type AgentLongErrorSummary = {
+  category: string;
+  code?: string;
+  name: string;
+  message: string;
+  cause?: string;
+  loginRequired: boolean;
+  statusCode?: number;
+  dbOperation?: string;
+  dbErrorName?: string;
+  dbErrorMessage?: string;
+  partsSizeKb?: number;
+  partCount?: number;
+  largestPartType?: string;
+  largestPartSizeKb?: number;
+  toolPartCount?: number;
+  dataPartCount?: number;
+  reasoningChars?: number;
+};
 
 const isHandledUserRateLimitError = (error: unknown): error is ChatSDKError => {
   if (!(error instanceof ChatSDKError)) return false;
@@ -126,7 +162,7 @@ const isHandledUserRateLimitError = (error: unknown): error is ChatSDKError => {
   );
 };
 
-const classifyAgentLongError = (error: unknown) => {
+const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
   const details = extractErrorDetails(error);
   const errorMessage = truncateForTriggerMetadata(
     typeof details.errorMessage === "string"
@@ -136,13 +172,32 @@ const classifyAgentLongError = (error: unknown) => {
 
   if (error instanceof ChatSDKError) {
     const code = `${error.type}:${error.surface}`;
+    const cause =
+      typeof error.cause === "string"
+        ? truncateForTriggerMetadata(error.cause)
+        : undefined;
+    const errorMetadata = error.metadata;
     return {
       category: error.type === "unauthorized" ? "login_required" : "chat_error",
       code,
       name: "ChatSDKError",
       message: errorMessage,
+      cause,
       loginRequired: error.type === "unauthorized",
       statusCode: error.statusCode,
+      dbOperation: getStringMetadata(errorMetadata, "db_operation"),
+      dbErrorName: getStringMetadata(errorMetadata, "db_error_name"),
+      dbErrorMessage: getStringMetadata(errorMetadata, "db_error_message"),
+      partsSizeKb: getNumberMetadata(errorMetadata, "parts_size_kb"),
+      partCount: getNumberMetadata(errorMetadata, "part_count"),
+      largestPartType: getStringMetadata(errorMetadata, "largest_part_type"),
+      largestPartSizeKb: getNumberMetadata(
+        errorMetadata,
+        "largest_part_size_kb",
+      ),
+      toolPartCount: getNumberMetadata(errorMetadata, "tool_part_count"),
+      dataPartCount: getNumberMetadata(errorMetadata, "data_part_count"),
+      reasoningChars: getNumberMetadata(errorMetadata, "reasoning_chars"),
     };
   }
 
@@ -181,6 +236,25 @@ const recordAgentLongFailureForDashboard = async (
 
   if (summary.code) metadata.set("errorCode", summary.code);
   if (summary.statusCode) metadata.set("errorStatusCode", summary.statusCode);
+  if (summary.cause) metadata.set("errorCause", summary.cause);
+  if (summary.dbOperation) metadata.set("dbOperation", summary.dbOperation);
+  if (summary.dbErrorName) metadata.set("dbErrorName", summary.dbErrorName);
+  if (summary.dbErrorMessage)
+    metadata.set("dbErrorMessage", summary.dbErrorMessage);
+  if (summary.partsSizeKb != null)
+    metadata.set("messagePartsSizeKb", summary.partsSizeKb);
+  if (summary.partCount != null)
+    metadata.set("messagePartCount", summary.partCount);
+  if (summary.largestPartType)
+    metadata.set("largestPartType", summary.largestPartType);
+  if (summary.largestPartSizeKb != null)
+    metadata.set("largestPartSizeKb", summary.largestPartSizeKb);
+  if (summary.toolPartCount != null)
+    metadata.set("toolPartCount", summary.toolPartCount);
+  if (summary.dataPartCount != null)
+    metadata.set("dataPartCount", summary.dataPartCount);
+  if (summary.reasoningChars != null)
+    metadata.set("reasoningChars", summary.reasoningChars);
 
   const errorTags = [`error_${summary.category}`];
   if (summary.code) {


### PR DESCRIPTION
## Summary

Adds structured diagnostics around the generic `bad_request:database` failure path so future Trigger.dev agent failures identify the exact database operation and message shape that caused the error.

## What changed

- Logs `database_operation_failed` from backend DB action wrappers with operation, original DB error, chat/user/message ids, and safe message part statistics.
- Logs `convex_message_save_failed` inside the Convex `messages.saveMessage` mutation before the original error is flattened to `Failed to save message`.
- Propagates safe DB diagnostics into chat-wide error events and Trigger run metadata.
- Adds a focused unit test to ensure diagnostics summarize sizes and counts without logging message content.

## Why

Recent Trigger.dev agent runs were surfacing only `An error occurred while executing a database query.` The pasted failure also ended with `Failed to save message`, but there was not enough structured data to tell whether this was a Convex document size issue, invalid value shape, or another mutation failure.

## Validation

- `pnpm test -- lib/db/__tests__/message-persistence-diagnostics.test.ts`
- Commit hook: `pnpm typecheck`
- Commit hook: full `pnpm test` (`79` suites, `1051` tests passing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting by replacing generic logs with structured diagnostics (message metadata, size/part counts, truncated error causes) to make failures easier to investigate.
* **Logging**
  * Enriched error events to include optional cause and metadata and extended dashboard error summaries with persistence/part metrics.
* **Tests**
  * Added test coverage for message persistence diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->