### PR TITLE
[codex] Secure subscription billing authorization

### DIFF
--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+const mockGetUserID = jest.fn();
+const mockGetUser = jest.fn();
+const mockListOrganizationMemberships = jest.fn();
+const mockCreateOrganizationMembership = jest.fn();
+const mockGetOrganization = jest.fn();
+const mockCreateOrganization = jest.fn();
+const mockUpdateOrganization = jest.fn();
+const mockListPrices = jest.fn();
+const mockListCustomers = jest.fn();
+const mockCreateCustomer = jest.fn();
+const mockRetrieveCustomer = jest.fn();
+const mockCreateCheckoutSession = jest.fn();
+const mockPostHogEvent = jest.fn();
+const mockPostHogFlush = jest.fn();
+
+jest.mock("next/server", () => {
+  return {
+    after: jest.fn((callback: () => void) => callback()),
+    NextResponse: {
+      json: jest.fn((body: unknown, init?: ResponseInit) => ({
+        status: init?.status ?? 200,
+        json: async () => body,
+      })),
+    },
+  };
+});
+
+jest.mock("@/lib/auth/get-user-id", () => ({
+  getUserID: mockGetUserID,
+}));
+
+jest.mock("@/app/api/workos", () => ({
+  workos: {
+    userManagement: {
+      getUser: mockGetUser,
+      listOrganizationMemberships: mockListOrganizationMemberships,
+      createOrganizationMembership: mockCreateOrganizationMembership,
+    },
+    organizations: {
+      getOrganization: mockGetOrganization,
+      createOrganization: mockCreateOrganization,
+      updateOrganization: mockUpdateOrganization,
+    },
+  },
+}));
+
+jest.mock("@/app/api/stripe", () => ({
+  stripe: {
+    prices: {
+      list: mockListPrices,
+    },
+    customers: {
+      list: mockListCustomers,
+      create: mockCreateCustomer,
+      retrieve: mockRetrieveCustomer,
+    },
+    checkout: {
+      sessions: {
+        create: mockCreateCheckoutSession,
+      },
+    },
+  },
+}));
+
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: {
+    event: mockPostHogEvent,
+    flush: mockPostHogFlush,
+  },
+}));
+
+function makeRequest(body: Record<string, unknown> = {}) {
+  return {
+    json: jest.fn().mockResolvedValue(body),
+    headers: {
+      get: jest.fn().mockReturnValue(null),
+    },
+  } as any;
+}
+
+describe("POST /api/subscribe", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_BASE_URL = "https://hackerai.example";
+
+    mockGetUserID.mockResolvedValue("user_123" as never);
+    mockGetUser.mockResolvedValue({
+      id: "user_123",
+      email: "user@example.com",
+      firstName: "Ada",
+      lastName: "Lovelace",
+    } as never);
+    mockListPrices.mockResolvedValue({
+      data: [
+        {
+          id: "price_pro",
+          recurring: { interval: "month", interval_count: 1 },
+          unit_amount: 2000,
+          currency: "usd",
+        },
+      ],
+    } as never);
+    mockCreateCheckoutSession.mockResolvedValue({
+      id: "cs_123",
+      url: "https://stripe.example/checkout",
+    } as never);
+  });
+
+  it("rejects existing organization members who are not billing admins", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          role: { slug: "member" },
+        },
+      ],
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({
+      error: "Only organization admins can manage billing",
+    });
+    expect(mockListOrganizationMemberships).toHaveBeenCalledWith({
+      userId: "user_123",
+      statuses: ["active"],
+    });
+    expect(mockGetOrganization).not.toHaveBeenCalled();
+    expect(mockCreateCustomer).not.toHaveBeenCalled();
+    expect(mockUpdateOrganization).not.toHaveBeenCalled();
+    expect(mockCreateCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it("uses an existing organization Stripe customer instead of replacing it", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          role: { slug: "admin" },
+        },
+      ],
+    } as never);
+    mockGetOrganization.mockResolvedValue({
+      id: "org_team",
+      stripeCustomerId: "cus_existing_org",
+    } as never);
+    mockRetrieveCustomer.mockResolvedValue({
+      id: "cus_existing_org",
+      metadata: {},
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(makeRequest({ plan: "team-monthly-plan" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ url: "https://stripe.example/checkout" });
+    expect(mockRetrieveCustomer).toHaveBeenCalledWith("cus_existing_org");
+    expect(mockListCustomers).not.toHaveBeenCalled();
+    expect(mockCreateCustomer).not.toHaveBeenCalled();
+    expect(mockUpdateOrganization).not.toHaveBeenCalled();
+    expect(mockCreateCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: "cus_existing_org",
+        metadata: expect.objectContaining({
+          workOSOrganizationId: "org_team",
+        }),
+      }),
+    );
+  });
+});

