### PR TITLE
[codex] Bind desktop auth callbacks to local state

### DIFF
--- a/app/api/auth/desktop-callback/route.ts
+++ b/app/api/auth/desktop-callback/route.ts
@@ -6,6 +6,8 @@ import {
 } from "@/lib/desktop-auth";
 import { workos } from "@/app/api/workos";
 
+const DESKTOP_AUTH_STATE_REGEX = /^[a-f0-9]{64}$/;
+
 type DesktopAuthSession = {
   accessToken: string;
   refreshToken: string;
@@ -62,6 +64,20 @@ export async function GET(request: NextRequest) {
     console.warn("[Desktop Auth] Invalid or expired OAuth state");
     return new Response(
       renderErrorPage("Authentication session expired. Please try again."),
+      {
+        status: 400,
+        headers: noStoreHeaders,
+      },
+    );
+  }
+
+  if (
+    !stateMetadata?.desktopAuthState ||
+    !DESKTOP_AUTH_STATE_REGEX.test(stateMetadata.desktopAuthState)
+  ) {
+    console.warn("[Desktop Auth] Missing desktop auth state metadata");
+    return new Response(
+      renderErrorPage("Invalid authentication request. Please try again."),
       {
         status: 400,
         headers: noStoreHeaders,
@@ -142,6 +158,7 @@ export async function GET(request: NextRequest) {
 
     const transferToken = await createDesktopTransferToken(sealedSession, {
       returnPath: stateMetadata?.returnPath,
+      desktopAuthState: stateMetadata.desktopAuthState,
     });
 
     if (!transferToken) {
@@ -158,14 +175,14 @@ export async function GET(request: NextRequest) {
 
     // In dev mode, redirect to local HTTP server instead of deep link
     if (stateMetadata?.devCallbackPort) {
-      const devCallbackUrl = `http://localhost:${stateMetadata.devCallbackPort}/auth-callback?token=${encodeURIComponent(transferToken)}&origin=${encodeURIComponent(origin)}`;
+      const devCallbackUrl = `http://localhost:${stateMetadata.devCallbackPort}/auth-callback?token=${encodeURIComponent(transferToken)}&origin=${encodeURIComponent(origin)}&desktop_state=${encodeURIComponent(stateMetadata.desktopAuthState)}`;
       return new Response(renderSuccessPage(devCallbackUrl), {
         status: 200,
         headers: noStoreHeaders,
       });
     }
 
-    const deepLinkUrl = `hackerai://auth?token=${encodeURIComponent(transferToken)}&origin=${encodeURIComponent(origin)}`;
+    const deepLinkUrl = `hackerai://auth?token=${encodeURIComponent(transferToken)}&origin=${encodeURIComponent(origin)}&desktop_state=${encodeURIComponent(stateMetadata.desktopAuthState)}`;
     return new Response(renderSuccessPage(deepLinkUrl), {
       status: 200,
       headers: noStoreHeaders,

--- a/app/desktop-callback/route.ts
+++ b/app/desktop-callback/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { exchangeDesktopTransferToken } from "@/lib/desktop-auth";
 
+const DESKTOP_AUTH_STATE_REGEX = /^[a-f0-9]{64}$/;
+
 function getCookieMaxAge(): number {
   const envMaxAge = process.env.WORKOS_COOKIE_MAX_AGE;
   if (envMaxAge) {
@@ -110,6 +112,7 @@ function renderErrorPage(
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const token = url.searchParams.get("token");
+  const desktopAuthState = url.searchParams.get("desktop_state");
   const error = url.searchParams.get("error");
   const retryUrl = `${url.origin}/desktop-login`;
 
@@ -141,7 +144,24 @@ export async function GET(request: Request) {
     );
   }
 
-  const sessionData = await exchangeDesktopTransferToken(token);
+  if (
+    typeof desktopAuthState !== "string" ||
+    !DESKTOP_AUTH_STATE_REGEX.test(desktopAuthState)
+  ) {
+    console.warn("[Desktop Callback] Missing or invalid desktop auth state");
+    return new Response(
+      renderErrorPage(
+        "Authentication Error",
+        "This sign-in request was not started from this desktop app. Please try signing in again.",
+        retryUrl,
+      ),
+      { status: 400, headers: noStoreHeaders },
+    );
+  }
+
+  const sessionData = await exchangeDesktopTransferToken(token, {
+    desktopAuthState,
+  });
 
   if (!sessionData) {
     console.warn("[Desktop Callback] Token exchange failed");

--- a/app/desktop-login/route.ts
+++ b/app/desktop-login/route.ts
@@ -3,6 +3,8 @@ import { createOAuthState } from "@/lib/desktop-auth";
 import { workos } from "@/app/api/workos";
 import { getAuthRedirectPath } from "@/lib/auth/auth-redirect-intents";
 
+const DESKTOP_AUTH_STATE_REGEX = /^[a-f0-9]{64}$/;
+
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const desktopCallbackUrl = `${url.origin}/api/auth/desktop-callback`;
@@ -19,11 +21,24 @@ export async function GET(request: Request) {
 
     // Pass dev callback port through OAuth state for dev mode auth
     const devCallbackPort = url.searchParams.get("dev_callback_port");
+    const desktopAuthState = url.searchParams.get("desktop_state");
     const screenHint =
       url.searchParams.get("screen_hint") === "sign-up" ? "sign-up" : "sign-in";
     const returnPath = getAuthRedirectPath(url) ?? undefined;
     const portNum = devCallbackPort ? parseInt(devCallbackPort, 10) : NaN;
+
+    if (
+      typeof desktopAuthState !== "string" ||
+      !DESKTOP_AUTH_STATE_REGEX.test(desktopAuthState)
+    ) {
+      console.warn("[Desktop Login] Missing or invalid desktop auth state");
+      return NextResponse.redirect(
+        new URL("/login?error=state_error", url.origin),
+      );
+    }
+
     const metadata = {
+      desktopAuthState,
       ...(!isNaN(portNum) && portNum > 0 && portNum <= 65535
         ? { devCallbackPort: portNum }
         : {}),

--- a/app/hooks/useTauri.ts
+++ b/app/hooks/useTauri.ts
@@ -77,6 +77,20 @@ export async function navigateToAuth(
       let loginUrl = `${window.location.origin}/desktop-login`;
       const fallbackUrl = new URL(resolvedPath, window.location.origin);
       const authSearchParams = new URLSearchParams(fallbackUrl.search);
+      const { invoke } = await import("@tauri-apps/api/core");
+
+      try {
+        const desktopAuthState = await invoke<string>(
+          "prepare_desktop_auth_state",
+        );
+        authSearchParams.set("desktop_state", desktopAuthState);
+      } catch (err) {
+        console.error("[Tauri] Failed to prepare desktop auth state:", err);
+        toast.error(
+          "Could not start secure desktop sign-in. Please try again.",
+        );
+        return;
+      }
 
       if (fallbackUrl.pathname === "/signup") {
         authSearchParams.set("screen_hint", "sign-up");
@@ -85,7 +99,6 @@ export async function navigateToAuth(
       // In dev mode, pass the local auth callback port so the server
       // redirects to localhost instead of the hackerai:// deep link
       try {
-        const { invoke } = await import("@tauri-apps/api/core");
         const port = await invoke<number>("get_dev_auth_port");
         if (port > 0) {
           authSearchParams.set("dev_callback_port", String(port));

--- a/lib/__tests__/desktop-auth.test.ts
+++ b/lib/__tests__/desktop-auth.test.ts
@@ -82,6 +82,21 @@ describe("createDesktopTransferToken", () => {
     );
   });
 
+  it("stores the desktop auth state with the transfer token", async () => {
+    const desktopAuthState = "c".repeat(64);
+    await createDesktopTransferToken("sealed-session-data", {
+      desktopAuthState,
+    });
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      expect.stringContaining("desktop-auth-transfer:"),
+      expect.objectContaining({
+        sealedSession: "sealed-session-data",
+        desktopAuthState,
+      }),
+      { ex: 300 },
+    );
+  });
+
   it("generates unique tokens", async () => {
     const token1 = await createDesktopTransferToken("session1");
     const token2 = await createDesktopTransferToken("session2");
@@ -109,6 +124,31 @@ describe("exchangeDesktopTransferToken", () => {
       sealedSession: "my-sealed-session",
       returnPath: "/#pricing",
     });
+  });
+
+  it("returns sealed session when desktop auth state matches", async () => {
+    const desktopAuthState = "d".repeat(64);
+    const token = await createDesktopTransferToken("my-sealed-session", {
+      desktopAuthState,
+    });
+    expect(token).not.toBeNull();
+
+    const result = await exchangeDesktopTransferToken(token!, {
+      desktopAuthState,
+    });
+    expect(result).toEqual({ sealedSession: "my-sealed-session" });
+  });
+
+  it("returns null when desktop auth state does not match", async () => {
+    const token = await createDesktopTransferToken("my-sealed-session", {
+      desktopAuthState: "e".repeat(64),
+    });
+    expect(token).not.toBeNull();
+
+    const result = await exchangeDesktopTransferToken(token!, {
+      desktopAuthState: "f".repeat(64),
+    });
+    expect(result).toBeNull();
   });
 
   it("returns null for invalid token format", async () => {
@@ -162,10 +202,18 @@ describe("createOAuthState", () => {
   });
 
   it("stores state with metadata as JSON", async () => {
-    await createOAuthState({ devCallbackPort: 3456, returnPath: "/#pricing" });
+    await createOAuthState({
+      devCallbackPort: 3456,
+      returnPath: "/#pricing",
+      desktopAuthState: "a".repeat(64),
+    });
     expect(mockRedis.set).toHaveBeenCalledWith(
       expect.stringContaining("desktop-oauth-state:"),
-      JSON.stringify({ devCallbackPort: 3456, returnPath: "/#pricing" }),
+      JSON.stringify({
+        devCallbackPort: 3456,
+        returnPath: "/#pricing",
+        desktopAuthState: "a".repeat(64),
+      }),
       { ex: 300 },
     );
   });
@@ -184,6 +232,7 @@ describe("verifyAndConsumeOAuthState", () => {
     const state = await createOAuthState({
       devCallbackPort: 9999,
       returnPath: "/#pricing",
+      desktopAuthState: "b".repeat(64),
     });
     expect(state).not.toBeNull();
 
@@ -192,6 +241,7 @@ describe("verifyAndConsumeOAuthState", () => {
     expect(result.metadata).toEqual({
       devCallbackPort: 9999,
       returnPath: "/#pricing",
+      desktopAuthState: "b".repeat(64),
     });
   });
 

--- a/lib/__tests__/desktop-auth.test.ts
+++ b/lib/__tests__/desktop-auth.test.ts
@@ -151,6 +151,16 @@ describe("exchangeDesktopTransferToken", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null when a state-bound token is exchanged without desktop auth state", async () => {
+    const token = await createDesktopTransferToken("my-sealed-session", {
+      desktopAuthState: "a".repeat(64),
+    });
+    expect(token).not.toBeNull();
+
+    const result = await exchangeDesktopTransferToken(token!);
+    expect(result).toBeNull();
+  });
+
   it("returns null for invalid token format", async () => {
     const result = await exchangeDesktopTransferToken("not-hex");
     expect(result).toBeNull();

--- a/lib/desktop-auth.ts
+++ b/lib/desktop-auth.ts
@@ -135,6 +135,11 @@ export async function exchangeDesktopTransferToken(
     return null;
   }
 
+  if (data.desktopAuthState && !options?.desktopAuthState) {
+    console.warn("[Desktop Auth] Desktop auth state required but not provided");
+    return null;
+  }
+
   if (
     options?.desktopAuthState &&
     data.desktopAuthState !== options.desktopAuthState

--- a/lib/desktop-auth.ts
+++ b/lib/desktop-auth.ts
@@ -10,6 +10,7 @@ type TransferTokenData = {
   sealedSession: string;
   createdAt: number;
   returnPath?: string;
+  desktopAuthState?: string;
 };
 
 function getRedis(): Redis | null {
@@ -36,7 +37,7 @@ function generateTransferToken(): string {
 
 export async function createDesktopTransferToken(
   sealedSession: string,
-  options?: { returnPath?: string },
+  options?: { returnPath?: string; desktopAuthState?: string },
 ): Promise<string | null> {
   const redis = getRedis();
   if (!redis) {
@@ -56,6 +57,9 @@ export async function createDesktopTransferToken(
   if (options?.returnPath) {
     data.returnPath = options.returnPath;
   }
+  if (options?.desktopAuthState) {
+    data.desktopAuthState = options.desktopAuthState;
+  }
 
   try {
     await redis.set(key, data, { ex: TRANSFER_TOKEN_TTL_SECONDS });
@@ -72,6 +76,7 @@ export async function createDesktopTransferToken(
 
 export async function exchangeDesktopTransferToken(
   transferToken: string,
+  options?: { desktopAuthState?: string },
 ): Promise<{
   sealedSession: string;
   returnPath?: string;
@@ -130,6 +135,14 @@ export async function exchangeDesktopTransferToken(
     return null;
   }
 
+  if (
+    options?.desktopAuthState &&
+    data.desktopAuthState !== options.desktopAuthState
+  ) {
+    console.warn("[Desktop Auth] Desktop auth state mismatch");
+    return null;
+  }
+
   const result: { sealedSession: string; returnPath?: string } = {
     sealedSession: data.sealedSession,
   };
@@ -142,6 +155,7 @@ export async function exchangeDesktopTransferToken(
 export type OAuthStateMetadata = {
   devCallbackPort?: number;
   returnPath?: string;
+  desktopAuthState?: string;
 };
 
 export async function createOAuthState(

--- a/packages/desktop/src-tauri/gen/schemas/acl-manifests.json
+++ b/packages/desktop/src-tauri/gen/schemas/acl-manifests.json
@@ -8,8 +8,10 @@
         "commands": {
           "allow": [
             "get_dev_auth_port",
+            "prepare_desktop_auth_state",
             "get_cmd_server_info",
             "get_local_file_metadata",
+            "read_local_file",
             "execute_command",
             "execute_stream_command",
             "cancel_stream_command",
@@ -1928,24 +1930,18 @@
     "default_permission": {
       "identifier": "default",
       "description": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n",
-      "permissions": [
-        "allow-ask",
-        "allow-confirm",
-        "allow-message",
-        "allow-save",
-        "allow-open"
-      ]
+      "permissions": ["allow-message", "allow-save", "allow-open"]
     },
     "permissions": {
       "allow-ask": {
         "identifier": "allow-ask",
-        "description": "Enables the ask command without any pre-configured scope.",
-        "commands": { "allow": ["ask"], "deny": [] }
+        "description": "Enables the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)",
+        "commands": { "allow": ["message"], "deny": [] }
       },
       "allow-confirm": {
         "identifier": "allow-confirm",
-        "description": "Enables the confirm command without any pre-configured scope.",
-        "commands": { "allow": ["confirm"], "deny": [] }
+        "description": "Enables the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)",
+        "commands": { "allow": ["message"], "deny": [] }
       },
       "allow-message": {
         "identifier": "allow-message",
@@ -1964,13 +1960,13 @@
       },
       "deny-ask": {
         "identifier": "deny-ask",
-        "description": "Denies the ask command without any pre-configured scope.",
-        "commands": { "allow": [], "deny": ["ask"] }
+        "description": "Denies the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)",
+        "commands": { "allow": [], "deny": ["message"] }
       },
       "deny-confirm": {
         "identifier": "deny-confirm",
-        "description": "Denies the confirm command without any pre-configured scope.",
-        "commands": { "allow": [], "deny": ["confirm"] }
+        "description": "Denies the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)",
+        "commands": { "allow": [], "deny": ["message"] }
       },
       "deny-message": {
         "identifier": "deny-message",

--- a/packages/desktop/src-tauri/gen/schemas/desktop-schema.json
+++ b/packages/desktop/src-tauri/gen/schemas/desktop-schema.json
@@ -2593,22 +2593,22 @@
           "markdownDescription": "Denies the unregister command without any pre-configured scope."
         },
         {
-          "description": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-ask`\n- `allow-confirm`\n- `allow-message`\n- `allow-save`\n- `allow-open`",
+          "description": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-message`\n- `allow-save`\n- `allow-open`",
           "type": "string",
           "const": "dialog:default",
-          "markdownDescription": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-ask`\n- `allow-confirm`\n- `allow-message`\n- `allow-save`\n- `allow-open`"
+          "markdownDescription": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-message`\n- `allow-save`\n- `allow-open`"
         },
         {
-          "description": "Enables the ask command without any pre-configured scope.",
+          "description": "Enables the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:allow-ask",
-          "markdownDescription": "Enables the ask command without any pre-configured scope."
+          "markdownDescription": "Enables the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)"
         },
         {
-          "description": "Enables the confirm command without any pre-configured scope.",
+          "description": "Enables the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:allow-confirm",
-          "markdownDescription": "Enables the confirm command without any pre-configured scope."
+          "markdownDescription": "Enables the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)"
         },
         {
           "description": "Enables the message command without any pre-configured scope.",
@@ -2629,16 +2629,16 @@
           "markdownDescription": "Enables the save command without any pre-configured scope."
         },
         {
-          "description": "Denies the ask command without any pre-configured scope.",
+          "description": "Denies the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:deny-ask",
-          "markdownDescription": "Denies the ask command without any pre-configured scope."
+          "markdownDescription": "Denies the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)"
         },
         {
-          "description": "Denies the confirm command without any pre-configured scope.",
+          "description": "Denies the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:deny-confirm",
-          "markdownDescription": "Denies the confirm command without any pre-configured scope."
+          "markdownDescription": "Denies the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)"
         },
         {
           "description": "Denies the message command without any pre-configured scope.",

--- a/packages/desktop/src-tauri/gen/schemas/macOS-schema.json
+++ b/packages/desktop/src-tauri/gen/schemas/macOS-schema.json
@@ -2593,22 +2593,22 @@
           "markdownDescription": "Denies the unregister command without any pre-configured scope."
         },
         {
-          "description": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-ask`\n- `allow-confirm`\n- `allow-message`\n- `allow-save`\n- `allow-open`",
+          "description": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-message`\n- `allow-save`\n- `allow-open`",
           "type": "string",
           "const": "dialog:default",
-          "markdownDescription": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-ask`\n- `allow-confirm`\n- `allow-message`\n- `allow-save`\n- `allow-open`"
+          "markdownDescription": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-message`\n- `allow-save`\n- `allow-open`"
         },
         {
-          "description": "Enables the ask command without any pre-configured scope.",
+          "description": "Enables the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:allow-ask",
-          "markdownDescription": "Enables the ask command without any pre-configured scope."
+          "markdownDescription": "Enables the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)"
         },
         {
-          "description": "Enables the confirm command without any pre-configured scope.",
+          "description": "Enables the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:allow-confirm",
-          "markdownDescription": "Enables the confirm command without any pre-configured scope."
+          "markdownDescription": "Enables the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)"
         },
         {
           "description": "Enables the message command without any pre-configured scope.",
@@ -2629,16 +2629,16 @@
           "markdownDescription": "Enables the save command without any pre-configured scope."
         },
         {
-          "description": "Denies the ask command without any pre-configured scope.",
+          "description": "Denies the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:deny-ask",
-          "markdownDescription": "Denies the ask command without any pre-configured scope."
+          "markdownDescription": "Denies the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)"
         },
         {
-          "description": "Denies the confirm command without any pre-configured scope.",
+          "description": "Denies the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:deny-confirm",
-          "markdownDescription": "Denies the confirm command without any pre-configured scope."
+          "markdownDescription": "Denies the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)"
         },
         {
           "description": "Denies the message command without any pre-configured scope.",

--- a/packages/desktop/src-tauri/permissions/desktop-command-bridge.toml
+++ b/packages/desktop/src-tauri/permissions/desktop-command-bridge.toml
@@ -3,6 +3,7 @@ identifier = "allow-desktop-command-bridge"
 description = "Allows the desktop webview to reach the local command bridge."
 commands.allow = [
   "get_dev_auth_port",
+  "prepare_desktop_auth_state",
   "get_cmd_server_info",
   "get_local_file_metadata",
   "read_local_file",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -12,6 +12,8 @@ use tauri_plugin_updater::UpdaterExt;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
+const DESKTOP_AUTH_STATE_TTL: Duration = Duration::from_secs(5 * 60);
+const MAX_PENDING_DESKTOP_AUTH_STATES: usize = 16;
 
 /// Port for the local dev auth callback server (0 = not started)
 static DEV_AUTH_PORT: AtomicU16 = AtomicU16::new(0);
@@ -22,10 +24,51 @@ static CMD_SERVER_PORT: AtomicU16 = AtomicU16::new(0);
 /// Session token for authenticating command server requests
 static CMD_SERVER_TOKEN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 
+struct PendingDesktopAuthStates(std::sync::Mutex<HashMap<String, SystemTime>>);
+
+fn generate_desktop_auth_state() -> String {
+    format!(
+        "{}{}",
+        uuid::Uuid::new_v4().simple(),
+        uuid::Uuid::new_v4().simple()
+    )
+}
+
+fn prune_expired_auth_states(states: &mut HashMap<String, SystemTime>, now: SystemTime) {
+    states.retain(|_, expires_at| *expires_at > now);
+    while states.len() >= MAX_PENDING_DESKTOP_AUTH_STATES {
+        if let Some(oldest_key) = states
+            .iter()
+            .min_by_key(|(_, expires_at)| *expires_at)
+            .map(|(state, _)| state.clone())
+        {
+            states.remove(&oldest_key);
+        } else {
+            break;
+        }
+    }
+}
+
 /// Get the dev auth callback port (0 if not running in dev mode)
 #[tauri::command]
 fn get_dev_auth_port() -> u16 {
     DEV_AUTH_PORT.load(Ordering::Relaxed)
+}
+
+#[tauri::command]
+fn prepare_desktop_auth_state(
+    pending_states: tauri::State<'_, PendingDesktopAuthStates>,
+) -> Result<String, String> {
+    let state = generate_desktop_auth_state();
+    let now = SystemTime::now();
+    let expires_at = now + DESKTOP_AUTH_STATE_TTL;
+    let mut states = pending_states
+        .0
+        .lock()
+        .map_err(|_| "desktop auth state lock poisoned".to_string())?;
+    prune_expired_auth_states(&mut states, now);
+    states.insert(state.clone(), expires_at);
+    Ok(state)
 }
 
 /// Get the command server port, session token, and OS info
@@ -996,17 +1039,28 @@ async fn start_dev_auth_server(app_handle: tauri::AppHandle) {
                 .query_pairs()
                 .find(|(k, _)| k == "origin")
                 .map(|(_, v)| v.to_string());
+            let desktop_state = parsed
+                .query_pairs()
+                .find(|(k, _)| k == "desktop_state")
+                .map(|(_, v)| v.to_string());
 
-            match token {
-                Some(ref t) if is_valid_token_format(t) => {
+            match (token, desktop_state) {
+                (Some(ref t), Some(ref state))
+                    if is_valid_token_format(t)
+                        && consume_pending_desktop_auth_state(&handle, state) =>
+                {
                     let origin = origin
                         .filter(|o| validate_origin(o))
                         .unwrap_or_else(|| "http://localhost:3000".to_string());
 
                     let encoded_token: String =
                         url::form_urlencoded::byte_serialize(t.as_bytes()).collect();
-                    let callback_url =
-                        format!("{}/desktop-callback?token={}", origin, encoded_token);
+                    let encoded_state: String =
+                        url::form_urlencoded::byte_serialize(state.as_bytes()).collect();
+                    let callback_url = format!(
+                        "{}/desktop-callback?token={}&desktop_state={}",
+                        origin, encoded_token, encoded_state
+                    );
 
                     log::info!(
                         "Dev auth: navigating to callback (token: {}...)",
@@ -1030,7 +1084,7 @@ async fn start_dev_auth_server(app_handle: tauri::AppHandle) {
                     let _ = stream.write_all(response.as_bytes()).await;
                 }
                 _ => {
-                    log::warn!("Dev auth: invalid or missing token");
+                    log::warn!("Dev auth: invalid or missing token/auth state");
                     let response = "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n";
                     let _ = stream.write_all(response.as_bytes()).await;
                 }
@@ -1108,6 +1162,32 @@ fn validate_origin(origin: &str) -> bool {
     }
 }
 
+fn consume_pending_desktop_auth_state(app: &tauri::AppHandle, desktop_state: &str) -> bool {
+    if !is_valid_token_format(desktop_state) {
+        return false;
+    }
+
+    let Some(pending_states) = app.try_state::<PendingDesktopAuthStates>() else {
+        log::error!("Desktop auth state store is unavailable");
+        return false;
+    };
+
+    let now = SystemTime::now();
+    let mut states = match pending_states.0.lock() {
+        Ok(states) => states,
+        Err(_) => {
+            log::error!("Desktop auth state lock poisoned");
+            return false;
+        }
+    };
+
+    prune_expired_auth_states(&mut states, now);
+    states
+        .remove(desktop_state)
+        .map(|expires_at| expires_at > now)
+        .unwrap_or(false)
+}
+
 fn handle_auth_deep_link(app: &tauri::AppHandle, url: &url::Url) {
     if url.scheme() != "hackerai" {
         return;
@@ -1125,6 +1205,18 @@ fn handle_auth_deep_link(app: &tauri::AppHandle, url: &url::Url) {
                     return;
                 }
 
+                let desktop_state = match url
+                    .query_pairs()
+                    .find(|(k, _)| k == "desktop_state")
+                    .map(|(_, v)| v.to_string())
+                {
+                    Some(state) if consume_pending_desktop_auth_state(app, &state) => state,
+                    _ => {
+                        log::error!("Auth deep link missing valid desktop auth state");
+                        return;
+                    }
+                };
+
                 if let Some(window) = app.get_webview_window("main") {
                     // Get and validate origin from deep link query params
                     let origin = url
@@ -1139,8 +1231,12 @@ fn handle_auth_deep_link(app: &tauri::AppHandle, url: &url::Url) {
 
                     let encoded_token: String =
                         url::form_urlencoded::byte_serialize(token.as_bytes()).collect();
-                    let callback_url =
-                        format!("{}/desktop-callback?token={}", origin, encoded_token);
+                    let encoded_state: String =
+                        url::form_urlencoded::byte_serialize(desktop_state.as_bytes()).collect();
+                    let callback_url = format!(
+                        "{}/desktop-callback?token={}&desktop_state={}",
+                        origin, encoded_token, encoded_state
+                    );
                     log::info!(
                         "Navigating to desktop callback (token: {}...)",
                         &token[..8.min(token.len())]
@@ -1322,6 +1418,7 @@ pub fn run() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             get_dev_auth_port,
+            prepare_desktop_auth_state,
             get_cmd_server_info,
             get_local_file_metadata,
             read_local_file,
@@ -1361,6 +1458,9 @@ pub fn run() {
             std::sync::Arc::new(std::sync::Mutex::new(HashMap::<String, u32>::new()))
                 as StreamCommandState,
         )
+        .manage(PendingDesktopAuthStates(std::sync::Mutex::new(
+            HashMap::new(),
+        )))
         .setup(|app| {
             #[cfg(desktop)]
             {


### PR DESCRIPTION
## Summary

Fixes the Linux desktop custom-protocol login CSRF/session-fixation path by requiring desktop auth callbacks to be bound to a nonce generated and stored by the local Tauri app.

## What changed

- Added a Tauri `prepare_desktop_auth_state` command that creates short-lived pending desktop auth states.
- Pass the desktop auth state through `/desktop-login`, the WorkOS callback, transfer-token creation, and the `hackerai://auth` deep link.
- Reject deep links unless the state matches a pending local desktop state, then pass the state to `/desktop-callback`.
- Require `/desktop-callback` to exchange transfer tokens with the matching desktop auth state.
- Updated desktop auth tests and Tauri permission/schema metadata.

## Validation

- `pnpm test -- lib/__tests__/desktop-auth.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint app/desktop-login/route.ts app/api/auth/desktop-callback/route.ts app/desktop-callback/route.ts app/hooks/useTauri.ts lib/desktop-auth.ts lib/__tests__/desktop-auth.test.ts`
- `pnpm exec prettier --check app/desktop-login/route.ts app/api/auth/desktop-callback/route.ts app/desktop-callback/route.ts app/hooks/useTauri.ts lib/desktop-auth.ts lib/__tests__/desktop-auth.test.ts packages/desktop/src-tauri/gen/schemas/acl-manifests.json packages/desktop/src-tauri/gen/schemas/desktop-schema.json packages/desktop/src-tauri/gen/schemas/macOS-schema.json`
- `cargo fmt --check && cargo check` from `packages/desktop/src-tauri`
- commit hook: full `pnpm typecheck` and full `pnpm test` (`101` suites, `1214` tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop sign-in flow now shares a short-lived secure state between desktop and web, improving reliability of deep-link and dev-mode callbacks.

* **Bug Fixes**
  * Stronger validation of desktop sign-in requests; invalid or missing desktop state now yields a clear error or redirects to signin.
  * Reduced edge-case failures when exchanging desktop transfer tokens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->