### PR TITLE
[codex] Refactor summarization status UI

### DIFF
--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -7,13 +7,13 @@ import { FeedbackInput } from "./FeedbackInput";
 import { BranchIndicator } from "./BranchIndicator";
 import { FinishReasonNotice } from "./FinishReasonNotice";
 import { splitWorkedForParts } from "./worked-for-parts";
-import { Shimmer } from "@/components/ai-elements/shimmer";
+import { SummarizationStatusDivider } from "./SummarizationStatusDivider";
 import {
   WorkedFor,
   WorkedForContent,
   WorkedForTrigger,
 } from "@/components/ai-elements/worked-for";
-import { ChevronDown, ChevronUp, FileSearch, WandSparkles } from "lucide-react";
+import { ChevronDown, ChevronUp, FileSearch } from "lucide-react";
 import {
   extractMessageText,
   hasTextContent,
@@ -612,12 +612,11 @@ export const MessageItem = memo(function MessageItem({
         {isLastAssistantMessage &&
           hasAnyContent &&
           summarizationStatus?.status === "started" && (
-            <div className="flex items-center gap-2 mt-2">
-              <WandSparkles className="w-4 h-4 text-muted-foreground" />
-              <Shimmer className="text-sm">
-                {`${summarizationStatus.message}...`}
-              </Shimmer>
-            </div>
+            <SummarizationStatusDivider
+              status={summarizationStatus.status}
+              message={summarizationStatus.message}
+              className="mb-1 mt-3"
+            />
           )}
 
         {/* Finish reason notice under last assistant message */}

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { MessageItem } from "./MessageItem";
 import { MessageErrorState } from "./MessageErrorState";
+import { SummarizationStatusDivider } from "./SummarizationStatusDivider";
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import { AllFilesDialog } from "./AllFilesDialog";
 import Loading from "@/components/ui/loading";
@@ -19,7 +20,6 @@ import { findLastAssistantMessageIndex } from "@/lib/utils/message-utils";
 import type { ChatStatus, ChatMessage } from "@/types";
 import type { FileDetails } from "@/types/file";
 import { toast } from "sonner";
-import { WandSparkles } from "lucide-react";
 import DotsSpinner from "@/components/ui/dots-spinner";
 import { hasTextContent } from "@/lib/utils/message-utils";
 import { useDataStreamState } from "./DataStreamProvider";
@@ -348,12 +348,11 @@ export const Messages = ({
             shouldShowLoadingDots) && (
             <div className="flex flex-col items-start">
               {showSummarizationSeparately && (
-                <div className="flex items-center gap-2">
-                  <WandSparkles className="w-4 h-4 text-muted-foreground" />
-                  <Shimmer className="text-sm">
-                    {`${summarizationStatus?.message}...`}
-                  </Shimmer>
-                </div>
+                <SummarizationStatusDivider
+                  status={summarizationStatus?.status}
+                  message={summarizationStatus?.message}
+                  className="mb-1 mt-0"
+                />
               )}
               {uploadStatus?.isUploading && (
                 <Shimmer className="text-sm">{`${uploadStatus.message}...`}</Shimmer>

--- a/app/components/SummarizationStatusDivider.tsx
+++ b/app/components/SummarizationStatusDivider.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { ScrollText } from "lucide-react";
+import { Shimmer } from "@/components/ai-elements/shimmer";
+import { cn } from "@/lib/utils";
+
+type SummarizationStatus = "started" | "completed" | string | undefined;
+
+interface SummarizationStatusDividerProps {
+  status?: SummarizationStatus;
+  message?: string;
+  className?: string;
+}
+
+const DEFAULT_STARTED_LABEL = "Automatically compacting context";
+const DEFAULT_COMPLETED_LABEL = "Context automatically compacted";
+
+const normalizeSummarizationLabel = (
+  status: SummarizationStatus,
+  message?: string,
+) => {
+  if (status === "started") {
+    return !message ||
+      message === "Summarizing chat context" ||
+      message === "Compacting context"
+      ? DEFAULT_STARTED_LABEL
+      : message;
+  }
+
+  return !message || message === "Chat context summarized"
+    ? DEFAULT_COMPLETED_LABEL
+    : message;
+};
+
+export function SummarizationStatusDivider({
+  status,
+  message,
+  className,
+}: SummarizationStatusDividerProps) {
+  const isStarted = status === "started";
+  const label = normalizeSummarizationLabel(status, message);
+
+  return (
+    <div
+      className={cn(
+        "not-prose my-4 flex w-full items-center gap-3 text-muted-foreground",
+        className,
+      )}
+      aria-live={isStarted ? "polite" : undefined}
+    >
+      <span className="h-px min-w-8 flex-1 bg-border" aria-hidden="true" />
+      <span className="inline-flex min-w-0 shrink items-center gap-2 px-1 text-sm leading-6 text-muted-foreground">
+        {!isStarted && (
+          <ScrollText className="size-4 shrink-0" aria-hidden="true" />
+        )}
+        {isStarted ? (
+          <Shimmer as="span" className="truncate text-sm leading-6">
+            {label}
+          </Shimmer>
+        ) : (
+          <span className="truncate">{label}</span>
+        )}
+      </span>
+      <span className="h-px min-w-8 flex-1 bg-border" aria-hidden="true" />
+    </div>
+  );
+}

--- a/app/components/tools/SummarizationHandler.tsx
+++ b/app/components/tools/SummarizationHandler.tsx
@@ -1,7 +1,6 @@
 import { memo } from "react";
 import { UIMessage } from "@ai-sdk/react";
-import { WandSparkles } from "lucide-react";
-import { Shimmer } from "@/components/ai-elements/shimmer";
+import { SummarizationStatusDivider } from "../SummarizationStatusDivider";
 
 interface SummarizationHandlerProps {
   message: UIMessage;
@@ -27,18 +26,10 @@ export const SummarizationHandler = memo(function SummarizationHandler({
   partIndex,
 }: SummarizationHandlerProps) {
   return (
-    <div
+    <SummarizationStatusDivider
       key={`${message.id}-summarization-${partIndex}`}
-      className="mb-3 flex items-center gap-2"
-    >
-      <WandSparkles className="w-4 h-4 text-muted-foreground" />
-      {part.data.status === "started" ? (
-        <Shimmer className="text-sm">{`${part.data.message}...`}</Shimmer>
-      ) : (
-        <span className="text-sm text-muted-foreground">
-          {part.data.message}
-        </span>
-      )}
-    </div>
+      status={part.data?.status}
+      message={part.data?.message}
+    />
   );
 }, areSummarizationPropsEqual);

--- a/app/share/[shareId]/components/SharedMessagePartHandler.tsx
+++ b/app/share/[shareId]/components/SharedMessagePartHandler.tsx
@@ -16,7 +16,6 @@ import {
   FileDown,
   ExternalLink,
   Globe,
-  WandSparkles,
 } from "lucide-react";
 import {
   getNotesIcon,
@@ -25,6 +24,7 @@ import {
   type NotesToolName,
 } from "@/app/components/tools/notes-tool-utils";
 import { MemoizedMarkdown } from "@/app/components/MemoizedMarkdown";
+import { SummarizationStatusDivider } from "@/app/components/SummarizationStatusDivider";
 import ToolBlock from "@/components/ui/tool-block";
 import {
   Reasoning,
@@ -849,13 +849,11 @@ function renderSummarizationPart(part: MessagePart, idx: number) {
   const data = (part as any).data as { status?: string; message?: string };
 
   return (
-    <div key={idx} className="mb-3 flex items-center gap-2">
-      <WandSparkles
-        className="w-4 h-4 text-muted-foreground"
-        aria-hidden="true"
-      />
-      <span className="text-sm text-muted-foreground">{data?.message}</span>
-    </div>
+    <SummarizationStatusDivider
+      key={idx}
+      status={data?.status}
+      message={data?.message}
+    />
   );
 }
 

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -83,6 +83,17 @@ describe("agent-long-transport — direct UI stream reader", () => {
   test("clearTimeout is called after normal stream end", () => {
     expect(transportSrc).toMatch(/clearTimeout\(\s*timeoutId\s*\)/);
   });
+
+  test("drains post-finish data chunks before closing the browser stream", () => {
+    expect(transportSrc).toMatch(/POST_FINISH_DRAIN_TIMEOUT_MS/);
+    expect(transportSrc).toMatch(/sawFinishChunk/);
+    expect(transportSrc).toMatch(
+      /chunkType\s*===\s*"finish"[\s\S]*sawFinishChunk\s*=\s*true[\s\S]*continue;/,
+    );
+    expect(transportSrc).not.toMatch(
+      /chunkType\s*===\s*"finish"[\s\S]{0,220}break;/,
+    );
+  });
 });
 
 describe("agent-long cancel route — compare-and-clear idempotency", () => {

--- a/lib/chat/agent-long-transport.ts
+++ b/lib/chat/agent-long-transport.ts
@@ -48,6 +48,7 @@ const TERMINAL_RUN_STATUSES = new Set([
 // this guarantees useChat eventually exits streaming state.
 const STREAM_TIMEOUT_MS = 5 * 60 * 1000;
 const STREAM_IDLE_TIMEOUT_SECONDS = STREAM_TIMEOUT_MS / 1000;
+const POST_FINISH_DRAIN_TIMEOUT_MS = 2_000;
 
 const buildSSEResponseFromRun = (
   { runId, publicAccessToken }: RunHandle,
@@ -192,6 +193,7 @@ const buildSSEResponseFromRun = (
           // closes the local stream in one tick, even when the LLM is mid-step
           // and no chunks are flowing.
           const abortSentinel = Symbol("aborted");
+          const postFinishDrainTimeout = Symbol("post-finish-drain-timeout");
           const abortPromise = new Promise<typeof abortSentinel>((resolve) => {
             if (!signal) return; // never resolves — Promise.race ignores it
             signal.addEventListener("abort", () => resolve(abortSentinel), {
@@ -200,12 +202,44 @@ const buildSSEResponseFromRun = (
           });
 
           let sawTerminalChunk = false;
+          let sawFinishChunk = false;
+          let timedOutAfterFinish = false;
           let firstEventReceived = false;
           const iter = uiStream[Symbol.asyncIterator]();
+          const readNextChunk = () => {
+            if (!sawFinishChunk) {
+              return Promise.race([iter.next(), abortPromise]);
+            }
+
+            let timeoutId: ReturnType<typeof setTimeout> | undefined;
+            const timeoutPromise = new Promise<typeof postFinishDrainTimeout>(
+              (resolve) => {
+                timeoutId = setTimeout(
+                  () => resolve(postFinishDrainTimeout),
+                  POST_FINISH_DRAIN_TIMEOUT_MS,
+                );
+              },
+            );
+
+            return Promise.race([
+              iter.next(),
+              abortPromise,
+              timeoutPromise,
+            ]).finally(() => {
+              if (timeoutId !== undefined) {
+                clearTimeout(timeoutId);
+              }
+            });
+          };
+
           while (true) {
-            const next = await Promise.race([iter.next(), abortPromise]);
+            const next = await readNextChunk();
             if (next === abortSentinel) {
               userAborted = true;
+              break;
+            }
+            if (next === postFinishDrainTimeout) {
+              timedOutAfterFinish = true;
               break;
             }
             if (next.done) break;
@@ -273,12 +307,17 @@ const buildSSEResponseFromRun = (
                 encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`),
               );
             }
-            // finish / abort / error are the last chunks useChat needs.
-            if (
-              chunkType === "finish" ||
-              chunkType === "abort" ||
-              chunkType === "error"
-            ) {
+            if (chunkType === "finish") {
+              // The task writes a few data chunks after `finish`
+              // (message-metadata, final context usage, auto-continue).
+              // Drain that short tail so the browser receives them.
+              sawTerminalChunk = true;
+              sawFinishChunk = true;
+              continue;
+            }
+
+            // abort / error are terminal and do not have useful trailing data.
+            if (chunkType === "abort" || chunkType === "error") {
               sawTerminalChunk = true;
               break;
             }
@@ -287,7 +326,7 @@ const buildSSEResponseFromRun = (
           // Flush any deltas that didn't trigger a count- or timer-based flush.
           flushDeltaBuffers();
 
-          if (userAborted) {
+          if (userAborted || timedOutAfterFinish) {
             // Release the trigger.dev subscription so it doesn't keep
             // streaming chunks into a dead controller.
             await iter.return?.(undefined).catch(() => undefined);

--- a/lib/utils/stream-writer-utils.ts
+++ b/lib/utils/stream-writer-utils.ts
@@ -41,7 +41,7 @@ export const writeSummarizationStarted = (
     id: "summarization-status",
     data: {
       status: "started",
-      message: "Summarizing chat context",
+      message: "Automatically compacting context",
     },
     transient: true, // Don't persist started state - only show during processing
   });
@@ -55,7 +55,7 @@ export const writeSummarizationCompleted = (
     id: "summarization-status",
     data: {
       status: "completed",
-      message: "Chat context summarized",
+      message: "Context automatically compacted",
     },
   });
 };
@@ -68,7 +68,7 @@ export const createSummarizationCompletedPart = (): UIMessagePart<
   id: "summarization-status",
   data: {
     status: "completed",
-    message: "Chat context summarized",
+    message: "Context automatically compacted",
   },
 });
 


### PR DESCRIPTION
## Summary

- Replace the inline summarization status UI with a shared Codex-style divider component.
- Update started/completed copy to “Automatically compacting context” and “Context automatically compacted”.
- Keep Trigger agent-long streams open briefly after `finish` so post-finish metadata and `data-auto-continue` reach the browser.

## Why

The UI now matches the compacting/completed treatment we want, and the Trigger transport no longer drops auto-continue signals written after `finish`. That dropped tail was why some agent-long runs appeared to stop after compaction/tool-call boundaries.

## Validation

- `pnpm exec prettier --check ...`
- `pnpm exec eslint ...`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm test -- lib/api/__tests__/agent-long-contracts.test.ts app/hooks/__tests__/useAutoContinue.test.ts --runInBand`
- pre-commit hook: `pnpm typecheck` and full `pnpm test` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements

* Updated status messages during context compacting operations to "Automatically compacting context" and "Context automatically compacted" for improved clarity
* Redesigned the visual presentation of summarization status indicators for clearer real-time feedback during operations
* Enhanced stream data handling during post-operation phases to improve overall system stability and reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->