### PR TITLE
[codex] Add Exacto routing to Kimi 2.7

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -223,9 +223,9 @@ describe("supportsMultimodalToolResults", () => {
   it("allows Kimi registry keys and OpenRouter slugs for image tool result experiments", () => {
     expect(supportsMultimodalToolResults("model-kimi-k2.7-code")).toBe(true);
     expect(supportsMultimodalToolResults("agent-model")).toBe(true);
-    expect(supportsMultimodalToolResults("moonshotai/kimi-k2.7-code")).toBe(
-      true,
-    );
+    expect(
+      supportsMultimodalToolResults("moonshotai/kimi-k2.7-code:exacto"),
+    ).toBe(true);
   });
 
   it("still rejects text-only DeepSeek routes", () => {

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -245,7 +245,7 @@ const openrouter = createOpenRouter({
 
 type OpenRouterInstance = typeof openrouter;
 
-const KIMI_K2_7_CODE_SLUG = "moonshotai/kimi-k2.7-code";
+const KIMI_K2_7_CODE_SLUG = "moonshotai/kimi-k2.7-code:exacto";
 
 const buildProviderMap = (or: OpenRouterInstance) =>
   ({

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -377,7 +377,7 @@ describe("createChatLogger provider stream termination", () => {
       chatLogger.recordProviderError(err, {
         mode: "agent",
         model: "agent-model",
-        requestedModelSlug: "moonshotai/kimi-k2.7-code",
+        requestedModelSlug: "moonshotai/kimi-k2.7-code:exacto",
       });
       chatLogger.emitUnexpectedError(err);
 
@@ -833,7 +833,7 @@ describe("createChatLogger provider stream timeout", () => {
       chatLogger.recordProviderError(err, {
         mode: "agent",
         model: "agent-model",
-        requestedModelSlug: "moonshotai/kimi-k2.7-code",
+        requestedModelSlug: "moonshotai/kimi-k2.7-code:exacto",
       });
       chatLogger.emitUnexpectedError(err);
 

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -21,7 +21,7 @@ jest.mock("@/lib/logger", () => ({
 const GEMINI_SLUG = "google/gemini-3-flash-preview";
 const GEMINI_3_5_SLUG = "google/gemini-3.5-flash";
 const GROK_SLUG = "x-ai/grok-4.3";
-const KIMI_SLUG = "moonshotai/kimi-k2.7-code";
+const KIMI_SLUG = "moonshotai/kimi-k2.7-code:exacto";
 
 describe("buildProviderOptions fallback chain", () => {
   it("resolves Opus 4.6 ask chain to Gemini slug", () => {

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -34,7 +34,7 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   "fallback-gemini-3.5-flash": { input: 1.5, output: 9.0 },
   "model-opus-4.6": { input: 5.0, output: 25.0 },
   // "agent-model" and "model-kimi-k2.7-code" route to
-  // moonshotai/kimi-k2.7-code via lib/ai/providers.ts. Rates from OpenRouter:
+  // moonshotai/kimi-k2.7-code:exacto via lib/ai/providers.ts. Rates from OpenRouter:
   // $0.95 in / $4.00 out per 1M tokens. The old model-kimi-k2.6 key remains
   // priced here as a compatibility alias. Cache-read discount ($0.16/M) applies
   // when provider cost is available via usage.raw.cost.


### PR DESCRIPTION
## Summary

- Route the shared Kimi K2.7 Code OpenRouter slug through the `:exacto` variant.
- Update fallback-chain, provider, logger, and rate-limit references that pin the Kimi slug.

## Why

OpenRouter's Exacto variant applies quality-first provider sorting for stronger tool-calling reliability. Kimi is used for agent routes, so routing it through `:exacto` should improve tool-heavy agent behavior without changing the internal model key exposed to the rest of the app.

## Validation

- `pnpm test -- --runTestsByPath lib/ai/__tests__/providers.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/api/__tests__/chat-logger.test.ts --runInBand`
- Commit hook: `pnpm typecheck`
- Commit hook: `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test suites to reflect Kimi K2.7 Code model identifier changes across provider and fallback scenarios.

* **Chores**
  * Updated Kimi K2.7 Code model routing configuration.
  * Clarified model pricing documentation references for accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->