### PR TITLE
[codex] Improve PostHog error logging

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,12 @@
 import { phLogger } from "@/lib/posthog/server";
+import { registerPostHogLogProvider } from "@/lib/posthog/logs";
 import type { Instrumentation } from "next";
+
+export function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    registerPostHogLogProvider();
+  }
+}
 
 export const onRequestError: Instrumentation.onRequestError = (
   error,

--- a/lib/posthog/__tests__/expected-convex-errors.test.ts
+++ b/lib/posthog/__tests__/expected-convex-errors.test.ts
@@ -47,6 +47,52 @@ describe("shouldDropExpectedConvexException", () => {
     ).toBe(true);
   });
 
+  it("drops expected upload validation errors", () => {
+    expect(
+      shouldDropExpectedConvexException({
+        event: "$exception",
+        properties: {
+          $exception_message:
+            'Uncaught ConvexError: {"code":"INVALID_FILE_SIZE","message":"A positive file size is required before generating an upload URL"}',
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDropExpectedConvexException({
+        event: "$exception",
+        properties: {
+          $exception_message:
+            "Uncaught Error: Batch size exceeds limit: Maximum 50 files allowed per request",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("drops expected chat authorization errors", () => {
+    expect(
+      shouldDropExpectedConvexException({
+        event: "$exception",
+        properties: {
+          $exception_message:
+            'Uncaught ConvexError: {"code":"CHAT_UNAUTHORIZED","message":"You don\\u0027t have permission to access this chat"}',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("drops Convex optimistic concurrency retries from file upload metadata", () => {
+    expect(
+      shouldDropExpectedConvexException({
+        event: "$exception",
+        properties: {
+          $exception_message:
+            'Documents read from or written to the "btreeNode" table changed while this mutation was being run and on every subsequent retry.',
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("keeps non-exception events with matching text", () => {
     expect(
       shouldDropExpectedConvexException({

--- a/lib/posthog/expected-convex-errors.ts
+++ b/lib/posthog/expected-convex-errors.ts
@@ -5,8 +5,14 @@ const IGNORED_CONVEX_EXCEPTION_MESSAGES = [
   "FILE_UPLOAD_RATE_LIMIT",
   "exceeds the maximum token limit",
   "cloud file upload limit",
+  "INVALID_FILE_SIZE",
+  "Batch size exceeds limit",
   "PAID_PLAN_REQUIRED",
   "Paid plan required for file uploads",
+  "CHAT_UNAUTHORIZED",
+  "Unauthorized: Chat does not belong to user",
+  "OptimisticConcurrencyControlFailure",
+  'Documents read from or written to the "btreeNode" table changed',
 ];
 
 type PostHogEventLike = {

--- a/lib/posthog/logs.ts
+++ b/lib/posthog/logs.ts
@@ -1,0 +1,291 @@
+type LogLevel = "info" | "warn" | "error";
+type OtlpValue =
+  | { stringValue: string }
+  | { doubleValue: number }
+  | { boolValue: boolean };
+
+type OtlpAttribute = {
+  key: string;
+  value: OtlpValue;
+};
+
+type QueuedLogRecord = {
+  timeUnixNano: string;
+  severityNumber: number;
+  severityText: string;
+  body: { stringValue: string };
+  attributes: OtlpAttribute[];
+};
+
+type EmitLogOptions = {
+  level: LogLevel;
+  event: string;
+  body: string;
+  attributes?: Record<string, unknown>;
+};
+
+const LOG_ATTRIBUTE_VALUE_MAX_LENGTH = 2_000;
+const LOG_ATTRIBUTE_COUNT_LIMIT = 80;
+const LOG_BATCH_SIZE = 50;
+const LOG_QUEUE_LIMIT = 1_000;
+const LOG_FLUSH_INTERVAL_MS = 2_000;
+const LOG_EXPORT_TIMEOUT_MS = 5_000;
+const DEFAULT_SERVICE_NAME = "hackerai-web";
+const POSTHOG_CORRELATION_KEYS = new Set(["posthogDistinctId", "sessionId"]);
+
+let pendingLogs: QueuedLogRecord[] = [];
+let flushPromise: Promise<void> | null = null;
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+function getEnvironment(): string {
+  return (
+    process.env.VERCEL_ENV ??
+    process.env.NODE_ENV ??
+    process.env.ENVIRONMENT ??
+    "unknown"
+  );
+}
+
+function getServiceName(): string {
+  return process.env.POSTHOG_LOG_SERVICE_NAME ?? DEFAULT_SERVICE_NAME;
+}
+
+function truncate(value: string, maxLength = LOG_ATTRIBUTE_VALUE_MAX_LENGTH) {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+}
+
+function getPostHogToken(): string | undefined {
+  return (
+    process.env.POSTHOG_PROJECT_TOKEN ??
+    process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+    undefined
+  );
+}
+
+function getPostHogIngestHost(): string {
+  const rawHost =
+    process.env.POSTHOG_LOG_HOST ??
+    process.env.NEXT_PUBLIC_POSTHOG_HOST ??
+    "https://us.i.posthog.com";
+  const host = rawHost.replace(/\/+$/, "");
+
+  if (host === "https://app.posthog.com" || host === "https://us.posthog.com") {
+    return "https://us.i.posthog.com";
+  }
+  if (host === "https://eu.posthog.com") {
+    return "https://eu.i.posthog.com";
+  }
+  return host;
+}
+
+function severityNumberFor(level: LogLevel): number {
+  if (level === "error") return 17;
+  if (level === "warn") return 13;
+  return 9;
+}
+
+function normalizeAttributeKey(key: string): string {
+  if (POSTHOG_CORRELATION_KEYS.has(key)) {
+    return key;
+  }
+
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^\w.]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase();
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function toOtlpValue(value: unknown): OtlpValue | undefined {
+  if (value === undefined || value === null) return undefined;
+
+  if (typeof value === "string") {
+    return { stringValue: truncate(value) };
+  }
+  if (typeof value === "boolean") {
+    return { boolValue: value };
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return undefined;
+    return { doubleValue: value };
+  }
+
+  return { stringValue: truncate(stringifyUnknown(value)) };
+}
+
+function toOtlpAttributes(
+  attributes: Record<string, unknown> = {},
+): OtlpAttribute[] {
+  const normalized: Record<string, unknown> = {
+    service: getServiceName(),
+    environment: getEnvironment(),
+    runtime: "node",
+    ...attributes,
+  };
+
+  return Object.entries(normalized)
+    .flatMap(([key, value]) => {
+      const normalizedKey = normalizeAttributeKey(key);
+      if (!normalizedKey) return [];
+
+      const otlpValue = toOtlpValue(value);
+      if (!otlpValue) return [];
+
+      return [{ key: normalizedKey, value: otlpValue }];
+    })
+    .slice(0, LOG_ATTRIBUTE_COUNT_LIMIT);
+}
+
+function nowUnixNano(): string {
+  return `${BigInt(Date.now()) * BigInt(1_000_000)}`;
+}
+
+function buildOtlpPayload(logs: QueuedLogRecord[]) {
+  return {
+    resourceLogs: [
+      {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: getServiceName() } },
+            {
+              key: "deployment.environment",
+              value: { stringValue: getEnvironment() },
+            },
+            {
+              key: "service.version",
+              value: {
+                stringValue: process.env.VERCEL_GIT_COMMIT_SHA ?? "dev",
+              },
+            },
+          ],
+        },
+        scopeLogs: [
+          {
+            scope: { name: getServiceName() },
+            logRecords: logs,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function scheduleFlush(delayMs: number): void {
+  if (flushTimer) {
+    if (delayMs > 0) return;
+    clearTimeout(flushTimer);
+  }
+
+  flushTimer = setTimeout(() => {
+    flushTimer = null;
+    void flushPostHogLogs().catch(() => {
+      // best-effort telemetry
+    });
+  }, delayMs);
+  flushTimer.unref?.();
+}
+
+export function registerPostHogLogProvider() {
+  // Kept as an explicit hook for Next instrumentation; the raw OTLP sender is
+  // initialized lazily so builds and edge runtimes do not need log setup work.
+}
+
+export function emitPostHogLog({
+  level,
+  event,
+  body,
+  attributes,
+}: EmitLogOptions): boolean {
+  if (!getPostHogToken()) return false;
+
+  pendingLogs.push({
+    timeUnixNano: nowUnixNano(),
+    severityNumber: severityNumberFor(level),
+    severityText: level.toUpperCase(),
+    body: { stringValue: truncate(body) },
+    attributes: toOtlpAttributes({
+      event,
+      ...attributes,
+    }),
+  });
+
+  if (pendingLogs.length > LOG_QUEUE_LIMIT) {
+    pendingLogs.splice(0, pendingLogs.length - LOG_QUEUE_LIMIT);
+  }
+  scheduleFlush(
+    pendingLogs.length >= LOG_BATCH_SIZE ? 0 : LOG_FLUSH_INTERVAL_MS,
+  );
+
+  return true;
+}
+
+async function flushBatch(logs: QueuedLogRecord[]): Promise<void> {
+  const token = getPostHogToken();
+  if (!token || logs.length === 0) return;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), LOG_EXPORT_TIMEOUT_MS);
+  timeout.unref?.();
+
+  try {
+    const response = await fetch(`${getPostHogIngestHost()}/i/v1/logs`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      signal: controller.signal,
+      body: JSON.stringify(buildOtlpPayload(logs)),
+    });
+
+    if (!response.ok) {
+      throw new Error(`PostHog log export failed: ${response.status}`);
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function flushPostHogLogs(): Promise<void> {
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+
+  if (flushPromise) {
+    await flushPromise;
+  }
+
+  const logsToFlush = pendingLogs.slice(0, LOG_BATCH_SIZE);
+  if (logsToFlush.length === 0) return;
+
+  flushPromise = (async () => {
+    await flushBatch(logsToFlush);
+    const flushedLogs = new Set(logsToFlush);
+    pendingLogs = pendingLogs.filter((log) => !flushedLogs.has(log));
+  })().finally(() => {
+    flushPromise = null;
+  });
+
+  try {
+    await flushPromise;
+  } catch (error) {
+    if (pendingLogs.length > 0) {
+      scheduleFlush(LOG_FLUSH_INTERVAL_MS);
+    }
+    throw error;
+  }
+
+  if (pendingLogs.length > 0) {
+    await flushPostHogLogs();
+  }
+}

--- a/lib/posthog/server.ts
+++ b/lib/posthog/server.ts
@@ -1,4 +1,5 @@
 import PostHogClient from "@/app/posthog";
+import { emitPostHogLog, flushPostHogLogs } from "@/lib/posthog/logs";
 import type { PostHog } from "posthog-node";
 
 let cachedClient: PostHog | null | undefined;
@@ -20,21 +21,138 @@ type EventFields = Record<string, unknown> & {
   $set?: Record<string, unknown>;
 };
 
+const TELEMETRY_STRING_MAX_LENGTH = 2_000;
+
 function distinctIdFor(userId: unknown): string {
   return typeof userId === "string" && userId.length > 0 ? userId : "system";
 }
 
+function getEnvironment(): string {
+  return (
+    process.env.VERCEL_ENV ??
+    process.env.NODE_ENV ??
+    process.env.ENVIRONMENT ??
+    "unknown"
+  );
+}
+
+function getServiceName(): string {
+  return process.env.POSTHOG_LOG_SERVICE_NAME ?? "hackerai-web";
+}
+
+function truncate(value: string, maxLength = TELEMETRY_STRING_MAX_LENGTH) {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function eventNameFor(message: string, fallback = "application_log"): string {
+  const normalized = message
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^\w]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase();
+  return normalized.length > 0 ? normalized.slice(0, 100) : fallback;
+}
+
+function serializeError(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return {
+      error_name: error.name,
+      error_message: truncate(error.message),
+      ...(error.stack && { error_stack: truncate(error.stack, 4_000) }),
+      ...("cause" in error &&
+        (error as { cause?: unknown }).cause !== undefined && {
+          error_cause:
+            (error as { cause?: unknown }).cause instanceof Error
+              ? truncate((error as { cause: Error }).cause.message)
+              : truncate(String((error as { cause?: unknown }).cause)),
+        }),
+    };
+  }
+
+  if (error === undefined) return {};
+
+  return {
+    error_name: "UnknownError",
+    error_message: truncate(stringifyUnknown(error)),
+  };
+}
+
+function commonLogFields({
+  level,
+  event,
+  message,
+  userId,
+}: {
+  level: "info" | "warn" | "error";
+  event: string;
+  message: string;
+  userId?: string;
+}) {
+  return {
+    level,
+    event,
+    message,
+    service: getServiceName(),
+    environment: getEnvironment(),
+    ...(userId && { posthogDistinctId: userId, user_id: userId }),
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function emitStructuredLog(
+  level: "info" | "warn" | "error",
+  message: string,
+  fields: LogFields,
+): boolean {
+  const event =
+    typeof fields.event === "string" && fields.event.length > 0
+      ? fields.event
+      : eventNameFor(message);
+  const { userId, error, ...rest } = fields;
+
+  try {
+    return emitPostHogLog({
+      level,
+      event,
+      body: message,
+      attributes: {
+        ...commonLogFields({ level, event, message, userId }),
+        ...rest,
+        ...serializeError(error),
+      },
+    });
+  } catch {
+    return false;
+  }
+}
+
 export const phLogger = {
   error(message: string, fields: LogFields = {}) {
+    const wroteLog = emitStructuredLog("error", message, fields);
     const client = getClient();
     if (!client) {
-      console.error(message, fields);
+      if (!wroteLog) console.error(message, fields);
       return;
     }
     try {
       const { userId, error, ...rest } = fields;
       const exception = error instanceof Error ? error : new Error(message);
+      const event =
+        typeof fields.event === "string" && fields.event.length > 0
+          ? fields.event
+          : eventNameFor(message);
       client.captureException(exception, distinctIdFor(userId), {
+        ...commonLogFields({ level: "error", event, message, userId }),
+        ...serializeError(exception),
         message,
         ...rest,
       });
@@ -44,17 +162,26 @@ export const phLogger = {
   },
 
   warn(message: string, fields: LogFields = {}) {
+    const wroteLog = emitStructuredLog("warn", message, fields);
     const client = getClient();
     if (!client) {
-      console.warn(message, fields);
+      if (!wroteLog) console.warn(message, fields);
       return;
     }
     try {
-      const { userId, ...rest } = fields;
+      const { userId, error, ...rest } = fields;
+      const event =
+        typeof fields.event === "string" && fields.event.length > 0
+          ? fields.event
+          : eventNameFor(message);
       client.capture({
         distinctId: distinctIdFor(userId),
         event: "log_warn",
-        properties: { message, level: "warning", ...rest },
+        properties: {
+          ...commonLogFields({ level: "warn", event, message, userId }),
+          ...rest,
+          ...serializeError(error),
+        },
       });
     } catch (telemetryError) {
       console.warn(message, { ...fields, telemetryError });
@@ -62,17 +189,26 @@ export const phLogger = {
   },
 
   info(message: string, fields: LogFields = {}) {
+    const wroteLog = emitStructuredLog("info", message, fields);
     const client = getClient();
     if (!client) {
-      console.log(message, fields);
+      if (!wroteLog) console.log(message, fields);
       return;
     }
     try {
-      const { userId, ...rest } = fields;
+      const { userId, error, ...rest } = fields;
+      const event =
+        typeof fields.event === "string" && fields.event.length > 0
+          ? fields.event
+          : eventNameFor(message);
       client.capture({
         distinctId: distinctIdFor(userId),
         event: "log_info",
-        properties: { message, level: "info", ...rest },
+        properties: {
+          ...commonLogFields({ level: "info", event, message, userId }),
+          ...rest,
+          ...serializeError(error),
+        },
       });
     } catch (telemetryError) {
       console.log(message, { ...fields, telemetryError });
@@ -95,10 +231,6 @@ export const phLogger = {
   },
 
   async flush(): Promise<void> {
-    try {
-      await getClient()?.flush();
-    } catch {
-      // best-effort
-    }
+    await Promise.allSettled([getClient()?.flush(), flushPostHogLogs()]);
   },
 };


### PR DESCRIPTION
## Summary

- add a lightweight PostHog Logs exporter for server-side structured logs
- wire `phLogger` errors, warnings, and info events into structured logs with service/env/user/error context
- filter additional expected Convex exception noise for upload validation, auth, token-limit, and optimistic concurrency cases
- add regression coverage for the expanded expected Convex exception filtering

## Why

A PostHog error review showed most recent active issues were either expected Convex validation/auth/upload errors, provider/network failures, or a single anonymous user producing a large unauthenticated local sandbox retry loop. The new logs should make future errors easier to triage with request/user/error context, while the client-side filter reduces known expected Convex noise.

## Validation

- `pnpm eslint instrumentation.ts lib/posthog/logs.ts lib/posthog/server.ts lib/posthog/expected-convex-errors.ts lib/posthog/__tests__/expected-convex-errors.test.ts`
- `pnpm jest lib/posthog/__tests__/expected-convex-errors.test.ts lib/api/__tests__/chat-logger.test.ts --runInBand`

Known existing blocker: full `pnpm typecheck` fails on `packages/local/src/index.ts` because module `ws` or its types cannot be found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured server-side telemetry and a buffered log export pipeline for sending rich logs.
* **Enhancements**
  * Improved log formatting, truncation, batching, and delivery reliability.
  * Expanded exception filtering to suppress additional known error patterns.
* **Tests**
  * Added coverage for newly ignored/expected error message patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->