### PR TITLE
[codex] fix desktop entitlement refresh

### DIFF
--- a/app/api/auth/desktop-callback/route.ts
+++ b/app/api/auth/desktop-callback/route.ts
@@ -6,6 +6,15 @@ import {
 } from "@/lib/desktop-auth";
 import { workos } from "@/app/api/workos";
 
+type DesktopAuthSession = {
+  accessToken: string;
+  refreshToken: string;
+  user: unknown;
+  impersonator?: unknown;
+  authenticationMethod?: unknown;
+  sealedSession?: string;
+};
+
 function escapeHtml(str: string): string {
   return str
     .replace(/&/g, "&amp;")
@@ -81,16 +90,55 @@ export async function GET(request: NextRequest) {
         clientId,
       });
 
-    const session = {
+    let session: DesktopAuthSession = {
       accessToken,
       refreshToken,
       user,
       impersonator,
     };
 
-    const sealedSession = await sealData(session, {
-      password: cookiePassword,
-    });
+    let organizationId: string | undefined;
+    try {
+      const memberships =
+        await workos.userManagement.listOrganizationMemberships({
+          userId: user.id,
+          statuses: ["active"],
+        });
+      organizationId = memberships.data?.[0]?.organizationId;
+    } catch (err) {
+      console.error(
+        "[Desktop Auth] Failed to fetch organization memberships:",
+        err,
+      );
+    }
+
+    if (organizationId) {
+      session = await workos.userManagement.authenticateWithRefreshToken({
+        clientId,
+        refreshToken,
+        organizationId,
+        session: {
+          sealSession: true,
+          cookiePassword,
+        },
+      });
+    }
+
+    const sealedSession =
+      session.sealedSession ??
+      (await sealData(
+        {
+          accessToken: session.accessToken,
+          refreshToken: session.refreshToken,
+          user: session.user,
+          impersonator: session.impersonator,
+          authenticationMethod: session.authenticationMethod,
+        },
+        {
+          password: cookiePassword,
+          ttl: 0,
+        },
+      ));
 
     const transferToken = await createDesktopTransferToken(sealedSession);
 

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -30,6 +30,8 @@ import type { UploadedFileState } from "@/types/file";
 import type { FileMessagePart } from "@/types/file";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useSandboxPreference } from "@/app/hooks/useSandboxPreference";
+import { isTauriEnvironment } from "@/app/hooks/useTauri";
+import { resolveSubscriptionTier } from "@/lib/auth/entitlements";
 import { chatSidebarStorage } from "@/lib/utils/sidebar-storage";
 import type { Id } from "@/convex/_generated/dataModel";
 import { useQuery } from "convex/react";
@@ -210,6 +212,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   }, []);
   const [isCheckingProPlan, setIsCheckingProPlan] = useState(false);
   const chatResetRef = useRef<(() => void) | null>(null);
+  const desktopEntitlementRefreshUserRef = useRef<string | null>(null);
 
   // Rate limit warning dismissal state (persists across chat switches)
   const [
@@ -323,35 +326,62 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   useEffect(() => {
     if (!user) {
       setSubscription("free");
+      desktopEntitlementRefreshUserRef.current = null;
       return;
     }
 
     if (Array.isArray(entitlements)) {
-      const hasUltra =
-        entitlements.includes("ultra-plan") ||
-        entitlements.includes("ultra-monthly-plan") ||
-        entitlements.includes("ultra-yearly-plan");
-      const hasTeam = entitlements.includes("team-plan");
-      const hasProPlus =
-        entitlements.includes("pro-plus-plan") ||
-        entitlements.includes("pro-plus-monthly-plan") ||
-        entitlements.includes("pro-plus-yearly-plan");
-      const hasPro =
-        entitlements.includes("pro-plan") ||
-        entitlements.includes("pro-monthly-plan") ||
-        entitlements.includes("pro-yearly-plan");
-      setSubscriptionWithNormalize(
-        hasUltra
-          ? "ultra"
-          : hasTeam
-            ? "team"
-            : hasProPlus
-              ? "pro-plus"
-              : hasPro
-                ? "pro"
-                : "free",
-      );
+      setSubscriptionWithNormalize(resolveSubscriptionTier(entitlements));
     }
+  }, [user, entitlements, setSubscriptionWithNormalize]);
+
+  // Desktop sessions are created through a separate OAuth transfer flow. Older
+  // desktop sessions may be unscoped, so refresh once to pull WorkOS
+  // entitlements from the user's organization before showing them as free.
+  useEffect(() => {
+    const refreshDesktopEntitlements = async () => {
+      if (!user || typeof window === "undefined" || !isTauriEnvironment()) {
+        return;
+      }
+
+      const currentEntitlements = Array.isArray(entitlements)
+        ? entitlements
+        : [];
+      if (resolveSubscriptionTier(currentEntitlements) !== "free") {
+        return;
+      }
+
+      const url = new URL(window.location.href);
+      if (url.searchParams.get("refresh") === "entitlements") {
+        return;
+      }
+
+      if (desktopEntitlementRefreshUserRef.current === user.id) {
+        return;
+      }
+      desktopEntitlementRefreshUserRef.current = user.id;
+
+      setIsCheckingProPlan(true);
+      try {
+        const response = await fetch("/api/entitlements", {
+          credentials: "include",
+        });
+        if (!response.ok) return;
+
+        const data = await response.json();
+        setSubscriptionWithNormalize(
+          resolveSubscriptionTier(
+            Array.isArray(data.entitlements) ? data.entitlements : [],
+          ),
+        );
+      } catch {
+        // Keep the token-derived tier; this is only a best-effort desktop heal.
+      } finally {
+        setIsCheckingProPlan(false);
+      }
+    };
+
+    refreshDesktopEntitlements();
   }, [user, entitlements, setSubscriptionWithNormalize]);
 
   // Refresh entitlements only when explicitly requested via URL param


### PR DESCRIPTION
## What changed

- Scope the desktop OAuth transfer session to the user's active WorkOS organization before sealing it for the desktop app.
- Add a one-time desktop entitlement refresh when the client token still resolves to `free`.
- Reuse the shared entitlement tier resolver in global state instead of duplicating entitlement slug checks.

## Why

Desktop login uses a custom WorkOS session transfer flow. That session could be created without an organization-scoped token, so WorkOS subscription entitlements were absent in desktop even when the same account showed a paid plan on web.

## Impact

Paid users signing into the desktop app should now receive the same subscription tier as web. Existing desktop sessions that are stuck on `free` get a best-effort one-time refresh to recover.

## Validation

- `pnpm typecheck`
- `pnpm exec eslint app/api/auth/desktop-callback/route.ts app/contexts/GlobalState.tsx`
- `pnpm test -- lib/auth/__tests__/use-auth-from-authkit.test.ts lib/__tests__/desktop-auth.test.ts --runInBand`
- Commit hook: Prettier, ESLint, `pnpm typecheck`, full `pnpm test` (`83` suites, `1078` tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication session handling to include organization context and updated security measures.
  * Enhanced subscription tier detection for desktop users with legacy sessions.
  * Better session initialization after OAuth code exchange.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->