### PR TITLE
Fix mid-stream budget hard-cap enforcement after extra-usage warning

### DIFF
--- a/lib/chat/budget-monitor.ts
+++ b/lib/chat/budget-monitor.ts
@@ -97,13 +97,9 @@ export class BudgetMonitor {
     let decision: "continue" | "abort" = "continue";
 
     for (const threshold of BUDGET_THRESHOLDS) {
-      if (
-        usedPercent < threshold ||
-        threshold <= this.highestThresholdEmitted
-      ) {
+      if (usedPercent < threshold) {
         continue;
       }
-      this.highestThresholdEmitted = threshold;
 
       if (threshold === 100) {
         const overflowDollars =
@@ -114,6 +110,10 @@ export class BudgetMonitor {
           snapshot.extraUsageBalanceAtStart - overflowDollars > 0;
 
         if (hasExtraCushion) {
+          if (threshold <= this.highestThresholdEmitted) {
+            continue;
+          }
+          this.highestThresholdEmitted = threshold;
           writeRateLimitWarning(this.writer, {
             warningType: "extra-usage-active",
             bucketType: "monthly",
@@ -130,6 +130,10 @@ export class BudgetMonitor {
           decision = "abort";
         }
       } else {
+        if (threshold <= this.highestThresholdEmitted) {
+          continue;
+        }
+        this.highestThresholdEmitted = threshold;
         this.emit({ usedPercent, projectedUsedPoints });
       }
     }


### PR DESCRIPTION
### Motivation
- The mid-stream `BudgetMonitor` could latch the 100% threshold when a small finite extra-usage cushion existed, emitting a one-time warning and then skipping later hard-cap checks which could allow unbounded overspend.
- The intent is to preserve warning deduplication while ensuring an actual hard-abort still happens once finite extra-usage is exhausted.

### Description
- Update `BudgetMonitor.checkAfterStep` to evaluate `usedPercent < threshold` first and only dedupe warnings, preventing `highestThresholdEmitted` from permanently suppressing later 100% enforcement. 
- For the 100% threshold the code now only skips if the warning was already emitted, but still re-evaluates the hard-cap on every step so aborts occur when the finite cushion is exceeded. 
- Retain existing behavior for non-100 thresholds while ensuring `highestThresholdEmitted` is set only when a threshold is actually emitted. 
- Change is confined to `lib/chat/budget-monitor.ts` and preserves the prior warning emission semantics.

### Testing
- Ran targeted unit tests: `npx jest lib/rate-limit/__tests__/token-bucket.test.ts --runInBand` which passed. 
- Pre-commit checks (`prettier --write`, `eslint --fix`, `tsc --noEmit`) ran during the commit and succeeded. 
- Full test suite executed as part of the commit hook (`jest`) completed successfully (91 test suites, 1147 tests passed). 
- Attempted the provided PoC Jest paths but they were not present in this checkout, so that specific run returned "No tests found."

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a147dd52f2083328e9bfc2e3293033b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal logic for budget threshold monitoring to better handle threshold state tracking and warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->