### PR TITLE
[codex] Guard provider image downloads by resolved size

### DIFF
--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -134,6 +134,43 @@ describe("processMessageFiles image size guards", () => {
     });
   });
 
+  it("keeps stored images when resolved storage size is within limit despite stale oversized metadata", async () => {
+    mockConvexAction.mockResolvedValue([
+      "https://storage.example/actually-small.png",
+    ]);
+    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
+      if (init?.method === "HEAD") {
+        return responseLike({
+          headers: { "content-length": String(2 * 1024 * 1024) },
+        });
+      }
+
+      throw new Error("Range probe should not run when HEAD has a size");
+    }) as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        mediaType: "image/png",
+        fileId: "file_actually_small",
+        name: "actually-small.png",
+        size: 40 * 1024 * 1024,
+        url: "https://example.com/actually-small.png",
+      }),
+      "ask",
+      "user123",
+      undefined,
+      "pro",
+    );
+
+    expect(result.messages[0].parts[1]).toMatchObject({
+      type: "file",
+      mediaType: "image/png",
+      name: "actually-small.png",
+      url: "https://storage.example/actually-small.png",
+    });
+  });
+
   it("omits URL-backed images when headers are inconclusive but the range probe exceeds 5 MB", async () => {
     mockConvexAction.mockResolvedValue([
       "https://storage.example/unknown-size.png",

--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -99,6 +99,41 @@ describe("processMessageFiles image size guards", () => {
     ]);
   });
 
+  it("omits images when resolved storage size exceeds stale message metadata", async () => {
+    mockConvexAction.mockResolvedValue([
+      "https://storage.example/stale-metadata.png",
+    ]);
+    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
+      if (init?.method === "HEAD") {
+        return responseLike({
+          headers: { "content-length": String(40 * 1024 * 1024) },
+        });
+      }
+
+      throw new Error("Range probe should not run when HEAD has a size");
+    }) as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        mediaType: "image/png",
+        fileId: "file_stale",
+        name: "stale-metadata.png",
+        size: 1024,
+        url: "https://example.com/stale-metadata.png",
+      }),
+      "ask",
+      "user123",
+      undefined,
+      "pro",
+    );
+
+    expect(result.messages[0].parts[1]).toEqual({
+      type: "text",
+      text: '[Image "stale-metadata.png" omitted: 40.0 MB exceeds the 30 MB per-image limit]',
+    });
+  });
+
   it("omits URL-backed images when headers are inconclusive but the range probe exceeds 5 MB", async () => {
     mockConvexAction.mockResolvedValue([
       "https://storage.example/unknown-size.png",

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -209,11 +209,10 @@ const imageOmittedText = (
   `[Image "${typeof name === "string" && name.length > 0 ? name : "unnamed"}" omitted: ${(sizeBytes / (1024 * 1024)).toFixed(1)} MB exceeds the ${limitBytes / (1024 * 1024)} MB per-image limit]`;
 
 /**
- * Replace image file parts whose declared size exceeds Anthropic's 5 MiB
- * per-image limit with a short text note. Without this, the model call fails
- * with `image exceeds 5 MB maximum` once OpenRouter re-encodes the URL as
- * base64. Older messages may not have a `size` field; those are checked
- * against the resolved storage URL below.
+ * Replace non-stored image file parts whose declared size exceeds Anthropic's
+ * 5 MiB per-image limit with a short text note. Stored `fileId` images are
+ * checked against their resolved storage URL below, so stale message metadata
+ * cannot omit an otherwise valid image.
  */
 const replaceOversizedImageParts = (messages: UIMessage[]) => {
   messages.forEach((msg) => {
@@ -222,6 +221,7 @@ const replaceOversizedImageParts = (messages: UIMessage[]) => {
       if (
         !isFilePart(part) ||
         !isSupportedImageMediaType(part.mediaType ?? "") ||
+        typeof (part as any).fileId === "string" ||
         typeof (part as any).size !== "number" ||
         (part as any).size <= MAX_IMAGE_SIZE
       ) {

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -212,7 +212,8 @@ const imageOmittedText = (
  * Replace image file parts whose declared size exceeds Anthropic's 5 MiB
  * per-image limit with a short text note. Without this, the model call fails
  * with `image exceeds 5 MB maximum` once OpenRouter re-encodes the URL as
- * base64. Older messages may not have a `size` field — those are left alone.
+ * base64. Older messages may not have a `size` field; those are checked
+ * against the resolved storage URL below.
  */
 const replaceOversizedImageParts = (messages: UIMessage[]) => {
   messages.forEach((msg) => {
@@ -364,17 +365,17 @@ const applyUrlsToFileParts = async (
         ] as any)
       : null;
     const isSupportedImage = isSupportedImageMediaType(file.mediaType ?? "");
+    // The storage URL is the provider-visible payload. Probe it even when the
+    // message has size metadata so stale or incorrect client/DB metadata can't
+    // leak an oversized image into OpenRouter and trigger a provider 413.
     const shouldProbeImageSize =
-      isSupportedImage &&
-      file.url &&
-      (!file.fileId || typeof firstPart?.size !== "number");
+      isSupportedImage && file.url && mode !== "agent";
     const probedImageSize = shouldProbeImageSize
       ? await probeImageSize(file.url, MAX_IMAGE_SIZE)
       : null;
-    const effectiveImageSize =
-      typeof firstPart?.size === "number"
-        ? firstPart.size
-        : (probedImageSize?.bytes ?? null);
+    const declaredImageSize =
+      typeof firstPart?.size === "number" ? firstPart.size : null;
+    const effectiveImageSize = probedImageSize?.bytes ?? declaredImageSize;
     const imageLimit =
       effectiveImageSize != null &&
       effectiveImageSize > MAX_PROVIDER_IMAGE_DOWNLOAD_SIZE
@@ -396,9 +397,8 @@ const applyUrlsToFileParts = async (
         size_bytes: effectiveImageSize,
         limit_bytes: imageLimit,
         size_source:
-          typeof firstPart?.size === "number"
-            ? "message_part"
-            : probedImageSize?.source,
+          probedImageSize?.source ??
+          (declaredImageSize != null ? "message_part" : undefined),
         mode,
       });
     }


### PR DESCRIPTION
## Summary

Prevents oversized Ask-mode image attachments from reaching OpenRouter by probing the resolved storage URL even when the message part already has size metadata.

## Root Cause

The chat file transform trusted `part.size` for stored images and skipped the provider-visible URL size probe. If that metadata was stale or incorrect, a resolved storage object over OpenRouter's 30 MB downloaded-image cap could still be sent to the provider and fail the stream with a 413.

## Impact

Oversized images are now replaced with the existing text omission note before the provider call. The storage URL remains authoritative for Ask-mode image sizing, while declared size metadata is used only as a fallback if probing cannot determine the size.

## Validation

- `pnpm test -- lib/utils/__tests__/file-transform-utils.test.ts --runInBand`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint lib/utils/file-transform-utils.ts lib/utils/__tests__/file-transform-utils.test.ts`
- Commit hook: full `tsc --noEmit` and full Jest suite, 112 suites / 1305 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved oversized-image handling by probing the actual storage URL for file size (ensuring images over the 30MB limit are omitted even when metadata is stale) and by leaving already-stored files untouched.
  * Omission warnings now indicate how the reported size was determined.

* **Tests**
  * Added tests covering omission vs retention behavior when resolved storage sizes differ from message metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->