### PR TITLE
[codex] Downgrade recoverable AuthKit callback logs

### DIFF
--- a/app/callback/route.ts
+++ b/app/callback/route.ts
@@ -1,5 +1,6 @@
 import { handleAuth } from "@workos-inc/authkit-nextjs";
 import {
+  isAuthCookieMissingError,
   isOauthCodeAlreadyExchangedError,
   withRecoverableAuthkitCallbackErrorSuppressed,
 } from "@/lib/auth/authkit-callback-logging";
@@ -28,9 +29,11 @@ const classifyCallbackError = (error: unknown): RecoveryBucket => {
   if (isOauthCodeAlreadyExchangedError(error)) {
     return "code_already_exchanged";
   }
+  if (isAuthCookieMissingError(error)) {
+    return "cookie_missing";
+  }
   if (!(error instanceof Error)) return "unknown";
   if (error.message.includes("OAuth state mismatch")) return "state_mismatch";
-  if (error.message.includes("Auth cookie missing")) return "cookie_missing";
   if (error.name === "ValiError") {
     const issues = (error as Error & { issues?: Array<{ expected?: string }> })
       .issues;

--- a/app/callback/route.ts
+++ b/app/callback/route.ts
@@ -1,4 +1,8 @@
 import { handleAuth } from "@workos-inc/authkit-nextjs";
+import {
+  isOauthCodeAlreadyExchangedError,
+  withRecoverableAuthkitCallbackErrorSuppressed,
+} from "@/lib/auth/authkit-callback-logging";
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -17,9 +21,13 @@ type RecoveryBucket =
   | "state_mismatch"
   | "verifier_missing"
   | "cookie_missing"
+  | "code_already_exchanged"
   | "unknown";
 
 const classifyCallbackError = (error: unknown): RecoveryBucket => {
+  if (isOauthCodeAlreadyExchangedError(error)) {
+    return "code_already_exchanged";
+  }
   if (!(error instanceof Error)) return "unknown";
   if (error.message.includes("OAuth state mismatch")) return "state_mismatch";
   if (error.message.includes("Auth cookie missing")) return "cookie_missing";
@@ -85,7 +93,8 @@ const buildRecoveryResponse = async (
   }
 
   // Recoverable cases (stale flow, multi-tab, scanner prefetch, ITP,
-  // cross-device link, embedded webview, missing cookie): one-click recovery.
+  // cross-device link, embedded webview, missing cookie, duplicate callback):
+  // one-click recovery.
   // Preserve post_login_redirect intent so the retry lands where they wanted.
   const loginUrl = new URL("/login", request.url);
   const loginResponse = NextResponse.redirect(loginUrl);
@@ -126,7 +135,11 @@ export async function GET(request: NextRequest) {
 
   let response: NextResponse;
   try {
-    response = (await authHandler(request)) as NextResponse;
+    // AuthKit logs known recoverable callback failures at error level before
+    // onError can hand them to our warning-level recovery path.
+    response = (await withRecoverableAuthkitCallbackErrorSuppressed(() =>
+      authHandler(request),
+    )) as NextResponse;
   } catch (error) {
     // Defensive: handleAuth shouldn't throw when onError is provided, but if
     // it ever does, fall back to the same recovery pipeline.

--- a/lib/auth/__tests__/authkit-callback-logging.test.ts
+++ b/lib/auth/__tests__/authkit-callback-logging.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, afterEach, jest } from "@jest/globals";
+
+import {
+  isOauthCodeAlreadyExchangedError,
+  isRecoverableAuthkitCallbackErrorLog,
+  withRecoverableAuthkitCallbackErrorSuppressed,
+} from "../authkit-callback-logging";
+
+const originalConsoleError = console.error;
+
+describe("authkit callback logging", () => {
+  afterEach(() => {
+    console.error = originalConsoleError;
+    jest.restoreAllMocks();
+  });
+
+  it("matches AuthKit's recoverable missing-cookie callback error", () => {
+    expect(
+      isRecoverableAuthkitCallbackErrorLog([
+        "[AuthKit callback error]",
+        new Error(
+          "Auth cookie missing - cannot verify OAuth state. Ensure Set-Cookie headers are propagated on redirects.",
+        ),
+      ]),
+    ).toBe(true);
+  });
+
+  it("does not match other AuthKit callback errors", () => {
+    expect(
+      isRecoverableAuthkitCallbackErrorLog([
+        "[AuthKit callback error]",
+        new Error("OAuth state mismatch"),
+      ]),
+    ).toBe(false);
+  });
+
+  it("matches already-exchanged OAuth code errors", () => {
+    const error = Object.assign(
+      new Error(
+        "Error: invalid_grant\nError Description: The code 'abc123' has already been exchanged.",
+      ),
+      {
+        status: 400,
+        error: "invalid_grant",
+        errorDescription: "The code 'abc123' has already been exchanged.",
+        rawData: {
+          error: "invalid_grant",
+          error_description: "The code 'abc123' has already been exchanged.",
+        },
+      },
+    );
+
+    expect(isOauthCodeAlreadyExchangedError(error)).toBe(true);
+    expect(
+      isRecoverableAuthkitCallbackErrorLog(["[AuthKit callback error]", error]),
+    ).toBe(true);
+  });
+
+  it("does not match other invalid_grant errors", () => {
+    const error = Object.assign(new Error("Error: invalid_grant"), {
+      error: "invalid_grant",
+      errorDescription: "The authorization code is expired.",
+    });
+
+    expect(isOauthCodeAlreadyExchangedError(error)).toBe(false);
+    expect(
+      isRecoverableAuthkitCallbackErrorLog(["[AuthKit callback error]", error]),
+    ).toBe(false);
+  });
+
+  it("suppresses only the recoverable AuthKit error log", async () => {
+    const consoleError = jest.fn();
+    console.error = consoleError as typeof console.error;
+
+    await withRecoverableAuthkitCallbackErrorSuppressed(async () => {
+      console.error(
+        "[AuthKit callback error]",
+        new Error("Auth cookie missing - cannot verify OAuth state."),
+      );
+      console.error(
+        "[AuthKit callback error]",
+        new Error(
+          "Error: invalid_grant\nError Description: The code 'abc123' has already been exchanged.",
+        ),
+      );
+      console.error("other error", new Error("boom"));
+    });
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith("other error", expect.any(Error));
+    expect(console.error).toBe(consoleError);
+  });
+
+  it("keeps the filter active for overlapping callback handlers", async () => {
+    const consoleError = jest.fn();
+    console.error = consoleError as typeof console.error;
+
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const first = withRecoverableAuthkitCallbackErrorSuppressed(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        }),
+    );
+    const second = withRecoverableAuthkitCallbackErrorSuppressed(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSecond = resolve;
+        }),
+    );
+
+    console.error(
+      "[AuthKit callback error]",
+      new Error("Auth cookie missing - cannot verify OAuth state."),
+    );
+
+    releaseFirst();
+    await first;
+
+    console.error(
+      "[AuthKit callback error]",
+      new Error("Auth cookie missing - cannot verify OAuth state."),
+    );
+
+    releaseSecond();
+    await second;
+
+    console.error("real error");
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith("real error");
+    expect(console.error).toBe(consoleError);
+  });
+});

