### PR TITLE
Guard refunds in agent-long outer catch to avoid refunding after observed usage

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -179,10 +179,19 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     const liveUsagePredicateIdx = taskSrc.indexOf(
       "const hasObservedUsage = () => !!observedUsageTracker?.hasUsage",
     );
+    const cleanupMapIdx = taskSrc.indexOf(
+      "runCleanupMap.set(ctx.run.id",
+      liveUsagePredicateIdx,
+    );
     const refundGuardIdx = taskSrc.indexOf("if (!hasObservedUsage())");
+    const cancelRefundGuardIdx = taskSrc.indexOf(
+      "if (!cleanup.hasObservedUsage())",
+    );
 
     expect(liveUsagePredicateIdx).toBeGreaterThan(-1);
+    expect(cleanupMapIdx).toBeGreaterThan(liveUsagePredicateIdx);
     expect(refundGuardIdx).toBeGreaterThan(liveUsagePredicateIdx);
+    expect(cancelRefundGuardIdx).toBeGreaterThan(-1);
     expect(taskSrc).not.toMatch(/hasObservedUsage\s*=\s*hasObservedUsage/);
   });
 

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -184,14 +184,22 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       liveUsagePredicateIdx,
     );
     const refundGuardIdx = taskSrc.indexOf("if (!hasObservedUsage())");
+    const onCancelIdx = taskSrc.indexOf("onCancel: async");
     const cancelRefundGuardIdx = taskSrc.indexOf(
       "if (!cleanup.hasObservedUsage())",
+      onCancelIdx,
+    );
+    const cancelRefundIdx = taskSrc.indexOf(
+      "cleanup.usageRefundTracker.refund()",
+      onCancelIdx,
     );
 
     expect(liveUsagePredicateIdx).toBeGreaterThan(-1);
     expect(cleanupMapIdx).toBeGreaterThan(liveUsagePredicateIdx);
     expect(refundGuardIdx).toBeGreaterThan(liveUsagePredicateIdx);
-    expect(cancelRefundGuardIdx).toBeGreaterThan(-1);
+    expect(onCancelIdx).toBeGreaterThan(-1);
+    expect(cancelRefundGuardIdx).toBeGreaterThan(onCancelIdx);
+    expect(cancelRefundIdx).toBeGreaterThan(cancelRefundGuardIdx);
     expect(taskSrc).not.toMatch(/hasObservedUsage\s*=\s*hasObservedUsage/);
   });
 

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -175,6 +175,17 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(throwIdx).toBeGreaterThan(terminalErrorIdx);
   });
 
