### PR TITLE
[codex] Warn for Pro model in Ask mode

### DIFF
--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -69,10 +69,9 @@ const AUTO_MODEL_DESCRIPTION =
 const shouldWarnForPaidHighCostModel = (
   subscription: SubscriptionTier,
   model: SelectedModel,
-  mode: ChatMode,
 ): boolean =>
   subscription !== "free" &&
-  (model === "hackerai-max" || (model === "hackerai-pro" && isAgentMode(mode)));
+  (model === "hackerai-max" || model === "hackerai-pro");
 
 const AutoOptionButton = ({
   isSelected,
@@ -376,7 +375,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
     }
 
     if (
-      shouldWarnForPaidHighCostModel(subscription, option.id, mode) &&
+      shouldWarnForPaidHighCostModel(subscription, option.id) &&
       !isHighCostModelUsageNoticeDismissed()
     ) {
       setOpen(false);

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -69,15 +69,24 @@ describe("ModelSelector", () => {
     expect(onChange).toHaveBeenCalledWith("auto");
   });
 
-  it("selects HackerAI Pro in ask mode without the high-cost warning", () => {
+  it("warns before selecting HackerAI Pro in ask mode on paid plans", () => {
     const onChange = jest.fn();
     render(<ModelSelector value="auto" onChange={onChange} mode="ask" />);
 
     fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
     fireEvent.click(screen.getByRole("button", { name: /HackerAI Pro/i }));
 
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId("high-cost-model-warning")).toBeVisible();
+    expect(screen.getByText("High-cost model")).toBeVisible();
+    expect(
+      screen.getByText(/long requests can use around \$10 of usage/i),
+    ).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: /Use HackerAI Pro/i }));
+
+    expect(mockDismissHighCostModelUsageNotice).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith("hackerai-pro");
-    expect(screen.queryByTestId("high-cost-model-warning")).toBeNull();
   });
 
   it("warns before selecting HackerAI Pro in agent mode on paid plans", () => {


### PR DESCRIPTION
## Summary

- Shows the high-cost model warning when paid users select HackerAI Pro in Ask mode.
- Keeps the existing Pro warning behavior for Agent mode and Max warning behavior unchanged.
- Updates the ModelSelector tests to require confirmation before applying HackerAI Pro in Ask mode.

## Why

HackerAI Pro previously only required confirmation in Agent mode. This makes the warning behavior consistent across Ask and Agent so users see the usage notice before selecting Pro in either surface.

## Validation

- `pnpm test -- app/components/ModelSelector/__tests__/ModelSelector.test.tsx --runInBand`
- Pre-commit hook: `pnpm typecheck`
- Pre-commit hook: `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * High-cost model warning now consistently appears when selecting HackerAI Pro or HackerAI Max on paid plans across all chat modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->