### PR TITLE
[codex] Add free agent conversion analytics

### DIFF
--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it, jest } from "@jest/globals";
 
 const {
   createChatLogger,
+  captureAgentCompletionAnalytics,
   captureAgentRun,
+  captureFreeAgentValueReached,
   captureToolCalls,
   captureUsageCost,
 } = require("../chat-logger");
@@ -107,6 +109,154 @@ describe("captureAgentRun", () => {
     });
 
     expect(capture).not.toHaveBeenCalled();
+  });
+});
+
+describe("captureFreeAgentValueReached", () => {
+  it("captures a free successful agent value event with user properties", () => {
+    const capture = jest.fn();
+
+    captureFreeAgentValueReached({
+      posthog: { capture } as any,
+      userId: "user_123",
+      chatId: "chat_123",
+      endpoint: "/api/agent",
+      mode: "agent",
+      subscription: "free",
+      sandboxInfo: { type: "e2b" },
+      outcome: "success",
+      chatLogger: {
+        getToolCalls: () => [{ name: "web_search" }, { name: "open_url" }],
+      } as any,
+    });
+
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      event: "hackerai-free_agent_value_reached",
+      properties: expect.objectContaining({
+        user_id: "user_123",
+        chat_id: "chat_123",
+        endpoint: "/api/agent",
+        mode: "agent",
+        subscription: "free",
+        subscription_tier: "free",
+        outcome: "success",
+        tool_call_count: 2,
+        agent_value_event_version: 1,
+        sandbox_type: "e2b",
+        $set_once: expect.objectContaining({
+          first_free_agent_value_reached_at: expect.any(String),
+        }),
+        $set: expect.objectContaining({
+          subscription_tier: "free",
+          last_free_agent_value_reached_at: expect.any(String),
+        }),
+      }),
+    });
+  });
+
+  it("does not capture for paid, ask mode, or unsuccessful runs", () => {
+    const capture = jest.fn();
+    const baseArgs = {
+      posthog: { capture } as any,
+      userId: "user_123",
+      chatId: "chat_123",
+      endpoint: "/api/agent" as const,
+      mode: "agent" as const,
+      subscription: "free",
+      sandboxInfo: { type: "e2b" },
+      outcome: "success" as const,
+      chatLogger: { getToolCalls: () => [] } as any,
+    };
+
+    captureFreeAgentValueReached({
+      ...baseArgs,
+      subscription: "pro",
+    });
+    captureFreeAgentValueReached({
+      ...baseArgs,
+      mode: "ask",
+    });
+    captureFreeAgentValueReached({
+      ...baseArgs,
+      outcome: "aborted",
+    });
+    captureFreeAgentValueReached({
+      ...baseArgs,
+      outcome: "error",
+    });
+
+    expect(capture).not.toHaveBeenCalled();
+  });
+});
+
+describe("captureAgentCompletionAnalytics", () => {
+  it("captures both agent completion and free value events for successful free agent runs", () => {
+    const capture = jest.fn();
+
+    captureAgentCompletionAnalytics({
+      posthog: { capture } as any,
+      userId: "user_123",
+      chatId: "chat_123",
+      endpoint: "/api/agent",
+      mode: "agent",
+      subscription: "free",
+      sandboxInfo: { type: "e2b" },
+      outcome: "success",
+      chatLogger: { getToolCalls: () => [{ name: "web_search" }] } as any,
+    });
+
+    expect(capture).toHaveBeenCalledTimes(2);
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      event: "hackerai-agent_run",
+      properties: {
+        mode: "agent",
+        subscription: "free",
+        outcome: "success",
+        sandboxType: "e2b",
+      },
+    });
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      event: "hackerai-free_agent_value_reached",
+      properties: expect.objectContaining({
+        user_id: "user_123",
+        chat_id: "chat_123",
+        endpoint: "/api/agent",
+        subscription_tier: "free",
+        outcome: "success",
+        tool_call_count: 1,
+      }),
+    });
+  });
+
+  it("keeps paid agent runs on the existing completion event only", () => {
+    const capture = jest.fn();
+
+    captureAgentCompletionAnalytics({
+      posthog: { capture } as any,
+      userId: "user_123",
+      chatId: "chat_123",
+      endpoint: "/api/agent",
+      mode: "agent",
+      subscription: "pro",
+      sandboxInfo: { type: "e2b" },
+      outcome: "success",
+      chatLogger: { getToolCalls: () => [{ name: "web_search" }] } as any,
+    });
+
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      event: "hackerai-agent_run",
+      properties: {
+        mode: "agent",
+        subscription: "pro",
+        outcome: "success",
+        sandboxType: "e2b",
+      },
+    });
   });
 });
 

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -40,7 +40,7 @@ import { countTokens } from "gpt-tokenizer";
 import { ChatSDKError } from "@/lib/errors";
 import PostHogClient from "@/app/posthog";
 import {
-  captureAgentRun,
+  captureAgentCompletionAnalytics,
   captureToolCalls,
   captureUsageCost,
   createChatLogger,
@@ -907,13 +907,19 @@ export const createChatHandler = (
                                   userId,
                                   mode,
                                 });
