### PR TITLE
[codex] fix raw unit economics costs

### DIFF
--- a/convex/__tests__/unitEconomicsReportingWindow.test.ts
+++ b/convex/__tests__/unitEconomicsReportingWindow.test.ts
@@ -38,6 +38,7 @@ type UsageLogRow = {
   cost_dollars: number;
   model_cost_dollars?: number;
   non_model_cost_dollars?: number;
+  cost_source?: "provider" | "token_estimate" | "raw_token_estimate";
 };
 
 type RevenueRow = {
@@ -61,8 +62,12 @@ type UnitEconomicsDailyRow = {
   day: string;
   gross_revenue_dollars: number;
   net_revenue_dollars: number;
+  model_cost_dollars?: number;
+  non_model_cost_dollars?: number;
   total_cost_dollars: number;
   gross_profit_dollars: number;
+  included_usage_cost_dollars?: number;
+  extra_usage_cost_dollars?: number;
 };
 
 function makeMockCtx(opts?: {
@@ -260,6 +265,53 @@ describe("unit economics reporting window", () => {
       net_revenue_dollars: 20,
       total_cost_dollars: 2,
       gross_profit_dollars: 18,
+    });
+  });
+
+  it("normalizes legacy token-estimated usage costs during rebuilds", async () => {
+    const userId = "user_1";
+    const { ctx, rollups } = makeMockCtx({
+      usage: [
+        {
+          _id: "usage-legacy",
+          user_id: userId,
+          _creationTime: REPORTING_START + 60_000,
+          type: "included",
+          input_tokens: 1_000_000,
+          output_tokens: 0,
+          total_tokens: 1_000_000,
+          cost_dollars: 0.9,
+          model_cost_dollars: 0.65,
+          non_model_cost_dollars: 0.25,
+          cost_source: "token_estimate",
+        },
+      ],
+      revenue: [
+        {
+          _id: "revenue-new",
+          entity_type: "user",
+          entity_id: userId,
+          user_id: userId,
+          occurred_at: REPORTING_START + 60_000,
+          gross_revenue_dollars: 20,
+          net_revenue_dollars: 20,
+        },
+      ],
+    });
+
+    await callRebuild(ctx, {
+      entityType: "user",
+      entityId: userId,
+      startTime: 0,
+      endTime: REPORTING_START + 120_000,
+    });
+
+    expect(rollups[0]).toMatchObject({
+      model_cost_dollars: 0.5,
+      non_model_cost_dollars: 0.25,
+      total_cost_dollars: 0.75,
+      included_usage_cost_dollars: 0.75,
+      gross_profit_dollars: 19.25,
     });
   });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -518,7 +518,11 @@ export default defineSchema({
     model_cost_dollars: v.optional(v.number()),
     non_model_cost_dollars: v.optional(v.number()),
     cost_source: v.optional(
-      v.union(v.literal("provider"), v.literal("token_estimate")),
+      v.union(
+        v.literal("provider"),
+        v.literal("token_estimate"),
+        v.literal("raw_token_estimate"),
+      ),
     ),
     // Legacy MAX Mode flag retained on historical rows. The feature was
     // removed and nothing reads or writes this anymore — kept in the schema

--- a/convex/unitEconomics.ts
+++ b/convex/unitEconomics.ts
@@ -4,6 +4,7 @@ import { validateServiceKey } from "./lib/utils";
 import {
   applyPaidStartMixDelta,
   applyUnitEconomicsDelta,
+  LEGACY_USAGE_COST_MULTIPLIER,
   recordPaidStartEventInternal,
   recordRevenueEventInternal,
   utcDay,
@@ -412,8 +413,15 @@ export const rebuildEntityDailyRollups = mutation({
             .take(maxRows);
 
     for (const log of usageRows) {
-      const modelCostDollars = log.model_cost_dollars ?? log.cost_dollars;
       const nonModelCostDollars = log.non_model_cost_dollars ?? 0;
+      const reportedModelCostDollars =
+        log.model_cost_dollars ??
+        Math.max(0, log.cost_dollars - nonModelCostDollars);
+      const modelCostDollars =
+        log.cost_source === "token_estimate"
+          ? reportedModelCostDollars / LEGACY_USAGE_COST_MULTIPLIER
+          : reportedModelCostDollars;
+      const costDollars = modelCostDollars + nonModelCostDollars;
       await applyUnitEconomicsDelta(ctx, {
         entityType: args.entityType as UnitEconomicsEntityType,
         entityId: args.entityId,
@@ -425,9 +433,8 @@ export const rebuildEntityDailyRollups = mutation({
         day: utcDay(log._creationTime),
         modelCostDollars,
         nonModelCostDollars,
-        includedUsageCostDollars:
-          log.type === "included" ? log.cost_dollars : 0,
-        extraUsageCostDollars: log.type === "extra" ? log.cost_dollars : 0,
+        includedUsageCostDollars: log.type === "included" ? costDollars : 0,
+        extraUsageCostDollars: log.type === "extra" ? costDollars : 0,
         usageRequestCount: 1,
         inputTokens: log.input_tokens,
         outputTokens: log.output_tokens,

--- a/convex/unitEconomicsLib.ts
+++ b/convex/unitEconomicsLib.ts
@@ -23,6 +23,8 @@ export type PaidStartConversionType =
   | "free_to_paid"
   | "paid_subscription_start";
 
+export const LEGACY_USAGE_COST_MULTIPLIER = 1.3;
+
 export function utcDay(timestampMs: number): string {
   return new Date(timestampMs).toISOString().slice(0, 10);
 }

--- a/convex/usageLogs.ts
+++ b/convex/usageLogs.ts
@@ -2,7 +2,11 @@ import { mutation, query } from "./_generated/server";
 import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
-import { applyUnitEconomicsDelta, utcDay } from "./unitEconomicsLib";
+import {
+  applyUnitEconomicsDelta,
+  LEGACY_USAGE_COST_MULTIPLIER,
+  utcDay,
+} from "./unitEconomicsLib";
 
 const typeValidator = v.union(v.literal("included"), v.literal("extra"));
 
@@ -39,19 +43,35 @@ export const logUsage = mutation({
     model_cost_dollars: v.optional(v.number()),
     non_model_cost_dollars: v.optional(v.number()),
     cost_source: v.optional(
-      v.union(v.literal("provider"), v.literal("token_estimate")),
+      v.union(
+        v.literal("provider"),
+        v.literal("token_estimate"),
+        v.literal("raw_token_estimate"),
+      ),
     ),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
 
-    const modelCostDollars = Number.isFinite(args.model_cost_dollars)
-      ? args.model_cost_dollars!
-      : args.cost_dollars;
     const nonModelCostDollars = Number.isFinite(args.non_model_cost_dollars)
       ? args.non_model_cost_dollars!
       : 0;
+    const reportedModelCostDollars = Number.isFinite(args.model_cost_dollars)
+      ? args.model_cost_dollars!
+      : Math.max(0, args.cost_dollars - nonModelCostDollars);
+    // Older app builds sent token_estimate costs after applying the 1.3 usage
+    // multiplier. Normalize those at ingestion so unit economics tracks raw
+    // model cost even during staggered deploys.
+    const modelCostDollars =
+      args.cost_source === "token_estimate"
+        ? reportedModelCostDollars / LEGACY_USAGE_COST_MULTIPLIER
+        : reportedModelCostDollars;
+    const costDollars = modelCostDollars + nonModelCostDollars;
+    const costSource =
+      args.cost_source === "token_estimate"
+        ? "raw_token_estimate"
+        : args.cost_source;
     const now = Date.now();
 
     await ctx.db.insert("usage_logs", {
@@ -68,19 +88,18 @@ export const logUsage = mutation({
       cache_read_tokens: args.cache_read_tokens,
       cache_write_tokens: args.cache_write_tokens,
       total_tokens: args.total_tokens,
-      cost_dollars: args.cost_dollars,
+      cost_dollars: costDollars,
       model_cost_dollars: modelCostDollars,
       non_model_cost_dollars: nonModelCostDollars,
-      cost_source: args.cost_source,
+      cost_source: costSource,
     });
 
     const commonDelta = {
       day: utcDay(now),
       modelCostDollars,
       nonModelCostDollars,
-      includedUsageCostDollars:
-        args.type === "included" ? args.cost_dollars : 0,
-      extraUsageCostDollars: args.type === "extra" ? args.cost_dollars : 0,
+      includedUsageCostDollars: args.type === "included" ? costDollars : 0,
+      extraUsageCostDollars: args.type === "extra" ? costDollars : 0,
       usageRequestCount: 1,
       inputTokens: args.input_tokens,
       outputTokens: args.output_tokens,

--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -195,15 +195,15 @@ describe("UsageTracker", () => {
       tracker.accumulateStep({ inputTokens: 1_000_000, outputTokens: 0 });
 
       const cost = tracker.computeCostDollars("model-default");
-      // 1M input tokens at $0.50/1M * 1.3x = 6500 points / 10000 = 0.65
-      expect(cost).toBe(0.65);
+      // 1M input tokens at $0.50/1M, excluding the billing multiplier.
+      expect(cost).toBe(0.5);
     });
 
     it("should include non-model costs when provider cost is unavailable", () => {
       tracker.accumulateStep({ inputTokens: 1_000_000, outputTokens: 0 });
       tracker.nonModelCost = 0.25;
 
-      expect(tracker.computeCostDollars("model-default")).toBe(0.9);
+      expect(tracker.computeCostDollars("model-default")).toBe(0.75);
     });
 
     it("should use token-based model cost + nonModelCost when modelProviderCost is 0 but providerCost is positive from sandbox/tool spend (post-resetModelLeg scenario)", () => {
@@ -214,9 +214,9 @@ describe("UsageTracker", () => {
       tracker.nonModelCost = 0.25;
       // modelProviderCost stays 0 because the fallback provider didn't emit cost.
 
-      // Must include BOTH the token-based model cost (0.65) AND the sandbox
+      // Must include BOTH the raw token-based model cost (0.50) AND the sandbox
       // spend (0.25). The old implementation returned just providerCost = 0.25.
-      expect(tracker.computeCostDollars("model-default")).toBe(0.9);
+      expect(tracker.computeCostDollars("model-default")).toBe(0.75);
     });
   });
 
@@ -314,7 +314,7 @@ describe("UsageTracker", () => {
           logUsageRecord: localMockLog,
         }));
         jest.doMock("@/lib/rate-limit", () => ({
-          calculateTokenCost: jest.fn(),
+          calculateRawTokenCost: jest.fn(),
           POINTS_PER_DOLLAR: 10_000,
         }));
         IsolatedTracker = require("../usage-tracker").UsageTracker;
@@ -358,6 +358,24 @@ describe("UsageTracker", () => {
         nonModelCostDollars: 0,
         costSource: "provider",
       });
+    });
+
+    it("labels token-estimated cost as a raw estimate", () => {
+      tracker.accumulateStep({ inputTokens: 1_000_000, outputTokens: 0 });
+
+      const usage = tracker.createUsageCostRecord({
+        selectedModel: "model-default",
+        configuredModelId: "model-config",
+        rateLimitInfo: {
+          remaining: 1000,
+          resetTime: new Date(),
+          limit: 250000,
+          pointsDeducted: 100,
+        },
+      });
+
+      expect(usage.costDollars).toBe(0.5);
+      expect(usage.costSource).toBe("raw_token_estimate");
     });
   });
 });

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -1348,7 +1348,7 @@ export async function logUsageRecord({
   costDollars: number;
   modelCostDollars?: number;
   nonModelCostDollars?: number;
-  costSource?: "provider" | "token_estimate";
+  costSource?: "provider" | "token_estimate" | "raw_token_estimate";
 }) {
   try {
     await getConvexClient().mutation(api.usageLogs.logUsage, {

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "@jest/globals";
 
 import {
   calculateTokenCost,
+  calculateRawTokenCost,
   calculateProratedCredits,
   getBudgetLimits,
   getCycleExpireSeconds,
@@ -65,6 +66,28 @@ describe("token-bucket", () => {
       expect(calculateTokenCost(10, "input")).toBe(1);
       // 10000 tokens at $0.50/1M * 1.3 = 65 points
       expect(calculateTokenCost(10000, "input")).toBe(65);
+    });
+  });
+
+  // ==========================================================================
+  // calculateRawTokenCost - Analytics/reporting cost without usage multiplier
+  // ==========================================================================
+  describe("calculateRawTokenCost", () => {
+    it("should return 0 for zero or negative tokens", () => {
+      expect(calculateRawTokenCost(0, "input")).toBe(0);
+      expect(calculateRawTokenCost(0, "output")).toBe(0);
+      expect(calculateRawTokenCost(-100, "input")).toBe(0);
+      expect(calculateRawTokenCost(-100, "output")).toBe(0);
+    });
+
+    it("should calculate raw input token cost without the 1.3x multiplier", () => {
+      expect(calculateRawTokenCost(1_000_000, "input")).toBe(5000);
+      expect(calculateRawTokenCost(1000, "input")).toBe(5);
+    });
+
+    it("should calculate raw output token cost without the 1.3x multiplier", () => {
+      expect(calculateRawTokenCost(1_000_000, "output")).toBe(30000);
+      expect(calculateRawTokenCost(1000, "output")).toBe(30);
     });
   });
 

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -39,6 +39,7 @@ export {
   clearOrgRemovedUsage,
   applyTeamSeatDebt,
   calculateTokenCost,
+  calculateRawTokenCost,
   getBudgetLimits,
   getSubscriptionPrice,
   getMonthlyBucketKey,

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -122,6 +122,22 @@ export const calculateTokenCost = (
   );
 };
 
+/**
+ * Estimate raw model cost for analytics/reporting only.
+ * Unlike calculateTokenCost, this intentionally excludes the normal usage
+ * multiplier so unit economics reflects provider-priced usage cost.
+ */
+export const calculateRawTokenCost = (
+  tokens: number,
+  type: "input" | "output",
+  modelName?: string,
+): number => {
+  if (tokens <= 0) return 0;
+  const pricing = getModelPricing(modelName);
+  const price = type === "input" ? pricing.input : pricing.output;
+  return Math.ceil((tokens / 1_000_000) * price * POINTS_PER_DOLLAR);
+};
+
 // =============================================================================
 // Budget Limits
 // =============================================================================

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -1,5 +1,5 @@
 import { logUsageRecord } from "@/lib/db/actions";
-import { calculateTokenCost, POINTS_PER_DOLLAR } from "@/lib/rate-limit";
+import { calculateRawTokenCost, POINTS_PER_DOLLAR } from "@/lib/rate-limit";
 import type { ChatMode, RateLimitInfo, SubscriptionTier } from "@/types";
 
 interface StepUsage {
@@ -24,7 +24,7 @@ export interface UsageCostRecord {
   costDollars: number;
   modelCostDollars: number;
   nonModelCostDollars: number;
-  costSource: "provider" | "token_estimate";
+  costSource: "provider" | "token_estimate" | "raw_token_estimate";
 }
 
 /**
@@ -113,8 +113,8 @@ export class UsageTracker {
       return this.providerCost - this.nonModelCost;
     }
     return (
-      (calculateTokenCost(this.inputTokens, "input", selectedModel) +
-        calculateTokenCost(this.outputTokens, "output", selectedModel)) /
+      (calculateRawTokenCost(this.inputTokens, "input", selectedModel) +
+        calculateRawTokenCost(this.outputTokens, "output", selectedModel)) /
       POINTS_PER_DOLLAR
     );
   }
@@ -183,7 +183,8 @@ export class UsageTracker {
       costDollars: modelCostDollars + this.nonModelCost,
       modelCostDollars,
       nonModelCostDollars: this.nonModelCost,
-      costSource: this.modelProviderCost > 0 ? "provider" : "token_estimate",
+      costSource:
+        this.modelProviderCost > 0 ? "provider" : "raw_token_estimate",
     };
   }
 


### PR DESCRIPTION
## Summary
- Adds a raw token-cost estimator for analytics/reporting while keeping the 1.3x multiplier in the rate-limit billing path.
- Logs token-estimated usage as `raw_token_estimate` so unit economics no longer counts the normal usage multiplier as cost.
- Normalizes legacy `token_estimate` usage rows during Convex ingestion and unit-economics rebuilds.
- Shares the legacy multiplier constant from `unitEconomicsLib` so ingestion and rebuild normalization cannot drift.

## Why
The paid unit economics dashboard was counting token-estimated usage costs after the 1.3x usage multiplier, making AI cost and profit metrics look worse than actual tracked provider/tool cost.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm test -- lib/rate-limit/__tests__/token-bucket.test.ts lib/__tests__/usage-tracker.test.ts convex/__tests__/unitEconomicsReportingWindow.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings outside this PR)
- Amend hook: `pnpm typecheck` and full `pnpm test` (133 suites, 1481 tests)

## Follow-up
Existing PostHog daily rollups should be rebuilt after deploy so historical May 31-now rows are rewritten without the multiplier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking raw token-estimated usage costs alongside existing provider and legacy cost sources.

* **Bug Fixes**
  * Improved unit-economics rebuild normalization for legacy token-estimated costs.
  * Refined daily rollups to use consistent normalized cost values for included vs extra usage breakdowns.

* **Tests**
  * Updated usage-tracking and unit-economics expectations for the new cost-source handling.
  * Added coverage for legacy normalization and raw token cost estimation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->