### PR TITLE
[codex] fix free user cost controls

### DIFF
--- a/app/components/RateLimitWarning.tsx
+++ b/app/components/RateLimitWarning.tsx
@@ -84,6 +84,9 @@ const getMessage = (data: RateLimitWarningData, timeString: string): string => {
   // Token bucket warning — show dollar amounts when available
   if (data.remainingPercent === 0) {
     if (data.cutOff) {
+      if (data.subscription === "free") {
+        return `You've reached your free monthly usage limit and this response was cut off. Upgrade to continue. Resets ${timeString}.`;
+      }
       return `You've reached your monthly limit and this response was cut off. Add credits or upgrade to continue. Resets ${timeString}.`;
     }
     return `You've reached your monthly usage limit. It resets ${timeString}.`;

--- a/lib/__tests__/token-utils.test.ts
+++ b/lib/__tests__/token-utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  getMaxTokensForSubscription,
+  MAX_TOKENS_FREE,
+  MAX_TOKENS_PAID,
+} from "@/lib/token-utils";
+
+describe("getMaxTokensForSubscription", () => {
+  it("uses the 128k cap for free users", () => {
+    expect(MAX_TOKENS_FREE).toBe(128000);
+    expect(getMaxTokensForSubscription("free")).toBe(128000);
+  });
+
+  it("uses the paid cap for paid users and unknown subscriptions", () => {
+    expect(getMaxTokensForSubscription("pro")).toBe(MAX_TOKENS_PAID);
+    expect(getMaxTokensForSubscription("pro-plus")).toBe(MAX_TOKENS_PAID);
+    expect(getMaxTokensForSubscription("ultra")).toBe(MAX_TOKENS_PAID);
+    expect(getMaxTokensForSubscription("team")).toBe(MAX_TOKENS_PAID);
+    expect(getMaxTokensForSubscription()).toBe(MAX_TOKENS_PAID);
+  });
+});

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -49,8 +49,9 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "model-deepseek-v4-flash": or("deepseek/deepseek-v4-flash"),
     "model-opus-4.6": or("anthropic/claude-opus-4.6"),
     "model-kimi-k2.6": or("moonshotai/kimi-k2.6:exacto"),
-    "fallback-agent-model": or("x-ai/grok-4.3"),
-    "fallback-ask-model": or("x-ai/grok-4.3"),
+    "fallback-agent-model": or("google/gemini-3-flash-preview"),
+    "fallback-ask-model": or("google/gemini-3-flash-preview"),
+    "fallback-grok-4.3": or("x-ai/grok-4.3"),
     "title-generator-model": or("deepseek/deepseek-v4-flash"),
   }) as Record<string, any>;
 
@@ -69,8 +70,9 @@ export const modelCutoffDates: Record<ModelName, string> &
   "model-deepseek-v4-flash": "May 2025",
   "model-opus-4.6": "May 2025",
   "model-kimi-k2.6": "April 2024",
-  "fallback-agent-model": "December 2025",
-  "fallback-ask-model": "December 2025",
+  "fallback-agent-model": "January 2025",
+  "fallback-ask-model": "January 2025",
+  "fallback-grok-4.3": "December 2025",
   "title-generator-model": "May 2025",
 };
 
@@ -87,6 +89,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-kimi-k2.6": "Moonshot Kimi K2.6",
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
   "fallback-ask-model": "Auto, an intelligent model router built by HackerAI",
+  "fallback-grok-4.3": "Auto, an intelligent model router built by HackerAI",
   "title-generator-model":
     "Auto, an intelligent model router built by HackerAI",
 };
@@ -109,6 +112,10 @@ export function isDeepSeekModel(modelName: string): boolean {
     modelName === "agent-model-free" ||
     modelName === "model-deepseek-v4-flash"
   );
