### PR TITLE
[codex] fix local attachment upload fallback

### DIFF
--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -20,6 +20,7 @@ import {
   getUploadBasePath,
   hasLocalDesktopSourcePaths,
   prepareLocalDesktopAttachmentsForTrigger,
+  rewriteSandboxFilePathsInMessages,
   stripLocalDesktopSourcePaths,
   uploadSandboxFiles,
 } from "@/lib/utils/sandbox-file-utils";
@@ -82,7 +83,7 @@ export async function POST(req: NextRequest) {
         );
       }
 
-      const { messages: preparedMessages, sandboxFiles } =
+      let { messages: preparedMessages, sandboxFiles } =
         prepareLocalDesktopAttachmentsForTrigger(
           messages,
           getUploadBasePath("desktop"),
@@ -115,6 +116,10 @@ export async function POST(req: NextRequest) {
             `Failed to prepare ${uploadResult.failedCount} local ${noun}. Please reattach and try again.`,
           );
         }
+        preparedMessages = rewriteSandboxFilePathsInMessages(
+          preparedMessages,
+          uploadResult.pathRewrites,
+        );
       }
       messagesForTrigger = preparedMessages;
       localDesktopAttachmentsPrepared = true;

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -87,6 +87,7 @@ import { createTrackedProvider } from "@/lib/ai/providers";
 import {
   uploadSandboxFiles,
   getUploadBasePath,
+  rewriteSandboxFilePathsInMessages,
   stripLocalDesktopSourcePaths,
 } from "@/lib/utils/sandbox-file-utils";
 import { after } from "next/server";
