### PR TITLE
[codex] fix subscription details billing plans

### DIFF
--- a/app/api/subscription-details/__tests__/route.test.ts
+++ b/app/api/subscription-details/__tests__/route.test.ts
@@ -99,6 +99,67 @@ describe("POST /api/subscription-details", () => {
     mockListSubscriptions.mockResolvedValue({ data: [] } as never);
   });
 
+  it.each(["pro-plus-monthly-plan", "pro-plus-yearly-plan"])(
+    "accepts %s as a target plan",
+    async (plan) => {
+      const { POST } = await import("../route");
+
+      const response = await POST(makeRequest({ plan }));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.totalDue).toBe(30);
+      expect(mockListPrices).toHaveBeenCalledWith({
+        lookup_keys: [plan],
+      });
+    },
+  );
+
+  it("allows organization owners to manage billing", async () => {
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [
+        {
+          organizationId: "org_team",
+          role: { slug: "owner" },
+        },
+      ],
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(makeRequest({ plan: "pro-monthly-plan" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.totalDue).toBe(30);
+    expect(mockListPrices).toHaveBeenCalledWith({
+      lookup_keys: ["pro-monthly-plan"],
+    });
+  });
+
+  it("rejects non-owner, non-admin members from managing billing", async () => {
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [
+        {
+          organizationId: "org_team",
+          role: { slug: "member" },
+        },
+      ],
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(makeRequest({ plan: "pro-monthly-plan" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({
+      error: "Only organization admins or owners can manage billing",
+    });
+    expect(mockGetOrganization).not.toHaveBeenCalled();
+    expect(mockListPrices).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["below the minimum", 1, "Quantity must be a finite integer of at least 2"],
     ["non-integer", 2.5, "Quantity must be a finite integer of at least 2"],

--- a/app/api/subscription-details/route.ts
+++ b/app/api/subscription-details/route.ts
@@ -7,6 +7,14 @@ import { getSuspensionMessage } from "@/lib/suspensionMessage";
 
 const MAX_TEAM_SEATS = 999;
 
+function canManageOrganizationBilling(
+  membership: Awaited<
+    ReturnType<typeof workos.userManagement.listOrganizationMemberships>
+  >["data"][number],
+) {
+  return membership.role?.slug === "admin" || membership.role?.slug === "owner";
+}
+
 function resolveQuantity(
   targetPlan: string,
   requestedQuantity: unknown,
@@ -50,8 +58,10 @@ export const POST = async (req: NextRequest) => {
 
     const allowedPlans = new Set([
       "pro-monthly-plan",
+      "pro-plus-monthly-plan",
       "ultra-monthly-plan",
       "pro-yearly-plan",
+      "pro-plus-yearly-plan",
       "ultra-yearly-plan",
       "team-monthly-plan",
       "team-yearly-plan",
@@ -78,9 +88,9 @@ export const POST = async (req: NextRequest) => {
     }
 
     const membership = existingMemberships.data[0];
-    if (membership.role?.slug !== "admin") {
+    if (!canManageOrganizationBilling(membership)) {
       return NextResponse.json(
-        { error: "Only organization admins can manage billing" },
+        { error: "Only organization admins or owners can manage billing" },
         { status: 403 },
       );
     }


### PR DESCRIPTION
## Summary

- Add Pro Plus monthly/yearly plan keys to the subscription-details plan allowlist.
- Allow organization owners, not only admins, to preview and confirm subscription changes.
- Add regression coverage for Pro Plus plan selection and billing role authorization.

## Root Cause

`POST /api/subscription-details` had drifted from the checkout route: Pro Plus lookup keys were missing from its allowlist, so requests for Pro Plus fell back to `pro-monthly-plan`. The same route also required `admin` while checkout allows both `admin` and `owner`, preventing some billing owners from managing their subscription.

## Validation

- `pnpm test -- app/api/subscription-details/__tests__/route.test.ts --runInBand`
- `pnpm exec eslint app/api/subscription-details/route.ts app/api/subscription-details/__tests__/route.test.ts`
- Pre-commit hook: `pnpm typecheck`
- Pre-commit hook: `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization owners can now manage billing settings (previously admin-only functionality)
  * Added support for yearly subscription plan options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->