### PR TITLE
Restrict file URL processing to trusted fileId-backed attachments

### DIFF
--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -74,6 +74,7 @@ describe("processMessageFiles image size guards", () => {
       makeMessage({
         type: "file",
         mediaType: "image/png",
+        fileId: "file_huge",
         name: "huge.png",
         url: "https://example.com/huge.png",
       }),
@@ -107,6 +108,7 @@ describe("processMessageFiles image size guards", () => {
       makeMessage({
         type: "file",
         mediaType: "image/png",
+        fileId: "file_unknown",
         name: "unknown-size.png",
         url: "https://example.com/unknown-size.png",
       }),
@@ -132,6 +134,7 @@ describe("processMessageFiles image size guards", () => {
       makeMessage({
         type: "file",
         mediaType: "image/png",
+        fileId: "file_small",
         name: "small.png",
         url: "https://example.com/small.png",
       }),
@@ -145,6 +148,30 @@ describe("processMessageFiles image size guards", () => {
       mediaType: "image/png",
       name: "small.png",
       url: "https://example.com/small.png",
+    });
+  });
+
+  it("does not probe or convert inline URL file parts without fileId", async () => {
+    const fetchSpy = jest.fn();
+    global.fetch = fetchSpy as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        mediaType: "application/pdf",
+        name: "inline.pdf",
+        url: "https://example.com/inline.pdf",
+      }),
+      "ask",
+      undefined,
+      "pro",
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.messages[0].parts[1]).toMatchObject({
+      type: "file",
+      mediaType: "application/pdf",
+      url: "https://example.com/inline.pdf",
     });
   });
 

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -234,8 +234,8 @@ const collectFilesToProcess = (
           typeof part.fileId === "string" ? part.fileId : undefined;
         const url =
           typeof (part as any).url === "string" ? (part as any).url : undefined;
-        const key = fileId ? `file:${fileId}` : url ? `url:${url}` : null;
-        if (!key) return;
+        if (!fileId) return;
+        const key = `file:${fileId}`;
 
         if (!files.has(key)) {
           files.set(key, {


### PR DESCRIPTION
### Motivation

- Fix an SSRF/data-exfiltration risk where inline `url`‑only file parts could be fetched or probed server-side (PDF conversion and image HEAD/ranged GETs). 
- Ensure only backend-trusted uploads are eligible for server-side fetching/probing rather than arbitrary user-supplied URLs. 
- Preserve existing behavior for legitimately uploaded files that have a backend `fileId`.

### Description

- Require a backend `fileId` in `collectFilesToProcess` and stop using `url:<user-url>` as a processing key so inline URL-only file parts are ignored by server-side fetch/probe logic. 
- Keep `file.url` handling and existing provider/image probing paths intact for trusted `fileId`-backed files so sandboxing and agent flows are unaffected. 
- Update tests in `lib/utils/__tests__/file-transform-utils.test.ts` to use `fileId` for URL-backed image fixtures and add a regression test asserting inline URL-only PDFs are not fetched or converted server-side.

### Testing

- Ran the focused test file with `pnpm jest lib/utils/__tests__/file-transform-utils.test.ts --runInBand` and all tests passed. 
- Ran the full pre-commit suite which includes `tsc --noEmit` and the full `jest` run and observed all test suites passing. 
- The changes are minimal and targeted to `collectFilesToProcess` to prevent untrusted URL fetch/probing while preserving existing trusted `fileId` workflows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1477fd4ee48332a50099d9b133d716)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unintended network calls when processing certain file types without identifiers.

* **Tests**
  * Improved test coverage for image size validation with consistent file identifiers.
  * Added test to verify no network requests occur for inline URL files without identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->