### PR TITLE
[codex] hide model selector for logged-out users

### DIFF
--- a/app/components/ChatInput/ChatInputToolbar.tsx
+++ b/app/components/ChatInput/ChatInputToolbar.tsx
@@ -12,6 +12,7 @@ import {
   type ContextUsageData,
 } from "@/app/components/ContextUsageIndicator";
 import { useGlobalState } from "@/app/contexts/GlobalState";
+import { useAuth } from "@workos-inc/authkit-nextjs/components";
 
 export interface ChatInputToolbarProps extends SubmitStopButtonProps {
   onAttachClick: () => void;
@@ -29,6 +30,7 @@ export function ChatInputToolbar({
   ...submitStopProps
 }: ChatInputToolbarProps) {
   const { selectedModel, setSelectedModel } = useGlobalState();
+  const { user } = useAuth();
 
   return (
     <div className="px-3 flex gap-2 items-center min-w-0">
@@ -36,11 +38,13 @@ export function ChatInputToolbar({
         <AttachmentButton onAttachClick={onAttachClick} />
       </div>
       <ChatModeSelector />
-      <ModelSelector
-        value={selectedModel}
-        onChange={setSelectedModel}
-        mode={chatMode}
-      />
+      {user ? (
+        <ModelSelector
+          value={selectedModel}
+          onChange={setSelectedModel}
+          mode={chatMode}
+        />
+      ) : null}
       <div className="ml-auto shrink-0 flex items-center gap-2.5">
         {showContextIndicator && contextUsage && (
           <ContextUsageIndicator

--- a/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
+++ b/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
@@ -1,0 +1,79 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { useAuth } from "@workos-inc/authkit-nextjs/components";
+
+jest.mock("@/app/components/AttachmentButton", () => ({
+  AttachmentButton: () => <button type="button">Attach</button>,
+}));
+
+jest.mock("../ChatModeSelector", () => ({
+  ChatModeSelector: () => <div data-testid="chat-mode-selector" />,
+}));
+
+jest.mock("@/app/components/ModelSelector", () => ({
+  ModelSelector: () => <div data-testid="model-selector" />,
+}));
+
+jest.mock("../SubmitStopButton", () => ({
+  SubmitStopButton: () => <button type="button">Send</button>,
+}));
+
+jest.mock("@/app/components/ContextUsageIndicator", () => ({
+  ContextUsageIndicator: () => <div data-testid="context-usage-indicator" />,
+}));
+
+jest.mock("@/app/contexts/GlobalState", () => ({
+  useGlobalState: () => ({
+    selectedModel: "auto",
+    setSelectedModel: jest.fn(),
+  }),
+}));
+
+const { ChatInputToolbar } = jest.requireActual<
+  typeof import("../ChatInputToolbar")
+>("../ChatInputToolbar");
+
+const defaultProps = {
+  onAttachClick: jest.fn(),
+  isGenerating: false,
+  hideStop: false,
+  onStop: jest.fn(),
+  onSubmit: jest.fn(),
+  status: "ready" as const,
+  isUploadingFiles: false,
+  input: "",
+  uploadedFiles: [],
+  chatMode: "ask" as const,
+};
+
+const mockAuthUser = (user: unknown) => {
+  jest.mocked(useAuth).mockReturnValue({
+    user,
+    entitlements: [],
+    isAuthenticated: Boolean(user),
+    signIn: jest.fn(),
+    signOut: jest.fn(),
+  } as ReturnType<typeof useAuth>);
+};
+
+describe("ChatInputToolbar", () => {
+  beforeEach(() => {
+    mockAuthUser(null);
+  });
+
+  it("hides the model selector for logged-out users", () => {
+    render(<ChatInputToolbar {...defaultProps} />);
+
+    expect(screen.getByTestId("chat-mode-selector")).toBeInTheDocument();
+    expect(screen.queryByTestId("model-selector")).not.toBeInTheDocument();
+  });
+
+  it("shows the model selector for logged-in users", () => {
+    mockAuthUser({ id: "user_123" });
+
+    render(<ChatInputToolbar {...defaultProps} />);
+
+    expect(screen.getByTestId("model-selector")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Hide the chat input model selector unless WorkOS auth reports a logged-in user. This keeps logged-out visitors from seeing the model picker while leaving the rest of the toolbar intact.

## Root Cause

`ChatInputToolbar` always mounted `ModelSelector`, and the selector only gated individual paid model choices. Logged-out users therefore still saw the selector trigger.

## Changes

- Read `user` from `useAuth()` in `ChatInputToolbar`.
- Render `ModelSelector` only when a user is present.
- Add focused toolbar coverage for logged-out and logged-in states.

## Validation

- Pre-commit hook ran `prettier --write`, `eslint --fix`, `pnpm typecheck`, and the full Jest suite: 134 suites / 1478 tests passed.
- Earlier targeted checks also passed for the toolbar and ChatInput integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model Selector now displays exclusively for authenticated users.

* **Tests**
  * Added test coverage to verify Model Selector visibility based on authentication status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->