### PR TITLE
[codex] Use SCAN for Redis rate limit cleanup

### DIFF
--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -6,6 +6,7 @@ import {
   getBudgetLimits,
   getCycleExpireSeconds,
   getSubscriptionPrice,
+  isUserRateLimitKey,
   POINTS_PER_DOLLAR,
 } from "../token-bucket";
 
@@ -177,6 +178,48 @@ describe("token-bucket", () => {
       const periodEnd = now + 31 * 24 * 60 * 60;
 
       expect(getCycleExpireSeconds(periodEnd, now)).toBe(32 * 24 * 60 * 60);
+    });
+  });
+
+  describe("isUserRateLimitKey", () => {
+    const userId = "user_123";
+
+    it("matches all rate-limit namespaces owned by the user", () => {
+      expect(isUserRateLimitKey(`usage:monthly:${userId}:pro`, userId)).toBe(
+        true,
+      );
+      expect(isUserRateLimitKey(`upgrade:carryover:${userId}`, userId)).toBe(
+        true,
+      );
+      expect(isUserRateLimitKey(`free_limit:${userId}:free:ask`, userId)).toBe(
+        true,
+      );
+      expect(isUserRateLimitKey(`free_referral_bonus:${userId}`, userId)).toBe(
+        true,
+      );
+      expect(
+        isUserRateLimitKey(`free_referral_bonus_grant:ref:${userId}`, userId),
+      ).toBe(true);
+      expect(
+        isUserRateLimitKey(`free_agent_limit:${userId}:agent`, userId),
+      ).toBe(true);
+      expect(
+        isUserRateLimitKey(`free_monthly_cost:${userId}:2026-06`, userId),
+      ).toBe(true);
+      expect(isUserRateLimitKey(`free_run_lock:${userId}`, userId)).toBe(true);
+      expect(
+        isUserRateLimitKey(`team:debt_applied:org_123:${userId}`, userId),
+      ).toBe(true);
+    });
+
+    it("rejects unrelated keys that contain the same user id", () => {
+      expect(isUserRateLimitKey(`chat:${userId}:messages`, userId)).toBe(false);
+      expect(
+        isUserRateLimitKey(`team:removed_usage:org_${userId}`, userId),
+      ).toBe(false);
+      expect(isUserRateLimitKey(`usage:monthly:user_456:pro`, userId)).toBe(
+        false,
+      );
     });
   });
 

--- a/lib/rate-limit/key-cleanup.ts
+++ b/lib/rate-limit/key-cleanup.ts
@@ -1,0 +1,14 @@
+export const isUserRateLimitKey = (key: string, userId: string): boolean => {
+  return (
+    key.startsWith(`usage:monthly:${userId}:`) ||
+    key === `upgrade:carryover:${userId}` ||
+    key.startsWith(`free_limit:${userId}:`) ||
+    key === `free_referral_bonus:${userId}` ||
+    (key.startsWith("free_referral_bonus_grant:") &&
+      key.endsWith(`:${userId}`)) ||
+    key.startsWith(`free_agent_limit:${userId}:`) ||
+    key.startsWith(`free_monthly_cost:${userId}:`) ||
+    key === `free_run_lock:${userId}` ||
+    (key.startsWith("team:debt_applied:") && key.endsWith(`:${userId}`))
+  );
+};

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -54,11 +54,58 @@ export const NORMAL_USAGE_MULTIPLIER = 1.3;
 
 /** 30 days in seconds — used for Redis TTLs aligned with billing cycles. */
 const THIRTY_DAYS_SECONDS = 30 * 24 * 60 * 60;
