### PR TITLE
[codex] Improve agent-long startup latency

### DIFF
--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -27,6 +27,7 @@ import {
 export const maxDuration = 30;
 
 export async function POST(req: NextRequest) {
+  const routeStartedAt = Date.now();
   try {
     const {
       messages,
@@ -133,6 +134,14 @@ export async function POST(req: NextRequest) {
     const triggerTags = [`user_${userId}`, `chat_${chatId}`];
     if (subscription !== "free") triggerTags.push(`sub_${subscription}`);
 
+    // Persisted chats are rehydrated from Convex inside the task after the
+    // route saves the latest user message. Avoid sending the same history
+    // through Trigger unless the task cannot rehydrate it, or the route has
+    // prepared desktop-local attachment tags that only exist in this payload.
+    const messagesForPayload =
+      temporary || localDesktopAttachmentsPrepared ? messagesForTrigger : [];
+
+    const triggerRequestedAt = Date.now();
     const handle = await tasks.trigger<typeof agentLongTask>(
       "agent-long",
       {
@@ -140,7 +149,7 @@ export async function POST(req: NextRequest) {
         userId,
         subscription,
         organizationId,
-        messages: messagesForTrigger,
+        messages: messagesForPayload,
         localDesktopAttachmentsPrepared,
         baseTodos: Array.isArray(todos) ? todos : [],
         sandboxPreference,
@@ -151,6 +160,10 @@ export async function POST(req: NextRequest) {
         regenerate,
         isNewChat,
         convexUrl: process.env.NEXT_PUBLIC_CONVEX_URL,
+        requestTiming: {
+          routeStartedAt,
+          triggerRequestedAt,
+        },
       },
       {
         tags: triggerTags,
@@ -160,20 +173,39 @@ export async function POST(req: NextRequest) {
           userId,
           subscription,
           loginRequired: false,
+          routeStartedAt,
+          triggerRequestedAt,
+          triggerPayloadMessageCount: messagesForPayload.length,
         },
       },
     );
 
-    if (!temporary) {
-      await setActiveTriggerRun({ chatId, triggerRunId: handle.id });
-    }
+    const triggerCompletedAt = Date.now();
 
     // Public access token scoped to this run only — the client uses it to
     // subscribe to the realtime stream without ever seeing TRIGGER_SECRET_KEY.
-    const publicAccessToken = await auth.createPublicToken({
-      scopes: { read: { runs: [handle.id] } },
-      // 6h is enough to cover the 1h max task duration plus reconnect grace.
-      expirationTime: "6h",
+    // Updating Convex with the active run id is independent, so overlap both
+    // network calls before returning the handle to the browser.
+    const [publicAccessToken] = await Promise.all([
+      auth.createPublicToken({
+        scopes: { read: { runs: [handle.id] } },
+        // 6h is enough to cover the 1h max task duration plus reconnect grace.
+        expirationTime: "6h",
+      }),
+      temporary
+        ? Promise.resolve(null)
+        : setActiveTriggerRun({ chatId, triggerRunId: handle.id }),
+    ]);
+
+    console.info("[/api/agent-long] started trigger run", {
+      chatId,
+      runId: handle.id,
+      routeDurationMs: Date.now() - routeStartedAt,
+      triggerDurationMs: triggerCompletedAt - triggerRequestedAt,
+      triggerPayloadMessageCount: messagesForPayload.length,
+      persistedMessageCount: messagesForPersistence.length,
+      temporary: !!temporary,
+      localDesktopAttachmentsPrepared,
     });
 
     return NextResponse.json({

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -110,6 +110,23 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(routeSrc).toMatch(/loginRequired:\s*false/);
   });
 
+  test("persisted chats send a trimmed Trigger payload and retain attachment exceptions", () => {
+    expect(routeSrc).toMatch(
+      /const messagesForPayload\s*=\s*temporary\s*\|\|\s*localDesktopAttachmentsPrepared\s*\?\s*messagesForTrigger\s*:\s*\[\]/s,
+    );
+    expect(routeSrc).toMatch(/messages:\s*messagesForPayload/);
+  });
+
+  test("public token creation and active run persistence are overlapped", () => {
+    const parallelIdx = routeSrc.indexOf("await Promise.all([");
+    const tokenIdx = routeSrc.indexOf("auth.createPublicToken", parallelIdx);
+    const activeRunIdx = routeSrc.indexOf("setActiveTriggerRun", parallelIdx);
+
+    expect(parallelIdx).toBeGreaterThan(-1);
+    expect(tokenIdx).toBeGreaterThan(parallelIdx);
+    expect(activeRunIdx).toBeGreaterThan(parallelIdx);
+  });
+
   test("handled user rate limits are returned after the UI error chunk is flushed", () => {
     const waitIdx = taskSrc.indexOf("await waitUntilComplete()");
     const streamErrorIdx = taskSrc.indexOf("if (terminalStreamError)", waitIdx);

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -433,6 +433,10 @@ export type AgentLongPayload = {
   regenerate?: boolean;
   isNewChat?: boolean;
   convexUrl?: string;
+  requestTiming?: {
+    routeStartedAt: number;
+    triggerRequestedAt: number;
+  };
 };
 
 export const agentLongTask = task({
@@ -504,7 +508,19 @@ export const agentLongTask = task({
     if (subscription !== "free") await tags.add(`sub_${subscription}`);
 
     // Lifecycle metadata so the dashboard shows progress for long runs.
-    metadata.set("status", "setup").set("chatId", chatId);
+    metadata
+      .set("status", "setup")
+      .set("chatId", chatId)
+      .set("triggerPayloadMessageCount", messages.length);
+    if (payload.requestTiming) {
+      metadata
+        .set("routeStartedAt", payload.requestTiming.routeStartedAt)
+        .set("triggerRequestedAt", payload.requestTiming.triggerRequestedAt)
+        .set(
+          "taskStartLatencyMs",
+          taskStartTime - payload.requestTiming.triggerRequestedAt,
+        );
+    }
 
     const usageRefundTracker = new UsageRefundTracker();
     usageRefundTracker.setUser(userId, subscription, organizationId);
@@ -533,19 +549,20 @@ export const agentLongTask = task({
     let streamPiped = false;
 
     try {
-      const userCustomization = await getUserCustomization({ userId });
-
       // Re-fetch from DB so we have fileTokens for summarization.
       // The route already saved the user message; newMessages:[] avoids duplicates.
-      const fetched = await getMessagesByChatId({
-        chatId,
-        userId,
-        subscription,
-        newMessages: [],
-        regenerate,
-        isTemporary: temporary,
-        mode,
-      });
+      const [userCustomization, fetched] = await Promise.all([
+        getUserCustomization({ userId }),
+        getMessagesByChatId({
+          chatId,
+          userId,
+          subscription,
+          newMessages: [],
+          regenerate,
+          isTemporary: temporary,
+          mode,
+        }),
+      ]);
       const { chat, fileTokens } = fetched;
       const truncatedMessages = fetched.truncatedMessages;
 
@@ -1409,7 +1426,10 @@ export const agentLongTask = task({
         },
       });
 
-      metadata.set("status", "streaming").set("model", selectedModel);
+      metadata
+        .set("status", "streaming")
+        .set("model", selectedModel)
+        .set("setupBeforeStreamMs", Date.now() - taskStartTime);
       const { waitUntilComplete } = agentUiStream.pipe(uiStream);
       streamPiped = true;
       await waitUntilComplete();


### PR DESCRIPTION
## Summary

- Trim Trigger.dev payloads for persisted agent-long chats so the task rehydrates persisted history from Convex instead of receiving duplicate message history.
- Overlap public token creation with active Trigger run persistence after task creation.
- Add Trigger metadata for startup timing and payload size, and parallelize initial task-side customization/message fetches.
- Add structural regression coverage for payload trimming and overlapped route work.

## Impact

This should reduce startup overhead for normal persisted agent-long chats and make remaining latency easier to diagnose in Trigger.dev metadata.

## Validation

- `pnpm jest lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `pnpm exec prettier --check app/api/agent-long/route.ts trigger/agent-long.ts lib/api/__tests__/agent-long-contracts.test.ts`
- `pnpm exec eslint app/api/agent-long/route.ts trigger/agent-long.ts lib/api/__tests__/agent-long-contracts.test.ts`

Full `pnpm exec tsc --noEmit --pretty false` is currently blocked by stale `.next/dev/types` imports for missing routes under `app/admin/economics`, `app/api/admin/economics`, and `app/api/analytics/attribution`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized concurrent execution for token creation and run tracking, reducing latency.
  * Enhanced database query efficiency through concurrent data fetching.

* **Monitoring & Instrumentation**
  * Added comprehensive timing measurements to track request lifecycle and task startup latency.
  * Expanded internal metadata logging for better operational insights.

* **Tests**
  * Added contract tests for payload handling and concurrent operation validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->