### PR TITLE
[codex] Improve Convex failure logging

### DIFF
--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -165,6 +165,42 @@ async function getDefaultPaymentMethodId(
   return typeof pm === "string" ? pm : pm?.id || null;
 }
 
+const REDACTED_VALUE = "[Redacted]";
+const SENSITIVE_FIELD_PATTERN =
+  /(["']?\b(?:serviceKey|service_key|apiKey|api_key|authorization|bearer|cookie|password|secret|token)\b["']?)(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,}]+)/gi;
+const ENV_SECRET_PATTERN =
+  /(["']?\b(?:CONVEX_SERVICE_ROLE_KEY|POSTHOG_API_KEY|STRIPE_SECRET_KEY)\b["']?)(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,}]+)/gi;
+
+const redactSensitiveErrorMessage = (message: string): string =>
+  message
+    .replace(SENSITIVE_FIELD_PATTERN, (_match, key, separator) => {
+      return `${key}${separator}"${REDACTED_VALUE}"`;
+    })
+    .replace(ENV_SECRET_PATTERN, (_match, key, separator) => {
+      return `${key}${separator}"${REDACTED_VALUE}"`;
+    });
+
+const serializeErrorForLog = (error: unknown) => {
+  const name = error instanceof Error ? error.name : "UnknownError";
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : (() => {
+            try {
+              return JSON.stringify(error);
+            } catch {
+              return String(error);
+            }
+          })();
+
+  return {
+    name,
+    message: redactSensitiveErrorMessage(message).slice(0, 1_000),
+  };
+};
+
 async function createAutoReloadPayment(
   customerId: string,
   paymentMethodId: string,
@@ -519,8 +555,10 @@ export const deductWithAutoReload = action({
       };
     }
 
+    const actionStartedAt = Date.now();
+
     // Get current settings (balance in both dollars and points)
-    const settings: {
+    let settings: {
       balanceDollars: number;
       balancePoints: number;
       enabled: boolean;
@@ -528,10 +566,27 @@ export const deductWithAutoReload = action({
       autoReloadThresholdDollars?: number;
       autoReloadThresholdPoints?: number;
       autoReloadAmountDollars?: number;
-    } = await ctx.runQuery(api.extraUsage.getExtraUsageBalanceForBackend, {
-      serviceKey: args.serviceKey,
-      userId: args.userId,
-    });
+    };
+    const balanceLookupStartedAt = Date.now();
+    try {
+      settings = await ctx.runQuery(
+        api.extraUsage.getExtraUsageBalanceForBackend,
+        {
+          serviceKey: args.serviceKey,
+          userId: args.userId,
+        },
+      );
+    } catch (error) {
+      convexLogger.error("extra_usage_balance_backend_query_failed", {
+        user_id: args.userId,
+        amount_points: args.amountPoints,
+        operation: "get_extra_usage_balance",
+        convex_function: "extraUsage.getExtraUsageBalanceForBackend",
+        duration_ms: Date.now() - balanceLookupStartedAt,
+        error: serializeErrorForLog(error),
+      });
+      throw error;
+    }
 
     // Use points for threshold comparison (more precise)
     const thresholdPoints: number = settings.autoReloadThresholdPoints ?? 0;
@@ -559,9 +614,25 @@ export const deductWithAutoReload = action({
       autoReloadTriggered = true;
 
       // Get Stripe customer ID
-      const stripeCustomerId = await getStripeCustomerId(args.userId);
+      const stripeLookupStartedAt = Date.now();
+      let stripeCustomerId: string | null = null;
+      try {
+        stripeCustomerId = await getStripeCustomerId(args.userId);
+      } catch (error) {
+        convexLogger.error("extra_usage_stripe_customer_lookup_failed", {
+          user_id: args.userId,
+          amount_points: args.amountPoints,
+          operation: "get_stripe_customer",
+          duration_ms: Date.now() - stripeLookupStartedAt,
+          error: serializeErrorForLog(error),
+        });
+        autoReloadResult = {
+          success: false,
+          reason: "stripe_lookup_failed",
+        };
+      }
       if (!stripeCustomerId) {
-        autoReloadResult = { success: false, reason: "no_stripe_customer" };
+        autoReloadResult ??= { success: false, reason: "no_stripe_customer" };
       } else {
         try {
           // Check if customer is blocked (fraud flagged) before attempting charge
@@ -633,7 +704,14 @@ export const deductWithAutoReload = action({
               }
             }
           }
-        } catch {
+        } catch (error) {
+          convexLogger.error("extra_usage_auto_reload_lookup_failed", {
+            user_id: args.userId,
+            amount_points: args.amountPoints,
+            operation: "prepare_auto_reload_payment",
+            duration_ms: Date.now() - stripeLookupStartedAt,
+            error: serializeErrorForLog(error),
+          });
           autoReloadResult = {
             success: false,
             reason: "stripe_lookup_failed",
@@ -663,25 +741,56 @@ export const deductWithAutoReload = action({
       (autoReloadResult.success ||
         !PRE_CHARGE_REASONS.has(autoReloadResult.reason ?? ""))
     ) {
-      await ctx.runMutation(internal.extraUsage.recordAutoReloadOutcome, {
-        userId: args.userId,
-        success: autoReloadResult.success,
-        failureReason: autoReloadResult.reason,
-      });
+      const recordOutcomeStartedAt = Date.now();
+      try {
+        await ctx.runMutation(internal.extraUsage.recordAutoReloadOutcome, {
+          userId: args.userId,
+          success: autoReloadResult.success,
+          failureReason: autoReloadResult.reason,
+        });
+      } catch (error) {
+        convexLogger.error("extra_usage_auto_reload_outcome_record_failed", {
+          user_id: args.userId,
+          amount_points: args.amountPoints,
+          operation: "record_auto_reload_outcome",
+          auto_reload_success: autoReloadResult.success,
+          auto_reload_failure_reason: autoReloadResult.reason,
+          duration_ms: Date.now() - recordOutcomeStartedAt,
+          error: serializeErrorForLog(error),
+        });
+        throw error;
+      }
     }
 
     // Now deduct from balance using points directly (no precision loss)
-    const deductResult: {
+    let deductResult: {
       success: boolean;
       newBalancePoints: number;
       newBalanceDollars: number;
       insufficientFunds: boolean;
       monthlyCapExceeded: boolean;
-    } = await ctx.runMutation(api.extraUsage.deductPoints, {
-      serviceKey: args.serviceKey,
-      userId: args.userId,
-      amountPoints: args.amountPoints,
-    });
+    };
+    const deductPointsStartedAt = Date.now();
+    try {
+      deductResult = await ctx.runMutation(api.extraUsage.deductPoints, {
+        serviceKey: args.serviceKey,
+        userId: args.userId,
+        amountPoints: args.amountPoints,
+      });
+    } catch (error) {
+      convexLogger.error("extra_usage_deduct_points_failed", {
+        user_id: args.userId,
+        amount_points: args.amountPoints,
+        operation: "deduct_points",
+        convex_function: "extraUsage.deductPoints",
+        auto_reload_triggered: autoReloadTriggered,
+        auto_reload_success: autoReloadResult?.success,
+        auto_reload_failure_reason: autoReloadResult?.reason,
+        duration_ms: Date.now() - deductPointsStartedAt,
+        error: serializeErrorForLog(error),
+      });
+      throw error;
+    }
 
     convexLogger.info("deduct_with_auto_reload", {
       user_id: args.userId,
@@ -694,6 +803,7 @@ export const deductWithAutoReload = action({
       auto_reload_success: autoReloadResult?.success,
       auto_reload_charged_dollars: autoReloadResult?.chargedAmountDollars,
       auto_reload_failure_reason: autoReloadResult?.reason,
+      duration_ms: Date.now() - actionStartedAt,
     });
 
     return {

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -297,13 +297,16 @@ export const getFileUrlAction = action({
 export const getFileUrlsByFileIdsAction = action({
   args: {
     serviceKey: v.string(),
-    userId: v.string(),
+    userId: v.optional(v.string()),
     fileIds: v.array(v.id("files")),
   },
   returns: v.array(v.union(v.string(), v.null())),
   handler: async (ctx, args): Promise<Array<string | null>> => {
     // Verify service role key
     validateServiceKey(args.serviceKey);
+    if (!args.userId) {
+      throw new Error("Missing userId for service file URL fetch");
+    }
 
     // Enforce batch size limit
     const MAX_BATCH_SIZE = 50;

--- a/lib/extra-usage.ts
+++ b/lib/extra-usage.ts
@@ -1,9 +1,49 @@
 import { POINTS_PER_DOLLAR } from "@/lib/rate-limit/token-bucket";
 import { getConvexClient } from "@/lib/db/convex-client";
 import { api } from "@/convex/_generated/api";
+import { phLogger } from "@/lib/posthog/server";
+import { stringifyRedactedError } from "@/lib/utils/error-redaction";
 
 /** Extra usage pricing multiplier */
 export const EXTRA_USAGE_MULTIPLIER = 1.05;
+
+const errorName = (error: unknown) =>
+  error instanceof Error ? error.name : "UnknownError";
+
+const logExtraUsageConvexFailure = ({
+  event,
+  message,
+  userId,
+  organizationId,
+  amountPoints,
+  convexFunction,
+  operation,
+  startedAt,
+  error,
+}: {
+  event: string;
+  message: string;
+  userId?: string;
+  organizationId?: string;
+  amountPoints?: number;
+  convexFunction: string;
+  operation: string;
+  startedAt: number;
+  error: unknown;
+}) => {
+  phLogger.error(message, {
+    event,
+    userId,
+    organization_id: organizationId,
+    amount_points: amountPoints,
+    convex_function: convexFunction,
+    operation,
+    component: "extra_usage",
+    duration_ms: Date.now() - startedAt,
+    error_name: errorName(error),
+    error_message: stringifyRedactedError(error),
+  });
+};
 
 export interface ExtraUsageBalance {
   balanceDollars: number;
@@ -52,6 +92,7 @@ export function pointsToDollars(points: number): number {
 export async function getExtraUsageBalance(
   userId: string,
 ): Promise<ExtraUsageBalance | null> {
+  const startedAt = Date.now();
   try {
     const convex = getConvexClient();
     const settings = await convex.query(
@@ -71,7 +112,15 @@ export async function getExtraUsageBalance(
       autoReloadAmountDollars: settings.autoReloadAmountDollars,
     };
   } catch (error) {
-    console.error("Error getting extra usage balance:", error);
+    logExtraUsageConvexFailure({
+      event: "extra_usage_balance_fetch_failed",
+      message: "Extra usage balance fetch failed",
+      userId,
+      convexFunction: "extraUsage.getExtraUsageBalanceForBackend",
+      operation: "get_extra_usage_balance",
+      startedAt,
+      error,
+    });
     return null;
   }
 }
@@ -113,6 +162,7 @@ export async function refundToBalance(
     };
   }
 
+  const startedAt = Date.now();
   try {
     const convex = getConvexClient();
 
@@ -127,7 +177,16 @@ export async function refundToBalance(
       newBalanceDollars: result.newBalanceDollars,
     };
   } catch (error) {
-    console.error("Error refunding to balance:", error);
+    logExtraUsageConvexFailure({
+      event: "extra_usage_refund_failed",
+      message: "Extra usage refund failed",
+      userId,
+      amountPoints: pointsToRefund,
+      convexFunction: "extraUsage.refundPoints",
+      operation: "refund_extra_usage_balance",
+      startedAt,
+      error,
+    });
     return {
       success: false,
       newBalanceDollars: 0,
@@ -160,6 +219,7 @@ export async function deductFromBalance(
     };
   }
 
+  const startedAt = Date.now();
   try {
     const convex = getConvexClient();
 
@@ -183,7 +243,16 @@ export async function deductFromBalance(
       autoReloadResult: result.autoReloadResult,
     };
   } catch (error) {
-    console.error("Error deducting from balance:", error);
+    logExtraUsageConvexFailure({
+      event: "extra_usage_deduction_failed",
+      message: "Extra usage deduction failed",
+      userId,
+      amountPoints: pointsUsed,
+      convexFunction: "extraUsageActions.deductWithAutoReload",
+      operation: "deduct_extra_usage_balance",
+      startedAt,
+      error,
+    });
     // Do NOT report as insufficientFunds — this was a service error, not an
     // empty balance. Returning insufficientFunds: false lets the caller
     // distinguish transient failures from actual balance exhaustion.
@@ -218,6 +287,7 @@ export async function getTeamExtraUsageState(
   organizationId: string,
   userId: string,
 ): Promise<TeamExtraUsageState | null> {
+  const startedAt = Date.now();
   try {
     const convex = getConvexClient();
     const state = await convex.query(
@@ -236,7 +306,16 @@ export async function getTeamExtraUsageState(
       memberDisabled: state.memberDisabled,
     };
   } catch (error) {
-    console.error("Error getting team extra usage state:", error);
+    logExtraUsageConvexFailure({
+      event: "team_extra_usage_state_fetch_failed",
+      message: "Team extra usage state fetch failed",
+      userId,
+      organizationId,
+      convexFunction: "teamExtraUsage.getTeamExtraUsageStateForBackend",
+      operation: "get_team_extra_usage_state",
+      startedAt,
+      error,
+    });
     return null;
   }
 }
@@ -261,6 +340,7 @@ export async function deductFromTeamBalance(
     };
   }
 
+  const startedAt = Date.now();
   try {
     const convex = getConvexClient();
     const result = await convex.action(
@@ -285,7 +365,17 @@ export async function deductFromTeamBalance(
       poolDisabled: result.poolDisabled,
     };
   } catch (error) {
-    console.error("Error deducting from team balance:", error);
+    logExtraUsageConvexFailure({
+      event: "team_extra_usage_deduction_failed",
+      message: "Team extra usage deduction failed",
+      userId,
+      organizationId,
+      amountPoints: pointsUsed,
+      convexFunction: "teamExtraUsageActions.deductWithAutoReloadForTeam",
+      operation: "deduct_team_extra_usage_balance",
+      startedAt,
+      error,
+    });
     return {
       success: false,
       newBalanceDollars: 0,
@@ -312,6 +402,7 @@ export async function refundToTeamBalance(
     };
   }
 
+  const startedAt = Date.now();
   try {
     const convex = getConvexClient();
     const result = await convex.mutation(api.teamExtraUsage.refundTeamPoints, {
@@ -325,7 +416,17 @@ export async function refundToTeamBalance(
       newBalanceDollars: result.newBalanceDollars,
     };
   } catch (error) {
-    console.error("Error refunding to team balance:", error);
+    logExtraUsageConvexFailure({
+      event: "team_extra_usage_refund_failed",
+      message: "Team extra usage refund failed",
+      userId,
+      organizationId,
+      amountPoints: pointsToRefund,
+      convexFunction: "teamExtraUsage.refundTeamPoints",
+      operation: "refund_team_extra_usage_balance",
+      startedAt,
+      error,
+    });
     return {
       success: false,
       newBalanceDollars: 0,

--- a/lib/utils/__tests__/error-redaction.test.ts
+++ b/lib/utils/__tests__/error-redaction.test.ts
@@ -26,4 +26,16 @@ describe("error redaction", () => {
     expect(redacted).not.toContain("service-secret");
     expect(redacted).not.toContain("token-secret");
   });
+
+  it("redacts known secret environment variable assignments", () => {
+    const message =
+      "Failed with CONVEX_SERVICE_ROLE_KEY=super-secret and STRIPE_SECRET_KEY='stripe-secret'";
+
+    const redacted = redactSensitiveErrorMessage(message);
+
+    expect(redacted).toContain('CONVEX_SERVICE_ROLE_KEY="[Redacted]"');
+    expect(redacted).toContain('STRIPE_SECRET_KEY="[Redacted]"');
+    expect(redacted).not.toContain("super-secret");
+    expect(redacted).not.toContain("stripe-secret");
+  });
 });

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -21,6 +21,7 @@ import { stringifyRedactedError } from "@/lib/utils/error-redaction";
 
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 const MAX_PROVIDER_IMAGE_DOWNLOAD_SIZE = 30 * 1024 * 1024;
+const MAX_CONVEX_FILE_URL_BATCH_SIZE = 50;
 
 type FileToProcess = {
   fileId?: string;
@@ -304,14 +305,38 @@ const fetchFileUrls = async (
   }
 
   try {
-    return await getConvexClient().action(
-      api.s3Actions.getFileUrlsByFileIdsAction,
-      {
-        serviceKey,
-        userId,
-        fileIds: fileIds as Id<"files">[],
-      },
+    const chunks: string[][] = [];
+    for (let i = 0; i < fileIds.length; i += MAX_CONVEX_FILE_URL_BATCH_SIZE) {
+      chunks.push(fileIds.slice(i, i + MAX_CONVEX_FILE_URL_BATCH_SIZE));
+    }
+
+    const chunkResults = await Promise.all(
+      chunks.map(async (chunk, index): Promise<(string | null)[]> => {
+        try {
+          return await getConvexClient().action(
+            api.s3Actions.getFileUrlsByFileIdsAction,
+            {
+              serviceKey,
+              userId,
+              fileIds: chunk as Id<"files">[],
+            },
+          );
+        } catch (error) {
+          logger.warn("file_url_fetch_chunk_failed", {
+            event: "file_url_fetch_chunk_failed",
+            service: "chat-handler",
+            error: stringifyRedactedError(error),
+            file_count: fileIds.length,
+            chunk_file_count: chunk.length,
+            chunk_index: index,
+            chunk_count: chunks.length,
+          });
+          return chunk.map(() => null);
+        }
+      }),
     );
+
+    return chunkResults.flat();
   } catch (error) {
     logger.warn("file_url_fetch_failed", {
       event: "file_url_fetch_failed",


### PR DESCRIPTION
## Summary

- Add structured PostHog logging around extra-usage Convex query/action/mutation failures.
- Add stage-specific Convex logs for balance lookup, Stripe lookup, auto-reload outcome recording, and point deduction.
- Chunk backend file URL fetches into max-50 batches and avoid leaking service keys in missing-user validation errors.
- Expand redaction coverage for secret environment variable assignments.

## Why

PostHog grouped many Convex runtime failures under the generic message `Your request couldn't be completed. Try again later.`, without enough context to tell which backend operation failed. This adds queryable operation/function/stage fields and fixes one concrete batch-size trigger.

## Validation

- `pnpm test -- lib/utils/__tests__/error-redaction.test.ts convex/__tests__/s3Actions.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- Pre-commit hook also ran full Jest suite: 1,305 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error resilience in payment processing to prevent cascading failures.
  * Enhanced error redaction to prevent accidental exposure of sensitive credentials in logs.

* **New Features**
  * Implemented batch processing for file operations to improve performance and reliability.
  * Added enhanced observability with structured error logging and timing metrics across payment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->