### PR TITLE
[codex] add PostHog usage cost analytics

### DIFF
--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -2,8 +2,19 @@ import { stripe } from "../stripe";
 import { workos } from "../workos";
 import { getUserID } from "@/lib/auth/get-user-id";
 import { buildWorkOSOrganizationName } from "@/lib/auth/workos-organization-name";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { getSuspensionMessage } from "@/lib/suspensionMessage";
+import { phLogger } from "@/lib/posthog/server";
+
+function planLookupKeyToTier(
+  lookupKey: string,
+): "pro" | "pro-plus" | "ultra" | "team" | null {
+  if (lookupKey.startsWith("ultra")) return "ultra";
+  if (lookupKey.startsWith("pro-plus")) return "pro-plus";
+  if (lookupKey.startsWith("team")) return "team";
+  if (lookupKey.startsWith("pro")) return "pro";
+  return null;
+}
 
 export const POST = async (req: NextRequest) => {
   try {
@@ -185,6 +196,18 @@ export const POST = async (req: NextRequest) => {
       mode: "subscription",
       success_url: successUrl.toString(),
       cancel_url: cancelUrl.toString(),
+      metadata: {
+        userId,
+        workOSOrganizationId: organization.id,
+        requestedPlan: subscriptionLevel,
+      },
+      subscription_data: {
+        metadata: {
+          userId,
+          workOSOrganizationId: organization.id,
+          requestedPlan: subscriptionLevel,
+        },
+      },
       custom_text: {
         submit: {
           message:
@@ -192,6 +215,30 @@ export const POST = async (req: NextRequest) => {
         },
       },
     });
+
+    const selectedPrice = price.data[0];
+    phLogger.event("checkout_started", {
+      userId,
+      org_id: organization.id,
+      from_tier: "free",
+      to_tier: planLookupKeyToTier(subscriptionLevel),
+      plan: subscriptionLevel,
+      billing_interval: selectedPrice.recurring?.interval,
+      billing_interval_count: selectedPrice.recurring?.interval_count,
+      quantity,
+      checkout_amount_dollars:
+        selectedPrice.unit_amount != null
+          ? (selectedPrice.unit_amount * quantity) / 100
+          : undefined,
+      currency: selectedPrice.currency,
+      stripe_customer_id: customer.id,
+      stripe_checkout_session_id: session.id,
+      stripe_price_id: selectedPrice.id,
+      $set: {
+        last_checkout_started_at: new Date().toISOString(),
+      },
+    });
+    after(() => phLogger.flush());
 
     return NextResponse.json({ url: session.url });
   } catch (error: unknown) {

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -36,6 +36,15 @@ function tierDirection(
   return "lateral";
 }
 
+const centsToDollars = (amount: number | null | undefined): number =>
+  (amount ?? 0) / 100;
+
+function priceBillingInterval(
+  price: Stripe.Price | undefined,
+): "day" | "week" | "month" | "year" | undefined {
+  return price?.recurring?.interval ?? undefined;
+}
+
 const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
 // =============================================================================
@@ -226,6 +235,47 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
     `[Subscription Webhook] invoice.paid (${billingReason ?? "unknown"}): resetting ${tier} buckets for ${userIds.length} user(s)`,
   );
   await Promise.all(userIds.map((uid) => resetRateLimitBuckets(uid, tier)));
+
+  if (billingReason === "subscription_create") {
+    const item = subscription.items?.data[0];
+    const price = item?.price;
+    const invoiceAmountPaidDollars = centsToDollars(
+      (invoice as { amount_paid?: number }).amount_paid,
+    );
+    const attributedRevenueDollars =
+      userIds.length > 0 ? invoiceAmountPaidDollars / userIds.length : 0;
+
+    for (const uid of userIds) {
+      phLogger.event("subscription_started", {
+        userId: uid,
+        from_tier: "free",
+        to_tier: tier,
+        conversion_type: "free_to_paid",
+        org_id: orgId,
+        user_count: userIds.length,
+        plan: price?.lookup_key,
+        billing_interval: priceBillingInterval(price),
+        billing_interval_count: price?.recurring?.interval_count,
+        quantity: item?.quantity,
+        invoice_amount_paid_dollars: invoiceAmountPaidDollars,
+        attributed_revenue_dollars: attributedRevenueDollars,
+        revenue_dollars: attributedRevenueDollars,
+        currency: invoice.currency,
+        stripe_customer_id: customerId,
+        stripe_subscription_id: subscription.id,
+        stripe_invoice_id: invoice.id,
+        stripe_price_id: price?.id,
+        $set: {
+          subscription_tier: tier,
+          last_subscription_started_at: new Date().toISOString(),
+        },
+        $set_once: {
+          first_subscription_started_at: new Date().toISOString(),
+          first_paid_tier: tier,
+        },
+      });
+    }
+  }
 
   // Clear team seat rotation debt on renewal (fresh cycle)
   if (tier === "team" && orgId) {

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -4,7 +4,11 @@ import { describe, expect, it, jest } from "@jest/globals";
 (globalThis as any).Response = class Response {};
 (globalThis as any).Headers = class Headers {};
 
-const { captureAgentRun, captureToolCalls } = require("../chat-logger");
+const {
+  captureAgentRun,
+  captureToolCalls,
+  captureUsageCost,
+} = require("../chat-logger");
 
 describe("captureToolCalls", () => {
   it("aggregates repeated tool calls by tool before sending PostHog events", () => {
@@ -101,5 +105,63 @@ describe("captureAgentRun", () => {
     });
 
     expect(capture).not.toHaveBeenCalled();
+  });
+});
+
+describe("captureUsageCost", () => {
+  it("captures a user-scoped cost event with queryable dollar fields", () => {
+    const capture = jest.fn();
+
+    captureUsageCost({
+      posthog: { capture } as any,
+      userId: "user_123",
+      subscription: "pro",
+      organizationId: "org_123",
+      chatId: "chat_123",
+      endpoint: "/api/chat",
+      mode: "agent",
+      usage: {
+        model: "claude-sonnet",
+        type: "extra",
+        inputTokens: 1000,
+        outputTokens: 500,
+        totalTokens: 1500,
+        cacheReadTokens: 200,
+        cacheWriteTokens: undefined,
+        costDollars: 0.42,
+        modelCostDollars: 0.3,
+        nonModelCostDollars: 0.12,
+        costSource: "provider",
+      },
+    });
+
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      event: "hackerai-usage_cost",
+      properties: expect.objectContaining({
+        user_id: "user_123",
+        subscription: "pro",
+        subscription_tier: "pro",
+        organization_id: "org_123",
+        chat_id: "chat_123",
+        endpoint: "/api/chat",
+        mode: "agent",
+        model: "claude-sonnet",
+        usage_type: "extra",
+        cost_dollars: 0.42,
+        model_cost_dollars: 0.3,
+        non_model_cost_dollars: 0.12,
+        input_tokens: 1000,
+        output_tokens: 500,
+        total_tokens: 1500,
+        cache_read_tokens: 200,
+        cache_write_tokens: 0,
+        cost_source: "provider",
+        $set: expect.objectContaining({
+          subscription_tier: "pro",
+          last_usage_cost_at: expect.any(String),
+        }),
+      }),
+    });
   });
 });

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -39,6 +39,7 @@ import PostHogClient from "@/app/posthog";
 import {
   captureAgentRun,
   captureToolCalls,
+  captureUsageCost,
   createChatLogger,
   shutdownPostHog,
   type ChatLogger,
@@ -567,13 +568,13 @@ export const createChatHandler = (
             mode === "agent" ? "fallback-agent-model" : "fallback-ask-model";
 
           const usageTracker = new UsageTracker();
-          let hasDeductedUsage = false;
+          let hasRecordedUsage = false;
           // Snapshot cache tokens before fallback retry so we can isolate fallback-only metrics
           let preFallbackCacheRead = 0;
           let preFallbackCacheWrite = 0;
 
           const deductAccumulatedUsage = async () => {
-            if (hasDeductedUsage || subscription === "free") return;
+            if (hasRecordedUsage) return;
             // Add E2B sandbox session cost (duration-based)
             const sandboxCost = getSandboxSessionCost();
             if (sandboxCost > 0) {
@@ -586,7 +587,14 @@ export const createChatHandler = (
               // No usage data reported — skip deduction
               return;
             }
-            hasDeductedUsage = true;
+            hasRecordedUsage = true;
+            const usageCostRecord = usageTracker.createUsageCostRecord({
+              selectedModel,
+              selectedModelOverride,
+              responseModel: state.responseModel,
+              configuredModelId,
+              rateLimitInfo,
+            });
 
             // Trust accumulated provider cost (sum of per-step usage.raw.cost) even on
             // non-clean streams. Each completed step reports authoritative cost with
@@ -601,25 +609,37 @@ export const createChatHandler = (
                 ? usageTracker.providerCost
                 : undefined;
 
-            await deductUsage(
+            if (subscription !== "free") {
+              await deductUsage(
+                userId,
+                subscription,
+                estimatedInputTokens,
+                usageTracker.inputTokens,
+                usageTracker.outputTokens,
+                extraUsageConfig,
+                providerCost,
+                selectedModel,
+                usageTracker.nonModelCost,
+                organizationId,
+              );
+              usageTracker.log({
+                userId,
+                selectedModel,
+                selectedModelOverride,
+                responseModel: state.responseModel,
+                configuredModelId,
+                rateLimitInfo,
+              });
+            }
+            captureUsageCost({
+              posthog,
               userId,
               subscription,
-              estimatedInputTokens,
-              usageTracker.inputTokens,
-              usageTracker.outputTokens,
-              extraUsageConfig,
-              providerCost,
-              selectedModel,
-              usageTracker.nonModelCost,
               organizationId,
-            );
-            usageTracker.log({
-              userId,
-              selectedModel,
-              selectedModelOverride,
-              responseModel: state.responseModel,
-              configuredModelId,
-              rateLimitInfo,
+              chatId,
+              endpoint,
+              mode,
+              usage: usageCostRecord,
             });
           };
 

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -22,6 +22,7 @@ import type { ChatSDKError } from "@/lib/errors";
 import type { PostHog } from "posthog-node";
 import { after } from "next/server";
 import { phLogger } from "@/lib/posthog/server";
+import type { UsageCostRecord } from "@/lib/usage-tracker";
 import {
   extractErrorDetails,
   extractRetryAttempts,
@@ -496,6 +497,61 @@ export function captureAgentRun({
       subscription,
       outcome,
       ...(sandboxInfo?.type && { sandboxType: sandboxInfo.type }),
+    },
+  });
+}
+
+/**
+ * Capture one cost event per request with usage. In PostHog, answer
+ * "how much does each user cost you?" by summing cost_dollars on
+ * hackerai-usage_cost grouped by distinct_id (or user_id).
+ */
+export function captureUsageCost({
+  posthog,
+  userId,
+  subscription,
+  organizationId,
+  chatId,
+  endpoint,
+  mode,
+  usage,
+}: {
+  posthog: PostHog | null;
+  userId: string;
+  subscription: string;
+  organizationId?: string;
+  chatId: string;
+  endpoint: "/api/chat" | "/api/agent";
+  mode: ChatMode;
+  usage: UsageCostRecord;
+}) {
+  if (!posthog) return;
+  posthog.capture({
+    distinctId: userId,
+    event: "hackerai-usage_cost",
+    properties: {
+      user_id: userId,
+      subscription,
+      subscription_tier: subscription,
+      ...(organizationId && { organization_id: organizationId }),
+      chat_id: chatId,
+      endpoint,
+      mode,
+      model: usage.model,
+      usage_type: usage.type,
+      cost_dollars: usage.costDollars,
+      model_cost_dollars: usage.modelCostDollars,
+      non_model_cost_dollars: usage.nonModelCostDollars,
+      input_tokens: usage.inputTokens,
+      output_tokens: usage.outputTokens,
+      total_tokens: usage.totalTokens,
+      cache_read_tokens: usage.cacheReadTokens ?? 0,
+      cache_write_tokens: usage.cacheWriteTokens ?? 0,
+      cost_source: usage.costSource,
+      $set: {
+        subscription_tier: subscription,
+        last_usage_cost_at: new Date().toISOString(),
+      },
     },
   });
 }

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -13,6 +13,20 @@ interface StepUsage {
   raw?: { cost?: number };
 }
 
+export interface UsageCostRecord {
+  model: string;
+  type: "included" | "extra";
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  costDollars: number;
+  modelCostDollars: number;
+  nonModelCostDollars: number;
+  costSource: "provider" | "token_estimate";
+}
+
 /**
  * Tracks accumulated token usage across stream steps and handles logging.
  * Shared between chat-handler.ts and agent-task.ts to avoid duplication.
@@ -138,14 +152,42 @@ export class UsageTracker {
     return responseModel || configuredModelId || selectedModel;
   }
 
-  log({
-    userId,
+  createUsageCostRecord({
     selectedModel,
     selectedModelOverride,
     responseModel,
     configuredModelId,
     rateLimitInfo,
   }: {
+    selectedModel: string;
+    selectedModelOverride?: string | null;
+    responseModel?: string;
+    configuredModelId: string;
+    rateLimitInfo: RateLimitInfo;
+  }): UsageCostRecord {
+    const model = this.resolveModelName({
+      selectedModelOverride,
+      responseModel,
+      configuredModelId,
+      selectedModel,
+    });
+    const modelCostDollars = this.computeModelCostDollars(selectedModel);
+    return {
+      model,
+      type: this.resolveUsageType(rateLimitInfo),
+      inputTokens: this.inputTokens,
+      outputTokens: this.outputTokens,
+      totalTokens: this.totalTokens || this.inputTokens + this.outputTokens,
+      cacheReadTokens: this.cacheReadTokens || undefined,
+      cacheWriteTokens: this.cacheWriteTokens || undefined,
+      costDollars: modelCostDollars + this.nonModelCost,
+      modelCostDollars,
+      nonModelCostDollars: this.nonModelCost,
+      costSource: this.modelProviderCost > 0 ? "provider" : "token_estimate",
+    };
+  }
+
+  log(args: {
     userId: string;
     selectedModel: string;
     selectedModelOverride?: string | null;
@@ -153,21 +195,17 @@ export class UsageTracker {
     configuredModelId: string;
     rateLimitInfo: RateLimitInfo;
   }) {
+    const usage = this.createUsageCostRecord(args);
     logUsageRecord({
-      userId,
-      model: this.resolveModelName({
-        selectedModelOverride,
-        responseModel,
-        configuredModelId,
-        selectedModel,
-      }),
-      type: this.resolveUsageType(rateLimitInfo),
-      inputTokens: this.inputTokens,
-      outputTokens: this.outputTokens,
-      totalTokens: this.totalTokens || this.inputTokens + this.outputTokens,
-      cacheReadTokens: this.cacheReadTokens || undefined,
-      cacheWriteTokens: this.cacheWriteTokens || undefined,
-      costDollars: this.computeCostDollars(selectedModel),
+      userId: args.userId,
+      model: usage.model,
+      type: usage.type,
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      totalTokens: usage.totalTokens,
+      cacheReadTokens: usage.cacheReadTokens,
+      cacheWriteTokens: usage.cacheWriteTokens,
+      costDollars: usage.costDollars,
     });
   }
 }

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -69,6 +69,7 @@ import {
 import {
   captureAgentRun,
   captureToolCalls,
+  captureUsageCost,
   createChatLogger,
   type ChatLogger,
 } from "@/lib/api/chat-logger";
@@ -835,12 +836,12 @@ export const agentLongTask = task({
           const fallbackModel = "fallback-agent-model";
 
           const usageTracker = new UsageTracker();
-          let hasDeductedUsage = false;
+          let hasRecordedUsage = false;
           let preFallbackCacheRead = 0;
           let preFallbackCacheWrite = 0;
 
           const deductAccumulatedUsage = async () => {
-            if (hasDeductedUsage || subscription === "free") return;
+            if (hasRecordedUsage) return;
             const sandboxCost = getSandboxSessionCost();
             if (sandboxCost > 0) {
               usageTracker.providerCost += sandboxCost;
@@ -848,29 +849,49 @@ export const agentLongTask = task({
               chatLogger?.getBuilder().addToolCost(sandboxCost);
             }
             if (!usageTracker.hasUsage) return;
-            hasDeductedUsage = true;
-            const providerCost =
-              usageTracker.modelProviderCost > 0
-                ? usageTracker.providerCost
-                : undefined;
-            await deductUsage(
-              userId,
-              subscription,
-              estimatedInputTokens,
-              usageTracker.inputTokens,
-              usageTracker.outputTokens,
-              extraUsageConfig,
-              providerCost,
-              selectedModel,
-              usageTracker.nonModelCost,
-            );
-            usageTracker.log({
-              userId,
+            hasRecordedUsage = true;
+            const usageCostRecord = usageTracker.createUsageCostRecord({
               selectedModel,
               selectedModelOverride,
               responseModel: state.responseModel,
               configuredModelId,
               rateLimitInfo,
+            });
+            const providerCost =
+              usageTracker.modelProviderCost > 0
+                ? usageTracker.providerCost
+                : undefined;
+            if (subscription !== "free") {
+              await deductUsage(
+                userId,
+                subscription,
+                estimatedInputTokens,
+                usageTracker.inputTokens,
+                usageTracker.outputTokens,
+                extraUsageConfig,
+                providerCost,
+                selectedModel,
+                usageTracker.nonModelCost,
+                organizationId,
+              );
+              usageTracker.log({
+                userId,
+                selectedModel,
+                selectedModelOverride,
+                responseModel: state.responseModel,
+                configuredModelId,
+                rateLimitInfo,
+              });
+            }
+            captureUsageCost({
+              posthog,
+              userId,
+              subscription,
+              organizationId,
+              chatId,
+              endpoint: "/api/agent",
+              mode,
+              usage: usageCostRecord,
             });
           };
 
@@ -1058,7 +1079,6 @@ export const agentLongTask = task({
                               sandboxInfo,
                               outcome: retryAborted ? "aborted" : "success",
                             });
-                            posthog?.shutdown();
                             chatLogger?.emitSuccess({
                               finishReason: state.streamFinishReason,
                               wasAborted: retryAborted,
@@ -1129,6 +1149,7 @@ export const agentLongTask = task({
                               sendFileMetadataToStream(accumulatedFiles);
                             }
                             await deductAccumulatedUsage();
+                            posthog?.shutdown();
                           },
                         }),
                         userStopSignal.signal,
@@ -1164,7 +1185,6 @@ export const agentLongTask = task({
                     sandboxInfo,
                     outcome: isAborted ? "aborted" : "success",
                   });
-                  posthog?.shutdown();
                   chatLogger?.emitSuccess({
                     finishReason: state.streamFinishReason,
                     wasAborted: isAborted,
@@ -1275,6 +1295,7 @@ export const agentLongTask = task({
                         }),
                       );
                       await deductAccumulatedUsage();
+                      posthog?.shutdown();
                       return;
                     }
 
@@ -1353,6 +1374,7 @@ export const agentLongTask = task({
                   }
 
                   await deductAccumulatedUsage();
+                  posthog?.shutdown();
                 },
               }),
               userStopSignal.signal,


### PR DESCRIPTION
## Summary

Adds PostHog analytics for user-level usage cost, subscription checkout intent, and free-to-paid conversion revenue so we can measure free-user economics end to end.

## What changed

- Added `hackerai-usage_cost` events with user, subscription, org, chat, endpoint, mode, model, token, and dollar-cost fields.
- Reused `UsageTracker` cost calculation through a reusable usage cost snapshot to avoid divergent analytics math.
- Captures cost analytics for free users while keeping existing paid-only billing deductions and Convex usage logging behavior.
- Wired the usage cost event into both normal chat requests and long-running agent tasks.
- Added `checkout_started` when `/api/subscribe` creates a Stripe Checkout session.
- Added Stripe metadata to Checkout sessions/subscriptions for easier customer/session correlation.
- Added `subscription_started` on `invoice.paid` with `billing_reason = subscription_create`, including attributed revenue fields.
- Added coverage for the emitted PostHog usage cost event shape.

## How to use in PostHog

- Conversion rate: funnel `checkout_started` → `subscription_started`.
- Free cost: sum `cost_dollars` on `hackerai-usage_cost` where `subscription_tier = free`.
- Revenue from converted users: sum `revenue_dollars` on `subscription_started`.
- Unit economics: compare pre-conversion `hackerai-usage_cost.cost_dollars` against `subscription_started.revenue_dollars` by `user_id` / `distinct_id`.

## Validation

- `pnpm tsc --noEmit`
- `pnpm test -- lib/api/__tests__/chat-logger.test.ts lib/__tests__/usage-tracker.test.ts`
- Pre-commit hook: `pnpm typecheck`
- Pre-commit hook: full `pnpm test` suite, 85 suites / 1092 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved usage and cost tracking with finer-grained reporting and more accurate billing/analytics across tiers.
  * Checkout flow now attaches richer metadata and emits enhanced events for better subscription visibility.
  * Subscription webhook emits clearer subscription-start events with billing interval and revenue attribution.

* **Tests**
  * Added tests covering usage cost reporting and analytics events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->