### PR TITLE
[codex] Fix oversized message persistence

### DIFF
--- a/convex/__tests__/messages.hidden.test.ts
+++ b/convex/__tests__/messages.hidden.test.ts
@@ -30,6 +30,7 @@ jest.mock("convex/values", () => ({
       this.name = "ConvexError";
     }
   },
+  getDocumentSize: jest.fn((value: unknown) => JSON.stringify(value).length),
 }));
 jest.mock("../_generated/api", () => ({
   internal: {
@@ -204,6 +205,59 @@ describe("saveMessage — is_hidden handling", () => {
     expect(mockCtx.db.insert).not.toHaveBeenCalledWith(
       "messages",
       expect.objectContaining({ is_hidden: true }),
+    );
+  });
+
+  it("truncates oversized search content while preserving the canonical parts", async () => {
+    setupExistingMessage(null);
+    const largeText = "x".repeat(557_726);
+
+    const { saveMessage } = await import("../messages");
+
+    await saveMessage.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      id: "msg-large-search-content",
+      chatId: CHAT_ID,
+      userId: USER_ID,
+      role: "user" as const,
+      parts: [{ type: "text", text: largeText }],
+    });
+
+    const inserted = mockCtx.db.insert.mock.calls[0][1];
+    expect(inserted.parts).toEqual([{ type: "text", text: largeText }]);
+    expect(inserted.content.length).toBeGreaterThan(256);
+    expect(inserted.content.length).toBeLessThan(largeText.length);
+    expect(JSON.stringify(inserted).length).toBeLessThanOrEqual(960 * 1024);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("message_search_content_truncated_for_storage"),
+    );
+  });
+
+  it("rejects messages that are too large even without indexed content", async () => {
+    setupExistingMessage(null);
+    const tooLargeText = "x".repeat(990 * 1024);
+
+    const { saveMessage } = await import("../messages");
+
+    await expect(
+      saveMessage.handler(mockCtx, {
+        serviceKey: SERVICE_KEY,
+        id: "msg-too-large",
+        chatId: CHAT_ID,
+        userId: USER_ID,
+        role: "user" as const,
+        parts: [{ type: "text", text: tooLargeText }],
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({
+        code: "MESSAGE_TOO_LARGE",
+        failureStage: "prepare_insert_message",
+      }),
+    });
+
+    expect(mockCtx.db.insert).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("convex_message_save_rejected_too_large"),
     );
   });
 

--- a/convex/__tests__/messages.hidden.test.ts
+++ b/convex/__tests__/messages.hidden.test.ts
@@ -8,30 +8,35 @@ jest.mock("../_generated/server", () => ({
   query: jest.fn((config: any) => config),
   internalQuery: jest.fn((config: any) => config),
 }));
-jest.mock("convex/values", () => ({
-  v: {
-    id: jest.fn(() => "id"),
-    null: jest.fn(() => "null"),
-    string: jest.fn(() => "string"),
-    number: jest.fn(() => "number"),
-    optional: jest.fn(() => "optional"),
-    object: jest.fn(() => "object"),
-    union: jest.fn(() => "union"),
-    array: jest.fn(() => "array"),
-    boolean: jest.fn(() => "boolean"),
-    literal: jest.fn(() => "literal"),
-    any: jest.fn(() => "any"),
-  },
-  ConvexError: class ConvexError extends Error {
-    data: any;
-    constructor(data: any) {
-      super(typeof data === "string" ? data : data.message);
-      this.data = data;
-      this.name = "ConvexError";
-    }
-  },
-  getDocumentSize: jest.fn((value: unknown) => JSON.stringify(value).length),
-}));
+jest.mock("convex/values", () => {
+  const actualValues =
+    jest.requireActual<typeof import("convex/values")>("convex/values");
+
+  return {
+    v: {
+      id: jest.fn(() => "id"),
+      null: jest.fn(() => "null"),
+      string: jest.fn(() => "string"),
+      number: jest.fn(() => "number"),
+      optional: jest.fn(() => "optional"),
+      object: jest.fn(() => "object"),
+      union: jest.fn(() => "union"),
+      array: jest.fn(() => "array"),
+      boolean: jest.fn(() => "boolean"),
+      literal: jest.fn(() => "literal"),
+      any: jest.fn(() => "any"),
+    },
+    ConvexError: class ConvexError extends Error {
+      data: any;
+      constructor(data: any) {
+        super(typeof data === "string" ? data : data.message);
+        this.data = data;
+        this.name = "ConvexError";
+      }
+    },
+    getDocumentSize: actualValues.getDocumentSize,
+  };
+});
 jest.mock("../_generated/api", () => ({
   internal: {
     messages: {

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1,5 +1,5 @@
 import { query, mutation, internalQuery } from "./_generated/server";
-import { v, ConvexError, type Value } from "convex/values";
+import { v, ConvexError, getDocumentSize, type Value } from "convex/values";
 import { internal } from "./_generated/api";
 import type { DataModel, Doc, Id } from "./_generated/dataModel";
 import {
@@ -83,6 +83,65 @@ const getJsonSize = (value: unknown): number => {
   } catch {
     return 0;
   }
+};
+
+const CONVEX_DOCUMENT_MAX_BYTES = 1024 * 1024;
+const MESSAGE_DOCUMENT_TARGET_BYTES = 960 * 1024;
+const MIN_SEARCH_CONTENT_CHARS = 256;
+
+const getMessageDocumentSize = (document: Record<string, unknown>): number =>
+  getDocumentSize(document as Record<string, Value>);
+
+const sliceValidUnicodePrefix = (value: string, end: number): string => {
+  const sliced = value.slice(0, end);
+  const lastCodeUnit = sliced.charCodeAt(sliced.length - 1);
+  if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) {
+    return sliced.slice(0, -1);
+  }
+  return sliced;
+};
+
+const fitSearchContentToDocument = (
+  baseDocument: Record<string, unknown>,
+  content: string,
+): { content?: string; fullSizeBytes: number; indexedSizeBytes?: number } => {
+  const fullDocument = { ...baseDocument, content };
+  const fullSizeBytes = getMessageDocumentSize(fullDocument);
+  if (fullSizeBytes <= MESSAGE_DOCUMENT_TARGET_BYTES) {
+    return { content, fullSizeBytes, indexedSizeBytes: fullSizeBytes };
+  }
+
+  let low = 0;
+  let high = content.length;
+  let best = "";
+  let bestSize: number | undefined;
+
+  while (low <= high) {
+    const midpoint = Math.floor((low + high) / 2);
+    const candidate = sliceValidUnicodePrefix(content, midpoint);
+    const candidateSize = getMessageDocumentSize({
+      ...baseDocument,
+      content: candidate,
+    });
+
+    if (candidateSize <= MESSAGE_DOCUMENT_TARGET_BYTES) {
+      best = candidate;
+      bestSize = candidateSize;
+      low = midpoint + 1;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+
+  if (best.length < MIN_SEARCH_CONTENT_CHARS) {
+    return { fullSizeBytes };
+  }
+
+  return {
+    content: best,
+    fullSizeBytes,
+    indexedSizeBytes: bestSize,
+  };
 };
 
 const getMessageSaveDiagnostics = (parts: any[]) => {
@@ -487,14 +546,12 @@ export const saveMessage = mutation({
       failureStage = "extract_content";
       const content = extractTextFromParts(partsForSave);
 
-      failureStage = "insert_message";
-      await ctx.db.insert("messages", {
+      const messageDocumentBase = {
         id: args.id,
         chat_id: args.chatId,
         user_id: args.userId,
         role: args.role,
         parts: partsForSave,
-        content: content || undefined,
         file_ids: fileIdsForSave,
         update_time: Date.now(),
         model: args.model,
@@ -504,6 +561,77 @@ export const saveMessage = mutation({
         finish_reason: args.finishReason,
         usage: args.usage,
         is_hidden: args.isHidden,
+      };
+      failureStage = "prepare_insert_message";
+      const baseDocumentSizeBytes = getMessageDocumentSize(messageDocumentBase);
+      if (baseDocumentSizeBytes > MESSAGE_DOCUMENT_TARGET_BYTES) {
+        throw new ConvexError({
+          code: "MESSAGE_TOO_LARGE",
+          message: "Message is too large to save",
+          failureStage: "prepare_insert_message",
+          baseDocumentSizeBytes,
+          maxDocumentSizeBytes: CONVEX_DOCUMENT_MAX_BYTES,
+          targetDocumentSizeBytes: MESSAGE_DOCUMENT_TARGET_BYTES,
+          operation: "messages.saveMessage",
+          chatId: args.chatId,
+          messageId: args.id,
+          role: args.role,
+          fileCount: args.fileIds?.length ?? 0,
+          ...getMessageSaveDiagnostics(args.parts),
+        });
+      }
+
+      const indexedContent =
+        content.length > 0
+          ? fitSearchContentToDocument(messageDocumentBase, content)
+          : null;
+
+      if (
+        indexedContent &&
+        indexedContent.content !== undefined &&
+        indexedContent.content.length < content.length
+      ) {
+        console.warn(
+          JSON.stringify({
+            level: "warn",
+            event: "message_search_content_truncated_for_storage",
+            service: "convex",
+            timestamp: new Date().toISOString(),
+            db_operation: "messages.saveMessage",
+            chat_id: args.chatId,
+            user_id: args.userId,
+            message_id: args.id,
+            message_role: args.role,
+            full_content_chars: content.length,
+            indexed_content_chars: indexedContent.content.length,
+            base_document_size_bytes: baseDocumentSizeBytes,
+            full_document_size_bytes: indexedContent.fullSizeBytes,
+            indexed_document_size_bytes: indexedContent.indexedSizeBytes,
+          }),
+        );
+      } else if (indexedContent && indexedContent.content === undefined) {
+        console.warn(
+          JSON.stringify({
+            level: "warn",
+            event: "message_search_content_omitted_for_storage",
+            service: "convex",
+            timestamp: new Date().toISOString(),
+            db_operation: "messages.saveMessage",
+            chat_id: args.chatId,
+            user_id: args.userId,
+            message_id: args.id,
+            message_role: args.role,
+            full_content_chars: content.length,
+            base_document_size_bytes: baseDocumentSizeBytes,
+            full_document_size_bytes: indexedContent.fullSizeBytes,
+          }),
+        );
+      }
+
+      failureStage = "insert_message";
+      await ctx.db.insert("messages", {
+        ...messageDocumentBase,
+        content: indexedContent?.content,
       });
 
       // Mark attached files as linked so purge won't remove them.
@@ -518,6 +646,30 @@ export const saveMessage = mutation({
       return null;
     } catch (error) {
       const causeData = getConvexErrorData(error);
+      if (getConvexErrorCode(causeData) === "MESSAGE_TOO_LARGE") {
+        console.warn(
+          JSON.stringify({
+            level: "warn",
+            event: "convex_message_save_rejected_too_large",
+            service: "convex",
+            timestamp: new Date().toISOString(),
+            db_operation: "messages.saveMessage",
+            failure_stage: failureStage,
+            chat_id: args.chatId,
+            user_id: args.userId,
+            message_id: args.id,
+            message_role: args.role,
+            mode: args.mode,
+            update_only: args.updateOnly === true,
+            hidden: args.isHidden === true,
+            file_count: args.fileIds?.length ?? 0,
+            convex_error_data: causeData,
+            ...getMessageSaveDiagnostics(args.parts),
+          }),
+        );
+        throw error;
+      }
+
       if (
         failureStage === "verify_chat_ownership" &&
         args.role === "assistant" &&

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -34,6 +34,7 @@ const loadSaveMessageWithMocks = async () => {
   return {
     getMessagesByChatId,
     mockCompactMessageForStorage,
+    mockMutation,
     mockQuery,
     saveMessage,
   };
@@ -75,6 +76,57 @@ describe("saveMessage", () => {
       self: "[Circular]",
     });
     expect(() => JSON.stringify(compactedMessage.parts)).not.toThrow();
+  });
+
+  it("maps Convex message-size rejections to a user-facing bad request", async () => {
+    const { saveMessage, mockMutation } = await loadSaveMessageWithMocks();
+    const convexError = new Error("[Request ID: abc] Server Error") as Error & {
+      data?: unknown;
+    };
+    convexError.name = "ConvexError";
+    convexError.data = {
+      code: "MESSAGE_TOO_LARGE",
+      message: "Message is too large to save",
+      failureStage: "prepare_insert_message",
+    };
+    mockMutation.mockRejectedValueOnce(convexError as never);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(
+        saveMessage({
+          chatId: "chat-1",
+          userId: "user-1",
+          message: {
+            id: "message-1",
+            role: "user",
+            parts: [{ type: "text", text: "x".repeat(990 * 1024) }],
+          },
+        }),
+      ).rejects.toMatchObject({
+        type: "bad_request",
+        surface: "api",
+        statusCode: 400,
+        cause:
+          "Your message is too large to save. Please shorten it or attach the content as a file instead.",
+        metadata: expect.objectContaining({
+          db_operation: "messages.saveMessage",
+          db_error_code: "MESSAGE_TOO_LARGE",
+        }),
+      });
+
+      const warnEvents = warnSpy.mock.calls.map(([line]) => {
+        const payload = JSON.parse(String(line));
+        return payload.event;
+      });
+      expect(warnEvents).toContain("message_save_rejected_too_large");
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
   });
 });
 

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -206,6 +206,7 @@ const getDatabaseFailureStage = (data: unknown): string | undefined =>
   getObjectString(data, "failureStage");
 
 const CHAT_UNAUTHORIZED_ERROR_CODE = "CHAT_UNAUTHORIZED";
+const MESSAGE_TOO_LARGE_ERROR_CODE = "MESSAGE_TOO_LARGE";
 
 const isChatNotFoundMessageSaveError = (
   operation: string,
@@ -216,6 +217,13 @@ const isChatNotFoundMessageSaveError = (
 
 const isChatUnauthorizedError = (dbErrorData: unknown): boolean =>
   getDatabaseErrorCode(dbErrorData) === CHAT_UNAUTHORIZED_ERROR_CODE;
+
+const isMessageTooLargeError = (
+  operation: string,
+  dbErrorData: unknown,
+): boolean =>
+  operation === "messages.saveMessage" &&
+  getDatabaseErrorCode(dbErrorData) === MESSAGE_TOO_LARGE_ERROR_CODE;
 
 const logChatMessagePreparationFailure = (
   event: string,
@@ -247,22 +255,32 @@ const databaseError = (
   const dbErrorData = getErrorData(error);
   const isChatNotFound = isChatNotFoundMessageSaveError(operation, dbErrorData);
   const isChatUnauthorized = isChatUnauthorizedError(dbErrorData);
-  const logLevel = isChatNotFound || isChatUnauthorized ? "warn" : "error";
+  const isMessageTooLarge = isMessageTooLargeError(operation, dbErrorData);
+  const logLevel =
+    isChatNotFound || isChatUnauthorized || isMessageTooLarge
+      ? "warn"
+      : "error";
   const event = isChatNotFound
     ? "database_operation_skipped_chat_not_found"
     : isChatUnauthorized
       ? "chat_access_denied"
-      : "database_operation_failed";
+      : isMessageTooLarge
+        ? "message_save_rejected_too_large"
+        : "database_operation_failed";
   const errorCode = isChatNotFound
     ? "not_found:chat"
     : isChatUnauthorized
       ? "forbidden:chat"
-      : "bad_request:database";
+      : isMessageTooLarge
+        ? "bad_request:api"
+        : "bad_request:database";
   const errorMessage = isChatNotFound
     ? `Chat no longer exists while saving message: ${operation}: ${dbErrorMessage}`
     : isChatUnauthorized
       ? `Chat access denied while executing database operation: ${operation}: ${dbErrorMessage}`
-      : `Database operation failed: ${operation}: ${dbErrorMessage}`;
+      : isMessageTooLarge
+        ? "Your message is too large to save. Please shorten it or attach the content as a file instead."
+        : `Database operation failed: ${operation}: ${dbErrorMessage}`;
   const diagnosticMetadata = {
     db_operation: operation,
     db_error_name: dbErrorName,


### PR DESCRIPTION
## Summary

Fixes message save failures where a large user text message could fit in `parts` but exceed Convex's 1 MiB document limit after being duplicated into the `content` search field.

## Root Cause

`messages.saveMessage` stored user text twice in the same Convex document: once in `parts`, and again in `content` for search/display. A ~560 KiB pasted text part could therefore become a ~1.06 MiB document and fail at insert time.

## Changes

- Measure pending message documents with Convex's `getDocumentSize` before insert.
- Preserve the canonical full message in `parts`.
- Truncate or omit only the duplicate `content` search copy when needed to keep the document under the storage target.
- Reject messages that are too large even without indexed content using `MESSAGE_TOO_LARGE`.
- Map `MESSAGE_TOO_LARGE` to a user-facing `bad_request:api` instead of a generic database error.
- Add regression coverage for large text persistence and error mapping.

## Validation

- `pnpm test -- convex/__tests__/messages.hidden.test.ts lib/db/__tests__/actions-save-message.test.ts --runInBand`
- `pnpm typecheck`
- Pre-commit hooks also ran Prettier, ESLint, full `pnpm typecheck`, and full `pnpm test` successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent message-size handling: stored searchable content is truncated to fit byte budgets while preserving valid Unicode and the complete canonical message.

* **Bug Fixes**
  * Oversized messages that cannot be stored are rejected with a clear, user-facing error and a suggestion to shorten or attach content; rejection now emits a specific warning event instead of an error log.

* **Tests**
  * Added tests covering truncation behavior and the rejection/error-mapping plus warning emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->