### PR TITLE
[codex] Fix team auto-reload cap precheck

### DIFF
--- a/convex/__tests__/teamExtraUsage.test.ts
+++ b/convex/__tests__/teamExtraUsage.test.ts
@@ -356,6 +356,30 @@ describe("deductTeamPoints", () => {
     });
   });
 
+  it("returns monthlyCapExceeded even when balance is insufficient", async () => {
+    const { ctx } = makeMockCtx({
+      team: [
+        enabledTeamRow({
+          balance_points: 100,
+          monthly_cap_points: 500,
+          monthly_spent_points: 400,
+          monthly_reset_date: new Date().toISOString().slice(0, 7),
+        }),
+      ],
+    });
+    const result = await callDeduct(ctx, {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      amountPoints: 200,
+    });
+    expect(result).toMatchObject({
+      success: false,
+      insufficientFunds: true,
+      monthlyCapExceeded: true,
+      memberCapExceeded: false,
+    });
+  });
+
   it("returns monthlyCapExceeded when team cap would be breached", async () => {
     const { ctx } = makeMockCtx({
       team: [
@@ -400,6 +424,34 @@ describe("deductTeamPoints", () => {
     });
     expect(result).toMatchObject({
       success: false,
+      memberCapExceeded: true,
+      monthlyCapExceeded: false,
+    });
+  });
+
+  it("returns memberCapExceeded even when balance is insufficient", async () => {
+    const { ctx } = makeMockCtx({
+      team: [enabledTeamRow({ balance_points: 100 })],
+      members: [
+        {
+          _id: "m-1",
+          organization_id: ORG_ID,
+          user_id: USER_ID,
+          monthly_limit_points: 1000,
+          monthly_spent_points: 900,
+          monthly_reset_date: new Date().toISOString().slice(0, 7),
+          updated_at: 0,
+        },
+      ],
+    });
+    const result = await callDeduct(ctx, {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      amountPoints: 200,
+    });
+    expect(result).toMatchObject({
+      success: false,
+      insufficientFunds: true,
       memberCapExceeded: true,
       monthlyCapExceeded: false,
     });
@@ -546,6 +598,46 @@ describe("deductWithAutoReloadForTeam", () => {
       newBalanceDollars: 7,
       autoReloadTriggered: true,
       autoReloadResult: { success: false, reason: "no_stripe_customer" },
+    });
+  });
+
+  it("does not auto-reload when cap precheck blocks an underfunded request", async () => {
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        enabled: true,
+        balanceDollars: 0.01,
+        balancePoints: 100,
+        autoReloadEnabled: true,
+        autoReloadThresholdDollars: 7.5,
+        autoReloadThresholdPoints: 75_000,
+        autoReloadAmountDollars: 15,
+        memberDisabled: false,
+      })),
+      runMutation: jest.fn(async () => ({
+        success: false,
+        newBalancePoints: 100,
+        newBalanceDollars: 0.01,
+        insufficientFunds: true,
+        monthlyCapExceeded: false,
+        memberCapExceeded: true,
+        memberDisabled: false,
+        poolDisabled: false,
+      })),
+    };
+
+    const result = await callDeductWithAutoReloadForTeam(ctx, {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      amountPoints: 200,
+    });
+
+    expect(mockGetOrganization).not.toHaveBeenCalled();
+    expect(ctx.runMutation).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      success: false,
+      insufficientFunds: true,
+      memberCapExceeded: true,
+      autoReloadTriggered: false,
     });
   });
 });

--- a/convex/teamExtraUsage.ts
+++ b/convex/teamExtraUsage.ts
@@ -252,22 +252,8 @@ export const deductTeamPoints = mutation({
       };
     }
 
-    const currentBalancePoints = team.balance_points ?? 0;
-
-    if (currentBalancePoints < args.amountPoints) {
-      return {
-        success: false,
-        newBalancePoints: currentBalancePoints,
-        newBalanceDollars: pointsToDollars(currentBalancePoints),
-        insufficientFunds: true,
-        monthlyCapExceeded: false,
-        memberCapExceeded: false,
-        memberDisabled: false,
-        poolDisabled: false,
-      };
-    }
-
     const currentMonth = currentMonthString();
+    const currentBalancePoints = team.balance_points ?? 0;
 
     // Reset team monthly spent if cycle rolled over
     let teamMonthlySpent = team.monthly_spent_points ?? 0;
@@ -336,6 +322,19 @@ export const deductTeamPoints = mutation({
           poolDisabled: false,
         };
       }
+    }
+
+    if (currentBalancePoints < args.amountPoints) {
+      return {
+        success: false,
+        newBalancePoints: currentBalancePoints,
+        newBalanceDollars: pointsToDollars(currentBalancePoints),
+        insufficientFunds: true,
+        monthlyCapExceeded: false,
+        memberCapExceeded: false,
+        memberDisabled: false,
+        poolDisabled: false,
+      };
     }
 
     // All checks passed — commit


### PR DESCRIPTION
## Summary

- Make team extra-usage deduction evaluate team, trust, and per-member caps before treating a request as insufficiently funded.
- Add regressions for capped requests with insufficient pool balance and for auto-reload avoiding Stripe lookup when the cap precheck blocks.

## Root cause

`deductTeamPoints` returned `insufficientFunds` before checking cap state. `deductWithAutoReloadForTeam` therefore could see an underfunded capped request as balance-only failure, trigger auto-reload, credit the pool, and only then rediscover the cap on the second deduction.

## Validation

- `pnpm test -- convex/__tests__/teamExtraUsage.test.ts --runInBand`
- Commit hook: Prettier, ESLint, `tsc --noEmit`, full `jest` suite (`93` suites, `1167` tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when multiple payment constraints are violated simultaneously (insufficient balance, monthly cap, per-member cap) by establishing consistent priority rules for failure messages
  * Auto-reload feature no longer attempts when cap validation blocks the transaction

* **Tests**
  * Added comprehensive test coverage for edge cases where insufficient funds coincide with cap limit violations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->