### PR TITLE
[codex] Fix message update ownership check

### DIFF
--- a/convex/__tests__/messages.hidden.test.ts
+++ b/convex/__tests__/messages.hidden.test.ts
@@ -147,6 +147,42 @@ describe("saveMessage — is_hidden handling", () => {
     );
   });
 
+  it("rejects hiding an existing message owned by another chat or user", async () => {
+    const existing = makeMessage({
+      _id: "victim-doc" as Id<"messages">,
+      id: "victim-message-id",
+      chat_id: "victim-chat",
+      user_id: "victim-user",
+      is_hidden: false,
+    });
+    setupExistingMessage(existing);
+
+    const { saveMessage } = await import("../messages");
+
+    await expect(
+      saveMessage.handler(mockCtx, {
+        serviceKey: SERVICE_KEY,
+        id: "victim-message-id",
+        chatId: CHAT_ID,
+        userId: USER_ID,
+        role: "user" as const,
+        parts: [{ type: "text", text: "continue" }],
+        isHidden: true,
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({
+        code: "MESSAGE_SAVE_FAILED",
+        failureStage: "verify_existing_message_ownership",
+        causeData: expect.objectContaining({
+          code: "MESSAGE_UNAUTHORIZED",
+        }),
+      }),
+    });
+
+    expect(mockCtx.db.patch).not.toHaveBeenCalled();
+    expect(mockCtx.runQuery).not.toHaveBeenCalled();
+  });
+
   it("should not include is_hidden: true on insert when isHidden is not provided", async () => {
     setupExistingMessage(null);
 

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -306,6 +306,17 @@ export const saveMessage = mutation({
         .first();
 
       if (existingMessage) {
+        if (
+          existingMessage.chat_id !== args.chatId ||
+          existingMessage.user_id !== args.userId
+        ) {
+          failureStage = "verify_existing_message_ownership";
+          throw new ConvexError({
+            code: "MESSAGE_UNAUTHORIZED",
+            message: "You don't have permission to update this message",
+          });
+        }
+
         // Build patch for fields that need updating
         const patch: Record<string, unknown> = {};
 


### PR DESCRIPTION
## Summary

Fixes an authorization gap in `messages.saveMessage` where an existing message was looked up by global message id and patched before verifying it belonged to the supplied chat and user.

## Root Cause

The existing-message update path returned early after applying patch fields such as `is_hidden`, while the chat ownership check only ran for new inserts. A crafted request could therefore target a known message id owned by another chat/user and hide or otherwise patch that row.

## Changes

- Require existing messages to match both `args.chatId` and `args.userId` before applying any patch.
- Add a regression test proving a cross-tenant `isHidden` update is rejected and no patch is written.

## Validation

- `pnpm test convex/__tests__/messages.hidden.test.ts --runInBand`
- `pnpm typecheck`
- Commit hook: Prettier, ESLint, `pnpm typecheck`, full `pnpm test` (101 suites, 1212 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened message security by preventing users from modifying messages that belong to other users or different chats. Unauthorized modification attempts are now properly rejected.

* **Tests**
  * Added comprehensive test coverage to verify that message ownership validation works correctly and rejects unauthorized modification attempts as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->