### PR TITLE
[codex] Gate referral program to paid users

### DIFF
--- a/app/api/referrals/__tests__/route.test.ts
+++ b/app/api/referrals/__tests__/route.test.ts
@@ -57,35 +57,22 @@ describe("GET /api/referrals", () => {
     );
   });
 
-  it("allows free users to create referral URLs", async () => {
+  it("blocks free users from creating referral URLs", async () => {
     mockGetUserIDAndPro.mockResolvedValueOnce({
       userId: "user_free",
       subscription: "free",
       organizationId: undefined,
-    } as never);
-    mockConvexMutation.mockResolvedValueOnce({
-      code: "UVVQDMV",
-      active: true,
-      referrerSubscriptionTier: "free",
-      attributedSignups: 0,
-      paidConversions: 0,
-      awardedDollars: 0,
     } as never);
     const { GET } = await import("../route");
 
     const response = await GET({} as any);
     const body = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(body.referralUrl).toBe("https://hackerai.co/invite/UVVQDMV");
-    expect(body.referrerSubscriptionTier).toBe("free");
-    expect(mockConvexMutation).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        userId: "user_free",
-        subscriptionTier: "free",
-      }),
+    expect(response.status).toBe(403);
+    expect(body.error).toBe(
+      "Referral links are currently available to paid customers.",
     );
+    expect(mockConvexMutation).not.toHaveBeenCalled();
   });
 
   it("returns the referrer tier reported by Convex", async () => {

--- a/app/api/referrals/route.ts
+++ b/app/api/referrals/route.ts
@@ -5,6 +5,7 @@ import { api } from "@/convex/_generated/api";
 import { getUserIDAndPro } from "@/lib/auth/get-user-id";
 import {
   getReferralRewardConfig,
+  isReferralReferrerTierEligible,
   isValidReferralCode,
 } from "@/lib/referrals/config";
 
@@ -30,6 +31,12 @@ export async function GET(req: NextRequest) {
   }
 
   const { userId, subscription, organizationId } = await getUserIDAndPro(req);
+  if (!isReferralReferrerTierEligible(subscription)) {
+    return NextResponse.json(
+      { error: "Referral links are currently available to paid customers." },
+      { status: 403 },
+    );
+  }
 
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
   if (!baseUrl) {

--- a/app/components/ReferralRewardDialog.tsx
+++ b/app/components/ReferralRewardDialog.tsx
@@ -115,16 +115,8 @@ export function ReferralRewardDialog({
   };
 
   const referrerReward = program?.referrerRewardDollars ?? 0;
-  const isFreeReferrer = program?.referrerSubscriptionTier === "free";
-  const referrerRewardTitle = isFreeReferrer
-    ? `Earn $${referrerReward} in usage credits`
-    : `Earn $${referrerReward} in extra usage credits`;
-  const referrerRewardCopy = isFreeReferrer ? (
-    <>
-      You get <b>${referrerReward} in usage credits</b> when they upgrade. Use
-      them after you upgrade to a paid plan.
-    </>
-  ) : (
+  const referrerRewardTitle = `Earn $${referrerReward} in extra usage credits`;
+  const referrerRewardCopy = (
     <>
       You get <b>${referrerReward} in extra usage credits</b> when they upgrade
     </>
@@ -164,9 +156,8 @@ export function ReferralRewardDialog({
               <ul className="flex list-disc flex-col gap-2 px-5">
                 <li>
                   <span className="text-muted-foreground text-sm">
-                    This promotion is available to new HackerAI users who sign
-                    up through your link only — we want to share HackerAI with
-                    fresh eyes and grow our community.
+                    Referral links are available to paid HackerAI customers and
+                    apply to new users who sign up through your link only.
                   </span>
                 </li>
                 <li>
@@ -174,12 +165,6 @@ export function ReferralRewardDialog({
                     Rewards are earned once your invitee creates a new account
                     and subscribes to any paid HackerAI plan. No credit is
                     granted for inactive or incomplete referrals.
-                  </span>
-                </li>
-                <li>
-                  <span className="text-muted-foreground text-sm">
-                    If you are on the Free plan, earned usage credits are saved
-                    to your account and become usable after you upgrade.
                   </span>
                 </li>
                 <li>

--- a/app/components/SidebarUserNav.tsx
+++ b/app/components/SidebarUserNav.tsx
@@ -384,7 +384,7 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
       />
 
       {/* Referral card */}
-      {!isCheckingProPlan && (
+      {!isCheckingProPlan && isPaidUser && (
         <ReferralSidebarCard
           isCollapsed={isCollapsed}
           onOpen={() => setReferralDialogOpen(true)}
@@ -496,14 +496,16 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
             </DropdownMenuItem>
           )}
 
-          <DropdownMenuItem
-            data-testid="referral-menu-item"
-            onSelect={() => setReferralDialogOpen(true)}
-            className="py-1.5"
-          >
-            <Gift className="mr-2 h-4 w-4 text-foreground" />
-            <span>Refer a friend</span>
-          </DropdownMenuItem>
+          {isPaidUser && (
+            <DropdownMenuItem
+              data-testid="referral-menu-item"
+              onSelect={() => setReferralDialogOpen(true)}
+              className="py-1.5"
+            >
+              <Gift className="mr-2 h-4 w-4 text-foreground" />
+              <span>Refer a friend</span>
+            </DropdownMenuItem>
+          )}
 
           {isPaidUser && (
             <div>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -54,25 +54,36 @@ const getSafeDisplayName = (user: {
   return parts.length > 0 ? parts.join(" ") : undefined;
 };
 
-const getReferralDisplayName = async (
+const getReferralInviteContext = async (
   referralCode: string,
-): Promise<string | undefined> => {
+): Promise<{ active: boolean; referrerName?: string }> => {
   try {
     const invite = await convex.query(api.referrals.getReferralInvite, {
       serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
       referralCode,
     });
 
-    if (!invite?.active) return undefined;
+    if (!invite?.active) return { active: false };
 
-    const referrer = await workos.userManagement.getUser(invite.referrerUserId);
-    return getSafeDisplayName(referrer);
+    try {
+      const referrer = await workos.userManagement.getUser(
+        invite.referrerUserId,
+      );
+      return { active: true, referrerName: getSafeDisplayName(referrer) };
+    } catch (error) {
+      console.warn("[signup] Failed to resolve referral referrer", {
+        referralCode,
+        referrerUserId: invite.referrerUserId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { active: true };
+    }
   } catch (error) {
     console.warn("[signup] Failed to resolve referral invite", {
       referralCode,
       error: error instanceof Error ? error.message : String(error),
     });
-    return undefined;
+    return { active: false };
   }
 };
 
@@ -85,6 +96,17 @@ export default async function SignupPage({ searchParams }: SignupPageProps) {
     redirect(buildAuthHref(params));
   }
 
+  const invite = await getReferralInviteContext(referralCode);
+  if (!invite.active) {
+    redirect(
+      buildAuthHref({
+        ...params,
+        referral_code: undefined,
+        ref: undefined,
+      }),
+    );
+  }
+
   const authHref = buildAuthHref({
     ...params,
     referral_code: referralCode,
@@ -94,9 +116,8 @@ export default async function SignupPage({ searchParams }: SignupPageProps) {
     bonusUnits > 0
       ? `Sign up and get ${bonusUnits} extra free request${bonusUnits === 1 ? "" : "s"}`
       : "Sign up through a referral link";
-  const referrerName = await getReferralDisplayName(referralCode);
-  const referralLine = referrerName
-    ? `You're signing up through ${referrerName}'s referral link. Create your account to redeem your starter requests.`
+  const referralLine = invite.referrerName
+    ? `You're signing up through ${invite.referrerName}'s referral link. Create your account to redeem your starter requests.`
     : "You're signing up through a custom referral link. Create your account to redeem your starter requests.";
 
   return (

--- a/convex/__tests__/referralsNotifications.test.ts
+++ b/convex/__tests__/referralsNotifications.test.ts
@@ -267,7 +267,7 @@ describe("referral reward notifications", () => {
     expect(queryCalls).not.toContain("user_customization");
   });
 
-  it("awards personal credits to free referrers after referred users convert", async () => {
+  it("withholds conversion rewards from free referrer codes", async () => {
     const { awardConversionReward } = await import("../referrals");
     const { ctx, tables } = makeMockCtx({
       referral_attributions: [
@@ -308,24 +308,25 @@ describe("referral reward notifications", () => {
       tier: "pro",
     });
 
-    expect(result.status).toBe("awarded");
-    expect(tables.extra_usage).toMatchObject([
-      {
-        user_id: USER_ID,
-        balance_points: 100_000,
-        auto_reload_enabled: false,
-      },
+    expect(result.status).toBe("withheld");
+    expect(result.reason).toBe("ineligible_referrer_tier");
+    expect(tables.referral_attributions[0]).toMatchObject({
+      conversion_reward_status: "withheld",
+      withheld_reason: "ineligible_referrer_tier",
+    });
+    expect(tables.referral_rewards).toMatchObject([
+      expect.objectContaining({
+        reward_type: "referrer_conversion",
+        status: "withheld",
+        reason: "ineligible_referrer_tier",
+      }),
     ]);
-    expect(tables.user_customization).toMatchObject([
-      {
-        user_id: USER_ID,
-        extra_usage_enabled: true,
-      },
-    ]);
+    expect(tables.extra_usage).toEqual([]);
+    expect(tables.user_customization).toEqual([]);
     expect(tables.team_extra_usage).toEqual([]);
   });
 
-  it("activates earned personal credits when an originally free referrer upgrades before conversion", async () => {
+  it("awards paid credits when an originally free referrer upgrades before conversion", async () => {
     const { awardConversionReward } = await import("../referrals");
     const { ctx, tables } = makeMockCtx({
       referral_attributions: [
@@ -380,9 +381,8 @@ describe("referral reward notifications", () => {
       {
         user_id: USER_ID,
         balance_points: 100_000,
-        auto_reload_enabled: false,
       },
     ]);
-    expect(tables.user_customization[0].extra_usage_enabled).toBe(true);
+    expect(tables.user_customization[0].extra_usage_enabled).toBe(false);
   });
 });

--- a/convex/referrals.ts
+++ b/convex/referrals.ts
@@ -7,6 +7,7 @@ import {
 import { ConvexError, v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 import { convexLogger } from "./lib/logger";
+import type { Id } from "./_generated/dataModel";
 
 const POINTS_PER_DOLLAR = 10_000;
 
@@ -37,13 +38,35 @@ const QUALIFYING_TIERS = new Set<PaidTier>([
 ]);
 
 const SUBSCRIPTION_ENDED_REASON = "subscription_ended";
+const INELIGIBLE_REFERRER_REASON = "ineligible_referrer_tier";
 
 const isReferralCodeUsable = (referralCode: {
+  status: "active" | "deactivated";
+  referrer_subscription_tier?: ReferrerTier;
+}) =>
+  referralCode.status === "active" &&
+  referralCode.referrer_subscription_tier != null &&
+  QUALIFYING_TIERS.has(referralCode.referrer_subscription_tier as PaidTier);
+
+const isReferralCodeReactivateable = (referralCode: {
   status: "active" | "deactivated";
   deactivated_reason?: string;
 }) =>
   referralCode.status === "active" ||
-  referralCode.deactivated_reason === SUBSCRIPTION_ENDED_REASON;
+  referralCode.deactivated_reason === SUBSCRIPTION_ENDED_REASON ||
+  referralCode.deactivated_reason === INELIGIBLE_REFERRER_REASON;
+
+const referralCodeBlockedReason = (
+  referralCode: {
+    status: "active" | "deactivated";
+    referrer_subscription_tier?: ReferrerTier;
+  } | null,
+) => {
+  if (!referralCode || referralCode.status !== "active") {
+    return "invalid_or_inactive_referral_code";
+  }
+  return INELIGIBLE_REFERRER_REASON;
+};
 
 const rewardTierForReferralCode = (
   referralCode: {
@@ -53,10 +76,23 @@ const rewardTierForReferralCode = (
   },
   fallback?: ReferrerTier,
 ): ReferrerTier | undefined =>
-  referralCode.status === "deactivated" &&
-  referralCode.deactivated_reason === SUBSCRIPTION_ENDED_REASON
-    ? "free"
-    : (referralCode.referrer_subscription_tier ?? fallback);
+  referralCode.referrer_subscription_tier ?? fallback;
+
+const deactivateReferralCode = async (
+  ctx: MutationCtx,
+  referralCodeId: Id<"referral_codes">,
+  now: number,
+  reason: string,
+) => {
+  await ctx.db.patch(referralCodeId, {
+    status: "deactivated",
+    deactivated_at: now,
+    deactivated_reason: reason,
+    referrer_subscription_tier: "free",
+    referrer_organization_id: undefined,
+    updated_at: now,
+  });
+};
 
 const dollarsToPoints = (dollars: number): number =>
   Math.round(dollars * POINTS_PER_DOLLAR);
@@ -308,6 +344,9 @@ export const getOrCreateReferralCode = mutation({
     validateServiceKey(args.serviceKey);
 
     const now = Date.now();
+    const isEligibleReferrer = QUALIFYING_TIERS.has(
+      args.subscriptionTier as PaidTier,
+    );
     const organizationId =
       args.subscriptionTier === "team" ? args.organizationId : undefined;
     const existingForUser = await ctx.db
@@ -316,12 +355,23 @@ export const getOrCreateReferralCode = mutation({
       .first();
 
     if (existingForUser) {
-      const canBeActive = isReferralCodeUsable(existingForUser);
+      const canBeActive =
+        isEligibleReferrer && isReferralCodeReactivateable(existingForUser);
 
       await ctx.db.patch(existingForUser._id, {
         status: canBeActive ? "active" : existingForUser.status,
         referrer_subscription_tier: args.subscriptionTier,
         referrer_organization_id: organizationId,
+        ...(canBeActive && {
+          deactivated_at: undefined,
+          deactivated_reason: undefined,
+        }),
+        ...(!isEligibleReferrer && {
+          status: "deactivated" as const,
+          deactivated_at: now,
+          deactivated_reason: INELIGIBLE_REFERRER_REASON,
+          referrer_organization_id: undefined,
+        }),
         updated_at: now,
       });
       return {
@@ -330,6 +380,13 @@ export const getOrCreateReferralCode = mutation({
         referrerSubscriptionTier: args.subscriptionTier,
         ...(await getReferralStats(ctx, args.userId)),
       };
+    }
+
+    if (!isEligibleReferrer) {
+      throw new ConvexError({
+        code: "REFERRAL_REFERRER_INELIGIBLE",
+        message: "Referral links are only available to paid customers.",
+      });
     }
 
     const existingForCode = await ctx.db
@@ -488,12 +545,15 @@ export const setReferralCodesPaidEligibility = mutation({
       if (!referralCode) continue;
 
       if (args.active) {
-        const canReactivate = isReferralCodeUsable(referralCode);
+        const subscriptionTier =
+          args.subscriptionTier ?? referralCode.referrer_subscription_tier;
+        const canReactivate =
+          subscriptionTier != null &&
+          QUALIFYING_TIERS.has(subscriptionTier as PaidTier) &&
+          isReferralCodeReactivateable(referralCode);
 
         if (!canReactivate) continue;
 
-        const subscriptionTier =
-          args.subscriptionTier ?? referralCode.referrer_subscription_tier;
         const organizationId =
           subscriptionTier === "team"
             ? (args.organizationId ?? referralCode.referrer_organization_id)
@@ -503,6 +563,8 @@ export const setReferralCodesPaidEligibility = mutation({
           status: "active",
           referrer_subscription_tier: subscriptionTier,
           referrer_organization_id: organizationId,
+          deactivated_at: undefined,
+          deactivated_reason: undefined,
           updated_at: now,
         });
         updated += 1;
@@ -511,11 +573,12 @@ export const setReferralCodesPaidEligibility = mutation({
 
       if (referralCode.status !== "active") continue;
 
-      await ctx.db.patch(referralCode._id, {
-        referrer_subscription_tier: "free",
-        referrer_organization_id: undefined,
-        updated_at: now,
-      });
+      await deactivateReferralCode(
+        ctx,
+        referralCode._id,
+        now,
+        SUBSCRIPTION_ENDED_REASON,
+      );
       updated += 1;
     }
 
@@ -592,18 +655,22 @@ export const attributeReferredSignup = mutation({
       .first();
 
     if (!referralCode || !isReferralCodeUsable(referralCode)) {
+      const reason = referralCodeBlockedReason(referralCode);
       await insertRewardLog(ctx, {
-        idempotencyKey: `referral_signup_blocked:${args.referredUserId}:${args.referralCode}`,
+        idempotencyKey: `referral_signup_blocked:${args.referredUserId}:${args.referralCode}:${reason}`,
         rewardType: "referred_signup",
         status: "withheld",
         amountDollars: 0,
         referredUserId: args.referredUserId,
         referralCode: args.referralCode,
-        reason: "invalid_or_inactive_referral_code",
+        referrerUserId: referralCode?.user_id,
+        reason,
       });
       return {
         status: "not_found" as const,
-        reason: "invalid_or_inactive_referral_code",
+        reason,
+        referrerUserId: referralCode?.user_id,
+        referrerSubscriptionTier: referralCode?.referrer_subscription_tier,
         starterBonusAwarded: false,
         starterBonusEligible: false,
         starterBonusUnits: 0,
@@ -611,17 +678,6 @@ export const attributeReferredSignup = mutation({
     }
 
     const referrerSubscriptionTier = rewardTierForReferralCode(referralCode);
-    if (
-      referralCode.status === "deactivated" &&
-      referralCode.deactivated_reason === SUBSCRIPTION_ENDED_REASON
-    ) {
-      await ctx.db.patch(referralCode._id, {
-        status: "active",
-        referrer_subscription_tier: "free",
-        referrer_organization_id: undefined,
-        updated_at: now,
-      });
-    }
 
     if (referralCode.user_id === args.referredUserId) {
       await insertRewardLog(ctx, {
@@ -973,13 +1029,14 @@ export const awardConversionReward = mutation({
       .first();
 
     if (!referralCode || !isReferralCodeUsable(referralCode)) {
+      const reason = referralCodeBlockedReason(referralCode);
       await ctx.db.patch(attribution._id, {
         conversion_reward_status: "withheld",
-        withheld_reason: "inactive_referral_code",
+        withheld_reason: reason,
         updated_at: Date.now(),
       });
       await insertRewardLog(ctx, {
-        idempotencyKey: `referral_conversion_withheld:${attribution._id}:inactive_referral_code`,
+        idempotencyKey: `referral_conversion_withheld:${attribution._id}:${reason}`,
         rewardType: "referrer_conversion",
         status: "withheld",
         amountDollars: 0,
@@ -990,11 +1047,11 @@ export const awardConversionReward = mutation({
         stripeCustomerId: args.stripeCustomerId,
         stripeSubscriptionId: args.stripeSubscriptionId,
         stripeInvoiceId: args.stripeInvoiceId,
-        reason: "inactive_referral_code",
+        reason,
       });
       return {
         status: "withheld" as const,
-        reason: "inactive_referral_code",
+        reason,
         referrerUserId: attribution.referrer_user_id,
         referredUserId: attribution.referred_user_id,
         referralCode: attribution.referral_code,
@@ -1017,18 +1074,6 @@ export const awardConversionReward = mutation({
           attribution.referrer_organization_id)
         : undefined;
 
-    if (
-      referralCode.status === "deactivated" &&
-      referralCode.deactivated_reason === SUBSCRIPTION_ENDED_REASON
-    ) {
-      await ctx.db.patch(referralCode._id, {
-        status: "active",
-        referrer_subscription_tier: "free",
-        referrer_organization_id: undefined,
-        updated_at: now,
-      });
-    }
-
     const reward = await grantReward(ctx, {
       idempotencyKey: `referral_conversion:${attribution._id}`,
       rewardType: "referrer_conversion",
@@ -1039,9 +1084,7 @@ export const awardConversionReward = mutation({
       referralCode: attribution.referral_code,
       subscriptionTier: referrerSubscriptionTier,
       organizationId: referrerOrganizationId,
-      activatePersonalCreditsForPaidUse:
-        attribution.referrer_subscription_tier === "free" ||
-        referrerSubscriptionTier === "free",
+      activatePersonalCreditsForPaidUse: false,
       stripeCheckoutSessionId: args.stripeCheckoutSessionId,
       stripeCustomerId: args.stripeCustomerId,
       stripeSubscriptionId: args.stripeSubscriptionId,

--- a/lib/referrals/config.ts
+++ b/lib/referrals/config.ts
@@ -11,6 +11,20 @@ export type ReferralRewardConfig = {
   cookieMaxAgeSeconds: number;
 };
 
+export type ReferralReferrerTier =
+  | "free"
+  | "pro"
+  | "pro-plus"
+  | "ultra"
+  | "team";
+
+const ELIGIBLE_REFERRER_TIERS = new Set<ReferralReferrerTier>([
+  "pro",
+  "pro-plus",
+  "ultra",
+  "team",
+]);
+
 const parsePositiveNumber = (
   raw: string | undefined,
   fallback: number,
@@ -46,4 +60,10 @@ export function getReferralRewardConfig(): ReferralRewardConfig {
 
 export function isValidReferralCode(code: string | null | undefined): boolean {
   return typeof code === "string" && REFERRAL_CODE_PATTERN.test(code);
+}
+
+export function isReferralReferrerTierEligible(
+  tier: string | null | undefined,
+): tier is Exclude<ReferralReferrerTier, "free"> {
+  return ELIGIBLE_REFERRER_TIERS.has(tier as ReferralReferrerTier);
 }


### PR DESCRIPTION
## Summary
- Gate referral link creation and sidebar referral entry points to paid users only.
- Treat active free-referrer codes as ineligible during invite lookup, signup attribution, and conversion reward payout.
- Redirect inactive/ineligible referral signup links back to normal signup instead of showing referral bonus copy.
- Update referral tests for the paid-only policy and ineligible free-referrer reward withholding.

## Why
PostHog showed the first week of referrals produced very little qualified paid growth: 350 attributed referred signups, 6 unique paid referral conversions, and 429 withheld reward attempts driven mostly by self-referrals and existing-user attempts. This keeps the analytics trail and paid-user referral channel, but removes the broad free-user incentive that was mostly noise and abuse pressure.

## Validation
- `pnpm jest app/api/referrals/__tests__/route.test.ts convex/__tests__/referralsNotifications.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- Commit hook: full `pnpm typecheck` and full `pnpm test` passed: 130 suites / 1,445 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Referral features now restricted to paid-tier customers; free users receive a 403 when attempting referral API access and UI elements are hidden
  * Referral codes auto-deactivate/reactivate based on referrer subscription and show clearer inactive/ineligible messages
  * Conversion rewards withheld for ineligible (free-tier) referrers until eligibility changes

* **New Features**
  * Signup flow cleans up invalid/expired referral links and displays referrer name only for active invites

* **Tests**
  * Updated tests to reflect new eligibility and withholding behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->