### PR TITLE
[codex] Compact oversized message saves

### DIFF
--- a/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
+++ b/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
@@ -5,6 +5,8 @@ import {
   pruneModelMessages,
   filterEmptyAssistantMessages,
   repairAnthropicModelMessages,
+  compactMessageForStorage,
+  estimateSerializedSizeBytes,
 } from "../prune-tool-outputs";
 
 // Helper to create a UIMessage with tool parts
@@ -690,6 +692,87 @@ describe("pruneToolOutputs", () => {
     expect(result.toolOutputCount).toBe(2);
     expect(result.totalToolOutputTokens).toBeGreaterThan(0);
     expect(result.tokensSaved).toBeGreaterThan(0);
+  });
+});
+
+describe("compactMessageForStorage", () => {
+  it("leaves small assistant messages unchanged", () => {
+    const message = makeAssistantMessage([
+      { type: "text", text: "small answer" },
+      makeToolPart(
+        "file",
+        { content: "ok", originalContent: "ok" },
+        { action: "read", path: "/tmp/a.txt" },
+      ),
+    ]);
+
+    const result = compactMessageForStorage(message, {
+      softLimitBytes: 10_000,
+    });
+
+    expect(result.compacted).toBe(false);
+    expect(result.message).toBe(message);
+    expect(result.prunedCount).toBe(0);
+  });
+
+  it("strips bulky UI-only file fields before storage", () => {
+    const message = makeAssistantMessage([
+      makeToolPart(
+        "file",
+        {
+          content: "latest content",
+          originalContent: "x".repeat(5000),
+          modifiedContent: "y".repeat(5000),
+        },
+        { action: "edit", path: "/tmp/a.txt" },
+      ),
+    ]);
+
+    const result = compactMessageForStorage(message, {
+      softLimitBytes: 1000,
+      toolOutputTokenBudget: 10_000,
+    });
+
+    const part = result.message.parts[0] as any;
+    expect(result.compacted).toBe(true);
+    expect(result.strippedUiOnlyFields).toBe(true);
+    expect(part.output).toEqual({ content: "latest content" });
+    expect(result.afterSizeBytes).toBeLessThan(result.beforeSizeBytes);
+  });
+
+  it("prunes old tool outputs when stripped parts are still too large", () => {
+    const message = makeAssistantMessage([
+      makeToolPart(
+        "file",
+        { content: "old ".repeat(2000) },
+        { action: "read", path: "/tmp/old.txt" },
+      ),
+      makeToolPart(
+        "file",
+        { content: "new ".repeat(2000) },
+        { action: "read", path: "/tmp/new.txt" },
+      ),
+    ]);
+
+    const result = compactMessageForStorage(message, {
+      softLimitBytes: 1000,
+      toolOutputTokenBudget: 100,
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.prunedCount).toBeGreaterThan(0);
+    expect(estimateSerializedSizeBytes(result.message.parts)).toBeLessThan(
+      estimateSerializedSizeBytes(message.parts),
+    );
+  });
+
+  it("does not compact user messages", () => {
+    const message = makeUserMessage("x".repeat(5000));
+
+    const result = compactMessageForStorage(message, { softLimitBytes: 100 });
+
+    expect(result.compacted).toBe(false);
+    expect(result.message).toBe(message);
   });
 });
 

--- a/lib/chat/compaction/prune-tool-outputs.ts
+++ b/lib/chat/compaction/prune-tool-outputs.ts
@@ -48,6 +48,18 @@ export interface PruneResult {
     | null;
 }
 
+export interface StorageCompactionResult<T extends UIMessage = UIMessage> {
+  message: T;
+  compacted: boolean;
+  beforeSizeBytes: number;
+  afterSizeBytes: number;
+  strippedUiOnlyFields: boolean;
+  prunedCount: number;
+}
+
+const STORAGE_MESSAGE_SOFT_LIMIT_BYTES = 850 * 1024;
+const STORAGE_TOOL_OUTPUT_TOKEN_BUDGET = 20_000;
+
 // ---------------------------------------------------------------------------
 // Placeholder builders per tool type
 // ---------------------------------------------------------------------------
@@ -145,6 +157,122 @@ const countOutputTokens = (output: unknown): number => {
   if (typeof output === "string") return countTokens(output);
   return countTokens(JSON.stringify(output));
 };
+
+export const estimateSerializedSizeBytes = (value: unknown): number =>
+  new TextEncoder().encode(JSON.stringify(value)).byteLength;
+
+const stripBulkyOutputFields = (part: ToolPart): ToolPart => {
+  if (!part || typeof part !== "object") return part;
+  const output = part.output;
+  if (!output || typeof output !== "object" || Array.isArray(output)) {
+    return part;
+  }
+
+  if (part.type === "tool-file") {
+    const { originalContent, modifiedContent, ...restOutput } =
+      output as Record<string, unknown>;
+
+    if (originalContent !== undefined || modifiedContent !== undefined) {
+      return { ...part, output: restOutput };
+    }
+  }
+
+  if (part.type === "tool-update_note") {
+    const { original, modified, ...restOutput } = output as Record<
+      string,
+      unknown
+    >;
+
+    if (original !== undefined || modified !== undefined) {
+      return { ...part, output: restOutput };
+    }
+  }
+
+  if (
+    part.type === "tool-run_terminal_cmd" ||
+    part.type === "tool-interact_terminal_session"
+  ) {
+    const { rawSnapshot, ...restOutput } = output as Record<string, unknown>;
+
+    if (rawSnapshot !== undefined) {
+      return { ...part, output: restOutput };
+    }
+  }
+
+  return part;
+};
+
+/**
+ * Compacts a single assistant UIMessage before database storage.
+ *
+ * Convex documents are capped at 1 MiB, so long agent runs can fail when a
+ * single assistant message accumulates many tool outputs. This preserves normal
+ * messages, then progressively removes UI-only bulk and old tool output detail
+ * once the serialized parts payload approaches the document limit.
+ */
+export function compactMessageForStorage<T extends UIMessage>(
+  message: T,
+  {
+    softLimitBytes = STORAGE_MESSAGE_SOFT_LIMIT_BYTES,
+    toolOutputTokenBudget = STORAGE_TOOL_OUTPUT_TOKEN_BUDGET,
+  }: {
+    softLimitBytes?: number;
+    toolOutputTokenBudget?: number;
+  } = {},
+): StorageCompactionResult<T> {
+  const beforeSizeBytes = estimateSerializedSizeBytes(message.parts);
+
+  if (message.role !== "assistant" || beforeSizeBytes <= softLimitBytes) {
+    return {
+      message,
+      compacted: false,
+      beforeSizeBytes,
+      afterSizeBytes: beforeSizeBytes,
+      strippedUiOnlyFields: false,
+      prunedCount: 0,
+    };
+  }
+
+  let strippedUiOnlyFields = false;
+  let parts = message.parts.map((part) => {
+    const stripped = stripBulkyOutputFields(part as ToolPart);
+    if (stripped !== part) strippedUiOnlyFields = true;
+    return stripped as UIMessage["parts"][number];
+  });
+
+  let afterSizeBytes = estimateSerializedSizeBytes(parts);
+  let prunedCount = 0;
+
+  if (afterSizeBytes > softLimitBytes) {
+    const pruneResult = pruneToolOutputs(
+      [{ ...message, parts }],
+      toolOutputTokenBudget,
+      0,
+    );
+    parts = pruneResult.messages[0]?.parts ?? parts;
+    prunedCount += pruneResult.prunedCount;
+    afterSizeBytes = estimateSerializedSizeBytes(parts);
+  }
+
+  if (afterSizeBytes > softLimitBytes) {
+    const pruneResult = pruneToolOutputs([{ ...message, parts }], 0, 0);
+    parts = pruneResult.messages[0]?.parts ?? parts;
+    prunedCount += pruneResult.prunedCount;
+    afterSizeBytes = estimateSerializedSizeBytes(parts);
+  }
+
+  const compacted =
+    strippedUiOnlyFields || prunedCount > 0 || afterSizeBytes < beforeSizeBytes;
+
+  return {
+    message: compacted ? ({ ...message, parts } as T) : message,
+    compacted,
+    beforeSizeBytes,
+    afterSizeBytes,
+    strippedUiOnlyFields,
+    prunedCount,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Main pruning function

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -16,6 +16,7 @@ import {
   truncateMessagesToTokenLimit,
 } from "@/lib/token-utils";
 import { fixIncompleteMessageParts } from "@/lib/chat/chat-processor";
+import { compactMessageForStorage } from "@/lib/chat/compaction/prune-tool-outputs";
 import type { SubscriptionTier, NoteCategory } from "@/types";
 import type { Id } from "@/convex/_generated/dataModel";
 import { v4 as uuidv4 } from "uuid";
@@ -96,9 +97,24 @@ export async function saveMessage({
       message.role === "assistant"
         ? fixIncompleteMessageParts(message.parts)
         : message.parts;
+    const storageSafeMessage =
+      message.role === "assistant"
+        ? compactMessageForStorage({ ...message, parts: fixedParts })
+        : null;
+    const storageSafeParts = storageSafeMessage?.message.parts ?? fixedParts;
+    if (storageSafeMessage?.compacted) {
+      console.info("[db] compacted assistant message before save", {
+        chatId,
+        messageId: message.id,
+        beforeSizeBytes: storageSafeMessage.beforeSizeBytes,
+        afterSizeBytes: storageSafeMessage.afterSizeBytes,
+        prunedCount: storageSafeMessage.prunedCount,
+        strippedUiOnlyFields: storageSafeMessage.strippedUiOnlyFields,
+      });
+    }
 
     // Extract file IDs from file parts
-    const fileIds = extractFileIdsFromParts(fixedParts);
+    const fileIds = extractFileIdsFromParts(storageSafeParts);
     const mergedFileIds = [
       ...fileIds,
       ...((extraFileIds || []).filter(Boolean) as string[]),
@@ -110,7 +126,7 @@ export async function saveMessage({
       chatId,
       userId,
       role: message.role,
-      parts: fixedParts,
+      parts: storageSafeParts,
       fileIds: mergedFileIds.length > 0 ? (mergedFileIds as any) : undefined,
       model,
       mode,


### PR DESCRIPTION
## Summary

Adds a storage-safety compaction step before saving assistant messages to Convex. Oversized assistant `parts` payloads now strip bulky UI-only fields and prune older tool outputs to compact placeholders before the `messages.saveMessage` mutation.

## Root cause

A long Trigger.dev agent run failed while saving the final assistant message because the serialized `parts` payload was about 1.1 MB. Convex documents have a 1 MiB limit, so storing many `tool-file` parts and reasoning blocks in one message can exceed the document ceiling even though model-context pruning has already run.

## Impact

Normal messages are unchanged. The compaction only activates for large assistant messages near the document limit, preserving recent tool detail while avoiding hard database write failures at the end of long agent runs.

## Validation

- `pnpm test -- lib/chat/compaction/__tests__/prune-tool-outputs.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- Commit hook: `tsc --noEmit`
- Commit hook: full `jest` suite, 76 suites / 1052 tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages are now automatically compacted before storage to improve efficiency.
  * Unnecessary UI-only fields in tool outputs are automatically stripped during storage.
  * Tool outputs are intelligently pruned when messages exceed size limits.

* **Tests**
  * Added comprehensive tests for the message compaction system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->