### PR TITLE
[codex] Secure file attachment ownership checks

### DIFF
--- a/convex/__tests__/messages.hidden.test.ts
+++ b/convex/__tests__/messages.hidden.test.ts
@@ -200,6 +200,79 @@ describe("saveMessage — is_hidden handling", () => {
     );
     expect(console.error).not.toHaveBeenCalled();
   });
+
+  it("rejects unowned file IDs before inserting a new message", async () => {
+    setupExistingMessage(null);
+    mockCtx.db.get.mockResolvedValue({
+      _id: "file-victim" as Id<"files">,
+      user_id: "victim-user",
+      is_attached: false,
+    });
+
+    const { saveMessage } = await import("../messages");
+
+    await expect(
+      saveMessage.handler(mockCtx, {
+        serviceKey: SERVICE_KEY,
+        id: "msg-unowned-file",
+        chatId: CHAT_ID,
+        userId: USER_ID,
+        role: "user" as const,
+        parts: [
+          { type: "text", text: "read this" },
+          { type: "file", fileId: "file-victim" as Id<"files"> },
+        ],
+        fileIds: ["file-victim" as Id<"files">],
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({
+        code: "MESSAGE_SAVE_FAILED",
+        failureStage: "validate_new_message_file_ownership",
+        causeMessage: "File does not belong to user",
+      }),
+    });
+
+    expect(mockCtx.db.insert).not.toHaveBeenCalled();
+    expect(mockCtx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it("rejects unowned file IDs before updating an existing message", async () => {
+    const existing = makeMessage({
+      _id: "existing-doc" as Id<"messages">,
+      file_ids: [],
+    });
+    setupExistingMessage(existing);
+    mockCtx.db.get.mockResolvedValue({
+      _id: "file-victim" as Id<"files">,
+      user_id: "victim-user",
+      is_attached: false,
+    });
+
+    const { saveMessage } = await import("../messages");
+
+    await expect(
+      saveMessage.handler(mockCtx, {
+        serviceKey: SERVICE_KEY,
+        id: "msg-1",
+        chatId: CHAT_ID,
+        userId: USER_ID,
+        role: "user" as const,
+        parts: [
+          { type: "text", text: "read this" },
+          { type: "file", fileId: "file-victim" as Id<"files"> },
+        ],
+        fileIds: ["file-victim" as Id<"files">],
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({
+        code: "MESSAGE_SAVE_FAILED",
+        failureStage: "validate_existing_message_file_ownership",
+        causeMessage: "File does not belong to user",
+      }),
+    });
+
+    expect(mockCtx.db.patch).not.toHaveBeenCalled();
+  });
 });
 
 describe("getMessagesByChatId — is_hidden filtering", () => {

--- a/convex/__tests__/s3Actions.test.ts
+++ b/convex/__tests__/s3Actions.test.ts
@@ -1358,6 +1358,7 @@ describe("s3Actions", () => {
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
         serviceKey: "test-service-key",
+        userId: "user123",
         fileIds: [mockFile1Id, mockFile2Id],
       });
 
@@ -1366,6 +1367,46 @@ describe("s3Actions", () => {
         "https://s3.amazonaws.com/file1-url",
         "https://s3.amazonaws.com/file2-url",
       ]);
+    });
+
+    it("should not generate URLs for files owned by another user", async () => {
+      const { generateS3DownloadUrl } = await import("../s3Utils");
+      const mockGenerateS3DownloadUrl =
+        generateS3DownloadUrl as jest.MockedFunction<
+          typeof generateS3DownloadUrl
+        >;
+
+      const { getFileUrlsByFileIdsAction } = await import("../s3Actions");
+
+      const mockFileId = "file1" as any;
+      const mockFile = {
+        _id: mockFileId,
+        s3_key: "users/victim/file1.pdf",
+        storage_id: undefined,
+        user_id: "victim",
+        name: "file1.pdf",
+        media_type: "application/pdf",
+        size: 1024,
+        file_token_size: 100,
+        is_attached: true,
+        _creationTime: Date.now(),
+      };
+
+      const mockCtx = {
+        runQuery: jest.fn().mockResolvedValue(mockFile),
+        storage: {
+          getUrl: jest.fn(),
+        },
+      } as any;
+
+      const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
+        serviceKey: "test-service-key",
+        userId: "attacker",
+        fileIds: [mockFileId],
+      });
+
+      expect(result).toEqual([null]);
+      expect(mockGenerateS3DownloadUrl).not.toHaveBeenCalled();
     });
 
     it("should handle mixed S3 and Convex files", async () => {
@@ -1424,6 +1465,7 @@ describe("s3Actions", () => {
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
         serviceKey: "test-service-key",
+        userId: "user123",
         fileIds: [mockFile1Id, mockFile2Id],
       });
 
@@ -1451,6 +1493,7 @@ describe("s3Actions", () => {
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
         serviceKey: "test-service-key",
+        userId: "user123",
         fileIds: [mockFile1Id, mockFile2Id],
       });
 
@@ -1472,6 +1515,7 @@ describe("s3Actions", () => {
       await expect(
         getFileUrlsByFileIdsAction.handler({} as any, {
           serviceKey: "invalid-key",
+          userId: "user123",
           fileIds: ["file1" as any],
         }),
       ).rejects.toThrow("Invalid service key");
@@ -1488,6 +1532,7 @@ describe("s3Actions", () => {
       await expect(
         getFileUrlsByFileIdsAction.handler(mockCtx, {
           serviceKey: "test-service-key",
+          userId: "user123",
           fileIds,
         }),
       ).rejects.toThrow("Batch size exceeds limit");
@@ -1563,6 +1608,7 @@ describe("s3Actions", () => {
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
         serviceKey: "test-service-key",
+        userId: "user123",
         fileIds: [mockFile1Id, mockFile2Id, mockFile3Id],
       });
 
@@ -1581,6 +1627,7 @@ describe("s3Actions", () => {
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
         serviceKey: "test-service-key",
+        userId: "user123",
         fileIds: [],
       });
 
@@ -1614,6 +1661,7 @@ describe("s3Actions", () => {
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
         serviceKey: "test-service-key",
+        userId: "user123",
         fileIds: [mockFile1Id],
       });
 

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -130,6 +130,7 @@ export const deleteFile = mutation({
 export const getFileTokensByFileIds = query({
   args: {
     serviceKey: v.string(),
+    userId: v.string(),
     fileIds: v.array(v.id("files")),
   },
   returns: v.array(v.number()),
@@ -142,8 +143,10 @@ export const getFileTokensByFileIds = query({
       args.fileIds.map((fileId) => ctx.db.get(fileId)),
     );
 
-    // Return token sizes, defaulting to 0 for missing files
-    return files.map((file) => file?.file_token_size ?? 0);
+    // Return token sizes only for files owned by the requester.
+    return files.map((file) =>
+      file && file.user_id === args.userId ? file.file_token_size : 0,
+    );
   },
 });
 
@@ -200,6 +203,7 @@ export const getFileMetadataByFileIds = query({
 export const getFileContentByFileIds = query({
   args: {
     serviceKey: v.string(),
+    userId: v.string(),
     fileIds: v.array(v.id("files")),
   },
   returns: v.array(
@@ -222,7 +226,7 @@ export const getFileContentByFileIds = query({
 
     // Return file content and metadata
     return files.map((file, index) => {
-      if (!file) {
+      if (!file || file.user_id !== args.userId) {
         return {
           id: args.fileIds[index],
           name: "Unknown",

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1,7 +1,7 @@
 import { query, mutation, internalQuery } from "./_generated/server";
 import { v, ConvexError, type Value } from "convex/values";
 import { internal } from "./_generated/api";
-import { Id } from "./_generated/dataModel";
+import type { Doc, Id } from "./_generated/dataModel";
 import { paginationOptsValidator } from "convex/server";
 import { validateServiceKey, copyChatSummary } from "./lib/utils";
 import { fileCountAggregate } from "./fileAggregate";
@@ -269,6 +269,36 @@ export const saveMessage = mutation({
     let failureStage = "start";
 
     try {
+      const ensureOwnedFiles = async (
+        fileIds: Id<"files">[] | undefined,
+      ): Promise<Doc<"files">[]> => {
+        if (!fileIds || fileIds.length === 0) return [];
+
+        const files = await Promise.all(
+          fileIds.map((fileId) =>
+            ctx.db.get(fileId).catch((error) => {
+              console.error(
+                `Failed to read file ${fileId} while validating ownership:`,
+                error,
+              );
+              return null;
+            }),
+          ),
+        );
+
+        for (let i = 0; i < fileIds.length; i++) {
+          const file = files[i];
+          if (!file) {
+            throw new Error("File not found");
+          }
+          if (file.user_id !== args.userId) {
+            throw new Error("File does not belong to user");
+          }
+        }
+
+        return files as Doc<"files">[];
+      };
+
       failureStage = "find_existing_message";
       const existingMessage = await ctx.db
         .query("messages")
@@ -287,25 +317,16 @@ export const saveMessage = mutation({
           );
 
           if (newFileIds.length > 0) {
+            failureStage = "validate_existing_message_file_ownership";
+            const files = await ensureOwnedFiles(newFileIds);
             patch.file_ids = [...currentFileIds, ...newFileIds];
 
             // Batch-read files in parallel, then only patch those that still
             // need the attached flag set. Skipping no-op patches avoids
             // invalidating the `by_is_attached` index for already-attached
             // files that just got referenced from another message.
-            const files = await Promise.all(
-              newFileIds.map((fileId) =>
-                ctx.db.get(fileId).catch((error) => {
-                  console.error(
-                    `Failed to read file ${fileId} while attaching:`,
-                    error,
-                  );
-                  return null;
-                }),
-              ),
-            );
             for (const file of files) {
-              if (file && !file.is_attached) {
+              if (!file.is_attached) {
                 failureStage = "patch_existing_message_file_attachment";
                 await ctx.db.patch(file._id, { is_attached: true });
               }
@@ -373,6 +394,12 @@ export const saveMessage = mutation({
         }
       }
 
+      let newMessageFiles: Doc<"files">[] = [];
+      if (args.fileIds && args.fileIds.length > 0) {
+        failureStage = "validate_new_message_file_ownership";
+        newMessageFiles = await ensureOwnedFiles(args.fileIds);
+      }
+
       failureStage = "extract_content";
       const content = extractTextFromParts(args.parts);
 
@@ -397,26 +424,10 @@ export const saveMessage = mutation({
 
       // Mark attached files as linked so purge won't remove them.
       // Batch-read in parallel, skip no-op patches when already attached.
-      if (args.fileIds && args.fileIds.length > 0) {
-        failureStage = "read_new_message_files";
-        const files = await Promise.all(
-          args.fileIds.map((fileId) =>
-            ctx.db.get(fileId).catch((e) => {
-              console.warn("Failed to read file while attaching:", fileId, e);
-              return null;
-            }),
-          ),
-        );
-        for (const file of files) {
-          if (!file) continue;
-          if (file.user_id !== args.userId) {
-            console.warn("Skipping file not owned by user:", file._id);
-            continue;
-          }
-          if (!file.is_attached) {
-            failureStage = "patch_new_message_file_attachment";
-            await ctx.db.patch(file._id, { is_attached: true });
-          }
+      for (const file of newMessageFiles) {
+        if (!file.is_attached) {
+          failureStage = "patch_new_message_file_attachment";
+          await ctx.db.patch(file._id, { is_attached: true });
         }
       }
 

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -275,6 +275,7 @@ export const getFileUrlAction = action({
 export const getFileUrlsByFileIdsAction = action({
   args: {
     serviceKey: v.string(),
+    userId: v.string(),
     fileIds: v.array(v.id("files")),
   },
   returns: v.array(v.union(v.string(), v.null())),
@@ -302,6 +303,15 @@ export const getFileUrlsByFileIdsAction = action({
 
           // Return null if file not found
           if (!file) {
+            return null;
+          }
+
+          if (file.user_id !== args.userId) {
+            convexLogger.warn("file_batch_url_access_denied", {
+              fileId,
+              caller: "service",
+              userId: args.userId,
+            });
             return null;
           }
 

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -268,6 +268,7 @@ export const createChatHandler = (
         await processChatMessages({
           messages: truncatedMessages,
           mode,
+          userId,
           subscription,
           uploadBasePath,
           modelOverride: selectedModelOverride,

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -623,6 +623,7 @@ const filterUIOnlyParts = <T extends { parts?: any[] }>(message: T): T => {
 export async function processChatMessages({
   messages,
   mode,
+  userId,
   subscription,
   uploadBasePath,
   modelOverride,
@@ -630,6 +631,7 @@ export async function processChatMessages({
 }: {
   messages: UIMessage[];
   mode: ChatMode;
+  userId: string;
   subscription: SubscriptionTier;
   uploadBasePath?: string;
   modelOverride?: SelectedModel;
@@ -650,6 +652,7 @@ export async function processChatMessages({
     await processMessageFiles(
       messagesWithLimitedFiles,
       mode,
+      userId,
       uploadBasePath,
       subscription,
       allowLocalDesktopFiles,

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -664,7 +664,7 @@ export async function getMessagesByChatId({
               (id) => !(id in fileTokensFromLoop),
             );
             if (uncachedIds.length > 0) {
-              const newTokens = await getFileTokensByIds(uncachedIds);
+              const newTokens = await getFileTokensByIds(uncachedIds, userId);
               Object.assign(fileTokensFromLoop, newTokens);
             }
           }
@@ -836,6 +836,7 @@ export async function getMessagesByChatId({
     subscription,
     mode === "agent", // Skip file tokens for agent mode (files go to sandbox)
     mode,
+    userId,
   );
   const truncatedMessages = truncateResult.messages;
   const fileTokens = truncateResult.fileTokens;
@@ -844,7 +845,7 @@ export async function getMessagesByChatId({
     let emptyPromptMetadata: Record<string, unknown> | undefined;
     try {
       const fileIds = extractAllFileIdsFromMessages(allMessages);
-      const fileTokens = await getFileTokensByIds(fileIds as any);
+      const fileTokens = await getFileTokensByIds(fileIds as any, userId);
       const maxTokens = getMaxTokensForSubscription(subscription, {
         mode,
       });

--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -79,6 +79,7 @@ describe("processMessageFiles image size guards", () => {
         url: "https://example.com/huge.png",
       }),
       "ask",
+      "user123",
       undefined,
       "pro",
     );
@@ -113,6 +114,7 @@ describe("processMessageFiles image size guards", () => {
         url: "https://example.com/unknown-size.png",
       }),
       "ask",
+      "user123",
       undefined,
       "pro",
     );
@@ -139,6 +141,7 @@ describe("processMessageFiles image size guards", () => {
         url: "https://example.com/small.png",
       }),
       "ask",
+      "user123",
       undefined,
       "pro",
     );
@@ -163,6 +166,7 @@ describe("processMessageFiles image size guards", () => {
         url: "https://example.com/inline.pdf",
       }),
       "ask",
+      "user123",
       undefined,
       "pro",
     );
@@ -190,6 +194,7 @@ describe("processMessageFiles image size guards", () => {
         url: "https://example.com/large.png",
       }),
       "agent",
+      "user123",
       "/home/user/upload",
       "pro",
     );

--- a/lib/utils/file-token-utils.ts
+++ b/lib/utils/file-token-utils.ts
@@ -34,6 +34,7 @@ export const extractFileIdsFromParts = (
  */
 export const getFileTokensByIds = async (
   fileIds: Id<"files">[],
+  userId: string,
 ): Promise<Record<Id<"files">, number>> => {
   if (!fileIds.length) return {};
 
@@ -42,6 +43,7 @@ export const getFileTokensByIds = async (
       api.fileStorage.getFileTokensByFileIds,
       {
         serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+        userId,
         fileIds,
       },
     );
@@ -80,6 +82,7 @@ export const truncateMessagesWithFileTokens = async (
   subscription: SubscriptionTier = "pro",
   skipFileTokens: boolean = false,
   mode?: import("@/types").ChatMode,
+  userId?: string,
 ): Promise<{
   messages: UIMessage[];
   fileTokens: Record<Id<"files">, number>;
@@ -87,7 +90,12 @@ export const truncateMessagesWithFileTokens = async (
   const maxTokens = getMaxTokensForSubscription(subscription, { mode });
   const fileTokens = skipFileTokens
     ? {}
-    : await getFileTokensByIds(extractAllFileIdsFromMessages(messages));
+    : userId
+      ? await getFileTokensByIds(
+          extractAllFileIdsFromMessages(messages),
+          userId,
+        )
+      : {};
 
   return {
     messages: truncateMessagesToTokenLimit(messages, fileTokens, maxTokens),
@@ -102,11 +110,17 @@ export const truncateMessagesWithPrecomputedTokens = async (
   messages: UIMessage[],
   subscription: SubscriptionTier = "pro",
   precomputedFileTokens?: Record<Id<"files">, number>,
+  userId?: string,
 ): Promise<UIMessage[]> => {
   const maxTokens = getMaxTokensForSubscription(subscription);
   const fileTokens =
     precomputedFileTokens ||
-    (await getFileTokensByIds(extractAllFileIdsFromMessages(messages)));
+    (userId
+      ? await getFileTokensByIds(
+          extractAllFileIdsFromMessages(messages),
+          userId,
+        )
+      : {});
 
   return truncateMessagesToTokenLimit(messages, fileTokens, maxTokens);
 };

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -253,7 +253,10 @@ const collectFilesToProcess = (
   return { hasMedia, files };
 };
 
-const fetchFileUrls = async (fileIds: string[]): Promise<(string | null)[]> => {
+const fetchFileUrls = async (
+  fileIds: string[],
+  userId: string,
+): Promise<(string | null)[]> => {
   if (!fileIds.length) return [];
 
   try {
@@ -261,6 +264,7 @@ const fetchFileUrls = async (fileIds: string[]): Promise<(string | null)[]> => {
       api.s3Actions.getFileUrlsByFileIdsAction,
       {
         serviceKey,
+        userId,
         fileIds: fileIds as Id<"files">[],
       },
     );
@@ -277,13 +281,14 @@ const applyUrlsToFileParts = async (
   messages: UIMessage[],
   filesToProcess: Map<string, FileToProcess>,
   mode: ChatMode,
+  userId: string,
 ) => {
   const filesNeedingUrls = Array.from(filesToProcess.values()).filter(
     (file) => file.fileId && !file.url,
   );
   const fileIdsNeedingUrls = filesNeedingUrls.map((file) => file.fileId!);
 
-  const fetchedUrls = await fetchFileUrls(fileIdsNeedingUrls);
+  const fetchedUrls = await fetchFileUrls(fileIdsNeedingUrls, userId);
 
   filesNeedingUrls.forEach((file, index) => {
     if (fetchedUrls[index]) {
@@ -383,6 +388,7 @@ const removeFilePartsWithoutUrls = (messages: UIMessage[]) => {
 const applyModeSpecificTransforms = async (
   messages: UIMessage[],
   mode: ChatMode,
+  userId: string,
   sandboxFiles: SandboxFile[],
   uploadBasePath?: string,
   maxFileTokens?: number,
@@ -401,6 +407,7 @@ const applyModeSpecificTransforms = async (
       await addDocumentContentToMessages(
         messages,
         nonMediaFileIds,
+        userId,
         maxFileTokens,
       );
     }
@@ -428,12 +435,14 @@ const applyModeSpecificTransforms = async (
  *
  * @param messages - Messages to process
  * @param mode - Chat mode ("ask" or "agent")
+ * @param userId - Authenticated requester used to authorize stored file IDs
  * @param uploadBasePath - Override for agent mode (/home/user/upload or /tmp/hackerai-upload for local dangerous)
  * @returns Processed messages with file metadata and sandbox files for upload
  */
 export const processMessageFiles = async (
   messages: UIMessage[],
-  mode: ChatMode = "ask",
+  mode: ChatMode,
+  userId: string,
   uploadBasePath?: string,
   subscription?: SubscriptionTier,
   allowLocalDesktopFiles: boolean = false,
@@ -462,7 +471,7 @@ export const processMessageFiles = async (
   const { hasMedia, files } = collectFilesToProcess(updatedMessages, mode);
 
   if (files.size > 0) {
-    await applyUrlsToFileParts(updatedMessages, files, mode);
+    await applyUrlsToFileParts(updatedMessages, files, mode, userId);
   }
 
   const maxFileTokens = subscription
@@ -472,6 +481,7 @@ export const processMessageFiles = async (
   await applyModeSpecificTransforms(
     updatedMessages,
     mode,
+    userId,
     sandboxFiles,
     uploadBasePath,
     maxFileTokens,
@@ -522,6 +532,7 @@ const formatUnprocessableDocument = (name: string, reason: string) =>
 const addDocumentContentToMessages = async (
   messages: UIMessage[],
   fileIds: Id<"files">[],
+  userId: string,
   maxFileTokens: number = getMaxFileTokens("pro"),
 ): Promise<void> => {
   if (!fileIds.length || !messages.length) return;
@@ -529,7 +540,7 @@ const addDocumentContentToMessages = async (
   try {
     const fileContents = await getConvexClient().query(
       api.fileStorage.getFileContentByFileIds,
-      { serviceKey, fileIds },
+      { serviceKey, userId, fileIds },
     );
 
     const processableFiles = new Map<

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -696,6 +696,7 @@ export const agentLongTask = task({
         await processChatMessages({
           messages: messagesForProcessing,
           mode,
+          userId,
           subscription,
           uploadBasePath,
           modelOverride: selectedModelOverride,


### PR DESCRIPTION
## Summary
- Require the authenticated requester `userId` when backend service-key helpers resolve file URLs, content, and token metadata.
- Refuse URL/content/token generation for file records whose `user_id` does not match the requester.
- Validate message `fileIds` before inserting new messages or updating existing message attachments.
- Thread `userId` through chat and agent-long file processing so persisted and temporary runs share the same checks.

## Root Cause
Agent-long reused the agent-mode sandbox upload pipeline, but the service-key file URL helper accepted only `serviceKey` plus client-controlled `fileIds`. That let backend code mint download URLs without proving the referenced file belonged to the authenticated requester. Temporary chats also skipped message persistence, so document-content helper paths needed the same requester check.

## Validation
- `pnpm test -- convex/__tests__/s3Actions.test.ts convex/__tests__/messages.hidden.test.ts lib/utils/__tests__/file-transform-utils.test.ts --runInBand`
- `pnpm typecheck`
- Pre-commit hook: `pnpm typecheck` and full `pnpm test` (`100` suites, `1206` tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened file access control by enforcing per-user ownership validation. Files not owned by the requesting user are no longer accessible through file lookups, URL generation, content retrieval, or message attachments.

* **Tests**
  * Added comprehensive tests validating file ownership and access control across storage operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->