+const REDIS_SCAN_COUNT = 500;
+const REDIS_DELETE_BATCH_SIZE = 100;
 const RATE_LIMIT_SERVICE_NOT_CONFIGURED =
   "Rate limiting service is not configured";
 
 const throwRateLimitServiceNotConfigured = (): never => {
   throw new ChatSDKError("rate_limit:chat", RATE_LIMIT_SERVICE_NOT_CONFIGURED);
+};
+
+type RedisClient = NonNullable<ReturnType<typeof createRedisClient>>;
+
+const scanRedisKeys = async (
+  redis: RedisClient,
+  pattern: string,
+): Promise<string[]> => {
+  let cursor = "0";
+  const keys: string[] = [];
+
+  do {
+    const [nextCursor, batch] = await redis.scan(cursor, {
+      match: pattern,
+      count: REDIS_SCAN_COUNT,
+    });
+    keys.push(...batch);
+    cursor = nextCursor;
+  } while (cursor !== "0");
+
+  return keys;
+};
+
+const deleteRedisKeys = async (
+  redis: RedisClient,
+  keys: string[],
+): Promise<void> => {
+  for (let index = 0; index < keys.length; index += REDIS_DELETE_BATCH_SIZE) {
+    await redis.del(...keys.slice(index, index + REDIS_DELETE_BATCH_SIZE));
+  }
+};
+
+export const isUserRateLimitKey = (key: string, userId: string): boolean => {
+  return (
+    key.startsWith(`usage:monthly:${userId}:`) ||
+    key === `upgrade:carryover:${userId}` ||
+    key.startsWith(`free_limit:${userId}:`) ||
+    key === `free_referral_bonus:${userId}` ||
+    (key.startsWith("free_referral_bonus_grant:") &&
+      key.endsWith(`:${userId}`)) ||
+    key.startsWith(`free_agent_limit:${userId}:`) ||
+    key.startsWith(`free_monthly_cost:${userId}:`) ||
+    key === `free_run_lock:${userId}` ||
+    (key.startsWith("team:debt_applied:") && key.endsWith(`:${userId}`))
+  );
 };
 
 // =============================================================================
