### PR TITLE
[codex] add paid unit economics tracking

### DIFF
--- a/app/api/extra-usage/confirm/route.ts
+++ b/app/api/extra-usage/confirm/route.ts
@@ -60,6 +60,16 @@ export async function GET(req: NextRequest) {
       userId,
       amountDollars,
       idempotencyKey: `cs_${session.id}`,
+      revenueSource: "extra_usage_purchase",
+      stripeCustomerId:
+        typeof session.customer === "string"
+          ? session.customer
+          : session.customer?.id,
+      stripeCheckoutSessionId: session.id,
+      stripePaymentIntentId:
+        typeof session.payment_intent === "string"
+          ? session.payment_intent
+          : session.payment_intent?.id,
     });
 
     return NextResponse.redirect(redirectUrl, { status: 303 });

--- a/app/api/extra-usage/webhook/route.ts
+++ b/app/api/extra-usage/webhook/route.ts
@@ -85,6 +85,16 @@ export async function POST(req: NextRequest) {
           amountDollars,
           idempotencyKey: `cs_${session.id}`,
           legacyIdempotencyKey: event.id, // Guards retries of pre-deploy webhooks that stored `evt_<id>`
+          revenueSource: "extra_usage_purchase",
+          stripeCustomerId:
+            typeof session.customer === "string"
+              ? session.customer
+              : session.customer?.id,
+          stripeCheckoutSessionId: session.id,
+          stripePaymentIntentId:
+            typeof session.payment_intent === "string"
+              ? session.payment_intent
+              : session.payment_intent?.id,
         });
 
         if (result.alreadyProcessed) {

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -265,15 +265,27 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
 
   const { tier, subscription } = resolved;
 
-  await recordSubscriptionRevenue({
-    invoice,
-    customerId,
-    userIds,
-    orgId: orgId ?? undefined,
-    tier,
-    subscription,
-    reason: resetMode.reason,
-  });
+  try {
+    await recordSubscriptionRevenue({
+      invoice,
+      customerId,
+      userIds,
+      orgId: orgId ?? undefined,
+      tier,
+      subscription,
+      reason: resetMode.reason,
+    });
+  } catch (error) {
+    console.error("[Subscription Webhook] Failed to record revenue:", {
+      error,
+      invoiceId: invoice.id,
+      customerId,
+      userCount: userIds.length,
+      orgId,
+      tier,
+      resetReason: resetMode.reason,
+    });
+  }
 
   if (resetMode.mode === "skip") {
     console.log(

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -46,6 +46,14 @@ function priceBillingInterval(
   return price?.recurring?.interval ?? undefined;
 }
 
+function invoicePaidAtMs(invoice: Stripe.Invoice): number {
+  const paidAt = invoice.status_transitions?.paid_at;
+  if (paidAt) return paidAt * 1000;
+  return (
+    ((invoice as { created?: number }).created ?? Date.now() / 1000) * 1000
+  );
+}
+
 const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
 // =============================================================================
@@ -128,6 +136,88 @@ async function resolveSubscription(subscriptionId: string): Promise<{
   }
 }
 
+async function recordSubscriptionRevenue({
+  invoice,
+  customerId,
+  userIds,
+  orgId,
+  tier,
+  subscription,
+  reason,
+}: {
+  invoice: Stripe.Invoice;
+  customerId: string;
+  userIds: string[];
+  orgId?: string;
+  tier: SubscriptionTier;
+  subscription: Stripe.Subscription;
+  reason: string;
+}) {
+  const grossRevenueDollars = centsToDollars(
+    (invoice as { amount_paid?: number }).amount_paid,
+  );
+
+  if (grossRevenueDollars <= 0 || userIds.length === 0) return;
+
+  const item = subscription.items?.data[0];
+  const price = item?.price;
+  const occurredAt = invoicePaidAtMs(invoice);
+  const attributedRevenueDollars = grossRevenueDollars / userIds.length;
+  const attributionStrategy = userIds.length > 1 ? "split_evenly" : "direct";
+
+  await Promise.all([
+    ...userIds.map((uid) =>
+      convex.mutation(api.unitEconomics.recordRevenueEvent, {
+        serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+        entityType: "user",
+        entityId: uid,
+        userId: uid,
+        organizationId: orgId,
+        source: "subscription",
+        sourceEventId: invoice.id,
+        idempotencyKey: `subscription:${invoice.id}:user:${uid}`,
+        grossRevenueDollars: attributedRevenueDollars,
+        currency: invoice.currency ?? "usd",
+        occurredAt,
+        attributionStrategy,
+        stripeCustomerId: customerId,
+        stripeSubscriptionId: subscription.id,
+        stripeInvoiceId: invoice.id,
+        stripePriceId: price?.id,
+        plan: price?.lookup_key ?? tier,
+        quantity: item?.quantity,
+        userCount: userIds.length,
+        description: reason,
+      }),
+    ),
+    ...(orgId
+      ? [
+          convex.mutation(api.unitEconomics.recordRevenueEvent, {
+            serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+            entityType: "organization",
+            entityId: orgId,
+            organizationId: orgId,
+            source: "subscription",
+            sourceEventId: invoice.id,
+            idempotencyKey: `subscription:${invoice.id}:organization:${orgId}`,
+            grossRevenueDollars,
+            currency: invoice.currency ?? "usd",
+            occurredAt,
+            attributionStrategy: "organization_pool",
+            stripeCustomerId: customerId,
+            stripeSubscriptionId: subscription.id,
+            stripeInvoiceId: invoice.id,
+            stripePriceId: price?.id,
+            plan: price?.lookup_key ?? tier,
+            quantity: item?.quantity,
+            userCount: userIds.length,
+            description: reason,
+          }),
+        ]
+      : []),
+  ]);
+}
+
 // =============================================================================
 // Event Handlers
 // =============================================================================
@@ -159,13 +249,6 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
   }
 
   const resetMode = getInvoicePaidBucketResetMode(invoice);
-  if (resetMode.mode === "skip") {
-    console.log(
-      `[Subscription Webhook] invoice.paid (${resetMode.reason}): skipping bucket reset for invoice ${invoice.id}`,
-    );
-    return;
-  }
-
   const [customerResult, resolved] = await Promise.all([
     resolveUserIdsFromCustomer(customerId),
     resolveSubscription(subscriptionId),
@@ -181,6 +264,23 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
   }
 
   const { tier, subscription } = resolved;
+
+  await recordSubscriptionRevenue({
+    invoice,
+    customerId,
+    userIds,
+    orgId: orgId ?? undefined,
+    tier,
+    subscription,
+    reason: resetMode.reason,
+  });
+
+  if (resetMode.mode === "skip") {
+    console.log(
+      `[Subscription Webhook] invoice.paid (${resetMode.reason}): skipping bucket reset for invoice ${invoice.id}`,
+    );
+    return;
+  }
 
   // Mid-cycle tier change: prorate credits based on remaining time in the cycle.
   // Only prorate if handleSubscriptionUpdated stashed old-tier data (confirms

--- a/app/api/team/extra-usage/confirm/route.ts
+++ b/app/api/team/extra-usage/confirm/route.ts
@@ -55,6 +55,16 @@ export async function GET(req: NextRequest) {
       organizationId,
       amountDollars,
       idempotencyKey: `cs_${session.id}`,
+      revenueSource: "team_extra_usage_purchase",
+      stripeCustomerId:
+        typeof session.customer === "string"
+          ? session.customer
+          : session.customer?.id,
+      stripeCheckoutSessionId: session.id,
+      stripePaymentIntentId:
+        typeof session.payment_intent === "string"
+          ? session.payment_intent
+          : session.payment_intent?.id,
     });
 
     return NextResponse.redirect(redirectUrl, { status: 303 });

--- a/app/api/team/extra-usage/webhook/route.ts
+++ b/app/api/team/extra-usage/webhook/route.ts
@@ -84,6 +84,16 @@ export async function POST(req: NextRequest) {
             amountDollars,
             idempotencyKey: `cs_${session.id}`,
             legacyIdempotencyKey: event.id,
+            revenueSource: "team_extra_usage_purchase",
+            stripeCustomerId:
+              typeof session.customer === "string"
+                ? session.customer
+                : session.customer?.id,
+            stripeCheckoutSessionId: session.id,
+            stripePaymentIntentId:
+              typeof session.payment_intent === "string"
+                ? session.payment_intent
+                : session.payment_intent?.id,
           },
         );
 

