### PR TITLE
fix: prevent summary leakage when forking shared chats

### DIFF
--- a/convex/sharedChats.ts
+++ b/convex/sharedChats.ts
@@ -1,6 +1,5 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
-import { copyChatSummary } from "./lib/utils";
 import { convexLogger } from "./lib/logger";
 
 /**
@@ -331,7 +330,7 @@ export const forkSharedChat = mutation({
     // Create new chat owned by the current user
     const newChatId = crypto.randomUUID();
 
-    const newChatDocId = await ctx.db.insert("chats", {
+    await ctx.db.insert("chats", {
       id: newChatId,
       title: chat.title,
       user_id: identity.subject,
@@ -339,11 +338,9 @@ export const forkSharedChat = mutation({
       update_time: Date.now(),
     });
 
-    // Copy messages to new chat, tracking old→new ID mapping for summary remapping
-    const messageIdMap = new Map<string, string>();
+    // Copy messages to new chat
     for (const msg of frozenMessages) {
       const newMessageId = crypto.randomUUID();
-      messageIdMap.set(msg.id, newMessageId);
       // Remove file/image parts entirely — the forking user doesn't own the
       // original files, signed URLs will expire, and placeholder parts render
       // as broken "Unknown file" cards in the regular chat view.
@@ -365,16 +362,6 @@ export const forkSharedChat = mutation({
         generation_time_ms: msg.generation_time_ms,
         finish_reason: msg.finish_reason,
         usage: msg.usage,
-      });
-    }
-
-    // Copy summary from original chat if it covers the forked messages
-    if (chat.latest_summary_id) {
-      await copyChatSummary(ctx.db, {
-        sourceSummaryId: chat.latest_summary_id,
-        targetChatDocId: newChatDocId,
-        targetChatId: newChatId,
-        messageIdMap,
       });
     }
 


### PR DESCRIPTION
### Motivation
- A cross-tenant confidentiality issue was introduced where `forkSharedChat` copied the original chat's `latest_summary_id` into a fork, allowing private backend summaries to be injected into the model context for the forking user. 
- The fork operation should only reproduce the frozen, public share-safe messages up to `share_date` and must not copy backend-only summaries or other private artifacts.

### Description
- Remove the `copyChatSummary` import and the call that copied `chat.latest_summary_id` into the fork so summaries are no longer transferred to shared-chat forks. 
- Drop the unused summary remapping state (`messageIdMap`) and the associated remapping scaffolding in the fork path while preserving the existing message-copy logic. 
- Keep the sanitized message copy behavior intact, including stripping `file` parts and copying only messages with `update_time <= chat.share_date` and `is_hidden !== true`.

### Testing
- Ran lint on the modified file with `pnpm eslint convex/sharedChats.ts` and it succeeded. 
- Type checking ran as part of pre-commit hooks via `tsc --noEmit` and succeeded. 
- Full Jest test suite was executed via `pnpm test` and all tests passed (91 suites, 1147 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14887e301c8332a3e2ec307a4fd90f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated shared chat forking to no longer copy summary information from the original chat.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->