### PR TITLE
[codex] Combine free request limits

### DIFF
--- a/app/components/RateLimitWarning.tsx
+++ b/app/components/RateLimitWarning.tsx
@@ -73,8 +73,8 @@ const formatTimeUntil = (resetTime: Date): string => {
 const getMessage = (data: RateLimitWarningData, timeString: string): string => {
   if (data.warningType === "sliding-window") {
     return data.remaining === 0
-      ? `You've used all your daily responses. Daily responses reset at midnight UTC.`
-      : `You have ${data.remaining} daily ${data.remaining === 1 ? "response" : "responses"} remaining today.`;
+      ? `You've used all your daily requests. Daily requests reset at midnight UTC.`
+      : `You have ${data.remaining} daily ${data.remaining === 1 ? "request" : "requests"} remaining today.`;
   }
 
   if (data.warningType === "extra-usage-active") {

--- a/lib/rate-limit/__tests__/index.test.ts
+++ b/lib/rate-limit/__tests__/index.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 
 describe("checkRateLimit", () => {
-  const mockLimitFn = jest.fn();
+  const mockEvalFn = jest.fn();
   const mockCheckTokenBucketLimit = jest.fn();
   const mockCreateRedisClient = jest.fn();
 
@@ -17,11 +17,7 @@ describe("checkRateLimit", () => {
     jest.clearAllMocks();
 
     // Default mock responses
-    mockLimitFn.mockResolvedValue({
-      success: true,
-      remaining: 5,
-      reset: Date.now() + 3600000,
-    });
+    mockEvalFn.mockResolvedValue([1, 5]);
 
     mockCheckTokenBucketLimit.mockResolvedValue({
       remaining: 5000,
@@ -35,15 +31,6 @@ describe("checkRateLimit", () => {
     let isolatedModule: typeof import("../index");
 
     jest.isolateModules(() => {
-      const MockRatelimit = jest.fn().mockImplementation(() => ({
-        limit: mockLimitFn,
-      }));
-      (MockRatelimit as any).fixedWindow = jest.fn().mockReturnValue({});
-
-      jest.doMock("@upstash/ratelimit", () => ({
-        Ratelimit: MockRatelimit,
-      }));
-
       jest.doMock("../redis", () => ({
         createRedisClient: mockCreateRedisClient,
       }));
@@ -64,14 +51,18 @@ describe("checkRateLimit", () => {
   };
 
   describe("free users", () => {
-    it("should use free agent rate limit for free users in agent mode", async () => {
+    it("should use the shared free rate limit with cost 2 in agent mode", async () => {
       const { checkRateLimit } = getIsolatedModule();
 
-      mockCreateRedisClient.mockReturnValue({});
+      mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
 
       const result = await checkRateLimit("user-123", "agent", "free", 0);
 
-      expect(mockLimitFn).toHaveBeenCalled();
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.any(String),
+        [expect.stringMatching(/^free_limit:user-123:free:\d+$/)],
+        [10, 2, expect.any(Number)],
+      );
       expect(mockCheckTokenBucketLimit).not.toHaveBeenCalled();
       expect(result.remaining).toBe(5);
     });
@@ -79,11 +70,15 @@ describe("checkRateLimit", () => {
     it("should use sliding window for free users in ask mode", async () => {
       const { checkRateLimit } = getIsolatedModule();
 
-      mockCreateRedisClient.mockReturnValue({});
+      mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
 
       const result = await checkRateLimit("user-123", "ask", "free", 0);
 
-      expect(mockLimitFn).toHaveBeenCalled();
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.any(String),
+        [expect.stringMatching(/^free_limit:user-123:free:\d+$/)],
+        [10, 1, expect.any(Number)],
+      );
       expect(mockCheckTokenBucketLimit).not.toHaveBeenCalled();
       expect(result.remaining).toBe(5);
     });
@@ -102,18 +97,14 @@ describe("checkRateLimit", () => {
     it("should throw rate limit error when free limit exceeded", async () => {
       const { checkRateLimit } = getIsolatedModule();
 
-      mockCreateRedisClient.mockReturnValue({});
-      mockLimitFn.mockResolvedValue({
-        success: false,
-        remaining: 0,
-        reset: Date.now() + 3600000,
-      });
+      mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
+      mockEvalFn.mockResolvedValue([0, 0]);
 
       try {
         await checkRateLimit("user-123", "ask", "free", 0);
         expect.fail("Should have thrown");
       } catch (error: any) {
-        expect(error.cause).toContain("daily responses");
+        expect(error.cause).toContain("daily requests");
         expect(error.cause).toContain("Upgrade plan");
       }
     });

--- a/lib/rate-limit/__tests__/sliding-window.test.ts
+++ b/lib/rate-limit/__tests__/sliding-window.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 
 describe("sliding-window", () => {
-  const mockLimitFn = jest.fn();
+  const mockEvalFn = jest.fn();
   const mockCreateRedisClient = jest.fn();
 
   beforeEach(() => {
@@ -14,26 +14,13 @@ describe("sliding-window", () => {
     jest.clearAllMocks();
 
     // Default mock responses
-    mockLimitFn.mockResolvedValue({
-      success: true,
-      remaining: 5,
-      reset: Date.now() + 3600000,
-    });
+    mockEvalFn.mockResolvedValue([1, 5]);
   });
 
   const getIsolatedModule = () => {
     let isolatedModule: typeof import("../sliding-window");
 
     jest.isolateModules(() => {
-      const MockRatelimit = jest.fn().mockImplementation(() => ({
-        limit: mockLimitFn,
-      }));
-      (MockRatelimit as any).fixedWindow = jest.fn().mockReturnValue({});
-
-      jest.doMock("@upstash/ratelimit", () => ({
-        Ratelimit: MockRatelimit,
-      }));
-
       jest.doMock("../redis", () => ({
         createRedisClient: mockCreateRedisClient,
       }));
@@ -54,35 +41,35 @@ describe("sliding-window", () => {
       expect(result.remaining).toBe(10);
       expect(result.limit).toBe(10);
       expect(result.rateLimitSkipped).toBe(true);
-      expect(mockLimitFn).not.toHaveBeenCalled();
+      expect(mockEvalFn).not.toHaveBeenCalled();
     });
 
     it("should use fixed window for free users", async () => {
       const { checkFreeUserRateLimit } = getIsolatedModule();
 
-      mockCreateRedisClient.mockReturnValue({});
+      mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
 
       const result = await checkFreeUserRateLimit("user-123");
 
-      expect(mockLimitFn).toHaveBeenCalled();
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.any(String),
+        [expect.stringMatching(/^free_limit:user-123:free:\d+$/)],
+        [10, 1, expect.any(Number)],
+      );
       expect(result.remaining).toBe(5);
     });
 
     it("should throw ChatSDKError when rate limit exceeded", async () => {
       const { checkFreeUserRateLimit } = getIsolatedModule();
 
-      mockCreateRedisClient.mockReturnValue({});
-      mockLimitFn.mockResolvedValue({
-        success: false,
-        remaining: 0,
-        reset: Date.now() + 3600000,
-      });
+      mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
+      mockEvalFn.mockResolvedValue([0, 0]);
 
       try {
         await checkFreeUserRateLimit("user-123");
         expect.fail("Should have thrown");
       } catch (error: any) {
-        expect(error.cause).toContain("daily responses");
+        expect(error.cause).toContain("daily requests");
         expect(error.cause).toContain("midnight UTC");
         expect(error.cause).toContain("Upgrade plan");
       }
@@ -91,8 +78,8 @@ describe("sliding-window", () => {
     it("should throw ChatSDKError on Redis errors", async () => {
       const { checkFreeUserRateLimit } = getIsolatedModule();
 
-      mockCreateRedisClient.mockReturnValue({});
-      mockLimitFn.mockRejectedValue(new Error("Redis connection failed"));
+      mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
+      mockEvalFn.mockRejectedValue(new Error("Redis connection failed"));
 
       try {
         await checkFreeUserRateLimit("user-123");
@@ -111,40 +98,40 @@ describe("sliding-window", () => {
       mockCreateRedisClient.mockReturnValue(null);
 
       const result = await checkFreeAgentRateLimit("user-123");
-      expect(result.remaining).toBe(5);
-      expect(result.limit).toBe(5);
+      expect(result.remaining).toBe(10);
+      expect(result.limit).toBe(10);
       expect(result.rateLimitSkipped).toBe(true);
-      expect(mockLimitFn).not.toHaveBeenCalled();
+      expect(mockEvalFn).not.toHaveBeenCalled();
     });
 
-    it("should use fixed window for free agent users", async () => {
+    it("should use the shared fixed window with a cost of 2", async () => {
       const { checkFreeAgentRateLimit } = getIsolatedModule();
 
-      mockCreateRedisClient.mockReturnValue({});
+      mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
 
       const result = await checkFreeAgentRateLimit("user-123");
 
-      expect(mockLimitFn).toHaveBeenCalled();
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.any(String),
+        [expect.stringMatching(/^free_limit:user-123:free:\d+$/)],
+        [10, 2, expect.any(Number)],
+      );
       expect(result.remaining).toBe(5);
     });
 
-    it("should throw ChatSDKError when agent rate limit exceeded", async () => {
+    it("should throw ChatSDKError when the shared free limit is exceeded", async () => {
       const { checkFreeAgentRateLimit } = getIsolatedModule();
 
-      mockCreateRedisClient.mockReturnValue({});
-      mockLimitFn.mockResolvedValue({
-        success: false,
-        remaining: 0,
-        reset: Date.now() + 3600000,
-      });
+      mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
+      mockEvalFn.mockResolvedValue([0, 1]);
 
       try {
         await checkFreeAgentRateLimit("user-123");
         expect.fail("Should have thrown");
       } catch (error: any) {
-        expect(error.cause).toContain("daily agent responses");
+        expect(error.cause).toContain("daily requests");
         expect(error.cause).toContain("midnight UTC");
-        expect(error.cause).toContain("Upgrade to Pro");
+        expect(error.cause).toContain("Upgrade plan");
       }
     });
   });

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -10,9 +10,10 @@
  *    - Supports extra usage (prepaid balance) when limits exceeded
  *
  * 2. Fixed Window (Free users):
- *    - Simple request counting within a daily fixed window (resets at midnight UTC)
- *    - Ask mode: 10/day (FREE_RATE_LIMIT_REQUESTS)
- *    - Agent mode (local sandbox only): 5/day (FREE_AGENT_RATE_LIMIT_REQUESTS)
+ *    - Shared request-unit counting within a daily fixed window (resets at midnight UTC)
+ *    - Ask mode costs 1 unit
+ *    - Agent mode (local sandbox only) costs 2 units
+ *    - Default free budget: 10 units/day (FREE_RATE_LIMIT_REQUESTS)
  */
 
 import { isAgentMode } from "@/lib/utils/mode-helpers";
@@ -86,7 +87,7 @@ export const checkRateLimit = async (
   // Free users: fixed daily window
   if (subscription === "free") {
     if (isAgentMode(mode)) {
-      // Free agent mode (local sandbox only) has a separate daily budget
+      // Free agent mode shares the daily free budget and consumes 2 units.
       return checkFreeAgentRateLimit(userId);
     }
     return checkFreeUserRateLimit(userId);

--- a/lib/rate-limit/sliding-window.ts
+++ b/lib/rate-limit/sliding-window.ts
@@ -1,25 +1,104 @@
 /**
  * Fixed Window Rate Limiting (Free Users)
  *
- * Simple request counting within a daily fixed window (resets at midnight UTC).
+ * Simple request-unit counting within a daily fixed window (resets at midnight UTC).
  * Used only for free users - paid users use token bucket (cost-based).
  */
 
-import { Ratelimit } from "@upstash/ratelimit";
 import { ChatSDKError } from "@/lib/errors";
 import type { RateLimitInfo } from "@/types";
 import { createRedisClient } from "./redis";
 
+const FREE_RATE_LIMIT_REQUESTS_DEFAULT = 10;
+const FREE_ASK_REQUEST_COST = 1;
+const FREE_AGENT_REQUEST_COST = 2;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+// Upstash fixedWindow supports `{ rate: 2 }`, but failed multi-unit calls are
+// counted before failure is returned. This checks capacity before incrementing
+// so a blocked agent request cannot consume the last ask unit.
+const CONSUME_FREE_REQUEST_UNITS_SCRIPT = `
+local key = KEYS[1]
+local requestLimit = tonumber(ARGV[1])
+local requestCost = tonumber(ARGV[2])
+local ttlMs = tonumber(ARGV[3])
+local used = tonumber(redis.call("GET", key) or "0")
+local remaining = requestLimit - used
+
+if requestCost > requestLimit or remaining < requestCost then
+  return {0, remaining}
+end
+
+local nextUsed = redis.call("INCRBY", key, requestCost)
+if nextUsed == requestCost then
+  redis.call("PEXPIRE", key, ttlMs)
+end
+
+return {1, requestLimit - nextUsed}
+`;
+
+const getFreeRequestLimit = (): number => {
+  const configuredLimit = parseInt(
+    process.env.FREE_RATE_LIMIT_REQUESTS || "",
+    10,
+  );
+  return Number.isFinite(configuredLimit) && configuredLimit > 0
+    ? configuredLimit
+    : FREE_RATE_LIMIT_REQUESTS_DEFAULT;
+};
+
+const getCurrentUtcDayWindow = () => {
+  const now = Date.now();
+  const bucket = Math.floor(now / ONE_DAY_MS);
+  const reset = (bucket + 1) * ONE_DAY_MS;
+  return {
+    bucket,
+    reset,
+    ttlMs: Math.max(1, reset - now),
+  };
+};
+
+const consumeFreeRequestUnits = async ({
+  redis,
+  userId,
+  requestLimit,
+  requestCost,
+  bucket,
+  ttlMs,
+}: {
+  redis: NonNullable<ReturnType<typeof createRedisClient>>;
+  userId: string;
+  requestLimit: number;
+  requestCost: number;
+  bucket: number;
+  ttlMs: number;
+}) => {
+  const rateLimitKey = `free_limit:${userId}:free:${bucket}`;
+  const result = (await redis.eval(
+    CONSUME_FREE_REQUEST_UNITS_SCRIPT,
+    [rateLimitKey],
+    [requestLimit, requestCost, ttlMs],
+  )) as [number | string, number | string];
+
+  return {
+    success: Number(result[0]) === 1,
+    remaining: Math.max(0, Number(result[1])),
+  };
+};
+
 /**
- * Check rate limit for free users using a fixed daily window.
+ * Check rate limit for free users using a fixed daily request-unit window.
  * Resets at midnight UTC each day.
  */
 export const checkFreeUserRateLimit = async (
   userId: string,
+  requestCost = FREE_ASK_REQUEST_COST,
 ): Promise<RateLimitInfo> => {
   const redis = createRedisClient();
 
-  const requestLimit = parseInt(process.env.FREE_RATE_LIMIT_REQUESTS || "10");
+  const requestLimit = getFreeRequestLimit();
+  const cost = Math.max(1, Math.trunc(requestCost));
+  const { bucket, reset, ttlMs } = getCurrentUtcDayWindow();
 
   if (!redis) {
     if (process.env.NODE_ENV !== "production") {
@@ -38,19 +117,19 @@ export const checkFreeUserRateLimit = async (
   }
 
   try {
-    const ratelimit = new Ratelimit({
+    const { success, remaining } = await consumeFreeRequestUnits({
       redis,
-      limiter: Ratelimit.fixedWindow(requestLimit, "1 d"),
-      prefix: "free_limit",
+      userId,
+      requestLimit,
+      requestCost: cost,
+      bucket,
+      ttlMs,
     });
-
-    const rateLimitKey = `${userId}:free`;
-    const { success, reset, remaining } = await ratelimit.limit(rateLimitKey);
 
     if (!success) {
       throw new ChatSDKError(
         "rate_limit:chat",
-        `You've used all your daily responses. Daily responses reset at midnight UTC.\n\nUpgrade plan for higher usage limits and more features.`,
+        `You've used all your daily requests. Daily requests reset at midnight UTC.\n\nUpgrade plan for higher usage limits and more features.`,
       );
     }
 
@@ -70,60 +149,11 @@ export const checkFreeUserRateLimit = async (
 
 /**
  * Check rate limit for free users in agent mode (local sandbox only).
- * Separate daily budget from ask mode. Resets at midnight UTC.
+ * Shares the free daily request-unit budget with ask mode. Agent requests cost
+ * 2 units, so the default 10-unit budget still allows up to 5 agent requests.
  */
 export const checkFreeAgentRateLimit = async (
   userId: string,
 ): Promise<RateLimitInfo> => {
-  const redis = createRedisClient();
-
-  const requestLimit = parseInt(
-    process.env.FREE_AGENT_RATE_LIMIT_REQUESTS || "5",
-  );
-
-  if (!redis) {
-    if (process.env.NODE_ENV !== "production") {
-      // Skip rate limiting in local dev/test when Redis is not configured
-      return {
-        remaining: requestLimit,
-        resetTime: new Date(Date.now() + 24 * 60 * 60 * 1000),
-        limit: requestLimit,
-        rateLimitSkipped: true,
-      };
-    }
-    throw new ChatSDKError(
-      "rate_limit:chat",
-      "Rate limiting service is not configured",
-    );
-  }
-
-  try {
-    const ratelimit = new Ratelimit({
-      redis,
-      limiter: Ratelimit.fixedWindow(requestLimit, "1 d"),
-      prefix: "free_agent_limit",
-    });
-
-    const rateLimitKey = `${userId}:free_agent`;
-    const { success, reset, remaining } = await ratelimit.limit(rateLimitKey);
-
-    if (!success) {
-      throw new ChatSDKError(
-        "rate_limit:chat",
-        `You've used all your daily agent responses. Daily responses reset at midnight UTC.\n\nUpgrade to Pro for higher limits and cloud sandbox access.`,
-      );
-    }
-
-    return {
-      remaining,
-      resetTime: new Date(reset),
-      limit: requestLimit,
-    };
-  } catch (error) {
-    if (error instanceof ChatSDKError) throw error;
-    throw new ChatSDKError(
-      "rate_limit:chat",
-      `Rate limiting service unavailable: ${error instanceof Error ? error.message : "Unknown error"}`,
-    );
-  }
+  return checkFreeUserRateLimit(userId, FREE_AGENT_REQUEST_COST);
 };

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -549,8 +549,8 @@ export const resetRateLimitBuckets = async (
  * Namespaces (keep in sync with key builders in this file and sliding-window.ts):
  *   - usage:monthly:<userId>:*       — monthly token bucket (any tier)
  *   - upgrade:carryover:<userId>     — upgrade proration stash
- *   - free_limit:<userId>:*          — free-tier ask sliding window
- *   - free_agent_limit:<userId>:*    — free-tier agent sliding window
+ *   - free_limit:<userId>:*          — free-tier shared ask/agent sliding window
+ *   - free_agent_limit:<userId>:*    — legacy free-tier agent sliding window
  *   - team:debt_applied:*:<userId>   — seat-debt idempotency flag (org-scoped)
  *
  * Deliberately NOT included: team:removed_usage:<orgId> (org counter, not

--- a/lib/utils/stream-writer-utils.ts
+++ b/lib/utils/stream-writer-utils.ts
@@ -95,7 +95,7 @@ export const findSummarizationInsertIndex = (
 // Unified rate limit warning data types
 export type RateLimitWarningData =
   | {
-      // Free users: sliding window (remaining count)
+      // Free users: sliding window (remaining request units)
       warningType: "sliding-window";
       remaining: number;
       resetTime: string;

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -62,10 +62,11 @@ If Redis is not configured, rate limiting is automatically disabled in local dev
 
 Two different strategies are used based on subscription tier:
 
-**Free tier — Fixed daily window (resets at midnight UTC):**
+**Free tier — Shared fixed daily request window (resets at midnight UTC):**
 
-- Ask mode: 10 requests per day (configure via `FREE_RATE_LIMIT_REQUESTS`)
-- Agent mode (local sandbox only): 5 requests per day (configure via `FREE_AGENT_RATE_LIMIT_REQUESTS`)
+- 10 request units per day (configure via `FREE_RATE_LIMIT_REQUESTS`)
+- Ask mode costs 1 unit
+- Agent mode (local sandbox only) costs 2 units, so the default budget allows up to 5 agent requests
 
 **Paid tiers — Cost-based token bucket (monthly, shared across all modes):**
 


### PR DESCRIPTION
## Summary

Combines the free ask and free agent daily limits into one shared request-unit bucket. Ask mode now costs 1 unit and agent mode costs 2 units, preserving the previous max of 5 free agent requests within the default 10-unit daily budget.

## Why

Free users previously had separate daily buckets for ask and agent. This makes the quota easier to reason about while still making agent usage more expensive than ask usage.

## Implementation notes

- Uses one `free_limit` Redis namespace for both modes.
- Keeps consumption atomic with a small Redis script so an agent request with only 1 unit remaining is rejected without consuming that last ask unit.
- Updates warning copy and docs from daily responses/separate agent quota to shared daily requests.
- Leaves deletion cleanup aware of legacy `free_agent_limit` keys so old counters can still be purged.

## Validation

- `pnpm test -- lib/rate-limit/__tests__ --runInBand`
- `pnpm typecheck`
- Pre-commit hook also ran full Jest: 85 suites, 1096 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated rate limit warning messages to clarify "daily requests" instead of "daily responses."

* **Documentation**
  * Refined free-tier rate limiting documentation: Ask and Agent modes now share a unified daily request budget (10 units/day), where Ask costs 1 unit and Agent costs 2 units per request.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->