### PR TITLE
[codex] Add OpenRouter app attribution

### DIFF
--- a/lib/ai/openrouter-attribution.ts
+++ b/lib/ai/openrouter-attribution.ts
@@ -1,0 +1,9 @@
+export const OPENROUTER_APP_REFERER = "https://hackerai.co";
+export const OPENROUTER_APP_TITLE = "HackerAI";
+export const OPENROUTER_APP_CATEGORIES = "cloud-agent,cli-agent";
+
+export const openrouterAttributionHeaders = {
+  "HTTP-Referer": OPENROUTER_APP_REFERER,
+  "X-OpenRouter-Title": OPENROUTER_APP_TITLE,
+  "X-OpenRouter-Categories": OPENROUTER_APP_CATEGORIES,
+} as const;

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -2,6 +2,7 @@ import { customProvider } from "ai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import type { ChatMode, SelectedModel } from "@/types/chat";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
+import { openrouterAttributionHeaders } from "@/lib/ai/openrouter-attribution";
 // import { withTracing } from "@posthog/ai";
 // import PostHogClient from "@/app/posthog";
 // import type { SubscriptionTier } from "@/types";
@@ -34,7 +35,10 @@ const kimiReasoningPatchFetch: typeof fetch = async (url, init) => {
   return globalThis.fetch(url, init);
 };
 
-const openrouter = createOpenRouter({ fetch: kimiReasoningPatchFetch });
+const openrouter = createOpenRouter({
+  fetch: kimiReasoningPatchFetch,
+  headers: openrouterAttributionHeaders,
+});
 
 type OpenRouterInstance = typeof openrouter;
 

--- a/scripts/check-openrouter-gen-id.ts
+++ b/scripts/check-openrouter-gen-id.ts
@@ -19,6 +19,7 @@ import { config } from "dotenv";
 import { resolve } from "path";
 import { generateText } from "ai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { openrouterAttributionHeaders } from "../lib/ai/openrouter-attribution";
 
 config({ path: resolve(process.cwd(), ".env.local") });
 
@@ -61,6 +62,7 @@ async function probeSuccess(openrouter: ReturnType<typeof createOpenRouter>) {
   const or = createOpenRouter({
     apiKey: process.env.OPENROUTER_API_KEY!,
     fetch: probeFetch,
+    headers: openrouterAttributionHeaders,
   });
 
   try {
@@ -212,6 +214,7 @@ async function main() {
   }
   const openrouter = createOpenRouter({
     apiKey: process.env.OPENROUTER_API_KEY,
+    headers: openrouterAttributionHeaders,
   });
   await probeSuccess(openrouter);
   await probeError(openrouter);


### PR DESCRIPTION
## Summary

Adds OpenRouter app attribution headers for HackerAI requests so OpenRouter can attribute usage to the app.

## Changes

- Adds shared OpenRouter attribution constants for app URL, title, and categories.
- Passes those headers through the central `createOpenRouter` provider configuration.
- Reuses the same attribution headers in the OpenRouter generation-id diagnostic script.

## Impact

All app model calls routed through the shared OpenRouter provider now include HackerAI attribution metadata. The diagnostic script stays aligned with production request metadata.

## Validation

- `git diff --cached --check`
- `pnpm run typecheck`
- Commit hooks ran `prettier --write`, `eslint --fix`, `tsc --noEmit`, and the full Jest suite: 107 suites / 1276 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenRouter API configuration to include proper application attribution headers for improved request identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->