### PR TITLE
[codex] Allow Kimi image tool results

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -1,6 +1,7 @@
 import {
   sanitizeOpenRouterRequestForGeminiFunctionResponses,
   sanitizeOpenRouterRequestForXai,
+  supportsMultimodalToolResults,
 } from "@/lib/ai/providers";
 
 describe("sanitizeOpenRouterRequestForXai", () => {
@@ -215,5 +216,22 @@ describe("sanitizeOpenRouterRequestForGeminiFunctionResponses", () => {
     expect(
       sanitizeOpenRouterRequestForGeminiFunctionResponses(geminiBodyWithoutRef),
     ).toEqual({ body: geminiBodyWithoutRef, changed: false });
+  });
+});
+
+describe("supportsMultimodalToolResults", () => {
+  it("allows Kimi registry keys and OpenRouter slugs for image tool result experiments", () => {
+    expect(supportsMultimodalToolResults("model-kimi-k2.6")).toBe(true);
+    expect(supportsMultimodalToolResults("agent-model")).toBe(true);
+    expect(supportsMultimodalToolResults("moonshotai/kimi-k2.6:exacto")).toBe(
+      true,
+    );
+  });
+
+  it("still rejects text-only DeepSeek routes", () => {
+    expect(supportsMultimodalToolResults("agent-model-free")).toBe(false);
+    expect(supportsMultimodalToolResults("model-deepseek-v4-flash")).toBe(
+      false,
+    );
   });
 });

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -323,6 +323,16 @@ export function isDeepSeekModel(modelName: string): boolean {
   );
 }
 
