### PR TITLE
[codex] Fix token bucket debit admission check

### DIFF
--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -163,6 +163,31 @@ describe("token-bucket async functions", () => {
       expect(result.monthly!.resetTime).toEqual(result.resetTime);
     });
 
+    it("should throw when the final monthly deduction fails after a successful peek", async () => {
+      const { checkTokenBucketLimit } = getIsolatedModule();
+
+      mockLimitFn
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 7,
+          reset: Date.now() + 3600000,
+          limit: 250000,
+        })
+        .mockResolvedValueOnce({
+          success: false,
+          remaining: 0,
+          reset: Date.now() + 3600000,
+          limit: 250000,
+        });
+
+      try {
+        await checkTokenBucketLimit("user-123", "pro", 1000);
+        expect.fail("Should have thrown");
+      } catch (error: any) {
+        expect(error.cause).toContain("monthly usage limit");
+      }
+    });
+
     it("should throw monthly cap exceeded error when extra usage cap hit", async () => {
       const { checkTokenBucketLimit } = getIsolatedModule();
 
@@ -525,27 +550,38 @@ describe("token-bucket async functions", () => {
   });
 
   describe("concurrent deduction safety", () => {
-    it("should handle concurrent checkTokenBucketLimit calls without double-spending", async () => {
+    it("should reject a concurrent check when its final deduction fails", async () => {
       const { checkTokenBucketLimit } = getIsolatedModule();
 
       // Simulate two concurrent requests seeing the same bucket state
+      let deductionCalls = 0;
       let callCount = 0;
       mockLimitFn.mockImplementation(
         async (_key: string, opts: { rate: number }) => {
           callCount++;
-          // Peek calls (rate: 0) return 100 remaining
+          // Peek calls (rate: 0) return enough remaining for one request.
           if (opts.rate === 0) {
             return {
               success: true,
-              remaining: 100,
+              remaining: 7,
               reset: Date.now() + 3600000,
               limit: 250000,
             };
           }
-          // Deduction calls succeed
+
+          deductionCalls++;
+          if (deductionCalls === 1) {
+            return {
+              success: true,
+              remaining: 0,
+              reset: Date.now() + 3600000,
+              limit: 250000,
+            };
+          }
+
           return {
-            success: true,
-            remaining: Math.max(0, 100 - opts.rate),
+            success: false,
+            remaining: 0,
             reset: Date.now() + 3600000,
             limit: 250000,
           };
@@ -553,14 +589,17 @@ describe("token-bucket async functions", () => {
       );
 
       // Run two concurrent checks
-      const [result1, result2] = await Promise.all([
+      const results = await Promise.allSettled([
         checkTokenBucketLimit("user-123", "pro", 1000),
         checkTokenBucketLimit("user-123", "pro", 1000),
       ]);
 
-      // Both should succeed and have deducted points
-      expect(result1.pointsDeducted).toBeDefined();
-      expect(result2.pointsDeducted).toBeDefined();
+      expect(
+        results.filter((result) => result.status === "fulfilled"),
+      ).toHaveLength(1);
+      expect(
+        results.filter((result) => result.status === "rejected"),
+      ).toHaveLength(1);
       // Limiter was called for both requests (peek + deduct each)
       expect(callCount).toBeGreaterThanOrEqual(4);
     });

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -199,6 +199,19 @@ export const checkTokenBucketLimit = async (
           ? " or upgrade to Ultra for higher limits"
           : "";
 
+    const monthlyLimitError = (reset: number) => {
+      const resetTime = formatTimeRemaining(new Date(reset));
+      return new ChatSDKError(
+        "rate_limit:chat",
+        `You've hit your monthly usage limit.\n\nYour limit resets ${resetTime}. To keep going now, add extra usage credits in Settings${upgradeHint}.`,
+        {
+          resetTimestamp: reset,
+          subscription,
+          capReason: "monthly_exhausted",
+        },
+      );
+    };
+
     // Helper to build RateLimitInfo from a limiter result
     const buildResult = (
       result: { remaining: number; reset: number },
@@ -252,6 +265,22 @@ export const checkTokenBucketLimit = async (
           const monthlyResult = await monthly.limiter.limit(monthly.key, {
             rate: bucketDeduct,
           });
+
+          if (!monthlyResult.success) {
+            try {
+              if (isTeamPool) {
+                await refundToTeamBalance(organizationId!, userId, shortfall);
+              } else {
+                await refundToBalance(userId, shortfall);
+              }
+            } catch (refundError) {
+              console.error(
+                "[checkTokenBucketLimit] Failed to refund extra usage after bucket debit failed:",
+                refundError,
+              );
+            }
+            throw monthlyLimitError(monthlyResult.reset);
+          }
 
           return buildResult(monthlyResult, bucketDeduct, shortfall);
         }
@@ -373,6 +402,10 @@ export const checkTokenBucketLimit = async (
     const monthlyResult = await monthly.limiter.limit(monthly.key, {
       rate: estimatedCost,
     });
+
+    if (!monthlyResult.success) {
+      throw monthlyLimitError(monthlyResult.reset);
+    }
 
     return buildResult(monthlyResult, estimatedCost);
   } catch (error) {


### PR DESCRIPTION
## Summary

Fixes the paid token-bucket admission path so a real bucket debit with `success: false` stops the request instead of returning a successful `RateLimitInfo`.

## Root cause

The limiter first peeked at the monthly bucket with `rate: 0`, then performed the real debit. The real debit result was passed into `buildResult` without checking `monthlyResult.success`, so concurrent requests could all pass the peek and a request whose debit failed could still proceed into expensive chat or agent processing.

## Changes

- Add a shared monthly-limit error helper for failed admission debits.
- Check `monthlyResult.success` after the normal upfront monthly bucket debit.
- Check `monthlyResult.success` after the extra-usage path's subscription bucket debit, and refund already-deducted extra usage if that bucket debit fails before admission.
- Update the concurrent token-bucket regression test so one raced debit succeeds and the failed raced debit is rejected.

## Validation

- `pnpm exec jest lib/rate-limit/__tests__/token-bucket.integration.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- full pre-commit hook: `tsc --noEmit` and `jest` (`98` suites, `1184` tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error messaging when monthly usage limits are exceeded, now includes upgrade tier guidance
* Added automatic token refund mechanism when monthly limit operations fail unexpectedly
* Enhanced reliability of monthly usage limit enforcement with better error recovery

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->