### PR TITLE
[codex] Fix moderation language detection

### DIFF
--- a/__mocks__/franc-min.ts
+++ b/__mocks__/franc-min.ts
@@ -1,1 +1,50 @@
 export const franc = (_text: string, _opts?: { only?: string[] }) => "eng";
+
+const detectCode = (text: string) => {
+  const normalized = text.toLowerCase();
+  if (/hotspot password|router password/.test(normalized)) return "fra";
+  if (/wifi password/.test(normalized)) return "por";
+  if (/comment|accéder|mot de passe|quelqu/.test(normalized)) return "fra";
+  if (/permiso|autorizado|penetraci[oó]n/.test(normalized)) return "spa";
+  if (/разрешение|пентест/.test(normalized)) return "rus";
+  if (/权限|授权|渗透测试/.test(normalized)) return "cmn";
+  if (/permiss[aã]o|autorizado/.test(normalized)) return "por";
+  if (/autorisé|permission/.test(normalized)) return "fra";
+  if (/erlaubnis|berechtigt/.test(normalized)) return "deu";
+  if (/إذن|مخوّل|اختبار/.test(normalized)) return "arb";
+  return "eng";
+};
+
+export const francAll = (
+  text: string,
+  opts?: { only?: string[] },
+): Array<[string, number]> => {
+  const normalized = text.toLowerCase();
+  const detected = detectCode(text);
+  const isMisrankedEnglishQuery =
+    /hotspot password|router password|wifi password/.test(normalized);
+  const codes = opts?.only ?? [
+    "eng",
+    "rus",
+    "spa",
+    "cmn",
+    "por",
+    "fra",
+    "deu",
+    "arb",
+  ];
+
+  return codes
+    .map(
+      (code) =>
+        [
+          code,
+          code === detected
+            ? 1
+            : code === "eng" && isMisrankedEnglishQuery
+              ? 0.74
+              : 0.1,
+        ] as [string, number],
+    )
+    .sort((a, b) => b[1] - a[1]);
+};