--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -125,7 +125,7 @@ describe("POST /api/subscribe", () => {
 
     expect(response.status).toBe(403);
     expect(body).toEqual({
-      error: "Only organization admins can manage billing",
+      error: "Only organization admins or owners can manage billing",
     });
     expect(mockListOrganizationMemberships).toHaveBeenCalledWith({
       userId: "user_123",
@@ -172,6 +172,48 @@ describe("POST /api/subscribe", () => {
         metadata: expect.objectContaining({
           workOSOrganizationId: "org_team",
         }),
+      }),
+    );
+  });
+
+  it("persists a metadata-matched Stripe customer onto the organization", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          role: { slug: "owner" },
+        },
+      ],
+    } as never);
+    mockGetOrganization.mockResolvedValue({
+      id: "org_team",
+    } as never);
+    mockListCustomers.mockResolvedValue({
+      data: [
+        {
+          id: "cus_matched",
+          metadata: {
+            workOSOrganizationId: "org_team",
+          },
+        },
+      ],
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(makeRequest({ plan: "team-monthly-plan" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ url: "https://stripe.example/checkout" });
+    expect(mockCreateCustomer).not.toHaveBeenCalled();
+    expect(mockUpdateOrganization).toHaveBeenCalledWith({
+      organization: "org_team",
+      stripeCustomerId: "cus_matched",
+    });
+    expect(mockCreateCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: "cus_matched",
       }),
     );
   });

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -78,7 +78,7 @@ export const POST = async (req: NextRequest) => {
       const membership = existingMemberships.data[0];
       if (!canManageOrganizationBilling(membership)) {
         return NextResponse.json(
-          { error: "Only organization admins can manage billing" },
+          { error: "Only organization admins or owners can manage billing" },
           { status: 403 },
         );
       }
@@ -134,6 +134,7 @@ export const POST = async (req: NextRequest) => {
 
     // Check if organization already has a Stripe customer
     let customer;
+    let shouldAttachCustomerToOrganization = false;
 
     if (organization.stripeCustomerId) {
       const existingCustomer = await stripe.customers.retrieve(
@@ -162,6 +163,7 @@ export const POST = async (req: NextRequest) => {
 
       if (matchingCustomer) {
         customer = matchingCustomer;
+        shouldAttachCustomerToOrganization = true;
       }
     }
 
@@ -186,6 +188,10 @@ export const POST = async (req: NextRequest) => {
         },
       });
 
+      shouldAttachCustomerToOrganization = true;
+    }
+
+    if (shouldAttachCustomerToOrganization) {
       // Update WorkOS organization with Stripe customer ID
       // This will allow WorkOS to automatically add entitlements to the access token
       await workos.organizations.updateOrganization({

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -16,6 +16,14 @@ function planLookupKeyToTier(
   return null;
 }
 
+function canManageOrganizationBilling(
+  membership: Awaited<
+    ReturnType<typeof workos.userManagement.listOrganizationMemberships>
+  >["data"][number],
+) {
+  return membership.role?.slug === "admin" || membership.role?.slug === "owner";
+}
+
 export const POST = async (req: NextRequest) => {
   try {
     const body = await req.json().catch(() => ({}));
@@ -60,6 +68,7 @@ export const POST = async (req: NextRequest) => {
     const existingMemberships =
       await workos.userManagement.listOrganizationMemberships({
         userId,
+        statuses: ["active"],
       });
 
     let organization;
@@ -67,6 +76,13 @@ export const POST = async (req: NextRequest) => {
     if (existingMemberships.data && existingMemberships.data.length > 0) {
       // User already has an organization, use the first one
       const membership = existingMemberships.data[0];
+      if (!canManageOrganizationBilling(membership)) {
+        return NextResponse.json(
+          { error: "Only organization admins can manage billing" },
+          { status: 403 },
+        );
+      }
+
       organization = await workos.organizations.getOrganization(
         membership.organizationId,
       );
@@ -119,31 +135,46 @@ export const POST = async (req: NextRequest) => {
     // Check if organization already has a Stripe customer
     let customer;
 
-    // Try to find existing customer by email and organization metadata
-    const existingCustomers = await stripe.customers.list({
-      email: user.email,
-      limit: 10, // Get more to check metadata
-    });
+    if (organization.stripeCustomerId) {
+      const existingCustomer = await stripe.customers.retrieve(
+        organization.stripeCustomerId,
+      );
 
-    // Look for a customer with matching organization ID in metadata
-    const matchingCustomer = existingCustomers.data.find(
-      (c) => c.metadata.workOSOrganizationId === organization.id,
-    );
+      if ("deleted" in existingCustomer && existingCustomer.deleted) {
+        return NextResponse.json(
+          { error: "Billing account is no longer available" },
+          { status: 409 },
+        );
+      }
 
-    if (matchingCustomer) {
+      customer = existingCustomer;
+    } else {
+      // Try to find existing customer by email and organization metadata
+      const existingCustomers = await stripe.customers.list({
+        email: user.email,
+        limit: 10, // Get more to check metadata
+      });
+
+      // Look for a customer with matching organization ID in metadata
+      const matchingCustomer = existingCustomers.data.find(
+        (c) => c.metadata.workOSOrganizationId === organization.id,
+      );
+
+      if (matchingCustomer) {
+        customer = matchingCustomer;
+      }
+    }
+
+    if (customer) {
       // Reject blocked customers (flagged by fraud webhook)
-      if (matchingCustomer.metadata.blocked === "true") {
+      if (customer.metadata.blocked === "true") {
         return NextResponse.json(
           {
-            error: getSuspensionMessage(
-              matchingCustomer.metadata.blocked_reason,
-            ),
+            error: getSuspensionMessage(customer.metadata.blocked_reason),
           },
           { status: 403 },
         );
       }
-
-      customer = matchingCustomer;
     }
 
     if (!customer) {

--- a/lib/actions/billing-portal.ts
+++ b/lib/actions/billing-portal.ts
@@ -15,7 +15,7 @@ export default async function redirectToBillingPortal() {
     throw new Error("No organization found");
   }
 
-  // Check if user is an admin of the organization (for team subscriptions)
+  // Check if user can manage billing for the organization.
   const memberships = await workos.userManagement.listOrganizationMemberships({
     userId: user.id,
     organizationId,
@@ -27,9 +27,11 @@ export default async function redirectToBillingPortal() {
     throw new Error("User is not a member of this organization");
   }
 
-  // Only admins can access billing portal for team subscriptions
-  if (userMembership.role?.slug !== "admin") {
-    throw new Error("Only admins can manage billing");
+  if (
+    userMembership.role?.slug !== "admin" &&
+    userMembership.role?.slug !== "owner"
+  ) {
+    throw new Error("Only admins or owners can manage billing");
   }
 
   const response = await fetch(


### PR DESCRIPTION
## Summary

- Require an active admin or owner organization membership before `/api/subscribe` can mutate billing for an existing WorkOS organization.
- Reuse an existing organization `stripeCustomerId` when present instead of looking up or creating a customer from the caller's email and updating the organization linkage.
- Add regression coverage for non-admin rejection and preserving the org Stripe customer.

## Why

The subscription route authenticated users but did not authorize billing control for existing organization memberships. A regular org member could reach the checkout flow and potentially attach a Stripe customer tied to their email to the shared organization.

## Validation

- `pnpm test app/api/subscribe/__tests__/route.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- Commit hook: `pnpm typecheck` and full `pnpm test` suite, 94 suites / 1166 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription creation now only allowed for organization admins or owners; others receive a forbidden response.
  * Better handling of existing customer records: deleted/blocked customers are detected and invalid states are surfaced.
  * Matched billing customers are reused and linked to the organization to avoid duplicate records.

* **Tests**
  * Added end-to-end tests covering subscription and checkout behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->