@@ -637,25 +684,16 @@ export const deleteUserRateLimitKeys = async (
   const redis = createRedisClient();
   if (!redis) return 0;
 
-  const patterns = [
-    `usage:monthly:${userId}:*`,
-    `upgrade:carryover:${userId}`,
-    `free_limit:${userId}:*`,
-    `free_referral_bonus:${userId}`,
-    `free_referral_bonus_grant:*:${userId}`,
-    `free_agent_limit:${userId}:*`,
-    `free_monthly_cost:${userId}:*`,
-    `free_run_lock:${userId}`,
-    `team:debt_applied:*:${userId}`,
-  ];
-
   try {
-    const keyBatches = await Promise.all(
-      patterns.map((pattern) => redis.keys(pattern)),
+    const keys = Array.from(
+      new Set(
+        (await scanRedisKeys(redis, `*${userId}*`)).filter((key) =>
+          isUserRateLimitKey(key, userId),
+        ),
+      ),
     );
-    const keys = Array.from(new Set(keyBatches.flat()));
     if (keys.length === 0) return 0;
-    await Promise.all(keys.map((key) => redis.del(key)));
+    await deleteRedisKeys(redis, keys);
     return keys.length;
   } catch (error) {
     console.error(

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -17,6 +17,9 @@ import {
   getLimitPressureContext,
   type LimitCapReason,
 } from "@/lib/limit-pressure";
+import { isUserRateLimitKey } from "./key-cleanup";
+
+export { isUserRateLimitKey } from "./key-cleanup";
 
 // =============================================================================
 // Configuration
@@ -91,21 +94,6 @@ const deleteRedisKeys = async (
   for (let index = 0; index < keys.length; index += REDIS_DELETE_BATCH_SIZE) {
     await redis.del(...keys.slice(index, index + REDIS_DELETE_BATCH_SIZE));
   }
-};
-
-export const isUserRateLimitKey = (key: string, userId: string): boolean => {
-  return (
-    key.startsWith(`usage:monthly:${userId}:`) ||
-    key === `upgrade:carryover:${userId}` ||
-    key.startsWith(`free_limit:${userId}:`) ||
-    key === `free_referral_bonus:${userId}` ||
-    (key.startsWith("free_referral_bonus_grant:") &&
-      key.endsWith(`:${userId}`)) ||
-    key.startsWith(`free_agent_limit:${userId}:`) ||
-    key.startsWith(`free_monthly_cost:${userId}:`) ||
-    key === `free_run_lock:${userId}` ||
-    (key.startsWith("team:debt_applied:") && key.endsWith(`:${userId}`))
-  );
 };
 
 // =============================================================================

--- a/scripts/reset-rate-limit.ts
+++ b/scripts/reset-rate-limit.ts
@@ -26,6 +26,7 @@ import { config } from "dotenv";
 import { resolve } from "path";
 import { Redis } from "@upstash/redis";
 import { WorkOS } from "@workos-inc/node";
+import { isUserRateLimitKey } from "../lib/rate-limit/key-cleanup";
 import { getTestUsersRecord } from "./test-users-config";
 
 // Load .env.e2e first so TEST_* can override, then .env.local
@@ -110,9 +111,11 @@ async function resetRateLimitForUser(
   console.log(`\n🔄 Resetting all rate limits for ${label}...\n`);
 
   try {
-    // Incrementally scan keys for this user; Upstash disables KEYS on large DBs.
+    // Scan broadly for the user ID, then delete only known rate-limit keys.
     const pattern = `*${userId}*`;
-    const allKeys = await scanRedisKeys(redis, pattern);
+    const allKeys = (await scanRedisKeys(redis, pattern)).filter((key) =>
+      isUserRateLimitKey(key, userId),
+    );
 
     if (!allKeys || allKeys.length === 0) {
       console.log(`ℹ️  No rate limit keys found for ${userEmail}`);

--- a/scripts/reset-rate-limit.ts
+++ b/scripts/reset-rate-limit.ts
@@ -34,10 +34,27 @@ config({ path: resolve(process.cwd(), ".env.local") });
 
 const REDIS_URL = process.env.UPSTASH_REDIS_REST_URL;
 const REDIS_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
+const REDIS_SCAN_COUNT = 500;
 
 type TestUserTier = "free" | "pro" | "ultra";
 
 const TEST_USERS = getTestUsersRecord();
+
+async function scanRedisKeys(redis: Redis, pattern: string): Promise<string[]> {
+  let cursor = "0";
+  const keys: string[] = [];
+
+  do {
+    const [nextCursor, batch] = await redis.scan(cursor, {
+      match: pattern,
+      count: REDIS_SCAN_COUNT,
+    });
+    keys.push(...batch);
+    cursor = nextCursor;
+  } while (cursor !== "0");
+
+  return keys;
+}
 
 async function getUserId(email: string): Promise<string | null> {
   const workos = new WorkOS(process.env.WORKOS_API_KEY, {
@@ -93,9 +110,9 @@ async function resetRateLimitForUser(
   console.log(`\n🔄 Resetting all rate limits for ${label}...\n`);
 
   try {
-    // Get all keys for this user using pattern matching
+    // Incrementally scan keys for this user; Upstash disables KEYS on large DBs.
     const pattern = `*${userId}*`;
-    const allKeys = await redis.keys(pattern);
+    const allKeys = await scanRedisKeys(redis, pattern);
 
     if (!allKeys || allKeys.length === 0) {
       console.log(`ℹ️  No rate limit keys found for ${userEmail}`);


### PR DESCRIPTION
## Summary

- Replaces Redis `KEYS` usage in account deletion rate-limit cleanup with cursor-based `SCAN`.
- Filters scanned results back to the known user rate-limit namespaces before deleting anything.
- Deletes matching Redis keys in small batches and updates the local reset utility to use `SCAN` too.
- Adds unit coverage for the namespace filter so unrelated keys containing the same user id are not deleted.

## Root Cause

Upstash disables the `KEYS` command when the database keyspace grows too large. The account deletion cleanup path called `redis.keys(...)` for wildcard rate-limit patterns, so once the Redis database crossed that threshold, cleanup started logging `ERR KEYS command is disabled ... please use SCAN`.

## Impact

Account deletion cleanup remains best-effort, but it can now work against large Upstash databases instead of failing immediately. This should stop the new cleanup errors and avoid leaving rate-limit keys around until TTL expiry.

## Validation

- `pnpm test -- --runTestsByPath lib/rate-limit/__tests__/token-bucket.test.ts --runInBand`
- `pnpm typecheck`
- Pre-commit hook: `tsc --noEmit`
- Pre-commit hook: full `jest` suite, 130 suites / 1447 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for rate-limit key validation and identification.

* **Chores**
  * Improved rate-limit cleanup: more reliable key discovery, filtering, deduplication, and batched deletions for safer, more efficient cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->