### PR TITLE
[codex] Remove extra usage trust caps

### DIFF
--- a/app/api/team/extra-usage/route.ts
+++ b/app/api/team/extra-usage/route.ts
@@ -57,8 +57,6 @@ export const GET = async (req: NextRequest) => {
         autoReloadAmountDollars: adminView.autoReloadAmountDollars,
         monthlyCapDollars: adminView.monthlyCapDollars,
         monthlySpentDollars: adminView.monthlySpentDollars,
-        trustCapDollars: adminView.trustCapDollars,
-        trustReason: adminView.trustReason,
         autoReloadDisabledReason: adminView.autoReloadDisabledReason,
       },
       members,

--- a/app/components/ExtraUsageSection.tsx
+++ b/app/components/ExtraUsageSection.tsx
@@ -176,32 +176,7 @@ const ExtraUsageSection = () => {
   const autoReloadDisabledReason = extraUsageSettings?.autoReloadDisabledReason;
   const monthlyCapDollars = extraUsageSettings?.monthlyCapDollars;
   const monthlySpentDollars = extraUsageSettings?.monthlySpentDollars ?? 0;
-  // TEMPORARY TRUST-CAP BYPASS:
-  // Restore these fields if HackerAI's own trust-based protection cap should
-  // be shown and combined with the user-set monthly spending limit again.
-  /*
-  const trustCapDollars = extraUsageSettings?.trustCapDollars;
-  const trustReason = extraUsageSettings?.trustReason;
-  */
-
-  // Trust-based protection caps are temporarily ignored. The visible and
-  // enforced cap is only the user-configured monthly spending limit.
   const effectiveCapDollars = monthlyCapDollars;
-
-  // TEMPORARY TRUST-CAP BYPASS:
-  // Restore this calculation if the displayed limit should become the lower of
-  // the user-set cap and HackerAI's trust-based protection cap again.
-  /*
-  const effectiveCapDollars =
-    monthlyCapDollars != null && trustCapDollars != null
-      ? Math.min(monthlyCapDollars, trustCapDollars)
-      : (monthlyCapDollars ?? trustCapDollars);
-
-  const isTrustCapActive =
-    trustCapDollars != null &&
-    trustReason !== "trusted" &&
-    (monthlyCapDollars == null || trustCapDollars <= monthlyCapDollars);
-  */
 
   // Get color class based on usage percentage (matches UsageTab)
   const getUsageColorClass = (percentage: number): string => {
@@ -287,24 +262,6 @@ const ExtraUsageSection = () => {
                     </p>
                   </div>
                 </div>
-                {/*
-                TEMPORARY TRUST-CAP BYPASS:
-                Restore this message if HackerAI's own trust-based protection
-                cap should be visible to users again.
-                {isTrustCapActive && (
-                  <p className="text-xs text-muted-foreground">
-                    Your extra usage limit is ${trustCapDollars}/month while
-                    your account builds payment history.{" "}
-                    <a
-                      href="mailto:support@hackerai.co"
-                      className="underline underline-offset-[3px] hover:text-foreground"
-                    >
-                      Contact us
-                    </a>{" "}
-                    for a higher limit.
-                  </p>
-                )}
-                */}
               </div>
             )}
 

--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -67,7 +67,6 @@ export const MessageErrorState = ({
     subscription === "free" ||
     subscription === "pro" ||
     subscription === "pro-plus";
-  const isTrustCapExceeded = metadata?.trustCapExceeded === true;
   const isSuspensionError = metadata?.suspensionCategory !== undefined;
 
   return (
@@ -78,18 +77,9 @@ export const MessageErrorState = ({
         ) : (
           <p>{errorMessage}</p>
         )}
-        {isRateLimitError && timeRemaining > 0 && !isTrustCapExceeded && (
+        {isRateLimitError && timeRemaining > 0 && (
           <p className="text-xs text-muted-foreground mt-1">
             Resets in {formatCountdown(timeRemaining)}
-          </p>
-        )}
-        {isRateLimitError && resetTimestamp && isTrustCapExceeded && (
-          <p className="text-xs text-muted-foreground mt-1">
-            Your limit resets on{" "}
-            {new Date(resetTimestamp).toLocaleDateString("en-US", {
-              month: "long",
-              day: "numeric",
-            })}
           </p>
         )}
       </div>
@@ -113,22 +103,7 @@ export const MessageErrorState = ({
             >
               View Usage
             </Button>
-            {isTrustCapExceeded && (
-              <Button
-                variant="default"
-                size="sm"
-                onClick={() =>
-                  window.open(
-                    "https://help.hackerai.co/",
-                    "_blank",
-                    "noopener,noreferrer",
-                  )
-                }
-              >
-                Contact Support
-              </Button>
-            )}
-            {isPaidUser && !isTrustCapExceeded && (
+            {isPaidUser && (
               <Button
                 variant="outline"
                 size="sm"
@@ -137,7 +112,7 @@ export const MessageErrorState = ({
                 Add Credits
               </Button>
             )}
-            {canUpgrade && !isTrustCapExceeded && (
+            {canUpgrade && (
               <Button variant="default" size="sm" onClick={redirectToPricing}>
                 Upgrade Plan
               </Button>

--- a/app/components/TeamExtraUsageSection.tsx
+++ b/app/components/TeamExtraUsageSection.tsx
@@ -29,8 +29,6 @@ type Pool = {
   autoReloadAmountDollars?: number;
   monthlyCapDollars?: number;
   monthlySpentDollars: number;
-  trustCapDollars: number | null;
-  trustReason: string;
   autoReloadDisabledReason?: string;
 };
 
@@ -229,32 +227,7 @@ export const TeamExtraUsageSection = () => {
   }
 
   const monthlyCapDollars = pool.monthlyCapDollars;
-  // TEMPORARY TRUST-CAP BYPASS:
-  // Restore these fields if HackerAI's own trust-based protection cap should
-  // be shown and combined with the admin-set team spending limit again.
-  /*
-  const trustCapDollars = pool.trustCapDollars;
-  const trustReason = pool.trustReason;
-  */
-
-  // Trust-based protection caps are temporarily ignored. The visible and
-  // enforced cap is only the admin-configured team monthly spending limit.
   const effectiveCapDollars = monthlyCapDollars;
-
-  // TEMPORARY TRUST-CAP BYPASS:
-  // Restore this calculation if the displayed limit should become the lower of
-  // the admin-set cap and HackerAI's trust-based protection cap again.
-  /*
-  const effectiveCapDollars =
-    monthlyCapDollars != null && trustCapDollars != null
-      ? Math.min(monthlyCapDollars, trustCapDollars)
-      : (monthlyCapDollars ?? trustCapDollars);
-
-  const isTrustCapActive =
-    trustCapDollars != null &&
-    trustReason !== "trusted" &&
-    (monthlyCapDollars == null || trustCapDollars <= monthlyCapDollars);
-  */
 
   return (
     <>
@@ -325,24 +298,6 @@ export const TeamExtraUsageSection = () => {
                     </p>
                   </div>
                 </div>
-                {/*
-                TEMPORARY TRUST-CAP BYPASS:
-                Restore this message if HackerAI's own trust-based protection
-                cap should be visible to team admins again.
-                {isTrustCapActive && (
-                  <p className="text-xs text-muted-foreground">
-                    Your team&apos;s extra usage limit is ${trustCapDollars}
-                    /month while your account builds payment history.{" "}
-                    <a
-                      href="mailto:support@hackerai.co"
-                      className="underline underline-offset-[3px] hover:text-foreground"
-                    >
-                      Contact us
-                    </a>{" "}
-                    for a higher limit.
-                  </p>
-                )}
-                */}
               </div>
             )}
 

--- a/convex/__tests__/teamExtraUsage.test.ts
+++ b/convex/__tests__/teamExtraUsage.test.ts
@@ -87,9 +87,6 @@ type TeamRow = {
   monthly_cap_points?: number;
   monthly_spent_points?: number;
   monthly_reset_date?: string;
-  first_successful_charge_at?: number;
-  cumulative_spend_dollars?: number;
-  override_monthly_cap_dollars?: number;
   auto_reload_consecutive_failures?: number;
   auto_reload_disabled_reason?: string;
   updated_at: number;
@@ -731,7 +728,7 @@ describe("addTeamCredits idempotency", () => {
     ).rejects.toThrow();
   });
 
-  it("credits the team balance and tracks cumulative spend", async () => {
+  it("credits the team balance", async () => {
     const { ctx, team } = makeMockCtx();
     const result = await callAddCredits(ctx, {
       organizationId: ORG_ID,
@@ -741,8 +738,6 @@ describe("addTeamCredits idempotency", () => {
     expect(result.newBalance).toBe(25);
     expect(team).toHaveLength(1);
     expect(team[0].balance_points).toBe(25 * POINTS_PER_DOLLAR);
-    expect(team[0].cumulative_spend_dollars).toBe(25);
-    expect(team[0].first_successful_charge_at).toBeGreaterThan(0);
   });
 
   it("returns alreadyProcessed when the idempotency key was already seen", async () => {

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -21,74 +21,6 @@ const dollarsToPoints = (dollars: number): number =>
 const pointsToDollars = (points: number): number => points / POINTS_PER_DOLLAR;
 
 // =============================================================================
-// Trust-Based Spending Cap
-// =============================================================================
-
-/**
- * Trust tier thresholds (modeled after Anthropic API tiers).
- * Both cumulative spend AND account age (since first charge) must be met to advance.
- *
- * Tier 1: cumulative_spend < $5  OR account < 7 days   → $100/month cap
- * Tier 2: cumulative_spend >= $5  AND account >= 7 days  → $500/month cap
- * Tier 3: cumulative_spend >= $40 AND account >= 30 days → $1,000/month cap
- * Tier 4: cumulative_spend >= $200 AND account >= 60 days → uncapped
- */
-const TRUST_TIERS = [
-  { minSpend: 200, minAgeDays: 60, capDollars: null }, // Tier 4: uncapped
-  { minSpend: 40, minAgeDays: 30, capDollars: 1000 }, // Tier 3
-  { minSpend: 5, minAgeDays: 7, capDollars: 500 }, // Tier 2
-] as const;
-
-const DEFAULT_TRUST_CAP_DOLLARS = 100; // Tier 1 default
-
-const DAYS_MS = 24 * 60 * 60 * 1000;
-
-export type TrustReason =
-  | "trusted" // Tier 4: fully uncapped
-  | "building-history" // Tier 1-3: need more spend/time
-  | "override"; // Manual override by support
-
-/**
- * Compute the effective monthly extra usage spending cap based on trust signals.
- * Returns null if uncapped (trusted user or manual override with no limit).
- */
-export function computeExtraUsageCap(settings: {
-  first_successful_charge_at?: number;
-  cumulative_spend_dollars?: number;
-  override_monthly_cap_dollars?: number;
-}): { capDollars: number | null; trustReason: TrustReason } {
-  // Manual override takes precedence
-  if (settings.override_monthly_cap_dollars !== undefined) {
-    return {
-      capDollars: settings.override_monthly_cap_dollars,
-      trustReason: "override",
-    };
-  }
-
-  const cumulativeSpend = settings.cumulative_spend_dollars ?? 0;
-  const firstChargeAt = settings.first_successful_charge_at;
-  const accountAgeDays = firstChargeAt
-    ? (Date.now() - firstChargeAt) / DAYS_MS
-    : 0;
-
-  // Check tiers from highest to lowest
-  for (const tier of TRUST_TIERS) {
-    if (cumulativeSpend >= tier.minSpend && accountAgeDays >= tier.minAgeDays) {
-      return {
-        capDollars: tier.capDollars,
-        trustReason: tier.capDollars === null ? "trusted" : "building-history",
-      };
-    }
-  }
-
-  // Default: Tier 1
-  return {
-    capDollars: DEFAULT_TRUST_CAP_DOLLARS,
-    trustReason: "building-history",
-  };
-}
-
-// =============================================================================
 // Webhook Idempotency
 // =============================================================================
 
@@ -345,23 +277,17 @@ export const addCredits = mutation({
     const currentBalancePoints = settings?.balance_points ?? 0;
     const newBalancePoints = currentBalancePoints + amountPoints;
 
-    // Update or create settings (also track trust fields)
+    // Update or create settings
     const now = Date.now();
     if (settings) {
       await ctx.db.patch(settings._id, {
         balance_points: newBalancePoints,
-        // Track cumulative spend for trust-based caps
-        first_successful_charge_at: settings.first_successful_charge_at ?? now,
-        cumulative_spend_dollars:
-          (settings.cumulative_spend_dollars ?? 0) + args.amountDollars,
         updated_at: now,
       });
     } else {
       await ctx.db.insert("extra_usage", {
         user_id: args.userId,
         balance_points: newBalancePoints,
-        first_successful_charge_at: now,
-        cumulative_spend_dollars: args.amountDollars,
         updated_at: now,
       });
     }
@@ -411,8 +337,6 @@ export const deductPoints = mutation({
     newBalanceDollars: v.number(),
     insufficientFunds: v.boolean(),
     monthlyCapExceeded: v.boolean(),
-    trustCapExceeded: v.optional(v.boolean()),
-    trustCapDollars: v.optional(v.union(v.null(), v.number())),
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
@@ -470,39 +394,17 @@ export const deductPoints = mutation({
       monthlySpentPoints = 0;
     }
 
-    // Compute effective monthly cap: lower of user-set cap and trust-based cap
-    const userCapPoints = settings.monthly_cap_points;
-    const { capDollars: trustCapDollars } = computeExtraUsageCap(settings);
-    const trustCapPoints =
-      trustCapDollars !== null ? dollarsToPoints(trustCapDollars) : undefined;
-
-    // Use the most restrictive cap (lowest non-undefined value)
-    let effectiveCapPoints: number | undefined;
-    if (userCapPoints !== undefined && trustCapPoints !== undefined) {
-      effectiveCapPoints = Math.min(userCapPoints, trustCapPoints);
-    } else {
-      effectiveCapPoints = userCapPoints ?? trustCapPoints;
-    }
-
-    // Determine which cap triggered (for frontend error messaging)
-    const isTrustCap =
-      effectiveCapPoints !== undefined &&
-      trustCapPoints !== undefined &&
-      effectiveCapPoints === trustCapPoints &&
-      (userCapPoints === undefined || trustCapPoints <= userCapPoints);
-
     // Check monthly spending cap before deducting
-    if (effectiveCapPoints !== undefined) {
+    const monthlyCapPoints = settings.monthly_cap_points;
+    if (monthlyCapPoints !== undefined) {
       const newMonthlySpent = monthlySpentPoints + args.amountPoints;
-      if (newMonthlySpent > effectiveCapPoints) {
+      if (newMonthlySpent > monthlyCapPoints) {
         convexLogger.warn("deduct_points_failed", {
           user_id: args.userId,
           amount_points: args.amountPoints,
           monthly_spent_points: monthlySpentPoints,
-          effective_cap_points: effectiveCapPoints,
-          trust_cap_dollars: trustCapDollars,
-          is_trust_cap: isTrustCap,
-          reason: isTrustCap ? "trust_cap_exceeded" : "monthly_cap_exceeded",
+          monthly_cap_points: monthlyCapPoints,
+          reason: "monthly_cap_exceeded",
           monthly_cap_exceeded: true,
         });
         return {
@@ -511,8 +413,6 @@ export const deductPoints = mutation({
           newBalanceDollars: pointsToDollars(currentBalancePoints),
           insufficientFunds: true,
           monthlyCapExceeded: true,
-          trustCapExceeded: isTrustCap,
-          trustCapDollars: isTrustCap ? trustCapDollars : undefined,
         };
       }
     }
@@ -535,7 +435,7 @@ export const deductPoints = mutation({
       previous_balance_points: currentBalancePoints,
       new_balance_points: newBalancePoints,
       monthly_spent_points: monthlySpentPoints,
-      monthly_cap_points: effectiveCapPoints,
+      monthly_cap_points: monthlyCapPoints,
     });
 
     return {
@@ -699,9 +599,6 @@ export const getExtraUsageSettings = query({
       autoReloadAmountDollars: v.optional(v.number()),
       monthlyCapDollars: v.optional(v.number()),
       monthlySpentDollars: v.number(),
-      // Trust-based spending cap
-      trustCapDollars: v.union(v.null(), v.number()), // null = uncapped
-      trustReason: v.string(),
       // If auto-reload was auto-disabled because the saved card kept failing,
       // surface a human-readable reason so the UI can prompt the user to fix it.
       autoReloadDisabledReason: v.optional(v.string()),
@@ -722,8 +619,6 @@ export const getExtraUsageSettings = query({
       return null;
     }
 
-    const { capDollars, trustReason } = computeExtraUsageCap(settings);
-
     return {
       balanceDollars: pointsToDollars(settings.balance_points),
       autoReloadEnabled: settings.auto_reload_enabled ?? false,
@@ -735,8 +630,6 @@ export const getExtraUsageSettings = query({
         ? pointsToDollars(settings.monthly_cap_points)
         : undefined,
       monthlySpentDollars: pointsToDollars(settings.monthly_spent_points ?? 0),
-      trustCapDollars: capDollars,
-      trustReason,
       autoReloadDisabledReason: settings.auto_reload_disabled_reason,
     };
   },

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -494,8 +494,6 @@ export const deductWithAutoReload = action({
     newBalanceDollars: v.number(),
     insufficientFunds: v.boolean(),
     monthlyCapExceeded: v.boolean(),
-    trustCapExceeded: v.optional(v.boolean()),
-    trustCapDollars: v.optional(v.union(v.null(), v.number())),
     autoReloadTriggered: v.boolean(),
     autoReloadResult: v.optional(
       v.object({
@@ -675,8 +673,6 @@ export const deductWithAutoReload = action({
       newBalanceDollars: number;
       insufficientFunds: boolean;
       monthlyCapExceeded: boolean;
-      trustCapExceeded?: boolean;
-      trustCapDollars?: number | null;
     } = await ctx.runMutation(api.extraUsage.deductPoints, {
       serviceKey: args.serviceKey,
       userId: args.userId,
@@ -701,8 +697,6 @@ export const deductWithAutoReload = action({
       newBalanceDollars: deductResult.newBalanceDollars,
       insufficientFunds: deductResult.insufficientFunds,
       monthlyCapExceeded: deductResult.monthlyCapExceeded,
-      trustCapExceeded: deductResult.trustCapExceeded,
-      trustCapDollars: deductResult.trustCapDollars,
       autoReloadTriggered,
       autoReloadResult,
     };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -154,10 +154,11 @@ export default defineSchema({
     monthly_cap_points: v.optional(v.number()),
     monthly_spent_points: v.optional(v.number()),
     monthly_reset_date: v.optional(v.string()),
-    // Trust-based spending cap fields
-    first_successful_charge_at: v.optional(v.number()), // Timestamp of first successful charge
-    cumulative_spend_dollars: v.optional(v.number()), // Total of all successful charges
-    override_monthly_cap_dollars: v.optional(v.number()), // Manual override set by support team
+    // Legacy trust-cap fields retained so old rows still pass validation.
+    // The trust-cap feature no longer reads or writes these values.
+    first_successful_charge_at: v.optional(v.number()),
+    cumulative_spend_dollars: v.optional(v.number()),
+    override_monthly_cap_dollars: v.optional(v.number()),
     // Auto-reload health tracking — disable after consecutive failures so a
     // broken saved card does not keep retrying.
     auto_reload_consecutive_failures: v.optional(v.number()),
@@ -178,6 +179,8 @@ export default defineSchema({
     monthly_cap_points: v.optional(v.number()),
     monthly_spent_points: v.optional(v.number()),
     monthly_reset_date: v.optional(v.string()),
+    // Legacy trust-cap fields retained so old rows still pass validation.
+    // The trust-cap feature no longer reads or writes these values.
     first_successful_charge_at: v.optional(v.number()),
     cumulative_spend_dollars: v.optional(v.number()),
     override_monthly_cap_dollars: v.optional(v.number()),

--- a/convex/teamExtraUsage.ts
+++ b/convex/teamExtraUsage.ts
@@ -7,7 +7,6 @@ import {
 import { v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 import { convexLogger } from "./lib/logger";
-import { computeExtraUsageCap } from "./extraUsage";
 
 // =============================================================================
 // Currency Conversion Helpers
@@ -142,17 +141,12 @@ export const addTeamCredits = mutation({
     if (row) {
       await ctx.db.patch(row._id, {
         balance_points: newBalancePoints,
-        first_successful_charge_at: row.first_successful_charge_at ?? now,
-        cumulative_spend_dollars:
-          (row.cumulative_spend_dollars ?? 0) + args.amountDollars,
         updated_at: now,
       });
     } else {
       await ctx.db.insert("team_extra_usage", {
         organization_id: args.organizationId,
         balance_points: newBalancePoints,
-        first_successful_charge_at: now,
-        cumulative_spend_dollars: args.amountDollars,
         updated_at: now,
       });
     }
@@ -189,7 +183,7 @@ export const addTeamCredits = mutation({
  *   - team pool enabled
  *   - member not disabled
  *   - member's per-member cap
- *   - team's monthly cap (with trust cap as ceiling)
+ *   - team's monthly cap
  *   - sufficient team balance
  */
 export const deductTeamPoints = mutation({
@@ -208,8 +202,6 @@ export const deductTeamPoints = mutation({
     memberCapExceeded: v.boolean(),
     memberDisabled: v.boolean(),
     poolDisabled: v.boolean(),
-    trustCapExceeded: v.optional(v.boolean()),
-    trustCapDollars: v.optional(v.union(v.null(), v.number())),
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
@@ -268,29 +260,11 @@ export const deductTeamPoints = mutation({
       memberMonthlySpent = 0;
     }
 
-    // Compute effective team cap (user-set vs trust)
-    const teamCap = team.monthly_cap_points;
-    const { capDollars: trustCapDollars } = computeExtraUsageCap(team);
-    const trustCapPoints =
-      trustCapDollars !== null ? dollarsToPoints(trustCapDollars) : undefined;
-
-    let effectiveTeamCap: number | undefined;
-    if (teamCap !== undefined && trustCapPoints !== undefined) {
-      effectiveTeamCap = Math.min(teamCap, trustCapPoints);
-    } else {
-      effectiveTeamCap = teamCap ?? trustCapPoints;
-    }
-
-    const isTrustCap =
-      effectiveTeamCap !== undefined &&
-      trustCapPoints !== undefined &&
-      effectiveTeamCap === trustCapPoints &&
-      (teamCap === undefined || trustCapPoints <= teamCap);
-
     // Team monthly cap check
-    if (effectiveTeamCap !== undefined) {
+    const teamCap = team.monthly_cap_points;
+    if (teamCap !== undefined) {
       const newTeamSpent = teamMonthlySpent + args.amountPoints;
-      if (newTeamSpent > effectiveTeamCap) {
+      if (newTeamSpent > teamCap) {
         return {
           success: false,
           newBalancePoints: currentBalancePoints,
@@ -300,8 +274,6 @@ export const deductTeamPoints = mutation({
           memberCapExceeded: false,
           memberDisabled: false,
           poolDisabled: false,
-          trustCapExceeded: isTrustCap,
-          trustCapDollars: isTrustCap ? trustCapDollars : undefined,
         };
       }
     }
@@ -555,8 +527,6 @@ export const getTeamExtraUsageAdminView = query({
     autoReloadAmountDollars: v.optional(v.number()),
     monthlyCapDollars: v.optional(v.number()),
     monthlySpentDollars: v.number(),
-    trustCapDollars: v.union(v.null(), v.number()),
-    trustReason: v.string(),
     autoReloadDisabledReason: v.optional(v.string()),
     members: v.array(
       v.object({
@@ -582,7 +552,6 @@ export const getTeamExtraUsageAdminView = query({
 
     const currentMonth = currentMonthString();
 
-    const { capDollars, trustReason } = computeExtraUsageCap(team ?? {});
     const teamMonthlySpent =
       team?.monthly_reset_date === currentMonth
         ? (team?.monthly_spent_points ?? 0)
@@ -600,8 +569,6 @@ export const getTeamExtraUsageAdminView = query({
         ? pointsToDollars(team.monthly_cap_points)
         : undefined,
       monthlySpentDollars: pointsToDollars(teamMonthlySpent),
-      trustCapDollars: capDollars,
-      trustReason,
       autoReloadDisabledReason: team?.auto_reload_disabled_reason,
       members: members.map((m) => {
         const spent =

--- a/convex/teamExtraUsageActions.ts
+++ b/convex/teamExtraUsageActions.ts
@@ -273,8 +273,6 @@ export const deductWithAutoReloadForTeam = action({
     memberCapExceeded: v.boolean(),
     memberDisabled: v.boolean(),
     poolDisabled: v.boolean(),
-    trustCapExceeded: v.optional(v.boolean()),
-    trustCapDollars: v.optional(v.union(v.null(), v.number())),
     autoReloadTriggered: v.boolean(),
     autoReloadResult: v.optional(
       v.object({
@@ -329,8 +327,6 @@ export const deductWithAutoReloadForTeam = action({
       memberCapExceeded: boolean;
       memberDisabled: boolean;
       poolDisabled: boolean;
-      trustCapExceeded?: boolean;
-      trustCapDollars?: number | null;
     } = await ctx.runMutation(api.teamExtraUsage.deductTeamPoints, {
       serviceKey: args.serviceKey,
       organizationId: args.organizationId,
@@ -348,8 +344,7 @@ export const deductWithAutoReloadForTeam = action({
         deductResult.monthlyCapExceeded ||
         deductResult.memberCapExceeded ||
         deductResult.memberDisabled ||
-        deductResult.poolDisabled ||
-        deductResult.trustCapExceeded);
+        deductResult.poolDisabled);
 
     if (blockedForNonBalanceReason) {
       return {
@@ -360,8 +355,6 @@ export const deductWithAutoReloadForTeam = action({
         memberCapExceeded: deductResult.memberCapExceeded,
         memberDisabled: deductResult.memberDisabled,
         poolDisabled: deductResult.poolDisabled,
-        trustCapExceeded: deductResult.trustCapExceeded,
-        trustCapDollars: deductResult.trustCapDollars,
         autoReloadTriggered: false,
       };
     }
@@ -532,8 +525,6 @@ export const deductWithAutoReloadForTeam = action({
       memberCapExceeded: deductResult.memberCapExceeded,
       memberDisabled: deductResult.memberDisabled,
       poolDisabled: deductResult.poolDisabled,
-      trustCapExceeded: deductResult.trustCapExceeded,
-      trustCapDollars: deductResult.trustCapDollars,
       autoReloadTriggered,
       autoReloadResult,
     };

--- a/lib/extra-usage.ts
+++ b/lib/extra-usage.ts
@@ -20,8 +20,6 @@ export interface DeductBalanceResult {
   newBalanceDollars: number;
   insufficientFunds: boolean;
   monthlyCapExceeded: boolean;
-  trustCapExceeded?: boolean;
-  trustCapDollars?: number | null;
   autoReloadTriggered?: boolean;
   autoReloadResult?: {
     success: boolean;
@@ -181,8 +179,6 @@ export async function deductFromBalance(
       newBalanceDollars: result.newBalanceDollars,
       insufficientFunds: result.insufficientFunds,
       monthlyCapExceeded: result.monthlyCapExceeded,
-      trustCapExceeded: result.trustCapExceeded,
-      trustCapDollars: result.trustCapDollars,
       autoReloadTriggered: result.autoReloadTriggered,
       autoReloadResult: result.autoReloadResult,
     };
@@ -247,8 +243,8 @@ export async function getTeamExtraUsageState(
 
 /**
  * Deduct from team balance for a specific member. Enforces per-member cap,
- * member-disabled flag, team-wide cap, trust cap. Triggers auto-reload on
- * the org's Stripe customer when applicable.
+ * member-disabled flag, and team-wide cap. Triggers auto-reload on the org's
+ * Stripe customer when applicable.
  */
 export async function deductFromTeamBalance(
   organizationId: string,
@@ -282,8 +278,6 @@ export async function deductFromTeamBalance(
       newBalanceDollars: result.newBalanceDollars,
       insufficientFunds: result.insufficientFunds,
       monthlyCapExceeded: result.monthlyCapExceeded,
-      trustCapExceeded: result.trustCapExceeded,
-      trustCapDollars: result.trustCapDollars,
       autoReloadTriggered: result.autoReloadTriggered,
       autoReloadResult: result.autoReloadResult,
       memberCapExceeded: result.memberCapExceeded,

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -319,17 +319,6 @@ export const checkTokenBucketLimit = async (
             });
           }
 
-          if (deductResult.trustCapExceeded) {
-            const capAmount = deductResult.trustCapDollars ?? 100;
-            const msg = `You've reached your extra usage limit of $${capAmount}/month. This limit grows automatically with your payment history. Need a higher limit? Chat with us through our Help Center.`;
-            throw new ChatSDKError("rate_limit:chat", msg, {
-              resetTimestamp: monthlyCheck.reset,
-              subscription,
-              trustCapExceeded: true,
-              capReason: "trust_cap",
-            });
-          }
-
           if (deductResult.monthlyCapExceeded) {
             const msg = `You've hit your monthly extra usage spending limit.\n\nYour limit resets ${resetTime}. To keep going now, increase your spending limit in Settings.`;
             throw new ChatSDKError("rate_limit:chat", msg, {


### PR DESCRIPTION
## Summary

- Remove the unused trust-tier extra usage cap calculation and enforcement from personal and team billing deduction paths.
- Stop updating trust-history fields when Stripe credits are added, while retaining legacy optional schema fields so existing Convex rows continue to validate.
- Remove trust-cap fields from API/action result shapes, rate-limit error handling, and extra-usage UI copy.

## Why

The trust cap was no longer used as a product control and was only partially enforced. Keeping it in deduction paths created confusing behavior and stale API/UI surfaces without reliably constraining Stripe charge creation.

## Validation

- `pnpm test -- convex/__tests__/teamExtraUsage.test.ts convex/__tests__/extraUsageActionsAuth.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint app/api/team/extra-usage/route.ts app/components/ExtraUsageSection.tsx app/components/MessageErrorState.tsx app/components/TeamExtraUsageSection.tsx convex/__tests__/teamExtraUsage.test.ts convex/extraUsage.ts convex/extraUsageActions.ts convex/schema.ts convex/teamExtraUsage.ts convex/teamExtraUsageActions.ts lib/extra-usage.ts lib/rate-limit/token-bucket.ts`
- Commit hook: full `pnpm test` passed, 100 suites / 1203 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified spending cap enforcement to rely solely on monthly limits, removing the trust-cap system.
  * Streamlined rate-limit error messaging by removing trust-cap-related UI elements and status indicators.
  * Reduced complexity in overage usage tracking and monthly spending controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->