### PR TITLE
[codex] Fix delete account dialog confirmation

### DIFF
--- a/__mocks__/workos.ts
+++ b/__mocks__/workos.ts
@@ -1,10 +1,10 @@
-export const useAuth = () => ({
+export const useAuth = jest.fn(() => ({
   user: null,
   entitlements: [],
   isAuthenticated: false,
   signIn: jest.fn(),
   signOut: jest.fn(),
-});
+}));
 
 export const useAccessToken = () => ({
   getAccessToken: jest.fn().mockResolvedValue("mock-access-token"),

--- a/app/components/DeleteAccountDialog.tsx
+++ b/app/components/DeleteAccountDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
@@ -16,7 +16,7 @@ import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Lock, TriangleAlert } from "lucide-react";
+import { Loader2, Lock, TriangleAlert } from "lucide-react";
 
 type DeleteAccountDialogProps = {
   open: boolean;
@@ -51,13 +51,24 @@ export const DeleteAccountDialog = ({
 
   const expectedEmail: string = useMemo(() => user?.email ?? "", [user]);
 
-  const canDelete = useMemo(() => {
-    if (!hasRecentLogin) return false;
-    const emailMatches =
-      emailInput.trim().toLowerCase() === expectedEmail.toLowerCase();
-    const phraseMatches = confirmInput.trim() === "DELETE";
-    return emailMatches && phraseMatches && !isDeleting;
-  }, [confirmInput, emailInput, expectedEmail, hasRecentLogin, isDeleting]);
+  const emailMatches = useMemo(() => {
+    if (!expectedEmail) return false;
+    return emailInput.trim().toLowerCase() === expectedEmail.toLowerCase();
+  }, [emailInput, expectedEmail]);
+
+  const phraseMatches = useMemo(
+    () => confirmInput.trim() === "DELETE",
+    [confirmInput],
+  );
+
+  const canDelete =
+    hasRecentLogin && emailMatches && phraseMatches && !isDeleting;
+
+  useEffect(() => {
+    if (open) return;
+    setEmailInput("");
+    setConfirmInput("");
+  }, [open]);
 
   const handleRefreshLogin = async () => {
     const { clientLogout } = await import("@/lib/utils/logout");
@@ -103,20 +114,20 @@ export const DeleteAccountDialog = ({
         <DialogHeader>
           <DialogTitle>Delete account - are you sure?</DialogTitle>
         </DialogHeader>
-        <div className="text-sm">
-          <p>
-            Deleting your account will remove all your data, including chats,
-            settings, and personal information. This action cannot be undone.
-          </p>
+        <DialogDescription
+          data-testid="delete-account-description"
+          className="pt-2 text-sm text-foreground"
+        >
+          Deleting your account will remove all your data, including chats,
+          settings, and personal information. This action cannot be undone.
+        </DialogDescription>
 
-          {!hasRecentLogin && (
-            <DialogDescription className="text-xs pt-4">
-              You may only delete your account if you have logged in within the
-              last 10 minutes. Please log in again, then return here to
-              continue.
-            </DialogDescription>
-          )}
-        </div>
+        {!hasRecentLogin && (
+          <p className="text-xs pt-4 text-muted-foreground">
+            You may only delete your account if you have logged in within the
+            last 10 minutes. Please log in again, then return here to continue.
+          </p>
+        )}
 
         {hasRecentLogin && (
           <div className="pt-4 space-y-4">
@@ -133,11 +144,7 @@ export const DeleteAccountDialog = ({
                 placeholder={expectedEmail || "name@example.com"}
                 value={emailInput}
                 onChange={(e) => setEmailInput(e.target.value)}
-                aria-invalid={
-                  Boolean(emailInput) &&
-                  emailInput.trim().toLowerCase() !==
-                    expectedEmail.toLowerCase()
-                }
+                aria-invalid={Boolean(emailInput) && !emailMatches}
               />
             </div>
 
@@ -160,30 +167,35 @@ export const DeleteAccountDialog = ({
           </div>
         )}
 
-        <DialogFooter>
+        <DialogFooter data-testid="delete-account-footer" className="pt-4">
           {!hasRecentLogin ? (
-            <Button onClick={handleRefreshLogin} className="w-full">
+            <Button
+              type="button"
+              data-testid="refresh-login-button"
+              variant="outline"
+              onClick={handleRefreshLogin}
+              className="w-full"
+            >
               Refresh login
             </Button>
-          ) : canDelete && !isDeleting ? (
+          ) : (
             <Button
+              type="button"
               data-testid="delete-button"
               variant="destructive"
               onClick={handleConfirmDelete}
+              disabled={!canDelete}
               className="w-full"
             >
-              <TriangleAlert aria-hidden="true" className="size-4" />
-              Permanently delete my account
+              {isDeleting ? (
+                <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+              ) : canDelete ? (
+                <TriangleAlert aria-hidden="true" className="size-4" />
+              ) : (
+                <Lock aria-hidden="true" className="size-4" />
+              )}
+              {isDeleting ? "Deleting..." : "Permanently delete my account"}
             </Button>
-          ) : (
-            <div
-              role="status"
-              aria-live="polite"
-              className="w-full h-10 rounded-md border border-input bg-input/30 dark:bg-input/30 text-muted-foreground flex items-center justify-center gap-2"
-            >
-              <Lock aria-hidden="true" className="size-4" />
-              <span>{isDeleting ? "Deleting..." : "Locked"}</span>
-            </div>
           )}
         </DialogFooter>
       </DialogContent>

--- a/app/components/__tests__/DeleteAccountDialog.test.tsx
+++ b/app/components/__tests__/DeleteAccountDialog.test.tsx
@@ -1,0 +1,131 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useAuth } from "@workos-inc/authkit-nextjs/components";
+import DeleteAccountDialog from "../DeleteAccountDialog";
+
+const mockDeleteAllUserData = jest.fn();
+
+jest.mock("@workos-inc/authkit-nextjs/components", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("convex/react", () => ({
+  useMutation: () => mockDeleteAllUserData,
+}));
+
+jest.mock("@/convex/_generated/api", () => ({
+  api: {
+    userDeletion: {
+      deleteAllUserData: "userDeletion.deleteAllUserData",
+    },
+  },
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    error: jest.fn(),
+  },
+}));
+
+describe("DeleteAccountDialog", () => {
+  const mockUser = {
+    email: "signin.hackerai.co.harmonize442@passmail.net",
+    lastSignInAt: new Date().toISOString(),
+  };
+  const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+  const renderDialog = () =>
+    render(<DeleteAccountDialog open={true} onOpenChange={jest.fn()} />);
+
+  const renderControlledDialog = (open: boolean) =>
+    render(<DeleteAccountDialog open={open} onOpenChange={jest.fn()} />);
+
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({
+      user: {
+        ...mockUser,
+        lastSignInAt: new Date().toISOString(),
+      },
+    } as ReturnType<typeof useAuth>);
+    mockDeleteAllUserData.mockReset();
+  });
+
+  it("keeps the delete button visible but disabled before confirmation", () => {
+    renderDialog();
+
+    expect(screen.getByTestId("delete-button")).toBeDisabled();
+    expect(screen.getByTestId("delete-account-description")).toHaveClass(
+      "pt-2",
+    );
+    expect(screen.getByTestId("delete-account-footer")).toHaveClass("pt-4");
+  });
+
+  it("shows the email in the input placeholder without filling it", () => {
+    renderDialog();
+
+    const emailInput = screen.getByTestId(
+      "email-confirmation",
+    ) as HTMLInputElement;
+
+    expect(emailInput.value).toBe("");
+    expect(emailInput.placeholder).toBe(mockUser.email);
+  });
+
+  it("enables account deletion only after email and phrase both match", () => {
+    renderDialog();
+
+    const deleteButton = screen.getByTestId("delete-button");
+    fireEvent.change(screen.getByTestId("delete-phrase-input"), {
+      target: { value: "DELETE" },
+    });
+
+    expect(deleteButton).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("email-confirmation"), {
+      target: { value: mockUser.email },
+    });
+
+    expect(deleteButton).toBeEnabled();
+  });
+
+  it("shows a refresh login action when the login is stale", () => {
+    mockUseAuth.mockReturnValue({
+      user: {
+        ...mockUser,
+        lastSignInAt: new Date(Date.now() - 11 * 60 * 1000).toISOString(),
+      },
+    } as ReturnType<typeof useAuth>);
+
+    renderDialog();
+
+    expect(screen.getByTestId("refresh-login-button")).toHaveTextContent(
+      "Refresh login",
+    );
+    expect(screen.queryByTestId("delete-button")).not.toBeInTheDocument();
+  });
+
+  it("resets confirmations after the dialog closes", () => {
+    const { rerender } = renderControlledDialog(true);
+
+    fireEvent.change(screen.getByTestId("delete-phrase-input"), {
+      target: { value: "DELETE" },
+    });
+    fireEvent.change(screen.getByTestId("email-confirmation"), {
+      target: { value: mockUser.email },
+    });
+
+    expect(screen.getByTestId("delete-button")).toBeEnabled();
+
+    rerender(<DeleteAccountDialog open={false} onOpenChange={jest.fn()} />);
+    rerender(<DeleteAccountDialog open={true} onOpenChange={jest.fn()} />);
+
+    expect(screen.getByTestId("delete-button")).toBeDisabled();
+    expect(
+      (screen.getByTestId("email-confirmation") as HTMLInputElement).value,
+    ).toBe("");
+    expect(
+      (screen.getByTestId("delete-phrase-input") as HTMLInputElement).value,
+    ).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- Keep the delete account action mounted as a real destructive button with a disabled state until confirmation is complete.
- Show the account email inside the email input placeholder, while keeping the input value empty until the user types it.
- Add explicit title/description and footer spacing so the popup content has breathing room.
- Reset the email and `DELETE` confirmations when the dialog closes so reopen starts locked.
- Make the stale-login `Refresh login` action use the quieter outline button style.
- Add regression coverage for the email placeholder, `DELETE`, stale-login, close/reopen, and spacing flows.

## Root Cause

The dialog previously replaced the delete button with a non-button `Locked` status until all requirements matched, which made the delete action appear broken and harder to test. Because the parent keeps the dialog component mounted while toggling `open`, confirmation state also persisted across close/reopen cycles. The local dialog content wrapper has a `gap` utility without a flex/grid display, so the title/description and footer needed explicit spacing. The stale-login branch used the default button style, which read too strongly inside the compact warning popup.

## Validation

- `pnpm test -- app/components/__tests__/DeleteAccountDialog.test.tsx --runInBand`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint app/components/DeleteAccountDialog.tsx app/components/__tests__/DeleteAccountDialog.test.tsx __mocks__/workos.ts`
- `pnpm exec prettier --check __mocks__/workos.ts app/components/DeleteAccountDialog.tsx app/components/__tests__/DeleteAccountDialog.test.tsx`
- Commit hook: `pnpm typecheck` and full `pnpm test` passed, 108 suites / 1,281 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added login refresh option in account deletion dialog for improved security workflow.

* **Bug Fixes**
  * Enhanced account deletion confirmation with improved validation and clearer messaging about deletion requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->