### PR TITLE
Tame AuthKit callback logging

### DIFF
--- a/app/callback/route.ts
+++ b/app/callback/route.ts
@@ -1,6 +1,8 @@
 import { handleAuth } from "@workos-inc/authkit-nextjs";
 import {
+  isAuthVerifierMissingError,
   isAuthCookieMissingError,
+  isMissingRequiredAuthParameterError,
   isOauthCodeAlreadyExchangedError,
   withRecoverableAuthkitCallbackErrorSuppressed,
 } from "@/lib/auth/authkit-callback-logging";
@@ -19,6 +21,7 @@ const hasPkceCookie = (request: NextRequest): boolean =>
   request.cookies.getAll().some((c) => c.name.startsWith(PKCE_COOKIE_PREFIX));
 
 type RecoveryBucket =
+  | "missing_auth_parameter"
   | "state_mismatch"
   | "verifier_missing"
   | "cookie_missing"
@@ -29,22 +32,17 @@ const classifyCallbackError = (error: unknown): RecoveryBucket => {
   if (isOauthCodeAlreadyExchangedError(error)) {
     return "code_already_exchanged";
   }
+  if (isMissingRequiredAuthParameterError(error)) {
+    return "missing_auth_parameter";
+  }
   if (isAuthCookieMissingError(error)) {
     return "cookie_missing";
   }
+  if (isAuthVerifierMissingError(error)) {
+    return "verifier_missing";
+  }
   if (!(error instanceof Error)) return "unknown";
   if (error.message.includes("OAuth state mismatch")) return "state_mismatch";
-  if (error.name === "ValiError") {
-    const issues = (error as Error & { issues?: Array<{ expected?: string }> })
-      .issues;
-    if (
-      issues?.some((i) =>
-        ['"nonce"', '"codeVerifier"'].includes(i.expected ?? ""),
-      )
-    ) {
-      return "verifier_missing";
-    }
-  }
   return "unknown";
 };
 
