### PR TITLE
[codex] Add source attribution tracking

### DIFF
--- a/app/api/analytics/attribution/route.ts
+++ b/app/api/analytics/attribution/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse, after } from "next/server";
+import { getUserID } from "@/lib/auth/get-user-id";
+import { phLogger } from "@/lib/posthog/server";
+import {
+  ATTRIBUTION_COOKIE_NAME,
+  attributionProperties,
+  decodeAttributionCookie,
+  sanitizeAttribution,
+} from "@/lib/analytics/attribution";
+
+export async function POST(req: NextRequest) {
+  const userId = await getUserID(req);
+  const body = await req.json().catch(() => ({}));
+  const attribution =
+    sanitizeAttribution(body?.attribution) ??
+    decodeAttributionCookie(req.cookies.get(ATTRIBUTION_COOKIE_NAME)?.value);
+
+  if (!attribution) {
+    return NextResponse.json({ ok: true, captured: false });
+  }
+
+  const props = attributionProperties(attribution);
+  const capturedAt = new Date().toISOString();
+
+  phLogger.event("user_attribution_captured", {
+    userId,
+    ...props,
+    $set_once: {
+      ...props,
+      first_attribution_captured_at: capturedAt,
+    },
+    $set: {
+      last_attribution_captured_at: capturedAt,
+    },
+  });
+  after(() => phLogger.flush());
+
+  return NextResponse.json({ ok: true, captured: true });
+}

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -5,6 +5,11 @@ import { buildWorkOSOrganizationName } from "@/lib/auth/workos-organization-name
 import { NextRequest, NextResponse, after } from "next/server";
 import { getSuspensionMessage } from "@/lib/suspensionMessage";
 import { phLogger } from "@/lib/posthog/server";
