### PR TITLE
[codex] Allow free user referrals

### DIFF
--- a/app/api/referrals/__tests__/route.test.ts
+++ b/app/api/referrals/__tests__/route.test.ts
@@ -32,6 +32,7 @@ describe("GET /api/referrals", () => {
     mockConvexMutation.mockResolvedValue({
       code: "UVVQDMV",
       active: true,
+      referrerSubscriptionTier: "pro",
       attributedSignups: 0,
       paidConversions: 0,
       awardedDollars: 0,
@@ -46,6 +47,7 @@ describe("GET /api/referrals", () => {
 
     expect(response.status).toBe(200);
     expect(body.referralUrl).toBe("https://hackerai.co/invite/UVVQDMV");
+    expect(body.referrerSubscriptionTier).toBe("pro");
     expect(body.referredSignupBonusUnits).toBe(10);
     expect(mockConvexMutation).toHaveBeenCalledWith(
       expect.anything(),
@@ -53,5 +55,59 @@ describe("GET /api/referrals", () => {
         codeCandidate: expect.stringMatching(/^[A-Z2-9]{7}$/),
       }),
     );
+  });
+
+  it("allows free users to create referral URLs", async () => {
+    mockGetUserIDAndPro.mockResolvedValueOnce({
+      userId: "user_free",
+      subscription: "free",
+      organizationId: undefined,
+    } as never);
+    mockConvexMutation.mockResolvedValueOnce({
+      code: "UVVQDMV",
+      active: true,
+      referrerSubscriptionTier: "free",
+      attributedSignups: 0,
+      paidConversions: 0,
+      awardedDollars: 0,
+    } as never);
+    const { GET } = await import("../route");
+
+    const response = await GET({} as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.referralUrl).toBe("https://hackerai.co/invite/UVVQDMV");
+    expect(body.referrerSubscriptionTier).toBe("free");
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        userId: "user_free",
+        subscriptionTier: "free",
+      }),
+    );
+  });
+
+  it("returns the referrer tier reported by Convex", async () => {
+    mockGetUserIDAndPro.mockResolvedValueOnce({
+      userId: "user_123",
+      subscription: "pro",
+      organizationId: undefined,
+    } as never);
+    mockConvexMutation.mockResolvedValueOnce({
+      code: "UVVQDMV",
+      active: true,
+      referrerSubscriptionTier: "free",
+      attributedSignups: 0,
+      paidConversions: 0,
+      awardedDollars: 0,
+    } as never);
+    const { GET } = await import("../route");
+
+    const response = await GET({} as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.referrerSubscriptionTier).toBe("free");
   });
 });

--- a/app/api/referrals/attribution/route.ts
+++ b/app/api/referrals/attribution/route.ts
@@ -64,6 +64,9 @@ export async function POST(req: NextRequest) {
     maxUserAgeDays: config.attributionMaxUserAgeDays,
     source: "referral_cookie",
   });
+  const referrerSubscriptionTier = (
+    result as { referrerSubscriptionTier?: string }
+  ).referrerSubscriptionTier;
 
   let starterBonusUnitsAwarded = false;
   let starterBonusUnits = 0;
