### PR TITLE
[codex] Handle missing legacy storage blobs

### DIFF
--- a/convex/__tests__/fileStorage.delete.test.ts
+++ b/convex/__tests__/fileStorage.delete.test.ts
@@ -493,4 +493,40 @@ describe("fileStorage - purgeLegacyConvexStorageFiles", () => {
       aggregateRemovedCount: 1,
     });
   });
+
+  it("clears stale DB references when the Convex storage blob is already missing", async () => {
+    const { chain } = makeQueryChain([attachedLegacyFile]);
+    mockCtx.db.query.mockReturnValue(chain);
+    mockCtx.storage.delete.mockRejectedValue(
+      new Error(`storage id ${attachedLegacyFile.storage_id} not found`),
+    );
+
+    const { purgeLegacyConvexStorageFiles } = await import("../fileStorage");
+
+    const result = await purgeLegacyConvexStorageFiles.handler(mockCtx, {
+      serviceKey: "service-key",
+      cutoffTimeMs,
+      dryRun: false,
+      includeAttached: true,
+    });
+
+    expect(mockCtx.storage.delete).toHaveBeenCalledWith(
+      attachedLegacyFile.storage_id,
+    );
+    expect(mockFileCountAggregate.deleteIfExists).toHaveBeenCalledWith(
+      mockCtx,
+      attachedLegacyFile,
+    );
+    expect(mockCtx.db.patch).toHaveBeenCalledWith(attachedLegacyFile._id, {
+      storage_id: undefined,
+    });
+    expect(result).toMatchObject({
+      deletedStorageCount: 0,
+      missingStorageCount: 1,
+      detachedRecordCount: 1,
+      aggregateRemovedCount: 1,
+      failedCount: 0,
+      failures: [],
+    });
+  });
 });

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -18,6 +18,12 @@ const LEGACY_CONVEX_PURGE_DEFAULT_LIMIT = 100;
 const LEGACY_CONVEX_PURGE_MAX_LIMIT = 500;
 const LEGACY_CONVEX_PURGE_SAMPLE_LIMIT = 20;
 
+function isMissingConvexStorageError(error: unknown): boolean {
+  return (
+    error instanceof Error && /^storage id .+ not found$/.test(error.message)
+  );
+}
+
 /**
  * Get download URL for a file by storageId (on-demand for non-image files)
  */
@@ -340,6 +346,7 @@ export const purgeLegacyConvexStorageFiles = mutation({
     attachedCount: v.number(),
     unattachedCount: v.number(),
     deletedStorageCount: v.number(),
+    missingStorageCount: v.number(),
     detachedRecordCount: v.number(),
     deletedRecordCount: v.number(),
     aggregateRemovedCount: v.number(),
@@ -417,6 +424,7 @@ export const purgeLegacyConvexStorageFiles = mutation({
       }));
 
     let deletedStorageCount = 0;
+    let missingStorageCount = 0;
     let detachedRecordCount = 0;
     let deletedRecordCount = 0;
     let aggregateRemovedCount = 0;
@@ -429,8 +437,20 @@ export const purgeLegacyConvexStorageFiles = mutation({
     if (!dryRun) {
       for (const file of candidates) {
         try {
-          await ctx.storage.delete(file.storage_id);
-          deletedStorageCount++;
+          try {
+            await ctx.storage.delete(file.storage_id);
+            deletedStorageCount++;
+          } catch (error) {
+            if (!isMissingConvexStorageError(error)) {
+              throw error;
+            }
+
+            missingStorageCount++;
+            convexLogger.warn("legacy_convex_storage_already_missing", {
+              fileId: file._id,
+              userId: file.user_id,
+            });
+          }
 
           await fileCountAggregate.deleteIfExists(ctx, file);
           aggregateRemovedCount++;
@@ -477,6 +497,7 @@ export const purgeLegacyConvexStorageFiles = mutation({
       attachedCount,
       unattachedCount,
       deletedStorageCount,
+      missingStorageCount,
       detachedRecordCount,
       deletedRecordCount,
       aggregateRemovedCount,
@@ -496,6 +517,7 @@ export const purgeLegacyConvexStorageFiles = mutation({
       attachedCount,
       unattachedCount,
       deletedStorageCount,
+      missingStorageCount,
       detachedRecordCount,
       deletedRecordCount,
       aggregateRemovedCount,


### PR DESCRIPTION
## Summary

Makes the legacy Convex storage purge idempotent when a `files.storage_id` points at a Convex storage blob that is already missing.

## Why

During the production purge, some rows failed with `storage id ... not found`. That means the blob is already gone, but the DB row still has `storage_id`, so the current purge keeps retrying the same stale rows forever.

## What changed

- Treat `storage id ... not found` as an already-deleted blob instead of a hard failure.
- Count those rows as `missingStorageCount`.
- Still remove the row from the storage aggregate.
- Still clear `storage_id` or delete the DB row depending on `deleteDatabaseRecords`.
- Add a regression test for already-missing Convex storage blobs.

## Validation

- `pnpm jest convex/__tests__/fileStorage.delete.test.ts --runInBand`
- `pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File cleanup operations now gracefully handle missing storage files, allowing the process to continue instead of failing. Enhanced tracking has been added for visibility into these edge cases.

* **Tests**
  * Added test coverage for file cleanup operations when underlying storage blobs are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->