### PR TITLE
[codex] Fix oversized message storage compaction

### DIFF
--- a/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
+++ b/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
@@ -501,6 +501,36 @@ describe("pruneToolOutputs", () => {
     expect(result.prunedCount).toBe(0);
   });
 
+  it("prunes natural string outputs while preserving compact placeholders", () => {
+    const messages: UIMessage[] = [
+      makeAssistantMessage([
+        makeToolPart("run_terminal_cmd", "line with data\n".repeat(2000), {
+          command: "old-string-output",
+        }),
+      ]),
+      makeAssistantMessage(
+        [
+          makeToolPart(
+            "run_terminal_cmd",
+            "[Terminal: ran 'already-pruned', exit code 0]",
+            { command: "already-pruned" },
+          ),
+        ],
+        "msg-new",
+      ),
+    ];
+
+    const result = pruneToolOutputs(messages, 0, NO_MIN);
+
+    expect(result.prunedCount).toBe(1);
+    expect((result.messages[0].parts[0] as any).output).toBe(
+      "[Terminal: ran 'old-string-output', exit code ?]",
+    );
+    expect((result.messages[1].parts[0] as any).output).toBe(
+      "[Terminal: ran 'already-pruned', exit code 0]",
+    );
+  });
+
   // --- Protected tools ---
 
   it("never prunes protected tools (todo_write)", () => {
@@ -785,6 +815,66 @@ describe("compactMessageForStorage", () => {
     expect(estimateSerializedSizeBytes(result.message.parts)).toBeLessThan(
       estimateSerializedSizeBytes(message.parts),
     );
+  });
+
+  it("compacts natural string outputs for oversized storage messages", () => {
+    const message = makeAssistantMessage(
+      Array.from({ length: 80 }, (_, index) =>
+        makeToolPart(
+          "run_terminal_cmd",
+          `command ${index} output\n${"finding detail ".repeat(120)}`,
+          { command: `run-check-${index}` },
+        ),
+      ),
+    );
+
+    const result = compactMessageForStorage(message, {
+      softLimitBytes: 50_000,
+      toolOutputTokenBudget: 0,
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.prunedCount).toBeGreaterThan(0);
+    expect(result.afterSizeBytes).toBeLessThanOrEqual(50_000);
+    expect((result.message.parts[0] as any).output).toBe(
+      "[Terminal: ran 'run-check-0', exit code ?]",
+    );
+  });
+
+  it("compacts old tool inputs when outputs are already compact", () => {
+    const longCommand = (index: number) =>
+      [
+        "python - <<'PY'",
+        ...Array.from(
+          { length: 250 },
+          (_, line) => `print('command ${index} line ${line}')`,
+        ),
+        "PY",
+      ].join("\n");
+    const newestCommand = longCommand(59);
+    const message = makeAssistantMessage(
+      Array.from({ length: 60 }, (_, index) =>
+        makeToolPart(
+          "run_terminal_cmd",
+          `[Terminal: ran 'command-${index}', exit code 0]`,
+          { command: longCommand(index) },
+        ),
+      ),
+    );
+
+    const result = compactMessageForStorage(message, {
+      softLimitBytes: 95_000,
+      toolOutputTokenBudget: 0,
+    });
+    const oldestCommand = (result.message.parts[0] as any).input.command;
+    const newestSavedCommand = (result.message.parts.at(-1) as any).input
+      .command;
+
+    expect(result.compacted).toBe(true);
+    expect(result.afterSizeBytes).toBeLessThanOrEqual(95_000);
+    expect(oldestCommand.length).toBeLessThanOrEqual(512);
+    expect(oldestCommand).toContain("[truncated for storage]");
+    expect(newestSavedCommand).toBe(newestCommand);
   });
 
   it("compacts oversized reasoning and storage-only status parts", () => {

--- a/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
+++ b/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
@@ -877,6 +877,30 @@ describe("compactMessageForStorage", () => {
     expect(newestSavedCommand).toBe(newestCommand);
   });
 
+  it("does not byte-compact unfinished tool calls", () => {
+    const command = "python -c \"print('still streaming')\" ".repeat(200);
+    const message = makeAssistantMessage([
+      {
+        type: "tool-run_terminal_cmd",
+        toolCallId: "call-streaming",
+        state: "input-streaming",
+        input: { command },
+      } as any,
+    ]);
+
+    const result = compactMessageForStorage(message, {
+      softLimitBytes: 100,
+      toolOutputTokenBudget: 0,
+    });
+    const part = result.message.parts[0] as any;
+
+    expect(result.compacted).toBe(false);
+    expect(result.afterSizeBytes).toBe(result.beforeSizeBytes);
+    expect(part.state).toBe("input-streaming");
+    expect(part.input.command).toBe(command);
+    expect(part.output).toBeUndefined();
+  });
+
   it("compacts oversized reasoning and storage-only status parts", () => {
     const message = makeAssistantMessage([
       { type: "step-start" },

--- a/lib/chat/compaction/prune-tool-outputs.ts
+++ b/lib/chat/compaction/prune-tool-outputs.ts
@@ -174,6 +174,11 @@ const isPrunableToolPart = (part: ToolPart): boolean => {
   return Boolean(toolName && !PROTECTED_TOOLS.has(toolName));
 };
 
+const isCompletedPrunableToolPart = (part: ToolPart): boolean =>
+  isPrunableToolPart(part) &&
+  (part.state === "output-available" || part.state === "output-error") &&
+  part.output != null;
+
 const truncateStorageString = (
   value: string,
   maxLength = STORAGE_TOOL_INPUT_STRING_LIMIT,
@@ -378,7 +383,7 @@ const compactToolPartsToByteLimit = (
     index++
   ) {
     const part = compactedParts[index] as ToolPart;
-    if (!part?.type?.startsWith(TOOL_TYPE_PREFIX)) continue;
+    if (!isCompletedPrunableToolPart(part)) continue;
 
     const compactedPart = compactToolPartForStorage(part);
     if (

--- a/lib/chat/compaction/prune-tool-outputs.ts
+++ b/lib/chat/compaction/prune-tool-outputs.ts
@@ -61,8 +61,14 @@ const STORAGE_MESSAGE_SOFT_LIMIT_BYTES = 850 * 1024;
 const STORAGE_TOOL_OUTPUT_TOKEN_BUDGET = 20_000;
 const STORAGE_REASONING_CHAR_BUDGET = 32_000;
 const STORAGE_REASONING_PART_CHAR_LIMIT = 8_000;
+const STORAGE_TOOL_INPUT_STRING_LIMIT = 512;
+const STORAGE_TOOL_INPUT_ARRAY_LIMIT = 20;
+const STORAGE_TOOL_INPUT_DEPTH_LIMIT = 3;
+const STORAGE_COMPACTED_STRING_SUFFIX = "... [truncated for storage]";
 const STORAGE_COMPACTED_REASONING_PREFIX =
   "[Earlier reasoning compacted for storage]\n\n";
+const COMPACT_PLACEHOLDER_PATTERN =
+  /^\[(Terminal|File|Match|Search|Files|URL|Tool): .+\]$/;
 
 // ---------------------------------------------------------------------------
 // Placeholder builders per tool type
@@ -89,7 +95,12 @@ const buildPlaceholderFromParts = (
     case "run_terminal_cmd": {
       const cmd = input?.command ?? "unknown";
       const shortCmd = cmd.length > 80 ? cmd.slice(0, 77) + "..." : cmd;
-      const exitCode = output?.exitCode ?? output?.exit_code ?? "?";
+      const exitCode =
+        output?.exitCode ??
+        output?.exit_code ??
+        output?.result?.exitCode ??
+        output?.result?.exit_code ??
+        "?";
       return `[Terminal: ran '${shortCmd}', exit code ${exitCode}]`;
     }
 
@@ -150,6 +161,96 @@ const buildPlaceholderFromParts = (
 const buildPlaceholder = (part: ToolPart): string => {
   const toolName = part.type.slice(TOOL_TYPE_PREFIX.length);
   return buildPlaceholderFromParts(toolName, part.input, part.output);
+};
+
+const isCompactPlaceholderOutput = (output: unknown): output is string =>
+  typeof output === "string" && COMPACT_PLACEHOLDER_PATTERN.test(output);
+
+const isPrunableToolPart = (part: ToolPart): boolean => {
+  const toolName = part.type?.startsWith(TOOL_TYPE_PREFIX)
+    ? part.type.slice(TOOL_TYPE_PREFIX.length)
+    : null;
+
+  return Boolean(toolName && !PROTECTED_TOOLS.has(toolName));
+};
+
+const truncateStorageString = (
+  value: string,
+  maxLength = STORAGE_TOOL_INPUT_STRING_LIMIT,
+): string => {
+  if (value.length <= maxLength) return value;
+  if (maxLength <= STORAGE_COMPACTED_STRING_SUFFIX.length) {
+    return value.slice(0, maxLength);
+  }
+
+  const contentBudget = maxLength - STORAGE_COMPACTED_STRING_SUFFIX.length;
+  const headBudget = Math.ceil(contentBudget * 0.65);
+  const tailBudget = contentBudget - headBudget;
+
+  return `${value.slice(0, headBudget)}${STORAGE_COMPACTED_STRING_SUFFIX}${
+    tailBudget > 0 ? value.slice(-tailBudget) : ""
+  }`;
+};
+
+const compactToolInputForStorage = (value: unknown, depth = 0): unknown => {
+  if (value == null) return value;
+  if (typeof value === "string") return truncateStorageString(value);
+  if (typeof value !== "object") return value;
+
+  if (depth >= STORAGE_TOOL_INPUT_DEPTH_LIMIT) {
+    if (Array.isArray(value)) {
+      return value.length > STORAGE_TOOL_INPUT_ARRAY_LIMIT
+        ? {
+            type: "array",
+            length: value.length,
+            truncated: true,
+          }
+        : value;
+    }
+
+    return {
+      type: "object",
+      keys: Object.keys(value as Record<string, unknown>).slice(
+        0,
+        STORAGE_TOOL_INPUT_ARRAY_LIMIT,
+      ),
+      truncated: true,
+    };
+  }
+
+  if (Array.isArray(value)) {
+    const compacted = value
+      .slice(0, STORAGE_TOOL_INPUT_ARRAY_LIMIT)
+      .map((item) => compactToolInputForStorage(item, depth + 1));
+    if (value.length > STORAGE_TOOL_INPUT_ARRAY_LIMIT) {
+      compacted.push({
+        truncated: true,
+        remaining: value.length - STORAGE_TOOL_INPUT_ARRAY_LIMIT,
+      });
+    }
+    return compacted;
+  }
+
+  const compacted: Record<string, unknown> = {};
+  for (const [key, childValue] of Object.entries(
+    value as Record<string, unknown>,
+  )) {
+    compacted[key] = compactToolInputForStorage(childValue, depth + 1);
+  }
+
+  return compacted;
+};
+
+const compactToolPartForStorage = (part: ToolPart): ToolPart => {
+  if (!isPrunableToolPart(part)) return part;
+
+  return {
+    ...part,
+    input: compactToolInputForStorage(part.input),
+    output: isCompactPlaceholderOutput(part.output)
+      ? part.output
+      : buildPlaceholder(part),
+  };
 };
 
 // ---------------------------------------------------------------------------
@@ -255,6 +356,54 @@ const stripStorageOnlyParts = (parts: UIMessage["parts"]): UIMessage["parts"] =>
       part?.type !== "step-start" && part?.type !== "data-summarization",
   );
 
+const compactToolPartsToByteLimit = (
+  parts: UIMessage["parts"],
+  softLimitBytes: number,
+): {
+  parts: UIMessage["parts"];
+  compactedCount: number;
+  afterSizeBytes: number;
+} => {
+  let afterSizeBytes = estimateSerializedSizeBytes(parts);
+  if (afterSizeBytes <= softLimitBytes) {
+    return { parts, compactedCount: 0, afterSizeBytes };
+  }
+
+  let compactedCount = 0;
+  let compactedParts = parts;
+
+  for (
+    let index = 0;
+    index < compactedParts.length && afterSizeBytes > softLimitBytes;
+    index++
+  ) {
+    const part = compactedParts[index] as ToolPart;
+    if (!part?.type?.startsWith(TOOL_TYPE_PREFIX)) continue;
+
+    const compactedPart = compactToolPartForStorage(part);
+    if (
+      estimateSerializedSizeBytes(compactedPart) >=
+      estimateSerializedSizeBytes(part)
+    ) {
+      continue;
+    }
+
+    compactedParts = compactedParts.map((currentPart, partIndex) =>
+      partIndex === index
+        ? (compactedPart as UIMessage["parts"][number])
+        : currentPart,
+    );
+    compactedCount++;
+    afterSizeBytes = estimateSerializedSizeBytes(compactedParts);
+  }
+
+  return {
+    parts: compactedParts,
+    compactedCount,
+    afterSizeBytes,
+  };
+};
+
 /**
  * Compacts a single assistant UIMessage before database storage.
  *
@@ -324,6 +473,16 @@ export function compactMessageForStorage<T extends UIMessage>(
     afterSizeBytes = estimateSerializedSizeBytes(parts);
   }
 
+  if (afterSizeBytes > softLimitBytes) {
+    const byteCompactionResult = compactToolPartsToByteLimit(
+      parts,
+      softLimitBytes,
+    );
+    parts = byteCompactionResult.parts;
+    prunedCount += byteCompactionResult.compactedCount;
+    afterSizeBytes = byteCompactionResult.afterSizeBytes;
+  }
+
   const compacted =
     strippedUiOnlyFields || prunedCount > 0 || afterSizeBytes < beforeSizeBytes;
 
@@ -382,7 +541,7 @@ export function pruneToolOutputs(
         !PROTECTED_TOOLS.has(toolName) &&
         (part.state === "output-available" || part.state === "output-error") &&
         part.output != null &&
-        typeof part.output !== "string" // skip already-pruned placeholders
+        !isCompactPlaceholderOutput(part.output)
       ) {
         toolEntries.push({
           msgIdx: mi,
@@ -556,8 +715,8 @@ export function pruneModelMessages(
       )
         continue;
 
-      // Skip already-pruned (string output = placeholder)
-      if (typeof part.output === "string") continue;
+      // Skip compact placeholders, but allow natural string outputs to prune.
+      if (isCompactPlaceholderOutput(part.output)) continue;
       if (part.output == null) continue;
 
       const tokens = countOutputTokens(part.output);


### PR DESCRIPTION
## Summary

Fixes oversized assistant message persistence when long agent runs accumulate many terminal/tool parts.

## Root Cause

The existing storage compaction was token-oriented and skipped any string tool output as if it were already compacted. Real terminal/file outputs can be natural strings after normal truncation, so many individually small outputs could still serialize above Convex's 1 MiB value limit. Also, output pruning kept full tool inputs, so hundreds of long command inputs could still keep `message.parts` too large.

## Changes

- Distinguish compact placeholder strings from natural string outputs, allowing real string outputs to be pruned.
- Add a final byte-budget storage compaction pass that compacts older tool outputs and truncates bulky tool inputs until the serialized parts payload is under the storage soft limit.
- Preserve protected tools and newest rich tool detail where possible.
- Add regressions for natural string outputs and already-compacted terminal outputs with long inputs.

## Validation

- `pnpm test -- lib/chat/compaction/__tests__/prune-tool-outputs.test.ts`
- `pnpm typecheck`
- Commit hooks also ran full `pnpm test` and `pnpm typecheck` successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Improved compaction and pruning to better meet token and byte budgets, including a byte-budget compaction fallback.
  * Enhanced detection of existing compact placeholders to avoid reprocessing and refined terminal placeholder formatting (exit codes redacted).
  * Added limits and truncation for long tool inputs while preserving newest inputs and skipping unfinished streaming calls.

* **Tests**
  * Added coverage for pruning, storage compaction, placeholder handling, input truncation, and streaming-call behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->