### PR TITLE
[codex] Suppress AuthKit state mismatch errors

### DIFF
--- a/app/callback/route.ts
+++ b/app/callback/route.ts
@@ -3,6 +3,7 @@ import {
   isAuthVerifierMissingError,
   isAuthCookieMissingError,
   isMissingRequiredAuthParameterError,
+  isOAuthStateMismatchError,
   isOauthCodeAlreadyExchangedError,
   withRecoverableAuthkitCallbackErrorSuppressed,
 } from "@/lib/auth/authkit-callback-logging";
@@ -41,8 +42,9 @@ const classifyCallbackError = (error: unknown): RecoveryBucket => {
   if (isAuthVerifierMissingError(error)) {
     return "verifier_missing";
   }
-  if (!(error instanceof Error)) return "unknown";
-  if (error.message.includes("OAuth state mismatch")) return "state_mismatch";
+  if (isOAuthStateMismatchError(error)) {
+    return "state_mismatch";
+  }
   return "unknown";
 };
 

--- a/lib/auth/__tests__/authkit-callback-logging.test.ts
+++ b/lib/auth/__tests__/authkit-callback-logging.test.ts
@@ -4,6 +4,7 @@ import {
   isAuthVerifierMissingError,
   isAuthCookieMissingError,
   isMissingRequiredAuthParameterError,
+  isOAuthStateMismatchError,
   isOauthCodeAlreadyExchangedError,
   isRecoverableAuthkitCallbackErrorLog,
   withRecoverableAuthkitCallbackErrorSuppressed,
@@ -66,11 +67,20 @@ describe("authkit callback logging", () => {
     ).toBe(true);
   });
 
-  it("does not match other AuthKit callback errors", () => {
+  it("matches OAuth state mismatch callback errors", () => {
+    const error = new Error("OAuth state mismatch");
+
+    expect(isOAuthStateMismatchError(error)).toBe(true);
+    expect(
+      isRecoverableAuthkitCallbackErrorLog(["[AuthKit callback error]", error]),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated AuthKit callback errors", () => {
     expect(
       isRecoverableAuthkitCallbackErrorLog([
         "[AuthKit callback error]",
-        new Error("OAuth state mismatch"),
+        new Error("OAuth provider unavailable"),
       ]),
     ).toBe(false);
   });
@@ -127,6 +137,10 @@ describe("authkit callback logging", () => {
       console.error(
         "[AuthKit callback error]",
         new Error("Missing required auth parameter"),
+      );
+      console.error(
+        "[AuthKit callback error]",
+        new Error("OAuth state mismatch"),
       );
       console.error(
         "[AuthKit callback error]",

--- a/lib/auth/authkit-callback-logging.ts
+++ b/lib/auth/authkit-callback-logging.ts
@@ -2,6 +2,7 @@ const AUTHKIT_CALLBACK_ERROR_PREFIX = "[AuthKit callback error]";
 const AUTH_COOKIE_MISSING_MESSAGE = "Auth cookie missing";
 const MISSING_REQUIRED_AUTH_PARAMETER_MESSAGE =
   "Missing required auth parameter";
+const OAUTH_STATE_MISMATCH_MESSAGE = "OAuth state mismatch";
 const INVALID_GRANT_ERROR = "invalid_grant";
 const CODE_ALREADY_EXCHANGED_MESSAGE = "already been exchanged";
 const VERIFIER_SCHEMA_KEYS = ['"nonce"', '"codeVerifier"'];
@@ -75,6 +76,12 @@ export const isMissingRequiredAuthParameterError = (
     .includes(MISSING_REQUIRED_AUTH_PARAMETER_MESSAGE.toLowerCase());
 };
 
+export const isOAuthStateMismatchError = (value: unknown): boolean => {
+  return collectErrorText(value)
+    .toLowerCase()
+    .includes(OAUTH_STATE_MISMATCH_MESSAGE.toLowerCase());
+};
+
 export const isAuthVerifierMissingError = (value: unknown): boolean => {
   if (value && typeof value === "object") {
     const error = value as {
@@ -104,6 +111,7 @@ export const isRecoverableAuthkitCallbackError = (value: unknown): boolean => {
     isAuthCookieMissingError(value) ||
     isOauthCodeAlreadyExchangedError(value) ||
     isMissingRequiredAuthParameterError(value) ||
+    isOAuthStateMismatchError(value) ||
     isAuthVerifierMissingError(value)
   );
 };


### PR DESCRIPTION
## Summary
- Treat `OAuth state mismatch` as a recoverable AuthKit callback error in the shared suppression helper.
- Reuse that shared matcher in the callback route classifier.
- Update focused AuthKit logging tests so the raw `[AuthKit callback error]` line is suppressed while unrelated AuthKit errors still pass through.

## Root Cause
`OAuth state mismatch` was recovered by `app/callback/route.ts`, but it was explicitly excluded from `isRecoverableAuthkitCallbackErrorLog`, so AuthKit's own `console.error` still appeared before our warning-level recovery log.

## Validation
- `git diff --check` passed.
- Focused Jest test was not run in this desktop shell because `pnpm`, `npm`, and `corepack` are unavailable on PATH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth state mismatch error detection and handling during authentication callbacks for more reliable error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->