### PR TITLE
[codex] Harden chat title generation

### DIFF
--- a/lib/actions/__tests__/index.test.ts
+++ b/lib/actions/__tests__/index.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { UIMessage, UIMessageStreamWriter } from "ai";
+
+const mockGenerateText = jest.fn();
+const mockLanguageModel = jest.fn((modelName: string) => ({ modelName }));
+
+jest.mock("ai", () => ({
+  generateText: (...args: unknown[]) => mockGenerateText(...args),
+  Output: {
+    object: (config: unknown) => ({ type: "object", ...config }),
+  },
+}));
+
+jest.mock("@/lib/ai/providers", () => ({
+  myProvider: {
+    languageModel: (modelName: string) => mockLanguageModel(modelName),
+  },
+}));
+
+jest.mock("@/lib/api/chat-stream-helpers", () => ({
+  isXaiSafetyError: jest.fn(() => false),
+}));
+
+const { generateTitleFromUserMessage, generateTitleFromUserMessageWithWriter } =
+  require("../index") as typeof import("../index");
+
+const makeMessage = (text: string): UIMessage[] =>
+  [
+    {
+      id: "message-1",
+      role: "user",
+      parts: [{ type: "text", text }],
+    },
+  ] as UIMessage[];
+
+describe("generateTitleFromUserMessage", () => {
+  beforeEach(() => {
+    mockGenerateText.mockReset();
+    mockLanguageModel.mockClear();
+  });
+
+  it("uses the title generator model with a small but safe output budget", async () => {
+    mockGenerateText.mockResolvedValue({
+      output: { title: "Web Recon Tips" },
+    });
+
+    await expect(
+      generateTitleFromUserMessage(
+        makeMessage("how do I enumerate subdomains"),
+      ),
+    ).resolves.toBe("Web Recon Tips");
+
+    expect(mockLanguageModel).toHaveBeenCalledWith("title-generator-model");
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxOutputTokens: 64,
+        maxRetries: 1,
+        temperature: 0,
+      }),
+    );
+  });
+
+  it("falls back to the first user message when structured output parsing fails", async () => {
+    mockGenerateText.mockRejectedValue(
+      Object.assign(new Error("No object generated"), {
+        name: "AI_NoObjectGeneratedError",
+      }),
+    );
+
+    await expect(
+      generateTitleFromUserMessage(
+        makeMessage("what wrong you think with this chat title"),
+      ),
+    ).resolves.toBe("what wrong you think with");
+  });
+
+  it("writes the fallback title without logging when the title model fails", async () => {
+    mockGenerateText.mockRejectedValue(
+      new Error("Unexpected end of JSON input"),
+    );
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const writer = {
+      write: jest.fn(),
+    } as unknown as UIMessageStreamWriter;
+
+    await expect(
+      generateTitleFromUserMessageWithWriter(
+        makeMessage("debug truncated title JSON responses"),
+        writer,
+      ),
+    ).resolves.toBe("debug truncated title JSON responses");
+
+    expect(writer.write).toHaveBeenCalledWith({
+      type: "data-title",
+      data: { chatTitle: "debug truncated title JSON responses" },
+      transient: true,
+    });
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/lib/actions/__tests__/index.test.ts
+++ b/lib/actions/__tests__/index.test.ts
@@ -60,6 +60,25 @@ describe("generateTitleFromUserMessage", () => {
     );
   });
 
+  it("constrains generated titles to non-empty strings under the chat title limit", async () => {
+    mockGenerateText.mockResolvedValue({
+      output: { title: "Schema Bound Title" },
+    });
+
+    await generateTitleFromUserMessage(makeMessage("title schema check"));
+
+    const generateTextOptions = mockGenerateText.mock.calls[0][0] as {
+      output: {
+        schema: { safeParse: (value: unknown) => { success: boolean } };
+      };
+    };
+    const schema = generateTextOptions.output.schema;
+
+    expect(schema.safeParse({ title: "Valid Title" }).success).toBe(true);
+    expect(schema.safeParse({ title: "" }).success).toBe(false);
+    expect(schema.safeParse({ title: "x".repeat(101) }).success).toBe(false);
+  });
+
   it("falls back to the first user message when structured output parsing fails", async () => {
     mockGenerateText.mockRejectedValue(
       Object.assign(new Error("No object generated"), {

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -72,7 +72,14 @@ export const generateTitleFromUserMessage = async (
       },
       output: Output.object({
         schema: z.object({
-          title: z.string().describe("The generated title (3-5 words)"),
+          title: z
+            .string()
+            .trim()
+            .min(1)
+            .max(MAX_GENERATED_TITLE_LENGTH)
+            .describe(
+              "A concise chat title, 3-5 words, in the same language as the user message",
+            ),
         }),
       }),
       temperature: 0,

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -3,6 +3,10 @@ import { myProvider } from "@/lib/ai/providers";
 import { z } from "zod";
 import { isXaiSafetyError } from "@/lib/api/chat-stream-helpers";
 
+const MAX_GENERATED_TITLE_LENGTH = 100;
+const TITLE_GENERATION_MAX_OUTPUT_TOKENS = 64;
+const FALLBACK_TITLE_WORD_LIMIT = 5;
+
 const truncateMiddle = (text: string, maxLength: number): string => {
   if (text.length <= maxLength) return text;
 
@@ -11,6 +15,28 @@ const truncateMiddle = (text: string, maxLength: number): string => {
   const end = text.substring(text.length - halfLength);
 
   return `${start}...${end}`;
+};
+
+const normalizeTitle = (title: unknown): string | undefined => {
+  if (typeof title !== "string") return undefined;
+
+  const normalized = title
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!normalized) return undefined;
+
+  return normalized.substring(0, MAX_GENERATED_TITLE_LENGTH);
+};
+
+const fallbackTitleFromMessage = (message: string): string | undefined => {
+  const normalized = message.replace(/\s+/g, " ").trim();
+  if (!normalized) return undefined;
+
+  return normalizeTitle(
+    normalized.split(" ").slice(0, FALLBACK_TITLE_WORD_LIMIT).join(" "),
+  );
 };
 
 export const DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE = (
@@ -29,33 +55,41 @@ export const generateTitleFromUserMessage = async (
   truncatedMessages: UIMessage[],
 ): Promise<string | undefined> => {
   const firstMessage = truncatedMessages[0];
-  const textContent = firstMessage.parts
+  const textContent = (firstMessage?.parts ?? [])
     .filter((part: { type: string; text?: string }) => part.type === "text")
     .map((part: { type: string; text?: string }) => part.text || "")
     .join(" ");
+  const fallbackTitle = fallbackTitleFromMessage(textContent);
 
-  const { output } = await generateText({
-    model: myProvider.languageModel("title-generator-model"),
-    providerOptions: {
-      xai: {
-        // Disable storing the conversation in XAI's database
-        store: false,
+  try {
+    const { output } = await generateText({
+      model: myProvider.languageModel("title-generator-model"),
+      providerOptions: {
+        xai: {
+          // Disable storing the conversation in XAI's database
+          store: false,
+        },
       },
-    },
-    output: Output.object({
-      schema: z.object({
-        title: z.string().describe("The generated title (3-5 words)"),
+      output: Output.object({
+        schema: z.object({
+          title: z.string().describe("The generated title (3-5 words)"),
+        }),
       }),
-    }),
-    messages: [
-      {
-        role: "user",
-        content: DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE(textContent),
-      },
-    ],
-  });
+      temperature: 0,
+      maxOutputTokens: TITLE_GENERATION_MAX_OUTPUT_TOKENS,
+      maxRetries: 1,
+      messages: [
+        {
+          role: "user",
+          content: DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE(textContent),
+        },
+      ],
+    });
 
-  return output?.title;
+    return normalizeTitle(output?.title) ?? fallbackTitle;
+  } catch {
+    return fallbackTitle;
+  }
 };
 
 export const generateTitleFromUserMessageWithWriter = async (

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -75,7 +75,7 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "fallback-ask-model": or("google/gemini-3-flash-preview"),
     "fallback-gemini-3.5-flash": or("google/gemini-3.5-flash"),
     "fallback-grok-4.3": or("x-ai/grok-4.3"),
-    "title-generator-model": or("google/gemini-2.5-flash"),
+    "title-generator-model": or("google/gemini-3-flash-preview"),
   }) as Record<string, any>;
 
 const baseProviders = buildProviderMap(openrouter);
@@ -115,7 +115,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "fallback-ask-model": "Auto, an intelligent model router built by HackerAI",
   "fallback-gemini-3.5-flash": "Google Gemini 3.5 Flash",
   "fallback-grok-4.3": "Auto, an intelligent model router built by HackerAI",
-  "title-generator-model": "Google Gemini 2.5 Flash",
+  "title-generator-model": "Google Gemini 3 Flash",
 };
 
 export const getModelDisplayName = (modelName: ModelName): string => {


### PR DESCRIPTION
## Summary

- Move the chat title generator from `google/gemini-2.5-flash` to `google/gemini-3-flash-preview`.
- Add a safer title-generation path with deterministic settings, a larger output budget, generated-title cleanup, first-message fallback, and stricter schema validation for non-empty titles under the 100-character chat title limit.
- Add regression coverage for malformed structured output and title schema constraints so title generation no longer logs noisy errors or accepts invalid generated titles.

## Root Cause

The title generator used structured object parsing for a very small background call. When the provider returned truncated JSON such as `{ "title":`, the AI SDK raised `AI_NoObjectGeneratedError` / `AI_JSONParseError`, which produced noisy production logs even though the main chat request succeeded.

## Validation

- `pnpm jest lib/actions/__tests__/index.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` passed with existing unrelated warnings
- Pre-commit hook: `pnpm typecheck` and full `pnpm test` (`113` suites, `1308` tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Tests**
  * Added unit tests covering title generation, schema validation, fallback behavior, and transient write behavior.

* **Bug Fixes**
  * Improved chat title generation with safer handling and deterministic fallback so titles are always produced.

* **Chores**
  * Switched title-generation model to Gemini 3 Flash for improved performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->