### PR TITLE
[codex] Track paid starts separately from revenue

### DIFF
--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -173,7 +173,7 @@ async function recordSubscriptionRevenue({
       ? subscriptionMrrDollars({
           price,
           quantity: item?.quantity ?? 1,
-          fallbackIntervalAmountDollars: grossRevenueDollars,
+          fallbackTotalIntervalAmountDollars: grossRevenueDollars,
         })
       : undefined;
   const attributedMrrDollars =
@@ -439,7 +439,7 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
     const subscriptionMrr = subscriptionMrrDollars({
       price,
       quantity: item?.quantity ?? 1,
-      fallbackIntervalAmountDollars: invoiceAmountPaidDollars,
+      fallbackTotalIntervalAmountDollars: invoiceAmountPaidDollars,
     });
     const attributedMrrDollars =
       subscriptionMrr === undefined

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -37,6 +37,8 @@ function tierDirection(
   return "lateral";
 }
 
+type PaidStartTier = Exclude<SubscriptionTier, "free">;
+
 const centsToDollars = (amount: number | null | undefined): number =>
   (amount ?? 0) / 100;
 
@@ -44,6 +46,53 @@ function priceBillingInterval(
   price: Stripe.Price | undefined,
 ): "day" | "week" | "month" | "year" | undefined {
   return price?.recurring?.interval ?? undefined;
+}
+
+function priceAmountDollars(
+  price: Stripe.Price | undefined,
+): number | undefined {
+  if (typeof price?.unit_amount === "number") return price.unit_amount / 100;
+
+  const decimalAmount = Number(price?.unit_amount_decimal);
+  return Number.isFinite(decimalAmount) ? decimalAmount / 100 : undefined;
+}
+
+function recurringIntervalMonths(
+  interval: "day" | "week" | "month" | "year" | undefined,
+  intervalCount = 1,
+): number | undefined {
+  if (!interval || intervalCount <= 0) return undefined;
+  const averageDaysPerMonth = 365 / 12;
+
+  switch (interval) {
+    case "day":
+      return intervalCount / averageDaysPerMonth;
+    case "week":
+      return (intervalCount * 7) / averageDaysPerMonth;
+    case "month":
+      return intervalCount;
+    case "year":
+      return intervalCount * 12;
+  }
+}
+
+function subscriptionMrrDollars(
+  price: Stripe.Price | undefined,
+  quantity = 1,
+  fallbackIntervalAmountDollars?: number,
+): number | undefined {
+  const amountDollars =
+    priceAmountDollars(price) ?? fallbackIntervalAmountDollars;
+  const intervalMonths = recurringIntervalMonths(
+    priceBillingInterval(price),
+    price?.recurring?.interval_count ?? 1,
+  );
+
+  if (amountDollars === undefined || intervalMonths === undefined) {
+    return undefined;
+  }
+
+  return (amountDollars * quantity) / intervalMonths;
 }
 
 function invoicePaidAtMs(invoice: Stripe.Invoice): number {
@@ -67,6 +116,10 @@ function planLookupKeyToTier(lookupKey: string): SubscriptionTier | null {
   if (lookupKey.startsWith("team")) return "team";
   if (lookupKey.startsWith("pro")) return "pro";
   return null;
+}
+
+function toPaidStartTier(tier: SubscriptionTier): PaidStartTier | null {
+  return tier === "free" ? null : tier;
 }
 
 // =============================================================================
@@ -164,6 +217,12 @@ async function recordSubscriptionRevenue({
   const occurredAt = invoicePaidAtMs(invoice);
   const attributedRevenueDollars = grossRevenueDollars / userIds.length;
   const attributionStrategy = userIds.length > 1 ? "split_evenly" : "direct";
+  const mrrDollars =
+    reason === "subscription_create" || reason === "subscription_cycle"
+      ? subscriptionMrrDollars(price, item?.quantity ?? 1, grossRevenueDollars)
+      : undefined;
+  const attributedMrrDollars =
+    mrrDollars === undefined ? undefined : mrrDollars / userIds.length;
 
   await Promise.all([
     ...userIds.map((uid) =>
@@ -177,6 +236,7 @@ async function recordSubscriptionRevenue({
         sourceEventId: invoice.id,
         idempotencyKey: `subscription:${invoice.id}:user:${uid}`,
         grossRevenueDollars: attributedRevenueDollars,
+        mrrDollars: attributedMrrDollars,
         currency: invoice.currency ?? "usd",
         occurredAt,
         attributionStrategy,
@@ -201,6 +261,7 @@ async function recordSubscriptionRevenue({
             sourceEventId: invoice.id,
             idempotencyKey: `subscription:${invoice.id}:organization:${orgId}`,
             grossRevenueDollars,
+            mrrDollars,
             currency: invoice.currency ?? "usd",
             occurredAt,
             attributionStrategy: "organization_pool",
@@ -216,6 +277,57 @@ async function recordSubscriptionRevenue({
         ]
       : []),
   ]);
+}
+
+async function recordPaidStartMix({
+  invoice,
+  customerId,
+  userIds,
+  orgId,
+  tier,
+  subscription,
+}: {
+  invoice: Stripe.Invoice;
+  customerId: string;
+  userIds: string[];
+  orgId?: string;
+  tier: SubscriptionTier;
+  subscription: Stripe.Subscription;
+}) {
+  const paidStartTier = toPaidStartTier(tier);
+  if (!paidStartTier || userIds.length === 0) return;
+
+  const item = subscription.items?.data[0];
+  const price = item?.price;
+  const occurredAt = invoicePaidAtMs(invoice);
+  const entityType = orgId ? "organization" : "user";
+  const entityId = orgId ?? userIds[0];
+  const paidSeatCount = item?.quantity ?? userIds.length;
+
+  await convex.mutation(api.unitEconomics.recordPaidStartEvent, {
+    serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+    entityType,
+    entityId,
+    userId: userIds[0],
+    organizationId: orgId,
+    sourceEventId: invoice.id,
+    idempotencyKey: `paid_start:${invoice.id}:${entityType}:${entityId}`,
+    occurredAt,
+    conversionType: "free_to_paid",
+    tier: paidStartTier,
+    plan: price?.lookup_key ?? paidStartTier,
+    paidAccountStartCount: 1,
+    paidUserStartCount: userIds.length,
+    paidSeatCount,
+    billingInterval: priceBillingInterval(price),
+    billingIntervalCount: price?.recurring?.interval_count,
+    quantity: item?.quantity,
+    userCount: userIds.length,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscription.id,
+    stripeInvoiceId: invoice.id,
+    stripePriceId: price?.id,
+  });
 }
 
 // =============================================================================
@@ -368,8 +480,39 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
     );
     const attributedRevenueDollars =
       userIds.length > 0 ? invoiceAmountPaidDollars / userIds.length : 0;
+    const billingInterval = priceBillingInterval(price);
+    const subscriptionMrr = subscriptionMrrDollars(
+      price,
+      item?.quantity ?? 1,
+      invoiceAmountPaidDollars,
+    );
+    const attributedMrrDollars =
+      subscriptionMrr === undefined
+        ? undefined
+        : subscriptionMrr / userIds.length;
+    const paidSeatCount = item?.quantity ?? userIds.length;
 
-    for (const uid of userIds) {
+    try {
+      await recordPaidStartMix({
+        invoice,
+        customerId,
+        userIds,
+        orgId: orgId ?? undefined,
+        tier,
+        subscription,
+      });
+    } catch (error) {
+      console.error("[Subscription Webhook] Failed to record paid start mix:", {
+        error,
+        invoiceId: invoice.id,
+        customerId,
+        userCount: userIds.length,
+        orgId,
+        tier,
+      });
+    }
+
+    for (const [index, uid] of userIds.entries()) {
       phLogger.event("subscription_started", {
         userId: uid,
         from_tier: "free",
@@ -378,12 +521,22 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
         org_id: orgId,
         user_count: userIds.length,
         plan: price?.lookup_key,
-        billing_interval: priceBillingInterval(price),
+        paid_account_start_count: index === 0 ? 1 : 0,
+        paid_user_start_count: 1,
+        paid_account_user_count: userIds.length,
+        paid_seat_count: paidSeatCount,
+        paid_start_plan: price?.lookup_key ?? tier,
+        paid_start_tier: tier,
+        billing_interval: billingInterval,
+        paid_start_billing_interval: billingInterval ?? "unknown",
         billing_interval_count: price?.recurring?.interval_count,
         quantity: item?.quantity,
         invoice_amount_paid_dollars: invoiceAmountPaidDollars,
         attributed_revenue_dollars: attributedRevenueDollars,
         revenue_dollars: attributedRevenueDollars,
+        subscription_mrr_dollars: subscriptionMrr,
+        attributed_mrr_dollars: attributedMrrDollars,
+        mrr_dollars: attributedMrrDollars,
         currency: invoice.currency,
         stripe_customer_id: customerId,
         stripe_subscription_id: subscription.id,

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -13,6 +13,10 @@ import {
 import { phLogger } from "@/lib/posthog/server";
 import { resolveUserIdsFromCustomer as resolveStripeCustomerUsers } from "@/lib/billing/resolve-customer-users";
 import { getInvoicePaidBucketResetMode } from "@/lib/billing/subscription-invoice-reset";
+import {
+  priceBillingInterval,
+  subscriptionMrrDollars,
+} from "@/lib/billing/subscription-mrr";
 import type { SubscriptionTier } from "@/types";
 
 // Linear ranking used to label tier transitions as upgrade/downgrade. Team is
@@ -41,59 +45,6 @@ type PaidStartTier = Exclude<SubscriptionTier, "free">;
 
 const centsToDollars = (amount: number | null | undefined): number =>
   (amount ?? 0) / 100;
-
-function priceBillingInterval(
-  price: Stripe.Price | undefined,
-): "day" | "week" | "month" | "year" | undefined {
-  return price?.recurring?.interval ?? undefined;
-}
-
-function priceAmountDollars(
-  price: Stripe.Price | undefined,
-): number | undefined {
-  if (typeof price?.unit_amount === "number") return price.unit_amount / 100;
-
-  const decimalAmount = Number(price?.unit_amount_decimal);
-  return Number.isFinite(decimalAmount) ? decimalAmount / 100 : undefined;
-}
-
-function recurringIntervalMonths(
-  interval: "day" | "week" | "month" | "year" | undefined,
-  intervalCount = 1,
-): number | undefined {
-  if (!interval || intervalCount <= 0) return undefined;
-  const averageDaysPerMonth = 365 / 12;
-
-  switch (interval) {
-    case "day":
-      return intervalCount / averageDaysPerMonth;
-    case "week":
-      return (intervalCount * 7) / averageDaysPerMonth;
-    case "month":
-      return intervalCount;
-    case "year":
-      return intervalCount * 12;
-  }
-}
-
-function subscriptionMrrDollars(
-  price: Stripe.Price | undefined,
-  quantity = 1,
-  fallbackIntervalAmountDollars?: number,
-): number | undefined {
-  const amountDollars =
-    priceAmountDollars(price) ?? fallbackIntervalAmountDollars;
-  const intervalMonths = recurringIntervalMonths(
-    priceBillingInterval(price),
-    price?.recurring?.interval_count ?? 1,
-  );
-
-  if (amountDollars === undefined || intervalMonths === undefined) {
-    return undefined;
-  }
-
-  return (amountDollars * quantity) / intervalMonths;
-}
 
 function invoicePaidAtMs(invoice: Stripe.Invoice): number {
   const paidAt = invoice.status_transitions?.paid_at;
@@ -219,7 +170,11 @@ async function recordSubscriptionRevenue({
   const attributionStrategy = userIds.length > 1 ? "split_evenly" : "direct";
   const mrrDollars =
     reason === "subscription_create" || reason === "subscription_cycle"
-      ? subscriptionMrrDollars(price, item?.quantity ?? 1, grossRevenueDollars)
+      ? subscriptionMrrDollars({
+          price,
+          quantity: item?.quantity ?? 1,
+          fallbackIntervalAmountDollars: grossRevenueDollars,
+        })
       : undefined;
   const attributedMrrDollars =
     mrrDollars === undefined ? undefined : mrrDollars / userIds.length;
@@ -481,11 +436,11 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
     const attributedRevenueDollars =
       userIds.length > 0 ? invoiceAmountPaidDollars / userIds.length : 0;
     const billingInterval = priceBillingInterval(price);
-    const subscriptionMrr = subscriptionMrrDollars(
+    const subscriptionMrr = subscriptionMrrDollars({
       price,
-      item?.quantity ?? 1,
-      invoiceAmountPaidDollars,
-    );
+      quantity: item?.quantity ?? 1,
+      fallbackIntervalAmountDollars: invoiceAmountPaidDollars,
+    });
     const attributedMrrDollars =
       subscriptionMrr === undefined
         ? undefined

--- a/convex/__tests__/unitEconomicsPaidStarts.test.ts
+++ b/convex/__tests__/unitEconomicsPaidStarts.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, jest } from "@jest/globals";
+import { recordPaidStartEventInternal } from "../unitEconomicsLib";
+
+type PaidStartEventRow = {
+  _id: string;
+  idempotency_key: string;
+  source_event_id: string;
+  entity_type: "user" | "organization";
+  entity_id: string;
+  user_id?: string;
+};
+
+type PaidStartMixDailyRow = {
+  _id: string;
+  day: string;
+  tier: string;
+  plan: string;
+  billing_interval: string;
+  paid_account_start_count: number;
+  paid_user_start_count: number;
+  paid_seat_count: number;
+};
+
+function makeMockCtx(opts?: {
+  events?: PaidStartEventRow[];
+  mixRows?: PaidStartMixDailyRow[];
+}) {
+  const events: PaidStartEventRow[] = [...(opts?.events ?? [])];
+  const mixRows: PaidStartMixDailyRow[] = [...(opts?.mixRows ?? [])];
+  let nextId = 1;
+  const mintId = () => `id-${nextId++}`;
+
+  const buildQuery = (table: string) => ({
+    withIndex: jest.fn((_indexName: string, predicate: any) => {
+      const captured: Record<string, string> = {};
+      const captureProxy = {
+        eq: (field: string, value: string) => {
+          captured[field] = value;
+          return captureProxy;
+        },
+      };
+      predicate(captureProxy);
+
+      const matches = (() => {
+        if (table === "paid_start_events") {
+          return events.filter(
+            (row) => row.idempotency_key === captured.idempotency_key,
+          );
+        }
+        if (table === "paid_start_mix_daily") {
+          return mixRows.filter(
+            (row) =>
+              row.day === captured.day &&
+              row.tier === captured.tier &&
+              row.billing_interval === captured.billing_interval &&
+              row.plan === captured.plan,
+          );
+        }
+        return [];
+      })();
+
+      return {
+        unique: async () => {
+          if (matches.length === 0) return null;
+          if (matches.length > 1) throw new Error(`duplicate ${table} rows`);
+          return matches[0];
+        },
+      };
+    }),
+  });
+
+  const ctx: any = {
+    db: {
+      query: jest.fn((table: string) => buildQuery(table)),
+      insert: jest.fn(async (table: string, doc: any) => {
+        const id = mintId();
+        const row = { _id: id, ...doc };
+        if (table === "paid_start_events") events.push(row);
+        else if (table === "paid_start_mix_daily") mixRows.push(row);
+        else throw new Error(`unexpected table: ${table}`);
+        return id;
+      }),
+      patch: jest.fn(async (id: string, patch: any) => {
+        const row = mixRows.find((candidate) => candidate._id === id);
+        if (!row) throw new Error(`row ${id} not found`);
+        Object.assign(row, patch);
+      }),
+    },
+  };
+
+  return { ctx, events, mixRows };
+}
+
+describe("paid start tracking", () => {
+  it("records account, user, and seat start counts idempotently", async () => {
+    const { ctx, events, mixRows } = makeMockCtx();
+    const occurredAt = Date.UTC(2026, 0, 15, 12);
+
+    const first = await recordPaidStartEventInternal(ctx, {
+      entityType: "organization",
+      entityId: "org_1",
+      userId: "user_1",
+      organizationId: "org_1",
+      sourceEventId: "in_1",
+      occurredAt,
+      conversionType: "free_to_paid",
+      tier: "ultra",
+      plan: "ultra-yearly-plan",
+      paidAccountStartCount: 1,
+      paidUserStartCount: 4,
+      paidSeatCount: 5,
+      billingInterval: "year",
+      billingIntervalCount: 1,
+      quantity: 5,
+      userCount: 4,
+      stripeCustomerId: "cus_1",
+      stripeSubscriptionId: "sub_1",
+      stripeInvoiceId: "in_1",
+      stripePriceId: "price_1",
+    });
+
+    const duplicate = await recordPaidStartEventInternal(ctx, {
+      entityType: "organization",
+      entityId: "org_1",
+      userId: "user_1",
+      sourceEventId: "in_1",
+      occurredAt,
+      conversionType: "free_to_paid",
+      tier: "ultra",
+      plan: "ultra-yearly-plan",
+      billingInterval: "year",
+    });
+
+    expect(first).toEqual({ alreadyRecorded: false });
+    expect(duplicate).toEqual({ alreadyRecorded: true });
+    expect(events).toHaveLength(1);
+    expect(mixRows).toMatchObject([
+      {
+        day: "2026-01-15",
+        tier: "ultra",
+        plan: "ultra-yearly-plan",
+        billing_interval: "year",
+        paid_account_start_count: 1,
+        paid_user_start_count: 4,
+        paid_seat_count: 5,
+      },
+    ]);
+    expect(mixRows[0]).not.toHaveProperty("gross_revenue_dollars");
+    expect(mixRows[0]).not.toHaveProperty("net_revenue_dollars");
+  });
+
+  it("aggregates multiple real starts into the same daily mix segment", async () => {
+    const { ctx, mixRows } = makeMockCtx();
+    const occurredAt = Date.UTC(2026, 0, 15, 12);
+
+    await recordPaidStartEventInternal(ctx, {
+      entityType: "user",
+      entityId: "user_1",
+      userId: "user_1",
+      sourceEventId: "in_1",
+      occurredAt,
+      conversionType: "free_to_paid",
+      tier: "pro-plus",
+      plan: "pro-plus-monthly-plan",
+      billingInterval: "month",
+    });
+    await recordPaidStartEventInternal(ctx, {
+      entityType: "user",
+      entityId: "user_2",
+      userId: "user_2",
+      sourceEventId: "in_2",
+      occurredAt,
+      conversionType: "free_to_paid",
+      tier: "pro-plus",
+      plan: "pro-plus-monthly-plan",
+      billingInterval: "month",
+    });
+
+    expect(mixRows).toHaveLength(1);
+    expect(mixRows[0]).toMatchObject({
+      day: "2026-01-15",
+      tier: "pro-plus",
+      plan: "pro-plus-monthly-plan",
+      billing_interval: "month",
+      paid_account_start_count: 2,
+      paid_user_start_count: 2,
+      paid_seat_count: 2,
+    });
+  });
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -378,6 +378,9 @@ export default defineSchema({
     idempotency_key: v.string(),
     gross_revenue_dollars: v.number(),
     net_revenue_dollars: v.number(),
+    // Normalized monthly recurring revenue for subscription invoices. Raw
+    // cash collected remains in gross/net revenue.
+    mrr_dollars: v.optional(v.number()),
     currency: v.string(),
     occurred_at: v.number(),
     attribution_strategy: v.union(
@@ -403,6 +406,84 @@ export default defineSchema({
     .index("by_org_occurred", ["organization_id", "occurred_at"])
     .index("by_source_event", ["source", "source_event_id"]),
 
+  // Append-only paid-start ledger for funnel health. One row is recorded per
+  // new paid account/subscription; user and seat counts are separate fields so
+  // team starts do not silently inflate account conversion volume.
+  paid_start_events: defineTable({
+    entity_type: v.union(v.literal("user"), v.literal("organization")),
+    entity_id: v.string(),
+    user_id: v.optional(v.string()),
+    organization_id: v.optional(v.string()),
+    source_event_id: v.string(),
+    idempotency_key: v.string(),
+    occurred_at: v.number(),
+    day: v.string(),
+    conversion_type: v.union(
+      v.literal("free_to_paid"),
+      v.literal("paid_subscription_start"),
+    ),
+    tier: v.union(
+      v.literal("pro"),
+      v.literal("pro-plus"),
+      v.literal("ultra"),
+      v.literal("team"),
+    ),
+    plan: v.optional(v.string()),
+    paid_account_start_count: v.number(),
+    paid_user_start_count: v.number(),
+    paid_seat_count: v.number(),
+    billing_interval: v.optional(
+      v.union(
+        v.literal("day"),
+        v.literal("week"),
+        v.literal("month"),
+        v.literal("year"),
+      ),
+    ),
+    billing_interval_count: v.optional(v.number()),
+    quantity: v.optional(v.number()),
+    user_count: v.optional(v.number()),
+    stripe_customer_id: v.optional(v.string()),
+    stripe_subscription_id: v.optional(v.string()),
+    stripe_invoice_id: v.optional(v.string()),
+    stripe_price_id: v.optional(v.string()),
+    created_at: v.number(),
+  })
+    .index("by_idempotency_key", ["idempotency_key"])
+    .index("by_entity_day", ["entity_type", "entity_id", "day"])
+    .index("by_day", ["day"])
+    .index("by_user_day", ["user_id", "day"])
+    .index("by_org_day", ["organization_id", "day"])
+    .index("by_tier_day", ["tier", "day"])
+    .index("by_source_event", ["source_event_id"]),
+
+  // Compact daily paid-start mix for dashboarding/PostHog warehouse sync.
+  // Counts only; join to revenue_events only when explicitly analyzing money.
+  paid_start_mix_daily: defineTable({
+    day: v.string(),
+    tier: v.union(
+      v.literal("pro"),
+      v.literal("pro-plus"),
+      v.literal("ultra"),
+      v.literal("team"),
+    ),
+    plan: v.string(),
+    billing_interval: v.union(
+      v.literal("day"),
+      v.literal("week"),
+      v.literal("month"),
+      v.literal("year"),
+      v.literal("unknown"),
+    ),
+    paid_account_start_count: v.number(),
+    paid_user_start_count: v.number(),
+    paid_seat_count: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_segment", ["day", "tier", "billing_interval", "plan"])
+    .index("by_day", ["day"])
+    .index("by_tier_day", ["tier", "day"]),
+
   // Compact daily rows intended for dashboarding and PostHog warehouse sync.
   // Query either entity_type=user for per-user profitability or
   // entity_type=organization for team pool/subscription reporting.
@@ -414,6 +495,7 @@ export default defineSchema({
     day: v.string(),
     gross_revenue_dollars: v.number(),
     net_revenue_dollars: v.number(),
+    mrr_dollars: v.optional(v.number()),
     model_cost_dollars: v.number(),
     non_model_cost_dollars: v.number(),
     total_cost_dollars: v.number(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -482,7 +482,9 @@ export default defineSchema({
   })
     .index("by_segment", ["day", "tier", "billing_interval", "plan"])
     .index("by_day", ["day"])
-    .index("by_tier_day", ["tier", "day"]),
+    .index("by_tier_day", ["tier", "day"])
+    .index("by_interval_day", ["billing_interval", "day"])
+    .index("by_tier_interval_day", ["tier", "billing_interval", "day"]),
 
   // Compact daily rows intended for dashboarding and PostHog warehouse sync.
   // Query either entity_type=user for per-user profitability or

--- a/convex/unitEconomics.ts
+++ b/convex/unitEconomics.ts
@@ -540,39 +540,55 @@ export const listPaidStartMixForPostHog = query({
     validateServiceKey(args.serviceKey);
 
     const limit = Math.min(Math.max(Math.round(args.limit ?? 1000), 1), 5000);
-    const rows = args.tier
-      ? await ctx.db
-          .query("paid_start_mix_daily")
-          .withIndex("by_tier_day", (q) =>
-            q
-              .eq("tier", args.tier!)
-              .gte("day", args.startDay)
-              .lte("day", args.endDay),
-          )
-          .take(limit)
-      : await ctx.db
-          .query("paid_start_mix_daily")
-          .withIndex("by_day", (q) =>
-            q.gte("day", args.startDay).lte("day", args.endDay),
-          )
-          .take(limit);
+    const rows =
+      args.tier && args.billingInterval
+        ? await ctx.db
+            .query("paid_start_mix_daily")
+            .withIndex("by_tier_interval_day", (q) =>
+              q
+                .eq("tier", args.tier!)
+                .eq("billing_interval", args.billingInterval!)
+                .gte("day", args.startDay)
+                .lte("day", args.endDay),
+            )
+            .take(limit)
+        : args.tier
+          ? await ctx.db
+              .query("paid_start_mix_daily")
+              .withIndex("by_tier_day", (q) =>
+                q
+                  .eq("tier", args.tier!)
+                  .gte("day", args.startDay)
+                  .lte("day", args.endDay),
+              )
+              .take(limit)
+          : args.billingInterval
+            ? await ctx.db
+                .query("paid_start_mix_daily")
+                .withIndex("by_interval_day", (q) =>
+                  q
+                    .eq("billing_interval", args.billingInterval!)
+                    .gte("day", args.startDay)
+                    .lte("day", args.endDay),
+                )
+                .take(limit)
+            : await ctx.db
+                .query("paid_start_mix_daily")
+                .withIndex("by_day", (q) =>
+                  q.gte("day", args.startDay).lte("day", args.endDay),
+                )
+                .take(limit);
 
-    return rows
-      .filter(
-        (row) =>
-          !args.billingInterval ||
-          row.billing_interval === args.billingInterval,
-      )
-      .sort((a, b) => {
-        const dayCompare = a.day.localeCompare(b.day);
-        if (dayCompare !== 0) return dayCompare;
-        const tierCompare = a.tier.localeCompare(b.tier);
-        if (tierCompare !== 0) return tierCompare;
-        const intervalCompare = a.billing_interval.localeCompare(
-          b.billing_interval,
-        );
-        if (intervalCompare !== 0) return intervalCompare;
-        return a.plan.localeCompare(b.plan);
-      });
+    return rows.sort((a, b) => {
+      const dayCompare = a.day.localeCompare(b.day);
+      if (dayCompare !== 0) return dayCompare;
+      const tierCompare = a.tier.localeCompare(b.tier);
+      if (tierCompare !== 0) return tierCompare;
+      const intervalCompare = a.billing_interval.localeCompare(
+        b.billing_interval,
+      );
+      if (intervalCompare !== 0) return intervalCompare;
+      return a.plan.localeCompare(b.plan);
+    });
   },
 });

--- a/convex/unitEconomics.ts
+++ b/convex/unitEconomics.ts
@@ -2,9 +2,15 @@ import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 import {
+  applyPaidStartMixDelta,
   applyUnitEconomicsDelta,
+  recordPaidStartEventInternal,
   recordRevenueEventInternal,
   utcDay,
+  type PaidStartBillingInterval,
+  type PaidStartConversionType,
+  type PaidStartMixBillingInterval,
+  type PaidStartTier,
   type UnitEconomicsAttributionStrategy,
   type UnitEconomicsEntityType,
   type UnitEconomicsRevenueSource,
@@ -28,8 +34,41 @@ const attributionStrategyValidator = v.union(
   v.literal("organization_pool"),
 );
 
+const paidStartTierValidator = v.union(
+  v.literal("pro"),
+  v.literal("pro-plus"),
+  v.literal("ultra"),
+  v.literal("team"),
+);
+
+const paidStartBillingIntervalValidator = v.union(
+  v.literal("day"),
+  v.literal("week"),
+  v.literal("month"),
+  v.literal("year"),
+);
+
+const paidStartMixBillingIntervalValidator = v.union(
+  v.literal("day"),
+  v.literal("week"),
+  v.literal("month"),
+  v.literal("year"),
+  v.literal("unknown"),
+);
+
+const paidStartConversionTypeValidator = v.union(
+  v.literal("free_to_paid"),
+  v.literal("paid_subscription_start"),
+);
+
 function assertFiniteMoney(value: number, field: string) {
   if (!Number.isFinite(value)) {
+    throw new Error(`${field} must be finite`);
+  }
+}
+
+function assertFiniteOptionalNumber(value: number | undefined, field: string) {
+  if (value !== undefined && !Number.isFinite(value)) {
     throw new Error(`${field} must be finite`);
   }
 }
@@ -40,6 +79,7 @@ function sumRows(rows: Array<any>) {
       grossRevenueDollars:
         totals.grossRevenueDollars + row.gross_revenue_dollars,
       netRevenueDollars: totals.netRevenueDollars + row.net_revenue_dollars,
+      mrrDollars: totals.mrrDollars + (row.mrr_dollars ?? 0),
       modelCostDollars: totals.modelCostDollars + row.model_cost_dollars,
       nonModelCostDollars:
         totals.nonModelCostDollars + row.non_model_cost_dollars,
@@ -60,6 +100,7 @@ function sumRows(rows: Array<any>) {
     {
       grossRevenueDollars: 0,
       netRevenueDollars: 0,
+      mrrDollars: 0,
       modelCostDollars: 0,
       nonModelCostDollars: 0,
       totalCostDollars: 0,
@@ -89,6 +130,7 @@ export const recordRevenueEvent = mutation({
     idempotencyKey: v.optional(v.string()),
     grossRevenueDollars: v.number(),
     netRevenueDollars: v.optional(v.number()),
+    mrrDollars: v.optional(v.number()),
     currency: v.optional(v.string()),
     occurredAt: v.optional(v.number()),
     attributionStrategy: attributionStrategyValidator,
@@ -112,6 +154,9 @@ export const recordRevenueEvent = mutation({
     if (args.netRevenueDollars !== undefined) {
       assertFiniteMoney(args.netRevenueDollars, "netRevenueDollars");
     }
+    if (args.mrrDollars !== undefined) {
+      assertFiniteMoney(args.mrrDollars, "mrrDollars");
+    }
 
     return await recordRevenueEventInternal(ctx, {
       entityType: args.entityType as UnitEconomicsEntityType,
@@ -123,6 +168,7 @@ export const recordRevenueEvent = mutation({
       idempotencyKey: args.idempotencyKey,
       grossRevenueDollars: args.grossRevenueDollars,
       netRevenueDollars: args.netRevenueDollars,
+      mrrDollars: args.mrrDollars,
       currency: args.currency,
       occurredAt: args.occurredAt,
       attributionStrategy:
@@ -137,6 +183,78 @@ export const recordRevenueEvent = mutation({
       quantity: args.quantity,
       userCount: args.userCount,
       description: args.description,
+    });
+  },
+});
+
+export const recordPaidStartEvent = mutation({
+  args: {
+    serviceKey: v.string(),
+    entityType: entityTypeValidator,
+    entityId: v.string(),
+    userId: v.optional(v.string()),
+    organizationId: v.optional(v.string()),
+    sourceEventId: v.string(),
+    idempotencyKey: v.optional(v.string()),
+    occurredAt: v.optional(v.number()),
+    conversionType: paidStartConversionTypeValidator,
+    tier: paidStartTierValidator,
+    plan: v.optional(v.string()),
+    paidAccountStartCount: v.optional(v.number()),
+    paidUserStartCount: v.optional(v.number()),
+    paidSeatCount: v.optional(v.number()),
+    billingInterval: v.optional(paidStartBillingIntervalValidator),
+    billingIntervalCount: v.optional(v.number()),
+    quantity: v.optional(v.number()),
+    userCount: v.optional(v.number()),
+    stripeCustomerId: v.optional(v.string()),
+    stripeSubscriptionId: v.optional(v.string()),
+    stripeInvoiceId: v.optional(v.string()),
+    stripePriceId: v.optional(v.string()),
+  },
+  returns: v.object({
+    alreadyRecorded: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    assertFiniteOptionalNumber(args.occurredAt, "occurredAt");
+    assertFiniteOptionalNumber(
+      args.paidAccountStartCount,
+      "paidAccountStartCount",
+    );
+    assertFiniteOptionalNumber(args.paidUserStartCount, "paidUserStartCount");
+    assertFiniteOptionalNumber(args.paidSeatCount, "paidSeatCount");
+    assertFiniteOptionalNumber(
+      args.billingIntervalCount,
+      "billingIntervalCount",
+    );
+    assertFiniteOptionalNumber(args.quantity, "quantity");
+    assertFiniteOptionalNumber(args.userCount, "userCount");
+
+    return await recordPaidStartEventInternal(ctx, {
+      entityType: args.entityType as UnitEconomicsEntityType,
+      entityId: args.entityId,
+      userId: args.userId,
+      organizationId: args.organizationId,
+      sourceEventId: args.sourceEventId,
+      idempotencyKey: args.idempotencyKey,
+      occurredAt: args.occurredAt,
+      conversionType: args.conversionType as PaidStartConversionType,
+      tier: args.tier as PaidStartTier,
+      plan: args.plan,
+      paidAccountStartCount: args.paidAccountStartCount,
+      paidUserStartCount: args.paidUserStartCount,
+      paidSeatCount: args.paidSeatCount,
+      billingInterval: args.billingInterval as
+        | PaidStartBillingInterval
+        | undefined,
+      billingIntervalCount: args.billingIntervalCount,
+      quantity: args.quantity,
+      userCount: args.userCount,
+      stripeCustomerId: args.stripeCustomerId,
+      stripeSubscriptionId: args.stripeSubscriptionId,
+      stripeInvoiceId: args.stripeInvoiceId,
+      stripePriceId: args.stripePriceId,
     });
   },
 });
@@ -294,6 +412,7 @@ export const rebuildEntityDailyRollups = mutation({
         day: utcDay(event.occurred_at),
         grossRevenueDollars: event.gross_revenue_dollars,
         netRevenueDollars: event.net_revenue_dollars,
+        mrrDollars: event.mrr_dollars,
         revenueEventCount: 1,
       });
     }
@@ -303,6 +422,74 @@ export const rebuildEntityDailyRollups = mutation({
       usageRowsApplied: usageRows.length,
       revenueRowsApplied: revenueRows.length,
       truncated: usageRows.length === maxRows || revenueRows.length === maxRows,
+    };
+  },
+});
+
+export const rebuildPaidStartMixDailyRollups = mutation({
+  args: {
+    serviceKey: v.string(),
+    startDay: v.string(),
+    endDay: v.string(),
+    maxRows: v.optional(v.number()),
+  },
+  returns: v.object({
+    deletedRollups: v.number(),
+    eventRowsApplied: v.number(),
+    truncated: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const maxRows = Math.min(
+      Math.max(Math.round(args.maxRows ?? 5000), 1),
+      10_000,
+    );
+
+    const existingRollups = await ctx.db
+      .query("paid_start_mix_daily")
+      .withIndex("by_day", (q) =>
+        q.gte("day", args.startDay).lte("day", args.endDay),
+      )
+      .take(maxRows);
+
+    for (const row of existingRollups) {
+      await ctx.db.delete(row._id);
+    }
+
+    if (existingRollups.length === maxRows) {
+      return {
+        deletedRollups: existingRollups.length,
+        eventRowsApplied: 0,
+        truncated: true,
+      };
+    }
+
+    const events = await ctx.db
+      .query("paid_start_events")
+      .withIndex("by_day", (q) =>
+        q.gte("day", args.startDay).lte("day", args.endDay),
+      )
+      .take(maxRows);
+
+    for (const event of events) {
+      await applyPaidStartMixDelta(ctx, {
+        day: event.day,
+        tier: event.tier as PaidStartTier,
+        plan: event.plan ?? event.tier,
+        billingInterval:
+          (event.billing_interval as PaidStartMixBillingInterval | undefined) ??
+          "unknown",
+        paidAccountStartCount: event.paid_account_start_count,
+        paidUserStartCount: event.paid_user_start_count,
+        paidSeatCount: event.paid_seat_count,
+      });
+    }
+
+    return {
+      deletedRollups: existingRollups.length,
+      eventRowsApplied: events.length,
+      truncated: events.length === maxRows,
     };
   },
 });
@@ -337,5 +524,55 @@ export const listDailyRollupsForPostHog = query({
         `${b.entity_type}:${b.entity_id}`,
       );
     });
+  },
+});
+
+export const listPaidStartMixForPostHog = query({
+  args: {
+    serviceKey: v.string(),
+    startDay: v.string(),
+    endDay: v.string(),
+    tier: v.optional(paidStartTierValidator),
+    billingInterval: v.optional(paidStartMixBillingIntervalValidator),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const limit = Math.min(Math.max(Math.round(args.limit ?? 1000), 1), 5000);
+    const rows = args.tier
+      ? await ctx.db
+          .query("paid_start_mix_daily")
+          .withIndex("by_tier_day", (q) =>
+            q
+              .eq("tier", args.tier!)
+              .gte("day", args.startDay)
+              .lte("day", args.endDay),
+          )
+          .take(limit)
+      : await ctx.db
+          .query("paid_start_mix_daily")
+          .withIndex("by_day", (q) =>
+            q.gte("day", args.startDay).lte("day", args.endDay),
+          )
+          .take(limit);
+
+    return rows
+      .filter(
+        (row) =>
+          !args.billingInterval ||
+          row.billing_interval === args.billingInterval,
+      )
+      .sort((a, b) => {
+        const dayCompare = a.day.localeCompare(b.day);
+        if (dayCompare !== 0) return dayCompare;
+        const tierCompare = a.tier.localeCompare(b.tier);
+        if (tierCompare !== 0) return tierCompare;
+        const intervalCompare = a.billing_interval.localeCompare(
+          b.billing_interval,
+        );
+        if (intervalCompare !== 0) return intervalCompare;
+        return a.plan.localeCompare(b.plan);
+      });
   },
 });

--- a/convex/unitEconomicsLib.ts
+++ b/convex/unitEconomicsLib.ts
@@ -13,6 +13,16 @@ export type UnitEconomicsAttributionStrategy =
   | "split_evenly"
   | "organization_pool";
 
+export type PaidStartTier = "pro" | "pro-plus" | "ultra" | "team";
+
+export type PaidStartBillingInterval = "day" | "week" | "month" | "year";
+
+export type PaidStartMixBillingInterval = PaidStartBillingInterval | "unknown";
+
+export type PaidStartConversionType =
+  | "free_to_paid"
+  | "paid_subscription_start";
+
 export function utcDay(timestampMs: number): string {
   return new Date(timestampMs).toISOString().slice(0, 10);
 }
@@ -31,6 +41,7 @@ export async function applyUnitEconomicsDelta(
     day: string;
     grossRevenueDollars?: number;
     netRevenueDollars?: number;
+    mrrDollars?: number;
     modelCostDollars?: number;
     nonModelCostDollars?: number;
     includedUsageCostDollars?: number;
@@ -58,6 +69,7 @@ export async function applyUnitEconomicsDelta(
     finite(existing?.gross_revenue_dollars) + finite(args.grossRevenueDollars);
   const netRevenueDollars =
     finite(existing?.net_revenue_dollars) + finite(args.netRevenueDollars);
+  const mrrDollars = finite(existing?.mrr_dollars) + finite(args.mrrDollars);
   const modelCostDollars =
     finite(existing?.model_cost_dollars) + finite(args.modelCostDollars);
   const nonModelCostDollars =
@@ -72,6 +84,7 @@ export async function applyUnitEconomicsDelta(
     day: args.day,
     gross_revenue_dollars: grossRevenueDollars,
     net_revenue_dollars: netRevenueDollars,
+    mrr_dollars: mrrDollars,
     model_cost_dollars: modelCostDollars,
     non_model_cost_dollars: nonModelCostDollars,
     total_cost_dollars: totalCostDollars,
@@ -104,6 +117,139 @@ export async function applyUnitEconomicsDelta(
   return await ctx.db.insert("unit_economics_daily", next);
 }
 
+export async function applyPaidStartMixDelta(
+  ctx: MutationCtx,
+  args: {
+    day: string;
+    tier: PaidStartTier;
+    plan: string;
+    billingInterval: PaidStartMixBillingInterval;
+    paidAccountStartCount?: number;
+    paidUserStartCount?: number;
+    paidSeatCount?: number;
+  },
+) {
+  const existing = await ctx.db
+    .query("paid_start_mix_daily")
+    .withIndex("by_segment", (q) =>
+      q
+        .eq("day", args.day)
+        .eq("tier", args.tier)
+        .eq("billing_interval", args.billingInterval)
+        .eq("plan", args.plan),
+    )
+    .unique();
+
+  const next = {
+    day: args.day,
+    tier: args.tier,
+    plan: args.plan,
+    billing_interval: args.billingInterval,
+    paid_account_start_count:
+      finite(existing?.paid_account_start_count) +
+      finite(args.paidAccountStartCount),
+    paid_user_start_count:
+      finite(existing?.paid_user_start_count) + finite(args.paidUserStartCount),
+    paid_seat_count:
+      finite(existing?.paid_seat_count) + finite(args.paidSeatCount),
+    updated_at: Date.now(),
+  };
+
+  if (existing) {
+    await ctx.db.patch(existing._id, next);
+    return existing._id;
+  }
+
+  return await ctx.db.insert("paid_start_mix_daily", next);
+}
+
+export async function recordPaidStartEventInternal(
+  ctx: MutationCtx,
+  args: {
+    entityType: UnitEconomicsEntityType;
+    entityId: string;
+    userId?: string;
+    organizationId?: string;
+    sourceEventId: string;
+    idempotencyKey?: string;
+    occurredAt?: number;
+    conversionType: PaidStartConversionType;
+    tier: PaidStartTier;
+    plan?: string;
+    paidAccountStartCount?: number;
+    paidUserStartCount?: number;
+    paidSeatCount?: number;
+    billingInterval?: PaidStartBillingInterval;
+    billingIntervalCount?: number;
+    quantity?: number;
+    userCount?: number;
+    stripeCustomerId?: string;
+    stripeSubscriptionId?: string;
+    stripeInvoiceId?: string;
+    stripePriceId?: string;
+  },
+): Promise<{ alreadyRecorded: boolean }> {
+  const idempotencyKey =
+    args.idempotencyKey ??
+    `paid_start:${args.sourceEventId}:${args.entityType}:${args.entityId}`;
+  const existing = await ctx.db
+    .query("paid_start_events")
+    .withIndex("by_idempotency_key", (q) =>
+      q.eq("idempotency_key", idempotencyKey),
+    )
+    .unique();
+
+  if (existing) {
+    return { alreadyRecorded: true };
+  }
+
+  const occurredAt = args.occurredAt ?? Date.now();
+  const day = utcDay(occurredAt);
+  const plan = args.plan ?? args.tier;
+  const billingInterval = args.billingInterval ?? "unknown";
+  const paidAccountStartCount = finite(args.paidAccountStartCount, 1);
+  const paidUserStartCount = finite(args.paidUserStartCount, 1);
+  const paidSeatCount = finite(args.paidSeatCount, paidUserStartCount);
+
+  await ctx.db.insert("paid_start_events", {
+    entity_type: args.entityType,
+    entity_id: args.entityId,
+    user_id: args.userId,
+    organization_id: args.organizationId,
+    source_event_id: args.sourceEventId,
+    idempotency_key: idempotencyKey,
+    occurred_at: occurredAt,
+    day,
+    conversion_type: args.conversionType,
+    tier: args.tier,
+    plan: args.plan,
+    paid_account_start_count: paidAccountStartCount,
+    paid_user_start_count: paidUserStartCount,
+    paid_seat_count: paidSeatCount,
+    billing_interval: args.billingInterval,
+    billing_interval_count: args.billingIntervalCount,
+    quantity: args.quantity,
+    user_count: args.userCount,
+    stripe_customer_id: args.stripeCustomerId,
+    stripe_subscription_id: args.stripeSubscriptionId,
+    stripe_invoice_id: args.stripeInvoiceId,
+    stripe_price_id: args.stripePriceId,
+    created_at: Date.now(),
+  });
+
+  await applyPaidStartMixDelta(ctx, {
+    day,
+    tier: args.tier,
+    plan,
+    billingInterval,
+    paidAccountStartCount,
+    paidUserStartCount,
+    paidSeatCount,
+  });
+
+  return { alreadyRecorded: false };
+}
+
 export async function recordRevenueEventInternal(
   ctx: MutationCtx,
   args: {
@@ -116,6 +262,7 @@ export async function recordRevenueEventInternal(
     idempotencyKey?: string;
     grossRevenueDollars: number;
     netRevenueDollars?: number;
+    mrrDollars?: number;
     currency?: string;
     occurredAt?: number;
     attributionStrategy: UnitEconomicsAttributionStrategy;
@@ -152,6 +299,8 @@ export async function recordRevenueEventInternal(
 
   const occurredAt = args.occurredAt ?? Date.now();
   const netRevenueDollars = finite(args.netRevenueDollars, grossRevenueDollars);
+  const mrrDollars =
+    args.mrrDollars === undefined ? undefined : finite(args.mrrDollars);
 
   await ctx.db.insert("revenue_events", {
     entity_type: args.entityType,
@@ -163,6 +312,7 @@ export async function recordRevenueEventInternal(
     idempotency_key: idempotencyKey,
     gross_revenue_dollars: grossRevenueDollars,
     net_revenue_dollars: netRevenueDollars,
+    mrr_dollars: mrrDollars,
     currency: args.currency ?? "usd",
     occurred_at: occurredAt,
     attribution_strategy: args.attributionStrategy,
@@ -187,6 +337,7 @@ export async function recordRevenueEventInternal(
     day: utcDay(occurredAt),
     grossRevenueDollars,
     netRevenueDollars,
+    mrrDollars,
     revenueEventCount: 1,
   });
 

--- a/convex/unitEconomicsLib.ts
+++ b/convex/unitEconomicsLib.ts
@@ -222,7 +222,7 @@ export async function recordPaidStartEventInternal(
     day,
     conversion_type: args.conversionType,
     tier: args.tier,
-    plan: args.plan,
+    plan,
     paid_account_start_count: paidAccountStartCount,
     paid_user_start_count: paidUserStartCount,
     paid_seat_count: paidSeatCount,

--- a/docs/unit-economics.md
+++ b/docs/unit-economics.md
@@ -120,6 +120,9 @@ unitEconomics.rebuildPaidStartMixDailyRollups({
 })
 ```
 
+This mutation also returns `truncated: true` when the row cap is hit. Re-run
+with a narrower day range when that happens.
+
 ## Revenue Accuracy
 
 Stripe revenue is recorded when credits are granted or subscription invoices are

--- a/docs/unit-economics.md
+++ b/docs/unit-economics.md
@@ -11,6 +11,14 @@ rather than raw request events.
   context.
 - `revenue_events`: append-only Stripe revenue ledger. Stores subscription,
   personal extra usage, and team extra usage revenue with idempotency keys.
+  Subscription rows may also include `mrr_dollars`, a normalized monthly
+  recurring revenue value derived from the recurring Stripe price cadence.
+- `paid_start_events`: append-only subscription-start ledger. Stores one
+  idempotent paid-start row per new paid account/subscription, with separate
+  account, user, and seat counts, but no revenue amounts.
+- `paid_start_mix_daily`: compact daily count rollup by tier, plan, and billing
+  interval. Use this for funnel-health mix charts so one high-value
+  annual/Ultra start does not dominate the conversion readout.
 - `unit_economics_daily`: materialized daily rollups for cheap dashboards and
   PostHog warehouse sync.
 
@@ -47,6 +55,7 @@ Important columns:
 - `day`
 - `gross_revenue_dollars`
 - `net_revenue_dollars`
+- `mrr_dollars`
 - `model_cost_dollars`
 - `non_model_cost_dollars`
 - `total_cost_dollars`
@@ -54,6 +63,30 @@ Important columns:
 - `usage_request_count`
 - `input_tokens`
 - `output_tokens`
+
+For paid-start funnel health, sync this separate count-only table:
+
+```text
+paid_start_mix_daily
+```
+
+Important columns:
+
+- `day`
+- `tier`
+- `plan`
+- `billing_interval`
+- `paid_account_start_count`
+- `paid_user_start_count`
+- `paid_seat_count`
+
+Use `sum(paid_account_start_count)` for account conversion volume and
+breakdowns by `tier`, `plan`, or `billing_interval`. Use
+`sum(paid_user_start_count)` or `sum(paid_seat_count)` when you intentionally
+want user/seat scale. Do not use `gross_revenue_dollars` or
+`net_revenue_dollars` as a proxy for paid starts; annual and Ultra invoices can
+otherwise make a weak funnel look healthy. For normalized subscription revenue,
+use `mrr_dollars` instead of dividing raw invoice revenue in dashboards.
 
 ## Backfill
 
@@ -76,6 +109,17 @@ The mutation rebuilds only one user or one organization at a time and returns
 `truncated: true` if the row cap was hit. Re-run with a narrower time range when
 that happens.
 
+Paid-start mix rows update automatically from new `subscription_create`
+invoices. To rebuild paid-start mix from existing `paid_start_events`, run:
+
+```text
+unitEconomics.rebuildPaidStartMixDailyRollups({
+  serviceKey,
+  startDay: "2026-01-01",
+  endDay: "2026-01-31"
+})
+```
+
 ## Revenue Accuracy
 
 Stripe revenue is recorded when credits are granted or subscription invoices are
@@ -83,3 +127,8 @@ paid. `net_revenue_dollars` currently equals gross Stripe revenue unless a
 future Stripe balance-transaction sync fills in processor fees. This keeps
 model and request expenses exact while leaving payment processing fees explicit
 instead of hidden in the model-cost calculation.
+
+`mrr_dollars` is not cash collected. It normalizes full subscription create and
+cycle invoices to monthly recurring value from the Stripe recurring price
+interval, for example annual price divided by 12. Raw invoice cash remains in
+`gross_revenue_dollars` and `net_revenue_dollars`.

--- a/lib/billing/__tests__/subscription-mrr.test.ts
+++ b/lib/billing/__tests__/subscription-mrr.test.ts
@@ -96,6 +96,41 @@ describe("subscription MRR normalization", () => {
     ).toBeUndefined();
   });
 
+  it("returns undefined for invalid numeric inputs", () => {
+    expect(
+      subscriptionMrrDollars({
+        price: price({ amountCents: 2500, interval: "month" }),
+        quantity: Number.NaN,
+      }),
+    ).toBeUndefined();
+    expect(
+      subscriptionMrrDollars({
+        price: price({ amountCents: 2500, interval: "month" }),
+        quantity: -1,
+      }),
+    ).toBeUndefined();
+    expect(
+      subscriptionMrrDollars({
+        price: price({ interval: "month" }),
+        fallbackTotalIntervalAmountDollars: Number.POSITIVE_INFINITY,
+      }),
+    ).toBeUndefined();
+    expect(
+      subscriptionMrrDollars({
+        price: price({ amountCents: 0, interval: "month" }),
+      }),
+    ).toBeUndefined();
+    expect(
+      subscriptionMrrDollars({
+        price: price({
+          amountCents: 2500,
+          interval: "month",
+          intervalCount: Number.NaN,
+        }),
+      }),
+    ).toBeUndefined();
+  });
+
   it("exposes the billing interval used by analytics dimensions", () => {
     expect(
       priceBillingInterval(price({ amountCents: 2500, interval: "month" })),

--- a/lib/billing/__tests__/subscription-mrr.test.ts
+++ b/lib/billing/__tests__/subscription-mrr.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  priceBillingInterval,
+  subscriptionMrrDollars,
+} from "../subscription-mrr";
+
+function price({
+  amountCents,
+  interval,
+  intervalCount = 1,
+}: {
+  amountCents?: number;
+  interval: "day" | "week" | "month" | "year";
+  intervalCount?: number;
+}) {
+  return {
+    unit_amount: amountCents,
+    recurring: {
+      interval,
+      interval_count: intervalCount,
+    },
+  } as any;
+}
+
+describe("subscription MRR normalization", () => {
+  it("keeps monthly subscription price as monthly revenue", () => {
+    expect(
+      subscriptionMrrDollars({
+        price: price({ amountCents: 2500, interval: "month" }),
+      }),
+    ).toBe(25);
+  });
+
+  it("normalizes annual subscription price over twelve months", () => {
+    expect(
+      subscriptionMrrDollars({
+        price: price({ amountCents: 25200, interval: "year" }),
+      }),
+    ).toBe(21);
+  });
+
+  it("includes subscription quantity in normalized MRR", () => {
+    expect(
+      subscriptionMrrDollars({
+        price: price({ amountCents: 6000, interval: "month" }),
+        quantity: 3,
+      }),
+    ).toBe(180);
+  });
+
+  it("uses fallback amount only when the price amount is unavailable", () => {
+    expect(
+      subscriptionMrrDollars({
+        price: price({ interval: "year" }),
+        fallbackIntervalAmountDollars: 120,
+      }),
+    ).toBe(10);
+  });
+
+  it("returns undefined when the billing cadence is missing or invalid", () => {
+    expect(
+      subscriptionMrrDollars({
+        price: undefined,
+        fallbackIntervalAmountDollars: 120,
+      }),
+    ).toBeUndefined();
+    expect(
+      subscriptionMrrDollars({
+        price: price({
+          amountCents: 12000,
+          interval: "month",
+          intervalCount: 0,
+        }),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("exposes the billing interval used by analytics dimensions", () => {
+    expect(
+      priceBillingInterval(price({ amountCents: 2500, interval: "month" })),
+    ).toBe("month");
+  });
+});

--- a/lib/billing/__tests__/subscription-mrr.test.ts
+++ b/lib/billing/__tests__/subscription-mrr.test.ts
@@ -6,15 +6,18 @@ import {
 
 function price({
   amountCents,
+  amountDecimal,
   interval,
   intervalCount = 1,
 }: {
   amountCents?: number;
+  amountDecimal?: string | null;
   interval: "day" | "week" | "month" | "year";
   intervalCount?: number;
 }) {
   return {
     unit_amount: amountCents,
+    unit_amount_decimal: amountDecimal,
     recurring: {
       interval,
       interval_count: intervalCount,
@@ -48,20 +51,38 @@ describe("subscription MRR normalization", () => {
     ).toBe(180);
   });
 
-  it("uses fallback amount only when the price amount is unavailable", () => {
+  it("uses fallback total amount only when the price amount is unavailable", () => {
     expect(
       subscriptionMrrDollars({
         price: price({ interval: "year" }),
-        fallbackIntervalAmountDollars: 120,
+        fallbackTotalIntervalAmountDollars: 120,
       }),
     ).toBe(10);
+  });
+
+  it("does not multiply fallback invoice totals by quantity again", () => {
+    expect(
+      subscriptionMrrDollars({
+        price: price({ interval: "year" }),
+        quantity: 5,
+        fallbackTotalIntervalAmountDollars: 1200,
+      }),
+    ).toBe(100);
+  });
+
+  it("does not coerce nullable Stripe decimal amounts into zero MRR", () => {
+    expect(
+      subscriptionMrrDollars({
+        price: price({ amountDecimal: null, interval: "month" }),
+      }),
+    ).toBeUndefined();
   });
 
   it("returns undefined when the billing cadence is missing or invalid", () => {
     expect(
       subscriptionMrrDollars({
         price: undefined,
-        fallbackIntervalAmountDollars: 120,
+        fallbackTotalIntervalAmountDollars: 120,
       }),
     ).toBeUndefined();
     expect(

--- a/lib/billing/subscription-mrr.ts
+++ b/lib/billing/subscription-mrr.ts
@@ -2,6 +2,10 @@ import type Stripe from "stripe";
 
 type BillingInterval = "day" | "week" | "month" | "year";
 
+function finitePositive(value: number | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
 export function priceBillingInterval(
   price: Stripe.Price | undefined,
 ): BillingInterval | undefined {
@@ -11,19 +15,23 @@ export function priceBillingInterval(
 function priceAmountDollars(
   price: Stripe.Price | undefined,
 ): number | undefined {
-  if (typeof price?.unit_amount === "number") return price.unit_amount / 100;
+  if (typeof price?.unit_amount === "number") {
+    const amountDollars = price.unit_amount / 100;
+    return finitePositive(amountDollars) ? amountDollars : undefined;
+  }
 
   if (price?.unit_amount_decimal == null) return undefined;
 
   const decimalAmount = Number(price.unit_amount_decimal);
-  return Number.isFinite(decimalAmount) ? decimalAmount / 100 : undefined;
+  const amountDollars = decimalAmount / 100;
+  return finitePositive(amountDollars) ? amountDollars : undefined;
 }
 
 function recurringIntervalMonths(
   interval: BillingInterval | undefined,
   intervalCount = 1,
 ): number | undefined {
-  if (!interval || intervalCount <= 0) return undefined;
+  if (!interval || !finitePositive(intervalCount)) return undefined;
   const averageDaysPerMonth = 365 / 12;
 
   switch (interval) {
@@ -47,6 +55,8 @@ export function subscriptionMrrDollars({
   quantity?: number;
   fallbackTotalIntervalAmountDollars?: number;
 }): number | undefined {
+  if (!finitePositive(quantity)) return undefined;
+
   const unitAmountDollars = priceAmountDollars(price);
   const totalIntervalAmountDollars =
     unitAmountDollars === undefined
@@ -58,8 +68,8 @@ export function subscriptionMrrDollars({
   );
 
   if (
-    totalIntervalAmountDollars === undefined ||
-    intervalMonths === undefined
+    !finitePositive(totalIntervalAmountDollars) ||
+    !finitePositive(intervalMonths)
   ) {
     return undefined;
   }

--- a/lib/billing/subscription-mrr.ts
+++ b/lib/billing/subscription-mrr.ts
@@ -1,0 +1,60 @@
+import type Stripe from "stripe";
+
+type BillingInterval = "day" | "week" | "month" | "year";
+
+export function priceBillingInterval(
+  price: Stripe.Price | undefined,
+): BillingInterval | undefined {
+  return price?.recurring?.interval ?? undefined;
+}
+
+function priceAmountDollars(
+  price: Stripe.Price | undefined,
+): number | undefined {
+  if (typeof price?.unit_amount === "number") return price.unit_amount / 100;
+
+  const decimalAmount = Number(price?.unit_amount_decimal);
+  return Number.isFinite(decimalAmount) ? decimalAmount / 100 : undefined;
+}
+
+function recurringIntervalMonths(
+  interval: BillingInterval | undefined,
+  intervalCount = 1,
+): number | undefined {
+  if (!interval || intervalCount <= 0) return undefined;
+  const averageDaysPerMonth = 365 / 12;
+
+  switch (interval) {
+    case "day":
+      return intervalCount / averageDaysPerMonth;
+    case "week":
+      return (intervalCount * 7) / averageDaysPerMonth;
+    case "month":
+      return intervalCount;
+    case "year":
+      return intervalCount * 12;
+  }
+}
+
+export function subscriptionMrrDollars({
+  price,
+  quantity = 1,
+  fallbackIntervalAmountDollars,
+}: {
+  price: Stripe.Price | undefined;
+  quantity?: number;
+  fallbackIntervalAmountDollars?: number;
+}): number | undefined {
+  const amountDollars =
+    priceAmountDollars(price) ?? fallbackIntervalAmountDollars;
+  const intervalMonths = recurringIntervalMonths(
+    priceBillingInterval(price),
+    price?.recurring?.interval_count ?? 1,
+  );
+
+  if (amountDollars === undefined || intervalMonths === undefined) {
+    return undefined;
+  }
+
+  return (amountDollars * quantity) / intervalMonths;
+}

--- a/lib/billing/subscription-mrr.ts
+++ b/lib/billing/subscription-mrr.ts
@@ -13,7 +13,9 @@ function priceAmountDollars(
 ): number | undefined {
   if (typeof price?.unit_amount === "number") return price.unit_amount / 100;
 
-  const decimalAmount = Number(price?.unit_amount_decimal);
+  if (price?.unit_amount_decimal == null) return undefined;
+
+  const decimalAmount = Number(price.unit_amount_decimal);
   return Number.isFinite(decimalAmount) ? decimalAmount / 100 : undefined;
 }
 
@@ -39,22 +41,28 @@ function recurringIntervalMonths(
 export function subscriptionMrrDollars({
   price,
   quantity = 1,
-  fallbackIntervalAmountDollars,
+  fallbackTotalIntervalAmountDollars,
 }: {
   price: Stripe.Price | undefined;
   quantity?: number;
-  fallbackIntervalAmountDollars?: number;
+  fallbackTotalIntervalAmountDollars?: number;
 }): number | undefined {
-  const amountDollars =
-    priceAmountDollars(price) ?? fallbackIntervalAmountDollars;
+  const unitAmountDollars = priceAmountDollars(price);
+  const totalIntervalAmountDollars =
+    unitAmountDollars === undefined
+      ? fallbackTotalIntervalAmountDollars
+      : unitAmountDollars * quantity;
   const intervalMonths = recurringIntervalMonths(
     priceBillingInterval(price),
     price?.recurring?.interval_count ?? 1,
   );
 
-  if (amountDollars === undefined || intervalMonths === undefined) {
+  if (
+    totalIntervalAmountDollars === undefined ||
+    intervalMonths === undefined
+  ) {
     return undefined;
   }
 
-  return (amountDollars * quantity) / intervalMonths;
+  return totalIntervalAmountDollars / intervalMonths;
 }


### PR DESCRIPTION
## Summary

- Add count-only paid-start ledgers and daily mix rollups for account, user, and seat starts by tier, plan, and billing interval.
- Add normalized `mrr_dollars` alongside raw subscription invoice revenue so annual and monthly plans can be compared without changing cash-collected fields.
- Extract subscription MRR normalization into a tested billing helper.
- Record paid-start mix from subscription-create invoices in the Stripe subscription webhook, and document the intended PostHog/warehouse fields.

## Why

Revenue is a poor proxy for funnel health: one annual or Ultra conversion can obscure whether paid-start volume is healthy. This keeps raw revenue, normalized MRR, and conversion counts as separate facts.

## Validation

- `pnpm jest lib/billing/__tests__/subscription-mrr.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (warnings only in existing unrelated files)
- pre-commit hook: `tsc --noEmit`
- pre-commit hook: full `jest` suite, 109 suites / 1287 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MRR (monthly recurring revenue) is now tracked for subscription billing and surfaced in revenue/analytics.
  * Paid-start events are recorded idempotently and aggregated daily by tier/plan/billing interval for funnel reporting.
  * Per-user analytics payloads now include paid-start counts, billing interval details, and MRR fields.

* **Documentation**
  * Unit economics docs updated with MRR guidance and paid-start rollup/backfill instructions.

* **Tests**
  * Added coverage for MRR normalization and paid-start idempotency/aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->