### PR TITLE
[codex] Fix moderation language detection fallback

### DIFF
--- a/__mocks__/franc-min.ts
+++ b/__mocks__/franc-min.ts
@@ -2,6 +2,7 @@ export const franc = (_text: string, _opts?: { only?: string[] }) => "eng";
 
 const detectCode = (text: string) => {
   const normalized = text.toLowerCase();
+  if (/login workflow|fails on staging/.test(normalized)) return "fra";
   if (/hotspot password|router password/.test(normalized)) return "fra";
   if (/wifi password/.test(normalized)) return "por";
   if (/comment|accéder|mot de passe|quelqu/.test(normalized)) return "fra";
@@ -23,6 +24,9 @@ export const francAll = (
   const detected = detectCode(text);
   const isMisrankedEnglishQuery =
     /hotspot password|router password|wifi password/.test(normalized);
+  const isClosePlainLatinEnglishQuery = /login workflow|fails on staging/.test(
+    normalized,
+  );
   const codes = opts?.only ?? [
     "eng",
     "rus",
@@ -41,9 +45,13 @@ export const francAll = (
           code,
           code === detected
             ? 1
-            : code === "eng" && isMisrankedEnglishQuery
-              ? 0.74
-              : 0.1,
+            : code === "eng" && isClosePlainLatinEnglishQuery
+              ? 0.933
+              : code === "deu" && isClosePlainLatinEnglishQuery
+                ? 0.955
+                : code === "eng" && isMisrankedEnglishQuery
+                  ? 0.74
+                  : 0.1,
         ] as [string, number],
     )
     .sort((a, b) => b[1] - a[1]);

--- a/lib/chat/__tests__/auth-disclaimer.test.ts
+++ b/lib/chat/__tests__/auth-disclaimer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
-import { detectLang } from "../auth-disclaimer";
+import { detectLang, detectLangWithDiagnostics } from "../auth-disclaimer";
 
 describe("detectLang", () => {
   it("prefers English for short English security questions with ambiguous detector scores", () => {
@@ -18,5 +18,46 @@ describe("detectLang", () => {
     expect(detectLang("如何访问某人的热点密码")).toBe("zh");
     expect(detectLang("كيف أصل إلى كلمة المرور")).toBe("ar");
     expect(detectLang("как получить пароль")).toBe("ru");
+  });
+
+  it("explains why ambiguous short Latin text falls back to English", () => {
+    const result = detectLangWithDiagnostics(
+      "How do I access someone hotspot password",
+    );
+
+    expect(result.language).toBe("en");
+    expect(result.diagnostics.selection_reason).toBe(
+      "short_latin_ambiguous_default_en",
+    );
+    expect(result.diagnostics.franc.ran).toBe(true);
+    expect(result.diagnostics.franc.top_code).toBe("fra");
+    expect(result.diagnostics.franc.english_score).toBe(0.74);
+    expect(result.diagnostics.text.letter_count).toBeGreaterThanOrEqual(25);
+    expect(result.diagnostics.scripts.dominant_script).toBe("latin");
+  });
+
+  it("prefers English for longer plain Latin text when franc is only slightly higher", () => {
+    const result = detectLangWithDiagnostics(
+      "Please check the login workflow and tell me why it fails on staging",
+    );
+
+    expect(result.language).toBe("en");
+    expect(result.diagnostics.selection_reason).toBe(
+      "plain_latin_english_close_default_en",
+    );
+    expect(result.diagnostics.franc.top_code).toBe("fra");
+    expect(result.diagnostics.franc.english_score).toBe(0.933);
+    expect(result.diagnostics.franc.top_score_minus_english).toBe(0.067);
+    expect(result.diagnostics.text.letter_count).toBeGreaterThan(40);
+    expect(result.diagnostics.text.has_diacritics).toBe(false);
+  });
+
+  it("explains dominant-script language selections", () => {
+    const result = detectLangWithDiagnostics("كيف أصل إلى كلمة المرور");
+
+    expect(result.language).toBe("ar");
+    expect(result.diagnostics.selection_reason).toBe("dominant_script");
+    expect(result.diagnostics.franc.ran).toBe(false);
+    expect(result.diagnostics.scripts.arabic_ratio).toBeGreaterThan(0.5);
   });
 });

--- a/lib/chat/auth-disclaimer.ts
+++ b/lib/chat/auth-disclaimer.ts
@@ -49,44 +49,179 @@ const MIN_CONFIDENCE_MARGIN = 0.05;
 
 const SHORT_LATIN_AMBIGUOUS_LETTER_LIMIT = 40;
 const SHORT_LATIN_ENGLISH_MARGIN = 0.3;
+const PLAIN_LATIN_ENGLISH_CLOSE_MARGIN = 0.1;
+const DOMINANT_SCRIPT_RATIO = 0.5;
+
+export type LanguageDetectionSelectionReason =
+  | "dominant_script"
+  | "short_text_default_en"
+  | "franc_no_result_default_en"
+  | "franc_und_default_en"
+  | "english_confidence_margin_default_en"
+  | "short_latin_ambiguous_default_en"
+  | "plain_latin_english_close_default_en"
+  | "franc_top_match"
+  | "unsupported_default_en";
+
+type ScriptName = "han" | "arabic" | "cyrillic" | "latin" | "other";
+
+export type LanguageDetectionDiagnostics = {
+  selected_language: SupportedLang;
+  selection_reason: LanguageDetectionSelectionReason;
+  thresholds: {
+    min_letter_count: number;
+    min_confidence_margin: number;
+    short_latin_ambiguous_letter_limit: number;
+    short_latin_english_margin: number;
+    plain_latin_english_close_margin: number;
+    dominant_script_ratio: number;
+  };
+  text: {
+    char_count: number;
+    trimmed_char_count: number;
+    letter_count: number;
+    whitespace_count: number;
+    newline_count: number;
+    numeric_count: number;
+    punctuation_count: number;
+    has_diacritics: boolean;
+    has_code_fence: boolean;
+    has_url_like_text: boolean;
+  };
+  scripts: {
+    han_count: number;
+    han_ratio: number;
+    arabic_count: number;
+    arabic_ratio: number;
+    cyrillic_count: number;
+    cyrillic_ratio: number;
+    latin_count: number;
+    latin_ratio: number;
+    other_letter_count: number;
+    other_letter_ratio: number;
+    dominant_script: ScriptName | null;
+    dominant_script_ratio: number;
+  };
+  franc: {
+    ran: boolean;
+    allowlist: string[];
+    candidates: Array<{
+      code: string;
+      language: SupportedLang | null;
+      score: number;
+    }>;
+    top_code?: string;
+    top_language?: SupportedLang | null;
+    top_score?: number;
+    english_score?: number;
+    normalized_english_gap?: number;
+    top_score_minus_english?: number;
+  };
+};
+
+export type LanguageDetectionResult = {
+  language: SupportedLang;
+  diagnostics: LanguageDetectionDiagnostics;
+};
 
 export function detectLang(text: string): SupportedLang {
-  const letterCount = (text.match(/\p{L}/gu) ?? []).length;
-  const scriptLang = detectByDominantScript(text, letterCount);
-  if (scriptLang) return scriptLang;
+  return detectLangWithDiagnostics(text).language;
+}
 
-  if (letterCount < MIN_LETTER_COUNT) return "en";
+export function detectLangWithDiagnostics(
+  text: string,
+): LanguageDetectionResult {
+  const letterCount = (text.match(/\p{L}/gu) ?? []).length;
+  const textDiagnostics = buildTextDiagnostics(text, letterCount);
+  const scriptDiagnostics = buildScriptDiagnostics(text, letterCount);
+  const baseDiagnostics = {
+    thresholds: buildThresholdDiagnostics(),
+    text: textDiagnostics,
+    scripts: scriptDiagnostics,
+    franc: buildFrancDiagnostics(),
+  };
+
+  const scriptLang = detectByDominantScript(scriptDiagnostics, letterCount);
+  if (scriptLang) {
+    return buildDetectionResult(scriptLang, "dominant_script", baseDiagnostics);
+  }
+
+  if (letterCount < MIN_LETTER_COUNT) {
+    return buildDetectionResult("en", "short_text_default_en", baseDiagnostics);
+  }
 
   const scores = francAll(text, { only: FRANC_ALLOWLIST });
+  const francDiagnostics = buildFrancDiagnostics(scores);
+  const diagnosticsWithFranc = {
+    ...baseDiagnostics,
+    franc: francDiagnostics,
+  };
   const top = scores[0];
-  if (!top || top[0] === "und") return "en";
+  if (!top) {
+    return buildDetectionResult(
+      "en",
+      "franc_no_result_default_en",
+      diagnosticsWithFranc,
+    );
+  }
+  if (top[0] === "und") {
+    return buildDetectionResult(
+      "en",
+      "franc_und_default_en",
+      diagnosticsWithFranc,
+    );
+  }
 
   const eng = scores.find(([code]) => code === "eng");
-  if (eng && 1 - eng[1] < MIN_CONFIDENCE_MARGIN) return "en";
+  if (eng && 1 - eng[1] < MIN_CONFIDENCE_MARGIN) {
+    return buildDetectionResult(
+      "en",
+      "english_confidence_margin_default_en",
+      diagnosticsWithFranc,
+    );
+  }
   if (
     eng &&
     shouldPreferEnglishForAmbiguousLatinText(text, letterCount, eng[1], top[1])
   ) {
-    return "en";
+    return buildDetectionResult(
+      "en",
+      "short_latin_ambiguous_default_en",
+      diagnosticsWithFranc,
+    );
+  }
+  if (eng && shouldPreferEnglishForClosePlainLatinText(text, eng[1], top[1])) {
+    return buildDetectionResult(
+      "en",
+      "plain_latin_english_close_default_en",
+      diagnosticsWithFranc,
+    );
   }
 
-  return ISO_639_3_TO_1[top[0]] ?? "en";
+  const selectedLanguage = ISO_639_3_TO_1[top[0]];
+  if (!selectedLanguage) {
+    return buildDetectionResult(
+      "en",
+      "unsupported_default_en",
+      diagnosticsWithFranc,
+    );
+  }
+
+  return buildDetectionResult(
+    selectedLanguage,
+    "franc_top_match",
+    diagnosticsWithFranc,
+  );
 }
 
 function detectByDominantScript(
-  text: string,
+  scripts: LanguageDetectionDiagnostics["scripts"],
   letterCount: number,
 ): SupportedLang | null {
   if (letterCount === 0) return null;
-
-  const hanCount = countMatches(text, /\p{Script=Han}/gu);
-  if (hanCount / letterCount > 0.5) return "zh";
-
-  const arabicCount = countMatches(text, /\p{Script=Arabic}/gu);
-  if (arabicCount / letterCount > 0.5) return "ar";
-
-  const cyrillicCount = countMatches(text, /\p{Script=Cyrillic}/gu);
-  if (cyrillicCount / letterCount > 0.5) return "ru";
+  if (scripts.han_count / letterCount > DOMINANT_SCRIPT_RATIO) return "zh";
+  if (scripts.arabic_count / letterCount > DOMINANT_SCRIPT_RATIO) return "ar";
+  if (scripts.cyrillic_count / letterCount > DOMINANT_SCRIPT_RATIO) return "ru";
 
   return null;
 }
@@ -118,4 +253,148 @@ function shouldPreferEnglishForAmbiguousLatinText(
     !hasDiacritics &&
     topScore - englishScore <= SHORT_LATIN_ENGLISH_MARGIN
   );
+}
+
+function shouldPreferEnglishForClosePlainLatinText(
+  text: string,
+  englishScore: number,
+  topScore: number,
+): boolean {
+  const letters = text.match(/\p{L}/gu) ?? [];
+  if (letters.length === 0) return false;
+
+  const onlyLatinLetters = letters.every((letter) =>
+    /\p{Script=Latin}/u.test(letter),
+  );
+  const hasDiacritics = /\p{Diacritic}/u.test(text.normalize("NFD"));
+
+  return (
+    onlyLatinLetters &&
+    !hasDiacritics &&
+    topScore - englishScore <= PLAIN_LATIN_ENGLISH_CLOSE_MARGIN
+  );
+}
+
+function buildDetectionResult(
+  language: SupportedLang,
+  reason: LanguageDetectionSelectionReason,
+  diagnostics: Omit<
+    LanguageDetectionDiagnostics,
+    "selected_language" | "selection_reason"
+  >,
+): LanguageDetectionResult {
+  return {
+    language,
+    diagnostics: {
+      selected_language: language,
+      selection_reason: reason,
+      ...diagnostics,
+    },
+  };
+}
+
+function buildThresholdDiagnostics(): LanguageDetectionDiagnostics["thresholds"] {
+  return {
+    min_letter_count: MIN_LETTER_COUNT,
+    min_confidence_margin: MIN_CONFIDENCE_MARGIN,
+    short_latin_ambiguous_letter_limit: SHORT_LATIN_AMBIGUOUS_LETTER_LIMIT,
+    short_latin_english_margin: SHORT_LATIN_ENGLISH_MARGIN,
+    plain_latin_english_close_margin: PLAIN_LATIN_ENGLISH_CLOSE_MARGIN,
+    dominant_script_ratio: DOMINANT_SCRIPT_RATIO,
+  };
+}
+
+function buildTextDiagnostics(
+  text: string,
+  letterCount: number,
+): LanguageDetectionDiagnostics["text"] {
+  return {
+    char_count: text.length,
+    trimmed_char_count: text.trim().length,
+    letter_count: letterCount,
+    whitespace_count: countMatches(text, /\s/gu),
+    newline_count: countMatches(text, /\r\n|\r|\n/gu),
+    numeric_count: countMatches(text, /\p{N}/gu),
+    punctuation_count: countMatches(text, /\p{P}/gu),
+    has_diacritics: /\p{Diacritic}/u.test(text.normalize("NFD")),
+    has_code_fence: /```/.test(text),
+    has_url_like_text: /\bhttps?:\/\//i.test(text),
+  };
+}
+
+function buildScriptDiagnostics(
+  text: string,
+  letterCount: number,
+): LanguageDetectionDiagnostics["scripts"] {
+  const hanCount = countMatches(text, /\p{Script=Han}/gu);
+  const arabicCount = countMatches(text, /\p{Script=Arabic}/gu);
+  const cyrillicCount = countMatches(text, /\p{Script=Cyrillic}/gu);
+  const latinCount = countMatches(text, /\p{Script=Latin}/gu);
+  const otherLetterCount = Math.max(
+    letterCount - hanCount - arabicCount - cyrillicCount - latinCount,
+    0,
+  );
+  const scriptCounts: Record<ScriptName, number> = {
+    han: hanCount,
+    arabic: arabicCount,
+    cyrillic: cyrillicCount,
+    latin: latinCount,
+    other: otherLetterCount,
+  };
+  const dominantScript = Object.entries(scriptCounts).reduce<{
+    script: ScriptName | null;
+    count: number;
+  }>(
+    (current, [script, count]) =>
+      count > current.count ? { script: script as ScriptName, count } : current,
+    { script: null, count: 0 },
+  );
+
+  return {
+    han_count: hanCount,
+    han_ratio: ratio(hanCount, letterCount),
+    arabic_count: arabicCount,
+    arabic_ratio: ratio(arabicCount, letterCount),
+    cyrillic_count: cyrillicCount,
+    cyrillic_ratio: ratio(cyrillicCount, letterCount),
+    latin_count: latinCount,
+    latin_ratio: ratio(latinCount, letterCount),
+    other_letter_count: otherLetterCount,
+    other_letter_ratio: ratio(otherLetterCount, letterCount),
+    dominant_script: dominantScript.script,
+    dominant_script_ratio: ratio(dominantScript.count, letterCount),
+  };
+}
+
+function buildFrancDiagnostics(
+  scores: Array<[string, number]> = [],
+): LanguageDetectionDiagnostics["franc"] {
+  const top = scores[0];
+  const english = scores.find(([code]) => code === "eng");
+
+  return {
+    ran: scores.length > 0,
+    allowlist: [...FRANC_ALLOWLIST],
+    candidates: scores.map(([code, score]) => ({
+      code,
+      language: ISO_639_3_TO_1[code] ?? null,
+      score: roundScore(score),
+    })),
+    top_code: top?.[0],
+    top_language: top ? (ISO_639_3_TO_1[top[0]] ?? null) : undefined,
+    top_score: top ? roundScore(top[1]) : undefined,
+    english_score: english ? roundScore(english[1]) : undefined,
+    normalized_english_gap: english ? roundScore(1 - english[1]) : undefined,
+    top_score_minus_english:
+      top && english ? roundScore(top[1] - english[1]) : undefined,
+  };
+}
+
+function ratio(count: number, total: number): number {
+  if (total === 0) return 0;
+  return roundScore(count / total);
+}
+
+function roundScore(value: number): number {
+  return Math.round(value * 1000) / 1000;
 }


### PR DESCRIPTION
## What changed

- Added a diagnostic-capable language detection result while keeping the existing `detectLang(text)` API intact.
- Added a plain-Latin close-English fallback so English wins when `franc-min` barely ranks another Latin-script language higher with no diacritics.
- Added regression coverage for ambiguous short English, longer plain-Latin English, and dominant-script selections.

## Why

Moderation appends an authorization disclaimer in the detected language. When language detection misclassifies plain English as French, the wrong-language parenthetical can influence the model response language. The observed case had French at `1.0` and English at `0.933`; this now selects English because the top score is within the close-English margin for plain Latin text.

## Notes

The earlier always-on console diagnostic logging was removed before merge. This PR does not add moderation console logs.

## Validation

- `pnpm test -- lib/chat/__tests__/auth-disclaimer.test.ts lib/__tests__/moderation.test.ts`
- `pnpm typecheck`
- `pnpm exec eslint __mocks__/franc-min.ts lib/chat/auth-disclaimer.ts lib/moderation.ts lib/chat/__tests__/auth-disclaimer.test.ts lib/__tests__/moderation.test.ts`
- Pre-commit hook after cleanup: `pnpm typecheck` and full `pnpm test` (`125` suites, `1406` tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language detection now returns detailed diagnostics describing scores, text/script metrics, and selection reasoning.

* **Bug Fixes**
  * Improved handling and more accurate results for ambiguous, short, or plain-Latin inputs.

* **Tests**
  * Expanded tests to validate diagnostic output, confidence metrics, and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->