### PR TITLE
[codex] Add agent browser sandbox support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -152,11 +152,16 @@ RUN set -eux; \
 # ============================================================================
 # User Setup
 # ============================================================================
-RUN useradd --create-home --shell /bin/bash user && \
-    usermod -aG sudo user && \
-    echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
-    mkdir -p /home/user/upload /home/user/go && \
-    chown -R user:user /home/user
+RUN set -eux; \
+    if ! id -u user >/dev/null 2>&1; then \
+      useradd --create-home --shell /bin/bash user; \
+    fi; \
+    usermod -aG sudo user; \
+    install -d -m 0755 /etc/sudoers.d /home/user/upload /home/user/go; \
+    printf 'user ALL=(ALL) NOPASSWD: ALL\n' > /etc/sudoers.d/hackerai-user; \
+    chmod 0440 /etc/sudoers.d/hackerai-user; \
+    user_group="$(id -gn user)"; \
+    chown -R "user:${user_group}" /home/user
 
 WORKDIR /home/user
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -165,8 +165,9 @@ RUN set -eux; \
 
 WORKDIR /home/user
 
-# Ensure Go bin paths are in PATH for login shells (su - user, bash -l)
-RUN printf 'export PATH=/home/user/.local/bin:/usr/local/go/bin:/home/user/go/bin:$PATH\n' \
+# Ensure login shells, including E2B's Dockerfile builder shell, keep system
+# binary directories after adding user-local and Go bin paths.
+RUN printf 'export PATH=/home/user/.local/bin:/usr/local/go/bin:/home/user/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n' \
     > /etc/profile.d/00-hackerai-path.sh && chmod 644 /etc/profile.d/00-hackerai-path.sh
 
 # ============================================================================

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,6 +69,7 @@ RUN apt-get update && \
     dnsutils \
     iproute2 \
     net-tools \
+    whois \
     traceroute \
     netcat-traditional \
     tcpdump \
@@ -125,6 +126,8 @@ RUN apt-get update && \
     nodejs \
     npm \
     tmux \
+    chromium \
+    fonts-liberation \
     # Forensics
     binwalk \
     foremost \
@@ -174,7 +177,12 @@ RUN pip3 install --break-system-packages \
     odfpy
 
 # Additional security-focused Python packages
-RUN pip3 install --break-system-packages requests aiohttp jinja2 'httpx[cli]' ratelimit pycryptodomex
+# Kali's python3-rich package may be newer than httpx[cli]'s rich<14
+# requirement, and pip cannot uninstall dpkg-owned packages without RECORD
+# metadata. Install a pip-managed compatible rich first so httpx[cli] resolves
+# against /usr/local without touching the distro package.
+RUN pip3 install --break-system-packages --ignore-installed 'rich<14,>=10' && \
+    pip3 install --break-system-packages requests aiohttp jinja2 'httpx[cli]' ratelimit pycryptodomex
 
 # ============================================================================
 # Git-based Security Tools
@@ -240,6 +248,19 @@ RUN set -eux; \
     ([ -f /opt/jwt_tool/jwt_tool.py ] && echo '#!/bin/bash\npython3 /opt/jwt_tool/jwt_tool.py "$@"' > /usr/local/bin/jwt-tool && chmod +x /usr/local/bin/jwt-tool) || true
 
 # ============================================================================
+# Browser Automation
+# ============================================================================
+ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV AGENT_BROWSER_USER_AGENT="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+ENV AGENT_BROWSER_ARGS="--disable-blink-features=AutomationControlled,--no-first-run,--no-default-browser-check,--disable-dev-shm-usage,--no-sandbox,--lang=en-US"
+ENV AGENT_BROWSER_SCREENSHOT_DIR=/home/user/agent-browser-screenshots
+
+RUN npm install -g agent-browser@0.26.0 && \
+    mkdir -p /home/user/agent-browser-screenshots && \
+    chown -R user:user /home/user/agent-browser-screenshots && \
+    agent-browser doctor --offline --quick
+
+# ============================================================================
 # Go-based Security Tools
 # ============================================================================
 RUN set -eux; \
