### PR TITLE
[codex] Fix WorkOS MFA factor listing

### DIFF
--- a/app/api/mfa/__tests__/workos-factors.test.ts
+++ b/app/api/mfa/__tests__/workos-factors.test.ts
@@ -1,0 +1,61 @@
+import { workos } from "@/app/api/workos";
+import { listUserMfaFactors } from "../workos-factors";
+
+jest.mock("@/app/api/workos", () => ({
+  workos: {
+    get: jest.fn(),
+  },
+}));
+
+const mockWorkosGet = workos.get as jest.Mock;
+
+describe("listUserMfaFactors", () => {
+  it("maps auth factors without requiring TOTP data", async () => {
+    mockWorkosGet.mockResolvedValueOnce({
+      data: {
+        data: [
+          {
+            id: "auth_factor_totp",
+            type: "totp",
+            created_at: "2026-06-04T15:00:00.000Z",
+            updated_at: "2026-06-04T15:01:00.000Z",
+            totp: {
+              issuer: "HackerAI",
+              user: "user@example.com",
+            },
+          },
+          {
+            id: "auth_factor_without_totp",
+            type: "sms",
+            created_at: "2026-06-04T15:02:00.000Z",
+            updated_at: "2026-06-04T15:03:00.000Z",
+          },
+        ],
+      },
+    });
+
+    await expect(listUserMfaFactors("user_123")).resolves.toEqual([
+      {
+        id: "auth_factor_totp",
+        type: "totp",
+        issuer: "HackerAI",
+        user: "user@example.com",
+        createdAt: "2026-06-04T15:00:00.000Z",
+        updatedAt: "2026-06-04T15:01:00.000Z",
+      },
+      {
+        id: "auth_factor_without_totp",
+        type: "sms",
+        issuer: undefined,
+        user: undefined,
+        createdAt: "2026-06-04T15:02:00.000Z",
+        updatedAt: "2026-06-04T15:03:00.000Z",
+      },
+    ]);
+
+    expect(mockWorkosGet).toHaveBeenCalledWith(
+      "/user_management/users/user_123/auth_factors",
+      { query: { order: "desc" } },
+    );
+  });
+});

--- a/app/api/mfa/delete/route.ts
+++ b/app/api/mfa/delete/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { workos } from "@/app/api/workos";
 import { getUserID } from "@/lib/auth/get-user-id";
 import { isUnauthorizedError } from "@/lib/api/response";
+import { listUserMfaFactors } from "@/app/api/mfa/workos-factors";
 
 interface DeleteMfaFactorRequest {
   factorId?: string;
@@ -50,10 +51,8 @@ export async function POST(req: NextRequest) {
     }
 
     // Ensure factor belongs to the authenticated user
-    const factors = await workos.multiFactorAuth.listUserAuthFactors({
-      userId,
-    });
-    const ownsFactor = factors.data.some((f) => f.id === factorId);
+    const factors = await listUserMfaFactors(userId);
+    const ownsFactor = factors.some((f) => f.id === factorId);
     if (!ownsFactor) {
       return NextResponse.json({ error: "Factor not found" }, { status: 404 });
     }

--- a/app/api/mfa/factors/route.ts
+++ b/app/api/mfa/factors/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserID } from "@/lib/auth/get-user-id";
-import { workos } from "@/app/api/workos";
 import { isUnauthorizedError } from "@/lib/api/response";
+import { listUserMfaFactors } from "@/app/api/mfa/workos-factors";
 
 export async function GET(req: NextRequest) {
   try {
@@ -19,23 +19,10 @@ export async function GET(req: NextRequest) {
       );
     }
 
-    // Get user's MFA factors from WorkOS
-    const factors = await workos.multiFactorAuth.listUserAuthFactors({
-      userId: userId,
-    });
-
-    // Transform factors for client response
-    const transformedFactors = factors.data.map((factor) => ({
-      id: factor.id,
-      type: factor.type,
-      issuer: factor.totp?.issuer,
-      user: factor.totp?.user,
-      createdAt: factor.createdAt,
-      updatedAt: factor.updatedAt,
-    }));
+    const factors = await listUserMfaFactors(userId);
 
     return NextResponse.json({
-      factors: transformedFactors,
+      factors,
     });
   } catch (error) {
     console.error("Get MFA factors error:", error);

--- a/app/api/mfa/workos-factors.ts
+++ b/app/api/mfa/workos-factors.ts
@@ -1,0 +1,43 @@
+import { workos } from "@/app/api/workos";
+
+interface WorkOSAuthFactorResponse {
+  id: string;
+  type: string;
+  created_at: string;
+  updated_at: string;
+  totp?: {
+    issuer?: string;
+    user?: string;
+  };
+}
+
+interface WorkOSAuthFactorsListResponse {
+  data: WorkOSAuthFactorResponse[];
+}
+
+export interface MfaFactor {
+  id: string;
+  type: string;
+  issuer?: string;
+  user?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function listUserMfaFactors(userId: string): Promise<MfaFactor[]> {
+  const { data } = await workos.get<WorkOSAuthFactorsListResponse>(
+    `/user_management/users/${encodeURIComponent(userId)}/auth_factors`,
+    {
+      query: { order: "desc" },
+    },
+  );
+
+  return data.data.map((factor) => ({
+    id: factor.id,
+    type: factor.type,
+    issuer: factor.totp?.issuer,
+    user: factor.totp?.user,
+    createdAt: factor.created_at,
+    updatedAt: factor.updated_at,
+  }));
+}


### PR DESCRIPTION
## Summary

- Added a guarded WorkOS AuthKit MFA factor listing helper that calls the raw `/user_management/users/:id/auth_factors` endpoint.
- Updated the MFA factors route and delete ownership check to use the guarded helper instead of `workos.multiFactorAuth.listUserAuthFactors()`.
- Added a regression test covering a WorkOS factor response without `totp` data.

## Root Cause

`@workos-inc/node@10.0.0` deserializes AuthKit user auth factors by unconditionally reading `factor.totp.issuer`. If WorkOS returns a non-TOTP factor or a factor missing `totp`, the SDK throws before the app can apply optional chaining. That caused `/api/mfa/factors` and the delete ownership check to fail with `Cannot read properties of undefined (reading 'issuer')`.

## Impact

The app can now list and verify ownership of MFA factors even when WorkOS includes a factor shape without TOTP metadata. TOTP metadata is still returned when present.

## Validation

- `pnpm test app/api/mfa/__tests__/workos-factors.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint app/api/mfa/workos-factors.ts app/api/mfa/factors/route.ts app/api/mfa/delete/route.ts app/api/mfa/__tests__/workos-factors.test.ts`
- `pnpm exec prettier --check app/api/mfa/workos-factors.ts app/api/mfa/factors/route.ts app/api/mfa/delete/route.ts app/api/mfa/__tests__/workos-factors.test.ts`
- Commit hook also ran `tsc --noEmit` and the full Jest suite: 113 suites / 1305 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated MFA factor retrieval logic into a reusable utility for improved code maintainability and consistency across authentication endpoints.

* **Tests**
  * Added comprehensive test suite for MFA factor retrieval and transformation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->