### PR TITLE
[codex] Add referral reward experiment

### DIFF
--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -16,6 +16,7 @@ import { useGlobalState } from "../contexts/GlobalState";
 import { usePentestgptMigration } from "../hooks/usePentestgptMigration";
 import { navigateToAuth } from "../hooks/useTauri";
 import { useTypingAnimation } from "../hooks/useTypingAnimation";
+import { useReferralClaim } from "../hooks/useReferralClaim";
 import { upsertDraft } from "@/lib/utils/client-storage";
 
 const LOGIN_TYPING_PREFIX = "Ask HackerAI to ";
@@ -112,6 +113,8 @@ const UnauthenticatedContent = () => {
 
 // Authenticated content that shows chat (UUID generated internally)
 const AuthenticatedContent = () => {
+  useReferralClaim();
+
   return <Chat autoResume={false} />;
 };
 

--- a/app/api/referrals/claim/route.ts
+++ b/app/api/referrals/claim/route.ts
@@ -1,0 +1,74 @@
+import { after, NextRequest, NextResponse } from "next/server";
+import { api } from "@/convex/_generated/api";
+import { getUserID } from "@/lib/auth/get-user-id";
+import { getConvexClient } from "@/lib/db/convex-client";
+import { phLogger } from "@/lib/posthog/server";
+import { decodeReferralCookie, REFERRAL_COOKIE_NAME } from "@/lib/referrals";
+
+export async function POST(req: NextRequest) {
+  let userId: string;
+  try {
+    userId = await getUserID(req);
+  } catch {
+    return NextResponse.json({ claimed: false }, { status: 401 });
+  }
+
+  const cookie = decodeReferralCookie(
+    req.cookies.get(REFERRAL_COOKIE_NAME)?.value,
+  );
+
+  if (!cookie) {
+    return NextResponse.json({
+      claimed: false,
+      reason: "no_referral_cookie",
+    });
+  }
+
+  try {
+    const convex = getConvexClient();
+    const result = await convex.mutation(api.referrals.claimReferralSignup, {
+      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+      referredUserId: userId,
+      referralCode: cookie.code,
+      referralLandingPath: cookie.landingPath,
+    });
+
+    phLogger.event("referral_signup_started", {
+      userId,
+      referral_code: cookie.code,
+      referral_landing_path: cookie.landingPath,
+    });
+
+    if (result.claimed) {
+      phLogger.event("referral_signup_completed", {
+        userId,
+        referrer_user_id: result.referrerUserId,
+        referral_code: result.referralCode,
+        referral_landing_path: cookie.landingPath,
+        starter_credits_awarded: result.starterCreditsAwarded,
+      });
+      phLogger.event("referral_reward_credited", {
+        userId,
+        referrer_user_id: result.referrerUserId,
+        referral_code: result.referralCode,
+        credits_awarded: result.starterCreditsAwarded,
+        reward_reason: "referred_signup_bonus",
+      });
+    }
+
+    after(() => phLogger.flush());
+
+    const response = NextResponse.json(result);
+    response.cookies.delete(REFERRAL_COOKIE_NAME);
+    return response;
+  } catch (error) {
+    phLogger.warn("referral_claim_failed", { userId, error });
+    const response = NextResponse.json({
+      claimed: false,
+      reason: "claim_failed",
+    });
+    response.cookies.delete(REFERRAL_COOKIE_NAME);
+    after(() => phLogger.flush());
+    return response;
+  }
+}

--- a/app/api/referrals/claim/route.ts
+++ b/app/api/referrals/claim/route.ts
@@ -25,9 +25,24 @@ export async function POST(req: NextRequest) {
   }
 
   try {
+    const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY;
+    if (!serviceKey) {
+      phLogger.error("referral_claim_missing_service_key", {
+        missing_env: "CONVEX_SERVICE_ROLE_KEY",
+      });
+      after(() => phLogger.flush());
+      return NextResponse.json(
+        {
+          claimed: false,
+          reason: "missing_server_configuration",
+        },
+        { status: 500 },
+      );
+    }
+
     const convex = getConvexClient();
     const result = await convex.mutation(api.referrals.claimReferralSignup, {
-      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+      serviceKey,
       referredUserId: userId,
       referralCode: cookie.code,
       referralLandingPath: cookie.landingPath,

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -5,6 +5,7 @@ import { buildWorkOSOrganizationName } from "@/lib/auth/workos-organization-name
 import { NextRequest, NextResponse, after } from "next/server";
 import { getSuspensionMessage } from "@/lib/suspensionMessage";
 import { phLogger } from "@/lib/posthog/server";
+import { getReferralAttribution } from "@/lib/referrals";
 
 function planLookupKeyToTier(
   lookupKey: string,
@@ -256,6 +257,7 @@ export const POST = async (req: NextRequest) => {
     });
 
     const selectedPrice = price.data[0];
+    const referralAttribution = await getReferralAttribution(userId);
     phLogger.event("checkout_started", {
       userId,
       org_id: organization.id,
@@ -273,6 +275,9 @@ export const POST = async (req: NextRequest) => {
       stripe_customer_id: customer.id,
       stripe_checkout_session_id: session.id,
       stripe_price_id: selectedPrice.id,
+      referrer_user_id: referralAttribution?.referrerUserId,
+      referral_code: referralAttribution?.referralCode,
+      referral_landing_path: referralAttribution?.referralLandingPath,
       client_distinct_id: posthogDistinctId ?? undefined,
       $session_id: posthogSessionId ?? undefined,
       $set: {

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -14,6 +14,10 @@ import { phLogger } from "@/lib/posthog/server";
 import { resolveUserIdsFromCustomer as resolveStripeCustomerUsers } from "@/lib/billing/resolve-customer-users";
 import { getInvoicePaidBucketResetMode } from "@/lib/billing/subscription-invoice-reset";
 import type { SubscriptionTier } from "@/types";
+import {
+  awardReferralConversion,
+  getReferralAttribution,
+} from "@/lib/referrals";
 
 // Linear ranking used to label tier transitions as upgrade/downgrade. Team is
 // pinned at the top because moves between team and individual plans are rare
@@ -258,6 +262,7 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
       userIds.length > 0 ? invoiceAmountPaidDollars / userIds.length : 0;
 
     for (const uid of userIds) {
+      const referralAttribution = await getReferralAttribution(uid);
       phLogger.event("subscription_started", {
         userId: uid,
         from_tier: "free",
@@ -277,6 +282,9 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
         stripe_subscription_id: subscription.id,
         stripe_invoice_id: invoice.id,
         stripe_price_id: price?.id,
+        referrer_user_id: referralAttribution?.referrerUserId,
+        referral_code: referralAttribution?.referralCode,
+        referral_landing_path: referralAttribution?.referralLandingPath,
         $set: {
           subscription_tier: tier,
           last_subscription_started_at: new Date().toISOString(),
@@ -286,6 +294,17 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
           first_paid_tier: tier,
         },
       });
+
+      if (referralAttribution) {
+        await awardReferralConversion({
+          referredUserId: uid,
+          qualifyingTier: tier,
+          idempotencyKey: `subscription:${subscription.id}`,
+          revenueDollars: attributedRevenueDollars,
+          stripeInvoiceId: invoice.id,
+          stripeSubscriptionId: subscription.id,
+        });
+      }
     }
   }
 

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -299,7 +299,7 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
         await awardReferralConversion({
           referredUserId: uid,
           qualifyingTier: tier,
-          idempotencyKey: `subscription:${subscription.id}`,
+          idempotencyKey: `subscription:${subscription.id}:user:${uid}`,
           revenueDollars: attributedRevenueDollars,
           stripeInvoiceId: invoice.id,
           stripeSubscriptionId: subscription.id,

--- a/app/api/workos/webhook/route.ts
+++ b/app/api/workos/webhook/route.ts
@@ -5,6 +5,7 @@ import { api } from "@/convex/_generated/api";
 import { workos } from "@/app/api/workos";
 import { captureUserSignedUp } from "@/lib/analytics/user-signup";
 import { phLogger } from "@/lib/posthog/server";
+import { getReferralAttribution } from "@/lib/referrals";
 
 const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
@@ -89,10 +90,12 @@ export async function POST(req: NextRequest) {
 
   try {
     if (event.event === "user.created") {
+      const referralAttribution = await getReferralAttribution(event.data.id);
       captureUserSignedUp({
         user: event.data,
         workosEventId: event.id,
         workosEventCreatedAt: event.createdAt,
+        referralAttribution,
       });
     }
   } catch (error) {

--- a/app/components/ReferralRewardDialog.tsx
+++ b/app/components/ReferralRewardDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from "react";
-import posthog from "posthog-js";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
@@ -20,47 +19,12 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { captureAuthenticatedEvent } from "@/lib/analytics/client";
-import { REFERRAL_REWARD_EXPERIMENT_FLAG } from "@/lib/referral-constants";
 import { Check, Copy, Gift, Share2, Sparkles, UserCheck } from "lucide-react";
 import { toast } from "sonner";
 
 const BASE_URL =
   process.env.NEXT_PUBLIC_BASE_URL ||
   (typeof window !== "undefined" ? window.location.origin : "");
-
-function useReferralExperimentEnabled(userId: string | undefined) {
-  const [enabled, setEnabled] = React.useState(() =>
-    userId
-      ? posthog.isFeatureEnabled(REFERRAL_REWARD_EXPERIMENT_FLAG) === true
-      : false,
-  );
-
-  React.useEffect(() => {
-    if (!userId) {
-      setEnabled(false);
-      return;
-    }
-
-    const update = () => {
-      setEnabled(
-        posthog.isFeatureEnabled(REFERRAL_REWARD_EXPERIMENT_FLAG) === true,
-      );
-    };
-
-    update();
-    const fallbackTimer = window.setTimeout(update, 500);
-    const unsubscribe = posthog.onFeatureFlags(update);
-
-    return () => {
-      window.clearTimeout(fallbackTimer);
-      if (typeof unsubscribe === "function") {
-        unsubscribe();
-      }
-    };
-  }, [userId]);
-
-  return enabled;
-}
 
 export function ReferralRewardEntry({
   isCollapsed,
@@ -70,13 +34,11 @@ export function ReferralRewardEntry({
   isFreeUser: boolean;
 }) {
   const { user } = useAuth();
-  const enabled = useReferralExperimentEnabled(user?.id);
 
   return (
     <ReferralRewardEntryContent
       isCollapsed={isCollapsed}
       isFreeUser={isFreeUser}
-      enabled={enabled}
       userId={user?.id}
     />
   );
@@ -85,12 +47,10 @@ export function ReferralRewardEntry({
 export function ReferralRewardEntryContent({
   isCollapsed,
   isFreeUser,
-  enabled,
   userId,
 }: {
   isCollapsed: boolean;
   isFreeUser: boolean;
-  enabled: boolean;
   userId?: string;
 }) {
   const [open, setOpen] = React.useState(false);
@@ -101,7 +61,7 @@ export function ReferralRewardEntryContent({
       lastCapturedUserRef.current = null;
       return;
     }
-    if (!enabled || !isFreeUser || lastCapturedUserRef.current === userId) {
+    if (!isFreeUser || lastCapturedUserRef.current === userId) {
       return;
     }
     lastCapturedUserRef.current = userId;
@@ -109,9 +69,9 @@ export function ReferralRewardEntryContent({
       placement: "sidebar_footer",
       collapsed: isCollapsed,
     });
-  }, [enabled, isCollapsed, isFreeUser, userId]);
+  }, [isCollapsed, isFreeUser, userId]);
 
-  if (!userId || !enabled || !isFreeUser) return null;
+  if (!userId || !isFreeUser) return null;
 
   const openDialog = () => {
     captureAuthenticatedEvent("referral_invite_opened", {

--- a/app/components/ReferralRewardDialog.tsx
+++ b/app/components/ReferralRewardDialog.tsx
@@ -155,7 +155,7 @@ export function ReferralRewardDialog({
   );
   const summary = useQuery(
     api.referrals.getReferralSummary,
-    effectiveUserId ? {} : "skip",
+    open && effectiveUserId ? {} : "skip",
   );
 
   const code = summary?.code ?? generatedCode;

--- a/app/components/ReferralRewardDialog.tsx
+++ b/app/components/ReferralRewardDialog.tsx
@@ -36,6 +36,16 @@ const BASE_URL =
   process.env.NEXT_PUBLIC_BASE_URL ||
   (typeof window !== "undefined" ? window.location.origin : "");
 
+const REFERRAL_TERMS = [
+  "This promotion is available to new HackerAI users who sign up through your invite link.",
+  "Rewards are granted only after the referred account is complete and meets the qualifying action: signup for starter credits, or a qualifying paid subscription for referrer credits.",
+  "Disposable or high-risk email accounts are not eligible. Referral emails may be checked with an email reputation or risk-scoring service.",
+  "Each new user can generate only one reward. No stacking, repeated claims, self-referrals, or loophole hunting.",
+  "Avoid spam or misuse of referral links. We monitor referral engagement and may review unusual activity.",
+  "If suspicious or non-compliant activity is detected, we may withhold rewards or deactivate a referral link.",
+  "We may update, pause, or discontinue the referral program at any time while the experiment is running.",
+];
+
 export function ReferralRewardEntry({
   isCollapsed,
   isFreeUser,
@@ -162,6 +172,7 @@ export function ReferralRewardDialog({
   const effectiveUserId = userId ?? user?.id;
   const [copied, setCopied] = React.useState(false);
   const [generatedCode, setGeneratedCode] = React.useState<string | null>(null);
+  const [termsOpen, setTermsOpen] = React.useState(false);
   const getOrCreateReferralCode = useMutation(
     api.referrals.getOrCreateReferralCode,
   );
@@ -205,8 +216,13 @@ export function ReferralRewardDialog({
     }
   };
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) setTermsOpen(false);
+    onOpenChange(nextOpen);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         showCloseButton={false}
         className="max-h-[95vh] w-[calc(100vw-2rem)] max-w-lg gap-4 overflow-y-auto rounded-3xl border-0 p-6 shadow-2xl"
@@ -361,6 +377,43 @@ export function ReferralRewardDialog({
           One reward per referred account. No self-referrals. Referrer credits
           require a qualifying paid subscription.
         </p>
+
+        {termsOpen ? (
+          <div
+            className="rounded-xl border bg-muted/30 p-4 text-sm leading-5 text-muted-foreground"
+            data-testid="referral-terms"
+          >
+            <div className="mb-2 font-medium text-foreground">
+              Referral terms
+            </div>
+            <ul className="space-y-2">
+              {REFERRAL_TERMS.map((term) => (
+                <li key={term} className="flex gap-2">
+                  <span
+                    aria-hidden="true"
+                    className="mt-2 size-1 rounded-full bg-muted-foreground"
+                  />
+                  <span>{term}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="link"
+            size="xs"
+            className="h-6 px-2 text-xs text-foreground decoration-transparent hover:decoration-current"
+            aria-expanded={termsOpen}
+            onClick={() => setTermsOpen((isOpen) => !isOpen)}
+          >
+            {termsOpen
+              ? "Hide Terms and Conditions"
+              : "View Terms and Conditions"}
+          </Button>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/app/components/ReferralRewardDialog.tsx
+++ b/app/components/ReferralRewardDialog.tsx
@@ -84,7 +84,7 @@ export function ReferralRewardEntryContent({
   return (
     <>
       {isCollapsed ? (
-        <div className="mb-1">
+        <div className="mb-2">
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -111,19 +111,21 @@ export function ReferralRewardEntryContent({
           data-testid="referral-button"
           onClick={openDialog}
           className={cn(
-            "mb-1 flex w-full items-center gap-2.5 rounded-t-2xl border border-sidebar-border px-4 py-2.5 text-left text-xs transition-colors",
-            "bg-sidebar-accent/40 hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+            "group/share-card pointer-events-auto mb-2 flex min-h-16 w-full cursor-pointer items-center justify-between gap-3 overflow-hidden rounded-xl border border-sidebar-border bg-muted/50 p-3 text-left transition-all hover:bg-muted/70 md:h-14",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
           )}
           aria-label="Share HackerAI"
         >
-          <Gift className="h-4 w-4 shrink-0 text-foreground" />
-          <span className="min-w-0">
-            <span className="block font-medium text-sidebar-foreground">
+          <span className="flex min-w-0 flex-col justify-between gap-1">
+            <span className="truncate text-base font-medium leading-none text-sidebar-foreground md:text-sm">
               Share HackerAI
             </span>
-            <span className="block truncate text-sidebar-accent-foreground">
-              Earn credits per paid referral
+            <span className="truncate text-sm text-muted-foreground md:text-xs">
+              10 credits per paid referral
             </span>
+          </span>
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-full border border-sidebar-border bg-muted/70 text-sidebar-foreground transition-all duration-200 group-hover/share-card:bg-sidebar-accent">
+            <Gift className="h-4 w-4 fill-current" />
           </span>
         </button>
       )}

--- a/app/components/ReferralRewardDialog.tsx
+++ b/app/components/ReferralRewardDialog.tsx
@@ -7,6 +7,7 @@ import { api } from "@/convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
@@ -19,7 +20,16 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { captureAuthenticatedEvent } from "@/lib/analytics/client";
-import { Check, Copy, Gift, Share2, Sparkles, UserCheck } from "lucide-react";
+import {
+  Check,
+  Copy,
+  Crown,
+  Gift,
+  LinkIcon,
+  MessageSquareText,
+  X,
+  Zap,
+} from "lucide-react";
 import { toast } from "sonner";
 
 const BASE_URL =
@@ -197,102 +207,160 @@ export function ReferralRewardDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[calc(100vw-2rem)] max-w-lg rounded-2xl p-0">
-        <div className="border-b px-5 py-4">
-          <div className="flex items-center gap-2">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-muted">
-              <Gift className="h-4 w-4" />
-            </div>
-            <div>
-              <DialogTitle className="text-lg">Share HackerAI</DialogTitle>
-              <DialogDescription className="text-sm">
-                Give friends starter credits and earn credits when they upgrade.
-              </DialogDescription>
-            </div>
-          </div>
-        </div>
+      <DialogContent
+        showCloseButton={false}
+        className="max-h-[95vh] w-[calc(100vw-2rem)] max-w-lg gap-4 overflow-y-auto rounded-3xl border-0 p-6 shadow-2xl"
+      >
+        <DialogTitle className="sr-only">Refer and earn</DialogTitle>
+        <DialogDescription className="sr-only">
+          Share HackerAI with friends and earn referral credits.
+        </DialogDescription>
 
-        <div className="space-y-5 px-5 py-5">
-          <div className="grid grid-cols-3 gap-2">
-            {[
-              ["Share", "your invite link", Share2],
-              ["They join", "and get 10 credits", UserCheck],
-              ["You earn", "10 credits on paid referral", Sparkles],
-            ].map(([title, body, Icon]) => (
-              <div
-                key={title as string}
-                className="rounded-lg border bg-muted/30 p-3"
-              >
-                <Icon className="mb-2 h-4 w-4 text-muted-foreground" />
-                <div className="text-sm font-medium">{title as string}</div>
-                <div className="text-xs text-muted-foreground">
-                  {body as string}
+        <div className="relative overflow-hidden rounded-xl border bg-muted/40">
+          <DialogClose asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="absolute right-3 top-3 z-20 h-8 w-8 rounded-full bg-background/80 text-foreground shadow-sm backdrop-blur hover:bg-background"
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </DialogClose>
+
+          <div className="absolute inset-0 bg-[linear-gradient(135deg,hsl(var(--muted)),hsl(var(--background)))]" />
+          <div className="absolute inset-x-0 bottom-0 h-20 border-t bg-background/45" />
+          <div className="relative flex min-h-[188px] flex-col justify-between p-5">
+            <div className="flex items-start gap-3 pr-10">
+              <div className="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-background text-foreground shadow-sm">
+                <Gift className="h-5 w-5 fill-current" />
+              </div>
+              <div className="min-w-0">
+                <div className="text-xl font-semibold leading-tight text-foreground">
+                  Share HackerAI
+                </div>
+                <div className="mt-1 max-w-[18rem] text-sm leading-5 text-muted-foreground">
+                  Give friends 10 starter credits and earn 10 credits when they
+                  upgrade.
                 </div>
               </div>
-            ))}
-          </div>
+            </div>
 
-          <div className="space-y-2">
-            <div className="text-sm font-medium">Invite link</div>
-            <div className="flex min-w-0 gap-2">
-              <div
-                data-testid="referral-link"
-                className="flex min-h-10 flex-1 items-center rounded-md border bg-muted/30 px-3 text-sm text-muted-foreground"
-              >
-                <span className="truncate">
-                  {inviteLink || "Creating referral link..."}
-                </span>
+            <div className="mt-8 grid grid-cols-2 gap-2">
+              <div className="rounded-2xl border bg-background/85 p-3 shadow-sm backdrop-blur">
+                <div className="text-2xl font-semibold leading-none">
+                  10 credits
+                </div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  for referred users
+                </div>
               </div>
-              <Button
-                type="button"
-                size="icon"
-                variant="outline"
-                onClick={copyInviteLink}
-                disabled={!inviteLink}
-                aria-label="Copy referral link"
-              >
-                {copied ? (
-                  <Check className="h-4 w-4" />
-                ) : (
-                  <Copy className="h-4 w-4" />
-                )}
-              </Button>
+              <div className="rounded-2xl border bg-background/85 p-3 shadow-sm backdrop-blur">
+                <div className="text-2xl font-semibold leading-none">
+                  10 credits
+                </div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  for paid referrals
+                </div>
+              </div>
             </div>
           </div>
-
-          <div className="grid grid-cols-4 gap-2 text-center">
-            <div className="rounded-lg border p-3">
-              <div className="text-lg font-semibold">
-                {summary?.balanceCredits ?? 0}
-              </div>
-              <div className="text-xs text-muted-foreground">Credits</div>
-            </div>
-            <div className="rounded-lg border p-3">
-              <div className="text-lg font-semibold">
-                {summary?.signedUp ?? 0}
-              </div>
-              <div className="text-xs text-muted-foreground">Signed up</div>
-            </div>
-            <div className="rounded-lg border p-3">
-              <div className="text-lg font-semibold">
-                {summary?.activated ?? 0}
-              </div>
-              <div className="text-xs text-muted-foreground">Activated</div>
-            </div>
-            <div className="rounded-lg border p-3">
-              <div className="text-lg font-semibold">
-                {summary?.converted ?? 0}
-              </div>
-              <div className="text-xs text-muted-foreground">Paid</div>
-            </div>
-          </div>
-
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            Rewards are limited to one per referred account. Self-referrals are
-            not eligible. Referrer credits are awarded after the referred user
-            starts a qualifying paid subscription.
-          </p>
         </div>
+
+        <div className="md:py-2">
+          <div className="mb-3 text-base font-normal text-muted-foreground">
+            How it works:
+          </div>
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center gap-3">
+              <Zap className="size-5 shrink-0 text-foreground" />
+              <span className="text-base font-normal text-foreground">
+                Share your invite link
+              </span>
+            </div>
+            <div className="flex items-center gap-3">
+              <Crown className="size-5 shrink-0 text-foreground" />
+              <span className="text-base font-normal text-foreground">
+                They sign up and get <b>extra 10 credits</b>
+              </span>
+            </div>
+            <div className="flex items-center gap-3">
+              <MessageSquareText className="size-5 shrink-0 text-foreground" />
+              <span className="text-base font-normal text-foreground">
+                You get <b>10 credits</b> once they subscribe to a qualifying
+                paid plan
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col">
+          <span className="mb-3 flex items-center gap-4 pr-2 text-base font-normal text-muted-foreground">
+            <span>
+              <b>{summary?.signedUp ?? 0}</b> signed up,{" "}
+              <b>{summary?.converted ?? 0}</b> paid referrals
+            </span>
+          </span>
+
+          <div className="flex flex-col gap-3 rounded-xl bg-muted p-2 md:flex-row">
+            <div
+              data-testid="referral-link"
+              className="flex h-10 min-w-0 flex-1 items-center rounded-lg bg-background px-2 text-sm text-muted-foreground"
+            >
+              <LinkIcon className="mr-2 size-5 shrink-0" />
+              <span className="truncate">
+                {inviteLink || "Creating referral link..."}
+              </span>
+            </div>
+            <Button
+              type="button"
+              className="h-10 w-full rounded-lg px-4 md:w-auto"
+              onClick={copyInviteLink}
+              disabled={!inviteLink}
+              aria-label="Copy referral link"
+            >
+              {copied ? (
+                <Check className="h-4 w-4" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+              <span>{copied ? "Copied" : "Copy link"}</span>
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-4 gap-2 text-center">
+          <div className="rounded-lg border p-3">
+            <div className="text-lg font-semibold">
+              {summary?.balanceCredits ?? 0}
+            </div>
+            <div className="text-xs text-muted-foreground">Credits</div>
+          </div>
+          <div className="rounded-lg border p-3">
+            <div className="text-lg font-semibold">
+              {summary?.signedUp ?? 0}
+            </div>
+            <div className="text-xs text-muted-foreground">Signed up</div>
+          </div>
+          <div className="rounded-lg border p-3">
+            <div className="text-lg font-semibold">
+              {summary?.activated ?? 0}
+            </div>
+            <div className="text-xs text-muted-foreground">Activated</div>
+          </div>
+          <div className="rounded-lg border p-3">
+            <div className="text-lg font-semibold">
+              {summary?.converted ?? 0}
+            </div>
+            <div className="text-xs text-muted-foreground">Paid</div>
+          </div>
+        </div>
+
+        <p className="text-center text-xs leading-relaxed text-muted-foreground">
+          One reward per referred account. No self-referrals. Referrer credits
+          require a qualifying paid subscription.
+        </p>
       </DialogContent>
     </Dialog>
   );

--- a/app/components/ReferralRewardDialog.tsx
+++ b/app/components/ReferralRewardDialog.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import React from "react";
+import posthog from "posthog-js";
+import { useAuth } from "@workos-inc/authkit-nextjs/components";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { captureAuthenticatedEvent } from "@/lib/analytics/client";
+import { REFERRAL_REWARD_EXPERIMENT_FLAG } from "@/lib/referral-constants";
+import { Check, Copy, Gift, Share2, Sparkles, UserCheck } from "lucide-react";
+import { toast } from "sonner";
+
+const BASE_URL =
+  process.env.NEXT_PUBLIC_BASE_URL ||
+  (typeof window !== "undefined" ? window.location.origin : "");
+
+function useReferralExperimentEnabled(userId: string | undefined) {
+  const [enabled, setEnabled] = React.useState(() =>
+    userId
+      ? posthog.isFeatureEnabled(REFERRAL_REWARD_EXPERIMENT_FLAG) === true
+      : false,
+  );
+
+  React.useEffect(() => {
+    if (!userId) {
+      setEnabled(false);
+      return;
+    }
+
+    const update = () => {
+      setEnabled(
+        posthog.isFeatureEnabled(REFERRAL_REWARD_EXPERIMENT_FLAG) === true,
+      );
+    };
+
+    update();
+    const fallbackTimer = window.setTimeout(update, 500);
+    const unsubscribe = posthog.onFeatureFlags(update);
+
+    return () => {
+      window.clearTimeout(fallbackTimer);
+      if (typeof unsubscribe === "function") {
+        unsubscribe();
+      }
+    };
+  }, [userId]);
+
+  return enabled;
+}
+
+export function ReferralRewardEntry({
+  isCollapsed,
+  isFreeUser,
+}: {
+  isCollapsed: boolean;
+  isFreeUser: boolean;
+}) {
+  const { user } = useAuth();
+  const enabled = useReferralExperimentEnabled(user?.id);
+
+  return (
+    <ReferralRewardEntryContent
+      isCollapsed={isCollapsed}
+      isFreeUser={isFreeUser}
+      enabled={enabled}
+      userId={user?.id}
+    />
+  );
+}
+
+export function ReferralRewardEntryContent({
+  isCollapsed,
+  isFreeUser,
+  enabled,
+  userId,
+}: {
+  isCollapsed: boolean;
+  isFreeUser: boolean;
+  enabled: boolean;
+  userId?: string;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const hasCapturedImpression = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!enabled || !isFreeUser || hasCapturedImpression.current) return;
+    hasCapturedImpression.current = true;
+    captureAuthenticatedEvent("referral_invite_impression", {
+      placement: "sidebar_footer",
+      collapsed: isCollapsed,
+    });
+  }, [enabled, isCollapsed, isFreeUser]);
+
+  if (!userId || !enabled || !isFreeUser) return null;
+
+  const openDialog = () => {
+    captureAuthenticatedEvent("referral_invite_opened", {
+      placement: "sidebar_footer",
+      collapsed: isCollapsed,
+    });
+    setOpen(true);
+  };
+
+  return (
+    <>
+      {isCollapsed ? (
+        <div className="mb-1">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  data-testid="referral-button-collapsed"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 w-full px-2"
+                  onClick={openDialog}
+                  aria-label="Share HackerAI"
+                >
+                  <Gift className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="right">
+                <p>Share HackerAI</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+      ) : (
+        <button
+          type="button"
+          data-testid="referral-button"
+          onClick={openDialog}
+          className={cn(
+            "mb-1 flex w-full items-center gap-2.5 rounded-t-2xl border border-sidebar-border px-4 py-2.5 text-left text-xs transition-colors",
+            "bg-sidebar-accent/40 hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+          )}
+          aria-label="Share HackerAI"
+        >
+          <Gift className="h-4 w-4 shrink-0 text-foreground" />
+          <span className="min-w-0">
+            <span className="block font-medium text-sidebar-foreground">
+              Share HackerAI
+            </span>
+            <span className="block truncate text-sidebar-accent-foreground">
+              Earn credits per paid referral
+            </span>
+          </span>
+        </button>
+      )}
+
+      <ReferralRewardDialog
+        open={open}
+        onOpenChange={setOpen}
+        userId={userId}
+      />
+    </>
+  );
+}
+
+export function ReferralRewardDialog({
+  open,
+  onOpenChange,
+  userId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  userId?: string;
+}) {
+  const { user } = useAuth();
+  const effectiveUserId = userId ?? user?.id;
+  const [copied, setCopied] = React.useState(false);
+  const [generatedCode, setGeneratedCode] = React.useState<string | null>(null);
+  const getOrCreateReferralCode = useMutation(
+    api.referrals.getOrCreateReferralCode,
+  );
+  const summary = useQuery(
+    api.referrals.getReferralSummary,
+    effectiveUserId ? { userId: effectiveUserId } : "skip",
+  );
+
+  const code = summary?.code ?? generatedCode;
+  const inviteLink = code ? `${BASE_URL}/invite/${code}` : "";
+
+  React.useEffect(() => {
+    if (!open || !effectiveUserId || code) return;
+
+    let cancelled = false;
+    getOrCreateReferralCode({ userId: effectiveUserId })
+      .then((result) => {
+        if (!cancelled) setGeneratedCode(result.code);
+      })
+      .catch(() => {
+        toast.error("Unable to create referral link");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [code, effectiveUserId, getOrCreateReferralCode, open]);
+
+  const copyInviteLink = async () => {
+    if (!inviteLink) return;
+
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      setCopied(true);
+      captureAuthenticatedEvent("referral_invite_copied", {
+        referral_code: code,
+      });
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      toast.error("Unable to copy link");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[calc(100vw-2rem)] max-w-lg rounded-2xl p-0">
+        <div className="border-b px-5 py-4">
+          <div className="flex items-center gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-muted">
+              <Gift className="h-4 w-4" />
+            </div>
+            <div>
+              <DialogTitle className="text-lg">Share HackerAI</DialogTitle>
+              <DialogDescription className="text-sm">
+                Give friends starter credits and earn credits when they upgrade.
+              </DialogDescription>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-5 px-5 py-5">
+          <div className="grid grid-cols-3 gap-2">
+            {[
+              ["Share", "your invite link", Share2],
+              ["They join", "and get 10 credits", UserCheck],
+              ["You earn", "10 credits on paid referral", Sparkles],
+            ].map(([title, body, Icon]) => (
+              <div
+                key={title as string}
+                className="rounded-lg border bg-muted/30 p-3"
+              >
+                <Icon className="mb-2 h-4 w-4 text-muted-foreground" />
+                <div className="text-sm font-medium">{title as string}</div>
+                <div className="text-xs text-muted-foreground">
+                  {body as string}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="space-y-2">
+            <div className="text-sm font-medium">Invite link</div>
+            <div className="flex min-w-0 gap-2">
+              <div
+                data-testid="referral-link"
+                className="flex min-h-10 flex-1 items-center rounded-md border bg-muted/30 px-3 text-sm text-muted-foreground"
+              >
+                <span className="truncate">
+                  {inviteLink || "Creating referral link..."}
+                </span>
+              </div>
+              <Button
+                type="button"
+                size="icon"
+                variant="outline"
+                onClick={copyInviteLink}
+                disabled={!inviteLink}
+                aria-label="Copy referral link"
+              >
+                {copied ? (
+                  <Check className="h-4 w-4" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-4 gap-2 text-center">
+            <div className="rounded-lg border p-3">
+              <div className="text-lg font-semibold">
+                {summary?.balanceCredits ?? 0}
+              </div>
+              <div className="text-xs text-muted-foreground">Credits</div>
+            </div>
+            <div className="rounded-lg border p-3">
+              <div className="text-lg font-semibold">
+                {summary?.signedUp ?? 0}
+              </div>
+              <div className="text-xs text-muted-foreground">Signed up</div>
+            </div>
+            <div className="rounded-lg border p-3">
+              <div className="text-lg font-semibold">
+                {summary?.activated ?? 0}
+              </div>
+              <div className="text-xs text-muted-foreground">Activated</div>
+            </div>
+            <div className="rounded-lg border p-3">
+              <div className="text-lg font-semibold">
+                {summary?.converted ?? 0}
+              </div>
+              <div className="text-xs text-muted-foreground">Paid</div>
+            </div>
+          </div>
+
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Rewards are limited to one per referred account. Self-referrals are
+            not eligible. Referrer credits are awarded after the referred user
+            starts a qualifying paid subscription.
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/components/ReferralRewardDialog.tsx
+++ b/app/components/ReferralRewardDialog.tsx
@@ -94,16 +94,22 @@ export function ReferralRewardEntryContent({
   userId?: string;
 }) {
   const [open, setOpen] = React.useState(false);
-  const hasCapturedImpression = React.useRef(false);
+  const lastCapturedUserRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
-    if (!enabled || !isFreeUser || hasCapturedImpression.current) return;
-    hasCapturedImpression.current = true;
+    if (!userId) {
+      lastCapturedUserRef.current = null;
+      return;
+    }
+    if (!enabled || !isFreeUser || lastCapturedUserRef.current === userId) {
+      return;
+    }
+    lastCapturedUserRef.current = userId;
     captureAuthenticatedEvent("referral_invite_impression", {
       placement: "sidebar_footer",
       collapsed: isCollapsed,
     });
-  }, [enabled, isCollapsed, isFreeUser]);
+  }, [enabled, isCollapsed, isFreeUser, userId]);
 
   if (!userId || !enabled || !isFreeUser) return null;
 
@@ -189,7 +195,7 @@ export function ReferralRewardDialog({
   );
   const summary = useQuery(
     api.referrals.getReferralSummary,
-    effectiveUserId ? { userId: effectiveUserId } : "skip",
+    effectiveUserId ? {} : "skip",
   );
 
   const code = summary?.code ?? generatedCode;
@@ -199,7 +205,7 @@ export function ReferralRewardDialog({
     if (!open || !effectiveUserId || code) return;
 
     let cancelled = false;
-    getOrCreateReferralCode({ userId: effectiveUserId })
+    getOrCreateReferralCode({})
       .then((result) => {
         if (!cancelled) setGeneratedCode(result.code);
       })

--- a/app/components/SidebarUserNav.tsx
+++ b/app/components/SidebarUserNav.tsx
@@ -7,6 +7,7 @@ import { api } from "@/convex/_generated/api";
 import {
   LogOut,
   Sparkle,
+  Zap,
   LifeBuoy,
   ChevronRight,
   ChevronDown,
@@ -72,29 +73,29 @@ const UpgradeBanner = ({ isCollapsed }: { isCollapsed: boolean }) => {
   };
 
   return (
-    <div className="relative">
+    <div className="mb-2">
       {!isCollapsed && (
-        <div className="relative rounded-t-2xl bg-premium-bg backdrop-blur-sm transition-all duration-200">
-          <div
-            role="button"
-            tabIndex={0}
+        <div className="relative">
+          <button
+            type="button"
             onClick={handleUpgrade}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                handleUpgrade();
-              }
-            }}
-            className="group relative z-10 flex w-full items-center rounded-t-2xl py-2.5 px-4 text-xs border border-sidebar-border hover:bg-premium-hover transition-all duration-150 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-none cursor-pointer"
+            className="group/share-card pointer-events-auto relative flex min-h-16 w-full cursor-pointer items-center justify-between gap-3 overflow-hidden rounded-xl border border-sidebar-border bg-muted/40 p-3 text-left transition-all hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 md:h-14"
             aria-label="Upgrade your plan"
           >
-            <span className="flex items-center gap-2.5">
-              <Sparkle className="h-4 w-4 text-premium-text fill-current" />
-              <span className="text-xs font-medium text-premium-text">
-                Upgrade your plan
+            <span className="pointer-events-none absolute inset-0 rounded-xl bg-gradient-to-r from-premium-text/60 via-chart-5/50 to-chart-2/45 opacity-0 transition-opacity duration-200 group-hover/share-card:opacity-100" />
+            <span className="pointer-events-none absolute inset-px rounded-[11px] bg-sidebar transition-colors duration-200 group-hover/share-card:bg-muted/70" />
+            <span className="relative flex min-w-0 flex-col justify-between gap-1">
+              <span className="truncate text-base font-medium leading-none text-sidebar-foreground md:text-sm">
+                Upgrade to Pro
+              </span>
+              <span className="truncate text-sm text-muted-foreground md:text-xs">
+                Unlock more features
               </span>
             </span>
-          </div>
+            <span className="relative flex size-8 shrink-0 items-center justify-center rounded-full bg-premium-bg text-premium-text">
+              <Zap className="h-4 w-4 fill-current" />
+            </span>
+          </button>
         </div>
       )}
     </div>

--- a/app/components/SidebarUserNav.tsx
+++ b/app/components/SidebarUserNav.tsx
@@ -236,7 +236,10 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
 
   return (
     <div className="relative">
-      <ReferralRewardEntry isCollapsed={isCollapsed} isFreeUser={!isProUser} />
+      <ReferralRewardEntry
+        isCollapsed={isCollapsed}
+        isFreeUser={!isCheckingProPlan && !isProUser}
+      />
 
       {/* Upgrade banner above user nav */}
       <UpgradeBanner isCollapsed={isCollapsed} />

--- a/app/components/SidebarUserNav.tsx
+++ b/app/components/SidebarUserNav.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/ui/tooltip";
 import { clientLogout } from "@/lib/utils/logout";
 import { openSettingsDialog } from "@/lib/utils/settings-dialog";
+import { ReferralRewardEntry } from "./ReferralRewardDialog";
 
 const NEXT_PUBLIC_HELP_CENTER_URL =
   process.env.NEXT_PUBLIC_HELP_CENTER_URL || "https://help.hackerai.co/en/";
@@ -235,6 +236,8 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
 
   return (
     <div className="relative">
+      <ReferralRewardEntry isCollapsed={isCollapsed} isFreeUser={!isProUser} />
+
       {/* Upgrade banner above user nav */}
       <UpgradeBanner isCollapsed={isCollapsed} />
 

--- a/app/components/__tests__/ReferralRewardDialog.test.tsx
+++ b/app/components/__tests__/ReferralRewardDialog.test.tsx
@@ -135,6 +135,18 @@ describe("ReferralRewardEntry", () => {
     expect(screen.getByText("Activated")).toBeInTheDocument();
     expect(screen.getByText("Paid")).toBeInTheDocument();
 
+    fireEvent.click(screen.getByRole("button", { name: /view terms/i }));
+
+    expect(screen.getByTestId("referral-terms")).toHaveTextContent(
+      "new HackerAI users",
+    );
+    expect(screen.getByTestId("referral-terms")).toHaveTextContent(
+      "high-risk email accounts",
+    );
+    expect(screen.getByTestId("referral-terms")).toHaveTextContent(
+      "deactivate a referral link",
+    );
+
     fireEvent.click(screen.getByLabelText("Copy referral link"));
 
     await waitFor(() => {

--- a/app/components/__tests__/ReferralRewardDialog.test.tsx
+++ b/app/components/__tests__/ReferralRewardDialog.test.tsx
@@ -74,7 +74,7 @@ describe("ReferralRewardEntry", () => {
     expect(await screen.findByTestId("referral-button")).toBeInTheDocument();
     expect(screen.getByText("Share HackerAI")).toBeInTheDocument();
     expect(
-      screen.getByText("Earn credits per paid referral"),
+      screen.getByText("10 credits per paid referral"),
     ).toBeInTheDocument();
     expect(mockUseQuery).toHaveBeenCalledWith(
       "referrals.getReferralSummary",

--- a/app/components/__tests__/ReferralRewardDialog.test.tsx
+++ b/app/components/__tests__/ReferralRewardDialog.test.tsx
@@ -6,8 +6,6 @@ const mockUseAuth = jest.fn();
 const mockUseQuery = jest.fn();
 const mockGetOrCreateReferralCode = jest.fn();
 const mockCaptureAuthenticatedEvent = jest.fn();
-const mockIsFeatureEnabled = jest.fn();
-const mockOnFeatureFlags = jest.fn();
 const mockToastError = jest.fn();
 
 jest.mock("@workos-inc/authkit-nextjs/components", () => ({
@@ -33,15 +31,6 @@ jest.mock("@/convex/_generated/api", () => ({
 jest.mock("@/lib/analytics/client", () => ({
   captureAuthenticatedEvent: (...args: unknown[]) =>
     mockCaptureAuthenticatedEvent(...args),
-}));
-
-jest.mock("posthog-js", () => ({
-  __esModule: true,
-  default: {
-    __loaded: true,
-    isFeatureEnabled: (...args: unknown[]) => mockIsFeatureEnabled(...args),
-    onFeatureFlags: (...args: unknown[]) => mockOnFeatureFlags(...args),
-  },
 }));
 
 jest.mock("sonner", () => ({
@@ -70,19 +59,14 @@ describe("ReferralRewardEntry", () => {
       converted: 1,
     });
     mockGetOrCreateReferralCode.mockResolvedValue({ code: "ABCD1234" });
-    mockIsFeatureEnabled.mockReturnValue(true);
-    mockOnFeatureFlags.mockImplementation((callback: () => void) => {
-      callback();
-    });
   });
 
-  it("renders the sidebar referral action for free users when the flag is enabled", async () => {
+  it("renders the sidebar referral action for free users", async () => {
     const { ReferralRewardEntryContent } = require("../ReferralRewardDialog");
     render(
       <ReferralRewardEntryContent
         isCollapsed={false}
         isFreeUser={true}
-        enabled={true}
         userId="user-123"
       />,
     );
@@ -100,7 +84,6 @@ describe("ReferralRewardEntry", () => {
       <ReferralRewardEntryContent
         isCollapsed={false}
         isFreeUser={false}
-        enabled={true}
         userId="user-123"
       />,
     );
@@ -108,14 +91,13 @@ describe("ReferralRewardEntry", () => {
     expect(screen.queryByTestId("referral-button")).not.toBeInTheDocument();
   });
 
-  it("does not render when the experiment flag is disabled", async () => {
+  it("does not render without a signed-in user", async () => {
     const { ReferralRewardEntryContent } = require("../ReferralRewardDialog");
     render(
       <ReferralRewardEntryContent
         isCollapsed={false}
         isFreeUser={true}
-        enabled={false}
-        userId="user-123"
+        userId={undefined}
       />,
     );
 
@@ -130,7 +112,6 @@ describe("ReferralRewardEntry", () => {
       <ReferralRewardEntryContent
         isCollapsed={false}
         isFreeUser={true}
-        enabled={true}
         userId="user-123"
       />,
     );

--- a/app/components/__tests__/ReferralRewardDialog.test.tsx
+++ b/app/components/__tests__/ReferralRewardDialog.test.tsx
@@ -1,0 +1,161 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mockUseAuth = jest.fn();
+const mockUseQuery = jest.fn();
+const mockGetOrCreateReferralCode = jest.fn();
+const mockCaptureAuthenticatedEvent = jest.fn();
+const mockIsFeatureEnabled = jest.fn();
+const mockOnFeatureFlags = jest.fn();
+const mockToastError = jest.fn();
+
+jest.mock("@workos-inc/authkit-nextjs/components", () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("convex/react", () => ({
+  __esModule: true,
+  useMutation: () => mockGetOrCreateReferralCode,
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+}));
+
+jest.mock("@/convex/_generated/api", () => ({
+  api: {
+    referrals: {
+      getOrCreateReferralCode: "referrals.getOrCreateReferralCode",
+      getReferralSummary: "referrals.getReferralSummary",
+    },
+  },
+}));
+
+jest.mock("@/lib/analytics/client", () => ({
+  captureAuthenticatedEvent: (...args: unknown[]) =>
+    mockCaptureAuthenticatedEvent(...args),
+}));
+
+jest.mock("posthog-js", () => ({
+  __esModule: true,
+  default: {
+    __loaded: true,
+    isFeatureEnabled: (...args: unknown[]) => mockIsFeatureEnabled(...args),
+    onFeatureFlags: (...args: unknown[]) => mockOnFeatureFlags(...args),
+  },
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: jest.fn(() => Promise.resolve()),
+  },
+});
+
+describe("ReferralRewardEntry", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      user: { id: "user-123", email: "user@example.com" },
+    });
+    mockUseQuery.mockReturnValue({
+      code: "ABCD1234",
+      balanceCredits: 10,
+      signedUp: 2,
+      activated: 1,
+      converted: 1,
+    });
+    mockGetOrCreateReferralCode.mockResolvedValue({ code: "ABCD1234" });
+    mockIsFeatureEnabled.mockReturnValue(true);
+    mockOnFeatureFlags.mockImplementation((callback: () => void) => {
+      callback();
+    });
+  });
+
+  it("renders the sidebar referral action for free users when the flag is enabled", async () => {
+    const { ReferralRewardEntryContent } = require("../ReferralRewardDialog");
+    render(
+      <ReferralRewardEntryContent
+        isCollapsed={false}
+        isFreeUser={true}
+        enabled={true}
+        userId="user-123"
+      />,
+    );
+
+    expect(await screen.findByTestId("referral-button")).toBeInTheDocument();
+    expect(screen.getByText("Share HackerAI")).toBeInTheDocument();
+    expect(
+      screen.getByText("Earn credits per paid referral"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render for paid users", () => {
+    const { ReferralRewardEntryContent } = require("../ReferralRewardDialog");
+    render(
+      <ReferralRewardEntryContent
+        isCollapsed={false}
+        isFreeUser={false}
+        enabled={true}
+        userId="user-123"
+      />,
+    );
+
+    expect(screen.queryByTestId("referral-button")).not.toBeInTheDocument();
+  });
+
+  it("does not render when the experiment flag is disabled", async () => {
+    const { ReferralRewardEntryContent } = require("../ReferralRewardDialog");
+    render(
+      <ReferralRewardEntryContent
+        isCollapsed={false}
+        isFreeUser={true}
+        enabled={false}
+        userId="user-123"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("referral-button")).not.toBeInTheDocument();
+    });
+  });
+
+  it("opens the modal, shows stats, and copies the invite link", async () => {
+    const { ReferralRewardEntryContent } = require("../ReferralRewardDialog");
+    render(
+      <ReferralRewardEntryContent
+        isCollapsed={false}
+        isFreeUser={true}
+        enabled={true}
+        userId="user-123"
+      />,
+    );
+
+    fireEvent.click(await screen.findByTestId("referral-button"));
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByTestId("referral-link")).toHaveTextContent(
+      "/invite/ABCD1234",
+    );
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("Signed up")).toBeInTheDocument();
+    expect(screen.getByText("Activated")).toBeInTheDocument();
+    expect(screen.getByText("Paid")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Copy referral link"));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        expect.stringContaining("/invite/ABCD1234"),
+      );
+    });
+    expect(mockCaptureAuthenticatedEvent).toHaveBeenCalledWith(
+      "referral_invite_copied",
+      { referral_code: "ABCD1234" },
+    );
+  });
+});

--- a/app/components/__tests__/ReferralRewardDialog.test.tsx
+++ b/app/components/__tests__/ReferralRewardDialog.test.tsx
@@ -76,6 +76,10 @@ describe("ReferralRewardEntry", () => {
     expect(
       screen.getByText("Earn credits per paid referral"),
     ).toBeInTheDocument();
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      "referrals.getReferralSummary",
+      "skip",
+    );
   });
 
   it("does not render for paid users", () => {
@@ -119,6 +123,10 @@ describe("ReferralRewardEntry", () => {
     fireEvent.click(await screen.findByTestId("referral-button"));
 
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      "referrals.getReferralSummary",
+      {},
+    );
     expect(screen.getByTestId("referral-link")).toHaveTextContent(
       "/invite/ABCD1234",
     );

--- a/app/hooks/useReferralClaim.ts
+++ b/app/hooks/useReferralClaim.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useAuth } from "@workos-inc/authkit-nextjs/components";
+import { useEffect, useRef } from "react";
+
+export function useReferralClaim() {
+  const { user } = useAuth();
+  const claimedUserRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!user?.id || claimedUserRef.current === user.id) return;
+    claimedUserRef.current = user.id;
+
+    fetch("/api/referrals/claim", {
+      method: "POST",
+      credentials: "include",
+    }).catch(() => {
+      // Best-effort: most sessions will not have a referral cookie.
+    });
+  }, [user?.id]);
+}

--- a/app/hooks/useReferralClaim.ts
+++ b/app/hooks/useReferralClaim.ts
@@ -9,13 +9,18 @@ export function useReferralClaim() {
 
   useEffect(() => {
     if (!user?.id || claimedUserRef.current === user.id) return;
-    claimedUserRef.current = user.id;
 
     fetch("/api/referrals/claim", {
       method: "POST",
       credentials: "include",
-    }).catch(() => {
-      // Best-effort: most sessions will not have a referral cookie.
-    });
+    })
+      .then((response) => {
+        if (response.ok) {
+          claimedUserRef.current = user.id;
+        }
+      })
+      .catch(() => {
+        // Best-effort: most sessions will not have a referral cookie.
+      });
   }, [user?.id]);
 }

--- a/app/invite/[code]/route.ts
+++ b/app/invite/[code]/route.ts
@@ -1,0 +1,67 @@
+import { after, NextRequest, NextResponse } from "next/server";
+import { api } from "@/convex/_generated/api";
+import { getConvexClient } from "@/lib/db/convex-client";
+import { phLogger } from "@/lib/posthog/server";
+import {
+  encodeReferralCookie,
+  REFERRAL_COOKIE_MAX_AGE_SECONDS,
+  REFERRAL_COOKIE_NAME,
+} from "@/lib/referrals";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ code: string }> },
+) {
+  const { code: rawCode } = await params;
+  const code = rawCode.toUpperCase();
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? req.nextUrl.origin;
+  const landingPath = `/invite/${encodeURIComponent(code)}`;
+  const redirectUrl = new URL("/signup", baseUrl);
+  const existingCookie = req.cookies.get(REFERRAL_COOKIE_NAME)?.value;
+
+  try {
+    const convex = getConvexClient();
+    const referralCode = await convex.query(api.referrals.getReferralCode, {
+      code,
+    });
+
+    if (!referralCode) {
+      return NextResponse.redirect(new URL("/signup", baseUrl), {
+        status: 303,
+      });
+    }
+
+    phLogger.event("referral_invite_viewed", {
+      userId: referralCode.referrerUserId,
+      referrer_user_id: referralCode.referrerUserId,
+      referral_code: referralCode.code,
+      referral_landing_path: landingPath,
+    });
+    after(() => phLogger.flush());
+
+    const response = NextResponse.redirect(redirectUrl, { status: 303 });
+    if (!existingCookie) {
+      response.cookies.set(
+        REFERRAL_COOKIE_NAME,
+        encodeReferralCookie({
+          code: referralCode.code,
+          landingPath,
+          viewedAt: Date.now(),
+        }),
+        {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === "production",
+          sameSite: "lax",
+          maxAge: REFERRAL_COOKIE_MAX_AGE_SECONDS,
+          path: "/",
+        },
+      );
+    }
+
+    return response;
+  } catch (error) {
+    phLogger.warn("referral_invite_route_failed", { code, error });
+    after(() => phLogger.flush());
+    return NextResponse.redirect(redirectUrl, { status: 303 });
+  }
+}

--- a/convex/__tests__/referrals.test.ts
+++ b/convex/__tests__/referrals.test.ts
@@ -1,0 +1,278 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+
+jest.mock("../_generated/server", () => ({
+  mutation: jest.fn((config: any) => config),
+  query: jest.fn((config: any) => config),
+}));
+
+jest.mock("convex/values", () => ({
+  v: {
+    id: jest.fn(() => "id"),
+    null: jest.fn(() => "null"),
+    string: jest.fn(() => "string"),
+    number: jest.fn(() => "number"),
+    optional: jest.fn(() => "optional"),
+    object: jest.fn(() => "object"),
+    union: jest.fn(() => "union"),
+    array: jest.fn(() => "array"),
+    boolean: jest.fn(() => "boolean"),
+    literal: jest.fn(() => "literal"),
+    any: jest.fn(() => "any"),
+  },
+}));
+
+jest.mock("../lib/utils", () => ({
+  validateServiceKey: jest.fn(),
+}));
+
+const SERVICE_KEY = "test-service-key";
+
+type Row = Record<string, any> & { _id: string };
+
+function makeMockCtx(initial?: Partial<Record<string, Row[]>>) {
+  const tables: Record<string, Row[]> = {
+    referral_codes: [...(initial?.referral_codes ?? [])],
+    referrals: [...(initial?.referrals ?? [])],
+    referral_credit_balances: [...(initial?.referral_credit_balances ?? [])],
+    referral_credit_ledger: [...(initial?.referral_credit_ledger ?? [])],
+  };
+
+  let nextId = 1;
+  const mintId = (table: string) => `${table}-${nextId++}`;
+
+  const getMatches = (table: string, captured: Record<string, any>) => {
+    return (tables[table] ?? []).filter((row) =>
+      Object.entries(captured).every(([field, value]) => row[field] === value),
+    );
+  };
+
+  const ctx: any = {
+    db: {
+      query: jest.fn((table: string) => ({
+        withIndex: jest.fn((_indexName: string, predicate: any) => {
+          const captured: Record<string, any> = {};
+          const captureProxy = {
+            eq: (field: string, value: any) => {
+              captured[field] = value;
+              return captureProxy;
+            },
+          };
+          predicate(captureProxy);
+          const matches = getMatches(table, captured);
+          return {
+            first: async () => matches[0] ?? null,
+            unique: async () => {
+              if (matches.length === 0) return null;
+              if (matches.length > 1) {
+                throw new Error(`Expected unique ${table} row`);
+              }
+              return matches[0];
+            },
+            collect: async () => matches,
+          };
+        }),
+      })),
+      insert: jest.fn(async (table: string, doc: Record<string, any>) => {
+        const row = { _id: mintId(table), ...doc };
+        tables[table].push(row);
+        return row._id;
+      }),
+      patch: jest.fn(async (id: string, patch: Record<string, any>) => {
+        const row = Object.values(tables)
+          .flat()
+          .find((candidate) => candidate._id === id);
+        if (!row) throw new Error(`row ${id} not found`);
+        Object.assign(row, patch);
+      }),
+      get: jest.fn(async (id: string) => {
+        return (
+          Object.values(tables)
+            .flat()
+            .find((candidate) => candidate._id === id) ?? null
+        );
+      }),
+    },
+  };
+
+  return { ctx, tables };
+}
+
+async function referralsModule() {
+  return import("../referrals");
+}
+
+describe("referrals", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, "now").mockReturnValue(1_000_000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("creates one stable referral code per user", async () => {
+    const { getOrCreateReferralCode } = await referralsModule();
+    const { ctx, tables } = makeMockCtx();
+
+    const first = await (getOrCreateReferralCode as any).handler(ctx, {
+      userId: "user-referrer",
+    });
+    const second = await (getOrCreateReferralCode as any).handler(ctx, {
+      userId: "user-referrer",
+    });
+
+    expect(first.code).toBe(second.code);
+    expect(tables.referral_codes).toHaveLength(1);
+  });
+
+  it("rejects self-referrals", async () => {
+    const { claimReferralSignup } = await referralsModule();
+    const { ctx } = makeMockCtx({
+      referral_codes: [
+        {
+          _id: "code-1",
+          user_id: "user-a",
+          code: "ABCD1234",
+          created_at: 1,
+        },
+      ],
+    });
+
+    const result = await (claimReferralSignup as any).handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      referredUserId: "user-a",
+      referralCode: "ABCD1234",
+    });
+
+    expect(result).toEqual({ claimed: false, reason: "self_referral" });
+  });
+
+  it("keeps first-touch attribution and awards starter credits once", async () => {
+    const { claimReferralSignup } = await referralsModule();
+    const { ctx, tables } = makeMockCtx({
+      referral_codes: [
+        {
+          _id: "code-1",
+          user_id: "referrer-a",
+          code: "FIRST123",
+          created_at: 1,
+        },
+        {
+          _id: "code-2",
+          user_id: "referrer-b",
+          code: "LAST1234",
+          created_at: 1,
+        },
+      ],
+    });
+
+    const first = await (claimReferralSignup as any).handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      referredUserId: "new-user",
+      referralCode: "FIRST123",
+      referralLandingPath: "/invite/FIRST123",
+    });
+    const second = await (claimReferralSignup as any).handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      referredUserId: "new-user",
+      referralCode: "LAST1234",
+      referralLandingPath: "/invite/LAST1234",
+    });
+
+    expect(first.claimed).toBe(true);
+    expect(second).toMatchObject({
+      claimed: false,
+      reason: "already_claimed",
+      referrerUserId: "referrer-a",
+      referralCode: "FIRST123",
+    });
+    expect(tables.referrals).toHaveLength(1);
+    expect(tables.referral_credit_balances[0]).toMatchObject({
+      user_id: "new-user",
+      balance_credits: 10,
+    });
+    expect(tables.referral_credit_ledger).toHaveLength(1);
+  });
+
+  it("awards referrer conversion credits once", async () => {
+    const { awardReferralConversion } = await referralsModule();
+    const { ctx, tables } = makeMockCtx({
+      referrals: [
+        {
+          _id: "referral-1",
+          referrer_user_id: "referrer-a",
+          referred_user_id: "new-user",
+          referral_code: "FIRST123",
+          status: "activated",
+          signed_up_at: 1,
+          activated_at: 2,
+          updated_at: 2,
+        },
+      ],
+    });
+
+    const first = await (awardReferralConversion as any).handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      referredUserId: "new-user",
+      qualifyingTier: "pro",
+      idempotencyKey: "sub_123",
+    });
+    const second = await (awardReferralConversion as any).handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      referredUserId: "new-user",
+      qualifyingTier: "pro",
+      idempotencyKey: "sub_123",
+    });
+
+    expect(first).toMatchObject({
+      awarded: true,
+      referrerUserId: "referrer-a",
+      creditsAwarded: 10,
+    });
+    expect(second).toMatchObject({
+      awarded: false,
+      reason: "already_converted",
+    });
+    expect(tables.referral_credit_balances[0]).toMatchObject({
+      user_id: "referrer-a",
+      balance_credits: 10,
+    });
+    expect(tables.referral_credit_ledger).toHaveLength(1);
+  });
+
+  it("does not allow referral credit spend to go negative", async () => {
+    const { spendReferralCredits } = await referralsModule();
+    const { ctx, tables } = makeMockCtx({
+      referral_credit_balances: [
+        {
+          _id: "balance-1",
+          user_id: "user-a",
+          balance_credits: 1,
+          updated_at: 1,
+        },
+      ],
+    });
+
+    const result = await (spendReferralCredits as any).handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      userId: "user-a",
+      amountCredits: 2,
+      idempotencyKey: "spend-1",
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      insufficientCredits: true,
+    });
+    expect(tables.referral_credit_balances[0].balance_credits).toBe(1);
+    expect(tables.referral_credit_ledger).toHaveLength(0);
+  });
+});

--- a/convex/__tests__/referrals.test.ts
+++ b/convex/__tests__/referrals.test.ts
@@ -36,7 +36,10 @@ const SERVICE_KEY = "test-service-key";
 
 type Row = Record<string, any> & { _id: string };
 
-function makeMockCtx(initial?: Partial<Record<string, Row[]>>) {
+function makeMockCtx(
+  initial?: Partial<Record<string, Row[]>>,
+  authUserId = "user-referrer",
+) {
   const tables: Record<string, Row[]> = {
     referral_codes: [...(initial?.referral_codes ?? [])],
     referrals: [...(initial?.referrals ?? [])],
@@ -76,6 +79,7 @@ function makeMockCtx(initial?: Partial<Record<string, Row[]>>) {
               return matches[0];
             },
             collect: async () => matches,
+            take: async (limit: number) => matches.slice(0, limit),
           };
         }),
       })),
@@ -98,6 +102,11 @@ function makeMockCtx(initial?: Partial<Record<string, Row[]>>) {
             .find((candidate) => candidate._id === id) ?? null
         );
       }),
+    },
+    auth: {
+      getUserIdentity: jest
+        .fn()
+        .mockResolvedValue(authUserId ? { subject: authUserId } : null),
     },
   };
 
@@ -122,15 +131,20 @@ describe("referrals", () => {
     const { getOrCreateReferralCode } = await referralsModule();
     const { ctx, tables } = makeMockCtx();
 
-    const first = await (getOrCreateReferralCode as any).handler(ctx, {
-      userId: "user-referrer",
-    });
-    const second = await (getOrCreateReferralCode as any).handler(ctx, {
-      userId: "user-referrer",
-    });
+    const first = await (getOrCreateReferralCode as any).handler(ctx, {});
+    const second = await (getOrCreateReferralCode as any).handler(ctx, {});
 
     expect(first.code).toBe(second.code);
     expect(tables.referral_codes).toHaveLength(1);
+  });
+
+  it("rejects unauthenticated public referral code creation", async () => {
+    const { getOrCreateReferralCode } = await referralsModule();
+    const { ctx } = makeMockCtx(undefined, "");
+
+    await expect(
+      (getOrCreateReferralCode as any).handler(ctx, {}),
+    ).rejects.toThrow("Unauthorized");
   });
 
   it("rejects self-referrals", async () => {
@@ -273,6 +287,31 @@ describe("referrals", () => {
       insufficientCredits: true,
     });
     expect(tables.referral_credit_balances[0].balance_credits).toBe(1);
+    expect(tables.referral_credit_ledger).toHaveLength(0);
+  });
+
+  it("rejects invalid referral credit spend amounts", async () => {
+    const { spendReferralCredits } = await referralsModule();
+    const { ctx, tables } = makeMockCtx({
+      referral_credit_balances: [
+        {
+          _id: "balance-1",
+          user_id: "user-a",
+          balance_credits: 10,
+          updated_at: 1,
+        },
+      ],
+    });
+
+    await expect(
+      (spendReferralCredits as any).handler(ctx, {
+        serviceKey: SERVICE_KEY,
+        userId: "user-a",
+        amountCredits: 0,
+        idempotencyKey: "spend-0",
+      }),
+    ).rejects.toThrow("amountCredits must be at least 1");
+    expect(tables.referral_credit_balances[0].balance_credits).toBe(10);
     expect(tables.referral_credit_ledger).toHaveLength(0);
   });
 });

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -25,6 +25,7 @@ import type * as messages from "../messages.js";
 import type * as notes from "../notes.js";
 import type * as rateLimitStatus from "../rateLimitStatus.js";
 import type * as redisPubsub from "../redisPubsub.js";
+import type * as referrals from "../referrals.js";
 import type * as s3Actions from "../s3Actions.js";
 import type * as s3Cleanup from "../s3Cleanup.js";
 import type * as s3Utils from "../s3Utils.js";
@@ -61,6 +62,7 @@ declare const fullApi: ApiFromModules<{
   notes: typeof notes;
   rateLimitStatus: typeof rateLimitStatus;
   redisPubsub: typeof redisPubsub;
+  referrals: typeof referrals;
   s3Actions: typeof s3Actions;
   s3Cleanup: typeof s3Cleanup;
   s3Utils: typeof s3Utils;

--- a/convex/referrals.ts
+++ b/convex/referrals.ts
@@ -1,0 +1,442 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { validateServiceKey } from "./lib/utils";
+
+export const REFERRAL_STARTER_CREDITS = 10;
+export const REFERRER_CONVERSION_CREDITS = 10;
+export const REFERRAL_REWARD_EXPERIMENT_FLAG = "referral_reward_experiment";
+
+const CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const REFERRAL_CODE_LENGTH = 8;
+
+type ReferralStatus = "signed_up" | "activated" | "converted";
+type LedgerReason =
+  | "referred_signup_bonus"
+  | "referrer_conversion_bonus"
+  | "free_usage_overflow";
+
+function generateReferralCode(): string {
+  let code = "";
+  for (let i = 0; i < REFERRAL_CODE_LENGTH; i++) {
+    code += CODE_ALPHABET[Math.floor(Math.random() * CODE_ALPHABET.length)];
+  }
+  return code;
+}
+
+async function getOrCreateBalance(ctx: any, userId: string, now: number) {
+  const existing = await ctx.db
+    .query("referral_credit_balances")
+    .withIndex("by_user", (q: any) => q.eq("user_id", userId))
+    .unique();
+
+  if (existing) return existing;
+
+  const id = await ctx.db.insert("referral_credit_balances", {
+    user_id: userId,
+    balance_credits: 0,
+    updated_at: now,
+  });
+  return ctx.db.get(id);
+}
+
+async function insertLedgerEntry(
+  ctx: any,
+  args: {
+    userId: string;
+    amountCredits: number;
+    type: "grant" | "spend";
+    reason: LedgerReason;
+    idempotencyKey: string;
+    relatedReferralId?: string;
+  },
+) {
+  const existing = await ctx.db
+    .query("referral_credit_ledger")
+    .withIndex("by_idempotency_key", (q: any) =>
+      q.eq("idempotency_key", args.idempotencyKey),
+    )
+    .unique();
+
+  if (existing) return { alreadyProcessed: true, ledger: existing };
+
+  const now = Date.now();
+  const balance = await getOrCreateBalance(ctx, args.userId, now);
+  const currentBalance = balance?.balance_credits ?? 0;
+  const nextBalance = currentBalance + args.amountCredits;
+
+  if (nextBalance < 0) {
+    return { alreadyProcessed: false, insufficientCredits: true };
+  }
+
+  await ctx.db.patch(balance._id, {
+    balance_credits: nextBalance,
+    updated_at: now,
+  });
+
+  const ledgerId = await ctx.db.insert("referral_credit_ledger", {
+    user_id: args.userId,
+    amount_credits: args.amountCredits,
+    type: args.type,
+    reason: args.reason,
+    idempotency_key: args.idempotencyKey,
+    related_referral_id: args.relatedReferralId,
+    created_at: now,
+  });
+
+  return {
+    alreadyProcessed: false,
+    insufficientCredits: false,
+    ledger: await ctx.db.get(ledgerId),
+    newBalanceCredits: nextBalance,
+  };
+}
+
+export const getOrCreateReferralCode = mutation({
+  args: { userId: v.string() },
+  returns: v.object({ code: v.string() }),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("referral_codes")
+      .withIndex("by_user", (q) => q.eq("user_id", args.userId))
+      .unique();
+
+    if (existing) return { code: existing.code };
+
+    for (let attempts = 0; attempts < 10; attempts++) {
+      const code = generateReferralCode();
+      const collision = await ctx.db
+        .query("referral_codes")
+        .withIndex("by_code", (q) => q.eq("code", code))
+        .unique();
+      if (collision) continue;
+
+      await ctx.db.insert("referral_codes", {
+        user_id: args.userId,
+        code,
+        created_at: Date.now(),
+      });
+      return { code };
+    }
+
+    throw new Error("Unable to generate referral code");
+  },
+});
+
+export const getReferralCode = query({
+  args: { code: v.string() },
+  returns: v.union(
+    v.null(),
+    v.object({
+      code: v.string(),
+      referrerUserId: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("referral_codes")
+      .withIndex("by_code", (q) => q.eq("code", args.code.toUpperCase()))
+      .unique();
+
+    if (!row) return null;
+
+    return {
+      code: row.code,
+      referrerUserId: row.user_id,
+    };
+  },
+});
+
+export const getReferralSummary = query({
+  args: { userId: v.string() },
+  returns: v.object({
+    code: v.optional(v.string()),
+    balanceCredits: v.number(),
+    signedUp: v.number(),
+    activated: v.number(),
+    converted: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const [codeRow, balanceRow, referrals] = await Promise.all([
+      ctx.db
+        .query("referral_codes")
+        .withIndex("by_user", (q) => q.eq("user_id", args.userId))
+        .unique(),
+      ctx.db
+        .query("referral_credit_balances")
+        .withIndex("by_user", (q) => q.eq("user_id", args.userId))
+        .unique(),
+      ctx.db
+        .query("referrals")
+        .withIndex("by_referrer", (q) => q.eq("referrer_user_id", args.userId))
+        .collect(),
+    ]);
+
+    return {
+      code: codeRow?.code,
+      balanceCredits: balanceRow?.balance_credits ?? 0,
+      signedUp: referrals.length,
+      activated: referrals.filter(
+        (r) => r.status === "activated" || r.status === "converted",
+      ).length,
+      converted: referrals.filter((r) => r.status === "converted").length,
+    };
+  },
+});
+
+export const getReferralAttributionForUser = query({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+  },
+  returns: v.union(
+    v.null(),
+    v.object({
+      referralId: v.id("referrals"),
+      referrerUserId: v.string(),
+      referredUserId: v.string(),
+      referralCode: v.string(),
+      referralLandingPath: v.optional(v.string()),
+      status: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    const referral = await ctx.db
+      .query("referrals")
+      .withIndex("by_referred_user", (q) =>
+        q.eq("referred_user_id", args.userId),
+      )
+      .unique();
+
+    if (!referral) return null;
+
+    return {
+      referralId: referral._id,
+      referrerUserId: referral.referrer_user_id,
+      referredUserId: referral.referred_user_id,
+      referralCode: referral.referral_code,
+      referralLandingPath: referral.referral_landing_path,
+      status: referral.status,
+    };
+  },
+});
+
+export const claimReferralSignup = mutation({
+  args: {
+    serviceKey: v.string(),
+    referredUserId: v.string(),
+    referralCode: v.string(),
+    referralLandingPath: v.optional(v.string()),
+  },
+  returns: v.object({
+    claimed: v.boolean(),
+    reason: v.optional(v.string()),
+    referrerUserId: v.optional(v.string()),
+    referralCode: v.optional(v.string()),
+    starterCreditsAwarded: v.optional(v.number()),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const codeRow = await ctx.db
+      .query("referral_codes")
+      .withIndex("by_code", (q) =>
+        q.eq("code", args.referralCode.toUpperCase()),
+      )
+      .unique();
+
+    if (!codeRow) return { claimed: false, reason: "invalid_code" };
+
+    if (codeRow.user_id === args.referredUserId) {
+      return { claimed: false, reason: "self_referral" };
+    }
+
+    const existing = await ctx.db
+      .query("referrals")
+      .withIndex("by_referred_user", (q) =>
+        q.eq("referred_user_id", args.referredUserId),
+      )
+      .unique();
+
+    if (existing) {
+      return {
+        claimed: false,
+        reason: "already_claimed",
+        referrerUserId: existing.referrer_user_id,
+        referralCode: existing.referral_code,
+      };
+    }
+
+    const now = Date.now();
+    const referralId = await ctx.db.insert("referrals", {
+      referrer_user_id: codeRow.user_id,
+      referred_user_id: args.referredUserId,
+      referral_code: codeRow.code,
+      referral_landing_path: args.referralLandingPath,
+      status: "signed_up" as ReferralStatus,
+      signed_up_at: now,
+      updated_at: now,
+    });
+
+    await insertLedgerEntry(ctx, {
+      userId: args.referredUserId,
+      amountCredits: REFERRAL_STARTER_CREDITS,
+      type: "grant",
+      reason: "referred_signup_bonus",
+      idempotencyKey: `referral_signup:${args.referredUserId}`,
+      relatedReferralId: referralId,
+    });
+
+    return {
+      claimed: true,
+      referrerUserId: codeRow.user_id,
+      referralCode: codeRow.code,
+      starterCreditsAwarded: REFERRAL_STARTER_CREDITS,
+    };
+  },
+});
+
+export const markReferralActivation = mutation({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+  },
+  returns: v.object({
+    activated: v.boolean(),
+    referrerUserId: v.optional(v.string()),
+    referralCode: v.optional(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    const referral = await ctx.db
+      .query("referrals")
+      .withIndex("by_referred_user", (q) =>
+        q.eq("referred_user_id", args.userId),
+      )
+      .unique();
+
+    if (!referral) return { activated: false };
+    if (referral.activated_at || referral.status === "converted") {
+      return {
+        activated: false,
+        referrerUserId: referral.referrer_user_id,
+        referralCode: referral.referral_code,
+      };
+    }
+
+    await ctx.db.patch(referral._id, {
+      status: "activated" as ReferralStatus,
+      activated_at: Date.now(),
+      updated_at: Date.now(),
+    });
+
+    return {
+      activated: true,
+      referrerUserId: referral.referrer_user_id,
+      referralCode: referral.referral_code,
+    };
+  },
+});
+
+export const awardReferralConversion = mutation({
+  args: {
+    serviceKey: v.string(),
+    referredUserId: v.string(),
+    qualifyingTier: v.string(),
+    idempotencyKey: v.string(),
+  },
+  returns: v.object({
+    awarded: v.boolean(),
+    reason: v.optional(v.string()),
+    referrerUserId: v.optional(v.string()),
+    referralCode: v.optional(v.string()),
+    creditsAwarded: v.optional(v.number()),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const referral = await ctx.db
+      .query("referrals")
+      .withIndex("by_referred_user", (q) =>
+        q.eq("referred_user_id", args.referredUserId),
+      )
+      .unique();
+
+    if (!referral) return { awarded: false, reason: "no_referral" };
+    if (referral.converted_at) {
+      return {
+        awarded: false,
+        reason: "already_converted",
+        referrerUserId: referral.referrer_user_id,
+        referralCode: referral.referral_code,
+      };
+    }
+
+    const ledger = await insertLedgerEntry(ctx, {
+      userId: referral.referrer_user_id,
+      amountCredits: REFERRER_CONVERSION_CREDITS,
+      type: "grant",
+      reason: "referrer_conversion_bonus",
+      idempotencyKey: `referral_conversion:${args.referredUserId}`,
+      relatedReferralId: referral._id,
+    });
+
+    if (ledger.alreadyProcessed) {
+      return {
+        awarded: false,
+        reason: "already_awarded",
+        referrerUserId: referral.referrer_user_id,
+        referralCode: referral.referral_code,
+      };
+    }
+
+    await ctx.db.patch(referral._id, {
+      status: "converted" as ReferralStatus,
+      converted_at: Date.now(),
+      qualifying_tier: args.qualifyingTier,
+      conversion_idempotency_key: args.idempotencyKey,
+      updated_at: Date.now(),
+    });
+
+    return {
+      awarded: true,
+      referrerUserId: referral.referrer_user_id,
+      referralCode: referral.referral_code,
+      creditsAwarded: REFERRER_CONVERSION_CREDITS,
+    };
+  },
+});
+
+export const spendReferralCredits = mutation({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+    amountCredits: v.number(),
+    idempotencyKey: v.string(),
+  },
+  returns: v.object({
+    success: v.boolean(),
+    alreadyProcessed: v.boolean(),
+    insufficientCredits: v.boolean(),
+    newBalanceCredits: v.optional(v.number()),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    const amount = Math.max(1, Math.trunc(args.amountCredits));
+
+    const result = await insertLedgerEntry(ctx, {
+      userId: args.userId,
+      amountCredits: -amount,
+      type: "spend",
+      reason: "free_usage_overflow",
+      idempotencyKey: args.idempotencyKey,
+    });
+
+    return {
+      success: !result.insufficientCredits,
+      alreadyProcessed: result.alreadyProcessed ?? false,
+      insufficientCredits: result.insufficientCredits ?? false,
+      newBalanceCredits: result.newBalanceCredits,
+    };
+  },
+});

--- a/convex/referrals.ts
+++ b/convex/referrals.ts
@@ -8,6 +8,7 @@ export const REFERRAL_REWARD_EXPERIMENT_FLAG = "referral_reward_experiment";
 
 const CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const REFERRAL_CODE_LENGTH = 8;
+const MAX_REFERRAL_SUMMARY_ROWS = 1000;
 
 type ReferralStatus = "signed_up" | "activated" | "converted";
 type LedgerReason =
@@ -21,6 +22,14 @@ function generateReferralCode(): string {
     code += CODE_ALPHABET[Math.floor(Math.random() * CODE_ALPHABET.length)];
   }
   return code;
+}
+
+async function requireAuthenticatedUserId(ctx: any): Promise<string> {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) {
+    throw new Error("Unauthorized");
+  }
+  return identity.subject;
 }
 
 async function getOrCreateBalance(ctx: any, userId: string, now: number) {
@@ -92,12 +101,13 @@ async function insertLedgerEntry(
 }
 
 export const getOrCreateReferralCode = mutation({
-  args: { userId: v.string() },
+  args: {},
   returns: v.object({ code: v.string() }),
-  handler: async (ctx, args) => {
+  handler: async (ctx) => {
+    const userId = await requireAuthenticatedUserId(ctx);
     const existing = await ctx.db
       .query("referral_codes")
-      .withIndex("by_user", (q) => q.eq("user_id", args.userId))
+      .withIndex("by_user", (q) => q.eq("user_id", userId))
       .unique();
 
     if (existing) return { code: existing.code };
@@ -111,7 +121,7 @@ export const getOrCreateReferralCode = mutation({
       if (collision) continue;
 
       await ctx.db.insert("referral_codes", {
-        user_id: args.userId,
+        user_id: userId,
         code,
         created_at: Date.now(),
       });
@@ -147,7 +157,7 @@ export const getReferralCode = query({
 });
 
 export const getReferralSummary = query({
-  args: { userId: v.string() },
+  args: {},
   returns: v.object({
     code: v.optional(v.string()),
     balanceCredits: v.number(),
@@ -155,20 +165,21 @@ export const getReferralSummary = query({
     activated: v.number(),
     converted: v.number(),
   }),
-  handler: async (ctx, args) => {
+  handler: async (ctx) => {
+    const userId = await requireAuthenticatedUserId(ctx);
     const [codeRow, balanceRow, referrals] = await Promise.all([
       ctx.db
         .query("referral_codes")
-        .withIndex("by_user", (q) => q.eq("user_id", args.userId))
+        .withIndex("by_user", (q) => q.eq("user_id", userId))
         .unique(),
       ctx.db
         .query("referral_credit_balances")
-        .withIndex("by_user", (q) => q.eq("user_id", args.userId))
+        .withIndex("by_user", (q) => q.eq("user_id", userId))
         .unique(),
       ctx.db
         .query("referrals")
-        .withIndex("by_referrer", (q) => q.eq("referrer_user_id", args.userId))
-        .collect(),
+        .withIndex("by_referrer", (q) => q.eq("referrer_user_id", userId))
+        .take(MAX_REFERRAL_SUMMARY_ROWS),
     ]);
 
     return {
@@ -422,7 +433,13 @@ export const spendReferralCredits = mutation({
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
-    const amount = Math.max(1, Math.trunc(args.amountCredits));
+    if (!Number.isFinite(args.amountCredits)) {
+      throw new Error("amountCredits must be a finite positive number");
+    }
+    const amount = Math.trunc(args.amountCredits);
+    if (amount < 1) {
+      throw new Error("amountCredits must be at least 1");
+    }
 
     const result = await insertLedgerEntry(ctx, {
       userId: args.userId,

--- a/convex/referrals.ts
+++ b/convex/referrals.ts
@@ -4,7 +4,6 @@ import { validateServiceKey } from "./lib/utils";
 
 export const REFERRAL_STARTER_CREDITS = 10;
 export const REFERRER_CONVERSION_CREDITS = 10;
-export const REFERRAL_REWARD_EXPERIMENT_FLAG = "referral_reward_experiment";
 
 const CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const REFERRAL_CODE_LENGTH = 8;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -165,6 +165,57 @@ export default defineSchema({
     updated_at: v.number(),
   }).index("by_user_id", ["user_id"]),
 
+  referral_codes: defineTable({
+    user_id: v.string(),
+    code: v.string(),
+    created_at: v.number(),
+  })
+    .index("by_user", ["user_id"])
+    .index("by_code", ["code"]),
+
+  referrals: defineTable({
+    referrer_user_id: v.string(),
+    referred_user_id: v.string(),
+    referral_code: v.string(),
+    referral_landing_path: v.optional(v.string()),
+    status: v.union(
+      v.literal("signed_up"),
+      v.literal("activated"),
+      v.literal("converted"),
+    ),
+    signed_up_at: v.number(),
+    activated_at: v.optional(v.number()),
+    converted_at: v.optional(v.number()),
+    qualifying_tier: v.optional(v.string()),
+    conversion_idempotency_key: v.optional(v.string()),
+    updated_at: v.number(),
+  })
+    .index("by_referred_user", ["referred_user_id"])
+    .index("by_referrer", ["referrer_user_id"])
+    .index("by_referrer_and_status", ["referrer_user_id", "status"]),
+
+  referral_credit_balances: defineTable({
+    user_id: v.string(),
+    balance_credits: v.number(),
+    updated_at: v.number(),
+  }).index("by_user", ["user_id"]),
+
+  referral_credit_ledger: defineTable({
+    user_id: v.string(),
+    amount_credits: v.number(),
+    type: v.union(v.literal("grant"), v.literal("spend")),
+    reason: v.union(
+      v.literal("referred_signup_bonus"),
+      v.literal("referrer_conversion_bonus"),
+      v.literal("free_usage_overflow"),
+    ),
+    idempotency_key: v.string(),
+    related_referral_id: v.optional(v.id("referrals")),
+    created_at: v.number(),
+  })
+    .index("by_user", ["user_id"])
+    .index("by_idempotency_key", ["idempotency_key"]),
+
   // Team-shared extra usage pool. Admin funds it; any member of the org draws
   // from it for overflow once the team subscription bucket is exhausted.
   // Same units as extra_usage (points; auto-reload amount in dollars).

--- a/lib/analytics/user-signup.ts
+++ b/lib/analytics/user-signup.ts
@@ -5,10 +5,16 @@ export function captureUserSignedUp({
   user,
   workosEventId,
   workosEventCreatedAt,
+  referralAttribution,
 }: {
   user: User;
   workosEventId: string;
   workosEventCreatedAt: string;
+  referralAttribution?: {
+    referrerUserId: string;
+    referralCode: string;
+    referralLandingPath?: string;
+  } | null;
 }) {
   phLogger.event("user_signed_up", {
     userId: user.id,
@@ -18,6 +24,9 @@ export function captureUserSignedUp({
     user_created_at: user.createdAt,
     workos_event_id: workosEventId,
     workos_event_created_at: workosEventCreatedAt,
+    referrer_user_id: referralAttribution?.referrerUserId,
+    referral_code: referralAttribution?.referralCode,
+    referral_landing_path: referralAttribution?.referralLandingPath,
     $insert_id: workosEventId,
     $set_once: {
       signed_up_at: user.createdAt,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -124,6 +124,23 @@ function getStreamContext() {
 
 export { getStreamContext };
 
+function getReferralCreditSpendRequestId({
+  chatId,
+  messages,
+  fallbackId,
+  regenerate,
+}: {
+  chatId: string;
+  messages: UIMessage[];
+  fallbackId: string;
+  regenerate?: boolean;
+}) {
+  const lastMessage = messages[messages.length - 1];
+  return lastMessage?.id
+    ? `${chatId}:${lastMessage.id}:${regenerate ? "regenerate" : "send"}`
+    : fallbackId;
+}
+
 export const createChatHandler = (
   endpoint: "/api/chat" | "/api/agent" = "/api/chat",
 ) => {
@@ -243,6 +260,13 @@ export const createChatHandler = (
         Array.isArray(todos) ? todos : [],
         { isTemporary: !!temporary, regenerate },
       );
+      const assistantMessageId = uuidv4();
+      const referralCreditSpendRequestId = getReferralCreditSpendRequestId({
+        chatId,
+        messages,
+        fallbackId: assistantMessageId,
+        regenerate,
+      });
 
       if (!temporary) {
         await handleInitialChatAndUserMessage({
@@ -258,7 +282,16 @@ export const createChatHandler = (
       // Free ask: pre-flight rate-limit before any token counting/model work.
       const freeAskRateLimitInfo =
         mode === "ask" && subscription === "free"
-          ? await checkRateLimit(userId, mode, subscription)
+          ? await checkRateLimit(
+              userId,
+              mode,
+              subscription,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              referralCreditSpendRequestId,
+            )
           : null;
 
       const uploadBasePath = isAgentMode(mode)
@@ -328,11 +361,15 @@ export const createChatHandler = (
           extraUsageConfig,
           selectedModel,
           organizationId,
+          referralCreditSpendRequestId,
         ));
 
       const freeMonthlyBudgetSnapshot =
         subscription === "free" && !rateLimitInfo.referralCreditsDeducted
-          ? await checkFreeMonthlyCostLimit(userId)
+          ? await checkFreeMonthlyCostLimit(
+              userId,
+              referralCreditSpendRequestId,
+            )
           : null;
 
       usageRefundTracker.recordDeductions(rateLimitInfo);
@@ -354,7 +391,6 @@ export const createChatHandler = (
       // PostHog client for analytics (initialized once, used at end of request)
       const posthog = PostHogClient();
 
-      const assistantMessageId = uuidv4();
       chatLogger.getBuilder().setAssistantId(assistantMessageId);
 
       if (temporary) {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -39,6 +39,7 @@ import { getMaxTokensForSubscription } from "@/lib/token-utils";
 import { countTokens } from "gpt-tokenizer";
 import { ChatSDKError } from "@/lib/errors";
 import PostHogClient from "@/app/posthog";
+import { markReferralActivation } from "@/lib/referrals";
 import {
   captureAgentRun,
   captureToolCalls,
@@ -330,7 +331,7 @@ export const createChatHandler = (
         ));
 
       const freeMonthlyBudgetSnapshot =
-        subscription === "free"
+        subscription === "free" && !rateLimitInfo.referralCreditsDeducted
           ? await checkFreeMonthlyCostLimit(userId)
           : null;
 
@@ -340,6 +341,9 @@ export const createChatHandler = (
         {
           pointsDeducted: rateLimitInfo.pointsDeducted,
           extraUsagePointsDeducted: rateLimitInfo.extraUsagePointsDeducted,
+          referralCreditsDeducted:
+            rateLimitInfo.referralCreditsDeducted ??
+            freeMonthlyBudgetSnapshot?.referralCreditsDeducted,
           monthly: rateLimitInfo.monthly,
           remaining: rateLimitInfo.remaining,
           subscription,
@@ -915,6 +919,9 @@ export const createChatHandler = (
                                   sandboxInfo,
                                   outcome: retryAborted ? "aborted" : "success",
                                 });
+                                if (!retryAborted) {
+                                  await markReferralActivation(userId);
+                                }
                                 shutdownPostHog(posthog);
                                 chatLogger!.emitSuccess({
                                   finishReason: state.streamFinishReason,
@@ -1126,6 +1133,9 @@ export const createChatHandler = (
                       sandboxInfo,
                       outcome: isAborted ? "aborted" : "success",
                     });
+                    if (!isAborted) {
+                      await markReferralActivation(userId);
+                    }
                     shutdownPostHog(posthog);
                     chatLogger!.emitSuccess({
                       finishReason: state.streamFinishReason,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -5,6 +5,7 @@ import {
   generateId,
   UIMessage,
 } from "ai";
+import { createHash } from "crypto";
 import { systemPrompt } from "@/lib/system-prompt";
 import { getResumeSection } from "@/lib/system-prompt/resume";
 import { AGENT_MAX_STREAM_DURATION_MS } from "@/lib/chat/stop-conditions";
@@ -127,18 +128,20 @@ export { getStreamContext };
 function getReferralCreditSpendRequestId({
   chatId,
   messages,
-  fallbackId,
   regenerate,
 }: {
   chatId: string;
   messages: UIMessage[];
-  fallbackId: string;
   regenerate?: boolean;
 }) {
   const lastMessage = messages[messages.length - 1];
+  const operation = regenerate ? "regenerate" : "send";
   return lastMessage?.id
-    ? `${chatId}:${lastMessage.id}:${regenerate ? "regenerate" : "send"}`
-    : fallbackId;
+    ? `${chatId}:${lastMessage.id}:${operation}`
+    : `${chatId}:fallback:${operation}:${createHash("sha256")
+        .update(JSON.stringify(messages))
+        .digest("hex")
+        .slice(0, 24)}`;
 }
 
 export const createChatHandler = (
@@ -264,7 +267,6 @@ export const createChatHandler = (
       const referralCreditSpendRequestId = getReferralCreditSpendRequestId({
         chatId,
         messages,
-        fallbackId: assistantMessageId,
         regenerate,
       });
 

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -60,6 +60,7 @@ export interface ChatContext {
 export interface RateLimitContext {
   pointsDeducted?: number;
   extraUsagePointsDeducted?: number;
+  referralCreditsDeducted?: number;
   monthly?: { remaining: number; limit: number };
   remaining?: number;
   subscription: string;
@@ -215,6 +216,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
       builder.setRateLimit({
         pointsDeducted: context.pointsDeducted,
         extraUsagePointsDeducted: context.extraUsagePointsDeducted,
+        referralCreditsDeducted: context.referralCreditsDeducted,
         monthlyRemainingPercent,
         freeRemaining:
           context.subscription === "free" ? context.remaining : undefined,

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -58,6 +58,7 @@ export interface ChatWideEvent {
   rate_limit?: {
     points_deducted?: number;
     extra_usage_points_deducted?: number;
+    referral_credits_deducted?: number;
     monthly_remaining_percent?: number;
     free_remaining?: number;
   };
@@ -290,12 +291,14 @@ export class WideEventBuilder {
   setRateLimit(info: {
     pointsDeducted?: number;
     extraUsagePointsDeducted?: number;
+    referralCreditsDeducted?: number;
     monthlyRemainingPercent?: number;
     freeRemaining?: number;
   }): this {
     this.event.rate_limit = {
       points_deducted: info.pointsDeducted,
       extra_usage_points_deducted: info.extraUsagePointsDeducted,
+      referral_credits_deducted: info.referralCreditsDeducted,
       monthly_remaining_percent: info.monthlyRemainingPercent,
       free_remaining: info.freeRemaining,
     };

--- a/lib/rate-limit/__tests__/free-monthly-cost.test.ts
+++ b/lib/rate-limit/__tests__/free-monthly-cost.test.ts
@@ -11,6 +11,7 @@ describe("free monthly cost limit", () => {
   const mockCreateRedisClient = jest.fn();
   const mockGet = jest.fn();
   const mockEval = jest.fn();
+  const mockSpendReferralCreditsForFreeUsage = jest.fn();
   const originalEnv = process.env.FREE_MONTHLY_COST_LIMIT_USD;
 
   beforeEach(() => {
@@ -19,6 +20,7 @@ describe("free monthly cost limit", () => {
     delete process.env.FREE_MONTHLY_COST_LIMIT_USD;
     mockGet.mockResolvedValue(null);
     mockEval.mockResolvedValue(1);
+    mockSpendReferralCreditsForFreeUsage.mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -35,6 +37,10 @@ describe("free monthly cost limit", () => {
     jest.isolateModules(() => {
       jest.doMock("../redis", () => ({
         createRedisClient: mockCreateRedisClient,
+      }));
+
+      jest.doMock("@/lib/referrals", () => ({
+        spendReferralCreditsForFreeUsage: mockSpendReferralCreditsForFreeUsage,
       }));
 
       isolatedModule = require("../free-monthly-cost");
@@ -70,6 +76,19 @@ describe("free monthly cost limit", () => {
       surface: "chat",
       cause: expect.stringContaining("free monthly usage"),
     });
+  });
+
+  it("spends one referral credit when the monthly free cost cap is exhausted", async () => {
+    process.env.FREE_MONTHLY_COST_LIMIT_USD = "0.01";
+    mockCreateRedisClient.mockReturnValue({ get: mockGet, eval: mockEval });
+    mockGet.mockResolvedValue(100);
+    mockSpendReferralCreditsForFreeUsage.mockResolvedValue(true);
+    const { checkFreeMonthlyCostLimit } = getIsolatedModule();
+
+    const snapshot = await checkFreeMonthlyCostLimit("user-123");
+
+    expect(snapshot.referralCreditsDeducted).toBe(1);
+    expect(snapshot.monthlyRemainingAtStart).toBe(0);
   });
 
   it("records actual free usage cost as monthly points", async () => {

--- a/lib/rate-limit/__tests__/free-monthly-cost.test.ts
+++ b/lib/rate-limit/__tests__/free-monthly-cost.test.ts
@@ -54,7 +54,7 @@ describe("free monthly cost limit", () => {
     mockGet.mockResolvedValue(1250);
     const { checkFreeMonthlyCostLimit } = getIsolatedModule();
 
-    const snapshot = await checkFreeMonthlyCostLimit("user-123");
+    const snapshot = await checkFreeMonthlyCostLimit("user-123", "request-123");
 
     expect(mockGet).toHaveBeenCalledWith(
       expect.stringMatching(/^free_monthly_cost:user-123:\d{4}-\d{2}$/),
@@ -71,7 +71,9 @@ describe("free monthly cost limit", () => {
     mockGet.mockResolvedValue(100);
     const { checkFreeMonthlyCostLimit } = getIsolatedModule();
 
-    await expect(checkFreeMonthlyCostLimit("user-123")).rejects.toMatchObject({
+    await expect(
+      checkFreeMonthlyCostLimit("user-123", "request-123"),
+    ).rejects.toMatchObject({
       type: "rate_limit",
       surface: "chat",
       cause: expect.stringContaining("free monthly usage"),
@@ -85,10 +87,17 @@ describe("free monthly cost limit", () => {
     mockSpendReferralCreditsForFreeUsage.mockResolvedValue(true);
     const { checkFreeMonthlyCostLimit } = getIsolatedModule();
 
-    const snapshot = await checkFreeMonthlyCostLimit("user-123");
+    const snapshot = await checkFreeMonthlyCostLimit("user-123", "request-123");
 
     expect(snapshot.referralCreditsDeducted).toBe(1);
     expect(snapshot.monthlyRemainingAtStart).toBe(0);
+    expect(mockSpendReferralCreditsForFreeUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(
+          /^free_monthly_overflow:user-123:\d{4}-\d{2}:request-123$/,
+        ),
+      }),
+    );
   });
 
   it("records actual free usage cost as monthly points", async () => {
@@ -109,7 +118,7 @@ describe("free monthly cost limit", () => {
     const { checkFreeMonthlyCostLimit, recordFreeMonthlyCost } =
       getIsolatedModule();
 
-    const snapshot = await checkFreeMonthlyCostLimit("user-123");
+    const snapshot = await checkFreeMonthlyCostLimit("user-123", "request-123");
 
     expect(snapshot.rateLimitSkipped).toBe(true);
     await expect(

--- a/lib/rate-limit/__tests__/index.test.ts
+++ b/lib/rate-limit/__tests__/index.test.ts
@@ -62,7 +62,16 @@ describe("checkRateLimit", () => {
 
       mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
 
-      const result = await checkRateLimit("user-123", "agent", "free", 0);
+      const result = await checkRateLimit(
+        "user-123",
+        "agent",
+        "free",
+        0,
+        undefined,
+        undefined,
+        undefined,
+        "request-123",
+      );
 
       expect(mockEvalFn).toHaveBeenCalledWith(
         expect.any(String),
@@ -78,7 +87,16 @@ describe("checkRateLimit", () => {
 
       mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
 
-      const result = await checkRateLimit("user-123", "ask", "free", 0);
+      const result = await checkRateLimit(
+        "user-123",
+        "ask",
+        "free",
+        0,
+        undefined,
+        undefined,
+        undefined,
+        "request-123",
+      );
 
       expect(mockEvalFn).toHaveBeenCalledWith(
         expect.any(String),
@@ -94,7 +112,16 @@ describe("checkRateLimit", () => {
 
       mockCreateRedisClient.mockReturnValue(null);
 
-      const result = await checkRateLimit("user-123", "ask", "free", 0);
+      const result = await checkRateLimit(
+        "user-123",
+        "ask",
+        "free",
+        0,
+        undefined,
+        undefined,
+        undefined,
+        "request-123",
+      );
       expect(result.remaining).toBe(10);
       expect(result.limit).toBe(10);
       expect(result.rateLimitSkipped).toBe(true);
@@ -107,7 +134,16 @@ describe("checkRateLimit", () => {
       mockEvalFn.mockResolvedValue([0, 0]);
 
       try {
-        await checkRateLimit("user-123", "ask", "free", 0);
+        await checkRateLimit(
+          "user-123",
+          "ask",
+          "free",
+          0,
+          undefined,
+          undefined,
+          undefined,
+          "request-123",
+        );
         expect.fail("Should have thrown");
       } catch (error: any) {
         expect(error.cause).toContain("daily requests");
@@ -122,7 +158,16 @@ describe("checkRateLimit", () => {
       mockEvalFn.mockResolvedValue([0, 0]);
       mockSpendReferralCreditsForFreeUsage.mockResolvedValue(true);
 
-      const result = await checkRateLimit("user-123", "ask", "free", 0);
+      const result = await checkRateLimit(
+        "user-123",
+        "ask",
+        "free",
+        0,
+        undefined,
+        undefined,
+        undefined,
+        "request-123",
+      );
 
       expect(result.referralCreditsDeducted).toBe(1);
       expect(result.remaining).toBe(0);

--- a/lib/rate-limit/__tests__/index.test.ts
+++ b/lib/rate-limit/__tests__/index.test.ts
@@ -11,6 +11,7 @@ describe("checkRateLimit", () => {
   const mockEvalFn = jest.fn();
   const mockCheckTokenBucketLimit = jest.fn();
   const mockCreateRedisClient = jest.fn();
+  const mockSpendReferralCreditsForFreeUsage = jest.fn();
 
   beforeEach(() => {
     jest.resetModules();
@@ -25,6 +26,7 @@ describe("checkRateLimit", () => {
       limit: 10000,
       pointsDeducted: 100,
     });
+    mockSpendReferralCreditsForFreeUsage.mockResolvedValue(false);
   });
 
   const getIsolatedModule = () => {
@@ -42,6 +44,10 @@ describe("checkRateLimit", () => {
         calculateTokenCost: jest.fn(),
         getBudgetLimits: jest.fn(),
         getSubscriptionPrice: jest.fn(),
+      }));
+
+      jest.doMock("@/lib/referrals", () => ({
+        spendReferralCreditsForFreeUsage: mockSpendReferralCreditsForFreeUsage,
       }));
 
       isolatedModule = require("../index");
@@ -107,6 +113,19 @@ describe("checkRateLimit", () => {
         expect(error.cause).toContain("daily requests");
         expect(error.cause).toContain("Upgrade plan");
       }
+    });
+
+    it("should spend referral credits when the free limit is exceeded", async () => {
+      const { checkRateLimit } = getIsolatedModule();
+
+      mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
+      mockEvalFn.mockResolvedValue([0, 0]);
+      mockSpendReferralCreditsForFreeUsage.mockResolvedValue(true);
+
+      const result = await checkRateLimit("user-123", "ask", "free", 0);
+
+      expect(result.referralCreditsDeducted).toBe(1);
+      expect(result.remaining).toBe(0);
     });
   });
 

--- a/lib/rate-limit/__tests__/sliding-window.test.ts
+++ b/lib/rate-limit/__tests__/sliding-window.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 describe("sliding-window", () => {
   const mockEvalFn = jest.fn();
   const mockCreateRedisClient = jest.fn();
+  const mockSpendReferralCreditsForFreeUsage = jest.fn();
 
   beforeEach(() => {
     jest.resetModules();
@@ -15,6 +16,7 @@ describe("sliding-window", () => {
 
     // Default mock responses
     mockEvalFn.mockResolvedValue([1, 5]);
+    mockSpendReferralCreditsForFreeUsage.mockResolvedValue(false);
   });
 
   const getIsolatedModule = () => {
@@ -23,6 +25,10 @@ describe("sliding-window", () => {
     jest.isolateModules(() => {
       jest.doMock("../redis", () => ({
         createRedisClient: mockCreateRedisClient,
+      }));
+
+      jest.doMock("@/lib/referrals", () => ({
+        spendReferralCreditsForFreeUsage: mockSpendReferralCreditsForFreeUsage,
       }));
 
       isolatedModule = require("../sliding-window");
@@ -73,6 +79,19 @@ describe("sliding-window", () => {
         expect(error.cause).toContain("midnight UTC");
         expect(error.cause).toContain("Upgrade plan");
       }
+    });
+
+    it("should spend referral credits when rate limit is exceeded", async () => {
+      const { checkFreeUserRateLimit } = getIsolatedModule();
+
+      mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
+      mockEvalFn.mockResolvedValue([0, 0]);
+      mockSpendReferralCreditsForFreeUsage.mockResolvedValue(true);
+
+      const result = await checkFreeUserRateLimit("user-123");
+
+      expect(result.referralCreditsDeducted).toBe(1);
+      expect(result.remaining).toBe(0);
     });
 
     it("should throw ChatSDKError on Redis errors", async () => {
@@ -133,6 +152,19 @@ describe("sliding-window", () => {
         expect(error.cause).toContain("midnight UTC");
         expect(error.cause).toContain("Upgrade plan");
       }
+    });
+
+    it("should spend two referral credits when the shared free limit is exceeded", async () => {
+      const { checkFreeAgentRateLimit } = getIsolatedModule();
+
+      mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
+      mockEvalFn.mockResolvedValue([0, 1]);
+      mockSpendReferralCreditsForFreeUsage.mockResolvedValue(true);
+
+      const result = await checkFreeAgentRateLimit("user-123");
+
+      expect(result.referralCreditsDeducted).toBe(2);
+      expect(result.remaining).toBe(0);
     });
   });
 });

--- a/lib/rate-limit/__tests__/sliding-window.test.ts
+++ b/lib/rate-limit/__tests__/sliding-window.test.ts
@@ -43,7 +43,7 @@ describe("sliding-window", () => {
 
       mockCreateRedisClient.mockReturnValue(null);
 
-      const result = await checkFreeUserRateLimit("user-123");
+      const result = await checkFreeUserRateLimit("user-123", "request-123");
       expect(result.remaining).toBe(10);
       expect(result.limit).toBe(10);
       expect(result.rateLimitSkipped).toBe(true);
@@ -55,7 +55,7 @@ describe("sliding-window", () => {
 
       mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
 
-      const result = await checkFreeUserRateLimit("user-123");
+      const result = await checkFreeUserRateLimit("user-123", "request-123");
 
       expect(mockEvalFn).toHaveBeenCalledWith(
         expect.any(String),
@@ -72,7 +72,7 @@ describe("sliding-window", () => {
       mockEvalFn.mockResolvedValue([0, 0]);
 
       try {
-        await checkFreeUserRateLimit("user-123");
+        await checkFreeUserRateLimit("user-123", "request-123");
         expect.fail("Should have thrown");
       } catch (error: any) {
         expect(error.cause).toContain("daily requests");
@@ -88,10 +88,17 @@ describe("sliding-window", () => {
       mockEvalFn.mockResolvedValue([0, 0]);
       mockSpendReferralCreditsForFreeUsage.mockResolvedValue(true);
 
-      const result = await checkFreeUserRateLimit("user-123");
+      const result = await checkFreeUserRateLimit("user-123", "request-123");
 
       expect(result.referralCreditsDeducted).toBe(1);
       expect(result.remaining).toBe(0);
+      expect(mockSpendReferralCreditsForFreeUsage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idempotencyKey: expect.stringMatching(
+            /^free_overflow:user-123:\d+:request-123$/,
+          ),
+        }),
+      );
     });
 
     it("should throw ChatSDKError on Redis errors", async () => {
@@ -101,7 +108,7 @@ describe("sliding-window", () => {
       mockEvalFn.mockRejectedValue(new Error("Redis connection failed"));
 
       try {
-        await checkFreeUserRateLimit("user-123");
+        await checkFreeUserRateLimit("user-123", "request-123");
         expect.fail("Should have thrown");
       } catch (error: any) {
         expect(error.cause).toContain("Rate limiting service unavailable");
@@ -116,7 +123,7 @@ describe("sliding-window", () => {
 
       mockCreateRedisClient.mockReturnValue(null);
 
-      const result = await checkFreeAgentRateLimit("user-123");
+      const result = await checkFreeAgentRateLimit("user-123", "request-123");
       expect(result.remaining).toBe(10);
       expect(result.limit).toBe(10);
       expect(result.rateLimitSkipped).toBe(true);
@@ -128,7 +135,7 @@ describe("sliding-window", () => {
 
       mockCreateRedisClient.mockReturnValue({ eval: mockEvalFn });
 
-      const result = await checkFreeAgentRateLimit("user-123");
+      const result = await checkFreeAgentRateLimit("user-123", "request-123");
 
       expect(mockEvalFn).toHaveBeenCalledWith(
         expect.any(String),
@@ -145,7 +152,7 @@ describe("sliding-window", () => {
       mockEvalFn.mockResolvedValue([0, 1]);
 
       try {
-        await checkFreeAgentRateLimit("user-123");
+        await checkFreeAgentRateLimit("user-123", "request-123");
         expect.fail("Should have thrown");
       } catch (error: any) {
         expect(error.cause).toContain("daily requests");
@@ -161,7 +168,7 @@ describe("sliding-window", () => {
       mockEvalFn.mockResolvedValue([0, 1]);
       mockSpendReferralCreditsForFreeUsage.mockResolvedValue(true);
 
-      const result = await checkFreeAgentRateLimit("user-123");
+      const result = await checkFreeAgentRateLimit("user-123", "request-123");
 
       expect(result.referralCreditsDeducted).toBe(2);
       expect(result.remaining).toBe(0);

--- a/lib/rate-limit/free-monthly-cost.ts
+++ b/lib/rate-limit/free-monthly-cost.ts
@@ -2,6 +2,7 @@ import { ChatSDKError } from "@/lib/errors";
 import { getFreeMonthlyCostLimitDollars } from "./free-config";
 import { POINTS_PER_DOLLAR } from "./token-bucket";
 import { createRedisClient } from "./redis";
+import { spendReferralCreditsForFreeUsage } from "@/lib/referrals";
 
 const RECORD_FREE_MONTHLY_COST_SCRIPT = `
 local key = KEYS[1]
@@ -27,6 +28,7 @@ export interface FreeMonthlyCostSnapshot {
   extraUsageBalanceAtStart: 0;
   extraUsageAutoReload: false;
   rateLimitSkipped?: boolean;
+  referralCreditsDeducted?: number;
 }
 
 const dollarsToPoints = (dollars: number): number => {
@@ -89,6 +91,23 @@ export async function checkFreeMonthlyCostLimit(
   const remainingPoints = Math.max(0, limitPoints - usedPoints);
 
   if (remainingPoints <= 0) {
+    const spentReferralCredit = await spendReferralCreditsForFreeUsage({
+      userId,
+      amountCredits: 1,
+      idempotencyKey: `free_monthly_overflow:${userId}:${bucket}:${Date.now()}`,
+    });
+
+    if (spentReferralCredit) {
+      return {
+        monthlyLimitPoints: limitPoints,
+        monthlyRemainingAtStart: 0,
+        monthlyResetTime: new Date(reset),
+        extraUsageBalanceAtStart: 0,
+        extraUsageAutoReload: false,
+        referralCreditsDeducted: 1,
+      };
+    }
+
     throw new ChatSDKError("rate_limit:chat", getLimitMessage(reset));
   }
 

--- a/lib/rate-limit/free-monthly-cost.ts
+++ b/lib/rate-limit/free-monthly-cost.ts
@@ -62,6 +62,7 @@ const getLimitMessage = (reset: number) =>
 
 export async function checkFreeMonthlyCostLimit(
   userId: string,
+  requestId: string,
 ): Promise<FreeMonthlyCostSnapshot> {
   const limitPoints = dollarsToPoints(getFreeMonthlyCostLimitDollars());
   const { bucket, reset } = getCurrentUtcMonthWindow();
@@ -94,7 +95,7 @@ export async function checkFreeMonthlyCostLimit(
     const spentReferralCredit = await spendReferralCreditsForFreeUsage({
       userId,
       amountCredits: 1,
-      idempotencyKey: `free_monthly_overflow:${userId}:${bucket}:${Date.now()}`,
+      idempotencyKey: `free_monthly_overflow:${userId}:${bucket}:${requestId}`,
     });
 
     if (spentReferralCredit) {

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -88,14 +88,18 @@ export const checkRateLimit = async (
   extraUsageConfig?: ExtraUsageConfig,
   modelName?: string,
   organizationId?: string,
+  requestId?: string,
 ): Promise<RateLimitInfo> => {
   // Free users: fixed daily window
   if (subscription === "free") {
+    if (!requestId) {
+      throw new Error("requestId is required for free rate limiting");
+    }
     if (isAgentMode(mode)) {
       // Free agent mode shares the daily free budget and consumes 2 units.
-      return checkFreeAgentRateLimit(userId);
+      return checkFreeAgentRateLimit(userId, requestId);
     }
-    return checkFreeUserRateLimit(userId);
+    return checkFreeUserRateLimit(userId, requestId);
   }
 
   // Paid users: token bucket (same budget for both modes)

--- a/lib/rate-limit/sliding-window.ts
+++ b/lib/rate-limit/sliding-window.ts
@@ -85,6 +85,7 @@ const consumeFreeRequestUnits = async ({
  */
 export const checkFreeUserRateLimit = async (
   userId: string,
+  requestId: string,
   requestCost = FREE_ASK_REQUEST_COST,
 ): Promise<RateLimitInfo> => {
   const redis = createRedisClient();
@@ -123,7 +124,7 @@ export const checkFreeUserRateLimit = async (
       const spentReferralCredits = await spendReferralCreditsForFreeUsage({
         userId,
         amountCredits: cost,
-        idempotencyKey: `free_overflow:${userId}:${bucket}:${Date.now()}`,
+        idempotencyKey: `free_overflow:${userId}:${bucket}:${requestId}`,
       });
 
       if (spentReferralCredits) {
@@ -162,6 +163,7 @@ export const checkFreeUserRateLimit = async (
  */
 export const checkFreeAgentRateLimit = async (
   userId: string,
+  requestId: string,
 ): Promise<RateLimitInfo> => {
-  return checkFreeUserRateLimit(userId, FREE_AGENT_REQUEST_COST);
+  return checkFreeUserRateLimit(userId, requestId, FREE_AGENT_REQUEST_COST);
 };

--- a/lib/rate-limit/sliding-window.ts
+++ b/lib/rate-limit/sliding-window.ts
@@ -13,6 +13,7 @@ import {
   getFreeRequestLimit,
 } from "./free-config";
 import { createRedisClient } from "./redis";
+import { spendReferralCreditsForFreeUsage } from "@/lib/referrals";
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -119,6 +120,21 @@ export const checkFreeUserRateLimit = async (
     });
 
     if (!success) {
+      const spentReferralCredits = await spendReferralCreditsForFreeUsage({
+        userId,
+        amountCredits: cost,
+        idempotencyKey: `free_overflow:${userId}:${bucket}:${Date.now()}`,
+      });
+
+      if (spentReferralCredits) {
+        return {
+          remaining: 0,
+          resetTime: new Date(reset),
+          limit: requestLimit,
+          referralCreditsDeducted: cost,
+        };
+      }
+
       throw new ChatSDKError(
         "rate_limit:chat",
         `You've used all your daily requests. Daily requests reset at midnight UTC.\n\nUpgrade plan for higher usage limits and more features.`,

--- a/lib/referral-constants.ts
+++ b/lib/referral-constants.ts
@@ -1,0 +1,5 @@
+export const REFERRAL_COOKIE_NAME = "hackerai_referral";
+export const REFERRAL_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+export const REFERRAL_REWARD_EXPERIMENT_FLAG = "referral_reward_experiment";
+export const REFERRED_STARTER_CREDITS = 10;
+export const REFERRER_CONVERSION_CREDITS = 10;

--- a/lib/referral-constants.ts
+++ b/lib/referral-constants.ts
@@ -1,5 +1,4 @@
 export const REFERRAL_COOKIE_NAME = "hackerai_referral";
 export const REFERRAL_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
-export const REFERRAL_REWARD_EXPERIMENT_FLAG = "referral_reward_experiment";
 export const REFERRED_STARTER_CREDITS = 10;
 export const REFERRER_CONVERSION_CREDITS = 10;

--- a/lib/referrals.ts
+++ b/lib/referrals.ts
@@ -1,0 +1,160 @@
+import { api } from "@/convex/_generated/api";
+import { getConvexClient } from "@/lib/db/convex-client";
+import { phLogger } from "@/lib/posthog/server";
+export {
+  REFERRAL_COOKIE_MAX_AGE_SECONDS,
+  REFERRAL_COOKIE_NAME,
+  REFERRAL_REWARD_EXPERIMENT_FLAG,
+  REFERRED_STARTER_CREDITS,
+  REFERRER_CONVERSION_CREDITS,
+} from "@/lib/referral-constants";
+
+export type ReferralCookiePayload = {
+  code: string;
+  landingPath: string;
+  viewedAt: number;
+};
+
+export type ReferralAttribution = {
+  referralId: string;
+  referrerUserId: string;
+  referredUserId: string;
+  referralCode: string;
+  referralLandingPath?: string;
+  status: string;
+};
+
+export function encodeReferralCookie(payload: ReferralCookiePayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+export function decodeReferralCookie(
+  value: string | undefined,
+): ReferralCookiePayload | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(value, "base64url").toString("utf8"),
+    ) as Partial<ReferralCookiePayload>;
+    if (
+      typeof parsed.code !== "string" ||
+      parsed.code.length === 0 ||
+      typeof parsed.landingPath !== "string" ||
+      typeof parsed.viewedAt !== "number"
+    ) {
+      return null;
+    }
+    return {
+      code: parsed.code.toUpperCase(),
+      landingPath: parsed.landingPath,
+      viewedAt: parsed.viewedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function spendReferralCreditsForFreeUsage(args: {
+  userId: string;
+  amountCredits: number;
+  idempotencyKey: string;
+}): Promise<boolean> {
+  try {
+    const convex = getConvexClient();
+    const result = await convex.mutation(api.referrals.spendReferralCredits, {
+      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+      userId: args.userId,
+      amountCredits: args.amountCredits,
+      idempotencyKey: args.idempotencyKey,
+    });
+    return result.success || result.alreadyProcessed;
+  } catch (error) {
+    phLogger.warn("referral_credit_spend_failed", {
+      userId: args.userId,
+      amount_credits: args.amountCredits,
+      error,
+    });
+    return false;
+  }
+}
+
+export async function getReferralAttribution(
+  userId: string,
+): Promise<ReferralAttribution | null> {
+  try {
+    const convex = getConvexClient();
+    return await convex.query(api.referrals.getReferralAttributionForUser, {
+      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+      userId,
+    });
+  } catch (error) {
+    phLogger.warn("referral_attribution_lookup_failed", { userId, error });
+    return null;
+  }
+}
+
+export async function markReferralActivation(userId: string): Promise<void> {
+  try {
+    const convex = getConvexClient();
+    const result = await convex.mutation(api.referrals.markReferralActivation, {
+      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+      userId,
+    });
+    if (result.activated) {
+      phLogger.event("referral_activation_completed", {
+        userId,
+        referrer_user_id: result.referrerUserId,
+        referral_code: result.referralCode,
+      });
+    }
+  } catch (error) {
+    phLogger.warn("referral_activation_mark_failed", { userId, error });
+  }
+}
+
+export async function awardReferralConversion(args: {
+  referredUserId: string;
+  qualifyingTier: string;
+  idempotencyKey: string;
+  revenueDollars?: number;
+  stripeInvoiceId?: string;
+  stripeSubscriptionId?: string;
+}): Promise<void> {
+  try {
+    const convex = getConvexClient();
+    const result = await convex.mutation(
+      api.referrals.awardReferralConversion,
+      {
+        serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+        referredUserId: args.referredUserId,
+        qualifyingTier: args.qualifyingTier,
+        idempotencyKey: args.idempotencyKey,
+      },
+    );
+
+    if (!result.awarded) return;
+
+    phLogger.event("referral_conversion_completed", {
+      userId: args.referredUserId,
+      referrer_user_id: result.referrerUserId,
+      referral_code: result.referralCode,
+      qualifying_tier: args.qualifyingTier,
+      revenue_dollars: args.revenueDollars,
+      stripe_invoice_id: args.stripeInvoiceId,
+      stripe_subscription_id: args.stripeSubscriptionId,
+    });
+    phLogger.event("referral_reward_credited", {
+      userId: result.referrerUserId,
+      referred_user_id: args.referredUserId,
+      referral_code: result.referralCode,
+      credits_awarded: result.creditsAwarded,
+      reward_reason: "referrer_conversion_bonus",
+    });
+  } catch (error) {
+    phLogger.warn("referral_conversion_award_failed", {
+      userId: args.referredUserId,
+      qualifying_tier: args.qualifyingTier,
+      error,
+    });
+  }
+}

--- a/lib/referrals.ts
+++ b/lib/referrals.ts
@@ -121,11 +121,16 @@ export async function awardReferralConversion(args: {
   stripeSubscriptionId?: string;
 }): Promise<void> {
   try {
+    const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY;
+    if (!serviceKey) {
+      throw new Error("Missing server configuration: CONVEX_SERVICE_ROLE_KEY");
+    }
+
     const convex = getConvexClient();
     const result = await convex.mutation(
       api.referrals.awardReferralConversion,
       {
-        serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+        serviceKey,
         referredUserId: args.referredUserId,
         qualifyingTier: args.qualifyingTier,
         idempotencyKey: args.idempotencyKey,
@@ -156,5 +161,6 @@ export async function awardReferralConversion(args: {
       qualifying_tier: args.qualifyingTier,
       error,
     });
+    throw error;
   }
 }

--- a/lib/referrals.ts
+++ b/lib/referrals.ts
@@ -4,7 +4,6 @@ import { phLogger } from "@/lib/posthog/server";
 export {
   REFERRAL_COOKIE_MAX_AGE_SECONDS,
   REFERRAL_COOKIE_NAME,
-  REFERRAL_REWARD_EXPERIMENT_FLAG,
   REFERRED_STARTER_CREDITS,
   REFERRER_CONVERSION_CREDITS,
 } from "@/lib/referral-constants";

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -793,11 +793,12 @@ export const agentLongTask = task({
               extraUsageConfig,
               selectedModel,
               organizationId,
+              assistantMessageId,
             );
 
             const freeMonthlyBudgetSnapshot =
-              subscription === "free"
-                ? await checkFreeMonthlyCostLimit(userId)
+              subscription === "free" && !rateLimitInfo.referralCreditsDeducted
+                ? await checkFreeMonthlyCostLimit(userId, assistantMessageId)
                 : null;
 
             usageRefundTracker.recordDeductions(rateLimitInfo);

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -306,6 +306,8 @@ export type RateLimitInfo = {
   pointsDeducted?: number;
   // Extra usage points deducted (only set when extra usage balance was used)
   extraUsagePointsDeducted?: number;
+  // Referral usage credits deducted for free-tier overflow.
+  referralCreditsDeducted?: number;
   // True when rate limiting was skipped (Redis not configured)
   rateLimitSkipped?: boolean;
 };


### PR DESCRIPTION
## Summary
- Add HAC-7 referral reward data model, Convex operations, invite landing route, and authenticated referral claim route.
- Add PostHog-gated sidebar referral UI with copyable invite link, reward explanation, stats, and credit balance.
- Wire referral attribution into signup, checkout, subscription-start, activation, conversion reward, and free-tier overflow credit usage.
- Extract referral claim into a dedicated authenticated hook instead of keeping it in global state.

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm lint` (passes with existing unrelated warnings)
- `pnpm jest` via pre-commit: 100 suites, 1196 tests passed
- `pnpm build` compiled and completed TypeScript, then failed during page-data collection because local WorkOS credentials are not configured for `/api/logout-all`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Referral program: invite links that set referral cookies, record invite views, and redirect to signup.
  * Claiming & attribution: authenticated users can claim referrals; referrals credit starter/conversion rewards and surface in analytics, webhooks, and billing flows.
  * Referral reward UI: sidebar entry and dialog to create/copy invite links, view credit breakdowns, and track invite events.
  * Free-tier integration: referral credits can be auto-spent to cover overflow usage during rate-limit checks.

* **Tests**
  * Added unit and UI tests covering referral flows, credit accounting, webhook/route behaviors, and rate-limit interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->