### PR TITLE
[codex] Harden summarization compaction inputs

### DIFF
--- a/app/components/ContextUsageIndicator.tsx
+++ b/app/components/ContextUsageIndicator.tsx
@@ -10,7 +10,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { SUMMARIZATION_THRESHOLD_PERCENTAGE } from "@/lib/chat/summarization/constants";
+import { getSummarizationThresholdTokens } from "@/lib/chat/summarization/constants";
 import { forwardRef, type ComponentPropsWithoutRef } from "react";
 
 export interface ContextUsageData {
@@ -38,10 +38,6 @@ function formatTokenCount(n: number): string {
 function formatExactTokenCount(n: number): string {
   return Math.round(n).toLocaleString();
 }
-
-const AUTO_COMPACT_PERCENT = Math.round(
-  SUMMARIZATION_THRESHOLD_PERCENTAGE * 100,
-);
 
 const CIRCLE_SIZE = 16;
 const STROKE_WIDTH = 2.5;
@@ -122,9 +118,8 @@ export const ContextUsageIndicator = ({
   if (usedTokens === 0 || maxTokens === 0) return null;
   const percent = Math.min((usedTokens / maxTokens) * 100, 100);
   const remaining = Math.max(0, 100 - Math.round(percent));
-  const autoCompactTokens = Math.floor(
-    maxTokens * SUMMARIZATION_THRESHOLD_PERCENTAGE,
-  );
+  const autoCompactTokens = getSummarizationThresholdTokens(maxTokens);
+  const autoCompactPercent = Math.round((autoCompactTokens / maxTokens) * 100);
   const tokensUntilAutoCompact = Math.max(0, autoCompactTokens - usedTokens);
   const dashOffset = CIRCUMFERENCE - (percent / 100) * CIRCUMFERENCE;
 
@@ -185,7 +180,7 @@ export const ContextUsageIndicator = ({
         </div>
         <div className="text-xs text-muted-foreground pt-1">
           Auto-compact starts at {formatExactTokenCount(autoCompactTokens)}{" "}
-          tokens ({AUTO_COMPACT_PERCENT}%).
+          tokens ({autoCompactPercent}%).
         </div>
         <div className="text-xs text-muted-foreground">
           {tokensUntilAutoCompact > 0

--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -86,6 +86,51 @@ function makeChatDoc(overrides: Record<string, any> = {}): Record<string, any> {
   };
 }
 
+describe("copyChatSummary", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("remaps cutoff IDs without copying source cutoff creation time", async () => {
+    const { copyChatSummary } = await import("../lib/utils");
+    const mockDb = {
+      get: jest.fn<any>().mockResolvedValue(
+        makeSummaryDoc({
+          summary_up_to_message_id: "source-msg",
+          summary_up_to_message_creation_time: 12345,
+          reason: "token_threshold",
+          prompt_version: "test-prompt-v1",
+        }),
+      ),
+      insert: jest.fn<any>().mockResolvedValue("new-summary-id"),
+      patch: jest.fn<any>().mockResolvedValue(undefined),
+    };
+
+    await copyChatSummary(mockDb as any, {
+      sourceSummaryId: SUMMARY_DOC_ID,
+      targetChatDocId: "target-chat-doc-id" as Id<"chats">,
+      targetChatId: "target-chat-id",
+      messageIdMap: new Map([["source-msg", "target-msg"]]),
+    });
+
+    expect(mockDb.insert).toHaveBeenCalledWith(
+      "chat_summaries",
+      expect.not.objectContaining({
+        summary_up_to_message_creation_time: 12345,
+      }),
+    );
+    expect(mockDb.insert).toHaveBeenCalledWith(
+      "chat_summaries",
+      expect.objectContaining({
+        summary_up_to_message_id: "target-msg",
+        reason: "token_threshold",
+        prompt_version: "test-prompt-v1",
+      }),
+    );
+  });
+});
+
 describe("saveLatestSummary — previous_summaries chain", () => {
   let mockCtx: any;
 

--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -170,6 +170,16 @@ describe("saveLatestSummary — previous_summaries chain", () => {
       chatId: CHAT_ID,
       summaryText: "new summary",
       summaryUpToMessageId: "msg-10",
+      metadata: {
+        reason: "token_threshold",
+        promptVersion: "test-prompt-v1",
+        model: "test-model",
+        status: "completed",
+        inputTokens: 100,
+        outputTokens: 20,
+        estimatedCompactedInputTokens: 90,
+        transcriptPath: "/tmp/agent-transcripts/test.json",
+      },
     });
 
     expect(mockCtx.db.insert).toHaveBeenCalledWith(
@@ -177,6 +187,14 @@ describe("saveLatestSummary — previous_summaries chain", () => {
       expect.objectContaining({
         previous_summaries: [],
         summary_up_to_message_creation_time: 10_000,
+        reason: "token_threshold",
+        prompt_version: "test-prompt-v1",
+        model: "test-model",
+        status: "completed",
+        input_tokens: 100,
+        output_tokens: 20,
+        estimated_compacted_input_tokens: 90,
+        transcript_path: "/tmp/agent-transcripts/test.json",
       }),
     );
   });

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -1093,6 +1093,22 @@ export const saveLatestSummary = mutation({
     chatId: v.string(),
     summaryText: v.string(),
     summaryUpToMessageId: v.string(),
+    metadata: v.optional(
+      v.object({
+        reason: v.optional(v.string()),
+        promptVersion: v.optional(v.string()),
+        model: v.optional(v.string()),
+        status: v.optional(v.string()),
+        error: v.optional(v.string()),
+        inputTokens: v.optional(v.number()),
+        outputTokens: v.optional(v.number()),
+        cacheReadTokens: v.optional(v.number()),
+        cacheWriteTokens: v.optional(v.number()),
+        cost: v.optional(v.number()),
+        estimatedCompactedInputTokens: v.optional(v.number()),
+        transcriptPath: v.optional(v.string()),
+      }),
+    ),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -1226,11 +1242,30 @@ export const saveLatestSummary = mutation({
           summaryTextSizeKB + previousSummariesTotalSizeKB,
       });
 
+      const summaryMetadata = Object.fromEntries(
+        Object.entries({
+          reason: args.metadata?.reason,
+          prompt_version: args.metadata?.promptVersion,
+          model: args.metadata?.model,
+          status: args.metadata?.status ?? "completed",
+          error: args.metadata?.error,
+          input_tokens: args.metadata?.inputTokens,
+          output_tokens: args.metadata?.outputTokens,
+          cache_read_tokens: args.metadata?.cacheReadTokens,
+          cache_write_tokens: args.metadata?.cacheWriteTokens,
+          cost: args.metadata?.cost,
+          estimated_compacted_input_tokens:
+            args.metadata?.estimatedCompactedInputTokens,
+          transcript_path: args.metadata?.transcriptPath,
+        }).filter(([, value]) => value !== undefined),
+      );
+
       const summaryId = await ctx.db.insert("chat_summaries", {
         chat_id: args.chatId,
         summary_text: args.summaryText,
         summary_up_to_message_id: args.summaryUpToMessageId,
         summary_up_to_message_creation_time: incomingCutoffCreationTime,
+        ...summaryMetadata,
         previous_summaries: previousSummaries,
       });
 

--- a/convex/lib/utils.ts
+++ b/convex/lib/utils.ts
@@ -37,10 +37,31 @@ export async function copyChatSummary(
         )!,
       }));
 
+    const metadata = Object.fromEntries(
+      Object.entries({
+        summary_up_to_message_creation_time:
+          summary.summary_up_to_message_creation_time,
+        reason: summary.reason,
+        prompt_version: summary.prompt_version,
+        model: summary.model,
+        status: summary.status,
+        error: summary.error,
+        input_tokens: summary.input_tokens,
+        output_tokens: summary.output_tokens,
+        cache_read_tokens: summary.cache_read_tokens,
+        cache_write_tokens: summary.cache_write_tokens,
+        cost: summary.cost,
+        estimated_compacted_input_tokens:
+          summary.estimated_compacted_input_tokens,
+        transcript_path: summary.transcript_path,
+      }).filter(([, value]) => value !== undefined),
+    );
+
     const summaryId = await db.insert("chat_summaries", {
       chat_id: opts.targetChatId,
       summary_text: summary.summary_text,
       summary_up_to_message_id: remappedId,
+      ...metadata,
       previous_summaries: remappedPrevious,
     });
 

--- a/convex/lib/utils.ts
+++ b/convex/lib/utils.ts
@@ -39,8 +39,6 @@ export async function copyChatSummary(
 
     const metadata = Object.fromEntries(
       Object.entries({
-        summary_up_to_message_creation_time:
-          summary.summary_up_to_message_creation_time,
         reason: summary.reason,
         prompt_version: summary.prompt_version,
         model: summary.model,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -56,6 +56,18 @@ export default defineSchema({
     summary_text: v.string(),
     summary_up_to_message_id: v.string(),
     summary_up_to_message_creation_time: v.optional(v.number()),
+    reason: v.optional(v.string()),
+    prompt_version: v.optional(v.string()),
+    model: v.optional(v.string()),
+    status: v.optional(v.string()),
+    error: v.optional(v.string()),
+    input_tokens: v.optional(v.number()),
+    output_tokens: v.optional(v.number()),
+    cache_read_tokens: v.optional(v.number()),
+    cache_write_tokens: v.optional(v.number()),
+    cost: v.optional(v.number()),
+    estimated_compacted_input_tokens: v.optional(v.number()),
+    transcript_path: v.optional(v.string()),
     previous_summaries: v.optional(
       v.array(
         v.object({

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -58,7 +58,7 @@ import {
 } from "@/lib/rate-limit/free-config";
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { getMaxTokensForSubscription } from "@/lib/token-utils";
-import { SUMMARIZATION_THRESHOLD_PERCENTAGE } from "@/lib/chat/summarization/constants";
+import { getSummarizationThresholdTokens } from "@/lib/chat/summarization/constants";
 import { getMaxStepsForUser } from "@/lib/chat/chat-processor";
 import {
   extractOpenRouterMetadata,
@@ -457,11 +457,6 @@ export async function createAgentStream(
 
     prepareStep: async ({ steps, messages }) => {
       try {
-        const threshold = Math.floor(
-          getMaxTokensForSubscription(ctx.subscription, { mode: ctx.mode }) *
-            SUMMARIZATION_THRESHOLD_PERCENTAGE,
-        );
-
         const pruneResult = pruneToolOutputs(state.finalMessages);
         if (pruneResult.prunedCount > 0) {
           state.finalMessages = pruneResult.messages;
@@ -594,9 +589,8 @@ export async function createAgentStream(
     stopWhen: [
       stepCountIs(getMaxStepsForUser(ctx.mode, ctx.subscription)),
       tokenExhaustedAfterSummarization({
-        threshold: Math.floor(
-          getMaxTokensForSubscription(ctx.subscription, { mode: ctx.mode }) *
-            SUMMARIZATION_THRESHOLD_PERCENTAGE,
+        threshold: getSummarizationThresholdTokens(
+          getMaxTokensForSubscription(ctx.subscription, { mode: ctx.mode }),
         ),
         getLastStepInputTokens: () => state.lastStepInputTokens,
         getHasSummarized: () => ctx.summarizationTracker.hasSummarized,

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -65,6 +65,7 @@ import {
   fetchOpenRouterGenerationMetadata,
   mergeOpenRouterMetadata,
 } from "@/lib/api/openrouter-metadata";
+import { classifyProviderOverflowError } from "@/lib/utils/error-utils";
 import type { UsageTracker } from "@/lib/usage-tracker";
 import type { BudgetMonitor } from "@/lib/chat/budget-monitor";
 import type { UsageRefundTracker } from "@/lib/rate-limit";
@@ -81,6 +82,8 @@ import type { ChatMode, SubscriptionTier } from "@/types";
 export type AgentStreamState = {
   /** Current UI messages fed into the model; updated each prepareStep. */
   finalMessages: UIMessage[];
+  /** Raw UI messages captured before in-memory pruning, for transcript sidecars. */
+  transcriptSourceMessages?: UIMessage[];
   /** Context-window usage data; updated after summarization and each step. */
   ctxUsage: { usedTokens: number; maxTokens: number };
   lastStepInputTokens: number;
@@ -459,6 +462,7 @@ export async function createAgentStream(
       try {
         const pruneResult = pruneToolOutputs(state.finalMessages);
         if (pruneResult.prunedCount > 0) {
+          state.transcriptSourceMessages ??= state.finalMessages;
           state.finalMessages = pruneResult.messages;
         }
 
@@ -490,6 +494,7 @@ export async function createAgentStream(
             chatSystemPrompt: ctx.currentSystemPrompt,
             tools: ctx.tools,
             providerOptions: getStepProviderOptions(),
+            transcriptMessages: state.transcriptSourceMessages,
           });
 
           if (result.needsSummarization && result.summarizedMessages) {
@@ -501,6 +506,7 @@ export async function createAgentStream(
             if (result.contextUsage) {
               state.ctxUsage = result.contextUsage;
             }
+            state.transcriptSourceMessages = undefined;
             const activeTools = await getActiveTools();
             const providerOptions = getStepProviderOptions();
             const preparedMessages = prepareProviderMessages(
@@ -723,6 +729,17 @@ export async function createAgentStream(
 
     onError: async ({ error }) => {
       state.providerError = error;
+      const overflowKind = classifyProviderOverflowError(error);
+      if (overflowKind) {
+        state.stoppedDueToTokenExhaustion = true;
+        state.streamFinishReason = TOKEN_EXHAUSTION_FINISH_REASON;
+        console.warn("[agent-stream] provider overflow detected", {
+          overflowKind,
+          chatId: ctx.chatId,
+          model: modelName,
+          hadSummarization: ctx.summarizationTracker.hasSummarized,
+        });
+      }
       if (!isXaiSafetyError(error)) {
         const fallbackSlugs = getFallbackSlugs(modelName, ctx.mode, {
           hasMultimodalToolResults: streamHasImageViewResults,

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -354,26 +354,26 @@ export async function runSummarizationStep(options: {
   transcriptMessages?: UIMessage[];
 }): Promise<SummarizationStepResult> {
   const { needsSummarization, summarizedMessages, summarizationUsage } =
-    await checkAndSummarizeIfNeeded(
-      options.messages,
-      options.subscription,
-      options.languageModel,
-      options.mode,
-      options.writer,
-      options.chatId,
-      options.fileTokens,
-      options.todos,
-      options.abortSignal,
-      options.ensureSandbox,
-      options.systemPromptTokens,
-      options.providerInputTokens ?? 0,
-      options.chatSystemPrompt,
-      options.tools,
-      options.providerOptions,
-      options.modelMessages,
-      options.transcriptMessages,
-      options.ctxMaxTokens,
-    );
+    await checkAndSummarizeIfNeeded({
+      uiMessages: options.messages,
+      subscription: options.subscription,
+      languageModel: options.languageModel,
+      mode: options.mode,
+      writer: options.writer,
+      chatId: options.chatId,
+      fileTokens: options.fileTokens,
+      todos: options.todos,
+      abortSignal: options.abortSignal,
+      ensureSandbox: options.ensureSandbox,
+      systemPromptTokens: options.systemPromptTokens,
+      providerInputTokens: options.providerInputTokens ?? 0,
+      chatSystemPrompt: options.chatSystemPrompt,
+      tools: options.tools,
+      providerOptions: options.providerOptions,
+      modelMessages: options.modelMessages,
+      transcriptMessages: options.transcriptMessages,
+      maxTokensOverride: options.ctxMaxTokens,
+    });
 
   if (!needsSummarization) {
     return { needsSummarization: false };

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -351,6 +351,7 @@ export async function runSummarizationStep(options: {
   tools?: ToolSet;
   providerOptions?: Record<string, Record<string, unknown>>;
   modelMessages?: ModelMessage[];
+  transcriptMessages?: UIMessage[];
 }): Promise<SummarizationStepResult> {
   const { needsSummarization, summarizedMessages, summarizationUsage } =
     await checkAndSummarizeIfNeeded(
@@ -370,6 +371,8 @@ export async function runSummarizationStep(options: {
       options.tools,
       options.providerOptions,
       options.modelMessages,
+      options.transcriptMessages,
+      options.ctxMaxTokens,
     );
 
   if (!needsSummarization) {

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -7,7 +7,8 @@ import type {
 } from "ai";
 import type { Todo } from "@/types";
 import {
-  SUMMARIZATION_THRESHOLD_PERCENTAGE,
+  getSummarizationThresholdTokens,
+  SUMMARIZATION_RESERVED_MAX_TOKENS,
   SUMMARY_TODO_BLOCK_MAX_TOKENS,
   SUMMARY_TODO_MAX_ITEMS,
 } from "../constants";
@@ -35,9 +36,7 @@ const { checkAndSummarizeIfNeeded } =
 const { isSummaryMessage, extractSummaryText, buildSummaryMessage } =
   require("../helpers") as typeof import("../helpers");
 
-const THRESHOLD = Math.floor(
-  MAX_TOKENS_PAID * SUMMARIZATION_THRESHOLD_PERCENTAGE,
-);
+const THRESHOLD = Math.floor(getSummarizationThresholdTokens(MAX_TOKENS_PAID));
 
 const TOKENS_PER_ABOVE_MSG = Math.ceil(THRESHOLD / 4) + 500;
 
@@ -112,6 +111,13 @@ describe("checkAndSummarizeIfNeeded", () => {
     jest.clearAllMocks();
     mockSaveChatSummary.mockResolvedValue(undefined);
     mockWriter = createMockWriter();
+  });
+
+  it("should cap reserved summarization headroom at 20k tokens", () => {
+    expect(getSummarizationThresholdTokens(128_000)).toBe(115_200);
+    expect(getSummarizationThresholdTokens(400_000)).toBe(
+      400_000 - SUMMARIZATION_RESERVED_MAX_TOKENS,
+    );
   });
 
   it("should skip summarization when message count is insufficient", async () => {
@@ -297,6 +303,89 @@ describe("checkAndSummarizeIfNeeded", () => {
     expect(output?.value.length).toBeLessThan(rawToolOutput.length);
     expect(output?.value).not.toContain("unique-tool-line-6000");
     expect(JSON.stringify(callMessages)).not.toContain(rawToolOutput);
+  });
+
+  it("should strip media-ish payloads from summarization modelMessages", async () => {
+    mockGenerateText.mockResolvedValue({ text: "Summary" });
+
+    const dataUri = `data:image/png;base64,${"a".repeat(10_000)}`;
+    const rawSnapshot = `dom-node-${"b".repeat(10_000)}`;
+    const modelMessages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            mediaType: "image/png",
+            filename: "upload.png",
+            data: dataUri,
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "tc-media",
+            toolName: "open_url",
+            input: { url: "https://example.test" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc-media",
+            toolName: "open_url",
+            output: {
+              type: "json",
+              value: {
+                screenshot: {
+                  mime: "image/png",
+                  filename: "page.png",
+                  url: dataUri,
+                },
+                rawSnapshot,
+                title: "Example page",
+              },
+            },
+          },
+        ],
+      },
+    ] as unknown as ModelMessage[];
+
+    await checkAndSummarizeIfNeeded(
+      fourMessagesAboveThreshold,
+      "free",
+      mockLanguageModel,
+      "agent",
+      mockWriter,
+      null,
+      {},
+      [],
+      undefined,
+      undefined,
+      0,
+      0,
+      "test-system-prompt",
+      undefined,
+      undefined,
+      modelMessages,
+    );
+
+    const serializedMessages = JSON.stringify(
+      mockGenerateText.mock.calls[0][0].messages,
+    );
+
+    expect(serializedMessages).toContain("[Attached image/png: page.png]");
+    expect(serializedMessages).toContain("[Attached image/png: upload.png]");
+    expect(serializedMessages).toContain("[rawSnapshot omitted for summary]");
+    expect(serializedMessages).toContain("media payloads omitted");
+    expect(serializedMessages).not.toContain(dataUri);
+    expect(serializedMessages).not.toContain(rawSnapshot);
   });
 
   it("should persist summary when chatId is provided", async () => {

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
-import type { UIMessage, UIMessageStreamWriter, LanguageModel } from "ai";
+import type {
+  UIMessage,
+  UIMessageStreamWriter,
+  LanguageModel,
+  ModelMessage,
+} from "ai";
 import type { Todo } from "@/types";
 import {
   SUMMARIZATION_THRESHOLD_PERCENTAGE,
@@ -219,6 +224,79 @@ describe("checkAndSummarizeIfNeeded", () => {
             .map((p: { text: string }) => p.text)
             .join("");
     expect(lastContent).toContain("security agent");
+  });
+
+  it("should compact huge tool outputs before sending modelMessages to the summarizer", async () => {
+    mockGenerateText.mockResolvedValue({ text: "Summary" });
+
+    const rawToolOutput = Array.from(
+      { length: 12_000 },
+      (_, i) => `unique-tool-line-${i}: ${"x".repeat(32)}`,
+    ).join("\n");
+    const modelMessages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "tc-huge",
+            toolName: "run_terminal_cmd",
+            input: { command: "cat huge.log" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc-huge",
+            toolName: "run_terminal_cmd",
+            output: {
+              type: "text",
+              value: rawToolOutput,
+            },
+          },
+        ],
+      },
+    ] as unknown as ModelMessage[];
+
+    await checkAndSummarizeIfNeeded(
+      fourMessagesAboveThreshold,
+      "free",
+      mockLanguageModel,
+      "agent",
+      mockWriter,
+      null,
+      {},
+      [],
+      undefined,
+      undefined,
+      0,
+      0,
+      "test-system-prompt",
+      undefined,
+      undefined,
+      modelMessages,
+    );
+
+    const callMessages = mockGenerateText.mock.calls[0][0].messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        output?: { type: string; value: string };
+      }>;
+    }>;
+    const toolMessage = callMessages.find((message) => message.role === "tool");
+    const output = toolMessage?.content[0]?.output;
+
+    expect(output).toEqual({
+      type: "text",
+      value: expect.stringContaining("run_terminal_cmd output preview"),
+    });
+    expect(output?.value.length).toBeLessThan(rawToolOutput.length);
+    expect(output?.value).not.toContain("unique-tool-line-6000");
+    expect(JSON.stringify(callMessages)).not.toContain(rawToolOutput);
   });
 
   it("should persist summary when chatId is provided", async () => {

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -4,8 +4,9 @@ import type {
   UIMessageStreamWriter,
   LanguageModel,
   ModelMessage,
+  ToolSet,
 } from "ai";
-import type { Todo } from "@/types";
+import type { ChatMode, SubscriptionTier, Todo } from "@/types";
 import {
   getSummarizationThresholdTokens,
   SUMMARIZATION_RESERVED_MAX_TOKENS,
@@ -81,6 +82,47 @@ const createMockWriter = (): UIMessageStreamWriter =>
 
 const mockLanguageModel = { modelId: "test-model" } as unknown as LanguageModel;
 
+const checkAndSummarizeForTest = (
+  uiMessages: UIMessage[],
+  subscription: SubscriptionTier,
+  languageModel: LanguageModel,
+  mode: ChatMode,
+  writer: UIMessageStreamWriter,
+  chatId: string | null,
+  fileTokens: Record<string, number> = {},
+  todos: Todo[] = [],
+  abortSignal?: AbortSignal,
+  ensureSandbox?: () => Promise<any>,
+  systemPromptTokens: number = 0,
+  providerInputTokens: number = 0,
+  chatSystemPrompt: string = "",
+  tools?: ToolSet,
+  providerOptions?: Record<string, Record<string, unknown>>,
+  modelMessages?: ModelMessage[],
+  transcriptMessages?: UIMessage[],
+  maxTokensOverride?: number,
+) =>
+  checkAndSummarizeIfNeeded({
+    uiMessages,
+    subscription,
+    languageModel,
+    mode,
+    writer,
+    chatId,
+    fileTokens: fileTokens as any,
+    todos,
+    abortSignal,
+    ensureSandbox,
+    systemPromptTokens,
+    providerInputTokens,
+    chatSystemPrompt,
+    tools,
+    providerOptions,
+    modelMessages,
+    transcriptMessages,
+    maxTokensOverride,
+  });
+
 /**
  * Extract all `[msg-N]` IDs from every generateText call's messages.
  * Used to verify which messages were included in summarization prompts.
@@ -129,7 +171,7 @@ describe("checkAndSummarizeIfNeeded", () => {
   it("should skip summarization when message count is insufficient", async () => {
     const messages = [createMessage("msg-1", "user")];
 
-    const result = await checkAndSummarizeIfNeeded(
+    const result = await checkAndSummarizeForTest(
       messages,
       "free",
       mockLanguageModel,
@@ -152,7 +194,7 @@ describe("checkAndSummarizeIfNeeded", () => {
   });
 
   it("should skip summarization when tokens are below threshold", async () => {
-    const result = await checkAndSummarizeIfNeeded(
+    const result = await checkAndSummarizeForTest(
       fourMessages,
       "free",
       mockLanguageModel,
@@ -175,7 +217,7 @@ describe("checkAndSummarizeIfNeeded", () => {
   it("should summarize and return correct structure when threshold exceeded", async () => {
     mockGenerateText.mockResolvedValue({ text: "Test summary content" });
 
-    const result = await checkAndSummarizeIfNeeded(
+    const result = await checkAndSummarizeForTest(
       fourMessagesAboveThreshold,
       "free",
       mockLanguageModel,
@@ -206,7 +248,7 @@ describe("checkAndSummarizeIfNeeded", () => {
   it("should use agent prompt when mode is agent", async () => {
     mockGenerateText.mockResolvedValue({ text: "Agent summary" });
 
-    const result = await checkAndSummarizeIfNeeded(
+    const result = await checkAndSummarizeForTest(
       fourMessagesAboveThreshold,
       "free",
       mockLanguageModel,
@@ -273,7 +315,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       },
     ] as unknown as ModelMessage[];
 
-    await checkAndSummarizeIfNeeded(
+    await checkAndSummarizeForTest(
       fourMessagesAboveThreshold,
       "free",
       mockLanguageModel,
@@ -363,7 +405,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       },
     ] as unknown as ModelMessage[];
 
-    await checkAndSummarizeIfNeeded(
+    await checkAndSummarizeForTest(
       fourMessagesAboveThreshold,
       "free",
       mockLanguageModel,
@@ -416,7 +458,7 @@ describe("checkAndSummarizeIfNeeded", () => {
   it("should persist summary when chatId is provided", async () => {
     mockGenerateText.mockResolvedValue({ text: "Summary" });
 
-    await checkAndSummarizeIfNeeded(
+    await checkAndSummarizeForTest(
       fourMessagesAboveThreshold,
       "free",
       mockLanguageModel,
@@ -453,7 +495,7 @@ describe("checkAndSummarizeIfNeeded", () => {
   it("should skip database persistence for temporary chats", async () => {
     mockGenerateText.mockResolvedValue({ text: "Summary" });
 
-    await checkAndSummarizeIfNeeded(
+    await checkAndSummarizeForTest(
       fourMessagesAboveThreshold,
       "free",
       mockLanguageModel,
@@ -475,7 +517,7 @@ describe("checkAndSummarizeIfNeeded", () => {
   it("should write summarization completed even when AI fails", async () => {
     mockGenerateText.mockRejectedValue(new Error("API error"));
 
-    const result = await checkAndSummarizeIfNeeded(
+    const result = await checkAndSummarizeForTest(
       fourMessagesAboveThreshold,
       "free",
       mockLanguageModel,
@@ -507,7 +549,7 @@ describe("checkAndSummarizeIfNeeded", () => {
     mockGenerateText.mockResolvedValue({ text: "Summary" });
     mockSaveChatSummary.mockRejectedValue(new Error("DB error"));
 
-    const result = await checkAndSummarizeIfNeeded(
+    const result = await checkAndSummarizeForTest(
       fourMessagesAboveThreshold,
       "free",
       mockLanguageModel,
@@ -544,7 +586,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       { id: "3", content: "Enumerate subdomains", status: "completed" },
     ];
 
-    const result = await checkAndSummarizeIfNeeded(
+    const result = await checkAndSummarizeForTest(
       fourMessagesAboveThreshold,
       "free",
       mockLanguageModel,
@@ -629,7 +671,7 @@ describe("checkAndSummarizeIfNeeded", () => {
     });
 
     await expect(
-      checkAndSummarizeIfNeeded(
+      checkAndSummarizeForTest(
         fourMessagesAboveThreshold,
         "free",
         mockLanguageModel,
@@ -667,7 +709,7 @@ describe("checkAndSummarizeIfNeeded", () => {
 
     const abortController = new AbortController();
 
-    await checkAndSummarizeIfNeeded(
+    await checkAndSummarizeForTest(
       fourMessagesAboveThreshold,
       "free",
       mockLanguageModel,
@@ -693,7 +735,7 @@ describe("checkAndSummarizeIfNeeded", () => {
   it("should not include todo block in summary when todos are empty", async () => {
     mockGenerateText.mockResolvedValue({ text: "Test summary content" });
 
-    const result = await checkAndSummarizeIfNeeded(
+    const result = await checkAndSummarizeForTest(
       fourMessagesAboveThreshold,
       "free",
       mockLanguageModel,
@@ -739,7 +781,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       createMessageWithTokens("real-4", "assistant", TOKENS_PER_ABOVE_MSG),
     ];
 
-    const result = await checkAndSummarizeIfNeeded(
+    const result = await checkAndSummarizeForTest(
       [summaryMsg, ...realMessages],
       "free",
       mockLanguageModel,
@@ -778,7 +820,7 @@ describe("checkAndSummarizeIfNeeded", () => {
     ];
 
     const input = [summaryMsg, ...realMessages];
-    const result = await checkAndSummarizeIfNeeded(
+    const result = await checkAndSummarizeForTest(
       input,
       "free",
       mockLanguageModel,
@@ -821,7 +863,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       createMessageWithTokens("real-4", "assistant", TOKENS_PER_ABOVE_MSG),
     ];
 
-    await checkAndSummarizeIfNeeded(
+    await checkAndSummarizeForTest(
       [summaryMsg, ...realMessages],
       "free",
       mockLanguageModel,
@@ -870,7 +912,7 @@ describe("checkAndSummarizeIfNeeded", () => {
     mockGenerateText.mockResolvedValueOnce({ text: "First summary" });
     mockGenerateText.mockResolvedValueOnce({ text: "Second summary" });
 
-    const result1 = await checkAndSummarizeIfNeeded(
+    const result1 = await checkAndSummarizeForTest(
       fourMessagesAboveThreshold,
       "free",
       mockLanguageModel,
@@ -898,7 +940,7 @@ describe("checkAndSummarizeIfNeeded", () => {
 
     const secondInput = [...result1.summarizedMessages, ...newMessages];
 
-    const result2 = await checkAndSummarizeIfNeeded(
+    const result2 = await checkAndSummarizeForTest(
       secondInput,
       "free",
       mockLanguageModel,
@@ -981,7 +1023,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       createMessageWithTokens("msg-4", "assistant", TOKENS_PER_ABOVE_MSG),
     ];
 
-    const result1 = await checkAndSummarizeIfNeeded(
+    const result1 = await checkAndSummarizeForTest(
       round1Messages,
       "free",
       mockLanguageModel,
@@ -1007,7 +1049,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       createMessageWithTokens("msg-8", "assistant", TOKENS_PER_ABOVE_MSG),
     ];
 
-    const result2 = await checkAndSummarizeIfNeeded(
+    const result2 = await checkAndSummarizeForTest(
       round2Input,
       "free",
       mockLanguageModel,
@@ -1033,7 +1075,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       createMessageWithTokens("msg-12", "assistant", TOKENS_PER_ABOVE_MSG),
     ];
 
-    const result3 = await checkAndSummarizeIfNeeded(
+    const result3 = await checkAndSummarizeForTest(
       round3Input,
       "free",
       mockLanguageModel,
@@ -1062,7 +1104,7 @@ describe("checkAndSummarizeIfNeeded", () => {
   it("should handle normal first-time summarization unchanged", async () => {
     mockGenerateText.mockResolvedValue({ text: "First summary" });
 
-    const result = await checkAndSummarizeIfNeeded(
+    const result = await checkAndSummarizeForTest(
       fourMessagesAboveThreshold,
       "free",
       mockLanguageModel,

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -408,7 +408,7 @@ describe("checkAndSummarizeIfNeeded", () => {
     });
     const serializedMessages = JSON.stringify(bounded);
 
-    expect(estimateSummaryInputTokens(bounded)).toBeLessThan(512);
+    expect(estimateSummaryInputTokens(bounded)).toBeLessThanOrEqual(512);
     expect(serializedMessages).toContain("Summary input shortened");
     expect(serializedMessages).not.toContain(hugeText);
   });

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -9,6 +9,7 @@ import type { Todo } from "@/types";
 import {
   getSummarizationThresholdTokens,
   SUMMARIZATION_RESERVED_MAX_TOKENS,
+  SUMMARY_PROMPT_VERSION,
   SUMMARY_TODO_BLOCK_MAX_TOKENS,
   SUMMARY_TODO_MAX_ITEMS,
 } from "../constants";
@@ -33,8 +34,13 @@ jest.doMock("@/lib/ai/providers", () => ({
 
 const { checkAndSummarizeIfNeeded } =
   require("../index") as typeof import("../index");
-const { isSummaryMessage, extractSummaryText, buildSummaryMessage } =
-  require("../helpers") as typeof import("../helpers");
+const {
+  isSummaryMessage,
+  extractSummaryText,
+  buildSummaryMessage,
+  boundModelMessagesForSummarization,
+  estimateSummaryInputTokens,
+} = require("../helpers") as typeof import("../helpers");
 
 const THRESHOLD = Math.floor(getSummarizationThresholdTokens(MAX_TOKENS_PAID));
 
@@ -73,7 +79,7 @@ const fourMessagesAboveThreshold: UIMessage[] = [
 const createMockWriter = (): UIMessageStreamWriter =>
   ({ write: jest.fn() }) as unknown as UIMessageStreamWriter;
 
-const mockLanguageModel = {} as LanguageModel;
+const mockLanguageModel = { modelId: "test-model" } as unknown as LanguageModel;
 
 /**
  * Extract all `[msg-N]` IDs from every generateText call's messages.
@@ -388,6 +394,25 @@ describe("checkAndSummarizeIfNeeded", () => {
     expect(serializedMessages).not.toContain(rawSnapshot);
   });
 
+  it("should bound total summarization modelMessages input", () => {
+    const hugeText = `keep-start ${"huge-text ".repeat(20_000)} keep-end`;
+    const messages = [
+      {
+        role: "user",
+        content: hugeText,
+      },
+    ] as unknown as ModelMessage[];
+
+    const bounded = boundModelMessagesForSummarization(messages, {
+      maxInputTokens: 512,
+    });
+    const serializedMessages = JSON.stringify(bounded);
+
+    expect(estimateSummaryInputTokens(bounded)).toBeLessThan(512);
+    expect(serializedMessages).toContain("Summary input shortened");
+    expect(serializedMessages).not.toContain(hugeText);
+  });
+
   it("should persist summary when chatId is provided", async () => {
     mockGenerateText.mockResolvedValue({ text: "Summary" });
 
@@ -407,11 +432,22 @@ describe("checkAndSummarizeIfNeeded", () => {
       "test-system-prompt",
     );
 
-    expect(mockSaveChatSummary).toHaveBeenCalledWith({
-      chatId: "chat-123",
-      summaryText: "Summary",
-      summaryUpToMessageId: "msg-4",
-    });
+    expect(mockSaveChatSummary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: "chat-123",
+        summaryText: "Summary",
+        summaryUpToMessageId: "msg-4",
+        metadata: expect.objectContaining({
+          reason: "token_threshold",
+          promptVersion: SUMMARY_PROMPT_VERSION,
+          model: "test-model",
+          status: "completed",
+          inputTokens: 0,
+          outputTokens: 0,
+          estimatedCompactedInputTokens: expect.any(Number),
+        }),
+      }),
+    );
   });
 
   it("should skip database persistence for temporary chats", async () => {

--- a/lib/chat/summarization/constants.ts
+++ b/lib/chat/summarization/constants.ts
@@ -1,8 +1,19 @@
 // Keep last N messages unsummarized for context
 export const MESSAGES_TO_KEEP_UNSUMMARIZED = 0;
 
-// Summarize at 90% of token limit to leave buffer for current response
-export const SUMMARIZATION_THRESHOLD_PERCENTAGE = 0.9;
+// Reserve context headroom before compaction so the next request still has
+// enough room for tool schemas, provider formatting overhead, and output.
+export const SUMMARIZATION_RESERVED_MAX_TOKENS = 20_000;
+export const SUMMARIZATION_RESERVED_TOKEN_PERCENTAGE = 0.1;
+
+export const getSummarizationThresholdTokens = (maxTokens: number): number => {
+  const usableMaxTokens = Math.max(0, maxTokens);
+  const reservedTokens = Math.min(
+    SUMMARIZATION_RESERVED_MAX_TOKENS,
+    Math.floor(usableMaxTokens * SUMMARIZATION_RESERVED_TOKEN_PERCENTAGE),
+  );
+  return Math.max(0, usableMaxTokens - reservedTokens);
+};
 
 // Keep persisted todos useful in the synthetic summary without letting stored
 // todo payloads bypass chat token budgeting.

--- a/lib/chat/summarization/constants.ts
+++ b/lib/chat/summarization/constants.ts
@@ -9,3 +9,7 @@ export const SUMMARIZATION_THRESHOLD_PERCENTAGE = 0.9;
 export const SUMMARY_TODO_MAX_ITEMS = 100;
 export const SUMMARY_TODO_CONTENT_MAX_TOKENS = 256;
 export const SUMMARY_TODO_BLOCK_MAX_TOKENS = 4096;
+
+// Bound individual tool results fed into the summarizer. Agent tool outputs can
+// be enormous, and summarization should see a preview rather than raw logs.
+export const SUMMARY_TOOL_OUTPUT_MAX_TOKENS = 2048;

--- a/lib/chat/summarization/constants.ts
+++ b/lib/chat/summarization/constants.ts
@@ -5,6 +5,7 @@ export const MESSAGES_TO_KEEP_UNSUMMARIZED = 0;
 // enough room for tool schemas, provider formatting overhead, and output.
 export const SUMMARIZATION_RESERVED_MAX_TOKENS = 20_000;
 export const SUMMARIZATION_RESERVED_TOKEN_PERCENTAGE = 0.1;
+export const SUMMARY_PROMPT_VERSION = "2026-06-11.opencode-anchored-summary-v2";
 
 export const getSummarizationThresholdTokens = (maxTokens: number): number => {
   const usableMaxTokens = Math.max(0, maxTokens);
@@ -24,3 +25,15 @@ export const SUMMARY_TODO_BLOCK_MAX_TOKENS = 4096;
 // Bound individual tool results fed into the summarizer. Agent tool outputs can
 // be enormous, and summarization should see a preview rather than raw logs.
 export const SUMMARY_TOOL_OUTPUT_MAX_TOKENS = 2048;
+
+// Bound the entire model-message projection sent to the summarizer. This is a
+// second safety net after per-tool/media compaction.
+export const SUMMARY_INPUT_MAX_TOKENS = 64_000;
+export const SUMMARY_OVERFLOW_TEXT_PART_MAX_TOKENS = 1024;
+export const SUMMARY_OVERFLOW_TOOL_OUTPUT_MAX_TOKENS = 512;
+
+export const getSummaryInputMaxTokens = (maxTokens: number): number =>
+  Math.min(
+    SUMMARY_INPUT_MAX_TOKENS,
+    getSummarizationThresholdTokens(maxTokens),
+  );

--- a/lib/chat/summarization/helpers.ts
+++ b/lib/chat/summarization/helpers.ts
@@ -19,6 +19,10 @@ import type { Id } from "@/convex/_generated/dataModel";
 
 import {
   MESSAGES_TO_KEEP_UNSUMMARIZED,
+  SUMMARY_INPUT_MAX_TOKENS,
+  SUMMARY_OVERFLOW_TEXT_PART_MAX_TOKENS,
+  SUMMARY_OVERFLOW_TOOL_OUTPUT_MAX_TOKENS,
+  SUMMARY_PROMPT_VERSION,
   SUMMARY_TODO_BLOCK_MAX_TOKENS,
   SUMMARY_TODO_CONTENT_MAX_TOKENS,
   SUMMARY_TODO_MAX_ITEMS,
@@ -33,9 +37,24 @@ import {
 export interface SummarizationUsage {
   inputTokens: number;
   outputTokens: number;
+  estimatedCompactedInputTokens?: number;
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
   cost?: number;
+}
+
+export interface SummaryPersistenceMetadata {
+  reason: "token_threshold" | "provider_input_threshold";
+  promptVersion: string;
+  model?: string;
+  status: "completed";
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  cost?: number;
+  estimatedCompactedInputTokens?: number;
+  transcriptPath?: string;
 }
 
 export interface SummarizationResult {
@@ -64,8 +83,10 @@ export const isAboveTokenThreshold = (
   fileTokens: Record<Id<"files">, number>,
   systemPromptTokens: number = 0,
   providerInputTokens: number = 0,
+  maxTokensOverride?: number,
 ): boolean => {
-  const maxTokens = getMaxTokensForSubscription(subscription);
+  const maxTokens =
+    maxTokensOverride ?? getMaxTokensForSubscription(subscription);
   const threshold = getSummarizationThresholdTokens(maxTokens);
 
   // If the provider already reported input tokens exceeding the threshold,
@@ -360,6 +381,165 @@ export const compactModelMessagesForSummarization = <T extends ModelMessage>(
   return changed ? compacted : messages;
 };
 
+const stringifySummaryMessages = (messages: ModelMessage[]): string => {
+  try {
+    return JSON.stringify(messages);
+  } catch {
+    return String(messages);
+  }
+};
+
+export const estimateSummaryInputTokens = (messages: ModelMessage[]): number =>
+  safeCountTokens(stringifySummaryMessages(messages));
+
+const truncateSummaryText = (text: string, maxTokens: number): string =>
+  safeCountTokens(text) > maxTokens
+    ? truncateContent(
+        text,
+        "\n[Summary input shortened: middle omitted]\n",
+        maxTokens,
+      )
+    : text;
+
+const compactContentPartForSummaryBudget = (
+  part: unknown,
+  maxTextPartTokens: number,
+): { value: unknown; changed: boolean } => {
+  if (part === null || typeof part !== "object") {
+    return { value: part, changed: false };
+  }
+
+  const record = part as Record<string, unknown>;
+
+  if (record.type === "text" && typeof record.text === "string") {
+    const text = truncateSummaryText(record.text, maxTextPartTokens);
+    return {
+      value: text === record.text ? part : { ...record, text },
+      changed: text !== record.text,
+    };
+  }
+
+  if (record.type === "tool-call" && record.input != null) {
+    const inputText = stringifyToolOutput(record.input);
+    if (safeCountTokens(inputText) <= maxTextPartTokens) {
+      return { value: part, changed: false };
+    }
+    const toolName =
+      typeof record.toolName === "string" ? record.toolName : "tool";
+    return {
+      value: {
+        ...record,
+        input: {
+          summary: `[${toolName} input omitted to fit summary budget: ${inputText.length} chars]`,
+        },
+      },
+      changed: true,
+    };
+  }
+
+  return { value: part, changed: false };
+};
+
+const compactTextPartsForSummaryBudget = <T extends ModelMessage>(
+  messages: T[],
+  maxTextPartTokens: number,
+): T[] => {
+  let changed = false;
+
+  const compacted = messages.map((message) => {
+    if (typeof message.content === "string") {
+      const content = truncateSummaryText(message.content, maxTextPartTokens);
+      if (content === message.content) return message;
+      changed = true;
+      return { ...message, content } as T;
+    }
+
+    if (!Array.isArray(message.content)) return message;
+
+    let contentChanged = false;
+    const content = message.content.map((part) => {
+      const compactedPart = compactContentPartForSummaryBudget(
+        part,
+        maxTextPartTokens,
+      );
+      if (compactedPart.changed) {
+        contentChanged = true;
+        return compactedPart.value as typeof part;
+      }
+      return part;
+    });
+
+    if (!contentChanged) return message;
+    changed = true;
+    return { ...message, content } as T;
+  });
+
+  return changed ? compacted : messages;
+};
+
+const fallbackSummaryInputMessages = (
+  messages: ModelMessage[],
+  maxInputTokens: number,
+): ModelMessage[] => {
+  const transcript = truncateContent(
+    stringifySummaryMessages(messages),
+    "\n[Summary input transcript shortened: middle omitted]\n",
+    Math.max(1, maxInputTokens - 256),
+  );
+
+  return [
+    {
+      role: "user",
+      content: `[Summary input transcript was too large after compaction; sanitized transcript follows.]\n${transcript}`,
+    },
+  ] as ModelMessage[];
+};
+
+export const boundModelMessagesForSummarization = (
+  messages: ModelMessage[],
+  {
+    maxInputTokens = SUMMARY_INPUT_MAX_TOKENS,
+    overflowToolOutputMaxTokens = SUMMARY_OVERFLOW_TOOL_OUTPUT_MAX_TOKENS,
+    overflowTextPartMaxTokens = SUMMARY_OVERFLOW_TEXT_PART_MAX_TOKENS,
+  }: {
+    maxInputTokens?: number;
+    overflowToolOutputMaxTokens?: number;
+    overflowTextPartMaxTokens?: number;
+  } = {},
+): ModelMessage[] => {
+  if (maxInputTokens <= 0) return fallbackSummaryInputMessages(messages, 1);
+  if (estimateSummaryInputTokens(messages) <= maxInputTokens) return messages;
+
+  let compacted = compactModelMessagesForSummarization(
+    messages,
+    overflowToolOutputMaxTokens,
+  );
+  compacted = compactTextPartsForSummaryBudget(
+    compacted,
+    overflowTextPartMaxTokens,
+  );
+  if (estimateSummaryInputTokens(compacted) <= maxInputTokens) {
+    return compacted;
+  }
+
+  compacted = compactTextPartsForSummaryBudget(compacted, 128);
+  if (estimateSummaryInputTokens(compacted) <= maxInputTokens) {
+    return compacted;
+  }
+
+  return fallbackSummaryInputMessages(compacted, maxInputTokens);
+};
+
+const getLanguageModelIdentifier = (
+  languageModel: LanguageModel,
+): string | undefined => {
+  const record = languageModel as unknown as Record<string, unknown>;
+  for (const key of ["modelId", "modelID", "id"] as const) {
+    if (typeof record[key] === "string") return record[key];
+  }
+  return undefined;
+};
+
 export const generateSummaryText = async (
   messagesToSummarize: UIMessage[],
   languageModel: LanguageModel,
@@ -370,6 +550,7 @@ export const generateSummaryText = async (
   providerOptions?: Record<string, Record<string, unknown>>,
   abortSignal?: AbortSignal,
   modelMessages?: ModelMessage[],
+  summaryInputMaxTokens: number = SUMMARY_INPUT_MAX_TOKENS,
 ): Promise<{ text: string; usage: SummarizationUsage }> => {
   const summarizationPrompt = getSummarizationPrompt(mode);
 
@@ -396,9 +577,15 @@ export const generateSummaryText = async (
   const sourceModelMessages =
     modelMessages ??
     (await convertToModelMessages(messagesToSummarize, { tools }));
-  const summaryModelMessages = compactModelMessagesForSummarization(
+  const compactedModelMessages = compactModelMessagesForSummarization(
     sourceModelMessages as ModelMessage[],
   );
+  const summaryModelMessages = boundModelMessagesForSummarization(
+    compactedModelMessages,
+    { maxInputTokens: summaryInputMaxTokens },
+  );
+  const estimatedCompactedInputTokens =
+    estimateSummaryInputTokens(summaryModelMessages);
 
   const result = await generateText({
     model: languageModel,
@@ -430,6 +617,7 @@ export const generateSummaryText = async (
     usage: {
       inputTokens: result.usage?.inputTokens ?? 0,
       outputTokens: result.usage?.outputTokens ?? 0,
+      estimatedCompactedInputTokens,
       ...(details?.cacheReadTokens
         ? { cacheReadTokens: details.cacheReadTokens }
         : undefined),
@@ -440,6 +628,35 @@ export const generateSummaryText = async (
     },
   };
 };
+
+export const buildSummaryPersistenceMetadata = ({
+  providerInputTokens,
+  threshold,
+  languageModel,
+  usage,
+  transcriptPath,
+}: {
+  providerInputTokens: number;
+  threshold: number;
+  languageModel: LanguageModel;
+  usage?: SummarizationUsage;
+  transcriptPath?: string | null;
+}): SummaryPersistenceMetadata => ({
+  reason:
+    providerInputTokens > threshold
+      ? "provider_input_threshold"
+      : "token_threshold",
+  promptVersion: SUMMARY_PROMPT_VERSION,
+  model: getLanguageModelIdentifier(languageModel),
+  status: "completed",
+  inputTokens: usage?.inputTokens,
+  outputTokens: usage?.outputTokens,
+  cacheReadTokens: usage?.cacheReadTokens,
+  cacheWriteTokens: usage?.cacheWriteTokens,
+  cost: usage?.cost,
+  estimatedCompactedInputTokens: usage?.estimatedCompactedInputTokens,
+  transcriptPath: transcriptPath ?? undefined,
+});
 
 export const buildSummaryMessage = (
   summaryText: string,
@@ -484,6 +701,7 @@ export const persistSummary = async (
   chatId: string | null,
   summaryText: string,
   cutoffMessageId: string,
+  metadata?: SummaryPersistenceMetadata,
 ): Promise<void> => {
   if (!chatId) return;
 
@@ -492,6 +710,7 @@ export const persistSummary = async (
       chatId,
       summaryText,
       summaryUpToMessageId: cutoffMessageId,
+      metadata,
     });
   } catch (error) {
     console.error("[Summarization] Failed to save summary:", error);

--- a/lib/chat/summarization/helpers.ts
+++ b/lib/chat/summarization/helpers.ts
@@ -19,11 +19,11 @@ import type { Id } from "@/convex/_generated/dataModel";
 
 import {
   MESSAGES_TO_KEEP_UNSUMMARIZED,
-  SUMMARIZATION_THRESHOLD_PERCENTAGE,
   SUMMARY_TODO_BLOCK_MAX_TOKENS,
   SUMMARY_TODO_CONTENT_MAX_TOKENS,
   SUMMARY_TODO_MAX_ITEMS,
   SUMMARY_TOOL_OUTPUT_MAX_TOKENS,
+  getSummarizationThresholdTokens,
 } from "./constants";
 import {
   AGENT_SUMMARIZATION_PROMPT,
@@ -66,7 +66,7 @@ export const isAboveTokenThreshold = (
   providerInputTokens: number = 0,
 ): boolean => {
   const maxTokens = getMaxTokensForSubscription(subscription);
-  const threshold = Math.floor(maxTokens * SUMMARIZATION_THRESHOLD_PERCENTAGE);
+  const threshold = getSummarizationThresholdTokens(maxTokens);
 
   // If the provider already reported input tokens exceeding the threshold,
   // trust that over our local gpt-tokenizer estimate (which misses tool
@@ -137,6 +137,152 @@ const toTextModelToolOutput = (value: string) => ({
   value,
 });
 
+const toTextModelContentPart = (text: string) => ({
+  type: "text" as const,
+  text,
+});
+
+const DATA_URI_PATTERN = /^data:([^;,]+)(?:;[^,]*)?,/i;
+const LONG_URL_LENGTH = 512;
+const RAW_SNAPSHOT_PLACEHOLDER = "[rawSnapshot omitted for summary]";
+
+const MEDIA_KEY_PATTERN =
+  /^(image|images|screenshot|screenshots|attachment|attachments|media|file|files|blob|base64|data|url|uri)$/i;
+const ALWAYS_OMIT_MEDIA_STRING_KEY_PATTERN = /^(base64|blob)$/i;
+
+const getStringField = (
+  value: Record<string, unknown>,
+  keys: string[],
+): string | undefined => {
+  for (const key of keys) {
+    const field = value[key];
+    if (typeof field === "string" && field.trim()) return field;
+  }
+  return undefined;
+};
+
+const describeDataUri = (value: string): string | null => {
+  const match = value.match(DATA_URI_PATTERN);
+  if (!match) return null;
+  return `[Attached ${match[1] || "media"}: data URI omitted]`;
+};
+
+const describeAttachmentObject = (
+  value: Record<string, unknown>,
+  keyHint?: string,
+): string | null => {
+  const mime =
+    getStringField(value, ["mime", "mimeType", "mediaType"]) ??
+    (typeof value.type === "string" && value.type.includes("/")
+      ? value.type
+      : undefined);
+  const filename =
+    getStringField(value, ["filename", "fileName", "name", "path"]) ?? "file";
+  const hasPayload = ["url", "uri", "data", "base64", "content", "value"].some(
+    (key) => typeof value[key] === "string" && value[key],
+  );
+  const keySuggestsMedia = keyHint ? MEDIA_KEY_PATTERN.test(keyHint) : false;
+  const typeSuggestsMedia =
+    typeof value.type === "string" && MEDIA_KEY_PATTERN.test(value.type);
+
+  if ((mime || keySuggestsMedia || typeSuggestsMedia) && hasPayload) {
+    return `[Attached ${mime ?? "media"}: ${filename}]`;
+  }
+
+  return null;
+};
+
+const sanitizeMediaPayloads = (
+  value: unknown,
+  keyHint?: string,
+  seen = new WeakSet<object>(),
+): { value: unknown; changed: boolean } => {
+  if (typeof value === "string") {
+    const dataUri = describeDataUri(value);
+    if (dataUri) return { value: dataUri, changed: true };
+
+    if (keyHint === "rawSnapshot") {
+      return { value: RAW_SNAPSHOT_PLACEHOLDER, changed: true };
+    }
+
+    if (
+      keyHint &&
+      MEDIA_KEY_PATTERN.test(keyHint) &&
+      (ALWAYS_OMIT_MEDIA_STRING_KEY_PATTERN.test(keyHint) ||
+        value.length > LONG_URL_LENGTH)
+    ) {
+      return {
+        value: `[${keyHint} omitted for summary: ${value.length} chars]`,
+        changed: true,
+      };
+    }
+
+    return { value, changed: false };
+  }
+
+  if (value === null || typeof value !== "object") {
+    return { value, changed: false };
+  }
+
+  if (seen.has(value)) {
+    return { value: "[circular payload omitted]", changed: true };
+  }
+  seen.add(value);
+
+  try {
+    if (Array.isArray(value)) {
+      let changed = false;
+      const items = value.map((item) => {
+        const result = sanitizeMediaPayloads(item, keyHint, seen);
+        changed ||= result.changed;
+        return result.value;
+      });
+      return { value: changed ? items : value, changed };
+    }
+
+    const record = value as Record<string, unknown>;
+    const attachment = describeAttachmentObject(record, keyHint);
+    if (attachment) return { value: attachment, changed: true };
+
+    let changed = false;
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, childValue] of Object.entries(record)) {
+      if (key === "rawSnapshot") {
+        sanitized[key] = RAW_SNAPSHOT_PLACEHOLDER;
+        changed = true;
+        continue;
+      }
+
+      const result = sanitizeMediaPayloads(childValue, key, seen);
+      sanitized[key] = result.value;
+      changed ||= result.changed;
+    }
+
+    return { value: changed ? sanitized : value, changed };
+  } finally {
+    seen.delete(value);
+  }
+};
+
+const sanitizeModelContentPart = (
+  part: unknown,
+): { value: unknown; changed: boolean } => {
+  if (part === null || typeof part !== "object") {
+    return sanitizeMediaPayloads(part);
+  }
+
+  const attachment = describeAttachmentObject(part as Record<string, unknown>);
+  if (attachment) {
+    return { value: toTextModelContentPart(attachment), changed: true };
+  }
+
+  const sanitized = sanitizeMediaPayloads(part);
+  if (typeof sanitized.value === "string") {
+    return { value: toTextModelContentPart(sanitized.value), changed: true };
+  }
+  return sanitized;
+};
+
 /**
  * Build a summarization-only projection of model messages.
  *
@@ -151,37 +297,57 @@ export const compactModelMessagesForSummarization = <T extends ModelMessage>(
   let changed = false;
 
   const compacted = messages.map((message) => {
-    if (message.role !== "tool" || !Array.isArray(message.content)) {
-      return message;
+    if (!Array.isArray(message.content)) {
+      const sanitizedContent = sanitizeMediaPayloads(message.content);
+      if (!sanitizedContent.changed) return message;
+
+      changed = true;
+      return { ...message, content: sanitizedContent.value } as T;
     }
 
     let contentChanged = false;
     const content = message.content.map((part) => {
       const partAny = part as Record<string, unknown>;
-      if (partAny.type !== "tool-result" || partAny.output == null) {
+      if (
+        message.role !== "tool" ||
+        partAny.type !== "tool-result" ||
+        partAny.output == null
+      ) {
+        const sanitizedPart = sanitizeModelContentPart(part);
+        if (sanitizedPart.changed) {
+          contentChanged = true;
+          return sanitizedPart.value as typeof part;
+        }
         return part;
       }
 
       const outputValue = unwrapModelToolOutput(partAny.output);
-      const outputText = stringifyToolOutput(outputValue);
+      const sanitizedOutput = sanitizeMediaPayloads(outputValue);
+      const outputText = stringifyToolOutput(sanitizedOutput.value);
       const outputTokens = safeCountTokens(outputText);
-      if (outputTokens <= maxToolOutputTokens) {
+      if (!sanitizedOutput.changed && outputTokens <= maxToolOutputTokens) {
         return part;
       }
 
       contentChanged = true;
-      const preview = truncateContent(
-        outputText,
-        "\n[Tool output shortened: middle omitted]\n",
-        maxToolOutputTokens,
-      );
+      const preview =
+        outputTokens > maxToolOutputTokens
+          ? truncateContent(
+              outputText,
+              "\n[Tool output shortened: middle omitted]\n",
+              maxToolOutputTokens,
+            )
+          : outputText;
       const toolName =
         typeof partAny.toolName === "string" ? partAny.toolName : "tool";
+      const prefix = sanitizedOutput.changed
+        ? `[${toolName} output preview: media payloads omitted`
+        : `[${toolName} output preview: shortened from ${outputTokens} tokens`;
 
       return {
         ...partAny,
         output: toTextModelToolOutput(
-          `[${toolName} output preview: shortened from ${outputTokens} tokens]\n${preview}`,
+          `${prefix}${outputTokens > maxToolOutputTokens ? `; shortened from ${outputTokens} tokens` : ""}]\n${preview}`,
         ),
       } as typeof part;
     });

--- a/lib/chat/summarization/helpers.ts
+++ b/lib/chat/summarization/helpers.ts
@@ -11,6 +11,7 @@ import {
   getMaxTokensForSubscription,
   countMessagesTokens,
   truncateContent,
+  safeCountTokens,
 } from "@/lib/token-utils";
 import { saveChatSummary } from "@/lib/db/actions";
 import { SubscriptionTier, ChatMode, Todo } from "@/types";
@@ -22,6 +23,7 @@ import {
   SUMMARY_TODO_BLOCK_MAX_TOKENS,
   SUMMARY_TODO_CONTENT_MAX_TOKENS,
   SUMMARY_TODO_MAX_ITEMS,
+  SUMMARY_TOOL_OUTPUT_MAX_TOKENS,
 } from "./constants";
 import {
   AGENT_SUMMARIZATION_PROMPT,
@@ -108,6 +110,90 @@ export const extractSummaryText = (message: UIMessage): string | null => {
   return match ? match[1] : null;
 };
 
+const isModelToolOutput = (
+  output: unknown,
+): output is { type: string; value?: unknown } =>
+  typeof output === "object" &&
+  output !== null &&
+  !Array.isArray(output) &&
+  typeof (output as { type?: unknown }).type === "string";
+
+const unwrapModelToolOutput = (output: unknown): unknown =>
+  isModelToolOutput(output) && Object.hasOwn(output, "value")
+    ? output.value
+    : output;
+
+const stringifyToolOutput = (output: unknown): string => {
+  if (typeof output === "string") return output;
+  try {
+    return JSON.stringify(output);
+  } catch {
+    return String(output);
+  }
+};
+
+const toTextModelToolOutput = (value: string) => ({
+  type: "text" as const,
+  value,
+});
+
+/**
+ * Build a summarization-only projection of model messages.
+ *
+ * This keeps tool-call/tool-result structure intact while bounding individual
+ * tool outputs. The full raw transcript can still be persisted separately; the
+ * summarizer only needs enough head/tail detail to preserve important facts.
+ */
+export const compactModelMessagesForSummarization = <T extends ModelMessage>(
+  messages: T[],
+  maxToolOutputTokens: number = SUMMARY_TOOL_OUTPUT_MAX_TOKENS,
+): T[] => {
+  let changed = false;
+
+  const compacted = messages.map((message) => {
+    if (message.role !== "tool" || !Array.isArray(message.content)) {
+      return message;
+    }
+
+    let contentChanged = false;
+    const content = message.content.map((part) => {
+      const partAny = part as Record<string, unknown>;
+      if (partAny.type !== "tool-result" || partAny.output == null) {
+        return part;
+      }
+
+      const outputValue = unwrapModelToolOutput(partAny.output);
+      const outputText = stringifyToolOutput(outputValue);
+      const outputTokens = safeCountTokens(outputText);
+      if (outputTokens <= maxToolOutputTokens) {
+        return part;
+      }
+
+      contentChanged = true;
+      const preview = truncateContent(
+        outputText,
+        "\n[Tool output shortened: middle omitted]\n",
+        maxToolOutputTokens,
+      );
+      const toolName =
+        typeof partAny.toolName === "string" ? partAny.toolName : "tool";
+
+      return {
+        ...partAny,
+        output: toTextModelToolOutput(
+          `[${toolName} output preview: shortened from ${outputTokens} tokens]\n${preview}`,
+        ),
+      } as typeof part;
+    });
+
+    if (!contentChanged) return message;
+    changed = true;
+    return { ...message, content } as T;
+  });
+
+  return changed ? compacted : messages;
+};
+
 export const generateSummaryText = async (
   messagesToSummarize: UIMessage[],
   languageModel: LanguageModel,
@@ -141,6 +227,13 @@ export const generateSummaryText = async (
       )
     : undefined;
 
+  const sourceModelMessages =
+    modelMessages ??
+    (await convertToModelMessages(messagesToSummarize, { tools }));
+  const summaryModelMessages = compactModelMessagesForSummarization(
+    sourceModelMessages as ModelMessage[],
+  );
+
   const result = await generateText({
     model: languageModel,
     system: chatSystemPrompt,
@@ -149,8 +242,7 @@ export const generateSummaryText = async (
 
     providerOptions: providerOptions as any,
     messages: [
-      ...(modelMessages ??
-        (await convertToModelMessages(messagesToSummarize, { tools }))),
+      ...summaryModelMessages,
       {
         role: "user" as const,
         content: `${summarizationPrompt}${incrementalNote}\n\nSummarize the above conversation using the structured format. Output ONLY the summary — do not continue the conversation or role-play as the assistant.`,

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -9,6 +9,7 @@ import {
 } from "ai";
 import { v4 as uuidv4 } from "uuid";
 import { SubscriptionTier, ChatMode, Todo, AnySandbox } from "@/types";
+import { getMaxTokensForSubscription } from "@/lib/token-utils";
 import {
   writeSummarizationStarted,
   writeSummarizationCompleted,
@@ -16,7 +17,11 @@ import {
 import { isE2BSandbox } from "@/lib/ai/tools/utils/sandbox-types";
 import type { Id } from "@/convex/_generated/dataModel";
 
-import { MESSAGES_TO_KEEP_UNSUMMARIZED } from "./constants";
+import {
+  MESSAGES_TO_KEEP_UNSUMMARIZED,
+  getSummaryInputMaxTokens,
+  getSummarizationThresholdTokens,
+} from "./constants";
 import {
   NO_SUMMARIZATION,
   isAboveTokenThreshold,
@@ -26,6 +31,7 @@ import {
   persistSummary,
   isSummaryMessage,
   extractSummaryText,
+  buildSummaryPersistenceMetadata,
 } from "./helpers";
 import type { SummarizationResult } from "./helpers";
 
@@ -142,6 +148,8 @@ export const checkAndSummarizeIfNeeded = async (
   tools?: ToolSet,
   providerOptions?: Record<string, Record<string, unknown>>,
   modelMessages?: ModelMessage[],
+  transcriptMessages?: UIMessage[],
+  maxTokensOverride?: number,
 ): Promise<SummarizationResult> => {
   // Detect and separate synthetic summary message from real messages
   let realMessages: UIMessage[];
@@ -160,6 +168,9 @@ export const checkAndSummarizeIfNeeded = async (
   }
 
   // Check token threshold on full messages (including summary) to determine need
+  const maxTokens =
+    maxTokensOverride ?? getMaxTokensForSubscription(subscription);
+  const summarizationThreshold = getSummarizationThresholdTokens(maxTokens);
   if (
     !isAboveTokenThreshold(
       uiMessages,
@@ -167,6 +178,7 @@ export const checkAndSummarizeIfNeeded = async (
       fileTokens,
       systemPromptTokens,
       providerInputTokens,
+      maxTokens,
     )
   ) {
     return NO_SUMMARIZATION(uiMessages);
@@ -193,6 +205,7 @@ export const checkAndSummarizeIfNeeded = async (
       providerOptions,
       abortSignal,
       modelMessages,
+      getSummaryInputMaxTokens(maxTokens),
     );
 
     // In agent modes, save the full transcript of summarized messages to the sandbox
@@ -202,7 +215,7 @@ export const checkAndSummarizeIfNeeded = async (
         ? ensureSandbox()
             .then((sandbox) =>
               saveTranscriptToSandbox(
-                messagesToSummarize,
+                transcriptMessages ?? messagesToSummarize,
                 sandbox,
                 modelMessages,
               ),
@@ -228,8 +241,15 @@ export const checkAndSummarizeIfNeeded = async (
     }
 
     const summaryMessage = buildSummaryMessage(finalSummaryText, todos);
+    const metadata = buildSummaryPersistenceMetadata({
+      providerInputTokens,
+      threshold: summarizationThreshold,
+      languageModel,
+      usage: summarizationUsage,
+      transcriptPath: savedPath,
+    });
 
-    await persistSummary(chatId, finalSummaryText, cutoffMessageId);
+    await persistSummary(chatId, finalSummaryText, cutoffMessageId, metadata);
 
     return {
       needsSummarization: true,

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -39,6 +39,27 @@ export type { SummarizationResult, SummarizationUsage } from "./helpers";
 
 export type EnsureSandbox = () => Promise<AnySandbox>;
 
+export interface CheckAndSummarizeOptions {
+  uiMessages: UIMessage[];
+  subscription: SubscriptionTier;
+  languageModel: LanguageModel;
+  mode: ChatMode;
+  writer: UIMessageStreamWriter;
+  chatId: string | null;
+  fileTokens?: Record<Id<"files">, number>;
+  todos?: Todo[];
+  abortSignal?: AbortSignal;
+  ensureSandbox?: EnsureSandbox;
+  systemPromptTokens?: number;
+  providerInputTokens?: number;
+  chatSystemPrompt?: string;
+  tools?: ToolSet;
+  providerOptions?: Record<string, Record<string, unknown>>;
+  modelMessages?: ModelMessage[];
+  transcriptMessages?: UIMessage[];
+  maxTokensOverride?: number;
+}
+
 /**
  * Builds the instructional notice appended to summaryText pointing the agent
  * to the saved transcript file on the sandbox filesystem.
@@ -131,26 +152,26 @@ const saveTranscriptToSandbox = async (
   return null;
 };
 
-export const checkAndSummarizeIfNeeded = async (
-  uiMessages: UIMessage[],
-  subscription: SubscriptionTier,
-  languageModel: LanguageModel,
-  mode: ChatMode,
-  writer: UIMessageStreamWriter,
-  chatId: string | null,
-  fileTokens: Record<Id<"files">, number> = {},
-  todos: Todo[] = [],
-  abortSignal?: AbortSignal,
-  ensureSandbox?: EnsureSandbox,
-  systemPromptTokens: number = 0,
-  providerInputTokens: number = 0,
-  chatSystemPrompt: string = "",
-  tools?: ToolSet,
-  providerOptions?: Record<string, Record<string, unknown>>,
-  modelMessages?: ModelMessage[],
-  transcriptMessages?: UIMessage[],
-  maxTokensOverride?: number,
-): Promise<SummarizationResult> => {
+export const checkAndSummarizeIfNeeded = async ({
+  uiMessages,
+  subscription,
+  languageModel,
+  mode,
+  writer,
+  chatId,
+  fileTokens = {},
+  todos = [],
+  abortSignal,
+  ensureSandbox,
+  systemPromptTokens = 0,
+  providerInputTokens = 0,
+  chatSystemPrompt = "",
+  tools,
+  providerOptions,
+  modelMessages,
+  transcriptMessages,
+  maxTokensOverride,
+}: CheckAndSummarizeOptions): Promise<SummarizationResult> => {
   // Detect and separate synthetic summary message from real messages
   let realMessages: UIMessage[];
   let existingSummaryText: string | null = null;

--- a/lib/chat/summarization/prompts.ts
+++ b/lib/chat/summarization/prompts.ts
@@ -2,6 +2,8 @@ export const AGENT_SUMMARIZATION_PROMPT =
   "You are a context condensation engine. You receive a conversation between a user and a security agent. " +
   "You must output ONLY a structured summary — never continue the conversation, never role-play as the agent, " +
   "and never produce tool calls or action plans.\n\n" +
+  "If the conversation includes an existing context summary block, treat it as an anchored summary. " +
+  "Update it by preserving still-true details, removing stale details, and merging in new facts from later messages.\n\n" +
   "ANALYSIS PHASE:\n" +
   "Before producing the summary, chronologically analyze each phase of the conversation. " +
   "For each phase, identify: the agent's objective, tools/techniques used, what was discovered " +
@@ -19,6 +21,8 @@ export const AGENT_SUMMARIZATION_PROMPT =
   "Preserve exact wording — the resuming agent must respect these constraints.\n\n" +
   "## Progress & Decisions\n" +
   "What has been completed, what approach was chosen, and what the agent was doing when interrupted.\n\n" +
+  "## Current State\n" +
+  "What is in progress right now, what is blocked, and any active assumptions. Use '(none)' when empty.\n\n" +
   "## Errors & Recovery\n" +
   "Tool failures, configuration issues, rate limits, and how they were resolved. " +
   "Separate from assessment findings — these are operational issues.\n\n" +
@@ -28,8 +32,13 @@ export const AGENT_SUMMARIZATION_PROMPT =
   "What the agent should do next, DIRECTLY related to the work in progress at interruption. " +
   "Include the exact state of the last operation. " +
   "Do not suggest new attack vectors that weren't part of the current approach.\n\n" +
+  "## Relevant Files & Artifacts\n" +
+  "Important file paths, transcript paths, scan outputs, logs, notes, or generated artifacts and why they matter. Use '(none)' when empty.\n\n" +
   "RULES:\n" +
   "- Output ONLY the structured summary. No preamble, no conversational text.\n" +
+  "- Keep every section header, even when a section is empty.\n" +
+  "- Use terse bullets, not prose paragraphs.\n" +
+  "- Do not mention that summarization or compaction happened.\n" +
   "- Preserve exact technical details (URLs, IPs, ports, headers, payloads).\n" +
   "- Include full sandbox file paths for important scan results and tool outputs (e.g. nmap XML, nuclei JSON, downloaded files).\n" +
   "- Compress verbose tool outputs into key findings.\n" +
@@ -50,6 +59,10 @@ export const AGENT_SUMMARIZATION_PROMPT =
   "- Completed: Port scan, service enumeration, web crawl, auth testing\n" +
   "- Chose to focus on API after finding OpenAPI spec at /api/docs\n" +
   "- Currently running SQLMap against /api/search endpoint\n\n" +
+  "## Current State\n" +
+  "- In progress: SQLMap against /api/search\n" +
+  "- Blocked: (none)\n" +
+  "- Assumptions: API testing remains in scope\n\n" +
   "## Errors & Recovery\n" +
   "- Nmap XML parsing failed due to IPv6 addresses — switched to -4 flag\n" +
   "- Rate limited by WAF after 50 req/s — reduced to 10 req/s\n\n" +
@@ -59,7 +72,9 @@ export const AGENT_SUMMARIZATION_PROMPT =
   "## Next Steps\n" +
   "- SQLMap was running against /api/search with --level=5 --risk=3,\n" +
   "  had completed 40% of payloads (file: /tmp/sqlmap/output.json)\n" +
-  "- After SQLMap completes, test /api/admin endpoints with stolen JWT";
+  "- After SQLMap completes, test /api/admin endpoints with stolen JWT\n\n" +
+  "## Relevant Files & Artifacts\n" +
+  "- /tmp/sqlmap/output.json: active SQLMap output";
 
 export const ASK_SUMMARIZATION_PROMPT =
   "You are performing context condensation for a conversational assistant. " +
@@ -67,6 +82,8 @@ export const ASK_SUMMARIZATION_PROMPT =
   "continue helping the user as if no summarization occurred.\n\n" +
   "Output ONLY the structured summary. Do not continue the conversation, " +
   "generate responses to the user, or produce tool calls.\n\n" +
+  "If the conversation includes an existing context summary block, treat it as an anchored summary. " +
+  "Update it by preserving still-true details, removing stale details, and merging in new facts from later messages.\n\n" +
   "OUTPUT FORMAT:\n" +
   "## Context & Goal\n" +
   "What the user is trying to accomplish overall.\n\n" +
@@ -75,11 +92,18 @@ export const ASK_SUMMARIZATION_PROMPT =
   "Include any URLs, code snippets, or technical details shared.\n\n" +
   "## Decisions & Conclusions\n" +
   "Facts established, recommendations given, choices made.\n\n" +
+  "## Current State\n" +
+  "What is in progress, what is blocked, and any active assumptions. Use '(none)' when empty.\n\n" +
   "## User Preferences & Corrections\n" +
   "Any stated preferences, constraints, or corrections the user made.\n\n" +
+  "## Relevant Files & Artifacts\n" +
+  "Important file paths, URLs, logs, documents, or generated artifacts and why they matter. Use '(none)' when empty.\n\n" +
   "## Open Threads\n" +
   "Unresolved questions, ongoing topics, or tasks the user may return to.\n\n" +
   "COMPRESSION GUIDELINES:\n" +
+  "- Keep every section header, even when a section is empty.\n" +
+  "- Use terse bullets, not prose paragraphs.\n" +
+  "- Do not mention that summarization or compaction happened.\n" +
   "- Preserve exact technical details when relevant.\n" +
   "- Summarize repetitive exchanges into consolidated form.\n" +
   "- Pay special attention to the most recent exchanges — these are the active context.\n" +

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -1093,17 +1093,39 @@ export async function saveChatSummary({
   chatId,
   summaryText,
   summaryUpToMessageId,
+  metadata,
 }: {
   chatId: string;
   summaryText: string;
   summaryUpToMessageId: string;
+  metadata?: {
+    reason?: string;
+    promptVersion?: string;
+    model?: string;
+    status?: string;
+    error?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+    cost?: number;
+    estimatedCompactedInputTokens?: number;
+    transcriptPath?: string;
+  };
 }) {
   try {
+    const compactedMetadata = metadata
+      ? Object.fromEntries(
+          Object.entries(metadata).filter(([, value]) => value !== undefined),
+        )
+      : undefined;
+
     await getConvexClient().mutation(api.chats.saveLatestSummary, {
       serviceKey,
       chatId,
       summaryText,
       summaryUpToMessageId,
+      ...(compactedMetadata ? { metadata: compactedMetadata } : {}),
     });
 
     return;

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "@jest/globals";
 import {
+  classifyProviderOverflowError,
   extractErrorDetails,
   extractRetryAttempts,
   getUserFriendlyProviderError,
@@ -423,5 +424,34 @@ describe("provider error classification", () => {
     });
 
     expect(getProviderErrorCategory(extractErrorDetails(err))).toBe("timeout");
+  });
+
+  it("classifies provider context overflow errors", () => {
+    const err = apiCallError({
+      statusCode: 400,
+      data: {
+        error: {
+          message:
+            "context_length_exceeded: maximum context length is 128000 tokens",
+        },
+      },
+    });
+
+    expect(classifyProviderOverflowError(err)).toBe("context");
+    expect(getUserFriendlyProviderError(err)).toContain("context limit");
+  });
+
+  it("classifies provider media overflow errors", () => {
+    const err = apiCallError({
+      statusCode: 413,
+      responseBody: JSON.stringify({
+        error: {
+          message: "image file too large; reduce the attachment size",
+        },
+      }),
+    });
+
+    expect(classifyProviderOverflowError(err)).toBe("media");
+    expect(getUserFriendlyProviderError(err)).toContain("attached media");
   });
 });

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -454,4 +454,14 @@ describe("provider error classification", () => {
     expect(classifyProviderOverflowError(err)).toBe("media");
     expect(getUserFriendlyProviderError(err)).toContain("attached media");
   });
+
+  it("does not classify generic payload overflow as media-only", () => {
+    const err = apiCallError({
+      statusCode: 413,
+      message: "payload too large",
+    });
+
+    expect(classifyProviderOverflowError(err)).toBe("context");
+    expect(getUserFriendlyProviderError(err)).toContain("context limit");
+  });
 });

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -158,6 +158,79 @@ const getOpenRouterProviderInfo = (
   return details;
 };
 
+const PROVIDER_CONTEXT_OVERFLOW_PATTERNS = [
+  /context[_\s-]?length[_\s-]?exceeded/i,
+  /context window/i,
+  /context limit/i,
+  /maximum context/i,
+  /max(?:imum)? token/i,
+  /input(?: is)? too long/i,
+  /prompt(?: is)? too long/i,
+  /request(?: entity)? too large/i,
+  /too many tokens/i,
+  /reduce (?:the )?(?:length|size)/i,
+  /exceeds? (?:the )?(?:model|provider).*(?:limit|maximum)/i,
+] as const;
+
+const PROVIDER_MEDIA_OVERFLOW_PATTERNS = [
+  /image(?: file)? too large/i,
+  /media(?: file)? too large/i,
+  /attachment(?: file)? too large/i,
+  /base64.*too large/i,
+  /payload too large/i,
+] as const;
+
+const sourceToSearchableStrings = (source: unknown): string[] => {
+  if (typeof source === "string") return [source];
+  if (!isRecord(source)) return [];
+
+  const result: string[] = [];
+  for (const key of [
+    "name",
+    "message",
+    "code",
+    "statusText",
+    "responseBody",
+  ] as const) {
+    const value = source[key];
+    if (typeof value === "string") result.push(value);
+  }
+
+  const providerInfo = getOpenRouterProviderInfo(source);
+  for (const value of Object.values(providerInfo)) {
+    if (typeof value === "string") result.push(value);
+  }
+
+  return result;
+};
+
+export const classifyProviderOverflowError = (
+  error: unknown,
+): "context" | "media" | null => {
+  const searchable = collectErrorSources(error).flatMap(
+    sourceToSearchableStrings,
+  );
+  if (
+    searchable.some((text) =>
+      PROVIDER_MEDIA_OVERFLOW_PATTERNS.some((pattern) => pattern.test(text)),
+    )
+  ) {
+    return "media";
+  }
+  if (
+    searchable.some((text) =>
+      PROVIDER_CONTEXT_OVERFLOW_PATTERNS.some((pattern) => pattern.test(text)),
+    )
+  ) {
+    return "context";
+  }
+  return null;
+};
+
+export const isProviderContextOrMediaOverflowError = (
+  error: unknown,
+): boolean => classifyProviderOverflowError(error) !== null;
+
 /**
  * Removes sensitive user data from provider error objects.
  * Fields containing user prompts/messages are completely removed.
@@ -475,9 +548,18 @@ export const extractRetryAttempts = (
 export const getUserFriendlyProviderError = (error: unknown): string => {
   const statusCode = extractStatusCode(error);
   const { providerName, detail } = extractProviderDetails(error);
+  const overflowKind = classifyProviderOverflowError(error);
 
   if (isProviderContentBlockedError(error)) {
     return "The model provider blocked this request because the conversation content was flagged by its safety system. Edit your last message or remove sensitive or raw tool output, then try again.";
+  }
+
+  if (overflowKind === "media") {
+    return "The model provider rejected this request because attached media or file payloads were too large. Remove or shrink the attachments, then try again.";
+  }
+
+  if (overflowKind === "context") {
+    return "The model provider rejected this request because the conversation exceeded its context limit. The conversation may need another compaction pass, or you can retry after removing large tool output or attachments.";
   }
 
   // Friendly summary based on status code

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -167,6 +167,7 @@ const PROVIDER_CONTEXT_OVERFLOW_PATTERNS = [
   /input(?: is)? too long/i,
   /prompt(?: is)? too long/i,
   /request(?: entity)? too large/i,
+  /payload too large/i,
   /too many tokens/i,
   /reduce (?:the )?(?:length|size)/i,
   /exceeds? (?:the )?(?:model|provider).*(?:limit|maximum)/i,
@@ -177,7 +178,6 @@ const PROVIDER_MEDIA_OVERFLOW_PATTERNS = [
   /media(?: file)? too large/i,
   /attachment(?: file)? too large/i,
   /base64.*too large/i,
-  /payload too large/i,
 ] as const;
 
 const sourceToSearchableStrings = (source: unknown): string[] => {


### PR DESCRIPTION
## Summary

- Add a summarization-only model-message projection that bounds oversized tool-result outputs before `generateText` runs.
- Strip media-ish structured payloads from summary inputs, including `data:` base64 URIs, `file`/`image` content parts, attachments, huge media fields, and `rawSnapshot` blobs.
- Bound the total summarization model-message input with a 64k safety cap, tighter overflow previews, and a sanitized fallback transcript when needed.
- Replace the fixed 90% compaction trigger with reserved headroom: `maxTokens - min(20_000, maxTokens * 0.1)`, using the active context budget where available.
- Persist first-class compaction metadata on `chat_summaries`: reason, prompt version, model, status, token usage, estimated compacted input tokens, and transcript path.
- Preserve raw pre-prune messages for transcript sidecars while keeping compact placeholders in model context.
- Classify provider context/media overflow errors and surface targeted recovery guidance instead of a generic provider error.
- Update compaction prompts with anchored-summary guidance, current state, and relevant artifact sections.

## Intentionally left out

- Tail-aware verbatim retention. We should do this separately with message-part/tool-result budgeting because one of our messages can contain very large tool output.
- Full automatic replay after provider overflow. This PR adds detection and recovery-facing state/messages; retrying the stream after emergency compaction needs a separate stream lifecycle change.

## Why

Agent runs can accumulate very large tool outputs or media payloads inside `modelMessages`. The summarizer already received pruned UI messages, but direct `modelMessages` could still carry raw huge outputs into the summary call. This keeps the summarizer focused on useful context while preserving structured tool-call/tool-result shape and retaining raw detail in transcript sidecars.

## Validation

- `pnpm test -- lib/chat/summarization/__tests__/index.test.ts`
- `pnpm test -- convex/__tests__/chatSummaryFallback.test.ts lib/utils/__tests__/error-utils.test.ts`
- `pnpm typecheck`
- `pnpm lint` passed with existing warnings only
- `pnpm test` passed: 130 suites, 1451 tests
- Commit hook ran Prettier, ESLint fix, `pnpm typecheck`, and full `pnpm test` successfully: 130 suites, 1451 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tooltip now shows computed auto-compact token threshold.
  * Tool outputs are compacted and media/attachments sanitized for summarization.
  * Summaries use explicit token budgets, include richer sections (Current State, Relevant Files, etc.), and persist expanded metadata (reason, model, tokens, transcript).
  * Agent flows can snapshot transcripts for summarization and support max-token overrides.

* **Bug Fixes**
  * Improved classification and user-facing handling for provider overflow / token exhaustion.

* **Tests**
  * Added/expanded tests for compaction, media stripping, token bounds, metadata persistence, and overflow classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->