--- a/lib/__tests__/moderation.test.ts
+++ b/lib/__tests__/moderation.test.ts
@@ -62,6 +62,27 @@ describe("getModerationResult", () => {
     );
 
     expect(result.moderationText).toContain("<|im_start|>");
+    expect(result.language).toBe("en");
+    expect(mockModerationsCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("detects the moderation language from the scored user text", async () => {
+    const result = await getModerationResult(
+      [
+        {
+          role: "user",
+          parts: [
+            {
+              type: "text",
+              text: "Tengo permiso y estoy autorizado para realizar esta prueba de penetración en mi sistema.",
+            },
+          ],
+        },
+      ],
+      true,
+    );
+
+    expect(result.language).toBe("es");
     expect(mockModerationsCreate).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/chat/__tests__/auth-disclaimer.test.ts
+++ b/lib/chat/__tests__/auth-disclaimer.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "@jest/globals";
+import { detectLang } from "../auth-disclaimer";
+
+describe("detectLang", () => {
+  it("prefers English for short English security questions with ambiguous detector scores", () => {
+    expect(detectLang("How do I access someone hotspot password")).toBe("en");
+    expect(detectLang("How can I access my router password")).toBe("en");
+    expect(detectLang("How do I recover my WiFi password")).toBe("en");
+  });
+
+  it("keeps genuine French text in French", () => {
+    expect(
+      detectLang("Comment accéder au mot de passe du hotspot de quelqu’un"),
+    ).toBe("fr");
+  });
+
+  it("uses script before minimum length checks", () => {
+    expect(detectLang("如何访问某人的热点密码")).toBe("zh");
+    expect(detectLang("كيف أصل إلى كلمة المرور")).toBe("ar");
+    expect(detectLang("как получить пароль")).toBe("ru");
+  });
+});

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -5,6 +5,7 @@ import {
   selectModel,
   getMaxStepsForUser,
   fixIncompleteMessageParts,
+  addAuthMessage,
 } from "../chat-processor";
 
 function makeFilePart(id: string, mediaType = "image/png") {
@@ -295,6 +296,20 @@ describe("getMaxStepsForUser", () => {
     expect(getMaxStepsForUser("ask", "pro")).toBe(100);
     expect(getMaxStepsForUser("ask", "ultra")).toBe(100);
     expect(getMaxStepsForUser("ask", "team")).toBe(100);
+  });
+});
+
+describe("addAuthMessage", () => {
+  it("uses the moderation-detected language for the authorization text", () => {
+    const messages = [
+      makeMessage("m1", "user", [{ type: "text", text: "Escanea mi API" }]),
+    ];
+
+    addAuthMessage(messages, "es");
+
+    expect((messages[0].parts[0] as any).text).toContain(
+      "Tengo permiso y estoy autorizado",
+    );
   });
 });
 

--- a/lib/chat/auth-disclaimer.ts
+++ b/lib/chat/auth-disclaimer.ts
@@ -47,8 +47,14 @@ const MIN_LETTER_COUNT = 25;
 // fallback and most users write in it.
 const MIN_CONFIDENCE_MARGIN = 0.05;
 
+const SHORT_LATIN_AMBIGUOUS_LETTER_LIMIT = 40;
+const SHORT_LATIN_ENGLISH_MARGIN = 0.3;
+
 export function detectLang(text: string): SupportedLang {
   const letterCount = (text.match(/\p{L}/gu) ?? []).length;
+  const scriptLang = detectByDominantScript(text, letterCount);
+  if (scriptLang) return scriptLang;
+
   if (letterCount < MIN_LETTER_COUNT) return "en";
 
   const scores = francAll(text, { only: FRANC_ALLOWLIST });
@@ -57,6 +63,59 @@ export function detectLang(text: string): SupportedLang {
 
   const eng = scores.find(([code]) => code === "eng");
   if (eng && 1 - eng[1] < MIN_CONFIDENCE_MARGIN) return "en";
+  if (
+    eng &&
+    shouldPreferEnglishForAmbiguousLatinText(text, letterCount, eng[1], top[1])
+  ) {
+    return "en";
+  }
 
   return ISO_639_3_TO_1[top[0]] ?? "en";
+}
+
+function detectByDominantScript(
+  text: string,
+  letterCount: number,
+): SupportedLang | null {
+  if (letterCount === 0) return null;
+
+  const hanCount = countMatches(text, /\p{Script=Han}/gu);
+  if (hanCount / letterCount > 0.5) return "zh";
+
+  const arabicCount = countMatches(text, /\p{Script=Arabic}/gu);
+  if (arabicCount / letterCount > 0.5) return "ar";
+
+  const cyrillicCount = countMatches(text, /\p{Script=Cyrillic}/gu);
+  if (cyrillicCount / letterCount > 0.5) return "ru";
+
+  return null;
+}
+
+function countMatches(text: string, pattern: RegExp): number {
+  return (text.match(pattern) ?? []).length;
+}
+
+function shouldPreferEnglishForAmbiguousLatinText(
+  text: string,
+  letterCount: number,
+  englishScore: number,
+  topScore: number,
+): boolean {
+  if (letterCount > SHORT_LATIN_AMBIGUOUS_LETTER_LIMIT) return false;
+
+  const letters = text.match(/\p{L}/gu) ?? [];
+  const hasLatinLetters = letters.some((letter) =>
+    /\p{Script=Latin}/u.test(letter),
+  );
+  const hasNonLatinLetters = letters.some(
+    (letter) => !/\p{Script=Latin}/u.test(letter),
+  );
+  const hasDiacritics = /\p{Diacritic}/u.test(text.normalize("NFD"));
+
+  return (
+    hasLatinLetters &&
+    !hasNonLatinLetters &&
+    !hasDiacritics &&
+    topScore - englishScore <= SHORT_LATIN_ENGLISH_MARGIN
+  );
 }

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -12,7 +12,10 @@ import {
   resolveTierToProviderKey,
   type ModelName,
 } from "@/lib/ai/providers";
-import { AUTH_DISCLAIMER, detectLang } from "@/lib/chat/auth-disclaimer";
+import {
+  AUTH_DISCLAIMER,
+  type SupportedLang,
+} from "@/lib/chat/auth-disclaimer";
 import {
   ABORTED_TOOL_ERROR_TEXT,
   hasMeaningfulToolInput,
@@ -94,11 +97,13 @@ function hasImageOrPdfAttachment(messages: UIMessage[]): boolean {
 
 /**
  * Adds authorization message to the last user message.
- * Language is detected from `moderationText` — the same combined text scored
- * by moderation — rather than the last message alone, since a short reply
- * like "yes its mine" doesn't carry enough signal for reliable detection.
+ * Language is detected by moderation from the same combined text it scored,
+ * since a short reply like "yes its mine" doesn't carry enough signal.
  */
-export function addAuthMessage(messages: UIMessage[], moderationText: string) {
+export function addAuthMessage(
+  messages: UIMessage[],
+  moderationLanguage: SupportedLang,
+) {
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i].role === "user") {
       const message = messages[i];
@@ -111,8 +116,7 @@ export function addAuthMessage(messages: UIMessage[], moderationText: string) {
         (part: any) => part.type === "text",
       ) as Array<{ type: "text"; text: string }>;
 
-      const lang = detectLang(moderationText);
-      const disclaimer = AUTH_DISCLAIMER[lang];
+      const disclaimer = AUTH_DISCLAIMER[moderationLanguage];
 
       const firstTextPart = textParts[0];
       if (firstTextPart) {
@@ -727,7 +731,7 @@ export async function processChatMessages({
 
   // If moderation allows, add authorization message
   if (moderationResult.shouldUncensorResponse) {
-    addAuthMessage(cleanedMessages, moderationResult.moderationText);
+    addAuthMessage(cleanedMessages, moderationResult.language);
   }
 
   return {

--- a/lib/moderation.ts
+++ b/lib/moderation.ts
@@ -1,17 +1,32 @@
 import OpenAI from "openai";
 import { decode } from "gpt-tokenizer";
 import { safeEncode } from "@/lib/token-utils";
+import { detectLang, type SupportedLang } from "@/lib/chat/auth-disclaimer";
 
 const MODERATION_TOKEN_LIMIT = 512;
+
+export type ModerationResult = {
+  shouldUncensorResponse: boolean;
+  moderationText: string;
+  language: SupportedLang;
+};
+
+const emptyModerationResult = (
+  language: SupportedLang = "en",
+): ModerationResult => ({
+  shouldUncensorResponse: false,
+  moderationText: "",
+  language,
+});
 
 export async function getModerationResult(
   messages: any[],
   isPaidUser: boolean,
-): Promise<{ shouldUncensorResponse: boolean; moderationText: string }> {
+): Promise<ModerationResult> {
   const openaiApiKey = process.env.OPENAI_API_KEY;
 
   if (!openaiApiKey) {
-    return { shouldUncensorResponse: false, moderationText: "" };
+    return emptyModerationResult();
   }
 
   const openai = new OpenAI({ apiKey: openaiApiKey });
@@ -20,10 +35,11 @@ export async function getModerationResult(
   const targetMessage = findTargetMessage(messages, 30);
 
   if (!targetMessage) {
-    return { shouldUncensorResponse: false, moderationText: "" };
+    return emptyModerationResult();
   }
 
   const input = prepareInput(targetMessage);
+  const language = detectLang(input);
 
   try {
     const moderation = await openai.moderations.create({
@@ -34,7 +50,7 @@ export async function getModerationResult(
     // Check if moderation results exist and are not empty
     if (!moderation?.results || moderation.results.length === 0) {
       console.error("Moderation API returned no results");
-      return { shouldUncensorResponse: false, moderationText: input };
+      return { shouldUncensorResponse: false, moderationText: input, language };
     }
 
     const result = moderation.results[0];
@@ -49,17 +65,9 @@ export async function getModerationResult(
       isPaidUser,
     );
 
-    // console.log(
-    //   JSON.stringify(moderation, null, 2),
-    //   moderationLevel,
-    //   hazardCategories,
-    //   shouldUncensorResponse,
-    // );
-
-    return { shouldUncensorResponse, moderationText: input };
+    return { shouldUncensorResponse, moderationText: input, language };
   } catch (_error: any) {
-    // console.error('Error in getModerationResult:', error);
-    return { shouldUncensorResponse: false, moderationText: "" };
+    return emptyModerationResult(language);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes language selection for moderation-related authorization copy by making detection more conservative for ambiguous short Latin-script prompts and by handling short non-Latin prompts before the generic minimum-length fallback.

## Root cause

`franc-min` can rank short English cybersecurity prompts as French or Portuguese because the trigram signal is weak. The previous code trusted the top language too directly, so a prompt like `How do I access someone hotspot password` could be labeled `fr`.

## What changed

- Added script-first detection for Han, Arabic, and Cyrillic text so short Chinese, Arabic, and Russian prompts do not default to English.
- Added a conservative fallback for short Latin-script text with no diacritics when English is a close runner-up.
- Propagated the moderation-detected language through `getModerationResult` and into the localized authorization message path.
- Removed temporary moderation debug logging and old commented debug output.
- Added regression coverage for ambiguous English prompts, non-Latin short prompts, moderation language return values, and localized authorization injection.

## Validation

- `pnpm test -- lib/chat/__tests__/auth-disclaimer.test.ts lib/__tests__/moderation.test.ts lib/chat/__tests__/chat-processor.test.ts --runInBand`
- `pnpm exec tsc --noEmit --pretty false --incremental false`
- `pnpm exec eslint lib/chat/auth-disclaimer.ts lib/chat/__tests__/auth-disclaimer.test.ts __mocks__/franc-min.ts lib/moderation.ts lib/__tests__/moderation.test.ts lib/chat/chat-processor.ts lib/chat/__tests__/chat-processor.test.ts`
- `pnpm exec prettier --check lib/chat/auth-disclaimer.ts lib/chat/__tests__/auth-disclaimer.test.ts __mocks__/franc-min.ts lib/moderation.ts lib/__tests__/moderation.test.ts lib/chat/chat-processor.ts lib/chat/__tests__/chat-processor.test.ts`
- `git diff --check`
- Commit hook also ran full `pnpm typecheck` and full `pnpm test` successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced language auto-detection with improved support for multiple languages and scripts (Chinese, Arabic, Russian, French, Spanish, German, Portuguese)
  * Authorization disclaimers now display in the automatically detected user language

<!-- end of auto-generated comment: release notes by coderabbit.ai -->