### PR TITLE
[codex] Add provider request diagnostics

### DIFF
--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -356,6 +356,81 @@ describe("createChatLogger provider stream termination", () => {
       logSpy.mockRestore();
     }
   });
+
+  it("attaches sanitized provider request diagnostics to provider errors", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_provider_shape",
+        endpoint: "/api/agent-long",
+      });
+      const providerRequest = {
+        model: "model-opus-4.6",
+        requested_model_slug: "anthropic/claude-opus-4.6",
+        step_index: 4,
+        source: "prepare_step",
+        message_count: 9,
+        role_counts: { user: 5, assistant: 4 },
+        content_part_counts: { text: 6, "tool-result": 3 },
+        last_message_role: "user",
+        last_message_content_types: ["tool-result"],
+        serialized_message_bytes: 680000,
+        estimated_serialized_message_tokens: 170000,
+        context_used_tokens: 171844,
+        context_max_tokens: 200000,
+        context_used_percent: 85.9,
+        system_tokens: 12000,
+        max_output_tokens: 64000,
+        tool_count: 12,
+        active_tool_count: 12,
+        active_tools_mode: "all",
+        reasoning_enabled: true,
+        fallback_model_count: 2,
+        fallback_model_slugs: ["google/gemini-3.5-flash", "x-ai/grok-4.3"],
+        has_user_attribution: true,
+        has_multimodal_tool_results: true,
+      };
+      const err = {
+        message: "Provider request failed",
+        responseBody: JSON.stringify({
+          error: {
+            code: 502,
+            message: "Invalid arguments passed to the model.",
+          },
+        }),
+        requestBodyValues: {
+          messages: [{ role: "user", content: "SECRET_PROMPT_TEXT" }],
+        },
+      };
+
+      chatLogger.recordProviderRequestDiagnostics(providerRequest);
+      chatLogger.recordProviderError(err, {
+        mode: "agent",
+        model: "model-opus-4.6",
+        requestedModelSlug: "anthropic/claude-opus-4.6",
+        providerRequest,
+      });
+      chatLogger.emitUnexpectedError(err);
+
+      const wideEvent = JSON.parse(String(logSpy.mock.calls[0][0]));
+      expect(wideEvent.provider_request).toMatchObject({
+        step_index: 4,
+        message_count: 9,
+        estimated_serialized_message_tokens: 170000,
+        content_part_counts: { text: 6, "tool-result": 3 },
+      });
+      expect(wideEvent.provider_error).not.toHaveProperty("request");
+      expect(JSON.stringify(wideEvent)).not.toContain("SECRET_PROMPT_TEXT");
+      expect(errorSpy.mock.calls.flat().map(String).join("\n")).not.toContain(
+        "SECRET_PROMPT_TEXT",
+      );
+    } finally {
+      errorSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
 });
 
 describe("createChatLogger ChatSDKError metadata", () => {

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -30,7 +30,6 @@ import {
   runSummarizationStep,
   writeContextUsage,
   getFallbackSlugs,
-  logOpenRouterFallbackIfFired,
   isXaiSafetyError,
 } from "@/lib/api/chat-stream-helpers";
 import {
@@ -72,6 +71,7 @@ import type { UsageRefundTracker } from "@/lib/rate-limit";
 import type { SummarizationTracker } from "@/lib/api/chat-stream-helpers";
 import type { ChatLogger } from "@/lib/api/chat-logger";
 import type { createTrackedProvider } from "@/lib/ai/providers";
+import type { ProviderRequestDiagnostics } from "@/lib/logger";
 import type { ChatMode, SubscriptionTier } from "@/types";
 
 // ---------------------------------------------------------------------------
@@ -144,6 +144,151 @@ const toolResultsContainImageViewResult = (toolResults: unknown[]): boolean =>
     if (!isRecord(toolResult) || toolResult.toolName !== "file") return false;
     return isImageViewOutput(toolResult.output);
   });
+
+const ESTIMATED_BYTES_PER_TOKEN = 4;
+
+const incrementCount = (counts: Record<string, number>, key: string): void => {
+  counts[key] = (counts[key] ?? 0) + 1;
+};
+
+const getSerializedBytes = (value: unknown): number | undefined => {
+  try {
+    return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+  } catch {
+    return undefined;
+  }
+};
+
+const getContentType = (part: unknown): string => {
+  if (isRecord(part) && typeof part.type === "string") return part.type;
+  if (part == null) return "empty";
+  if (Array.isArray(part)) return "array";
+  return typeof part;
+};
+
+const summarizeContentTypes = (content: unknown): string[] => {
+  if (typeof content === "string") return content.trim() ? ["text"] : ["empty"];
+  if (!Array.isArray(content)) return [getContentType(content)];
+  if (content.length === 0) return ["empty"];
+  return content.map(getContentType);
+};
+
+const addContentPartCounts = (
+  content: unknown,
+  counts: Record<string, number>,
+): void => {
+  for (const type of summarizeContentTypes(content)) {
+    incrementCount(counts, type);
+  }
+};
+
+const contentHasToolCall = (content: unknown): boolean =>
+  Array.isArray(content) &&
+  content.some((part) => isRecord(part) && part.type === "tool-call");
+
+const summarizeProviderOptions = (
+  providerOptions: unknown,
+): Pick<
+  ProviderRequestDiagnostics,
+  | "reasoning_enabled"
+  | "reasoning_effort"
+  | "fallback_model_count"
+  | "fallback_model_slugs"
+  | "has_user_attribution"
+> => {
+  const openrouter =
+    isRecord(providerOptions) && isRecord(providerOptions.openrouter)
+      ? providerOptions.openrouter
+      : undefined;
+  const reasoning = isRecord(openrouter?.reasoning)
+    ? openrouter.reasoning
+    : undefined;
+  const fallbackModelSlugs = Array.isArray(openrouter?.models)
+    ? openrouter.models.filter(
+        (model): model is string => typeof model === "string",
+      )
+    : [];
+
+  return {
+    reasoning_enabled:
+      typeof reasoning?.enabled === "boolean" ? reasoning.enabled : undefined,
+    reasoning_effort:
+      typeof reasoning?.effort === "string" ? reasoning.effort : undefined,
+    fallback_model_count: fallbackModelSlugs.length,
+    fallback_model_slugs:
+      fallbackModelSlugs.length > 0 ? fallbackModelSlugs : undefined,
+    has_user_attribution: typeof openrouter?.user === "string",
+  };
+};
+
+const buildProviderRequestDiagnostics = (args: {
+  modelName: string;
+  requestedSlug?: string;
+  stepIndex: number;
+  source: ProviderRequestDiagnostics["source"];
+  messages: ModelMessage[];
+  providerOptions: unknown;
+  activeTools: readonly unknown[] | undefined;
+  availableToolCount: number;
+  contextUsage: { usedTokens: number; maxTokens: number };
+  systemTokens: number;
+  maxOutputTokens: number;
+  hasMultimodalToolResults: boolean;
+}): ProviderRequestDiagnostics => {
+  const roleCounts: Record<string, number> = {};
+  const contentPartCounts: Record<string, number> = {};
+
+  for (const message of args.messages) {
+    const messageRecord = message as Record<string, unknown>;
+    const role =
+      typeof messageRecord.role === "string" ? messageRecord.role : "unknown";
+    incrementCount(roleCounts, role);
+    addContentPartCounts(messageRecord.content, contentPartCounts);
+  }
+
+  const lastMessage = args.messages.at(-1) as
+    | Record<string, unknown>
+    | undefined;
+  const serializedBytes = getSerializedBytes(args.messages);
+  const contextUsedPercent =
+    args.contextUsage.maxTokens > 0
+      ? Math.round(
+          (args.contextUsage.usedTokens / args.contextUsage.maxTokens) * 1000,
+        ) / 10
+      : 0;
+
+  return {
+    model: args.modelName,
+    requested_model_slug: args.requestedSlug,
+    step_index: args.stepIndex,
+    source: args.source,
+    message_count: args.messages.length,
+    role_counts: roleCounts,
+    content_part_counts: contentPartCounts,
+    last_message_role:
+      typeof lastMessage?.role === "string" ? lastMessage.role : undefined,
+    last_message_content_types: summarizeContentTypes(lastMessage?.content),
+    trailing_assistant_has_tool_call:
+      lastMessage?.role === "assistant"
+        ? contentHasToolCall(lastMessage.content)
+        : undefined,
+    serialized_message_bytes: serializedBytes,
+    estimated_serialized_message_tokens:
+      serializedBytes != null
+        ? Math.ceil(serializedBytes / ESTIMATED_BYTES_PER_TOKEN)
+        : undefined,
+    context_used_tokens: args.contextUsage.usedTokens,
+    context_max_tokens: args.contextUsage.maxTokens,
+    context_used_percent: contextUsedPercent,
+    system_tokens: args.systemTokens,
+    max_output_tokens: args.maxOutputTokens,
+    tool_count: args.availableToolCount,
+    active_tool_count: args.activeTools?.length ?? args.availableToolCount,
+    active_tools_mode: args.activeTools ? "subset" : "all",
+    ...summarizeProviderOptions(args.providerOptions),
+    has_multimodal_tool_results: args.hasMultimodalToolResults,
+  };
+};
 
 // ---------------------------------------------------------------------------
 // Immutable context — everything the runner needs besides mutable state.
@@ -261,18 +406,54 @@ export async function createAgentStream(
     }
     return repair.messages as ModelMessage[];
   };
