### PR TITLE
[codex] Handle binary media in summary compaction

### DIFF
--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -40,6 +40,7 @@ const {
   extractSummaryText,
   buildSummaryMessage,
   boundModelMessagesForSummarization,
+  compactModelMessagesForSummarization,
   estimateSummaryInputTokens,
 } = require("../helpers") as typeof import("../helpers");
 
@@ -503,6 +504,35 @@ describe("checkAndSummarizeIfNeeded", () => {
     expect(serializedMessages).toContain("media payloads omitted");
     expect(serializedMessages).not.toContain(dataUri);
     expect(serializedMessages).not.toContain(rawSnapshot);
+  });
+
+  it("should convert native image and binary file parts to text placeholders", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            mediaType: "image/png",
+            image: new Uint8Array([1, 2, 3, 4]),
+          },
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            filename: "report.pdf",
+            data: new Uint8Array([5, 6, 7, 8]),
+          },
+        ],
+      },
+    ] as unknown as ModelMessage[];
+
+    const compacted = compactModelMessagesForSummarization(messages);
+
+    expect(compacted[0].content).toEqual([
+      { type: "text", text: "[Attached image/png: file]" },
+      { type: "text", text: "[Attached application/pdf: report.pdf]" },
+    ]);
+    expect(JSON.stringify(compacted)).not.toContain('"0":1');
   });
 
   it("should bound total summarization modelMessages input", () => {

--- a/lib/chat/summarization/helpers.ts
+++ b/lib/chat/summarization/helpers.ts
@@ -217,9 +217,15 @@ const describeAttachmentObject = (
       : undefined);
   const filename =
     getStringField(value, ["filename", "fileName", "name", "path"]) ?? "file";
-  const hasPayload = ["url", "uri", "data", "base64", "content", "value"].some(
-    (key) => typeof value[key] === "string" && value[key],
-  );
+  const hasPayload = [
+    "url",
+    "uri",
+    "image",
+    "data",
+    "base64",
+    "content",
+    "value",
+  ].some((key) => value[key] != null && value[key] !== "");
   const keySuggestsMedia = keyHint ? MEDIA_KEY_PATTERN.test(keyHint) : false;
   const typeSuggestsMedia =
     typeof value.type === "string" && MEDIA_KEY_PATTERN.test(value.type);


### PR DESCRIPTION
## Summary

- Treat native AI SDK image parts and binary file/image payloads as media during summary compaction.
- Convert those media parts into textual attachment placeholders before they reach the summary model.
- Add a regression test covering native `image` parts and binary `file` parts.

## Why

Summary generation should preserve the fact that an attachment existed without passing raw binary/base64 media into the compaction model. The previous detector only considered string payloads and missed the native `image` field plus non-string payloads like `Uint8Array`.

## Validation

- `pnpm jest lib/chat/summarization/__tests__/index.test.ts --runInBand --runTestsByPath`
- `pnpm exec eslint lib/chat/summarization/helpers.ts lib/chat/summarization/__tests__/index.test.ts --max-warnings=0`
- commit hook: `pnpm typecheck`
- commit hook: `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for message compaction with binary media and file attachments

* **Bug Fixes**
  * Enhanced detection of media attachments in chat message summarization to correctly identify binary content and files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->