### PR TITLE
[codex] Bound summary todo payloads

### DIFF
--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 import type { UIMessage, UIMessageStreamWriter, LanguageModel } from "ai";
 import type { Todo } from "@/types";
-import { SUMMARIZATION_THRESHOLD_PERCENTAGE } from "../constants";
-import { MAX_TOKENS_PAID } from "@/lib/token-utils";
+import {
+  SUMMARIZATION_THRESHOLD_PERCENTAGE,
+  SUMMARY_TODO_BLOCK_MAX_TOKENS,
+  SUMMARY_TODO_MAX_ITEMS,
+} from "../constants";
+import { MAX_TOKENS_PAID, safeCountTokens } from "@/lib/token-utils";
 
 const mockGenerateText = jest.fn<() => Promise<any>>();
 const mockSaveChatSummary = jest.fn<() => Promise<void>>();
@@ -23,7 +27,7 @@ jest.doMock("@/lib/ai/providers", () => ({
 
 const { checkAndSummarizeIfNeeded } =
   require("../index") as typeof import("../index");
-const { isSummaryMessage, extractSummaryText } =
+const { isSummaryMessage, extractSummaryText, buildSummaryMessage } =
   require("../helpers") as typeof import("../helpers");
 
 const THRESHOLD = Math.floor(
@@ -376,6 +380,38 @@ describe("checkAndSummarizeIfNeeded", () => {
       type: "text",
       text: expect.stringContaining("[completed] Enumerate subdomains"),
     });
+  });
+
+  it("should bound todo content in summary messages", () => {
+    const todos: Todo[] = Array.from(
+      { length: SUMMARY_TODO_MAX_ITEMS + 25 },
+      (_, index) => ({
+        id: `todo-${index}`,
+        content: `todo-${index} ${"large todo content ".repeat(1000)}`,
+        status: "pending",
+      }),
+    );
+
+    const summaryMessage = buildSummaryMessage("Bounded summary", todos);
+    const summaryText = summaryMessage.parts[0];
+
+    expect(summaryText).toEqual({
+      type: "text",
+      text: expect.stringContaining("<current_todos>"),
+    });
+    expect(summaryText).toEqual({
+      type: "text",
+      text: expect.stringContaining("[... current_todos truncated ...]"),
+    });
+
+    if (summaryText.type !== "text") {
+      throw new Error("Expected summary message to contain text");
+    }
+
+    expect(summaryText.text).not.toContain("todo-124");
+    expect(safeCountTokens(summaryText.text)).toBeLessThanOrEqual(
+      SUMMARY_TODO_BLOCK_MAX_TOKENS + 32,
+    );
   });
 
   it("should abort summarization and not write completed when signal is aborted", async () => {

--- a/lib/chat/summarization/constants.ts
+++ b/lib/chat/summarization/constants.ts
@@ -3,3 +3,9 @@ export const MESSAGES_TO_KEEP_UNSUMMARIZED = 0;
 
 // Summarize at 90% of token limit to leave buffer for current response
 export const SUMMARIZATION_THRESHOLD_PERCENTAGE = 0.9;
+
+// Keep persisted todos useful in the synthetic summary without letting stored
+// todo payloads bypass chat token budgeting.
+export const SUMMARY_TODO_MAX_ITEMS = 100;
+export const SUMMARY_TODO_CONTENT_MAX_TOKENS = 256;
+export const SUMMARY_TODO_BLOCK_MAX_TOKENS = 4096;

--- a/lib/chat/summarization/helpers.ts
+++ b/lib/chat/summarization/helpers.ts
@@ -10,6 +10,7 @@ import { v4 as uuidv4 } from "uuid";
 import {
   getMaxTokensForSubscription,
   countMessagesTokens,
+  truncateContent,
 } from "@/lib/token-utils";
 import { saveChatSummary } from "@/lib/db/actions";
 import { SubscriptionTier, ChatMode, Todo } from "@/types";
@@ -18,6 +19,9 @@ import type { Id } from "@/convex/_generated/dataModel";
 import {
   MESSAGES_TO_KEEP_UNSUMMARIZED,
   SUMMARIZATION_THRESHOLD_PERCENTAGE,
+  SUMMARY_TODO_BLOCK_MAX_TOKENS,
+  SUMMARY_TODO_CONTENT_MAX_TOKENS,
+  SUMMARY_TODO_MAX_ITEMS,
 } from "./constants";
 import {
   AGENT_SUMMARIZATION_PROMPT,
@@ -185,10 +189,29 @@ export const buildSummaryMessage = (
   let text = `<context_summary>\n${summaryText}\n</context_summary>`;
 
   if (todos.length > 0) {
-    const todoLines = todos
-      .map((todo) => `- [${todo.status}] ${todo.content}`)
+    const visibleTodos = todos.slice(0, SUMMARY_TODO_MAX_ITEMS);
+    const omittedCount = todos.length - visibleTodos.length;
+    const todoLines = visibleTodos
+      .map((todo) => {
+        const content = truncateContent(
+          todo.content,
+          " [... truncated]",
+          SUMMARY_TODO_CONTENT_MAX_TOKENS,
+        );
+        return `- [${todo.status}] ${content}`;
+      })
+      .concat(
+        omittedCount > 0
+          ? [`- [... ${omittedCount} additional todos omitted ...]`]
+          : [],
+      )
       .join("\n");
-    text += `\n<current_todos>\n${todoLines}\n</current_todos>`;
+    const boundedTodoLines = truncateContent(
+      todoLines,
+      "\n[... current_todos truncated ...]",
+      SUMMARY_TODO_BLOCK_MAX_TOKENS,
+    );
+    text += `\n<current_todos>\n${boundedTodoLines}\n</current_todos>`;
   }
 
   return {


### PR DESCRIPTION
## Summary

Fixes an accounting/context-budget bypass in chat summarization where persisted todos were appended to the synthetic summary message after the summarization threshold check without any count or token bound.

## Changes

- Adds explicit limits for summary todo inclusion: maximum todo count, per-todo content tokens, and total `<current_todos>` block tokens.
- Truncates oversized todo content before appending it to the model-facing summary message.
- Preserves useful current todo context while adding omission/truncation markers when the stored todo payload is larger than the budget.
- Adds a regression test covering oversized todo payloads in generated summary messages.

## Validation

- `pnpm jest lib/chat/summarization/__tests__/index.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings outside this change)
- Commit hook ran `pnpm typecheck` and full `pnpm test`: 100 suites / 1204 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Summarization now intelligently bounds and truncates todo lists to keep summaries within size limits
  * System indicates when todo items are omitted from summaries due to space constraints

* **Tests**
  * Added verification that summary messages properly truncate oversized todo content

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->