### PR TITLE
[codex] Fix attachment URL trust boundary

### DIFF
--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -1,9 +1,12 @@
 import { processMessageFiles } from "../file-transform-utils";
 
 jest.mock("server-only", () => ({}));
+const mockConvexAction = jest.fn();
+const mockConvexQuery = jest.fn();
 jest.mock("@/lib/db/convex-client", () => ({
   getConvexClient: jest.fn(() => ({
-    action: jest.fn(),
+    action: mockConvexAction,
+    query: mockConvexQuery,
   })),
 }));
 
@@ -51,6 +54,8 @@ describe("processMessageFiles image size guards", () => {
   let consoleWarnSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    mockConvexAction.mockResolvedValue([]);
+    mockConvexQuery.mockResolvedValue([]);
     consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
   });
 
@@ -60,6 +65,7 @@ describe("processMessageFiles image size guards", () => {
   });
 
   it("omits URL-backed images when HEAD shows provider download size over 30 MB", async () => {
+    mockConvexAction.mockResolvedValue(["https://storage.example/huge.png"]);
     global.fetch = jest.fn(async (_url, init?: RequestInit) => {
       if (init?.method === "HEAD") {
         return responseLike({
@@ -94,6 +100,9 @@ describe("processMessageFiles image size guards", () => {
   });
 
   it("omits URL-backed images when headers are inconclusive but the range probe exceeds 5 MB", async () => {
+    mockConvexAction.mockResolvedValue([
+      "https://storage.example/unknown-size.png",
+    ]);
     global.fetch = jest.fn(async (_url, init?: RequestInit) => {
       if (init?.method === "HEAD") {
         return responseLike({});
@@ -126,6 +135,7 @@ describe("processMessageFiles image size guards", () => {
   });
 
   it("keeps URL-backed images when content-length is within the image limit", async () => {
+    mockConvexAction.mockResolvedValue(["https://storage.example/small.png"]);
     global.fetch = jest.fn(async () => {
       return responseLike({
         headers: { "content-length": String(2 * 1024 * 1024) },
@@ -150,7 +160,7 @@ describe("processMessageFiles image size guards", () => {
       type: "file",
       mediaType: "image/png",
       name: "small.png",
-      url: "https://example.com/small.png",
+      url: "https://storage.example/small.png",
     });
   });
 
@@ -180,6 +190,7 @@ describe("processMessageFiles image size guards", () => {
   });
 
   it("stages oversized Agent images into the sandbox instead of sending them inline", async () => {
+    mockConvexAction.mockResolvedValue(["https://storage.example/large.png"]);
     global.fetch = jest.fn(async () => {
       throw new Error("Agent image with declared size should not be probed");
     }) as any;
@@ -202,7 +213,7 @@ describe("processMessageFiles image size guards", () => {
     expect(result.sandboxFiles).toEqual([
       {
         kind: "url",
-        url: "https://example.com/large.png",
+        url: "https://storage.example/large.png",
         localPath: "/home/user/upload/large.png",
       },
     ]);
@@ -212,6 +223,90 @@ describe("processMessageFiles image size guards", () => {
         type: "text",
         text: '<attachment filename="large.png" local_path="/home/user/upload/large.png" />',
       },
+    ]);
+  });
+
+  it("does not stage a client-supplied URL when storage resolution fails", async () => {
+    mockConvexAction.mockResolvedValue([null]);
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        fileId: "file_unowned",
+        mediaType: "text/plain",
+        name: "notes.txt",
+        size: 100,
+        url: "http://169.254.169.254/latest/meta-data",
+      }),
+      "agent",
+      "user123",
+      "/home/user/upload",
+      "pro",
+    );
+
+    expect(result.sandboxFiles).toEqual([]);
+    expect(JSON.stringify(result.messages)).not.toContain("169.254.169.254");
+  });
+
+  it("fetches ask-mode PDFs from the storage-resolved URL, not the client URL", async () => {
+    mockConvexAction.mockResolvedValue(["https://storage.example/trusted.pdf"]);
+    const fetchSpy = jest.fn(async () => ({
+      ok: true,
+      arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+    }));
+    global.fetch = fetchSpy as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        fileId: "file_pdf",
+        mediaType: "application/pdf",
+        name: "trusted.pdf",
+        size: 100,
+        url: "http://169.254.169.254/latest/meta-data",
+      }),
+      "ask",
+      "user123",
+      undefined,
+      "pro",
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://storage.example/trusted.pdf",
+      expect.any(Object),
+    );
+    expect(
+      fetchSpy.mock.calls.some(([url]) =>
+        String(url).includes("169.254.169.254"),
+      ),
+    ).toBe(false);
+    expect(result.messages[0].parts[1]).toMatchObject({
+      type: "file",
+      url: "data:application/pdf;base64,AQID",
+    });
+  });
+
+  it("strips client URLs from stored ask-mode non-media file parts", async () => {
+    mockConvexQuery.mockResolvedValue([]);
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        fileId: "file_text",
+        mediaType: "text/plain",
+        name: "notes.txt",
+        size: 100,
+        url: "http://169.254.169.254/latest/meta-data",
+      }),
+      "ask",
+      "user123",
+      undefined,
+      "pro",
+    );
+
+    expect(JSON.stringify(result.messages)).not.toContain("169.254.169.254");
+    expect(result.messages[0].parts).toEqual([
+      { type: "text", text: "what is this?" },
     ]);
   });
 });

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -182,6 +182,33 @@ describe("desktop-local sandbox file helpers", () => {
     }
   });
 
+  it("blocks internal URL downloads before invoking the sandbox", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const downloadFromUrl = jest.fn();
+
+    try {
+      const result = await uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "http://169.254.169.254/latest/meta-data",
+            localPath: "/home/user/upload/meta-data",
+          },
+        ],
+        async () => ({
+          files: { downloadFromUrl },
+        }),
+      );
+
+      expect(result.failedCount).toBe(1);
+      expect(downloadFromUrl).not.toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it("rewrites attachment tags after upload path fallback", () => {
     const messages = [
       {

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -16,6 +16,7 @@ import { extractAllFileIdsFromMessages, isFilePart } from "./file-token-utils";
 import { getMaxFileTokens } from "../token-utils";
 import type { SubscriptionTier } from "@/types";
 import { logger } from "@/lib/logger";
+import { validateDownloadUrl } from "@/lib/ai/tools/utils/path-validation";
 
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 const MAX_PROVIDER_IMAGE_DOWNLOAD_SIZE = 30 * 1024 * 1024;
@@ -30,6 +31,36 @@ type FileToProcess = {
 type SizeProbeResult = {
   bytes: number;
   source: "content_length" | "content_range" | "download_probe";
+};
+
+const redactUrlForLog = (url: string): string => {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return url.split("?")[0];
+  }
+};
+
+const validateResolvedFileUrl = (
+  url: string | null | undefined,
+  fileId: string,
+): string | null => {
+  if (!url) return null;
+
+  try {
+    validateDownloadUrl(url);
+    return url;
+  } catch (error) {
+    logger.warn("resolved_file_url_rejected", {
+      event: "resolved_file_url_rejected",
+      service: "chat-handler",
+      file_id: fileId,
+      url: redactUrlForLog(url),
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
 };
 
 const containsPdfAttachments = (messages: UIMessage[]): boolean =>
@@ -222,6 +253,14 @@ const collectFilesToProcess = (
     (msg.parts as any[]).forEach((part, partIndex) => {
       if (!isFilePart(part)) return;
 
+      const fileId = typeof part.fileId === "string" ? part.fileId : undefined;
+      if (fileId) {
+        // File IDs are storage references, not proof that a request-supplied URL
+        // is safe. Clear any client URL so every server-side fetch/download uses
+        // an owner-checked URL resolved from storage below.
+        delete (part as any).url;
+      }
+
       if (isMediaFile(part.mediaType)) hasMedia = true;
 
       const shouldProcess =
@@ -230,17 +269,13 @@ const collectFilesToProcess = (
         isMediaFile(part.mediaType);
 
       if (shouldProcess) {
-        const fileId =
-          typeof part.fileId === "string" ? part.fileId : undefined;
-        const url =
-          typeof (part as any).url === "string" ? (part as any).url : undefined;
         if (!fileId) return;
+
         const key = `file:${fileId}`;
 
         if (!files.has(key)) {
           files.set(key, {
             fileId,
-            url,
             mediaType: part.mediaType,
             positions: [],
           });
@@ -291,8 +326,12 @@ const applyUrlsToFileParts = async (
   const fetchedUrls = await fetchFileUrls(fileIdsNeedingUrls, userId);
 
   filesNeedingUrls.forEach((file, index) => {
-    if (fetchedUrls[index]) {
-      file.url = fetchedUrls[index];
+    const resolvedUrl = validateResolvedFileUrl(
+      fetchedUrls[index],
+      file.fileId!,
+    );
+    if (resolvedUrl) {
+      file.url = resolvedUrl;
     }
   });
 

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { createHash } from "node:crypto";
 import { UIMessage } from "ai";
 import type { SandboxPreference } from "@/types";
+import { validateDownloadUrl } from "@/lib/ai/tools/utils/path-validation";
 
 export type SandboxFile = {
   localPath: string;
@@ -275,6 +276,8 @@ const downloadFileToSandbox = async (
   url: string,
   localPath: string,
 ): Promise<void> => {
+  validateDownloadUrl(url);
+
   // CentrifugoSandbox has downloadFromUrl method
   if (sandbox.files?.downloadFromUrl) {
     return sandbox.files.downloadFromUrl(url, localPath);


### PR DESCRIPTION
## Summary

- Strip request-supplied URLs from stored file parts before any server-side processing.
- Resolve attachment URLs from owned storage using the authenticated user/file ID path and reject unsafe resolved URLs.
- Reuse the SSRF URL guard before sandbox download fallback paths.
- Add regressions for agent sandbox staging, ask-mode PDF conversion, non-media file parts, and internal URL sandbox downloads.

## Root cause

Stored attachment parts accepted a client-provided `url` alongside `fileId`, so agent-mode sandbox staging and ask-mode PDF conversion could use a URL chosen by the request instead of one resolved from owned storage.

## Validation

- `pnpm test -- lib/utils/__tests__/file-transform-utils.test.ts lib/utils/__tests__/sandbox-file-utils.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec prettier --check lib/utils/file-transform-utils.ts lib/utils/sandbox-file-utils.ts lib/utils/__tests__/file-transform-utils.test.ts lib/utils/__tests__/sandbox-file-utils.test.ts`
- `pnpm lint -- lib/utils/file-transform-utils.ts lib/utils/sandbox-file-utils.ts lib/utils/__tests__/file-transform-utils.test.ts lib/utils/__tests__/sandbox-file-utils.test.ts` (0 errors; existing warnings elsewhere)
- pre-commit: full `pnpm test` passed: 102 suites, 1,234 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of file URLs to prevent unauthorized downloads from internal sources.
  * Improved security when processing storage-resolved file URLs.

* **Tests**
  * Added test coverage for URL safety validation and internal URL blocking.
  * Expanded test scenarios for file handling and storage resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->