@@ -70,6 +68,7 @@ const buildRecoveryResponse = async (
     }
   }
   const logPayload = {
+    event: "auth.callback_invalid",
     bucket,
     hasVerifierCookie,
     userAgent: request.headers.get("user-agent"),
@@ -80,11 +79,18 @@ const buildRecoveryResponse = async (
   // Distinct prefix from authkit's own `[AuthKit callback error]` so log
   // aggregators don't double-count and so we can grep this wrapper separately.
   if (bucket === "unknown") {
-    console.error("[callback] unrecoverable", error, logPayload);
+    console.error("[callback] unrecoverable", error, {
+      ...logPayload,
+      event: "auth.callback_failed",
+    });
     return NextResponse.redirect(new URL("/auth-error?code=500", request.url));
   }
 
-  console.warn("[callback] recovering", logPayload);
+  if (bucket === "missing_auth_parameter") {
+    console.info("[callback] invalid_request", logPayload);
+  } else {
+    console.warn("[callback] recovering", logPayload);
+  }
 
   // Only verifier_missing with the cookie still present indicates genuine
   // corruption/tampering worth surfacing as an error. Everything else →

--- a/lib/auth/__tests__/authkit-callback-logging.test.ts
+++ b/lib/auth/__tests__/authkit-callback-logging.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, afterEach, jest } from "@jest/globals";
 
 import {
+  isAuthVerifierMissingError,
   isAuthCookieMissingError,
+  isMissingRequiredAuthParameterError,
   isOauthCodeAlreadyExchangedError,
   isRecoverableAuthkitCallbackErrorLog,
   withRecoverableAuthkitCallbackErrorSuppressed,
@@ -32,6 +34,35 @@ describe("authkit callback logging", () => {
       isAuthCookieMissingError({
         message: "Auth cookie missing - cannot verify OAuth state.",
       }),
+    ).toBe(true);
+  });
+
+  it("matches missing auth parameter callback errors", () => {
+    const error = new Error("Missing required auth parameter");
+
+    expect(isMissingRequiredAuthParameterError(error)).toBe(true);
+    expect(
+      isRecoverableAuthkitCallbackErrorLog(["[AuthKit callback error]", error]),
+    ).toBe(true);
+  });
+
+  it("matches missing verifier schema callback errors", () => {
+    const error = Object.assign(
+      new Error('Invalid key: Expected "nonce" but received undefined'),
+      {
+        name: "ValiError",
+        issues: [
+          {
+            expected: '"nonce"',
+            received: "undefined",
+          },
+        ],
+      },
+    );
+
+    expect(isAuthVerifierMissingError(error)).toBe(true);
+    expect(
+      isRecoverableAuthkitCallbackErrorLog(["[AuthKit callback error]", error]),
     ).toBe(true);
   });
 
@@ -91,6 +122,25 @@ describe("authkit callback logging", () => {
         "[AuthKit callback error]",
         new Error(
           "Error: invalid_grant\nError Description: The code 'abc123' has already been exchanged.",
+        ),
+      );
+      console.error(
+        "[AuthKit callback error]",
+        new Error("Missing required auth parameter"),
+      );
+      console.error(
+        "[AuthKit callback error]",
+        Object.assign(
+          new Error('Invalid key: Expected "nonce" but received undefined'),
+          {
+            name: "ValiError",
+            issues: [
+              {
+                expected: '"nonce"',
+                received: "undefined",
+              },
+            ],
+          },
         ),
       );
       console.error("other error", new Error("boom"));

--- a/lib/auth/authkit-callback-logging.ts
+++ b/lib/auth/authkit-callback-logging.ts
@@ -1,7 +1,10 @@
 const AUTHKIT_CALLBACK_ERROR_PREFIX = "[AuthKit callback error]";
 const AUTH_COOKIE_MISSING_MESSAGE = "Auth cookie missing";
+const MISSING_REQUIRED_AUTH_PARAMETER_MESSAGE =
+  "Missing required auth parameter";
 const INVALID_GRANT_ERROR = "invalid_grant";
 const CODE_ALREADY_EXCHANGED_MESSAGE = "already been exchanged";
+const VERIFIER_SCHEMA_KEYS = ['"nonce"', '"codeVerifier"'];
 
 let activeSuppressions = 0;
 let originalConsoleError: typeof console.error | null = null;
@@ -64,9 +67,44 @@ export const isOauthCodeAlreadyExchangedError = (value: unknown): boolean => {
   );
 };
 
+export const isMissingRequiredAuthParameterError = (
+  value: unknown,
+): boolean => {
+  return collectErrorText(value)
+    .toLowerCase()
+    .includes(MISSING_REQUIRED_AUTH_PARAMETER_MESSAGE.toLowerCase());
+};
+
+export const isAuthVerifierMissingError = (value: unknown): boolean => {
+  if (value && typeof value === "object") {
+    const error = value as {
+      issues?: Array<{ expected?: string; received?: string }>;
+    };
+    if (
+      error.issues?.some(
+        (issue) =>
+          VERIFIER_SCHEMA_KEYS.includes(issue.expected ?? "") &&
+          issue.received === "undefined",
+      )
+    ) {
+      return true;
+    }
+  }
+
+  const errorText = collectErrorText(value);
+  return VERIFIER_SCHEMA_KEYS.some(
+    (key) =>
+      errorText.includes(`Expected ${key}`) &&
+      errorText.includes("received undefined"),
+  );
+};
+
 export const isRecoverableAuthkitCallbackError = (value: unknown): boolean => {
   return (
-    isAuthCookieMissingError(value) || isOauthCodeAlreadyExchangedError(value)
+    isAuthCookieMissingError(value) ||
+    isOauthCodeAlreadyExchangedError(value) ||
+    isMissingRequiredAuthParameterError(value) ||
+    isAuthVerifierMissingError(value)
   );
 };
 


### PR DESCRIPTION
## Summary
- classify missing AuthKit callback parameters as invalid callback requests instead of unrecoverable errors
- suppress AuthKit's duplicate error-level callback logs for missing parameters and missing verifier schema data
- log malformed callback requests at info level with structured event payloads while preserving the existing login retry flow

## Verification
- `pnpm test -- lib/auth/__tests__/authkit-callback-logging.test.ts --runInBand`
- `pnpm exec prettier --check app/callback/route.ts lib/auth/authkit-callback-logging.ts lib/auth/__tests__/authkit-callback-logging.test.ts`
- `pnpm exec eslint app/callback/route.ts lib/auth/authkit-callback-logging.ts lib/auth/__tests__/authkit-callback-logging.test.ts`
- `pnpm typecheck`
- pre-commit hook: `pnpm typecheck` and full `pnpm test` (122 suites / 1360 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced authentication callback error recovery to properly handle missing required parameters
  * Improved error logging with specific event tracking for invalid and failed authentication attempts
  * Refined error classification to better route different error categories

* **Tests**
  * Added test coverage for new authentication error recovery scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->