### PR TITLE
[codex] Continue legacy purge when cleanup hits read limits

### DIFF
--- a/convex/__tests__/fileStorage.delete.test.ts
+++ b/convex/__tests__/fileStorage.delete.test.ts
@@ -529,4 +529,42 @@ describe("fileStorage - purgeLegacyConvexStorageFiles", () => {
       failures: [],
     });
   });
+
+  it("still clears storage_id when aggregate cleanup exceeds Convex read limits", async () => {
+    const { chain } = makeQueryChain([attachedLegacyFile]);
+    mockCtx.db.query.mockReturnValue(chain);
+    mockFileCountAggregate.deleteIfExists.mockRejectedValueOnce(
+      new Error(
+        "Uncaught Error: Too many bytes read in a single function execution (limit: 16777216 bytes).",
+      ),
+    );
+
+    const { purgeLegacyConvexStorageFiles } = await import("../fileStorage");
+
+    const result = await purgeLegacyConvexStorageFiles.handler(mockCtx, {
+      serviceKey: "service-key",
+      cutoffTimeMs,
+      dryRun: false,
+      includeAttached: true,
+    });
+
+    expect(mockCtx.storage.delete).toHaveBeenCalledWith(
+      attachedLegacyFile.storage_id,
+    );
+    expect(mockFileCountAggregate.deleteIfExists).toHaveBeenCalledWith(
+      mockCtx,
+      attachedLegacyFile,
+    );
+    expect(mockCtx.db.patch).toHaveBeenCalledWith(attachedLegacyFile._id, {
+      storage_id: undefined,
+    });
+    expect(result).toMatchObject({
+      deletedStorageCount: 1,
+      aggregateRemovedCount: 0,
+      aggregateFailedCount: 1,
+      detachedRecordCount: 1,
+      failedCount: 0,
+      failures: [],
+    });
+  });
 });

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -350,6 +350,7 @@ export const purgeLegacyConvexStorageFiles = mutation({
     detachedRecordCount: v.number(),
     deletedRecordCount: v.number(),
     aggregateRemovedCount: v.number(),
+    aggregateFailedCount: v.number(),
     failedCount: v.number(),
     samples: v.array(
       v.object({
@@ -428,6 +429,7 @@ export const purgeLegacyConvexStorageFiles = mutation({
     let detachedRecordCount = 0;
     let deletedRecordCount = 0;
     let aggregateRemovedCount = 0;
+    let aggregateFailedCount = 0;
     const failures: Array<{
       fileId: Id<"files">;
       name: string;
@@ -452,8 +454,27 @@ export const purgeLegacyConvexStorageFiles = mutation({
             });
           }
 
-          await fileCountAggregate.deleteIfExists(ctx, file);
-          aggregateRemovedCount++;
+          try {
+            await fileCountAggregate.deleteIfExists(ctx, file);
+            aggregateRemovedCount++;
+          } catch (error) {
+            aggregateFailedCount++;
+            convexLogger.warn(
+              "legacy_convex_storage_aggregate_cleanup_failed",
+              {
+                fileId: file._id,
+                userId: file.user_id,
+                error:
+                  error instanceof Error
+                    ? {
+                        name: error.name,
+                        message: error.message,
+                        stack: error.stack,
+                      }
+                    : String(error),
+              },
+            );
+          }
 
           if (deleteDatabaseRecords) {
             await ctx.db.delete(file._id);
@@ -501,6 +522,7 @@ export const purgeLegacyConvexStorageFiles = mutation({
       detachedRecordCount,
       deletedRecordCount,
       aggregateRemovedCount,
+      aggregateFailedCount,
       failedCount: failures.length,
       samples,
       failures,
@@ -521,6 +543,7 @@ export const purgeLegacyConvexStorageFiles = mutation({
       detachedRecordCount,
       deletedRecordCount,
       aggregateRemovedCount,
+      aggregateFailedCount,
       failedCount: failures.length,
     });
 


### PR DESCRIPTION
## Summary

Makes the legacy Convex storage purge continue when cleanup encounters Convex read-limit issues.

## Why

During production cleanup we saw two related failure modes:

- `fileCountAggregate.deleteIfExists(...)` can fail with `Too many bytes read in a single function execution` after the Convex storage blob is already deleted.
- The candidate query itself can hit the same read limit after many rows have already had `storage_id` cleared, because querying by `s3_key: undefined` scans too many already-detached rows.

Both cases can leave stale `storage_id` values around or prevent the purge from finding the next batch efficiently.

## What changed

- Query purge candidates from the existing `by_storage_id` index, so rows with `storage_id: undefined` are skipped by the index instead of scanned and filtered later.
- Keep filtering to legacy Convex-only files: `s3_key` missing and `_creationTime` older than cutoff.
- Wrap aggregate cleanup in its own best-effort block.
- Add `aggregateFailedCount` to the purge result.
- Continue clearing `storage_id` / deleting the DB row even if aggregate cleanup fails.
- Add regression coverage for missing storage blobs and aggregate read-limit failures.

## Operational note

For the current cleanup, continue using `deleteDatabaseRecords: false`. Rows with `aggregateFailedCount > 0` will have their legacy storage reference cleared, but their quota aggregate entry may need a separate aggregate repair/backfill later.

## Validation

- `pnpm jest convex/__tests__/fileStorage.delete.test.ts --runInBand`
- `pnpm typecheck`
- Commit hooks also ran full `pnpm test`: 132 suites / 1488 tests passed