### PR TITLE
[codex] Add Grok fallback for Kimi agent model

### DIFF
--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -31,7 +31,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("resolves Opus 4.6 agent chain to Kimi slug", () => {
+  it("resolves Opus 4.6 agent chain to Kimi then Grok slugs", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -39,7 +39,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG],
+      models: [KIMI_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
@@ -57,7 +57,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("resolves Sonnet 4.6 agent chain to Kimi slug", () => {
+  it("resolves Sonnet 4.6 agent chain to Kimi then Grok slugs", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -65,7 +65,28 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG],
+      models: [KIMI_SLUG, GROK_SLUG],
+      user: "user-1",
+    });
+  });
+
+  it("falls back from auto agent Kimi to Grok", () => {
+    const opts = buildProviderOptions(false, "user-1", "agent-model", "agent");
+    expect(opts.openrouter).toMatchObject({
+      models: [GROK_SLUG],
+      user: "user-1",
+    });
+  });
+
+  it("falls back from explicit Kimi to Grok", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-kimi-k2.6",
+      "agent",
+    );
+    expect(opts.openrouter).toMatchObject({
+      models: [GROK_SLUG],
       user: "user-1",
     });
   });
@@ -108,7 +129,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(reasoning.openrouter).toMatchObject({
       reasoning: { enabled: true },
-      models: [KIMI_SLUG],
+      models: [KIMI_SLUG, GROK_SLUG],
     });
 
     const noReasoning = buildProviderOptions(
@@ -119,7 +140,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(noReasoning.openrouter).toMatchObject({
       reasoning: { enabled: false },
-      models: [KIMI_SLUG],
+      models: [KIMI_SLUG, GROK_SLUG],
     });
   });
 });

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -465,12 +465,14 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "agent-model-free": ["fallback-agent-model"],
   "model-deepseek-v4-flash": ["fallback-ask-model"],
   "ask-model": ["fallback-grok-4.3"],
+  "agent-model": ["fallback-grok-4.3"],
   "model-gemini-3-flash": ["fallback-grok-4.3"],
+  "model-kimi-k2.6": ["fallback-grok-4.3"],
 };
 
 const ANTHROPIC_FALLBACK_CHAIN_BY_MODE: Record<ChatMode, readonly ModelName[]> =
   {
-    agent: ["model-kimi-k2.6"],
+    agent: ["model-kimi-k2.6", "fallback-grok-4.3"],
     ask: ["model-gemini-3-flash"],
   };
 


### PR DESCRIPTION
## Summary

Adds Grok 4.3 as the OpenRouter fallback for Kimi-backed agent models.

## Why

Kimi/OpenRouter can fail with upstream streaming timeouts while an agent response or tool call is in flight. Adding `x-ai/grok-4.3` to the fallback chain gives auto agent and explicit Kimi runs another provider/model path instead of failing immediately.

## Changes

- Route `agent-model` fallback to `fallback-grok-4.3`.
- Route explicit `model-kimi-k2.6` fallback to `fallback-grok-4.3`.
- Extend Anthropic agent fallback from `Kimi` to `Kimi -> Grok`.
- Update fallback-chain tests for the new model routing.

## Validation

- `pnpm test -- lib/api/__tests__/chat-stream-helpers-fallback.test.ts --runInBand`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model fallback routing for agent operations with support for cascade failover to additional models when primary selection is unavailable.

* **Tests**
  * Updated test coverage for multi-model fallback scenarios in agent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->