### PR TITLE
[codex] Handle file token limit as expected upload block

### DIFF
--- a/app/hooks/useFileUpload.ts
+++ b/app/hooks/useFileUpload.ts
@@ -46,6 +46,18 @@ const logLocalAttachmentDebug = (
 const getFilenameFromPath = (path: string) =>
   path.split(/[\\/]/).filter(Boolean).pop() || "selected file";
 
+const isExpectedFileUploadError = (error: unknown): boolean => {
+  if (error instanceof ConvexError) {
+    const errorData = error.data as { code?: string };
+    return (
+      errorData?.code === "FILE_TOKEN_LIMIT_EXCEEDED" ||
+      errorData?.code === "FILE_UPLOAD_RATE_LIMIT" ||
+      errorData?.code === "PAID_PLAN_REQUIRED"
+    );
+  }
+  return false;
+};
+
 const fileFromBase64 = (
   base64: string,
   name: string,
@@ -292,7 +304,11 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
           url,
         });
       } catch (error) {
-        console.error("Failed to upload file:", error);
+        if (isExpectedFileUploadError(error)) {
+          console.warn("File upload blocked:", error);
+        } else {
+          console.error("Failed to upload file:", error);
+        }
 
         // Extract error message from ConvexError or regular Error
         const errorMessage = (() => {

--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -190,7 +190,7 @@ const validateTokenLimit = (
   if (totalTokens > maxTokens) {
     throw new ConvexError({
       code: "FILE_TOKEN_LIMIT_EXCEEDED",
-      message: `File "${fileName}" exceeds the maximum token limit of ${maxTokens.toLocaleString()} tokens. Current tokens: ${totalTokens.toLocaleString()}. Tip: Switch to Agent or Agent Long mode to upload larger files without token limits.`,
+      message: `File "${fileName}" exceeds the maximum token limit of ${maxTokens.toLocaleString()} tokens. Current tokens: ${totalTokens.toLocaleString()}. Tip: Switch to Agent mode to upload larger files without token limits.`,
     });
   }
 };
@@ -406,7 +406,7 @@ const processFileAuto = async (
         if (!skipTokenValidation && fallbackTokens > maxTokens) {
           throw new ConvexError({
             code: "FILE_TOKEN_LIMIT_EXCEEDED",
-            message: `File "${fileName || "unknown"}" exceeds the maximum token limit of ${maxTokens.toLocaleString()} tokens. Current tokens: ${fallbackTokens.toLocaleString()}. Tip: Switch to Agent or Agent Long mode to upload larger files without token limits.`,
+            message: `File "${fileName || "unknown"}" exceeds the maximum token limit of ${maxTokens.toLocaleString()} tokens. Current tokens: ${fallbackTokens.toLocaleString()}. Tip: Switch to Agent mode to upload larger files without token limits.`,
           });
         }
 
@@ -816,16 +816,29 @@ export const saveFile = action({
     } catch (error) {
       // Check if this is a ConvexError (including token limit errors) - re-throw as-is
       if (error instanceof ConvexError) {
+        const errorData = error.data as { code?: string; message?: string };
         // Best-effort cleanup: delete storage before re-throwing
-        convexLogger.error("file_upload_processing_convex_error", {
-          userId: actingUserId,
-          fileName: args.name,
-          size: args.size,
-          mediaType: args.mediaType,
-          mode: args.mode,
-          errorCode: (error.data as { code?: string })?.code,
-          errorMessage: (error.data as { message?: string })?.message,
-        });
+        if (errorData?.code === "FILE_TOKEN_LIMIT_EXCEEDED") {
+          convexLogger.warn("file_upload_token_limit_exceeded", {
+            userId: actingUserId,
+            fileName: args.name,
+            size: args.size,
+            mediaType: args.mediaType,
+            mode: args.mode,
+            errorCode: errorData.code,
+            errorMessage: errorData.message,
+          });
+        } else {
+          convexLogger.error("file_upload_processing_convex_error", {
+            userId: actingUserId,
+            fileName: args.name,
+            size: args.size,
+            mediaType: args.mediaType,
+            mode: args.mode,
+            errorCode: errorData?.code,
+            errorMessage: errorData?.message,
+          });
+        }
         try {
           if (args.s3Key) {
             await ctx.scheduler.runAfter(
@@ -857,7 +870,7 @@ export const saveFile = action({
         error instanceof Error &&
         error.message.includes("exceeds the maximum token limit")
       ) {
-        convexLogger.error("file_upload_token_limit_exceeded", {
+        convexLogger.warn("file_upload_token_limit_exceeded", {
           userId: actingUserId,
           fileName: args.name,
           size: args.size,


### PR DESCRIPTION
## Summary

Treat oversized Ask-mode file uploads as an expected validation block instead of an application error.

## What Changed

- Downgraded `FILE_TOKEN_LIMIT_EXCEEDED` upload logging from error to warning in Convex file processing.
- Updated the user-facing token-limit guidance to mention Agent mode only, since Agent Long is no longer an exposed option.
- Changed the client upload hook to use `console.warn` for expected upload blocks while preserving `console.error` for unexpected failures.

## Why

Users can intentionally hit the Ask-mode file token limit with large files. That should remain visible for product analytics/debugging, but it should not pollute PostHog error tracking as an uncaught exception.

## Validation

- `pnpm exec prettier --check convex/fileActions.ts app/hooks/useFileUpload.ts`
- `pnpm exec eslint app/hooks/useFileUpload.ts --ext .ts,.tsx`
- `pnpm typecheck`
- Commit hook: prettier, eslint, `tsc --noEmit`, and Jest (`83` suites / `1079` tests passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload error handling to properly classify and manage errors related to token limits and upload constraints.
  * Updated token limit exceeded error messages to recommend switching to Agent mode.

* **Improvements**
  * Enhanced logging for file operations to better classify and diagnose upload-related errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->