### PR TITLE
[codex] add unit economics dashboard

### DIFF
--- a/app/(chat)/layout.tsx
+++ b/app/(chat)/layout.tsx
@@ -2,6 +2,7 @@
 
 import { Authenticated, Unauthenticated, AuthLoading } from "convex/react";
 import { ChatLayout } from "@/app/components/ChatLayout";
+import { AttributionSync } from "@/app/components/AttributionSync";
 import Loading from "@/components/ui/loading";
 
 const fullWidthShell = (
@@ -32,6 +33,7 @@ export default function ChatRouteLayout({
       </Unauthenticated>
       <Authenticated>
         <div className="h-dvh min-h-0 flex flex-col bg-background overflow-hidden">
+          <AttributionSync />
           <ChatLayout>{children}</ChatLayout>
         </div>
       </Authenticated>

--- a/app/admin/economics/page.tsx
+++ b/app/admin/economics/page.tsx
@@ -1,0 +1,284 @@
+import { ConvexHttpClient } from "convex/browser";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import type { ComponentType } from "react";
+import {
+  Activity,
+  ArrowLeft,
+  BadgeDollarSign,
+  Gauge,
+  RefreshCw,
+  TrendingUp,
+  Users,
+} from "lucide-react";
+import Link from "next/link";
+import { api } from "@/convex/_generated/api";
+import { isAdminUserId } from "@/lib/admin";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export const dynamic = "force-dynamic";
+
+const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+
+type SearchParams = Promise<{
+  startDay?: string;
+  endDay?: string;
+}>;
+
+const dayPattern = /^\d{4}-\d{2}-\d{2}$/;
+
+function dayString(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function defaultRange() {
+  const end = new Date();
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 30);
+  return { startDay: dayString(start), endDay: dayString(end) };
+}
+
+function cleanDay(value: string | undefined, fallback: string): string {
+  return value && dayPattern.test(value) ? value : fallback;
+}
+
+const dollars = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+});
+
+const preciseDollars = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 4,
+  maximumFractionDigits: 4,
+});
+
+const integer = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+});
+
+const percent = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  maximumFractionDigits: 1,
+});
+
+function Metric({
+  title,
+  value,
+  detail,
+  icon: Icon,
+}: {
+  title: string;
+  value: string;
+  detail?: string;
+  icon: ComponentType<{ className?: string }>;
+}) {
+  return (
+    <Card className="rounded-lg gap-4 py-5">
+      <CardHeader className="flex flex-row items-center justify-between gap-3 px-5">
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          {title}
+        </CardTitle>
+        <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+      </CardHeader>
+      <CardContent className="px-5">
+        <div className="text-2xl font-semibold tracking-normal">{value}</div>
+        {detail ? (
+          <div className="mt-1 text-xs text-muted-foreground">{detail}</div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex items-center justify-between gap-4 border-b border-border py-3 last:border-b-0">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <span className="text-sm font-medium tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+export default async function EconomicsPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const { user } = await withAuth({ ensureSignedIn: true });
+  if (!isAdminUserId(user.id)) {
+    redirect("/auth-error?code=403");
+  }
+
+  const params = await searchParams;
+  const fallback = defaultRange();
+  const startDay = cleanDay(params.startDay, fallback.startDay);
+  const endDay = cleanDay(params.endDay, fallback.endDay);
+
+  const summary = await convex.query(api.economics.getEconomicsSummary, {
+    serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+    startDay,
+    endDay,
+  });
+
+  const contributionPerActiveUser =
+    summary.users.active > 0
+      ? summary.margin.contributionDollars / summary.users.active
+      : 0;
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-4 py-6 sm:px-6 lg:px-8">
+        <header className="flex flex-col gap-5 border-b border-border pb-6 lg:flex-row lg:items-end lg:justify-between">
+          <div className="min-w-0">
+            <Button asChild variant="ghost" size="sm" className="-ml-3 mb-3">
+              <Link href="/">
+                <ArrowLeft className="h-4 w-4" />
+                Back
+              </Link>
+            </Button>
+            <h1 className="text-2xl font-semibold tracking-normal">
+              Unit Economics
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+              Internal cost and revenue summary for free limits, margins, and
+              acquisition decisions.
+            </p>
+          </div>
+
+          <form
+            className="grid w-full gap-3 sm:grid-cols-[1fr_1fr_auto] lg:w-auto"
+            method="GET"
+          >
+            <label className="grid gap-1.5 text-xs text-muted-foreground">
+              Start
+              <Input name="startDay" type="date" defaultValue={startDay} />
+            </label>
+            <label className="grid gap-1.5 text-xs text-muted-foreground">
+              End
+              <Input name="endDay" type="date" defaultValue={endDay} />
+            </label>
+            <Button type="submit" className="self-end">
+              <RefreshCw className="h-4 w-4" />
+              Apply
+            </Button>
+          </form>
+        </header>
+
+        <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <Metric
+            title="Net Revenue"
+            value={dollars.format(summary.revenue.netRevenueDollars)}
+            detail={`${dollars.format(summary.revenue.grossRevenueDollars)} gross`}
+            icon={BadgeDollarSign}
+          />
+          <Metric
+            title="Total Cost"
+            value={dollars.format(summary.usage.totalCostDollars)}
+            detail={`${integer.format(summary.usage.requests)} requests`}
+            icon={Activity}
+          />
+          <Metric
+            title="Contribution"
+            value={dollars.format(summary.margin.contributionDollars)}
+            detail={`${percent.format(summary.margin.grossMargin)} margin`}
+            icon={TrendingUp}
+          />
+          <Metric
+            title="30d Conversion"
+            value={percent.format(summary.conversion.freeToPaid30d)}
+            detail={`${integer.format(summary.users.signupCohort)} signup cohort`}
+            icon={Gauge}
+          />
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-3">
+          <Card className="rounded-lg">
+            <CardHeader>
+              <CardTitle className="text-base">Users</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Row
+                label="Active users"
+                value={integer.format(summary.users.active)}
+              />
+              <Row
+                label="Active free users"
+                value={integer.format(summary.users.activeFree)}
+              />
+              <Row
+                label="Active paid users"
+                value={integer.format(summary.users.activePaid)}
+              />
+              <Row
+                label="Signup cohort"
+                value={integer.format(summary.users.signupCohort)}
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-lg">
+            <CardHeader>
+              <CardTitle className="text-base">Cost</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Row
+                label="Free cost"
+                value={dollars.format(summary.usage.freeCostDollars)}
+              />
+              <Row
+                label="Paid cost"
+                value={dollars.format(summary.usage.paidCostDollars)}
+              />
+              <Row
+                label="Free cost/user"
+                value={preciseDollars.format(
+                  summary.usage.freeCostPerActiveFreeUser,
+                )}
+              />
+              <Row
+                label="Paid cost/user"
+                value={preciseDollars.format(
+                  summary.usage.paidCostPerActivePaidUser,
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-lg">
+            <CardHeader>
+              <CardTitle className="text-base">Revenue</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Row label="ARPU" value={dollars.format(summary.revenue.arpu)} />
+              <Row
+                label="ARPPU"
+                value={dollars.format(summary.revenue.arppu)}
+              />
+              <Row
+                label="Refunds"
+                value={dollars.format(summary.revenue.refundDollars)}
+              />
+              <Row
+                label="Contribution/user"
+                value={dollars.format(contributionPerActiveUser)}
+              />
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="flex items-center gap-2 rounded-lg border border-border px-4 py-3 text-sm text-muted-foreground">
+          <Users className="h-4 w-4 shrink-0" />
+          <span>
+            Data comes from Convex daily aggregates and Stripe webhooks. PostHog
+            is not needed to view this dashboard.
+          </span>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/admin/economics/page.tsx
+++ b/app/admin/economics/page.tsx
@@ -6,7 +6,9 @@ import {
   Activity,
   ArrowLeft,
   BadgeDollarSign,
+  Download,
   Gauge,
+  Info,
   RefreshCw,
   TrendingUp,
   Users,
@@ -104,6 +106,11 @@ function Row({ label, value }: { label: string; value: string | number }) {
   );
 }
 
+function csvUrl(startDay: string, endDay: string): string {
+  const params = new URLSearchParams({ startDay, endDay, format: "csv" });
+  return `/api/admin/economics?${params.toString()}`;
+}
+
 export default async function EconomicsPage({
   searchParams,
 }: {
@@ -129,6 +136,11 @@ export default async function EconomicsPage({
     summary.users.active > 0
       ? summary.margin.contributionDollars / summary.users.active
       : 0;
+  const hasEconomicsData =
+    summary.usage.requests > 0 ||
+    summary.revenue.grossRevenueDollars !== 0 ||
+    summary.revenue.netRevenueDollars !== 0 ||
+    summary.usage.totalCostDollars !== 0;
 
   return (
     <main className="min-h-screen bg-background text-foreground">
@@ -150,24 +162,43 @@ export default async function EconomicsPage({
             </p>
           </div>
 
-          <form
-            className="grid w-full gap-3 sm:grid-cols-[1fr_1fr_auto] lg:w-auto"
-            method="GET"
-          >
-            <label className="grid gap-1.5 text-xs text-muted-foreground">
-              Start
-              <Input name="startDay" type="date" defaultValue={startDay} />
-            </label>
-            <label className="grid gap-1.5 text-xs text-muted-foreground">
-              End
-              <Input name="endDay" type="date" defaultValue={endDay} />
-            </label>
-            <Button type="submit" className="self-end">
-              <RefreshCw className="h-4 w-4" />
-              Apply
+          <div className="flex w-full flex-col gap-3 lg:w-auto">
+            <form
+              className="grid w-full gap-3 sm:grid-cols-[1fr_1fr_auto] lg:w-auto"
+              method="GET"
+            >
+              <label className="grid gap-1.5 text-xs text-muted-foreground">
+                Start
+                <Input name="startDay" type="date" defaultValue={startDay} />
+              </label>
+              <label className="grid gap-1.5 text-xs text-muted-foreground">
+                End
+                <Input name="endDay" type="date" defaultValue={endDay} />
+              </label>
+              <Button type="submit" className="self-end">
+                <RefreshCw className="h-4 w-4" />
+                Apply
+              </Button>
+            </form>
+            <Button asChild variant="outline" className="w-full lg:self-end">
+              <Link href={csvUrl(startDay, endDay)}>
+                <Download className="h-4 w-4" />
+                Export CSV
+              </Link>
             </Button>
-          </form>
+          </div>
         </header>
+
+        {!hasEconomicsData ? (
+          <section className="flex items-start gap-3 rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+            <Info className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>
+              No usage or revenue rows were found for this range. Economics data
+              starts after this instrumentation is deployed and the first LLM
+              usage or Stripe revenue event is recorded.
+            </span>
+          </section>
+        ) : null}
 
         <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
           <Metric

--- a/app/admin/economics/page.tsx
+++ b/app/admin/economics/page.tsx
@@ -11,7 +11,6 @@ import {
   Info,
   RefreshCw,
   TrendingUp,
-  Users,
 } from "lucide-react";
 import Link from "next/link";
 import { api } from "@/convex/_generated/api";
@@ -300,14 +299,6 @@ export default async function EconomicsPage({
               />
             </CardContent>
           </Card>
-        </section>
-
-        <section className="flex items-center gap-2 rounded-lg border border-border px-4 py-3 text-sm text-muted-foreground">
-          <Users className="h-4 w-4 shrink-0" />
-          <span>
-            Data comes from Convex daily aggregates and Stripe webhooks. PostHog
-            is not needed to view this dashboard.
-          </span>
         </section>
       </div>
     </main>

--- a/app/api/admin/economics/route.ts
+++ b/app/api/admin/economics/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "@/convex/_generated/api";
+import { getUserID } from "@/lib/auth/get-user-id";
+import { isAdminUserId } from "@/lib/admin";
+
+const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+
+async function assertAdmin(req: NextRequest) {
+  let userId: string;
+  try {
+    userId = await getUserID(req);
+  } catch {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!isAdminUserId(userId)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return null;
+}
+
+const dayString = (date: Date): string => date.toISOString().slice(0, 10);
+
+function defaultRange() {
+  const end = new Date();
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 30);
+  return { startDay: dayString(start), endDay: dayString(end) };
+}
+
+export async function GET(req: NextRequest) {
+  const forbidden = await assertAdmin(req);
+  if (forbidden) return forbidden;
+
+  const fallback = defaultRange();
+  const startDay =
+    req.nextUrl.searchParams.get("startDay") ?? fallback.startDay;
+  const endDay = req.nextUrl.searchParams.get("endDay") ?? fallback.endDay;
+
+  const summary = await convex.query(api.economics.getEconomicsSummary, {
+    serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+    startDay,
+    endDay,
+  });
+
+  return NextResponse.json(summary);
+}

--- a/app/api/admin/economics/route.ts
+++ b/app/api/admin/economics/route.ts
@@ -51,12 +51,25 @@ async function assertAdmin(req: NextRequest) {
 }
 
 const dayString = (date: Date): string => date.toISOString().slice(0, 10);
+const dayPattern = /^\d{4}-\d{2}-\d{2}$/;
 
 function defaultRange() {
   const end = new Date();
   const start = new Date(end);
   start.setUTCDate(start.getUTCDate() - 30);
   return { startDay: dayString(start), endDay: dayString(end) };
+}
+
+function parseDay(value: string | null, fallback: string): string | null {
+  const day = value ?? fallback;
+  if (!dayPattern.test(day)) return null;
+
+  const parsed = new Date(`${day}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime()) || dayString(parsed) !== day) {
+    return null;
+  }
+
+  return day;
 }
 
 function csvEscape(value: string | number): string {
@@ -100,9 +113,21 @@ export async function GET(req: NextRequest) {
   if (forbidden) return forbidden;
 
   const fallback = defaultRange();
-  const startDay =
-    req.nextUrl.searchParams.get("startDay") ?? fallback.startDay;
-  const endDay = req.nextUrl.searchParams.get("endDay") ?? fallback.endDay;
+  const startDay = parseDay(
+    req.nextUrl.searchParams.get("startDay"),
+    fallback.startDay,
+  );
+  const endDay = parseDay(
+    req.nextUrl.searchParams.get("endDay"),
+    fallback.endDay,
+  );
+
+  if (!startDay || !endDay || startDay > endDay) {
+    return NextResponse.json(
+      { error: "Invalid date range. Use YYYY-MM-DD with startDay <= endDay." },
+      { status: 400 },
+    );
+  }
 
   const summary: EconomicsSummary = await convex.query(
     api.economics.getEconomicsSummary,

--- a/app/api/admin/economics/route.ts
+++ b/app/api/admin/economics/route.ts
@@ -6,6 +6,36 @@ import { isAdminUserId } from "@/lib/admin";
 
 const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
+type EconomicsSummary = {
+  range: { startDay: string; endDay: string };
+  users: {
+    active: number;
+    activeFree: number;
+    activePaid: number;
+    signupCohort: number;
+  };
+  usage: {
+    requests: number;
+    freeCostDollars: number;
+    paidCostDollars: number;
+    totalCostDollars: number;
+    freeCostPerActiveFreeUser: number;
+    paidCostPerActivePaidUser: number;
+  };
+  revenue: {
+    grossRevenueDollars: number;
+    refundDollars: number;
+    netRevenueDollars: number;
+    arpu: number;
+    arppu: number;
+  };
+  conversion: { freeToPaid30d: number };
+  margin: {
+    contributionDollars: number;
+    grossMargin: number;
+  };
+};
+
 async function assertAdmin(req: NextRequest) {
   let userId: string;
   try {
@@ -29,6 +59,42 @@ function defaultRange() {
   return { startDay: dayString(start), endDay: dayString(end) };
 }
 
+function csvEscape(value: string | number): string {
+  const text = String(value);
+  return /[",\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+function economicsSummaryCsv(summary: EconomicsSummary): string {
+  const rows: Array<[string, string | number]> = [
+    ["start_day", summary.range.startDay],
+    ["end_day", summary.range.endDay],
+    ["active_users", summary.users.active],
+    ["active_free_users", summary.users.activeFree],
+    ["active_paid_users", summary.users.activePaid],
+    ["signup_cohort", summary.users.signupCohort],
+    ["requests", summary.usage.requests],
+    ["free_cost_dollars", summary.usage.freeCostDollars],
+    ["paid_cost_dollars", summary.usage.paidCostDollars],
+    ["total_cost_dollars", summary.usage.totalCostDollars],
+    ["free_cost_per_active_free_user", summary.usage.freeCostPerActiveFreeUser],
+    ["paid_cost_per_active_paid_user", summary.usage.paidCostPerActivePaidUser],
+    ["gross_revenue_dollars", summary.revenue.grossRevenueDollars],
+    ["refund_dollars", summary.revenue.refundDollars],
+    ["net_revenue_dollars", summary.revenue.netRevenueDollars],
+    ["arpu", summary.revenue.arpu],
+    ["arppu", summary.revenue.arppu],
+    ["free_to_paid_30d", summary.conversion.freeToPaid30d],
+    ["contribution_dollars", summary.margin.contributionDollars],
+    ["gross_margin", summary.margin.grossMargin],
+  ];
+
+  return [
+    "metric,value",
+    ...rows.map((row) => row.map(csvEscape).join(",")),
+    "",
+  ].join("\n");
+}
+
 export async function GET(req: NextRequest) {
   const forbidden = await assertAdmin(req);
   if (forbidden) return forbidden;
@@ -38,11 +104,23 @@ export async function GET(req: NextRequest) {
     req.nextUrl.searchParams.get("startDay") ?? fallback.startDay;
   const endDay = req.nextUrl.searchParams.get("endDay") ?? fallback.endDay;
 
-  const summary = await convex.query(api.economics.getEconomicsSummary, {
-    serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
-    startDay,
-    endDay,
-  });
+  const summary: EconomicsSummary = await convex.query(
+    api.economics.getEconomicsSummary,
+    {
+      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+      startDay,
+      endDay,
+    },
+  );
+
+  if (req.nextUrl.searchParams.get("format") === "csv") {
+    return new NextResponse(economicsSummaryCsv(summary), {
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="hackerai-economics-${startDay}-to-${endDay}.csv"`,
+      },
+    });
+  }
 
   return NextResponse.json(summary);
 }

--- a/app/api/analytics/attribution/route.ts
+++ b/app/api/analytics/attribution/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "@/convex/_generated/api";
+import { getUserIDAndPro } from "@/lib/auth/get-user-id";
+
+const ATTRIBUTION_COOKIE = "hai_attribution";
+const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+
+const cleanString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0
+    ? value.slice(0, 500)
+    : undefined;
+
+export async function POST(req: NextRequest) {
+  const { userId, subscription, organizationId } = await getUserIDAndPro(req);
+  const cookieStore = await cookies();
+  const raw = cookieStore.get(ATTRIBUTION_COOKIE)?.value;
+  let attribution: Record<string, unknown> = {};
+
+  if (raw) {
+    try {
+      attribution = JSON.parse(decodeURIComponent(raw));
+    } catch {
+      attribution = {};
+    }
+  }
+
+  await convex.mutation(api.economics.upsertUserAccount, {
+    serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+    user_id: userId,
+    current_subscription_tier: subscription,
+    workos_organization_id: organizationId,
+    utm_source: cleanString(attribution.utm_source),
+    utm_medium: cleanString(attribution.utm_medium),
+    utm_campaign: cleanString(attribution.utm_campaign),
+    utm_content: cleanString(attribution.utm_content),
+    utm_term: cleanString(attribution.utm_term),
+    gclid: cleanString(attribution.gclid),
+    fbclid: cleanString(attribution.fbclid),
+    landing_page: cleanString(attribution.landing_page),
+    referrer: cleanString(attribution.referrer),
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/extra-usage/confirm/route.ts
+++ b/app/api/extra-usage/confirm/route.ts
@@ -55,12 +55,37 @@ export async function GET(req: NextRequest) {
       return NextResponse.redirect(redirectUrl, { status: 303 });
     }
 
-    await convex.mutation(api.extraUsage.addCredits, {
+    const result = await convex.mutation(api.extraUsage.addCredits, {
       serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
       userId,
       amountDollars,
       idempotencyKey: `cs_${session.id}`,
     });
+
+    if (!result.alreadyProcessed) {
+      await convex.mutation(api.economics.recordRevenueEvent, {
+        serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+        dedupe_key: `extra_usage:${session.id}:${userId}`,
+        stripe_event_id: `checkout_confirm:${session.id}`,
+        event_type: "checkout.session.confirmed",
+        revenue_type: "extra_usage",
+        occurred_at: (session.created ?? Math.floor(Date.now() / 1000)) * 1000,
+        user_id: userId,
+        stripe_customer_id:
+          typeof session.customer === "string"
+            ? session.customer
+            : session.customer?.id,
+        stripe_checkout_session_id: session.id,
+        currency: session.currency ?? "usd",
+        gross_revenue_dollars: amountDollars,
+        refund_dollars: 0,
+        dispute_dollars: 0,
+        net_revenue_dollars: amountDollars,
+        metadata: {
+          source: "extra_usage_confirm",
+        },
+      });
+    }
 
     return NextResponse.redirect(redirectUrl, { status: 303 });
   } catch (err) {

--- a/app/api/extra-usage/confirm/route.ts
+++ b/app/api/extra-usage/confirm/route.ts
@@ -55,37 +55,35 @@ export async function GET(req: NextRequest) {
       return NextResponse.redirect(redirectUrl, { status: 303 });
     }
 
-    const result = await convex.mutation(api.extraUsage.addCredits, {
+    await convex.mutation(api.extraUsage.addCredits, {
       serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
       userId,
       amountDollars,
       idempotencyKey: `cs_${session.id}`,
     });
 
-    if (!result.alreadyProcessed) {
-      await convex.mutation(api.economics.recordRevenueEvent, {
-        serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
-        dedupe_key: `extra_usage:${session.id}:${userId}`,
-        stripe_event_id: `checkout_confirm:${session.id}`,
-        event_type: "checkout.session.confirmed",
-        revenue_type: "extra_usage",
-        occurred_at: (session.created ?? Math.floor(Date.now() / 1000)) * 1000,
-        user_id: userId,
-        stripe_customer_id:
-          typeof session.customer === "string"
-            ? session.customer
-            : session.customer?.id,
-        stripe_checkout_session_id: session.id,
-        currency: session.currency ?? "usd",
-        gross_revenue_dollars: amountDollars,
-        refund_dollars: 0,
-        dispute_dollars: 0,
-        net_revenue_dollars: amountDollars,
-        metadata: {
-          source: "extra_usage_confirm",
-        },
-      });
-    }
+    await convex.mutation(api.economics.recordRevenueEvent, {
+      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+      dedupe_key: `extra_usage:${session.id}:${userId}`,
+      stripe_event_id: `checkout_confirm:${session.id}`,
+      event_type: "checkout.session.confirmed",
+      revenue_type: "extra_usage",
+      occurred_at: (session.created ?? Math.floor(Date.now() / 1000)) * 1000,
+      user_id: userId,
+      stripe_customer_id:
+        typeof session.customer === "string"
+          ? session.customer
+          : session.customer?.id,
+      stripe_checkout_session_id: session.id,
+      currency: session.currency ?? "usd",
+      gross_revenue_dollars: amountDollars,
+      refund_dollars: 0,
+      dispute_dollars: 0,
+      net_revenue_dollars: amountDollars,
+      metadata: {
+        source: "extra_usage_confirm",
+      },
+    });
 
     return NextResponse.redirect(redirectUrl, { status: 303 });
   } catch (err) {

--- a/app/api/extra-usage/webhook/route.ts
+++ b/app/api/extra-usage/webhook/route.ts
@@ -90,9 +90,8 @@ export async function POST(req: NextRequest) {
 
         if (result.alreadyProcessed) {
           console.log(
-            `[Extra Usage Webhook] Checkout session ${session.id} already processed, skipping`,
+            `[Extra Usage Webhook] Checkout session ${session.id} already credited, ensuring revenue is recorded`,
           );
-          break;
         }
 
         await convex.mutation(api.economics.recordRevenueEvent, {

--- a/app/api/extra-usage/webhook/route.ts
+++ b/app/api/extra-usage/webhook/route.ts
@@ -5,6 +5,7 @@ import { api } from "@/convex/_generated/api";
 import Stripe from "stripe";
 
 const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 
 /**
  * POST /api/extra-usage/webhook
@@ -80,7 +81,7 @@ export async function POST(req: NextRequest) {
       // the same key) can race without double-crediting.
       try {
         const result = await convex.mutation(api.extraUsage.addCredits, {
-          serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+          serviceKey,
           userId,
           amountDollars,
           idempotencyKey: `cs_${session.id}`,
@@ -91,7 +92,31 @@ export async function POST(req: NextRequest) {
           console.log(
             `[Extra Usage Webhook] Checkout session ${session.id} already processed, skipping`,
           );
+          break;
         }
+
+        await convex.mutation(api.economics.recordRevenueEvent, {
+          serviceKey,
+          dedupe_key: `extra_usage:${session.id}:${userId}`,
+          stripe_event_id: event.id,
+          event_type: event.type,
+          revenue_type: "extra_usage",
+          occurred_at: (session.created ?? event.created) * 1000,
+          user_id: userId,
+          stripe_customer_id:
+            typeof session.customer === "string"
+              ? session.customer
+              : session.customer?.id,
+          stripe_checkout_session_id: session.id,
+          currency: session.currency ?? "usd",
+          gross_revenue_dollars: amountDollars,
+          refund_dollars: 0,
+          dispute_dollars: 0,
+          net_revenue_dollars: amountDollars,
+          metadata: {
+            source: "extra_usage_checkout",
+          },
+        });
       } catch (error) {
         console.error("[Extra Usage Webhook] FAILED to add credits:", error);
         // Return 500 so Stripe retries

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -37,6 +37,7 @@ function tierDirection(
 }
 
 const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 
 // =============================================================================
 // Tier Resolution
@@ -57,6 +58,96 @@ function planLookupKeyToTier(lookupKey: string): SubscriptionTier | null {
 
 const resolveUserIdsFromCustomer = (customerId: string) =>
   resolveStripeCustomerUsers(customerId, "Subscription Webhook");
+
+const centsToDollars = (amount: number | null | undefined): number =>
+  (amount ?? 0) / 100;
+
+async function recordRevenueForUsers({
+  event,
+  userIds,
+  orgId,
+  customerId,
+  tier,
+  revenueType,
+  grossDollars,
+  refundDollars = 0,
+  disputeDollars = 0,
+  stripeFeeDollars,
+  netDollars,
+  stripeInvoiceId,
+  stripeSubscriptionId,
+  metadata,
+}: {
+  event: Stripe.Event;
+  userIds: string[];
+  orgId: string | null;
+  customerId?: string | null;
+  tier?: SubscriptionTier | null;
+  revenueType: "subscription" | "refund" | "dispute";
+  grossDollars: number;
+  refundDollars?: number;
+  disputeDollars?: number;
+  stripeFeeDollars?: number;
+  netDollars: number;
+  stripeInvoiceId?: string | null;
+  stripeSubscriptionId?: string | null;
+  metadata?: Record<string, unknown>;
+}) {
+  if (userIds.length === 0) return;
+  const divisor = userIds.length;
+  await Promise.all(
+    userIds.map((uid) =>
+      convex.mutation(api.economics.recordRevenueEvent, {
+        serviceKey,
+        dedupe_key: `${event.id}:${uid}`,
+        stripe_event_id: event.id,
+        event_type: event.type,
+        revenue_type: revenueType,
+        occurred_at: event.created * 1000,
+        user_id: uid,
+        organization_id: orgId ?? undefined,
+        stripe_customer_id: customerId ?? undefined,
+        stripe_invoice_id: stripeInvoiceId ?? undefined,
+        stripe_subscription_id: stripeSubscriptionId ?? undefined,
+        tier: tier ?? undefined,
+        currency: "usd",
+        gross_revenue_dollars: grossDollars / divisor,
+        refund_dollars: refundDollars / divisor,
+        dispute_dollars: disputeDollars / divisor,
+        stripe_fee_dollars:
+          stripeFeeDollars === undefined
+            ? undefined
+            : stripeFeeDollars / divisor,
+        net_revenue_dollars: netDollars / divisor,
+        metadata,
+      }),
+    ),
+  );
+}
+
+async function upsertSubscriptionAccounts({
+  userIds,
+  orgId,
+  customerId,
+  tier,
+}: {
+  userIds: string[];
+  orgId: string | null;
+  customerId?: string | null;
+  tier: SubscriptionTier;
+}) {
+  await Promise.all(
+    userIds.map((uid) =>
+      convex.mutation(api.economics.upsertUserAccount, {
+        serviceKey,
+        user_id: uid,
+        current_subscription_tier: tier,
+        stripe_customer_id: customerId ?? undefined,
+        workos_organization_id: orgId ?? undefined,
+      }),
+    ),
+  );
+}
 
 /** Infer subscription tier from a Stripe product name (fallback when lookup_key is missing). */
 function tierFromProductName(name: string): SubscriptionTier | null {
@@ -123,7 +214,10 @@ async function resolveSubscription(subscriptionId: string): Promise<{
 // =============================================================================
 
 /** Handle invoice.paid — reset rate limit buckets on subscription payment. */
-async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
+async function handleInvoicePaid(
+  invoice: Stripe.Invoice,
+  event: Stripe.Event,
+): Promise<void> {
   // In Stripe API 2026-03-25, subscription lives under invoice.parent.subscription_details
   const subDetails = invoice.parent?.subscription_details;
   const subscriptionId = subDetails
@@ -164,6 +258,24 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
 
   const { tier, subscription } = resolved;
   const billingReason = (invoice as any).billing_reason as string | undefined;
+  const grossDollars = centsToDollars(invoice.amount_paid);
+
+  await recordRevenueForUsers({
+    event,
+    userIds,
+    orgId,
+    customerId,
+    tier,
+    revenueType: "subscription",
+    grossDollars,
+    netDollars: grossDollars,
+    stripeInvoiceId: invoice.id,
+    stripeSubscriptionId: subscription.id,
+    metadata: {
+      billing_reason: billingReason,
+      user_count: userIds.length,
+    },
+  });
 
   // Mid-cycle tier change: prorate credits based on remaining time in the cycle.
   // Only prorate if handleSubscriptionUpdated stashed old-tier data (confirms
@@ -289,6 +401,15 @@ async function handleSubscriptionUpdated(
   );
 
   const direction = tierDirection(previousTier, currentTier);
+  if (currentTier) {
+    await upsertSubscriptionAccounts({
+      userIds,
+      orgId,
+      customerId,
+      tier: currentTier,
+    });
+  }
+
   for (const uid of userIds) {
     phLogger.event("subscription_changed", {
       userId: uid,
@@ -343,6 +464,13 @@ async function handleSubscriptionDeleted(
   );
 
   for (const uid of userIds) {
+    await convex.mutation(api.economics.upsertUserAccount, {
+      serviceKey,
+      user_id: uid,
+      current_subscription_tier: "free",
+      stripe_customer_id: customerId,
+      workos_organization_id: orgId ?? undefined,
+    });
     phLogger.event("subscription_cancelled", {
       userId: uid,
       tier,
@@ -351,6 +479,65 @@ async function handleSubscriptionDeleted(
       $set: { subscription_tier: "free" },
     });
   }
+}
+
+async function handleChargeRefunded(
+  charge: Stripe.Charge,
+  event: Stripe.Event,
+): Promise<void> {
+  const customerId =
+    typeof charge.customer === "string" ? charge.customer : charge.customer?.id;
+  if (!customerId) return;
+
+  const { userIds, orgId } = await resolveUserIdsFromCustomer(customerId);
+  const refundDollars = centsToDollars(charge.amount_refunded);
+  if (refundDollars <= 0) return;
+
+  await recordRevenueForUsers({
+    event,
+    userIds,
+    orgId,
+    customerId,
+    revenueType: "refund",
+    grossDollars: 0,
+    refundDollars,
+    netDollars: -refundDollars,
+    metadata: { charge_id: charge.id },
+  });
+}
+
+async function handleDisputeCreated(
+  dispute: Stripe.Dispute,
+  event: Stripe.Event,
+): Promise<void> {
+  const chargeId =
+    typeof dispute.charge === "string" ? dispute.charge : dispute.charge?.id;
+  if (!chargeId) return;
+
+  const charge = await stripe.charges.retrieve(chargeId);
+  const customerId =
+    typeof charge.customer === "string" ? charge.customer : charge.customer?.id;
+  if (!customerId) return;
+
+  const { userIds, orgId } = await resolveUserIdsFromCustomer(customerId);
+  const disputeDollars = centsToDollars(dispute.amount);
+
+  await recordRevenueForUsers({
+    event,
+    userIds,
+    orgId,
+    customerId,
+    revenueType: "dispute",
+    grossDollars: 0,
+    disputeDollars,
+    netDollars: -disputeDollars,
+    metadata: {
+      dispute_id: dispute.id,
+      charge_id: chargeId,
+      reason: dispute.reason,
+      status: dispute.status,
+    },
+  });
 }
 
 // =============================================================================
@@ -400,58 +587,81 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // Idempotency check (check only — mark after successful processing)
+  // Atomic claim — eliminates the TOCTOU window where two concurrent
+  // deliveries of the same event.id could both pass a read-then-write
+  // pre-check and both run side effects. Stale pending claims are reclaimable
+  // by Stripe retries.
+  let claimState: "acquired" | "already_processed" | "claim_held";
   try {
-    const result = await convex.mutation(api.extraUsage.checkAndMarkWebhook, {
-      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
-      eventId: event.id,
-      checkOnly: true,
-    });
-
-    if (result.alreadyProcessed) {
-      console.log(
-        `[Subscription Webhook] Event ${event.id} already processed, skipping`,
-      );
-      return NextResponse.json({ received: true });
-    }
+    const result = await convex.mutation(
+      api.extraUsage.claimWebhookProcessing,
+      {
+        serviceKey,
+        eventId: event.id,
+      },
+    );
+    claimState = result.state;
   } catch (error) {
-    console.error("[Subscription Webhook] Idempotency check failed:", error);
-    // Return 500 so Stripe retries
+    console.error("[Subscription Webhook] Claim failed:", error);
     return NextResponse.json(
-      { error: "Failed to check idempotency" },
+      { error: "Failed to claim webhook" },
       { status: 500 },
     );
   }
 
-  // Handle events
-  switch (event.type) {
-    case "invoice.paid": {
-      await handleInvoicePaid(event.data.object as Stripe.Invoice);
-      break;
+  if (claimState !== "acquired") {
+    console.log(
+      `[Subscription Webhook] Event ${event.id} ${claimState}, skipping`,
+    );
+    return NextResponse.json({ received: true });
+  }
+
+  try {
+    switch (event.type) {
+      case "invoice.paid": {
+        await handleInvoicePaid(event.data.object as Stripe.Invoice, event);
+        break;
+      }
+      case "customer.subscription.updated": {
+        await handleSubscriptionUpdated(
+          event.data.object as Stripe.Subscription,
+          event.data.previous_attributes as
+            | Partial<Stripe.Subscription>
+            | undefined,
+        );
+        break;
+      }
+      case "customer.subscription.deleted": {
+        await handleSubscriptionDeleted(
+          event.data.object as Stripe.Subscription,
+        );
+        break;
+      }
+      case "charge.refunded": {
+        await handleChargeRefunded(event.data.object as Stripe.Charge, event);
+        break;
+      }
+      case "charge.dispute.created": {
+        await handleDisputeCreated(event.data.object as Stripe.Dispute, event);
+        break;
+      }
     }
-    case "customer.subscription.updated": {
-      await handleSubscriptionUpdated(
-        event.data.object as Stripe.Subscription,
-        event.data.previous_attributes as
-          | Partial<Stripe.Subscription>
-          | undefined,
-      );
-      break;
-    }
-    case "customer.subscription.deleted": {
-      await handleSubscriptionDeleted(event.data.object as Stripe.Subscription);
-      break;
-    }
+  } catch (error) {
+    console.error(
+      `[Subscription Webhook] Handler failed for event ${event.id} (${event.type}):`,
+      error,
+    );
+    return NextResponse.json({ error: "Handler failed" }, { status: 500 });
   }
 
   // Flush queued PostHog events after the response is sent. Webhook handlers
   // terminate quickly enough that buffered events would otherwise be dropped.
   after(() => phLogger.flush());
 
-  // Mark as processed after successful handling
+  // Mark as processed after successful handling.
   try {
-    await convex.mutation(api.extraUsage.checkAndMarkWebhook, {
-      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+    await convex.mutation(api.extraUsage.finalizeWebhookProcessing, {
+      serviceKey,
       eventId: event.id,
     });
   } catch (error) {

--- a/app/components/AttributionSync.tsx
+++ b/app/components/AttributionSync.tsx
@@ -9,11 +9,20 @@ export function AttributionSync() {
   useEffect(() => {
     if (!user?.id) return;
     const key = `hackerai:attribution-synced:${user.id}`;
-    if (window.localStorage.getItem(key) === "true") return;
+    try {
+      if (window.localStorage.getItem(key) === "true") return;
+    } catch {
+      // Some privacy modes disable localStorage; keep sync best-effort.
+    }
 
     fetch("/api/analytics/attribution", { method: "POST" })
       .then((res) => {
-        if (res.ok) window.localStorage.setItem(key, "true");
+        if (!res.ok) return;
+        try {
+          window.localStorage.setItem(key, "true");
+        } catch {
+          // Attribution already synced; cache failure should not affect the app.
+        }
       })
       .catch(() => {
         // Best-effort analytics sync; never block the app shell.

--- a/app/components/AttributionSync.tsx
+++ b/app/components/AttributionSync.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAuth } from "@workos-inc/authkit-nextjs/components";
+
+export function AttributionSync() {
+  const { user } = useAuth();
+
+  useEffect(() => {
+    if (!user?.id) return;
+    const key = `hackerai:attribution-synced:${user.id}`;
+    if (window.localStorage.getItem(key) === "true") return;
+
+    fetch("/api/analytics/attribution", { method: "POST" })
+      .then((res) => {
+        if (res.ok) window.localStorage.setItem(key, "true");
+      })
+      .catch(() => {
+        // Best-effort analytics sync; never block the app shell.
+      });
+  }, [user?.id]);
+
+  return null;
+}

--- a/convex/__tests__/economics.test.ts
+++ b/convex/__tests__/economics.test.ts
@@ -1,0 +1,204 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+
+jest.mock("../_generated/server", () => ({
+  mutation: jest.fn((config: any) => config),
+  query: jest.fn((config: any) => config),
+}));
+
+jest.mock("convex/values", () => ({
+  v: {
+    any: jest.fn(() => "any"),
+    boolean: jest.fn(() => "boolean"),
+    literal: jest.fn(() => "literal"),
+    null: jest.fn(() => "null"),
+    number: jest.fn(() => "number"),
+    object: jest.fn(() => "object"),
+    optional: jest.fn(() => "optional"),
+    string: jest.fn(() => "string"),
+    union: jest.fn(() => "union"),
+  },
+}));
+
+jest.mock("../lib/utils", () => ({
+  validateServiceKey: jest.fn(),
+}));
+
+type Row = Record<string, any> & { _id: string };
+
+function makeCtx() {
+  const tables: Record<string, Row[]> = {
+    user_accounts: [],
+    user_economics_daily: [],
+    processed_webhooks: [],
+  };
+
+  const matches = (row: Row, filters: Array<[string, any]>) =>
+    filters.every(([field, value]) => row[field] === value);
+
+  const makeQueryResult = (table: string, filters: Array<[string, any]>) => ({
+    unique: async () => {
+      const rows = tables[table].filter((row) => matches(row, filters));
+      if (rows.length > 1) throw new Error("not unique");
+      return rows[0] ?? null;
+    },
+    first: async () =>
+      tables[table].find((row) => matches(row, filters)) ?? null,
+    collect: async () => tables[table].filter((row) => matches(row, filters)),
+  });
+
+  const ctx: any = {
+    db: {
+      query: jest.fn((table: string) => ({
+        withIndex: jest.fn((_indexName: string, predicate: any) => {
+          const filters: Array<[string, any]> = [];
+          predicate({
+            eq: (field: string, value: any) => {
+              filters.push([field, value]);
+              return {
+                eq: (nextField: string, nextValue: any) => {
+                  filters.push([nextField, nextValue]);
+                  return {
+                    eq: (thirdField: string, thirdValue: any) => {
+                      filters.push([thirdField, thirdValue]);
+                      return {
+                        eq: (fourthField: string, fourthValue: any) => {
+                          filters.push([fourthField, fourthValue]);
+                          return {
+                            eq: (fifthField: string, fifthValue: any) => {
+                              filters.push([fifthField, fifthValue]);
+                              return {};
+                            },
+                          };
+                        },
+                      };
+                    },
+                  };
+                },
+              };
+            },
+            gte: () => ({ lte: () => ({}) }),
+          });
+          return makeQueryResult(table, filters);
+        }),
+        collect: async () => tables[table],
+      })),
+      insert: jest.fn(async (table: string, doc: Record<string, any>) => {
+        const row = { _id: `${table}-${tables[table].length + 1}`, ...doc };
+        tables[table].push(row);
+        return row._id;
+      }),
+      patch: jest.fn(async (id: string, patch: Record<string, any>) => {
+        for (const rows of Object.values(tables)) {
+          const row = rows.find((candidate) => candidate._id === id);
+          if (row) Object.assign(row, patch);
+        }
+      }),
+    },
+  };
+
+  return { ctx, tables };
+}
+
+const serviceKey = "service-key";
+
+describe("economics aggregates", () => {
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockReturnValue(Date.parse("2026-05-20T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("aggregates daily usage into a single user/day/tier row", async () => {
+    const { aggregateUsage } = await import("../economics");
+    const { ctx, tables } = makeCtx();
+
+    const args = {
+      serviceKey,
+      user_id: "user_1",
+      subscription_tier: "free" as const,
+      mode: "ask" as const,
+      model: "auto",
+      type: "included" as const,
+      input_tokens: 10,
+      output_tokens: 20,
+      cache_read_tokens: 3,
+      total_tokens: 30,
+      model_cost_dollars: 0.01,
+      non_model_cost_dollars: 0,
+      total_cost_dollars: 0.01,
+    };
+
+    await (aggregateUsage as any).handler(ctx, args);
+    await (aggregateUsage as any).handler(ctx, args);
+
+    expect(tables.user_economics_daily).toHaveLength(1);
+    expect(tables.user_economics_daily[0]).toMatchObject({
+      day: "2026-05-20",
+      request_count: 2,
+      input_tokens: 20,
+      output_tokens: 40,
+      llm_cost_dollars: 0.02,
+      total_cost_dollars: 0.02,
+      gross_revenue_dollars: 0,
+      net_revenue_dollars: 0,
+    });
+    expect(tables.user_accounts[0]).toMatchObject({
+      user_id: "user_1",
+      current_subscription_tier: "free",
+    });
+  });
+
+  it("adds revenue to the same daily economics table", async () => {
+    const { recordRevenueEvent } = await import("../economics");
+    const { ctx, tables } = makeCtx();
+
+    const args = {
+      serviceKey,
+      dedupe_key: "evt_1:user_1",
+      stripe_event_id: "evt_1",
+      event_type: "invoice.paid",
+      revenue_type: "subscription" as const,
+      occurred_at: Date.parse("2026-05-20T01:00:00Z"),
+      user_id: "user_1",
+      organization_id: "org_1",
+      stripe_customer_id: "cus_1",
+      tier: "pro" as const,
+      currency: "usd",
+      gross_revenue_dollars: 25,
+      refund_dollars: 0,
+      dispute_dollars: 0,
+      net_revenue_dollars: 25,
+    };
+
+    const result = await (recordRevenueEvent as any).handler(ctx, args);
+    const duplicate = await (recordRevenueEvent as any).handler(ctx, args);
+
+    expect(result).toEqual({ alreadyProcessed: false });
+    expect(duplicate).toEqual({ alreadyProcessed: true });
+    expect(tables.user_economics_daily).toHaveLength(1);
+    expect(tables.user_economics_daily[0]).toMatchObject({
+      gross_revenue_dollars: 25,
+      net_revenue_dollars: 25,
+      total_cost_dollars: 0,
+    });
+    expect(tables.user_accounts[0]).toMatchObject({
+      user_id: "user_1",
+      current_subscription_tier: "pro",
+      first_paid_at: args.occurred_at,
+    });
+    expect(tables.processed_webhooks).toHaveLength(1);
+    expect(tables.processed_webhooks[0]).toMatchObject({
+      event_id: "economics:evt_1:user_1",
+      status: "completed",
+    });
+  });
+});

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as chatStreams from "../chatStreams.js";
 import type * as chats from "../chats.js";
 import type * as constants from "../constants.js";
 import type * as crons from "../crons.js";
+import type * as economics from "../economics.js";
 import type * as extraUsage from "../extraUsage.js";
 import type * as extraUsageActions from "../extraUsageActions.js";
 import type * as feedback from "../feedback.js";
@@ -48,6 +49,7 @@ declare const fullApi: ApiFromModules<{
   chats: typeof chats;
   constants: typeof constants;
   crons: typeof crons;
+  economics: typeof economics;
   extraUsage: typeof extraUsage;
   extraUsageActions: typeof extraUsageActions;
   feedback: typeof feedback;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -85,6 +85,32 @@ export const runStaleConnectionsPurge = internalAction({
   },
 });
 
+/**
+ * Keep detailed per-request paid usage logs for user-facing history, while
+ * relying on user_economics_daily for long-term economics.
+ */
+export const runUsageLogsPurge = internalAction({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx) => {
+    const cutoff = Date.now() - 90 * 24 * 60 * 60 * 1000;
+    const limit = 100;
+    let lastDeletedCount = 0;
+    for (let i = 0; i < 10; i++) {
+      const { deletedCount } = await ctx.runMutation(
+        internal.usageLogs.purgeOldUsageLogs,
+        { cutoffTimeMs: cutoff, limit },
+      );
+      lastDeletedCount = deletedCount;
+      if (deletedCount < limit) break;
+    }
+    if (lastDeletedCount === limit) {
+      await ctx.scheduler.runAfter(0, internal.crons.runUsageLogsPurge, {});
+    }
+    return null;
+  },
+});
+
 const crons = cronJobs();
 
 crons.interval(
@@ -105,6 +131,13 @@ crons.interval(
   "purge stale disconnected sandbox connections older than 30d",
   { hours: 24 },
   internal.crons.runStaleConnectionsPurge,
+  {},
+);
+
+crons.interval(
+  "purge detailed usage logs older than 90d",
+  { hours: 24 },
+  internal.crons.runUsageLogsPurge,
   {},
 );
 

--- a/convex/economics.ts
+++ b/convex/economics.ts
@@ -1,0 +1,425 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { validateServiceKey } from "./lib/utils";
+
+const subscriptionTierValidator = v.union(
+  v.literal("free"),
+  v.literal("pro"),
+  v.literal("pro-plus"),
+  v.literal("ultra"),
+  v.literal("team"),
+);
+
+const modeValidator = v.union(
+  v.literal("ask"),
+  v.literal("agent"),
+  v.literal("agent-long"),
+);
+
+const optionalAttributionArgs = {
+  utm_source: v.optional(v.string()),
+  utm_medium: v.optional(v.string()),
+  utm_campaign: v.optional(v.string()),
+  utm_content: v.optional(v.string()),
+  utm_term: v.optional(v.string()),
+  gclid: v.optional(v.string()),
+  fbclid: v.optional(v.string()),
+  landing_page: v.optional(v.string()),
+  referrer: v.optional(v.string()),
+};
+
+const dayFromMs = (ms: number): string =>
+  new Date(ms).toISOString().slice(0, 10);
+
+type Tier = "free" | "pro" | "pro-plus" | "ultra" | "team";
+
+function attributionPatch(
+  existing: Record<string, unknown> | null,
+  args: Record<string, unknown>,
+) {
+  const patch: Record<string, string> = {};
+  for (const key of Object.keys(optionalAttributionArgs)) {
+    const incoming = args[key];
+    if (
+      typeof incoming === "string" &&
+      incoming.length > 0 &&
+      !existing?.[key]
+    ) {
+      patch[key] = incoming.slice(0, 500);
+    }
+  }
+  return patch;
+}
+
+async function upsertUserAccountImpl(
+  ctx: any,
+  args: {
+    user_id: string;
+    current_subscription_tier?: Tier;
+    stripe_customer_id?: string;
+    workos_organization_id?: string;
+    first_paid_at?: number;
+    utm_source?: string;
+    utm_medium?: string;
+    utm_campaign?: string;
+    utm_content?: string;
+    utm_term?: string;
+    gclid?: string;
+    fbclid?: string;
+    landing_page?: string;
+    referrer?: string;
+  },
+) {
+  const now = Date.now();
+  const existing = await ctx.db
+    .query("user_accounts")
+    .withIndex("by_user_id", (q: any) => q.eq("user_id", args.user_id))
+    .unique();
+
+  const tier = args.current_subscription_tier ?? "free";
+  const firstPaidAt =
+    args.first_paid_at ??
+    (tier !== "free" && !existing?.first_paid_at ? now : undefined);
+  const attrPatch = attributionPatch(existing, args);
+
+  if (!existing) {
+    await ctx.db.insert("user_accounts", {
+      user_id: args.user_id,
+      first_seen_at: now,
+      last_seen_at: now,
+      current_subscription_tier: tier,
+      ...(firstPaidAt && { first_paid_at: firstPaidAt }),
+      ...(args.stripe_customer_id && {
+        stripe_customer_id: args.stripe_customer_id,
+      }),
+      ...(args.workos_organization_id && {
+        workos_organization_id: args.workos_organization_id,
+      }),
+      ...attrPatch,
+      updated_at: now,
+    });
+    return;
+  }
+
+  await ctx.db.patch(existing._id, {
+    last_seen_at: now,
+    ...(args.current_subscription_tier && {
+      current_subscription_tier: args.current_subscription_tier,
+    }),
+    ...(firstPaidAt &&
+      !existing.first_paid_at && { first_paid_at: firstPaidAt }),
+    ...(args.stripe_customer_id && {
+      stripe_customer_id: args.stripe_customer_id,
+    }),
+    ...(args.workos_organization_id && {
+      workos_organization_id: args.workos_organization_id,
+    }),
+    ...attrPatch,
+    updated_at: now,
+  });
+}
+
+async function updateDailyEconomics(
+  ctx: any,
+  args: {
+    day: string;
+    user_id: string;
+    subscription_tier: Tier;
+    request_count?: number;
+    input_tokens?: number;
+    output_tokens?: number;
+    total_tokens?: number;
+    llm_cost_dollars?: number;
+    tool_cost_dollars?: number;
+    total_cost_dollars?: number;
+    gross_revenue_dollars?: number;
+    refund_dollars?: number;
+    net_revenue_dollars?: number;
+  },
+) {
+  const now = Date.now();
+  const existing = await ctx.db
+    .query("user_economics_daily")
+    .withIndex("by_day_user_tier", (q: any) =>
+      q
+        .eq("day", args.day)
+        .eq("user_id", args.user_id)
+        .eq("subscription_tier", args.subscription_tier),
+    )
+    .unique();
+
+  const delta = {
+    request_count: args.request_count ?? 0,
+    input_tokens: args.input_tokens ?? 0,
+    output_tokens: args.output_tokens ?? 0,
+    total_tokens: args.total_tokens ?? 0,
+    llm_cost_dollars: args.llm_cost_dollars ?? 0,
+    tool_cost_dollars: args.tool_cost_dollars ?? 0,
+    total_cost_dollars: args.total_cost_dollars ?? 0,
+    gross_revenue_dollars: args.gross_revenue_dollars ?? 0,
+    refund_dollars: args.refund_dollars ?? 0,
+    net_revenue_dollars: args.net_revenue_dollars ?? 0,
+  };
+
+  if (!existing) {
+    await ctx.db.insert("user_economics_daily", {
+      day: args.day,
+      user_id: args.user_id,
+      subscription_tier: args.subscription_tier,
+      ...delta,
+      updated_at: now,
+    });
+    return;
+  }
+
+  await ctx.db.patch(existing._id, {
+    request_count: existing.request_count + delta.request_count,
+    input_tokens: existing.input_tokens + delta.input_tokens,
+    output_tokens: existing.output_tokens + delta.output_tokens,
+    total_tokens: existing.total_tokens + delta.total_tokens,
+    llm_cost_dollars: existing.llm_cost_dollars + delta.llm_cost_dollars,
+    tool_cost_dollars: existing.tool_cost_dollars + delta.tool_cost_dollars,
+    total_cost_dollars: existing.total_cost_dollars + delta.total_cost_dollars,
+    gross_revenue_dollars:
+      existing.gross_revenue_dollars + delta.gross_revenue_dollars,
+    refund_dollars: existing.refund_dollars + delta.refund_dollars,
+    net_revenue_dollars:
+      existing.net_revenue_dollars + delta.net_revenue_dollars,
+    updated_at: now,
+  });
+}
+
+export const upsertUserAccount = mutation({
+  args: {
+    serviceKey: v.string(),
+    user_id: v.string(),
+    current_subscription_tier: v.optional(subscriptionTierValidator),
+    stripe_customer_id: v.optional(v.string()),
+    workos_organization_id: v.optional(v.string()),
+    first_paid_at: v.optional(v.number()),
+    ...optionalAttributionArgs,
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    await upsertUserAccountImpl(ctx, args);
+    return null;
+  },
+});
+
+export const aggregateUsage = mutation({
+  args: {
+    serviceKey: v.string(),
+    user_id: v.string(),
+    subscription_tier: subscriptionTierValidator,
+    mode: modeValidator,
+    model: v.string(),
+    type: v.union(v.literal("included"), v.literal("extra")),
+    input_tokens: v.number(),
+    output_tokens: v.number(),
+    cache_read_tokens: v.optional(v.number()),
+    cache_write_tokens: v.optional(v.number()),
+    total_tokens: v.number(),
+    model_cost_dollars: v.number(),
+    non_model_cost_dollars: v.number(),
+    total_cost_dollars: v.number(),
+    occurred_at: v.optional(v.number()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    const day = dayFromMs(args.occurred_at ?? Date.now());
+
+    await updateDailyEconomics(ctx, {
+      day,
+      user_id: args.user_id,
+      subscription_tier: args.subscription_tier,
+      request_count: 1,
+      input_tokens: args.input_tokens,
+      output_tokens: args.output_tokens,
+      total_tokens: args.total_tokens,
+      llm_cost_dollars: args.model_cost_dollars,
+      tool_cost_dollars: args.non_model_cost_dollars,
+      total_cost_dollars: args.total_cost_dollars,
+    });
+    await upsertUserAccountImpl(ctx, {
+      user_id: args.user_id,
+      current_subscription_tier: args.subscription_tier,
+    });
+
+    return null;
+  },
+});
+
+export const recordRevenueEvent = mutation({
+  args: {
+    serviceKey: v.string(),
+    dedupe_key: v.string(),
+    stripe_event_id: v.string(),
+    event_type: v.string(),
+    revenue_type: v.union(
+      v.literal("subscription"),
+      v.literal("extra_usage"),
+      v.literal("refund"),
+      v.literal("dispute"),
+      v.literal("adjustment"),
+    ),
+    occurred_at: v.number(),
+    user_id: v.optional(v.string()),
+    organization_id: v.optional(v.string()),
+    stripe_customer_id: v.optional(v.string()),
+    stripe_invoice_id: v.optional(v.string()),
+    stripe_subscription_id: v.optional(v.string()),
+    stripe_checkout_session_id: v.optional(v.string()),
+    tier: v.optional(subscriptionTierValidator),
+    currency: v.optional(v.string()),
+    gross_revenue_dollars: v.number(),
+    refund_dollars: v.optional(v.number()),
+    dispute_dollars: v.optional(v.number()),
+    stripe_fee_dollars: v.optional(v.number()),
+    net_revenue_dollars: v.number(),
+    metadata: v.optional(v.any()),
+  },
+  returns: v.object({ alreadyProcessed: v.boolean() }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    if (!args.user_id) return { alreadyProcessed: false };
+
+    const economicsEventId = `economics:${args.dedupe_key}`;
+    const existingEvent = await ctx.db
+      .query("processed_webhooks")
+      .withIndex("by_event_id", (q) => q.eq("event_id", economicsEventId))
+      .unique();
+
+    if (existingEvent) {
+      return { alreadyProcessed: true };
+    }
+
+    const tier = args.tier ?? "free";
+    await updateDailyEconomics(ctx, {
+      day: dayFromMs(args.occurred_at),
+      user_id: args.user_id,
+      subscription_tier: tier,
+      gross_revenue_dollars: args.gross_revenue_dollars,
+      refund_dollars: (args.refund_dollars ?? 0) + (args.dispute_dollars ?? 0),
+      net_revenue_dollars: args.net_revenue_dollars,
+    });
+    await upsertUserAccountImpl(ctx, {
+      user_id: args.user_id,
+      current_subscription_tier: tier,
+      stripe_customer_id: args.stripe_customer_id,
+      workos_organization_id: args.organization_id,
+      first_paid_at:
+        args.net_revenue_dollars > 0 && args.revenue_type !== "refund"
+          ? args.occurred_at
+          : undefined,
+    });
+    await ctx.db.insert("processed_webhooks", {
+      event_id: economicsEventId,
+      processed_at: Date.now(),
+      status: "completed",
+    });
+
+    return { alreadyProcessed: false };
+  },
+});
+
+export const getEconomicsSummary = query({
+  args: {
+    serviceKey: v.string(),
+    startDay: v.string(),
+    endDay: v.string(),
+  },
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const rows = await ctx.db
+      .query("user_economics_daily")
+      .withIndex("by_day", (q) =>
+        q.gte("day", args.startDay).lte("day", args.endDay),
+      )
+      .collect();
+
+    const activeUsers = new Set<string>();
+    const activeFreeUsers = new Set<string>();
+    const activePaidUsers = new Set<string>();
+    let requestCount = 0;
+    let freeCost = 0;
+    let paidCost = 0;
+    let totalCost = 0;
+    let grossRevenue = 0;
+    let refundDollars = 0;
+    let netRevenue = 0;
+
+    for (const row of rows) {
+      activeUsers.add(row.user_id);
+      requestCount += row.request_count;
+      totalCost += row.total_cost_dollars;
+      grossRevenue += row.gross_revenue_dollars;
+      refundDollars += row.refund_dollars;
+      netRevenue += row.net_revenue_dollars;
+
+      if (row.subscription_tier === "free") {
+        activeFreeUsers.add(row.user_id);
+        freeCost += row.total_cost_dollars;
+      } else {
+        activePaidUsers.add(row.user_id);
+        paidCost += row.total_cost_dollars;
+      }
+    }
+
+    const startMs = Date.parse(`${args.startDay}T00:00:00.000Z`);
+    const endMs = Date.parse(`${args.endDay}T23:59:59.999Z`);
+    const cohort = await ctx.db
+      .query("user_accounts")
+      .withIndex("by_first_seen", (q) =>
+        q.gte("first_seen_at", startMs).lte("first_seen_at", endMs),
+      )
+      .collect();
+
+    const converted30d = cohort.filter(
+      (account) =>
+        account.first_paid_at !== undefined &&
+        account.first_paid_at - account.first_seen_at <=
+          30 * 24 * 60 * 60 * 1000,
+    ).length;
+
+    const activeUserCount = activeUsers.size;
+    const activePaidUserCount = activePaidUsers.size;
+    const activeFreeUserCount = activeFreeUsers.size;
+
+    return {
+      range: { startDay: args.startDay, endDay: args.endDay },
+      users: {
+        active: activeUserCount,
+        activeFree: activeFreeUserCount,
+        activePaid: activePaidUserCount,
+        signupCohort: cohort.length,
+      },
+      usage: {
+        requests: requestCount,
+        freeCostDollars: freeCost,
+        paidCostDollars: paidCost,
+        totalCostDollars: totalCost,
+        freeCostPerActiveFreeUser:
+          activeFreeUserCount > 0 ? freeCost / activeFreeUserCount : 0,
+        paidCostPerActivePaidUser:
+          activePaidUserCount > 0 ? paidCost / activePaidUserCount : 0,
+      },
+      revenue: {
+        grossRevenueDollars: grossRevenue,
+        refundDollars,
+        netRevenueDollars: netRevenue,
+        arpu: activeUserCount > 0 ? netRevenue / activeUserCount : 0,
+        arppu: activePaidUserCount > 0 ? netRevenue / activePaidUserCount : 0,
+      },
+      conversion: {
+        freeToPaid30d: cohort.length > 0 ? converted30d / cohort.length : 0,
+      },
+      margin: {
+        contributionDollars: netRevenue - totalCost,
+        grossMargin: netRevenue > 0 ? (netRevenue - totalCost) / netRevenue : 0,
+      },
+    };
+  },
+});

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -113,6 +113,7 @@ export const purgeOldProcessedWebhooks = internalMutation({
 
     let deletedCount = 0;
     for (const row of rows) {
+      if (row.event_id.startsWith("economics:")) continue;
       if (row.processed_at < args.cutoffTimeMs) {
         await ctx.db.delete(row._id);
         deletedCount++;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -317,6 +317,18 @@ export default defineSchema({
   // Per-request usage logs for the usage dashboard
   usage_logs: defineTable({
     user_id: v.string(),
+    subscription_tier: v.optional(
+      v.union(
+        v.literal("free"),
+        v.literal("pro"),
+        v.literal("pro-plus"),
+        v.literal("ultra"),
+        v.literal("team"),
+      ),
+    ),
+    mode: v.optional(
+      v.union(v.literal("ask"), v.literal("agent"), v.literal("agent-long")),
+    ),
     model: v.string(),
     type: v.union(v.literal("included"), v.literal("extra")),
     input_tokens: v.number(),
@@ -324,6 +336,8 @@ export default defineSchema({
     cache_read_tokens: v.optional(v.number()),
     cache_write_tokens: v.optional(v.number()),
     total_tokens: v.number(),
+    model_cost_dollars: v.optional(v.number()),
+    non_model_cost_dollars: v.optional(v.number()),
     cost_dollars: v.number(),
     // Legacy MAX Mode flag retained on historical rows. The feature was
     // removed and nothing reads or writes this anymore — kept in the schema
@@ -336,6 +350,61 @@ export default defineSchema({
   })
     .index("by_user", ["user_id"])
     .index("by_user_and_model", ["user_id", "model"]),
+
+  user_accounts: defineTable({
+    user_id: v.string(),
+    first_seen_at: v.number(),
+    last_seen_at: v.number(),
+    first_paid_at: v.optional(v.number()),
+    current_subscription_tier: v.union(
+      v.literal("free"),
+      v.literal("pro"),
+      v.literal("pro-plus"),
+      v.literal("ultra"),
+      v.literal("team"),
+    ),
+    stripe_customer_id: v.optional(v.string()),
+    workos_organization_id: v.optional(v.string()),
+    utm_source: v.optional(v.string()),
+    utm_medium: v.optional(v.string()),
+    utm_campaign: v.optional(v.string()),
+    utm_content: v.optional(v.string()),
+    utm_term: v.optional(v.string()),
+    gclid: v.optional(v.string()),
+    fbclid: v.optional(v.string()),
+    landing_page: v.optional(v.string()),
+    referrer: v.optional(v.string()),
+    updated_at: v.number(),
+  })
+    .index("by_user_id", ["user_id"])
+    .index("by_first_seen", ["first_seen_at"])
+    .index("by_current_tier", ["current_subscription_tier"]),
+
+  user_economics_daily: defineTable({
+    day: v.string(),
+    user_id: v.string(),
+    subscription_tier: v.union(
+      v.literal("free"),
+      v.literal("pro"),
+      v.literal("pro-plus"),
+      v.literal("ultra"),
+      v.literal("team"),
+    ),
+    request_count: v.number(),
+    input_tokens: v.number(),
+    output_tokens: v.number(),
+    total_tokens: v.number(),
+    llm_cost_dollars: v.number(),
+    tool_cost_dollars: v.number(),
+    total_cost_dollars: v.number(),
+    gross_revenue_dollars: v.number(),
+    refund_dollars: v.number(),
+    net_revenue_dollars: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_day", ["day"])
+    .index("by_user_day", ["user_id", "day"])
+    .index("by_day_user_tier", ["day", "user_id", "subscription_tier"]),
 
   // Webhook idempotency (prevents double-crediting on Stripe retries)
   processed_webhooks: defineTable({

--- a/convex/usageLogs.ts
+++ b/convex/usageLogs.ts
@@ -1,9 +1,21 @@
-import { mutation, query } from "./_generated/server";
+import { internalMutation, mutation, query } from "./_generated/server";
 import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 
 const typeValidator = v.union(v.literal("included"), v.literal("extra"));
+const subscriptionTierValidator = v.union(
+  v.literal("free"),
+  v.literal("pro"),
+  v.literal("pro-plus"),
+  v.literal("ultra"),
+  v.literal("team"),
+);
+const modeValidator = v.union(
+  v.literal("ask"),
+  v.literal("agent"),
+  v.literal("agent-long"),
+);
 
 const cleanModelName = (model: string): string =>
   model
@@ -13,6 +25,100 @@ const cleanModelName = (model: string): string =>
     .replace(/^[a-z-]+\//, "")
     .replace(/-\d{8}$/, "");
 
+const dayFromMs = (ms: number): string =>
+  new Date(ms).toISOString().slice(0, 10);
+
+async function upsertAccountForUsage(
+  ctx: any,
+  userId: string,
+  subscriptionTier: "free" | "pro" | "pro-plus" | "ultra" | "team",
+) {
+  const now = Date.now();
+  const existing = await ctx.db
+    .query("user_accounts")
+    .withIndex("by_user_id", (q: any) => q.eq("user_id", userId))
+    .unique();
+
+  if (!existing) {
+    await ctx.db.insert("user_accounts", {
+      user_id: userId,
+      first_seen_at: now,
+      last_seen_at: now,
+      current_subscription_tier: subscriptionTier,
+      ...(subscriptionTier !== "free" && { first_paid_at: now }),
+      updated_at: now,
+    });
+    return;
+  }
+
+  await ctx.db.patch(existing._id, {
+    last_seen_at: now,
+    current_subscription_tier: subscriptionTier,
+    ...(subscriptionTier !== "free" &&
+      !existing.first_paid_at && { first_paid_at: now }),
+    updated_at: now,
+  });
+}
+
+async function aggregateUsageDaily(
+  ctx: any,
+  args: {
+    user_id: string;
+    subscription_tier: "free" | "pro" | "pro-plus" | "ultra" | "team";
+    input_tokens: number;
+    output_tokens: number;
+    total_tokens: number;
+    model_cost_dollars: number;
+    non_model_cost_dollars: number;
+    cost_dollars: number;
+  },
+) {
+  const now = Date.now();
+  const day = dayFromMs(now);
+  const existing = await ctx.db
+    .query("user_economics_daily")
+    .withIndex("by_day_user_tier", (q: any) =>
+      q
+        .eq("day", day)
+        .eq("user_id", args.user_id)
+        .eq("subscription_tier", args.subscription_tier),
+    )
+    .unique();
+
+  if (!existing) {
+    await ctx.db.insert("user_economics_daily", {
+      day,
+      user_id: args.user_id,
+      subscription_tier: args.subscription_tier,
+      request_count: 1,
+      input_tokens: args.input_tokens,
+      output_tokens: args.output_tokens,
+      total_tokens: args.total_tokens,
+      llm_cost_dollars: args.model_cost_dollars,
+      tool_cost_dollars: args.non_model_cost_dollars,
+      total_cost_dollars: args.cost_dollars,
+      gross_revenue_dollars: 0,
+      refund_dollars: 0,
+      net_revenue_dollars: 0,
+      updated_at: now,
+    });
+  } else {
+    await ctx.db.patch(existing._id, {
+      request_count: existing.request_count + 1,
+      input_tokens: existing.input_tokens + args.input_tokens,
+      output_tokens: existing.output_tokens + args.output_tokens,
+      total_tokens: existing.total_tokens + args.total_tokens,
+      llm_cost_dollars: existing.llm_cost_dollars + args.model_cost_dollars,
+      tool_cost_dollars:
+        existing.tool_cost_dollars + args.non_model_cost_dollars,
+      total_cost_dollars: existing.total_cost_dollars + args.cost_dollars,
+      updated_at: now,
+    });
+  }
+
+  await upsertAccountForUsage(ctx, args.user_id, args.subscription_tier);
+}
+
 /**
  * Insert a usage log record (called from backend after each request).
  */
@@ -20,6 +126,8 @@ export const logUsage = mutation({
   args: {
     serviceKey: v.string(),
     user_id: v.string(),
+    subscription_tier: v.optional(subscriptionTierValidator),
+    mode: v.optional(modeValidator),
     model: v.string(),
     type: typeValidator,
     input_tokens: v.number(),
@@ -27,25 +135,71 @@ export const logUsage = mutation({
     cache_read_tokens: v.optional(v.number()),
     cache_write_tokens: v.optional(v.number()),
     total_tokens: v.number(),
+    model_cost_dollars: v.optional(v.number()),
+    non_model_cost_dollars: v.optional(v.number()),
     cost_dollars: v.number(),
+    persist_raw_log: v.optional(v.boolean()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
 
-    await ctx.db.insert("usage_logs", {
-      user_id: args.user_id,
-      model: args.model,
-      type: args.type,
-      input_tokens: args.input_tokens,
-      output_tokens: args.output_tokens,
-      cache_read_tokens: args.cache_read_tokens,
-      cache_write_tokens: args.cache_write_tokens,
-      total_tokens: args.total_tokens,
-      cost_dollars: args.cost_dollars,
-    });
+    const modelCostDollars = args.model_cost_dollars ?? args.cost_dollars;
+    const nonModelCostDollars = args.non_model_cost_dollars ?? 0;
+
+    if (args.persist_raw_log ?? true) {
+      await ctx.db.insert("usage_logs", {
+        user_id: args.user_id,
+        subscription_tier: args.subscription_tier,
+        mode: args.mode,
+        model: args.model,
+        type: args.type,
+        input_tokens: args.input_tokens,
+        output_tokens: args.output_tokens,
+        cache_read_tokens: args.cache_read_tokens,
+        cache_write_tokens: args.cache_write_tokens,
+        total_tokens: args.total_tokens,
+        model_cost_dollars: modelCostDollars,
+        non_model_cost_dollars: nonModelCostDollars,
+        cost_dollars: args.cost_dollars,
+      });
+    }
+
+    if (args.subscription_tier) {
+      await aggregateUsageDaily(ctx, {
+        user_id: args.user_id,
+        subscription_tier: args.subscription_tier,
+        input_tokens: args.input_tokens,
+        output_tokens: args.output_tokens,
+        total_tokens: args.total_tokens,
+        model_cost_dollars: modelCostDollars,
+        non_model_cost_dollars: nonModelCostDollars,
+        cost_dollars: args.cost_dollars,
+      });
+    }
 
     return null;
+  },
+});
+
+export const purgeOldUsageLogs = internalMutation({
+  args: {
+    cutoffTimeMs: v.number(),
+    limit: v.optional(v.number()),
+  },
+  returns: v.object({ deletedCount: v.number() }),
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? 100;
+    const rows = await ctx.db.query("usage_logs").order("asc").take(limit);
+    let deletedCount = 0;
+
+    for (const row of rows) {
+      if (row._creationTime >= args.cutoffTimeMs) break;
+      await ctx.db.delete(row._id);
+      deletedCount++;
+    }
+
+    return { deletedCount };
   },
 });
 

--- a/convex/usageLogs.ts
+++ b/convex/usageLogs.ts
@@ -1,4 +1,9 @@
-import { internalMutation, mutation, query } from "./_generated/server";
+import {
+  internalMutation,
+  mutation,
+  query,
+  type MutationCtx,
+} from "./_generated/server";
 import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
@@ -29,14 +34,14 @@ const dayFromMs = (ms: number): string =>
   new Date(ms).toISOString().slice(0, 10);
 
 async function upsertAccountForUsage(
-  ctx: any,
+  ctx: MutationCtx,
   userId: string,
   subscriptionTier: "free" | "pro" | "pro-plus" | "ultra" | "team",
 ) {
   const now = Date.now();
   const existing = await ctx.db
     .query("user_accounts")
-    .withIndex("by_user_id", (q: any) => q.eq("user_id", userId))
+    .withIndex("by_user_id", (q) => q.eq("user_id", userId))
     .unique();
 
   if (!existing) {
@@ -61,7 +66,7 @@ async function upsertAccountForUsage(
 }
 
 async function aggregateUsageDaily(
-  ctx: any,
+  ctx: MutationCtx,
   args: {
     user_id: string;
     subscription_tier: "free" | "pro" | "pro-plus" | "ultra" | "team";
@@ -77,7 +82,7 @@ async function aggregateUsageDaily(
   const day = dayFromMs(now);
   const existing = await ctx.db
     .query("user_economics_daily")
-    .withIndex("by_day_user_tier", (q: any) =>
+    .withIndex("by_day_user_tier", (q) =>
       q
         .eq("day", day)
         .eq("user_id", args.user_id)

--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -329,6 +329,8 @@ describe("UsageTracker", () => {
 
       t.log({
         userId: "user-123",
+        subscription: "pro",
+        mode: "ask",
         selectedModel: "model-default",
         configuredModelId: "model-config",
         rateLimitInfo: {
@@ -341,6 +343,8 @@ describe("UsageTracker", () => {
 
       expect(localMockLog).toHaveBeenCalledWith({
         userId: "user-123",
+        subscription: "pro",
+        mode: "ask",
         model: "auto",
         type: "included",
         inputTokens: 1000,
@@ -348,8 +352,56 @@ describe("UsageTracker", () => {
         totalTokens: 1500,
         cacheReadTokens: undefined,
         cacheWriteTokens: undefined,
+        modelCostDollars: 0.01,
+        nonModelCostDollars: undefined,
         costDollars: 0.01,
+        persistRawLog: true,
       });
+    });
+
+    it("should aggregate free usage without persisting raw logs", () => {
+      const localMockLog = jest.fn();
+
+      let IsolatedTracker: typeof UsageTracker;
+      jest.isolateModules(() => {
+        jest.doMock("@/lib/db/actions", () => ({
+          logUsageRecord: localMockLog,
+        }));
+        jest.doMock("@/lib/rate-limit", () => ({
+          calculateTokenCost: jest.fn(() => 1),
+          POINTS_PER_DOLLAR: 10_000,
+        }));
+        IsolatedTracker = require("../usage-tracker").UsageTracker;
+      });
+
+      const t = new IsolatedTracker!();
+      t.accumulateStep({
+        inputTokens: 1000,
+        outputTokens: 500,
+        raw: { cost: 0.01 },
+      });
+
+      t.log({
+        userId: "free-user",
+        subscription: "free",
+        mode: "ask",
+        selectedModel: "ask-model-free",
+        configuredModelId: "deepseek/deepseek-v4-flash",
+        rateLimitInfo: {
+          remaining: 0,
+          resetTime: new Date(),
+          limit: 10,
+        },
+      });
+
+      expect(localMockLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "free-user",
+          subscription: "free",
+          mode: "ask",
+          persistRawLog: false,
+        }),
+      );
     });
   });
 });

--- a/lib/admin.ts
+++ b/lib/admin.ts
@@ -1,0 +1,13 @@
+export function adminUserIds(): Set<string> {
+  return new Set(
+    (process.env.ADMIN_USER_IDS ?? "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean),
+  );
+}
+
+export function isAdminUserId(userId: string | null | undefined): boolean {
+  if (!userId) return false;
+  return adminUserIds().has(userId);
+}

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -199,6 +199,12 @@ export async function createAgentStream(
       ctx.userId,
       modelName,
       ctx.mode,
+      {
+        sessionId: ctx.chatId,
+        traceId: `${ctx.chatId}:${modelName}:${ctx.streamStartTime}`,
+        subscriptionTier: ctx.subscription,
+        selectedModel: modelName,
+      },
     ),
 
     prepareStep: async ({ steps, messages }) => {
@@ -237,6 +243,12 @@ export async function createAgentStream(
               ctx.userId,
               modelName,
               ctx.mode,
+              {
+                sessionId: ctx.chatId,
+                traceId: `${ctx.chatId}:summarization:${ctx.streamStartTime}`,
+                subscriptionTier: ctx.subscription,
+                selectedModel: modelName,
+              },
             ),
           });
 

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -571,7 +571,7 @@ export const createChatHandler = (
           let preFallbackCacheWrite = 0;
 
           const deductAccumulatedUsage = async () => {
-            if (hasDeductedUsage || subscription === "free") return;
+            if (hasDeductedUsage) return;
             // Add E2B sandbox session cost (duration-based)
             const sandboxCost = getSandboxSessionCost();
             if (sandboxCost > 0) {
@@ -599,20 +599,24 @@ export const createChatHandler = (
                 ? usageTracker.providerCost
                 : undefined;
 
-            await deductUsage(
-              userId,
-              subscription,
-              estimatedInputTokens,
-              usageTracker.inputTokens,
-              usageTracker.outputTokens,
-              extraUsageConfig,
-              providerCost,
-              selectedModel,
-              usageTracker.nonModelCost,
-              organizationId,
-            );
+            if (subscription !== "free") {
+              await deductUsage(
+                userId,
+                subscription,
+                estimatedInputTokens,
+                usageTracker.inputTokens,
+                usageTracker.outputTokens,
+                extraUsageConfig,
+                providerCost,
+                selectedModel,
+                usageTracker.nonModelCost,
+                organizationId,
+              );
+            }
             usageTracker.log({
               userId,
+              subscription,
+              mode,
               selectedModel,
               selectedModelOverride,
               responseModel: state.responseModel,

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -515,6 +515,13 @@ export function buildProviderOptions(
   userId?: string,
   modelName?: string,
   mode?: ChatMode,
+  trace?: {
+    sessionId: string;
+    traceId: string;
+    subscriptionTier: SubscriptionTier;
+    selectedModel: string;
+    environment?: string;
+  },
 ) {
   const modelId = modelName ? resolveSlug(modelName) : undefined;
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
@@ -531,6 +538,21 @@ export function buildProviderOptions(
         : { reasoning: { enabled: false } }),
       ...(userId && { user: userId }),
       ...(fallbackSlugs.length > 0 && { models: fallbackSlugs }),
+      ...(trace && {
+        extraBody: {
+          session_id: trace.sessionId,
+          trace: {
+            trace_id: trace.traceId,
+            mode,
+            subscription_tier: trace.subscriptionTier,
+            selected_model: trace.selectedModel,
+            environment:
+              trace.environment ??
+              process.env.VERCEL_ENV ??
+              process.env.NODE_ENV,
+          },
+        },
+      }),
     },
   } as const;
 }

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -954,6 +954,8 @@ export async function getNotes({
 
 export async function logUsageRecord({
   userId,
+  subscription,
+  mode,
   model,
   type,
   inputTokens,
@@ -961,9 +963,14 @@ export async function logUsageRecord({
   totalTokens,
   cacheReadTokens,
   cacheWriteTokens,
+  modelCostDollars,
+  nonModelCostDollars,
   costDollars,
+  persistRawLog = true,
 }: {
   userId: string;
+  subscription?: SubscriptionTier;
+  mode?: ChatMode;
   model: string;
   type: "included" | "extra";
   inputTokens: number;
@@ -971,12 +978,17 @@ export async function logUsageRecord({
   totalTokens: number;
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
+  modelCostDollars?: number;
+  nonModelCostDollars?: number;
   costDollars: number;
+  persistRawLog?: boolean;
 }) {
   try {
     await getConvexClient().mutation(api.usageLogs.logUsage, {
       serviceKey,
       user_id: userId,
+      subscription_tier: subscription,
+      mode,
       model,
       type,
       input_tokens: inputTokens,
@@ -984,15 +996,22 @@ export async function logUsageRecord({
       cache_read_tokens: cacheReadTokens,
       cache_write_tokens: cacheWriteTokens,
       total_tokens: totalTokens,
+      model_cost_dollars: modelCostDollars,
+      non_model_cost_dollars: nonModelCostDollars,
       cost_dollars: costDollars,
+      persist_raw_log: persistRawLog,
     });
   } catch (error) {
     console.error("Failed to log usage record:", {
       error,
       userId,
+      subscription,
+      mode,
       model,
       type,
       costDollars,
+      modelCostDollars,
+      nonModelCostDollars,
       inputTokens,
       outputTokens,
     });

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -1,6 +1,7 @@
 import { logUsageRecord } from "@/lib/db/actions";
 import { calculateTokenCost, POINTS_PER_DOLLAR } from "@/lib/rate-limit";
 import type { RateLimitInfo } from "@/types";
+import type { ChatMode, SubscriptionTier } from "@/types/chat";
 
 interface StepUsage {
   inputTokens?: number;
@@ -140,6 +141,8 @@ export class UsageTracker {
 
   log({
     userId,
+    subscription,
+    mode,
     selectedModel,
     selectedModelOverride,
     responseModel,
@@ -147,14 +150,23 @@ export class UsageTracker {
     rateLimitInfo,
   }: {
     userId: string;
+    subscription: SubscriptionTier;
+    mode: ChatMode;
     selectedModel: string;
     selectedModelOverride?: string | null;
     responseModel?: string;
     configuredModelId: string;
     rateLimitInfo: RateLimitInfo;
   }) {
+    const modelCostDollars = Math.max(
+      0,
+      this.computeModelCostDollars(selectedModel),
+    );
+    const totalCostDollars = this.computeCostDollars(selectedModel);
     logUsageRecord({
       userId,
+      subscription,
+      mode,
       model: this.resolveModelName({
         selectedModelOverride,
         responseModel,
@@ -167,7 +179,10 @@ export class UsageTracker {
       totalTokens: this.totalTokens || this.inputTokens + this.outputTokens,
       cacheReadTokens: this.cacheReadTokens || undefined,
       cacheWriteTokens: this.cacheWriteTokens || undefined,
-      costDollars: this.computeCostDollars(selectedModel),
+      modelCostDollars,
+      nonModelCostDollars: this.nonModelCost || undefined,
+      costDollars: totalCostDollars,
+      persistRawLog: subscription !== "free",
     });
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -50,6 +50,87 @@ function isBrowserRequest(request: NextRequest): boolean {
 }
 
 const SESSION_HEADER = "x-workos-session";
+const ATTRIBUTION_COOKIE = "hai_attribution";
+const ATTRIBUTION_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "gclid",
+  "fbclid",
+] as const;
+
+function sanitizedLandingPage(request: NextRequest): string {
+  const params = new URLSearchParams();
+  for (const key of ATTRIBUTION_KEYS) {
+    const value = request.nextUrl.searchParams.get(key);
+    if (value) params.set(key, value.slice(0, 500));
+  }
+
+  const query = params.toString();
+  return query
+    ? `${request.nextUrl.pathname}?${query}`
+    : request.nextUrl.pathname;
+}
+
+function sanitizedReferrer(request: NextRequest): string | undefined {
+  const raw = request.headers.get("referer");
+  if (!raw) return undefined;
+
+  try {
+    const referrer = new URL(raw);
+    return `${referrer.origin}${referrer.pathname}`.slice(0, 500);
+  } catch {
+    return undefined;
+  }
+}
+
+function withAttributionCookie(
+  request: NextRequest,
+  response: NextResponse,
+): NextResponse {
+  if (!isBrowserRequest(request)) return response;
+
+  const incoming: Record<string, string> = {};
+  for (const key of ATTRIBUTION_KEYS) {
+    const value = request.nextUrl.searchParams.get(key);
+    if (value) incoming[key] = value.slice(0, 500);
+  }
+
+  const hasNewAttribution = Object.keys(incoming).length > 0;
+  const existingCookie = request.cookies.get(ATTRIBUTION_COOKIE)?.value;
+  if (!hasNewAttribution && existingCookie) return response;
+
+  let existing: Record<string, string> = {};
+  if (existingCookie) {
+    try {
+      existing = JSON.parse(decodeURIComponent(existingCookie));
+    } catch {
+      existing = {};
+    }
+  }
+
+  const payload = {
+    ...existing,
+    ...incoming,
+    landing_page: existing.landing_page ?? sanitizedLandingPage(request),
+    referrer: existing.referrer ?? sanitizedReferrer(request),
+  };
+
+  response.cookies.set(
+    ATTRIBUTION_COOKIE,
+    encodeURIComponent(JSON.stringify(payload)),
+    {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 90 * 24 * 60 * 60,
+      path: "/",
+    },
+  );
+  return response;
+}
 
 export default async function middleware(
   request: NextRequest,
@@ -62,8 +143,11 @@ export default async function middleware(
     const hasSession = request.cookies.has("wos-session");
 
     if (!hasSession && !isUnauthenticatedPath(pathname)) {
-      return NextResponse.redirect(
-        new URL("/desktop-callback?error=unauthenticated", request.url),
+      return withAttributionCookie(
+        request,
+        NextResponse.redirect(
+          new URL("/desktop-callback?error=unauthenticated", request.url),
+        ),
       );
     }
   }
@@ -88,10 +172,13 @@ export default async function middleware(
   const responseHeaders = buildResponseHeaders(headers);
 
   if (session.user || isUnauthenticatedPath(pathname)) {
-    return NextResponse.next({
-      request: { headers: requestHeaders },
-      headers: responseHeaders,
-    });
+    return withAttributionCookie(
+      request,
+      NextResponse.next({
+        request: { headers: requestHeaders },
+        headers: responseHeaders,
+      }),
+    );
   }
 
   // If rate-limited (not a real session expiry), don't redirect to login
@@ -99,26 +186,35 @@ export default async function middleware(
     if (!isBrowserRequest(request)) {
       const rateLimitHeaders = new Headers(responseHeaders);
       rateLimitHeaders.set("Retry-After", "5");
-      return NextResponse.json(
-        { code: "rate_limited", message: "Please retry shortly." },
-        { status: 503, headers: rateLimitHeaders },
+      return withAttributionCookie(
+        request,
+        NextResponse.json(
+          { code: "rate_limited", message: "Please retry shortly." },
+          { status: 503, headers: rateLimitHeaders },
+        ),
       );
     }
     // For browser requests, let through rather than forcing a confusing login redirect
-    return NextResponse.next({
-      request: { headers: requestHeaders },
-      headers: responseHeaders,
-    });
+    return withAttributionCookie(
+      request,
+      NextResponse.next({
+        request: { headers: requestHeaders },
+        headers: responseHeaders,
+      }),
+    );
   }
 
   if (!isBrowserRequest(request)) {
-    return NextResponse.json(
-      {
-        code: "unauthorized:auth",
-        message: "You need to sign in before continuing.",
-        cause: "Session expired or invalid",
-      },
-      { status: 401, headers: responseHeaders },
+    return withAttributionCookie(
+      request,
+      NextResponse.json(
+        {
+          code: "unauthorized:auth",
+          message: "You need to sign in before continuing.",
+          cause: "Session expired or invalid",
+        },
+        { status: 401, headers: responseHeaders },
+      ),
     );
   }
 
@@ -129,10 +225,16 @@ export default async function middleware(
     });
     const errorUrl = new URL("/auth-error", request.url);
     errorUrl.searchParams.set("code", "503");
-    return NextResponse.redirect(errorUrl, { headers: responseHeaders });
+    return withAttributionCookie(
+      request,
+      NextResponse.redirect(errorUrl, { headers: responseHeaders }),
+    );
   }
 
-  return NextResponse.redirect(authorizationUrl, { headers: responseHeaders });
+  return withAttributionCookie(
+    request,
+    NextResponse.redirect(authorizationUrl, { headers: responseHeaders }),
+  );
 }
 
 function buildRequestHeaders(

--- a/middleware.ts
+++ b/middleware.ts
@@ -51,6 +51,8 @@ function isBrowserRequest(request: NextRequest): boolean {
 
 const SESSION_HEADER = "x-workos-session";
 const ATTRIBUTION_COOKIE = "hai_attribution";
+const ATTRIBUTION_VALUE_MAX_LENGTH = 180;
+const ATTRIBUTION_URL_MAX_LENGTH = 500;
 const ATTRIBUTION_KEYS = [
   "utm_source",
   "utm_medium",
@@ -61,17 +63,59 @@ const ATTRIBUTION_KEYS = [
   "fbclid",
 ] as const;
 
+type AttributionPayload = Partial<
+  Record<
+    (typeof ATTRIBUTION_KEYS)[number] | "landing_page" | "referrer",
+    string
+  >
+>;
+
+function cleanAttributionValue(value: unknown, maxLength: number) {
+  return typeof value === "string" && value.length > 0
+    ? value.slice(0, maxLength)
+    : undefined;
+}
+
+function normalizeAttributionPayload(value: unknown): AttributionPayload {
+  if (!value || typeof value !== "object") return {};
+
+  const source = value as Record<string, unknown>;
+  const normalized: AttributionPayload = {};
+  for (const key of ATTRIBUTION_KEYS) {
+    const clean = cleanAttributionValue(
+      source[key],
+      ATTRIBUTION_VALUE_MAX_LENGTH,
+    );
+    if (clean) normalized[key] = clean;
+  }
+
+  const landingPage = cleanAttributionValue(
+    source.landing_page,
+    ATTRIBUTION_URL_MAX_LENGTH,
+  );
+  if (landingPage) normalized.landing_page = landingPage;
+
+  const referrer = cleanAttributionValue(
+    source.referrer,
+    ATTRIBUTION_URL_MAX_LENGTH,
+  );
+  if (referrer) normalized.referrer = referrer;
+
+  return normalized;
+}
+
 function sanitizedLandingPage(request: NextRequest): string {
   const params = new URLSearchParams();
   for (const key of ATTRIBUTION_KEYS) {
     const value = request.nextUrl.searchParams.get(key);
-    if (value) params.set(key, value.slice(0, 500));
+    if (value) params.set(key, value.slice(0, ATTRIBUTION_VALUE_MAX_LENGTH));
   }
 
   const query = params.toString();
-  return query
+  const landingPage = query
     ? `${request.nextUrl.pathname}?${query}`
     : request.nextUrl.pathname;
+  return landingPage.slice(0, ATTRIBUTION_URL_MAX_LENGTH);
 }
 
 function sanitizedReferrer(request: NextRequest): string | undefined {
@@ -80,7 +124,10 @@ function sanitizedReferrer(request: NextRequest): string | undefined {
 
   try {
     const referrer = new URL(raw);
-    return `${referrer.origin}${referrer.pathname}`.slice(0, 500);
+    return `${referrer.origin}${referrer.pathname}`.slice(
+      0,
+      ATTRIBUTION_URL_MAX_LENGTH,
+    );
   } catch {
     return undefined;
   }
@@ -95,17 +142,19 @@ function withAttributionCookie(
   const incoming: Record<string, string> = {};
   for (const key of ATTRIBUTION_KEYS) {
     const value = request.nextUrl.searchParams.get(key);
-    if (value) incoming[key] = value.slice(0, 500);
+    if (value) incoming[key] = value.slice(0, ATTRIBUTION_VALUE_MAX_LENGTH);
   }
 
   const hasNewAttribution = Object.keys(incoming).length > 0;
   const existingCookie = request.cookies.get(ATTRIBUTION_COOKIE)?.value;
   if (!hasNewAttribution && existingCookie) return response;
 
-  let existing: Record<string, string> = {};
+  let existing: AttributionPayload = {};
   if (existingCookie) {
     try {
-      existing = JSON.parse(decodeURIComponent(existingCookie));
+      existing = normalizeAttributionPayload(
+        JSON.parse(decodeURIComponent(existingCookie)),
+      );
     } catch {
       existing = {};
     }

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -838,7 +838,7 @@ export const agentLongTask = task({
           let preFallbackCacheWrite = 0;
 
           const deductAccumulatedUsage = async () => {
-            if (hasDeductedUsage || subscription === "free") return;
+            if (hasDeductedUsage) return;
             const sandboxCost = getSandboxSessionCost();
             if (sandboxCost > 0) {
               usageTracker.providerCost += sandboxCost;
@@ -851,19 +851,23 @@ export const agentLongTask = task({
               usageTracker.modelProviderCost > 0
                 ? usageTracker.providerCost
                 : undefined;
-            await deductUsage(
-              userId,
-              subscription,
-              estimatedInputTokens,
-              usageTracker.inputTokens,
-              usageTracker.outputTokens,
-              extraUsageConfig,
-              providerCost,
-              selectedModel,
-              usageTracker.nonModelCost,
-            );
+            if (subscription !== "free") {
+              await deductUsage(
+                userId,
+                subscription,
+                estimatedInputTokens,
+                usageTracker.inputTokens,
+                usageTracker.outputTokens,
+                extraUsageConfig,
+                providerCost,
+                selectedModel,
+                usageTracker.nonModelCost,
+              );
+            }
             usageTracker.log({
               userId,
+              subscription,
+              mode,
               selectedModel,
               selectedModelOverride,
               responseModel: state.responseModel,


### PR DESCRIPTION
## Summary

Adds a low-cost internal unit economics dashboard for HackerAI, backed by Convex daily aggregates instead of high-volume PostHog request tracing.

## What changed

- Added `user_accounts` and `user_economics_daily` aggregate tables for user lifecycle, usage cost, and revenue rollups.
- Added server-side usage aggregation for free and paid users while keeping raw `usage_logs` only for paid history.
- Added Stripe revenue capture for subscription invoices, refunds, disputes, and extra-usage purchases.
- Added first-party attribution capture and sync after login.
- Added admin-only `/admin/economics` page and `/api/admin/economics` JSON endpoint gated by `ADMIN_USER_IDS`.
- Hardened revenue idempotency and subscription webhook processing with atomic webhook claims and economics-level dedupe keys.
- Sanitized stored attribution URLs to avoid saving sensitive query parameters.

## Impact

Admins can now see free cost/user, paid cost/user, ARPU, ARPPU, 30-day conversion, contribution, and margin directly inside HackerAI without sending every LLM request to PostHog.

## Validation

- Pre-commit hook ran `prettier --write`, `eslint --fix`, `pnpm typecheck`, and full `pnpm test`.
- Full Jest result: 84 suites passed, 1081 tests passed.
- Additional focused checks previously passed for economics aggregation, webhook claims, usage tracking, and fallback usage accounting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin economics dashboard: date filters, CSV export, top-level metrics and detailed per-user/cost cards
  * Client-side attribution sync (runs once per authenticated user) and server endpoint to receive attribution data
  * Attribution cookie capture from marketing query params for improved tracking

* **Improvements**
  * Richer usage & cost tracking with model vs non-model breakdown and per-tier daily aggregation
  * Payment/webhook reliability: extra-usage, subscription, refund and dispute events now record revenue consistently
  * Daily purge of old usage logs to limit storage growth and improve performance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->