### PR TITLE
fix(pty): enforce guardrails for interact_terminal_session send input

### DIFF
--- a/lib/ai/tools/__tests__/interact-terminal-session.test.ts
+++ b/lib/ai/tools/__tests__/interact-terminal-session.test.ts
@@ -259,6 +259,25 @@ describe("interact_terminal_session — PTY action dispatch", () => {
     expect(handle.sendInputCalls.length).toBe(before);
   });
 
+  test("send blocks guardrail-matched destructive input", async () => {
+    const e2b = makeFakeE2BSandbox();
+    const handle = makeFakeHandle();
+
+    const { context } = makeContext({ sandbox: e2b });
+    const sessionId = await createSession(context, handle);
+    const before = handle.sendInputCalls.length;
+
+    const tool = createInteractTerminalSession(context);
+    const result = (await runTool(tool, {
+      action: "send",
+      session: sessionId,
+      input: "rm -rf /\n",
+    })) as { result: { error?: string } };
+
+    expect(result.result.error).toMatch(/Input blocked by security guardrail/);
+    expect(handle.sendInputCalls.length).toBe(before);
+  });
+
   test("send translates tmux key names and passes raw text verbatim", async () => {
     const e2b = makeFakeE2BSandbox();
     const handle = makeFakeHandle();

--- a/lib/ai/tools/__tests__/interact-terminal-session.test.ts
+++ b/lib/ai/tools/__tests__/interact-terminal-session.test.ts
@@ -278,6 +278,32 @@ describe("interact_terminal_session — PTY action dispatch", () => {
     expect(handle.sendInputCalls.length).toBe(before);
   });
 
+  test("send blocks destructive input assembled across split sends", async () => {
+    const e2b = makeFakeE2BSandbox();
+    const handle = makeFakeHandle();
+
+    const { context } = makeContext({ sandbox: e2b });
+    const sessionId = await createSession(context, handle);
+
+    const tool = createInteractTerminalSession(context);
+    const first = (await runTool(tool, {
+      action: "send",
+      session: sessionId,
+      input: "rm -",
+    })) as { result: { error?: string } };
+    expect(first.result.error).toBeUndefined();
+
+    const beforeBlockedChunk = handle.sendInputCalls.length;
+    const result = (await runTool(tool, {
+      action: "send",
+      session: sessionId,
+      input: "rf /\n",
+    })) as { result: { error?: string } };
+
+    expect(result.result.error).toMatch(/Input blocked by security guardrail/);
+    expect(handle.sendInputCalls.length).toBe(beforeBlockedChunk);
+  });
+
   test("send translates tmux key names and passes raw text verbatim", async () => {
     const e2b = makeFakeE2BSandbox();
     const handle = makeFakeHandle();

--- a/lib/ai/tools/interact-terminal-session.ts
+++ b/lib/ai/tools/interact-terminal-session.ts
@@ -13,6 +13,11 @@ import {
   peekExited,
 } from "./utils/pty-wait-utils";
 import { translateInput } from "./utils/pty-keys";
+import {
+  parseGuardrailConfig,
+  getEffectiveGuardrails,
+  checkCommandGuardrails,
+} from "./utils/guardrails";
 
 // ─── Interactive PTY constants ──────────────────────────────────────────
 const MAX_INPUT_BYTES_PER_SEND = 8 * 1024;
@@ -28,7 +33,9 @@ const SEND_IMMEDIATE_OUTPUT_WINDOW_MS = 500;
 const WAIT_QUIET_WINDOW_MS = 500;
 
 export const createInteractTerminalSession = (context: ToolContext) => {
-  const { writer, chatId, ptySessionManager } = context;
+  const { writer, chatId, ptySessionManager, guardrailsConfig } = context;
+  const userGuardrailConfig = parseGuardrailConfig(guardrailsConfig);
+  const effectiveGuardrails = getEffectiveGuardrails(userGuardrailConfig);
 
   return tool({
     description: `Interact with persistent shell sessions in the sandbox environment.
@@ -221,6 +228,15 @@ export const createInteractTerminalSession = (context: ToolContext) => {
         // Translate tmux key names (C-c, Up, Enter, ...) to escape sequences;
         // raw text passes through unchanged with trailing newline normalized
         // to CR so "echo hi\n" submits the line as a real Enter.
+        const guardrailResult = checkCommandGuardrails(
+          input,
+          effectiveGuardrails,
+        );
+        if (!guardrailResult.allowed) {
+          return errorResult(
+            `Input blocked by security guardrail "${guardrailResult.policyName}": ${guardrailResult.message}. This input pattern has been blocked for safety.`,
+          );
+        }
         const bytes = translateInput(input);
         if (bytes.byteLength > MAX_INPUT_BYTES_PER_SEND) {
           return errorResult(

--- a/lib/ai/tools/interact-terminal-session.ts
+++ b/lib/ai/tools/interact-terminal-session.ts
@@ -12,7 +12,7 @@ import {
   stripAnsi,
   peekExited,
 } from "./utils/pty-wait-utils";
-import { translateInput } from "./utils/pty-keys";
+import { TMUX_SPECIAL_KEYS, translateInput } from "./utils/pty-keys";
 import {
   parseGuardrailConfig,
   getEffectiveGuardrails,
@@ -31,6 +31,47 @@ const SEND_IMMEDIATE_OUTPUT_WINDOW_MS = 500;
 // as "process settled" — typically a redrawn prompt or completed command.
 // `timeout` remains the hard ceiling for processes that never settle.
 const WAIT_QUIET_WINDOW_MS = 500;
+const CLEAR_PENDING_INPUT_KEYS = new Set(["C-c", "C-u"]);
+const BACKSPACE_KEYS = new Set(["BSpace", "Backspace", "C-h"]);
+const SUBMIT_INPUT_KEYS = new Set(["Enter", "Return", "C-j"]);
+
+const getGuardrailInputFragment = (input: string): string => {
+  if (SUBMIT_INPUT_KEYS.has(input)) return "\n";
+  if (input === "Space") return " ";
+  if (input === "Tab" || input === "C-i") return "\t";
+  if (
+    TMUX_SPECIAL_KEYS.has(input) ||
+    (input.startsWith("M-") && input.length === 3) ||
+    (input.startsWith("C-S-") && input.length === 5)
+  ) {
+    return "";
+  }
+  return input;
+};
+
+const getGuardrailInputState = (
+  pendingInput: string,
+  input: string,
+): { checkInput: string; nextPendingInput: string } => {
+  if (CLEAR_PENDING_INPUT_KEYS.has(input)) {
+    return { checkInput: pendingInput, nextPendingInput: "" };
+  }
+  if (BACKSPACE_KEYS.has(input)) {
+    const nextPendingInput = pendingInput.slice(0, -1);
+    return { checkInput: nextPendingInput, nextPendingInput };
+  }
+
+  const checkInput = (pendingInput + getGuardrailInputFragment(input))
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
+  const lastNewlineIndex = checkInput.lastIndexOf("\n");
+  const nextPendingInput =
+    lastNewlineIndex === -1
+      ? checkInput
+      : checkInput.slice(lastNewlineIndex + 1);
+
+  return { checkInput, nextPendingInput };
+};
 
 export const createInteractTerminalSession = (context: ToolContext) => {
   const { writer, chatId, ptySessionManager, guardrailsConfig } = context;
@@ -61,7 +102,7 @@ export const createInteractTerminalSession = (context: ToolContext) => {
 - For modifier combinations: M-key (Alt), C-S-key (Ctrl+Shift)
 - Note: Use official tmux names (BSpace not Backspace, DC not Delete, Escape not Esc)
 - For non-key strings in \`input\`, DO NOT perform any escaping; send the raw string directly
-- Raw input BYPASSES command guardrails; never forward untrusted content
+- Raw input is checked against command guardrails, including text accumulated across split sends; never forward untrusted content
 </instructions>
 
 <recommended_usage>
@@ -228,8 +269,12 @@ export const createInteractTerminalSession = (context: ToolContext) => {
         // Translate tmux key names (C-c, Up, Enter, ...) to escape sequences;
         // raw text passes through unchanged with trailing newline normalized
         // to CR so "echo hi\n" submits the line as a real Enter.
-        const guardrailResult = checkCommandGuardrails(
+        const { checkInput, nextPendingInput } = getGuardrailInputState(
+          session.pendingGuardrailInput,
           input,
+        );
+        const guardrailResult = checkCommandGuardrails(
+          checkInput,
           effectiveGuardrails,
         );
         if (!guardrailResult.allowed) {
@@ -254,6 +299,7 @@ export const createInteractTerminalSession = (context: ToolContext) => {
             `Failed to send input: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
+        session.pendingGuardrailInput = nextPendingInput;
         session.lastActivityAt = Date.now();
         // Capture the immediate response chunk — prompts that echo a reply
         // ("Hello, X!") show up here. Use action=wait for processes that

--- a/lib/ai/tools/utils/pty-session-manager.ts
+++ b/lib/ai/tools/utils/pty-session-manager.ts
@@ -50,6 +50,8 @@ export interface PtySession {
   readCursor: number;
   /** Flipped once when the ring first drops any bytes. Never reset. */
   bufferTruncated: boolean;
+  /** Current unsubmitted shell input used to guardrail split `send` calls. */
+  pendingGuardrailInput: string;
 }
 
 export interface CreateSessionOpts {
@@ -127,6 +129,7 @@ export class PtySessionManager {
         buffer: [],
         readCursor: 0,
         bufferTruncated: false,
+        pendingGuardrailInput: "",
         droppedBytes: 0,
         idleTimer: null,
         lifetimeTimer: null,


### PR DESCRIPTION
### Motivation
- Close a guardrail bypass where `interact_terminal_session` could send arbitrary bytes to an interactive PTY after a benign `run_terminal_cmd` created the shell, allowing destructive commands to run despite initial command checks. 
- Ensure the same command-pattern guardrail pipeline that blocks dangerous `run_terminal_cmd` commands also applies to later `send` inputs into persistent PTY sessions.

### Description
- Import and wire `parseGuardrailConfig`, `getEffectiveGuardrails`, and `checkCommandGuardrails` into `createInteractTerminalSession` and compute `effectiveGuardrails` from `context.guardrailsConfig`. 
- Validate `input` in the `action=send` handler with `checkCommandGuardrails` and return a structured blocked-input error when a critical guardrail matches, before any PTY bytes are translated or written. 
- Add a regression unit test to `interact-terminal-session.test.ts` that asserts a destructive payload (`rm -rf /\n`) is blocked and that the PTY `sendInput` is not invoked.

### Testing
- Ran the updated unit tests for `interact_terminal_session` with `npx jest lib/ai/tools/__tests__/interact-terminal-session.test.ts --runInBand` and observed the suite pass (12 tests passed). 
- Ran the full test pipeline (prettier, `eslint --fix`, `tsc --noEmit`) and the full Jest test suite; all automated checks and tests passed (91 test suites, 1148 tests overall). 
- The newly added regression test passed, verifying the guardrail blocks dangerous `send` inputs and prevents calling `sendInput`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a147f12b3688332930be75c20519a63)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal sessions now enforce command guardrails: destructive commands are blocked before execution and return a clear security error to the caller.
* **Tests**
  * Added tests verifying blocked behavior for destructive commands, including when a command is sent in split fragments to ensure accumulated input is checked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/527?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->