### PR TITLE
[codex] Guard URL-only image attachments

### DIFF
--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -261,6 +261,33 @@ describe("processMessageFiles image size guards", () => {
     });
   });
 
+  it("omits inline URL image file parts without fileId before provider use", async () => {
+    const fetchSpy = jest.fn();
+    global.fetch = fetchSpy as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        mediaType: "image/png",
+        name: "legacy-huge.png",
+        url: "https://example.com/legacy-huge.png",
+      }),
+      "ask",
+      "user123",
+      undefined,
+      "pro",
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(JSON.stringify(result.messages)).not.toContain(
+      "https://example.com/legacy-huge.png",
+    );
+    expect(result.messages[0].parts[1]).toEqual({
+      type: "text",
+      text: '[Image "legacy-huge.png" omitted: URL-backed image attachments must be reattached before they can be sent to the model]',
+    });
+  });
+
   it("stages oversized Agent images into the sandbox instead of sending them inline", async () => {
     mockConvexAction.mockResolvedValue(["https://storage.example/large.png"]);
     global.fetch = jest.fn(async () => {

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -76,6 +76,9 @@ const isMediaFile = (mediaType?: string) =>
   mediaType &&
   (isSupportedImageMediaType(mediaType) || mediaType === "application/pdf");
 
+const isImageMediaType = (mediaType?: string) =>
+  typeof mediaType === "string" && mediaType.toLowerCase().startsWith("image/");
+
 const convertUrlToBase64DataUrl = async (
   url: string,
   mediaType: string,
@@ -209,6 +212,9 @@ const imageOmittedText = (
 ) =>
   `[Image "${typeof name === "string" && name.length > 0 ? name : "unnamed"}" omitted: ${(sizeBytes / (1024 * 1024)).toFixed(1)} MB exceeds the ${limitBytes / (1024 * 1024)} MB per-image limit]`;
 
+const untrustedImageUrlOmittedText = (name: unknown) =>
+  `[Image "${typeof name === "string" && name.length > 0 ? name : "unnamed"}" omitted: URL-backed image attachments must be reattached before they can be sent to the model]`;
+
 /**
  * Replace non-stored image file parts whose declared size exceeds Anthropic's
  * 5 MiB per-image limit with a short text note. Stored `fileId` images are
@@ -235,6 +241,39 @@ const replaceOversizedImageParts = (messages: UIMessage[]) => {
           (part as any).size,
           MAX_IMAGE_SIZE,
         ),
+      };
+    });
+  });
+};
+
+/**
+ * Legacy URL-only image parts are provider-visible but cannot be owner-checked
+ * or safely size-probed server-side. Replace them before OpenRouter can
+ * download an oversized image and fail the request with a provider 413.
+ */
+const replaceUntrustedImageUrlParts = (messages: UIMessage[]) => {
+  messages.forEach((msg) => {
+    if (!msg.parts) return;
+    msg.parts = (msg.parts as any[]).map((part) => {
+      if (
+        !isFilePart(part) ||
+        !isImageMediaType(part.mediaType) ||
+        typeof (part as any).fileId === "string" ||
+        typeof (part as any).url !== "string"
+      ) {
+        return part;
+      }
+
+      logger.warn("untrusted_image_url_attachment_omitted", {
+        event: "untrusted_image_url_attachment_omitted",
+        service: "chat-handler",
+        media_type: part.mediaType,
+        mode: "provider-prep",
+      });
+
+      return {
+        type: "text",
+        text: untrustedImageUrlOmittedText((part as any).name),
       };
     });
   });
@@ -542,6 +581,7 @@ export const processMessageFiles = async (
   if (mode !== "agent") {
     replaceOversizedImageParts(updatedMessages);
   }
+  replaceUntrustedImageUrlParts(updatedMessages);
 
   const { hasMedia, files } = collectFilesToProcess(updatedMessages, mode);
 


### PR DESCRIPTION
## Summary

This PR prevents legacy URL-only image file parts from reaching OpenRouter as provider-visible image URLs. Those parts cannot be owner-checked or safely size-probed server-side, so the transform now replaces them with a short text note before provider conversion.

## Root Cause

The existing oversized-image guard covers trusted `fileId` attachments by resolving an owner-checked storage URL and probing that URL before the model call. Older or malformed image parts that only carry `url` skip that path, remain valid provider content, and can still trigger OpenRouter's `Downloaded image content cannot exceed 30MB` 413.

## Impact

Trusted stored image attachments continue to work as before. URL-only image attachments now ask the user/model context to reattach the image instead of poisoning retries or regenerations with a provider 413.

## Validation

- `pnpm test -- lib/utils/__tests__/file-transform-utils.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (0 errors, existing warnings only)
- Commit hook ran full `pnpm typecheck` and full `pnpm test`: 123 suites / 1,382 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Images provided via URLs that cannot be verified are now replaced with a message prompting reattachment before sending to the model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->