### PR TITLE
[codex] Allow large agent uploads

### DIFF
--- a/app/hooks/__tests__/useFileUpload.local-desktop.test.tsx
+++ b/app/hooks/__tests__/useFileUpload.local-desktop.test.tsx
@@ -72,7 +72,7 @@ describe("useFileUpload desktop-local agent attachments", () => {
     global.fetch = originalFetch;
   });
 
-  it("uses Tauri file paths without calling S3 in desktop Agent mode", async () => {
+  it("uses Tauri file paths for large files without calling S3 in desktop Agent mode", async () => {
     (pickLocalFiles as jest.Mock).mockResolvedValue([
       "/Users/alice/report.txt",
     ]);
@@ -80,7 +80,7 @@ describe("useFileUpload desktop-local agent attachments", () => {
       path: "/Users/alice/report.txt",
       name: "report.txt",
       mediaType: "text/plain",
-      size: 1024,
+      size: 25 * 1024 * 1024,
       lastModified: 123,
     });
 
@@ -101,6 +101,37 @@ describe("useFileUpload desktop-local agent attachments", () => {
         }),
       );
     });
+    expect(generateS3UploadUrlAction).not.toHaveBeenCalled();
+    expect(saveFile).not.toHaveBeenCalled();
+  });
+
+  it("keeps large desktop-selected images local for sandbox-only Agent access", async () => {
+    (pickLocalFiles as jest.Mock).mockResolvedValue(["/Users/alice/large.png"]);
+    (getLocalFileMetadata as jest.Mock).mockResolvedValue({
+      path: "/Users/alice/large.png",
+      name: "large.png",
+      mediaType: "image/png",
+      size: 8 * 1024 * 1024,
+      lastModified: 123,
+    });
+
+    const { result } = renderHook(() => useFileUpload("agent"));
+
+    act(() => {
+      result.current.handleAttachClick();
+    });
+
+    await waitFor(() => {
+      expect(addUploadedFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          uploaded: true,
+          uploading: false,
+          storage: "local-desktop",
+          localPath: "/Users/alice/large.png",
+        }),
+      );
+    });
+    expect(readLocalFile).not.toHaveBeenCalled();
     expect(generateS3UploadUrlAction).not.toHaveBeenCalled();
     expect(saveFile).not.toHaveBeenCalled();
   });
