### PR TITLE
[codex] Prevent historical file view serialization IO

### DIFF
--- a/lib/ai/tools/__tests__/prompt-serialization.test.ts
+++ b/lib/ai/tools/__tests__/prompt-serialization.test.ts
@@ -1,0 +1,110 @@
+import { convertToModelMessages, type ToolSet, type UIMessage } from "ai";
+import { createPromptSerializationTools } from "../prompt-serialization";
+
+describe("createPromptSerializationTools", () => {
+  it("serializes historical file view outputs without calling the live file tool", async () => {
+    const liveFileToModelOutput = jest.fn(() => {
+      throw new Error("live file serializer should not run for history");
+    });
+    const tools = createPromptSerializationTools({
+      file: { toModelOutput: liveFileToModelOutput },
+    } as unknown as ToolSet);
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-file",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { action: "view", path: "/tmp/private.png" },
+            output: {
+              action: "view",
+              content: "Viewing image file: private.png (image/png, 68 bytes).",
+              path: "/tmp/private.png",
+              filename: "private.png",
+              mediaType: "image/png",
+              sizeBytes: 68,
+              kind: "image",
+            },
+          },
+        ],
+      },
+    ] as UIMessage[];
+
+    const result = await convertToModelMessages(messages, { tools });
+
+    expect(liveFileToModelOutput).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "file",
+            input: { action: "view", path: "/tmp/private.png" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "file",
+            output: {
+              type: "text",
+              value: "Viewing image file: private.png (image/png, 68 bytes).",
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("preserves non-file tool serializers for provider-compatible history", async () => {
+    const openUrlToModelOutput = jest.fn(({ output }) => ({
+      type: "text" as const,
+      value: `serialized:${String(output)}`,
+    }));
+    const tools = createPromptSerializationTools({
+      open_url: { toModelOutput: openUrlToModelOutput },
+    } as unknown as ToolSet);
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-open_url",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { url: "https://example.com" },
+            output: "tool result",
+          },
+        ],
+      },
+    ] as UIMessage[];
+
+    const result = await convertToModelMessages(messages, { tools });
+
+    expect(openUrlToModelOutput).toHaveBeenCalledWith({
+      toolCallId: "call-1",
+      input: { url: "https://example.com" },
+      output: "tool result",
+    });
+    expect(result[1]).toMatchObject({
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          output: { type: "text", value: "serialized:tool result" },
+        },
+      ],
+    });
+  });
+});

