### PR TITLE
[codex] validate chat mode at runtime

### DIFF
--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -33,6 +33,7 @@ import type {
   SandboxBootInfo,
   CaidoReadyInfo,
 } from "@/types";
+import { isChatMode } from "@/types";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import type { Geo } from "@vercel/functions";
 import { FileAccumulator } from "./utils/file-accumulator";
@@ -64,6 +65,10 @@ export const createTools = (
   onSandboxBoot?: (info: SandboxBootInfo) => void,
   onCaidoReady?: (info: CaidoReadyInfo) => void,
 ) => {
+  if (!isChatMode(mode)) {
+    throw new Error("Invalid chat mode.");
+  }
+
   let sandbox: AnySandbox | null = null;
   let sandboxFirstUsedAt: number | null = null;
 

--- a/lib/api/__tests__/chat-handler-mode-validation.test.ts
+++ b/lib/api/__tests__/chat-handler-mode-validation.test.ts
@@ -1,0 +1,44 @@
+import fs from "fs";
+import path from "path";
+
+const chatHandlerSrc = fs.readFileSync(
+  path.resolve(__dirname, "../chat-handler.ts"),
+  "utf8",
+);
+
+const toolsSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../ai/tools/index.ts"),
+  "utf8",
+);
+
+const systemPromptSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../system-prompt.ts"),
+  "utf8",
+);
+
+describe("chat mode validation", () => {
+  test("chat handler validates the runtime mode before applying gates", () => {
+    const validationIdx = chatHandlerSrc.indexOf("isChatMode(parsedMode)");
+    const freeAgentGateIdx = chatHandlerSrc.indexOf("assertFreeAgentGates({");
+
+    expect(validationIdx).toBeGreaterThan(-1);
+    expect(freeAgentGateIdx).toBeGreaterThan(validationIdx);
+    expect(chatHandlerSrc).toMatch(/Invalid chat mode\./);
+  });
+
+  test("tools fail closed for unknown modes", () => {
+    const validationIdx = toolsSrc.indexOf("isChatMode(mode)");
+    const askBranchIdx = toolsSrc.indexOf('mode === "ask"');
+
+    expect(validationIdx).toBeGreaterThan(-1);
+    expect(askBranchIdx).toBeGreaterThan(validationIdx);
+  });
+
+  test("system prompt fails closed for unknown modes", () => {
+    const validationIdx = systemPromptSrc.indexOf("isChatMode(mode)");
+    const askBranchIdx = systemPromptSrc.indexOf('mode === "ask"');
+
+    expect(validationIdx).toBeGreaterThan(-1);
+    expect(askBranchIdx).toBeGreaterThan(validationIdx);
+  });
+});

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -20,7 +20,7 @@ import type {
   SelectedModel,
   RateLimitInfo,
 } from "@/types";
-import { coerceSelectedModel } from "@/types";
+import { coerceSelectedModel, isChatMode } from "@/types";
 import { getBaseTodosForRequest } from "@/lib/utils/todo-utils";
 import {
   acquireFreeRunConcurrencyLock,
@@ -148,7 +148,7 @@ export const createChatHandler = (
     try {
       const {
         messages,
-        mode,
+        mode: rawMode,
         todos,
         chatId,
         regenerate,
@@ -159,7 +159,7 @@ export const createChatHandler = (
         useClientMessagesForRegenerate,
       }: {
         messages: UIMessage[];
-        mode: ChatMode;
+        mode?: string;
         chatId: string;
         todos?: Todo[];
         regenerate?: boolean;
@@ -169,6 +169,11 @@ export const createChatHandler = (
         isAutoContinue?: boolean;
         useClientMessagesForRegenerate?: boolean;
       } = await req.json();
+      const parsedMode = typeof rawMode === "string" ? rawMode : null;
+      if (!isChatMode(parsedMode)) {
+        throw new ChatSDKError("bad_request:api", "Invalid chat mode.");
+      }
+      const mode: ChatMode = parsedMode;
       outerChatId = chatId;
 
       const selectedModelOverride: SelectedModel | undefined =

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -1,6 +1,10 @@
-import type { ChatMode, SubscriptionTier } from "@/types";
+import {
+  isChatMode,
+  type ChatMode,
+  type SubscriptionTier,
+  type UserCustomization,
+} from "@/types";
 import { getPersonalityInstructions } from "./system-prompt/personality";
-import type { UserCustomization } from "@/types";
 import { generateUserBio } from "./system-prompt/bio";
 import { getNotesDisabledMessage } from "./system-prompt/notes";
 import {
@@ -382,6 +386,10 @@ export const systemPrompt = async (
   isTemporary?: boolean,
   sandboxContext?: string | null,
 ): Promise<string> => {
+  if (!isChatMode(mode)) {
+    throw new Error("Invalid chat mode.");
+  }
+
   const shouldIncludeNotes =
     (subscription !== "free" || mode === "agent") &&
     (userCustomization?.include_memory_entries ?? true);


### PR DESCRIPTION
## Summary

- Validate the runtime `mode` from `/api/chat` and `/api/agent` request bodies with `isChatMode()` before entitlement gates or downstream processing.
- Add fail-closed validation in `createTools()` and `systemPrompt()` so unknown modes cannot fall into the non-ask agent branch.
- Add regression coverage for the handler validation and lower-layer fail-closed checks.

## Root Cause

The shared chat handler trusted `req.json()` as `mode: ChatMode`, so legacy or arbitrary string literals could bypass TypeScript-only mode restrictions at runtime. Downstream code treated any mode other than `ask` as agent-capable.

## Validation

- `pnpm test -- lib/api/__tests__/chat-handler-mode-validation.test.ts lib/api/__tests__/chat-handler-pty-cleanup.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint lib/api/chat-handler.ts lib/ai/tools/index.ts lib/system-prompt.ts lib/api/__tests__/chat-handler-mode-validation.test.ts`
- Commit hook: `pnpm typecheck` and full `pnpm test` (`94` suites, `1167` tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added runtime validation for chat modes across request handling and tool initialization to ensure invalid modes are rejected before processing.

* **Tests**
  * Added comprehensive test suite verifying chat mode validation ensures failures occur early for invalid mode values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->