### PR TITLE
[codex] Improve provider content block UX

### DIFF
--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -41,10 +41,9 @@ export const MessageErrorState = ({
   onRetry,
   onReconnect,
 }: MessageErrorStateProps) => {
-  const { subscription } = useGlobalState();
+  const { subscription, initializeNewChat } = useGlobalState();
   const isRateLimitError =
     error instanceof ChatSDKError && error.type === "rate_limit";
-  const canReconnect = !!onReconnect && isNetworkStreamError(error);
 
   const metadata = error instanceof ChatSDKError ? error.metadata : undefined;
   const resetTimestamp = metadata?.resetTimestamp as number | undefined;
@@ -74,6 +73,13 @@ export const MessageErrorState = ({
     }
     return error.message || "An error occurred.";
   })();
+  const isProviderContentBlocked =
+    metadata?.providerErrorCategory === "content_blocked" ||
+    /provider blocked this request|flagged by its safety system|PROHIBITED_CONTENT|content[_ -]?filter|content[_ -]?policy/i.test(
+      errorMessage,
+    );
+  const canReconnect =
+    !isProviderContentBlocked && !!onReconnect && isNetworkStreamError(error);
 
   const isPaidUser = subscription !== "free";
   const canUpgrade = shouldShowUpgradeCta({ subscription, capReason });
