### PR TITLE
[codex] Clarify local browser automation guidance

### DIFF
--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -77,6 +77,9 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).not.toContain(
       "All operations execute in isolated sandbox containers",
     );
+    expect(prompt).not.toContain(
+      "agent-browser is installed in the cloud sandbox",
+    );
   });
 
   it("keeps cloud sandbox isolation scoped to the default cloud sandbox", async () => {

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -645,6 +645,31 @@ describe("CentrifugoSandbox", () => {
       expect(context).toContain("DANGEROUS MODE");
       expect(context).toContain("Linux");
       expect(context).toContain("pentest-box");
+      expect(context).toContain("Browser automation is host-dependent");
+      expect(context).toContain(
+        "command -v agent-browser && agent-browser --version",
+      );
+      expect(context).toContain(
+        "do not install browser automation packages on the host unless the user explicitly asks",
+      );
+    });
+
+    it("uses a cmd-compatible browser probe on Windows", () => {
+      const sandbox = createSandbox({
+        osInfo: {
+          platform: "win32",
+          arch: "x86_64",
+          release: "11",
+          hostname: "windows-box",
+        },
+      });
+
+      const context = sandbox.getSandboxContext();
+
+      expect(context).toContain(
+        "where agent-browser && agent-browser --version",
+      );
+      expect(context).not.toContain("command -v agent-browser");
     });
 
     it("returns null without osInfo", () => {

--- a/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
+++ b/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
@@ -2,8 +2,19 @@ jest.mock("@e2b/code-interpreter", () => ({
   Sandbox: class MockSandbox {},
 }));
 
+const mockConvexQuery = jest.fn();
+const mockConvexMutation = jest.fn();
+
+jest.mock("@/lib/db/convex-client", () => ({
+  getConvexClient: () => ({
+    query: mockConvexQuery,
+    mutation: mockConvexMutation,
+  }),
+}));
+
 import {
   filterConnectionsByPresence,
+  HybridSandboxManager,
   LOCAL_SANDBOX_PRESENCE_GRACE_MS,
 } from "../hybrid-sandbox-manager";
 import {
@@ -124,5 +135,49 @@ describe("presenceHasConnectionId", () => {
         info: { connectionId: "conn-legacy" },
       }),
     ).toBe("conn-legacy");
+  });
+});
+
+describe("HybridSandboxManager browser automation prompt", () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockConvexQuery.mockReset();
+    mockConvexMutation.mockReset();
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("uses a cmd-compatible browser probe for Windows local contexts", async () => {
+    mockConvexQuery.mockResolvedValue([
+      makeConnection({
+        connectionId: "desktop-conn",
+        name: "Desktop",
+        isDesktop: true,
+        osInfo: {
+          platform: "win32",
+          arch: "x86_64",
+          release: "11",
+          hostname: "windows-box",
+        },
+      }),
+    ]);
+
+    const manager = new HybridSandboxManager(
+      "user-1",
+      jest.fn(),
+      "desktop",
+      "service-key",
+      null,
+      "pro",
+    );
+
+    const context = await manager.getSandboxContextForPrompt();
+
+    expect(context).toContain("where agent-browser && agent-browser --version");
+    expect(context).not.toContain("command -v agent-browser");
   });
 });

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -158,12 +158,18 @@ export class CentrifugoSandbox extends EventEmitter {
         platform === "win32"
           ? `Commands are invoked via cmd.exe /C (NOT PowerShell). Use cmd.exe syntax — do not use PowerShell cmdlets or syntax like Invoke-WebRequest, $env:, or backtick escapes.`
           : `Commands are invoked via /bin/bash -c.`;
+      const agentBrowserProbe =
+        platform === "win32"
+          ? "where agent-browser && agent-browser --version"
+          : "command -v agent-browser && agent-browser --version";
       return `You are executing commands on ${platformName} ${release} (${arch}) in DANGEROUS MODE.
 ${shellInfo}
 Commands run directly on the host OS "${hostname}" without Docker isolation. Be careful with:
 - File system operations (no sandbox protection)
 - Network operations (direct access to host network)
-- Process management (can affect host system)${capabilities?.pty === false ? "\n\nInteractive PTY sessions are not available on this connection. Use non-interactive terminal commands only." : ""}`;
+- Process management (can affect host system)
+
+Browser automation is host-dependent on this connection. Chromium and agent-browser are preinstalled only in the Cloud sandbox. If browser automation is needed, first check with \`${agentBrowserProbe}\`. Use agent-browser only if it is already installed, and do not install browser automation packages on the host unless the user explicitly asks.${capabilities?.pty === false ? "\n\nInteractive PTY sessions are not available on this connection. Use non-interactive terminal commands only." : ""}`;
     }
 
     return null;

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -622,6 +622,10 @@ export class HybridSandboxManager implements SandboxManager {
         platform === "win32"
           ? "C:\\temp\\hackerai-upload"
           : "/tmp/hackerai-upload";
+      const agentBrowserProbe =
+        platform === "win32"
+          ? "where agent-browser && agent-browser --version"
+          : "command -v agent-browser && agent-browser --version";
 
       return `<sandbox_environment>
 IMPORTANT: You are connected to a LOCAL machine in DANGEROUS MODE. Commands run directly on the host OS without Docker isolation.
@@ -640,6 +644,12 @@ Security Warning:
 - Be careful with destructive commands
 
 Available tools depend on what's installed on the host system.
+
+Browser Automation:
+- Chromium and agent-browser are preinstalled only in the Cloud sandbox.
+- On this host, browser automation is host-dependent. If browser automation is needed, first check with \`${agentBrowserProbe}\`.
+- Use agent-browser only if it is already installed. Do not install browser automation packages on the host unless the user explicitly asks.
+- If agent-browser is unavailable, continue with other installed tools when possible or tell the user they can switch to the Cloud sandbox for the preinstalled browser workflow.
 </sandbox_environment>`;
     }
 

