### PR TITLE
[codex] Fix local attachment download timeouts

### DIFF
--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -565,15 +565,19 @@ describe("CentrifugoSandbox", () => {
         retryConnrefused: true,
       };
       const runs: string[] = [];
-      (sandbox as any).commands.run = jest.fn(async (cmd: string) => {
-        runs.push(cmd);
-        return { stdout: "", stderr: "", exitCode: 0 };
-      });
-      return { sandbox, runs };
+      const runOptions: unknown[] = [];
+      (sandbox as any).commands.run = jest.fn(
+        async (cmd: string, opts?: unknown) => {
+          runOptions.push(opts);
+          runs.push(cmd);
+          return { stdout: "", stderr: "", exitCode: 0 };
+        },
+      );
+      return { sandbox, runs, runOptions };
     }
 
     it("downloadFromUrl emits POSIX mkdir + curl with MSYS paths", async () => {
-      const { sandbox, runs } = createWindowsBashSandbox();
+      const { sandbox, runs, runOptions } = createWindowsBashSandbox();
       // Mock validateDownloadUrl is real; use an https URL it accepts.
       await sandbox.files.downloadFromUrl(
         "https://example.com/image.png",
@@ -589,6 +593,48 @@ describe("CentrifugoSandbox", () => {
       expect(cmd).toContain("-o '/c/temp/hackerai-upload/image.png'");
       expect(cmd).not.toContain("if not exist");
       expect(cmd).not.toContain("\\");
+      expect(runOptions[0]).toMatchObject({
+        displayName: "Downloading: image.png",
+        timeoutMs: 120000,
+      });
+    });
+
+    it("downloadFromUrl retries local command wrapper timeouts", async () => {
+      const { sandbox } = createWindowsBashSandbox();
+      (sandbox as any).commands.run = jest
+        .fn()
+        .mockResolvedValueOnce({
+          stdout: "",
+          stderr: "\n[Command timed out and was terminated]",
+          exitCode: 124,
+        })
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+
+      const promise = sandbox.files.downloadFromUrl(
+        "https://example.com/large.har",
+        "/tmp/hackerai-upload/large.har",
+      );
+
+      await jest.advanceTimersByTimeAsync(500);
+      await promise;
+
+      expect((sandbox as any).commands.run).toHaveBeenCalledTimes(2);
+      expect((sandbox as any).commands.run).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining("curl -fsSL"),
+        expect.objectContaining({
+          displayName: "Downloading: large.har",
+          timeoutMs: 120000,
+        }),
+      );
+      expect((sandbox as any).commands.run).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining("curl -fsSL"),
+        expect.objectContaining({
+          displayName: "Downloading: large.har (retry 1)",
+          timeoutMs: 120000,
+        }),
+      );
     });
 
     it("ensureDirectory emits mkdir -p with MSYS path", async () => {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -31,6 +31,8 @@ const IGNORED_MESSAGE_TYPES = new Set([
   "pty_error",
 ]);
 
+const FILE_DOWNLOAD_TIMEOUT_MS = 120000;
+
 export function parseSandboxMessage(
   data: unknown,
 ): CommandResponseMessage | null {
@@ -949,11 +951,13 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       //   35 = TLS handshake/read error (e.g. S3 "unexpected eof")
       //   56 = failure receiving network data
       //   92 = HTTP/2 stream error
-      const TRANSIENT_EXIT_CODES = new Set([7, 18, 23, 28, 35, 56, 92]);
+      //   124 = local command wrapper timeout
+      const TRANSIENT_EXIT_CODES = new Set([7, 18, 23, 28, 35, 56, 92, 124]);
       const MAX_ATTEMPTS = 3;
 
       let result = await this.commands.run(command, {
         displayName: `Downloading: ${fileName}`,
+        timeoutMs: FILE_DOWNLOAD_TIMEOUT_MS,
       });
       for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
         if (result.exitCode === 0) break;
@@ -969,6 +973,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
         await new Promise((r) => setTimeout(r, 500 * attempt));
         result = await this.commands.run(command, {
           displayName: `Downloading: ${fileName} (retry ${attempt})`,
+          timeoutMs: FILE_DOWNLOAD_TIMEOUT_MS,
         });
       }
       if (result.exitCode !== 0) {


### PR DESCRIPTION
## Summary
- Increase local/Centrifugo attachment download command timeout to 120 seconds.
- Retry local command wrapper timeout exit code `124` during URL attachment downloads.
- Add regression coverage for long-running local downloads and retry behavior.

## Root Cause
Large or slow URL attachments could be killed by the local command bridge's 30 second default timeout even while `curl` was actively writing the file. The downloader handled curl timeout code `28`, but not the wrapper timeout code `124`.

## Impact
Users uploading larger HARs or slower S3-backed files through local sandbox mode should see fewer false download failures.

## Validation
- `pnpm jest lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts --runInBand`
- `pnpm exec eslint lib/ai/tools/utils/centrifugo-sandbox.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts`
- `pnpm typecheck`
- Pre-commit hook also ran Prettier, ESLint, `pnpm typecheck`, and full `pnpm test` successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file download reliability by adding a 120-second timeout and automatic retry logic for timeout errors.

* **Tests**
  * Enhanced test coverage to verify download timeout values and retry behavior when operations exceed the timeout threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->