### PR TITLE
[codex] Use Gemini fallback in ask mode

### DIFF
--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -19,18 +19,50 @@ jest.mock("@/lib/logger", () => ({
 // Slugs the test asserts against. These match the registry in lib/ai/providers.ts.
 // If the registry slug for a model changes, update both places intentionally.
 const KIMI_SLUG = "moonshotai/kimi-k2.6:exacto";
+const GEMINI_SLUG = "google/gemini-3-flash-preview";
 
 describe("buildProviderOptions fallback chain", () => {
-  it("resolves Opus 4.6 chain to Kimi slug", () => {
-    const opts = buildProviderOptions(false, "user-1", "model-opus-4.6");
+  it("resolves Opus 4.6 ask chain to Gemini slug", () => {
+    const opts = buildProviderOptions(false, "user-1", "model-opus-4.6", "ask");
+    expect(opts.openrouter).toMatchObject({
+      models: [GEMINI_SLUG],
+      user: "user-1",
+    });
+  });
+
+  it("resolves Opus 4.6 agent chain to Kimi slug", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-opus-4.6",
+      "agent",
+    );
     expect(opts.openrouter).toMatchObject({
       models: [KIMI_SLUG],
       user: "user-1",
     });
   });
 
-  it("resolves Sonnet 4.6 chain to Kimi slug", () => {
-    const opts = buildProviderOptions(false, "user-1", "model-sonnet-4.6");
+  it("resolves Sonnet 4.6 ask chain to Gemini slug", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-sonnet-4.6",
+      "ask",
+    );
+    expect(opts.openrouter).toMatchObject({
+      models: [GEMINI_SLUG],
+      user: "user-1",
+    });
+  });
+
+  it("resolves Sonnet 4.6 agent chain to Kimi slug", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-sonnet-4.6",
+      "agent",
+    );
     expect(opts.openrouter).toMatchObject({
       models: [KIMI_SLUG],
       user: "user-1",
@@ -64,13 +96,23 @@ describe("buildProviderOptions fallback chain", () => {
   });
 
   it("includes reasoning settings independent of fallback chain", () => {
-    const reasoning = buildProviderOptions(true, "user-1", "model-opus-4.6");
+    const reasoning = buildProviderOptions(
+      true,
+      "user-1",
+      "model-opus-4.6",
+      "agent",
+    );
     expect(reasoning.openrouter).toMatchObject({
       reasoning: { enabled: true },
       models: [KIMI_SLUG],
     });
 
-    const noReasoning = buildProviderOptions(false, "user-1", "model-opus-4.6");
+    const noReasoning = buildProviderOptions(
+      false,
+      "user-1",
+      "model-opus-4.6",
+      "agent",
+    );
     expect(noReasoning.openrouter).toMatchObject({
       reasoning: { enabled: false },
       models: [KIMI_SLUG],

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -198,6 +198,7 @@ export async function createAgentStream(
       ctx.isReasoningModel,
       ctx.userId,
       modelName,
+      ctx.mode,
     ),
 
     prepareStep: async ({ steps, messages }) => {
@@ -235,6 +236,7 @@ export async function createAgentStream(
               ctx.isReasoningModel,
               ctx.userId,
               modelName,
+              ctx.mode,
             ),
           });
 
@@ -388,7 +390,7 @@ export async function createAgentStream(
       state.streamUsage = usage as Record<string, unknown>;
       state.responseModel = response?.modelId;
 
-      const fallbackSlugs = getFallbackSlugs(modelName);
+      const fallbackSlugs = getFallbackSlugs(modelName, ctx.mode);
       logOpenRouterFallbackIfFired({
         fallbackSlugs,
         requestedSlug,

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -449,17 +449,32 @@ export class SummarizationTracker {
  *
  * Claude chats are repaired for Anthropic-compatible message shapes before
  * this fallback can fire. If Opus/Sonnet still fails due to provider-side
- * issues, Kimi preserves agent availability.
+ * issues, use a mode-appropriate fallback: Kimi for agent, Gemini for ask.
  *
  * Keys and values are registry names (see lib/ai/providers.ts) — the actual
  * OpenRouter slugs are resolved at request-build time so this stays in sync
  * with the registry.
  */
 const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
-  "model-opus-4.6": ["model-kimi-k2.6"],
-  "model-sonnet-4.6": ["model-kimi-k2.6"],
   "ask-model-free": ["fallback-ask-model"],
   "agent-model-free": ["fallback-agent-model"],
+};
+
+const ANTHROPIC_FALLBACK_CHAIN_BY_MODE: Record<ChatMode, readonly ModelName[]> =
+  {
+    agent: ["model-kimi-k2.6"],
+    ask: ["model-gemini-3-flash"],
+  };
+
+const getFallbackKeys = (
+  modelName?: string,
+  mode?: ChatMode,
+): readonly ModelName[] | undefined => {
+  if (!modelName) return undefined;
+  if (modelName === "model-opus-4.6" || modelName === "model-sonnet-4.6") {
+    return ANTHROPIC_FALLBACK_CHAIN_BY_MODE[mode ?? "agent"];
+  }
+  return MODEL_FALLBACK_CHAIN[modelName as ModelName];
 };
 
 const resolveSlug = (modelName: string): string | undefined => {
@@ -480,10 +495,11 @@ const resolveSlug = (modelName: string): string | undefined => {
  * Resolve a model's fallback chain to OpenRouter slugs.
  * Returns an empty array if the model has no chain or all entries are stale.
  */
-export function getFallbackSlugs(modelName?: string): string[] {
-  const fallbackKeys = modelName
-    ? MODEL_FALLBACK_CHAIN[modelName as ModelName]
-    : undefined;
+export function getFallbackSlugs(
+  modelName?: string,
+  mode?: ChatMode,
+): string[] {
+  const fallbackKeys = getFallbackKeys(modelName, mode);
   return (
     fallbackKeys
       ?.map((key) => resolveSlug(key))
@@ -498,10 +514,11 @@ export function buildProviderOptions(
   isReasoningModel: boolean,
   userId?: string,
   modelName?: string,
+  mode?: ChatMode,
 ) {
   const modelId = modelName ? resolveSlug(modelName) : undefined;
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
-  const fallbackSlugs = getFallbackSlugs(modelName);
+  const fallbackSlugs = getFallbackSlugs(modelName, mode);
   return {
     openrouter: {
       ...(isReasoningModel


### PR DESCRIPTION
## Summary

This updates the OpenRouter fallback chain so Anthropic ask-mode requests fall back to Gemini instead of Kimi, while agent-mode requests keep the existing Kimi fallback.

## Why

Ask mode can include image and PDF file parts. Gemini is a better fallback for that path because it supports multimodal inputs, while the previous static fallback chain routed both `model-opus-4.6` and `model-sonnet-4.6` to `model-kimi-k2.6` regardless of chat mode.

## Changes

- Added mode-aware fallback resolution for `model-opus-4.6` and `model-sonnet-4.6`.
- Ask mode now falls back to `model-gemini-3-flash`.
- Agent mode keeps falling back to `model-kimi-k2.6`.
- Passed chat mode into provider option and fallback logging resolution.
- Updated fallback-chain tests for ask and agent behavior.

## Validation

- `npm test -- chat-stream-helpers-fallback.test.ts`
- `npm run typecheck`
- Commit hook: `npm run typecheck` and full `npm test` (`80 passed`, `1061 tests`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced fallback intelligence: Anthropic Opus and Sonnet 4.6 models now intelligently adapt their fallback model selection based on your active chat mode. When primary models become unavailable, these models automatically select the most appropriate alternative for your conversation type, ensuring better reliability and consistent performance across agent and ask modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->