### PR TITLE
[codex] Improve provider error observability

### DIFF
--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1,5 +1,5 @@
 import { query, mutation, internalQuery } from "./_generated/server";
-import { v, ConvexError } from "convex/values";
+import { v, ConvexError, type Value } from "convex/values";
 import { internal } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
 import { paginationOptsValidator } from "convex/server";
@@ -66,6 +66,18 @@ const getMessageSaveDiagnostics = (parts: any[]) => {
     tool_part_count: toolPartCount,
     data_part_count: dataPartCount,
   };
+};
+
+const getErrorName = (error: unknown): string =>
+  error instanceof Error ? error.name : typeof error;
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const getConvexErrorData = (error: unknown): Value | undefined => {
+  if (!error || typeof error !== "object") return undefined;
+  const data = (error as { data?: unknown }).data;
+  return data === undefined ? undefined : (data as Value);
 };
 
 /**
@@ -245,8 +257,10 @@ export const saveMessage = mutation({
   returns: v.null(),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
+    let failureStage = "start";
 
     try {
+      failureStage = "find_existing_message";
       const existingMessage = await ctx.db
         .query("messages")
         .withIndex("by_message_id", (q) => q.eq("id", args.id))
@@ -283,6 +297,7 @@ export const saveMessage = mutation({
             );
             for (const file of files) {
               if (file && !file.is_attached) {
+                failureStage = "patch_existing_message_file_attachment";
                 await ctx.db.patch(file._id, { is_attached: true });
               }
             }
@@ -323,6 +338,7 @@ export const saveMessage = mutation({
         // Apply patch if there are changes
         if (Object.keys(patch).length > 0) {
           patch.update_time = Date.now();
+          failureStage = "patch_existing_message";
           await ctx.db.patch(existingMessage._id, patch);
         }
 
@@ -334,6 +350,7 @@ export const saveMessage = mutation({
           return null;
         }
 
+        failureStage = "verify_chat_ownership";
         const chatExists: boolean = await ctx.runQuery(
           internal.messages.verifyChatOwnership,
           {
@@ -347,8 +364,10 @@ export const saveMessage = mutation({
         }
       }
 
+      failureStage = "extract_content";
       const content = extractTextFromParts(args.parts);
 
+      failureStage = "insert_message";
       await ctx.db.insert("messages", {
         id: args.id,
         chat_id: args.chatId,
@@ -370,6 +389,7 @@ export const saveMessage = mutation({
       // Mark attached files as linked so purge won't remove them.
       // Batch-read in parallel, skip no-op patches when already attached.
       if (args.fileIds && args.fileIds.length > 0) {
+        failureStage = "read_new_message_files";
         const files = await Promise.all(
           args.fileIds.map((fileId) =>
             ctx.db.get(fileId).catch((e) => {
@@ -385,6 +405,7 @@ export const saveMessage = mutation({
             continue;
           }
           if (!file.is_attached) {
+            failureStage = "patch_new_message_file_attachment";
             await ctx.db.patch(file._id, { is_attached: true });
           }
         }
@@ -392,6 +413,7 @@ export const saveMessage = mutation({
 
       return null;
     } catch (error) {
+      const causeData = getConvexErrorData(error);
       console.error(
         JSON.stringify({
           level: "error",
@@ -399,6 +421,7 @@ export const saveMessage = mutation({
           service: "convex",
           timestamp: new Date().toISOString(),
           db_operation: "messages.saveMessage",
+          failure_stage: failureStage,
           chat_id: args.chatId,
           user_id: args.userId,
           message_id: args.id,
@@ -409,12 +432,30 @@ export const saveMessage = mutation({
           update_only: args.updateOnly === true,
           hidden: args.isHidden === true,
           file_count: args.fileIds?.length ?? 0,
-          error_name: error instanceof Error ? error.name : typeof error,
-          error_message: error instanceof Error ? error.message : String(error),
+          error_name: getErrorName(error),
+          error_message: getErrorMessage(error),
+          convex_error_data: causeData,
           ...getMessageSaveDiagnostics(args.parts),
         }),
       );
-      throw new Error("Failed to save message");
+      throw new ConvexError({
+        code: "MESSAGE_SAVE_FAILED",
+        message: "Failed to save message",
+        failureStage,
+        causeName: getErrorName(error),
+        causeMessage: getErrorMessage(error),
+        causeData,
+        operation: "messages.saveMessage",
+        chatId: args.chatId,
+        messageId: args.id,
+        role: args.role,
+        mode: args.mode,
+        finishReason: args.finishReason,
+        updateOnly: args.updateOnly === true,
+        hidden: args.isHidden === true,
+        fileCount: args.fileIds?.length ?? 0,
+        ...getMessageSaveDiagnostics(args.parts),
+      });
     }
   },
 });

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -112,9 +112,9 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
 
   test("handled user rate limits are returned after the UI error chunk is flushed", () => {
     const waitIdx = taskSrc.indexOf("await waitUntilComplete()");
-    const streamErrorIdx = taskSrc.indexOf("if (streamError)", waitIdx);
+    const streamErrorIdx = taskSrc.indexOf("if (terminalStreamError)", waitIdx);
     const handledRateLimitIdx = taskSrc.indexOf(
-      "isHandledUserRateLimitError(streamError)",
+      "isHandledUserRateLimitError(terminalStreamError)",
       streamErrorIdx,
     );
     const returnIdx = taskSrc.indexOf(
@@ -128,15 +128,34 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
   });
 
   test("non-rate-limit stream errors are still rethrown after the handled branch", () => {
-    const streamErrorIdx = taskSrc.indexOf("if (streamError)");
+    const streamErrorIdx = taskSrc.indexOf("if (terminalStreamError)");
     const handledRateLimitIdx = taskSrc.indexOf(
-      "isHandledUserRateLimitError(streamError)",
+      "isHandledUserRateLimitError(terminalStreamError)",
       streamErrorIdx,
     );
-    const throwIdx = taskSrc.indexOf("throw streamError", handledRateLimitIdx);
+    const throwIdx = taskSrc.indexOf(
+      "throw terminalStreamError",
+      handledRateLimitIdx,
+    );
     expect(streamErrorIdx).toBeGreaterThan(-1);
     expect(handledRateLimitIdx).toBeGreaterThan(streamErrorIdx);
     expect(throwIdx).toBeGreaterThan(streamErrorIdx);
+  });
+
+  test("provider finishReason error fails the task after the UI stream drains", () => {
+    const waitIdx = taskSrc.indexOf("await waitUntilComplete()");
+    const terminalErrorIdx = taskSrc.indexOf(
+      "getTerminalProviderStreamError(terminalAgentState)",
+      waitIdx,
+    );
+    const throwIdx = taskSrc.indexOf(
+      "throw terminalStreamError",
+      terminalErrorIdx,
+    );
+
+    expect(waitIdx).toBeGreaterThan(-1);
+    expect(terminalErrorIdx).toBeGreaterThan(waitIdx);
+    expect(throwIdx).toBeGreaterThan(terminalErrorIdx);
   });
 
   test("task catch records structured metadata for dashboard filtering", () => {

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -79,6 +79,8 @@ export type AgentStreamState = {
   streamFinishReason: string | undefined;
   streamUsage: Record<string, unknown> | undefined;
   responseModel: string | undefined;
+  /** Original provider/AI SDK error captured from streamText.onError. */
+  providerError: unknown;
   /** Stop-condition flags set by the respective onFired callbacks. */
   stoppedDueToTokenExhaustion: boolean;
   /** Maps to stoppedDueToPreemptiveTimeout in chat-handler, stoppedDueToElapsedTimeout in agent-long. */
