### PR TITLE
[codex] Show aborted tool calls

### DIFF
--- a/app/components/tools/FileHandler.tsx
+++ b/app/components/tools/FileHandler.tsx
@@ -5,6 +5,7 @@ import type { ChatStatus } from "@/types";
 import type { SidebarFile } from "@/types/chat";
 import { isSidebarFile } from "@/types/chat";
 import { useToolSidebar } from "../../hooks/useToolSidebar";
+import { isUserStoppedToolError } from "@/lib/chat/tool-abort-utils";
 
 interface FileInput {
   action: "read" | "write" | "append" | "edit";
@@ -29,6 +30,7 @@ function areFilePropsEqual(
   if (prev.part.state !== next.part.state) return false;
   if (prev.part.toolCallId !== next.part.toolCallId) return false;
   if (prev.part.output !== next.part.output) return false;
+  if (prev.part.errorText !== next.part.errorText) return false;
   if (prev.part.input !== next.part.input) return false;
   return true;
 }
@@ -39,6 +41,11 @@ export const FileHandler = memo(function FileHandler({
 }: FileHandlerProps) {
   const input = part.input as FileInput | undefined;
   const action = input?.action;
+  const outputErrorText =
+    typeof part.errorText === "string" ? part.errorText : undefined;
+  const isIncompleteState =
+    part.state === "input-streaming" || part.state === "input-available";
+  const isStoppedIncomplete = isIncompleteState && status !== "streaming";
 
   const getFileRange = () => {
     if (!input?.range) return "";
@@ -55,15 +62,21 @@ export const FileHandler = memo(function FileHandler({
   // failures still read clearly.
   const briefText = input?.brief?.trim() || "";
   const isOutputError =
-    part.state === "output-available" &&
-    typeof part.output === "object" &&
-    part.output !== null &&
-    "error" in part.output;
+    isStoppedIncomplete ||
+    part.state === "output-error" ||
+    (part.state === "output-available" &&
+      typeof part.output === "object" &&
+      part.output !== null &&
+      "error" in part.output);
+  const isStoppedByUser =
+    isStoppedIncomplete || isUserStoppedToolError(outputErrorText);
   const useBriefOnly = !!briefText && !isOutputError;
   const briefLabel = (fallback: string) =>
     useBriefOnly ? briefText : fallback;
   const briefTarget = (fallback: string | undefined) =>
     useBriefOnly ? undefined : fallback;
+  const errorLabel = (failed: string, stopped: string) =>
+    isStoppedByUser ? stopped : failed;
 
   // Compute sidebar content based on action and state
   const sidebarContent = useMemo((): SidebarFile | null => {
@@ -82,17 +95,18 @@ export const FileHandler = memo(function FileHandler({
         content: input.text || "",
         action: action === "append" ? "appending" : "creating",
         toolCallId,
-        isExecuting: true,
+        isExecuting: status === "streaming",
       };
     }
 
     // Output available — build content from result
-    if (part.state === "output-available") {
+    if (part.state === "output-available" || part.state === "output-error") {
       const output = part.output;
       const isError =
-        typeof output === "object" && output !== null && "error" in output;
+        part.state === "output-error" ||
+        (typeof output === "object" && output !== null && "error" in output);
       const errorMessage = isError
-        ? (output as { error: string }).error
+        ? outputErrorText || (output as { error: string } | undefined)?.error
         : undefined;
 
       if (action === "read") {
@@ -187,7 +201,15 @@ export const FileHandler = memo(function FileHandler({
     }
 
     return null;
-  }, [action, part.state, part.output, input, part.toolCallId]);
+  }, [
+    action,
+    part.state,
+    part.output,
+    input,
+    part.toolCallId,
+    outputErrorText,
+    status,
+  ]);
 
   const { handleOpenInSidebar, handleKeyDown } = useToolSidebar({
     toolCallId: part.toolCallId,
@@ -202,6 +224,16 @@ export const FileHandler = memo(function FileHandler({
 
     switch (state) {
       case "input-streaming":
+        if (isStoppedIncomplete && input?.path) {
+          return (
+            <ToolBlock
+              key={toolCallId}
+              icon={<FileText />}
+              action="Stopped reading"
+              target={`${input.path}${getFileRange()}`}
+            />
+          );
+        }
         return status === "streaming" ? (
           <ToolBlock
             key={toolCallId}
@@ -211,6 +243,16 @@ export const FileHandler = memo(function FileHandler({
           />
         ) : null;
       case "input-available":
+        if (isStoppedIncomplete && input?.path) {
+          return (
+            <ToolBlock
+              key={toolCallId}
+              icon={<FileText />}
+              action="Stopped reading"
+              target={`${input.path}${getFileRange()}`}
+            />
+          );
+        }
         return status === "streaming" ? (
           <ToolBlock
             key={toolCallId}
@@ -222,14 +264,19 @@ export const FileHandler = memo(function FileHandler({
             isShimmer={true}
           />
         ) : null;
-      case "output-available": {
+      case "output-available":
+      case "output-error": {
         if (!input) return null;
 
         return (
           <ToolBlock
             key={toolCallId}
             icon={<FileText />}
-            action={briefLabel(isOutputError ? `Failed to read` : "Read")}
+            action={briefLabel(
+              isOutputError
+                ? errorLabel("Failed to read", "Stopped reading")
+                : "Read",
+            )}
             target={briefTarget(`${input.path}${getFileRange()}`)}
             isClickable={isClickable}
             onClick={handleOpenInSidebar}
@@ -250,7 +297,20 @@ export const FileHandler = memo(function FileHandler({
         const hasContent = !!input?.text;
         const hasFilePath = !!input?.path;
 
-        if (status !== "streaming") return null;
+        if (status !== "streaming") {
+          if (!hasFilePath) return null;
+          return (
+            <ToolBlock
+              key={toolCallId}
+              icon={<FilePlus />}
+              action="Stopped writing"
+              target={input.path}
+              isClickable={isClickable}
+              onClick={isClickable ? handleOpenInSidebar : undefined}
+              onKeyDown={isClickable ? handleKeyDown : undefined}
+            />
+          );
+        }
 
         return (
           <ToolBlock
@@ -266,7 +326,20 @@ export const FileHandler = memo(function FileHandler({
         );
       }
       case "input-available":
-        if (status !== "streaming") return null;
+        if (status !== "streaming") {
+          if (!input?.path) return null;
+          return (
+            <ToolBlock
+              key={toolCallId}
+              icon={<FilePlus />}
+              action="Stopped writing"
+              target={input.path}
+              isClickable={isClickable}
+              onClick={isClickable ? handleOpenInSidebar : undefined}
+              onKeyDown={isClickable ? handleKeyDown : undefined}
+            />
+          );
+        }
         return (
           <ToolBlock
             key={toolCallId}
@@ -279,7 +352,8 @@ export const FileHandler = memo(function FileHandler({
             onKeyDown={isClickable ? handleKeyDown : undefined}
           />
         );
-      case "output-available": {
+      case "output-available":
+      case "output-error": {
         if (!input) return null;
 
         return (
@@ -287,7 +361,9 @@ export const FileHandler = memo(function FileHandler({
             key={toolCallId}
             icon={<FilePlus />}
             action={briefLabel(
-              isOutputError ? "Failed to write" : "Successfully wrote",
+              isOutputError
+                ? errorLabel("Failed to write", "Stopped writing")
+                : "Successfully wrote",
             )}
             target={briefTarget(input.path)}
             isClickable={isClickable}
@@ -309,7 +385,20 @@ export const FileHandler = memo(function FileHandler({
         const hasContent = !!input?.text;
         const hasFilePath = !!input?.path;
 
-        if (status !== "streaming") return null;
+        if (status !== "streaming") {
+          if (!hasFilePath) return null;
+          return (
+            <ToolBlock
+              key={toolCallId}
+              icon={<FileOutput />}
+              action="Stopped appending to"
+              target={input.path}
+              isClickable={isClickable}
+              onClick={isClickable ? handleOpenInSidebar : undefined}
+              onKeyDown={isClickable ? handleKeyDown : undefined}
+            />
+          );
+        }
 
         return (
           <ToolBlock
@@ -325,7 +414,20 @@ export const FileHandler = memo(function FileHandler({
         );
       }
       case "input-available":
-        if (status !== "streaming") return null;
+        if (status !== "streaming") {
+          if (!input?.path) return null;
+          return (
+            <ToolBlock
+              key={toolCallId}
+              icon={<FileOutput />}
+              action="Stopped appending to"
+              target={input.path}
+              isClickable={isClickable}
+              onClick={isClickable ? handleOpenInSidebar : undefined}
+              onKeyDown={isClickable ? handleKeyDown : undefined}
+            />
+          );
+        }
         return (
           <ToolBlock
             key={toolCallId}
@@ -338,7 +440,8 @@ export const FileHandler = memo(function FileHandler({
             onKeyDown={isClickable ? handleKeyDown : undefined}
           />
         );
-      case "output-available": {
+      case "output-available":
+      case "output-error": {
         if (!input) return null;
 
         return (
@@ -347,7 +450,7 @@ export const FileHandler = memo(function FileHandler({
             icon={<FileOutput />}
             action={briefLabel(
               isOutputError
-                ? "Failed to append to"
+                ? errorLabel("Failed to append to", "Stopped appending to")
                 : "Successfully appended to",
             )}
             target={briefTarget(input.path)}
@@ -367,6 +470,16 @@ export const FileHandler = memo(function FileHandler({
 
     switch (state) {
       case "input-streaming":
+        if (isStoppedIncomplete && input?.path) {
+          return (
+            <ToolBlock
+              key={toolCallId}
+              icon={<FilePen />}
+              action="Stopped editing"
+              target={input.path}
+            />
+          );
+        }
         return status === "streaming" ? (
           <ToolBlock
             key={toolCallId}
@@ -376,6 +489,16 @@ export const FileHandler = memo(function FileHandler({
           />
         ) : null;
       case "input-available":
+        if (isStoppedIncomplete && input?.path) {
+          return (
+            <ToolBlock
+              key={toolCallId}
+              icon={<FilePen />}
+              action="Stopped editing"
+              target={input.path}
+            />
+          );
+        }
         return status === "streaming" ? (
           <ToolBlock
             key={toolCallId}
@@ -389,14 +512,19 @@ export const FileHandler = memo(function FileHandler({
             isShimmer={true}
           />
         ) : null;
-      case "output-available": {
+      case "output-available":
+      case "output-error": {
         if (!input) return null;
 
         return (
           <ToolBlock
             key={toolCallId}
             icon={<FilePen />}
-            action={briefLabel(isOutputError ? "Failed to edit" : "Edited")}
+            action={briefLabel(
+              isOutputError
+                ? errorLabel("Failed to edit", "Stopped editing")
+                : "Edited",
+            )}
             target={briefTarget(input.path)}
             isClickable={isClickable}
             onClick={handleOpenInSidebar}

--- a/app/components/tools/FileToolsHandler.tsx
+++ b/app/components/tools/FileToolsHandler.tsx
@@ -18,6 +18,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
+import { isUserStoppedToolError } from "@/lib/chat/tool-abort-utils";
 
 interface DiffDataPart {
   type: "data-diff";
@@ -198,6 +199,9 @@ export const FileToolsHandler = ({
   });
 
   const isClickable = !!sidebarContent;
+  const isStoppedByUser = isUserStoppedToolError(part.errorText);
+  const errorLabel = (failed: string, stopped: string) =>
+    isStoppedByUser ? stopped : failed;
 
   const renderReadFileTool = () => {
     const { toolCallId, state, input } = part;
@@ -261,6 +265,16 @@ export const FileToolsHandler = ({
           </div>
         );
       }
+      case "output-error":
+        if (!readInput) return null;
+        return (
+          <ToolBlock
+            key={toolCallId}
+            icon={<FileText />}
+            action={errorLabel("Failed to read", "Stopped reading")}
+            target={`${readInput.target_file}${getFileRange()}`}
+          />
+        );
       default:
         return null;
     }
@@ -322,6 +336,16 @@ export const FileToolsHandler = ({
             <OpenFileButton filePath={writeInput.file_path} />
           </div>
         );
+      case "output-error":
+        if (!writeInput) return null;
+        return (
+          <ToolBlock
+            key={toolCallId}
+            icon={<FilePlus />}
+            action={errorLabel("Failed to write", "Stopped writing")}
+            target={writeInput.file_path}
+          />
+        );
       default:
         return null;
     }
@@ -367,6 +391,16 @@ export const FileToolsHandler = ({
           />
         );
       }
+      case "output-error":
+        if (!deleteInput) return null;
+        return (
+          <ToolBlock
+            key={toolCallId}
+            icon={<FileMinus />}
+            action={errorLabel("Failed to delete", "Stopped deleting")}
+            target={deleteInput.target_file}
+          />
+        );
       default:
         return null;
     }
@@ -426,6 +460,16 @@ export const FileToolsHandler = ({
           </div>
         );
       }
+      case "output-error":
+        if (!searchReplaceInput) return null;
+        return (
+          <ToolBlock
+            key={toolCallId}
+            icon={<FilePen />}
+            action={errorLabel("Failed to edit", "Stopped editing")}
+            target={searchReplaceInput.file_path}
+          />
+        );
       default:
         return null;
     }
@@ -491,6 +535,16 @@ export const FileToolsHandler = ({
           </div>
         );
       }
+      case "output-error":
+        if (!multiEditInput) return null;
+        return (
+          <ToolBlock
+            key={toolCallId}
+            icon={<FilePen />}
+            action={errorLabel("Failed to apply edits", "Stopped editing")}
+            target={multiEditInput.file_path}
+          />
+        );
       default:
         return null;
     }

--- a/app/components/tools/GetTerminalFilesHandler.tsx
+++ b/app/components/tools/GetTerminalFilesHandler.tsx
@@ -8,6 +8,7 @@ import {
   type SidebarSharedFiles,
 } from "@/types/chat";
 import type { FileDetails } from "@/types/file";
+import { isUserStoppedToolError } from "@/lib/chat/tool-abort-utils";
 
 interface TerminalFilesPart {
   toolCallId: string;
@@ -17,6 +18,7 @@ interface TerminalFilesPart {
     | "output-available"
     | "output-error";
   input?: { files: string[]; brief?: string };
+  errorText?: string;
   output?: {
     result: string;
     files?: Array<{ path: string }>;
@@ -37,6 +39,7 @@ export const GetTerminalFilesHandler = memo(function GetTerminalFilesHandler({
   sharedFileDetails,
 }: GetTerminalFilesHandlerProps) {
   const { toolCallId, state, input, output } = part;
+  const isStoppedByUser = isUserStoppedToolError(part.errorText);
 
   // Memoize requestedPaths to prevent unstable references from triggering
   // infinite re-render loops via useToolSidebar's updateSidebarContent effect.
@@ -145,7 +148,7 @@ export const GetTerminalFilesHandler = memo(function GetTerminalFilesHandler({
         <ToolBlock
           key={toolCallId}
           icon={<FileDown />}
-          action="Failed to share"
+          action={isStoppedByUser ? "Stopped sharing" : "Failed to share"}
           target={getFileNames(requestedPaths)}
         />
       );

--- a/app/components/tools/HttpRequestToolHandler.tsx
+++ b/app/components/tools/HttpRequestToolHandler.tsx
@@ -5,6 +5,7 @@ import { Globe } from "lucide-react";
 import type { ChatStatus, SidebarTerminal } from "@/types/chat";
 import { isSidebarTerminal } from "@/types/chat";
 import { useToolSidebar } from "../../hooks/useToolSidebar";
+import { isUserStoppedToolError } from "@/lib/chat/tool-abort-utils";
 
 interface HttpRequestToolHandlerProps {
   message: UIMessage;
@@ -18,6 +19,7 @@ export const HttpRequestToolHandler = ({
   status,
 }: HttpRequestToolHandlerProps) => {
   const { toolCallId, state, input, output, errorText } = part;
+  const isStoppedByUser = isUserStoppedToolError(errorText);
 
   const httpInput = input as {
     url: string;
@@ -135,7 +137,7 @@ export const HttpRequestToolHandler = ({
         <ToolBlock
           key={toolCallId}
           icon={<Globe />}
-          action="Request failed"
+          action={isStoppedByUser ? "Stopped request" : "Request failed"}
           target={displayCommand}
           isClickable={true}
           onClick={handleOpenInSidebar}

--- a/app/components/tools/NotesToolHandler.tsx
+++ b/app/components/tools/NotesToolHandler.tsx
@@ -3,6 +3,7 @@ import ToolBlock from "@/components/ui/tool-block";
 import type { ChatStatus, SidebarNote, SidebarNotes } from "@/types/chat";
 import { isSidebarNotes } from "@/types/chat";
 import { useToolSidebar } from "../../hooks/useToolSidebar";
+import { isUserStoppedToolError } from "@/lib/chat/tool-abort-utils";
 import {
   getNotesIcon,
   getNotesStreamingActionText,
@@ -22,7 +23,22 @@ export const NotesToolHandler = memo(function NotesToolHandler({
   status,
   toolName,
 }: NotesToolHandlerProps) {
-  const { toolCallId, state, input, output } = part;
+  const { toolCallId, state, input, output, errorText } = part;
+  const isStoppedByUser = isUserStoppedToolError(errorText);
+  const stoppedActionText = () => {
+    switch (toolName) {
+      case "create_note":
+        return "Stopped creating note";
+      case "list_notes":
+        return "Stopped listing notes";
+      case "update_note":
+        return "Stopped updating note";
+      case "delete_note":
+        return "Stopped deleting note";
+      default:
+        return "Stopped note action";
+    }
+  };
 
   const getTarget = () => {
     if (toolName === "create_note" && input?.title) {
@@ -150,6 +166,20 @@ export const NotesToolHandler = memo(function NotesToolHandler({
         />
       );
     }
+
+    case "output-error":
+      return (
+        <ToolBlock
+          key={toolCallId}
+          icon={getNotesIcon(toolName, "h-4 w-4")}
+          action={
+            isStoppedByUser
+              ? stoppedActionText()
+              : getNotesActionText(toolName, true)
+          }
+          target={getTarget()}
+        />
+      );
 
     default:
       return null;

--- a/app/components/tools/ProxyToolHandler.tsx
+++ b/app/components/tools/ProxyToolHandler.tsx
@@ -4,6 +4,7 @@ import { Radar } from "lucide-react";
 import type { ChatStatus, SidebarProxy } from "@/types/chat";
 import { isSidebarProxy } from "@/types/chat";
 import { useToolSidebar } from "../../hooks/useToolSidebar";
+import { isUserStoppedToolError } from "@/lib/chat/tool-abort-utils";
 
 interface ProxyToolHandlerProps {
   part: any;
@@ -224,6 +225,7 @@ export const ProxyToolHandler = ({
   toolName,
 }: ProxyToolHandlerProps) => {
   const { toolCallId, state, input, output, errorText } = part;
+  const isStoppedByUser = isUserStoppedToolError(errorText);
 
   const displayTarget = useMemo(() => {
     if (!input) return "";
@@ -292,7 +294,9 @@ export const ProxyToolHandler = ({
   const getActionText = (): string => {
     if (state === "input-streaming") return "Preparing proxy action";
     if (isExecuting) return PROXY_ACTION_LABELS[toolName] || "Proxying";
-    if (output?.result?.error || errorText) return "Proxy action failed";
+    if (output?.result?.error || errorText) {
+      return isStoppedByUser ? "Stopped proxy action" : "Proxy action failed";
+    }
     return PROXY_COMPLETED_LABELS[toolName] || "Proxied";
   };
 
@@ -336,7 +340,9 @@ export const ProxyToolHandler = ({
         <ToolBlock
           key={toolCallId}
           icon={<Radar />}
-          action="Proxy action failed"
+          action={
+            isStoppedByUser ? "Stopped proxy action" : "Proxy action failed"
+          }
           target={displayTarget}
           isClickable={true}
           onClick={handleOpenInSidebar}

--- a/app/components/tools/TerminalToolHandler.tsx
+++ b/app/components/tools/TerminalToolHandler.tsx
@@ -12,6 +12,7 @@ import {
   type ShellToolInput,
   type ShellToolOutput,
 } from "./shell-tool-utils";
+import { isUserStoppedToolError } from "@/lib/chat/tool-abort-utils";
 
 interface TerminalToolHandlerProps {
   message: UIMessage;
@@ -112,6 +113,7 @@ export const TerminalToolHandler = memo(function TerminalToolHandler({
   });
 
   const shellAction = (input as { action?: string })?.action;
+  const isStoppedByUser = isUserStoppedToolError(errorText);
 
   switch (state) {
     case "input-streaming": {
@@ -168,7 +170,7 @@ export const TerminalToolHandler = memo(function TerminalToolHandler({
         <ToolBlock
           key={toolCallId}
           icon={<Terminal />}
-          action={blockAction(false)}
+          action={isStoppedByUser ? "Stopped command" : blockAction(false)}
           target={blockTarget}
           isClickable
           onClick={handleOpenInSidebar}

--- a/app/components/tools/TodoToolHandler.tsx
+++ b/app/components/tools/TodoToolHandler.tsx
@@ -4,6 +4,7 @@ import ToolBlock from "@/components/ui/tool-block";
 import { TodoBlock } from "@/components/ui/todo-block";
 import { ListTodo } from "lucide-react";
 import type { ChatStatus, Todo, TodoWriteInput } from "@/types";
+import { isUserStoppedToolError } from "@/lib/chat/tool-abort-utils";
 
 interface TodoToolHandlerProps {
   message: UIMessage;
@@ -29,8 +30,15 @@ export const TodoToolHandler = memo(function TodoToolHandler({
   part,
   status,
 }: TodoToolHandlerProps) {
-  const { toolCallId, state, input, output } = part;
+  const { toolCallId, state, input, output, errorText } = part;
   const todoInput = input as TodoWriteInput;
+  const isStoppedByUser = isUserStoppedToolError(errorText);
+  const stoppedTodoAction = todoInput?.merge
+    ? "Stopped updating to-do list"
+    : "Stopped creating to-do list";
+  const failedTodoAction = todoInput?.merge
+    ? "Todo update failed"
+    : "Todo creation failed";
 
   switch (state) {
     case "input-streaming":
@@ -75,6 +83,20 @@ export const TodoToolHandler = memo(function TodoToolHandler({
         />
       );
     }
+
+    case "output-error":
+      return (
+        <ToolBlock
+          key={toolCallId}
+          icon={<ListTodo />}
+          action={isStoppedByUser ? stoppedTodoAction : failedTodoAction}
+          target={
+            todoInput?.todos?.length
+              ? `${todoInput.todos.length} items`
+              : undefined
+          }
+        />
+      );
 
     default:
       return null;

--- a/app/components/tools/WebToolHandler.tsx
+++ b/app/components/tools/WebToolHandler.tsx
@@ -4,6 +4,7 @@ import { Search, ExternalLink } from "lucide-react";
 import type { ChatStatus, SidebarWebSearch, WebSearchResult } from "@/types";
 import { isSidebarWebSearch } from "@/types/chat";
 import { useToolSidebar } from "../../hooks/useToolSidebar";
+import { isUserStoppedToolError } from "@/lib/chat/tool-abort-utils";
 
 interface WebSearchInput {
   queries?: string[];
@@ -31,6 +32,7 @@ interface WebToolHandlerProps {
     state: string;
     input?: WebSearchInput | OpenUrlInput | LegacyWebInput;
     output?: WebSearchResult[] | { result?: WebSearchResult[] };
+    errorText?: string;
   };
   status: ChatStatus;
 }
@@ -51,7 +53,8 @@ export const WebToolHandler = memo(function WebToolHandler({
   part,
   status,
 }: WebToolHandlerProps) {
-  const { toolCallId, toolName, type, state, input, output } = part;
+  const { toolCallId, toolName, type, state, input, output, errorText } = part;
+  const isStoppedByUser = isUserStoppedToolError(errorText);
 
   // Determine if this is an open_url action
   const isOpenUrl =
@@ -187,6 +190,24 @@ export const WebToolHandler = memo(function WebToolHandler({
           isClickable={canOpenSidebar}
           onClick={canOpenSidebar ? handleOpenInSidebar : undefined}
           onKeyDown={canOpenSidebar ? handleKeyDown : undefined}
+        />
+      );
+
+    case "output-error":
+      return (
+        <ToolBlock
+          key={toolCallId}
+          icon={icon}
+          action={
+            isOpenUrl
+              ? isStoppedByUser
+                ? "Stopped opening URL"
+                : "Failed to open URL"
+              : isStoppedByUser
+                ? "Stopped searching web"
+                : "Search failed"
+          }
+          target={target}
         />
       );
 

--- a/app/share/[shareId]/components/SharedMessagePartHandler.tsx
+++ b/app/share/[shareId]/components/SharedMessagePartHandler.tsx
@@ -39,6 +39,7 @@ import {
   type ShellToolOutput,
 } from "@/app/components/tools/shell-tool-utils";
 import { PROXY_COMPLETED_LABELS } from "@/app/components/tools/ProxyToolHandler";
+import { isUserStoppedToolError } from "@/lib/chat/tool-abort-utils";
 
 interface MessagePart {
   type: string;
@@ -57,6 +58,9 @@ interface SharedMessagePartHandlerProps {
   isUser: boolean;
   allParts?: MessagePart[];
 }
+
+const isStoppedToolPart = (part: MessagePart) =>
+  isUserStoppedToolError(part.errorText);
 
 export const SharedMessagePartHandler = ({
   part,
@@ -269,18 +273,42 @@ function renderLegacyFileTool(
     sidebarAction = "reading";
   }
   if (part.type === "tool-write_file") {
-    action = "Successfully wrote";
+    action =
+      part.state === "output-error"
+        ? isStoppedToolPart(part)
+          ? "Stopped writing"
+          : "Failed to write"
+        : "Successfully wrote";
     icon = <FilePlus aria-hidden="true" />;
     sidebarAction = "writing";
   }
   if (part.type === "tool-delete_file") {
-    action = "Successfully deleted";
+    action =
+      part.state === "output-error"
+        ? isStoppedToolPart(part)
+          ? "Stopped deleting"
+          : "Failed to delete"
+        : "Successfully deleted";
     icon = <FileMinus aria-hidden="true" />;
   }
   if (part.type === "tool-search_replace" || part.type === "tool-multi_edit") {
-    action = "Successfully edited";
+    action =
+      part.state === "output-error"
+        ? isStoppedToolPart(part)
+          ? "Stopped editing"
+          : "Failed to edit"
+        : "Successfully edited";
     icon = <FilePen aria-hidden="true" />;
     sidebarAction = "editing";
+  }
+  if (part.type === "tool-read_file" && part.state === "output-error") {
+    action = isStoppedToolPart(part) ? "Stopped reading" : "Failed to read";
+  }
+
+  if (part.state === "output-error") {
+    return (
+      <ToolBlock key={idx} icon={icon} action={action} target={filePath} />
+    );
   }
 
   if (part.state === "output-available") {
@@ -395,13 +423,32 @@ function renderFileTool(
     sidebarAction = "editing";
   }
 
-  if (fileOutput?.error) {
-    action = `Failed to ${fileAction}`;
+  const isError = part.state === "output-error" || !!fileOutput?.error;
+  if (isError) {
+    if (isStoppedToolPart(part)) {
+      if (fileAction === "read") action = "Stopped reading";
+      if (fileAction === "write") action = "Stopped writing";
+      if (fileAction === "append") action = "Stopped appending to";
+      if (fileAction === "edit") action = "Stopped editing";
+    } else {
+      action = `Failed to ${fileAction}`;
+    }
   }
 
   // Mirror the live FileHandler: when the model supplies a `brief` and the
   // call didn't error, the brief stands alone as the block label.
-  const useBriefOnly = !!brief && !fileOutput?.error;
+  const useBriefOnly = !!brief && !isError;
+
+  if (part.state === "output-error") {
+    return (
+      <ToolBlock
+        key={idx}
+        icon={icon}
+        action={action}
+        target={`${filePath}${getFileRange()}`}
+      />
+    );
+  }
 
   if (part.state === "output-available") {
     const handleOpenInSidebar = () => {
@@ -471,6 +518,19 @@ function renderWebSearchTool(part: MessagePart, idx: number) {
 
   const brief = webInput?.brief?.trim() || "";
 
+  if (part.state === "output-error") {
+    return (
+      <ToolBlock
+        key={idx}
+        icon={<Search aria-hidden="true" />}
+        action={
+          isStoppedToolPart(part) ? "Stopped searching web" : "Search failed"
+        }
+        target={target}
+      />
+    );
+  }
+
   if (part.state === "output-available") {
     return (
       <ToolBlock
@@ -488,6 +548,19 @@ function renderWebSearchTool(part: MessagePart, idx: number) {
 function renderOpenUrlTool(part: MessagePart, idx: number) {
   const urlInput = part.input as { url?: string; brief?: string };
   const brief = urlInput?.brief?.trim() || "";
+
+  if (part.state === "output-error") {
+    return (
+      <ToolBlock
+        key={idx}
+        icon={<ExternalLink aria-hidden="true" />}
+        action={
+          isStoppedToolPart(part) ? "Stopped opening URL" : "Failed to open URL"
+        }
+        target={urlInput?.url}
+      />
+    );
+  }
 
   if (part.state === "output-available") {
     return (
@@ -514,11 +587,23 @@ function renderGetTerminalFilesTool(part: MessagePart, idx: number) {
     return paths.map((path) => path.split("/").pop() || path).join(", ");
   };
 
+  const fileNames = getFileNames(filesInput?.files || []);
+  const brief = filesInput?.brief?.trim() || "";
+
+  if (part.state === "output-error") {
+    return (
+      <ToolBlock
+        key={idx}
+        icon={<FileDown aria-hidden="true" />}
+        action={isStoppedToolPart(part) ? "Stopped sharing" : "Failed to share"}
+        target={fileNames}
+      />
+    );
+  }
+
   if (part.state === "output-available") {
     const fileCount =
       filesOutput?.files?.length || filesOutput?.fileUrls?.length || 0;
-    const fileNames = getFileNames(filesInput?.files || []);
-    const brief = filesInput?.brief?.trim() || "";
 
     return (
       <ToolBlock
@@ -557,6 +642,27 @@ function renderTodoTool(part: MessagePart, idx: number) {
         key={idx}
         icon={<ListTodo aria-hidden="true" />}
         action="Updated todos"
+      />
+    );
+  }
+  if (part.state === "output-error") {
+    const todoInput = part.input as { merge?: boolean; todos?: unknown[] };
+    const stoppedTodoAction = todoInput?.merge
+      ? "Stopped updating to-do list"
+      : "Stopped creating to-do list";
+    const failedTodoAction = todoInput?.merge
+      ? "Todo update failed"
+      : "Todo creation failed";
+    return (
+      <ToolBlock
+        key={idx}
+        icon={<ListTodo aria-hidden="true" />}
+        action={isStoppedToolPart(part) ? stoppedTodoAction : failedTodoAction}
+        target={
+          todoInput?.todos?.length
+            ? `${todoInput.todos.length} items`
+            : undefined
+        }
       />
     );
   }
@@ -616,9 +722,14 @@ function renderProxyTool(
     return "";
   };
 
-  const isError = !!part.errorText || !!part.output?.result?.error;
+  const isError =
+    part.state === "output-error" ||
+    !!part.errorText ||
+    !!part.output?.result?.error;
   const actionText = isError
-    ? "Proxy action failed"
+    ? isStoppedToolPart(part)
+      ? "Stopped proxy action"
+      : "Proxy action failed"
     : PROXY_COMPLETED_LABELS[toolName] || "Executed";
 
   if (
@@ -730,7 +841,9 @@ function renderHttpRequestTool(
     : "";
 
   const getActionText = () => {
-    if (httpOutput?.error) return "Request failed";
+    if (part.state === "output-error" || httpOutput?.error || part.errorText) {
+      return isStoppedToolPart(part) ? "Stopped request" : "Request failed";
+    }
     return "Requested";
   };
 
@@ -742,7 +855,7 @@ function renderHttpRequestTool(
     const handleOpenInSidebar = () => {
       openSidebar({
         command: displayCommand,
-        output: httpOutput?.output || httpOutput?.error || "",
+        output: httpOutput?.output || httpOutput?.error || part.errorText || "",
         isExecuting: false,
         toolCallId: part.toolCallId || "",
       });
@@ -854,6 +967,21 @@ function renderNotesTool(
     }
     return undefined;
   };
+
+  if (part.state === "output-error") {
+    return (
+      <ToolBlock
+        key={idx}
+        icon={getNotesIcon(toolName)}
+        action={
+          isStoppedToolPart(part)
+            ? "Stopped note action"
+            : getNotesActionText(toolName, true)
+        }
+        target={getTarget()}
+      />
+    );
+  }
 
   if (part.state === "output-available") {
     // Check for failure state

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -76,6 +76,7 @@ import {
 } from "@/lib/utils/stream-cancellation";
 import { v4 as uuidv4 } from "uuid";
 import { processChatMessages, selectModel } from "@/lib/chat/chat-processor";
+import { summarizeIncompleteToolParts } from "@/lib/chat/tool-abort-utils";
 import { createTrackedProvider } from "@/lib/ai/providers";
 import {
   uploadSandboxFiles,
@@ -1079,6 +1080,26 @@ export const createChatHandler = (
                           p.toolCallId,
                       ),
                   );
+                  const incompleteToolSummaries = isAborted
+                    ? summarizeIncompleteToolParts(messages)
+                    : [];
+                  if (incompleteToolSummaries.length > 0) {
+                    console.info(
+                      JSON.stringify({
+                        level: "info",
+                        event: "abort_incomplete_tool_calls_detected",
+                        service: "chat-handler",
+                        timestamp: new Date().toISOString(),
+                        chat_id: chatId,
+                        user_id: userId,
+                        mode,
+                        finish_reason: state.streamFinishReason,
+                        is_preemptive_abort: isPreemptiveAbort,
+                        incomplete_tool_count: incompleteToolSummaries.length,
+                        incomplete_tools: incompleteToolSummaries,
+                      }),
+                    );
+                  }
 
                   // On abort, streamText.onFinish may not have fired yet, so state.streamUsage
                   // could be undefined. Await usage from result to ensure we capture it.
@@ -1097,6 +1118,8 @@ export const createChatHandler = (
                   }
 
                   const hasUsageToRecord = Boolean(resolvedUsage);
+                  const shouldSkipSaveSignal =
+                    cancellationSubscriber.shouldSkipSave();
 
                   // If user aborted (not pre-emptive), skip message save when:
                   // 1. skipSave signal received via Redis (edit/regenerate/retry — message will be discarded)
@@ -1104,11 +1127,27 @@ export const createChatHandler = (
                   if (
                     isAborted &&
                     !isPreemptiveAbort &&
-                    (cancellationSubscriber.shouldSkipSave() ||
+                    (shouldSkipSaveSignal ||
                       (newFileIds.length === 0 &&
                         !hasIncompleteToolCalls &&
                         !hasUsageToRecord))
                   ) {
+                    console.info(
+                      JSON.stringify({
+                        level: "info",
+                        event: "abort_message_save_skipped",
+                        service: "chat-handler",
+                        timestamp: new Date().toISOString(),
+                        chat_id: chatId,
+                        user_id: userId,
+                        mode,
+                        finish_reason: state.streamFinishReason,
+                        skip_save_signal: shouldSkipSaveSignal,
+                        new_file_count: newFileIds.length,
+                        has_incomplete_tool_calls: hasIncompleteToolCalls,
+                        has_usage_to_record: hasUsageToRecord,
+                      }),
+                    );
                     await deductAccumulatedUsage();
                     return;
                   }

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -317,7 +317,7 @@ describe("fixIncompleteMessageParts", () => {
     expect(result).toEqual(parts);
   });
 
-  it("should remove incomplete tool with input but no output", () => {
+  it("should mark incomplete renderable tool with input as aborted", () => {
     const parts = [
       { type: "step-start" },
       {
@@ -328,8 +328,15 @@ describe("fixIncompleteMessageParts", () => {
       },
     ];
     const result = fixIncompleteMessageParts(parts);
-    // Tool never executed (no output), so remove it and its step-start
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe("step-start");
+    expect(result[1]).toMatchObject({
+      type: "tool-create_note",
+      toolCallId: "call_1",
+      state: "output-error",
+      input: { title: "Test", content: "Content" },
+      errorText: "Stopped by user before the tool completed.",
+    });
   });
 
   it("should remove tool parts with input-streaming and no input", () => {
@@ -362,7 +369,7 @@ describe("fixIncompleteMessageParts", () => {
     expect(result[0].type).toBe("text");
   });
 
-  it("should remove incomplete tool with partial input but no output", () => {
+  it("should mark incomplete tool with partial meaningful input as aborted", () => {
     const parts = [
       { type: "step-start" },
       {
@@ -373,8 +380,44 @@ describe("fixIncompleteMessageParts", () => {
       },
     ];
     const result = fixIncompleteMessageParts(parts);
-    // Tool never produced output, so remove entirely
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({
+      type: "tool-create_note",
+      state: "output-error",
+      input: { title: "Partial" },
+      errorText: "Stopped by user before the tool completed.",
+    });
+  });
+
+  it("should mark incomplete file writes with streamed path metadata as aborted", () => {
+    const parts = [
+      { type: "step-start" },
+      {
+        input: {
+          action: "write",
+          brief: "Test with cloudscraper to handle Cloudflare challenge",
+          path: "/home/user/telenet_cloudscraper.py",
+        },
+        state: "input-streaming",
+        toolCallId: "toolu_vrtx_01CY5UvLdoBKwymCRD5TB8r3",
+        type: "tool-file",
+      },
+    ];
+
+    const result = fixIncompleteMessageParts(parts);
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({
+      type: "tool-file",
+      state: "output-error",
+      toolCallId: "toolu_vrtx_01CY5UvLdoBKwymCRD5TB8r3",
+      input: {
+        action: "write",
+        brief: "Test with cloudscraper to handle Cloudflare challenge",
+        path: "/home/user/telenet_cloudscraper.py",
+      },
+      errorText: "Stopped by user before the tool completed.",
+    });
   });
 
   it("should handle mixed complete and incomplete parts", () => {

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -13,6 +13,10 @@ import {
   type ModelName,
 } from "@/lib/ai/providers";
 import { AUTH_DISCLAIMER, detectLang } from "@/lib/chat/auth-disclaimer";
+import {
+  ABORTED_TOOL_ERROR_TEXT,
+  hasMeaningfulToolInput,
+} from "@/lib/chat/tool-abort-utils";
 /**
  * Get maximum steps allowed for a user based on mode and subscription.
  * Agent mode: 100 steps (all tiers).
@@ -121,18 +125,118 @@ export function addAuthMessage(messages: UIMessage[], moderationText: string) {
   }
 }
 
+const ABORT_RENDERABLE_TOOL_TYPES = new Set([
+  "tool-file",
+  "tool-read_file",
+  "tool-write_file",
+  "tool-delete_file",
+  "tool-search_replace",
+  "tool-multi_edit",
+  "tool-web_search",
+  "tool-open_url",
+  "tool-web",
+  "tool-shell",
+  "tool-run_terminal_cmd",
+  "tool-interact_terminal_session",
+  "tool-http_request",
+  "tool-get_terminal_files",
+  "tool-todo_write",
+  "tool-create_note",
+  "tool-list_notes",
+  "tool-update_note",
+  "tool-delete_note",
+  "tool-list_requests",
+  "tool-view_request",
+  "tool-send_request",
+  "tool-scope_rules",
+  "tool-list_sitemap",
+  "tool-view_sitemap_entry",
+]);
+
+type IncompleteMessagePartsLogContext = {
+  service?: string;
+  source?: string;
+  chatId?: string;
+  userId?: string;
+  messageId?: string;
+  mode?: string;
+  finishReason?: string;
+  updateOnly?: boolean;
+};
+
+function logIncompleteToolPartHandled({
+  action,
+  part,
+  context,
+}: {
+  action: "converted_to_output_error" | "dropped";
+  part: any;
+  context?: IncompleteMessagePartsLogContext;
+}) {
+  if (!context) return;
+
+  console.info(
+    JSON.stringify({
+      level: "info",
+      event: "incomplete_tool_part_handled",
+      service: context.service ?? "chat-processor",
+      timestamp: new Date().toISOString(),
+      source: context.source,
+      chat_id: context.chatId,
+      user_id: context.userId,
+      message_id: context.messageId,
+      mode: context.mode,
+      finish_reason: context.finishReason,
+      update_only: context.updateOnly,
+      action,
+      tool_type: part.type,
+      tool_call_id: part.toolCallId,
+      original_state: part.state,
+      has_input: part.input != null,
+      has_meaningful_input: hasMeaningfulToolInput(part.input),
+      input_keys:
+        part.input &&
+        typeof part.input === "object" &&
+        !Array.isArray(part.input)
+          ? Object.keys(part.input as Record<string, unknown>).sort()
+          : [],
+    }),
+  );
+}
+
+function createAbortedToolPart(part: any): any | null {
+  if (
+    !ABORT_RENDERABLE_TOOL_TYPES.has(part.type) ||
+    !part.toolCallId ||
+    !hasMeaningfulToolInput(part.input)
+  ) {
+    return null;
+  }
+
+  const { output: _output, result: _result, ...restPart } = part;
+  return {
+    ...restPart,
+    state: "output-error",
+    errorText: ABORTED_TOOL_ERROR_TEXT,
+  };
+}
+
 /**
  * Fixes incomplete tool invocations and removes incomplete reasoning from message parts.
  * This can happen when a stream is interrupted. Without proper handling:
  * - Tool invocations without results cause AI_MissingToolResultsError
  * - Incomplete reasoning parts may cause "must include at least one parts field" errors
  *
- * We add placeholder results for tools and remove incomplete reasoning (along with
- * any step-start that immediately precedes it).
+ * We mark renderable aborted tools as output-error when they have enough input
+ * to show what was stopped, and remove empty incomplete tools/reasoning (along
+ * with any step-start that immediately precedes them).
  *
  * This function is exported for use in db/actions.ts as well.
  */
-export function fixIncompleteMessageParts(parts: any[]): any[] {
+export function fixIncompleteMessageParts(
+  parts: any[],
+  options?: { logContext?: IncompleteMessagePartsLogContext },
+): any[] {
   // First pass: fix incomplete tool invocations
   const partsWithFixedTools = parts.map((part: any) => {
     // Check for custom tool-xxx parts that aren't in a completed state
@@ -151,12 +255,25 @@ export function fixIncompleteMessageParts(parts: any[]): any[] {
       isToolPart && part.state === "result" && part.result !== undefined;
 
     if (isIncomplete || hasWrongFormat) {
-      // If the tool never executed (input-streaming or input-available), remove it entirely.
-      // These tools were interrupted before producing any output, so there's nothing real
-      // to report. Keeping them with fabricated output pollutes the conversation history.
-      // This also prevents "must have at least one content element" errors from providers
-      // like xAI/Grok when the conversation is resumed with empty tool args.
       if (isIncomplete && part.output == null && part.result == null) {
+        const abortedPart = createAbortedToolPart(part);
+        if (abortedPart) {
+          logIncompleteToolPartHandled({
+            action: "converted_to_output_error",
+            part,
+            context: options?.logContext,
+          });
+          return abortedPart;
+        }
+
+        // Empty or unknown tools were interrupted before producing any useful
+        // display state. Removing them avoids polluting model history with
+        // fabricated tool calls and prevents provider errors on resume.
+        logIncompleteToolPartHandled({
+          action: "dropped",
+          part,
+          context: options?.logContext,
+        });
         return null; // Mark for removal in second pass
       }
 

--- a/lib/chat/tool-abort-utils.ts
+++ b/lib/chat/tool-abort-utils.ts
@@ -1,0 +1,73 @@
+export const ABORTED_TOOL_ERROR_TEXT =
+  "Stopped by user before the tool completed.";
+
+export const isUserStoppedToolError = (errorText: unknown): boolean =>
+  typeof errorText === "string" && /stopped|aborted/i.test(errorText);
+
+export function hasMeaningfulToolInput(input: unknown): boolean {
+  if (input == null) return false;
+  if (typeof input === "string") return input.trim().length > 0;
+  if (typeof input === "number" || typeof input === "boolean") return true;
+  if (Array.isArray(input)) return input.some(hasMeaningfulToolInput);
+  if (typeof input !== "object") return false;
+  return Object.values(input as Record<string, unknown>).some(
+    hasMeaningfulToolInput,
+  );
+}
+
+type MessageLike = {
+  id?: string;
+  role?: string;
+  parts?: unknown[];
+};
+
+export function summarizeIncompleteToolParts(messages: MessageLike[]) {
+  const summaries: Array<{
+    message_id?: string;
+    tool_type?: string;
+    tool_call_id?: string;
+    state?: string;
+    has_input: boolean;
+    has_meaningful_input: boolean;
+    input_keys: string[];
+  }> = [];
+
+  for (const message of messages) {
+    if (message.role !== "assistant" || !Array.isArray(message.parts)) {
+      continue;
+    }
+
+    for (const rawPart of message.parts) {
+      const part = rawPart as {
+        type?: string;
+        toolCallId?: string;
+        state?: string;
+        input?: unknown;
+      };
+      if (
+        !part.type?.startsWith("tool-") ||
+        part.state === "output-available" ||
+        !part.toolCallId
+      ) {
+        continue;
+      }
+
+      summaries.push({
+        message_id: message.id,
+        tool_type: part.type,
+        tool_call_id: part.toolCallId,
+        state: part.state,
+        has_input: part.input != null,
+        has_meaningful_input: hasMeaningfulToolInput(part.input),
+        input_keys:
+          part.input &&
+          typeof part.input === "object" &&
+          !Array.isArray(part.input)
+            ? Object.keys(part.input as Record<string, unknown>).sort()
+            : [],
+      });
+    }
+  }
+
+  return summaries;
+}

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -153,7 +153,18 @@ export async function saveMessage({
     // Fix incomplete tool invocations for assistant messages (from interrupted streams)
     fixedParts =
       message.role === "assistant"
-        ? fixIncompleteMessageParts(message.parts)
+        ? fixIncompleteMessageParts(message.parts, {
+            logContext: {
+              service: "chat-handler",
+              source: "save_message",
+              chatId,
+              userId,
+              messageId: message.id,
+              mode,
+              finishReason,
+              updateOnly,
+            },
+          })
         : message.parts;
     const storageSafeMessage =
       message.role === "assistant"

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -22,6 +22,7 @@ import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { generateTitleFromUserMessageWithWriter } from "@/lib/actions";
 import { createTrackedProvider } from "@/lib/ai/providers";
 import { processChatMessages } from "@/lib/chat/chat-processor";
+import { summarizeIncompleteToolParts } from "@/lib/chat/tool-abort-utils";
 import {
   sendRateLimitWarnings,
   SummarizationTracker,
@@ -1213,6 +1214,27 @@ export const agentLongTask = task({
                             p.toolCallId,
                         ),
                     );
+                    const incompleteToolSummaries = isAborted
+                      ? summarizeIncompleteToolParts(finishedMessages)
+                      : [];
+                    if (incompleteToolSummaries.length > 0) {
+                      console.info(
+                        JSON.stringify({
+                          level: "info",
+                          event:
+                            "agent_long_abort_incomplete_tool_calls_detected",
+                          service: "agent-long",
+                          timestamp: new Date().toISOString(),
+                          chat_id: chatId,
+                          user_id: userId,
+                          mode: "agent",
+                          finish_reason: state.streamFinishReason,
+                          trigger_signal_aborted: triggerSignal.aborted,
+                          incomplete_tool_count: incompleteToolSummaries.length,
+                          incomplete_tools: incompleteToolSummaries,
+                        }),
+                      );
+                    }
                     if (
                       isAborted &&
                       !triggerSignal.aborted &&
@@ -1220,6 +1242,21 @@ export const agentLongTask = task({
                       !hasIncompleteToolCalls &&
                       !resolvedUsage
                     ) {
+                      console.info(
+                        JSON.stringify({
+                          level: "info",
+                          event: "agent_long_abort_message_save_skipped",
+                          service: "agent-long",
+                          timestamp: new Date().toISOString(),
+                          chat_id: chatId,
+                          user_id: userId,
+                          mode: "agent",
+                          finish_reason: state.streamFinishReason,
+                          new_file_count: newFileIds.length,
+                          has_incomplete_tool_calls: hasIncompleteToolCalls,
+                          has_usage_to_record: Boolean(resolvedUsage),
+                        }),
+                      );
                       await deductAccumulatedUsage();
                       return;
                     }


### PR DESCRIPTION
## Summary

Show user-visible tool calls as stopped when a stream is aborted after meaningful tool input has arrived, instead of silently dropping them from the transcript.

## Details

- Convert known renderable incomplete tool parts with meaningful input into `output-error` parts during message cleanup.
- Keep empty or unknown half-started tool calls removed to avoid noisy transcripts and provider resume issues.
- Render stopped states across file, terminal, web, todo, notes, proxy, HTTP, get-terminal-files, and shared-chat views.
- Centralize the stopped-tool marker and detection in `lib/chat/tool-abort-utils.ts`.

## Root Cause

`fixIncompleteMessageParts` removed incomplete tool calls with no output. That was safe for model history, but for partially streamed visible tools, such as a `tool-file` write with a path and brief, the UI lost the action entirely after user abort.

## Validation

- `pnpm jest lib/chat/__tests__/chat-processor.test.ts --runInBand`
- `pnpm typecheck`
- Commit hook: prettier, eslint --fix, `pnpm typecheck`, full `pnpm test` (84 suites, 1083 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * UI now distinguishes user-stopped tool actions ("Stopped…") from generic failures across files, terminal, web, notes, todos, HTTP, proxy and related tools.
  * Incomplete/aborted tool runs with meaningful input are preserved and shown as aborted/error ("Stopped…") instead of being silently removed.

* **Tests**
  * Updated tests to cover aborted-tool preservation and aborted/errored rendering.

* **Chores**
  * Added structured abort logging for improved diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->