@@ -115,10 +121,29 @@ export const MessageErrorState = ({
   }, [capReason, extraUsageCta, isPaidUser, isRateLimitError, subscription]);
 
   return (
-    <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3">
-      <div className="text-destructive text-sm mb-2">
+    <div
+      className={
+        isProviderContentBlocked
+          ? "bg-amber-500/10 border border-amber-500/25 rounded-lg p-3"
+          : "bg-destructive/10 border border-destructive/20 rounded-lg p-3"
+      }
+    >
+      <div
+        className={
+          isProviderContentBlocked
+            ? "text-foreground text-sm mb-2"
+            : "text-destructive text-sm mb-2"
+        }
+      >
         {isRateLimitError ? (
           <MemoizedMarkdown content={errorMessage} />
+        ) : isProviderContentBlocked ? (
+          <>
+            <p>{errorMessage}</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              Retrying with the same conversation usually fails again.
+            </p>
+          </>
         ) : (
           <p>{errorMessage}</p>
         )}
@@ -184,6 +209,10 @@ export const MessageErrorState = ({
               </Button>
             )}
           </>
+        ) : isProviderContentBlocked ? (
+          <Button variant="outline" size="sm" onClick={initializeNewChat}>
+            New Chat
+          </Button>
         ) : (
           <>
             {isSuspensionError ? (

--- a/app/components/__tests__/MessageErrorState.test.tsx
+++ b/app/components/__tests__/MessageErrorState.test.tsx
@@ -1,0 +1,68 @@
+import "@testing-library/jest-dom";
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ChatSDKError } from "@/lib/errors";
+import { TestWrapper } from "../testUtils";
+
+jest.mock("@/lib/analytics/client", () => ({
+  captureAddCreditCtaClick: jest.fn(),
+  captureAddCreditCtaImpression: jest.fn(),
+  captureUpgradeCtaImpression: jest.fn(),
+}));
+
+import { MessageErrorState } from "../MessageErrorState";
+
+describe("MessageErrorState", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not offer same-payload retry for provider content blocks", () => {
+    const error = new ChatSDKError(
+      "forbidden:stream",
+      "The model provider blocked this request because the conversation content was flagged by its safety system. Edit your last message or remove sensitive or raw tool output, then try again.",
+      {
+        providerErrorCategory: "content_blocked",
+        providerStatusCode: 403,
+        providerErrorRetriable: false,
+      },
+    );
+
+    render(
+      <TestWrapper>
+        <MessageErrorState
+          error={error}
+          onRetry={jest.fn()}
+          onReconnect={jest.fn()}
+        />
+      </TestWrapper>,
+    );
+
+    expect(
+      screen.getByText(/flagged by its safety system/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Retrying with the same conversation/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^retry$/i })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /new chat/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps retry available for ordinary errors", () => {
+    const onRetry = jest.fn();
+
+    render(
+      <TestWrapper>
+        <MessageErrorState
+          error={new Error("Network broke")}
+          onRetry={onRetry}
+        />
+      </TestWrapper>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^retry$/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -320,6 +320,46 @@ describe("captureUsageCost", () => {
 });
 
 describe("createChatLogger provider stream termination", () => {
+  it("logs provider safety blocks as non-retryable content blocks", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_content_blocked",
+        endpoint: "/api/chat",
+      });
+      const err = Object.assign(new Error("PROHIBITED_CONTENT"), {
+        statusCode: 403,
+      });
+
+      chatLogger.recordProviderError(err, {
+        mode: "ask",
+        model: "ask-model-free",
+        requestedModelSlug: "deepseek/deepseek-v4-flash",
+      });
+      chatLogger.emitUnexpectedError(err);
+
+      const errorOutput = errorSpy.mock.calls.flat().map(String).join("\n");
+      const wideEvent = JSON.parse(String(logSpy.mock.calls[0][0]));
+
+      expect(errorOutput).toContain("Provider content blocked");
+      expect(errorOutput).toContain("provider_content_blocked");
+      expect(wideEvent.error).toMatchObject({
+        type: "ProviderContentBlocked",
+        retriable: false,
+      });
+      expect(wideEvent.provider_error).toMatchObject({
+        category: "content_blocked",
+        status_code: 403,
+        retriable: false,
+      });
+    } finally {
+      errorSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+
   it("logs terminated provider streams as warnings and suppresses duplicate unexpected route errors", () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -105,7 +105,10 @@ import { getMaxStepsForUser } from "@/lib/chat/chat-processor";
 import { phLogger } from "@/lib/posthog/server";
 import {
   extractErrorDetails,
+  getProviderErrorCategory,
+  getProviderStatusCode,
   getUserFriendlyProviderError,
+  isProviderContentBlockedError,
 } from "@/lib/utils/error-utils";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import {
@@ -846,7 +849,12 @@ export const createChatHandler = () => {
                       );
 
                       // Retry with fallback model if not already retrying (only for auto models)
-                      if (!isRetryWithFallback && !isAborted && isAutoModel) {
+                      if (
+                        !isRetryWithFallback &&
+                        !isAborted &&
+                        isAutoModel &&
+                        !isProviderContentBlockedError(state.providerError)
+                      ) {
                         isRetryWithFallback = true;
                         state.lastStepInputTokens = 0;
                         state.stoppedDueToTokenExhaustion = false;
@@ -1520,9 +1528,22 @@ export const createChatHandler = () => {
       // Handle unexpected errors (provider failures, etc.)
       chatLogger?.emitUnexpectedError(error);
 
+      const providerDetails = extractErrorDetails(error);
+      const providerErrorCategory = getProviderErrorCategory(providerDetails);
+      const providerStatusCode = getProviderStatusCode(providerDetails);
+      const isContentBlocked = providerErrorCategory === "content_blocked";
       const unexpectedError = new ChatSDKError(
-        "bad_request:stream",
+        isContentBlocked ? "forbidden:stream" : "bad_request:stream",
         getUserFriendlyProviderError(error),
+        {
+          providerErrorCategory,
+          providerStatusCode,
+          providerErrorRetriable:
+            providerErrorCategory === "rate_limited" ||
+            providerErrorCategory === "provider_5xx" ||
+            providerErrorCategory === "stream_terminated" ||
+            providerErrorCategory === "timeout",
+        },
       );
       return unexpectedError.toResponse();
     }

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -108,7 +108,6 @@ import {
   getProviderErrorCategory,
   getProviderStatusCode,
   getUserFriendlyProviderError,
-  isProviderContentBlockedError,
 } from "@/lib/utils/error-utils";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import {
@@ -849,12 +848,7 @@ export const createChatHandler = () => {
                       );
 
                       // Retry with fallback model if not already retrying (only for auto models)
-                      if (
-                        !isRetryWithFallback &&
-                        !isAborted &&
-                        isAutoModel &&
-                        !isProviderContentBlockedError(state.providerError)
-                      ) {
+                      if (!isRetryWithFallback && !isAborted && isAutoModel) {
                         isRetryWithFallback = true;
                         state.lastStepInputTokens = 0;
                         state.stoppedDueToTokenExhaustion = false;

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -140,6 +140,9 @@ const COMPACT_CHAT_ERROR_METADATA_KEYS = [
   "primaryCta",
   "eligibleCtas",
   "resetTimestamp",
+  "providerErrorCategory",
+  "providerStatusCode",
+  "providerErrorRetriable",
 ] as const;
 
 const compactChatErrorMetadata = (
@@ -157,20 +160,25 @@ const compactChatErrorMetadata = (
 };
 
 const providerErrorEventName = (category: ProviderErrorCategory): string =>
-  category === "stream_terminated"
-    ? "provider_stream_terminated"
-    : "provider_streaming_error";
+  category === "content_blocked"
+    ? "provider_content_blocked"
+    : category === "stream_terminated"
+      ? "provider_stream_terminated"
+      : "provider_streaming_error";
 
 const providerErrorMessage = (category: ProviderErrorCategory): string =>
-  category === "stream_terminated"
-    ? "Provider stream terminated"
-    : category === "timeout"
-      ? "Provider stream timeout"
-      : "Provider streaming error";
+  category === "content_blocked"
+    ? "Provider content blocked"
+    : category === "stream_terminated"
+      ? "Provider stream terminated"
+      : category === "timeout"
+        ? "Provider stream timeout"
+        : "Provider streaming error";
 
 const providerWideErrorType = (
   category: ProviderErrorCategory | undefined,
 ): string => {
+  if (category === "content_blocked") return "ProviderContentBlocked";
   if (category === "stream_terminated") return "ProviderStreamTerminated";
   if (category === "timeout") return "ProviderTimeout";
   if (category) return "ProviderError";
@@ -463,7 +471,10 @@ export function createChatLogger(config: ChatLoggerConfig) {
         url: details.providerUrl as string | undefined,
         reason: (error as { reason?: string })?.reason,
         message: getProviderDiagnosticMessage(details),
-        retriable: details.isRetryable as boolean | undefined,
+        retriable:
+          typeof details.isRetryable === "boolean"
+            ? details.isRetryable
+            : isRetriableProviderCategory(category),
         attempts,
       });
     },

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -109,6 +109,8 @@ export function getMessageByErrorCode(errorCode: ErrorCode): string {
 
     case "bad_request:stream":
       return "The model provider returned an error.";
+    case "forbidden:stream":
+      return "The model provider blocked this request.";
 
     case "not_found:document":
       return "The requested document was not found. Please check the document ID and try again.";

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -387,6 +387,30 @@ describe("provider error classification", () => {
     expect(isProviderContentBlockedError(err)).toBe(false);
   });
 
+  it("classifies explicit content policy block messages", () => {
+    const err = apiCallError({
+      statusCode: 403,
+      message: "Request was rejected for a safety policy violation.",
+    });
+
+    expect(getProviderErrorCategory(extractErrorDetails(err))).toBe(
+      "content_blocked",
+    );
+    expect(isProviderContentBlockedError(err)).toBe(true);
+  });
+
+  it("does not classify moderation service failures as content blocks", () => {
+    const err = apiCallError({
+      statusCode: 503,
+      message: "moderation service unavailable",
+    });
+
+    expect(getProviderErrorCategory(extractErrorDetails(err))).toBe(
+      "provider_5xx",
+    );
+    expect(isProviderContentBlockedError(err)).toBe(false);
+  });
+
   it("classifies provider-specific messages when the top-level message is generic", () => {
     const err = apiCallError({
       statusCode: undefined,

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from "@jest/globals";
 import {
   extractErrorDetails,
   extractRetryAttempts,
+  getUserFriendlyProviderError,
   getProviderErrorCategory,
   getProviderStatusCode,
+  isProviderContentBlockedError,
   isProviderStreamTerminatedError,
 } from "../error-utils";
 
@@ -356,6 +358,33 @@ describe("provider error classification", () => {
     const details = extractErrorDetails(err);
     expect(getProviderStatusCode(details)).toBe(502);
     expect(getProviderErrorCategory(details)).toBe("provider_5xx");
+  });
+
+  it("classifies provider safety blocks separately from generic 403s", () => {
+    const err = apiCallError({
+      statusCode: 403,
+      message: "PROHIBITED_CONTENT",
+    });
+
+    expect(getProviderErrorCategory(extractErrorDetails(err))).toBe(
+      "content_blocked",
+    );
+    expect(isProviderContentBlockedError(err)).toBe(true);
+    expect(getUserFriendlyProviderError(err)).toBe(
+      "The model provider blocked this request because the conversation content was flagged by its safety system. Edit your last message or remove sensitive or raw tool output, then try again.",
+    );
+  });
+
+  it("keeps non-safety 403s as provider 4xx errors", () => {
+    const err = apiCallError({
+      statusCode: 403,
+      message: "Access denied for this model",
+    });
+
+    expect(getProviderErrorCategory(extractErrorDetails(err))).toBe(
+      "provider_4xx",
+    );
+    expect(isProviderContentBlockedError(err)).toBe(false);
   });
 
   it("classifies provider-specific messages when the top-level message is generic", () => {

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -259,6 +259,7 @@ export const extractErrorDetails = (
 
 export type ProviderErrorCategory =
   | "rate_limited"
+  | "content_blocked"
   | "provider_5xx"
   | "provider_4xx"
   | "stream_terminated"
@@ -277,6 +278,30 @@ const parseHttpStatus = (value: unknown): number | undefined => {
     ? code
     : undefined;
 };
+
+const getProviderMessageText = (details: Record<string, unknown>): string => {
+  return [
+    details.errorMessage,
+    details.providerErrorMessage,
+    details.providerRawError,
+    details.cause,
+    details.responseBody,
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ");
+};
+
+export const isProviderContentBlockedDetails = (
+  details: Record<string, unknown>,
+): boolean => {
+  const message = getProviderMessageText(details);
+  return /PROHIBITED_CONTENT|content[_ -]?filter|content[_ -]?policy|policy violation|blocked by (?:the )?(?:provider )?(?:safety|moderation)|safety system|safety policy|unsafe content|harmful content|moderation/i.test(
+    message,
+  );
+};
+
+export const isProviderContentBlockedError = (error: unknown): boolean =>
+  isProviderContentBlockedDetails(extractErrorDetails(error));
 
 export const getProviderStatusCode = (
   details: Record<string, unknown>,
@@ -299,17 +324,11 @@ export const getProviderErrorCategory = (
     parseHttpStatus(details.statusCode) ??
     parseHttpStatus(details.providerErrorCode);
   if (statusCode === 429) return "rate_limited";
+  if (isProviderContentBlockedDetails(details)) return "content_blocked";
   if (statusCode != null && statusCode >= 500) return "provider_5xx";
   if (statusCode != null && statusCode >= 400) return "provider_4xx";
 
-  const message = [
-    details.errorMessage,
-    details.providerErrorMessage,
-    details.providerRawError,
-    details.cause,
-  ]
-    .filter((value): value is string => typeof value === "string")
-    .join(" ");
+  const message = getProviderMessageText(details);
   if (
     /terminated|aborted|abort|network connection lost|connection (?:reset|closed|lost)|socket hang up|unexpected eof/i.test(
       message,
@@ -455,6 +474,10 @@ export const extractRetryAttempts = (
 export const getUserFriendlyProviderError = (error: unknown): string => {
   const statusCode = extractStatusCode(error);
   const { providerName, detail } = extractProviderDetails(error);
+
+  if (isProviderContentBlockedError(error)) {
+    return "The model provider blocked this request because the conversation content was flagged by its safety system. Edit your last message or remove sensitive or raw tool output, then try again.";
+  }
 
   // Friendly summary based on status code
   const summary = getStatusSummary(statusCode);

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -291,13 +291,14 @@ const getProviderMessageText = (details: Record<string, unknown>): string => {
     .join(" ");
 };
 
+const PROVIDER_CONTENT_BLOCK_PATTERN =
+  /\bPROHIBITED_CONTENT\b|\b(?:content[_ -]?(?:filter|policy)|safety policy|moderation policy|safety system|moderation system)\b.{0,80}\b(?:block(?:ed)?|flag(?:ged)?|reject(?:ed)?|prohibit(?:ed)?|violate(?:s|d|ion)?|unsafe|harmful)\b|\b(?:block(?:ed)?|flag(?:ged)?|reject(?:ed)?|prohibit(?:ed)?|violate(?:s|d|ion)?|unsafe|harmful)\b.{0,80}\b(?:content[_ -]?(?:filter|policy)|safety policy|moderation policy|safety system|moderation system)\b|\bblocked by (?:the )?(?:provider )?(?:safety|moderation)(?: system| filter)?\b|\b(?:unsafe|harmful) content\b/i;
+
 export const isProviderContentBlockedDetails = (
   details: Record<string, unknown>,
 ): boolean => {
   const message = getProviderMessageText(details);
-  return /PROHIBITED_CONTENT|content[_ -]?filter|content[_ -]?policy|policy violation|blocked by (?:the )?(?:provider )?(?:safety|moderation)|safety system|safety policy|unsafe content|harmful content|moderation/i.test(
-    message,
-  );
+  return PROVIDER_CONTENT_BLOCK_PATTERN.test(message);
 };
 
 export const isProviderContentBlockedError = (error: unknown): boolean =>


### PR DESCRIPTION
## Summary

- Classify provider safety/content blocks as a distinct `content_blocked` category.
- Return `forbidden:stream` metadata when all attempted providers fail with blocked content, while preserving the existing fallback path.
- Update the message error UI to hide same-payload manual retry for blocked content and offer a fresh chat path.

## Why

Provider `403 PROHIBITED_CONTENT` responses were being treated like generic provider 4xx failures. That made the UX look like an ordinary provider error and made logs harder to distinguish from access/configuration issues.

## Impact

Users now get clearer recovery guidance after the configured model/fallback path fails, logs can distinguish content blocks from access/configuration 4xxs, and fallback remains available to maximize the chance that another provider can handle the request.

## Validation

- `pnpm test -- lib/utils/__tests__/error-utils.test.ts lib/api/__tests__/chat-logger.test.ts app/components/__tests__/MessageErrorState.test.tsx`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- pre-commit hook: `pnpm typecheck` and full `pnpm test` (127 suites, 1425 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Distinct amber-styled UI for provider safety blocks with clearer user guidance (suggests editing/removing content) and a "New Chat" action.

* **Bug Fixes**
  * Stops futile retry/reconnect/upgrade prompts for provider content-blocked responses so users aren’t urged to retry when it typically fails.
  * Error handling now classifies provider safety blocks reliably to drive correct messaging and actions.

* **Tests**
  * Added tests validating content-block detection, user-facing messaging, action availability, and logging of provider-block events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->