### PR TITLE
[codex] Remove legacy Convex file storage support

### DIFF
--- a/app/components/AllFilesDialog.tsx
+++ b/app/components/AllFilesDialog.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from "react";
 import { X, Download, Circle, CircleCheck, File } from "lucide-react";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { useConvex, useAction } from "convex/react";
+import { useAction } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useFileUrlCacheContext } from "@/app/contexts/FileUrlCacheContext";
 import type { FilePart } from "@/types/file";
@@ -142,7 +142,6 @@ const AllFilesDialog = ({
   files,
   chatTitle,
 }: AllFilesDialogProps) => {
-  const convex = useConvex();
   const getFileUrlAction = useAction(api.s3Actions.getFileUrlAction);
   const fileUrlCache = useFileUrlCacheContext();
   const [selectionMode, setSelectionMode] = useState(false);
@@ -191,22 +190,15 @@ const AllFilesDialog = ({
             }
           }
 
-          // Fetch URL based on storage type
           try {
             let url: string | null = null;
 
             if (file.part.fileId) {
-              // S3 file - fetch presigned URL
               url = await getFileUrlAction({ fileId: file.part.fileId });
               // Cache it
               if (url && fileUrlCache) {
                 fileUrlCache.setCachedUrl(file.part.fileId, url);
               }
-            } else if (file.part.storageId) {
-              // Convex storage file - fetch URL
-              url = await convex.query(api.fileStorage.getFileDownloadUrl, {
-                storageId: file.part.storageId,
-              });
             }
 
             if (url) {
@@ -229,7 +221,7 @@ const AllFilesDialog = ({
     return () => {
       cancelled = true;
     };
-  }, [open, files, getFileUrlAction, convex, fileUrlCache]);
+  }, [open, files, getFileUrlAction, fileUrlCache]);
 
   const handleEnterSelectionMode = () => {
     setSelectionMode(true);
@@ -282,14 +274,6 @@ const AllFilesDialog = ({
             if (!url) {
               if (file.part.fileId) {
                 url = await getFileUrlAction({ fileId: file.part.fileId });
-              } else if (file.part.storageId) {
-                const fetchedUrl = await convex.query(
-                  api.fileStorage.getFileDownloadUrl,
-                  {
-                    storageId: file.part.storageId,
-                  },
-                );
-                url = fetchedUrl || undefined;
               }
             }
 

--- a/app/components/ComputerSidebar.tsx
+++ b/app/components/ComputerSidebar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Image from "next/image";
 import { createPortal } from "react-dom";
-import { useAction, useConvex } from "convex/react";
+import { useAction } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import {
   Eye,
@@ -74,7 +74,6 @@ const SidebarPreviewImage = ({
   file: FilePart & { page?: number };
   label: string;
 }) => {
-  const convex = useConvex();
   const getFileUrlAction = useAction(api.s3Actions.getFileUrlAction);
   const fileUrlCache = useFileUrlCacheContext();
   const [fileUrl, setFileUrl] = useState<string | null>(() => {
@@ -112,10 +111,6 @@ const SidebarPreviewImage = ({
           if (url && fileUrlCache) {
             fileUrlCache.setCachedUrl(file.fileId, url);
           }
-        } else if (file.storageId) {
-          url = await convex.query(api.fileStorage.getFileDownloadUrl, {
-            storageId: file.storageId,
-          });
         }
 
         if (!cancelled) {
@@ -141,14 +136,7 @@ const SidebarPreviewImage = ({
     return () => {
       cancelled = true;
     };
-  }, [
-    convex,
-    file.fileId,
-    file.storageId,
-    file.url,
-    fileUrlCache,
-    getFileUrlAction,
-  ]);
+  }, [file.fileId, file.url, fileUrlCache, getFileUrlAction]);
 
   if (error) {
     return (
@@ -741,7 +729,6 @@ export const ComputerSidebarBase: React.FC<ComputerSidebarProps> = ({
                                       | Id<"files">
                                       | undefined,
                                     s3Key: file.s3Key,
-                                    storageId: file.storageId,
                                     name: file.name,
                                     filename: file.name,
                                     mediaType: file.mediaType,

--- a/app/components/FilePartRenderer.tsx
+++ b/app/components/FilePartRenderer.tsx
@@ -8,7 +8,7 @@ import React, {
   useRef,
 } from "react";
 import { createPortal } from "react-dom";
-import { useConvex, useAction } from "convex/react";
+import { useAction } from "convex/react";
 import { ConvexError } from "convex/values";
 import { api } from "@/convex/_generated/api";
 import { ImageViewer } from "./ImageViewer";
@@ -24,7 +24,6 @@ const FilePartRendererComponent = ({
   messageId,
   totalFileParts = 1,
 }: FilePartRendererProps) => {
-  const convex = useConvex();
   const getFileUrlAction = useAction(api.s3Actions.getFileUrlAction);
   const fileUrlCache = useFileUrlCacheContext();
   // Use ref to access cache without adding to useEffect dependencies
@@ -52,7 +51,6 @@ const FilePartRendererComponent = ({
   // Track the last fetched identifiers to avoid unnecessary refetches
   const lastFetchedRef = useRef<{
     fileId?: string;
-    storageId?: string;
     url?: string;
   }>({});
 
@@ -66,7 +64,6 @@ const FilePartRendererComponent = ({
     // Check if we already fetched for these same identifiers
     const sameIdentifiers =
       lastFetchedRef.current.fileId === part.fileId &&
-      lastFetchedRef.current.storageId === part.storageId &&
       lastFetchedRef.current.url === part.url;
 
     // If identifiers haven't changed and we have a URL, skip refetch
@@ -77,14 +74,13 @@ const FilePartRendererComponent = ({
     // Update tracking ref
     lastFetchedRef.current = {
       fileId: part.fileId,
-      storageId: part.storageId,
       url: part.url,
     };
 
     async function fetchUrl() {
       const cache = fileUrlCacheRef.current;
 
-      // If we have fileId (for S3 files), check cache first
+      // If we have fileId, check cache first
       if (part.fileId) {
         if (cache) {
           const cachedUrl = cache.getCachedUrl(part.fileId);
@@ -120,38 +116,9 @@ const FilePartRendererComponent = ({
         return;
       }
 
-      // Fallback: if no fileId but we have part.url (Convex storage), use it
+      // Fallback for transient already-resolved URLs.
       if (part.url) {
         setFileUrl(part.url);
-        return;
-      }
-
-      // If we have storageId (for Convex files), fetch URL on-demand for images
-      if (part.storageId) {
-        setUrlError(null);
-        try {
-          const url = await convex.query(api.fileStorage.getFileDownloadUrl, {
-            storageId: part.storageId,
-          });
-          if (url) {
-            setFileUrl(url);
-          } else {
-            setUrlError("Failed to get download URL");
-          }
-        } catch (error) {
-          console.error("Failed to fetch download URL:", error);
-          const errorMessage =
-            error instanceof ConvexError
-              ? (error.data as { message?: string })?.message ||
-                error.message ||
-                "Failed to load file"
-              : error instanceof Error
-                ? error.message
-                : "Failed to load file";
-          setUrlError(errorMessage);
-          toast.error(errorMessage);
-        }
-        return;
       }
     }
 
@@ -159,14 +126,7 @@ const FilePartRendererComponent = ({
     // Note: fileUrl is intentionally not in deps - we check it inside the effect
     // fileUrlCacheRef is a ref, so it doesn't need to be in deps
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    part.url,
-    part.fileId,
-    part.storageId,
-    part.mediaType,
-    getFileUrlAction,
-    convex,
-  ]);
+  }, [part.url, part.fileId, part.mediaType, getFileUrlAction]);
 
   const handleDownload = useCallback(async (url: string, fileName: string) => {
     try {
@@ -229,18 +189,14 @@ const FilePartRendererComponent = ({
         let url: string | null = null;
 
         if (part.fileId) {
-          // S3 file - fetch presigned URL
           url = await getFileUrlAction({ fileId: part.fileId });
 
           // Cache it for future clicks
           if (url && cache) {
             cache.setCachedUrl(part.fileId, url);
           }
-        } else if (part.storageId) {
-          // Convex storage file - fetch URL
-          url = await convex.query(api.fileStorage.getFileDownloadUrl, {
-            storageId: part.storageId,
-          });
+        } else if (part.url) {
+          url = part.url;
         }
 
         if (url) {
@@ -264,14 +220,7 @@ const FilePartRendererComponent = ({
         toast.error(errorMessage);
       }
     },
-    [
-      fileUrl,
-      handleDownload,
-      part.fileId,
-      part.storageId,
-      getFileUrlAction,
-      convex,
-    ],
+    [fileUrl, handleDownload, part.fileId, part.url, getFileUrlAction],
   );
 
   // Memoize file preview component to prevent unnecessary re-renders
@@ -282,7 +231,6 @@ const FilePartRendererComponent = ({
       fileName,
       subtitle,
       url,
-      storageId,
       fileId,
     }: {
       partId: string;
@@ -290,7 +238,6 @@ const FilePartRendererComponent = ({
       fileName: string;
       subtitle: string;
       url?: string;
-      storageId?: string;
       fileId?: string;
     }) => {
       const content = (
@@ -306,7 +253,7 @@ const FilePartRendererComponent = ({
               {subtitle}
             </div>
           </div>
-          {(url || storageId || fileId) && (
+          {(url || fileId) && (
             <div className="flex items-center justify-center w-6 h-6 rounded-md border border-border opacity-0 group-hover:opacity-100 transition-opacity">
               <Download className="w-4 h-4 text-muted-foreground" />
             </div>
@@ -314,7 +261,7 @@ const FilePartRendererComponent = ({
         </div>
       );
 
-      if (url || storageId || fileId) {
+      if (url || fileId) {
         return (
           <button
             key={partId}
@@ -354,7 +301,6 @@ const FilePartRendererComponent = ({
             fileName={part.name || part.filename || "Unknown file"}
             subtitle={urlError}
             url={undefined}
-            storageId={undefined}
             fileId={undefined}
           />
         );
@@ -371,13 +317,12 @@ const FilePartRendererComponent = ({
             fileName={part.name || part.filename || "Local file"}
             subtitle="Local-only attachment"
             url={undefined}
-            storageId={undefined}
             fileId={undefined}
           />
         );
       }
 
-      if (!actualUrl && !part.storageId && !part.fileId) {
+      if (!actualUrl && !part.fileId) {
         // Error state for files without URLs or storage references
         return (
           <FilePreviewCard
@@ -386,7 +331,6 @@ const FilePartRendererComponent = ({
             fileName={part.name || part.filename || "Unknown file"}
             subtitle="File not available"
             url={undefined}
-            storageId={undefined}
             fileId={undefined}
           />
         );
@@ -402,7 +346,6 @@ const FilePartRendererComponent = ({
               fileName={part.name || part.filename || "Unknown image"}
               subtitle="Image URL not available"
               url={undefined}
-              storageId={undefined}
               fileId={undefined}
             />
           );
@@ -453,7 +396,7 @@ const FilePartRendererComponent = ({
         );
       }
 
-      // Handle all non-image files with the new UI (use storageId or fileId if no URL)
+      // Handle all non-image files with the new UI.
       return (
         <FilePreviewCard
           partId={partId}
@@ -461,7 +404,6 @@ const FilePartRendererComponent = ({
           fileName={part.name || part.filename || "Document"}
           subtitle="Document"
           url={actualUrl}
-          storageId={part.storageId}
           fileId={part.fileId}
         />
       );
@@ -474,10 +416,9 @@ const FilePartRendererComponent = ({
   const renderedFilePart = useMemo(() => {
     const partId = `${messageId}-file-${partIndex}`;
 
-    // Check if this is a file part with either URL, storageId, or fileId
+    // Check if this is a file part with either URL, fileId, or local metadata.
     if (
       part.url ||
-      part.storageId ||
       part.fileId ||
       part.storage === "local-desktop" ||
       fileUrl
@@ -493,7 +434,6 @@ const FilePartRendererComponent = ({
         fileName={part.name || part.filename || "Unknown file"}
         subtitle="Document"
         url={part.url}
-        storageId={part.storageId}
         fileId={part.fileId}
       />
     );
@@ -502,7 +442,6 @@ const FilePartRendererComponent = ({
     messageId,
     partIndex,
     part.url,
-    part.storageId,
     part.fileId,
     fileUrl,
     urlError,
@@ -539,7 +478,6 @@ export const FilePartRenderer = memo(
       prevProps.partIndex === nextProps.partIndex &&
       prevProps.totalFileParts === nextProps.totalFileParts &&
       prevProps.part.url === nextProps.part.url &&
-      prevProps.part.storageId === nextProps.part.storageId &&
       prevProps.part.storage === nextProps.part.storage &&
       prevProps.part.localAttachmentId === nextProps.part.localAttachmentId &&
       prevProps.part.fileId === nextProps.part.fileId &&

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -263,7 +263,7 @@ export const MessageItem = memo(function MessageItem({
 
   const savedFiles = useMemo(() => {
     if (isUser || !effectiveFileDetails) return [];
-    return effectiveFileDetails.filter((f) => f.url || f.storageId || f.s3Key);
+    return effectiveFileDetails.filter((f) => f.url || f.fileId || f.s3Key);
   }, [isUser, effectiveFileDetails]);
 
   const renderAssistantPart = (
@@ -556,7 +556,6 @@ export const MessageItem = memo(function MessageItem({
                     key={`${message.id}-saved-file-${savedFiles.length - 1}`}
                     part={{
                       url: savedFiles[savedFiles.length - 1].url ?? undefined,
-                      storageId: savedFiles[savedFiles.length - 1].storageId,
                       fileId: savedFiles[savedFiles.length - 1].fileId,
                       s3Key: savedFiles[savedFiles.length - 1].s3Key,
                       name: savedFiles[savedFiles.length - 1].name,
@@ -592,7 +591,6 @@ export const MessageItem = memo(function MessageItem({
                     key={`${message.id}-saved-file-${fileIndex}`}
                     part={{
                       url: file.url ?? undefined,
-                      storageId: file.storageId,
                       fileId: file.fileId,
                       s3Key: file.s3Key,
                       name: file.name,

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -222,11 +222,10 @@ export const Messages = ({
       if (!fileDetails || fileDetails.length === 0) return;
 
       const files = fileDetails
-        .filter((file) => file.url || file.storageId || file.s3Key)
+        .filter((file) => file.url || file.fileId || file.s3Key)
         .map((file, fileIndex) => ({
           part: {
             url: file.url ?? undefined,
-            storageId: file.storageId,
             fileId: file.fileId,
             s3Key: file.s3Key,
             name: file.name,

--- a/app/components/ShareDialog.tsx
+++ b/app/components/ShareDialog.tsx
@@ -230,7 +230,7 @@ export const ShareDialog = ({
                           const savedFiles = isUser
                             ? []
                             : (message.fileDetails || []).filter(
-                                (f) => f.storageId || f.s3Key,
+                                (f) => f.fileId || f.s3Key,
                               );
 
                           return (
@@ -314,7 +314,6 @@ export const ShareDialog = ({
                                     <FilePartRenderer
                                       key={`${message.id}-saved-file-${fileIndex}`}
                                       part={{
-                                        storageId: file.storageId,
                                         fileId: file.fileId,
                                         s3Key: file.s3Key,
                                         name: file.name,

--- a/app/components/tools/GetTerminalFilesHandler.tsx
+++ b/app/components/tools/GetTerminalFilesHandler.tsx
@@ -63,7 +63,6 @@ export const GetTerminalFilesHandler = memo(function GetTerminalFilesHandler({
         mediaType: f.mediaType,
         fileId: f.fileId as string,
         s3Key: f.s3Key,
-        storageId: f.storageId,
       }),
     );
 

--- a/app/hooks/useFileUrlCache.ts
+++ b/app/hooks/useFileUrlCache.ts
@@ -67,7 +67,7 @@ export function useFileUrlCache(messages: ChatMessage[]) {
 
         for (const file of message.fileDetails) {
           // Only process files that:
-          // 1. Have an S3 key (not Convex storage)
+          // 1. Have an S3 key
           // 2. Are supported image types
           // 3. Haven't been prefetched yet
           // 4. Haven't been seen in this run

--- a/app/share/[shareId]/components/SharedMessagePartHandler.tsx
+++ b/app/share/[shareId]/components/SharedMessagePartHandler.tsx
@@ -392,7 +392,6 @@ function renderFileTool(
       name?: string;
       filename?: string;
       mediaType?: string;
-      storageId?: string;
       s3Key?: string;
       page?: number;
     }>;

--- a/convex/__tests__/fileActions.upload-policy.test.ts
+++ b/convex/__tests__/fileActions.upload-policy.test.ts
@@ -128,11 +128,6 @@ describe("fileActions saveFile upload policy", () => {
       scheduler: {
         runAfter: jest.fn().mockResolvedValue(undefined),
       },
-      storage: {
-        delete: jest.fn().mockResolvedValue(undefined),
-        getUrl: jest.fn().mockResolvedValue("https://storage.example/file"),
-        getMetadata: jest.fn().mockResolvedValue({ size: 1024 }),
-      },
       runQuery: jest.fn(),
       runMutation: jest.fn().mockResolvedValue("file_123"),
     }) as any;
@@ -287,13 +282,12 @@ describe("fileActions saveFile upload policy", () => {
     );
   });
 
-  it("rejects storageId uploads without touching Convex storage", async () => {
+  it("rejects uploads without an S3 key", async () => {
     const { saveFile } = await import("../fileActions");
     const ctx = makeCtx();
 
     await expect(
       saveFile.handler(ctx, {
-        storageId: "storage_large_bin",
         name: "large.bin",
         mediaType: "application/octet-stream",
         size: 1024,
@@ -301,12 +295,10 @@ describe("fileActions saveFile upload policy", () => {
       }),
     ).rejects.toMatchObject({
       data: expect.objectContaining({
-        code: "CONVEX_STORAGE_UPLOADS_DISABLED",
+        code: "INVALID_STORAGE_ARGS",
       }),
     });
 
-    expect(ctx.storage.getMetadata).not.toHaveBeenCalled();
-    expect(ctx.storage.delete).not.toHaveBeenCalled();
     expect(ctx.runQuery).not.toHaveBeenCalled();
     expect(global.fetch).not.toHaveBeenCalled();
     expect(ctx.runMutation).not.toHaveBeenCalled();

--- a/convex/__tests__/fileStorage.aggregate.test.ts
+++ b/convex/__tests__/fileStorage.aggregate.test.ts
@@ -162,7 +162,6 @@ describe("fileStorage - Aggregate Integration", () => {
             user_id: "other-user",
             name: "secret.txt",
             media_type: "text/plain",
-            storage_id: "storage-secret",
             s3_key: undefined,
           }),
         },
@@ -222,7 +221,6 @@ describe("fileStorage - Aggregate Integration", () => {
           is_attached: false,
         }),
       );
-      expect(mockCtx.db.insert.mock.calls[0][1].storage_id).toBeUndefined();
       expect(mockFileCountAggregate.insertIfDoesNotExist).toHaveBeenCalledWith(
         mockCtx,
         mockFile,
@@ -359,7 +357,6 @@ describe("fileStorage - Aggregate Integration", () => {
       expect(mockCtx.db.patch).toHaveBeenCalledWith(
         testFileId,
         expect.objectContaining({
-          storage_id: undefined,
           file_token_size: 100,
         }),
       );

--- a/convex/__tests__/fileStorage.delete.test.ts
+++ b/convex/__tests__/fileStorage.delete.test.ts
@@ -96,9 +96,6 @@ describe("fileStorage - deleteFile", () => {
         get: jest.fn().mockResolvedValue(mockFile),
         delete: jest.fn().mockResolvedValue(undefined),
       },
-      storage: {
-        delete: jest.fn().mockResolvedValue(undefined),
-      },
       scheduler: {
         runAfter: jest.fn().mockResolvedValue(undefined),
       },
@@ -148,7 +145,6 @@ describe("fileStorage - deleteFile", () => {
   describe("S3 File Deletion", () => {
     it("should schedule S3 deletion for S3 files", async () => {
       mockFile.s3_key = "users/test-user-123/test-file.pdf";
-      mockFile.storage_id = undefined;
       mockCtx.db.get.mockResolvedValue(mockFile);
 
       const { deleteFile } = await import("../fileStorage");
@@ -162,9 +158,6 @@ describe("fileStorage - deleteFile", () => {
         { s3Key: mockFile.s3_key },
       );
 
-      // Verify Convex storage delete was not called
-      expect(mockCtx.storage.delete).not.toHaveBeenCalled();
-
       // Verify aggregate was updated
       expect(mockFileCountAggregate.deleteIfExists).toHaveBeenCalledWith(
         mockCtx,
@@ -177,7 +170,6 @@ describe("fileStorage - deleteFile", () => {
 
     it("should delete DB record even if S3 scheduling fails", async () => {
       mockFile.s3_key = "users/test-user-123/test-file.pdf";
-      mockFile.storage_id = undefined;
       mockCtx.db.get.mockResolvedValue(mockFile);
       mockCtx.scheduler.runAfter.mockRejectedValue(
         new Error("Scheduler error"),
@@ -194,72 +186,20 @@ describe("fileStorage - deleteFile", () => {
     });
   });
 
-  describe("Convex Storage File Deletion", () => {
-    it("should delete Convex storage for Convex files", async () => {
-      mockFile.storage_id = "storage-id-123" as Id<"_storage">;
-      mockFile.s3_key = undefined;
-      mockCtx.db.get.mockResolvedValue(mockFile);
-
-      const { deleteFile } = await import("../fileStorage");
-
-      await deleteFile.handler(mockCtx, { fileId: testFileId });
-
-      // Verify Convex storage delete was called
-      expect(mockCtx.storage.delete).toHaveBeenCalledWith(mockFile.storage_id);
-
-      // Verify S3 deletion was not scheduled (scheduler might be called for aggregate but not S3)
-      expect(mockCtx.scheduler.runAfter).not.toHaveBeenCalledWith(
-        expect.anything(),
-        "internal.s3Cleanup.deleteS3ObjectAction",
-        expect.anything(),
-      );
-
-      // Verify aggregate was updated
-      expect(mockFileCountAggregate.deleteIfExists).toHaveBeenCalledWith(
-        mockCtx,
-        mockFile,
-      );
-
-      // Verify database record was deleted
-      expect(mockCtx.db.delete).toHaveBeenCalledWith(testFileId);
-    });
-
-    it("should delete DB record even if Convex storage deletion fails", async () => {
-      mockFile.storage_id = "storage-id-123" as Id<"_storage">;
-      mockFile.s3_key = undefined;
-      mockCtx.db.get.mockResolvedValue(mockFile);
-      mockCtx.storage.delete.mockRejectedValue(
-        new Error("Storage delete failed"),
-      );
-
-      const { deleteFile } = await import("../fileStorage");
-
-      await expect(
-        deleteFile.handler(mockCtx, { fileId: testFileId }),
-      ).rejects.toThrow("Storage delete failed");
-
-      // DB delete should not be called if storage delete fails
-      expect(mockCtx.db.delete).not.toHaveBeenCalled();
-    });
-  });
-
   describe("Edge Cases", () => {
-    it("should warn and still delete DB record if file has neither s3_key nor storage_id", async () => {
+    it("should warn and still delete DB record if file has no s3_key", async () => {
       mockFile.s3_key = undefined;
-      mockFile.storage_id = undefined;
       mockCtx.db.get.mockResolvedValue(mockFile);
 
       const { deleteFile } = await import("../fileStorage");
 
       await deleteFile.handler(mockCtx, { fileId: testFileId });
 
-      // Should warn about missing storage reference
+      // Should warn about missing S3 object reference
       expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining("has neither s3_key nor storage_id"),
+        expect.stringContaining("has no s3_key"),
       );
 
-      // Should not attempt storage deletion
-      expect(mockCtx.storage.delete).not.toHaveBeenCalled();
       // S3 cleanup should not be scheduled (aggregate delete attempts are okay)
       expect(mockCtx.scheduler.runAfter).not.toHaveBeenCalledWith(
         expect.anything(),
@@ -278,7 +218,7 @@ describe("fileStorage - deleteFile", () => {
     });
 
     it("should return null on successful deletion", async () => {
-      mockFile.storage_id = "storage-id-123" as Id<"_storage">;
+      mockFile.s3_key = "users/test-user-123/test-file.pdf";
       mockCtx.db.get.mockResolvedValue(mockFile);
 
       const { deleteFile } = await import("../fileStorage");
@@ -286,297 +226,6 @@ describe("fileStorage - deleteFile", () => {
       const result = await deleteFile.handler(mockCtx, { fileId: testFileId });
 
       expect(result).toBeNull();
-    });
-  });
-});
-
-describe("fileStorage - purgeLegacyConvexStorageFiles", () => {
-  let mockCtx: any;
-  const cutoffTimeMs = Date.parse("2025-12-14T00:00:00.000Z");
-
-  const attachedLegacyFile = {
-    _id: "attached-file-id" as Id<"files">,
-    storage_id: "attached-storage-id" as Id<"_storage">,
-    s3_key: undefined,
-    user_id: "user-1",
-    name: "attached.pdf",
-    media_type: "application/pdf",
-    size: 2048,
-    file_token_size: 0,
-    is_attached: true,
-    _creationTime: cutoffTimeMs - 1000,
-  };
-
-  const unattachedLegacyFile = {
-    _id: "unattached-file-id" as Id<"files">,
-    storage_id: "unattached-storage-id" as Id<"_storage">,
-    s3_key: undefined,
-    user_id: "user-1",
-    name: "orphan.txt",
-    media_type: "text/plain",
-    size: 1024,
-    file_token_size: 12,
-    is_attached: false,
-    _creationTime: cutoffTimeMs - 2000,
-  };
-
-  const makeQueryChain = (rows: any[]) => {
-    const rangeBuilder: any = {
-      eq: jest.fn(() => rangeBuilder),
-      gt: jest.fn(() => "range"),
-      lt: jest.fn(() => "range"),
-    };
-    const filterBuilder = {
-      field: jest.fn((field: string) => field),
-      neq: jest.fn(() => true),
-      eq: jest.fn(() => true),
-      lt: jest.fn(() => true),
-      and: jest.fn(() => true),
-    };
-    const chain: any = {
-      withIndex: jest.fn((_indexName: string, range: any) => {
-        range(rangeBuilder);
-        return chain;
-      }),
-      order: jest.fn(() => chain),
-      filter: jest.fn((predicate: any) => {
-        predicate(filterBuilder);
-        return chain;
-      }),
-      take: jest.fn().mockResolvedValue(rows),
-    };
-
-    return { chain, rangeBuilder, filterBuilder };
-  };
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.spyOn(console, "log").mockImplementation(() => {});
-    jest.spyOn(console, "error").mockImplementation(() => {});
-    jest.spyOn(console, "warn").mockImplementation(() => {});
-
-    mockCtx = {
-      db: {
-        query: jest.fn(),
-        patch: jest.fn().mockResolvedValue(undefined),
-        delete: jest.fn().mockResolvedValue(undefined),
-      },
-      storage: {
-        delete: jest.fn().mockResolvedValue(undefined),
-      },
-    };
-  });
-
-  it("reports legacy Convex storage candidates without deleting anything in dry run", async () => {
-    const { chain, rangeBuilder, filterBuilder } = makeQueryChain([
-      attachedLegacyFile,
-      unattachedLegacyFile,
-    ]);
-    mockCtx.db.query.mockReturnValue(chain);
-
-    const { purgeLegacyConvexStorageFiles } = await import("../fileStorage");
-
-    const result = await purgeLegacyConvexStorageFiles.handler(mockCtx, {
-      serviceKey: "service-key",
-      cutoffTimeMs,
-      dryRun: true,
-      includeAttached: true,
-    });
-
-    expect(result).toMatchObject({
-      dryRun: true,
-      candidateCount: 2,
-      totalBytes: 3072,
-      attachedCount: 1,
-      unattachedCount: 1,
-      deletedStorageCount: 0,
-      detachedRecordCount: 0,
-      deletedRecordCount: 0,
-      failedCount: 0,
-    });
-    expect(chain.withIndex).toHaveBeenCalledWith(
-      "by_storage_id",
-      expect.any(Function),
-    );
-    expect(rangeBuilder.gt).toHaveBeenCalledWith("storage_id", undefined);
-    expect(filterBuilder.eq).toHaveBeenCalledWith("s3_key", undefined);
-    expect(filterBuilder.lt).toHaveBeenCalledWith(
-      "_creationTime",
-      cutoffTimeMs,
-    );
-    expect(result.samples).toHaveLength(2);
-    expect(mockCtx.storage.delete).not.toHaveBeenCalled();
-    expect(mockCtx.db.patch).not.toHaveBeenCalled();
-    expect(mockCtx.db.delete).not.toHaveBeenCalled();
-    expect(mockFileCountAggregate.deleteIfExists).not.toHaveBeenCalled();
-  });
-
-  it("deletes Convex storage and clears storage_id by default", async () => {
-    const { chain } = makeQueryChain([attachedLegacyFile]);
-    mockCtx.db.query.mockReturnValue(chain);
-
-    const { purgeLegacyConvexStorageFiles } = await import("../fileStorage");
-
-    const result = await purgeLegacyConvexStorageFiles.handler(mockCtx, {
-      serviceKey: "service-key",
-      cutoffTimeMs,
-      dryRun: false,
-      includeAttached: true,
-    });
-
-    expect(mockCtx.storage.delete).toHaveBeenCalledWith(
-      attachedLegacyFile.storage_id,
-    );
-    expect(mockFileCountAggregate.deleteIfExists).toHaveBeenCalledWith(
-      mockCtx,
-      attachedLegacyFile,
-    );
-    expect(mockCtx.db.patch).toHaveBeenCalledWith(attachedLegacyFile._id, {
-      storage_id: undefined,
-    });
-    expect(mockCtx.db.delete).not.toHaveBeenCalled();
-    expect(result).toMatchObject({
-      dryRun: false,
-      candidateCount: 1,
-      deletedStorageCount: 1,
-      detachedRecordCount: 1,
-      deletedRecordCount: 0,
-      aggregateRemovedCount: 1,
-      failedCount: 0,
-    });
-  });
-
-  it("skips attached files when includeAttached is false", async () => {
-    const { chain, filterBuilder } = makeQueryChain([
-      attachedLegacyFile,
-      unattachedLegacyFile,
-    ]);
-    mockCtx.db.query.mockReturnValue(chain);
-
-    const { purgeLegacyConvexStorageFiles } = await import("../fileStorage");
-
-    const result = await purgeLegacyConvexStorageFiles.handler(mockCtx, {
-      serviceKey: "service-key",
-      cutoffTimeMs,
-      dryRun: false,
-      includeAttached: false,
-    });
-
-    expect(filterBuilder.eq).toHaveBeenCalledWith("is_attached", false);
-    expect(mockCtx.storage.delete).toHaveBeenCalledTimes(1);
-    expect(mockCtx.storage.delete).toHaveBeenCalledWith(
-      unattachedLegacyFile.storage_id,
-    );
-    expect(mockCtx.storage.delete).not.toHaveBeenCalledWith(
-      attachedLegacyFile.storage_id,
-    );
-    expect(result).toMatchObject({
-      candidateCount: 1,
-      attachedCount: 0,
-      unattachedCount: 1,
-      deletedStorageCount: 1,
-      detachedRecordCount: 1,
-    });
-  });
-
-  it("deletes database records only when explicitly requested", async () => {
-    const { chain } = makeQueryChain([unattachedLegacyFile]);
-    mockCtx.db.query.mockReturnValue(chain);
-
-    const { purgeLegacyConvexStorageFiles } = await import("../fileStorage");
-
-    const result = await purgeLegacyConvexStorageFiles.handler(mockCtx, {
-      serviceKey: "service-key",
-      cutoffTimeMs,
-      dryRun: false,
-      includeAttached: true,
-      deleteDatabaseRecords: true,
-    });
-
-    expect(mockCtx.storage.delete).toHaveBeenCalledWith(
-      unattachedLegacyFile.storage_id,
-    );
-    expect(mockCtx.db.delete).toHaveBeenCalledWith(unattachedLegacyFile._id);
-    expect(mockCtx.db.patch).not.toHaveBeenCalled();
-    expect(result).toMatchObject({
-      deletedStorageCount: 1,
-      detachedRecordCount: 0,
-      deletedRecordCount: 1,
-      aggregateRemovedCount: 1,
-    });
-  });
-
-  it("clears stale DB references when the Convex storage blob is already missing", async () => {
-    const { chain } = makeQueryChain([attachedLegacyFile]);
-    mockCtx.db.query.mockReturnValue(chain);
-    mockCtx.storage.delete.mockRejectedValue(
-      new Error(`storage id ${attachedLegacyFile.storage_id} not found`),
-    );
-
-    const { purgeLegacyConvexStorageFiles } = await import("../fileStorage");
-
-    const result = await purgeLegacyConvexStorageFiles.handler(mockCtx, {
-      serviceKey: "service-key",
-      cutoffTimeMs,
-      dryRun: false,
-      includeAttached: true,
-    });
-
-    expect(mockCtx.storage.delete).toHaveBeenCalledWith(
-      attachedLegacyFile.storage_id,
-    );
-    expect(mockFileCountAggregate.deleteIfExists).toHaveBeenCalledWith(
-      mockCtx,
-      attachedLegacyFile,
-    );
-    expect(mockCtx.db.patch).toHaveBeenCalledWith(attachedLegacyFile._id, {
-      storage_id: undefined,
-    });
-    expect(result).toMatchObject({
-      deletedStorageCount: 0,
-      missingStorageCount: 1,
-      detachedRecordCount: 1,
-      aggregateRemovedCount: 1,
-      failedCount: 0,
-      failures: [],
-    });
-  });
-
-  it("still clears storage_id when aggregate cleanup exceeds Convex read limits", async () => {
-    const { chain } = makeQueryChain([attachedLegacyFile]);
-    mockCtx.db.query.mockReturnValue(chain);
-    mockFileCountAggregate.deleteIfExists.mockRejectedValueOnce(
-      new Error(
-        "Uncaught Error: Too many bytes read in a single function execution (limit: 16777216 bytes).",
-      ),
-    );
-
-    const { purgeLegacyConvexStorageFiles } = await import("../fileStorage");
-
-    const result = await purgeLegacyConvexStorageFiles.handler(mockCtx, {
-      serviceKey: "service-key",
-      cutoffTimeMs,
-      dryRun: false,
-      includeAttached: true,
-    });
-
-    expect(mockCtx.storage.delete).toHaveBeenCalledWith(
-      attachedLegacyFile.storage_id,
-    );
-    expect(mockFileCountAggregate.deleteIfExists).toHaveBeenCalledWith(
-      mockCtx,
-      attachedLegacyFile,
-    );
-    expect(mockCtx.db.patch).toHaveBeenCalledWith(attachedLegacyFile._id, {
-      storage_id: undefined,
-    });
-    expect(result).toMatchObject({
-      deletedStorageCount: 1,
-      aggregateRemovedCount: 0,
-      aggregateFailedCount: 1,
-      detachedRecordCount: 1,
-      failedCount: 0,
-      failures: [],
     });
   });
 });

--- a/convex/__tests__/s3Actions.test.ts
+++ b/convex/__tests__/s3Actions.test.ts
@@ -500,7 +500,6 @@ describe("s3Actions", () => {
       const mockFile = {
         _id: mockFileId,
         s3_key: "users/user123/123-uuid-test.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "test.pdf",
         media_type: "application/pdf",
@@ -519,9 +518,6 @@ describe("s3Actions", () => {
           }),
         },
         runQuery: jest.fn().mockResolvedValue(mockFile),
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       const result = await getFileUrlAction.handler(mockCtx, {
@@ -534,48 +530,6 @@ describe("s3Actions", () => {
       expect(mockGenerateS3DownloadUrl).toHaveBeenCalledWith(
         "users/user123/123-uuid-test.pdf",
       );
-    });
-
-    it("should return Convex URL for legacy file", async () => {
-      const { getFileUrlAction } = await import("../s3Actions");
-
-      const mockFileId = "file123" as any;
-      const mockStorageId = "storage123" as any;
-      const mockFile = {
-        _id: mockFileId,
-        s3_key: undefined,
-        storage_id: mockStorageId,
-        user_id: "user123",
-        name: "test.pdf",
-        media_type: "application/pdf",
-        size: 1024,
-        file_token_size: 100,
-        is_attached: true,
-        _creationTime: Date.now(),
-      };
-
-      const mockCtx = {
-        auth: {
-          getUserIdentity: jest.fn().mockResolvedValue({
-            subject: "user123",
-            email: "test@example.com",
-            entitlements: ["pro-plan"],
-          }),
-        },
-        runQuery: jest.fn().mockResolvedValue(mockFile),
-        storage: {
-          getUrl: jest
-            .fn()
-            .mockResolvedValue("https://convex.cloud/storage/file-url"),
-        },
-      } as any;
-
-      const result = await getFileUrlAction.handler(mockCtx, {
-        fileId: mockFileId,
-      });
-
-      expect(result).toBe("https://convex.cloud/storage/file-url");
-      expect(mockCtx.storage.getUrl).toHaveBeenCalledWith(mockStorageId);
     });
 
     it("should throw error for unauthenticated user", async () => {
@@ -618,7 +572,6 @@ describe("s3Actions", () => {
       const mockFile = {
         _id: mockFileId,
         s3_key: "users/user456/123-uuid-test.pdf",
-        storage_id: undefined,
         user_id: "user456",
         name: "test.pdf",
         media_type: "application/pdf",
@@ -644,14 +597,13 @@ describe("s3Actions", () => {
       ).rejects.toThrow("Access denied");
     });
 
-    it("should throw error for file with no storage reference", async () => {
+    it("should throw error for file with no S3 storage reference", async () => {
       const { getFileUrlAction } = await import("../s3Actions");
 
       const mockFileId = "file123" as any;
       const mockFile = {
         _id: mockFileId,
         s3_key: undefined,
-        storage_id: undefined,
         user_id: "user123",
         name: "test.pdf",
         media_type: "application/pdf",
@@ -674,40 +626,7 @@ describe("s3Actions", () => {
 
       await expect(
         getFileUrlAction.handler(mockCtx, { fileId: mockFileId }),
-      ).rejects.toThrow("File has no storage reference");
-    });
-
-    it("should throw error for file with both storage references (invalid state)", async () => {
-      const { getFileUrlAction } = await import("../s3Actions");
-
-      const mockFileId = "file123" as any;
-      const mockFile = {
-        _id: mockFileId,
-        s3_key: "users/user123/123-uuid-test.pdf",
-        storage_id: "storage123" as any,
-        user_id: "user123",
-        name: "test.pdf",
-        media_type: "application/pdf",
-        size: 1024,
-        file_token_size: 100,
-        is_attached: true,
-        _creationTime: Date.now(),
-      };
-
-      const mockCtx = {
-        auth: {
-          getUserIdentity: jest.fn().mockResolvedValue({
-            subject: "user123",
-            email: "test@example.com",
-            entitlements: ["pro-plan"],
-          }),
-        },
-        runQuery: jest.fn().mockResolvedValue(mockFile),
-      } as any;
-
-      await expect(
-        getFileUrlAction.handler(mockCtx, { fileId: mockFileId }),
-      ).rejects.toThrow("File has both S3 and Convex storage references");
+      ).rejects.toThrow("File has no S3 storage reference");
     });
 
     it("should handle S3 download URL generation errors", async () => {
@@ -727,7 +646,6 @@ describe("s3Actions", () => {
       const mockFile = {
         _id: mockFileId,
         s3_key: "users/user123/123-uuid-test.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "test.pdf",
         media_type: "application/pdf",
@@ -746,51 +664,11 @@ describe("s3Actions", () => {
           }),
         },
         runQuery: jest.fn().mockResolvedValue(mockFile),
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       await expect(
         getFileUrlAction.handler(mockCtx, { fileId: mockFileId }),
       ).rejects.toThrow("Failed to get file URL");
-    });
-
-    it("should handle Convex storage URL errors", async () => {
-      const { getFileUrlAction } = await import("../s3Actions");
-
-      const mockFileId = "file123" as any;
-      const mockStorageId = "storage123" as any;
-      const mockFile = {
-        _id: mockFileId,
-        s3_key: undefined,
-        storage_id: mockStorageId,
-        user_id: "user123",
-        name: "test.pdf",
-        media_type: "application/pdf",
-        size: 1024,
-        file_token_size: 100,
-        is_attached: true,
-        _creationTime: Date.now(),
-      };
-
-      const mockCtx = {
-        auth: {
-          getUserIdentity: jest.fn().mockResolvedValue({
-            subject: "user123",
-            email: "test@example.com",
-            entitlements: ["pro-plan"],
-          }),
-        },
-        runQuery: jest.fn().mockResolvedValue(mockFile),
-        storage: {
-          getUrl: jest.fn().mockResolvedValue(null),
-        },
-      } as any;
-
-      await expect(
-        getFileUrlAction.handler(mockCtx, { fileId: mockFileId }),
-      ).rejects.toThrow("Failed to generate Convex storage URL");
     });
   });
 
@@ -816,7 +694,6 @@ describe("s3Actions", () => {
       const mockFile1 = {
         _id: mockFile1Id,
         s3_key: "users/user123/file1.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file1.pdf",
         media_type: "application/pdf",
@@ -829,7 +706,6 @@ describe("s3Actions", () => {
       const mockFile2 = {
         _id: mockFile2Id,
         s3_key: "users/user123/file2.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file2.pdf",
         media_type: "application/pdf",
@@ -842,7 +718,6 @@ describe("s3Actions", () => {
       const mockFile3 = {
         _id: mockFile3Id,
         s3_key: "users/user123/file3.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file3.pdf",
         media_type: "application/pdf",
@@ -865,9 +740,6 @@ describe("s3Actions", () => {
           .mockResolvedValueOnce(mockFile1)
           .mockResolvedValueOnce(mockFile2)
           .mockResolvedValueOnce(mockFile3),
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       const result = await getFileUrlsBatchAction.handler(mockCtx, {
@@ -881,7 +753,7 @@ describe("s3Actions", () => {
       });
     });
 
-    it("should generate URLs for mixed S3 and Convex files", async () => {
+    it("should skip files without S3 keys", async () => {
       const { generateS3DownloadUrl } = await import("../s3Utils");
       const mockGenerateS3DownloadUrl =
         generateS3DownloadUrl as jest.MockedFunction<
@@ -900,7 +772,6 @@ describe("s3Actions", () => {
       const mockFile1 = {
         _id: mockFile1Id,
         s3_key: "users/user123/file1.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file1.pdf",
         media_type: "application/pdf",
@@ -913,7 +784,6 @@ describe("s3Actions", () => {
       const mockFile2 = {
         _id: mockFile2Id,
         s3_key: undefined,
-        storage_id: "storage123" as any,
         user_id: "user123",
         name: "file2.pdf",
         media_type: "application/pdf",
@@ -935,11 +805,6 @@ describe("s3Actions", () => {
           .fn()
           .mockResolvedValueOnce(mockFile1)
           .mockResolvedValueOnce(mockFile2),
-        storage: {
-          getUrl: jest
-            .fn()
-            .mockResolvedValue("https://convex.cloud/storage/file2-url"),
-        },
       } as any;
 
       const result = await getFileUrlsBatchAction.handler(mockCtx, {
@@ -948,7 +813,6 @@ describe("s3Actions", () => {
 
       expect(result).toEqual({
         file1: "https://s3.amazonaws.com/file1-url",
-        file2: "https://convex.cloud/storage/file2-url",
       });
     });
 
@@ -971,7 +835,6 @@ describe("s3Actions", () => {
       const mockFile1 = {
         _id: mockFile1Id,
         s3_key: "users/user123/file1.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file1.pdf",
         media_type: "application/pdf",
@@ -984,7 +847,6 @@ describe("s3Actions", () => {
       const mockFile2 = {
         _id: mockFile2Id,
         s3_key: "users/user456/file2.pdf",
-        storage_id: undefined,
         user_id: "user456", // Different owner
         name: "file2.pdf",
         media_type: "application/pdf",
@@ -1006,9 +868,6 @@ describe("s3Actions", () => {
           .fn()
           .mockResolvedValueOnce(mockFile1)
           .mockResolvedValueOnce(mockFile2),
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       const result = await getFileUrlsBatchAction.handler(mockCtx, {
@@ -1041,7 +900,6 @@ describe("s3Actions", () => {
       const mockFile1 = {
         _id: mockFile1Id,
         s3_key: "users/user123/file1.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file1.pdf",
         media_type: "application/pdf",
@@ -1063,9 +921,6 @@ describe("s3Actions", () => {
           .fn()
           .mockResolvedValueOnce(mockFile1)
           .mockResolvedValueOnce(null), // File not found
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       const result = await getFileUrlsBatchAction.handler(mockCtx, {
@@ -1079,7 +934,7 @@ describe("s3Actions", () => {
       expect(result.file2).toBeUndefined();
     });
 
-    it("should skip files with no storage reference", async () => {
+    it("should skip files with no S3 key", async () => {
       const { getFileUrlsBatchAction } = await import("../s3Actions");
 
       const mockFile1Id = "file1" as any;
@@ -1087,7 +942,6 @@ describe("s3Actions", () => {
       const mockFile1 = {
         _id: mockFile1Id,
         s3_key: undefined,
-        storage_id: undefined,
         user_id: "user123",
         name: "file1.pdf",
         media_type: "application/pdf",
@@ -1106,48 +960,6 @@ describe("s3Actions", () => {
           }),
         },
         runQuery: jest.fn().mockResolvedValue(mockFile1),
-        storage: {
-          getUrl: jest.fn(),
-        },
-      } as any;
-
-      const result = await getFileUrlsBatchAction.handler(mockCtx, {
-        fileIds: [mockFile1Id],
-      });
-
-      expect(result).toEqual({});
-    });
-
-    it("should skip files with both storage references (invalid state)", async () => {
-      const { getFileUrlsBatchAction } = await import("../s3Actions");
-
-      const mockFile1Id = "file1" as any;
-
-      const mockFile1 = {
-        _id: mockFile1Id,
-        s3_key: "users/user123/file1.pdf",
-        storage_id: "storage123" as any,
-        user_id: "user123",
-        name: "file1.pdf",
-        media_type: "application/pdf",
-        size: 1024,
-        file_token_size: 100,
-        is_attached: true,
-        _creationTime: Date.now(),
-      };
-
-      const mockCtx = {
-        auth: {
-          getUserIdentity: jest.fn().mockResolvedValue({
-            subject: "user123",
-            email: "test@example.com",
-            entitlements: ["pro-plan"],
-          }),
-        },
-        runQuery: jest.fn().mockResolvedValue(mockFile1),
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       const result = await getFileUrlsBatchAction.handler(mockCtx, {
@@ -1178,7 +990,6 @@ describe("s3Actions", () => {
       const mockFile1 = {
         _id: mockFile1Id,
         s3_key: "users/user123/file1.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file1.pdf",
         media_type: "application/pdf",
@@ -1191,7 +1002,6 @@ describe("s3Actions", () => {
       const mockFile2 = {
         _id: mockFile2Id,
         s3_key: "users/user123/file2.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file2.pdf",
         media_type: "application/pdf",
@@ -1204,7 +1014,6 @@ describe("s3Actions", () => {
       const mockFile3 = {
         _id: mockFile3Id,
         s3_key: "users/user123/file3.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file3.pdf",
         media_type: "application/pdf",
@@ -1227,9 +1036,6 @@ describe("s3Actions", () => {
           .mockResolvedValueOnce(mockFile1)
           .mockResolvedValueOnce(mockFile2)
           .mockResolvedValueOnce(mockFile3),
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       const result = await getFileUrlsBatchAction.handler(mockCtx, {
@@ -1308,7 +1114,6 @@ describe("s3Actions", () => {
       const mockFile1 = {
         _id: mockFile1Id,
         s3_key: "users/user456/file1.pdf",
-        storage_id: undefined,
         user_id: "user456", // Different owner
         name: "file1.pdf",
         media_type: "application/pdf",
@@ -1321,7 +1126,6 @@ describe("s3Actions", () => {
       const mockFile2 = {
         _id: mockFile2Id,
         s3_key: "users/user789/file2.pdf",
-        storage_id: undefined,
         user_id: "user789", // Different owner
         name: "file2.pdf",
         media_type: "application/pdf",
@@ -1343,9 +1147,6 @@ describe("s3Actions", () => {
           .fn()
           .mockResolvedValueOnce(mockFile1)
           .mockResolvedValueOnce(mockFile2),
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       const result = await getFileUrlsBatchAction.handler(mockCtx, {
@@ -1380,7 +1181,6 @@ describe("s3Actions", () => {
       const mockFile1 = {
         _id: mockFile1Id,
         s3_key: "users/user123/file1.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file1.pdf",
         media_type: "application/pdf",
@@ -1393,7 +1193,6 @@ describe("s3Actions", () => {
       const mockFile2 = {
         _id: mockFile2Id,
         s3_key: "users/user123/file2.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file2.pdf",
         media_type: "application/pdf",
@@ -1408,9 +1207,6 @@ describe("s3Actions", () => {
           .fn()
           .mockResolvedValueOnce(mockFile1)
           .mockResolvedValueOnce(mockFile2),
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
@@ -1439,7 +1235,6 @@ describe("s3Actions", () => {
       const mockFile = {
         _id: mockFileId,
         s3_key: "users/victim/file1.pdf",
-        storage_id: undefined,
         user_id: "victim",
         name: "file1.pdf",
         media_type: "application/pdf",
@@ -1451,9 +1246,6 @@ describe("s3Actions", () => {
 
       const mockCtx = {
         runQuery: jest.fn().mockResolvedValue(mockFile),
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
@@ -1466,7 +1258,7 @@ describe("s3Actions", () => {
       expect(mockGenerateS3DownloadUrl).not.toHaveBeenCalled();
     });
 
-    it("should handle mixed S3 and Convex files", async () => {
+    it("should return null for files without S3 keys", async () => {
       const { generateS3DownloadUrl } = await import("../s3Utils");
       const mockGenerateS3DownloadUrl =
         generateS3DownloadUrl as jest.MockedFunction<
@@ -1485,7 +1277,6 @@ describe("s3Actions", () => {
       const mockFile1 = {
         _id: mockFile1Id,
         s3_key: "users/user123/file1.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file1.pdf",
         media_type: "application/pdf",
@@ -1498,7 +1289,6 @@ describe("s3Actions", () => {
       const mockFile2 = {
         _id: mockFile2Id,
         s3_key: undefined,
-        storage_id: "storage123" as any,
         user_id: "user123",
         name: "file2.pdf",
         media_type: "application/pdf",
@@ -1513,11 +1303,6 @@ describe("s3Actions", () => {
           .fn()
           .mockResolvedValueOnce(mockFile1)
           .mockResolvedValueOnce(mockFile2),
-        storage: {
-          getUrl: jest
-            .fn()
-            .mockResolvedValue("https://convex.cloud/storage/file2-url"),
-        },
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
@@ -1526,10 +1311,7 @@ describe("s3Actions", () => {
         fileIds: [mockFile1Id, mockFile2Id],
       });
 
-      expect(result).toEqual([
-        "https://s3.amazonaws.com/file1-url",
-        "https://convex.cloud/storage/file2-url",
-      ]);
+      expect(result).toEqual(["https://s3.amazonaws.com/file1-url", null]);
     });
 
     it("should return null for files not found", async () => {
@@ -1543,9 +1325,6 @@ describe("s3Actions", () => {
           .fn()
           .mockResolvedValueOnce(null)
           .mockResolvedValueOnce(null),
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
@@ -1616,7 +1395,6 @@ describe("s3Actions", () => {
       const mockFile1 = {
         _id: mockFile1Id,
         s3_key: "users/user123/file1.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file1.pdf",
         media_type: "application/pdf",
@@ -1629,7 +1407,6 @@ describe("s3Actions", () => {
       const mockFile2 = {
         _id: mockFile2Id,
         s3_key: "users/user123/file2.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file2.pdf",
         media_type: "application/pdf",
@@ -1642,7 +1419,6 @@ describe("s3Actions", () => {
       const mockFile3 = {
         _id: mockFile3Id,
         s3_key: "users/user123/file3.pdf",
-        storage_id: undefined,
         user_id: "user123",
         name: "file3.pdf",
         media_type: "application/pdf",
@@ -1658,9 +1434,6 @@ describe("s3Actions", () => {
           .mockResolvedValueOnce(mockFile1)
           .mockResolvedValueOnce(mockFile2)
           .mockResolvedValueOnce(mockFile3),
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
@@ -1689,7 +1462,6 @@ describe("s3Actions", () => {
       const mockFile = {
         _id: mockFileId,
         s3_key: "users/victim/file1.pdf",
-        storage_id: undefined,
         user_id: "victim-user",
         name: "file1.pdf",
         media_type: "application/pdf",
@@ -1701,9 +1473,6 @@ describe("s3Actions", () => {
 
       const mockCtx = {
         runQuery: jest.fn().mockResolvedValue(mockFile),
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
@@ -1714,10 +1483,9 @@ describe("s3Actions", () => {
 
       expect(result).toEqual([null]);
       expect(mockGenerateS3DownloadUrl).not.toHaveBeenCalled();
-      expect(mockCtx.storage.getUrl).not.toHaveBeenCalled();
     });
 
-    it("should return null for unowned Convex storage files", async () => {
+    it("should return null for unowned files without S3 keys", async () => {
       const { generateS3DownloadUrl } = await import("../s3Utils");
       const mockGenerateS3DownloadUrl =
         generateS3DownloadUrl as jest.MockedFunction<
@@ -1729,7 +1497,6 @@ describe("s3Actions", () => {
       const mockFile = {
         _id: mockFileId,
         s3_key: undefined,
-        storage_id: "storage-victim" as any,
         user_id: "victim-user",
         name: "file1.pdf",
         media_type: "application/pdf",
@@ -1741,9 +1508,6 @@ describe("s3Actions", () => {
 
       const mockCtx = {
         runQuery: jest.fn().mockResolvedValue(mockFile),
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
@@ -1754,7 +1518,6 @@ describe("s3Actions", () => {
 
       expect(result).toEqual([null]);
       expect(mockGenerateS3DownloadUrl).not.toHaveBeenCalled();
-      expect(mockCtx.storage.getUrl).not.toHaveBeenCalled();
     });
 
     it("should handle empty file IDs array", async () => {
@@ -1771,7 +1534,7 @@ describe("s3Actions", () => {
       expect(result).toEqual([]);
     });
 
-    it("should return null for files with no storage reference", async () => {
+    it("should return null for files with no S3 key", async () => {
       const { getFileUrlsByFileIdsAction } = await import("../s3Actions");
 
       const mockFile1Id = "file1" as any;
@@ -1779,7 +1542,6 @@ describe("s3Actions", () => {
       const mockFile1 = {
         _id: mockFile1Id,
         s3_key: undefined,
-        storage_id: undefined,
         user_id: "user123",
         name: "file1.pdf",
         media_type: "application/pdf",
@@ -1791,9 +1553,6 @@ describe("s3Actions", () => {
 
       const mockCtx = {
         runQuery: jest.fn().mockResolvedValue(mockFile1),
-        storage: {
-          getUrl: jest.fn(),
-        },
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -57,17 +57,13 @@ describe("userDeletion", () => {
         delete: jest.fn(),
       };
 
-      const mockStorage = {
-        delete: jest.fn(),
-      };
-
       const mockAuth = {
         getUserIdentity: jest.fn().mockResolvedValue({
           subject: "user123",
         }),
       };
 
-      // Mock files with both S3 and Convex storage
+      // Mock files with S3 objects and one DB-only file row.
       const mockFiles = [
         {
           _id: "file1",
@@ -91,7 +87,6 @@ describe("userDeletion", () => {
         },
         {
           _id: "file3",
-          storage_id: "storage123",
           user_id: "user123",
           name: "file3.txt",
           media_type: "text/plain",
@@ -123,7 +118,6 @@ describe("userDeletion", () => {
       const mockCtx = {
         auth: mockAuth,
         db: mockDb,
-        storage: mockStorage,
         scheduler: mockScheduler,
       };
 
@@ -138,9 +132,6 @@ describe("userDeletion", () => {
         },
       );
 
-      // Verify Convex storage file was deleted
-      expect(mockStorage.delete).toHaveBeenCalledWith("storage123");
-
       // Verify all file records were deleted
       expect(mockDb.delete).toHaveBeenCalledWith("file1");
       expect(mockDb.delete).toHaveBeenCalledWith("file2");
@@ -152,7 +143,7 @@ describe("userDeletion", () => {
       );
     });
 
-    it("should handle only Convex files (no S3 files)", async () => {
+    it("should handle file rows without S3 keys", async () => {
       const { deleteAllUserData } = await import("../userDeletion");
 
       const mockScheduler = {
@@ -161,10 +152,6 @@ describe("userDeletion", () => {
 
       const mockDb = {
         query: jest.fn(),
-        delete: jest.fn(),
-      };
-
-      const mockStorage = {
         delete: jest.fn(),
       };
 
@@ -177,7 +164,6 @@ describe("userDeletion", () => {
       const mockFiles = [
         {
           _id: "file1",
-          storage_id: "storage123",
           user_id: "user123",
           name: "file1.txt",
           media_type: "text/plain",
@@ -207,7 +193,6 @@ describe("userDeletion", () => {
       const mockCtx = {
         auth: mockAuth,
         db: mockDb,
-        storage: mockStorage,
         scheduler: mockScheduler,
       };
 
@@ -216,14 +201,11 @@ describe("userDeletion", () => {
       // Verify S3 batch deletion was NOT scheduled (no S3 files)
       expect(mockScheduler.runAfter).not.toHaveBeenCalled();
 
-      // Verify Convex storage file was deleted
-      expect(mockStorage.delete).toHaveBeenCalledWith("storage123");
-
       // Verify file record was deleted
       expect(mockDb.delete).toHaveBeenCalledWith("file1");
     });
 
-    it("should handle only S3 files (no Convex files)", async () => {
+    it("should handle only S3 files", async () => {
       const { deleteAllUserData } = await import("../userDeletion");
 
       const mockScheduler = {
@@ -232,10 +214,6 @@ describe("userDeletion", () => {
 
       const mockDb = {
         query: jest.fn(),
-        delete: jest.fn(),
-      };
-
-      const mockStorage = {
         delete: jest.fn(),
       };
 
@@ -278,7 +256,6 @@ describe("userDeletion", () => {
       const mockCtx = {
         auth: mockAuth,
         db: mockDb,
-        storage: mockStorage,
         scheduler: mockScheduler,
       };
 
@@ -290,9 +267,6 @@ describe("userDeletion", () => {
         "deleteS3ObjectsBatchAction",
         { s3Keys: ["users/user456/file1.pdf"] },
       );
-
-      // Verify Convex storage delete was NOT called
-      expect(mockStorage.delete).not.toHaveBeenCalled();
 
       // Verify file record was deleted
       expect(mockDb.delete).toHaveBeenCalledWith("file1");
@@ -307,10 +281,6 @@ describe("userDeletion", () => {
 
       const mockDb = {
         query: jest.fn(),
-        delete: jest.fn(),
-      };
-
-      const mockStorage = {
         delete: jest.fn(),
       };
 
@@ -353,7 +323,6 @@ describe("userDeletion", () => {
       const mockCtx = {
         auth: mockAuth,
         db: mockDb,
-        storage: mockStorage,
         scheduler: mockScheduler,
       };
 
@@ -372,83 +341,6 @@ describe("userDeletion", () => {
       expect(mockDb.delete).toHaveBeenCalledWith("file1");
     });
 
-    it("should handle Convex storage deletion errors gracefully", async () => {
-      const { deleteAllUserData } = await import("../userDeletion");
-
-      const mockScheduler = {
-        runAfter: jest.fn(),
-      };
-
-      const mockDb = {
-        query: jest.fn(),
-        delete: jest.fn(),
-      };
-
-      const mockStorage = {
-        delete: jest
-          .fn()
-          .mockRejectedValue(new Error("Storage deletion failed")),
-      };
-
-      const mockAuth = {
-        getUserIdentity: jest.fn().mockResolvedValue({
-          subject: "user999",
-        }),
-      };
-
-      const mockFiles = [
-        {
-          _id: "file1",
-          storage_id: "storage123",
-          user_id: "user999",
-          name: "file1.txt",
-          media_type: "text/plain",
-          size: 500,
-          file_token_size: 50,
-          is_attached: true,
-        },
-      ];
-
-      const mockQueryBuilder = {
-        withIndex: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        collect: jest.fn(),
-        first: jest.fn(),
-      };
-
-      mockDb.query.mockReturnValue(mockQueryBuilder);
-
-      mockQueryBuilder.collect
-        .mockResolvedValueOnce([]) // chats
-        .mockResolvedValueOnce(mockFiles) // files
-        .mockResolvedValueOnce([]) // notes
-        .mockResolvedValueOnce([]); // messages
-
-      mockQueryBuilder.first.mockResolvedValue(null);
-
-      const mockCtx = {
-        auth: mockAuth,
-        db: mockDb,
-        storage: mockStorage,
-        scheduler: mockScheduler,
-      };
-
-      // Should not throw
-      await expect(
-        deleteAllUserData.handler(mockCtx, {}),
-      ).resolves.not.toThrow();
-
-      // Verify warning was logged
-      expect(console.warn).toHaveBeenCalledWith(
-        "Failed to delete storage blob:",
-        "storage123",
-        expect.any(Error),
-      );
-
-      // Verify file record was still deleted
-      expect(mockDb.delete).toHaveBeenCalledWith("file1");
-    });
-
     it("should handle empty file list", async () => {
       const { deleteAllUserData } = await import("../userDeletion");
 
@@ -458,10 +350,6 @@ describe("userDeletion", () => {
 
       const mockDb = {
         query: jest.fn(),
-        delete: jest.fn(),
-      };
-
-      const mockStorage = {
         delete: jest.fn(),
       };
 
@@ -491,7 +379,6 @@ describe("userDeletion", () => {
       const mockCtx = {
         auth: mockAuth,
         db: mockDb,
-        storage: mockStorage,
         scheduler: mockScheduler,
       };
 
@@ -499,9 +386,6 @@ describe("userDeletion", () => {
 
       // Verify S3 batch deletion was NOT scheduled (no files)
       expect(mockScheduler.runAfter).not.toHaveBeenCalled();
-
-      // Verify storage delete was NOT called
-      expect(mockStorage.delete).not.toHaveBeenCalled();
     });
 
     it("should throw error if user is not authenticated", async () => {

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -48,9 +48,9 @@ async function deleteNextUserChatBatch(ctx: MutationCtx, userId: string) {
   if (messages.length > 0) {
     for (const message of messages) {
       if (!message.source_message_id && message.file_ids?.length) {
-        for (const storageId of message.file_ids) {
+        for (const fileId of message.file_ids) {
           try {
-            const file = await ctx.db.get(storageId);
+            const file = await ctx.db.get(fileId);
             if (file) {
               if (file.s3_key) {
                 await ctx.scheduler.runAfter(
@@ -59,14 +59,11 @@ async function deleteNextUserChatBatch(ctx: MutationCtx, userId: string) {
                   { s3Key: file.s3_key },
                 );
               }
-              if (file.storage_id) {
-                await ctx.storage.delete(file.storage_id);
-              }
               await fileCountAggregate.deleteIfExists(ctx, file);
               await ctx.db.delete(file._id);
             }
           } catch (error) {
-            console.error(`Failed to delete file ${storageId}:`, error);
+            console.error(`Failed to delete file ${fileId}:`, error);
           }
         }
       }
@@ -740,11 +737,10 @@ export const deleteChat = mutation({
         if (!message.source_message_id) {
           // Clean up files associated with this message
           if (message.file_ids && message.file_ids.length > 0) {
-            for (const storageId of message.file_ids) {
+            for (const fileId of message.file_ids) {
               try {
-                const file = await ctx.db.get(storageId);
+                const file = await ctx.db.get(fileId);
                 if (file) {
-                  // Delete from appropriate storage
                   if (file.s3_key) {
                     await ctx.scheduler.runAfter(
                       0,
@@ -752,15 +748,12 @@ export const deleteChat = mutation({
                       { s3Key: file.s3_key },
                     );
                   }
-                  if (file.storage_id) {
-                    await ctx.storage.delete(file.storage_id);
-                  }
                   // Delete from aggregate
                   await fileCountAggregate.deleteIfExists(ctx, file);
                   await ctx.db.delete(file._id);
                 }
               } catch (error) {
-                console.error(`Failed to delete file ${storageId}:`, error);
+                console.error(`Failed to delete file ${fileId}:`, error);
                 // Continue with deletion even if file cleanup fails
               }
             }
@@ -1018,9 +1011,9 @@ export const deleteAllChatsForUser = mutation({
 
       for (const message of messages) {
         if (!message.source_message_id && message.file_ids?.length) {
-          for (const storageId of message.file_ids) {
+          for (const fileId of message.file_ids) {
             try {
-              const file = await ctx.db.get(storageId);
+              const file = await ctx.db.get(fileId);
               if (file) {
                 if (file.s3_key) {
                   await ctx.scheduler.runAfter(
@@ -1029,14 +1022,11 @@ export const deleteAllChatsForUser = mutation({
                     { s3Key: file.s3_key },
                   );
                 }
-                if (file.storage_id) {
-                  await ctx.storage.delete(file.storage_id);
-                }
                 await fileCountAggregate.deleteIfExists(ctx, file);
                 await ctx.db.delete(file._id);
               }
             } catch (error) {
-              console.error(`Failed to delete file ${storageId}:`, error);
+              console.error(`Failed to delete file ${fileId}:`, error);
             }
           }
         }

--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -653,9 +653,6 @@ const processDocxFile = async (
  */
 export const saveFile = action({
   args: {
-    // Accepted only to return a stable error to stale clients. New file
-    // uploads must go through S3.
-    storageId: v.optional(v.id("_storage")),
     s3Key: v.optional(v.string()),
     name: v.string(),
     mediaType: v.string(),
@@ -673,13 +670,6 @@ export const saveFile = action({
     tokens: v.number(),
   }),
   handler: async (ctx, args) => {
-    if (args.storageId) {
-      throw new ConvexError({
-        code: "CONVEX_STORAGE_UPLOADS_DISABLED",
-        message:
-          "Convex storage uploads are no longer supported. Upload files through S3 instead.",
-      });
-    }
     if (!args.s3Key) {
       throw new ConvexError({
         code: "INVALID_STORAGE_ARGS",

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -4,7 +4,6 @@ import {
   mutation,
   query,
 } from "./_generated/server";
-import { Id } from "./_generated/dataModel";
 import { v, ConvexError } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 import { internal } from "./_generated/api";
@@ -14,69 +13,9 @@ import { convexLogger } from "./lib/logger";
 
 // Maximum storage per user: 10 GB
 const MAX_STORAGE_BYTES = 10 * 1024 * 1024 * 1024; // 10737418240 bytes
-const LEGACY_CONVEX_PURGE_DEFAULT_LIMIT = 100;
-const LEGACY_CONVEX_PURGE_MAX_LIMIT = 500;
-const LEGACY_CONVEX_PURGE_SAMPLE_LIMIT = 20;
-
-function isMissingConvexStorageError(error: unknown): boolean {
-  return (
-    error instanceof Error && /^storage id .+ not found$/.test(error.message)
-  );
-}
-
-/**
- * Get download URL for a file by storageId (on-demand for non-image files)
- */
-export const getFileDownloadUrl = query({
-  args: {
-    storageId: v.string(),
-  },
-  returns: v.union(v.string(), v.null()),
-  handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
-
-    if (!user) {
-      throw new ConvexError({
-        code: "UNAUTHORIZED",
-        message: "Unauthorized: User not authenticated",
-      });
-    }
-
-    // Direct lookup by storage_id using index
-    const file = await ctx.db
-      .query("files")
-      .withIndex("by_storage_id", (q) =>
-        q.eq("storage_id", args.storageId as Id<"_storage">),
-      )
-      .first();
-
-    // Stale message/file UI can outlive deleted storage rows. Treat missing as
-    // an unavailable URL instead of a Convex exception.
-    if (!file) {
-      convexLogger.warn("file_download_url_missing_file", {
-        user_id: user.subject,
-        storage_id: args.storageId,
-      });
-      return null;
-    }
-
-    if (file.user_id !== user.subject) {
-      convexLogger.warn("file_download_url_access_denied", {
-        user_id: user.subject,
-        file_id: file._id,
-        storage_id: args.storageId,
-      });
-      return null;
-    }
-
-    // Generate and return signed URL
-    return await ctx.storage.getUrl(args.storageId);
-  },
-});
 
 /**
  * Delete file from storage by file ID
- * Handles both S3 and Convex storage files
  */
 export const deleteFile = mutation({
   args: {
@@ -110,18 +49,14 @@ export const deleteFile = mutation({
       });
     }
 
-    // Delete from appropriate storage
+    // Delete from S3 storage when this row still has an object reference.
     if (file.s3_key) {
-      // Schedule S3 deletion using the cleanup action
       await ctx.scheduler.runAfter(0, internal.s3Cleanup.deleteS3ObjectAction, {
         s3Key: file.s3_key,
       });
-    } else if (file.storage_id) {
-      // Delete from Convex storage
-      await ctx.storage.delete(file.storage_id);
     } else {
       console.warn(
-        `File ${args.fileId} has neither s3_key nor storage_id, skipping storage deletion`,
+        `File ${args.fileId} has no s3_key, skipping storage deletion`,
       );
     }
 
@@ -174,7 +109,6 @@ export const getFileMetadataByFileIds = query({
         fileId: v.id("files"),
         name: v.string(),
         mediaType: v.string(),
-        storageId: v.optional(v.id("_storage")),
         s3Key: v.optional(v.string()),
       }),
       v.null(),
@@ -199,7 +133,6 @@ export const getFileMetadataByFileIds = query({
         fileId: args.fileIds[index],
         name: file.name,
         mediaType: file.media_type,
-        storageId: file.storage_id,
         s3Key: file.s3_key,
       };
     });
@@ -264,7 +197,6 @@ export const getFileContentByFileIds = query({
 
 /**
  * Internal mutation: purge unattached files older than cutoff
- * Handles both S3 and Convex storage files
  */
 export const purgeExpiredUnattachedFiles = internalMutation({
   args: {
@@ -286,20 +218,15 @@ export const purgeExpiredUnattachedFiles = internalMutation({
     let deletedCount = 0;
     for (const file of candidates) {
       try {
-        // Delete from appropriate storage
         if (file.s3_key) {
-          // Schedule S3 deletion using the cleanup action
           await ctx.scheduler.runAfter(
             0,
             internal.s3Cleanup.deleteS3ObjectAction,
             { s3Key: file.s3_key },
           );
-        } else if (file.storage_id) {
-          // Delete from Convex storage
-          await ctx.storage.delete(file.storage_id);
         } else {
           console.warn(
-            `File ${file._id} has neither s3_key nor storage_id, skipping storage deletion`,
+            `File ${file._id} has no s3_key, skipping storage deletion`,
           );
         }
       } catch (e) {
@@ -318,244 +245,6 @@ export const purgeExpiredUnattachedFiles = internalMutation({
 });
 
 /**
- * Admin mutation: purge legacy Convex storage blobs for files older than a cutoff.
- *
- * New uploads use S3, but older file rows can still point at Convex storage via
- * `storage_id`. This deletes those blobs in batches and clears the storage ID
- * from the file row so old chat metadata can survive without exposing a
- * long-lived Convex storage URL. Pass `deleteDatabaseRecords: true` only if you
- * intentionally want the file rows removed as well.
- */
-export const purgeLegacyConvexStorageFiles = mutation({
-  args: {
-    serviceKey: v.string(),
-    cutoffTimeMs: v.number(),
-    limit: v.optional(v.number()),
-    dryRun: v.optional(v.boolean()),
-    includeAttached: v.optional(v.boolean()),
-    deleteDatabaseRecords: v.optional(v.boolean()),
-  },
-  returns: v.object({
-    dryRun: v.boolean(),
-    cutoffTimeMs: v.number(),
-    limit: v.number(),
-    includeAttached: v.boolean(),
-    deleteDatabaseRecords: v.boolean(),
-    candidateCount: v.number(),
-    totalBytes: v.number(),
-    attachedCount: v.number(),
-    unattachedCount: v.number(),
-    deletedStorageCount: v.number(),
-    missingStorageCount: v.number(),
-    detachedRecordCount: v.number(),
-    deletedRecordCount: v.number(),
-    aggregateRemovedCount: v.number(),
-    aggregateFailedCount: v.number(),
-    failedCount: v.number(),
-    samples: v.array(
-      v.object({
-        fileId: v.id("files"),
-        userId: v.string(),
-        name: v.string(),
-        size: v.number(),
-        isAttached: v.boolean(),
-        creationTimeMs: v.number(),
-      }),
-    ),
-    failures: v.array(
-      v.object({
-        fileId: v.id("files"),
-        name: v.string(),
-        error: v.string(),
-      }),
-    ),
-  }),
-  handler: async (ctx, args) => {
-    validateServiceKey(args.serviceKey);
-
-    const limit = Math.min(
-      Math.max(Math.round(args.limit ?? LEGACY_CONVEX_PURGE_DEFAULT_LIMIT), 1),
-      LEGACY_CONVEX_PURGE_MAX_LIMIT,
-    );
-    const dryRun = args.dryRun ?? true;
-    const includeAttached = args.includeAttached ?? true;
-    const deleteDatabaseRecords = args.deleteDatabaseRecords ?? false;
-
-    const legacyQuery = ctx.db
-      .query("files")
-      .withIndex("by_storage_id", (q) => q.gt("storage_id", undefined))
-      .order("asc");
-
-    const candidateRows = includeAttached
-      ? await legacyQuery
-          .filter((q) =>
-            q.and(
-              q.eq(q.field("s3_key"), undefined),
-              q.lt(q.field("_creationTime"), args.cutoffTimeMs),
-            ),
-          )
-          .take(limit)
-      : await legacyQuery
-          .filter((q) =>
-            q.and(
-              q.eq(q.field("s3_key"), undefined),
-              q.lt(q.field("_creationTime"), args.cutoffTimeMs),
-              q.eq(q.field("is_attached"), false),
-            ),
-          )
-          .take(limit);
-
-    type LegacyConvexFile = (typeof candidateRows)[number] & {
-      storage_id: Id<"_storage">;
-    };
-
-    const candidates = candidateRows.filter(
-      (file): file is LegacyConvexFile =>
-        file.storage_id !== undefined && (includeAttached || !file.is_attached),
-    );
-
-    const totalBytes = candidates.reduce((sum, file) => sum + file.size, 0);
-    const attachedCount = candidates.filter((file) => file.is_attached).length;
-    const unattachedCount = candidates.length - attachedCount;
-    const samples = candidates
-      .slice(0, LEGACY_CONVEX_PURGE_SAMPLE_LIMIT)
-      .map((file) => ({
-        fileId: file._id,
-        userId: file.user_id,
-        name: file.name,
-        size: file.size,
-        isAttached: file.is_attached,
-        creationTimeMs: file._creationTime,
-      }));
-
-    let deletedStorageCount = 0;
-    let missingStorageCount = 0;
-    let detachedRecordCount = 0;
-    let deletedRecordCount = 0;
-    let aggregateRemovedCount = 0;
-    let aggregateFailedCount = 0;
-    const failures: Array<{
-      fileId: Id<"files">;
-      name: string;
-      error: string;
-    }> = [];
-
-    if (!dryRun) {
-      for (const file of candidates) {
-        try {
-          try {
-            await ctx.storage.delete(file.storage_id);
-            deletedStorageCount++;
-          } catch (error) {
-            if (!isMissingConvexStorageError(error)) {
-              throw error;
-            }
-
-            missingStorageCount++;
-            convexLogger.warn("legacy_convex_storage_already_missing", {
-              fileId: file._id,
-              userId: file.user_id,
-            });
-          }
-
-          try {
-            await fileCountAggregate.deleteIfExists(ctx, file);
-            aggregateRemovedCount++;
-          } catch (error) {
-            aggregateFailedCount++;
-            convexLogger.warn(
-              "legacy_convex_storage_aggregate_cleanup_failed",
-              {
-                fileId: file._id,
-                userId: file.user_id,
-                error:
-                  error instanceof Error
-                    ? {
-                        name: error.name,
-                        message: error.message,
-                        stack: error.stack,
-                      }
-                    : String(error),
-              },
-            );
-          }
-
-          if (deleteDatabaseRecords) {
-            await ctx.db.delete(file._id);
-            deletedRecordCount++;
-          } else {
-            await ctx.db.patch(file._id, { storage_id: undefined });
-            detachedRecordCount++;
-          }
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          failures.push({
-            fileId: file._id,
-            name: file.name,
-            error: message,
-          });
-          convexLogger.error("legacy_convex_storage_purge_failed", {
-            fileId: file._id,
-            userId: file.user_id,
-            error:
-              error instanceof Error
-                ? {
-                    name: error.name,
-                    message: error.message,
-                    stack: error.stack,
-                  }
-                : String(error),
-          });
-        }
-      }
-    }
-
-    const result = {
-      dryRun,
-      cutoffTimeMs: args.cutoffTimeMs,
-      limit,
-      includeAttached,
-      deleteDatabaseRecords,
-      candidateCount: candidates.length,
-      totalBytes,
-      attachedCount,
-      unattachedCount,
-      deletedStorageCount,
-      missingStorageCount,
-      detachedRecordCount,
-      deletedRecordCount,
-      aggregateRemovedCount,
-      aggregateFailedCount,
-      failedCount: failures.length,
-      samples,
-      failures,
-    };
-
-    convexLogger.info("legacy_convex_storage_purge_completed", {
-      dryRun,
-      cutoffTimeMs: args.cutoffTimeMs,
-      limit,
-      includeAttached,
-      deleteDatabaseRecords,
-      candidateCount: candidates.length,
-      totalBytes,
-      attachedCount,
-      unattachedCount,
-      deletedStorageCount,
-      missingStorageCount,
-      detachedRecordCount,
-      deletedRecordCount,
-      aggregateRemovedCount,
-      aggregateFailedCount,
-      failedCount: failures.length,
-    });
-
-    return result;
-  },
-});
-
-/**
  * Internal query to get a file by ID
  * Used by actions that need to verify file existence and ownership
  */
@@ -566,7 +255,6 @@ export const getFileById = internalQuery({
   returns: v.union(
     v.object({
       _id: v.id("files"),
-      storage_id: v.optional(v.id("_storage")),
       s3_key: v.optional(v.string()),
       user_id: v.string(),
       name: v.string(),
@@ -679,7 +367,6 @@ export const saveFileToDb = internalMutation({
       }
 
       await ctx.db.patch(existing._id, {
-        storage_id: undefined,
         name: args.name,
         media_type: args.mediaType,
         file_token_size: args.fileTokenSize,

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -808,7 +808,6 @@ export const getMessagesByChatId = query({
               name: v.string(),
               mediaType: v.optional(v.string()),
               url: v.optional(v.union(v.string(), v.null())),
-              storageId: v.optional(v.string()),
               s3Key: v.optional(v.string()),
             }),
           ),
@@ -868,7 +867,7 @@ export const getMessagesByChatId = query({
       // DON'T generate URLs here - they expire and get cached with the query!
       // Frontend will fetch URLs on-demand via actions (avoids stale cached URLs)
       // V8-SAFE: This query does NOT call generateS3DownloadUrl or any Node.js built-ins.
-      // Only file metadata (fileId, name, mediaType, s3Key, storageId) is returned.
+      // Only file metadata (fileId, name, mediaType, s3Key) is returned.
       const fileDetailsMap = new Map();
       files.forEach((file, index) => {
         if (file && file.user_id === user.subject) {
@@ -877,7 +876,6 @@ export const getMessagesByChatId = query({
             name: file.name,
             mediaType: file.media_type,
             // url: removed - generate on-demand to avoid caching expired URLs
-            storageId: file.storage_id,
             s3Key: file.s3_key,
           });
         }
@@ -1125,9 +1123,9 @@ export const deleteLastAssistantMessage = mutation({
         // Delete files and messages
         for (const msg of messagesToDelete) {
           if (msg.file_ids && msg.file_ids.length > 0) {
-            for (const storageId of msg.file_ids) {
+            for (const fileId of msg.file_ids) {
               try {
-                const file = await ctx.db.get(storageId);
+                const file = await ctx.db.get(fileId);
                 if (file) {
                   if (file.s3_key) {
                     await ctx.scheduler.runAfter(
@@ -1135,14 +1133,12 @@ export const deleteLastAssistantMessage = mutation({
                       internal.s3Cleanup.deleteS3ObjectAction,
                       { s3Key: file.s3_key },
                     );
-                  } else if (file.storage_id) {
-                    await ctx.storage.delete(file.storage_id);
                   }
                   await fileCountAggregate.deleteIfExists(ctx, file);
                   await ctx.db.delete(file._id);
                 }
               } catch (error) {
-                console.error(`Failed to delete file ${storageId}:`, error);
+                console.error(`Failed to delete file ${fileId}:`, error);
               }
             }
           }
@@ -1807,15 +1803,12 @@ export const regenerateWithNewContent = mutation({
         try {
           const file = await ctx.db.get(fileId);
           if (file) {
-            // Delete from appropriate storage
             if (file.s3_key) {
               await ctx.scheduler.runAfter(
                 0,
                 internal.s3Cleanup.deleteS3ObjectAction,
                 { s3Key: file.s3_key },
               );
-            } else if (file.storage_id) {
-              await ctx.storage.delete(file.storage_id);
             }
             // Delete from aggregate
             await fileCountAggregate.deleteIfExists(ctx, file);
@@ -1874,15 +1867,12 @@ export const regenerateWithNewContent = mutation({
             try {
               const file = await ctx.db.get(fileId);
               if (file) {
-                // Delete from appropriate storage
                 if (file.s3_key) {
                   await ctx.scheduler.runAfter(
                     0,
                     internal.s3Cleanup.deleteS3ObjectAction,
                     { s3Key: file.s3_key },
                   );
-                } else if (file.storage_id) {
-                  await ctx.storage.delete(file.storage_id);
                 }
                 // Delete from aggregate
                 await fileCountAggregate.deleteIfExists(ctx, file);
@@ -2014,7 +2004,7 @@ export const getSharedMessages = query({
             return {
               type: isImage ? "image" : "file",
               placeholder: true,
-              // SECURITY: Do NOT include url, storage_id, file_id, name, or mediaType
+              // SECURITY: Do NOT include url, file_id, name, or mediaType
             };
           }
           // Keep text parts as-is
@@ -2052,7 +2042,6 @@ export const getPreviewMessages = query({
             fileId: v.id("files"),
             name: v.string(),
             mediaType: v.optional(v.string()),
-            storageId: v.optional(v.string()),
             s3Key: v.optional(v.string()),
           }),
         ),
@@ -2110,7 +2099,6 @@ export const getPreviewMessages = query({
             fileId: fileIdArray[index],
             name: file.name,
             mediaType: file.media_type,
-            storageId: file.storage_id,
             s3Key: file.s3_key,
           });
         }

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -196,16 +196,14 @@ export const generateS3UploadUrlAction = action({
 });
 
 /**
- * Generate download URL for a file (S3 presigned or Convex storage URL)
+ * Generate an S3 presigned download URL for a file.
  *
  * This action:
  * - Authenticates the user via ctx.auth
  * - Fetches the file record from database
  * - Verifies user has access to the file (ownership check)
- * - Generates appropriate URL based on storage type:
- *   - S3: Returns presigned URL (valid for 1 hour)
- *   - Convex: Returns Convex storage URL
- * - Enforces storage invariant (exactly one storage reference)
+ * - Requires the file to have an S3 object reference
+ * - Returns a presigned URL (valid for 1 hour)
  */
 export const getFileUrlAction = action({
   args: {
@@ -241,32 +239,12 @@ export const getFileUrlAction = action({
         );
       }
 
-      // Enforce storage invariant: exactly one storage reference
-      const hasS3Key = !!file.s3_key;
-      const hasStorageId = !!file.storage_id;
-
-      if (!hasS3Key && !hasStorageId) {
-        throw new Error("File has no storage reference");
+      if (!file.s3_key) {
+        throw new Error("File has no S3 storage reference");
       }
 
-      if (hasS3Key && hasStorageId) {
-        throw new Error(
-          "File has both S3 and Convex storage references (invalid state)",
-        );
-      }
-
-      // Generate appropriate URL based on storage type
-      if (file.s3_key) {
-        // S3 file: Generate presigned download URL (valid for 1 hour)
-        return await generateS3DownloadUrl(file.s3_key);
-      } else {
-        // Convex file: Get Convex storage URL
-        const url = await ctx.storage.getUrl(file.storage_id!);
-        if (!url) {
-          throw new Error("Failed to generate Convex storage URL");
-        }
-        return url;
-      }
+      // S3 file: Generate presigned download URL (valid for 1 hour)
+      return await generateS3DownloadUrl(file.s3_key);
     } catch (error) {
       convexLogger.error("file_get_url_failed", {
         userId: identity.subject,
@@ -290,7 +268,7 @@ export const getFileUrlAction = action({
  * This action:
  * - Authenticates via service key (for backend use)
  * - Accepts array of file IDs (max 50 files)
- * - Generates URLs for both S3 and Convex storage files
+ * - Generates S3 presigned URLs
  * - Returns array of URLs (matching order of fileIds, null for missing files)
  * - Handles partial failures gracefully
  */
@@ -340,13 +318,8 @@ export const getFileUrlsByFileIdsAction = action({
             return null;
           }
 
-          // Generate URL based on storage type
           if (file.s3_key) {
-            // S3 file: Generate presigned download URL
             return await generateS3DownloadUrl(file.s3_key);
-          } else if (file.storage_id) {
-            // Convex file: Get Convex storage URL
-            return await ctx.storage.getUrl(file.storage_id);
           }
 
           return null;
@@ -376,7 +349,7 @@ export const getFileUrlsByFileIdsAction = action({
  * - Accepts array of file IDs (max 50 files)
  * - Fetches file records using internal query
  * - Applies access control per file (skips files user doesn't own)
- * - Generates URLs for accessible files only (S3 presigned or Convex storage)
+ * - Generates S3 presigned URLs for accessible files only
  * - Processes S3 URLs in parallel for better performance
  * - Returns map of fileId -> url (only includes accessible files)
  * - Handles partial failures gracefully (skips failed files)
@@ -426,32 +399,13 @@ export const getFileUrlsBatchAction = action({
           continue;
         }
 
-        // Enforce storage invariant
-        const hasS3Key = !!file.s3_key;
-        const hasStorageId = !!file.storage_id;
-
-        // Skip if no storage reference
-        if (!hasS3Key && !hasStorageId) {
+        // Skip files that no longer have an S3 object reference.
+        if (!file.s3_key) {
           continue;
         }
 
-        // Skip if both storage references (invalid state)
-        if (hasS3Key && hasStorageId) {
-          continue;
-        }
-
-        // Generate URL based on storage type
-        if (file.s3_key) {
-          // S3 file: Generate presigned download URL
-          const url = await generateS3DownloadUrl(file.s3_key);
-          urlMap[fileId] = url;
-        } else if (file.storage_id) {
-          // Convex file: Get Convex storage URL
-          const url = await ctx.storage.getUrl(file.storage_id);
-          if (url) {
-            urlMap[fileId] = url;
-          }
-        }
+        const url = await generateS3DownloadUrl(file.s3_key);
+        urlMap[fileId] = url;
       } catch (error) {
         // Log error but continue processing other files (partial failure handling)
         convexLogger.error("file_batch_url_generation_failed", {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -112,9 +112,6 @@ export default defineSchema({
     }),
 
   files: defineTable({
-    // Legacy field for Convex storage (existing files)
-    storage_id: v.optional(v.id("_storage")),
-    // New field for S3 storage
     s3_key: v.optional(v.string()),
     user_id: v.string(),
     name: v.string(),
@@ -126,8 +123,7 @@ export default defineSchema({
   })
     .index("by_user_id", ["user_id"])
     .index("by_is_attached", ["is_attached"])
-    .index("by_s3_key", ["s3_key"])
-    .index("by_storage_id", ["storage_id"]),
+    .index("by_s3_key", ["s3_key"]),
 
   feedback: defineTable({
     feedback_type: v.union(v.literal("positive"), v.literal("negative")),

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -10,9 +10,8 @@ import { fileCountAggregate } from "./fileAggregate";
  * 1) Feedback records (referenced by messages)
  * 2) Messages (owned by user, reference chats and files)
  * 3) Chats (owned by user)
- * 4) Files + storage (owned by user, may be referenced by messages)
- *    - S3 files: Batch deleted using scheduled action
- *    - Convex storage files: Deleted directly
+ * 4) Files + S3 objects (owned by user, may be referenced by messages)
+ *    - S3 objects: Batch deleted using scheduled action
  * 5) Notes (owned by user)
  * 6) User customization (owned by user)
  *
@@ -98,7 +97,7 @@ export const deleteAllUserData = mutation({
         }),
       );
 
-      // Step 4: Delete files and storage blobs (safe since messages no longer reference them)
+      // Step 4: Delete files and S3 objects (safe since messages no longer reference them)
 
       // Collect S3 keys for batch deletion
       const s3Keys: string[] = [];
@@ -106,21 +105,8 @@ export const deleteAllUserData = mutation({
       await Promise.all(
         files.map(async (file) => {
           try {
-            // Handle S3 files
             if (file.s3_key) {
               s3Keys.push(file.s3_key);
-            }
-            // Handle Convex storage files
-            if (file.storage_id) {
-              try {
-                await ctx.storage.delete(file.storage_id);
-              } catch (e) {
-                console.warn(
-                  "Failed to delete storage blob:",
-                  file.storage_id,
-                  e,
-                );
-              }
             }
 
             // Delete from aggregate

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -33,7 +33,6 @@ type ViewPreviewFile = {
   name: string;
   mediaType: string;
   s3Key?: string;
-  storageId?: Id<"_storage">;
 };
 
 type ViewMetadata = {
@@ -914,7 +913,6 @@ async function uploadViewPreviewFiles(args: {
       name: uploaded.name,
       mediaType: uploaded.mediaType,
       s3Key: uploaded.s3Key,
-      storageId: uploaded.storageId,
     },
   ];
 }

--- a/lib/ai/tools/get-terminal-files.ts
+++ b/lib/ai/tools/get-terminal-files.ts
@@ -89,7 +89,6 @@ Usage:
                 name: saved.name,
                 mediaType: saved.mediaType,
                 s3Key: saved.s3Key,
-                storageId: saved.storageId,
               });
 
               // Stream file metadata immediately so the client can show the file card
@@ -105,7 +104,6 @@ Usage:
                         name: saved.name,
                         mediaType: saved.mediaType,
                         s3Key: saved.s3Key,
-                        storageId: saved.storageId,
                       },
                     ],
                   },

--- a/lib/ai/tools/utils/file-accumulator.ts
+++ b/lib/ai/tools/utils/file-accumulator.ts
@@ -5,7 +5,6 @@ export interface AccumulatedFileMetadata {
   name: string;
   mediaType: string;
   s3Key?: string;
-  storageId?: Id<"_storage">;
 }
 
 export class FileAccumulator {

--- a/lib/ai/tools/utils/sandbox-file-uploader.ts
+++ b/lib/ai/tools/utils/sandbox-file-uploader.ts
@@ -27,7 +27,6 @@ export type UploadedFileInfo = {
   name: string;
   mediaType: string;
   s3Key?: string;
-  storageId?: Id<"_storage">;
 };
 
 /**

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -446,7 +446,6 @@ export const createChatHandler = () => {
                 name: string;
                 mediaType: string;
                 s3Key?: string;
-                storageId?: Id<"_storage">;
               }>,
             ) => {
               if (!fileMetadata || fileMetadata.length === 0) return;

--- a/lib/utils/sidebar-utils.ts
+++ b/lib/utils/sidebar-utils.ts
@@ -622,7 +622,6 @@ export function extractSidebarContentFromMessage(
         mediaType: f.mediaType,
         fileId: f.fileId,
         s3Key: f.s3Key,
-        storageId: f.storageId,
       }));
 
       contentList.push({

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -933,7 +933,6 @@ export const agentLongTask = task({
                 name: string;
                 mediaType: string;
                 s3Key?: string;
-                storageId?: Id<"_storage">;
               }>,
             ) => {
               if (!fileMetadata || fileMetadata.length === 0) return;

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -230,7 +230,6 @@ export interface SidebarSharedFiles {
     mediaType?: string;
     fileId?: string;
     s3Key?: string;
-    storageId?: string;
   }>;
   requestedPaths: string[];
   isExecuting: boolean;

--- a/types/file.ts
+++ b/types/file.ts
@@ -47,7 +47,6 @@ export interface FilePart {
   mediaType?: string;
   storage?: "s3" | "local-desktop";
   localAttachmentId?: string;
-  storageId?: string; // Storage ID for on-demand URL fetching (Convex files)
   s3Key?: string; // S3 key for on-demand URL fetching (S3 files)
 }
 
@@ -105,7 +104,6 @@ export interface FileDetails {
   name: string;
   mediaType?: string;
   url?: string | null;
-  storageId?: string;
   s3Key?: string;
 }
 


### PR DESCRIPTION
## Summary

Removes the legacy Convex file storage compatibility path now that the old blobs have been purged.

- Drops the `files.storage_id` schema field and `by_storage_id` index.
- Removes the legacy Convex storage URL query and purge mutation.
- Makes file URL generation, deletion, upload metadata, streamed file metadata, and UI rendering S3-only.
- Removes frontend `storageId` fallbacks and cleans up tests for the old dual-storage model.

## Impact

Old file rows without `s3_key` are treated as unavailable metadata instead of attempting to fetch a long-lived Convex storage URL. New uploads and generated files continue to use S3 presigned URLs.

## Validation

- `rg -n "storage_id|storageId|getFileDownloadUrl|ctx\.storage|generateUploadUrl|purgeLegacyConvexStorageFiles|by_storage_id" . -S --glob '!node_modules/**' --glob '!**/.next/**' --glob '!**/.git/**' --glob '!pnpm-lock.yaml'`
- `pnpm test -- convex/__tests__/fileStorage.delete.test.ts convex/__tests__/fileStorage.aggregate.test.ts convex/__tests__/s3Actions.test.ts convex/__tests__/userDeletion.test.ts convex/__tests__/fileActions.upload-policy.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- Pre-commit hook: Prettier, ESLint fix, `tsc --noEmit`, full `jest` suite (`132 passed`, `1475 tests passed`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated file storage architecture to improve reliability and consistency. Enhanced file URL generation and download mechanisms for more stable and performant file operations across preview, download, and sharing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->