### PR TITLE
[codex] Capture cancellation reasons

### DIFF
--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -1016,18 +1016,23 @@ async function recordCancellationCompleted(args: {
   const completedAt =
     args.completionType === "deleted" ? (canceledAt ?? Date.now()) : Date.now();
 
+  let updatedCount = 0;
   try {
-    await convex.mutation(api.cancellationReasons.markCancellationCompleted, {
-      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
-      stripeSubscriptionId: args.subscription.id,
-      stripeCustomerId: args.customerId,
-      userIds: args.userIds,
-      organizationId: args.orgId,
-      subscriptionTier: args.tier ?? undefined,
-      stripeCancellationReason,
-      cancelAtPeriodEnd: args.subscription.cancel_at_period_end,
-      completedAt,
-    });
+    const result = await convex.mutation(
+      api.cancellationReasons.markCancellationCompleted,
+      {
+        serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+        stripeSubscriptionId: args.subscription.id,
+        stripeCustomerId: args.customerId,
+        userIds: args.userIds,
+        organizationId: args.orgId,
+        subscriptionTier: args.tier ?? undefined,
+        stripeCancellationReason,
+        cancelAtPeriodEnd: args.subscription.cancel_at_period_end,
+        completedAt,
+      },
+    );
+    updatedCount = result.updatedCount;
   } catch (error) {
     phLogger.warn("cancellation_reason_completion_update_failed", {
       stripe_customer_id: args.customerId,
@@ -1037,12 +1042,16 @@ async function recordCancellationCompleted(args: {
     });
   }
 
+  if (updatedCount === 0) {
+    return;
+  }
+
   for (const uid of args.userIds) {
     phLogger.event(
       PAID_FUNNEL_EVENTS.cancellationCompleted,
       paidFunnelProperties({
         userId: uid,
-        tier: args.tier,
+        subscription_tier: args.tier,
         org_id: args.orgId,
         plan: args.price?.lookup_key,
         billing_interval: priceBillingInterval(args.price),

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -865,6 +865,46 @@ async function handleSubscriptionUpdated(
   subscription: Stripe.Subscription,
   previousAttributes: Partial<Stripe.Subscription> | undefined,
 ): Promise<void> {
+  const cancellationJustScheduled =
+    subscription.cancel_at_period_end === true &&
+    Boolean(previousAttributes) &&
+    Object.prototype.hasOwnProperty.call(
+      previousAttributes,
+      "cancel_at_period_end",
+    ) &&
+    (previousAttributes as { cancel_at_period_end?: boolean })
+      .cancel_at_period_end !== true;
+
+  if (cancellationJustScheduled) {
+    const customerId =
+      typeof subscription.customer === "string"
+        ? subscription.customer
+        : subscription.customer?.id;
+
+    if (customerId) {
+      const currentPrice = subscription.items?.data[0]?.price;
+      const lookupKey = currentPrice?.lookup_key ?? null;
+      const tier = lookupKey ? planLookupKeyToTier(lookupKey) : null;
+      const { userIds, orgId } = await resolveUserIdsFromCustomer(customerId);
+
+      if (userIds.length === 0) {
+        console.error(
+          `[Subscription Webhook] subscription.updated cancellation: could not resolve users for customer ${customerId}`,
+        );
+      } else {
+        await recordCancellationCompleted({
+          subscription,
+          customerId,
+          userIds,
+          orgId: orgId ?? undefined,
+          tier,
+          price: currentPrice,
+          completionType: "scheduled",
+        });
+      }
+    }
+  }
+
   // Only act if the subscription items actually changed (plan change)
   const previousItems = (previousAttributes as any)?.items;
   if (!previousItems) return;
@@ -959,6 +999,66 @@ async function handleSubscriptionUpdated(
   }
 }
 
+async function recordCancellationCompleted(args: {
+  subscription: Stripe.Subscription;
+  customerId: string;
+  userIds: string[];
+  orgId?: string;
+  tier: SubscriptionTier | null;
+  price?: Stripe.Price;
+  completionType: "scheduled" | "deleted";
+}) {
+  const stripeCancellationReason =
+    args.subscription.cancellation_details?.reason ?? undefined;
+  const canceledAt = args.subscription.canceled_at
+    ? args.subscription.canceled_at * 1000
+    : undefined;
+  const completedAt =
+    args.completionType === "deleted" ? (canceledAt ?? Date.now()) : Date.now();
+
+  try {
+    await convex.mutation(api.cancellationReasons.markCancellationCompleted, {
+      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+      stripeSubscriptionId: args.subscription.id,
+      stripeCustomerId: args.customerId,
+      userIds: args.userIds,
+      organizationId: args.orgId,
+      subscriptionTier: args.tier ?? undefined,
+      stripeCancellationReason,
+      cancelAtPeriodEnd: args.subscription.cancel_at_period_end,
+      completedAt,
+    });
+  } catch (error) {
+    phLogger.warn("cancellation_reason_completion_update_failed", {
+      stripe_customer_id: args.customerId,
+      stripe_subscription_id: args.subscription.id,
+      org_id: args.orgId,
+      error,
+    });
+  }
+
+  for (const uid of args.userIds) {
+    phLogger.event(
+      PAID_FUNNEL_EVENTS.cancellationCompleted,
+      paidFunnelProperties({
+        userId: uid,
+        tier: args.tier,
+        org_id: args.orgId,
+        plan: args.price?.lookup_key,
+        billing_interval: priceBillingInterval(args.price),
+        billing_interval_count: args.price?.recurring?.interval_count,
+        cancellation_reason: stripeCancellationReason,
+        cancellation_completion_type: args.completionType,
+        cancel_at_period_end: args.subscription.cancel_at_period_end,
+        stripe_customer_id: args.customerId,
+        stripe_subscription_id: args.subscription.id,
+        stripe_price_id: args.price?.id,
+        $insert_id: `${PAID_FUNNEL_EVENTS.cancellationCompleted}:${args.subscription.id}`,
+      }),
+    );
+  }
+}
+
 /** Handle customer.subscription.deleted — emit churn analytics for the lapsed paid users. */
 async function handleSubscriptionDeleted(
   subscription: Stripe.Subscription,
@@ -985,6 +1085,16 @@ async function handleSubscriptionDeleted(
   console.log(
     `[Subscription Webhook] subscription.deleted: tier ${tier ?? "unknown"} cancelled for ${userIds.length} user(s) (reason: ${cancellationReason ?? "none"})`,
   );
+
+  await recordCancellationCompleted({
+    subscription,
+    customerId,
+    userIds,
+    orgId: orgId ?? undefined,
+    tier,
+    price: subscription.items?.data[0]?.price,
+    completionType: "deleted",
+  });
 
   for (const uid of userIds) {
     phLogger.event("subscription_cancelled", {

--- a/app/components/CancelSubscriptionDialog.tsx
+++ b/app/components/CancelSubscriptionDialog.tsx
@@ -11,18 +11,17 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useGlobalState } from "@/app/contexts/GlobalState";
 import cancelSubscriptionAction from "@/lib/actions/cancel-subscription";
 import { toast } from "sonner";
-import { CheckCircle2, Loader2, X as XIcon } from "lucide-react";
+import {
+  CheckCircle2,
+  Heart,
+  Loader2,
+  LockKeyhole,
+  X as XIcon,
+} from "lucide-react";
 import {
   proFeatures,
   proPlusFeatures,
@@ -39,6 +38,7 @@ import {
   PAID_FUNNEL_EVENTS,
   paidFunnelProperties,
 } from "@/lib/analytics/paid-funnel";
+import { cn } from "@/lib/utils";
 
 type CancelSubscriptionDialogProps = {
   open: boolean;
@@ -48,6 +48,10 @@ type CancelSubscriptionDialogProps = {
 type CancellationResult = {
   currentPeriodEnd?: number;
 };
+
+type CancellationStep = "feedback" | "confirm";
+
+const reasonOptionBadges = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
 
 function getFeaturesForTier(tier: SubscriptionTier) {
   switch (tier) {
@@ -96,6 +100,7 @@ export const CancelSubscriptionDialog = ({
   const [showValidation, setShowValidation] = useState(false);
   const [cancellationResult, setCancellationResult] =
     useState<CancellationResult | null>(null);
+  const [step, setStep] = useState<CancellationStep>("feedback");
   const openRef = useRef(open);
   const requestIdRef = useRef(0);
 
@@ -120,6 +125,7 @@ export const CancelSubscriptionDialog = ({
       setShowValidation(false);
       setIsProcessing(false);
       setCancellationResult(null);
+      setStep("feedback");
       return;
     }
 
@@ -133,10 +139,22 @@ export const CancelSubscriptionDialog = ({
     );
   }, [open, subscription]);
 
+  const handleContinueToConfirmation = useCallback(() => {
+    const trimmedReasonDetails = reasonDetails.trim();
+    if (!reasonCategory || !trimmedReasonDetails) {
+      setShowValidation(true);
+      return;
+    }
+
+    setShowValidation(false);
+    setStep("confirm");
+  }, [reasonCategory, reasonDetails]);
+
   const handleCancelSubscription = useCallback(async () => {
     const trimmedReasonDetails = reasonDetails.trim();
     if (!reasonCategory || !trimmedReasonDetails) {
       setShowValidation(true);
+      setStep("feedback");
       return;
     }
 
@@ -191,9 +209,20 @@ export const CancelSubscriptionDialog = ({
     [subscription],
   );
 
+  const handleBack = useCallback(() => {
+    if (step === "confirm") {
+      setStep("feedback");
+      return;
+    }
+
+    handleOpenChange(false);
+  }, [handleOpenChange, step]);
+
   const features = getFeaturesForTier(subscription);
   const planName = getPlanDisplayName(subscription);
-  const detailsMissing = showValidation && !reasonDetails.trim();
+  const trimmedReasonDetails = reasonDetails.trim();
+  const hasRequiredReason = Boolean(reasonCategory && trimmedReasonDetails);
+  const detailsMissing = showValidation && !trimmedReasonDetails;
   const categoryMissing = showValidation && !reasonCategory;
   const periodEndDate = cancellationResult?.currentPeriodEnd
     ? new Intl.DateTimeFormat(undefined, {
@@ -202,73 +231,178 @@ export const CancelSubscriptionDialog = ({
         year: "numeric",
       }).format(new Date(cancellationResult.currentPeriodEnd))
     : null;
+  const isConfirmStep = step === "confirm";
+  const StepIcon = cancellationResult
+    ? CheckCircle2
+    : isConfirmStep
+      ? LockKeyhole
+      : Heart;
+  const stepLabel = cancellationResult
+    ? "Cancellation scheduled"
+    : isConfirmStep
+      ? "Final confirmation"
+      : "Your feedback";
+  const selectedReasonLabel = CANCELLATION_REASON_OPTIONS.find(
+    (option) => option.value === reasonCategory,
+  )?.label;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
+      <DialogContent
+        showCloseButton={false}
+        className="flex max-h-[90vh] flex-col overflow-hidden p-0 sm:max-w-[560px]"
+      >
+        <div className="flex items-center justify-between border-b border-border bg-muted/40 px-5 py-3">
+          <div className="flex min-w-0 items-center gap-3 text-sm font-semibold text-lime-400">
+            <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-lime-400/15 text-lime-400">
+              <StepIcon className="size-4" aria-hidden="true" />
+            </span>
+            <span className="truncate">{stepLabel}</span>
+          </div>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={() => handleOpenChange(false)}
+            disabled={isProcessing}
+            className="flex size-8 shrink-0 items-center justify-center rounded-md bg-lime-400/15 text-lime-400 transition-colors hover:bg-lime-400/25 focus-visible:ring-2 focus-visible:ring-lime-400 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+          >
+            <XIcon className="size-4" aria-hidden="true" />
+          </button>
+        </div>
+
         {cancellationResult ? (
           <>
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <CheckCircle2 className="h-5 w-5 text-emerald-600" />
-                Cancellation scheduled
-              </DialogTitle>
-              <DialogDescription>
-                {periodEndDate
-                  ? `You'll keep your ${planName} plan until ${periodEndDate}.`
-                  : `You'll keep your ${planName} plan until the end of your current billing period.`}
-              </DialogDescription>
-            </DialogHeader>
-            <DialogFooter className="mt-4">
+            <div className="min-h-0 flex-1 overflow-y-auto px-6 py-7 sm:px-8">
+              <DialogHeader className="gap-3 text-left sm:text-left">
+                <DialogTitle className="text-3xl leading-tight font-semibold sm:text-4xl">
+                  Cancellation scheduled
+                </DialogTitle>
+                <DialogDescription className="text-base leading-7">
+                  {periodEndDate
+                    ? `You'll keep your ${planName} plan until ${periodEndDate}.`
+                    : `You'll keep your ${planName} plan until the end of your current billing period.`}
+                </DialogDescription>
+              </DialogHeader>
+            </div>
+            <DialogFooter className="border-t border-border px-6 py-5 sm:px-8">
               <Button
-                className="w-full"
+                className="h-11 w-full sm:w-44"
                 onClick={() => handleOpenChange(false)}
               >
                 Done
               </Button>
             </DialogFooter>
           </>
-        ) : (
+        ) : isConfirmStep ? (
           <>
-            <DialogHeader>
-              <DialogTitle>Before you cancel</DialogTitle>
-              <DialogDescription>
-                {`If you cancel, you'll keep your ${planName} plan until the end of your current billing period.`}
-              </DialogDescription>
-            </DialogHeader>
+            <div className="min-h-0 flex-1 overflow-y-auto px-6 py-7 sm:px-8">
+              <DialogHeader className="gap-4 text-left sm:text-left">
+                <DialogTitle className="text-3xl leading-tight font-semibold sm:text-4xl">
+                  Are you sure you want to cancel?
+                </DialogTitle>
+                <DialogDescription className="text-base leading-7">
+                  {`You'll keep your ${planName} plan until the end of your current billing period, then lose access to these benefits.`}
+                </DialogDescription>
+              </DialogHeader>
 
-            <div className="space-y-4 mt-2">
-              <div className="space-y-2">
-                <Label htmlFor="cancellation-reason-category">
-                  Main reason
-                </Label>
-                <Select
-                  value={reasonCategory}
-                  onValueChange={handleReasonCategoryChange}
-                  disabled={isProcessing}
-                >
-                  <SelectTrigger
-                    id="cancellation-reason-category"
-                    aria-invalid={categoryMissing}
-                  >
-                    <SelectValue placeholder="Select a reason" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {CANCELLATION_REASON_OPTIONS.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {categoryMissing ? (
-                  <p className="text-xs text-destructive">
-                    Please select a main reason.
-                  </p>
-                ) : null}
+              <div className="mt-7 rounded-lg border border-border bg-muted/40 p-5">
+                <ul className="space-y-2 text-sm leading-6 text-foreground">
+                  {features.map((feature, index) => (
+                    <li key={index} className="flex gap-3">
+                      <span className="mt-2 size-1.5 shrink-0 rounded-full bg-foreground" />
+                      <span>{feature.text}</span>
+                    </li>
+                  ))}
+                </ul>
               </div>
 
-              <div className="space-y-2">
+              <div className="mt-5 rounded-md border border-border bg-background/60 p-3 text-sm text-muted-foreground">
+                <span className="font-medium text-foreground">Reason:</span>{" "}
+                {selectedReasonLabel}
+              </div>
+            </div>
+
+            <div className="flex flex-col-reverse gap-3 border-t border-border px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-8">
+              <Button
+                variant="destructive"
+                onClick={handleCancelSubscription}
+                disabled={isProcessing}
+                className="h-11 w-full sm:w-48"
+              >
+                {isProcessing ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  "Confirm & Cancel"
+                )}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={handleBack}
+                disabled={isProcessing}
+                className="h-11 w-full sm:w-36"
+              >
+                Back
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="min-h-0 flex-1 overflow-y-auto px-6 py-7 sm:px-8">
+              <DialogHeader className="gap-3 text-left sm:text-left">
+                <DialogTitle className="text-3xl leading-tight font-semibold sm:text-4xl">
+                  Before you go...
+                </DialogTitle>
+                <DialogDescription className="text-base leading-7">
+                  Could you share why you&apos;re leaving so we can improve?
+                </DialogDescription>
+              </DialogHeader>
+
+              <div
+                className="mt-7 space-y-2"
+                role="radiogroup"
+                aria-label="Main cancellation reason"
+                aria-invalid={categoryMissing}
+              >
+                {CANCELLATION_REASON_OPTIONS.map((option, index) => {
+                  const isSelected = reasonCategory === option.value;
+
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      role="radio"
+                      aria-checked={isSelected}
+                      onClick={() => handleReasonCategoryChange(option.value)}
+                      disabled={isProcessing}
+                      className={cn(
+                        "flex h-14 w-full items-center gap-4 rounded-md border px-4 text-left text-base font-medium transition-colors focus-visible:ring-2 focus-visible:ring-lime-400 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50",
+                        isSelected
+                          ? "border-lime-400/70 bg-lime-400/10 text-foreground"
+                          : "border-border bg-muted/40 text-foreground hover:bg-muted",
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "flex size-8 shrink-0 items-center justify-center rounded-md text-sm font-semibold",
+                          isSelected
+                            ? "bg-lime-400 text-black"
+                            : "bg-lime-400/15 text-lime-400",
+                        )}
+                      >
+                        {reasonOptionBadges[index]}
+                      </span>
+                      <span className="min-w-0 truncate">{option.label}</span>
+                    </button>
+                  );
+                })}
+              </div>
+              {categoryMissing ? (
+                <p className="mt-2 text-xs text-destructive">
+                  Please select a main reason.
+                </p>
+              ) : null}
+
+              <div className="mt-6 space-y-2">
                 <Label htmlFor="cancellation-reason-details">
                   Tell us what happened
                 </Label>
@@ -283,7 +417,7 @@ export const CancelSubscriptionDialog = ({
                   disabled={isProcessing}
                   aria-invalid={detailsMissing}
                   placeholder="A short note is required before continuing."
-                  className="min-h-24 resize-none"
+                  className="min-h-28 resize-none bg-muted/30"
                 />
                 {detailsMissing ? (
                   <p className="text-xs text-destructive">
@@ -293,43 +427,26 @@ export const CancelSubscriptionDialog = ({
               </div>
             </div>
 
-            <div className="mt-2 text-sm text-muted-foreground">
-              {"After that, you'll lose access to:"}
-            </div>
-
-            <ul className="space-y-2">
-              {features.map((feature, index) => (
-                <li key={index} className="flex items-start gap-3">
-                  <XIcon className="h-4 w-4 shrink-0 mt-0.5 text-destructive" />
-                  <span className="text-sm text-muted-foreground">
-                    {feature.text}
-                  </span>
-                </li>
-              ))}
-            </ul>
-
-            <DialogFooter className="mt-4 flex flex-col gap-2 sm:flex-col">
+            <div className="flex flex-col-reverse gap-3 border-t border-border px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-8">
+              <Button
+                onClick={handleContinueToConfirmation}
+                disabled={isProcessing}
+                className={cn(
+                  "h-11 w-full sm:w-36",
+                  !hasRequiredReason && "opacity-60",
+                )}
+              >
+                Next
+              </Button>
               <Button
                 variant="outline"
-                onClick={() => handleOpenChange(false)}
+                onClick={handleBack}
                 disabled={isProcessing}
-                className="w-full"
+                className="h-11 w-full sm:w-36"
               >
-                Keep my subscription
+                Back
               </Button>
-              <Button
-                variant="destructive"
-                onClick={handleCancelSubscription}
-                disabled={isProcessing}
-                className="w-full"
-              >
-                {isProcessing ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  "Cancel subscription"
-                )}
-              </Button>
-            </DialogFooter>
+            </div>
           </>
         )}
       </DialogContent>

--- a/app/components/CancelSubscriptionDialog.tsx
+++ b/app/components/CancelSubscriptionDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import {
   Dialog,
   DialogContent,
@@ -10,10 +10,19 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { useGlobalState } from "@/app/contexts/GlobalState";
-import redirectToBillingPortalAction from "@/lib/actions/billing-portal";
+import cancelSubscriptionAction from "@/lib/actions/cancel-subscription";
 import { toast } from "sonner";
-import { Loader2, X as XIcon } from "lucide-react";
+import { CheckCircle2, Loader2, X as XIcon } from "lucide-react";
 import {
   proFeatures,
   proPlusFeatures,
@@ -21,10 +30,23 @@ import {
   teamFeatures,
 } from "@/lib/pricing/features";
 import type { SubscriptionTier } from "@/types";
+import {
+  CANCELLATION_REASON_OPTIONS,
+  type CancellationReasonCategory,
+} from "@/lib/billing/cancellation-reasons";
+import { captureAuthenticatedEvent } from "@/lib/analytics/client";
+import {
+  PAID_FUNNEL_EVENTS,
+  paidFunnelProperties,
+} from "@/lib/analytics/paid-funnel";
 
 type CancelSubscriptionDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+};
+
+type CancellationResult = {
+  currentPeriodEnd?: number;
 };
 
 function getFeaturesForTier(tier: SubscriptionTier) {
@@ -67,73 +89,220 @@ export const CancelSubscriptionDialog = ({
 }: CancelSubscriptionDialogProps) => {
   const { subscription } = useGlobalState();
   const [isProcessing, setIsProcessing] = useState(false);
+  const [reasonCategory, setReasonCategory] = useState<
+    CancellationReasonCategory | ""
+  >("");
+  const [reasonDetails, setReasonDetails] = useState("");
+  const [showValidation, setShowValidation] = useState(false);
+  const [cancellationResult, setCancellationResult] =
+    useState<CancellationResult | null>(null);
 
-  const handleGoToBillingPortal = useCallback(async () => {
+  useEffect(() => {
+    if (!open) {
+      setReasonCategory("");
+      setReasonDetails("");
+      setShowValidation(false);
+      setIsProcessing(false);
+      setCancellationResult(null);
+      return;
+    }
+
+    captureAuthenticatedEvent(
+      PAID_FUNNEL_EVENTS.cancellationStarted,
+      paidFunnelProperties({
+        subscription_tier: subscription,
+        surface: "cancel_subscription_dialog",
+        source: "account_settings",
+      }),
+    );
+  }, [open, subscription]);
+
+  const handleCancelSubscription = useCallback(async () => {
+    const trimmedReasonDetails = reasonDetails.trim();
+    if (!reasonCategory || !trimmedReasonDetails) {
+      setShowValidation(true);
+      return;
+    }
+
     setIsProcessing(true);
     try {
-      const url = await redirectToBillingPortalAction();
-      if (url) {
-        window.location.href = url;
-        return;
-      }
-      toast.error("Failed to open billing portal");
+      const result = await cancelSubscriptionAction({
+        cancellationReason: {
+          reasonCategory,
+          reasonDetails: trimmedReasonDetails,
+        },
+      });
+      setCancellationResult({
+        currentPeriodEnd: result.currentPeriodEnd,
+      });
+      toast.success("Subscription scheduled to cancel");
     } catch (error) {
       toast.error(
         error instanceof Error
           ? error.message
-          : "Failed to open billing portal",
+          : "Failed to cancel subscription",
       );
     } finally {
       setIsProcessing(false);
     }
-  }, []);
+  }, [reasonCategory, reasonDetails]);
+
+  const handleReasonCategoryChange = useCallback(
+    (value: string) => {
+      const nextReasonCategory = value as CancellationReasonCategory;
+      setReasonCategory(nextReasonCategory);
+      setShowValidation(false);
+      captureAuthenticatedEvent(
+        PAID_FUNNEL_EVENTS.cancellationReasonSelected,
+        paidFunnelProperties({
+          subscription_tier: subscription,
+          reason_category: nextReasonCategory,
+          surface: "cancel_subscription_dialog",
+          source: "account_settings",
+        }),
+      );
+    },
+    [subscription],
+  );
 
   const features = getFeaturesForTier(subscription);
   const planName = getPlanDisplayName(subscription);
+  const detailsMissing = showValidation && !reasonDetails.trim();
+  const categoryMissing = showValidation && !reasonCategory;
+  const periodEndDate = cancellationResult?.currentPeriodEnd
+    ? new Intl.DateTimeFormat(undefined, {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+      }).format(new Date(cancellationResult.currentPeriodEnd))
+    : null;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>Before you cancel</DialogTitle>
-          <DialogDescription>
-            {`If you cancel, you'll keep your ${planName} plan until the end of your current billing period. After that, you'll lose access to:`}
-          </DialogDescription>
-        </DialogHeader>
+        {cancellationResult ? (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <CheckCircle2 className="h-5 w-5 text-emerald-600" />
+                Cancellation scheduled
+              </DialogTitle>
+              <DialogDescription>
+                {periodEndDate
+                  ? `You'll keep your ${planName} plan until ${periodEndDate}.`
+                  : `You'll keep your ${planName} plan until the end of your current billing period.`}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="mt-4">
+              <Button className="w-full" onClick={() => onOpenChange(false)}>
+                Done
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Before you cancel</DialogTitle>
+              <DialogDescription>
+                {`If you cancel, you'll keep your ${planName} plan until the end of your current billing period.`}
+              </DialogDescription>
+            </DialogHeader>
 
-        <ul className="space-y-2 mt-2">
-          {features.map((feature, index) => (
-            <li key={index} className="flex items-start gap-3">
-              <XIcon className="h-4 w-4 shrink-0 mt-0.5 text-destructive" />
-              <span className="text-sm text-muted-foreground">
-                {feature.text}
-              </span>
-            </li>
-          ))}
-        </ul>
+            <div className="space-y-4 mt-2">
+              <div className="space-y-2">
+                <Label htmlFor="cancellation-reason-category">
+                  Main reason
+                </Label>
+                <Select
+                  value={reasonCategory}
+                  onValueChange={handleReasonCategoryChange}
+                  disabled={isProcessing}
+                >
+                  <SelectTrigger
+                    id="cancellation-reason-category"
+                    aria-invalid={categoryMissing}
+                  >
+                    <SelectValue placeholder="Select a reason" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {CANCELLATION_REASON_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {categoryMissing ? (
+                  <p className="text-xs text-destructive">
+                    Please select a main reason.
+                  </p>
+                ) : null}
+              </div>
 
-        <DialogFooter className="mt-4 flex flex-col gap-2 sm:flex-col">
-          <Button
-            variant="outline"
-            onClick={() => onOpenChange(false)}
-            disabled={isProcessing}
-            className="w-full"
-          >
-            Keep my subscription
-          </Button>
-          <Button
-            variant="destructive"
-            onClick={handleGoToBillingPortal}
-            disabled={isProcessing}
-            className="w-full"
-          >
-            {isProcessing ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              "Continue to cancel"
-            )}
-          </Button>
-        </DialogFooter>
+              <div className="space-y-2">
+                <Label htmlFor="cancellation-reason-details">
+                  Tell us what happened
+                </Label>
+                <Textarea
+                  id="cancellation-reason-details"
+                  value={reasonDetails}
+                  onChange={(event) => {
+                    setReasonDetails(event.target.value);
+                    setShowValidation(false);
+                  }}
+                  maxLength={2000}
+                  disabled={isProcessing}
+                  aria-invalid={detailsMissing}
+                  placeholder="A short note is required before continuing."
+                  className="min-h-24 resize-none"
+                />
+                {detailsMissing ? (
+                  <p className="text-xs text-destructive">
+                    Please write a cancellation reason.
+                  </p>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="mt-2 text-sm text-muted-foreground">
+              {"After that, you'll lose access to:"}
+            </div>
+
+            <ul className="space-y-2">
+              {features.map((feature, index) => (
+                <li key={index} className="flex items-start gap-3">
+                  <XIcon className="h-4 w-4 shrink-0 mt-0.5 text-destructive" />
+                  <span className="text-sm text-muted-foreground">
+                    {feature.text}
+                  </span>
+                </li>
+              ))}
+            </ul>
+
+            <DialogFooter className="mt-4 flex flex-col gap-2 sm:flex-col">
+              <Button
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isProcessing}
+                className="w-full"
+              >
+                Keep my subscription
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleCancelSubscription}
+                disabled={isProcessing}
+                className="w-full"
+              >
+                {isProcessing ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  "Cancel subscription"
+                )}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/app/components/CancelSubscriptionDialog.tsx
+++ b/app/components/CancelSubscriptionDialog.tsx
@@ -109,6 +109,7 @@ export const CancelSubscriptionDialog = ({
     useState<CancellationResult | null>(null);
   const [step, setStep] = useState<CancellationStep>("feedback");
   const openRef = useRef(open);
+  const wasOpenRef = useRef(false);
   const requestIdRef = useRef(0);
 
   const handleOpenChange = useCallback(
@@ -123,7 +124,9 @@ export const CancelSubscriptionDialog = ({
   );
 
   useEffect(() => {
+    const wasOpen = wasOpenRef.current;
     openRef.current = open;
+    wasOpenRef.current = open;
 
     if (!open) {
       requestIdRef.current += 1;
@@ -133,6 +136,10 @@ export const CancelSubscriptionDialog = ({
       setIsProcessing(false);
       setCancellationResult(null);
       setStep("feedback");
+      return;
+    }
+
+    if (wasOpen) {
       return;
     }
 

--- a/app/components/CancelSubscriptionDialog.tsx
+++ b/app/components/CancelSubscriptionDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import {
   Dialog,
   DialogContent,
@@ -96,9 +96,25 @@ export const CancelSubscriptionDialog = ({
   const [showValidation, setShowValidation] = useState(false);
   const [cancellationResult, setCancellationResult] =
     useState<CancellationResult | null>(null);
+  const openRef = useRef(open);
+  const requestIdRef = useRef(0);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      openRef.current = nextOpen;
+      if (!nextOpen) {
+        requestIdRef.current += 1;
+      }
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange],
+  );
 
   useEffect(() => {
+    openRef.current = open;
+
     if (!open) {
+      requestIdRef.current += 1;
       setReasonCategory("");
       setReasonDetails("");
       setShowValidation(false);
@@ -125,6 +141,8 @@ export const CancelSubscriptionDialog = ({
     }
 
     setIsProcessing(true);
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
     try {
       const result = await cancelSubscriptionAction({
         cancellationReason: {
@@ -132,18 +150,26 @@ export const CancelSubscriptionDialog = ({
           reasonDetails: trimmedReasonDetails,
         },
       });
+      if (!openRef.current || requestIdRef.current !== requestId) {
+        return;
+      }
       setCancellationResult({
         currentPeriodEnd: result.currentPeriodEnd,
       });
       toast.success("Subscription scheduled to cancel");
     } catch (error) {
+      if (!openRef.current || requestIdRef.current !== requestId) {
+        return;
+      }
       toast.error(
         error instanceof Error
           ? error.message
           : "Failed to cancel subscription",
       );
     } finally {
-      setIsProcessing(false);
+      if (openRef.current && requestIdRef.current === requestId) {
+        setIsProcessing(false);
+      }
     }
   }, [reasonCategory, reasonDetails]);
 
@@ -178,7 +204,7 @@ export const CancelSubscriptionDialog = ({
     : null;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
         {cancellationResult ? (
           <>
@@ -194,7 +220,10 @@ export const CancelSubscriptionDialog = ({
               </DialogDescription>
             </DialogHeader>
             <DialogFooter className="mt-4">
-              <Button className="w-full" onClick={() => onOpenChange(false)}>
+              <Button
+                className="w-full"
+                onClick={() => handleOpenChange(false)}
+              >
                 Done
               </Button>
             </DialogFooter>
@@ -282,7 +311,7 @@ export const CancelSubscriptionDialog = ({
             <DialogFooter className="mt-4 flex flex-col gap-2 sm:flex-col">
               <Button
                 variant="outline"
-                onClick={() => onOpenChange(false)}
+                onClick={() => handleOpenChange(false)}
                 disabled={isProcessing}
                 className="w-full"
               >

--- a/app/components/CancelSubscriptionDialog.tsx
+++ b/app/components/CancelSubscriptionDialog.tsx
@@ -52,6 +52,13 @@ type CancellationResult = {
 type CancellationStep = "feedback" | "confirm";
 
 const reasonOptionBadges = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
+const visibleCancellationReasonValues: CancellationReasonCategory[] = [
+  "too_expensive",
+  "not_using_enough",
+  "missing_feature",
+  "too_slow_or_unreliable",
+  "other",
+];
 
 function getFeaturesForTier(tier: SubscriptionTier) {
   switch (tier) {
@@ -245,6 +252,9 @@ export const CancelSubscriptionDialog = ({
   const selectedReasonLabel = CANCELLATION_REASON_OPTIONS.find(
     (option) => option.value === reasonCategory,
   )?.label;
+  const visibleCancellationReasonOptions = CANCELLATION_REASON_OPTIONS.filter(
+    (option) => visibleCancellationReasonValues.includes(option.value),
+  );
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -253,8 +263,8 @@ export const CancelSubscriptionDialog = ({
         className="flex max-h-[90vh] flex-col overflow-hidden p-0 sm:max-w-[560px]"
       >
         <div className="flex items-center justify-between border-b border-border bg-muted/40 px-5 py-3">
-          <div className="flex min-w-0 items-center gap-3 text-sm font-semibold text-lime-400">
-            <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-lime-400/15 text-lime-400">
+          <div className="flex min-w-0 items-center gap-3 text-sm font-semibold text-premium-text">
+            <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-premium-bg text-premium-text">
               <StepIcon className="size-4" aria-hidden="true" />
             </span>
             <span className="truncate">{stepLabel}</span>
@@ -264,7 +274,7 @@ export const CancelSubscriptionDialog = ({
             aria-label="Close"
             onClick={() => handleOpenChange(false)}
             disabled={isProcessing}
-            className="flex size-8 shrink-0 items-center justify-center rounded-md bg-lime-400/15 text-lime-400 transition-colors hover:bg-lime-400/25 focus-visible:ring-2 focus-visible:ring-lime-400 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+            className="flex size-8 shrink-0 items-center justify-center rounded-md bg-premium-bg text-premium-text transition-colors hover:bg-premium-hover focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
           >
             <XIcon className="size-4" aria-hidden="true" />
           </button>
@@ -363,7 +373,7 @@ export const CancelSubscriptionDialog = ({
                 aria-label="Main cancellation reason"
                 aria-invalid={categoryMissing}
               >
-                {CANCELLATION_REASON_OPTIONS.map((option, index) => {
+                {visibleCancellationReasonOptions.map((option, index) => {
                   const isSelected = reasonCategory === option.value;
 
                   return (
@@ -375,9 +385,9 @@ export const CancelSubscriptionDialog = ({
                       onClick={() => handleReasonCategoryChange(option.value)}
                       disabled={isProcessing}
                       className={cn(
-                        "flex h-14 w-full items-center gap-4 rounded-md border px-4 text-left text-base font-medium transition-colors focus-visible:ring-2 focus-visible:ring-lime-400 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50",
+                        "flex h-14 w-full items-center gap-4 rounded-md border px-4 text-left text-base font-medium transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50",
                         isSelected
-                          ? "border-lime-400/70 bg-lime-400/10 text-foreground"
+                          ? "border-violet-500/70 bg-premium-bg text-foreground"
                           : "border-border bg-muted/40 text-foreground hover:bg-muted",
                       )}
                     >
@@ -385,8 +395,8 @@ export const CancelSubscriptionDialog = ({
                         className={cn(
                           "flex size-8 shrink-0 items-center justify-center rounded-md text-sm font-semibold",
                           isSelected
-                            ? "bg-lime-400 text-black"
-                            : "bg-lime-400/15 text-lime-400",
+                            ? "bg-premium-text text-background"
+                            : "bg-premium-bg text-premium-text",
                         )}
                       >
                         {reasonOptionBadges[index]}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as cancellationReasons from "../cancellationReasons.js";
 import type * as chatStreams from "../chatStreams.js";
 import type * as chats from "../chats.js";
 import type * as constants from "../constants.js";
@@ -47,6 +48,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  cancellationReasons: typeof cancellationReasons;
   chatStreams: typeof chatStreams;
   chats: typeof chats;
   constants: typeof constants;

--- a/convex/cancellationReasons.ts
+++ b/convex/cancellationReasons.ts
@@ -5,6 +5,9 @@ import { validateServiceKey } from "./lib/utils";
 const RECENT_USAGE_DAYS = 30;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const MAX_REASON_DETAILS_LENGTH = 2_000;
+const MAX_RECENT_USAGE_LOGS = 5_000;
+const MAX_COMPLETION_CANDIDATES = 100;
+const MAX_REPORT_ROWS = 10_000;
 
 const subscriptionTierValidator = v.union(
   v.literal("free"),
@@ -31,6 +34,11 @@ const usageSegmentValidator = v.union(
   v.literal("light"),
   v.literal("moderate"),
   v.literal("heavy"),
+);
+
+const sourceValidator = v.union(
+  v.literal("in_app"),
+  v.literal("billing_portal"),
 );
 
 type RecentUsageSegment = "none" | "light" | "moderate" | "heavy";
@@ -71,7 +79,8 @@ async function recentUsageSummary(
     .withIndex("by_user", (q) =>
       q.eq("user_id", userId).gte("_creationTime", startTime),
     )
-    .collect();
+    .order("desc")
+    .take(MAX_RECENT_USAGE_LOGS);
 
   const requestCount = logs.length;
   const costDollars = logs.reduce(
@@ -106,6 +115,7 @@ export const recordCancellationStarted = mutation({
     accountCreatedAt: v.optional(v.number()),
     accountAgeDays: v.optional(v.number()),
     startedAt: v.optional(v.number()),
+    source: v.optional(sourceValidator),
   },
   returns: v.id("cancellation_reasons"),
   handler: async (ctx, args) => {
@@ -115,7 +125,7 @@ export const recordCancellationStarted = mutation({
     const recentUsage = await recentUsageSummary(ctx, args.userId, now);
     const reasonDetails = normalizeReasonDetails(args.reasonDetails);
 
-    return await ctx.db.insert("cancellation_reasons", {
+    const cancellationReasonId = await ctx.db.insert("cancellation_reasons", {
       user_id: args.userId,
       organization_id: args.organizationId,
       stripe_customer_id: args.stripeCustomerId,
@@ -124,9 +134,8 @@ export const recordCancellationStarted = mutation({
       plan: args.plan,
       subscription_tier: args.subscriptionTier,
       reason_category: args.reasonCategory,
-      reason_details: reasonDetails,
       status: "started",
-      source: "billing_portal",
+      source: args.source ?? "in_app",
       started_at: now,
       account_created_at: args.accountCreatedAt,
       account_age_days: args.accountAgeDays,
@@ -137,6 +146,21 @@ export const recordCancellationStarted = mutation({
       recent_usage_segment: recentUsage.segment,
       updated_at: now,
     });
+
+    const reasonDetailsId = await ctx.db.insert("cancellation_reason_details", {
+      cancellation_reason_id: cancellationReasonId,
+      user_id: args.userId,
+      organization_id: args.organizationId,
+      stripe_subscription_id: args.stripeSubscriptionId,
+      reason_details: reasonDetails,
+      created_at: now,
+    });
+
+    await ctx.db.patch(cancellationReasonId, {
+      reason_details_id: reasonDetailsId,
+    });
+
+    return cancellationReasonId;
   },
 });
 
@@ -164,7 +188,8 @@ export const markCancellationCompleted = mutation({
       .withIndex("by_stripe_subscription_id", (q) =>
         q.eq("stripe_subscription_id", args.stripeSubscriptionId),
       )
-      .collect();
+      .order("desc")
+      .take(MAX_COMPLETION_CANDIDATES);
 
     const userIdSet = args.userIds ? new Set(args.userIds) : null;
     const candidates = rows
@@ -230,7 +255,8 @@ export const getCancellationReasonReport = query({
         }
         return q;
       })
-      .collect();
+      .order("desc")
+      .take(MAX_REPORT_ROWS);
 
     const groups = new Map<
       string,

--- a/convex/cancellationReasons.ts
+++ b/convex/cancellationReasons.ts
@@ -1,0 +1,295 @@
+import { mutation, query, type MutationCtx } from "./_generated/server";
+import { v } from "convex/values";
+import { validateServiceKey } from "./lib/utils";
+
+const RECENT_USAGE_DAYS = 30;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const MAX_REASON_DETAILS_LENGTH = 2_000;
+
+const subscriptionTierValidator = v.union(
+  v.literal("free"),
+  v.literal("pro"),
+  v.literal("pro-plus"),
+  v.literal("ultra"),
+  v.literal("team"),
+);
+
+const reasonCategoryValidator = v.union(
+  v.literal("too_expensive"),
+  v.literal("not_using_enough"),
+  v.literal("missing_feature"),
+  v.literal("results_not_good_enough"),
+  v.literal("too_slow_or_unreliable"),
+  v.literal("hit_usage_limits"),
+  v.literal("switched_tool"),
+  v.literal("temporary_pause"),
+  v.literal("other"),
+);
+
+const usageSegmentValidator = v.union(
+  v.literal("none"),
+  v.literal("light"),
+  v.literal("moderate"),
+  v.literal("heavy"),
+);
+
+type RecentUsageSegment = "none" | "light" | "moderate" | "heavy";
+type CancellationReasonCategory =
+  | "too_expensive"
+  | "not_using_enough"
+  | "missing_feature"
+  | "results_not_good_enough"
+  | "too_slow_or_unreliable"
+  | "hit_usage_limits"
+  | "switched_tool"
+  | "temporary_pause"
+  | "other";
+
+function usageSegment(requestCount: number): RecentUsageSegment {
+  if (requestCount <= 0) return "none";
+  if (requestCount <= 10) return "light";
+  if (requestCount <= 50) return "moderate";
+  return "heavy";
+}
+
+function normalizeReasonDetails(details: string): string {
+  const normalized = details.trim().slice(0, MAX_REASON_DETAILS_LENGTH);
+  if (!normalized) {
+    throw new Error("Cancellation reason details are required");
+  }
+  return normalized;
+}
+
+async function recentUsageSummary(
+  ctx: MutationCtx,
+  userId: string,
+  now: number,
+) {
+  const startTime = now - RECENT_USAGE_DAYS * MS_PER_DAY;
+  const logs = await ctx.db
+    .query("usage_logs")
+    .withIndex("by_user", (q) =>
+      q.eq("user_id", userId).gte("_creationTime", startTime),
+    )
+    .collect();
+
+  const requestCount = logs.length;
+  const costDollars = logs.reduce(
+    (sum, log) => sum + (log.cost_dollars ?? 0),
+    0,
+  );
+  const totalTokens = logs.reduce(
+    (sum, log) => sum + (log.total_tokens ?? 0),
+    0,
+  );
+
+  return {
+    requestCount,
+    costDollars,
+    totalTokens,
+    segment: usageSegment(requestCount),
+  };
+}
+
+export const recordCancellationStarted = mutation({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+    organizationId: v.optional(v.string()),
+    stripeCustomerId: v.optional(v.string()),
+    stripeSubscriptionId: v.optional(v.string()),
+    stripePriceId: v.optional(v.string()),
+    plan: v.optional(v.string()),
+    subscriptionTier: v.optional(subscriptionTierValidator),
+    reasonCategory: reasonCategoryValidator,
+    reasonDetails: v.string(),
+    accountCreatedAt: v.optional(v.number()),
+    accountAgeDays: v.optional(v.number()),
+    startedAt: v.optional(v.number()),
+  },
+  returns: v.id("cancellation_reasons"),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const now = args.startedAt ?? Date.now();
+    const recentUsage = await recentUsageSummary(ctx, args.userId, now);
+    const reasonDetails = normalizeReasonDetails(args.reasonDetails);
+
+    return await ctx.db.insert("cancellation_reasons", {
+      user_id: args.userId,
+      organization_id: args.organizationId,
+      stripe_customer_id: args.stripeCustomerId,
+      stripe_subscription_id: args.stripeSubscriptionId,
+      stripe_price_id: args.stripePriceId,
+      plan: args.plan,
+      subscription_tier: args.subscriptionTier,
+      reason_category: args.reasonCategory,
+      reason_details: reasonDetails,
+      status: "started",
+      source: "billing_portal",
+      started_at: now,
+      account_created_at: args.accountCreatedAt,
+      account_age_days: args.accountAgeDays,
+      recent_usage_days: RECENT_USAGE_DAYS,
+      recent_usage_request_count: recentUsage.requestCount,
+      recent_usage_cost_dollars: recentUsage.costDollars,
+      recent_usage_total_tokens: recentUsage.totalTokens,
+      recent_usage_segment: recentUsage.segment,
+      updated_at: now,
+    });
+  },
+});
+
+export const markCancellationCompleted = mutation({
+  args: {
+    serviceKey: v.string(),
+    stripeSubscriptionId: v.string(),
+    stripeCustomerId: v.optional(v.string()),
+    userIds: v.optional(v.array(v.string())),
+    organizationId: v.optional(v.string()),
+    subscriptionTier: v.optional(subscriptionTierValidator),
+    stripeCancellationReason: v.optional(v.string()),
+    cancelAtPeriodEnd: v.optional(v.boolean()),
+    completedAt: v.optional(v.number()),
+  },
+  returns: v.object({
+    matchedCount: v.number(),
+    updatedCount: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const rows = await ctx.db
+      .query("cancellation_reasons")
+      .withIndex("by_stripe_subscription_id", (q) =>
+        q.eq("stripe_subscription_id", args.stripeSubscriptionId),
+      )
+      .collect();
+
+    const userIdSet = args.userIds ? new Set(args.userIds) : null;
+    const candidates = rows
+      .filter((row) => row.status !== "completed")
+      .filter((row) => !userIdSet || userIdSet.has(row.user_id))
+      .sort((a, b) => b.started_at - a.started_at);
+
+    const target = candidates[0];
+    if (!target) {
+      return { matchedCount: rows.length, updatedCount: 0 };
+    }
+
+    const completedAt = args.completedAt ?? Date.now();
+    await ctx.db.patch(target._id, {
+      status: "completed",
+      completed_at: completedAt,
+      stripe_customer_id: args.stripeCustomerId ?? target.stripe_customer_id,
+      organization_id: args.organizationId ?? target.organization_id,
+      subscription_tier: args.subscriptionTier ?? target.subscription_tier,
+      stripe_cancellation_reason: args.stripeCancellationReason,
+      cancel_at_period_end: args.cancelAtPeriodEnd,
+      updated_at: completedAt,
+    });
+
+    return { matchedCount: rows.length, updatedCount: 1 };
+  },
+});
+
+export const getCancellationReasonReport = query({
+  args: {
+    serviceKey: v.string(),
+    startAt: v.optional(v.number()),
+    endAt: v.optional(v.number()),
+    subscriptionTier: v.optional(subscriptionTierValidator),
+    recentUsageSegment: v.optional(usageSegmentValidator),
+  },
+  returns: v.array(
+    v.object({
+      plan: v.string(),
+      subscriptionTier: v.string(),
+      recentUsageSegment: usageSegmentValidator,
+      reasonCategory: reasonCategoryValidator,
+      startedCount: v.number(),
+      completedCount: v.number(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const rows = await ctx.db
+      .query("cancellation_reasons")
+      .withIndex("by_started_at", (q) => {
+        if (args.startAt !== undefined && args.endAt !== undefined) {
+          return q
+            .gte("started_at", args.startAt)
+            .lte("started_at", args.endAt);
+        }
+        if (args.startAt !== undefined) {
+          return q.gte("started_at", args.startAt);
+        }
+        if (args.endAt !== undefined) {
+          return q.lte("started_at", args.endAt);
+        }
+        return q;
+      })
+      .collect();
+
+    const groups = new Map<
+      string,
+      {
+        plan: string;
+        subscriptionTier: string;
+        recentUsageSegment: RecentUsageSegment;
+        reasonCategory: CancellationReasonCategory;
+        startedCount: number;
+        completedCount: number;
+      }
+    >();
+
+    for (const row of rows) {
+      if (
+        args.subscriptionTier &&
+        row.subscription_tier !== args.subscriptionTier
+      ) {
+        continue;
+      }
+      if (
+        args.recentUsageSegment &&
+        row.recent_usage_segment !== args.recentUsageSegment
+      ) {
+        continue;
+      }
+
+      const plan = row.plan ?? "unknown";
+      const tier = row.subscription_tier ?? "unknown";
+      const key = [
+        plan,
+        tier,
+        row.recent_usage_segment,
+        row.reason_category,
+      ].join("|");
+      const group = groups.get(key) ?? {
+        plan,
+        subscriptionTier: tier,
+        recentUsageSegment: row.recent_usage_segment,
+        reasonCategory: row.reason_category,
+        startedCount: 0,
+        completedCount: 0,
+      };
+
+      group.startedCount += 1;
+      if (row.status === "completed") {
+        group.completedCount += 1;
+      }
+      groups.set(key, group);
+    }
+
+    return Array.from(groups.values()).sort((a, b) => {
+      const tierCompare = a.subscriptionTier.localeCompare(b.subscriptionTier);
+      if (tierCompare !== 0) return tierCompare;
+      const segmentCompare = a.recentUsageSegment.localeCompare(
+        b.recentUsageSegment,
+      );
+      if (segmentCompare !== 0) return segmentCompare;
+      return b.startedCount - a.startedCount;
+    });
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -187,8 +187,11 @@ export default defineSchema({
     created_at: v.number(),
   })
     .index("by_cancellation_reason_id", ["cancellation_reason_id"])
-    .index("by_user_created", ["user_id", "created_at"])
-    .index("by_subscription_created", ["stripe_subscription_id", "created_at"]),
+    .index("by_user_id_and_created_at", ["user_id", "created_at"])
+    .index("by_stripe_subscription_id_and_created_at", [
+      "stripe_subscription_id",
+      "created_at",
+    ]),
 
   user_customization: defineTable({
     user_id: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -122,6 +122,62 @@ export default defineSchema({
     feedback_details: v.optional(v.string()),
   }),
 
+  cancellation_reasons: defineTable({
+    user_id: v.string(),
+    organization_id: v.optional(v.string()),
+    stripe_customer_id: v.optional(v.string()),
+    stripe_subscription_id: v.optional(v.string()),
+    stripe_price_id: v.optional(v.string()),
+    plan: v.optional(v.string()),
+    subscription_tier: v.optional(
+      v.union(
+        v.literal("free"),
+        v.literal("pro"),
+        v.literal("pro-plus"),
+        v.literal("ultra"),
+        v.literal("team"),
+      ),
+    ),
+    reason_category: v.union(
+      v.literal("too_expensive"),
+      v.literal("not_using_enough"),
+      v.literal("missing_feature"),
+      v.literal("results_not_good_enough"),
+      v.literal("too_slow_or_unreliable"),
+      v.literal("hit_usage_limits"),
+      v.literal("switched_tool"),
+      v.literal("temporary_pause"),
+      v.literal("other"),
+    ),
+    reason_details: v.string(),
+    status: v.union(v.literal("started"), v.literal("completed")),
+    source: v.literal("billing_portal"),
+    started_at: v.number(),
+    completed_at: v.optional(v.number()),
+    account_created_at: v.optional(v.number()),
+    account_age_days: v.optional(v.number()),
+    recent_usage_days: v.number(),
+    recent_usage_request_count: v.number(),
+    recent_usage_cost_dollars: v.number(),
+    recent_usage_total_tokens: v.number(),
+    recent_usage_segment: v.union(
+      v.literal("none"),
+      v.literal("light"),
+      v.literal("moderate"),
+      v.literal("heavy"),
+    ),
+    stripe_cancellation_reason: v.optional(v.string()),
+    cancel_at_period_end: v.optional(v.boolean()),
+    updated_at: v.number(),
+  })
+    .index("by_user_started", ["user_id", "started_at"])
+    .index("by_org_started", ["organization_id", "started_at"])
+    .index("by_stripe_subscription_id", ["stripe_subscription_id"])
+    .index("by_stripe_customer_id", ["stripe_customer_id"])
+    .index("by_tier_started", ["subscription_tier", "started_at"])
+    .index("by_started_at", ["started_at"])
+    .index("by_status_started", ["status", "started_at"]),
+
   user_customization: defineTable({
     user_id: v.string(),
     nickname: v.optional(v.string()),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -149,9 +149,9 @@ export default defineSchema({
       v.literal("temporary_pause"),
       v.literal("other"),
     ),
-    reason_details: v.string(),
+    reason_details_id: v.optional(v.id("cancellation_reason_details")),
     status: v.union(v.literal("started"), v.literal("completed")),
-    source: v.literal("billing_portal"),
+    source: v.union(v.literal("in_app"), v.literal("billing_portal")),
     started_at: v.number(),
     completed_at: v.optional(v.number()),
     account_created_at: v.optional(v.number()),
@@ -177,6 +177,18 @@ export default defineSchema({
     .index("by_tier_started", ["subscription_tier", "started_at"])
     .index("by_started_at", ["started_at"])
     .index("by_status_started", ["status", "started_at"]),
+
+  cancellation_reason_details: defineTable({
+    cancellation_reason_id: v.id("cancellation_reasons"),
+    user_id: v.string(),
+    organization_id: v.optional(v.string()),
+    stripe_subscription_id: v.optional(v.string()),
+    reason_details: v.string(),
+    created_at: v.number(),
+  })
+    .index("by_cancellation_reason_id", ["cancellation_reason_id"])
+    .index("by_user_created", ["user_id", "created_at"])
+    .index("by_subscription_created", ["stripe_subscription_id", "created_at"]),
 
   user_customization: defineTable({
     user_id: v.string(),

--- a/lib/actions/billing-context.ts
+++ b/lib/actions/billing-context.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { workos } from "@/app/api/workos";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+
+export type BillingActionContext = {
+  organizationId: string;
+  user: NonNullable<Awaited<ReturnType<typeof withAuth>>["user"]>;
+  stripeCustomerId: string;
+};
+
+export async function getBillingActionContext(): Promise<BillingActionContext> {
+  const { organizationId, user } = await withAuth();
+
+  if (!user?.id) {
+    throw new Error("User not authenticated");
+  }
+
+  if (!organizationId) {
+    throw new Error("No organization found");
+  }
+
+  const memberships = await workos.userManagement.listOrganizationMemberships({
+    userId: user.id,
+    organizationId,
+    statuses: ["active"],
+  });
+
+  const userMembership = memberships.data[0];
+  if (!userMembership) {
+    throw new Error("User is not a member of this organization");
+  }
+
+  if (
+    userMembership.role?.slug !== "admin" &&
+    userMembership.role?.slug !== "owner"
+  ) {
+    throw new Error("Only admins or owners can manage billing");
+  }
+
+  const response = await fetch(
+    `${workos.baseURL}/organizations/${organizationId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.WORKOS_API_KEY}`,
+        "content-type": "application/json",
+      },
+    },
+  );
+  if (!response.ok) {
+    throw new Error("Failed to fetch organization details");
+  }
+  const workosOrg = await response.json();
+
+  if (!workosOrg?.stripe_customer_id) {
+    throw new Error("No billing account found for this organization");
+  }
+
+  return {
+    organizationId,
+    user,
+    stripeCustomerId: workosOrg.stripe_customer_id,
+  };
+}

--- a/lib/actions/billing-portal.ts
+++ b/lib/actions/billing-portal.ts
@@ -1,60 +1,14 @@
 "use server";
 
 import { stripe } from "../../app/api/stripe";
-import { workos } from "@/app/api/workos";
-import { withAuth } from "@workos-inc/authkit-nextjs";
+import { getBillingActionContext } from "@/lib/actions/billing-context";
 
 export default async function redirectToBillingPortal() {
-  const { organizationId, user } = await withAuth();
-
-  if (!user?.id) {
-    throw new Error("User not authenticated");
-  }
-
-  if (!organizationId) {
-    throw new Error("No organization found");
-  }
-
-  // Check if user can manage billing for the organization.
-  const memberships = await workos.userManagement.listOrganizationMemberships({
-    userId: user.id,
-    organizationId,
-    statuses: ["active"],
-  });
-
-  const userMembership = memberships.data[0];
-  if (!userMembership) {
-    throw new Error("User is not a member of this organization");
-  }
-
-  if (
-    userMembership.role?.slug !== "admin" &&
-    userMembership.role?.slug !== "owner"
-  ) {
-    throw new Error("Only admins or owners can manage billing");
-  }
-
-  const response = await fetch(
-    `${workos.baseURL}/organizations/${organizationId}`,
-    {
-      headers: {
-        Authorization: `Bearer ${process.env.WORKOS_API_KEY}`,
-        "content-type": "application/json",
-      },
-    },
-  );
-  if (!response.ok) {
-    throw new Error("Failed to fetch organization details");
-  }
-  const workosOrg = await response.json();
-
-  if (!workosOrg?.stripe_customer_id) {
-    throw new Error("No billing account found for this organization");
-  }
+  const { stripeCustomerId } = await getBillingActionContext();
 
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
   const billingPortalSession = await stripe.billingPortal.sessions.create({
-    customer: workosOrg.stripe_customer_id,
+    customer: stripeCustomerId,
     return_url: `${baseUrl}`,
   });
 

--- a/lib/actions/cancel-subscription.ts
+++ b/lib/actions/cancel-subscription.ts
@@ -162,6 +162,7 @@ export default async function cancelSubscriptionAction(
           accountCreatedAt,
           accountAgeDays,
           startedAt: now,
+          source: "in_app",
         },
       );
     } catch (error) {

--- a/lib/actions/cancel-subscription.ts
+++ b/lib/actions/cancel-subscription.ts
@@ -1,0 +1,265 @@
+"use server";
+
+import { stripe } from "../../app/api/stripe";
+import { api } from "@/convex/_generated/api";
+import { getBillingActionContext } from "@/lib/actions/billing-context";
+import {
+  isCancellationReasonCategory,
+  normalizeCancellationReasonDetails,
+  type CancellationReasonCategory,
+} from "@/lib/billing/cancellation-reasons";
+import { getConvexClient } from "@/lib/db/convex-client";
+import { phLogger } from "@/lib/posthog/server";
+import {
+  PAID_FUNNEL_EVENTS,
+  paidFunnelProperties,
+  planLookupKeyToTier,
+} from "@/lib/analytics/paid-funnel";
+import type { SubscriptionTier } from "@/types";
+
+type CancellationReasonInput = {
+  reasonCategory: CancellationReasonCategory;
+  reasonDetails: string;
+};
+
+type CancelSubscriptionInput = {
+  cancellationReason: CancellationReasonInput;
+};
+
+type SubscriptionContext = {
+  id: string;
+  priceId?: string;
+  plan?: string;
+  tier?: SubscriptionTier;
+  currentPeriodEnd?: number;
+};
+
+function parseCancellationReasonInput(
+  value: CancelSubscriptionInput["cancellationReason"],
+): CancellationReasonInput {
+  const reasonCategory = value?.reasonCategory;
+  const reasonDetails = normalizeCancellationReasonDetails(
+    value?.reasonDetails,
+  );
+
+  if (!isCancellationReasonCategory(reasonCategory)) {
+    throw new Error("Please select the main cancellation reason");
+  }
+
+  if (!reasonDetails) {
+    throw new Error("Please write a cancellation reason before continuing");
+  }
+
+  return {
+    reasonCategory,
+    reasonDetails,
+  };
+}
+
+function parseCreatedAtMs(value: unknown): number | undefined {
+  const raw = (value as { createdAt?: unknown; created_at?: unknown }) ?? {};
+  const createdAt = raw.createdAt ?? raw.created_at;
+
+  if (createdAt instanceof Date) return createdAt.getTime();
+  if (typeof createdAt === "string" || typeof createdAt === "number") {
+    const timestamp = new Date(createdAt).getTime();
+    return Number.isFinite(timestamp) ? timestamp : undefined;
+  }
+
+  return undefined;
+}
+
+function subscriptionTierFromLookupKey(
+  lookupKey: string | null | undefined,
+): SubscriptionTier | undefined {
+  return planLookupKeyToTier(lookupKey ?? undefined) ?? undefined;
+}
+
+function currentPeriodEndMs(subscription: unknown): number | undefined {
+  const currentPeriodEnd = (subscription as { current_period_end?: unknown })
+    .current_period_end;
+  return typeof currentPeriodEnd === "number" &&
+    Number.isFinite(currentPeriodEnd) &&
+    currentPeriodEnd > 0
+    ? currentPeriodEnd * 1000
+    : undefined;
+}
+
+async function getActiveSubscriptionContext(
+  stripeCustomerId: string,
+): Promise<SubscriptionContext> {
+  const subscriptions = await stripe.subscriptions.list({
+    customer: stripeCustomerId,
+    status: "all",
+    limit: 10,
+    expand: ["data.items.data.price"],
+  });
+  const currentSubscription = subscriptions.data.find((subscription) =>
+    ["active", "trialing", "past_due", "unpaid"].includes(subscription.status),
+  );
+
+  if (!currentSubscription) {
+    throw new Error("No active subscription found");
+  }
+
+  if (currentSubscription.cancel_at_period_end) {
+    throw new Error("Your subscription is already scheduled to cancel");
+  }
+
+  const price = currentSubscription.items.data[0]?.price;
+  return {
+    id: currentSubscription.id,
+    priceId: price?.id,
+    plan: price?.lookup_key ?? undefined,
+    tier: subscriptionTierFromLookupKey(price?.lookup_key),
+    currentPeriodEnd: currentPeriodEndMs(currentSubscription),
+  };
+}
+
+function stripeCancellationFeedback(
+  reasonCategory: CancellationReasonCategory,
+) {
+  if (reasonCategory === "too_expensive") return "too_expensive";
+  if (reasonCategory === "missing_feature") return "missing_features";
+  if (reasonCategory === "switched_tool") return "switched_service";
+  if (reasonCategory === "not_using_enough") return "unused";
+  return "other";
+}
+
+export default async function cancelSubscriptionAction(
+  input: CancelSubscriptionInput,
+) {
+  const cancellationReason = parseCancellationReasonInput(
+    input.cancellationReason,
+  );
+  const { organizationId, user, stripeCustomerId } =
+    await getBillingActionContext();
+  const subscriptionContext =
+    await getActiveSubscriptionContext(stripeCustomerId);
+
+  const now = Date.now();
+  const accountCreatedAt = parseCreatedAtMs(user);
+  const accountAgeDays = accountCreatedAt
+    ? Math.max(0, Math.floor((now - accountCreatedAt) / 86_400_000))
+    : undefined;
+  const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY;
+
+  if (serviceKey) {
+    try {
+      await getConvexClient().mutation(
+        api.cancellationReasons.recordCancellationStarted,
+        {
+          serviceKey,
+          userId: user.id,
+          organizationId,
+          stripeCustomerId,
+          stripeSubscriptionId: subscriptionContext.id,
+          stripePriceId: subscriptionContext.priceId,
+          plan: subscriptionContext.plan,
+          subscriptionTier: subscriptionContext.tier,
+          reasonCategory: cancellationReason.reasonCategory,
+          reasonDetails: cancellationReason.reasonDetails,
+          accountCreatedAt,
+          accountAgeDays,
+          startedAt: now,
+        },
+      );
+    } catch (error) {
+      phLogger.error("Failed to record cancellation reason", {
+        userId: user.id,
+        org_id: organizationId,
+        stripe_customer_id: stripeCustomerId,
+        stripe_subscription_id: subscriptionContext.id,
+        error,
+      });
+    }
+  } else {
+    phLogger.error("Failed to record cancellation reason", {
+      userId: user.id,
+      org_id: organizationId,
+      stripe_customer_id: stripeCustomerId,
+      stripe_subscription_id: subscriptionContext.id,
+      error: new Error("CONVEX_SERVICE_ROLE_KEY is not set"),
+    });
+  }
+
+  const updatedSubscription = await stripe.subscriptions.update(
+    subscriptionContext.id,
+    {
+      cancel_at_period_end: true,
+      cancellation_details: {
+        feedback: stripeCancellationFeedback(cancellationReason.reasonCategory),
+      },
+    },
+  );
+
+  const completedAt = updatedSubscription.canceled_at
+    ? updatedSubscription.canceled_at * 1000
+    : Date.now();
+
+  if (serviceKey) {
+    try {
+      await getConvexClient().mutation(
+        api.cancellationReasons.markCancellationCompleted,
+        {
+          serviceKey,
+          stripeSubscriptionId: subscriptionContext.id,
+          stripeCustomerId,
+          userIds: [user.id],
+          organizationId,
+          subscriptionTier: subscriptionContext.tier,
+          stripeCancellationReason:
+            updatedSubscription.cancellation_details?.reason ?? undefined,
+          cancelAtPeriodEnd: updatedSubscription.cancel_at_period_end,
+          completedAt,
+        },
+      );
+    } catch (error) {
+      phLogger.warn("cancellation_reason_completion_update_failed", {
+        userId: user.id,
+        org_id: organizationId,
+        stripe_customer_id: stripeCustomerId,
+        stripe_subscription_id: subscriptionContext.id,
+        error,
+      });
+    }
+  }
+
+  phLogger.event(
+    PAID_FUNNEL_EVENTS.cancellationReasonSubmitted,
+    paidFunnelProperties({
+      userId: user.id,
+      org_id: organizationId,
+      subscription_tier: subscriptionContext.tier,
+      plan: subscriptionContext.plan,
+      reason_category: cancellationReason.reasonCategory,
+      reason_details_length: cancellationReason.reasonDetails.length,
+      stripe_customer_id: stripeCustomerId,
+      stripe_subscription_id: subscriptionContext.id,
+    }),
+  );
+  phLogger.event(
+    PAID_FUNNEL_EVENTS.cancellationCompleted,
+    paidFunnelProperties({
+      userId: user.id,
+      org_id: organizationId,
+      subscription_tier: subscriptionContext.tier,
+      plan: subscriptionContext.plan,
+      reason_category: cancellationReason.reasonCategory,
+      cancellation_completion_type: "scheduled_in_app",
+      cancel_at_period_end: updatedSubscription.cancel_at_period_end,
+      stripe_customer_id: stripeCustomerId,
+      stripe_subscription_id: subscriptionContext.id,
+      stripe_price_id: subscriptionContext.priceId,
+      $insert_id: `${PAID_FUNNEL_EVENTS.cancellationCompleted}:${subscriptionContext.id}:in_app`,
+    }),
+  );
+
+  return {
+    canceled: true,
+    cancelAtPeriodEnd: updatedSubscription.cancel_at_period_end,
+    currentPeriodEnd:
+      currentPeriodEndMs(updatedSubscription) ??
+      subscriptionContext.currentPeriodEnd,
+  };
+}

--- a/lib/analytics/paid-funnel.ts
+++ b/lib/analytics/paid-funnel.ts
@@ -9,6 +9,10 @@ export const PAID_FUNNEL_EVENTS = {
   addCreditCheckoutSucceeded: "add_credit_checkout_succeeded",
   checkoutStarted: "checkout_started",
   checkoutSucceeded: "checkout_succeeded",
+  cancellationStarted: "cancellation_started",
+  cancellationReasonSelected: "cancellation_reason_selected",
+  cancellationReasonSubmitted: "cancellation_reason_free_text_submitted",
+  cancellationCompleted: "cancellation_completed",
   limitHit: "limit_hit",
 } as const;
 

--- a/lib/billing/__tests__/cancellation-reasons.test.ts
+++ b/lib/billing/__tests__/cancellation-reasons.test.ts
@@ -1,0 +1,29 @@
+import {
+  CANCELLATION_REASON_DETAILS_MAX_LENGTH,
+  isCancellationReasonCategory,
+  normalizeCancellationReasonDetails,
+} from "../cancellation-reasons";
+
+describe("cancellation reason helpers", () => {
+  it("recognizes only supported reason categories", () => {
+    expect(isCancellationReasonCategory("too_expensive")).toBe(true);
+    expect(isCancellationReasonCategory("temporary_pause")).toBe(true);
+    expect(isCancellationReasonCategory("")).toBe(false);
+    expect(isCancellationReasonCategory("too expensive")).toBe(false);
+  });
+
+  it("requires written details", () => {
+    expect(normalizeCancellationReasonDetails("  too pricey for now  ")).toBe(
+      "too pricey for now",
+    );
+    expect(normalizeCancellationReasonDetails("   ")).toBeNull();
+    expect(normalizeCancellationReasonDetails(undefined)).toBeNull();
+  });
+
+  it("caps written details before storage", () => {
+    const oversized = "x".repeat(CANCELLATION_REASON_DETAILS_MAX_LENGTH + 10);
+    expect(normalizeCancellationReasonDetails(oversized)).toHaveLength(
+      CANCELLATION_REASON_DETAILS_MAX_LENGTH,
+    );
+  });
+});

--- a/lib/billing/cancellation-reasons.ts
+++ b/lib/billing/cancellation-reasons.ts
@@ -1,0 +1,37 @@
+export const CANCELLATION_REASON_DETAILS_MAX_LENGTH = 2_000;
+
+export const CANCELLATION_REASON_OPTIONS = [
+  { value: "too_expensive", label: "Too expensive" },
+  { value: "not_using_enough", label: "Not using it enough" },
+  { value: "missing_feature", label: "Missing feature" },
+  { value: "results_not_good_enough", label: "Results were not good enough" },
+  { value: "too_slow_or_unreliable", label: "Too slow or unreliable" },
+  { value: "hit_usage_limits", label: "Hit usage limits too often" },
+  { value: "switched_tool", label: "Switched to another tool" },
+  { value: "temporary_pause", label: "Temporary pause / will return later" },
+  { value: "other", label: "Other" },
+] as const;
+
+export type CancellationReasonCategory =
+  (typeof CANCELLATION_REASON_OPTIONS)[number]["value"];
+
+const CANCELLATION_REASON_VALUES = new Set<string>(
+  CANCELLATION_REASON_OPTIONS.map((option) => option.value),
+);
+
+export function isCancellationReasonCategory(
+  value: unknown,
+): value is CancellationReasonCategory {
+  return typeof value === "string" && CANCELLATION_REASON_VALUES.has(value);
+}
+
+export function normalizeCancellationReasonDetails(
+  value: unknown,
+): string | null {
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  return trimmed.slice(0, CANCELLATION_REASON_DETAILS_MAX_LENGTH);
+}


### PR DESCRIPTION
## Summary

- Require a cancellation reason category and written details before a paid user cancels.
- Replace the Stripe portal redirect for cancellation with an in-app server action that schedules `cancel_at_period_end` through Stripe.
- Store cancellation reasons in Convex with plan, tier, subscription, account age, and recent usage segment fields, plus a grouped report query.
- Keep detailed free text in our storage path; Stripe receives only a coarse cancellation feedback enum.
- Reconcile completed cancellations from Stripe subscription update/delete webhooks.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm exec eslint app/components/CancelSubscriptionDialog.tsx app/api/subscription/webhook/route.ts lib/actions/billing-context.ts lib/actions/billing-portal.ts lib/actions/cancel-subscription.ts lib/billing/cancellation-reasons.ts lib/billing/__tests__/cancellation-reasons.test.ts convex/cancellationReasons.ts`
- `pnpm exec prettier --check app/components/CancelSubscriptionDialog.tsx app/api/subscription/webhook/route.ts lib/actions/billing-context.ts lib/actions/billing-portal.ts lib/actions/cancel-subscription.ts lib/billing/cancellation-reasons.ts lib/billing/__tests__/cancellation-reasons.test.ts convex/cancellationReasons.ts convex/schema.ts lib/analytics/paid-funnel.ts convex/_generated/api.d.ts`
- `pnpm test -- lib/billing/__tests__/cancellation-reasons.test.ts --runInBand`
- `pnpm exec convex codegen`
- Full commit hook: `tsc --noEmit` and full `jest` suite, 125 suites / 1396 tests passed

## Notes

- Browser sanity check rendered the local homepage without console errors on `localhost:3001`; I did not perform a live authenticated Stripe cancellation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app cancellation flow: required reason/details, validation, two-step confirm UI, loading state, and “keep until end of billing period” messaging
  * Server-side cancel action that schedules end-of-period cancellations and returns scheduling info

* **Analytics**
  * New paid-funnel events: cancellationStarted, cancellationReasonSelected, cancellationReasonSubmitted, cancellationCompleted

* **Backend**
  * Cancellation tracking and reporting for started vs completed cancellations, including scheduled and deleted completions and normalized reason details
  * New billing-context helper to resolve customer identifiers

* **Refactor**
  * Simplified billing portal session flow

* **Tests**
  * Tests for cancellation-reason validation and normalization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->