### PR TITLE
[codex] Set plan-based extra usage caps

### DIFF
--- a/app/components/ExtraUsageSection.tsx
+++ b/app/components/ExtraUsageSection.tsx
@@ -12,8 +12,10 @@ import {
   AdjustSpendingLimitDialog,
   AutoReloadDialog,
 } from "@/app/components/extra-usage";
+import { useGlobalState } from "@/app/contexts/GlobalState";
 
 const ExtraUsageSection = () => {
+  const { subscription } = useGlobalState();
   // User customization for extra usage enabled flag
   const userCustomization = useQuery(
     api.userCustomization.getUserCustomization,
@@ -23,7 +25,9 @@ const ExtraUsageSection = () => {
   );
 
   // Extra usage settings (balance and auto-reload config)
-  const extraUsageSettings = useQuery(api.extraUsage.getExtraUsageSettings);
+  const extraUsageSettings = useQuery(api.extraUsage.getExtraUsageSettings, {
+    subscription,
+  });
   const updateExtraUsageSettings = useMutation(
     api.extraUsage.updateExtraUsageSettings,
   );
@@ -277,8 +281,7 @@ const ExtraUsageSection = () => {
                 </div>
                 {isTrustCapActive && (
                   <p className="text-xs text-muted-foreground">
-                    Your extra usage limit is ${trustCapDollars}/month while
-                    your account builds payment history.{" "}
+                    Your plan extra usage limit is ${trustCapDollars}/month.{" "}
                     <a
                       href="mailto:support@hackerai.co"
                       className="underline underline-offset-[3px] hover:text-foreground"

--- a/app/components/SidebarUserNav.tsx
+++ b/app/components/SidebarUserNav.tsx
@@ -124,14 +124,24 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
     api.rateLimitStatus.getAgentRateLimitStatus,
   );
 
-  const extraUsageSettings = useQuery(api.extraUsage.getExtraUsageSettings);
+  const extraUsageSettings = useQuery(api.extraUsage.getExtraUsageSettings, {
+    subscription,
+  });
   const userCustomization = useQuery(
     api.userCustomization.getUserCustomization,
   );
   const extraUsageEnabled = userCustomization?.extra_usage_enabled ?? false;
   const extraUsageMonthlySpentDollars =
     extraUsageSettings?.monthlySpentDollars ?? 0;
-  const extraUsageMonthlyCapDollars = extraUsageSettings?.monthlyCapDollars;
+  const extraUsageMonthlyCapDollars =
+    extraUsageSettings?.monthlyCapDollars != null &&
+    extraUsageSettings?.trustCapDollars != null
+      ? Math.min(
+          extraUsageSettings.monthlyCapDollars,
+          extraUsageSettings.trustCapDollars,
+        )
+      : (extraUsageSettings?.monthlyCapDollars ??
+        extraUsageSettings?.trustCapDollars);
 
   const fetchTokenUsage = useCallback(async () => {
     if (!isPaidUser) return;

--- a/app/components/usage/OnDemandUsageCard.tsx
+++ b/app/components/usage/OnDemandUsageCard.tsx
@@ -11,13 +11,23 @@ interface OnDemandUsageCardProps {
 }
 
 const OnDemandUsageCard = ({ subscription }: OnDemandUsageCardProps) => {
-  const extraUsageSettings = useQuery(api.extraUsage.getExtraUsageSettings);
+  const extraUsageSettings = useQuery(api.extraUsage.getExtraUsageSettings, {
+    subscription,
+  });
   const userCustomization = useQuery(
     api.userCustomization.getUserCustomization,
   );
 
   const extraUsageEnabled = userCustomization?.extra_usage_enabled ?? false;
-  const monthlyCapDollars = extraUsageSettings?.monthlyCapDollars;
+  const monthlyCapDollars =
+    extraUsageSettings?.monthlyCapDollars != null &&
+    extraUsageSettings?.trustCapDollars != null
+      ? Math.min(
+          extraUsageSettings.monthlyCapDollars,
+          extraUsageSettings.trustCapDollars,
+        )
+      : (extraUsageSettings?.monthlyCapDollars ??
+        extraUsageSettings?.trustCapDollars);
   const monthlySpentDollars = extraUsageSettings?.monthlySpentDollars ?? 0;
   const balanceDollars = extraUsageSettings?.balanceDollars ?? 0;
 

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -2,6 +2,7 @@ import { internalMutation, mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 import { convexLogger } from "./lib/logger";
+import type { SubscriptionTier } from "../types";
 
 // =============================================================================
 // Currency Conversion Helpers
@@ -24,14 +25,29 @@ const pointsToDollars = (points: number): number => points / POINTS_PER_DOLLAR;
 // Trust-Based Spending Cap
 // =============================================================================
 
+const subscriptionTierValidator = v.union(
+  v.literal("free"),
+  v.literal("pro"),
+  v.literal("pro-plus"),
+  v.literal("team"),
+  v.literal("ultra"),
+);
+
 /**
- * Trust tier thresholds (modeled after Anthropic API tiers).
- * Both cumulative spend AND account age (since first charge) must be met to advance.
- *
- * Tier 1: cumulative_spend < $5  OR account < 7 days   → $100/month cap
- * Tier 2: cumulative_spend >= $5  AND account >= 7 days  → $500/month cap
- * Tier 3: cumulative_spend >= $40 AND account >= 30 days → $1,000/month cap
- * Tier 4: cumulative_spend >= $200 AND account >= 60 days → uncapped
+ * Plan-based extra usage caps. Manual support overrides still take precedence.
+ * "normal" maps to the Pro plan in the product.
+ */
+const PLAN_EXTRA_USAGE_CAP_DOLLARS: Partial<
+  Record<SubscriptionTier, number | null>
+> = {
+  pro: 200,
+  "pro-plus": 600,
+  ultra: 1000,
+};
+
+/**
+ * Legacy trust tier thresholds. Kept as a fallback for team pools and older
+ * callers that don't have a subscription tier available.
  */
 const TRUST_TIERS = [
   { minSpend: 200, minAgeDays: 60, capDollars: null }, // Tier 4: uncapped
@@ -45,6 +61,7 @@ const DAYS_MS = 24 * 60 * 60 * 1000;
 
 export type TrustReason =
   | "trusted" // Tier 4: fully uncapped
+  | "plan" // Plan-based cap
   | "building-history" // Tier 1-3: need more spend/time
   | "override"; // Manual override by support
 
@@ -56,12 +73,24 @@ export function computeExtraUsageCap(settings: {
   first_successful_charge_at?: number;
   cumulative_spend_dollars?: number;
   override_monthly_cap_dollars?: number;
+  subscription?: SubscriptionTier;
 }): { capDollars: number | null; trustReason: TrustReason } {
   // Manual override takes precedence
   if (settings.override_monthly_cap_dollars !== undefined) {
     return {
       capDollars: settings.override_monthly_cap_dollars,
       trustReason: "override",
+    };
+  }
+
+  const planCap = settings.subscription
+    ? PLAN_EXTRA_USAGE_CAP_DOLLARS[settings.subscription]
+    : undefined;
+
+  if (planCap !== undefined) {
+    return {
+      capDollars: planCap,
+      trustReason: "plan",
     };
   }
 
@@ -389,6 +418,7 @@ export const deductPoints = mutation({
     serviceKey: v.string(),
     userId: v.string(),
     amountPoints: v.number(),
+    subscription: v.optional(subscriptionTierValidator),
   },
   returns: v.object({
     success: v.boolean(),
@@ -457,7 +487,10 @@ export const deductPoints = mutation({
 
     // Compute effective monthly cap: lower of user-set cap and trust-based cap
     const userCapPoints = settings.monthly_cap_points;
-    const { capDollars: trustCapDollars } = computeExtraUsageCap(settings);
+    const { capDollars: trustCapDollars } = computeExtraUsageCap({
+      ...settings,
+      subscription: args.subscription as SubscriptionTier | undefined,
+    });
     const trustCapPoints =
       trustCapDollars !== null ? dollarsToPoints(trustCapDollars) : undefined;
 
@@ -674,7 +707,9 @@ export const getExtraUsageBalanceForBackend = query({
  * Returns all values in dollars (converted from points storage).
  */
 export const getExtraUsageSettings = query({
-  args: {},
+  args: {
+    subscription: v.optional(subscriptionTierValidator),
+  },
   returns: v.union(
     v.null(),
     v.object({
@@ -692,7 +727,7 @@ export const getExtraUsageSettings = query({
       autoReloadDisabledReason: v.optional(v.string()),
     }),
   ),
-  handler: async (ctx) => {
+  handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
       return null;
@@ -707,7 +742,10 @@ export const getExtraUsageSettings = query({
       return null;
     }
 
-    const { capDollars, trustReason } = computeExtraUsageCap(settings);
+    const { capDollars, trustReason } = computeExtraUsageCap({
+      ...settings,
+      subscription: args.subscription as SubscriptionTier | undefined,
+    });
 
     return {
       balanceDollars: pointsToDollars(settings.balance_points),

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -463,6 +463,15 @@ export const deductWithAutoReload = action({
     serviceKey: v.string(),
     userId: v.string(),
     amountPoints: v.number(),
+    subscription: v.optional(
+      v.union(
+        v.literal("free"),
+        v.literal("pro"),
+        v.literal("pro-plus"),
+        v.literal("team"),
+        v.literal("ultra"),
+      ),
+    ),
   },
   returns: v.object({
     success: v.boolean(),
@@ -656,6 +665,7 @@ export const deductWithAutoReload = action({
       serviceKey: args.serviceKey,
       userId: args.userId,
       amountPoints: args.amountPoints,
+      ...(args.subscription ? { subscription: args.subscription } : {}),
     });
 
     convexLogger.info("deduct_with_auto_reload", {

--- a/lib/extra-usage.ts
+++ b/lib/extra-usage.ts
@@ -1,6 +1,7 @@
 import { POINTS_PER_DOLLAR } from "@/lib/rate-limit/token-bucket";
 import { getConvexClient } from "@/lib/db/convex-client";
 import { api } from "@/convex/_generated/api";
+import type { SubscriptionTier } from "@/types";
 
 /** Extra usage pricing multiplier */
 export const EXTRA_USAGE_MULTIPLIER = 1.05;
@@ -146,10 +147,12 @@ export async function refundToBalance(
  *
  * @param userId - User ID
  * @param pointsUsed - Number of points to deduct
+ * @param subscription - Paid tier used for plan-based extra usage caps
  */
 export async function deductFromBalance(
   userId: string,
   pointsUsed: number,
+  subscription?: SubscriptionTier,
 ): Promise<DeductBalanceResult> {
   // No-op: nothing to deduct, balance unchanged (actual balance not fetched to avoid extra call)
   if (pointsUsed <= 0) {
@@ -173,6 +176,7 @@ export async function deductFromBalance(
         serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
         userId,
         amountPoints: pointsUsed,
+        ...(subscription ? { subscription } : {}),
       },
     );
 

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -243,7 +243,7 @@ export const checkTokenBucketLimit = async (
         const isTeamPool = subscription === "team" && !!organizationId;
         const deductResult = isTeamPool
           ? await deductFromTeamBalance(organizationId!, userId, shortfall)
-          : await deductFromBalance(userId, shortfall);
+          : await deductFromBalance(userId, shortfall, subscription);
 
         if (deductResult.success) {
           // Extra usage covered the shortfall. Deduct only what subscription contributed.
@@ -292,7 +292,7 @@ export const checkTokenBucketLimit = async (
 
           if (deductResult.trustCapExceeded) {
             const capAmount = deductResult.trustCapDollars ?? 100;
-            const msg = `You've reached your extra usage limit of $${capAmount}/month. This limit grows automatically with your payment history. Need a higher limit? Chat with us through our Help Center.`;
+            const msg = `You've reached your extra usage limit of $${capAmount}/month. Need a higher limit? Chat with us through our Help Center.`;
             throw new ChatSDKError("rate_limit:chat", msg, {
               resetTimestamp: monthlyCheck.reset,
               subscription,
@@ -486,7 +486,7 @@ export const deductUsage = async (
       if (isTeamPool) {
         await deductFromTeamBalance(organizationId!, userId, fromExtraUsage);
       } else {
-        await deductFromBalance(userId, fromExtraUsage);
+        await deductFromBalance(userId, fromExtraUsage, subscription);
       }
     }
   } catch (error) {


### PR DESCRIPTION
## Summary

- Set personal extra usage caps by subscription tier: Pro $200/month, Pro+ $600/month, Ultra $1,000/month.
- Thread the subscription tier through backend extra usage deduction so the server enforces the same cap the UI displays.
- Update extra usage UI surfaces to show the effective cap, including the lower of a user-set spending limit and the plan cap.

## Validation

- Passed: `pnpm exec eslint app/components/ExtraUsageSection.tsx app/components/SidebarUserNav.tsx app/components/usage/OnDemandUsageCard.tsx lib/extra-usage.ts lib/rate-limit/token-bucket.ts convex/extraUsage.ts convex/extraUsageActions.ts`
- Passed: `pnpm jest lib/__tests__/extra-usage.test.ts lib/rate-limit/__tests__/token-bucket.test.ts --runInBand`
- Full `pnpm typecheck` was attempted from a clean worktree, but it still fails on existing `packages/local` issues unrelated to this change: missing `ws`/`node-pty` type resolution and an implicit `any` in `packages/local/src/process-runner.ts`.

## Notes

The original local checkout has unrelated unresolved changes in `app/components/ContextUsageIndicator.tsx`, so this PR was prepared in a clean temporary worktree based on fresh `origin/main` to avoid touching that work.