@@ -278,6 +299,7 @@ RUN set -eux; \
     which subfinder && echo "✓ subfinder" && \
     which dnsrecon && echo "✓ dnsrecon" && \
     which dnsenum && echo "✓ dnsenum" && \
+    which whois && echo "✓ whois" && \
     which ffuf && echo "✓ ffuf" && \
     which arjun && echo "✓ arjun" && \
     which gobuster && echo "✓ gobuster" && \
@@ -302,6 +324,8 @@ RUN set -eux; \
     which zaproxy && echo "✓ zaproxy" && \
     which httpx && echo "✓ httpx" && \
     which caido-cli && echo "✓ caido-cli" && \
+    which chromium && echo "✓ chromium" && \
+    which agent-browser && echo "✓ agent-browser" && \
     which rg && echo "✓ ripgrep" && \
     which go && echo "✓ go" && \
     which python3 && echo "✓ python3" && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -231,25 +231,6 @@ RUN set -eux; \
     rm -rf /tmp/httpx_extracted /tmp/httpx.zip
 
 # ============================================================================
-# Caido CLI — Web Security Proxy (free, headless, GraphQL API)
-# ============================================================================
-RUN set -eux; \
-    arch=$(uname -m); \
-    if [ "$arch" = "x86_64" ]; then CAIDO_ARCH="x86_64"; \
-    elif [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then CAIDO_ARCH="aarch64"; \
-    else echo "Unsupported architecture: $arch" && exit 1; fi; \
-    CAIDO_VERSION=$(curl -s https://api.github.com/repos/caido/caido/releases/latest \
-      | grep '"tag_name"' | cut -d'"' -f4); \
-    echo "Installing caido-cli ${CAIDO_VERSION} for ${CAIDO_ARCH}"; \
-    wget -qO /tmp/caido-cli.tar.gz \
-      "https://caido.download/releases/${CAIDO_VERSION}/caido-cli-${CAIDO_VERSION}-linux-${CAIDO_ARCH}.tar.gz" && \
-    tar -xzf /tmp/caido-cli.tar.gz -C /tmp && \
-    chmod +x /tmp/caido-cli && \
-    mv /tmp/caido-cli /usr/local/bin/caido-cli && \
-    rm /tmp/caido-cli.tar.gz && \
-    mkdir -p /app/certs
-
-# ============================================================================
 # Create Wrapper Scripts for Python Tools
 # ============================================================================
 RUN set -eux; \
@@ -332,7 +313,6 @@ RUN set -eux; \
     which trivy && echo "✓ trivy" && \
     which zaproxy && echo "✓ zaproxy" && \
     which httpx && echo "✓ httpx" && \
-    which caido-cli && echo "✓ caido-cli" && \
     which chromium && echo "✓ chromium" && \
     which agent-browser && echo "✓ agent-browser" && \
     which rg && echo "✓ ripgrep" && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -217,14 +217,17 @@ RUN set -eux; \
     elif [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then platform="linux_arm64"; \
     else platform="linux_amd64"; fi; \
     HTTPX_URL=$(curl -s https://api.github.com/repos/projectdiscovery/httpx/releases/latest \
-      | grep -Eo '"browser_download_url"\s*:\s*"[^"]*' | cut -d '"' -f4 \
-      | grep -E "${platform}\\.zip$" | head -n1); \
+      | grep "browser_download_url" | cut -d '"' -f4 \
+      | grep "${platform}.zip$" | head -n1); \
+    test -n "$HTTPX_URL"; \
     echo "Fetching httpx: $HTTPX_URL"; \
-    wget -qO /tmp/httpx.zip "$HTTPX_URL" && \
-    mkdir -p /tmp/httpx_extracted && \
-    unzip -q /tmp/httpx.zip -d /tmp/httpx_extracted || true && \
-    find /tmp/httpx_extracted -type f -name httpx -exec mv {} /usr/local/bin/httpx \; || true && \
-    chmod +x /usr/local/bin/httpx || true && \
+    wget -qO /tmp/httpx.zip "$HTTPX_URL"; \
+    mkdir -p /tmp/httpx_extracted; \
+    unzip -q /tmp/httpx.zip -d /tmp/httpx_extracted; \
+    httpx_bin=$(find /tmp/httpx_extracted -type f -name httpx | head -n1); \
+    test -n "$httpx_bin"; \
+    mv "$httpx_bin" /usr/local/bin/httpx; \
+    chmod +x /usr/local/bin/httpx; \
     rm -rf /tmp/httpx_extracted /tmp/httpx.zip
 
 # ============================================================================

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -49,6 +49,25 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     );
   });
 
