### PR TITLE
[codex] Use Claude Opus 4.7

### DIFF
--- a/app/components/ModelSelector/__tests__/options-drift.test.ts
+++ b/app/components/ModelSelector/__tests__/options-drift.test.ts
@@ -48,10 +48,10 @@ describe("ModelSelector tier ↔ provider drift", () => {
       "model-sonnet-4.6",
     );
     expect(resolveTierToProviderKey("hackerai-max", "ask")).toBe(
-      "model-opus-4.6",
+      "model-opus-4.7",
     );
     expect(resolveTierToProviderKey("hackerai-max", "agent")).toBe(
-      "model-opus-4.6",
+      "model-opus-4.7",
     );
   });
 

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -29,7 +29,7 @@ export const ASK_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-max",
     label: "HackerAI Max",
     description: "Maximum intelligence for complex work",
-    poweredBy: "Claude Opus 4.6",
+    poweredBy: "Claude Opus 4.7",
   },
 ];
 
@@ -52,7 +52,7 @@ export const AGENT_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-max",
     label: "HackerAI Max",
     description: "Maximum intelligence for complex work",
-    poweredBy: "Claude Opus 4.6",
+    poweredBy: "Claude Opus 4.7",
     thinking: true,
   },
 ];

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -47,7 +47,7 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "model-sonnet-4.6": or("anthropic/claude-sonnet-4-6"),
     "model-gemini-3-flash": or("google/gemini-3-flash-preview"),
     "model-deepseek-v4-flash": or("deepseek/deepseek-v4-flash"),
-    "model-opus-4.6": or("anthropic/claude-opus-4.6"),
+    "model-opus-4.7": or("anthropic/claude-opus-4.7"),
     "model-kimi-k2.6": or("moonshotai/kimi-k2.6:exacto"),
     "fallback-agent-model": or("x-ai/grok-4.3"),
     "fallback-ask-model": or("x-ai/grok-4.3"),
@@ -67,7 +67,7 @@ export const modelCutoffDates: Record<ModelName, string> &
   "model-sonnet-4.6": "May 2025",
   "model-gemini-3-flash": "January 2025",
   "model-deepseek-v4-flash": "May 2025",
-  "model-opus-4.6": "May 2025",
+  "model-opus-4.7": "January 2026",
   "model-kimi-k2.6": "April 2024",
   "fallback-agent-model": "December 2025",
   "fallback-ask-model": "December 2025",
@@ -83,7 +83,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-sonnet-4.6": "Anthropic Claude Sonnet 4.6",
   "model-gemini-3-flash": "Google Gemini 3 Flash",
   "model-deepseek-v4-flash": "DeepSeek V4 Flash",
-  "model-opus-4.6": "Anthropic Claude Opus 4.6",
+  "model-opus-4.7": "Anthropic Claude Opus 4.7",
   "model-kimi-k2.6": "Moonshot Kimi K2.6",
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
   "fallback-ask-model": "Auto, an intelligent model router built by HackerAI",
