### PR TITLE
[codex] Require S3 for new file uploads

### DIFF
--- a/convex/__tests__/fileActions.upload-policy.test.ts
+++ b/convex/__tests__/fileActions.upload-policy.test.ts
@@ -299,10 +299,9 @@ describe("fileActions saveFile upload policy", () => {
     expect(ctx.runMutation).not.toHaveBeenCalled();
   });
 
-  it("rejects storageId uploads based on storage metadata, not client size", async () => {
+  it("rejects storageId uploads without touching Convex storage", async () => {
     const { saveFile } = await import("../fileActions");
     const ctx = makeCtx();
-    ctx.storage.getMetadata.mockResolvedValueOnce({ size: 21 * 1024 * 1024 });
 
     await expect(
       saveFile.handler(ctx, {
@@ -313,11 +312,14 @@ describe("fileActions saveFile upload policy", () => {
         mode: "ask",
       }),
     ).rejects.toMatchObject({
-      data: expect.objectContaining({ code: "FILE_SIZE_EXCEEDED" }),
+      data: expect.objectContaining({
+        code: "CONVEX_STORAGE_UPLOADS_DISABLED",
+      }),
     });
 
-    expect(ctx.storage.getMetadata).toHaveBeenCalledWith("storage_large_bin");
-    expect(ctx.storage.delete).toHaveBeenCalledWith("storage_large_bin");
+    expect(ctx.storage.getMetadata).not.toHaveBeenCalled();
+    expect(ctx.storage.delete).not.toHaveBeenCalled();
+    expect(ctx.runQuery).not.toHaveBeenCalled();
     expect(global.fetch).not.toHaveBeenCalled();
     expect(ctx.runMutation).not.toHaveBeenCalled();
   });

--- a/convex/__tests__/fileActions.upload-policy.test.ts
+++ b/convex/__tests__/fileActions.upload-policy.test.ts
@@ -38,7 +38,6 @@ jest.mock("../_generated/api", () => ({
   internal: {
     fileStorage: {
       saveFileToDb: "internal.fileStorage.saveFileToDb",
-      getFileByS3Key: "internal.fileStorage.getFileByS3Key",
     },
     s3Cleanup: {
       deleteS3ObjectAction: "internal.s3Cleanup.deleteS3ObjectAction",
@@ -134,25 +133,7 @@ describe("fileActions saveFile upload policy", () => {
         getUrl: jest.fn().mockResolvedValue("https://storage.example/file"),
         getMetadata: jest.fn().mockResolvedValue({ size: 1024 }),
       },
-      runQuery: jest.fn(async (_fn: unknown, args: { s3Key?: string }) => ({
-        _id: "file_reservation_123",
-        s3_key: args.s3Key,
-        user_id: "user123",
-        name: "reserved.txt",
-        media_type: "text/plain",
-        size: args.s3Key?.includes("large.bin")
-          ? 21 * 1024 * 1024
-          : args.s3Key?.includes("large.png")
-            ? 8 * 1024 * 1024
-            : args.s3Key?.includes("archive.zip")
-              ? 25 * 1024 * 1024
-              : args.s3Key?.includes("huge.bin")
-                ? 251 * 1024 * 1024
-                : 1024,
-        file_token_size: 0,
-        is_attached: false,
-        _creationTime: Date.now(),
-      })),
+      runQuery: jest.fn(),
       runMutation: jest.fn().mockResolvedValue("file_123"),
     }) as any;
 
@@ -207,20 +188,16 @@ describe("fileActions saveFile upload policy", () => {
     expect(ctx.runMutation).not.toHaveBeenCalled();
   });
 
-  it("rejects S3 uploads when the actual object size differs from the reservation", async () => {
+  it("cleans up S3 when final reservation mutation detects a size mismatch", async () => {
     const { saveFile } = await import("../fileActions");
+    const { ConvexError } = await import("convex/values");
     const ctx = makeCtx();
-    ctx.runQuery.mockResolvedValueOnce({
-      _id: "file_reservation_123",
-      s3_key: "users/user123/notes.txt",
-      user_id: "user123",
-      name: "notes.txt",
-      media_type: "text/plain",
-      size: 512,
-      file_token_size: 0,
-      is_attached: false,
-      _creationTime: Date.now(),
-    });
+    ctx.runMutation.mockRejectedValueOnce(
+      new ConvexError({
+        code: "FILE_SIZE_MISMATCH",
+        message: "Uploaded file size does not match reserved size.",
+      }),
+    );
 
     await expect(
       saveFile.handler(ctx, {
@@ -228,7 +205,7 @@ describe("fileActions saveFile upload policy", () => {
         name: "notes.txt",
         mediaType: "text/plain",
         size: 512,
-        mode: "ask",
+        mode: "agent",
       }),
     ).rejects.toMatchObject({
       data: expect.objectContaining({ code: "FILE_SIZE_MISMATCH" }),
@@ -240,23 +217,19 @@ describe("fileActions saveFile upload policy", () => {
       { s3Key: "users/user123/notes.txt" },
     );
     expect(global.fetch).not.toHaveBeenCalled();
-    expect(ctx.runMutation).not.toHaveBeenCalled();
+    expect(ctx.runQuery).not.toHaveBeenCalled();
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      "internal.fileStorage.saveFileToDb",
+      expect.objectContaining({
+        s3Key: "users/user123/notes.txt",
+        size: 1024,
+      }),
+    );
   });
 
-  it("rejects cross-user S3 reservations without deleting the object", async () => {
+  it("rejects cross-user S3 keys without deleting the object", async () => {
     const { saveFile } = await import("../fileActions");
     const ctx = makeCtx();
-    ctx.runQuery.mockResolvedValueOnce({
-      _id: "file_reservation_victim",
-      s3_key: "users/victim/notes.txt",
-      user_id: "victim",
-      name: "notes.txt",
-      media_type: "text/plain",
-      size: 1024,
-      file_token_size: 0,
-      is_attached: false,
-      _creationTime: Date.now(),
-    });
 
     await expect(
       saveFile.handler(ctx, {
@@ -274,29 +247,44 @@ describe("fileActions saveFile upload policy", () => {
 
     expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
     expect(global.fetch).not.toHaveBeenCalled();
+    expect(ctx.runQuery).not.toHaveBeenCalled();
     expect(ctx.runMutation).not.toHaveBeenCalled();
   });
 
-  it("does not delete unreserved S3 keys outside the acting user's prefix", async () => {
+  it("cleans up user-scoped S3 objects when final reservation is missing", async () => {
     const { saveFile } = await import("../fileActions");
+    const { ConvexError } = await import("convex/values");
     const ctx = makeCtx();
-    ctx.runQuery.mockResolvedValueOnce(null);
+    ctx.runMutation.mockRejectedValueOnce(
+      new ConvexError({
+        code: "MISSING_UPLOAD_RESERVATION",
+        message: "S3 uploads must have an existing upload reservation.",
+      }),
+    );
 
     await expect(
       saveFile.handler(ctx, {
-        s3Key: "users/victim/orphan.txt",
+        s3Key: "users/user123/orphan.txt",
         name: "orphan.txt",
         mediaType: "text/plain",
         size: 1024,
-        mode: "ask",
+        mode: "agent",
       }),
     ).rejects.toMatchObject({
-      data: expect.objectContaining({ code: "INVALID_UPLOAD_RESERVATION" }),
+      data: expect.objectContaining({ code: "MISSING_UPLOAD_RESERVATION" }),
     });
 
-    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+    expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      "internal.s3Cleanup.deleteS3ObjectAction",
+      { s3Key: "users/user123/orphan.txt" },
+    );
     expect(global.fetch).not.toHaveBeenCalled();
-    expect(ctx.runMutation).not.toHaveBeenCalled();
+    expect(ctx.runQuery).not.toHaveBeenCalled();
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      "internal.fileStorage.saveFileToDb",
+      expect.objectContaining({ s3Key: "users/user123/orphan.txt" }),
+    );
   });
 
   it("rejects storageId uploads without touching Convex storage", async () => {

--- a/convex/__tests__/fileStorage.aggregate.test.ts
+++ b/convex/__tests__/fileStorage.aggregate.test.ts
@@ -190,8 +190,12 @@ describe("fileStorage - Aggregate Integration", () => {
         is_attached: false,
       };
 
+      const unique = jest.fn<any>().mockResolvedValue(null);
       const mockCtx: any = {
         db: {
+          query: jest.fn<any>().mockReturnValue({
+            withIndex: jest.fn<any>().mockReturnValue({ unique }),
+          }),
           insert: jest.fn<any>().mockResolvedValue(testFileId),
           get: jest.fn<any>().mockResolvedValue(mockFile),
         },
@@ -199,11 +203,13 @@ describe("fileStorage - Aggregate Integration", () => {
 
       const { saveFileToDb } = (await import("../fileStorage")) as any;
       const result = await saveFileToDb.handler(mockCtx, {
+        s3Key: "users/test-user-123/test.pdf",
         userId: testUserId,
         name: "test.pdf",
         mediaType: "application/pdf",
         size: 1024,
         fileTokenSize: 100,
+        trustedServiceGenerated: true,
       });
 
       expect(result).toBe(testFileId);
@@ -211,14 +217,42 @@ describe("fileStorage - Aggregate Integration", () => {
         "files",
         expect.objectContaining({
           user_id: testUserId,
+          s3_key: "users/test-user-123/test.pdf",
           name: "test.pdf",
           is_attached: false,
         }),
       );
+      expect(mockCtx.db.insert.mock.calls[0][1].storage_id).toBeUndefined();
       expect(mockFileCountAggregate.insertIfDoesNotExist).toHaveBeenCalledWith(
         mockCtx,
         mockFile,
       );
+    });
+
+    it("should reject metadata saves without an S3 key", async () => {
+      const mockCtx: any = {
+        db: {
+          query: jest.fn<any>(),
+          insert: jest.fn<any>(),
+        },
+      };
+
+      const { saveFileToDb } = (await import("../fileStorage")) as any;
+
+      await expect(
+        saveFileToDb.handler(mockCtx, {
+          userId: testUserId,
+          name: "legacy.pdf",
+          mediaType: "application/pdf",
+          size: 1024,
+          fileTokenSize: 100,
+        }),
+      ).rejects.toMatchObject({
+        data: expect.objectContaining({ code: "S3_KEY_REQUIRED" }),
+      });
+
+      expect(mockCtx.db.query).not.toHaveBeenCalled();
+      expect(mockCtx.db.insert).not.toHaveBeenCalled();
     });
 
     it("should check storage limit before saving file", async () => {
@@ -226,8 +260,12 @@ describe("fileStorage - Aggregate Integration", () => {
       const usedBytes = 9 * 1024 * 1024 * 1024;
       mockFileCountAggregate.sum.mockResolvedValue(usedBytes);
 
+      const unique = jest.fn<any>().mockResolvedValue(null);
       const mockCtx: any = {
         db: {
+          query: jest.fn<any>().mockReturnValue({
+            withIndex: jest.fn<any>().mockReturnValue({ unique }),
+          }),
           insert: jest.fn<any>().mockResolvedValue(testFileId),
           get: jest.fn<any>().mockResolvedValue(null),
         },
@@ -238,11 +276,13 @@ describe("fileStorage - Aggregate Integration", () => {
       // Try to upload a 500 MB file (should succeed, under limit)
       const smallFileSize = 500 * 1024 * 1024;
       await saveFileToDb.handler(mockCtx, {
+        s3Key: "users/test-user-123/small.pdf",
         userId: testUserId,
         name: "small.pdf",
         mediaType: "application/pdf",
         size: smallFileSize,
         fileTokenSize: 100,
+        trustedServiceGenerated: true,
       });
 
       expect(mockCtx.db.insert).toHaveBeenCalled();
@@ -253,8 +293,12 @@ describe("fileStorage - Aggregate Integration", () => {
       const usedBytes = 9.5 * 1024 * 1024 * 1024;
       mockFileCountAggregate.sum.mockResolvedValue(usedBytes);
 
+      const unique = jest.fn<any>().mockResolvedValue(null);
       const mockCtx: any = {
         db: {
+          query: jest.fn<any>().mockReturnValue({
+            withIndex: jest.fn<any>().mockReturnValue({ unique }),
+          }),
           insert: jest.fn<any>().mockResolvedValue(testFileId),
           get: jest.fn<any>().mockResolvedValue(null),
         },
@@ -266,11 +310,13 @@ describe("fileStorage - Aggregate Integration", () => {
       const largeFileSize = 1 * 1024 * 1024 * 1024;
       await expect(
         saveFileToDb.handler(mockCtx, {
+          s3Key: "users/test-user-123/large.pdf",
           userId: testUserId,
           name: "large.pdf",
           mediaType: "application/pdf",
           size: largeFileSize,
           fileTokenSize: 100,
+          trustedServiceGenerated: true,
         }),
       ).rejects.toThrow("Storage limit exceeded");
 
@@ -312,7 +358,10 @@ describe("fileStorage - Aggregate Integration", () => {
       expect(result).toBe(testFileId);
       expect(mockCtx.db.patch).toHaveBeenCalledWith(
         testFileId,
-        expect.objectContaining({ file_token_size: 100 }),
+        expect.objectContaining({
+          storage_id: undefined,
+          file_token_size: 100,
+        }),
       );
       expect(mockCtx.db.insert).not.toHaveBeenCalled();
       expect(mockFileCountAggregate.sum).not.toHaveBeenCalled();

--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -745,6 +745,36 @@ export const saveFile = action({
     // Token was already consumed at URL generation step
     await checkFileUploadRateLimit(actingUserId, false, { entitlements });
 
+    if (!isUserScopedS3Key(s3Key, actingUserId)) {
+      throw new ConvexError({
+        code: "UNAUTHORIZED_UPLOAD_RESERVATION",
+        message: `Failed to upload ${args.name}: Upload reservation belongs to another user`,
+      });
+    }
+
+    const cleanupUploadedObject = async (stage: string) => {
+      try {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.s3Cleanup.deleteS3ObjectAction,
+          {
+            s3Key,
+          },
+        );
+      } catch (cleanupError) {
+        convexLogger.warn("file_upload_storage_cleanup_failed", {
+          userId: actingUserId,
+          fileName: args.name,
+          stage,
+          s3Key,
+          error:
+            cleanupError instanceof Error
+              ? { name: cleanupError.name, message: cleanupError.message }
+              : String(cleanupError),
+        });
+      }
+    };
+
     let verifiedSize = args.size;
     try {
       verifiedSize = await getS3ObjectSizeBytes(s3Key);
@@ -765,41 +795,6 @@ export const saveFile = action({
       });
     }
 
-    const reservation = await ctx.runQuery(
-      internal.fileStorage.getFileByS3Key,
-      {
-        s3Key,
-      },
-    );
-    if (!reservation) {
-      if (isUserScopedS3Key(s3Key, actingUserId)) {
-        await ctx.scheduler.runAfter(
-          0,
-          internal.s3Cleanup.deleteS3ObjectAction,
-          { s3Key },
-        );
-      }
-      throw new ConvexError({
-        code: "INVALID_UPLOAD_RESERVATION",
-        message: `Failed to upload ${args.name}: Upload reservation not found`,
-      });
-    }
-    if (reservation.user_id !== actingUserId) {
-      throw new ConvexError({
-        code: "UNAUTHORIZED_UPLOAD_RESERVATION",
-        message: `Failed to upload ${args.name}: Upload reservation belongs to another user`,
-      });
-    }
-    if (reservation.size !== verifiedSize) {
-      await ctx.scheduler.runAfter(0, internal.s3Cleanup.deleteS3ObjectAction, {
-        s3Key,
-      });
-      throw new ConvexError({
-        code: "FILE_SIZE_MISMATCH",
-        message: `File "${args.name}" uploaded size does not match the reserved upload size`,
-      });
-    }
-
     const uploadLimits = getUploadLimitsForMode(args.mode, {
       surface: "backend",
     });
@@ -817,26 +812,7 @@ export const saveFile = action({
       uploadValidation.code === "FILE_SIZE_EXCEEDED"
     ) {
       // Clean up storage before throwing error
-      try {
-        await ctx.scheduler.runAfter(
-          0,
-          internal.s3Cleanup.deleteS3ObjectAction,
-          {
-            s3Key,
-          },
-        );
-      } catch (deleteError) {
-        convexLogger.warn("file_upload_storage_cleanup_failed", {
-          userId: actingUserId,
-          fileName: args.name,
-          stage: "oversized",
-          s3Key,
-          error:
-            deleteError instanceof Error
-              ? { name: deleteError.name, message: deleteError.message }
-              : String(deleteError),
-        });
-      }
+      await cleanupUploadedObject("oversized");
       throw new ConvexError({
         code: "FILE_SIZE_EXCEEDED",
         message: `File "${args.name}" exceeds the maximum file size limit of ${uploadLimits.maxFileSizeBytes / (1024 * 1024)} MB. Current size: ${(verifiedSize / (1024 * 1024)).toFixed(2)} MB`,
@@ -847,26 +823,7 @@ export const saveFile = action({
       !uploadValidation.valid &&
       uploadValidation.code === "IMAGE_SIZE_EXCEEDED"
     ) {
-      try {
-        await ctx.scheduler.runAfter(
-          0,
-          internal.s3Cleanup.deleteS3ObjectAction,
-          {
-            s3Key,
-          },
-        );
-      } catch (deleteError) {
-        convexLogger.warn("file_upload_storage_cleanup_failed", {
-          userId: actingUserId,
-          fileName: args.name,
-          stage: "oversized_image",
-          s3Key,
-          error:
-            deleteError instanceof Error
-              ? { name: deleteError.name, message: deleteError.message }
-              : String(deleteError),
-        });
-      }
+      await cleanupUploadedObject("oversized_image");
       throw new ConvexError({
         code: "IMAGE_SIZE_EXCEEDED",
         message: `Image "${args.name}" exceeds the maximum image size limit of ${uploadLimits.maxProviderImageSizeBytes / (1024 * 1024)} MB. Current size: ${(verifiedSize / (1024 * 1024)).toFixed(2)} MB`,
@@ -962,24 +919,7 @@ export const saveFile = action({
             errorMessage: errorData?.message,
           });
         }
-        try {
-          await ctx.scheduler.runAfter(
-            0,
-            internal.s3Cleanup.deleteS3ObjectAction,
-            { s3Key },
-          );
-        } catch (cleanupError) {
-          convexLogger.warn("file_upload_storage_cleanup_failed", {
-            userId: actingUserId,
-            fileName: args.name,
-            stage: "post_processing_error",
-            s3Key,
-            error:
-              cleanupError instanceof Error
-                ? { name: cleanupError.name, message: cleanupError.message }
-                : String(cleanupError),
-          });
-        }
+        await cleanupUploadedObject("post_processing_error");
         throw error; // Re-throw ConvexError as-is
       }
 
@@ -997,24 +937,7 @@ export const saveFile = action({
           errorMessage: error.message,
         });
         // Best-effort cleanup before throwing standardized error
-        try {
-          await ctx.scheduler.runAfter(
-            0,
-            internal.s3Cleanup.deleteS3ObjectAction,
-            { s3Key },
-          );
-        } catch (cleanupError) {
-          convexLogger.warn("file_upload_storage_cleanup_failed", {
-            userId: actingUserId,
-            fileName: args.name,
-            stage: "post_processing_error",
-            s3Key,
-            error:
-              cleanupError instanceof Error
-                ? { name: cleanupError.name, message: cleanupError.message }
-                : String(cleanupError),
-          });
-        }
+        await cleanupUploadedObject("post_processing_error");
         // Convert to ConvexError for consistent error handling
         throw new ConvexError({
           code: "FILE_TOKEN_LIMIT_EXCEEDED",
@@ -1035,26 +958,7 @@ export const saveFile = action({
             : String(error),
       });
       // Best-effort cleanup before throwing standardized error
-      try {
-        await ctx.scheduler.runAfter(
-          0,
-          internal.s3Cleanup.deleteS3ObjectAction,
-          {
-            s3Key,
-          },
-        );
-      } catch (cleanupError) {
-        convexLogger.warn("file_upload_storage_cleanup_failed", {
-          userId: actingUserId,
-          fileName: args.name,
-          stage: "post_unexpected_error",
-          s3Key,
-          error:
-            cleanupError instanceof Error
-              ? { name: cleanupError.name, message: cleanupError.message }
-              : String(cleanupError),
-        });
-      }
+      await cleanupUploadedObject("post_unexpected_error");
       const errorMsg = error instanceof Error ? error.message : "Unknown error";
       throw new ConvexError({
         code: "FILE_PROCESSING_FAILED",
@@ -1063,15 +967,31 @@ export const saveFile = action({
     }
 
     // Use internal mutation to save to database
-    const fileId = (await ctx.runMutation(internal.fileStorage.saveFileToDb, {
-      s3Key,
-      userId: actingUserId,
-      name: args.name,
-      mediaType: args.mediaType,
-      size: verifiedSize,
-      fileTokenSize: tokenSize,
-      content: fileContent,
-    })) as Id<"files">;
+    let fileId: Id<"files">;
+    try {
+      fileId = (await ctx.runMutation(internal.fileStorage.saveFileToDb, {
+        s3Key,
+        userId: actingUserId,
+        name: args.name,
+        mediaType: args.mediaType,
+        size: verifiedSize,
+        fileTokenSize: tokenSize,
+        content: fileContent,
+      })) as Id<"files">;
+    } catch (error) {
+      const errorCode =
+        error instanceof ConvexError
+          ? (error.data as { code?: string } | undefined)?.code
+          : undefined;
+      if (
+        errorCode === "MISSING_UPLOAD_RESERVATION" ||
+        errorCode === "FILE_SIZE_MISMATCH" ||
+        errorCode === "UNAUTHORIZED"
+      ) {
+        await cleanupUploadedObject("metadata_save_failed");
+      }
+      throw error;
+    }
 
     // Return the file URL, database file ID, and token count
     return {

--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -653,6 +653,8 @@ const processDocxFile = async (
  */
 export const saveFile = action({
   args: {
+    // Accepted only to return a stable error to stale clients. New file
+    // uploads must go through S3.
     storageId: v.optional(v.id("_storage")),
     s3Key: v.optional(v.string()),
     name: v.string(),
@@ -671,19 +673,21 @@ export const saveFile = action({
     tokens: v.number(),
   }),
   handler: async (ctx, args) => {
-    // Storage invariant validation: exactly one of storageId or s3Key must be provided
-    if (!args.storageId && !args.s3Key) {
+    if (args.storageId) {
       throw new ConvexError({
-        code: "INVALID_STORAGE_ARGS",
-        message: "Must provide either storageId or s3Key",
+        code: "CONVEX_STORAGE_UPLOADS_DISABLED",
+        message:
+          "Convex storage uploads are no longer supported. Upload files through S3 instead.",
       });
     }
-    if (args.storageId && args.s3Key) {
+    if (!args.s3Key) {
       throw new ConvexError({
         code: "INVALID_STORAGE_ARGS",
-        message: "Cannot provide both storageId and s3Key",
+        message: "s3Key is required for file uploads",
       });
     }
+    const s3Key = args.s3Key;
+
     let actingUserId: string;
     let entitlements: Array<string> = [];
 
@@ -742,83 +746,58 @@ export const saveFile = action({
     await checkFileUploadRateLimit(actingUserId, false, { entitlements });
 
     let verifiedSize = args.size;
-    if (args.s3Key) {
-      try {
-        verifiedSize = await getS3ObjectSizeBytes(args.s3Key);
-      } catch (error) {
-        convexLogger.error("file_upload_s3_metadata_fetch_failed", {
-          userId: actingUserId,
-          fileName: args.name,
-          s3Key: args.s3Key,
-          mode: args.mode,
-          error:
-            error instanceof Error
-              ? { name: error.name, message: error.message }
-              : String(error),
-        });
-        throw new ConvexError({
-          code: "FILE_NOT_FOUND",
-          message: `Failed to upload ${args.name}: File not found in storage`,
-        });
-      }
+    try {
+      verifiedSize = await getS3ObjectSizeBytes(s3Key);
+    } catch (error) {
+      convexLogger.error("file_upload_s3_metadata_fetch_failed", {
+        userId: actingUserId,
+        fileName: args.name,
+        s3Key,
+        mode: args.mode,
+        error:
+          error instanceof Error
+            ? { name: error.name, message: error.message }
+            : String(error),
+      });
+      throw new ConvexError({
+        code: "FILE_NOT_FOUND",
+        message: `Failed to upload ${args.name}: File not found in storage`,
+      });
+    }
 
-      const reservation = await ctx.runQuery(
-        internal.fileStorage.getFileByS3Key,
-        { s3Key: args.s3Key },
-      );
-      if (!reservation) {
-        if (isUserScopedS3Key(args.s3Key, actingUserId)) {
-          await ctx.scheduler.runAfter(
-            0,
-            internal.s3Cleanup.deleteS3ObjectAction,
-            { s3Key: args.s3Key },
-          );
-        }
-        throw new ConvexError({
-          code: "INVALID_UPLOAD_RESERVATION",
-          message: `Failed to upload ${args.name}: Upload reservation not found`,
-        });
-      }
-      if (reservation.user_id !== actingUserId) {
-        throw new ConvexError({
-          code: "UNAUTHORIZED_UPLOAD_RESERVATION",
-          message: `Failed to upload ${args.name}: Upload reservation belongs to another user`,
-        });
-      }
-      if (reservation.size !== verifiedSize) {
+    const reservation = await ctx.runQuery(
+      internal.fileStorage.getFileByS3Key,
+      {
+        s3Key,
+      },
+    );
+    if (!reservation) {
+      if (isUserScopedS3Key(s3Key, actingUserId)) {
         await ctx.scheduler.runAfter(
           0,
           internal.s3Cleanup.deleteS3ObjectAction,
-          { s3Key: args.s3Key },
+          { s3Key },
         );
-        throw new ConvexError({
-          code: "FILE_SIZE_MISMATCH",
-          message: `File "${args.name}" uploaded size does not match the reserved upload size`,
-        });
       }
-    } else if (args.storageId) {
-      try {
-        const metadata = await ctx.storage.getMetadata(args.storageId);
-        if (!metadata) {
-          throw new Error("Storage metadata not found");
-        }
-        verifiedSize = metadata.size;
-      } catch (error) {
-        convexLogger.error("file_upload_storage_metadata_fetch_failed", {
-          userId: actingUserId,
-          fileName: args.name,
-          storageId: args.storageId,
-          mode: args.mode,
-          error:
-            error instanceof Error
-              ? { name: error.name, message: error.message }
-              : String(error),
-        });
-        throw new ConvexError({
-          code: "FILE_NOT_FOUND",
-          message: `Failed to upload ${args.name}: File not found in storage`,
-        });
-      }
+      throw new ConvexError({
+        code: "INVALID_UPLOAD_RESERVATION",
+        message: `Failed to upload ${args.name}: Upload reservation not found`,
+      });
+    }
+    if (reservation.user_id !== actingUserId) {
+      throw new ConvexError({
+        code: "UNAUTHORIZED_UPLOAD_RESERVATION",
+        message: `Failed to upload ${args.name}: Upload reservation belongs to another user`,
+      });
+    }
+    if (reservation.size !== verifiedSize) {
+      await ctx.scheduler.runAfter(0, internal.s3Cleanup.deleteS3ObjectAction, {
+        s3Key,
+      });
+      throw new ConvexError({
+        code: "FILE_SIZE_MISMATCH",
+        message: `File "${args.name}" uploaded size does not match the reserved upload size`,
+      });
     }
 
     const uploadLimits = getUploadLimitsForMode(args.mode, {
@@ -839,22 +818,19 @@ export const saveFile = action({
     ) {
       // Clean up storage before throwing error
       try {
-        if (args.s3Key) {
-          await ctx.scheduler.runAfter(
-            0,
-            internal.s3Cleanup.deleteS3ObjectAction,
-            { s3Key: args.s3Key },
-          );
-        } else if (args.storageId) {
-          await ctx.storage.delete(args.storageId);
-        }
+        await ctx.scheduler.runAfter(
+          0,
+          internal.s3Cleanup.deleteS3ObjectAction,
+          {
+            s3Key,
+          },
+        );
       } catch (deleteError) {
         convexLogger.warn("file_upload_storage_cleanup_failed", {
           userId: actingUserId,
           fileName: args.name,
           stage: "oversized",
-          s3Key: args.s3Key,
-          storageId: args.storageId,
+          s3Key,
           error:
             deleteError instanceof Error
               ? { name: deleteError.name, message: deleteError.message }
@@ -872,22 +848,19 @@ export const saveFile = action({
       uploadValidation.code === "IMAGE_SIZE_EXCEEDED"
     ) {
       try {
-        if (args.s3Key) {
-          await ctx.scheduler.runAfter(
-            0,
-            internal.s3Cleanup.deleteS3ObjectAction,
-            { s3Key: args.s3Key },
-          );
-        } else if (args.storageId) {
-          await ctx.storage.delete(args.storageId);
-        }
+        await ctx.scheduler.runAfter(
+          0,
+          internal.s3Cleanup.deleteS3ObjectAction,
+          {
+            s3Key,
+          },
+        );
       } catch (deleteError) {
         convexLogger.warn("file_upload_storage_cleanup_failed", {
           userId: actingUserId,
           fileName: args.name,
           stage: "oversized_image",
-          s3Key: args.s3Key,
-          storageId: args.storageId,
+          s3Key,
           error:
             deleteError instanceof Error
               ? { name: deleteError.name, message: deleteError.message }
@@ -900,15 +873,7 @@ export const saveFile = action({
       });
     }
 
-    // Get file content from appropriate storage
-    let fileUrl: string | null;
-    if (args.s3Key) {
-      // Fetch from S3
-      fileUrl = await generateS3DownloadUrl(args.s3Key);
-    } else {
-      // Get from Convex storage
-      fileUrl = await ctx.storage.getUrl(args.storageId!);
-    }
+    const fileUrl = await generateS3DownloadUrl(s3Key);
 
     if (!fileUrl) {
       throw new ConvexError({
@@ -998,22 +963,17 @@ export const saveFile = action({
           });
         }
         try {
-          if (args.s3Key) {
-            await ctx.scheduler.runAfter(
-              0,
-              internal.s3Cleanup.deleteS3ObjectAction,
-              { s3Key: args.s3Key },
-            );
-          } else if (args.storageId) {
-            await ctx.storage.delete(args.storageId);
-          }
+          await ctx.scheduler.runAfter(
+            0,
+            internal.s3Cleanup.deleteS3ObjectAction,
+            { s3Key },
+          );
         } catch (cleanupError) {
           convexLogger.warn("file_upload_storage_cleanup_failed", {
             userId: actingUserId,
             fileName: args.name,
             stage: "post_processing_error",
-            s3Key: args.s3Key,
-            storageId: args.storageId,
+            s3Key,
             error:
               cleanupError instanceof Error
                 ? { name: cleanupError.name, message: cleanupError.message }
@@ -1038,22 +998,17 @@ export const saveFile = action({
         });
         // Best-effort cleanup before throwing standardized error
         try {
-          if (args.s3Key) {
-            await ctx.scheduler.runAfter(
-              0,
-              internal.s3Cleanup.deleteS3ObjectAction,
-              { s3Key: args.s3Key },
-            );
-          } else if (args.storageId) {
-            await ctx.storage.delete(args.storageId);
-          }
+          await ctx.scheduler.runAfter(
+            0,
+            internal.s3Cleanup.deleteS3ObjectAction,
+            { s3Key },
+          );
         } catch (cleanupError) {
           convexLogger.warn("file_upload_storage_cleanup_failed", {
             userId: actingUserId,
             fileName: args.name,
             stage: "post_processing_error",
-            s3Key: args.s3Key,
-            storageId: args.storageId,
+            s3Key,
             error:
               cleanupError instanceof Error
                 ? { name: cleanupError.name, message: cleanupError.message }
@@ -1081,22 +1036,19 @@ export const saveFile = action({
       });
       // Best-effort cleanup before throwing standardized error
       try {
-        if (args.s3Key) {
-          await ctx.scheduler.runAfter(
-            0,
-            internal.s3Cleanup.deleteS3ObjectAction,
-            { s3Key: args.s3Key },
-          );
-        } else if (args.storageId) {
-          await ctx.storage.delete(args.storageId);
-        }
+        await ctx.scheduler.runAfter(
+          0,
+          internal.s3Cleanup.deleteS3ObjectAction,
+          {
+            s3Key,
+          },
+        );
       } catch (cleanupError) {
         convexLogger.warn("file_upload_storage_cleanup_failed", {
           userId: actingUserId,
           fileName: args.name,
           stage: "post_unexpected_error",
-          s3Key: args.s3Key,
-          storageId: args.storageId,
+          s3Key,
           error:
             cleanupError instanceof Error
               ? { name: cleanupError.name, message: cleanupError.message }
@@ -1112,8 +1064,7 @@ export const saveFile = action({
 
     // Use internal mutation to save to database
     const fileId = (await ctx.runMutation(internal.fileStorage.saveFileToDb, {
-      storageId: args.storageId,
-      s3Key: args.s3Key,
+      s3Key,
       userId: actingUserId,
       name: args.name,
       mediaType: args.mediaType,

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -423,8 +423,7 @@ export const createPendingS3File = internalMutation({
  */
 export const saveFileToDb = internalMutation({
   args: {
-    storageId: v.optional(v.id("_storage")),
-    s3Key: v.optional(v.string()),
+    s3Key: v.string(),
     userId: v.string(),
     name: v.string(),
     mediaType: v.string(),
@@ -435,41 +434,46 @@ export const saveFileToDb = internalMutation({
   },
   returns: v.id("files"),
   handler: async (ctx, args) => {
-    if (args.s3Key) {
-      const existing = await ctx.db
-        .query("files")
-        .withIndex("by_s3_key", (q) => q.eq("s3_key", args.s3Key))
-        .unique();
-      if (existing) {
-        if (existing.user_id !== args.userId) {
-          throw new ConvexError({
-            code: "UNAUTHORIZED",
-            message: "Upload reservation does not belong to this user.",
-          });
-        }
-        if (existing.size !== args.size) {
-          throw new ConvexError({
-            code: "FILE_SIZE_MISMATCH",
-            message: "Uploaded file size does not match reserved size.",
-          });
-        }
+    if (!args.s3Key) {
+      throw new ConvexError({
+        code: "S3_KEY_REQUIRED",
+        message: "S3 key is required to save file metadata.",
+      });
+    }
 
-        await ctx.db.patch(existing._id, {
-          storage_id: args.storageId,
-          name: args.name,
-          media_type: args.mediaType,
-          file_token_size: args.fileTokenSize,
-          content: args.content,
-          is_attached: false,
-        });
-        return existing._id;
-      }
-      if (!args.trustedServiceGenerated) {
+    const existing = await ctx.db
+      .query("files")
+      .withIndex("by_s3_key", (q) => q.eq("s3_key", args.s3Key))
+      .unique();
+    if (existing) {
+      if (existing.user_id !== args.userId) {
         throw new ConvexError({
-          code: "MISSING_UPLOAD_RESERVATION",
-          message: "S3 uploads must have an existing upload reservation.",
+          code: "UNAUTHORIZED",
+          message: "Upload reservation does not belong to this user.",
         });
       }
+      if (existing.size !== args.size) {
+        throw new ConvexError({
+          code: "FILE_SIZE_MISMATCH",
+          message: "Uploaded file size does not match reserved size.",
+        });
+      }
+
+      await ctx.db.patch(existing._id, {
+        storage_id: undefined,
+        name: args.name,
+        media_type: args.mediaType,
+        file_token_size: args.fileTokenSize,
+        content: args.content,
+        is_attached: false,
+      });
+      return existing._id;
+    }
+    if (!args.trustedServiceGenerated) {
+      throw new ConvexError({
+        code: "MISSING_UPLOAD_RESERVATION",
+        message: "S3 uploads must have an existing upload reservation.",
+      });
     }
 
     // Check storage limit
@@ -485,7 +489,6 @@ export const saveFileToDb = internalMutation({
     }
 
     const fileId = await ctx.db.insert("files", {
-      storage_id: args.storageId,
       s3_key: args.s3Key,
       user_id: args.userId,
       name: args.name,

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -338,34 +338,6 @@ export const getFileById = internalQuery({
   },
 });
 
-export const getFileByS3Key = internalQuery({
-  args: {
-    s3Key: v.string(),
-  },
-  returns: v.union(
-    v.object({
-      _id: v.id("files"),
-      storage_id: v.optional(v.id("_storage")),
-      s3_key: v.optional(v.string()),
-      user_id: v.string(),
-      name: v.string(),
-      media_type: v.string(),
-      size: v.number(),
-      file_token_size: v.number(),
-      content: v.optional(v.string()),
-      is_attached: v.boolean(),
-      _creationTime: v.number(),
-    }),
-    v.null(),
-  ),
-  handler: async (ctx, args) => {
-    return await ctx.db
-      .query("files")
-      .withIndex("by_s3_key", (q) => q.eq("s3_key", args.s3Key))
-      .unique();
-  },
-});
-
 export const createPendingS3File = internalMutation({
   args: {
     s3Key: v.string(),


### PR DESCRIPTION
## Summary

- Reject stale `storageId` uploads in `fileActions.saveFile` with an explicit disabled-path error.
- Require `s3Key` for new internal file metadata saves and stop writing `storage_id` for newly-created file rows.
- Keep the existing legacy read/delete paths intact for rows that already have Convex storage ids.

## Why

New uploads already use S3, but the backend still had creation paths that could accept Convex native storage ids. This closes those creation paths while preserving compatibility for older file records.

## Validation

- `pnpm test -- convex/__tests__/fileActions.upload-policy.test.ts convex/__tests__/fileStorage.aggregate.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec prettier --check convex/fileActions.ts convex/fileStorage.ts convex/__tests__/fileActions.upload-policy.test.ts convex/__tests__/fileStorage.aggregate.test.ts`
- Pre-commit hook: `pnpm typecheck` and full `pnpm test` passed on commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Uploads now exclusively use S3; alternative storage uploads are rejected and URL generation simplified.
  * Cleanup behavior unified to remove only the S3 object on failures.

* **Bug Fixes**
  * Stronger validation: uploaded size and reservation ownership are enforced; mismatches return clear error codes and trigger S3 cleanup.

* **Tests**
  * Expanded tests for failure paths, size/reservation validation, and immediate rejection of disabled storage uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->