### PR TITLE
[codex] Validate web search queries

### DIFF
--- a/lib/ai/tools/__tests__/web-search.test.ts
+++ b/lib/ai/tools/__tests__/web-search.test.ts
@@ -96,6 +96,83 @@ describe("web_search", () => {
     expect(summary).not.toContain("a0611dc9caa93928");
   });
 
+  it("returns a validation message for blank queries without calling Perplexity or logging", async () => {
+    const onToolCost = jest.fn();
+    global.fetch = jest.fn();
+
+    const result = await runTool(createWebSearch(makeContext(onToolCost)), {
+      queries: ["", "   ", "\n"],
+      brief: "search with blank input",
+    });
+
+    expect(result).toBe(
+      "Error performing web search: Provide at least one non-empty query.",
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(onToolCost).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("trims and drops blank query variants before calling Perplexity", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      response(
+        JSON.stringify({
+          id: "search-1",
+          results: [
+            {
+              title: "Perplexity status",
+              url: "https://status.perplexity.ai",
+              snippet: "Service status page",
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+
+    const result = await runTool(createWebSearch(makeContext()), {
+      queries: [" ", " perplexity status ", "\n"],
+      brief: "check provider status",
+    });
+
+    const requestInit = (global.fetch as jest.Mock).mock
+      .calls[0][1] as RequestInit;
+    expect(JSON.parse(requestInit.body as string)).toMatchObject({
+      query: "perplexity status",
+    });
+    expect(result).toEqual([
+      {
+        title: "Perplexity status",
+        url: "https://status.perplexity.ai",
+        content: "Service status page",
+        date: null,
+        lastUpdated: null,
+      },
+    ]);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("rejects overlong queries without calling Perplexity or logging", async () => {
+    const onToolCost = jest.fn();
+    global.fetch = jest.fn();
+
+    const result = await runTool(createWebSearch(makeContext(onToolCost)), {
+      queries: ["x".repeat(8193)],
+      brief: "search with overlong input",
+    });
+
+    expect(result).toBe(
+      "Error performing web search: Each query must be 8192 characters or fewer.",
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(onToolCost).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
   it("retries a transient 504 and returns results when a later attempt succeeds", async () => {
     jest.useFakeTimers();
 

--- a/lib/ai/tools/web-search.ts
+++ b/lib/ai/tools/web-search.ts
@@ -23,6 +23,16 @@ const PERPLEXITY_SEARCH_URL = "https://api.perplexity.ai/search";
 const WEB_SEARCH_MAX_ATTEMPTS = 3;
 const WEB_SEARCH_RETRY_BASE_DELAY_MS = 300;
 const WEB_SEARCH_RETRY_JITTER_MS = 75;
+const PERPLEXITY_QUERY_MAX_LENGTH = 8192;
+const EMPTY_QUERY_TOOL_ERROR =
+  "Error performing web search: Provide at least one non-empty query.";
+const QUERY_TOO_LONG_TOOL_ERROR = `Error performing web search: Each query must be ${PERPLEXITY_QUERY_MAX_LENGTH} characters or fewer.`;
+
+const webSearchQuerySchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(PERPLEXITY_QUERY_MAX_LENGTH);
 
 const sleep = (delayMs: number, signal?: AbortSignal): Promise<void> => {
   if (delayMs <= 0) return Promise.resolve();
@@ -157,6 +167,22 @@ const fetchPerplexitySearch = async (
   throw new Error("Web search failed before any Perplexity response was read");
 };
 
+const normalizeSearchQueries = (
+  rawQueries: string[],
+): { queries: string[]; error?: string } => {
+  const queries = rawQueries.map((query) => query.trim()).filter(Boolean);
+
+  if (queries.length === 0) {
+    return { queries, error: EMPTY_QUERY_TOOL_ERROR };
+  }
+
+  if (queries.some((query) => query.length > PERPLEXITY_QUERY_MAX_LENGTH)) {
+    return { queries, error: QUERY_TOO_LONG_TOOL_ERROR };
+  }
+
+  return { queries: queries.slice(0, 3) };
+};
+
 export const createWebSearch = (context: ToolContext) => {
   const { userLocation, onToolCost } = context;
 
@@ -177,11 +203,11 @@ export const createWebSearch = (context: ToolContext) => {
 </instructions>`,
     inputSchema: z.object({
       queries: z
-        .array(z.string())
+        .array(webSearchQuerySchema)
         .min(1)
         .max(3)
         .describe(
-          "MAXIMUM 3 query variants (1-3 items only). Express the same search intent with different wording.",
+          "MAXIMUM 3 non-empty query variants (1-3 items only). Express the same search intent with different wording.",
         ),
       time: z
         .enum(["all", "past_day", "past_week", "past_month", "past_year"])
@@ -207,8 +233,10 @@ export const createWebSearch = (context: ToolContext) => {
       { abortSignal },
     ) => {
       try {
-        // Defensively cap at 3 queries in case the model sends more
-        const queries = rawQueries.slice(0, 3);
+        const { queries, error } = normalizeSearchQueries(rawQueries);
+        if (error) {
+          return error;
+        }
 
         const searchBody = buildPerplexitySearchBody(
           queries.length === 1 ? queries[0] : queries,


### PR DESCRIPTION
## Summary

- Trim and validate web search query strings before building the Perplexity request body.
- Return a quiet tool-level validation message for all-blank or overlong queries instead of calling Perplexity and logging a provider error.
- Add regression tests for blank query input, mixed blank/valid variants, and the Perplexity 8192-character query limit.

## Root Cause

The web search tool schema accepted empty strings, and direct `execute` calls could bypass schema validation entirely. Empty query arrays were sent to Perplexity, which rejected them with a 400 validation error that was logged as `Web search tool error`.

## Impact

Expected user/model input validation failures no longer create noisy provider error logs, consume web-search cost, or make unnecessary external requests.

## Validation

- `pnpm test lib/ai/tools/__tests__/web-search.test.ts --runInBand`
- `pnpm exec eslint lib/ai/tools/web-search.ts lib/ai/tools/__tests__/web-search.test.ts`
- `pnpm exec prettier --check lib/ai/tools/web-search.ts lib/ai/tools/__tests__/web-search.test.ts`
- Commit hook also ran `pnpm typecheck` and full `pnpm test`: 124 suites / 1393 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Web search tool now validates and rejects empty or blank queries with clear error messages
  * Added maximum query length limit (8192 characters) to prevent oversized inputs
  * Query variants are normalized to handle whitespace consistently and enforce 1–3 variant limits

* **Tests**
  * Added comprehensive test coverage for query validation and constraint enforcement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->