### PR TITLE
[codex] Warn on high-cost model selection

### DIFF
--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Brain, Check, ChevronDown, ChevronRight, Lock } from "lucide-react";
+import {
+  AlertTriangle,
+  Brain,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Lock,
+} from "lucide-react";
 import {
   Popover,
   PopoverContent,
@@ -30,7 +37,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { useState } from "react";
-import type { ChatMode, SelectedModel } from "@/types/chat";
+import type { ChatMode, SelectedModel, SubscriptionTier } from "@/types/chat";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import { useGlobalState } from "@/app/contexts/GlobalState";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -44,8 +51,8 @@ import {
   type ModelOption,
 } from "./ModelSelector/constants";
 import {
-  dismissProMaxUsageNotice,
-  isProMaxUsageNoticeDismissed,
+  dismissHighCostModelUsageNotice,
+  isHighCostModelUsageNoticeDismissed,
 } from "@/lib/utils/pro-max-notice-cookie";
 
 // ── Shared sub-components ──────────────────────────────────────────
@@ -58,6 +65,13 @@ interface ModelSelectorProps {
 
 const AUTO_MODEL_DESCRIPTION =
   "Balanced quality and speed, recommended for most tasks";
+
+const shouldWarnForPaidHighCostModel = (
+  subscription: SubscriptionTier,
+  model: SelectedModel,
+): boolean =>
+  subscription !== "free" &&
+  (model === "hackerai-pro" || model === "hackerai-max");
 
 const AutoOptionButton = ({
   isSelected,
@@ -315,15 +329,13 @@ const ModelOptionList = ({
 
 export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
-  const [pendingProMaxNotice, setPendingProMaxNotice] =
+  const [pendingHighCostNotice, setPendingHighCostNotice] =
     useState<ModelOption | null>(null);
   const { subscription } = useGlobalState();
   const isMobile = useIsMobile();
 
   const isAuto = value === "auto";
   const isFreeUser = subscription === "free";
-  /** Base Pro tier: Max is flagged as unusually heavy usage vs higher plans. */
-  const isBaseProTier = subscription === "pro";
 
   const options = isAgentMode(mode) ? AGENT_MODEL_OPTIONS : ASK_MODEL_OPTIONS;
 
@@ -363,26 +375,26 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
     }
 
     if (
-      isBaseProTier &&
-      option.id === "hackerai-max" &&
-      !isProMaxUsageNoticeDismissed()
+      shouldWarnForPaidHighCostModel(subscription, option.id) &&
+      !isHighCostModelUsageNoticeDismissed()
     ) {
-      setPendingProMaxNotice(option);
+      setOpen(false);
+      setPendingHighCostNotice(option);
       return;
     }
 
     applyModelChoice(option);
   };
 
-  const handleDismissProMaxNotice = () => {
-    setPendingProMaxNotice(null);
+  const handleDismissHighCostNotice = () => {
+    setPendingHighCostNotice(null);
   };
 
-  const handleConfirmProMax = () => {
-    if (!pendingProMaxNotice) return;
-    dismissProMaxUsageNotice();
-    applyModelChoice(pendingProMaxNotice);
-    setPendingProMaxNotice(null);
+  const handleConfirmHighCostModel = () => {
+    if (!pendingHighCostNotice) return;
+    dismissHighCostModelUsageNotice();
+    applyModelChoice(pendingHighCostNotice);
+    setPendingHighCostNotice(null);
   };
 
   const trigger = (
@@ -399,27 +411,42 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
     </Button>
   );
 
-  const maxUsageNoticeDialog = (
+  const highCostUsageNoticeDialog = (
     <AlertDialog
-      open={pendingProMaxNotice !== null}
+      open={pendingHighCostNotice !== null}
       onOpenChange={(nextOpen) => {
-        if (!nextOpen) handleDismissProMaxNotice();
+        if (!nextOpen) handleDismissHighCostNotice();
       }}
     >
-      <AlertDialogContent className="sm:max-w-md">
-        <AlertDialogHeader>
-          <AlertDialogTitle>Higher usage</AlertDialogTitle>
-          <AlertDialogDescription className="text-left">
-            HackerAI Max uses quota much faster than Standard or Pro. One long
-            task can use much of what&apos;s included on Pro.
+      <AlertDialogContent
+        data-testid="high-cost-model-warning"
+        className="sm:max-w-[460px] border-amber-500/70 shadow-2xl ring-4 ring-amber-500/20 dark:border-amber-400/60"
+      >
+        <AlertDialogHeader className="gap-3">
+          <AlertDialogTitle className="flex items-center gap-3 text-xl">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-amber-500/15 text-amber-700 dark:bg-amber-400/15 dark:text-amber-300">
+              <AlertTriangle className="h-5 w-5" />
+            </span>
+            <span>High-cost model</span>
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-left text-sm leading-relaxed text-foreground/80">
+            {pendingHighCostNotice?.label ?? "This model"} is powerful, but it
+            can burn through included usage much faster than Standard.
           </AlertDialogDescription>
+          <div className="rounded-md border border-amber-500/40 bg-amber-50 px-3 py-2 text-left text-sm font-medium leading-relaxed text-amber-950 shadow-sm dark:border-amber-400/40 dark:bg-amber-950/40 dark:text-amber-100">
+            Some long requests can cost around $10 once extra usage credits are
+            being used.
+          </div>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel onClick={handleDismissProMaxNotice}>
-            Cancel
+          <AlertDialogCancel onClick={handleDismissHighCostNotice}>
+            Pick another model
           </AlertDialogCancel>
-          <AlertDialogAction onClick={handleConfirmProMax}>
-            Continue
+          <AlertDialogAction
+            onClick={handleConfirmHighCostModel}
+            className="bg-amber-600 text-white hover:bg-amber-700 focus-visible:ring-amber-500/50 dark:bg-amber-500 dark:text-black dark:hover:bg-amber-400"
+          >
+            Use {pendingHighCostNotice?.label ?? "model"}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
@@ -430,7 +457,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
     return (
       <>
         {trigger}
-        {maxUsageNoticeDialog}
+        {highCostUsageNoticeDialog}
         <Sheet open={open} onOpenChange={setOpen}>
           <SheetContent
             side="bottom"
@@ -461,7 +488,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
 
   return (
     <>
-      {maxUsageNoticeDialog}
+      {highCostUsageNoticeDialog}
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>{trigger}</PopoverTrigger>
         <PopoverContent className="w-[270px] p-1.5 rounded-xl" align="start">

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -411,6 +411,13 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
     </Button>
   );
 
+  const includedUsageLabel =
+    subscription === "team" ? "your team's included usage" : "included usage";
+  const extraUsageCreditsLabel =
+    subscription === "team"
+      ? "team extra usage credits"
+      : "extra usage credits";
+
   const highCostUsageNoticeDialog = (
     <AlertDialog
       open={pendingHighCostNotice !== null}
@@ -431,11 +438,11 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
           </AlertDialogTitle>
           <AlertDialogDescription className="text-left text-sm leading-relaxed text-foreground/80">
             {pendingHighCostNotice?.label ?? "This model"} is powerful, but it
-            can burn through included usage much faster than Standard.
+            can burn through {includedUsageLabel} much faster than Standard.
           </AlertDialogDescription>
           <div className="rounded-md border border-amber-500/40 bg-amber-50 px-3 py-2 text-left text-sm font-medium leading-relaxed text-amber-950 shadow-sm dark:border-amber-400/40 dark:bg-amber-950/40 dark:text-amber-100">
-            Some long requests can cost around $10 once extra usage credits are
-            being used.
+            Some long requests can cost around $10 once {extraUsageCreditsLabel}{" "}
+            are being used.
           </div>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -411,12 +411,8 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
     </Button>
   );
 
-  const includedUsageLabel =
-    subscription === "team" ? "your team's included usage" : "included usage";
-  const extraUsageCreditsLabel =
-    subscription === "team"
-      ? "team extra usage credits"
-      : "extra usage credits";
+  const usageLabel =
+    subscription === "team" ? "your team's usage" : "your usage";
 
   const highCostUsageNoticeDialog = (
     <AlertDialog
@@ -438,9 +434,8 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
           </AlertDialogTitle>
           <AlertDialogDescription className="text-left text-sm leading-relaxed text-foreground/80">
             {pendingHighCostNotice?.label ?? "This model"} is powerful, but it
-            can burn through {includedUsageLabel} much faster than Standard.
-            Some long requests can cost around $10 once {extraUsageCreditsLabel}{" "}
-            are being used.
+            can use a lot more of {usageLabel} than Standard, and long requests
+            can use around $10 of usage.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -427,12 +427,12 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
     >
       <AlertDialogContent
         data-testid="high-cost-model-warning"
-        className="sm:max-w-[460px] border-amber-500/70 shadow-2xl ring-4 ring-amber-500/20 dark:border-amber-400/60"
+        className="sm:max-w-[460px]"
       >
-        <AlertDialogHeader className="gap-3">
-          <AlertDialogTitle className="flex items-center gap-3 text-xl">
-            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-amber-500/15 text-amber-700 dark:bg-amber-400/15 dark:text-amber-300">
-              <AlertTriangle className="h-5 w-5" />
+        <AlertDialogHeader className="gap-2">
+          <AlertDialogTitle className="flex items-center gap-2 text-lg">
+            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+              <AlertTriangle className="h-4 w-4" />
             </span>
             <span>High-cost model</span>
           </AlertDialogTitle>
@@ -440,7 +440,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
             {pendingHighCostNotice?.label ?? "This model"} is powerful, but it
             can burn through {includedUsageLabel} much faster than Standard.
           </AlertDialogDescription>
-          <div className="rounded-md border border-amber-500/40 bg-amber-50 px-3 py-2 text-left text-sm font-medium leading-relaxed text-amber-950 shadow-sm dark:border-amber-400/40 dark:bg-amber-950/40 dark:text-amber-100">
+          <div className="rounded-md border border-border bg-muted px-3 py-2 text-left text-sm leading-relaxed text-muted-foreground">
             Some long requests can cost around $10 once {extraUsageCreditsLabel}{" "}
             are being used.
           </div>
@@ -449,10 +449,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
           <AlertDialogCancel onClick={handleDismissHighCostNotice}>
             Pick another model
           </AlertDialogCancel>
-          <AlertDialogAction
-            onClick={handleConfirmHighCostModel}
-            className="bg-amber-600 text-white hover:bg-amber-700 focus-visible:ring-amber-500/50 dark:bg-amber-500 dark:text-black dark:hover:bg-amber-400"
-          >
+          <AlertDialogAction onClick={handleConfirmHighCostModel}>
             Use {pendingHighCostNotice?.label ?? "model"}
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -439,11 +439,9 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
           <AlertDialogDescription className="text-left text-sm leading-relaxed text-foreground/80">
             {pendingHighCostNotice?.label ?? "This model"} is powerful, but it
             can burn through {includedUsageLabel} much faster than Standard.
-          </AlertDialogDescription>
-          <div className="rounded-md border border-border bg-muted px-3 py-2 text-left text-sm leading-relaxed text-muted-foreground">
             Some long requests can cost around $10 once {extraUsageCreditsLabel}{" "}
             are being used.
-          </div>
+          </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel onClick={handleDismissHighCostNotice}>

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -80,7 +80,7 @@ describe("ModelSelector", () => {
     expect(screen.getByTestId("high-cost-model-warning")).toBeVisible();
     expect(screen.getByText("High-cost model")).toBeVisible();
     expect(
-      screen.getByText(/Some long requests can cost around \$10/i),
+      screen.getByText(/long requests can use around \$10 of usage/i),
     ).toBeVisible();
 
     fireEvent.click(screen.getByRole("button", { name: /Use HackerAI Pro/i }));
@@ -111,7 +111,9 @@ describe("ModelSelector", () => {
     fireEvent.click(screen.getByRole("button", { name: /HackerAI Pro/i }));
 
     expect(onChange).not.toHaveBeenCalled();
-    expect(screen.getByText(/your team's included usage/i)).toBeVisible();
-    expect(screen.getByText(/team extra usage credits/i)).toBeVisible();
+    expect(screen.getByText(/your team's usage/i)).toBeVisible();
+    expect(
+      screen.getByText(/long requests can use around \$10 of usage/i),
+    ).toBeVisible();
   });
 });

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -101,4 +101,17 @@ describe("ModelSelector", () => {
     expect(screen.getByTestId("high-cost-model-warning")).toBeVisible();
     expect(screen.getByText(/HackerAI Max is powerful/i)).toBeVisible();
   });
+
+  it("uses team-specific warning copy for team users", () => {
+    mockSubscription = "team";
+    const onChange = jest.fn();
+    render(<ModelSelector value="auto" onChange={onChange} mode="ask" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /HackerAI Pro/i }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText(/your team's included usage/i)).toBeVisible();
+    expect(screen.getByText(/team extra usage credits/i)).toBeVisible();
+  });
 });

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -4,6 +4,8 @@ import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import type { SubscriptionTier } from "@/types/chat";
 
 let mockSubscription: SubscriptionTier;
+const mockIsHighCostModelUsageNoticeDismissed = jest.fn();
+const mockDismissHighCostModelUsageNotice = jest.fn();
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({
@@ -15,6 +17,12 @@ jest.mock("@/hooks/use-mobile", () => ({
   useIsMobile: () => false,
 }));
 
+jest.mock("@/lib/utils/pro-max-notice-cookie", () => ({
+  isHighCostModelUsageNoticeDismissed: () =>
+    mockIsHighCostModelUsageNoticeDismissed(),
+  dismissHighCostModelUsageNotice: () => mockDismissHighCostModelUsageNotice(),
+}));
+
 const { ModelSelector } = jest.requireActual<
   typeof import("../../ModelSelector")
 >("../../ModelSelector");
@@ -22,6 +30,8 @@ const { ModelSelector } = jest.requireActual<
 describe("ModelSelector", () => {
   beforeEach(() => {
     mockSubscription = "pro-plus";
+    mockIsHighCostModelUsageNoticeDismissed.mockReturnValue(false);
+    mockDismissHighCostModelUsageNotice.mockClear();
   });
 
   it("shows model choices immediately while Auto is selected", () => {
@@ -57,5 +67,38 @@ describe("ModelSelector", () => {
     );
 
     expect(onChange).toHaveBeenCalledWith("auto");
+  });
+
+  it("warns before selecting HackerAI Pro on paid plans", () => {
+    const onChange = jest.fn();
+    render(<ModelSelector value="auto" onChange={onChange} mode="ask" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /HackerAI Pro/i }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId("high-cost-model-warning")).toBeVisible();
+    expect(screen.getByText("High-cost model")).toBeVisible();
+    expect(
+      screen.getByText(/Some long requests can cost around \$10/i),
+    ).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: /Use HackerAI Pro/i }));
+
+    expect(mockDismissHighCostModelUsageNotice).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("hackerai-pro");
+  });
+
+  it("warns before selecting HackerAI Max on paid tiers above Pro", () => {
+    mockSubscription = "ultra";
+    const onChange = jest.fn();
+    render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /HackerAI Max/i }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId("high-cost-model-warning")).toBeVisible();
+    expect(screen.getByText(/HackerAI Max is powerful/i)).toBeVisible();
   });
 });

--- a/lib/utils/pro-max-notice-cookie.ts
+++ b/lib/utils/pro-max-notice-cookie.ts
@@ -1,22 +1,27 @@
 const COOKIE_NAME = "hackerai_pro_max_usage_ack";
 
-/** Long-lived dismissal; informational only (not auth). */
+/** Long-lived dismissal for the Pro/Max high-cost notice; informational only. */
 const MAX_AGE_SEC = 60 * 60 * 24 * 365 * 5;
 
 /**
  * Parses a `document.cookie`-style header so logic is testable without DOM.
  */
-export const isProMaxUsageNoticeDismissedFromCookieHeader = (
+export const isHighCostModelUsageNoticeDismissedFromCookieHeader = (
   cookieHeader: string,
 ): boolean =>
   new RegExp(`(?:^|;\\s*)${COOKIE_NAME}=1(?:;|$)`).test(cookieHeader);
 
-export const isProMaxUsageNoticeDismissed = (): boolean => {
+export const isHighCostModelUsageNoticeDismissed = (): boolean => {
   if (typeof document === "undefined") return false;
-  return isProMaxUsageNoticeDismissedFromCookieHeader(document.cookie);
+  return isHighCostModelUsageNoticeDismissedFromCookieHeader(document.cookie);
 };
 
-export const dismissProMaxUsageNotice = (): void => {
+export const dismissHighCostModelUsageNotice = (): void => {
   if (typeof document === "undefined") return;
   document.cookie = `${COOKIE_NAME}=1; path=/; max-age=${MAX_AGE_SEC}; SameSite=Lax`;
 };
+
+export const isProMaxUsageNoticeDismissedFromCookieHeader =
+  isHighCostModelUsageNoticeDismissedFromCookieHeader;
+export const isProMaxUsageNoticeDismissed = isHighCostModelUsageNoticeDismissed;
+export const dismissProMaxUsageNotice = dismissHighCostModelUsageNotice;


### PR DESCRIPTION
## Summary

Adds a stronger high-cost model warning in the model selector for paid users choosing HackerAI Pro or HackerAI Max.

## What changed

- Warn paid users before selecting either HackerAI Pro or HackerAI Max.
- Make the warning more prominent with an alert icon, amber border/ring, stronger copy, and an explicit note that long requests can cost around $10 once extra usage credits are being used.
- Rename the notice helper exports around a broader high-cost-model concept while keeping the existing cookie name and legacy exports compatible.
- Add focused model selector coverage for HackerAI Pro and Max warning behavior.

## Why

Previously the notice only applied to HackerAI Max on the base Pro tier. HackerAI Pro can also be expensive on pay-for-props/extra-usage plans, so users should get a clear warning before choosing a model that can burn through included usage or paid credits quickly.

## Validation

- `pnpm exec jest app/components/ModelSelector/__tests__/ModelSelector.test.tsx --runInBand`
- `pnpm exec jest lib/utils/__tests__/pro-max-notice-cookie.test.ts --runInBand`
- `pnpm exec eslint app/components/ModelSelector.tsx app/components/ModelSelector/__tests__/ModelSelector.test.tsx lib/utils/pro-max-notice-cookie.ts lib/utils/__tests__/pro-max-notice-cookie.test.ts`
- `pnpm typecheck`
- Commit hook: `prettier --write`, `eslint --fix`, `pnpm typecheck`, full `pnpm test` (`124` suites / `1395` tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a "High-cost model" warning dialog (desktop and mobile) when selecting costly models on paid plans, with confirm and dismiss actions.
  * Team accounts see tailored warning copy.
  * Dismissal now persists across sessions so users won't see the notice again once dismissed.

* **Tests**
  * Updated tests to cover warning display, dismissal, confirmation flow, and team-specific copy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->