### PR TITLE
[codex] Handle HAC-8 limit-pressure monetization

### DIFF
--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -10,6 +10,11 @@ import {
   captureAddCreditCtaImpression,
   captureUpgradeCtaImpression,
 } from "@/lib/analytics/client";
+import type { LimitCapReason } from "@/lib/limit-pressure";
+import {
+  getExtraUsageLimitCta,
+  shouldShowUpgradeCta,
+} from "@/lib/limit-pressure";
 
 interface MessageErrorStateProps {
   error: Error;
@@ -43,7 +48,7 @@ export const MessageErrorState = ({
 
   const metadata = error instanceof ChatSDKError ? error.metadata : undefined;
   const resetTimestamp = metadata?.resetTimestamp as number | undefined;
-  const capReason = metadata?.capReason as string | undefined;
+  const capReason = metadata?.capReason as LimitCapReason | undefined;
   const upgradeImpressionRef = useRef(false);
   const addCreditImpressionRef = useRef(false);
 
@@ -71,10 +76,8 @@ export const MessageErrorState = ({
   })();
 
   const isPaidUser = subscription !== "free";
-  const canUpgrade =
-    subscription === "free" ||
-    subscription === "pro" ||
-    subscription === "pro-plus";
+  const canUpgrade = shouldShowUpgradeCta({ subscription, capReason });
+  const extraUsageCta = getExtraUsageLimitCta({ subscription, capReason });
   const isSuspensionError = metadata?.suspensionCategory !== undefined;
 
   useEffect(() => {
@@ -92,7 +95,12 @@ export const MessageErrorState = ({
   }, [canUpgrade, capReason, isRateLimitError, subscription]);
 
   useEffect(() => {
-    if (!isRateLimitError || !isPaidUser || addCreditImpressionRef.current) {
+    if (
+      !isRateLimitError ||
+      !isPaidUser ||
+      !extraUsageCta ||
+      addCreditImpressionRef.current
+    ) {
       return;
     }
 
@@ -102,9 +110,9 @@ export const MessageErrorState = ({
       source: "rate_limit_error",
       from_tier: subscription,
       cap_reason: capReason,
-      cta_text: "Add Credits",
+      cta_text: extraUsageCta.analyticsText,
     });
-  }, [capReason, isPaidUser, isRateLimitError, subscription]);
+  }, [capReason, extraUsageCta, isPaidUser, isRateLimitError, subscription]);
 
   return (
     <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3">
@@ -140,7 +148,7 @@ export const MessageErrorState = ({
             >
               View Usage
             </Button>
-            {isPaidUser && (
+            {extraUsageCta && (
               <Button
                 variant="outline"
                 size="sm"
@@ -150,12 +158,12 @@ export const MessageErrorState = ({
                     source: "rate_limit_error",
                     from_tier: subscription,
                     cap_reason: capReason,
-                    cta_text: "Add Credits",
+                    cta_text: extraUsageCta.analyticsText,
                   });
-                  openSettingsDialog("Extra Usage");
+                  openSettingsDialog(extraUsageCta.settingsTab);
                 }}
               >
-                Add Credits
+                {extraUsageCta.label}
               </Button>
             )}
             {canUpgrade && (

--- a/app/components/RateLimitWarning.tsx
+++ b/app/components/RateLimitWarning.tsx
@@ -4,6 +4,12 @@ import { Button } from "@/components/ui/button";
 import { redirectToPricing } from "../hooks/usePricingDialog";
 import { openSettingsDialog } from "@/lib/utils/settings-dialog";
 import type { ChatMode, SubscriptionTier } from "@/types";
+import type { LimitCapReason } from "@/lib/limit-pressure";
+import {
+  getExtraUsageLimitCta,
+  getLimitTypeForCapReason,
+  shouldShowUpgradeCta,
+} from "@/lib/limit-pressure";
 import {
   captureAddCreditCtaClick,
   captureAddCreditCtaImpression,
@@ -28,6 +34,7 @@ export type RateLimitWarningData =
       severity?: "info" | "warning";
       usedDollars?: number;
       limitDollars?: number;
+      capReason?: LimitCapReason;
       midStream?: boolean;
       cutOff?: boolean;
     }
@@ -36,6 +43,7 @@ export type RateLimitWarningData =
       bucketType: "monthly";
       resetTime: Date;
       subscription: SubscriptionTier;
+      capReason?: LimitCapReason;
       midStream?: boolean;
     };
 
@@ -93,6 +101,9 @@ const getMessage = (data: RateLimitWarningData, timeString: string): string => {
       if (data.subscription === "free") {
         return `You've reached your free monthly usage limit and this response was cut off. Upgrade to continue. Resets ${timeString}.`;
       }
+      if (data.capReason === "extra_usage_cap") {
+        return `You've reached your extra usage spending limit and this response was cut off. Increase your limit to continue. Resets ${timeString}.`;
+      }
       return `You've reached your monthly limit and this response was cut off. Add credits or upgrade to continue. Resets ${timeString}.`;
     }
     return `You've reached your monthly usage limit. It resets ${timeString}.`;
@@ -116,19 +127,27 @@ export const RateLimitWarning = ({
   const capturedAddCreditImpressionRef = useRef(false);
   const timeString = formatTimeUntil(data.resetTime);
   const message = getMessage(data, timeString);
+  const capReason =
+    data.warningType === "sliding-window" ? undefined : data.capReason;
+  const extraUsageCta =
+    data.warningType === "token-bucket"
+      ? getExtraUsageLimitCta({
+          subscription: data.subscription,
+          capReason,
+        })
+      : null;
   const showUpgrade =
     data.warningType !== "extra-usage-active" &&
-    (data.subscription === "free" ||
-      data.subscription === "pro" ||
-      data.subscription === "pro-plus");
-  const showAddCredits =
-    data.warningType === "token-bucket" && data.subscription !== "free";
+    shouldShowUpgradeCta({
+      subscription: data.subscription,
+      capReason,
+    });
   const limitType =
     data.warningType === "sliding-window"
       ? "daily_requests"
       : data.warningType === "token-bucket"
-        ? data.bucketType
-        : "extra_usage_active";
+        ? getLimitTypeForCapReason(capReason)
+        : getLimitTypeForCapReason(data.capReason ?? "extra_usage_active");
   const limitSeverity =
     data.warningType === "token-bucket" && data.remainingPercent === 0
       ? "hit"
@@ -143,12 +162,13 @@ export const RateLimitWarning = ({
       from_tier: data.subscription,
       limit_type: limitType,
       limit_severity: limitSeverity,
+      cap_reason: capReason,
       cta_text: "Upgrade plan",
     });
-  }, [data.subscription, limitSeverity, limitType, showUpgrade]);
+  }, [capReason, data.subscription, limitSeverity, limitType, showUpgrade]);
 
   useEffect(() => {
-    if (!showAddCredits || capturedAddCreditImpressionRef.current) return;
+    if (!extraUsageCta || capturedAddCreditImpressionRef.current) return;
     capturedAddCreditImpressionRef.current = true;
     captureAddCreditCtaImpression({
       surface: "rate_limit_warning",
@@ -156,9 +176,10 @@ export const RateLimitWarning = ({
       from_tier: data.subscription,
       limit_type: limitType,
       limit_severity: limitSeverity,
-      cta_text: "Add credits",
+      cap_reason: capReason,
+      cta_text: extraUsageCta.analyticsText,
     });
-  }, [data.subscription, limitSeverity, limitType, showAddCredits]);
+  }, [capReason, data.subscription, extraUsageCta, limitSeverity, limitType]);
 
   return (
     <div
@@ -167,7 +188,7 @@ export const RateLimitWarning = ({
     >
       <div className="flex-1 flex items-center gap-2 flex-wrap">
         <span className="text-foreground text-sm">{message}</span>
-        {showAddCredits && (
+        {extraUsageCta && (
           <Button
             onClick={() => {
               captureAddCreditCtaClick({
@@ -176,15 +197,16 @@ export const RateLimitWarning = ({
                 from_tier: data.subscription,
                 limit_type: limitType,
                 limit_severity: limitSeverity,
-                cta_text: "Add credits",
+                cap_reason: capReason,
+                cta_text: extraUsageCta.analyticsText,
               });
-              openSettingsDialog("Extra Usage");
+              openSettingsDialog(extraUsageCta.settingsTab);
             }}
             size="sm"
             variant="outline"
             className="h-7 px-3 text-xs font-medium border-black/8 dark:border-border"
           >
-            Add credits
+            {extraUsageCta.label}
           </Button>
         )}
         {showUpgrade && (
@@ -195,6 +217,7 @@ export const RateLimitWarning = ({
                 source: "limit_pressure",
                 from_tier: data.subscription,
                 limit_type: limitType,
+                reason: capReason,
                 cta_text: "Upgrade plan",
               })
             }

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -584,6 +584,9 @@ export const getExtraUsageBalanceForBackend = query({
     autoReloadThresholdDollars: v.optional(v.number()),
     autoReloadThresholdPoints: v.optional(v.number()),
     autoReloadAmountDollars: v.optional(v.number()),
+    monthlyCapDollars: v.optional(v.number()),
+    monthlySpentDollars: v.number(),
+    monthlyRemainingDollars: v.optional(v.number()),
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
@@ -602,6 +605,17 @@ export const getExtraUsageBalanceForBackend = query({
 
     const balancePoints = settings?.balance_points ?? 0;
     const thresholdPoints = settings?.auto_reload_threshold_points;
+    const now = new Date();
+    const currentMonth = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const monthlySpentPoints =
+      settings?.monthly_reset_date === currentMonth
+        ? (settings?.monthly_spent_points ?? 0)
+        : 0;
+    const monthlyCapPoints = settings?.monthly_cap_points;
+    const monthlyRemainingPoints =
+      monthlyCapPoints === undefined
+        ? undefined
+        : Math.max(0, monthlyCapPoints - monthlySpentPoints);
 
     return {
       balanceDollars: pointsToDollars(balancePoints),
@@ -613,6 +627,15 @@ export const getExtraUsageBalanceForBackend = query({
         : undefined,
       autoReloadThresholdPoints: thresholdPoints,
       autoReloadAmountDollars: settings?.auto_reload_amount_dollars,
+      monthlyCapDollars:
+        monthlyCapPoints === undefined
+          ? undefined
+          : pointsToDollars(monthlyCapPoints),
+      monthlySpentDollars: pointsToDollars(monthlySpentPoints),
+      monthlyRemainingDollars:
+        monthlyRemainingPoints === undefined
+          ? undefined
+          : pointsToDollars(monthlyRemainingPoints),
     };
   },
 });

--- a/convex/teamExtraUsage.ts
+++ b/convex/teamExtraUsage.ts
@@ -505,6 +505,11 @@ export const getTeamExtraUsageStateForBackend = query({
     autoReloadThresholdPoints: v.optional(v.number()),
     autoReloadAmountDollars: v.optional(v.number()),
     memberDisabled: v.boolean(),
+    monthlyCapDollars: v.optional(v.number()),
+    monthlySpentDollars: v.number(),
+    memberMonthlyLimitDollars: v.optional(v.number()),
+    memberMonthlySpentDollars: v.number(),
+    monthlyRemainingDollars: v.optional(v.number()),
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
@@ -522,6 +527,32 @@ export const getTeamExtraUsageStateForBackend = query({
       .first();
 
     const thresholdPoints = team?.auto_reload_threshold_points;
+    const currentMonth = currentMonthString();
+    const teamMonthlySpent =
+      team?.monthly_reset_date === currentMonth
+        ? (team?.monthly_spent_points ?? 0)
+        : 0;
+    const memberMonthlySpent =
+      member?.monthly_reset_date === currentMonth
+        ? (member?.monthly_spent_points ?? 0)
+        : 0;
+    const teamCapPoints = team?.monthly_cap_points;
+    const memberCapPoints = member?.monthly_limit_points;
+    const teamRemainingPoints =
+      teamCapPoints === undefined
+        ? undefined
+        : Math.max(0, teamCapPoints - teamMonthlySpent);
+    const memberRemainingPoints =
+      memberCapPoints === undefined
+        ? undefined
+        : Math.max(0, memberCapPoints - memberMonthlySpent);
+    const monthlyRemainingPoints =
+      teamRemainingPoints === undefined && memberRemainingPoints === undefined
+        ? undefined
+        : Math.min(
+            teamRemainingPoints ?? Number.POSITIVE_INFINITY,
+            memberRemainingPoints ?? Number.POSITIVE_INFINITY,
+          );
 
     return {
       enabled: team?.enabled ?? false,
@@ -534,6 +565,20 @@ export const getTeamExtraUsageStateForBackend = query({
       autoReloadThresholdPoints: thresholdPoints,
       autoReloadAmountDollars: team?.auto_reload_amount_dollars,
       memberDisabled: member?.disabled ?? false,
+      monthlyCapDollars:
+        teamCapPoints === undefined
+          ? undefined
+          : pointsToDollars(teamCapPoints),
+      monthlySpentDollars: pointsToDollars(teamMonthlySpent),
+      memberMonthlyLimitDollars:
+        memberCapPoints === undefined
+          ? undefined
+          : pointsToDollars(memberCapPoints),
+      memberMonthlySpentDollars: pointsToDollars(memberMonthlySpent),
+      monthlyRemainingDollars:
+        monthlyRemainingPoints === undefined
+          ? undefined
+          : pointsToDollars(monthlyRemainingPoints),
     };
   },
 });

--- a/docs/paid-funnel-analytics.md
+++ b/docs/paid-funnel-analytics.md
@@ -49,6 +49,13 @@ Paid funnel events use stable snake_case event names. Most events include
 - `amount_dollars`, `checkout_amount_dollars`, `revenue_dollars`: money fields
   in USD unless `currency` says otherwise.
 - `cap_reason`, `limit_type`, `reset_timestamp`: limit-pressure context.
+- `primary_cta`, `eligible_ctas`, `upgrade_available`,
+  `add_credit_available`: monetization paths shown or available for that
+  limit pressure moment.
+- `cost_guardrail`: true when the blocker is an extra-usage/team spending cap
+  or payment guardrail rather than the included monthly bucket alone.
+- `paid_monthly_exhaustion`: true for paid users whose included monthly bucket
+  is exhausted and can be resolved through add-credit/upgrade flow.
 
 ## Data Minimization
 
@@ -69,7 +76,8 @@ Paid funnel events use stable snake_case event names. Most events include
 - Checkout start to subscription: `checkout_started -> subscription_started`,
   joined or filtered by `checkout_attempt_id`.
 - Limit pressure to paid/add-credit: `limit_hit -> upgrade_cta_clicked` and
-  `limit_hit -> add_credit_checkout_succeeded`.
+  `limit_hit -> add_credit_checkout_succeeded`, grouped by `primary_cta`,
+  `eligible_ctas`, and `cap_reason`.
 - Referral revenue:
   `referred_signup_attributed -> referred_user_paid_conversion`, grouped by
   `referral_code`.

--- a/lib/__tests__/limit-pressure.test.ts
+++ b/lib/__tests__/limit-pressure.test.ts
@@ -1,0 +1,59 @@
+import {
+  getEligibleLimitCtas,
+  getExtraUsageLimitCta,
+  getLimitPressureContext,
+  shouldShowUpgradeCta,
+} from "../limit-pressure";
+
+describe("limit pressure helpers", () => {
+  it("routes free limit pressure to upgrade only", () => {
+    expect(
+      getLimitPressureContext({
+        subscription: "free",
+        capReason: "daily_requests_exhausted",
+      }),
+    ).toMatchObject({
+      limitType: "daily_requests",
+      upgradeAvailable: true,
+      addCreditAvailable: false,
+      primaryCta: "upgrade_plan",
+      eligibleCtas: ["upgrade_plan"],
+    });
+  });
+
+  it("routes paid monthly exhaustion to add credits and paid upgrades when available", () => {
+    expect(
+      getEligibleLimitCtas({
+        subscription: "pro",
+        capReason: "monthly_exhausted",
+      }),
+    ).toEqual(["add_credits", "upgrade_plan"]);
+    expect(
+      getExtraUsageLimitCta({
+        subscription: "ultra",
+        capReason: "monthly_exhausted",
+      }),
+    ).toMatchObject({
+      label: "Add Credits",
+      analyticsText: "Add Credits",
+    });
+  });
+
+  it("routes extra-usage caps to the spending-limit guardrail instead of upgrade", () => {
+    expect(
+      shouldShowUpgradeCta({
+        subscription: "pro-plus",
+        capReason: "extra_usage_cap",
+      }),
+    ).toBe(false);
+    expect(
+      getExtraUsageLimitCta({
+        subscription: "pro-plus",
+        capReason: "extra_usage_cap",
+      }),
+    ).toMatchObject({
+      label: "Increase Limit",
+      analyticsText: "Increase Limit",
+    });
+  });
+});

--- a/lib/api/__tests__/build-extra-usage-config.test.ts
+++ b/lib/api/__tests__/build-extra-usage-config.test.ts
@@ -222,6 +222,34 @@ describe("buildExtraUsageConfig — individual paid users (pro / pro-plus / ultr
     });
   });
 
+  it("includes personal monthly cap remaining for mid-stream guardrails", async () => {
+    mockGetUserBalance.mockResolvedValue({
+      balanceDollars: 30,
+      balancePoints: 300_000,
+      enabled: true,
+      autoReloadEnabled: true,
+      monthlyCapDollars: 50,
+      monthlySpentDollars: 45,
+      monthlyRemainingDollars: 5,
+    });
+
+    const config = await buildExtraUsageConfig({
+      userId: USER_ID,
+      subscription: "pro-plus",
+      userCustomization: { extra_usage_enabled: true } as any,
+    });
+
+    expect(config).toMatchObject({
+      enabled: true,
+      hasBalance: true,
+      balanceDollars: 30,
+      autoReloadEnabled: true,
+      monthlyCapDollars: 50,
+      monthlySpentDollars: 45,
+      monthlyRemainingDollars: 5,
+    });
+  });
+
   it("returns optimistic config when personal balance query fails", async () => {
     mockGetUserBalance.mockResolvedValue(null);
 

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -13,6 +13,7 @@ const {
   captureUsageCost,
 } = require("../chat-logger");
 const { ChatSDKError } = require("../../errors");
+const { phLogger } = require("../../posthog/server");
 
 describe("captureToolCalls", () => {
   it("aggregates repeated tool calls by tool before sending PostHog events", () => {
@@ -413,6 +414,104 @@ describe("createChatLogger ChatSDKError metadata", () => {
       expect(wideEvent.error.metadata).not.toHaveProperty("usage_keys");
       expect(wideEvent.error.metadata).not.toHaveProperty("parts_size_bytes");
     } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("emits limit pressure funnel properties for paid monthly exhaustion", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const eventSpy = jest.spyOn(phLogger, "event").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_limit",
+        endpoint: "/api/chat",
+      });
+      chatLogger.setRequestDetails({
+        mode: "agent",
+        isTemporary: false,
+        isRegenerate: false,
+      });
+      chatLogger.setUser({ id: "user_123", subscription: "pro" });
+      chatLogger.setRateLimit(
+        {
+          subscription: "pro",
+          monthly: { remaining: 0, limit: 250_000 },
+        },
+        undefined,
+      );
+
+      chatLogger.emitChatError(
+        new ChatSDKError("rate_limit:chat", "Monthly limit hit", {
+          capReason: "monthly_exhausted",
+          resetTimestamp: 1_800_000_000_000,
+        }),
+      );
+
+      expect(eventSpy).toHaveBeenCalledWith(
+        "limit_hit",
+        expect.objectContaining({
+          subscription_tier: "pro",
+          limit_type: "monthly",
+          cap_reason: "monthly_exhausted",
+          paid_monthly_exhaustion: true,
+          add_credit_available: true,
+          primary_cta: "add_credits",
+          eligible_ctas: ["add_credits", "upgrade_plan"],
+          chat_id: "chat_limit",
+        }),
+      );
+      expect(eventSpy).toHaveBeenCalledWith(
+        "monthly_cap_hit",
+        expect.objectContaining({
+          subscription: "pro",
+          cap_reason: "monthly_exhausted",
+          primary_cta: "add_credits",
+          eligible_ctas: ["add_credits", "upgrade_plan"],
+        }),
+      );
+    } finally {
+      eventSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+
+  it("does not emit monthly_cap_hit for paid billing service outages", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const eventSpy = jest.spyOn(phLogger, "event").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_billing_unavailable",
+        endpoint: "/api/chat",
+      });
+      chatLogger.setRequestDetails({
+        mode: "agent",
+        isTemporary: false,
+        isRegenerate: false,
+      });
+      chatLogger.setUser({ id: "user_123", subscription: "pro" });
+
+      chatLogger.emitChatError(
+        new ChatSDKError("rate_limit:chat", "Billing unavailable", {
+          capReason: "billing_unavailable",
+          resetTimestamp: 1_800_000_000_000,
+        }),
+      );
+
+      expect(eventSpy).toHaveBeenCalledWith(
+        "limit_hit",
+        expect.objectContaining({
+          cap_reason: "billing_unavailable",
+          limit_type: "billing",
+        }),
+      );
+      expect(eventSpy).not.toHaveBeenCalledWith(
+        "monthly_cap_hit",
+        expect.anything(),
+      );
+    } finally {
+      eventSpy.mockRestore();
       logSpy.mockRestore();
     }
   });

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -18,6 +18,7 @@ import type {
   SandboxInfo,
   SandboxBootInfo,
 } from "@/types";
+import { isSubscriptionTier } from "@/types";
 import type { ChatSDKError } from "@/lib/errors";
 import type { PostHog } from "posthog-node";
 import { after } from "next/server";
@@ -35,6 +36,12 @@ import {
   getProviderStatusCode,
   type ProviderErrorCategory,
 } from "@/lib/utils/error-utils";
+import {
+  getLimitPressureContext,
+  getLimitTypeForCapReason,
+  isPaidMonthlyCapHitReason,
+  type LimitCapReason,
+} from "@/lib/limit-pressure";
 
 export interface ChatLoggerConfig {
   chatId: string;
@@ -119,6 +126,15 @@ const COMPACT_CHAT_ERROR_METADATA_KEYS = [
   "max_tokens",
   "file_ids_count",
   "largest_file_token",
+  "capReason",
+  "limitType",
+  "costGuardrail",
+  "paidMonthlyExhaustion",
+  "upgradeAvailable",
+  "addCreditAvailable",
+  "primaryCta",
+  "eligibleCtas",
+  "resetTimestamp",
 ] as const;
 
 const compactChatErrorMetadata = (
@@ -455,13 +471,28 @@ export function createChatLogger(config: ChatLoggerConfig) {
 
       if (error.type === "rate_limit" && subscription) {
         const capReason =
-          (error.metadata?.capReason as string | undefined) ?? "unknown";
+          (error.metadata?.capReason as LimitCapReason | undefined) ??
+          "unknown";
         const resetTimestamp = error.metadata?.resetTimestamp as
           | number
           | undefined;
-        const limitType = capReason.includes("daily")
-          ? "daily_requests"
-          : "monthly";
+        const subscriptionTier = isSubscriptionTier(subscription)
+          ? subscription
+          : undefined;
+        const pressure = subscriptionTier
+          ? getLimitPressureContext({
+              subscription: subscriptionTier,
+              capReason,
+            })
+          : {
+              limitType: getLimitTypeForCapReason(capReason),
+              costGuardrail: false,
+              paidMonthlyExhaustion: false,
+              upgradeAvailable: false,
+              addCreditAvailable: false,
+              primaryCta: undefined,
+              eligibleCtas: [],
+            };
 
         phLogger.event(
           PAID_FUNNEL_EVENTS.limitHit,
@@ -469,10 +500,18 @@ export function createChatLogger(config: ChatLoggerConfig) {
             userId,
             subscription_tier: subscription,
             mode,
-            limit_type: limitType,
+            limit_type: pressure.limitType,
             cap_reason: capReason,
             monthly_remaining_percent: monthlyRemainingPercent,
             reset_timestamp: resetTimestamp,
+            cost_guardrail: pressure.costGuardrail,
+            paid_monthly_exhaustion: pressure.paidMonthlyExhaustion,
+            upgrade_available: pressure.upgradeAvailable,
+            add_credit_available: pressure.addCreditAvailable,
+            primary_cta: pressure.primaryCta,
+            eligible_ctas: pressure.eligibleCtas,
+            chat_id: config.chatId,
+            endpoint: config.endpoint,
             $set: {
               subscription_tier: subscription,
               last_limit_hit_at: new Date().toISOString(),
@@ -487,16 +526,26 @@ export function createChatLogger(config: ChatLoggerConfig) {
       if (
         error.type === "rate_limit" &&
         subscription &&
+        isSubscriptionTier(subscription) &&
         subscription !== "free"
       ) {
         const capReason =
-          (error.metadata?.capReason as string | undefined) ?? "unknown";
+          (error.metadata?.capReason as LimitCapReason | undefined) ??
+          "unknown";
+        if (!isPaidMonthlyCapHitReason(capReason)) return;
+        const pressure = getLimitPressureContext({
+          subscription,
+          capReason,
+        });
         phLogger.event("monthly_cap_hit", {
           userId,
           subscription,
           mode,
           cap_reason: capReason,
           monthly_remaining_percent: monthlyRemainingPercent,
+          cost_guardrail: pressure.costGuardrail,
+          primary_cta: pressure.primaryCta,
+          eligible_ctas: pressure.eligibleCtas,
           chat_id: config.chatId,
           endpoint: config.endpoint,
           $set: {

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -48,6 +48,7 @@ import { generateNotesSection } from "@/lib/system-prompt/notes";
 import { logger } from "@/lib/logger";
 import { UsageTracker } from "@/lib/usage-tracker";
 import { ChatSDKError } from "@/lib/errors";
+import type { LimitCapReason } from "@/lib/limit-pressure";
 import {
   getExtraUsageBalance,
   getTeamExtraUsageState,
@@ -179,6 +180,7 @@ export function sendRateLimitWarnings(
           monthlyLimitPoints: rateLimitInfo.monthly.limit,
           resetTime: rateLimitInfo.monthly.resetTime,
           subscription,
+          capReason: "monthly_near_limit",
         });
       }
     }
@@ -204,6 +206,8 @@ export interface TokenBucketEmitContext {
   midStream?: boolean;
   /** Set when the response was cut off because the bucket hit 0. */
   cutOff?: boolean;
+  /** Monetization/guardrail reason that should drive the client CTA. */
+  capReason?: LimitCapReason;
 }
 
 export function emitTokenBucketThresholdWarning(
@@ -223,6 +227,7 @@ export function emitTokenBucketThresholdWarning(
     usedDollars:
       Math.round((ctx.projectedUsedPoints / POINTS_PER_DOLLAR) * 100) / 100,
     limitDollars: ctx.monthlyLimitPoints / POINTS_PER_DOLLAR,
+    ...(ctx.capReason ? { capReason: ctx.capReason } : {}),
     ...(ctx.midStream ? { midStream: true } : {}),
     ...(ctx.cutOff ? { cutOff: true } : {}),
   });
@@ -945,6 +950,15 @@ export async function buildExtraUsageConfig(args: {
         hasBalance: state.balanceDollars > 0,
         balanceDollars: state.balanceDollars,
         autoReloadEnabled: state.autoReloadEnabled,
+        ...(state.monthlyCapDollars !== undefined && {
+          monthlyCapDollars: state.monthlyCapDollars,
+        }),
+        ...(state.monthlySpentDollars !== undefined && {
+          monthlySpentDollars: state.monthlySpentDollars,
+        }),
+        ...(state.monthlyRemainingDollars !== undefined && {
+          monthlyRemainingDollars: state.monthlyRemainingDollars,
+        }),
       };
     }
     return undefined;
@@ -967,6 +981,15 @@ export async function buildExtraUsageConfig(args: {
       hasBalance: balanceInfo.balanceDollars > 0,
       balanceDollars: balanceInfo.balanceDollars,
       autoReloadEnabled: balanceInfo.autoReloadEnabled,
+      ...(balanceInfo.monthlyCapDollars !== undefined && {
+        monthlyCapDollars: balanceInfo.monthlyCapDollars,
+      }),
+      ...(balanceInfo.monthlySpentDollars !== undefined && {
+        monthlySpentDollars: balanceInfo.monthlySpentDollars,
+      }),
+      ...(balanceInfo.monthlyRemainingDollars !== undefined && {
+        monthlyRemainingDollars: balanceInfo.monthlyRemainingDollars,
+      }),
     };
   }
   return undefined;

--- a/lib/chat/__tests__/budget-monitor.test.ts
+++ b/lib/chat/__tests__/budget-monitor.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import {
+  BudgetMonitor,
+  captureBudgetSnapshot,
+  type BudgetSnapshot,
+} from "../budget-monitor";
+import type { ExtraUsageConfig, RateLimitInfo } from "@/types";
+
+const makeWriter = () =>
+  ({
+    write: jest.fn(),
+  }) as any;
+
+const baseSnapshot: BudgetSnapshot = {
+  monthlyLimitPoints: 100,
+  monthlyRemainingAtStart: 10,
+  monthlyResetTime: new Date("2026-06-30T00:00:00.000Z"),
+  extraUsageBalanceAtStart: 100,
+  extraUsageAutoReload: true,
+};
+
+describe("BudgetMonitor", () => {
+  it("aborts with extra_usage_cap when overflow would exceed the monthly extra-usage cap", () => {
+    const writer = makeWriter();
+    const monitor = new BudgetMonitor(
+      {
+        ...baseSnapshot,
+        extraUsageMonthlyRemainingAtStart: 0,
+      },
+      writer,
+      "pro",
+    );
+
+    const decision = monitor.checkAfterStep(0.002);
+
+    expect(decision).toBe("abort");
+    expect(writer.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "data-rate-limit-warning",
+        data: expect.objectContaining({
+          warningType: "token-bucket",
+          cutOff: true,
+          capReason: "extra_usage_cap",
+        }),
+      }),
+    );
+  });
+
+  it("continues into extra usage when balance and monthly cap remaining cover overflow", () => {
+    const writer = makeWriter();
+    const monitor = new BudgetMonitor(
+      {
+        ...baseSnapshot,
+        extraUsageAutoReload: false,
+        extraUsageBalanceAtStart: 1,
+        extraUsageMonthlyRemainingAtStart: 1,
+      },
+      writer,
+      "pro",
+    );
+
+    const decision = monitor.checkAfterStep(0.002);
+
+    expect(decision).toBe("continue");
+    expect(writer.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "data-rate-limit-warning",
+        data: expect.objectContaining({
+          warningType: "extra-usage-active",
+          capReason: "extra_usage_active",
+        }),
+      }),
+    );
+  });
+});
+
+describe("captureBudgetSnapshot", () => {
+  it("includes monthly extra-usage remaining for mid-stream guardrails", () => {
+    const rateLimitInfo: RateLimitInfo = {
+      remaining: 10,
+      resetTime: new Date("2026-06-30T00:00:00.000Z"),
+      limit: 100,
+      monthly: {
+        remaining: 10,
+        limit: 100,
+        resetTime: new Date("2026-06-30T00:00:00.000Z"),
+      },
+    };
+    const extraUsageConfig: ExtraUsageConfig = {
+      enabled: true,
+      hasBalance: true,
+      balanceDollars: 25,
+      autoReloadEnabled: true,
+      monthlyRemainingDollars: 3,
+    };
+
+    expect(
+      captureBudgetSnapshot({
+        rateLimitInfo,
+        extraUsageConfig,
+        subscription: "pro",
+      }),
+    ).toMatchObject({
+      extraUsageBalanceAtStart: 25,
+      extraUsageAutoReload: true,
+      extraUsageMonthlyRemainingAtStart: 3,
+    });
+  });
+});

--- a/lib/chat/budget-monitor.ts
+++ b/lib/chat/budget-monitor.ts
@@ -12,6 +12,7 @@ import {
   type TokenBucketEmitContext,
 } from "@/lib/api/chat-stream-helpers";
 import { writeRateLimitWarning } from "@/lib/utils/stream-writer-utils";
+import type { LimitCapReason } from "@/lib/limit-pressure";
 
 // 50% is intentionally omitted: at the halfway mark there's no actionable
 // signal for the user, so an in-product banner is noise. The ladder matches
@@ -26,6 +27,7 @@ export interface BudgetSnapshot {
   monthlyResetTime: Date;
   extraUsageBalanceAtStart: number;
   extraUsageAutoReload: boolean;
+  extraUsageMonthlyRemainingAtStart?: number;
 }
 
 /**
@@ -55,6 +57,8 @@ export function captureBudgetSnapshot(args: {
     monthlyResetTime: monthlyResetTime!,
     extraUsageBalanceAtStart: extraUsageConfig?.balanceDollars ?? 0,
     extraUsageAutoReload: extraUsageConfig?.autoReloadEnabled ?? false,
+    extraUsageMonthlyRemainingAtStart:
+      extraUsageConfig?.monthlyRemainingDollars,
   };
 }
 
@@ -105,9 +109,15 @@ export class BudgetMonitor {
         const overflowDollars =
           Math.max(0, projectedUsedPoints - snapshot.monthlyLimitPoints) /
           POINTS_PER_DOLLAR;
-        const hasExtraCushion =
+        const guardrailRemaining = snapshot.extraUsageMonthlyRemainingAtStart;
+        const guardrailAllowsOverflow =
+          guardrailRemaining === undefined ||
+          overflowDollars <= guardrailRemaining;
+        const balanceAllowsOverflow =
           snapshot.extraUsageAutoReload ||
-          snapshot.extraUsageBalanceAtStart - overflowDollars > 0;
+          snapshot.extraUsageBalanceAtStart >= overflowDollars;
+        const hasExtraCushion =
+          guardrailAllowsOverflow && balanceAllowsOverflow;
 
         if (hasExtraCushion) {
           if (threshold <= this.highestThresholdEmitted) {
@@ -119,13 +129,21 @@ export class BudgetMonitor {
             bucketType: "monthly",
             resetTime: snapshot.monthlyResetTime.toISOString(),
             subscription: this.subscription,
+            capReason: "extra_usage_active",
             midStream: true,
           });
         } else {
+          const capReason: LimitCapReason =
+            this.subscription === "free"
+              ? "free_monthly_exhausted"
+              : !guardrailAllowsOverflow
+                ? "extra_usage_cap"
+                : "monthly_exhausted";
           this.emit({
             usedPercent: 100,
             projectedUsedPoints: snapshot.monthlyLimitPoints,
             cutOff: true,
+            capReason,
           });
           decision = "abort";
         }
@@ -145,6 +163,7 @@ export class BudgetMonitor {
     usedPercent: number;
     projectedUsedPoints: number;
     cutOff?: boolean;
+    capReason?: LimitCapReason;
   }): void {
     const ctx: TokenBucketEmitContext = {
       usedPercent: args.usedPercent,
@@ -154,6 +173,7 @@ export class BudgetMonitor {
       subscription: this.subscription,
       midStream: true,
       cutOff: args.cutOff,
+      capReason: args.capReason,
     };
     emitTokenBucketThresholdWarning(this.writer, ctx);
   }

--- a/lib/extra-usage.ts
+++ b/lib/extra-usage.ts
@@ -53,6 +53,9 @@ export interface ExtraUsageBalance {
   autoReloadThresholdDollars?: number;
   autoReloadThresholdPoints?: number;
   autoReloadAmountDollars?: number;
+  monthlyCapDollars?: number;
+  monthlySpentDollars?: number;
+  monthlyRemainingDollars?: number;
 }
 
 export interface DeductBalanceResult {
@@ -110,6 +113,9 @@ export async function getExtraUsageBalance(
       autoReloadThresholdDollars: settings.autoReloadThresholdDollars,
       autoReloadThresholdPoints: settings.autoReloadThresholdPoints,
       autoReloadAmountDollars: settings.autoReloadAmountDollars,
+      monthlyCapDollars: settings.monthlyCapDollars,
+      monthlySpentDollars: settings.monthlySpentDollars,
+      monthlyRemainingDollars: settings.monthlyRemainingDollars,
     };
   } catch (error) {
     logExtraUsageConvexFailure({
@@ -277,6 +283,11 @@ export interface TeamExtraUsageState {
   balancePoints: number;
   autoReloadEnabled: boolean;
   memberDisabled: boolean;
+  monthlyCapDollars?: number;
+  monthlySpentDollars?: number;
+  memberMonthlyLimitDollars?: number;
+  memberMonthlySpentDollars?: number;
+  monthlyRemainingDollars?: number;
 }
 
 /**
@@ -304,6 +315,11 @@ export async function getTeamExtraUsageState(
       balancePoints: state.balancePoints,
       autoReloadEnabled: state.autoReloadEnabled,
       memberDisabled: state.memberDisabled,
+      monthlyCapDollars: state.monthlyCapDollars,
+      monthlySpentDollars: state.monthlySpentDollars,
+      memberMonthlyLimitDollars: state.memberMonthlyLimitDollars,
+      memberMonthlySpentDollars: state.memberMonthlySpentDollars,
+      monthlyRemainingDollars: state.monthlyRemainingDollars,
     };
   } catch (error) {
     logExtraUsageConvexFailure({

--- a/lib/limit-pressure.ts
+++ b/lib/limit-pressure.ts
@@ -1,0 +1,196 @@
+import type { SubscriptionTier } from "@/types";
+
+export type LimitCapReason =
+  | "daily_requests_exhausted"
+  | "free_monthly_exhausted"
+  | "monthly_exhausted"
+  | "extra_usage_cap"
+  | "team_member_cap"
+  | "team_member_disabled"
+  | "team_pool_disabled"
+  | "auto_reload_failed"
+  | "billing_unavailable"
+  | "monthly_near_limit"
+  | "extra_usage_active"
+  | (string & {});
+
+export type LimitType =
+  | "daily_requests"
+  | "free_monthly"
+  | "monthly"
+  | "extra_usage"
+  | "team_extra_usage"
+  | "billing";
+
+export type LimitCta =
+  | "upgrade_plan"
+  | "add_credits"
+  | "increase_spending_limit"
+  | "update_payment_method"
+  | "open_team_extra_usage";
+
+export type ExtraUsageLimitCta = {
+  label: string;
+  analyticsText: string;
+  settingsTab: "Extra Usage" | "Usage";
+};
+
+const UPGRADABLE_TIERS = new Set<SubscriptionTier>(["free", "pro", "pro-plus"]);
+
+const DIRECT_EXTRA_USAGE_REASONS = new Set<string>([
+  "monthly_exhausted",
+  "monthly_near_limit",
+]);
+
+const MONTHLY_CAP_HIT_REASONS = new Set<string>([
+  "monthly_exhausted",
+  "extra_usage_cap",
+  "team_member_cap",
+]);
+
+const COST_GUARDRAIL_REASONS = new Set<string>([
+  "extra_usage_cap",
+  "team_member_cap",
+  "team_member_disabled",
+  "team_pool_disabled",
+  "auto_reload_failed",
+]);
+
+export function getLimitTypeForCapReason(
+  capReason: LimitCapReason | undefined,
+): LimitType {
+  if (!capReason) return "monthly";
+  if (capReason.includes("daily")) return "daily_requests";
+  if (capReason === "free_monthly_exhausted") return "free_monthly";
+  if (
+    capReason === "team_member_cap" ||
+    capReason === "team_member_disabled" ||
+    capReason === "team_pool_disabled"
+  ) {
+    return "team_extra_usage";
+  }
+  if (
+    capReason === "extra_usage_cap" ||
+    capReason === "auto_reload_failed" ||
+    capReason === "extra_usage_active"
+  ) {
+    return "extra_usage";
+  }
+  if (capReason === "billing_unavailable") return "billing";
+  return "monthly";
+}
+
+export function isCostGuardrailCapReason(
+  capReason: LimitCapReason | undefined,
+): boolean {
+  return !!capReason && COST_GUARDRAIL_REASONS.has(capReason);
+}
+
+export function isPaidMonthlyCapHitReason(
+  capReason: LimitCapReason | undefined,
+): boolean {
+  return !!capReason && MONTHLY_CAP_HIT_REASONS.has(capReason);
+}
+
+export function isPaidMonthlyExhaustionReason(
+  capReason: LimitCapReason | undefined,
+): boolean {
+  return capReason === "monthly_exhausted";
+}
+
+export function shouldShowUpgradeCta(args: {
+  subscription: SubscriptionTier;
+  capReason?: LimitCapReason;
+}): boolean {
+  const { subscription, capReason } = args;
+  if (!UPGRADABLE_TIERS.has(subscription)) return false;
+  if (subscription === "free") return true;
+
+  return !capReason || DIRECT_EXTRA_USAGE_REASONS.has(capReason);
+}
+
+export function getExtraUsageLimitCta(args: {
+  subscription: SubscriptionTier;
+  capReason?: LimitCapReason;
+}): ExtraUsageLimitCta | null {
+  const { subscription, capReason } = args;
+  if (subscription === "free") return null;
+
+  if (capReason === "extra_usage_cap") {
+    return {
+      label: "Increase Limit",
+      analyticsText: "Increase Limit",
+      settingsTab: "Extra Usage",
+    };
+  }
+
+  if (capReason === "auto_reload_failed") {
+    return {
+      label: "Update Payment",
+      analyticsText: "Update Payment",
+      settingsTab: "Extra Usage",
+    };
+  }
+
+  if (capReason === "team_pool_disabled") {
+    return {
+      label: "Team Usage",
+      analyticsText: "Open Team Usage",
+      settingsTab: "Extra Usage",
+    };
+  }
+
+  if (capReason === "team_member_cap" || capReason === "team_member_disabled") {
+    return null;
+  }
+
+  if (capReason === "billing_unavailable") {
+    return null;
+  }
+
+  return {
+    label: "Add Credits",
+    analyticsText: "Add Credits",
+    settingsTab: "Extra Usage",
+  };
+}
+
+export function getEligibleLimitCtas(args: {
+  subscription: SubscriptionTier;
+  capReason?: LimitCapReason;
+}): LimitCta[] {
+  const ctas: LimitCta[] = [];
+  const extraUsageCta = getExtraUsageLimitCta(args);
+  if (extraUsageCta?.analyticsText === "Add Credits") {
+    ctas.push("add_credits");
+  } else if (extraUsageCta?.analyticsText === "Increase Limit") {
+    ctas.push("increase_spending_limit");
+  } else if (extraUsageCta?.analyticsText === "Update Payment") {
+    ctas.push("update_payment_method");
+  } else if (extraUsageCta?.analyticsText === "Open Team Usage") {
+    ctas.push("open_team_extra_usage");
+  }
+
+  if (shouldShowUpgradeCta(args)) ctas.push("upgrade_plan");
+
+  return ctas;
+}
+
+export function getLimitPressureContext(args: {
+  subscription: SubscriptionTier;
+  capReason?: LimitCapReason;
+}) {
+  const { subscription, capReason } = args;
+  const eligibleCtas = getEligibleLimitCtas(args);
+
+  return {
+    limitType: getLimitTypeForCapReason(capReason),
+    costGuardrail: isCostGuardrailCapReason(capReason),
+    paidMonthlyExhaustion:
+      subscription !== "free" && isPaidMonthlyExhaustionReason(capReason),
+    upgradeAvailable: eligibleCtas.includes("upgrade_plan"),
+    addCreditAvailable: eligibleCtas.includes("add_credits"),
+    primaryCta: eligibleCtas[0],
+    eligibleCtas,
+  };
+}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -52,6 +52,9 @@ export interface ChatWideEvent {
     enabled?: boolean;
     has_balance?: boolean;
     balance_dollars?: number;
+    monthly_cap_dollars?: number;
+    monthly_spent_dollars?: number;
+    monthly_remaining_dollars?: number;
     auto_reload_enabled?: boolean;
   };
 
@@ -290,6 +293,9 @@ export class WideEventBuilder {
         enabled: config.enabled,
         has_balance: config.hasBalance,
         balance_dollars: config.balanceDollars,
+        monthly_cap_dollars: config.monthlyCapDollars,
+        monthly_spent_dollars: config.monthlySpentDollars,
+        monthly_remaining_dollars: config.monthlyRemainingDollars,
         auto_reload_enabled: config.autoReloadEnabled,
       };
     }

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -173,6 +173,13 @@ describe("token-bucket async functions", () => {
         expect.fail("Should have thrown");
       } catch (error: any) {
         expect(error.cause).toContain("usage limit");
+        expect(error.metadata).toMatchObject({
+          capReason: "monthly_exhausted",
+          paidMonthlyExhaustion: true,
+          addCreditAvailable: true,
+          primaryCta: "add_credits",
+          eligibleCtas: ["add_credits", "upgrade_plan"],
+        });
       }
     });
 
@@ -258,6 +265,13 @@ describe("token-bucket async functions", () => {
         expect.fail("Should have thrown");
       } catch (error: any) {
         expect(error.cause).toContain("monthly extra usage spending limit");
+        expect(error.metadata).toMatchObject({
+          capReason: "extra_usage_cap",
+          costGuardrail: true,
+          addCreditAvailable: false,
+          primaryCta: "increase_spending_limit",
+          eligibleCtas: ["increase_spending_limit"],
+        });
       }
     });
 

--- a/lib/rate-limit/free-monthly-cost.ts
+++ b/lib/rate-limit/free-monthly-cost.ts
@@ -2,6 +2,7 @@ import { ChatSDKError } from "@/lib/errors";
 import { getFreeMonthlyCostLimitDollars } from "./free-config";
 import { POINTS_PER_DOLLAR } from "./token-bucket";
 import { createRedisClient } from "./redis";
+import { getLimitPressureContext } from "@/lib/limit-pressure";
 
 const RECORD_FREE_MONTHLY_COST_SCRIPT = `
 local key = KEYS[1]
@@ -93,6 +94,10 @@ export async function checkFreeMonthlyCostLimit(
       resetTimestamp: reset,
       subscription: "free",
       capReason: "free_monthly_exhausted",
+      ...getLimitPressureContext({
+        subscription: "free",
+        capReason: "free_monthly_exhausted",
+      }),
     });
   }
 

--- a/lib/rate-limit/sliding-window.ts
+++ b/lib/rate-limit/sliding-window.ts
@@ -7,6 +7,7 @@
 
 import { ChatSDKError } from "@/lib/errors";
 import type { RateLimitInfo } from "@/types";
+import { getLimitPressureContext } from "@/lib/limit-pressure";
 import {
   FREE_AGENT_REQUEST_COST,
   FREE_ASK_REQUEST_COST,
@@ -220,6 +221,10 @@ export const checkFreeUserRateLimit = async (
           resetTimestamp: reset,
           subscription: "free",
           capReason: "daily_requests_exhausted",
+          ...getLimitPressureContext({
+            subscription: "free",
+            capReason: "daily_requests_exhausted",
+          }),
         },
       );
     }

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -13,6 +13,10 @@ import {
   refundToTeamBalance,
 } from "@/lib/extra-usage";
 import { getSuspensionMessage } from "@/lib/suspensionMessage";
+import {
+  getLimitPressureContext,
+  type LimitCapReason,
+} from "@/lib/limit-pressure";
 
 // =============================================================================
 // Configuration
@@ -229,17 +233,32 @@ export const checkTokenBucketLimit = async (
         : subscription === "pro-plus"
           ? " or upgrade to Ultra for higher limits"
           : "";
+    const continueWithCreditsHint =
+      subscription === "team"
+        ? "Ask your team admin to add team extra usage credits to keep going now."
+        : `To keep going now, add extra usage credits in Settings${upgradeHint}.`;
+    const emptyCreditsHint =
+      subscription === "team"
+        ? "your team's extra usage balance is empty"
+        : "your extra usage balance is empty";
+    const limitMetadata = (
+      reset: number,
+      capReason: LimitCapReason,
+      extra: Record<string, unknown> = {},
+    ) => ({
+      resetTimestamp: reset,
+      subscription,
+      capReason,
+      ...getLimitPressureContext({ subscription, capReason }),
+      ...extra,
+    });
 
     const monthlyLimitError = (reset: number) => {
       const resetTime = formatTimeRemaining(new Date(reset));
       return new ChatSDKError(
         "rate_limit:chat",
-        `You've hit your monthly usage limit.\n\nYour limit resets ${resetTime}. To keep going now, add extra usage credits in Settings${upgradeHint}.`,
-        {
-          resetTimestamp: reset,
-          subscription,
-          capReason: "monthly_exhausted",
-        },
+        `You've hit your monthly usage limit.\n\nYour limit resets ${resetTime}. ${continueWithCreditsHint}`,
+        limitMetadata(reset, "monthly_exhausted"),
       );
     };
 
@@ -323,40 +342,40 @@ export const checkTokenBucketLimit = async (
           // Team-pool specific: admin disabled this member's pool access.
           if (deductResult.memberDisabled) {
             const msg = `Your team admin has paused your access to team extra usage. Ask them to re-enable it to continue beyond your subscription limit.`;
-            throw new ChatSDKError("rate_limit:chat", msg, {
-              resetTimestamp: monthlyCheck.reset,
-              subscription,
-              capReason: "team_member_disabled",
-            });
+            throw new ChatSDKError(
+              "rate_limit:chat",
+              msg,
+              limitMetadata(monthlyCheck.reset, "team_member_disabled"),
+            );
           }
 
           // Team-pool specific: admin disabled the pool entirely.
           if (deductResult.poolDisabled) {
             const msg = `Your team's extra usage pool is disabled.\n\nYour subscription limit resets ${resetTime}. Ask your team admin to enable team extra usage to continue.`;
-            throw new ChatSDKError("rate_limit:chat", msg, {
-              resetTimestamp: monthlyCheck.reset,
-              subscription,
-              capReason: "team_pool_disabled",
-            });
+            throw new ChatSDKError(
+              "rate_limit:chat",
+              msg,
+              limitMetadata(monthlyCheck.reset, "team_pool_disabled"),
+            );
           }
 
           // Team-pool specific: this member hit their per-member monthly cap.
           if (deductResult.memberCapExceeded) {
             const msg = `You've hit your team-set monthly spending limit.\n\nYour limit resets ${resetTime}. Ask your team admin to raise your limit to continue.`;
-            throw new ChatSDKError("rate_limit:chat", msg, {
-              resetTimestamp: monthlyCheck.reset,
-              subscription,
-              capReason: "team_member_cap",
-            });
+            throw new ChatSDKError(
+              "rate_limit:chat",
+              msg,
+              limitMetadata(monthlyCheck.reset, "team_member_cap"),
+            );
           }
 
           if (deductResult.monthlyCapExceeded) {
             const msg = `You've hit your monthly extra usage spending limit.\n\nYour limit resets ${resetTime}. To keep going now, increase your spending limit in Settings.`;
-            throw new ChatSDKError("rate_limit:chat", msg, {
-              resetTimestamp: monthlyCheck.reset,
-              subscription,
-              capReason: "extra_usage_cap",
-            });
+            throw new ChatSDKError(
+              "rate_limit:chat",
+              msg,
+              limitMetadata(monthlyCheck.reset, "extra_usage_cap"),
+            );
           }
 
           // If we tried auto-reload and Stripe declined the card, give the
@@ -379,20 +398,19 @@ export const checkTokenBucketLimit = async (
                 ? getSuspensionMessage(null)
                 : `Auto-reload couldn't charge your card (${reason}). Update your payment method in Settings, then try again.`;
             throw new ChatSDKError("rate_limit:chat", msg, {
-              resetTimestamp: monthlyCheck.reset,
-              subscription,
-              autoReloadFailed: true,
-              autoReloadFailureReason: reason,
-              capReason: "auto_reload_failed",
+              ...limitMetadata(monthlyCheck.reset, "auto_reload_failed", {
+                autoReloadFailed: true,
+                autoReloadFailureReason: reason,
+              }),
             });
           }
 
-          const msg = `You've hit your usage limit and your extra usage balance is empty.\n\nYour limit resets ${resetTime}. To keep going now, add credits in Settings${upgradeHint}.`;
-          throw new ChatSDKError("rate_limit:chat", msg, {
-            resetTimestamp: monthlyCheck.reset,
-            subscription,
-            capReason: "monthly_exhausted",
-          });
+          const msg = `You've hit your usage limit and ${emptyCreditsHint}.\n\nYour limit resets ${resetTime}. ${continueWithCreditsHint}`;
+          throw new ChatSDKError(
+            "rate_limit:chat",
+            msg,
+            limitMetadata(monthlyCheck.reset, "monthly_exhausted"),
+          );
         }
 
         // Deduction failed for a service reason (not insufficient funds) —
@@ -400,22 +418,18 @@ export const checkTokenBucketLimit = async (
         throw new ChatSDKError(
           "rate_limit:chat",
           "Extra usage billing is temporarily unavailable. Please try again in a few moments.",
-          {
-            resetTimestamp: monthlyCheck.reset,
-            subscription,
-            capReason: "billing_unavailable",
-          },
+          limitMetadata(monthlyCheck.reset, "billing_unavailable"),
         );
       }
 
       // No extra usage enabled - throw standard rate limit error
       const resetTime = formatTimeRemaining(new Date(monthlyCheck.reset));
-      const msg = `You've hit your monthly usage limit.\n\nYour limit resets ${resetTime}. To keep going now, add extra usage credits in Settings${upgradeHint}.`;
-      throw new ChatSDKError("rate_limit:chat", msg, {
-        resetTimestamp: monthlyCheck.reset,
-        subscription,
-        capReason: "monthly_exhausted",
-      });
+      const msg = `You've hit your monthly usage limit.\n\nYour limit resets ${resetTime}. ${continueWithCreditsHint}`;
+      throw new ChatSDKError(
+        "rate_limit:chat",
+        msg,
+        limitMetadata(monthlyCheck.reset, "monthly_exhausted"),
+      );
     }
 
     // Step 3: Have capacity, deduct from monthly bucket

--- a/lib/utils/parse-rate-limit-warning.ts
+++ b/lib/utils/parse-rate-limit-warning.ts
@@ -1,5 +1,6 @@
 import type { RateLimitWarningData } from "@/app/components/RateLimitWarning";
 import { isChatMode, isSubscriptionTier } from "@/types/chat";
+import type { LimitCapReason } from "@/lib/limit-pressure";
 
 const WARNING_TYPES = [
   "sliding-window",
@@ -83,6 +84,10 @@ export function parseRateLimitWarning(
   }
 
   const midStream = rawData.midStream === true;
+  const capReason =
+    isString(rawData.capReason) && rawData.capReason.length > 0
+      ? (rawData.capReason as LimitCapReason)
+      : undefined;
 
   if (warningType === "extra-usage-active") {
     const bucketType = rawData.bucketType as RawBucketType | undefined;
@@ -98,6 +103,7 @@ export function parseRateLimitWarning(
         bucketType,
         resetTime,
         subscription,
+        ...(capReason && { capReason }),
         midStream: true,
       };
     }
@@ -107,6 +113,7 @@ export function parseRateLimitWarning(
         bucketType,
         resetTime,
         subscription,
+        ...(capReason && { capReason }),
       };
     }
     const storageKey = `${EXTRA_USAGE_STORAGE_KEY_PREFIX}${bucketType}`;
@@ -120,6 +127,7 @@ export function parseRateLimitWarning(
       bucketType,
       resetTime,
       subscription,
+      ...(capReason && { capReason }),
     };
   }
 
@@ -183,6 +191,7 @@ export function parseRateLimitWarning(
     ...(severity && { severity }),
     ...(usedDollars !== undefined && { usedDollars }),
     ...(limitDollars !== undefined && { limitDollars }),
+    ...(capReason && { capReason }),
     ...(midStream && { midStream: true }),
     ...(cutOff && { cutOff: true }),
   };

--- a/lib/utils/stream-writer-utils.ts
+++ b/lib/utils/stream-writer-utils.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { UIMessagePart, UIMessageStreamWriter } from "ai";
 import type { ChatMode, SubscriptionTier } from "@/types";
+import type { LimitCapReason } from "@/lib/limit-pressure";
 
 // Upload status notifications
 export const writeUploadStartStatus = (
@@ -112,6 +113,7 @@ export type RateLimitWarningData =
       severity?: "info" | "warning";
       usedDollars?: number;
       limitDollars?: number;
+      capReason?: LimitCapReason;
       // Mid-stream emits bypass localStorage dedup so threshold escalations
       // (50→80→95→100) within a single stream always reach the client.
       midStream?: boolean;
@@ -124,6 +126,7 @@ export type RateLimitWarningData =
       bucketType: "monthly";
       resetTime: string;
       subscription: SubscriptionTier;
+      capReason?: LimitCapReason;
       midStream?: boolean;
     };
 

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -339,6 +339,12 @@ export interface ExtraUsageConfig {
   hasBalance?: boolean;
   /** Current balance in dollars (for UI display) */
   balanceDollars?: number;
+  /** Optional monthly extra-usage spending cap in dollars */
+  monthlyCapDollars?: number;
+  /** Extra-usage spend already consumed in the current month */
+  monthlySpentDollars?: number;
+  /** Remaining extra-usage spend allowed by the monthly cap */
+  monthlyRemainingDollars?: number;
   /** Whether auto-reload is enabled (can use extra usage even with $0 balance) */
   autoReloadEnabled?: boolean;
 }


### PR DESCRIPTION
## Summary

Implements the HAC-8 monetization and paid-cap handling layer before any automatic cheap-model fallback.

- Adds a shared limit-pressure policy for cap reasons, CTA selection, and analytics-safe context.
- Routes paid monthly exhaustion to add-credit flow, with plan upgrades still available for Pro and Pro Plus.
- Surfaces guardrail-specific actions such as increasing extra-usage limits or opening team usage settings instead of showing misleading add-credit buttons.
- Exposes personal/team extra-usage monthly cap remaining to runtime budget checks and enforces those caps mid-stream.
- Enriches `limit_hit` and narrows legacy `monthly_cap_hit` to true paid monthly cap blockers.

## Why

HAC-8 needs clean upgrade/add-credit and cost-guardrail handling before trying automatic cheap-model fallback. This gives us the monetization rails and measurement baseline so fallback can be evaluated without hiding revenue intent or overrunning user/admin spending caps.

## Validation

- `pnpm test -- lib/__tests__/limit-pressure.test.ts lib/chat/__tests__/budget-monitor.test.ts lib/api/__tests__/build-extra-usage-config.test.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts lib/api/__tests__/chat-logger.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings only)
- Commit hook also ran full `pnpm typecheck` and full `pnpm test` successfully: 126 suites, 1402 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monthly spending guardrails for extra usage limits with cap and remaining balance tracking.
  * Enhanced rate-limit error messaging with dynamic Call-To-Action guidance based on subscription tier and limit scenario.

* **Improvements**
  * Enriched analytics events with cap reason and CTA data for better monetization insights.
  * Improved Call-To-Action availability logic for upgrade and add-credits buttons based on subscription and limit context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->