### PR TITLE
[codex] Fix Windows upload path quoting

### DIFF
--- a/lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts
@@ -260,7 +260,7 @@ describe("uploadSandboxFileToConvex", () => {
             exitCode: 1,
           };
         }
-        if (command.startsWith("for %I")) {
+        if (command.startsWith("setlocal EnableDelayedExpansion && for %I")) {
           return { stdout: "4321", stderr: "", exitCode: 0 };
         }
         return { stdout: "", stderr: "unexpected command", exitCode: 1 };
@@ -270,13 +270,19 @@ describe("uploadSandboxFileToConvex", () => {
     await uploadSandboxFileToConvex({
       sandbox: sandbox as any,
       userId: "u1",
-      fullPath: "C:\\Users\\user\\report.zip",
+      fullPath: "C:\\Users\\user\\Research & Dev\\report.zip",
     });
 
     expect(sandbox.commands.run).toHaveBeenNthCalledWith(
       2,
-      'for %I in ("C:\\Users\\user\\report.zip") do @echo %~zI',
-      expect.objectContaining({ displayName: "" }),
+      'setlocal EnableDelayedExpansion && for %I in ("!HACKERAI_FILE_SIZE_PATH!") do @echo %~zI',
+      expect.objectContaining({
+        displayName: "",
+        envVars: expect.objectContaining({
+          HACKERAI_FILE_SIZE_PATH:
+            "C:\\Users\\user\\Research & Dev\\report.zip",
+        }),
+      }),
     );
     expect(mockGenerateS3UploadUrl).toHaveBeenCalledWith(
       "report.zip",
@@ -284,6 +290,34 @@ describe("uploadSandboxFileToConvex", () => {
       "u1",
       4321,
     );
+  });
+
+  test("rejects unsafe Windows size fallback paths before running cmd.exe fallback", async () => {
+    const sandbox = makeSandbox(0, false, true);
+    (sandbox.commands.run as jest.Mock).mockImplementation(
+      async (command: string) => {
+        if (command.includes("stat -c%s")) {
+          return {
+            stdout: "",
+            stderr: "'[' is not recognized as an internal or external command",
+            exitCode: 1,
+          };
+        }
+        return { stdout: "", stderr: "unexpected command", exitCode: 1 };
+      },
+    );
+
+    await expect(
+      uploadSandboxFileToConvex({
+        sandbox: sandbox as any,
+        userId: "u1",
+        fullPath:
+          'C:\\Users\\user\\report" & whoami > C:\\Users\\user\\poc.txt & ".zip',
+      }),
+    ).rejects.toThrow(/unsupported character/);
+
+    expect(sandbox.commands.run).toHaveBeenCalledTimes(1);
+    expect(mockGenerateS3UploadUrl).not.toHaveBeenCalled();
   });
 
   test("derives the file name from Windows-style paths", async () => {

--- a/lib/ai/tools/utils/sandbox-file-uploader.ts
+++ b/lib/ai/tools/utils/sandbox-file-uploader.ts
@@ -16,6 +16,8 @@ const MAX_GENERATED_FILE_SIZE_MB =
   MAX_GENERATED_FILE_SIZE_BYTES / (1024 * 1024);
 const SANDBOX_UPLOAD_TIMEOUT_MS = 5 * 60 * 1000;
 const SANDBOX_UPLOAD_STATUS_MARKER = "__HACKERAI_UPLOAD_EXIT_CODE__:";
+const WINDOWS_FILE_SIZE_PATH_ENV_VAR = "HACKERAI_FILE_SIZE_PATH";
+const UNSUPPORTED_WINDOWS_FILE_SIZE_PATH_CHARS = /[\0"!\r\n^]/;
 
 export type UploadedFileInfo = {
   url: string;
@@ -49,6 +51,30 @@ function shellQuote(value: string): string {
 
 function shouldTryWindowsFileSizeFallback(sandbox: AnySandbox): boolean {
   return isCentrifugoSandbox(sandbox) && sandbox.isWindows();
+}
+
+function formatUnsupportedWindowsPathCharacter(character: string): string {
+  switch (character) {
+    case "\0":
+      return "\\0";
+    case "\r":
+      return "\\r";
+    case "\n":
+      return "\\n";
+    default:
+      return character;
+  }
+}
+
+function assertWindowsFileSizeFallbackPathSafe(fullPath: string): void {
+  const unsupportedCharacter = fullPath.match(
+    UNSUPPORTED_WINDOWS_FILE_SIZE_PATH_CHARS,
+  )?.[0];
+  if (!unsupportedCharacter) return;
+
+  throw new Error(
+    `Cannot safely get file size for Windows path containing unsupported character ${formatUnsupportedWindowsPathCharacter(unsupportedCharacter)}.`,
+  );
 }
 
 function formatFileSizeFailure(
@@ -126,16 +152,23 @@ async function getSandboxFileSize(
     throw formatFileSizeFailure(fullPath, statResult);
   }
 
-  // Windows cmd.exe fallback: %~zI expands to the file size.
-  const escapedForCmd = fullPath.replace(/"/g, '\\"');
+  assertWindowsFileSizeFallbackPathSafe(fullPath);
+
+  // Windows cmd.exe fallback: delayed expansion avoids reparsing path
+  // metacharacters such as & after the command has been parsed.
+  const winCommand = `setlocal EnableDelayedExpansion && for %I in ("!${WINDOWS_FILE_SIZE_PATH_ENV_VAR}!") do @echo %~zI`;
   let winResult: SandboxCommandResult;
   try {
-    winResult = await sandbox.commands.run(
-      `for %I in ("${escapedForCmd}") do @echo %~zI`,
-      { ...commandOptions, displayName: "" } as typeof commandOptions & {
-        displayName?: string;
+    winResult = await sandbox.commands.run(winCommand, {
+      ...commandOptions,
+      envVars: {
+        ...(commandOptions.envVars ?? {}),
+        [WINDOWS_FILE_SIZE_PATH_ENV_VAR]: fullPath,
       },
-    );
+      displayName: "",
+    } as typeof commandOptions & {
+      displayName?: string;
+    });
   } catch (error) {
     const commandResult = commandErrorToResult(error);
     if (!commandResult) {


### PR DESCRIPTION
## Summary

- Stop interpolating Windows local-sandbox upload paths directly into the `cmd.exe` file-size fallback command.
- Pass the path through `HACKERAI_FILE_SIZE_PATH` and use delayed expansion for the `for %I` size check.
- Fail closed for path characters that can break the narrow Windows fallback setup, including quotes, `!`, caret, NUL, and newlines.
- Add regression coverage for the quote-plus-ampersand payload from the Codex Security finding.

## Root Cause

The generated-file upload helper escaped double quotes with POSIX-style backslash escaping before building a Windows `cmd.exe` command. `cmd.exe` does not treat backslash as a quote escape, so a crafted file path could break out of the quoted `for %I in (...)` path and inject command separators.

## Validation

- `pnpm exec jest lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts --runInBand`
- `pnpm exec eslint lib/ai/tools/utils/sandbox-file-uploader.ts lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts`
- `pnpm exec prettier --check lib/ai/tools/utils/sandbox-file-uploader.ts lib/ai/tools/utils/__tests__/sandbox-file-uploader.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- Commit hook also ran full `pnpm typecheck` and full `pnpm test`: 120 test suites, 1347 tests passed.

Fixes Codex Security finding `CS-20260604-001`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Windows file path validation to prevent command injection attacks during file size detection operations. File paths containing unsafe characters are now validated and rejected before any upload or fallback command execution.

* **Tests**
  * Enhanced file upload tests to verify proper handling and rejection of file paths with dangerous characters on Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->