### PR TITLE
[codex] Redact Convex file validation logs

### DIFF
--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -26,6 +26,7 @@ import { hasRestageableLocalDesktopAttachments } from "@/lib/utils/local-attachm
 import type { ChatMode } from "@/types/chat";
 import { getMessagePersistenceDiagnostics } from "./message-persistence-diagnostics";
 import { sanitizeForConvexValue } from "./convex-value-sanitizer";
+import { stringifyRedactedError } from "@/lib/utils/error-redaction";
 
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 const MAX_DATABASE_ERROR_MESSAGE_LENGTH = 500;
@@ -62,13 +63,7 @@ const sensitiveErrorDataKeys = new Set([
 export { setConvexUrl };
 
 const stringifyError = (error: unknown): string => {
-  if (error instanceof Error) return error.message;
-  if (typeof error === "string") return error;
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return String(error);
-  }
+  return stringifyRedactedError(error);
 };
 
 const getErrorData = (error: unknown): unknown => {
@@ -94,7 +89,9 @@ const isSensitiveErrorDataKey = (key: string): boolean => {
   const normalized = key.replace(/[-_\s]/g, "").toLowerCase();
   return (
     sensitiveErrorDataKeys.has(normalized) ||
-    /apikey|authorization|bearer|cookie|password|secret/.test(normalized)
+    /apikey|authorization|bearer|cookie|password|secret|servicekey/.test(
+      normalized,
+    )
   );
 };
 

--- a/lib/utils/__tests__/error-redaction.test.ts
+++ b/lib/utils/__tests__/error-redaction.test.ts
@@ -1,0 +1,29 @@
+import {
+  redactSensitiveErrorMessage,
+  stringifyRedactedError,
+} from "../error-redaction";
+
+describe("error redaction", () => {
+  it("redacts service keys from Convex validation messages", () => {
+    const message =
+      'ArgumentValidationError: Object is missing the required field `userId`.\n\nObject: {fileIds: ["file1"], serviceKey: "secret-value"}';
+
+    expect(redactSensitiveErrorMessage(message)).toContain(
+      'serviceKey: "[Redacted]"',
+    );
+    expect(redactSensitiveErrorMessage(message)).not.toContain("secret-value");
+  });
+
+  it("redacts sensitive fields from non-Error values", () => {
+    const redacted = stringifyRedactedError({
+      message: "failed",
+      service_key: "service-secret",
+      token: "token-secret",
+    });
+
+    expect(redacted).toContain('service_key":"[Redacted]"');
+    expect(redacted).toContain('token":"[Redacted]"');
+    expect(redacted).not.toContain("service-secret");
+    expect(redacted).not.toContain("token-secret");
+  });
+});

--- a/lib/utils/error-redaction.ts
+++ b/lib/utils/error-redaction.ts
@@ -1,0 +1,33 @@
+const REDACTED_VALUE = "[Redacted]";
+
+const SENSITIVE_FIELD_PATTERN =
+  /(["']?\b(?:serviceKey|service_key|apiKey|api_key|authorization|bearer|cookie|password|secret|token)\b["']?)(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,}]+)/gi;
+
+const ENV_SECRET_PATTERN =
+  /(["']?\b(?:CONVEX_SERVICE_ROLE_KEY|POSTHOG_API_KEY|STRIPE_SECRET_KEY)\b["']?)(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,}]+)/gi;
+
+export const redactSensitiveErrorMessage = (message: string): string =>
+  message
+    .replace(SENSITIVE_FIELD_PATTERN, (_match, key, separator) => {
+      return `${key}${separator}"${REDACTED_VALUE}"`;
+    })
+    .replace(ENV_SECRET_PATTERN, (_match, key, separator) => {
+      return `${key}${separator}"${REDACTED_VALUE}"`;
+    });
+
+export const stringifyRedactedError = (error: unknown): string => {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : (() => {
+            try {
+              return JSON.stringify(error);
+            } catch {
+              return String(error);
+            }
+          })();
+
+  return redactSensitiveErrorMessage(message);
+};

--- a/lib/utils/file-token-utils.ts
+++ b/lib/utils/file-token-utils.ts
@@ -10,6 +10,8 @@ import {
 } from "@/lib/token-utils";
 import type { SubscriptionTier } from "@/types";
 import type { FileMessagePart } from "@/types/file";
+import { logger } from "@/lib/logger";
+import { stringifyRedactedError } from "@/lib/utils/error-redaction";
 
 /**
  * Type guard to check if a message part is a file part
@@ -34,9 +36,17 @@ export const extractFileIdsFromParts = (
  */
 export const getFileTokensByIds = async (
   fileIds: Id<"files">[],
-  userId: string,
+  userId: string | undefined,
 ): Promise<Record<Id<"files">, number>> => {
   if (!fileIds.length) return {};
+  if (!userId) {
+    logger.warn("file_token_fetch_skipped_missing_user_id", {
+      event: "file_token_fetch_skipped_missing_user_id",
+      service: "chat-handler",
+      file_count: fileIds.length,
+    });
+    return {};
+  }
 
   try {
     const tokens = await getConvexClient().query(
@@ -52,7 +62,12 @@ export const getFileTokensByIds = async (
       fileIds.map((id, i) => [id, tokens[i] || 0]),
     ) as Record<Id<"files">, number>;
   } catch (error) {
-    console.error("Failed to fetch file tokens:", error);
+    logger.warn("file_token_fetch_failed", {
+      event: "file_token_fetch_failed",
+      service: "chat-handler",
+      error: stringifyRedactedError(error),
+      file_count: fileIds.length,
+    });
     return {};
   }
 };

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -17,6 +17,7 @@ import { getMaxFileTokens } from "../token-utils";
 import type { SubscriptionTier } from "@/types";
 import { logger } from "@/lib/logger";
 import { validateDownloadUrl } from "@/lib/ai/tools/utils/path-validation";
+import { stringifyRedactedError } from "@/lib/utils/error-redaction";
 
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 const MAX_PROVIDER_IMAGE_DOWNLOAD_SIZE = 30 * 1024 * 1024;
@@ -290,9 +291,17 @@ const collectFilesToProcess = (
 
 const fetchFileUrls = async (
   fileIds: string[],
-  userId: string,
+  userId: string | undefined,
 ): Promise<(string | null)[]> => {
   if (!fileIds.length) return [];
+  if (!userId) {
+    logger.warn("file_url_fetch_skipped_missing_user_id", {
+      event: "file_url_fetch_skipped_missing_user_id",
+      service: "chat-handler",
+      file_count: fileIds.length,
+    });
+    return [];
+  }
 
   try {
     return await getConvexClient().action(
@@ -304,9 +313,11 @@ const fetchFileUrls = async (
       },
     );
   } catch (error) {
-    console.error("Failed to fetch file URLs:", {
-      error: error instanceof Error ? error.message : String(error),
-      fileCount: fileIds.length,
+    logger.warn("file_url_fetch_failed", {
+      event: "file_url_fetch_failed",
+      service: "chat-handler",
+      error: stringifyRedactedError(error),
+      file_count: fileIds.length,
     });
     return [];
   }
@@ -571,10 +582,18 @@ const formatUnprocessableDocument = (name: string, reason: string) =>
 const addDocumentContentToMessages = async (
   messages: UIMessage[],
   fileIds: Id<"files">[],
-  userId: string,
+  userId: string | undefined,
   maxFileTokens: number = getMaxFileTokens("pro"),
 ): Promise<void> => {
   if (!fileIds.length || !messages.length) return;
+  if (!userId) {
+    logger.warn("document_content_fetch_skipped_missing_user_id", {
+      event: "document_content_fetch_skipped_missing_user_id",
+      service: "chat-handler",
+      file_count: fileIds.length,
+    });
+    return;
+  }
 
   try {
     const fileContents = await getConvexClient().query(
@@ -644,9 +663,11 @@ const addDocumentContentToMessages = async (
       }
     });
   } catch (error) {
-    console.error("Failed to fetch and add document content:", {
-      error: error instanceof Error ? error.message : String(error),
-      fileIds,
+    logger.warn("document_content_fetch_failed", {
+      event: "document_content_fetch_failed",
+      service: "chat-handler",
+      error: stringifyRedactedError(error),
+      file_count: fileIds.length,
     });
   }
 };


### PR DESCRIPTION
## Summary

- Add a shared error redaction helper for sensitive fields such as `serviceKey`, tokens, and secrets.
- Guard backend file URL/content/token fetches when `userId` is missing so Convex does not emit noisy argument validation errors.
- Route file-processing and database error messages through redaction before logging.

## Root Cause

A backend file-fetch path could attempt Convex calls without a runtime `userId`. Convex then rejected the object before the handler ran, and the validation message included the submitted `serviceKey` in the logged object.

## Impact

The file fetch gracefully degrades when the authenticated user context is unavailable, and any similar validation/logging path redacts sensitive values before they reach logs.

## Validation

- `pnpm typecheck`
- `pnpm eslint lib/utils/error-redaction.ts lib/utils/file-transform-utils.ts lib/utils/file-token-utils.ts lib/db/actions.ts lib/utils/__tests__/error-redaction.test.ts`
- `pnpm exec prettier --check lib/utils/error-redaction.ts lib/utils/file-transform-utils.ts lib/utils/file-token-utils.ts lib/db/actions.ts lib/utils/__tests__/error-redaction.test.ts`
- `pnpm jest lib/utils/__tests__/error-redaction.test.ts lib/utils/__tests__/file-transform-utils.test.ts --runInBand`
- Commit hook: full `pnpm test` passed, 104 suites / 1249 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Implemented automatic redaction of sensitive fields (API keys, credentials, authentication tokens) from error messages logged to the database to prevent accidental exposure.

* **Bug Fixes**
  * Improved error handling for missing user information in file operations with graceful fallback behavior.
  * Enhanced error logging throughout the application to prevent exposure of sensitive data.

* **Tests**
  * Added comprehensive test coverage validating redaction of sensitive information in error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->