### PR TITLE
[codex] Show extra usage balance in sidebar

### DIFF
--- a/app/components/SidebarUserNav.tsx
+++ b/app/components/SidebarUserNav.tsx
@@ -129,9 +129,14 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
     api.userCustomization.getUserCustomization,
   );
   const extraUsageEnabled = userCustomization?.extra_usage_enabled ?? false;
+  const extraUsageBalanceDollars = extraUsageSettings?.balanceDollars ?? 0;
   const extraUsageMonthlySpentDollars =
     extraUsageSettings?.monthlySpentDollars ?? 0;
   const extraUsageMonthlyCapDollars = extraUsageSettings?.monthlyCapDollars;
+  const extraUsageMonthlyLimitLabel =
+    extraUsageMonthlyCapDollars != null
+      ? `$${extraUsageMonthlyCapDollars.toFixed(2)} limit`
+      : "No limit";
 
   const fetchTokenUsage = useCallback(async () => {
     if (!isPaidUser) return;
@@ -402,21 +407,31 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
                         </div>
                       </div>
                       {extraUsageEnabled && (
-                        <div className="flex items-center justify-between py-1.5 text-sm">
-                          <span className="text-muted-foreground">
-                            Extra usage
-                          </span>
-                          <div className="flex items-center gap-3 tabular-nums text-muted-foreground">
-                            <span>
-                              ${extraUsageMonthlySpentDollars.toFixed(2)}
+                        <>
+                          <div className="flex items-center justify-between py-1.5 text-sm">
+                            <span className="text-muted-foreground">
+                              Extra balance
                             </span>
-                            <span>
-                              {extraUsageMonthlyCapDollars
-                                ? `/ $${extraUsageMonthlyCapDollars.toFixed(2)}`
-                                : "No limit"}
+                            <span className="min-w-0 text-right tabular-nums text-muted-foreground">
+                              ${extraUsageBalanceDollars.toFixed(2)} available
                             </span>
                           </div>
-                        </div>
+                          <div className="flex items-center justify-between py-1.5 text-sm">
+                            <span className="text-muted-foreground">
+                              This month
+                            </span>
+                            <div className="ml-3 flex min-w-0 flex-wrap items-center justify-end gap-x-1.5 gap-y-0.5 text-right tabular-nums text-muted-foreground">
+                              <span>
+                                ${extraUsageMonthlySpentDollars.toFixed(2)}{" "}
+                                spent
+                              </span>
+                              <span className="text-muted-foreground/60">
+                                /
+                              </span>
+                              <span>{extraUsageMonthlyLimitLabel}</span>
+                            </div>
+                          </div>
+                        </>
                       )}
                     </>
                   ) : (


### PR DESCRIPTION
## Summary

Updates the sidebar Usage flyout so extra usage shows the user's available balance first, then separates out this month's spend and cap.

## Why

The previous single `Extra usage` row rendered monthly extra usage spend as `$0.00` when a user had credits but had not consumed overage yet. That made users with unlimited extra usage and a positive balance think their balance was zero.

## Impact

Paid users with extra usage enabled now see:

- `Extra balance` with `$X.XX available`
- `This month` with `$Y.YY spent / No limit` or the configured monthly limit

## Validation

- `pnpm exec prettier --check app/components/SidebarUserNav.tsx`
- `pnpm exec eslint app/components/SidebarUserNav.tsx`
- `pnpm exec tsc --noEmit --pretty false`
- pre-commit hook: `tsc --noEmit`
- pre-commit hook: `jest` (104 suites, 1249 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Usage dropdown to display Extra Balance and monthly spending as separate rows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->