@@ -102,6 +105,7 @@ export async function POST(req: NextRequest) {
         phLogger.warn("referral_signup_bonus_grant_failed", {
           userId,
           referrer_user_id: result.referrerUserId,
+          referrer_subscription_tier: referrerSubscriptionTier,
           referral_code: referralCode,
           starter_bonus_units: result.starterBonusUnits,
         });
@@ -110,6 +114,7 @@ export async function POST(req: NextRequest) {
       phLogger.warn("referral_signup_bonus_grant_failed", {
         userId,
         referrer_user_id: result.referrerUserId,
+        referrer_subscription_tier: referrerSubscriptionTier,
         referral_code: referralCode,
         starter_bonus_units: result.starterBonusUnits,
         error: error instanceof Error ? error.message : String(error),
@@ -121,6 +126,7 @@ export async function POST(req: NextRequest) {
     phLogger.event("referred_signup_attributed", {
       userId,
       referrer_user_id: result.referrerUserId,
+      referrer_subscription_tier: referrerSubscriptionTier,
       referral_code: referralCode,
       starter_bonus_awarded: starterBonusUnitsAwarded,
       starter_bonus_units: starterBonusUnits,
@@ -129,6 +135,7 @@ export async function POST(req: NextRequest) {
     phLogger.event("referral_reward_withheld", {
       userId,
       referrer_user_id: result.referrerUserId,
+      referrer_subscription_tier: referrerSubscriptionTier,
       referral_code: referralCode,
       reason: result.reason,
       reward_type: "referred_signup",

--- a/app/api/referrals/route.ts
+++ b/app/api/referrals/route.ts
@@ -30,12 +30,6 @@ export async function GET(req: NextRequest) {
   }
 
   const { userId, subscription, organizationId } = await getUserIDAndPro(req);
-  if (subscription === "free") {
-    return NextResponse.json(
-      { error: "Paid subscription required" },
-      { status: 403 },
-    );
-  }
 
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
   if (!baseUrl) {
@@ -48,6 +42,7 @@ export async function GET(req: NextRequest) {
   let result: {
     code: string;
     active: boolean;
+    referrerSubscriptionTier: string;
     attributedSignups: number;
     paidConversions: number;
     awardedDollars: number;
@@ -93,6 +88,7 @@ export async function GET(req: NextRequest) {
     code: result.code,
     active: result.active,
     referralUrl: referralUrl.toString(),
+    referrerSubscriptionTier: result.referrerSubscriptionTier,
     referrerRewardDollars: config.referrerRewardDollars,
     referredSignupBonusUnits: config.referredSignupBonusUnits,
     stats: {

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -75,9 +75,14 @@ export const POST = async (req: NextRequest) => {
         );
 
         if (attribution.status === "attributed") {
+          const referrerSubscriptionTier = (
+            attribution as { referrerSubscriptionTier?: string }
+          ).referrerSubscriptionTier;
+
           phLogger.event("referred_signup_attributed", {
             userId,
             referrer_user_id: attribution.referrerUserId,
+            referrer_subscription_tier: referrerSubscriptionTier,
             referral_code: referralCode,
             starter_bonus_awarded: attribution.starterBonusAwarded,
             starter_bonus_units: 0,
@@ -324,9 +329,14 @@ export const POST = async (req: NextRequest) => {
         );
 
         if (referralSession?.recorded) {
+          const referrerSubscriptionTier = (
+            referralSession as { referrerSubscriptionTier?: string }
+          ).referrerSubscriptionTier;
+
           phLogger.event("referral_stripe_checkout_session_created", {
             userId,
             referrer_user_id: referralSession.referrerUserId,
+            referrer_subscription_tier: referrerSubscriptionTier,
             referral_code: referralSession.referralCode,
             stripe_customer_id: customer.id,
             stripe_checkout_session_id: session.id,

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -203,12 +203,16 @@ async function awardReferralConversion(args: {
       plan: args.plan,
       tier: args.tier,
     });
+    const referrerSubscriptionTier = (
+      result as { referrerSubscriptionTier?: string }
+    ).referrerSubscriptionTier;
 
     if (result.status === "awarded" || result.status === "already_awarded") {
       if (result.referredUserId ?? referredUserId) {
         phLogger.event("referred_user_paid_conversion", {
           userId: result.referredUserId ?? referredUserId,
           referrer_user_id: result.referrerUserId,
+          referrer_subscription_tier: referrerSubscriptionTier,
           referral_code: result.referralCode,
           reward_status: result.status,
           plan: args.plan,
@@ -224,6 +228,7 @@ async function awardReferralConversion(args: {
         phLogger.event("referrer_credits_awarded", {
           userId: result.referrerUserId,
           referred_user_id: result.referredUserId ?? referredUserId,
+          referrer_subscription_tier: referrerSubscriptionTier,
           referral_code: result.referralCode,
           reward_dollars: config.referrerRewardDollars,
           plan: args.plan,
@@ -238,6 +243,7 @@ async function awardReferralConversion(args: {
       phLogger.event("referral_reward_withheld", {
         userId: result.referredUserId ?? referredUserId,
         referrer_user_id: result.referrerUserId,
+        referrer_subscription_tier: referrerSubscriptionTier,
         referral_code: result.referralCode,
         reward_type: "referrer_conversion",
         reason: result.reason,
@@ -273,7 +279,7 @@ async function setReferralCodesPaidEligibility(args: {
   }
 
   const subscriptionTier =
-    args.active && args.tier && args.tier !== "free" ? args.tier : undefined;
+    args.tier && args.tier !== "free" ? args.tier : "free";
 
   try {
     await convex.mutation(api.referrals.setReferralCodesPaidEligibility, {

--- a/app/components/ReferralRewardDialog.tsx
+++ b/app/components/ReferralRewardDialog.tsx
@@ -28,6 +28,7 @@ type ReferralProgram = {
   code: string;
   active: boolean;
   referralUrl: string;
+  referrerSubscriptionTier: string;
   referrerRewardDollars: number;
   referredSignupBonusUnits: number;
   stats: {
@@ -76,6 +77,7 @@ export function ReferralRewardDialog({
         setProgram(body);
         captureAuthenticatedEvent("referral_modal_opened", {
           referral_code: body.code,
+          referrer_subscription_tier: body.referrerSubscriptionTier,
           referrer_reward_dollars: body.referrerRewardDollars,
           referred_signup_bonus_units: body.referredSignupBonusUnits,
         });
@@ -104,6 +106,7 @@ export function ReferralRewardDialog({
       toast.success("Referral link copied");
       captureAuthenticatedEvent("referral_link_copied", {
         referral_code: program.code,
+        referrer_subscription_tier: program.referrerSubscriptionTier,
       });
       window.setTimeout(() => setCopied(false), 1800);
     } catch {
@@ -112,6 +115,20 @@ export function ReferralRewardDialog({
   };
 
   const referrerReward = program?.referrerRewardDollars ?? 0;
+  const isFreeReferrer = program?.referrerSubscriptionTier === "free";
+  const referrerRewardTitle = isFreeReferrer
+    ? `Earn $${referrerReward} in usage credits`
+    : `Earn $${referrerReward} in extra usage credits`;
+  const referrerRewardCopy = isFreeReferrer ? (
+    <>
+      You get <b>${referrerReward} in usage credits</b> when they upgrade. Use
+      them after you upgrade to a paid plan.
+    </>
+  ) : (
+    <>
+      You get <b>${referrerReward} in extra usage credits</b> when they upgrade
+    </>
+  );
   const referredSignupBonusUnits = program?.referredSignupBonusUnits ?? 0;
   const referredSignupBonusCopy =
     referredSignupBonusUnits > 0
@@ -157,6 +174,12 @@ export function ReferralRewardDialog({
                     Rewards are earned once your invitee creates a new account
                     and subscribes to any paid HackerAI plan. No credit is
                     granted for inactive or incomplete referrals.
+                  </span>
+                </li>
+                <li>
+                  <span className="text-muted-foreground text-sm">
+                    If you are on the Free plan, earned usage credits are saved
+                    to your account and become usable after you upgrade.
                   </span>
                 </li>
                 <li>
@@ -215,7 +238,7 @@ export function ReferralRewardDialog({
                 <Gift className="size-7" />
               </div>
               <DialogTitle className="text-2xl font-semibold">
-                Earn ${referrerReward} in credits
+                {referrerRewardTitle}
               </DialogTitle>
               <DialogDescription className="text-muted-foreground max-w-xs text-sm">
                 Invite friends. When they upgrade, you both win.
@@ -291,8 +314,7 @@ export function ReferralRewardDialog({
                         <Coins className="size-5" />
                       </span>
                       <span className="text-foreground text-base font-normal">
-                        You get <b>${referrerReward} in extra usage credits</b>{" "}
-                        once they subscribe to any paid plan
+                        {referrerRewardCopy}
                       </span>
                     </li>
                   </ul>

--- a/app/components/SidebarUserNav.tsx
+++ b/app/components/SidebarUserNav.tsx
@@ -352,8 +352,8 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
         onOpenChange={setReferralDialogOpen}
       />
 
-      {/* Referral card for paid users */}
-      {isPaidUser && !isCheckingProPlan && (
+      {/* Referral card */}
+      {!isCheckingProPlan && (
         <ReferralSidebarCard
           isCollapsed={isCollapsed}
           onOpen={() => setReferralDialogOpen(true)}
@@ -482,17 +482,17 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
             </DropdownMenuItem>
           )}
 
+          <DropdownMenuItem
+            data-testid="referral-menu-item"
+            onSelect={() => setReferralDialogOpen(true)}
+            className="py-1.5"
+          >
+            <Gift className="mr-2 h-4 w-4 text-foreground" />
+            <span>Refer a friend</span>
+          </DropdownMenuItem>
+
           {isPaidUser && (
             <div>
-              <DropdownMenuItem
-                data-testid="referral-menu-item"
-                onSelect={() => setReferralDialogOpen(true)}
-                className="py-1.5"
-              >
-                <Gift className="mr-2 h-4 w-4 text-foreground" />
-                <span>Refer a friend</span>
-              </DropdownMenuItem>
-
               <DropdownMenuItem
                 onSelect={(e) => {
                   e.preventDefault();

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -204,6 +204,11 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   const [sidebarContent, setSidebarContent] = useState<SidebarContent | null>(
     null,
   );
+  const [subscription, setSubscription] = useState<SubscriptionTier>("free");
+  const setSubscriptionWithNormalize = useCallback((tier: SubscriptionTier) => {
+    setSubscription(tier);
+  }, []);
+  const [isCheckingProPlan, setIsCheckingProPlan] = useState(false);
 
   // Persist chat mode preference to localStorage on change
   useEffect(() => {
@@ -284,14 +289,18 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
       (notification) => notification.rewardId,
     );
 
-    toast.success("Referral reward added", {
-      description: `You earned ${amountLabel} in extra usage credits.`,
-    });
+    const description =
+      subscription === "free"
+        ? `You earned ${amountLabel} in usage credits. They apply after you upgrade.`
+        : `You earned ${amountLabel} in extra usage credits.`;
+
+    toast.success("Referral reward added", { description });
     void markReferralRewardNotificationsSeen({ rewardIds }).catch(() => {
       // The toast is non-critical; the next app load can retry marking it seen.
     });
   }, [
     markReferralRewardNotificationsSeen,
+    subscription,
     unreadReferralRewardNotifications,
     user,
   ]);
@@ -313,11 +322,6 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     },
     [],
   );
-  const [subscription, setSubscription] = useState<SubscriptionTier>("free");
-  const setSubscriptionWithNormalize = useCallback((tier: SubscriptionTier) => {
-    setSubscription(tier);
-  }, []);
-  const [isCheckingProPlan, setIsCheckingProPlan] = useState(false);
   const chatResetRef = useRef<(() => void) | null>(null);
   const desktopEntitlementRefreshUserRef = useRef<string | null>(null);
 

--- a/convex/__tests__/referralsNotifications.test.ts
+++ b/convex/__tests__/referralsNotifications.test.ts
@@ -266,4 +266,123 @@ describe("referral reward notifications", () => {
     expect(tables.user_customization[0].extra_usage_enabled).toBe(false);
     expect(queryCalls).not.toContain("user_customization");
   });
+
+  it("awards personal credits to free referrers after referred users convert", async () => {
+    const { awardConversionReward } = await import("../referrals");
+    const { ctx, tables } = makeMockCtx({
+      referral_attributions: [
+        {
+          _id: "attribution_1",
+          referred_user_id: REFERRED_USER_ID,
+          referrer_user_id: USER_ID,
+          referral_code: "FREE123",
+          referrer_subscription_tier: "free",
+          status: "attributed",
+          sign_up_reward_status: "awarded",
+          conversion_reward_status: "pending",
+          created_at: 1,
+          updated_at: 1,
+        },
+      ],
+      referral_codes: [
+        {
+          _id: "code_1",
+          user_id: USER_ID,
+          code: "FREE123",
+          status: "active",
+          referrer_subscription_tier: "free",
+          created_at: 1,
+          updated_at: 1,
+        },
+      ],
+    });
+
+    const result = await awardConversionReward.handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      referrerRewardDollars: 10,
+      referredUserId: REFERRED_USER_ID,
+      stripeCustomerId: "cus_123",
+      stripeSubscriptionId: "sub_123",
+      stripeInvoiceId: "in_123",
+      plan: "pro-monthly-plan",
+      tier: "pro",
+    });
+
+    expect(result.status).toBe("awarded");
+    expect(tables.extra_usage).toMatchObject([
+      {
+        user_id: USER_ID,
+        balance_points: 100_000,
+        auto_reload_enabled: false,
+      },
+    ]);
+    expect(tables.user_customization).toMatchObject([
+      {
+        user_id: USER_ID,
+        extra_usage_enabled: true,
+      },
+    ]);
+    expect(tables.team_extra_usage).toEqual([]);
+  });
+
+  it("activates earned personal credits when an originally free referrer upgrades before conversion", async () => {
+    const { awardConversionReward } = await import("../referrals");
+    const { ctx, tables } = makeMockCtx({
+      referral_attributions: [
+        {
+          _id: "attribution_1",
+          referred_user_id: REFERRED_USER_ID,
+          referrer_user_id: USER_ID,
+          referral_code: "UPGRADE",
+          referrer_subscription_tier: "free",
+          status: "attributed",
+          sign_up_reward_status: "awarded",
+          conversion_reward_status: "pending",
+          created_at: 1,
+          updated_at: 1,
+        },
+      ],
+      referral_codes: [
+        {
+          _id: "code_1",
+          user_id: USER_ID,
+          code: "UPGRADE",
+          status: "active",
+          referrer_subscription_tier: "pro",
+          created_at: 1,
+          updated_at: 1,
+        },
+      ],
+      user_customization: [
+        {
+          _id: "customization_1",
+          user_id: USER_ID,
+          extra_usage_enabled: false,
+          updated_at: 1,
+        },
+      ],
+    });
+
+    const result = await awardConversionReward.handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      referrerRewardDollars: 10,
+      referredUserId: REFERRED_USER_ID,
+      stripeCustomerId: "cus_123",
+      stripeSubscriptionId: "sub_123",
+      stripeInvoiceId: "in_123",
+      plan: "pro-monthly-plan",
+      tier: "pro",
+    });
+
+    expect(result.status).toBe("awarded");
+    expect(result.referrerSubscriptionTier).toBe("pro");
+    expect(tables.extra_usage).toMatchObject([
+      {
+        user_id: USER_ID,
+        balance_points: 100_000,
+        auto_reload_enabled: false,
+      },
+    ]);
+    expect(tables.user_customization[0].extra_usage_enabled).toBe(true);
+  });
 });

--- a/convex/referrals.ts
+++ b/convex/referrals.ts
@@ -17,7 +17,16 @@ const paidTierValidator = v.union(
   v.literal("team"),
 );
 
+const referrerTierValidator = v.union(
+  v.literal("free"),
+  v.literal("pro"),
+  v.literal("pro-plus"),
+  v.literal("ultra"),
+  v.literal("team"),
+);
+
 type PaidTier = "pro" | "pro-plus" | "ultra" | "team";
+type ReferrerTier = "free" | PaidTier;
 type RewardType = "referred_signup" | "referrer_conversion";
 
 const QUALIFYING_TIERS = new Set<PaidTier>([
@@ -28,6 +37,26 @@ const QUALIFYING_TIERS = new Set<PaidTier>([
 ]);
 
 const SUBSCRIPTION_ENDED_REASON = "subscription_ended";
+
+const isReferralCodeUsable = (referralCode: {
+  status: "active" | "deactivated";
+  deactivated_reason?: string;
+}) =>
+  referralCode.status === "active" ||
+  referralCode.deactivated_reason === SUBSCRIPTION_ENDED_REASON;
+
+const rewardTierForReferralCode = (
+  referralCode: {
+    status: "active" | "deactivated";
+    deactivated_reason?: string;
+    referrer_subscription_tier?: ReferrerTier;
+  },
+  fallback?: ReferrerTier,
+): ReferrerTier | undefined =>
+  referralCode.status === "deactivated" &&
+  referralCode.deactivated_reason === SUBSCRIPTION_ENDED_REASON
+    ? "free"
+    : (referralCode.referrer_subscription_tier ?? fallback);
 
 const dollarsToPoints = (dollars: number): number =>
   Math.round(dollars * POINTS_PER_DOLLAR);
@@ -64,6 +93,7 @@ async function addPersonalCredits(
   userId: string,
   amountDollars: number,
   now: number,
+  options?: { activateForPaidUse?: boolean },
 ) {
   const amountPoints = dollarsToPoints(amountDollars);
   const row = await ctx.db
@@ -75,14 +105,36 @@ async function addPersonalCredits(
   if (row) {
     await ctx.db.patch(row._id, {
       balance_points: newBalancePoints,
+      ...(options?.activateForPaidUse && { auto_reload_enabled: false }),
       updated_at: now,
     });
   } else {
     await ctx.db.insert("extra_usage", {
       user_id: userId,
       balance_points: newBalancePoints,
+      ...(options?.activateForPaidUse && { auto_reload_enabled: false }),
       updated_at: now,
     });
+  }
+
+  if (options?.activateForPaidUse) {
+    const customization = await ctx.db
+      .query("user_customization")
+      .withIndex("by_user_id", (q) => q.eq("user_id", userId))
+      .first();
+
+    if (customization) {
+      await ctx.db.patch(customization._id, {
+        extra_usage_enabled: true,
+        updated_at: now,
+      });
+    } else {
+      await ctx.db.insert("user_customization", {
+        user_id: userId,
+        extra_usage_enabled: true,
+        updated_at: now,
+      });
+    }
   }
 
   return pointsToDollars(newBalancePoints);
@@ -176,8 +228,9 @@ async function grantReward(
     referrerUserId?: string;
     referredUserId?: string;
     referralCode?: string;
-    subscriptionTier?: PaidTier;
+    subscriptionTier?: ReferrerTier;
     organizationId?: string;
+    activatePersonalCreditsForPaidUse?: boolean;
     stripeCheckoutSessionId?: string;
     stripeCustomerId?: string;
     stripeSubscriptionId?: string;
@@ -203,7 +256,9 @@ async function grantReward(
   const newBalance =
     args.subscriptionTier === "team" && args.organizationId
       ? await addTeamCredits(ctx, args.organizationId, args.amountDollars, now)
-      : await addPersonalCredits(ctx, args.userId, args.amountDollars, now);
+      : await addPersonalCredits(ctx, args.userId, args.amountDollars, now, {
+          activateForPaidUse: args.activatePersonalCreditsForPaidUse,
+        });
 
   await insertRewardLog(ctx, {
     idempotencyKey: args.idempotencyKey,
@@ -237,13 +292,14 @@ export const getOrCreateReferralCode = mutation({
   args: {
     serviceKey: v.string(),
     userId: v.string(),
-    subscriptionTier: paidTierValidator,
+    subscriptionTier: referrerTierValidator,
     organizationId: v.optional(v.string()),
     codeCandidate: v.string(),
   },
   returns: v.object({
     code: v.string(),
     active: v.boolean(),
+    referrerSubscriptionTier: referrerTierValidator,
     attributedSignups: v.number(),
     paidConversions: v.number(),
     awardedDollars: v.number(),
@@ -252,25 +308,26 @@ export const getOrCreateReferralCode = mutation({
     validateServiceKey(args.serviceKey);
 
     const now = Date.now();
+    const organizationId =
+      args.subscriptionTier === "team" ? args.organizationId : undefined;
     const existingForUser = await ctx.db
       .query("referral_codes")
       .withIndex("by_user_id", (q) => q.eq("user_id", args.userId))
       .first();
 
     if (existingForUser) {
-      const canBeActive =
-        existingForUser.status === "active" ||
-        existingForUser.deactivated_reason === SUBSCRIPTION_ENDED_REASON;
+      const canBeActive = isReferralCodeUsable(existingForUser);
 
       await ctx.db.patch(existingForUser._id, {
         status: canBeActive ? "active" : existingForUser.status,
         referrer_subscription_tier: args.subscriptionTier,
-        referrer_organization_id: args.organizationId,
+        referrer_organization_id: organizationId,
         updated_at: now,
       });
       return {
         code: existingForUser.code,
         active: canBeActive,
+        referrerSubscriptionTier: args.subscriptionTier,
         ...(await getReferralStats(ctx, args.userId)),
       };
     }
@@ -289,7 +346,7 @@ export const getOrCreateReferralCode = mutation({
       code: args.codeCandidate,
       status: "active",
       referrer_subscription_tier: args.subscriptionTier,
-      referrer_organization_id: args.organizationId,
+      referrer_organization_id: organizationId,
       created_at: now,
       updated_at: now,
     });
@@ -297,6 +354,7 @@ export const getOrCreateReferralCode = mutation({
     return {
       code: args.codeCandidate,
       active: true,
+      referrerSubscriptionTier: args.subscriptionTier,
       ...(await getReferralStats(ctx, args.userId)),
     };
   },
@@ -398,7 +456,7 @@ export const getReferralInvite = query({
 
     return {
       code: referralCode.code,
-      active: referralCode.status === "active",
+      active: isReferralCodeUsable(referralCode),
       referrerUserId: referralCode.user_id,
     };
   },
@@ -409,7 +467,7 @@ export const setReferralCodesPaidEligibility = mutation({
     serviceKey: v.string(),
     userIds: v.array(v.string()),
     active: v.boolean(),
-    subscriptionTier: v.optional(paidTierValidator),
+    subscriptionTier: v.optional(referrerTierValidator),
     organizationId: v.optional(v.string()),
   },
   returns: v.object({
@@ -430,18 +488,21 @@ export const setReferralCodesPaidEligibility = mutation({
       if (!referralCode) continue;
 
       if (args.active) {
-        const canReactivate =
-          referralCode.status === "active" ||
-          referralCode.deactivated_reason === SUBSCRIPTION_ENDED_REASON;
+        const canReactivate = isReferralCodeUsable(referralCode);
 
         if (!canReactivate) continue;
 
+        const subscriptionTier =
+          args.subscriptionTier ?? referralCode.referrer_subscription_tier;
+        const organizationId =
+          subscriptionTier === "team"
+            ? (args.organizationId ?? referralCode.referrer_organization_id)
+            : undefined;
+
         await ctx.db.patch(referralCode._id, {
           status: "active",
-          referrer_subscription_tier:
-            args.subscriptionTier ?? referralCode.referrer_subscription_tier,
-          referrer_organization_id:
-            args.organizationId ?? referralCode.referrer_organization_id,
+          referrer_subscription_tier: subscriptionTier,
+          referrer_organization_id: organizationId,
           updated_at: now,
         });
         updated += 1;
@@ -451,9 +512,8 @@ export const setReferralCodesPaidEligibility = mutation({
       if (referralCode.status !== "active") continue;
 
       await ctx.db.patch(referralCode._id, {
-        status: "deactivated",
-        deactivated_at: now,
-        deactivated_reason: SUBSCRIPTION_ENDED_REASON,
+        referrer_subscription_tier: "free",
+        referrer_organization_id: undefined,
         updated_at: now,
       });
       updated += 1;
@@ -482,6 +542,7 @@ export const attributeReferredSignup = mutation({
     ),
     reason: v.optional(v.string()),
     referrerUserId: v.optional(v.string()),
+    referrerSubscriptionTier: v.optional(referrerTierValidator),
     starterBonusAwarded: v.boolean(),
     starterBonusEligible: v.boolean(),
     starterBonusUnits: v.number(),
@@ -516,6 +577,7 @@ export const attributeReferredSignup = mutation({
       return {
         status: "already_attributed" as const,
         referrerUserId: existing.referrer_user_id,
+        referrerSubscriptionTier: existing.referrer_subscription_tier,
         starterBonusAwarded: existing.sign_up_reward_status === "awarded",
         starterBonusEligible:
           existing.sign_up_reward_status === "none" &&
@@ -529,7 +591,7 @@ export const attributeReferredSignup = mutation({
       .withIndex("by_code", (q) => q.eq("code", args.referralCode))
       .first();
 
-    if (!referralCode || referralCode.status !== "active") {
+    if (!referralCode || !isReferralCodeUsable(referralCode)) {
       await insertRewardLog(ctx, {
         idempotencyKey: `referral_signup_blocked:${args.referredUserId}:${args.referralCode}`,
         rewardType: "referred_signup",
@@ -548,6 +610,19 @@ export const attributeReferredSignup = mutation({
       };
     }
 
+    const referrerSubscriptionTier = rewardTierForReferralCode(referralCode);
+    if (
+      referralCode.status === "deactivated" &&
+      referralCode.deactivated_reason === SUBSCRIPTION_ENDED_REASON
+    ) {
+      await ctx.db.patch(referralCode._id, {
+        status: "active",
+        referrer_subscription_tier: "free",
+        referrer_organization_id: undefined,
+        updated_at: now,
+      });
+    }
+
     if (referralCode.user_id === args.referredUserId) {
       await insertRewardLog(ctx, {
         idempotencyKey: `referral_signup_blocked:${args.referredUserId}:self`,
@@ -563,6 +638,7 @@ export const attributeReferredSignup = mutation({
         status: "blocked" as const,
         reason: "self_referral",
         referrerUserId: referralCode.user_id,
+        referrerSubscriptionTier,
         starterBonusAwarded: false,
         starterBonusEligible: false,
         starterBonusUnits: 0,
@@ -590,6 +666,7 @@ export const attributeReferredSignup = mutation({
           status: "blocked" as const,
           reason: "existing_user",
           referrerUserId: referralCode.user_id,
+          referrerSubscriptionTier,
           starterBonusAwarded: false,
           starterBonusEligible: false,
           starterBonusUnits: 0,
@@ -601,8 +678,11 @@ export const attributeReferredSignup = mutation({
       referred_user_id: args.referredUserId,
       referrer_user_id: referralCode.user_id,
       referral_code: referralCode.code,
-      referrer_subscription_tier: referralCode.referrer_subscription_tier,
-      referrer_organization_id: referralCode.referrer_organization_id,
+      referrer_subscription_tier: referrerSubscriptionTier,
+      referrer_organization_id:
+        referrerSubscriptionTier === "team"
+          ? referralCode.referrer_organization_id
+          : undefined,
       status: "attributed",
       signup_bonus_units: starterBonusUnits,
       sign_up_reward_status: "none",
@@ -622,6 +702,7 @@ export const attributeReferredSignup = mutation({
     return {
       status: "attributed" as const,
       referrerUserId: referralCode.user_id,
+      referrerSubscriptionTier,
       starterBonusAwarded: false,
       starterBonusEligible: starterBonusUnits > 0,
       starterBonusUnits,
@@ -718,6 +799,7 @@ export const recordReferralCheckoutSession = mutation({
     recorded: v.boolean(),
     referralCode: v.optional(v.string()),
     referrerUserId: v.optional(v.string()),
+    referrerSubscriptionTier: v.optional(referrerTierValidator),
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
@@ -744,6 +826,7 @@ export const recordReferralCheckoutSession = mutation({
       recorded: true,
       referralCode: attribution.referral_code,
       referrerUserId: attribution.referrer_user_id,
+      referrerSubscriptionTier: attribution.referrer_subscription_tier,
     };
   },
 });
@@ -771,6 +854,7 @@ export const awardConversionReward = mutation({
     referrerUserId: v.optional(v.string()),
     referredUserId: v.optional(v.string()),
     referralCode: v.optional(v.string()),
+    referrerSubscriptionTier: v.optional(referrerTierValidator),
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
@@ -838,6 +922,7 @@ export const awardConversionReward = mutation({
         referrerUserId: attribution.referrer_user_id,
         referredUserId: attribution.referred_user_id,
         referralCode: attribution.referral_code,
+        referrerSubscriptionTier: attribution.referrer_subscription_tier,
       };
     }
 
@@ -848,6 +933,7 @@ export const awardConversionReward = mutation({
         referrerUserId: attribution.referrer_user_id,
         referredUserId: attribution.referred_user_id,
         referralCode: attribution.referral_code,
+        referrerSubscriptionTier: attribution.referrer_subscription_tier,
       };
     }
 
@@ -877,6 +963,7 @@ export const awardConversionReward = mutation({
         referrerUserId: attribution.referrer_user_id,
         referredUserId: attribution.referred_user_id,
         referralCode: attribution.referral_code,
+        referrerSubscriptionTier: attribution.referrer_subscription_tier,
       };
     }
 
@@ -885,14 +972,14 @@ export const awardConversionReward = mutation({
       .withIndex("by_code", (q) => q.eq("code", attribution.referral_code))
       .first();
 
-    if (!referralCode || referralCode.status !== "active") {
+    if (!referralCode || !isReferralCodeUsable(referralCode)) {
       await ctx.db.patch(attribution._id, {
         conversion_reward_status: "withheld",
-        withheld_reason: "referrer_not_paid",
+        withheld_reason: "inactive_referral_code",
         updated_at: Date.now(),
       });
       await insertRewardLog(ctx, {
-        idempotencyKey: `referral_conversion_withheld:${attribution._id}:referrer_not_paid`,
+        idempotencyKey: `referral_conversion_withheld:${attribution._id}:inactive_referral_code`,
         rewardType: "referrer_conversion",
         status: "withheld",
         amountDollars: 0,
@@ -903,15 +990,43 @@ export const awardConversionReward = mutation({
         stripeCustomerId: args.stripeCustomerId,
         stripeSubscriptionId: args.stripeSubscriptionId,
         stripeInvoiceId: args.stripeInvoiceId,
-        reason: "referrer_not_paid",
+        reason: "inactive_referral_code",
       });
       return {
         status: "withheld" as const,
-        reason: "referrer_not_paid",
+        reason: "inactive_referral_code",
         referrerUserId: attribution.referrer_user_id,
         referredUserId: attribution.referred_user_id,
         referralCode: attribution.referral_code,
+        referrerSubscriptionTier: referralCode
+          ? rewardTierForReferralCode(
+              referralCode,
+              attribution.referrer_subscription_tier,
+            )
+          : attribution.referrer_subscription_tier,
       };
+    }
+
+    const referrerSubscriptionTier = rewardTierForReferralCode(
+      referralCode,
+      attribution.referrer_subscription_tier,
+    );
+    const referrerOrganizationId =
+      referrerSubscriptionTier === "team"
+        ? (referralCode.referrer_organization_id ??
+          attribution.referrer_organization_id)
+        : undefined;
+
+    if (
+      referralCode.status === "deactivated" &&
+      referralCode.deactivated_reason === SUBSCRIPTION_ENDED_REASON
+    ) {
+      await ctx.db.patch(referralCode._id, {
+        status: "active",
+        referrer_subscription_tier: "free",
+        referrer_organization_id: undefined,
+        updated_at: now,
+      });
     }
 
     const reward = await grantReward(ctx, {
@@ -922,8 +1037,11 @@ export const awardConversionReward = mutation({
       referrerUserId: attribution.referrer_user_id,
       referredUserId: attribution.referred_user_id,
       referralCode: attribution.referral_code,
-      subscriptionTier: attribution.referrer_subscription_tier,
-      organizationId: attribution.referrer_organization_id,
+      subscriptionTier: referrerSubscriptionTier,
+      organizationId: referrerOrganizationId,
+      activatePersonalCreditsForPaidUse:
+        attribution.referrer_subscription_tier === "free" ||
+        referrerSubscriptionTier === "free",
       stripeCheckoutSessionId: args.stripeCheckoutSessionId,
       stripeCustomerId: args.stripeCustomerId,
       stripeSubscriptionId: args.stripeSubscriptionId,
@@ -944,6 +1062,7 @@ export const awardConversionReward = mutation({
       referrerUserId: attribution.referrer_user_id,
       referredUserId: attribution.referred_user_id,
       referralCode: attribution.referral_code,
+      referrerSubscriptionTier,
     };
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -210,6 +210,7 @@ export default defineSchema({
     status: v.union(v.literal("active"), v.literal("deactivated")),
     referrer_subscription_tier: v.optional(
       v.union(
+        v.literal("free"),
         v.literal("pro"),
         v.literal("pro-plus"),
         v.literal("ultra"),
@@ -231,6 +232,7 @@ export default defineSchema({
     referral_code: v.string(),
     referrer_subscription_tier: v.optional(
       v.union(
+        v.literal("free"),
         v.literal("pro"),
         v.literal("pro-plus"),
         v.literal("ultra"),


### PR DESCRIPTION
## Summary

- Allow free users to create and share referral links from the referral API and sidebar UI.
- Store `free` as a valid referrer tier, keep referral codes usable after paid subscription cancellation, and route conversion rewards to personal credits unless the current referrer tier is `team`.
- Preserve the referred-user signup bonus flow so users signing up through referral links still receive the configured starter request units.
- Add `referrer_subscription_tier` to referral PostHog event payloads so free-vs-paid referral performance can be broken down directly.
- Make referral reward copy tier-aware: free users see usage credits that apply after upgrade, while paid users see extra usage credits.
- Return the referrer tier reported by Convex from `/api/referrals` so API consumers use the persisted referral state.
- Activate earned personal usage credits for originally-free referrers, with auto-reload forced off, so the balance is visible/usable after they upgrade without creating surprise charges.

## Impact

Free users can now participate in the referral program. Referrer credits are still awarded only after the referred user converts to a paid plan. Free referrers are not given spendable free-tier extra usage; their earned usage credits are banked and activated for paid-plan use after they upgrade. Referred users can still receive the 10 free request units configured by `REFERRAL_REFERRED_SIGNUP_BONUS_UNITS`.

## Validation

- `pnpm test -- app/api/referrals/__tests__/route.test.ts --runInBand`
- `pnpm test -- app/api/referrals/__tests__/route.test.ts convex/__tests__/referralsNotifications.test.ts app/api/subscribe/__tests__/route.test.ts --runInBand`
- `pnpm test -- convex/__tests__/referralsNotifications.test.ts lib/api/__tests__/build-extra-usage-config.test.ts app/api/referrals/__tests__/route.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint app/api/referrals/route.ts app/api/referrals/__tests__/route.test.ts`
- `pnpm exec eslint app/api/referrals/route.ts app/api/referrals/attribution/route.ts app/api/referrals/__tests__/route.test.ts app/api/subscribe/route.ts app/api/subscribe/__tests__/route.test.ts app/api/subscription/webhook/route.ts app/components/SidebarUserNav.tsx app/components/ReferralRewardDialog.tsx app/contexts/GlobalState.tsx convex/referrals.ts convex/schema.ts convex/__tests__/referralsNotifications.test.ts`
- `pnpm exec eslint convex/referrals.ts convex/__tests__/referralsNotifications.test.ts app/components/ReferralRewardDialog.tsx`
- Commit hook: `pnpm typecheck` and full `pnpm test` (122 suites, 1362 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Free users can generate and share referral invitation links; referral UI shown to all users.

* **Improvements**
  * System now records and surfaces referrer subscription tier across referral flows, analytics, and webhooks.
  * Referral eligibility/reactivation, reward routing (team vs personal), and messaging adapt based on referrer tier; free-tier behavior refined.
  * Schema extended to include a "free" referrer tier.

* **Tests**
  * Added tests covering free referrer tier and reward awarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->