### PR TITLE
[codex] Limit ask uploads to ten files

### DIFF
--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -20,6 +20,7 @@ import {
   getAutoContinueChainAssistantIds,
   getMessagesUpToLastRealUser,
 } from "@/lib/utils/message-utils";
+import { getMaxFilesLimitForMode } from "@/lib/utils/file-utils";
 
 interface UseChatHandlersProps {
   chatId: string;
@@ -223,6 +224,14 @@ export const useChatHandlers = ({
     // Allow submission if there's text input or uploaded files
     const hasValidFiles = uploadedFiles.some((f) => f.uploaded && f.url);
     if (input.trim() || hasValidFiles) {
+      const maxFilesLimit = getMaxFilesLimitForMode(chatMode);
+      if (uploadedFiles.length > maxFilesLimit) {
+        toast.error("Cannot send files in this mode", {
+          description: `Maximum ${maxFilesLimit} files allowed. Please remove some files or switch modes.`,
+        });
+        return;
+      }
+
       // If streaming in Agent mode, check queue behavior
       if (status === "streaming") {
         const validFiles = uploadedFiles.filter(

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -284,14 +284,15 @@ export const useChatHandlers = ({
         }
       }
       // Check token limit before sending based on user plan
+      const currentChatMode = chatModeRef.current;
       const tokenCount = countInputTokens(input, uploadedFiles);
       const maxTokens = getMaxTokensForSubscription(subscription, {
-        mode: chatMode,
+        mode: currentChatMode,
       });
 
       // Additional validation for Ask mode: ensure files don't exceed Ask mode token limits
       // This prevents uploading files in Agent mode then switching to Ask mode to send them
-      if (chatMode === "ask" && uploadedFiles.length > 0) {
+      if (currentChatMode === "ask" && uploadedFiles.length > 0) {
         const fileTokens = uploadedFiles.reduce(
           (total, file) => total + (file.tokens || 0),
           0,
@@ -339,7 +340,7 @@ export const useChatHandlers = ({
           },
           {
             body: {
-              mode: chatModeRef.current,
+              mode: currentChatMode,
               todos,
               temporary: temporaryChatsEnabled,
               sandboxPreference,
@@ -355,7 +356,7 @@ export const useChatHandlers = ({
           { text: input },
           {
             body: {
-              mode: chatModeRef.current,
+              mode: currentChatMode,
               todos,
               temporary: temporaryChatsEnabled,
               sandboxPreference,

--- a/app/hooks/useFileUpload.ts
+++ b/app/hooks/useFileUpload.ts
@@ -4,7 +4,7 @@ import { useMutation, useAction } from "convex/react";
 import { ConvexError } from "convex/values";
 import { api } from "@/convex/_generated/api";
 import {
-  MAX_FILES_LIMIT,
+  getMaxFilesLimitForMode,
   validateFile,
   validateImageFile,
   createFileMessagePartFromUploadedFile,
@@ -22,6 +22,7 @@ const RATE_LIMIT_WARNING_THRESHOLD = 10;
 
 export const useFileUpload = (mode: ChatMode = "ask") => {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const maxFilesLimit = getMaxFilesLimitForMode(mode);
   const {
     uploadedFiles,
     addUploadedFile,
@@ -82,8 +83,8 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
       let filesToProcess = files;
       let truncated = false;
 
-      if (totalFiles > MAX_FILES_LIMIT) {
-        const remainingSlots = MAX_FILES_LIMIT - existingUploadedCount;
+      if (totalFiles > maxFilesLimit) {
+        const remainingSlots = maxFilesLimit - existingUploadedCount;
         if (remainingSlots <= 0) {
           return {
             validFiles: [],
@@ -127,7 +128,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
         processedCount: filesToProcess.length,
       };
     },
-    [uploadedFiles.length],
+    [uploadedFiles.length, maxFilesLimit],
   );
 
   // Helper function to show feedback messages
@@ -142,7 +143,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
       // Handle case where no slots are available
       if (!hasRemainingSlots) {
         toast.error(
-          `Maximum ${MAX_FILES_LIMIT} files allowed. Please remove some files before adding more.`,
+          `Maximum ${maxFilesLimit} files allowed. Please remove some files before adding more.`,
         );
         return;
       }
@@ -150,7 +151,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
       // Add truncation message
       if (result.truncated) {
         messages.push(
-          `Only ${result.processedCount} files were added. Maximum ${MAX_FILES_LIMIT} files allowed.`,
+          `Only ${result.processedCount} files were added. Maximum ${maxFilesLimit} files allowed.`,
         );
       }
 
@@ -166,7 +167,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
         toast.error(messages.join("\n\n"));
       }
     },
-    [],
+    [maxFilesLimit],
   );
 
   // Upload file to S3 storage
@@ -306,7 +307,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
 
       // Check if we have slots available
       const existingUploadedCount = uploadedFiles.length;
-      const remainingSlots = MAX_FILES_LIMIT - existingUploadedCount;
+      const remainingSlots = maxFilesLimit - existingUploadedCount;
       const hasRemainingSlots = remainingSlots > 0;
 
       // Show feedback messages
@@ -323,6 +324,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
       showProcessingFeedback,
       startFileUploads,
       uploadedFiles.length,
+      maxFilesLimit,
     ],
   );
 

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -31,61 +31,61 @@ describe("limitImageParts", () => {
     expect(result).toBe(messages); // same reference, no changes
   });
 
-  it("should return messages unchanged when exactly at the limit (20 images)", () => {
-    const parts = Array.from({ length: 20 }, (_, i) => makeFilePart(`f${i}`));
+  it("should return messages unchanged when exactly at the ask limit (10 images)", () => {
+    const parts = Array.from({ length: 10 }, (_, i) => makeFilePart(`f${i}`));
     const messages = [makeMessage("m1", "user", parts)];
-    const result = limitImageParts(messages);
+    const result = limitImageParts(messages, "ask");
     expect(result).toBe(messages);
   });
 
-  it("should remove oldest images when over the limit", () => {
-    const parts = Array.from({ length: 25 }, (_, i) => makeFilePart(`f${i}`));
+  it("should remove oldest images when over the ask limit", () => {
+    const parts = Array.from({ length: 15 }, (_, i) => makeFilePart(`f${i}`));
     const messages = [makeMessage("m1", "user", parts)];
-    const result = limitImageParts(messages);
+    const result = limitImageParts(messages, "ask");
 
     const remainingFiles = result[0].parts.filter(
       (p: any) => p.type === "file",
     );
-    expect(remainingFiles).toHaveLength(20);
-    // Should keep f5..f24 (the 20 most recent), removing f0..f4
+    expect(remainingFiles).toHaveLength(10);
+    // Should keep f5..f14 (the 10 most recent), removing f0..f4
     expect((remainingFiles[0] as any).fileId).toBe("f5");
-    expect((remainingFiles[19] as any).fileId).toBe("f24");
+    expect((remainingFiles[9] as any).fileId).toBe("f14");
   });
 
-  it("should remove oldest images across multiple messages", () => {
-    // 5 messages with 5 images each = 25 total, should keep last 20
-    const messages = Array.from({ length: 5 }, (_, msgIdx) => {
+  it("should remove oldest images across multiple messages in ask mode", () => {
+    // 3 messages with 5 images each = 15 total, should keep last 10
+    const messages = Array.from({ length: 3 }, (_, msgIdx) => {
       const parts = Array.from({ length: 5 }, (_, fileIdx) =>
         makeFilePart(`f${msgIdx * 5 + fileIdx}`),
       );
       return makeMessage(`m${msgIdx}`, "user", parts);
     });
 
-    const result = limitImageParts(messages);
+    const result = limitImageParts(messages, "ask");
 
     const allFiles = result.flatMap((msg) =>
       msg.parts.filter((p: any) => p.type === "file"),
     );
-    expect(allFiles).toHaveLength(20);
+    expect(allFiles).toHaveLength(10);
     // Oldest 5 images (f0..f4) from first message should be removed
     expect((allFiles[0] as any).fileId).toBe("f5");
-    expect((allFiles[19] as any).fileId).toBe("f24");
+    expect((allFiles[9] as any).fileId).toBe("f14");
   });
 
   it("should preserve non-file parts when removing images", () => {
     const parts: any[] = [
       { type: "text", text: "check these images" },
-      ...Array.from({ length: 22 }, (_, i) => makeFilePart(`f${i}`)),
+      ...Array.from({ length: 12 }, (_, i) => makeFilePart(`f${i}`)),
     ];
     const messages = [makeMessage("m1", "user", parts)];
-    const result = limitImageParts(messages);
+    const result = limitImageParts(messages, "ask");
 
     const textParts = result[0].parts.filter((p: any) => p.type === "text");
     const fileParts = result[0].parts.filter((p: any) => p.type === "file");
 
     expect(textParts).toHaveLength(1);
     expect((textParts[0] as any).text).toBe("check these images");
-    expect(fileParts).toHaveLength(20);
+    expect(fileParts).toHaveLength(10);
   });
 
   it("should handle messages with no parts", () => {
@@ -98,11 +98,11 @@ describe("limitImageParts", () => {
   });
 
   it("should only limit images, leaving PDFs and other file types untouched", () => {
-    const parts = Array.from({ length: 45 }, (_, i) =>
+    const parts = Array.from({ length: 25 }, (_, i) =>
       makeFilePart(`f${i}`, i % 2 === 0 ? "image/png" : "application/pdf"),
     );
     const messages = [makeMessage("m1", "user", parts)];
-    const result = limitImageParts(messages);
+    const result = limitImageParts(messages, "ask");
 
     const remainingFiles = result[0].parts.filter(
       (p: any) => p.type === "file",
@@ -114,10 +114,10 @@ describe("limitImageParts", () => {
       (p: any) => p.mediaType === "application/pdf",
     );
 
-    // All 22 PDFs should remain (odd indices: 1,3,5,...,43 = 22 PDFs)
-    expect(pdfs).toHaveLength(22);
-    // Only 20 most recent images should remain (even indices: 0,2,4,...,44 = 23 images, keep last 20)
-    expect(images).toHaveLength(20);
+    // All 12 PDFs should remain (odd indices: 1,3,5,...,23 = 12 PDFs)
+    expect(pdfs).toHaveLength(12);
+    // Only 10 most recent images should remain (even indices: 0,2,4,...,24 = 13 images, keep last 10)
+    expect(images).toHaveLength(10);
   });
 
   it("should not remove any files when all are non-image types", () => {
@@ -127,6 +127,26 @@ describe("limitImageParts", () => {
     const messages = [makeMessage("m1", "user", parts)];
     const result = limitImageParts(messages);
     expect(result).toBe(messages); // no images, nothing to limit
+  });
+
+  it("should allow 20 images in agent mode", () => {
+    const parts = Array.from({ length: 20 }, (_, i) => makeFilePart(`f${i}`));
+    const messages = [makeMessage("m1", "user", parts)];
+    const result = limitImageParts(messages, "agent");
+    expect(result).toBe(messages);
+  });
+
+  it("should remove oldest images only after the agent limit", () => {
+    const parts = Array.from({ length: 25 }, (_, i) => makeFilePart(`f${i}`));
+    const messages = [makeMessage("m1", "user", parts)];
+    const result = limitImageParts(messages, "agent");
+
+    const remainingFiles = result[0].parts.filter(
+      (p: any) => p.type === "file",
+    );
+    expect(remainingFiles).toHaveLength(20);
+    expect((remainingFiles[0] as any).fileId).toBe("f5");
+    expect((remainingFiles[19] as any).fileId).toBe("f24");
   });
 });
 

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -3,7 +3,10 @@ import type { ChatMode, SubscriptionTier, SelectedModel } from "@/types";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import { UIMessage } from "ai";
 import { processMessageFiles } from "@/lib/utils/file-transform-utils";
-import { isSupportedImageMediaType } from "@/lib/utils/file-utils";
+import {
+  getMaxFilesLimitForMode,
+  isSupportedImageMediaType,
+} from "@/lib/utils/file-utils";
 import {
   isAnthropicModel,
   resolveTierToProviderKey,
@@ -388,9 +391,11 @@ function stripOriginalContentFromMessages(messages: UIMessage[]): UIMessage[] {
  * Only counts image files — PDFs and other file types
  * are left untouched. Keeps the most recent images by removing the oldest ones first.
  */
-const MAX_IMAGES_PER_CONVERSATION = 20;
-
-export function limitImageParts(messages: UIMessage[]): UIMessage[] {
+export function limitImageParts(
+  messages: UIMessage[],
+  mode: ChatMode = "ask",
+): UIMessage[] {
+  const maxImagesPerConversation = getMaxFilesLimitForMode(mode);
   const imagePositions: Array<{ messageIndex: number; partIndex: number }> = [];
 
   for (let i = 0; i < messages.length; i++) {
@@ -407,19 +412,19 @@ export function limitImageParts(messages: UIMessage[]): UIMessage[] {
     });
   }
 
-  if (imagePositions.length <= MAX_IMAGES_PER_CONVERSATION) {
+  if (imagePositions.length <= maxImagesPerConversation) {
     return messages;
   }
 
-  const removedCount = imagePositions.length - MAX_IMAGES_PER_CONVERSATION;
+  const removedCount = imagePositions.length - maxImagesPerConversation;
   console.log(
-    `[limitImageParts] Removing ${removedCount} oldest image parts (${imagePositions.length} total, limit ${MAX_IMAGES_PER_CONVERSATION})`,
+    `[limitImageParts] Removing ${removedCount} oldest image parts (${imagePositions.length} total, limit ${maxImagesPerConversation})`,
   );
 
-  // Remove the oldest images, keep the last MAX_IMAGES_PER_CONVERSATION
+  // Remove the oldest images, keep the last maxImagesPerConversation.
   const toRemove = new Set(
     imagePositions
-      .slice(0, imagePositions.length - MAX_IMAGES_PER_CONVERSATION)
+      .slice(0, imagePositions.length - maxImagesPerConversation)
       .map(({ messageIndex, partIndex }) => `${messageIndex}:${partIndex}`),
   );
 
@@ -516,7 +521,10 @@ export async function processChatMessages({
 
   // Limit image parts before fetching URLs to avoid unnecessary S3 requests
   // Keep image attachment pruning aligned with the per-message upload cap.
-  const messagesWithLimitedFiles = limitImageParts(messagesWithoutUIOnlyParts);
+  const messagesWithLimitedFiles = limitImageParts(
+    messagesWithoutUIOnlyParts,
+    mode,
+  );
 
   // Process all file attachments: transform URLs, detect media/PDFs, and add document content
   const { messages: messagesWithUrls, sandboxFiles } =

--- a/lib/utils/file-utils.ts
+++ b/lib/utils/file-utils.ts
@@ -1,4 +1,5 @@
 import { FileMessagePart, UploadedFileState } from "@/types/file";
+import type { ChatMode } from "@/types/chat";
 
 /** Rate limit info returned from upload URL generation */
 export type RateLimitInfo = {
@@ -23,8 +24,20 @@ export const MAX_FILE_SIZE = 10 * 1024 * 1024;
  */
 export const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
 
+/** Maximum number of files allowed in Ask mode. */
+export const ASK_MODE_MAX_FILES_LIMIT = 10;
+
+/** Maximum number of files allowed in Agent mode. */
+export const AGENT_MODE_MAX_FILES_LIMIT = 20;
+
 /** Maximum number of files allowed to be uploaded at once */
-export const MAX_FILES_LIMIT = 20;
+export const MAX_FILES_LIMIT = AGENT_MODE_MAX_FILES_LIMIT;
+
+export function getMaxFilesLimitForMode(mode: ChatMode): number {
+  return mode === "agent"
+    ? AGENT_MODE_MAX_FILES_LIMIT
+    : ASK_MODE_MAX_FILES_LIMIT;
+}
 
 /** Supported image formats for AI processing */
 const SUPPORTED_IMAGE_TYPES = new Set([


### PR DESCRIPTION
## Summary

This PR makes file upload limits mode-aware:

- Ask mode now allows up to 10 uploaded files, matching Claude image constraints.
- Agent mode keeps the higher 20-file limit.
- Backend image pruning now uses the current chat mode so provider calls stay aligned with the composer limit.
- Sending is guarded when a user uploads more files in Agent mode and then switches back to Ask mode.

## Validation

- `pnpm jest lib/chat/__tests__/chat-processor.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint app/hooks/useChatHandlers.ts app/hooks/useFileUpload.ts lib/chat/chat-processor.ts lib/chat/__tests__/chat-processor.test.ts lib/utils/file-utils.ts`
- Commit hook: full `pnpm test` passed, 80 suites / 1061 tests

Note: `lib/ai/providers.ts` has an unrelated local unstaged change and is intentionally excluded from this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File upload limits now vary by chat mode: Ask = 10 files, Agent = 20 files.
  * Validation prevents submitting when uploaded files exceed the current mode's limit; user-facing messages show the correct max.

* **Bug Fixes**
  * Image attachment pruning and processing now respect mode-specific limits.

* **Tests**
  * Unit tests updated to cover mode-specific file/image limits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->