### PR TITLE
[codex] Fix regenerate summary leakage

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -88,6 +88,9 @@ E2B_TEMPLATE=terminal-agent-sandbox
 # to prevent WorkOS rate limits. Value is rollout percentage (0-100).
 # NEXT_PUBLIC_FF_CROSS_TAB_TOKEN_SHARING=0
 
+# Development-only auto-compaction threshold override.
+# NEXT_PUBLIC_DEV_SUMMARIZATION_THRESHOLD_TOKENS=12000
+
 # =============================================================================
 # REFERRALS (Optional)
 # =============================================================================

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -439,11 +439,12 @@ export const useChatHandlers = ({
       : [];
 
     if (!temporaryChatsEnabled) {
-      // Delete the entire trailing auto-continue chain (all assistant + hidden user messages)
-      // back to the last real user message, so regeneration starts from the original request
+      // Delete the trailing response chain and clear summaries that may include
+      // that deleted work, so regeneration starts from the original request.
       if (chainAssistantIds.length > 0) {
         await deleteLastAssistantMessage({
           chatId,
+          resetSummary: true,
           todos: cleanedTodos,
         });
       }

--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -614,6 +614,65 @@ describe("checkAndInvalidateSummary via deleteLastAssistantMessage", () => {
     );
   });
 
+  it("should clear summaries when deleting for regenerate", async () => {
+    const assistantMsg = makeAssistantMessage({ _creationTime: 5000 });
+    const chatDoc = makeChatDoc();
+    const oldSummary = makeSummaryDoc({
+      _id: "old-summary-doc-id" as Id<"chat_summaries">,
+    });
+    const latestSummary = makeSummaryDoc();
+
+    mockCtx.db.query.mockImplementation((table: string) => {
+      if (table === "messages") {
+        return {
+          withIndex: jest.fn().mockReturnValue({
+            order: jest.fn().mockReturnValue({
+              collect: jest.fn<any>().mockResolvedValue([assistantMsg]),
+            }),
+          }),
+        };
+      }
+
+      if (table === "chats") {
+        return {
+          withIndex: jest.fn().mockReturnValue({
+            first: jest.fn<any>().mockResolvedValue(chatDoc),
+          }),
+        };
+      }
+
+      if (table === "chat_summaries") {
+        return {
+          withIndex: jest.fn().mockReturnValue({
+            collect: jest
+              .fn<any>()
+              .mockResolvedValue([latestSummary, oldSummary]),
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const { deleteLastAssistantMessage } = await import("../messages");
+
+    await deleteLastAssistantMessage.handler(mockCtx, {
+      chatId: CHAT_ID,
+      resetSummary: true,
+    });
+
+    expect(mockCtx.db.patch).toHaveBeenCalledWith(CHAT_DOC_ID, {
+      latest_summary_id: undefined,
+    });
+
+    const deleteArgs = mockCtx.db.delete.mock.calls.map(
+      (call: any[]) => call[0],
+    );
+    expect(deleteArgs).toContain(SUMMARY_DOC_ID);
+    expect(deleteArgs).toContain("old-summary-doc-id");
+    expect(deleteArgs).toContain(ASSISTANT_MSG_ID);
+  });
+
   it("should fall back to first valid previous summary when current is invalid", async () => {
     const assistantMsg = makeAssistantMessage({ _creationTime: 2000 });
     const chatDoc = makeChatDoc();

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -328,6 +328,32 @@ const checkAndInvalidateSummary = async (
   }
 };
 
+const clearChatSummaries = async (ctx: any, chatId: string) => {
+  const chat = await ctx.db
+    .query("chats")
+    .withIndex("by_chat_id", (q: any) => q.eq("id", chatId))
+    .first();
+
+  if (chat?.latest_summary_id) {
+    await ctx.db.patch(chat._id, {
+      latest_summary_id: undefined,
+    });
+  }
+
+  const summaries = await ctx.db
+    .query("chat_summaries")
+    .withIndex("by_chat_id", (q: any) => q.eq("chat_id", chatId))
+    .collect();
+
+  for (const summary of summaries) {
+    try {
+      await ctx.db.delete(summary._id);
+    } catch (error) {
+      console.error(`Failed to delete summary ${summary._id}:`, error);
+    }
+  }
+};
+
 export const verifyChatOwnership = internalQuery({
   args: {
     chatId: v.string(),
@@ -1015,6 +1041,7 @@ export const saveAssistantMessage = mutation({
 export const deleteLastAssistantMessage = mutation({
   args: {
     chatId: v.string(),
+    resetSummary: v.optional(v.boolean()),
     todos: v.optional(
       v.array(
         v.object({
@@ -1081,15 +1108,19 @@ export const deleteLastAssistantMessage = mutation({
           }
         }
 
-        // Check summary invalidation for all messages being deleted
-        await checkAndInvalidateSummary(
-          ctx,
-          args.chatId,
-          messagesToDelete.map((m) => ({
-            id: m.id,
-            creationTime: m._creationTime,
-          })),
-        );
+        if (args.resetSummary) {
+          await clearChatSummaries(ctx, args.chatId);
+        } else {
+          // Check summary invalidation for all messages being deleted
+          await checkAndInvalidateSummary(
+            ctx,
+            args.chatId,
+            messagesToDelete.map((m) => ({
+              id: m.id,
+              creationTime: m._creationTime,
+            })),
+          );
+        }
 
         // Delete files and messages
         for (const msg of messagesToDelete) {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -554,7 +554,9 @@ export const createChatHandler = () => {
 
             // Inject resume context into messages instead of system prompt
             // to keep the system prompt stable for caching
-            const resumeContext = getResumeSection(chat?.finish_reason);
+            const resumeContext = regenerate
+              ? ""
+              : getResumeSection(chat?.finish_reason);
             if (resumeContext) {
               finalMessages = appendSystemReminderToLastUserMessage(
                 finalMessages,

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -168,6 +168,48 @@ describe("checkAndSummarizeIfNeeded", () => {
     );
   });
 
+  it("should allow a lower summarization threshold in development", () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    const originalDevThreshold =
+      process.env.NEXT_PUBLIC_DEV_SUMMARIZATION_THRESHOLD_TOKENS;
+
+    process.env.NODE_ENV = "development";
+    process.env.NEXT_PUBLIC_DEV_SUMMARIZATION_THRESHOLD_TOKENS = "12000";
+
+    try {
+      expect(getSummarizationThresholdTokens(128_000)).toBe(12_000);
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+      if (originalDevThreshold === undefined) {
+        delete process.env.NEXT_PUBLIC_DEV_SUMMARIZATION_THRESHOLD_TOKENS;
+      } else {
+        process.env.NEXT_PUBLIC_DEV_SUMMARIZATION_THRESHOLD_TOKENS =
+          originalDevThreshold;
+      }
+    }
+  });
+
+  it("should ignore the development threshold outside development", () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    const originalDevThreshold =
+      process.env.NEXT_PUBLIC_DEV_SUMMARIZATION_THRESHOLD_TOKENS;
+
+    process.env.NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_DEV_SUMMARIZATION_THRESHOLD_TOKENS = "12000";
+
+    try {
+      expect(getSummarizationThresholdTokens(128_000)).toBe(115_200);
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+      if (originalDevThreshold === undefined) {
+        delete process.env.NEXT_PUBLIC_DEV_SUMMARIZATION_THRESHOLD_TOKENS;
+      } else {
+        process.env.NEXT_PUBLIC_DEV_SUMMARIZATION_THRESHOLD_TOKENS =
+          originalDevThreshold;
+      }
+    }
+  });
+
   it("should skip summarization when message count is insufficient", async () => {
     const messages = [createMessage("msg-1", "user")];
 

--- a/lib/chat/summarization/constants.ts
+++ b/lib/chat/summarization/constants.ts
@@ -5,10 +5,33 @@ export const MESSAGES_TO_KEEP_UNSUMMARIZED = 0;
 // enough room for tool schemas, provider formatting overhead, and output.
 export const SUMMARIZATION_RESERVED_MAX_TOKENS = 20_000;
 export const SUMMARIZATION_RESERVED_TOKEN_PERCENTAGE = 0.1;
+export const DEV_SUMMARIZATION_THRESHOLD_TOKENS_ENV =
+  "NEXT_PUBLIC_DEV_SUMMARIZATION_THRESHOLD_TOKENS";
 export const SUMMARY_PROMPT_VERSION = "2026-06-11.opencode-anchored-summary-v2";
+
+const getDevSummarizationThresholdTokens = (
+  maxTokens: number,
+): number | null => {
+  if (process.env.NODE_ENV !== "development") return null;
+
+  const configuredTokens = Number.parseInt(
+    process.env.NEXT_PUBLIC_DEV_SUMMARIZATION_THRESHOLD_TOKENS ?? "",
+    10,
+  );
+
+  if (!Number.isFinite(configuredTokens) || configuredTokens <= 0) {
+    return null;
+  }
+
+  return Math.min(maxTokens, Math.floor(configuredTokens));
+};
 
 export const getSummarizationThresholdTokens = (maxTokens: number): number => {
   const usableMaxTokens = Math.max(0, maxTokens);
+  const devThresholdTokens =
+    getDevSummarizationThresholdTokens(usableMaxTokens);
+  if (devThresholdTokens !== null) return devThresholdTokens;
+
   const reservedTokens = Math.min(
     SUMMARIZATION_RESERVED_MAX_TOKENS,
     Math.floor(usableMaxTokens * SUMMARIZATION_RESERVED_TOKEN_PERCENTAGE),

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -183,4 +183,41 @@ describe("getMessagesByChatId", () => {
       errorSpy.mockRestore();
     }
   });
+
+  it("does not inject a stored summary while regenerating", async () => {
+    const { getMessagesByChatId, mockQuery } = await loadSaveMessageWithMocks();
+    const lastUserMessage = {
+      id: "user-message-1",
+      role: "user" as const,
+      parts: [{ type: "text" as const, text: "do recon on hackerai.co" }],
+    };
+
+    mockQuery
+      .mockResolvedValueOnce({
+        id: "chat-1",
+        user_id: "user-1",
+        latest_summary_id: "summary-1",
+      })
+      .mockResolvedValueOnce({
+        page: [lastUserMessage],
+        isDone: true,
+        continueCursor: "",
+      });
+
+    const result = await getMessagesByChatId({
+      chatId: "chat-1",
+      userId: "user-1",
+      subscription: "pro",
+      newMessages: [],
+      regenerate: true,
+      isTemporary: false,
+      mode: "agent",
+    });
+
+    expect(result.truncatedMessages).toEqual([lastUserMessage]);
+    expect(JSON.stringify(result.truncatedMessages)).not.toContain(
+      "context_summary",
+    );
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
 });

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -646,9 +646,10 @@ export async function getMessagesByChatId({
     if (!isNewChat && !shouldUseClientMessagesForRegenerate) {
       try {
         // Fetch latest summary only if chat has a summary ID
-        const latestSummary = chat?.latest_summary_id
-          ? await getLatestSummary({ chatId })
-          : null;
+        const latestSummary =
+          !regenerate && chat?.latest_summary_id
+            ? await getLatestSummary({ chatId })
+            : null;
 
         // Adaptive paginated backfill: fetch pages until token budget is hit or cap reached
         const PAGE_SIZE = 24;
@@ -744,9 +745,9 @@ export async function getMessagesByChatId({
           // Use all fetched messages chronologically as existing
           existingMessages = [...fetchedDesc].reverse();
         } else {
-          // Apply summary if it exists (regardless of current mode)
-          // Note: Summaries are only created in agent mode but provide value in any mode
-          if (latestSummary) {
+          // Apply summary if it exists, except during regeneration where the
+          // deleted assistant response must not leak back into the new run.
+          if (latestSummary && !regenerate) {
             const summaryUpToId = latestSummary.summary_up_to_message_id;
 
             // Find cutoff index once

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1035,7 +1035,9 @@ export const agentLongTask = task({
 
             let finalMessages = processedMessages;
 
-            const resumeContext = getResumeSection(chat?.finish_reason);
+            const resumeContext = regenerate
+              ? ""
+              : getResumeSection(chat?.finish_reason);
             if (resumeContext) {
               finalMessages = appendSystemReminderToLastUserMessage(
                 finalMessages,


### PR DESCRIPTION
## Summary
- Prevent persisted regenerate requests from fetching or injecting stored conversation summaries.
- Clear chat summaries when the regenerate delete path removes the trailing assistant response chain.
- Suppress old finish-reason resume reminders during regenerate so a fresh regenerated answer does not receive stale "continue where you left off" instructions.
- Add a development-only auto-compaction threshold override for easier local testing.

## Root Cause
Regenerate trims/deletes the old assistant response, but the backend history rehydration path still treated the chat's stored `latest_summary_id` as valid. That meant `getMessagesByChatId` could prepend a synthetic summary user message before the visible regenerated prompt. In agent mode, a later preamble explicitly told the model to continue from that summary, so regenerating after compaction looked like an auto-continue of the deleted run.

The original summary injection path was introduced by `2fcf2d031` (`feat: add automatic conversation summarization for agent mode (#60)`) without a regenerate guard. `8e44e446` later added the agent resume preamble, amplifying the symptom.

## Validation
- `pnpm test -- lib/db/__tests__/actions-save-message.test.ts convex/__tests__/chatSummaryFallback.test.ts lib/chat/summarization/__tests__/index.test.ts app/components/__tests__/ContextUsageIndicator.test.tsx`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- Commit hook also ran `pnpm typecheck` and full `pnpm test`: 131 suites, 1467 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message regeneration now properly clears all associated chat summaries, ensuring clean message restarts.
  * Resume context no longer injected during message regeneration, preventing unwanted context contamination.

* **Chores**
  * Development-only summarization threshold configuration option added for testing purposes.

* **Tests**
  * Comprehensive test coverage added for message regeneration, chat summaries, and summarization configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->