### PR TITLE
[codex] Fix S3 presigned upload limits

### DIFF
--- a/__mocks__/@aws-sdk/client-s3.ts
+++ b/__mocks__/@aws-sdk/client-s3.ts
@@ -4,14 +4,18 @@ export const S3Client = jest.fn().mockImplementation((config: any) => ({
   send: mockSend,
 }));
 
-export class PutObjectCommand {
-  constructor(params: any) {}
-}
+export const PutObjectCommand = jest.fn().mockImplementation((params: any) => ({
+  params,
+}));
 
 export class GetObjectCommand {
   constructor(params: any) {}
 }
 
 export class DeleteObjectCommand {
+  constructor(params: any) {}
+}
+
+export class HeadObjectCommand {
   constructor(params: any) {}
 }

--- a/convex/__tests__/fileActions.upload-policy.test.ts
+++ b/convex/__tests__/fileActions.upload-policy.test.ts
@@ -38,6 +38,7 @@ jest.mock("../_generated/api", () => ({
   internal: {
     fileStorage: {
       saveFileToDb: "internal.fileStorage.saveFileToDb",
+      getFileByS3Key: "internal.fileStorage.getFileByS3Key",
     },
     s3Cleanup: {
       deleteS3ObjectAction: "internal.s3Cleanup.deleteS3ObjectAction",
@@ -133,6 +134,25 @@ describe("fileActions saveFile upload policy", () => {
         getUrl: jest.fn().mockResolvedValue("https://storage.example/file"),
         getMetadata: jest.fn().mockResolvedValue({ size: 1024 }),
       },
+      runQuery: jest.fn(async (_fn: unknown, args: { s3Key?: string }) => ({
+        _id: "file_reservation_123",
+        s3_key: args.s3Key,
+        user_id: "user123",
+        name: "reserved.txt",
+        media_type: "text/plain",
+        size: args.s3Key?.includes("large.bin")
+          ? 21 * 1024 * 1024
+          : args.s3Key?.includes("large.png")
+            ? 8 * 1024 * 1024
+            : args.s3Key?.includes("archive.zip")
+              ? 25 * 1024 * 1024
+              : args.s3Key?.includes("huge.bin")
+                ? 251 * 1024 * 1024
+                : 1024,
+        file_token_size: 0,
+        is_attached: false,
+        _creationTime: Date.now(),
+      })),
       runMutation: jest.fn().mockResolvedValue("file_123"),
     }) as any;
 
@@ -183,6 +203,98 @@ describe("fileActions saveFile upload policy", () => {
       "internal.s3Cleanup.deleteS3ObjectAction",
       { s3Key: "users/user123/large.bin" },
     );
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("rejects S3 uploads when the actual object size differs from the reservation", async () => {
+    const { saveFile } = await import("../fileActions");
+    const ctx = makeCtx();
+    ctx.runQuery.mockResolvedValueOnce({
+      _id: "file_reservation_123",
+      s3_key: "users/user123/notes.txt",
+      user_id: "user123",
+      name: "notes.txt",
+      media_type: "text/plain",
+      size: 512,
+      file_token_size: 0,
+      is_attached: false,
+      _creationTime: Date.now(),
+    });
+
+    await expect(
+      saveFile.handler(ctx, {
+        s3Key: "users/user123/notes.txt",
+        name: "notes.txt",
+        mediaType: "text/plain",
+        size: 512,
+        mode: "ask",
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({ code: "FILE_SIZE_MISMATCH" }),
+    });
+
+    expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      "internal.s3Cleanup.deleteS3ObjectAction",
+      { s3Key: "users/user123/notes.txt" },
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("rejects cross-user S3 reservations without deleting the object", async () => {
+    const { saveFile } = await import("../fileActions");
+    const ctx = makeCtx();
+    ctx.runQuery.mockResolvedValueOnce({
+      _id: "file_reservation_victim",
+      s3_key: "users/victim/notes.txt",
+      user_id: "victim",
+      name: "notes.txt",
+      media_type: "text/plain",
+      size: 1024,
+      file_token_size: 0,
+      is_attached: false,
+      _creationTime: Date.now(),
+    });
+
+    await expect(
+      saveFile.handler(ctx, {
+        s3Key: "users/victim/notes.txt",
+        name: "notes.txt",
+        mediaType: "text/plain",
+        size: 1024,
+        mode: "ask",
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({
+        code: "UNAUTHORIZED_UPLOAD_RESERVATION",
+      }),
+    });
+
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("does not delete unreserved S3 keys outside the acting user's prefix", async () => {
+    const { saveFile } = await import("../fileActions");
+    const ctx = makeCtx();
+    ctx.runQuery.mockResolvedValueOnce(null);
+
+    await expect(
+      saveFile.handler(ctx, {
+        s3Key: "users/victim/orphan.txt",
+        name: "orphan.txt",
+        mediaType: "text/plain",
+        size: 1024,
+        mode: "ask",
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({ code: "INVALID_UPLOAD_RESERVATION" }),
+    });
+
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
     expect(global.fetch).not.toHaveBeenCalled();
     expect(ctx.runMutation).not.toHaveBeenCalled();
   });

--- a/convex/__tests__/fileStorage.aggregate.test.ts
+++ b/convex/__tests__/fileStorage.aggregate.test.ts
@@ -178,6 +178,170 @@ describe("fileStorage - Aggregate Integration", () => {
 
       expect(mockCtx.db.insert).not.toHaveBeenCalled();
     });
+
+    it("should finalize an existing S3 upload reservation without double-counting storage", async () => {
+      const reservedFile = {
+        _id: testFileId,
+        s3_key: "users/test-user-123/file.pdf",
+        user_id: testUserId,
+        name: "file.pdf",
+        media_type: "application/pdf",
+        size: 1024,
+        file_token_size: 0,
+        is_attached: false,
+      };
+      const unique = jest.fn<any>().mockResolvedValue(reservedFile);
+      const mockCtx: any = {
+        db: {
+          query: jest.fn<any>().mockReturnValue({
+            withIndex: jest.fn<any>().mockReturnValue({ unique }),
+          }),
+          patch: jest.fn<any>().mockResolvedValue(undefined),
+          insert: jest.fn<any>(),
+        },
+      };
+
+      const { saveFileToDb } = (await import("../fileStorage")) as any;
+      const result = await saveFileToDb.handler(mockCtx, {
+        s3Key: "users/test-user-123/file.pdf",
+        userId: testUserId,
+        name: "file.pdf",
+        mediaType: "application/pdf",
+        size: 1024,
+        fileTokenSize: 100,
+      });
+
+      expect(result).toBe(testFileId);
+      expect(mockCtx.db.patch).toHaveBeenCalledWith(
+        testFileId,
+        expect.objectContaining({ file_token_size: 100 }),
+      );
+      expect(mockCtx.db.insert).not.toHaveBeenCalled();
+      expect(mockFileCountAggregate.sum).not.toHaveBeenCalled();
+      expect(
+        mockFileCountAggregate.insertIfDoesNotExist,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("should reject S3 saves without a reservation", async () => {
+      const unique = jest.fn<any>().mockResolvedValue(null);
+      const mockCtx: any = {
+        db: {
+          query: jest.fn<any>().mockReturnValue({
+            withIndex: jest.fn<any>().mockReturnValue({ unique }),
+          }),
+          insert: jest.fn<any>(),
+        },
+      };
+
+      const { saveFileToDb } = (await import("../fileStorage")) as any;
+      await expect(
+        saveFileToDb.handler(mockCtx, {
+          s3Key: "users/test-user-123/file.pdf",
+          userId: testUserId,
+          name: "file.pdf",
+          mediaType: "application/pdf",
+          size: 1024,
+          fileTokenSize: 100,
+        }),
+      ).rejects.toMatchObject({
+        data: expect.objectContaining({ code: "MISSING_UPLOAD_RESERVATION" }),
+      });
+
+      expect(mockCtx.db.insert).not.toHaveBeenCalled();
+      expect(mockFileCountAggregate.sum).not.toHaveBeenCalled();
+    });
+
+    it("should allow trusted service-generated S3 saves without a reservation", async () => {
+      const unique = jest.fn<any>().mockResolvedValue(null);
+      const mockFile = {
+        _id: testFileId,
+        s3_key: "users/test-user-123/generated.zip",
+        user_id: testUserId,
+        name: "generated.zip",
+        media_type: "application/zip",
+        size: 1024,
+        file_token_size: 0,
+        is_attached: false,
+      };
+      const mockCtx: any = {
+        db: {
+          query: jest.fn<any>().mockReturnValue({
+            withIndex: jest.fn<any>().mockReturnValue({ unique }),
+          }),
+          insert: jest.fn<any>().mockResolvedValue(testFileId),
+          get: jest.fn<any>().mockResolvedValue(mockFile),
+        },
+      };
+
+      const { saveFileToDb } = (await import("../fileStorage")) as any;
+      const result = await saveFileToDb.handler(mockCtx, {
+        s3Key: "users/test-user-123/generated.zip",
+        userId: testUserId,
+        name: "generated.zip",
+        mediaType: "application/zip",
+        size: 1024,
+        fileTokenSize: 0,
+        trustedServiceGenerated: true,
+      });
+
+      expect(result).toBe(testFileId);
+      expect(mockCtx.db.insert).toHaveBeenCalled();
+      expect(mockFileCountAggregate.insertIfDoesNotExist).toHaveBeenCalledWith(
+        mockCtx,
+        mockFile,
+      );
+    });
+  });
+
+  describe("createPendingS3File", () => {
+    it("should reserve storage for pending S3 uploads", async () => {
+      const mockFile = {
+        _id: testFileId,
+        s3_key: "users/test-user-123/file.pdf",
+        user_id: testUserId,
+        name: "file.pdf",
+        media_type: "application/pdf",
+        size: 1024,
+        file_token_size: 0,
+        is_attached: false,
+      };
+      const unique = jest.fn<any>().mockResolvedValue(null);
+      const mockCtx: any = {
+        db: {
+          query: jest.fn<any>().mockReturnValue({
+            withIndex: jest.fn<any>().mockReturnValue({ unique }),
+          }),
+          insert: jest.fn<any>().mockResolvedValue(testFileId),
+          get: jest.fn<any>().mockResolvedValue(mockFile),
+        },
+      };
+
+      const { createPendingS3File } = (await import("../fileStorage")) as any;
+      const result = await createPendingS3File.handler(mockCtx, {
+        s3Key: "users/test-user-123/file.pdf",
+        userId: testUserId,
+        name: "file.pdf",
+        mediaType: "application/pdf",
+        size: 1024,
+      });
+
+      expect(result).toBe(testFileId);
+      expect(mockCtx.db.insert).toHaveBeenCalledWith(
+        "files",
+        expect.objectContaining({
+          s3_key: "users/test-user-123/file.pdf",
+          user_id: testUserId,
+          size: 1024,
+          file_token_size: 0,
+          is_attached: false,
+        }),
+      );
+      expect(mockFileCountAggregate.insertIfDoesNotExist).toHaveBeenCalledWith(
+        mockCtx,
+        mockFile,
+      );
+    });
   });
 
   describe("getUserStorageUsage", () => {

--- a/convex/__tests__/s3Actions.test.ts
+++ b/convex/__tests__/s3Actions.test.ts
@@ -25,6 +25,7 @@ jest.mock("../_generated/api", () => ({
   internal: {
     fileStorage: {
       getUserStorageUsage: "internal.fileStorage.getUserStorageUsage",
+      createPendingS3File: "internal.fileStorage.createPendingS3File",
     },
   },
 }));
@@ -83,11 +84,13 @@ describe("s3Actions", () => {
           maxBytes: 10 * 1024 * 1024 * 1024, // 10 GB max
           availableBytes: 9 * 1024 * 1024 * 1024, // 9 GB available
         }),
+        runMutation: jest.fn<any>().mockResolvedValue("file_123"),
       };
 
       const result = await generateS3UploadUrlAction.handler(mockCtx, {
         fileName: "test.pdf",
         contentType: "application/pdf",
+        size: 1024,
       });
 
       expect(result).toEqual({
@@ -104,6 +107,17 @@ describe("s3Actions", () => {
         "test.pdf",
         "application/pdf",
         "user123",
+        1024,
+      );
+      expect(mockCtx.runMutation).toHaveBeenCalledWith(
+        "internal.fileStorage.createPendingS3File",
+        {
+          s3Key: "users/user123/123-uuid-test.pdf",
+          userId: "user123",
+          name: "test.pdf",
+          mediaType: "application/pdf",
+          size: 1024,
+        },
       );
 
       expect(mockCheckFileUploadRateLimit).toHaveBeenCalledWith(
@@ -142,6 +156,38 @@ describe("s3Actions", () => {
 
       expect(mockCtx.runQuery).not.toHaveBeenCalled();
       expect(mockCheckFileUploadRateLimit).not.toHaveBeenCalled();
+      expect(mockGenerateS3UploadUrl).not.toHaveBeenCalled();
+    });
+
+    it("should reject missing size before generating an upload URL", async () => {
+      const { generateS3UploadUrl } = await import("../s3Utils");
+      const mockGenerateS3UploadUrl =
+        generateS3UploadUrl as jest.MockedFunction<typeof generateS3UploadUrl>;
+      const { generateS3UploadUrlAction } = await import("../s3Actions");
+
+      const mockCtx: any = {
+        auth: {
+          getUserIdentity: jest.fn<any>().mockResolvedValue({
+            subject: "user123",
+            email: "test@example.com",
+            entitlements: ["pro-plan"],
+          }),
+        },
+        runQuery: jest.fn<any>(),
+        runMutation: jest.fn<any>(),
+      };
+
+      await expect(
+        generateS3UploadUrlAction.handler(mockCtx, {
+          fileName: "test.pdf",
+          contentType: "application/pdf",
+        }),
+      ).rejects.toMatchObject({
+        data: expect.objectContaining({ code: "INVALID_FILE_SIZE" }),
+      });
+
+      expect(mockCtx.runQuery).not.toHaveBeenCalled();
+      expect(mockCtx.runMutation).not.toHaveBeenCalled();
       expect(mockGenerateS3UploadUrl).not.toHaveBeenCalled();
     });
 
@@ -254,12 +300,14 @@ describe("s3Actions", () => {
           maxBytes: 10 * 1024 * 1024 * 1024,
           availableBytes: 9 * 1024 * 1024 * 1024,
         }),
+        runMutation: jest.fn<any>().mockResolvedValue("file_123"),
       };
 
       await expect(
         generateS3UploadUrlAction.handler(mockCtx, {
           fileName: "test.pdf",
           contentType: "application/pdf",
+          size: 1024,
         }),
       ).rejects.toThrow("Failed to generate upload URL");
     });
@@ -305,10 +353,14 @@ describe("s3Actions", () => {
       const { generateS3UploadUrlAction } = await import("../s3Actions");
 
       const testCases = [
-        { fileName: "image.png", contentType: "image/png" },
-        { fileName: "document.pdf", contentType: "application/pdf" },
-        { fileName: "data.csv", contentType: "text/csv" },
-        { fileName: "notes.txt", contentType: "text/plain" },
+        { fileName: "image.png", contentType: "image/png", size: 1024 },
+        {
+          fileName: "document.pdf",
+          contentType: "application/pdf",
+          size: 1024,
+        },
+        { fileName: "data.csv", contentType: "text/csv", size: 1024 },
+        { fileName: "notes.txt", contentType: "text/plain", size: 1024 },
       ];
 
       for (const testCase of testCases) {
@@ -332,6 +384,7 @@ describe("s3Actions", () => {
             maxBytes: 10 * 1024 * 1024 * 1024,
             availableBytes: 9 * 1024 * 1024 * 1024,
           }),
+          runMutation: jest.fn<any>().mockResolvedValue("file_123"),
         };
 
         await generateS3UploadUrlAction.handler(mockCtx, testCase);
@@ -340,6 +393,7 @@ describe("s3Actions", () => {
           testCase.fileName,
           testCase.contentType,
           "user123",
+          testCase.size,
         );
       }
     });
@@ -378,6 +432,7 @@ describe("s3Actions", () => {
         generateS3UploadUrlAction.handler(mockCtx, {
           fileName: "test.pdf",
           contentType: "application/pdf",
+          size: 1024,
         }),
       ).rejects.toThrow("file upload limit");
     });
@@ -410,11 +465,13 @@ describe("s3Actions", () => {
           maxBytes: 10 * 1024 * 1024 * 1024,
           availableBytes: 9 * 1024 * 1024 * 1024,
         }),
+        runMutation: jest.fn<any>().mockResolvedValue("file_123"),
       };
 
       const result = await generateS3UploadUrlAction.handler(mockCtx, {
         fileName: "test.pdf",
         contentType: "application/pdf",
+        size: 1024,
       });
 
       expect(result).toEqual({

--- a/convex/__tests__/s3Utils.test.ts
+++ b/convex/__tests__/s3Utils.test.ts
@@ -85,6 +85,7 @@ describe("s3Utils", () => {
         "test.pdf",
         "application/pdf",
         "user123",
+        1024,
       );
 
       expect(result).toHaveProperty("uploadUrl");
@@ -96,6 +97,25 @@ describe("s3Utils", () => {
       expect(mockGetSignedUrl).toHaveBeenCalled();
     });
 
+    it("should bind expected content length into the PutObject command", async () => {
+      const { PutObjectCommand } = await import("@aws-sdk/client-s3");
+      const { getSignedUrl } = await import("@aws-sdk/s3-request-presigner");
+      const mockGetSignedUrl = getSignedUrl as jest.MockedFunction<
+        typeof getSignedUrl
+      >;
+      mockGetSignedUrl.mockResolvedValue("https://s3.amazonaws.com/signed-url");
+
+      const { generateS3UploadUrl } = await import("../s3Utils");
+
+      await generateS3UploadUrl("test.pdf", "application/pdf", "user123", 1024);
+
+      expect(PutObjectCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ContentLength: 1024,
+        }),
+      );
+    });
+
     it("should use correct expiration time", async () => {
       const { getSignedUrl } = await import("@aws-sdk/s3-request-presigner");
       const mockGetSignedUrl = getSignedUrl as jest.MockedFunction<
@@ -105,7 +125,7 @@ describe("s3Utils", () => {
 
       const { generateS3UploadUrl } = await import("../s3Utils");
 
-      await generateS3UploadUrl("test.pdf", "application/pdf", "user123");
+      await generateS3UploadUrl("test.pdf", "application/pdf", "user123", 1024);
 
       const callArgs = mockGetSignedUrl.mock.calls[0];
       expect(callArgs[2]).toEqual(expect.objectContaining({ expiresIn: 3600 }));

--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -36,7 +36,10 @@ import {
   validateUploadPolicy,
 } from "../lib/utils/upload-policy";
 import { FILE_TOKEN_PERCENT, MAX_TOKENS_PAID } from "../lib/token-utils";
-import { MAX_GENERATED_FILE_SIZE_BYTES } from "../lib/constants/s3";
+import {
+  MAX_GENERATED_FILE_SIZE_BYTES,
+  S3_USER_FILES_PREFIX,
+} from "../lib/constants/s3";
 import {
   hasPaidEntitlement,
   parseEntitlements,
@@ -51,6 +54,9 @@ type FileUploadRateLimitConfig = {
   limit: number;
   window: typeof FILE_UPLOAD_WINDOW;
 };
+
+const isUserScopedS3Key = (s3Key: string, userId: string) =>
+  s3Key.startsWith(`${S3_USER_FILES_PREFIX}/${userId}/`);
 
 const FILE_UPLOAD_RATE_LIMITS: Record<
   FileUploadRateLimitTier,
@@ -751,6 +757,41 @@ export const saveFile = action({
           message: `Failed to upload ${args.name}: File not found in storage`,
         });
       }
+
+      const reservation = await ctx.runQuery(
+        internal.fileStorage.getFileByS3Key,
+        { s3Key: args.s3Key },
+      );
+      if (!reservation) {
+        if (isUserScopedS3Key(args.s3Key, actingUserId)) {
+          await ctx.scheduler.runAfter(
+            0,
+            internal.s3Cleanup.deleteS3ObjectAction,
+            { s3Key: args.s3Key },
+          );
+        }
+        throw new ConvexError({
+          code: "INVALID_UPLOAD_RESERVATION",
+          message: `Failed to upload ${args.name}: Upload reservation not found`,
+        });
+      }
+      if (reservation.user_id !== actingUserId) {
+        throw new ConvexError({
+          code: "UNAUTHORIZED_UPLOAD_RESERVATION",
+          message: `Failed to upload ${args.name}: Upload reservation belongs to another user`,
+        });
+      }
+      if (reservation.size !== verifiedSize) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.s3Cleanup.deleteS3ObjectAction,
+          { s3Key: args.s3Key },
+        );
+        throw new ConvexError({
+          code: "FILE_SIZE_MISMATCH",
+          message: `File "${args.name}" uploaded size does not match the reserved upload size`,
+        });
+      }
     } else if (args.storageId) {
       try {
         const metadata = await ctx.storage.getMetadata(args.storageId);
@@ -1161,6 +1202,7 @@ export const saveSandboxGeneratedFile = action({
         mediaType: args.mediaType,
         size: args.size,
         fileTokenSize: 0,
+        trustedServiceGenerated: true,
       })) as Id<"files">;
 
       return {

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -333,6 +333,85 @@ export const getFileById = internalQuery({
   },
 });
 
+export const getFileByS3Key = internalQuery({
+  args: {
+    s3Key: v.string(),
+  },
+  returns: v.union(
+    v.object({
+      _id: v.id("files"),
+      storage_id: v.optional(v.id("_storage")),
+      s3_key: v.optional(v.string()),
+      user_id: v.string(),
+      name: v.string(),
+      media_type: v.string(),
+      size: v.number(),
+      file_token_size: v.number(),
+      content: v.optional(v.string()),
+      is_attached: v.boolean(),
+      _creationTime: v.number(),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("files")
+      .withIndex("by_s3_key", (q) => q.eq("s3_key", args.s3Key))
+      .unique();
+  },
+});
+
+export const createPendingS3File = internalMutation({
+  args: {
+    s3Key: v.string(),
+    userId: v.string(),
+    name: v.string(),
+    mediaType: v.string(),
+    size: v.number(),
+  },
+  returns: v.id("files"),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("files")
+      .withIndex("by_s3_key", (q) => q.eq("s3_key", args.s3Key))
+      .unique();
+    if (existing) {
+      throw new ConvexError({
+        code: "DUPLICATE_S3_KEY",
+        message: "An upload reservation already exists for this S3 key",
+      });
+    }
+
+    const currentStorageBytes = await fileCountAggregate.sum(ctx, {
+      namespace: args.userId,
+    });
+    if (currentStorageBytes + args.size > MAX_STORAGE_BYTES) {
+      const usedGB = (currentStorageBytes / (1024 * 1024 * 1024)).toFixed(2);
+      throw new ConvexError({
+        code: "STORAGE_LIMIT_EXCEEDED",
+        message: `Storage limit exceeded. You are using ${usedGB} GB of 10 GB.`,
+      });
+    }
+
+    const fileId = await ctx.db.insert("files", {
+      s3_key: args.s3Key,
+      user_id: args.userId,
+      name: args.name,
+      media_type: args.mediaType,
+      size: args.size,
+      file_token_size: 0,
+      is_attached: false,
+    });
+
+    const doc = await ctx.db.get(fileId);
+    if (doc) {
+      await fileCountAggregate.insertIfDoesNotExist(ctx, doc);
+    }
+
+    return fileId;
+  },
+});
+
 /**
  * Internal mutation to save file metadata to database
  * This is separated from the action to handle database operations
@@ -347,9 +426,47 @@ export const saveFileToDb = internalMutation({
     size: v.number(),
     fileTokenSize: v.number(),
     content: v.optional(v.string()),
+    trustedServiceGenerated: v.optional(v.boolean()),
   },
   returns: v.id("files"),
   handler: async (ctx, args) => {
+    if (args.s3Key) {
+      const existing = await ctx.db
+        .query("files")
+        .withIndex("by_s3_key", (q) => q.eq("s3_key", args.s3Key))
+        .unique();
+      if (existing) {
+        if (existing.user_id !== args.userId) {
+          throw new ConvexError({
+            code: "UNAUTHORIZED",
+            message: "Upload reservation does not belong to this user.",
+          });
+        }
+        if (existing.size !== args.size) {
+          throw new ConvexError({
+            code: "FILE_SIZE_MISMATCH",
+            message: "Uploaded file size does not match reserved size.",
+          });
+        }
+
+        await ctx.db.patch(existing._id, {
+          storage_id: args.storageId,
+          name: args.name,
+          media_type: args.mediaType,
+          file_token_size: args.fileTokenSize,
+          content: args.content,
+          is_attached: false,
+        });
+        return existing._id;
+      }
+      if (!args.trustedServiceGenerated) {
+        throw new ConvexError({
+          code: "MISSING_UPLOAD_RESERVATION",
+          message: "S3 uploads must have an existing upload reservation.",
+        });
+      }
+    }
+
     // Check storage limit
     const currentStorageBytes = await fileCountAggregate.sum(ctx, {
       namespace: args.userId,

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -83,20 +83,30 @@ export const generateS3UploadUrlAction = action({
       throw new Error("Invalid contentType: contentType cannot be empty");
     }
 
-    if (args.size !== undefined) {
-      const validation = validateUploadPolicy({
-        mode: args.mode ?? "ask",
-        size: args.size,
-        mediaType: args.contentType,
-        surface: "client",
+    if (
+      args.size === undefined ||
+      !Number.isFinite(args.size) ||
+      args.size <= 0
+    ) {
+      throw new ConvexError({
+        code: "INVALID_FILE_SIZE",
+        message:
+          "A positive file size is required before generating an upload URL",
       });
+    }
 
-      if (!validation.valid) {
-        throw new ConvexError({
-          code: validation.code,
-          message: validation.message,
-        });
-      }
+    const validation = validateUploadPolicy({
+      mode: args.mode ?? "ask",
+      size: args.size,
+      mediaType: args.contentType,
+      surface: "client",
+    });
+
+    if (!validation.valid) {
+      throw new ConvexError({
+        code: validation.code,
+        message: validation.message,
+      });
     }
 
     const userId = identity.subject;
@@ -142,7 +152,16 @@ export const generateS3UploadUrlAction = action({
         args.fileName,
         args.contentType,
         userId,
+        args.size,
       );
+
+      await ctx.runMutation(internal.fileStorage.createPendingS3File, {
+        s3Key,
+        userId,
+        name: args.fileName,
+        mediaType: args.contentType,
+        size: args.size,
+      });
 
       return {
         uploadUrl,
@@ -156,6 +175,9 @@ export const generateS3UploadUrlAction = action({
           : undefined,
       };
     } catch (error) {
+      if (error instanceof ConvexError) {
+        throw error;
+      }
       convexLogger.error("file_upload_url_generation_failed", {
         userId,
         fileName: args.fileName,

--- a/convex/s3Utils.ts
+++ b/convex/s3Utils.ts
@@ -63,6 +63,7 @@ export async function generateS3UploadUrl(
   fileName: string,
   contentType: string,
   userId: string,
+  contentLength?: number,
 ): Promise<{ uploadUrl: string; s3Key: string }> {
   try {
     const s3Client = getS3Client();
@@ -73,6 +74,7 @@ export async function generateS3UploadUrl(
       Bucket: bucketName,
       Key: s3Key,
       ContentType: contentType,
+      ContentLength: contentLength,
     });
 
     const uploadUrl = await getSignedUrl(s3Client, command, {

--- a/lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts
@@ -174,6 +174,7 @@ describe("uploadSandboxFileToConvex", () => {
       "report.txt",
       "application/octet-stream",
       "u1",
+      1234,
     );
     expect(mockConvexAction).toHaveBeenCalledWith(
       expect.anything(),

--- a/lib/ai/tools/utils/sandbox-file-uploader.ts
+++ b/lib/ai/tools/utils/sandbox-file-uploader.ts
@@ -210,6 +210,7 @@ export async function uploadSandboxFileToConvex(args: {
     name,
     mediaType,
     userId,
+    fileSize,
   );
 
   await uploadGeneratedFileFromSandboxToUrl({


### PR DESCRIPTION
## Summary

- Require a positive file size before issuing S3 presigned upload URLs.
- Bind the expected content length into the S3 `PutObject` presign and pass generated artifact sizes through the same utility.
- Create an unattached `files` reservation before returning an S3 upload URL so quota accounting and orphan cleanup cover abandoned direct S3 PUTs.
- Verify S3 save calls against the authenticated user's reservation and actual S3 object size before fetching or processing content.

## Root Cause

The S3 presign flow could previously grant direct bucket write capability before the backend had a database row or size-bound reservation for that object. If the client skipped `saveFile`, cleanup could not discover the object; if the client lied about size, backend processing relied too much on caller-supplied metadata.

## Validation

- `pnpm typecheck`
- `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upload URL requests now require and record file size and create a pending upload reservation; sandbox uploads now send size.

* **Bug Fixes**
  * Enforced positive file-size validation and clearer error codes.
  * Uploads that mismatch reservations or belong to another user are rejected; orphaned S3 objects are scheduled for cleanup when appropriate.
  * Trusted service uploads can finalize without a prior reservation.

* **Tests**
  * Expanded coverage for reservation, size validation, finalization, and cleanup workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->