--- a/lib/auth/__tests__/authkit-callback-logging.test.ts
+++ b/lib/auth/__tests__/authkit-callback-logging.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, jest } from "@jest/globals";
 
 import {
+  isAuthCookieMissingError,
   isOauthCodeAlreadyExchangedError,
   isRecoverableAuthkitCallbackErrorLog,
   withRecoverableAuthkitCallbackErrorSuppressed,
@@ -22,6 +23,15 @@ describe("authkit callback logging", () => {
           "Auth cookie missing - cannot verify OAuth state. Ensure Set-Cookie headers are propagated on redirects.",
         ),
       ]),
+    ).toBe(true);
+  });
+
+  it("matches non-Error missing-cookie callback values", () => {
+    expect(isAuthCookieMissingError("Auth cookie missing")).toBe(true);
+    expect(
+      isAuthCookieMissingError({
+        message: "Auth cookie missing - cannot verify OAuth state.",
+      }),
     ).toBe(true);
   });
 

--- a/lib/auth/authkit-callback-logging.ts
+++ b/lib/auth/authkit-callback-logging.ts
@@ -1,0 +1,112 @@
+const AUTHKIT_CALLBACK_ERROR_PREFIX = "[AuthKit callback error]";
+const AUTH_COOKIE_MISSING_MESSAGE = "Auth cookie missing";
+const INVALID_GRANT_ERROR = "invalid_grant";
+const CODE_ALREADY_EXCHANGED_MESSAGE = "already been exchanged";
+
+let activeSuppressions = 0;
+let originalConsoleError: typeof console.error | null = null;
+
+const hasRecoverableAuthCookieMessage = (value: unknown): boolean => {
+  if (typeof value === "string") {
+    return value.includes(AUTH_COOKIE_MISSING_MESSAGE);
+  }
+
+  if (value && typeof value === "object" && "message" in value) {
+    const message = (value as { message?: unknown }).message;
+    return (
+      typeof message === "string" &&
+      message.includes(AUTH_COOKIE_MISSING_MESSAGE)
+    );
+  }
+
+  return false;
+};
+
+const getStringValue = (
+  value: Record<string, unknown>,
+  key: string,
+): string | null => {
+  const fieldValue = value[key];
+  return typeof fieldValue === "string" ? fieldValue : null;
+};
+
+const collectErrorText = (value: unknown): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (!value || typeof value !== "object") {
+    return "";
+  }
+
+  const record = value as Record<string, unknown>;
+  const rawData =
+    record.rawData && typeof record.rawData === "object"
+      ? (record.rawData as Record<string, unknown>)
+      : {};
+
+  return [
+    getStringValue(record, "message"),
+    getStringValue(record, "error"),
+    getStringValue(record, "errorDescription"),
+    getStringValue(rawData, "error"),
+    getStringValue(rawData, "error_description"),
+  ]
+    .filter((text): text is string => Boolean(text))
+    .join("\n");
+};
+
+export const isOauthCodeAlreadyExchangedError = (value: unknown): boolean => {
+  const errorText = collectErrorText(value).toLowerCase();
+  return (
+    errorText.includes(INVALID_GRANT_ERROR) &&
+    errorText.includes(CODE_ALREADY_EXCHANGED_MESSAGE)
+  );
+};
+
+export const isRecoverableAuthkitCallbackError = (value: unknown): boolean => {
+  return (
+    hasRecoverableAuthCookieMessage(value) ||
+    isOauthCodeAlreadyExchangedError(value)
+  );
+};
+
+export const isRecoverableAuthkitCallbackErrorLog = (
+  args: readonly unknown[],
+): boolean => {
+  return (
+    args[0] === AUTHKIT_CALLBACK_ERROR_PREFIX &&
+    args.some(isRecoverableAuthkitCallbackError)
+  );
+};
+
+const filteredConsoleError: typeof console.error = (...args) => {
+  if (isRecoverableAuthkitCallbackErrorLog(args)) {
+    return;
+  }
+
+  (originalConsoleError ?? console.error)(...args);
+};
+
+export const withRecoverableAuthkitCallbackErrorSuppressed = async <T>(
+  operation: () => T | Promise<T>,
+): Promise<T> => {
+  if (activeSuppressions === 0) {
+    originalConsoleError = console.error;
+    console.error = filteredConsoleError;
+  }
+  activeSuppressions += 1;
+
+  try {
+    return await operation();
+  } finally {
+    activeSuppressions -= 1;
+    if (activeSuppressions === 0) {
+      const restoreConsoleError = originalConsoleError;
+      originalConsoleError = null;
+      if (restoreConsoleError) {
+        console.error = restoreConsoleError;
+      }
+    }
+  }
+};

