### PR TITLE
[codex] Secure account deletion for shared orgs

### DIFF
--- a/app/api/delete-account/__tests__/route.test.ts
+++ b/app/api/delete-account/__tests__/route.test.ts
@@ -1,0 +1,242 @@
+import { POST } from "../route";
+import { getUserIDWithFreshLogin } from "@/lib/auth/get-user-id";
+import { deleteUserRateLimitKeys } from "@/lib/rate-limit/token-bucket";
+import { stripe } from "../../stripe";
+import { workos } from "../../workos";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("@/lib/auth/get-user-id", () => ({
+  getUserIDWithFreshLogin: jest.fn(),
+}));
+
+jest.mock("@/lib/rate-limit/token-bucket", () => ({
+  deleteUserRateLimitKeys: jest.fn(),
+}));
+
+jest.mock("../../stripe", () => ({
+  stripe: {
+    subscriptions: {
+      list: jest.fn(),
+      cancel: jest.fn(),
+    },
+    customers: {
+      del: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../workos", () => ({
+  workos: {
+    userManagement: {
+      listOrganizationMemberships: jest.fn(),
+      deleteOrganizationMembership: jest.fn(),
+      deleteUser: jest.fn(),
+    },
+    organizations: {
+      getOrganization: jest.fn(),
+      deleteOrganization: jest.fn(),
+    },
+  },
+}));
+
+const mockGetUserIDWithFreshLogin =
+  getUserIDWithFreshLogin as jest.MockedFunction<
+    typeof getUserIDWithFreshLogin
+  >;
+const mockDeleteUserRateLimitKeys =
+  deleteUserRateLimitKeys as jest.MockedFunction<
+    typeof deleteUserRateLimitKeys
+  >;
+const mockListOrganizationMemberships = workos.userManagement
+  .listOrganizationMemberships as jest.MockedFunction<
+  typeof workos.userManagement.listOrganizationMemberships
+>;
+const mockDeleteOrganizationMembership = workos.userManagement
+  .deleteOrganizationMembership as jest.MockedFunction<
+  typeof workos.userManagement.deleteOrganizationMembership
+>;
+const mockDeleteUser = workos.userManagement.deleteUser as jest.MockedFunction<
+  typeof workos.userManagement.deleteUser
+>;
+const mockGetOrganization = workos.organizations
+  .getOrganization as jest.MockedFunction<
+  typeof workos.organizations.getOrganization
+>;
+const mockDeleteOrganization = workos.organizations
+  .deleteOrganization as jest.MockedFunction<
+  typeof workos.organizations.deleteOrganization
+>;
+const mockListSubscriptions = stripe.subscriptions.list as jest.MockedFunction<
+  typeof stripe.subscriptions.list
+>;
+const mockCancelSubscription = stripe.subscriptions
+  .cancel as jest.MockedFunction<typeof stripe.subscriptions.cancel>;
+const mockDeleteCustomer = stripe.customers.del as jest.MockedFunction<
+  typeof stripe.customers.del
+>;
+
+const request = () => ({ url: "https://hackerai.test/api/delete-account" });
+
+describe("POST /api/delete-account", () => {
+  beforeEach(() => {
+    mockGetUserIDWithFreshLogin.mockResolvedValue("user_123");
+    mockDeleteUserRateLimitKeys.mockResolvedValue(undefined);
+    mockDeleteOrganizationMembership.mockResolvedValue(undefined as never);
+    mockDeleteUser.mockResolvedValue(undefined as never);
+    mockDeleteOrganization.mockResolvedValue(undefined as never);
+    mockCancelSubscription.mockResolvedValue({} as never);
+    mockDeleteCustomer.mockResolvedValue({} as never);
+  });
+
+  it("removes only the caller's membership for shared organizations", async () => {
+    const callerMembership = {
+      id: "membership_user",
+      organizationId: "org_team",
+      userId: "user_123",
+      role: { slug: "member" },
+    };
+
+    mockListOrganizationMemberships
+      .mockResolvedValueOnce({ data: [callerMembership] } as never)
+      .mockResolvedValueOnce({
+        data: [
+          callerMembership,
+          {
+            id: "membership_admin",
+            organizationId: "org_team",
+            userId: "user_admin",
+            role: { slug: "admin" },
+          },
+        ],
+      } as never);
+
+    const response = await POST(request() as any);
+
+    expect(response.status).toBe(200);
+    expect(mockDeleteOrganizationMembership).toHaveBeenCalledWith(
+      "membership_user",
+    );
+    expect(mockGetOrganization).not.toHaveBeenCalled();
+    expect(mockListSubscriptions).not.toHaveBeenCalled();
+    expect(mockCancelSubscription).not.toHaveBeenCalled();
+    expect(mockDeleteCustomer).not.toHaveBeenCalled();
+    expect(mockDeleteOrganization).not.toHaveBeenCalled();
+    expect(mockDeleteUser).toHaveBeenCalledWith("user_123");
+  });
+
+  it("deletes billing and organization resources for a solo admin organization", async () => {
+    const callerMembership = {
+      id: "membership_user",
+      organizationId: "org_solo",
+      userId: "user_123",
+      role: { slug: "admin" },
+    };
+
+    mockListOrganizationMemberships
+      .mockResolvedValueOnce({ data: [callerMembership] } as never)
+      .mockResolvedValueOnce({ data: [callerMembership] } as never);
+    mockGetOrganization.mockResolvedValue({
+      id: "org_solo",
+      stripeCustomerId: "cus_123",
+    } as never);
+    mockListSubscriptions.mockResolvedValue({
+      data: [{ id: "sub_1" }, { id: "sub_2" }],
+    } as never);
+
+    const response = await POST(request() as any);
+
+    expect(response.status).toBe(200);
+    expect(mockListSubscriptions).toHaveBeenCalledWith({
+      customer: "cus_123",
+      status: "all",
+      limit: 100,
+    });
+    expect(mockCancelSubscription).toHaveBeenCalledWith("sub_1");
+    expect(mockCancelSubscription).toHaveBeenCalledWith("sub_2");
+    expect(mockDeleteCustomer).toHaveBeenCalledWith("cus_123");
+    expect(mockDeleteOrganization).toHaveBeenCalledWith("org_solo");
+    expect(mockDeleteOrganizationMembership).not.toHaveBeenCalled();
+    expect(mockDeleteUser).toHaveBeenCalledWith("user_123");
+  });
+
+  it("does not delete org billing when a shared-org admin deletes their account", async () => {
+    const callerMembership = {
+      id: "membership_admin",
+      organizationId: "org_team",
+      userId: "user_123",
+      role: { slug: "admin" },
+    };
+
+    mockListOrganizationMemberships
+      .mockResolvedValueOnce({ data: [callerMembership] } as never)
+      .mockResolvedValueOnce({
+        data: [
+          callerMembership,
+          {
+            id: "membership_other_admin",
+            organizationId: "org_team",
+            userId: "user_admin",
+            role: { slug: "admin" },
+          },
+          {
+            id: "membership_member",
+            organizationId: "org_team",
+            userId: "user_member",
+            role: { slug: "member" },
+          },
+        ],
+      } as never);
+
+    const response = await POST(request() as any);
+
+    expect(response.status).toBe(200);
+    expect(mockDeleteOrganizationMembership).toHaveBeenCalledWith(
+      "membership_admin",
+    );
+    expect(mockListSubscriptions).not.toHaveBeenCalled();
+    expect(mockDeleteCustomer).not.toHaveBeenCalled();
+    expect(mockDeleteOrganization).not.toHaveBeenCalled();
+    expect(mockDeleteUser).toHaveBeenCalledWith("user_123");
+  });
+
+  it("blocks deletion when the caller is the last admin of a shared organization", async () => {
+    const callerMembership = {
+      id: "membership_admin",
+      organizationId: "org_team",
+      userId: "user_123",
+      role: { slug: "admin" },
+    };
+
+    mockListOrganizationMemberships
+      .mockResolvedValueOnce({ data: [callerMembership] } as never)
+      .mockResolvedValueOnce({
+        data: [
+          callerMembership,
+          {
+            id: "membership_member",
+            organizationId: "org_team",
+            userId: "user_member",
+            role: { slug: "member" },
+          },
+        ],
+      } as never);
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("last admin");
+    expect(mockDeleteOrganizationMembership).not.toHaveBeenCalled();
+    expect(mockListSubscriptions).not.toHaveBeenCalled();
+    expect(mockDeleteOrganization).not.toHaveBeenCalled();
+    expect(mockDeleteUser).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/delete-account/route.ts
+++ b/app/api/delete-account/route.ts
@@ -5,6 +5,74 @@ import { getUserIDWithFreshLogin } from "@/lib/auth/get-user-id";
 import { deleteUserRateLimitKeys } from "@/lib/rate-limit/token-bucket";
 import { ChatSDKError } from "@/lib/errors";
 
+type OrganizationMembership = Awaited<
+  ReturnType<typeof workos.userManagement.listOrganizationMemberships>
+>["data"][number];
+
+type MembershipDeletionPlan = {
+  membership: OrganizationMembership;
+  deleteOrganization: boolean;
+  blockReason?: string;
+};
+
+async function removeMembership(membership: OrganizationMembership) {
+  try {
+    await workos.userManagement.deleteOrganizationMembership(membership.id);
+  } catch (memErr) {
+    console.error(
+      "Failed to delete organization membership:",
+      membership.id,
+      memErr,
+    );
+  }
+}
+
+async function getMembershipDeletionPlan(
+  membership: OrganizationMembership,
+): Promise<MembershipDeletionPlan> {
+  try {
+    const activeMembershipsPage =
+      await workos.userManagement.listOrganizationMemberships({
+        organizationId: membership.organizationId,
+        statuses: ["active"],
+      });
+    const activeMemberships = activeMembershipsPage.data;
+    const activeCallerMembership = activeMemberships.find(
+      (activeMembership) => activeMembership.id === membership.id,
+    );
+    const isSoleActiveMember =
+      activeMemberships.length === 1 &&
+      activeCallerMembership?.id === membership.id;
+    const isAdmin =
+      membership.role?.slug === "admin" ||
+      activeCallerMembership?.role?.slug === "admin";
+    const activeAdminCount = activeMemberships.filter(
+      (activeMembership) => activeMembership.role?.slug === "admin",
+    ).length;
+
+    if (!isSoleActiveMember && isAdmin && activeAdminCount <= 1) {
+      return {
+        membership,
+        deleteOrganization: false,
+        blockReason:
+          "Cannot delete account while you are the last admin of a shared organization. Promote another admin or leave the team first.",
+      };
+    }
+
+    return {
+      membership,
+      deleteOrganization: isSoleActiveMember && isAdmin,
+    };
+  } catch (e) {
+    console.warn(
+      "Failed to verify organization membership count; removing membership only:",
+      membership.organizationId,
+      e,
+    );
+    return { membership, deleteOrganization: false };
+  }
+}
+
 export const POST = async (req: NextRequest) => {
   try {
     // Enforce recent login (10-minute window) before any destructive action
@@ -18,80 +86,88 @@ export const POST = async (req: NextRequest) => {
       },
     );
 
-    // Process each organization from memberships: cancel at most one active Stripe subscription and remove org
+    const membershipDeletionPlans = await Promise.all(
+      memberships.data.map(getMembershipDeletionPlan),
+    );
+    const blockedPlan = membershipDeletionPlans.find(
+      (plan) => plan.blockReason,
+    );
+
+    if (blockedPlan?.blockReason) {
+      return NextResponse.json(
+        { error: blockedPlan.blockReason },
+        { status: 400 },
+      );
+    }
+
+    // Process each organization from memberships. Only delete org-level billing
+    // and identity resources after proving this user is the sole active admin.
     await Promise.all(
-      memberships.data.map(async (membership) => {
-        const orgId = membership.organizationId;
+      membershipDeletionPlans.map(
+        async ({ membership, deleteOrganization }) => {
+          const orgId = membership.organizationId;
 
-        // Load organization to get Stripe customer ID if present
-        let org: any = null;
-        try {
-          org = await workos.organizations.getOrganization(orgId);
-        } catch (e) {
-          console.warn("Failed to load organization:", orgId, e);
-        }
+          if (!deleteOrganization) {
+            await removeMembership(membership);
+            return;
+          }
 
-        const stripeCustomerId: string | undefined = org?.stripeCustomerId;
+          // Load organization to get Stripe customer ID if present
+          let org: any = null;
+          try {
+            org = await workos.organizations.getOrganization(orgId);
+          } catch (e) {
+            console.warn("Failed to load organization:", orgId, e);
+          }
 
-        // Cancel all subscriptions for the Stripe customer (no status checks), then delete the customer
-        if (stripeCustomerId) {
-          const subs = await stripe.subscriptions.list({
-            customer: stripeCustomerId,
-            status: "all",
-            limit: 100,
-          });
+          const stripeCustomerId: string | undefined = org?.stripeCustomerId;
 
-          // Cancel subscriptions, continue on failures
-          for (const sub of subs.data) {
+          // Cancel all subscriptions for the Stripe customer (no status checks), then delete the customer
+          if (stripeCustomerId) {
+            const subs = await stripe.subscriptions.list({
+              customer: stripeCustomerId,
+              status: "all",
+              limit: 100,
+            });
+
+            // Cancel subscriptions, continue on failures
+            for (const sub of subs.data) {
+              try {
+                await stripe.subscriptions.cancel(sub.id as string);
+              } catch (subErr) {
+                console.warn(
+                  "Failed to cancel subscription, continuing:",
+                  sub.id,
+                  subErr,
+                );
+              }
+            }
+
+            // Delete the Stripe customer after cancellations
             try {
-              await stripe.subscriptions.cancel(sub.id as string);
-            } catch (subErr) {
-              console.warn(
-                "Failed to cancel subscription, continuing:",
-                sub.id,
-                subErr,
+              await stripe.customers.del(stripeCustomerId);
+            } catch (custErr) {
+              console.error(
+                "Failed to delete Stripe customer:",
+                stripeCustomerId,
+                custErr,
               );
             }
           }
 
-          // Delete the Stripe customer after cancellations
+          // Delete the WorkOS organization only for verified single-member orgs.
           try {
-            await stripe.customers.del(stripeCustomerId);
-          } catch (custErr) {
-            console.error(
-              "Failed to delete Stripe customer:",
-              stripeCustomerId,
-              custErr,
+            await workos.organizations.deleteOrganization(orgId);
+          } catch (orgDeleteErr) {
+            console.warn(
+              "Failed to delete organization, removing membership instead:",
+              orgId,
+              orgDeleteErr,
             );
+            await removeMembership(membership);
           }
-        }
-
-        // Try to delete the WorkOS organization entirely
-        // NOTE: Currently safe since subscriptions are single-person only (one user per org).
-        // TODO: If team plans are added, check membership count before deleting org to avoid
-        // user-triggered deletion of shared organizations. Only delete if sole member or owner.
-        try {
-          // Prefer deleting the organization; if it fails (e.g., shared org), fall back to removing membership
-          await workos.organizations.deleteOrganization(orgId);
-        } catch (orgDeleteErr) {
-          console.warn(
-            "Failed to delete organization, removing membership instead:",
-            orgId,
-            orgDeleteErr,
-          );
-          try {
-            await workos.userManagement.deleteOrganizationMembership(
-              membership.id,
-            );
-          } catch (memErr) {
-            console.error(
-              "Failed to delete organization membership:",
-              membership.id,
-              memErr,
-            );
-          }
-        }
-      }),
+        },
+      ),
     );
 
     // Purge Redis rate-limit keys. Best-effort: WorkOS user deletion proceeds


### PR DESCRIPTION
## Summary

Fixes account deletion so a user-level delete cannot escalate into deleting shared organization billing or identity resources.

## What changed

- Preflights each WorkOS membership before mutating anything.
- Only cancels Stripe billing and deletes the WorkOS organization when the caller is verified as the sole active admin member.
- For shared organizations, removes only the caller's membership.
- Blocks account deletion when the caller is the last admin of a shared organization, matching the existing team-member removal safety model.
- Adds route-level tests for shared member, solo admin, shared admin with another admin, and last-admin shared-org behavior.

## Validation

- `pnpm test app/api/delete-account/__tests__/route.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings outside this change)
- Pre-commit hook: `tsc --noEmit` and full `jest` suite, 94 suites / 1168 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account deletion now prevents removal if you're the sole admin of a shared organization
  * Improved resource cleanup during account deletion

* **Tests**
  * Added comprehensive test suite for account deletion scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->