### PR TITLE
[codex] Fix Convex tool output serialization

### DIFF
--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -804,7 +804,13 @@ In using these tools, adhere to the following guidelines:
           });
         } // end of executeCommand
       } catch (error) {
-        return error as CommandExitError;
+        return {
+          result: {
+            exitCode: error instanceof CommandExitError ? error.exitCode : 1,
+            output: "",
+            error: error instanceof Error ? error.message : String(error),
+          },
+        };
       }
     },
     // For interactive PTY results, strip rawSnapshot from what the model

--- a/lib/db/__tests__/convex-value-sanitizer.test.ts
+++ b/lib/db/__tests__/convex-value-sanitizer.test.ts
@@ -44,6 +44,29 @@ describe("sanitizeForConvexValue", () => {
     });
   });
 
+  it("handles circular Error causes without throwing", () => {
+    const first = new Error("first") as Error & { cause?: unknown };
+    const second = new Error("second") as Error & { cause?: unknown };
+    first.cause = second;
+    second.cause = first;
+
+    expect(sanitizeForConvexValue(first)).toEqual({
+      error: "first",
+      name: "Error",
+      message: "first",
+      cause: {
+        error: "second",
+        name: "Error",
+        message: "second",
+        cause: {
+          error: "[Circular]",
+          name: "Error",
+          message: "[Circular]",
+        },
+      },
+    });
+  });
+
   it("normalizes unsupported scalar values nested in arrays and objects", () => {
     const result = sanitizeForConvexValue({
       array: [undefined, Number.NaN, Symbol("x")],
@@ -59,6 +82,22 @@ describe("sanitizeForConvexValue", () => {
         keep: "yes",
       },
     });
+  });
+
+  it("keeps only Convex-compatible bigint values as bigint", () => {
+    expect(sanitizeForConvexValue(-(1n << 63n))).toBe(-(1n << 63n));
+    expect(sanitizeForConvexValue((1n << 63n) - 1n)).toBe((1n << 63n) - 1n);
+    expect(sanitizeForConvexValue(1n << 63n)).toBe("9223372036854775808");
+    expect(sanitizeForConvexValue(-(1n << 63n) - 1n)).toBe(
+      "-9223372036854775809",
+    );
+  });
+
+  it("normalizes invalid Date instances without throwing", () => {
+    expect(sanitizeForConvexValue(new Date("2026-05-18T12:00:00.000Z"))).toBe(
+      "2026-05-18T12:00:00.000Z",
+    );
+    expect(sanitizeForConvexValue(new Date(Number.NaN))).toBeNull();
   });
 
   it("converts ArrayBuffer views into sliced ArrayBuffers", () => {

--- a/lib/db/__tests__/convex-value-sanitizer.test.ts
+++ b/lib/db/__tests__/convex-value-sanitizer.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "@jest/globals";
+import { sanitizeForConvexValue } from "../convex-value-sanitizer";
+
+describe("sanitizeForConvexValue", () => {
+  it("converts Error instances in tool outputs into plain objects", () => {
+    const error = new Error(
+      "Local sandbox disconnected. Reconnect your desktop app or upgrade to Pro for cloud sandbox.",
+    ) as Error & { code?: string; statusCode?: number };
+    error.code = "SANDBOX_DISCONNECTED";
+    error.statusCode = 503;
+
+    const result = sanitizeForConvexValue({
+      parts: [
+        { type: "step-start" },
+        {
+          type: "tool-run_terminal_cmd",
+          state: "output-available",
+          output: error,
+        },
+      ],
+    }) as {
+      parts: Array<{ output?: { error?: string; code?: string } }>;
+    };
+
+    expect(result.parts[1].output).toEqual({
+      error:
+        "Local sandbox disconnected. Reconnect your desktop app or upgrade to Pro for cloud sandbox.",
+      name: "Error",
+      message:
+        "Local sandbox disconnected. Reconnect your desktop app or upgrade to Pro for cloud sandbox.",
+      code: "SANDBOX_DISCONNECTED",
+      statusCode: 503,
+    });
+    expect(result.parts[1].output).not.toBe(error);
+  });
+
+  it("handles circular references without throwing", () => {
+    const value: Record<string, unknown> = { ok: true };
+    value.self = value;
+
+    expect(sanitizeForConvexValue(value)).toEqual({
+      ok: true,
+      self: "[Circular]",
+    });
+  });
+
+  it("normalizes unsupported scalar values nested in arrays and objects", () => {
+    const result = sanitizeForConvexValue({
+      array: [undefined, Number.NaN, Symbol("x")],
+      object: {
+        keep: "yes",
+        drop: undefined,
+      },
+    });
+
+    expect(result).toEqual({
+      array: [null, null, "Symbol(x)"],
+      object: {
+        keep: "yes",
+      },
+    });
+  });
+});

--- a/lib/db/__tests__/convex-value-sanitizer.test.ts
+++ b/lib/db/__tests__/convex-value-sanitizer.test.ts
@@ -60,4 +60,23 @@ describe("sanitizeForConvexValue", () => {
       },
     });
   });
