### PR TITLE
[codex] Pin E2B sandbox build to repo Dockerfile

### DIFF
--- a/e2b/template.ts
+++ b/e2b/template.ts
@@ -1,6 +1,7 @@
+import { resolve } from "path";
 import { Template } from "e2b";
 
 export const template = Template()
   .skipCache()
-  .fromImage("hackerai/sandbox:latest")
+  .fromDockerfile(resolve(__dirname, "../docker/Dockerfile"))
   .setWorkdir("/home/user");


### PR DESCRIPTION
## Summary

This changes the E2B sandbox template to build from the repository's `docker/Dockerfile` instead of pulling `hackerai/sandbox:latest` from Docker Hub.

## Why

The previous template source introduced a mutable external registry dependency into the production `terminal-agent-sandbox` build path. Rebuilding the E2B template could package whatever the Docker Hub `latest` tag resolved to at that time, rather than the Dockerfile reviewed in this repository or the GHCR artifact built by CI.

Using `Template().fromDockerfile(...)` restores the repository Dockerfile as the source of truth for the E2B template and removes the `hackerai/sandbox:latest` trust boundary from sandbox creation.

## Validation

- `pnpm typecheck`
- `pnpm exec prettier --check e2b/template.ts`
- `npx tsx -e "import { Template } from 'e2b'; import { template } from './e2b/template'; console.log(Template.toDockerfile(template).split('\\n').slice(0, 3).join('\\n'))"`
- Pre-commit hook: `pnpm typecheck`
- Pre-commit hook: `pnpm test` (98 suites, 1192 tests passed)

Note: the E2B serialization probe reports unsupported Docker metadata instructions such as `LABEL`, but it successfully parses the Dockerfile into a template starting from `kalilinux/kali-rolling`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated template configuration to build from a local Dockerfile instead of using a pre-built image.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->