### PR TITLE
[codex] Fix tokenizer special token chat route errors

### DIFF
--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -13,8 +13,7 @@ if (typeof (Promise as unknown as { try?: unknown }).try !== "function") {
 
 import { action } from "./_generated/server";
 import { v, ConvexError } from "convex/values";
-import { countTokens } from "gpt-tokenizer";
-import { encode, decode } from "gpt-tokenizer";
+import { decode } from "gpt-tokenizer";
 import { getDocument } from "pdfjs-serverless";
 import { CSVLoader } from "@langchain/community/document_loaders/fs/csv";
 import mammoth from "mammoth";
@@ -35,7 +34,12 @@ import {
   isSupportedImageMediaType,
   validateUploadPolicy,
 } from "../lib/utils/upload-policy";
-import { FILE_TOKEN_PERCENT, MAX_TOKENS_PAID } from "../lib/token-utils";
+import {
+  FILE_TOKEN_PERCENT,
+  MAX_TOKENS_PAID,
+  safeCountTokens,
+  safeEncode,
+} from "../lib/token-utils";
 import {
   MAX_GENERATED_FILE_SIZE_BYTES,
   S3_USER_FILES_PREFIX,
@@ -223,11 +227,11 @@ const truncateContentByTokens = (
   content: string,
   maxTokens: number,
 ): string => {
-  const tokens = encode(content);
+  const tokens = safeEncode(content);
   if (tokens.length <= maxTokens) return content;
 
   const truncationSuffix = "\n\n[Content truncated due to token limit]";
-  const suffixTokens = countTokens(truncationSuffix);
+  const suffixTokens = safeCountTokens(truncationSuffix);
   const budgetForContent = maxTokens - suffixTokens;
 
   if (budgetForContent <= 0) {
@@ -466,7 +470,7 @@ const processFileAuto = async (
         const fileBuffer = Buffer.from(await blob.arrayBuffer());
         const textDecoder = new TextDecoder("utf-8");
         const textContent = textDecoder.decode(fileBuffer);
-        const fallbackTokens = countTokens(textContent);
+        const fallbackTokens = safeCountTokens(textContent);
 
         // Check token limit for fallback processing
         if (!skipTokenValidation && fallbackTokens > maxTokens) {
@@ -538,7 +542,7 @@ const processPdfFile = async (pdf: Blob): Promise<FileItemChunk[]> => {
   return [
     {
       content: completeText,
-      tokens: countTokens(completeText),
+      tokens: safeCountTokens(completeText),
     },
   ];
 };
@@ -551,7 +555,7 @@ const processCsvFile = async (csv: Blob): Promise<FileItemChunk[]> => {
   return [
     {
       content: completeText,
-      tokens: countTokens(completeText),
+      tokens: safeCountTokens(completeText),
     },
   ];
 };
@@ -566,7 +570,7 @@ const processJsonFile = async (json: Blob): Promise<FileItemChunk[]> => {
   return [
     {
       content: completeText,
-      tokens: countTokens(completeText),
+      tokens: safeCountTokens(completeText),
     },
   ];
 };
@@ -579,7 +583,7 @@ const processTxtFile = async (txt: Blob): Promise<FileItemChunk[]> => {
   return [
     {
       content: textContent,
-      tokens: countTokens(textContent),
+      tokens: safeCountTokens(textContent),
     },
   ];
 };
@@ -598,7 +602,7 @@ const processMarkdownFile = async (
   return [
     {
       content: finalContent,
-      tokens: countTokens(finalContent),
+      tokens: safeCountTokens(finalContent),
     },
   ];
 };
@@ -628,7 +632,7 @@ const processDocxFile = async (
       completeText = result.value;
     }
 
-    const tokens = countTokens(completeText);
+    const tokens = safeCountTokens(completeText);
 
     return [
       {

--- a/lib/__tests__/moderation.test.ts
+++ b/lib/__tests__/moderation.test.ts
@@ -1,0 +1,67 @@
+import {
+  describe,
+  expect,
+  it,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+
+const mockModerationsCreate = jest.fn();
+
+jest.mock("openai", () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    moderations: {
+      create: mockModerationsCreate,
+    },
+  })),
+}));
+
+const { getModerationResult } =
+  require("@/lib/moderation") as typeof import("@/lib/moderation");
+
+describe("getModerationResult", () => {
+  const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
+
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = "test-key";
+    mockModerationsCreate.mockReset();
+    mockModerationsCreate.mockResolvedValue({
+      results: [
+        {
+          categories: {
+            harassment: false,
+          },
+          category_scores: {
+            harassment: 0,
+          },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+  });
+
+  it("treats tokenizer special sentinels as normal text", async () => {
+    const result = await getModerationResult(
+      [
+        {
+          role: "user",
+          parts: [
+            {
+              type: "text",
+              text: "Please inspect this literal marker: <|im_start|>",
+            },
+          ],
+        },
+      ],
+      false,
+    );
+
+    expect(result.moderationText).toContain("<|im_start|>");
+    expect(mockModerationsCreate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/__tests__/token-utils.test.ts
+++ b/lib/__tests__/token-utils.test.ts
@@ -4,6 +4,7 @@ import {
   MAX_TOKENS_FREE,
   MAX_TOKENS_PAID,
   safeCountTokens,
+  safeEncode,
   sliceByTokens,
   truncateContent,
 } from "@/lib/token-utils";
@@ -28,6 +29,10 @@ describe("special token sentinels", () => {
     expect(() =>
       safeCountTokens("literal <|im_start|> sentinel"),
     ).not.toThrow();
+  });
+
+  it("encodes reserved tokenizer sentinels as plain text", () => {
+    expect(() => safeEncode("literal <|im_start|> sentinel")).not.toThrow();
   });
 
   it("preserves reserved tokenizer sentinel text when slicing", () => {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -35,8 +35,10 @@ import {
   captureBudgetSnapshot,
 } from "@/lib/chat/budget-monitor";
 import { UsageTracker } from "@/lib/usage-tracker";
-import { getMaxTokensForSubscription } from "@/lib/token-utils";
-import { countTokens } from "gpt-tokenizer";
+import {
+  getMaxTokensForSubscription,
+  safeCountTokens,
+} from "@/lib/token-utils";
 import { ChatSDKError } from "@/lib/errors";
 import PostHogClient from "@/app/posthog";
 import {
@@ -538,7 +540,7 @@ export const createChatHandler = () => {
               sandboxContext,
             );
 
-            const systemPromptTokens = countTokens(currentSystemPrompt);
+            const systemPromptTokens = safeCountTokens(currentSystemPrompt);
 
             const contextUsageOn = isContextUsageEnabled(subscription, mode);
             const ctxSystemTokens = contextUsageOn ? systemPromptTokens : 0;

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -37,7 +37,7 @@ import {
   findSummarizationInsertIndex,
 } from "@/lib/utils/stream-writer-utils";
 import { POINTS_PER_DOLLAR } from "@/lib/rate-limit/token-bucket";
-import { countMessagesTokens } from "@/lib/token-utils";
+import { countMessagesTokens, safeCountTokens } from "@/lib/token-utils";
 import {
   checkAndSummarizeIfNeeded,
   type EnsureSandbox,
@@ -53,7 +53,6 @@ import {
   getTeamExtraUsageState,
 } from "@/lib/extra-usage";
 import { systemPrompt } from "@/lib/system-prompt";
-import { countTokens } from "gpt-tokenizer";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 
 /**
@@ -1010,7 +1009,7 @@ export async function estimatePreflightInputTokens(args: {
     temporary,
     null,
   );
-  const systemTokens = countTokens(estimatedSystemPrompt);
+  const systemTokens = safeCountTokens(estimatedSystemPrompt);
   const toolSchemaOverhead = isAgentMode(mode) ? 1500 : 500;
   return messageTokens + systemTokens + toolSchemaOverhead;
 }

--- a/lib/moderation.ts
+++ b/lib/moderation.ts
@@ -1,5 +1,6 @@
 import OpenAI from "openai";
-import { encode, decode } from "gpt-tokenizer";
+import { decode } from "gpt-tokenizer";
+import { safeEncode } from "@/lib/token-utils";
 
 const MODERATION_TOKEN_LIMIT = 512;
 
@@ -144,7 +145,7 @@ function prepareInput(message: any): string {
 }
 
 function truncateByTokens(content: string): string {
-  const tokens = encode(content);
+  const tokens = safeEncode(content);
   if (tokens.length <= MODERATION_TOKEN_LIMIT) {
     return content;
   }

--- a/lib/token-utils.ts
+++ b/lib/token-utils.ts
@@ -39,7 +39,9 @@ export const safeCountTokens = (content: string): number => {
   }
 };
 
-const safeEncode = (content: string): ReturnType<typeof encodeGptTokens> => {
+export const safeEncode = (
+  content: string,
+): ReturnType<typeof encodeGptTokens> => {
   try {
     return encodeGptTokens(content);
   } catch (error) {

--- a/lib/utils/terminal-executor.ts
+++ b/lib/utils/terminal-executor.ts
@@ -1,9 +1,9 @@
-import { countTokens } from "gpt-tokenizer";
 import {
   STREAM_MAX_TOKENS,
   TOOL_DEFAULT_MAX_TOKENS,
   TRUNCATION_MESSAGE,
   TIMEOUT_MESSAGE,
+  safeCountTokens,
   truncateContent,
   sliceByTokens,
 } from "@/lib/token-utils";
@@ -67,13 +67,13 @@ export const createTerminalHandler = (
     // Don't stream if truncated or timed out
     if (truncated || timedOut) return;
 
-    const tokens = countTokens(output);
+    const tokens = safeCountTokens(output);
     if (totalTokens + tokens > maxTokens) {
       truncated = true;
 
       // Calculate how much content we can still fit
       const remainingTokens = maxTokens - totalTokens;
-      const truncationTokens = countTokens(TRUNCATION_MESSAGE);
+      const truncationTokens = safeCountTokens(TRUNCATION_MESSAGE);
 
       if (remainingTokens > truncationTokens) {
         // We can fit some content plus the truncation message
@@ -81,7 +81,7 @@ export const createTerminalHandler = (
         const truncatedOutput = sliceByTokens(output, contentBudget);
         if (truncatedOutput.trim()) {
           await onOutput(truncatedOutput);
-          totalTokens += countTokens(truncatedOutput);
+          totalTokens += safeCountTokens(truncatedOutput);
         }
       }
 
@@ -129,7 +129,7 @@ export const createTerminalHandler = (
  * Truncates terminal output to fit within token limits
  */
 export function truncateTerminalOutput(output: string): TerminalResult {
-  if (countTokens(output) <= TOOL_DEFAULT_MAX_TOKENS) {
+  if (safeCountTokens(output) <= TOOL_DEFAULT_MAX_TOKENS) {
     return { output };
   }
   return { output: truncateContent(output) };

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -12,7 +12,6 @@ import {
   UIMessage,
 } from "ai";
 import type { Geo } from "@vercel/functions";
-import { countTokens } from "gpt-tokenizer";
 import PostHogClient from "@/app/posthog";
 
 import { systemPrompt } from "@/lib/system-prompt";
@@ -59,7 +58,10 @@ import {
   prepareForNewStream,
   setConvexUrl,
 } from "@/lib/db/actions";
-import { getMaxTokensForSubscription } from "@/lib/token-utils";
+import {
+  getMaxTokensForSubscription,
+  safeCountTokens,
+} from "@/lib/token-utils";
 import { getBaseTodosForRequest } from "@/lib/utils/todo-utils";
 import {
   writeAutoContinue,
@@ -946,7 +948,7 @@ export const agentLongTask = task({
               temporary,
               sandboxContext,
             );
-            const systemPromptTokens = countTokens(currentSystemPrompt);
+            const systemPromptTokens = safeCountTokens(currentSystemPrompt);
 
             const contextUsageOn = isContextUsageEnabled(subscription, mode);
             const ctxSystemTokens = contextUsageOn ? systemPromptTokens : 0;


### PR DESCRIPTION
## Summary

Fixes chat route failures when literal tokenizer sentinels such as `<|im_start|>` appear in user, transcript, terminal, or file content.

## Root Cause

The previous fix guarded the shared token utility and compaction path, but several chat-facing code paths still called `gpt-tokenizer` directly. Those direct calls treated ChatML-style markers as disallowed special tokens and could throw before normal route error handling, producing a 503 during `/api/chat`, especially on regenerate flows that re-tokenize stored content.

## Changes

- Export `safeEncode` from `lib/token-utils.ts` so truncation paths can use the same special-token fallback as token counting.
- Route moderation truncation, chat preflight/system prompt accounting, agent-long accounting, terminal output truncation, and Convex file token counting through `safeCountTokens` / `safeEncode`.
- Add regression coverage for moderation handling of literal `<|im_start|>` and direct safe encoding.

## Validation

- `pnpm test -- lib/__tests__/token-utils.test.ts lib/__tests__/moderation.test.ts lib/chat/compaction/__tests__/prune-tool-outputs.test.ts`
- Pre-commit full `pnpm test`: 113 suites / 1306 tests passed
- Pre-commit `pnpm typecheck`
- `pnpm lint` passed with existing warnings only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for moderation API behavior with special character handling.
  * Added validation for tokenization edge cases with reserved sentinel text.

* **Bug Fixes**
  * Enhanced token counting robustness across file processing, chat interfaces, moderation workflows, and terminal output handling.

* **Refactor**
  * Updated tokenization utilities to use safer wrappers for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->