### PR TITLE
[codex] Use Gemini 2.5 Flash for chat titles

### DIFF
--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -53,7 +53,7 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "fallback-ask-model": or("google/gemini-3-flash-preview"),
     "fallback-gemini-3.5-flash": or("google/gemini-3.5-flash"),
     "fallback-grok-4.3": or("x-ai/grok-4.3"),
-    "title-generator-model": or("google/gemini-2.5-flash-lite"),
+    "title-generator-model": or("google/gemini-2.5-flash"),
   }) as Record<string, any>;
 
 const baseProviders = buildProviderMap(openrouter);
@@ -93,7 +93,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "fallback-ask-model": "Auto, an intelligent model router built by HackerAI",
   "fallback-gemini-3.5-flash": "Google Gemini 3.5 Flash",
   "fallback-grok-4.3": "Auto, an intelligent model router built by HackerAI",
-  "title-generator-model": "Google Gemini 2.5 Flash Lite",
+  "title-generator-model": "Google Gemini 2.5 Flash",
 };
 
 export const getModelDisplayName = (modelName: ModelName): string => {


### PR DESCRIPTION
## Summary

- Switch `title-generator-model` from `google/gemini-2.5-flash-lite` to `google/gemini-2.5-flash`.
- Update the internal display name from Google Gemini 2.5 Flash Lite to Google Gemini 2.5 Flash.

## Why

Production logs showed repeated `AI_NoObjectGeneratedError` failures while generating structured chat titles with the Lite model. Using the non-Lite Gemini 2.5 Flash model may reduce malformed or truncated JSON responses for this small structured-output task.

## Impact

Only chat title generation changes. Main chat routing and user-selectable model options are unchanged.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test -- app/components/ModelSelector/__tests__/options-drift.test.ts --runInBand`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Title generation now uses Google Gemini 2.5 Flash model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->