+  it("describes cloud sandbox browser automation tools", async () => {
+    const prompt = await systemPrompt(
+      "user_123",
+      "agent",
+      "pro",
+      "agent-model",
+      null,
+      false,
+      null,
+    );
+
+    expect(prompt).toContain("whois");
+    expect(prompt).toContain("Chromium and agent-browser");
+    expect(prompt).toContain("agent-browser snapshot -i");
+    expect(prompt).toContain("agent-browser set viewport 1920 1080");
+    expect(prompt).toContain("/home/user/agent-browser-screenshots");
+    expect(prompt).toContain("file tool's view action");
+  });
+
   it("does not describe a command sandbox in ask mode", async () => {
     const prompt = await systemPrompt(
       "user_123",

--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -333,13 +333,9 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
       "agent_browser_terminal_command_used",
       expect.objectContaining({
         userId: "u1",
-        user_id: "u1",
         chat_id: "chat-1",
         mode: "agent",
-        subscription: "pro",
         subscription_tier: "pro",
-        configured_model: "configured-model",
-        active_model: "active-model",
         sandbox_type: "remote-connection",
         primary_action: "open",
         actions: ["open", "screenshot"],
@@ -347,8 +343,15 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
         used_via_npx: false,
         interactive: false,
         is_background: false,
+        agent_browser_usage_event_version: 1,
       }),
     );
+    expect(mockPhEvent.mock.calls[0]?.[1]).not.toHaveProperty("user_id");
+    expect(mockPhEvent.mock.calls[0]?.[1]).not.toHaveProperty("subscription");
+    expect(mockPhEvent.mock.calls[0]?.[1]).not.toHaveProperty(
+      "configured_model",
+    );
+    expect(mockPhEvent.mock.calls[0]?.[1]).not.toHaveProperty("active_model");
     expect(JSON.stringify(mockPhEvent.mock.calls)).not.toContain(
       "secret.example",
     );

--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -36,7 +36,19 @@ jest.mock("../utils/proxy-manager", () => ({
   ensureCaido: async () => undefined,
 }));
 
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: {
+    event: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    flush: jest.fn(),
+  },
+}));
+
+import { phLogger } from "@/lib/posthog/server";
 import { createRunTerminalCmd } from "../run-terminal-cmd";
