### PR TITLE
[codex] Add curated pentest playbooks

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,10 @@ ENV HOME=/home/user
 ENV GOPATH=/home/user/go
 ENV GOCACHE=/home/user/go/.cache
 ENV PATH=/home/user/.local/bin:/usr/local/go/bin:/home/user/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV AGENT_BROWSER_USER_AGENT="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+ENV AGENT_BROWSER_ARGS="--disable-blink-features=AutomationControlled,--no-first-run,--no-default-browser-check,--lang=en-US,--no-sandbox,--disable-dev-shm-usage"
+ENV AGENT_BROWSER_SCREENSHOT_DIR=/home/user/.agent-browser-screenshots
 
 # ============================================================================
 # Base System Setup (use default Kali CDN mirror - auto-routes to healthy mirrors)
@@ -125,6 +129,9 @@ RUN apt-get update && \
     nodejs \
     npm \
     tmux \
+    # Browser automation
+    chromium \
+    fonts-liberation \
     # Forensics
     binwalk \
     foremost \
@@ -152,7 +159,7 @@ RUN set -eux; \
 RUN useradd --create-home --shell /bin/bash user && \
     usermod -aG sudo user && \
     echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
-    mkdir -p /home/user/upload /home/user/go && \
+    mkdir -p /home/user/upload /home/user/go /home/user/.agent-browser-screenshots && \
     chown -R user:user /home/user
 
 WORKDIR /home/user
@@ -175,6 +182,12 @@ RUN pip3 install --break-system-packages \
 
 # Additional security-focused Python packages
 RUN pip3 install --break-system-packages requests aiohttp jinja2 'httpx[cli]' ratelimit pycryptodomex
+
+# ============================================================================
+# Browser Automation CLI
+# ============================================================================
+RUN npm install -g agent-browser@0.26.0 && \
+    agent-browser doctor --offline --quick
 
 # ============================================================================
 # Git-based Security Tools
@@ -301,6 +314,9 @@ RUN set -eux; \
     which trivy && echo "✓ trivy" && \
     which zaproxy && echo "✓ zaproxy" && \
     which httpx && echo "✓ httpx" && \
+    which chromium && echo "✓ chromium" && \
+    which agent-browser && echo "✓ agent-browser" && \
+    agent-browser doctor --offline --quick && \
     which caido-cli && echo "✓ caido-cli" && \
     which rg && echo "✓ ripgrep" && \
     which go && echo "✓ go" && \

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -65,4 +65,40 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
       "For the default cloud sandbox, commands run in an isolated container",
     );
   });
+
+  it("includes curated pentest playbooks in agent mode", async () => {
+    const prompt = await systemPrompt(
+      "user_123",
+      "agent",
+      "pro",
+      "agent-model",
+      null,
+      false,
+      null,
+    );
+
+    expect(prompt).toContain("<curated_pentest_playbook>");
+    expect(prompt).toContain("agent-browser open <url>");
+    expect(prompt).toContain("httpx -l hosts.txt");
+    expect(prompt).toContain("-noninteractive");
+    expect(prompt).toContain("JWT/OIDC");
+    expect(prompt).toContain("IDOR/BOLA");
+    expect(prompt).toContain("SSRF");
+    expect(prompt).toContain("XXE");
+  });
+
+  it("keeps terminal-only pentest playbooks out of ask mode", async () => {
+    const prompt = await systemPrompt(
+      "user_123",
+      "ask",
+      "pro",
+      "ask-model",
+      null,
+      false,
+      null,
+    );
+
+    expect(prompt).not.toContain("<curated_pentest_playbook>");
+    expect(prompt).not.toContain("agent-browser open <url>");
+  });
 });

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -3,6 +3,7 @@ import { getPersonalityInstructions } from "./system-prompt/personality";
 import type { UserCustomization } from "@/types";
 import { generateUserBio } from "./system-prompt/bio";
 import { getNotesDisabledMessage } from "./system-prompt/notes";
