### PR TITLE
[codex] desktop local-first agent attachments

### DIFF
--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -96,15 +96,16 @@ export async function POST(req: NextRequest) {
           subscription,
         );
         let stagedSandbox: any = null;
-        const uploadResult = await uploadSandboxFiles(
-          sandboxFiles,
-          async () => {
+        let uploadResult: Awaited<ReturnType<typeof uploadSandboxFiles>>;
+        try {
+          uploadResult = await uploadSandboxFiles(sandboxFiles, async () => {
             const { sandbox } = await sandboxManager.getSandbox();
             stagedSandbox = sandbox;
             return sandbox;
-          },
-        );
-        await stagedSandbox?.close?.().catch(() => {});
+          });
+        } finally {
+          await stagedSandbox?.close?.().catch(() => {});
+        }
         if (uploadResult.failedCount > 0) {
           const noun =
             uploadResult.failedCount === 1 ? "attachment" : "attachments";

--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -15,6 +15,14 @@ import { assertFreeAgentGates } from "@/lib/api/chat-stream-helpers";
 import { coerceSelectedModel } from "@/types";
 import { ChatSDKError } from "@/lib/errors";
 import type { Todo, SandboxPreference, SelectedModel } from "@/types";
+import { HybridSandboxManager } from "@/lib/ai/tools/utils/hybrid-sandbox-manager";
+import {
+  getUploadBasePath,
+  hasLocalDesktopSourcePaths,
+  prepareLocalDesktopAttachmentsForTrigger,
+  stripLocalDesktopSourcePaths,
+  uploadSandboxFiles,
+} from "@/lib/utils/sandbox-file-utils";
 
 export const maxDuration = 30;
 
@@ -61,11 +69,60 @@ export async function POST(req: NextRequest) {
     const isNewChat =
       !temporary && !existingChat && !regenerate && !isAutoContinue;
 
+    let messagesForPersistence = stripLocalDesktopSourcePaths(messages);
+    let messagesForTrigger = messagesForPersistence;
+    let localDesktopAttachmentsPrepared = false;
+
+    if (hasLocalDesktopSourcePaths(messages)) {
+      if (sandboxPreference !== "desktop") {
+        throw new ChatSDKError(
+          "bad_request:api",
+          "Desktop-local attachments can only be used with the desktop sandbox.",
+        );
+      }
+
+      const { messages: preparedMessages, sandboxFiles } =
+        prepareLocalDesktopAttachmentsForTrigger(
+          messages,
+          getUploadBasePath("desktop"),
+        );
+      if (sandboxFiles.length > 0) {
+        const sandboxManager = new HybridSandboxManager(
+          userId,
+          () => {},
+          "desktop",
+          process.env.CONVEX_SERVICE_ROLE_KEY!,
+          null,
+          subscription,
+        );
+        let stagedSandbox: any = null;
+        const uploadResult = await uploadSandboxFiles(
+          sandboxFiles,
+          async () => {
+            const { sandbox } = await sandboxManager.getSandbox();
+            stagedSandbox = sandbox;
+            return sandbox;
+          },
+        );
+        await stagedSandbox?.close?.().catch(() => {});
+        if (uploadResult.failedCount > 0) {
+          const noun =
+            uploadResult.failedCount === 1 ? "attachment" : "attachments";
+          throw new ChatSDKError(
+            "bad_request:api",
+            `Failed to prepare ${uploadResult.failedCount} local ${noun}. Please reattach and try again.`,
+          );
+        }
+      }
+      messagesForTrigger = preparedMessages;
+      localDesktopAttachmentsPrepared = true;
+    }
+
     if (!temporary) {
       await handleInitialChatAndUserMessage({
         chatId,
         userId,
-        messages,
+        messages: messagesForPersistence,
         regenerate,
         chat: existingChat ?? null,
         isHidden: isAutoContinue ? true : undefined,
@@ -82,7 +139,8 @@ export async function POST(req: NextRequest) {
         userId,
         subscription,
         organizationId,
-        messages,
+        messages: messagesForTrigger,
+        localDesktopAttachmentsPrepared,
         baseTodos: Array.isArray(todos) ? todos : [],
         sandboxPreference,
         selectedModel: selectedModelOverride,

--- a/app/components/FilePartRenderer.tsx
+++ b/app/components/FilePartRenderer.tsx
@@ -363,6 +363,20 @@ const FilePartRendererComponent = ({
       // Use the fetched URL or the URL from props
       const actualUrl = fileUrl || part.url;
 
+      if (part.storage === "local-desktop") {
+        return (
+          <FilePreviewCard
+            partId={partId}
+            icon={<File className="h-6 w-6 text-white" />}
+            fileName={part.name || part.filename || "Local file"}
+            subtitle="Local-only attachment"
+            url={undefined}
+            storageId={undefined}
+            fileId={undefined}
+          />
+        );
+      }
+
       if (!actualUrl && !part.storageId && !part.fileId) {
         // Error state for files without URLs or storage references
         return (
@@ -461,7 +475,13 @@ const FilePartRendererComponent = ({
     const partId = `${messageId}-file-${partIndex}`;
 
     // Check if this is a file part with either URL, storageId, or fileId
-    if (part.url || part.storageId || part.fileId || fileUrl) {
+    if (
+      part.url ||
+      part.storageId ||
+      part.fileId ||
+      part.storage === "local-desktop" ||
+      fileUrl
+    ) {
       return <ConvexFilePart part={part} partId={partId} />;
     }
 
@@ -519,6 +539,8 @@ export const FilePartRenderer = memo(
       prevProps.totalFileParts === nextProps.totalFileParts &&
       prevProps.part.url === nextProps.part.url &&
       prevProps.part.storageId === nextProps.part.storageId &&
+      prevProps.part.storage === nextProps.part.storage &&
+      prevProps.part.localAttachmentId === nextProps.part.localAttachmentId &&
       prevProps.part.fileId === nextProps.part.fileId &&
       prevProps.part.s3Key === nextProps.part.s3Key &&
       prevProps.part.name === nextProps.part.name &&

--- a/app/components/FileUploadPreview.tsx
+++ b/app/components/FileUploadPreview.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { X, File, Loader2 } from "lucide-react";
+import { X, File as FileIcon, Loader2 } from "lucide-react";
 import { useEffect, useState, useCallback, useRef } from "react";
 import Image from "next/image";
 import {
@@ -16,7 +16,7 @@ import {
 } from "@/types/file";
 
 const isBrowserFile = (file: File | LocalDesktopFile): file is File =>
-  typeof File !== "undefined" && file instanceof File;
+  typeof globalThis.File !== "undefined" && file instanceof globalThis.File;
 
 export const FileUploadPreview = ({
   uploadedFiles,
@@ -198,7 +198,7 @@ export const FileUploadPreview = ({
                             ) : filePreview.error ? (
                               <X className="h-6 w-6 text-white" />
                             ) : (
-                              <File className="h-6 w-6 text-white" />
+                              <FileIcon className="h-6 w-6 text-white" />
                             )}
                           </div>
                           <div className="overflow-hidden flex-1">

--- a/app/components/FileUploadPreview.tsx
+++ b/app/components/FileUploadPreview.tsx
@@ -12,7 +12,11 @@ import {
   UploadedFileState,
   FileUploadPreviewProps,
   FilePreview,
+  LocalDesktopFile,
 } from "@/types/file";
+
+const isBrowserFile = (file: File | LocalDesktopFile): file is File =>
+  typeof File !== "undefined" && file instanceof File;
 
 export const FileUploadPreview = ({
   uploadedFiles,
@@ -45,7 +49,10 @@ export const FileUploadPreview = ({
         };
 
         // Generate base64 preview for images - this will show immediately while uploading
-        if (isImageFile(uploadedFile.file)) {
+        if (
+          isImageFile(uploadedFile.file) &&
+          isBrowserFile(uploadedFile.file)
+        ) {
           const fileKey = generateFileKey(uploadedFile.file);
           const cachedPreview = previewCache.current.get(fileKey);
 
@@ -207,7 +214,7 @@ export const FileUploadPreview = ({
                             >
                               {filePreview.error
                                 ? "Upload failed"
-                                : `Document • ${formatFileSize(filePreview.file.size)}`}
+                                : `${uploadedFiles[index]?.storage === "local-desktop" ? "Local file" : "Document"} • ${formatFileSize(filePreview.file.size)}`}
                             </div>
                           </div>
                         </div>

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1014,15 +1014,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
         sendMessage(
           {
             text: nextMessage.text,
-            files: nextMessage.files
-              ? nextMessage.files.map((f) => ({
-                  type: "file" as const,
-                  filename: f.file.name,
-                  mediaType: f.file.type,
-                  url: f.url,
-                  fileId: f.fileId,
-                }))
-              : undefined,
+            files: nextMessage.files as any,
           },
           {
             body: {

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -27,6 +27,7 @@ import {
   computeReplaceAssistantTodos,
 } from "@/lib/utils/todo-utils";
 import type { UploadedFileState } from "@/types/file";
+import type { FileMessagePart } from "@/types/file";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useSandboxPreference } from "@/app/hooks/useSandboxPreference";
 import { chatSidebarStorage } from "@/lib/utils/sidebar-storage";
@@ -99,10 +100,7 @@ interface GlobalStateType {
 
   // Message queue state (for Agent mode)
   messageQueue: QueuedMessage[];
-  queueMessage: (
-    text: string,
-    files?: Array<{ file: File; fileId: Id<"files">; url: string }>,
-  ) => void;
+  queueMessage: (text: string, files?: FileMessagePart[]) => void;
   removeQueuedMessage: (id: string) => void;
   clearQueue: () => void;
   dequeueNext: () => QueuedMessage | null;
@@ -540,10 +538,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
 
   // Message queue handlers
   const queueMessage = useCallback(
-    (
-      text: string,
-      files?: Array<{ file: File; fileId: Id<"files">; url: string }>,
-    ) => {
+    (text: string, files?: FileMessagePart[]) => {
       setMessageQueue((prev) => {
         // Limit queue size to 10 messages
         if (prev.length >= 10) {

--- a/app/hooks/__tests__/useFileUpload.local-desktop.test.tsx
+++ b/app/hooks/__tests__/useFileUpload.local-desktop.test.tsx
@@ -38,6 +38,8 @@ jest.mock("@/app/hooks/useTauri", () => ({
 }));
 
 describe("useFileUpload desktop-local agent attachments", () => {
+  const originalFetch = global.fetch;
+
   beforeEach(() => {
     jest.clearAllMocks();
     global.fetch = jest.fn().mockResolvedValue({ ok: true }) as any;
@@ -59,6 +61,10 @@ describe("useFileUpload desktop-local agent attachments", () => {
       fileId: "file_123",
       tokens: 10,
     });
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
   });
 
   it("uses Tauri file paths without calling S3 in desktop Agent mode", async () => {

--- a/app/hooks/__tests__/useFileUpload.local-desktop.test.tsx
+++ b/app/hooks/__tests__/useFileUpload.local-desktop.test.tsx
@@ -1,0 +1,118 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useFileUpload } from "../useFileUpload";
+import { getLocalFileMetadata, pickLocalFiles } from "@/app/hooks/useTauri";
+
+const addUploadedFile = jest.fn();
+const updateUploadedFile = jest.fn();
+const removeUploadedFile = jest.fn();
+const deleteFile = jest.fn();
+const saveFile = jest.fn();
+const generateS3UploadUrlAction = jest.fn();
+
+let globalState: any;
+
+jest.mock("convex/react", () => ({
+  useMutation: () => deleteFile,
+  useAction: (action: unknown) =>
+    String(action).includes("generateS3UploadUrlAction")
+      ? generateS3UploadUrlAction
+      : saveFile,
+}));
+
+jest.mock("@/convex/_generated/api", () => ({
+  api: {
+    fileStorage: { deleteFile: "deleteFile" },
+    fileActions: { saveFile: "saveFile" },
+    s3Actions: { generateS3UploadUrlAction: "generateS3UploadUrlAction" },
+  },
+}));
+
+jest.mock("../../contexts/GlobalState", () => ({
+  useGlobalState: () => globalState,
+}));
+
+jest.mock("@/app/hooks/useTauri", () => ({
+  isTauriEnvironment: jest.fn(() => true),
+  pickLocalFiles: jest.fn(),
+  getLocalFileMetadata: jest.fn(),
+}));
+
+describe("useFileUpload desktop-local agent attachments", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as any;
+    globalState = {
+      uploadedFiles: [],
+      addUploadedFile,
+      updateUploadedFile,
+      removeUploadedFile,
+      subscription: "pro",
+      getTotalTokens: jest.fn(() => 0),
+      sandboxPreference: "desktop",
+    };
+    generateS3UploadUrlAction.mockResolvedValue({
+      uploadUrl: "https://s3.example/upload",
+      s3Key: "users/u1/report.txt",
+    });
+    saveFile.mockResolvedValue({
+      url: "https://s3.example/download",
+      fileId: "file_123",
+      tokens: 10,
+    });
+  });
+
+  it("uses Tauri file paths without calling S3 in desktop Agent mode", async () => {
+    (pickLocalFiles as jest.Mock).mockResolvedValue([
+      "/Users/alice/report.txt",
+    ]);
+    (getLocalFileMetadata as jest.Mock).mockResolvedValue({
+      path: "/Users/alice/report.txt",
+      name: "report.txt",
+      mediaType: "text/plain",
+      size: 1024,
+      lastModified: 123,
+    });
+
+    const { result } = renderHook(() => useFileUpload("agent"));
+
+    act(() => {
+      result.current.handleAttachClick();
+    });
+
+    await waitFor(() => {
+      expect(addUploadedFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          uploaded: true,
+          uploading: false,
+          storage: "local-desktop",
+          localPath: "/Users/alice/report.txt",
+          localAttachmentId: expect.any(String),
+        }),
+      );
+    });
+    expect(generateS3UploadUrlAction).not.toHaveBeenCalled();
+    expect(saveFile).not.toHaveBeenCalled();
+  });
+
+  it("keeps the S3 upload path outside desktop Agent mode", async () => {
+    globalState.sandboxPreference = "e2b";
+    const file = new File(["hello"], "report.txt", { type: "text/plain" });
+    const { result } = renderHook(() => useFileUpload("agent"));
+
+    await act(async () => {
+      await result.current.handleFileUploadEvent({
+        target: { files: [file] },
+      } as any);
+    });
+
+    await waitFor(() => {
+      expect(generateS3UploadUrlAction).toHaveBeenCalledWith({
+        fileName: "report.txt",
+        contentType: "text/plain",
+      });
+    });
+    expect(addUploadedFile).toHaveBeenCalledWith(
+      expect.objectContaining({ uploading: true, uploaded: false }),
+    );
+  });
+});

--- a/app/hooks/__tests__/useFileUpload.local-desktop.test.tsx
+++ b/app/hooks/__tests__/useFileUpload.local-desktop.test.tsx
@@ -1,6 +1,10 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { useFileUpload } from "../useFileUpload";
-import { getLocalFileMetadata, pickLocalFiles } from "@/app/hooks/useTauri";
+import {
+  getLocalFileMetadata,
+  pickLocalFiles,
+  readLocalFile,
+} from "@/app/hooks/useTauri";
 
 const addUploadedFile = jest.fn();
 const updateUploadedFile = jest.fn();
@@ -35,6 +39,7 @@ jest.mock("@/app/hooks/useTauri", () => ({
   isTauriEnvironment: jest.fn(() => true),
   pickLocalFiles: jest.fn(),
   getLocalFileMetadata: jest.fn(),
+  readLocalFile: jest.fn(),
 }));
 
 describe("useFileUpload desktop-local agent attachments", () => {
@@ -98,6 +103,46 @@ describe("useFileUpload desktop-local agent attachments", () => {
     });
     expect(generateS3UploadUrlAction).not.toHaveBeenCalled();
     expect(saveFile).not.toHaveBeenCalled();
+  });
+
+  it("uploads desktop-selected images through S3 for preview and model visibility", async () => {
+    (pickLocalFiles as jest.Mock).mockResolvedValue(["/Users/alice/logo.svg"]);
+    (getLocalFileMetadata as jest.Mock).mockResolvedValue({
+      path: "/Users/alice/logo.svg",
+      name: "logo.svg",
+      mediaType: "image/svg+xml",
+      size: 36,
+      lastModified: 123,
+    });
+    (readLocalFile as jest.Mock).mockResolvedValue({
+      path: "/Users/alice/logo.svg",
+      name: "logo.svg",
+      mediaType: "image/svg+xml",
+      size: 36,
+      lastModified: 123,
+      base64: btoa("<svg xmlns='http://www.w3.org/2000/svg'></svg>"),
+    });
+
+    const { result } = renderHook(() => useFileUpload("agent"));
+
+    act(() => {
+      result.current.handleAttachClick();
+    });
+
+    await waitFor(() => {
+      expect(generateS3UploadUrlAction).toHaveBeenCalledWith({
+        fileName: "logo.svg",
+        contentType: "image/svg+xml",
+      });
+    });
+    expect(addUploadedFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uploading: true,
+        uploaded: false,
+        storage: "s3",
+      }),
+    );
+    expect(saveFile).toHaveBeenCalled();
   });
 
   it("keeps the S3 upload path outside desktop Agent mode", async () => {

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -5,6 +5,7 @@ import { useGlobalState } from "../contexts/GlobalState";
 import { useLatestRef } from "@/app/hooks/useLatestRef";
 import { isTauriEnvironment } from "@/app/hooks/useTauri";
 import { shouldUseAgentLongForAgent } from "@/lib/chat/agent-routing";
+import { isAgentMode } from "@/lib/utils/mode-helpers";
 import type { ChatMessage, ChatStatus } from "@/types";
 import { Id } from "@/convex/_generated/dataModel";
 import {
@@ -20,7 +21,10 @@ import {
   getAutoContinueChainAssistantIds,
   getMessagesUpToLastRealUser,
 } from "@/lib/utils/message-utils";
-import { getMaxFilesLimitForMode } from "@/lib/utils/file-utils";
+import {
+  createFileMessagePartFromUploadedFile,
+  getMaxFilesLimitForMode,
+} from "@/lib/utils/file-utils";
 
 interface UseChatHandlersProps {
   chatId: string;
@@ -84,7 +88,16 @@ export const useChatHandlers = ({
   // previous mode in the request body. Reading from a ref always gets the
   // latest value at the moment of the click.
   const chatModeRef = useLatestRef(chatMode);
+  const sandboxPreferenceRef = useLatestRef(sandboxPreference);
   const subscriptionRef = useLatestRef(subscription);
+
+  const isSendableUploadedFile = (file: (typeof uploadedFiles)[number]) =>
+    file.uploaded &&
+    !file.uploading &&
+    !file.error &&
+    (file.storage === "local-desktop"
+      ? !!file.localAttachmentId && !!file.localPath
+      : !!file.url && !!file.fileId);
 
   const deleteLastAssistantMessage = useMutation(
     api.messages.deleteLastAssistantMessage,
@@ -222,7 +235,7 @@ export const useChatHandlers = ({
       return;
     }
     // Allow submission if there's text input or uploaded files
-    const hasValidFiles = uploadedFiles.some((f) => f.uploaded && f.url);
+    const hasValidFiles = uploadedFiles.some(isSendableUploadedFile);
     if (input.trim() || hasValidFiles) {
       const maxFilesLimit = getMaxFilesLimitForMode(chatMode);
       if (uploadedFiles.length > maxFilesLimit) {
@@ -232,22 +245,32 @@ export const useChatHandlers = ({
         return;
       }
 
+      const currentChatMode = chatModeRef.current;
+      const hasLocalDesktopFiles = uploadedFiles.some(
+        (file) => file.storage === "local-desktop",
+      );
+      if (
+        hasLocalDesktopFiles &&
+        (!isAgentMode(currentChatMode) ||
+          sandboxPreferenceRef.current !== "desktop")
+      ) {
+        toast.error("Local attachments require desktop Agent mode", {
+          description:
+            "Switch back to Agent mode with the desktop sandbox or reattach the file for upload.",
+        });
+        return;
+      }
+
       // If streaming in Agent mode, check queue behavior
       if (status === "streaming") {
-        const validFiles = uploadedFiles.filter(
-          (file) => file.uploaded && file.url && file.fileId,
-        );
+        const validFiles = uploadedFiles
+          .filter(isSendableUploadedFile)
+          .map(createFileMessagePartFromUploadedFile)
+          .filter((part): part is NonNullable<typeof part> => part !== null);
 
         if (queueBehavior === "queue") {
           // Queue the message - will auto-send after current response completes
-          queueMessage(
-            input,
-            validFiles.map((f) => ({
-              file: f.file,
-              fileId: f.fileId! as Id<"files">,
-              url: f.url!,
-            })),
-          );
+          queueMessage(input, validFiles);
           clearInput();
           clearUploadedFiles();
           return;
@@ -284,7 +307,6 @@ export const useChatHandlers = ({
         }
       }
       // Check token limit before sending based on user plan
-      const currentChatMode = chatModeRef.current;
       const tokenCount = countInputTokens(input, uploadedFiles);
       const maxTokens = getMaxTokensForSubscription(subscription, {
         mode: currentChatMode,
@@ -320,23 +342,15 @@ export const useChatHandlers = ({
 
       try {
         // Get file objects from uploaded files - URLs are already resolved in global state
-        const validFiles = uploadedFiles.filter(
-          (file) => file.uploaded && file.url && file.fileId,
-        );
+        const validFiles = uploadedFiles
+          .filter(isSendableUploadedFile)
+          .map(createFileMessagePartFromUploadedFile)
+          .filter((part): part is NonNullable<typeof part> => part !== null);
 
         sendMessage(
           {
             text: input.trim() || undefined,
-            files:
-              validFiles.length > 0
-                ? validFiles.map((uploadedFile) => ({
-                    type: "file" as const,
-                    filename: uploadedFile.file.name,
-                    mediaType: uploadedFile.file.type,
-                    url: uploadedFile.url!,
-                    fileId: uploadedFile.fileId!,
-                  }))
-                : undefined,
+            files: validFiles.length > 0 ? validFiles : undefined,
           },
           {
             body: {
@@ -708,13 +722,7 @@ export const useChatHandlers = ({
 
       // Only add files if they exist
       if (validFiles.length > 0) {
-        messagePayload.files = validFiles.map((f) => ({
-          type: "file" as const,
-          filename: f.file.name,
-          mediaType: f.file.type,
-          url: f.url,
-          fileId: f.fileId,
-        }));
+        messagePayload.files = validFiles;
       }
 
       sendMessage(messagePayload, {

--- a/app/hooks/useFileUpload.ts
+++ b/app/hooks/useFileUpload.ts
@@ -37,7 +37,7 @@ const logLocalAttachmentDebug = (
 ) => {
   if (typeof window === "undefined") return;
   const enabled =
-    process.env.NODE_ENV !== "production" ||
+    process.env.NODE_ENV === "development" ||
     window.localStorage.getItem("hackerai:debug-local-attachments") === "1";
   if (!enabled) return;
   console.info(`[local-attachments] ${event}`, data);

--- a/app/hooks/useFileUpload.ts
+++ b/app/hooks/useFileUpload.ts
@@ -12,10 +12,20 @@ import {
   RateLimitInfo,
 } from "@/lib/utils/file-utils";
 import { getMaxFileTokens } from "@/lib/token-utils";
-import { FileProcessingResult, FileSource } from "@/types/file";
+import {
+  FileProcessingResult,
+  FileSource,
+  LocalDesktopFile,
+} from "@/types/file";
 import type { ChatMode } from "@/types/chat";
 import { useGlobalState } from "../contexts/GlobalState";
 import { Id } from "@/convex/_generated/dataModel";
+import { isAgentMode } from "@/lib/utils/mode-helpers";
+import {
+  getLocalFileMetadata,
+  isTauriEnvironment,
+  pickLocalFiles,
+} from "./useTauri";
 
 // Show warning when remaining uploads are at or below this threshold
 const RATE_LIMIT_WARNING_THRESHOLD = 10;
@@ -30,6 +40,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
     removeUploadedFile,
     subscription,
     getTotalTokens,
+    sandboxPreference,
   } = useGlobalState();
 
   // Drag and drop state
@@ -45,6 +56,11 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
   const generateS3UploadUrlAction = useAction(
     api.s3Actions.generateS3UploadUrlAction,
   );
+
+  const shouldUseLocalDesktopAttachments =
+    isTauriEnvironment() &&
+    isAgentMode(mode) &&
+    sandboxPreference === "desktop";
 
   // Helper to show rate limit warning (throttled to once per minute)
   const showRateLimitWarning = useCallback((rateLimit: RateLimitInfo) => {
@@ -294,6 +310,86 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
     [uploadedFiles.length, addUploadedFile, uploadFileToS3],
   );
 
+  const startLocalDesktopFiles = useCallback(
+    (files: Array<LocalDesktopFile & { path: string }>) => {
+      files.forEach((file) => {
+        addUploadedFile({
+          file: {
+            name: file.name,
+            type: file.type,
+            size: file.size,
+            lastModified: file.lastModified,
+          },
+          uploading: false,
+          uploaded: true,
+          storage: "local-desktop",
+          localAttachmentId:
+            typeof crypto !== "undefined" && crypto.randomUUID
+              ? crypto.randomUUID()
+              : `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+          localPath: file.path,
+          tokens: 0,
+        });
+      });
+    },
+    [addUploadedFile],
+  );
+
+  const processLocalDesktopPaths = useCallback(
+    async (paths: string[]) => {
+      if (subscription === "free") {
+        toast.error("Upgrade plan to upload files.");
+        return;
+      }
+
+      const existingUploadedCount = uploadedFiles.length;
+      const remainingSlots = maxFilesLimit - existingUploadedCount;
+      if (remainingSlots <= 0) {
+        toast.error(
+          `Maximum ${maxFilesLimit} files allowed. Please remove some files before adding more.`,
+        );
+        return;
+      }
+
+      const selectedPaths = paths.slice(0, remainingSlots);
+      if (paths.length > selectedPaths.length) {
+        toast.error(
+          `Only ${selectedPaths.length} files were added. Maximum ${maxFilesLimit} files allowed.`,
+        );
+      }
+
+      const validFiles: Array<LocalDesktopFile & { path: string }> = [];
+      const invalidFiles: string[] = [];
+
+      for (const path of selectedPaths) {
+        const metadata = await getLocalFileMetadata(path);
+        if (!metadata) continue;
+
+        const file = {
+          path: metadata.path,
+          name: metadata.name,
+          type: metadata.mediaType || "application/octet-stream",
+          size: metadata.size,
+          lastModified: metadata.lastModified || Date.now(),
+        };
+        const validation = validateFile(file);
+        if (!validation.valid) {
+          invalidFiles.push(`${file.name}: ${validation.error}`);
+          continue;
+        }
+        validFiles.push(file);
+      }
+
+      if (invalidFiles.length > 0) {
+        toast.error(`Some files were invalid:\n${invalidFiles.join("\n")}`);
+      }
+      if (validFiles.length > 0) {
+        startLocalDesktopFiles(validFiles);
+      }
+    },
+    [subscription, uploadedFiles.length, maxFilesLimit, startLocalDesktopFiles],
+  );
+
   // Unified file processing function
   const processFiles = useCallback(
     async (files: File[], source: FileSource) => {
@@ -346,7 +442,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
     const uploadedFile = uploadedFiles[indexToRemove];
 
     // If the file was uploaded to Convex, delete it from storage
-    if (uploadedFile?.fileId) {
+    if (uploadedFile?.fileId && uploadedFile.storage !== "local-desktop") {
       try {
         await deleteFile({
           fileId: uploadedFile.fileId as Id<"files">,
@@ -362,6 +458,14 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
   };
 
   const handleAttachClick = () => {
+    if (shouldUseLocalDesktopAttachments) {
+      pickLocalFiles().then((paths) => {
+        if (paths.length > 0) {
+          processLocalDesktopPaths(paths);
+        }
+      });
+      return;
+    }
     fileInputRef.current?.click();
   };
 

--- a/app/hooks/useFileUpload.ts
+++ b/app/hooks/useFileUpload.ts
@@ -42,6 +42,9 @@ const logLocalAttachmentDebug = (
   console.info(`[local-attachments] ${event}`, data);
 };
 
+const getFilenameFromPath = (path: string) =>
+  path.split(/[\\/]/).filter(Boolean).pop() || "selected file";
+
 export const useFileUpload = (mode: ChatMode = "ask") => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const maxFilesLimit = getMaxFilesLimitForMode(mode);
@@ -386,8 +389,25 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
       const invalidFiles: string[] = [];
 
       for (const path of selectedPaths) {
-        const metadata = await getLocalFileMetadata(path);
-        if (!metadata) continue;
+        let metadata: Awaited<ReturnType<typeof getLocalFileMetadata>>;
+        try {
+          metadata = await getLocalFileMetadata(path);
+        } catch (error) {
+          logLocalAttachmentDebug("local-metadata-error", {
+            fileName: getFilenameFromPath(path),
+            error: error instanceof Error ? error.message : String(error),
+          });
+          invalidFiles.push(
+            `${getFilenameFromPath(path)}: could not read file metadata`,
+          );
+          continue;
+        }
+        if (!metadata) {
+          invalidFiles.push(
+            `${getFilenameFromPath(path)}: could not read file metadata`,
+          );
+          continue;
+        }
 
         const file = {
           path: metadata.path,
@@ -497,14 +517,21 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
     });
 
     if (shouldUseLocalDesktopAttachments) {
-      pickLocalFiles().then((paths) => {
-        logLocalAttachmentDebug("local-picker-result", {
-          selectedCount: paths.length,
+      pickLocalFiles()
+        .then(async (paths) => {
+          logLocalAttachmentDebug("local-picker-result", {
+            selectedCount: paths.length,
+          });
+          if (paths.length > 0) {
+            await processLocalDesktopPaths(paths);
+          }
+        })
+        .catch((error) => {
+          logLocalAttachmentDebug("local-picker-error", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          toast.error("Failed to open file picker");
         });
-        if (paths.length > 0) {
-          processLocalDesktopPaths(paths);
-        }
-      });
       return;
     }
     fileInputRef.current?.click();

--- a/app/hooks/useFileUpload.ts
+++ b/app/hooks/useFileUpload.ts
@@ -25,6 +25,7 @@ import {
   getLocalFileMetadata,
   isTauriEnvironment,
   pickLocalFiles,
+  readLocalFile,
 } from "./useTauri";
 
 // Show warning when remaining uploads are at or below this threshold
@@ -44,6 +45,23 @@ const logLocalAttachmentDebug = (
 
 const getFilenameFromPath = (path: string) =>
   path.split(/[\\/]/).filter(Boolean).pop() || "selected file";
+
+const fileFromBase64 = (
+  base64: string,
+  name: string,
+  type: string,
+  lastModified: number,
+): File => {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new File([bytes], name, {
+    type: type || "application/octet-stream",
+    lastModified,
+  });
+};
 
 export const useFileUpload = (mode: ChatMode = "ask") => {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -307,6 +325,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
       updateUploadedFile,
       showRateLimitWarning,
       mode,
+      sandboxPreference,
       subscription,
     ],
   );
@@ -331,15 +350,36 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
     [uploadedFiles.length, addUploadedFile, uploadFileToS3],
   );
 
-  const startLocalDesktopFiles = useCallback(
-    (files: Array<LocalDesktopFile & { path: string }>) => {
-      files.forEach((file) => {
+  const startDesktopSelectedFiles = useCallback(
+    (
+      files: Array<
+        | {
+            storage: "local-desktop";
+            file: LocalDesktopFile & { path: string };
+          }
+        | { storage: "s3"; file: File }
+      >,
+    ) => {
+      const startingIndex = uploadedFiles.length;
+
+      files.forEach((entry, index) => {
+        if (entry.storage === "s3") {
+          addUploadedFile({
+            file: entry.file,
+            uploading: true,
+            uploaded: false,
+            storage: "s3",
+          });
+          uploadFileToS3(entry.file, startingIndex + index);
+          return;
+        }
+
         addUploadedFile({
           file: {
-            name: file.name,
-            type: file.type,
-            size: file.size,
-            lastModified: file.lastModified,
+            name: entry.file.name,
+            type: entry.file.type,
+            size: entry.file.size,
+            lastModified: entry.file.lastModified,
           },
           uploading: false,
           uploaded: true,
@@ -348,18 +388,18 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
             typeof crypto !== "undefined" && crypto.randomUUID
               ? crypto.randomUUID()
               : `${Date.now()}-${Math.random().toString(36).slice(2)}`,
-          localPath: file.path,
+          localPath: entry.file.path,
           tokens: 0,
         });
         logLocalAttachmentDebug("local-file-added", {
-          fileName: file.name,
-          mediaType: file.type,
-          size: file.size,
-          hasLocalPath: Boolean(file.path),
+          fileName: entry.file.name,
+          mediaType: entry.file.type,
+          size: entry.file.size,
+          hasLocalPath: Boolean(entry.file.path),
         });
       });
     },
-    [addUploadedFile],
+    [addUploadedFile, uploadFileToS3, uploadedFiles.length],
   );
 
   const processLocalDesktopPaths = useCallback(
@@ -385,7 +425,13 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
         );
       }
 
-      const validFiles: Array<LocalDesktopFile & { path: string }> = [];
+      const validFiles: Array<
+        | {
+            storage: "local-desktop";
+            file: LocalDesktopFile & { path: string };
+          }
+        | { storage: "s3"; file: File }
+      > = [];
       const invalidFiles: string[] = [];
 
       for (const path of selectedPaths) {
@@ -427,17 +473,44 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
           invalidFiles.push(`${file.name}: ${validation.error}`);
           continue;
         }
-        validFiles.push(file);
+
+        if (isImageFile(file)) {
+          const localFileData = await readLocalFile(path);
+          if (!localFileData) {
+            invalidFiles.push(`${file.name}: could not read image file`);
+            continue;
+          }
+          const browserFile = fileFromBase64(
+            localFileData.base64,
+            localFileData.name,
+            localFileData.mediaType || "application/octet-stream",
+            localFileData.lastModified || Date.now(),
+          );
+          const imageValidation = await validateImageFile(browserFile);
+          if (!imageValidation.valid) {
+            invalidFiles.push(`${browserFile.name}: ${imageValidation.error}`);
+            continue;
+          }
+          validFiles.push({ storage: "s3", file: browserFile });
+          continue;
+        }
+
+        validFiles.push({ storage: "local-desktop", file });
       }
 
       if (invalidFiles.length > 0) {
         toast.error(`Some files were invalid:\n${invalidFiles.join("\n")}`);
       }
       if (validFiles.length > 0) {
-        startLocalDesktopFiles(validFiles);
+        startDesktopSelectedFiles(validFiles);
       }
     },
-    [subscription, uploadedFiles.length, maxFilesLimit, startLocalDesktopFiles],
+    [
+      subscription,
+      uploadedFiles.length,
+      maxFilesLimit,
+      startDesktopSelectedFiles,
+    ],
   );
 
   // Unified file processing function

--- a/app/hooks/useFileUpload.ts
+++ b/app/hooks/useFileUpload.ts
@@ -30,6 +30,18 @@ import {
 // Show warning when remaining uploads are at or below this threshold
 const RATE_LIMIT_WARNING_THRESHOLD = 10;
 
+const logLocalAttachmentDebug = (
+  event: string,
+  data: Record<string, unknown>,
+) => {
+  if (typeof window === "undefined") return;
+  const enabled =
+    process.env.NODE_ENV !== "production" ||
+    window.localStorage.getItem("hackerai:debug-local-attachments") === "1";
+  if (!enabled) return;
+  console.info(`[local-attachments] ${event}`, data);
+};
+
 export const useFileUpload = (mode: ChatMode = "ask") => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const maxFilesLimit = getMaxFilesLimitForMode(mode);
@@ -190,6 +202,12 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
   const uploadFileToS3 = useCallback(
     async (file: File, uploadIndex: number) => {
       try {
+        logLocalAttachmentDebug("s3-upload-start", {
+          fileName: file.name,
+          mode,
+          sandboxPreference,
+        });
+
         // Step 1: Generate presigned S3 upload URL
         const { uploadUrl, s3Key, rateLimit } = await generateS3UploadUrlAction(
           {
@@ -330,6 +348,12 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
           localPath: file.path,
           tokens: 0,
         });
+        logLocalAttachmentDebug("local-file-added", {
+          fileName: file.name,
+          mediaType: file.type,
+          size: file.size,
+          hasLocalPath: Boolean(file.path),
+        });
       });
     },
     [addUploadedFile],
@@ -372,6 +396,12 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
           size: metadata.size,
           lastModified: metadata.lastModified || Date.now(),
         };
+        logLocalAttachmentDebug("local-metadata-read", {
+          fileName: file.name,
+          mediaType: file.type,
+          size: file.size,
+          hasLocalPath: Boolean(file.path),
+        });
         const validation = validateFile(file);
         if (!validation.valid) {
           invalidFiles.push(`${file.name}: ${validation.error}`);
@@ -458,8 +488,19 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
   };
 
   const handleAttachClick = () => {
+    const isTauri = isTauriEnvironment();
+    logLocalAttachmentDebug("attach-click", {
+      isTauri,
+      mode,
+      sandboxPreference,
+      shouldUseLocalDesktopAttachments,
+    });
+
     if (shouldUseLocalDesktopAttachments) {
       pickLocalFiles().then((paths) => {
+        logLocalAttachmentDebug("local-picker-result", {
+          selectedCount: paths.length,
+        });
         if (paths.length > 0) {
           processLocalDesktopPaths(paths);
         }

--- a/app/hooks/useTauri.ts
+++ b/app/hooks/useTauri.ts
@@ -101,6 +101,10 @@ export type LocalFileMetadata = {
   lastModified: number;
 };
 
+export type LocalFileData = LocalFileMetadata & {
+  base64: string;
+};
+
 export async function pickLocalFiles(): Promise<string[]> {
   if (!detectTauri()) return [];
 
@@ -132,6 +136,23 @@ export async function getLocalFileMetadata(
   } catch (err) {
     console.error("[Tauri] Failed to read local file metadata:", err);
     toast.error("Failed to read local file metadata");
+    return null;
+  }
+}
+
+export async function readLocalFile(
+  path: string,
+): Promise<LocalFileData | null> {
+  if (!detectTauri()) return null;
+
+  try {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<LocalFileData>("read_local_file", {
+      path,
+    });
+  } catch (err) {
+    console.error("[Tauri] Failed to read local file:", err);
+    toast.error("Failed to read local file");
     return null;
   }
 }

--- a/app/hooks/useTauri.ts
+++ b/app/hooks/useTauri.ts
@@ -93,6 +93,49 @@ export async function getCmdServerInfo(): Promise<{
   }
 }
 
+export type LocalFileMetadata = {
+  path: string;
+  name: string;
+  mediaType: string;
+  size: number;
+  lastModified: number;
+};
+
+export async function pickLocalFiles(): Promise<string[]> {
+  if (!detectTauri()) return [];
+
+  try {
+    const dialog = await import("@tauri-apps/plugin-dialog");
+    const selected = await dialog.open({
+      multiple: true,
+      directory: false,
+    });
+    if (!selected) return [];
+    return Array.isArray(selected) ? selected : [selected];
+  } catch (err) {
+    console.error("[Tauri] Failed to pick local files:", err);
+    toast.error("Failed to open file picker");
+    return [];
+  }
+}
+
+export async function getLocalFileMetadata(
+  path: string,
+): Promise<LocalFileMetadata | null> {
+  if (!detectTauri()) return null;
+
+  try {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<LocalFileMetadata>("get_local_file_metadata", {
+      path,
+    });
+  } catch (err) {
+    console.error("[Tauri] Failed to read local file metadata:", err);
+    toast.error("Failed to read local file metadata");
+    return null;
+  }
+}
+
 /**
  * Reveal a file or folder in the OS file manager (Finder/Explorer).
  */

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -791,6 +791,34 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
       return result.stdout;
     },
 
+    copyLocal: async (
+      sourceRawPath: string,
+      destRawPath: string,
+    ): Promise<void> => {
+      const sourceCtx = await this.shellContext(sourceRawPath);
+      const destCtx = await this.shellContext(destRawPath);
+      const fileName = destCtx.path.split(/[/\\]/).pop() || "file";
+      const dir = CentrifugoSandbox.parentDir(destCtx.path);
+
+      const mkdirPart = !dir
+        ? ""
+        : destCtx.useBash
+          ? `mkdir -p ${destCtx.escapePath(dir)} &&`
+          : `if not exist ${destCtx.escapePath(dir)} mkdir ${destCtx.escapePath(dir)} &&`;
+      const copyPart = destCtx.useBash
+        ? `cp -f ${sourceCtx.escapePath(sourceCtx.path)} ${destCtx.escapePath(destCtx.path)}`
+        : `copy /Y ${sourceCtx.escapePath(sourceCtx.path)} ${destCtx.escapePath(destCtx.path)} >nul`;
+
+      const result = await this.commands.run(`${mkdirPart} ${copyPart}`, {
+        displayName: `Preparing: ${fileName}`,
+      });
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `Failed to prepare local file: ${result.stderr || result.stdout}`,
+        );
+      }
+    },
+
     remove: async (rawPath: string): Promise<void> => {
       const { useBash, path, escapePath } = await this.shellContext(rawPath);
       const fileName = path.split(/[/\\]/).pop() || "file";

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -80,6 +80,7 @@ import { createTrackedProvider } from "@/lib/ai/providers";
 import {
   uploadSandboxFiles,
   getUploadBasePath,
+  stripLocalDesktopSourcePaths,
 } from "@/lib/utils/sandbox-file-utils";
 import { after } from "next/server";
 import { createResumableStreamContext } from "resumable-stream";
@@ -219,7 +220,7 @@ export const createChatHandler = (
         await handleInitialChatAndUserMessage({
           chatId,
           userId,
-          messages: truncatedMessages,
+          messages: stripLocalDesktopSourcePaths(truncatedMessages),
           regenerate,
           chat,
           isHidden: isAutoContinue ? true : undefined,
@@ -243,6 +244,8 @@ export const createChatHandler = (
           subscription,
           uploadBasePath,
           modelOverride: selectedModelOverride,
+          allowLocalDesktopFiles:
+            isAgentMode(mode) && sandboxPreference === "desktop",
         });
 
       // Empty after processing → Gemini rejects with "must include at least one parts field".

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -434,7 +434,12 @@ export const createChatHandler = (
           }
 
           if (isAgentMode(mode) && sandboxFiles && sandboxFiles.length > 0) {
-            writeUploadStartStatus(writer);
+            writeUploadStartStatus(
+              writer,
+              sandboxFiles.every((file) => file.kind === "localPath")
+                ? "Preparing local attachments on your computer"
+                : "Uploading attachments to the computer",
+            );
             let uploadResult: { failedCount: number } = { failedCount: 0 };
             try {
               uploadResult = await uploadSandboxFiles(

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -509,12 +509,14 @@ export async function processChatMessages({
   subscription,
   uploadBasePath,
   modelOverride,
+  allowLocalDesktopFiles = false,
 }: {
   messages: UIMessage[];
   mode: ChatMode;
   subscription: SubscriptionTier;
   uploadBasePath?: string;
   modelOverride?: SelectedModel;
+  allowLocalDesktopFiles?: boolean;
 }) {
   // Filter out UI-only parts (data-summarization) that AI providers don't understand
   const messagesWithoutUIOnlyParts = messages.map(filterUIOnlyParts);
@@ -533,6 +535,7 @@ export async function processChatMessages({
       mode,
       uploadBasePath,
       subscription,
+      allowLocalDesktopFiles,
     );
 
   // Fix incomplete tool invocations and reasoning (from interrupted streams) before filtering.

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -89,4 +89,40 @@ describe("desktop-local sandbox file helpers", () => {
     );
     expect(downloadFromUrl).not.toHaveBeenCalled();
   });
+
+  it("redacts desktop source paths from staging failure logs", async () => {
+    const sourcePath = "/Users/alice/Secrets/report.pdf";
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      await uploadSandboxFiles(
+        [
+          {
+            kind: "localPath",
+            path: sourcePath,
+            localPath: "/tmp/hackerai-upload/report.pdf",
+          },
+        ],
+        async () => ({
+          files: {
+            copyLocal: jest
+              .fn()
+              .mockRejectedValue(
+                new Error(`Failed to copy ${sourcePath}: permission denied`),
+              ),
+          },
+        }),
+      );
+
+      const logged = consoleErrorSpy.mock.calls
+        .map((call) => JSON.stringify(call))
+        .join("\n");
+      expect(logged).not.toContain(sourcePath);
+      expect(logged).toContain("[redacted-local-path]");
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
 });

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -1,0 +1,92 @@
+jest.mock("server-only", () => ({}), { virtual: true });
+
+import type { UIMessage } from "ai";
+import {
+  prepareLocalDesktopAttachmentsForTrigger,
+  stripLocalDesktopSourcePaths,
+  uploadSandboxFiles,
+} from "../sandbox-file-utils";
+
+const makeLocalMessage = (): UIMessage =>
+  ({
+    id: "m1",
+    role: "user",
+    parts: [
+      { type: "text", text: "inspect this" },
+      {
+        type: "file",
+        storage: "local-desktop",
+        localAttachmentId: "local-1",
+        localPath: "/Users/alice/Secrets/report.pdf",
+        name: "report.pdf",
+        mediaType: "application/pdf",
+        size: 123,
+      },
+    ],
+  }) as UIMessage;
+
+describe("desktop-local sandbox file helpers", () => {
+  it("removes source paths before persistence", () => {
+    const [message] = stripLocalDesktopSourcePaths([makeLocalMessage()]);
+
+    const filePart = message.parts?.find((part: any) => part.type === "file");
+    expect(filePart).toMatchObject({
+      type: "file",
+      storage: "local-desktop",
+      localAttachmentId: "local-1",
+      name: "report.pdf",
+    });
+    expect((filePart as any).localPath).toBeUndefined();
+  });
+
+  it("prepares trigger messages with staged attachment tags but no source path", () => {
+    const { messages, sandboxFiles } = prepareLocalDesktopAttachmentsForTrigger(
+      [makeLocalMessage()],
+      "/tmp/hackerai-upload",
+    );
+
+    expect(sandboxFiles).toEqual([
+      {
+        kind: "localPath",
+        path: "/Users/alice/Secrets/report.pdf",
+        localPath: "/tmp/hackerai-upload/report.pdf",
+      },
+    ]);
+    expect(JSON.stringify(messages)).not.toContain(
+      "/Users/alice/Secrets/report.pdf",
+    );
+    expect(
+      messages[0].parts?.some(
+        (part: any) =>
+          part.type === "text" &&
+          part.text ===
+            '<attachment filename="report.pdf" local_path="/tmp/hackerai-upload/report.pdf" />',
+      ),
+    ).toBe(true);
+  });
+
+  it("copies desktop-local files through the local sandbox instead of downloading", async () => {
+    const copyLocal = jest.fn().mockResolvedValue(undefined);
+    const downloadFromUrl = jest.fn();
+
+    const result = await uploadSandboxFiles(
+      [
+        {
+          kind: "localPath",
+          path: "/Users/alice/Secrets/report.pdf",
+          localPath: "/tmp/hackerai-upload/report.pdf",
+        },
+      ],
+      async () => ({
+        files: { copyLocal, downloadFromUrl },
+      }),
+    );
+
+    expect(result.failedCount).toBe(0);
+    expect(copyLocal).toHaveBeenCalledWith(
+      "/Users/alice/Secrets/report.pdf",
+      "/tmp/hackerai-upload/report.pdf",
+    );
+    expect(downloadFromUrl).not.toHaveBeenCalled();
+  });
+});

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -296,11 +296,14 @@ const applyModeSpecificTransforms = async (
   sandboxFiles: SandboxFile[],
   uploadBasePath?: string,
   maxFileTokens?: number,
+  allowLocalDesktopFiles?: boolean,
 ) => {
   const fileIds = extractAllFileIdsFromMessages(messages);
 
   if (mode === "agent") {
-    collectSandboxFiles(messages, sandboxFiles, uploadBasePath);
+    collectSandboxFiles(messages, sandboxFiles, uploadBasePath, {
+      allowLocalDesktopFiles,
+    });
     removeNonMediaFileParts(messages);
   } else {
     const nonMediaFileIds = filterNonMediaFileIds(messages, fileIds);
@@ -343,6 +346,7 @@ export const processMessageFiles = async (
   mode: ChatMode = "ask",
   uploadBasePath?: string,
   subscription?: SubscriptionTier,
+  allowLocalDesktopFiles: boolean = false,
 ): Promise<{
   messages: UIMessage[];
   hasMediaFiles: boolean;
@@ -379,6 +383,7 @@ export const processMessageFiles = async (
     sandboxFiles,
     uploadBasePath,
     maxFileTokens,
+    allowLocalDesktopFiles,
   );
 
   return {

--- a/lib/utils/file-utils.ts
+++ b/lib/utils/file-utils.ts
@@ -1,4 +1,8 @@
-import { FileMessagePart, UploadedFileState } from "@/types/file";
+import {
+  FileMessagePart,
+  LocalDesktopFile,
+  UploadedFileState,
+} from "@/types/file";
 import type { ChatMode } from "@/types/chat";
 
 /** Rate limit info returned from upload URL generation */
@@ -58,14 +62,17 @@ export function isSupportedImageMediaType(mediaType: string): boolean {
 /**
  * Check if file is an image
  */
-export function isImageFile(file: File): boolean {
+export function isImageFile(file: File | LocalDesktopFile): boolean {
   return file.type.startsWith("image/");
 }
 
 /**
  * Validate file for upload
  */
-export function validateFile(file: File): { valid: boolean; error?: string } {
+export function validateFile(file: File | LocalDesktopFile): {
+  valid: boolean;
+  error?: string;
+} {
   if (file.size > MAX_FILE_SIZE) {
     return {
       valid: false,
@@ -133,7 +140,27 @@ export async function validateImageFile(
 export function createFileMessagePartFromUploadedFile(
   uploadedFile: UploadedFileState,
 ): FileMessagePart | null {
-  if (!uploadedFile.fileId || !uploadedFile.uploaded) {
+  if (!uploadedFile.uploaded) {
+    return null;
+  }
+
+  if (uploadedFile.storage === "local-desktop") {
+    if (!uploadedFile.localAttachmentId || !uploadedFile.localPath) {
+      return null;
+    }
+
+    return {
+      type: "file" as const,
+      mediaType: uploadedFile.file.type || "application/octet-stream",
+      name: uploadedFile.file.name,
+      size: uploadedFile.file.size,
+      storage: "local-desktop",
+      localAttachmentId: uploadedFile.localAttachmentId,
+      localPath: uploadedFile.localPath,
+    };
+  }
+
+  if (!uploadedFile.fileId) {
     return null;
   }
 
@@ -143,6 +170,7 @@ export function createFileMessagePartFromUploadedFile(
     fileId: uploadedFile.fileId,
     name: uploadedFile.file.name,
     size: uploadedFile.file.size,
+    storage: "s3",
   };
 }
 

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -5,9 +5,17 @@ import { UIMessage } from "ai";
 import type { SandboxPreference } from "@/types";
 
 export type SandboxFile = {
-  url: string;
   localPath: string;
-};
+} & (
+  | {
+      kind: "url";
+      url: string;
+    }
+  | {
+      kind: "localPath";
+      path: string;
+    }
+);
 
 /**
  * E2B uses /home/user/upload; any local connection uses /tmp/hackerai-upload
@@ -27,7 +35,7 @@ const getLastUserMessageIndex = (messages: UIMessage[]): number => {
   return -1;
 };
 
-const sanitizeFilenameForTerminal = (filename: string): string => {
+export const sanitizeFilenameForTerminal = (filename: string): string => {
   const basename = filename.split(/[/\\]/g).pop() ?? "file";
   const lastDotIndex = basename.lastIndexOf(".");
   const hasExtension = lastDotIndex > 0;
@@ -64,6 +72,7 @@ export const collectSandboxFiles = (
   updatedMessages: UIMessage[],
   sandboxFiles: SandboxFile[],
   uploadBasePath: string = getUploadBasePath(undefined),
+  options: { allowLocalDesktopFiles?: boolean } = {},
 ): void => {
   const lastUserIdx = getLastUserMessageIndex(updatedMessages);
   if (lastUserIdx === -1) return;
@@ -73,14 +82,40 @@ export const collectSandboxFiles = (
 
     const tags: string[] = [];
     (msg.parts as any[]).forEach((part) => {
-      if (part?.type === "file" && part?.fileId && part?.url) {
+      if (part?.type !== "file") return;
+
+      if (part?.storage === "local-desktop") {
+        if (!part.localPath) return;
+        if (!options.allowLocalDesktopFiles) {
+          throw new Error(
+            "Desktop-local attachments can only be used with the desktop sandbox.",
+          );
+        }
+        const sanitizedName = sanitizeFilenameForTerminal(
+          part.name || part.filename || "file",
+        );
+        const localPath = `${uploadBasePath}/${sanitizedName}`;
+        if (i === lastUserIdx) {
+          sandboxFiles.push({
+            kind: "localPath",
+            path: part.localPath,
+            localPath,
+          });
+        }
+        tags.push(
+          `<attachment filename="${sanitizedName}" local_path="${localPath}" />`,
+        );
+        return;
+      }
+
+      if (part?.fileId && part?.url) {
         const sanitizedName = sanitizeFilenameForTerminal(
           part.name || part.filename || "file",
         );
         const localPath = `${uploadBasePath}/${sanitizedName}`;
 
         if (i === lastUserIdx) {
-          sandboxFiles.push({ url: part.url, localPath });
+          sandboxFiles.push({ kind: "url", url: part.url, localPath });
         }
         tags.push(
           `<attachment filename="${sanitizedName}" local_path="${localPath}" />`,
@@ -92,6 +127,89 @@ export const collectSandboxFiles = (
       (msg.parts as any[]).push({ type: "text", text: tags.join("\n") });
     }
   });
+};
+
+export const stripLocalDesktopSourcePaths = <T extends { parts?: any[] }>(
+  messages: T[],
+): T[] =>
+  messages.map((message) => {
+    if (!message.parts) return message;
+    return {
+      ...message,
+      parts: message.parts.map((part) => {
+        if (part?.type !== "file" || part.storage !== "local-desktop") {
+          return part;
+        }
+        const { localPath: _localPath, ...safePart } = part;
+        return safePart;
+      }),
+    };
+  });
+
+export const hasLocalDesktopSourcePaths = (
+  messages: Array<{ parts?: any[] }>,
+): boolean =>
+  messages.some((message) =>
+    message.parts?.some(
+      (part) =>
+        part?.type === "file" &&
+        part.storage === "local-desktop" &&
+        typeof part.localPath === "string" &&
+        part.localPath.length > 0,
+    ),
+  );
+
+export const prepareLocalDesktopAttachmentsForTrigger = (
+  messages: UIMessage[],
+  uploadBasePath: string = getUploadBasePath("desktop"),
+): { messages: UIMessage[]; sandboxFiles: SandboxFile[] } => {
+  const clonedMessages =
+    typeof structuredClone === "function"
+      ? structuredClone(messages)
+      : JSON.parse(JSON.stringify(messages));
+  const preparedMessages = stripLocalDesktopSourcePaths(
+    clonedMessages,
+  ) as UIMessage[];
+  const sandboxFiles: SandboxFile[] = [];
+  const lastUserIdx = getLastUserMessageIndex(messages);
+
+  messages.forEach((message, messageIndex) => {
+    if (message.role !== "user" || !message.parts) return;
+
+    const tags: string[] = [];
+    (message.parts as any[]).forEach((part) => {
+      if (
+        part?.type !== "file" ||
+        part.storage !== "local-desktop" ||
+        !part.localPath
+      ) {
+        return;
+      }
+      const sanitizedName = sanitizeFilenameForTerminal(
+        part.name || part.filename || "file",
+      );
+      const localPath = `${uploadBasePath}/${sanitizedName}`;
+      if (messageIndex === lastUserIdx) {
+        sandboxFiles.push({
+          kind: "localPath",
+          path: part.localPath,
+          localPath,
+        });
+      }
+      tags.push(
+        `<attachment filename="${sanitizedName}" local_path="${localPath}" />`,
+      );
+    });
+
+    if (tags.length > 0) {
+      (preparedMessages[messageIndex].parts as any[]).push({
+        type: "text",
+        text: tags.join("\n"),
+      });
+    }
+  });
+
+  return { messages: preparedMessages, sandboxFiles };
 };
 
 /**
@@ -172,6 +290,20 @@ const downloadFileToSandbox = async (
   );
 };
 
+const copyLocalFileToSandbox = async (
+  sandbox: any,
+  sourcePath: string,
+  localPath: string,
+): Promise<void> => {
+  if (!sandbox.files?.copyLocal) {
+    throw new Error(
+      "Desktop-local attachments require a desktop local sandbox.",
+    );
+  }
+
+  return sandbox.files.copyLocal(sourcePath, localPath);
+};
+
 const safeUrlForLog = (url: string): string => {
   try {
     const parsed = new URL(url);
@@ -179,6 +311,23 @@ const safeUrlForLog = (url: string): string => {
   } catch {
     return url.split("?")[0];
   }
+};
+
+const describeSandboxFileForLog = (file: SandboxFile) => {
+  if (file.kind === "url") {
+    return {
+      kind: file.kind,
+      url: safeUrlForLog(file.url),
+      urlLength: file.url.length,
+      protocol: file.url.split("://")[0],
+      localPath: file.localPath,
+    };
+  }
+  return {
+    kind: file.kind,
+    sourcePath: "[redacted-local-path]",
+    localPath: file.localPath,
+  };
 };
 
 /**
@@ -204,7 +353,9 @@ export const uploadSandboxFiles = async (
 
   const results = await Promise.allSettled(
     sandboxFiles.map((file) =>
-      downloadFileToSandbox(sandbox, file.url, file.localPath),
+      file.kind === "url"
+        ? downloadFileToSandbox(sandbox, file.url, file.localPath)
+        : copyLocalFileToSandbox(sandbox, file.path, file.localPath),
     ),
   );
 
@@ -220,10 +371,7 @@ export const uploadSandboxFiles = async (
       const file = sandboxFiles[i];
       const result = results[i] as PromiseRejectedResult;
       console.error("  -", {
-        url: safeUrlForLog(file.url),
-        urlLength: file.url.length,
-        localPath: file.localPath,
-        protocol: file.url.split("://")[0],
+        ...describeSandboxFileForLog(file),
         error:
           result.reason instanceof Error
             ? result.reason.message

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -21,7 +21,7 @@ const logLocalAttachmentDebug = (
   event: string,
   data: Record<string, unknown>,
 ) => {
-  if (process.env.NODE_ENV === "production") return;
+  if (process.env.NODE_ENV !== "development") return;
   console.info(`[local-attachments] ${event}`, data);
 };
 
@@ -344,6 +344,15 @@ const describeSandboxFileForLog = (file: SandboxFile) => {
   };
 };
 
+const redactSandboxUploadError = (
+  file: SandboxFile,
+  error: unknown,
+): string => {
+  const message = error instanceof Error ? error.message : String(error);
+  if (file.kind !== "localPath") return message;
+  return message.split(file.path).join("[redacted-local-path]");
+};
+
 /**
  * Uploads files to the sandbox environment in parallel
  * - Downloads files directly from S3 URLs using curl in the sandbox
@@ -393,10 +402,7 @@ export const uploadSandboxFiles = async (
       const result = results[i] as PromiseRejectedResult;
       console.error("  -", {
         ...describeSandboxFileForLog(file),
-        error:
-          result.reason instanceof Error
-            ? result.reason.message
-            : String(result.reason),
+        error: redactSandboxUploadError(file, result.reason),
       });
     });
   }

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -17,6 +17,14 @@ export type SandboxFile = {
     }
 );
 
+const logLocalAttachmentDebug = (
+  event: string,
+  data: Record<string, unknown>,
+) => {
+  if (process.env.NODE_ENV === "production") return;
+  console.info(`[local-attachments] ${event}`, data);
+};
+
 /**
  * E2B uses /home/user/upload; any local connection uses /tmp/hackerai-upload
  * since the host machine may not have /home/user (e.g. macOS in dangerous mode).
@@ -209,6 +217,12 @@ export const prepareLocalDesktopAttachmentsForTrigger = (
     }
   });
 
+  logLocalAttachmentDebug("prepared-trigger-local-files", {
+    fileCount: sandboxFiles.length,
+    scrubbedHasLocalPath:
+      JSON.stringify(preparedMessages).includes("localPath"),
+  });
+
   return { messages: preparedMessages, sandboxFiles };
 };
 
@@ -342,6 +356,13 @@ export const uploadSandboxFiles = async (
   ensureSandbox: () => Promise<any>,
 ): Promise<{ failedCount: number }> => {
   if (sandboxFiles.length === 0) return { failedCount: 0 };
+
+  logLocalAttachmentDebug("sandbox-staging-start", {
+    totalCount: sandboxFiles.length,
+    localPathCount: sandboxFiles.filter((file) => file.kind === "localPath")
+      .length,
+    urlCount: sandboxFiles.filter((file) => file.kind === "url").length,
+  });
 
   let sandbox: any;
   try {

--- a/lib/utils/stream-writer-utils.ts
+++ b/lib/utils/stream-writer-utils.ts
@@ -4,11 +4,14 @@ import { UIMessagePart, UIMessageStreamWriter } from "ai";
 import type { ChatMode, SubscriptionTier } from "@/types";
 
 // Upload status notifications
-export const writeUploadStartStatus = (writer: UIMessageStreamWriter): void => {
+export const writeUploadStartStatus = (
+  writer: UIMessageStreamWriter,
+  message: string = "Uploading attachments to the computer",
+): void => {
   writer.write({
     type: "data-upload-status",
     data: {
-      message: "Uploading attachments to the computer",
+      message,
       isUploading: true,
     },
     transient: true,

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@trigger.dev/build": "4.4.6",
     "@trigger.dev/react-hooks": "4.4.6",
     "@trigger.dev/sdk": "4.4.6",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -14,11 +14,12 @@
   "dependencies": {
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-deep-link": "^2.4.9",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
+    "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-os": "^2.3.2",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.3.5",
-    "@tauri-apps/plugin-updater": "^2.10.1",
-    "@tauri-apps/plugin-opener": "^2.5.4"
+    "@tauri-apps/plugin-updater": "^2.10.1"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.11.2",

--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -20,6 +20,7 @@
     "process:default",
     "updater:default",
     "deep-link:default",
+    "dialog:default",
     "opener:default",
     {
       "identifier": "opener:allow-open-path",

--- a/packages/desktop/src-tauri/gen/schemas/acl-manifests.json
+++ b/packages/desktop/src-tauri/gen/schemas/acl-manifests.json
@@ -9,6 +9,7 @@
           "allow": [
             "get_dev_auth_port",
             "get_cmd_server_info",
+            "get_local_file_metadata",
             "execute_command",
             "execute_stream_command",
             "cancel_stream_command",

--- a/packages/desktop/src-tauri/gen/schemas/capabilities.json
+++ b/packages/desktop/src-tauri/gen/schemas/capabilities.json
@@ -19,6 +19,7 @@
       "process:default",
       "updater:default",
       "deep-link:default",
+      "dialog:default",
       "opener:default",
       {
         "identifier": "opener:allow-open-path",

--- a/packages/desktop/src-tauri/permissions/desktop-command-bridge.toml
+++ b/packages/desktop/src-tauri/permissions/desktop-command-bridge.toml
@@ -4,6 +4,7 @@ description = "Allows the desktop webview to reach the local command bridge."
 commands.allow = [
   "get_dev_auth_port",
   "get_cmd_server_info",
+  "get_local_file_metadata",
   "execute_command",
   "execute_stream_command",
   "cancel_stream_command",

--- a/packages/desktop/src-tauri/permissions/desktop-command-bridge.toml
+++ b/packages/desktop/src-tauri/permissions/desktop-command-bridge.toml
@@ -5,6 +5,7 @@ commands.allow = [
   "get_dev_auth_port",
   "get_cmd_server_info",
   "get_local_file_metadata",
+  "read_local_file",
   "execute_command",
   "execute_stream_command",
   "cancel_stream_command",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -53,6 +53,17 @@ struct LocalFileMetadata {
     last_modified: u64,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LocalFileData {
+    path: String,
+    name: String,
+    media_type: String,
+    size: u64,
+    last_modified: u64,
+    base64: String,
+}
+
 fn json_error_body(message: &str) -> String {
     serde_json::to_string(&serde_json::json!({ "error": message }))
         .unwrap_or_else(|_| r#"{"error":"serialization failed"}"#.to_string())
@@ -121,6 +132,23 @@ fn get_local_file_metadata(path: String) -> Result<LocalFileMetadata, String> {
         media_type: guess_media_type(&path_buf),
         size: metadata.len(),
         last_modified,
+    })
+}
+
+#[tauri::command]
+fn read_local_file(path: String) -> Result<LocalFileData, String> {
+    use base64::Engine;
+
+    let metadata = get_local_file_metadata(path.clone())?;
+    let bytes = fs::read(&path).map_err(|e| format!("Read error: {}", e))?;
+
+    Ok(LocalFileData {
+        path: metadata.path,
+        name: metadata.name,
+        media_type: metadata.media_type,
+        size: metadata.size,
+        last_modified: metadata.last_modified,
+        base64: base64::engine::general_purpose::STANDARD.encode(bytes),
     })
 }
 
@@ -1295,6 +1323,7 @@ pub fn run() {
             get_dev_auth_port,
             get_cmd_server_info,
             get_local_file_metadata,
+            read_local_file,
             execute_command,
             execute_stream_command,
             cancel_stream_command,

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -86,6 +86,7 @@ fn guess_media_type(path: &std::path::Path) -> String {
         .as_str()
     {
         "png" => "image/png",
+        "svg" => "image/svg+xml",
         "jpg" | "jpeg" => "image/jpeg",
         "webp" => "image/webp",
         "gif" => "image/gif",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1,12 +1,12 @@
 mod platform;
 mod pty;
 
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use serde::{Deserialize, Serialize};
 use tauri::Manager;
 use tauri_plugin_updater::UpdaterExt;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -41,6 +41,74 @@ fn get_cmd_server_info() -> CmdServerInfo {
 struct CmdServerInfo {
     port: u16,
     token: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LocalFileMetadata {
+    path: String,
+    name: String,
+    media_type: String,
+    size: u64,
+    last_modified: u64,
+}
+
+fn guess_media_type(path: &std::path::Path) -> String {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "webp" => "image/webp",
+        "gif" => "image/gif",
+        "pdf" => "application/pdf",
+        "txt" => "text/plain",
+        "md" | "markdown" => "text/markdown",
+        "csv" => "text/csv",
+        "json" => "application/json",
+        "html" | "htm" => "text/html",
+        "js" | "mjs" | "cjs" => "text/javascript",
+        "ts" | "tsx" => "text/typescript",
+        "css" => "text/css",
+        "xml" => "application/xml",
+        "zip" => "application/zip",
+        "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        _ => "application/octet-stream",
+    }
+    .to_string()
+}
+
+#[tauri::command]
+fn get_local_file_metadata(path: String) -> Result<LocalFileMetadata, String> {
+    let path_buf = PathBuf::from(&path);
+    let metadata = fs::metadata(&path_buf).map_err(|e| format!("Metadata error: {}", e))?;
+    if !metadata.is_file() {
+        return Err("Selected path is not a file".to_string());
+    }
+
+    let name = path_buf
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("file")
+        .to_string();
+    let last_modified = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0);
+
+    Ok(LocalFileMetadata {
+        path,
+        name,
+        media_type: guess_media_type(&path_buf),
+        size: metadata.len(),
+        last_modified,
+    })
 }
 
 // ── Command Execution Server ──────────────────────────────────────────
@@ -227,13 +295,18 @@ const MAX_HEADER_SIZE: usize = 256 * 1024;
 const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
 
 /// Parse an HTTP request from the stream, returning (method, path, headers, body)
-async fn parse_http_request(stream: &mut tokio::net::TcpStream) -> Result<(String, String, HashMap<String, String>, String), String> {
+async fn parse_http_request(
+    stream: &mut tokio::net::TcpStream,
+) -> Result<(String, String, HashMap<String, String>, String), String> {
     let mut buf = vec![0u8; 64 * 1024]; // 64KB initial buffer
     let mut total_read = 0;
 
     // Read headers first (with size cap to prevent OOM)
     loop {
-        let n = stream.read(&mut buf[total_read..]).await.map_err(|e| e.to_string())?;
+        let n = stream
+            .read(&mut buf[total_read..])
+            .await
+            .map_err(|e| e.to_string())?;
         if n == 0 {
             return Err("Connection closed".into());
         }
@@ -260,7 +333,8 @@ async fn parse_http_request(stream: &mut tokio::net::TcpStream) -> Result<(Strin
     }
 
     // Find header/body boundary in raw bytes to avoid string/byte index mismatch
-    let header_end = buf[..total_read].windows(4)
+    let header_end = buf[..total_read]
+        .windows(4)
         .position(|w| w == b"\r\n\r\n")
         .ok_or("No header end")?;
     let body_start_idx = header_end + 4;
@@ -285,7 +359,8 @@ async fn parse_http_request(stream: &mut tokio::net::TcpStream) -> Result<(Strin
     }
 
     // Read body based on content-length
-    let content_length: usize = headers.get("content-length")
+    let content_length: usize = headers
+        .get("content-length")
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
 
@@ -302,7 +377,10 @@ async fn parse_http_request(stream: &mut tokio::net::TcpStream) -> Result<(Strin
         let mut remaining_buf = vec![0u8; remaining];
         let mut read_so_far = 0;
         while read_so_far < remaining {
-            let n = stream.read(&mut remaining_buf[read_so_far..]).await.map_err(|e| e.to_string())?;
+            let n = stream
+                .read(&mut remaining_buf[read_so_far..])
+                .await
+                .map_err(|e| e.to_string())?;
             if n == 0 {
                 break;
             }
@@ -316,13 +394,19 @@ async fn parse_http_request(stream: &mut tokio::net::TcpStream) -> Result<(Strin
     Ok((method, path, headers, body))
 }
 
-async fn handle_cmd_request(mut stream: tokio::net::TcpStream, expected_token: &str) -> Result<(), String> {
+async fn handle_cmd_request(
+    mut stream: tokio::net::TcpStream,
+    expected_token: &str,
+) -> Result<(), String> {
     let (method, path, headers, body) = parse_http_request(&mut stream).await?;
 
     // CORS preflight
     if method == "OPTIONS" {
         let response = "HTTP/1.1 204 No Content\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type, Authorization\r\nAccess-Control-Max-Age: 86400\r\n\r\n";
-        stream.write_all(response.as_bytes()).await.map_err(|e| e.to_string())?;
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .map_err(|e| e.to_string())?;
         return Ok(());
     }
 
@@ -335,7 +419,10 @@ async fn handle_cmd_request(mut stream: tokio::net::TcpStream, expected_token: &
             "HTTP/1.1 401 Unauthorized\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\n\r\n{}",
             body.len(), body
         );
-        stream.write_all(response.as_bytes()).await.map_err(|e| e.to_string())?;
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .map_err(|e| e.to_string())?;
         return Ok(());
     }
 
@@ -345,7 +432,7 @@ async fn handle_cmd_request(mut stream: tokio::net::TcpStream, expected_token: &
     }
 
     let (route_path, _query_string) = if let Some(idx) = path.find('?') {
-        (&path[..idx], &path[idx+1..])
+        (&path[..idx], &path[idx + 1..])
     } else {
         (path.as_str(), "")
     };
@@ -363,25 +450,28 @@ async fn handle_cmd_request(mut stream: tokio::net::TcpStream, expected_token: &
     let (status, resp_body) = match result {
         Ok(json) => ("200 OK", json),
         Err(e) if e == "not found" => ("404 Not Found", format!(r#"{{"error":"not found"}}"#)),
-        Err(e) => ("500 Internal Server Error", format!(r#"{{"error":"{}"}}"#, e.replace('"', "\\\""))),
+        Err(e) => (
+            "500 Internal Server Error",
+            format!(r#"{{"error":"{}"}}"#, e.replace('"', "\\\"")),
+        ),
     };
 
     let response = format!(
         "HTTP/1.1 {}\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\n\r\n{}",
         status, resp_body.len(), resp_body
     );
-    stream.write_all(response.as_bytes()).await.map_err(|e| e.to_string())?;
+    stream
+        .write_all(response.as_bytes())
+        .await
+        .map_err(|e| e.to_string())?;
     Ok(())
 }
 
 async fn handle_execute(body: &str) -> Result<String, String> {
-    let req: ExecRequest = serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
+    let req: ExecRequest =
+        serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
 
-    let mut cmd = platform::build_command(
-        &req.command,
-        req.cwd.as_deref(),
-        req.env.as_ref(),
-    );
+    let mut cmd = platform::build_command(&req.command, req.cwd.as_deref(), req.env.as_ref());
 
     let child = cmd.spawn().map_err(|e| format!("Failed to spawn: {}", e))?;
 
@@ -393,12 +483,20 @@ async fn handle_execute(body: &str) -> Result<String, String> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let stdout_str = if stdout.len() > MAX_OUTPUT {
-        format!("{}... [truncated, {} total bytes]", &stdout[..MAX_OUTPUT], stdout.len())
+        format!(
+            "{}... [truncated, {} total bytes]",
+            &stdout[..MAX_OUTPUT],
+            stdout.len()
+        )
     } else {
         stdout.to_string()
     };
     let stderr_str = if stderr.len() > MAX_OUTPUT {
-        format!("{}... [truncated, {} total bytes]", &stderr[..MAX_OUTPUT], stderr.len())
+        format!(
+            "{}... [truncated, {} total bytes]",
+            &stderr[..MAX_OUTPUT],
+            stderr.len()
+        )
     } else {
         stderr.to_string()
     };
@@ -418,19 +516,22 @@ async fn handle_execute(body: &str) -> Result<String, String> {
 ///   {"type":"stderr","data":"..."}
 ///   {"type":"exit","exit_code":0}
 ///   {"type":"error","message":"..."}
-async fn handle_execute_stream(body: &str, stream: &mut tokio::net::TcpStream) -> Result<(), String> {
-    let req: ExecRequest = serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
+async fn handle_execute_stream(
+    body: &str,
+    stream: &mut tokio::net::TcpStream,
+) -> Result<(), String> {
+    let req: ExecRequest =
+        serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
 
-    let mut cmd = platform::build_command(
-        &req.command,
-        req.cwd.as_deref(),
-        req.env.as_ref(),
-    );
+    let mut cmd = platform::build_command(&req.command, req.cwd.as_deref(), req.env.as_ref());
 
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            let err_body = format!(r#"{{"error":"Failed to spawn: {}"}}"#, e.to_string().replace('"', "\\\""));
+            let err_body = format!(
+                r#"{{"error":"Failed to spawn: {}"}}"#,
+                e.to_string().replace('"', "\\\"")
+            );
             let resp = format!(
                 "HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\n\r\n{}",
                 err_body.len(), err_body
@@ -442,7 +543,10 @@ async fn handle_execute_stream(body: &str, stream: &mut tokio::net::TcpStream) -
 
     // Send chunked response headers
     let headers = "HTTP/1.1 200 OK\r\nContent-Type: application/x-ndjson\r\nAccess-Control-Allow-Origin: *\r\nTransfer-Encoding: chunked\r\n\r\n";
-    stream.write_all(headers.as_bytes()).await.map_err(|e| e.to_string())?;
+    stream
+        .write_all(headers.as_bytes())
+        .await
+        .map_err(|e| e.to_string())?;
 
     let timeout = Duration::from_millis(req.timeout_ms);
     let mut stdout = child.stdout.take().unwrap();
@@ -489,21 +593,31 @@ async fn handle_execute_stream(body: &str, stream: &mut tokio::net::TcpStream) -
 
         // Wait for process to exit
         child.wait().await
-    }).await;
+    })
+    .await;
 
     match result {
         Ok(Ok(status)) => {
-            let line = format!(r#"{{"type":"exit","exit_code":{}}}"#, status.code().unwrap_or(-1));
+            let line = format!(
+                r#"{{"type":"exit","exit_code":{}}}"#,
+                status.code().unwrap_or(-1)
+            );
             write_chunk(stream, &line).await;
         }
         Ok(Err(e)) => {
-            let line = format!(r#"{{"type":"error","message":"Process error: {}"}}"#, e.to_string().replace('"', "\\\""));
+            let line = format!(
+                r#"{{"type":"error","message":"Process error: {}"}}"#,
+                e.to_string().replace('"', "\\\"")
+            );
             write_chunk(stream, &line).await;
         }
         Err(_) => {
             // Timeout — gracefully kill the process
             platform::graceful_kill(&mut child).await;
-            let line = format!(r#"{{"type":"error","message":"Command timed out after {}ms"}}"#, req.timeout_ms);
+            let line = format!(
+                r#"{{"type":"error","message":"Command timed out after {}ms"}}"#,
+                req.timeout_ms
+            );
             write_chunk(stream, &line).await;
         }
     }
@@ -526,50 +640,73 @@ async fn write_chunk(stream: &mut tokio::net::TcpStream, data: &str) {
 }
 
 async fn handle_file_read(body: &str) -> Result<String, String> {
-    let req: FileReadRequest = serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
-    let content = tokio::fs::read_to_string(&req.path).await.map_err(|e| format!("Read error: {}", e))?;
+    let req: FileReadRequest =
+        serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
+    let content = tokio::fs::read_to_string(&req.path)
+        .await
+        .map_err(|e| format!("Read error: {}", e))?;
     serde_json::to_string(&serde_json::json!({ "content": content })).map_err(|e| e.to_string())
 }
 
 async fn handle_file_write(body: &str) -> Result<String, String> {
-    let req: FileWriteRequest = serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
+    let req: FileWriteRequest =
+        serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
 
     // Ensure parent directory exists
     if let Some(parent) = std::path::Path::new(&req.path).parent() {
-        tokio::fs::create_dir_all(parent).await.map_err(|e| format!("Mkdir error: {}", e))?;
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("Mkdir error: {}", e))?;
     }
 
     if req.is_base64 {
         use base64::Engine;
-        let bytes = base64::engine::general_purpose::STANDARD.decode(&req.content)
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&req.content)
             .map_err(|e| format!("Base64 decode error: {}", e))?;
-        tokio::fs::write(&req.path, bytes).await.map_err(|e| format!("Write error: {}", e))?;
+        tokio::fs::write(&req.path, bytes)
+            .await
+            .map_err(|e| format!("Write error: {}", e))?;
     } else {
-        tokio::fs::write(&req.path, &req.content).await.map_err(|e| format!("Write error: {}", e))?;
+        tokio::fs::write(&req.path, &req.content)
+            .await
+            .map_err(|e| format!("Write error: {}", e))?;
     }
 
     Ok(r#"{"ok":true}"#.to_string())
 }
 
 async fn handle_file_remove(body: &str) -> Result<String, String> {
-    let req: FileRemoveRequest = serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
+    let req: FileRemoveRequest =
+        serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
     let path = std::path::Path::new(&req.path);
 
     if path.is_dir() {
-        tokio::fs::remove_dir_all(path).await.map_err(|e| format!("Remove error: {}", e))?;
+        tokio::fs::remove_dir_all(path)
+            .await
+            .map_err(|e| format!("Remove error: {}", e))?;
     } else {
-        tokio::fs::remove_file(path).await.map_err(|e| format!("Remove error: {}", e))?;
+        tokio::fs::remove_file(path)
+            .await
+            .map_err(|e| format!("Remove error: {}", e))?;
     }
 
     Ok(r#"{"ok":true}"#.to_string())
 }
 
 async fn handle_file_list(body: &str) -> Result<String, String> {
-    let req: FileListRequest = serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
+    let req: FileListRequest =
+        serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
     let mut entries = Vec::new();
-    let mut dir = tokio::fs::read_dir(&req.path).await.map_err(|e| format!("ReadDir error: {}", e))?;
+    let mut dir = tokio::fs::read_dir(&req.path)
+        .await
+        .map_err(|e| format!("ReadDir error: {}", e))?;
 
-    while let Some(entry) = dir.next_entry().await.map_err(|e| format!("Entry error: {}", e))? {
+    while let Some(entry) = dir
+        .next_entry()
+        .await
+        .map_err(|e| format!("Entry error: {}", e))?
+    {
         let name = entry.file_name().to_string_lossy().to_string();
         entries.push(serde_json::json!({ "name": name }));
     }
@@ -582,15 +719,21 @@ async fn handle_file_list(body: &str) -> Result<String, String> {
 #[derive(Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase", tag = "type")]
 enum StreamEvent {
-    Stdout { data: String },
-    Stderr { data: String },
+    Stdout {
+        data: String,
+    },
+    Stderr {
+        data: String,
+    },
     Exit {
         // Explicit rename needed: Tauri 2's Channel<T> does not apply
         // rename_all to fields inside internally-tagged enum variants.
         #[serde(rename = "exitCode")]
         exit_code: i32,
     },
-    Error { message: String },
+    Error {
+        message: String,
+    },
 }
 
 type StreamCommandState = std::sync::Arc<std::sync::Mutex<HashMap<String, u32>>>;
@@ -611,12 +754,20 @@ async fn execute_command(
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let stdout_str = if stdout.len() > MAX_OUTPUT {
-        format!("{}... [truncated, {} total bytes]", &stdout[..MAX_OUTPUT], stdout.len())
+        format!(
+            "{}... [truncated, {} total bytes]",
+            &stdout[..MAX_OUTPUT],
+            stdout.len()
+        )
     } else {
         stdout.to_string()
     };
     let stderr_str = if stderr.len() > MAX_OUTPUT {
-        format!("{}... [truncated, {} total bytes]", &stderr[..MAX_OUTPUT], stderr.len())
+        format!(
+            "{}... [truncated, {} total bytes]",
+            &stderr[..MAX_OUTPUT],
+            stderr.len()
+        )
     } else {
         stderr.to_string()
     };
@@ -682,18 +833,25 @@ async fn execute_stream_command(
             }
         }
         child.wait().await
-    }).await;
+    })
+    .await;
 
     match result {
         Ok(Ok(status)) => {
-            let _ = on_event.send(StreamEvent::Exit { exit_code: status.code().unwrap_or(-1) });
+            let _ = on_event.send(StreamEvent::Exit {
+                exit_code: status.code().unwrap_or(-1),
+            });
         }
         Ok(Err(e)) => {
-            let _ = on_event.send(StreamEvent::Error { message: format!("Process error: {}", e) });
+            let _ = on_event.send(StreamEvent::Error {
+                message: format!("Process error: {}", e),
+            });
         }
         Err(_) => {
             platform::graceful_kill(&mut child).await;
-            let _ = on_event.send(StreamEvent::Error { message: format!("Command timed out after {}ms", timeout_ms.unwrap_or(30000)) });
+            let _ = on_event.send(StreamEvent::Error {
+                message: format!("Command timed out after {}ms", timeout_ms.unwrap_or(30000)),
+            });
         }
     }
     if let Ok(mut commands) = state.lock() {
@@ -745,7 +903,10 @@ async fn start_dev_auth_server(app_handle: tauri::AppHandle) {
         }
     };
     DEV_AUTH_PORT.store(port, Ordering::Relaxed);
-    log::info!("Dev auth callback server listening on http://localhost:{}", port);
+    log::info!(
+        "Dev auth callback server listening on http://localhost:{}",
+        port
+    );
 
     loop {
         let (mut stream, _) = match listener.accept().await {
@@ -796,10 +957,12 @@ async fn start_dev_auth_server(app_handle: tauri::AppHandle) {
                 }
             };
 
-            let token = parsed.query_pairs()
+            let token = parsed
+                .query_pairs()
                 .find(|(k, _)| k == "token")
                 .map(|(_, v)| v.to_string());
-            let origin = parsed.query_pairs()
+            let origin = parsed
+                .query_pairs()
                 .find(|(k, _)| k == "origin")
                 .map(|(_, v)| v.to_string());
 
@@ -811,9 +974,13 @@ async fn start_dev_auth_server(app_handle: tauri::AppHandle) {
 
                     let encoded_token: String =
                         url::form_urlencoded::byte_serialize(t.as_bytes()).collect();
-                    let callback_url = format!("{}/desktop-callback?token={}", origin, encoded_token);
+                    let callback_url =
+                        format!("{}/desktop-callback?token={}", origin, encoded_token);
 
-                    log::info!("Dev auth: navigating to callback (token: {}...)", &t[..8.min(t.len())]);
+                    log::info!(
+                        "Dev auth: navigating to callback (token: {}...)",
+                        &t[..8.min(t.len())]
+                    );
 
                     if let Some(window) = handle.get_webview_window("main") {
                         let _ = window.set_focus();
@@ -842,7 +1009,10 @@ async fn start_dev_auth_server(app_handle: tauri::AppHandle) {
 }
 
 fn get_last_update_check_file(app: &tauri::AppHandle) -> Option<PathBuf> {
-    app.path().app_data_dir().ok().map(|dir| dir.join("last_update_check"))
+    app.path()
+        .app_data_dir()
+        .ok()
+        .map(|dir| dir.join("last_update_check"))
 }
 
 fn should_check_for_updates(app: &tauri::AppHandle) -> bool {
@@ -913,7 +1083,11 @@ fn handle_auth_deep_link(app: &tauri::AppHandle, url: &url::Url) {
     }
 
     if url.host_str() == Some("auth") || url.path() == "/auth" || url.path() == "auth" {
-        match url.query_pairs().find(|(k, _)| k == "token").map(|(_, v)| v) {
+        match url
+            .query_pairs()
+            .find(|(k, _)| k == "token")
+            .map(|(_, v)| v)
+        {
             Some(token) => {
                 if !is_valid_token_format(&token) {
                     log::error!("Invalid token format in deep link");
@@ -922,7 +1096,8 @@ fn handle_auth_deep_link(app: &tauri::AppHandle, url: &url::Url) {
 
                 if let Some(window) = app.get_webview_window("main") {
                     // Get and validate origin from deep link query params
-                    let origin = url.query_pairs()
+                    let origin = url
+                        .query_pairs()
                         .find(|(k, _)| k == "origin")
                         .map(|(_, v)| v.to_string())
                         .filter(|o| validate_origin(o))
@@ -931,9 +1106,14 @@ fn handle_auth_deep_link(app: &tauri::AppHandle, url: &url::Url) {
                             "https://hackerai.co".to_string()
                         });
 
-                    let encoded_token: String = url::form_urlencoded::byte_serialize(token.as_bytes()).collect();
-                    let callback_url = format!("{}/desktop-callback?token={}", origin, encoded_token);
-                    log::info!("Navigating to desktop callback (token: {}...)", &token[..8.min(token.len())]);
+                    let encoded_token: String =
+                        url::form_urlencoded::byte_serialize(token.as_bytes()).collect();
+                    let callback_url =
+                        format!("{}/desktop-callback?token={}", origin, encoded_token);
+                    log::info!(
+                        "Navigating to desktop callback (token: {}...)",
+                        &token[..8.min(token.len())]
+                    );
 
                     match callback_url.parse() {
                         Ok(parsed_url) => {
@@ -973,7 +1153,8 @@ async fn check_for_updates(app: tauri::AppHandle, silent: bool) {
                 log::warn!("Auto-update check failed to get updater: {}", e);
             } else {
                 log::error!("Failed to get updater: {}", e);
-                let _ = app.dialog()
+                let _ = app
+                    .dialog()
                     .message(format!("Failed to check for updates: {}", e))
                     .kind(MessageDialogKind::Error)
                     .title("Update Error")
@@ -988,7 +1169,8 @@ async fn check_for_updates(app: tauri::AppHandle, silent: bool) {
             let version = update.version.clone();
             log::info!("Update available: {}", version);
 
-            let should_update = app.dialog()
+            let should_update = app
+                .dialog()
                 .message(format!(
                     "A new version ({}) is available. Would you like to update now?",
                     version
@@ -1002,18 +1184,23 @@ async fn check_for_updates(app: tauri::AppHandle, silent: bool) {
                 log::info!("User accepted update to version {}", version);
                 if let Err(e) = update.download_and_install(|_, _| {}, || {}).await {
                     log::error!("Failed to install update: {}", e);
-                    let _ = app.dialog()
+                    let _ = app
+                        .dialog()
                         .message(format!("Failed to install update: {}", e))
                         .kind(MessageDialogKind::Error)
                         .title("Update Error")
                         .blocking_show();
                 } else {
                     log::info!("Update installed successfully");
-                    let restart_now = app.dialog()
+                    let restart_now = app
+                        .dialog()
                         .message("Update installed successfully. Restart now to apply changes?")
                         .kind(MessageDialogKind::Info)
                         .title("Update Complete")
-                        .buttons(MessageDialogButtons::OkCancelCustom("Restart Now".into(), "Later".into()))
+                        .buttons(MessageDialogButtons::OkCancelCustom(
+                            "Restart Now".into(),
+                            "Later".into(),
+                        ))
                         .blocking_show();
                     if restart_now {
                         app.restart();
@@ -1026,7 +1213,8 @@ async fn check_for_updates(app: tauri::AppHandle, silent: bool) {
                 log::info!("No updates available (auto-check)");
             } else {
                 log::info!("No updates available");
-                let _ = app.dialog()
+                let _ = app
+                    .dialog()
                     .message("You're running the latest version.")
                     .kind(MessageDialogKind::Info)
                     .title("No Updates")
@@ -1038,7 +1226,8 @@ async fn check_for_updates(app: tauri::AppHandle, silent: bool) {
                 log::warn!("Auto-update check failed: {}", e);
             } else {
                 log::error!("Failed to check for updates: {}", e);
-                let _ = app.dialog()
+                let _ = app
+                    .dialog()
                     .message(format!("Failed to check for updates: {}", e))
                     .kind(MessageDialogKind::Error)
                     .title("Update Error")
@@ -1100,7 +1289,18 @@ async fn execute_pty_kill(
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![get_dev_auth_port, get_cmd_server_info, execute_command, execute_stream_command, cancel_stream_command, execute_pty_create, execute_pty_input, execute_pty_resize, execute_pty_kill])
+        .invoke_handler(tauri::generate_handler![
+            get_dev_auth_port,
+            get_cmd_server_info,
+            get_local_file_metadata,
+            execute_command,
+            execute_stream_command,
+            cancel_stream_command,
+            execute_pty_create,
+            execute_pty_input,
+            execute_pty_resize,
+            execute_pty_kill
+        ])
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_shell::init())
@@ -1125,7 +1325,10 @@ pub fn run() {
             }
         }))
         .manage(std::sync::Arc::new(std::sync::Mutex::new(pty::PtyManager::new())) as PtyState)
-        .manage(std::sync::Arc::new(std::sync::Mutex::new(HashMap::<String, u32>::new())) as StreamCommandState)
+        .manage(
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::<String, u32>::new()))
+                as StreamCommandState,
+        )
         .setup(|app| {
             #[cfg(desktop)]
             {

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -53,6 +53,19 @@ struct LocalFileMetadata {
     last_modified: u64,
 }
 
+fn json_error_body(message: &str) -> String {
+    serde_json::to_string(&serde_json::json!({ "error": message }))
+        .unwrap_or_else(|_| r#"{"error":"serialization failed"}"#.to_string())
+}
+
+fn json_stream_error_line(message: &str) -> String {
+    serde_json::to_string(&serde_json::json!({
+        "type": "error",
+        "message": message,
+    }))
+    .unwrap_or_else(|_| r#"{"type":"error","message":"serialization failed"}"#.to_string())
+}
+
 fn guess_media_type(path: &std::path::Path) -> String {
     match path
         .extension()
@@ -449,11 +462,8 @@ async fn handle_cmd_request(
 
     let (status, resp_body) = match result {
         Ok(json) => ("200 OK", json),
-        Err(e) if e == "not found" => ("404 Not Found", format!(r#"{{"error":"not found"}}"#)),
-        Err(e) => (
-            "500 Internal Server Error",
-            format!(r#"{{"error":"{}"}}"#, e.replace('"', "\\\"")),
-        ),
+        Err(e) if e == "not found" => ("404 Not Found", json_error_body("not found")),
+        Err(e) => ("500 Internal Server Error", json_error_body(&e)),
     };
 
     let response = format!(
@@ -528,10 +538,7 @@ async fn handle_execute_stream(
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            let err_body = format!(
-                r#"{{"error":"Failed to spawn: {}"}}"#,
-                e.to_string().replace('"', "\\\"")
-            );
+            let err_body = json_error_body(&format!("Failed to spawn: {}", e));
             let resp = format!(
                 "HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\n\r\n{}",
                 err_body.len(), err_body
@@ -605,19 +612,14 @@ async fn handle_execute_stream(
             write_chunk(stream, &line).await;
         }
         Ok(Err(e)) => {
-            let line = format!(
-                r#"{{"type":"error","message":"Process error: {}"}}"#,
-                e.to_string().replace('"', "\\\"")
-            );
+            let line = json_stream_error_line(&format!("Process error: {}", e));
             write_chunk(stream, &line).await;
         }
         Err(_) => {
             // Timeout — gracefully kill the process
             platform::graceful_kill(&mut child).await;
-            let line = format!(
-                r#"{{"type":"error","message":"Command timed out after {}ms"}}"#,
-                req.timeout_ms
-            );
+            let line =
+                json_stream_error_line(&format!("Command timed out after {}ms", req.timeout_ms));
             write_chunk(stream, &line).await;
         }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       '@radix-ui/react-use-controllable-state':
         specifier: ^1.2.2
         version: 1.2.2(@types/react@19.1.9)(react@19.2.6)
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.7.1
+        version: 2.7.1
       '@trigger.dev/build':
         specifier: 4.4.6
         version: 4.4.6(magicast@0.3.5)(supports-color@10.2.2)(typescript@6.0.2)
@@ -398,6 +401,9 @@ importers:
       '@tauri-apps/plugin-deep-link':
         specifier: ^2.4.9
         version: 2.4.9
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.7.1
+        version: 2.7.1
       '@tauri-apps/plugin-opener':
         specifier: ^2.5.4
         version: 2.5.4
@@ -3614,6 +3620,9 @@ packages:
 
   '@tauri-apps/plugin-deep-link@2.4.9':
     resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
+
+  '@tauri-apps/plugin-dialog@2.7.1':
+    resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
@@ -11704,6 +11713,10 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.0
 
+  '@tauri-apps/plugin-dialog@2.7.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
   '@tauri-apps/plugin-opener@2.5.4':
     dependencies:
       '@tauri-apps/api': 2.11.0
@@ -14378,7 +14391,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.15.2(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.15.2)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -16724,7 +16737,7 @@ snapshots:
 
   resumable-stream@2.2.12: {}
 
-  retry-axios@2.6.0(axios@1.15.2(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.15.2):
     dependencies:
       axios: 1.15.2(debug@4.4.3)
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -401,6 +401,7 @@ export type AgentLongPayload = {
   subscription: SubscriptionTier;
   organizationId?: string;
   messages: UIMessage[];
+  localDesktopAttachmentsPrepared?: boolean;
   baseTodos: Todo[];
   sandboxPreference?: SandboxPreference;
   selectedModel?: SelectedModel;
@@ -455,6 +456,7 @@ export const agentLongTask = task({
       subscription,
       organizationId,
       messages,
+      localDesktopAttachmentsPrepared,
       sandboxPreference,
       selectedModel: selectedModelOverride,
       userLocation,
@@ -532,13 +534,21 @@ export const agentLongTask = task({
       );
 
       const uploadBasePath = getUploadBasePath(sandboxPreference);
+      const messagesForProcessing =
+        localDesktopAttachmentsPrepared && messages.length > 0
+          ? messages
+          : truncatedMessages.length
+            ? truncatedMessages
+            : messages;
+
       const { processedMessages, selectedModel, sandboxFiles } =
         await processChatMessages({
-          messages: truncatedMessages.length ? truncatedMessages : messages,
+          messages: messagesForProcessing,
           mode,
           subscription,
           uploadBasePath,
           modelOverride: selectedModelOverride,
+          allowLocalDesktopFiles: sandboxPreference === "desktop",
         });
 
       if (!processedMessages.length) {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -719,7 +719,12 @@ export const agentLongTask = task({
           }
 
           if (sandboxFiles && sandboxFiles.length > 0) {
-            writeUploadStartStatus(writer);
+            writeUploadStartStatus(
+              writer,
+              sandboxFiles.every((file) => file.kind === "localPath")
+                ? "Preparing local attachments on your computer"
+                : "Uploading attachments to the computer",
+            );
             let uploadResult: { failedCount: number } = { failedCount: 0 };
             try {
               uploadResult = await uploadSandboxFiles(

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -540,6 +540,7 @@ export const agentLongTask = task({
           : truncatedMessages.length
             ? truncatedMessages
             : messages;
+      const messagesForAccounting = messagesForProcessing;
 
       const { processedMessages, selectedModel, sandboxFiles } =
         await processChatMessages({
@@ -567,12 +568,12 @@ export const agentLongTask = task({
         selectedModel,
         userCustomization,
         temporary,
-        truncatedMessages,
+        truncatedMessages: messagesForAccounting,
       });
 
       chatLogger.setChat(
         {
-          messageCount: truncatedMessages.length,
+          messageCount: messagesForAccounting.length,
           estimatedInputTokens,
           isNewChat: !!isNewChat,
           fileCount: 0,
@@ -774,7 +775,7 @@ export const agentLongTask = task({
             : 0;
           const initialCtxUsage = contextUsageOn
             ? computeContextUsage(
-                truncatedMessages,
+                messagesForAccounting,
                 fileTokens,
                 ctxSystemTokens,
                 ctxMaxTokens,

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -323,11 +323,7 @@ export interface ExtraUsageConfig {
 export interface QueuedMessage {
   id: string;
   text: string;
-  files?: Array<{
-    file: File;
-    fileId: Id<"files">;
-    url: string;
-  }>;
+  files?: import("@/types/file").FileMessagePart[];
   timestamp: number;
 }
 

--- a/types/file.ts
+++ b/types/file.ts
@@ -3,19 +3,36 @@ import { Id } from "@/convex/_generated/dataModel";
 export interface FileMessagePart {
   type: "file";
   mediaType: string;
-  fileId: string; // Database file ID for backend operations
+  fileId?: string; // Database file ID for backend operations
   name: string;
   size: number;
+  storage?: "s3" | "local-desktop";
+  localAttachmentId?: string;
+  /**
+   * Transient source path for desktop-local agent attachments.
+   * Must never be persisted to Convex or long-lived task payloads.
+   */
+  localPath?: string;
   // DON'T store URL in message parts - S3 URLs expire!
   // URLs are generated on-demand via fileId
   // url: string;
 }
 
+export interface LocalDesktopFile {
+  name: string;
+  type: string;
+  size: number;
+  lastModified: number;
+}
+
 export interface UploadedFileState {
-  file: File;
+  file: File | LocalDesktopFile;
   uploading: boolean;
   uploaded: boolean;
   error?: string;
+  storage?: "s3" | "local-desktop";
+  localAttachmentId?: string;
+  localPath?: string;
   fileId?: string; // Database file ID for backend operations
   url?: string; // Store the resolved URL
   tokens?: number; // Token count for the file
@@ -28,6 +45,8 @@ export interface FilePart {
   name?: string;
   filename?: string;
   mediaType?: string;
+  storage?: "s3" | "local-desktop";
+  localAttachmentId?: string;
   storageId?: string; // Storage ID for on-demand URL fetching (Convex files)
   s3Key?: string; // S3 key for on-demand URL fetching (S3 files)
 }
@@ -47,7 +66,7 @@ export interface FileUploadPreviewProps {
 }
 
 export interface FilePreview {
-  file: File;
+  file: File | LocalDesktopFile;
   preview?: string;
   loading: boolean;
   uploading: boolean;


### PR DESCRIPTION
## Summary

Implements desktop-local Agent attachments so Tauri desktop users can attach path-backed files without uploading those file bytes to HackerAI/S3.

## What changed

- Adds a desktop-only local attachment path for Agent mode when `sandboxPreference === "desktop"`.
- Uses the Tauri dialog picker and a metadata command to create local-only attachment state.
- Stages local files into `/tmp/hackerai-upload` through the desktop sandbox bridge instead of downloading from S3.
- Scrubs transient `localPath` values before Convex persistence and before Trigger.dev payloads.
- Keeps existing S3 upload behavior for Ask mode, web, cloud E2B, remote sandboxes, and paste/drop blobs.
- Renders local-only file chips and blocks sending those attachments outside desktop Agent mode.

## Validation

- `pnpm typecheck`
- `pnpm test -- lib/utils/__tests__/sandbox-file-utils.test.ts app/hooks/__tests__/useFileUpload.local-desktop.test.tsx lib/chat/__tests__/chat-processor.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `cargo check` in `packages/desktop/src-tauri`
- `pnpm lint` passed with existing warnings only
- Commit hook ran `pnpm typecheck` and full `pnpm test`: 82 suites passed, 1068 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attach and send local desktop files from the desktop app in Agent/desktop sandbox mode; desktop file picker, metadata inspection, and local-file read added.

* **Improvements**
  * Local source paths are removed from outbound messages; desktop attachments are staged/prepared securely and upload-status text is clearer.
  * Better upload previews and clearer labels for local vs cloud files; sending/queuing validates desktop-only attachments.

* **Tests**
  * Added coverage for desktop-local selection, staging, and upload flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->