### PR TITLE
[codex] Prefer signup for product intent auth

### DIFF
--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -16,6 +16,7 @@ import { useGlobalState } from "../contexts/GlobalState";
 import { usePentestgptMigration } from "../hooks/usePentestgptMigration";
 import { navigateToAuth } from "../hooks/useTauri";
 import { useTypingAnimation } from "../hooks/useTypingAnimation";
+import { upsertDraft } from "@/lib/utils/client-storage";
 
 const LOGIN_TYPING_PREFIX = "Ask HackerAI to ";
 const LOGIN_TYPING_TAILS = [
@@ -27,11 +28,16 @@ const LOGIN_TYPING_TAILS = [
   "hunt for bugs in...",
 ];
 
-// Simple unauthenticated content that redirects to login on message send
+// Simple unauthenticated content that redirects to signup on message send
 const UnauthenticatedContent = () => {
+  const { input } = useGlobalState();
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    navigateToAuth("/login");
+    if (input.trim()) {
+      upsertDraft("new", input);
+    }
+    navigateToAuth("/signup", { preferSignInForReturningUser: true });
   };
 
   const animatedTail = useTypingAnimation({
@@ -50,7 +56,9 @@ const UnauthenticatedContent = () => {
         window.location.hash === "#pricing" ||
         window.location.hash === "#team-pricing-seat-selection"
       ) {
-        navigateToAuth("/login");
+        navigateToAuth("/signup?intent=pricing", {
+          preferSignInForReturningUser: true,
+        });
       }
     };
     checkHash();

--- a/app/api/auth/desktop-callback/route.ts
+++ b/app/api/auth/desktop-callback/route.ts
@@ -140,7 +140,9 @@ export async function GET(request: NextRequest) {
         },
       ));
 
