### PR TITLE
[codex] Update attachment and context usage limits

### DIFF
--- a/app/components/ContextUsageIndicator.tsx
+++ b/app/components/ContextUsageIndicator.tsx
@@ -10,6 +10,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { SUMMARIZATION_THRESHOLD_PERCENTAGE } from "@/lib/chat/summarization/constants";
 import { forwardRef, type ComponentPropsWithoutRef } from "react";
 
 export interface ContextUsageData {
@@ -37,6 +38,10 @@ function formatTokenCount(n: number): string {
 function formatExactTokenCount(n: number): string {
   return Math.round(n).toLocaleString();
 }
+
+const AUTO_COMPACT_PERCENT = Math.round(
+  SUMMARIZATION_THRESHOLD_PERCENTAGE * 100,
+);
 
 const CIRCLE_SIZE = 16;
 const STROKE_WIDTH = 2.5;
@@ -117,6 +122,10 @@ export const ContextUsageIndicator = ({
   if (usedTokens === 0 || maxTokens === 0) return null;
   const percent = Math.min((usedTokens / maxTokens) * 100, 100);
   const remaining = Math.max(0, 100 - Math.round(percent));
+  const autoCompactTokens = Math.floor(
+    maxTokens * SUMMARIZATION_THRESHOLD_PERCENTAGE,
+  );
+  const tokensUntilAutoCompact = Math.max(0, autoCompactTokens - usedTokens);
   const dashOffset = CIRCUMFERENCE - (percent / 100) * CIRCUMFERENCE;
 
   if (variant === "compact-popover") {
@@ -169,7 +178,13 @@ export const ContextUsageIndicator = ({
           used
         </div>
         <div className="text-xs text-muted-foreground pt-1">
-          HackerAI automatically compacts its context
+          Auto-compact starts at {formatExactTokenCount(autoCompactTokens)}{" "}
+          tokens ({AUTO_COMPACT_PERCENT}%).
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {tokensUntilAutoCompact > 0
+            ? `${formatExactTokenCount(tokensUntilAutoCompact)} tokens until auto-compact`
+            : "Auto-compact threshold reached"}
         </div>
       </TooltipContent>
     </Tooltip>

--- a/app/components/ContextUsageIndicator.tsx
+++ b/app/components/ContextUsageIndicator.tsx
@@ -10,7 +10,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { SUMMARIZATION_THRESHOLD_PERCENTAGE } from "@/lib/chat/summarization/constants";
 import { forwardRef, type ComponentPropsWithoutRef } from "react";
 
 export interface ContextUsageData {
@@ -34,14 +33,6 @@ function formatTokenCount(n: number): string {
   }
   return String(n);
 }
-
-function formatExactTokenCount(n: number): string {
-  return Math.round(n).toLocaleString();
-}
-
-const AUTO_COMPACT_PERCENT = Math.round(
-  SUMMARIZATION_THRESHOLD_PERCENTAGE * 100,
-);
 
 const CIRCLE_SIZE = 16;
 const STROKE_WIDTH = 2.5;
@@ -122,10 +113,6 @@ export const ContextUsageIndicator = ({
   if (usedTokens === 0 || maxTokens === 0) return null;
   const percent = Math.min((usedTokens / maxTokens) * 100, 100);
   const remaining = Math.max(0, 100 - Math.round(percent));
-  const autoCompactTokens = Math.floor(
-    maxTokens * SUMMARIZATION_THRESHOLD_PERCENTAGE,
-  );
-  const tokensUntilAutoCompact = Math.max(0, autoCompactTokens - usedTokens);
   const dashOffset = CIRCUMFERENCE - (percent / 100) * CIRCUMFERENCE;
 
   if (variant === "compact-popover") {
@@ -142,12 +129,18 @@ export const ContextUsageIndicator = ({
           side="top"
           align="end"
           sideOffset={8}
-          className="w-auto max-w-[240px] px-3 py-2.5 text-center"
+          className="w-auto max-w-[240px] px-3 py-2.5 text-center space-y-0.5"
         >
           <div className="font-medium text-xs">Context window:</div>
+          <div className="text-xs">
+            {Math.round(percent)}% used ({remaining}% left)
+          </div>
           <div className="text-xs tabular-nums">
-            {remaining}% left ({formatExactTokenCount(usedTokens)} used /{" "}
-            {formatExactTokenCount(maxTokens)})
+            {formatTokenCount(usedTokens)} / {formatTokenCount(maxTokens)}{" "}
+            tokens used
+          </div>
+          <div className="text-xs text-muted-foreground pt-1">
+            HackerAI automatically compacts its context
           </div>
         </PopoverContent>
       </Popover>
@@ -178,13 +171,7 @@ export const ContextUsageIndicator = ({
           used
         </div>
         <div className="text-xs text-muted-foreground pt-1">
-          Auto-compact starts at {formatExactTokenCount(autoCompactTokens)}{" "}
-          tokens ({AUTO_COMPACT_PERCENT}%).
-        </div>
-        <div className="text-xs text-muted-foreground">
-          {tokensUntilAutoCompact > 0
-            ? `${formatExactTokenCount(tokensUntilAutoCompact)} tokens until auto-compact`
-            : "Auto-compact threshold reached"}
+          HackerAI automatically compacts its context
         </div>
       </TooltipContent>
     </Tooltip>

--- a/app/components/__tests__/ContextUsageIndicator.test.tsx
+++ b/app/components/__tests__/ContextUsageIndicator.test.tsx
@@ -1,8 +1,22 @@
 import "@testing-library/jest-dom";
-import { describe, it, expect } from "@jest/globals";
+import { afterAll, beforeAll, describe, it, expect } from "@jest/globals";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ContextUsageIndicator } from "../ContextUsageIndicator";
+
+const originalResizeObserver = global.ResizeObserver;
+
+beforeAll(() => {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+afterAll(() => {
+  global.ResizeObserver = originalResizeObserver;
+});
 
 describe("ContextUsageIndicator", () => {
   const defaultProps = {
@@ -55,6 +69,25 @@ describe("ContextUsageIndicator", () => {
         "aria-label",
         "Context usage: 8.0k of 100k tokens",
       );
+    });
+  });
+
+  describe("Desktop tooltip", () => {
+    it("shows the exact auto-compact threshold on hover", async () => {
+      const user = userEvent.setup();
+
+      render(<ContextUsageIndicator {...defaultProps} />);
+
+      await user.hover(screen.getByTestId("context-usage-indicator"));
+
+      expect(
+        await screen.findAllByText(
+          "Auto-compact starts at 90,000 tokens (90%).",
+        ),
+      ).not.toHaveLength(0);
+      expect(
+        screen.getAllByText("82,000 tokens until auto-compact"),
+      ).not.toHaveLength(0);
     });
   });
 

--- a/app/components/__tests__/ContextUsageIndicator.test.tsx
+++ b/app/components/__tests__/ContextUsageIndicator.test.tsx
@@ -72,33 +72,14 @@ describe("ContextUsageIndicator", () => {
     });
   });
 
-  describe("Desktop tooltip", () => {
-    it("shows the exact auto-compact threshold on hover", async () => {
-      const user = userEvent.setup();
-
-      render(<ContextUsageIndicator {...defaultProps} />);
-
-      await user.hover(screen.getByTestId("context-usage-indicator"));
-
-      expect(
-        await screen.findAllByText(
-          "Auto-compact starts at 90,000 tokens (90%).",
-        ),
-      ).not.toHaveLength(0);
-      expect(
-        screen.getAllByText("82,000 tokens until auto-compact"),
-      ).not.toHaveLength(0);
-    });
-  });
-
   describe("Compact popover", () => {
     it("opens a short mobile-friendly message on click", async () => {
       const user = userEvent.setup();
 
       render(
         <ContextUsageIndicator
-          usedTokens={189833}
-          maxTokens={258000}
+          usedTokens={8500}
+          maxTokens={200000}
           variant="compact-popover"
         />,
       );
@@ -106,8 +87,10 @@ describe("ContextUsageIndicator", () => {
       await user.click(screen.getByTestId("context-usage-indicator"));
 
       expect(screen.getByText("Context window:")).toBeInTheDocument();
+      expect(screen.getByText("4% used (96% left)")).toBeInTheDocument();
+      expect(screen.getByText("8.5k / 200k tokens used")).toBeInTheDocument();
       expect(
-        screen.getByText("26% left (189,833 used / 258,000)"),
+        screen.getByText("HackerAI automatically compacts its context"),
       ).toBeInTheDocument();
     });
   });

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -31,30 +31,30 @@ describe("limitImageParts", () => {
     expect(result).toBe(messages); // same reference, no changes
   });
 
-  it("should return messages unchanged when exactly at the limit (10 images)", () => {
-    const parts = Array.from({ length: 10 }, (_, i) => makeFilePart(`f${i}`));
+  it("should return messages unchanged when exactly at the limit (20 images)", () => {
+    const parts = Array.from({ length: 20 }, (_, i) => makeFilePart(`f${i}`));
     const messages = [makeMessage("m1", "user", parts)];
     const result = limitImageParts(messages);
     expect(result).toBe(messages);
   });
 
   it("should remove oldest images when over the limit", () => {
-    const parts = Array.from({ length: 15 }, (_, i) => makeFilePart(`f${i}`));
+    const parts = Array.from({ length: 25 }, (_, i) => makeFilePart(`f${i}`));
     const messages = [makeMessage("m1", "user", parts)];
     const result = limitImageParts(messages);
 
     const remainingFiles = result[0].parts.filter(
       (p: any) => p.type === "file",
     );
-    expect(remainingFiles).toHaveLength(10);
-    // Should keep f5..f14 (the 10 most recent), removing f0..f4
+    expect(remainingFiles).toHaveLength(20);
+    // Should keep f5..f24 (the 20 most recent), removing f0..f4
     expect((remainingFiles[0] as any).fileId).toBe("f5");
-    expect((remainingFiles[9] as any).fileId).toBe("f14");
+    expect((remainingFiles[19] as any).fileId).toBe("f24");
   });
 
   it("should remove oldest images across multiple messages", () => {
-    // 3 messages with 5 images each = 15 total, should keep last 10
-    const messages = Array.from({ length: 3 }, (_, msgIdx) => {
+    // 5 messages with 5 images each = 25 total, should keep last 20
+    const messages = Array.from({ length: 5 }, (_, msgIdx) => {
       const parts = Array.from({ length: 5 }, (_, fileIdx) =>
         makeFilePart(`f${msgIdx * 5 + fileIdx}`),
       );
@@ -66,16 +66,16 @@ describe("limitImageParts", () => {
     const allFiles = result.flatMap((msg) =>
       msg.parts.filter((p: any) => p.type === "file"),
     );
-    expect(allFiles).toHaveLength(10);
+    expect(allFiles).toHaveLength(20);
     // Oldest 5 images (f0..f4) from first message should be removed
     expect((allFiles[0] as any).fileId).toBe("f5");
-    expect((allFiles[9] as any).fileId).toBe("f14");
+    expect((allFiles[19] as any).fileId).toBe("f24");
   });
 
   it("should preserve non-file parts when removing images", () => {
     const parts: any[] = [
       { type: "text", text: "check these images" },
-      ...Array.from({ length: 12 }, (_, i) => makeFilePart(`f${i}`)),
+      ...Array.from({ length: 22 }, (_, i) => makeFilePart(`f${i}`)),
     ];
     const messages = [makeMessage("m1", "user", parts)];
     const result = limitImageParts(messages);
@@ -85,7 +85,7 @@ describe("limitImageParts", () => {
 
     expect(textParts).toHaveLength(1);
     expect((textParts[0] as any).text).toBe("check these images");
-    expect(fileParts).toHaveLength(10);
+    expect(fileParts).toHaveLength(20);
   });
 
   it("should handle messages with no parts", () => {
@@ -98,7 +98,7 @@ describe("limitImageParts", () => {
   });
 
   it("should only limit images, leaving PDFs and other file types untouched", () => {
-    const parts = Array.from({ length: 25 }, (_, i) =>
+    const parts = Array.from({ length: 45 }, (_, i) =>
       makeFilePart(`f${i}`, i % 2 === 0 ? "image/png" : "application/pdf"),
     );
     const messages = [makeMessage("m1", "user", parts)];
@@ -114,10 +114,10 @@ describe("limitImageParts", () => {
       (p: any) => p.mediaType === "application/pdf",
     );
 
-    // All 12 PDFs should remain (odd indices: 1,3,5,...,23 = 12 PDFs)
-    expect(pdfs).toHaveLength(12);
-    // Only 10 most recent images should remain (even indices: 0,2,4,...,24 = 13 images, keep last 10)
-    expect(images).toHaveLength(10);
+    // All 22 PDFs should remain (odd indices: 1,3,5,...,43 = 22 PDFs)
+    expect(pdfs).toHaveLength(22);
+    // Only 20 most recent images should remain (even indices: 0,2,4,...,44 = 23 images, keep last 20)
+    expect(images).toHaveLength(20);
   });
 
   it("should not remove any files when all are non-image types", () => {

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -385,11 +385,10 @@ function stripOriginalContentFromMessages(messages: UIMessage[]): UIMessage[] {
 
 /**
  * Limits the number of image file parts across all messages to stay within provider limits.
- * Google Vertex AI (Gemini 3) limits requests to 10 image links, returning
- * INVALID_ARGUMENT if exceeded. Only counts image files — PDFs and other file types
+ * Only counts image files — PDFs and other file types
  * are left untouched. Keeps the most recent images by removing the oldest ones first.
  */
-const MAX_IMAGES_PER_CONVERSATION = 10;
+const MAX_IMAGES_PER_CONVERSATION = 20;
 
 export function limitImageParts(messages: UIMessage[]): UIMessage[] {
   const imagePositions: Array<{ messageIndex: number; partIndex: number }> = [];
@@ -516,7 +515,7 @@ export async function processChatMessages({
   const messagesWithoutUIOnlyParts = messages.map(filterUIOnlyParts);
 
   // Limit image parts before fetching URLs to avoid unnecessary S3 requests
-  // Vertex AI (Gemini 3) limits conversations to 10 images
+  // Keep image attachment pruning aligned with the per-message upload cap.
   const messagesWithLimitedFiles = limitImageParts(messagesWithoutUIOnlyParts);
 
   // Process all file attachments: transform URLs, detect media/PDFs, and add document content

--- a/lib/utils/file-utils.ts
+++ b/lib/utils/file-utils.ts
@@ -24,7 +24,7 @@ export const MAX_FILE_SIZE = 10 * 1024 * 1024;
 export const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
 
 /** Maximum number of files allowed to be uploaded at once */
-export const MAX_FILES_LIMIT = 5;
+export const MAX_FILES_LIMIT = 20;
 
 /** Supported image formats for AI processing */
 const SUPPORTED_IMAGE_TYPES = new Set([


### PR DESCRIPTION
## Summary

- Raise the frontend attachment upload cap to 20 files.
- Align image attachment pruning with the 20-file cap so images are not pruned at the old 10-image mark.
- Update the mobile context usage popover to show the full context breakdown and compaction note.

## Why

Users can now attach up to 20 files, so the model-prep pruning behavior needs to match that limit. Mobile users also now see the same useful context-window details that desktop users already had, without changing the desktop tooltip.

## Validation

- `pnpm test -- app/components/__tests__/ContextUsageIndicator.test.tsx lib/chat/__tests__/chat-processor.test.ts`
- `pnpm exec prettier --check app/components/ContextUsageIndicator.tsx app/components/__tests__/ContextUsageIndicator.test.tsx lib/chat/chat-processor.ts lib/chat/__tests__/chat-processor.test.ts lib/utils/file-utils.ts`
- Commit hook: `pnpm typecheck`
- Commit hook: `pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context usage indicator popover now shows rounded percent used, "% left", and simplified token usage text.
  * Maximum file upload limit increased to 20 files.
  * Maximum images per conversation increased to 20 images.

* **Tests**
  * Stabilized relevant component tests with global test-environment setup/teardown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->