### PR TITLE
[codex] Fix sandbox attachment upload write failures

### DIFF
--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -182,6 +182,86 @@ describe("desktop-local sandbox file helpers", () => {
     }
   });
 
+  it("normalizes thrown E2B curl write errors and retries in a writable directory", async () => {
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const run = jest.fn(async (command: string) => {
+      if (command.includes("curl") && command.includes("/home/user/upload")) {
+        const error = new Error("exit status 23") as Error & {
+          exitCode: number;
+          stdout: string;
+          stderr: string;
+        };
+        error.exitCode = 23;
+        error.stdout = "";
+        error.stderr = "curl: (23) Failure writing output to destination";
+        throw error;
+      }
+
+      if (command.includes("for base in")) {
+        return {
+          exitCode: 0,
+          stdout: "/tmp/hackerai-upload/report.pdf",
+          stderr: "",
+        };
+      }
+
+      if (
+        command.includes("curl") &&
+        command.includes("/tmp/hackerai-upload")
+      ) {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+
+      if (command.includes("df -h /home/user")) {
+        return {
+          exitCode: 0,
+          stdout: "Filesystem Size Used Avail Use% Mounted on\n",
+          stderr: "",
+        };
+      }
+
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+
+    try {
+      const result = await uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "https://example.com/report.pdf",
+            localPath: "/home/user/upload/report.pdf",
+          },
+        ],
+        async () => ({
+          commands: { run },
+        }),
+      );
+
+      expect(result).toEqual({
+        failedCount: 0,
+        pathRewrites: [
+          {
+            from: "/home/user/upload/report.pdf",
+            to: "/tmp/hackerai-upload/report.pdf",
+          },
+        ],
+      });
+
+      const homeCurlAttempts = run.mock.calls.filter(([command]) =>
+        String(command).includes("-o '/home/user/upload/report.pdf'"),
+      );
+      const fallbackCurlAttempts = run.mock.calls.filter(([command]) =>
+        String(command).includes("-o '/tmp/hackerai-upload/report.pdf'"),
+      );
+      expect(homeCurlAttempts).toHaveLength(3);
+      expect(fallbackCurlAttempts).toHaveLength(1);
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
   it("blocks internal URL downloads before invoking the sandbox", async () => {
     const consoleErrorSpy = jest
       .spyOn(console, "error")

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -28,12 +28,71 @@ type SandboxUploadResult = {
   pathRewrites: SandboxFilePathRewrite[];
 };
 
+type SandboxCommandResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  error?: string;
+};
+
 const logLocalAttachmentDebug = (
   event: string,
   data: Record<string, unknown>,
 ) => {
   if (process.env.NODE_ENV !== "development") return;
   console.info(`[local-attachments] ${event}`, data);
+};
+
+const extractCommandExitCode = (error: unknown): number | null => {
+  if (typeof error === "object" && error !== null) {
+    const maybeExitCode = (error as { exitCode?: unknown }).exitCode;
+    if (typeof maybeExitCode === "number") return maybeExitCode;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  const match = message.match(/\bexit status (\d+)\b/i);
+  if (!match) return null;
+
+  return Number.parseInt(match[1], 10);
+};
+
+const commandErrorToResult = (error: unknown): SandboxCommandResult | null => {
+  const exitCode = extractCommandExitCode(error);
+  if (exitCode === null) return null;
+
+  const commandError =
+    typeof error === "object" && error !== null
+      ? (error as { stdout?: unknown; stderr?: unknown })
+      : {};
+  const message = error instanceof Error ? error.message : String(error);
+
+  return {
+    stdout: typeof commandError.stdout === "string" ? commandError.stdout : "",
+    stderr:
+      typeof commandError.stderr === "string" && commandError.stderr
+        ? commandError.stderr
+        : message,
+    exitCode,
+    error: message,
+  };
+};
+
+const runSandboxCommand = async (
+  sandbox: any,
+  command: string,
+): Promise<SandboxCommandResult> => {
+  try {
+    const result = await sandbox.commands.run(command);
+    return {
+      stdout: result?.stdout ?? "",
+      stderr: result?.stderr ?? "",
+      exitCode: typeof result?.exitCode === "number" ? result.exitCode : 0,
+    };
+  } catch (error) {
+    const commandResult = commandErrorToResult(error);
+    if (commandResult) return commandResult;
+    throw error;
+  }
 };
 
 /**
@@ -302,7 +361,7 @@ const downloadFileToSandbox = async (
     `curl -fsSL --retry 3 --retry-all-errors --retry-delay 1 --create-dirs ` +
     `-o '${escapedLocalPath}' '${escapedUrl}'`;
 
-  let result = await sandbox.commands.run(curlCmd);
+  let result = await runSandboxCommand(sandbox, curlCmd);
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     if (result.exitCode === 0) return;
     if (
@@ -315,14 +374,15 @@ const downloadFileToSandbox = async (
       `[sandbox-download] curl exit ${result.exitCode} on attempt ${attempt}/${MAX_ATTEMPTS} for ${localPath}, retrying`,
     );
     await new Promise((r) => setTimeout(r, 500 * attempt));
-    result = await sandbox.commands.run(curlCmd);
+    result = await runSandboxCommand(sandbox, curlCmd);
   }
 
   // Best-effort diagnostics probe — never let this mask the original error.
   let diagnostics = "";
   try {
-    const probe = await sandbox.commands.run(
-      `df -h /home/user; ls -la /home/user/upload 2>/dev/null; id`,
+    const probe = await runSandboxCommand(
+      sandbox,
+      `df -h /home/user 2>&1 || true; ls -la /home/user/upload 2>&1 || true; id 2>&1 || true`,
     );
     diagnostics = (probe.stdout || "").slice(0, 1024);
   } catch {
@@ -364,15 +424,27 @@ const copyLocalFileToSandbox = async (
 const shellQuote = (value: string): string =>
   `'${value.replace(/'/g, "'\\''")}'`;
 
+const UPLOAD_PATH_FALLBACK_PREFIXES = [
+  "/tmp/hackerai-upload/",
+  "/home/user/upload/",
+];
+
+const UPLOAD_PATH_FALLBACK_ERROR_PATTERN =
+  /permission denied|read-only file system|cannot create directory|failed to create directory|exitCode:\s*23|exit status 23|curl:\s*\(23\)|write error|failed writing body|failure writing output|no space left on device/i;
+
 const shouldTryUploadPathFallback = (
   localPath: string,
   error: unknown,
 ): boolean => {
-  if (!localPath.startsWith("/tmp/hackerai-upload/")) return false;
+  if (
+    !UPLOAD_PATH_FALLBACK_PREFIXES.some((prefix) =>
+      localPath.startsWith(prefix),
+    )
+  ) {
+    return false;
+  }
   const message = error instanceof Error ? error.message : String(error);
-  return /permission denied|read-only file system|cannot create directory|failed to create directory/i.test(
-    message,
-  );
+  return UPLOAD_PATH_FALLBACK_ERROR_PATTERN.test(message);
 };
 
 const resolveWritableUploadFallbackPath = async (


### PR DESCRIPTION
## Summary

Fixes attachment staging failures where E2B command execution throws a bare `exit status 23` during `curl` downloads into `/home/user/upload`.

## Root Cause

The sandbox attachment download helper expected `sandbox.commands.run()` to return an `{ exitCode }` result for non-zero `curl` exits. E2B can instead throw a command error such as `exit status 23`, which bypassed the existing retry and diagnostic path and caused the chat request to fail with a generic attachment upload error.

## Changes

- Normalize thrown sandbox command exits into command results so existing retry logic handles them.
- Treat upload write-path failures under `/home/user/upload` as eligible for writable-directory fallback.
- Keep failures hard when staging still fails, so the agent does not answer without the user attachment.
- Add a regression test for the thrown E2B `curl` exit `23` path.

## Validation

- `pnpm test -- lib/utils/__tests__/sandbox-file-utils.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint lib/utils/sandbox-file-utils.ts lib/utils/__tests__/sandbox-file-utils.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced file upload resilience with improved error handling for write destination failures and automatic fallback to alternative paths when needed.
  * Strengthened retry logic and diagnostics for upload operations to better handle transient errors.

* **Tests**
  * Added comprehensive test coverage for file upload failure scenarios and fallback path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->