### PR TITLE
[codex] Classify chat authorization denials as warnings

### DIFF
--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -5,6 +5,7 @@ const loadSaveMessageWithMocks = async () => {
   process.env.NEXT_PUBLIC_CONVEX_URL = "https://example.convex.cloud";
 
   const mockMutation = jest.fn().mockResolvedValue({ id: "message-1" });
+  const mockQuery = jest.fn();
   const mockCompactMessageForStorage = jest.fn((message: any) => {
     const sizeBytes = JSON.stringify(message.parts).length;
     return {
@@ -21,7 +22,7 @@ const loadSaveMessageWithMocks = async () => {
   jest.doMock("convex/browser", () => ({
     ConvexHttpClient: class {
       mutation = mockMutation;
-      query = jest.fn();
+      query = mockQuery;
       action = jest.fn();
     },
   }));
@@ -29,8 +30,13 @@ const loadSaveMessageWithMocks = async () => {
     compactMessageForStorage: mockCompactMessageForStorage,
   }));
 
-  const { saveMessage } = await import("../actions");
-  return { saveMessage, mockCompactMessageForStorage };
+  const { getMessagesByChatId, saveMessage } = await import("../actions");
+  return {
+    getMessagesByChatId,
+    mockCompactMessageForStorage,
+    mockQuery,
+    saveMessage,
+  };
 };
 
 describe("saveMessage", () => {
@@ -69,5 +75,60 @@ describe("saveMessage", () => {
       self: "[Circular]",
     });
     expect(() => JSON.stringify(compactedMessage.parts)).not.toThrow();
+  });
+});
+
+describe("getMessagesByChatId", () => {
+  it("treats chat history authorization denials as warnings and forbidden chat errors", async () => {
+    const { getMessagesByChatId, mockQuery } = await loadSaveMessageWithMocks();
+    const convexError = new Error("[Request ID: abc] Server Error") as Error & {
+      data?: unknown;
+    };
+    convexError.name = "ConvexError";
+    convexError.data = {
+      code: "CHAT_UNAUTHORIZED",
+      message: "You don't have permission to access this chat",
+    };
+
+    mockQuery
+      .mockResolvedValueOnce({ id: "chat-1", user_id: "user-1" })
+      .mockRejectedValueOnce(convexError);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(
+        getMessagesByChatId({
+          chatId: "chat-1",
+          userId: "user-1",
+          subscription: "free",
+          newMessages: [],
+          regenerate: true,
+          isTemporary: false,
+          mode: "ask",
+        }),
+      ).rejects.toMatchObject({
+        type: "forbidden",
+        surface: "chat",
+        statusCode: 403,
+        metadata: expect.objectContaining({
+          db_operation: "messages.getMessagesPageForBackend",
+          db_error_code: "CHAT_UNAUTHORIZED",
+        }),
+      });
+
+      const warnEvents = warnSpy.mock.calls.map(([line]) => {
+        const payload = JSON.parse(String(line));
+        return payload.event;
+      });
+
+      expect(warnEvents).toContain("chat_history_fetch_failed");
+      expect(warnEvents).toContain("chat_access_denied");
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -205,12 +205,17 @@ const getDatabaseErrorCode = (data: unknown): string | undefined =>
 const getDatabaseFailureStage = (data: unknown): string | undefined =>
   getObjectString(data, "failureStage");
 
+const CHAT_UNAUTHORIZED_ERROR_CODE = "CHAT_UNAUTHORIZED";
+
 const isChatNotFoundMessageSaveError = (
   operation: string,
   dbErrorData: unknown,
 ): boolean =>
   operation === "messages.saveMessage" &&
   getDatabaseErrorCode(dbErrorData) === "CHAT_NOT_FOUND";
+
+const isChatUnauthorizedError = (dbErrorData: unknown): boolean =>
+  getDatabaseErrorCode(dbErrorData) === CHAT_UNAUTHORIZED_ERROR_CODE;
 
 const logChatMessagePreparationFailure = (
   event: string,
@@ -241,6 +246,23 @@ const databaseError = (
   const dbErrorMessage = truncateDiagnosticString(stringifyError(error));
   const dbErrorData = getErrorData(error);
   const isChatNotFound = isChatNotFoundMessageSaveError(operation, dbErrorData);
+  const isChatUnauthorized = isChatUnauthorizedError(dbErrorData);
+  const logLevel = isChatNotFound || isChatUnauthorized ? "warn" : "error";
+  const event = isChatNotFound
+    ? "database_operation_skipped_chat_not_found"
+    : isChatUnauthorized
+      ? "chat_access_denied"
+      : "database_operation_failed";
+  const errorCode = isChatNotFound
+    ? "not_found:chat"
+    : isChatUnauthorized
+      ? "forbidden:chat"
+      : "bad_request:database";
+  const errorMessage = isChatNotFound
+    ? `Chat no longer exists while saving message: ${operation}: ${dbErrorMessage}`
+    : isChatUnauthorized
+      ? `Chat access denied while executing database operation: ${operation}: ${dbErrorMessage}`
+      : `Database operation failed: ${operation}: ${dbErrorMessage}`;
   const diagnosticMetadata = {
     db_operation: operation,
     db_error_name: dbErrorName,
@@ -252,29 +274,21 @@ const databaseError = (
   };
 
   const logPayload = {
-    level: isChatNotFound ? "warn" : "error",
-    event: isChatNotFound
-      ? "database_operation_skipped_chat_not_found"
-      : "database_operation_failed",
+    level: logLevel,
+    event,
     service: "chat-handler",
     timestamp: new Date().toISOString(),
     ...diagnosticMetadata,
   };
 
   const logLine = JSON.stringify(logPayload);
-  if (isChatNotFound) {
+  if (logLevel === "warn") {
     console.warn(logLine);
   } else {
     console.error(logLine);
   }
 
-  return new ChatSDKError(
-    isChatNotFound ? "not_found:chat" : "bad_request:database",
-    isChatNotFound
-      ? `Chat no longer exists while saving message: ${operation}: ${dbErrorMessage}`
-      : `Database operation failed: ${operation}: ${dbErrorMessage}`,
-    diagnosticMetadata,
-  );
+  return new ChatSDKError(errorCode, errorMessage, diagnosticMetadata);
 };
 
 export async function getChatById({ id }: { id: string }) {


### PR DESCRIPTION
## Summary

- Classify Convex `CHAT_UNAUTHORIZED` database errors as expected chat access denials.
- Emit a structured `chat_access_denied` warning instead of `database_operation_failed` at error level.
- Surface the request as `forbidden:chat` / HTTP 403 rather than `bad_request:database` / HTTP 400.
- Add a regression test for the history rehydrate path that triggered the noisy log sequence.

## Why

`CHAT_UNAUTHORIZED` is produced by the chat ownership check when a user tries to access a chat they do not own. That is useful audit/diagnostic signal, but it is not a database outage or failed query that should page as an application error.

## Validation

- `pnpm jest lib/db/__tests__/actions-save-message.test.ts --runInBand`
- `pnpm typecheck`
- Commit hook also ran Prettier, ESLint, `tsc --noEmit`, and the full Jest suite: 122 suites / 1359 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for chat authorization, now properly distinguishing between access-denied and not-found errors with appropriate status codes and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->