### PR TITLE
Secure desktop local file access

### DIFF
--- a/app/hooks/useTauri.ts
+++ b/app/hooks/useTauri.ts
@@ -151,13 +151,8 @@ export async function pickLocalFiles(): Promise<string[]> {
   if (!detectTauri()) return [];
 
   try {
-    const dialog = await import("@tauri-apps/plugin-dialog");
-    const selected = await dialog.open({
-      multiple: true,
-      directory: false,
-    });
-    if (!selected) return [];
-    return Array.isArray(selected) ? selected : [selected];
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<string[]>("pick_local_files");
   } catch (err) {
     console.error("[Tauri] Failed to pick local files:", err);
     toast.error("Failed to open file picker");

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -197,6 +197,55 @@ describe("targetConnectionId filtering", () => {
       expect.objectContaining({ command: "echo broadcast" }),
     );
   });
+
+  it("routes desktop-local attachment copies through the native grant check", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const config = buildConfig();
+    const bridge = new DesktopSandboxBridge(config);
+    await bridge.start();
+
+    const handler = getPublicationHandler();
+    (invoke as jest.Mock).mockClear();
+
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "copy_granted_local_file") {
+        return undefined;
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    };
+
+    const payload = btoa(
+      JSON.stringify({
+        sourcePath: "/Users/alice/report.pdf",
+        destPath: "/tmp/hackerai-upload/report.pdf",
+      }),
+    );
+
+    handler({
+      data: {
+        type: "command",
+        commandId: "cmd-copy",
+        command: `__hackerai_copy_granted_local_file__ ${payload}`,
+        targetConnectionId: "conn-123",
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(invoke).toHaveBeenCalledWith("copy_granted_local_file", {
+      sourcePath: "/Users/alice/report.pdf",
+      destPath: "/tmp/hackerai-upload/report.pdf",
+    });
+    expect(invoke).not.toHaveBeenCalledWith(
+      "execute_stream_command",
+      expect.anything(),
+    );
+    expect(mockSubscription.publish).toHaveBeenCalledWith({
+      type: "exit",
+      commandId: "cmd-copy",
+      exitCode: 0,
+    });
+  });
 });
 
 // ── extractUserIdFromToken ────────────────────────────────────────────

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -15,6 +15,8 @@ import {
   DEFAULT_PTY_ROWS,
 } from "@/lib/ai/tools/utils/pty-session-manager";
 
