### PR TITLE
[codex] Route Trigger runs by Vercel continent

### DIFF
--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -12,6 +12,7 @@ import {
   setActiveTriggerRun,
 } from "@/lib/db/actions";
 import { assertFreeAgentGates } from "@/lib/api/chat-stream-helpers";
+import { getTriggerRegionForVercelRequest } from "@/lib/api/trigger-region";
 import { coerceSelectedModel } from "@/types";
 import { ChatSDKError } from "@/lib/errors";
 import type { Todo, SandboxPreference, SelectedModel } from "@/types";
@@ -56,6 +57,7 @@ export async function POST(req: NextRequest) {
     const { userId, subscription, organizationId } = await getUserIDAndPro(req);
     await assertUserCanMakeCostIncurringRequest(userId);
     const userLocation = geolocation(req);
+    const triggerRegion = getTriggerRegionForVercelRequest(req);
 
     assertFreeAgentGates({
       mode: "agent",
@@ -196,6 +198,7 @@ export async function POST(req: NextRequest) {
       },
       {
         tags: triggerTags,
+        region: triggerRegion,
         metadata: {
           status: "queued",
           chatId,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -342,4 +342,21 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(emptyPayloadIdx).toBeGreaterThan(guardIdx);
     expect(triggerIdx).toBeGreaterThan(emptyPayloadIdx);
   });
+
+  test("agent-long passes Vercel-derived region to Trigger.dev", () => {
+    const routingIdx = routeSrc.indexOf(
+      "getTriggerRegionForVercelRequest(req)",
+    );
+    const triggerIdx = routeSrc.indexOf("tasks.trigger", routingIdx);
+    const regionOptionIdx = routeSrc.indexOf(
+      "region: triggerRegion",
+      triggerIdx,
+    );
+
+    expect(routingIdx).toBeGreaterThan(-1);
+    expect(triggerIdx).toBeGreaterThan(routingIdx);
+    expect(regionOptionIdx).toBeGreaterThan(triggerIdx);
+    expect(routeSrc).not.toMatch(/vercelIpContinent|vercelIpCountry/);
+    expect(routeSrc).not.toMatch(/trigger region routing/);
+  });
 });

--- a/lib/api/__tests__/trigger-region.test.ts
+++ b/lib/api/__tests__/trigger-region.test.ts
@@ -1,0 +1,49 @@
+import { getTriggerRegionForVercelRequest } from "../trigger-region";
+
+function requestWithHeaders(headers: Record<string, string | undefined>) {
+  return {
+    headers: new Headers(
+      Object.entries(headers).filter(
+        (entry): entry is [string, string] => entry[1] !== undefined,
+      ),
+    ),
+  };
+}
+
+describe("getTriggerRegionForVercelRequest", () => {
+  test("routes European requests to eu-central-1", () => {
+    expect(
+      getTriggerRegionForVercelRequest(
+        requestWithHeaders({
+          "x-vercel-ip-continent": "EU",
+        }),
+      ),
+    ).toBe("eu-central-1");
+  });
+
+  test("routes non-European requests to us-east-1", () => {
+    expect(
+      getTriggerRegionForVercelRequest(
+        requestWithHeaders({
+          "x-vercel-ip-continent": "NA",
+        }),
+      ),
+    ).toBe("us-east-1");
+  });
+
+  test("defaults to us-east-1 when Vercel headers are unavailable", () => {
+    expect(getTriggerRegionForVercelRequest(requestWithHeaders({}))).toBe(
+      "us-east-1",
+    );
+  });
+
+  test("normalizes Vercel header values", () => {
+    expect(
+      getTriggerRegionForVercelRequest(
+        requestWithHeaders({
+          "x-vercel-ip-continent": " eu ",
+        }),
+      ),
+    ).toBe("eu-central-1");
+  });
+});

--- a/lib/api/trigger-region.ts
+++ b/lib/api/trigger-region.ts
@@ -1,0 +1,16 @@
+export type TriggerRunRegion = "eu-central-1" | "us-east-1";
+
+function normalizeVercelHeader(value: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toUpperCase() : null;
+}
+
+export function getTriggerRegionForVercelRequest(request: {
+  headers: Headers;
+}): TriggerRunRegion {
+  const continent = normalizeVercelHeader(
+    request.headers.get("x-vercel-ip-continent"),
+  );
+
+  return continent === "EU" ? "eu-central-1" : "us-east-1";
+}


### PR DESCRIPTION
## Summary

Route Trigger.dev `agent-long` runs based on Vercel server-side geo headers.

- Adds a small helper that maps `x-vercel-ip-continent: EU` to `eu-central-1` and defaults everything else to `us-east-1`.
- Passes the selected region to `tasks.trigger` for `agent-long` runs.
- Keeps the routing decision out of logs and Trigger metadata after preview verification.
- Adds focused tests for the region helper and a contract test for the Trigger option wiring.

## Why

Local `next dev` does not include Vercel geo headers, so local requests use the safe `us-east-1` fallback. Preview/staging/prod requests use Vercel injected continent headers to schedule EU users closer to Europe.

## Validation

- `pnpm test -- lib/api/__tests__/trigger-region.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec prettier --check app/api/agent-long/route.ts lib/api/trigger-region.ts lib/api/__tests__/trigger-region.test.ts lib/api/__tests__/agent-long-contracts.test.ts`
- pre-commit hook: `pnpm typecheck`
- pre-commit hook: `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic regional routing for agent task execution, selecting the optimal region (Europe or US) based on request location for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->