### PR TITLE
[codex] Pin Tauri action to commit SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -220,7 +220,7 @@ jobs:
           rm $CERTIFICATE_PATH
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}


### PR DESCRIPTION
## Summary

- Pin `tauri-apps/tauri-action` to the exact commit currently behind `v0` / `v0.6.2`.
- Add Dependabot configuration for weekly GitHub Actions update PRs.

## Why

The desktop build workflow passes Apple signing and notarization credentials to the Tauri GitHub Action after importing the Apple certificate into a macOS keychain. Referencing the action through the mutable `v0` tag leaves those high-value release credentials exposed to any future tag movement or action compromise.

Pinning to a full commit SHA makes the action reference immutable. Dependabot can then propose future action updates as reviewable PRs instead of relying on a moving tag.

## Validation

- Confirmed `tauri-apps/tauri-action@v0` currently dereferences to `84b9d35b5fc46c1e45415bdb6144030364f7ebc5`.
- Parsed `.github/dependabot.yml` as valid YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration to enable automated dependency updates for GitHub Actions.
  * Enhanced build workflow stability with pinned deployment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->