+import { PENTEST_SKILLS_SECTION } from "./system-prompt/pentest-skills";
 import {
   getModelCutoffDate,
   getModelDisplayName,
@@ -38,13 +39,13 @@ export const PREINSTALLED_PENTESTING_TOOLS = `Pre-installed Pentesting Tools:
 - Auth/Bruteforce: hydra (login bruteforcer)
 - SMB/NetBIOS: smbclient, smbmap, nbtscan, python3-impacket, enum4linux
 - Network Discovery: arp-scan
-- Web Recon: gospider (web spider/crawler), katana (advanced web crawler)
+- Web Recon: gospider (web spider/crawler), katana (advanced web crawler), agent-browser (headless browser automation)
 - Git/Repository Analysis: gitdumper, gitextractor (dump/extract git repos)
 - Secret Scanning: trufflehog (find credentials in git/filesystems)
 - Vulnerability Assessment: nuclei (vulnerability scanner with templates), trivy (container/dependency scanner), zaproxy (OWASP ZAP), vulnx/cvemap (CVE vulnerability mapping)
 - Forensics: binwalk, foremost (file carving)
 - Utilities: gobuster, socat, proxychains4, hashid, libimage-exiftool-perl (exiftool), cewl
-- Specialized: jwt_tool (JWT manipulation), interactsh-client (OOB interaction testing), SecLists (/home/user/SecLists or /usr/share/seclists)
+- Specialized: jwt-tool (JWT manipulation), interactsh-client (OOB interaction testing), SecLists (/home/user/SecLists or /usr/share/seclists)
 - Documents: reportlab, python-docx, openpyxl, python-pptx, pandas, pypandoc, pandoc, odfpy`;
 
 type SecurityExecutionEnvironment = "ask" | "cloud" | "local-host";
@@ -278,6 +279,8 @@ When running security scans:
 - If a scan returns no results, consider: wrong target? wrong port? firewall? Try an alternative approach before reporting "nothing found"
 - Chain scan results intelligently — use output from reconnaissance to inform targeted exploitation
 </scan_methodology>
+
+${PENTEST_SKILLS_SECTION}
 
 ${sandboxContext ? sandboxContext + "\n\n" + getProxySection(caidoEnabled, true, caidoPort) : getDefaultSandboxEnvironmentSection(caidoEnabled, caidoPort)}
 

--- a/lib/system-prompt/pentest-skills.ts
+++ b/lib/system-prompt/pentest-skills.ts
@@ -1,0 +1,32 @@
+export const PENTEST_SKILLS_SECTION = `<curated_pentest_playbook>
+Use these concise playbooks during authorized assessments. They are defaults for accuracy and efficiency, not permission to expand target scope.
+
+<browser_automation>
+- Use agent-browser for browser-driven workflows when available in the sandbox. Core loop: \`agent-browser open <url>\`, \`agent-browser snapshot -i\`, interact with fresh \`@eN\` refs, wait for expected state, then re-snapshot.
+- Treat snapshot refs as stale after navigation, form submission, dynamic rendering, or dialogs. Prefer accessibility snapshots and semantic locators before raw CSS selectors.
+- Use screenshots for visual proof or layout-sensitive behavior; close browser sessions when finished.
+</browser_automation>
+
+<tooling_defaults>
+- httpx: prefer JSONL and explicit throttles for automation, e.g. \`httpx -l hosts.txt -sc -title -server -td -fr -timeout 10 -retries 1 -rl 50 -t 25 -silent -j -o httpx.jsonl\`. Use \`-nf\` when host-only input needs both HTTP and HTTPS.
+- ffuf: include \`-noninteractive\`, explicit match/filter strategy, calibration, timeout, rate/thread limits, and structured output. Ensure \`FUZZ\` appears exactly where input mutates.
+- katana: keep depth, concurrency, parallelism, rate, timeout, and extension filters explicit. Prefer JSONL output; use JS crawling for endpoint discovery and headless mode only when regular crawling misses client-rendered routes.
+- Python: use Python to coordinate, parse, batch, replay, and validate findings around established tools. Write reusable scripts for iterative work; use one-off heredocs or \`python3 -c\` only for small transformations.
+- OAST: use \`interactsh-client\` for blind SSRF, XXE, and RCE confirmation; correlate each callback to the triggering payload.
+</tooling_defaults>
+
+<vulnerability_playbooks>
+- JWT/OIDC: inventory issuers, audiences, token types, JWKS endpoints, and consumers. Test algorithm pinning, \`none\`, RS-to-HS confusion, \`kid\` lookup abuse, \`jku\`/\`x5u\`/\`jwk\` trust, claim enforcement, token type confusion, refresh rotation, and cross-service reuse. Use \`jwt-tool\` for attack matrices and HMAC secret checks when applicable.
+- IDOR/BOLA: build a subject x object x action matrix with at least two principals. Seed IDs from list/search/export/job/file endpoints, then swap identifiers across path, query, body, headers, cookies, JWT claims, GraphQL, WebSocket, and batch operations. Compare owner and non-owner evidence precisely.
+- RCE: identify execution sinks such as shell wrappers, template engines, expression languages, deserializers, media converters, and admin integrations. Start with timing, output, or OAST oracles; confirm context with minimal commands before attempting broader control.
+- SSRF: enumerate every user-controlled URL, host, path, webhook, preview, import, and renderer. Test OAST first, then loopback, RFC1918, link-local, cloud metadata, Kubernetes, Docker, Redis, FastCGI, parser differentials, redirects, protocols, and header/method control.
+- XXE: test XML consumers, uploads, SOAP/SAML/XML-RPC, SVG/Office files, XInclude, and XSLT. Establish whether DOCTYPE, external entities, network access, file reads, or transclusion are active; use OAST and minimal file/internal URL probes for validation.
+</vulnerability_playbooks>
+
+<validation_habits>
+- Prefer established tools for breadth, then use targeted scripts for custom validation and anomaly triage.
+- Save parseable outputs, deduplicate noisy results, and chain recon into focused exploit validation.
+- A vulnerability is not real until you can show reproducible impact with controlled requests/responses, role-separated evidence, or correlated OAST callbacks.
+- When a scan returns nothing, reassess target, protocol, filters, auth state, rate limits, and alternate tooling before concluding no issue exists.
+</validation_habits>
+</curated_pentest_playbook>`;


### PR DESCRIPTION
## Summary

- Add a concise agent-mode pentest playbook adapted from the curated HAC-12 Strix scope.
- Cover operational defaults for agent-browser, httpx, ffuf, katana, Python, and OAST validation.
- Add focused JWT/OIDC, IDOR/BOLA, RCE, SSRF, and XXE guidance without bulk-importing Strix skill files.
- Install pinned `agent-browser@0.26.0` with Chromium in the sandbox image and validate it during the Docker build.

## Impact

HackerAI agents get higher-signal, parseable tool defaults and vulnerability workflows while keeping the prompt guidance narrow and maintainable.

## Validation

- `pnpm test -- lib/__tests__/system-prompt.test.ts --runInBand`
- `pnpm typecheck`
- Commit hook: `prettier --write`, `eslint --fix`, `pnpm typecheck`, full `pnpm test` (112 suites, 1306 tests)

## Notes

- I did not run a full Docker image build locally; the Dockerfile now runs `agent-browser doctor --offline --quick` during image build and tool validation.