### PR TITLE
[codex] remove Convex memories

### DIFF
--- a/app/components/PersonalizationTab.tsx
+++ b/app/components/PersonalizationTab.tsx
@@ -11,14 +11,12 @@ import type { SubscriptionTier } from "@/types";
 
 interface PersonalizationTabProps {
   onCustomInstructions: () => void;
-  // onManageMemories: () => void;
   onManageNotes: () => void;
   subscription?: SubscriptionTier;
 }
 
 const PersonalizationTab = ({
   onCustomInstructions,
-  // onManageMemories,
   onManageNotes,
   subscription,
 }: PersonalizationTabProps) => {
@@ -50,7 +48,7 @@ const PersonalizationTab = ({
         </div>
       </div>
 
-      {/* Notes Section (formerly Memory Section) */}
+      {/* Notes Section */}
       {subscription && (
         <div>
           <h3 className="text-lg font-medium mb-4 pb-2 border-b">Notes</h3>
@@ -63,11 +61,11 @@ const PersonalizationTab = ({
                 </div>
               </div>
               <Switch
-                checked={userCustomization?.include_memory_entries ?? true}
+                checked={userCustomization?.include_notes ?? true}
                 onCheckedChange={async (checked) => {
                   try {
                     await saveCustomization({
-                      include_memory_entries: checked,
+                      include_notes: checked,
                     });
                   } catch (error) {
                     console.error("Failed to save customization:", error);
@@ -90,9 +88,6 @@ const PersonalizationTab = ({
               <div>
                 <div className="font-medium">Manage notes</div>
               </div>
-              {/* <Button variant="outline" size="sm" onClick={onManageMemories}>
-                Manage
-              </Button> */}
               <Button variant="outline" size="sm" onClick={onManageNotes}>
                 Manage
               </Button>

--- a/app/trust/page.tsx
+++ b/app/trust/page.tsx
@@ -199,7 +199,7 @@ export default function TrustPage() {
                 "URLs and search queries used when the agent browses or searches the web",
                 "Terminal commands and their output from agent sandbox sessions",
                 "Browser screenshots captured inside the agent sandbox",
-                "Memories, notes, and custom instructions you save",
+                "Notes and custom instructions you save",
                 "Account information such as your email address and name",
                 "Usage analytics and error diagnostics",
               ]}

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -115,7 +115,6 @@ describe("userDeletion", () => {
       mockQueryBuilder.collect
         .mockResolvedValueOnce([]) // chats
         .mockResolvedValueOnce(mockFiles) // files
-        .mockResolvedValueOnce([]) // memories
         .mockResolvedValueOnce([]) // notes
         .mockResolvedValueOnce([]); // messages
 
@@ -200,7 +199,6 @@ describe("userDeletion", () => {
       mockQueryBuilder.collect
         .mockResolvedValueOnce([]) // chats
         .mockResolvedValueOnce(mockFiles) // files
-        .mockResolvedValueOnce([]) // memories
         .mockResolvedValueOnce([]) // notes
         .mockResolvedValueOnce([]); // messages
 
@@ -272,7 +270,6 @@ describe("userDeletion", () => {
       mockQueryBuilder.collect
         .mockResolvedValueOnce([]) // chats
         .mockResolvedValueOnce(mockFiles) // files
-        .mockResolvedValueOnce([]) // memories
         .mockResolvedValueOnce([]) // notes
         .mockResolvedValueOnce([]); // messages
 
@@ -348,7 +345,6 @@ describe("userDeletion", () => {
       mockQueryBuilder.collect
         .mockResolvedValueOnce([]) // chats
         .mockResolvedValueOnce(mockFiles) // files
-        .mockResolvedValueOnce([]) // memories
         .mockResolvedValueOnce([]) // notes
         .mockResolvedValueOnce([]); // messages
 
@@ -425,7 +421,6 @@ describe("userDeletion", () => {
       mockQueryBuilder.collect
         .mockResolvedValueOnce([]) // chats
         .mockResolvedValueOnce(mockFiles) // files
-        .mockResolvedValueOnce([]) // memories
         .mockResolvedValueOnce([]) // notes
         .mockResolvedValueOnce([]); // messages
 
@@ -488,7 +483,6 @@ describe("userDeletion", () => {
       mockQueryBuilder.collect
         .mockResolvedValueOnce([]) // chats
         .mockResolvedValueOnce([]) // files - empty
-        .mockResolvedValueOnce([]) // memories
         .mockResolvedValueOnce([]) // notes
         .mockResolvedValueOnce([]); // messages
 

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -133,7 +133,7 @@ export const createNoteForBackend = mutation({
 
 /**
  * Get notes for backend processing (for system prompt injection)
- * Enforces token limit based on user plan (same as memories)
+ * Enforces token limit based on user plan.
  * Returns notes sorted by updated_at (newest first)
  */
 export const getNotesForBackend = query({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -213,6 +213,10 @@ export default defineSchema({
     traits: v.optional(v.string()),
     additional_info: v.optional(v.string()),
     updated_at: v.number(),
+    include_notes: v.optional(v.boolean()),
+    // Legacy preference retained on historical rows so old documents still
+    // pass validation. New code writes include_notes and uses this only as a
+    // fallback when returning older customization rows.
     include_memory_entries: v.optional(v.boolean()),
     guardrails_config: v.optional(v.string()),
     caido_enabled: v.optional(v.boolean()),
@@ -414,16 +418,6 @@ export default defineSchema({
     ])
     .index("by_user_and_source", ["user_id", "source_id"])
     .index("by_customer_and_status", ["stripe_customer_id", "status"]),
-
-  memories: defineTable({
-    user_id: v.string(),
-    memory_id: v.string(),
-    content: v.string(),
-    update_time: v.number(),
-    tokens: v.number(),
-  })
-    .index("by_memory_id", ["memory_id"])
-    .index("by_user_and_update_time", ["user_id", "update_time"]),
 
   notes: defineTable({
     user_id: v.string(),

--- a/convex/userCustomization.ts
+++ b/convex/userCustomization.ts
@@ -2,6 +2,12 @@ import { mutation, query } from "./_generated/server";
 import { v, ConvexError } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 
+const shouldIncludeNotes = (customization: {
+  include_notes?: boolean;
+  include_memory_entries?: boolean;
+}) =>
+  customization.include_notes ?? customization.include_memory_entries ?? true;
+
 /**
  * Save or update user customization data
  */
@@ -12,7 +18,7 @@ export const saveUserCustomization = mutation({
     personality: v.optional(v.string()),
     traits: v.optional(v.string()),
     additional_info: v.optional(v.string()),
-    include_memory_entries: v.optional(v.boolean()),
+    include_notes: v.optional(v.boolean()),
     guardrails_config: v.optional(v.string()),
     caido_enabled: v.optional(v.boolean()),
     caido_port: v.optional(v.number()),
@@ -105,8 +111,8 @@ export const saveUserCustomization = mutation({
           patch.traits = args.traits.trim() || undefined;
         if (args.additional_info !== undefined)
           patch.additional_info = args.additional_info.trim() || undefined;
-        if (args.include_memory_entries !== undefined)
-          patch.include_memory_entries = args.include_memory_entries;
+        if (args.include_notes !== undefined)
+          patch.include_notes = args.include_notes;
         if (args.guardrails_config !== undefined)
           patch.guardrails_config = args.guardrails_config.trim() || undefined;
         if (args.caido_enabled !== undefined)
@@ -126,7 +132,7 @@ export const saveUserCustomization = mutation({
           personality: args.personality?.trim() || undefined,
           traits: args.traits?.trim() || undefined,
           additional_info: args.additional_info?.trim() || undefined,
-          include_memory_entries: args.include_memory_entries ?? true,
+          include_notes: args.include_notes ?? true,
           guardrails_config: args.guardrails_config?.trim() || undefined,
           caido_enabled: args.caido_enabled,
           caido_port: args.caido_port ? args.caido_port : undefined,
@@ -163,7 +169,7 @@ export const getUserCustomization = query({
       personality: v.optional(v.string()),
       traits: v.optional(v.string()),
       additional_info: v.optional(v.string()),
-      include_memory_entries: v.boolean(),
+      include_notes: v.boolean(),
       guardrails_config: v.optional(v.string()),
       caido_enabled: v.boolean(),
       caido_port: v.optional(v.number()),
@@ -193,7 +199,7 @@ export const getUserCustomization = query({
         personality: customization.personality,
         traits: customization.traits,
         additional_info: customization.additional_info,
-        include_memory_entries: customization.include_memory_entries ?? true,
+        include_notes: shouldIncludeNotes(customization),
         guardrails_config: customization.guardrails_config,
         caido_enabled: customization.caido_enabled ?? false,
         caido_port: customization.caido_port,
@@ -223,7 +229,7 @@ export const getUserCustomizationForBackend = query({
       personality: v.optional(v.string()),
       traits: v.optional(v.string()),
       additional_info: v.optional(v.string()),
-      include_memory_entries: v.boolean(),
+      include_notes: v.boolean(),
       guardrails_config: v.optional(v.string()),
       caido_enabled: v.boolean(),
       caido_port: v.optional(v.number()),
@@ -250,7 +256,7 @@ export const getUserCustomizationForBackend = query({
         personality: customization.personality,
         traits: customization.traits,
         additional_info: customization.additional_info,
-        include_memory_entries: customization.include_memory_entries ?? true,
+        include_notes: shouldIncludeNotes(customization),
         guardrails_config: customization.guardrails_config,
         caido_enabled: customization.caido_enabled ?? false,
         caido_port: customization.caido_port,

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -13,9 +13,8 @@ import { fileCountAggregate } from "./fileAggregate";
  * 4) Files + storage (owned by user, may be referenced by messages)
  *    - S3 files: Batch deleted using scheduled action
  *    - Convex storage files: Deleted directly
- * 5) Memories (owned by user)
- * 6) Notes (owned by user)
- * 7) User customization (owned by user)
+ * 5) Notes (owned by user)
+ * 6) User customization (owned by user)
  *
  * Uses parallel queries and deletions for optimal performance.
  * S3 cleanup is scheduled asynchronously and errors don't block user deletion.
@@ -31,7 +30,7 @@ export const deleteAllUserData = mutation({
 
     try {
       // Fetch all user data in parallel using indexed queries
-      const [chats, files, memories, notes, customization, messagesByUser] =
+      const [chats, files, notes, customization, messagesByUser] =
         await Promise.all([
           ctx.db
             .query("chats")
@@ -42,12 +41,6 @@ export const deleteAllUserData = mutation({
           ctx.db
             .query("files")
             .withIndex("by_user_id", (q) => q.eq("user_id", user.subject))
-            .collect(),
-          ctx.db
-            .query("memories")
-            .withIndex("by_user_and_update_time", (q) =>
-              q.eq("user_id", user.subject),
-            )
             .collect(),
           ctx.db
             .query("notes")
@@ -158,18 +151,7 @@ export const deleteAllUserData = mutation({
         }
       }
 
-      // Step 5: Delete memories (independent of other data)
-      await Promise.all(
-        memories.map(async (memory) => {
-          try {
-            await ctx.db.delete(memory._id);
-          } catch (error) {
-            console.error(`Failed to delete memory ${memory._id}:`, error);
-          }
-        }),
-      );
-
-      // Step 6: Delete notes (independent of other data)
+      // Step 5: Delete notes (independent of other data)
       await Promise.all(
         notes.map(async (note) => {
           try {
@@ -180,7 +162,7 @@ export const deleteAllUserData = mutation({
         }),
       );
 
-      // Step 7: Delete user customization (independent of other data)
+      // Step 6: Delete user customization (independent of other data)
       if (customization) {
         try {
           await ctx.db.delete(customization._id);

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -50,7 +50,7 @@ export const createTools = (
   mode: ChatMode = "agent",
   userLocation: Geo,
   initialTodos?: Todo[],
-  memoryEnabled: boolean = true,
+  notesEnabled: boolean = true,
   isTemporary: boolean = false,
   assistantMessageId?: string,
   sandboxPreference?: SandboxPreference,
@@ -146,7 +146,7 @@ export const createTools = (
       file: createFile(context),
       todo_write: createTodoWrite(context),
       ...(!isTemporary &&
-        memoryEnabled && {
+        notesEnabled && {
           create_note: createCreateNote(context),
           list_notes: createListNotes(context),
           update_note: createUpdateNote(context),
@@ -166,7 +166,7 @@ export const createTools = (
     return mode === "ask"
       ? {
           ...(!isTemporary &&
-            memoryEnabled && {
+            notesEnabled && {
               create_note: allTools.create_note,
               list_notes: allTools.list_notes,
               update_note: allTools.update_note,

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -777,7 +777,7 @@ describe("createChatLogger OpenRouter metadata", () => {
           messageCount: 1,
           estimatedInputTokens: 100,
           isNewChat: false,
-          memoryEnabled: false,
+          notesEnabled: false,
         },
         "model-opus-4.6",
       );

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -287,9 +287,9 @@ export const createChatHandler = () => {
         );
       }
 
-      const memoryEnabled =
+      const notesEnabled =
         (subscription !== "free" || isAgentMode(mode)) &&
-        (userCustomization?.include_memory_entries ?? true);
+        (userCustomization?.include_notes ?? true);
 
       const estimatedInputTokens = await estimatePreflightInputTokens({
         mode,
@@ -309,7 +309,7 @@ export const createChatHandler = () => {
           isNewChat,
           fileCount: fileCounts.totalFiles,
           imageCount: fileCounts.imageCount,
-          memoryEnabled,
+          notesEnabled,
         },
         selectedModel,
       );
@@ -416,7 +416,7 @@ export const createChatHandler = () => {
               mode,
               userLocation,
               baseTodos,
-              memoryEnabled,
+              notesEnabled,
               temporary,
               assistantMessageId,
               sandboxPreference,
@@ -566,8 +566,7 @@ export const createChatHandler = () => {
 
             // Inject notes into messages instead of system prompt
             // to keep the system prompt stable for prompt caching
-            const shouldIncludeNotes =
-              userCustomization?.include_memory_entries ?? true;
+            const shouldIncludeNotes = userCustomization?.include_notes ?? true;
             const noteInjectionOpts = {
               userId,
               subscription,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -67,7 +67,7 @@ export interface ChatContext {
   isNewChat: boolean;
   fileCount?: number;
   imageCount?: number;
-  memoryEnabled: boolean;
+  notesEnabled: boolean;
 }
 
 export interface RateLimitContext {

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -73,7 +73,7 @@ export interface ChatWideEvent {
     is_new_chat: boolean;
     file_count?: number;
     image_count?: number;
-    memory_enabled: boolean;
+    notes_enabled: boolean;
   };
 
   // Extra usage context (paid users)
@@ -304,7 +304,7 @@ export class WideEventBuilder {
     isNewChat: boolean;
     fileCount?: number;
     imageCount?: number;
-    memoryEnabled: boolean;
+    notesEnabled: boolean;
   }): this {
     this.event.chat = {
       message_count: chat.messageCount,
@@ -312,7 +312,7 @@ export class WideEventBuilder {
       is_new_chat: chat.isNewChat,
       file_count: chat.fileCount,
       image_count: chat.imageCount,
-      memory_enabled: chat.memoryEnabled,
+      notes_enabled: chat.notesEnabled,
     };
     return this;
   }

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -430,7 +430,7 @@ export const systemPrompt = async (
 ): Promise<string> => {
   const shouldIncludeNotes =
     (subscription !== "free" || mode === "agent") &&
-    (userCustomization?.include_memory_entries ?? true);
+    (userCustomization?.include_notes ?? true);
 
   const personalityInstructions = getPersonalityInstructions(
     userCustomization?.personality,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -764,7 +764,7 @@ export const agentLongTask = task({
         );
       }
 
-      const memoryEnabled = userCustomization?.include_memory_entries ?? true;
+      const notesEnabled = userCustomization?.include_notes ?? true;
 
       const estimatedInputTokens = await estimatePreflightInputTokens({
         mode,
@@ -783,7 +783,7 @@ export const agentLongTask = task({
           isNewChat: !!isNewChat,
           fileCount: 0,
           imageCount: 0,
-          memoryEnabled,
+          notesEnabled,
         },
         selectedModel,
       );
@@ -907,7 +907,7 @@ export const agentLongTask = task({
               mode,
               userLocation,
               baseTodos,
-              memoryEnabled,
+              notesEnabled,
               !!temporary,
               assistantMessageId,
               sandboxPreference,
@@ -1048,8 +1048,7 @@ export const agentLongTask = task({
             const noteInjectionOpts = {
               userId,
               subscription,
-              shouldIncludeNotes:
-                userCustomization?.include_memory_entries ?? true,
+              shouldIncludeNotes: userCustomization?.include_notes ?? true,
               isTemporary: !!temporary as boolean | undefined,
             };
             finalMessages = await injectNotesIntoMessages(

--- a/types/user.ts
+++ b/types/user.ts
@@ -4,7 +4,7 @@ export interface UserCustomization {
   readonly personality?: string;
   readonly traits?: string;
   readonly additional_info?: string;
-  readonly include_memory_entries?: boolean;
+  readonly include_notes?: boolean;
   readonly caido_enabled?: boolean;
   /** Custom Caido port for local sandbox users with an existing Caido instance (default: 48080). */
   readonly caido_port?: number;


### PR DESCRIPTION
## Summary

Removes the old Convex `memories` table and account-deletion cleanup path now that production memory rows have been deleted and notes are the active persistence surface.

## Changes

- Remove the `memories` table from the Convex schema.
- Stop querying/deleting `memories` during account deletion.
- Rename the live customization toggle and runtime plumbing from `include_memory_entries` / `memoryEnabled` to notes-focused names.
- Preserve existing opt-out preferences by returning `include_notes` from the old `include_memory_entries` field only when reading older customization rows.
- Update settings and trust-page copy so the product no longer advertises memories.

## Validation

- `pnpm exec convex codegen`
- `pnpm jest convex/__tests__/userDeletion.test.ts lib/api/__tests__/chat-logger.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- Pre-commit hook: `tsc --noEmit` and full `jest` suite: 131 suites / 1469 tests passed

## Notes

`include_memory_entries` remains only as an optional legacy schema field and read fallback so historical `user_customization` rows still validate and keep their previous notes opt-out behavior; new writes use `include_notes`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Notes feature is now fully integrated and functional with proper persistence and management options.

* **Bug Fixes**
  * Fixed Notes customization setting to save and restore correctly.

* **Documentation**
  * Updated terminology throughout the app from "Memory" to "Notes" for consistency.
  * Updated data processing documentation to reflect current feature set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->