### PR TITLE
[codex] Default free desktop users to agent mode

### DIFF
--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -47,6 +47,8 @@ import {
   cleanupExpiredDrafts,
   markHasAuthenticatedBefore,
 } from "@/lib/utils/client-storage";
+import { captureAuthenticatedEvent } from "@/lib/analytics/client";
+import { shouldDefaultFreeUserToAgent } from "@/lib/activation/agent-first-default";
 
 interface GlobalStateType {
   // Input state
@@ -193,13 +195,21 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   const isMobile = useIsMobile();
   const prevIsMobile = useRef(isMobile);
   const shownReferralRewardNotificationsRef = useRef(new Set<string>());
+  const initialSavedChatModeRef = useRef<ChatMode | null>(null);
+  const hasUserSelectedModeThisSessionRef = useRef(false);
+  const agentFirstDefaultAppliedRef = useRef(false);
   const [input, setInput] = useState("");
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFileState[]>([]);
-  const [chatMode, setChatMode] = useState<ChatMode>(() => {
+  const [chatMode, setChatModeState] = useState<ChatMode>(() => {
     const saved = readChatMode();
     if (!isChatMode(saved)) return "ask";
+    initialSavedChatModeRef.current = saved;
     return saved;
   });
+  const setChatMode = useCallback((mode: ChatMode) => {
+    hasUserSelectedModeThisSessionRef.current = true;
+    setChatModeState(mode);
+  }, []);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sidebarContent, setSidebarContent] = useState<SidebarContent | null>(
     null,
@@ -207,6 +217,14 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
 
   // Persist chat mode preference to localStorage on change
   useEffect(() => {
+    if (
+      initialSavedChatModeRef.current === null &&
+      !agentFirstDefaultAppliedRef.current &&
+      !hasUserSelectedModeThisSessionRef.current
+    ) {
+      return;
+    }
+
     writeChatMode(chatMode);
   }, [chatMode]);
 
@@ -393,6 +411,63 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     const urlParams = new URLSearchParams(window.location.search);
     return urlParams.get("temporary-chat") === "true";
   });
+
+  useEffect(() => {
+    if (agentFirstDefaultAppliedRef.current) return;
+
+    if (
+      !shouldDefaultFreeUserToAgent({
+        chatMode,
+        defaultLocalSandboxPreference,
+        hasLocalSandbox,
+        hasSavedChatMode: initialSavedChatModeRef.current !== null,
+        hasUserSelectedModeThisSession:
+          hasUserSelectedModeThisSessionRef.current,
+        isCheckingProPlan,
+        isMobile,
+        subscription,
+        temporaryChatsEnabled,
+        userPresent: Boolean(user),
+      })
+    ) {
+      return;
+    }
+
+    agentFirstDefaultAppliedRef.current = true;
+    setChatModeState("agent");
+    setSandboxPreference(defaultLocalSandboxPreference!);
+    if (selectedModel !== "auto") {
+      setSelectedModelRaw("auto");
+    }
+
+    const now = new Date().toISOString();
+    captureAuthenticatedEvent("first_experience_exposed", {
+      experiment_key: "free_agent_first_v1",
+      variant: "agent_first",
+      subscription,
+      has_local_sandbox: hasLocalSandbox,
+      sandbox_preference: defaultLocalSandboxPreference,
+      surface: "new_chat",
+      previous_saved_mode: false,
+      current_mode_before: chatMode,
+      $set_once: {
+        first_experience_variant: "agent_first",
+        first_experience_exposed_at: now,
+      },
+    });
+  }, [
+    chatMode,
+    defaultLocalSandboxPreference,
+    hasLocalSandbox,
+    isCheckingProPlan,
+    isMobile,
+    selectedModel,
+    setSandboxPreference,
+    subscription,
+    temporaryChatsEnabled,
+    user,
+  ]);
+
   // Initialize team pricing dialog from URL hash
   const [teamPricingDialogOpen, setTeamPricingDialogOpen] = useState(() => {
     if (typeof window === "undefined") return false;

--- a/lib/activation/__tests__/agent-first-default.test.ts
+++ b/lib/activation/__tests__/agent-first-default.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  type AgentFirstDefaultEligibility,
+  shouldDefaultFreeUserToAgent,
+} from "../agent-first-default";
+
+const baseEligibility: AgentFirstDefaultEligibility = {
+  chatMode: "ask",
+  defaultLocalSandboxPreference: "desktop",
+  hasLocalSandbox: true,
+  hasSavedChatMode: false,
+  hasUserSelectedModeThisSession: false,
+  isCheckingProPlan: false,
+  isMobile: false,
+  subscription: "free",
+  temporaryChatsEnabled: false,
+  userPresent: true,
+};
+
+describe("shouldDefaultFreeUserToAgent", () => {
+  it("defaults an eligible first-time free desktop user with a local sandbox to Agent", () => {
+    expect(shouldDefaultFreeUserToAgent(baseEligibility)).toBe(true);
+  });
+
+  it("does not override a saved mode preference", () => {
+    expect(
+      shouldDefaultFreeUserToAgent({
+        ...baseEligibility,
+        hasSavedChatMode: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not override a mode selected during the current session", () => {
+    expect(
+      shouldDefaultFreeUserToAgent({
+        ...baseEligibility,
+        hasUserSelectedModeThisSession: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not default mobile users to Agent", () => {
+    expect(
+      shouldDefaultFreeUserToAgent({
+        ...baseEligibility,
+        isMobile: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not default users without a local sandbox to Agent", () => {
+    expect(
+      shouldDefaultFreeUserToAgent({
+        ...baseEligibility,
+        defaultLocalSandboxPreference: null,
+        hasLocalSandbox: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not default paid users to Agent through the free-user experiment", () => {
+    expect(
+      shouldDefaultFreeUserToAgent({
+        ...baseEligibility,
+        subscription: "pro",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not default to Agent while subscription status is being checked", () => {
+    expect(
+      shouldDefaultFreeUserToAgent({
+        ...baseEligibility,
+        isCheckingProPlan: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not default temporary chats to Agent", () => {
+    expect(
+      shouldDefaultFreeUserToAgent({
+        ...baseEligibility,
+        temporaryChatsEnabled: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/lib/activation/agent-first-default.ts
+++ b/lib/activation/agent-first-default.ts
@@ -1,0 +1,41 @@
+import type { ChatMode, SandboxPreference } from "@/types/chat";
+import type { SubscriptionTier } from "@/types";
+
+export type AgentFirstDefaultEligibility = {
+  chatMode: ChatMode;
+  defaultLocalSandboxPreference: SandboxPreference | null;
+  hasLocalSandbox: boolean;
+  hasSavedChatMode: boolean;
+  hasUserSelectedModeThisSession: boolean;
+  isCheckingProPlan: boolean;
+  isMobile: boolean | undefined;
+  subscription: SubscriptionTier;
+  temporaryChatsEnabled: boolean;
+  userPresent: boolean;
+};
+
+export function shouldDefaultFreeUserToAgent({
+  chatMode,
+  defaultLocalSandboxPreference,
+  hasLocalSandbox,
+  hasSavedChatMode,
+  hasUserSelectedModeThisSession,
+  isCheckingProPlan,
+  isMobile,
+  subscription,
+  temporaryChatsEnabled,
+  userPresent,
+}: AgentFirstDefaultEligibility): boolean {
+  return (
+    userPresent &&
+    subscription === "free" &&
+    !isCheckingProPlan &&
+    isMobile === false &&
+    !temporaryChatsEnabled &&
+    chatMode === "ask" &&
+    !hasSavedChatMode &&
+    !hasUserSelectedModeThisSession &&
+    hasLocalSandbox &&
+    Boolean(defaultLocalSandboxPreference)
+  );
+}


### PR DESCRIPTION
## Summary

Default first-time eligible free desktop users into Agent mode when a local sandbox is available, instead of silently persisting Ask mode as their first preference.

## What changed

- Added an eligibility helper for the free-user Agent-first default.
- Updated `GlobalStateProvider` to avoid immediately saving the passive Ask default when no user preference exists.
- Automatically switches eligible free desktop users with a local sandbox to Agent, selects the local sandbox preference, and forces Auto model selection.
- Captures a best-effort `first_experience_exposed` event with `variant: "agent_first"` for cohort analysis.
- Added focused helper tests for the eligibility rules.

## Why

The current data suggests feature-building alone is unlikely to move conversion much unless more users reach the Agent experience. This change makes Agent the default first experience for free desktop users who can actually run it, while preserving saved mode choices and manual mode changes.

## Impact

Existing users with a saved mode preference are not overridden. Mobile users, temporary chats, users without a local sandbox, paid users, and sessions still checking subscription state remain unchanged.

## Validation

- `git diff --cached --check`
- Not run: Jest/TypeScript/format scripts, because this environment does not have `pnpm`, `npm`, `gh`, or installed project dependencies available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Free users may now be automatically switched to agent mode on first load under specific eligibility conditions, with analytics tracking enabled.

* **Tests**
  * Added test suite validating agent mode default eligibility logic across various user scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->