### PR TITLE
[codex] Fix sandbox presence probe

### DIFF
--- a/app/api/sandbox/presence/route.ts
+++ b/app/api/sandbox/presence/route.ts
@@ -6,10 +6,7 @@ import { ConvexHttpClient } from "convex/browser";
 import { api } from "@/convex/_generated/api";
 import { phLogger } from "@/lib/posthog/server";
 import { sandboxConnectionChannel } from "@/lib/centrifugo/types";
-
-interface CentrifugoPresenceResult {
-  clients?: Record<string, unknown>;
-}
+import { presenceHasConnectionId } from "@/lib/centrifugo/presence";
 
 export async function GET(request: NextRequest) {
   let userId: string;
@@ -79,9 +76,8 @@ export async function GET(request: NextRequest) {
 
           sub.on("subscribed", async () => {
             try {
-              const result = (await sub.presence()) as CentrifugoPresenceResult;
-              const clients = result.clients ?? {};
-              if (Object.keys(clients).length > 0) {
+              const result = await sub.presence();
+              if (presenceHasConnectionId(result, connection.connectionId)) {
                 onlineConnectionIds.add(connection.connectionId);
               }
               cleanup();

--- a/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
+++ b/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
@@ -6,6 +6,10 @@ import {
   filterConnectionsByPresence,
   LOCAL_SANDBOX_PRESENCE_GRACE_MS,
 } from "../hybrid-sandbox-manager";
+import {
+  getConnectionIdFromPresenceClient,
+  presenceHasConnectionId,
+} from "@/lib/centrifugo/presence";
 import type { ConnectionInfo } from "../sandbox-types";
 
 const baseConnection: ConnectionInfo = {
@@ -73,5 +77,52 @@ describe("filterConnectionsByPresence", () => {
 
     expect(result.availableConnections).toEqual([live]);
     expect(result.staleConnections).toEqual([stale]);
+  });
+});
+
+describe("presenceHasConnectionId", () => {
+  it("ignores the backend probe subscriber when it has no connection info", () => {
+    expect(
+      presenceHasConnectionId(
+        {
+          clients: {
+            "probe-client": {
+              client: "probe-client",
+              user: "user-1",
+            },
+          },
+        },
+        "conn-stale",
+      ),
+    ).toBe(false);
+  });
+
+  it("matches the local sandbox connection from Centrifugo connInfo", () => {
+    expect(
+      presenceHasConnectionId(
+        {
+          clients: {
+            "probe-client": {
+              client: "probe-client",
+              user: "user-1",
+            },
+            "sandbox-client": {
+              client: "sandbox-client",
+              user: "user-1",
+              connInfo: { connectionId: "conn-live" },
+            },
+          },
+        },
+        "conn-live",
+      ),
+    ).toBe(true);
+  });
+
+  it("supports legacy presence info field names", () => {
+    expect(
+      getConnectionIdFromPresenceClient({
+        info: { connectionId: "conn-legacy" },
+      }),
+    ).toBe("conn-legacy");
   });
 });

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -15,6 +15,7 @@ import { SANDBOX_ENVIRONMENT_TOOLS } from "./sandbox-tools";
 import { getPlatformDisplayName } from "./platform-utils";
 import { generateCentrifugoToken } from "@/lib/centrifugo/jwt";
 import { sandboxConnectionChannel } from "@/lib/centrifugo/types";
+import { presenceHasConnectionId } from "@/lib/centrifugo/presence";
 
 type SandboxInstance = Sandbox | CentrifugoSandbox;
 
@@ -44,10 +45,6 @@ export interface SandboxFallbackInfo {
 const MAX_SANDBOX_HEALTH_FAILURES = 5;
 export const LOCAL_SANDBOX_PRESENCE_GRACE_MS = 30_000;
 const LOCAL_SANDBOX_PRESENCE_TIMEOUT_MS = 2_000;
-
-interface CentrifugoPresenceResult {
-  clients?: Record<string, unknown>;
-}
 
 interface PresenceProbeResult {
   reliable: boolean;
@@ -163,9 +160,7 @@ async function queryLiveSandboxConnectionIds(
             try {
               const result = await sub.presence();
               cleanup();
-              const clients =
-                (result as CentrifugoPresenceResult).clients ?? {};
-              if (Object.keys(clients).length > 0) {
+              if (presenceHasConnectionId(result, connectionId)) {
                 onlineConnectionIds.add(connectionId);
               }
               resolve();

--- a/lib/centrifugo/presence.ts
+++ b/lib/centrifugo/presence.ts
@@ -1,0 +1,45 @@
+type PresenceClientInfo = {
+  connInfo?: unknown;
+  info?: unknown;
+};
+
+type PresenceResultLike = {
+  clients?: Record<string, unknown>;
+  presence?: Record<string, unknown>;
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+
+const getPresenceClients = (
+  presence: PresenceResultLike,
+): Record<string, unknown> => presence.clients ?? presence.presence ?? {};
+
+const getConnectionIdFromInfo = (info: unknown): string | null => {
+  const record = asRecord(info);
+  const connectionId = record?.connectionId;
+  return typeof connectionId === "string" ? connectionId : null;
+};
+
+export const getConnectionIdFromPresenceClient = (
+  clientInfo: unknown,
+): string | null => {
+  const client = asRecord(clientInfo) as PresenceClientInfo | null;
+  if (!client) return null;
+
+  return (
+    getConnectionIdFromInfo(client.connInfo) ??
+    getConnectionIdFromInfo(client.info)
+  );
+};
+
+export const presenceHasConnectionId = (
+  presence: PresenceResultLike,
+  connectionId: string,
+): boolean =>
+  Object.values(getPresenceClients(presence)).some(
+    (clientInfo) =>
+      getConnectionIdFromPresenceClient(clientInfo) === connectionId,
+  );


### PR DESCRIPTION
## What changed

- Added a shared Centrifugo presence helper that only treats a sandbox connection as online when a presence entry carries the expected `connectionId` from connection JWT `connInfo`.
- Updated backend sandbox selection and the `/api/sandbox/presence` endpoint to use that helper.
- Added regression tests for the self-probe case, live `connInfo` match, and legacy `info` shape.

## Why

The backend presence probe subscribes to the same per-connection channel it is checking. Centrifugo presence includes current channel subscribers, so the probe could count itself as proof that a local/desktop sandbox was online. That allowed stale connections to be selected, after which attachment staging commands were published successfully but no local sandbox returned stdout/stderr/exit, producing `firstMsg: no` command timeouts.

## Validation

- `pnpm test -- lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts --runInBand`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint app/api/sandbox/presence/route.ts lib/ai/tools/utils/hybrid-sandbox-manager.ts lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts lib/centrifugo/presence.ts`
- Commit hook: full `tsc --noEmit` and full Jest suite, 107 suites / 1272 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored sandbox connection presence detection logic, consolidating helper utilities for improved code organization and maintainability.

* **Tests**
  * Added comprehensive test coverage for presence validation across multiple scenarios, including connection state changes, missing connection information, and support for legacy presence data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->