### PR TITLE
[codex] Harden Perplexity web search retries

### DIFF
--- a/lib/ai/tools/__tests__/web-search.test.ts
+++ b/lib/ai/tools/__tests__/web-search.test.ts
@@ -1,0 +1,220 @@
+import type { ToolContext } from "@/types";
+import { createWebSearch } from "../web-search";
+import { summarizePerplexityErrorBody } from "../utils/perplexity";
+
+const HTML_504 = `
+<html>
+  <body>
+    <h1>Sorry! There was a server error while processing your request.</h1>
+    <h2>Please try again shortly.</h2>
+    <div class="cf-error-details cf-error-504">
+      <h1>Gateway time-out</h1>
+      <p>The web server reported a gateway time-out error.</p>
+      <ul>
+        <li>Ray ID: a0611dc9caa93928</li>
+        <li>Your IP address: 54.81.73.203</li>
+        <li>Error reference number: 504</li>
+      </ul>
+    </div>
+  </body>
+</html>`;
+
+function makeContext(onToolCost = jest.fn()): ToolContext {
+  return {
+    userLocation: { country: "US" },
+    onToolCost,
+  } as unknown as ToolContext;
+}
+
+async function runTool(
+  tool: ReturnType<typeof createWebSearch>,
+  input: Record<string, unknown>,
+) {
+  const execute = (
+    tool as unknown as {
+      execute: (i: unknown, o: unknown) => Promise<unknown>;
+    }
+  ).execute;
+
+  return execute(input, {
+    toolCallId: "call-1",
+    abortSignal: undefined,
+    messages: [],
+  });
+}
+
+function response(
+  body: string,
+  init: {
+    headers?: Record<string, string>;
+    status: number;
+    statusText?: string;
+  },
+): Response {
+  const headers = new Map(
+    Object.entries(init.headers || {}).map(([key, value]) => [
+      key.toLowerCase(),
+      value,
+    ]),
+  );
+
+  return {
+    ok: init.status >= 200 && init.status < 300,
+    status: init.status,
+    statusText: init.statusText || "",
+    headers: {
+      get: (key: string) => headers.get(key.toLowerCase()) || null,
+    },
+    text: jest.fn(async () => body),
+    json: jest.fn(async () => JSON.parse(body)),
+  } as unknown as Response;
+}
+
+describe("web_search", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.PERPLEXITY_API_KEY = "test-key";
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.PERPLEXITY_API_KEY;
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("sanitizes Perplexity HTML error bodies", () => {
+    const summary = summarizePerplexityErrorBody(HTML_504, "text/html");
+
+    expect(summary).toContain("Gateway time-out");
+    expect(summary).toContain("gateway time-out error");
+    expect(summary).not.toContain("<html");
+    expect(summary).not.toContain("54.81.73.203");
+    expect(summary).not.toContain("a0611dc9caa93928");
+  });
+
+  it("retries a transient 504 and returns results when a later attempt succeeds", async () => {
+    jest.useFakeTimers();
+
+    const onToolCost = jest.fn();
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        response(HTML_504, {
+          status: 504,
+          statusText: "Gateway Timeout",
+          headers: { "content-type": "text/html" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        response(
+          JSON.stringify({
+            id: "search-1",
+            results: [
+              {
+                title: "Perplexity status",
+                url: "https://status.perplexity.ai",
+                snippet: "Service status page",
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      );
+
+    const resultPromise = runTool(createWebSearch(makeContext(onToolCost)), {
+      queries: ["perplexity status"],
+      brief: "check provider status",
+    });
+    await jest.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([
+      {
+        title: "Perplexity status",
+        url: "https://status.perplexity.ai",
+        content: "Service status page",
+        date: null,
+        lastUpdated: null,
+      },
+    ]);
+    expect(onToolCost).toHaveBeenCalledWith(0.005);
+    expect(console.warn).toHaveBeenCalledWith(
+      "Web search provider error; retrying",
+      expect.objectContaining({
+        attempt: 1,
+        maxAttempts: 3,
+        status: 504,
+        bodySummary: expect.stringContaining("Gateway time-out"),
+      }),
+    );
+  });
+
+  it("returns a compact fallback message after repeated 504s", async () => {
+    jest.useFakeTimers();
+
+    global.fetch = jest.fn().mockResolvedValue(
+      response(HTML_504, {
+        status: 504,
+        statusText: "Gateway Timeout",
+        headers: { "content-type": "text/html" },
+      }),
+    );
+
+    const resultPromise = runTool(createWebSearch(makeContext()), {
+      queries: ["perplexity status"],
+      brief: "check provider status",
+    });
+    await jest.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(result).toBe(
+      "Error performing web search: Perplexity search is temporarily unavailable (HTTP 504 Gateway Timeout after 3 attempts). Please retry shortly or continue without live web results if the task can proceed.",
+    );
+    expect(result).not.toContain("<html");
+    expect(result).not.toContain("54.81.73.203");
+
+    expect(console.error).toHaveBeenCalledWith(
+      "Web search tool error:",
+      expect.objectContaining({
+        name: "PerplexityApiError",
+        status: 504,
+        retryable: true,
+        bodySummary: expect.stringContaining("Gateway time-out"),
+      }),
+    );
+    const loggedPayload = (console.error as jest.Mock).mock.calls[0][1] as {
+      bodySummary: string;
+    };
+    expect(loggedPayload.bodySummary).not.toContain("<html");
+    expect(loggedPayload.bodySummary).not.toContain("54.81.73.203");
+  });
+
+  it("does not retry authorization failures", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      response(JSON.stringify({ error: "invalid api key" }), {
+        status: 401,
+        statusText: "Unauthorized",
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const result = await runTool(createWebSearch(makeContext()), {
+      queries: ["perplexity status"],
+      brief: "check provider status",
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(result).toBe(
+      "Error performing web search: Perplexity search is not authorized (HTTP 401 Unauthorized). Check the Perplexity API key or account access.",
+    );
+  });
+});

--- a/lib/ai/tools/utils/perplexity.ts
+++ b/lib/ai/tools/utils/perplexity.ts
@@ -22,6 +22,140 @@ export interface PerplexitySearchResponse {
   id: string;
 }
 
+export class PerplexityApiError extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  readonly bodySummary: string;
+  readonly retryable: boolean;
+
+  constructor({
+    status,
+    statusText,
+    bodySummary,
+    retryable,
+  }: {
+    status: number;
+    statusText: string;
+    bodySummary: string;
+    retryable: boolean;
+  }) {
+    const statusLabel = statusText ? `${status} ${statusText}` : `${status}`;
+    const summary = bodySummary ? `: ${bodySummary}` : "";
+    super(`Perplexity API error ${statusLabel}${summary}`);
+    this.name = "PerplexityApiError";
+    this.status = status;
+    this.statusText = statusText;
+    this.bodySummary = bodySummary;
+    this.retryable = retryable;
+  }
+}
+
+const ERROR_BODY_SUMMARY_MAX_LENGTH = 400;
+
+const RETRYABLE_PERPLEXITY_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+
+const HTML_ENTITY_MAP: Record<string, string> = {
+  amp: "&",
+  gt: ">",
+  lt: "<",
+  nbsp: " ",
+  quot: '"',
+  "#160": " ",
+  "#39": "'",
+};
+
+const normalizeWhitespace = (value: string): string =>
+  value.replace(/\s+/g, " ").trim();
+
+const decodeBasicHtmlEntities = (value: string): string =>
+  value.replace(/&([a-zA-Z0-9#]+);/g, (match, entity) => {
+    return HTML_ENTITY_MAP[entity] ?? match;
+  });
+
+const stripHtml = (value: string): string =>
+  normalizeWhitespace(
+    decodeBasicHtmlEntities(
+      value
+        .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+        .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+        .replace(/<[^>]+>/g, " "),
+    ),
+  );
+
+const extractHtmlTagText = (html: string, tagName: string): string[] => {
+  const matches = html.matchAll(
+    new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)<\\/${tagName}>`, "gi"),
+  );
+
+  return Array.from(matches)
+    .map((match) => stripHtml(match[1] ?? ""))
+    .filter(Boolean);
+};
+
+const redactNetworkDetails = (value: string): string =>
+  value
+    .replace(
+      /\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)\b/g,
+      "[Redacted IP]",
+    )
+    .replace(/\bRay ID:\s*[a-f0-9]+\b/gi, "Ray ID: [Redacted]");
+
+const truncateSummary = (value: string): string =>
+  value.length > ERROR_BODY_SUMMARY_MAX_LENGTH
+    ? `${value.slice(0, ERROR_BODY_SUMMARY_MAX_LENGTH - 1)}…`
+    : value;
+
+export const isRetryablePerplexityStatus = (status: number): boolean =>
+  RETRYABLE_PERPLEXITY_STATUSES.has(status);
+
+export const summarizePerplexityErrorBody = (
+  body: string,
+  contentType = "",
+): string => {
+  const trimmed = body.trim();
+  if (!trimmed) return "";
+
+  let summary = "";
+
+  if (contentType.includes("json") || trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed) as {
+        error?: unknown;
+        message?: unknown;
+        detail?: unknown;
+      };
+      const error =
+        typeof parsed.error === "string"
+          ? parsed.error
+          : parsed.error &&
+              typeof parsed.error === "object" &&
+              "message" in parsed.error &&
+              typeof parsed.error.message === "string"
+            ? parsed.error.message
+            : undefined;
+      const message =
+        error ||
+        (typeof parsed.message === "string" ? parsed.message : undefined) ||
+        (typeof parsed.detail === "string" ? parsed.detail : undefined);
+      summary = message || trimmed;
+    } catch {
+      summary = trimmed;
+    }
+  } else if (/<[a-z][\s\S]*>/i.test(trimmed)) {
+    const tagSummaries = [
+      ...extractHtmlTagText(trimmed, "h1"),
+      ...extractHtmlTagText(trimmed, "p"),
+      ...extractHtmlTagText(trimmed, "h2"),
+    ];
+    summary =
+      tagSummaries.length > 0 ? tagSummaries.join(". ") : stripHtml(trimmed);
+  } else {
+    summary = trimmed;
+  }
+
+  return truncateSummary(redactNetworkDetails(normalizeWhitespace(summary)));
+};
+
 export interface FormattedSearchResult {
   title: string;
   url: string;

--- a/lib/ai/tools/web-search.ts
+++ b/lib/ai/tools/web-search.ts
@@ -1,12 +1,16 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { ToolContext } from "@/types";
+import { stringifyRedactedError } from "@/lib/utils/error-redaction";
 import {
+  PerplexityApiError,
   PerplexitySearchResult,
   PerplexitySearchResponse,
   RECENCY_MAP,
   buildPerplexitySearchBody,
   formatSearchResults,
+  isRetryablePerplexityStatus,
+  summarizePerplexityErrorBody,
 } from "./utils/perplexity";
 
 /**
@@ -15,6 +19,143 @@ import {
  */
 /** Perplexity Search API cost: $5 per 1K requests */
 const WEB_SEARCH_COST_PER_REQUEST = 0.005;
+const PERPLEXITY_SEARCH_URL = "https://api.perplexity.ai/search";
+const WEB_SEARCH_MAX_ATTEMPTS = 3;
+const WEB_SEARCH_RETRY_BASE_DELAY_MS = 300;
+const WEB_SEARCH_RETRY_JITTER_MS = 75;
+
+const sleep = (delayMs: number, signal?: AbortSignal): Promise<void> => {
+  if (delayMs <= 0) return Promise.resolve();
+  if (signal?.aborted) {
+    return Promise.reject(new DOMException("Operation aborted", "AbortError"));
+  }
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => signal?.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      cleanup();
+      reject(new DOMException("Operation aborted", "AbortError"));
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, delayMs);
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+};
+
+const getRetryDelayMs = (attemptIndex: number): number => {
+  const exponentialDelay =
+    WEB_SEARCH_RETRY_BASE_DELAY_MS * Math.pow(2, attemptIndex);
+  const jitter = Math.random() * WEB_SEARCH_RETRY_JITTER_MS;
+  return Math.round(exponentialDelay + jitter);
+};
+
+const createPerplexityApiError = async (
+  response: Response,
+): Promise<PerplexityApiError> => {
+  const errorText = await response.text();
+  const bodySummary = summarizePerplexityErrorBody(
+    errorText,
+    response.headers.get("content-type") || "",
+  );
+
+  return new PerplexityApiError({
+    status: response.status,
+    statusText: response.statusText,
+    bodySummary,
+    retryable: isRetryablePerplexityStatus(response.status),
+  });
+};
+
+const formatPerplexityFailureForTool = (
+  error: PerplexityApiError,
+  attempts: number,
+): string => {
+  const statusText = error.statusText ? ` ${error.statusText}` : "";
+
+  if (error.retryable) {
+    return `Error performing web search: Perplexity search is temporarily unavailable (HTTP ${error.status}${statusText} after ${attempts} attempts). Please retry shortly or continue without live web results if the task can proceed.`;
+  }
+
+  if (error.status === 401 || error.status === 403) {
+    return `Error performing web search: Perplexity search is not authorized (HTTP ${error.status}${statusText}). Check the Perplexity API key or account access.`;
+  }
+
+  return `Error performing web search: Perplexity search failed (HTTP ${error.status}${statusText}).`;
+};
+
+const fetchPerplexitySearch = async (
+  searchBody: Record<string, unknown>,
+  abortSignal?: AbortSignal,
+): Promise<Response> => {
+  for (
+    let attemptIndex = 0;
+    attemptIndex < WEB_SEARCH_MAX_ATTEMPTS;
+    attemptIndex++
+  ) {
+    const attempt = attemptIndex + 1;
+    const isFinalAttempt = attempt === WEB_SEARCH_MAX_ATTEMPTS;
+
+    try {
+      const response = await fetch(PERPLEXITY_SEARCH_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${process.env.PERPLEXITY_API_KEY || ""}`,
+        },
+        body: JSON.stringify(searchBody),
+        signal: abortSignal,
+      });
+
+      if (response.ok) {
+        return response;
+      }
+
+      const error = await createPerplexityApiError(response);
+
+      if (!error.retryable || isFinalAttempt) {
+        throw error;
+      }
+
+      const delayMs = getRetryDelayMs(attemptIndex);
+      console.warn("Web search provider error; retrying", {
+        attempt,
+        maxAttempts: WEB_SEARCH_MAX_ATTEMPTS,
+        status: error.status,
+        statusText: error.statusText,
+        bodySummary: error.bodySummary,
+        delayMs,
+      });
+      await sleep(delayMs, abortSignal);
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw error;
+      }
+
+      if (error instanceof PerplexityApiError) {
+        throw error;
+      }
+
+      if (isFinalAttempt) {
+        throw error;
+      }
+
+      const delayMs = getRetryDelayMs(attemptIndex);
+      console.warn("Web search network error; retrying", {
+        attempt,
+        maxAttempts: WEB_SEARCH_MAX_ATTEMPTS,
+        error: stringifyRedactedError(error),
+        delayMs,
+      });
+      await sleep(delayMs, abortSignal);
+    }
+  }
+
+  throw new Error("Web search failed before any Perplexity response was read");
+};
 
 export const createWebSearch = (context: ToolContext) => {
   const { userLocation, onToolCost } = context;
@@ -77,22 +218,7 @@ export const createWebSearch = (context: ToolContext) => {
           },
         );
 
-        const response = await fetch("https://api.perplexity.ai/search", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${process.env.PERPLEXITY_API_KEY || ""}`,
-          },
-          body: JSON.stringify(searchBody),
-          signal: abortSignal,
-        });
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          throw new Error(
-            `Perplexity API error: ${response.status} - ${errorText}`,
-          );
-        }
+        const response = await fetchPerplexitySearch(searchBody, abortSignal);
 
         // Report web search cost ($5 per 1K requests)
         onToolCost?.(WEB_SEARCH_COST_PER_REQUEST);
@@ -119,9 +245,23 @@ export const createWebSearch = (context: ToolContext) => {
         if (error instanceof Error && error.name === "AbortError") {
           return "Error: Operation aborted";
         }
-        console.error("Web search tool error:", error);
-        const errorMessage =
-          error instanceof Error ? error.message : "Unknown error occurred";
+
+        if (error instanceof PerplexityApiError) {
+          console.error("Web search tool error:", {
+            name: error.name,
+            status: error.status,
+            statusText: error.statusText,
+            retryable: error.retryable,
+            bodySummary: error.bodySummary,
+          });
+          return formatPerplexityFailureForTool(
+            error,
+            error.retryable ? WEB_SEARCH_MAX_ATTEMPTS : 1,
+          );
+        }
+
+        const errorMessage = stringifyRedactedError(error);
+        console.error("Web search tool error:", errorMessage);
         return `Error performing web search: ${errorMessage}`;
       }
     },


### PR DESCRIPTION
## What changed

- Added retry/backoff for transient Perplexity web-search failures including 408, 429, and 5xx responses.
- Added compact, sanitized Perplexity error handling so HTML error pages are not logged or returned in full.
- Added focused regression tests for Cloudflare/Perplexity 504 HTML timeout responses, retry success, compact final failure messaging, and auth failures.

## Why

Perplexity can return a full HTML Cloudflare 504 page when the upstream search API times out. The previous web-search tool threw the entire response body, which made logs and model-visible errors noisy and could expose network details such as IP addresses and Ray IDs.

## Impact

Transient upstream search failures now retry automatically, final failures give the model a short actionable fallback message, and logs retain useful status diagnostics without dumping full provider HTML.

## Validation

- `pnpm jest lib/ai/tools/__tests__/web-search.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint lib/ai/tools/web-search.ts lib/ai/tools/utils/perplexity.ts lib/ai/tools/__tests__/web-search.test.ts`
- Commit hook: `pnpm typecheck` and full `pnpm test` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Web search now automatically retries transient network failures for improved reliability
  * Error messages are sanitized to prevent exposure of sensitive information
  * Authorization and connection failures are handled appropriately with clear user feedback

* **Tests**
  * Added comprehensive test suite for web search functionality covering error scenarios and retry behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->