--- a/lib/ai/tools/prompt-serialization.ts
+++ b/lib/ai/tools/prompt-serialization.ts
@@ -1,0 +1,66 @@
+import type { ToolSet } from "ai";
+
+type ToolModelOutputArgs = {
+  toolCallId?: string;
+  input?: unknown;
+  output: unknown;
+};
+
+type ToolWithModelOutput = {
+  toModelOutput?: (args: ToolModelOutputArgs) => unknown | Promise<unknown>;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const createTextOutput = (value: string) => ({
+  type: "text" as const,
+  value,
+});
+
+const createPureFileModelOutput = ({ output }: ToolModelOutputArgs) => {
+  if (typeof output === "string") {
+    return createTextOutput(output);
+  }
+
+  if (isRecord(output)) {
+    if ("error" in output) {
+      return createTextOutput(`Error: ${String(output.error)}`);
+    }
+
+    if (output.action === "view") {
+      return createTextOutput(
+        typeof output.content === "string"
+          ? output.content
+          : JSON.stringify(output),
+      );
+    }
+
+    if (typeof output.content === "string") {
+      return createTextOutput(output.content);
+    }
+  }
+
+  return createTextOutput(JSON.stringify(output));
+};
+
+/**
+ * Tool results in persisted UI messages are untrusted historical data.
+ * Keep conversion formatting, but make file-view serialization text-only so
+ * prompt rebuilding cannot re-open attacker-controlled paths.
+ */
+export const createPromptSerializationTools = (tools: ToolSet): ToolSet => {
+  const fileTool = tools.file as (ToolWithModelOutput & object) | undefined;
+
+  if (!fileTool || typeof fileTool !== "object") {
+    return tools;
+  }
+
+  return {
+    ...tools,
+    file: {
+      ...fileTool,
+      toModelOutput: createPureFileModelOutput,
+    },
+  } as unknown as ToolSet;
+};

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -60,6 +60,7 @@ import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { getMaxTokensForSubscription } from "@/lib/token-utils";
 import { SUMMARIZATION_THRESHOLD_PERCENTAGE } from "@/lib/chat/summarization/constants";
 import { getMaxStepsForUser } from "@/lib/chat/chat-processor";
+import { createPromptSerializationTools } from "@/lib/ai/tools/prompt-serialization";
 import {
   extractOpenRouterMetadata,
   fetchOpenRouterGenerationMetadata,
@@ -434,8 +435,11 @@ export async function createAgentStream(
     return latestProviderRequestDiagnostics;
   };
   const initialProviderOptions = getStepProviderOptions();
+  const promptSerializationTools = createPromptSerializationTools(ctx.tools);
   const initialModelMessages = prepareProviderMessages(
-    await convertToModelMessages(state.finalMessages, { tools: ctx.tools }),
+    await convertToModelMessages(state.finalMessages, {
+      tools: promptSerializationTools,
+    }),
   );
   recordProviderRequestDiagnostics({
     stepIndex: 0,
@@ -510,7 +514,7 @@ export async function createAgentStream(
             const providerOptions = getStepProviderOptions();
             const preparedMessages = prepareProviderMessages(
               await convertToModelMessages(result.summarizedMessages, {
-                tools: ctx.tools,
+                tools: createPromptSerializationTools(ctx.tools),
               }),
             );
             recordProviderRequestDiagnostics({

--- a/lib/chat/summarization/helpers.ts
+++ b/lib/chat/summarization/helpers.ts
@@ -15,6 +15,7 @@ import {
 import { saveChatSummary } from "@/lib/db/actions";
 import { SubscriptionTier, ChatMode, Todo } from "@/types";
 import type { Id } from "@/convex/_generated/dataModel";
+import { createPromptSerializationTools } from "@/lib/ai/tools/prompt-serialization";
 
 import {
   MESSAGES_TO_KEEP_UNSUMMARIZED,
@@ -150,7 +151,9 @@ export const generateSummaryText = async (
     providerOptions: providerOptions as any,
     messages: [
       ...(modelMessages ??
-        (await convertToModelMessages(messagesToSummarize, { tools }))),
+        (await convertToModelMessages(messagesToSummarize, {
+          tools: tools ? createPromptSerializationTools(tools) : undefined,
+        }))),
       {
         role: "user" as const,
         content: `${summarizationPrompt}${incrementalNote}\n\nSummarize the above conversation using the structured format. Output ONLY the summary — do not continue the conversation or role-play as the assistant.`,


### PR DESCRIPTION
## Summary

- Add a prompt-serialization-safe tool registry that keeps historical tool result formatting while making `file.view` outputs text-only.
- Use the safe registry when converting persisted UI messages for the agent stream and summarization.
- Add a regression test proving forged historical `tool-file` view output does not call the live file serializer, while non-file tool serializers still run for provider-compatible history.

## Root Cause

`convertToModelMessages(..., { tools })` invokes each tool's `toModelOutput` hook for historical `tool-*` UI parts. The live `file.toModelOutput` hook re-opens `output.path` to attach image data for current `view` results, so forged or shared historical `tool-file` output could make prompt serialization perform sandbox/local filesystem I/O.

## Validation

- `pnpm test -- lib/ai/tools/__tests__/file.test.ts lib/ai/tools/__tests__/prompt-serialization.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- Commit hook: full `pnpm typecheck` and full `pnpm test` passed: 131 suites / 1447 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool output serialization consistency across all message conversion workflows
  * Enhanced file tool handling for better compatibility with AI model message formatting

* **Tests**
  * Added comprehensive validation tests for tool serialization behavior and message history transformation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->