### PR TITLE
[codex] Add feedback retention cleanup

### DIFF
--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -524,6 +524,33 @@ describe("checkAndInvalidateSummary via deleteLastAssistantMessage", () => {
     expect(chatPatchCalls).toHaveLength(0);
   });
 
+  it("should delete feedback before deleting regenerated assistant messages", async () => {
+    const assistantMsg = makeAssistantMessage({
+      _creationTime: 5000,
+      feedback_id: "feedback-1" as Id<"feedback">,
+    });
+    const chatDoc = makeChatDoc({ latest_summary_id: undefined });
+
+    setupDbQueryChain({
+      assistantMessage: assistantMsg,
+      chatDoc,
+      cutoffMessage: null,
+    });
+
+    const { deleteLastAssistantMessage } = await import("../messages");
+
+    await deleteLastAssistantMessage.handler(mockCtx, { chatId: CHAT_ID });
+
+    const deleteArgs = mockCtx.db.delete.mock.calls.map(
+      (call: any[]) => call[0],
+    );
+    expect(deleteArgs).toContain("feedback-1");
+    expect(deleteArgs).toContain(ASSISTANT_MSG_ID);
+    expect(deleteArgs.indexOf("feedback-1")).toBeLessThan(
+      deleteArgs.indexOf(ASSISTANT_MSG_ID),
+    );
+  });
+
   it("should fall back to first valid previous summary when current is invalid", async () => {
     const assistantMsg = makeAssistantMessage({ _creationTime: 2000 });
     const chatDoc = makeChatDoc();
@@ -741,5 +768,108 @@ describe("checkAndInvalidateSummary via deleteLastAssistantMessage", () => {
     );
 
     expect(mockCtx.db.delete).toHaveBeenCalledWith(SUMMARY_DOC_ID);
+  });
+});
+
+describe("regenerateWithNewContent feedback cleanup", () => {
+  let mockCtx: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    mockCtx = {
+      auth: {
+        getUserIdentity: jest.fn<any>().mockResolvedValue({ subject: USER_ID }),
+      },
+      db: {
+        query: jest.fn(),
+        get: jest.fn<any>().mockResolvedValue(null),
+        patch: jest.fn<any>().mockResolvedValue(undefined),
+        delete: jest.fn<any>().mockResolvedValue(undefined),
+      },
+      runQuery: jest.fn<any>().mockResolvedValue(true),
+      scheduler: {
+        runAfter: jest.fn<any>().mockResolvedValue(undefined),
+      },
+      storage: {
+        delete: jest.fn<any>().mockResolvedValue(undefined),
+      },
+    };
+  });
+
+  it("should delete feedback for later messages removed by edit-regenerate", async () => {
+    const editedUserMessage = {
+      _id: "user-doc-1" as Id<"messages">,
+      id: "user-msg-1",
+      chat_id: CHAT_ID,
+      user_id: USER_ID,
+      role: "user",
+      parts: [{ type: "text", text: "old prompt" }],
+      content: "old prompt",
+      _creationTime: 1000,
+      file_ids: undefined,
+    };
+    const laterAssistantMessage = {
+      _id: "asst-doc-1" as Id<"messages">,
+      id: "asst-msg-1",
+      chat_id: CHAT_ID,
+      user_id: USER_ID,
+      role: "assistant",
+      parts: [{ type: "text", text: "old response" }],
+      _creationTime: 2000,
+      file_ids: undefined,
+      feedback_id: "feedback-2" as Id<"feedback">,
+    };
+    const chatDoc = makeChatDoc({ latest_summary_id: undefined });
+
+    mockCtx.db.query.mockImplementation((table: string) => {
+      if (table === "messages") {
+        return {
+          withIndex: jest.fn((indexName: string) => {
+            if (indexName === "by_message_id") {
+              return {
+                first: jest.fn<any>().mockResolvedValue(editedUserMessage),
+              };
+            }
+            if (indexName === "by_chat_id") {
+              return {
+                collect: jest
+                  .fn<any>()
+                  .mockResolvedValue([laterAssistantMessage]),
+              };
+            }
+            throw new Error(`Unexpected messages index ${indexName}`);
+          }),
+        };
+      }
+
+      if (table === "chats") {
+        return {
+          withIndex: jest.fn().mockReturnValue({
+            first: jest.fn<any>().mockResolvedValue(chatDoc),
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const { regenerateWithNewContent } = await import("../messages");
+
+    await regenerateWithNewContent.handler(mockCtx, {
+      messageId: editedUserMessage.id,
+      newContent: "new prompt",
+    });
+
+    const deleteArgs = mockCtx.db.delete.mock.calls.map(
+      (call: any[]) => call[0],
+    );
+    expect(deleteArgs).toContain("feedback-2");
+    expect(deleteArgs).toContain(laterAssistantMessage._id);
+    expect(deleteArgs.indexOf("feedback-2")).toBeLessThan(
+      deleteArgs.indexOf(laterAssistantMessage._id),
+    );
   });
 });

--- a/convex/__tests__/feedbackCleanup.test.ts
+++ b/convex/__tests__/feedbackCleanup.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+jest.mock("../_generated/server", () => ({
+  mutation: jest.fn((config: any) => config),
+  internalMutation: jest.fn((config: any) => config),
+}));
+
+jest.mock("convex/values", () => ({
+  v: {
+    string: jest.fn(() => "string"),
+    number: jest.fn(() => "number"),
+    optional: jest.fn(() => "optional"),
+    object: jest.fn(() => "object"),
+    union: jest.fn(() => "union"),
+    literal: jest.fn((value) => value),
+    id: jest.fn(() => "id"),
+    null: jest.fn(() => "null"),
+  },
+  ConvexError: class ConvexError extends Error {
+    data: unknown;
+    constructor(data: unknown) {
+      super(
+        typeof data === "string" ? data : (data as { message: string }).message,
+      );
+      this.data = data;
+      this.name = "ConvexError";
+    }
+  },
+}));
+
+jest.mock("../lib/logger", () => ({
+  convexLogger: {
+    warn: jest.fn(),
+  },
+}));
+
+function buildQuery<T>(rows: T[]) {
+  const lt = jest.fn<any>().mockReturnValue("lt");
+  const eq = jest.fn<any>().mockReturnValue("eq");
+  const query: any = {
+    withIndex: jest.fn<any>((_name: string, builder: any) => {
+      builder({ lt, eq });
+      return query;
+    }),
+    order: jest.fn<any>().mockReturnThis(),
+    take: jest.fn<any>().mockResolvedValue(rows),
+    collect: jest.fn<any>().mockResolvedValue(rows),
+    lt,
+    eq,
+  };
+  return query;
+}
+
+describe("feedback cleanup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("deletes old feedback and clears linked message pointers first", async () => {
+    const cutoffTimeMs = Date.now() - 180 * 24 * 60 * 60 * 1000;
+    const feedbackRows = [
+      { _id: "feedback-1", _creationTime: cutoffTimeMs - 1_000 },
+      { _id: "feedback-2", _creationTime: cutoffTimeMs - 500 },
+    ];
+    const messageRows = [{ _id: "message-1", feedback_id: "feedback-1" }];
+    const feedbackQuery = buildQuery(feedbackRows);
+    const firstMessagesQuery = buildQuery(messageRows);
+    const secondMessagesQuery = buildQuery([]);
+
+    const mockCtx: any = {
+      db: {
+        query: jest.fn<any>((table: string) => {
+          if (table === "feedback") return feedbackQuery;
+          if (table === "messages") {
+            return mockCtx.db.query.mock.calls.filter(
+              ([name]: [string]) => name === "messages",
+            ).length === 1
+              ? firstMessagesQuery
+              : secondMessagesQuery;
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+        patch: jest.fn<any>(),
+        delete: jest.fn<any>(),
+      },
+    };
+
+    const { purgeOldFeedback } = (await import("../feedback")) as any;
+    const result = await purgeOldFeedback.handler(mockCtx, {
+      cutoffTimeMs,
+      limit: 2,
+    });
+
+    expect(result).toEqual({ deletedCount: 2 });
+    expect(feedbackQuery.withIndex).toHaveBeenCalledWith(
+      "by_creation_time",
+      expect.any(Function),
+    );
+    expect(feedbackQuery.lt).toHaveBeenCalledWith(
+      "_creationTime",
+      cutoffTimeMs,
+    );
+    expect(feedbackQuery.take).toHaveBeenCalledWith(2);
+    expect(firstMessagesQuery.withIndex).toHaveBeenCalledWith(
+      "by_feedback_id",
+      expect.any(Function),
+    );
+    expect(firstMessagesQuery.eq).toHaveBeenCalledWith(
+      "feedback_id",
+      "feedback-1",
+    );
+    expect(mockCtx.db.patch).toHaveBeenCalledWith("message-1", {
+      feedback_id: undefined,
+    });
+    expect(mockCtx.db.delete).toHaveBeenNthCalledWith(1, "feedback-1");
+    expect(mockCtx.db.delete).toHaveBeenNthCalledWith(2, "feedback-2");
+  });
+
+  it("returns zero and does not delete when there are no expired rows", async () => {
+    const feedbackQuery = buildQuery([]);
+    const mockCtx: any = {
+      db: {
+        query: jest.fn<any>().mockReturnValue(feedbackQuery),
+        patch: jest.fn<any>(),
+        delete: jest.fn<any>(),
+      },
+    };
+
+    const { purgeOldFeedback } = (await import("../feedback")) as any;
+    const result = await purgeOldFeedback.handler(mockCtx, {
+      cutoffTimeMs: Date.now(),
+    });
+
+    expect(result).toEqual({ deletedCount: 0 });
+    expect(feedbackQuery.take).toHaveBeenCalledWith(100);
+    expect(mockCtx.db.patch).not.toHaveBeenCalled();
+    expect(mockCtx.db.delete).not.toHaveBeenCalled();
+  });
+});

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -3,6 +3,8 @@ import { internal } from "./_generated/api";
 import { internalAction } from "./_generated/server";
 import { v } from "convex/values";
 
+const FEEDBACK_RETENTION_MS = 180 * 24 * 60 * 60 * 1000;
+
 export const runPurge = internalAction({
   args: {},
   returns: v.null(),
@@ -85,6 +87,35 @@ export const runStaleConnectionsPurge = internalAction({
   },
 });
 
+/**
+ * Delete feedback older than 180 days. Feedback may include user-written detail
+ * text, so retain it for product-quality analysis without storing it forever.
+ *
+ * Processes up to 10 batches per run. If the last batch fills `limit`, more
+ * work remains — schedule a follow-up so backlog can't outpace the daily cron.
+ */
+export const runOldFeedbackPurge = internalAction({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx) => {
+    const cutoff = Date.now() - FEEDBACK_RETENTION_MS;
+    const limit = 100;
+    let lastDeletedCount = 0;
+    for (let i = 0; i < 10; i++) {
+      const { deletedCount } = await ctx.runMutation(
+        internal.feedback.purgeOldFeedback,
+        { cutoffTimeMs: cutoff, limit },
+      );
+      lastDeletedCount = deletedCount;
+      if (deletedCount < limit) break;
+    }
+    if (lastDeletedCount === limit) {
+      await ctx.scheduler.runAfter(0, internal.crons.runOldFeedbackPurge, {});
+    }
+    return null;
+  },
+});
+
 const crons = cronJobs();
 
 crons.interval(
@@ -105,6 +136,13 @@ crons.interval(
   "purge stale disconnected sandbox connections older than 30d",
   { hours: 24 },
   internal.crons.runStaleConnectionsPurge,
+  {},
+);
+
+crons.interval(
+  "purge feedback older than 180d",
+  { hours: 24 },
+  internal.crons.runOldFeedbackPurge,
   {},
 );
 

--- a/convex/feedback.ts
+++ b/convex/feedback.ts
@@ -1,4 +1,4 @@
-import { mutation } from "./_generated/server";
+import { internalMutation, mutation } from "./_generated/server";
 import { v, ConvexError } from "convex/values";
 import { convexLogger } from "./lib/logger";
 
@@ -64,5 +64,43 @@ export const createFeedback = mutation({
 
       return feedbackId;
     }
+  },
+});
+
+/**
+ * Delete feedback older than the provided cutoff and clear any message pointers
+ * first so messages never retain dangling feedback_id references.
+ */
+export const purgeOldFeedback = internalMutation({
+  args: {
+    cutoffTimeMs: v.number(),
+    limit: v.optional(v.number()),
+  },
+  returns: v.object({ deletedCount: v.number() }),
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? 100;
+
+    const candidates = await ctx.db
+      .query("feedback")
+      .withIndex("by_creation_time", (q) =>
+        q.lt("_creationTime", args.cutoffTimeMs),
+      )
+      .order("asc")
+      .take(limit);
+
+    for (const feedback of candidates) {
+      const linkedMessages = await ctx.db
+        .query("messages")
+        .withIndex("by_feedback_id", (q) => q.eq("feedback_id", feedback._id))
+        .collect();
+
+      for (const message of linkedMessages) {
+        await ctx.db.patch(message._id, { feedback_id: undefined });
+      }
+
+      await ctx.db.delete(feedback._id);
+    }
+
+    return { deletedCount: candidates.length };
   },
 });

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1115,6 +1115,16 @@ export const deleteLastAssistantMessage = mutation({
               }
             }
           }
+          if (msg.feedback_id) {
+            try {
+              await ctx.db.delete(msg.feedback_id);
+            } catch (error) {
+              console.error(
+                `Failed to delete feedback ${msg.feedback_id}:`,
+                error,
+              );
+            }
+          }
           await ctx.db.delete(msg._id);
         }
       }
