### PR TITLE
[codex] Harden macOS rustup install in desktop build

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -51,7 +51,7 @@ jobs:
   build:
     needs: prepare
     permissions:
-      contents: write
+      contents: read
     environment: ${{ matrix.platform == 'windows-latest' && 'trusted-signing' || '' }}
     strategy:
       fail-fast: false
@@ -79,6 +79,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -113,19 +115,47 @@ jobs:
           # already scoped to packages/desktop/src-tauri and covers it.
           cache: false
 
-      - name: Install Rust stable (macOS — bypass rustup-init shim)
+      - name: Install Rust stable (macOS - pinned rustup-init)
         if: matrix.platform == 'macos-latest'
         shell: bash
+        env:
+          RUSTUP_VERSION: 1.29.0
+          RUSTUP_INIT_SHA256_AARCH64_APPLE_DARWIN: aeb4105778ca1bd3c6b0e75768f581c656633cd51368fa61289b6a71696ac7e1
+          RUSTUP_INIT_SHA256_X86_64_APPLE_DARWIN: 33cf85df9142bc6d29cbc62fa5ca1d4c29622cddb55213a4c1a43c457fb9b2d7
         run: |
+          set -euo pipefail
+
           # The standard rust-toolchain actions short-circuit on
           # `command -v rustup`, but the GitHub-hosted macOS runner ships a
           # `rustup-init` shim aliased as `rustup`/`cargo`, fooling that
           # heuristic. The action then skips installing the real toolchain
           # and `cargo metadata` invokes the shim, which doesn't know
-          # `metadata` and dies with rustup-init's usage screen. Install
-          # rustup directly to bypass the broken detection.
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL \
-            https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
+          # `metadata` and dies with rustup-init's usage screen. Download an
+          # archived rustup-init binary and verify its pinned checksum instead
+          # of executing a live shell installer.
+          case "$(uname -m)" in
+            arm64)
+              rustup_host="aarch64-apple-darwin"
+              rustup_sha256="$RUSTUP_INIT_SHA256_AARCH64_APPLE_DARWIN"
+              ;;
+            x86_64)
+              rustup_host="x86_64-apple-darwin"
+              rustup_sha256="$RUSTUP_INIT_SHA256_X86_64_APPLE_DARWIN"
+              ;;
+            *)
+              echo "::error::Unsupported macOS runner architecture: $(uname -m)"
+              exit 1
+              ;;
+          esac
+
+          rustup_init="$RUNNER_TEMP/rustup-init"
+          rustup_url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustup_host}/rustup-init"
+
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSLo "$rustup_init" "$rustup_url"
+          printf '%s  %s\n' "$rustup_sha256" "$rustup_init" | shasum -a 256 -c -
+          chmod +x "$rustup_init"
+          "$rustup_init" -y --default-host "$rustup_host" --default-toolchain stable --profile minimal --no-modify-path
+
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           "$HOME/.cargo/bin/rustup" target add "${{ matrix.target }}"
           "$HOME/.cargo/bin/cargo" --version
@@ -289,10 +319,14 @@ jobs:
     needs: [prepare, build]
     runs-on: macos-latest
     if: needs.prepare.outputs.should_release == 'true'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Download macOS arm64 artifact
         uses: actions/download-artifact@v4
@@ -483,6 +517,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

- Replace the macOS `curl | sh` rustup install path with an archived `rustup-init` 1.29.0 binary download.
- Verify the macOS arm64 and x86_64 installers against pinned SHA256 values before execution.
- Keep the original macOS runner shim workaround and explicit target install behavior intact.
- Reduce token exposure by making non-publishing jobs read-only and disabling checkout credential persistence where pushes are not needed.

## Why

The desktop release workflow installed Rust on macOS by executing the live rustup shell installer before later signing, notarization, updater signing, and artifact upload steps. A compromised installer delivery path could persist tool wrappers into `$HOME/.cargo/bin`, affect later build steps, or target release credentials.

This keeps the manual macOS install path because the original commit was working around GitHub-hosted macOS runner shim behavior, but removes the unpinned remote shell execution from the release job.

## Validation

- `git diff --check`
- Parsed `.github/workflows/desktop-build.yml` with Ruby YAML loader
- Syntax-checked the updated macOS bash block after substituting the GitHub matrix expression
- Fetched Rust's published `.sha256` files for the archived macOS `rustup-init` 1.29.0 binaries and confirmed they match the pinned workflow values
- Confirmed no `curl | sh` or `sh.rustup.rs` path remains in the workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated desktop build workflow with revised permission settings and checkout configurations across multiple jobs.
  * Improved macOS Rust toolchain installation process with archive-based setup and checksum verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->