### PR TITLE
[codex] Fix sandbox file size preflight

### DIFF
--- a/lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts
@@ -26,12 +26,16 @@ let mockConvexAction: jest.Mock;
 let consoleWarnSpy: jest.SpyInstance;
 let consoleErrorSpy: jest.SpyInstance;
 
-function makeSandbox(size: number, e2b = false) {
+function makeSandbox(size: number, e2b = false, windows = false) {
   return {
     ...(e2b ? {} : { sandboxKind: "centrifugo" as const }),
+    isWindows: jest.fn(() => windows),
     commands: {
       run: jest.fn(async (command: string) => {
-        if (command.startsWith("stat ")) {
+        if (command.includes("stat -c%s")) {
+          return { stdout: String(size), stderr: "", exitCode: 0 };
+        }
+        if (command.startsWith("for %I")) {
           return { stdout: String(size), stderr: "", exitCode: 0 };
         }
         if (command.includes("curl -fsSL -X PUT")) {
@@ -197,7 +201,7 @@ describe("uploadSandboxFileToConvex", () => {
     const sandbox = makeSandbox(1234, true);
     (sandbox.commands.run as jest.Mock).mockImplementation(
       async (command: string) => {
-        if (command.startsWith("stat ")) {
+        if (command.includes("stat -c%s")) {
           return { stdout: "1234", stderr: "", exitCode: 0 };
         }
         if (command.includes("curl -fsSL -X PUT")) {
@@ -219,6 +223,67 @@ describe("uploadSandboxFileToConvex", () => {
         mediaType: "image/png",
       }),
     ).rejects.toThrow(/curl: \(56\) response ended early/);
+  });
+
+  test("does not run Windows size fallback for E2B stat failures", async () => {
+    const sandbox = makeSandbox(0, true);
+    (sandbox.commands.run as jest.Mock).mockResolvedValueOnce({
+      stdout: "",
+      stderr: "File not found: /home/user/missing.zip\n",
+      exitCode: 66,
+    });
+
+    await expect(
+      uploadSandboxFileToConvex({
+        sandbox: sandbox as any,
+        userId: "u1",
+        fullPath: "/home/user/missing.zip",
+      }),
+    ).rejects.toThrow(/File not found: \/home\/user\/missing\.zip/);
+
+    expect(sandbox.commands.run).toHaveBeenCalledTimes(1);
+    expect(mockGenerateS3UploadUrl).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"event":"sandbox_generated_file_size_failed"'),
+    );
+    expect(consoleErrorSpy.mock.calls[0][0]).not.toContain("windows_exit_code");
+  });
+
+  test("uses Windows size fallback for Windows Centrifugo sandboxes", async () => {
+    const sandbox = makeSandbox(0, false, true);
+    (sandbox.commands.run as jest.Mock).mockImplementation(
+      async (command: string) => {
+        if (command.includes("stat -c%s")) {
+          return {
+            stdout: "",
+            stderr: "'[' is not recognized as an internal or external command",
+            exitCode: 1,
+          };
+        }
+        if (command.startsWith("for %I")) {
+          return { stdout: "4321", stderr: "", exitCode: 0 };
+        }
+        return { stdout: "", stderr: "unexpected command", exitCode: 1 };
+      },
+    );
+
+    await uploadSandboxFileToConvex({
+      sandbox: sandbox as any,
+      userId: "u1",
+      fullPath: "C:\\Users\\user\\report.zip",
+    });
+
+    expect(sandbox.commands.run).toHaveBeenNthCalledWith(
+      2,
+      'for %I in ("C:\\Users\\user\\report.zip") do @echo %~zI',
+      expect.objectContaining({ displayName: "" }),
+    );
+    expect(mockGenerateS3UploadUrl).toHaveBeenCalledWith(
+      "report.zip",
+      "application/octet-stream",
+      "u1",
+      4321,
+    );
   });
 
   test("derives the file name from Windows-style paths", async () => {

--- a/lib/ai/tools/utils/sandbox-file-uploader.ts
+++ b/lib/ai/tools/utils/sandbox-file-uploader.ts
@@ -4,7 +4,7 @@ import { ConvexError } from "convex/values";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
 import type { AnySandbox } from "@/types";
-import { isE2BSandbox } from "./sandbox-types";
+import { isCentrifugoSandbox, isE2BSandbox } from "./sandbox-types";
 import { buildSandboxCommandOptions } from "./sandbox-command-options";
 import { generateS3UploadUrl } from "@/convex/s3Utils";
 import { getConvexClient } from "@/lib/db/convex-client";
@@ -47,6 +47,32 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+function shouldTryWindowsFileSizeFallback(sandbox: AnySandbox): boolean {
+  return isCentrifugoSandbox(sandbox) && sandbox.isWindows();
+}
+
+function formatFileSizeFailure(
+  fullPath: string,
+  statResult: SandboxCommandResult,
+  winResult?: SandboxCommandResult,
+): Error {
+  const details = [
+    statResult.stderr,
+    statResult.stdout,
+    winResult?.stderr,
+    winResult?.stdout,
+  ]
+    .map((value) => value?.trim())
+    .filter(Boolean)
+    .join("; ");
+
+  return new Error(
+    `Failed to get file size for ${fullPath}: ${
+      details || `stat command failed with exit code ${statResult.exitCode}`
+    }`,
+  );
+}
+
 async function getSandboxFileSize(
   sandbox: AnySandbox,
   fullPath: string,
@@ -56,7 +82,7 @@ async function getSandboxFileSize(
   let statResult: SandboxCommandResult;
   try {
     statResult = await sandbox.commands.run(
-      `stat -c%s ${quotedPath} 2>/dev/null || stat -f%z ${quotedPath} 2>/dev/null`,
+      `if [ ! -e ${quotedPath} ] && [ ! -L ${quotedPath} ]; then printf 'File not found: %s\\n' ${quotedPath} >&2; exit 66; fi; stat -c%s ${quotedPath} 2>/dev/null || stat -f%z ${quotedPath}`,
       { ...commandOptions, displayName: "" } as typeof commandOptions & {
         displayName?: string;
       },
@@ -84,6 +110,20 @@ async function getSandboxFileSize(
   let fileSize = parseInt(statResult.stdout.trim(), 10);
   if (!isNaN(fileSize) && statResult.exitCode === 0) {
     return fileSize;
+  }
+
+  if (!shouldTryWindowsFileSizeFallback(sandbox)) {
+    logger.error("sandbox_generated_file_size_failed", undefined, {
+      event: "sandbox_generated_file_size_failed",
+      service: "chat-handler",
+      sandbox_type: getSandboxLogType(sandbox),
+      file_name: getFileNameFromPath(fullPath),
+      file_path: fullPath,
+      stat_exit_code: statResult.exitCode,
+      stat_stderr: statResult.stderr?.slice(0, 500),
+      stat_stdout: statResult.stdout?.slice(0, 500),
+    });
+    throw formatFileSizeFailure(fullPath, statResult);
   }
 
   // Windows cmd.exe fallback: %~zI expands to the file size.
@@ -136,11 +176,7 @@ async function getSandboxFileSize(
     windows_stderr: winResult.stderr?.slice(0, 500),
     windows_stdout: winResult.stdout?.slice(0, 500),
   });
-  throw new Error(
-    `Failed to get file size for ${fullPath}: ${
-      statResult.stderr || winResult.stderr || "stat command failed"
-    }`,
-  );
+  throw formatFileSizeFailure(fullPath, statResult, winResult);
 }
 
 function assertSandboxFileSizeAllowed(fileName: string, size: number): void {


### PR DESCRIPTION
## Summary
- Keep the Windows `cmd.exe` file-size fallback scoped to Windows local sandboxes instead of running it for E2B/Linux failures.
- Add an existence check to the POSIX size probe so missing generated files report a clear `File not found` error.
- Preserve the original `stat` failure details in logs and add regression coverage for E2B and Windows fallback behavior.

## Root Cause
When `get_terminal_files` tried to attach an E2B-generated file whose `stat` probe failed, the uploader always attempted a Windows-only `for %I ...` fallback. Because E2B runs bash, that fallback produced a misleading syntax error and obscured the real missing/wrong-path file-size failure.

## Validation
- `pnpm jest lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint lib/ai/tools/utils/sandbox-file-uploader.ts lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts`
- `pnpm exec prettier --check lib/ai/tools/utils/sandbox-file-uploader.ts lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts`
- Pre-commit hook: `pnpm typecheck` and full `pnpm test` (112 suites / 1306 tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved sandbox file-size detection with Windows-specific fallback behavior when standard detection fails
  * Enhanced error handling and logging for file size operation failures

* **Tests**
  * Added comprehensive test coverage for Windows sandbox fallback scenarios across different sandbox types
  * Verified proper error reporting when file size detection fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->