### PR TITLE
[codex] Remove legacy agent endpoint

### DIFF
--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -1,5 +1,0 @@
-import { createChatHandler } from "@/lib/api/chat-handler";
-
-export const maxDuration = 800;
-
-export const POST = createChatHandler("/api/agent");

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2,4 +2,4 @@ import { createChatHandler } from "@/lib/api/chat-handler";
 
 export const maxDuration = 420;
 
-export const POST = createChatHandler("/api/chat");
+export const POST = createChatHandler();

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -32,7 +32,11 @@ import {
   fetchAgentLongStream,
   resumeAgentLongStream,
 } from "@/lib/chat/agent-long-transport";
-import { shouldUseAgentLongForAgent } from "@/lib/chat/agent-routing";
+import {
+  LEGACY_DESKTOP_AGENT_UPDATE_MESSAGE,
+  isLegacyDesktopAgentClient,
+  shouldUseAgentLongForAgent,
+} from "@/lib/chat/agent-routing";
 import { isTauriEnvironment } from "@/app/hooks/useTauri";
 import { stripAgentLongHeartbeatPartsFromMessages } from "@/lib/chat/agent-long-heartbeat";
 import { toast } from "sonner";
@@ -344,10 +348,17 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       api: "/api/chat",
       fetch: async (input, init) => {
         const mode = chatModeRef.current;
+        const isTauri = isTauriEnvironment();
+        if (isLegacyDesktopAgentClient({ mode, isTauri })) {
+          throw new ChatSDKError(
+            "forbidden:chat",
+            LEGACY_DESKTOP_AGENT_UPDATE_MESSAGE,
+          );
+        }
         const useTriggerAgent = shouldUseAgentLongForAgent({
           mode,
           subscription: subscriptionRef.current,
-          isTauri: isTauriEnvironment(),
+          isTauri,
         });
         if (useTriggerAgent) {
           // useChat reuses this fetch for both POST sendMessages and GET
@@ -375,9 +386,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
             init,
           );
         }
-        const url =
-          input === "/api/chat" && mode === "agent" ? "/api/agent" : input;
-        return fetchWithErrorHandlers(url, init);
+        return fetchWithErrorHandlers(input, init);
       },
       prepareReconnectToStreamRequest: ({ id, api }) => {
         // Use the agent-long resume endpoint when there is a stored trigger run

--- a/e2e/helpers/mock-handlers.ts
+++ b/e2e/helpers/mock-handlers.ts
@@ -34,18 +34,6 @@ export async function setupMocks(
         }),
       });
     });
