### PR TITLE
[codex] Add paid daily free allowance

### DIFF
--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -8,6 +8,8 @@ import { openSettingsDialog } from "@/lib/utils/settings-dialog";
 import {
   captureAddCreditCtaClick,
   captureAddCreditCtaImpression,
+  capturePaidDailyFreeAllowanceClick,
+  capturePaidDailyFreeAllowanceImpression,
   captureUpgradeCtaImpression,
 } from "@/lib/analytics/client";
 import type { LimitCapReason } from "@/lib/limit-pressure";
@@ -15,10 +17,11 @@ import {
   getExtraUsageLimitCta,
   shouldShowUpgradeCta,
 } from "@/lib/limit-pressure";
+import type { RetryOptions } from "../hooks/useChatHandlers";
 
 interface MessageErrorStateProps {
   error: Error;
-  onRetry: () => void;
+  onRetry: (options?: RetryOptions) => void;
   onReconnect?: () => void;
 }
 
@@ -51,6 +54,7 @@ export const MessageErrorState = ({
   const capReason = metadata?.capReason as LimitCapReason | undefined;
   const upgradeImpressionRef = useRef(false);
   const addCreditImpressionRef = useRef(false);
+  const paidDailyFreeAllowanceImpressionRef = useRef(false);
 
   const [timeRemaining, setTimeRemaining] = useState<number>(0);
 
@@ -79,6 +83,15 @@ export const MessageErrorState = ({
   const canUpgrade = shouldShowUpgradeCta({ subscription, capReason });
   const extraUsageCta = getExtraUsageLimitCta({ subscription, capReason });
   const isSuspensionError = metadata?.suspensionCategory !== undefined;
+  const paidDailyFreeAllowance =
+    metadata?.paidDailyFreeAllowance &&
+    typeof metadata.paidDailyFreeAllowance === "object"
+      ? (metadata.paidDailyFreeAllowance as Record<string, unknown>)
+      : undefined;
+  const canUsePaidDailyFreeAllowance =
+    isRateLimitError &&
+    paidDailyFreeAllowance?.type === "paid_daily_free_allowance" &&
+    paidDailyFreeAllowance.available === true;
 
   useEffect(() => {
     if (!isRateLimitError || !canUpgrade || upgradeImpressionRef.current)
@@ -114,6 +127,32 @@ export const MessageErrorState = ({
     });
   }, [capReason, extraUsageCta, isPaidUser, isRateLimitError, subscription]);
 
+  useEffect(() => {
+    if (
+      !canUsePaidDailyFreeAllowance ||
+      paidDailyFreeAllowanceImpressionRef.current
+    ) {
+      return;
+    }
+
+    paidDailyFreeAllowanceImpressionRef.current = true;
+    capturePaidDailyFreeAllowanceImpression({
+      surface: "message_error_state",
+      source: "rate_limit_error",
+      from_tier: subscription,
+      cap_reason: capReason,
+      cta_text: "Use today's free request",
+      allowance_requests_remaining: paidDailyFreeAllowance?.requestsRemaining,
+      allowance_cost_remaining_dollars:
+        paidDailyFreeAllowance?.costRemainingDollars,
+    });
+  }, [
+    canUsePaidDailyFreeAllowance,
+    capReason,
+    paidDailyFreeAllowance,
+    subscription,
+  ]);
+
   return (
     <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3">
       <div className="text-destructive text-sm mb-2">
@@ -134,7 +173,7 @@ export const MessageErrorState = ({
             <Button
               variant="destructive"
               size="sm"
-              onClick={onRetry}
+              onClick={() => onRetry()}
               disabled={timeRemaining > 0 && !isPaidUser}
             >
               {timeRemaining > 0 && !isPaidUser
@@ -150,7 +189,11 @@ export const MessageErrorState = ({
             </Button>
             {extraUsageCta && (
               <Button
-                variant="outline"
+                variant={
+                  extraUsageCta.analyticsText === "Add Credits"
+                    ? "default"
+                    : "outline"
+                }
                 size="sm"
                 onClick={() => {
                   captureAddCreditCtaClick({
@@ -166,9 +209,37 @@ export const MessageErrorState = ({
                 {extraUsageCta.label}
               </Button>
             )}
+            {canUsePaidDailyFreeAllowance && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  capturePaidDailyFreeAllowanceClick({
+                    surface: "message_error_state",
+                    source: "rate_limit_error",
+                    from_tier: subscription,
+                    cap_reason: capReason,
+                    cta_text: "Use today's free request",
+                    allowance_requests_remaining:
+                      paidDailyFreeAllowance?.requestsRemaining,
+                    allowance_cost_remaining_dollars:
+                      paidDailyFreeAllowance?.costRemainingDollars,
+                  });
+                  onRetry({
+                    limitRescue: { type: "paid_daily_free_allowance" },
+                  });
+                }}
+              >
+                Use today&apos;s free request
+              </Button>
+            )}
             {canUpgrade && (
               <Button
-                variant="default"
+                variant={
+                  extraUsageCta?.analyticsText === "Add Credits"
+                    ? "outline"
+                    : "default"
+                }
                 size="sm"
                 onClick={() =>
                   redirectToPricing({
@@ -207,7 +278,11 @@ export const MessageErrorState = ({
                     Reconnect
                   </Button>
                 )}
-                <Button variant="destructive" size="sm" onClick={onRetry}>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => onRetry()}
+                >
                   Retry
                 </Button>
               </>

--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -10,6 +10,11 @@ import {
   captureAddCreditCtaImpression,
   captureUpgradeCtaImpression,
 } from "@/lib/analytics/client";
+import type { LimitCapReason } from "@/lib/limit-pressure";
+import {
+  getExtraUsageLimitCta,
+  shouldShowUpgradeCta,
+} from "@/lib/limit-pressure";
 
 interface MessageErrorStateProps {
   error: Error;
@@ -43,7 +48,7 @@ export const MessageErrorState = ({
 
   const metadata = error instanceof ChatSDKError ? error.metadata : undefined;
   const resetTimestamp = metadata?.resetTimestamp as number | undefined;
-  const capReason = metadata?.capReason as string | undefined;
+  const capReason = metadata?.capReason as LimitCapReason | undefined;
   const upgradeImpressionRef = useRef(false);
   const addCreditImpressionRef = useRef(false);
 
@@ -71,10 +76,8 @@ export const MessageErrorState = ({
   })();
 
   const isPaidUser = subscription !== "free";
-  const canUpgrade =
-    subscription === "free" ||
-    subscription === "pro" ||
-    subscription === "pro-plus";
+  const canUpgrade = shouldShowUpgradeCta({ subscription, capReason });
+  const extraUsageCta = getExtraUsageLimitCta({ subscription, capReason });
   const isSuspensionError = metadata?.suspensionCategory !== undefined;
 
   useEffect(() => {
@@ -92,7 +95,12 @@ export const MessageErrorState = ({
   }, [canUpgrade, capReason, isRateLimitError, subscription]);
 
   useEffect(() => {
-    if (!isRateLimitError || !isPaidUser || addCreditImpressionRef.current) {
+    if (
+      !isRateLimitError ||
+      !isPaidUser ||
+      !extraUsageCta ||
+      addCreditImpressionRef.current
+    ) {
       return;
     }
 
@@ -102,9 +110,9 @@ export const MessageErrorState = ({
       source: "rate_limit_error",
       from_tier: subscription,
       cap_reason: capReason,
-      cta_text: "Add Credits",
+      cta_text: extraUsageCta.analyticsText,
     });
-  }, [capReason, isPaidUser, isRateLimitError, subscription]);
+  }, [capReason, extraUsageCta, isPaidUser, isRateLimitError, subscription]);
 
   return (
     <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3">
@@ -140,7 +148,7 @@ export const MessageErrorState = ({
             >
               View Usage
             </Button>
-            {isPaidUser && (
+            {extraUsageCta && (
               <Button
                 variant="outline"
                 size="sm"
@@ -150,12 +158,12 @@ export const MessageErrorState = ({
                     source: "rate_limit_error",
                     from_tier: subscription,
                     cap_reason: capReason,
-                    cta_text: "Add Credits",
+                    cta_text: extraUsageCta.analyticsText,
                   });
-                  openSettingsDialog("Extra Usage");
+                  openSettingsDialog(extraUsageCta.settingsTab);
                 }}
               >
-                Add Credits
+                {extraUsageCta.label}
               </Button>
             )}
             {canUpgrade && (

--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -141,7 +141,7 @@ export const MessageErrorState = ({
       source: "rate_limit_error",
       from_tier: subscription,
       cap_reason: capReason,
-      cta_text: "Use today's free request",
+      cta_text: "Try free Ask",
       allowance_requests_remaining: paidDailyFreeAllowance?.requestsRemaining,
       allowance_cost_remaining_dollars:
         paidDailyFreeAllowance?.costRemainingDollars,
@@ -219,7 +219,7 @@ export const MessageErrorState = ({
                     source: "rate_limit_error",
                     from_tier: subscription,
                     cap_reason: capReason,
-                    cta_text: "Use today's free request",
+                    cta_text: "Try free Ask",
                     allowance_requests_remaining:
                       paidDailyFreeAllowance?.requestsRemaining,
                     allowance_cost_remaining_dollars:
@@ -230,7 +230,7 @@ export const MessageErrorState = ({
                   });
                 }}
               >
-                Use today&apos;s free request
+                Try free Ask
               </Button>
             )}
             {canUpgrade && (

--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/analytics/client";
 import type { LimitCapReason } from "@/lib/limit-pressure";
 import {
+  PAID_DAILY_FREE_ASK_CTA_TEXT,
   getExtraUsageLimitCta,
   shouldShowUpgradeCta,
 } from "@/lib/limit-pressure";
@@ -141,7 +142,7 @@ export const MessageErrorState = ({
       source: "rate_limit_error",
       from_tier: subscription,
       cap_reason: capReason,
-      cta_text: "Try free Ask",
+      cta_text: PAID_DAILY_FREE_ASK_CTA_TEXT,
       allowance_requests_remaining: paidDailyFreeAllowance?.requestsRemaining,
       allowance_cost_remaining_dollars:
         paidDailyFreeAllowance?.costRemainingDollars,
@@ -219,7 +220,7 @@ export const MessageErrorState = ({
                     source: "rate_limit_error",
                     from_tier: subscription,
                     cap_reason: capReason,
-                    cta_text: "Try free Ask",
+                    cta_text: PAID_DAILY_FREE_ASK_CTA_TEXT,
                     allowance_requests_remaining:
                       paidDailyFreeAllowance?.requestsRemaining,
                     allowance_cost_remaining_dollars:
@@ -230,7 +231,7 @@ export const MessageErrorState = ({
                   });
                 }}
               >
-                Try free Ask
+                {PAID_DAILY_FREE_ASK_CTA_TEXT}
               </Button>
             )}
             {canUpgrade && (

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -18,6 +18,7 @@ import { FileUrlCacheProvider } from "../contexts/FileUrlCacheContext";
 import { findLastAssistantMessageIndex } from "@/lib/utils/message-utils";
 import type { ChatStatus, ChatMessage } from "@/types";
 import type { FileDetails } from "@/types/file";
+import type { RetryOptions } from "../hooks/useChatHandlers";
 import { toast } from "sonner";
 import { WandSparkles } from "lucide-react";
 import DotsSpinner from "@/components/ui/dots-spinner";
@@ -28,7 +29,7 @@ interface MessagesProps {
   messages: ChatMessage[];
   setMessages: Dispatch<SetStateAction<ChatMessage[]>>;
   onRegenerate: () => void;
-  onRetry: () => void;
+  onRetry: (options?: RetryOptions) => void;
   onContinue?: () => void;
   onReconnect?: () => void;
   onEditMessage: (

--- a/app/components/RateLimitWarning.tsx
+++ b/app/components/RateLimitWarning.tsx
@@ -104,6 +104,9 @@ const getMessage = (data: RateLimitWarningData, timeString: string): string => {
       if (data.capReason === "extra_usage_cap") {
         return `You've reached your extra usage spending limit and this response was cut off. Increase your limit to continue. Resets ${timeString}.`;
       }
+      if (data.capReason === "paid_daily_free_allowance_cut_off") {
+        return `You've reached today's free request cost limit and this response was cut off. Add credits to continue. Resets ${timeString}.`;
+      }
       return `You've reached your monthly limit and this response was cut off. Add credits or upgrade to continue. Resets ${timeString}.`;
     }
     return `You've reached your monthly usage limit. It resets ${timeString}.`;
@@ -203,7 +206,11 @@ export const RateLimitWarning = ({
               openSettingsDialog(extraUsageCta.settingsTab);
             }}
             size="sm"
-            variant="outline"
+            variant={
+              extraUsageCta.analyticsText === "Add Credits"
+                ? "default"
+                : "outline"
+            }
             className="h-7 px-3 text-xs font-medium border-black/8 dark:border-border"
           >
             {extraUsageCta.label}

--- a/app/components/RateLimitWarning.tsx
+++ b/app/components/RateLimitWarning.tsx
@@ -4,6 +4,12 @@ import { Button } from "@/components/ui/button";
 import { redirectToPricing } from "../hooks/usePricingDialog";
 import { openSettingsDialog } from "@/lib/utils/settings-dialog";
 import type { ChatMode, SubscriptionTier } from "@/types";
+import type { LimitCapReason } from "@/lib/limit-pressure";
+import {
+  getExtraUsageLimitCta,
+  getLimitTypeForCapReason,
+  shouldShowUpgradeCta,
+} from "@/lib/limit-pressure";
 import {
   captureAddCreditCtaClick,
   captureAddCreditCtaImpression,
@@ -28,6 +34,7 @@ export type RateLimitWarningData =
       severity?: "info" | "warning";
       usedDollars?: number;
       limitDollars?: number;
+      capReason?: LimitCapReason;
       midStream?: boolean;
       cutOff?: boolean;
     }
@@ -36,6 +43,7 @@ export type RateLimitWarningData =
       bucketType: "monthly";
       resetTime: Date;
       subscription: SubscriptionTier;
+      capReason?: LimitCapReason;
       midStream?: boolean;
     };
 
@@ -93,6 +101,9 @@ const getMessage = (data: RateLimitWarningData, timeString: string): string => {
       if (data.subscription === "free") {
         return `You've reached your free monthly usage limit and this response was cut off. Upgrade to continue. Resets ${timeString}.`;
       }
+      if (data.capReason === "extra_usage_cap") {
+        return `You've reached your extra usage spending limit and this response was cut off. Increase your limit to continue. Resets ${timeString}.`;
+      }
       return `You've reached your monthly limit and this response was cut off. Add credits or upgrade to continue. Resets ${timeString}.`;
     }
     return `You've reached your monthly usage limit. It resets ${timeString}.`;
@@ -116,19 +127,27 @@ export const RateLimitWarning = ({
   const capturedAddCreditImpressionRef = useRef(false);
   const timeString = formatTimeUntil(data.resetTime);
   const message = getMessage(data, timeString);
+  const capReason =
+    data.warningType === "sliding-window" ? undefined : data.capReason;
+  const extraUsageCta =
+    data.warningType === "token-bucket"
+      ? getExtraUsageLimitCta({
+          subscription: data.subscription,
+          capReason,
+        })
+      : null;
   const showUpgrade =
     data.warningType !== "extra-usage-active" &&
-    (data.subscription === "free" ||
-      data.subscription === "pro" ||
-      data.subscription === "pro-plus");
-  const showAddCredits =
-    data.warningType === "token-bucket" && data.subscription !== "free";
+    shouldShowUpgradeCta({
+      subscription: data.subscription,
+      capReason,
+    });
   const limitType =
     data.warningType === "sliding-window"
       ? "daily_requests"
       : data.warningType === "token-bucket"
-        ? data.bucketType
-        : "extra_usage_active";
+        ? getLimitTypeForCapReason(capReason)
+        : getLimitTypeForCapReason(data.capReason ?? "extra_usage_active");
   const limitSeverity =
     data.warningType === "token-bucket" && data.remainingPercent === 0
       ? "hit"
@@ -143,12 +162,13 @@ export const RateLimitWarning = ({
       from_tier: data.subscription,
       limit_type: limitType,
       limit_severity: limitSeverity,
+      cap_reason: capReason,
       cta_text: "Upgrade plan",
     });
-  }, [data.subscription, limitSeverity, limitType, showUpgrade]);
+  }, [capReason, data.subscription, limitSeverity, limitType, showUpgrade]);
 
   useEffect(() => {
-    if (!showAddCredits || capturedAddCreditImpressionRef.current) return;
+    if (!extraUsageCta || capturedAddCreditImpressionRef.current) return;
     capturedAddCreditImpressionRef.current = true;
     captureAddCreditCtaImpression({
       surface: "rate_limit_warning",
@@ -156,9 +176,10 @@ export const RateLimitWarning = ({
       from_tier: data.subscription,
       limit_type: limitType,
       limit_severity: limitSeverity,
-      cta_text: "Add credits",
+      cap_reason: capReason,
+      cta_text: extraUsageCta.analyticsText,
     });
-  }, [data.subscription, limitSeverity, limitType, showAddCredits]);
+  }, [capReason, data.subscription, extraUsageCta, limitSeverity, limitType]);
 
   return (
     <div
@@ -167,7 +188,7 @@ export const RateLimitWarning = ({
     >
       <div className="flex-1 flex items-center gap-2 flex-wrap">
         <span className="text-foreground text-sm">{message}</span>
-        {showAddCredits && (
+        {extraUsageCta && (
           <Button
             onClick={() => {
               captureAddCreditCtaClick({
@@ -176,15 +197,16 @@ export const RateLimitWarning = ({
                 from_tier: data.subscription,
                 limit_type: limitType,
                 limit_severity: limitSeverity,
-                cta_text: "Add credits",
+                cap_reason: capReason,
+                cta_text: extraUsageCta.analyticsText,
               });
-              openSettingsDialog("Extra Usage");
+              openSettingsDialog(extraUsageCta.settingsTab);
             }}
             size="sm"
             variant="outline"
             className="h-7 px-3 text-xs font-medium border-black/8 dark:border-border"
           >
-            Add credits
+            {extraUsageCta.label}
           </Button>
         )}
         {showUpgrade && (
@@ -195,6 +217,7 @@ export const RateLimitWarning = ({
                 source: "limit_pressure",
                 from_tier: data.subscription,
                 limit_type: limitType,
+                reason: capReason,
                 cta_text: "Upgrade plan",
               })
             }

--- a/app/components/RateLimitWarning.tsx
+++ b/app/components/RateLimitWarning.tsx
@@ -105,7 +105,7 @@ const getMessage = (data: RateLimitWarningData, timeString: string): string => {
         return `You've reached your extra usage spending limit and this response was cut off. Increase your limit to continue. Resets ${timeString}.`;
       }
       if (data.capReason === "paid_daily_free_allowance_cut_off") {
-        return `You've reached today's free request cost limit and this response was cut off. Add credits to continue. Resets ${timeString}.`;
+        return `Today's free Ask allowance was used up and this response was cut off. Add credits to continue. Resets ${timeString}.`;
       }
       return `You've reached your monthly limit and this response was cut off. Add credits or upgrade to continue. Resets ${timeString}.`;
     }

--- a/app/components/__tests__/MessageErrorState.test.tsx
+++ b/app/components/__tests__/MessageErrorState.test.tsx
@@ -38,7 +38,7 @@ describe("MessageErrorState paid daily free allowance", () => {
     jest.clearAllMocks();
   });
 
-  it("shows Add Credits plus a secondary free-request retry CTA when allowance is available", async () => {
+  it("shows Add Credits plus a secondary free Ask retry CTA when allowance is available", async () => {
     const user = userEvent.setup();
     const onRetry = jest.fn();
     const error = new ChatSDKError(
@@ -59,13 +59,13 @@ describe("MessageErrorState paid daily free allowance", () => {
 
     expect(screen.getByRole("button", { name: "Add Credits" })).toBeVisible();
     const freeRequestButton = screen.getByRole("button", {
-      name: "Use today's free request",
+      name: "Try free Ask",
     });
     expect(freeRequestButton).toBeVisible();
     expect(capturePaidDailyFreeAllowanceImpression).toHaveBeenCalledWith(
       expect.objectContaining({
         surface: "message_error_state",
-        cta_text: "Use today's free request",
+        cta_text: "Try free Ask",
         allowance_requests_remaining: 1,
         allowance_cost_remaining_dollars: 0.1,
       }),
@@ -76,7 +76,7 @@ describe("MessageErrorState paid daily free allowance", () => {
     expect(capturePaidDailyFreeAllowanceClick).toHaveBeenCalledWith(
       expect.objectContaining({
         surface: "message_error_state",
-        cta_text: "Use today's free request",
+        cta_text: "Try free Ask",
       }),
     );
     expect(onRetry).toHaveBeenCalledWith({
@@ -100,8 +100,6 @@ describe("MessageErrorState paid daily free allowance", () => {
 
     render(<MessageErrorState error={error} onRetry={jest.fn()} />);
 
-    expect(
-      screen.queryByRole("button", { name: "Use today's free request" }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Try free Ask" })).toBeNull();
   });
 });

--- a/app/components/__tests__/MessageErrorState.test.tsx
+++ b/app/components/__tests__/MessageErrorState.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, jest, beforeEach } from "@jest/globals";
 import { ChatSDKError } from "@/lib/errors";
+import { PAID_DAILY_FREE_ASK_CTA_TEXT } from "@/lib/limit-pressure";
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({ subscription: "pro" }),
@@ -59,13 +60,13 @@ describe("MessageErrorState paid daily free allowance", () => {
 
     expect(screen.getByRole("button", { name: "Add Credits" })).toBeVisible();
     const freeRequestButton = screen.getByRole("button", {
-      name: "Try free Ask",
+      name: PAID_DAILY_FREE_ASK_CTA_TEXT,
     });
     expect(freeRequestButton).toBeVisible();
     expect(capturePaidDailyFreeAllowanceImpression).toHaveBeenCalledWith(
       expect.objectContaining({
         surface: "message_error_state",
-        cta_text: "Try free Ask",
+        cta_text: PAID_DAILY_FREE_ASK_CTA_TEXT,
         allowance_requests_remaining: 1,
         allowance_cost_remaining_dollars: 0.1,
       }),
@@ -76,7 +77,7 @@ describe("MessageErrorState paid daily free allowance", () => {
     expect(capturePaidDailyFreeAllowanceClick).toHaveBeenCalledWith(
       expect.objectContaining({
         surface: "message_error_state",
-        cta_text: "Try free Ask",
+        cta_text: PAID_DAILY_FREE_ASK_CTA_TEXT,
       }),
     );
     expect(onRetry).toHaveBeenCalledWith({
@@ -100,6 +101,8 @@ describe("MessageErrorState paid daily free allowance", () => {
 
     render(<MessageErrorState error={error} onRetry={jest.fn()} />);
 
-    expect(screen.queryByRole("button", { name: "Try free Ask" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: PAID_DAILY_FREE_ASK_CTA_TEXT }),
+    ).toBeNull();
   });
 });

--- a/app/components/__tests__/MessageErrorState.test.tsx
+++ b/app/components/__tests__/MessageErrorState.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import { ChatSDKError } from "@/lib/errors";
+
+jest.mock("@/app/contexts/GlobalState", () => ({
+  useGlobalState: () => ({ subscription: "pro" }),
+}));
+
+jest.mock("../MemoizedMarkdown", () => ({
+  MemoizedMarkdown: ({ content }: { content: string }) => <p>{content}</p>,
+}));
+
+jest.mock("@/lib/utils/settings-dialog", () => ({
+  openSettingsDialog: jest.fn(),
+}));
+
+jest.mock("@/app/hooks/usePricingDialog", () => ({
+  redirectToPricing: jest.fn(),
+}));
+
+jest.mock("@/lib/analytics/client", () => ({
+  captureAddCreditCtaClick: jest.fn(),
+  captureAddCreditCtaImpression: jest.fn(),
+  capturePaidDailyFreeAllowanceClick: jest.fn(),
+  capturePaidDailyFreeAllowanceImpression: jest.fn(),
+  captureUpgradeCtaImpression: jest.fn(),
+}));
+
+const { MessageErrorState } = require("../MessageErrorState");
+const {
+  capturePaidDailyFreeAllowanceClick,
+  capturePaidDailyFreeAllowanceImpression,
+} = require("@/lib/analytics/client");
+
+describe("MessageErrorState paid daily free allowance", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows Add Credits plus a secondary free-request retry CTA when allowance is available", async () => {
+    const user = userEvent.setup();
+    const onRetry = jest.fn();
+    const error = new ChatSDKError(
+      "rate_limit:chat",
+      "You've hit your monthly usage limit.",
+      {
+        capReason: "monthly_exhausted",
+        paidDailyFreeAllowance: {
+          type: "paid_daily_free_allowance",
+          available: true,
+          requestsRemaining: 1,
+          costRemainingDollars: 0.1,
+        },
+      },
+    );
+
+    render(<MessageErrorState error={error} onRetry={onRetry} />);
+
+    expect(screen.getByRole("button", { name: "Add Credits" })).toBeVisible();
+    const freeRequestButton = screen.getByRole("button", {
+      name: "Use today's free request",
+    });
+    expect(freeRequestButton).toBeVisible();
+    expect(capturePaidDailyFreeAllowanceImpression).toHaveBeenCalledWith(
+      expect.objectContaining({
+        surface: "message_error_state",
+        cta_text: "Use today's free request",
+        allowance_requests_remaining: 1,
+        allowance_cost_remaining_dollars: 0.1,
+      }),
+    );
+
+    await user.click(freeRequestButton);
+
+    expect(capturePaidDailyFreeAllowanceClick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        surface: "message_error_state",
+        cta_text: "Use today's free request",
+      }),
+    );
+    expect(onRetry).toHaveBeenCalledWith({
+      limitRescue: { type: "paid_daily_free_allowance" },
+    });
+  });
+
+  it("does not show the free-request CTA when allowance is unavailable", () => {
+    const error = new ChatSDKError(
+      "rate_limit:chat",
+      "You've hit your monthly usage limit.",
+      {
+        capReason: "monthly_exhausted",
+        paidDailyFreeAllowance: {
+          type: "paid_daily_free_allowance",
+          available: false,
+          unavailableReason: "request_limit_reached",
+        },
+      },
+    );
+
+    render(<MessageErrorState error={error} onRetry={jest.fn()} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Use today's free request" }),
+    ).toBeNull();
+  });
+});

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -6,7 +6,7 @@ import { useLatestRef } from "@/app/hooks/useLatestRef";
 import { isTauriEnvironment } from "@/app/hooks/useTauri";
 import { shouldUseAgentLongForAgent } from "@/lib/chat/agent-routing";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
-import type { ChatMessage, ChatStatus } from "@/types";
+import type { ChatMessage, ChatStatus, LimitRescueRequest } from "@/types";
 import { Id } from "@/convex/_generated/dataModel";
 import {
   countInputTokens,
@@ -43,6 +43,10 @@ interface UseChatHandlersProps {
   onStopCallback?: () => void;
   resetAutoContinueCount?: () => void;
 }
+
+export type RetryOptions = {
+  limitRescue?: LimitRescueRequest;
+};
 
 export const useChatHandlers = ({
   chatId,
@@ -475,7 +479,7 @@ export const useChatHandlers = ({
     }
   };
 
-  const handleRetry = async () => {
+  const handleRetry = async (options: RetryOptions = {}) => {
     setIsAutoResuming(false);
     resetAutoContinueCount?.();
 
@@ -502,6 +506,7 @@ export const useChatHandlers = ({
           temporary: false,
           sandboxPreference,
           selectedModel,
+          ...(options.limitRescue && { limitRescue: options.limitRescue }),
         },
       });
     } else {
@@ -526,6 +531,7 @@ export const useChatHandlers = ({
           sandboxPreference,
 
           selectedModel,
+          ...(options.limitRescue && { limitRescue: options.limitRescue }),
         },
       });
     }

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -584,6 +584,9 @@ export const getExtraUsageBalanceForBackend = query({
     autoReloadThresholdDollars: v.optional(v.number()),
     autoReloadThresholdPoints: v.optional(v.number()),
     autoReloadAmountDollars: v.optional(v.number()),
+    monthlyCapDollars: v.optional(v.number()),
+    monthlySpentDollars: v.number(),
+    monthlyRemainingDollars: v.optional(v.number()),
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
@@ -602,6 +605,17 @@ export const getExtraUsageBalanceForBackend = query({
 
     const balancePoints = settings?.balance_points ?? 0;
     const thresholdPoints = settings?.auto_reload_threshold_points;
+    const now = new Date();
+    const currentMonth = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const monthlySpentPoints =
+      settings?.monthly_reset_date === currentMonth
+        ? (settings?.monthly_spent_points ?? 0)
+        : 0;
+    const monthlyCapPoints = settings?.monthly_cap_points;
+    const monthlyRemainingPoints =
+      monthlyCapPoints === undefined
+        ? undefined
+        : Math.max(0, monthlyCapPoints - monthlySpentPoints);
 
     return {
       balanceDollars: pointsToDollars(balancePoints),
@@ -613,6 +627,15 @@ export const getExtraUsageBalanceForBackend = query({
         : undefined,
       autoReloadThresholdPoints: thresholdPoints,
       autoReloadAmountDollars: settings?.auto_reload_amount_dollars,
+      monthlyCapDollars:
+        monthlyCapPoints === undefined
+          ? undefined
+          : pointsToDollars(monthlyCapPoints),
+      monthlySpentDollars: pointsToDollars(monthlySpentPoints),
+      monthlyRemainingDollars:
+        monthlyRemainingPoints === undefined
+          ? undefined
+          : pointsToDollars(monthlyRemainingPoints),
     };
   },
 });

--- a/convex/teamExtraUsage.ts
+++ b/convex/teamExtraUsage.ts
@@ -505,6 +505,11 @@ export const getTeamExtraUsageStateForBackend = query({
     autoReloadThresholdPoints: v.optional(v.number()),
     autoReloadAmountDollars: v.optional(v.number()),
     memberDisabled: v.boolean(),
+    monthlyCapDollars: v.optional(v.number()),
+    monthlySpentDollars: v.number(),
+    memberMonthlyLimitDollars: v.optional(v.number()),
+    memberMonthlySpentDollars: v.number(),
+    monthlyRemainingDollars: v.optional(v.number()),
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
@@ -522,6 +527,32 @@ export const getTeamExtraUsageStateForBackend = query({
       .first();
 
     const thresholdPoints = team?.auto_reload_threshold_points;
+    const currentMonth = currentMonthString();
+    const teamMonthlySpent =
+      team?.monthly_reset_date === currentMonth
+        ? (team?.monthly_spent_points ?? 0)
+        : 0;
+    const memberMonthlySpent =
+      member?.monthly_reset_date === currentMonth
+        ? (member?.monthly_spent_points ?? 0)
+        : 0;
+    const teamCapPoints = team?.monthly_cap_points;
+    const memberCapPoints = member?.monthly_limit_points;
+    const teamRemainingPoints =
+      teamCapPoints === undefined
+        ? undefined
+        : Math.max(0, teamCapPoints - teamMonthlySpent);
+    const memberRemainingPoints =
+      memberCapPoints === undefined
+        ? undefined
+        : Math.max(0, memberCapPoints - memberMonthlySpent);
+    const monthlyRemainingPoints =
+      teamRemainingPoints === undefined && memberRemainingPoints === undefined
+        ? undefined
+        : Math.min(
+            teamRemainingPoints ?? Number.POSITIVE_INFINITY,
+            memberRemainingPoints ?? Number.POSITIVE_INFINITY,
+          );
 
     return {
       enabled: team?.enabled ?? false,
@@ -534,6 +565,20 @@ export const getTeamExtraUsageStateForBackend = query({
       autoReloadThresholdPoints: thresholdPoints,
       autoReloadAmountDollars: team?.auto_reload_amount_dollars,
       memberDisabled: member?.disabled ?? false,
+      monthlyCapDollars:
+        teamCapPoints === undefined
+          ? undefined
+          : pointsToDollars(teamCapPoints),
+      monthlySpentDollars: pointsToDollars(teamMonthlySpent),
+      memberMonthlyLimitDollars:
+        memberCapPoints === undefined
+          ? undefined
+          : pointsToDollars(memberCapPoints),
+      memberMonthlySpentDollars: pointsToDollars(memberMonthlySpent),
+      monthlyRemainingDollars:
+        monthlyRemainingPoints === undefined
+          ? undefined
+          : pointsToDollars(monthlyRemainingPoints),
     };
   },
 });

--- a/docs/paid-funnel-analytics.md
+++ b/docs/paid-funnel-analytics.md
@@ -49,6 +49,13 @@ Paid funnel events use stable snake_case event names. Most events include
 - `amount_dollars`, `checkout_amount_dollars`, `revenue_dollars`: money fields
   in USD unless `currency` says otherwise.
 - `cap_reason`, `limit_type`, `reset_timestamp`: limit-pressure context.
+- `primary_cta`, `eligible_ctas`, `upgrade_available`,
+  `add_credit_available`: monetization paths shown or available for that
+  limit pressure moment.
+- `cost_guardrail`: true when the blocker is an extra-usage/team spending cap
+  or payment guardrail rather than the included monthly bucket alone.
+- `paid_monthly_exhaustion`: true for paid users whose included monthly bucket
+  is exhausted and can be resolved through add-credit/upgrade flow.
 
 ## Data Minimization
 
@@ -69,7 +76,8 @@ Paid funnel events use stable snake_case event names. Most events include
 - Checkout start to subscription: `checkout_started -> subscription_started`,
   joined or filtered by `checkout_attempt_id`.
 - Limit pressure to paid/add-credit: `limit_hit -> upgrade_cta_clicked` and
-  `limit_hit -> add_credit_checkout_succeeded`.
+  `limit_hit -> add_credit_checkout_succeeded`, grouped by `primary_cta`,
+  `eligible_ctas`, and `cap_reason`.
 - Referral revenue:
   `referred_signup_attributed -> referred_user_paid_conversion`, grouped by
   `referral_code`.

--- a/lib/__tests__/limit-pressure.test.ts
+++ b/lib/__tests__/limit-pressure.test.ts
@@ -1,0 +1,59 @@
+import {
+  getEligibleLimitCtas,
+  getExtraUsageLimitCta,
+  getLimitPressureContext,
+  shouldShowUpgradeCta,
+} from "../limit-pressure";
+
+describe("limit pressure helpers", () => {
+  it("routes free limit pressure to upgrade only", () => {
+    expect(
+      getLimitPressureContext({
+        subscription: "free",
+        capReason: "daily_requests_exhausted",
+      }),
+    ).toMatchObject({
+      limitType: "daily_requests",
+      upgradeAvailable: true,
+      addCreditAvailable: false,
+      primaryCta: "upgrade_plan",
+      eligibleCtas: ["upgrade_plan"],
+    });
+  });
+
+  it("routes paid monthly exhaustion to add credits and paid upgrades when available", () => {
+    expect(
+      getEligibleLimitCtas({
+        subscription: "pro",
+        capReason: "monthly_exhausted",
+      }),
+    ).toEqual(["add_credits", "upgrade_plan"]);
+    expect(
+      getExtraUsageLimitCta({
+        subscription: "ultra",
+        capReason: "monthly_exhausted",
+      }),
+    ).toMatchObject({
+      label: "Add Credits",
+      analyticsText: "Add Credits",
+    });
+  });
+
+  it("routes extra-usage caps to the spending-limit guardrail instead of upgrade", () => {
+    expect(
+      shouldShowUpgradeCta({
+        subscription: "pro-plus",
+        capReason: "extra_usage_cap",
+      }),
+    ).toBe(false);
+    expect(
+      getExtraUsageLimitCta({
+        subscription: "pro-plus",
+        capReason: "extra_usage_cap",
+      }),
+    ).toMatchObject({
+      label: "Increase Limit",
+      analyticsText: "Increase Limit",
+    });
+  });
+});

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -68,6 +68,24 @@ export function captureAddCreditCtaClick(properties: CtaAnalyticsProperties) {
   );
 }
 
+export function capturePaidDailyFreeAllowanceImpression(
+  properties: CtaAnalyticsProperties,
+) {
+  return captureAuthenticatedEvent(
+    PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceImpressed,
+    paidFunnelProperties(properties),
+  );
+}
+
+export function capturePaidDailyFreeAllowanceClick(
+  properties: CtaAnalyticsProperties,
+) {
+  return captureAuthenticatedEvent(
+    PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceClicked,
+    paidFunnelProperties(properties),
+  );
+}
+
 export function newCheckoutAttemptId() {
   return createCheckoutAttemptId();
 }

--- a/lib/analytics/paid-funnel.ts
+++ b/lib/analytics/paid-funnel.ts
@@ -10,6 +10,12 @@ export const PAID_FUNNEL_EVENTS = {
   checkoutStarted: "checkout_started",
   checkoutSucceeded: "checkout_succeeded",
   limitHit: "limit_hit",
+  paidDailyFreeAllowanceImpressed: "paid_daily_free_allowance_impressed",
+  paidDailyFreeAllowanceClicked: "paid_daily_free_allowance_clicked",
+  paidDailyFreeAllowanceStarted: "paid_daily_free_allowance_started",
+  paidDailyFreeAllowanceSucceeded: "paid_daily_free_allowance_succeeded",
+  paidDailyFreeAllowanceBlocked: "paid_daily_free_allowance_blocked",
+  paidDailyFreeAllowanceCutOff: "paid_daily_free_allowance_cut_off",
 } as const;
 
 export type PaidFunnelPlan =

--- a/lib/api/__tests__/build-extra-usage-config.test.ts
+++ b/lib/api/__tests__/build-extra-usage-config.test.ts
@@ -222,6 +222,34 @@ describe("buildExtraUsageConfig — individual paid users (pro / pro-plus / ultr
     });
   });
 
+  it("includes personal monthly cap remaining for mid-stream guardrails", async () => {
+    mockGetUserBalance.mockResolvedValue({
+      balanceDollars: 30,
+      balancePoints: 300_000,
+      enabled: true,
+      autoReloadEnabled: true,
+      monthlyCapDollars: 50,
+      monthlySpentDollars: 45,
+      monthlyRemainingDollars: 5,
+    });
+
+    const config = await buildExtraUsageConfig({
+      userId: USER_ID,
+      subscription: "pro-plus",
+      userCustomization: { extra_usage_enabled: true } as any,
+    });
+
+    expect(config).toMatchObject({
+      enabled: true,
+      hasBalance: true,
+      balanceDollars: 30,
+      autoReloadEnabled: true,
+      monthlyCapDollars: 50,
+      monthlySpentDollars: 45,
+      monthlyRemainingDollars: 5,
+    });
+  });
+
   it("returns optimistic config when personal balance query fails", async () => {
     mockGetUserBalance.mockResolvedValue(null);
 

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -286,6 +286,13 @@ describe("captureUsageCost", () => {
         nonModelCostDollars: 0.12,
         costSource: "provider",
       },
+      paidDailyFreeAllowance: {
+        active: true,
+        cutOff: false,
+        requestLimit: 1,
+        costLimitDollars: 0.1,
+        resetTimestamp: 1_800_000_000_000,
+      },
     });
 
     expect(capture).toHaveBeenCalledWith({
@@ -310,6 +317,12 @@ describe("captureUsageCost", () => {
         cache_read_tokens: 200,
         cache_write_tokens: 0,
         cost_source: "provider",
+        limit_rescue_type: "paid_daily_free_allowance",
+        paid_daily_free_allowance_active: true,
+        paid_daily_free_allowance_cut_off: false,
+        paid_daily_free_allowance_request_limit: 1,
+        paid_daily_free_allowance_cost_limit_dollars: 0.1,
+        paid_daily_free_allowance_reset_timestamp: 1_800_000_000_000,
         $set: expect.objectContaining({
           subscription_tier: "pro",
           last_usage_cost_at: expect.any(String),
@@ -445,6 +458,15 @@ describe("createChatLogger ChatSDKError metadata", () => {
         new ChatSDKError("rate_limit:chat", "Monthly limit hit", {
           capReason: "monthly_exhausted",
           resetTimestamp: 1_800_000_000_000,
+          paidDailyFreeAllowance: {
+            type: "paid_daily_free_allowance",
+            available: true,
+            requestsRemaining: 1,
+            requestLimit: 1,
+            costRemainingDollars: 0.1,
+            costLimitDollars: 0.1,
+            rolloutPercent: 10,
+          },
         }),
       );
 
@@ -458,6 +480,12 @@ describe("createChatLogger ChatSDKError metadata", () => {
           add_credit_available: true,
           primary_cta: "add_credits",
           eligible_ctas: ["add_credits", "upgrade_plan"],
+          paid_daily_free_allowance_available: true,
+          paid_daily_free_allowance_requests_remaining: 1,
+          paid_daily_free_allowance_request_limit: 1,
+          paid_daily_free_allowance_cost_remaining_dollars: 0.1,
+          paid_daily_free_allowance_cost_limit_dollars: 0.1,
+          paid_daily_free_allowance_rollout_percent: 10,
           chat_id: "chat_limit",
         }),
       );

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -13,6 +13,7 @@ const {
   captureUsageCost,
 } = require("../chat-logger");
 const { ChatSDKError } = require("../../errors");
+const { phLogger } = require("../../posthog/server");
 
 describe("captureToolCalls", () => {
   it("aggregates repeated tool calls by tool before sending PostHog events", () => {
@@ -413,6 +414,104 @@ describe("createChatLogger ChatSDKError metadata", () => {
       expect(wideEvent.error.metadata).not.toHaveProperty("usage_keys");
       expect(wideEvent.error.metadata).not.toHaveProperty("parts_size_bytes");
     } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("emits limit pressure funnel properties for paid monthly exhaustion", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const eventSpy = jest.spyOn(phLogger, "event").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_limit",
+        endpoint: "/api/chat",
+      });
+      chatLogger.setRequestDetails({
+        mode: "agent",
+        isTemporary: false,
+        isRegenerate: false,
+      });
+      chatLogger.setUser({ id: "user_123", subscription: "pro" });
+      chatLogger.setRateLimit(
+        {
+          subscription: "pro",
+          monthly: { remaining: 0, limit: 250_000 },
+        },
+        undefined,
+      );
+
+      chatLogger.emitChatError(
+        new ChatSDKError("rate_limit:chat", "Monthly limit hit", {
+          capReason: "monthly_exhausted",
+          resetTimestamp: 1_800_000_000_000,
+        }),
+      );
+
+      expect(eventSpy).toHaveBeenCalledWith(
+        "limit_hit",
+        expect.objectContaining({
+          subscription_tier: "pro",
+          limit_type: "monthly",
+          cap_reason: "monthly_exhausted",
+          paid_monthly_exhaustion: true,
+          add_credit_available: true,
+          primary_cta: "add_credits",
+          eligible_ctas: ["add_credits", "upgrade_plan"],
+          chat_id: "chat_limit",
+        }),
+      );
+      expect(eventSpy).toHaveBeenCalledWith(
+        "monthly_cap_hit",
+        expect.objectContaining({
+          subscription: "pro",
+          cap_reason: "monthly_exhausted",
+          primary_cta: "add_credits",
+          eligible_ctas: ["add_credits", "upgrade_plan"],
+        }),
+      );
+    } finally {
+      eventSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+
+  it("does not emit monthly_cap_hit for paid billing service outages", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const eventSpy = jest.spyOn(phLogger, "event").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_billing_unavailable",
+        endpoint: "/api/chat",
+      });
+      chatLogger.setRequestDetails({
+        mode: "agent",
+        isTemporary: false,
+        isRegenerate: false,
+      });
+      chatLogger.setUser({ id: "user_123", subscription: "pro" });
+
+      chatLogger.emitChatError(
+        new ChatSDKError("rate_limit:chat", "Billing unavailable", {
+          capReason: "billing_unavailable",
+          resetTimestamp: 1_800_000_000_000,
+        }),
+      );
+
+      expect(eventSpy).toHaveBeenCalledWith(
+        "limit_hit",
+        expect.objectContaining({
+          cap_reason: "billing_unavailable",
+          limit_type: "billing",
+        }),
+      );
+      expect(eventSpy).not.toHaveBeenCalledWith(
+        "monthly_cap_hit",
+        expect.anything(),
+      );
+    } finally {
+      eventSpy.mockRestore();
       logSpy.mockRestore();
     }
   });

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -20,7 +20,6 @@ import type {
   SandboxPreference,
   SelectedModel,
   RateLimitInfo,
-  SubscriptionTier,
 } from "@/types";
 import { coerceSelectedModel, isLimitRescueRequest } from "@/types";
 import { getBaseTodosForRequest } from "@/lib/utils/todo-utils";
@@ -40,7 +39,6 @@ import {
 import {
   BudgetMonitor,
   captureBudgetSnapshot,
-  type BudgetSnapshot,
 } from "@/lib/chat/budget-monitor";
 import { UsageTracker } from "@/lib/usage-tracker";
 import {
@@ -111,10 +109,15 @@ import {
 import { Id } from "@/convex/_generated/dataModel";
 import { getMaxStepsForUser } from "@/lib/chat/chat-processor";
 import { phLogger } from "@/lib/posthog/server";
+import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
 import {
-  PAID_FUNNEL_EVENTS,
-  paidFunnelProperties,
-} from "@/lib/analytics/paid-funnel";
+  PAID_DAILY_FREE_ALLOWANCE_MODEL,
+  capturePaidDailyFreeAllowanceServerEvent,
+  createPaidDailyFreeAllowanceBudgetSnapshot,
+  createPaidDailyFreeAllowanceRateLimitInfo,
+  createPaidDailyFreeAllowanceUsageLogContext,
+  getRateLimitErrorCapReason,
+} from "@/lib/api/paid-daily-free-allowance-rescue";
 import {
   extractErrorDetails,
   getUserFriendlyProviderError,
@@ -136,86 +139,6 @@ function getStreamContext() {
 }
 
 export { getStreamContext };
-
-const PAID_DAILY_FREE_ALLOWANCE_MODEL = "ask-model-free";
-
-function getCapReason(error: ChatSDKError): string | undefined {
-  return typeof error.metadata?.capReason === "string"
-    ? error.metadata.capReason
-    : undefined;
-}
-
-function createPaidDailyFreeAllowanceRateLimitInfo(
-  reservation: PaidDailyFreeAllowanceReservation,
-): RateLimitInfo {
-  return {
-    remaining: 0,
-    resetTime: reservation.status.resetTime,
-    limit: 0,
-    ...(reservation.status.rateLimitSkipped && { rateLimitSkipped: true }),
-  };
-}
-
-function createPaidDailyFreeAllowanceBudgetSnapshot(
-  reservation: PaidDailyFreeAllowanceReservation,
-): BudgetSnapshot | null {
-  if (reservation.status.rateLimitSkipped) return null;
-
-  return {
-    monthlyLimitPoints: reservation.status.costLimitPoints,
-    monthlyRemainingAtStart: reservation.status.costRemainingPoints,
-    monthlyResetTime: reservation.status.resetTime,
-    extraUsageBalanceAtStart: 0,
-    extraUsageAutoReload: false,
-    extraUsageOverflowAllowed: false,
-    capReasonOnExhaustion: "paid_daily_free_allowance_cut_off",
-  };
-}
-
-function capturePaidDailyFreeAllowanceEvent({
-  event,
-  userId,
-  subscription,
-  mode,
-  chatId,
-  endpoint,
-  reservation,
-  extra,
-}: {
-  event: (typeof PAID_FUNNEL_EVENTS)[keyof typeof PAID_FUNNEL_EVENTS];
-  userId: string;
-  subscription: SubscriptionTier;
-  mode: ChatMode;
-  chatId: string;
-  endpoint: "/api/chat";
-  reservation?: PaidDailyFreeAllowanceReservation;
-  extra?: Record<string, unknown>;
-}) {
-  const status = reservation?.status;
-  phLogger.event(
-    event,
-    paidFunnelProperties({
-      userId,
-      subscription_tier: subscription,
-      mode,
-      chat_id: chatId,
-      endpoint,
-      limit_rescue_type: "paid_daily_free_allowance",
-      paid_daily_free_allowance_request_limit: status?.requestLimit,
-      paid_daily_free_allowance_requests_remaining: status?.requestsRemaining,
-      paid_daily_free_allowance_cost_limit_dollars: status?.costLimitDollars,
-      paid_daily_free_allowance_cost_remaining_dollars:
-        status?.costRemainingDollars,
-      paid_daily_free_allowance_reset_timestamp: status?.resetTimestamp,
-      paid_daily_free_allowance_unavailable_reason:
-        status?.unavailableReason ?? reservation?.blockReason,
-      ...extra,
-      $set: {
-        subscription_tier: subscription,
-      },
-    }),
-  );
-}
 
 export const createChatHandler = () => {
   return async (req: NextRequest) => {
@@ -438,10 +361,10 @@ export const createChatHandler = () => {
           throw error;
         }
 
-        const capReason = getCapReason(error);
+        const capReason = getRateLimitErrorCapReason(error);
         if (capReason !== "monthly_exhausted") {
           if (limitRescue) {
-            capturePaidDailyFreeAllowanceEvent({
+            capturePaidDailyFreeAllowanceServerEvent({
               event: PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceBlocked,
               userId,
               subscription,
@@ -487,7 +410,7 @@ export const createChatHandler = () => {
         };
 
         if (!allowanceReservation.allowed) {
-          capturePaidDailyFreeAllowanceEvent({
+          capturePaidDailyFreeAllowanceServerEvent({
             event: PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceBlocked,
             userId,
             subscription,
@@ -510,7 +433,7 @@ export const createChatHandler = () => {
         chatLogger.setChat(chatLogContext, selectedModel);
         rateLimitInfo =
           createPaidDailyFreeAllowanceRateLimitInfo(allowanceReservation);
-        capturePaidDailyFreeAllowanceEvent({
+        capturePaidDailyFreeAllowanceServerEvent({
           event: PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceStarted,
           userId,
           subscription,
@@ -882,7 +805,7 @@ export const createChatHandler = () => {
                     rateLimitInfo,
                   });
                   const cutOff = state.stoppedDueToBudgetExhaustion;
-                  capturePaidDailyFreeAllowanceEvent({
+                  capturePaidDailyFreeAllowanceServerEvent({
                     event: cutOff
                       ? PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceCutOff
                       : PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceSucceeded,
@@ -944,17 +867,11 @@ export const createChatHandler = () => {
                   mode,
                   usage: usageCostRecord,
                   ...(paidDailyFreeAllowanceReservation && {
-                    paidDailyFreeAllowance: {
-                      active: true,
-                      cutOff: state.stoppedDueToBudgetExhaustion,
-                      requestLimit:
-                        paidDailyFreeAllowanceReservation.status.requestLimit,
-                      costLimitDollars:
-                        paidDailyFreeAllowanceReservation.status
-                          .costLimitDollars,
-                      resetTimestamp:
-                        paidDailyFreeAllowanceReservation.status.resetTimestamp,
-                    },
+                    paidDailyFreeAllowance:
+                      createPaidDailyFreeAllowanceUsageLogContext(
+                        paidDailyFreeAllowanceReservation,
+                        state.stoppedDueToBudgetExhaustion,
+                      ),
                   }),
                 });
               } finally {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -15,24 +15,32 @@ import { getUserIDAndPro } from "@/lib/auth/get-user-id";
 import { assertUserCanMakeCostIncurringRequest } from "@/lib/suspensions";
 import type {
   ChatMode,
+  LimitRescueRequest,
   Todo,
   SandboxPreference,
   SelectedModel,
   RateLimitInfo,
+  SubscriptionTier,
 } from "@/types";
-import { coerceSelectedModel } from "@/types";
+import { coerceSelectedModel, isLimitRescueRequest } from "@/types";
 import { getBaseTodosForRequest } from "@/lib/utils/todo-utils";
 import {
   acquireFreeRunConcurrencyLock,
   checkFreeMonthlyCostLimit,
   checkRateLimit,
   deductUsage,
+  getPaidDailyFreeAllowanceStatus,
+  paidDailyFreeAllowanceStatusToMetadata,
+  recordPaidDailyFreeAllowanceCost,
   recordFreeMonthlyCost,
+  reservePaidDailyFreeAllowanceRequest,
+  type PaidDailyFreeAllowanceReservation,
   UsageRefundTracker,
 } from "@/lib/rate-limit";
 import {
   BudgetMonitor,
   captureBudgetSnapshot,
+  type BudgetSnapshot,
 } from "@/lib/chat/budget-monitor";
 import { UsageTracker } from "@/lib/usage-tracker";
 import {
@@ -83,7 +91,7 @@ import {
   createPreemptiveTimeout,
 } from "@/lib/utils/stream-cancellation";
 import { v4 as uuidv4 } from "uuid";
-import { processChatMessages, selectModel } from "@/lib/chat/chat-processor";
+import { processChatMessages } from "@/lib/chat/chat-processor";
 import { summarizeIncompleteToolParts } from "@/lib/chat/tool-abort-utils";
 import { createTrackedProvider } from "@/lib/ai/providers";
 import {
@@ -103,6 +111,10 @@ import {
 import { Id } from "@/convex/_generated/dataModel";
 import { getMaxStepsForUser } from "@/lib/chat/chat-processor";
 import { phLogger } from "@/lib/posthog/server";
+import {
+  PAID_FUNNEL_EVENTS,
+  paidFunnelProperties,
+} from "@/lib/analytics/paid-funnel";
 import {
   extractErrorDetails,
   getUserFriendlyProviderError,
@@ -124,6 +136,86 @@ function getStreamContext() {
 }
 
 export { getStreamContext };
+
+const PAID_DAILY_FREE_ALLOWANCE_MODEL = "ask-model-free";
+
+function getCapReason(error: ChatSDKError): string | undefined {
+  return typeof error.metadata?.capReason === "string"
+    ? error.metadata.capReason
+    : undefined;
+}
+
+function createPaidDailyFreeAllowanceRateLimitInfo(
+  reservation: PaidDailyFreeAllowanceReservation,
+): RateLimitInfo {
+  return {
+    remaining: 0,
+    resetTime: reservation.status.resetTime,
+    limit: 0,
+    ...(reservation.status.rateLimitSkipped && { rateLimitSkipped: true }),
+  };
+}
+
+function createPaidDailyFreeAllowanceBudgetSnapshot(
+  reservation: PaidDailyFreeAllowanceReservation,
+): BudgetSnapshot | null {
+  if (reservation.status.rateLimitSkipped) return null;
+
+  return {
+    monthlyLimitPoints: reservation.status.costLimitPoints,
+    monthlyRemainingAtStart: reservation.status.costRemainingPoints,
+    monthlyResetTime: reservation.status.resetTime,
+    extraUsageBalanceAtStart: 0,
+    extraUsageAutoReload: false,
+    extraUsageOverflowAllowed: false,
+    capReasonOnExhaustion: "paid_daily_free_allowance_cut_off",
+  };
+}
+
+function capturePaidDailyFreeAllowanceEvent({
+  event,
+  userId,
+  subscription,
+  mode,
+  chatId,
+  endpoint,
+  reservation,
+  extra,
+}: {
+  event: (typeof PAID_FUNNEL_EVENTS)[keyof typeof PAID_FUNNEL_EVENTS];
+  userId: string;
+  subscription: SubscriptionTier;
+  mode: ChatMode;
+  chatId: string;
+  endpoint: "/api/chat";
+  reservation?: PaidDailyFreeAllowanceReservation;
+  extra?: Record<string, unknown>;
+}) {
+  const status = reservation?.status;
+  phLogger.event(
+    event,
+    paidFunnelProperties({
+      userId,
+      subscription_tier: subscription,
+      mode,
+      chat_id: chatId,
+      endpoint,
+      limit_rescue_type: "paid_daily_free_allowance",
+      paid_daily_free_allowance_request_limit: status?.requestLimit,
+      paid_daily_free_allowance_requests_remaining: status?.requestsRemaining,
+      paid_daily_free_allowance_cost_limit_dollars: status?.costLimitDollars,
+      paid_daily_free_allowance_cost_remaining_dollars:
+        status?.costRemainingDollars,
+      paid_daily_free_allowance_reset_timestamp: status?.resetTimestamp,
+      paid_daily_free_allowance_unavailable_reason:
+        status?.unavailableReason ?? reservation?.blockReason,
+      ...extra,
+      $set: {
+        subscription_tier: subscription,
+      },
+    }),
+  );
+}
 
 export const createChatHandler = () => {
   return async (req: NextRequest) => {
@@ -158,6 +250,7 @@ export const createChatHandler = () => {
         selectedModel: rawSelectedModel,
         isAutoContinue,
         useClientMessagesForRegenerate,
+        limitRescue: rawLimitRescue,
       }: {
         messages: UIMessage[];
         mode: ChatMode;
@@ -169,11 +262,17 @@ export const createChatHandler = () => {
         selectedModel?: string;
         isAutoContinue?: boolean;
         useClientMessagesForRegenerate?: boolean;
+        limitRescue?: unknown;
       } = await req.json();
       outerChatId = chatId;
 
       const selectedModelOverride: SelectedModel | undefined =
         coerceSelectedModel(rawSelectedModel ?? null) ?? undefined;
+      const limitRescue: LimitRescueRequest | undefined = isLimitRescueRequest(
+        rawLimitRescue,
+      )
+        ? rawLimitRescue
+        : undefined;
 
       chatLogger = createChatLogger({ chatId, endpoint });
       chatLogger.setRequestDetails({
@@ -300,17 +399,15 @@ export const createChatHandler = () => {
       });
 
       const fileCounts = countFileAttachments(truncatedMessages);
-      chatLogger.setChat(
-        {
-          messageCount: truncatedMessages.length,
-          estimatedInputTokens,
-          isNewChat,
-          fileCount: fileCounts.totalFiles,
-          imageCount: fileCounts.imageCount,
-          memoryEnabled,
-        },
-        selectedModel,
-      );
+      const chatLogContext = {
+        messageCount: truncatedMessages.length,
+        estimatedInputTokens,
+        isNewChat,
+        fileCount: fileCounts.totalFiles,
+        imageCount: fileCounts.imageCount,
+        memoryEnabled,
+      };
+      chatLogger.setChat(chatLogContext, selectedModel);
 
       const extraUsageConfig = await buildExtraUsageConfig({
         userId,
@@ -319,17 +416,113 @@ export const createChatHandler = () => {
         organizationId,
       });
 
-      const rateLimitInfo: RateLimitInfo =
-        freeAskRateLimitInfo ??
-        (await checkRateLimit(
+      let paidDailyFreeAllowanceReservation:
+        | PaidDailyFreeAllowanceReservation
+        | undefined;
+      let rateLimitInfo: RateLimitInfo;
+
+      try {
+        rateLimitInfo =
+          freeAskRateLimitInfo ??
+          (await checkRateLimit(
+            userId,
+            mode,
+            subscription,
+            estimatedInputTokens,
+            extraUsageConfig,
+            selectedModel,
+            organizationId,
+          ));
+      } catch (error) {
+        if (!(error instanceof ChatSDKError)) {
+          throw error;
+        }
+
+        const capReason = getCapReason(error);
+        if (capReason !== "monthly_exhausted") {
+          if (limitRescue) {
+            capturePaidDailyFreeAllowanceEvent({
+              event: PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceBlocked,
+              userId,
+              subscription,
+              mode,
+              chatId,
+              endpoint,
+              extra: {
+                blocked_reason: "not_monthly_exhausted",
+                cap_reason: capReason,
+              },
+            });
+          }
+          throw error;
+        }
+
+        const allowanceContext = {
           userId,
-          mode,
           subscription,
-          estimatedInputTokens,
-          extraUsageConfig,
-          selectedModel,
-          organizationId,
-        ));
+          mode,
+          capReason,
+          hasAttachments: fileCounts.totalFiles > 0,
+        };
+        const allowanceStatus =
+          await getPaidDailyFreeAllowanceStatus(allowanceContext);
+        const allowanceMetadata =
+          paidDailyFreeAllowanceStatusToMetadata(allowanceStatus);
+        error.metadata = {
+          ...error.metadata,
+          paidDailyFreeAllowance: allowanceMetadata,
+        };
+
+        if (!limitRescue) {
+          throw error;
+        }
+
+        const allowanceReservation =
+          await reservePaidDailyFreeAllowanceRequest(allowanceContext);
+        error.metadata = {
+          ...error.metadata,
+          paidDailyFreeAllowance: paidDailyFreeAllowanceStatusToMetadata(
+            allowanceReservation.status,
+          ),
+        };
+
+        if (!allowanceReservation.allowed) {
+          capturePaidDailyFreeAllowanceEvent({
+            event: PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceBlocked,
+            userId,
+            subscription,
+            mode,
+            chatId,
+            endpoint,
+            reservation: allowanceReservation,
+            extra: {
+              blocked_reason:
+                allowanceReservation.blockReason ??
+                allowanceReservation.status.unavailableReason,
+              cap_reason: capReason,
+            },
+          });
+          throw error;
+        }
+
+        paidDailyFreeAllowanceReservation = allowanceReservation;
+        selectedModel = PAID_DAILY_FREE_ALLOWANCE_MODEL;
+        chatLogger.setChat(chatLogContext, selectedModel);
+        rateLimitInfo =
+          createPaidDailyFreeAllowanceRateLimitInfo(allowanceReservation);
+        capturePaidDailyFreeAllowanceEvent({
+          event: PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceStarted,
+          userId,
+          subscription,
+          mode,
+          chatId,
+          endpoint,
+          reservation: allowanceReservation,
+          extra: {
+            selected_model: selectedModel,
+          },
+        });
+      }
 
       const freeMonthlyBudgetSnapshot =
         subscription === "free"
@@ -595,7 +788,14 @@ export const createChatHandler = () => {
               extraUsageConfig,
               subscription,
             });
+            const paidDailyFreeAllowanceBudgetSnapshot =
+              paidDailyFreeAllowanceReservation
+                ? createPaidDailyFreeAllowanceBudgetSnapshot(
+                    paidDailyFreeAllowanceReservation,
+                  )
+                : null;
             const effectiveBudgetSnapshot =
+              paidDailyFreeAllowanceBudgetSnapshot ??
               budgetSnapshot ??
               (freeMonthlyBudgetSnapshot?.rateLimitSkipped
                 ? null
@@ -663,7 +863,46 @@ export const createChatHandler = () => {
                     ? usageTracker.providerCost
                     : undefined;
 
-                if (subscription === "free") {
+                if (paidDailyFreeAllowanceReservation) {
+                  await recordPaidDailyFreeAllowanceCost(
+                    userId,
+                    usageCostRecord.costDollars,
+                  );
+                  usageTracker.log({
+                    userId,
+                    organizationId,
+                    chatId,
+                    endpoint,
+                    mode,
+                    subscription,
+                    selectedModel,
+                    selectedModelOverride,
+                    responseModel: state.responseModel,
+                    configuredModelId,
+                    rateLimitInfo,
+                  });
+                  const cutOff = state.stoppedDueToBudgetExhaustion;
+                  capturePaidDailyFreeAllowanceEvent({
+                    event: cutOff
+                      ? PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceCutOff
+                      : PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceSucceeded,
+                    userId,
+                    subscription,
+                    mode,
+                    chatId,
+                    endpoint,
+                    reservation: paidDailyFreeAllowanceReservation,
+                    extra: {
+                      cost_dollars: usageCostRecord.costDollars,
+                      model_cost_dollars: usageCostRecord.modelCostDollars,
+                      non_model_cost_dollars:
+                        usageCostRecord.nonModelCostDollars,
+                      selected_model: selectedModel,
+                      response_model: state.responseModel,
+                      cost_source: usageCostRecord.costSource,
+                    },
+                  });
+                } else if (subscription === "free") {
                   await recordFreeMonthlyCost(
                     userId,
                     usageCostRecord.costDollars,
@@ -704,6 +943,19 @@ export const createChatHandler = () => {
                   endpoint,
                   mode,
                   usage: usageCostRecord,
+                  ...(paidDailyFreeAllowanceReservation && {
+                    paidDailyFreeAllowance: {
+                      active: true,
+                      cutOff: state.stoppedDueToBudgetExhaustion,
+                      requestLimit:
+                        paidDailyFreeAllowanceReservation.status.requestLimit,
+                      costLimitDollars:
+                        paidDailyFreeAllowanceReservation.status
+                          .costLimitDollars,
+                      resetTimestamp:
+                        paidDailyFreeAllowanceReservation.status.resetTimestamp,
+                    },
+                  }),
                 });
               } finally {
                 await releaseFreeRunLockOnce();

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -18,6 +18,7 @@ import type {
   SandboxInfo,
   SandboxBootInfo,
 } from "@/types";
+import { isSubscriptionTier } from "@/types";
 import type { ChatSDKError } from "@/lib/errors";
 import type { PostHog } from "posthog-node";
 import { after } from "next/server";
@@ -35,6 +36,12 @@ import {
   getProviderStatusCode,
   type ProviderErrorCategory,
 } from "@/lib/utils/error-utils";
+import {
+  getLimitPressureContext,
+  getLimitTypeForCapReason,
+  isPaidMonthlyCapHitReason,
+  type LimitCapReason,
+} from "@/lib/limit-pressure";
 
 export interface ChatLoggerConfig {
   chatId: string;
@@ -119,6 +126,15 @@ const COMPACT_CHAT_ERROR_METADATA_KEYS = [
   "max_tokens",
   "file_ids_count",
   "largest_file_token",
+  "capReason",
+  "limitType",
+  "costGuardrail",
+  "paidMonthlyExhaustion",
+  "upgradeAvailable",
+  "addCreditAvailable",
+  "primaryCta",
+  "eligibleCtas",
+  "resetTimestamp",
 ] as const;
 
 const compactChatErrorMetadata = (
@@ -455,13 +471,28 @@ export function createChatLogger(config: ChatLoggerConfig) {
 
       if (error.type === "rate_limit" && subscription) {
         const capReason =
-          (error.metadata?.capReason as string | undefined) ?? "unknown";
+          (error.metadata?.capReason as LimitCapReason | undefined) ??
+          "unknown";
         const resetTimestamp = error.metadata?.resetTimestamp as
           | number
           | undefined;
-        const limitType = capReason.includes("daily")
-          ? "daily_requests"
-          : "monthly";
+        const subscriptionTier = isSubscriptionTier(subscription)
+          ? subscription
+          : undefined;
+        const pressure = subscriptionTier
+          ? getLimitPressureContext({
+              subscription: subscriptionTier,
+              capReason,
+            })
+          : {
+              limitType: getLimitTypeForCapReason(capReason),
+              costGuardrail: false,
+              paidMonthlyExhaustion: false,
+              upgradeAvailable: false,
+              addCreditAvailable: false,
+              primaryCta: undefined,
+              eligibleCtas: [],
+            };
 
         phLogger.event(
           PAID_FUNNEL_EVENTS.limitHit,
@@ -469,10 +500,18 @@ export function createChatLogger(config: ChatLoggerConfig) {
             userId,
             subscription_tier: subscription,
             mode,
-            limit_type: limitType,
+            limit_type: pressure.limitType,
             cap_reason: capReason,
             monthly_remaining_percent: monthlyRemainingPercent,
             reset_timestamp: resetTimestamp,
+            cost_guardrail: pressure.costGuardrail,
+            paid_monthly_exhaustion: pressure.paidMonthlyExhaustion,
+            upgrade_available: pressure.upgradeAvailable,
+            add_credit_available: pressure.addCreditAvailable,
+            primary_cta: pressure.primaryCta,
+            eligible_ctas: pressure.eligibleCtas,
+            chat_id: config.chatId,
+            endpoint: config.endpoint,
             $set: {
               subscription_tier: subscription,
               last_limit_hit_at: new Date().toISOString(),
@@ -487,16 +526,26 @@ export function createChatLogger(config: ChatLoggerConfig) {
       if (
         error.type === "rate_limit" &&
         subscription &&
+        isSubscriptionTier(subscription) &&
         subscription !== "free"
       ) {
         const capReason =
-          (error.metadata?.capReason as string | undefined) ?? "unknown";
+          (error.metadata?.capReason as LimitCapReason | undefined) ??
+          "unknown";
+        if (!isPaidMonthlyCapHitReason(capReason)) return;
+        const pressure = getLimitPressureContext({
+          subscription,
+          capReason,
+        });
         phLogger.event("monthly_cap_hit", {
           userId,
           subscription,
           mode,
           cap_reason: capReason,
           monthly_remaining_percent: monthlyRemainingPercent,
+          cost_guardrail: pressure.costGuardrail,
+          primary_cta: pressure.primaryCta,
+          eligible_ctas: pressure.eligibleCtas,
           chat_id: config.chatId,
           endpoint: config.endpoint,
           $set: {

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -135,6 +135,7 @@ const COMPACT_CHAT_ERROR_METADATA_KEYS = [
   "primaryCta",
   "eligibleCtas",
   "resetTimestamp",
+  "paidDailyFreeAllowance",
 ] as const;
 
 const compactChatErrorMetadata = (
@@ -493,6 +494,11 @@ export function createChatLogger(config: ChatLoggerConfig) {
               primaryCta: undefined,
               eligibleCtas: [],
             };
+        const paidDailyFreeAllowance =
+          error.metadata?.paidDailyFreeAllowance &&
+          typeof error.metadata.paidDailyFreeAllowance === "object"
+            ? (error.metadata.paidDailyFreeAllowance as Record<string, unknown>)
+            : undefined;
 
         phLogger.event(
           PAID_FUNNEL_EVENTS.limitHit,
@@ -510,6 +516,20 @@ export function createChatLogger(config: ChatLoggerConfig) {
             add_credit_available: pressure.addCreditAvailable,
             primary_cta: pressure.primaryCta,
             eligible_ctas: pressure.eligibleCtas,
+            paid_daily_free_allowance_available:
+              paidDailyFreeAllowance?.available,
+            paid_daily_free_allowance_unavailable_reason:
+              paidDailyFreeAllowance?.unavailableReason,
+            paid_daily_free_allowance_requests_remaining:
+              paidDailyFreeAllowance?.requestsRemaining,
+            paid_daily_free_allowance_request_limit:
+              paidDailyFreeAllowance?.requestLimit,
+            paid_daily_free_allowance_cost_remaining_dollars:
+              paidDailyFreeAllowance?.costRemainingDollars,
+            paid_daily_free_allowance_cost_limit_dollars:
+              paidDailyFreeAllowance?.costLimitDollars,
+            paid_daily_free_allowance_rollout_percent:
+              paidDailyFreeAllowance?.rolloutPercent,
             chat_id: config.chatId,
             endpoint: config.endpoint,
             $set: {
@@ -785,6 +805,7 @@ export function captureUsageCost({
   endpoint,
   mode,
   usage,
+  paidDailyFreeAllowance,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -794,6 +815,13 @@ export function captureUsageCost({
   endpoint: "/api/chat" | "/api/agent-long";
   mode: ChatMode;
   usage: UsageCostRecord;
+  paidDailyFreeAllowance?: {
+    active: boolean;
+    cutOff?: boolean;
+    requestLimit?: number;
+    costLimitDollars?: number;
+    resetTimestamp?: number;
+  };
 }) {
   if (!posthog) return;
   posthog.capture({
@@ -818,6 +846,18 @@ export function captureUsageCost({
       cache_read_tokens: usage.cacheReadTokens ?? 0,
       cache_write_tokens: usage.cacheWriteTokens ?? 0,
       cost_source: usage.costSource,
+      ...(paidDailyFreeAllowance?.active && {
+        limit_rescue_type: "paid_daily_free_allowance",
+        paid_daily_free_allowance_active: true,
+        paid_daily_free_allowance_cut_off:
+          paidDailyFreeAllowance.cutOff === true,
+        paid_daily_free_allowance_request_limit:
+          paidDailyFreeAllowance.requestLimit,
+        paid_daily_free_allowance_cost_limit_dollars:
+          paidDailyFreeAllowance.costLimitDollars,
+        paid_daily_free_allowance_reset_timestamp:
+          paidDailyFreeAllowance.resetTimestamp,
+      }),
       $set: {
         subscription_tier: subscription,
         last_usage_cost_at: new Date().toISOString(),

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -48,6 +48,7 @@ import { generateNotesSection } from "@/lib/system-prompt/notes";
 import { logger } from "@/lib/logger";
 import { UsageTracker } from "@/lib/usage-tracker";
 import { ChatSDKError } from "@/lib/errors";
+import type { LimitCapReason } from "@/lib/limit-pressure";
 import {
   getExtraUsageBalance,
   getTeamExtraUsageState,
@@ -179,6 +180,7 @@ export function sendRateLimitWarnings(
           monthlyLimitPoints: rateLimitInfo.monthly.limit,
           resetTime: rateLimitInfo.monthly.resetTime,
           subscription,
+          capReason: "monthly_near_limit",
         });
       }
     }
@@ -204,6 +206,8 @@ export interface TokenBucketEmitContext {
   midStream?: boolean;
   /** Set when the response was cut off because the bucket hit 0. */
   cutOff?: boolean;
+  /** Monetization/guardrail reason that should drive the client CTA. */
+  capReason?: LimitCapReason;
 }
 
 export function emitTokenBucketThresholdWarning(
@@ -223,6 +227,7 @@ export function emitTokenBucketThresholdWarning(
     usedDollars:
       Math.round((ctx.projectedUsedPoints / POINTS_PER_DOLLAR) * 100) / 100,
     limitDollars: ctx.monthlyLimitPoints / POINTS_PER_DOLLAR,
+    ...(ctx.capReason ? { capReason: ctx.capReason } : {}),
     ...(ctx.midStream ? { midStream: true } : {}),
     ...(ctx.cutOff ? { cutOff: true } : {}),
   });
@@ -945,6 +950,15 @@ export async function buildExtraUsageConfig(args: {
         hasBalance: state.balanceDollars > 0,
         balanceDollars: state.balanceDollars,
         autoReloadEnabled: state.autoReloadEnabled,
+        ...(state.monthlyCapDollars !== undefined && {
+          monthlyCapDollars: state.monthlyCapDollars,
+        }),
+        ...(state.monthlySpentDollars !== undefined && {
+          monthlySpentDollars: state.monthlySpentDollars,
+        }),
+        ...(state.monthlyRemainingDollars !== undefined && {
+          monthlyRemainingDollars: state.monthlyRemainingDollars,
+        }),
       };
     }
     return undefined;
@@ -967,6 +981,15 @@ export async function buildExtraUsageConfig(args: {
       hasBalance: balanceInfo.balanceDollars > 0,
       balanceDollars: balanceInfo.balanceDollars,
       autoReloadEnabled: balanceInfo.autoReloadEnabled,
+      ...(balanceInfo.monthlyCapDollars !== undefined && {
+        monthlyCapDollars: balanceInfo.monthlyCapDollars,
+      }),
+      ...(balanceInfo.monthlySpentDollars !== undefined && {
+        monthlySpentDollars: balanceInfo.monthlySpentDollars,
+      }),
+      ...(balanceInfo.monthlyRemainingDollars !== undefined && {
+        monthlyRemainingDollars: balanceInfo.monthlyRemainingDollars,
+      }),
     };
   }
   return undefined;

--- a/lib/api/paid-daily-free-allowance-rescue.ts
+++ b/lib/api/paid-daily-free-allowance-rescue.ts
@@ -1,0 +1,113 @@
+import "server-only";
+
+import type { BudgetSnapshot } from "@/lib/chat/budget-monitor";
+import type { ChatSDKError } from "@/lib/errors";
+import type { LimitCapReason } from "@/lib/limit-pressure";
+import {
+  PAID_FUNNEL_EVENTS,
+  paidFunnelProperties,
+} from "@/lib/analytics/paid-funnel";
+import { phLogger } from "@/lib/posthog/server";
+import type { PaidDailyFreeAllowanceReservation } from "@/lib/rate-limit";
+import type { ChatMode, RateLimitInfo, SubscriptionTier } from "@/types";
+
+export const PAID_DAILY_FREE_ALLOWANCE_MODEL = "ask-model-free";
+
+type PaidDailyFreeAllowanceEvent =
+  | typeof PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceStarted
+  | typeof PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceSucceeded
+  | typeof PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceBlocked
+  | typeof PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceCutOff;
+
+export function getRateLimitErrorCapReason(
+  error: ChatSDKError,
+): LimitCapReason | undefined {
+  return typeof error.metadata?.capReason === "string"
+    ? error.metadata.capReason
+    : undefined;
+}
+
+export function createPaidDailyFreeAllowanceRateLimitInfo(
+  reservation: PaidDailyFreeAllowanceReservation,
+): RateLimitInfo {
+  return {
+    remaining: 0,
+    resetTime: reservation.status.resetTime,
+    limit: 0,
+    ...(reservation.status.rateLimitSkipped && { rateLimitSkipped: true }),
+  };
+}
+
+export function createPaidDailyFreeAllowanceBudgetSnapshot(
+  reservation: PaidDailyFreeAllowanceReservation,
+): BudgetSnapshot | null {
+  if (reservation.status.rateLimitSkipped) return null;
+
+  return {
+    monthlyLimitPoints: reservation.status.costLimitPoints,
+    monthlyRemainingAtStart: reservation.status.costRemainingPoints,
+    monthlyResetTime: reservation.status.resetTime,
+    extraUsageBalanceAtStart: 0,
+    extraUsageAutoReload: false,
+    extraUsageOverflowAllowed: false,
+    capReasonOnExhaustion: "paid_daily_free_allowance_cut_off",
+  };
+}
+
+export function capturePaidDailyFreeAllowanceServerEvent({
+  event,
+  userId,
+  subscription,
+  mode,
+  chatId,
+  endpoint,
+  reservation,
+  extra,
+}: {
+  event: PaidDailyFreeAllowanceEvent;
+  userId: string;
+  subscription: SubscriptionTier;
+  mode: ChatMode;
+  chatId: string;
+  endpoint: "/api/chat";
+  reservation?: PaidDailyFreeAllowanceReservation;
+  extra?: Record<string, unknown>;
+}) {
+  const status = reservation?.status;
+  phLogger.event(
+    event,
+    paidFunnelProperties({
+      userId,
+      subscription_tier: subscription,
+      mode,
+      chat_id: chatId,
+      endpoint,
+      limit_rescue_type: "paid_daily_free_allowance",
+      paid_daily_free_allowance_request_limit: status?.requestLimit,
+      paid_daily_free_allowance_requests_remaining: status?.requestsRemaining,
+      paid_daily_free_allowance_cost_limit_dollars: status?.costLimitDollars,
+      paid_daily_free_allowance_cost_remaining_dollars:
+        status?.costRemainingDollars,
+      paid_daily_free_allowance_reset_timestamp: status?.resetTimestamp,
+      paid_daily_free_allowance_unavailable_reason:
+        status?.unavailableReason ?? reservation?.blockReason,
+      ...extra,
+      $set: {
+        subscription_tier: subscription,
+      },
+    }),
+  );
+}
+
+export function createPaidDailyFreeAllowanceUsageLogContext(
+  reservation: PaidDailyFreeAllowanceReservation,
+  cutOff: boolean,
+) {
+  return {
+    active: true,
+    cutOff,
+    requestLimit: reservation.status.requestLimit,
+    costLimitDollars: reservation.status.costLimitDollars,
+    resetTimestamp: reservation.status.resetTimestamp,
+  };
+}

--- a/lib/chat/__tests__/budget-monitor.test.ts
+++ b/lib/chat/__tests__/budget-monitor.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import {
+  BudgetMonitor,
+  captureBudgetSnapshot,
+  type BudgetSnapshot,
+} from "../budget-monitor";
+import type { ExtraUsageConfig, RateLimitInfo } from "@/types";
+
+const makeWriter = () =>
+  ({
+    write: jest.fn(),
+  }) as any;
+
+const baseSnapshot: BudgetSnapshot = {
+  monthlyLimitPoints: 100,
+  monthlyRemainingAtStart: 10,
+  monthlyResetTime: new Date("2026-06-30T00:00:00.000Z"),
+  extraUsageBalanceAtStart: 100,
+  extraUsageAutoReload: true,
+};
+
+describe("BudgetMonitor", () => {
+  it("aborts with extra_usage_cap when overflow would exceed the monthly extra-usage cap", () => {
+    const writer = makeWriter();
+    const monitor = new BudgetMonitor(
+      {
+        ...baseSnapshot,
+        extraUsageMonthlyRemainingAtStart: 0,
+      },
+      writer,
+      "pro",
+    );
+
+    const decision = monitor.checkAfterStep(0.002);
+
+    expect(decision).toBe("abort");
+    expect(writer.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "data-rate-limit-warning",
+        data: expect.objectContaining({
+          warningType: "token-bucket",
+          cutOff: true,
+          capReason: "extra_usage_cap",
+        }),
+      }),
+    );
+  });
+
+  it("continues into extra usage when balance and monthly cap remaining cover overflow", () => {
+    const writer = makeWriter();
+    const monitor = new BudgetMonitor(
+      {
+        ...baseSnapshot,
+        extraUsageAutoReload: false,
+        extraUsageBalanceAtStart: 1,
+        extraUsageMonthlyRemainingAtStart: 1,
+      },
+      writer,
+      "pro",
+    );
+
+    const decision = monitor.checkAfterStep(0.002);
+
+    expect(decision).toBe("continue");
+    expect(writer.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "data-rate-limit-warning",
+        data: expect.objectContaining({
+          warningType: "extra-usage-active",
+          capReason: "extra_usage_active",
+        }),
+      }),
+    );
+  });
+});
+
+describe("captureBudgetSnapshot", () => {
+  it("includes monthly extra-usage remaining for mid-stream guardrails", () => {
+    const rateLimitInfo: RateLimitInfo = {
+      remaining: 10,
+      resetTime: new Date("2026-06-30T00:00:00.000Z"),
+      limit: 100,
+      monthly: {
+        remaining: 10,
+        limit: 100,
+        resetTime: new Date("2026-06-30T00:00:00.000Z"),
+      },
+    };
+    const extraUsageConfig: ExtraUsageConfig = {
+      enabled: true,
+      hasBalance: true,
+      balanceDollars: 25,
+      autoReloadEnabled: true,
+      monthlyRemainingDollars: 3,
+    };
+
+    expect(
+      captureBudgetSnapshot({
+        rateLimitInfo,
+        extraUsageConfig,
+        subscription: "pro",
+      }),
+    ).toMatchObject({
+      extraUsageBalanceAtStart: 25,
+      extraUsageAutoReload: true,
+      extraUsageMonthlyRemainingAtStart: 3,
+    });
+  });
+});

--- a/lib/chat/__tests__/budget-monitor.test.ts
+++ b/lib/chat/__tests__/budget-monitor.test.ts
@@ -72,6 +72,38 @@ describe("BudgetMonitor", () => {
       }),
     );
   });
+
+  it("aborts with the paid daily free allowance cap reason when overflow is disabled", () => {
+    const writer = makeWriter();
+    const monitor = new BudgetMonitor(
+      {
+        monthlyLimitPoints: 1000,
+        monthlyRemainingAtStart: 100,
+        monthlyResetTime: new Date("2026-06-12T00:00:00.000Z"),
+        extraUsageBalanceAtStart: 0,
+        extraUsageAutoReload: false,
+        extraUsageOverflowAllowed: false,
+        capReasonOnExhaustion: "paid_daily_free_allowance_cut_off",
+      },
+      writer,
+      "pro",
+    );
+
+    const decision = monitor.checkAfterStep(0.02);
+
+    expect(decision).toBe("abort");
+    expect(writer.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "data-rate-limit-warning",
+        data: expect.objectContaining({
+          warningType: "token-bucket",
+          cutOff: true,
+          capReason: "paid_daily_free_allowance_cut_off",
+          limitDollars: 0.1,
+        }),
+      }),
+    );
+  });
 });
 
 describe("captureBudgetSnapshot", () => {

--- a/lib/chat/budget-monitor.ts
+++ b/lib/chat/budget-monitor.ts
@@ -12,6 +12,7 @@ import {
   type TokenBucketEmitContext,
 } from "@/lib/api/chat-stream-helpers";
 import { writeRateLimitWarning } from "@/lib/utils/stream-writer-utils";
+import type { LimitCapReason } from "@/lib/limit-pressure";
 
 // 50% is intentionally omitted: at the halfway mark there's no actionable
 // signal for the user, so an in-product banner is noise. The ladder matches
@@ -26,6 +27,7 @@ export interface BudgetSnapshot {
   monthlyResetTime: Date;
   extraUsageBalanceAtStart: number;
   extraUsageAutoReload: boolean;
+  extraUsageMonthlyRemainingAtStart?: number;
 }
 
 /**
@@ -55,6 +57,8 @@ export function captureBudgetSnapshot(args: {
     monthlyResetTime: monthlyResetTime!,
     extraUsageBalanceAtStart: extraUsageConfig?.balanceDollars ?? 0,
     extraUsageAutoReload: extraUsageConfig?.autoReloadEnabled ?? false,
+    extraUsageMonthlyRemainingAtStart:
+      extraUsageConfig?.monthlyRemainingDollars,
   };
 }
 
@@ -105,9 +109,15 @@ export class BudgetMonitor {
         const overflowDollars =
           Math.max(0, projectedUsedPoints - snapshot.monthlyLimitPoints) /
           POINTS_PER_DOLLAR;
-        const hasExtraCushion =
+        const guardrailRemaining = snapshot.extraUsageMonthlyRemainingAtStart;
+        const guardrailAllowsOverflow =
+          guardrailRemaining === undefined ||
+          overflowDollars <= guardrailRemaining;
+        const balanceAllowsOverflow =
           snapshot.extraUsageAutoReload ||
-          snapshot.extraUsageBalanceAtStart - overflowDollars > 0;
+          snapshot.extraUsageBalanceAtStart >= overflowDollars;
+        const hasExtraCushion =
+          guardrailAllowsOverflow && balanceAllowsOverflow;
 
         if (hasExtraCushion) {
           if (threshold <= this.highestThresholdEmitted) {
@@ -119,13 +129,21 @@ export class BudgetMonitor {
             bucketType: "monthly",
             resetTime: snapshot.monthlyResetTime.toISOString(),
             subscription: this.subscription,
+            capReason: "extra_usage_active",
             midStream: true,
           });
         } else {
+          const capReason: LimitCapReason =
+            this.subscription === "free"
+              ? "free_monthly_exhausted"
+              : !guardrailAllowsOverflow
+                ? "extra_usage_cap"
+                : "monthly_exhausted";
           this.emit({
             usedPercent: 100,
             projectedUsedPoints: snapshot.monthlyLimitPoints,
             cutOff: true,
+            capReason,
           });
           decision = "abort";
         }
@@ -145,6 +163,7 @@ export class BudgetMonitor {
     usedPercent: number;
     projectedUsedPoints: number;
     cutOff?: boolean;
+    capReason?: LimitCapReason;
   }): void {
     const ctx: TokenBucketEmitContext = {
       usedPercent: args.usedPercent,
@@ -154,6 +173,7 @@ export class BudgetMonitor {
       subscription: this.subscription,
       midStream: true,
       cutOff: args.cutOff,
+      capReason: args.capReason,
     };
     emitTokenBucketThresholdWarning(this.writer, ctx);
   }

--- a/lib/chat/budget-monitor.ts
+++ b/lib/chat/budget-monitor.ts
@@ -28,6 +28,8 @@ export interface BudgetSnapshot {
   extraUsageBalanceAtStart: number;
   extraUsageAutoReload: boolean;
   extraUsageMonthlyRemainingAtStart?: number;
+  capReasonOnExhaustion?: LimitCapReason;
+  extraUsageOverflowAllowed?: boolean;
 }
 
 /**
@@ -117,7 +119,9 @@ export class BudgetMonitor {
           snapshot.extraUsageAutoReload ||
           snapshot.extraUsageBalanceAtStart >= overflowDollars;
         const hasExtraCushion =
-          guardrailAllowsOverflow && balanceAllowsOverflow;
+          snapshot.extraUsageOverflowAllowed !== false &&
+          guardrailAllowsOverflow &&
+          balanceAllowsOverflow;
 
         if (hasExtraCushion) {
           if (threshold <= this.highestThresholdEmitted) {
@@ -134,11 +138,12 @@ export class BudgetMonitor {
           });
         } else {
           const capReason: LimitCapReason =
-            this.subscription === "free"
+            snapshot.capReasonOnExhaustion ??
+            (this.subscription === "free"
               ? "free_monthly_exhausted"
               : !guardrailAllowsOverflow
                 ? "extra_usage_cap"
-                : "monthly_exhausted";
+                : "monthly_exhausted");
           this.emit({
             usedPercent: 100,
             projectedUsedPoints: snapshot.monthlyLimitPoints,

--- a/lib/extra-usage.ts
+++ b/lib/extra-usage.ts
@@ -53,6 +53,9 @@ export interface ExtraUsageBalance {
   autoReloadThresholdDollars?: number;
   autoReloadThresholdPoints?: number;
   autoReloadAmountDollars?: number;
+  monthlyCapDollars?: number;
+  monthlySpentDollars?: number;
+  monthlyRemainingDollars?: number;
 }
 
 export interface DeductBalanceResult {
@@ -110,6 +113,9 @@ export async function getExtraUsageBalance(
       autoReloadThresholdDollars: settings.autoReloadThresholdDollars,
       autoReloadThresholdPoints: settings.autoReloadThresholdPoints,
       autoReloadAmountDollars: settings.autoReloadAmountDollars,
+      monthlyCapDollars: settings.monthlyCapDollars,
+      monthlySpentDollars: settings.monthlySpentDollars,
+      monthlyRemainingDollars: settings.monthlyRemainingDollars,
     };
   } catch (error) {
     logExtraUsageConvexFailure({
@@ -277,6 +283,11 @@ export interface TeamExtraUsageState {
   balancePoints: number;
   autoReloadEnabled: boolean;
   memberDisabled: boolean;
+  monthlyCapDollars?: number;
+  monthlySpentDollars?: number;
+  memberMonthlyLimitDollars?: number;
+  memberMonthlySpentDollars?: number;
+  monthlyRemainingDollars?: number;
 }
 
 /**
@@ -304,6 +315,11 @@ export async function getTeamExtraUsageState(
       balancePoints: state.balancePoints,
       autoReloadEnabled: state.autoReloadEnabled,
       memberDisabled: state.memberDisabled,
+      monthlyCapDollars: state.monthlyCapDollars,
+      monthlySpentDollars: state.monthlySpentDollars,
+      memberMonthlyLimitDollars: state.memberMonthlyLimitDollars,
+      memberMonthlySpentDollars: state.memberMonthlySpentDollars,
+      monthlyRemainingDollars: state.monthlyRemainingDollars,
     };
   } catch (error) {
     logExtraUsageConvexFailure({

--- a/lib/limit-pressure.ts
+++ b/lib/limit-pressure.ts
@@ -10,6 +10,8 @@ export type LimitCapReason =
   | "team_pool_disabled"
   | "auto_reload_failed"
   | "billing_unavailable"
+  | "paid_daily_free_allowance_exhausted"
+  | "paid_daily_free_allowance_cut_off"
   | "monthly_near_limit"
   | "extra_usage_active"
   | (string & {});
@@ -20,7 +22,8 @@ export type LimitType =
   | "monthly"
   | "extra_usage"
   | "team_extra_usage"
-  | "billing";
+  | "billing"
+  | "paid_daily_free_allowance";
 
 export type LimitCta =
   | "upgrade_plan"
@@ -60,6 +63,9 @@ export function getLimitTypeForCapReason(
   capReason: LimitCapReason | undefined,
 ): LimitType {
   if (!capReason) return "monthly";
+  if (capReason.startsWith("paid_daily_free_allowance")) {
+    return "paid_daily_free_allowance";
+  }
   if (capReason.includes("daily")) return "daily_requests";
   if (capReason === "free_monthly_exhausted") return "free_monthly";
   if (

--- a/lib/limit-pressure.ts
+++ b/lib/limit-pressure.ts
@@ -1,0 +1,196 @@
+import type { SubscriptionTier } from "@/types";
+
+export type LimitCapReason =
+  | "daily_requests_exhausted"
+  | "free_monthly_exhausted"
+  | "monthly_exhausted"
+  | "extra_usage_cap"
+  | "team_member_cap"
+  | "team_member_disabled"
+  | "team_pool_disabled"
+  | "auto_reload_failed"
+  | "billing_unavailable"
+  | "monthly_near_limit"
+  | "extra_usage_active"
+  | (string & {});
+
+export type LimitType =
+  | "daily_requests"
+  | "free_monthly"
+  | "monthly"
+  | "extra_usage"
+  | "team_extra_usage"
+  | "billing";
+
+export type LimitCta =
+  | "upgrade_plan"
+  | "add_credits"
+  | "increase_spending_limit"
+  | "update_payment_method"
+  | "open_team_extra_usage";
+
+export type ExtraUsageLimitCta = {
+  label: string;
+  analyticsText: string;
+  settingsTab: "Extra Usage" | "Usage";
+};
+
+const UPGRADABLE_TIERS = new Set<SubscriptionTier>(["free", "pro", "pro-plus"]);
+
+const DIRECT_EXTRA_USAGE_REASONS = new Set<string>([
+  "monthly_exhausted",
+  "monthly_near_limit",
+]);
+
+const MONTHLY_CAP_HIT_REASONS = new Set<string>([
+  "monthly_exhausted",
+  "extra_usage_cap",
+  "team_member_cap",
+]);
+
+const COST_GUARDRAIL_REASONS = new Set<string>([
+  "extra_usage_cap",
+  "team_member_cap",
+  "team_member_disabled",
+  "team_pool_disabled",
+  "auto_reload_failed",
+]);
+
+export function getLimitTypeForCapReason(
+  capReason: LimitCapReason | undefined,
+): LimitType {
+  if (!capReason) return "monthly";
+  if (capReason.includes("daily")) return "daily_requests";
+  if (capReason === "free_monthly_exhausted") return "free_monthly";
+  if (
+    capReason === "team_member_cap" ||
+    capReason === "team_member_disabled" ||
+    capReason === "team_pool_disabled"
+  ) {
+    return "team_extra_usage";
+  }
+  if (
+    capReason === "extra_usage_cap" ||
+    capReason === "auto_reload_failed" ||
+    capReason === "extra_usage_active"
+  ) {
+    return "extra_usage";
+  }
+  if (capReason === "billing_unavailable") return "billing";
+  return "monthly";
+}
+
+export function isCostGuardrailCapReason(
+  capReason: LimitCapReason | undefined,
+): boolean {
+  return !!capReason && COST_GUARDRAIL_REASONS.has(capReason);
+}
+
+export function isPaidMonthlyCapHitReason(
+  capReason: LimitCapReason | undefined,
+): boolean {
+  return !!capReason && MONTHLY_CAP_HIT_REASONS.has(capReason);
+}
+
+export function isPaidMonthlyExhaustionReason(
+  capReason: LimitCapReason | undefined,
+): boolean {
+  return capReason === "monthly_exhausted";
+}
+
+export function shouldShowUpgradeCta(args: {
+  subscription: SubscriptionTier;
+  capReason?: LimitCapReason;
+}): boolean {
+  const { subscription, capReason } = args;
+  if (!UPGRADABLE_TIERS.has(subscription)) return false;
+  if (subscription === "free") return true;
+
+  return !capReason || DIRECT_EXTRA_USAGE_REASONS.has(capReason);
+}
+
+export function getExtraUsageLimitCta(args: {
+  subscription: SubscriptionTier;
+  capReason?: LimitCapReason;
+}): ExtraUsageLimitCta | null {
+  const { subscription, capReason } = args;
+  if (subscription === "free") return null;
+
+  if (capReason === "extra_usage_cap") {
+    return {
+      label: "Increase Limit",
+      analyticsText: "Increase Limit",
+      settingsTab: "Extra Usage",
+    };
+  }
+
+  if (capReason === "auto_reload_failed") {
+    return {
+      label: "Update Payment",
+      analyticsText: "Update Payment",
+      settingsTab: "Extra Usage",
+    };
+  }
+
+  if (capReason === "team_pool_disabled") {
+    return {
+      label: "Team Usage",
+      analyticsText: "Open Team Usage",
+      settingsTab: "Extra Usage",
+    };
+  }
+
+  if (capReason === "team_member_cap" || capReason === "team_member_disabled") {
+    return null;
+  }
+
+  if (capReason === "billing_unavailable") {
+    return null;
+  }
+
+  return {
+    label: "Add Credits",
+    analyticsText: "Add Credits",
+    settingsTab: "Extra Usage",
+  };
+}
+
+export function getEligibleLimitCtas(args: {
+  subscription: SubscriptionTier;
+  capReason?: LimitCapReason;
+}): LimitCta[] {
+  const ctas: LimitCta[] = [];
+  const extraUsageCta = getExtraUsageLimitCta(args);
+  if (extraUsageCta?.analyticsText === "Add Credits") {
+    ctas.push("add_credits");
+  } else if (extraUsageCta?.analyticsText === "Increase Limit") {
+    ctas.push("increase_spending_limit");
+  } else if (extraUsageCta?.analyticsText === "Update Payment") {
+    ctas.push("update_payment_method");
+  } else if (extraUsageCta?.analyticsText === "Open Team Usage") {
+    ctas.push("open_team_extra_usage");
+  }
+
+  if (shouldShowUpgradeCta(args)) ctas.push("upgrade_plan");
+
+  return ctas;
+}
+
+export function getLimitPressureContext(args: {
+  subscription: SubscriptionTier;
+  capReason?: LimitCapReason;
+}) {
+  const { subscription, capReason } = args;
+  const eligibleCtas = getEligibleLimitCtas(args);
+
+  return {
+    limitType: getLimitTypeForCapReason(capReason),
+    costGuardrail: isCostGuardrailCapReason(capReason),
+    paidMonthlyExhaustion:
+      subscription !== "free" && isPaidMonthlyExhaustionReason(capReason),
+    upgradeAvailable: eligibleCtas.includes("upgrade_plan"),
+    addCreditAvailable: eligibleCtas.includes("add_credits"),
+    primaryCta: eligibleCtas[0],
+    eligibleCtas,
+  };
+}

--- a/lib/limit-pressure.ts
+++ b/lib/limit-pressure.ts
@@ -1,5 +1,7 @@
 import type { SubscriptionTier } from "@/types";
 
+export const PAID_DAILY_FREE_ASK_CTA_TEXT = "Try free Ask";
+
 export type LimitCapReason =
   | "daily_requests_exhausted"
   | "free_monthly_exhausted"

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -52,6 +52,9 @@ export interface ChatWideEvent {
     enabled?: boolean;
     has_balance?: boolean;
     balance_dollars?: number;
+    monthly_cap_dollars?: number;
+    monthly_spent_dollars?: number;
+    monthly_remaining_dollars?: number;
     auto_reload_enabled?: boolean;
   };
 
@@ -290,6 +293,9 @@ export class WideEventBuilder {
         enabled: config.enabled,
         has_balance: config.hasBalance,
         balance_dollars: config.balanceDollars,
+        monthly_cap_dollars: config.monthlyCapDollars,
+        monthly_spent_dollars: config.monthlySpentDollars,
+        monthly_remaining_dollars: config.monthlyRemainingDollars,
         auto_reload_enabled: config.autoReloadEnabled,
       };
     }

--- a/lib/rate-limit/__tests__/paid-daily-free-allowance.test.ts
+++ b/lib/rate-limit/__tests__/paid-daily-free-allowance.test.ts
@@ -1,0 +1,226 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+describe("paid daily free allowance", () => {
+  const mockCreateRedisClient = jest.fn();
+  const mockIsFeatureEnabled = jest.fn();
+  const redisStore = new Map<string, number>();
+  const originalEnv = {
+    rollout: process.env.PAID_DAILY_FREE_ALLOWANCE_ROLLOUT_PERCENT,
+    requests: process.env.PAID_DAILY_FREE_ALLOWANCE_REQUESTS_PER_DAY,
+    cost: process.env.PAID_DAILY_FREE_ALLOWANCE_COST_LIMIT_USD,
+    nodeEnv: process.env.NODE_ENV,
+  };
+
+  const mockRedis = {
+    get: jest.fn(async (key: string) => redisStore.get(key) ?? null),
+    eval: jest.fn(async (_script: string, keys: string[], args: number[]) => {
+      if (keys.length === 2) {
+        const [requestsKey, costKey] = keys;
+        const [requestLimit, costLimit] = args;
+        const requestsUsed = redisStore.get(requestsKey) ?? 0;
+        const costUsed = redisStore.get(costKey) ?? 0;
+        if (requestsUsed >= requestLimit) {
+          return [0, "request_limit_reached", requestsUsed, costUsed];
+        }
+        if (costUsed >= costLimit) {
+          return [0, "cost_limit_reached", requestsUsed, costUsed];
+        }
+        const nextRequests = requestsUsed + 1;
+        redisStore.set(requestsKey, nextRequests);
+        redisStore.set(costKey, costUsed);
+        return [1, "ok", nextRequests, costUsed];
+      }
+
+      const [costKey] = keys;
+      const [costPoints] = args;
+      const nextCost = (redisStore.get(costKey) ?? 0) + costPoints;
+      redisStore.set(costKey, nextCost);
+      return nextCost;
+    }),
+  };
+
+  const getIsolatedModule = () => {
+    let isolatedModule: typeof import("../paid-daily-free-allowance");
+
+    jest.isolateModules(() => {
+      jest.doMock("server-only", () => ({}), { virtual: true });
+      jest.doMock("../redis", () => ({
+        createRedisClient: mockCreateRedisClient,
+      }));
+      jest.doMock("../../auth/feature-flags", () => ({
+        isFeatureEnabled: mockIsFeatureEnabled,
+      }));
+
+      isolatedModule = require("../paid-daily-free-allowance");
+    });
+
+    return isolatedModule!;
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    redisStore.clear();
+    process.env.NODE_ENV = "test";
+    process.env.PAID_DAILY_FREE_ALLOWANCE_ROLLOUT_PERCENT = "100";
+    delete process.env.PAID_DAILY_FREE_ALLOWANCE_REQUESTS_PER_DAY;
+    delete process.env.PAID_DAILY_FREE_ALLOWANCE_COST_LIMIT_USD;
+    mockCreateRedisClient.mockReturnValue(mockRedis);
+    mockIsFeatureEnabled.mockReturnValue(true);
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-06-11T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    if (originalEnv.rollout === undefined) {
+      delete process.env.PAID_DAILY_FREE_ALLOWANCE_ROLLOUT_PERCENT;
+    } else {
+      process.env.PAID_DAILY_FREE_ALLOWANCE_ROLLOUT_PERCENT =
+        originalEnv.rollout;
+    }
+    if (originalEnv.requests === undefined) {
+      delete process.env.PAID_DAILY_FREE_ALLOWANCE_REQUESTS_PER_DAY;
+    } else {
+      process.env.PAID_DAILY_FREE_ALLOWANCE_REQUESTS_PER_DAY =
+        originalEnv.requests;
+    }
+    if (originalEnv.cost === undefined) {
+      delete process.env.PAID_DAILY_FREE_ALLOWANCE_COST_LIMIT_USD;
+    } else {
+      process.env.PAID_DAILY_FREE_ALLOWANCE_COST_LIMIT_USD = originalEnv.cost;
+    }
+    process.env.NODE_ENV = originalEnv.nodeEnv;
+  });
+
+  const eligibleContext = {
+    userId: "user_123",
+    subscription: "pro" as const,
+    mode: "ask" as const,
+    capReason: "monthly_exhausted" as const,
+    hasAttachments: false,
+  };
+
+  it("reports one available paid Ask rescue by default", async () => {
+    const { getPaidDailyFreeAllowanceStatus } = getIsolatedModule();
+
+    const status = await getPaidDailyFreeAllowanceStatus(eligibleContext);
+
+    expect(status).toMatchObject({
+      available: true,
+      requestLimit: 1,
+      requestsUsed: 0,
+      requestsRemaining: 1,
+      costLimitDollars: 0.1,
+      costUsedDollars: 0,
+      costRemainingDollars: 0.1,
+      resetTimestamp: Date.parse("2026-06-12T00:00:00.000Z"),
+    });
+  });
+
+  it("excludes unsupported tiers, agent mode, attachments, and rollout-disabled users", async () => {
+    const { getPaidDailyFreeAllowanceStatus } = getIsolatedModule();
+
+    await expect(
+      getPaidDailyFreeAllowanceStatus({
+        ...eligibleContext,
+        subscription: "free",
+      }),
+    ).resolves.toMatchObject({
+      available: false,
+      unavailableReason: "unsupported_subscription",
+    });
+    await expect(
+      getPaidDailyFreeAllowanceStatus({ ...eligibleContext, mode: "agent" }),
+    ).resolves.toMatchObject({
+      available: false,
+      unavailableReason: "unsupported_mode",
+    });
+    await expect(
+      getPaidDailyFreeAllowanceStatus({
+        ...eligibleContext,
+        hasAttachments: true,
+      }),
+    ).resolves.toMatchObject({
+      available: false,
+      unavailableReason: "attachments_not_supported",
+    });
+
+    mockIsFeatureEnabled.mockReturnValue(false);
+    await expect(
+      getPaidDailyFreeAllowanceStatus(eligibleContext),
+    ).resolves.toMatchObject({
+      available: false,
+      unavailableReason: "rollout_disabled",
+    });
+  });
+
+  it("reserves only the configured number of requests per UTC day", async () => {
+    const { reservePaidDailyFreeAllowanceRequest } = getIsolatedModule();
+
+    await expect(
+      reservePaidDailyFreeAllowanceRequest(eligibleContext),
+    ).resolves.toMatchObject({
+      allowed: true,
+      status: {
+        requestsUsed: 1,
+        requestsRemaining: 0,
+      },
+    });
+    await expect(
+      reservePaidDailyFreeAllowanceRequest(eligibleContext),
+    ).resolves.toMatchObject({
+      allowed: false,
+      blockReason: "request_limit_reached",
+    });
+  });
+
+  it("blocks new rescue requests once recorded cost reaches the daily cap", async () => {
+    const {
+      getPaidDailyFreeAllowanceStatus,
+      recordPaidDailyFreeAllowanceCost,
+    } = getIsolatedModule();
+
+    await recordPaidDailyFreeAllowanceCost("user_123", 0.11);
+
+    await expect(
+      getPaidDailyFreeAllowanceStatus(eligibleContext),
+    ).resolves.toMatchObject({
+      available: false,
+      unavailableReason: "cost_limit_reached",
+      costUsedDollars: 0.11,
+      costRemainingDollars: 0,
+    });
+  });
+
+  it("keys counters to the UTC date and resets at midnight UTC", async () => {
+    const {
+      getPaidDailyFreeAllowanceKeys,
+      getPaidDailyFreeAllowanceStatus,
+      reservePaidDailyFreeAllowanceRequest,
+    } = getIsolatedModule();
+
+    jest.setSystemTime(new Date("2026-06-11T23:59:00.000Z"));
+    await reservePaidDailyFreeAllowanceRequest(eligibleContext);
+    const june11Keys = getPaidDailyFreeAllowanceKeys("user_123", "2026-06-11");
+    expect(redisStore.get(june11Keys.requestsKey)).toBe(1);
+
+    jest.setSystemTime(new Date("2026-06-12T00:00:01.000Z"));
+    const june12Status = await getPaidDailyFreeAllowanceStatus(eligibleContext);
+    const june12Keys = getPaidDailyFreeAllowanceKeys("user_123", "2026-06-12");
+
+    expect(june12Status).toMatchObject({
+      available: true,
+      requestsUsed: 0,
+      resetTimestamp: Date.parse("2026-06-13T00:00:00.000Z"),
+    });
+    expect(redisStore.get(june12Keys.requestsKey)).toBeUndefined();
+  });
+});

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -173,6 +173,13 @@ describe("token-bucket async functions", () => {
         expect.fail("Should have thrown");
       } catch (error: any) {
         expect(error.cause).toContain("usage limit");
+        expect(error.metadata).toMatchObject({
+          capReason: "monthly_exhausted",
+          paidMonthlyExhaustion: true,
+          addCreditAvailable: true,
+          primaryCta: "add_credits",
+          eligibleCtas: ["add_credits", "upgrade_plan"],
+        });
       }
     });
 
@@ -258,6 +265,13 @@ describe("token-bucket async functions", () => {
         expect.fail("Should have thrown");
       } catch (error: any) {
         expect(error.cause).toContain("monthly extra usage spending limit");
+        expect(error.metadata).toMatchObject({
+          capReason: "extra_usage_cap",
+          costGuardrail: true,
+          addCreditAvailable: false,
+          primaryCta: "increase_spending_limit",
+          eligibleCtas: ["increase_spending_limit"],
+        });
       }
     });
 

--- a/lib/rate-limit/free-monthly-cost.ts
+++ b/lib/rate-limit/free-monthly-cost.ts
@@ -2,6 +2,7 @@ import { ChatSDKError } from "@/lib/errors";
 import { getFreeMonthlyCostLimitDollars } from "./free-config";
 import { POINTS_PER_DOLLAR } from "./token-bucket";
 import { createRedisClient } from "./redis";
+import { getLimitPressureContext } from "@/lib/limit-pressure";
 
 const RECORD_FREE_MONTHLY_COST_SCRIPT = `
 local key = KEYS[1]
@@ -93,6 +94,10 @@ export async function checkFreeMonthlyCostLimit(
       resetTimestamp: reset,
       subscription: "free",
       capReason: "free_monthly_exhausted",
+      ...getLimitPressureContext({
+        subscription: "free",
+        capReason: "free_monthly_exhausted",
+      }),
     });
   }
 

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -61,6 +61,22 @@ export {
   checkFreeMonthlyCostLimit,
   recordFreeMonthlyCost,
 } from "./free-monthly-cost";
+export {
+  getPaidDailyFreeAllowanceStatus,
+  reservePaidDailyFreeAllowanceRequest,
+  recordPaidDailyFreeAllowanceCost,
+  paidDailyFreeAllowanceStatusToMetadata,
+  getPaidDailyFreeAllowanceKeys,
+  getPaidDailyFreeAllowanceRolloutPercent,
+  getPaidDailyFreeAllowanceRequestsPerDay,
+  getPaidDailyFreeAllowanceCostLimitDollars,
+  PAID_DAILY_FREE_ALLOWANCE_COST_LIMIT_USD_DEFAULT,
+  PAID_DAILY_FREE_ALLOWANCE_REQUESTS_PER_DAY_DEFAULT,
+  PAID_DAILY_FREE_ALLOWANCE_ROLLOUT_PERCENT_DEFAULT,
+  type PaidDailyFreeAllowanceMetadata,
+  type PaidDailyFreeAllowanceReservation,
+  type PaidDailyFreeAllowanceStatus,
+} from "./paid-daily-free-allowance";
 
 // Import for internal use
 import { checkTokenBucketLimit } from "./token-bucket";

--- a/lib/rate-limit/paid-daily-free-allowance.ts
+++ b/lib/rate-limit/paid-daily-free-allowance.ts
@@ -1,0 +1,464 @@
+import "server-only";
+
+import { isFeatureEnabled } from "@/lib/auth/feature-flags";
+import { ChatSDKError } from "@/lib/errors";
+import type { ChatMode, SubscriptionTier } from "@/types";
+import { POINTS_PER_DOLLAR } from "./token-bucket";
+import { createRedisClient } from "./redis";
+import type { LimitCapReason } from "@/lib/limit-pressure";
+
+export const PAID_DAILY_FREE_ALLOWANCE_FEATURE_KEY =
+  "paid-daily-free-allowance";
+export const PAID_DAILY_FREE_ALLOWANCE_REQUESTS_PER_DAY_DEFAULT = 1;
+export const PAID_DAILY_FREE_ALLOWANCE_COST_LIMIT_USD_DEFAULT = 0.1;
+export const PAID_DAILY_FREE_ALLOWANCE_ROLLOUT_PERCENT_DEFAULT = 10;
+
+const PAID_INDIVIDUAL_TIERS = new Set<SubscriptionTier>([
+  "pro",
+  "pro-plus",
+  "ultra",
+]);
+
+const RESERVE_PAID_DAILY_FREE_ALLOWANCE_SCRIPT = `
+local requestKey = KEYS[1]
+local costKey = KEYS[2]
+local requestLimit = tonumber(ARGV[1])
+local costLimit = tonumber(ARGV[2])
+local ttlMs = tonumber(ARGV[3])
+
+local currentRequests = tonumber(redis.call("GET", requestKey) or "0")
+local currentCost = tonumber(redis.call("GET", costKey) or "0")
+
+if currentRequests >= requestLimit then
+  return {0, "request_limit_reached", currentRequests, currentCost}
+end
+
+if currentCost >= costLimit then
+  return {0, "cost_limit_reached", currentRequests, currentCost}
+end
+
+local nextRequests = redis.call("INCRBY", requestKey, 1)
+if nextRequests == 1 then
+  redis.call("PEXPIRE", requestKey, ttlMs)
+end
+
+if redis.call("EXISTS", costKey) == 0 then
+  redis.call("SET", costKey, currentCost, "PX", ttlMs)
+else
+  redis.call("PEXPIRE", costKey, ttlMs)
+end
+
+return {1, "ok", nextRequests, currentCost}
+`;
+
+const RECORD_PAID_DAILY_FREE_ALLOWANCE_COST_SCRIPT = `
+local costKey = KEYS[1]
+local costPoints = tonumber(ARGV[1])
+local ttlMs = tonumber(ARGV[2])
+
+if costPoints <= 0 then
+  return tonumber(redis.call("GET", costKey) or "0")
+end
+
+local nextCost = redis.call("INCRBY", costKey, costPoints)
+redis.call("PEXPIRE", costKey, ttlMs)
+return nextCost
+`;
+
+export type PaidDailyFreeAllowanceUnavailableReason =
+  | "unsupported_mode"
+  | "unsupported_subscription"
+  | "not_monthly_exhausted"
+  | "attachments_not_supported"
+  | "rollout_disabled"
+  | "redis_unavailable"
+  | "request_limit_reached"
+  | "cost_limit_reached";
+
+export interface PaidDailyFreeAllowanceStatus {
+  type: "paid_daily_free_allowance";
+  available: boolean;
+  enabledByRollout: boolean;
+  rolloutPercent: number;
+  requestLimit: number;
+  requestsUsed: number;
+  requestsRemaining: number;
+  costLimitDollars: number;
+  costUsedDollars: number;
+  costRemainingDollars: number;
+  costLimitPoints: number;
+  costUsedPoints: number;
+  costRemainingPoints: number;
+  resetTime: Date;
+  resetTimestamp: number;
+  unavailableReason?: PaidDailyFreeAllowanceUnavailableReason;
+  rateLimitSkipped?: boolean;
+}
+
+export interface PaidDailyFreeAllowanceReservation {
+  allowed: boolean;
+  status: PaidDailyFreeAllowanceStatus;
+  blockReason?: PaidDailyFreeAllowanceUnavailableReason;
+}
+
+export type PaidDailyFreeAllowanceMetadata = {
+  type: "paid_daily_free_allowance";
+  available: boolean;
+  enabledByRollout: boolean;
+  rolloutPercent: number;
+  requestLimit: number;
+  requestsUsed: number;
+  requestsRemaining: number;
+  costLimitDollars: number;
+  costUsedDollars: number;
+  costRemainingDollars: number;
+  resetTimestamp: number;
+  unavailableReason?: PaidDailyFreeAllowanceUnavailableReason;
+  rateLimitSkipped?: boolean;
+};
+
+type PaidDailyFreeAllowanceContext = {
+  userId: string;
+  subscription: SubscriptionTier;
+  mode: ChatMode;
+  capReason?: LimitCapReason;
+  hasAttachments?: boolean;
+};
+
+function envNumber({
+  name,
+  defaultValue,
+  min,
+  max,
+}: {
+  name: string;
+  defaultValue: number;
+  min: number;
+  max: number;
+}): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return defaultValue;
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return defaultValue;
+  return Math.min(max, Math.max(min, parsed));
+}
+
+export function getPaidDailyFreeAllowanceRolloutPercent(): number {
+  return envNumber({
+    name: "PAID_DAILY_FREE_ALLOWANCE_ROLLOUT_PERCENT",
+    defaultValue: PAID_DAILY_FREE_ALLOWANCE_ROLLOUT_PERCENT_DEFAULT,
+    min: 0,
+    max: 100,
+  });
+}
+
+export function getPaidDailyFreeAllowanceRequestsPerDay(): number {
+  return Math.floor(
+    envNumber({
+      name: "PAID_DAILY_FREE_ALLOWANCE_REQUESTS_PER_DAY",
+      defaultValue: PAID_DAILY_FREE_ALLOWANCE_REQUESTS_PER_DAY_DEFAULT,
+      min: 0,
+      max: 100,
+    }),
+  );
+}
+
+export function getPaidDailyFreeAllowanceCostLimitDollars(): number {
+  return envNumber({
+    name: "PAID_DAILY_FREE_ALLOWANCE_COST_LIMIT_USD",
+    defaultValue: PAID_DAILY_FREE_ALLOWANCE_COST_LIMIT_USD_DEFAULT,
+    min: 0,
+    max: 100,
+  });
+}
+
+function dollarsToPoints(dollars: number): number {
+  if (!Number.isFinite(dollars) || dollars <= 0) return 0;
+  return Math.ceil(dollars * POINTS_PER_DOLLAR);
+}
+
+function pointsToDollars(points: number): number {
+  return Math.round((points / POINTS_PER_DOLLAR) * 10_000) / 10_000;
+}
+
+function getCurrentUtcDayWindow(now = new Date()) {
+  const bucket = now.toISOString().slice(0, 10);
+  const reset = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate() + 1,
+  );
+
+  return {
+    bucket,
+    reset,
+    ttlMs: Math.max(1, reset - now.getTime()),
+  };
+}
+
+export function getPaidDailyFreeAllowanceKeys(
+  userId: string,
+  bucket = getCurrentUtcDayWindow().bucket,
+) {
+  const prefix = `paid_daily_free_allowance:${userId}:${bucket}`;
+  return {
+    requestsKey: `${prefix}:requests`,
+    costKey: `${prefix}:cost`,
+  };
+}
+
+function baseStatus(
+  ctx: PaidDailyFreeAllowanceContext,
+  reason?: PaidDailyFreeAllowanceUnavailableReason,
+): PaidDailyFreeAllowanceStatus {
+  const requestLimit = getPaidDailyFreeAllowanceRequestsPerDay();
+  const costLimitDollars = getPaidDailyFreeAllowanceCostLimitDollars();
+  const costLimitPoints = dollarsToPoints(costLimitDollars);
+  const rolloutPercent = getPaidDailyFreeAllowanceRolloutPercent();
+  const enabledByRollout = isFeatureEnabled(
+    ctx.userId,
+    PAID_DAILY_FREE_ALLOWANCE_FEATURE_KEY,
+    rolloutPercent,
+  );
+  const { reset } = getCurrentUtcDayWindow();
+
+  return {
+    type: "paid_daily_free_allowance",
+    available: false,
+    enabledByRollout,
+    rolloutPercent,
+    requestLimit,
+    requestsUsed: 0,
+    requestsRemaining: requestLimit,
+    costLimitDollars,
+    costUsedDollars: 0,
+    costRemainingDollars: costLimitDollars,
+    costLimitPoints,
+    costUsedPoints: 0,
+    costRemainingPoints: costLimitPoints,
+    resetTime: new Date(reset),
+    resetTimestamp: reset,
+    ...(reason && { unavailableReason: reason }),
+  };
+}
+
+function getStaticUnavailableReason(
+  ctx: PaidDailyFreeAllowanceContext,
+): PaidDailyFreeAllowanceUnavailableReason | null {
+  if (ctx.mode !== "ask") return "unsupported_mode";
+  if (!PAID_INDIVIDUAL_TIERS.has(ctx.subscription)) {
+    return "unsupported_subscription";
+  }
+  if (ctx.capReason !== "monthly_exhausted") return "not_monthly_exhausted";
+  if (ctx.hasAttachments) return "attachments_not_supported";
+  return null;
+}
+
+export async function getPaidDailyFreeAllowanceStatus(
+  ctx: PaidDailyFreeAllowanceContext,
+): Promise<PaidDailyFreeAllowanceStatus> {
+  const staticReason = getStaticUnavailableReason(ctx);
+  if (staticReason) return baseStatus(ctx, staticReason);
+
+  const requestLimit = getPaidDailyFreeAllowanceRequestsPerDay();
+  const costLimitDollars = getPaidDailyFreeAllowanceCostLimitDollars();
+  const costLimitPoints = dollarsToPoints(costLimitDollars);
+  const rolloutPercent = getPaidDailyFreeAllowanceRolloutPercent();
+  const enabledByRollout = isFeatureEnabled(
+    ctx.userId,
+    PAID_DAILY_FREE_ALLOWANCE_FEATURE_KEY,
+    rolloutPercent,
+  );
+  const { bucket, reset } = getCurrentUtcDayWindow();
+
+  if (!enabledByRollout) return baseStatus(ctx, "rollout_disabled");
+
+  const redis = createRedisClient();
+  if (!redis) {
+    if (process.env.NODE_ENV !== "production") {
+      return {
+        ...baseStatus(ctx),
+        available: requestLimit > 0 && costLimitPoints > 0,
+        requestLimit,
+        requestsRemaining: requestLimit,
+        costLimitDollars,
+        costRemainingDollars: costLimitDollars,
+        costLimitPoints,
+        costRemainingPoints: costLimitPoints,
+        rateLimitSkipped: true,
+      };
+    }
+
+    return baseStatus(ctx, "redis_unavailable");
+  }
+
+  const { requestsKey, costKey } = getPaidDailyFreeAllowanceKeys(
+    ctx.userId,
+    bucket,
+  );
+  const [rawRequestsUsed, rawCostUsed] = await Promise.all([
+    redis.get(requestsKey),
+    redis.get(costKey),
+  ]);
+  const requestsUsed = Math.max(0, Number(rawRequestsUsed ?? 0));
+  const costUsedPoints = Math.max(0, Number(rawCostUsed ?? 0));
+  const requestsRemaining = Math.max(0, requestLimit - requestsUsed);
+  const costRemainingPoints = Math.max(0, costLimitPoints - costUsedPoints);
+  const unavailableReason =
+    requestsRemaining <= 0
+      ? "request_limit_reached"
+      : costRemainingPoints <= 0
+        ? "cost_limit_reached"
+        : undefined;
+
+  return {
+    type: "paid_daily_free_allowance",
+    available: !unavailableReason && requestLimit > 0 && costLimitPoints > 0,
+    enabledByRollout,
+    rolloutPercent,
+    requestLimit,
+    requestsUsed,
+    requestsRemaining,
+    costLimitDollars,
+    costUsedDollars: pointsToDollars(costUsedPoints),
+    costRemainingDollars: pointsToDollars(costRemainingPoints),
+    costLimitPoints,
+    costUsedPoints,
+    costRemainingPoints,
+    resetTime: new Date(reset),
+    resetTimestamp: reset,
+    ...(unavailableReason && { unavailableReason }),
+  };
+}
+
+export async function reservePaidDailyFreeAllowanceRequest(
+  ctx: PaidDailyFreeAllowanceContext,
+): Promise<PaidDailyFreeAllowanceReservation> {
+  const status = await getPaidDailyFreeAllowanceStatus(ctx);
+  if (!status.available) {
+    return { allowed: false, status, blockReason: status.unavailableReason };
+  }
+
+  const redis = createRedisClient();
+  if (!redis) {
+    if (process.env.NODE_ENV !== "production") {
+      return {
+        allowed: true,
+        status: {
+          ...status,
+          requestsUsed: status.requestsUsed + 1,
+          requestsRemaining: Math.max(0, status.requestsRemaining - 1),
+          rateLimitSkipped: true,
+        },
+      };
+    }
+
+    return {
+      allowed: false,
+      status: {
+        ...status,
+        available: false,
+        unavailableReason: "redis_unavailable",
+      },
+      blockReason: "redis_unavailable",
+    };
+  }
+
+  const { bucket, reset, ttlMs } = getCurrentUtcDayWindow();
+  const { requestsKey, costKey } = getPaidDailyFreeAllowanceKeys(
+    ctx.userId,
+    bucket,
+  );
+  const result = (await redis.eval(
+    RESERVE_PAID_DAILY_FREE_ALLOWANCE_SCRIPT,
+    [requestsKey, costKey],
+    [status.requestLimit, status.costLimitPoints, ttlMs],
+  )) as [
+    number,
+    PaidDailyFreeAllowanceUnavailableReason | "ok",
+    number,
+    number,
+  ];
+
+  const [allowedRaw, rawReason, requestsUsedRaw, costUsedRaw] = result;
+  const allowed = allowedRaw === 1;
+  const requestsUsed = Math.max(0, Number(requestsUsedRaw ?? 0));
+  const costUsedPoints = Math.max(0, Number(costUsedRaw ?? 0));
+  const requestsRemaining = Math.max(0, status.requestLimit - requestsUsed);
+  const costRemainingPoints = Math.max(
+    0,
+    status.costLimitPoints - costUsedPoints,
+  );
+  const blockReason = allowed ? undefined : rawReason;
+  const nextStatus: PaidDailyFreeAllowanceStatus = {
+    ...status,
+    available: allowed && requestsRemaining > 0 && costRemainingPoints > 0,
+    requestsUsed,
+    requestsRemaining,
+    costUsedPoints,
+    costUsedDollars: pointsToDollars(costUsedPoints),
+    costRemainingPoints,
+    costRemainingDollars: pointsToDollars(costRemainingPoints),
+    resetTime: new Date(reset),
+    resetTimestamp: reset,
+    ...(blockReason &&
+      blockReason !== "ok" && {
+        unavailableReason: blockReason,
+      }),
+  };
+
+  return {
+    allowed,
+    status: nextStatus,
+    ...(blockReason && blockReason !== "ok" && { blockReason }),
+  };
+}
+
+export async function recordPaidDailyFreeAllowanceCost(
+  userId: string,
+  costDollars: number,
+): Promise<number> {
+  const costPoints = dollarsToPoints(costDollars);
+  if (costPoints <= 0) return 0;
+
+  const redis = createRedisClient();
+  if (!redis) {
+    if (process.env.NODE_ENV !== "production") return costPoints;
+    throw new ChatSDKError(
+      "rate_limit:chat",
+      "Rate limiting service is not configured",
+    );
+  }
+
+  const { bucket, ttlMs } = getCurrentUtcDayWindow();
+  const { costKey } = getPaidDailyFreeAllowanceKeys(userId, bucket);
+  const nextCost = await redis.eval(
+    RECORD_PAID_DAILY_FREE_ALLOWANCE_COST_SCRIPT,
+    [costKey],
+    [costPoints, ttlMs],
+  );
+  return Math.max(0, Number(nextCost ?? 0));
+}
+
+export function paidDailyFreeAllowanceStatusToMetadata(
+  status: PaidDailyFreeAllowanceStatus,
+): PaidDailyFreeAllowanceMetadata {
+  return {
+    type: status.type,
+    available: status.available,
+    enabledByRollout: status.enabledByRollout,
+    rolloutPercent: status.rolloutPercent,
+    requestLimit: status.requestLimit,
+    requestsUsed: status.requestsUsed,
+    requestsRemaining: status.requestsRemaining,
+    costLimitDollars: status.costLimitDollars,
+    costUsedDollars: status.costUsedDollars,
+    costRemainingDollars: status.costRemainingDollars,
+    resetTimestamp: status.resetTimestamp,
+    ...(status.unavailableReason && {
+      unavailableReason: status.unavailableReason,
+    }),
+    ...(status.rateLimitSkipped && { rateLimitSkipped: true }),
+  };
+}

--- a/lib/rate-limit/sliding-window.ts
+++ b/lib/rate-limit/sliding-window.ts
@@ -7,6 +7,7 @@
 
 import { ChatSDKError } from "@/lib/errors";
 import type { RateLimitInfo } from "@/types";
+import { getLimitPressureContext } from "@/lib/limit-pressure";
 import {
   FREE_AGENT_REQUEST_COST,
   FREE_ASK_REQUEST_COST,
@@ -220,6 +221,10 @@ export const checkFreeUserRateLimit = async (
           resetTimestamp: reset,
           subscription: "free",
           capReason: "daily_requests_exhausted",
+          ...getLimitPressureContext({
+            subscription: "free",
+            capReason: "daily_requests_exhausted",
+          }),
         },
       );
     }

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -13,6 +13,10 @@ import {
   refundToTeamBalance,
 } from "@/lib/extra-usage";
 import { getSuspensionMessage } from "@/lib/suspensionMessage";
+import {
+  getLimitPressureContext,
+  type LimitCapReason,
+} from "@/lib/limit-pressure";
 
 // =============================================================================
 // Configuration
@@ -229,17 +233,32 @@ export const checkTokenBucketLimit = async (
         : subscription === "pro-plus"
           ? " or upgrade to Ultra for higher limits"
           : "";
+    const continueWithCreditsHint =
+      subscription === "team"
+        ? "Ask your team admin to add team extra usage credits to keep going now."
+        : `To keep going now, add extra usage credits in Settings${upgradeHint}.`;
+    const emptyCreditsHint =
+      subscription === "team"
+        ? "your team's extra usage balance is empty"
+        : "your extra usage balance is empty";
+    const limitMetadata = (
+      reset: number,
+      capReason: LimitCapReason,
+      extra: Record<string, unknown> = {},
+    ) => ({
+      resetTimestamp: reset,
+      subscription,
+      capReason,
+      ...getLimitPressureContext({ subscription, capReason }),
+      ...extra,
+    });
 
     const monthlyLimitError = (reset: number) => {
       const resetTime = formatTimeRemaining(new Date(reset));
       return new ChatSDKError(
         "rate_limit:chat",
-        `You've hit your monthly usage limit.\n\nYour limit resets ${resetTime}. To keep going now, add extra usage credits in Settings${upgradeHint}.`,
-        {
-          resetTimestamp: reset,
-          subscription,
-          capReason: "monthly_exhausted",
-        },
+        `You've hit your monthly usage limit.\n\nYour limit resets ${resetTime}. ${continueWithCreditsHint}`,
+        limitMetadata(reset, "monthly_exhausted"),
       );
     };
 
@@ -323,40 +342,40 @@ export const checkTokenBucketLimit = async (
           // Team-pool specific: admin disabled this member's pool access.
           if (deductResult.memberDisabled) {
             const msg = `Your team admin has paused your access to team extra usage. Ask them to re-enable it to continue beyond your subscription limit.`;
-            throw new ChatSDKError("rate_limit:chat", msg, {
-              resetTimestamp: monthlyCheck.reset,
-              subscription,
-              capReason: "team_member_disabled",
-            });
+            throw new ChatSDKError(
+              "rate_limit:chat",
+              msg,
+              limitMetadata(monthlyCheck.reset, "team_member_disabled"),
+            );
           }
 
           // Team-pool specific: admin disabled the pool entirely.
           if (deductResult.poolDisabled) {
             const msg = `Your team's extra usage pool is disabled.\n\nYour subscription limit resets ${resetTime}. Ask your team admin to enable team extra usage to continue.`;
-            throw new ChatSDKError("rate_limit:chat", msg, {
-              resetTimestamp: monthlyCheck.reset,
-              subscription,
-              capReason: "team_pool_disabled",
-            });
+            throw new ChatSDKError(
+              "rate_limit:chat",
+              msg,
+              limitMetadata(monthlyCheck.reset, "team_pool_disabled"),
+            );
           }
 
           // Team-pool specific: this member hit their per-member monthly cap.
           if (deductResult.memberCapExceeded) {
             const msg = `You've hit your team-set monthly spending limit.\n\nYour limit resets ${resetTime}. Ask your team admin to raise your limit to continue.`;
-            throw new ChatSDKError("rate_limit:chat", msg, {
-              resetTimestamp: monthlyCheck.reset,
-              subscription,
-              capReason: "team_member_cap",
-            });
+            throw new ChatSDKError(
+              "rate_limit:chat",
+              msg,
+              limitMetadata(monthlyCheck.reset, "team_member_cap"),
+            );
           }
 
           if (deductResult.monthlyCapExceeded) {
             const msg = `You've hit your monthly extra usage spending limit.\n\nYour limit resets ${resetTime}. To keep going now, increase your spending limit in Settings.`;
-            throw new ChatSDKError("rate_limit:chat", msg, {
-              resetTimestamp: monthlyCheck.reset,
-              subscription,
-              capReason: "extra_usage_cap",
-            });
+            throw new ChatSDKError(
+              "rate_limit:chat",
+              msg,
+              limitMetadata(monthlyCheck.reset, "extra_usage_cap"),
+            );
           }
 
           // If we tried auto-reload and Stripe declined the card, give the
@@ -379,20 +398,19 @@ export const checkTokenBucketLimit = async (
                 ? getSuspensionMessage(null)
                 : `Auto-reload couldn't charge your card (${reason}). Update your payment method in Settings, then try again.`;
             throw new ChatSDKError("rate_limit:chat", msg, {
-              resetTimestamp: monthlyCheck.reset,
-              subscription,
-              autoReloadFailed: true,
-              autoReloadFailureReason: reason,
-              capReason: "auto_reload_failed",
+              ...limitMetadata(monthlyCheck.reset, "auto_reload_failed", {
+                autoReloadFailed: true,
+                autoReloadFailureReason: reason,
+              }),
             });
           }
 
-          const msg = `You've hit your usage limit and your extra usage balance is empty.\n\nYour limit resets ${resetTime}. To keep going now, add credits in Settings${upgradeHint}.`;
-          throw new ChatSDKError("rate_limit:chat", msg, {
-            resetTimestamp: monthlyCheck.reset,
-            subscription,
-            capReason: "monthly_exhausted",
-          });
+          const msg = `You've hit your usage limit and ${emptyCreditsHint}.\n\nYour limit resets ${resetTime}. ${continueWithCreditsHint}`;
+          throw new ChatSDKError(
+            "rate_limit:chat",
+            msg,
+            limitMetadata(monthlyCheck.reset, "monthly_exhausted"),
+          );
         }
 
         // Deduction failed for a service reason (not insufficient funds) —
@@ -400,22 +418,18 @@ export const checkTokenBucketLimit = async (
         throw new ChatSDKError(
           "rate_limit:chat",
           "Extra usage billing is temporarily unavailable. Please try again in a few moments.",
-          {
-            resetTimestamp: monthlyCheck.reset,
-            subscription,
-            capReason: "billing_unavailable",
-          },
+          limitMetadata(monthlyCheck.reset, "billing_unavailable"),
         );
       }
 
       // No extra usage enabled - throw standard rate limit error
       const resetTime = formatTimeRemaining(new Date(monthlyCheck.reset));
-      const msg = `You've hit your monthly usage limit.\n\nYour limit resets ${resetTime}. To keep going now, add extra usage credits in Settings${upgradeHint}.`;
-      throw new ChatSDKError("rate_limit:chat", msg, {
-        resetTimestamp: monthlyCheck.reset,
-        subscription,
-        capReason: "monthly_exhausted",
-      });
+      const msg = `You've hit your monthly usage limit.\n\nYour limit resets ${resetTime}. ${continueWithCreditsHint}`;
+      throw new ChatSDKError(
+        "rate_limit:chat",
+        msg,
+        limitMetadata(monthlyCheck.reset, "monthly_exhausted"),
+      );
     }
 
     // Step 3: Have capacity, deduct from monthly bucket

--- a/lib/utils/parse-rate-limit-warning.ts
+++ b/lib/utils/parse-rate-limit-warning.ts
@@ -1,5 +1,6 @@
 import type { RateLimitWarningData } from "@/app/components/RateLimitWarning";
 import { isChatMode, isSubscriptionTier } from "@/types/chat";
+import type { LimitCapReason } from "@/lib/limit-pressure";
 
 const WARNING_TYPES = [
   "sliding-window",
@@ -83,6 +84,10 @@ export function parseRateLimitWarning(
   }
 
   const midStream = rawData.midStream === true;
+  const capReason =
+    isString(rawData.capReason) && rawData.capReason.length > 0
+      ? (rawData.capReason as LimitCapReason)
+      : undefined;
 
   if (warningType === "extra-usage-active") {
     const bucketType = rawData.bucketType as RawBucketType | undefined;
@@ -98,6 +103,7 @@ export function parseRateLimitWarning(
         bucketType,
         resetTime,
         subscription,
+        ...(capReason && { capReason }),
         midStream: true,
       };
     }
@@ -107,6 +113,7 @@ export function parseRateLimitWarning(
         bucketType,
         resetTime,
         subscription,
+        ...(capReason && { capReason }),
       };
     }
     const storageKey = `${EXTRA_USAGE_STORAGE_KEY_PREFIX}${bucketType}`;
@@ -120,6 +127,7 @@ export function parseRateLimitWarning(
       bucketType,
       resetTime,
       subscription,
+      ...(capReason && { capReason }),
     };
   }
 
@@ -183,6 +191,7 @@ export function parseRateLimitWarning(
     ...(severity && { severity }),
     ...(usedDollars !== undefined && { usedDollars }),
     ...(limitDollars !== undefined && { limitDollars }),
+    ...(capReason && { capReason }),
     ...(midStream && { midStream: true }),
     ...(cutOff && { cutOff: true }),
   };

--- a/lib/utils/stream-writer-utils.ts
+++ b/lib/utils/stream-writer-utils.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { UIMessagePart, UIMessageStreamWriter } from "ai";
 import type { ChatMode, SubscriptionTier } from "@/types";
+import type { LimitCapReason } from "@/lib/limit-pressure";
 
 // Upload status notifications
 export const writeUploadStartStatus = (
@@ -112,6 +113,7 @@ export type RateLimitWarningData =
       severity?: "info" | "warning";
       usedDollars?: number;
       limitDollars?: number;
+      capReason?: LimitCapReason;
       // Mid-stream emits bypass localStorage dedup so threshold escalations
       // (50→80→95→100) within a single stream always reach the client.
       midStream?: boolean;
@@ -124,6 +126,7 @@ export type RateLimitWarningData =
       bucketType: "monthly";
       resetTime: string;
       subscription: SubscriptionTier;
+      capReason?: LimitCapReason;
       midStream?: boolean;
     };
 

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -339,6 +339,12 @@ export interface ExtraUsageConfig {
   hasBalance?: boolean;
   /** Current balance in dollars (for UI display) */
   balanceDollars?: number;
+  /** Optional monthly extra-usage spending cap in dollars */
+  monthlyCapDollars?: number;
+  /** Extra-usage spend already consumed in the current month */
+  monthlySpentDollars?: number;
+  /** Remaining extra-usage spend allowed by the monthly cap */
+  monthlyRemainingDollars?: number;
   /** Whether auto-reload is enabled (can use extra usage even with $0 balance) */
   autoReloadEnabled?: boolean;
 }

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -72,6 +72,20 @@ export function isSelectedModel(value: string | null): value is SelectedModel {
   );
 }
 
+export type LimitRescueRequest = {
+  type: "paid_daily_free_allowance";
+};
+
+export function isLimitRescueRequest(
+  value: unknown,
+): value is LimitRescueRequest {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    (value as { type?: unknown }).type === "paid_daily_free_allowance"
+  );
+}
+
 export type SubscriptionTier = "free" | "pro" | "pro-plus" | "ultra" | "team";
 
 export const SUBSCRIPTION_TIERS: readonly SubscriptionTier[] = [


### PR DESCRIPTION
## Summary
- add paid daily free allowance for individual paid users blocked by monthly_exhausted
- expose availability metadata on normal limit hits, then allow an explicit Ask-mode rescue retry
- force rescue requests to ask-model-free, track the daily request/cost budget in Redis, and emit PostHog events
- keep Add Credits primary while adding a secondary Use today's free request CTA

## User Impact
Paid Pro, Pro Plus, and Ultra users who exhaust their monthly included usage can make one text-only Ask request per UTC day on the cheap route, capped at $0.10/day. Agent mode, team users, file/image/PDF asks, billing failures, auto-reload failures, and extra-usage cap states remain excluded.

## Validation
- pnpm test -- lib/rate-limit/__tests__/paid-daily-free-allowance.test.ts lib/chat/__tests__/budget-monitor.test.ts lib/api/__tests__/chat-logger.test.ts app/components/__tests__/MessageErrorState.test.tsx --runInBand
- pnpm test -- lib/rate-limit/__tests__/index.test.ts lib/rate-limit/__tests__/free-monthly-cost.test.ts --runInBand
- pnpm typecheck
- pnpm lint
- pre-commit: prettier --write, eslint --fix, pnpm typecheck, full pnpm test (128 suites / 1410 tests)

## Rollout Notes
Set PAID_DAILY_FREE_ALLOWANCE_ROLLOUT_PERCENT to 10 initially. Defaults are 1 request/day and PAID_DAILY_FREE_ALLOWANCE_COST_LIMIT_USD=0.10.