### PR TITLE
[codex] Enforce paid entitlements before S3 upload URLs

### DIFF
--- a/convex/__tests__/s3Actions.test.ts
+++ b/convex/__tests__/s3Actions.test.ts
@@ -74,6 +74,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn<any>().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         // Mock runQuery to return storage usage (user has space available)
@@ -108,8 +109,40 @@ describe("s3Actions", () => {
       expect(mockCheckFileUploadRateLimit).toHaveBeenCalledWith(
         "user123",
         true,
-        { entitlements: [] },
+        { entitlements: ["pro-plan"] },
       );
+    });
+
+    it("should reject free users before generating an upload URL", async () => {
+      const { generateS3UploadUrl } = await import("../s3Utils");
+      const mockGenerateS3UploadUrl =
+        generateS3UploadUrl as jest.MockedFunction<typeof generateS3UploadUrl>;
+      const { generateS3UploadUrlAction } = await import("../s3Actions");
+
+      const mockCtx: any = {
+        auth: {
+          getUserIdentity: jest.fn<any>().mockResolvedValue({
+            subject: "free-user",
+            email: "free@example.com",
+            entitlements: [],
+          }),
+        },
+        runQuery: jest.fn<any>(),
+      };
+
+      await expect(
+        generateS3UploadUrlAction.handler(mockCtx, {
+          fileName: "test.pdf",
+          contentType: "application/pdf",
+          size: 1024,
+        }),
+      ).rejects.toMatchObject({
+        data: expect.objectContaining({ code: "PAID_PLAN_REQUIRED" }),
+      });
+
+      expect(mockCtx.runQuery).not.toHaveBeenCalled();
+      expect(mockCheckFileUploadRateLimit).not.toHaveBeenCalled();
+      expect(mockGenerateS3UploadUrl).not.toHaveBeenCalled();
     });
 
     it("should throw error for unauthenticated user", async () => {
@@ -139,6 +172,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
       } as any;
@@ -160,6 +194,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
       } as any;
@@ -181,6 +216,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
       } as any;
