### PR TITLE
[codex] Increase paid agent runtime limit

### DIFF
--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -218,7 +218,7 @@ export async function POST(req: NextRequest) {
     const [publicAccessToken] = await Promise.all([
       auth.createPublicToken({
         scopes: { read: { runs: [handle.id] } },
-        // 6h is enough to cover the 1h max task duration plus reconnect grace.
+        // 6h is enough to cover the max task duration plus reconnect grace.
         expirationTime: "6h",
       }),
       temporary

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -131,6 +131,25 @@ describe("agent-long resume route — 204 on terminal + self-heal on 404", () =>
 });
 
 describe("agent-long task — Trigger.dev dashboard error visibility", () => {
+  test("uses a paid two-hour task cap with a separate free-plan runtime cap", () => {
+    expect(taskSrc).toMatch(
+      /AGENT_LONG_FREE_MAX_DURATION_SECONDS\s*=\s*60\s*\*\s*60/,
+    );
+    expect(taskSrc).toMatch(
+      /AGENT_LONG_PAID_MAX_DURATION_SECONDS\s*=\s*2\s*\*\s*60\s*\*\s*60/,
+    );
+    expect(taskSrc).toMatch(
+      /AGENT_LONG_TRIGGER_MAX_DURATION_SECONDS\s*=\s*AGENT_LONG_PAID_MAX_DURATION_SECONDS/,
+    );
+    expect(taskSrc).toMatch(
+      /subscription\s*===\s*"free"[\s\S]*AGENT_LONG_FREE_MAX_DURATION_SECONDS[\s\S]*AGENT_LONG_PAID_MAX_DURATION_SECONDS/,
+    );
+    expect(taskSrc).toMatch(
+      /maxDuration:\s*AGENT_LONG_TRIGGER_MAX_DURATION_SECONDS/,
+    );
+    expect(taskSrc).toMatch(/maxDurationMs:\s*agentLongMaxDurationMs/);
+  });
+
   test("runs are triggered with filterable queued metadata and tags", () => {
     expect(routeSrc).toMatch(/tags:\s*triggerTags/);
     expect(routeSrc).toMatch(/metadata:\s*{/);

--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -13,8 +13,9 @@ export default defineConfig({
   // "WebSocket constructor not found" when CentrifugoSandbox connects.
   runtime: "node-22",
   logLevel: "log",
-  // Up to one hour per agent-long run.
-  maxDuration: 3600,
+  // Up to two hours per agent-long run. The task enforces a lower free-plan
+  // runtime cap inside trigger/agent-long.ts.
+  maxDuration: 2 * 60 * 60,
   retries: {
     enabledInDev: false,
     default: {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -107,10 +107,25 @@ import {
   AGENT_LONG_HEARTBEAT_PART_TYPE,
   stripAgentLongHeartbeatParts,
 } from "@/lib/chat/agent-long-heartbeat";
+import { PREEMPTIVE_TIMEOUT_FINISH_REASON } from "@/lib/chat/stop-conditions";
 import { FREE_AGENT_LONG_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
 
-// Leave 2 min for cleanup before trigger.dev hits maxDuration: 60 * 60.
-const AGENT_LONG_MAX_DURATION_MS = 58 * 60 * 1000;
+const AGENT_LONG_FREE_MAX_DURATION_SECONDS = 60 * 60;
+const AGENT_LONG_PAID_MAX_DURATION_SECONDS = 2 * 60 * 60;
+const AGENT_LONG_CLEANUP_GRACE_MS = 2 * 60 * 1000;
+const AGENT_LONG_TRIGGER_MAX_DURATION_SECONDS =
+  AGENT_LONG_PAID_MAX_DURATION_SECONDS;
+
+const getAgentLongPlanDurationMs = (subscription: SubscriptionTier) =>
+  (subscription === "free"
+    ? AGENT_LONG_FREE_MAX_DURATION_SECONDS
+    : AGENT_LONG_PAID_MAX_DURATION_SECONDS) * 1000;
+
+const getAgentLongMaxDurationMs = (subscription: SubscriptionTier) =>
+  Math.max(
+    0,
+    getAgentLongPlanDurationMs(subscription) - AGENT_LONG_CLEANUP_GRACE_MS,
+  );
 
 type AgentLongUiStreamPart = Parameters<UIMessageStreamWriter["write"]>[0];
 
@@ -572,7 +587,7 @@ export type AgentLongPayload = {
 
 export const agentLongTask = task({
   id: "agent-long",
-  maxDuration: 60 * 60,
+  maxDuration: AGENT_LONG_TRIGGER_MAX_DURATION_SECONDS,
   // Streaming tasks must not retry: a retry emits new chunks into the same
   // "ui" stream the client already subscribed to, producing duplicate output.
   // Provider errors are handled internally via the fallback-model path.
@@ -632,9 +647,10 @@ export const agentLongTask = task({
 
     // Capture task start time here, before any async setup, so the
     // elapsedTimeExceeds stop condition counts from task launch rather
-    // than stream launch. Without this, slow setup (>2 min) would cause
-    // the 58-min stop to fire after trigger.dev's 60-min hard SIGKILL.
+    // than stream launch. Without this, slow setup (>2 min) could push
+    // the soft stop past the plan-specific runtime cap.
     const taskStartTime = Date.now();
+    const agentLongMaxDurationMs = getAgentLongMaxDurationMs(subscription);
 
     // Tag for dashboard filtering; add subscription tier for paid-only queries.
     await tags.add([`user_${userId}`, `chat_${chatId}`]);
@@ -693,6 +709,8 @@ export const agentLongTask = task({
       chatLogger,
       chatId,
     });
+
+    let agentLongTimeout: ReturnType<typeof setTimeout> | undefined;
 
     try {
       // Re-fetch from DB so we have fileTokens for summarization.
@@ -773,7 +791,7 @@ export const agentLongTask = task({
       chatLogger.getBuilder().setAssistantId(assistantMessageId);
 
       // Wire trigger.dev's abort signal into a local controller.
-      // Fires on runs.cancel() (UI Stop) and maxDuration exceeded.
+      // Fires on runs.cancel() (UI Stop) and Trigger's maxDuration.
       const userStopSignal = new AbortController();
       triggerSignal.addEventListener("abort", () => userStopSignal.abort(), {
         once: true,
@@ -782,6 +800,23 @@ export const agentLongTask = task({
       const summarizationTracker = new SummarizationTracker();
       chatLogger.startStream();
       let terminalAgentState: AgentStreamState | undefined;
+      let agentLongDurationExceeded = false;
+      const markAgentLongDurationExceeded = () => {
+        agentLongDurationExceeded = true;
+        if (terminalAgentState) {
+          terminalAgentState.stoppedDueToElapsedTimeout = true;
+          terminalAgentState.streamFinishReason ??=
+            PREEMPTIVE_TIMEOUT_FINISH_REASON;
+        }
+      };
+      const agentLongTimeoutDelayMs = Math.max(
+        0,
+        agentLongMaxDurationMs - (Date.now() - taskStartTime),
+      );
+      agentLongTimeout = setTimeout(() => {
+        markAgentLongDurationExceeded();
+        userStopSignal.abort();
+      }, agentLongTimeoutDelayMs);
 
       // Rate limit check happens inside execute so a thrown ChatSDKError
       // (e.g. "exceeded daily messages") flows through createUIMessageStream's
@@ -1038,8 +1073,8 @@ export const agentLongTask = task({
               ? new BudgetMonitor(effectiveBudgetSnapshot, writer, subscription)
               : null;
 
-            // Use task start time (not stream start time) so the 58-min stop
-            // condition always fires 2 min before the 60-min hard SIGKILL.
+            // Use task start time (not stream start time) so the soft stop
+            // leaves cleanup grace before the plan-specific runtime cap.
             const streamStartTime = taskStartTime;
             const configuredModelId =
               trackedProvider.languageModel(selectedModel).modelId;
@@ -1148,7 +1183,7 @@ export const agentLongTask = task({
               streamStartTime,
               contextUsageOn,
               isReasoningModel: true, // long mode is always agent mode
-              maxDurationMs: AGENT_LONG_MAX_DURATION_MS,
+              maxDurationMs: agentLongMaxDurationMs,
               writer,
               abortController: userStopSignal,
               summarizationTracker,
@@ -1159,8 +1194,10 @@ export const agentLongTask = task({
               ensureSandbox,
               chatLogger,
               usageRefundTracker,
-              // trigger.dev has no Vercel-style hard preemptive timeout
-              getHardTimeoutReason: () => null,
+              getHardTimeoutReason: () =>
+                agentLongDurationExceeded
+                  ? PREEMPTIVE_TIMEOUT_FINISH_REASON
+                  : null,
             };
 
             const createStream = (modelName: string) => {
@@ -1653,9 +1690,9 @@ export const agentLongTask = task({
                         });
                       }
 
-                      // Don't auto-continue on elapsed timeout — a 58-min run is large enough
-                      // that the user should explicitly decide whether to continue rather than
-                      // silently chaining up to 5 more hour-long runs.
+                      // Don't auto-continue on elapsed timeout. Runs that hit
+                      // their plan cap are large enough that the user should
+                      // explicitly decide whether to continue.
                       if (
                         (state.stoppedDueToTokenExhaustion ||
                           state.streamFinishReason === "tool-calls") &&
@@ -1823,6 +1860,7 @@ export const agentLongTask = task({
       await phLogger.flush().catch(() => {});
       throw error;
     } finally {
+      if (agentLongTimeout) clearTimeout(agentLongTimeout);
       runCleanupMap.delete(ctx.run.id);
       if (!payload.temporary) {
         try {


### PR DESCRIPTION
## Summary

- Raise the Trigger agent-long task ceiling to two hours for paid-user runs.
- Keep free users on the existing one-hour plan cap by deriving the runtime limit from `subscription` inside the task.
- Preserve the two-minute cleanup grace before each plan cap and add a contract test to guard the paid/free split.
- Update stale route wording for the realtime read token duration.

## Validation

- `pnpm test -- lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `pnpm exec eslint trigger/agent-long.ts trigger.config.ts app/api/agent-long/route.ts lib/api/__tests__/agent-long-contracts.test.ts`
- `pnpm typecheck`
- Pre-commit hook: `pnpm typecheck` and full `pnpm test` (126 suites, 1419 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent-long tasks now enforce subscription-specific runtime limits, with free and paid plans having distinct maximum durations. Tasks automatically stop when reaching plan-specific time caps.

* **Tests**
  * Added structural contract test verifying subscription tier-based runtime cap configuration and enforcement across plan types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->