+import {
+  attributionProperties,
+  sanitizeAttribution,
+  stripeAttributionMetadata,
+} from "@/lib/analytics/attribution";
 
 function planLookupKeyToTier(
   lookupKey: string,
@@ -21,6 +26,9 @@ export const POST = async (req: NextRequest) => {
     const body = await req.json().catch(() => ({}));
     const requestedPlan: string | undefined = body?.plan;
     const requestedQuantity: number | undefined = body?.quantity;
+    const attribution = sanitizeAttribution(body?.attribution);
+    const attributionProps = attributionProperties(attribution);
+    const stripeAttribution = stripeAttributionMetadata(attribution);
     // Get user ID from authenticated session
     const userId = await getUserID(req);
 
@@ -200,12 +208,14 @@ export const POST = async (req: NextRequest) => {
         userId,
         workOSOrganizationId: organization.id,
         requestedPlan: subscriptionLevel,
+        ...stripeAttribution,
       },
       subscription_data: {
         metadata: {
           userId,
           workOSOrganizationId: organization.id,
           requestedPlan: subscriptionLevel,
+          ...stripeAttribution,
         },
       },
       custom_text: {
@@ -219,6 +229,7 @@ export const POST = async (req: NextRequest) => {
     const selectedPrice = price.data[0];
     phLogger.event("checkout_started", {
       userId,
+      ...attributionProps,
       org_id: organization.id,
       from_tier: "free",
       to_tier: planLookupKeyToTier(subscriptionLevel),
@@ -234,6 +245,7 @@ export const POST = async (req: NextRequest) => {
       stripe_customer_id: customer.id,
       stripe_checkout_session_id: session.id,
       stripe_price_id: selectedPrice.id,
+      $set_once: attributionProps,
       $set: {
         last_checkout_started_at: new Date().toISOString(),
       },

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -13,6 +13,7 @@ import {
 import { phLogger } from "@/lib/posthog/server";
 import { resolveUserIdsFromCustomer as resolveStripeCustomerUsers } from "@/lib/billing/resolve-customer-users";
 import type { SubscriptionTier } from "@/types";
+import { attributionFromStripeMetadata } from "@/lib/analytics/attribution";
 
 // Linear ranking used to label tier transitions as upgrade/downgrade. Team is
 // pinned at the top because moves between team and individual plans are rare
@@ -244,10 +245,14 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
     );
     const attributedRevenueDollars =
       userIds.length > 0 ? invoiceAmountPaidDollars / userIds.length : 0;
+    const attributionProps = attributionFromStripeMetadata(
+      subscription.metadata,
+    );
 
     for (const uid of userIds) {
       phLogger.event("subscription_started", {
         userId: uid,
+        ...attributionProps,
         from_tier: "free",
         to_tier: tier,
         conversion_type: "free_to_paid",
@@ -270,6 +275,7 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
           last_subscription_started_at: new Date().toISOString(),
         },
         $set_once: {
+          ...attributionProps,
           first_subscription_started_at: new Date().toISOString(),
           first_paid_tier: tier,
         },

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -50,6 +50,7 @@ import { useLatestRef } from "../hooks/useLatestRef";
 import { useDataStreamDispatch } from "./DataStreamProvider";
 import { removeDraft } from "@/lib/utils/client-storage";
 import { parseRateLimitWarning } from "@/lib/utils/parse-rate-limit-warning";
+import { getInitialAttribution } from "@/lib/analytics/attribution";
 import Loading from "@/components/ui/loading";
 
 import { HackingSuggestions } from "./HackingSuggestions";
@@ -436,6 +437,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
           body: {
             chatId: id,
             messages: messagesWithoutUrls,
+            attribution: getInitialAttribution(),
             ...body,
           },
         };

--- a/app/hooks/useUpgrade.ts
+++ b/app/hooks/useUpgrade.ts
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { toast } from "sonner";
+import {
+  getInitialAttribution,
+  type InitialAttribution,
+} from "@/lib/analytics/attribution";
 
 export const useUpgrade = () => {
   const { user } = useAuth();
@@ -35,9 +39,17 @@ export const useUpgrade = () => {
     setUpgradeLoading(true);
 
     try {
-      const requestBody: { plan: string; quantity?: number } = {
+      const requestBody: {
+        plan: string;
+        quantity?: number;
+        attribution?: InitialAttribution;
+      } = {
         plan: planKey || "pro-monthly-plan",
       };
+      const attribution = getInitialAttribution();
+      if (attribution) {
+        requestBody.attribution = attribution;
+      }
 
       // Add quantity for team plans
       if (quantity && quantity > 1) {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -3,10 +3,22 @@
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { useEffect } from "react";
+import { useAuth } from "@workos-inc/authkit-nextjs/components";
+import {
+  attributionProperties,
+  captureInitialAttribution,
+  hasSyncedAttributionForUser,
+  markAttributionSyncedForUser,
+} from "@/lib/analytics/attribution";
 import { useGlobalState } from "./contexts/GlobalState";
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   const { subscription } = useGlobalState();
+  const { user } = useAuth();
+
+  useEffect(() => {
+    captureInitialAttribution();
+  }, []);
 
   useEffect(() => {
     if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
@@ -32,7 +44,41 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
         autocapture: false, // Disable automatic event capture, as we capture manually
       });
     }
-  }, [subscription]);
+
+    const attribution = captureInitialAttribution();
+    const attributionProps = attributionProperties(attribution);
+    if (Object.keys(attributionProps).length > 0) {
+      posthog.register(attributionProps);
+    }
+
+    if (user?.id) {
+      posthog.identify(user.id);
+    }
+  }, [subscription, user?.id]);
+
+  useEffect(() => {
+    if (!user?.id || hasSyncedAttributionForUser(user.id)) return;
+
+    const attribution = captureInitialAttribution();
+    if (!attribution) return;
+
+    fetch("/api/analytics/attribution", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ attribution }),
+      keepalive: true,
+    })
+      .then((response) => {
+        if (response.ok) {
+          markAttributionSyncedForUser(user.id);
+        }
+      })
+      .catch(() => {
+        // Best-effort analytics sync.
+      });
+  }, [user?.id]);
 
   return <PHProvider client={posthog}>{children}</PHProvider>;
 }

--- a/app/signup/route.ts
+++ b/app/signup/route.ts
@@ -4,5 +4,8 @@ import { redirectToAuthorizationUrl } from "@/lib/auth/auth-redirect-intents";
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const authorizationUrl = await getSignUpUrl();
-  return redirectToAuthorizationUrl(authorizationUrl, url);
+  return redirectToAuthorizationUrl(authorizationUrl, url, {
+    captureAttribution: true,
+    referrer: request.headers.get("referer"),
+  });
 }

--- a/lib/analytics/__tests__/attribution.test.ts
+++ b/lib/analytics/__tests__/attribution.test.ts
@@ -1,0 +1,83 @@
+import {
+  attributionProperties,
+  buildInitialAttribution,
+  decodeAttributionCookie,
+  encodeAttributionCookie,
+  sanitizeAttribution,
+  stripeAttributionMetadata,
+} from "../attribution";
+
+describe("attribution", () => {
+  it("captures UTM first-touch values from the landing URL", () => {
+    const attribution = buildInitialAttribution({
+      href: "https://hackerai.co/?utm_source=Google&utm_medium=CPC&utm_campaign=Launch&gclid=abc123&email=test@example.com",
+      capturedAt: "2026-05-23T12:00:00.000Z",
+    });
+
+    expect(attribution).toEqual(
+      expect.objectContaining({
+        initial_source: "google",
+        initial_medium: "cpc",
+        initial_campaign: "launch",
+        initial_landing_page: "https://hackerai.co/",
+        initial_landing_path: "/",
+        initial_landing_query:
+          "utm_source=Google&utm_medium=CPC&utm_campaign=Launch&gclid=abc123",
+        initial_gclid: "abc123",
+        initial_captured_at: "2026-05-23T12:00:00.000Z",
+      }),
+    );
+    expect(attribution?.initial_landing_query).not.toContain("email=");
+  });
+
+  it("falls back to an external referrer when no UTM source exists", () => {
+    const attribution = buildInitialAttribution({
+      href: "https://hackerai.co/pricing",
+      referrer: "https://www.producthunt.com/posts/hackerai",
+      capturedAt: "2026-05-23T12:00:00.000Z",
+    });
+
+    expect(attribution).toEqual(
+      expect.objectContaining({
+        initial_source: "producthunt.com",
+        initial_medium: "referral",
+        initial_referring_domain: "producthunt.com",
+        initial_landing_path: "/pricing",
+      }),
+    );
+  });
+
+  it("sanitizes untrusted attribution payloads before server capture", () => {
+    const sanitized = sanitizeAttribution({
+      initial_source: "x".repeat(600),
+      initial_medium: "referral",
+      initial_landing_page: "https://hackerai.co/",
+      initial_landing_path: "/",
+      initial_captured_at: "2026-05-23T12:00:00.000Z",
+      ignored: "value",
+    });
+
+    expect(sanitized?.initial_source).toHaveLength(500);
+    expect(attributionProperties(sanitized)).not.toHaveProperty("ignored");
+    expect(stripeAttributionMetadata(sanitized)).toEqual(
+      expect.objectContaining({
+        initial_source: "x".repeat(500),
+        initial_medium: "referral",
+      }),
+    );
+  });
+
+  it("decodes raw and URL-encoded cookie values", () => {
+    const attribution = buildInitialAttribution({
+      href: "https://hackerai.co/?utm_source=x&utm_medium=social",
+      capturedAt: "2026-05-23T12:00:00.000Z",
+    });
+    const cookieValue = encodeAttributionCookie(attribution);
+
+    expect(decodeAttributionCookie(cookieValue)?.initial_source).toBe("x");
+    expect(
+      decodeAttributionCookie(encodeURIComponent(cookieValue ?? ""))
+        ?.initial_medium,
+    ).toBe("social");
+  });
+});

--- a/lib/analytics/attribution.ts
+++ b/lib/analytics/attribution.ts
@@ -1,0 +1,336 @@
+export type InitialAttribution = {
+  initial_source: string;
+  initial_medium: string;
+  initial_campaign?: string;
+  initial_content?: string;
+  initial_term?: string;
+  initial_referrer?: string;
+  initial_referring_domain?: string;
+  initial_landing_page: string;
+  initial_landing_path: string;
+  initial_landing_query?: string;
+  initial_gclid?: string;
+  initial_fbclid?: string;
+  initial_msclkid?: string;
+  initial_captured_at: string;
+};
+
+const ATTRIBUTION_STORAGE_KEY = "hackerai.initial_attribution.v1";
+const ATTRIBUTION_COOKIE_NAME = "hackerai_initial_attribution";
+const ATTRIBUTION_SYNC_PREFIX = "hackerai.attribution_synced.";
+
+const TRACKING_QUERY_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "gclid",
+  "fbclid",
+  "msclkid",
+] as const;
+
+const ATTRIBUTION_KEYS = [
+  "initial_source",
+  "initial_medium",
+  "initial_campaign",
+  "initial_content",
+  "initial_term",
+  "initial_referrer",
+  "initial_referring_domain",
+  "initial_landing_page",
+  "initial_landing_path",
+  "initial_landing_query",
+  "initial_gclid",
+  "initial_fbclid",
+  "initial_msclkid",
+  "initial_captured_at",
+] as const;
+
+const STRIPE_ATTRIBUTION_KEYS = [
+  "initial_source",
+  "initial_medium",
+  "initial_campaign",
+  "initial_referring_domain",
+  "initial_landing_path",
+  "initial_gclid",
+  "initial_fbclid",
+  "initial_msclkid",
+] as const;
+
+function clean(value: string | null | undefined, maxLength = 500) {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return trimmed.slice(0, maxLength);
+}
+
+function cleanLower(value: string | null | undefined, maxLength = 120) {
+  return clean(value, maxLength)?.toLowerCase();
+}
+
+function normalizeDomain(hostname: string | null | undefined) {
+  return cleanLower(hostname?.replace(/^www\./, ""), 180);
+}
+
+function externalReferrerFor(referrer: string | null | undefined, url: URL) {
+  const rawReferrer = clean(referrer, 500);
+  if (!rawReferrer) return null;
+
+  try {
+    const referrerUrl = new URL(rawReferrer);
+    if (referrerUrl.origin === url.origin) return null;
+    return {
+      href: referrerUrl.href.slice(0, 500),
+      domain: normalizeDomain(referrerUrl.hostname),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function trackingQuery(searchParams: URLSearchParams) {
+  const params = new URLSearchParams();
+  for (const key of TRACKING_QUERY_KEYS) {
+    const value = clean(searchParams.get(key), 180);
+    if (value) params.set(key, value);
+  }
+  const query = params.toString();
+  return query || undefined;
+}
+
+export function buildInitialAttribution({
+  href,
+  referrer,
+  capturedAt = new Date().toISOString(),
+}: {
+  href: string;
+  referrer?: string | null;
+  capturedAt?: string;
+}): InitialAttribution | null {
+  try {
+    const url = new URL(href);
+    const externalReferrer = externalReferrerFor(referrer, url);
+    const utmSource = cleanLower(url.searchParams.get("utm_source"));
+    const utmMedium = cleanLower(url.searchParams.get("utm_medium"));
+    const source = utmSource ?? externalReferrer?.domain ?? "direct";
+    const medium = utmMedium ?? (externalReferrer ? "referral" : "direct");
+    const landingQuery = trackingQuery(url.searchParams);
+
+    return {
+      initial_source: source,
+      initial_medium: medium,
+      ...(cleanLower(url.searchParams.get("utm_campaign"), 180) && {
+        initial_campaign: cleanLower(url.searchParams.get("utm_campaign"), 180),
+      }),
+      ...(clean(url.searchParams.get("utm_content"), 180) && {
+        initial_content: clean(url.searchParams.get("utm_content"), 180),
+      }),
+      ...(clean(url.searchParams.get("utm_term"), 180) && {
+        initial_term: clean(url.searchParams.get("utm_term"), 180),
+      }),
+      ...(externalReferrer?.href && {
+        initial_referrer: externalReferrer.href,
+      }),
+      ...(externalReferrer?.domain && {
+        initial_referring_domain: externalReferrer.domain,
+      }),
+      initial_landing_page: `${url.origin}${url.pathname}`,
+      initial_landing_path: url.pathname,
+      ...(landingQuery && { initial_landing_query: landingQuery }),
+      ...(clean(url.searchParams.get("gclid"), 180) && {
+        initial_gclid: clean(url.searchParams.get("gclid"), 180),
+      }),
+      ...(clean(url.searchParams.get("fbclid"), 180) && {
+        initial_fbclid: clean(url.searchParams.get("fbclid"), 180),
+      }),
+      ...(clean(url.searchParams.get("msclkid"), 180) && {
+        initial_msclkid: clean(url.searchParams.get("msclkid"), 180),
+      }),
+      initial_captured_at: capturedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function sanitizeAttribution(input: unknown): InitialAttribution | null {
+  if (!input || typeof input !== "object") return null;
+
+  const source = input as Record<string, unknown>;
+  const sanitized: Record<string, string> = {};
+  for (const key of ATTRIBUTION_KEYS) {
+    const value = source[key];
+    if (typeof value !== "string") continue;
+    const cleanedValue = clean(value);
+    if (cleanedValue) sanitized[key] = cleanedValue;
+  }
+
+  if (
+    !sanitized.initial_source ||
+    !sanitized.initial_medium ||
+    !sanitized.initial_landing_page ||
+    !sanitized.initial_landing_path ||
+    !sanitized.initial_captured_at
+  ) {
+    return null;
+  }
+
+  return sanitized as InitialAttribution;
+}
+
+export function attributionProperties(
+  attribution: InitialAttribution | null | undefined,
+) {
+  if (!attribution) return {};
+  return ATTRIBUTION_KEYS.reduce<Record<string, string>>((props, key) => {
+    const value = attribution[key];
+    if (value) props[key] = value;
+    return props;
+  }, {});
+}
+
+export function stripeAttributionMetadata(
+  attribution: InitialAttribution | null | undefined,
+) {
+  if (!attribution) return {};
+  return STRIPE_ATTRIBUTION_KEYS.reduce<Record<string, string>>(
+    (metadata, key) => {
+      const value = attribution[key];
+      if (value) metadata[key] = value.slice(0, 500);
+      return metadata;
+    },
+    {},
+  );
+}
+
+export function attributionFromStripeMetadata(
+  metadata: StripeAttributionMetadata | null | undefined,
+) {
+  if (!metadata) return {};
+  return STRIPE_ATTRIBUTION_KEYS.reduce<Record<string, string>>(
+    (props, key) => {
+      const value = metadata[key];
+      if (typeof value === "string" && value.trim()) {
+        props[key] = value.trim().slice(0, 500);
+      }
+      return props;
+    },
+    {},
+  );
+}
+
+type StripeAttributionMetadata = Partial<
+  Record<(typeof STRIPE_ATTRIBUTION_KEYS)[number], string>
+>;
+
+export function encodeAttributionCookie(
+  attribution: InitialAttribution | null | undefined,
+) {
+  if (!attribution) return null;
+  return JSON.stringify(attribution);
+}
+
+export function decodeAttributionCookie(
+  value: string | null | undefined,
+): InitialAttribution | null {
+  if (!value) return null;
+  try {
+    return sanitizeAttribution(JSON.parse(value));
+  } catch {
+    try {
+      return sanitizeAttribution(JSON.parse(decodeURIComponent(value)));
+    } catch {
+      return null;
+    }
+  }
+}
+
+function readCookie(name: string) {
+  if (typeof document === "undefined") return null;
+  const encodedName = `${name}=`;
+  const match = document.cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(encodedName));
+  return match ? match.slice(encodedName.length) : null;
+}
+
+function writeAttributionCookie(attribution: InitialAttribution) {
+  if (typeof document === "undefined") return;
+  const encoded = encodeAttributionCookie(attribution);
+  if (!encoded) return;
+  const secure =
+    typeof window !== "undefined" && window.location.protocol === "https:"
+      ? "; secure"
+      : "";
+  document.cookie = `${ATTRIBUTION_COOKIE_NAME}=${encodeURIComponent(encoded)}; max-age=${60 * 60 * 24 * 90}; path=/; samesite=lax${secure}`;
+}
+
+export function getInitialAttribution(): InitialAttribution | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const stored = window.localStorage.getItem(ATTRIBUTION_STORAGE_KEY);
+    const attribution = sanitizeAttribution(stored ? JSON.parse(stored) : null);
+    if (attribution) return attribution;
+  } catch {
+    // Ignore unavailable storage.
+  }
+
+  const cookieAttribution = decodeAttributionCookie(
+    readCookie(ATTRIBUTION_COOKIE_NAME),
+  );
+  if (cookieAttribution) return cookieAttribution;
+
+  return null;
+}
+
+export function captureInitialAttribution(): InitialAttribution | null {
+  if (typeof window === "undefined") return null;
+
+  const existing = getInitialAttribution();
+  if (existing) {
+    writeAttributionCookie(existing);
+    return existing;
+  }
+
+  const attribution = buildInitialAttribution({
+    href: window.location.href,
+    referrer: document.referrer,
+  });
+  if (!attribution) return null;
+
+  try {
+    window.localStorage.setItem(
+      ATTRIBUTION_STORAGE_KEY,
+      JSON.stringify(attribution),
+    );
+  } catch {
+    // Ignore unavailable storage.
+  }
+  writeAttributionCookie(attribution);
+  return attribution;
+}
+
+export function hasSyncedAttributionForUser(userId: string) {
+  if (typeof window === "undefined") return false;
+  try {
+    return (
+      window.localStorage.getItem(`${ATTRIBUTION_SYNC_PREFIX}${userId}`) ===
+      "true"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function markAttributionSyncedForUser(userId: string) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(`${ATTRIBUTION_SYNC_PREFIX}${userId}`, "true");
+  } catch {
+    // Ignore unavailable storage.
+  }
+}
+
+export { ATTRIBUTION_COOKIE_NAME };

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -47,6 +47,7 @@ import {
   shutdownPostHog,
   type ChatLogger,
 } from "@/lib/api/chat-logger";
+import { sanitizeAttribution } from "@/lib/analytics/attribution";
 import {
   countFileAttachments,
   stripImageAttachments,
@@ -154,6 +155,7 @@ export const createChatHandler = (
         sandboxPreference,
         selectedModel: rawSelectedModel,
         isAutoContinue,
+        attribution: rawAttribution,
       }: {
         messages: UIMessage[];
         mode: ChatMode;
@@ -164,8 +166,10 @@ export const createChatHandler = (
         sandboxPreference?: SandboxPreference;
         selectedModel?: string;
         isAutoContinue?: boolean;
+        attribution?: unknown;
       } = await req.json();
       outerChatId = chatId;
+      const attribution = sanitizeAttribution(rawAttribution);
 
       const selectedModelOverride: SelectedModel | undefined =
         coerceSelectedModel(rawSelectedModel ?? null) ?? undefined;
@@ -681,6 +685,7 @@ export const createChatHandler = (
                   endpoint,
                   mode,
                   usage: usageCostRecord,
+                  attribution,
                 });
               } finally {
                 await releaseFreeRunLockOnce();

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -24,6 +24,10 @@ import { after } from "next/server";
 import { phLogger } from "@/lib/posthog/server";
 import type { UsageCostRecord } from "@/lib/usage-tracker";
 import {
+  attributionProperties,
+  type InitialAttribution,
+} from "@/lib/analytics/attribution";
+import {
   extractErrorDetails,
   extractRetryAttempts,
   getProviderErrorCategory,
@@ -611,6 +615,7 @@ export function captureUsageCost({
   endpoint,
   mode,
   usage,
+  attribution,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -620,12 +625,15 @@ export function captureUsageCost({
   endpoint: "/api/chat" | "/api/agent";
   mode: ChatMode;
   usage: UsageCostRecord;
+  attribution?: InitialAttribution | null;
 }) {
   if (!posthog) return;
+  const attributionProps = attributionProperties(attribution);
   posthog.capture({
     distinctId: userId,
     event: "hackerai-usage_cost",
     properties: {
+      ...attributionProps,
       user_id: userId,
       subscription,
       subscription_tier: subscription,
@@ -647,6 +655,10 @@ export function captureUsageCost({
       $set: {
         subscription_tier: subscription,
         last_usage_cost_at: new Date().toISOString(),
+      },
+      $set_once: {
+        ...attributionProps,
+        first_usage_at: new Date().toISOString(),
       },
     },
   });

--- a/lib/auth/__tests__/auth-redirect-intents.test.ts
+++ b/lib/auth/__tests__/auth-redirect-intents.test.ts
@@ -1,0 +1,101 @@
+import {
+  ATTRIBUTION_COOKIE_NAME,
+  decodeAttributionCookie,
+} from "@/lib/analytics/attribution";
+import { redirectToAuthorizationUrl } from "../auth-redirect-intents";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    redirect: (url: string) => {
+      const setCookies: string[] = [];
+      const response = {
+        headers: {
+          append: (name: string, value: string) => {
+            if (name.toLowerCase() === "set-cookie") setCookies.push(value);
+          },
+          get: (name: string) => {
+            if (name.toLowerCase() === "set-cookie") {
+              return setCookies.join(", ");
+            }
+            if (name.toLowerCase() === "location") return url;
+            return null;
+          },
+          getSetCookie: () => setCookies,
+        },
+        cookies: {
+          set: () => {},
+        },
+      } as unknown as Response & {
+        cookies: {
+          set: (
+            name: string,
+            value: string,
+            options?: { path?: string; maxAge?: number },
+          ) => void;
+        };
+      };
+      response.cookies = {
+        set: (name, value, options = {}) => {
+          response.headers.append(
+            "set-cookie",
+            `${name}=${encodeURIComponent(value)}; Path=${options.path ?? "/"}; Max-Age=${options.maxAge ?? ""}`,
+          );
+        },
+      };
+      return response;
+    },
+  },
+}));
+
+function readCookie(response: Response, name: string) {
+  const setCookie = response.headers.getSetCookie
+    ? response.headers.getSetCookie()
+    : [response.headers.get("set-cookie") ?? ""];
+  const cookie = setCookie.find((value) => value.startsWith(`${name}=`));
+  if (!cookie) return null;
+  return cookie.split(";", 1)[0]?.slice(name.length + 1) ?? null;
+}
+
+describe("redirectToAuthorizationUrl", () => {
+  it("preserves referrer attribution when signup redirects before client code runs", () => {
+    const response = redirectToAuthorizationUrl(
+      "https://auth.example.com/signup",
+      new URL("https://hackerai.co/signup"),
+      {
+        captureAttribution: true,
+        referrer: "https://www.producthunt.com/posts/hackerai",
+      },
+    );
+
+    const attribution = decodeAttributionCookie(
+      readCookie(response, ATTRIBUTION_COOKIE_NAME),
+    );
+    expect(attribution).toEqual(
+      expect.objectContaining({
+        initial_source: "producthunt.com",
+        initial_medium: "referral",
+        initial_landing_path: "/signup",
+      }),
+    );
+  });
+
+  it("still captures campaign params without explicit capture options", () => {
+    const response = redirectToAuthorizationUrl(
+      "https://auth.example.com/signup",
+      new URL(
+        "https://hackerai.co/signup?utm_source=x&utm_medium=social&utm_campaign=launch",
+      ),
+    );
+
+    const attribution = decodeAttributionCookie(
+      readCookie(response, ATTRIBUTION_COOKIE_NAME),
+    );
+    expect(attribution).toEqual(
+      expect.objectContaining({
+        initial_source: "x",
+        initial_medium: "social",
+        initial_campaign: "launch",
+      }),
+    );
+  });
+});

--- a/lib/auth/auth-redirect-intents.ts
+++ b/lib/auth/auth-redirect-intents.ts
@@ -1,4 +1,9 @@
 import { NextResponse } from "next/server";
+import {
+  ATTRIBUTION_COOKIE_NAME,
+  buildInitialAttribution,
+  encodeAttributionCookie,
+} from "@/lib/analytics/attribution";
 
 export const AUTH_REDIRECT_INTENTS: Record<string, string> = {
   pricing: "/#pricing",
@@ -23,6 +28,7 @@ export function getAuthRedirectPath(url: URL): string | null {
 export function redirectToAuthorizationUrl(
   authorizationUrl: string,
   requestUrl: URL,
+  options: { captureAttribution?: boolean; referrer?: string | null } = {},
 ): NextResponse {
   const response = NextResponse.redirect(authorizationUrl);
   const redirectPath = getAuthRedirectPath(requestUrl);
@@ -33,6 +39,32 @@ export function redirectToAuthorizationUrl(
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
       maxAge: 600,
+      path: "/",
+    });
+  }
+
+  const hasTrackingParams =
+    requestUrl.searchParams.has("utm_source") ||
+    requestUrl.searchParams.has("utm_medium") ||
+    requestUrl.searchParams.has("utm_campaign") ||
+    requestUrl.searchParams.has("gclid") ||
+    requestUrl.searchParams.has("fbclid") ||
+    requestUrl.searchParams.has("msclkid");
+  const shouldCaptureAttribution =
+    options.captureAttribution || hasTrackingParams || !!options.referrer;
+  const attributionCookie = shouldCaptureAttribution
+    ? encodeAttributionCookie(
+        buildInitialAttribution({
+          href: requestUrl.toString(),
+          referrer: options.referrer,
+        }),
+      )
+    : null;
+  if (attributionCookie) {
+    response.cookies.set(ATTRIBUTION_COOKIE_NAME, attributionCookie, {
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 90,
       path: "/",
     });
   }


### PR DESCRIPTION
## Summary

- Add first-touch attribution capture for UTM params, referrer domain, landing page/path, and ad click IDs.
- Persist attribution in browser storage/cookie and sync it for authenticated users through a server-side analytics endpoint.
- Attach attribution properties to checkout, subscription start, and usage-cost events so PostHog funnels can be broken down by source/campaign/referrer.
- Preserve attribution for direct `/signup` redirects before WorkOS takes over, including non-UTM external referrers.

## Impact

This creates the lightweight capture layer needed to analyze `signup -> first usage -> paid` quality by source before paid ads or a fuller referrer system are introduced.

## Validation

- `pnpm typecheck`
- `pnpm jest lib/analytics/__tests__/attribution.test.ts lib/auth/__tests__/auth-redirect-intents.test.ts --runInBand`
- Commit hook: `prettier --write`, `eslint --fix`, `pnpm typecheck`, full `pnpm test` (`92` suites, `1139` tests passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attribution tracking: capture, sanitize, persist and decode visitor source info (UTM, referrer) client-side and via cookie/localStorage.
  * Analytics integration: attribution is included in analytics events, subscription/checkout flows, billing/usage events, and a server endpoint records first/last capture timestamps.
  * Signup/redirect support: attribution preserved across OAuth/redirect flows and attached to upgrade/checkout requests.

* **Tests**
  * Added end-to-end tests for attribution parsing, sanitization, cookie encoding/decoding, and redirect capture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->