### PR TITLE
Reinstate trust-based extra-usage cap enforcement

### DIFF
--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -455,28 +455,28 @@ export const deductPoints = mutation({
       monthlySpentPoints = 0;
     }
 
-    // Compute effective monthly cap from the user-set cap only. The
-    // trust-based protection cap (for example the default $100/month cap) is
-    // intentionally ignored for now.
+    // Compute effective monthly cap: lower of user-set cap and trust-based cap
     const userCapPoints = settings.monthly_cap_points;
-    let effectiveCapPoints = userCapPoints;
-
-    // TEMPORARY TRUST-CAP BYPASS:
-    // Restore this block if HackerAI's own trust-based protection caps should
-    // be combined with user-set monthly spending limits again.
-    /*
     const { capDollars: trustCapDollars } = computeExtraUsageCap(settings);
     const trustCapPoints =
       trustCapDollars !== null ? dollarsToPoints(trustCapDollars) : undefined;
 
-    if (effectiveCapPoints !== undefined && trustCapPoints !== undefined) {
-      effectiveCapPoints = Math.min(effectiveCapPoints, trustCapPoints);
+    // Use the most restrictive cap (lowest non-undefined value)
+    let effectiveCapPoints: number | undefined;
+    if (userCapPoints !== undefined && trustCapPoints !== undefined) {
+      effectiveCapPoints = Math.min(userCapPoints, trustCapPoints);
     } else {
-      effectiveCapPoints = effectiveCapPoints ?? trustCapPoints;
+      effectiveCapPoints = userCapPoints ?? trustCapPoints;
     }
-    */
 
-    // Check user-set monthly spending cap before deducting
+    // Determine which cap triggered (for frontend error messaging)
+    const isTrustCap =
+      effectiveCapPoints !== undefined &&
+      trustCapPoints !== undefined &&
+      effectiveCapPoints === trustCapPoints &&
+      (userCapPoints === undefined || trustCapPoints <= userCapPoints);
+
+    // Check monthly spending cap before deducting
     if (effectiveCapPoints !== undefined) {
       const newMonthlySpent = monthlySpentPoints + args.amountPoints;
       if (newMonthlySpent > effectiveCapPoints) {
@@ -485,7 +485,9 @@ export const deductPoints = mutation({
           amount_points: args.amountPoints,
           monthly_spent_points: monthlySpentPoints,
           effective_cap_points: effectiveCapPoints,
-          reason: "monthly_cap_exceeded",
+          trust_cap_dollars: trustCapDollars,
+          is_trust_cap: isTrustCap,
+          reason: isTrustCap ? "trust_cap_exceeded" : "monthly_cap_exceeded",
           monthly_cap_exceeded: true,
         });
         return {
@@ -494,7 +496,8 @@ export const deductPoints = mutation({
           newBalanceDollars: pointsToDollars(currentBalancePoints),
           insufficientFunds: true,
           monthlyCapExceeded: true,
-          trustCapExceeded: false,
+          trustCapExceeded: isTrustCap,
+          trustCapDollars: isTrustCap ? trustCapDollars : undefined,
         };
       }
     }

--- a/convex/teamExtraUsage.ts
+++ b/convex/teamExtraUsage.ts
@@ -267,25 +267,24 @@ export const deductTeamPoints = mutation({
       memberMonthlySpent = 0;
     }
 
-    // Compute effective team cap from the admin-set cap only. The trust-based
-    // protection cap is intentionally ignored for now.
+    // Compute effective team cap (user-set vs trust)
     const teamCap = team.monthly_cap_points;
-    let effectiveTeamCap = teamCap;
-
-    // TEMPORARY TRUST-CAP BYPASS:
-    // Restore this block if HackerAI's own trust-based protection caps should
-    // be combined with admin-set team spending limits again.
-    /*
     const { capDollars: trustCapDollars } = computeExtraUsageCap(team);
     const trustCapPoints =
       trustCapDollars !== null ? dollarsToPoints(trustCapDollars) : undefined;
 
-    if (effectiveTeamCap !== undefined && trustCapPoints !== undefined) {
-      effectiveTeamCap = Math.min(effectiveTeamCap, trustCapPoints);
+    let effectiveTeamCap: number | undefined;
+    if (teamCap !== undefined && trustCapPoints !== undefined) {
+      effectiveTeamCap = Math.min(teamCap, trustCapPoints);
     } else {
-      effectiveTeamCap = effectiveTeamCap ?? trustCapPoints;
+      effectiveTeamCap = teamCap ?? trustCapPoints;
     }
-    */
+
+    const isTrustCap =
+      effectiveTeamCap !== undefined &&
+      trustCapPoints !== undefined &&
+      effectiveTeamCap === trustCapPoints &&
+      (teamCap === undefined || trustCapPoints <= teamCap);
 
     // Team monthly cap check
     if (effectiveTeamCap !== undefined) {
@@ -300,7 +299,8 @@ export const deductTeamPoints = mutation({
           memberCapExceeded: false,
           memberDisabled: false,
           poolDisabled: false,
-          trustCapExceeded: false,
+          trustCapExceeded: isTrustCap,
+          trustCapDollars: isTrustCap ? trustCapDollars : undefined,
         };
       }
     }


### PR DESCRIPTION
### Motivation
- A recent change commented out trust-based and monthly cap enforcement in the extra-usage deduction paths while still decrementing balances, allowing spending to proceed past configured or trust-derived limits and risking unexpected auto-reload charges.
- The fix restores the intended protection so admin-configured team caps, per-member caps, and default trust caps are enforced before deductions occur.

### Description
- Restored combined effective-cap computation and enforcement in `convex/extraUsage.ts` so personal monthly caps and trust-based caps are computed and the most restrictive cap is applied before deducting points.
- Restored combined effective-team-cap computation and enforcement in `convex/teamExtraUsage.ts` so team monthly caps, trust-based caps, and per-member limits are enforced before committing deductions.
- Reinstated trust-cap metadata and logging fields (`trustCapExceeded`, `trustCapDollars`, `is_trust_cap`, `trust_cap_dollars`) so callers and logs can distinguish trust-cap failures from configured monthly-cap failures.
- Maintained existing behaviour for insufficient funds, disabled pools/members, and per-member admin-configured limits while making the cap logic conservative (choose the lowest non-undefined cap).

### Testing
- Ran the full TypeScript check with `tsc --noEmit`, which succeeded.
- Ran the full test suite with `jest`, which passed (all tests green).
- Ran the targeted team tests `pnpm jest convex/__tests__/teamExtraUsage.test.ts --runInBand --no-cache`, which passed and validated expected cap-enforcement behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1479bbb33c833298137d2b8f98e75a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spending cap enforcement to incorporate trust-based limits alongside user-set monthly caps for both individual and team accounts.
  * Improved error reporting to accurately identify which spending limit (trust-based or user-set) was exceeded and include relevant cap details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->