--- a/lib/auth/authkit-callback-logging.ts
+++ b/lib/auth/authkit-callback-logging.ts
@@ -6,7 +6,7 @@ const CODE_ALREADY_EXCHANGED_MESSAGE = "already been exchanged";
 let activeSuppressions = 0;
 let originalConsoleError: typeof console.error | null = null;
 
-const hasRecoverableAuthCookieMessage = (value: unknown): boolean => {
+export const isAuthCookieMissingError = (value: unknown): boolean => {
   if (typeof value === "string") {
     return value.includes(AUTH_COOKIE_MISSING_MESSAGE);
   }
@@ -66,8 +66,7 @@ export const isOauthCodeAlreadyExchangedError = (value: unknown): boolean => {
 
 export const isRecoverableAuthkitCallbackError = (value: unknown): boolean => {
   return (
-    hasRecoverableAuthCookieMessage(value) ||
-    isOauthCodeAlreadyExchangedError(value)
+    isAuthCookieMissingError(value) || isOauthCodeAlreadyExchangedError(value)
   );
 };
 


### PR DESCRIPTION
## Summary

- Downgrade recoverable AuthKit callback failures from error-level noise to the existing warning-level recovery path.
- Treat missing auth cookies and duplicate OAuth callback hits (`invalid_grant` with an already-exchanged code) as recoverable.
- Keep other AuthKit callback failures, including other `invalid_grant` variants, visible as errors.

## Why

AuthKit logs callback failures at error level before the route-level `onError` recovery handler can classify them. These two cases are expected browser/OAuth edge cases, so they were creating noisy production error logs even though the app recovered by redirecting the user back through login.

## Validation

- `pnpm test lib/auth/__tests__/authkit-callback-logging.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (passes with existing unrelated warnings)
- Commit hooks: `pnpm typecheck` and full `pnpm test` (`108` suites, `1282` tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More precise recovery classification for OAuth callback failures (including "code already exchanged") and improved routing of recoverable auth callback errors to the warning-level recovery flow.
  * Temporarily suppresses noisy recoverable callback error logs so only relevant errors remain visible.

* **Tests**
  * Added comprehensive tests covering detection, classification, scoped log suppression, and concurrent recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->