+import { detectAgentBrowserUsage } from "../utils/agent-browser-usage";
 import type { PtyHandle } from "../utils/e2b-pty-adapter";
 import {
   PtySessionManager,
@@ -163,6 +175,9 @@ function makeContext(opts: {
     backgroundProcessTracker: {} as never,
     ptySessionManager,
     mode: "agent",
+    modelName: "configured-model",
+    getCurrentModelName: () => "active-model",
+    subscription: "pro",
     isE2BSandbox: (s: unknown) => {
       if (!s || typeof s !== "object") return false;
       if ((s as { sandboxKind?: unknown }).sandboxKind === "centrifugo")
@@ -176,6 +191,10 @@ function makeContext(opts: {
 
   return { context, writerWrites, sandboxManager, ptySessionManager };
 }
+
+const mockPhEvent = phLogger.event as jest.MockedFunction<
+  typeof phLogger.event
+>;
 
 // Helper: invoke the tool.execute with given args/options.
 async function runTool(
@@ -198,6 +217,39 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
   beforeEach(() => {
     mockCreateE2BPtyHandle.mockReset();
     mockCreateCentrifugoPtyHandle.mockReset();
+    mockPhEvent.mockClear();
+  });
+
+  test("detectAgentBrowserUsage extracts sanitized actions", () => {
+    const usage = detectAgentBrowserUsage(
+      "agent-browser open https://secret.example/login && agent-browser snapshot -i",
+    );
+
+    expect(usage).toEqual({
+      invocationCount: 2,
+      primaryAction: "open",
+      actions: ["open", "snapshot"],
+      usedViaNpx: false,
+    });
+    expect(JSON.stringify(usage)).not.toContain("secret.example");
+  });
+
+  test("detectAgentBrowserUsage supports env prefixes and npx", () => {
+    expect(
+      detectAgentBrowserUsage(
+        "AGENT_BROWSER_SESSION_NAME=scan npx -y agent-browser click @e3",
+      ),
+    ).toEqual({
+      invocationCount: 1,
+      primaryAction: "click",
+      actions: ["click"],
+      usedViaNpx: true,
+    });
+  });
+
+  test("detectAgentBrowserUsage ignores whitespace-only mentions", () => {
+    expect(detectAgentBrowserUsage("echo agent-browser open")).toBeNull();
+    expect(detectAgentBrowserUsage("agent-browser-next open")).toBeNull();
   });
 
   test("regression: legacy schema {command, brief, is_background, timeout} still works", async () => {
@@ -250,6 +302,56 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     expect(
       (nonE2B.commands.run as jest.Mock).mock.calls[0][0] as string,
     ).toContain("echo hi");
+  });
+
+  test("logs sanitized agent-browser terminal usage to PostHog", async () => {
+    const nonE2B = {
+      sandboxKind: "centrifugo" as const,
+      isWindows: () => false,
+      commands: {
+        run: jest.fn(
+          async (_cmd: string, opts?: { onStdout?: (s: string) => void }) => {
+            opts?.onStdout?.("opened\n");
+            return { stdout: "opened\n", stderr: "", exitCode: 0 };
+          },
+        ),
+      },
+    };
+
+    const { context } = makeContext({ sandbox: nonE2B });
+    const tool = createRunTerminalCmd(context);
+
+    await runTool(tool, {
+      command:
+        "agent-browser open https://secret.example/login && agent-browser screenshot",
+      brief: "open a browser page",
+      is_background: false,
+      timeout: 5,
+    });
+
+    expect(mockPhEvent).toHaveBeenCalledWith(
+      "agent_browser_terminal_command_used",
+      expect.objectContaining({
+        userId: "u1",
+        user_id: "u1",
+        chat_id: "chat-1",
+        mode: "agent",
+        subscription: "pro",
+        subscription_tier: "pro",
+        configured_model: "configured-model",
+        active_model: "active-model",
+        sandbox_type: "remote-connection",
+        primary_action: "open",
+        actions: ["open", "screenshot"],
+        invocation_count: 2,
+        used_via_npx: false,
+        interactive: false,
+        is_background: false,
+      }),
+    );
+    expect(JSON.stringify(mockPhEvent.mock.calls)).not.toContain(
+      "secret.example",
+    );
   });
 
   test("schema defaults action=exec and interactive=false when omitted", async () => {

--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -237,7 +237,7 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
   test("detectAgentBrowserUsage supports env prefixes and npx", () => {
     expect(
       detectAgentBrowserUsage(
-        "AGENT_BROWSER_SESSION_NAME=scan npx -y agent-browser click @e3",
+        "AGENT_BROWSER_SESSION_NAME=scan npx -y agent-browser@0.26.0 click @e3",
       ),
     ).toEqual({
       invocationCount: 1,

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -39,6 +39,7 @@ import {
   stripAnsi,
   peekExited,
 } from "./utils/pty-wait-utils";
+import { captureAgentBrowserUsage } from "./utils/agent-browser-usage";
 
 const DEFAULT_STREAM_TIMEOUT_SECONDS = 60;
 const MAX_TIMEOUT_SECONDS = 600;
@@ -242,6 +243,14 @@ In using these tools, adhere to the following guidelines:
             };
           }
 
+          captureAgentBrowserUsage({
+            context,
+            command,
+            sandbox,
+            interactive: true,
+            isBackground: false,
+          });
+
           // Set up Caido proxy env vars before spawning the PTY so the session
           // launches with proxy env pointing at a running Caido. Mirrors the
           // non-interactive `executeCommand` flow: only eager on E2B; on
@@ -442,6 +451,14 @@ In using these tools, adhere to the following guidelines:
         return executeCommand(sandbox);
 
         async function executeCommand(sandboxInstance: typeof sandbox) {
+          captureAgentBrowserUsage({
+            context,
+            command,
+            sandbox: sandboxInstance,
+            interactive: false,
+            isBackground: is_background,
+          });
+
           // Ensure Caido proxy is running + authenticated before commands route through it.
           // Only eager on E2B; local sandboxes defer setup to proxy tool invocations.
           // This is a no-op after the first successful call (cached per session).

--- a/lib/ai/tools/utils/agent-browser-usage.ts
+++ b/lib/ai/tools/utils/agent-browser-usage.ts
@@ -1,0 +1,138 @@
+import type { AnySandbox, SandboxType, ToolContext } from "@/types";
+import { phLogger } from "@/lib/posthog/server";
+import { isCentrifugoSandbox, isE2BSandbox } from "./sandbox-types";
+
+const AGENT_BROWSER_INVOCATION_RE =
+  /(?:^|[;&|()]\s*)(?:(?:env\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s;&|()]+)\s+)*)?(?:npx\s+(?:--yes\s+|-y\s+)?)?agent-browser(?=$|\s|[;&|()])(?:\s+([^\s;&|()]+))?/g;
+
+const KNOWN_AGENT_BROWSER_ACTIONS = new Set([
+  "open",
+  "snapshot",
+  "click",
+  "dblclick",
+  "hover",
+  "focus",
+  "fill",
+  "type",
+  "press",
+  "check",
+  "uncheck",
+  "select",
+  "upload",
+  "scroll",
+  "scrollintoview",
+  "drag",
+  "find",
+  "wait",
+  "get",
+  "eval",
+  "screenshot",
+  "close",
+  "viewport",
+  "tab",
+  "network",
+  "record",
+  "frame",
+  "dialog",
+  "keyboard",
+  "state",
+  "set",
+  "auth",
+  "doctor",
+  "react",
+  "vitals",
+  "pushstate",
+  "skills",
+  "batch",
+  "diff",
+  "key",
+]);
+
+export type AgentBrowserCommandUsage = {
+  invocationCount: number;
+  primaryAction: string;
+  actions: string[];
+  usedViaNpx: boolean;
+};
+
+function normalizeAgentBrowserAction(rawAction: string | undefined): string {
+  if (!rawAction) return "unknown";
+  const action = rawAction.replace(/^["']|["']$/g, "").toLowerCase();
+  if (!action || action.startsWith("-")) return "option";
+  if (KNOWN_AGENT_BROWSER_ACTIONS.has(action)) return action;
+  if (/^[a-z][a-z0-9_-]{0,40}$/.test(action)) return "other";
+  return "unknown";
+}
+
+export function detectAgentBrowserUsage(
+  command: string,
+): AgentBrowserCommandUsage | null {
+  const actions: string[] = [];
+  let invocationCount = 0;
+  let usedViaNpx = false;
+
+  AGENT_BROWSER_INVOCATION_RE.lastIndex = 0;
+  for (
+    let match = AGENT_BROWSER_INVOCATION_RE.exec(command);
+    match !== null;
+    match = AGENT_BROWSER_INVOCATION_RE.exec(command)
+  ) {
+    invocationCount++;
+    const matchedCommand = match[0] ?? "";
+    if (/\bnpx\s+(?:--yes\s+|-y\s+)?agent-browser\b/.test(matchedCommand)) {
+      usedViaNpx = true;
+    }
+    const action = normalizeAgentBrowserAction(match[1]);
+    if (!actions.includes(action)) actions.push(action);
+  }
+
+  if (invocationCount === 0) return null;
+  return {
+    invocationCount,
+    primaryAction: actions[0] ?? "unknown",
+    actions,
+    usedViaNpx,
+  };
+}
+
+function getAgentBrowserSandboxType(
+  context: ToolContext,
+  sandbox: AnySandbox,
+): SandboxType | "unknown" {
+  const sandboxType = context.sandboxManager.getSandboxType("run_terminal_cmd");
+  if (sandboxType) return sandboxType;
+  if (isCentrifugoSandbox(sandbox)) return "remote-connection";
+  if (isE2BSandbox(sandbox)) return "e2b";
+  return "unknown";
+}
+
+export function captureAgentBrowserUsage(args: {
+  context: ToolContext;
+  command: string;
+  sandbox: AnySandbox;
+  interactive: boolean;
+  isBackground: boolean;
+}): void {
+  const usage = detectAgentBrowserUsage(args.command);
+  if (!usage) return;
+
+  const activeModel = args.context.getCurrentModelName?.();
+
+  phLogger.event("agent_browser_terminal_command_used", {
+    userId: args.context.userID,
+    user_id: args.context.userID,
+    chat_id: args.context.chatId,
+    mode: args.context.mode,
+    subscription: args.context.subscription,
+    subscription_tier: args.context.subscription,
+    configured_model: args.context.modelName,
+    active_model: activeModel ?? args.context.modelName,
+    sandbox_type: getAgentBrowserSandboxType(args.context, args.sandbox),
+    primary_action: usage.primaryAction,
+    actions: usage.actions,
+    invocation_count: usage.invocationCount,
+    used_via_npx: usage.usedViaNpx,
+    interactive: args.interactive,
+    is_background: args.isBackground,
+  });
+}

--- a/lib/ai/tools/utils/agent-browser-usage.ts
+++ b/lib/ai/tools/utils/agent-browser-usage.ts
@@ -120,17 +120,11 @@ export function captureAgentBrowserUsage(args: {
   const usage = detectAgentBrowserUsage(args.command);
   if (!usage) return;
 
-  const activeModel = args.context.getCurrentModelName?.();
-
   phLogger.event("agent_browser_terminal_command_used", {
     userId: args.context.userID,
-    user_id: args.context.userID,
     chat_id: args.context.chatId,
     mode: args.context.mode,
-    subscription: args.context.subscription,
     subscription_tier: args.context.subscription,
-    configured_model: args.context.modelName,
-    active_model: activeModel ?? args.context.modelName,
     sandbox_type: getAgentBrowserSandboxType(args.context, args.sandbox),
     primary_action: usage.primaryAction,
     actions: usage.actions,
@@ -138,5 +132,6 @@ export function captureAgentBrowserUsage(args: {
     used_via_npx: usage.usedViaNpx,
     interactive: args.interactive,
     is_background: args.isBackground,
+    agent_browser_usage_event_version: 1,
   });
 }

--- a/lib/ai/tools/utils/agent-browser-usage.ts
+++ b/lib/ai/tools/utils/agent-browser-usage.ts
@@ -3,7 +3,7 @@ import { phLogger } from "@/lib/posthog/server";
 import { isCentrifugoSandbox, isE2BSandbox } from "./sandbox-types";
 
 const AGENT_BROWSER_INVOCATION_RE =
-  /(?:^|[;&|()]\s*)(?:(?:env\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s;&|()]+)\s+)*)?(?:npx\s+(?:--yes\s+|-y\s+)?)?agent-browser(?=$|\s|[;&|()])(?:\s+([^\s;&|()]+))?/g;
+  /(?:^|[;&|()]\s*)(?:(?:env\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s;&|()]+)\s+)*)?(?:npx\s+(?:--yes\s+|-y\s+)?)?agent-browser(?:@[^\s;&|()]+)?(?=$|\s|[;&|()])(?:\s+([^\s;&|()]+))?/g;
 
 const KNOWN_AGENT_BROWSER_ACTIONS = new Set([
   "open",
@@ -79,7 +79,11 @@ export function detectAgentBrowserUsage(
   ) {
     invocationCount++;
     const matchedCommand = match[0] ?? "";
-    if (/\bnpx\s+(?:--yes\s+|-y\s+)?agent-browser\b/.test(matchedCommand)) {
+    if (
+      /\bnpx\s+(?:--yes\s+|-y\s+)?agent-browser(?:@[^\s;&|()]+)?(?=$|\s|[;&|()])/.test(
+        matchedCommand,
+      )
+    ) {
       usedViaNpx = true;
     }
     const action = normalizeAgentBrowserAction(match[1]);

--- a/lib/ai/tools/utils/sandbox.ts
+++ b/lib/ai/tools/utils/sandbox.ts
@@ -20,7 +20,8 @@ const MAX_CREATE_RETRIES = 3;
  */
 // v8: upgraded sandbox CPU (4 cores) and memory (2GB)
 // v9: added Caido proxy (caido-cli install, lazy start via ensureCaido, HTTP_PROXY env vars)
-const SANDBOX_VERSION = "v9";
+// v10: added whois, Chromium, and agent-browser browser automation
+const SANDBOX_VERSION = "v10";
 
 /**
  * Ensures a sandbox connection is established and maintained

--- a/lib/ai/tools/utils/sandbox.ts
+++ b/lib/ai/tools/utils/sandbox.ts
@@ -21,7 +21,8 @@ const MAX_CREATE_RETRIES = 3;
 // v8: upgraded sandbox CPU (4 cores) and memory (2GB)
 // v9: added Caido proxy (caido-cli install, lazy start via ensureCaido, HTTP_PROXY env vars)
 // v10: added whois, Chromium, and agent-browser browser automation
-const SANDBOX_VERSION = "v10";
+// v11: removed preinstalled caido-cli from the sandbox image
+const SANDBOX_VERSION = "v11";
 
 /**
  * Ensures a sandbox connection is established and maintained

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -31,7 +31,7 @@ DO NOT switch the working language midway unless explicitly requested by the use
 // Shared pentesting tools list for sandbox environments
 export const PREINSTALLED_PENTESTING_TOOLS = `Pre-installed Pentesting Tools:
 - Network Scanning: nmap (network mapping/port scanning), naabu (fast port scanner), httpx (HTTP prober)
-- Subdomain/DNS: subfinder (subdomain enumeration), dnsrecon, dnsenum
+- Subdomain/DNS: subfinder (subdomain enumeration), dnsrecon, dnsenum, whois
 - Web Fuzzing: ffuf (fast fuzzer), dirsearch (directory/file discovery), arjun (parameter discovery)
 - Web Scanners: nikto (web server scanner), whatweb (web technology identifier), wpscan (WordPress scanner), wapiti (web vulnerability scanner), wafw00f (WAF detection)
 - Injection: sqlmap (SQL injection detection/exploitation)
@@ -45,7 +45,28 @@ export const PREINSTALLED_PENTESTING_TOOLS = `Pre-installed Pentesting Tools:
 - Forensics: binwalk, foremost (file carving)
 - Utilities: gobuster, socat, proxychains4, hashid, libimage-exiftool-perl (exiftool), cewl
 - Specialized: jwt_tool (JWT manipulation), interactsh-client (OOB interaction testing), SecLists (/home/user/SecLists or /usr/share/seclists)
+- Browser Automation: Chromium and agent-browser (headless browser CLI with accessibility snapshots, element refs, form interaction, screenshots, tabs, and network inspection)
 - Documents: reportlab, python-docx, openpyxl, python-pptx, pandas, pypandoc, pandoc, odfpy`;
+
+const AGENT_BROWSER_SECTION = `<agent_browser>
+agent-browser is installed in the cloud sandbox for headless Chromium automation through terminal commands.
+
+Preferred workflow:
+- Open a page: \`agent-browser open <url>\`
+- Inspect interactable elements: \`agent-browser snapshot -i\`
+- Interact with refs from the latest snapshot: \`agent-browser click @e3\`, \`agent-browser fill @e4 "value"\`, \`agent-browser press Enter\`
+- After any page change, wait for the expected URL/text/element and run \`agent-browser snapshot -i\` again because refs become stale.
+
+Useful reading commands:
+- \`agent-browser snapshot -i -u\` to include link URLs.
+- \`agent-browser get text @e1\`, \`agent-browser get attr @e1 href\`, \`agent-browser get url\`, and \`agent-browser get title\` for targeted extraction.
+- Use semantic locators such as \`agent-browser find role button click --name "Submit"\` when a snapshot ref is unavailable.
+
+Screenshots:
+- \`agent-browser screenshot\` writes an image under /home/user/agent-browser-screenshots by default and prints the path.
+- Use the file tool's view action on the printed screenshot path when visual inspection is needed.
+- For pages with responsive layouts, run \`agent-browser set viewport 1920 1080\` once before navigating.
+</agent_browser>`;
 
 type SecurityExecutionEnvironment = "ask" | "cloud" | "local-host";
 
@@ -169,6 +190,8 @@ Development Environment:
 - Golang 1.24.2 (commands: go)
 
 ${PREINSTALLED_PENTESTING_TOOLS}
+
+${AGENT_BROWSER_SECTION}
 
 ${getProxySection(caidoEnabled, false, caidoPort)}
 </sandbox_environment>`;


### PR DESCRIPTION
## Summary

- Add `whois`, Chromium, and pinned `agent-browser@0.26.0` to the sandbox image.
- Document the cloud sandbox `agent-browser` workflow in the system prompt, including snapshots, refs, screenshots, and viewport setup.
- Capture sanitized PostHog usage for terminal-driven `agent-browser` commands without logging URLs, raw commands, hostnames, or form values.
- Bump the sandbox image version to `v11` so existing sandboxes are recreated with the new tooling and without preinstalled Caido.
- Remove preinstalled `caido-cli` from the sandbox image because the proxy path is currently disabled and we do not want the extra image/build maintenance drag.
- Fix Kali/E2B build issues: Debian `rich` vs `httpx[cli]`, idempotent `user` setup, stable login-shell PATH, and E2B-safe `httpx` binary download shell.

## Context

HAC-19 called out Strix's browser workflow as the most useful delta. This keeps `agent-browser` as a terminal workflow rather than adding a separate tool surface, while still giving us usage counts in PostHog.

Caido proxy remains disabled at the product/tooling layer. This PR now also removes the preinstalled `caido-cli` binary from the sandbox image; any future proxy reactivation should be handled as a separate scoped issue.

## Validation

- `pnpm test -- lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/__tests__/system-prompt.test.ts`
- `pnpm typecheck`
- `pnpm lint -- lib/ai/tools/utils/agent-browser-usage.ts lib/ai/tools/run-terminal-cmd.ts lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/system-prompt.ts lib/__tests__/system-prompt.test.ts` (passes with existing unrelated warnings)
- Commit hooks repeatedly ran `prettier --write`, `eslint --fix`, `pnpm typecheck`, and full `pnpm test` successfully: 112 suites / 1309 tests passed.
- Dockerfile shell checks for the PATH and `httpx` download fixes were reproduced in `kalilinux/kali-rolling` containers.
- Earlier local Docker build passed before the latest Caido removal; rerun `pnpm docker:build:push` from this branch before deploying the final image.
