### PR TITLE
[codex] track agent runs by sandbox type

### DIFF
--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -15,7 +15,7 @@ describe("captureToolCalls", () => {
         { name: "run_terminal_cmd", sandbox_type: "e2b" },
         { name: "run_terminal_cmd", sandbox_type: "e2b" },
         { name: "open_url" },
-        { name: "run_terminal_cmd", sandbox_type: "local" },
+        { name: "run_terminal_cmd", sandbox_type: "remote-connection" },
       ],
     };
 
@@ -35,7 +35,6 @@ describe("captureToolCalls", () => {
         toolName: "run_terminal_cmd",
         count: 3,
         toolCallCount: 3,
-        legacyEventName: "hackerai-run_terminal_cmd",
       },
     });
     expect(capture).toHaveBeenCalledWith({
@@ -46,7 +45,6 @@ describe("captureToolCalls", () => {
         toolName: "open_url",
         count: 1,
         toolCallCount: 1,
-        legacyEventName: "hackerai-open_url",
       },
     });
   });

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -4,10 +4,10 @@ import { describe, expect, it, jest } from "@jest/globals";
 (globalThis as any).Response = class Response {};
 (globalThis as any).Headers = class Headers {};
 
-const { captureToolCalls } = require("../chat-logger");
+const { captureAgentRun, captureToolCalls } = require("../chat-logger");
 
 describe("captureToolCalls", () => {
-  it("aggregates repeated tool calls before sending PostHog events", () => {
+  it("aggregates repeated tool calls by tool before sending PostHog events", () => {
     const capture = jest.fn();
     const posthog = { capture };
     const chatLogger = {
@@ -26,17 +26,16 @@ describe("captureToolCalls", () => {
       mode: "agent",
     });
 
-    expect(capture).toHaveBeenCalledTimes(3);
+    expect(capture).toHaveBeenCalledTimes(2);
     expect(capture).toHaveBeenCalledWith({
       distinctId: "user_123",
       event: "hackerai-tool_usage",
       properties: {
         mode: "agent",
         toolName: "run_terminal_cmd",
-        count: 2,
-        toolCallCount: 2,
+        count: 3,
+        toolCallCount: 3,
         legacyEventName: "hackerai-run_terminal_cmd",
-        sandboxType: "e2b",
       },
     });
     expect(capture).toHaveBeenCalledWith({
@@ -50,18 +49,6 @@ describe("captureToolCalls", () => {
         legacyEventName: "hackerai-open_url",
       },
     });
-    expect(capture).toHaveBeenCalledWith({
-      distinctId: "user_123",
-      event: "hackerai-tool_usage",
-      properties: {
-        mode: "agent",
-        toolName: "run_terminal_cmd",
-        count: 1,
-        toolCallCount: 1,
-        legacyEventName: "hackerai-run_terminal_cmd",
-        sandboxType: "local",
-      },
-    });
   });
 
   it("does nothing when there are no recorded tool calls", () => {
@@ -72,6 +59,47 @@ describe("captureToolCalls", () => {
       chatLogger: { getToolCalls: () => [] } as any,
       userId: "user_123",
       mode: "agent",
+    });
+
+    expect(capture).not.toHaveBeenCalled();
+  });
+});
+
+describe("captureAgentRun", () => {
+  it("captures one sanitized agent run event with sandbox type", () => {
+    const capture = jest.fn();
+
+    captureAgentRun({
+      posthog: { capture } as any,
+      userId: "user_123",
+      mode: "agent",
+      subscription: "pro",
+      sandboxInfo: { type: "remote-connection", name: "Work laptop" },
+      outcome: "success",
+    });
+
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      event: "hackerai-agent_run",
+      properties: {
+        mode: "agent",
+        subscription: "pro",
+        outcome: "success",
+        sandboxType: "remote-connection",
+      },
+    });
+  });
+
+  it("does not capture agent run events for ask mode", () => {
+    const capture = jest.fn();
+
+    captureAgentRun({
+      posthog: { capture } as any,
+      userId: "user_123",
+      mode: "ask",
+      subscription: "pro",
+      sandboxInfo: { type: "e2b" },
+      outcome: "success",
     });
 
     expect(capture).not.toHaveBeenCalled();

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -37,6 +37,7 @@ import { countTokens } from "gpt-tokenizer";
 import { ChatSDKError } from "@/lib/errors";
 import PostHogClient from "@/app/posthog";
 import {
+  captureAgentRun,
   captureToolCalls,
   createChatLogger,
   shutdownPostHog,
@@ -795,9 +796,8 @@ export const createChatHandler = (
                             subscriberStopped = true;
                           }
 
-                          chatLogger!.setSandbox(
-                            sandboxManager.getSandboxInfo(),
-                          );
+                          const sandboxInfo = sandboxManager.getSandboxInfo();
+                          chatLogger!.setSandbox(sandboxInfo);
                           // Use fallback-only cache tokens (subtract pre-fallback snapshot)
                           // so the wide event isn't mixing cumulative cache with retry-only usage
                           const fallbackCacheRead =
@@ -820,6 +820,14 @@ export const createChatHandler = (
                             chatLogger,
                             userId,
                             mode,
+                          });
+                          captureAgentRun({
+                            posthog,
+                            userId,
+                            mode,
+                            subscription,
+                            sandboxInfo,
+                            outcome: retryAborted ? "aborted" : "success",
                           });
                           shutdownPostHog(posthog);
                           chatLogger!.emitSuccess({
@@ -999,13 +1007,22 @@ export const createChatHandler = (
 
                 // Emit wide event
                 stepStart = Date.now();
-                chatLogger!.setSandbox(sandboxManager.getSandboxInfo());
+                const sandboxInfo = sandboxManager.getSandboxInfo();
+                chatLogger!.setSandbox(sandboxInfo);
                 chatLogger!.setCacheMetrics({
                   cacheHitRate: usageTracker.cacheHitRate,
                   cacheReadTokens: usageTracker.cacheReadTokens,
                   cacheWriteTokens: usageTracker.cacheWriteTokens,
                 });
                 captureToolCalls({ posthog, chatLogger, userId, mode });
+                captureAgentRun({
+                  posthog,
+                  userId,
+                  mode,
+                  subscription,
+                  sandboxInfo,
+                  outcome: isAborted ? "aborted" : "success",
+                });
                 shutdownPostHog(posthog);
                 chatLogger!.emitSuccess({
                   finishReason: state.streamFinishReason,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -15,6 +15,7 @@ import type {
   CaidoReadyInfo,
   ChatMode,
   ExtraUsageConfig,
+  SandboxInfo,
   SandboxBootInfo,
 } from "@/types";
 import type { ChatSDKError } from "@/lib/errors";
@@ -425,7 +426,7 @@ export type ChatLogger = ReturnType<typeof createChatLogger>;
 
 /**
  * Capture aggregated tool usage to PostHog at end of request.
- * One event is emitted per tool/sandbox bucket to keep analytics useful while
+ * One event is emitted per tool to keep analytics useful while
  * avoiding the cost of one PostHog event per individual tool call.
  */
 export function captureToolCalls({
@@ -445,17 +446,16 @@ export function captureToolCalls({
 
   const aggregatedToolCalls = new Map<
     string,
-    { name: string; sandbox_type?: string; count: number }
+    { name: string; count: number }
   >();
 
   for (const tool of toolCalls) {
-    const key = `${tool.name}:${tool.sandbox_type ?? ""}`;
-    const existing = aggregatedToolCalls.get(key);
+    const existing = aggregatedToolCalls.get(tool.name);
     if (existing) {
       existing.count += 1;
       continue;
     }
-    aggregatedToolCalls.set(key, { ...tool, count: 1 });
+    aggregatedToolCalls.set(tool.name, { name: tool.name, count: 1 });
   }
 
   for (const tool of aggregatedToolCalls.values()) {
@@ -468,10 +468,37 @@ export function captureToolCalls({
         count: tool.count,
         toolCallCount: tool.count,
         legacyEventName: "hackerai-" + tool.name,
-        ...(tool.sandbox_type && { sandboxType: tool.sandbox_type }),
       },
     });
   }
+}
+
+export function captureAgentRun({
+  posthog,
+  userId,
+  mode,
+  subscription,
+  sandboxInfo,
+  outcome,
+}: {
+  posthog: PostHog | null;
+  userId: string;
+  mode: ChatMode;
+  subscription: string;
+  sandboxInfo: SandboxInfo | null;
+  outcome: "success" | "aborted" | "error";
+}) {
+  if (!posthog || mode !== "agent") return;
+  posthog.capture({
+    distinctId: userId,
+    event: "hackerai-agent_run",
+    properties: {
+      mode,
+      subscription,
+      outcome,
+      ...(sandboxInfo?.type && { sandboxType: sandboxInfo.type }),
+    },
+  });
 }
 
 export function shutdownPostHog(posthog: PostHog | null) {

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -467,7 +467,6 @@ export function captureToolCalls({
         toolName: tool.name,
         count: tool.count,
         toolCallCount: tool.count,
-        legacyEventName: "hackerai-" + tool.name,
       },
     });
   }

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -67,6 +67,7 @@ import {
   getUploadBasePath,
 } from "@/lib/utils/sandbox-file-utils";
 import {
+  captureAgentRun,
   captureToolCalls,
   createChatLogger,
   type ChatLogger,
@@ -1033,9 +1034,8 @@ export const agentLongTask = task({
                               preFallbackCacheWrite;
                             const fallbackCacheTotal =
                               fallbackCacheRead + fallbackCacheWrite;
-                            chatLogger?.setSandbox(
-                              sandboxManager.getSandboxInfo(),
-                            );
+                            const sandboxInfo = sandboxManager.getSandboxInfo();
+                            chatLogger?.setSandbox(sandboxInfo);
                             chatLogger?.setCacheMetrics({
                               cacheHitRate:
                                 fallbackCacheTotal > 0
@@ -1049,6 +1049,14 @@ export const agentLongTask = task({
                               chatLogger,
                               userId,
                               mode,
+                            });
+                            captureAgentRun({
+                              posthog,
+                              userId,
+                              mode,
+                              subscription,
+                              sandboxInfo,
+                              outcome: retryAborted ? "aborted" : "success",
                             });
                             posthog?.shutdown();
                             chatLogger?.emitSuccess({
@@ -1140,13 +1148,22 @@ export const agentLongTask = task({
                     state.streamFinishReason = undefined;
                   }
 
-                  chatLogger?.setSandbox(sandboxManager.getSandboxInfo());
+                  const sandboxInfo = sandboxManager.getSandboxInfo();
+                  chatLogger?.setSandbox(sandboxInfo);
                   chatLogger?.setCacheMetrics({
                     cacheHitRate: usageTracker.cacheHitRate,
                     cacheReadTokens: usageTracker.cacheReadTokens,
                     cacheWriteTokens: usageTracker.cacheWriteTokens,
                   });
                   captureToolCalls({ posthog, chatLogger, userId, mode });
+                  captureAgentRun({
+                    posthog,
+                    userId,
+                    mode,
+                    subscription,
+                    sandboxInfo,
+                    outcome: isAborted ? "aborted" : "success",
+                  });
                   posthog?.shutdown();
                   chatLogger?.emitSuccess({
                     finishReason: state.streamFinishReason,


### PR DESCRIPTION
## Summary

Adds a low-volume `hackerai-agent_run` PostHog event emitted once per completed or aborted agent response. The event includes sanitized `sandboxType`, `subscription`, and `outcome`, so we can chart unique Agent users by cloud, desktop, or remote connection without relying on terminal/tool telemetry.

Also removes the `legacyEventName` property from the already-merged `hackerai-tool_usage` event so that event stays focused on `toolName`, `count`, and `toolCallCount`.

## Why

The tool usage chart answers tool volume questions. Agent environment adoption should be measured at the run level, otherwise users who do not trigger sandbox-backed tools are missed and heavy tool users can distort the picture.

## Validation

- `pnpm jest lib/api/__tests__/chat-logger.test.ts --runInBand`
- `pnpm eslint lib/api/chat-logger.ts lib/api/chat-handler.ts trigger/agent-long.ts lib/api/__tests__/chat-logger.test.ts`
- `pnpm typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added agent run analytics event tracking to capture mode, outcome, and subscription metrics.

* **Tests**
  * Expanded test coverage for agent run capture scenarios.
  * Updated event aggregation tests to reflect new behavior.

* **Chores**
  * Improved event aggregation for analytics tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->