### PR TITLE
[codex] Fix trigger agent long provider error classification

### DIFF
--- a/convex/__tests__/messages.hidden.test.ts
+++ b/convex/__tests__/messages.hidden.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import type { Id } from "../_generated/dataModel";
+import { ConvexError } from "convex/values";
 
 jest.mock("../_generated/server", () => ({
   mutation: jest.fn((config: any) => config),
@@ -168,6 +169,36 @@ describe("saveMessage — is_hidden handling", () => {
       "messages",
       expect.objectContaining({ is_hidden: true }),
     );
+  });
+
+  it("skips assistant inserts when the chat was deleted before save", async () => {
+    setupExistingMessage(null);
+    mockCtx.runQuery.mockRejectedValue(
+      new ConvexError({
+        code: "CHAT_NOT_FOUND",
+        message: "This chat doesn't exist",
+      }),
+    );
+
+    const { saveMessage } = await import("../messages");
+
+    await expect(
+      saveMessage.handler(mockCtx, {
+        serviceKey: SERVICE_KEY,
+        id: "msg-assistant",
+        chatId: CHAT_ID,
+        userId: USER_ID,
+        role: "assistant" as const,
+        parts: [{ type: "text", text: "done" }],
+        finishReason: "preemptive-timeout",
+      }),
+    ).resolves.toBeNull();
+
+    expect(mockCtx.db.insert).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("convex_message_save_skipped_chat_not_found"),
+    );
+    expect(console.error).not.toHaveBeenCalled();
   });
 });
 

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -80,6 +80,15 @@ const getConvexErrorData = (error: unknown): Value | undefined => {
   return data === undefined ? undefined : (data as Value);
 };
 