@@ -210,6 +246,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn<any>().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest.fn<any>().mockResolvedValue({
@@ -238,6 +275,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn<any>().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest.fn<any>(),
@@ -286,6 +324,7 @@ describe("s3Actions", () => {
             getUserIdentity: jest.fn<any>().mockResolvedValue({
               subject: "user123",
               email: "test@example.com",
+              entitlements: ["pro-plan"],
             }),
           },
           runQuery: jest.fn<any>().mockResolvedValue({
@@ -325,6 +364,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn<any>().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest.fn<any>().mockResolvedValue({
@@ -362,6 +402,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn<any>().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest.fn<any>().mockResolvedValue({
@@ -417,6 +458,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest.fn().mockResolvedValue(mockFile),
@@ -460,6 +502,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest.fn().mockResolvedValue(mockFile),
@@ -500,6 +543,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest.fn().mockResolvedValue(null),
@@ -532,6 +576,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest.fn().mockResolvedValue(mockFile),
@@ -564,6 +609,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest.fn().mockResolvedValue(mockFile),
@@ -596,6 +642,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest.fn().mockResolvedValue(mockFile),
@@ -638,6 +685,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest.fn().mockResolvedValue(mockFile),
@@ -674,6 +722,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest.fn().mockResolvedValue(mockFile),
@@ -751,6 +800,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest
@@ -821,6 +871,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest
@@ -891,6 +942,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest
@@ -947,6 +999,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest
@@ -992,6 +1045,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest.fn().mockResolvedValue(mockFile1),
@@ -1030,6 +1084,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest.fn().mockResolvedValue(mockFile1),
@@ -1107,6 +1162,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest
@@ -1153,6 +1209,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
       } as any;
@@ -1173,6 +1230,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
       } as any;
@@ -1221,6 +1279,7 @@ describe("s3Actions", () => {
           getUserIdentity: jest.fn().mockResolvedValue({
             subject: "user123",
             email: "test@example.com",
+            entitlements: ["pro-plan"],
           }),
         },
         runQuery: jest

--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -37,6 +37,10 @@ import {
 } from "../lib/utils/upload-policy";
 import { FILE_TOKEN_PERCENT, MAX_TOKENS_PAID } from "../lib/token-utils";
 import { MAX_GENERATED_FILE_SIZE_BYTES } from "../lib/constants/s3";
+import {
+  hasPaidEntitlement,
+  parseEntitlements,
+} from "../lib/auth/entitlements";
 
 const FILE_UPLOAD_WINDOW = "5 h";
 
@@ -694,11 +698,7 @@ export const saveFile = action({
         });
       }
       actingUserId = user.subject;
-      entitlements = Array.isArray(user.entitlements)
-        ? user.entitlements.filter(
-            (e: unknown): e is string => typeof e === "string",
-          )
-        : [];
+      entitlements = parseEntitlements(user.entitlements);
 
       // Security: Only backend (service key) flows can directly set skipTokenValidation
       // Client can use mode="agent" to skip validation
@@ -720,19 +720,7 @@ export const saveFile = action({
       args.skipTokenValidation || isAgentUploadMode;
 
     // Check if paid tier (free tier cannot upload)
-    const hasPaidEntitlement =
-      entitlements.includes("ultra-plan") ||
-      entitlements.includes("ultra-monthly-plan") ||
-      entitlements.includes("ultra-yearly-plan") ||
-      entitlements.includes("pro-plus-plan") ||
-      entitlements.includes("pro-plus-monthly-plan") ||
-      entitlements.includes("pro-plus-yearly-plan") ||
-      entitlements.includes("team-plan") ||
-      entitlements.includes("pro-plan") ||
-      entitlements.includes("pro-monthly-plan") ||
-      entitlements.includes("pro-yearly-plan");
-
-    if (!hasPaidEntitlement) {
+    if (!hasPaidEntitlement(entitlements)) {
       throw new ConvexError({
         code: "PAID_PLAN_REQUIRED",
         message: "Paid plan required for file uploads",

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -9,6 +9,7 @@ import { convexLogger } from "./lib/logger";
 import { checkFileUploadRateLimit } from "./fileActions";
 import { Doc } from "./_generated/dataModel";
 import { validateUploadPolicy } from "../lib/utils/upload-policy";
+import { hasPaidEntitlement } from "../lib/auth/entitlements";
 
 type StorageUsage = {
   usedBytes: number;
@@ -98,9 +99,15 @@ export const generateS3UploadUrlAction = action({
       }
     }
 
-    // Get user ID from identity
     const userId = identity.subject;
     const entitlements = getIdentityEntitlements(identity);
+
+    if (!hasPaidEntitlement(entitlements)) {
+      throw new ConvexError({
+        code: "PAID_PLAN_REQUIRED",
+        message: "Paid plan required for file uploads",
+      });
+    }
 
     // Check storage limit before allowing upload
     const storageUsage: StorageUsage = await ctx.runQuery(

--- a/lib/auth/entitlements.ts
+++ b/lib/auth/entitlements.ts
@@ -44,3 +44,7 @@ export function resolveSubscriptionTier(
   }
   return "free";
 }
+
+export function hasPaidEntitlement(entitlements: readonly string[]): boolean {
+  return resolveSubscriptionTier(entitlements) !== "free";
+}


### PR DESCRIPTION
## Summary

- Enforce paid-plan entitlements in `generateS3UploadUrlAction` before storage usage checks, rate-limit consumption, or presigned URL generation.
- Share the existing entitlement parsing/resolution logic with the upload save path so URL generation and metadata save use the same paid-plan definition.
- Add regression coverage proving free users receive `PAID_PLAN_REQUIRED` before any upload URL side effects occur.

## Root cause

The S3 upload URL action authenticated users and checked storage/rate limits, but did not verify upload entitlement until `saveFile`, after the client could already PUT bytes to S3 and skip metadata creation.

## Validation

- `pnpm test -- convex/__tests__/s3Actions.test.ts convex/__tests__/fileActions.upload-policy.test.ts --runInBand`
- `pnpm typecheck`
- Pre-commit hook: `prettier --write`, `eslint --fix`, `pnpm typecheck`, full `pnpm test` (98 suites, 1184 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 upload functionality now restricted to paid plan subscribers

* **Tests**
  * Enhanced test coverage for paid plan gating and entitlement validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->