### PR TITLE
[codex] Shorten long user messages

### DIFF
--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useCallback, Fragment } from "react";
+import { memo, useMemo, useCallback, Fragment, useState } from "react";
 import { MessageActions } from "./MessageActions";
 import { MessagePartHandler } from "./MessagePartHandler";
 import { FilePartRenderer } from "./FilePartRenderer";
@@ -13,7 +13,7 @@ import {
   WorkedForContent,
   WorkedForTrigger,
 } from "@/components/ai-elements/worked-for";
-import { FileSearch, WandSparkles } from "lucide-react";
+import { ChevronDown, FileSearch, WandSparkles } from "lucide-react";
 import {
   extractMessageText,
   hasTextContent,
@@ -22,6 +22,23 @@ import {
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import type { ChatStatus, ChatMessage, ChatMode } from "@/types";
 import type { FileDetails } from "@/types/file";
+
+const USER_MESSAGE_PREVIEW_LINE_LIMIT = 12;
+const USER_MESSAGE_PREVIEW_CHAR_LIMIT = 1_200;
+
+const splitMessageLines = (text: string) => text.split(/\r\n|\r|\n/);
+
+const isLongUserMessageText = (text: string) =>
+  text.length > USER_MESSAGE_PREVIEW_CHAR_LIMIT ||
+  splitMessageLines(text).length > USER_MESSAGE_PREVIEW_LINE_LIMIT;
+
+const getUserMessagePreview = (text: string) => {
+  const linePreview = splitMessageLines(text)
+    .slice(0, USER_MESSAGE_PREVIEW_LINE_LIMIT)
+    .join("\n");
+
+  return linePreview.slice(0, USER_MESSAGE_PREVIEW_CHAR_LIMIT).trimEnd();
+};
 
 interface MessageItemProps {
   message: ChatMessage;
@@ -144,6 +161,7 @@ export const MessageItem = memo(function MessageItem({
   showingLoadingIndicator,
   summarizationStatus,
 }: MessageItemProps) {
+  const [isUserMessageExpanded, setIsUserMessageExpanded] = useState(false);
   const isUser = message.role === "user";
   const isLastAssistantMessage =
     message.role === "assistant" &&
@@ -175,6 +193,21 @@ export const MessageItem = memo(function MessageItem({
     () => splitWorkedForParts(message.parts),
     [message.parts],
   );
+
+  const shouldCollapseUserMessage =
+    isUser &&
+    nonFileParts.length > 0 &&
+    nonFileParts.every((part) => part.type === "text") &&
+    isLongUserMessageText(messageText);
+
+  const collapsedUserMessageText = useMemo(
+    () => (shouldCollapseUserMessage ? getUserMessagePreview(messageText) : ""),
+    [messageText, shouldCollapseUserMessage],
+  );
+
+  const handleShowFullUserMessage = useCallback(() => {
+    setIsUserMessageExpanded(true);
+  }, []);
 
   const isStreamingThisMessage =
     message.role === "assistant" &&
@@ -344,16 +377,34 @@ export const MessageItem = memo(function MessageItem({
               >
                 {isUser ? (
                   <div className="whitespace-pre-wrap break-words">
-                    {nonFileParts.map((part, partIndex) => (
-                      <MessagePartHandler
-                        key={`${message.id}-${partIndex}`}
-                        message={message}
-                        part={part}
-                        partIndex={partIndex}
-                        status={effectiveStatus}
-                        terminalOutputByToolCallId={terminalOutputByToolCallId}
-                      />
-                    ))}
+                    {shouldCollapseUserMessage && !isUserMessageExpanded ? (
+                      <>
+                        <div>{collapsedUserMessageText}</div>
+                        <div aria-hidden="true">...</div>
+                        <button
+                          type="button"
+                          onClick={handleShowFullUserMessage}
+                          aria-expanded={false}
+                          className="mt-2 flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                        >
+                          <span>Show fulll message</span>
+                          <ChevronDown className="size-4 shrink-0" />
+                        </button>
+                      </>
+                    ) : (
+                      nonFileParts.map((part, partIndex) => (
+                        <MessagePartHandler
+                          key={`${message.id}-${partIndex}`}
+                          message={message}
+                          part={part}
+                          partIndex={partIndex}
+                          status={effectiveStatus}
+                          terminalOutputByToolCallId={
+                            terminalOutputByToolCallId
+                          }
+                        />
+                      ))
+                    )}
                   </div>
                 ) : !shouldUseWorkedFor ? (
                   nonFileParts.map((part, partIndex) => (

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -23,7 +23,7 @@ import { isAgentMode } from "@/lib/utils/mode-helpers";
 import type { ChatStatus, ChatMessage, ChatMode } from "@/types";
 import type { FileDetails } from "@/types/file";
 
-const USER_MESSAGE_PREVIEW_LINE_LIMIT = 12;
+const USER_MESSAGE_PREVIEW_LINE_LIMIT = 20;
 const USER_MESSAGE_PREVIEW_CHAR_LIMIT = 1_200;
 
 const splitMessageLines = (text: string) => text.split(/\r\n|\r|\n/);

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -33,11 +33,13 @@ const isLongUserMessageText = (text: string) =>
   splitMessageLines(text).length > USER_MESSAGE_PREVIEW_LINE_LIMIT;
 
 const getUserMessagePreview = (text: string) => {
-  const linePreview = splitMessageLines(text)
-    .slice(0, USER_MESSAGE_PREVIEW_LINE_LIMIT)
-    .join("\n");
+  const lines = splitMessageLines(text);
 
-  return linePreview.slice(0, USER_MESSAGE_PREVIEW_CHAR_LIMIT).trimEnd();
+  if (lines.length > USER_MESSAGE_PREVIEW_LINE_LIMIT) {
+    return lines.slice(0, USER_MESSAGE_PREVIEW_LINE_LIMIT).join("\n");
+  }
+
+  return text.slice(0, USER_MESSAGE_PREVIEW_CHAR_LIMIT).trimEnd();
 };
 
 interface MessageItemProps {

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -13,7 +13,7 @@ import {
   WorkedForContent,
   WorkedForTrigger,
 } from "@/components/ai-elements/worked-for";
-import { ChevronDown, FileSearch, WandSparkles } from "lucide-react";
+import { ChevronDown, ChevronUp, FileSearch, WandSparkles } from "lucide-react";
 import {
   extractMessageText,
   hasTextContent,
@@ -209,6 +209,10 @@ export const MessageItem = memo(function MessageItem({
     setIsUserMessageExpanded(true);
   }, []);
 
+  const handleShowLessUserMessage = useCallback(() => {
+    setIsUserMessageExpanded(false);
+  }, []);
+
   const isStreamingThisMessage =
     message.role === "assistant" &&
     isLastAssistantMessage &&
@@ -392,18 +396,31 @@ export const MessageItem = memo(function MessageItem({
                         </button>
                       </>
                     ) : (
-                      nonFileParts.map((part, partIndex) => (
-                        <MessagePartHandler
-                          key={`${message.id}-${partIndex}`}
-                          message={message}
-                          part={part}
-                          partIndex={partIndex}
-                          status={effectiveStatus}
-                          terminalOutputByToolCallId={
-                            terminalOutputByToolCallId
-                          }
-                        />
-                      ))
+                      <>
+                        {nonFileParts.map((part, partIndex) => (
+                          <MessagePartHandler
+                            key={`${message.id}-${partIndex}`}
+                            message={message}
+                            part={part}
+                            partIndex={partIndex}
+                            status={effectiveStatus}
+                            terminalOutputByToolCallId={
+                              terminalOutputByToolCallId
+                            }
+                          />
+                        ))}
+                        {shouldCollapseUserMessage && isUserMessageExpanded && (
+                          <button
+                            type="button"
+                            onClick={handleShowLessUserMessage}
+                            aria-expanded={true}
+                            className="mt-2 flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                          >
+                            <span>Show less</span>
+                            <ChevronUp className="size-4 shrink-0" />
+                          </button>
+                        )}
+                      </>
                     )}
                   </div>
                 ) : !shouldUseWorkedFor ? (

--- a/app/components/__tests__/MessageItem.worked-for.test.tsx
+++ b/app/components/__tests__/MessageItem.worked-for.test.tsx
@@ -248,7 +248,7 @@ describe("MessageItem WorkedFor rendering", () => {
 describe("MessageItem user message collapse", () => {
   it("collapses long user messages behind a full-message button", () => {
     const longMessage = Array.from(
-      { length: 18 },
+      { length: 24 },
       (_, index) => `line ${index + 1}`,
     ).join("\n");
 
@@ -260,14 +260,17 @@ describe("MessageItem user message collapse", () => {
     expect(
       screen.getByRole("button", { name: /show fulll message/i }),
     ).toBeInTheDocument();
-    expect(screen.getByText("...")).toBeInTheDocument();
-    expect(screen.getByText(/line 12/)).toBeInTheDocument();
-    expect(screen.queryByText(/line 18/)).not.toBeInTheDocument();
+    const ellipsis = screen.getByText("...");
+    expect(ellipsis).toBeInTheDocument();
+    expect(ellipsis.tagName).toBe("DIV");
+    expect(ellipsis).toHaveTextContent(/^\.{3}$/);
+    expect(screen.getByText(/line 20/)).toBeInTheDocument();
+    expect(screen.queryByText(/line 24/)).not.toBeInTheDocument();
   });
 
   it("shows the full user message and allows collapsing it again", () => {
     const longMessage = Array.from(
-      { length: 18 },
+      { length: 24 },
       (_, index) => `line ${index + 1}`,
     ).join("\n");
 
@@ -283,14 +286,14 @@ describe("MessageItem user message collapse", () => {
     expect(
       screen.queryByRole("button", { name: /show fulll message/i }),
     ).not.toBeInTheDocument();
-    expect(screen.getByText(/line 18/)).toBeInTheDocument();
+    expect(screen.getByText(/line 24/)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /show less/i }),
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /show less/i }));
 
-    expect(screen.queryByText(/line 18/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/line 24/)).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /show fulll message/i }),
     ).toBeInTheDocument();

--- a/app/components/__tests__/MessageItem.worked-for.test.tsx
+++ b/app/components/__tests__/MessageItem.worked-for.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MessageItem } from "../MessageItem";
 import type { ChatMessage, ChatMode, ChatStatus } from "@/types";
 
@@ -53,6 +53,18 @@ const assistantMessage = {
     generationTimeMs: 1_500,
   },
 } as unknown as ChatMessage;
+
+const createUserMessage = (text: string) =>
+  ({
+    id: "user-1",
+    role: "user",
+    parts: [
+      {
+        type: "text",
+        text,
+      },
+    ],
+  }) as unknown as ChatMessage;
 
 const renderMessageItem = ({
   mode,
@@ -230,5 +242,59 @@ describe("MessageItem WorkedFor rendering", () => {
 
     expect(screen.queryByText(/worked for/i)).not.toBeInTheDocument();
     expect(screen.getByText("ran command")).toBeInTheDocument();
+  });
+});
+
+describe("MessageItem user message collapse", () => {
+  it("collapses long user messages behind a full-message button", () => {
+    const longMessage = Array.from(
+      { length: 18 },
+      (_, index) => `line ${index + 1}`,
+    ).join("\n");
+
+    renderMessageItem({
+      mode: "ask",
+      message: createUserMessage(longMessage),
+    });
+
+    expect(
+      screen.getByRole("button", { name: /show fulll message/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("...")).toBeInTheDocument();
+    expect(screen.getByText(/line 12/)).toBeInTheDocument();
+    expect(screen.queryByText(/line 18/)).not.toBeInTheDocument();
+  });
+
+  it("shows the full user message after the button is clicked", () => {
+    const longMessage = Array.from(
+      { length: 18 },
+      (_, index) => `line ${index + 1}`,
+    ).join("\n");
+
+    renderMessageItem({
+      mode: "ask",
+      message: createUserMessage(longMessage),
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /show fulll message/i }),
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /show fulll message/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/line 18/)).toBeInTheDocument();
+  });
+
+  it("leaves short user messages expanded", () => {
+    renderMessageItem({
+      mode: "ask",
+      message: createUserMessage("short message"),
+    });
+
+    expect(screen.getByText("short message")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /show fulll message/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/app/components/__tests__/MessageItem.worked-for.test.tsx
+++ b/app/components/__tests__/MessageItem.worked-for.test.tsx
@@ -247,9 +247,10 @@ describe("MessageItem WorkedFor rendering", () => {
 
 describe("MessageItem user message collapse", () => {
   it("collapses long user messages behind a full-message button", () => {
-    const longMessage = Array.from(
-      { length: 24 },
-      (_, index) => `line ${index + 1}`,
+    const longMessage = Array.from({ length: 24 }, (_, index) =>
+      index === 19
+        ? `line 20 ${"x".repeat(1_300)} exact-line-20-tail`
+        : `line ${index + 1}`,
     ).join("\n");
 
     renderMessageItem({
@@ -265,7 +266,28 @@ describe("MessageItem user message collapse", () => {
     expect(ellipsis.tagName).toBe("DIV");
     expect(ellipsis).toHaveTextContent(/^\.{3}$/);
     expect(screen.getByText(/line 20/)).toBeInTheDocument();
+    expect(screen.getByText(/exact-line-20-tail/)).toBeInTheDocument();
     expect(screen.queryByText(/line 24/)).not.toBeInTheDocument();
+  });
+
+  it("collapses very long single-line user messages by character count", () => {
+    const longMessage = `start-${"x".repeat(1_194)}hidden-tail`;
+
+    renderMessageItem({
+      mode: "ask",
+      message: createUserMessage(longMessage),
+    });
+
+    expect(
+      screen.getByRole("button", { name: /show fulll message/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/hidden-tail/)).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /show fulll message/i }),
+    );
+
+    expect(screen.getByText(/hidden-tail/)).toBeInTheDocument();
   });
 
   it("shows the full user message and allows collapsing it again", () => {

--- a/app/components/__tests__/MessageItem.worked-for.test.tsx
+++ b/app/components/__tests__/MessageItem.worked-for.test.tsx
@@ -265,7 +265,7 @@ describe("MessageItem user message collapse", () => {
     expect(screen.queryByText(/line 18/)).not.toBeInTheDocument();
   });
 
-  it("shows the full user message after the button is clicked", () => {
+  it("shows the full user message and allows collapsing it again", () => {
     const longMessage = Array.from(
       { length: 18 },
       (_, index) => `line ${index + 1}`,
@@ -284,6 +284,16 @@ describe("MessageItem user message collapse", () => {
       screen.queryByRole("button", { name: /show fulll message/i }),
     ).not.toBeInTheDocument();
     expect(screen.getByText(/line 18/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /show less/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /show less/i }));
+
+    expect(screen.queryByText(/line 18/)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /show fulll message/i }),
+    ).toBeInTheDocument();
   });
 
   it("leaves short user messages expanded", () => {


### PR DESCRIPTION
## Summary

- Collapse long user text messages into a preview in chat bubbles.
- Add a `Show fulll message` control that expands the full message in place.
- Cover collapsed, expanded, and short-message user bubble behavior in tests.

## Why

Very large user prompts can dominate the chat timeline and make it harder to scan the conversation. This keeps long prompts compact while preserving access to the full text.

## Validation

- `pnpm test -- app/components/__tests__/MessageItem.worked-for.test.tsx --runInBand`
- `pnpm exec eslint app/components/MessageItem.tsx app/components/__tests__/MessageItem.worked-for.test.tsx`
- `pnpm typecheck`
- Commit hook: `prettier --write`, `eslint --fix`, `pnpm typecheck`, full `pnpm test` (104 suites, 1252 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long user messages are now collapsed by default with a truncated preview and a "Show full message" button; expanded view shows the full message and a "Show less" button. Short messages remain fully expanded.

* **Tests**
  * Added tests covering collapse/expand behavior for multi-line and very long single-line user messages and ensuring short messages stay expanded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->