### PR TITLE
[codex] Reduce Convex query fanout

### DIFF
--- a/app/components/RemoteControlTab.tsx
+++ b/app/components/RemoteControlTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { useQuery, useMutation } from "convex/react";
+import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -178,9 +178,9 @@ const RemoteControlTab = () => {
     selectedModel,
     setSelectedModel,
     temporaryChatsEnabled,
+    localConnections: connections,
   } = useGlobalState();
 
-  const connections = useQuery(api.localSandbox.listConnections);
   const tokenResult = useMutation(api.localSandbox.getToken);
   const regenerateToken = useMutation(api.localSandbox.regenerateToken);
 

--- a/app/components/SandboxSelector.tsx
+++ b/app/components/SandboxSelector.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useQuery } from "convex/react";
-import { api } from "@/convex/_generated/api";
 import {
   Check,
   Cloud,
@@ -47,7 +45,7 @@ export function SandboxSelector({
   const [open, setOpen] = useState(false);
   const [connectHovered, setConnectHovered] = useState(false);
   const { isTauri } = useTauri();
-  const { subscription } = useGlobalState();
+  const { subscription, localConnections: connections } = useGlobalState();
   const isFreeUser = subscription === "free";
 
   const detectedPlatform = useMemo(() => {
@@ -55,7 +53,6 @@ export function SandboxSelector({
     return detectPlatform();
   }, []);
 
-  const connections = useQuery(api.localSandbox.listConnections);
   const cloudOption: ConnectionOption = {
     id: "e2b",
     label: "Cloud",

--- a/app/components/__tests__/RemoteControlTab.test.tsx
+++ b/app/components/__tests__/RemoteControlTab.test.tsx
@@ -35,7 +35,6 @@ const mockSetSelectedModel = jest.fn(
 );
 
 jest.mock("convex/react", () => ({
-  useQuery: jest.fn(() => mockConnections),
   useMutation: jest.fn(() => jest.fn()),
 }));
 
@@ -49,6 +48,7 @@ jest.mock("@/app/contexts/GlobalState", () => ({
     selectedModel: mockSelectedModel,
     setSelectedModel: mockSetSelectedModel,
     temporaryChatsEnabled: mockTemporaryChatsEnabled,
+    localConnections: mockConnections,
   }),
 }));
 

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -225,6 +225,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     selectedModel,
     setSelectedModel,
     subscription,
+    localConnections,
   } = useGlobalState();
 
   // Simple logic: use route chatId if provided, otherwise generate new one
@@ -304,19 +305,10 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     shouldFetchMessages ? { id: chatId } : "skip",
   );
 
-  // Query local sandbox connections only when we need to validate a non-E2B sandbox_type
+  // Use the shared local sandbox connection subscription when validating a saved non-E2B sandbox.
   const storedSandboxType = (chatData as any)?.sandbox_type as
     | string
     | undefined;
-  const needsConnectionValidation =
-    !!storedSandboxType &&
-    storedSandboxType !== "e2b" &&
-    storedSandboxType !== "tauri" &&
-    !hasInitializedSandboxRef.current;
-  const localConnections = useQuery(
-    api.localSandbox.listConnections,
-    needsConnectionValidation ? undefined : "skip",
-  );
 
   // Prefer the mid-stream title — the server seeds chatData.title with the
   // user's first message before generation completes, which would otherwise

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -121,6 +121,9 @@ interface GlobalStateType {
   // Whether a local sandbox (desktop or remote) is available
   hasLocalSandbox: boolean;
 
+  // Active local sandbox connections, shared to avoid duplicate Convex subscriptions
+  localConnections: LocalSandboxConnection[] | undefined;
+
   // The sandbox preference to use for free agent mode (desktop or first remote connection ID)
   defaultLocalSandboxPreference: SandboxPreference | null;
 
@@ -164,6 +167,23 @@ const GlobalStateContext = createContext<GlobalStateType | undefined>(
 
 interface GlobalStateProviderProps {
   children: ReactNode;
+}
+
+interface LocalSandboxConnection {
+  connectionId: string;
+  name: string;
+  osInfo?: {
+    platform: string;
+    arch: string;
+    release: string;
+    hostname: string;
+  };
+  lastSeen: number;
+  isDesktop: boolean;
+  capabilities: {
+    commands: boolean;
+    pty: boolean;
+  };
 }
 
 export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
@@ -325,7 +345,10 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     useSandboxPreference(!!user);
 
   // Check for available local sandbox connections
-  const localConnections = useQuery(api.localSandbox.listConnections);
+  const localConnections = useQuery(
+    api.localSandbox.listConnections,
+    user ? undefined : "skip",
+  );
   const hasLocalSandbox = useMemo(
     () => desktopBridgeActive || (localConnections?.length ?? 0) > 0,
     [desktopBridgeActive, localConnections],
@@ -846,6 +869,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     setSandboxPreference,
     desktopBridgeActive,
     hasLocalSandbox,
+    localConnections,
     defaultLocalSandboxPreference,
 
     selectedModel,

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -505,25 +505,30 @@ export const getUserChats = query({
     try {
       const MAX_PINNED_CHATS = 100;
 
-      // Step 1: Fetch pinned chats only, ordered by pinned_at asc (first pinned = first in list)
-      const pinnedChats = await ctx.db
-        .query("chats")
-        .withIndex("by_user_and_pinned", (q) =>
-          q.eq("user_id", identity.subject).gt("pinned_at", 0),
-        )
-        .order("asc")
-        .take(MAX_PINNED_CHATS);
+      const isFirstPage =
+        args.paginationOpts.cursor == null || args.paginationOpts.cursor === "";
 
-      if (pinnedChats.length === MAX_PINNED_CHATS) {
+      // Step 1: Fetch pinned chats only for the first page. Later pages can
+      // filter pinned rows directly from their own page payload, which avoids
+      // rereading every pinned chat on each pagination request.
+      const pinnedChats = isFirstPage
+        ? await ctx.db
+            .query("chats")
+            .withIndex("by_user_and_pinned", (q) =>
+              q.eq("user_id", identity.subject).gt("pinned_at", 0),
+            )
+            .order("asc")
+            .take(MAX_PINNED_CHATS)
+        : [];
+
+      if (isFirstPage && pinnedChats.length === MAX_PINNED_CHATS) {
         convexLogger.warn("chat_sidebar_pinned_cap_reached", {
           user_id: identity.subject,
           pinned_cap: MAX_PINNED_CHATS,
           requested_page_size: args.paginationOpts.numItems,
-          has_cursor: Boolean(args.paginationOpts.cursor),
+          has_cursor: false,
         });
       }
-
-      const pinnedIds = new Set(pinnedChats.map((c) => c.id));
 
       // Step 2: Fetch one page (no over-fetch: slicing would lose items permanently
       // because the cursor advances past all fetched items)
@@ -535,9 +540,7 @@ export const getUserChats = query({
         .order("desc")
         .paginate(args.paginationOpts);
 
-      const unpinnedPage = result.page.filter((c) => !pinnedIds.has(c.id));
-      const isFirstPage =
-        args.paginationOpts.cursor == null || args.paginationOpts.cursor === "";
+      const unpinnedPage = result.page.filter((c) => c.pinned_at == null);
       const combinedPage = isFirstPage
         ? [...pinnedChats, ...unpinnedPage]
         : unpinnedPage;


### PR DESCRIPTION
## Summary

- Reuse the global `localSandbox.listConnections` subscription across chat, sandbox selector, and remote-control UI instead of mounting duplicate Convex subscriptions.
- Skip the full pinned-chat query on subsequent `getUserChats` pagination pages; later pages filter pinned rows from their own payload.
- Keeps the PostHog-side cleanup focused on explicit Convex capacity messages while reducing avoidable app-side Convex load.

## Why

PostHog showed recurring Convex capacity/system-operation failures on the production deployment, with hot functions including `localSandbox:listConnections` and `chats:getUserChats`. These changes reduce unnecessary query fanout and repeated reads without changing user-visible behavior.

## Validation

- `pnpm typecheck`
- Targeted ESLint on changed files: 0 errors, existing hook warnings remain in `app/components/chat.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized local sandbox connection data management for improved performance
  * Enhanced pinned chat pagination handling to reduce unnecessary queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->