### PR TITLE
[codex] Improve provider error diagnostics

### DIFF
--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -501,6 +501,61 @@ describe("createChatLogger provider stream termination", () => {
       logSpy.mockRestore();
     }
   });
+
+  it("enriches PostHog exception messages for Error provider failures", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_provider_error_instance",
+        endpoint: "/api/chat",
+      });
+      const providerError = Object.assign(
+        new Error("Provider request failed"),
+        {
+          name: "AI_APICallError",
+          statusCode: 400,
+          responseBody: JSON.stringify({
+            id: "gen-error-instance",
+            error: {
+              code: 400,
+              message: "Provider returned error",
+              metadata: {
+                provider_name: "Anthropic",
+                raw: "tool_result without corresponding tool_use",
+              },
+            },
+          }),
+        },
+      );
+
+      chatLogger.recordProviderError(providerError, {
+        mode: "ask",
+        model: "model-opus-4.6",
+        requestedModelSlug: "anthropic/claude-opus-4.6",
+      });
+
+      const posthogErrorCall = errorSpy.mock.calls.find(
+        (call) =>
+          call[0] === "Provider streaming error" &&
+          typeof call[1] === "object" &&
+          call[1] !== null,
+      );
+      const fields = posthogErrorCall?.[1] as { error?: unknown } | undefined;
+      const capturedError = fields?.error as
+        | (Error & { cause?: unknown })
+        | undefined;
+
+      expect(capturedError).toBeInstanceOf(Error);
+      expect(capturedError?.name).toBe("AI_APICallError");
+      expect(capturedError?.message).toBe(
+        "tool_result without corresponding tool_use",
+      );
+      expect(capturedError?.cause).toBe(providerError);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });
 
 describe("createChatLogger ChatSDKError metadata", () => {

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -431,6 +431,76 @@ describe("createChatLogger provider stream termination", () => {
       logSpy.mockRestore();
     }
   });
+
+  it("logs nested provider raw errors for generic 400 provider wrappers", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_provider_wrapper",
+        endpoint: "/api/chat",
+      });
+      const nestedProviderError = Object.assign(
+        new Error("Provider request failed"),
+        {
+          name: "AI_APICallError",
+          statusCode: 400,
+          responseBody: JSON.stringify({
+            id: "gen-400-wrapper",
+            error: {
+              code: 400,
+              message: "Provider returned error",
+              metadata: {
+                provider_name: "Anthropic",
+                raw: "tool_result without corresponding tool_use",
+              },
+            },
+          }),
+          requestBodyValues: {
+            messages: [{ role: "user", content: "SECRET_PROMPT_TEXT" }],
+          },
+          isRetryable: false,
+        },
+      );
+      const err = {
+        message: "Provider returned error",
+        code: 400,
+        error: nestedProviderError,
+      };
+
+      chatLogger.recordProviderError(err, {
+        mode: "ask",
+        model: "model-opus-4.6",
+        requestedModelSlug: "anthropic/claude-opus-4.6",
+      });
+      chatLogger.emitUnexpectedError(err);
+
+      const providerErrorOutput = errorSpy.mock.calls
+        .flat()
+        .map(String)
+        .join("\n");
+      const wideEvent = JSON.parse(String(logSpy.mock.calls[0][0]));
+
+      expect(providerErrorOutput).toContain(
+        '"provider_error_category":"provider_4xx"',
+      );
+      expect(providerErrorOutput).toContain(
+        '"providerRawError":"tool_result without corresponding tool_use"',
+      );
+      expect(providerErrorOutput).not.toContain("SECRET_PROMPT_TEXT");
+      expect(wideEvent.provider_error).toMatchObject({
+        category: "provider_4xx",
+        status_code: 400,
+        message: "tool_result without corresponding tool_use",
+        retriable: false,
+      });
+      expect(JSON.stringify(wideEvent)).not.toContain("SECRET_PROMPT_TEXT");
+    } finally {
+      errorSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
 });
 
 describe("createChatLogger ChatSDKError metadata", () => {
@@ -595,6 +665,7 @@ describe("createChatLogger provider stream timeout", () => {
 
   it("uses nested provider status codes in wide events", () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
 
     try {
@@ -623,6 +694,7 @@ describe("createChatLogger provider stream timeout", () => {
       expect(wideEvent.provider_error.status_code).toBe(502);
     } finally {
       warnSpy.mockRestore();
+      errorSpy.mockRestore();
       logSpy.mockRestore();
     }
   });

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -83,10 +83,7 @@ function posthogProviderException(
   details: Record<string, unknown>,
 ): Error {
   if (error instanceof Error) return error;
-  const message =
-    typeof details.errorMessage === "string" && details.errorMessage.length > 0
-      ? details.errorMessage
-      : "Provider streaming error";
+  const message = getProviderDiagnosticMessage(details);
   return new Error(message);
 }
 
@@ -155,6 +152,22 @@ const providerWideErrorType = (
   if (category === "timeout") return "ProviderTimeout";
   if (category) return "ProviderError";
   return "UnexpectedError";
+};
+
+const getProviderDiagnosticMessage = (
+  details: Record<string, unknown>,
+): string => {
+  for (const key of [
+    "providerRawError",
+    "providerErrorMessage",
+    "errorMessage",
+  ] as const) {
+    const value = details[key];
+    if (typeof value === "string" && value.length > 0 && value !== "undefined")
+      return value;
+  }
+
+  return "Provider streaming error";
 };
 
 const isRetriableProviderCategory = (
@@ -426,7 +439,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
         statusCode: providerStatusCode,
         url: details.providerUrl as string | undefined,
         reason: (error as { reason?: string })?.reason,
-        message: details.errorMessage as string | undefined,
+        message: getProviderDiagnosticMessage(details),
         retriable: details.isRetryable as boolean | undefined,
         attempts,
       });
@@ -531,14 +544,11 @@ export function createChatLogger(config: ChatLoggerConfig) {
         (inferredProviderCategory !== "unknown"
           ? inferredProviderCategory
           : undefined);
+      const diagnosticMessage = getProviderDiagnosticMessage(details);
       const message =
-        (typeof details.errorMessage === "string" &&
-          details.errorMessage !== "undefined" &&
-          details.errorMessage) ||
-        (typeof details.providerErrorMessage === "string"
-          ? details.providerErrorMessage
-          : undefined) ||
-        "Unknown error occurred";
+        diagnosticMessage !== "Provider streaming error"
+          ? diagnosticMessage
+          : "Unknown error occurred";
 
       if (!providerCategory) {
         logger.error(

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -82,9 +82,16 @@ function posthogProviderException(
   error: unknown,
   details: Record<string, unknown>,
 ): Error {
-  if (error instanceof Error) return error;
   const message = getProviderDiagnosticMessage(details);
-  return new Error(message);
+  if (!(error instanceof Error)) return new Error(message);
+  if (message === "Provider streaming error" || message === error.message) {
+    return error;
+  }
+
+  const enriched = new Error(message);
+  enriched.name = error.name;
+  (enriched as Error & { cause?: unknown }).cause = error;
+  return enriched;
 }
 
 const truncateLogString = (value: string, maxLength = 500): string =>

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -67,6 +67,30 @@ describe("extractRetryAttempts -> request_id", () => {
     });
   });
 
+  it("extracts OpenRouter provider metadata from a direct parsed error body", () => {
+    const err = {
+      message: "Provider returned error",
+      code: 400,
+      id: "gen-direct-400",
+      error: {
+        code: 400,
+        message: "Provider returned error",
+        metadata: {
+          provider_name: "Anthropic",
+          raw: "tool_result without corresponding tool_use",
+        },
+      },
+    };
+
+    expect(extractErrorDetails(err)).toMatchObject({
+      providerName: "Anthropic",
+      providerErrorCode: 400,
+      providerErrorMessage: "Provider returned error",
+      providerRawError: "tool_result without corresponding tool_use",
+      openrouterGenerationId: "gen-direct-400",
+    });
+  });
+
   it("prefers OpenRouter gen-id from error.data over cf-ray header", () => {
     const err = retryError([
       apiCallError({
@@ -206,6 +230,50 @@ describe("extractRetryAttempts -> request_id", () => {
   });
 });
 
+describe("extractErrorDetails -> wrapped provider errors", () => {
+  it("extracts nested OpenRouter details from generic provider wrappers", () => {
+    const nested = apiCallError({
+      statusCode: 400,
+      responseBody: JSON.stringify({
+        id: "gen-400-wrapper",
+        error: {
+          code: 400,
+          message: "Provider returned error",
+          metadata: {
+            provider_name: "Anthropic",
+            raw: "tool_result without corresponding tool_use",
+          },
+        },
+      }),
+      requestBodyValues: {
+        messages: [{ role: "user", content: "SECRET_PROMPT_TEXT" }],
+      },
+    });
+    const err = {
+      message: "Provider returned error",
+      code: 400,
+      error: nested,
+    };
+
+    const details = extractErrorDetails(err);
+
+    expect(details).toMatchObject({
+      errorName: "AI_APICallError",
+      errorMessage: "Provider returned error",
+      errorCode: 400,
+      statusCode: 400,
+      providerName: "Anthropic",
+      providerErrorCode: 400,
+      providerErrorMessage: "Provider returned error",
+      providerRawError: "tool_result without corresponding tool_use",
+      openrouterGenerationId: "gen-400-wrapper",
+    });
+    expect(getProviderStatusCode(details)).toBe(400);
+    expect(getProviderErrorCategory(details)).toBe("provider_4xx");
+    expect(JSON.stringify(details)).not.toContain("SECRET_PROMPT_TEXT");
+  });
+});
+
 describe("provider error classification", () => {
   it("classifies undici terminated errors as provider stream termination", () => {
     const err = Object.assign(new TypeError("terminated"), {
@@ -236,6 +304,17 @@ describe("provider error classification", () => {
     expect(getProviderErrorCategory(extractErrorDetails(err))).toBe(
       "provider_5xx",
     );
+  });
+
+  it("uses top-level numeric provider error codes as status codes", () => {
+    const err = {
+      code: 400,
+      message: "Provider returned error",
+    };
+
+    const details = extractErrorDetails(err);
+    expect(getProviderStatusCode(details)).toBe(400);
+    expect(getProviderErrorCategory(details)).toBe("provider_4xx");
   });
 
   it("classifies upstream idle timeouts without an HTTP status as provider timeouts", () => {

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -46,14 +46,50 @@ const parseJsonObject = (
   }
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const collectErrorSources = (
+  source: unknown,
+  seen = new WeakSet<object>(),
+  depth = 0,
+): unknown[] => {
+  if (!isRecord(source) || depth > 3 || seen.has(source)) return [source];
+  seen.add(source);
+
+  const sources: unknown[] = [source];
+  for (const key of ["error", "cause"] as const) {
+    const nested = source[key];
+    if (nested !== undefined) {
+      sources.push(...collectErrorSources(nested, seen, depth + 1));
+    }
+  }
+
+  const errors = source.errors;
+  if (Array.isArray(errors)) {
+    for (const nested of errors.slice(0, 5)) {
+      sources.push(...collectErrorSources(nested, seen, depth + 1));
+    }
+  }
+
+  return sources;
+};
+
 const getOpenRouterPayload = (
   source: unknown,
 ): Record<string, unknown> | null => {
-  if (!source || typeof source !== "object") return null;
-  const anySource = source as Record<string, unknown>;
+  if (!isRecord(source)) return null;
+  const anySource = source;
 
   if (anySource.data && typeof anySource.data === "object") {
     return anySource.data as Record<string, unknown>;
+  }
+
+  if (
+    isRecord(anySource.error) &&
+    ("code" in anySource.error || "metadata" in anySource.error)
+  ) {
+    return anySource;
   }
 
   if (typeof anySource.responseBody === "string") {
@@ -66,43 +102,57 @@ const getOpenRouterPayload = (
 const getOpenRouterProviderInfo = (
   source: unknown,
 ): Record<string, unknown> => {
-  const payload = getOpenRouterPayload(source);
-  if (!payload) return {};
+  const payloads = collectErrorSources(source)
+    .map(getOpenRouterPayload)
+    .filter((payload): payload is Record<string, unknown> => payload !== null);
+  if (payloads.length === 0) return {};
 
   const details: Record<string, unknown> = {};
-  const id = pickBodyId(payload);
-  if (id) details.openrouterGenerationId = id;
+  for (const payload of payloads) {
+    const id = pickBodyId(payload);
+    if (id && details.openrouterGenerationId === undefined) {
+      details.openrouterGenerationId = id;
+    }
 
-  const nested =
-    payload.error && typeof payload.error === "object"
-      ? (payload.error as Record<string, unknown>)
-      : undefined;
-  if (!nested) return details;
+    const nested = isRecord(payload.error) ? payload.error : undefined;
+    if (!nested) continue;
 
-  if (typeof nested.code === "number" || typeof nested.code === "string") {
-    details.providerErrorCode = nested.code;
-  }
-  if (typeof nested.message === "string" && nested.message.length > 0) {
-    details.providerErrorMessage = truncate(
-      nested.message,
-      OPENROUTER_DETAIL_MAX_LENGTH,
-    );
-  }
+    if (
+      details.providerErrorCode === undefined &&
+      (typeof nested.code === "number" || typeof nested.code === "string")
+    ) {
+      details.providerErrorCode = nested.code;
+    }
+    if (
+      details.providerErrorMessage === undefined &&
+      typeof nested.message === "string" &&
+      nested.message.length > 0
+    ) {
+      details.providerErrorMessage = truncate(
+        nested.message,
+        OPENROUTER_DETAIL_MAX_LENGTH,
+      );
+    }
 
-  const metadata =
-    nested.metadata && typeof nested.metadata === "object"
-      ? (nested.metadata as Record<string, unknown>)
-      : undefined;
-  if (!metadata) return details;
+    const metadata = isRecord(nested.metadata) ? nested.metadata : undefined;
+    if (!metadata) continue;
 
-  if (typeof metadata.provider_name === "string") {
-    details.providerName = metadata.provider_name;
-  }
-  if (typeof metadata.raw === "string" && metadata.raw.length > 0) {
-    details.providerRawError = truncate(
-      metadata.raw,
-      OPENROUTER_DETAIL_MAX_LENGTH,
-    );
+    if (
+      details.providerName === undefined &&
+      typeof metadata.provider_name === "string"
+    ) {
+      details.providerName = metadata.provider_name;
+    }
+    if (
+      details.providerRawError === undefined &&
+      typeof metadata.raw === "string" &&
+      metadata.raw.length > 0
+    ) {
+      details.providerRawError = truncate(
+        metadata.raw,
+        OPENROUTER_DETAIL_MAX_LENGTH,
+      );
+    }
   }
 
   return details;
@@ -155,11 +205,19 @@ const removeSensitiveData = (data: unknown): unknown => {
 export const extractErrorDetails = (
   error: unknown,
 ): Record<string, unknown> => {
-  const err = error instanceof Error ? error : null;
-  const anyError = error as Record<string, unknown>;
+  const sources = collectErrorSources(error);
+  const err = sources.find((source) => source instanceof Error) as
+    | Error
+    | undefined;
+  const records = sources.filter(isRecord);
+  const primaryRecord = records[0];
 
   const details: Record<string, unknown> = {
-    errorName: err?.name || "UnknownError",
+    errorName:
+      err?.name ||
+      (typeof primaryRecord?.name === "string"
+        ? primaryRecord.name
+        : "UnknownError"),
     errorMessage: getErrorMessage(error),
   };
 
@@ -168,27 +226,30 @@ export const extractErrorDetails = (
     details.errorStack = err.stack;
   }
 
-  // Extract provider-specific error details (AI SDK format)
-  if ("statusCode" in anyError) {
-    details.statusCode = anyError.statusCode;
-  }
-  if ("url" in anyError) {
-    details.providerUrl = anyError.url;
-  }
-  if ("responseBody" in anyError) {
-    details.responseBody = removeSensitiveData(anyError.responseBody);
-  }
-  if ("isRetryable" in anyError) {
-    details.isRetryable = anyError.isRetryable;
-  }
-  if ("data" in anyError) {
-    details.providerData = removeSensitiveData(anyError.data);
-  }
-  if ("cause" in anyError && anyError.cause) {
-    details.cause = getErrorMessage(anyError.cause);
-  }
-  if ("code" in anyError) {
-    details.errorCode = anyError.code;
+  // Extract provider-specific error details (AI SDK format). Walk common
+  // wrapper fields so stream/UI wrappers do not hide APICallError diagnostics.
+  for (const source of records) {
+    if (details.statusCode === undefined && "statusCode" in source) {
+      details.statusCode = source.statusCode;
+    }
+    if (details.providerUrl === undefined && "url" in source) {
+      details.providerUrl = source.url;
+    }
+    if (details.responseBody === undefined && "responseBody" in source) {
+      details.responseBody = removeSensitiveData(source.responseBody);
+    }
+    if (details.isRetryable === undefined && "isRetryable" in source) {
+      details.isRetryable = source.isRetryable;
+    }
+    if (details.providerData === undefined && "data" in source) {
+      details.providerData = removeSensitiveData(source.data);
+    }
+    if (details.cause === undefined && "cause" in source && source.cause) {
+      details.cause = getErrorMessage(source.cause);
+    }
+    if (details.errorCode === undefined && "code" in source) {
+      details.errorCode = source.code;
+    }
   }
 
   Object.assign(details, getOpenRouterProviderInfo(error));
@@ -204,32 +265,39 @@ export type ProviderErrorCategory =
   | "timeout"
   | "unknown";
 
+const parseHttpStatus = (value: unknown): number | undefined => {
+  const code =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number(value)
+        : undefined;
+
+  return code != null && Number.isInteger(code) && code >= 400 && code <= 599
+    ? code
+    : undefined;
+};
+
 export const getProviderStatusCode = (
   details: Record<string, unknown>,
 ): number | undefined => {
-  const statusCode =
-    typeof details.statusCode === "number" ? details.statusCode : undefined;
+  const statusCode = parseHttpStatus(details.statusCode);
   if (statusCode != null) return statusCode;
 
-  const rawProviderErrorCode = details.providerErrorCode;
-  const providerErrorCode =
-    typeof rawProviderErrorCode === "number"
-      ? rawProviderErrorCode
-      : typeof rawProviderErrorCode === "string"
-        ? Number(rawProviderErrorCode)
-        : undefined;
-  return providerErrorCode != null &&
-    Number.isInteger(providerErrorCode) &&
-    providerErrorCode >= 400 &&
-    providerErrorCode <= 599
-    ? providerErrorCode
-    : undefined;
+  for (const key of ["providerErrorCode", "errorCode"] as const) {
+    const code = parseHttpStatus(details[key]);
+    if (code != null) return code;
+  }
+
+  return undefined;
 };
 
 export const getProviderErrorCategory = (
   details: Record<string, unknown>,
 ): ProviderErrorCategory => {
-  const statusCode = getProviderStatusCode(details);
+  const statusCode =
+    parseHttpStatus(details.statusCode) ??
+    parseHttpStatus(details.providerErrorCode);
   if (statusCode === 429) return "rate_limited";
   if (statusCode != null && statusCode >= 500) return "provider_5xx";
   if (statusCode != null && statusCode >= 400) return "provider_4xx";
@@ -250,6 +318,14 @@ export const getProviderErrorCategory = (
     return "stream_terminated";
   }
   if (/timeout|timed out/i.test(message)) return "timeout";
+
+  const fallbackStatusCode = parseHttpStatus(details.errorCode);
+  if (fallbackStatusCode === 429) return "rate_limited";
+  if (fallbackStatusCode != null && fallbackStatusCode >= 500)
+    return "provider_5xx";
+  if (fallbackStatusCode != null && fallbackStatusCode >= 400)
+    return "provider_4xx";
+
   return "unknown";
 };
 
@@ -289,7 +365,7 @@ const pickBodyId = (body: unknown): string | undefined => {
 };
 
 const extractRequestId = (error: unknown): string | undefined => {
-  if (!error || typeof error !== "object") return undefined;
+  if (!isRecord(error)) return undefined;
   const e = error as {
     responseHeaders?: Record<string, unknown>;
     data?: unknown;
@@ -322,7 +398,7 @@ const extractRequestId = (error: unknown): string | undefined => {
 };
 
 const toAttempt = (error: unknown): ProviderAttempt => {
-  const anyError = (error ?? {}) as Record<string, unknown>;
+  const anyError = isRecord(error) ? error : {};
   const providerInfo = getOpenRouterProviderInfo(error);
   const statusCode =
     typeof anyError.statusCode === "number"


### PR DESCRIPTION
## Summary

- unwrap nested provider error wrappers so OpenRouter/AI SDK details survive generic `Provider returned error` messages
- preserve sanitized provider metadata such as status codes, provider name, raw provider message, response body metadata, and generation IDs
- prefer provider raw/error messages in provider error wide events and PostHog exceptions
- add regression coverage for generic 400 provider wrappers and direct parsed OpenRouter error bodies

## Why

Provider streaming failures could arrive as generic wrapper objects, which flattened useful upstream details into `Provider returned error` and sometimes classified top-level `code: 400` failures as `unknown`. That made incidents harder to diagnose, especially for model payload rejections involving tools or multimodal content.

## Validation

- `pnpm test -- lib/utils/__tests__/error-utils.test.ts --runInBand`
- `pnpm test -- lib/api/__tests__/chat-logger.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint lib/utils/error-utils.ts lib/api/chat-logger.ts lib/utils/__tests__/error-utils.test.ts lib/api/__tests__/chat-logger.test.ts`
- commit hook: full `pnpm typecheck` and full `pnpm test` (`124` suites, `1408` tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better extraction and selection of provider diagnostic messages so reported errors are clearer and more accurate.
  * Improved provider status/category inference and numeric-status handling.
  * Enhanced sensitive-data filtering to ensure prompt text is omitted from logs and event payloads.

* **Tests**
  * Expanded coverage for wrapped/nested provider errors and logging, including console.error verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->