### PR TITLE
fix tokenizer special token pruning

### DIFF
--- a/lib/__tests__/token-utils.test.ts
+++ b/lib/__tests__/token-utils.test.ts
@@ -3,6 +3,9 @@ import {
   getMaxTokensForSubscription,
   MAX_TOKENS_FREE,
   MAX_TOKENS_PAID,
+  safeCountTokens,
+  sliceByTokens,
+  truncateContent,
 } from "@/lib/token-utils";
 
 describe("getMaxTokensForSubscription", () => {
@@ -17,5 +20,27 @@ describe("getMaxTokensForSubscription", () => {
     expect(getMaxTokensForSubscription("ultra")).toBe(MAX_TOKENS_PAID);
     expect(getMaxTokensForSubscription("team")).toBe(MAX_TOKENS_PAID);
     expect(getMaxTokensForSubscription()).toBe(MAX_TOKENS_PAID);
+  });
+});
+
+describe("special token sentinels", () => {
+  it("counts reserved tokenizer sentinels as plain text", () => {
+    expect(() =>
+      safeCountTokens("literal <|im_start|> sentinel"),
+    ).not.toThrow();
+  });
+
+  it("preserves reserved tokenizer sentinel text when slicing", () => {
+    const content = "prefix <|im_start|> suffix ".repeat(20);
+
+    expect(sliceByTokens(content, 20)).not.toContain("<\\|");
+  });
+
+  it("preserves reserved tokenizer sentinel text when truncating", () => {
+    const content = `prefix <|im_start|> ${"middle ".repeat(200)}suffix <|im_end|>`;
+    const truncated = truncateContent(content, "\n[truncated]\n", 20);
+
+    expect(truncated).toContain("<|im_end|>");
+    expect(truncated).not.toContain("<\\|");
   });
 });

--- a/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
+++ b/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
@@ -61,6 +61,27 @@ describe("pruneToolOutputs", () => {
     expect(result.messages).toBe(messages); // same reference
   });
 
