### PR TITLE
[codex] Guard oversized image URLs

### DIFF
--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -1,0 +1,150 @@
+import { processMessageFiles } from "../file-transform-utils";
+
+jest.mock("server-only", () => ({}));
+jest.mock("@/lib/db/convex-client", () => ({
+  getConvexClient: jest.fn(() => ({
+    action: jest.fn(),
+  })),
+}));
+
+const makeMessage = (part: Record<string, unknown>) =>
+  [
+    {
+      id: "m1",
+      role: "user",
+      parts: [{ type: "text", text: "what is this?" }, part],
+    },
+  ] as any;
+
+const responseLike = ({
+  status = 200,
+  headers = {},
+  body = null,
+}: {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: { getReader: () => { read: () => Promise<any> } } | null;
+}) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) => headers[name.toLowerCase()] ?? null,
+    },
+    body,
+  }) as Response;
+
+const streamBody = (...chunks: Uint8Array[]) => ({
+  getReader: () => {
+    let index = 0;
+    return {
+      read: async () =>
+        index < chunks.length
+          ? { done: false, value: chunks[index++] }
+          : { done: true },
+    };
+  },
+});
+
+describe("processMessageFiles image size guards", () => {
+  const originalFetch = global.fetch;
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("omits URL-backed images when HEAD shows provider download size over 30 MB", async () => {
+    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
+      if (init?.method === "HEAD") {
+        return responseLike({
+          headers: { "content-length": String(40 * 1024 * 1024) },
+        });
+      }
+
+      throw new Error("Range probe should not run when HEAD has a size");
+    }) as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        mediaType: "image/png",
+        name: "huge.png",
+        url: "https://example.com/huge.png",
+      }),
+      "ask",
+      undefined,
+      "pro",
+    );
+
+    expect(result.messages[0].parts).toEqual([
+      { type: "text", text: "what is this?" },
+      {
+        type: "text",
+        text: '[Image "huge.png" omitted: 40.0 MB exceeds the 30 MB per-image limit]',
+      },
+    ]);
+  });
+
+  it("omits URL-backed images when headers are inconclusive but the range probe exceeds 5 MB", async () => {
+    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
+      if (init?.method === "HEAD") {
+        return responseLike({});
+      }
+
+      return responseLike({
+        status: 206,
+        body: streamBody(new Uint8Array(5 * 1024 * 1024 + 1)),
+      });
+    }) as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        mediaType: "image/png",
+        name: "unknown-size.png",
+        url: "https://example.com/unknown-size.png",
+      }),
+      "ask",
+      undefined,
+      "pro",
+    );
+
+    expect(result.messages[0].parts[1]).toEqual({
+      type: "text",
+      text: '[Image "unknown-size.png" omitted: 5.0 MB exceeds the 5 MB per-image limit]',
+    });
+  });
+
+  it("keeps URL-backed images when content-length is within the image limit", async () => {
+    global.fetch = jest.fn(async () => {
+      return responseLike({
+        headers: { "content-length": String(2 * 1024 * 1024) },
+      });
+    }) as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        mediaType: "image/png",
+        name: "small.png",
+        url: "https://example.com/small.png",
+      }),
+      "ask",
+      undefined,
+      "pro",
+    );
+
+    expect(result.messages[0].parts[1]).toMatchObject({
+      type: "file",
+      mediaType: "image/png",
+      name: "small.png",
+      url: "https://example.com/small.png",
+    });
+  });
+});

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -16,6 +16,18 @@ import { logger } from "@/lib/logger";
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 const MAX_PROVIDER_IMAGE_DOWNLOAD_SIZE = 30 * 1024 * 1024;
 