+  let latestProviderRequestDiagnostics: ProviderRequestDiagnostics | undefined;
+  const recordProviderRequestDiagnostics = (args: {
+    stepIndex: number;
+    source: ProviderRequestDiagnostics["source"];
+    messages: ModelMessage[];
+    providerOptions: unknown;
+    activeTools: Array<keyof typeof ctx.tools> | undefined;
+  }) => {
+    latestProviderRequestDiagnostics = buildProviderRequestDiagnostics({
+      modelName,
+      requestedSlug,
+      stepIndex: args.stepIndex,
+      source: args.source,
+      messages: args.messages,
+      providerOptions: args.providerOptions,
+      activeTools: args.activeTools,
+      availableToolCount: Object.keys(ctx.tools).length,
+      contextUsage: state.ctxUsage,
+      systemTokens: ctx.systemPromptTokens,
+      maxOutputTokens,
+      hasMultimodalToolResults: streamHasImageViewResults,
+    });
+    ctx.chatLogger?.recordProviderRequestDiagnostics(
+      latestProviderRequestDiagnostics,
+    );
+    return latestProviderRequestDiagnostics;
+  };
+  const initialProviderOptions = getStepProviderOptions();
+  const initialModelMessages = prepareProviderMessages(
+    await convertToModelMessages(state.finalMessages, { tools: ctx.tools }),
+  );
+  recordProviderRequestDiagnostics({
+    stepIndex: 0,
+    source: "initial",
+    messages: initialModelMessages,
+    providerOptions: initialProviderOptions,
+    activeTools: initialActiveTools,
+  });
 
   return streamText({
     model: requestedLanguageModel,
     maxOutputTokens,
     system: buildSystemPrompt(ctx.currentSystemPrompt, modelName),
-    messages: prepareProviderMessages(
-      await convertToModelMessages(state.finalMessages, { tools: ctx.tools }),
-    ),
+    messages: initialModelMessages,
     tools: ctx.tools,
     activeTools: initialActiveTools,
     abortSignal: ctx.abortController.signal,
-    providerOptions: getStepProviderOptions(),
+    providerOptions: initialProviderOptions,
 
     prepareStep: async ({ steps, messages }) => {
       try {
@@ -325,14 +506,24 @@ export async function createAgentStream(
             if (result.contextUsage) {
               state.ctxUsage = result.contextUsage;
             }
+            const activeTools = await getActiveTools();
+            const providerOptions = getStepProviderOptions();
+            const preparedMessages = prepareProviderMessages(
+              await convertToModelMessages(result.summarizedMessages, {
+                tools: ctx.tools,
+              }),
+            );
+            recordProviderRequestDiagnostics({
+              stepIndex: steps.length + 1,
+              source: "summarized_prepare_step",
+              messages: preparedMessages,
+              providerOptions,
+              activeTools,
+            });
             return {
-              activeTools: await getActiveTools(),
-              providerOptions: getStepProviderOptions(),
-              messages: prepareProviderMessages(
-                await convertToModelMessages(result.summarizedMessages, {
-                  tools: ctx.tools,
-                }),
-              ),
+              activeTools,
+              providerOptions,
+              messages: preparedMessages,
             };
           }
         }
@@ -365,15 +556,25 @@ export async function createAgentStream(
           }
         }
 
+        const activeTools = await getActiveTools();
+        const providerOptions = getStepProviderOptions();
+        const preparedMessages = prepareProviderMessages(
+          addCacheBreakpointToLastUserMessage(
+            updatedMessages,
+            modelName,
+          ) as ModelMessage[],
+        ) as typeof messages;
+        recordProviderRequestDiagnostics({
+          stepIndex: steps.length + 1,
+          source: "prepare_step",
+          messages: preparedMessages as ModelMessage[],
+          providerOptions,
+          activeTools,
+        });
         return {
-          activeTools: await getActiveTools(),
-          providerOptions: getStepProviderOptions(),
-          messages: prepareProviderMessages(
-            addCacheBreakpointToLastUserMessage(
-              updatedMessages,
-              modelName,
-            ) as ModelMessage[],
-          ) as typeof messages,
+          activeTools,
+          providerOptions,
+          messages: preparedMessages,
         };
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
@@ -505,12 +706,6 @@ export async function createAgentStream(
       const fallbackSlugs = getFallbackSlugs(modelName, ctx.mode, {
         hasMultimodalToolResults: streamHasImageViewResults,
       });
-      logOpenRouterFallbackIfFired({
-        fallbackSlugs,
-        requestedSlug,
-        responseModel: state.responseModel,
-        chatId: ctx.chatId,
-      });
       if (state.responseModel && fallbackSlugs.includes(state.responseModel)) {
         ctx.chatLogger?.recordModelFallback({
           requested: requestedSlug,
@@ -547,6 +742,7 @@ export async function createAgentStream(
           userId: ctx.userId,
           subscription: ctx.subscription,
           isTemporary: ctx.temporary,
+          providerRequest: latestProviderRequestDiagnostics,
         });
       }
       if (!ctx.usageTracker.hasUsage) {

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -9,6 +9,7 @@ import {
   createWideEventBuilder,
   logger,
   type ChatWideEvent,
+  type ProviderRequestDiagnostics,
   type WideEventBuilder,
 } from "@/lib/logger";
 import type {
@@ -333,6 +334,13 @@ export function createChatLogger(config: ChatLoggerConfig) {
     },
 
     /**
+     * Record sanitized provider request shape for later error diagnosis.
+     */
+    recordProviderRequestDiagnostics(diagnostics: ProviderRequestDiagnostics) {
+      builder.setProviderRequestDiagnostics(diagnostics);
+    },
+
+    /**
      * Set cache metrics for the wide event
      */
     setCacheMetrics(metrics: {
@@ -361,8 +369,10 @@ export function createChatLogger(config: ChatLoggerConfig) {
         userId?: string;
         subscription?: string;
         isTemporary?: boolean;
+        providerRequest?: ProviderRequestDiagnostics;
       },
     ) {
+      const { providerRequest, ...providerContext } = context;
       const details = extractErrorDetails(error);
       const attempts = extractRetryAttempts(error);
       const category = getProviderErrorCategory(details);
@@ -375,9 +385,10 @@ export function createChatLogger(config: ChatLoggerConfig) {
         chat_id: config.chatId,
         endpoint: config.endpoint,
         provider_error_category: category,
-        ...context,
+        ...providerContext,
         ...details,
         ...(attempts && { provider_attempts: attempts }),
+        ...(providerRequest && { provider_request: providerRequest }),
       };
 
       if (category === "stream_terminated" || category === "timeout") {
@@ -395,9 +406,10 @@ export function createChatLogger(config: ChatLoggerConfig) {
         chatId: config.chatId,
         endpoint: config.endpoint,
         providerErrorCategory: category,
-        ...context,
+        ...providerContext,
         ...details,
         ...(attempts && { provider_attempts: attempts }),
+        ...(providerRequest && { provider_request: providerRequest }),
       };
 
       if (category === "stream_terminated" || category === "timeout") {

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -573,28 +573,6 @@ export function buildProviderOptions(
   } as const;
 }
 
-/**
- * Logs `[fallback-fired]` when the served model is one of the slugs we
- * explicitly listed in the OpenRouter `models` chain. We can't use a naive
- * `served !== requested` check because OpenRouter sometimes returns the
- * requested model under a different label (dated snapshots, reordered tokens)
- * — that's not a fallback. Membership in our chain is the authoritative
- * signal.
- */
-export function logOpenRouterFallbackIfFired(args: {
-  fallbackSlugs: readonly string[];
-  responseModel: string | undefined;
-  requestedSlug: string | undefined;
-  chatId: string;
-}) {
-  const { fallbackSlugs, responseModel, requestedSlug, chatId } = args;
-  if (!responseModel) return;
-  if (!fallbackSlugs.includes(responseModel)) return;
-  console.log(
-    `[fallback-fired] requested=${requestedSlug ?? "?"} served=${responseModel} chat=${chatId}`,
-  );
-}
-
 const ANTHROPIC_CACHE_BREAKPOINT = {
   openrouter: { cacheControl: { type: "ephemeral" as const } },
 };

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -10,6 +10,35 @@
 import type { ChatMode, ExtraUsageConfig } from "@/types";
 import type { OpenRouterModelMetadata } from "@/lib/api/openrouter-metadata";
 
+export interface ProviderRequestDiagnostics {
+  model: string;
+  requested_model_slug?: string;
+  step_index: number;
+  source: "initial" | "prepare_step" | "summarized_prepare_step";
+  message_count: number;
+  role_counts: Record<string, number>;
+  content_part_counts: Record<string, number>;
+  last_message_role?: string;
+  last_message_content_types?: string[];
+  trailing_assistant_has_tool_call?: boolean;
+  serialized_message_bytes?: number;
+  estimated_serialized_message_tokens?: number;
+  context_used_tokens: number;
+  context_max_tokens: number;
+  context_used_percent: number;
+  system_tokens: number;
+  max_output_tokens: number;
+  tool_count: number;
+  active_tool_count: number;
+  active_tools_mode: "all" | "subset";
+  reasoning_enabled?: boolean;
+  reasoning_effort?: string;
+  fallback_model_count: number;
+  fallback_model_slugs?: string[];
+  has_user_attribution: boolean;
+  has_multimodal_tool_results: boolean;
+}
+
 /**
  * Wide event structure for chat/agent API requests
  */
@@ -164,6 +193,10 @@ export interface ChatWideEvent {
 
   // Tool execution
   tool_call_count?: number;
+
+  // Sanitized shape of the most recent model request prepared for the provider.
+  // Never contains prompt text, tool arguments, file contents, or user ids.
+  provider_request?: ProviderRequestDiagnostics;
 
   // Outcome. `partial` means the request returned 200 but the provider stream
   // errored — either we recovered via fallback or we sent an error chunk to
@@ -362,6 +395,14 @@ export class WideEventBuilder {
     this.event.model.actual = fallback.served;
     this.event.model.fallback_triggered = true;
     this.event.model.fallback_chain = fallback.chain;
+    return this;
+  }
+
+  /**
+   * Record the sanitized shape of the latest provider request.
+   */
+  setProviderRequestDiagnostics(diagnostics: ProviderRequestDiagnostics): this {
+    this.event.provider_request = diagnostics;
     return this;
   }
 


### PR DESCRIPTION
## Summary

Adds sanitized provider-request diagnostics to agent stream logging so the next opaque provider failure can be correlated with the shape of the request that preceded it.

## What changed

- Adds a `ProviderRequestDiagnostics` block to chat wide events and provider-error details.
- Records the initial provider request and each prepared model step in `agent-stream-runner`.
- Threads the diagnostic through runtime logs and PostHog provider-error telemetry.
- Adds a focused test that verifies diagnostic data is emitted without leaking raw prompt text.

## Why

OpenRouter/Anthropic can return generic errors like `502 Invalid arguments passed to the model` without enough detail to distinguish provider instability from a malformed or pathological request shape. These fields expose bounded, content-free shape metrics like step index, message counts, part counts, estimated serialized size, context usage percent, fallback count, reasoning mode, and multimodal-tool state.

## Validation

- `pnpm typecheck`
- `pnpm jest lib/api/__tests__/chat-logger.test.ts --runInBand`
- Commit hooks also ran Prettier, ESLint, `pnpm typecheck`, and the full Jest suite: 124 suites / 1394 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced provider-request diagnostics so richer request metadata is captured and attached to error/log events for better monitoring.
* **Tests**
  * Added a test ensuring sensitive request values are not leaked into logged events or console output.
* **Chores**
  * Removed a legacy fallback logging helper no longer used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->