### PR TITLE
Fix WorkOS organization names for checkout

### DIFF
--- a/app/api/migrate-pentestgpt/route.ts
+++ b/app/api/migrate-pentestgpt/route.ts
@@ -1,6 +1,7 @@
 import { stripe } from "../stripe";
 import { workos } from "../workos";
 import { getUserIDAndPro } from "@/lib/auth/get-user-id";
+import { buildWorkOSOrganizationName } from "@/lib/auth/workos-organization-name";
 import { NextRequest, NextResponse } from "next/server";
 
 export const POST = async (req: NextRequest) => {
@@ -149,9 +150,9 @@ export const POST = async (req: NextRequest) => {
       }
     }
 
-    // Create new organization with user's email as name
+    // Create new organization with a WorkOS-safe display name.
     const organization = await workos.organizations.createOrganization({
-      name: user.email,
+      name: buildWorkOSOrganizationName(user),
     });
 
     // Create organization membership for user as admin

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,6 +1,7 @@
 import { stripe } from "../stripe";
 import { workos } from "../workos";
 import { getUserID } from "@/lib/auth/get-user-id";
+import { buildWorkOSOrganizationName } from "@/lib/auth/workos-organization-name";
 import { NextRequest, NextResponse } from "next/server";
 import { getSuspensionMessage } from "@/lib/suspensionMessage";
 
@@ -12,9 +13,9 @@ export const POST = async (req: NextRequest) => {
     // Get user ID from authenticated session
     const userId = await getUserID(req);
 
-    // Get user details from WorkOS to use email as organization name
+    // Get user details from WorkOS to create a personal organization.
     const user = await workos.userManagement.getUser(userId);
-    const orgName = user.email;
+    const orgName = buildWorkOSOrganizationName(user);
     const allowedPlans = new Set([
       "pro-monthly-plan",
       "pro-plus-monthly-plan",

--- a/lib/auth/__tests__/workos-organization-name.test.ts
+++ b/lib/auth/__tests__/workos-organization-name.test.ts
@@ -1,0 +1,38 @@
+import { buildWorkOSOrganizationName } from "../workos-organization-name";
+
+describe("buildWorkOSOrganizationName", () => {
+  it("uses the user's display name when available", () => {
+    expect(
+      buildWorkOSOrganizationName({
+        email: "billing@example.com",
+        firstName: "Ada",
+        lastName: "Lovelace",
+      }),
+    ).toBe("Ada Lovelace");
+  });
+
+  it("falls back to a sanitized email local part", () => {
+    expect(
+      buildWorkOSOrganizationName({
+        email: "john+billing@example.com",
+      }),
+    ).toBe("john billing");
+  });
+
+  it("keeps characters allowed by WorkOS organization names", () => {
+    expect(
+      buildWorkOSOrganizationName({
+        firstName: "O'Connor-Smith",
+        lastName: "& Co. (NY), Inc.",
+      }),
+    ).toBe("O'Connor-Smith & Co. (NY), Inc.");
+  });
+
+  it("falls back when there is no valid organization name content", () => {
+    expect(
+      buildWorkOSOrganizationName({
+        email: "...+++@example.com",
+      }),
+    ).toBe("Personal Workspace");
+  });
+});

--- a/lib/auth/workos-organization-name.ts
+++ b/lib/auth/workos-organization-name.ts
@@ -1,0 +1,35 @@
+const FALLBACK_ORGANIZATION_NAME = "Personal Workspace";
+const MAX_ORGANIZATION_NAME_LENGTH = 255;
+
+const disallowedWorkOSOrganizationNameChars = /[^\p{L}\p{N} '\-&.,()]+/gu;
+const hasWorkOSOrganizationNameContent = /[\p{L}\p{N}]/u;
+
+type OrganizationNameInput = {
+  email?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+};
+
+export function buildWorkOSOrganizationName({
+  email,
+  firstName,
+  lastName,
+}: OrganizationNameInput): string {
+  const displayName = [firstName, lastName]
+    .map((part) => part?.trim())
+    .filter(Boolean)
+    .join(" ");
+
+  const emailLocalPart = email?.split("@")[0] ?? "";
+  const candidate = displayName || emailLocalPart || FALLBACK_ORGANIZATION_NAME;
+  const sanitized = candidate
+    .replace(disallowedWorkOSOrganizationNameChars, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_ORGANIZATION_NAME_LENGTH)
+    .trim();
+
+  return hasWorkOSOrganizationNameContent.test(sanitized)
+    ? sanitized
+    : FALLBACK_ORGANIZATION_NAME;
+}


### PR DESCRIPTION
## Summary
- Stop using raw user email as the WorkOS organization name during checkout and PentestGPT migration
- Add a shared helper that builds a WorkOS-safe organization name from display name or sanitized email local-part
- Cover display name, email fallback, allowed punctuation, and fallback behavior with tests

## Verification
- pnpm test -- lib/auth/__tests__/workos-organization-name.test.ts --runInBand
- pnpm typecheck
- pnpm exec eslint app/api/subscribe/route.ts app/api/migrate-pentestgpt/route.ts lib/auth/workos-organization-name.ts lib/auth/__tests__/workos-organization-name.test.ts
- pre-commit: pnpm typecheck && pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced organization naming: now derives names from user display names when available, with intelligent fallback to email local part or "Personal Workspace" as default across migration and subscription flows.

* **Tests**
  * Added test suite for organization naming logic, covering display name usage, email fallback, character sanitization, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->