+
+  it("converts ArrayBuffer views into sliced ArrayBuffers", () => {
+    const backingBuffer = new Uint8Array([1, 2, 3, 4, 5]).buffer;
+    const view = new Uint8Array(backingBuffer, 1, 3);
+    const dataView = new DataView(backingBuffer, 2, 2);
+
+    const result = sanitizeForConvexValue({
+      view,
+      dataView,
+    }) as { view: ArrayBuffer; dataView: ArrayBuffer };
+
+    expect(result.view).toBeInstanceOf(ArrayBuffer);
+    expect(result.view).not.toBe(backingBuffer);
+    expect([...new Uint8Array(result.view)]).toEqual([2, 3, 4]);
+
+    expect(result.dataView).toBeInstanceOf(ArrayBuffer);
+    expect(result.dataView).not.toBe(backingBuffer);
+    expect([...new Uint8Array(result.dataView)]).toEqual([3, 4]);
+  });
 });

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -23,6 +23,7 @@ import { AGENT_RESUME_PREAMBLE } from "@/lib/chat/summarization/prompts";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import type { ChatMode } from "@/types/chat";
 import { getMessagePersistenceDiagnostics } from "./message-persistence-diagnostics";
+import { sanitizeForConvexValue } from "./convex-value-sanitizer";
 
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 const MAX_DATABASE_ERROR_MESSAGE_LENGTH = 500;
@@ -150,6 +151,11 @@ export async function saveMessage({
       message.role === "assistant"
         ? fixIncompleteMessageParts(message.parts)
         : message.parts;
+
+    fixedParts = sanitizeForConvexValue(fixedParts) as UIMessagePart<
+      any,
+      any
+    >[];
 
     // Extract file IDs from file parts
     const fileIds = extractFileIdsFromParts(fixedParts);

--- a/lib/db/convex-value-sanitizer.ts
+++ b/lib/db/convex-value-sanitizer.ts
@@ -12,6 +12,19 @@ const primitiveErrorFieldNames = [
   "syscall",
 ] as const;
 
+const arrayBufferViewToArrayBuffer = (view: ArrayBufferView): ArrayBuffer => {
+  if (view.buffer instanceof ArrayBuffer) {
+    return view.buffer.slice(
+      view.byteOffset,
+      view.byteOffset + view.byteLength,
+    );
+  }
+
+  const copy = new Uint8Array(view.byteLength);
+  copy.set(new Uint8Array(view.buffer, view.byteOffset, view.byteLength));
+  return copy.buffer;
+};
+
 const sanitizeError = (error: Error, seen: WeakSet<object>) => {
   const sanitized: Record<string, unknown> = {
     error: error.message || error.name || "Error",
@@ -82,7 +95,7 @@ export function sanitizeForConvexValue(
   }
 
   if (ArrayBuffer.isView(value)) {
-    return value;
+    return arrayBufferViewToArrayBuffer(value);
   }
 
   if (typeof value !== "object") {

--- a/lib/db/convex-value-sanitizer.ts
+++ b/lib/db/convex-value-sanitizer.ts
@@ -12,6 +12,9 @@ const primitiveErrorFieldNames = [
   "syscall",
 ] as const;
 
+const MIN_CONVEX_BIGINT = -BigInt("9223372036854775808");
+const MAX_CONVEX_BIGINT = BigInt("9223372036854775807");
+
 const arrayBufferViewToArrayBuffer = (view: ArrayBufferView): ArrayBuffer => {
   if (view.buffer instanceof ArrayBuffer) {
     return view.buffer.slice(
@@ -26,6 +29,15 @@ const arrayBufferViewToArrayBuffer = (view: ArrayBufferView): ArrayBuffer => {
 };
 
 const sanitizeError = (error: Error, seen: WeakSet<object>) => {
+  if (seen.has(error)) {
+    return {
+      error: "[Circular]",
+      name: error.name || "Error",
+      message: "[Circular]",
+    };
+  }
+  seen.add(error);
+
   const sanitized: Record<string, unknown> = {
     error: error.message || error.name || "Error",
     name: error.name || "Error",
@@ -49,6 +61,7 @@ const sanitizeError = (error: Error, seen: WeakSet<object>) => {
     sanitized.cause = sanitizeForConvexValue(cause, seen);
   }
 
+  seen.delete(error);
   return sanitized;
 };
 
@@ -66,12 +79,15 @@ export function sanitizeForConvexValue(
   if (value === null || value === undefined) return value;
 
   const valueType = typeof value;
-  if (
-    valueType === "string" ||
-    valueType === "boolean" ||
-    valueType === "bigint"
-  ) {
+  if (valueType === "string" || valueType === "boolean") {
     return value;
+  }
+
+  if (valueType === "bigint") {
+    const bigintValue = value as bigint;
+    return bigintValue >= MIN_CONVEX_BIGINT && bigintValue <= MAX_CONVEX_BIGINT
+      ? bigintValue
+      : bigintValue.toString();
   }
 
   if (valueType === "number") {
@@ -87,7 +103,7 @@ export function sanitizeForConvexValue(
   }
 
   if (value instanceof Date) {
-    return value.toISOString();
+    return Number.isFinite(value.getTime()) ? value.toISOString() : null;
   }
 
   if (value instanceof ArrayBuffer) {

--- a/lib/db/convex-value-sanitizer.ts
+++ b/lib/db/convex-value-sanitizer.ts
@@ -1,0 +1,137 @@
+const isPlainObject = (value: object): boolean => {
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+};
+
+const primitiveErrorFieldNames = [
+  "code",
+  "status",
+  "statusCode",
+  "exitCode",
+  "errno",
+  "syscall",
+] as const;
+
+const sanitizeError = (error: Error, seen: WeakSet<object>) => {
+  const sanitized: Record<string, unknown> = {
+    error: error.message || error.name || "Error",
+    name: error.name || "Error",
+    message: error.message || "Error",
+  };
+
+  for (const key of primitiveErrorFieldNames) {
+    const value = (error as unknown as Record<string, unknown>)[key];
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean" ||
+      value === null
+    ) {
+      sanitized[key] = value;
+    }
+  }
+
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause !== undefined && cause !== error) {
+    sanitized.cause = sanitizeForConvexValue(cause, seen);
+  }
+
+  return sanitized;
+};
+
+/**
+ * Convert arbitrary SDK/tool payloads into values Convex can persist.
+ *
+ * AI SDK tool parts can carry thrown Error instances in `output` when a tool
+ * fails outside its normal result shape. Convex rejects class instances even
+ * under `v.any()`, so normalize those objects before mutation calls.
+ */
+export function sanitizeForConvexValue(
+  value: unknown,
+  seen = new WeakSet<object>(),
+): unknown {
+  if (value === null || value === undefined) return value;
+
+  const valueType = typeof value;
+  if (
+    valueType === "string" ||
+    valueType === "boolean" ||
+    valueType === "bigint"
+  ) {
+    return value;
+  }
+
+  if (valueType === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (valueType === "function" || valueType === "symbol") {
+    return String(value);
+  }
+
+  if (value instanceof Error) {
+    return sanitizeError(value, seen);
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return value;
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    return value;
+  }
+
+  if (typeof value !== "object") {
+    return String(value);
+  }
+
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    const sanitized = value.map((item) => {
+      const sanitizedItem = sanitizeForConvexValue(item, seen);
+      return sanitizedItem === undefined ? null : sanitizedItem;
+    });
+    seen.delete(value);
+    return sanitized;
+  }
+
+  const toJSON = (value as { toJSON?: unknown }).toJSON;
+  if (typeof toJSON === "function" && !isPlainObject(value)) {
+    try {
+      const jsonValue = toJSON.call(value);
+      if (jsonValue !== value) {
+        const sanitized = sanitizeForConvexValue(jsonValue, seen);
+        seen.delete(value);
+        return sanitized;
+      }
+    } catch {
+      // Fall through to enumerable fields.
+    }
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, childValue] of Object.entries(
+    value as Record<string, unknown>,
+  )) {
+    const sanitizedChild = sanitizeForConvexValue(childValue, seen);
+    if (sanitizedChild !== undefined) {
+      sanitized[key] = sanitizedChild;
+    }
+  }
+
+  if (!isPlainObject(value) && Object.keys(sanitized).length === 0) {
+    seen.delete(value);
+    return String(value);
+  }
+
+  seen.delete(value);
+  return sanitized;
+}


### PR DESCRIPTION
## Summary

Fixes a chat persistence failure where AI SDK tool parts could carry a raw `Error` instance in `part.output`, causing Convex to reject `messages.saveMessage` even though the stream had completed.

## Root Cause

`run_terminal_cmd` could return an `Error` object directly from its outer catch path when sandbox setup failed, for example during a local sandbox disconnect. Convex does not accept class instances as values, so persisting assistant message parts failed with `Error {} is not a supported Convex type`.

## Changes

- Normalize outer `run_terminal_cmd` failures into a plain tool result object.
- Add a DB-boundary `sanitizeForConvexValue` helper for message parts before calling Convex.
- Cover `Error` instances, circular references, unsupported scalar values, and related edge cases with unit tests.

## Validation

- `pnpm test -- lib/db/__tests__/convex-value-sanitizer.test.ts lib/db/__tests__/message-persistence-diagnostics.test.ts`
- `pnpm test -- lib/ai/tools/__tests__/run-terminal-cmd.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint lib/db/convex-value-sanitizer.ts lib/db/__tests__/convex-value-sanitizer.test.ts lib/db/actions.ts lib/ai/tools/run-terminal-cmd.ts`
- Commit hook: `pnpm typecheck` and full `pnpm test` suite, 80 suites / 1054 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sanitizer to normalize arbitrary payloads for safe storage.

* **Bug Fixes**
  * Standardized tool error payloads so failures store consistent exit code, output, and error text.
  * Improved serialization: handles circular references, embedded Error objects, unsupported scalars, bigint clamping, Date normalization, and ArrayBuffer views.

* **Tests**
  * Added tests covering sanitization behaviors and edge cases.

* **Chores**
  * Apply sanitization before persisting messages to improve reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->