-    const transferToken = await createDesktopTransferToken(sealedSession);
+    const transferToken = await createDesktopTransferToken(sealedSession, {
+      returnPath: stateMetadata?.returnPath,
+    });
 
     if (!transferToken) {
       return new Response(

--- a/app/components/ChatInput/ChatModeSelector.tsx
+++ b/app/components/ChatInput/ChatModeSelector.tsx
@@ -31,7 +31,7 @@ export function ChatModeSelector({ className }: ChatModeSelectorProps) {
 
   const handleAgentModeClick = () => {
     if (!user) {
-      navigateToAuth("/login");
+      navigateToAuth("/signup", { preferSignInForReturningUser: true });
       return;
     }
     if (temporaryChatsEnabled) {

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -61,7 +61,11 @@ const Header: React.FC<HeaderProps> = ({ chatTitle, hideDownload = false }) => {
               </Button>
               <Button
                 data-testid="sign-up-button"
-                onClick={() => navigateToAuth("/signup")}
+                onClick={() =>
+                  navigateToAuth("/signup", {
+                    preferSignInForReturningUser: true,
+                  })
+                }
                 variant="outline"
                 size="default"
                 className="min-w-16 rounded-[10px]"
@@ -94,7 +98,11 @@ const Header: React.FC<HeaderProps> = ({ chatTitle, hideDownload = false }) => {
             </Button>
             <Button
               data-testid="sign-up-button-mobile"
-              onClick={() => navigateToAuth("/signup")}
+              onClick={() =>
+                navigateToAuth("/signup", {
+                  preferSignInForReturningUser: true,
+                })
+              }
               variant="outline"
               size="sm"
               className="rounded-[10px]"

--- a/app/components/PricingDialog.tsx
+++ b/app/components/PricingDialog.tsx
@@ -265,7 +265,9 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
 
   const handleTeamClick = () => {
     if (!user) {
-      navigateToAuth("/login");
+      navigateToAuth("/signup?intent=pricing", {
+        preferSignInForReturningUser: true,
+      });
       return;
     }
 
@@ -294,7 +296,10 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
         disabled: false,
         className: "",
         variant: "secondary" as const,
-        onClick: () => navigateToAuth("/signup"),
+        onClick: () =>
+          navigateToAuth("/signup", {
+            preferSignInForReturningUser: true,
+          }),
       };
     } else {
       return {
@@ -343,7 +348,10 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
         disabled: false,
         className: "",
         variant: "default" as const,
-        onClick: () => navigateToAuth("/login"),
+        onClick: () =>
+          navigateToAuth("/signup?intent=pricing", {
+            preferSignInForReturningUser: true,
+          }),
       };
     }
   };
@@ -379,7 +387,10 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
         disabled: false,
         className: "font-semibold bg-[#615eeb] hover:bg-[#504bb8] text-white",
         variant: "default" as const,
-        onClick: () => navigateToAuth("/login"),
+        onClick: () =>
+          navigateToAuth("/signup?intent=pricing", {
+            preferSignInForReturningUser: true,
+          }),
       };
     }
   };
@@ -416,7 +427,10 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
         disabled: false,
         className: "font-semibold bg-[#615eeb] hover:bg-[#504bb8] text-white",
         variant: "default" as const,
-        onClick: () => navigateToAuth("/login"),
+        onClick: () =>
+          navigateToAuth("/signup?intent=pricing", {
+            preferSignInForReturningUser: true,
+          }),
       };
     }
   };

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -45,6 +45,7 @@ import {
   readSelectedModel,
   writeSelectedModel,
   cleanupExpiredDrafts,
+  markHasAuthenticatedBefore,
 } from "@/lib/utils/client-storage";
 
 interface GlobalStateType {
@@ -188,6 +189,12 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   useEffect(() => {
     writeChatMode(chatMode);
   }, [chatMode]);
+
+  useEffect(() => {
+    if (user) {
+      markHasAuthenticatedBefore();
+    }
+  }, [user]);
 
   // Initialize chat sidebar state
   const [chatSidebarOpen, setChatSidebarOpen] = useState(() =>

--- a/app/desktop-callback/route.ts
+++ b/app/desktop-callback/route.ts
@@ -21,6 +21,15 @@ function escapeHtml(str: string): string {
     .replace(/'/g, "&#039;");
 }
 
+function isValidLocalPath(path: string | undefined): path is string {
+  return (
+    typeof path === "string" &&
+    path.startsWith("/") &&
+    !path.startsWith("//") &&
+    !path.startsWith("/\\")
+  );
+}
+
 function renderErrorPage(
   title: string,
   message: string,
@@ -146,7 +155,10 @@ export async function GET(request: Request) {
     );
   }
 
-  const response = NextResponse.redirect(new URL("/", request.url));
+  const redirectPath = isValidLocalPath(sessionData.returnPath)
+    ? sessionData.returnPath
+    : "/";
+  const response = NextResponse.redirect(new URL(redirectPath, request.url));
 
   response.cookies.set("wos-session", sessionData.sealedSession, {
     httpOnly: true,

--- a/app/desktop-login/route.ts
+++ b/app/desktop-login/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createOAuthState } from "@/lib/desktop-auth";
 import { workos } from "@/app/api/workos";
+import { getAuthRedirectPath } from "@/lib/auth/auth-redirect-intents";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -18,13 +19,20 @@ export async function GET(request: Request) {
 
     // Pass dev callback port through OAuth state for dev mode auth
     const devCallbackPort = url.searchParams.get("dev_callback_port");
+    const screenHint =
+      url.searchParams.get("screen_hint") === "sign-up" ? "sign-up" : "sign-in";
+    const returnPath = getAuthRedirectPath(url) ?? undefined;
     const portNum = devCallbackPort ? parseInt(devCallbackPort, 10) : NaN;
-    const metadata =
-      !isNaN(portNum) && portNum > 0 && portNum <= 65535
+    const metadata = {
+      ...(!isNaN(portNum) && portNum > 0 && portNum <= 65535
         ? { devCallbackPort: portNum }
-        : undefined;
+        : {}),
+      ...(returnPath ? { returnPath } : {}),
+    };
 
-    const state = await createOAuthState(metadata);
+    const state = await createOAuthState(
+      Object.keys(metadata).length > 0 ? metadata : undefined,
+    );
     if (!state) {
       console.error("[Desktop Login] Failed to create OAuth state");
       return NextResponse.redirect(
@@ -37,6 +45,7 @@ export async function GET(request: Request) {
       clientId: process.env.WORKOS_CLIENT_ID,
       redirectUri: desktopCallbackUrl,
       state,
+      screenHint,
     });
 
     return NextResponse.redirect(authorizationUrl);

--- a/app/hooks/useTauri.ts
+++ b/app/hooks/useTauri.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { toast } from "sonner";
+import { hasAuthenticatedBefore } from "@/lib/utils/client-storage";
 
 declare global {
   interface Window {
@@ -38,12 +39,48 @@ export async function openInBrowser(url: string): Promise<boolean> {
   }
 }
 
+type AuthFallbackPath =
+  | "/login"
+  | "/signup"
+  | `/login?${string}`
+  | `/signup?${string}`;
+
+type NavigateToAuthOptions = {
+  preferSignInForReturningUser?: boolean;
+};
+
+function resolveAuthPath(
+  fallbackPath: AuthFallbackPath,
+  options?: NavigateToAuthOptions,
+): AuthFallbackPath {
+  if (!options?.preferSignInForReturningUser || !hasAuthenticatedBefore()) {
+    return fallbackPath;
+  }
+
+  const authUrl = new URL(fallbackPath, window.location.origin);
+  if (authUrl.pathname !== "/signup") {
+    return fallbackPath;
+  }
+
+  authUrl.pathname = "/login";
+  return `${authUrl.pathname}${authUrl.search}` as AuthFallbackPath;
+}
+
 export async function navigateToAuth(
-  fallbackPath: "/login" | "/signup",
+  fallbackPath: AuthFallbackPath,
+  options?: NavigateToAuthOptions,
 ): Promise<void> {
+  const resolvedPath = resolveAuthPath(fallbackPath, options);
+
   if (detectTauri()) {
     try {
       let loginUrl = `${window.location.origin}/desktop-login`;
+      const fallbackUrl = new URL(resolvedPath, window.location.origin);
+      const authSearchParams = new URLSearchParams(fallbackUrl.search);
+
+      if (fallbackUrl.pathname === "/signup") {
+        authSearchParams.set("screen_hint", "sign-up");
+      }
 
       // In dev mode, pass the local auth callback port so the server
       // redirects to localhost instead of the hackerai:// deep link
@@ -51,10 +88,15 @@ export async function navigateToAuth(
         const { invoke } = await import("@tauri-apps/api/core");
         const port = await invoke<number>("get_dev_auth_port");
         if (port > 0) {
-          loginUrl += `?dev_callback_port=${port}`;
+          authSearchParams.set("dev_callback_port", String(port));
         }
       } catch {
         // Not in dev mode or command not available
+      }
+
+      const query = authSearchParams.toString();
+      if (query) {
+        loginUrl += `?${query}`;
       }
 
       const opened = await openInBrowser(loginUrl);
@@ -63,7 +105,7 @@ export async function navigateToAuth(
       // Fall through to web navigation
     }
   }
-  window.location.href = fallbackPath;
+  window.location.href = resolvedPath;
 }
 
 /**

--- a/app/login/route.ts
+++ b/app/login/route.ts
@@ -1,36 +1,8 @@
-import { NextResponse } from "next/server";
 import { getSignInUrl } from "@workos-inc/authkit-nextjs";
-
-const ALLOWED_INTENTS: Record<string, string> = {
-  pricing: "/#pricing",
-  "migrate-pentestgpt": "/?confirm-migrate-pentestgpt=true",
-};
+import { redirectToAuthorizationUrl } from "@/lib/auth/auth-redirect-intents";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
-  const intent = url.searchParams.get("intent");
-  const confirmMigrate = url.searchParams.get("confirm-migrate-pentestgpt");
-
   const authorizationUrl = await getSignInUrl();
-  const response = NextResponse.redirect(authorizationUrl);
-
-  let redirectPath = null;
-
-  if (intent && ALLOWED_INTENTS[intent]) {
-    redirectPath = ALLOWED_INTENTS[intent];
-  } else if (confirmMigrate === "true") {
-    redirectPath = ALLOWED_INTENTS["migrate-pentestgpt"];
-  }
-
-  if (redirectPath) {
-    response.cookies.set("post_login_redirect", redirectPath, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      maxAge: 600,
-      path: "/",
-    });
-  }
-
-  return response;
+  return redirectToAuthorizationUrl(authorizationUrl, url);
 }

--- a/app/signup/route.ts
+++ b/app/signup/route.ts
@@ -1,7 +1,8 @@
-import { redirect } from "next/navigation";
 import { getSignUpUrl } from "@workos-inc/authkit-nextjs";
+import { redirectToAuthorizationUrl } from "@/lib/auth/auth-redirect-intents";
 
-export async function GET() {
+export async function GET(request: Request) {
+  const url = new URL(request.url);
   const authorizationUrl = await getSignUpUrl();
-  return redirect(authorizationUrl);
+  return redirectToAuthorizationUrl(authorizationUrl, url);
 }

--- a/lib/__tests__/desktop-auth.test.ts
+++ b/lib/__tests__/desktop-auth.test.ts
@@ -68,6 +68,20 @@ describe("createDesktopTransferToken", () => {
     );
   });
 
+  it("stores the optional return path with the transfer token", async () => {
+    await createDesktopTransferToken("sealed-session-data", {
+      returnPath: "/#pricing",
+    });
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      expect.stringContaining("desktop-auth-transfer:"),
+      expect.objectContaining({
+        sealedSession: "sealed-session-data",
+        returnPath: "/#pricing",
+      }),
+      { ex: 300 },
+    );
+  });
+
   it("generates unique tokens", async () => {
     const token1 = await createDesktopTransferToken("session1");
     const token2 = await createDesktopTransferToken("session2");
@@ -82,6 +96,19 @@ describe("exchangeDesktopTransferToken", () => {
 
     const result = await exchangeDesktopTransferToken(token!);
     expect(result).toEqual({ sealedSession: "my-sealed-session" });
+  });
+
+  it("returns the preserved return path for valid token", async () => {
+    const token = await createDesktopTransferToken("my-sealed-session", {
+      returnPath: "/#pricing",
+    });
+    expect(token).not.toBeNull();
+
+    const result = await exchangeDesktopTransferToken(token!);
+    expect(result).toEqual({
+      sealedSession: "my-sealed-session",
+      returnPath: "/#pricing",
+    });
   });
 
   it("returns null for invalid token format", async () => {
@@ -135,10 +162,10 @@ describe("createOAuthState", () => {
   });
 
   it("stores state with metadata as JSON", async () => {
-    await createOAuthState({ devCallbackPort: 3456 });
+    await createOAuthState({ devCallbackPort: 3456, returnPath: "/#pricing" });
     expect(mockRedis.set).toHaveBeenCalledWith(
       expect.stringContaining("desktop-oauth-state:"),
-      JSON.stringify({ devCallbackPort: 3456 }),
+      JSON.stringify({ devCallbackPort: 3456, returnPath: "/#pricing" }),
       { ex: 300 },
     );
   });
@@ -154,12 +181,18 @@ describe("verifyAndConsumeOAuthState", () => {
   });
 
   it("returns valid with metadata for a stored state", async () => {
-    const state = await createOAuthState({ devCallbackPort: 9999 });
+    const state = await createOAuthState({
+      devCallbackPort: 9999,
+      returnPath: "/#pricing",
+    });
     expect(state).not.toBeNull();
 
     const result = await verifyAndConsumeOAuthState(state!);
     expect(result.valid).toBe(true);
-    expect(result.metadata).toEqual({ devCallbackPort: 9999 });
+    expect(result.metadata).toEqual({
+      devCallbackPort: 9999,
+      returnPath: "/#pricing",
+    });
   });
 
   it("returns invalid for non-existent state", async () => {

--- a/lib/auth/auth-redirect-intents.ts
+++ b/lib/auth/auth-redirect-intents.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+export const AUTH_REDIRECT_INTENTS: Record<string, string> = {
+  pricing: "/#pricing",
+  "migrate-pentestgpt": "/?confirm-migrate-pentestgpt=true",
+};
+
+export function getAuthRedirectPath(url: URL): string | null {
+  const intent = url.searchParams.get("intent");
+  const confirmMigrate = url.searchParams.get("confirm-migrate-pentestgpt");
+
+  if (intent && AUTH_REDIRECT_INTENTS[intent]) {
+    return AUTH_REDIRECT_INTENTS[intent];
+  }
+
+  if (confirmMigrate === "true") {
+    return AUTH_REDIRECT_INTENTS["migrate-pentestgpt"];
+  }
+
+  return null;
+}
+
+export function redirectToAuthorizationUrl(
+  authorizationUrl: string,
+  requestUrl: URL,
+): NextResponse {
+  const response = NextResponse.redirect(authorizationUrl);
+  const redirectPath = getAuthRedirectPath(requestUrl);
+
+  if (redirectPath) {
+    response.cookies.set("post_login_redirect", redirectPath, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 600,
+      path: "/",
+    });
+  }
+
+  return response;
+}

--- a/lib/desktop-auth.ts
+++ b/lib/desktop-auth.ts
@@ -9,6 +9,7 @@ const TOKEN_FORMAT_REGEX = /^[a-f0-9]{64}$/;
 type TransferTokenData = {
   sealedSession: string;
   createdAt: number;
+  returnPath?: string;
 };
 
 function getRedis(): Redis | null {
@@ -35,6 +36,7 @@ function generateTransferToken(): string {
 
 export async function createDesktopTransferToken(
   sealedSession: string,
+  options?: { returnPath?: string },
 ): Promise<string | null> {
   const redis = getRedis();
   if (!redis) {
@@ -51,6 +53,9 @@ export async function createDesktopTransferToken(
     sealedSession,
     createdAt: Date.now(),
   };
+  if (options?.returnPath) {
+    data.returnPath = options.returnPath;
+  }
 
   try {
     await redis.set(key, data, { ex: TRANSFER_TOKEN_TTL_SECONDS });
@@ -67,7 +72,10 @@ export async function createDesktopTransferToken(
 
 export async function exchangeDesktopTransferToken(
   transferToken: string,
-): Promise<{ sealedSession: string } | null> {
+): Promise<{
+  sealedSession: string;
+  returnPath?: string;
+} | null> {
   if (!TOKEN_FORMAT_REGEX.test(transferToken)) {
     console.warn("[Desktop Auth] Invalid transfer token format");
     return null;
@@ -122,11 +130,18 @@ export async function exchangeDesktopTransferToken(
     return null;
   }
 
-  return { sealedSession: data.sealedSession };
+  const result: { sealedSession: string; returnPath?: string } = {
+    sealedSession: data.sealedSession,
+  };
+  if (typeof data.returnPath === "string") {
+    result.returnPath = data.returnPath;
+  }
+  return result;
 }
 
 export type OAuthStateMetadata = {
   devCallbackPort?: number;
+  returnPath?: string;
 };
 
 export async function createOAuthState(

--- a/lib/utils/__tests__/client-storage.test.ts
+++ b/lib/utils/__tests__/client-storage.test.ts
@@ -3,6 +3,8 @@ import {
   readSelectedModel,
   writeSelectedModel,
   clearSelectedModelFromStorage,
+  hasAuthenticatedBefore,
+  markHasAuthenticatedBefore,
 } from "../client-storage";
 
 const STORAGE_KEY = "selected_model";
@@ -130,5 +132,20 @@ describe("client-storage selected model", () => {
       expect(window.localStorage.getItem(LEGACY_ASK_KEY)).toBeNull();
       expect(window.localStorage.getItem(LEGACY_AGENT_KEY)).toBeNull();
     });
+  });
+});
+
+describe("client-storage auth marker", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns false before the browser has authenticated", () => {
+    expect(hasAuthenticatedBefore()).toBe(false);
+  });
+
+  it("persists that this browser has authenticated before", () => {
+    markHasAuthenticatedBefore();
+    expect(hasAuthenticatedBefore()).toBe(true);
   });
 });

--- a/lib/utils/client-storage.ts
+++ b/lib/utils/client-storage.ts
@@ -19,6 +19,7 @@ export type ConversationDraftStore = {
 export const CONVERSATION_DRAFTS_STORAGE_KEY = "conversation_drafts";
 export const NULL_THREAD_DRAFT_ID = "null_thread";
 export const CHAT_MODE_STORAGE_KEY = "chat_mode";
+const HAS_AUTHENTICATED_BEFORE_STORAGE_KEY = "hackerai_has_authed_before";
 const SELECTED_MODEL_STORAGE_KEY = "selected_model";
 
 const isBrowser = (): boolean => typeof window !== "undefined";
@@ -66,6 +67,27 @@ export const writeChatMode = (mode: ChatMode): void => {
     window.localStorage.setItem(CHAT_MODE_STORAGE_KEY, mode);
   } catch {
     // ignore
+  }
+};
+
+export const markHasAuthenticatedBefore = (): void => {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(HAS_AUTHENTICATED_BEFORE_STORAGE_KEY, "true");
+  } catch {
+    // ignore
+  }
+};
+
+export const hasAuthenticatedBefore = (): boolean => {
+  if (!isBrowser()) return false;
+  try {
+    return (
+      window.localStorage.getItem(HAS_AUTHENTICATED_BEFORE_STORAGE_KEY) ===
+      "true"
+    );
+  } catch {
+    return false;
   }
 };
 


### PR DESCRIPTION
## Summary

- Route product-intent unauthenticated flows through WorkOS sign-up instead of sign-in for first-time browsers.
- Remember when a browser has authenticated before, then use sign-in for returning-user product-intent flows after logout.
- Preserve typed public prompts before auth by saving the new-chat draft synchronously.
- Share post-auth redirect intent handling between /login and /signup, including pricing return paths.
- Pass the sign-up screen hint through desktop auth when requested.
- Preserve desktop/Tauri auth return intent through OAuth state and the desktop transfer token so pricing CTAs can return to pricing after auth.

## Validation

- pnpm typecheck
- pnpm lint (passes with existing warnings)
- pnpm test -- lib/utils/__tests__/client-storage.test.ts
- pnpm test -- lib/__tests__/desktop-auth.test.ts
- git diff --check

Note: a later full pre-commit Jest run hit an unrelated timeout in lib/ai/tools/__tests__/interact-terminal-session.test.ts; the targeted auth/storage checks above passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat drafts now auto-save for unauthenticated users when submitting input.
  * The app records whether a user has previously authenticated.

* **Improvements**
  * Unauthenticated flows now redirect to signup (with pricing intent when applicable) across chat, agent mode, pricing, and header actions.
  * Desktop auth/navigation better preserves desired post-auth return paths and sign-in/sign-up preferences.

* **Tests**
  * Added tests for the authentication-history marker.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->