### PR TITLE
[codex] fix agent-long empty prompt handling

### DIFF
--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -64,6 +64,30 @@ export async function POST(req: NextRequest) {
       rawSelectedModel,
     });
 
+    const requestMessages = Array.isArray(messages) ? messages : [];
+    if (!regenerate && !isAutoContinue && requestMessages.length === 0) {
+      console.warn(
+        JSON.stringify({
+          level: "warn",
+          event: "agent_long_empty_message_payload_rejected",
+          service: "chat-handler",
+          timestamp: new Date().toISOString(),
+          chat_id: chatId,
+          user_id: userId,
+          temporary: !!temporary,
+          subscription,
+        }),
+      );
+      throw new ChatSDKError(
+        "bad_request:api",
+        "No message content was found for this request. Please send a new message and try again.",
+        {
+          empty_prompt: true,
+          new_messages_count: 0,
+        },
+      );
+    }
+
     // Fetch existing chat to: (a) detect isNewChat for title generation,
     // (b) pass to handleInitialChatAndUserMessage so it skips saveChat on
     //     regenerate/auto-continue and does the ownership check instead.
@@ -71,11 +95,11 @@ export async function POST(req: NextRequest) {
     const isNewChat =
       !temporary && !existingChat && !regenerate && !isAutoContinue;
 
-    let messagesForPersistence = stripLocalDesktopSourcePaths(messages);
+    let messagesForPersistence = stripLocalDesktopSourcePaths(requestMessages);
     let messagesForTrigger = messagesForPersistence;
     let localDesktopAttachmentsPrepared = false;
 
-    if (hasLocalDesktopSourcePaths(messages)) {
+    if (hasLocalDesktopSourcePaths(requestMessages)) {
       if (sandboxPreference !== "desktop") {
         throw new ChatSDKError(
           "bad_request:api",
@@ -85,7 +109,7 @@ export async function POST(req: NextRequest) {
 
       let { messages: preparedMessages, sandboxFiles } =
         prepareLocalDesktopAttachmentsForTrigger(
-          messages,
+          requestMessages,
           getUploadBasePath("desktop"),
         );
       if (sandboxFiles.length > 0) {

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -41,6 +41,11 @@ const taskSrc = fs.readFileSync(
   "utf8",
 );
 
+const dbActionsSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../db/actions.ts"),
+  "utf8",
+);
+
 describe("agent-long-transport — STREAM_TIMEOUT_MS guard", () => {
   test("STREAM_TIMEOUT_MS is set to 30 seconds", () => {
     expect(transportSrc).toMatch(/STREAM_TIMEOUT_MS\s*=\s*30[_,]?000/);
@@ -210,5 +215,52 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(/login_required/);
     expect(taskSrc).toMatch(/error_\$\{summary\.category\}/);
     expect(taskSrc).toMatch(/metadata\.flush\(\)/);
+  });
+
+  test("empty rehydrated history is classified separately from oversized input", () => {
+    const emptyPromptIdx = dbActionsSrc.indexOf("chat_prompt_empty");
+    const emptyMessageIdx = dbActionsSrc.indexOf(
+      "No message content was found for this request",
+      emptyPromptIdx,
+    );
+    const tooLargeIdx = dbActionsSrc.indexOf(
+      "Your input (including any attached files) is too large",
+      emptyMessageIdx,
+    );
+
+    expect(emptyPromptIdx).toBeGreaterThan(-1);
+    expect(emptyMessageIdx).toBeGreaterThan(emptyPromptIdx);
+    expect(tooLargeIdx).toBeGreaterThan(emptyMessageIdx);
+    expect(dbActionsSrc).toMatch(/empty_prompt:\s*true/);
+    expect(taskSrc).toMatch(/errorMetadata\?\.empty_prompt\s*===\s*true/);
+    expect(taskSrc).toMatch(/"empty_prompt"/);
+  });
+
+  test("agent-long DB rehydrate failures are not swallowed when no payload messages exist", () => {
+    const fetchFailedIdx = dbActionsSrc.indexOf("chat_history_fetch_failed");
+    const zeroNewMessagesIdx = dbActionsSrc.indexOf(
+      "newMessages.length === 0",
+      fetchFailedIdx,
+    );
+    const rethrowIdx = dbActionsSrc.indexOf(
+      'databaseError("messages.getMessagesPageForBackend"',
+      zeroNewMessagesIdx,
+    );
+
+    expect(fetchFailedIdx).toBeGreaterThan(-1);
+    expect(zeroNewMessagesIdx).toBeGreaterThan(fetchFailedIdx);
+    expect(rethrowIdx).toBeGreaterThan(zeroNewMessagesIdx);
+  });
+
+  test("normal agent-long sends reject empty message payloads before triggering", () => {
+    const guardIdx = routeSrc.indexOf("requestMessages.length === 0");
+    const emptyPayloadIdx = routeSrc.indexOf(
+      "agent_long_empty_message_payload_rejected",
+    );
+    const triggerIdx = routeSrc.indexOf("tasks.trigger", emptyPayloadIdx);
+
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(emptyPayloadIdx).toBeGreaterThan(guardIdx);
+    expect(triggerIdx).toBeGreaterThan(emptyPayloadIdx);
   });
 });

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -105,6 +105,15 @@ const COMPACT_CHAT_ERROR_METADATA_KEYS = [
   "reasoning_chars",
   "was_aborted",
   "was_preemptive_timeout",
+  "empty_prompt",
+  "truncation_dropped_all_messages",
+  "existing_messages_count",
+  "new_messages_count",
+  "all_messages_count",
+  "total_tokens_before",
+  "max_tokens",
+  "file_ids_count",
+  "largest_file_token",
 ] as const;
 
 const compactChatErrorMetadata = (

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -214,6 +214,26 @@ const isChatNotFoundMessageSaveError = (
   operation === "messages.saveMessage" &&
   getDatabaseErrorCode(dbErrorData) === "CHAT_NOT_FOUND";
 
+const logChatMessagePreparationFailure = (
+  event: string,
+  level: "warn" | "error",
+  fields: Record<string, unknown>,
+) => {
+  const payload = {
+    level,
+    event,
+    service: "chat-handler",
+    timestamp: new Date().toISOString(),
+    ...fields,
+  };
+  const line = JSON.stringify(payload);
+  if (level === "warn") {
+    console.warn(line);
+  } else {
+    console.error(line);
+  }
+};
+
 const databaseError = (
   operation: string,
   error: unknown,
@@ -747,8 +767,28 @@ export async function getMessagesByChatId({
           };
         }
       } catch (error) {
-        // If error fetching, use empty array
-        console.warn("Failed to fetch existing messages:", error);
+        logChatMessagePreparationFailure("chat_history_fetch_failed", "warn", {
+          chat_id: chatId,
+          user_id: userId,
+          mode,
+          is_temporary: !!isTemporary,
+          regenerate: !!regenerate,
+          new_messages_count: newMessages.length,
+          error_name: error instanceof Error ? error.name : typeof error,
+          error_message: truncateDiagnosticString(stringifyError(error)),
+          db_error_data: getErrorData(error),
+        });
+
+        if (newMessages.length === 0) {
+          throw databaseError("messages.getMessagesPageForBackend", error, {
+            chat_id: chatId,
+            user_id: userId,
+            mode,
+            is_temporary: !!isTemporary,
+            regenerate: !!regenerate,
+            new_messages_count: newMessages.length,
+          });
+        }
       }
     }
   }
@@ -784,7 +824,7 @@ export async function getMessagesByChatId({
   const fileTokens = truncateResult.fileTokens;
 
   if (!truncatedMessages || truncatedMessages.length === 0) {
-    // Structured diagnostic log (no user content)
+    let emptyPromptMetadata: Record<string, unknown> | undefined;
     try {
       const fileIds = extractAllFileIdsFromMessages(allMessages);
       const fileTokens = await getFileTokensByIds(fileIds as any);
@@ -792,30 +832,54 @@ export async function getMessagesByChatId({
         mode,
       });
       const totalTokensBefore = countMessagesTokens(allMessages, fileTokens);
-      console.error("chat-truncation-empty", {
-        chatId,
-        userId,
-        isTemporary: !!isTemporary,
+      const largestFileToken = Object.values(fileTokens).length
+        ? Math.max(...Object.values(fileTokens))
+        : 0;
+      emptyPromptMetadata = {
+        chat_id: chatId,
+        user_id: userId,
+        is_temporary: !!isTemporary,
         regenerate: !!regenerate,
         subscription,
-        existingMessagesCount: existingMessages.length,
-        newMessagesCount: newMessages.length,
-        allMessagesCount: allMessages.length,
-        totalTokensBefore,
-        maxTokens,
-        fileIdsCount: fileIds.length,
-        fileTokensSample: Object.entries(fileTokens)
+        mode,
+        existing_messages_count: existingMessages.length,
+        new_messages_count: newMessages.length,
+        all_messages_count: allMessages.length,
+        total_tokens_before: totalTokensBefore,
+        max_tokens: maxTokens,
+        file_ids_count: fileIds.length,
+        file_tokens_sample: Object.entries(fileTokens)
           .slice(0, 5)
           .map(([k, v]) => ({ fileId: k, tokens: v })),
-        largestFileToken: Object.values(fileTokens).length
-          ? Math.max(...Object.values(fileTokens))
-          : 0,
-      });
+        largest_file_token: largestFileToken,
+      };
+      logChatMessagePreparationFailure(
+        allMessages.length === 0
+          ? "chat_prompt_empty"
+          : "chat_truncation_dropped_all_messages",
+        "error",
+        emptyPromptMetadata,
+      );
     } catch {}
+
+    if (allMessages.length === 0) {
+      throw new ChatSDKError(
+        "bad_request:api",
+        "No message content was found for this request. Please send a new message and try again.",
+        {
+          empty_prompt: true,
+          ...emptyPromptMetadata,
+        },
+      );
+    }
 
     throw new ChatSDKError(
       "bad_request:api",
       "Your input (including any attached files) is too large to process. Please remove some attachments or shorten your message and try again.",
+      {
+        truncation_dropped_all_messages: true,
+        ...emptyPromptMetadata,
+      },
     );
   }
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -161,6 +161,15 @@ type AgentLongErrorSummary = {
   toolPartCount?: number;
   dataPartCount?: number;
   reasoningChars?: number;
+  emptyPrompt?: boolean;
+  truncationDroppedAllMessages?: boolean;
+  existingMessagesCount?: number;
+  newMessagesCount?: number;
+  allMessagesCount?: number;
+  totalTokensBefore?: number;
+  maxTokens?: number;
+  fileIdsCount?: number;
+  largestFileToken?: number;
 };
 
 const isHandledUserRateLimitError = (error: unknown): error is ChatSDKError => {
@@ -214,7 +223,11 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
           ? "login_required"
           : isChatNotFoundError(error)
             ? "chat_not_found"
-            : "chat_error",
+            : errorMetadata?.empty_prompt === true
+              ? "empty_prompt"
+              : errorMetadata?.truncation_dropped_all_messages === true
+                ? "input_too_large"
+                : "chat_error",
       code,
       name: "ChatSDKError",
       message: errorMessage,
@@ -234,6 +247,22 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
       toolPartCount: getNumberMetadata(errorMetadata, "tool_part_count"),
       dataPartCount: getNumberMetadata(errorMetadata, "data_part_count"),
       reasoningChars: getNumberMetadata(errorMetadata, "reasoning_chars"),
+      emptyPrompt: errorMetadata?.empty_prompt === true,
+      truncationDroppedAllMessages:
+        errorMetadata?.truncation_dropped_all_messages === true,
+      existingMessagesCount: getNumberMetadata(
+        errorMetadata,
+        "existing_messages_count",
+      ),
+      newMessagesCount: getNumberMetadata(errorMetadata, "new_messages_count"),
+      allMessagesCount: getNumberMetadata(errorMetadata, "all_messages_count"),
+      totalTokensBefore: getNumberMetadata(
+        errorMetadata,
+        "total_tokens_before",
+      ),
+      maxTokens: getNumberMetadata(errorMetadata, "max_tokens"),
+      fileIdsCount: getNumberMetadata(errorMetadata, "file_ids_count"),
+      largestFileToken: getNumberMetadata(errorMetadata, "largest_file_token"),
     };
   }
 
@@ -317,6 +346,23 @@ const recordAgentLongFailureForDashboard = async (
     metadata.set("dataPartCount", summary.dataPartCount);
   if (summary.reasoningChars != null)
     metadata.set("reasoningChars", summary.reasoningChars);
+  if (summary.emptyPrompt) metadata.set("emptyPrompt", true);
+  if (summary.truncationDroppedAllMessages) {
+    metadata.set("truncationDroppedAllMessages", true);
+  }
+  if (summary.existingMessagesCount != null)
+    metadata.set("existingMessagesCount", summary.existingMessagesCount);
+  if (summary.newMessagesCount != null)
+    metadata.set("newMessagesCount", summary.newMessagesCount);
+  if (summary.allMessagesCount != null)
+    metadata.set("allMessagesCount", summary.allMessagesCount);
+  if (summary.totalTokensBefore != null)
+    metadata.set("totalTokensBefore", summary.totalTokensBefore);
+  if (summary.maxTokens != null) metadata.set("maxTokens", summary.maxTokens);
+  if (summary.fileIdsCount != null)
+    metadata.set("fileIdsCount", summary.fileIdsCount);
+  if (summary.largestFileToken != null)
+    metadata.set("largestFileToken", summary.largestFileToken);
 
   const errorTags = [`error_${summary.category}`];
   if (summary.code) {


### PR DESCRIPTION
## Summary

Fixes the misleading `input too large` failure path when agent-long rehydrates an empty chat history.

## What changed

- Reject normal `/api/agent-long` sends with an empty `messages` payload before starting a Trigger run.
- Split empty prompt handling from true token truncation in `getMessagesByChatId`.
- Preserve structured metadata for empty prompts and truncation drops in wide events and Trigger metadata.
- Stop swallowing backend history fetch failures when agent-long has no payload fallback.
- Add contract coverage for empty rehydration, DB rehydrate failure handling, and route-level empty payload rejection.

## Why

The previous code logged `chat-truncation-empty` with zero messages and zero tokens, then surfaced the generic attachment/input-size error. That obscured the real failure: the request had no visible message content or could not rehydrate persisted chat history.

## Validation

- `pnpm test -- lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `pnpm typecheck`
- Pre-commit hook: `pnpm test` passed 92 suites / 1154 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message validation to reject empty message payloads before processing
  * Enhanced error detection and categorization for truncated content and empty prompts
  * Better error reporting with contextual metadata in dashboard diagnostics

* **Chores**
  * Expanded structured logging for chat handler preparation failures and message processing events

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->