### PR TITLE
[codex] Guard file reads against oversized text

### DIFF
--- a/lib/ai/tools/__tests__/file.test.ts
+++ b/lib/ai/tools/__tests__/file.test.ts
@@ -65,15 +65,22 @@ async function runTool(
 
 function makeSandbox(
   commandRun: jest.Mock<Promise<FakeCommandResult>, [string, any?]>,
+  opts?: { windows?: boolean },
 ) {
   return {
+    ...(opts?.windows
+      ? {
+          sandboxKind: "centrifugo" as const,
+          isWindows: () => true,
+        }
+      : {}),
     commands: { run: commandRun },
     files: {
       read: jest.fn(async () => {
         throw new Error("files.read should not be called");
       }),
       write: jest.fn(async () => undefined),
-      remove: jest.fn(),
+      remove: jest.fn(async () => undefined),
       list: jest.fn(),
     },
   };
@@ -139,7 +146,11 @@ describe("file tool large text safety", () => {
 
   test("refuses edit on oversized files before reading them", async () => {
     const commandRun = jest.fn(async () => ({
-      stdout: "5000000\n",
+      stdout: JSON.stringify({
+        kind: "file",
+        path: "/tmp/download.php",
+        sizeBytes: 5_000_000,
+      }),
       stderr: "",
       exitCode: 0,
     }));
@@ -161,7 +172,11 @@ describe("file tool large text safety", () => {
     const commandRun = jest
       .fn<Promise<FakeCommandResult>, [string, any?]>()
       .mockResolvedValueOnce({
-        stdout: "5000000\n",
+        stdout: JSON.stringify({
+          kind: "file",
+          path: "/tmp/download.php",
+          sizeBytes: 5_000_000,
+        }),
         stderr: "",
         exitCode: 0,
       })
@@ -186,6 +201,126 @@ describe("file tool large text safety", () => {
       "\nnew line\n",
       { user: "user" },
     );
+    expect(sandbox.files.read).not.toHaveBeenCalled();
+  });
+
+  test("fails closed when file size cannot be determined", async () => {
+    const commandRun = jest
+      .fn<Promise<FakeCommandResult>, [string, any?]>()
+      .mockResolvedValueOnce({
+        stdout: "",
+        stderr: "python missing",
+        exitCode: 1,
+      })
+      .mockResolvedValueOnce({
+        stdout: "",
+        stderr: "python missing",
+        exitCode: 1,
+      });
+    const sandbox = makeSandbox(commandRun);
+    const tool = createFile(makeContext(sandbox));
+
+    const result = (await runTool(tool, {
+      action: "read",
+      path: "/tmp/download.php",
+      brief: "Read when size probe fails",
+    })) as { error: string };
+
+    expect(result.error).toContain("Unable to determine file size");
+    expect(sandbox.files.read).not.toHaveBeenCalled();
+  });
+
+  test("uses a Windows-compatible Python script path for bounded reads", async () => {
+    const commandRun = jest
+      .fn<Promise<FakeCommandResult>, [string, any?]>()
+      .mockResolvedValueOnce({
+        stdout: "$BASH_VERSION\r\n",
+        stderr: "",
+        exitCode: 0,
+      })
+      .mockImplementationOnce(async (command, opts) => {
+        expect(command).toMatch(/^python "C:\\temp\\hackerai_script_/);
+        expect(command).not.toContain("<<'PY'");
+        expect(opts.envVars.HACKERAI_FILE_READ_PATH).toBe(
+          "C:\\temp\\download.php",
+        );
+        return {
+          stdout: JSON.stringify({
+            path: "C:\\temp\\download.php",
+            sizeBytes: 5_000_000,
+            totalLines: 2_216_265,
+            content: "line 500\nline 501\n",
+            startLine: 500,
+            truncated: false,
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      });
+    const sandbox = makeSandbox(commandRun, { windows: true });
+    const tool = createFile(makeContext(sandbox));
+
+    const result = (await runTool(tool, {
+      action: "read",
+      path: "/tmp/download.php",
+      brief: "Read a range on Windows",
+      range: [500, 501],
+    })) as { content: string };
+
+    expect(result.content).toContain("   500|line 500");
+    expect(result.content).toContain("   501|line 501");
+    expect(sandbox.files.read).not.toHaveBeenCalled();
+  });
+
+  test("oversized append on Windows does not use POSIX cat/rm commands", async () => {
+    const commandRun = jest
+      .fn<Promise<FakeCommandResult>, [string, any?]>()
+      .mockResolvedValueOnce({
+        stdout: "$BASH_VERSION\r\n",
+        stderr: "",
+        exitCode: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          kind: "file",
+          path: "C:\\temp\\download.php",
+          sizeBytes: 5_000_000,
+        }),
+        stderr: "",
+        exitCode: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: "$BASH_VERSION\r\n",
+        stderr: "",
+        exitCode: 0,
+      })
+      .mockImplementationOnce(async (command, opts) => {
+        expect(command).toMatch(/^python "C:\\temp\\hackerai_script_/);
+        expect(command).not.toContain("cat ");
+        expect(command).not.toContain("rm -f");
+        expect(opts.envVars.HACKERAI_FILE_APPEND_TARGET_PATH).toBe(
+          "C:\\temp\\download.php",
+        );
+        expect(opts.envVars.HACKERAI_FILE_APPEND_SOURCE_PATH).toMatch(
+          /^C:\\temp\\hackerai_append_/,
+        );
+        return {
+          stdout: "",
+          stderr: "",
+          exitCode: 0,
+        };
+      });
+    const sandbox = makeSandbox(commandRun, { windows: true });
+    const tool = createFile(makeContext(sandbox));
+
+    const result = (await runTool(tool, {
+      action: "append",
+      path: "/tmp/download.php",
+      brief: "Append safely on Windows",
+      text: "\nnew line\n",
+    })) as { content: string };
+
+    expect(result.content).toContain("full diff preview was skipped");
     expect(sandbox.files.read).not.toHaveBeenCalled();
   });
 });

--- a/lib/ai/tools/__tests__/file.test.ts
+++ b/lib/ai/tools/__tests__/file.test.ts
@@ -1,0 +1,191 @@
+jest.mock("../utils/sandbox-file-uploader", () => ({
+  uploadSandboxFileToConvex: jest.fn(),
+}));
+
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: { event: jest.fn() },
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn() },
+}));
+
+import { createFile } from "../file";
+import type { ToolContext } from "@/types";
+
+type FakeCommandResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+function makeContext(sandbox: unknown): ToolContext {
+  return {
+    sandboxManager: {
+      getSandbox: jest.fn(async () => ({ sandbox })),
+      setSandbox: jest.fn(),
+      getSandboxType: jest.fn(),
+      getSandboxInfo: jest.fn(() => null),
+      getEffectivePreference: jest.fn(() => "e2b"),
+      recordHealthFailure: jest.fn(() => false),
+      resetHealthFailures: jest.fn(),
+      isSandboxUnavailable: jest.fn(() => false),
+    },
+    writer: { write: jest.fn() } as never,
+    userLocation: {} as never,
+    todoManager: {} as never,
+    userID: "user-1",
+    chatId: "chat-1",
+    fileAccumulator: {} as never,
+    backgroundProcessTracker: {} as never,
+    ptySessionManager: {} as never,
+    mode: "agent",
+    modelName: "openai/gpt-5",
+    subscription: "pro",
+    isE2BSandbox: (() => true) as never,
+    caidoEnabled: false,
+  };
+}
+
+async function runTool(
+  tool: ReturnType<typeof createFile>,
+  input: Record<string, unknown>,
+) {
+  const execute = (
+    tool as unknown as {
+      execute: (i: unknown, o: unknown) => Promise<unknown>;
+    }
+  ).execute;
+  return execute(input, {
+    toolCallId: "call-1",
+    abortSignal: undefined,
+    messages: [],
+  });
+}
+
+function makeSandbox(
+  commandRun: jest.Mock<Promise<FakeCommandResult>, [string, any?]>,
+) {
+  return {
+    commands: { run: commandRun },
+    files: {
+      read: jest.fn(async () => {
+        throw new Error("files.read should not be called");
+      }),
+      write: jest.fn(async () => undefined),
+      remove: jest.fn(),
+      list: jest.fn(),
+    },
+  };
+}
+
+describe("file tool large text safety", () => {
+  test("does not load oversized files for full reads", async () => {
+    const commandRun = jest.fn(async () => ({
+      stdout: JSON.stringify({
+        path: "/tmp/download.php",
+        sizeBytes: 5_000_000,
+        totalLines: 2_216_265,
+        tooLarge: true,
+      }),
+      stderr: "",
+      exitCode: 0,
+    }));
+    const sandbox = makeSandbox(commandRun);
+    const tool = createFile(makeContext(sandbox));
+
+    const result = (await runTool(tool, {
+      action: "read",
+      path: "/tmp/download.php",
+      brief: "Read a large file",
+    })) as { content: string };
+
+    expect(result.content).toContain("too large to read in full");
+    expect(result.content).toContain("range [1, 200]");
+    expect(sandbox.files.read).not.toHaveBeenCalled();
+  });
+
+  test("reads ranges through the bounded sandbox-side path", async () => {
+    const commandRun = jest.fn(async (_command, opts) => {
+      expect(opts.envVars.HACKERAI_FILE_READ_RANGE_START).toBe("500");
+      expect(opts.envVars.HACKERAI_FILE_READ_RANGE_END).toBe("501");
+      return {
+        stdout: JSON.stringify({
+          path: "/tmp/download.php",
+          sizeBytes: 5_000_000,
+          totalLines: 2_216_265,
+          content: "line 500\nline 501\n",
+          startLine: 500,
+          truncated: false,
+        }),
+        stderr: "",
+        exitCode: 0,
+      };
+    });
+    const sandbox = makeSandbox(commandRun);
+    const tool = createFile(makeContext(sandbox));
+
+    const result = (await runTool(tool, {
+      action: "read",
+      path: "/tmp/download.php",
+      brief: "Read a range",
+      range: [500, 501],
+    })) as { content: string };
+
+    expect(result.content).toContain("   500|line 500");
+    expect(result.content).toContain("   501|line 501");
+    expect(sandbox.files.read).not.toHaveBeenCalled();
+  });
+
+  test("refuses edit on oversized files before reading them", async () => {
+    const commandRun = jest.fn(async () => ({
+      stdout: "5000000\n",
+      stderr: "",
+      exitCode: 0,
+    }));
+    const sandbox = makeSandbox(commandRun);
+    const tool = createFile(makeContext(sandbox));
+
+    const result = (await runTool(tool, {
+      action: "edit",
+      path: "/tmp/download.php",
+      brief: "Patch a huge file",
+      edits: [{ find: "old", replace: "new" }],
+    })) as { error: string };
+
+    expect(result.error).toContain("too large for the edit action");
+    expect(sandbox.files.read).not.toHaveBeenCalled();
+  });
+
+  test("appends to oversized files without reading existing content", async () => {
+    const commandRun = jest
+      .fn<Promise<FakeCommandResult>, [string, any?]>()
+      .mockResolvedValueOnce({
+        stdout: "5000000\n",
+        stderr: "",
+        exitCode: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+      });
+    const sandbox = makeSandbox(commandRun);
+    const tool = createFile(makeContext(sandbox));
+
+    const result = (await runTool(tool, {
+      action: "append",
+      path: "/tmp/download.php",
+      brief: "Append safely",
+      text: "\nnew line\n",
+    })) as { content: string };
+
+    expect(result.content).toContain("full diff preview was skipped");
+    expect(sandbox.files.write).toHaveBeenCalledWith(
+      expect.stringContaining("/tmp/hackerai_append_"),
+      "\nnew line\n",
+      { user: "user" },
+    );
+    expect(sandbox.files.read).not.toHaveBeenCalled();
+  });
+});

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
-import type { ToolContext } from "@/types";
+import type { AnySandbox, ToolContext } from "@/types";
 import { truncateOutput } from "@/lib/token-utils";
 import { supportsMultimodalToolResults } from "@/lib/ai/providers";
 import { buildSandboxCommandOptions } from "./utils/sandbox-command-options";
@@ -11,6 +11,8 @@ import { logger } from "@/lib/logger";
 import { phLogger } from "@/lib/posthog/server";
 
 const MAX_VIEW_FILE_BYTES = 10 * 1024 * 1024;
+const MAX_TEXT_FILE_READ_BYTES = 1024 * 1024;
+const MAX_TEXT_READ_RESULT_BYTES = 1024 * 1024;
 const FILE_ACTIONS_WITH_VIEW = [
   "view",
   "read",
@@ -126,6 +128,102 @@ if include_data:
 emit(payload)
 `;
 
+const READ_TEXT_FILE_SCRIPT = String.raw`
+import json
+import os
+import sys
+
+path = os.environ["HACKERAI_FILE_READ_PATH"]
+range_start = int(os.environ.get("HACKERAI_FILE_READ_RANGE_START", "0"))
+range_end = int(os.environ.get("HACKERAI_FILE_READ_RANGE_END", "-1"))
+max_full_bytes = int(os.environ.get("HACKERAI_FILE_READ_MAX_FULL_BYTES", "1048576"))
+max_result_bytes = int(os.environ.get("HACKERAI_FILE_READ_MAX_RESULT_BYTES", "1048576"))
+
+def emit(payload, code=0):
+    print(json.dumps(payload, separators=(",", ":")))
+    sys.exit(code)
+
+if range_start < 0:
+    emit({"error": f"Invalid start_line: {range_start}. Line numbers are 1-indexed, must be >= 1."}, 2)
+if range_start > 0 and range_end != -1 and range_end < range_start:
+    emit({"error": f"Invalid range: start_line ({range_start}) cannot be greater than end_line ({range_end})."}, 2)
+
+if not os.path.isfile(path):
+    emit({"error": f"File not found or is not a regular file: {path}"}, 3)
+
+size = os.path.getsize(path)
+
+def count_lines(file_path, file_size):
+    if file_size == 0:
+        return 0
+    lines = 0
+    last_byte = b""
+    with open(file_path, "rb") as f:
+        while True:
+            chunk = f.read(1024 * 1024)
+            if not chunk:
+                break
+            lines += chunk.count(b"\n")
+            last_byte = chunk[-1:]
+    if last_byte != b"\n":
+        lines += 1
+    return lines
+
+total_lines = count_lines(path, size)
+if range_start == 0 and size > max_full_bytes:
+    emit({
+        "path": path,
+        "sizeBytes": size,
+        "totalLines": total_lines,
+        "tooLarge": True,
+    })
+
+if range_start > 0:
+    if range_start > total_lines:
+        emit({"error": f"Invalid start_line: {range_start}. File has {total_lines} lines (1-indexed)."}, 2)
+    if range_end != -1 and range_end > total_lines:
+        emit({"error": f"Invalid end_line: {range_end}. File has {total_lines} lines (1-indexed)."}, 2)
+
+selected = []
+selected_bytes = 0
+truncated = False
+start_line = range_start if range_start > 0 else 1
+
+def add_text(text):
+    global selected_bytes, truncated
+    encoded = text.encode("utf-8", errors="replace")
+    remaining = max_result_bytes - selected_bytes
+    if remaining <= 0:
+        truncated = True
+        return False
+    if len(encoded) > remaining:
+        selected.append(encoded[:remaining].decode("utf-8", errors="replace"))
+        selected_bytes = max_result_bytes
+        truncated = True
+        return False
+    selected.append(text)
+    selected_bytes += len(encoded)
+    return True
+
+with open(path, "r", encoding="utf-8", errors="replace", newline="") as f:
+    for line_no, line in enumerate(f, 1):
+        if range_start > 0 and line_no < range_start:
+            continue
+        if range_start > 0 and range_end != -1 and line_no > range_end:
+            break
+        if not add_text(line):
+            break
+
+emit({
+    "path": path,
+    "sizeBytes": size,
+    "totalLines": total_lines,
+    "content": "".join(selected),
+    "startLine": start_line,
+    "truncated": truncated,
+})
+`;
+
 const getFilename = (path: string) => path.split("/").pop() || path;
 
 const getFileExtension = (path: string): string | undefined => {
@@ -234,6 +332,294 @@ function errorToLog(error: unknown) {
   }
 
   return { message: String(error) };
+}
+
+type SandboxCommandResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  error?: string;
+};
+
+type SandboxTextReadPayload = {
+  path: string;
+  sizeBytes: number;
+  totalLines: number;
+  content?: string;
+  startLine?: number;
+  tooLarge?: boolean;
+  truncated?: boolean;
+  error?: string;
+};
+
+function commandErrorToResult(error: unknown): SandboxCommandResult | null {
+  if (!(error instanceof Error)) return null;
+
+  const commandError = error as Error & {
+    exitCode?: unknown;
+    stdout?: unknown;
+    stderr?: unknown;
+  };
+
+  if (typeof commandError.exitCode !== "number") return null;
+
+  return {
+    stdout:
+      typeof commandError.stdout === "string"
+        ? commandError.stdout
+        : error.message,
+    stderr: typeof commandError.stderr === "string" ? commandError.stderr : "",
+    exitCode: commandError.exitCode,
+    error: error.message,
+  };
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(value >= 10 ? 1 : 2)} ${units[unitIndex]}`;
+}
+
+async function runSandboxCommand(
+  sandbox: AnySandbox,
+  command: string,
+  envVars?: Record<string, string>,
+  timeoutMs = 60_000,
+): Promise<SandboxCommandResult> {
+  try {
+    const result = await sandbox.commands.run(command, {
+      ...buildSandboxCommandOptions(sandbox, undefined, envVars),
+      envs: envVars,
+      timeoutMs,
+    } as ReturnType<typeof buildSandboxCommandOptions> & {
+      envs?: Record<string, string>;
+    });
+    return {
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      exitCode: typeof result.exitCode === "number" ? result.exitCode : 0,
+    };
+  } catch (error) {
+    const commandResult = commandErrorToResult(error);
+    if (commandResult) return commandResult;
+    throw error;
+  }
+}
+
+async function getSandboxFileSize(
+  sandbox: AnySandbox,
+  path: string,
+): Promise<number | null> {
+  const quotedPath = shellQuote(path);
+  const statResult = await runSandboxCommand(
+    sandbox,
+    `stat -c%s ${quotedPath} 2>/dev/null || stat -f%z ${quotedPath} 2>/dev/null`,
+    undefined,
+    30_000,
+  ).catch(() => null);
+
+  const statSize = statResult
+    ? Number.parseInt(statResult.stdout.trim(), 10)
+    : NaN;
+  if (statResult?.exitCode === 0 && Number.isFinite(statSize)) {
+    return statSize;
+  }
+
+  const escapedForCmd = path.replace(/"/g, '\\"');
+  const winResult = await runSandboxCommand(
+    sandbox,
+    `for %I in ("${escapedForCmd}") do @echo %~zI`,
+    undefined,
+    30_000,
+  ).catch(() => null);
+
+  const winSize = winResult
+    ? Number.parseInt(winResult.stdout.trim(), 10)
+    : NaN;
+  if (winResult?.exitCode === 0 && Number.isFinite(winSize)) {
+    return winSize;
+  }
+
+  return null;
+}
+
+function buildNumberedFileContent(args: {
+  filename: string;
+  content: string;
+  startLineNumber?: number;
+  truncated?: boolean;
+}): {
+  content: string;
+  originalContent: string;
+} {
+  const { filename, content, startLineNumber = 1, truncated } = args;
+  const lines = content.split("\n");
+  const numberedLines = lines.map((line, index) => {
+    const lineNumber = startLineNumber + index;
+    return `${lineNumber.toString().padStart(6)}|${line}`;
+  });
+
+  const truncatedNotice = truncated
+    ? `\n\n[Range output truncated at ${formatBytes(MAX_TEXT_READ_RESULT_BYTES)}. Request a narrower line range to continue.]`
+    : "";
+  const numberedContent = numberedLines.join("\n");
+  const result = `Text file: ${filename}\nLatest content with line numbers:\n${numberedContent}${truncatedNotice}`;
+
+  return {
+    content: truncateOutput({
+      content: result,
+      mode: "read-file",
+    }) as string,
+    originalContent: truncateOutput({
+      content,
+      mode: "read-file",
+    }),
+  };
+}
+
+async function readSandboxTextFile(
+  sandbox: AnySandbox,
+  path: string,
+  range?: number[],
+): Promise<SandboxTextReadPayload> {
+  const envVars = {
+    HACKERAI_FILE_READ_PATH: path,
+    HACKERAI_FILE_READ_RANGE_START: String(range?.[0] ?? 0),
+    HACKERAI_FILE_READ_RANGE_END: String(range?.[1] ?? -1),
+    HACKERAI_FILE_READ_MAX_FULL_BYTES: String(MAX_TEXT_FILE_READ_BYTES),
+    HACKERAI_FILE_READ_MAX_RESULT_BYTES: String(MAX_TEXT_READ_RESULT_BYTES),
+  };
+  const command = `PYTHON_BIN="$(command -v python3 || command -v python)" && "$PYTHON_BIN" - <<'PY'\n${READ_TEXT_FILE_SCRIPT}\nPY`;
+  const result = await runSandboxCommand(sandbox, command, envVars, 120_000);
+  const stdout = result.stdout.trim();
+  let payload: SandboxTextReadPayload;
+
+  try {
+    payload = JSON.parse(stdout);
+  } catch {
+    throw new Error(
+      `Failed to inspect text file: ${
+        result.stderr || stdout || "No output returned"
+      }`,
+    );
+  }
+
+  if (result.exitCode !== 0 || payload.error) {
+    throw new Error(payload.error || result.stderr || "Failed to read file");
+  }
+
+  return payload;
+}
+
+async function readSandboxTextFileWithFallback(
+  sandbox: AnySandbox,
+  path: string,
+  range?: number[],
+): Promise<SandboxTextReadPayload> {
+  try {
+    return await readSandboxTextFile(sandbox, path, range);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    if (
+      errorMessage.startsWith("Invalid ") ||
+      errorMessage.includes("File not found")
+    ) {
+      throw error;
+    }
+
+    const size = await getSandboxFileSize(sandbox, path);
+    if (size !== null && size > MAX_TEXT_FILE_READ_BYTES) {
+      if (range) {
+        throw new Error(
+          `Unable to perform a bounded range read for ${path}, and the file is too large to load safely (${formatBytes(size)}). Use a targeted terminal command that writes a small result to a separate file.`,
+        );
+      }
+
+      return {
+        path,
+        sizeBytes: size,
+        totalLines: 0,
+        tooLarge: true,
+      };
+    }
+
+    const fileContent = await sandbox.files.read(path, {
+      user: "user" as const,
+    });
+    const lines = fileContent.split("\n");
+
+    if (range) {
+      const [start, end] = range;
+      if (start < 1) {
+        throw new Error(
+          `Invalid start_line: ${start}. Line numbers are 1-indexed, must be >= 1.`,
+        );
+      }
+      if (end !== -1 && end < start) {
+        throw new Error(
+          `Invalid range: start_line (${start}) cannot be greater than end_line (${end}).`,
+        );
+      }
+      if (start > lines.length) {
+        throw new Error(
+          `Invalid start_line: ${start}. File has ${lines.length} lines (1-indexed).`,
+        );
+      }
+      if (end !== -1 && end > lines.length) {
+        throw new Error(
+          `Invalid end_line: ${end}. File has ${lines.length} lines (1-indexed).`,
+        );
+      }
+      const startIndex = start - 1;
+      const endIndex = end === -1 ? lines.length : end;
+      return {
+        path,
+        sizeBytes: Buffer.byteLength(fileContent),
+        totalLines: lines.length,
+        content: lines.slice(startIndex, endIndex).join("\n"),
+        startLine: start,
+      };
+    }
+
+    return {
+      path,
+      sizeBytes: Buffer.byteLength(fileContent),
+      totalLines: lines.length,
+      content: fileContent,
+      startLine: 1,
+    };
+  }
+}
+
+async function appendSandboxTextFile(
+  sandbox: AnySandbox,
+  path: string,
+  text: string,
+): Promise<void> {
+  const tempPath = `/tmp/hackerai_append_${Date.now()}_${Math.random().toString(36).slice(2)}.tmp`;
+  await sandbox.files.write(tempPath, text, {
+    user: "user" as const,
+  });
+
+  const result = await runSandboxCommand(
+    sandbox,
+    `cat ${shellQuote(tempPath)} >> ${shellQuote(path)} && rm -f ${shellQuote(tempPath)}`,
+    undefined,
+    60_000,
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || result.stdout || "Failed to append file");
+  }
 }
 
 const getSandboxViewPath = (sandbox: unknown, path: string): string => {
@@ -420,6 +806,7 @@ export const createFile = (context: ToolContext) => {
     "For extensive modifications to shorter files, use 'write' to rewrite the entire file instead of 'edit'.",
     "Under read action, the range parameter represents line number ranges (1-indexed, -1 for end of file).",
     "If the range parameter is not specified, the entire file will be read by default.",
+    "Oversized files are not loaded in full; read will return file metadata and range guidance instead.",
     "DO NOT use the range parameter when reading a file for the first time; if the content is too long and gets truncated, the result will include range hints.",
     "write and append actions will automatically create files if they do not exist.",
     "When writing and appending text, ensure necessary trailing newlines are used to comply with POSIX standards.",
@@ -562,80 +949,35 @@ ${instructionsDescription}`,
           }
 
           case "read": {
-            const fileContent = await sandbox.files.read(path, {
-              user: "user" as const,
-            });
+            const filename = path.split("/").pop() || path;
+            const readPayload = await readSandboxTextFileWithFallback(
+              sandbox,
+              path,
+              range,
+            );
 
-            if (!fileContent || fileContent.trim() === "") {
+            if (readPayload.tooLarge) {
+              const totalLines =
+                readPayload.totalLines > 0
+                  ? `${readPayload.totalLines} lines`
+                  : "line count unavailable";
+              return {
+                content: `Text file: ${filename}\nFile is too large to read in full (${formatBytes(readPayload.sizeBytes)}, ${totalLines}). Use the range parameter to read a smaller slice, e.g. range [1, 200].`,
+                originalContent: "",
+              };
+            }
+
+            if (!readPayload.content || readPayload.content.trim() === "") {
               return { error: "File is empty." };
             }
 
-            const lines = fileContent.split("\n");
-            const filename = path.split("/").pop() || path;
-            const totalLines = lines.length;
-
-            // Validate range if provided
-            if (range) {
-              const [start, end] = range;
-
-              if (start < 1) {
-                return {
-                  error: `Invalid start_line: ${start}. Line numbers are 1-indexed, must be >= 1.`,
-                };
-              }
-
-              if (end !== -1 && end < start) {
-                return {
-                  error: `Invalid range: start_line (${start}) cannot be greater than end_line (${end}).`,
-                };
-              }
-
-              if (start > totalLines) {
-                return {
-                  error: `Invalid start_line: ${start}. File ${filename} has ${totalLines} lines (1-indexed).`,
-                };
-              }
-
-              if (end !== -1 && end > totalLines) {
-                return {
-                  error: `Invalid end_line: ${end}. File ${filename} has ${totalLines} lines (1-indexed).`,
-                };
-              }
-            }
-
-            // Apply range if provided
-            let processedLines = lines;
-            let startLineNumber = 1;
-
-            if (range) {
-              const [start, end] = range;
-              startLineNumber = start;
-              const startIndex = start - 1; // Convert to 0-based index
-              const endIndex = end === -1 ? lines.length : end;
-              processedLines = lines.slice(startIndex, endIndex);
-            }
-
-            // Add line numbers (padded format with pipe separator)
-            const numberedLines = processedLines.map((line, index) => {
-              const lineNumber = startLineNumber + index;
-              return `${lineNumber.toString().padStart(6)}|${line}`;
-            });
-
-            const numberedContent = numberedLines.join("\n");
-            const result = `Text file: ${filename}\nLatest content with line numbers:\n${numberedContent}`;
-            const truncatedResult = truncateOutput({
-              content: result,
-              mode: "read-file",
-            }) as string;
-
             // Return object with raw content for UI and formatted content for model
-            return {
-              content: truncatedResult,
-              originalContent: truncateOutput({
-                content: processedLines.join("\n"),
-                mode: "read-file",
-              }),
-            };
+            return buildNumberedFileContent({
+              filename,
+              content: readPayload.content,
+              startLineNumber: readPayload.startLine,
+              truncated: readPayload.truncated,
+            });
           }
 
           case "write": {
@@ -653,6 +995,17 @@ ${instructionsDescription}`,
           case "append": {
             if (text === undefined) {
               return { error: "text is required for append action" };
+            }
+
+            const existingSize = await getSandboxFileSize(sandbox, path);
+            if (
+              existingSize !== null &&
+              existingSize > MAX_TEXT_FILE_READ_BYTES
+            ) {
+              await appendSandboxTextFile(sandbox, path, text);
+              return {
+                content: `File appended: ${path}\nExisting file is ${formatBytes(existingSize)}, so the full diff preview was skipped to avoid loading the entire file into memory.`,
+              };
             }
 
             // Read existing content first
@@ -690,6 +1043,16 @@ ${instructionsDescription}`,
           case "edit": {
             if (!edits || edits.length === 0) {
               return { error: "edits array is required for edit action" };
+            }
+
+            const existingSize = await getSandboxFileSize(sandbox, path);
+            if (
+              existingSize !== null &&
+              existingSize > MAX_TEXT_FILE_READ_BYTES
+            ) {
+              return {
+                error: `File ${path} is too large for the edit action (${formatBytes(existingSize)}). Use a targeted shell command, restore the file from a clean source, or replace it with the write action instead of loading the whole file into memory.`,
+              };
             }
 
             // Read existing content

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -224,6 +224,49 @@ emit({
 })
 `;
 
+const FILE_STATE_SCRIPT = String.raw`
+import json
+import os
+import sys
+
+path = os.environ["HACKERAI_FILE_STATE_PATH"]
+
+def emit(payload, code=0):
+    print(json.dumps(payload, separators=(",", ":")))
+    sys.exit(code)
+
+if not os.path.exists(path):
+    emit({"kind": "missing", "path": path})
+
+if not os.path.isfile(path):
+    emit({"kind": "not_file", "path": path})
+
+emit({
+    "kind": "file",
+    "path": path,
+    "sizeBytes": os.path.getsize(path),
+})
+`;
+
+const APPEND_TEXT_FILE_SCRIPT = String.raw`
+import os
+
+target_path = os.environ["HACKERAI_FILE_APPEND_TARGET_PATH"]
+source_path = os.environ["HACKERAI_FILE_APPEND_SOURCE_PATH"]
+
+with open(source_path, "rb") as source, open(target_path, "ab") as target:
+    while True:
+        chunk = source.read(1024 * 1024)
+        if not chunk:
+            break
+        target.write(chunk)
+
+try:
+    os.remove(source_path)
+except OSError:
+    pass
+`;
+
 const getFilename = (path: string) => path.split("/").pop() || path;
 
 const getFileExtension = (path: string): string | undefined => {
@@ -352,6 +395,12 @@ type SandboxTextReadPayload = {
   error?: string;
 };
 
+type SandboxFileState =
+  | { kind: "file"; path: string; sizeBytes: number }
+  | { kind: "missing"; path: string }
+  | { kind: "not_file"; path: string }
+  | { kind: "unknown"; path: string; error: string };
+
 function commandErrorToResult(error: unknown): SandboxCommandResult | null {
   if (!(error instanceof Error)) return null;
 
@@ -376,6 +425,10 @@ function commandErrorToResult(error: unknown): SandboxCommandResult | null {
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function cmdQuote(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
 }
 
 function formatBytes(bytes: number): string {
@@ -416,41 +469,132 @@ async function runSandboxCommand(
   }
 }
 
-async function getSandboxFileSize(
+function isWindowsSandbox(sandbox: AnySandbox): boolean {
+  return isCentrifugoSandbox(sandbox) && sandbox.isWindows();
+}
+
+function getWindowsNativePath(path: string): string {
+  if (/^[A-Za-z]:[\\/]/.test(path)) return path;
+  if (path.startsWith("/tmp/")) {
+    return `C:\\temp${path.slice(4).replace(/\//g, "\\")}`;
+  }
+  return path.replace(/\//g, "\\");
+}
+
+function getPythonPathForSandbox(sandbox: AnySandbox, path: string): string {
+  return isWindowsSandbox(sandbox) ? getWindowsNativePath(path) : path;
+}
+
+function toWindowsBashPath(path: string): string {
+  const drive = path.match(/^([A-Za-z]):[\\/](.*)$/);
+  if (drive) {
+    return `/${drive[1].toLowerCase()}/${drive[2].replace(/\\/g, "/")}`;
+  }
+  return path.replace(/\\/g, "/");
+}
+
+async function detectSandboxShell(
+  sandbox: AnySandbox,
+): Promise<"bash" | "cmd"> {
+  if (!isWindowsSandbox(sandbox)) return "bash";
+
+  const probe = await runSandboxCommand(
+    sandbox,
+    "echo $BASH_VERSION",
+    undefined,
+    10_000,
+  ).catch(() => null);
+  if (probe?.exitCode === 0 && /^\d/.test(probe.stdout.trim())) {
+    return "bash";
+  }
+
+  return "cmd";
+}
+
+async function runPythonScript(
+  sandbox: AnySandbox,
+  script: string,
+  envVars: Record<string, string>,
+  timeoutMs: number,
+): Promise<SandboxCommandResult> {
+  if (!isWindowsSandbox(sandbox)) {
+    const command = `PYTHON_BIN="$(command -v python3 || command -v python)" && "$PYTHON_BIN" - <<'PY'\n${script}\nPY`;
+    return runSandboxCommand(sandbox, command, envVars, timeoutMs);
+  }
+
+  const shell = await detectSandboxShell(sandbox);
+  const tempScriptPath = `/tmp/hackerai_script_${Date.now()}_${Math.random().toString(36).slice(2)}.py`;
+  await sandbox.files.write(tempScriptPath, script, {
+    user: "user" as const,
+  });
+
+  const nativePath = getWindowsNativePath(tempScriptPath);
+  const commandPath =
+    shell === "bash" ? toWindowsBashPath(nativePath) : nativePath;
+  const quotedPath =
+    shell === "bash" ? shellQuote(commandPath) : cmdQuote(commandPath);
+  const command =
+    shell === "bash"
+      ? `PYTHON_BIN="$(command -v python3 || command -v python)" && "$PYTHON_BIN" ${quotedPath}; status=$?; rm -f ${quotedPath}; exit $status`
+      : `python ${quotedPath}`;
+
+  try {
+    return await runSandboxCommand(sandbox, command, envVars, timeoutMs);
+  } finally {
+    if (shell === "cmd") {
+      await sandbox.files.remove(tempScriptPath).catch(() => undefined);
+    }
+  }
+}
+
+async function getSandboxFileState(
   sandbox: AnySandbox,
   path: string,
-): Promise<number | null> {
-  const quotedPath = shellQuote(path);
-  const statResult = await runSandboxCommand(
+): Promise<SandboxFileState> {
+  const pythonPath = getPythonPathForSandbox(sandbox, path);
+  const result = await runPythonScript(
     sandbox,
-    `stat -c%s ${quotedPath} 2>/dev/null || stat -f%z ${quotedPath} 2>/dev/null`,
-    undefined,
+    FILE_STATE_SCRIPT,
+    { HACKERAI_FILE_STATE_PATH: pythonPath },
     30_000,
-  ).catch(() => null);
+  ).catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      stdout: "",
+      stderr: message,
+      exitCode: 1,
+    } satisfies SandboxCommandResult;
+  });
 
-  const statSize = statResult
-    ? Number.parseInt(statResult.stdout.trim(), 10)
-    : NaN;
-  if (statResult?.exitCode === 0 && Number.isFinite(statSize)) {
-    return statSize;
+  if (result.exitCode !== 0) {
+    return {
+      kind: "unknown",
+      path,
+      error: result.stderr || result.stdout || "file state command failed",
+    };
   }
 
-  const escapedForCmd = path.replace(/"/g, '\\"');
-  const winResult = await runSandboxCommand(
-    sandbox,
-    `for %I in ("${escapedForCmd}") do @echo %~zI`,
-    undefined,
-    30_000,
-  ).catch(() => null);
-
-  const winSize = winResult
-    ? Number.parseInt(winResult.stdout.trim(), 10)
-    : NaN;
-  if (winResult?.exitCode === 0 && Number.isFinite(winSize)) {
-    return winSize;
+  try {
+    const payload = JSON.parse(result.stdout.trim()) as SandboxFileState;
+    if (
+      payload.kind === "file" &&
+      typeof payload.sizeBytes === "number" &&
+      Number.isFinite(payload.sizeBytes)
+    ) {
+      return { ...payload, path };
+    }
+    if (payload.kind === "missing" || payload.kind === "not_file") {
+      return { ...payload, path };
+    }
+  } catch {
+    // Fall through to unknown below.
   }
 
-  return null;
+  return {
+    kind: "unknown",
+    path,
+    error: result.stderr || result.stdout || "invalid file state response",
+  };
 }
 
 function buildNumberedFileContent(args: {
@@ -492,15 +636,20 @@ async function readSandboxTextFile(
   path: string,
   range?: number[],
 ): Promise<SandboxTextReadPayload> {
+  const pythonPath = getPythonPathForSandbox(sandbox, path);
   const envVars = {
-    HACKERAI_FILE_READ_PATH: path,
+    HACKERAI_FILE_READ_PATH: pythonPath,
     HACKERAI_FILE_READ_RANGE_START: String(range?.[0] ?? 0),
     HACKERAI_FILE_READ_RANGE_END: String(range?.[1] ?? -1),
     HACKERAI_FILE_READ_MAX_FULL_BYTES: String(MAX_TEXT_FILE_READ_BYTES),
     HACKERAI_FILE_READ_MAX_RESULT_BYTES: String(MAX_TEXT_READ_RESULT_BYTES),
   };
-  const command = `PYTHON_BIN="$(command -v python3 || command -v python)" && "$PYTHON_BIN" - <<'PY'\n${READ_TEXT_FILE_SCRIPT}\nPY`;
-  const result = await runSandboxCommand(sandbox, command, envVars, 120_000);
+  const result = await runPythonScript(
+    sandbox,
+    READ_TEXT_FILE_SCRIPT,
+    envVars,
+    120_000,
+  );
   const stdout = result.stdout.trim();
   let payload: SandboxTextReadPayload;
 
@@ -537,17 +686,28 @@ async function readSandboxTextFileWithFallback(
       throw error;
     }
 
-    const size = await getSandboxFileSize(sandbox, path);
-    if (size !== null && size > MAX_TEXT_FILE_READ_BYTES) {
+    const state = await getSandboxFileState(sandbox, path);
+    if (state.kind === "unknown") {
+      throw new Error(
+        `Unable to determine file size for ${path}; refusing to load the file into memory. ${state.error}`,
+      );
+    }
+    if (state.kind === "missing") {
+      throw new Error(`File not found or is not a regular file: ${path}`);
+    }
+    if (state.kind === "not_file") {
+      throw new Error(`File is not a regular file: ${path}`);
+    }
+    if (state.sizeBytes > MAX_TEXT_FILE_READ_BYTES) {
       if (range) {
         throw new Error(
-          `Unable to perform a bounded range read for ${path}, and the file is too large to load safely (${formatBytes(size)}). Use a targeted terminal command that writes a small result to a separate file.`,
+          `Unable to perform a bounded range read for ${path}, and the file is too large to load safely (${formatBytes(state.sizeBytes)}). Use a targeted terminal command that writes a small result to a separate file.`,
         );
       }
 
       return {
         path,
-        sizeBytes: size,
+        sizeBytes: state.sizeBytes,
         totalLines: 0,
         tooLarge: true,
       };
@@ -611,10 +771,16 @@ async function appendSandboxTextFile(
     user: "user" as const,
   });
 
-  const result = await runSandboxCommand(
+  const result = await runPythonScript(
     sandbox,
-    `cat ${shellQuote(tempPath)} >> ${shellQuote(path)} && rm -f ${shellQuote(tempPath)}`,
-    undefined,
+    APPEND_TEXT_FILE_SCRIPT,
+    {
+      HACKERAI_FILE_APPEND_TARGET_PATH: getPythonPathForSandbox(sandbox, path),
+      HACKERAI_FILE_APPEND_SOURCE_PATH: getPythonPathForSandbox(
+        sandbox,
+        tempPath,
+      ),
+    },
     60_000,
   );
   if (result.exitCode !== 0) {
@@ -997,14 +1163,24 @@ ${instructionsDescription}`,
               return { error: "text is required for append action" };
             }
 
-            const existingSize = await getSandboxFileSize(sandbox, path);
+            const existingState = await getSandboxFileState(sandbox, path);
+            if (existingState.kind === "unknown") {
+              return {
+                error: `Cannot append safely because the existing file size could not be determined for ${path}. ${existingState.error}`,
+              };
+            }
+            if (existingState.kind === "not_file") {
+              return {
+                error: `Cannot append to ${path} because it is not a file.`,
+              };
+            }
             if (
-              existingSize !== null &&
-              existingSize > MAX_TEXT_FILE_READ_BYTES
+              existingState.kind === "file" &&
+              existingState.sizeBytes > MAX_TEXT_FILE_READ_BYTES
             ) {
               await appendSandboxTextFile(sandbox, path, text);
               return {
-                content: `File appended: ${path}\nExisting file is ${formatBytes(existingSize)}, so the full diff preview was skipped to avoid loading the entire file into memory.`,
+                content: `File appended: ${path}\nExisting file is ${formatBytes(existingState.sizeBytes)}, so the full diff preview was skipped to avoid loading the entire file into memory.`,
               };
             }
 
@@ -1045,13 +1221,23 @@ ${instructionsDescription}`,
               return { error: "edits array is required for edit action" };
             }
 
-            const existingSize = await getSandboxFileSize(sandbox, path);
-            if (
-              existingSize !== null &&
-              existingSize > MAX_TEXT_FILE_READ_BYTES
-            ) {
+            const existingState = await getSandboxFileState(sandbox, path);
+            if (existingState.kind === "unknown") {
               return {
-                error: `File ${path} is too large for the edit action (${formatBytes(existingSize)}). Use a targeted shell command, restore the file from a clean source, or replace it with the write action instead of loading the whole file into memory.`,
+                error: `Cannot edit ${path} safely because the file size could not be determined. ${existingState.error}`,
+              };
+            }
+            if (existingState.kind === "missing") {
+              return {
+                error: `Cannot edit file ${path} - file is empty or does not exist`,
+              };
+            }
+            if (existingState.kind === "not_file") {
+              return { error: `Cannot edit ${path} because it is not a file.` };
+            }
+            if (existingState.sizeBytes > MAX_TEXT_FILE_READ_BYTES) {
+              return {
+                error: `File ${path} is too large for the edit action (${formatBytes(existingState.sizeBytes)}). Use a targeted shell command, restore the file from a clean source, or replace it with the write action instead of loading the whole file into memory.`,
               };
             }
 


### PR DESCRIPTION
## Summary

- Add sandbox-side bounded text file inspection for the file tool.
- Return metadata and range guidance instead of loading oversized files into the Trigger worker.
- Refuse full-file edits on oversized files and append to large files without reading existing content into memory.
- Add regression tests for oversized full reads, ranged reads, edit refusal, and append behavior.

## Root Cause

A Trigger.dev agent run could hit `TASK_PROCESS_OOM_KILLED` when the file tool loaded a very large text file, such as a corrupted multi-million-line `download.php`, into the worker process before truncation happened.

## Impact

The agent can still inspect large files in smaller line ranges, but accidental full reads and edits no longer pull oversized content into memory.

## Validation

- `pnpm test -- lib/ai/tools/__tests__/file.test.ts --runInBand`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint lib/ai/tools/file.ts lib/ai/tools/__tests__/file.test.ts`
- Commit hook also ran full `pnpm typecheck` and full `pnpm test` successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Safer handling of large files: prevents full-file loads, returns guidance for oversized reads, blocks edits on very large files, and skips full reads when appending.
* **Documentation**
  * Updated tool instructions to describe oversized-file behavior.
* **Tests**
  * Added tests covering large-file safety, read/append/edit behaviors, and Windows compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->