### PR TITLE
[codex] fix subscription invoice usage resets

### DIFF
--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/rate-limit";
 import { phLogger } from "@/lib/posthog/server";
 import { resolveUserIdsFromCustomer as resolveStripeCustomerUsers } from "@/lib/billing/resolve-customer-users";
+import { getInvoicePaidBucketResetMode } from "@/lib/billing/subscription-invoice-reset";
 import type { SubscriptionTier } from "@/types";
 
 // Linear ranking used to label tier transitions as upgrade/downgrade. Team is
@@ -157,6 +158,14 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
     return;
   }
 
+  const resetMode = getInvoicePaidBucketResetMode(invoice);
+  if (resetMode.mode === "skip") {
+    console.log(
+      `[Subscription Webhook] invoice.paid (${resetMode.reason}): skipping bucket reset for invoice ${invoice.id}`,
+    );
+    return;
+  }
+
   const [customerResult, resolved] = await Promise.all([
     resolveUserIdsFromCustomer(customerId),
     resolveSubscription(subscriptionId),
@@ -172,13 +181,12 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
   }
 
   const { tier, subscription } = resolved;
-  const billingReason = (invoice as any).billing_reason as string | undefined;
 
   // Mid-cycle tier change: prorate credits based on remaining time in the cycle.
   // Only prorate if handleSubscriptionUpdated stashed old-tier data (confirms
   // a real tier change). Other subscription_update reasons (quantity changes,
-  // billing anchor changes) fall through to the full reset path.
-  if (billingReason === "subscription_update") {
+  // billing anchor changes) are ignored so they cannot mint fresh credits.
+  if (resetMode.mode === "subscription_update_proration") {
     // Check each user for a tier-change stash; collect those that have one
     const stashResults = await Promise.all(
       userIds.map(async (uid) => ({
@@ -227,16 +235,20 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
 
       return;
     }
-    // No stash found for any user — not a tier change, fall through to full reset
+
+    console.log(
+      `[Subscription Webhook] invoice.paid (subscription_update): no tier-change stash for invoice ${invoice.id}; skipping bucket reset`,
+    );
+    return;
   }
 
   // Regular renewal or new subscription: full credits
   console.log(
-    `[Subscription Webhook] invoice.paid (${billingReason ?? "unknown"}): resetting ${tier} buckets for ${userIds.length} user(s)`,
+    `[Subscription Webhook] invoice.paid (${resetMode.reason}): resetting ${tier} buckets for ${userIds.length} user(s)`,
   );
   await Promise.all(userIds.map((uid) => resetRateLimitBuckets(uid, tier)));
 
-  if (billingReason === "subscription_create") {
+  if (resetMode.reason === "subscription_create") {
     const item = subscription.items?.data[0];
     const price = item?.price;
     const invoiceAmountPaidDollars = centsToDollars(

--- a/lib/billing/__tests__/subscription-invoice-reset.test.ts
+++ b/lib/billing/__tests__/subscription-invoice-reset.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "@jest/globals";
+import { getInvoicePaidBucketResetMode } from "../subscription-invoice-reset";
+
+describe("getInvoicePaidBucketResetMode", () => {
+  it("allows full resets for paid renewal invoices", () => {
+    expect(
+      getInvoicePaidBucketResetMode({
+        billing_reason: "subscription_cycle",
+        amount_paid: 4000,
+      }),
+    ).toEqual({
+      mode: "full_reset",
+      reason: "subscription_cycle",
+    });
+  });
+
+  it("allows full resets for paid subscription creation invoices", () => {
+    expect(
+      getInvoicePaidBucketResetMode({
+        billing_reason: "subscription_create",
+        amount_paid: 2500,
+      }),
+    ).toEqual({
+      mode: "full_reset",
+      reason: "subscription_create",
+    });
+  });
+
+  it("routes subscription updates only through the proration path", () => {
+    expect(
+      getInvoicePaidBucketResetMode({
+        billing_reason: "subscription_update",
+        amount_paid: 100,
+      }),
+    ).toEqual({
+      mode: "subscription_update_proration",
+      reason: "subscription_update",
+    });
+  });
+
+  it("skips manual and threshold invoices", () => {
+    expect(
+      getInvoicePaidBucketResetMode({
+        billing_reason: "manual",
+        amount_paid: 4000,
+      }),
+    ).toEqual({
+      mode: "skip",
+      reason: "manual",
+    });
+
+    expect(
+      getInvoicePaidBucketResetMode({
+        billing_reason: "subscription_threshold",
+        amount_paid: 4000,
+      }),
+    ).toEqual({
+      mode: "skip",
+      reason: "subscription_threshold",
+    });
+  });
+
+  it("skips zero-dollar and credit-paid renewal invoices", () => {
+    expect(
+      getInvoicePaidBucketResetMode({
+        billing_reason: "subscription_cycle",
+        amount_paid: 0,
+      }),
+    ).toEqual({
+      mode: "skip",
+      reason: "subscription_cycle:non_positive_amount",
+    });
+  });
+});

--- a/lib/billing/subscription-invoice-reset.ts
+++ b/lib/billing/subscription-invoice-reset.ts
@@ -1,0 +1,48 @@
+type InvoiceForBucketReset = {
+  billing_reason?: string | null;
+  amount_paid?: number | null;
+};
+
+type InvoicePaidBucketResetMode =
+  | { mode: "full_reset"; reason: "subscription_create" | "subscription_cycle" }
+  | { mode: "subscription_update_proration"; reason: "subscription_update" }
+  | { mode: "skip"; reason: string };
+
+const FULL_RESET_BILLING_REASONS = new Set([
+  "subscription_create",
+  "subscription_cycle",
+]);
+
+/**
+ * Decide whether a paid subscription invoice should refresh usage credits.
+ *
+ * Full bucket resets are only safe for first paid subscription invoices and
+ * true billing-cycle renewals. Stripe also sends invoice.paid for prorated
+ * subscription updates, manual invoices, threshold invoices, and zero/credit
+ * invoices; those must not mint a fresh usage budget.
+ */
+export function getInvoicePaidBucketResetMode(
+  invoice: InvoiceForBucketReset,
+): InvoicePaidBucketResetMode {
+  const billingReason = invoice.billing_reason ?? "unknown";
+
+  if (billingReason === "subscription_update") {
+    return {
+      mode: "subscription_update_proration",
+      reason: "subscription_update",
+    };
+  }
+
+  if (!FULL_RESET_BILLING_REASONS.has(billingReason)) {
+    return { mode: "skip", reason: billingReason };
+  }
+
+  if ((invoice.amount_paid ?? 0) <= 0) {
+    return { mode: "skip", reason: `${billingReason}:non_positive_amount` };
+  }
+
+  return {
+    mode: "full_reset",
+    reason: billingReason as "subscription_create" | "subscription_cycle",
+  };
+}


### PR DESCRIPTION
## Summary

Fixes subscription `invoice.paid` handling so only real paid subscription starts and billing-cycle renewals mint a full usage bucket.

## Root Cause

The webhook treated any paid subscription invoice as a renewal. Stripe also emits `invoice.paid` for subscription updates, including prorated team seat changes, so same-tier updates could fall through to a full bucket reset.

## Changes

- Add a small invoice reset classifier for `invoice.paid` events.
- Allow full resets only for positive-amount `subscription_create` and `subscription_cycle` invoices.
- Keep `subscription_update` invoices on the existing tier-change proration path, and skip them when no tier-change stash exists.
- Skip manual, threshold, unknown, and zero/credit-paid invoices.
- Add regression coverage for renewal, creation, subscription update, manual/threshold, and zero-dollar cases.

## Validation

- `pnpm jest lib/billing/__tests__/subscription-invoice-reset.test.ts --runInBand`
- `pnpm exec prettier --check app/api/subscription/webhook/route.ts lib/billing/subscription-invoice-reset.ts lib/billing/__tests__/subscription-invoice-reset.test.ts`
- `pnpm typecheck`
- `pnpm exec eslint app/api/subscription/webhook/route.ts lib/billing/subscription-invoice-reset.ts lib/billing/__tests__/subscription-invoice-reset.test.ts`
- Commit hook: `pnpm typecheck` and full `pnpm test` passed, 94 suites / 1169 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved paid subscription invoice handling to prevent incorrect usage-credit bucket resets. The system now intelligently routes different invoice types—subscription renewals, updates, and manual charges—to appropriate reset behaviors, ensuring accurate rate-limit management across billing scenarios.

* **Tests**
  * Added comprehensive test coverage for subscription invoice reset behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->