### PR TITLE
[codex] reduce expected PostHog noise and batch chat deletion

### DIFF
--- a/app/hooks/useFileUpload.ts
+++ b/app/hooks/useFileUpload.ts
@@ -311,9 +311,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
           url,
         });
       } catch (error) {
-        if (isExpectedFileUploadError(error)) {
-          console.warn("File upload blocked:", error);
-        } else {
+        if (!isExpectedFileUploadError(error)) {
           console.error("Failed to upload file:", error);
         }
 

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,11 +2,59 @@
 
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
+import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { useEffect } from "react";
 import { useGlobalState } from "./contexts/GlobalState";
 
+const IGNORED_CONVEX_EXCEPTION_MESSAGES = [
+  "Unauthorized: User not authenticated",
+  "Invalid arguments provided",
+];
+
+function getExceptionMessages(event: {
+  properties?: Record<string, unknown>;
+}): string[] {
+  const properties = event.properties ?? {};
+  const messages: string[] = [];
+
+  if (typeof properties.$exception_message === "string") {
+    messages.push(properties.$exception_message);
+  }
+
+  if (Array.isArray(properties.$exception_list)) {
+    for (const exception of properties.$exception_list) {
+      if (
+        exception &&
+        typeof exception === "object" &&
+        "value" in exception &&
+        typeof exception.value === "string"
+      ) {
+        messages.push(exception.value);
+      }
+    }
+  }
+
+  return messages;
+}
+
+function shouldDropExpectedConvexException(event: {
+  event?: string;
+  properties?: Record<string, unknown>;
+}) {
+  if (event.event !== "$exception") {
+    return false;
+  }
+
+  return getExceptionMessages(event).some((message) =>
+    IGNORED_CONVEX_EXCEPTION_MESSAGES.some((ignoredMessage) =>
+      message.includes(ignoredMessage),
+    ),
+  );
+}
+
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   const { subscription } = useGlobalState();
+  const { user } = useAuth();
 
   useEffect(() => {
     if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
@@ -18,9 +66,14 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       process.env.NEXT_PUBLIC_POSTHOG_TRACK_FREE_USERS === "true";
     const isPaidUser = subscription !== "free";
 
-    const shouldTrack = trackFreeUsers ? !isPaidUser : isPaidUser;
+    const shouldTrack =
+      Boolean(user) && (trackFreeUsers ? !isPaidUser : isPaidUser);
 
     if (!shouldTrack) {
+      if (posthog.__loaded) {
+        posthog.reset();
+        posthog.opt_out_capturing();
+      }
       return;
     }
 
@@ -30,9 +83,25 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
         api_host: `${process.env.NEXT_PUBLIC_POSTHOG_HOST}`,
         capture_pageview: false, // Disable automatic pageview capture, as we capture manually
         autocapture: false, // Disable automatic event capture, as we capture manually
+        before_send: (event) => {
+          if (!event || shouldDropExpectedConvexException(event)) {
+            return null;
+          }
+
+          return event;
+        },
       });
     }
-  }, [subscription]);
+
+    posthog.opt_in_capturing();
+    posthog.identify(user!.id, {
+      email: user!.email,
+      name:
+        [user!.firstName, user!.lastName].filter(Boolean).join(" ") ||
+        user!.email,
+      subscription,
+    });
+  }, [subscription, user]);
 
   return <PHProvider client={posthog}>{children}</PHProvider>;
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -9,6 +9,8 @@ import { useGlobalState } from "./contexts/GlobalState";
 const IGNORED_CONVEX_EXCEPTION_MESSAGES = [
   "Unauthorized: User not authenticated",
   "Invalid arguments provided",
+  "FILE_TOKEN_LIMIT_EXCEEDED",
+  "exceeds the maximum token limit",
 ];
 
 function getExceptionMessages(event: {

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -1,4 +1,5 @@
-import { query, mutation } from "./_generated/server";
+import { query, mutation, internalMutation } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
 import { v, ConvexError } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { internal } from "./_generated/api";
@@ -7,6 +8,97 @@ import { MAX_PREVIOUS_SUMMARIES } from "./constants";
 import { validateServiceKey } from "./lib/utils";
 import { coerceSelectedModel } from "../types/chat";
 import { convexLogger } from "./lib/logger";
+
+const DELETE_ALL_CHATS_MESSAGE_BATCH_SIZE = 10;
+const DELETE_ALL_CHATS_SUMMARY_BATCH_SIZE = 25;
+
+async function scheduleDeleteAllChatsBatch(ctx: MutationCtx, userId: string) {
+  await ctx.scheduler.runAfter(0, internal.chats.deleteAllChatsBatch, {
+    userId,
+  });
+}
+
+async function deleteNextUserChatBatch(ctx: MutationCtx, userId: string) {
+  const chat = await ctx.db
+    .query("chats")
+    .withIndex("by_user_and_updated", (q) => q.eq("user_id", userId))
+    .first();
+
+  if (!chat) {
+    return false;
+  }
+
+  const messages = await ctx.db
+    .query("messages")
+    .withIndex("by_chat_id", (q) => q.eq("chat_id", chat.id))
+    .take(DELETE_ALL_CHATS_MESSAGE_BATCH_SIZE);
+
+  if (messages.length > 0) {
+    for (const message of messages) {
+      if (!message.source_message_id && message.file_ids?.length) {
+        for (const storageId of message.file_ids) {
+          try {
+            const file = await ctx.db.get(storageId);
+            if (file) {
+              if (file.s3_key) {
+                await ctx.scheduler.runAfter(
+                  0,
+                  internal.s3Cleanup.deleteS3ObjectAction,
+                  { s3Key: file.s3_key },
+                );
+              }
+              if (file.storage_id) {
+                await ctx.storage.delete(file.storage_id);
+              }
+              await fileCountAggregate.deleteIfExists(ctx, file);
+              await ctx.db.delete(file._id);
+            }
+          } catch (error) {
+            console.error(`Failed to delete file ${storageId}:`, error);
+          }
+        }
+      }
+
+      if (message.feedback_id) {
+        try {
+          await ctx.db.delete(message.feedback_id);
+        } catch (error) {
+          console.error(
+            `Failed to delete feedback ${message.feedback_id}:`,
+            error,
+          );
+        }
+      }
+
+      await ctx.db.delete(message._id);
+    }
+
+    await scheduleDeleteAllChatsBatch(ctx, userId);
+    return true;
+  }
+
+  const summaries = await ctx.db
+    .query("chat_summaries")
+    .withIndex("by_chat_id", (q) => q.eq("chat_id", chat.id))
+    .take(DELETE_ALL_CHATS_SUMMARY_BATCH_SIZE);
+
+  if (summaries.length > 0) {
+    for (const summary of summaries) {
+      try {
+        await ctx.db.delete(summary._id);
+      } catch (error) {
+        console.error(`Failed to delete summary ${summary._id}:`, error);
+      }
+    }
+
+    await scheduleDeleteAllChatsBatch(ctx, userId);
+    return true;
+  }
+
+  await ctx.db.delete(chat._id);
+  await scheduleDeleteAllChatsBatch(ctx, userId);
+  return true;
+}
 
 /**
  * Get a chat by its ID
@@ -798,7 +890,7 @@ export const renameChat = mutation({
 export const deleteAllChats = mutation({
   args: {},
   returns: v.null(),
-  handler: async (ctx, args) => {
+  handler: async (ctx) => {
     const user = await ctx.auth.getUserIdentity();
 
     if (!user) {
@@ -809,103 +901,27 @@ export const deleteAllChats = mutation({
     }
 
     try {
-      // Get all chats for the user
-      const userChats = await ctx.db
-        .query("chats")
-        .withIndex("by_user_and_updated", (q) => q.eq("user_id", user.subject))
-        .collect();
-
-      // Delete each chat and its associated data
-      for (const chat of userChats) {
-        // Delete all messages and their associated files for this chat
-        const messages = await ctx.db
-          .query("messages")
-          .withIndex("by_chat_id", (q) => q.eq("chat_id", chat.id))
-          .collect();
-
-        for (const message of messages) {
-          // Skip deleting files for copied messages (they reference original chat files)
-          if (!message.source_message_id) {
-            // Clean up files associated with this message
-            if (message.file_ids && message.file_ids.length > 0) {
-              for (const storageId of message.file_ids) {
-                try {
-                  const file = await ctx.db.get(storageId);
-                  if (file) {
-                    // Delete from appropriate storage
-                    if (file.s3_key) {
-                      await ctx.scheduler.runAfter(
-                        0,
-                        internal.s3Cleanup.deleteS3ObjectAction,
-                        { s3Key: file.s3_key },
-                      );
-                    }
-                    if (file.storage_id) {
-                      await ctx.storage.delete(file.storage_id);
-                    }
-                    // Delete from aggregate
-                    await fileCountAggregate.deleteIfExists(ctx, file);
-                    await ctx.db.delete(file._id);
-                  }
-                } catch (error) {
-                  console.error(`Failed to delete file ${storageId}:`, error);
-                  // Continue with deletion even if file cleanup fails
-                }
-              }
-            }
-          }
-
-          // Clean up feedback associated with this message
-          if (message.feedback_id) {
-            try {
-              await ctx.db.delete(message.feedback_id);
-            } catch (error) {
-              console.error(
-                `Failed to delete feedback ${message.feedback_id}:`,
-                error,
-              );
-              // Continue with deletion even if feedback cleanup fails
-            }
-          }
-
-          await ctx.db.delete(message._id);
-        }
-
-        // Delete chat summaries
-        if (chat.latest_summary_id) {
-          try {
-            await ctx.db.delete(chat.latest_summary_id);
-          } catch (error) {
-            console.error(
-              `Failed to delete summary ${chat.latest_summary_id}:`,
-              error,
-            );
-            // Continue with deletion even if summary cleanup fails
-          }
-        }
-
-        // Delete all historical summaries for this chat
-        const summaries = await ctx.db
-          .query("chat_summaries")
-          .withIndex("by_chat_id", (q) => q.eq("chat_id", chat.id))
-          .collect();
-
-        for (const summary of summaries) {
-          try {
-            await ctx.db.delete(summary._id);
-          } catch (error) {
-            console.error(`Failed to delete summary ${summary._id}:`, error);
-            // Continue with deletion even if summary cleanup fails
-          }
-        }
-
-        // Delete the chat itself
-        await ctx.db.delete(chat._id);
-      }
+      await deleteNextUserChatBatch(ctx, user.subject);
 
       return null;
     } catch (error) {
       console.error("Failed to delete all chats:", error);
+      throw error;
+    }
+  },
+});
+
+export const deleteAllChatsBatch = internalMutation({
+  args: {
+    userId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    try {
+      await deleteNextUserChatBatch(ctx, args.userId);
+      return null;
+    } catch (error) {
+      console.error("Failed to delete all chats batch:", error);
       throw error;
     }
   },


### PR DESCRIPTION
## Summary

- Drop noisy PostHog `$exception` events for expected Convex auth/argument/file-token-limit errors.
- Require an authenticated WorkOS user before enabling client-side PostHog capture.
- Identify tracked users so future errors are attributed to real user IDs instead of anonymous generated IDs.
- Stop console-logging expected file upload validation errors while still showing the user-facing toast.
- Batch `deleteAllChats` through an internal scheduled mutation so large chat histories do not exceed Convex read limits.

## Why

Anonymous visitors were triggering repeated expected Convex errors such as `Unauthorized: User not authenticated` and `Invalid arguments provided`, which created noisy PostHog error tracking issues under anonymous identities like `greedy-cod-889`.

File uploads over the Ask-mode token limit are also expected validation failures. The upload hook handled them, but still logged the `ConvexError` object to the console, which could be picked up by PostHog error tracking.

A separate PostHog issue showed `Too many bytes read in a single function execution` at `convex/chats.ts`, caused by `deleteAllChats` collecting all chats/messages/summaries in one mutation. The fix deletes a bounded number of messages or summaries per execution and schedules the next batch.

## Validation

- `pnpm typecheck`
- Commit hook: prettier, eslint, typecheck, and Jest (`90` suites / `1134` tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error logging in file upload operations to properly distinguish between expected and unexpected errors

* **Performance**
  * Chat deletion now processes incrementally in batches rather than all at once

* **Analytics & Privacy**
  * Analytics tracking now requires user authentication before enabling identification
  * Added filtering to suppress specific exception events from being tracked

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->