+const COPY_GRANTED_LOCAL_FILE_COMMAND = "__hackerai_copy_granted_local_file__";
+
 type RefreshTokenResult =
   | { ok: true; centrifugoToken: string }
   | {
@@ -45,6 +47,11 @@ interface StreamChunk {
   exitCode?: number;
   message?: string;
 }
+
+type CopyGrantedLocalFilePayload = {
+  sourcePath: string;
+  destPath: string;
+};
 
 // "Unauthenticated" UNAUTHORIZED still throws server-side (the user's auth
 // identity is missing/expired, not a connection lifecycle event), so the
@@ -259,6 +266,39 @@ export class DesktopSandboxBridge {
     return payload.sub;
   }
 
+  private parseCopyGrantedLocalFileCommand(
+    command: string,
+  ): CopyGrantedLocalFilePayload | null {
+    if (!command.startsWith(`${COPY_GRANTED_LOCAL_FILE_COMMAND} `)) {
+      return null;
+    }
+
+    const encodedPayload = command
+      .slice(COPY_GRANTED_LOCAL_FILE_COMMAND.length)
+      .trim();
+    if (!encodedPayload) {
+      throw new Error("Missing local file copy payload");
+    }
+
+    const binary = atob(encodedPayload);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    const payload = JSON.parse(
+      new TextDecoder().decode(bytes),
+    ) as Partial<CopyGrantedLocalFilePayload>;
+
+    if (
+      typeof payload.sourcePath !== "string" ||
+      typeof payload.destPath !== "string"
+    ) {
+      throw new Error("Invalid local file copy payload");
+    }
+
+    return {
+      sourcePath: payload.sourcePath,
+      destPath: payload.destPath,
+    };
+  }
+
   private async getOsInfo(): Promise<
     | { platform: string; arch: string; release: string; hostname: string }
     | undefined
@@ -333,6 +373,14 @@ export class DesktopSandboxBridge {
     this.activeCommands.add(commandId);
 
     try {
+      const copyLocalPayload = this.parseCopyGrantedLocalFileCommand(
+        command.command,
+      );
+      if (copyLocalPayload) {
+        await this.handleCopyGrantedLocalFile(commandId, copyLocalPayload);
+        return;
+      }
+
       const { invoke, Channel } = await import("@tauri-apps/api/core");
 
       const channel = new Channel<StreamChunk>();
@@ -367,6 +415,22 @@ export class DesktopSandboxBridge {
     } finally {
       this.activeCommands.delete(commandId);
     }
+  }
+
+  private async handleCopyGrantedLocalFile(
+    commandId: string,
+    payload: CopyGrantedLocalFilePayload,
+  ): Promise<void> {
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("copy_granted_local_file", {
+      sourcePath: payload.sourcePath,
+      destPath: payload.destPath,
+    });
+    await this.publishResult({
+      type: "exit",
+      commandId,
+      exitCode: 0,
+    });
   }
 
   private async handleCommandCancel(

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -31,6 +31,8 @@ const IGNORED_MESSAGE_TYPES = new Set([
   "pty_error",
 ]);
 
+const COPY_GRANTED_LOCAL_FILE_COMMAND = "__hackerai_copy_granted_local_file__";
+
 export function parseSandboxMessage(
   data: unknown,
 ): CommandResponseMessage | null {
@@ -819,23 +821,21 @@ Commands run directly on the host OS "${hostname}" without Docker isolation. Be 
       sourceRawPath: string,
       destRawPath: string,
     ): Promise<void> => {
-      const sourceCtx = await this.shellContext(sourceRawPath);
-      const destCtx = await this.shellContext(destRawPath);
-      const fileName = destCtx.path.split(/[/\\]/).pop() || "file";
-      const dir = CentrifugoSandbox.parentDir(destCtx.path);
+      const fileName = destRawPath.split(/[/\\]/).pop() || "file";
+      const payload = Buffer.from(
+        JSON.stringify({
+          sourcePath: sourceRawPath,
+          destPath: destRawPath,
+        }),
+        "utf8",
+      ).toString("base64");
 
-      const mkdirPart = !dir
-        ? ""
-        : destCtx.useBash
-          ? `mkdir -p ${destCtx.escapePath(dir)} &&`
-          : `if not exist ${destCtx.escapePath(dir)} mkdir ${destCtx.escapePath(dir)} &&`;
-      const copyPart = destCtx.useBash
-        ? `cp -f ${sourceCtx.escapePath(sourceCtx.path)} ${destCtx.escapePath(destCtx.path)}`
-        : `copy /Y ${sourceCtx.escapePath(sourceCtx.path)} ${destCtx.escapePath(destCtx.path)} >nul`;
-
-      const result = await this.commands.run(`${mkdirPart} ${copyPart}`, {
-        displayName: `Preparing: ${fileName}`,
-      });
+      const result = await this.commands.run(
+        `${COPY_GRANTED_LOCAL_FILE_COMMAND} ${payload}`,
+        {
+          displayName: `Preparing: ${fileName}`,
+        },
+      );
       if (result.exitCode !== 0) {
         throw new Error(
           `Failed to prepare local file: ${result.stderr || result.stdout}`,

--- a/packages/desktop/src-tauri/gen/schemas/acl-manifests.json
+++ b/packages/desktop/src-tauri/gen/schemas/acl-manifests.json
@@ -9,7 +9,10 @@
           "allow": [
             "get_dev_auth_port",
             "get_cmd_server_info",
+            "pick_local_files",
+            "copy_granted_local_file",
             "get_local_file_metadata",
+            "read_local_file",
             "execute_command",
             "execute_stream_command",
             "cancel_stream_command",

--- a/packages/desktop/src-tauri/permissions/desktop-command-bridge.toml
+++ b/packages/desktop/src-tauri/permissions/desktop-command-bridge.toml
@@ -4,6 +4,8 @@ description = "Allows the desktop webview to reach the local command bridge."
 commands.allow = [
   "get_dev_auth_port",
   "get_cmd_server_info",
+  "pick_local_files",
+  "copy_granted_local_file",
   "get_local_file_metadata",
   "read_local_file",
   "execute_command",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -2,16 +2,19 @@ mod platform;
 mod pty;
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::Manager;
 use tauri_plugin_updater::UpdaterExt;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
+const MAX_LOCAL_FILE_READ_BYTES: u64 = 20 * 1024 * 1024;
+const DESKTOP_UPLOAD_DIR: &str = "/tmp/hackerai-upload";
 
 /// Port for the local dev auth callback server (0 = not started)
 static DEV_AUTH_PORT: AtomicU16 = AtomicU16::new(0);
@@ -21,6 +24,8 @@ static CMD_SERVER_PORT: AtomicU16 = AtomicU16::new(0);
 
 /// Session token for authenticating command server requests
 static CMD_SERVER_TOKEN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+type LocalFileGrantState = Arc<Mutex<HashSet<PathBuf>>>;
 
 /// Get the dev auth callback port (0 if not running in dev mode)
 #[tauri::command]
@@ -107,15 +112,18 @@ fn guess_media_type(path: &std::path::Path) -> String {
     .to_string()
 }
 
-#[tauri::command]
-fn get_local_file_metadata(path: String) -> Result<LocalFileMetadata, String> {
-    let path_buf = PathBuf::from(&path);
-    let metadata = fs::metadata(&path_buf).map_err(|e| format!("Metadata error: {}", e))?;
+fn local_file_access_error() -> String {
+    "Local file access has not been granted for this path".to_string()
+}
+
+fn inspect_local_file(path: &Path) -> Result<(PathBuf, LocalFileMetadata), String> {
+    let canonical_path = fs::canonicalize(path).map_err(|e| format!("Metadata error: {}", e))?;
+    let metadata = fs::metadata(&canonical_path).map_err(|e| format!("Metadata error: {}", e))?;
     if !metadata.is_file() {
         return Err("Selected path is not a file".to_string());
     }
 
-    let name = path_buf
+    let name = canonical_path
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("file")
@@ -127,21 +135,133 @@ fn get_local_file_metadata(path: String) -> Result<LocalFileMetadata, String> {
         .map(|duration| duration.as_millis() as u64)
         .unwrap_or(0);
 
-    Ok(LocalFileMetadata {
-        path,
+    let local_metadata = LocalFileMetadata {
+        path: canonical_path.to_string_lossy().to_string(),
         name,
-        media_type: guess_media_type(&path_buf),
+        media_type: guess_media_type(&canonical_path),
         size: metadata.len(),
         last_modified,
-    })
+    };
+
+    Ok((canonical_path, local_metadata))
+}
+
+fn granted_local_file_path(path: &str, grants: &LocalFileGrantState) -> Result<PathBuf, String> {
+    let canonical_path =
+        fs::canonicalize(PathBuf::from(path)).map_err(|_| local_file_access_error())?;
+    let guard = grants
+        .lock()
+        .map_err(|_| "Local file grant state is unavailable".to_string())?;
+
+    if guard.contains(&canonical_path) {
+        Ok(canonical_path)
+    } else {
+        Err(local_file_access_error())
+    }
+}
+
+fn desktop_upload_destination_path(path: &str) -> Result<PathBuf, String> {
+    let normalized = path.replace('\\', "/");
+    let upload_prefix = format!("{}/", DESKTOP_UPLOAD_DIR);
+    let Some(relative_path) = normalized.strip_prefix(&upload_prefix) else {
+        return Err("Destination path is outside the desktop upload directory".to_string());
+    };
+
+    let mut safe_relative_path = PathBuf::new();
+    for segment in relative_path.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return Err("Destination path contains an unsafe segment".to_string());
+        }
+        safe_relative_path.push(segment);
+    }
+
+    if safe_relative_path.as_os_str().is_empty() {
+        return Err("Destination path must include a file name".to_string());
+    }
+
+    #[cfg(windows)]
+    let upload_root = PathBuf::from(r"C:\temp\hackerai-upload");
+    #[cfg(not(windows))]
+    let upload_root = PathBuf::from(DESKTOP_UPLOAD_DIR);
+
+    Ok(upload_root.join(safe_relative_path))
 }
 
 #[tauri::command]
-fn read_local_file(path: String) -> Result<LocalFileData, String> {
+fn pick_local_files(
+    app: tauri::AppHandle,
+    grants: tauri::State<'_, LocalFileGrantState>,
+) -> Result<Vec<String>, String> {
+    use tauri_plugin_dialog::DialogExt;
+
+    let Some(selected) = app.dialog().file().blocking_pick_files() else {
+        return Ok(Vec::new());
+    };
+
+    let mut picked_paths = Vec::new();
+    let mut granted_paths = Vec::new();
+
+    for selected_path in selected {
+        let path = selected_path
+            .into_path()
+            .map_err(|_| "Selected file path is not readable".to_string())?;
+        let (canonical_path, metadata) = inspect_local_file(&path)?;
+        picked_paths.push(metadata.path);
+        granted_paths.push(canonical_path);
+    }
+
+    let mut guard = grants
+        .lock()
+        .map_err(|_| "Local file grant state is unavailable".to_string())?;
+    guard.extend(granted_paths);
+
+    Ok(picked_paths)
+}
+
+#[tauri::command]
+fn copy_granted_local_file(
+    source_path: String,
+    dest_path: String,
+    grants: tauri::State<'_, LocalFileGrantState>,
+) -> Result<(), String> {
+    let granted_path = granted_local_file_path(&source_path, &grants)?;
+    let dest_path = desktop_upload_destination_path(&dest_path)?;
+
+    if let Some(parent) = dest_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("Create directory error: {}", e))?;
+    }
+
+    fs::copy(&granted_path, &dest_path).map_err(|e| format!("Copy error: {}", e))?;
+    Ok(())
+}
+
+#[tauri::command]
+fn get_local_file_metadata(
+    path: String,
+    grants: tauri::State<'_, LocalFileGrantState>,
+) -> Result<LocalFileMetadata, String> {
+    let granted_path = granted_local_file_path(&path, &grants)?;
+    let (_, metadata) = inspect_local_file(&granted_path)?;
+    Ok(metadata)
+}
+
+#[tauri::command]
+fn read_local_file(
+    path: String,
+    grants: tauri::State<'_, LocalFileGrantState>,
+) -> Result<LocalFileData, String> {
     use base64::Engine;
 
-    let metadata = get_local_file_metadata(path.clone())?;
-    let bytes = fs::read(&path).map_err(|e| format!("Read error: {}", e))?;
+    let granted_path = granted_local_file_path(&path, &grants)?;
+    let (_, metadata) = inspect_local_file(&granted_path)?;
+    if metadata.size > MAX_LOCAL_FILE_READ_BYTES {
+        return Err(format!(
+            "Selected file is too large to read inline (max {} MB)",
+            MAX_LOCAL_FILE_READ_BYTES / 1024 / 1024
+        ));
+    }
+
+    let bytes = fs::read(&granted_path).map_err(|e| format!("Read error: {}", e))?;
 
     Ok(LocalFileData {
         path: metadata.path,
@@ -1323,6 +1443,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             get_dev_auth_port,
             get_cmd_server_info,
+            pick_local_files,
+            copy_granted_local_file,
             get_local_file_metadata,
             read_local_file,
             execute_command,
@@ -1357,6 +1479,7 @@ pub fn run() {
             }
         }))
         .manage(std::sync::Arc::new(std::sync::Mutex::new(pty::PtyManager::new())) as PtyState)
+        .manage(Arc::new(Mutex::new(HashSet::<PathBuf>::new())) as LocalFileGrantState)
         .manage(
             std::sync::Arc::new(std::sync::Mutex::new(HashMap::<String, u32>::new()))
                 as StreamCommandState,


### PR DESCRIPTION
## Summary

- move desktop file picking into a native Tauri command that records canonical user-selected path grants
- require native grants for local file metadata, inline reads, and desktop-local attachment staging
- route desktop-local sandbox copies through a grant-checked native command instead of server-built shell copy commands

## Validation

- cargo check (packages/desktop/src-tauri)
- pnpm test -- --runTestsByPath app/hooks/__tests__/useFileUpload.local-desktop.test.tsx lib/utils/__tests__/sandbox-file-utils.test.ts app/services/__tests__/desktop-sandbox-bridge.test.ts
- pnpm typecheck
- pnpm exec eslint app/hooks/useTauri.ts app/services/desktop-sandbox-bridge.ts app/services/__tests__/desktop-sandbox-bridge.test.ts lib/ai/tools/utils/centrifugo-sandbox.ts
- pnpm exec prettier --check app/hooks/useTauri.ts app/services/desktop-sandbox-bridge.ts lib/ai/tools/utils/centrifugo-sandbox.ts packages/desktop/src-tauri/gen/schemas/acl-manifests.json