-
-    // Agent mode: Vercel streaming (same shape as /api/chat)
-    await page.route("**/api/agent", async (route: Route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          message: "This is a mocked Agent response for testing",
-          done: true,
-        }),
-      });
-    });
   }
 
   // Note: WorkOS and Convex are used with real test data

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -120,7 +120,7 @@ describe("captureFreeAgentValueReached", () => {
       posthog: { capture } as any,
       userId: "user_123",
       chatId: "chat_123",
-      endpoint: "/api/agent",
+      endpoint: "/api/agent-long",
       mode: "agent",
       subscription: "free",
       sandboxInfo: { type: "e2b" },
@@ -136,7 +136,7 @@ describe("captureFreeAgentValueReached", () => {
       properties: expect.objectContaining({
         user_id: "user_123",
         chat_id: "chat_123",
-        endpoint: "/api/agent",
+        endpoint: "/api/agent-long",
         mode: "agent",
         subscription: "free",
         subscription_tier: "free",
@@ -161,7 +161,7 @@ describe("captureFreeAgentValueReached", () => {
       posthog: { capture } as any,
       userId: "user_123",
       chatId: "chat_123",
-      endpoint: "/api/agent" as const,
+      endpoint: "/api/agent-long" as const,
       mode: "agent" as const,
       subscription: "free",
       sandboxInfo: { type: "e2b" },
@@ -198,7 +198,7 @@ describe("captureAgentCompletionAnalytics", () => {
       posthog: { capture } as any,
       userId: "user_123",
       chatId: "chat_123",
-      endpoint: "/api/agent",
+      endpoint: "/api/agent-long",
       mode: "agent",
       subscription: "free",
       sandboxInfo: { type: "e2b" },
@@ -223,7 +223,7 @@ describe("captureAgentCompletionAnalytics", () => {
       properties: expect.objectContaining({
         user_id: "user_123",
         chat_id: "chat_123",
-        endpoint: "/api/agent",
+        endpoint: "/api/agent-long",
         subscription_tier: "free",
         outcome: "success",
         tool_call_count: 1,
@@ -238,7 +238,7 @@ describe("captureAgentCompletionAnalytics", () => {
       posthog: { capture } as any,
       userId: "user_123",
       chatId: "chat_123",
-      endpoint: "/api/agent",
+      endpoint: "/api/agent-long",
       mode: "agent",
       subscription: "pro",
       sandboxInfo: { type: "e2b" },
@@ -327,7 +327,7 @@ describe("createChatLogger provider stream termination", () => {
     try {
       const chatLogger = createChatLogger({
         chatId: "chat_terminated",
-        endpoint: "/api/agent",
+        endpoint: "/api/agent-long",
       });
       const err = Object.assign(new TypeError("terminated"), {
         cause: "other side closed",
@@ -365,7 +365,7 @@ describe("createChatLogger ChatSDKError metadata", () => {
     try {
       const chatLogger = createChatLogger({
         chatId: "chat_missing",
-        endpoint: "/api/agent",
+        endpoint: "/api/agent-long",
       });
       const err = new ChatSDKError(
         "not_found:chat",
@@ -427,7 +427,7 @@ describe("createChatLogger provider stream timeout", () => {
     try {
       const chatLogger = createChatLogger({
         chatId: "chat_timeout",
-        endpoint: "/api/agent",
+        endpoint: "/api/agent-long",
       });
       const err = {
         code: 502,
@@ -468,7 +468,7 @@ describe("createChatLogger provider stream timeout", () => {
     try {
       const chatLogger = createChatLogger({
         chatId: "chat_provider_code",
-        endpoint: "/api/agent",
+        endpoint: "/api/agent-long",
       });
       const err = {
         message: "Provider request failed",

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -1,7 +1,7 @@
 /**
  * Shared streamText factory for the agent loop.
  *
- * Both /api/agent (chat-handler.ts) and the trigger.dev agent-long task
+ * Both the Next.js chat handler and the trigger.dev agent-long task
  * run the same multi-step tool loop. This module owns the single canonical
  * implementation of that loop — prepareStep, stopWhen, onChunk, onStepFinish,
  * streamText.onFinish, onError, onAbort — so divergence is impossible.

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -123,10 +123,9 @@ function getStreamContext() {
 
 export { getStreamContext };
 
-export const createChatHandler = (
-  endpoint: "/api/chat" | "/api/agent" = "/api/chat",
-) => {
+export const createChatHandler = () => {
   return async (req: NextRequest) => {
+    const endpoint = "/api/chat" as const;
     let preemptiveTimeout:
       | ReturnType<typeof createPreemptiveTimeout>
       | undefined;

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -33,7 +33,7 @@ import {
 
 export interface ChatLoggerConfig {
   chatId: string;
-  endpoint: "/api/chat" | "/api/agent";
+  endpoint: "/api/chat" | "/api/agent-long";
 }
 
 export interface RequestDetails {
@@ -584,7 +584,7 @@ type AgentCompletionAnalyticsArgs = {
   posthog: PostHog | null;
   userId: string;
   chatId: string;
-  endpoint: "/api/chat" | "/api/agent";
+  endpoint: "/api/chat" | "/api/agent-long";
   mode: ChatMode;
   subscription: string;
   sandboxInfo: SandboxInfo | null;
@@ -634,7 +634,7 @@ export function captureFreeAgentValueReached({
   posthog: PostHog | null;
   userId: string;
   chatId: string;
-  endpoint: "/api/chat" | "/api/agent";
+  endpoint: "/api/chat" | "/api/agent-long";
   mode: ChatMode;
   subscription: string;
   sandboxInfo: SandboxInfo | null;
@@ -707,7 +707,7 @@ export function captureUsageCost({
   subscription: string;
   organizationId?: string;
   chatId: string;
-  endpoint: "/api/chat" | "/api/agent";
+  endpoint: "/api/chat" | "/api/agent-long";
   mode: ChatMode;
   usage: UsageCostRecord;
 }) {

--- a/lib/chat/__tests__/agent-routing.test.ts
+++ b/lib/chat/__tests__/agent-routing.test.ts
@@ -1,4 +1,5 @@
 import {
+  isLegacyDesktopAgentClient,
   isHackerAIDesktopUserAgent,
   shouldUseAgentLongForAgent,
 } from "../agent-routing";
@@ -25,7 +26,7 @@ describe("agent routing", () => {
     ).toBe(true);
   });
 
-  test("keeps the existing web and free-user Trigger.dev routing", () => {
+  test("routes web and current desktop free-user agent mode through Trigger.dev", () => {
     expect(
       shouldUseAgentLongForAgent({
         mode: "agent",
@@ -39,11 +40,12 @@ describe("agent routing", () => {
         mode: "agent",
         subscription: "free",
         isTauri: true,
+        userAgent: DESKTOP_UA,
       }),
     ).toBe(true);
   });
 
-  test("does not route non-agent modes or legacy desktop user agents through agent-long", () => {
+  test("does not route non-agent modes through agent-long", () => {
     expect(
       shouldUseAgentLongForAgent({
         mode: "ask",
@@ -52,13 +54,23 @@ describe("agent routing", () => {
         userAgent: DESKTOP_UA,
       }),
     ).toBe(false);
+  });
 
+  test("blocks legacy desktop user agents from agent mode until they update", () => {
+    const legacyUserAgent = "Mozilla/5.0 Safari/605.1.15";
+    expect(
+      isLegacyDesktopAgentClient({
+        mode: "agent",
+        isTauri: true,
+        userAgent: legacyUserAgent,
+      }),
+    ).toBe(true);
     expect(
       shouldUseAgentLongForAgent({
         mode: "agent",
         subscription: "pro",
         isTauri: true,
-        userAgent: "Mozilla/5.0 Safari/605.1.15",
+        userAgent: legacyUserAgent,
       }),
     ).toBe(false);
   });

--- a/lib/chat/agent-routing.ts
+++ b/lib/chat/agent-routing.ts
@@ -2,15 +2,29 @@ import type { ChatMode } from "@/types";
 
 const HACKERAI_DESKTOP_USER_AGENT_TOKEN = "HackerAI-Desktop";
 
+export const LEGACY_DESKTOP_AGENT_UPDATE_MESSAGE =
+  "Agent mode now requires the latest HackerAI Desktop app. Please update HackerAI Desktop, then try again.";
+
 export function isHackerAIDesktopUserAgent(
   userAgent: string | null | undefined = getBrowserUserAgent(),
 ): boolean {
   return userAgent?.includes(HACKERAI_DESKTOP_USER_AGENT_TOKEN) ?? false;
 }
 
+export function isLegacyDesktopAgentClient({
+  mode,
+  isTauri,
+  userAgent,
+}: {
+  mode: ChatMode | string;
+  isTauri: boolean;
+  userAgent?: string | null;
+}): boolean {
+  return mode === "agent" && isTauri && !isHackerAIDesktopUserAgent(userAgent);
+}
+
 export function shouldUseAgentLongForAgent({
   mode,
-  subscription,
   isTauri,
   userAgent,
 }: {
@@ -21,11 +35,7 @@ export function shouldUseAgentLongForAgent({
 }): boolean {
   if (mode !== "agent") return false;
 
-  if (isHackerAIDesktopUserAgent(userAgent)) {
-    return true;
-  }
-
-  return !isTauri || subscription === "free";
+  return !isLegacyDesktopAgentClient({ mode, isTauri, userAgent });
 }
 
 function getBrowserUserAgent(): string {

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -21,7 +21,7 @@ export interface ChatWideEvent {
 
   // Service context
   service: "chat-handler";
-  endpoint: "/api/chat" | "/api/agent";
+  endpoint: "/api/chat" | "/api/agent-long";
   version: string;
   region?: string;
 
@@ -204,7 +204,7 @@ export class WideEventBuilder {
   constructor(
     requestId: string,
     chatId: string,
-    endpoint: "/api/chat" | "/api/agent",
+    endpoint: "/api/chat" | "/api/agent-long",
   ) {
     this.event = {
       timestamp: new Date().toISOString(),
@@ -689,7 +689,7 @@ export const logger = {
  */
 export function createWideEventBuilder(
   chatId: string,
-  endpoint: "/api/chat" | "/api/agent",
+  endpoint: "/api/chat" | "/api/agent-long",
 ): WideEventBuilder {
   const requestId = `req_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
   return new WideEventBuilder(requestId, chatId, endpoint);

--- a/lib/utils/stream-cancellation.ts
+++ b/lib/utils/stream-cancellation.ts
@@ -20,7 +20,7 @@ type PollOptions = {
   pollIntervalMs?: number;
 };
 
-type ApiEndpoint = "/api/chat" | "/api/agent" | "/api/chat/[id]/stream";
+type ApiEndpoint = "/api/chat" | "/api/chat/[id]/stream";
 
 type PreemptiveTimeoutOptions = {
   chatId: string;

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -632,7 +632,7 @@ export const agentLongTask = task({
 
     let chatLogger: ChatLogger | undefined = createChatLogger({
       chatId,
-      endpoint: "/api/agent",
+      endpoint: "/api/agent-long",
     });
     chatLogger.setRequestDetails({
       mode,
@@ -1078,7 +1078,7 @@ export const agentLongTask = task({
                   subscription,
                   organizationId,
                   chatId,
-                  endpoint: "/api/agent",
+                  endpoint: "/api/agent-long",
                   mode,
                   usage: usageCostRecord,
                 });
@@ -1282,7 +1282,7 @@ export const agentLongTask = task({
                                     posthog,
                                     userId,
                                     chatId,
-                                    endpoint: "/api/agent",
+                                    endpoint: "/api/agent-long",
                                     mode,
                                     subscription,
                                     sandboxInfo,
@@ -1406,7 +1406,7 @@ export const agentLongTask = task({
                         posthog,
                         userId,
                         chatId,
-                        endpoint: "/api/agent",
+                        endpoint: "/api/agent-long",
                         mode,
                         subscription,
                         sandboxInfo,


### PR DESCRIPTION
## Summary

- Remove the legacy `/api/agent` Next.js endpoint.
- Route Agent mode exclusively through the Trigger.dev `/api/agent-long` path.
- Detect legacy desktop clients that lack the `HackerAI-Desktop` user-agent token and show an update-required error instead of serving the old non-durable path.
- Update logging, analytics endpoint labels, tests, and e2e mocks to reflect `/api/agent-long`.

## Why

Agent execution has moved to Trigger.dev. Keeping `/api/agent` around preserved a stale Vercel-backed fallback for legacy desktop clients, which could provide a worse service path instead of asking users to update.

## Validation

- `pnpm test -- lib/chat/__tests__/agent-routing.test.ts lib/api/__tests__/chat-logger.test.ts lib/api/__tests__/agent-long-contracts.test.ts`
- `pnpm typecheck`
- Pre-commit hook also ran prettier, eslint, typecheck, and the full Jest suite: 101 suites / 1212 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user guidance messaging to help HackerAI Desktop app users update to the latest version for agent mode support.
  * Improved agent routing logic for better compatibility and performance.

* **Bug Fixes**
  * Blocked legacy desktop clients from accessing agent features, with clear error messaging to guide users toward supported versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->