@@ -98,6 +100,7 @@ export function initAgentStreamState(
     streamFinishReason: undefined,
     streamUsage: undefined,
     responseModel: undefined,
+    providerError: undefined,
     stoppedDueToTokenExhaustion: false,
     stoppedDueToElapsedTimeout: false,
     stoppedDueToDoomLoop: false,
@@ -415,10 +418,15 @@ export async function createAgentStream(
     },
 
     onError: async ({ error }) => {
+      state.providerError = error;
       if (!isXaiSafetyError(error)) {
+        const fallbackSlugs = getFallbackSlugs(modelName, ctx.mode);
         ctx.chatLogger?.recordProviderError(error, {
           mode: ctx.mode,
           model: modelName,
+          requestedModelSlug: requestedSlug,
+          fallbackModelSlugs:
+            fallbackSlugs.length > 0 ? fallbackSlugs : undefined,
           userId: ctx.userId,
           subscription: ctx.subscription,
           isTemporary: ctx.temporary,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -566,6 +566,8 @@ export const createChatHandler = (
           ].includes(selectedModel);
           const fallbackModel =
             mode === "agent" ? "fallback-agent-model" : "fallback-ask-model";
+          const fallbackModelId =
+            trackedProvider.languageModel(fallbackModel).modelId;
 
           const usageTracker = new UsageTracker();
           let hasRecordedUsage = false;
@@ -694,8 +696,11 @@ export const createChatHandler = (
                 chatId,
                 endpoint,
                 mode,
+                providerGateway: "openrouter",
                 originalModel: selectedModel,
+                requestedModelSlug: configuredModelId,
                 fallbackModel,
+                fallbackModelSlug: fallbackModelId,
                 userId,
                 subscription,
                 isTemporary: temporary,
@@ -1210,27 +1215,68 @@ export const createChatHandler = (
                     // On user-initiated abort, use updateOnly as safety net:
                     // only patch existing messages (add files/usage), don't create new ones.
                     // This prevents orphan messages when Redis skipSave signal was missed.
-                    await saveMessage({
-                      chatId,
-                      userId,
-                      message: processedMessage,
-                      extraFileIds: newFileIds,
-                      model: state.responseModel || configuredModelId,
-                      mode,
-                      generationStartedAt:
-                        processedMessage.role === "assistant"
-                          ? streamStartTime
-                          : undefined,
-                      generationTimeMs: Date.now() - streamStartTime,
-                      finishReason: state.streamFinishReason,
-                      usage: resolvedUsage ?? state.streamUsage,
-                      updateOnly:
-                        isAborted && !isPreemptiveAbort ? true : undefined,
-                      isHidden:
-                        isAutoContinue && processedMessage.role === "user"
-                          ? true
-                          : undefined,
-                    });
+                    try {
+                      await saveMessage({
+                        chatId,
+                        userId,
+                        message: processedMessage,
+                        extraFileIds: newFileIds,
+                        model: state.responseModel || configuredModelId,
+                        mode,
+                        generationStartedAt:
+                          processedMessage.role === "assistant"
+                            ? streamStartTime
+                            : undefined,
+                        generationTimeMs: Date.now() - streamStartTime,
+                        finishReason: state.streamFinishReason,
+                        usage: resolvedUsage ?? state.streamUsage,
+                        updateOnly:
+                          isAborted && !isPreemptiveAbort ? true : undefined,
+                        isHidden:
+                          isAutoContinue && processedMessage.role === "user"
+                            ? true
+                            : undefined,
+                        wasAborted: isAborted,
+                        wasPreemptiveTimeout: isPreemptiveAbort,
+                      });
+                    } catch (error) {
+                      if (isPreemptiveAbort) {
+                        console.error(
+                          JSON.stringify({
+                            level: "error",
+                            event: "preemptive_timeout_message_save_failed",
+                            service: "chat-handler",
+                            timestamp: new Date().toISOString(),
+                            chat_id: chatId,
+                            user_id: userId,
+                            message_id: processedMessage.id,
+                            message_role: processedMessage.role,
+                            mode,
+                            model: state.responseModel || configuredModelId,
+                            finish_reason: state.streamFinishReason,
+                            time_since_timeout_trigger_ms: triggerTime
+                              ? Date.now() - triggerTime
+                              : null,
+                            stream_duration_ms: Date.now() - streamStartTime,
+                            error_name:
+                              error instanceof Error
+                                ? error.name
+                                : typeof error,
+                            error_message:
+                              error instanceof Error
+                                ? error.message
+                                : String(error),
+                            error_metadata:
+                              error &&
+                              typeof error === "object" &&
+                              "metadata" in error
+                                ? (error as { metadata?: unknown }).metadata
+                                : undefined,
+                          }),
+                        );
+                      }
+                      throw error;
+                    }
                   }
                   logStep("save_messages", stepStart);
 

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -284,6 +284,8 @@ export function createChatLogger(config: ChatLoggerConfig) {
       context: {
         mode?: string;
         model?: string;
+        requestedModelSlug?: string;
+        fallbackModelSlugs?: string[];
         userId?: string;
         subscription?: string;
         isTemporary?: boolean;
@@ -299,6 +301,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
         {
           chat_id: config.chatId,
           endpoint: config.endpoint,
+          provider_gateway: "openrouter",
           provider_error_category: category,
           ...context,
           ...details,
@@ -310,6 +313,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
         error: posthogProviderException(error, details),
         chatId: config.chatId,
         endpoint: config.endpoint,
+        providerGateway: "openrouter",
         providerErrorCategory: category,
         ...context,
         ...details,

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -42,6 +42,12 @@ const stringifyError = (error: unknown): string => {
   }
 };
 
+const getErrorData = (error: unknown): unknown => {
+  if (!error || typeof error !== "object") return undefined;
+  const data = (error as { data?: unknown }).data;
+  return data === undefined ? undefined : data;
+};
+
 const truncateDiagnosticString = (value: string): string =>
   value.length > MAX_DATABASE_ERROR_MESSAGE_LENGTH
     ? `${value.slice(0, MAX_DATABASE_ERROR_MESSAGE_LENGTH)}...`
@@ -58,6 +64,7 @@ const databaseError = (
     db_operation: operation,
     db_error_name: dbErrorName,
     db_error_message: dbErrorMessage,
+    db_error_data: getErrorData(error),
     ...metadata,
   };
 
@@ -127,6 +134,8 @@ export async function saveMessage({
   usage,
   updateOnly,
   isHidden,
+  wasAborted,
+  wasPreemptiveTimeout,
 }: {
   chatId: string;
   userId: string;
@@ -144,6 +153,8 @@ export async function saveMessage({
   usage?: Record<string, unknown>;
   updateOnly?: boolean;
   isHidden?: boolean;
+  wasAborted?: boolean;
+  wasPreemptiveTimeout?: boolean;
 }) {
   let fixedParts = message.parts;
   let partsForSave = message.parts;
@@ -243,6 +254,8 @@ export async function saveMessage({
       finish_reason: finishReason,
       update_only: updateOnly === true,
       hidden: isHidden === true,
+      was_aborted: wasAborted,
+      was_preemptive_timeout: wasPreemptiveTimeout,
       extra_file_count: extraFileIds?.length ?? 0,
       usage_keys: usage ? Object.keys(usage).sort() : undefined,
       ...persistenceDiagnostics,

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -28,7 +28,35 @@ import { sanitizeForConvexValue } from "./convex-value-sanitizer";
 
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 const MAX_DATABASE_ERROR_MESSAGE_LENGTH = 500;
+const MAX_DATABASE_ERROR_DATA_STRING_LENGTH = 500;
+const MAX_DATABASE_ERROR_DATA_BYTES = 4 * 1024;
+const MAX_DATABASE_ERROR_DATA_DEPTH = 3;
+const MAX_DATABASE_ERROR_DATA_ARRAY_LENGTH = 20;
 const LARGE_MESSAGE_SAVE_WARNING_BYTES = 850 * 1024;
+const REDACTED_ERROR_DATA_VALUE = "[Redacted]";
+
+const sensitiveErrorDataKeys = new Set([
+  "authorization",
+  "body",
+  "content",
+  "cookie",
+  "cookies",
+  "file",
+  "files",
+  "headers",
+  "messages",
+  "output",
+  "parts",
+  "password",
+  "prompt",
+  "request",
+  "requestbody",
+  "response",
+  "responsebody",
+  "result",
+  "text",
+  "token",
+]);
 
 export { setConvexUrl };
 
@@ -45,7 +73,105 @@ const stringifyError = (error: unknown): string => {
 const getErrorData = (error: unknown): unknown => {
   if (!error || typeof error !== "object") return undefined;
   const data = (error as { data?: unknown }).data;
-  return data === undefined ? undefined : data;
+  return data === undefined ? undefined : sanitizeErrorData(data);
+};
+
+const getJsonByteLength = (value: unknown): number => {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), "utf-8");
+  } catch {
+    return 0;
+  }
+};
+
+const truncateErrorDataString = (value: string): string =>
+  value.length > MAX_DATABASE_ERROR_DATA_STRING_LENGTH
+    ? `${value.slice(0, MAX_DATABASE_ERROR_DATA_STRING_LENGTH)}...`
+    : value;
+
+const isSensitiveErrorDataKey = (key: string): boolean => {
+  const normalized = key.replace(/[-_\s]/g, "").toLowerCase();
+  return (
+    sensitiveErrorDataKeys.has(normalized) ||
+    /apikey|authorization|bearer|cookie|password|secret/.test(normalized)
+  );
+};
+
+const summarizeErrorDataObject = (value: object) => ({
+  truncated: true,
+  keys: Object.keys(value).slice(0, MAX_DATABASE_ERROR_DATA_ARRAY_LENGTH),
+});
+
+const sanitizeErrorDataValue = (
+  value: unknown,
+  depth: number,
+  seen: WeakSet<object>,
+): unknown => {
+  if (value === null || value === undefined) return value;
+
+  if (typeof value === "string") return truncateErrorDataString(value);
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "function" || typeof value === "symbol") {
+    return String(value);
+  }
+  if (typeof value !== "object") return String(value);
+
+  if (seen.has(value)) return "[Circular]";
+  if (depth >= MAX_DATABASE_ERROR_DATA_DEPTH) {
+    return summarizeErrorDataObject(value);
+  }
+
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    const sanitized = value
+      .slice(0, MAX_DATABASE_ERROR_DATA_ARRAY_LENGTH)
+      .map((item) => sanitizeErrorDataValue(item, depth + 1, seen));
+    if (value.length > MAX_DATABASE_ERROR_DATA_ARRAY_LENGTH) {
+      sanitized.push({
+        truncated: true,
+        remaining: value.length - MAX_DATABASE_ERROR_DATA_ARRAY_LENGTH,
+      });
+    }
+    seen.delete(value);
+    return sanitized;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, childValue] of Object.entries(
+    value as Record<string, unknown>,
+  )) {
+    sanitized[key] = isSensitiveErrorDataKey(key)
+      ? REDACTED_ERROR_DATA_VALUE
+      : sanitizeErrorDataValue(childValue, depth + 1, seen);
+  }
+
+  seen.delete(value);
+  return sanitized;
+};
+
+const sanitizeErrorData = (data: unknown): unknown => {
+  const sanitized = sanitizeErrorDataValue(data, 0, new WeakSet<object>());
+  const sizeBytes = getJsonByteLength(sanitized);
+  if (sizeBytes <= MAX_DATABASE_ERROR_DATA_BYTES) return sanitized;
+
+  if (sanitized && typeof sanitized === "object") {
+    return {
+      truncated: true,
+      size_bytes: sizeBytes,
+      keys: Object.keys(sanitized).slice(
+        0,
+        MAX_DATABASE_ERROR_DATA_ARRAY_LENGTH,
+      ),
+    };
+  }
+
+  return {
+    truncated: true,
+    size_bytes: sizeBytes,
+  };
 };
 
 const truncateDiagnosticString = (value: string): string =>

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "@jest/globals";
-import { extractRetryAttempts } from "../error-utils";
+import { extractErrorDetails, extractRetryAttempts } from "../error-utils";
 
 const apiCallError = (overrides: Record<string, unknown>) =>
   Object.assign(new Error("Internal Server Error"), {
@@ -15,6 +15,52 @@ const retryError = (errors: unknown[]) =>
   });
 
 describe("extractRetryAttempts -> request_id", () => {
+  it("extracts OpenRouter provider metadata from data.error.metadata", () => {
+    const err = apiCallError({
+      data: {
+        id: "gen-1778016347-NLwcIgc6sf7HbOc1VW4x",
+        error: {
+          code: 502,
+          message: "Upstream idle timeout exceeded",
+          metadata: {
+            provider_name: "Moonshot AI",
+            raw: "upstream idle timeout exceeded after 60s",
+          },
+        },
+      },
+    });
+
+    expect(extractErrorDetails(err)).toMatchObject({
+      providerName: "Moonshot AI",
+      providerErrorCode: 502,
+      providerErrorMessage: "Upstream idle timeout exceeded",
+      providerRawError: "upstream idle timeout exceeded after 60s",
+      openrouterGenerationId: "gen-1778016347-NLwcIgc6sf7HbOc1VW4x",
+    });
+  });
+
+  it("extracts OpenRouter provider metadata from responseBody JSON", () => {
+    const err = apiCallError({
+      responseBody: JSON.stringify({
+        id: "gen-9999999999-abcdefabcdef",
+        error: {
+          code: 503,
+          message: "Provider overloaded",
+          metadata: {
+            provider_name: "Anthropic",
+          },
+        },
+      }),
+    });
+
+    expect(extractErrorDetails(err)).toMatchObject({
+      providerName: "Anthropic",
+      providerErrorCode: 503,
+      providerErrorMessage: "Provider overloaded",
+      openrouterGenerationId: "gen-9999999999-abcdefabcdef",
+    });
+  });
+
   it("prefers OpenRouter gen-id from error.data over cf-ray header", () => {
     const err = retryError([
       apiCallError({
@@ -131,6 +177,22 @@ describe("extractRetryAttempts -> request_id", () => {
 
     const ids = extractRetryAttempts(err)?.map((a) => a.request_id);
     expect(ids).toEqual(["gen-aaa", "gen-bbb", "ray-3"]);
+  });
+
+  it("adds provider name to retry attempts when OpenRouter exposes it", () => {
+    const err = retryError([
+      apiCallError({
+        data: {
+          error: {
+            metadata: {
+              provider_name: "Google",
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(extractRetryAttempts(err)?.[0].provider_name).toBe("Google");
   });
 
   it("returns undefined when error has no errors[] array", () => {

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -19,6 +19,10 @@ export const getErrorMessage = (err: unknown): string => {
   }
 };
 
+const truncate = (str: string, max: number): string => {
+  return str.length > max ? str.slice(0, max) + "…" : str;
+};
+
 const SENSITIVE_KEYS = new Set([
   "requestBodyValues",
   "prompt",
@@ -26,6 +30,83 @@ const SENSITIVE_KEYS = new Set([
   "content",
   "text",
 ]);
+
+const OPENROUTER_DETAIL_MAX_LENGTH = 500;
+
+const parseJsonObject = (
+  value: string,
+): Record<string, unknown> | undefined => {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const getOpenRouterPayload = (
+  source: unknown,
+): Record<string, unknown> | null => {
+  if (!source || typeof source !== "object") return null;
+  const anySource = source as Record<string, unknown>;
+
+  if (anySource.data && typeof anySource.data === "object") {
+    return anySource.data as Record<string, unknown>;
+  }
+
+  if (typeof anySource.responseBody === "string") {
+    return parseJsonObject(anySource.responseBody) ?? null;
+  }
+
+  return null;
+};
+
+const getOpenRouterProviderInfo = (
+  source: unknown,
+): Record<string, unknown> => {
+  const payload = getOpenRouterPayload(source);
+  if (!payload) return {};
+
+  const details: Record<string, unknown> = {};
+  const id = pickBodyId(payload);
+  if (id) details.openrouterGenerationId = id;
+
+  const nested =
+    payload.error && typeof payload.error === "object"
+      ? (payload.error as Record<string, unknown>)
+      : undefined;
+  if (!nested) return details;
+
+  if (typeof nested.code === "number" || typeof nested.code === "string") {
+    details.providerErrorCode = nested.code;
+  }
+  if (typeof nested.message === "string" && nested.message.length > 0) {
+    details.providerErrorMessage = truncate(
+      nested.message,
+      OPENROUTER_DETAIL_MAX_LENGTH,
+    );
+  }
+
+  const metadata =
+    nested.metadata && typeof nested.metadata === "object"
+      ? (nested.metadata as Record<string, unknown>)
+      : undefined;
+  if (!metadata) return details;
+
+  if (typeof metadata.provider_name === "string") {
+    details.providerName = metadata.provider_name;
+  }
+  if (typeof metadata.raw === "string" && metadata.raw.length > 0) {
+    details.providerRawError = truncate(
+      metadata.raw,
+      OPENROUTER_DETAIL_MAX_LENGTH,
+    );
+  }
+
+  return details;
+};
 
 /**
  * Removes sensitive user data from provider error objects.
@@ -110,6 +191,8 @@ export const extractErrorDetails = (
     details.errorCode = anyError.code;
   }
 
+  Object.assign(details, getOpenRouterProviderInfo(error));
+
   return details;
 };
 
@@ -118,6 +201,7 @@ export interface ProviderAttempt {
   message: string;
   error_name?: string;
   request_id?: string;
+  provider_name?: string;
 }
 
 const REQUEST_ID_HEADERS = [
@@ -179,6 +263,7 @@ const extractRequestId = (error: unknown): string | undefined => {
 
 const toAttempt = (error: unknown): ProviderAttempt => {
   const anyError = (error ?? {}) as Record<string, unknown>;
+  const providerInfo = getOpenRouterProviderInfo(error);
   const statusCode =
     typeof anyError.statusCode === "number"
       ? anyError.statusCode
@@ -196,6 +281,10 @@ const toAttempt = (error: unknown): ProviderAttempt => {
     message: getErrorMessage(error),
     error_name: errorName,
     request_id: extractRequestId(error),
+    provider_name:
+      typeof providerInfo.providerName === "string"
+        ? providerInfo.providerName
+        : undefined,
   };
 };
 
@@ -361,8 +450,4 @@ function extractMessageFromResponseBody(body: string): string | undefined {
     }
   }
   return undefined;
-}
-
-function truncate(str: string, max: number): string {
-  return str.length > max ? str.slice(0, max) + "…" : str;
 }

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -91,6 +91,7 @@ import {
   createAgentStream,
   initAgentStreamState,
   type AgentStreamContext,
+  type AgentStreamState,
 } from "@/lib/api/agent-stream-runner";
 import {
   AGENT_LONG_HEARTBEAT_INTERVAL_MS,
@@ -216,6 +217,24 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
     statusCode:
       typeof details.statusCode === "number" ? details.statusCode : undefined,
   };
+};
+
+const getTerminalProviderStreamError = (
+  state:
+    | Pick<AgentStreamState, "streamFinishReason" | "providerError">
+    | undefined,
+): unknown | undefined => {
+  if (!state) return undefined;
+  if (state.streamFinishReason !== "error") return undefined;
+  if (state.providerError) return state.providerError;
+
+  return Object.assign(
+    new Error("Provider stream finished with error finish reason"),
+    {
+      name: "ProviderStreamError",
+      finishReason: state.streamFinishReason,
+    },
+  );
 };
 
 const recordAgentLongFailureForDashboard = async (
@@ -598,6 +617,7 @@ export const agentLongTask = task({
 
       const summarizationTracker = new SummarizationTracker();
       chatLogger.startStream();
+      let terminalAgentState: AgentStreamState | undefined;
 
       // Rate limit check happens inside execute so a thrown ChatSDKError
       // (e.g. "exceeded daily messages") flows through createUIMessageStream's
@@ -810,6 +830,7 @@ export const agentLongTask = task({
           // Mutable stream state — updated in-place by the shared runner and
           // read back here in toUIMessageStream.onFinish.
           const state = initAgentStreamState(finalMessages, initialCtxUsage);
+          terminalAgentState = state;
 
           const budgetSnapshot = captureBudgetSnapshot({
             rateLimitInfo,
@@ -834,6 +855,8 @@ export const agentLongTask = task({
             "agent-model-free",
           ].includes(selectedModel);
           const fallbackModel = "fallback-agent-model";
+          const fallbackModelId =
+            trackedProvider.languageModel(fallbackModel).modelId;
 
           const usageTracker = new UsageTracker();
           let hasRecordedUsage = false;
@@ -945,8 +968,11 @@ export const agentLongTask = task({
                 {
                   error,
                   chatId,
+                  providerGateway: "openrouter",
                   originalModel: selectedModel,
+                  requestedModelSlug: configuredModelId,
                   fallbackModel,
+                  fallbackModelSlug: fallbackModelId,
                   userId,
                   subscription,
                   preFallbackCacheReadTokens: usageTracker.cacheReadTokens,
@@ -1388,13 +1414,18 @@ export const agentLongTask = task({
       streamPiped = true;
       await waitUntilComplete();
 
-      if (streamError) {
-        if (isHandledUserRateLimitError(streamError)) {
-          await recordAgentLongHandledRateLimitForDashboard(streamError, {
-            chatId,
-            userId,
-            runId: ctx.run.id,
-          }).catch((metadataError) => {
+      const terminalStreamError =
+        streamError ?? getTerminalProviderStreamError(terminalAgentState);
+      if (terminalStreamError) {
+        if (isHandledUserRateLimitError(terminalStreamError)) {
+          await recordAgentLongHandledRateLimitForDashboard(
+            terminalStreamError,
+            {
+              chatId,
+              userId,
+              runId: ctx.run.id,
+            },
+          ).catch((metadataError) => {
             metadata.set("status", "rate_limited");
             console.error(
               "[agent-long] failed to record rate limit metadata:",
@@ -1402,11 +1433,11 @@ export const agentLongTask = task({
             );
           });
           await usageRefundTracker.refund().catch(() => {});
-          chatLogger?.emitChatError(streamError);
+          chatLogger?.emitChatError(terminalStreamError);
           await phLogger.flush().catch(() => {});
           return { chatId, assistantMessageId };
         }
-        throw streamError;
+        throw terminalStreamError;
       }
 
       metadata.set("status", "done");


### PR DESCRIPTION
## Summary

- Preserve Convex `saveMessage` failure stages and structured error data so persistence failures expose the real cause.
- Add OpenRouter/provider breadcrumbs to provider streaming errors, including requested model slug, fallback chain, provider name, raw provider error, and generation id when available.
- Make agent-long Trigger.dev runs fail when the model stream terminates with `finishReason: "error"`, after the UI stream has drained its final error chunks.

## Why

Recent provider and persistence failures were too opaque: Vercel logs showed generic database/provider errors, while Trigger.dev could mark a run successful even though the streamed response ended in an error. This PR keeps the user-facing stream behavior intact while making backend logs and Trigger status reflect the actual failure.

## Validation

- `pnpm test -- lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `pnpm test -- lib/utils/__tests__/error-utils.test.ts convex/__tests__/messages.hidden.test.ts --runInBand`
- `pnpm exec eslint trigger/agent-long.ts lib/api/agent-stream-runner.ts lib/api/__tests__/agent-long-contracts.test.ts lib/utils/error-utils.ts lib/utils/__tests__/error-utils.test.ts lib/api/chat-logger.ts lib/api/chat-handler.ts`
- `pnpm typecheck` is still blocked by pre-existing stale `.next/dev/types/validator.ts` imports for missing generated route modules: `app/admin/economics/page.js`, `app/api/admin/economics/route.js`, and `app/api/analytics/attribution/route.js`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust error handling with structured logs capturing failure stage, error name/message, and related diagnostics
  * Improved provider-error capture with richer model and gateway identifiers; post-stream persistence now surfaces and logs preemptive/abort failures

* **New Features**
  * Safer, sanitized extraction of error payloads (truncation/redaction) for diagnostics
  * Provider attempts now include provider-specific metadata where available

* **Tests**
  * Updated tests to reflect new terminal-stream error handling and provider metadata extraction

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->