+}
+
+export function isGeminiModel(modelName: string): boolean {
+  return modelName === "ask-model" || modelName === "model-gemini-3-flash";
 }
 
 /**

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -20,6 +20,7 @@ jest.mock("@/lib/logger", () => ({
 // If the registry slug for a model changes, update both places intentionally.
 const KIMI_SLUG = "moonshotai/kimi-k2.6:exacto";
 const GEMINI_SLUG = "google/gemini-3-flash-preview";
+const GROK_SLUG = "x-ai/grok-4.3";
 
 describe("buildProviderOptions fallback chain", () => {
   it("resolves Opus 4.6 ask chain to Gemini slug", () => {
@@ -69,17 +70,20 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("keeps fallback for free auto agent model", () => {
+  it("falls back from free DeepSeek agent model to Gemini", () => {
     const opts = buildProviderOptions(false, "user-1", "agent-model-free");
     expect(opts.openrouter).toMatchObject({
-      models: ["x-ai/grok-4.3"],
+      models: [GEMINI_SLUG],
       user: "user-1",
     });
   });
 
-  it("emits no `models` field for a model without a chain entry", () => {
+  it("falls back from Gemini to Grok", () => {
     const opts = buildProviderOptions(false, "user-1", "model-gemini-3-flash");
-    expect(opts.openrouter).not.toHaveProperty("models");
+    expect(opts.openrouter).toMatchObject({
+      models: [GROK_SLUG],
+      user: "user-1",
+    });
   });
 
   it("does not throw for an unknown registry key — no chain, no slug", () => {

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -170,6 +170,7 @@ export async function createAgentStream(
 ) {
   const requestedLanguageModel = ctx.trackedProvider.languageModel(modelName);
   const requestedSlug = requestedLanguageModel.modelId;
+  const maxOutputTokens = ctx.subscription === "free" ? 4096 : 30000;
   const prepareProviderMessages = (
     messages: ModelMessage[],
   ): ModelMessage[] => {
@@ -190,7 +191,7 @@ export async function createAgentStream(
 
   return streamText({
     model: requestedLanguageModel,
-    maxOutputTokens: 30000,
+    maxOutputTokens,
     system: buildSystemPrompt(ctx.currentSystemPrompt, modelName),
     messages: prepareProviderMessages(
       await convertToModelMessages(state.finalMessages),

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -53,6 +53,7 @@ import {
   pruneModelMessages,
 } from "@/lib/chat/compaction/prune-tool-outputs";
 import { isAnthropicModel } from "@/lib/ai/providers";
+import { FREE_MAX_OUTPUT_TOKENS } from "@/lib/rate-limit/free-config";
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { getMaxTokensForSubscription } from "@/lib/token-utils";
 import { SUMMARIZATION_THRESHOLD_PERCENTAGE } from "@/lib/chat/summarization/constants";
@@ -170,7 +171,8 @@ export async function createAgentStream(
 ) {
   const requestedLanguageModel = ctx.trackedProvider.languageModel(modelName);
   const requestedSlug = requestedLanguageModel.modelId;
-  const maxOutputTokens = ctx.subscription === "free" ? 4096 : 30000;
+  const maxOutputTokens =
+    ctx.subscription === "free" ? FREE_MAX_OUTPUT_TOKENS : 30000;
   const prepareProviderMessages = (
     messages: ModelMessage[],
   ): ModelMessage[] => {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -786,600 +786,621 @@ export const createChatHandler = (
                   }
                 },
                 onFinish: async ({ messages, isAborted }) => {
-                  // Check if stream finished with only step-start (indicates incomplete response)
-                  const lastAssistantMessage = messages
-                    .slice()
-                    .reverse()
-                    .find((m) => m.role === "assistant");
-                  const hasOnlyStepStart =
-                    lastAssistantMessage?.parts?.length === 1 &&
-                    lastAssistantMessage.parts[0]?.type === "step-start";
+                  let retryScheduled = false;
+                  try {
+                    // Check if stream finished with only step-start (indicates incomplete response)
+                    const lastAssistantMessage = messages
+                      .slice()
+                      .reverse()
+                      .find((m) => m.role === "assistant");
+                    const hasOnlyStepStart =
+                      lastAssistantMessage?.parts?.length === 1 &&
+                      lastAssistantMessage.parts[0]?.type === "step-start";
 
-                  if (hasOnlyStepStart) {
-                    phLogger.warn(
-                      "Stream finished incomplete - triggering fallback",
-                      {
-                        chatId,
-                        endpoint,
-                        mode,
-                        model: selectedModel,
-                        userId,
-                        subscription,
-                        isTemporary: temporary,
-                        messageCount: messages.length,
-                        parts: lastAssistantMessage?.parts,
-                        isRetryWithFallback,
-                        assistantMessageId,
-                      },
-                    );
+                    if (hasOnlyStepStart) {
+                      phLogger.warn(
+                        "Stream finished incomplete - triggering fallback",
+                        {
+                          chatId,
+                          endpoint,
+                          mode,
+                          model: selectedModel,
+                          userId,
+                          subscription,
+                          isTemporary: temporary,
+                          messageCount: messages.length,
+                          parts: lastAssistantMessage?.parts,
+                          isRetryWithFallback,
+                          assistantMessageId,
+                        },
+                      );
 
-                    // Retry with fallback model if not already retrying (only for auto models)
-                    if (!isRetryWithFallback && !isAborted && isAutoModel) {
-                      isRetryWithFallback = true;
-                      state.lastStepInputTokens = 0;
-                      state.stoppedDueToTokenExhaustion = false;
-                      state.stoppedDueToElapsedTimeout = false;
-                      state.stoppedDueToDoomLoop = false;
-                      state.stoppedDueToBudgetExhaustion = false;
-                      const fallbackStartTime = Date.now();
-                      preFallbackCacheRead = usageTracker.cacheReadTokens;
-                      preFallbackCacheWrite = usageTracker.cacheWriteTokens;
+                      // Retry with fallback model if not already retrying (only for auto models)
+                      if (!isRetryWithFallback && !isAborted && isAutoModel) {
+                        isRetryWithFallback = true;
+                        state.lastStepInputTokens = 0;
+                        state.stoppedDueToTokenExhaustion = false;
+                        state.stoppedDueToElapsedTimeout = false;
+                        state.stoppedDueToDoomLoop = false;
+                        state.stoppedDueToBudgetExhaustion = false;
+                        const fallbackStartTime = Date.now();
+                        preFallbackCacheRead = usageTracker.cacheReadTokens;
+                        preFallbackCacheWrite = usageTracker.cacheWriteTokens;
 
-                      // Discard the failed primary leg's model usage so the
-                      // user is only billed for the fallback. Non-model spend
-                      // (sandbox/tools) is preserved.
-                      usageTracker.resetModelLeg();
+                        // Discard the failed primary leg's model usage so the
+                        // user is only billed for the fallback. Non-model spend
+                        // (sandbox/tools) is preserved.
+                        usageTracker.resetModelLeg();
 
-                      const retryResult = await createStream(fallbackModel);
-                      const retryMessageId = generateId();
+                        const retryResult = await createStream(fallbackModel);
+                        const retryMessageId = generateId();
 
-                      writer.merge(
-                        retryResult.toUIMessageStream({
-                          generateMessageId: () => retryMessageId,
-                          messageMetadata: ({ part }) => {
-                            if (part.type === "start") {
-                              return {
-                                mode,
-                                generationStartedAt: fallbackStartTime,
-                              };
-                            }
-
-                            if (part.type === "finish") {
-                              return {
-                                mode,
-                                generationStartedAt: fallbackStartTime,
-                                generationTimeMs:
-                                  Date.now() - fallbackStartTime,
-                              };
-                            }
-                          },
-                          onFinish: async ({
-                            messages: retryMessages,
-                            isAborted: retryAborted,
-                          }) => {
-                            // Cleanup for retry
-                            preemptiveTimeout?.clear();
-                            if (!subscriberStopped) {
-                              await cancellationSubscriber.stop();
-                              subscriberStopped = true;
-                            }
-
-                            const sandboxInfo = sandboxManager.getSandboxInfo();
-                            chatLogger!.setSandbox(sandboxInfo);
-                            // Use fallback-only cache tokens (subtract pre-fallback snapshot)
-                            // so the wide event isn't mixing cumulative cache with retry-only usage
-                            const fallbackCacheRead =
-                              usageTracker.cacheReadTokens -
-                              preFallbackCacheRead;
-                            const fallbackCacheWrite =
-                              usageTracker.cacheWriteTokens -
-                              preFallbackCacheWrite;
-                            const fallbackCacheTotal =
-                              fallbackCacheRead + fallbackCacheWrite;
-                            chatLogger!.setCacheMetrics({
-                              cacheHitRate:
-                                fallbackCacheTotal > 0
-                                  ? fallbackCacheRead / fallbackCacheTotal
-                                  : null,
-                              cacheReadTokens: fallbackCacheRead,
-                              cacheWriteTokens: fallbackCacheWrite,
-                            });
-                            captureToolCalls({
-                              posthog,
-                              chatLogger,
-                              userId,
-                              mode,
-                            });
-                            captureAgentRun({
-                              posthog,
-                              userId,
-                              mode,
-                              subscription,
-                              sandboxInfo,
-                              outcome: retryAborted ? "aborted" : "success",
-                            });
-                            shutdownPostHog(posthog);
-                            chatLogger!.emitSuccess({
-                              finishReason: state.streamFinishReason,
-                              wasAborted: retryAborted,
-                              wasPreemptiveTimeout: false,
-                              hadSummarization:
-                                summarizationTracker.hasSummarized,
-                            });
-
-                            const generatedTitle = await titlePromise;
-
-                            if (!temporary) {
-                              const mergedTodos = getTodoManager().mergeWith(
-                                baseTodos,
-                                retryMessageId,
-                              );
-
-                              if (
-                                generatedTitle ||
-                                state.streamFinishReason ||
-                                mergedTodos.length > 0
-                              ) {
-                                await updateChat({
-                                  chatId,
-                                  title: generatedTitle,
-                                  finishReason: state.streamFinishReason,
-                                  todos: mergedTodos,
-                                  defaultModelSlug: mode,
-                                  sandboxType:
-                                    sandboxManager.getEffectivePreference(),
-                                  selectedModel: selectedModelOverride,
-                                });
-                              } else {
-                                await prepareForNewStream({ chatId });
+                        writer.merge(
+                          retryResult.toUIMessageStream({
+                            generateMessageId: () => retryMessageId,
+                            messageMetadata: ({ part }) => {
+                              if (part.type === "start") {
+                                return {
+                                  mode,
+                                  generationStartedAt: fallbackStartTime,
+                                };
                               }
 
-                              const accumulatedFiles =
-                                getFileAccumulator().getAll();
-                              const newFileIds = accumulatedFiles.map(
-                                (f) => f.fileId,
-                              );
-
-                              // Only save NEW assistant messages from retry (skip already-saved user messages)
-                              for (const msg of retryMessages) {
-                                if (msg.role !== "assistant") continue;
-
-                                const processed =
-                                  summarizationTracker.processMessageForSave(
-                                    msg,
-                                  );
-
-                                await saveMessage({
-                                  chatId,
-                                  userId,
-                                  message: processed,
-                                  extraFileIds: newFileIds,
-                                  usage: state.streamUsage,
-                                  model: state.responseModel,
+                              if (part.type === "finish") {
+                                return {
                                   mode,
                                   generationStartedAt: fallbackStartTime,
                                   generationTimeMs:
                                     Date.now() - fallbackStartTime,
-                                  finishReason: state.streamFinishReason,
-                                });
+                                };
                               }
+                            },
+                            onFinish: async ({
+                              messages: retryMessages,
+                              isAborted: retryAborted,
+                            }) => {
+                              try {
+                                // Cleanup for retry
+                                preemptiveTimeout?.clear();
+                                if (!subscriberStopped) {
+                                  await cancellationSubscriber.stop();
+                                  subscriberStopped = true;
+                                }
 
-                              // Send file metadata via stream for resumable stream clients
-                              sendFileMetadataToStream(accumulatedFiles);
-                            } else {
-                              // For temporary chats, send file metadata via stream before cleanup
-                              const tempFiles = getFileAccumulator().getAll();
-                              sendFileMetadataToStream(tempFiles);
+                                const sandboxInfo =
+                                  sandboxManager.getSandboxInfo();
+                                chatLogger!.setSandbox(sandboxInfo);
+                                // Use fallback-only cache tokens (subtract pre-fallback snapshot)
+                                // so the wide event isn't mixing cumulative cache with retry-only usage
+                                const fallbackCacheRead =
+                                  usageTracker.cacheReadTokens -
+                                  preFallbackCacheRead;
+                                const fallbackCacheWrite =
+                                  usageTracker.cacheWriteTokens -
+                                  preFallbackCacheWrite;
+                                const fallbackCacheTotal =
+                                  fallbackCacheRead + fallbackCacheWrite;
+                                chatLogger!.setCacheMetrics({
+                                  cacheHitRate:
+                                    fallbackCacheTotal > 0
+                                      ? fallbackCacheRead / fallbackCacheTotal
+                                      : null,
+                                  cacheReadTokens: fallbackCacheRead,
+                                  cacheWriteTokens: fallbackCacheWrite,
+                                });
+                                captureToolCalls({
+                                  posthog,
+                                  chatLogger,
+                                  userId,
+                                  mode,
+                                });
+                                captureAgentRun({
+                                  posthog,
+                                  userId,
+                                  mode,
+                                  subscription,
+                                  sandboxInfo,
+                                  outcome: retryAborted ? "aborted" : "success",
+                                });
+                                shutdownPostHog(posthog);
+                                chatLogger!.emitSuccess({
+                                  finishReason: state.streamFinishReason,
+                                  wasAborted: retryAborted,
+                                  wasPreemptiveTimeout: false,
+                                  hadSummarization:
+                                    summarizationTracker.hasSummarized,
+                                });
 
-                              // Ensure temp stream row is removed backend-side
-                              await deleteTempStreamForBackend({ chatId });
-                            }
+                                const generatedTitle = await titlePromise;
 
-                            // Verify fallback produced valid content
-                            const fallbackAssistantMessage = retryMessages
-                              .slice()
-                              .reverse()
-                              .find((m) => m.role === "assistant");
-                            const fallbackHasContent =
-                              fallbackAssistantMessage?.parts?.some(
-                                (p) =>
-                                  p.type === "text" ||
-                                  p.type?.startsWith("tool-") ||
-                                  p.type === "reasoning",
-                              ) ?? false;
-                            const fallbackPartTypes =
-                              fallbackAssistantMessage?.parts?.map(
-                                (p) => p.type,
-                              ) ?? [];
+                                if (!temporary) {
+                                  const mergedTodos =
+                                    getTodoManager().mergeWith(
+                                      baseTodos,
+                                      retryMessageId,
+                                    );
 
-                            phLogger.info("Fallback completed", {
-                              chatId,
-                              originalModel: selectedModel,
-                              originalAssistantMessageId: assistantMessageId,
-                              fallbackModel,
-                              fallbackAssistantMessageId: retryMessageId,
-                              fallbackDurationMs:
-                                Date.now() - fallbackStartTime,
-                              fallbackSuccess: fallbackHasContent,
-                              fallbackWasAborted: retryAborted,
-                              fallbackMessageCount: retryMessages.length,
-                              fallbackPartTypes,
-                              preFallbackCacheReadTokens: preFallbackCacheRead,
-                              preFallbackCacheWriteTokens:
-                                preFallbackCacheWrite,
-                              fallbackCacheReadTokens: fallbackCacheRead,
-                              fallbackCacheWriteTokens: fallbackCacheWrite,
-                              fallbackCacheHitRate:
-                                fallbackCacheTotal > 0
-                                  ? fallbackCacheRead / fallbackCacheTotal
-                                  : null,
-                              userId,
-                              subscription,
-                            });
+                                  if (
+                                    generatedTitle ||
+                                    state.streamFinishReason ||
+                                    mergedTodos.length > 0
+                                  ) {
+                                    await updateChat({
+                                      chatId,
+                                      title: generatedTitle,
+                                      finishReason: state.streamFinishReason,
+                                      todos: mergedTodos,
+                                      defaultModelSlug: mode,
+                                      sandboxType:
+                                        sandboxManager.getEffectivePreference(),
+                                      selectedModel: selectedModelOverride,
+                                    });
+                                  } else {
+                                    await prepareForNewStream({ chatId });
+                                  }
 
-                            // Deduct accumulated usage (includes both original + retry streams)
-                            await deductAccumulatedUsage();
-                          },
-                          sendReasoning: true,
-                        }),
-                      );
+                                  const accumulatedFiles =
+                                    getFileAccumulator().getAll();
+                                  const newFileIds = accumulatedFiles.map(
+                                    (f) => f.fileId,
+                                  );
 
-                      return; // Skip normal cleanup - retry handles it
-                    }
-                  }
+                                  // Only save NEW assistant messages from retry (skip already-saved user messages)
+                                  for (const msg of retryMessages) {
+                                    if (msg.role !== "assistant") continue;
 
-                  const isPreemptiveAbort =
-                    preemptiveTimeout?.isPreemptive() ?? false;
-                  const onFinishStartTime = Date.now();
-                  const triggerTime = preemptiveTimeout?.getTriggerTime();
+                                    const processed =
+                                      summarizationTracker.processMessageForSave(
+                                        msg,
+                                      );
 
-                  // Helper to log step timing during preemptive timeout
-                  const logStep = (step: string, stepStartTime: number) => {
-                    if (isPreemptiveAbort) {
-                      const stepDuration = Date.now() - stepStartTime;
-                      const totalElapsed =
-                        Date.now() - (triggerTime || onFinishStartTime);
-                      phLogger.info("Preemptive timeout cleanup step", {
-                        chatId,
-                        step,
-                        stepDurationMs: stepDuration,
-                        totalElapsedSinceTriggerMs: totalElapsed,
-                        endpoint,
-                      });
-                    }
-                  };
+                                    await saveMessage({
+                                      chatId,
+                                      userId,
+                                      message: processed,
+                                      extraFileIds: newFileIds,
+                                      usage: state.streamUsage,
+                                      model: state.responseModel,
+                                      mode,
+                                      generationStartedAt: fallbackStartTime,
+                                      generationTimeMs:
+                                        Date.now() - fallbackStartTime,
+                                      finishReason: state.streamFinishReason,
+                                    });
+                                  }
 
-                  if (isPreemptiveAbort) {
-                    phLogger.info("Preemptive timeout onFinish started", {
-                      chatId,
-                      endpoint,
-                      timeSinceTriggerMs: triggerTime
-                        ? onFinishStartTime - triggerTime
-                        : null,
-                      messageCount: messages.length,
-                      isTemporary: temporary,
-                    });
-                  }
+                                  // Send file metadata via stream for resumable stream clients
+                                  sendFileMetadataToStream(accumulatedFiles);
+                                } else {
+                                  // For temporary chats, send file metadata via stream before cleanup
+                                  const tempFiles =
+                                    getFileAccumulator().getAll();
+                                  sendFileMetadataToStream(tempFiles);
 
-                  // Clear pre-emptive timeout
-                  let stepStart = Date.now();
-                  preemptiveTimeout?.clear();
-                  logStep("clear_timeout", stepStart);
+                                  // Ensure temp stream row is removed backend-side
+                                  await deleteTempStreamForBackend({ chatId });
+                                }
 
-                  // Stop cancellation subscriber
-                  stepStart = Date.now();
-                  await cancellationSubscriber.stop();
-                  subscriberStopped = true;
-                  logStep("stop_cancellation_subscriber", stepStart);
+                                // Verify fallback produced valid content
+                                const fallbackAssistantMessage = retryMessages
+                                  .slice()
+                                  .reverse()
+                                  .find((m) => m.role === "assistant");
+                                const fallbackHasContent =
+                                  fallbackAssistantMessage?.parts?.some(
+                                    (p) =>
+                                      p.type === "text" ||
+                                      p.type?.startsWith("tool-") ||
+                                      p.type === "reasoning",
+                                  ) ?? false;
+                                const fallbackPartTypes =
+                                  fallbackAssistantMessage?.parts?.map(
+                                    (p) => p.type,
+                                  ) ?? [];
 
-                  // Clear finish reason for user-initiated aborts (not pre-emptive timeouts)
-                  // This prevents showing "going off course" message when user clicks stop
-                  if (isAborted && !isPreemptiveAbort) {
-                    state.streamFinishReason = undefined;
-                  }
+                                phLogger.info("Fallback completed", {
+                                  chatId,
+                                  originalModel: selectedModel,
+                                  originalAssistantMessageId:
+                                    assistantMessageId,
+                                  fallbackModel,
+                                  fallbackAssistantMessageId: retryMessageId,
+                                  fallbackDurationMs:
+                                    Date.now() - fallbackStartTime,
+                                  fallbackSuccess: fallbackHasContent,
+                                  fallbackWasAborted: retryAborted,
+                                  fallbackMessageCount: retryMessages.length,
+                                  fallbackPartTypes,
+                                  preFallbackCacheReadTokens:
+                                    preFallbackCacheRead,
+                                  preFallbackCacheWriteTokens:
+                                    preFallbackCacheWrite,
+                                  fallbackCacheReadTokens: fallbackCacheRead,
+                                  fallbackCacheWriteTokens: fallbackCacheWrite,
+                                  fallbackCacheHitRate:
+                                    fallbackCacheTotal > 0
+                                      ? fallbackCacheRead / fallbackCacheTotal
+                                      : null,
+                                  userId,
+                                  subscription,
+                                });
 
-                  // Emit wide event
-                  stepStart = Date.now();
-                  const sandboxInfo = sandboxManager.getSandboxInfo();
-                  chatLogger!.setSandbox(sandboxInfo);
-                  chatLogger!.setCacheMetrics({
-                    cacheHitRate: usageTracker.cacheHitRate,
-                    cacheReadTokens: usageTracker.cacheReadTokens,
-                    cacheWriteTokens: usageTracker.cacheWriteTokens,
-                  });
-                  captureToolCalls({ posthog, chatLogger, userId, mode });
-                  captureAgentRun({
-                    posthog,
-                    userId,
-                    mode,
-                    subscription,
-                    sandboxInfo,
-                    outcome: isAborted ? "aborted" : "success",
-                  });
-                  shutdownPostHog(posthog);
-                  chatLogger!.emitSuccess({
-                    finishReason: state.streamFinishReason,
-                    wasAborted: isAborted,
-                    wasPreemptiveTimeout: isPreemptiveAbort,
-                    hadSummarization: summarizationTracker.hasSummarized,
-                  });
-                  logStep("emit_success_event", stepStart);
-
-                  // Sandbox cleanup is automatic with auto-pause
-                  // The sandbox will auto-pause after inactivity timeout (7 minutes)
-                  // No manual pause needed
-
-                  // Always wait for title generation to complete
-                  stepStart = Date.now();
-                  const generatedTitle = await titlePromise;
-                  logStep("wait_title_generation", stepStart);
-
-                  if (!temporary) {
-                    stepStart = Date.now();
-                    const mergedTodos = getTodoManager().mergeWith(
-                      baseTodos,
-                      assistantMessageId,
-                    );
-                    logStep("merge_todos", stepStart);
-
-                    const shouldPersist = regenerate
-                      ? true
-                      : Boolean(
-                          generatedTitle ||
-                          state.streamFinishReason ||
-                          mergedTodos.length > 0,
+                                // Deduct accumulated usage (includes both original + retry streams)
+                                await deductAccumulatedUsage();
+                              } finally {
+                                await releaseFreeRunLockOnce();
+                              }
+                            },
+                            sendReasoning: true,
+                          }),
                         );
 
-                    if (shouldPersist) {
-                      // updateChat automatically clears stream state (active_stream_id and canceled_at)
-                      stepStart = Date.now();
-                      await updateChat({
-                        chatId,
-                        title: generatedTitle,
-                        finishReason: state.streamFinishReason,
-                        todos: mergedTodos,
-                        defaultModelSlug: mode,
-                        sandboxType: sandboxManager.getEffectivePreference(),
-                        selectedModel: selectedModelOverride,
-                      });
-                      logStep("update_chat", stepStart);
-                    } else {
-                      // If not persisting, still need to clear stream state
-                      stepStart = Date.now();
-                      await prepareForNewStream({ chatId });
-                      logStep("prepare_for_new_stream", stepStart);
-                    }
-
-                    stepStart = Date.now();
-                    const accumulatedFiles = getFileAccumulator().getAll();
-                    const newFileIds = accumulatedFiles.map((f) => f.fileId);
-                    logStep("get_accumulated_files", stepStart);
-
-                    // Check if any messages have incomplete tool calls that need completion
-                    const hasIncompleteToolCalls = messages.some(
-                      (msg) =>
-                        msg.role === "assistant" &&
-                        msg.parts?.some(
-                          (p: {
-                            type?: string;
-                            state?: string;
-                            toolCallId?: string;
-                          }) =>
-                            p.type?.startsWith("tool-") &&
-                            p.state !== "output-available" &&
-                            p.toolCallId,
-                        ),
-                    );
-                    const incompleteToolSummaries = isAborted
-                      ? summarizeIncompleteToolParts(messages)
-                      : [];
-                    if (incompleteToolSummaries.length > 0) {
-                      console.info(
-                        JSON.stringify({
-                          level: "info",
-                          event: "abort_incomplete_tool_calls_detected",
-                          service: "chat-handler",
-                          timestamp: new Date().toISOString(),
-                          chat_id: chatId,
-                          user_id: userId,
-                          mode,
-                          finish_reason: state.streamFinishReason,
-                          is_preemptive_abort: isPreemptiveAbort,
-                          incomplete_tool_count: incompleteToolSummaries.length,
-                          incomplete_tools: incompleteToolSummaries,
-                        }),
-                      );
-                    }
-
-                    // On abort, streamText.onFinish may not have fired yet, so state.streamUsage
-                    // could be undefined. Await usage from result to ensure we capture it.
-                    // This must happen BEFORE we decide whether to skip saving.
-                    let resolvedUsage: Record<string, unknown> | undefined =
-                      state.streamUsage;
-                    if (!resolvedUsage && isAborted) {
-                      try {
-                        resolvedUsage = (await result.usage) as Record<
-                          string,
-                          unknown
-                        >;
-                      } catch {
-                        // Usage unavailable on abort - continue without it
+                        retryScheduled = true;
+                        return; // Skip normal cleanup - retry handles it
                       }
                     }
 
-                    const hasUsageToRecord = Boolean(resolvedUsage);
-                    const shouldSkipSaveSignal =
-                      cancellationSubscriber.shouldSkipSave();
+                    const isPreemptiveAbort =
+                      preemptiveTimeout?.isPreemptive() ?? false;
+                    const onFinishStartTime = Date.now();
+                    const triggerTime = preemptiveTimeout?.getTriggerTime();
 
-                    // If user aborted (not pre-emptive), skip message save when:
-                    // 1. skipSave signal received via Redis (edit/regenerate/retry — message will be discarded)
-                    // 2. No files, tools, or usage to record (frontend already saved the message)
-                    if (
-                      isAborted &&
-                      !isPreemptiveAbort &&
-                      (shouldSkipSaveSignal ||
-                        (newFileIds.length === 0 &&
-                          !hasIncompleteToolCalls &&
-                          !hasUsageToRecord))
-                    ) {
-                      console.info(
-                        JSON.stringify({
-                          level: "info",
-                          event: "abort_message_save_skipped",
-                          service: "chat-handler",
-                          timestamp: new Date().toISOString(),
-                          chat_id: chatId,
-                          user_id: userId,
-                          mode,
-                          finish_reason: state.streamFinishReason,
-                          skip_save_signal: shouldSkipSaveSignal,
-                          new_file_count: newFileIds.length,
-                          has_incomplete_tool_calls: hasIncompleteToolCalls,
-                          has_usage_to_record: hasUsageToRecord,
-                        }),
-                      );
-                      await deductAccumulatedUsage();
-                      return;
-                    }
-
-                    // Save messages (either full save or just append extraFileIds)
-                    stepStart = Date.now();
-                    for (const message of messages) {
-                      let processedMessage =
-                        summarizationTracker.processMessageForSave(message);
-
-                      // Skip saving messages with no parts or files
-                      // This prevents saving empty messages on error that would accumulate on retry
-                      if (
-                        (!processedMessage.parts ||
-                          processedMessage.parts.length === 0) &&
-                        newFileIds.length === 0
-                      ) {
-                        continue;
-                      }
-
-                      // Use resolvedUsage which was already awaited above on abort
-                      // Falls back to state.streamUsage for non-abort cases
-                      // On user-initiated abort, use updateOnly as safety net:
-                      // only patch existing messages (add files/usage), don't create new ones.
-                      // This prevents orphan messages when Redis skipSave signal was missed.
-                      try {
-                        await saveMessage({
+                    // Helper to log step timing during preemptive timeout
+                    const logStep = (step: string, stepStartTime: number) => {
+                      if (isPreemptiveAbort) {
+                        const stepDuration = Date.now() - stepStartTime;
+                        const totalElapsed =
+                          Date.now() - (triggerTime || onFinishStartTime);
+                        phLogger.info("Preemptive timeout cleanup step", {
                           chatId,
-                          userId,
-                          message: processedMessage,
-                          extraFileIds: newFileIds,
-                          model: state.responseModel || configuredModelId,
-                          mode,
-                          generationStartedAt:
-                            processedMessage.role === "assistant"
-                              ? streamStartTime
-                              : undefined,
-                          generationTimeMs: Date.now() - streamStartTime,
-                          finishReason: state.streamFinishReason,
-                          usage: resolvedUsage ?? state.streamUsage,
-                          updateOnly:
-                            isAborted && !isPreemptiveAbort ? true : undefined,
-                          isHidden:
-                            isAutoContinue && processedMessage.role === "user"
-                              ? true
-                              : undefined,
-                          wasAborted: isAborted,
-                          wasPreemptiveTimeout: isPreemptiveAbort,
+                          step,
+                          stepDurationMs: stepDuration,
+                          totalElapsedSinceTriggerMs: totalElapsed,
+                          endpoint,
                         });
-                      } catch (error) {
-                        if (isPreemptiveAbort) {
-                          console.error(
-                            JSON.stringify({
-                              level: "error",
-                              event: "preemptive_timeout_message_save_failed",
-                              service: "chat-handler",
-                              timestamp: new Date().toISOString(),
-                              chat_id: chatId,
-                              user_id: userId,
-                              message_id: processedMessage.id,
-                              message_role: processedMessage.role,
-                              mode,
-                              model: state.responseModel || configuredModelId,
-                              finish_reason: state.streamFinishReason,
-                              time_since_timeout_trigger_ms: triggerTime
-                                ? Date.now() - triggerTime
-                                : null,
-                              stream_duration_ms: Date.now() - streamStartTime,
-                              error_name:
-                                error instanceof Error
-                                  ? error.name
-                                  : typeof error,
-                              error_message:
-                                error instanceof Error
-                                  ? error.message
-                                  : String(error),
-                              error_metadata:
-                                error &&
-                                typeof error === "object" &&
-                                "metadata" in error
-                                  ? (error as { metadata?: unknown }).metadata
-                                  : undefined,
-                            }),
-                          );
-                        }
-                        throw error;
                       }
+                    };
+
+                    if (isPreemptiveAbort) {
+                      phLogger.info("Preemptive timeout onFinish started", {
+                        chatId,
+                        endpoint,
+                        timeSinceTriggerMs: triggerTime
+                          ? onFinishStartTime - triggerTime
+                          : null,
+                        messageCount: messages.length,
+                        isTemporary: temporary,
+                      });
                     }
-                    logStep("save_messages", stepStart);
 
-                    // Send file metadata via stream for resumable stream clients
-                    // Uses accumulated metadata directly - no DB query needed!
-                    stepStart = Date.now();
-                    sendFileMetadataToStream(accumulatedFiles);
-                    logStep("send_file_metadata", stepStart);
-                  } else {
-                    // For temporary chats, send file metadata via stream before cleanup
-                    stepStart = Date.now();
-                    const tempFiles = getFileAccumulator().getAll();
-                    sendFileMetadataToStream(tempFiles);
-                    logStep("send_temp_file_metadata", stepStart);
+                    // Clear pre-emptive timeout
+                    let stepStart = Date.now();
+                    preemptiveTimeout?.clear();
+                    logStep("clear_timeout", stepStart);
 
-                    // Ensure temp stream row is removed backend-side
+                    // Stop cancellation subscriber
                     stepStart = Date.now();
-                    await deleteTempStreamForBackend({ chatId });
-                    logStep("delete_temp_stream", stepStart);
-                  }
+                    await cancellationSubscriber.stop();
+                    subscriberStopped = true;
+                    logStep("stop_cancellation_subscriber", stepStart);
 
-                  if (isPreemptiveAbort) {
-                    const totalDuration = Date.now() - onFinishStartTime;
-                    phLogger.info("Preemptive timeout onFinish completed", {
-                      chatId,
-                      endpoint,
-                      totalOnFinishDurationMs: totalDuration,
-                      totalSinceTriggerMs: triggerTime
-                        ? Date.now() - triggerTime
-                        : null,
+                    // Clear finish reason for user-initiated aborts (not pre-emptive timeouts)
+                    // This prevents showing "going off course" message when user clicks stop
+                    if (isAborted && !isPreemptiveAbort) {
+                      state.streamFinishReason = undefined;
+                    }
+
+                    // Emit wide event
+                    stepStart = Date.now();
+                    const sandboxInfo = sandboxManager.getSandboxInfo();
+                    chatLogger!.setSandbox(sandboxInfo);
+                    chatLogger!.setCacheMetrics({
+                      cacheHitRate: usageTracker.cacheHitRate,
+                      cacheReadTokens: usageTracker.cacheReadTokens,
+                      cacheWriteTokens: usageTracker.cacheWriteTokens,
                     });
-                    await phLogger.flush();
-                  }
-
-                  // Send updated context usage with output tokens included
-                  if (contextUsageOn) {
-                    writeContextUsage(writer, {
-                      usedTokens:
-                        state.ctxUsage.usedTokens +
-                        usageTracker.streamOutputTokens,
-                      maxTokens: state.ctxUsage.maxTokens,
+                    captureToolCalls({ posthog, chatLogger, userId, mode });
+                    captureAgentRun({
+                      posthog,
+                      userId,
+                      mode,
+                      subscription,
+                      sandboxInfo,
+                      outcome: isAborted ? "aborted" : "success",
                     });
-                  }
+                    shutdownPostHog(posthog);
+                    chatLogger!.emitSuccess({
+                      finishReason: state.streamFinishReason,
+                      wasAborted: isAborted,
+                      wasPreemptiveTimeout: isPreemptiveAbort,
+                      hadSummarization: summarizationTracker.hasSummarized,
+                    });
+                    logStep("emit_success_event", stepStart);
 
-                  if (
-                    (state.stoppedDueToTokenExhaustion ||
-                      state.stoppedDueToElapsedTimeout ||
-                      state.streamFinishReason === "tool-calls") &&
-                    isAgentMode(mode) &&
-                    !temporary
-                  ) {
-                    writeAutoContinue(writer);
-                  }
+                    // Sandbox cleanup is automatic with auto-pause
+                    // The sandbox will auto-pause after inactivity timeout (7 minutes)
+                    // No manual pause needed
 
-                  await deductAccumulatedUsage();
+                    // Always wait for title generation to complete
+                    stepStart = Date.now();
+                    const generatedTitle = await titlePromise;
+                    logStep("wait_title_generation", stepStart);
+
+                    if (!temporary) {
+                      stepStart = Date.now();
+                      const mergedTodos = getTodoManager().mergeWith(
+                        baseTodos,
+                        assistantMessageId,
+                      );
+                      logStep("merge_todos", stepStart);
+
+                      const shouldPersist = regenerate
+                        ? true
+                        : Boolean(
+                            generatedTitle ||
+                            state.streamFinishReason ||
+                            mergedTodos.length > 0,
+                          );
+
+                      if (shouldPersist) {
+                        // updateChat automatically clears stream state (active_stream_id and canceled_at)
+                        stepStart = Date.now();
+                        await updateChat({
+                          chatId,
+                          title: generatedTitle,
+                          finishReason: state.streamFinishReason,
+                          todos: mergedTodos,
+                          defaultModelSlug: mode,
+                          sandboxType: sandboxManager.getEffectivePreference(),
+                          selectedModel: selectedModelOverride,
+                        });
+                        logStep("update_chat", stepStart);
+                      } else {
+                        // If not persisting, still need to clear stream state
+                        stepStart = Date.now();
+                        await prepareForNewStream({ chatId });
+                        logStep("prepare_for_new_stream", stepStart);
+                      }
+
+                      stepStart = Date.now();
+                      const accumulatedFiles = getFileAccumulator().getAll();
+                      const newFileIds = accumulatedFiles.map((f) => f.fileId);
+                      logStep("get_accumulated_files", stepStart);
+
+                      // Check if any messages have incomplete tool calls that need completion
+                      const hasIncompleteToolCalls = messages.some(
+                        (msg) =>
+                          msg.role === "assistant" &&
+                          msg.parts?.some(
+                            (p: {
+                              type?: string;
+                              state?: string;
+                              toolCallId?: string;
+                            }) =>
+                              p.type?.startsWith("tool-") &&
+                              p.state !== "output-available" &&
+                              p.toolCallId,
+                          ),
+                      );
+                      const incompleteToolSummaries = isAborted
+                        ? summarizeIncompleteToolParts(messages)
+                        : [];
+                      if (incompleteToolSummaries.length > 0) {
+                        console.info(
+                          JSON.stringify({
+                            level: "info",
+                            event: "abort_incomplete_tool_calls_detected",
+                            service: "chat-handler",
+                            timestamp: new Date().toISOString(),
+                            chat_id: chatId,
+                            user_id: userId,
+                            mode,
+                            finish_reason: state.streamFinishReason,
+                            is_preemptive_abort: isPreemptiveAbort,
+                            incomplete_tool_count:
+                              incompleteToolSummaries.length,
+                            incomplete_tools: incompleteToolSummaries,
+                          }),
+                        );
+                      }
+
+                      // On abort, streamText.onFinish may not have fired yet, so state.streamUsage
+                      // could be undefined. Await usage from result to ensure we capture it.
+                      // This must happen BEFORE we decide whether to skip saving.
+                      let resolvedUsage: Record<string, unknown> | undefined =
+                        state.streamUsage;
+                      if (!resolvedUsage && isAborted) {
+                        try {
+                          resolvedUsage = (await result.usage) as Record<
+                            string,
+                            unknown
+                          >;
+                        } catch {
+                          // Usage unavailable on abort - continue without it
+                        }
+                      }
+
+                      const hasUsageToRecord = Boolean(resolvedUsage);
+                      const shouldSkipSaveSignal =
+                        cancellationSubscriber.shouldSkipSave();
+
+                      // If user aborted (not pre-emptive), skip message save when:
+                      // 1. skipSave signal received via Redis (edit/regenerate/retry — message will be discarded)
+                      // 2. No files, tools, or usage to record (frontend already saved the message)
+                      if (
+                        isAborted &&
+                        !isPreemptiveAbort &&
+                        (shouldSkipSaveSignal ||
+                          (newFileIds.length === 0 &&
+                            !hasIncompleteToolCalls &&
+                            !hasUsageToRecord))
+                      ) {
+                        console.info(
+                          JSON.stringify({
+                            level: "info",
+                            event: "abort_message_save_skipped",
+                            service: "chat-handler",
+                            timestamp: new Date().toISOString(),
+                            chat_id: chatId,
+                            user_id: userId,
+                            mode,
+                            finish_reason: state.streamFinishReason,
+                            skip_save_signal: shouldSkipSaveSignal,
+                            new_file_count: newFileIds.length,
+                            has_incomplete_tool_calls: hasIncompleteToolCalls,
+                            has_usage_to_record: hasUsageToRecord,
+                          }),
+                        );
+                        await deductAccumulatedUsage();
+                        return;
+                      }
+
+                      // Save messages (either full save or just append extraFileIds)
+                      stepStart = Date.now();
+                      for (const message of messages) {
+                        let processedMessage =
+                          summarizationTracker.processMessageForSave(message);
+
+                        // Skip saving messages with no parts or files
+                        // This prevents saving empty messages on error that would accumulate on retry
+                        if (
+                          (!processedMessage.parts ||
+                            processedMessage.parts.length === 0) &&
+                          newFileIds.length === 0
+                        ) {
+                          continue;
+                        }
+
+                        // Use resolvedUsage which was already awaited above on abort
+                        // Falls back to state.streamUsage for non-abort cases
+                        // On user-initiated abort, use updateOnly as safety net:
+                        // only patch existing messages (add files/usage), don't create new ones.
+                        // This prevents orphan messages when Redis skipSave signal was missed.
+                        try {
+                          await saveMessage({
+                            chatId,
+                            userId,
+                            message: processedMessage,
+                            extraFileIds: newFileIds,
+                            model: state.responseModel || configuredModelId,
+                            mode,
+                            generationStartedAt:
+                              processedMessage.role === "assistant"
+                                ? streamStartTime
+                                : undefined,
+                            generationTimeMs: Date.now() - streamStartTime,
+                            finishReason: state.streamFinishReason,
+                            usage: resolvedUsage ?? state.streamUsage,
+                            updateOnly:
+                              isAborted && !isPreemptiveAbort
+                                ? true
+                                : undefined,
+                            isHidden:
+                              isAutoContinue && processedMessage.role === "user"
+                                ? true
+                                : undefined,
+                            wasAborted: isAborted,
+                            wasPreemptiveTimeout: isPreemptiveAbort,
+                          });
+                        } catch (error) {
+                          if (isPreemptiveAbort) {
+                            console.error(
+                              JSON.stringify({
+                                level: "error",
+                                event: "preemptive_timeout_message_save_failed",
+                                service: "chat-handler",
+                                timestamp: new Date().toISOString(),
+                                chat_id: chatId,
+                                user_id: userId,
+                                message_id: processedMessage.id,
+                                message_role: processedMessage.role,
+                                mode,
+                                model: state.responseModel || configuredModelId,
+                                finish_reason: state.streamFinishReason,
+                                time_since_timeout_trigger_ms: triggerTime
+                                  ? Date.now() - triggerTime
+                                  : null,
+                                stream_duration_ms:
+                                  Date.now() - streamStartTime,
+                                error_name:
+                                  error instanceof Error
+                                    ? error.name
+                                    : typeof error,
+                                error_message:
+                                  error instanceof Error
+                                    ? error.message
+                                    : String(error),
+                                error_metadata:
+                                  error &&
+                                  typeof error === "object" &&
+                                  "metadata" in error
+                                    ? (error as { metadata?: unknown }).metadata
+                                    : undefined,
+                              }),
+                            );
+                          }
+                          throw error;
+                        }
+                      }
+                      logStep("save_messages", stepStart);
+
+                      // Send file metadata via stream for resumable stream clients
+                      // Uses accumulated metadata directly - no DB query needed!
+                      stepStart = Date.now();
+                      sendFileMetadataToStream(accumulatedFiles);
+                      logStep("send_file_metadata", stepStart);
+                    } else {
+                      // For temporary chats, send file metadata via stream before cleanup
+                      stepStart = Date.now();
+                      const tempFiles = getFileAccumulator().getAll();
+                      sendFileMetadataToStream(tempFiles);
+                      logStep("send_temp_file_metadata", stepStart);
+
+                      // Ensure temp stream row is removed backend-side
+                      stepStart = Date.now();
+                      await deleteTempStreamForBackend({ chatId });
+                      logStep("delete_temp_stream", stepStart);
+                    }
+
+                    if (isPreemptiveAbort) {
+                      const totalDuration = Date.now() - onFinishStartTime;
+                      phLogger.info("Preemptive timeout onFinish completed", {
+                        chatId,
+                        endpoint,
+                        totalOnFinishDurationMs: totalDuration,
+                        totalSinceTriggerMs: triggerTime
+                          ? Date.now() - triggerTime
+                          : null,
+                      });
+                      await phLogger.flush();
+                    }
+
+                    // Send updated context usage with output tokens included
+                    if (contextUsageOn) {
+                      writeContextUsage(writer, {
+                        usedTokens:
+                          state.ctxUsage.usedTokens +
+                          usageTracker.streamOutputTokens,
+                        maxTokens: state.ctxUsage.maxTokens,
+                      });
+                    }
+
+                    if (
+                      (state.stoppedDueToTokenExhaustion ||
+                        state.stoppedDueToElapsedTimeout ||
+                        state.streamFinishReason === "tool-calls") &&
+                      isAgentMode(mode) &&
+                      !temporary
+                    ) {
+                      writeAutoContinue(writer);
+                    }
+
+                    await deductAccumulatedUsage();
+                  } finally {
+                    if (!retryScheduled) {
+                      await releaseFreeRunLockOnce();
+                    }
+                  }
                 },
                 sendReasoning: true,
               }),

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -24,8 +24,10 @@ import { coerceSelectedModel } from "@/types";
 import { getBaseTodosForRequest } from "@/lib/utils/todo-utils";
 import {
   acquireFreeRunConcurrencyLock,
+  checkFreeMonthlyCostLimit,
   checkRateLimit,
   deductUsage,
+  recordFreeMonthlyCost,
   UsageRefundTracker,
 } from "@/lib/rate-limit";
 import {
@@ -323,6 +325,11 @@ export const createChatHandler = (
           organizationId,
         ));
 
+      const freeMonthlyBudgetSnapshot =
+        subscription === "free"
+          ? await checkFreeMonthlyCostLimit(userId)
+          : null;
+
       usageRefundTracker.recordDeductions(rateLimitInfo);
 
       chatLogger.setRateLimit(
@@ -564,18 +571,20 @@ export const createChatHandler = (
                 : { usedTokens: 0, maxTokens: 0 },
             );
 
-            // Mid-stream budget enforcement (paid users only). Snapshot bucket
-            // state once; the monitor emits threshold warnings (80/95/100) and
-            // signals "abort" when the bucket hits 0 with no extra-usage
-            // cushion. captureBudgetSnapshot returns null when enforcement
-            // shouldn't run (free, no bucket, rate limiting skipped in dev).
+            // Mid-stream budget enforcement. Paid users use their subscription
+            // bucket; free users use an internal monthly cost cap.
             const budgetSnapshot = captureBudgetSnapshot({
               rateLimitInfo,
               extraUsageConfig,
               subscription,
             });
-            const budgetMonitor = budgetSnapshot
-              ? new BudgetMonitor(budgetSnapshot, writer, subscription)
+            const effectiveBudgetSnapshot =
+              budgetSnapshot ??
+              (freeMonthlyBudgetSnapshot?.rateLimitSkipped
+                ? null
+                : freeMonthlyBudgetSnapshot);
+            const budgetMonitor = effectiveBudgetSnapshot
+              ? new BudgetMonitor(effectiveBudgetSnapshot, writer, subscription)
               : null;
             const isReasoningModel = isAgentMode(mode);
 
@@ -637,7 +646,12 @@ export const createChatHandler = (
                     ? usageTracker.providerCost
                     : undefined;
 
-                if (subscription !== "free") {
+                if (subscription === "free") {
+                  await recordFreeMonthlyCost(
+                    userId,
+                    usageCostRecord.costDollars,
+                  );
+                } else {
                   await deductUsage(
                     userId,
                     subscription,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -23,6 +23,7 @@ import type {
 import { coerceSelectedModel } from "@/types";
 import { getBaseTodosForRequest } from "@/lib/utils/todo-utils";
 import {
+  acquireFreeRunConcurrencyLock,
   checkRateLimit,
   deductUsage,
   UsageRefundTracker,
@@ -58,6 +59,7 @@ import {
   assertFreeAgentGates,
   buildExtraUsageConfig,
   estimatePreflightInputTokens,
+  getRetryFallbackModel,
 } from "@/lib/api/chat-stream-helpers";
 import { geolocation } from "@vercel/functions";
 import { NextRequest } from "next/server";
@@ -106,6 +108,8 @@ import {
   type AgentStreamContext,
 } from "@/lib/api/agent-stream-runner";
 
+const FREE_RUN_LOCK_TTL_SECONDS = 15 * 60;
+
 function getStreamContext() {
   try {
     return createResumableStreamContext({ waitUntil: after });
@@ -130,6 +134,13 @@ export const createChatHandler = (
     // Wide event logger for structured logging
     let chatLogger: ChatLogger | undefined;
     let outerChatId: string | undefined;
+    let releaseFreeRunLock: (() => Promise<void>) | undefined;
+    const releaseFreeRunLockOnce = async () => {
+      const release = releaseFreeRunLock;
+      if (!release) return;
+      releaseFreeRunLock = undefined;
+      await release();
+    };
 
     try {
       const {
@@ -169,6 +180,13 @@ export const createChatHandler = (
         await getUserIDAndPro(req);
       await assertUserCanMakeCostIncurringRequest(userId);
       usageRefundTracker.setUser(userId, subscription, organizationId);
+      if (subscription === "free") {
+        const lock = await acquireFreeRunConcurrencyLock(
+          userId,
+          FREE_RUN_LOCK_TTL_SECONDS,
+        );
+        releaseFreeRunLock = lock.release;
+      }
       const userLocation = geolocation(req);
 
       // Add user context to logger (only region, not full location for privacy)
@@ -359,983 +377,1004 @@ export const createChatHandler = (
           return getUserFriendlyProviderError(error);
         },
         execute: async ({ writer }) => {
-          sendRateLimitWarnings(writer, { subscription, mode, rateLimitInfo });
-
-          const {
-            tools,
-            getSandbox,
-            ensureSandbox,
-            getTodoManager,
-            getFileAccumulator,
-            sandboxManager,
-            getSandboxSessionCost,
-          } = createTools(
-            userId,
-            chatId,
-            writer,
-            mode,
-            userLocation,
-            baseTodos,
-            memoryEnabled,
-            temporary,
-            assistantMessageId,
-            sandboxPreference,
-            process.env.CONVEX_SERVICE_ROLE_KEY,
-            userCustomization?.guardrails_config,
-            // Caido proxy temporarily disabled for all users.
-            // Was: subscription !== "free" && (userCustomization?.caido_enabled ?? false)
-            false,
-            undefined, // caido_port (disabled)
-            undefined, // appendMetadataStream
-            (costDollars: number) => {
-              usageTracker.providerCost += costDollars;
-              usageTracker.nonModelCost += costDollars;
-              chatLogger?.getBuilder().addToolCost(costDollars);
-            },
-            subscription,
-            (info) => chatLogger?.setSandboxBoot(info),
-            (info) => chatLogger?.setCaidoReady(info),
-          );
-
-          // Helper to send file metadata via stream for resumable stream clients
-          // Uses accumulated metadata directly - no DB query needed!
-          const sendFileMetadataToStream = (
-            fileMetadata: Array<{
-              fileId: Id<"files">;
-              name: string;
-              mediaType: string;
-              s3Key?: string;
-              storageId?: Id<"_storage">;
-            }>,
-          ) => {
-            if (!fileMetadata || fileMetadata.length === 0) return;
-
-            writer.write({
-              type: "data-file-metadata",
-              data: {
-                messageId: assistantMessageId,
-                fileDetails: fileMetadata,
-              },
-            });
-          };
-
-          // Get sandbox context for system prompt (only for local sandboxes)
-          let sandboxContext: string | null = null;
-          if (
-            isAgentMode(mode) &&
-            "getSandboxContextForPrompt" in sandboxManager
-          ) {
-            try {
-              sandboxContext = await (
-                sandboxManager as {
-                  getSandboxContextForPrompt: () => Promise<string | null>;
-                }
-              ).getSandboxContextForPrompt();
-            } catch (error) {
-              console.warn("Failed to get sandbox context for prompt:", error);
-            }
-          }
-
-          if (isAgentMode(mode) && sandboxFiles && sandboxFiles.length > 0) {
-            writeUploadStartStatus(
-              writer,
-              sandboxFiles.every((file) => file.kind === "localPath")
-                ? "Preparing local attachments on your computer"
-                : "Uploading attachments to the computer",
-            );
-            let uploadResult: { failedCount: number } = { failedCount: 0 };
-            try {
-              uploadResult = await uploadSandboxFiles(
-                sandboxFiles,
-                ensureSandbox,
-              );
-            } finally {
-              writeUploadCompleteStatus(writer);
-            }
-            if (uploadResult.failedCount > 0) {
-              const noun =
-                uploadResult.failedCount === 1 ? "attachment" : "attachments";
-              const uploadError = new ChatSDKError(
-                "bad_request:stream",
-                `Failed to upload ${uploadResult.failedCount} ${noun} to the computer. Please try again.`,
-              );
-              // Errors thrown from execute are caught by createUIMessageStream's
-              // onError and never reach the outer catch, so refund / timeout
-              // clear / error logging must happen here. refund() is idempotent.
-              preemptiveTimeout?.clear();
-              await usageRefundTracker.refund();
-              chatLogger?.emitChatError(uploadError);
-              throw uploadError;
-            }
-          }
-
-          // Generate title in parallel only for non-temporary new chats
-          const titlePromise =
-            isNewChat && !temporary
-              ? generateTitleFromUserMessageWithWriter(
-                  processedMessages,
-                  writer,
-                )
-              : Promise.resolve(undefined);
-
-          const trackedProvider = createTrackedProvider();
-
-          let currentSystemPrompt = await systemPrompt(
-            userId,
-            mode,
-            subscription,
-            selectedModel,
-            userCustomization,
-            temporary,
-            sandboxContext,
-          );
-
-          const systemPromptTokens = countTokens(currentSystemPrompt);
-
-          const contextUsageOn = isContextUsageEnabled(subscription, mode);
-          const ctxSystemTokens = contextUsageOn ? systemPromptTokens : 0;
-          const ctxMaxTokens = contextUsageOn
-            ? getMaxTokensForSubscription(subscription, { mode })
-            : 0;
-          // finalMessages will be set in prepareStep if summarization is needed
-          let finalMessages = processedMessages;
-
-          // Inject resume context into messages instead of system prompt
-          // to keep the system prompt stable for caching
-          const resumeContext = getResumeSection(chat?.finish_reason);
-          if (resumeContext) {
-            finalMessages = appendSystemReminderToLastUserMessage(
-              finalMessages,
-              resumeContext,
-            );
-          }
-
-          // Inject notes into messages instead of system prompt
-          // to keep the system prompt stable for prompt caching
-          const shouldIncludeNotes =
-            userCustomization?.include_memory_entries ?? true;
-          const noteInjectionOpts = {
-            userId,
-            subscription,
-            shouldIncludeNotes,
-            isTemporary: temporary,
-          };
-          finalMessages = await injectNotesIntoMessages(
-            finalMessages,
-            noteInjectionOpts,
-          );
-
-          // Mutable stream state — updated in-place by the shared runner.
-          const state = initAgentStreamState(
-            finalMessages,
-            contextUsageOn
-              ? computeContextUsage(
-                  truncatedMessages,
-                  fileTokens,
-                  ctxSystemTokens,
-                  ctxMaxTokens,
-                )
-              : { usedTokens: 0, maxTokens: 0 },
-          );
-
-          // Mid-stream budget enforcement (paid users only). Snapshot bucket
-          // state once; the monitor emits threshold warnings (80/95/100) and
-          // signals "abort" when the bucket hits 0 with no extra-usage
-          // cushion. captureBudgetSnapshot returns null when enforcement
-          // shouldn't run (free, no bucket, rate limiting skipped in dev).
-          const budgetSnapshot = captureBudgetSnapshot({
-            rateLimitInfo,
-            extraUsageConfig,
-            subscription,
-          });
-          const budgetMonitor = budgetSnapshot
-            ? new BudgetMonitor(budgetSnapshot, writer, subscription)
-            : null;
-          const isReasoningModel = isAgentMode(mode);
-
-          const streamStartTime = Date.now();
-          const configuredModelId =
-            trackedProvider.languageModel(selectedModel).modelId;
-
-          let isRetryWithFallback = false;
-          const isAutoModel = [
-            "ask-model",
-            "ask-model-free",
-            "agent-model",
-            "agent-model-free",
-          ].includes(selectedModel);
-          const fallbackModel =
-            mode === "agent" ? "fallback-agent-model" : "fallback-ask-model";
-          const fallbackModelId =
-            trackedProvider.languageModel(fallbackModel).modelId;
-
-          const usageTracker = new UsageTracker();
-          let hasRecordedUsage = false;
-          // Snapshot cache tokens before fallback retry so we can isolate fallback-only metrics
-          let preFallbackCacheRead = 0;
-          let preFallbackCacheWrite = 0;
-
-          const deductAccumulatedUsage = async () => {
-            if (hasRecordedUsage) return;
-            // Add E2B sandbox session cost (duration-based)
-            const sandboxCost = getSandboxSessionCost();
-            if (sandboxCost > 0) {
-              usageTracker.providerCost += sandboxCost;
-              usageTracker.nonModelCost += sandboxCost;
-              chatLogger?.getBuilder().addToolCost(sandboxCost);
-            }
-
-            if (!usageTracker.hasUsage) {
-              // No usage data reported — skip deduction
-              return;
-            }
-            hasRecordedUsage = true;
-            const usageCostRecord = usageTracker.createUsageCostRecord({
-              selectedModel,
-              selectedModelOverride,
-              responseModel: state.responseModel,
-              configuredModelId,
+          try {
+            sendRateLimitWarnings(writer, {
+              subscription,
+              mode,
               rateLimitInfo,
             });
 
-            // Trust accumulated provider cost (sum of per-step usage.raw.cost) even on
-            // non-clean streams. Each completed step reports authoritative cost with
-            // cache discounts baked in, so summing them is more accurate than the
-            // token-based fallback (which ignores cache reads and overcharges).
-            // Gate on modelProviderCost (not providerCost) because providerCost also
-            // includes tool/sandbox spend — if the model never reported raw.cost,
-            // tool/sandbox cost alone would incorrectly suppress the token fallback
-            // and drop the model portion entirely.
-            const providerCost =
-              usageTracker.modelProviderCost > 0
-                ? usageTracker.providerCost
-                : undefined;
+            const {
+              tools,
+              getSandbox,
+              ensureSandbox,
+              getTodoManager,
+              getFileAccumulator,
+              sandboxManager,
+              getSandboxSessionCost,
+            } = createTools(
+              userId,
+              chatId,
+              writer,
+              mode,
+              userLocation,
+              baseTodos,
+              memoryEnabled,
+              temporary,
+              assistantMessageId,
+              sandboxPreference,
+              process.env.CONVEX_SERVICE_ROLE_KEY,
+              userCustomization?.guardrails_config,
+              // Caido proxy temporarily disabled for all users.
+              // Was: subscription !== "free" && (userCustomization?.caido_enabled ?? false)
+              false,
+              undefined, // caido_port (disabled)
+              undefined, // appendMetadataStream
+              (costDollars: number) => {
+                usageTracker.providerCost += costDollars;
+                usageTracker.nonModelCost += costDollars;
+                chatLogger?.getBuilder().addToolCost(costDollars);
+              },
+              subscription,
+              (info) => chatLogger?.setSandboxBoot(info),
+              (info) => chatLogger?.setCaidoReady(info),
+            );
 
-            if (subscription !== "free") {
-              await deductUsage(
-                userId,
-                subscription,
-                estimatedInputTokens,
-                usageTracker.inputTokens,
-                usageTracker.outputTokens,
-                extraUsageConfig,
-                providerCost,
-                selectedModel,
-                usageTracker.nonModelCost,
-                organizationId,
-              );
-              usageTracker.log({
-                userId,
-                selectedModel,
-                selectedModelOverride,
-                responseModel: state.responseModel,
-                configuredModelId,
-                rateLimitInfo,
+            // Helper to send file metadata via stream for resumable stream clients
+            // Uses accumulated metadata directly - no DB query needed!
+            const sendFileMetadataToStream = (
+              fileMetadata: Array<{
+                fileId: Id<"files">;
+                name: string;
+                mediaType: string;
+                s3Key?: string;
+                storageId?: Id<"_storage">;
+              }>,
+            ) => {
+              if (!fileMetadata || fileMetadata.length === 0) return;
+
+              writer.write({
+                type: "data-file-metadata",
+                data: {
+                  messageId: assistantMessageId,
+                  fileDetails: fileMetadata,
+                },
               });
+            };
+
+            // Get sandbox context for system prompt (only for local sandboxes)
+            let sandboxContext: string | null = null;
+            if (
+              isAgentMode(mode) &&
+              "getSandboxContextForPrompt" in sandboxManager
+            ) {
+              try {
+                sandboxContext = await (
+                  sandboxManager as {
+                    getSandboxContextForPrompt: () => Promise<string | null>;
+                  }
+                ).getSandboxContextForPrompt();
+              } catch (error) {
+                console.warn(
+                  "Failed to get sandbox context for prompt:",
+                  error,
+                );
+              }
             }
-            captureUsageCost({
-              posthog,
+
+            if (isAgentMode(mode) && sandboxFiles && sandboxFiles.length > 0) {
+              writeUploadStartStatus(
+                writer,
+                sandboxFiles.every((file) => file.kind === "localPath")
+                  ? "Preparing local attachments on your computer"
+                  : "Uploading attachments to the computer",
+              );
+              let uploadResult: { failedCount: number } = { failedCount: 0 };
+              try {
+                uploadResult = await uploadSandboxFiles(
+                  sandboxFiles,
+                  ensureSandbox,
+                );
+              } finally {
+                writeUploadCompleteStatus(writer);
+              }
+              if (uploadResult.failedCount > 0) {
+                const noun =
+                  uploadResult.failedCount === 1 ? "attachment" : "attachments";
+                const uploadError = new ChatSDKError(
+                  "bad_request:stream",
+                  `Failed to upload ${uploadResult.failedCount} ${noun} to the computer. Please try again.`,
+                );
+                // Errors thrown from execute are caught by createUIMessageStream's
+                // onError and never reach the outer catch, so refund / timeout
+                // clear / error logging must happen here. refund() is idempotent.
+                preemptiveTimeout?.clear();
+                await usageRefundTracker.refund();
+                chatLogger?.emitChatError(uploadError);
+                throw uploadError;
+              }
+            }
+
+            // Generate title in parallel only for non-temporary new chats
+            const titlePromise =
+              isNewChat && !temporary
+                ? generateTitleFromUserMessageWithWriter(
+                    processedMessages,
+                    writer,
+                  )
+                : Promise.resolve(undefined);
+
+            const trackedProvider = createTrackedProvider();
+
+            let currentSystemPrompt = await systemPrompt(
+              userId,
+              mode,
+              subscription,
+              selectedModel,
+              userCustomization,
+              temporary,
+              sandboxContext,
+            );
+
+            const systemPromptTokens = countTokens(currentSystemPrompt);
+
+            const contextUsageOn = isContextUsageEnabled(subscription, mode);
+            const ctxSystemTokens = contextUsageOn ? systemPromptTokens : 0;
+            const ctxMaxTokens = contextUsageOn
+              ? getMaxTokensForSubscription(subscription, { mode })
+              : 0;
+            // finalMessages will be set in prepareStep if summarization is needed
+            let finalMessages = processedMessages;
+
+            // Inject resume context into messages instead of system prompt
+            // to keep the system prompt stable for caching
+            const resumeContext = getResumeSection(chat?.finish_reason);
+            if (resumeContext) {
+              finalMessages = appendSystemReminderToLastUserMessage(
+                finalMessages,
+                resumeContext,
+              );
+            }
+
+            // Inject notes into messages instead of system prompt
+            // to keep the system prompt stable for prompt caching
+            const shouldIncludeNotes =
+              userCustomization?.include_memory_entries ?? true;
+            const noteInjectionOpts = {
               userId,
               subscription,
-              organizationId,
-              chatId,
-              endpoint,
-              mode,
-              usage: usageCostRecord,
+              shouldIncludeNotes,
+              isTemporary: temporary,
+            };
+            finalMessages = await injectNotesIntoMessages(
+              finalMessages,
+              noteInjectionOpts,
+            );
+
+            // Mutable stream state — updated in-place by the shared runner.
+            const state = initAgentStreamState(
+              finalMessages,
+              contextUsageOn
+                ? computeContextUsage(
+                    truncatedMessages,
+                    fileTokens,
+                    ctxSystemTokens,
+                    ctxMaxTokens,
+                  )
+                : { usedTokens: 0, maxTokens: 0 },
+            );
+
+            // Mid-stream budget enforcement (paid users only). Snapshot bucket
+            // state once; the monitor emits threshold warnings (80/95/100) and
+            // signals "abort" when the bucket hits 0 with no extra-usage
+            // cushion. captureBudgetSnapshot returns null when enforcement
+            // shouldn't run (free, no bucket, rate limiting skipped in dev).
+            const budgetSnapshot = captureBudgetSnapshot({
+              rateLimitInfo,
+              extraUsageConfig,
+              subscription,
             });
-          };
+            const budgetMonitor = budgetSnapshot
+              ? new BudgetMonitor(budgetSnapshot, writer, subscription)
+              : null;
+            const isReasoningModel = isAgentMode(mode);
 
-          // Shared runner context.
-          const streamCtx: AgentStreamContext = {
-            trackedProvider,
-            currentSystemPrompt,
-            tools,
-            mode,
-            userId,
-            subscription,
-            chatId,
-            temporary,
-            fileTokens,
-            noteInjectionOpts,
-            systemPromptTokens,
-            ctxSystemTokens,
-            ctxMaxTokens,
-            streamStartTime,
-            contextUsageOn,
-            isReasoningModel,
-            maxDurationMs: AGENT_MAX_STREAM_DURATION_MS,
-            writer,
-            abortController: userStopSignal,
-            summarizationTracker,
-            usageTracker,
-            budgetMonitor,
-            sandboxManager,
-            getTodoManager,
-            ensureSandbox,
-            chatLogger,
-            usageRefundTracker,
-            getHardTimeoutReason: () =>
-              preemptiveTimeout?.isPreemptive() ? "timeout" : null,
-          };
+            const streamStartTime = Date.now();
+            const configuredModelId =
+              trackedProvider.languageModel(selectedModel).modelId;
 
-          const createStream = (modelName: string) =>
-            createAgentStream(modelName, streamCtx, state);
+            let isRetryWithFallback = false;
+            const isAutoModel = [
+              "ask-model",
+              "ask-model-free",
+              "agent-model",
+              "agent-model-free",
+            ].includes(selectedModel);
+            const fallbackModel = getRetryFallbackModel(selectedModel, mode);
+            const fallbackModelId =
+              trackedProvider.languageModel(fallbackModel).modelId;
 
-          let result;
-          try {
-            result = await createStream(selectedModel);
-          } catch (error) {
-            // If provider returns error (e.g., INVALID_ARGUMENT from Gemini), retry with fallback.
-            if (
-              isProviderApiError(error) &&
-              !isRetryWithFallback &&
-              isAutoModel
-            ) {
-              phLogger.error("Provider API error, retrying with fallback", {
-                error,
-                chatId,
-                endpoint,
-                mode,
-                providerGateway: "openrouter",
-                originalModel: selectedModel,
-                requestedModelSlug: configuredModelId,
-                fallbackModel,
-                fallbackModelSlug: fallbackModelId,
-                userId,
-                subscription,
-                isTemporary: temporary,
-                preFallbackCacheReadTokens: usageTracker.cacheReadTokens,
-                preFallbackCacheWriteTokens: usageTracker.cacheWriteTokens,
-                ...extractErrorDetails(error),
-              });
+            const usageTracker = new UsageTracker();
+            let hasRecordedUsage = false;
+            // Snapshot cache tokens before fallback retry so we can isolate fallback-only metrics
+            let preFallbackCacheRead = 0;
+            let preFallbackCacheWrite = 0;
 
-              isRetryWithFallback = true;
-              state.lastStepInputTokens = 0;
-              state.stoppedDueToTokenExhaustion = false;
-              state.stoppedDueToElapsedTimeout = false;
-              state.stoppedDueToDoomLoop = false;
-              state.stoppedDueToBudgetExhaustion = false;
-              preFallbackCacheRead = usageTracker.cacheReadTokens;
-              preFallbackCacheWrite = usageTracker.cacheWriteTokens;
-              // Discard the failed primary leg's model usage so the user is
-              // only billed for the fallback. Non-model spend (sandbox/tools)
-              // is preserved.
-              usageTracker.resetModelLeg();
-              result = await createStream(fallbackModel);
-            } else {
-              throw error;
-            }
-          }
-
-          writer.merge(
-            result.toUIMessageStream({
-              generateMessageId: () => assistantMessageId,
-              messageMetadata: ({ part }) => {
-                if (part.type === "start") {
-                  return { mode, generationStartedAt: streamStartTime };
+            const deductAccumulatedUsage = async () => {
+              try {
+                if (hasRecordedUsage) return;
+                // Add E2B sandbox session cost (duration-based)
+                const sandboxCost = getSandboxSessionCost();
+                if (sandboxCost > 0) {
+                  usageTracker.providerCost += sandboxCost;
+                  usageTracker.nonModelCost += sandboxCost;
+                  chatLogger?.getBuilder().addToolCost(sandboxCost);
                 }
 
-                if (part.type === "finish") {
-                  return {
-                    mode,
-                    generationStartedAt: streamStartTime,
-                    generationTimeMs: Date.now() - streamStartTime,
-                  };
+                if (!usageTracker.hasUsage) {
+                  // No usage data reported — skip deduction
+                  return;
                 }
-              },
-              onFinish: async ({ messages, isAborted }) => {
-                // Check if stream finished with only step-start (indicates incomplete response)
-                const lastAssistantMessage = messages
-                  .slice()
-                  .reverse()
-                  .find((m) => m.role === "assistant");
-                const hasOnlyStepStart =
-                  lastAssistantMessage?.parts?.length === 1 &&
-                  lastAssistantMessage.parts[0]?.type === "step-start";
+                hasRecordedUsage = true;
+                const usageCostRecord = usageTracker.createUsageCostRecord({
+                  selectedModel,
+                  selectedModelOverride,
+                  responseModel: state.responseModel,
+                  configuredModelId,
+                  rateLimitInfo,
+                });
 
-                if (hasOnlyStepStart) {
-                  phLogger.warn(
-                    "Stream finished incomplete - triggering fallback",
-                    {
-                      chatId,
-                      endpoint,
-                      mode,
-                      model: selectedModel,
-                      userId,
-                      subscription,
-                      isTemporary: temporary,
-                      messageCount: messages.length,
-                      parts: lastAssistantMessage?.parts,
-                      isRetryWithFallback,
-                      assistantMessageId,
-                    },
+                // Trust accumulated provider cost (sum of per-step usage.raw.cost) even on
+                // non-clean streams. Each completed step reports authoritative cost with
+                // cache discounts baked in, so summing them is more accurate than the
+                // token-based fallback (which ignores cache reads and overcharges).
+                // Gate on modelProviderCost (not providerCost) because providerCost also
+                // includes tool/sandbox spend — if the model never reported raw.cost,
+                // tool/sandbox cost alone would incorrectly suppress the token fallback
+                // and drop the model portion entirely.
+                const providerCost =
+                  usageTracker.modelProviderCost > 0
+                    ? usageTracker.providerCost
+                    : undefined;
+
+                if (subscription !== "free") {
+                  await deductUsage(
+                    userId,
+                    subscription,
+                    estimatedInputTokens,
+                    usageTracker.inputTokens,
+                    usageTracker.outputTokens,
+                    extraUsageConfig,
+                    providerCost,
+                    selectedModel,
+                    usageTracker.nonModelCost,
+                    organizationId,
                   );
+                  usageTracker.log({
+                    userId,
+                    selectedModel,
+                    selectedModelOverride,
+                    responseModel: state.responseModel,
+                    configuredModelId,
+                    rateLimitInfo,
+                  });
+                }
+                captureUsageCost({
+                  posthog,
+                  userId,
+                  subscription,
+                  organizationId,
+                  chatId,
+                  endpoint,
+                  mode,
+                  usage: usageCostRecord,
+                });
+              } finally {
+                await releaseFreeRunLockOnce();
+              }
+            };
 
-                  // Retry with fallback model if not already retrying (only for auto models)
-                  if (!isRetryWithFallback && !isAborted && isAutoModel) {
-                    isRetryWithFallback = true;
-                    state.lastStepInputTokens = 0;
-                    state.stoppedDueToTokenExhaustion = false;
-                    state.stoppedDueToElapsedTimeout = false;
-                    state.stoppedDueToDoomLoop = false;
-                    state.stoppedDueToBudgetExhaustion = false;
-                    const fallbackStartTime = Date.now();
-                    preFallbackCacheRead = usageTracker.cacheReadTokens;
-                    preFallbackCacheWrite = usageTracker.cacheWriteTokens;
+            // Shared runner context.
+            const streamCtx: AgentStreamContext = {
+              trackedProvider,
+              currentSystemPrompt,
+              tools,
+              mode,
+              userId,
+              subscription,
+              chatId,
+              temporary,
+              fileTokens,
+              noteInjectionOpts,
+              systemPromptTokens,
+              ctxSystemTokens,
+              ctxMaxTokens,
+              streamStartTime,
+              contextUsageOn,
+              isReasoningModel,
+              maxDurationMs: AGENT_MAX_STREAM_DURATION_MS,
+              writer,
+              abortController: userStopSignal,
+              summarizationTracker,
+              usageTracker,
+              budgetMonitor,
+              sandboxManager,
+              getTodoManager,
+              ensureSandbox,
+              chatLogger,
+              usageRefundTracker,
+              getHardTimeoutReason: () =>
+                preemptiveTimeout?.isPreemptive() ? "timeout" : null,
+            };
 
-                    // Discard the failed primary leg's model usage so the
-                    // user is only billed for the fallback. Non-model spend
-                    // (sandbox/tools) is preserved.
-                    usageTracker.resetModelLeg();
+            const createStream = (modelName: string) =>
+              createAgentStream(modelName, streamCtx, state);
 
-                    const retryResult = await createStream(fallbackModel);
-                    const retryMessageId = generateId();
+            let result;
+            try {
+              result = await createStream(selectedModel);
+            } catch (error) {
+              // If provider returns error (e.g., INVALID_ARGUMENT from Gemini), retry with fallback.
+              if (
+                isProviderApiError(error) &&
+                !isRetryWithFallback &&
+                isAutoModel
+              ) {
+                phLogger.error("Provider API error, retrying with fallback", {
+                  error,
+                  chatId,
+                  endpoint,
+                  mode,
+                  providerGateway: "openrouter",
+                  originalModel: selectedModel,
+                  requestedModelSlug: configuredModelId,
+                  fallbackModel,
+                  fallbackModelSlug: fallbackModelId,
+                  userId,
+                  subscription,
+                  isTemporary: temporary,
+                  preFallbackCacheReadTokens: usageTracker.cacheReadTokens,
+                  preFallbackCacheWriteTokens: usageTracker.cacheWriteTokens,
+                  ...extractErrorDetails(error),
+                });
 
-                    writer.merge(
-                      retryResult.toUIMessageStream({
-                        generateMessageId: () => retryMessageId,
-                        messageMetadata: ({ part }) => {
-                          if (part.type === "start") {
-                            return {
-                              mode,
-                              generationStartedAt: fallbackStartTime,
-                            };
-                          }
+                isRetryWithFallback = true;
+                state.lastStepInputTokens = 0;
+                state.stoppedDueToTokenExhaustion = false;
+                state.stoppedDueToElapsedTimeout = false;
+                state.stoppedDueToDoomLoop = false;
+                state.stoppedDueToBudgetExhaustion = false;
+                preFallbackCacheRead = usageTracker.cacheReadTokens;
+                preFallbackCacheWrite = usageTracker.cacheWriteTokens;
+                // Discard the failed primary leg's model usage so the user is
+                // only billed for the fallback. Non-model spend (sandbox/tools)
+                // is preserved.
+                usageTracker.resetModelLeg();
+                result = await createStream(fallbackModel);
+              } else {
+                throw error;
+              }
+            }
 
-                          if (part.type === "finish") {
-                            return {
-                              mode,
-                              generationStartedAt: fallbackStartTime,
-                              generationTimeMs: Date.now() - fallbackStartTime,
-                            };
-                          }
-                        },
-                        onFinish: async ({
-                          messages: retryMessages,
-                          isAborted: retryAborted,
-                        }) => {
-                          // Cleanup for retry
-                          preemptiveTimeout?.clear();
-                          if (!subscriberStopped) {
-                            await cancellationSubscriber.stop();
-                            subscriberStopped = true;
-                          }
+            writer.merge(
+              result.toUIMessageStream({
+                generateMessageId: () => assistantMessageId,
+                messageMetadata: ({ part }) => {
+                  if (part.type === "start") {
+                    return { mode, generationStartedAt: streamStartTime };
+                  }
 
-                          const sandboxInfo = sandboxManager.getSandboxInfo();
-                          chatLogger!.setSandbox(sandboxInfo);
-                          // Use fallback-only cache tokens (subtract pre-fallback snapshot)
-                          // so the wide event isn't mixing cumulative cache with retry-only usage
-                          const fallbackCacheRead =
-                            usageTracker.cacheReadTokens - preFallbackCacheRead;
-                          const fallbackCacheWrite =
-                            usageTracker.cacheWriteTokens -
-                            preFallbackCacheWrite;
-                          const fallbackCacheTotal =
-                            fallbackCacheRead + fallbackCacheWrite;
-                          chatLogger!.setCacheMetrics({
-                            cacheHitRate:
-                              fallbackCacheTotal > 0
-                                ? fallbackCacheRead / fallbackCacheTotal
-                                : null,
-                            cacheReadTokens: fallbackCacheRead,
-                            cacheWriteTokens: fallbackCacheWrite,
-                          });
-                          captureToolCalls({
-                            posthog,
-                            chatLogger,
-                            userId,
-                            mode,
-                          });
-                          captureAgentRun({
-                            posthog,
-                            userId,
-                            mode,
-                            subscription,
-                            sandboxInfo,
-                            outcome: retryAborted ? "aborted" : "success",
-                          });
-                          shutdownPostHog(posthog);
-                          chatLogger!.emitSuccess({
-                            finishReason: state.streamFinishReason,
-                            wasAborted: retryAborted,
-                            wasPreemptiveTimeout: false,
-                            hadSummarization:
-                              summarizationTracker.hasSummarized,
-                          });
+                  if (part.type === "finish") {
+                    return {
+                      mode,
+                      generationStartedAt: streamStartTime,
+                      generationTimeMs: Date.now() - streamStartTime,
+                    };
+                  }
+                },
+                onFinish: async ({ messages, isAborted }) => {
+                  // Check if stream finished with only step-start (indicates incomplete response)
+                  const lastAssistantMessage = messages
+                    .slice()
+                    .reverse()
+                    .find((m) => m.role === "assistant");
+                  const hasOnlyStepStart =
+                    lastAssistantMessage?.parts?.length === 1 &&
+                    lastAssistantMessage.parts[0]?.type === "step-start";
 
-                          const generatedTitle = await titlePromise;
+                  if (hasOnlyStepStart) {
+                    phLogger.warn(
+                      "Stream finished incomplete - triggering fallback",
+                      {
+                        chatId,
+                        endpoint,
+                        mode,
+                        model: selectedModel,
+                        userId,
+                        subscription,
+                        isTemporary: temporary,
+                        messageCount: messages.length,
+                        parts: lastAssistantMessage?.parts,
+                        isRetryWithFallback,
+                        assistantMessageId,
+                      },
+                    );
 
-                          if (!temporary) {
-                            const mergedTodos = getTodoManager().mergeWith(
-                              baseTodos,
-                              retryMessageId,
-                            );
+                    // Retry with fallback model if not already retrying (only for auto models)
+                    if (!isRetryWithFallback && !isAborted && isAutoModel) {
+                      isRetryWithFallback = true;
+                      state.lastStepInputTokens = 0;
+                      state.stoppedDueToTokenExhaustion = false;
+                      state.stoppedDueToElapsedTimeout = false;
+                      state.stoppedDueToDoomLoop = false;
+                      state.stoppedDueToBudgetExhaustion = false;
+                      const fallbackStartTime = Date.now();
+                      preFallbackCacheRead = usageTracker.cacheReadTokens;
+                      preFallbackCacheWrite = usageTracker.cacheWriteTokens;
 
-                            if (
-                              generatedTitle ||
-                              state.streamFinishReason ||
-                              mergedTodos.length > 0
-                            ) {
-                              await updateChat({
-                                chatId,
-                                title: generatedTitle,
-                                finishReason: state.streamFinishReason,
-                                todos: mergedTodos,
-                                defaultModelSlug: mode,
-                                sandboxType:
-                                  sandboxManager.getEffectivePreference(),
-                                selectedModel: selectedModelOverride,
-                              });
-                            } else {
-                              await prepareForNewStream({ chatId });
+                      // Discard the failed primary leg's model usage so the
+                      // user is only billed for the fallback. Non-model spend
+                      // (sandbox/tools) is preserved.
+                      usageTracker.resetModelLeg();
+
+                      const retryResult = await createStream(fallbackModel);
+                      const retryMessageId = generateId();
+
+                      writer.merge(
+                        retryResult.toUIMessageStream({
+                          generateMessageId: () => retryMessageId,
+                          messageMetadata: ({ part }) => {
+                            if (part.type === "start") {
+                              return {
+                                mode,
+                                generationStartedAt: fallbackStartTime,
+                              };
                             }
 
-                            const accumulatedFiles =
-                              getFileAccumulator().getAll();
-                            const newFileIds = accumulatedFiles.map(
-                              (f) => f.fileId,
-                            );
-
-                            // Only save NEW assistant messages from retry (skip already-saved user messages)
-                            for (const msg of retryMessages) {
-                              if (msg.role !== "assistant") continue;
-
-                              const processed =
-                                summarizationTracker.processMessageForSave(msg);
-
-                              await saveMessage({
-                                chatId,
-                                userId,
-                                message: processed,
-                                extraFileIds: newFileIds,
-                                usage: state.streamUsage,
-                                model: state.responseModel,
+                            if (part.type === "finish") {
+                              return {
                                 mode,
                                 generationStartedAt: fallbackStartTime,
                                 generationTimeMs:
                                   Date.now() - fallbackStartTime,
-                                finishReason: state.streamFinishReason,
-                              });
+                              };
+                            }
+                          },
+                          onFinish: async ({
+                            messages: retryMessages,
+                            isAborted: retryAborted,
+                          }) => {
+                            // Cleanup for retry
+                            preemptiveTimeout?.clear();
+                            if (!subscriberStopped) {
+                              await cancellationSubscriber.stop();
+                              subscriberStopped = true;
                             }
 
-                            // Send file metadata via stream for resumable stream clients
-                            sendFileMetadataToStream(accumulatedFiles);
-                          } else {
-                            // For temporary chats, send file metadata via stream before cleanup
-                            const tempFiles = getFileAccumulator().getAll();
-                            sendFileMetadataToStream(tempFiles);
+                            const sandboxInfo = sandboxManager.getSandboxInfo();
+                            chatLogger!.setSandbox(sandboxInfo);
+                            // Use fallback-only cache tokens (subtract pre-fallback snapshot)
+                            // so the wide event isn't mixing cumulative cache with retry-only usage
+                            const fallbackCacheRead =
+                              usageTracker.cacheReadTokens -
+                              preFallbackCacheRead;
+                            const fallbackCacheWrite =
+                              usageTracker.cacheWriteTokens -
+                              preFallbackCacheWrite;
+                            const fallbackCacheTotal =
+                              fallbackCacheRead + fallbackCacheWrite;
+                            chatLogger!.setCacheMetrics({
+                              cacheHitRate:
+                                fallbackCacheTotal > 0
+                                  ? fallbackCacheRead / fallbackCacheTotal
+                                  : null,
+                              cacheReadTokens: fallbackCacheRead,
+                              cacheWriteTokens: fallbackCacheWrite,
+                            });
+                            captureToolCalls({
+                              posthog,
+                              chatLogger,
+                              userId,
+                              mode,
+                            });
+                            captureAgentRun({
+                              posthog,
+                              userId,
+                              mode,
+                              subscription,
+                              sandboxInfo,
+                              outcome: retryAborted ? "aborted" : "success",
+                            });
+                            shutdownPostHog(posthog);
+                            chatLogger!.emitSuccess({
+                              finishReason: state.streamFinishReason,
+                              wasAborted: retryAborted,
+                              wasPreemptiveTimeout: false,
+                              hadSummarization:
+                                summarizationTracker.hasSummarized,
+                            });
 
-                            // Ensure temp stream row is removed backend-side
-                            await deleteTempStreamForBackend({ chatId });
-                          }
+                            const generatedTitle = await titlePromise;
 
-                          // Verify fallback produced valid content
-                          const fallbackAssistantMessage = retryMessages
-                            .slice()
-                            .reverse()
-                            .find((m) => m.role === "assistant");
-                          const fallbackHasContent =
-                            fallbackAssistantMessage?.parts?.some(
-                              (p) =>
-                                p.type === "text" ||
-                                p.type?.startsWith("tool-") ||
-                                p.type === "reasoning",
-                            ) ?? false;
-                          const fallbackPartTypes =
-                            fallbackAssistantMessage?.parts?.map(
-                              (p) => p.type,
-                            ) ?? [];
+                            if (!temporary) {
+                              const mergedTodos = getTodoManager().mergeWith(
+                                baseTodos,
+                                retryMessageId,
+                              );
 
-                          phLogger.info("Fallback completed", {
-                            chatId,
-                            originalModel: selectedModel,
-                            originalAssistantMessageId: assistantMessageId,
-                            fallbackModel,
-                            fallbackAssistantMessageId: retryMessageId,
-                            fallbackDurationMs: Date.now() - fallbackStartTime,
-                            fallbackSuccess: fallbackHasContent,
-                            fallbackWasAborted: retryAborted,
-                            fallbackMessageCount: retryMessages.length,
-                            fallbackPartTypes,
-                            preFallbackCacheReadTokens: preFallbackCacheRead,
-                            preFallbackCacheWriteTokens: preFallbackCacheWrite,
-                            fallbackCacheReadTokens: fallbackCacheRead,
-                            fallbackCacheWriteTokens: fallbackCacheWrite,
-                            fallbackCacheHitRate:
-                              fallbackCacheTotal > 0
-                                ? fallbackCacheRead / fallbackCacheTotal
-                                : null,
-                            userId,
-                            subscription,
-                          });
+                              if (
+                                generatedTitle ||
+                                state.streamFinishReason ||
+                                mergedTodos.length > 0
+                              ) {
+                                await updateChat({
+                                  chatId,
+                                  title: generatedTitle,
+                                  finishReason: state.streamFinishReason,
+                                  todos: mergedTodos,
+                                  defaultModelSlug: mode,
+                                  sandboxType:
+                                    sandboxManager.getEffectivePreference(),
+                                  selectedModel: selectedModelOverride,
+                                });
+                              } else {
+                                await prepareForNewStream({ chatId });
+                              }
 
-                          // Deduct accumulated usage (includes both original + retry streams)
-                          await deductAccumulatedUsage();
-                        },
-                        sendReasoning: true,
-                      }),
-                    );
+                              const accumulatedFiles =
+                                getFileAccumulator().getAll();
+                              const newFileIds = accumulatedFiles.map(
+                                (f) => f.fileId,
+                              );
 
-                    return; // Skip normal cleanup - retry handles it
-                  }
-                }
+                              // Only save NEW assistant messages from retry (skip already-saved user messages)
+                              for (const msg of retryMessages) {
+                                if (msg.role !== "assistant") continue;
 
-                const isPreemptiveAbort =
-                  preemptiveTimeout?.isPreemptive() ?? false;
-                const onFinishStartTime = Date.now();
-                const triggerTime = preemptiveTimeout?.getTriggerTime();
+                                const processed =
+                                  summarizationTracker.processMessageForSave(
+                                    msg,
+                                  );
 
-                // Helper to log step timing during preemptive timeout
-                const logStep = (step: string, stepStartTime: number) => {
-                  if (isPreemptiveAbort) {
-                    const stepDuration = Date.now() - stepStartTime;
-                    const totalElapsed =
-                      Date.now() - (triggerTime || onFinishStartTime);
-                    phLogger.info("Preemptive timeout cleanup step", {
-                      chatId,
-                      step,
-                      stepDurationMs: stepDuration,
-                      totalElapsedSinceTriggerMs: totalElapsed,
-                      endpoint,
-                    });
-                  }
-                };
+                                await saveMessage({
+                                  chatId,
+                                  userId,
+                                  message: processed,
+                                  extraFileIds: newFileIds,
+                                  usage: state.streamUsage,
+                                  model: state.responseModel,
+                                  mode,
+                                  generationStartedAt: fallbackStartTime,
+                                  generationTimeMs:
+                                    Date.now() - fallbackStartTime,
+                                  finishReason: state.streamFinishReason,
+                                });
+                              }
 
-                if (isPreemptiveAbort) {
-                  phLogger.info("Preemptive timeout onFinish started", {
-                    chatId,
-                    endpoint,
-                    timeSinceTriggerMs: triggerTime
-                      ? onFinishStartTime - triggerTime
-                      : null,
-                    messageCount: messages.length,
-                    isTemporary: temporary,
-                  });
-                }
+                              // Send file metadata via stream for resumable stream clients
+                              sendFileMetadataToStream(accumulatedFiles);
+                            } else {
+                              // For temporary chats, send file metadata via stream before cleanup
+                              const tempFiles = getFileAccumulator().getAll();
+                              sendFileMetadataToStream(tempFiles);
 
-                // Clear pre-emptive timeout
-                let stepStart = Date.now();
-                preemptiveTimeout?.clear();
-                logStep("clear_timeout", stepStart);
+                              // Ensure temp stream row is removed backend-side
+                              await deleteTempStreamForBackend({ chatId });
+                            }
 
-                // Stop cancellation subscriber
-                stepStart = Date.now();
-                await cancellationSubscriber.stop();
-                subscriberStopped = true;
-                logStep("stop_cancellation_subscriber", stepStart);
+                            // Verify fallback produced valid content
+                            const fallbackAssistantMessage = retryMessages
+                              .slice()
+                              .reverse()
+                              .find((m) => m.role === "assistant");
+                            const fallbackHasContent =
+                              fallbackAssistantMessage?.parts?.some(
+                                (p) =>
+                                  p.type === "text" ||
+                                  p.type?.startsWith("tool-") ||
+                                  p.type === "reasoning",
+                              ) ?? false;
+                            const fallbackPartTypes =
+                              fallbackAssistantMessage?.parts?.map(
+                                (p) => p.type,
+                              ) ?? [];
 
-                // Clear finish reason for user-initiated aborts (not pre-emptive timeouts)
-                // This prevents showing "going off course" message when user clicks stop
-                if (isAborted && !isPreemptiveAbort) {
-                  state.streamFinishReason = undefined;
-                }
+                            phLogger.info("Fallback completed", {
+                              chatId,
+                              originalModel: selectedModel,
+                              originalAssistantMessageId: assistantMessageId,
+                              fallbackModel,
+                              fallbackAssistantMessageId: retryMessageId,
+                              fallbackDurationMs:
+                                Date.now() - fallbackStartTime,
+                              fallbackSuccess: fallbackHasContent,
+                              fallbackWasAborted: retryAborted,
+                              fallbackMessageCount: retryMessages.length,
+                              fallbackPartTypes,
+                              preFallbackCacheReadTokens: preFallbackCacheRead,
+                              preFallbackCacheWriteTokens:
+                                preFallbackCacheWrite,
+                              fallbackCacheReadTokens: fallbackCacheRead,
+                              fallbackCacheWriteTokens: fallbackCacheWrite,
+                              fallbackCacheHitRate:
+                                fallbackCacheTotal > 0
+                                  ? fallbackCacheRead / fallbackCacheTotal
+                                  : null,
+                              userId,
+                              subscription,
+                            });
 
-                // Emit wide event
-                stepStart = Date.now();
-                const sandboxInfo = sandboxManager.getSandboxInfo();
-                chatLogger!.setSandbox(sandboxInfo);
-                chatLogger!.setCacheMetrics({
-                  cacheHitRate: usageTracker.cacheHitRate,
-                  cacheReadTokens: usageTracker.cacheReadTokens,
-                  cacheWriteTokens: usageTracker.cacheWriteTokens,
-                });
-                captureToolCalls({ posthog, chatLogger, userId, mode });
-                captureAgentRun({
-                  posthog,
-                  userId,
-                  mode,
-                  subscription,
-                  sandboxInfo,
-                  outcome: isAborted ? "aborted" : "success",
-                });
-                shutdownPostHog(posthog);
-                chatLogger!.emitSuccess({
-                  finishReason: state.streamFinishReason,
-                  wasAborted: isAborted,
-                  wasPreemptiveTimeout: isPreemptiveAbort,
-                  hadSummarization: summarizationTracker.hasSummarized,
-                });
-                logStep("emit_success_event", stepStart);
-
-                // Sandbox cleanup is automatic with auto-pause
-                // The sandbox will auto-pause after inactivity timeout (7 minutes)
-                // No manual pause needed
-
-                // Always wait for title generation to complete
-                stepStart = Date.now();
-                const generatedTitle = await titlePromise;
-                logStep("wait_title_generation", stepStart);
-
-                if (!temporary) {
-                  stepStart = Date.now();
-                  const mergedTodos = getTodoManager().mergeWith(
-                    baseTodos,
-                    assistantMessageId,
-                  );
-                  logStep("merge_todos", stepStart);
-
-                  const shouldPersist = regenerate
-                    ? true
-                    : Boolean(
-                        generatedTitle ||
-                        state.streamFinishReason ||
-                        mergedTodos.length > 0,
+                            // Deduct accumulated usage (includes both original + retry streams)
+                            await deductAccumulatedUsage();
+                          },
+                          sendReasoning: true,
+                        }),
                       );
 
-                  if (shouldPersist) {
-                    // updateChat automatically clears stream state (active_stream_id and canceled_at)
-                    stepStart = Date.now();
-                    await updateChat({
-                      chatId,
-                      title: generatedTitle,
-                      finishReason: state.streamFinishReason,
-                      todos: mergedTodos,
-                      defaultModelSlug: mode,
-                      sandboxType: sandboxManager.getEffectivePreference(),
-                      selectedModel: selectedModelOverride,
-                    });
-                    logStep("update_chat", stepStart);
-                  } else {
-                    // If not persisting, still need to clear stream state
-                    stepStart = Date.now();
-                    await prepareForNewStream({ chatId });
-                    logStep("prepare_for_new_stream", stepStart);
-                  }
-
-                  stepStart = Date.now();
-                  const accumulatedFiles = getFileAccumulator().getAll();
-                  const newFileIds = accumulatedFiles.map((f) => f.fileId);
-                  logStep("get_accumulated_files", stepStart);
-
-                  // Check if any messages have incomplete tool calls that need completion
-                  const hasIncompleteToolCalls = messages.some(
-                    (msg) =>
-                      msg.role === "assistant" &&
-                      msg.parts?.some(
-                        (p: {
-                          type?: string;
-                          state?: string;
-                          toolCallId?: string;
-                        }) =>
-                          p.type?.startsWith("tool-") &&
-                          p.state !== "output-available" &&
-                          p.toolCallId,
-                      ),
-                  );
-                  const incompleteToolSummaries = isAborted
-                    ? summarizeIncompleteToolParts(messages)
-                    : [];
-                  if (incompleteToolSummaries.length > 0) {
-                    console.info(
-                      JSON.stringify({
-                        level: "info",
-                        event: "abort_incomplete_tool_calls_detected",
-                        service: "chat-handler",
-                        timestamp: new Date().toISOString(),
-                        chat_id: chatId,
-                        user_id: userId,
-                        mode,
-                        finish_reason: state.streamFinishReason,
-                        is_preemptive_abort: isPreemptiveAbort,
-                        incomplete_tool_count: incompleteToolSummaries.length,
-                        incomplete_tools: incompleteToolSummaries,
-                      }),
-                    );
-                  }
-
-                  // On abort, streamText.onFinish may not have fired yet, so state.streamUsage
-                  // could be undefined. Await usage from result to ensure we capture it.
-                  // This must happen BEFORE we decide whether to skip saving.
-                  let resolvedUsage: Record<string, unknown> | undefined =
-                    state.streamUsage;
-                  if (!resolvedUsage && isAborted) {
-                    try {
-                      resolvedUsage = (await result.usage) as Record<
-                        string,
-                        unknown
-                      >;
-                    } catch {
-                      // Usage unavailable on abort - continue without it
+                      return; // Skip normal cleanup - retry handles it
                     }
                   }
 
-                  const hasUsageToRecord = Boolean(resolvedUsage);
-                  const shouldSkipSaveSignal =
-                    cancellationSubscriber.shouldSkipSave();
+                  const isPreemptiveAbort =
+                    preemptiveTimeout?.isPreemptive() ?? false;
+                  const onFinishStartTime = Date.now();
+                  const triggerTime = preemptiveTimeout?.getTriggerTime();
 
-                  // If user aborted (not pre-emptive), skip message save when:
-                  // 1. skipSave signal received via Redis (edit/regenerate/retry — message will be discarded)
-                  // 2. No files, tools, or usage to record (frontend already saved the message)
-                  if (
-                    isAborted &&
-                    !isPreemptiveAbort &&
-                    (shouldSkipSaveSignal ||
-                      (newFileIds.length === 0 &&
-                        !hasIncompleteToolCalls &&
-                        !hasUsageToRecord))
-                  ) {
-                    console.info(
-                      JSON.stringify({
-                        level: "info",
-                        event: "abort_message_save_skipped",
-                        service: "chat-handler",
-                        timestamp: new Date().toISOString(),
-                        chat_id: chatId,
-                        user_id: userId,
-                        mode,
-                        finish_reason: state.streamFinishReason,
-                        skip_save_signal: shouldSkipSaveSignal,
-                        new_file_count: newFileIds.length,
-                        has_incomplete_tool_calls: hasIncompleteToolCalls,
-                        has_usage_to_record: hasUsageToRecord,
-                      }),
-                    );
-                    await deductAccumulatedUsage();
-                    return;
-                  }
-
-                  // Save messages (either full save or just append extraFileIds)
-                  stepStart = Date.now();
-                  for (const message of messages) {
-                    let processedMessage =
-                      summarizationTracker.processMessageForSave(message);
-
-                    // Skip saving messages with no parts or files
-                    // This prevents saving empty messages on error that would accumulate on retry
-                    if (
-                      (!processedMessage.parts ||
-                        processedMessage.parts.length === 0) &&
-                      newFileIds.length === 0
-                    ) {
-                      continue;
-                    }
-
-                    // Use resolvedUsage which was already awaited above on abort
-                    // Falls back to state.streamUsage for non-abort cases
-                    // On user-initiated abort, use updateOnly as safety net:
-                    // only patch existing messages (add files/usage), don't create new ones.
-                    // This prevents orphan messages when Redis skipSave signal was missed.
-                    try {
-                      await saveMessage({
+                  // Helper to log step timing during preemptive timeout
+                  const logStep = (step: string, stepStartTime: number) => {
+                    if (isPreemptiveAbort) {
+                      const stepDuration = Date.now() - stepStartTime;
+                      const totalElapsed =
+                        Date.now() - (triggerTime || onFinishStartTime);
+                      phLogger.info("Preemptive timeout cleanup step", {
                         chatId,
-                        userId,
-                        message: processedMessage,
-                        extraFileIds: newFileIds,
-                        model: state.responseModel || configuredModelId,
-                        mode,
-                        generationStartedAt:
-                          processedMessage.role === "assistant"
-                            ? streamStartTime
-                            : undefined,
-                        generationTimeMs: Date.now() - streamStartTime,
-                        finishReason: state.streamFinishReason,
-                        usage: resolvedUsage ?? state.streamUsage,
-                        updateOnly:
-                          isAborted && !isPreemptiveAbort ? true : undefined,
-                        isHidden:
-                          isAutoContinue && processedMessage.role === "user"
-                            ? true
-                            : undefined,
-                        wasAborted: isAborted,
-                        wasPreemptiveTimeout: isPreemptiveAbort,
+                        step,
+                        stepDurationMs: stepDuration,
+                        totalElapsedSinceTriggerMs: totalElapsed,
+                        endpoint,
                       });
-                    } catch (error) {
-                      if (isPreemptiveAbort) {
-                        console.error(
-                          JSON.stringify({
-                            level: "error",
-                            event: "preemptive_timeout_message_save_failed",
-                            service: "chat-handler",
-                            timestamp: new Date().toISOString(),
-                            chat_id: chatId,
-                            user_id: userId,
-                            message_id: processedMessage.id,
-                            message_role: processedMessage.role,
-                            mode,
-                            model: state.responseModel || configuredModelId,
-                            finish_reason: state.streamFinishReason,
-                            time_since_timeout_trigger_ms: triggerTime
-                              ? Date.now() - triggerTime
-                              : null,
-                            stream_duration_ms: Date.now() - streamStartTime,
-                            error_name:
-                              error instanceof Error
-                                ? error.name
-                                : typeof error,
-                            error_message:
-                              error instanceof Error
-                                ? error.message
-                                : String(error),
-                            error_metadata:
-                              error &&
-                              typeof error === "object" &&
-                              "metadata" in error
-                                ? (error as { metadata?: unknown }).metadata
-                                : undefined,
-                          }),
-                        );
-                      }
-                      throw error;
                     }
+                  };
+
+                  if (isPreemptiveAbort) {
+                    phLogger.info("Preemptive timeout onFinish started", {
+                      chatId,
+                      endpoint,
+                      timeSinceTriggerMs: triggerTime
+                        ? onFinishStartTime - triggerTime
+                        : null,
+                      messageCount: messages.length,
+                      isTemporary: temporary,
+                    });
                   }
-                  logStep("save_messages", stepStart);
 
-                  // Send file metadata via stream for resumable stream clients
-                  // Uses accumulated metadata directly - no DB query needed!
-                  stepStart = Date.now();
-                  sendFileMetadataToStream(accumulatedFiles);
-                  logStep("send_file_metadata", stepStart);
-                } else {
-                  // For temporary chats, send file metadata via stream before cleanup
-                  stepStart = Date.now();
-                  const tempFiles = getFileAccumulator().getAll();
-                  sendFileMetadataToStream(tempFiles);
-                  logStep("send_temp_file_metadata", stepStart);
+                  // Clear pre-emptive timeout
+                  let stepStart = Date.now();
+                  preemptiveTimeout?.clear();
+                  logStep("clear_timeout", stepStart);
 
-                  // Ensure temp stream row is removed backend-side
+                  // Stop cancellation subscriber
                   stepStart = Date.now();
-                  await deleteTempStreamForBackend({ chatId });
-                  logStep("delete_temp_stream", stepStart);
-                }
+                  await cancellationSubscriber.stop();
+                  subscriberStopped = true;
+                  logStep("stop_cancellation_subscriber", stepStart);
 
-                if (isPreemptiveAbort) {
-                  const totalDuration = Date.now() - onFinishStartTime;
-                  phLogger.info("Preemptive timeout onFinish completed", {
-                    chatId,
-                    endpoint,
-                    totalOnFinishDurationMs: totalDuration,
-                    totalSinceTriggerMs: triggerTime
-                      ? Date.now() - triggerTime
-                      : null,
+                  // Clear finish reason for user-initiated aborts (not pre-emptive timeouts)
+                  // This prevents showing "going off course" message when user clicks stop
+                  if (isAborted && !isPreemptiveAbort) {
+                    state.streamFinishReason = undefined;
+                  }
+
+                  // Emit wide event
+                  stepStart = Date.now();
+                  const sandboxInfo = sandboxManager.getSandboxInfo();
+                  chatLogger!.setSandbox(sandboxInfo);
+                  chatLogger!.setCacheMetrics({
+                    cacheHitRate: usageTracker.cacheHitRate,
+                    cacheReadTokens: usageTracker.cacheReadTokens,
+                    cacheWriteTokens: usageTracker.cacheWriteTokens,
                   });
-                  await phLogger.flush();
-                }
-
-                // Send updated context usage with output tokens included
-                if (contextUsageOn) {
-                  writeContextUsage(writer, {
-                    usedTokens:
-                      state.ctxUsage.usedTokens +
-                      usageTracker.streamOutputTokens,
-                    maxTokens: state.ctxUsage.maxTokens,
+                  captureToolCalls({ posthog, chatLogger, userId, mode });
+                  captureAgentRun({
+                    posthog,
+                    userId,
+                    mode,
+                    subscription,
+                    sandboxInfo,
+                    outcome: isAborted ? "aborted" : "success",
                   });
-                }
+                  shutdownPostHog(posthog);
+                  chatLogger!.emitSuccess({
+                    finishReason: state.streamFinishReason,
+                    wasAborted: isAborted,
+                    wasPreemptiveTimeout: isPreemptiveAbort,
+                    hadSummarization: summarizationTracker.hasSummarized,
+                  });
+                  logStep("emit_success_event", stepStart);
 
-                if (
-                  (state.stoppedDueToTokenExhaustion ||
-                    state.stoppedDueToElapsedTimeout ||
-                    state.streamFinishReason === "tool-calls") &&
-                  isAgentMode(mode) &&
-                  !temporary
-                ) {
-                  writeAutoContinue(writer);
-                }
+                  // Sandbox cleanup is automatic with auto-pause
+                  // The sandbox will auto-pause after inactivity timeout (7 minutes)
+                  // No manual pause needed
 
-                await deductAccumulatedUsage();
-              },
-              sendReasoning: true,
-            }),
-          );
+                  // Always wait for title generation to complete
+                  stepStart = Date.now();
+                  const generatedTitle = await titlePromise;
+                  logStep("wait_title_generation", stepStart);
+
+                  if (!temporary) {
+                    stepStart = Date.now();
+                    const mergedTodos = getTodoManager().mergeWith(
+                      baseTodos,
+                      assistantMessageId,
+                    );
+                    logStep("merge_todos", stepStart);
+
+                    const shouldPersist = regenerate
+                      ? true
+                      : Boolean(
+                          generatedTitle ||
+                          state.streamFinishReason ||
+                          mergedTodos.length > 0,
+                        );
+
+                    if (shouldPersist) {
+                      // updateChat automatically clears stream state (active_stream_id and canceled_at)
+                      stepStart = Date.now();
+                      await updateChat({
+                        chatId,
+                        title: generatedTitle,
+                        finishReason: state.streamFinishReason,
+                        todos: mergedTodos,
+                        defaultModelSlug: mode,
+                        sandboxType: sandboxManager.getEffectivePreference(),
+                        selectedModel: selectedModelOverride,
+                      });
+                      logStep("update_chat", stepStart);
+                    } else {
+                      // If not persisting, still need to clear stream state
+                      stepStart = Date.now();
+                      await prepareForNewStream({ chatId });
+                      logStep("prepare_for_new_stream", stepStart);
+                    }
+
+                    stepStart = Date.now();
+                    const accumulatedFiles = getFileAccumulator().getAll();
+                    const newFileIds = accumulatedFiles.map((f) => f.fileId);
+                    logStep("get_accumulated_files", stepStart);
+
+                    // Check if any messages have incomplete tool calls that need completion
+                    const hasIncompleteToolCalls = messages.some(
+                      (msg) =>
+                        msg.role === "assistant" &&
+                        msg.parts?.some(
+                          (p: {
+                            type?: string;
+                            state?: string;
+                            toolCallId?: string;
+                          }) =>
+                            p.type?.startsWith("tool-") &&
+                            p.state !== "output-available" &&
+                            p.toolCallId,
+                        ),
+                    );
+                    const incompleteToolSummaries = isAborted
+                      ? summarizeIncompleteToolParts(messages)
+                      : [];
+                    if (incompleteToolSummaries.length > 0) {
+                      console.info(
+                        JSON.stringify({
+                          level: "info",
+                          event: "abort_incomplete_tool_calls_detected",
+                          service: "chat-handler",
+                          timestamp: new Date().toISOString(),
+                          chat_id: chatId,
+                          user_id: userId,
+                          mode,
+                          finish_reason: state.streamFinishReason,
+                          is_preemptive_abort: isPreemptiveAbort,
+                          incomplete_tool_count: incompleteToolSummaries.length,
+                          incomplete_tools: incompleteToolSummaries,
+                        }),
+                      );
+                    }
+
+                    // On abort, streamText.onFinish may not have fired yet, so state.streamUsage
+                    // could be undefined. Await usage from result to ensure we capture it.
+                    // This must happen BEFORE we decide whether to skip saving.
+                    let resolvedUsage: Record<string, unknown> | undefined =
+                      state.streamUsage;
+                    if (!resolvedUsage && isAborted) {
+                      try {
+                        resolvedUsage = (await result.usage) as Record<
+                          string,
+                          unknown
+                        >;
+                      } catch {
+                        // Usage unavailable on abort - continue without it
+                      }
+                    }
+
+                    const hasUsageToRecord = Boolean(resolvedUsage);
+                    const shouldSkipSaveSignal =
+                      cancellationSubscriber.shouldSkipSave();
+
+                    // If user aborted (not pre-emptive), skip message save when:
+                    // 1. skipSave signal received via Redis (edit/regenerate/retry — message will be discarded)
+                    // 2. No files, tools, or usage to record (frontend already saved the message)
+                    if (
+                      isAborted &&
+                      !isPreemptiveAbort &&
+                      (shouldSkipSaveSignal ||
+                        (newFileIds.length === 0 &&
+                          !hasIncompleteToolCalls &&
+                          !hasUsageToRecord))
+                    ) {
+                      console.info(
+                        JSON.stringify({
+                          level: "info",
+                          event: "abort_message_save_skipped",
+                          service: "chat-handler",
+                          timestamp: new Date().toISOString(),
+                          chat_id: chatId,
+                          user_id: userId,
+                          mode,
+                          finish_reason: state.streamFinishReason,
+                          skip_save_signal: shouldSkipSaveSignal,
+                          new_file_count: newFileIds.length,
+                          has_incomplete_tool_calls: hasIncompleteToolCalls,
+                          has_usage_to_record: hasUsageToRecord,
+                        }),
+                      );
+                      await deductAccumulatedUsage();
+                      return;
+                    }
+
+                    // Save messages (either full save or just append extraFileIds)
+                    stepStart = Date.now();
+                    for (const message of messages) {
+                      let processedMessage =
+                        summarizationTracker.processMessageForSave(message);
+
+                      // Skip saving messages with no parts or files
+                      // This prevents saving empty messages on error that would accumulate on retry
+                      if (
+                        (!processedMessage.parts ||
+                          processedMessage.parts.length === 0) &&
+                        newFileIds.length === 0
+                      ) {
+                        continue;
+                      }
+
+                      // Use resolvedUsage which was already awaited above on abort
+                      // Falls back to state.streamUsage for non-abort cases
+                      // On user-initiated abort, use updateOnly as safety net:
+                      // only patch existing messages (add files/usage), don't create new ones.
+                      // This prevents orphan messages when Redis skipSave signal was missed.
+                      try {
+                        await saveMessage({
+                          chatId,
+                          userId,
+                          message: processedMessage,
+                          extraFileIds: newFileIds,
+                          model: state.responseModel || configuredModelId,
+                          mode,
+                          generationStartedAt:
+                            processedMessage.role === "assistant"
+                              ? streamStartTime
+                              : undefined,
+                          generationTimeMs: Date.now() - streamStartTime,
+                          finishReason: state.streamFinishReason,
+                          usage: resolvedUsage ?? state.streamUsage,
+                          updateOnly:
+                            isAborted && !isPreemptiveAbort ? true : undefined,
+                          isHidden:
+                            isAutoContinue && processedMessage.role === "user"
+                              ? true
+                              : undefined,
+                          wasAborted: isAborted,
+                          wasPreemptiveTimeout: isPreemptiveAbort,
+                        });
+                      } catch (error) {
+                        if (isPreemptiveAbort) {
+                          console.error(
+                            JSON.stringify({
+                              level: "error",
+                              event: "preemptive_timeout_message_save_failed",
+                              service: "chat-handler",
+                              timestamp: new Date().toISOString(),
+                              chat_id: chatId,
+                              user_id: userId,
+                              message_id: processedMessage.id,
+                              message_role: processedMessage.role,
+                              mode,
+                              model: state.responseModel || configuredModelId,
+                              finish_reason: state.streamFinishReason,
+                              time_since_timeout_trigger_ms: triggerTime
+                                ? Date.now() - triggerTime
+                                : null,
+                              stream_duration_ms: Date.now() - streamStartTime,
+                              error_name:
+                                error instanceof Error
+                                  ? error.name
+                                  : typeof error,
+                              error_message:
+                                error instanceof Error
+                                  ? error.message
+                                  : String(error),
+                              error_metadata:
+                                error &&
+                                typeof error === "object" &&
+                                "metadata" in error
+                                  ? (error as { metadata?: unknown }).metadata
+                                  : undefined,
+                            }),
+                          );
+                        }
+                        throw error;
+                      }
+                    }
+                    logStep("save_messages", stepStart);
+
+                    // Send file metadata via stream for resumable stream clients
+                    // Uses accumulated metadata directly - no DB query needed!
+                    stepStart = Date.now();
+                    sendFileMetadataToStream(accumulatedFiles);
+                    logStep("send_file_metadata", stepStart);
+                  } else {
+                    // For temporary chats, send file metadata via stream before cleanup
+                    stepStart = Date.now();
+                    const tempFiles = getFileAccumulator().getAll();
+                    sendFileMetadataToStream(tempFiles);
+                    logStep("send_temp_file_metadata", stepStart);
+
+                    // Ensure temp stream row is removed backend-side
+                    stepStart = Date.now();
+                    await deleteTempStreamForBackend({ chatId });
+                    logStep("delete_temp_stream", stepStart);
+                  }
+
+                  if (isPreemptiveAbort) {
+                    const totalDuration = Date.now() - onFinishStartTime;
+                    phLogger.info("Preemptive timeout onFinish completed", {
+                      chatId,
+                      endpoint,
+                      totalOnFinishDurationMs: totalDuration,
+                      totalSinceTriggerMs: triggerTime
+                        ? Date.now() - triggerTime
+                        : null,
+                    });
+                    await phLogger.flush();
+                  }
+
+                  // Send updated context usage with output tokens included
+                  if (contextUsageOn) {
+                    writeContextUsage(writer, {
+                      usedTokens:
+                        state.ctxUsage.usedTokens +
+                        usageTracker.streamOutputTokens,
+                      maxTokens: state.ctxUsage.maxTokens,
+                    });
+                  }
+
+                  if (
+                    (state.stoppedDueToTokenExhaustion ||
+                      state.stoppedDueToElapsedTimeout ||
+                      state.streamFinishReason === "tool-calls") &&
+                    isAgentMode(mode) &&
+                    !temporary
+                  ) {
+                    writeAutoContinue(writer);
+                  }
+
+                  await deductAccumulatedUsage();
+                },
+                sendReasoning: true,
+              }),
+            );
+          } catch (error) {
+            await releaseFreeRunLockOnce();
+            throw error;
+          }
         },
       });
 
@@ -1372,6 +1411,7 @@ export const createChatHandler = (
     } catch (error) {
       // Clear timeout if error occurs before onFinish
       preemptiveTimeout?.clear();
+      await releaseFreeRunLockOnce();
 
       // Best-effort PTY cleanup — the stream may never have reached onFinish.
       if (outerChatId) {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -109,8 +109,7 @@ import {
   initAgentStreamState,
   type AgentStreamContext,
 } from "@/lib/api/agent-stream-runner";
-
-const FREE_RUN_LOCK_TTL_SECONDS = 15 * 60;
+import { FREE_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
 
 function getStreamContext() {
   try {

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -21,7 +21,12 @@ import type {
   Todo,
   UserCustomization,
 } from "@/types";
-import { isAnthropicModel, myProvider } from "@/lib/ai/providers";
+import {
+  isAnthropicModel,
+  isDeepSeekModel,
+  isGeminiModel,
+  myProvider,
+} from "@/lib/ai/providers";
 import type { ModelName } from "@/lib/ai/providers";
 import type { ContextUsageData } from "@/app/components/ContextUsageIndicator";
 import type { Id } from "@/convex/_generated/dataModel";
@@ -458,6 +463,9 @@ export class SummarizationTracker {
 const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "ask-model-free": ["fallback-ask-model"],
   "agent-model-free": ["fallback-agent-model"],
+  "model-deepseek-v4-flash": ["fallback-ask-model"],
+  "ask-model": ["fallback-grok-4.3"],
+  "model-gemini-3-flash": ["fallback-grok-4.3"],
 };
 
 const ANTHROPIC_FALLBACK_CHAIN_BY_MODE: Record<ChatMode, readonly ModelName[]> =
@@ -476,6 +484,19 @@ const getFallbackKeys = (
   }
   return MODEL_FALLBACK_CHAIN[modelName as ModelName];
 };
+
+export function getRetryFallbackModel(
+  modelName: ModelName,
+  mode: ChatMode,
+): ModelName {
+  if (isDeepSeekModel(modelName)) {
+    return mode === "agent" ? "fallback-agent-model" : "fallback-ask-model";
+  }
+  if (isGeminiModel(modelName)) {
+    return "fallback-grok-4.3";
+  }
+  return "fallback-grok-4.3";
+}
 
 const resolveSlug = (modelName: string): string | undefined => {
   try {

--- a/lib/rate-limit/__tests__/free-concurrency.test.ts
+++ b/lib/rate-limit/__tests__/free-concurrency.test.ts
@@ -63,6 +63,21 @@ describe("acquireFreeRunConcurrencyLock", () => {
     });
   });
 
+  it("allows release to be retried when Redis unlock fails", async () => {
+    mockCreateRedisClient.mockReturnValue({ set: mockSet, eval: mockEval });
+    mockEval
+      .mockRejectedValueOnce(new Error("temporary redis failure"))
+      .mockResolvedValueOnce(1);
+    const { acquireFreeRunConcurrencyLock } = getIsolatedModule();
+
+    const lock = await acquireFreeRunConcurrencyLock("user-123", 60);
+
+    await expect(lock.release()).rejects.toThrow("temporary redis failure");
+    await expect(lock.release()).resolves.toBeUndefined();
+
+    expect(mockEval).toHaveBeenCalledTimes(2);
+  });
+
   it("skips the lock outside production when Redis is unavailable", async () => {
     mockCreateRedisClient.mockReturnValue(null);
     const { acquireFreeRunConcurrencyLock } = getIsolatedModule();

--- a/lib/rate-limit/__tests__/free-concurrency.test.ts
+++ b/lib/rate-limit/__tests__/free-concurrency.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+describe("acquireFreeRunConcurrencyLock", () => {
+  const mockCreateRedisClient = jest.fn();
+  const mockSet = jest.fn();
+  const mockEval = jest.fn();
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockSet.mockResolvedValue("OK");
+    mockEval.mockResolvedValue(1);
+  });
+
+  const getIsolatedModule = () => {
+    let isolatedModule: typeof import("../free-concurrency");
+
+    jest.isolateModules(() => {
+      jest.doMock("../redis", () => ({
+        createRedisClient: mockCreateRedisClient,
+      }));
+
+      isolatedModule = require("../free-concurrency");
+    });
+
+    return isolatedModule!;
+  };
+
+  it("acquires a per-user Redis lock and releases it by token", async () => {
+    mockCreateRedisClient.mockReturnValue({ set: mockSet, eval: mockEval });
+    const { acquireFreeRunConcurrencyLock } = getIsolatedModule();
+
+    const lock = await acquireFreeRunConcurrencyLock("user-123", 60);
+
+    expect(mockSet).toHaveBeenCalledWith(
+      "free_run_lock:user-123",
+      expect.any(String),
+      { nx: true, ex: 60 },
+    );
+
+    await lock.release();
+    await lock.release();
+
+    expect(mockEval).toHaveBeenCalledTimes(1);
+    expect(mockEval).toHaveBeenCalledWith(
+      expect.any(String),
+      ["free_run_lock:user-123"],
+      [expect.any(String)],
+    );
+  });
+
+  it("throws a rate-limit error when another free run is active", async () => {
+    mockCreateRedisClient.mockReturnValue({ set: mockSet, eval: mockEval });
+    mockSet.mockResolvedValue(null);
+    const { acquireFreeRunConcurrencyLock } = getIsolatedModule();
+
+    await expect(
+      acquireFreeRunConcurrencyLock("user-123", 60),
+    ).rejects.toMatchObject({
+      type: "rate_limit",
+      surface: "chat",
+      cause: expect.stringContaining("already have a free request running"),
+    });
+  });
+
+  it("skips the lock outside production when Redis is unavailable", async () => {
+    mockCreateRedisClient.mockReturnValue(null);
+    const { acquireFreeRunConcurrencyLock } = getIsolatedModule();
+
+    const lock = await acquireFreeRunConcurrencyLock("user-123", 60);
+
+    expect(lock.rateLimitSkipped).toBe(true);
+    await expect(lock.release()).resolves.toBeUndefined();
+  });
+});

--- a/lib/rate-limit/__tests__/free-monthly-cost.test.ts
+++ b/lib/rate-limit/__tests__/free-monthly-cost.test.ts
@@ -1,0 +1,100 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+
+describe("free monthly cost limit", () => {
+  const mockCreateRedisClient = jest.fn();
+  const mockGet = jest.fn();
+  const mockEval = jest.fn();
+  const originalEnv = process.env.FREE_MONTHLY_COST_LIMIT_USD;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    delete process.env.FREE_MONTHLY_COST_LIMIT_USD;
+    mockGet.mockResolvedValue(null);
+    mockEval.mockResolvedValue(1);
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.FREE_MONTHLY_COST_LIMIT_USD;
+    } else {
+      process.env.FREE_MONTHLY_COST_LIMIT_USD = originalEnv;
+    }
+  });
+
+  const getIsolatedModule = () => {
+    let isolatedModule: typeof import("../free-monthly-cost");
+
+    jest.isolateModules(() => {
+      jest.doMock("../redis", () => ({
+        createRedisClient: mockCreateRedisClient,
+      }));
+
+      isolatedModule = require("../free-monthly-cost");
+    });
+
+    return isolatedModule!;
+  };
+
+  it("checks the default $0.25 monthly free cost cap", async () => {
+    mockCreateRedisClient.mockReturnValue({ get: mockGet, eval: mockEval });
+    mockGet.mockResolvedValue(1250);
+    const { checkFreeMonthlyCostLimit } = getIsolatedModule();
+
+    const snapshot = await checkFreeMonthlyCostLimit("user-123");
+
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.stringMatching(/^free_monthly_cost:user-123:\d{4}-\d{2}$/),
+    );
+    expect(snapshot.monthlyLimitPoints).toBe(2500);
+    expect(snapshot.monthlyRemainingAtStart).toBe(1250);
+    expect(snapshot.extraUsageBalanceAtStart).toBe(0);
+    expect(snapshot.extraUsageAutoReload).toBe(false);
+  });
+
+  it("throws a rate-limit error when the monthly free cost cap is exhausted", async () => {
+    process.env.FREE_MONTHLY_COST_LIMIT_USD = "0.01";
+    mockCreateRedisClient.mockReturnValue({ get: mockGet, eval: mockEval });
+    mockGet.mockResolvedValue(100);
+    const { checkFreeMonthlyCostLimit } = getIsolatedModule();
+
+    await expect(checkFreeMonthlyCostLimit("user-123")).rejects.toMatchObject({
+      type: "rate_limit",
+      surface: "chat",
+      cause: expect.stringContaining("free monthly usage"),
+    });
+  });
+
+  it("records actual free usage cost as monthly points", async () => {
+    mockCreateRedisClient.mockReturnValue({ get: mockGet, eval: mockEval });
+    const { recordFreeMonthlyCost } = getIsolatedModule();
+
+    await recordFreeMonthlyCost("user-123", 0.0123);
+
+    expect(mockEval).toHaveBeenCalledWith(
+      expect.any(String),
+      [expect.stringMatching(/^free_monthly_cost:user-123:\d{4}-\d{2}$/)],
+      [123, expect.any(Number)],
+    );
+  });
+
+  it("skips checks outside production when Redis is unavailable", async () => {
+    mockCreateRedisClient.mockReturnValue(null);
+    const { checkFreeMonthlyCostLimit, recordFreeMonthlyCost } =
+      getIsolatedModule();
+
+    const snapshot = await checkFreeMonthlyCostLimit("user-123");
+
+    expect(snapshot.rateLimitSkipped).toBe(true);
+    await expect(
+      recordFreeMonthlyCost("user-123", 0.01),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/lib/rate-limit/free-concurrency.ts
+++ b/lib/rate-limit/free-concurrency.ts
@@ -1,0 +1,65 @@
+import { ChatSDKError } from "@/lib/errors";
+import { createRedisClient } from "./redis";
+
+const FREE_RUN_LOCK_TTL_SECONDS_DEFAULT = 15 * 60;
+
+const RELEASE_FREE_RUN_LOCK_SCRIPT = `
+local key = KEYS[1]
+local token = ARGV[1]
+
+if redis.call("GET", key) == token then
+  return redis.call("DEL", key)
+end
+
+return 0
+`;
+
+export type FreeRunConcurrencyLock = {
+  release: () => Promise<void>;
+  rateLimitSkipped?: boolean;
+};
+
+const freeRunLockKey = (userId: string) => `free_run_lock:${userId}`;
+
+export async function acquireFreeRunConcurrencyLock(
+  userId: string,
+  ttlSeconds = FREE_RUN_LOCK_TTL_SECONDS_DEFAULT,
+): Promise<FreeRunConcurrencyLock> {
+  const redis = createRedisClient();
+
+  if (!redis) {
+    if (process.env.NODE_ENV !== "production") {
+      return {
+        rateLimitSkipped: true,
+        release: async () => {},
+      };
+    }
+    throw new ChatSDKError(
+      "rate_limit:chat",
+      "Rate limiting service is not configured",
+    );
+  }
+
+  const lockKey = freeRunLockKey(userId);
+  const lockToken = crypto.randomUUID();
+  const acquired = await redis.set(lockKey, lockToken, {
+    nx: true,
+    ex: Math.max(1, Math.trunc(ttlSeconds)),
+  });
+
+  if (acquired !== "OK") {
+    throw new ChatSDKError(
+      "rate_limit:chat",
+      "You already have a free request running. Please wait for it to finish before starting another one.",
+    );
+  }
+
+  let released = false;
+  return {
+    release: async () => {
+      if (released) return;
+      released = true;
+      await redis.eval(RELEASE_FREE_RUN_LOCK_SCRIPT, [lockKey], [lockToken]);
+    },
+  };
+}

--- a/lib/rate-limit/free-concurrency.ts
+++ b/lib/rate-limit/free-concurrency.ts
@@ -1,7 +1,6 @@
 import { ChatSDKError } from "@/lib/errors";
+import { FREE_RUN_LOCK_TTL_SECONDS } from "./free-config";
 import { createRedisClient } from "./redis";
-
-const FREE_RUN_LOCK_TTL_SECONDS_DEFAULT = 15 * 60;
 
 const RELEASE_FREE_RUN_LOCK_SCRIPT = `
 local key = KEYS[1]
@@ -23,7 +22,7 @@ const freeRunLockKey = (userId: string) => `free_run_lock:${userId}`;
 
 export async function acquireFreeRunConcurrencyLock(
   userId: string,
-  ttlSeconds = FREE_RUN_LOCK_TTL_SECONDS_DEFAULT,
+  ttlSeconds = FREE_RUN_LOCK_TTL_SECONDS,
 ): Promise<FreeRunConcurrencyLock> {
   const redis = createRedisClient();
 

--- a/lib/rate-limit/free-concurrency.ts
+++ b/lib/rate-limit/free-concurrency.ts
@@ -57,8 +57,8 @@ export async function acquireFreeRunConcurrencyLock(
   return {
     release: async () => {
       if (released) return;
-      released = true;
       await redis.eval(RELEASE_FREE_RUN_LOCK_SCRIPT, [lockKey], [lockToken]);
+      released = true;
     },
   };
 }

--- a/lib/rate-limit/free-config.ts
+++ b/lib/rate-limit/free-config.ts
@@ -1,0 +1,25 @@
+export const FREE_MONTHLY_COST_LIMIT_USD_DEFAULT = 0.25;
+export const FREE_RUN_LOCK_TTL_SECONDS = 15 * 60;
+export const FREE_AGENT_LONG_RUN_LOCK_TTL_SECONDS = 65 * 60;
+export const FREE_MAX_OUTPUT_TOKENS = 4096;
+export const FREE_MAX_CONTEXT_TOKENS = 128000;
+export const FREE_RATE_LIMIT_REQUESTS_DEFAULT = 10;
+export const FREE_ASK_REQUEST_COST = 1;
+export const FREE_AGENT_REQUEST_COST = 2;
+
+export const getFreeRequestLimit = (): number => {
+  const configuredLimit = parseInt(
+    process.env.FREE_RATE_LIMIT_REQUESTS || "",
+    10,
+  );
+  return Number.isFinite(configuredLimit) && configuredLimit > 0
+    ? configuredLimit
+    : FREE_RATE_LIMIT_REQUESTS_DEFAULT;
+};
+
+export const getFreeMonthlyCostLimitDollars = (): number => {
+  const configuredLimit = Number(process.env.FREE_MONTHLY_COST_LIMIT_USD);
+  return Number.isFinite(configuredLimit) && configuredLimit > 0
+    ? configuredLimit
+    : FREE_MONTHLY_COST_LIMIT_USD_DEFAULT;
+};

--- a/lib/rate-limit/free-monthly-cost.ts
+++ b/lib/rate-limit/free-monthly-cost.ts
@@ -1,8 +1,7 @@
 import { ChatSDKError } from "@/lib/errors";
+import { getFreeMonthlyCostLimitDollars } from "./free-config";
 import { POINTS_PER_DOLLAR } from "./token-bucket";
 import { createRedisClient } from "./redis";
-
-const FREE_MONTHLY_COST_LIMIT_USD_DEFAULT = 0.25;
 
 const RECORD_FREE_MONTHLY_COST_SCRIPT = `
 local key = KEYS[1]
@@ -29,13 +28,6 @@ export interface FreeMonthlyCostSnapshot {
   extraUsageAutoReload: false;
   rateLimitSkipped?: boolean;
 }
-
-const getFreeMonthlyCostLimitDollars = (): number => {
-  const configuredLimit = Number(process.env.FREE_MONTHLY_COST_LIMIT_USD);
-  return Number.isFinite(configuredLimit) && configuredLimit > 0
-    ? configuredLimit
-    : FREE_MONTHLY_COST_LIMIT_USD_DEFAULT;
-};
 
 const dollarsToPoints = (dollars: number): number => {
   if (!Number.isFinite(dollars) || dollars <= 0) return 0;

--- a/lib/rate-limit/free-monthly-cost.ts
+++ b/lib/rate-limit/free-monthly-cost.ts
@@ -1,0 +1,134 @@
+import { ChatSDKError } from "@/lib/errors";
+import { POINTS_PER_DOLLAR } from "./token-bucket";
+import { createRedisClient } from "./redis";
+
+const FREE_MONTHLY_COST_LIMIT_USD_DEFAULT = 0.25;
+
+const RECORD_FREE_MONTHLY_COST_SCRIPT = `
+local key = KEYS[1]
+local points = tonumber(ARGV[1])
+local ttlMs = tonumber(ARGV[2])
+
+if points <= 0 then
+  return tonumber(redis.call("GET", key) or "0")
+end
+
+local nextUsed = redis.call("INCRBY", key, points)
+if nextUsed == points then
+  redis.call("PEXPIRE", key, ttlMs)
+end
+
+return nextUsed
+`;
+
+export interface FreeMonthlyCostSnapshot {
+  monthlyLimitPoints: number;
+  monthlyRemainingAtStart: number;
+  monthlyResetTime: Date;
+  extraUsageBalanceAtStart: 0;
+  extraUsageAutoReload: false;
+  rateLimitSkipped?: boolean;
+}
+
+const getFreeMonthlyCostLimitDollars = (): number => {
+  const configuredLimit = Number(process.env.FREE_MONTHLY_COST_LIMIT_USD);
+  return Number.isFinite(configuredLimit) && configuredLimit > 0
+    ? configuredLimit
+    : FREE_MONTHLY_COST_LIMIT_USD_DEFAULT;
+};
+
+const dollarsToPoints = (dollars: number): number => {
+  if (!Number.isFinite(dollars) || dollars <= 0) return 0;
+  return Math.ceil(dollars * POINTS_PER_DOLLAR);
+};
+
+const getCurrentUtcMonthWindow = () => {
+  const now = new Date();
+  const bucket = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  const reset = Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1);
+
+  return {
+    bucket,
+    reset,
+    ttlMs: Math.max(1, reset - now.getTime()),
+  };
+};
+
+const freeMonthlyCostKey = (userId: string, bucket: string) =>
+  `free_monthly_cost:${userId}:${bucket}`;
+
+const getLimitMessage = (reset: number) =>
+  `You've used your free monthly usage. Free usage resets on ${new Date(
+    reset,
+  ).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  })}. Upgrade for higher limits and more features.`;
+
+export async function checkFreeMonthlyCostLimit(
+  userId: string,
+): Promise<FreeMonthlyCostSnapshot> {
+  const limitPoints = dollarsToPoints(getFreeMonthlyCostLimitDollars());
+  const { bucket, reset } = getCurrentUtcMonthWindow();
+  const redis = createRedisClient();
+
+  if (!redis) {
+    if (process.env.NODE_ENV !== "production") {
+      return {
+        monthlyLimitPoints: limitPoints,
+        monthlyRemainingAtStart: limitPoints,
+        monthlyResetTime: new Date(reset),
+        extraUsageBalanceAtStart: 0,
+        extraUsageAutoReload: false,
+        rateLimitSkipped: true,
+      };
+    }
+    throw new ChatSDKError(
+      "rate_limit:chat",
+      "Rate limiting service is not configured",
+    );
+  }
+
+  const usedPoints = Math.max(
+    0,
+    Number((await redis.get(freeMonthlyCostKey(userId, bucket))) ?? 0),
+  );
+  const remainingPoints = Math.max(0, limitPoints - usedPoints);
+
+  if (remainingPoints <= 0) {
+    throw new ChatSDKError("rate_limit:chat", getLimitMessage(reset));
+  }
+
+  return {
+    monthlyLimitPoints: limitPoints,
+    monthlyRemainingAtStart: remainingPoints,
+    monthlyResetTime: new Date(reset),
+    extraUsageBalanceAtStart: 0,
+    extraUsageAutoReload: false,
+  };
+}
+
+export async function recordFreeMonthlyCost(
+  userId: string,
+  costDollars: number,
+): Promise<void> {
+  const costPoints = dollarsToPoints(costDollars);
+  if (costPoints <= 0) return;
+
+  const redis = createRedisClient();
+  if (!redis) {
+    if (process.env.NODE_ENV !== "production") return;
+    throw new ChatSDKError(
+      "rate_limit:chat",
+      "Rate limiting service is not configured",
+    );
+  }
+
+  const { bucket, ttlMs } = getCurrentUtcMonthWindow();
+  await redis.eval(
+    RECORD_FREE_MONTHLY_COST_SCRIPT,
+    [freeMonthlyCostKey(userId, bucket)],
+    [costPoints, ttlMs],
+  );
+}

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -54,6 +54,10 @@ export {
 export { createRedisClient, formatTimeRemaining } from "./redis";
 export { UsageRefundTracker } from "./refund";
 export { acquireFreeRunConcurrencyLock } from "./free-concurrency";
+export {
+  checkFreeMonthlyCostLimit,
+  recordFreeMonthlyCost,
+} from "./free-monthly-cost";
 
 // Import for internal use
 import { checkTokenBucketLimit } from "./token-bucket";

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -53,6 +53,7 @@ export {
 // Re-export utilities
 export { createRedisClient, formatTimeRemaining } from "./redis";
 export { UsageRefundTracker } from "./refund";
+export { acquireFreeRunConcurrencyLock } from "./free-concurrency";
 
 // Import for internal use
 import { checkTokenBucketLimit } from "./token-bucket";

--- a/lib/rate-limit/sliding-window.ts
+++ b/lib/rate-limit/sliding-window.ts
@@ -7,11 +7,13 @@
 
 import { ChatSDKError } from "@/lib/errors";
 import type { RateLimitInfo } from "@/types";
+import {
+  FREE_AGENT_REQUEST_COST,
+  FREE_ASK_REQUEST_COST,
+  getFreeRequestLimit,
+} from "./free-config";
 import { createRedisClient } from "./redis";
 
-const FREE_RATE_LIMIT_REQUESTS_DEFAULT = 10;
-const FREE_ASK_REQUEST_COST = 1;
-const FREE_AGENT_REQUEST_COST = 2;
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 // Upstash fixedWindow supports `{ rate: 2 }`, but failed multi-unit calls are
@@ -36,16 +38,6 @@ end
 
 return {1, requestLimit - nextUsed}
 `;
-
-const getFreeRequestLimit = (): number => {
-  const configuredLimit = parseInt(
-    process.env.FREE_RATE_LIMIT_REQUESTS || "",
-    10,
-  );
-  return Number.isFinite(configuredLimit) && configuredLimit > 0
-    ? configuredLimit
-    : FREE_RATE_LIMIT_REQUESTS_DEFAULT;
-};
 
 const getCurrentUtcDayWindow = () => {
   const now = Date.now();

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -551,6 +551,8 @@ export const resetRateLimitBuckets = async (
  *   - upgrade:carryover:<userId>     — upgrade proration stash
  *   - free_limit:<userId>:*          — free-tier shared ask/agent sliding window
  *   - free_agent_limit:<userId>:*    — legacy free-tier agent sliding window
+ *   - free_monthly_cost:<userId>:*   — free-tier monthly provider/tool cost cap
+ *   - free_run_lock:<userId>         — free-tier active-run concurrency lock
  *   - team:debt_applied:*:<userId>   — seat-debt idempotency flag (org-scoped)
  *
  * Deliberately NOT included: team:removed_usage:<orgId> (org counter, not
@@ -567,6 +569,8 @@ export const deleteUserRateLimitKeys = async (
     `upgrade:carryover:${userId}`,
     `free_limit:${userId}:*`,
     `free_agent_limit:${userId}:*`,
+    `free_monthly_cost:${userId}:*`,
+    `free_run_lock:${userId}`,
     `team:debt_applied:*:${userId}`,
   ];
 

--- a/lib/token-utils.ts
+++ b/lib/token-utils.ts
@@ -3,7 +3,7 @@ import { countTokens, encode, decode } from "gpt-tokenizer";
 import type { SubscriptionTier } from "@/types";
 import type { Id } from "@/convex/_generated/dataModel";
 
-export const MAX_TOKENS_FREE = 32000;
+export const MAX_TOKENS_FREE = 128000;
 export const MAX_TOKENS_PAID = 200000;
 /**
  * Percentage of context window budget allocated to file uploads in Ask mode.
@@ -12,9 +12,10 @@ export const MAX_TOKENS_PAID = 200000;
 export const FILE_TOKEN_PERCENT = 0.5;
 
 export const getMaxTokensForSubscription = (
-  _subscription?: SubscriptionTier,
+  subscription?: SubscriptionTier,
   _opts?: { mode?: import("@/types").ChatMode },
 ): number => {
+  if (subscription === "free") return MAX_TOKENS_FREE;
   return MAX_TOKENS_PAID;
 };
 

--- a/lib/token-utils.ts
+++ b/lib/token-utils.ts
@@ -2,8 +2,9 @@ import { UIMessage, UIMessagePart } from "ai";
 import { countTokens, encode, decode } from "gpt-tokenizer";
 import type { SubscriptionTier } from "@/types";
 import type { Id } from "@/convex/_generated/dataModel";
+import { FREE_MAX_CONTEXT_TOKENS } from "@/lib/rate-limit/free-config";
 
-export const MAX_TOKENS_FREE = 128000;
+export const MAX_TOKENS_FREE = FREE_MAX_CONTEXT_TOKENS;
 export const MAX_TOKENS_PAID = 200000;
 /**
  * Percentage of context window budget allocated to file uploads in Ask mode.

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -43,8 +43,10 @@ import {
 import { UsageTracker } from "@/lib/usage-tracker";
 import {
   acquireFreeRunConcurrencyLock,
+  checkFreeMonthlyCostLimit,
   checkRateLimit,
   deductUsage,
+  recordFreeMonthlyCost,
   UsageRefundTracker,
 } from "@/lib/rate-limit";
 import { assertUserCanMakeCostIncurringRequest } from "@/lib/suspensions";
@@ -736,6 +738,11 @@ export const agentLongTask = task({
               organizationId,
             );
 
+            const freeMonthlyBudgetSnapshot =
+              subscription === "free"
+                ? await checkFreeMonthlyCostLimit(userId)
+                : null;
+
             usageRefundTracker.recordDeductions(rateLimitInfo);
             chatLogger?.setRateLimit(
               {
@@ -918,8 +925,13 @@ export const agentLongTask = task({
               extraUsageConfig,
               subscription,
             });
-            const budgetMonitor = budgetSnapshot
-              ? new BudgetMonitor(budgetSnapshot, writer, subscription)
+            const effectiveBudgetSnapshot =
+              budgetSnapshot ??
+              (freeMonthlyBudgetSnapshot?.rateLimitSkipped
+                ? null
+                : freeMonthlyBudgetSnapshot);
+            const budgetMonitor = effectiveBudgetSnapshot
+              ? new BudgetMonitor(effectiveBudgetSnapshot, writer, subscription)
               : null;
 
             // Use task start time (not stream start time) so the 58-min stop
@@ -966,7 +978,12 @@ export const agentLongTask = task({
                   usageTracker.modelProviderCost > 0
                     ? usageTracker.providerCost
                     : undefined;
-                if (subscription !== "free") {
+                if (subscription === "free") {
+                  await recordFreeMonthlyCost(
+                    userId,
+                    usageCostRecord.costDollars,
+                  );
+                } else {
                   await deductUsage(
                     userId,
                     subscription,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1119,409 +1119,429 @@ export const agentLongTask = task({
                     messages: finishedMessages,
                     isAborted,
                   }) => {
-                    // Retry with fallback if stream only produced step-start (incomplete response)
-                    const lastAssistantMessage = finishedMessages
-                      .slice()
-                      .reverse()
-                      .find((m) => m.role === "assistant");
-                    const lastAssistantMessageParts =
-                      stripAgentLongHeartbeatParts(
-                        lastAssistantMessage ?? { parts: [] },
-                      ).parts ?? [];
-                    const hasOnlyStepStart =
-                      lastAssistantMessageParts.length === 1 &&
-                      (lastAssistantMessageParts[0] as { type?: string })
-                        ?.type === "step-start";
+                    let retryScheduled = false;
+                    try {
+                      // Retry with fallback if stream only produced step-start (incomplete response)
+                      const lastAssistantMessage = finishedMessages
+                        .slice()
+                        .reverse()
+                        .find((m) => m.role === "assistant");
+                      const lastAssistantMessageParts =
+                        stripAgentLongHeartbeatParts(
+                          lastAssistantMessage ?? { parts: [] },
+                        ).parts ?? [];
+                      const hasOnlyStepStart =
+                        lastAssistantMessageParts.length === 1 &&
+                        (lastAssistantMessageParts[0] as { type?: string })
+                          ?.type === "step-start";
 
-                    if (
-                      hasOnlyStepStart &&
-                      !isRetryWithFallback &&
-                      !isAborted &&
-                      isAutoModel
-                    ) {
-                      isRetryWithFallback = true;
-                      state.lastStepInputTokens = 0;
-                      state.stoppedDueToTokenExhaustion = false;
-                      state.stoppedDueToElapsedTimeout = false;
-                      state.stoppedDueToDoomLoop = false;
-                      state.stoppedDueToBudgetExhaustion = false;
-                      const fallbackStartTime = Date.now();
-                      preFallbackCacheRead = usageTracker.cacheReadTokens;
-                      preFallbackCacheWrite = usageTracker.cacheWriteTokens;
-                      usageTracker.resetModelLeg();
-                      const retryResult = await createStream(fallbackModel);
-                      const retryMessageId = generateId();
-
-                      writer.merge(
-                        withAgentLongStreamHeartbeat(
-                          retryResult.toUIMessageStream({
-                            generateMessageId: () => retryMessageId,
-                            sendReasoning: true,
-                            messageMetadata: ({ part }) => {
-                              if (part.type === "start") {
-                                return {
-                                  mode,
-                                  generationStartedAt: fallbackStartTime,
-                                };
-                              }
-
-                              if (part.type === "finish") {
-                                return {
-                                  mode,
-                                  generationStartedAt: fallbackStartTime,
-                                  generationTimeMs:
-                                    Date.now() - fallbackStartTime,
-                                };
-                              }
-                            },
-                            onFinish: async ({
-                              messages: retryMessages,
-                              isAborted: retryAborted,
-                            }) => {
-                              const fallbackCacheRead =
-                                usageTracker.cacheReadTokens -
-                                preFallbackCacheRead;
-                              const fallbackCacheWrite =
-                                usageTracker.cacheWriteTokens -
-                                preFallbackCacheWrite;
-                              const fallbackCacheTotal =
-                                fallbackCacheRead + fallbackCacheWrite;
-                              const sandboxInfo =
-                                sandboxManager.getSandboxInfo();
-                              chatLogger?.setSandbox(sandboxInfo);
-                              chatLogger?.setCacheMetrics({
-                                cacheHitRate:
-                                  fallbackCacheTotal > 0
-                                    ? fallbackCacheRead / fallbackCacheTotal
-                                    : null,
-                                cacheReadTokens: fallbackCacheRead,
-                                cacheWriteTokens: fallbackCacheWrite,
-                              });
-                              captureToolCalls({
-                                posthog,
-                                chatLogger,
-                                userId,
-                                mode,
-                              });
-                              captureAgentRun({
-                                posthog,
-                                userId,
-                                mode,
-                                subscription,
-                                sandboxInfo,
-                                outcome: retryAborted
-                                  ? "aborted"
-                                  : isTerminalProviderStreamError(state)
-                                    ? "error"
-                                    : "success",
-                              });
-                              if (!isTerminalProviderStreamError(state)) {
-                                chatLogger?.emitSuccess({
-                                  finishReason: state.streamFinishReason,
-                                  wasAborted: retryAborted,
-                                  wasPreemptiveTimeout: false,
-                                  hadSummarization:
-                                    summarizationTracker.hasSummarized,
-                                });
-                              }
-
-                              const generatedTitle = await titlePromise;
-                              if (!temporary) {
-                                const mergedTodos = getTodoManager().mergeWith(
-                                  baseTodos,
-                                  retryMessageId,
-                                );
-                                if (
-                                  generatedTitle ||
-                                  state.streamFinishReason ||
-                                  mergedTodos.length > 0
-                                ) {
-                                  await updateChat({
-                                    chatId,
-                                    title: generatedTitle,
-                                    finishReason: state.streamFinishReason,
-                                    todos: mergedTodos,
-                                    defaultModelSlug: "agent",
-                                    sandboxType:
-                                      sandboxManager.getEffectivePreference(),
-                                    selectedModel: selectedModelOverride,
-                                  });
-                                } else {
-                                  await prepareForNewStream({ chatId });
-                                }
-                                const accumulatedFiles =
-                                  getFileAccumulator().getAll();
-                                const newFileIds = accumulatedFiles.map(
-                                  (f) => f.fileId,
-                                );
-                                const fallbackGenerationTimeMs =
-                                  Date.now() - fallbackStartTime;
-                                for (const msg of retryMessages) {
-                                  if (msg.role !== "assistant") continue;
-                                  const processed =
-                                    stripAgentLongHeartbeatParts(
-                                      summarizationTracker.processMessageForSave(
-                                        msg,
-                                      ),
-                                    );
-                                  await saveMessage({
-                                    chatId,
-                                    userId,
-                                    message: processed,
-                                    extraFileIds: newFileIds,
-                                    usage: state.streamUsage,
-                                    model: state.responseModel,
-                                    mode,
-                                    generationStartedAt: fallbackStartTime,
-                                    generationTimeMs: fallbackGenerationTimeMs,
-                                    finishReason: state.streamFinishReason,
-                                  });
-                                }
-                                writer.write({
-                                  type: "message-metadata",
-                                  messageMetadata: {
-                                    mode,
-                                    generationStartedAt: fallbackStartTime,
-                                    generationTimeMs: fallbackGenerationTimeMs,
-                                  },
-                                });
-                                sendFileMetadataToStream(accumulatedFiles);
-                              }
-                              await deductAccumulatedUsage();
-                              posthog?.shutdown();
-                            },
-                          }),
-                          userStopSignal.signal,
-                        ),
-                      );
-                      return;
-                    }
-
-                    // User-initiated cancel via trigger.dev: clear finish reason
-                    // so the client doesn't show spurious "going off course" messages.
-                    if (
-                      isAborted &&
-                      triggerSignal.aborted &&
-                      !state.stoppedDueToBudgetExhaustion &&
-                      !state.stoppedDueToElapsedTimeout
-                    ) {
-                      state.streamFinishReason = undefined;
-                    }
-
-                    const sandboxInfo = sandboxManager.getSandboxInfo();
-                    chatLogger?.setSandbox(sandboxInfo);
-                    chatLogger?.setCacheMetrics({
-                      cacheHitRate: usageTracker.cacheHitRate,
-                      cacheReadTokens: usageTracker.cacheReadTokens,
-                      cacheWriteTokens: usageTracker.cacheWriteTokens,
-                    });
-                    captureToolCalls({ posthog, chatLogger, userId, mode });
-                    captureAgentRun({
-                      posthog,
-                      userId,
-                      mode,
-                      subscription,
-                      sandboxInfo,
-                      outcome: isAborted
-                        ? "aborted"
-                        : isTerminalProviderStreamError(state)
-                          ? "error"
-                          : "success",
-                    });
-                    if (!isTerminalProviderStreamError(state)) {
-                      chatLogger?.emitSuccess({
-                        finishReason: state.streamFinishReason,
-                        wasAborted: isAborted,
-                        wasPreemptiveTimeout: state.stoppedDueToElapsedTimeout,
-                        hadSummarization: summarizationTracker.hasSummarized,
-                      });
-                    }
-
-                    const generatedTitle = await titlePromise;
-
-                    if (!temporary) {
-                      const mergedTodos = getTodoManager().mergeWith(
-                        baseTodos,
-                        assistantMessageId,
-                      );
-                      const shouldPersist = regenerate
-                        ? true
-                        : Boolean(
-                            generatedTitle ||
-                            state.streamFinishReason ||
-                            mergedTodos.length > 0,
-                          );
-
-                      if (shouldPersist) {
-                        await updateChat({
-                          chatId,
-                          title: generatedTitle,
-                          finishReason: state.streamFinishReason,
-                          todos: mergedTodos,
-                          defaultModelSlug: "agent",
-                          sandboxType: sandboxManager.getEffectivePreference(),
-                          selectedModel: selectedModelOverride,
-                        });
-                      } else {
-                        await prepareForNewStream({ chatId });
-                      }
-
-                      const accumulatedFiles = getFileAccumulator().getAll();
-                      const newFileIds = accumulatedFiles.map((f) => f.fileId);
-
-                      let resolvedUsage: Record<string, unknown> | undefined =
-                        state.streamUsage;
-                      if (!resolvedUsage && isAborted) {
-                        try {
-                          resolvedUsage = (await result.usage) as Record<
-                            string,
-                            unknown
-                          >;
-                        } catch {
-                          // Usage unavailable on abort
-                        }
-                      }
-
-                      const hasIncompleteToolCalls = finishedMessages.some(
-                        (msg) =>
-                          msg.role === "assistant" &&
-                          msg.parts?.some(
-                            (p: {
-                              type?: string;
-                              state?: string;
-                              toolCallId?: string;
-                            }) =>
-                              p.type?.startsWith("tool-") &&
-                              p.state !== "output-available" &&
-                              p.toolCallId,
-                          ),
-                      );
-                      const incompleteToolSummaries = isAborted
-                        ? summarizeIncompleteToolParts(finishedMessages)
-                        : [];
-                      if (incompleteToolSummaries.length > 0) {
-                        console.info(
-                          JSON.stringify({
-                            level: "info",
-                            event:
-                              "agent_long_abort_incomplete_tool_calls_detected",
-                            service: "agent-long",
-                            timestamp: new Date().toISOString(),
-                            chat_id: chatId,
-                            user_id: userId,
-                            mode: "agent",
-                            finish_reason: state.streamFinishReason,
-                            trigger_signal_aborted: triggerSignal.aborted,
-                            incomplete_tool_count:
-                              incompleteToolSummaries.length,
-                            incomplete_tools: incompleteToolSummaries,
-                          }),
-                        );
-                      }
                       if (
-                        isAborted &&
-                        !triggerSignal.aborted &&
-                        newFileIds.length === 0 &&
-                        !hasIncompleteToolCalls &&
-                        !resolvedUsage
+                        hasOnlyStepStart &&
+                        !isRetryWithFallback &&
+                        !isAborted &&
+                        isAutoModel
                       ) {
-                        console.info(
-                          JSON.stringify({
-                            level: "info",
-                            event: "agent_long_abort_message_save_skipped",
-                            service: "agent-long",
-                            timestamp: new Date().toISOString(),
-                            chat_id: chatId,
-                            user_id: userId,
-                            mode: "agent",
-                            finish_reason: state.streamFinishReason,
-                            new_file_count: newFileIds.length,
-                            has_incomplete_tool_calls: hasIncompleteToolCalls,
-                            has_usage_to_record: Boolean(resolvedUsage),
-                          }),
+                        isRetryWithFallback = true;
+                        state.lastStepInputTokens = 0;
+                        state.stoppedDueToTokenExhaustion = false;
+                        state.stoppedDueToElapsedTimeout = false;
+                        state.stoppedDueToDoomLoop = false;
+                        state.stoppedDueToBudgetExhaustion = false;
+                        const fallbackStartTime = Date.now();
+                        preFallbackCacheRead = usageTracker.cacheReadTokens;
+                        preFallbackCacheWrite = usageTracker.cacheWriteTokens;
+                        usageTracker.resetModelLeg();
+                        const retryResult = await createStream(fallbackModel);
+                        const retryMessageId = generateId();
+
+                        writer.merge(
+                          withAgentLongStreamHeartbeat(
+                            retryResult.toUIMessageStream({
+                              generateMessageId: () => retryMessageId,
+                              sendReasoning: true,
+                              messageMetadata: ({ part }) => {
+                                if (part.type === "start") {
+                                  return {
+                                    mode,
+                                    generationStartedAt: fallbackStartTime,
+                                  };
+                                }
+
+                                if (part.type === "finish") {
+                                  return {
+                                    mode,
+                                    generationStartedAt: fallbackStartTime,
+                                    generationTimeMs:
+                                      Date.now() - fallbackStartTime,
+                                  };
+                                }
+                              },
+                              onFinish: async ({
+                                messages: retryMessages,
+                                isAborted: retryAborted,
+                              }) => {
+                                try {
+                                  const fallbackCacheRead =
+                                    usageTracker.cacheReadTokens -
+                                    preFallbackCacheRead;
+                                  const fallbackCacheWrite =
+                                    usageTracker.cacheWriteTokens -
+                                    preFallbackCacheWrite;
+                                  const fallbackCacheTotal =
+                                    fallbackCacheRead + fallbackCacheWrite;
+                                  const sandboxInfo =
+                                    sandboxManager.getSandboxInfo();
+                                  chatLogger?.setSandbox(sandboxInfo);
+                                  chatLogger?.setCacheMetrics({
+                                    cacheHitRate:
+                                      fallbackCacheTotal > 0
+                                        ? fallbackCacheRead / fallbackCacheTotal
+                                        : null,
+                                    cacheReadTokens: fallbackCacheRead,
+                                    cacheWriteTokens: fallbackCacheWrite,
+                                  });
+                                  captureToolCalls({
+                                    posthog,
+                                    chatLogger,
+                                    userId,
+                                    mode,
+                                  });
+                                  captureAgentRun({
+                                    posthog,
+                                    userId,
+                                    mode,
+                                    subscription,
+                                    sandboxInfo,
+                                    outcome: retryAborted
+                                      ? "aborted"
+                                      : isTerminalProviderStreamError(state)
+                                        ? "error"
+                                        : "success",
+                                  });
+                                  if (!isTerminalProviderStreamError(state)) {
+                                    chatLogger?.emitSuccess({
+                                      finishReason: state.streamFinishReason,
+                                      wasAborted: retryAborted,
+                                      wasPreemptiveTimeout: false,
+                                      hadSummarization:
+                                        summarizationTracker.hasSummarized,
+                                    });
+                                  }
+
+                                  const generatedTitle = await titlePromise;
+                                  if (!temporary) {
+                                    const mergedTodos =
+                                      getTodoManager().mergeWith(
+                                        baseTodos,
+                                        retryMessageId,
+                                      );
+                                    if (
+                                      generatedTitle ||
+                                      state.streamFinishReason ||
+                                      mergedTodos.length > 0
+                                    ) {
+                                      await updateChat({
+                                        chatId,
+                                        title: generatedTitle,
+                                        finishReason: state.streamFinishReason,
+                                        todos: mergedTodos,
+                                        defaultModelSlug: "agent",
+                                        sandboxType:
+                                          sandboxManager.getEffectivePreference(),
+                                        selectedModel: selectedModelOverride,
+                                      });
+                                    } else {
+                                      await prepareForNewStream({ chatId });
+                                    }
+                                    const accumulatedFiles =
+                                      getFileAccumulator().getAll();
+                                    const newFileIds = accumulatedFiles.map(
+                                      (f) => f.fileId,
+                                    );
+                                    const fallbackGenerationTimeMs =
+                                      Date.now() - fallbackStartTime;
+                                    for (const msg of retryMessages) {
+                                      if (msg.role !== "assistant") continue;
+                                      const processed =
+                                        stripAgentLongHeartbeatParts(
+                                          summarizationTracker.processMessageForSave(
+                                            msg,
+                                          ),
+                                        );
+                                      await saveMessage({
+                                        chatId,
+                                        userId,
+                                        message: processed,
+                                        extraFileIds: newFileIds,
+                                        usage: state.streamUsage,
+                                        model: state.responseModel,
+                                        mode,
+                                        generationStartedAt: fallbackStartTime,
+                                        generationTimeMs:
+                                          fallbackGenerationTimeMs,
+                                        finishReason: state.streamFinishReason,
+                                      });
+                                    }
+                                    writer.write({
+                                      type: "message-metadata",
+                                      messageMetadata: {
+                                        mode,
+                                        generationStartedAt: fallbackStartTime,
+                                        generationTimeMs:
+                                          fallbackGenerationTimeMs,
+                                      },
+                                    });
+                                    sendFileMetadataToStream(accumulatedFiles);
+                                  }
+                                  await deductAccumulatedUsage();
+                                  posthog?.shutdown();
+                                } finally {
+                                  await releaseFreeRunLockOnce();
+                                }
+                              },
+                            }),
+                            userStopSignal.signal,
+                          ),
                         );
-                        await deductAccumulatedUsage();
-                        posthog?.shutdown();
+                        retryScheduled = true;
                         return;
                       }
 
-                      const finalGenerationTimeMs =
-                        Date.now() - streamStartTime;
-                      let savedAssistantMessage = false;
-                      for (const message of finishedMessages) {
-                        const processed = stripAgentLongHeartbeatParts(
-                          summarizationTracker.processMessageForSave(message),
-                        );
-                        if (
-                          (!processed.parts || processed.parts.length === 0) &&
-                          newFileIds.length === 0
-                        ) {
-                          continue;
-                        }
-                        await saveMessage({
-                          chatId,
-                          userId,
-                          message: processed,
-                          extraFileIds: newFileIds,
-                          model: state.responseModel || configuredModelId,
-                          mode,
-                          generationStartedAt:
-                            processed.role === "assistant"
-                              ? streamStartTime
-                              : undefined,
-                          generationTimeMs: finalGenerationTimeMs,
-                          finishReason: state.streamFinishReason,
-                          usage: resolvedUsage ?? state.streamUsage,
-                          updateOnly:
-                            isAborted && !state.stoppedDueToElapsedTimeout
-                              ? true
-                              : undefined,
-                          isHidden:
-                            isAutoContinue && processed.role === "user"
-                              ? true
-                              : undefined,
-                        });
-                        if (processed.role === "assistant") {
-                          savedAssistantMessage = true;
-                        }
+                      // User-initiated cancel via trigger.dev: clear finish reason
+                      // so the client doesn't show spurious "going off course" messages.
+                      if (
+                        isAborted &&
+                        triggerSignal.aborted &&
+                        !state.stoppedDueToBudgetExhaustion &&
+                        !state.stoppedDueToElapsedTimeout
+                      ) {
+                        state.streamFinishReason = undefined;
                       }
 
-                      if (savedAssistantMessage) {
-                        writer.write({
-                          type: "message-metadata",
-                          messageMetadata: {
-                            mode,
-                            generationStartedAt: streamStartTime,
-                            generationTimeMs: finalGenerationTimeMs,
-                          },
-                        });
-                      }
-
-                      sendFileMetadataToStream(accumulatedFiles);
-                    }
-
-                    if (contextUsageOn) {
-                      writeContextUsage(writer, {
-                        usedTokens:
-                          state.ctxUsage.usedTokens +
-                          usageTracker.streamOutputTokens,
-                        maxTokens: state.ctxUsage.maxTokens,
+                      const sandboxInfo = sandboxManager.getSandboxInfo();
+                      chatLogger?.setSandbox(sandboxInfo);
+                      chatLogger?.setCacheMetrics({
+                        cacheHitRate: usageTracker.cacheHitRate,
+                        cacheReadTokens: usageTracker.cacheReadTokens,
+                        cacheWriteTokens: usageTracker.cacheWriteTokens,
                       });
-                    }
+                      captureToolCalls({ posthog, chatLogger, userId, mode });
+                      captureAgentRun({
+                        posthog,
+                        userId,
+                        mode,
+                        subscription,
+                        sandboxInfo,
+                        outcome: isAborted
+                          ? "aborted"
+                          : isTerminalProviderStreamError(state)
+                            ? "error"
+                            : "success",
+                      });
+                      if (!isTerminalProviderStreamError(state)) {
+                        chatLogger?.emitSuccess({
+                          finishReason: state.streamFinishReason,
+                          wasAborted: isAborted,
+                          wasPreemptiveTimeout:
+                            state.stoppedDueToElapsedTimeout,
+                          hadSummarization: summarizationTracker.hasSummarized,
+                        });
+                      }
 
-                    // Don't auto-continue on elapsed timeout — a 58-min run is large enough
-                    // that the user should explicitly decide whether to continue rather than
-                    // silently chaining up to 5 more hour-long runs.
-                    if (
-                      (state.stoppedDueToTokenExhaustion ||
-                        state.streamFinishReason === "tool-calls") &&
-                      !temporary
-                    ) {
-                      writeAutoContinue(writer);
-                    }
+                      const generatedTitle = await titlePromise;
 
-                    await deductAccumulatedUsage();
-                    posthog?.shutdown();
+                      if (!temporary) {
+                        const mergedTodos = getTodoManager().mergeWith(
+                          baseTodos,
+                          assistantMessageId,
+                        );
+                        const shouldPersist = regenerate
+                          ? true
+                          : Boolean(
+                              generatedTitle ||
+                              state.streamFinishReason ||
+                              mergedTodos.length > 0,
+                            );
+
+                        if (shouldPersist) {
+                          await updateChat({
+                            chatId,
+                            title: generatedTitle,
+                            finishReason: state.streamFinishReason,
+                            todos: mergedTodos,
+                            defaultModelSlug: "agent",
+                            sandboxType:
+                              sandboxManager.getEffectivePreference(),
+                            selectedModel: selectedModelOverride,
+                          });
+                        } else {
+                          await prepareForNewStream({ chatId });
+                        }
+
+                        const accumulatedFiles = getFileAccumulator().getAll();
+                        const newFileIds = accumulatedFiles.map(
+                          (f) => f.fileId,
+                        );
+
+                        let resolvedUsage: Record<string, unknown> | undefined =
+                          state.streamUsage;
+                        if (!resolvedUsage && isAborted) {
+                          try {
+                            resolvedUsage = (await result.usage) as Record<
+                              string,
+                              unknown
+                            >;
+                          } catch {
+                            // Usage unavailable on abort
+                          }
+                        }
+
+                        const hasIncompleteToolCalls = finishedMessages.some(
+                          (msg) =>
+                            msg.role === "assistant" &&
+                            msg.parts?.some(
+                              (p: {
+                                type?: string;
+                                state?: string;
+                                toolCallId?: string;
+                              }) =>
+                                p.type?.startsWith("tool-") &&
+                                p.state !== "output-available" &&
+                                p.toolCallId,
+                            ),
+                        );
+                        const incompleteToolSummaries = isAborted
+                          ? summarizeIncompleteToolParts(finishedMessages)
+                          : [];
+                        if (incompleteToolSummaries.length > 0) {
+                          console.info(
+                            JSON.stringify({
+                              level: "info",
+                              event:
+                                "agent_long_abort_incomplete_tool_calls_detected",
+                              service: "agent-long",
+                              timestamp: new Date().toISOString(),
+                              chat_id: chatId,
+                              user_id: userId,
+                              mode: "agent",
+                              finish_reason: state.streamFinishReason,
+                              trigger_signal_aborted: triggerSignal.aborted,
+                              incomplete_tool_count:
+                                incompleteToolSummaries.length,
+                              incomplete_tools: incompleteToolSummaries,
+                            }),
+                          );
+                        }
+                        if (
+                          isAborted &&
+                          !triggerSignal.aborted &&
+                          newFileIds.length === 0 &&
+                          !hasIncompleteToolCalls &&
+                          !resolvedUsage
+                        ) {
+                          console.info(
+                            JSON.stringify({
+                              level: "info",
+                              event: "agent_long_abort_message_save_skipped",
+                              service: "agent-long",
+                              timestamp: new Date().toISOString(),
+                              chat_id: chatId,
+                              user_id: userId,
+                              mode: "agent",
+                              finish_reason: state.streamFinishReason,
+                              new_file_count: newFileIds.length,
+                              has_incomplete_tool_calls: hasIncompleteToolCalls,
+                              has_usage_to_record: Boolean(resolvedUsage),
+                            }),
+                          );
+                          await deductAccumulatedUsage();
+                          posthog?.shutdown();
+                          return;
+                        }
+
+                        const finalGenerationTimeMs =
+                          Date.now() - streamStartTime;
+                        let savedAssistantMessage = false;
+                        for (const message of finishedMessages) {
+                          const processed = stripAgentLongHeartbeatParts(
+                            summarizationTracker.processMessageForSave(message),
+                          );
+                          if (
+                            (!processed.parts ||
+                              processed.parts.length === 0) &&
+                            newFileIds.length === 0
+                          ) {
+                            continue;
+                          }
+                          await saveMessage({
+                            chatId,
+                            userId,
+                            message: processed,
+                            extraFileIds: newFileIds,
+                            model: state.responseModel || configuredModelId,
+                            mode,
+                            generationStartedAt:
+                              processed.role === "assistant"
+                                ? streamStartTime
+                                : undefined,
+                            generationTimeMs: finalGenerationTimeMs,
+                            finishReason: state.streamFinishReason,
+                            usage: resolvedUsage ?? state.streamUsage,
+                            updateOnly:
+                              isAborted && !state.stoppedDueToElapsedTimeout
+                                ? true
+                                : undefined,
+                            isHidden:
+                              isAutoContinue && processed.role === "user"
+                                ? true
+                                : undefined,
+                          });
+                          if (processed.role === "assistant") {
+                            savedAssistantMessage = true;
+                          }
+                        }
+
+                        if (savedAssistantMessage) {
+                          writer.write({
+                            type: "message-metadata",
+                            messageMetadata: {
+                              mode,
+                              generationStartedAt: streamStartTime,
+                              generationTimeMs: finalGenerationTimeMs,
+                            },
+                          });
+                        }
+
+                        sendFileMetadataToStream(accumulatedFiles);
+                      }
+
+                      if (contextUsageOn) {
+                        writeContextUsage(writer, {
+                          usedTokens:
+                            state.ctxUsage.usedTokens +
+                            usageTracker.streamOutputTokens,
+                          maxTokens: state.ctxUsage.maxTokens,
+                        });
+                      }
+
+                      // Don't auto-continue on elapsed timeout — a 58-min run is large enough
+                      // that the user should explicitly decide whether to continue rather than
+                      // silently chaining up to 5 more hour-long runs.
+                      if (
+                        (state.stoppedDueToTokenExhaustion ||
+                          state.streamFinishReason === "tool-calls") &&
+                        !temporary
+                      ) {
+                        writeAutoContinue(writer);
+                      }
+
+                      await deductAccumulatedUsage();
+                      posthog?.shutdown();
+                    } finally {
+                      if (!retryScheduled) {
+                        await releaseFreeRunLockOnce();
+                      }
+                    }
                   },
                 }),
                 userStopSignal.signal,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -34,6 +34,7 @@ import {
   isContextUsageEnabled,
   isProviderApiError,
   injectNotesIntoMessages,
+  getRetryFallbackModel,
 } from "@/lib/api/chat-stream-helpers";
 import {
   BudgetMonitor,
@@ -41,6 +42,7 @@ import {
 } from "@/lib/chat/budget-monitor";
 import { UsageTracker } from "@/lib/usage-tracker";
 import {
+  acquireFreeRunConcurrencyLock,
   checkRateLimit,
   deductUsage,
   UsageRefundTracker,
@@ -102,6 +104,7 @@ import {
 
 // Leave 2 min for cleanup before trigger.dev hits maxDuration: 60 * 60.
 const AGENT_LONG_MAX_DURATION_MS = 58 * 60 * 1000;
+const AGENT_LONG_FREE_RUN_LOCK_TTL_SECONDS = 65 * 60;
 
 type AgentLongUiStreamPart = Parameters<UIMessageStreamWriter["write"]>[0];
 
@@ -566,6 +569,13 @@ export const agentLongTask = task({
 
     const usageRefundTracker = new UsageRefundTracker();
     usageRefundTracker.setUser(userId, subscription, organizationId);
+    let releaseFreeRunLock: (() => Promise<void>) | undefined;
+    const releaseFreeRunLockOnce = async () => {
+      const release = releaseFreeRunLock;
+      if (!release) return;
+      releaseFreeRunLock = undefined;
+      await release();
+    };
 
     let chatLogger: ChatLogger | undefined = createChatLogger({
       chatId,
@@ -699,784 +709,811 @@ export const agentLongTask = task({
           return getUserFriendlyProviderError(error);
         },
         execute: async ({ writer }) => {
-          await assertUserCanMakeCostIncurringRequest(userId);
-
-          extraUsageConfig = await buildExtraUsageConfig({
-            userId,
-            subscription,
-            userCustomization,
-            organizationId,
-          });
-
-          rateLimitInfo = await checkRateLimit(
-            userId,
-            mode,
-            subscription,
-            estimatedInputTokens,
-            extraUsageConfig,
-            selectedModel,
-            organizationId,
-          );
-
-          usageRefundTracker.recordDeductions(rateLimitInfo);
-          chatLogger?.setRateLimit(
-            {
-              pointsDeducted: rateLimitInfo.pointsDeducted,
-              extraUsagePointsDeducted: rateLimitInfo.extraUsagePointsDeducted,
-              monthly: rateLimitInfo.monthly,
-              remaining: rateLimitInfo.remaining,
-              subscription,
-            },
-            extraUsageConfig,
-          );
-
-          sendRateLimitWarnings(writer, {
-            subscription,
-            mode,
-            rateLimitInfo,
-          });
-
-          const {
-            tools,
-            ensureSandbox,
-            getTodoManager,
-            getFileAccumulator,
-            sandboxManager,
-            getSandboxSessionCost,
-          } = createTools(
-            userId,
-            chatId,
-            writer,
-            mode,
-            userLocation,
-            baseTodos,
-            memoryEnabled,
-            !!temporary,
-            assistantMessageId,
-            sandboxPreference,
-            process.env.CONVEX_SERVICE_ROLE_KEY,
-            userCustomization?.guardrails_config,
-            false,
-            undefined,
-            undefined,
-            (costDollars: number) => {
-              usageTracker.providerCost += costDollars;
-              usageTracker.nonModelCost += costDollars;
-              chatLogger?.getBuilder().addToolCost(costDollars);
-            },
-            subscription,
-            (info) => chatLogger?.setSandboxBoot(info),
-            undefined,
-          );
-
-          const sendFileMetadataToStream = (
-            fileMetadata: Array<{
-              fileId: Id<"files">;
-              name: string;
-              mediaType: string;
-              s3Key?: string;
-              storageId?: Id<"_storage">;
-            }>,
-          ) => {
-            if (!fileMetadata || fileMetadata.length === 0) return;
-            writer.write({
-              type: "data-file-metadata",
-              data: {
-                messageId: assistantMessageId,
-                fileDetails: fileMetadata,
-              },
-            });
-          };
-
-          let sandboxContext: string | null = null;
-          if ("getSandboxContextForPrompt" in sandboxManager) {
-            try {
-              sandboxContext = await (
-                sandboxManager as {
-                  getSandboxContextForPrompt: () => Promise<string | null>;
-                }
-              ).getSandboxContextForPrompt();
-            } catch (err) {
-              console.warn("[agent-long] Failed to get sandbox context:", err);
-            }
-          }
-
-          if (sandboxFiles && sandboxFiles.length > 0) {
-            writeUploadStartStatus(
-              writer,
-              sandboxFiles.every((file) => file.kind === "localPath")
-                ? "Preparing local attachments on your computer"
-                : "Uploading attachments to the computer",
-            );
-            let uploadResult: { failedCount: number } = { failedCount: 0 };
-            try {
-              uploadResult = await uploadSandboxFiles(
-                sandboxFiles,
-                ensureSandbox,
-              );
-            } finally {
-              writeUploadCompleteStatus(writer);
-            }
-            if (uploadResult.failedCount > 0) {
-              const noun =
-                uploadResult.failedCount === 1 ? "attachment" : "attachments";
-              const uploadError = new ChatSDKError(
-                "bad_request:stream",
-                `Failed to upload ${uploadResult.failedCount} ${noun} to the computer. Please try again.`,
-              );
-              await usageRefundTracker.refund();
-              chatLogger?.emitChatError(uploadError);
-              throw uploadError;
-            }
-          }
-
-          const titlePromise =
-            isNewChat && !temporary
-              ? generateTitleFromUserMessageWithWriter(
-                  processedMessages,
-                  writer,
-                )
-              : Promise.resolve(undefined);
-
-          const trackedProvider = createTrackedProvider();
-          const currentSystemPrompt = await systemPrompt(
-            userId,
-            mode,
-            subscription,
-            selectedModel,
-            userCustomization,
-            temporary,
-            sandboxContext,
-          );
-          const systemPromptTokens = countTokens(currentSystemPrompt);
-
-          const contextUsageOn = isContextUsageEnabled(subscription, mode);
-          const ctxSystemTokens = contextUsageOn ? systemPromptTokens : 0;
-          const ctxMaxTokens = contextUsageOn
-            ? getMaxTokensForSubscription(subscription, { mode })
-            : 0;
-          const initialCtxUsage = contextUsageOn
-            ? computeContextUsage(
-                messagesForAccounting,
-                fileTokens,
-                ctxSystemTokens,
-                ctxMaxTokens,
-              )
-            : { usedTokens: 0, maxTokens: 0 };
-
-          let finalMessages = processedMessages;
-
-          const resumeContext = getResumeSection(chat?.finish_reason);
-          if (resumeContext) {
-            finalMessages = appendSystemReminderToLastUserMessage(
-              finalMessages,
-              resumeContext,
-            );
-          }
-
-          const noteInjectionOpts = {
-            userId,
-            subscription,
-            shouldIncludeNotes:
-              userCustomization?.include_memory_entries ?? true,
-            isTemporary: !!temporary as boolean | undefined,
-          };
-          finalMessages = await injectNotesIntoMessages(
-            finalMessages,
-            noteInjectionOpts,
-          );
-
-          // Mutable stream state — updated in-place by the shared runner and
-          // read back here in toUIMessageStream.onFinish.
-          const state = initAgentStreamState(finalMessages, initialCtxUsage);
-          terminalAgentState = state;
-
-          const budgetSnapshot = captureBudgetSnapshot({
-            rateLimitInfo,
-            extraUsageConfig,
-            subscription,
-          });
-          const budgetMonitor = budgetSnapshot
-            ? new BudgetMonitor(budgetSnapshot, writer, subscription)
-            : null;
-
-          // Use task start time (not stream start time) so the 58-min stop
-          // condition always fires 2 min before the 60-min hard SIGKILL.
-          const streamStartTime = taskStartTime;
-          const configuredModelId =
-            trackedProvider.languageModel(selectedModel).modelId;
-
-          let isRetryWithFallback = false;
-          const isAutoModel = [
-            "ask-model",
-            "ask-model-free",
-            "agent-model",
-            "agent-model-free",
-          ].includes(selectedModel);
-          const fallbackModel = "fallback-agent-model";
-          const fallbackModelId =
-            trackedProvider.languageModel(fallbackModel).modelId;
-
-          const usageTracker = new UsageTracker();
-          let hasRecordedUsage = false;
-          let preFallbackCacheRead = 0;
-          let preFallbackCacheWrite = 0;
-
-          const deductAccumulatedUsage = async () => {
-            if (hasRecordedUsage) return;
-            const sandboxCost = getSandboxSessionCost();
-            if (sandboxCost > 0) {
-              usageTracker.providerCost += sandboxCost;
-              usageTracker.nonModelCost += sandboxCost;
-              chatLogger?.getBuilder().addToolCost(sandboxCost);
-            }
-            if (!usageTracker.hasUsage) return;
-            hasRecordedUsage = true;
-            const usageCostRecord = usageTracker.createUsageCostRecord({
-              selectedModel,
-              selectedModelOverride,
-              responseModel: state.responseModel,
-              configuredModelId,
-              rateLimitInfo,
-            });
-            const providerCost =
-              usageTracker.modelProviderCost > 0
-                ? usageTracker.providerCost
-                : undefined;
-            if (subscription !== "free") {
-              await deductUsage(
+          try {
+            await assertUserCanMakeCostIncurringRequest(userId);
+            if (subscription === "free") {
+              const lock = await acquireFreeRunConcurrencyLock(
                 userId,
-                subscription,
-                estimatedInputTokens,
-                usageTracker.inputTokens,
-                usageTracker.outputTokens,
-                extraUsageConfig,
-                providerCost,
-                selectedModel,
-                usageTracker.nonModelCost,
-                organizationId,
+                AGENT_LONG_FREE_RUN_LOCK_TTL_SECONDS,
               );
-              usageTracker.log({
-                userId,
-                selectedModel,
-                selectedModelOverride,
-                responseModel: state.responseModel,
-                configuredModelId,
-                rateLimitInfo,
-              });
+              releaseFreeRunLock = lock.release;
             }
-            captureUsageCost({
-              posthog,
+
+            extraUsageConfig = await buildExtraUsageConfig({
               userId,
               subscription,
+              userCustomization,
               organizationId,
-              chatId,
-              endpoint: "/api/agent",
-              mode,
-              usage: usageCostRecord,
             });
-          };
 
-          // Shared runner context — immutable deps + platform hook.
-          const streamCtx: AgentStreamContext = {
-            trackedProvider,
-            currentSystemPrompt,
-            tools,
-            mode,
-            userId,
-            subscription,
-            chatId,
-            temporary,
-            fileTokens,
-            noteInjectionOpts,
-            systemPromptTokens,
-            ctxSystemTokens,
-            ctxMaxTokens,
-            streamStartTime,
-            contextUsageOn,
-            isReasoningModel: true, // long mode is always agent mode
-            maxDurationMs: AGENT_LONG_MAX_DURATION_MS,
-            writer,
-            abortController: userStopSignal,
-            summarizationTracker,
-            usageTracker,
-            budgetMonitor,
-            sandboxManager,
-            getTodoManager,
-            ensureSandbox,
-            chatLogger,
-            usageRefundTracker,
-            // trigger.dev has no Vercel-style hard preemptive timeout
-            getHardTimeoutReason: () => null,
-          };
+            rateLimitInfo = await checkRateLimit(
+              userId,
+              mode,
+              subscription,
+              estimatedInputTokens,
+              extraUsageConfig,
+              selectedModel,
+              organizationId,
+            );
 
-          const createStream = (modelName: string) =>
-            createAgentStream(modelName, streamCtx, state);
+            usageRefundTracker.recordDeductions(rateLimitInfo);
+            chatLogger?.setRateLimit(
+              {
+                pointsDeducted: rateLimitInfo.pointsDeducted,
+                extraUsagePointsDeducted:
+                  rateLimitInfo.extraUsagePointsDeducted,
+                monthly: rateLimitInfo.monthly,
+                remaining: rateLimitInfo.remaining,
+                subscription,
+              },
+              extraUsageConfig,
+            );
 
-          let result;
-          try {
-            result = await createStream(selectedModel);
-          } catch (error) {
-            if (
-              isProviderApiError(error) &&
-              !isRetryWithFallback &&
-              isAutoModel
-            ) {
-              phLogger.error(
-                "[agent-long] Provider API error, retrying with fallback",
-                {
-                  error,
-                  chatId,
-                  providerGateway: "openrouter",
-                  originalModel: selectedModel,
-                  requestedModelSlug: configuredModelId,
-                  fallbackModel,
-                  fallbackModelSlug: fallbackModelId,
+            sendRateLimitWarnings(writer, {
+              subscription,
+              mode,
+              rateLimitInfo,
+            });
+
+            const {
+              tools,
+              ensureSandbox,
+              getTodoManager,
+              getFileAccumulator,
+              sandboxManager,
+              getSandboxSessionCost,
+            } = createTools(
+              userId,
+              chatId,
+              writer,
+              mode,
+              userLocation,
+              baseTodos,
+              memoryEnabled,
+              !!temporary,
+              assistantMessageId,
+              sandboxPreference,
+              process.env.CONVEX_SERVICE_ROLE_KEY,
+              userCustomization?.guardrails_config,
+              false,
+              undefined,
+              undefined,
+              (costDollars: number) => {
+                usageTracker.providerCost += costDollars;
+                usageTracker.nonModelCost += costDollars;
+                chatLogger?.getBuilder().addToolCost(costDollars);
+              },
+              subscription,
+              (info) => chatLogger?.setSandboxBoot(info),
+              undefined,
+            );
+
+            const sendFileMetadataToStream = (
+              fileMetadata: Array<{
+                fileId: Id<"files">;
+                name: string;
+                mediaType: string;
+                s3Key?: string;
+                storageId?: Id<"_storage">;
+              }>,
+            ) => {
+              if (!fileMetadata || fileMetadata.length === 0) return;
+              writer.write({
+                type: "data-file-metadata",
+                data: {
+                  messageId: assistantMessageId,
+                  fileDetails: fileMetadata,
+                },
+              });
+            };
+
+            let sandboxContext: string | null = null;
+            if ("getSandboxContextForPrompt" in sandboxManager) {
+              try {
+                sandboxContext = await (
+                  sandboxManager as {
+                    getSandboxContextForPrompt: () => Promise<string | null>;
+                  }
+                ).getSandboxContextForPrompt();
+              } catch (err) {
+                console.warn(
+                  "[agent-long] Failed to get sandbox context:",
+                  err,
+                );
+              }
+            }
+
+            if (sandboxFiles && sandboxFiles.length > 0) {
+              writeUploadStartStatus(
+                writer,
+                sandboxFiles.every((file) => file.kind === "localPath")
+                  ? "Preparing local attachments on your computer"
+                  : "Uploading attachments to the computer",
+              );
+              let uploadResult: { failedCount: number } = { failedCount: 0 };
+              try {
+                uploadResult = await uploadSandboxFiles(
+                  sandboxFiles,
+                  ensureSandbox,
+                );
+              } finally {
+                writeUploadCompleteStatus(writer);
+              }
+              if (uploadResult.failedCount > 0) {
+                const noun =
+                  uploadResult.failedCount === 1 ? "attachment" : "attachments";
+                const uploadError = new ChatSDKError(
+                  "bad_request:stream",
+                  `Failed to upload ${uploadResult.failedCount} ${noun} to the computer. Please try again.`,
+                );
+                await usageRefundTracker.refund();
+                chatLogger?.emitChatError(uploadError);
+                throw uploadError;
+              }
+            }
+
+            const titlePromise =
+              isNewChat && !temporary
+                ? generateTitleFromUserMessageWithWriter(
+                    processedMessages,
+                    writer,
+                  )
+                : Promise.resolve(undefined);
+
+            const trackedProvider = createTrackedProvider();
+            const currentSystemPrompt = await systemPrompt(
+              userId,
+              mode,
+              subscription,
+              selectedModel,
+              userCustomization,
+              temporary,
+              sandboxContext,
+            );
+            const systemPromptTokens = countTokens(currentSystemPrompt);
+
+            const contextUsageOn = isContextUsageEnabled(subscription, mode);
+            const ctxSystemTokens = contextUsageOn ? systemPromptTokens : 0;
+            const ctxMaxTokens = contextUsageOn
+              ? getMaxTokensForSubscription(subscription, { mode })
+              : 0;
+            const initialCtxUsage = contextUsageOn
+              ? computeContextUsage(
+                  messagesForAccounting,
+                  fileTokens,
+                  ctxSystemTokens,
+                  ctxMaxTokens,
+                )
+              : { usedTokens: 0, maxTokens: 0 };
+
+            let finalMessages = processedMessages;
+
+            const resumeContext = getResumeSection(chat?.finish_reason);
+            if (resumeContext) {
+              finalMessages = appendSystemReminderToLastUserMessage(
+                finalMessages,
+                resumeContext,
+              );
+            }
+
+            const noteInjectionOpts = {
+              userId,
+              subscription,
+              shouldIncludeNotes:
+                userCustomization?.include_memory_entries ?? true,
+              isTemporary: !!temporary as boolean | undefined,
+            };
+            finalMessages = await injectNotesIntoMessages(
+              finalMessages,
+              noteInjectionOpts,
+            );
+
+            // Mutable stream state — updated in-place by the shared runner and
+            // read back here in toUIMessageStream.onFinish.
+            const state = initAgentStreamState(finalMessages, initialCtxUsage);
+            terminalAgentState = state;
+
+            const budgetSnapshot = captureBudgetSnapshot({
+              rateLimitInfo,
+              extraUsageConfig,
+              subscription,
+            });
+            const budgetMonitor = budgetSnapshot
+              ? new BudgetMonitor(budgetSnapshot, writer, subscription)
+              : null;
+
+            // Use task start time (not stream start time) so the 58-min stop
+            // condition always fires 2 min before the 60-min hard SIGKILL.
+            const streamStartTime = taskStartTime;
+            const configuredModelId =
+              trackedProvider.languageModel(selectedModel).modelId;
+
+            let isRetryWithFallback = false;
+            const isAutoModel = [
+              "ask-model",
+              "ask-model-free",
+              "agent-model",
+              "agent-model-free",
+            ].includes(selectedModel);
+            const fallbackModel = getRetryFallbackModel(selectedModel, mode);
+            const fallbackModelId =
+              trackedProvider.languageModel(fallbackModel).modelId;
+
+            const usageTracker = new UsageTracker();
+            let hasRecordedUsage = false;
+            let preFallbackCacheRead = 0;
+            let preFallbackCacheWrite = 0;
+
+            const deductAccumulatedUsage = async () => {
+              try {
+                if (hasRecordedUsage) return;
+                const sandboxCost = getSandboxSessionCost();
+                if (sandboxCost > 0) {
+                  usageTracker.providerCost += sandboxCost;
+                  usageTracker.nonModelCost += sandboxCost;
+                  chatLogger?.getBuilder().addToolCost(sandboxCost);
+                }
+                if (!usageTracker.hasUsage) return;
+                hasRecordedUsage = true;
+                const usageCostRecord = usageTracker.createUsageCostRecord({
+                  selectedModel,
+                  selectedModelOverride,
+                  responseModel: state.responseModel,
+                  configuredModelId,
+                  rateLimitInfo,
+                });
+                const providerCost =
+                  usageTracker.modelProviderCost > 0
+                    ? usageTracker.providerCost
+                    : undefined;
+                if (subscription !== "free") {
+                  await deductUsage(
+                    userId,
+                    subscription,
+                    estimatedInputTokens,
+                    usageTracker.inputTokens,
+                    usageTracker.outputTokens,
+                    extraUsageConfig,
+                    providerCost,
+                    selectedModel,
+                    usageTracker.nonModelCost,
+                    organizationId,
+                  );
+                  usageTracker.log({
+                    userId,
+                    selectedModel,
+                    selectedModelOverride,
+                    responseModel: state.responseModel,
+                    configuredModelId,
+                    rateLimitInfo,
+                  });
+                }
+                captureUsageCost({
+                  posthog,
                   userId,
                   subscription,
-                  preFallbackCacheReadTokens: usageTracker.cacheReadTokens,
-                  preFallbackCacheWriteTokens: usageTracker.cacheWriteTokens,
-                  ...extractErrorDetails(error),
-                },
-              );
-              isRetryWithFallback = true;
-              state.lastStepInputTokens = 0;
-              state.stoppedDueToTokenExhaustion = false;
-              state.stoppedDueToElapsedTimeout = false;
-              state.stoppedDueToDoomLoop = false;
-              state.stoppedDueToBudgetExhaustion = false;
-              preFallbackCacheRead = usageTracker.cacheReadTokens;
-              preFallbackCacheWrite = usageTracker.cacheWriteTokens;
-              usageTracker.resetModelLeg();
-              result = await createStream(fallbackModel);
-            } else {
-              throw error;
-            }
-          }
+                  organizationId,
+                  chatId,
+                  endpoint: "/api/agent",
+                  mode,
+                  usage: usageCostRecord,
+                });
+              } finally {
+                await releaseFreeRunLockOnce();
+              }
+            };
 
-          writer.merge(
-            withAgentLongStreamHeartbeat(
-              result.toUIMessageStream({
-                generateMessageId: () => assistantMessageId,
-                sendReasoning: true,
-                messageMetadata: ({ part }) => {
-                  if (part.type === "start") {
-                    return { mode, generationStartedAt: streamStartTime };
-                  }
+            // Shared runner context — immutable deps + platform hook.
+            const streamCtx: AgentStreamContext = {
+              trackedProvider,
+              currentSystemPrompt,
+              tools,
+              mode,
+              userId,
+              subscription,
+              chatId,
+              temporary,
+              fileTokens,
+              noteInjectionOpts,
+              systemPromptTokens,
+              ctxSystemTokens,
+              ctxMaxTokens,
+              streamStartTime,
+              contextUsageOn,
+              isReasoningModel: true, // long mode is always agent mode
+              maxDurationMs: AGENT_LONG_MAX_DURATION_MS,
+              writer,
+              abortController: userStopSignal,
+              summarizationTracker,
+              usageTracker,
+              budgetMonitor,
+              sandboxManager,
+              getTodoManager,
+              ensureSandbox,
+              chatLogger,
+              usageRefundTracker,
+              // trigger.dev has no Vercel-style hard preemptive timeout
+              getHardTimeoutReason: () => null,
+            };
 
-                  if (part.type === "finish") {
-                    return {
-                      mode,
-                      generationStartedAt: streamStartTime,
-                      generationTimeMs: Date.now() - streamStartTime,
-                    };
-                  }
-                },
-                onFinish: async ({ messages: finishedMessages, isAborted }) => {
-                  // Retry with fallback if stream only produced step-start (incomplete response)
-                  const lastAssistantMessage = finishedMessages
-                    .slice()
-                    .reverse()
-                    .find((m) => m.role === "assistant");
-                  const lastAssistantMessageParts =
-                    stripAgentLongHeartbeatParts(
-                      lastAssistantMessage ?? { parts: [] },
-                    ).parts ?? [];
-                  const hasOnlyStepStart =
-                    lastAssistantMessageParts.length === 1 &&
-                    (lastAssistantMessageParts[0] as { type?: string })
-                      ?.type === "step-start";
+            const createStream = (modelName: string) =>
+              createAgentStream(modelName, streamCtx, state);
 
-                  if (
-                    hasOnlyStepStart &&
-                    !isRetryWithFallback &&
-                    !isAborted &&
-                    isAutoModel
-                  ) {
-                    isRetryWithFallback = true;
-                    state.lastStepInputTokens = 0;
-                    state.stoppedDueToTokenExhaustion = false;
-                    state.stoppedDueToElapsedTimeout = false;
-                    state.stoppedDueToDoomLoop = false;
-                    state.stoppedDueToBudgetExhaustion = false;
-                    const fallbackStartTime = Date.now();
-                    preFallbackCacheRead = usageTracker.cacheReadTokens;
-                    preFallbackCacheWrite = usageTracker.cacheWriteTokens;
-                    usageTracker.resetModelLeg();
-                    const retryResult = await createStream(fallbackModel);
-                    const retryMessageId = generateId();
-
-                    writer.merge(
-                      withAgentLongStreamHeartbeat(
-                        retryResult.toUIMessageStream({
-                          generateMessageId: () => retryMessageId,
-                          sendReasoning: true,
-                          messageMetadata: ({ part }) => {
-                            if (part.type === "start") {
-                              return {
-                                mode,
-                                generationStartedAt: fallbackStartTime,
-                              };
-                            }
-
-                            if (part.type === "finish") {
-                              return {
-                                mode,
-                                generationStartedAt: fallbackStartTime,
-                                generationTimeMs:
-                                  Date.now() - fallbackStartTime,
-                              };
-                            }
-                          },
-                          onFinish: async ({
-                            messages: retryMessages,
-                            isAborted: retryAborted,
-                          }) => {
-                            const fallbackCacheRead =
-                              usageTracker.cacheReadTokens -
-                              preFallbackCacheRead;
-                            const fallbackCacheWrite =
-                              usageTracker.cacheWriteTokens -
-                              preFallbackCacheWrite;
-                            const fallbackCacheTotal =
-                              fallbackCacheRead + fallbackCacheWrite;
-                            const sandboxInfo = sandboxManager.getSandboxInfo();
-                            chatLogger?.setSandbox(sandboxInfo);
-                            chatLogger?.setCacheMetrics({
-                              cacheHitRate:
-                                fallbackCacheTotal > 0
-                                  ? fallbackCacheRead / fallbackCacheTotal
-                                  : null,
-                              cacheReadTokens: fallbackCacheRead,
-                              cacheWriteTokens: fallbackCacheWrite,
-                            });
-                            captureToolCalls({
-                              posthog,
-                              chatLogger,
-                              userId,
-                              mode,
-                            });
-                            captureAgentRun({
-                              posthog,
-                              userId,
-                              mode,
-                              subscription,
-                              sandboxInfo,
-                              outcome: retryAborted
-                                ? "aborted"
-                                : isTerminalProviderStreamError(state)
-                                  ? "error"
-                                  : "success",
-                            });
-                            if (!isTerminalProviderStreamError(state)) {
-                              chatLogger?.emitSuccess({
-                                finishReason: state.streamFinishReason,
-                                wasAborted: retryAborted,
-                                wasPreemptiveTimeout: false,
-                                hadSummarization:
-                                  summarizationTracker.hasSummarized,
-                              });
-                            }
-
-                            const generatedTitle = await titlePromise;
-                            if (!temporary) {
-                              const mergedTodos = getTodoManager().mergeWith(
-                                baseTodos,
-                                retryMessageId,
-                              );
-                              if (
-                                generatedTitle ||
-                                state.streamFinishReason ||
-                                mergedTodos.length > 0
-                              ) {
-                                await updateChat({
-                                  chatId,
-                                  title: generatedTitle,
-                                  finishReason: state.streamFinishReason,
-                                  todos: mergedTodos,
-                                  defaultModelSlug: "agent",
-                                  sandboxType:
-                                    sandboxManager.getEffectivePreference(),
-                                  selectedModel: selectedModelOverride,
-                                });
-                              } else {
-                                await prepareForNewStream({ chatId });
-                              }
-                              const accumulatedFiles =
-                                getFileAccumulator().getAll();
-                              const newFileIds = accumulatedFiles.map(
-                                (f) => f.fileId,
-                              );
-                              const fallbackGenerationTimeMs =
-                                Date.now() - fallbackStartTime;
-                              for (const msg of retryMessages) {
-                                if (msg.role !== "assistant") continue;
-                                const processed = stripAgentLongHeartbeatParts(
-                                  summarizationTracker.processMessageForSave(
-                                    msg,
-                                  ),
-                                );
-                                await saveMessage({
-                                  chatId,
-                                  userId,
-                                  message: processed,
-                                  extraFileIds: newFileIds,
-                                  usage: state.streamUsage,
-                                  model: state.responseModel,
-                                  mode,
-                                  generationStartedAt: fallbackStartTime,
-                                  generationTimeMs: fallbackGenerationTimeMs,
-                                  finishReason: state.streamFinishReason,
-                                });
-                              }
-                              writer.write({
-                                type: "message-metadata",
-                                messageMetadata: {
-                                  mode,
-                                  generationStartedAt: fallbackStartTime,
-                                  generationTimeMs: fallbackGenerationTimeMs,
-                                },
-                              });
-                              sendFileMetadataToStream(accumulatedFiles);
-                            }
-                            await deductAccumulatedUsage();
-                            posthog?.shutdown();
-                          },
-                        }),
-                        userStopSignal.signal,
-                      ),
-                    );
-                    return;
-                  }
-
-                  // User-initiated cancel via trigger.dev: clear finish reason
-                  // so the client doesn't show spurious "going off course" messages.
-                  if (
-                    isAborted &&
-                    triggerSignal.aborted &&
-                    !state.stoppedDueToBudgetExhaustion &&
-                    !state.stoppedDueToElapsedTimeout
-                  ) {
-                    state.streamFinishReason = undefined;
-                  }
-
-                  const sandboxInfo = sandboxManager.getSandboxInfo();
-                  chatLogger?.setSandbox(sandboxInfo);
-                  chatLogger?.setCacheMetrics({
-                    cacheHitRate: usageTracker.cacheHitRate,
-                    cacheReadTokens: usageTracker.cacheReadTokens,
-                    cacheWriteTokens: usageTracker.cacheWriteTokens,
-                  });
-                  captureToolCalls({ posthog, chatLogger, userId, mode });
-                  captureAgentRun({
-                    posthog,
+            let result;
+            try {
+              result = await createStream(selectedModel);
+            } catch (error) {
+              if (
+                isProviderApiError(error) &&
+                !isRetryWithFallback &&
+                isAutoModel
+              ) {
+                phLogger.error(
+                  "[agent-long] Provider API error, retrying with fallback",
+                  {
+                    error,
+                    chatId,
+                    providerGateway: "openrouter",
+                    originalModel: selectedModel,
+                    requestedModelSlug: configuredModelId,
+                    fallbackModel,
+                    fallbackModelSlug: fallbackModelId,
                     userId,
-                    mode,
                     subscription,
-                    sandboxInfo,
-                    outcome: isAborted
-                      ? "aborted"
-                      : isTerminalProviderStreamError(state)
-                        ? "error"
-                        : "success",
-                  });
-                  if (!isTerminalProviderStreamError(state)) {
-                    chatLogger?.emitSuccess({
-                      finishReason: state.streamFinishReason,
-                      wasAborted: isAborted,
-                      wasPreemptiveTimeout: state.stoppedDueToElapsedTimeout,
-                      hadSummarization: summarizationTracker.hasSummarized,
-                    });
-                  }
+                    preFallbackCacheReadTokens: usageTracker.cacheReadTokens,
+                    preFallbackCacheWriteTokens: usageTracker.cacheWriteTokens,
+                    ...extractErrorDetails(error),
+                  },
+                );
+                isRetryWithFallback = true;
+                state.lastStepInputTokens = 0;
+                state.stoppedDueToTokenExhaustion = false;
+                state.stoppedDueToElapsedTimeout = false;
+                state.stoppedDueToDoomLoop = false;
+                state.stoppedDueToBudgetExhaustion = false;
+                preFallbackCacheRead = usageTracker.cacheReadTokens;
+                preFallbackCacheWrite = usageTracker.cacheWriteTokens;
+                usageTracker.resetModelLeg();
+                result = await createStream(fallbackModel);
+              } else {
+                throw error;
+              }
+            }
 
-                  const generatedTitle = await titlePromise;
-
-                  if (!temporary) {
-                    const mergedTodos = getTodoManager().mergeWith(
-                      baseTodos,
-                      assistantMessageId,
-                    );
-                    const shouldPersist = regenerate
-                      ? true
-                      : Boolean(
-                          generatedTitle ||
-                          state.streamFinishReason ||
-                          mergedTodos.length > 0,
-                        );
-
-                    if (shouldPersist) {
-                      await updateChat({
-                        chatId,
-                        title: generatedTitle,
-                        finishReason: state.streamFinishReason,
-                        todos: mergedTodos,
-                        defaultModelSlug: "agent",
-                        sandboxType: sandboxManager.getEffectivePreference(),
-                        selectedModel: selectedModelOverride,
-                      });
-                    } else {
-                      await prepareForNewStream({ chatId });
+            writer.merge(
+              withAgentLongStreamHeartbeat(
+                result.toUIMessageStream({
+                  generateMessageId: () => assistantMessageId,
+                  sendReasoning: true,
+                  messageMetadata: ({ part }) => {
+                    if (part.type === "start") {
+                      return { mode, generationStartedAt: streamStartTime };
                     }
 
-                    const accumulatedFiles = getFileAccumulator().getAll();
-                    const newFileIds = accumulatedFiles.map((f) => f.fileId);
-
-                    let resolvedUsage: Record<string, unknown> | undefined =
-                      state.streamUsage;
-                    if (!resolvedUsage && isAborted) {
-                      try {
-                        resolvedUsage = (await result.usage) as Record<
-                          string,
-                          unknown
-                        >;
-                      } catch {
-                        // Usage unavailable on abort
-                      }
+                    if (part.type === "finish") {
+                      return {
+                        mode,
+                        generationStartedAt: streamStartTime,
+                        generationTimeMs: Date.now() - streamStartTime,
+                      };
                     }
+                  },
+                  onFinish: async ({
+                    messages: finishedMessages,
+                    isAborted,
+                  }) => {
+                    // Retry with fallback if stream only produced step-start (incomplete response)
+                    const lastAssistantMessage = finishedMessages
+                      .slice()
+                      .reverse()
+                      .find((m) => m.role === "assistant");
+                    const lastAssistantMessageParts =
+                      stripAgentLongHeartbeatParts(
+                        lastAssistantMessage ?? { parts: [] },
+                      ).parts ?? [];
+                    const hasOnlyStepStart =
+                      lastAssistantMessageParts.length === 1 &&
+                      (lastAssistantMessageParts[0] as { type?: string })
+                        ?.type === "step-start";
 
-                    const hasIncompleteToolCalls = finishedMessages.some(
-                      (msg) =>
-                        msg.role === "assistant" &&
-                        msg.parts?.some(
-                          (p: {
-                            type?: string;
-                            state?: string;
-                            toolCallId?: string;
-                          }) =>
-                            p.type?.startsWith("tool-") &&
-                            p.state !== "output-available" &&
-                            p.toolCallId,
-                        ),
-                    );
-                    const incompleteToolSummaries = isAborted
-                      ? summarizeIncompleteToolParts(finishedMessages)
-                      : [];
-                    if (incompleteToolSummaries.length > 0) {
-                      console.info(
-                        JSON.stringify({
-                          level: "info",
-                          event:
-                            "agent_long_abort_incomplete_tool_calls_detected",
-                          service: "agent-long",
-                          timestamp: new Date().toISOString(),
-                          chat_id: chatId,
-                          user_id: userId,
-                          mode: "agent",
-                          finish_reason: state.streamFinishReason,
-                          trigger_signal_aborted: triggerSignal.aborted,
-                          incomplete_tool_count: incompleteToolSummaries.length,
-                          incomplete_tools: incompleteToolSummaries,
-                        }),
-                      );
-                    }
                     if (
-                      isAborted &&
-                      !triggerSignal.aborted &&
-                      newFileIds.length === 0 &&
-                      !hasIncompleteToolCalls &&
-                      !resolvedUsage
+                      hasOnlyStepStart &&
+                      !isRetryWithFallback &&
+                      !isAborted &&
+                      isAutoModel
                     ) {
-                      console.info(
-                        JSON.stringify({
-                          level: "info",
-                          event: "agent_long_abort_message_save_skipped",
-                          service: "agent-long",
-                          timestamp: new Date().toISOString(),
-                          chat_id: chatId,
-                          user_id: userId,
-                          mode: "agent",
-                          finish_reason: state.streamFinishReason,
-                          new_file_count: newFileIds.length,
-                          has_incomplete_tool_calls: hasIncompleteToolCalls,
-                          has_usage_to_record: Boolean(resolvedUsage),
-                        }),
+                      isRetryWithFallback = true;
+                      state.lastStepInputTokens = 0;
+                      state.stoppedDueToTokenExhaustion = false;
+                      state.stoppedDueToElapsedTimeout = false;
+                      state.stoppedDueToDoomLoop = false;
+                      state.stoppedDueToBudgetExhaustion = false;
+                      const fallbackStartTime = Date.now();
+                      preFallbackCacheRead = usageTracker.cacheReadTokens;
+                      preFallbackCacheWrite = usageTracker.cacheWriteTokens;
+                      usageTracker.resetModelLeg();
+                      const retryResult = await createStream(fallbackModel);
+                      const retryMessageId = generateId();
+
+                      writer.merge(
+                        withAgentLongStreamHeartbeat(
+                          retryResult.toUIMessageStream({
+                            generateMessageId: () => retryMessageId,
+                            sendReasoning: true,
+                            messageMetadata: ({ part }) => {
+                              if (part.type === "start") {
+                                return {
+                                  mode,
+                                  generationStartedAt: fallbackStartTime,
+                                };
+                              }
+
+                              if (part.type === "finish") {
+                                return {
+                                  mode,
+                                  generationStartedAt: fallbackStartTime,
+                                  generationTimeMs:
+                                    Date.now() - fallbackStartTime,
+                                };
+                              }
+                            },
+                            onFinish: async ({
+                              messages: retryMessages,
+                              isAborted: retryAborted,
+                            }) => {
+                              const fallbackCacheRead =
+                                usageTracker.cacheReadTokens -
+                                preFallbackCacheRead;
+                              const fallbackCacheWrite =
+                                usageTracker.cacheWriteTokens -
+                                preFallbackCacheWrite;
+                              const fallbackCacheTotal =
+                                fallbackCacheRead + fallbackCacheWrite;
+                              const sandboxInfo =
+                                sandboxManager.getSandboxInfo();
+                              chatLogger?.setSandbox(sandboxInfo);
+                              chatLogger?.setCacheMetrics({
+                                cacheHitRate:
+                                  fallbackCacheTotal > 0
+                                    ? fallbackCacheRead / fallbackCacheTotal
+                                    : null,
+                                cacheReadTokens: fallbackCacheRead,
+                                cacheWriteTokens: fallbackCacheWrite,
+                              });
+                              captureToolCalls({
+                                posthog,
+                                chatLogger,
+                                userId,
+                                mode,
+                              });
+                              captureAgentRun({
+                                posthog,
+                                userId,
+                                mode,
+                                subscription,
+                                sandboxInfo,
+                                outcome: retryAborted
+                                  ? "aborted"
+                                  : isTerminalProviderStreamError(state)
+                                    ? "error"
+                                    : "success",
+                              });
+                              if (!isTerminalProviderStreamError(state)) {
+                                chatLogger?.emitSuccess({
+                                  finishReason: state.streamFinishReason,
+                                  wasAborted: retryAborted,
+                                  wasPreemptiveTimeout: false,
+                                  hadSummarization:
+                                    summarizationTracker.hasSummarized,
+                                });
+                              }
+
+                              const generatedTitle = await titlePromise;
+                              if (!temporary) {
+                                const mergedTodos = getTodoManager().mergeWith(
+                                  baseTodos,
+                                  retryMessageId,
+                                );
+                                if (
+                                  generatedTitle ||
+                                  state.streamFinishReason ||
+                                  mergedTodos.length > 0
+                                ) {
+                                  await updateChat({
+                                    chatId,
+                                    title: generatedTitle,
+                                    finishReason: state.streamFinishReason,
+                                    todos: mergedTodos,
+                                    defaultModelSlug: "agent",
+                                    sandboxType:
+                                      sandboxManager.getEffectivePreference(),
+                                    selectedModel: selectedModelOverride,
+                                  });
+                                } else {
+                                  await prepareForNewStream({ chatId });
+                                }
+                                const accumulatedFiles =
+                                  getFileAccumulator().getAll();
+                                const newFileIds = accumulatedFiles.map(
+                                  (f) => f.fileId,
+                                );
+                                const fallbackGenerationTimeMs =
+                                  Date.now() - fallbackStartTime;
+                                for (const msg of retryMessages) {
+                                  if (msg.role !== "assistant") continue;
+                                  const processed =
+                                    stripAgentLongHeartbeatParts(
+                                      summarizationTracker.processMessageForSave(
+                                        msg,
+                                      ),
+                                    );
+                                  await saveMessage({
+                                    chatId,
+                                    userId,
+                                    message: processed,
+                                    extraFileIds: newFileIds,
+                                    usage: state.streamUsage,
+                                    model: state.responseModel,
+                                    mode,
+                                    generationStartedAt: fallbackStartTime,
+                                    generationTimeMs: fallbackGenerationTimeMs,
+                                    finishReason: state.streamFinishReason,
+                                  });
+                                }
+                                writer.write({
+                                  type: "message-metadata",
+                                  messageMetadata: {
+                                    mode,
+                                    generationStartedAt: fallbackStartTime,
+                                    generationTimeMs: fallbackGenerationTimeMs,
+                                  },
+                                });
+                                sendFileMetadataToStream(accumulatedFiles);
+                              }
+                              await deductAccumulatedUsage();
+                              posthog?.shutdown();
+                            },
+                          }),
+                          userStopSignal.signal,
+                        ),
                       );
-                      await deductAccumulatedUsage();
-                      posthog?.shutdown();
                       return;
                     }
 
-                    const finalGenerationTimeMs = Date.now() - streamStartTime;
-                    let savedAssistantMessage = false;
-                    for (const message of finishedMessages) {
-                      const processed = stripAgentLongHeartbeatParts(
-                        summarizationTracker.processMessageForSave(message),
-                      );
-                      if (
-                        (!processed.parts || processed.parts.length === 0) &&
-                        newFileIds.length === 0
-                      ) {
-                        continue;
-                      }
-                      await saveMessage({
-                        chatId,
-                        userId,
-                        message: processed,
-                        extraFileIds: newFileIds,
-                        model: state.responseModel || configuredModelId,
-                        mode,
-                        generationStartedAt:
-                          processed.role === "assistant"
-                            ? streamStartTime
-                            : undefined,
-                        generationTimeMs: finalGenerationTimeMs,
-                        finishReason: state.streamFinishReason,
-                        usage: resolvedUsage ?? state.streamUsage,
-                        updateOnly:
-                          isAborted && !state.stoppedDueToElapsedTimeout
-                            ? true
-                            : undefined,
-                        isHidden:
-                          isAutoContinue && processed.role === "user"
-                            ? true
-                            : undefined,
-                      });
-                      if (processed.role === "assistant") {
-                        savedAssistantMessage = true;
-                      }
+                    // User-initiated cancel via trigger.dev: clear finish reason
+                    // so the client doesn't show spurious "going off course" messages.
+                    if (
+                      isAborted &&
+                      triggerSignal.aborted &&
+                      !state.stoppedDueToBudgetExhaustion &&
+                      !state.stoppedDueToElapsedTimeout
+                    ) {
+                      state.streamFinishReason = undefined;
                     }
 
-                    if (savedAssistantMessage) {
-                      writer.write({
-                        type: "message-metadata",
-                        messageMetadata: {
-                          mode,
-                          generationStartedAt: streamStartTime,
-                          generationTimeMs: finalGenerationTimeMs,
-                        },
-                      });
-                    }
-
-                    sendFileMetadataToStream(accumulatedFiles);
-                  }
-
-                  if (contextUsageOn) {
-                    writeContextUsage(writer, {
-                      usedTokens:
-                        state.ctxUsage.usedTokens +
-                        usageTracker.streamOutputTokens,
-                      maxTokens: state.ctxUsage.maxTokens,
+                    const sandboxInfo = sandboxManager.getSandboxInfo();
+                    chatLogger?.setSandbox(sandboxInfo);
+                    chatLogger?.setCacheMetrics({
+                      cacheHitRate: usageTracker.cacheHitRate,
+                      cacheReadTokens: usageTracker.cacheReadTokens,
+                      cacheWriteTokens: usageTracker.cacheWriteTokens,
                     });
-                  }
+                    captureToolCalls({ posthog, chatLogger, userId, mode });
+                    captureAgentRun({
+                      posthog,
+                      userId,
+                      mode,
+                      subscription,
+                      sandboxInfo,
+                      outcome: isAborted
+                        ? "aborted"
+                        : isTerminalProviderStreamError(state)
+                          ? "error"
+                          : "success",
+                    });
+                    if (!isTerminalProviderStreamError(state)) {
+                      chatLogger?.emitSuccess({
+                        finishReason: state.streamFinishReason,
+                        wasAborted: isAborted,
+                        wasPreemptiveTimeout: state.stoppedDueToElapsedTimeout,
+                        hadSummarization: summarizationTracker.hasSummarized,
+                      });
+                    }
 
-                  // Don't auto-continue on elapsed timeout — a 58-min run is large enough
-                  // that the user should explicitly decide whether to continue rather than
-                  // silently chaining up to 5 more hour-long runs.
-                  if (
-                    (state.stoppedDueToTokenExhaustion ||
-                      state.streamFinishReason === "tool-calls") &&
-                    !temporary
-                  ) {
-                    writeAutoContinue(writer);
-                  }
+                    const generatedTitle = await titlePromise;
 
-                  await deductAccumulatedUsage();
-                  posthog?.shutdown();
-                },
-              }),
-              userStopSignal.signal,
-            ),
-          );
+                    if (!temporary) {
+                      const mergedTodos = getTodoManager().mergeWith(
+                        baseTodos,
+                        assistantMessageId,
+                      );
+                      const shouldPersist = regenerate
+                        ? true
+                        : Boolean(
+                            generatedTitle ||
+                            state.streamFinishReason ||
+                            mergedTodos.length > 0,
+                          );
+
+                      if (shouldPersist) {
+                        await updateChat({
+                          chatId,
+                          title: generatedTitle,
+                          finishReason: state.streamFinishReason,
+                          todos: mergedTodos,
+                          defaultModelSlug: "agent",
+                          sandboxType: sandboxManager.getEffectivePreference(),
+                          selectedModel: selectedModelOverride,
+                        });
+                      } else {
+                        await prepareForNewStream({ chatId });
+                      }
+
+                      const accumulatedFiles = getFileAccumulator().getAll();
+                      const newFileIds = accumulatedFiles.map((f) => f.fileId);
+
+                      let resolvedUsage: Record<string, unknown> | undefined =
+                        state.streamUsage;
+                      if (!resolvedUsage && isAborted) {
+                        try {
+                          resolvedUsage = (await result.usage) as Record<
+                            string,
+                            unknown
+                          >;
+                        } catch {
+                          // Usage unavailable on abort
+                        }
+                      }
+
+                      const hasIncompleteToolCalls = finishedMessages.some(
+                        (msg) =>
+                          msg.role === "assistant" &&
+                          msg.parts?.some(
+                            (p: {
+                              type?: string;
+                              state?: string;
+                              toolCallId?: string;
+                            }) =>
+                              p.type?.startsWith("tool-") &&
+                              p.state !== "output-available" &&
+                              p.toolCallId,
+                          ),
+                      );
+                      const incompleteToolSummaries = isAborted
+                        ? summarizeIncompleteToolParts(finishedMessages)
+                        : [];
+                      if (incompleteToolSummaries.length > 0) {
+                        console.info(
+                          JSON.stringify({
+                            level: "info",
+                            event:
+                              "agent_long_abort_incomplete_tool_calls_detected",
+                            service: "agent-long",
+                            timestamp: new Date().toISOString(),
+                            chat_id: chatId,
+                            user_id: userId,
+                            mode: "agent",
+                            finish_reason: state.streamFinishReason,
+                            trigger_signal_aborted: triggerSignal.aborted,
+                            incomplete_tool_count:
+                              incompleteToolSummaries.length,
+                            incomplete_tools: incompleteToolSummaries,
+                          }),
+                        );
+                      }
+                      if (
+                        isAborted &&
+                        !triggerSignal.aborted &&
+                        newFileIds.length === 0 &&
+                        !hasIncompleteToolCalls &&
+                        !resolvedUsage
+                      ) {
+                        console.info(
+                          JSON.stringify({
+                            level: "info",
+                            event: "agent_long_abort_message_save_skipped",
+                            service: "agent-long",
+                            timestamp: new Date().toISOString(),
+                            chat_id: chatId,
+                            user_id: userId,
+                            mode: "agent",
+                            finish_reason: state.streamFinishReason,
+                            new_file_count: newFileIds.length,
+                            has_incomplete_tool_calls: hasIncompleteToolCalls,
+                            has_usage_to_record: Boolean(resolvedUsage),
+                          }),
+                        );
+                        await deductAccumulatedUsage();
+                        posthog?.shutdown();
+                        return;
+                      }
+
+                      const finalGenerationTimeMs =
+                        Date.now() - streamStartTime;
+                      let savedAssistantMessage = false;
+                      for (const message of finishedMessages) {
+                        const processed = stripAgentLongHeartbeatParts(
+                          summarizationTracker.processMessageForSave(message),
+                        );
+                        if (
+                          (!processed.parts || processed.parts.length === 0) &&
+                          newFileIds.length === 0
+                        ) {
+                          continue;
+                        }
+                        await saveMessage({
+                          chatId,
+                          userId,
+                          message: processed,
+                          extraFileIds: newFileIds,
+                          model: state.responseModel || configuredModelId,
+                          mode,
+                          generationStartedAt:
+                            processed.role === "assistant"
+                              ? streamStartTime
+                              : undefined,
+                          generationTimeMs: finalGenerationTimeMs,
+                          finishReason: state.streamFinishReason,
+                          usage: resolvedUsage ?? state.streamUsage,
+                          updateOnly:
+                            isAborted && !state.stoppedDueToElapsedTimeout
+                              ? true
+                              : undefined,
+                          isHidden:
+                            isAutoContinue && processed.role === "user"
+                              ? true
+                              : undefined,
+                        });
+                        if (processed.role === "assistant") {
+                          savedAssistantMessage = true;
+                        }
+                      }
+
+                      if (savedAssistantMessage) {
+                        writer.write({
+                          type: "message-metadata",
+                          messageMetadata: {
+                            mode,
+                            generationStartedAt: streamStartTime,
+                            generationTimeMs: finalGenerationTimeMs,
+                          },
+                        });
+                      }
+
+                      sendFileMetadataToStream(accumulatedFiles);
+                    }
+
+                    if (contextUsageOn) {
+                      writeContextUsage(writer, {
+                        usedTokens:
+                          state.ctxUsage.usedTokens +
+                          usageTracker.streamOutputTokens,
+                        maxTokens: state.ctxUsage.maxTokens,
+                      });
+                    }
+
+                    // Don't auto-continue on elapsed timeout — a 58-min run is large enough
+                    // that the user should explicitly decide whether to continue rather than
+                    // silently chaining up to 5 more hour-long runs.
+                    if (
+                      (state.stoppedDueToTokenExhaustion ||
+                        state.streamFinishReason === "tool-calls") &&
+                      !temporary
+                    ) {
+                      writeAutoContinue(writer);
+                    }
+
+                    await deductAccumulatedUsage();
+                    posthog?.shutdown();
+                  },
+                }),
+                userStopSignal.signal,
+              ),
+            );
+          } catch (error) {
+            await releaseFreeRunLockOnce();
+            throw error;
+          }
         },
       });
 
@@ -1517,6 +1554,7 @@ export const agentLongTask = task({
       metadata.set("status", "done");
       await phLogger.flush().catch(() => {});
     } catch (error) {
+      await releaseFreeRunLockOnce();
       const chatMissingAfterStream =
         streamPiped &&
         error instanceof ChatSDKError &&

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -103,10 +103,10 @@ import {
   AGENT_LONG_HEARTBEAT_PART_TYPE,
   stripAgentLongHeartbeatParts,
 } from "@/lib/chat/agent-long-heartbeat";
+import { FREE_AGENT_LONG_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
 
 // Leave 2 min for cleanup before trigger.dev hits maxDuration: 60 * 60.
 const AGENT_LONG_MAX_DURATION_MS = 58 * 60 * 1000;
-const AGENT_LONG_FREE_RUN_LOCK_TTL_SECONDS = 65 * 60;
 
 type AgentLongUiStreamPart = Parameters<UIMessageStreamWriter["write"]>[0];
 
@@ -716,7 +716,7 @@ export const agentLongTask = task({
             if (subscription === "free") {
               const lock = await acquireFreeRunConcurrencyLock(
                 userId,
-                AGENT_LONG_FREE_RUN_LOCK_TTL_SECONDS,
+                FREE_AGENT_LONG_RUN_LOCK_TTL_SECONDS,
               );
               releaseFreeRunLock = lock.release;
             }


### PR DESCRIPTION
## Summary
- Restore a real 128k context cap for free users and cap free-user stream output at 4096 tokens.
- Add a Redis-backed one-active-run lock for free users across normal chat/agent streams and long-running Trigger agent runs.
- Update model fallback routing so DeepSeek falls back to Gemini 3 Flash, while Gemini falls back to Grok 4.3.

## Why
Free users could run high-cost sessions because the free token cap was not being applied, free output could stream up to the paid cap, and concurrent free runs were not blocked. The fallback routing also sent DeepSeek failures directly to Grok, which is materially more expensive.

## Validation
- Full pre-commit hook passed: `pnpm typecheck` and `pnpm test`.
- Additional targeted checks run before commit: fallback-chain tests, token utility tests, free concurrency tests, rate-limit routing tests, typecheck, and targeted eslint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Concurrency limiting for free-tier requests (per-run lock)
  * Free-tier monthly cost quota with enforcement and recording
  * Grok 4.3 added to model fallback chain; Gemini-related fallbacks updated

* **Improvements**
  * Increased free-tier token limit from 32,000 → 128,000
  * Subscription-aware token allocation and smarter fallback selection
  * Rate-limit messaging now clarifies free monthly cutoff

* **Tests**
  * New tests for free concurrency and free-monthly cost behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->