### PR TITLE
[codex] Fix PentestGPT migration org deletion

### DIFF
--- a/app/api/migrate-pentestgpt/__tests__/route.test.ts
+++ b/app/api/migrate-pentestgpt/__tests__/route.test.ts
@@ -1,0 +1,263 @@
+import { POST } from "../route";
+import { getUserIDAndPro } from "@/lib/auth/get-user-id";
+import { stripe } from "../../stripe";
+import { workos } from "../../workos";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("@/lib/auth/get-user-id", () => ({
+  getUserIDAndPro: jest.fn(),
+}));
+
+jest.mock("../../stripe", () => ({
+  stripe: {
+    customers: {
+      list: jest.fn(),
+      update: jest.fn(),
+    },
+    paymentMethods: {
+      retrieve: jest.fn(),
+      attach: jest.fn(),
+    },
+    prices: {
+      list: jest.fn(),
+      retrieve: jest.fn(),
+    },
+    subscriptions: {
+      list: jest.fn(),
+      create: jest.fn(),
+      cancel: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../workos", () => ({
+  workos: {
+    userManagement: {
+      getUser: jest.fn(),
+      listOrganizationMemberships: jest.fn(),
+      createOrganizationMembership: jest.fn(),
+    },
+    organizations: {
+      createOrganization: jest.fn(),
+      updateOrganization: jest.fn(),
+      deleteOrganization: jest.fn(),
+    },
+  },
+}));
+
+const mockGetUserIDAndPro = getUserIDAndPro as jest.MockedFunction<
+  typeof getUserIDAndPro
+>;
+const mockGetUser = workos.userManagement.getUser as jest.MockedFunction<
+  typeof workos.userManagement.getUser
+>;
+const mockListOrganizationMemberships = workos.userManagement
+  .listOrganizationMemberships as jest.MockedFunction<
+  typeof workos.userManagement.listOrganizationMemberships
+>;
+const mockCreateOrganizationMembership = workos.userManagement
+  .createOrganizationMembership as jest.MockedFunction<
+  typeof workos.userManagement.createOrganizationMembership
+>;
+const mockCreateOrganization = workos.organizations
+  .createOrganization as jest.MockedFunction<
+  typeof workos.organizations.createOrganization
+>;
+const mockUpdateOrganization = workos.organizations
+  .updateOrganization as jest.MockedFunction<
+  typeof workos.organizations.updateOrganization
+>;
+const mockDeleteOrganization = workos.organizations
+  .deleteOrganization as jest.MockedFunction<
+  typeof workos.organizations.deleteOrganization
+>;
+const mockListCustomers = stripe.customers.list as jest.MockedFunction<
+  typeof stripe.customers.list
+>;
+const mockUpdateCustomer = stripe.customers.update as jest.MockedFunction<
+  typeof stripe.customers.update
+>;
+const mockRetrievePaymentMethod = stripe.paymentMethods
+  .retrieve as jest.MockedFunction<typeof stripe.paymentMethods.retrieve>;
+const mockListPrices = stripe.prices.list as jest.MockedFunction<
+  typeof stripe.prices.list
+>;
+const mockRetrievePrice = stripe.prices.retrieve as jest.MockedFunction<
+  typeof stripe.prices.retrieve
+>;
+const mockListSubscriptions = stripe.subscriptions.list as jest.MockedFunction<
+  typeof stripe.subscriptions.list
+>;
+const mockCreateSubscription = stripe.subscriptions
+  .create as jest.MockedFunction<typeof stripe.subscriptions.create>;
+const mockCancelSubscription = stripe.subscriptions
+  .cancel as jest.MockedFunction<typeof stripe.subscriptions.cancel>;
+
+const request = () => ({ url: "https://hackerai.test/api/migrate-pentestgpt" });
+
+describe("POST /api/migrate-pentestgpt", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetUserIDAndPro.mockResolvedValue({
+      userId: "user_123",
+      subscription: "free",
+    });
+    mockGetUser.mockResolvedValue({
+      id: "user_123",
+      email: "user@example.com",
+      firstName: "Ada",
+      lastName: "Lovelace",
+    } as never);
+    mockListCustomers.mockResolvedValue({
+      data: [
+        {
+          id: "cus_legacy",
+          metadata: {},
+          invoice_settings: {},
+        },
+      ],
+    } as never);
+    mockListSubscriptions.mockResolvedValue({
+      data: [
+        {
+          id: "sub_legacy",
+          default_payment_method: "pm_legacy",
+          items: {
+            data: [
+              {
+                quantity: 1,
+                current_period_end: 4_102_444_800,
+                price: {
+                  id: "price_legacy",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } as never);
+    mockRetrievePrice.mockResolvedValue({
+      id: "price_legacy",
+      metadata: {},
+      product: {
+        id: "prod_legacy",
+        name: "PentestGPT Pro",
+        metadata: {},
+        deleted: false,
+      },
+      recurring: {
+        interval: "month",
+      },
+    } as never);
+    mockListPrices.mockResolvedValue({
+      data: [
+        {
+          id: "price_destination",
+        },
+      ],
+    } as never);
+    mockRetrievePaymentMethod.mockResolvedValue({
+      id: "pm_legacy",
+      customer: "cus_legacy",
+    } as never);
+    mockCreateOrganization.mockResolvedValue({
+      id: "org_new",
+    } as never);
+    mockCreateOrganizationMembership.mockResolvedValue({} as never);
+    mockUpdateCustomer.mockResolvedValue({} as never);
+    mockUpdateOrganization.mockResolvedValue({} as never);
+    mockCreateSubscription.mockResolvedValue({ id: "sub_new" } as never);
+    mockCancelSubscription.mockResolvedValue({ id: "sub_legacy" } as never);
+  });
+
+  it("does not enumerate or delete existing WorkOS organizations", async () => {
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, showTeamWelcome: false });
+    expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
+    expect(mockDeleteOrganization).not.toHaveBeenCalled();
+    expect(mockCreateOrganization).toHaveBeenCalledWith({
+      name: "Ada Lovelace",
+    });
+    expect(mockCreateSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: "cus_legacy",
+        items: [{ price: "price_destination", quantity: 1 }],
+      }),
+    );
+  });
+
+  it("does not create or delete WorkOS organizations when destination price is missing", async () => {
+    mockListPrices.mockResolvedValueOnce({ data: [] } as never);
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toEqual({ error: "Destination subscription price not found" });
+    expect(mockCreateOrganization).not.toHaveBeenCalled();
+    expect(mockCreateOrganizationMembership).not.toHaveBeenCalled();
+    expect(mockUpdateOrganization).not.toHaveBeenCalled();
+    expect(mockDeleteOrganization).not.toHaveBeenCalled();
+    expect(mockUpdateCustomer).not.toHaveBeenCalled();
+    expect(mockCreateSubscription).not.toHaveBeenCalled();
+    expect(mockCancelSubscription).not.toHaveBeenCalled();
+  });
+
+  it("does not create or delete WorkOS organizations when no reusable payment method exists", async () => {
+    mockListCustomers.mockResolvedValueOnce({
+      data: [
+        {
+          id: "cus_legacy",
+          metadata: {},
+          invoice_settings: {},
+        },
+      ],
+    } as never);
+    mockListSubscriptions.mockResolvedValueOnce({
+      data: [
+        {
+          id: "sub_legacy",
+          items: {
+            data: [
+              {
+                quantity: 1,
+                current_period_end: 4_102_444_800,
+                price: {
+                  id: "price_legacy",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } as never);
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      error:
+        "No reusable payment method found on legacy subscription or customer",
+    });
+    expect(mockCreateOrganization).not.toHaveBeenCalled();
+    expect(mockCreateOrganizationMembership).not.toHaveBeenCalled();
+    expect(mockUpdateOrganization).not.toHaveBeenCalled();
+    expect(mockDeleteOrganization).not.toHaveBeenCalled();
+    expect(mockUpdateCustomer).not.toHaveBeenCalled();
+    expect(mockCreateSubscription).not.toHaveBeenCalled();
+    expect(mockCancelSubscription).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/migrate-pentestgpt/route.ts
+++ b/app/api/migrate-pentestgpt/route.ts
@@ -115,68 +115,6 @@ export const POST = async (req: NextRequest) => {
       }
     }
 
-    // Check if user has existing organizations
-    const existingMemberships =
-      await workos.userManagement.listOrganizationMemberships({
-        userId,
-      });
-
-    // Delete existing organizations where the user is an admin, regardless of Stripe customer
-    if (existingMemberships.data && existingMemberships.data.length > 0) {
-      for (const membership of existingMemberships.data) {
-        const orgId = membership.organizationId;
-
-        // Determine if the user is an active admin in this organization
-        const roleObjSlug: string | undefined = (membership as any)?.role?.slug;
-        const rolesArr: Array<{ slug?: string }> | undefined = (
-          membership as any
-        )?.roles;
-        const hasAdminInRoles = Array.isArray(rolesArr)
-          ? rolesArr.some((r) => r?.slug === "admin")
-          : false;
-        const isActive = (membership as any)?.status === "active";
-        const isAdmin =
-          (roleObjSlug === "admin" || hasAdminInRoles) && isActive;
-
-        if (!isAdmin) {
-          continue;
-        }
-
-        try {
-          await workos.organizations.deleteOrganization(orgId);
-        } catch (error) {
-          console.error(`Failed to delete organization ${orgId}:`, error);
-        }
-      }
-    }
-
-    // Create new organization with a WorkOS-safe display name.
-    const organization = await workos.organizations.createOrganization({
-      name: buildWorkOSOrganizationName(user),
-    });
-
-    // Create organization membership for user as admin
-    await workos.userManagement.createOrganizationMembership({
-      organizationId: organization.id,
-      userId,
-      roleSlug: "admin",
-    });
-
-    // Update Stripe customer metadata to link to new WorkOS organization
-    await stripe.customers.update(pentestGPTCustomer.id, {
-      metadata: {
-        workOSOrganizationId: organization.id,
-        source: "pentestgpt-migrated",
-      },
-    });
-
-    // Update WorkOS organization with Stripe customer ID
-    // This will allow WorkOS to automatically add entitlements to the access token
-    await workos.organizations.updateOrganization({
-      organization: organization.id,
-      stripeCustomerId: pentestGPTCustomer.id,
-    });
-
     // Create new subscription on the linked customer with matching plan and interval
     const allowedPlans = new Set([
       "pro-monthly-plan",
@@ -214,6 +152,61 @@ export const POST = async (req: NextRequest) => {
 
     const destinationPriceId = destinationPrices.data[0].id;
 
+    const legacySub: any = pentestGPTSubscription;
+    let paymentMethodId: string | undefined;
+    let defaultSourceId: string | undefined;
+
+    // Prefer explicit default on legacy subscription
+    if (typeof legacySub.default_payment_method === "string") {
+      paymentMethodId = legacySub.default_payment_method as string;
+    } else if (legacySub.default_payment_method?.id) {
+      paymentMethodId = legacySub.default_payment_method.id as string;
+    }
+
+    // Fallback to latest invoice's payment intent method
+    if (!paymentMethodId) {
+      const maybePM = legacySub?.latest_invoice?.payment_intent?.payment_method;
+      if (typeof maybePM === "string") {
+        paymentMethodId = maybePM as string;
+      } else if (maybePM?.id) {
+        paymentMethodId = maybePM.id as string;
+      }
+    }
+
+    // Fallback to customer's default payment method
+    if (!paymentMethodId) {
+      const custDefaultPm = (pentestGPTCustomer as any)?.invoice_settings
+        ?.default_payment_method;
+      if (typeof custDefaultPm === "string") {
+        paymentMethodId = custDefaultPm as string;
+      } else if (custDefaultPm?.id) {
+        paymentMethodId = custDefaultPm.id as string;
+      }
+    }
+
+    // Last resort: legacy default source (for older sources)
+    if (!paymentMethodId) {
+      const custDefaultSource = (pentestGPTCustomer as any)?.default_source;
+      if (typeof custDefaultSource === "string") {
+        defaultSourceId = custDefaultSource as string;
+      } else if (custDefaultSource?.id) {
+        defaultSourceId = custDefaultSource.id as string;
+      }
+    }
+
+    if (!paymentMethodId && !defaultSourceId) {
+      console.error(
+        "No reusable payment method found on legacy subscription or customer",
+      );
+      return NextResponse.json(
+        {
+          error:
+            "No reusable payment method found on legacy subscription or customer",
+        },
+        { status: 400 },
+      );
+    }
+
     // Compute optional trial_end based on remaining time on the old subscription
     const nowInSeconds = Math.floor(Date.now() / 1000);
     // Compute trial end using the legacy subscription's period end. Prefer the maximum
@@ -243,64 +236,36 @@ export const POST = async (req: NextRequest) => {
         ? oldCurrentPeriodEnd
         : undefined;
 
+    // Create new organization with a WorkOS-safe display name only after all
+    // migration prerequisites have been validated.
+    const organization = await workos.organizations.createOrganization({
+      name: buildWorkOSOrganizationName(user),
+    });
+
+    // Create organization membership for user as admin
+    await workos.userManagement.createOrganizationMembership({
+      organizationId: organization.id,
+      userId,
+      roleSlug: "admin",
+    });
+
+    // Update Stripe customer metadata to link to new WorkOS organization
+    await stripe.customers.update(pentestGPTCustomer.id, {
+      metadata: {
+        workOSOrganizationId: organization.id,
+        source: "pentestgpt-migrated",
+      },
+    });
+
+    // Update WorkOS organization with Stripe customer ID
+    // This will allow WorkOS to automatically add entitlements to the access token
+    await workos.organizations.updateOrganization({
+      organization: organization.id,
+      stripeCustomerId: pentestGPTCustomer.id,
+    });
+
     // Always reuse the old subscription's payment method for the new subscription
     try {
-      const legacySub: any = pentestGPTSubscription;
-      let paymentMethodId: string | undefined;
-      let defaultSourceId: string | undefined;
-
-      // Prefer explicit default on legacy subscription
-      if (typeof legacySub.default_payment_method === "string") {
-        paymentMethodId = legacySub.default_payment_method as string;
-      } else if (legacySub.default_payment_method?.id) {
-        paymentMethodId = legacySub.default_payment_method.id as string;
-      }
-
-      // Fallback to latest invoice's payment intent method
-      if (!paymentMethodId) {
-        const maybePM =
-          legacySub?.latest_invoice?.payment_intent?.payment_method;
-        if (typeof maybePM === "string") {
-          paymentMethodId = maybePM as string;
-        } else if (maybePM?.id) {
-          paymentMethodId = maybePM.id as string;
-        }
-      }
-
-      // Fallback to customer's default payment method
-      if (!paymentMethodId) {
-        const custDefaultPm = (pentestGPTCustomer as any)?.invoice_settings
-          ?.default_payment_method;
-        if (typeof custDefaultPm === "string") {
-          paymentMethodId = custDefaultPm as string;
-        } else if (custDefaultPm?.id) {
-          paymentMethodId = custDefaultPm.id as string;
-        }
-      }
-
-      // Last resort: legacy default source (for older sources)
-      if (!paymentMethodId) {
-        const custDefaultSource = (pentestGPTCustomer as any)?.default_source;
-        if (typeof custDefaultSource === "string") {
-          defaultSourceId = custDefaultSource as string;
-        } else if (custDefaultSource?.id) {
-          defaultSourceId = custDefaultSource.id as string;
-        }
-      }
-
-      if (!paymentMethodId && !defaultSourceId) {
-        console.error(
-          "No reusable payment method found on legacy subscription or customer",
-        );
-        return NextResponse.json(
-          {
-            error:
-              "No reusable payment method found on legacy subscription or customer",
-          },
-          { status: 400 },
-        );
-      }
-
       // Ensure the payment method is attached to the destination customer
       if (paymentMethodId) {
         try {


### PR DESCRIPTION
## Summary

Fixes the PentestGPT migration route so it no longer enumerates and deletes every active-admin WorkOS organization for the migrating user.

## Root cause

The migration endpoint found legacy eligibility by email, then cleaned up all active admin WorkOS memberships before destination Stripe validation. That made unrelated shared organizations deletable with server-side WorkOS privileges, and deletion could happen even when the migration later failed.

## Changes

- Removed the broad `listOrganizationMemberships` / `deleteOrganization` cleanup from `/api/migrate-pentestgpt`.
- Moved destination price and reusable payment-method validation before WorkOS organization creation or customer/org linking.
- Added route tests covering no existing-org enumeration/deletion and no WorkOS writes when destination price or payment method validation fails.

## Validation

- `pnpm test -- app/api/migrate-pentestgpt/__tests__/route.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint app/api/migrate-pentestgpt/route.ts app/api/migrate-pentestgpt/__tests__/route.test.ts`
- Full pre-commit hook: `tsc --noEmit` and `jest` (102 suites, 1214 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for subscription migrations to validate successful transfers and error handling.

* **Refactor**
  * Improved subscription migration with better payment method handling and clearer error messages for common failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->