### PR TITLE
[codex] fix Termux local client startup

### DIFF
--- a/convex/localSandbox.ts
+++ b/convex/localSandbox.ts
@@ -200,6 +200,12 @@ export const connect = mutation({
         hostname: v.string(),
       }),
     ),
+    capabilities: v.optional(
+      v.object({
+        commands: v.boolean(),
+        pty: v.boolean(),
+      }),
+    ),
   },
   returns: v.object({
     success: v.boolean(),
@@ -236,6 +242,7 @@ export const connect = mutation({
       client_version: args.clientVersion,
       mode: "dangerous",
       os_info: args.osInfo,
+      capabilities: args.capabilities ?? { commands: true, pty: true },
       last_heartbeat: Date.now(),
       status: "connected",
       created_at: Date.now(),
@@ -461,6 +468,7 @@ export const connectDesktop = mutation({
       client_version: "desktop",
       mode: "dangerous",
       os_info: args.osInfo,
+      capabilities: { commands: true, pty: true },
       last_heartbeat: Date.now(),
       status: "connected",
       created_at: Date.now(),
@@ -603,6 +611,10 @@ export const listConnections = query({
       ),
       lastSeen: v.number(),
       isDesktop: v.boolean(),
+      capabilities: v.object({
+        commands: v.boolean(),
+        pty: v.boolean(),
+      }),
     }),
   ),
   handler: async (ctx) => {
@@ -626,6 +638,7 @@ export const listConnections = query({
       osInfo: conn.os_info,
       lastSeen: conn.last_heartbeat,
       isDesktop: conn.client_version === "desktop",
+      capabilities: conn.capabilities ?? { commands: true, pty: true },
     }));
   },
 });
@@ -649,6 +662,10 @@ export const listConnectionsForBackend = query({
       ),
       lastSeen: v.number(),
       isDesktop: v.boolean(),
+      capabilities: v.object({
+        commands: v.boolean(),
+        pty: v.boolean(),
+      }),
     }),
   ),
   handler: async (ctx, args) => {
@@ -667,6 +684,7 @@ export const listConnectionsForBackend = query({
       osInfo: conn.os_info,
       lastSeen: conn.last_heartbeat,
       isDesktop: conn.client_version === "desktop",
+      capabilities: conn.capabilities ?? { commands: true, pty: true },
     }));
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -292,6 +292,12 @@ export default defineSchema({
         hostname: v.string(),
       }),
     ),
+    capabilities: v.optional(
+      v.object({
+        commands: v.boolean(),
+        pty: v.boolean(),
+      }),
+    ),
     last_heartbeat: v.number(),
     status: v.union(v.literal("connected"), v.literal("disconnected")),
     created_at: v.number(),

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -226,6 +226,17 @@ In using these tools, adhere to the following guidelines:
             };
           }
 
+          if (isCentrifugo && !sandbox.supportsPty()) {
+            return {
+              result: {
+                output: "",
+                exitCode: 1,
+                error:
+                  "Interactive terminal sessions are unavailable on this local connection. Use non-interactive terminal commands instead.",
+              },
+            };
+          }
+
           // Set up Caido proxy env vars before spawning the PTY so the session
           // launches with proxy env pointing at a running Caido. Mirrors the
           // non-interactive `executeCommand` flow: only eager on E2B; on

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -226,7 +226,12 @@ In using these tools, adhere to the following guidelines:
             };
           }
 