@@ -133,6 +164,8 @@ describe("useFileUpload desktop-local agent attachments", () => {
       expect(generateS3UploadUrlAction).toHaveBeenCalledWith({
         fileName: "logo.svg",
         contentType: "image/svg+xml",
+        size: expect.any(Number),
+        mode: "agent",
       });
     });
     expect(addUploadedFile).toHaveBeenCalledWith(
@@ -160,6 +193,8 @@ describe("useFileUpload desktop-local agent attachments", () => {
       expect(generateS3UploadUrlAction).toHaveBeenCalledWith({
         fileName: "report.txt",
         contentType: "text/plain",
+        size: file.size,
+        mode: "agent",
       });
     });
     expect(addUploadedFile).toHaveBeenCalledWith(

--- a/app/hooks/useFileUpload.ts
+++ b/app/hooks/useFileUpload.ts
@@ -5,6 +5,7 @@ import { ConvexError } from "convex/values";
 import { api } from "@/convex/_generated/api";
 import {
   getMaxFilesLimitForMode,
+  MAX_IMAGE_SIZE,
   validateFile,
   validateImageFile,
   createFileMessagePartFromUploadedFile,
@@ -164,14 +165,18 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
 
       for (const file of filesToProcess) {
         // Basic validation (size, etc.)
-        const basicValidation = validateFile(file);
+        const basicValidation = validateFile(file, { mode });
         if (!basicValidation.valid) {
           invalidFiles.push(`${file.name}: ${basicValidation.error}`);
           continue;
         }
 
-        // Image-specific validation
-        if (isImageFile(file)) {
+        // Provider-visible images should be decodable; larger Agent images are
+        // staged into the sandbox instead of sent inline to the model.
+        if (
+          isImageFile(file) &&
+          (mode !== "agent" || file.size <= MAX_IMAGE_SIZE)
+        ) {
           const imageValidation = await validateImageFile(file);
           if (!imageValidation.valid) {
             invalidFiles.push(`${file.name}: ${imageValidation.error}`);
@@ -189,7 +194,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
         processedCount: filesToProcess.length,
       };
     },
-    [uploadedFiles.length, maxFilesLimit],
+    [uploadedFiles.length, maxFilesLimit, mode],
   );
 
   // Helper function to show feedback messages
@@ -246,6 +251,8 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
           {
             fileName: file.name,
             contentType: file.type || "application/octet-stream",
+            size: file.size,
+            mode,
           },
         );
 
@@ -484,13 +491,18 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
           size: file.size,
           hasLocalPath: Boolean(file.path),
         });
-        const validation = validateFile(file);
+        const validation = validateFile(file, { mode });
         if (!validation.valid) {
           invalidFiles.push(`${file.name}: ${validation.error}`);
           continue;
         }
 
         if (isImageFile(file)) {
+          if (isAgentMode(mode) && file.size > MAX_IMAGE_SIZE) {
+            validFiles.push({ storage: "local-desktop", file });
+            continue;
+          }
+
           const localFileData = await readLocalFile(path);
           if (!localFileData) {
             invalidFiles.push(`${file.name}: could not read image file`);
@@ -526,6 +538,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
       uploadedFiles.length,
       maxFilesLimit,
       startDesktopSelectedFiles,
+      mode,
     ],
   );
 

--- a/convex/__tests__/fileActions.upload-policy.test.ts
+++ b/convex/__tests__/fileActions.upload-policy.test.ts
@@ -1,0 +1,239 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+
+jest.mock("../_generated/server", () => ({
+  action: jest.fn((config: any) => config),
+}));
+
+jest.mock("convex/values", () => ({
+  v: {
+    id: jest.fn(() => "id"),
+    string: jest.fn(() => "string"),
+    number: jest.fn(() => "number"),
+    boolean: jest.fn(() => "boolean"),
+    optional: jest.fn(() => "optional"),
+    object: jest.fn(() => "object"),
+    union: jest.fn(() => "union"),
+    literal: jest.fn(() => "literal"),
+  },
+  ConvexError: class ConvexError extends Error {
+    data: unknown;
+    constructor(data: unknown) {
+      super(
+        typeof data === "string" ? data : (data as { message: string }).message,
+      );
+      this.data = data;
+      this.name = "ConvexError";
+    }
+  },
+}));
+
+jest.mock("../_generated/api", () => ({
+  internal: {
+    fileStorage: {
+      saveFileToDb: "internal.fileStorage.saveFileToDb",
+    },
+    s3Cleanup: {
+      deleteS3ObjectAction: "internal.s3Cleanup.deleteS3ObjectAction",
+    },
+  },
+}));
+
+jest.mock("../s3Utils", () => ({
+  generateS3DownloadUrl: jest.fn(),
+}));
+
+jest.mock("pdfjs-serverless", () => ({
+  getDocument: jest.fn(),
+}));
+
+jest.mock("isbinaryfile", () => ({
+  isBinaryFile: jest.fn(),
+}));
+
+jest.mock("../lib/utils", () => ({
+  validateServiceKey: jest.fn(),
+}));
+
+describe("fileActions saveFile upload policy", () => {
+  const originalFetch = global.fetch;
+  const makeCtx = () =>
+    ({
+      auth: {
+        getUserIdentity: jest.fn().mockResolvedValue({
+          subject: "user123",
+          entitlements: ["pro-plan"],
+        }),
+      },
+      scheduler: {
+        runAfter: jest.fn().mockResolvedValue(undefined),
+      },
+      storage: {
+        delete: jest.fn().mockResolvedValue(undefined),
+        getUrl: jest.fn().mockResolvedValue("https://storage.example/file"),
+      },
+      runMutation: jest.fn().mockResolvedValue("file_123"),
+    }) as any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    global.fetch = jest.fn() as any;
+
+    const { generateS3DownloadUrl } = await import("../s3Utils");
+    (generateS3DownloadUrl as jest.Mock).mockResolvedValue(
+      "https://s3.example/download",
+    );
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("rejects Ask files above the backend file cap and cleans up S3", async () => {
+    const { saveFile } = await import("../fileActions");
+    const ctx = makeCtx();
+
+    await expect(
+      saveFile.handler(ctx, {
+        s3Key: "users/user123/large.bin",
+        name: "large.bin",
+        mediaType: "application/octet-stream",
+        size: 21 * 1024 * 1024,
+        mode: "ask",
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({ code: "FILE_SIZE_EXCEEDED" }),
+    });
+
+    expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      "internal.s3Cleanup.deleteS3ObjectAction",
+      { s3Key: "users/user123/large.bin" },
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("rejects Ask images above the provider image cap", async () => {
+    const { saveFile } = await import("../fileActions");
+    const ctx = makeCtx();
+
+    await expect(
+      saveFile.handler(ctx, {
+        s3Key: "users/user123/large.png",
+        name: "large.png",
+        mediaType: "image/png",
+        size: 6 * 1024 * 1024,
+        mode: "ask",
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({ code: "IMAGE_SIZE_EXCEEDED" }),
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("accepts oversized Agent files as sandbox-only metadata without parsing", async () => {
+    const { saveFile } = await import("../fileActions");
+    const ctx = makeCtx();
+
+    const result = await saveFile.handler(ctx, {
+      s3Key: "users/user123/archive.zip",
+      name: "archive.zip",
+      mediaType: "application/zip",
+      size: 25 * 1024 * 1024,
+      mode: "agent",
+    });
+
+    expect(result).toEqual({
+      url: "https://s3.example/download",
+      fileId: "file_123",
+      tokens: 0,
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      "internal.fileStorage.saveFileToDb",
+      expect.objectContaining({
+        s3Key: "users/user123/archive.zip",
+        size: 25 * 1024 * 1024,
+        fileTokenSize: 0,
+        content: undefined,
+      }),
+    );
+  });
+
+  it("saves small Agent files as metadata-only attachments too", async () => {
+    const { saveFile } = await import("../fileActions");
+    const ctx = makeCtx();
+
+    await saveFile.handler(ctx, {
+      s3Key: "users/user123/notes.txt",
+      name: "notes.txt",
+      mediaType: "text/plain",
+      size: 1024,
+      mode: "agent",
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      "internal.fileStorage.saveFileToDb",
+      expect.objectContaining({
+        name: "notes.txt",
+        fileTokenSize: 0,
+        content: undefined,
+      }),
+    );
+  });
+
+  it("accepts oversized Agent images as sandbox-only metadata without parsing", async () => {
+    const { saveFile } = await import("../fileActions");
+    const ctx = makeCtx();
+
+    await saveFile.handler(ctx, {
+      s3Key: "users/user123/large.png",
+      name: "large.png",
+      mediaType: "image/png",
+      size: 8 * 1024 * 1024,
+      mode: "agent",
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      "internal.fileStorage.saveFileToDb",
+      expect.objectContaining({
+        name: "large.png",
+        fileTokenSize: 0,
+        content: undefined,
+      }),
+    );
+  });
+
+  it("rejects Agent files above the sandbox staging cap", async () => {
+    const { saveFile } = await import("../fileActions");
+    const ctx = makeCtx();
+
+    await expect(
+      saveFile.handler(ctx, {
+        s3Key: "users/user123/huge.bin",
+        name: "huge.bin",
+        mediaType: "application/octet-stream",
+        size: 251 * 1024 * 1024,
+        mode: "agent",
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({ code: "FILE_SIZE_EXCEEDED" }),
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+});

--- a/convex/__tests__/s3Actions.test.ts
+++ b/convex/__tests__/s3Actions.test.ts
@@ -15,7 +15,6 @@ jest.mock("../lib/utils", () => ({
 }));
 
 // Mock fileActions module for rate limiting
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockCheckFileUploadRateLimit = jest.fn<any>();
 jest.mock("../fileActions", () => ({
   checkFileUploadRateLimit: mockCheckFileUploadRateLimit,
@@ -70,17 +69,14 @@ describe("s3Actions", () => {
       const { generateS3UploadUrlAction } = await import("../s3Actions");
 
       // Create mock context - rate limiting is handled by mocked checkFileUploadRateLimit
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mockCtx: any = {
         auth: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           getUserIdentity: jest.fn<any>().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
           }),
         },
         // Mock runQuery to return storage usage (user has space available)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         runQuery: jest.fn<any>().mockResolvedValue({
           usedBytes: 1024 * 1024 * 1024, // 1 GB used
           maxBytes: 10 * 1024 * 1024 * 1024, // 10 GB max
@@ -208,16 +204,13 @@ describe("s3Actions", () => {
       const { generateS3UploadUrlAction } = await import("../s3Actions");
 
       // Create mock context with runQuery for storage check
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mockCtx: any = {
         auth: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           getUserIdentity: jest.fn<any>().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
           }),
         },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         runQuery: jest.fn<any>().mockResolvedValue({
           usedBytes: 1024 * 1024 * 1024,
           maxBytes: 10 * 1024 * 1024 * 1024,
@@ -231,6 +224,38 @@ describe("s3Actions", () => {
           contentType: "application/pdf",
         }),
       ).rejects.toThrow("Failed to generate upload URL");
+    });
+
+    it("should reject oversized files before generating an upload URL", async () => {
+      const { generateS3UploadUrl } = await import("../s3Utils");
+      const mockGenerateS3UploadUrl =
+        generateS3UploadUrl as jest.MockedFunction<typeof generateS3UploadUrl>;
+      const { generateS3UploadUrlAction } = await import("../s3Actions");
+
+      const mockCtx: any = {
+        auth: {
+          getUserIdentity: jest.fn<any>().mockResolvedValue({
+            subject: "user123",
+            email: "test@example.com",
+          }),
+        },
+        runQuery: jest.fn<any>(),
+      };
+
+      await expect(
+        generateS3UploadUrlAction.handler(mockCtx, {
+          fileName: "large.pdf",
+          contentType: "application/pdf",
+          size: 11 * 1024 * 1024,
+          mode: "ask",
+        }),
+      ).rejects.toMatchObject({
+        data: expect.objectContaining({ code: "FILE_SIZE_EXCEEDED" }),
+      });
+
+      expect(mockCtx.runQuery).not.toHaveBeenCalled();
+      expect(mockCheckFileUploadRateLimit).not.toHaveBeenCalled();
+      expect(mockGenerateS3UploadUrl).not.toHaveBeenCalled();
     });
 
     it("should accept various file types", async () => {
@@ -255,16 +280,13 @@ describe("s3Actions", () => {
         });
 
         // Create mock context with runQuery for storage check
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const mockCtx: any = {
           auth: {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             getUserIdentity: jest.fn<any>().mockResolvedValue({
               subject: "user123",
               email: "test@example.com",
             }),
           },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           runQuery: jest.fn<any>().mockResolvedValue({
             usedBytes: 1024 * 1024 * 1024,
             maxBytes: 10 * 1024 * 1024 * 1024,
@@ -297,16 +319,13 @@ describe("s3Actions", () => {
 
       const { generateS3UploadUrlAction } = await import("../s3Actions");
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mockCtx: any = {
         auth: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           getUserIdentity: jest.fn<any>().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
           }),
         },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         runQuery: jest.fn<any>().mockResolvedValue({
           usedBytes: 1024 * 1024 * 1024,
           maxBytes: 10 * 1024 * 1024 * 1024,
@@ -337,16 +356,13 @@ describe("s3Actions", () => {
 
       const { generateS3UploadUrlAction } = await import("../s3Actions");
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mockCtx: any = {
         auth: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           getUserIdentity: jest.fn<any>().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
           }),
         },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         runQuery: jest.fn<any>().mockResolvedValue({
           usedBytes: 1024 * 1024 * 1024,
           maxBytes: 10 * 1024 * 1024 * 1024,

--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -31,14 +31,12 @@ import type {
 import { Id } from "./_generated/dataModel";
 import { validateServiceKey } from "./lib/utils";
 import {
+  getUploadLimitsForMode,
   isSupportedImageMediaType,
-  MAX_IMAGE_SIZE,
-} from "../lib/utils/file-utils";
+  validateUploadPolicy,
+} from "../lib/utils/upload-policy";
 import { FILE_TOKEN_PERCENT, MAX_TOKENS_PAID } from "../lib/token-utils";
 import { MAX_GENERATED_FILE_SIZE_BYTES } from "../lib/constants/s3";
-
-// Maximum file size: 20 MB (enforced regardless of skipTokenValidation)
-const MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024;
 
 // File upload rate limit: 80 files per 5 hours for paid tiers
 const FILE_UPLOAD_LIMIT = 80;
@@ -658,10 +656,10 @@ export const saveFile = action({
     // Determine if we should skip token validation based on mode
     // Agent mode: files are accessed in sandbox, no token counting needed
     // Ask mode: files are included in context, token counting required
+    const isAgentUploadMode =
+      args.mode === "agent" || args.mode === "agent-long";
     const shouldSkipTokenValidation =
-      args.skipTokenValidation ||
-      args.mode === "agent" ||
-      args.mode === "agent-long";
+      args.skipTokenValidation || isAgentUploadMode;
 
     // Check if paid tier (free tier cannot upload)
     const hasPaidEntitlement =
@@ -687,8 +685,22 @@ export const saveFile = action({
     // Token was already consumed at URL generation step
     await checkFileUploadRateLimit(actingUserId, false);
 
-    // Enforce file size limit (20 MB) regardless of skipTokenValidation
-    if (args.size > MAX_FILE_SIZE_BYTES) {
+    const uploadLimits = getUploadLimitsForMode(args.mode, {
+      surface: "backend",
+    });
+    const uploadValidation = validateUploadPolicy({
+      mode: args.mode,
+      size: args.size,
+      mediaType: args.mediaType,
+      surface: "backend",
+    });
+
+    // Ask-mode uploads are processed for model context; Agent uploads may be
+    // larger because oversized attachments are staged into the sandbox only.
+    if (
+      !uploadValidation.valid &&
+      uploadValidation.code === "FILE_SIZE_EXCEEDED"
+    ) {
       // Clean up storage before throwing error
       try {
         if (args.s3Key) {
@@ -715,13 +727,13 @@ export const saveFile = action({
       }
       throw new ConvexError({
         code: "FILE_SIZE_EXCEEDED",
-        message: `File "${args.name}" exceeds the maximum file size limit of 20 MB. Current size: ${(args.size / (1024 * 1024)).toFixed(2)} MB`,
+        message: `File "${args.name}" exceeds the maximum file size limit of ${uploadLimits.maxFileSizeBytes / (1024 * 1024)} MB. Current size: ${(args.size / (1024 * 1024)).toFixed(2)} MB`,
       });
     }
 
     if (
-      isSupportedImageMediaType(args.mediaType) &&
-      args.size > MAX_IMAGE_SIZE
+      !uploadValidation.valid &&
+      uploadValidation.code === "IMAGE_SIZE_EXCEEDED"
     ) {
       try {
         if (args.s3Key) {
@@ -748,7 +760,7 @@ export const saveFile = action({
       }
       throw new ConvexError({
         code: "IMAGE_SIZE_EXCEEDED",
-        message: `Image "${args.name}" exceeds the maximum image size limit of ${MAX_IMAGE_SIZE / (1024 * 1024)} MB. Current size: ${(args.size / (1024 * 1024)).toFixed(2)} MB`,
+        message: `Image "${args.name}" exceeds the maximum image size limit of ${uploadLimits.maxProviderImageSizeBytes / (1024 * 1024)} MB. Current size: ${(args.size / (1024 * 1024)).toFixed(2)} MB`,
       });
     }
 
@@ -769,49 +781,59 @@ export const saveFile = action({
       });
     }
 
-    const response = await fetch(fileUrl);
-
-    if (!response.ok) {
-      throw new ConvexError({
-        code: "FILE_FETCH_FAILED",
-        message: `Failed to upload ${args.name}: ${response.statusText}`,
-      });
-    }
-
-    const file = await response.blob();
-
     // Calculate token size using the comprehensive file processing logic
     let tokenSize = 0;
     let fileContent: string | undefined = undefined;
 
     try {
-      // Compute file token limit based on subscription (all paid tiers use MAX_TOKENS_PAID)
-      const maxFileTokens = Math.floor(MAX_TOKENS_PAID * FILE_TOKEN_PERCENT);
+      if (isAgentUploadMode) {
+        convexLogger.info("agent_file_upload_saved_without_processing", {
+          userId: actingUserId,
+          fileName: args.name,
+          size: args.size,
+          mediaType: args.mediaType,
+          mode: args.mode,
+        });
+      } else {
+        const response = await fetch(fileUrl);
 
-      // Use the comprehensive file processing for all file types (including auto-detection and default handling)
-      const chunks = await processFileAuto(
-        file,
-        args.name,
-        args.mediaType,
-        undefined,
-        shouldSkipTokenValidation,
-        maxFileTokens,
-      );
-      tokenSize = chunks.reduce((total, chunk) => total + chunk.tokens, 0);
+        if (!response.ok) {
+          throw new ConvexError({
+            code: "FILE_FETCH_FAILED",
+            message: `Failed to upload ${args.name}: ${response.statusText}`,
+          });
+        }
 
-      // Save content for non-image, non-PDF, non-binary files
-      // Note: Unsupported image formats will have content extracted, so we check for supported images
-      const shouldSaveContent =
-        !isSupportedImageMediaType(args.mediaType) &&
-        args.mediaType !== "application/pdf" &&
-        chunks.length > 0 &&
-        chunks[0].content.length > 0;
+        const file = await response.blob();
 
-      if (shouldSaveContent) {
-        const rawContent = chunks.map((chunk) => chunk.content).join("\n\n");
-        // Always truncate content to maxFileTokens before saving to database
-        // This ensures database content field stays reasonable even for agent mode files
-        fileContent = truncateContentByTokens(rawContent, maxFileTokens);
+        // Compute file token limit based on subscription (all paid tiers use MAX_TOKENS_PAID)
+        const maxFileTokens = Math.floor(MAX_TOKENS_PAID * FILE_TOKEN_PERCENT);
+
+        // Use the comprehensive file processing for all file types (including auto-detection and default handling)
+        const chunks = await processFileAuto(
+          file,
+          args.name,
+          args.mediaType,
+          undefined,
+          shouldSkipTokenValidation,
+          maxFileTokens,
+        );
+        tokenSize = chunks.reduce((total, chunk) => total + chunk.tokens, 0);
+
+        // Save content for non-image, non-PDF, non-binary files
+        // Note: Unsupported image formats will have content extracted, so we check for supported images
+        const shouldSaveContent =
+          !isSupportedImageMediaType(args.mediaType) &&
+          args.mediaType !== "application/pdf" &&
+          chunks.length > 0 &&
+          chunks[0].content.length > 0;
+
+        if (shouldSaveContent) {
+          const rawContent = chunks.map((chunk) => chunk.content).join("\n\n");
+          // Always truncate content to maxFileTokens before saving to database
+          // This ensures database content field stays reasonable even for agent mode files
+          fileContent = truncateContentByTokens(rawContent, maxFileTokens);
+        }
       }
     } catch (error) {
       // Check if this is a ConvexError (including token limit errors) - re-throw as-is

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -8,6 +8,7 @@ import { validateServiceKey } from "./lib/utils";
 import { convexLogger } from "./lib/logger";
 import { checkFileUploadRateLimit } from "./fileActions";
 import { Doc } from "./_generated/dataModel";
+import { validateUploadPolicy } from "../lib/utils/upload-policy";
 
 type StorageUsage = {
   usedBytes: number;
@@ -31,6 +32,8 @@ export const generateS3UploadUrlAction = action({
   args: {
     fileName: v.string(),
     contentType: v.string(),
+    size: v.optional(v.number()),
+    mode: v.optional(v.union(v.literal("ask"), v.literal("agent"))),
   },
   returns: v.object({
     uploadUrl: v.string(),
@@ -61,6 +64,22 @@ export const generateS3UploadUrlAction = action({
       throw new Error("Invalid contentType: contentType cannot be empty");
     }
 
+    if (args.size !== undefined) {
+      const validation = validateUploadPolicy({
+        mode: args.mode ?? "ask",
+        size: args.size,
+        mediaType: args.contentType,
+        surface: "client",
+      });
+
+      if (!validation.valid) {
+        throw new ConvexError({
+          code: validation.code,
+          message: validation.message,
+        });
+      }
+    }
+
     // Get user ID from identity
     const userId = identity.subject;
 
@@ -74,6 +93,14 @@ export const generateS3UploadUrlAction = action({
       throw new ConvexError({
         code: "STORAGE_LIMIT_EXCEEDED",
         message: `Storage limit exceeded. You are using ${usedGB} GB of 10 GB. Please delete some files to upload new ones.`,
+      });
+    }
+    if (args.size !== undefined && storageUsage.availableBytes < args.size) {
+      const usedGB = (storageUsage.usedBytes / (1024 * 1024 * 1024)).toFixed(2);
+      const requestedMB = (args.size / (1024 * 1024)).toFixed(2);
+      throw new ConvexError({
+        code: "STORAGE_LIMIT_EXCEEDED",
+        message: `Storage limit exceeded. You are using ${usedGB} GB of 10 GB and this file requires ${requestedMB} MB. Please delete some files to upload new ones.`,
       });
     }
 

--- a/lib/constants/s3.ts
+++ b/lib/constants/s3.ts
@@ -19,6 +19,9 @@ export const getS3UrlExpirationBufferSeconds = (): number => {
 // Maximum file size (20 MB)
 export const MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024;
 
+// Maximum user attachment size for Agent mode sandbox staging (250 MB)
+export const MAX_AGENT_FILE_SIZE_BYTES = 250 * 1024 * 1024;
+
 // Maximum assistant-generated downloadable artifact size (250 MB)
 export const MAX_GENERATED_FILE_SIZE_BYTES = 250 * 1024 * 1024;
 

--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -147,4 +147,39 @@ describe("processMessageFiles image size guards", () => {
       url: "https://example.com/small.png",
     });
   });
+
+  it("stages oversized Agent images into the sandbox instead of sending them inline", async () => {
+    global.fetch = jest.fn(async () => {
+      throw new Error("Agent image with declared size should not be probed");
+    }) as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        fileId: "file_large",
+        mediaType: "image/png",
+        name: "large.png",
+        size: 8 * 1024 * 1024,
+        url: "https://example.com/large.png",
+      }),
+      "agent",
+      "/home/user/upload",
+      "pro",
+    );
+
+    expect(result.sandboxFiles).toEqual([
+      {
+        kind: "url",
+        url: "https://example.com/large.png",
+        localPath: "/home/user/upload/large.png",
+      },
+    ]);
+    expect(result.messages[0].parts).toEqual([
+      { type: "text", text: "what is this?" },
+      {
+        type: "text",
+        text: '<attachment filename="large.png" local_path="/home/user/upload/large.png" />',
+      },
+    ]);
+  });
 });

--- a/lib/utils/__tests__/upload-policy.test.ts
+++ b/lib/utils/__tests__/upload-policy.test.ts
@@ -1,0 +1,50 @@
+import { validateUploadPolicy } from "../upload-policy";
+
+describe("upload policy messages", () => {
+  it("recommends Agent mode when Ask file uploads exceed the client byte limit", () => {
+    const result = validateUploadPolicy({
+      mode: "ask",
+      size: 11 * 1024 * 1024,
+      mediaType: "application/pdf",
+      surface: "client",
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      code: "FILE_SIZE_EXCEEDED",
+      message:
+        "File size must be less than 10MB. Switch to Agent mode to upload larger files for sandbox analysis.",
+    });
+  });
+
+  it("recommends Agent mode when Ask image uploads exceed the provider image limit", () => {
+    const result = validateUploadPolicy({
+      mode: "ask",
+      size: 6 * 1024 * 1024,
+      mediaType: "image/png",
+      surface: "client",
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      code: "IMAGE_SIZE_EXCEEDED",
+      message:
+        "Image size must be less than 5MB. Switch to Agent mode to upload larger files for sandbox analysis.",
+    });
+  });
+
+  it("does not recommend switching modes when Agent uploads exceed the sandbox cap", () => {
+    const result = validateUploadPolicy({
+      mode: "agent",
+      size: 251 * 1024 * 1024,
+      mediaType: "application/zip",
+      surface: "client",
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      code: "FILE_SIZE_EXCEEDED",
+      message: "File size must be less than 250MB.",
+    });
+  });
+});

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -5,7 +5,11 @@ import { getConvexClient } from "@/lib/db/convex-client";
 import { UIMessage } from "ai";
 import type { ChatMode, FileContent } from "@/types";
 import { Id } from "@/convex/_generated/dataModel";
-import { isSupportedImageMediaType, MAX_IMAGE_SIZE } from "./file-utils";
+import {
+  isSandboxOnlyAgentUpload,
+  isSupportedImageMediaType,
+  MAX_PROVIDER_IMAGE_SIZE_BYTES as MAX_IMAGE_SIZE,
+} from "./upload-policy";
 import type { SandboxFile } from "./sandbox-file-utils";
 import { collectSandboxFiles } from "./sandbox-file-utils";
 import { extractAllFileIdsFromMessages, isFilePart } from "./file-token-utils";
@@ -326,7 +330,7 @@ const applyUrlsToFileParts = async (
       effectiveImageSize != null &&
       effectiveImageSize > imageLimit;
 
-    if (shouldOmitImage) {
+    if (shouldOmitImage && mode !== "agent") {
       logger.warn("image_attachment_omitted_before_provider_call", {
         event: "image_attachment_omitted_before_provider_call",
         service: "chat-handler",
@@ -347,7 +351,7 @@ const applyUrlsToFileParts = async (
     file.positions.forEach(({ messageIndex, partIndex }) => {
       const filePart = messages[messageIndex].parts![partIndex] as any;
       if (filePart.type !== "file") return;
-      if (shouldOmitImage) {
+      if (shouldOmitImage && mode !== "agent") {
         messages[messageIndex].parts![partIndex] = {
           type: "text",
           text: imageOmittedText(
@@ -390,7 +394,7 @@ const applyModeSpecificTransforms = async (
     collectSandboxFiles(messages, sandboxFiles, uploadBasePath, {
       allowLocalDesktopFiles,
     });
-    removeNonMediaFileParts(messages);
+    removeNonMediaAndOversizedImageFileParts(messages);
   } else {
     const nonMediaFileIds = filterNonMediaFileIds(messages, fileIds);
     if (nonMediaFileIds.length > 0) {
@@ -451,7 +455,9 @@ export const processMessageFiles = async (
   const updatedMessages = JSON.parse(JSON.stringify(messages)) as UIMessage[];
   const sandboxFiles: SandboxFile[] = [];
 
-  replaceOversizedImageParts(updatedMessages);
+  if (mode !== "agent") {
+    replaceOversizedImageParts(updatedMessages);
+  }
 
   const { hasMedia, files } = collectFilesToProcess(updatedMessages, mode);
 
@@ -607,11 +613,20 @@ const pruneFileParts = (
   });
 };
 
-const removeNonMediaFileParts = (messages: UIMessage[]) =>
-  pruneFileParts(
-    messages,
-    (mediaType) => !!mediaType && isSupportedImageMediaType(mediaType),
-  );
+const removeNonMediaAndOversizedImageFileParts = (messages: UIMessage[]) => {
+  messages.forEach((msg) => {
+    if (!msg.parts) return;
+    msg.parts = msg.parts.filter((part: any) => {
+      if (part?.type !== "file") return true;
+      if (!isSupportedImageMediaType(part.mediaType ?? "")) return false;
+      return !isSandboxOnlyAgentUpload({
+        mode: "agent",
+        size: typeof part.size === "number" ? part.size : 0,
+        mediaType: part.mediaType ?? "",
+      });
+    });
+  });
+};
 
 const removeAudioFileParts = (messages: UIMessage[]) =>
   pruneFileParts(messages, (mediaType) => !mediaType?.startsWith("audio/"));

--- a/lib/utils/file-utils.ts
+++ b/lib/utils/file-utils.ts
@@ -4,6 +4,20 @@ import {
   UploadedFileState,
 } from "@/types/file";
 import type { ChatMode } from "@/types/chat";
+import {
+  AGENT_MODE_MAX_FILES_LIMIT,
+  getMaxFilesLimitForUploadMode,
+  isSupportedImageMediaType,
+  MAX_ASK_FILE_SIZE_BYTES,
+  MAX_PROVIDER_IMAGE_SIZE_BYTES,
+  validateUploadPolicy,
+} from "./upload-policy";
+
+export {
+  AGENT_MODE_MAX_FILES_LIMIT,
+  ASK_MODE_MAX_FILES_LIMIT,
+  isSupportedImageMediaType,
+} from "./upload-policy";
 
 /** Rate limit info returned from upload URL generation */
 export type RateLimitInfo = {
@@ -19,44 +33,20 @@ export type UploadUrlResult = {
 };
 
 /** Maximum file size allowed (10MB) */
-export const MAX_FILE_SIZE = 10 * 1024 * 1024;
+export const MAX_FILE_SIZE = MAX_ASK_FILE_SIZE_BYTES;
 
 /**
  * Maximum image size allowed (5MB).
  * Anthropic's Vertex/API endpoints reject base64 images over 5 MiB of raw bytes,
  * and OpenRouter re-encodes our S3 URLs as base64 before forwarding.
  */
-export const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
-
-/** Maximum number of files allowed in Ask mode. */
-export const ASK_MODE_MAX_FILES_LIMIT = 10;
-
-/** Maximum number of files allowed in Agent mode. */
-export const AGENT_MODE_MAX_FILES_LIMIT = 20;
+export const MAX_IMAGE_SIZE = MAX_PROVIDER_IMAGE_SIZE_BYTES;
 
 /** Maximum number of files allowed to be uploaded at once */
 export const MAX_FILES_LIMIT = AGENT_MODE_MAX_FILES_LIMIT;
 
 export function getMaxFilesLimitForMode(mode: ChatMode): number {
-  return mode === "agent"
-    ? AGENT_MODE_MAX_FILES_LIMIT
-    : ASK_MODE_MAX_FILES_LIMIT;
-}
-
-/** Supported image formats for AI processing */
-const SUPPORTED_IMAGE_TYPES = new Set([
-  "image/png",
-  "image/jpeg",
-  "image/jpg",
-  "image/webp",
-  "image/gif",
-]);
-
-/**
- * Check if media type is a supported image format for AI
- */
-export function isSupportedImageMediaType(mediaType: string): boolean {
-  return SUPPORTED_IMAGE_TYPES.has(mediaType.toLowerCase());
+  return getMaxFilesLimitForUploadMode(mode);
 }
 
 /**
@@ -69,23 +59,21 @@ export function isImageFile(file: File | LocalDesktopFile): boolean {
 /**
  * Validate file for upload
  */
-export function validateFile(file: File | LocalDesktopFile): {
+export function validateFile(
+  file: File | LocalDesktopFile,
+  options: { mode?: ChatMode } = {},
+): {
   valid: boolean;
   error?: string;
 } {
-  if (file.size > MAX_FILE_SIZE) {
-    return {
-      valid: false,
-      error: `File size must be less than ${MAX_FILE_SIZE / (1024 * 1024)}MB`,
-    };
-  }
-  if (isImageFile(file) && file.size > MAX_IMAGE_SIZE) {
-    return {
-      valid: false,
-      error: `Image size must be less than ${MAX_IMAGE_SIZE / (1024 * 1024)}MB`,
-    };
-  }
-  return { valid: true };
+  const validation = validateUploadPolicy({
+    mode: options.mode ?? "ask",
+    size: file.size,
+    mediaType: file.type || "application/octet-stream",
+  });
+  return validation.valid
+    ? { valid: true }
+    : { valid: false, error: validation.message };
 }
 
 /**

--- a/lib/utils/upload-policy.ts
+++ b/lib/utils/upload-policy.ts
@@ -1,0 +1,105 @@
+import type { ChatMode } from "@/types/chat";
+import {
+  MAX_AGENT_FILE_SIZE_BYTES,
+  MAX_FILE_SIZE_BYTES,
+} from "@/lib/constants/s3";
+
+export type UploadPolicyMode = ChatMode | "agent-long";
+
+export const MAX_ASK_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+export const MAX_PROVIDER_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
+
+export const ASK_MODE_MAX_FILES_LIMIT = 10;
+export const AGENT_MODE_MAX_FILES_LIMIT = 20;
+const AGENT_UPLOAD_TIP =
+  "Switch to Agent mode to upload larger files for sandbox analysis.";
+
+const SUPPORTED_IMAGE_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/webp",
+  "image/gif",
+]);
+
+export function isSupportedImageMediaType(mediaType: string): boolean {
+  return SUPPORTED_IMAGE_TYPES.has(mediaType.toLowerCase());
+}
+
+export function isAgentUploadMode(mode?: UploadPolicyMode): boolean {
+  return mode === "agent" || mode === "agent-long";
+}
+
+export function getMaxFilesLimitForUploadMode(mode: ChatMode): number {
+  return isAgentUploadMode(mode)
+    ? AGENT_MODE_MAX_FILES_LIMIT
+    : ASK_MODE_MAX_FILES_LIMIT;
+}
+
+export function getUploadLimitsForMode(
+  mode?: UploadPolicyMode,
+  options: { surface?: "client" | "backend" } = {},
+): {
+  maxFileSizeBytes: number;
+  maxProviderImageSizeBytes: number;
+} {
+  const askMaxFileSizeBytes =
+    options.surface === "backend"
+      ? MAX_FILE_SIZE_BYTES
+      : MAX_ASK_FILE_SIZE_BYTES;
+
+  return {
+    maxFileSizeBytes: isAgentUploadMode(mode)
+      ? MAX_AGENT_FILE_SIZE_BYTES
+      : askMaxFileSizeBytes,
+    maxProviderImageSizeBytes: MAX_PROVIDER_IMAGE_SIZE_BYTES,
+  };
+}
+
+export function isSandboxOnlyAgentUpload(args: {
+  mode?: UploadPolicyMode;
+  size: number;
+  mediaType: string;
+}): boolean {
+  if (!isAgentUploadMode(args.mode)) return false;
+  if (args.size > MAX_FILE_SIZE_BYTES) return true;
+  return (
+    isSupportedImageMediaType(args.mediaType) &&
+    args.size > MAX_PROVIDER_IMAGE_SIZE_BYTES
+  );
+}
+
+export function validateUploadPolicy(args: {
+  mode?: UploadPolicyMode;
+  size: number;
+  mediaType: string;
+  surface?: "client" | "backend";
+}): { valid: true } | { valid: false; code: string; message: string } {
+  const { maxFileSizeBytes, maxProviderImageSizeBytes } =
+    getUploadLimitsForMode(args.mode, { surface: args.surface });
+
+  if (args.size > maxFileSizeBytes) {
+    const agentTip = !isAgentUploadMode(args.mode)
+      ? ` ${AGENT_UPLOAD_TIP}`
+      : "";
+    return {
+      valid: false,
+      code: "FILE_SIZE_EXCEEDED",
+      message: `File size must be less than ${maxFileSizeBytes / (1024 * 1024)}MB.${agentTip}`,
+    };
+  }
+
+  if (
+    !isAgentUploadMode(args.mode) &&
+    isSupportedImageMediaType(args.mediaType) &&
+    args.size > maxProviderImageSizeBytes
+  ) {
+    return {
+      valid: false,
+      code: "IMAGE_SIZE_EXCEEDED",
+      message: `Image size must be less than ${maxProviderImageSizeBytes / (1024 * 1024)}MB. ${AGENT_UPLOAD_TIP}`,
+    };
+  }
+
+  return { valid: true };
+}


### PR DESCRIPTION
## Summary

- Adds a shared upload policy module for Ask/Agent file limits and provider-image limits.
- Allows Agent attachments up to 250 MB for sandbox staging while keeping Ask-mode file/image limits strict.
- Saves Agent uploads as metadata-only attachments, avoiding upload-time parsing/token extraction.
- Rejects oversized files during presigned URL generation when size and mode are available.
- Stages oversized Agent images into the sandbox instead of sending them as provider-visible image parts.
- Shows Ask-mode byte-size validation errors with a recommendation to switch to Agent mode for larger sandbox uploads.

## Why

Agent mode uses sandbox file access, so large attachments should not be constrained by Ask-mode context/provider limits. The previous shared validation path blocked large Agent files before they could be staged into the sandbox, and Ask-mode size errors did not tell users about the Agent-mode path.

## Validation

- `pnpm test -- lib/utils/__tests__/upload-policy.test.ts app/hooks/__tests__/useFileUpload.local-desktop.test.tsx lib/utils/__tests__/file-transform-utils.test.ts convex/__tests__/fileActions.upload-policy.test.ts convex/__tests__/s3Actions.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint lib/utils/upload-policy.ts lib/utils/__tests__/upload-policy.test.ts app/hooks/useFileUpload.ts convex/s3Actions.ts convex/fileActions.ts`
- Commit hook also ran full `pnpm typecheck` and full `pnpm test`: 90 suites / 1133 tests passed.
