### PR TITLE
[codex] Harden subscription quantity validation

### DIFF
--- a/app/api/subscription-details/__tests__/route.test.ts
+++ b/app/api/subscription-details/__tests__/route.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+const mockGetUserID = jest.fn();
+const mockGetUser = jest.fn();
+const mockListOrganizationMemberships = jest.fn();
+const mockGetOrganization = jest.fn();
+const mockListCustomers = jest.fn();
+const mockListPrices = jest.fn();
+const mockListSubscriptions = jest.fn();
+const mockCreatePreview = jest.fn();
+const mockUpdateSubscription = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: ResponseInit) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("@/lib/auth/get-user-id", () => ({
+  getUserID: mockGetUserID,
+}));
+
+jest.mock("../../workos", () => ({
+  workos: {
+    userManagement: {
+      getUser: mockGetUser,
+      listOrganizationMemberships: mockListOrganizationMemberships,
+    },
+    organizations: {
+      getOrganization: mockGetOrganization,
+    },
+  },
+}));
+
+jest.mock("../../stripe", () => ({
+  stripe: {
+    customers: {
+      list: mockListCustomers,
+    },
+    prices: {
+      list: mockListPrices,
+    },
+    subscriptions: {
+      list: mockListSubscriptions,
+      update: mockUpdateSubscription,
+    },
+    invoices: {
+      createPreview: mockCreatePreview,
+    },
+    products: {
+      retrieve: jest.fn(),
+    },
+  },
+}));
+
+function makeRequest(body: Record<string, unknown> = {}) {
+  return {
+    json: jest.fn().mockResolvedValue(body),
+  } as any;
+}
+
+describe("POST /api/subscription-details", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetUserID.mockResolvedValue("user_123" as never);
+    mockGetUser.mockResolvedValue({
+      id: "user_123",
+      email: "billing@example.com",
+    } as never);
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          role: { slug: "admin" },
+        },
+      ],
+    } as never);
+    mockGetOrganization.mockResolvedValue({ id: "org_team" } as never);
+    mockListCustomers.mockResolvedValue({
+      data: [
+        {
+          id: "cus_team",
+          metadata: { workOSOrganizationId: "org_team" },
+        },
+      ],
+    } as never);
+    mockListPrices.mockResolvedValue({
+      data: [
+        {
+          id: "price_team",
+          unit_amount: 3000,
+        },
+      ],
+    } as never);
+    mockListSubscriptions.mockResolvedValue({ data: [] } as never);
+  });
+
+  it.each([
+    ["below the minimum", 1, "Quantity must be a finite integer of at least 2"],
+    ["non-integer", 2.5, "Quantity must be a finite integer of at least 2"],
+    ["non-finite", Infinity, "Quantity must be a finite integer of at least 2"],
+    ["non-number", "999", "Quantity must be a finite integer of at least 2"],
+    ["too large", 1000, "Maximum 999 seats allowed"],
+  ])("rejects %s team quantities", async (_name, quantity, error) => {
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      makeRequest({ plan: "team-monthly-plan", quantity }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({ error });
+    expect(mockListSubscriptions).not.toHaveBeenCalled();
+    expect(mockCreatePreview).not.toHaveBeenCalled();
+    expect(mockUpdateSubscription).not.toHaveBeenCalled();
+  });
+
+  it("defaults omitted team quantity to two seats", async () => {
+    const { POST } = await import("../route");
+
+    const response = await POST(makeRequest({ plan: "team-monthly-plan" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.quantity).toBe(2);
+    expect(body.nextInvoiceAmount).toBe(60);
+    expect(mockListSubscriptions).toHaveBeenCalledWith({
+      customer: "cus_team",
+      status: "active",
+      limit: 1,
+    });
+  });
+});

--- a/app/api/subscription-details/route.ts
+++ b/app/api/subscription-details/route.ts
@@ -5,12 +5,48 @@ import { NextRequest, NextResponse } from "next/server";
 import { SubscriptionTier } from "@/types/chat";
 import { getSuspensionMessage } from "@/lib/suspensionMessage";
 
+const MAX_TEAM_SEATS = 999;
+
+function resolveQuantity(
+  targetPlan: string,
+  requestedQuantity: unknown,
+): { valid: true; value: number } | { valid: false; error: string } {
+  if (!targetPlan.includes("team")) {
+    return { valid: true, value: 1 };
+  }
+
+  if (requestedQuantity === undefined) {
+    return { valid: true, value: 2 };
+  }
+
+  if (
+    typeof requestedQuantity !== "number" ||
+    !Number.isFinite(requestedQuantity) ||
+    !Number.isInteger(requestedQuantity) ||
+    requestedQuantity < 2
+  ) {
+    return {
+      valid: false,
+      error: "Quantity must be a finite integer of at least 2",
+    };
+  }
+
+  if (requestedQuantity > MAX_TEAM_SEATS) {
+    return {
+      valid: false,
+      error: `Maximum ${MAX_TEAM_SEATS} seats allowed`,
+    };
+  }
+
+  return { valid: true, value: requestedQuantity };
+}
+
 export const POST = async (req: NextRequest) => {
   try {
     const body = await req.json().catch(() => ({}));
     const requestedPlan = body?.plan;
     const confirm: boolean = body?.confirm === true;
-    const requestedQuantity: number | undefined = body?.quantity;
+    const requestedQuantity: unknown = body?.quantity;
 
     const allowedPlans = new Set([
       "pro-monthly-plan",
@@ -97,22 +133,14 @@ export const POST = async (req: NextRequest) => {
       ? targetPrice.unit_amount / 100
       : 0;
 
-    // Validate and set quantity for team plans
-    const isTeamPlan = targetPlan?.includes("team");
-    const quantity = isTeamPlan
-      ? Math.max(requestedQuantity || 2, 2) // Minimum 2 seats for team
-      : 1;
-
-    if (
-      isTeamPlan &&
-      requestedQuantity !== undefined &&
-      requestedQuantity < 2
-    ) {
+    const quantityResult = resolveQuantity(targetPlan, requestedQuantity);
+    if (!quantityResult.valid) {
       return NextResponse.json(
-        { error: "Team plans require minimum 2 seats" },
+        { error: quantityResult.error },
         { status: 400 },
       );
     }
+    const quantity = quantityResult.value;
 
     // Get active subscription for prorated calculation
     const subscriptions = await stripe.subscriptions.list({


### PR DESCRIPTION
## Summary

Harden `/api/subscription-details` so team-plan quantities use the same shape of validation as the dedicated team seats route.

## What changed

- Adds a `MAX_TEAM_SEATS` cap of 999 for team subscription quantity changes.
- Rejects non-number, non-finite, non-integer, below-minimum, and over-limit quantities before subscription preview/update work proceeds.
- Preserves the existing default of 2 seats when a team quantity is omitted and 1 seat for non-team plans.
- Adds focused API route coverage for invalid team quantities and the omitted-quantity default.

## Why

The admin authorization bypass is already fixed, but `/api/subscription-details` still accepted weakly validated team seat quantities. This closes that remaining validation gap and keeps billing mutations bounded to valid integer seat counts.

## Validation

- `pnpm jest app/api/subscription-details/__tests__/route.test.ts --runInBand`
- `pnpm exec prettier --check app/api/subscription-details/route.ts app/api/subscription-details/__tests__/route.test.ts`
- `pnpm exec eslint app/api/subscription-details/route.ts app/api/subscription-details/__tests__/route.test.ts`
- `pnpm typecheck`
- Pre-commit hook: full `pnpm test` passed, 99 suites / 1189 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for subscription quantity validation.

* **Bug Fixes**
  * Improved validation for team plan seat quantities with specific error messages.
  * Team plans now default to 2 seats when quantity is unspecified.
  * Enforced maximum team seat limit of 999.
  * Quantity values must be integers ≥ 2 for team plans.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->