### PR TITLE
[codex] fix oversized agent message saves

### DIFF
--- a/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
+++ b/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
@@ -766,6 +766,35 @@ describe("compactMessageForStorage", () => {
     );
   });
 
+  it("compacts oversized reasoning and storage-only status parts", () => {
+    const message = makeAssistantMessage([
+      { type: "step-start" },
+      { type: "data-summarization", data: { status: "completed" } },
+      { type: "reasoning", text: "old ".repeat(20_000), state: "done" },
+      { type: "text", text: "final answer" },
+    ]);
+
+    const result = compactMessageForStorage(message, {
+      softLimitBytes: 1_000,
+      toolOutputTokenBudget: 10_000,
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(
+      result.message.parts.some((part) => part.type === "step-start"),
+    ).toBe(false);
+    expect(
+      result.message.parts.some((part) => part.type === "data-summarization"),
+    ).toBe(false);
+    expect(estimateSerializedSizeBytes(result.message.parts)).toBeLessThan(
+      estimateSerializedSizeBytes(message.parts),
+    );
+    expect(result.message.parts.at(-1)).toEqual({
+      type: "text",
+      text: "final answer",
+    });
+  });
+
   it("does not compact user messages", () => {
     const message = makeUserMessage("x".repeat(5000));
 

--- a/lib/chat/compaction/prune-tool-outputs.ts
+++ b/lib/chat/compaction/prune-tool-outputs.ts
@@ -59,6 +59,10 @@ export interface StorageCompactionResult<T extends UIMessage = UIMessage> {
 
 const STORAGE_MESSAGE_SOFT_LIMIT_BYTES = 850 * 1024;
 const STORAGE_TOOL_OUTPUT_TOKEN_BUDGET = 20_000;
+const STORAGE_REASONING_CHAR_BUDGET = 32_000;
+const STORAGE_REASONING_PART_CHAR_LIMIT = 8_000;
+const STORAGE_COMPACTED_REASONING_PREFIX =
+  "[Earlier reasoning compacted for storage]\n\n";
 
 // ---------------------------------------------------------------------------
 // Placeholder builders per tool type
@@ -202,6 +206,55 @@ const stripBulkyOutputFields = (part: ToolPart): ToolPart => {
   return part;
 };
 
+const compactReasoningParts = (
+  parts: UIMessage["parts"],
+): UIMessage["parts"] => {
+  let remainingReasoningChars = STORAGE_REASONING_CHAR_BUDGET;
+
+  const compacted = parts
+    .slice()
+    .reverse()
+    .map((part) => {
+      if (part?.type !== "reasoning") return part;
+
+      const text = typeof part.text === "string" ? part.text : "";
+      if (!text.trim()) return null;
+      if (remainingReasoningChars <= 0) return null;
+
+      const charLimit = Math.min(
+        remainingReasoningChars,
+        STORAGE_REASONING_PART_CHAR_LIMIT,
+      );
+      remainingReasoningChars -= Math.min(text.length, charLimit);
+
+      if (text.length <= charLimit) return part;
+
+      const prefixBudget = Math.min(
+        STORAGE_COMPACTED_REASONING_PREFIX.length,
+        charLimit,
+      );
+      const tailBudget = Math.max(0, charLimit - prefixBudget);
+
+      return {
+        ...part,
+        text: `${STORAGE_COMPACTED_REASONING_PREFIX.slice(
+          0,
+          prefixBudget,
+        )}${tailBudget > 0 ? text.slice(-tailBudget) : ""}`,
+      };
+    })
+    .filter((part): part is UIMessage["parts"][number] => part !== null)
+    .reverse();
+
+  return compacted;
+};
+
+const stripStorageOnlyParts = (parts: UIMessage["parts"]): UIMessage["parts"] =>
+  parts.filter(
+    (part) =>
+      part?.type !== "step-start" && part?.type !== "data-summarization",
+  );
+
 /**
  * Compacts a single assistant UIMessage before database storage.
  *
@@ -258,6 +311,16 @@ export function compactMessageForStorage<T extends UIMessage>(
     const pruneResult = pruneToolOutputs([{ ...message, parts }], 0, 0);
     parts = pruneResult.messages[0]?.parts ?? parts;
     prunedCount += pruneResult.prunedCount;
+    afterSizeBytes = estimateSerializedSizeBytes(parts);
+  }
+
+  if (afterSizeBytes > softLimitBytes) {
+    parts = compactReasoningParts(parts);
+    afterSizeBytes = estimateSerializedSizeBytes(parts);
+  }
+
+  if (afterSizeBytes > softLimitBytes) {
+    parts = stripStorageOnlyParts(parts);
     afterSizeBytes = estimateSerializedSizeBytes(parts);
   }
 

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -28,6 +28,7 @@ import { sanitizeForConvexValue } from "./convex-value-sanitizer";
 
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 const MAX_DATABASE_ERROR_MESSAGE_LENGTH = 500;
+const LARGE_MESSAGE_SAVE_WARNING_BYTES = 850 * 1024;
 
 export { setConvexUrl };
 
@@ -145,6 +146,8 @@ export async function saveMessage({
   isHidden?: boolean;
 }) {
   let fixedParts = message.parts;
+  let partsForSave = message.parts;
+  let persistenceDiagnostics = getMessagePersistenceDiagnostics(partsForSave);
 
   try {
     // Fix incomplete tool invocations for assistant messages (from interrupted streams)
@@ -168,13 +171,34 @@ export async function saveMessage({
       });
     }
 
-    fixedParts = sanitizeForConvexValue(fixedParts) as UIMessagePart<
+    partsForSave = sanitizeForConvexValue(storageSafeParts) as UIMessagePart<
       any,
       any
     >[];
+    persistenceDiagnostics = getMessagePersistenceDiagnostics(partsForSave);
+    if (
+      message.role === "assistant" &&
+      persistenceDiagnostics.parts_size_bytes > LARGE_MESSAGE_SAVE_WARNING_BYTES
+    ) {
+      console.warn(
+        JSON.stringify({
+          level: "warn",
+          event: "large_message_save_attempt",
+          service: "chat-handler",
+          timestamp: new Date().toISOString(),
+          chat_id: chatId,
+          user_id: userId,
+          message_id: message.id,
+          mode,
+          model,
+          finish_reason: finishReason,
+          ...persistenceDiagnostics,
+        }),
+      );
+    }
 
     // Extract file IDs from file parts
-    const fileIds = extractFileIdsFromParts(storageSafeParts);
+    const fileIds = extractFileIdsFromParts(partsForSave);
     const mergedFileIds = [
       ...fileIds,
       ...((extraFileIds || []).filter(Boolean) as string[]),
@@ -186,7 +210,7 @@ export async function saveMessage({
       chatId,
       userId,
       role: message.role,
-      parts: storageSafeParts,
+      parts: partsForSave,
       fileIds: mergedFileIds.length > 0 ? (mergedFileIds as any) : undefined,
       model,
       mode,
@@ -210,7 +234,7 @@ export async function saveMessage({
       hidden: isHidden === true,
       extra_file_count: extraFileIds?.length ?? 0,
       usage_keys: usage ? Object.keys(usage).sort() : undefined,
-      ...getMessagePersistenceDiagnostics(fixedParts),
+      ...persistenceDiagnostics,
     });
   }
 }


### PR DESCRIPTION
## Summary

Fixes long `agent-long` runs that can complete successfully but fail in `onFinish` when persisting an oversized assistant message to Convex.

## Root Cause

A long agent run can accumulate a single assistant message with many tool, reasoning, and UI status parts. The failing run had a persisted parts payload around 1.2 MB, which can exceed Convex's per-document storage limit. The DB save diagnostics also measured the wrong part array after compaction, making failures harder to interpret.

## Changes

- Save the sanitized, storage-compacted message parts instead of the pre-compaction parts.
- Add structured warning logs for large assistant message save attempts using post-compaction diagnostics.
- Add fallback storage compaction for oversized reasoning parts and storage-only status parts like `step-start` and `data-summarization`.
- Add test coverage for the oversized reasoning/status compaction path.

## User Impact

For normal runs, transcript rendering should be unchanged. For very large agent runs, older reasoning/status detail may be compacted so the final assistant response can still persist instead of the whole run failing at save time.

## Validation

- `pnpm test -- lib/chat/compaction/__tests__/prune-tool-outputs.test.ts --runInBand`
- `pnpm typecheck`
- Commit hook: `pnpm typecheck`
- Commit hook: full `pnpm test` (83 suites, 1079 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for message compaction to verify oversized parts are handled correctly.

* **Refactor**
  * Enhanced message storage optimization with improved reasoning part compaction and removal of storage-only parts.
  * Added warning system for message payloads exceeding configured size thresholds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->