### PR TITLE
[codex] Fix billing cycle usage resets

### DIFF
--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -89,6 +89,27 @@ const metadataString = (
   return typeof value === "string" && value.length > 0 ? value : undefined;
 };
 
+function subscriptionCurrentPeriodEndSeconds(
+  subscription: Stripe.Subscription,
+): number | undefined {
+  const periodEnd = (subscription as { current_period_end?: unknown })
+    .current_period_end;
+  return typeof periodEnd === "number" &&
+    Number.isFinite(periodEnd) &&
+    periodEnd > 0
+    ? periodEnd
+    : undefined;
+}
+
+function monthlyUsagePeriodEndSeconds(
+  subscription: Stripe.Subscription,
+): number | undefined {
+  const price = subscription.items?.data[0]?.price;
+  if (priceBillingInterval(price) !== "month") return undefined;
+  if ((price?.recurring?.interval_count ?? 1) !== 1) return undefined;
+  return subscriptionCurrentPeriodEndSeconds(subscription);
+}
+
 /** Infer subscription tier from a Stripe product name (fallback when lookup_key is missing). */
 function tierFromProductName(name: string): SubscriptionTier | null {
   const lower = name.toLowerCase();
@@ -548,8 +569,12 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
       // Any users without a stash (shouldn't happen, but safe fallback)
       const nonTierChangeUsers = stashResults.filter((r) => r.stash === null);
       if (nonTierChangeUsers.length > 0) {
+        const fallbackUsagePeriodEnd =
+          monthlyUsagePeriodEndSeconds(subscription);
         await Promise.all(
-          nonTierChangeUsers.map(({ uid }) => resetRateLimitBuckets(uid, tier)),
+          nonTierChangeUsers.map(({ uid }) =>
+            resetRateLimitBuckets(uid, tier, fallbackUsagePeriodEnd),
+          ),
         );
       }
 
@@ -566,7 +591,10 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
   console.log(
     `[Subscription Webhook] invoice.paid (${resetMode.reason}): resetting ${tier} buckets for ${userIds.length} user(s)`,
   );
-  await Promise.all(userIds.map((uid) => resetRateLimitBuckets(uid, tier)));
+  const usagePeriodEnd = monthlyUsagePeriodEndSeconds(subscription);
+  await Promise.all(
+    userIds.map((uid) => resetRateLimitBuckets(uid, tier, usagePeriodEnd)),
+  );
 
   if (resetMode.reason === "subscription_create") {
     const item = subscription.items?.data[0];

--- a/app/components/SidebarUserNav.tsx
+++ b/app/components/SidebarUserNav.tsx
@@ -338,6 +338,13 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
     return user.firstName || user.lastName || "User";
   };
 
+  const includedUsageRemainingPercentage =
+    tokenUsage && tokenUsage.monthly.limit > 0
+      ? Math.round(
+          (tokenUsage.monthly.remaining / tokenUsage.monthly.limit) * 100,
+        )
+      : 0;
+
   return (
     <div className="relative">
       <ReferralRewardDialog
@@ -511,11 +518,9 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
                   ) : tokenUsage ? (
                     <>
                       <div className="flex items-center justify-between py-1.5 text-sm">
-                        <span className="text-muted-foreground">Monthly</span>
+                        <span className="text-muted-foreground">Included</span>
                         <div className="flex items-center gap-3 tabular-nums text-muted-foreground">
-                          <span>
-                            {tokenUsage.monthly.usagePercentage}% used
-                          </span>
+                          <span>{includedUsageRemainingPercentage}% left</span>
                           {tokenUsage.monthly.resetTime && (
                             <span>
                               {new Date(

--- a/app/components/UpgradeConfirmationDialog.tsx
+++ b/app/components/UpgradeConfirmationDialog.tsx
@@ -272,6 +272,9 @@ const UpgradeConfirmationDialog: React.FC<UpgradeConfirmationDialogProps> = ({
                         Estimate; subject to changes to your account balance or
                         usage.
                       </div>
+                      <div className="text-xs text-muted-foreground mt-1">
+                        Full included usage renews on this billing date.
+                      </div>
                     </div>
                     <div className="text-base font-semibold">
                       ${Number(details.nextInvoiceAmount).toFixed(2)}

--- a/app/components/usage/IncludedUsageCard.tsx
+++ b/app/components/usage/IncludedUsageCard.tsx
@@ -35,7 +35,7 @@ const formatPointsAsDollars = (points: number): string => {
 const formatResetDateShort = (resetTime: string | null): string => {
   if (!resetTime) return "";
   const date = new Date(resetTime);
-  return `Resets ${date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`;
+  return `Renews ${date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`;
 };
 
 const formatResetDateFull = (resetTime: string | null): string => {
@@ -52,9 +52,9 @@ const formatResetDateFull = (resetTime: string | null): string => {
   });
 };
 
-const getUsageColorClass = (percentage: number): string => {
-  if (percentage >= 90) return "bg-red-500";
-  if (percentage >= 70) return "bg-orange-500";
+const getRemainingColorClass = (percentage: number): string => {
+  if (percentage <= 10) return "bg-red-500";
+  if (percentage <= 30) return "bg-orange-500";
   return "bg-blue-500";
 };
 
@@ -112,14 +112,21 @@ const IncludedUsageCard = ({ subscription }: IncludedUsageCardProps) => {
     return calculateUsageProjection(remainingDollars, resetTime, dailyUsage);
   }, [tokenUsage, dailyUsage]);
 
+  const remainingPercentage =
+    tokenUsage && tokenUsage.monthly.limit > 0
+      ? Math.round(
+          (tokenUsage.monthly.remaining / tokenUsage.monthly.limit) * 100,
+        )
+      : 0;
+
   return (
     <div className="rounded-lg border bg-card p-4 space-y-3">
-      <p className="text-xs text-muted-foreground">Your included usage</p>
+      <p className="text-xs text-muted-foreground">Included usage remaining</p>
       {tokenUsage ? (
         <>
           <div className="flex items-baseline gap-1.5">
             <span className="text-2xl font-semibold tabular-nums">
-              {formatPointsAsDollars(tokenUsage.monthly.used)}
+              {formatPointsAsDollars(tokenUsage.monthly.remaining)}
             </span>
             <span className="text-sm text-muted-foreground">
               / {formatPointsAsDollars(tokenUsage.monthly.limit)}
@@ -127,9 +134,9 @@ const IncludedUsageCard = ({ subscription }: IncludedUsageCardProps) => {
           </div>
           <div className="relative h-1.5 w-full overflow-hidden rounded-full bg-muted">
             <div
-              className={`h-full transition-all duration-500 ${getUsageColorClass(tokenUsage.monthly.usagePercentage)}`}
+              className={`h-full transition-all duration-500 ${getRemainingColorClass(remainingPercentage)}`}
               style={{
-                width: `${Math.min(100, tokenUsage.monthly.usagePercentage)}%`,
+                width: `${Math.min(100, remainingPercentage)}%`,
               }}
             />
           </div>
@@ -148,6 +155,7 @@ const IncludedUsageCard = ({ subscription }: IncludedUsageCardProps) => {
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">
+                  Included usage renews{" "}
                   {formatResetDateFull(tokenUsage.monthly.resetTime)}
                 </TooltipContent>
               </Tooltip>

--- a/convex/rateLimitStatus.ts
+++ b/convex/rateLimitStatus.ts
@@ -4,6 +4,7 @@ import { action } from "./_generated/server";
 import { v } from "convex/values";
 import {
   getBudgetLimits,
+  getMonthlyBucketKey,
   getSubscriptionPrice,
 } from "../lib/rate-limit/token-bucket";
 import type { SubscriptionTier } from "../types";
@@ -20,6 +21,11 @@ async function getCachedModules() {
     };
   }
   return _cachedModules;
+}
+
+function finiteNonNegativeNumber(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return Math.max(0, value);
 }
 
 /**
@@ -120,19 +126,34 @@ export const getAgentRateLimitStatus = action({
       const monthlyResult = await monthlyRatelimit.limit(monthlyKey, {
         rate: 0,
       });
+      const monthlyStorageKey = getMonthlyBucketKey(userId, subscription);
+      const storedCycleAllocation = finiteNonNegativeNumber(
+        await redis.hget(monthlyStorageKey, "cycleAllocation"),
+      );
 
       const monthlyRemaining = Math.min(
         Math.max(0, monthlyResult.remaining),
         monthlyLimit,
       );
-      const monthlyUsed = monthlyLimit - monthlyRemaining;
+      const cycleAllocation =
+        storedCycleAllocation === null
+          ? monthlyLimit
+          : Math.min(storedCycleAllocation, monthlyLimit);
+      const effectiveMonthlyLimit = Math.min(
+        monthlyLimit,
+        Math.max(monthlyRemaining, cycleAllocation),
+      );
+      const monthlyUsed = Math.max(0, effectiveMonthlyLimit - monthlyRemaining);
 
       return {
         monthly: {
           remaining: monthlyRemaining,
-          limit: monthlyLimit,
+          limit: effectiveMonthlyLimit,
           used: monthlyUsed,
-          usagePercentage: Math.round((monthlyUsed / monthlyLimit) * 100),
+          usagePercentage:
+            effectiveMonthlyLimit > 0
+              ? Math.round((monthlyUsed / effectiveMonthlyLimit) * 100)
+              : 0,
           resetTime: new Date(monthlyResult.reset).toISOString(),
         },
         monthlyBudgetUsd,

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -537,50 +537,56 @@ describe("token-bucket async functions", () => {
       const nowSeconds = 1_700_000_000;
       const periodEndSeconds = nowSeconds + 31 * 24 * 60 * 60;
       const nowSpy = jest.spyOn(Date, "now").mockReturnValue(nowSeconds * 1000);
-      const { resetRateLimitBuckets } = getIsolatedModule();
 
-      await resetRateLimitBuckets("user-123", "pro", periodEndSeconds);
+      try {
+        const { resetRateLimitBuckets } = getIsolatedModule();
 
-      expect(mockHsetFn).toHaveBeenCalledWith(
-        "usage:monthly:user-123:pro",
-        expect.objectContaining({
-          refilledAt: (periodEndSeconds - 30 * 24 * 60 * 60) * 1000,
-          cycleAllocation: 250_000,
-        }),
-      );
-      expect(mockExpireFn).toHaveBeenCalledWith(
-        "usage:monthly:user-123:pro",
-        32 * 24 * 60 * 60,
-      );
+        await resetRateLimitBuckets("user-123", "pro", periodEndSeconds);
 
-      nowSpy.mockRestore();
+        expect(mockHsetFn).toHaveBeenCalledWith(
+          "usage:monthly:user-123:pro",
+          expect.objectContaining({
+            refilledAt: (periodEndSeconds - 30 * 24 * 60 * 60) * 1000,
+            cycleAllocation: 250_000,
+          }),
+        );
+        expect(mockExpireFn).toHaveBeenCalledWith(
+          "usage:monthly:user-123:pro",
+          32 * 24 * 60 * 60,
+        );
+      } finally {
+        nowSpy.mockRestore();
+      }
     });
 
     it("does not backdate reset metadata for a stale Stripe period end", async () => {
       const nowSeconds = 1_700_000_000;
       const stalePeriodEndSeconds = nowSeconds - 60;
       const nowSpy = jest.spyOn(Date, "now").mockReturnValue(nowSeconds * 1000);
-      const { resetRateLimitBuckets } = getIsolatedModule();
 
-      await resetRateLimitBuckets("user-123", "pro", stalePeriodEndSeconds);
+      try {
+        const { resetRateLimitBuckets } = getIsolatedModule();
 
-      const metadata = mockHsetFn.mock.calls.find(
-        ([key]) => key === "usage:monthly:user-123:pro",
-      )?.[1] as Record<string, number> | undefined;
+        await resetRateLimitBuckets("user-123", "pro", stalePeriodEndSeconds);
 
-      expect(metadata).toEqual(
-        expect.objectContaining({
-          cycleAllocation: 250_000,
-          cycleTierMax: 250_000,
-        }),
-      );
-      expect(metadata).not.toHaveProperty("refilledAt");
-      expect(mockExpireFn).toHaveBeenCalledWith(
-        "usage:monthly:user-123:pro",
-        30 * 24 * 60 * 60,
-      );
+        const metadata = mockHsetFn.mock.calls.find(
+          ([key]) => key === "usage:monthly:user-123:pro",
+        )?.[1] as Record<string, number> | undefined;
 
-      nowSpy.mockRestore();
+        expect(metadata).toEqual(
+          expect.objectContaining({
+            cycleAllocation: 250_000,
+            cycleTierMax: 250_000,
+          }),
+        );
+        expect(metadata).not.toHaveProperty("refilledAt");
+        expect(mockExpireFn).toHaveBeenCalledWith(
+          "usage:monthly:user-123:pro",
+          30 * 24 * 60 * 60,
+        );
+      } finally {
+        nowSpy.mockRestore();
+      }
     });
 
     it("should not throw when Redis delete fails", async () => {

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -556,6 +556,33 @@ describe("token-bucket async functions", () => {
       nowSpy.mockRestore();
     });
 
+    it("does not backdate reset metadata for a stale Stripe period end", async () => {
+      const nowSeconds = 1_700_000_000;
+      const stalePeriodEndSeconds = nowSeconds - 60;
+      const nowSpy = jest.spyOn(Date, "now").mockReturnValue(nowSeconds * 1000);
+      const { resetRateLimitBuckets } = getIsolatedModule();
+
+      await resetRateLimitBuckets("user-123", "pro", stalePeriodEndSeconds);
+
+      const metadata = mockHsetFn.mock.calls.find(
+        ([key]) => key === "usage:monthly:user-123:pro",
+      )?.[1] as Record<string, number> | undefined;
+
+      expect(metadata).toEqual(
+        expect.objectContaining({
+          cycleAllocation: 250_000,
+          cycleTierMax: 250_000,
+        }),
+      );
+      expect(metadata).not.toHaveProperty("refilledAt");
+      expect(mockExpireFn).toHaveBeenCalledWith(
+        "usage:monthly:user-123:pro",
+        30 * 24 * 60 * 60,
+      );
+
+      nowSpy.mockRestore();
+    });
+
     it("should not throw when Redis delete fails", async () => {
       const { resetRateLimitBuckets } = getIsolatedModule();
 

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -518,11 +518,42 @@ describe("token-bucket async functions", () => {
       await resetRateLimitBuckets("user-123", "pro");
 
       expect(mockDelFn).toHaveBeenCalledWith("usage:monthly:user-123:pro");
+      expect(mockHsetFn).toHaveBeenCalledWith(
+        "usage:monthly:user-123:pro",
+        expect.objectContaining({
+          cycleAllocation: 250_000,
+          cycleTierMax: 250_000,
+          cycleStartedAt: expect.any(Number),
+        }),
+      );
       // Verify explicit 30-day TTL is set
       expect(mockExpireFn).toHaveBeenCalledWith(
         "usage:monthly:user-123:pro",
         30 * 24 * 60 * 60,
       );
+    });
+
+    it("aligns monthly reset metadata to the Stripe period end", async () => {
+      const nowSeconds = 1_700_000_000;
+      const periodEndSeconds = nowSeconds + 31 * 24 * 60 * 60;
+      const nowSpy = jest.spyOn(Date, "now").mockReturnValue(nowSeconds * 1000);
+      const { resetRateLimitBuckets } = getIsolatedModule();
+
+      await resetRateLimitBuckets("user-123", "pro", periodEndSeconds);
+
+      expect(mockHsetFn).toHaveBeenCalledWith(
+        "usage:monthly:user-123:pro",
+        expect.objectContaining({
+          refilledAt: (periodEndSeconds - 30 * 24 * 60 * 60) * 1000,
+          cycleAllocation: 250_000,
+        }),
+      );
+      expect(mockExpireFn).toHaveBeenCalledWith(
+        "usage:monthly:user-123:pro",
+        32 * 24 * 60 * 60,
+      );
+
+      nowSpy.mockRestore();
     });
 
     it("should not throw when Redis delete fails", async () => {

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -4,6 +4,7 @@ import {
   calculateTokenCost,
   calculateProratedCredits,
   getBudgetLimits,
+  getCycleExpireSeconds,
   getSubscriptionPrice,
   POINTS_PER_DOLLAR,
 } from "../token-bucket";
@@ -162,6 +163,20 @@ describe("token-bucket", () => {
   describe("POINTS_PER_DOLLAR", () => {
     it("should be 10000 (1 point = $0.0001)", () => {
       expect(POINTS_PER_DOLLAR).toBe(10_000);
+    });
+  });
+
+  describe("getCycleExpireSeconds", () => {
+    it("uses the default 30-day TTL without a future billing period end", () => {
+      expect(getCycleExpireSeconds(undefined, 1_000)).toBe(30 * 24 * 60 * 60);
+      expect(getCycleExpireSeconds(999, 1_000)).toBe(30 * 24 * 60 * 60);
+    });
+
+    it("keeps buckets alive through longer billing periods", () => {
+      const now = 1_000;
+      const periodEnd = now + 31 * 24 * 60 * 60;
+
+      expect(getCycleExpireSeconds(periodEnd, now)).toBe(32 * 24 * 60 * 60);
     });
   });
 

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -41,6 +41,8 @@ export {
   calculateTokenCost,
   getBudgetLimits,
   getSubscriptionPrice,
+  getMonthlyBucketKey,
+  getCycleExpireSeconds,
   POINTS_PER_DOLLAR,
 } from "./token-bucket";
 

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -115,8 +115,28 @@ export const getSubscriptionPrice = (
 // =============================================================================
 
 /** Build the Redis key used by the monthly token bucket. */
-const monthlyBucketKey = (userId: string, tier: SubscriptionTier) =>
+export const getMonthlyBucketKey = (userId: string, tier: SubscriptionTier) =>
   `usage:monthly:${userId}:${tier}`;
+
+export const getCycleExpireSeconds = (
+  periodEndSeconds?: number,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): number => {
+  if (
+    !periodEndSeconds ||
+    !Number.isFinite(periodEndSeconds) ||
+    periodEndSeconds <= nowSeconds
+  ) {
+    return THIRTY_DAYS_SECONDS;
+  }
+
+  // Keep display metadata alive through 31-day billing periods and webhook lag.
+  const oneDayBufferSeconds = 24 * 60 * 60;
+  return Math.max(
+    THIRTY_DAYS_SECONDS,
+    Math.ceil(periodEndSeconds - nowSeconds + oneDayBufferSeconds),
+  );
+};
 
 /**
  * Create rate limiter for a user (shared between agent and ask modes).
@@ -182,7 +202,7 @@ export const checkTokenBucketLimit = async (
     const isNewTeamBucket =
       subscription === "team" &&
       organizationId &&
-      !(await redis.exists(monthlyBucketKey(userId, "team")));
+      !(await redis.exists(getMonthlyBucketKey(userId, "team")));
 
     const { monthly, monthlyLimit } = createRateLimiter(
       redis,
@@ -545,7 +565,7 @@ const refundBucketTokens = async (
   if (!redis) return;
 
   const { monthly: monthlyLimit } = getBudgetLimits(subscription);
-  const monthlyKey = monthlyBucketKey(userId, subscription);
+  const monthlyKey = getMonthlyBucketKey(userId, subscription);
 
   try {
     const monthlyTokens = await redis.hincrby(
@@ -571,8 +591,9 @@ const refundBucketTokens = async (
 export const resetRateLimitBuckets = async (
   userId: string,
   subscription: SubscriptionTier,
+  periodEndSeconds?: number,
 ): Promise<void> => {
-  await initProratedBucket(userId, subscription, 1.0, 0);
+  await initProratedBucket(userId, subscription, 1.0, 0, periodEndSeconds);
 };
 
 /**
@@ -647,7 +668,7 @@ export const stashOldBucketRemaining = async (
   const redis = createRedisClient();
   if (!redis) return;
 
-  const monthlyKey = monthlyBucketKey(userId, oldTier);
+  const monthlyKey = getMonthlyBucketKey(userId, oldTier);
   const stashKey = `upgrade:carryover:${userId}`;
   const oldTierMax = MONTHLY_CREDITS[oldTier] ?? 0;
 
@@ -747,12 +768,12 @@ export const initProratedBucket = async (
   const newTierMax = MONTHLY_CREDITS[newTier] ?? 0;
   if (newTierMax === 0) return;
 
-  const { burnAmount } = calculateProratedCredits(
+  const { burnAmount, totalCredits } = calculateProratedCredits(
     newTierMax,
     proratedRatio,
     consumedCredits,
   );
-  const monthlyKey = monthlyBucketKey(userId, newTier);
+  const monthlyKey = getMonthlyBucketKey(userId, newTier);
 
   try {
     // Delete any existing bucket for the new tier
@@ -772,6 +793,12 @@ export const initProratedBucket = async (
     // hardcoded to 30 d, so setting `refilledAt = periodEnd - 30 d` makes the
     // reported reset land exactly on the next invoice date. `refilledAt` is
     // an internal field of @upstash/ratelimit — re-verify on SDK upgrades.
+    const bucketMetadata: Record<string, number> = {
+      cycleAllocation: totalCredits,
+      cycleTierMax: newTierMax,
+      cycleStartedAt: Date.now(),
+    };
+
     if (
       periodEndSeconds &&
       Number.isFinite(periodEndSeconds) &&
@@ -779,11 +806,11 @@ export const initProratedBucket = async (
     ) {
       const targetRefilledAtMs =
         (periodEndSeconds - THIRTY_DAYS_SECONDS) * 1000;
-      await redis.hset(monthlyKey, { refilledAt: targetRefilledAtMs });
+      bucketMetadata.refilledAt = targetRefilledAtMs;
     }
 
-    // Align TTL to 30 days from now
-    await redis.expire(monthlyKey, THIRTY_DAYS_SECONDS);
+    await redis.hset(monthlyKey, bucketMetadata);
+    await redis.expire(monthlyKey, getCycleExpireSeconds(periodEndSeconds));
   } catch (error) {
     console.error(`[initProratedBucket] Failed for user ${userId}:`, error);
   }
@@ -814,7 +841,7 @@ export const getTeamMemberConsumed = async (
 
   try {
     const tokens = await redis.hget<number>(
-      monthlyBucketKey(userId, "team"),
+      getMonthlyBucketKey(userId, "team"),
       "tokens",
     );
     return Math.max(0, TEAM_CREDITS - (tokens ?? TEAM_CREDITS));

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -798,11 +798,12 @@ export const initProratedBucket = async (
       cycleTierMax: newTierMax,
       cycleStartedAt: Date.now(),
     };
+    const nowSeconds = Math.floor(bucketMetadata.cycleStartedAt / 1000);
 
     if (
       periodEndSeconds &&
       Number.isFinite(periodEndSeconds) &&
-      periodEndSeconds > 0
+      periodEndSeconds > nowSeconds
     ) {
       const targetRefilledAtMs =
         (periodEndSeconds - THIRTY_DAYS_SECONDS) * 1000;
@@ -810,7 +811,10 @@ export const initProratedBucket = async (
     }
 
     await redis.hset(monthlyKey, bucketMetadata);
-    await redis.expire(monthlyKey, getCycleExpireSeconds(periodEndSeconds));
+    await redis.expire(
+      monthlyKey,
+      getCycleExpireSeconds(periodEndSeconds, nowSeconds),
+    );
   } catch (error) {
     console.error(`[initProratedBucket] Failed for user ${userId}:`, error);
   }


### PR DESCRIPTION
## Summary

- Align monthly subscription usage-bucket reset metadata to Stripe's current billing-period end on paid subscription invoices.
- Store per-cycle allocation metadata so prorated upgrade allocation is not displayed as customer-spent usage.
- Update usage and upgrade confirmation copy to make the distinction between immediate prorated upgrades and the next full billing-date renewal clearer.

## Root cause

Paid usage buckets were initialized around a generic 30-day token-bucket interval. Mid-cycle upgrades already adjusted `refilledAt` to Stripe's period end, but regular monthly subscription creates/renewals did not pass the Stripe period end into the bucket reset path. The UI also displayed `full tier limit - remaining`, which made prorated allocation burns look like actual usage.

## Validation

- `pnpm jest lib/rate-limit/__tests__/token-bucket.test.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts app/components/__tests__/UpgradeConfirmationDialog.test.tsx --runInBand`
- `pnpm typecheck`
- `pnpm lint -- app/api/subscription/webhook/route.ts app/components/SidebarUserNav.tsx app/components/UpgradeConfirmationDialog.tsx app/components/usage/IncludedUsageCard.tsx convex/rateLimitStatus.ts lib/rate-limit/token-bucket.ts lib/rate-limit/index.ts lib/rate-limit/__tests__/token-bucket.test.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts`
- Commit hook: `pnpm typecheck` and full `pnpm test` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added informational text clarifying that full included usage renews on your billing date.

* **Improvements**
  * UI now shows remaining included usage percent (labeled "Included") and uses "Renews" wording.
  * Rate-limit buckets and renewals are aligned to subscription billing periods and respect per-cycle allocations, improving accuracy for prorations and mid-cycle events.

* **Tests**
  * Added and enhanced tests validating monthly cycle behavior, TTLs, and bucket reset timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->