+  it("counts tool outputs containing tokenizer special tokens without throwing", () => {
+    const messages: UIMessage[] = [
+      makeAssistantMessage([
+        makeToolPart(
+          "file",
+          {
+            content:
+              "Shell script contains a literal sentinel: <|im_start|>\nDone.",
+          },
+          { action: "read", path: "/tmp/script.sh" },
+        ),
+      ]),
+    ];
+
+    const result = pruneToolOutputs(messages, 50_000, NO_MIN);
+
+    expect(result.prunedCount).toBe(0);
+    expect(result.skipReason).toBe("within-budget");
+    expect(result.messages).toBe(messages);
+  });
+
   it("prunes oldest tool outputs first when over budget", () => {
     // Create a large output string that will exceed a small budget
     const largeOutput = "x".repeat(5000); // ~1250 tokens
@@ -862,6 +883,34 @@ describe("pruneModelMessages", () => {
     ];
 
     const result = pruneModelMessages(messages, 50_000, NO_MIN);
+    expect(result.prunedCount).toBe(0);
+    expect(result.skipReason).toBe("within-budget");
+    expect(result.messages).toBe(messages);
+  });
+
+  it("counts model tool results containing tokenizer special tokens without throwing", () => {
+    const messages = [
+      makeAssistantModelMsg([
+        {
+          toolCallId: "c1",
+          toolName: "file",
+          args: { action: "read", path: "/tmp/upgrade_model.sh" },
+        },
+      ]),
+      makeToolModelMsg([
+        {
+          toolCallId: "c1",
+          toolName: "file",
+          output: {
+            content:
+              "Template text includes reserved model syntax: <|im_start|>system",
+          },
+        },
+      ]),
+    ];
+
+    const result = pruneModelMessages(messages, 50_000, NO_MIN);
+
     expect(result.prunedCount).toBe(0);
     expect(result.skipReason).toBe("within-budget");
     expect(result.messages).toBe(messages);

--- a/lib/chat/compaction/prune-tool-outputs.ts
+++ b/lib/chat/compaction/prune-tool-outputs.ts
@@ -1,5 +1,5 @@
 import type { UIMessage } from "ai";
-import { countTokens } from "gpt-tokenizer";
+import { safeCountTokens } from "@/lib/token-utils";
 
 /**
  * Default rolling token budget for tool outputs (protection window).
@@ -158,8 +158,8 @@ const buildPlaceholder = (part: ToolPart): string => {
 
 const countOutputTokens = (output: unknown): number => {
   if (output == null) return 0;
-  if (typeof output === "string") return countTokens(output);
-  return countTokens(JSON.stringify(output));
+  if (typeof output === "string") return safeCountTokens(output);
+  return safeCountTokens(JSON.stringify(output));
 };
 
 export const estimateSerializedSizeBytes = (value: unknown): number =>
@@ -416,7 +416,7 @@ export function pruneToolOutputs(
     if (remainingBudget <= 0) {
       toPrune.add(`${entry.msgIdx}:${entry.partIdx}`);
       prunedCount++;
-      const placeholderTokens = countTokens(buildPlaceholder(entry.part));
+      const placeholderTokens = safeCountTokens(buildPlaceholder(entry.part));
       tokensSaved += entry.tokens - placeholderTokens;
       continue;
     }
@@ -600,7 +600,7 @@ export function pruneModelMessages(
         args,
         entry.output,
       );
-      tokensSaved += entry.tokens - countTokens(placeholder);
+      tokensSaved += entry.tokens - safeCountTokens(placeholder);
       continue;
     }
     remainingBudget -= entry.tokens;

--- a/lib/token-utils.ts
+++ b/lib/token-utils.ts
@@ -9,21 +9,18 @@ import type { Id } from "@/convex/_generated/dataModel";
 import { FREE_MAX_CONTEXT_TOKENS } from "@/lib/rate-limit/free-config";
 
 const DISALLOWED_SPECIAL_TOKEN_MESSAGE = "Disallowed special token";
-const SPECIAL_TOKEN_PATTERN = /<\|[^|]+?\|>/g;
+const TOKENIZE_SPECIAL_TOKENS_AS_TEXT: NonNullable<
+  Parameters<typeof encodeGptTokens>[1]
+> = {
+  disallowedSpecial: new Set(),
+};
 let hasLoggedSpecialTokenFallback = false;
-
-const escapeTokenizerSpecialTokens = (content: string): string =>
-  content.replace(SPECIAL_TOKEN_PATTERN, (token) =>
-    token.replace("<|", "<\\|"),
-  );
 
 const logSpecialTokenFallback = (): void => {
   if (hasLoggedSpecialTokenFallback) return;
 
   hasLoggedSpecialTokenFallback = true;
-  console.warn(
-    "[token-utils] Escaped tokenizer special token while counting untrusted text",
-  );
+  console.warn("[token-utils] Tokenized special token sentinel as plain text");
 };
 
 export const safeCountTokens = (content: string): number => {
@@ -35,7 +32,7 @@ export const safeCountTokens = (content: string): number => {
       error.message.includes(DISALLOWED_SPECIAL_TOKEN_MESSAGE)
     ) {
       logSpecialTokenFallback();
-      return countGptTokens(escapeTokenizerSpecialTokens(content));
+      return countGptTokens(content, TOKENIZE_SPECIAL_TOKENS_AS_TEXT);
     }
 
     throw error;
@@ -51,7 +48,7 @@ const safeEncode = (content: string): ReturnType<typeof encodeGptTokens> => {
       error.message.includes(DISALLOWED_SPECIAL_TOKEN_MESSAGE)
     ) {
       logSpecialTokenFallback();
-      return encodeGptTokens(escapeTokenizerSpecialTokens(content));
+      return encodeGptTokens(content, TOKENIZE_SPECIAL_TOKENS_AS_TEXT);
     }
 
     throw error;

--- a/lib/token-utils.ts
+++ b/lib/token-utils.ts
@@ -1,8 +1,62 @@
 import { UIMessage, UIMessagePart } from "ai";
-import { countTokens, encode, decode } from "gpt-tokenizer";
+import {
+  countTokens as countGptTokens,
+  encode as encodeGptTokens,
+  decode,
+} from "gpt-tokenizer";
 import type { SubscriptionTier } from "@/types";
 import type { Id } from "@/convex/_generated/dataModel";
 import { FREE_MAX_CONTEXT_TOKENS } from "@/lib/rate-limit/free-config";
+
+const DISALLOWED_SPECIAL_TOKEN_MESSAGE = "Disallowed special token";
+const SPECIAL_TOKEN_PATTERN = /<\|[^|]+?\|>/g;
+let hasLoggedSpecialTokenFallback = false;
+
+const escapeTokenizerSpecialTokens = (content: string): string =>
+  content.replace(SPECIAL_TOKEN_PATTERN, (token) =>
+    token.replace("<|", "<\\|"),
+  );
+
+const logSpecialTokenFallback = (): void => {
+  if (hasLoggedSpecialTokenFallback) return;
+
+  hasLoggedSpecialTokenFallback = true;
+  console.warn(
+    "[token-utils] Escaped tokenizer special token while counting untrusted text",
+  );
+};
+
+export const safeCountTokens = (content: string): number => {
+  try {
+    return countGptTokens(content);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes(DISALLOWED_SPECIAL_TOKEN_MESSAGE)
+    ) {
+      logSpecialTokenFallback();
+      return countGptTokens(escapeTokenizerSpecialTokens(content));
+    }
+
+    throw error;
+  }
+};
+
+const safeEncode = (content: string): ReturnType<typeof encodeGptTokens> => {
+  try {
+    return encodeGptTokens(content);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes(DISALLOWED_SPECIAL_TOKEN_MESSAGE)
+    ) {
+      logSpecialTokenFallback();
+      return encodeGptTokens(escapeTokenizerSpecialTokens(content));
+    }
+
+    throw error;
+  }
+};
 
 export const MAX_TOKENS_FREE = FREE_MAX_CONTEXT_TOKENS;
 export const MAX_TOKENS_PAID = 200000;
@@ -64,7 +118,7 @@ const countPartTokens = (
   fileTokens: Record<Id<"files">, number> = {},
 ): number => {
   if (part.type === "text" && "text" in part) {
-    return countTokens((part as { text?: string }).text || "");
+    return safeCountTokens((part as { text?: string }).text || "");
   }
   if (
     part.type === "file" &&
@@ -82,10 +136,10 @@ const countPartTokens = (
   if (hasMetadata) {
     const { providerMetadata, callProviderMetadata, ...partWithoutMetadata } =
       partAny;
-    return countTokens(JSON.stringify(partWithoutMetadata));
+    return safeCountTokens(JSON.stringify(partWithoutMetadata));
   }
 
-  return countTokens(JSON.stringify(part));
+  return safeCountTokens(JSON.stringify(part));
 };
 
 /**
@@ -160,12 +214,12 @@ export const truncateContent = (
   marker: string = TRUNCATION_MESSAGE,
   maxTokens: number = TOOL_DEFAULT_MAX_TOKENS,
 ): string => {
-  const tokens = encode(content);
+  const tokens = safeEncode(content);
   if (tokens.length <= maxTokens) return content;
 
-  const markerTokens = countTokens(marker);
+  const markerTokens = safeCountTokens(marker);
   if (maxTokens <= markerTokens) {
-    return maxTokens <= 0 ? "" : decode(encode(marker).slice(-maxTokens));
+    return maxTokens <= 0 ? "" : decode(safeEncode(marker).slice(-maxTokens));
   }
 
   const budgetForContent = maxTokens - markerTokens;
@@ -186,7 +240,7 @@ export const truncateContent = (
 export const sliceByTokens = (content: string, maxTokens: number): string => {
   if (maxTokens <= 0) return "";
 
-  const tokens = encode(content);
+  const tokens = safeEncode(content);
   if (tokens.length <= maxTokens) return content;
 
   return decode(tokens.slice(0, maxTokens));
@@ -199,7 +253,7 @@ export const countInputTokens = (
   input: string,
   uploadedFiles: Array<{ tokens?: number }> = [],
 ): number => {
-  const textTokens = countTokens(input);
+  const textTokens = safeCountTokens(input);
   const fileTokens = uploadedFiles.reduce(
     (total, file) => total + (file.tokens || 0),
     0,


### PR DESCRIPTION
## Summary
- Add safe token counting/encoding for reserved tokenizer sentinel strings in untrusted text.
- Use the safe counter while pruning UI and model tool outputs so prepareStep does not fail before response persistence.
- Add regression tests for tool outputs containing `<|im_start|>`.

## Test plan
- `pnpm test -- lib/chat/compaction/__tests__/prune-tool-outputs.test.ts --runInBand`
- `pnpm exec eslint lib/token-utils.ts lib/chat/compaction/prune-tool-outputs.ts lib/chat/compaction/__tests__/prune-tool-outputs.test.ts`
- Pre-commit hook: `pnpm typecheck` and full `pnpm test`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token counting to safely handle reserved tokenizer sentinel sequences so pruning and token-budget calculations no longer error on special tokens.

* **Tests**
  * Added tests verifying safe token counting, slicing, truncation, and pruning behavior preserve sentinel text and do not throw when special tokens appear.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->