+type FileToProcess = {
+  fileId?: string;
+  url?: string;
+  mediaType?: string;
+  positions: Array<{ messageIndex: number; partIndex: number }>;
+};
+
+type SizeProbeResult = {
+  bytes: number;
+  source: "content_length" | "content_range" | "download_probe";
+};
+
 const containsPdfAttachments = (messages: UIMessage[]): boolean =>
   messages.some((msg: any) =>
     (msg.parts || []).some(
@@ -56,7 +68,23 @@ const convertUrlToBase64DataUrl = async (
   }
 };
 
-const probeContentLength = async (url: string): Promise<number | null> => {
+const parseContentLength = (value: string | null): number | null => {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+};
+
+const parseContentRangeTotal = (value: string | null): number | null => {
+  if (!value) return null;
+  const match = value.match(/\/(\d+)$/);
+  if (!match) return null;
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+};
+
+const probeContentLength = async (
+  url: string,
+): Promise<SizeProbeResult | null> => {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 10000);
 
@@ -66,16 +94,76 @@ const probeContentLength = async (url: string): Promise<number | null> => {
       signal: controller.signal,
     });
     if (!response.ok) return null;
-    const length = response.headers.get("content-length");
-    if (!length) return null;
-    const parsed = Number(length);
-    return Number.isFinite(parsed) ? parsed : null;
+    const parsed = parseContentLength(response.headers.get("content-length"));
+    return parsed == null ? null : { bytes: parsed, source: "content_length" };
   } catch {
     return null;
   } finally {
     clearTimeout(timeoutId);
   }
 };
