### PR TITLE
[codex] Fix summary save race

### DIFF
--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -92,6 +92,7 @@ describe("saveLatestSummary — previous_summaries chain", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "log").mockImplementation(() => {});
     jest.spyOn(console, "warn").mockImplementation(() => {});
 
     mockCtx = {
@@ -112,16 +113,55 @@ describe("saveLatestSummary — previous_summaries chain", () => {
     mockCtx.db.query.mockReturnValue({ withIndex: withIndexMock });
   });
 
-  function setupChatQuery(chat: Record<string, any> | null): void {
-    const withIndexMock = jest.fn().mockReturnValue({
-      first: jest.fn<any>().mockResolvedValue(chat),
+  function setupSaveSummaryQueries(
+    chat: Record<string, any> | null,
+    opts: {
+      incomingCutoffCreationTime?: number | null;
+      previousCutoffCreationTime?: number | null;
+    } = {},
+  ): void {
+    const {
+      incomingCutoffCreationTime = 10_000,
+      previousCutoffCreationTime = 5_000,
+    } = opts;
+    let messageQueryCount = 0;
+
+    mockCtx.db.query.mockImplementation((table: string) => {
+      if (table === "chats") {
+        return {
+          withIndex: jest.fn().mockReturnValue({
+            first: jest.fn<any>().mockResolvedValue(chat),
+          }),
+        };
+      }
+
+      if (table === "messages") {
+        const creationTime =
+          messageQueryCount++ === 0
+            ? incomingCutoffCreationTime
+            : previousCutoffCreationTime;
+        return {
+          withIndex: jest.fn().mockReturnValue({
+            first: jest
+              .fn<any>()
+              .mockResolvedValue(
+                creationTime === null ? null : { _creationTime: creationTime },
+              ),
+          }),
+        };
+      }
+
+      return {
+        withIndex: jest.fn().mockReturnValue({
+          first: jest.fn<any>().mockResolvedValue(null),
+        }),
+      };
     });
-    mockCtx.db.query.mockReturnValue({ withIndex: withIndexMock });
   }
 
   it("should set previous_summaries to [] when no existing summary", async () => {
     const chat = makeChatDoc({ latest_summary_id: undefined });
-    setupChatQuery(chat);
+    setupSaveSummaryQueries(chat);
 
     const { saveLatestSummary } = await import("../chats");
 
@@ -136,17 +176,19 @@ describe("saveLatestSummary — previous_summaries chain", () => {
       "chat_summaries",
       expect.objectContaining({
         previous_summaries: [],
+        summary_up_to_message_creation_time: 10_000,
       }),
     );
   });
 
   it("should push old summary into previous_summaries[0] on second save", async () => {
     const chat = makeChatDoc();
-    setupChatQuery(chat);
+    setupSaveSummaryQueries(chat);
 
     const oldSummary = makeSummaryDoc({
       summary_text: "old text",
       summary_up_to_message_id: "msg-5",
+      summary_up_to_message_creation_time: 5_000,
       previous_summaries: [],
     });
     mockCtx.db.get.mockResolvedValue(oldSummary);
@@ -164,15 +206,20 @@ describe("saveLatestSummary — previous_summaries chain", () => {
       "chat_summaries",
       expect.objectContaining({
         previous_summaries: [
-          { summary_text: "old text", summary_up_to_message_id: "msg-5" },
+          {
+            summary_text: "old text",
+            summary_up_to_message_id: "msg-5",
+            summary_up_to_message_creation_time: 5_000,
+          },
         ],
       }),
     );
+    expect(mockCtx.db.delete).not.toHaveBeenCalledWith(SUMMARY_DOC_ID);
   });
 
   it("should preserve the chain: [old, ...old_previous_summaries]", async () => {
     const chat = makeChatDoc();
-    setupChatQuery(chat);
+    setupSaveSummaryQueries(chat);
 
     const existingChain = [
       { summary_text: "even-older", summary_up_to_message_id: "msg-1" },
@@ -180,6 +227,7 @@ describe("saveLatestSummary — previous_summaries chain", () => {
     const oldSummary = makeSummaryDoc({
       summary_text: "old text",
       summary_up_to_message_id: "msg-5",
+      summary_up_to_message_creation_time: 5_000,
       previous_summaries: existingChain,
     });
     mockCtx.db.get.mockResolvedValue(oldSummary);
@@ -197,7 +245,11 @@ describe("saveLatestSummary — previous_summaries chain", () => {
       "chat_summaries",
       expect.objectContaining({
         previous_summaries: [
-          { summary_text: "old text", summary_up_to_message_id: "msg-5" },
+          {
+            summary_text: "old text",
+            summary_up_to_message_id: "msg-5",
+            summary_up_to_message_creation_time: 5_000,
+          },
           { summary_text: "even-older", summary_up_to_message_id: "msg-1" },
         ],
       }),
@@ -206,7 +258,7 @@ describe("saveLatestSummary — previous_summaries chain", () => {
 
   it("should truncate previous_summaries at MAX_PREVIOUS_SUMMARIES (10)", async () => {
     const chat = makeChatDoc();
-    setupChatQuery(chat);
+    setupSaveSummaryQueries(chat);
 
     const existingChain = Array.from({ length: 11 }, (_, i) => ({
       summary_text: `prev-${i}`,
@@ -215,6 +267,7 @@ describe("saveLatestSummary — previous_summaries chain", () => {
     const oldSummary = makeSummaryDoc({
       summary_text: "old text",
       summary_up_to_message_id: "msg-5",
+      summary_up_to_message_creation_time: 5_000,
       previous_summaries: existingChain,
     });
     mockCtx.db.get.mockResolvedValue(oldSummary);
@@ -234,7 +287,81 @@ describe("saveLatestSummary — previous_summaries chain", () => {
     expect(insertedDoc.previous_summaries[0]).toEqual({
       summary_text: "old text",
       summary_up_to_message_id: "msg-5",
+      summary_up_to_message_creation_time: 5_000,
     });
+  });
+
+  it("should skip stale saves when an existing summary has a newer cutoff", async () => {
+    const chat = makeChatDoc();
+    setupSaveSummaryQueries(chat, { incomingCutoffCreationTime: 5_000 });
+
+    const oldSummary = makeSummaryDoc({
+      summary_text: "newer summary",
+      summary_up_to_message_id: "msg-10",
+      summary_up_to_message_creation_time: 10_000,
+    });
+    mockCtx.db.get.mockResolvedValue(oldSummary);
+
+    const { saveLatestSummary } = await import("../chats");
+
+    await saveLatestSummary.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      chatId: CHAT_ID,
+      summaryText: "stale summary",
+      summaryUpToMessageId: "msg-5",
+    });
+
+    expect(mockCtx.db.insert).not.toHaveBeenCalled();
+    expect(mockCtx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it("should save a different cutoff message with the same creation time", async () => {
+    const chat = makeChatDoc();
+    setupSaveSummaryQueries(chat, { incomingCutoffCreationTime: 10_000 });
+
+    const oldSummary = makeSummaryDoc({
+      summary_text: "same-ms summary",
+      summary_up_to_message_id: "msg-10",
+      summary_up_to_message_creation_time: 10_000,
+    });
+    mockCtx.db.get.mockResolvedValue(oldSummary);
+
+    const { saveLatestSummary } = await import("../chats");
+
+    await saveLatestSummary.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      chatId: CHAT_ID,
+      summaryText: "new same-ms summary",
+      summaryUpToMessageId: "msg-11",
+    });
+
+    expect(mockCtx.db.insert).toHaveBeenCalledWith(
+      "chat_summaries",
+      expect.objectContaining({
+        summary_up_to_message_id: "msg-11",
+        summary_up_to_message_creation_time: 10_000,
+      }),
+    );
+    expect(mockCtx.db.patch).toHaveBeenCalledWith(CHAT_DOC_ID, {
+      latest_summary_id: "new-summary-id",
+    });
+  });
+
+  it("should skip saves when the incoming cutoff message was deleted", async () => {
+    const chat = makeChatDoc({ latest_summary_id: undefined });
+    setupSaveSummaryQueries(chat, { incomingCutoffCreationTime: null });
+
+    const { saveLatestSummary } = await import("../chats");
+
+    await saveLatestSummary.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      chatId: CHAT_ID,
+      summaryText: "orphaned summary",
+      summaryUpToMessageId: "deleted-msg",
+    });
+
+    expect(mockCtx.db.insert).not.toHaveBeenCalled();
+    expect(mockCtx.db.patch).not.toHaveBeenCalled();
   });
 });
 

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -12,6 +12,18 @@ import { convexLogger } from "./lib/logger";
 const DELETE_ALL_CHATS_MESSAGE_BATCH_SIZE = 10;
 const DELETE_ALL_CHATS_SUMMARY_BATCH_SIZE = 25;
 
+async function getMessageCreationTimeById(
+  ctx: MutationCtx,
+  messageId: string,
+): Promise<number | null> {
+  const message = await ctx.db
+    .query("messages")
+    .withIndex("by_message_id", (q) => q.eq("id", messageId))
+    .first();
+
+  return message?._creationTime ?? null;
+}
+
 async function scheduleDeleteAllChatsBatch(ctx: MutationCtx, userId: string) {
   await ctx.scheduler.runAfter(0, internal.chats.deleteAllChatsBatch, {
     userId,
@@ -1095,39 +1107,100 @@ export const saveLatestSummary = mutation({
         return null;
       }
 
+      const incomingCutoffCreationTime = await getMessageCreationTimeById(
+        ctx,
+        args.summaryUpToMessageId,
+      );
+
+      if (incomingCutoffCreationTime === null) {
+        convexLogger.warn("chat_summary_cutoff_missing", {
+          service: "convex",
+          environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+          chat_id: args.chatId,
+          summary_up_to_message_id: args.summaryUpToMessageId,
+        });
+        return null;
+      }
+
       // Log sizes to help diagnose document limit issues
       const summaryTextSizeKB = Math.round(
         new TextEncoder().encode(args.summaryText).length / 1024,
       );
-      console.log("[saveLatestSummary] Saving summary", {
-        chatId: args.chatId,
-        summaryTextSizeKB,
-        hasPreviousSummary: !!chat.latest_summary_id,
+      convexLogger.info("chat_summary_save_started", {
+        service: "convex",
+        environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+        chat_id: args.chatId,
+        summary_up_to_message_id: args.summaryUpToMessageId,
+        summary_up_to_message_creation_time: incomingCutoffCreationTime,
+        summary_text_size_kb: summaryTextSizeKB,
+        has_previous_summary: !!chat.latest_summary_id,
+        previous_summary_id: chat.latest_summary_id,
       });
 
       let previousSummaries: {
         summary_text: string;
         summary_up_to_message_id: string;
+        summary_up_to_message_creation_time?: number;
       }[] = [];
 
       if (chat.latest_summary_id) {
-        try {
-          const oldSummary = await ctx.db.get(chat.latest_summary_id);
-          if (oldSummary) {
-            previousSummaries = [
-              {
-                summary_text: oldSummary.summary_text,
-                summary_up_to_message_id: oldSummary.summary_up_to_message_id,
-              },
-              ...(oldSummary.previous_summaries ?? []),
-            ].slice(0, MAX_PREVIOUS_SUMMARIES);
+        const oldSummary = await ctx.db.get(chat.latest_summary_id);
+        if (oldSummary) {
+          const oldSummaryWithCreationTime = oldSummary as typeof oldSummary & {
+            summary_up_to_message_creation_time?: number;
+          };
+          const previousSummaryCutoffCreationTime =
+            oldSummaryWithCreationTime.summary_up_to_message_creation_time ??
+            (await getMessageCreationTimeById(
+              ctx,
+              oldSummary.summary_up_to_message_id,
+            ));
+
+          const isStaleSummary =
+            previousSummaryCutoffCreationTime !== null &&
+            (incomingCutoffCreationTime < previousSummaryCutoffCreationTime ||
+              (incomingCutoffCreationTime ===
+                previousSummaryCutoffCreationTime &&
+                args.summaryUpToMessageId ===
+                  oldSummary.summary_up_to_message_id));
+
+          if (isStaleSummary) {
+            convexLogger.info("chat_summary_stale_save_skipped", {
+              service: "convex",
+              environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+              chat_id: args.chatId,
+              incoming_summary_up_to_message_id: args.summaryUpToMessageId,
+              incoming_summary_up_to_message_creation_time:
+                incomingCutoffCreationTime,
+              current_summary_id: chat.latest_summary_id,
+              current_summary_up_to_message_id:
+                oldSummary.summary_up_to_message_id,
+              current_summary_up_to_message_creation_time:
+                previousSummaryCutoffCreationTime,
+            });
+            return null;
           }
-          await ctx.db.patch(chat._id, {
-            latest_summary_id: undefined,
+
+          previousSummaries = [
+            {
+              summary_text: oldSummary.summary_text,
+              summary_up_to_message_id: oldSummary.summary_up_to_message_id,
+              ...(previousSummaryCutoffCreationTime !== null
+                ? {
+                    summary_up_to_message_creation_time:
+                      previousSummaryCutoffCreationTime,
+                  }
+                : undefined),
+            },
+            ...(oldSummary.previous_summaries ?? []),
+          ].slice(0, MAX_PREVIOUS_SUMMARIES);
+        } else {
+          convexLogger.warn("chat_summary_latest_missing", {
+            service: "convex",
+            environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+            chat_id: args.chatId,
+            latest_summary_id: chat.latest_summary_id,
           });
-          await ctx.db.delete(chat.latest_summary_id);
-        } catch (error) {
-          // Continue anyway - old summary cleanup is not critical
         }
       }
 
@@ -1138,18 +1211,23 @@ export const saveLatestSummary = mutation({
           0,
         ) / 1024,
       );
-      console.log("[saveLatestSummary] Document sizes", {
-        chatId: args.chatId,
-        summaryTextSizeKB,
-        previousSummariesCount: previousSummaries.length,
-        previousSummariesTotalSizeKB,
-        estimatedTotalSizeKB: summaryTextSizeKB + previousSummariesTotalSizeKB,
+      convexLogger.info("chat_summary_document_sized", {
+        service: "convex",
+        environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+        chat_id: args.chatId,
+        summary_up_to_message_id: args.summaryUpToMessageId,
+        summary_text_size_kb: summaryTextSizeKB,
+        previous_summaries_count: previousSummaries.length,
+        previous_summaries_total_size_kb: previousSummariesTotalSizeKB,
+        estimated_total_size_kb:
+          summaryTextSizeKB + previousSummariesTotalSizeKB,
       });
 
       const summaryId = await ctx.db.insert("chat_summaries", {
         chat_id: args.chatId,
         summary_text: args.summaryText,
         summary_up_to_message_id: args.summaryUpToMessageId,
+        summary_up_to_message_creation_time: incomingCutoffCreationTime,
         previous_summaries: previousSummaries,
       });
 
@@ -1159,11 +1237,25 @@ export const saveLatestSummary = mutation({
         latest_summary_id: summaryId,
       });
 
+      convexLogger.info("chat_summary_saved", {
+        service: "convex",
+        environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+        chat_id: args.chatId,
+        summary_id: summaryId,
+        summary_up_to_message_id: args.summaryUpToMessageId,
+        summary_up_to_message_creation_time: incomingCutoffCreationTime,
+        previous_summary_id: chat.latest_summary_id,
+        previous_summaries_count: previousSummaries.length,
+      });
+
       return null;
     } catch (error) {
-      console.error("[saveLatestSummary] Failed to save chat summary:", {
-        chatId: args.chatId,
-        summaryTextLength: args.summaryText.length,
+      convexLogger.error("chat_summary_save_failed", {
+        service: "convex",
+        environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+        chat_id: args.chatId,
+        summary_up_to_message_id: args.summaryUpToMessageId,
+        summary_text_length: args.summaryText.length,
         error: error instanceof Error ? error.message : String(error),
       });
       throw error;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -55,11 +55,13 @@ export default defineSchema({
     chat_id: v.string(),
     summary_text: v.string(),
     summary_up_to_message_id: v.string(),
+    summary_up_to_message_creation_time: v.optional(v.number()),
     previous_summaries: v.optional(
       v.array(
         v.object({
           summary_text: v.string(),
           summary_up_to_message_id: v.string(),
+          summary_up_to_message_creation_time: v.optional(v.number()),
         }),
       ),
     ),


### PR DESCRIPTION
## Summary

Fixes a Convex optimistic concurrency race in chat summary persistence.

`saveLatestSummary` previously read the existing summary document, cleared the chat reference, deleted the old summary, inserted a new summary, then patched the chat. Overlapping summary saves for the same chat could repeatedly touch the same `chat_summaries` document and trigger Convex retry conflicts.

This PR makes the save path append-only for prior summaries, stores cutoff message creation time for ordering, and skips stale late-arriving summary saves. It also adds structured `chat_summary_*` logs so future incidents can be filtered by `chat_id` and cutoff metadata.

## Validation

- `pnpm test -- convex/__tests__/chatSummaryFallback.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec prettier --check convex/chats.ts convex/schema.ts convex/__tests__/chatSummaryFallback.test.ts`
- pre-commit hook: full `pnpm test` suite, 91 suites / 1137 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale chat summaries from overwriting newer ones and improved handling when referenced messages are deleted or missing; adds per-summary cutoff timestamps for more accurate preservation.

* **Tests**
  * Expanded test coverage for summary-save behavior, including deleted-cutoff and equal-timestamp edge cases; improved test setup and noise suppression.

* **Chores**
  * Updated data schema to store optional per-summary creation times.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->