@@ -259,7 +260,7 @@ export const createChatHandler = (
         ? getUploadBasePath(sandboxPreference)
         : undefined;
 
-      const { processedMessages, selectedModel, sandboxFiles } =
+      let { processedMessages, selectedModel, sandboxFiles } =
         await processChatMessages({
           messages: truncatedMessages,
           mode,
@@ -475,7 +476,11 @@ export const createChatHandler = (
                   ? "Preparing local attachments on your computer"
                   : "Uploading attachments to the computer",
               );
-              let uploadResult: { failedCount: number } = { failedCount: 0 };
+              let uploadResult: Awaited<ReturnType<typeof uploadSandboxFiles>> =
+                {
+                  failedCount: 0,
+                  pathRewrites: [],
+                };
               try {
                 uploadResult = await uploadSandboxFiles(
                   sandboxFiles,
@@ -499,6 +504,10 @@ export const createChatHandler = (
                 chatLogger?.emitChatError(uploadError);
                 throw uploadError;
               }
+              processedMessages = rewriteSandboxFilePathsInMessages(
+                processedMessages,
+                uploadResult.pathRewrites,
+              );
             }
 
             // Generate title in parallel only for non-temporary new chats

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -3,6 +3,7 @@ jest.mock("server-only", () => ({}), { virtual: true });
 import type { UIMessage } from "ai";
 import {
   prepareLocalDesktopAttachmentsForTrigger,
+  rewriteSandboxFilePathsInMessages,
   stripLocalDesktopSourcePaths,
   uploadSandboxFiles,
 } from "../sandbox-file-utils";
@@ -124,5 +125,86 @@ describe("desktop-local sandbox file helpers", () => {
     } finally {
       consoleErrorSpy.mockRestore();
     }
+  });
+
+  it("retries url uploads in a writable directory when /tmp is not writable", async () => {
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const downloadFromUrl = jest
+      .fn()
+      .mockRejectedValueOnce(
+        new Error(
+          "Failed to download file: mkdir: cannot create directory '/tmp/hackerai-upload': Permission denied",
+        ),
+      )
+      .mockResolvedValueOnce(undefined);
+    const run = jest.fn().mockResolvedValue({
+      exitCode: 0,
+      stdout: "/home/alice/hackerai-upload/report.pdf",
+      stderr: "",
+    });
+
+    try {
+      const result = await uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "https://example.com/report.pdf",
+            localPath: "/tmp/hackerai-upload/report.pdf",
+          },
+        ],
+        async () => ({
+          commands: { run },
+          files: { downloadFromUrl },
+        }),
+      );
+
+      expect(result).toEqual({
+        failedCount: 0,
+        pathRewrites: [
+          {
+            from: "/tmp/hackerai-upload/report.pdf",
+            to: "/home/alice/hackerai-upload/report.pdf",
+          },
+        ],
+      });
+      expect(downloadFromUrl).toHaveBeenCalledWith(
+        "https://example.com/report.pdf",
+        "/tmp/hackerai-upload/report.pdf",
+      );
+      expect(downloadFromUrl).toHaveBeenCalledWith(
+        "https://example.com/report.pdf",
+        "/home/alice/hackerai-upload/report.pdf",
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
+  it("rewrites attachment tags after upload path fallback", () => {
+    const messages = [
+      {
+        id: "m1",
+        role: "user",
+        parts: [
+          {
+            type: "text",
+            text: '<attachment filename="report.pdf" local_path="/tmp/hackerai-upload/report.pdf" />',
+          },
+        ],
+      },
+    ] as UIMessage[];
+
+    const rewritten = rewriteSandboxFilePathsInMessages(messages, [
+      {
+        from: "/tmp/hackerai-upload/report.pdf",
+        to: "/home/alice/hackerai-upload/report.pdf",
+      },
+    ]);
+
+    expect(rewritten[0].parts?.[0]).toMatchObject({
+      text: '<attachment filename="report.pdf" local_path="/home/alice/hackerai-upload/report.pdf" />',
+    });
   });
 });

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -17,6 +17,16 @@ export type SandboxFile = {
     }
 );
 
+export type SandboxFilePathRewrite = {
+  from: string;
+  to: string;
+};
+
+type SandboxUploadResult = {
+  failedCount: number;
+  pathRewrites: SandboxFilePathRewrite[];
+};
+
 const logLocalAttachmentDebug = (
   event: string,
   data: Record<string, unknown>,
@@ -166,6 +176,36 @@ export const hasLocalDesktopSourcePaths = (
         part.localPath.length > 0,
     ),
   );
+
+const replaceAllPathOccurrences = (
+  value: string,
+  rewrites: SandboxFilePathRewrite[],
+): string =>
+  rewrites.reduce(
+    (text, rewrite) => text.split(rewrite.from).join(rewrite.to),
+    value,
+  );
+
+export const rewriteSandboxFilePathsInMessages = <T extends { parts?: any[] }>(
+  messages: T[],
+  rewrites: SandboxFilePathRewrite[],
+): T[] => {
+  if (rewrites.length === 0) return messages;
+
+  return messages.map((message) => {
+    if (!message.parts) return message;
+    return {
+      ...message,
+      parts: message.parts.map((part) => {
+        if (typeof part?.text !== "string") return part;
+        return {
+          ...part,
+          text: replaceAllPathOccurrences(part.text, rewrites),
+        };
+      }),
+    };
+  });
+};
 
 export const prepareLocalDesktopAttachmentsForTrigger = (
   messages: UIMessage[],
@@ -318,6 +358,107 @@ const copyLocalFileToSandbox = async (
   return sandbox.files.copyLocal(sourcePath, localPath);
 };
 
+const shellQuote = (value: string): string =>
+  `'${value.replace(/'/g, "'\\''")}'`;
+
+const shouldTryUploadPathFallback = (
+  localPath: string,
+  error: unknown,
+): boolean => {
+  if (!localPath.startsWith("/tmp/hackerai-upload/")) return false;
+  const message = error instanceof Error ? error.message : String(error);
+  return /permission denied|read-only file system|cannot create directory|failed to create directory/i.test(
+    message,
+  );
+};
+
+const resolveWritableUploadFallbackPath = async (
+  sandbox: any,
+  originalLocalPath: string,
+): Promise<string | null> => {
+  const fileName = originalLocalPath.split(/[/\\]/).pop();
+  if (!fileName || !sandbox.commands?.run) return null;
+
+  const script = [
+    `filename=${shellQuote(fileName)}`,
+    `for base in "\${TMPDIR:-/tmp}" /var/tmp "\${HOME:-}" "\${PWD:-.}"; do`,
+    `  [ -n "$base" ] || continue`,
+    `  dir="$base/hackerai-upload"`,
+    `  if mkdir -p "$dir" 2>/dev/null && [ -w "$dir" ]; then`,
+    `    cd "$dir" 2>/dev/null && printf '%s/%s' "$(pwd -P)" "$filename"`,
+    `    exit 0`,
+    `  fi`,
+    `done`,
+    `exit 1`,
+  ].join("\n");
+
+  const result = await sandbox.commands.run(script, {
+    displayName: "",
+  });
+  if (result.exitCode !== 0) return null;
+  const fallbackPath = result.stdout.trim();
+  return fallbackPath ? fallbackPath : null;
+};
+
+const stageSandboxFile = async (
+  sandbox: any,
+  file: SandboxFile,
+): Promise<SandboxFilePathRewrite | null> => {
+  try {
+    if (file.kind === "url") {
+      await downloadFileToSandbox(sandbox, file.url, file.localPath);
+    } else {
+      await copyLocalFileToSandbox(sandbox, file.path, file.localPath);
+    }
+    return null;
+  } catch (error) {
+    if (!shouldTryUploadPathFallback(file.localPath, error)) {
+      throw error;
+    }
+
+    const fallbackPath = await resolveWritableUploadFallbackPath(
+      sandbox,
+      file.localPath,
+    );
+    if (!fallbackPath || fallbackPath === file.localPath) {
+      throw error;
+    }
+
+    console.warn(
+      `[sandbox-upload] ${file.localPath} is not writable, retrying attachment staging at ${fallbackPath}`,
+    );
+
+    const fallbackFile = { ...file, localPath: fallbackPath } as SandboxFile;
+    try {
+      if (fallbackFile.kind === "url") {
+        await downloadFileToSandbox(
+          sandbox,
+          fallbackFile.url,
+          fallbackFile.localPath,
+        );
+      } else {
+        await copyLocalFileToSandbox(
+          sandbox,
+          fallbackFile.path,
+          fallbackFile.localPath,
+        );
+      }
+    } catch (fallbackError) {
+      const originalMessage =
+        error instanceof Error ? error.message : String(error);
+      const fallbackMessage =
+        fallbackError instanceof Error
+          ? fallbackError.message
+          : String(fallbackError);
+      throw new Error(
+        `${originalMessage}\nFallback upload path also failed: ${fallbackMessage}`,
+      );
+    }
+
+    return { from: file.localPath, to: fallbackPath };
+  }
+};
+
 const safeUrlForLog = (url: string): string => {
   try {
     const parsed = new URL(url);
@@ -363,8 +504,8 @@ const redactSandboxUploadError = (
 export const uploadSandboxFiles = async (
   sandboxFiles: SandboxFile[],
   ensureSandbox: () => Promise<any>,
-): Promise<{ failedCount: number }> => {
-  if (sandboxFiles.length === 0) return { failedCount: 0 };
+): Promise<SandboxUploadResult> => {
+  if (sandboxFiles.length === 0) return { failedCount: 0, pathRewrites: [] };
 
   logLocalAttachmentDebug("sandbox-staging-start", {
     totalCount: sandboxFiles.length,
@@ -378,15 +519,11 @@ export const uploadSandboxFiles = async (
     sandbox = await ensureSandbox();
   } catch (e) {
     console.error("Failed to acquire sandbox for upload:", e);
-    return { failedCount: sandboxFiles.length };
+    return { failedCount: sandboxFiles.length, pathRewrites: [] };
   }
 
   const results = await Promise.allSettled(
-    sandboxFiles.map((file) =>
-      file.kind === "url"
-        ? downloadFileToSandbox(sandbox, file.url, file.localPath)
-        : copyLocalFileToSandbox(sandbox, file.path, file.localPath),
-    ),
+    sandboxFiles.map((file) => stageSandboxFile(sandbox, file)),
   );
 
   const failedIndices = results
@@ -407,5 +544,9 @@ export const uploadSandboxFiles = async (
     });
   }
 
-  return { failedCount: failedIndices.length };
+  const pathRewrites = results.flatMap((result) =>
+    result.status === "fulfilled" && result.value ? [result.value] : [],
+  );
+
+  return { failedCount: failedIndices.length, pathRewrites };
 };

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -69,6 +69,7 @@ import {
 import {
   uploadSandboxFiles,
   getUploadBasePath,
+  rewriteSandboxFilePathsInMessages,
 } from "@/lib/utils/sandbox-file-utils";
 import {
   captureAgentRun,
@@ -635,7 +636,7 @@ export const agentLongTask = task({
             : messages;
       const messagesForAccounting = messagesForProcessing;
 
-      const { processedMessages, selectedModel, sandboxFiles } =
+      let { processedMessages, selectedModel, sandboxFiles } =
         await processChatMessages({
           messages: messagesForProcessing,
           mode,
@@ -837,7 +838,11 @@ export const agentLongTask = task({
                   ? "Preparing local attachments on your computer"
                   : "Uploading attachments to the computer",
               );
-              let uploadResult: { failedCount: number } = { failedCount: 0 };
+              let uploadResult: Awaited<ReturnType<typeof uploadSandboxFiles>> =
+                {
+                  failedCount: 0,
+                  pathRewrites: [],
+                };
               try {
                 uploadResult = await uploadSandboxFiles(
                   sandboxFiles,
@@ -857,6 +862,10 @@ export const agentLongTask = task({
                 chatLogger?.emitChatError(uploadError);
                 throw uploadError;
               }
+              processedMessages = rewriteSandboxFilePathsInMessages(
+                processedMessages,
+                uploadResult.pathRewrites,
+              );
             }
 
             const titlePromise =


### PR DESCRIPTION
## Summary
- Retry attachment staging in a writable fallback directory when `/tmp/hackerai-upload` cannot be created on a local computer.
- Rewrite generated attachment tags to point at the fallback path before the model sees them.
- Apply the same rewrite path in `/api/agent`, Trigger long-running agents, and prepared desktop-local Trigger payloads.

## Root Cause
Local/Centrifugo attachment staging assumed `/tmp/hackerai-upload` was writable. In Trigger/local computer environments where `/tmp` is locked down, `mkdir -p /tmp/hackerai-upload` failed before `curl` could download the S3 attachment, which surfaced as a misleading provider stream error.

## Validation
- `pnpm test -- lib/utils/__tests__/sandbox-file-utils.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- pre-commit hook: full `pnpm typecheck` and `pnpm test` passed (`91` suites, `1137` tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic file path rewriting in messages when sandbox uploads are redirected to fallback directories due to write failures
  * Improved upload resilience with fallback mechanisms for permission-based failures

* **Tests**
  * Added test coverage for sandbox file upload fallback behavior and message path rewriting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->