### PR TITLE
[codex] Remove chat message content visibility

### DIFF
--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -151,14 +151,6 @@ export const MessageItem = memo(function MessageItem({
     index === lastAssistantMessageIndex;
   const canRegenerate = status === "ready" || status === "error";
   const isLastMessage = index === messagesLength - 1;
-  const isLoading = status === "submitted" || status === "streaming";
-  const isActiveUserPromptDuringGeneration =
-    isUser &&
-    isLoading &&
-    lastAssistantMessageIndex !== undefined &&
-    index === lastAssistantMessageIndex - 1;
-  const shouldUseContentVisibility =
-    !isLastMessage && !isActiveUserPromptDuringGeneration;
 
   // Only the last assistant message should propagate "streaming" status to its
   // tool handlers. Old messages may have tools stuck in input-available /
@@ -307,15 +299,6 @@ export const MessageItem = memo(function MessageItem({
         className={`flex flex-col ${isUser ? "items-end" : "items-start"}`}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={onMouseLeave}
-        style={{
-          // Keep the active prompt rendered while its response starts. If a
-          // long prompt becomes non-last and collapses to the 100px intrinsic
-          // placeholder, the chat scroll position jumps upward mid-stream.
-          contentVisibility: shouldUseContentVisibility ? "auto" : "visible",
-          containIntrinsicSize: shouldUseContentVisibility
-            ? "auto 100px"
-            : undefined,
-        }}
       >
         {isEditing && isUser ? (
           <div className="w-full">


### PR DESCRIPTION
## Summary

Fixes repeated chat scroll jumps by removing `content-visibility` virtualization from mounted chat messages.

## Root Cause

`MessageItem` used `content-visibility: auto` with `containIntrinsicSize: auto 100px` for messages that were no longer the last item. That lets the browser replace an off-screen message with a 100px intrinsic placeholder. With long prompts, this changes the measured scroll height when new messages or chunks arrive.

The first version fixed the active first prompt. The follow-up tail-window version fixed the first few sends, but the same collapse returned as soon as the long prompt fell outside that window. Since any mounted long message can affect scroll height during generation, the robust fix is to remove this optimization from message items.

Pagination already limits how much history is mounted, so this favors scroll correctness over a fragile CSS optimization.

## Changes

- Remove `content-visibility` / `containIntrinsicSize` from `MessageItem` wrappers.
- Keep message height measurement stable across sends and streaming chunks.

## Validation

- `pnpm typecheck`
- `pnpm exec eslint app/components/MessageItem.tsx`
- Commit hook ran `prettier --write`, `eslint --fix`, `pnpm typecheck`, and full `pnpm test`: 80 suites / 1067 tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted message rendering behavior during the generation process

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->