+const getConvexErrorCode = (data: Value | undefined): string | undefined => {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return undefined;
+  }
+
+  const code = (data as Record<string, unknown>).code;
+  return typeof code === "string" ? code : undefined;
+};
+
 /**
  * Helper function to check if deleted messages invalidate the chat summary
  * Clears latest_summary_id if the summary's cutoff message was deleted
@@ -414,6 +423,36 @@ export const saveMessage = mutation({
       return null;
     } catch (error) {
       const causeData = getConvexErrorData(error);
+      if (
+        failureStage === "verify_chat_ownership" &&
+        args.role === "assistant" &&
+        getConvexErrorCode(causeData) === "CHAT_NOT_FOUND"
+      ) {
+        console.warn(
+          JSON.stringify({
+            level: "warn",
+            event: "convex_message_save_skipped_chat_not_found",
+            service: "convex",
+            timestamp: new Date().toISOString(),
+            db_operation: "messages.saveMessage",
+            failure_stage: failureStage,
+            chat_id: args.chatId,
+            user_id: args.userId,
+            message_id: args.id,
+            message_role: args.role,
+            mode: args.mode,
+            model: args.model,
+            finish_reason: args.finishReason,
+            update_only: args.updateOnly === true,
+            hidden: args.isHidden === true,
+            file_count: args.fileIds?.length ?? 0,
+            convex_error_code: "CHAT_NOT_FOUND",
+            ...getMessageSaveDiagnostics(args.parts),
+          }),
+        );
+        return null;
+      }
+
       console.error(
         JSON.stringify({
           level: "error",

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { EventEmitter } from "events";
-import { CentrifugoSandbox } from "../centrifugo-sandbox";
+import { CentrifugoSandbox, parseSandboxMessage } from "../centrifugo-sandbox";
 import type { CentrifugoConfig } from "../centrifugo-sandbox";
 
 // Track all created mock subscriptions and clients for assertions
@@ -99,6 +99,51 @@ describe("CentrifugoSandbox", () => {
   afterEach(() => {
     jest.useRealTimers();
     crypto.randomUUID = originalRandomUUID;
+  });
+
+  describe("parseSandboxMessage", () => {
+    it("ignores known PTY traffic without warning", () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        expect(
+          parseSandboxMessage({
+            type: "pty_create",
+            sessionId: "pty-1",
+            command: "bash",
+          }),
+        ).toBeNull();
+        expect(
+          parseSandboxMessage({
+            type: "pty_data",
+            sessionId: "pty-1",
+            data: "hello",
+          }),
+        ).toBeNull();
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("still warns for truly unknown message types", () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        expect(
+          parseSandboxMessage({
+            type: "something_else",
+            commandId: FIXED_UUID,
+          }),
+        ).toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+          "Invalid sandbox message: unknown type",
+          "something_else",
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
   });
 
   describe("commands.run happy path", () => {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -20,13 +20,30 @@ const VALID_MESSAGE_TYPES = new Set([
   "error",
 ]);
 
-function parseSandboxMessage(data: unknown): CommandResponseMessage | null {
+const IGNORED_MESSAGE_TYPES = new Set([
+  "pty_create",
+  "pty_input",
+  "pty_resize",
+  "pty_kill",
+  "pty_ready",
+  "pty_data",
+  "pty_exit",
+  "pty_error",
+]);
+
+export function parseSandboxMessage(
+  data: unknown,
+): CommandResponseMessage | null {
   if (typeof data !== "object" || data === null) {
     console.warn("Invalid sandbox message: not an object", data);
     return null;
   }
 
   const msg = data as Record<string, unknown>;
+
+  if (typeof msg.type === "string" && IGNORED_MESSAGE_TYPES.has(msg.type)) {
+    return null;
+  }
 
   if (typeof msg.type !== "string" || !VALID_MESSAGE_TYPES.has(msg.type)) {
     console.warn("Invalid sandbox message: unknown type", msg.type);

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, jest } from "@jest/globals";
 (globalThis as any).Headers = class Headers {};
 
 const {
+  createChatLogger,
   captureAgentRun,
   captureToolCalls,
   captureUsageCost,
@@ -163,5 +164,45 @@ describe("captureUsageCost", () => {
         }),
       }),
     });
+  });
+});
+
+describe("createChatLogger provider stream termination", () => {
+  it("logs terminated provider streams as warnings and suppresses duplicate unexpected route errors", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_terminated",
+        endpoint: "/api/agent",
+      });
+      const err = Object.assign(new TypeError("terminated"), {
+        cause: "other side closed",
+      });
+
+      chatLogger.recordProviderError(err, {
+        mode: "agent",
+        model: "agent-model",
+        requestedModelSlug: "moonshotai/kimi-k2.6:exacto",
+      });
+      chatLogger.emitUnexpectedError(err);
+
+      const warnOutput = warnSpy.mock.calls.flat().map(String).join("\n");
+      const errorOutput = errorSpy.mock.calls.flat().map(String).join("\n");
+      const wideEvents = logSpy.mock.calls.flat().map(String).join("\n");
+
+      expect(warnOutput).toContain("Provider stream terminated");
+      expect(warnOutput).toContain("provider_stream_terminated");
+      expect(errorOutput).not.toContain("Unexpected error in chat route");
+      expect(errorOutput).not.toContain("Provider streaming error");
+      expect(wideEvents).toContain('"type":"ProviderStreamTerminated"');
+      expect(wideEvents).toContain('"category":"stream_terminated"');
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+      logSpy.mockRestore();
+    }
   });
 });

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -10,6 +10,7 @@ const {
   captureToolCalls,
   captureUsageCost,
 } = require("../chat-logger");
+const { ChatSDKError } = require("../../errors");
 
 describe("captureToolCalls", () => {
   it("aggregates repeated tool calls by tool before sending PostHog events", () => {
@@ -202,6 +203,66 @@ describe("createChatLogger provider stream termination", () => {
     } finally {
       warnSpy.mockRestore();
       errorSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+});
+
+describe("createChatLogger ChatSDKError metadata", () => {
+  it("keeps wide event error metadata compact and drops bulky nested diagnostics", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_missing",
+        endpoint: "/api/agent",
+      });
+      const err = new ChatSDKError(
+        "not_found:chat",
+        "Chat no longer exists while saving message",
+        {
+          db_operation: "messages.saveMessage",
+          db_error_name: "ConvexError",
+          db_error_message: "[Request ID: abc] Server Error",
+          db_error_code: "CHAT_NOT_FOUND",
+          db_failure_stage: "verify_chat_ownership",
+          db_error_data: {
+            code: "MESSAGE_SAVE_FAILED",
+            causeData: {
+              code: "CHAT_NOT_FOUND",
+              message: "This chat doesn't exist",
+            },
+          },
+          part_types: {
+            reasoning: 90,
+            "tool-run_terminal_cmd": 74,
+          },
+          usage_keys: ["inputTokens", "outputTokens"],
+          parts_size_bytes: 564266,
+          parts_size_kb: 551,
+          part_count: 288,
+          tool_part_count: 99,
+        },
+      );
+
+      chatLogger.emitChatError(err);
+
+      const wideEvent = JSON.parse(String(logSpy.mock.calls[0][0]));
+      expect(wideEvent.error.metadata).toEqual({
+        db_operation: "messages.saveMessage",
+        db_error_name: "ConvexError",
+        db_error_message: "[Request ID: abc] Server Error",
+        db_error_code: "CHAT_NOT_FOUND",
+        db_failure_stage: "verify_chat_ownership",
+        parts_size_kb: 551,
+        part_count: 288,
+        tool_part_count: 99,
+      });
+      expect(wideEvent.error.metadata).not.toHaveProperty("db_error_data");
+      expect(wideEvent.error.metadata).not.toHaveProperty("part_types");
+      expect(wideEvent.error.metadata).not.toHaveProperty("usage_keys");
+      expect(wideEvent.error.metadata).not.toHaveProperty("parts_size_bytes");
+    } finally {
       logSpy.mockRestore();
     }
   });

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -310,4 +310,38 @@ describe("createChatLogger provider stream timeout", () => {
       logSpy.mockRestore();
     }
   });
+
+  it("uses nested provider status codes in wide events", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_provider_code",
+        endpoint: "/api/agent",
+      });
+      const err = {
+        message: "Provider request failed",
+        responseBody: JSON.stringify({
+          error: {
+            code: 502,
+            message: "Provider overloaded",
+          },
+        }),
+      };
+
+      chatLogger.recordProviderError(err, {
+        mode: "agent",
+        model: "agent-model",
+      });
+      chatLogger.emitUnexpectedError(err);
+
+      const wideEvent = JSON.parse(String(logSpy.mock.calls[0][0]));
+      expect(wideEvent.status_code).toBe(502);
+      expect(wideEvent.provider_error.status_code).toBe(502);
+    } finally {
+      warnSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
 });

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -206,3 +206,47 @@ describe("createChatLogger provider stream termination", () => {
     }
   });
 });
+
+describe("createChatLogger provider stream timeout", () => {
+  it("logs upstream idle timeouts as provider timeout warnings with the provider message", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_timeout",
+        endpoint: "/api/agent",
+      });
+      const err = {
+        code: 502,
+        message: "Upstream idle timeout exceeded",
+      };
+
+      chatLogger.recordProviderError(err, {
+        mode: "agent",
+        model: "agent-model",
+        requestedModelSlug: "moonshotai/kimi-k2.6:exacto",
+      });
+      chatLogger.emitUnexpectedError(err);
+
+      const warnOutput = warnSpy.mock.calls.flat().map(String).join("\n");
+      const errorOutput = errorSpy.mock.calls.flat().map(String).join("\n");
+      const wideEvents = logSpy.mock.calls.flat().map(String).join("\n");
+
+      expect(warnOutput).toContain("Provider stream timeout");
+      expect(warnOutput).toContain('"provider_error_category":"timeout"');
+      expect(errorOutput).not.toContain("Unexpected error in chat route");
+      expect(errorOutput).not.toContain("Provider streaming error");
+      expect(wideEvents).toContain('"type":"ProviderTimeout"');
+      expect(wideEvents).toContain(
+        '"message":"Upstream idle timeout exceeded"',
+      );
+      expect(wideEvents).toContain('"retriable":true');
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -94,7 +94,18 @@ const providerErrorEventName = (category: ProviderErrorCategory): string =>
 const providerErrorMessage = (category: ProviderErrorCategory): string =>
   category === "stream_terminated"
     ? "Provider stream terminated"
-    : "Provider streaming error";
+    : category === "timeout"
+      ? "Provider stream timeout"
+      : "Provider streaming error";
+
+const providerWideErrorType = (
+  category: ProviderErrorCategory | undefined,
+): string => {
+  if (category === "stream_terminated") return "ProviderStreamTerminated";
+  if (category === "timeout") return "ProviderTimeout";
+  if (category) return "ProviderError";
+  return "UnexpectedError";
+};
 
 const isRetriableProviderCategory = (
   category: ProviderErrorCategory,
@@ -317,7 +328,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
         ...(attempts && { provider_attempts: attempts }),
       };
 
-      if (category === "stream_terminated") {
+      if (category === "stream_terminated" || category === "timeout") {
         logger.warn(providerErrorMessage(category), logContext);
       } else {
         logger.error(
@@ -338,7 +349,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
         ...(attempts && { provider_attempts: attempts }),
       };
 
-      if (category === "stream_terminated") {
+      if (category === "stream_terminated" || category === "timeout") {
         phLogger.warn(providerErrorMessage(category), phContext);
       } else {
         phLogger.error(providerErrorMessage(category), {
@@ -422,10 +433,23 @@ export function createChatLogger(config: ChatLoggerConfig) {
      * provider errors.
      */
     emitUnexpectedError(error: unknown) {
+      const details = extractErrorDetails(error);
+      const inferredProviderCategory = getProviderErrorCategory(details);
+      const providerCategory =
+        lastProviderErrorCategory ??
+        (inferredProviderCategory !== "unknown"
+          ? inferredProviderCategory
+          : undefined);
       const message =
-        error instanceof Error ? error.message : "Unknown error occurred";
+        (typeof details.errorMessage === "string" &&
+          details.errorMessage !== "undefined" &&
+          details.errorMessage) ||
+        (typeof details.providerErrorMessage === "string"
+          ? details.providerErrorMessage
+          : undefined) ||
+        "Unknown error occurred";
 
-      if (!lastProviderErrorCategory) {
+      if (!providerCategory) {
         logger.error(
           "Unexpected error in chat route",
           error instanceof Error ? error : undefined,
@@ -434,16 +458,11 @@ export function createChatLogger(config: ChatLoggerConfig) {
       }
 
       builder.setError({
-        type:
-          lastProviderErrorCategory === "stream_terminated"
-            ? "ProviderStreamTerminated"
-            : lastProviderErrorCategory
-              ? "ProviderError"
-              : "UnexpectedError",
+        type: providerWideErrorType(providerCategory),
         message,
         statusCode: lastProviderErrorStatusCode ?? 503,
-        retriable: lastProviderErrorCategory
-          ? isRetriableProviderCategory(lastProviderErrorCategory)
+        retriable: providerCategory
+          ? isRetriableProviderCategory(providerCategory)
           : false,
       });
       logger.info(builder.build());

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -27,6 +27,7 @@ import {
   extractErrorDetails,
   extractRetryAttempts,
   getProviderErrorCategory,
+  getProviderStatusCode,
   type ProviderErrorCategory,
 } from "@/lib/utils/error-utils";
 
@@ -347,9 +348,9 @@ export function createChatLogger(config: ChatLoggerConfig) {
       const details = extractErrorDetails(error);
       const attempts = extractRetryAttempts(error);
       const category = getProviderErrorCategory(details);
+      const providerStatusCode = getProviderStatusCode(details);
       lastProviderErrorCategory = category;
-      lastProviderErrorStatusCode =
-        typeof details.statusCode === "number" ? details.statusCode : undefined;
+      lastProviderErrorStatusCode = providerStatusCode;
 
       const logContext = {
         event: providerErrorEventName(category),
@@ -394,7 +395,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
 
       builder.markProviderError({
         category,
-        statusCode: details.statusCode as number | undefined,
+        statusCode: providerStatusCode,
         url: details.providerUrl as string | undefined,
         reason: (error as { reason?: string })?.reason,
         message: details.errorMessage as string | undefined,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -26,6 +26,8 @@ import type { UsageCostRecord } from "@/lib/usage-tracker";
 import {
   extractErrorDetails,
   extractRetryAttempts,
+  getProviderErrorCategory,
+  type ProviderErrorCategory,
 } from "@/lib/utils/error-utils";
 
 export interface ChatLoggerConfig {
@@ -69,20 +71,6 @@ export interface StreamResult {
   hadSummarization: boolean;
 }
 
-function providerErrorCategory(details: Record<string, unknown>): string {
-  const statusCode =
-    typeof details.statusCode === "number" ? details.statusCode : undefined;
-  if (statusCode === 429) return "rate_limited";
-  if (statusCode != null && statusCode >= 500) return "provider_5xx";
-  if (statusCode != null && statusCode >= 400) return "provider_4xx";
-
-  const message =
-    typeof details.errorMessage === "string" ? details.errorMessage : "";
-  if (/terminated|aborted|abort/i.test(message)) return "stream_terminated";
-  if (/timeout|timed out/i.test(message)) return "timeout";
-  return "unknown";
-}
-
 function posthogProviderException(
   error: unknown,
   details: Record<string, unknown>,
@@ -98,6 +86,24 @@ function posthogProviderException(
 const truncateLogString = (value: string, maxLength = 500): string =>
   value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
 
+const providerErrorEventName = (category: ProviderErrorCategory): string =>
+  category === "stream_terminated"
+    ? "provider_stream_terminated"
+    : "provider_streaming_error";
+
+const providerErrorMessage = (category: ProviderErrorCategory): string =>
+  category === "stream_terminated"
+    ? "Provider stream terminated"
+    : "Provider streaming error";
+
+const isRetriableProviderCategory = (
+  category: ProviderErrorCategory,
+): boolean =>
+  category === "rate_limited" ||
+  category === "provider_5xx" ||
+  category === "stream_terminated" ||
+  category === "timeout";
+
 /**
  * Creates a chat logger instance for tracking wide events
  */
@@ -111,6 +117,8 @@ export function createChatLogger(config: ChatLoggerConfig) {
   let subscription: string | undefined;
   let mode: ChatMode | undefined;
   let monthlyRemainingPercent: number | undefined;
+  let lastProviderErrorCategory: ProviderErrorCategory | undefined;
+  let lastProviderErrorStatusCode: number | undefined;
 
   return {
     /**
@@ -273,8 +281,8 @@ export function createChatLogger(config: ChatLoggerConfig) {
 
     /**
      * Record a provider streaming error. Fans out to:
-     *   - Vercel runtime logs (structured JSON via logger.error)
-     *   - PostHog exception capture (phLogger.error)
+     *   - Vercel runtime logs (structured JSON via logger.warn/logger.error)
+     *   - PostHog telemetry (warnings for transport closes, exceptions for errors)
      *   - The wide event (had_provider_error + provider_error fields)
      *
      * Does NOT change outcome — emitSuccess/emitChatError still decides that.
@@ -293,24 +301,34 @@ export function createChatLogger(config: ChatLoggerConfig) {
     ) {
       const details = extractErrorDetails(error);
       const attempts = extractRetryAttempts(error);
-      const category = providerErrorCategory(details);
+      const category = getProviderErrorCategory(details);
+      lastProviderErrorCategory = category;
+      lastProviderErrorStatusCode =
+        typeof details.statusCode === "number" ? details.statusCode : undefined;
 
-      logger.error(
-        "Provider streaming error",
-        error instanceof Error ? error : undefined,
-        {
-          chat_id: config.chatId,
-          endpoint: config.endpoint,
-          provider_gateway: "openrouter",
-          provider_error_category: category,
-          ...context,
-          ...details,
-          ...(attempts && { provider_attempts: attempts }),
-        },
-      );
+      const logContext = {
+        event: providerErrorEventName(category),
+        chat_id: config.chatId,
+        endpoint: config.endpoint,
+        provider_gateway: "openrouter",
+        provider_error_category: category,
+        ...context,
+        ...details,
+        ...(attempts && { provider_attempts: attempts }),
+      };
 
-      phLogger.error("Provider streaming error", {
-        error: posthogProviderException(error, details),
+      if (category === "stream_terminated") {
+        logger.warn(providerErrorMessage(category), logContext);
+      } else {
+        logger.error(
+          providerErrorMessage(category),
+          error instanceof Error ? error : undefined,
+          logContext,
+        );
+      }
+
+      const phContext = {
+        event: providerErrorEventName(category),
         chatId: config.chatId,
         endpoint: config.endpoint,
         providerGateway: "openrouter",
@@ -318,9 +336,19 @@ export function createChatLogger(config: ChatLoggerConfig) {
         ...context,
         ...details,
         ...(attempts && { provider_attempts: attempts }),
-      });
+      };
+
+      if (category === "stream_terminated") {
+        phLogger.warn(providerErrorMessage(category), phContext);
+      } else {
+        phLogger.error(providerErrorMessage(category), {
+          error: posthogProviderException(error, details),
+          ...phContext,
+        });
+      }
 
       builder.markProviderError({
+        category,
         statusCode: details.statusCode as number | undefined,
         url: details.providerUrl as string | undefined,
         reason: (error as { reason?: string })?.reason,
@@ -390,23 +418,33 @@ export function createChatLogger(config: ChatLoggerConfig) {
     },
 
     /**
-     * Finalize and emit error event for unexpected errors
+     * Finalize and emit error event for unexpected or previously recorded
+     * provider errors.
      */
     emitUnexpectedError(error: unknown) {
       const message =
         error instanceof Error ? error.message : "Unknown error occurred";
 
-      logger.error(
-        "Unexpected error in chat route",
-        error instanceof Error ? error : undefined,
-        { chatId: config.chatId },
-      );
+      if (!lastProviderErrorCategory) {
+        logger.error(
+          "Unexpected error in chat route",
+          error instanceof Error ? error : undefined,
+          { event: "chat_route_unexpected_error", chatId: config.chatId },
+        );
+      }
 
       builder.setError({
-        type: "UnexpectedError",
+        type:
+          lastProviderErrorCategory === "stream_terminated"
+            ? "ProviderStreamTerminated"
+            : lastProviderErrorCategory
+              ? "ProviderError"
+              : "UnexpectedError",
         message,
-        statusCode: 503,
-        retriable: false,
+        statusCode: lastProviderErrorStatusCode ?? 503,
+        retriable: lastProviderErrorCategory
+          ? isRetriableProviderCategory(lastProviderErrorCategory)
+          : false,
       });
       logger.info(builder.build());
     },

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -86,6 +86,40 @@ function posthogProviderException(
 const truncateLogString = (value: string, maxLength = 500): string =>
   value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
 
+const COMPACT_CHAT_ERROR_METADATA_KEYS = [
+  "db_operation",
+  "db_error_name",
+  "db_error_message",
+  "db_error_code",
+  "db_failure_stage",
+  "finish_reason",
+  "message_role",
+  "mode",
+  "parts_size_kb",
+  "part_count",
+  "largest_part_type",
+  "largest_part_size_kb",
+  "tool_part_count",
+  "data_part_count",
+  "reasoning_chars",
+  "was_aborted",
+  "was_preemptive_timeout",
+] as const;
+
+const compactChatErrorMetadata = (
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined => {
+  if (!metadata) return undefined;
+
+  const compact: Record<string, unknown> = {};
+  for (const key of COMPACT_CHAT_ERROR_METADATA_KEYS) {
+    const value = metadata[key];
+    if (value !== undefined) compact[key] = value;
+  }
+
+  return Object.keys(compact).length > 0 ? compact : undefined;
+};
+
 const providerErrorEventName = (category: ProviderErrorCategory): string =>
   category === "stream_terminated"
     ? "provider_stream_terminated"
@@ -398,7 +432,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
         cause,
         statusCode: error.statusCode,
         retriable: error.type === "rate_limit",
-        metadata: error.metadata,
+        metadata: compactChatErrorMetadata(error.metadata),
       });
       logger.info(builder.build());
 

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -179,6 +179,38 @@ const truncateDiagnosticString = (value: string): string =>
     ? `${value.slice(0, MAX_DATABASE_ERROR_MESSAGE_LENGTH)}...`
     : value;
 
+const getObjectString = (value: unknown, key: string): string | undefined => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const child = (value as Record<string, unknown>)[key];
+  return typeof child === "string" ? child : undefined;
+};
+
+const getNestedObject = (
+  value: unknown,
+  key: string,
+): Record<string, unknown> | undefined => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const child = (value as Record<string, unknown>)[key];
+  return child && typeof child === "object" && !Array.isArray(child)
+    ? (child as Record<string, unknown>)
+    : undefined;
+};
+
+const getDatabaseErrorCode = (data: unknown): string | undefined =>
+  getObjectString(data, "code") ??
+  getObjectString(getNestedObject(data, "causeData"), "code");
+
+const isChatNotFoundMessageSaveError = (
+  operation: string,
+  dbErrorData: unknown,
+): boolean =>
+  operation === "messages.saveMessage" &&
+  getDatabaseErrorCode(dbErrorData) === "CHAT_NOT_FOUND";
+
 const databaseError = (
   operation: string,
   error: unknown,
@@ -186,27 +218,39 @@ const databaseError = (
 ) => {
   const dbErrorName = error instanceof Error ? error.name : typeof error;
   const dbErrorMessage = truncateDiagnosticString(stringifyError(error));
+  const dbErrorData = getErrorData(error);
+  const isChatNotFound = isChatNotFoundMessageSaveError(operation, dbErrorData);
   const diagnosticMetadata = {
     db_operation: operation,
     db_error_name: dbErrorName,
     db_error_message: dbErrorMessage,
-    db_error_data: getErrorData(error),
+    db_error_data: dbErrorData,
+    db_error_code: getDatabaseErrorCode(dbErrorData),
     ...metadata,
   };
 
-  console.error(
-    JSON.stringify({
-      level: "error",
-      event: "database_operation_failed",
-      service: "chat-handler",
-      timestamp: new Date().toISOString(),
-      ...diagnosticMetadata,
-    }),
-  );
+  const logPayload = {
+    level: isChatNotFound ? "warn" : "error",
+    event: isChatNotFound
+      ? "database_operation_skipped_chat_not_found"
+      : "database_operation_failed",
+    service: "chat-handler",
+    timestamp: new Date().toISOString(),
+    ...diagnosticMetadata,
+  };
+
+  const logLine = JSON.stringify(logPayload);
+  if (isChatNotFound) {
+    console.warn(logLine);
+  } else {
+    console.error(logLine);
+  }
 
   return new ChatSDKError(
-    "bad_request:database",
-    `Database operation failed: ${operation}: ${dbErrorMessage}`,
+    isChatNotFound ? "not_found:chat" : "bad_request:database",
+    isChatNotFound
+      ? `Chat no longer exists while saving message: ${operation}: ${dbErrorMessage}`
+      : `Database operation failed: ${operation}: ${dbErrorMessage}`,
     diagnosticMetadata,
   );
 };

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -204,6 +204,9 @@ const getDatabaseErrorCode = (data: unknown): string | undefined =>
   getObjectString(data, "code") ??
   getObjectString(getNestedObject(data, "causeData"), "code");
 
+const getDatabaseFailureStage = (data: unknown): string | undefined =>
+  getObjectString(data, "failureStage");
+
 const isChatNotFoundMessageSaveError = (
   operation: string,
   dbErrorData: unknown,
@@ -226,6 +229,7 @@ const databaseError = (
     db_error_message: dbErrorMessage,
     db_error_data: dbErrorData,
     db_error_code: getDatabaseErrorCode(dbErrorData),
+    db_failure_stage: getDatabaseFailureStage(dbErrorData),
     ...metadata,
   };
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -174,6 +174,7 @@ export interface ChatWideEvent {
   // one where the model leg died and we recovered (fallback, partial output).
   had_provider_error?: boolean;
   provider_error?: {
+    category?: string;
     status_code?: number;
     url?: string;
     reason?: string;
@@ -534,6 +535,7 @@ export class WideEventBuilder {
    * outcome — call setSuccess/setError separately based on overall result.
    */
   markProviderError(details: {
+    category?: string;
     statusCode?: number;
     url?: string;
     reason?: string;
@@ -543,6 +545,7 @@ export class WideEventBuilder {
   }): this {
     this.event.had_provider_error = true;
     this.event.provider_error = {
+      category: details.category,
       status_code: details.statusCode,
       url: details.url,
       reason: details.reason,

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -227,4 +227,13 @@ describe("provider error classification", () => {
       "provider_5xx",
     );
   });
+
+  it("classifies upstream idle timeouts without an HTTP status as provider timeouts", () => {
+    const err = {
+      code: 502,
+      message: "Upstream idle timeout exceeded",
+    };
+
+    expect(getProviderErrorCategory(extractErrorDetails(err))).toBe("timeout");
+  });
 });

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -3,6 +3,7 @@ import {
   extractErrorDetails,
   extractRetryAttempts,
   getProviderErrorCategory,
+  getProviderStatusCode,
   isProviderStreamTerminatedError,
 } from "../error-utils";
 
@@ -233,6 +234,36 @@ describe("provider error classification", () => {
       code: 502,
       message: "Upstream idle timeout exceeded",
     };
+
+    expect(getProviderErrorCategory(extractErrorDetails(err))).toBe("timeout");
+  });
+
+  it("uses nested provider status codes when direct HTTP status is missing", () => {
+    const err = apiCallError({
+      statusCode: undefined,
+      responseBody: JSON.stringify({
+        error: {
+          code: 502,
+          message: "Provider overloaded",
+        },
+      }),
+    });
+
+    const details = extractErrorDetails(err);
+    expect(getProviderStatusCode(details)).toBe(502);
+    expect(getProviderErrorCategory(details)).toBe("provider_5xx");
+  });
+
+  it("classifies provider-specific messages when the top-level message is generic", () => {
+    const err = apiCallError({
+      statusCode: undefined,
+      message: "Provider request failed",
+      responseBody: JSON.stringify({
+        error: {
+          message: "Upstream idle timeout exceeded",
+        },
+      }),
+    });
 
     expect(getProviderErrorCategory(extractErrorDetails(err))).toBe("timeout");
   });

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -254,6 +254,22 @@ describe("provider error classification", () => {
     expect(getProviderErrorCategory(details)).toBe("provider_5xx");
   });
 
+  it("uses numeric string provider status codes when direct HTTP status is missing", () => {
+    const err = apiCallError({
+      statusCode: undefined,
+      responseBody: JSON.stringify({
+        error: {
+          code: "502",
+          message: "Provider overloaded",
+        },
+      }),
+    });
+
+    const details = extractErrorDetails(err);
+    expect(getProviderStatusCode(details)).toBe(502);
+    expect(getProviderErrorCategory(details)).toBe("provider_5xx");
+  });
+
   it("classifies provider-specific messages when the top-level message is generic", () => {
     const err = apiCallError({
       statusCode: undefined,

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "@jest/globals";
-import { extractErrorDetails, extractRetryAttempts } from "../error-utils";
+import {
+  extractErrorDetails,
+  extractRetryAttempts,
+  getProviderErrorCategory,
+  isProviderStreamTerminatedError,
+} from "../error-utils";
 
 const apiCallError = (overrides: Record<string, unknown>) =>
   Object.assign(new Error("Internal Server Error"), {
@@ -197,5 +202,29 @@ describe("extractRetryAttempts -> request_id", () => {
 
   it("returns undefined when error has no errors[] array", () => {
     expect(extractRetryAttempts(new Error("nope"))).toBeUndefined();
+  });
+});
+
+describe("provider error classification", () => {
+  it("classifies undici terminated errors as provider stream termination", () => {
+    const err = Object.assign(new TypeError("terminated"), {
+      cause: "other side closed",
+    });
+
+    expect(getProviderErrorCategory(extractErrorDetails(err))).toBe(
+      "stream_terminated",
+    );
+    expect(isProviderStreamTerminatedError(err)).toBe(true);
+  });
+
+  it("classifies provider status codes before message patterns", () => {
+    const err = apiCallError({
+      statusCode: 503,
+      message: "terminated",
+    });
+
+    expect(getProviderErrorCategory(extractErrorDetails(err))).toBe(
+      "provider_5xx",
+    );
   });
 });

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -196,6 +196,33 @@ export const extractErrorDetails = (
   return details;
 };
 
+export type ProviderErrorCategory =
+  | "rate_limited"
+  | "provider_5xx"
+  | "provider_4xx"
+  | "stream_terminated"
+  | "timeout"
+  | "unknown";
+
+export const getProviderErrorCategory = (
+  details: Record<string, unknown>,
+): ProviderErrorCategory => {
+  const statusCode =
+    typeof details.statusCode === "number" ? details.statusCode : undefined;
+  if (statusCode === 429) return "rate_limited";
+  if (statusCode != null && statusCode >= 500) return "provider_5xx";
+  if (statusCode != null && statusCode >= 400) return "provider_4xx";
+
+  const message =
+    typeof details.errorMessage === "string" ? details.errorMessage : "";
+  if (/terminated|aborted|abort/i.test(message)) return "stream_terminated";
+  if (/timeout|timed out/i.test(message)) return "timeout";
+  return "unknown";
+};
+
+export const isProviderStreamTerminatedError = (error: unknown): boolean =>
+  getProviderErrorCategory(extractErrorDetails(error)) === "stream_terminated";
+
 export interface ProviderAttempt {
   status_code?: number;
   message: string;

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -211,11 +211,15 @@ export const getProviderStatusCode = (
     typeof details.statusCode === "number" ? details.statusCode : undefined;
   if (statusCode != null) return statusCode;
 
+  const rawProviderErrorCode = details.providerErrorCode;
   const providerErrorCode =
-    typeof details.providerErrorCode === "number"
-      ? details.providerErrorCode
-      : undefined;
+    typeof rawProviderErrorCode === "number"
+      ? rawProviderErrorCode
+      : typeof rawProviderErrorCode === "string"
+        ? Number(rawProviderErrorCode)
+        : undefined;
   return providerErrorCode != null &&
+    Number.isInteger(providerErrorCode) &&
     providerErrorCode >= 400 &&
     providerErrorCode <= 599
     ? providerErrorCode

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -204,17 +204,40 @@ export type ProviderErrorCategory =
   | "timeout"
   | "unknown";
 
+export const getProviderStatusCode = (
+  details: Record<string, unknown>,
+): number | undefined => {
+  const statusCode =
+    typeof details.statusCode === "number" ? details.statusCode : undefined;
+  if (statusCode != null) return statusCode;
+
+  const providerErrorCode =
+    typeof details.providerErrorCode === "number"
+      ? details.providerErrorCode
+      : undefined;
+  return providerErrorCode != null &&
+    providerErrorCode >= 400 &&
+    providerErrorCode <= 599
+    ? providerErrorCode
+    : undefined;
+};
+
 export const getProviderErrorCategory = (
   details: Record<string, unknown>,
 ): ProviderErrorCategory => {
-  const statusCode =
-    typeof details.statusCode === "number" ? details.statusCode : undefined;
+  const statusCode = getProviderStatusCode(details);
   if (statusCode === 429) return "rate_limited";
   if (statusCode != null && statusCode >= 500) return "provider_5xx";
   if (statusCode != null && statusCode >= 400) return "provider_4xx";
 
-  const message =
-    typeof details.errorMessage === "string" ? details.errorMessage : "";
+  const message = [
+    details.errorMessage,
+    details.providerErrorMessage,
+    details.providerRawError,
+    details.cause,
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ");
   if (/terminated|aborted|abort/i.test(message)) return "stream_terminated";
   if (/timeout|timed out/i.test(message)) return "timeout";
   return "unknown";

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -251,6 +251,12 @@ const getTerminalProviderStreamError = (
   );
 };
 
+const isTerminalProviderStreamError = (
+  state:
+    | Pick<AgentStreamState, "streamFinishReason" | "providerError">
+    | undefined,
+): boolean => state?.streamFinishReason === "error";
+
 const recordAgentLongFailureForDashboard = async (
   error: unknown,
   context: {
@@ -1117,15 +1123,21 @@ export const agentLongTask = task({
                               mode,
                               subscription,
                               sandboxInfo,
-                              outcome: retryAborted ? "aborted" : "success",
+                              outcome: retryAborted
+                                ? "aborted"
+                                : isTerminalProviderStreamError(state)
+                                  ? "error"
+                                  : "success",
                             });
-                            chatLogger?.emitSuccess({
-                              finishReason: state.streamFinishReason,
-                              wasAborted: retryAborted,
-                              wasPreemptiveTimeout: false,
-                              hadSummarization:
-                                summarizationTracker.hasSummarized,
-                            });
+                            if (!isTerminalProviderStreamError(state)) {
+                              chatLogger?.emitSuccess({
+                                finishReason: state.streamFinishReason,
+                                wasAborted: retryAborted,
+                                wasPreemptiveTimeout: false,
+                                hadSummarization:
+                                  summarizationTracker.hasSummarized,
+                              });
+                            }
 
                             const generatedTitle = await titlePromise;
                             if (!temporary) {
@@ -1223,14 +1235,20 @@ export const agentLongTask = task({
                     mode,
                     subscription,
                     sandboxInfo,
-                    outcome: isAborted ? "aborted" : "success",
+                    outcome: isAborted
+                      ? "aborted"
+                      : isTerminalProviderStreamError(state)
+                        ? "error"
+                        : "success",
                   });
-                  chatLogger?.emitSuccess({
-                    finishReason: state.streamFinishReason,
-                    wasAborted: isAborted,
-                    wasPreemptiveTimeout: state.stoppedDueToElapsedTimeout,
-                    hadSummarization: summarizationTracker.hasSummarized,
-                  });
+                  if (!isTerminalProviderStreamError(state)) {
+                    chatLogger?.emitSuccess({
+                      finishReason: state.streamFinishReason,
+                      wasAborted: isAborted,
+                      wasPreemptiveTimeout: state.stoppedDueToElapsedTimeout,
+                      hadSummarization: summarizationTracker.hasSummarized,
+                    });
+                  }
 
                   const generatedTitle = await titlePromise;
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -167,6 +167,13 @@ const isHandledUserRateLimitError = (error: unknown): error is ChatSDKError => {
   );
 };
 
+const isChatNotFoundError = (error: ChatSDKError): boolean => {
+  if (error.type === "not_found" && error.surface === "chat") return true;
+  return (
+    getStringMetadata(error.metadata, "db_error_code") === "CHAT_NOT_FOUND"
+  );
+};
+
 const classifyProviderDashboardCategory = (
   error: unknown,
   details: Record<string, unknown>,
@@ -196,7 +203,12 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
         : undefined;
     const errorMetadata = error.metadata;
     return {
-      category: error.type === "unauthorized" ? "login_required" : "chat_error",
+      category:
+        error.type === "unauthorized"
+          ? "login_required"
+          : isChatNotFoundError(error)
+            ? "chat_not_found"
+            : "chat_error",
       code,
       name: "ChatSDKError",
       message: errorMessage,
@@ -267,8 +279,10 @@ const recordAgentLongFailureForDashboard = async (
   },
 ) => {
   const summary = classifyAgentLongError(error);
+  const runStatus =
+    summary.category === "chat_not_found" ? "chat_not_found" : "failed";
   metadata
-    .set("status", "failed")
+    .set("status", runStatus)
     .set("errorCategory", summary.category)
     .set("errorName", summary.name)
     .set("errorMessage", summary.message)
@@ -304,13 +318,21 @@ const recordAgentLongFailureForDashboard = async (
   }
   await tags.add(errorTags);
 
-  triggerLogger.error("[agent-long] run failed", {
+  const logFields = {
     chatId: context.chatId,
     userId: context.userId,
     runId: context.runId,
     phase: context.phase,
     ...summary,
-  });
+  };
+  if (summary.category === "chat_not_found") {
+    triggerLogger.warn("[agent-long] run ended because chat is missing", {
+      ...logFields,
+      status: runStatus,
+    });
+  } else {
+    triggerLogger.error("[agent-long] run failed", logFields);
+  }
 
   await metadata.flush();
 };
@@ -1475,6 +1497,10 @@ export const agentLongTask = task({
       metadata.set("status", "done");
       await phLogger.flush().catch(() => {});
     } catch (error) {
+      const chatMissingAfterStream =
+        streamPiped &&
+        error instanceof ChatSDKError &&
+        isChatNotFoundError(error);
       await recordAgentLongFailureForDashboard(error, {
         chatId,
         userId,
@@ -1498,6 +1524,11 @@ export const agentLongTask = task({
         .catch((err) =>
           console.error("[agent-long] PTY closeAll (outer catch) failed:", err),
         );
+
+      if (chatMissingAfterStream) {
+        await phLogger.flush().catch(() => {});
+        return { chatId, assistantMessageId };
+      }
 
       // Pre-stream setup failed (DB fetch, message processing, etc.). Emit a
       // one-shot UI stream whose onError converts the caught error into the

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -76,6 +76,7 @@ import {
 import { phLogger } from "@/lib/posthog/server";
 import {
   extractErrorDetails,
+  getProviderErrorCategory,
   getUserFriendlyProviderError,
 } from "@/lib/utils/error-utils";
 import { ChatSDKError } from "@/lib/errors";
@@ -166,6 +167,19 @@ const isHandledUserRateLimitError = (error: unknown): error is ChatSDKError => {
   );
 };
 
+const classifyProviderDashboardCategory = (
+  error: unknown,
+  details: Record<string, unknown>,
+): string => {
+  const category = getProviderErrorCategory(details);
+  if (category === "stream_terminated") return "provider_stream_terminated";
+  if (category === "timeout") return "provider_timeout";
+  if (category !== "unknown" || isProviderApiError(error)) {
+    return "provider_error";
+  }
+  return "unexpected_error";
+};
+
 const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
   const details = extractErrorDetails(error);
   const errorMessage = truncateForTriggerMetadata(
@@ -206,7 +220,7 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
   }
 
   return {
-    category: isProviderApiError(error) ? "provider_error" : "unexpected_error",
+    category: classifyProviderDashboardCategory(error, details),
     code: typeof details.errorCode === "string" ? details.errorCode : undefined,
     name:
       typeof details.errorName === "string"


### PR DESCRIPTION
## Summary

- Classify provider stream termination errors consistently across chat logging and Trigger.dev agent-long run metadata.
- Downgrade `TypeError("terminated")` provider transport closes to warning-level `provider_stream_terminated` telemetry instead of duplicate generic route errors.
- Preserve a single wide request event with `ProviderStreamTerminated`, `provider_error.category`, and retriable metadata.
- Add regression coverage for undici `terminated` errors and chat logger output.

## Root Cause

Provider transport closures during streaming were recorded by the provider error path, then later surfaced again through the outer catch as `UnexpectedError` / `unexpected_error`. That made upstream stream termination look like an application bug and produced duplicate error noise.

## Validation

- `pnpm jest lib/utils/__tests__/error-utils.test.ts lib/api/__tests__/chat-logger.test.ts --runInBand`
- `pnpm exec prettier --check lib/utils/error-utils.ts lib/api/chat-logger.ts lib/logger.ts trigger/agent-long.ts lib/utils/__tests__/error-utils.test.ts lib/api/__tests__/chat-logger.test.ts`
- `pnpm exec tsc --noEmit --pretty false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip saving assistant messages when a chat is missing and emit a warning instead of failing.
  * Reduce noisy errors by better detecting and categorizing provider stream terminations and timeouts.

* **New Features**
  * Exported sandbox message parser now ignores PTY-related messages.

* **Tests**
  * Added tests for chat-deleted save behavior, provider error classification/logging, and sandbox message parsing.

* **Chores**
  * Improved error categorization, structured logging, telemetry, and wide-event provider error metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->