### PR TITLE
[codex] Enable medium ask reasoning for Pro and Max

### DIFF
--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -162,6 +162,30 @@ describe("buildProviderOptions fallback chain", () => {
     expect(opts.openrouter).not.toHaveProperty("models");
   });
 
+  it.each([
+    "ask-model",
+    "ask-model-free",
+    "model-gemini-3-flash",
+    "model-deepseek-v4-flash",
+  ])(
+    "keeps reasoning disabled for auto/standard ask mode model %s",
+    (modelName) => {
+      const opts = buildProviderOptions(false, "user-1", modelName, "ask");
+      expect(opts.openrouter.reasoning).toEqual({ enabled: false });
+    },
+  );
+
+  it.each(["model-deepseek-v4-pro", "model-sonnet-4.6", "model-opus-4.6"])(
+    "enables medium reasoning for ask mode model %s",
+    (modelName) => {
+      const opts = buildProviderOptions(false, "user-1", modelName, "ask");
+      expect(opts.openrouter.reasoning).toEqual({
+        enabled: true,
+        effort: "medium",
+      });
+    },
+  );
+
   it("includes reasoning settings independent of fallback chain", () => {
     const reasoning = buildProviderOptions(
       true,

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -490,6 +490,16 @@ const ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN = [
   "fallback-grok-4.3",
 ] as const satisfies readonly ModelName[];
 
+const ASK_MEDIUM_REASONING_MODELS = [
+  "model-deepseek-v4-pro",
+  "model-sonnet-4.6",
+  "model-opus-4.6",
+] as const satisfies readonly ModelName[];
+
+const isAskMediumReasoningModel = (modelName?: string): boolean =>
+  typeof modelName === "string" &&
+  (ASK_MEDIUM_REASONING_MODELS as readonly string[]).includes(modelName);
+
 type FallbackOptions = {
   hasMultimodalToolResults?: boolean;
 };
@@ -566,17 +576,12 @@ export function buildProviderOptions(
   const modelId = modelName ? resolveSlug(modelName) : undefined;
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
   const fallbackSlugs = getFallbackSlugs(modelName, mode, options);
-  const isAskProOrMaxModel =
-    mode === "ask" &&
-    (modelName === "model-deepseek-v4-pro" ||
-      modelName === "model-sonnet-4.6" ||
-      modelName === "model-opus-4.6");
   const reasoning = isReasoningModel
     ? {
         enabled: true,
         ...(isDeepSeekV4 && { effort: "xhigh" }),
       }
-    : isAskProOrMaxModel
+    : mode === "ask" && isAskMediumReasoningModel(modelName)
       ? { enabled: true, effort: "medium" }
       : { enabled: false };
 

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -566,16 +566,23 @@ export function buildProviderOptions(
   const modelId = modelName ? resolveSlug(modelName) : undefined;
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
   const fallbackSlugs = getFallbackSlugs(modelName, mode, options);
+  const isAskProOrMaxModel =
+    mode === "ask" &&
+    (modelName === "model-deepseek-v4-pro" ||
+      modelName === "model-sonnet-4.6" ||
+      modelName === "model-opus-4.6");
+  const reasoning = isReasoningModel
+    ? {
+        enabled: true,
+        ...(isDeepSeekV4 && { effort: "xhigh" }),
+      }
+    : isAskProOrMaxModel
+      ? { enabled: true, effort: "medium" }
+      : { enabled: false };
+
   return {
     openrouter: {
-      ...(isReasoningModel
-        ? {
-            reasoning: {
-              enabled: true,
-              ...(isDeepSeekV4 && { effort: "xhigh" }),
-            },
-          }
-        : { reasoning: { enabled: false } }),
+      reasoning,
       ...(userId && { user: userId }),
       ...(fallbackSlugs.length > 0 && { models: fallbackSlugs }),
     },


### PR DESCRIPTION
## Summary

- Enable OpenRouter medium reasoning only for ask-mode Pro and Max model routes.
- Keep auto and Standard ask models explicitly non-reasoning for the narrower rollout.
- Add provider-options coverage for both ask-mode buckets.

## Why

Ask mode previously treated all non-agent routes as non-reasoning. This change lets higher-tier ask models use medium reasoning without changing the cost/latency profile of auto or Standard ask routes.

## Validation

- `pnpm test -- lib/api/__tests__/chat-stream-helpers-fallback.test.ts --runInBand`
- `pnpm typecheck`
- Commit hook: full `jest` suite, 131 suites / 1470 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined OpenRouter reasoning configuration for ask-mode models to enable medium-effort reasoning for select model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->