@@ -128,7 +128,7 @@ export function resolveTierToProviderKey(
     case "hackerai-pro":
       return "model-sonnet-4.6";
     case "hackerai-max":
-      return "model-opus-4.6";
+      return "model-opus-4.7";
   }
 }
 

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -22,19 +22,19 @@ const KIMI_SLUG = "moonshotai/kimi-k2.6:exacto";
 const GEMINI_SLUG = "google/gemini-3-flash-preview";
 
 describe("buildProviderOptions fallback chain", () => {
-  it("resolves Opus 4.6 ask chain to Gemini slug", () => {
-    const opts = buildProviderOptions(false, "user-1", "model-opus-4.6", "ask");
+  it("resolves Opus 4.7 ask chain to Gemini slug", () => {
+    const opts = buildProviderOptions(false, "user-1", "model-opus-4.7", "ask");
     expect(opts.openrouter).toMatchObject({
       models: [GEMINI_SLUG],
       user: "user-1",
     });
   });
 
-  it("resolves Opus 4.6 agent chain to Kimi slug", () => {
+  it("resolves Opus 4.7 agent chain to Kimi slug", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
-      "model-opus-4.6",
+      "model-opus-4.7",
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
@@ -99,7 +99,7 @@ describe("buildProviderOptions fallback chain", () => {
     const reasoning = buildProviderOptions(
       true,
       "user-1",
-      "model-opus-4.6",
+      "model-opus-4.7",
       "agent",
     );
     expect(reasoning.openrouter).toMatchObject({
@@ -110,7 +110,7 @@ describe("buildProviderOptions fallback chain", () => {
     const noReasoning = buildProviderOptions(
       false,
       "user-1",
-      "model-opus-4.6",
+      "model-opus-4.7",
       "agent",
     );
     expect(noReasoning.openrouter).toMatchObject({

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -471,7 +471,7 @@ const getFallbackKeys = (
   mode?: ChatMode,
 ): readonly ModelName[] | undefined => {
   if (!modelName) return undefined;
-  if (modelName === "model-opus-4.6" || modelName === "model-sonnet-4.6") {
+  if (modelName === "model-opus-4.7" || modelName === "model-sonnet-4.6") {
     return ANTHROPIC_FALLBACK_CHAIN_BY_MODE[mode ?? "agent"];
   }
   return MODEL_FALLBACK_CHAIN[modelName as ModelName];

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -207,8 +207,8 @@ describe("selectModel", () => {
       );
     });
 
-    it("should map HackerAI Max to Opus 4.6", () => {
-      expect(selectModel("ask", "pro", "hackerai-max")).toBe("model-opus-4.6");
+    it("should map HackerAI Max to Opus 4.7", () => {
+      expect(selectModel("ask", "pro", "hackerai-max")).toBe("model-opus-4.7");
     });
   });
 
@@ -226,9 +226,9 @@ describe("selectModel", () => {
       );
     });
 
-    it("should map HackerAI Max to Opus 4.6 in agent mode", () => {
+    it("should map HackerAI Max to Opus 4.7 in agent mode", () => {
       expect(selectModel("agent", "pro", "hackerai-max")).toBe(
-        "model-opus-4.6",
+        "model-opus-4.7",
       );
     });
 

--- a/lib/chat/compaction/prune-tool-outputs.ts
+++ b/lib/chat/compaction/prune-tool-outputs.ts
@@ -570,7 +570,7 @@ const hasUsefulAssistantContent = (content: unknown): boolean => {
 
 /**
  * Anthropic treats a final assistant message in the prompt as an assistant
- * prefill. Claude Opus 4.6 / Sonnet 4.6 reject prefill, so before calling an
+ * prefill. Claude Opus 4.7 / Sonnet 4.6 reject prefill, so before calling an
  * Anthropic model we ensure the prompt does not end with assistant content.
  *
  * When the trailing assistant message has useful non-tool context, preserve it

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -23,7 +23,7 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   default: { input: 0.5, output: 3.0 },
   "model-sonnet-4.6": { input: 3.0, output: 15.0 },
   "model-gemini-3-flash": { input: 0.5, output: 3.0 },
-  "model-opus-4.6": { input: 5.0, output: 25.0 },
+  "model-opus-4.7": { input: 5.0, output: 25.0 },
   // "agent-model", "agent-model-free", and "model-kimi-k2.6" all route to
   // moonshotai/kimi-k2.6:exacto via lib/ai/providers.ts. Rates from Moonshot AI
   // direct provider (int4): $0.95 in / $4.00 out per 1M tokens. Cache-read

--- a/lib/utils/__tests__/client-storage.test.ts
+++ b/lib/utils/__tests__/client-storage.test.ts
@@ -36,6 +36,12 @@ describe("client-storage selected model", () => {
       expect(window.localStorage.getItem(STORAGE_KEY)).toBe("hackerai-max");
     });
 
+    it("migrates Opus 4.7 underlying-model ids to HackerAI Max", () => {
+      window.localStorage.setItem(STORAGE_KEY, "opus-4.7");
+      expect(readSelectedModel()).toBe("hackerai-max");
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe("hackerai-max");
+    });
+
     it("maps legacy gemini-3-flash and kimi-k2.6 both to hackerai-standard", () => {
       window.localStorage.setItem(STORAGE_KEY, "gemini-3-flash");
       expect(readSelectedModel()).toBe("hackerai-standard");

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -35,6 +35,7 @@ export const SELECTABLE_MODELS: readonly SelectedModel[] = [
 export const LEGACY_MODEL_ID_MAP: Record<string, SelectedModel> = {
   "sonnet-4.6": "hackerai-pro",
   "opus-4.6": "hackerai-max",
+  "opus-4.7": "hackerai-max",
   "gemini-3-flash": "hackerai-standard",
   "kimi-k2.6": "hackerai-standard",
   // Grok was removed from the picker before the tier rebrand. Both variants


### PR DESCRIPTION
## Summary

- Switch HackerAI Max from Claude Opus 4.6 to `anthropic/claude-opus-4.7`
- Update model display labels, fallback handling, pricing map keys, and storage migration coverage
- Refresh tests that assert Max tier routing and OpenRouter fallback behavior

## Validation

- `pnpm jest lib/api/__tests__/chat-stream-helpers-fallback.test.ts app/components/ModelSelector/__tests__/options-drift.test.ts lib/chat/__tests__/chat-processor.test.ts lib/utils/__tests__/client-storage.test.ts lib/rate-limit/__tests__/token-bucket.test.ts --runInBand`
- `pnpm typecheck`
- Precommit hook: `prettier --write`, `eslint --fix`, `pnpm typecheck`, `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Upgraded the "Max" tier model to Claude Opus 4.7 with a knowledge cutoff date of January 2026.

* **Chores**
  * Added pricing configuration and fallback support for the new model version.
  * Added migration handling for legacy model references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->