### PR TITLE
[codex] Fix Windows Git Bash discovery hijack

### DIFF
--- a/packages/desktop/src-tauri/src/platform.rs
+++ b/packages/desktop/src-tauri/src/platform.rs
@@ -76,14 +76,13 @@ pub fn get_shell_config() -> ShellConfig {
 /// Locate `bash.exe` from Git for Windows. Tries:
 ///   1. `HACKERAI_BASH_PATH` env override
 ///   2. Common install locations
-///   3. `where git` → `<gitDir>/../../bin/bash.exe`
+///   3. PATH/PATHEXT lookup for `git` without invoking a searched helper
 #[cfg(windows)]
 fn find_git_bash() -> Option<String> {
     use std::path::PathBuf;
-    use std::process::Command as StdCommand;
 
     if let Ok(p) = std::env::var("HACKERAI_BASH_PATH") {
-        if PathBuf::from(&p).exists() {
+        if PathBuf::from(&p).is_file() {
             return Some(p);
         }
     }
@@ -93,31 +92,74 @@ fn find_git_bash() -> Option<String> {
         "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
     ];
     for c in &candidates {
-        if PathBuf::from(c).exists() {
+        if PathBuf::from(c).is_file() {
             return Some((*c).to_string());
         }
     }
 
-    if let Ok(out) = StdCommand::new("where").arg("git").output() {
-        if out.status.success() {
-            let stdout = String::from_utf8_lossy(&out.stdout);
-            for line in stdout.lines() {
-                let line = line.trim();
-                if line.to_lowercase().ends_with("git.exe") {
-                    // <gitDir>/cmd/git.exe → <gitDir>/bin/bash.exe
-                    let p = PathBuf::from(line);
-                    if let Some(git_dir) = p.parent().and_then(|d| d.parent()) {
-                        let bash = git_dir.join("bin").join("bash.exe");
-                        if bash.exists() {
-                            return bash.to_str().map(|s| s.to_string());
-                        }
-                    }
-                }
-            }
-        }
+    if let Some(git) = find_windows_executable_on_path("git") {
+        return resolve_git_bash_from_git(&git);
     }
 
     None
+}
+
+#[cfg(windows)]
+fn resolve_git_bash_from_git(git: &std::path::Path) -> Option<String> {
+    // <gitDir>\cmd\git.exe -> <gitDir>\bin\bash.exe
+    let git_dir = git.parent().and_then(|d| d.parent())?;
+    let bash = git_dir.join("bin").join("bash.exe");
+    if bash.is_file() {
+        bash.to_str().map(|s| s.to_string())
+    } else {
+        None
+    }
+}
+
+#[cfg(windows)]
+fn find_windows_executable_on_path(command: &str) -> Option<std::path::PathBuf> {
+    let extensions = get_windows_path_extensions(command);
+    for dir in get_windows_path_entries() {
+        for extension in &extensions {
+            let candidate = dir.join(format!("{command}{extension}"));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(windows)]
+fn get_windows_path_entries() -> Vec<std::path::PathBuf> {
+    std::env::var_os("PATH")
+        .map(|path| {
+            std::env::split_paths(&path)
+                .filter(|entry| entry.is_absolute())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(windows)]
+fn get_windows_path_extensions(command: &str) -> Vec<String> {
+    if std::path::Path::new(command).extension().is_some() {
+        return vec![String::new()];
+    }
+
+    let pathext = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
+    pathext
+        .split(';')
+        .map(str::trim)
+        .filter(|extension| !extension.is_empty())
+        .map(|extension| {
+            if extension.starts_with('.') {
+                extension.to_string()
+            } else {
+                format!(".{extension}")
+            }
+        })
+        .collect()
 }
 
 /// Build a `tokio::process::Command` from an exec request.

--- a/packages/desktop/src-tauri/src/pty.rs
+++ b/packages/desktop/src-tauri/src/pty.rs
@@ -59,14 +59,13 @@ impl PtyManager {
             })
             .map_err(|e| format!("Failed to open PTY: {}", e))?;
 
-        let shell = get_default_shell();
+        let shell_config = platform::get_shell_config();
 
         let mut cmd = if command.is_empty() {
-            CommandBuilder::new(&shell)
+            CommandBuilder::new(&shell_config.shell)
         } else {
-            let mut c = CommandBuilder::new(&shell);
-            let shell_flag = get_shell_exec_flag(&shell);
-            c.arg(shell_flag);
+            let mut c = CommandBuilder::new(&shell_config.shell);
+            c.arg(shell_config.flag);
             c.arg(&command);
             c
         };
@@ -267,19 +266,4 @@ fn send_exit(on_data: &Channel<String>, exit_code: i32, session_id: &str) {
     })
     .to_string();
     let _ = on_data.send(msg);
-}
-
-/// Get the default shell for the current platform.
-fn get_default_shell() -> String {
-    let config = platform::get_shell_config();
-    config.shell
-}
-
-/// Get the flag used to execute a command string in the given shell.
-fn get_shell_exec_flag(shell: &str) -> &'static str {
-    if shell.contains("cmd") {
-        "/C"
-    } else {
-        "-c"
-    }
 }

--- a/packages/desktop/src-tauri/src/pty.rs
+++ b/packages/desktop/src-tauri/src/pty.rs
@@ -2,6 +2,7 @@ use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::thread;
 use tauri::ipc::Channel;
@@ -15,6 +16,7 @@ struct PtySession {
     child: Box<dyn portable_pty::Child + Send + Sync>,
     writer: Box<dyn Write + Send>,
     reader_shutdown: Arc<std::sync::atomic::AtomicBool>,
+    command_script: Option<PathBuf>,
 }
 
 pub struct PtyManager {
@@ -60,15 +62,7 @@ impl PtyManager {
             .map_err(|e| format!("Failed to open PTY: {}", e))?;
 
         let shell_config = platform::get_shell_config();
-
-        let mut cmd = if command.is_empty() {
-            CommandBuilder::new(&shell_config.shell)
-        } else {
-            let mut c = CommandBuilder::new(&shell_config.shell);
-            c.arg(shell_config.flag);
-            c.arg(&command);
-            c
-        };
+        let (mut cmd, command_script) = build_pty_command(&shell_config, &command)?;
 
         if let Some(ref dir) = cwd {
             cmd.cwd(dir);
@@ -80,39 +74,51 @@ impl PtyManager {
             }
         }
 
-        let child = pair
-            .slave
-            .spawn_command(cmd)
-            .map_err(|e| format!("Failed to spawn command: {}", e))?;
+        let child = match pair.slave.spawn_command(cmd) {
+            Ok(child) => child,
+            Err(e) => {
+                cleanup_command_script(command_script.as_deref());
+                return Err(format!("Failed to spawn command: {}", e));
+            }
+        };
 
         let pid = child.process_id();
 
-        let reader = pair
-            .master
-            .try_clone_reader()
-            .map_err(|e| format!("Failed to clone PTY reader: {}", e))?;
+        let reader = match pair.master.try_clone_reader() {
+            Ok(reader) => reader,
+            Err(e) => {
+                cleanup_command_script(command_script.as_deref());
+                return Err(format!("Failed to clone PTY reader: {}", e));
+            }
+        };
 
         let shutdown_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let shutdown_clone = shutdown_flag.clone();
+        let command_script_cleanup = command_script.clone();
 
         let session_id_clone = session_id.clone();
         thread::spawn(move || {
             pty_reader_thread(reader, on_data, shutdown_clone, session_id_clone);
+            cleanup_command_script(command_script_cleanup.as_deref());
         });
 
         // Take the writer ONCE at creation time and cache it. Calling
         // take_writer() on every send_input duplicates the fd each time,
         // which was causing sendInput failures and eventual resource issues.
-        let writer = pair
-            .master
-            .take_writer()
-            .map_err(|e| format!("Failed to get PTY writer: {}", e))?;
+        let writer = match pair.master.take_writer() {
+            Ok(writer) => writer,
+            Err(e) => {
+                cleanup_command_script(command_script.as_deref());
+                return Err(format!("Failed to get PTY writer: {}", e));
+            }
+        };
 
         let session = PtySession {
             master: pair.master,
             child,
             writer,
             reader_shutdown: shutdown_flag,
+            command_script,
         };
 
         let result = PtyCreateResult {
@@ -173,12 +179,13 @@ impl PtyManager {
             .reader_shutdown
             .store(true, std::sync::atomic::Ordering::Relaxed);
 
-        session
-            .child
-            .kill()
-            .map_err(|e| format!("Failed to kill PTY child: {}", e))?;
+        if let Err(e) = session.child.kill() {
+            cleanup_command_script(session.command_script.as_deref());
+            return Err(format!("Failed to kill PTY child: {}", e));
+        }
 
         let _ = session.child.wait();
+        cleanup_command_script(session.command_script.as_deref());
 
         Ok(())
     }
@@ -190,6 +197,74 @@ impl PtyManager {
                 log::warn!("Failed to kill PTY session '{}': {}", id, e);
             }
         }
+    }
+}
+
+fn build_pty_command(
+    shell_config: &platform::ShellConfig,
+    command: &str,
+) -> Result<(CommandBuilder, Option<PathBuf>), String> {
+    if command.is_empty() {
+        return Ok((CommandBuilder::new(&shell_config.shell), None));
+    }
+
+    #[cfg(windows)]
+    if shell_config.is_cmd {
+        // portable-pty does not expose raw_arg, so keep the command body out of
+        // its MSVCRT-style argument quoting path when falling back to cmd.exe.
+        let script = write_cmd_script(command)?;
+        let mut cmd = CommandBuilder::new(&shell_config.shell);
+        cmd.arg(shell_config.flag);
+        cmd.arg("call");
+        cmd.arg(script.as_os_str());
+        return Ok((cmd, Some(script)));
+    }
+
+    let mut cmd = CommandBuilder::new(&shell_config.shell);
+    cmd.arg(shell_config.flag);
+    cmd.arg(command);
+    Ok((cmd, None))
+}
+
+#[cfg(windows)]
+fn write_cmd_script(command: &str) -> Result<PathBuf, String> {
+    use std::fs::OpenOptions;
+    use uuid::Uuid;
+
+    for _ in 0..8 {
+        let path = std::env::temp_dir().join(format!("hackerai-pty-{}.cmd", Uuid::new_v4()));
+        let mut file = match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => file,
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => {
+                return Err(format!(
+                    "Failed to create temporary cmd script '{}': {}",
+                    path.display(),
+                    err
+                ));
+            }
+        };
+
+        file.write_all(b"@echo off\r\n")
+            .and_then(|_| file.write_all(command.as_bytes()))
+            .and_then(|_| file.write_all(b"\r\n"))
+            .map_err(|err| {
+                format!(
+                    "Failed to write temporary cmd script '{}': {}",
+                    path.display(),
+                    err
+                )
+            })?;
+
+        return Ok(path);
+    }
+
+    Err("Failed to create a unique temporary cmd script".to_string())
+}
+
+fn cleanup_command_script(path: Option<&Path>) {
+    if let Some(path) = path {
+        let _ = std::fs::remove_file(path);
     }
 }
 

--- a/packages/local/src/utils.ts
+++ b/packages/local/src/utils.ts
@@ -3,9 +3,8 @@
  * Extracted for testability.
  */
 
-import { existsSync } from "fs";
-import { execSync } from "child_process";
-import { join, dirname } from "path";
+import { statSync } from "fs";
+import { win32 as pathWin32 } from "path";
 
 // Align with LLM context limits (~4096 tokens ≈ 12288 chars)
 export const MAX_OUTPUT_SIZE = 12288;
@@ -66,37 +65,91 @@ export function getDefaultShell(platform: string): ShellConfig {
  * Locate `bash.exe` from Git for Windows. Tries, in order:
  *   1. `HACKERAI_BASH_PATH` environment override
  *   2. Common install locations
- *   3. `where git` → resolve `<gitDir>/../../bin/bash.exe`
+ *   3. PATH/PATHEXT lookup for `git` without invoking a searched helper
  * Returns null if not found.
  */
 export function findGitBash(): string | null {
   const override = process.env.HACKERAI_BASH_PATH;
-  if (override && existsSync(override)) return override;
+  if (override && isFile(override)) return override;
 
   const candidates = [
     "C:\\Program Files\\Git\\bin\\bash.exe",
     "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
   ];
   for (const c of candidates) {
-    if (existsSync(c)) return c;
+    if (isFile(c)) return c;
   }
 
-  try {
-    const out = execSync("where git", {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    const gitExe = out.split(/\r?\n/).find((l) => l.trim().endsWith("git.exe"));
-    if (gitExe) {
-      // <gitDir>/cmd/git.exe → <gitDir>/bin/bash.exe
-      const bash = join(dirname(dirname(gitExe.trim())), "bin", "bash.exe");
-      if (existsSync(bash)) return bash;
-    }
-  } catch {
-    // `where` not found or no git installed — fall through
+  const git = findWindowsExecutableOnPath("git");
+  if (git) {
+    const bash = resolveGitBashFromGit(git);
+    if (bash) return bash;
   }
 
   return null;
+}
+
+function resolveGitBashFromGit(git: string): string | null {
+  // <gitDir>\cmd\git.exe -> <gitDir>\bin\bash.exe
+  const bash = pathWin32.join(
+    pathWin32.dirname(pathWin32.dirname(git)),
+    "bin",
+    "bash.exe",
+  );
+  return isFile(bash) ? bash : null;
+}
+
+function findWindowsExecutableOnPath(command: string): string | null {
+  const extensions = getWindowsPathExtensions(command);
+  for (const dir of getWindowsPathEntries()) {
+    for (const extension of extensions) {
+      const candidate = pathWin32.join(dir, `${command}${extension}`);
+      if (isFile(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+function getWindowsPathEntries(): string[] {
+  const pathKey = Object.keys(process.env).find(
+    (key) => key.toLowerCase() === "path",
+  );
+  const pathValue = pathKey ? process.env[pathKey] : undefined;
+  if (!pathValue) return [];
+
+  return pathValue
+    .split(";")
+    .map((entry) => entry.trim().replace(/^"|"$/g, ""))
+    .filter(
+      (entry) => entry !== "" && entry !== "." && pathWin32.isAbsolute(entry),
+    );
+}
+
+function getWindowsPathExtensions(command: string): string[] {
+  if (pathWin32.extname(command)) return [""];
+
+  const pathExtKey = Object.keys(process.env).find(
+    (key) => key.toLowerCase() === "pathext",
+  );
+  const pathExtValue = pathExtKey ? process.env[pathExtKey] : undefined;
+  const extensions = pathExtValue
+    ? pathExtValue.split(";")
+    : [".COM", ".EXE", ".BAT", ".CMD"];
+
+  return extensions
+    .map((extension) => extension.trim())
+    .filter(Boolean)
+    .map((extension) =>
+      extension.startsWith(".") ? extension : `.${extension}`,
+    );
+}
+
+function isFile(file: string): boolean {
+  try {
+    return statSync(file).isFile();
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the Windows Git Bash discovery fallback in both the Node local client and the Tauri desktop client so it no longer executes a searched `where` helper.

## Root Cause

The previous fallback used `execSync("where git")` in the Node client and `StdCommand::new("where")` in the desktop client. On Windows, resolving `where` by basename can execute an attacker-controlled `where.exe`, `where.cmd`, or `where.bat` from the current directory or PATH before any intended sandbox command runs.

## Changes

- Removed shell-based `execSync("where git")` from `packages/local/src/utils.ts`.
- Removed `StdCommand::new("where")` from `packages/desktop/src-tauri/src/platform.rs`.
- Added conservative Windows PATH/PATHEXT scanning that does not spawn a helper process.
- Skips current-directory and relative PATH entries during discovery.
- Requires discovered `git` and derived `bash.exe` paths to be files.
- Preserves the existing discovery order: env override, common Program Files locations, then Git-derived Bash fallback.

## Validation

- `pnpm --dir packages/local build`
- `cargo fmt --manifest-path packages/desktop/src-tauri/Cargo.toml`
- `cargo check --manifest-path packages/desktop/src-tauri/Cargo.toml`
- `rg -n "where git|StdCommand::new\\(\\\"where\\\"\\)|execSync\\(" packages/local/src packages/desktop/src-tauri/src -S`
- Pre-commit hook: root `tsc --noEmit`
- Pre-commit hook: root `jest` passed 102 suites / 1230 tests

Note: I also attempted a Windows Rust target check from macOS earlier, but the dependency stack failed before this crate on `ring` because the environment lacks Windows/MSVC C headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Git Bash discovery on Windows: honors HACKERAI_BASH_PATH, checks common Git install locations, and searches PATH/PATHEXT without invoking external commands for more reliable startup.
  * Standardized shell launch flow: build and manage shell commands centrally, ensure temporary command-script cleanup, and unify how shells and execution flags are applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->