### PR TITLE
[codex] Warn Pro Plus users about expensive models

### DIFF
--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -66,11 +66,18 @@ interface ModelSelectorProps {
 const AUTO_MODEL_DESCRIPTION =
   "Balanced quality and speed, recommended for most tasks";
 
+const HIGH_COST_MODEL_WARNING_TIERS = new Set<SubscriptionTier>([
+  "pro",
+  "pro-plus",
+  "ultra",
+  "team",
+]);
+
 const shouldWarnForPaidHighCostModel = (
   subscription: SubscriptionTier,
   model: SelectedModel,
 ): boolean =>
-  subscription !== "free" &&
+  HIGH_COST_MODEL_WARNING_TIERS.has(subscription) &&
   (model === "hackerai-pro" || model === "hackerai-max");
 
 const AutoOptionButton = ({

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -69,7 +69,7 @@ describe("ModelSelector", () => {
     expect(onChange).toHaveBeenCalledWith("auto");
   });
 
-  it("warns before selecting HackerAI Pro on paid plans", () => {
+  it("warns before selecting HackerAI Pro on Pro Plus plans", () => {
     const onChange = jest.fn();
     render(<ModelSelector value="auto" onChange={onChange} mode="ask" />);
 
@@ -87,6 +87,18 @@ describe("ModelSelector", () => {
 
     expect(mockDismissHighCostModelUsageNotice).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith("hackerai-pro");
+  });
+
+  it("warns before selecting HackerAI Max on Pro Plus plans", () => {
+    const onChange = jest.fn();
+    render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /HackerAI Max/i }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId("high-cost-model-warning")).toBeVisible();
+    expect(screen.getByText(/HackerAI Max is powerful/i)).toBeVisible();
   });
 
   it("warns before selecting HackerAI Max on paid tiers above Pro", () => {


### PR DESCRIPTION
## Summary

- Make the high-cost model warning tier list explicit and include Pro Plus.
- Add ModelSelector coverage for Pro Plus users selecting HackerAI Pro and HackerAI Max.

## Why

Pro Plus users should see the same warning about expensive models before selecting the higher-cost HackerAI Pro/Max options.

## Validation

- `pnpm test app/components/ModelSelector/__tests__/ModelSelector.test.tsx --runInBand`
- `pnpm exec eslint app/components/ModelSelector.tsx app/components/ModelSelector/__tests__/ModelSelector.test.tsx`
- Pre-commit hook: `pnpm typecheck`
- Pre-commit hook: `pnpm test`