### PR TITLE
[codex] Suppress expected Convex upload errors in PostHog

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -5,54 +5,7 @@ import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { useEffect } from "react";
 import { useGlobalState } from "./contexts/GlobalState";
-
-const IGNORED_CONVEX_EXCEPTION_MESSAGES = [
-  "Unauthorized: User not authenticated",
-  "Invalid arguments provided",
-  "FILE_TOKEN_LIMIT_EXCEEDED",
-  "exceeds the maximum token limit",
-];
-
-function getExceptionMessages(event: {
-  properties?: Record<string, unknown>;
-}): string[] {
-  const properties = event.properties ?? {};
-  const messages: string[] = [];
-
-  if (typeof properties.$exception_message === "string") {
-    messages.push(properties.$exception_message);
-  }
-
-  if (Array.isArray(properties.$exception_list)) {
-    for (const exception of properties.$exception_list) {
-      if (
-        exception &&
-        typeof exception === "object" &&
-        "value" in exception &&
-        typeof exception.value === "string"
-      ) {
-        messages.push(exception.value);
-      }
-    }
-  }
-
-  return messages;
-}
-
-function shouldDropExpectedConvexException(event: {
-  event?: string;
-  properties?: Record<string, unknown>;
-}) {
-  if (event.event !== "$exception") {
-    return false;
-  }
-
-  return getExceptionMessages(event).some((message) =>
-    IGNORED_CONVEX_EXCEPTION_MESSAGES.some((ignoredMessage) =>
-      message.includes(ignoredMessage),
-    ),
-  );
-}
+import { shouldDropExpectedConvexException } from "@/lib/posthog/expected-convex-errors";
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   const { subscription } = useGlobalState();

--- a/lib/posthog/__tests__/expected-convex-errors.test.ts
+++ b/lib/posthog/__tests__/expected-convex-errors.test.ts
@@ -1,0 +1,59 @@
+import { shouldDropExpectedConvexException } from "../expected-convex-errors";
+
+describe("shouldDropExpectedConvexException", () => {
+  it("drops paid-plan upload errors from nested exception values", () => {
+    expect(
+      shouldDropExpectedConvexException({
+        event: "$exception",
+        properties: {
+          $exception_list: [
+            {
+              value:
+                'Uncaught ConvexError: {"code":"PAID_PLAN_REQUIRED","message":"Paid plan required for file uploads"}',
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("drops file token limit errors even when PostHog nests the message", () => {
+    expect(
+      shouldDropExpectedConvexException({
+        event: "$exception",
+        properties: {
+          $exception_stack_trace: {
+            values: [
+              {
+                value:
+                  'Uncaught ConvexError: {"code":"FILE_TOKEN_LIMIT_EXCEEDED","message":"File \\"semgrep-postmessage-report.html\\" exceeds the maximum token limit of 100,000 tokens. Current tokens: 156,123."}',
+              },
+            ],
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps non-exception events with matching text", () => {
+    expect(
+      shouldDropExpectedConvexException({
+        event: "file_upload_failed",
+        properties: {
+          message: "PAID_PLAN_REQUIRED",
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps unexpected exceptions", () => {
+    expect(
+      shouldDropExpectedConvexException({
+        event: "$exception",
+        properties: {
+          $exception_message: "Uncaught TypeError: Cannot read properties",
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/lib/posthog/expected-convex-errors.ts
+++ b/lib/posthog/expected-convex-errors.ts
@@ -1,0 +1,47 @@
+const IGNORED_CONVEX_EXCEPTION_MESSAGES = [
+  "Unauthorized: User not authenticated",
+  "Invalid arguments provided",
+  "FILE_TOKEN_LIMIT_EXCEEDED",
+  "exceeds the maximum token limit",
+  "PAID_PLAN_REQUIRED",
+  "Paid plan required for file uploads",
+];
+
+type PostHogEventLike = {
+  event?: string;
+  properties?: Record<string, unknown>;
+};
+
+const collectStrings = (value: unknown, strings: string[] = []): string[] => {
+  if (typeof value === "string") {
+    strings.push(value);
+    return strings;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectStrings(item, strings);
+    }
+    return strings;
+  }
+
+  if (value && typeof value === "object") {
+    for (const nestedValue of Object.values(value)) {
+      collectStrings(nestedValue, strings);
+    }
+  }
+
+  return strings;
+};
+
+export function shouldDropExpectedConvexException(event: PostHogEventLike) {
+  if (event.event !== "$exception") {
+    return false;
+  }
+
+  return collectStrings(event.properties).some((message) =>
+    IGNORED_CONVEX_EXCEPTION_MESSAGES.some((ignoredMessage) =>
+      message.includes(ignoredMessage),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

- Move expected Convex exception filtering into a shared PostHog helper.
- Suppress `PAID_PLAN_REQUIRED` upload errors and file token limit errors even when PostHog nests the exception text outside `$exception_message`.
- Add unit coverage for the exact paid-plan and file-token examples, plus guardrails for non-exception events and unexpected exceptions.

## Root cause

The existing filter only checked `$exception_message` and `$exception_list[].value`, and it did not include the paid-plan upload code. PostHog exception payloads can contain the useful Convex error text in other nested fields, so token-limit errors could still be captured despite the existing string check.

## Validation

- `pnpm jest lib/posthog/__tests__/expected-convex-errors.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- Commit hook: full `pnpm test` passed, 94 suites / 1168 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal exception filtering logic for PostHog analytics into a dedicated utility module for improved code organization and maintainability.

* **Tests**
  * Added comprehensive test coverage for exception filtering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->