### PR TITLE
[codex] Query legacy purge by storage id

### DIFF
--- a/convex/__tests__/fileStorage.delete.test.ts
+++ b/convex/__tests__/fileStorage.delete.test.ts
@@ -323,12 +323,14 @@ describe("fileStorage - purgeLegacyConvexStorageFiles", () => {
   const makeQueryChain = (rows: any[]) => {
     const rangeBuilder: any = {
       eq: jest.fn(() => rangeBuilder),
+      gt: jest.fn(() => "range"),
       lt: jest.fn(() => "range"),
     };
     const filterBuilder = {
       field: jest.fn((field: string) => field),
       neq: jest.fn(() => true),
       eq: jest.fn(() => true),
+      lt: jest.fn(() => true),
       and: jest.fn(() => true),
     };
     const chain: any = {
@@ -366,7 +368,7 @@ describe("fileStorage - purgeLegacyConvexStorageFiles", () => {
   });
 
   it("reports legacy Convex storage candidates without deleting anything in dry run", async () => {
-    const { chain } = makeQueryChain([
+    const { chain, rangeBuilder, filterBuilder } = makeQueryChain([
       attachedLegacyFile,
       unattachedLegacyFile,
     ]);
@@ -392,6 +394,16 @@ describe("fileStorage - purgeLegacyConvexStorageFiles", () => {
       deletedRecordCount: 0,
       failedCount: 0,
     });
+    expect(chain.withIndex).toHaveBeenCalledWith(
+      "by_storage_id",
+      expect.any(Function),
+    );
+    expect(rangeBuilder.gt).toHaveBeenCalledWith("storage_id", undefined);
+    expect(filterBuilder.eq).toHaveBeenCalledWith("s3_key", undefined);
+    expect(filterBuilder.lt).toHaveBeenCalledWith(
+      "_creationTime",
+      cutoffTimeMs,
+    );
     expect(result.samples).toHaveLength(2);
     expect(mockCtx.storage.delete).not.toHaveBeenCalled();
     expect(mockCtx.db.patch).not.toHaveBeenCalled();

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -383,19 +383,23 @@ export const purgeLegacyConvexStorageFiles = mutation({
 
     const legacyQuery = ctx.db
       .query("files")
-      .withIndex("by_s3_key", (q) =>
-        q.eq("s3_key", undefined).lt("_creationTime", args.cutoffTimeMs),
-      )
+      .withIndex("by_storage_id", (q) => q.gt("storage_id", undefined))
       .order("asc");
 
     const candidateRows = includeAttached
       ? await legacyQuery
-          .filter((q) => q.neq(q.field("storage_id"), undefined))
+          .filter((q) =>
+            q.and(
+              q.eq(q.field("s3_key"), undefined),
+              q.lt(q.field("_creationTime"), args.cutoffTimeMs),
+            ),
+          )
           .take(limit)
       : await legacyQuery
           .filter((q) =>
             q.and(
-              q.neq(q.field("storage_id"), undefined),
+              q.eq(q.field("s3_key"), undefined),
+              q.lt(q.field("_creationTime"), args.cutoffTimeMs),
               q.eq(q.field("is_attached"), false),
             ),
           )


### PR DESCRIPTION
## Summary

Changes the legacy Convex storage purge candidate query to use the existing `by_storage_id` index instead of starting from `s3_key: undefined`.

## Why

After many rows are purged, they keep `s3_key: undefined` but now have `storage_id: undefined`. The old query started from `by_s3_key` and filtered out already-detached rows later, which can scan too many rows and fail with:

`Too many bytes read in a single function execution`

## What changed

- Query candidates with `by_storage_id` and `storage_id > undefined` so already-detached rows are skipped by the index.
- Keep filters for legacy Convex-only rows: missing `s3_key` and `_creationTime` older than the cutoff.
- Preserve `includeAttached: false` behavior.
- Update tests to assert the purge uses the storage-id index and cutoff filter.

## Validation

- `pnpm jest convex/__tests__/fileStorage.delete.test.ts --runInBand`
- `pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for file storage cleanup operations with enhanced mock support for additional query builder methods and strengthened validation of query construction and filtering behavior.

* **Refactor**
  * Optimized query selection logic for file storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->