### PR TITLE
fix: make checkout credit idempotency durable

### DIFF
--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -304,6 +304,18 @@ export const addCredits = mutation({
 
     // Idempotency: skip if already processed (prevents double-credit on webhook retries
     // and across both the post-checkout confirm path and the async webhook path)
+    if (args.idempotencyKey) {
+      const durableExisting = await ctx.db
+        .query("processed_checkout_sessions")
+        .withIndex("by_session_key", (q) =>
+          q.eq("session_key", args.idempotencyKey!),
+        )
+        .first();
+      if (durableExisting) {
+        return { newBalance: 0, alreadyProcessed: true };
+      }
+    }
+
     const dedupKeys = [args.idempotencyKey, args.legacyIdempotencyKey].filter(
       (k): k is string => typeof k === "string" && k.length > 0,
     );
@@ -357,6 +369,10 @@ export const addCredits = mutation({
 
     // Mark processed after success (so retries work if above fails)
     if (args.idempotencyKey) {
+      await ctx.db.insert("processed_checkout_sessions", {
+        session_key: args.idempotencyKey,
+        processed_at: Date.now(),
+      });
       await ctx.db.insert("processed_webhooks", {
         event_id: args.idempotencyKey,
         processed_at: Date.now(),

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -304,13 +304,12 @@ export const addCredits = mutation({
 
     // Idempotency: skip if already processed (prevents double-credit on webhook retries
     // and across both the post-checkout confirm path and the async webhook path)
-    if (args.idempotencyKey) {
+    const sessionKey = args.idempotencyKey;
+    if (sessionKey) {
       const durableExisting = await ctx.db
         .query("processed_checkout_sessions")
-        .withIndex("by_session_key", (q) =>
-          q.eq("session_key", args.idempotencyKey!),
-        )
-        .first();
+        .withIndex("by_session_key", (q) => q.eq("session_key", sessionKey))
+        .unique();
       if (durableExisting) {
         return { newBalance: 0, alreadyProcessed: true };
       }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -356,4 +356,12 @@ export default defineSchema({
     status: v.optional(v.union(v.literal("pending"), v.literal("completed"))),
     claimed_at: v.optional(v.number()),
   }).index("by_event_id", ["event_id"]),
+
+  // Durable idempotency records for user-visible checkout session confirms.
+  // Unlike webhook retry deduplication, these keys must not be time-purged
+  // because a paid Checkout Session ID can be replayed by the purchaser.
+  processed_checkout_sessions: defineTable({
+    session_key: v.string(),
+    processed_at: v.number(),
+  }).index("by_session_key", ["session_key"]),
 });

--- a/convex/teamExtraUsage.ts
+++ b/convex/teamExtraUsage.ts
@@ -99,13 +99,12 @@ export const addTeamCredits = mutation({
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
 
-    if (args.idempotencyKey) {
+    const sessionKey = args.idempotencyKey;
+    if (sessionKey) {
       const durableExisting = await ctx.db
         .query("processed_checkout_sessions")
-        .withIndex("by_session_key", (q) =>
-          q.eq("session_key", args.idempotencyKey!),
-        )
-        .first();
+        .withIndex("by_session_key", (q) => q.eq("session_key", sessionKey))
+        .unique();
       if (durableExisting) {
         return { newBalance: 0, alreadyProcessed: true };
       }

--- a/convex/teamExtraUsage.ts
+++ b/convex/teamExtraUsage.ts
@@ -99,6 +99,18 @@ export const addTeamCredits = mutation({
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
 
+    if (args.idempotencyKey) {
+      const durableExisting = await ctx.db
+        .query("processed_checkout_sessions")
+        .withIndex("by_session_key", (q) =>
+          q.eq("session_key", args.idempotencyKey!),
+        )
+        .first();
+      if (durableExisting) {
+        return { newBalance: 0, alreadyProcessed: true };
+      }
+    }
+
     const dedupKeys = [args.idempotencyKey, args.legacyIdempotencyKey].filter(
       (k): k is string => typeof k === "string" && k.length > 0,
     );
@@ -147,6 +159,10 @@ export const addTeamCredits = mutation({
     }
 
     if (args.idempotencyKey) {
+      await ctx.db.insert("processed_checkout_sessions", {
+        session_key: args.idempotencyKey,
+        processed_at: Date.now(),
+      });
       await ctx.db.insert("processed_webhooks", {
         event_id: args.idempotencyKey,
         processed_at: Date.now(),


### PR DESCRIPTION
### Motivation
- The confirm endpoints (`/api/extra-usage/confirm` and `/api/team/extra-usage/confirm`) accept a user-visible Stripe Checkout Session ID and could be replayed after the `processed_webhooks` rows were purged, allowing duplicate credits.  
- `processed_webhooks` is intentionally time-purged (7 days) for Stripe retry deduplication and is therefore unsuitable as the sole protection for a user-replayable confirm flow.  
- The goal is to prevent replay of valid paid Checkout Sessions while preserving the async webhook safety net and existing behavior.

### Description
- Added a durable idempotency table `processed_checkout_sessions` to the schema for checkout-session keys so confirm-path deduplication does not rely on the 7-day webhook table (`convex/schema.ts`).  
- In `addCredits`, added a pre-check against `processed_checkout_sessions` and wrote a durable record to `processed_checkout_sessions` after a successful credit, while retaining the existing insert to `processed_webhooks` for webhook parity (`convex/extraUsage.ts`).  
- Applied the identical durable idempotency pre-check and post-write to the team flow in `addTeamCredits` so team confirm endpoints are protected the same way (`convex/teamExtraUsage.ts`).  
- Preserved the webhook async path and existing `processed_webhooks` behavior so the webhook remains the safety net and legacy dedup still works.

### Testing
- Ran the focused unit tests for the team idempotency scenario with `pnpm jest convex/__tests__/teamExtraUsage.test.ts -t "addTeamCredits idempotency" --runInBand`, and the matching tests passed.  
- Ran static type checks with `pnpm typecheck` (`tsc --noEmit`) and it succeeded.  
- Ran the full test suite via the repo test hook (`pnpm test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14826df8f0833299be22ebf848b314)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added durable tracking for checkout session confirmations to reliably record processed sessions.

* **Bug Fixes**
  - Enhanced deduplication to prevent duplicate crediting for individual and team purchases by checking session records before applying credits and marking completions after processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/521?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->