@@ -1850,6 +1860,17 @@ export const regenerateWithNewContent = mutation({
             } catch (error) {
               console.error(`Failed to delete file ${fileId}:`, error);
             }
+          }
+        }
+
+        if (msg.feedback_id) {
+          try {
+            await ctx.db.delete(msg.feedback_id);
+          } catch (error) {
+            console.error(
+              `Failed to delete feedback ${msg.feedback_id}:`,
+              error,
+            );
           }
         }
 


### PR DESCRIPTION
## Summary

Adds a daily Convex cleanup job for feedback records older than 180 days. The purge runs in bounded batches, follows the existing cron backfill pattern, and reschedules itself immediately when a full batch suggests more work remains.

The feedback cleanup mutation clears any `messages.feedback_id` pointers before deleting feedback rows so messages do not retain dangling references after retention cleanup.

Regenerate cleanup now also deletes feedback immediately for messages it removes, including the trailing assistant-message regenerate path and edit-triggered regenerate path.

## Impact

User-written feedback details are retained for product quality analysis for 180 days instead of being stored indefinitely. Feedback tied to deleted or regenerated-away messages is cleaned up promptly instead of being left orphaned.

## Validation

- `pnpm jest convex/__tests__/chatSummaryFallback.test.ts convex/__tests__/feedbackCleanup.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec prettier --check convex/messages.ts convex/__tests__/chatSummaryFallback.test.ts convex/feedback.ts convex/crons.ts convex/__tests__/feedbackCleanup.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automatic feedback purge that removes feedback older than ~180 days in batched runs, scheduled every 24 hours and re-triggered as needed to keep backlog timely.

* **Bug Fixes**
  * Message-deletion flows now also remove linked feedback records (with failures logged but deletion proceeding) to avoid dangling references; deletion ordering ensured.

* **Tests**
  * New tests cover purge behavior (including no-op when nothing to delete) and feedback cleanup ordering during message/regeneration workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->