### PR TITLE
[codex] Show message hover timestamps

### DIFF
--- a/app/components/MessageActions.tsx
+++ b/app/components/MessageActions.tsx
@@ -42,6 +42,74 @@ interface MessageActionsProps {
   }>;
 }
 
+interface MessageActionVisibility {
+  shouldRenderActions: boolean;
+  actionsAreVisible: boolean;
+  shouldReserveTimestamp: boolean;
+  timestampIsVisible: boolean;
+}
+
+const timestampClassName =
+  "flex h-7 items-center px-1.5 text-sm leading-none text-muted-foreground tabular-nums whitespace-nowrap transition-opacity duration-200 ease-in-out";
+
+export function getMessageActionVisibility({
+  isUser,
+  isLastAssistantMessage,
+  isMobile,
+  isHovered,
+  isEditing,
+  isLastAssistantLoading,
+  hasTimestamp,
+}: {
+  isUser: boolean;
+  isLastAssistantMessage: boolean;
+  isMobile: boolean;
+  isHovered: boolean;
+  isEditing: boolean;
+  isLastAssistantLoading: boolean;
+  hasTimestamp: boolean;
+}): MessageActionVisibility {
+  const shouldRenderActions = !isLastAssistantLoading && !isEditing;
+  const isHistoricalAssistant = !isUser && !isLastAssistantMessage;
+  const requiresDesktopHover = isUser || isHistoricalAssistant;
+  const actionsAreVisible =
+    shouldRenderActions && (!requiresDesktopHover || isMobile || isHovered);
+  const shouldReserveTimestamp =
+    shouldRenderActions && !isMobile && hasTimestamp;
+  const timestampIsVisible = shouldReserveTimestamp && isHovered;
+
+  return {
+    shouldRenderActions,
+    actionsAreVisible,
+    shouldReserveTimestamp,
+    timestampIsVisible,
+  };
+}
+
+function MessageTimestamp({
+  dateTime,
+  display,
+  isVisible,
+}: {
+  dateTime: string;
+  display: string;
+  isVisible: boolean;
+}) {
+  return (
+    <time
+      dateTime={dateTime}
+      className={cn(
+        timestampClassName,
+        isVisible
+          ? "opacity-70"
+          : "opacity-0 group-focus-within/message-actions:opacity-70",
+      )}
+    >
+      {display}
+    </time>
+  );
+}
+
 export const MessageActions = ({
   messageText,
   isUser,
@@ -105,17 +173,25 @@ export const MessageActions = ({
   const isLastAssistantLoading =
     isLastAssistantMessage &&
     (status === "submitted" || status === "streaming");
-  const shouldRenderActions = !isLastAssistantLoading && !isEditing;
-  const isHistoricalAssistant = !isUser && !isLastAssistantMessage;
-  const requiresDesktopHover = isUser || isHistoricalAssistant;
-  const actionsAreVisible =
-    shouldRenderActions && (!requiresDesktopHover || isMobile || isHovered);
   const formattedCreatedAt = formatMessageActionTimestamp(messageCreatedAt);
-  const shouldRenderTimestamp =
-    shouldRenderActions &&
-    !isMobile &&
-    formattedCreatedAt !== null &&
-    (isHovered || requiresDesktopHover);
+  const timestampDateTime =
+    formattedCreatedAt !== null && typeof messageCreatedAt === "number"
+      ? new Date(messageCreatedAt).toISOString()
+      : null;
+  const {
+    shouldRenderActions,
+    actionsAreVisible,
+    shouldReserveTimestamp,
+    timestampIsVisible,
+  } = getMessageActionVisibility({
+    isUser,
+    isLastAssistantMessage,
+    isMobile,
+    isHovered,
+    isEditing,
+    isLastAssistantLoading,
+    hasTimestamp: formattedCreatedAt !== null && timestampDateTime !== null,
+  });
 
   // Reset isRegenerating when status changes back to idle
   const isLoading = status === "submitted" || status === "streaming";
@@ -126,7 +202,7 @@ export const MessageActions = ({
   return (
     <div
       className={cn(
-        "mt-1 flex flex-wrap items-center gap-2 transition-opacity duration-200 ease-in-out",
+        "group/message-actions mt-1 flex flex-wrap items-center gap-2 transition-opacity duration-200 ease-in-out",
         isUser ? "justify-end" : "justify-start",
         actionsAreVisible
           ? "opacity-100"
@@ -135,13 +211,12 @@ export const MessageActions = ({
     >
       {shouldRenderActions ? (
         <>
-          {isUser && shouldRenderTimestamp && (
-            <time
-              dateTime={new Date(messageCreatedAt!).toISOString()}
-              className="flex h-7 items-center px-1.5 text-sm leading-none text-muted-foreground opacity-70 tabular-nums whitespace-nowrap"
-            >
-              {formattedCreatedAt}
-            </time>
+          {isUser && shouldReserveTimestamp && (
+            <MessageTimestamp
+              dateTime={timestampDateTime!}
+              display={formattedCreatedAt!}
+              isVisible={timestampIsVisible}
+            />
           )}
 
           <div className="flex items-center space-x-2">
@@ -318,13 +393,12 @@ export const MessageActions = ({
             </Button>
           )}
 
-          {!isUser && shouldRenderTimestamp && (
-            <time
-              dateTime={new Date(messageCreatedAt!).toISOString()}
-              className="flex h-7 items-center px-1.5 text-sm leading-none text-muted-foreground opacity-70 tabular-nums whitespace-nowrap"
-            >
-              {formattedCreatedAt}
-            </time>
+          {!isUser && shouldReserveTimestamp && (
+            <MessageTimestamp
+              dateTime={timestampDateTime!}
+              display={formattedCreatedAt!}
+              isVisible={timestampIsVisible}
+            />
           )}
         </>
       ) : (

--- a/app/components/MessageActions.tsx
+++ b/app/components/MessageActions.tsx
@@ -116,7 +116,6 @@ export const MessageActions = ({
     !isMobile &&
     formattedCreatedAt !== null &&
     (isHovered || requiresDesktopHover);
-  const hiddenActionTabIndex = actionsAreVisible ? undefined : -1;
 
   // Reset isRegenerating when status changes back to idle
   const isLoading = status === "submitted" || status === "streaming";
@@ -129,9 +128,10 @@ export const MessageActions = ({
       className={cn(
         "mt-1 flex flex-wrap items-center gap-2 transition-opacity duration-200 ease-in-out",
         isUser ? "justify-end" : "justify-start",
-        actionsAreVisible ? "opacity-100" : "pointer-events-none opacity-0",
+        actionsAreVisible
+          ? "opacity-100"
+          : "pointer-events-none opacity-0 focus-within:pointer-events-auto focus-within:opacity-100",
       )}
-      aria-hidden={!actionsAreVisible}
     >
       {shouldRenderActions ? (
         <>
@@ -150,7 +150,6 @@ export const MessageActions = ({
               trigger={
                 <button
                   onClick={handleCopy}
-                  tabIndex={hiddenActionTabIndex}
                   className="p-1.5 opacity-70 hover:opacity-100 transition-opacity rounded hover:bg-secondary text-muted-foreground"
                   aria-label={copied ? "Copied!" : "Copy message"}
                 >
@@ -168,7 +167,6 @@ export const MessageActions = ({
                 trigger={
                   <button
                     onClick={onEdit}
-                    tabIndex={hiddenActionTabIndex}
                     className="p-1.5 opacity-70 hover:opacity-100 transition-opacity rounded hover:bg-secondary text-muted-foreground"
                     aria-label="Edit message"
                   >
@@ -191,7 +189,6 @@ export const MessageActions = ({
                       <button
                         type="button"
                         onClick={() => handleFeedback("positive")}
-                        tabIndex={hiddenActionTabIndex}
                         className={`p-1.5 transition-opacity rounded hover:bg-secondary ${
                           existingFeedback === "positive"
                             ? "opacity-100 text-primary-foreground"
@@ -219,7 +216,6 @@ export const MessageActions = ({
                     <button
                       type="button"
                       onClick={() => handleFeedback("negative")}
-                      tabIndex={hiddenActionTabIndex}
                       className={`p-1.5 transition-opacity rounded hover:bg-secondary ${
                         existingFeedback === "negative" ||
                         isAwaitingFeedbackDetails
@@ -254,7 +250,6 @@ export const MessageActions = ({
                     type="button"
                     onClick={handleRegenerate}
                     disabled={!canRegenerate || isRegenerating}
-                    tabIndex={hiddenActionTabIndex}
                     className="p-1.5 opacity-70 hover:opacity-100 disabled:opacity-50 transition-opacity rounded hover:bg-secondary text-muted-foreground"
                     aria-label="Regenerate response"
                   >
@@ -274,7 +269,6 @@ export const MessageActions = ({
                   <button
                     type="button"
                     onClick={onBranch}
-                    tabIndex={hiddenActionTabIndex}
                     className="p-1.5 opacity-70 hover:opacity-100 transition-opacity rounded hover:bg-secondary text-muted-foreground"
                     aria-label="Branch in new chat"
                   >
@@ -293,7 +287,6 @@ export const MessageActions = ({
               variant="ghost"
               size="sm"
               onClick={() => setIsSourcesOpen(true)}
-              tabIndex={hiddenActionTabIndex}
               className="group/footnote bg-background hover:bg-muted flex w-fit items-center gap-1.5 rounded-3xl px-3 py-1.5 h-auto"
               aria-label="View sources"
             >

--- a/app/components/MessageActions.tsx
+++ b/app/components/MessageActions.tsx
@@ -305,7 +305,7 @@ export const MessageActions = ({
           {shouldShowTimestamp && (
             <time
               dateTime={new Date(messageCreatedAt!).toISOString()}
-              className="text-xs text-muted-foreground/80 tabular-nums whitespace-nowrap"
+              className="flex h-7 items-center px-1.5 text-[16px] leading-none text-muted-foreground opacity-70 tabular-nums whitespace-nowrap"
             >
               {formattedCreatedAt}
             </time>

--- a/app/components/MessageActions.tsx
+++ b/app/components/MessageActions.tsx
@@ -138,7 +138,7 @@ export const MessageActions = ({
           {isUser && shouldRenderTimestamp && (
             <time
               dateTime={new Date(messageCreatedAt!).toISOString()}
-              className="flex h-7 items-center px-1.5 text-[16px] leading-none text-muted-foreground opacity-70 tabular-nums whitespace-nowrap"
+              className="flex h-7 items-center px-1.5 text-sm leading-none text-muted-foreground opacity-70 tabular-nums whitespace-nowrap"
             >
               {formattedCreatedAt}
             </time>
@@ -328,7 +328,7 @@ export const MessageActions = ({
           {!isUser && shouldRenderTimestamp && (
             <time
               dateTime={new Date(messageCreatedAt!).toISOString()}
-              className="flex h-7 items-center px-1.5 text-[16px] leading-none text-muted-foreground opacity-70 tabular-nums whitespace-nowrap"
+              className="flex h-7 items-center px-1.5 text-sm leading-none text-muted-foreground opacity-70 tabular-nums whitespace-nowrap"
             >
               {formattedCreatedAt}
             </time>

--- a/app/components/MessageActions.tsx
+++ b/app/components/MessageActions.tsx
@@ -12,6 +12,7 @@ import Image from "next/image";
 import type { ChatStatus } from "@/types";
 import { WithTooltip } from "@/components/ui/with-tooltip";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { formatMessageActionTimestamp } from "@/lib/utils/message-time";
 import { SourcesDialog } from "./SourcesDialog";
 
@@ -25,6 +26,7 @@ interface MessageActionsProps {
   onBranch?: () => void;
   isHovered: boolean;
   isEditing: boolean;
+  isMobile?: boolean;
   messageCreatedAt?: number;
   status: ChatStatus;
   onFeedback?: (type: "positive" | "negative") => void;
@@ -50,6 +52,7 @@ export const MessageActions = ({
   onBranch,
   isHovered,
   isEditing,
+  isMobile = false,
   messageCreatedAt,
   status,
   onFeedback,
@@ -102,11 +105,18 @@ export const MessageActions = ({
   const isLastAssistantLoading =
     isLastAssistantMessage &&
     (status === "submitted" || status === "streaming");
-  const shouldShowActions =
-    !isLastAssistantLoading && !isEditing && (isUser ? isHovered : true); // Always show for assistant, only on hover for user
+  const shouldRenderActions = !isLastAssistantLoading && !isEditing;
+  const isHistoricalAssistant = !isUser && !isLastAssistantMessage;
+  const requiresDesktopHover = isUser || isHistoricalAssistant;
+  const actionsAreVisible =
+    shouldRenderActions && (!requiresDesktopHover || isMobile || isHovered);
   const formattedCreatedAt = formatMessageActionTimestamp(messageCreatedAt);
-  const shouldShowTimestamp =
-    shouldShowActions && isHovered && formattedCreatedAt !== null;
+  const shouldRenderTimestamp =
+    shouldRenderActions &&
+    !isMobile &&
+    formattedCreatedAt !== null &&
+    (isHovered || requiresDesktopHover);
+  const hiddenActionTabIndex = actionsAreVisible ? undefined : -1;
 
   // Reset isRegenerating when status changes back to idle
   const isLoading = status === "submitted" || status === "streaming";
@@ -116,27 +126,40 @@ export const MessageActions = ({
 
   return (
     <div
-      className={`mt-1 flex flex-wrap items-center gap-2 transition-opacity duration-200 ease-in-out ${isUser ? "justify-end" : "justify-start"} ${shouldShowActions ? "opacity-100" : "opacity-0"}`}
+      className={cn(
+        "mt-1 flex flex-wrap items-center gap-2 transition-opacity duration-200 ease-in-out",
+        isUser ? "justify-end" : "justify-start",
+        actionsAreVisible ? "opacity-100" : "pointer-events-none opacity-0",
+      )}
+      aria-hidden={!actionsAreVisible}
     >
-      {shouldShowActions ? (
+      {shouldRenderActions ? (
         <>
+          {isUser && shouldRenderTimestamp && (
+            <time
+              dateTime={new Date(messageCreatedAt!).toISOString()}
+              className="flex h-7 items-center px-1.5 text-[16px] leading-none text-muted-foreground opacity-70 tabular-nums whitespace-nowrap"
+            >
+              {formattedCreatedAt}
+            </time>
+          )}
+
           <div className="flex items-center space-x-2">
-            {(isUser || isLastAssistantMessage) && (
-              <WithTooltip
-                display={copied ? "Copied!" : "Copy message"}
-                trigger={
-                  <button
-                    onClick={handleCopy}
-                    className="p-1.5 opacity-70 hover:opacity-100 transition-opacity rounded hover:bg-secondary text-muted-foreground"
-                    aria-label={copied ? "Copied!" : "Copy message"}
-                  >
-                    {copied ? <Check size={16} /> : <Copy size={16} />}
-                  </button>
-                }
-                side="bottom"
-                delayDuration={300}
-              />
-            )}
+            <WithTooltip
+              display={copied ? "Copied!" : "Copy message"}
+              trigger={
+                <button
+                  onClick={handleCopy}
+                  tabIndex={hiddenActionTabIndex}
+                  className="p-1.5 opacity-70 hover:opacity-100 transition-opacity rounded hover:bg-secondary text-muted-foreground"
+                  aria-label={copied ? "Copied!" : "Copy message"}
+                >
+                  {copied ? <Check size={16} /> : <Copy size={16} />}
+                </button>
+              }
+              side="bottom"
+              delayDuration={300}
+            />
 
             {/* Show edit only for user messages */}
             {isUser && (
@@ -145,6 +168,7 @@ export const MessageActions = ({
                 trigger={
                   <button
                     onClick={onEdit}
+                    tabIndex={hiddenActionTabIndex}
                     className="p-1.5 opacity-70 hover:opacity-100 transition-opacity rounded hover:bg-secondary text-muted-foreground"
                     aria-label="Edit message"
                   >
@@ -157,59 +181,28 @@ export const MessageActions = ({
             )}
 
             {/* Show feedback buttons only for assistant messages and not in temporary chats */}
-            {!isUser &&
-              isLastAssistantMessage &&
-              onFeedback &&
-              !isTemporaryChat && (
-                <>
-                  {/* Hide positive feedback button when awaiting negative feedback details */}
-                  {!isAwaitingFeedbackDetails && (
-                    <WithTooltip
-                      display={"Good response"}
-                      trigger={
-                        <button
-                          type="button"
-                          onClick={() => handleFeedback("positive")}
-                          className={`p-1.5 transition-opacity rounded hover:bg-secondary ${
-                            existingFeedback === "positive"
-                              ? "opacity-100 text-primary-foreground"
-                              : "opacity-70 hover:opacity-100 text-muted-foreground"
-                          }`}
-                          aria-label="Good response"
-                        >
-                          <ThumbsUp
-                            size={16}
-                            fill={
-                              existingFeedback === "positive"
-                                ? "currentColor"
-                                : "none"
-                            }
-                          />
-                        </button>
-                      }
-                      side="bottom"
-                      delayDuration={300}
-                    />
-                  )}
+            {!isUser && onFeedback && !isTemporaryChat && (
+              <>
+                {/* Hide positive feedback button when awaiting negative feedback details */}
+                {!isAwaitingFeedbackDetails && (
                   <WithTooltip
-                    display={"Poor response"}
+                    display={"Good response"}
                     trigger={
                       <button
                         type="button"
-                        onClick={() => handleFeedback("negative")}
+                        onClick={() => handleFeedback("positive")}
+                        tabIndex={hiddenActionTabIndex}
                         className={`p-1.5 transition-opacity rounded hover:bg-secondary ${
-                          existingFeedback === "negative" ||
-                          isAwaitingFeedbackDetails
+                          existingFeedback === "positive"
                             ? "opacity-100 text-primary-foreground"
                             : "opacity-70 hover:opacity-100 text-muted-foreground"
                         }`}
-                        aria-label="Poor response"
+                        aria-label="Good response"
                       >
-                        <ThumbsDown
+                        <ThumbsUp
                           size={16}
                           fill={
-                            existingFeedback === "negative" ||
-                            isAwaitingFeedbackDetails
+                            existingFeedback === "positive"
                               ? "currentColor"
                               : "none"
                           }
@@ -219,8 +212,38 @@ export const MessageActions = ({
                     side="bottom"
                     delayDuration={300}
                   />
-                </>
-              )}
+                )}
+                <WithTooltip
+                  display={"Poor response"}
+                  trigger={
+                    <button
+                      type="button"
+                      onClick={() => handleFeedback("negative")}
+                      tabIndex={hiddenActionTabIndex}
+                      className={`p-1.5 transition-opacity rounded hover:bg-secondary ${
+                        existingFeedback === "negative" ||
+                        isAwaitingFeedbackDetails
+                          ? "opacity-100 text-primary-foreground"
+                          : "opacity-70 hover:opacity-100 text-muted-foreground"
+                      }`}
+                      aria-label="Poor response"
+                    >
+                      <ThumbsDown
+                        size={16}
+                        fill={
+                          existingFeedback === "negative" ||
+                          isAwaitingFeedbackDetails
+                            ? "currentColor"
+                            : "none"
+                        }
+                      />
+                    </button>
+                  }
+                  side="bottom"
+                  delayDuration={300}
+                />
+              </>
+            )}
 
             {/* Show regenerate only for the last assistant message */}
             {!isUser && isLastAssistantMessage && (
@@ -231,6 +254,7 @@ export const MessageActions = ({
                     type="button"
                     onClick={handleRegenerate}
                     disabled={!canRegenerate || isRegenerating}
+                    tabIndex={hiddenActionTabIndex}
                     className="p-1.5 opacity-70 hover:opacity-100 disabled:opacity-50 transition-opacity rounded hover:bg-secondary text-muted-foreground"
                     aria-label="Regenerate response"
                   >
@@ -243,26 +267,24 @@ export const MessageActions = ({
             )}
 
             {/* Show branch only for assistant messages and not in temporary chats */}
-            {!isUser &&
-              isLastAssistantMessage &&
-              onBranch &&
-              !isTemporaryChat && (
-                <WithTooltip
-                  display={"Branch in new chat"}
-                  trigger={
-                    <button
-                      type="button"
-                      onClick={onBranch}
-                      className="p-1.5 opacity-70 hover:opacity-100 transition-opacity rounded hover:bg-secondary text-muted-foreground"
-                      aria-label="Branch in new chat"
-                    >
-                      <Split size={16} />
-                    </button>
-                  }
-                  side="bottom"
-                  delayDuration={300}
-                />
-              )}
+            {!isUser && onBranch && !isTemporaryChat && (
+              <WithTooltip
+                display={"Branch in new chat"}
+                trigger={
+                  <button
+                    type="button"
+                    onClick={onBranch}
+                    tabIndex={hiddenActionTabIndex}
+                    className="p-1.5 opacity-70 hover:opacity-100 transition-opacity rounded hover:bg-secondary text-muted-foreground"
+                    aria-label="Branch in new chat"
+                  >
+                    <Split size={16} />
+                  </button>
+                }
+                side="bottom"
+                delayDuration={300}
+              />
+            )}
           </div>
 
           {/* Sources (only for assistant messages with web results) - positioned at the end */}
@@ -271,6 +293,7 @@ export const MessageActions = ({
               variant="ghost"
               size="sm"
               onClick={() => setIsSourcesOpen(true)}
+              tabIndex={hiddenActionTabIndex}
               className="group/footnote bg-background hover:bg-muted flex w-fit items-center gap-1.5 rounded-3xl px-3 py-1.5 h-auto"
               aria-label="View sources"
             >
@@ -302,7 +325,7 @@ export const MessageActions = ({
             </Button>
           )}
 
-          {shouldShowTimestamp && (
+          {!isUser && shouldRenderTimestamp && (
             <time
               dateTime={new Date(messageCreatedAt!).toISOString()}
               className="flex h-7 items-center px-1.5 text-[16px] leading-none text-muted-foreground opacity-70 tabular-nums whitespace-nowrap"

--- a/app/components/MessageActions.tsx
+++ b/app/components/MessageActions.tsx
@@ -12,6 +12,7 @@ import Image from "next/image";
 import type { ChatStatus } from "@/types";
 import { WithTooltip } from "@/components/ui/with-tooltip";
 import { Button } from "@/components/ui/button";
+import { formatMessageActionTimestamp } from "@/lib/utils/message-time";
 import { SourcesDialog } from "./SourcesDialog";
 
 interface MessageActionsProps {
@@ -24,6 +25,7 @@ interface MessageActionsProps {
   onBranch?: () => void;
   isHovered: boolean;
   isEditing: boolean;
+  messageCreatedAt?: number;
   status: ChatStatus;
   onFeedback?: (type: "positive" | "negative") => void;
   existingFeedback?: "positive" | "negative" | null;
@@ -48,6 +50,7 @@ export const MessageActions = ({
   onBranch,
   isHovered,
   isEditing,
+  messageCreatedAt,
   status,
   onFeedback,
   existingFeedback,
@@ -101,6 +104,9 @@ export const MessageActions = ({
     (status === "submitted" || status === "streaming");
   const shouldShowActions =
     !isLastAssistantLoading && !isEditing && (isUser ? isHovered : true); // Always show for assistant, only on hover for user
+  const formattedCreatedAt = formatMessageActionTimestamp(messageCreatedAt);
+  const shouldShowTimestamp =
+    shouldShowActions && isHovered && formattedCreatedAt !== null;
 
   // Reset isRegenerating when status changes back to idle
   const isLoading = status === "submitted" || status === "streaming";
@@ -294,6 +300,15 @@ export const MessageActions = ({
                 Sources
               </div>
             </Button>
+          )}
+
+          {shouldShowTimestamp && (
+            <time
+              dateTime={new Date(messageCreatedAt!).toISOString()}
+              className="text-xs text-muted-foreground/80 tabular-nums whitespace-nowrap"
+            >
+              {formattedCreatedAt}
+            </time>
           )}
         </>
       ) : (

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -107,6 +107,9 @@ function areMessageItemPropsEqual(
       next.message.metadata?.generationTimeMs
     )
       return false;
+    if (prev.message.createdAt !== next.message.createdAt) return false;
+    if (prev.message.metadata?.createdAt !== next.message.metadata?.createdAt)
+      return false;
   }
 
   return true;
@@ -563,6 +566,7 @@ export const MessageItem = memo(function MessageItem({
           onBranch={!isUser && onBranchMessage ? handleBranch : undefined}
           isHovered={isHovered}
           isEditing={isEditing}
+          messageCreatedAt={message.createdAt ?? message.metadata?.createdAt}
           status={status}
           onFeedback={handleFeedbackClick}
           existingFeedback={message.metadata?.feedbackType || null}

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -31,6 +31,7 @@ interface MessageItemProps {
   status: ChatStatus;
   isHovered: boolean;
   isEditing: boolean;
+  isMobile?: boolean;
   feedbackInputMessageId: string | null;
   tempChatFileDetails?: Map<string, FileDetails[]>;
   finishReason?: string;
@@ -70,6 +71,7 @@ function areMessageItemPropsEqual(
   if (prev.status !== next.status) return false;
   if (prev.isHovered !== next.isHovered) return false;
   if (prev.isEditing !== next.isEditing) return false;
+  if (prev.isMobile !== next.isMobile) return false;
   if (prev.feedbackInputMessageId !== next.feedbackInputMessageId) return false;
   if (prev.index !== next.index) return false;
   if (prev.messagesLength !== next.messagesLength) return false;
@@ -123,6 +125,7 @@ export const MessageItem = memo(function MessageItem({
   status,
   isHovered,
   isEditing,
+  isMobile,
   feedbackInputMessageId,
   tempChatFileDetails,
   finishReason,
@@ -566,6 +569,7 @@ export const MessageItem = memo(function MessageItem({
           onBranch={!isUser && onBranchMessage ? handleBranch : undefined}
           isHovered={isHovered}
           isEditing={isEditing}
+          isMobile={isMobile}
           messageCreatedAt={message.createdAt ?? message.metadata?.createdAt}
           status={status}
           onFeedback={handleFeedbackClick}

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -48,6 +48,7 @@ interface MessagesProps {
     | "Exhausted";
   loadMore?: (numItems: number) => void;
   isTemporaryChat?: boolean;
+  isMobile?: boolean;
   tempChatFileDetails?: Map<string, FileDetails[]>;
   finishReason?: string;
   uploadStatus?: { message: string; isUploading: boolean } | null;
@@ -77,6 +78,7 @@ export const Messages = ({
   paginationStatus,
   loadMore,
   isTemporaryChat,
+  isMobile,
   tempChatFileDetails,
   finishReason,
   uploadStatus,
@@ -307,6 +309,7 @@ export const Messages = ({
               status={status}
               isHovered={hoveredMessageId === message.id}
               isEditing={editingMessageId === message.id}
+              isMobile={isMobile}
               feedbackInputMessageId={feedbackInputMessageId}
               tempChatFileDetails={tempChatFileDetails}
               finishReason={finishReason}

--- a/app/components/__tests__/MessageActions.visibility.test.ts
+++ b/app/components/__tests__/MessageActions.visibility.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "@jest/globals";
+import { getMessageActionVisibility } from "../MessageActions";
+
+const baseVisibilityInput = {
+  isUser: false,
+  isLastAssistantMessage: true,
+  isMobile: false,
+  isHovered: false,
+  isEditing: false,
+  isLastAssistantLoading: false,
+  hasTimestamp: true,
+};
+
+describe("getMessageActionVisibility", () => {
+  it("keeps the last assistant actions visible and reserves timestamp space", () => {
+    expect(getMessageActionVisibility(baseVisibilityInput)).toEqual({
+      shouldRenderActions: true,
+      actionsAreVisible: true,
+      shouldReserveTimestamp: true,
+      timestampIsVisible: false,
+    });
+  });
+
+  it("shows historical assistant actions only on desktop hover", () => {
+    expect(
+      getMessageActionVisibility({
+        ...baseVisibilityInput,
+        isLastAssistantMessage: false,
+      }),
+    ).toEqual({
+      shouldRenderActions: true,
+      actionsAreVisible: false,
+      shouldReserveTimestamp: true,
+      timestampIsVisible: false,
+    });
+
+    expect(
+      getMessageActionVisibility({
+        ...baseVisibilityInput,
+        isLastAssistantMessage: false,
+        isHovered: true,
+      }),
+    ).toEqual({
+      shouldRenderActions: true,
+      actionsAreVisible: true,
+      shouldReserveTimestamp: true,
+      timestampIsVisible: true,
+    });
+  });
+
+  it("shows user actions only on desktop hover with timestamp first", () => {
+    expect(
+      getMessageActionVisibility({
+        ...baseVisibilityInput,
+        isUser: true,
+        isLastAssistantMessage: false,
+      }),
+    ).toMatchObject({
+      shouldRenderActions: true,
+      actionsAreVisible: false,
+      shouldReserveTimestamp: true,
+    });
+
+    expect(
+      getMessageActionVisibility({
+        ...baseVisibilityInput,
+        isUser: true,
+        isLastAssistantMessage: false,
+        isHovered: true,
+      }),
+    ).toEqual({
+      shouldRenderActions: true,
+      actionsAreVisible: true,
+      shouldReserveTimestamp: true,
+      timestampIsVisible: true,
+    });
+  });
+
+  it("keeps actions visible and timestamp hidden on mobile", () => {
+    expect(
+      getMessageActionVisibility({
+        ...baseVisibilityInput,
+        isUser: true,
+        isLastAssistantMessage: false,
+        isMobile: true,
+      }),
+    ).toEqual({
+      shouldRenderActions: true,
+      actionsAreVisible: true,
+      shouldReserveTimestamp: false,
+      timestampIsVisible: false,
+    });
+  });
+
+  it("suppresses actions while editing or while the last assistant is loading", () => {
+    expect(
+      getMessageActionVisibility({
+        ...baseVisibilityInput,
+        isEditing: true,
+      }),
+    ).toEqual({
+      shouldRenderActions: false,
+      actionsAreVisible: false,
+      shouldReserveTimestamp: false,
+      timestampIsVisible: false,
+    });
+
+    expect(
+      getMessageActionVisibility({
+        ...baseVisibilityInput,
+        isLastAssistantLoading: true,
+      }),
+    ).toEqual({
+      shouldRenderActions: false,
+      actionsAreVisible: false,
+      shouldReserveTimestamp: false,
+      timestampIsVisible: false,
+    });
+  });
+});

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1216,6 +1216,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
                   paginationStatus={paginatedMessages.status}
                   loadMore={paginatedMessages.loadMore}
                   isTemporaryChat={isTempChat}
+                  isMobile={isMobile}
                   tempChatFileDetails={tempChatFileDetails}
                   finishReason={chatData?.finish_reason}
                   uploadStatus={uploadStatus}

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1028,6 +1028,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
           {
             text: nextMessage.text,
             files: nextMessage.files as any,
+            metadata: { createdAt: nextMessage.timestamp },
           },
           {
             body: {

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -352,6 +352,7 @@ export const useChatHandlers = ({
           {
             text: input.trim() || undefined,
             files: validFiles.length > 0 ? validFiles : undefined,
+            metadata: { createdAt: Date.now() },
           },
           {
             body: {
@@ -368,7 +369,7 @@ export const useChatHandlers = ({
         console.error("Failed to process files:", error);
         // Fallback to text-only message if file processing fails
         sendMessage(
-          { text: input },
+          { text: input, metadata: { createdAt: Date.now() } },
           {
             body: {
               mode: currentChatMode,
@@ -732,6 +733,8 @@ export const useChatHandlers = ({
       if (validFiles.length > 0) {
         messagePayload.files = validFiles;
       }
+
+      messagePayload.metadata = { createdAt: message.timestamp };
 
       sendMessage(messagePayload, {
         body: {

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -612,6 +612,7 @@ export const getMessagesByChatId = query({
           v.literal("system"),
         ),
         parts: v.array(v.any()),
+        created_at: v.number(),
         source_message_id: v.optional(v.string()),
         feedback: v.union(
           v.object({
@@ -732,6 +733,7 @@ export const getMessagesByChatId = query({
           id: message.id,
           role: message.role,
           parts: message.parts,
+          created_at: message._creationTime,
           source_message_id: message.source_message_id,
           feedback,
           mode: message.mode,

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -28,6 +28,7 @@ describe("utils", () => {
         {
           id: "msg1",
           role: "user",
+          created_at: 1_700_000_000_000,
           parts: [{ type: "text", text: "Hello" }],
         },
         {
@@ -44,6 +45,7 @@ describe("utils", () => {
       expect(result).toHaveLength(2);
       expect(result[0].id).toBe("msg1");
       expect(result[0].role).toBe("user");
+      expect(result[0].createdAt).toBe(1_700_000_000_000);
       expect(result[0].parts[0]).toEqual({ type: "text", text: "Hello" });
       expect(result[1].sourceMessageId).toBe("msg1");
       expect(result[1].metadata?.feedbackType).toBe("positive");

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -787,12 +787,17 @@ export const createChatHandler = () => {
                 generateMessageId: () => assistantMessageId,
                 messageMetadata: ({ part }) => {
                   if (part.type === "start") {
-                    return { mode, generationStartedAt: streamStartTime };
+                    return {
+                      mode,
+                      createdAt: streamStartTime,
+                      generationStartedAt: streamStartTime,
+                    };
                   }
 
                   if (part.type === "finish") {
                     return {
                       mode,
+                      createdAt: streamStartTime,
                       generationStartedAt: streamStartTime,
                       generationTimeMs: Date.now() - streamStartTime,
                     };
@@ -855,6 +860,7 @@ export const createChatHandler = () => {
                               if (part.type === "start") {
                                 return {
                                   mode,
+                                  createdAt: fallbackStartTime,
                                   generationStartedAt: fallbackStartTime,
                                 };
                               }
@@ -862,6 +868,7 @@ export const createChatHandler = () => {
                               if (part.type === "finish") {
                                 return {
                                   mode,
+                                  createdAt: fallbackStartTime,
                                   generationStartedAt: fallbackStartTime,
                                   generationTimeMs:
                                     Date.now() - fallbackStartTime,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -9,6 +9,7 @@ export interface MessageRecord {
   id: string;
   role: "user" | "assistant" | "system";
   parts: UIMessagePart<any, any>[];
+  created_at?: number;
   source_message_id?: string;
   feedback?: {
     feedbackType: "positive" | "negative";
@@ -53,6 +54,9 @@ export function convertToUIMessages(messages: MessageRecord[]): ChatMessage[] {
   return messages.map((message) => ({
     id: message.id,
     role: message.role,
+    ...(typeof message.created_at === "number"
+      ? { createdAt: message.created_at }
+      : {}),
     // Sanitize parts: remove any old URLs that may be stored in database
     // URLs expire, so we always fetch fresh ones via fileId
     parts: message.parts.map((part: any) => {

--- a/lib/utils/__tests__/message-time.test.ts
+++ b/lib/utils/__tests__/message-time.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "@jest/globals";
+import { formatMessageActionTimestamp } from "../message-time";
+
+describe("formatMessageActionTimestamp", () => {
+  it("shows only the time for messages from the same day", () => {
+    const now = new Date(2026, 4, 29, 15, 0);
+    const timestamp = new Date(2026, 4, 29, 8, 36).getTime();
+
+    expect(formatMessageActionTimestamp(timestamp, now)).toBe("8:36 AM");
+  });
+
+  it("shows weekday and time for messages from yesterday or earlier", () => {
+    const now = new Date(2026, 4, 29, 15, 0);
+    const timestamp = new Date(2026, 4, 28, 8, 36).getTime();
+
+    expect(formatMessageActionTimestamp(timestamp, now)).toBe(
+      "Thursday 8:36 AM",
+    );
+  });
+
+  it("returns null for missing or invalid timestamps", () => {
+    expect(formatMessageActionTimestamp(undefined)).toBeNull();
+    expect(formatMessageActionTimestamp(Number.NaN)).toBeNull();
+  });
+});

--- a/lib/utils/message-time.ts
+++ b/lib/utils/message-time.ts
@@ -1,0 +1,19 @@
+import { format, isSameDay } from "date-fns";
+
+export function formatMessageActionTimestamp(
+  timestamp: number | undefined,
+  now: Date = new Date(),
+): string | null {
+  if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
+    return null;
+  }
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return isSameDay(date, now)
+    ? format(date, "h:mm a")
+    : format(date, "EEEE h:mm a");
+}

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1171,12 +1171,17 @@ export const agentLongTask = task({
                   sendReasoning: true,
                   messageMetadata: ({ part }) => {
                     if (part.type === "start") {
-                      return { mode, generationStartedAt: streamStartTime };
+                      return {
+                        mode,
+                        createdAt: streamStartTime,
+                        generationStartedAt: streamStartTime,
+                      };
                     }
 
                     if (part.type === "finish") {
                       return {
                         mode,
+                        createdAt: streamStartTime,
                         generationStartedAt: streamStartTime,
                         generationTimeMs: Date.now() - streamStartTime,
                       };
@@ -1230,6 +1235,7 @@ export const agentLongTask = task({
                                 if (part.type === "start") {
                                   return {
                                     mode,
+                                    createdAt: fallbackStartTime,
                                     generationStartedAt: fallbackStartTime,
                                   };
                                 }
@@ -1237,6 +1243,7 @@ export const agentLongTask = task({
                                 if (part.type === "finish") {
                                   return {
                                     mode,
+                                    createdAt: fallbackStartTime,
                                     generationStartedAt: fallbackStartTime,
                                     generationTimeMs:
                                       Date.now() - fallbackStartTime,
@@ -1357,6 +1364,7 @@ export const agentLongTask = task({
                                       type: "message-metadata",
                                       messageMetadata: {
                                         mode,
+                                        createdAt: fallbackStartTime,
                                         generationStartedAt: fallbackStartTime,
                                         generationTimeMs:
                                           fallbackGenerationTimeMs,
@@ -1581,6 +1589,7 @@ export const agentLongTask = task({
                             type: "message-metadata",
                             messageMetadata: {
                               mode,
+                              createdAt: streamStartTime,
                               generationStartedAt: streamStartTime,
                               generationTimeMs: finalGenerationTimeMs,
                             },

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -285,6 +285,7 @@ export const messageMetadataSchema = z.object({
   feedbackType: z.enum(["positive", "negative"]).optional(),
   isAutoContinue: z.boolean().optional(),
   mode: z.enum(["agent", "ask"]).optional(),
+  createdAt: z.number().optional(),
   generationStartedAt: z.number().optional(),
   generationTimeMs: z.number().optional(),
 });
@@ -292,6 +293,7 @@ export const messageMetadataSchema = z.object({
 export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
 
 export type ChatMessage = UIMessage<MessageMetadata> & {
+  createdAt?: number;
   fileDetails?: FileDetails[];
   sourceMessageId?: string;
 };


### PR DESCRIPTION
## Summary

Adds a hover-only timestamp to the message actions row so users can see when a specific message was sent without adding always-visible clutter. Same-day messages render as a local time like `8:36 AM`; older messages include the weekday, like `Thursday 8:36 AM`.

## Details

- Carries Convex message `_creationTime` through the client message model as `createdAt`.
- Adds metadata timestamps for optimistic, queued, temporary, and streaming assistant messages so hover timestamps work before persistence catches up.
- Adds a small formatter utility and unit coverage for same-day versus older messages.

## Validation

- `pnpm exec jest lib/__tests__/utils.test.ts lib/utils/__tests__/message-time.test.ts --runInBand`
- `pnpm typecheck`
- Commit hook: `prettier --write`, `eslint --fix`, `pnpm typecheck`, full `pnpm test` (`105` suites, `1252` tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Action rows now display smart-formatted message timestamps and handle placement differently for user vs assistant messages.
  * Message list is mobile-aware so action/timestamp visibility adapts to mobile layouts.

* **Behavior Changes**
  * Feedback and branch buttons render more consistently for assistant messages while still respecting temporary/awaiting-feedback states.
  * Message items update when timestamps change to ensure UI reflects new creation times.

* **Reliability / Tests**
  * Timestamps are propagated with sent/streamed messages and covered by new unit tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->