+export function isKimiModel(modelName: string): boolean {
+  const normalized = modelName.toLowerCase();
+  return (
+    normalized === "agent-model" ||
+    normalized === "model-kimi-k2.6" ||
+    normalized.includes("moonshotai/kimi") ||
+    normalized.includes("kimi-")
+  );
+}
+
 export function supportsMultimodalToolResults(modelName?: string): boolean {
   if (!modelName) return false;
 
@@ -330,6 +340,7 @@ export function supportsMultimodalToolResults(modelName?: string): boolean {
 
   return (
     normalized === "ask-model" ||
+    isKimiModel(normalized) ||
     normalized.includes("gemini") ||
     normalized.includes("google/") ||
     isAnthropicModel(normalized) ||

--- a/lib/ai/tools/__tests__/file.test.ts
+++ b/lib/ai/tools/__tests__/file.test.ts
@@ -11,6 +11,7 @@ jest.mock("@/lib/logger", () => ({
 }));
 
 import { createFile } from "../file";
+import { uploadSandboxFileToConvex } from "../utils/sandbox-file-uploader";
 import type { ToolContext } from "@/types";
 
 type FakeCommandResult = {
@@ -19,7 +20,15 @@ type FakeCommandResult = {
   exitCode: number;
 };
 
-function makeContext(sandbox: unknown): ToolContext {
+const mockUploadSandboxFileToConvex =
+  uploadSandboxFileToConvex as jest.MockedFunction<
+    typeof uploadSandboxFileToConvex
+  >;
+
+function makeContext(
+  sandbox: unknown,
+  overrides: Partial<ToolContext> = {},
+): ToolContext {
   return {
     sandboxManager: {
       getSandbox: jest.fn(async () => ({ sandbox })),
@@ -44,6 +53,7 @@ function makeContext(sandbox: unknown): ToolContext {
     subscription: "pro",
     isE2BSandbox: (() => true) as never,
     caidoEnabled: false,
+    ...overrides,
   };
 }
 
@@ -61,6 +71,18 @@ async function runTool(
     abortSignal: undefined,
     messages: [],
   });
+}
+
+async function runToModelOutput(
+  tool: ReturnType<typeof createFile>,
+  output: unknown,
+) {
+  const toModelOutput = (
+    tool as unknown as {
+      toModelOutput: (i: { output: unknown }) => Promise<unknown>;
+    }
+  ).toModelOutput;
+  return toModelOutput({ output });
 }
 
 function makeSandbox(
@@ -322,5 +344,79 @@ describe("file tool large text safety", () => {
 
     expect(result.content).toContain("full diff preview was skipped");
     expect(sandbox.files.read).not.toHaveBeenCalled();
+  });
+});
+
+describe("file tool image view", () => {
+  beforeEach(() => {
+    mockUploadSandboxFileToConvex.mockReset();
+  });
+
+  test("allows Kimi to view sandbox images as multimodal tool output", async () => {
+    mockUploadSandboxFileToConvex.mockResolvedValue({
+      fileId: "file-1" as never,
+      name: "screenshot.png",
+      mediaType: "image/png",
+    });
+
+    const commandRun = jest
+      .fn<Promise<FakeCommandResult>, [string, any?]>()
+      .mockImplementationOnce(async (_command, opts) => {
+        expect(opts.envVars.HACKERAI_FILE_VIEW_INCLUDE_DATA).toBe("0");
+        return {
+          stdout: JSON.stringify({
+            path: "/tmp/screenshot.png",
+            mediaType: "image/png",
+            sizeBytes: 68,
+            kind: "image",
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      })
+      .mockImplementationOnce(async (_command, opts) => {
+        expect(opts.envVars.HACKERAI_FILE_VIEW_INCLUDE_DATA).toBe("1");
+        return {
+          stdout: JSON.stringify({
+            path: "/tmp/screenshot.png",
+            mediaType: "image/png",
+            sizeBytes: 68,
+            kind: "image",
+            data: "iVBORw0KGgo=",
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      });
+    const sandbox = makeSandbox(commandRun);
+    const tool = createFile(
+      makeContext(sandbox, { modelName: "model-kimi-k2.6" }),
+    );
+
+    const result = await runTool(tool, {
+      action: "view",
+      path: "/tmp/screenshot.png",
+      brief: "Inspect the screenshot",
+    });
+    expect(result).toMatchObject({
+      action: "view",
+      mediaType: "image/png",
+      kind: "image",
+    });
+
+    await expect(runToModelOutput(tool, result)).resolves.toEqual({
+      type: "content",
+      value: [
+        {
+          type: "text",
+          text: "Viewing image file: screenshot.png (image/png, 68 bytes).",
+        },
+        {
+          type: "image-data",
+          data: "iVBORw0KGgo=",
+          mediaType: "image/png",
+        },
+      ],
+    });
   });
 });

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -24,7 +24,7 @@ const FILE_ACTIONS_TEXT_ONLY = ["read", "write", "append", "edit"] as const;
 type FileAction = (typeof FILE_ACTIONS_WITH_VIEW)[number];
 
 const MULTIMODAL_UPGRADE_MESSAGE =
-  "The current model does not support multimodal tool results for sandbox images. Please select HackerAI Pro or HackerAI Max and retry the view action.";
+  "The current model does not support multimodal tool results for sandbox images. Please select a model with image viewing support and retry the view action.";
 
 type ViewKind = "image";
 
@@ -964,7 +964,7 @@ export const createFile = (context: ToolContext) => {
         ]
       : [
           "Use 'read' for text-based or line-oriented formats.",
-          "This model cannot view sandbox images directly; ask the user to select HackerAI Pro or HackerAI Max for multimodal image viewing.",
+          "This model cannot view sandbox images directly; ask the user to select a model with image viewing support.",
         ]),
     "Code MUST be saved to a file using this tool before execution via the shell tool.",
     "DO NOT write partial or truncated content; always output the full content.",


### PR DESCRIPTION
## Summary

- Enables the Kimi/Standard agent model keys and Moonshot Kimi OpenRouter slug in the multimodal tool-result capability gate.
- Lets the file tool expose `view` for Kimi and return AI SDK `image-data` content back to the model.
- Updates unsupported-model copy to avoid incorrectly telling users that only Pro/Max can view sandbox images.

## Why

Manual testing showed Kimi can consume the AI SDK multimodal tool result shape for image viewing. The previous guard blocked HackerAI Standard before the request could reach the provider.

## Validation

- `pnpm test -- lib/ai/__tests__/providers.test.ts lib/ai/tools/__tests__/file.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec prettier --check lib/ai/providers.ts lib/ai/tools/file.ts lib/ai/__tests__/providers.test.ts lib/ai/tools/__tests__/file.test.ts`
- `pnpm lint` (passes with existing unrelated warnings)
- Pre-commit hook: full Jest suite, 126 suites / 1421 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing sandbox images as multimodal tool output in compatible models.

* **Improvements**
  * Updated messaging for image viewing capabilities to be more generic, guiding users to select models with image support rather than specific model names.

* **Tests**
  * Expanded test coverage for multimodal image tool functionality and model capability detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->