### PR TITLE
[codex] Filter stale local sandbox connections

### DIFF
--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -212,6 +212,33 @@ describe("CentrifugoSandbox", () => {
         `Command timeout after ${timeoutMs + 5000}ms`,
       );
     });
+
+    it("does not count the echoed command publication as the first response", async () => {
+      const sandbox = createSandbox();
+      const timeoutMs = 1000;
+
+      const { promise } = startCommand(sandbox, "sleep 999", {
+        timeoutMs,
+      });
+
+      await jest.advanceTimersByTimeAsync(0);
+
+      const sub = mockSubscriptions[0];
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      sub.emit("publication", {
+        data: {
+          type: "command",
+          commandId: FIXED_UUID,
+          command: "sleep 999",
+        },
+      });
+
+      jest.advanceTimersByTime(timeoutMs + 5000 + 1);
+
+      await expect(promise).rejects.toThrow("firstMsg: no");
+    });
   });
 
   describe("commands.run cleanup", () => {

--- a/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
+++ b/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
@@ -1,0 +1,77 @@
+jest.mock("@e2b/code-interpreter", () => ({
+  Sandbox: class MockSandbox {},
+}));
+
+import {
+  filterConnectionsByPresence,
+  LOCAL_SANDBOX_PRESENCE_GRACE_MS,
+} from "../hybrid-sandbox-manager";
+import type { ConnectionInfo } from "../sandbox-types";
+
+const baseConnection: ConnectionInfo = {
+  connectionId: "conn-online",
+  name: "Local",
+  lastSeen: 1_000,
+  isDesktop: false,
+  capabilities: { commands: true, pty: true },
+};
+
+const makeConnection = (
+  overrides: Partial<ConnectionInfo>,
+): ConnectionInfo => ({
+  ...baseConnection,
+  ...overrides,
+});
+
+describe("filterConnectionsByPresence", () => {
+  it("keeps online connections even when their heartbeat is old", () => {
+    const now = 100_000;
+    const connections = [
+      makeConnection({ connectionId: "conn-online", lastSeen: 1 }),
+    ];
+
+    const result = filterConnectionsByPresence(
+      connections,
+      new Set(["conn-online"]),
+      now,
+    );
+
+    expect(result.availableConnections).toEqual(connections);
+    expect(result.staleConnections).toEqual([]);
+  });
+
+  it("keeps recently seen connections during the presence grace window", () => {
+    const now = 100_000;
+    const recentLastSeen = now - LOCAL_SANDBOX_PRESENCE_GRACE_MS + 1;
+    const connections = [
+      makeConnection({ connectionId: "conn-recent", lastSeen: recentLastSeen }),
+    ];
+
+    const result = filterConnectionsByPresence(connections, new Set(), now);
+
+    expect(result.availableConnections).toEqual(connections);
+    expect(result.staleConnections).toEqual([]);
+  });
+
+  it("filters connections that are absent from presence after the grace window", () => {
+    const now = 100_000;
+    const staleLastSeen = now - LOCAL_SANDBOX_PRESENCE_GRACE_MS - 1;
+    const stale = makeConnection({
+      connectionId: "conn-stale",
+      lastSeen: staleLastSeen,
+    });
+    const live = makeConnection({
+      connectionId: "conn-live",
+      lastSeen: staleLastSeen,
+    });
+
+    const result = filterConnectionsByPresence(
+      [stale, live],
+      new Set(["conn-live"]),
+      now,
+    );
+
+    expect(result.availableConnections).toEqual([live]);
+    expect(result.staleConnections).toEqual([stale]);
+  });
+});

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -324,11 +324,14 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
 
         subscription.on("publication", (ctx) => {
           if (settled) return;
-          if (!tFirstMessage) tFirstMessage = Date.now();
 
           const message = parseSandboxMessage(ctx.data);
           if (!message) return;
           if (message.commandId !== commandId) return;
+          if (message.type === "command" || message.type === "command_cancel") {
+            return;
+          }
+          if (!tFirstMessage) tFirstMessage = Date.now();
 
           switch (message.type) {
             case "stdout":

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -1,4 +1,5 @@
 import { Sandbox } from "@e2b/code-interpreter";
+import { Centrifuge } from "centrifuge";
 import type {
   SandboxBootInfo,
   SandboxManager,
@@ -12,6 +13,8 @@ import { getConvexClient } from "@/lib/db/convex-client";
 import { api } from "@/convex/_generated/api";
 import { SANDBOX_ENVIRONMENT_TOOLS } from "./sandbox-tools";
 import { getPlatformDisplayName } from "./platform-utils";
+import { generateCentrifugoToken } from "@/lib/centrifugo/jwt";
+import { sandboxChannel } from "@/lib/centrifugo/types";
 
 type SandboxInstance = Sandbox | CentrifugoSandbox;
 
@@ -39,6 +42,158 @@ export interface SandboxFallbackInfo {
  * - Dangerous mode (no Docker) with OS context for AI
  */
 const MAX_SANDBOX_HEALTH_FAILURES = 5;
+export const LOCAL_SANDBOX_PRESENCE_GRACE_MS = 30_000;
+const LOCAL_SANDBOX_PRESENCE_TIMEOUT_MS = 2_000;
+
+interface CentrifugoPresenceClient {
+  connInfo?: { connectionId?: string } | null;
+}
+
+interface CentrifugoPresenceResult {
+  clients?: Record<string, CentrifugoPresenceClient>;
+}
+
+interface PresenceProbeResult {
+  reliable: boolean;
+  onlineConnectionIds: Set<string>;
+  durationMs: number;
+  error?: unknown;
+}
+
+interface PresenceFilterResult {
+  availableConnections: ConnectionInfo[];
+  staleConnections: ConnectionInfo[];
+}
+
+const logStructured = (
+  level: "warn" | "error",
+  event: string,
+  fields: Record<string, unknown>,
+) => {
+  const payload = {
+    timestamp: new Date().toISOString(),
+    level,
+    event,
+    service: "chat-handler",
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+    request_id: process.env.VERCEL_REQUEST_ID ?? null,
+    ...fields,
+  };
+
+  const message = JSON.stringify(payload);
+  if (level === "error") {
+    console.error(message);
+  } else {
+    console.warn(message);
+  }
+};
+
+export function filterConnectionsByPresence(
+  connections: ConnectionInfo[],
+  onlineConnectionIds: Set<string>,
+  now = Date.now(),
+): PresenceFilterResult {
+  const availableConnections: ConnectionInfo[] = [];
+  const staleConnections: ConnectionInfo[] = [];
+
+  for (const connection of connections) {
+    const recentlySeen =
+      connection.lastSeen != null &&
+      now - connection.lastSeen <= LOCAL_SANDBOX_PRESENCE_GRACE_MS;
+    if (onlineConnectionIds.has(connection.connectionId) || recentlySeen) {
+      availableConnections.push(connection);
+    } else {
+      staleConnections.push(connection);
+    }
+  }
+
+  return { availableConnections, staleConnections };
+}
+
+async function queryLiveSandboxConnectionIds(
+  userId: string,
+): Promise<PresenceProbeResult> {
+  const wsUrl = process.env.CENTRIFUGO_WS_URL;
+  if (!wsUrl) {
+    return {
+      reliable: false,
+      onlineConnectionIds: new Set(),
+      durationMs: 0,
+      error: new Error("CENTRIFUGO_WS_URL is not configured"),
+    };
+  }
+
+  const start = Date.now();
+  let client: Centrifuge | null = null;
+
+  try {
+    const token = await generateCentrifugoToken(userId, 30);
+    client = new Centrifuge(wsUrl, { token });
+    const sub = client.newSubscription(sandboxChannel(userId));
+
+    const presence = await new Promise<CentrifugoPresenceResult>(
+      (resolve, reject) => {
+        const timeout = setTimeout(() => {
+          cleanup();
+          reject(new Error("Centrifugo presence timeout"));
+        }, LOCAL_SANDBOX_PRESENCE_TIMEOUT_MS);
+
+        const cleanup = () => {
+          clearTimeout(timeout);
+          sub.removeAllListeners();
+        };
+
+        sub.on("subscribed", async () => {
+          try {
+            const result = await sub.presence();
+            cleanup();
+            resolve(result as CentrifugoPresenceResult);
+          } catch (error) {
+            cleanup();
+            reject(error);
+          }
+        });
+
+        sub.on("error", (ctx) => {
+          cleanup();
+          reject(
+            new Error(ctx.error?.message ?? "Centrifugo subscription error"),
+          );
+        });
+
+        sub.subscribe();
+        client!.connect();
+      },
+    );
+
+    const onlineConnectionIds = new Set<string>();
+    for (const entry of Object.values(presence.clients ?? {})) {
+      const connectionId = entry.connInfo?.connectionId;
+      if (connectionId) {
+        onlineConnectionIds.add(connectionId);
+      }
+    }
+
+    return {
+      reliable: true,
+      onlineConnectionIds,
+      durationMs: Date.now() - start,
+    };
+  } catch (error) {
+    return {
+      reliable: false,
+      onlineConnectionIds: new Set(),
+      durationMs: Date.now() - start,
+      error,
+    };
+  } finally {
+    try {
+      client?.disconnect();
+    } catch {
+      // Ignore cleanup failures.
+    }
+  }
+}
 
 export class HybridSandboxManager implements SandboxManager {
   private sandbox: SandboxInstance | null = null;
@@ -198,9 +353,73 @@ export class HybridSandboxManager implements SandboxManager {
           userId: this.userID,
         },
       );
-      return connections;
+      if (connections.length === 0) {
+        return connections;
+      }
+
+      const presence = await queryLiveSandboxConnectionIds(this.userID);
+      if (!presence.reliable) {
+        logStructured("warn", "local_sandbox_presence_unavailable", {
+          user_id: this.userID,
+          connection_count: connections.length,
+          duration_ms: presence.durationMs,
+          error:
+            presence.error instanceof Error
+              ? presence.error.message
+              : String(presence.error ?? "unknown"),
+        });
+        return connections;
+      }
+
+      const { availableConnections, staleConnections } =
+        filterConnectionsByPresence(connections, presence.onlineConnectionIds);
+
+      if (staleConnections.length > 0) {
+        logStructured("warn", "local_sandbox_stale_connections_filtered", {
+          user_id: this.userID,
+          stale_connection_count: staleConnections.length,
+          available_connection_count: availableConnections.length,
+          online_connection_count: presence.onlineConnectionIds.size,
+          duration_ms: presence.durationMs,
+          stale_connection_ids: staleConnections.map(
+            (connection) => connection.connectionId,
+          ),
+        });
+
+        const disconnectResults = await Promise.allSettled(
+          staleConnections.map((connection) =>
+            getConvexClient().mutation(api.localSandbox.disconnectByBackend, {
+              serviceKey: this.serviceKey,
+              connectionId: connection.connectionId,
+            }),
+          ),
+        );
+
+        const failedDisconnects = disconnectResults.filter(
+          (result) => result.status === "rejected",
+        );
+        if (failedDisconnects.length > 0) {
+          logStructured("error", "local_sandbox_stale_disconnect_failed", {
+            user_id: this.userID,
+            failed_count: failedDisconnects.length,
+            stale_connection_count: staleConnections.length,
+            errors: failedDisconnects.map((result) =>
+              result.status === "rejected" && result.reason instanceof Error
+                ? result.reason.message
+                : String(
+                    result.status === "rejected" ? result.reason : "unknown",
+                  ),
+            ),
+          });
+        }
+      }
+
+      return availableConnections;
     } catch (error) {
-      console.error(`[${this.userID}] Failed to list connections:`, error);
+      logStructured("error", "local_sandbox_connections_list_failed", {
+        user_id: this.userID,
+        error: error instanceof Error ? error.message : String(error),
+      });
       return [];
     }
   }


### PR DESCRIPTION
## Summary

- Probe Centrifugo presence before the backend selects local sandbox connections for agent runs.
- Filter and best-effort disconnect stale `connected` rows when presence is reliable, while failing open if presence cannot be queried.
- Add structured logs for unavailable presence, stale filtering, disconnect failures, and connection-list failures.
- Make command timeout diagnostics ignore echoed `command` publications so `firstMsg` reflects actual sandbox responses.

## Root Cause

The backend trusted Convex rows with `status: connected` even when the local desktop/runner was no longer present on Centrifugo. Attachment staging could then publish a download command to a stale connection and wait until the outer 35s timeout fired. The timeout log also counted the echoed command publication as `firstMsg`, making a dead bridge look like it had responded.

## Validation

- `pnpm test -- lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint lib/ai/tools/utils/hybrid-sandbox-manager.ts lib/ai/tools/utils/centrifugo-sandbox.ts lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts`
- Commit hook: full `pnpm test` passed, 101 suites / 1207 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for command timeout handling and connection presence filtering.

* **Bug Fixes**
  * Improved command message filtering to properly exclude echoed command publications from response timing.

* **Improvements**
  * Sandbox connection management now uses live presence detection.
  * Automatic cleanup of stale sandbox connections with configurable grace period.
  * Enhanced reliability of local sandbox connection selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/544?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->