### PR TITLE
Verify real S3 object size when saving uploads

### DIFF
--- a/convex/__tests__/fileActions.upload-policy.test.ts
+++ b/convex/__tests__/fileActions.upload-policy.test.ts
@@ -47,6 +47,7 @@ jest.mock("../_generated/api", () => ({
 
 jest.mock("../s3Utils", () => ({
   generateS3DownloadUrl: jest.fn(),
+  getS3ObjectSizeBytes: jest.fn(),
 }));
 
 jest.mock("pdfjs-serverless", () => ({
@@ -87,9 +88,19 @@ describe("fileActions saveFile upload policy", () => {
     delete process.env.UPSTASH_REDIS_REST_TOKEN;
     global.fetch = jest.fn() as any;
 
-    const { generateS3DownloadUrl } = await import("../s3Utils");
+    const { generateS3DownloadUrl, getS3ObjectSizeBytes } =
+      await import("../s3Utils");
     (generateS3DownloadUrl as jest.Mock).mockResolvedValue(
       "https://s3.example/download",
+    );
+    (getS3ObjectSizeBytes as jest.Mock).mockImplementation(
+      async (s3Key: string) => {
+        if (s3Key.includes("large.bin")) return 21 * 1024 * 1024;
+        if (s3Key.includes("large.png")) return 8 * 1024 * 1024;
+        if (s3Key.includes("archive.zip")) return 25 * 1024 * 1024;
+        if (s3Key.includes("huge.bin")) return 251 * 1024 * 1024;
+        return 1024;
+      },
     );
   });
 

--- a/convex/__tests__/fileActions.upload-policy.test.ts
+++ b/convex/__tests__/fileActions.upload-policy.test.ts
@@ -78,6 +78,7 @@ describe("fileActions saveFile upload policy", () => {
       storage: {
         delete: jest.fn().mockResolvedValue(undefined),
         getUrl: jest.fn().mockResolvedValue("https://storage.example/file"),
+        getMetadata: jest.fn().mockResolvedValue({ size: 1024 }),
       },
       runMutation: jest.fn().mockResolvedValue("file_123"),
     }) as any;
@@ -129,6 +130,29 @@ describe("fileActions saveFile upload policy", () => {
       "internal.s3Cleanup.deleteS3ObjectAction",
       { s3Key: "users/user123/large.bin" },
     );
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("rejects storageId uploads based on storage metadata, not client size", async () => {
+    const { saveFile } = await import("../fileActions");
+    const ctx = makeCtx();
+    ctx.storage.getMetadata.mockResolvedValueOnce({ size: 21 * 1024 * 1024 });
+
+    await expect(
+      saveFile.handler(ctx, {
+        storageId: "storage_large_bin",
+        name: "large.bin",
+        mediaType: "application/octet-stream",
+        size: 1024,
+        mode: "ask",
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({ code: "FILE_SIZE_EXCEEDED" }),
+    });
+
+    expect(ctx.storage.getMetadata).toHaveBeenCalledWith("storage_large_bin");
+    expect(ctx.storage.delete).toHaveBeenCalledWith("storage_large_bin");
     expect(global.fetch).not.toHaveBeenCalled();
     expect(ctx.runMutation).not.toHaveBeenCalled();
   });

--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -705,6 +705,29 @@ export const saveFile = action({
           message: `Failed to upload ${args.name}: File not found in storage`,
         });
       }
+    } else if (args.storageId) {
+      try {
+        const metadata = await ctx.storage.getMetadata(args.storageId);
+        if (!metadata) {
+          throw new Error("Storage metadata not found");
+        }
+        verifiedSize = metadata.size;
+      } catch (error) {
+        convexLogger.error("file_upload_storage_metadata_fetch_failed", {
+          userId: actingUserId,
+          fileName: args.name,
+          storageId: args.storageId,
+          mode: args.mode,
+          error:
+            error instanceof Error
+              ? { name: error.name, message: error.message }
+              : String(error),
+        });
+        throw new ConvexError({
+          code: "FILE_NOT_FOUND",
+          message: `Failed to upload ${args.name}: File not found in storage`,
+        });
+      }
     }
 
     const uploadLimits = getUploadLimitsForMode(args.mode, {

--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -21,7 +21,7 @@ import mammoth from "mammoth";
 import WordExtractor from "word-extractor";
 import { isBinaryFile } from "isbinaryfile";
 import { internal } from "./_generated/api";
-import { generateS3DownloadUrl } from "./s3Utils";
+import { generateS3DownloadUrl, getS3ObjectSizeBytes } from "./s3Utils";
 import { convexLogger } from "./lib/logger";
 import type {
   FileItemChunk,
@@ -685,12 +685,34 @@ export const saveFile = action({
     // Token was already consumed at URL generation step
     await checkFileUploadRateLimit(actingUserId, false);
 
+    let verifiedSize = args.size;
+    if (args.s3Key) {
+      try {
+        verifiedSize = await getS3ObjectSizeBytes(args.s3Key);
+      } catch (error) {
+        convexLogger.error("file_upload_s3_metadata_fetch_failed", {
+          userId: actingUserId,
+          fileName: args.name,
+          s3Key: args.s3Key,
+          mode: args.mode,
+          error:
+            error instanceof Error
+              ? { name: error.name, message: error.message }
+              : String(error),
+        });
+        throw new ConvexError({
+          code: "FILE_NOT_FOUND",
+          message: `Failed to upload ${args.name}: File not found in storage`,
+        });
+      }
+    }
+
     const uploadLimits = getUploadLimitsForMode(args.mode, {
       surface: "backend",
     });
     const uploadValidation = validateUploadPolicy({
       mode: args.mode,
-      size: args.size,
+      size: verifiedSize,
       mediaType: args.mediaType,
       surface: "backend",
     });
@@ -727,7 +749,7 @@ export const saveFile = action({
       }
       throw new ConvexError({
         code: "FILE_SIZE_EXCEEDED",
-        message: `File "${args.name}" exceeds the maximum file size limit of ${uploadLimits.maxFileSizeBytes / (1024 * 1024)} MB. Current size: ${(args.size / (1024 * 1024)).toFixed(2)} MB`,
+        message: `File "${args.name}" exceeds the maximum file size limit of ${uploadLimits.maxFileSizeBytes / (1024 * 1024)} MB. Current size: ${(verifiedSize / (1024 * 1024)).toFixed(2)} MB`,
       });
     }
 
@@ -760,7 +782,7 @@ export const saveFile = action({
       }
       throw new ConvexError({
         code: "IMAGE_SIZE_EXCEEDED",
-        message: `Image "${args.name}" exceeds the maximum image size limit of ${uploadLimits.maxProviderImageSizeBytes / (1024 * 1024)} MB. Current size: ${(args.size / (1024 * 1024)).toFixed(2)} MB`,
+        message: `Image "${args.name}" exceeds the maximum image size limit of ${uploadLimits.maxProviderImageSizeBytes / (1024 * 1024)} MB. Current size: ${(verifiedSize / (1024 * 1024)).toFixed(2)} MB`,
       });
     }
 
@@ -790,7 +812,7 @@ export const saveFile = action({
         convexLogger.info("agent_file_upload_saved_without_processing", {
           userId: actingUserId,
           fileName: args.name,
-          size: args.size,
+          size: verifiedSize,
           mediaType: args.mediaType,
           mode: args.mode,
         });
@@ -981,7 +1003,7 @@ export const saveFile = action({
       userId: actingUserId,
       name: args.name,
       mediaType: args.mediaType,
-      size: args.size,
+      size: verifiedSize,
       fileTokenSize: tokenSize,
       content: fileContent,
     })) as Id<"files">;

--- a/convex/s3Utils.ts
+++ b/convex/s3Utils.ts
@@ -3,6 +3,7 @@ import {
   PutObjectCommand,
   GetObjectCommand,
   DeleteObjectCommand,
+  HeadObjectCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { v4 as uuidv4 } from "uuid";
@@ -133,6 +134,33 @@ export async function deleteS3Object(s3Key: string): Promise<void> {
     console.error("Failed to delete S3 object:", error);
     throw new Error(
       "Failed to delete S3 object: " +
+        (error instanceof Error ? error.message : "Unknown error"),
+    );
+  }
+}
+
+/**
+ * Get S3 object size in bytes.
+ */
+export async function getS3ObjectSizeBytes(s3Key: string): Promise<number> {
+  try {
+    const s3Client = getS3Client();
+    const bucketName = getRequiredEnvVar("AWS_S3_BUCKET_NAME");
+
+    const command = new HeadObjectCommand({
+      Bucket: bucketName,
+      Key: s3Key,
+    });
+
+    const result = await s3Client.send(command);
+    if (typeof result.ContentLength !== "number") {
+      throw new Error("S3 object ContentLength is missing");
+    }
+    return result.ContentLength;
+  } catch (error) {
+    console.error("Failed to fetch S3 object metadata:", error);
+    throw new Error(
+      "Failed to fetch S3 object metadata: " +
         (error instanceof Error ? error.message : "Unknown error"),
     );
   }


### PR DESCRIPTION
### Motivation
- The Agent upload flow trusted client-provided `size` when issuing presigned PUT URLs and when saving metadata, allowing an attacker to underreport size and bypass per-user quotas and the `MAX_AGENT_FILE_SIZE_BYTES` cap.  
- The backend skipped fetching Agent-mode S3 objects, so storage/accounting and upload-policy checks were not based on authoritative S3 metadata.

### Description
- Add `getS3ObjectSizeBytes` which issues an S3 `HeadObject` to read `ContentLength` in `convex/s3Utils.ts`.  
- In `convex/fileActions.ts` fetch S3 metadata when `args.s3Key` is present and set a `verifiedSize` from S3, falling back to `args.size` when not applicable.  
- Run upload policy validation against `verifiedSize` and persist `verifiedSize` to the DB via the existing `saveFileToDb` call so quota/accounting use authoritative values.  
- Update unit tests to mock `getS3ObjectSizeBytes` behavior in `convex/__tests__/fileActions.upload-policy.test.ts` to preserve deterministic test scenarios.

### Testing
- Ran the targeted test file with `pnpm -s jest convex/__tests__/fileActions.upload-policy.test.ts --runInBand` and it passed (6/6 tests).  
- Ran the full test suite via the project test hook (`pnpm test`) and all tests passed (`91` suites, `1147` tests).  
- Type-check (`tsc --noEmit`) completed successfully during the commit hooks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1477e9a010833284f299e1f62bd931)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Uploads now verify file size using the authoritative storage object metadata (when available) before policy checks, improving enforcement and preventing client-reported size spoofing. Missing remote metadata produces a clear file-not-found error and logs context.
* **Tests**
  * Added tests ensuring storage-backed uploads reject client-provided sizes, cleanup occurs, and no unexpected network or DB actions run.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->