### PR TITLE
[codex] Use DeepSeek Pro for Ask Pro text

### DIFF
--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -69,9 +69,10 @@ const AUTO_MODEL_DESCRIPTION =
 const shouldWarnForPaidHighCostModel = (
   subscription: SubscriptionTier,
   model: SelectedModel,
+  mode: ChatMode,
 ): boolean =>
   subscription !== "free" &&
-  (model === "hackerai-pro" || model === "hackerai-max");
+  (model === "hackerai-max" || (model === "hackerai-pro" && isAgentMode(mode)));
 
 const AutoOptionButton = ({
   isSelected,
@@ -375,7 +376,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
     }
 
     if (
-      shouldWarnForPaidHighCostModel(subscription, option.id) &&
+      shouldWarnForPaidHighCostModel(subscription, option.id, mode) &&
       !isHighCostModelUsageNoticeDismissed()
     ) {
       setOpen(false);

--- a/app/components/ModelSelector/CostIndicator.tsx
+++ b/app/components/ModelSelector/CostIndicator.tsx
@@ -8,15 +8,14 @@ import { isAgentMode } from "@/lib/utils/mode-helpers";
 
 type CostTier = "low" | "medium" | "high" | "very-high";
 
-// Cost tier per HackerAI tier id. Standard is mode-aware: in ask it routes
-// through the cheap DeepSeek V4 Flash text path (low), in agent it runs on
-// Kimi K2.6 (medium).
+// Cost tier per HackerAI tier id. Standard and Pro are mode-aware in ask;
+// Agent keeps the higher-cost coding/automation models.
 export function getCostTier(modelId: string, mode?: ChatMode): CostTier {
   switch (modelId) {
     case "hackerai-standard":
       return mode && isAgentMode(mode) ? "medium" : "low";
     case "hackerai-pro":
-      return "high";
+      return mode && isAgentMode(mode) ? "high" : "medium";
     case "hackerai-max":
       return "very-high";
     default:

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -69,9 +69,20 @@ describe("ModelSelector", () => {
     expect(onChange).toHaveBeenCalledWith("auto");
   });
 
-  it("warns before selecting HackerAI Pro on paid plans", () => {
+  it("selects HackerAI Pro in ask mode without the high-cost warning", () => {
     const onChange = jest.fn();
     render(<ModelSelector value="auto" onChange={onChange} mode="ask" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /HackerAI Pro/i }));
+
+    expect(onChange).toHaveBeenCalledWith("hackerai-pro");
+    expect(screen.queryByTestId("high-cost-model-warning")).toBeNull();
+  });
+
+  it("warns before selecting HackerAI Pro in agent mode on paid plans", () => {
+    const onChange = jest.fn();
+    render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
 
     fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
     fireEvent.click(screen.getByRole("button", { name: /HackerAI Pro/i }));
@@ -105,7 +116,7 @@ describe("ModelSelector", () => {
   it("uses team-specific warning copy for team users", () => {
     mockSubscription = "team";
     const onChange = jest.fn();
-    render(<ModelSelector value="auto" onChange={onChange} mode="ask" />);
+    render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
 
     fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
     fireEvent.click(screen.getByRole("button", { name: /HackerAI Pro/i }));

--- a/app/components/ModelSelector/__tests__/options-drift.test.ts
+++ b/app/components/ModelSelector/__tests__/options-drift.test.ts
@@ -40,13 +40,16 @@ describe("ModelSelector tier ↔ provider drift", () => {
     );
   });
 
-  it("HackerAI Pro and Max resolve to the same provider in both modes", () => {
+  it("HackerAI Pro resolves to DeepSeek in ask mode and Sonnet in agent mode", () => {
     expect(resolveTierToProviderKey("hackerai-pro", "ask")).toBe(
-      "model-sonnet-4.6",
+      "model-deepseek-v4-pro",
     );
     expect(resolveTierToProviderKey("hackerai-pro", "agent")).toBe(
       "model-sonnet-4.6",
     );
+  });
+
+  it("HackerAI Max resolves to the same provider in both modes", () => {
     expect(resolveTierToProviderKey("hackerai-max", "ask")).toBe(
       "model-opus-4.6",
     );

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -23,7 +23,8 @@ export const ASK_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-pro",
     label: "HackerAI Pro",
     description: "Superior performance for most assignments",
-    poweredBy: "Claude Sonnet 4.6",
+    poweredBy:
+      "DeepSeek V4 Pro · switches to Claude Sonnet 4.6 for images & PDFs",
   },
   {
     id: "hackerai-max",

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -233,5 +233,6 @@ describe("supportsMultimodalToolResults", () => {
     expect(supportsMultimodalToolResults("model-deepseek-v4-flash")).toBe(
       false,
     );
+    expect(supportsMultimodalToolResults("model-deepseek-v4-pro")).toBe(false);
   });
 });

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -254,6 +254,7 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "model-sonnet-4.6": or("anthropic/claude-sonnet-4-6"),
     "model-gemini-3-flash": or("google/gemini-3-flash-preview"),
     "model-deepseek-v4-flash": or("deepseek/deepseek-v4-flash"),
+    "model-deepseek-v4-pro": or("deepseek/deepseek-v4-pro"),
     "model-opus-4.6": or("anthropic/claude-opus-4.6"),
     "model-kimi-k2.6": or("moonshotai/kimi-k2.6:exacto"),
     "fallback-agent-model": or("google/gemini-3-flash-preview"),
@@ -276,6 +277,7 @@ export const modelCutoffDates: Record<ModelName, string> &
   "model-sonnet-4.6": "May 2025",
   "model-gemini-3-flash": "January 2025",
   "model-deepseek-v4-flash": "May 2025",
+  "model-deepseek-v4-pro": "May 2025",
   "model-opus-4.6": "May 2025",
   "model-kimi-k2.6": "April 2024",
   "fallback-agent-model": "January 2025",
@@ -294,6 +296,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-sonnet-4.6": "Anthropic Claude Sonnet 4.6",
   "model-gemini-3-flash": "Google Gemini 3 Flash",
   "model-deepseek-v4-flash": "DeepSeek V4 Flash",
+  "model-deepseek-v4-pro": "DeepSeek V4 Pro",
   "model-opus-4.6": "Anthropic Claude Opus 4.6",
   "model-kimi-k2.6": "Moonshot Kimi K2.6",
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
@@ -319,7 +322,8 @@ export function isDeepSeekModel(modelName: string): boolean {
   return (
     modelName === "ask-model-free" ||
     modelName === "agent-model-free" ||
-    modelName === "model-deepseek-v4-flash"
+    modelName === "model-deepseek-v4-flash" ||
+    modelName === "model-deepseek-v4-pro"
   );
 }
 
@@ -363,8 +367,8 @@ export function isGeminiModel(modelName: string): boolean {
 /**
  * Map a HackerAI tier id to the underlying provider key for a given mode.
  * Returns `null` for `"auto"` (the caller routes to the auto-router model
- * key instead). The Pro/Max tiers map to the same model in both modes; only
- * Lite differs (Gemini 3 Flash for ask, Kimi K2.6 for agent).
+ * key instead). Standard and Pro are mode-aware; Max maps to Opus in both
+ * modes.
  */
 export function resolveTierToProviderKey(
   tier: SelectedModel,
@@ -375,7 +379,7 @@ export function resolveTierToProviderKey(
     case "hackerai-standard":
       return isAgentMode(mode) ? "model-kimi-k2.6" : "model-gemini-3-flash";
     case "hackerai-pro":
-      return "model-sonnet-4.6";
+      return isAgentMode(mode) ? "model-sonnet-4.6" : "model-deepseek-v4-pro";
     case "hackerai-max":
       return "model-opus-4.6";
   }

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -128,6 +128,19 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
+  it("falls back from explicit DeepSeek Pro ask model to Gemini", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-deepseek-v4-pro",
+      "ask",
+    );
+    expect(opts.openrouter).toMatchObject({
+      models: [GEMINI_SLUG],
+      user: "user-1",
+    });
+  });
+
   it("falls back from Gemini to Grok", () => {
     const opts = buildProviderOptions(false, "user-1", "model-gemini-3-flash");
     expect(opts.openrouter).toMatchObject({

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -469,6 +469,7 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "ask-model-free": ["fallback-ask-model"],
   "agent-model-free": ["fallback-agent-model"],
   "model-deepseek-v4-flash": ["fallback-ask-model"],
+  "model-deepseek-v4-pro": ["fallback-ask-model"],
   "ask-model": ["fallback-grok-4.3"],
   "agent-model": ["fallback-grok-4.3"],
   "model-gemini-3-flash": ["fallback-grok-4.3"],

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -182,16 +182,22 @@ describe("selectModel", () => {
     });
   });
 
-  // Tier override — Pro/Max map to the same provider key in both modes
+  // Tier override — Pro is mode/content-aware; Max maps to Opus in both modes
   describe("tier override for ask mode (paid users)", () => {
-    it("should map HackerAI Pro to Sonnet 4.6 in ask mode", () => {
+    it("should map HackerAI Pro to DeepSeek V4 Pro for text-only ask mode", () => {
       expect(selectModel("ask", "ultra", "hackerai-pro")).toBe(
-        "model-sonnet-4.6",
+        "model-deepseek-v4-pro",
       );
     });
 
-    it("should map HackerAI Pro to Sonnet 4.6 for team users", () => {
+    it("should map HackerAI Pro to DeepSeek V4 Pro for team users", () => {
       expect(selectModel("ask", "team", "hackerai-pro")).toBe(
+        "model-deepseek-v4-pro",
+      );
+    });
+
+    it("should keep HackerAI Pro on Sonnet 4.6 when an image/PDF is attached", () => {
+      expect(selectModel("ask", "pro", "hackerai-pro", true)).toBe(
         "model-sonnet-4.6",
       );
     });

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -34,12 +34,14 @@ export const getMaxStepsForUser = (
 };
 
 /**
- * Selects the appropriate model based on mode and subscription
+ * Selects the appropriate model based on mode and subscription.
  * @param mode - Chat mode (ask or agent)
  * @param hasImageOrPdf - Whether any message has an image or PDF attachment.
  *   Paid ASK on the Standard/auto route normally uses DeepSeek V4 Flash
  *   (text-only, much cheaper); when an image or PDF is present we promote to
- *   Gemini 3 Flash so vision/document parts are actually understood.
+ *   Gemini 3 Flash so vision/document parts are actually understood. Paid ASK
+ *   Pro mirrors that shape with DeepSeek V4 Pro for text and Sonnet 4.6 for
+ *   image/PDF prompts.
  * @returns Model name to use
  */
 export function selectModel(
@@ -75,6 +77,10 @@ export function selectModel(
   // auto-router label.
   if (selectedModel === "hackerai-standard" && !isAgent) {
     return askUsesDeepSeek ? "model-deepseek-v4-flash" : "model-gemini-3-flash";
+  }
+
+  if (selectedModel === "hackerai-pro" && !isAgent) {
+    return hasImageOrPdf ? "model-sonnet-4.6" : "model-deepseek-v4-pro";
   }
 
   const providerKey = resolveTierToProviderKey(selectedModel, mode);

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -377,6 +377,15 @@ describe("token-bucket", () => {
       );
     });
 
+    it("should use DeepSeek V4 Pro pricing ($0.435/$0.87)", () => {
+      expect(
+        calculateTokenCost(1_000_000, "input", "model-deepseek-v4-pro"),
+      ).toBe(5655);
+      expect(
+        calculateTokenCost(1_000_000, "output", "model-deepseek-v4-pro"),
+      ).toBe(11310);
+    });
+
     it("expensive models should deplete budget faster", () => {
       const monthlyBudget = getBudgetLimits("pro").monthly;
       // Typical conversation: 2000 input + 500 output tokens

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -30,6 +30,7 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   default: { input: 0.5, output: 3.0 },
   "model-sonnet-4.6": { input: 3.0, output: 15.0 },
   "model-gemini-3-flash": { input: 0.5, output: 3.0 },
+  "model-deepseek-v4-pro": { input: 0.435, output: 0.87 },
   "fallback-gemini-3.5-flash": { input: 1.5, output: 9.0 },
   "model-opus-4.6": { input: 5.0, output: 25.0 },
   // "agent-model", "agent-model-free", and "model-kimi-k2.6" all route to


### PR DESCRIPTION
## Summary

- Route HackerAI Pro in Ask mode to DeepSeek V4 Pro for text-only requests.
- Keep Ask Pro image/PDF requests and Agent Pro requests on Claude Sonnet 4.6.
- Register DeepSeek V4 Pro in the provider map, fallback chain, usage estimate pricing, selector labels, cost indicator, and drift tests.

## Impact

Ask Pro text chats now use the cheaper DeepSeek Pro path immediately, without an A/B gate. Multimodal Ask Pro prompts still use the multimodal-capable Sonnet path.

## Validation

- `pnpm typecheck`
- `pnpm test -- lib/chat/__tests__/chat-processor.test.ts app/components/ModelSelector/__tests__/options-drift.test.ts app/components/ModelSelector/__tests__/ModelSelector.test.tsx lib/ai/__tests__/providers.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/rate-limit/__tests__/token-bucket.test.ts`
- pre-commit hooks: `pnpm typecheck` and full `pnpm test` (131 suites, 1454 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HackerAI Pro now intelligently switches between DeepSeek V4 Pro and Claude Sonnet 4.6 based on usage mode and content type, using DeepSeek for text-only tasks and Claude for images and PDFs.

* **Improvements**
  * Updated cost warnings and indicators to reflect mode-specific model pricing for HackerAI Pro.
  * Enhanced display text to clarify which models power HackerAI Pro in different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->