--- a/convex/__tests__/teamExtraUsage.test.ts
+++ b/convex/__tests__/teamExtraUsage.test.ts
@@ -110,6 +110,21 @@ type WebhookRow = {
   status?: "pending" | "completed";
 };
 
+type RevenueRow = {
+  _id: string;
+  idempotency_key: string;
+  entity_type: "user" | "organization";
+  entity_id: string;
+  source_event_id: string;
+};
+
+type UnitEconomicsDailyRow = {
+  _id: string;
+  entity_type: "user" | "organization";
+  entity_id: string;
+  day: string;
+};
+
 /**
  * Mock ctx that simulates the three tables touched by team extra usage:
  * team_extra_usage, team_member_usage, processed_webhooks. Index lookups
@@ -120,10 +135,14 @@ function makeMockCtx(opts?: {
   team?: TeamRow[];
   members?: MemberRow[];
   webhooks?: WebhookRow[];
+  revenue?: RevenueRow[];
+  rollups?: UnitEconomicsDailyRow[];
 }) {
   const team: TeamRow[] = [...(opts?.team ?? [])];
   const members: MemberRow[] = [...(opts?.members ?? [])];
   const webhooks: WebhookRow[] = [...(opts?.webhooks ?? [])];
+  const revenue: RevenueRow[] = [...(opts?.revenue ?? [])];
+  const rollups: UnitEconomicsDailyRow[] = [...(opts?.rollups ?? [])];
 
   let nextId = 1;
   const mintId = () => `id-${nextId++}`;
@@ -159,6 +178,19 @@ function makeMockCtx(opts?: {
           if (table === "processed_webhooks") {
             return webhooks.filter((r) => r.event_id === captured.event_id);
           }
+          if (table === "revenue_events") {
+            return revenue.filter(
+              (r) => r.idempotency_key === captured.idempotency_key,
+            );
+          }
+          if (table === "unit_economics_daily") {
+            return rollups.filter(
+              (r) =>
+                r.entity_type === captured.entity_type &&
+                r.entity_id === captured.entity_id &&
+                r.day === captured.day,
+            );
+          }
           return [];
         })();
         void depth;
@@ -189,23 +221,25 @@ function makeMockCtx(opts?: {
         if (table === "team_extra_usage") team.push(row);
         else if (table === "team_member_usage") members.push(row);
         else if (table === "processed_webhooks") webhooks.push(row);
+        else if (table === "revenue_events") revenue.push(row);
+        else if (table === "unit_economics_daily") rollups.push(row);
         else throw new Error(`unexpected table: ${table}`);
         return id;
       }),
       patch: jest.fn(async (id: string, patch: any) => {
-        const all: any[] = [...team, ...members, ...webhooks];
+        const all: any[] = [...team, ...members, ...webhooks, ...rollups];
         const row = all.find((r) => r._id === id);
         if (!row) throw new Error(`row ${id} not found`);
         Object.assign(row, patch);
       }),
       get: jest.fn(async (id: string) => {
-        const all: any[] = [...team, ...members, ...webhooks];
+        const all: any[] = [...team, ...members, ...webhooks, ...rollups];
         return all.find((r) => r._id === id) ?? null;
       }),
     },
   };
 
-  return { ctx, team, members, webhooks };
+  return { ctx, team, members, webhooks, revenue, rollups };
 }
 
 async function callDeduct(

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -32,6 +32,8 @@ import type * as sharedChats from "../sharedChats.js";
 import type * as teamExtraUsage from "../teamExtraUsage.js";
 import type * as teamExtraUsageActions from "../teamExtraUsageActions.js";
 import type * as tempStreams from "../tempStreams.js";
+import type * as unitEconomics from "../unitEconomics.js";
+import type * as unitEconomicsLib from "../unitEconomicsLib.js";
 import type * as usageLogs from "../usageLogs.js";
 import type * as userCustomization from "../userCustomization.js";
 import type * as userDeletion from "../userDeletion.js";
@@ -68,6 +70,8 @@ declare const fullApi: ApiFromModules<{
   teamExtraUsage: typeof teamExtraUsage;
   teamExtraUsageActions: typeof teamExtraUsageActions;
   tempStreams: typeof tempStreams;
+  unitEconomics: typeof unitEconomics;
+  unitEconomicsLib: typeof unitEconomicsLib;
   usageLogs: typeof usageLogs;
   userCustomization: typeof userCustomization;
   userDeletion: typeof userDeletion;

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -2,6 +2,7 @@ import { internalMutation, mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 import { convexLogger } from "./lib/logger";
+import { recordRevenueEventInternal } from "./unitEconomicsLib";
 
 // =============================================================================
 // Currency Conversion Helpers
@@ -226,6 +227,15 @@ export const addCredits = mutation({
     amountDollars: v.number(),
     idempotencyKey: v.optional(v.string()), // Primary dedup key (session-scoped: `cs_<id>`)
     legacyIdempotencyKey: v.optional(v.string()), // Stripe event ID — checked only to guard pre-deploy webhook retries
+    revenueSource: v.optional(
+      v.union(
+        v.literal("extra_usage_purchase"),
+        v.literal("extra_usage_auto_reload"),
+      ),
+    ),
+    stripeCustomerId: v.optional(v.string()),
+    stripeCheckoutSessionId: v.optional(v.string()),
+    stripePaymentIntentId: v.optional(v.string()),
   },
   returns: v.object({
     newBalance: v.number(), // Returns dollars
@@ -303,6 +313,29 @@ export const addCredits = mutation({
         processed_at: Date.now(),
       });
     }
+
+    await recordRevenueEventInternal(ctx, {
+      entityType: "user",
+      entityId: args.userId,
+      userId: args.userId,
+      source: "extra_usage",
+      sourceEventId:
+        args.stripeCheckoutSessionId ??
+        args.stripePaymentIntentId ??
+        args.idempotencyKey ??
+        `extra_usage:${args.userId}:${Date.now()}`,
+      idempotencyKey:
+        args.idempotencyKey ??
+        args.stripePaymentIntentId ??
+        args.stripeCheckoutSessionId,
+      grossRevenueDollars: args.amountDollars,
+      currency: "usd",
+      attributionStrategy: "direct",
+      stripeCustomerId: args.stripeCustomerId,
+      stripeCheckoutSessionId: args.stripeCheckoutSessionId,
+      stripePaymentIntentId: args.stripePaymentIntentId,
+      description: args.revenueSource ?? "extra_usage_purchase",
+    });
 
     convexLogger.info("credits_added", {
       user_id: args.userId,

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -615,6 +615,10 @@ export const deductWithAutoReload = action({
                     serviceKey: args.serviceKey,
                     userId: args.userId,
                     amountDollars: amountToCharge,
+                    idempotencyKey: paymentResult.paymentIntentId,
+                    revenueSource: "extra_usage_auto_reload",
+                    stripeCustomerId,
+                    stripePaymentIntentId: paymentResult.paymentIntentId,
                   });
                   autoReloadResult = {
                     success: true,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -328,6 +328,13 @@ export default defineSchema({
   // Per-request usage logs for the usage dashboard
   usage_logs: defineTable({
     user_id: v.string(),
+    organization_id: v.optional(v.string()),
+    chat_id: v.optional(v.string()),
+    endpoint: v.optional(
+      v.union(v.literal("/api/chat"), v.literal("/api/agent-long")),
+    ),
+    mode: v.optional(v.union(v.literal("ask"), v.literal("agent"))),
+    subscription: v.optional(v.string()),
     model: v.string(),
     type: v.union(v.literal("included"), v.literal("extra")),
     input_tokens: v.number(),
@@ -336,6 +343,11 @@ export default defineSchema({
     cache_write_tokens: v.optional(v.number()),
     total_tokens: v.number(),
     cost_dollars: v.number(),
+    model_cost_dollars: v.optional(v.number()),
+    non_model_cost_dollars: v.optional(v.number()),
+    cost_source: v.optional(
+      v.union(v.literal("provider"), v.literal("token_estimate")),
+    ),
     // Legacy MAX Mode flag retained on historical rows. The feature was
     // removed and nothing reads or writes this anymore — kept in the schema
     // so old rows still pass validation.
@@ -346,7 +358,82 @@ export default defineSchema({
     byok: v.optional(v.boolean()),
   })
     .index("by_user", ["user_id"])
-    .index("by_user_and_model", ["user_id", "model"]),
+    .index("by_user_and_model", ["user_id", "model"])
+    .index("by_org", ["organization_id"]),
+
+  // Durable revenue ledger for unit economics reporting. Revenue is stored as
+  // gross/net dollars because usage costs are sub-cent dollar values already.
+  revenue_events: defineTable({
+    entity_type: v.union(v.literal("user"), v.literal("organization")),
+    entity_id: v.string(),
+    user_id: v.optional(v.string()),
+    organization_id: v.optional(v.string()),
+    source: v.union(
+      v.literal("subscription"),
+      v.literal("extra_usage"),
+      v.literal("team_extra_usage"),
+      v.literal("manual_adjustment"),
+    ),
+    source_event_id: v.string(),
+    idempotency_key: v.string(),
+    gross_revenue_dollars: v.number(),
+    net_revenue_dollars: v.number(),
+    currency: v.string(),
+    occurred_at: v.number(),
+    attribution_strategy: v.union(
+      v.literal("direct"),
+      v.literal("split_evenly"),
+      v.literal("organization_pool"),
+    ),
+    stripe_customer_id: v.optional(v.string()),
+    stripe_subscription_id: v.optional(v.string()),
+    stripe_invoice_id: v.optional(v.string()),
+    stripe_checkout_session_id: v.optional(v.string()),
+    stripe_payment_intent_id: v.optional(v.string()),
+    stripe_price_id: v.optional(v.string()),
+    plan: v.optional(v.string()),
+    quantity: v.optional(v.number()),
+    user_count: v.optional(v.number()),
+    description: v.optional(v.string()),
+    created_at: v.number(),
+  })
+    .index("by_idempotency_key", ["idempotency_key"])
+    .index("by_entity_occurred", ["entity_type", "entity_id", "occurred_at"])
+    .index("by_user_occurred", ["user_id", "occurred_at"])
+    .index("by_org_occurred", ["organization_id", "occurred_at"])
+    .index("by_source_event", ["source", "source_event_id"]),
+
+  // Compact daily rows intended for dashboarding and PostHog warehouse sync.
+  // Query either entity_type=user for per-user profitability or
+  // entity_type=organization for team pool/subscription reporting.
+  unit_economics_daily: defineTable({
+    entity_type: v.union(v.literal("user"), v.literal("organization")),
+    entity_id: v.string(),
+    user_id: v.optional(v.string()),
+    organization_id: v.optional(v.string()),
+    day: v.string(),
+    gross_revenue_dollars: v.number(),
+    net_revenue_dollars: v.number(),
+    model_cost_dollars: v.number(),
+    non_model_cost_dollars: v.number(),
+    total_cost_dollars: v.number(),
+    gross_profit_dollars: v.number(),
+    included_usage_cost_dollars: v.number(),
+    extra_usage_cost_dollars: v.number(),
+    usage_request_count: v.number(),
+    revenue_event_count: v.number(),
+    input_tokens: v.number(),
+    output_tokens: v.number(),
+    cache_read_tokens: v.number(),
+    cache_write_tokens: v.number(),
+    total_tokens: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_entity_day", ["entity_type", "entity_id", "day"])
+    .index("by_day", ["day"])
+    .index("by_type_day", ["entity_type", "day"])
+    .index("by_user_day", ["user_id", "day"])
+    .index("by_org_day", ["organization_id", "day"]),
 
   // Webhook idempotency (prevents double-crediting on Stripe retries)
   processed_webhooks: defineTable({

--- a/convex/teamExtraUsage.ts
+++ b/convex/teamExtraUsage.ts
@@ -7,6 +7,7 @@ import {
 import { v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 import { convexLogger } from "./lib/logger";
+import { recordRevenueEventInternal } from "./unitEconomicsLib";
 
 // =============================================================================
 // Currency Conversion Helpers
@@ -90,6 +91,15 @@ export const addTeamCredits = mutation({
     amountDollars: v.number(),
     idempotencyKey: v.optional(v.string()),
     legacyIdempotencyKey: v.optional(v.string()),
+    revenueSource: v.optional(
+      v.union(
+        v.literal("team_extra_usage_purchase"),
+        v.literal("team_extra_usage_auto_reload"),
+      ),
+    ),
+    stripeCustomerId: v.optional(v.string()),
+    stripeCheckoutSessionId: v.optional(v.string()),
+    stripePaymentIntentId: v.optional(v.string()),
   },
   returns: v.object({
     newBalance: v.number(),
@@ -161,6 +171,29 @@ export const addTeamCredits = mutation({
         processed_at: Date.now(),
       });
     }
+
+    await recordRevenueEventInternal(ctx, {
+      entityType: "organization",
+      entityId: args.organizationId,
+      organizationId: args.organizationId,
+      source: "team_extra_usage",
+      sourceEventId:
+        args.stripeCheckoutSessionId ??
+        args.stripePaymentIntentId ??
+        args.idempotencyKey ??
+        `team_extra_usage:${args.organizationId}:${Date.now()}`,
+      idempotencyKey:
+        args.idempotencyKey ??
+        args.stripePaymentIntentId ??
+        args.stripeCheckoutSessionId,
+      grossRevenueDollars: args.amountDollars,
+      currency: "usd",
+      attributionStrategy: "organization_pool",
+      stripeCustomerId: args.stripeCustomerId,
+      stripeCheckoutSessionId: args.stripeCheckoutSessionId,
+      stripePaymentIntentId: args.stripePaymentIntentId,
+      description: args.revenueSource ?? "team_extra_usage_purchase",
+    });
 
     convexLogger.info("team_credits_added", {
       organization_id: args.organizationId,

--- a/convex/teamExtraUsageActions.ts
+++ b/convex/teamExtraUsageActions.ts
@@ -434,6 +434,10 @@ export const deductWithAutoReloadForTeam = action({
                     serviceKey: args.serviceKey,
                     organizationId: args.organizationId,
                     amountDollars: amountToCharge,
+                    idempotencyKey: paymentResult.paymentIntentId,
+                    revenueSource: "team_extra_usage_auto_reload",
+                    stripeCustomerId,
+                    stripePaymentIntentId: paymentResult.paymentIntentId,
                   });
                   if (deductResult.success) {
                     deductResult = {

--- a/convex/unitEconomics.ts
+++ b/convex/unitEconomics.ts
@@ -1,0 +1,332 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { validateServiceKey } from "./lib/utils";
+import {
+  applyUnitEconomicsDelta,
+  recordRevenueEventInternal,
+  utcDay,
+  type UnitEconomicsAttributionStrategy,
+  type UnitEconomicsEntityType,
+  type UnitEconomicsRevenueSource,
+} from "./unitEconomicsLib";
+
+const entityTypeValidator = v.union(
+  v.literal("user"),
+  v.literal("organization"),
+);
+
+const revenueSourceValidator = v.union(
+  v.literal("subscription"),
+  v.literal("extra_usage"),
+  v.literal("team_extra_usage"),
+  v.literal("manual_adjustment"),
+);
+
+const attributionStrategyValidator = v.union(
+  v.literal("direct"),
+  v.literal("split_evenly"),
+  v.literal("organization_pool"),
+);
+
+function assertFiniteMoney(value: number, field: string) {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${field} must be finite`);
+  }
+}
+
+function sumRows(rows: Array<any>) {
+  return rows.reduce(
+    (totals, row) => ({
+      grossRevenueDollars:
+        totals.grossRevenueDollars + row.gross_revenue_dollars,
+      netRevenueDollars: totals.netRevenueDollars + row.net_revenue_dollars,
+      modelCostDollars: totals.modelCostDollars + row.model_cost_dollars,
+      nonModelCostDollars:
+        totals.nonModelCostDollars + row.non_model_cost_dollars,
+      totalCostDollars: totals.totalCostDollars + row.total_cost_dollars,
+      grossProfitDollars: totals.grossProfitDollars + row.gross_profit_dollars,
+      includedUsageCostDollars:
+        totals.includedUsageCostDollars + row.included_usage_cost_dollars,
+      extraUsageCostDollars:
+        totals.extraUsageCostDollars + row.extra_usage_cost_dollars,
+      usageRequestCount: totals.usageRequestCount + row.usage_request_count,
+      revenueEventCount: totals.revenueEventCount + row.revenue_event_count,
+      inputTokens: totals.inputTokens + row.input_tokens,
+      outputTokens: totals.outputTokens + row.output_tokens,
+      cacheReadTokens: totals.cacheReadTokens + row.cache_read_tokens,
+      cacheWriteTokens: totals.cacheWriteTokens + row.cache_write_tokens,
+      totalTokens: totals.totalTokens + row.total_tokens,
+    }),
+    {
+      grossRevenueDollars: 0,
+      netRevenueDollars: 0,
+      modelCostDollars: 0,
+      nonModelCostDollars: 0,
+      totalCostDollars: 0,
+      grossProfitDollars: 0,
+      includedUsageCostDollars: 0,
+      extraUsageCostDollars: 0,
+      usageRequestCount: 0,
+      revenueEventCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      totalTokens: 0,
+    },
+  );
+}
+
+export const recordRevenueEvent = mutation({
+  args: {
+    serviceKey: v.string(),
+    entityType: entityTypeValidator,
+    entityId: v.string(),
+    userId: v.optional(v.string()),
+    organizationId: v.optional(v.string()),
+    source: revenueSourceValidator,
+    sourceEventId: v.string(),
+    idempotencyKey: v.optional(v.string()),
+    grossRevenueDollars: v.number(),
+    netRevenueDollars: v.optional(v.number()),
+    currency: v.optional(v.string()),
+    occurredAt: v.optional(v.number()),
+    attributionStrategy: attributionStrategyValidator,
+    stripeCustomerId: v.optional(v.string()),
+    stripeSubscriptionId: v.optional(v.string()),
+    stripeInvoiceId: v.optional(v.string()),
+    stripeCheckoutSessionId: v.optional(v.string()),
+    stripePaymentIntentId: v.optional(v.string()),
+    stripePriceId: v.optional(v.string()),
+    plan: v.optional(v.string()),
+    quantity: v.optional(v.number()),
+    userCount: v.optional(v.number()),
+    description: v.optional(v.string()),
+  },
+  returns: v.object({
+    alreadyRecorded: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    assertFiniteMoney(args.grossRevenueDollars, "grossRevenueDollars");
+    if (args.netRevenueDollars !== undefined) {
+      assertFiniteMoney(args.netRevenueDollars, "netRevenueDollars");
+    }
+
+    return await recordRevenueEventInternal(ctx, {
+      entityType: args.entityType as UnitEconomicsEntityType,
+      entityId: args.entityId,
+      userId: args.userId,
+      organizationId: args.organizationId,
+      source: args.source as UnitEconomicsRevenueSource,
+      sourceEventId: args.sourceEventId,
+      idempotencyKey: args.idempotencyKey,
+      grossRevenueDollars: args.grossRevenueDollars,
+      netRevenueDollars: args.netRevenueDollars,
+      currency: args.currency,
+      occurredAt: args.occurredAt,
+      attributionStrategy:
+        args.attributionStrategy as UnitEconomicsAttributionStrategy,
+      stripeCustomerId: args.stripeCustomerId,
+      stripeSubscriptionId: args.stripeSubscriptionId,
+      stripeInvoiceId: args.stripeInvoiceId,
+      stripeCheckoutSessionId: args.stripeCheckoutSessionId,
+      stripePaymentIntentId: args.stripePaymentIntentId,
+      stripePriceId: args.stripePriceId,
+      plan: args.plan,
+      quantity: args.quantity,
+      userCount: args.userCount,
+      description: args.description,
+    });
+  },
+});
+
+export const getEntitySummary = query({
+  args: {
+    serviceKey: v.string(),
+    entityType: entityTypeValidator,
+    entityId: v.string(),
+    startDay: v.optional(v.string()),
+    endDay: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const startDay = args.startDay ?? "0000-00-00";
+    const endDay = args.endDay ?? "9999-99-99";
+    const rows = await ctx.db
+      .query("unit_economics_daily")
+      .withIndex("by_entity_day", (q) =>
+        q
+          .eq("entity_type", args.entityType)
+          .eq("entity_id", args.entityId)
+          .gte("day", startDay)
+          .lte("day", endDay),
+      )
+      .collect();
+
+    return {
+      entityType: args.entityType,
+      entityId: args.entityId,
+      startDay,
+      endDay,
+      totals: sumRows(rows),
+      days: rows.sort((a, b) => a.day.localeCompare(b.day)),
+    };
+  },
+});
+
+export const rebuildEntityDailyRollups = mutation({
+  args: {
+    serviceKey: v.string(),
+    entityType: entityTypeValidator,
+    entityId: v.string(),
+    startTime: v.optional(v.number()),
+    endTime: v.optional(v.number()),
+    maxRows: v.optional(v.number()),
+  },
+  returns: v.object({
+    deletedRollups: v.number(),
+    usageRowsApplied: v.number(),
+    revenueRowsApplied: v.number(),
+    truncated: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const startTime = args.startTime ?? 0;
+    const endTime = args.endTime ?? Date.now();
+    const maxRows = Math.min(
+      Math.max(Math.round(args.maxRows ?? 5000), 1),
+      10_000,
+    );
+    const startDay = utcDay(startTime);
+    const endDay = utcDay(endTime);
+
+    const existingRollups = await ctx.db
+      .query("unit_economics_daily")
+      .withIndex("by_entity_day", (q) =>
+        q
+          .eq("entity_type", args.entityType)
+          .eq("entity_id", args.entityId)
+          .gte("day", startDay)
+          .lte("day", endDay),
+      )
+      .collect();
+
+    for (const row of existingRollups) {
+      await ctx.db.delete(row._id);
+    }
+
+    const usageRows =
+      args.entityType === "user"
+        ? await ctx.db
+            .query("usage_logs")
+            .withIndex("by_user", (q) =>
+              q
+                .eq("user_id", args.entityId)
+                .gte("_creationTime", startTime)
+                .lte("_creationTime", endTime),
+            )
+            .take(maxRows)
+        : await ctx.db
+            .query("usage_logs")
+            .withIndex("by_org", (q) =>
+              q
+                .eq("organization_id", args.entityId)
+                .gte("_creationTime", startTime)
+                .lte("_creationTime", endTime),
+            )
+            .take(maxRows);
+
+    for (const log of usageRows) {
+      const modelCostDollars = log.model_cost_dollars ?? log.cost_dollars;
+      const nonModelCostDollars = log.non_model_cost_dollars ?? 0;
+      await applyUnitEconomicsDelta(ctx, {
+        entityType: args.entityType as UnitEconomicsEntityType,
+        entityId: args.entityId,
+        userId: args.entityType === "user" ? args.entityId : undefined,
+        organizationId:
+          args.entityType === "organization"
+            ? args.entityId
+            : log.organization_id,
+        day: utcDay(log._creationTime),
+        modelCostDollars,
+        nonModelCostDollars,
+        includedUsageCostDollars:
+          log.type === "included" ? log.cost_dollars : 0,
+        extraUsageCostDollars: log.type === "extra" ? log.cost_dollars : 0,
+        usageRequestCount: 1,
+        inputTokens: log.input_tokens,
+        outputTokens: log.output_tokens,
+        cacheReadTokens: log.cache_read_tokens ?? 0,
+        cacheWriteTokens: log.cache_write_tokens ?? 0,
+        totalTokens: log.total_tokens,
+      });
+    }
+
+    const revenueRows = await ctx.db
+      .query("revenue_events")
+      .withIndex("by_entity_occurred", (q) =>
+        q
+          .eq("entity_type", args.entityType)
+          .eq("entity_id", args.entityId)
+          .gte("occurred_at", startTime)
+          .lte("occurred_at", endTime),
+      )
+      .take(maxRows);
+
+    for (const event of revenueRows) {
+      await applyUnitEconomicsDelta(ctx, {
+        entityType: args.entityType as UnitEconomicsEntityType,
+        entityId: args.entityId,
+        userId: event.user_id,
+        organizationId: event.organization_id,
+        day: utcDay(event.occurred_at),
+        grossRevenueDollars: event.gross_revenue_dollars,
+        netRevenueDollars: event.net_revenue_dollars,
+        revenueEventCount: 1,
+      });
+    }
+
+    return {
+      deletedRollups: existingRollups.length,
+      usageRowsApplied: usageRows.length,
+      revenueRowsApplied: revenueRows.length,
+      truncated: usageRows.length === maxRows || revenueRows.length === maxRows,
+    };
+  },
+});
+
+export const listDailyRollupsForPostHog = query({
+  args: {
+    serviceKey: v.string(),
+    startDay: v.string(),
+    endDay: v.string(),
+    entityType: v.optional(entityTypeValidator),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const limit = Math.min(Math.max(Math.round(args.limit ?? 1000), 1), 5000);
+    const query = ctx.db
+      .query("unit_economics_daily")
+      .withIndex("by_day", (q) =>
+        q.gte("day", args.startDay).lte("day", args.endDay),
+      );
+    const rows = args.entityType
+      ? await query
+          .filter((q) => q.eq(q.field("entity_type"), args.entityType))
+          .take(limit)
+      : await query.take(limit);
+
+    return rows.sort((a, b) => {
+      const dayCompare = a.day.localeCompare(b.day);
+      if (dayCompare !== 0) return dayCompare;
+      return `${a.entity_type}:${a.entity_id}`.localeCompare(
+        `${b.entity_type}:${b.entity_id}`,
+      );
+    });
+  },
+});

--- a/convex/unitEconomics.ts
+++ b/convex/unitEconomics.ts
@@ -212,10 +212,19 @@ export const rebuildEntityDailyRollups = mutation({
           .gte("day", startDay)
           .lte("day", endDay),
       )
-      .collect();
+      .take(maxRows);
 
     for (const row of existingRollups) {
       await ctx.db.delete(row._id);
+    }
+
+    if (existingRollups.length === maxRows) {
+      return {
+        deletedRollups: existingRollups.length,
+        usageRowsApplied: 0,
+        revenueRowsApplied: 0,
+        truncated: true,
+      };
     }
 
     const usageRows =

--- a/convex/unitEconomicsLib.ts
+++ b/convex/unitEconomicsLib.ts
@@ -1,0 +1,194 @@
+import type { MutationCtx } from "./_generated/server";
+
+export type UnitEconomicsEntityType = "user" | "organization";
+
+export type UnitEconomicsRevenueSource =
+  | "subscription"
+  | "extra_usage"
+  | "team_extra_usage"
+  | "manual_adjustment";
+
+export type UnitEconomicsAttributionStrategy =
+  | "direct"
+  | "split_evenly"
+  | "organization_pool";
+
+export function utcDay(timestampMs: number): string {
+  return new Date(timestampMs).toISOString().slice(0, 10);
+}
+
+function finite(value: number | undefined, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+export async function applyUnitEconomicsDelta(
+  ctx: MutationCtx,
+  args: {
+    entityType: UnitEconomicsEntityType;
+    entityId: string;
+    userId?: string;
+    organizationId?: string;
+    day: string;
+    grossRevenueDollars?: number;
+    netRevenueDollars?: number;
+    modelCostDollars?: number;
+    nonModelCostDollars?: number;
+    includedUsageCostDollars?: number;
+    extraUsageCostDollars?: number;
+    usageRequestCount?: number;
+    revenueEventCount?: number;
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+    totalTokens?: number;
+  },
+) {
+  const existing = await ctx.db
+    .query("unit_economics_daily")
+    .withIndex("by_entity_day", (q) =>
+      q
+        .eq("entity_type", args.entityType)
+        .eq("entity_id", args.entityId)
+        .eq("day", args.day),
+    )
+    .unique();
+
+  const grossRevenueDollars =
+    finite(existing?.gross_revenue_dollars) + finite(args.grossRevenueDollars);
+  const netRevenueDollars =
+    finite(existing?.net_revenue_dollars) + finite(args.netRevenueDollars);
+  const modelCostDollars =
+    finite(existing?.model_cost_dollars) + finite(args.modelCostDollars);
+  const nonModelCostDollars =
+    finite(existing?.non_model_cost_dollars) + finite(args.nonModelCostDollars);
+  const totalCostDollars = modelCostDollars + nonModelCostDollars;
+
+  const next = {
+    entity_type: args.entityType,
+    entity_id: args.entityId,
+    user_id: args.userId ?? existing?.user_id,
+    organization_id: args.organizationId ?? existing?.organization_id,
+    day: args.day,
+    gross_revenue_dollars: grossRevenueDollars,
+    net_revenue_dollars: netRevenueDollars,
+    model_cost_dollars: modelCostDollars,
+    non_model_cost_dollars: nonModelCostDollars,
+    total_cost_dollars: totalCostDollars,
+    gross_profit_dollars: netRevenueDollars - totalCostDollars,
+    included_usage_cost_dollars:
+      finite(existing?.included_usage_cost_dollars) +
+      finite(args.includedUsageCostDollars),
+    extra_usage_cost_dollars:
+      finite(existing?.extra_usage_cost_dollars) +
+      finite(args.extraUsageCostDollars),
+    usage_request_count:
+      finite(existing?.usage_request_count) + finite(args.usageRequestCount),
+    revenue_event_count:
+      finite(existing?.revenue_event_count) + finite(args.revenueEventCount),
+    input_tokens: finite(existing?.input_tokens) + finite(args.inputTokens),
+    output_tokens: finite(existing?.output_tokens) + finite(args.outputTokens),
+    cache_read_tokens:
+      finite(existing?.cache_read_tokens) + finite(args.cacheReadTokens),
+    cache_write_tokens:
+      finite(existing?.cache_write_tokens) + finite(args.cacheWriteTokens),
+    total_tokens: finite(existing?.total_tokens) + finite(args.totalTokens),
+    updated_at: Date.now(),
+  };
+
+  if (existing) {
+    await ctx.db.patch(existing._id, next);
+    return existing._id;
+  }
+
+  return await ctx.db.insert("unit_economics_daily", next);
+}
+
+export async function recordRevenueEventInternal(
+  ctx: MutationCtx,
+  args: {
+    entityType: UnitEconomicsEntityType;
+    entityId: string;
+    userId?: string;
+    organizationId?: string;
+    source: UnitEconomicsRevenueSource;
+    sourceEventId: string;
+    idempotencyKey?: string;
+    grossRevenueDollars: number;
+    netRevenueDollars?: number;
+    currency?: string;
+    occurredAt?: number;
+    attributionStrategy: UnitEconomicsAttributionStrategy;
+    stripeCustomerId?: string;
+    stripeSubscriptionId?: string;
+    stripeInvoiceId?: string;
+    stripeCheckoutSessionId?: string;
+    stripePaymentIntentId?: string;
+    stripePriceId?: string;
+    plan?: string;
+    quantity?: number;
+    userCount?: number;
+    description?: string;
+  },
+): Promise<{ alreadyRecorded: boolean }> {
+  const grossRevenueDollars = finite(args.grossRevenueDollars);
+  if (grossRevenueDollars === 0) {
+    return { alreadyRecorded: false };
+  }
+
+  const idempotencyKey =
+    args.idempotencyKey ??
+    `${args.source}:${args.sourceEventId}:${args.entityType}:${args.entityId}`;
+  const existing = await ctx.db
+    .query("revenue_events")
+    .withIndex("by_idempotency_key", (q) =>
+      q.eq("idempotency_key", idempotencyKey),
+    )
+    .unique();
+
+  if (existing) {
+    return { alreadyRecorded: true };
+  }
+
+  const occurredAt = args.occurredAt ?? Date.now();
+  const netRevenueDollars = finite(args.netRevenueDollars, grossRevenueDollars);
+
+  await ctx.db.insert("revenue_events", {
+    entity_type: args.entityType,
+    entity_id: args.entityId,
+    user_id: args.userId,
+    organization_id: args.organizationId,
+    source: args.source,
+    source_event_id: args.sourceEventId,
+    idempotency_key: idempotencyKey,
+    gross_revenue_dollars: grossRevenueDollars,
+    net_revenue_dollars: netRevenueDollars,
+    currency: args.currency ?? "usd",
+    occurred_at: occurredAt,
+    attribution_strategy: args.attributionStrategy,
+    stripe_customer_id: args.stripeCustomerId,
+    stripe_subscription_id: args.stripeSubscriptionId,
+    stripe_invoice_id: args.stripeInvoiceId,
+    stripe_checkout_session_id: args.stripeCheckoutSessionId,
+    stripe_payment_intent_id: args.stripePaymentIntentId,
+    stripe_price_id: args.stripePriceId,
+    plan: args.plan,
+    quantity: args.quantity,
+    user_count: args.userCount,
+    description: args.description,
+    created_at: Date.now(),
+  });
+
+  await applyUnitEconomicsDelta(ctx, {
+    entityType: args.entityType,
+    entityId: args.entityId,
+    userId: args.userId,
+    organizationId: args.organizationId,
+    day: utcDay(occurredAt),
+    grossRevenueDollars,
+    netRevenueDollars,
+    revenueEventCount: 1,
+  });
+
+  return { alreadyRecorded: false };
+}

--- a/convex/usageLogs.ts
+++ b/convex/usageLogs.ts
@@ -2,6 +2,7 @@ import { mutation, query } from "./_generated/server";
 import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
+import { applyUnitEconomicsDelta, utcDay } from "./unitEconomicsLib";
 
 const typeValidator = v.union(v.literal("included"), v.literal("extra"));
 
@@ -20,6 +21,13 @@ export const logUsage = mutation({
   args: {
     serviceKey: v.string(),
     user_id: v.string(),
+    organization_id: v.optional(v.string()),
+    chat_id: v.optional(v.string()),
+    endpoint: v.optional(
+      v.union(v.literal("/api/chat"), v.literal("/api/agent-long")),
+    ),
+    mode: v.optional(v.union(v.literal("ask"), v.literal("agent"))),
+    subscription: v.optional(v.string()),
     model: v.string(),
     type: typeValidator,
     input_tokens: v.number(),
@@ -28,13 +36,31 @@ export const logUsage = mutation({
     cache_write_tokens: v.optional(v.number()),
     total_tokens: v.number(),
     cost_dollars: v.number(),
+    model_cost_dollars: v.optional(v.number()),
+    non_model_cost_dollars: v.optional(v.number()),
+    cost_source: v.optional(
+      v.union(v.literal("provider"), v.literal("token_estimate")),
+    ),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
 
+    const modelCostDollars = Number.isFinite(args.model_cost_dollars)
+      ? args.model_cost_dollars!
+      : args.cost_dollars;
+    const nonModelCostDollars = Number.isFinite(args.non_model_cost_dollars)
+      ? args.non_model_cost_dollars!
+      : 0;
+    const now = Date.now();
+
     await ctx.db.insert("usage_logs", {
       user_id: args.user_id,
+      organization_id: args.organization_id,
+      chat_id: args.chat_id,
+      endpoint: args.endpoint,
+      mode: args.mode,
+      subscription: args.subscription,
       model: args.model,
       type: args.type,
       input_tokens: args.input_tokens,
@@ -43,7 +69,42 @@ export const logUsage = mutation({
       cache_write_tokens: args.cache_write_tokens,
       total_tokens: args.total_tokens,
       cost_dollars: args.cost_dollars,
+      model_cost_dollars: modelCostDollars,
+      non_model_cost_dollars: nonModelCostDollars,
+      cost_source: args.cost_source,
     });
+
+    const commonDelta = {
+      day: utcDay(now),
+      modelCostDollars,
+      nonModelCostDollars,
+      includedUsageCostDollars:
+        args.type === "included" ? args.cost_dollars : 0,
+      extraUsageCostDollars: args.type === "extra" ? args.cost_dollars : 0,
+      usageRequestCount: 1,
+      inputTokens: args.input_tokens,
+      outputTokens: args.output_tokens,
+      cacheReadTokens: args.cache_read_tokens ?? 0,
+      cacheWriteTokens: args.cache_write_tokens ?? 0,
+      totalTokens: args.total_tokens,
+    };
+
+    await applyUnitEconomicsDelta(ctx, {
+      ...commonDelta,
+      entityType: "user",
+      entityId: args.user_id,
+      userId: args.user_id,
+      organizationId: args.organization_id,
+    });
+
+    if (args.organization_id) {
+      await applyUnitEconomicsDelta(ctx, {
+        ...commonDelta,
+        entityType: "organization",
+        entityId: args.organization_id,
+        organizationId: args.organization_id,
+      });
+    }
 
     return null;
   },
@@ -133,6 +194,9 @@ export const getUserUsageLogs = query({
         cache_write_tokens: log.cache_write_tokens,
         total_tokens: log.total_tokens,
         cost_dollars: log.cost_dollars,
+        model_cost_dollars: log.model_cost_dollars,
+        non_model_cost_dollars: log.non_model_cost_dollars,
+        cost_source: log.cost_source,
       })),
     };
   },

--- a/docs/unit-economics.md
+++ b/docs/unit-economics.md
@@ -1,0 +1,80 @@
+# Unit Economics Tracking
+
+Convex is the durable source of truth for per-user and per-organization unit
+economics. PostHog should consume compact warehouse tables from Convex rather
+than raw request events.
+
+## Data Model
+
+- `usage_logs`: one row per cost-bearing AI request. Stores token counts, model
+  cost, non-model cost, subscription tier, chat, endpoint, and org context.
+- `revenue_events`: append-only Stripe revenue ledger. Stores subscription,
+  personal extra usage, and team extra usage revenue with idempotency keys.
+- `unit_economics_daily`: materialized daily rollups for cheap dashboards and
+  PostHog warehouse sync.
+
+Use `entity_type = "user"` for per-user profitability:
+
+```text
+net_revenue_dollars - total_cost_dollars = gross_profit_dollars
+```
+
+Use `entity_type = "organization"` for team subscription and team extra usage
+pool reporting.
+
+## PostHog
+
+Sync `unit_economics_daily` from Convex to PostHog. Do not send each request as
+a PostHog event for this reporting path.
+
+Recommended PostHog table:
+
+```text
+unit_economics_daily
+```
+
+Important columns:
+
+- `entity_type`
+- `entity_id`
+- `user_id`
+- `organization_id`
+- `day`
+- `gross_revenue_dollars`
+- `net_revenue_dollars`
+- `model_cost_dollars`
+- `non_model_cost_dollars`
+- `total_cost_dollars`
+- `gross_profit_dollars`
+- `usage_request_count`
+- `input_tokens`
+- `output_tokens`
+
+## Backfill
+
+New requests and revenue update `unit_economics_daily` automatically. For older
+`usage_logs`, run the service-key guarded Convex mutation:
+
+```text
+unitEconomics.rebuildEntityDailyRollups({
+  serviceKey,
+  entityType: "user",
+  entityId: "<workos-user-id>",
+  startTime: 0,
+  endTime: Date.now()
+})
+```
+
+Run the same mutation with `entityType: "organization"` for team reporting.
+
+The mutation rebuilds only one user or one organization at a time and returns
+`truncated: true` if the row cap was hit. Re-run with a narrower time range when
+that happens.
+
+## Revenue Accuracy
+
+Stripe revenue is recorded when credits are granted or subscription invoices are
+paid. `net_revenue_dollars` currently equals gross Stripe revenue unless a
+future Stripe balance-transaction sync fills in processor fees. This keeps
+model and request expenses exact while leaving payment processing fees explicit
+instead of hidden in the model-cost calculation.

--- a/docs/unit-economics.md
+++ b/docs/unit-economics.md
@@ -1,13 +1,14 @@
 # Unit Economics Tracking
 
-Convex is the durable source of truth for per-user and per-organization unit
-economics. PostHog should consume compact warehouse tables from Convex rather
-than raw request events.
+Convex is the durable source of truth for paid per-user and per-organization
+unit economics. PostHog should consume compact warehouse tables from Convex
+rather than raw request events.
 
 ## Data Model
 
-- `usage_logs`: one row per cost-bearing AI request. Stores token counts, model
-  cost, non-model cost, subscription tier, chat, endpoint, and org context.
+- `usage_logs`: one row per paid cost-bearing AI request. Stores token counts,
+  model cost, non-model cost, subscription tier, chat, endpoint, and org
+  context.
 - `revenue_events`: append-only Stripe revenue ledger. Stores subscription,
   personal extra usage, and team extra usage revenue with idempotency keys.
 - `unit_economics_daily`: materialized daily rollups for cheap dashboards and
@@ -21,6 +22,10 @@ net_revenue_dollars - total_cost_dollars = gross_profit_dollars
 
 Use `entity_type = "organization"` for team subscription and team extra usage
 pool reporting.
+
+Free-plan requests are intentionally excluded from durable Convex usage logging
+for now to keep write volume low. They still use the existing free monthly cost
+guard, but they do not update `usage_logs` or `unit_economics_daily`.
 
 ## PostHog
 
@@ -52,8 +57,8 @@ Important columns:
 
 ## Backfill
 
-New requests and revenue update `unit_economics_daily` automatically. For older
-`usage_logs`, run the service-key guarded Convex mutation:
+New paid requests and revenue update `unit_economics_daily` automatically. For
+older `usage_logs`, run the service-key guarded Convex mutation:
 
 ```text
 unitEconomics.rebuildEntityDailyRollups({

--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -341,6 +341,11 @@ describe("UsageTracker", () => {
 
       expect(localMockLog).toHaveBeenCalledWith({
         userId: "user-123",
+        organizationId: undefined,
+        chatId: undefined,
+        endpoint: undefined,
+        mode: undefined,
+        subscription: undefined,
         model: "auto",
         type: "included",
         inputTokens: 1000,
@@ -349,6 +354,9 @@ describe("UsageTracker", () => {
         cacheReadTokens: undefined,
         cacheWriteTokens: undefined,
         costDollars: 0.01,
+        modelCostDollars: 0.01,
+        nonModelCostDollars: 0,
+        costSource: "provider",
       });
     });
   });

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -676,15 +676,20 @@ export const createChatHandler = () => {
                     usageTracker.nonModelCost,
                     organizationId,
                   );
-                  usageTracker.log({
-                    userId,
-                    selectedModel,
-                    selectedModelOverride,
-                    responseModel: state.responseModel,
-                    configuredModelId,
-                    rateLimitInfo,
-                  });
                 }
+                usageTracker.log({
+                  userId,
+                  organizationId,
+                  chatId,
+                  endpoint,
+                  mode,
+                  subscription,
+                  selectedModel,
+                  selectedModelOverride,
+                  responseModel: state.responseModel,
+                  configuredModelId,
+                  rateLimitInfo,
+                });
                 captureUsageCost({
                   posthog,
                   userId,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -676,20 +676,20 @@ export const createChatHandler = () => {
                     usageTracker.nonModelCost,
                     organizationId,
                   );
+                  usageTracker.log({
+                    userId,
+                    organizationId,
+                    chatId,
+                    endpoint,
+                    mode,
+                    subscription,
+                    selectedModel,
+                    selectedModelOverride,
+                    responseModel: state.responseModel,
+                    configuredModelId,
+                    rateLimitInfo,
+                  });
                 }
-                usageTracker.log({
-                  userId,
-                  organizationId,
-                  chatId,
-                  endpoint,
-                  mode,
-                  subscription,
-                  selectedModel,
-                  selectedModelOverride,
-                  responseModel: state.responseModel,
-                  configuredModelId,
-                  rateLimitInfo,
-                });
                 captureUsageCost({
                   posthog,
                   userId,

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -1260,6 +1260,11 @@ export async function getNotes({
 
 export async function logUsageRecord({
   userId,
+  organizationId,
+  chatId,
+  endpoint,
+  mode,
+  subscription,
   model,
   type,
   inputTokens,
@@ -1268,8 +1273,16 @@ export async function logUsageRecord({
   cacheReadTokens,
   cacheWriteTokens,
   costDollars,
+  modelCostDollars,
+  nonModelCostDollars,
+  costSource,
 }: {
   userId: string;
+  organizationId?: string;
+  chatId?: string;
+  endpoint?: "/api/chat" | "/api/agent-long";
+  mode?: ChatMode;
+  subscription?: SubscriptionTier;
   model: string;
   type: "included" | "extra";
   inputTokens: number;
@@ -1278,11 +1291,19 @@ export async function logUsageRecord({
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
   costDollars: number;
+  modelCostDollars?: number;
+  nonModelCostDollars?: number;
+  costSource?: "provider" | "token_estimate";
 }) {
   try {
     await getConvexClient().mutation(api.usageLogs.logUsage, {
       serviceKey,
       user_id: userId,
+      organization_id: organizationId,
+      chat_id: chatId,
+      endpoint,
+      mode,
+      subscription,
       model,
       type,
       input_tokens: inputTokens,
@@ -1291,14 +1312,25 @@ export async function logUsageRecord({
       cache_write_tokens: cacheWriteTokens,
       total_tokens: totalTokens,
       cost_dollars: costDollars,
+      model_cost_dollars: modelCostDollars,
+      non_model_cost_dollars: nonModelCostDollars,
+      cost_source: costSource,
     });
   } catch (error) {
     console.error("Failed to log usage record:", {
       error,
       userId,
+      organizationId,
+      chatId,
+      endpoint,
+      mode,
+      subscription,
       model,
       type,
       costDollars,
+      modelCostDollars,
+      nonModelCostDollars,
+      costSource,
       inputTokens,
       outputTokens,
     });

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -1,6 +1,6 @@
 import { logUsageRecord } from "@/lib/db/actions";
 import { calculateTokenCost, POINTS_PER_DOLLAR } from "@/lib/rate-limit";
-import type { RateLimitInfo } from "@/types";
+import type { ChatMode, RateLimitInfo, SubscriptionTier } from "@/types";
 
 interface StepUsage {
   inputTokens?: number;
@@ -189,6 +189,11 @@ export class UsageTracker {
 
   log(args: {
     userId: string;
+    organizationId?: string;
+    chatId?: string;
+    endpoint?: "/api/chat" | "/api/agent-long";
+    mode?: ChatMode;
+    subscription?: SubscriptionTier;
     selectedModel: string;
     selectedModelOverride?: string | null;
     responseModel?: string;
@@ -198,6 +203,11 @@ export class UsageTracker {
     const usage = this.createUsageCostRecord(args);
     logUsageRecord({
       userId: args.userId,
+      organizationId: args.organizationId,
+      chatId: args.chatId,
+      endpoint: args.endpoint,
+      mode: args.mode,
+      subscription: args.subscription,
       model: usage.model,
       type: usage.type,
       inputTokens: usage.inputTokens,
@@ -206,6 +216,9 @@ export class UsageTracker {
       cacheReadTokens: usage.cacheReadTokens,
       cacheWriteTokens: usage.cacheWriteTokens,
       costDollars: usage.costDollars,
+      modelCostDollars: usage.modelCostDollars,
+      nonModelCostDollars: usage.nonModelCostDollars,
+      costSource: usage.costSource,
     });
   }
 }

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1063,15 +1063,20 @@ export const agentLongTask = task({
                     usageTracker.nonModelCost,
                     organizationId,
                   );
-                  usageTracker.log({
-                    userId,
-                    selectedModel,
-                    selectedModelOverride,
-                    responseModel: state.responseModel,
-                    configuredModelId,
-                    rateLimitInfo,
-                  });
                 }
+                usageTracker.log({
+                  userId,
+                  organizationId,
+                  chatId,
+                  endpoint: "/api/agent-long",
+                  mode,
+                  subscription,
+                  selectedModel,
+                  selectedModelOverride,
+                  responseModel: state.responseModel,
+                  configuredModelId,
+                  rateLimitInfo,
+                });
                 captureUsageCost({
                   posthog,
                   userId,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1063,20 +1063,20 @@ export const agentLongTask = task({
                     usageTracker.nonModelCost,
                     organizationId,
                   );
+                  usageTracker.log({
+                    userId,
+                    organizationId,
+                    chatId,
+                    endpoint: "/api/agent-long",
+                    mode,
+                    subscription,
+                    selectedModel,
+                    selectedModelOverride,
+                    responseModel: state.responseModel,
+                    configuredModelId,
+                    rateLimitInfo,
+                  });
                 }
-                usageTracker.log({
-                  userId,
-                  organizationId,
-                  chatId,
-                  endpoint: "/api/agent-long",
-                  mode,
-                  subscription,
-                  selectedModel,
-                  selectedModelOverride,
-                  responseModel: state.responseModel,
-                  configuredModelId,
-                  rateLimitInfo,
-                });
                 captureUsageCost({
                   posthog,
                   userId,


### PR DESCRIPTION
## Summary

Adds durable unit economics tracking in Convex so we can report revenue, paid model/request expenses, and gross profit per paid user or organization without sending every request as a PostHog event.

## What changed

- Adds `revenue_events` and `unit_economics_daily` Convex tables.
- Extends `usage_logs` with model/non-model cost breakdowns, org/chat/endpoint/subscription context, and daily rollup updates.
- Keeps durable Convex usage logging limited to non-free subscriptions to avoid high write volume from free traffic.
- Records Stripe subscription invoice revenue, personal extra usage purchases, team extra usage purchases, and auto-reload revenue.
- Adds service-key guarded unit economics queries/backfill helpers for PostHog warehouse sync and historical rollup rebuilds.
- Documents the reporting model in `docs/unit-economics.md`.

## Validation

- `pnpm exec convex codegen`
- `pnpm test -- lib/__tests__/usage-tracker.test.ts convex/__tests__/teamExtraUsage.test.ts --runInBand`
- `pnpm exec eslint app/api/extra-usage/confirm/route.ts app/api/extra-usage/webhook/route.ts app/api/subscription/webhook/route.ts app/api/team/extra-usage/confirm/route.ts app/api/team/extra-usage/webhook/route.ts convex/extraUsage.ts convex/extraUsageActions.ts convex/schema.ts convex/teamExtraUsage.ts convex/teamExtraUsageActions.ts convex/usageLogs.ts convex/unitEconomics.ts convex/unitEconomicsLib.ts lib/db/actions.ts lib/usage-tracker.ts trigger/agent-long.ts`
- `pnpm exec eslint lib/api/chat-handler.ts trigger/agent-long.ts`
- `git diff --check`

`pnpm run typecheck` is blocked by an existing generated Next artifact: `.next/dev/types/validator.ts` references missing `../../../app/api/agent/route.js`. The edited files pass the targeted checks above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added revenue tracking and attribution for purchases, subscriptions, and auto-reload flows, including Stripe identifiers for robust idempotency and reporting.
  * Introduced unit-economics system with daily rollups, revenue ledger, and APIs for recording and rebuilding financial rollups.
  * Enhanced usage logging with detailed model vs non-model cost breakdown and richer request context (organization, chat, endpoint, mode, subscription).

* **Documentation**
  * Added comprehensive unit-economics tracking guide.

* **Tests**
  * Updated tests/mocks to reflect new logging and revenue schemas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hackerai-tech/hackerai/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->