### PR TITLE
[codex] Optimize Convex shared reads

### DIFF
--- a/app/share/[shareId]/SharedChatView.tsx
+++ b/app/share/[shareId]/SharedChatView.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useQuery, useMutation } from "convex/react";
+import { useConvex, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
-import { SharedMessages } from "./SharedMessages";
+import { SharedMessages, type SharedMessage } from "./SharedMessages";
 import { Loader2, AlertCircle } from "lucide-react";
 import { SharedChatProvider, useSharedChatContext } from "./SharedChatContext";
 import { ComputerSidebarBase } from "@/app/components/ComputerSidebar";
@@ -13,13 +13,17 @@ import ChatHeader from "@/app/components/ChatHeader";
 import MainSidebar from "@/app/components/Sidebar";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { useGlobalState } from "@/app/contexts/GlobalState";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ChatInput } from "@/app/components/ChatInput";
 import { upsertDraft } from "@/lib/utils/client-storage";
 
 // Desktop wrapper component that connects ComputerSidebarBase to SharedChatContext
-function SharedComputerSidebarDesktop({ messages }: { messages: any[] }) {
+function SharedComputerSidebarDesktop({
+  messages,
+}: {
+  messages: SharedMessage[];
+}) {
   const { sidebarOpen, sidebarContent, closeSidebar, openSidebar } =
     useSharedChatContext();
 
@@ -43,7 +47,11 @@ function SharedComputerSidebarDesktop({ messages }: { messages: any[] }) {
 }
 
 // Mobile wrapper component for full-screen sidebar overlay
-function SharedComputerSidebarMobile({ messages }: { messages: any[] }) {
+function SharedComputerSidebarMobile({
+  messages,
+}: {
+  messages: SharedMessage[];
+}) {
   const { sidebarOpen, sidebarContent, closeSidebar, openSidebar } =
     useSharedChatContext();
 
@@ -72,25 +80,87 @@ interface SharedChatViewProps {
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+type SharedChat = {
+  id: string;
+  title: string;
+  share_id: string;
+  share_date: number;
+  update_time: number;
+};
+
+type SharedSnapshot = {
+  shareId: string;
+  chat: SharedChat | null | undefined;
+  messages: SharedMessage[] | undefined;
+};
+
 export function SharedChatView({ shareId }: SharedChatViewProps) {
   const isMobile = useIsMobile();
   const { user, loading: authLoading } = useAuth();
   const { chatSidebarOpen, setChatSidebarOpen, input } = useGlobalState();
   const router = useRouter();
+  const convex = useConvex();
   const forkSharedChatMutation = useMutation(api.sharedChats.forkSharedChat);
   const [isForking, setIsForking] = useState(false);
+  const [snapshot, setSnapshot] = useState<SharedSnapshot>(() => ({
+    shareId,
+    chat: undefined,
+    messages: undefined,
+  }));
+  const loadGenerationRef = useRef(0);
 
   // Validate shareId format before making database query
   const isValidUUID = UUID_REGEX.test(shareId);
 
-  const chat = useQuery(
-    api.sharedChats.getSharedChat,
-    isValidUUID ? { shareId } : "skip",
-  );
-  const messages = useQuery(
-    api.messages.getSharedMessages,
-    chat ? { chatId: chat.id } : "skip",
-  );
+  useEffect(() => {
+    const generation = loadGenerationRef.current + 1;
+    loadGenerationRef.current = generation;
+
+    if (!isValidUUID) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadSharedSnapshot = async () => {
+      try {
+        const nextChat = await convex.query(api.sharedChats.getSharedChat, {
+          shareId,
+        });
+        if (cancelled || loadGenerationRef.current !== generation) return;
+
+        if (!nextChat) {
+          setSnapshot({ shareId, chat: null, messages: [] });
+          return;
+        }
+
+        setSnapshot({ shareId, chat: nextChat, messages: undefined });
+
+        const nextMessages = await convex.query(
+          api.messages.getSharedMessages,
+          {
+            chatId: nextChat.id,
+          },
+        );
+        if (cancelled || loadGenerationRef.current !== generation) return;
+        setSnapshot({ shareId, chat: nextChat, messages: nextMessages });
+      } catch (error) {
+        console.error("Failed to load shared chat:", error);
+        if (cancelled || loadGenerationRef.current !== generation) return;
+        setSnapshot({ shareId, chat: null, messages: [] });
+      }
+    };
+
+    void loadSharedSnapshot();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [convex, isValidUUID, shareId]);
+
+  const isSnapshotCurrent = snapshot.shareId === shareId;
+  const chat = isSnapshotCurrent ? snapshot.chat : undefined;
+  const messages = isSnapshotCurrent ? snapshot.messages : undefined;
 
   // Update page title when chat loads
   useEffect(() => {

--- a/app/share/[shareId]/SharedMessages.tsx
+++ b/app/share/[shareId]/SharedMessages.tsx
@@ -3,7 +3,7 @@
 import { ImageIcon, FileIcon } from "lucide-react";
 import { SharedMessagePartHandler } from "./components/SharedMessagePartHandler";
 
-interface MessagePart {
+export interface SharedMessagePart {
   type: string;
   text?: string;
   placeholder?: boolean;
@@ -14,16 +14,16 @@ interface MessagePart {
   errorText?: string;
 }
 
-interface Message {
+export interface SharedMessage {
   id: string;
   role: "user" | "assistant" | "system";
-  parts: MessagePart[];
+  parts: SharedMessagePart[];
   content?: string;
   update_time: number;
 }
 
 interface SharedMessagesProps {
-  messages: Message[];
+  messages: SharedMessage[];
   shareDate: number;
 }
 

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1975,19 +1975,18 @@ export const getSharedMessages = query({
         return [];
       }
 
-      // Get all messages for this chat
+      // Get only messages frozen into the share. This keeps public share reads
+      // proportional to the shared snapshot instead of the full live chat.
       const messages = await ctx.db
         .query("messages")
-        .withIndex("by_chat_id", (q) => q.eq("chat_id", args.chatId))
+        .withIndex("by_chat_id_and_update_time", (q) =>
+          q.eq("chat_id", args.chatId).lte("update_time", chat.share_date!),
+        )
         .order("asc")
         .collect();
 
-      // FROZEN CONTENT: Filter messages to only those created/updated before share_date
-      // This ensures new messages added after sharing are not visible
-      // Also exclude hidden messages (e.g. auto-continue rows)
-      const frozenMessages = messages.filter(
-        (msg) => msg.update_time <= chat.share_date! && msg.is_hidden !== true,
-      );
+      // FROZEN CONTENT: Exclude hidden messages (e.g. auto-continue rows).
+      const frozenMessages = messages.filter((msg) => msg.is_hidden !== true);
 
       // Strip sensitive data and replace files with placeholders
       return frozenMessages.map((msg) => ({

--- a/convex/referrals.ts
+++ b/convex/referrals.ts
@@ -432,20 +432,18 @@ export const getUnreadRewardNotifications = query({
 
     const rewards = await ctx.db
       .query("referral_rewards")
-      .withIndex("by_referrer_user_id", (q) =>
-        q.eq("referrer_user_id", identity.subject),
+      .withIndex("by_referrer_notification", (q) =>
+        q
+          .eq("referrer_user_id", identity.subject)
+          .eq("reward_type", "referrer_conversion")
+          .eq("status", "awarded")
+          .eq("notification_seen_at", undefined),
       )
       .order("desc")
       .take(20);
 
     return rewards
-      .filter(
-        (reward) =>
-          reward.reward_type === "referrer_conversion" &&
-          reward.status === "awarded" &&
-          reward.amount_dollars > 0 &&
-          reward.notification_seen_at === undefined,
-      )
+      .filter((reward) => reward.amount_dollars > 0)
       .map((reward) => ({
         rewardId: reward._id,
         amountDollars: reward.amount_dollars,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -45,6 +45,7 @@ export default defineSchema({
     .index("by_chat_id", ["id"])
     .index("by_user_and_updated", ["user_id", "update_time"])
     .index("by_user_and_pinned", ["user_id", "pinned_at"])
+    .index("by_user_and_share_date", ["user_id", "share_date"])
     .index("by_share_id", ["share_id"])
     .searchIndex("search_title", {
       searchField: "title",
@@ -104,6 +105,7 @@ export default defineSchema({
   })
     .index("by_message_id", ["id"])
     .index("by_chat_id", ["chat_id"])
+    .index("by_chat_id_and_update_time", ["chat_id", "update_time"])
     .index("by_feedback_id", ["feedback_id"])
     .index("by_user_id", ["user_id"])
     .searchIndex("search_content", {
@@ -384,6 +386,13 @@ export default defineSchema({
   })
     .index("by_idempotency_key", ["idempotency_key"])
     .index("by_referrer_user_id", ["referrer_user_id"])
+    .index("by_referrer_notification", [
+      "referrer_user_id",
+      "reward_type",
+      "status",
+      "notification_seen_at",
+      "created_at",
+    ])
     .index("by_referred_user_id", ["referred_user_id"]),
 
   user_suspensions: defineTable({

--- a/convex/sharedChats.ts
+++ b/convex/sharedChats.ts
@@ -262,12 +262,14 @@ export const getUserSharedChats = query({
 
     const chats = await ctx.db
       .query("chats")
-      .withIndex("by_user_and_updated", (q) =>
-        q.eq("user_id", identity.subject),
+      .withIndex("by_user_and_share_date", (q) =>
+        q.eq("user_id", identity.subject).gt("share_date", 0),
       )
+      .order("desc")
       .collect();
 
-    // Filter and map to only shared chats
+    // Map only chats with complete share metadata. The index already excludes
+    // ordinary unshared chats, so this defensive check is cheap.
     return chats
       .filter((chat) => chat.share_id && chat.share_date)
       .map((chat) => ({
@@ -277,8 +279,7 @@ export const getUserSharedChats = query({
         share_id: chat.share_id!,
         share_date: chat.share_date!,
         update_time: chat.update_time,
-      }))
-      .sort((a, b) => b.share_date - a.share_date); // Most recent first
+      }));
   },
 });
 
@@ -316,16 +317,16 @@ export const forkSharedChat = mutation({
       throw new Error("Shared chat not found");
     }
 
-    // Get all messages up to share_date (frozen content)
+    // Get only messages up to share_date (frozen content)
     const messages = await ctx.db
       .query("messages")
-      .withIndex("by_chat_id", (q) => q.eq("chat_id", chat.id))
+      .withIndex("by_chat_id_and_update_time", (q) =>
+        q.eq("chat_id", chat.id).lte("update_time", chat.share_date!),
+      )
       .order("asc")
       .collect();
 
-    const frozenMessages = messages.filter(
-      (msg) => msg.update_time <= chat.share_date! && msg.is_hidden !== true,
-    );
+    const frozenMessages = messages.filter((msg) => msg.is_hidden !== true);
 
     // Create new chat owned by the current user
     const newChatId = crypto.randomUUID();
@@ -385,8 +386,8 @@ export const unshareAllChats = mutation({
 
     const sharedChats = await ctx.db
       .query("chats")
-      .withIndex("by_user_and_updated", (q) =>
-        q.eq("user_id", identity.subject),
+      .withIndex("by_user_and_share_date", (q) =>
+        q.eq("user_id", identity.subject).gt("share_date", 0),
       )
       .collect();
 

--- a/convex/usageLogs.ts
+++ b/convex/usageLogs.ts
@@ -125,14 +125,6 @@ export const getDailyUsageSummary = query({
     }
     const userId = identity.subject;
     const days = Math.min(Math.max(Math.round(args.days ?? 7), 1), 30);
-    const startDate = Date.now() - days * 24 * 60 * 60 * 1000;
-
-    const logs = await ctx.db
-      .query("usage_logs")
-      .withIndex("by_user", (q) =>
-        q.eq("user_id", userId).gte("_creationTime", startDate),
-      )
-      .collect();
 
     // Aggregate by day (UTC), zero-filling missing days
     const dailyMap = new Map<string, number>();
@@ -142,9 +134,23 @@ export const getDailyUsageSummary = query({
       d.setUTCDate(d.getUTCDate() - i);
       dailyMap.set(d.toISOString().slice(0, 10), 0);
     }
-    for (const log of logs) {
-      const day = new Date(log._creationTime).toISOString().slice(0, 10);
-      dailyMap.set(day, (dailyMap.get(day) ?? 0) + log.cost_dollars);
+
+    const dayKeys = Array.from(dailyMap.keys());
+    const rollups = await ctx.db
+      .query("unit_economics_daily")
+      .withIndex("by_user_day", (q) =>
+        q
+          .eq("user_id", userId)
+          .gte("day", dayKeys[0])
+          .lte("day", dayKeys[dayKeys.length - 1]),
+      )
+      .collect();
+
+    for (const row of rollups) {
+      dailyMap.set(
+        row.day,
+        row.included_usage_cost_dollars + row.extra_usage_cost_dollars,
+      );
     }
 
     return Array.from(dailyMap.entries())


### PR DESCRIPTION
## Summary

- Switch public shared chat pages from reactive `useQuery` subscriptions to one-shot `convex.query()` snapshot reads.
- Add compound indexes for shared chat lists, frozen shared-message reads, and unread referral notifications.
- Rewrite shared chat and referral queries to push filtering into Convex indexes.
- Read daily usage summaries from existing `unit_economics_daily` rollups instead of raw `usage_logs`.

## Why

This applies the main recommendations from Convex's OpenClaw optimization article: use one-shot reads for non-realtime public snapshots, avoid reading broad result sets only to filter in JavaScript, and prefer compact rollup/digest-style tables for hot dashboard reads.

## Validation

- `pnpm exec tsc --noEmit --pretty false`
- `pnpm test --runTestsByPath convex/__tests__/referralsNotifications.test.ts convex/__tests__/messages.hidden.test.ts convex/__tests__/unitEconomicsPaidStarts.test.ts --runInBand`
- `pnpm exec prettier --check 'app/share/[shareId]/SharedChatView.tsx' convex/schema.ts convex/sharedChats.ts convex/messages.ts convex/referrals.ts convex/usageLogs.ts`
- `pnpm lint` (passes with existing warnings)
- Pre-commit hook also ran `pnpm typecheck` and the full Jest suite: 133 suites / 1476 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared chat data loading with enhanced validation.

* **Performance**
  * Optimized database queries for shared chats, referral notifications, and usage summaries.
  * Added database indexes to improve query performance across multiple features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->