+
+const probeDownloadSize = async (
+  url: string,
+  limitBytes: number,
+): Promise<SizeProbeResult | null> => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30000);
+
+  try {
+    const response = await fetch(url, {
+      headers: { Range: `bytes=0-${limitBytes}` },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) return null;
+
+    const rangeTotal = parseContentRangeTotal(
+      response.headers.get("content-range"),
+    );
+    if (rangeTotal != null) {
+      return { bytes: rangeTotal, source: "content_range" };
+    }
+
+    const contentLength = parseContentLength(
+      response.headers.get("content-length"),
+    );
+    if (contentLength != null && response.status !== 206) {
+      return { bytes: contentLength, source: "content_length" };
+    }
+
+    if (!response.body) {
+      return contentLength == null
+        ? null
+        : { bytes: contentLength, source: "download_probe" };
+    }
+
+    const reader = response.body.getReader();
+    let bytes = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > limitBytes) {
+        controller.abort();
+        return { bytes, source: "download_probe" };
+      }
+    }
+
+    return { bytes, source: "download_probe" };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};
+
+const probeImageSize = async (
+  url: string,
+  limitBytes: number,
+): Promise<SizeProbeResult | null> =>
+  (await probeContentLength(url)) ?? (await probeDownloadSize(url, limitBytes));
 
 const imageOmittedText = (
   name: unknown,
@@ -119,30 +207,16 @@ const collectFilesToProcess = (
   mode: ChatMode,
 ): {
   hasMedia: boolean;
-  files: Map<
-    string,
-    {
-      url?: string;
-      mediaType?: string;
-      positions: Array<{ messageIndex: number; partIndex: number }>;
-    }
-  >;
+  files: Map<string, FileToProcess>;
 } => {
   let hasMedia = false;
-  const files = new Map<
-    string,
-    {
-      url?: string;
-      mediaType?: string;
-      positions: Array<{ messageIndex: number; partIndex: number }>;
-    }
-  >();
+  const files = new Map<string, FileToProcess>();
 
   messages.forEach((msg, messageIndex) => {
     if (!msg.parts) return;
 
     (msg.parts as any[]).forEach((part, partIndex) => {
-      if (!isFilePart(part) || !part.fileId) return;
+      if (!isFilePart(part)) return;
 
       if (isMediaFile(part.mediaType)) hasMedia = true;
 
@@ -152,10 +226,22 @@ const collectFilesToProcess = (
         isMediaFile(part.mediaType);
 
       if (shouldProcess) {
-        if (!files.has(part.fileId)) {
-          files.set(part.fileId, { mediaType: part.mediaType, positions: [] });
+        const fileId =
+          typeof part.fileId === "string" ? part.fileId : undefined;
+        const url =
+          typeof (part as any).url === "string" ? (part as any).url : undefined;
+        const key = fileId ? `file:${fileId}` : url ? `url:${url}` : null;
+        if (!key) return;
+
+        if (!files.has(key)) {
+          files.set(key, {
+            fileId,
+            url,
+            mediaType: part.mediaType,
+            positions: [],
+          });
         }
-        files.get(part.fileId)!.positions.push({ messageIndex, partIndex });
+        files.get(key)!.positions.push({ messageIndex, partIndex });
       }
     });
   });
@@ -185,30 +271,23 @@ const fetchFileUrls = async (fileIds: string[]): Promise<(string | null)[]> => {
 
 const applyUrlsToFileParts = async (
   messages: UIMessage[],
-  filesToProcess: Map<
-    string,
-    {
-      url?: string;
-      mediaType?: string;
-      positions: Array<{ messageIndex: number; partIndex: number }>;
-    }
-  >,
+  filesToProcess: Map<string, FileToProcess>,
   mode: ChatMode,
 ) => {
-  const fileIdsNeedingUrls = Array.from(filesToProcess.entries())
-    .filter(([_, file]) => !file.url)
-    .map(([fileId]) => fileId);
+  const filesNeedingUrls = Array.from(filesToProcess.values()).filter(
+    (file) => file.fileId && !file.url,
+  );
+  const fileIdsNeedingUrls = filesNeedingUrls.map((file) => file.fileId!);
 
   const fetchedUrls = await fetchFileUrls(fileIdsNeedingUrls);
 
-  fileIdsNeedingUrls.forEach((fileId, index) => {
-    const file = filesToProcess.get(fileId);
-    if (file && fetchedUrls[index]) {
+  filesNeedingUrls.forEach((file, index) => {
+    if (fetchedUrls[index]) {
       file.url = fetchedUrls[index];
     }
   });
 
-  for (const [fileId, file] of filesToProcess) {
+  for (const [fileKey, file] of filesToProcess) {
     if (!file.url) continue;
 
     // Only convert PDFs to base64 in "ask" mode for inline viewing.
@@ -226,12 +305,17 @@ const applyUrlsToFileParts = async (
         ] as any)
       : null;
     const isSupportedImage = isSupportedImageMediaType(file.mediaType ?? "");
-    const probedImageSize =
-      isSupportedImage && typeof firstPart?.size !== "number"
-        ? await probeContentLength(file.url)
-        : null;
+    const shouldProbeImageSize =
+      isSupportedImage &&
+      file.url &&
+      (!file.fileId || typeof firstPart?.size !== "number");
+    const probedImageSize = shouldProbeImageSize
+      ? await probeImageSize(file.url, MAX_IMAGE_SIZE)
+      : null;
     const effectiveImageSize =
-      typeof firstPart?.size === "number" ? firstPart.size : probedImageSize;
+      typeof firstPart?.size === "number"
+        ? firstPart.size
+        : (probedImageSize?.bytes ?? null);
     const imageLimit =
       effectiveImageSize != null &&
       effectiveImageSize > MAX_PROVIDER_IMAGE_DOWNLOAD_SIZE
@@ -246,14 +330,16 @@ const applyUrlsToFileParts = async (
       logger.warn("image_attachment_omitted_before_provider_call", {
         event: "image_attachment_omitted_before_provider_call",
         service: "chat-handler",
-        file_id: fileId,
+        file_id: file.fileId,
+        file_ref: file.fileId ? "file_id" : "inline_url",
+        file_key: file.fileId ? fileKey : undefined,
         media_type: file.mediaType,
         size_bytes: effectiveImageSize,
         limit_bytes: imageLimit,
         size_source:
           typeof firstPart?.size === "number"
             ? "message_part"
-            : "content_length",
+            : probedImageSize?.source,
         mode,
       });
     }


### PR DESCRIPTION
## Summary

Adds a backend guard for image file parts that already carry direct URLs, so oversized images are replaced with an omission note before the provider request is sent.

## Why

Fresh browser uploads are already limited, but history, temporary flows, or generated URL-backed file parts can bypass upload-time size metadata. OpenRouter then downloads the image during the chat completion request and rejects it with `413 Downloaded image content cannot exceed 30MB`.

## Changes

- Processes direct URL-backed image file parts, not only `fileId` attachments.
- Probes image size with `HEAD` and falls back to a bounded range/stream read when headers are missing or inconclusive.
- Preserves small images and replaces oversized ones with a text omission note before `streamText`.
- Adds focused tests for oversized URL images and allowed small URL images.

## Validation

- `pnpm test -- lib/utils/__tests__/file-transform-utils.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm eslint lib/utils/file-transform-utils.ts lib/utils/__tests__/file-transform-utils.test.ts`
- Commit hook: `pnpm typecheck` and full `pnpm test` (`84` suites, `1082` tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced image file size validation with improved detection and handling of oversized image files.
  * Oversized images are now properly identified and replaced with informative messages indicating size limit violations.

* **Tests**
  * Added comprehensive test suite for image size limit enforcement scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->