--- a/lib/utils/redis-pubsub.ts
+++ b/lib/utils/redis-pubsub.ts
@@ -1,12 +1,10 @@
-import { createClient, type RedisClientType } from "redis";
-
-type RedisClient = RedisClientType;
+import { createClient } from "redis";
 
 /**
  * Create a dedicated subscriber client for a specific channel.
  * Each subscription needs its own client in Redis pub/sub.
  */
-export const createRedisSubscriber = async (): Promise<RedisClient | null> => {
+export async function createRedisSubscriber() {
   const redisUrl = process.env.REDIS_URL;
 
   if (!redisUrl) {
@@ -24,7 +22,7 @@ export const createRedisSubscriber = async (): Promise<RedisClient | null> => {
     console.warn("Failed to connect Redis subscriber:", error);
     return null;
   }
-};
+}
 
 /**
  * Get the cancellation channel name for a chat.

--- a/lib/utils/stream-cancellation.ts
+++ b/lib/utils/stream-cancellation.ts
@@ -6,10 +6,7 @@ import {
   createRedisSubscriber,
   getCancelChannel,
 } from "@/lib/utils/redis-pubsub";
-import type { RedisClientType } from "redis";
 import { phLogger } from "@/lib/posthog/server";
-
-type RedisClient = RedisClientType;
 
 type PollOptions = {
   chatId: string;
@@ -121,7 +118,7 @@ export const createCancellationSubscriber = async ({
   onStop,
   pollIntervalMs = 1000,
 }: PollOptions): Promise<CancellationSubscriberResult> => {
-  let subscriber: RedisClient | null = null;
+  let subscriber: Awaited<ReturnType<typeof createRedisSubscriber>> = null;
   let stopped = false;
   let onStopCalled = false;
   const channel = getCancelChannel(chatId);


### PR DESCRIPTION
## Summary

- Clarifies Desktop and Remote Connection prompt context so browser automation is treated as host-dependent instead of cloud-preinstalled.
- Instructs the agent to check for `agent-browser` before use on local hosts and avoid installing browser automation packages unless the user explicitly asks.
- Keeps the cloud sandbox `agent-browser` workflow unchanged.
- Fixes a Redis subscriber client type mismatch that was causing `pnpm typecheck` to fail on current `main`.

## Validation

- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm jest lib/__tests__/system-prompt.test.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts --runInBand`
- Commit hook full test suite: 124 suites / 1393 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced browser-automation guidance in sandbox prompts: clarifies Chromium/agent-browser availability, adds platform-specific probe checks, and advises against installing host browser packages unless requested.

* **Tests**
  * Updated and added tests to verify the improved sandbox guidance, platform-specific probe commands, and an adjusted system-prompt assertion.

* **Refactor**
  * Simplified subscriber function signature and small TypeScript import/type cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->