-          if (isCentrifugo && !sandbox.supportsPty()) {
+          const supportsCentrifugoPty =
+            !isCentrifugo ||
+            typeof sandbox.supportsPty !== "function" ||
+            sandbox.supportsPty();
+
+          if (!supportsCentrifugoPty) {
             return {
               result: {
                 output: "",

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -124,6 +124,10 @@ export class CentrifugoSandbox extends EventEmitter {
     return this.connectionInfo.name;
   }
 
+  supportsPty(): boolean {
+    return this.connectionInfo.capabilities?.pty !== false;
+  }
+
   getUserId(): string {
     return this.userId;
   }
@@ -144,7 +148,7 @@ export class CentrifugoSandbox extends EventEmitter {
    * Get sandbox context for AI based on mode
    */
   getSandboxContext(): string | null {
-    const { osInfo } = this.connectionInfo;
+    const { capabilities, osInfo } = this.connectionInfo;
 
     if (osInfo) {
       const { platform, arch, release, hostname } = osInfo;
@@ -159,7 +163,7 @@ ${shellInfo}
 Commands run directly on the host OS "${hostname}" without Docker isolation. Be careful with:
 - File system operations (no sandbox protection)
 - Network operations (direct access to host network)
-- Process management (can affect host system)`;
+- Process management (can affect host system)${capabilities?.pty === false ? "\n\nInteractive PTY sessions are not available on this connection. Use non-interactive terminal commands only." : ""}`;
     }
 
     return null;

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -173,6 +173,19 @@ export class HybridSandboxManager implements SandboxManager {
       : "remote-connection";
   }
 
+  async supportsInteractivePty(): Promise<boolean> {
+    if (this.sandboxPreference === "e2b") {
+      return true;
+    }
+
+    const connection = await this.getPreferredOrFallbackConnection();
+    if (!connection) {
+      return this.subscription !== "free";
+    }
+
+    return connection.capabilities?.pty !== false;
+  }
+
   /**
    * List available connections for this user
    */
@@ -261,6 +274,18 @@ export class HybridSandboxManager implements SandboxManager {
     return this.getE2BSandbox();
   }
 
+  private async getPreferredOrFallbackConnection(): Promise<ConnectionInfo | null> {
+    const connections = await this.listConnections();
+    const preferredConnection =
+      this.sandboxPreference === "desktop"
+        ? connections.find((conn) => conn.isDesktop)
+        : connections.find(
+            (conn) => conn.connectionId === this.sandboxPreference,
+          );
+
+    return preferredConnection ?? connections[0] ?? null;
+  }
+
   /**
    * Create and wire up a CentrifugoSandbox for the given connection.
    */
@@ -339,15 +364,7 @@ export class HybridSandboxManager implements SandboxManager {
       return null;
     }
 
-    const connections = await this.listConnections();
-    const preferredConnection =
-      this.sandboxPreference === "desktop"
-        ? connections.find((conn) => conn.isDesktop)
-        : connections.find(
-            (conn) => conn.connectionId === this.sandboxPreference,
-          );
-
-    const connection = preferredConnection || connections[0];
+    const connection = await this.getPreferredOrFallbackConnection();
     if (!connection) {
       return null;
     }
@@ -378,6 +395,7 @@ System Environment:
 - Hostname: ${hostname}
 - Mode: DANGEROUS (no Docker isolation)
 - User attachments: ${uploadPath}
+- Interactive terminal: ${connection.capabilities?.pty === false ? "unavailable" : "available"}
 
 Security Warning:
 - File system operations affect the host directly

--- a/lib/ai/tools/utils/sandbox-types.ts
+++ b/lib/ai/tools/utils/sandbox-types.ts
@@ -15,6 +15,10 @@ export interface ConnectionInfo {
   osInfo?: OsInfo;
   lastSeen?: number;
   isDesktop?: boolean;
+  capabilities?: {
+    commands: boolean;
+    pty: boolean;
+  };
 }
 
 /**

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -172,7 +172,13 @@ export async function createAgentStream(
   const getActiveTools = async (): Promise<
     Array<keyof typeof ctx.tools> | undefined
   > => {
-    const supportsPty = await ctx.sandboxManager.supportsInteractivePty?.();
+    let supportsPty: boolean | undefined;
+    try {
+      supportsPty = await ctx.sandboxManager.supportsInteractivePty?.();
+    } catch (error) {
+      console.warn("[agent-stream] PTY capability probe failed:", error);
+      return undefined;
+    }
     if (supportsPty !== false) {
       return undefined;
     }

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -145,6 +145,7 @@ export type AgentStreamContext = {
   budgetMonitor: BudgetMonitor | null;
   sandboxManager: {
     getSandboxType(toolName: string): string | undefined;
+    supportsInteractivePty?(): Promise<boolean>;
   };
   getTodoManager: () => { getAllTodos: () => import("@/types").Todo[] };
   ensureSandbox: import("@/lib/chat/summarization").EnsureSandbox;
@@ -168,6 +169,19 @@ export async function createAgentStream(
   ctx: AgentStreamContext,
   state: AgentStreamState,
 ) {
+  const getActiveTools = async (): Promise<
+    Array<keyof typeof ctx.tools> | undefined
+  > => {
+    const supportsPty = await ctx.sandboxManager.supportsInteractivePty?.();
+    if (supportsPty !== false) {
+      return undefined;
+    }
+
+    return Object.keys(ctx.tools).filter(
+      (toolName) => toolName !== "interact_terminal_session",
+    ) as Array<keyof typeof ctx.tools>;
+  };
+  const initialActiveTools = await getActiveTools();
   const requestedLanguageModel = ctx.trackedProvider.languageModel(modelName);
   const requestedSlug = requestedLanguageModel.modelId;
   const prepareProviderMessages = (
@@ -196,6 +210,7 @@ export async function createAgentStream(
       await convertToModelMessages(state.finalMessages),
     ),
     tools: ctx.tools,
+    activeTools: initialActiveTools,
     abortSignal: ctx.abortController.signal,
     providerOptions: buildProviderOptions(
       ctx.isReasoningModel,
@@ -253,6 +268,7 @@ export async function createAgentStream(
               state.ctxUsage = result.contextUsage;
             }
             return {
+              activeTools: await getActiveTools(),
               messages: prepareProviderMessages(
                 await convertToModelMessages(result.summarizedMessages),
               ),
@@ -294,6 +310,7 @@ export async function createAgentStream(
         }
 
         return {
+          activeTools: await getActiveTools(),
           messages: prepareProviderMessages(
             addCacheBreakpointToLastUserMessage(
               updatedMessages,

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hackerai/local",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "HackerAI Local Sandbox Client - Execute commands on your local machine",
   "bin": {
     "hackerai-local": "./dist/index.js"
@@ -35,8 +35,10 @@
   "dependencies": {
     "centrifuge": "^5.5.3",
     "convex": "^1.39.1",
-    "node-pty": "^1.2.0-beta.12",
     "ws": "^8.20.1"
+  },
+  "optionalDependencies": {
+    "node-pty": "^1.2.0-beta.12"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/packages/local/pnpm-lock.yaml
+++ b/packages/local/pnpm-lock.yaml
@@ -14,12 +14,13 @@ importers:
       convex:
         specifier: ^1.39.1
         version: 1.39.1
-      node-pty:
-        specifier: ^1.2.0-beta.12
-        version: 1.2.0-beta.13
       ws:
         specifier: ^8.20.1
         version: 8.20.1
+    optionalDependencies:
+      node-pty:
+        specifier: ^1.2.0-beta.12
+        version: 1.2.0-beta.13
     devDependencies:
       '@types/node':
         specifier: ^25.8.0
@@ -463,11 +464,13 @@ snapshots:
 
   long@5.3.2: {}
 
-  node-addon-api@7.1.1: {}
+  node-addon-api@7.1.1:
+    optional: true
 
   node-pty@1.2.0-beta.13:
     dependencies:
       node-addon-api: 7.1.1
+    optional: true
 
   prettier@3.6.2: {}
 

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -27,6 +27,7 @@ import {
   ProcessRunner,
   ProcessRunOptions,
   ProcessRunResult,
+  isPtyAvailable,
 } from "./process-runner";
 
 const DEFAULT_SHELL = getDefaultShell(os.platform());
@@ -171,6 +172,11 @@ interface OsInfo {
   arch: string;
   release: string;
   hostname: string;
+}
+
+interface ClientCapabilities {
+  commands: boolean;
+  pty: boolean;
 }
 
 interface CentrifugoCommandMessage {
@@ -424,6 +430,13 @@ class LocalSandboxClient {
     };
   }
 
+  private getCapabilities(): ClientCapabilities {
+    return {
+      commands: true,
+      pty: isPtyAvailable(),
+    };
+  }
+
   private async connect(): Promise<void> {
     console.log(chalk.blue("Connecting to HackerAI..."));
 
@@ -435,6 +448,7 @@ class LocalSandboxClient {
           connectionName: this.config.name,
           clientVersion: "1.0.0",
           osInfo: this.getOsInfo(),
+          capabilities: this.getCapabilities(),
         } as never,
       )) as ConnectResult;
 

--- a/packages/local/src/process-runner.ts
+++ b/packages/local/src/process-runner.ts
@@ -51,8 +51,17 @@ interface PtyModule {
 const FLUSH_INTERVAL_MS = 16;
 const FLUSH_THRESHOLD_BYTES = 32 * 1024; // 32 KB
 const SIGTERM_GRACE_MS = 5_000;
-const NODE_PTY_UNAVAILABLE_MESSAGE =
+export const NODE_PTY_UNAVAILABLE_MESSAGE =
   "Interactive terminal sessions are unavailable because node-pty could not be loaded. Non-interactive commands still work.";
+
+export function isPtyAvailable(): boolean {
+  try {
+    require("node-pty");
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function loadPty(): PtyModule {
   try {

--- a/packages/local/src/process-runner.ts
+++ b/packages/local/src/process-runner.ts
@@ -1,9 +1,5 @@
 import * as os from "os";
 
-import * as pty from "node-pty";
-
-import type { IPty } from "node-pty";
-
 // ---------------------------------------------------------------------------
 // Public interfaces
 // ---------------------------------------------------------------------------
@@ -25,6 +21,29 @@ export interface ProcessRunnerEvents {
   error: (sessionId: string, error: Error) => void;
 }
 
+interface PtyProcess {
+  pid: number;
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(signal?: string): void;
+  onData(listener: (data: string) => void): void;
+  onExit(listener: (event: { exitCode?: number }) => void): void;
+}
+
+interface PtyModule {
+  spawn(
+    file: string,
+    args: string[],
+    options: {
+      name: string;
+      cols: number;
+      rows: number;
+      cwd: string;
+      env: Record<string, string>;
+    },
+  ): PtyProcess;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -32,13 +51,24 @@ export interface ProcessRunnerEvents {
 const FLUSH_INTERVAL_MS = 16;
 const FLUSH_THRESHOLD_BYTES = 32 * 1024; // 32 KB
 const SIGTERM_GRACE_MS = 5_000;
+const NODE_PTY_UNAVAILABLE_MESSAGE =
+  "Interactive terminal sessions are unavailable because node-pty could not be loaded. Non-interactive commands still work.";
+
+function loadPty(): PtyModule {
+  try {
+    return require("node-pty") as PtyModule;
+  } catch (error: unknown) {
+    const cause = error instanceof Error ? ` ${error.message}` : "";
+    throw new Error(`${NODE_PTY_UNAVAILABLE_MESSAGE}${cause}`);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // ProcessRunner
 // ---------------------------------------------------------------------------
 
 export class ProcessRunner {
-  private readonly activeProcesses: Map<string, IPty> = new Map();
+  private readonly activeProcesses: Map<string, PtyProcess> = new Map();
   private readonly outputBuffers: Map<string, string> = new Map();
   private readonly killTimers: Map<string, NodeJS.Timeout> = new Map();
   private readonly listeners: Map<
@@ -87,7 +117,8 @@ export class ProcessRunner {
       Object.assign(env, opts.env);
     }
 
-    const proc: IPty = pty.spawn(shell, ["-l", "-c", command], {
+    const pty = loadPty();
+    const proc = pty.spawn(shell, ["-l", "-c", command], {
       name: "xterm-256color",
       cols,
       rows,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,9 +438,6 @@ importers:
       convex:
         specifier: ^1.39.1
         version: 1.39.1(react@19.2.6)
-      node-pty:
-        specifier: ^1.2.0-beta.12
-        version: 1.2.0-beta.12
       ws:
         specifier: ^8.20.1
         version: 8.20.1
@@ -454,6 +451,10 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+    optionalDependencies:
+      node-pty:
+        specifier: ^1.2.0-beta.12
+        version: 1.2.0-beta.12
 
 packages:
 
@@ -15960,7 +15961,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  node-addon-api@7.1.1: {}
+  node-addon-api@7.1.1:
+    optional: true
 
   node-domexception@1.0.0: {}
 
@@ -15981,6 +15983,7 @@ snapshots:
   node-pty@1.2.0-beta.12:
     dependencies:
       node-addon-api: 7.1.1
+    optional: true
 
   node-releases@2.0.26: {}
 

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -37,6 +37,8 @@ export interface SandboxManager {
   resetHealthFailures(): void;
   /** Check if the sandbox has been marked as permanently unavailable for this session. */
   isSandboxUnavailable(): boolean;
+  /** Whether the effective sandbox can create interactive PTY sessions. */
+  supportsInteractivePty?(): Promise<boolean>;
 }
 
 export interface SandboxBootInfo {


### PR DESCRIPTION
## Summary

- Make `node-pty` optional for `@hackerai/local` so Termux/Android installs can continue when the native PTY module has no android-arm64 prebuild.
- Lazy-load `node-pty` only when an interactive PTY session is created, allowing normal command execution to start without the native module.
- Add local sandbox capability reporting (`commands`, `pty`) so clients can advertise when interactive PTY is unavailable.
- Hide `interact_terminal_session` from active tools for selected local connections with `pty: false`, and keep a runtime guard for `run_terminal_cmd interactive=true`.
- Bump `@hackerai/local` to `0.8.2` and update lockfiles to mark `node-pty` optional.

## Root Cause

`@hackerai/local@0.8.x` imported `node-pty` at startup and required it as a normal dependency. On Termux, `node-pty` has no `android-arm64` prebuild, so npm falls back to `node-gyp rebuild`; users without a full native build toolchain fail before the CLI can start.

## Impact

Termux users can keep using non-interactive local command execution. Interactive PTY sessions are only exposed when the connected client reports PTY support.

## Validation

- `pnpm --filter @hackerai/local build`
- `npx convex codegen`
- Focused ESLint over changed TS files
- Packed `@hackerai/local@0.8.2`, installed it with `npm install --omit=optional --ignore-scripts`, confirmed `node-pty` was omitted, and verified `node ./node_modules/@hackerai/local/dist/index.js --help` works.

## Notes

- The repo-wide `tsc --noEmit` was attempted, but it currently fails on unrelated generated `.next/dev/types` references to missing app route/page files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connections now record and expose per-connection capabilities (commands, PTY/interactive terminal).
  * CLI reports client capabilities on connect; tools and prompts adapt when interactive terminals are unavailable.

* **Bug Fixes**
  * Interactive terminal attempts now return a clear error when not supported by a connection.

* **Chores**
  * Patch version bumped to 0.8.2; dependency ordering adjusted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->