### PR TITLE
[codex] fix image attachment loading flicker

### DIFF
--- a/app/components/FilePartRenderer.tsx
+++ b/app/components/FilePartRenderer.tsx
@@ -12,7 +12,7 @@ import { useConvex, useAction } from "convex/react";
 import { ConvexError } from "convex/values";
 import { api } from "@/convex/_generated/api";
 import { ImageViewer } from "./ImageViewer";
-import { AlertCircle, File, Download } from "lucide-react";
+import { AlertCircle, File, Download, Loader2 } from "lucide-react";
 import { FilePart, FilePartRendererProps } from "@/types/file";
 import { toast } from "sonner";
 import { useFileUrlCacheContext } from "../contexts/FileUrlCacheContext";
@@ -89,6 +89,7 @@ const FilePartRendererComponent = ({
         if (cache) {
           const cachedUrl = cache.getCachedUrl(part.fileId);
           if (cachedUrl) {
+            setUrlError(null);
             setFileUrl(cachedUrl);
             return;
           }
@@ -122,6 +123,7 @@ const FilePartRendererComponent = ({
 
       // Fallback: if no fileId but we have part.url (Convex storage), use it
       if (part.url) {
+        setUrlError(null);
         setFileUrl(part.url);
         return;
       }
@@ -134,6 +136,7 @@ const FilePartRendererComponent = ({
             storageId: part.storageId,
           });
           if (url) {
+            setUrlError(null);
             setFileUrl(url);
           } else {
             setUrlError("Failed to get download URL");
@@ -392,9 +395,28 @@ const FilePartRendererComponent = ({
         );
       }
 
-      // Handle image files - they should always have URL
+      // Handle image files - resolve fetchable URLs before showing a real error
       if (part.mediaType?.startsWith("image/")) {
         if (!actualUrl) {
+          if (part.fileId || part.storageId) {
+            const isMultipleImages = totalFileParts > 1;
+            const loadingClass = isMultipleImages
+              ? "h-32 w-32"
+              : "h-36 w-36 max-w-64";
+
+            return (
+              <div key={partId} className="overflow-hidden rounded-lg">
+                <div
+                  className={`${loadingClass} bg-token-main-surface-secondary text-token-text-tertiary relative flex items-center justify-center overflow-hidden rounded-lg`}
+                  aria-label={`Loading ${part.name || part.filename || "image"}`}
+                  role="status"
+                >
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                </div>
+              </div>
+            );
+          }
+
           return (
             <FilePreviewCard
               partId={partId}

--- a/app/components/__tests__/FilePartRenderer.test.tsx
+++ b/app/components/__tests__/FilePartRenderer.test.tsx
@@ -1,0 +1,76 @@
+import "@testing-library/jest-dom";
+import { act, render, screen } from "@testing-library/react";
+import { useAction } from "convex/react";
+import type { ComponentProps } from "react";
+import { FileUrlCacheProvider } from "@/app/contexts/FileUrlCacheContext";
+import { FilePartRenderer } from "../FilePartRenderer";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ alt, src, ...props }: any) => {
+    const React = require("react");
+    return React.createElement("img", { alt, src, ...props });
+  },
+}));
+
+describe("FilePartRenderer", () => {
+  let mockGetFileUrlAction: jest.Mock;
+  let cache: Map<string, string>;
+
+  beforeEach(() => {
+    mockGetFileUrlAction = useAction({} as any) as unknown as jest.Mock;
+    mockGetFileUrlAction.mockReset();
+    cache = new Map();
+  });
+
+  function renderWithCache(
+    part: ComponentProps<typeof FilePartRenderer>["part"],
+  ) {
+    return render(
+      <FileUrlCacheProvider
+        getCachedUrl={(fileId) => cache.get(fileId) ?? null}
+        setCachedUrl={(fileId, url) => cache.set(fileId, url)}
+      >
+        <FilePartRenderer
+          part={part}
+          partIndex={0}
+          messageId="message-1"
+          totalFileParts={1}
+        />
+      </FileUrlCacheProvider>,
+    );
+  }
+
+  it("shows a loading image tile instead of a transient unavailable error while fetching a file URL", async () => {
+    let resolveUrl: (url: string) => void = () => {};
+    mockGetFileUrlAction.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveUrl = resolve;
+      }),
+    );
+
+    renderWithCache({
+      fileId: "file-1" as any,
+      name: "screenshot.png",
+      mediaType: "image/png",
+      s3Key: "uploads/screenshot.png",
+    });
+
+    expect(
+      screen.queryByText("Image URL not available"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: "Loading screenshot.png" }),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      resolveUrl("https://files.example/screenshot.png");
+    });
+
+    expect(await screen.findByAltText("screenshot.png")).toHaveAttribute(
+      "src",
+      "https://files.example/screenshot.png",
+    );
+    expect(cache.get("file-1")).toBe("https://files.example/screenshot.png");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the brief "Image URL not available" flash that appears after sending an image attachment, switching chats, or reloading before the presigned image URL has finished resolving.

## Root Cause

Image file parts with a `fileId` or `storageId` rendered the unavailable/error card on the initial paint whenever `actualUrl` was still empty, even though the component had enough information to fetch the URL asynchronously. The URL fetch then completed shortly after, causing a visible transient error.

## Changes

- Show a loading image tile while a fetchable image URL is pending.
- Clear stale URL error state when a cached, provided, or freshly fetched URL becomes available.
- Add a regression test that keeps the URL fetch pending and verifies the unavailable error does not render during that window.

## Validation

- `pnpm test -- app/components/__tests__/FilePartRenderer.test.tsx --runInBand`
- `pnpm exec eslint app/components/FilePartRenderer.tsx app/components/__tests__/FilePartRenderer.test.tsx`
- `pnpm typecheck`
- `pnpm exec prettier --check app/components/FilePartRenderer.tsx app/components/__tests__/FilePartRenderer.test.tsx`
- Commit hook also ran `tsc --noEmit` and the full Jest suite: 133 suites / 1,489 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a spinner placeholder while image URLs are being resolved.

* **Bug Fixes**
  * Prevented stale “Image URL not available” messaging from persisting after a valid image URL becomes available.

* **Tests**
  * Added coverage for image URL caching and loading behavior, including the intermediate loading state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->