### PR TITLE
fix(billing): validate plan keys and require admin for subscription updates

### DIFF
--- a/app/api/subscription-details/route.ts
+++ b/app/api/subscription-details/route.ts
@@ -8,9 +8,22 @@ import { getSuspensionMessage } from "@/lib/suspensionMessage";
 export const POST = async (req: NextRequest) => {
   try {
     const body = await req.json().catch(() => ({}));
-    const targetPlan: string | undefined = body?.plan;
+    const requestedPlan = body?.plan;
     const confirm: boolean = body?.confirm === true;
     const requestedQuantity: number | undefined = body?.quantity;
+
+    const allowedPlans = new Set([
+      "pro-monthly-plan",
+      "ultra-monthly-plan",
+      "pro-yearly-plan",
+      "ultra-yearly-plan",
+      "team-monthly-plan",
+      "team-yearly-plan",
+    ]);
+    const targetPlan =
+      typeof requestedPlan === "string" && allowedPlans.has(requestedPlan)
+        ? requestedPlan
+        : "pro-monthly-plan";
 
     const userId = await getUserID(req);
     const user = await workos.userManagement.getUser(userId);
@@ -29,6 +42,13 @@ export const POST = async (req: NextRequest) => {
     }
 
     const membership = existingMemberships.data[0];
+    if (membership.role?.slug !== "admin") {
+      return NextResponse.json(
+        { error: "Only organization admins can manage billing" },
+        { status: 403 },
+      );
+    }
+
     const organization = await workos.organizations.getOrganization(
       membership.organizationId,
     );
@@ -62,7 +82,7 @@ export const POST = async (req: NextRequest) => {
 
     // Get target price
     const targetPrices = await stripe.prices.list({
-      lookup_keys: [targetPlan || "pro-monthly-plan"],
+      lookup_keys: [targetPlan],
     });
 
     if (!targetPrices.data || targetPrices.data.length === 0) {


### PR DESCRIPTION
### Motivation
- Prevent authenticated users from supplying arbitrary Stripe `lookup_key` values to mutate subscriptions and to ensure only authorized org admins can perform billing changes.

### Description
- Add an explicit allowlist of public plan lookup keys and normalize untrusted `body.plan` to a safe default via `allowedPlans` and `targetPlan` in `app/api/subscription-details/route.ts`.
- Require the caller's organization membership role to be `admin` and return `403` for non-admins before performing billing operations.
- Ensure Stripe lookup calls use the validated `targetPlan` (remove direct use of untrusted `body.plan`) so `stripe.prices.list` only searches approved keys.
- Preserve existing proration and subscription update behavior while restricting which plans can be selected and who may confirm changes.

### Testing
- Ran `pnpm exec eslint app/api/subscription-details/route.ts` with no reported issues.
- Typechecking executed (`tsc --noEmit`) as part of the pre-commit hooks and succeeded.
- Full test suite executed (`pnpm test` / `jest`) and passed: 91 test suites, 1149 tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a2c3b16483329411bcd08ddeaf8c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security & Bug Fixes**
  * Restricted subscription management to organization admins only; non-admins now receive an access error.
  * Enhanced billing plan validation with fallback to default plan for invalid requests.
  * Improved Stripe price lookup with stricter plan verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->