### PR TITLE
[codex] track authenticated checkout funnel

### DIFF
--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -21,6 +21,8 @@ export const POST = async (req: NextRequest) => {
     const body = await req.json().catch(() => ({}));
     const requestedPlan: string | undefined = body?.plan;
     const requestedQuantity: number | undefined = body?.quantity;
+    const posthogDistinctId = req.headers.get("x-posthog-distinct-id");
+    const posthogSessionId = req.headers.get("x-posthog-session-id");
     // Get user ID from authenticated session
     const userId = await getUserID(req);
 
@@ -234,6 +236,8 @@ export const POST = async (req: NextRequest) => {
       stripe_customer_id: customer.id,
       stripe_checkout_session_id: session.id,
       stripe_price_id: selectedPrice.id,
+      client_distinct_id: posthogDistinctId ?? undefined,
+      $session_id: posthogSessionId ?? undefined,
       $set: {
         last_checkout_started_at: new Date().toISOString(),
       },

--- a/app/hooks/usePricingDialog.ts
+++ b/app/hooks/usePricingDialog.ts
@@ -1,8 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { SubscriptionTier } from "@/types";
+import { captureAuthenticatedEvent } from "@/lib/analytics/client";
 
 export const usePricingDialog = (subscription?: SubscriptionTier) => {
   const [showPricing, setShowPricing] = useState(false);
+  const capturedPricingViewRef = useRef(false);
 
   useEffect(() => {
     // Check if URL hash is #pricing
@@ -22,6 +24,20 @@ export const usePricingDialog = (subscription?: SubscriptionTier) => {
       }
 
       setShowPricing(shouldShow);
+      if (!shouldShow) {
+        capturedPricingViewRef.current = false;
+        return;
+      }
+
+      if (!capturedPricingViewRef.current) {
+        if (
+          captureAuthenticatedEvent("pricing_viewed", {
+            subscription,
+          })
+        ) {
+          capturedPricingViewRef.current = true;
+        }
+      }
     };
 
     // Check on mount

--- a/app/hooks/useUpgrade.ts
+++ b/app/hooks/useUpgrade.ts
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { toast } from "sonner";
+import {
+  captureAuthenticatedEvent,
+  getPostHogRequestHeaders,
+} from "@/lib/analytics/client";
 
 export const useUpgrade = () => {
   const { user } = useAuth();
@@ -35,8 +39,9 @@ export const useUpgrade = () => {
     setUpgradeLoading(true);
 
     try {
+      const selectedPlan = planKey || "pro-monthly-plan";
       const requestBody: { plan: string; quantity?: number } = {
-        plan: planKey || "pro-monthly-plan",
+        plan: selectedPlan,
       };
 
       // Add quantity for team plans
@@ -46,10 +51,18 @@ export const useUpgrade = () => {
 
       // Use regular checkout for new subscriptions (free users)
       if (!currentSubscription || currentSubscription === "free") {
+        captureAuthenticatedEvent("checkout_intent_clicked", {
+          plan: selectedPlan,
+          quantity,
+          from_tier: currentSubscription ?? "free",
+          checkout_type: "new_subscription",
+        });
+
         const res = await fetch("/api/subscribe", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
+            ...getPostHogRequestHeaders(),
           },
           body: JSON.stringify(requestBody),
         });
@@ -66,6 +79,12 @@ export const useUpgrade = () => {
         const { error, url } = data;
 
         if (url) {
+          captureAuthenticatedEvent("checkout_redirected", {
+            plan: selectedPlan,
+            quantity,
+            from_tier: currentSubscription ?? "free",
+            checkout_type: "new_subscription",
+          });
           window.location.href = url;
           return;
         }
@@ -78,10 +97,18 @@ export const useUpgrade = () => {
       } else {
         // For existing subscribers, use immediate subscription update
         // This prevents the "free credit" exploit
+        captureAuthenticatedEvent("subscription_change_intent_clicked", {
+          plan: selectedPlan,
+          quantity,
+          from_tier: currentSubscription,
+          checkout_type: "subscription_change",
+        });
+
         const res = await fetch("/api/subscription-details", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
+            ...getPostHogRequestHeaders(),
           },
           body: JSON.stringify({
             plan: planKey,

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -61,15 +61,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
 
-    // Determine if we should track this user:
-    // - By default (env not set): only track paid users (pro, ultra, team)
-    // - If NEXT_PUBLIC_POSTHOG_TRACK_FREE_USERS=true: only track free users
-    const trackFreeUsers =
-      process.env.NEXT_PUBLIC_POSTHOG_TRACK_FREE_USERS === "true";
-    const isPaidUser = subscription !== "free";
-
-    const shouldTrack =
-      Boolean(user) && (trackFreeUsers ? !isPaidUser : isPaidUser);
+    const shouldTrack = Boolean(user);
 
     if (!shouldTrack) {
       if (posthog.__loaded) {

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import posthog from "posthog-js";
+
+type ClientAnalyticsProperties = Record<string, unknown>;
+
+type PostHogWithSession = typeof posthog & {
+  get_session_id?: () => string;
+};
+
+function isPostHogReady() {
+  return Boolean(posthog.__loaded);
+}
+
+export function captureAuthenticatedEvent(
+  event: string,
+  properties: ClientAnalyticsProperties = {},
+) {
+  if (!isPostHogReady()) return false;
+
+  try {
+    posthog.capture(event, properties);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getPostHogRequestHeaders(): HeadersInit {
+  if (!isPostHogReady()) return {};
+
+  const posthogWithSession = posthog as PostHogWithSession;
+  const distinctId = posthog.get_distinct_id();
+  const sessionId = posthogWithSession.get_session_id?.();
+
+  return {
+    ...(distinctId && { "X-POSTHOG-DISTINCT-ID": distinctId }),
+    ...(sessionId && { "X-POSTHOG-SESSION-ID": sessionId }),
+  };
+}


### PR DESCRIPTION
## Summary

- Track authenticated-only pricing and checkout funnel milestones in PostHog.
- Capture `pricing_viewed`, `checkout_intent_clicked`, `checkout_redirected`, and `subscription_change_intent_clicked` without anonymous pageviews, referrer, URL, or UTM payloads.
- Pass PostHog distinct/session headers into subscription checkout so the existing server-side `checkout_started` event can stitch back to the authenticated client session.
- Initialize client-side PostHog for authenticated users instead of only the prior paid/free toggle subset.

## Why

This keeps analytics focused on founder-useful paid funnel questions without adding anonymous traffic volume or low-signal CTA/source tracking.

## Validation

- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- Pre-commit hook: `prettier --write`, `eslint --fix`, `pnpm typecheck`, full `pnpm test` (`91` suites / `1135` tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved analytics tracking across pricing and subscription features to capture user intent and engagement metrics throughout checkout and upgrade journeys
  * Enhanced telemetry by adding session and identity context to checkout and subscription workflows for more accurate user tracking and insights
  * Simplified analytics configuration to prioritize tracking of authenticated user activity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->