+  test("outer catch checks live usage tracker before refunding", () => {
+    const liveUsagePredicateIdx = taskSrc.indexOf(
+      "const hasObservedUsage = () => !!observedUsageTracker?.hasUsage",
+    );
+    const refundGuardIdx = taskSrc.indexOf("if (!hasObservedUsage())");
+
+    expect(liveUsagePredicateIdx).toBeGreaterThan(-1);
+    expect(refundGuardIdx).toBeGreaterThan(liveUsagePredicateIdx);
+    expect(taskSrc).not.toMatch(/hasObservedUsage\s*=\s*hasObservedUsage/);
+  });
+
   test("task catch records structured metadata for dashboard filtering", () => {
     expect(taskSrc).toMatch(/recordAgentLongFailureForDashboard/);
     expect(taskSrc).toMatch(/errorCategory/);

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -460,6 +460,7 @@ const withAgentLongStreamHeartbeat = (
 // Shared between run() and onCancel() since onCancel is defined at task scope.
 type RunCleanupState = {
   usageRefundTracker: UsageRefundTracker;
+  hasObservedUsage: () => boolean;
   chatLogger: ChatLogger | undefined;
   chatId: string;
 };
@@ -510,7 +511,9 @@ export const agentLongTask = task({
       runPromise.catch(() => undefined),
       new Promise((r) => setTimeout(r, 5000)),
     ]);
-    await cleanup.usageRefundTracker.refund().catch(() => {});
+    if (!cleanup.hasObservedUsage()) {
+      await cleanup.usageRefundTracker.refund().catch(() => {});
+    }
     await ptySessionManager.closeAll(cleanup.chatId).catch(() => {});
     await phLogger.flush().catch(() => {});
     runCleanupMap.delete(ctx.run.id);
@@ -595,8 +598,6 @@ export const agentLongTask = task({
       region: userLocation?.region,
     });
 
-    runCleanupMap.set(ctx.run.id, { usageRefundTracker, chatLogger, chatId });
-
     // Set to true once the real UI stream is piped to agentUiStream. If a
     // pre-stream setup step throws before this, the outer catch emits a
     // synthetic error stream so the frontend receives a proper error chunk
@@ -604,6 +605,12 @@ export const agentLongTask = task({
     let streamPiped = false;
     let observedUsageTracker: UsageTracker | undefined;
     const hasObservedUsage = () => !!observedUsageTracker?.hasUsage;
+    runCleanupMap.set(ctx.run.id, {
+      usageRefundTracker,
+      hasObservedUsage,
+      chatLogger,
+      chatId,
+    });
 
     try {
       // Re-fetch from DB so we have fileTokens for summarization.

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -602,8 +602,8 @@ export const agentLongTask = task({
     // synthetic error stream so the frontend receives a proper error chunk
     // instead of a silent abort.
     let streamPiped = false;
-    let hasObservedUsage = false;
     let observedUsageTracker: UsageTracker | undefined;
+    const hasObservedUsage = () => !!observedUsageTracker?.hasUsage;
 
     try {
       // Re-fetch from DB so we have fileTokens for summarization.
@@ -1562,9 +1562,6 @@ export const agentLongTask = task({
           } catch (error) {
             await releaseFreeRunLockOnce();
             throw error;
-          } finally {
-            hasObservedUsage =
-              hasObservedUsage || !!observedUsageTracker?.hasUsage;
           }
         },
       });
@@ -1623,7 +1620,7 @@ export const agentLongTask = task({
           metadataError,
         );
       });
-      if (!hasObservedUsage) {
+      if (!hasObservedUsage()) {
         await usageRefundTracker.refund().catch(() => {});
       }
       if (error instanceof ChatSDKError) {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -602,6 +602,8 @@ export const agentLongTask = task({
     // synthetic error stream so the frontend receives a proper error chunk
     // instead of a silent abort.
     let streamPiped = false;
+    let hasObservedUsage = false;
+    let observedUsageTracker: UsageTracker | undefined;
 
     try {
       // Re-fetch from DB so we have fileTokens for summarization.
@@ -961,6 +963,7 @@ export const agentLongTask = task({
               trackedProvider.languageModel(fallbackModel).modelId;
 
             const usageTracker = new UsageTracker();
+            observedUsageTracker = usageTracker;
             let hasRecordedUsage = false;
             let preFallbackCacheRead = 0;
             let preFallbackCacheWrite = 0;
@@ -1559,6 +1562,9 @@ export const agentLongTask = task({
           } catch (error) {
             await releaseFreeRunLockOnce();
             throw error;
+          } finally {
+            hasObservedUsage =
+              hasObservedUsage || !!observedUsageTracker?.hasUsage;
           }
         },
       });
@@ -1617,7 +1623,9 @@ export const agentLongTask = task({
           metadataError,
         );
       });
-      await usageRefundTracker.refund().catch(() => {});
+      if (!hasObservedUsage) {
+        await usageRefundTracker.refund().catch(() => {});
+      }
       if (error instanceof ChatSDKError) {
         chatLogger?.emitChatError(error);
       } else {


### PR DESCRIPTION
### Motivation
- Close an accounting bypass where a post-stream error rethrown into the outer catch caused unconditional refunds even after provider/tool/sandbox usage had been recorded. This prevented attackers from inducing late failures to get unbilled provider cost while reclaiming user credits. 

### Description
- Add a task-scoped `hasObservedUsage` flag and `observedUsageTracker` reference in `trigger/agent-long.ts` to record whether any `UsageTracker` observed usage during the stream. 
- Assign the per-stream `UsageTracker` instance to `observedUsageTracker` and update `hasObservedUsage` in the `execute` block `finally` so late stream failures reflect real usage state. 
- Gate the outer `usageRefundTracker.refund()` call so refunds are only issued when `hasObservedUsage` is false, preserving the original intent of the `hasUsage` refund guard and keeping handled rate-limit refund behavior unchanged.

### Testing
- Ran TypeScript typecheck with `pnpm -s tsc --noEmit` and it succeeded. 
- Ran targeted unit tests with `pnpm -s jest lib/api/__tests__/agent-long-contracts.test.ts` and they passed. 
- Ran the full test suite via the project test hook (`jest`) and all suites passed (`91` suites, `1147` tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a147e11e6588332902ee2f9dedcaa89)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refund behavior during agent runs now only issues refunds when no usage was observed, preventing incorrect refunds on partial or failed executions and improving billing accuracy and consistency across run lifecycles.

* **Tests**
  * Added a structural test that verifies both cancellation and outer error paths check observed-usage before performing refunds, preventing regressions in refund logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->