### PR TITLE
[codex] Sanitize Convex message field names

### DIFF
--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -26,6 +26,7 @@ import {
   getMaxFilesLimitForMode,
 } from "@/lib/utils/file-utils";
 import { hasRestageableLocalDesktopAttachments } from "@/lib/utils/local-attachment-messages";
+import { sanitizeForConvexValue } from "@/lib/db/convex-value-sanitizer";
 
 interface UseChatHandlersProps {
   chatId: string;
@@ -113,6 +114,8 @@ export const useChatHandlers = ({
   const cancelTempStreamMutation = useMutation(
     api.tempStreams.cancelTempStreamFromClient,
   );
+  const getConvexSafeParts = (parts: ChatMessage["parts"]) =>
+    sanitizeForConvexValue(parts) as ChatMessage["parts"];
 
   // Mirrors the transport routing rule in app/components/chat.tsx. Persistent
   // chats only; temporary chats use the legacy Redis pub/sub cancel path.
@@ -196,7 +199,7 @@ export const useChatHandlers = ({
               id: lastMessage.id,
               chatId,
               role: lastMessage.role,
-              parts: lastMessage.parts,
+              parts: getConvexSafeParts(lastMessage.parts),
               mode: lastMessage.metadata?.mode ?? chatModeRef.current,
               generationStartedAt,
               generationTimeMs,
@@ -295,7 +298,7 @@ export const useChatHandlers = ({
                 id: lastMessage.id,
                 chatId,
                 role: lastMessage.role,
-                parts: lastMessage.parts,
+                parts: getConvexSafeParts(lastMessage.parts),
               }).catch((error) => {
                 console.error("Failed to save message on stop:", error);
               });

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -78,6 +78,45 @@ describe("saveMessage", () => {
     expect(() => JSON.stringify(compactedMessage.parts)).not.toThrow();
   });
 
+  it("sanitizes usage metadata before saving", async () => {
+    const { saveMessage, mockMutation } = await loadSaveMessageWithMocks();
+    const invalidUsageKey = "$provider\nraw";
+
+    await expect(
+      saveMessage({
+        chatId: "chat-1",
+        userId: "user-1",
+        message: {
+          id: "message-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "done" }],
+        },
+        usage: {
+          inputTokens: 12,
+          [invalidUsageKey]: { ok: true },
+        },
+      }),
+    ).resolves.toBeDefined();
+
+    const mutationArgs = mockMutation.mock.calls[0]?.[1] as {
+      usage?: Record<string, unknown>;
+    };
+    expect(mutationArgs.usage?.inputTokens).toBe(12);
+    expect(mutationArgs.usage?.[invalidUsageKey]).toBeUndefined();
+
+    const renamedFields = mutationArgs.usage?._convex_renamed_fields as Array<{
+      storedKey: string;
+      originalKey: string;
+    }>;
+    const renamedUsageField = renamedFields.find(
+      (field) => field.originalKey === invalidUsageKey,
+    );
+    expect(renamedUsageField?.storedKey).toMatch(/^field_provider_raw_/);
+    expect(mutationArgs.usage?.[renamedUsageField!.storedKey]).toEqual({
+      ok: true,
+    });
+  });
+
   it("maps Convex message-size rejections to a user-facing bad request", async () => {
     const { saveMessage, mockMutation } = await loadSaveMessageWithMocks();
     const convexError = new Error("[Request ID: abc] Server Error") as Error & {

--- a/lib/db/__tests__/convex-value-sanitizer.test.ts
+++ b/lib/db/__tests__/convex-value-sanitizer.test.ts
@@ -195,4 +195,33 @@ describe("sanitizeForConvexValue", () => {
     expect(longRename?.originalKey.endsWith("...")).toBe(true);
     expect(input[longRename!.storedKey]).toBe("kept");
   });
+
+  it("keeps sanitizer metadata on a stable key", () => {
+    const result = sanitizeForConvexValue({
+      _convex_renamed_fields: "user payload",
+      $reserved: true,
+    }) as Record<string, unknown>;
+
+    expectConvexCompatibleFieldNames(result);
+
+    const renamedFields = result._convex_renamed_fields as Array<{
+      storedKey: string;
+      originalKey: string;
+    }>;
+    expect(renamedFields).toHaveLength(2);
+
+    const reservedRename = renamedFields.find(
+      (field) => field.originalKey === "$reserved",
+    );
+    expect(result[reservedRename!.storedKey]).toBe(true);
+
+    const userMetadataRename = renamedFields.find(
+      (field) => field.originalKey === "_convex_renamed_fields",
+    );
+    expect(userMetadataRename?.storedKey).toMatch(
+      /^field_convex_renamed_fields_/,
+    );
+    expect(result[userMetadataRename!.storedKey]).toBe("user payload");
+    expect(result._convex_renamed_fields_1).toBeUndefined();
+  });
 });

--- a/lib/db/__tests__/convex-value-sanitizer.test.ts
+++ b/lib/db/__tests__/convex-value-sanitizer.test.ts
@@ -1,6 +1,28 @@
 import { describe, expect, it } from "@jest/globals";
 import { sanitizeForConvexValue } from "../convex-value-sanitizer";
 
+const expectConvexCompatibleFieldNames = (value: unknown) => {
+  if (!value || typeof value !== "object" || value instanceof ArrayBuffer) {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach(expectConvexCompatibleFieldNames);
+    return;
+  }
+
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    expect(key.length).toBeLessThanOrEqual(1024);
+    expect(key.startsWith("$")).toBe(false);
+    for (let i = 0; i < key.length; i++) {
+      const charCode = key.charCodeAt(i);
+      expect(charCode).toBeGreaterThanOrEqual(32);
+      expect(charCode).toBeLessThan(127);
+    }
+    expectConvexCompatibleFieldNames(child);
+  }
+};
+
 describe("sanitizeForConvexValue", () => {
   it("converts Error instances in tool outputs into plain objects", () => {
     const error = new Error(
@@ -117,5 +139,60 @@ describe("sanitizeForConvexValue", () => {
     expect(result.dataView).toBeInstanceOf(ArrayBuffer);
     expect(result.dataView).not.toBe(backingBuffer);
     expect([...new Uint8Array(result.dataView)]).toEqual([3, 4]);
+  });
+
+  it("renames object fields Convex cannot persist", () => {
+    const commandKey = `command'"cat > /tmp/patch3.py << 'PY'\nprint("hi")`;
+    const longNonAsciiKey = `action_check_${"quietly_".repeat(140)}针头`;
+
+    const result = sanitizeForConvexValue({
+      parts: [
+        {
+          type: "tool-run_terminal_cmd",
+          input: {
+            [commandKey]: "echo hi",
+            $reserved: true,
+            [longNonAsciiKey]: "kept",
+            command: "still exact",
+          },
+        },
+      ],
+    }) as {
+      parts: Array<{
+        input: Record<
+          string,
+          string | boolean | Array<{ storedKey: string; originalKey: string }>
+        >;
+      }>;
+    };
+
+    expectConvexCompatibleFieldNames(result);
+
+    const input = result.parts[0].input;
+    expect(input.command).toBe("still exact");
+
+    const renamedFields = input._convex_renamed_fields as Array<{
+      storedKey: string;
+      originalKey: string;
+    }>;
+    expect(renamedFields).toHaveLength(3);
+
+    const commandRename = renamedFields.find(
+      (field) => field.originalKey === commandKey,
+    );
+    expect(commandRename?.storedKey).toMatch(/^field_command_/);
+    expect(input[commandRename!.storedKey]).toBe("echo hi");
+
+    const reservedRename = renamedFields.find(
+      (field) => field.originalKey === "$reserved",
+    );
+    expect(input[reservedRename!.storedKey]).toBe(true);
+
+    const longRename = renamedFields.find((field) =>
+      field.originalKey.startsWith("action_check_"),
+    );
+    expect(longRename?.storedKey.length).toBeLessThanOrEqual(200);
+    expect(longRename?.originalKey.endsWith("...")).toBe(true);
+    expect(input[longRename!.storedKey]).toBe("kept");
   });
 });

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -454,6 +454,9 @@ export async function saveMessage({
       ...fileIds,
       ...((extraFileIds || []).filter(Boolean) as string[]),
     ];
+    const usageForSave = sanitizeForConvexValue(usage) as
+      | Record<string, unknown>
+      | undefined;
 
     return await getConvexClient().mutation(api.messages.saveMessage, {
       serviceKey,
@@ -468,7 +471,7 @@ export async function saveMessage({
       generationStartedAt,
       generationTimeMs,
       finishReason,
-      usage,
+      usage: usageForSave,
       updateOnly,
       isHidden,
     });

--- a/lib/db/convex-value-sanitizer.ts
+++ b/lib/db/convex-value-sanitizer.ts
@@ -210,14 +210,23 @@ export function sanitizeForConvexValue(
   const usedKeys = new Set(
     entries
       .map(([key]) => (isValidConvexObjectFieldName(key) ? key : undefined))
+      .filter((key) => key !== RENAMED_FIELDS_METADATA_KEY)
       .filter((key): key is string => key !== undefined),
   );
   const renamedFields: Array<{ storedKey: string; originalKey: string }> = [];
+  let userMetadataValue: unknown;
+  let hasUserMetadataValue = false;
 
   for (const [key, childValue] of entries) {
     const sanitizedChild = sanitizeForConvexValue(childValue, seen);
     if (sanitizedChild !== undefined) {
       if (isValidConvexObjectFieldName(key)) {
+        if (key === RENAMED_FIELDS_METADATA_KEY) {
+          userMetadataValue = sanitizedChild;
+          hasUserMetadataValue = true;
+          continue;
+        }
+
         sanitized[key] = sanitizedChild;
         continue;
       }
@@ -233,11 +242,22 @@ export function sanitizeForConvexValue(
   }
 
   if (renamedFields.length > 0) {
-    const metadataKey = getUniqueFieldName(
-      RENAMED_FIELDS_METADATA_KEY,
-      usedKeys,
-    );
-    sanitized[metadataKey] = renamedFields;
+    if (hasUserMetadataValue) {
+      const sanitizedKey = sanitizeInvalidFieldName(
+        RENAMED_FIELDS_METADATA_KEY,
+        usedKeys,
+      );
+      usedKeys.add(sanitizedKey);
+      sanitized[sanitizedKey] = userMetadataValue;
+      renamedFields.push({
+        storedKey: sanitizedKey,
+        originalKey: RENAMED_FIELDS_METADATA_KEY,
+      });
+    }
+
+    sanitized[RENAMED_FIELDS_METADATA_KEY] = renamedFields;
+  } else if (hasUserMetadataValue) {
+    sanitized[RENAMED_FIELDS_METADATA_KEY] = userMetadataValue;
   }
 
   if (!isPlainObject(value) && Object.keys(sanitized).length === 0) {

--- a/lib/db/convex-value-sanitizer.ts
+++ b/lib/db/convex-value-sanitizer.ts
@@ -14,6 +14,65 @@ const primitiveErrorFieldNames = [
 
 const MIN_CONVEX_BIGINT = -BigInt("9223372036854775808");
 const MAX_CONVEX_BIGINT = BigInt("9223372036854775807");
+const MAX_CONVEX_FIELD_NAME_LENGTH = 1024;
+const MAX_SANITIZED_FIELD_NAME_LENGTH = 200;
+const MAX_ORIGINAL_FIELD_NAME_PREVIEW_LENGTH = 512;
+const RENAMED_FIELDS_METADATA_KEY = "_convex_renamed_fields";
+
+const isValidConvexObjectFieldName = (key: string): boolean => {
+  if (key.length > MAX_CONVEX_FIELD_NAME_LENGTH) return false;
+  if (key.startsWith("$")) return false;
+
+  for (let i = 0; i < key.length; i++) {
+    const charCode = key.charCodeAt(i);
+    if (charCode < 32 || charCode >= 127) return false;
+  }
+
+  return true;
+};
+
+const hashString = (value: string): string => {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+};
+
+const previewFieldName = (key: string): string =>
+  key.length > MAX_ORIGINAL_FIELD_NAME_PREVIEW_LENGTH
+    ? `${key.slice(0, MAX_ORIGINAL_FIELD_NAME_PREVIEW_LENGTH)}...`
+    : key;
+
+const getUniqueFieldName = (candidate: string, usedKeys: Set<string>) => {
+  if (!usedKeys.has(candidate)) return candidate;
+
+  let suffix = 1;
+  while (true) {
+    const suffixText = `_${suffix}`;
+    const maxBaseLength = MAX_SANITIZED_FIELD_NAME_LENGTH - suffixText.length;
+    const base = candidate.slice(0, Math.max(1, maxBaseLength));
+    const nextCandidate = `${base}${suffixText}`;
+    if (!usedKeys.has(nextCandidate)) return nextCandidate;
+    suffix++;
+  }
+};
+
+const sanitizeInvalidFieldName = (
+  key: string,
+  usedKeys: Set<string>,
+): string => {
+  const hash = hashString(key);
+  const suffix = `_${hash}`;
+  const prefix = "field_";
+  const normalized = key.replace(/[^A-Za-z0-9_]/g, "_").replace(/^_+/, "");
+  const maxBodyLength =
+    MAX_SANITIZED_FIELD_NAME_LENGTH - prefix.length - suffix.length;
+  const body = (normalized || "value").slice(0, Math.max(1, maxBodyLength));
+
+  return getUniqueFieldName(`${prefix}${body}${suffix}`, usedKeys);
+};
 
 const arrayBufferViewToArrayBuffer = (view: ArrayBufferView): ArrayBuffer => {
   if (view.buffer instanceof ArrayBuffer) {
@@ -147,13 +206,38 @@ export function sanitizeForConvexValue(
   }
 
   const sanitized: Record<string, unknown> = {};
-  for (const [key, childValue] of Object.entries(
-    value as Record<string, unknown>,
-  )) {
+  const entries = Object.entries(value as Record<string, unknown>);
+  const usedKeys = new Set(
+    entries
+      .map(([key]) => (isValidConvexObjectFieldName(key) ? key : undefined))
+      .filter((key): key is string => key !== undefined),
+  );
+  const renamedFields: Array<{ storedKey: string; originalKey: string }> = [];
+
+  for (const [key, childValue] of entries) {
     const sanitizedChild = sanitizeForConvexValue(childValue, seen);
     if (sanitizedChild !== undefined) {
-      sanitized[key] = sanitizedChild;
+      if (isValidConvexObjectFieldName(key)) {
+        sanitized[key] = sanitizedChild;
+        continue;
+      }
+
+      const sanitizedKey = sanitizeInvalidFieldName(key, usedKeys);
+      usedKeys.add(sanitizedKey);
+      sanitized[sanitizedKey] = sanitizedChild;
+      renamedFields.push({
+        storedKey: sanitizedKey,
+        originalKey: previewFieldName(key),
+      });
     }
+  }
+
+  if (renamedFields.length > 0) {
+    const metadataKey = getUniqueFieldName(
+      RENAMED_FIELDS_METADATA_KEY,
+      usedKeys,
+    );
+    sanitized[metadataKey] = renamedFields;
   }
 
   if (!isPlainObject(value) && Object.keys(sanitized).length === 0) {


### PR DESCRIPTION
## What changed

- Renames object keys that Convex cannot persist before saving chat message parts or usage metadata.
- Preserves normal message/tool fields unchanged and records renamed fields in `_convex_renamed_fields` for debugging.
- Applies the same sanitizer to client-side stop/save paths before calling `saveAssistantMessage`.
- Adds regressions for newline, `$`-prefixed, non-ASCII, and overlong field names.

## Why

`messages.saveMessage` can receive arbitrary SDK/tool payloads. Convex validates nested object field names even under `v.any()`, so malformed tool inputs with control characters, non-ASCII text, `$` prefixes, or very long generated names could make the database reject the whole assistant message.

## Validation

- `pnpm jest lib/db/__tests__/convex-value-sanitizer.test.ts lib/db/__tests__/actions-save-message.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- Commit hook: `pnpm typecheck` and full `pnpm test` passed: 132 suites, 1477 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Convex-compatible sanitization for chat message content and usage/metadata, including safe handling of problematic field names, reserved metadata, and rename tracking to prevent persistence failures.

* **Tests**
  * Added Jest coverage for Convex value sanitization and message persistence, verifying field-name constraints, deterministic renaming behavior, and correct sanitizer metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->