### PR TITLE
[codex] Fail closed when paid rate limits lack Redis

### DIFF
--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -5,10 +5,18 @@
  * with fully mocked dependencies (Redis, Ratelimit, extra-usage).
  * No real external services are called.
  */
-import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
 
 describe("token-bucket async functions", () => {
   // Mock functions we can control
+  const mockCreateRedisClient = jest.fn();
   const mockLimitFn = jest.fn();
   const mockHincrbyFn = jest.fn();
   const mockHsetFn = jest.fn();
@@ -16,6 +24,7 @@ describe("token-bucket async functions", () => {
   const mockExpireFn = jest.fn();
   const mockDeductFromBalance = jest.fn();
   const mockRefundToBalance = jest.fn();
+  const originalNodeEnv = process.env.NODE_ENV;
 
   beforeEach(() => {
     jest.resetModules();
@@ -42,6 +51,20 @@ describe("token-bucket async functions", () => {
       success: true,
       newBalanceDollars: 10,
     });
+    mockCreateRedisClient.mockReturnValue({
+      hincrby: mockHincrbyFn,
+      hset: mockHsetFn,
+      del: mockDelFn,
+      expire: mockExpireFn,
+    });
+  });
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
   });
 
   const getIsolatedModule = () => {
@@ -69,12 +92,7 @@ describe("token-bucket async functions", () => {
       }));
 
       jest.doMock("../redis", () => ({
-        createRedisClient: jest.fn(() => ({
-          hincrby: mockHincrbyFn,
-          hset: mockHsetFn,
-          del: mockDelFn,
-          expire: mockExpireFn,
-        })),
+        createRedisClient: mockCreateRedisClient,
         formatTimeRemaining: jest.fn(() => "5 hours"),
       }));
 
@@ -112,6 +130,32 @@ describe("token-bucket async functions", () => {
       expect(result).toHaveProperty("limit");
       expect(result.pointsDeducted).toBeDefined();
       expect(mockLimitFn).toHaveBeenCalled();
+    });
+
+    it("should skip paid rate limiting outside production when Redis is unavailable", async () => {
+      mockCreateRedisClient.mockReturnValue(null);
+      const { checkTokenBucketLimit } = getIsolatedModule();
+
+      const result = await checkTokenBucketLimit("user-123", "pro", 1000);
+
+      expect(result.rateLimitSkipped).toBe(true);
+      expect(result.remaining).toBe(result.limit);
+      expect(mockLimitFn).not.toHaveBeenCalled();
+    });
+
+    it("should fail closed for paid users in production when Redis is unavailable", async () => {
+      process.env.NODE_ENV = "production";
+      mockCreateRedisClient.mockReturnValue(null);
+      const { checkTokenBucketLimit } = getIsolatedModule();
+
+      await expect(
+        checkTokenBucketLimit("user-123", "pro", 1000),
+      ).rejects.toMatchObject({
+        type: "rate_limit",
+        surface: "chat",
+        cause: "Rate limiting service is not configured",
+      });
+      expect(mockLimitFn).not.toHaveBeenCalled();
     });
 
     it("should throw rate limit error when limits exceeded", async () => {
@@ -254,6 +298,31 @@ describe("token-bucket async functions", () => {
       await deductUsage("user-123", "pro", 1000, 1200, 500);
 
       expect(mockLimitFn).toHaveBeenCalled();
+    });
+
+    it("should skip usage deduction outside production when Redis is unavailable", async () => {
+      mockCreateRedisClient.mockReturnValue(null);
+      const { deductUsage } = getIsolatedModule();
+
+      await expect(
+        deductUsage("user-123", "pro", 1000, 1200, 500),
+      ).resolves.toBeUndefined();
+      expect(mockLimitFn).not.toHaveBeenCalled();
+    });
+
+    it("should fail closed for paid usage deduction in production when Redis is unavailable", async () => {
+      process.env.NODE_ENV = "production";
+      mockCreateRedisClient.mockReturnValue(null);
+      const { deductUsage } = getIsolatedModule();
+
+      await expect(
+        deductUsage("user-123", "pro", 1000, 1200, 500),
+      ).rejects.toMatchObject({
+        type: "rate_limit",
+        surface: "chat",
+        cause: "Rate limiting service is not configured",
+      });
+      expect(mockLimitFn).not.toHaveBeenCalled();
     });
 
     it("should use extra usage when bucket depleted", async () => {

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -49,6 +49,12 @@ export const NORMAL_USAGE_MULTIPLIER = 1.3;
 
 /** 30 days in seconds — used for Redis TTLs aligned with billing cycles. */
 const THIRTY_DAYS_SECONDS = 30 * 24 * 60 * 60;
+const RATE_LIMIT_SERVICE_NOT_CONFIGURED =
+  "Rate limiting service is not configured";
+
+const throwRateLimitServiceNotConfigured = (): never => {
+  throw new ChatSDKError("rate_limit:chat", RATE_LIMIT_SERVICE_NOT_CONFIGURED);
+};
 
 // =============================================================================
 // Cost Calculation
@@ -151,7 +157,11 @@ export const checkTokenBucketLimit = async (
   const redis = createRedisClient();
 
   if (!redis) {
-    // Skip rate limiting if Redis is not configured (e.g. local dev)
+    if (process.env.NODE_ENV === "production") {
+      throwRateLimitServiceNotConfigured();
+    }
+
+    // Skip rate limiting if Redis is not configured in local dev/test.
     const { monthly } = getBudgetLimits(subscription);
     return {
       remaining: monthly,
@@ -430,7 +440,10 @@ export const deductUsage = async (
   organizationId?: string,
 ): Promise<void> => {
   const redis = createRedisClient();
-  if (!redis) return;
+  if (!redis) {
+    if (process.env.NODE_ENV !== "production") return;
+    throwRateLimitServiceNotConfigured();
+  }
 
   try {
     const { monthly, monthlyLimit } = createRateLimiter(


### PR DESCRIPTION
## Summary

- Fail closed for paid token-bucket rate limiting when Redis is missing in production.
- Keep the existing local/test developer convenience path that returns `rateLimitSkipped` when Redis is unavailable outside production.
- Fail closed during paid usage deduction in production if Redis is unavailable, preventing silent accounting no-ops.
- Add regression coverage for missing-Redis paid rate checks and usage deduction in production and non-production modes.

## Root Cause

The paid token-bucket path returned a successful `RateLimitInfo` with `rateLimitSkipped: true` whenever `createRedisClient()` returned `null`. Unlike the free limiter, that branch had no production guard, so a production deployment missing Upstash Redis configuration could allow paid requests to proceed without budget enforcement or post-request usage deduction.

## Impact

Production deployments now reject cost-incurring paid requests when the rate-limit/accounting backend is not configured, while local development and tests can still run without Redis.

## Validation

- `pnpm test -- lib/rate-limit/__tests__/token-bucket.integration.test.ts --runInBand`
- `pnpm exec eslint lib/rate-limit/token-bucket.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts`
- `git diff --check -- lib/rate-limit/token-bucket.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts`
- Commit hook: `tsc --noEmit`
- Commit hook: `jest` (102 suites, 1234 tests passing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Rate Limiting Service Resilience**: Rate limiting behavior is now environment-aware. Production environments enforce strict error handling when the service is unavailable, while non-production environments gracefully skip rate limiting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->