-                                captureAgentRun({
+                                const outcome = retryAborted
+                                  ? "aborted"
+                                  : "success";
+                                captureAgentCompletionAnalytics({
                                   posthog,
                                   userId,
+                                  chatId,
+                                  endpoint,
                                   mode,
                                   subscription,
                                   sandboxInfo,
-                                  outcome: retryAborted ? "aborted" : "success",
+                                  outcome,
+                                  chatLogger,
                                 });
                                 shutdownPostHog(posthog);
                                 chatLogger!.emitSuccess({
@@ -1118,13 +1124,17 @@ export const createChatHandler = (
                       cacheWriteTokens: usageTracker.cacheWriteTokens,
                     });
                     captureToolCalls({ posthog, chatLogger, userId, mode });
-                    captureAgentRun({
+                    const outcome = isAborted ? "aborted" : "success";
+                    captureAgentCompletionAnalytics({
                       posthog,
                       userId,
+                      chatId,
+                      endpoint,
                       mode,
                       subscription,
                       sandboxInfo,
-                      outcome: isAborted ? "aborted" : "success",
+                      outcome,
+                      chatLogger,
                     });
                     shutdownPostHog(posthog);
                     chatLogger!.emitSuccess({

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -578,6 +578,20 @@ export function captureToolCalls({
   }
 }
 
+export type AgentRunOutcome = "success" | "aborted" | "error";
+
+type AgentCompletionAnalyticsArgs = {
+  posthog: PostHog | null;
+  userId: string;
+  chatId: string;
+  endpoint: "/api/chat" | "/api/agent";
+  mode: ChatMode;
+  subscription: string;
+  sandboxInfo: SandboxInfo | null;
+  outcome: AgentRunOutcome;
+  chatLogger: ChatLogger | undefined;
+};
+
 export function captureAgentRun({
   posthog,
   userId,
@@ -591,7 +605,7 @@ export function captureAgentRun({
   mode: ChatMode;
   subscription: string;
   sandboxInfo: SandboxInfo | null;
-  outcome: "success" | "aborted" | "error";
+  outcome: AgentRunOutcome;
 }) {
   if (!posthog || mode !== "agent") return;
   posthog.capture({
@@ -604,6 +618,73 @@ export function captureAgentRun({
       ...(sandboxInfo?.type && { sandboxType: sandboxInfo.type }),
     },
   });
+}
+
+export function captureFreeAgentValueReached({
+  posthog,
+  userId,
+  chatId,
+  endpoint,
+  mode,
+  subscription,
+  sandboxInfo,
+  outcome,
+  chatLogger,
+}: {
+  posthog: PostHog | null;
+  userId: string;
+  chatId: string;
+  endpoint: "/api/chat" | "/api/agent";
+  mode: ChatMode;
+  subscription: string;
+  sandboxInfo: SandboxInfo | null;
+  outcome: AgentRunOutcome;
+  chatLogger: ChatLogger | undefined;
+}) {
+  if (!posthog || mode !== "agent" || subscription !== "free") return;
+  if (outcome !== "success") return;
+
+  const now = new Date().toISOString();
+  const toolCallCount = chatLogger?.getToolCalls().length ?? 0;
+
+  posthog.capture({
+    distinctId: userId,
+    event: "hackerai-free_agent_value_reached",
+    properties: {
+      user_id: userId,
+      chat_id: chatId,
+      endpoint,
+      mode,
+      subscription,
+      subscription_tier: subscription,
+      outcome,
+      tool_call_count: toolCallCount,
+      agent_value_event_version: 1,
+      ...(sandboxInfo?.type && { sandbox_type: sandboxInfo.type }),
+      $set_once: {
+        first_free_agent_value_reached_at: now,
+      },
+      $set: {
+        subscription_tier: subscription,
+        last_free_agent_value_reached_at: now,
+      },
+    },
+  });
+}
+
+export function captureAgentCompletionAnalytics(
+  args: AgentCompletionAnalyticsArgs,
+) {
+  const { posthog, userId, mode, subscription, sandboxInfo, outcome } = args;
+  captureAgentRun({
+    posthog,
+    userId,
+    mode,
+    subscription,
+    sandboxInfo,
+    outcome,
+  });
+  captureFreeAgentValueReached(args);
 }
 
 /**

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -73,7 +73,7 @@ import {
 } from "@/lib/utils/sandbox-file-utils";
 import { getEmptyProcessedMessagesCause } from "@/lib/utils/local-attachment-messages";
 import {
-  captureAgentRun,
+  captureAgentCompletionAnalytics,
   captureToolCalls,
   captureUsageCost,
   createChatLogger,
@@ -1272,17 +1272,21 @@ export const agentLongTask = task({
                                     userId,
                                     mode,
                                   });
-                                  captureAgentRun({
+                                  const outcome = retryAborted
+                                    ? "aborted"
+                                    : isTerminalProviderStreamError(state)
+                                      ? "error"
+                                      : "success";
+                                  captureAgentCompletionAnalytics({
                                     posthog,
                                     userId,
+                                    chatId,
+                                    endpoint: "/api/agent",
                                     mode,
                                     subscription,
                                     sandboxInfo,
-                                    outcome: retryAborted
-                                      ? "aborted"
-                                      : isTerminalProviderStreamError(state)
-                                        ? "error"
-                                        : "success",
+                                    outcome,
+                                    chatLogger,
                                   });
                                   if (!isTerminalProviderStreamError(state)) {
                                     chatLogger?.emitSuccess({
@@ -1392,17 +1396,21 @@ export const agentLongTask = task({
                         cacheWriteTokens: usageTracker.cacheWriteTokens,
                       });
                       captureToolCalls({ posthog, chatLogger, userId, mode });
-                      captureAgentRun({
+                      const outcome = isAborted
+                        ? "aborted"
+                        : isTerminalProviderStreamError(state)
+                          ? "error"
+                          : "success";
+                      captureAgentCompletionAnalytics({
                         posthog,
                         userId,
+                        chatId,
+                        endpoint: "/api/agent",
                         mode,
                         subscription,
                         sandboxInfo,
-                        outcome: isAborted
-                          ? "aborted"
-                          : isTerminalProviderStreamError(state)
-                            ? "error"
-                            : "success",
+                        outcome,
+                        chatLogger,
                       });
                       if (!isTerminalProviderStreamError(state)) {
                         chatLogger?.emitSuccess({


### PR DESCRIPTION
## Summary

- add `hackerai-free_agent_value_reached` for successful free-user agent runs
- centralize agent completion telemetry in `captureAgentCompletionAnalytics` so `hackerai-agent_run` and free activation tracking stay in sync
- wire the shared helper through regular and Trigger long-agent completion paths
- cover the free-only/success-only behavior and wrapper behavior in `chat-logger` tests

## PostHog setup

Create a 7-day funnel:

`user_signed_up` -> `hackerai-free_agent_value_reached` -> `subscription_started`

Then compare cohorts of free signups who reached `hackerai-free_agent_value_reached` within 24h against free signups who did not. Use those cohorts to compare checkout rate, subscription rate, time to subscribe, and cancellation rate.

## Validation

- `jest -- lib/api/__tests__/chat-logger.test.ts` passes: 13/13 tests
- `tsc --noEmit` passes with the existing sibling checkout dependencies temporarily linked into this worktree, then removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced agent run analytics instrumentation to capture detailed completion data and outcome tracking.

* **Tests**
  * Added comprehensive test coverage for agent completion analytics, including validation of event emission and property capture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->