### PR TITLE
[codex] Fix file-only regenerate attachment handling

### DIFF
--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -25,6 +25,7 @@ import {
   createFileMessagePartFromUploadedFile,
   getMaxFilesLimitForMode,
 } from "@/lib/utils/file-utils";
+import { hasRestageableLocalDesktopAttachments } from "@/lib/utils/local-attachment-messages";
 
 interface UseChatHandlersProps {
   chatId: string;
@@ -430,6 +431,12 @@ export const useChatHandlers = ({
     const trimmedMessages = getMessagesUpToLastRealUser(messages);
     setMessages(trimmedMessages);
 
+    const shouldSendClientMessagesForRegenerate =
+      hasRestageableLocalDesktopAttachments(trimmedMessages);
+    const persistentRegenerateMessages = shouldSendClientMessagesForRegenerate
+      ? trimmedMessages
+      : [];
+
     if (!temporaryChatsEnabled) {
       // Delete the entire trailing auto-continue chain (all assistant + hidden user messages)
       // back to the last real user message, so regeneration starts from the original request
@@ -443,9 +450,10 @@ export const useChatHandlers = ({
       regenerate({
         body: {
           mode: chatModeRef.current,
-          messages: [],
+          messages: persistentRegenerateMessages,
           todos: cleanedTodos,
           regenerate: true,
+          useClientMessagesForRegenerate: shouldSendClientMessagesForRegenerate,
           temporary: false,
           sandboxPreference,
           selectedModel,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -90,6 +90,7 @@ import {
   rewriteSandboxFilePathsInMessages,
   stripLocalDesktopSourcePaths,
 } from "@/lib/utils/sandbox-file-utils";
+import { getEmptyProcessedMessagesCause } from "@/lib/utils/local-attachment-messages";
 import { after } from "next/server";
 import { createResumableStreamContext } from "resumable-stream";
 import {
@@ -155,6 +156,7 @@ export const createChatHandler = (
         sandboxPreference,
         selectedModel: rawSelectedModel,
         isAutoContinue,
+        useClientMessagesForRegenerate,
       }: {
         messages: UIMessage[];
         mode: ChatMode;
@@ -165,6 +167,7 @@ export const createChatHandler = (
         sandboxPreference?: SandboxPreference;
         selectedModel?: string;
         isAutoContinue?: boolean;
+        useClientMessagesForRegenerate?: boolean;
       } = await req.json();
       outerChatId = chatId;
 
@@ -226,6 +229,7 @@ export const createChatHandler = (
         regenerate,
         isTemporary: temporary,
         mode,
+        useClientMessagesForRegenerate,
       });
       const { chat, isNewChat, fileTokens } = fetched;
       const truncatedMessages =
@@ -275,7 +279,7 @@ export const createChatHandler = (
       if (!processedMessages || processedMessages.length === 0) {
         throw new ChatSDKError(
           "bad_request:api",
-          "Your message could not be processed. Please include some text with your file attachments and try again.",
+          getEmptyProcessedMessagesCause(truncatedMessages),
         );
       }
 

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -22,6 +22,7 @@ import type { Id } from "@/convex/_generated/dataModel";
 import { v4 as uuidv4 } from "uuid";
 import { AGENT_RESUME_PREAMBLE } from "@/lib/chat/summarization/prompts";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
+import { hasRestageableLocalDesktopAttachments } from "@/lib/utils/local-attachment-messages";
 import type { ChatMode } from "@/types/chat";
 import { getMessagePersistenceDiagnostics } from "./message-persistence-diagnostics";
 import { sanitizeForConvexValue } from "./convex-value-sanitizer";
@@ -552,6 +553,7 @@ export async function getMessagesByChatId({
   subscription,
   isTemporary,
   mode,
+  useClientMessagesForRegenerate,
 }: {
   chatId: string;
   userId: string;
@@ -560,6 +562,7 @@ export async function getMessagesByChatId({
   regenerate?: boolean;
   isTemporary?: boolean;
   mode?: import("@/types").ChatMode;
+  useClientMessagesForRegenerate?: boolean;
 }) {
   // For temporary chats, skip database operations
   let chat = undefined;
@@ -571,8 +574,22 @@ export async function getMessagesByChatId({
     chat = await getChatById({ id: chatId });
     isNewChat = !chat;
 
+    const shouldUseClientMessagesForRegenerate =
+      !!regenerate &&
+      !!useClientMessagesForRegenerate &&
+      Array.isArray(newMessages) &&
+      newMessages.length > 0 &&
+      hasRestageableLocalDesktopAttachments(newMessages);
+
+    if (!isNewChat && shouldUseClientMessagesForRegenerate) {
+      // Persisted local desktop attachments are saved without source paths.
+      // When the current client still has those paths, use that trimmed
+      // history for this regenerate so the files can be staged again.
+      existingMessages = newMessages;
+    }
+
     // Only fetch existing messages if chat exists
-    if (!isNewChat) {
+    if (!isNewChat && !shouldUseClientMessagesForRegenerate) {
       try {
         // Fetch latest summary only if chat has a summary ID
         const latestSummary = chat?.latest_summary_id

--- a/lib/utils/__tests__/local-attachment-messages.test.ts
+++ b/lib/utils/__tests__/local-attachment-messages.test.ts
@@ -1,0 +1,73 @@
+import {
+  getEmptyProcessedMessagesCause,
+  hasRestageableLocalDesktopAttachments,
+  hasUnrestageableLocalDesktopAttachments,
+} from "../local-attachment-messages";
+
+describe("local attachment message helpers", () => {
+  it("detects local desktop attachments that still have a source path", () => {
+    const messages = [
+      {
+        parts: [
+          { type: "text", text: "inspect this" },
+          {
+            type: "file",
+            storage: "local-desktop",
+            localPath: "/Users/alice/report.pdf",
+          },
+        ],
+      },
+    ];
+
+    expect(hasRestageableLocalDesktopAttachments(messages)).toBe(true);
+    expect(hasUnrestageableLocalDesktopAttachments(messages)).toBe(false);
+  });
+
+  it("detects persisted local desktop attachments that lost their source path", () => {
+    const messages = [
+      {
+        parts: [
+          {
+            type: "file",
+            storage: "local-desktop",
+            localAttachmentId: "local-1",
+            name: "report.pdf",
+          },
+        ],
+      },
+    ];
+
+    expect(hasRestageableLocalDesktopAttachments(messages)).toBe(false);
+    expect(hasUnrestageableLocalDesktopAttachments(messages)).toBe(true);
+  });
+
+  it("uses a reattach-specific error for unstageable local files", () => {
+    expect(
+      getEmptyProcessedMessagesCause([
+        {
+          parts: [
+            {
+              type: "file",
+              storage: "local-desktop",
+              name: "report.pdf",
+            },
+          ],
+        },
+      ]),
+    ).toBe(
+      "The attached local file is no longer available to this request. Please reattach it and try again.",
+    );
+  });
+
+  it("uses a preparation error for other attachment-only empty requests", () => {
+    expect(
+      getEmptyProcessedMessagesCause([
+        {
+          parts: [{ type: "file", fileId: "file_123", name: "report.pdf" }],
+        },
+      ]),
+    ).toBe(
+      "The attached file could not be prepared for this request. Please reattach it or add a short message and try again.",
+    );
+  });
+});

--- a/lib/utils/local-attachment-messages.ts
+++ b/lib/utils/local-attachment-messages.ts
@@ -1,0 +1,56 @@
+type MessageWithParts = {
+  parts?: unknown[];
+};
+
+const getPartFields = (part: unknown) =>
+  part && typeof part === "object"
+    ? (part as { type?: unknown; storage?: unknown; localPath?: unknown })
+    : undefined;
+
+const isLocalDesktopFilePart = (part: unknown) => {
+  const fields = getPartFields(part);
+  return fields?.type === "file" && fields.storage === "local-desktop";
+};
+
+export const hasRestageableLocalDesktopAttachments = (
+  messages: MessageWithParts[],
+): boolean =>
+  messages.some((message) =>
+    message.parts?.some(
+      (part) =>
+        isLocalDesktopFilePart(part) &&
+        typeof getPartFields(part)?.localPath === "string" &&
+        (getPartFields(part)?.localPath as string).length > 0,
+    ),
+  );
+
+export const hasUnrestageableLocalDesktopAttachments = (
+  messages: MessageWithParts[],
+): boolean =>
+  messages.some((message) =>
+    message.parts?.some(
+      (part) =>
+        isLocalDesktopFilePart(part) &&
+        (typeof getPartFields(part)?.localPath !== "string" ||
+          getPartFields(part)?.localPath === ""),
+    ),
+  );
+
+export const hasFileAttachments = (messages: MessageWithParts[]): boolean =>
+  messages.some((message) =>
+    message.parts?.some((part) => getPartFields(part)?.type === "file"),
+  );
+
+export const getEmptyProcessedMessagesCause = (
+  messages: MessageWithParts[],
+): string => {
+  if (hasUnrestageableLocalDesktopAttachments(messages)) {
+    return "The attached local file is no longer available to this request. Please reattach it and try again.";
+  }
+
+  if (hasFileAttachments(messages)) {
+    return "The attached file could not be prepared for this request. Please reattach it or add a short message and try again.";
+  }
+
+  return "Your message could not be processed because it did not contain any usable content. Please add a short message and try again.";
+};

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -71,6 +71,7 @@ import {
   getUploadBasePath,
   rewriteSandboxFilePathsInMessages,
 } from "@/lib/utils/sandbox-file-utils";
+import { getEmptyProcessedMessagesCause } from "@/lib/utils/local-attachment-messages";
 import {
   captureAgentRun,
   captureToolCalls,
@@ -658,7 +659,7 @@ export const agentLongTask = task({
       if (!processedMessages.length) {
         throw new ChatSDKError(
           "bad_request:api",
-          "Your message could not be processed. Please include some text with your file attachments and try again.",
+          getEmptyProcessedMessagesCause(messagesForProcessing),
         );
       }
 


### PR DESCRIPTION
## Summary

Fixes a file-only regenerate path where local desktop attachments could be stripped down to an empty backend request after persistence removed the source path.

## What changed

- Added shared helpers to distinguish restageable local desktop attachments from persisted attachments that need reattaching.
- Updated persistent regenerate to send trimmed client messages only when the client still has local desktop source paths.
- Taught the backend to use those client messages for regenerate only when they actually contain restageable local attachments.
- Replaced the misleading "include some text" empty-request error with attachment-aware causes for both `/api/agent` and Trigger agent runs.
- Added unit coverage for the local attachment helper behavior.

## Validation

- `pnpm test -- local-attachment-messages.test.ts`
- `pnpm typecheck`
- `pnpm lint -- app/hooks/useChatHandlers.ts lib/api/chat-handler.ts lib/db/actions.ts trigger/agent-long.ts lib/utils/local-attachment-messages.ts lib/utils/__tests__/local-attachment-messages.test.ts` (completed with existing warnings, no errors)
- Commit hook: `pnpm typecheck` and full `pnpm test` passed: 92 suites, 1154 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced error messages when attachments cannot be processed during chat regeneration, providing clearer guidance on next steps
  * Improved chat regeneration behavior with local file attachments, enabling better reuse of restageable attachments

* **Tests**
  * Added comprehensive test coverage for attachment handling and detection scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->