### PR TITLE
[codex] Sanitize message parts before storage compaction

### DIFF
--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+const loadSaveMessageWithMocks = async () => {
+  jest.resetModules();
+  process.env.NEXT_PUBLIC_CONVEX_URL = "https://example.convex.cloud";
+
+  const mockMutation = jest.fn().mockResolvedValue({ id: "message-1" });
+  const mockCompactMessageForStorage = jest.fn((message: any) => {
+    const sizeBytes = JSON.stringify(message.parts).length;
+    return {
+      message,
+      compacted: false,
+      beforeSizeBytes: sizeBytes,
+      afterSizeBytes: sizeBytes,
+      strippedUiOnlyFields: false,
+      prunedCount: 0,
+    };
+  });
+
+  jest.doMock("server-only", () => ({}), { virtual: true });
+  jest.doMock("convex/browser", () => ({
+    ConvexHttpClient: class {
+      mutation = mockMutation;
+      query = jest.fn();
+      action = jest.fn();
+    },
+  }));
+  jest.doMock("@/lib/chat/compaction/prune-tool-outputs", () => ({
+    compactMessageForStorage: mockCompactMessageForStorage,
+  }));
+
+  const { saveMessage } = await import("../actions");
+  return { saveMessage, mockCompactMessageForStorage };
+};
+
+describe("saveMessage", () => {
+  it("sanitizes assistant parts before storage compaction", async () => {
+    const { saveMessage, mockCompactMessageForStorage } =
+      await loadSaveMessageWithMocks();
+    const circularOutput: Record<string, unknown> = { ok: true };
+    circularOutput.self = circularOutput;
+
+    await expect(
+      saveMessage({
+        chatId: "chat-1",
+        userId: "user-1",
+        message: {
+          id: "message-1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-run_terminal_cmd",
+              state: "output-available",
+              input: { command: "echo hi" },
+              output: circularOutput,
+            } as any,
+          ],
+        },
+      }),
+    ).resolves.toBeDefined();
+
+    const compactedMessage = mockCompactMessageForStorage.mock
+      .calls[0]?.[0] as {
+      parts: Array<{ output?: unknown }>;
+    };
+
+    expect(compactedMessage.parts[0].output).toEqual({
+      ok: true,
+      self: "[Circular]",
+    });
+    expect(() => JSON.stringify(compactedMessage.parts)).not.toThrow();
+  });
+});

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -351,11 +351,16 @@ export async function saveMessage({
             },
           })
         : message.parts;
+    const convexSafeParts = sanitizeForConvexValue(fixedParts) as UIMessagePart<
+      any,
+      any
+    >[];
     const storageSafeMessage =
       message.role === "assistant"
-        ? compactMessageForStorage({ ...message, parts: fixedParts })
+        ? compactMessageForStorage({ ...message, parts: convexSafeParts })
         : null;
-    const storageSafeParts = storageSafeMessage?.message.parts ?? fixedParts;
+    const storageSafeParts =
+      storageSafeMessage?.message.parts ?? convexSafeParts;
     if (storageSafeMessage?.compacted) {
       console.info("[db] compacted assistant message before save", {
         chatId,


### PR DESCRIPTION
## Summary

Fixes the remaining save-path gap where assistant message compaction could attempt to JSON.stringify unsafe runtime values before Convex sanitization ran.

## What changed

- Sanitizes fixed message parts before calling `compactMessageForStorage`.
- Keeps the final `sanitizeForConvexValue` pass before `messages.saveMessage` as a defensive boundary.
- Adds a regression test proving circular tool output is normalized before compaction tries to stringify assistant parts.

## Validation

- `pnpm test -- lib/db/__tests__/actions-save-message.test.ts lib/db/__tests__/convex-value-sanitizer.test.ts`
- `pnpm typecheck`
- Pre-commit hook: full `pnpm test` passed, 92 suites / 1151 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message storage handling to safely process assistant messages containing tool outputs with circular references, preventing data integrity issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->