### PR TITLE
[codex] Limit PostHog replays to paid users

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -104,7 +104,6 @@ E2B_TEMPLATE=terminal-agent-sandbox
 # Used for product analytics, tool-call events, and server error tracking.
 # NEXT_PUBLIC_POSTHOG_KEY=phc_
 # NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
-# NEXT_PUBLIC_POSTHOG_TRACK_FREE_USERS=true
 
 # =============================================================================
 # PAYMENTS (Optional - Stripe)

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -18,6 +18,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 
     if (!shouldTrack) {
       if (posthog.__loaded) {
+        posthog.stopSessionRecording();
         posthog.reset();
         posthog.opt_out_capturing();
       }
@@ -30,6 +31,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
         api_host: `${process.env.NEXT_PUBLIC_POSTHOG_HOST}`,
         capture_pageview: false, // Disable automatic pageview capture, as we capture manually
         autocapture: false, // Disable automatic event capture, as we capture manually
+        disable_session_recording: true,
         before_send: (event) => {
           if (!event || shouldDropExpectedConvexException(event)) {
             return null;
@@ -48,6 +50,15 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
         user!.email,
       subscription,
     });
+
+    if (subscription !== "free") {
+      if (!posthog.sessionRecordingStarted()) {
+        posthog.startSessionRecording();
+      }
+      return;
+    }
+
+    posthog.stopSessionRecording();
   }, [subscription, user]);
 
   return <PHProvider client={posthog}>{children}</PHProvider>;


### PR DESCRIPTION
## Summary
- Disable PostHog session recording by default in the client SDK.
- Start session recording only after identifying a signed-in paid user.
- Stop session recording for free or logged-out users.
- Remove the stale `NEXT_PUBLIC_POSTHOG_TRACK_FREE_USERS` example variable, which no longer controls tracking.

## Why
Free-user analytics were enabled for authenticated funnel tracking, which meant that turning on PostHog session replay at the project level could record free users too. This keeps analytics available for free users while making replay capture paid-only in code.

## Validation
- `pnpm typecheck`
- `pnpm exec eslint app/providers.tsx`
- Pre-commit hook: Prettier, ESLint, `pnpm typecheck`, and Jest (`130` suites / `1445` tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed unused environment variable example.
  * Updated session recording behavior: disabled by default, then controlled based on subscription tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->