### PR TITLE
[codex] Fix sandbox command channel isolation

### DIFF
--- a/app/api/sandbox/presence/route.ts
+++ b/app/api/sandbox/presence/route.ts
@@ -94,7 +94,9 @@ export async function GET(request: NextRequest) {
 
           sub.on("error", (ctx) => {
             cleanup();
-            reject(new Error(ctx.error?.message));
+            reject(
+              new Error(ctx.error?.message ?? "Centrifugo subscription error"),
+            );
           });
 
           sub.subscribe();

--- a/app/api/sandbox/presence/route.ts
+++ b/app/api/sandbox/presence/route.ts
@@ -1,19 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { Centrifuge } from "centrifuge";
+import { Centrifuge, type Subscription } from "centrifuge";
 import { getUserID } from "@/lib/auth/get-user-id";
 import { generateCentrifugoToken } from "@/lib/centrifugo/jwt";
 import { ConvexHttpClient } from "convex/browser";
 import { api } from "@/convex/_generated/api";
 import { phLogger } from "@/lib/posthog/server";
-
-interface CentrifugoPresenceClient {
-  client: string;
-  user: string;
-  connInfo: { connectionId?: string } | null;
-}
+import { sandboxConnectionChannel } from "@/lib/centrifugo/types";
 
 interface CentrifugoPresenceResult {
-  clients: Record<string, CentrifugoPresenceClient>;
+  clients?: Record<string, unknown>;
 }
 
 export async function GET(request: NextRequest) {
@@ -23,7 +18,6 @@ export async function GET(request: NextRequest) {
   } catch {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-  const channel = `sandbox:user#${userId}`;
 
   const wsUrl = process.env.CENTRIFUGO_WS_URL;
   const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
@@ -36,61 +30,13 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const onlineConnectionIds = new Set<string>();
-  let presenceReliable = false;
-
-  let client: Centrifuge | null = null;
-  try {
-    const token = await generateCentrifugoToken(userId, 30);
-    client = new Centrifuge(wsUrl, { token });
-    const sub = client.newSubscription(channel);
-
-    const presenceData: CentrifugoPresenceResult = await new Promise(
-      (resolve, reject) => {
-        const timeout = setTimeout(() => {
-          reject(new Error("Centrifugo presence timeout"));
-        }, 5000);
-
-        sub.on("subscribed", async () => {
-          clearTimeout(timeout);
-          try {
-            const result = await sub.presence();
-            resolve(result as CentrifugoPresenceResult);
-          } catch (e) {
-            reject(e);
-          }
-        });
-
-        sub.on("error", (ctx) => {
-          clearTimeout(timeout);
-          reject(new Error(ctx.error?.message));
-        });
-
-        sub.subscribe();
-        client!.connect();
-      },
-    );
-
-    const clients = presenceData?.clients ?? {};
-    for (const entry of Object.values(clients)) {
-      if (entry.connInfo?.connectionId) {
-        onlineConnectionIds.add(entry.connInfo.connectionId);
-      }
-    }
-    presenceReliable = true;
-  } catch (err) {
-    console.error("Centrifugo presence request failed:", err);
-  } finally {
-    if (client) {
-      client.disconnect();
-    }
-  }
-
-  // Fetch connection metadata from Convex
+  // Fetch connection metadata from Convex before probing per-connection
+  // Centrifugo channels. The previous shared per-user presence channel exposed
+  // every connection id to any same-user subscriber.
   if (!convexUrl || !serviceKey) {
     return NextResponse.json({
       connections: [],
-      onlineCount: onlineConnectionIds.size,
+      onlineCount: 0,
     });
   }
 
@@ -99,6 +45,76 @@ export async function GET(request: NextRequest) {
     api.localSandbox.listConnectionsForBackend,
     { serviceKey, userId },
   );
+
+  const onlineConnectionIds = new Set<string>();
+  let presenceReliable = false;
+
+  let client: Centrifuge | null = null;
+  const subscriptions: Subscription[] = [];
+  try {
+    const token = await generateCentrifugoToken(userId, 30);
+    client = new Centrifuge(wsUrl, { token });
+
+    const probes = connections.map(
+      (connection) =>
+        new Promise<void>((resolve, reject) => {
+          const sub = client!.newSubscription(
+            sandboxConnectionChannel(userId, connection.connectionId),
+          );
+          subscriptions.push(sub);
+
+          const timeout = setTimeout(() => {
+            cleanup();
+            reject(
+              new Error(
+                `Centrifugo presence timeout for connection ${connection.connectionId}`,
+              ),
+            );
+          }, 5000);
+
+          const cleanup = () => {
+            clearTimeout(timeout);
+            sub.removeAllListeners();
+          };
+
+          sub.on("subscribed", async () => {
+            try {
+              const result = (await sub.presence()) as CentrifugoPresenceResult;
+              const clients = result.clients ?? {};
+              if (Object.keys(clients).length > 0) {
+                onlineConnectionIds.add(connection.connectionId);
+              }
+              cleanup();
+              resolve();
+            } catch (e) {
+              cleanup();
+              reject(e);
+            }
+          });
+
+          sub.on("error", (ctx) => {
+            cleanup();
+            reject(new Error(ctx.error?.message));
+          });
+
+          sub.subscribe();
+        }),
+    );
+
+    client.connect();
+    await Promise.all(probes);
+    presenceReliable = true;
+  } catch (err) {
+    console.error("Centrifugo presence request failed:", err);
+  } finally {
+    for (const sub of subscriptions) {
+      sub.removeAllListeners();
+      sub.unsubscribe();
+    }
+    if (client) {
+      client.disconnect();
+    }
+  }
 
   // Mark each connection with live presence status
   const enriched = connections.map((conn) => ({

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -163,7 +163,7 @@ describe("targetConnectionId filtering", () => {
     );
   });
 
-  it("handles command when targetConnectionId is undefined (broadcast)", async () => {
+  it("ignores command when targetConnectionId is undefined", async () => {
     const { invoke } = await import("@tauri-apps/api/core");
     const config = buildConfig();
     const bridge = new DesktopSandboxBridge(config);
@@ -192,9 +192,36 @@ describe("targetConnectionId filtering", () => {
 
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(invoke).toHaveBeenCalledWith(
+    expect(invoke).not.toHaveBeenCalledWith(
       "execute_stream_command",
-      expect.objectContaining({ command: "echo broadcast" }),
+      expect.anything(),
+    );
+  });
+
+  it("ignores PTY control messages when targetConnectionId is undefined", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const config = buildConfig();
+    const bridge = new DesktopSandboxBridge(config);
+    await bridge.start();
+
+    const handler = getPublicationHandler();
+    (invoke as jest.Mock).mockClear();
+
+    handler({
+      data: {
+        type: "pty_create",
+        sessionId: "pty-1",
+        command: "bash",
+        cols: 80,
+        rows: 24,
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(invoke).not.toHaveBeenCalledWith(
+      "execute_pty_create",
+      expect.anything(),
     );
   });
 });
@@ -208,7 +235,7 @@ describe("extractUserIdFromToken", () => {
     await bridge.start();
 
     expect(mockClient.newSubscription).toHaveBeenCalledWith(
-      "sandbox:user#user-456",
+      "sandbox:connection:conn-123#user-456",
     );
   });
 

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -1,7 +1,7 @@
 import { Centrifuge, type Subscription } from "centrifuge";
 import posthog from "posthog-js";
 import {
-  sandboxChannel,
+  sandboxConnectionChannel,
   type SandboxMessage,
   type CommandCancelMessage,
   type CommandMessage,
@@ -44,6 +44,35 @@ interface StreamChunk {
   data?: string;
   exitCode?: number;
   message?: string;
+}
+
+type TargetedIncomingMessage =
+  | CommandMessage
+  | CommandCancelMessage
+  | PtyCreateMessage
+  | PtyInputMessage
+  | PtyResizeMessage
+  | PtyKillMessage;
+
+function isTargetedIncomingMessage(
+  message: unknown,
+): message is TargetedIncomingMessage {
+  if (typeof message !== "object" || message === null) {
+    return false;
+  }
+  const { type, targetConnectionId } = message as {
+    type?: unknown;
+    targetConnectionId?: unknown;
+  };
+  return (
+    typeof targetConnectionId === "string" &&
+    (type === "command" ||
+      type === "command_cancel" ||
+      type === "pty_create" ||
+      type === "pty_input" ||
+      type === "pty_resize" ||
+      type === "pty_kill")
+  );
 }
 
 // "Unauthenticated" UNAUTHORIZED still throws server-side (the user's auth
@@ -182,16 +211,17 @@ export class DesktopSandboxBridge {
     });
 
     const userId = this.extractUserIdFromToken(centrifugoToken);
-    const channel = sandboxChannel(userId);
+    const channel = sandboxConnectionChannel(userId, connectionId);
     this.subscription = this.client.newSubscription(channel);
 
     this.subscription.on("publication", (ctx) => {
-      const message = ctx.data as SandboxMessage;
+      const message = ctx.data;
 
-      // Gate on targetConnectionId for all message types that carry it
-      const targetId = (message as { targetConnectionId?: string })
-        .targetConnectionId;
-      if (targetId && targetId !== this.connectionId) {
+      if (!isTargetedIncomingMessage(message)) {
+        return;
+      }
+
+      if (message.targetConnectionId !== this.connectionId) {
         return;
       }
 

--- a/docker/centrifugo/README.md
+++ b/docker/centrifugo/README.md
@@ -91,7 +91,7 @@ sudo docker compose up -d
 
 ## Channel Security
 
-Channels use the format `sandbox:user#userId` where `#` is Centrifugo's user boundary. Combined with `allow_user_limited_channels: true`, only the JWT-authenticated user matching `userId` can subscribe to their channel.
+Command and result streams use per-connection channels in the format `sandbox:connection:connectionId#userId`, where `#` is Centrifugo's user boundary. Combined with `allow_user_limited_channels: true`, only the JWT-authenticated user matching `userId` can subscribe, while the random `connectionId` keeps one authorized local agent from joining another agent's command stream.
 
 ## Environment Variables
 

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -45,7 +45,10 @@ jest.mock("@/lib/centrifugo/jwt", () => ({
 }));
 
 jest.mock("@/lib/centrifugo/types", () => ({
-  sandboxChannel: jest.fn((userId: string) => `sandbox:user#${userId}`),
+  sandboxConnectionChannel: jest.fn(
+    (userId: string, connectionId: string) =>
+      `sandbox:connection:${connectionId}#${userId}`,
+  ),
 }));
 
 // Use a stable UUID for assertions
@@ -163,6 +166,9 @@ describe("CentrifugoSandbox", () => {
 
       const sub = mockSubscriptions[0];
       expect(sub).toBeDefined();
+      expect(mockClients[0].newSubscription).toHaveBeenCalledWith(
+        "sandbox:connection:conn-1#user-1",
+      );
 
       // Simulate "subscribed" event, then publications
       sub.emit("subscribed");

--- a/lib/ai/tools/utils/centrifugo-pty-adapter.ts
+++ b/lib/ai/tools/utils/centrifugo-pty-adapter.ts
@@ -18,7 +18,7 @@
 
 import { Centrifuge, type Subscription } from "centrifuge";
 
-import { sandboxChannel } from "@/lib/centrifugo/types";
+import { sandboxConnectionChannel } from "@/lib/centrifugo/types";
 import type { PtyHandle, CreatePtyOptions } from "./e2b-pty-adapter";
 import type { CentrifugoSandbox } from "./centrifugo-sandbox";
 import { createResolvableExited } from "./pty-exited-promise";
@@ -40,14 +40,14 @@ interface PtyCreatePayload {
   rows: number;
   cwd?: string;
   env?: Record<string, string>;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 interface PtyInputPayload {
   type: "pty_input";
   sessionId: string;
   data: string;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 interface PtyResizePayload {
@@ -55,13 +55,13 @@ interface PtyResizePayload {
   sessionId: string;
   cols: number;
   rows: number;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 interface PtyKillPayload {
   type: "pty_kill";
   sessionId: string;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 type PtyOutgoingPayload =
@@ -147,7 +147,7 @@ function parsePtyMessage(data: unknown): PtyIncomingMsg | null {
 /**
  * Create a PtyHandle that tunnels through Centrifugo to a local runner.
  *
- * Uses the same `sandbox:user#{userId}` channel as one-shot commands.
+ * Uses the same per-connection channel as one-shot commands.
  * Filters incoming publications by `sessionId`.
  */
 export async function createCentrifugoPtyHandle(
@@ -157,7 +157,7 @@ export async function createCentrifugoPtyHandle(
   const sessionId = crypto.randomUUID();
   const userId = sandbox.getUserId();
   const connectionId = sandbox.getConnectionId();
-  const channel = sandboxChannel(userId);
+  const channel = sandboxConnectionChannel(userId, connectionId);
 
   // Long-lived token: PTY sessions can last minutes.
   const tokenExpSeconds = 600;

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -3,7 +3,7 @@ import { Centrifuge, type Subscription } from "centrifuge";
 
 import { generateCentrifugoToken } from "@/lib/centrifugo/jwt";
 import {
-  sandboxChannel,
+  sandboxConnectionChannel,
   type CommandResponseMessage,
   type CommandMessage,
 } from "@/lib/centrifugo/types";
@@ -197,7 +197,10 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
     }> => {
       const commandId = crypto.randomUUID();
       const timeout = opts?.timeoutMs ?? 30000;
-      const channel = sandboxChannel(this.userId);
+      const channel = sandboxConnectionChannel(
+        this.userId,
+        this.connectionInfo.connectionId,
+      );
 
       // Generate short-lived JWT for this subscription (30s + command timeout)
       const tokenExpSeconds = Math.ceil(timeout / 1000) + 30;

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -1,5 +1,5 @@
 import { Sandbox } from "@e2b/code-interpreter";
-import { Centrifuge } from "centrifuge";
+import { Centrifuge, type Subscription } from "centrifuge";
 import type {
   SandboxBootInfo,
   SandboxManager,
@@ -14,7 +14,7 @@ import { api } from "@/convex/_generated/api";
 import { SANDBOX_ENVIRONMENT_TOOLS } from "./sandbox-tools";
 import { getPlatformDisplayName } from "./platform-utils";
 import { generateCentrifugoToken } from "@/lib/centrifugo/jwt";
-import { sandboxChannel } from "@/lib/centrifugo/types";
+import { sandboxConnectionChannel } from "@/lib/centrifugo/types";
 
 type SandboxInstance = Sandbox | CentrifugoSandbox;
 
@@ -45,12 +45,8 @@ const MAX_SANDBOX_HEALTH_FAILURES = 5;
 export const LOCAL_SANDBOX_PRESENCE_GRACE_MS = 30_000;
 const LOCAL_SANDBOX_PRESENCE_TIMEOUT_MS = 2_000;
 
-interface CentrifugoPresenceClient {
-  connInfo?: { connectionId?: string } | null;
-}
-
 interface CentrifugoPresenceResult {
-  clients?: Record<string, CentrifugoPresenceClient>;
+  clients?: Record<string, unknown>;
 }
 
 interface PresenceProbeResult {
@@ -112,7 +108,16 @@ export function filterConnectionsByPresence(
 
 async function queryLiveSandboxConnectionIds(
   userId: string,
+  connectionIds: string[],
 ): Promise<PresenceProbeResult> {
+  if (connectionIds.length === 0) {
+    return {
+      reliable: true,
+      onlineConnectionIds: new Set(),
+      durationMs: 0,
+    };
+  }
+
   const wsUrl = process.env.CENTRIFUGO_WS_URL;
   if (!wsUrl) {
     return {
@@ -125,54 +130,64 @@ async function queryLiveSandboxConnectionIds(
 
   const start = Date.now();
   let client: Centrifuge | null = null;
+  const subscriptions: Subscription[] = [];
 
   try {
     const token = await generateCentrifugoToken(userId, 30);
     client = new Centrifuge(wsUrl, { token });
-    const sub = client.newSubscription(sandboxChannel(userId));
+    const onlineConnectionIds = new Set<string>();
 
-    const presence = await new Promise<CentrifugoPresenceResult>(
-      (resolve, reject) => {
-        const timeout = setTimeout(() => {
-          cleanup();
-          reject(new Error("Centrifugo presence timeout"));
-        }, LOCAL_SANDBOX_PRESENCE_TIMEOUT_MS);
-
-        const cleanup = () => {
-          clearTimeout(timeout);
-          sub.removeAllListeners();
-        };
-
-        sub.on("subscribed", async () => {
-          try {
-            const result = await sub.presence();
-            cleanup();
-            resolve(result as CentrifugoPresenceResult);
-          } catch (error) {
-            cleanup();
-            reject(error);
-          }
-        });
-
-        sub.on("error", (ctx) => {
-          cleanup();
-          reject(
-            new Error(ctx.error?.message ?? "Centrifugo subscription error"),
+    const probes = connectionIds.map(
+      (connectionId) =>
+        new Promise<void>((resolve, reject) => {
+          const sub = client!.newSubscription(
+            sandboxConnectionChannel(userId, connectionId),
           );
-        });
+          subscriptions.push(sub);
 
-        sub.subscribe();
-        client!.connect();
-      },
+          const timeout = setTimeout(() => {
+            cleanup();
+            reject(
+              new Error(
+                `Centrifugo presence timeout for connection ${connectionId}`,
+              ),
+            );
+          }, LOCAL_SANDBOX_PRESENCE_TIMEOUT_MS);
+
+          const cleanup = () => {
+            clearTimeout(timeout);
+            sub.removeAllListeners();
+          };
+
+          sub.on("subscribed", async () => {
+            try {
+              const result = await sub.presence();
+              cleanup();
+              const clients =
+                (result as CentrifugoPresenceResult).clients ?? {};
+              if (Object.keys(clients).length > 0) {
+                onlineConnectionIds.add(connectionId);
+              }
+              resolve();
+            } catch (error) {
+              cleanup();
+              reject(error);
+            }
+          });
+
+          sub.on("error", (ctx) => {
+            cleanup();
+            reject(
+              new Error(ctx.error?.message ?? "Centrifugo subscription error"),
+            );
+          });
+
+          sub.subscribe();
+        }),
     );
 
-    const onlineConnectionIds = new Set<string>();
-    for (const entry of Object.values(presence.clients ?? {})) {
-      const connectionId = entry.connInfo?.connectionId;
-      if (connectionId) {
-        onlineConnectionIds.add(connectionId);
-      }
-    }
+    client.connect();
+    await Promise.all(probes);
 
     return {
       reliable: true,
@@ -188,6 +203,10 @@ async function queryLiveSandboxConnectionIds(
     };
   } finally {
     try {
+      for (const sub of subscriptions) {
+        sub.removeAllListeners();
+        sub.unsubscribe();
+      }
       client?.disconnect();
     } catch {
       // Ignore cleanup failures.
@@ -357,7 +376,10 @@ export class HybridSandboxManager implements SandboxManager {
         return connections;
       }
 
-      const presence = await queryLiveSandboxConnectionIds(this.userID);
+      const presence = await queryLiveSandboxConnectionIds(
+        this.userID,
+        connections.map((connection) => connection.connectionId),
+      );
       if (!presence.reliable) {
         logStructured("warn", "local_sandbox_presence_unavailable", {
           user_id: this.userID,

--- a/lib/centrifugo/types.ts
+++ b/lib/centrifugo/types.ts
@@ -7,13 +7,13 @@ export interface CommandMessage {
   timeout?: number;
   background?: boolean;
   displayName?: string;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 export interface CommandCancelMessage {
   type: "command_cancel";
   commandId: string;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 export interface StdoutMessage {
@@ -51,14 +51,14 @@ export interface PtyCreateMessage {
   rows?: number;
   cwd?: string;
   env?: Record<string, string>;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 export interface PtyInputMessage {
   type: "pty_input";
   sessionId: string;
   data: string;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 export interface PtyResizeMessage {
@@ -66,13 +66,13 @@ export interface PtyResizeMessage {
   sessionId: string;
   cols: number;
   rows: number;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 export interface PtyKillMessage {
   type: "pty_kill";
   sessionId: string;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 // ── PTY outgoing messages (local runner / desktop bridge → server) ────
@@ -123,12 +123,14 @@ export type SandboxMessage =
   | PtyErrorMessage;
 
 /**
- * Build the Centrifugo channel name for a user's sandbox.
- * The `#` is Centrifugo's user channel boundary separator: with
- * `allow_user_limited_channels: true` in the server config, Centrifugo
- * restricts subscription to clients whose JWT `sub` claim matches the
- * segment after `#`.
+ * Build the Centrifugo channel name for a single local/desktop sandbox
+ * connection. The `#` segment keeps Centrifugo's user-limited channel check,
+ * while the random connection id prevents same-user agents from sharing one
+ * command stream.
  */
-export function sandboxChannel(userId: string): string {
-  return `sandbox:user#${userId}`;
+export function sandboxConnectionChannel(
+  userId: string,
+  connectionId: string,
+): string {
+  return `sandbox:connection:${connectionId}#${userId}`;
 }

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hackerai/local",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "HackerAI Local Sandbox Client - Execute commands on your local machine",
   "bin": {
     "hackerai-local": "./dist/index.js"

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -188,13 +188,13 @@ interface CentrifugoCommandMessage {
   timeout?: number;
   background?: boolean;
   displayName?: string;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 interface CentrifugoCommandCancelMessage {
   type: "command_cancel";
   commandId: string;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 interface CentrifugoStdoutMessage {
@@ -232,14 +232,14 @@ interface PtyCreateMessage {
   rows?: number;
   cwd?: string;
   env?: Record<string, string>;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 interface PtyInputMessage {
   type: "pty_input";
   sessionId: string;
   data: string;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 interface PtyResizeMessage {
@@ -247,14 +247,14 @@ interface PtyResizeMessage {
   sessionId: string;
   cols: number;
   rows: number;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 interface PtyKillMessage {
   type: "pty_kill";
   sessionId: string;
   signal?: string;
-  targetConnectionId?: string;
+  targetConnectionId: string;
 }
 
 type CentrifugoPtyIncomingMessage =
@@ -262,6 +262,32 @@ type CentrifugoPtyIncomingMessage =
   | PtyInputMessage
   | PtyResizeMessage
   | PtyKillMessage;
+
+type TargetedIncomingMessage =
+  | CentrifugoCommandMessage
+  | CentrifugoCommandCancelMessage
+  | CentrifugoPtyIncomingMessage;
+
+function isTargetedIncomingMessage(
+  message: unknown,
+): message is TargetedIncomingMessage {
+  if (typeof message !== "object" || message === null) {
+    return false;
+  }
+  const { type, targetConnectionId } = message as {
+    type?: unknown;
+    targetConnectionId?: unknown;
+  };
+  return (
+    typeof targetConnectionId === "string" &&
+    (type === "command" ||
+      type === "command_cancel" ||
+      type === "pty_create" ||
+      type === "pty_input" ||
+      type === "pty_resize" ||
+      type === "pty_kill")
+  );
+}
 
 // --- PTY outgoing message types ---
 
@@ -557,21 +583,19 @@ class LocalSandboxClient {
       },
     });
 
-    const channel = `sandbox:user#${this.userId}`;
+    const channel = `sandbox:connection:${this.connectionId}#${this.userId}`;
     this.subscription = this.centrifuge.newSubscription(channel);
 
     this.subscription.on("publication", (ctx: PublicationContext) => {
       if (this.isShuttingDown) return;
 
-      const message = ctx.data as
-        | CentrifugoCommandMessage
-        | CentrifugoCommandCancelMessage
-        | CentrifugoPtyIncomingMessage;
+      const message = ctx.data;
 
-      // Gate on targetConnectionId for all message types that carry it
-      const targetId = (message as { targetConnectionId?: string })
-        .targetConnectionId;
-      if (targetId && targetId !== this.connectionId) {
+      if (!isTargetedIncomingMessage(message)) {
+        return;
+      }
+
+      if (message.targetConnectionId !== this.connectionId) {
         return;
       }
 


### PR DESCRIPTION
## Summary

Fixes the local sandbox command-forgery path by moving command and result traffic off the shared per-user Centrifugo channel and onto per-connection channels.

## What changed

- Use `sandbox:connection:<connectionId>#<userId>` for local, desktop, one-shot command, and PTY streams.
- Require `targetConnectionId` on command and PTY control message types.
- Drop inbound local/desktop command/control publications unless they are targeted at the current connection.
- Update presence probes to check known per-connection channels instead of enumerating a shared per-user channel.
- Update Centrifugo docs and tests for the per-connection channel model.

## Why

The previous shared `sandbox:user#<userId>` channel let any same-user subscriber publish command messages that other local/desktop agents would execute. Missing `targetConnectionId` was treated as broadcast, and the shared channel also exposed connection-level traffic. Per-connection channels keep the Centrifugo user boundary while preventing one authorized local agent from joining another agent's command stream.

## Validation

- `pnpm test -- app/services/__tests__/desktop-sandbox-bridge.test.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts`
- `pnpm typecheck`
- `pnpm --dir packages/local build`
- `pnpm lint` (passes with existing warnings)
- pre-commit: full `jest` suite, 102 suites / 1231 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Presence detection now tracks individual connections for more accurate online counts.
  * Command and message routing uses per-connection channels so communications are scoped to each active connection.

* **Bug Fixes**
  * Commands and PTY control messages without a matching target connection are now ignored to prevent cross-connection delivery.

* **Documentation**
  * Channel security docs updated to describe the new connection-scoped channel format.

* **Tests**
  * Updated tests to reflect per-connection channel behavior and targeted message handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->