### PR TITLE
[codex] Retry agent-long reasoning-only stream failures

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -222,6 +222,32 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(throwIdx).toBeGreaterThan(terminalErrorIdx);
   });
 
+  test("provider stream errors with reasoning-only output can retry on fallback", () => {
+    const helperImportIdx = taskSrc.indexOf("shouldRetryAgentLongWithFallback");
+    const partsIdx = taskSrc.indexOf(
+      "const lastAssistantMessageParts",
+      helperImportIdx,
+    );
+    const retryDecisionIdx = taskSrc.indexOf(
+      "shouldRetryAgentLongWithFallback(",
+      partsIdx,
+    );
+    const terminalProviderErrorIdx = taskSrc.indexOf(
+      "hasTerminalProviderStreamError:",
+      retryDecisionIdx,
+    );
+    const fallbackIdx = taskSrc.indexOf(
+      "const retryResult = await createStream(fallbackModel)",
+      terminalProviderErrorIdx,
+    );
+
+    expect(helperImportIdx).toBeGreaterThan(-1);
+    expect(partsIdx).toBeGreaterThan(helperImportIdx);
+    expect(retryDecisionIdx).toBeGreaterThan(partsIdx);
+    expect(terminalProviderErrorIdx).toBeGreaterThan(retryDecisionIdx);
+    expect(fallbackIdx).toBeGreaterThan(terminalProviderErrorIdx);
+  });
+
   test("outer catch checks live usage tracker before refunding", () => {
     const liveUsagePredicateIdx = taskSrc.indexOf(
       "const hasObservedUsage = () => !!observedUsageTracker?.hasUsage",

--- a/lib/chat/__tests__/agent-long-provider-retry.test.ts
+++ b/lib/chat/__tests__/agent-long-provider-retry.test.ts
@@ -1,0 +1,96 @@
+import { shouldRetryAgentLongWithFallback } from "../agent-long-provider-retry";
+
+describe("shouldRetryAgentLongWithFallback", () => {
+  it("preserves the legacy retry for streams that only emitted step-start", () => {
+    expect(
+      shouldRetryAgentLongWithFallback([{ type: "step-start" }], {
+        hasTerminalProviderStreamError: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("retries terminal provider errors that emitted only reasoning", () => {
+    expect(
+      shouldRetryAgentLongWithFallback(
+        [
+          { type: "step-start" },
+          { type: "reasoning", text: "thinking", state: "done" },
+        ],
+        { hasTerminalProviderStreamError: true },
+      ),
+    ).toBe(true);
+  });
+
+  it("allows hidden metadata around reasoning-only provider output", () => {
+    expect(
+      shouldRetryAgentLongWithFallback(
+        [
+          { type: "data-agent-heartbeat", data: { at: 1 } },
+          { type: "step-start" },
+          { type: "reasoning", text: "thinking", state: "done" },
+          { type: "data-context-usage", data: { usedTokens: 100 } },
+        ],
+        { hasTerminalProviderStreamError: true },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not retry reasoning-only output for a non-terminal provider stream", () => {
+    expect(
+      shouldRetryAgentLongWithFallback(
+        [
+          { type: "step-start" },
+          { type: "reasoning", text: "thinking", state: "done" },
+        ],
+        { hasTerminalProviderStreamError: false },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not discard visible text when a provider stream fails", () => {
+    expect(
+      shouldRetryAgentLongWithFallback(
+        [
+          { type: "step-start" },
+          { type: "reasoning", text: "thinking", state: "done" },
+          { type: "text", text: "visible answer" },
+        ],
+        { hasTerminalProviderStreamError: true },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not discard tool calls or tool output when a provider stream fails", () => {
+    expect(
+      shouldRetryAgentLongWithFallback(
+        [
+          { type: "step-start" },
+          {
+            type: "tool-shell",
+            toolCallId: "call_1",
+            state: "output-available",
+          },
+        ],
+        { hasTerminalProviderStreamError: true },
+      ),
+    ).toBe(false);
+
+    expect(
+      shouldRetryAgentLongWithFallback(
+        [
+          { type: "step-start" },
+          { type: "data-terminal", data: { toolCallId: "call_1" } },
+        ],
+        { hasTerminalProviderStreamError: true },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not retry empty assistant output", () => {
+    expect(
+      shouldRetryAgentLongWithFallback([], {
+        hasTerminalProviderStreamError: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/lib/chat/agent-long-provider-retry.ts
+++ b/lib/chat/agent-long-provider-retry.ts
@@ -1,0 +1,54 @@
+type MessagePartLike = {
+  type?: unknown;
+};
+
+type RetryDecisionOptions = {
+  hasTerminalProviderStreamError: boolean;
+};
+
+const FALLBACK_SAFE_METADATA_PART_TYPES = new Set([
+  "data-agent-heartbeat",
+  "data-context-usage",
+]);
+
+const getPartType = (part: unknown): string | undefined => {
+  if (!part || typeof part !== "object") return undefined;
+  const type = (part as MessagePartLike).type;
+  return typeof type === "string" ? type : undefined;
+};
+
+const isOnlyStepStart = (parts: unknown[]): boolean =>
+  parts.length === 1 && getPartType(parts[0]) === "step-start";
+
+const isFallbackSafeProviderPart = (part: unknown): boolean => {
+  const type = getPartType(part);
+  return (
+    type === "step-start" ||
+    type === "reasoning" ||
+    (type != null && FALLBACK_SAFE_METADATA_PART_TYPES.has(type))
+  );
+};
+
+const hasReasoningPart = (parts: unknown[]): boolean =>
+  parts.some((part) => getPartType(part) === "reasoning");
+
+const isReasoningOnlyProviderOutput = (parts: unknown[]): boolean =>
+  parts.length > 0 &&
+  hasReasoningPart(parts) &&
+  parts.every(isFallbackSafeProviderPart);
+
+export const shouldRetryAgentLongWithFallback = (
+  parts: unknown[],
+  options: RetryDecisionOptions,
+): boolean => {
+  // Preserve the older guard for streams that never got past the first step.
+  if (isOnlyStepStart(parts)) return true;
+
+  // If the provider stream dies after emitting only reasoning/metadata, there
+  // is no text, tool call, or tool output to preserve. Retrying on fallback is
+  // safer than failing the whole run on a discarded provider socket.
+  return (
+    options.hasTerminalProviderStreamError &&
+    isReasoningOnlyProviderOutput(parts)
+  );
+};

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -108,6 +108,7 @@ import {
   stripAgentLongHeartbeatParts,
 } from "@/lib/chat/agent-long-heartbeat";
 import { PREEMPTIVE_TIMEOUT_FINISH_REASON } from "@/lib/chat/stop-conditions";
+import { shouldRetryAgentLongWithFallback } from "@/lib/chat/agent-long-provider-retry";
 import { FREE_AGENT_LONG_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
 
 const AGENT_LONG_FREE_MAX_DURATION_SECONDS = 60 * 60;
@@ -1275,7 +1276,8 @@ export const agentLongTask = task({
                   }) => {
                     let retryScheduled = false;
                     try {
-                      // Retry with fallback if stream only produced step-start (incomplete response)
+                      // Retry with fallback if the primary stream failed before
+                      // producing text, tool calls, or tool output worth saving.
                       const lastAssistantMessage = finishedMessages
                         .slice()
                         .reverse()
@@ -1284,13 +1286,17 @@ export const agentLongTask = task({
                         stripAgentLongHeartbeatParts(
                           lastAssistantMessage ?? { parts: [] },
                         ).parts ?? [];
-                      const hasOnlyStepStart =
-                        lastAssistantMessageParts.length === 1 &&
-                        (lastAssistantMessageParts[0] as { type?: string })
-                          ?.type === "step-start";
+                      const shouldRetryWithFallback =
+                        shouldRetryAgentLongWithFallback(
+                          lastAssistantMessageParts,
+                          {
+                            hasTerminalProviderStreamError:
+                              isTerminalProviderStreamError(state),
+                          },
+                        );
 
                       if (
-                        hasOnlyStepStart &&
+                        shouldRetryWithFallback &&
                         !isRetryWithFallback &&
                         !isAborted &&
                         isAutoModel


### PR DESCRIPTION
## Summary

Adds a narrowly scoped fallback retry for `agent-long` provider stream failures that terminate after emitting only non-durable assistant output: `step-start`, reasoning, and hidden metadata.

## Why

OpenRouter/Moonshot streams can occasionally terminate mid-reasoning with `TypeError: terminated` / `UND_ERR_SOCKET`. Previously, `agent-long` only retried when the assistant message contained exactly `step-start`, so reasoning-only provider failures were surfaced as failed runs even though there was no visible text, tool call, or tool output worth preserving.

## Impact

When the primary auto-model stream dies before producing durable output, `agent-long` now retries on the configured fallback model. Visible partial responses and tool activity are still preserved and not silently discarded.

## Validation

- `pnpm exec jest --runTestsByPath lib/chat/__tests__/agent-long-provider-retry.test.ts lib/api/__tests__/agent-long-contracts.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint trigger/agent-long.ts lib/chat/agent-long-provider-retry.ts lib/chat/__tests__/agent-long-provider-retry.test.ts lib/api/__tests__/agent-long-contracts.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added broader test coverage for agent-long retry and fallback behavior to improve reliability.

* **Bug Fixes**
  * Improved handling when a provider stream terminates so agent-long runs can resort to a fallback provider without losing visible content or tool outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->