### PR TITLE
[codex] Improve free Agent upgrade moment

### DIFF
--- a/app/(chat)/c/[id]/page.tsx
+++ b/app/(chat)/c/[id]/page.tsx
@@ -12,7 +12,8 @@ export default function Page(props: { params: Promise<{ id: string }> }) {
   const params = use(props.params);
   const chatId = params.id;
   const { subscription } = useGlobalState();
-  const { showPricing, handleClosePricing } = usePricingDialog(subscription);
+  const { showPricing, handleClosePricing, pricingContext } =
+    usePricingDialog(subscription);
 
   return (
     <>
@@ -36,7 +37,11 @@ export default function Page(props: { params: Promise<{ id: string }> }) {
         </div>
       </Unauthenticated>
 
-      <PricingDialog isOpen={showPricing} onClose={handleClosePricing} />
+      <PricingDialog
+        isOpen={showPricing}
+        onClose={handleClosePricing}
+        context={pricingContext}
+      />
     </>
   );
 }

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -126,7 +126,8 @@ export default function Page() {
     migrateFromPentestgptDialogOpen,
     setMigrateFromPentestgptDialogOpen,
   } = useGlobalState();
-  const { showPricing, handleClosePricing } = usePricingDialog(subscription);
+  const { showPricing, handleClosePricing, pricingContext } =
+    usePricingDialog(subscription);
 
   const { isMigrating, migrate } = usePentestgptMigration();
   const searchParams =
@@ -159,7 +160,11 @@ export default function Page() {
       <Authenticated>
         <AuthenticatedContent />
         <ExtraUsagePurchaseToast />
-        <PricingDialog isOpen={showPricing} onClose={handleClosePricing} />
+        <PricingDialog
+          isOpen={showPricing}
+          onClose={handleClosePricing}
+          context={pricingContext}
+        />
         <TeamPricingDialog
           isOpen={teamPricingDialogOpen}
           onClose={() => setTeamPricingDialogOpen(false)}

--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -306,4 +306,65 @@ describe("POST /api/subscribe", () => {
       "referral_referred_user_id",
     );
   });
+
+  it("persists checkout attribution in Stripe metadata and analytics", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [],
+    } as never);
+    mockCreateOrganization.mockResolvedValue({
+      id: "org_new",
+    } as never);
+    mockCreateCustomer.mockResolvedValue({
+      id: "cus_new",
+      metadata: {},
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      makeRequest({
+        plan: "pro-plus-monthly-plan",
+        checkoutAttemptId: "ca_limit_pressure_123",
+        source: "limit_pressure",
+        surface: "rate_limit_warning",
+        reason: "monthly_exhausted",
+        limitType: "monthly",
+        fromTier: "free",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.checkoutAttemptId).toBe("ca_limit_pressure_123");
+    expect(mockCreateCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          checkoutAttemptId: "ca_limit_pressure_123",
+          checkoutSource: "limit_pressure",
+          checkoutSurface: "rate_limit_warning",
+          checkoutReason: "monthly_exhausted",
+          checkoutLimitType: "monthly",
+        }),
+        subscription_data: expect.objectContaining({
+          metadata: expect.objectContaining({
+            checkoutAttemptId: "ca_limit_pressure_123",
+            checkoutSource: "limit_pressure",
+            checkoutSurface: "rate_limit_warning",
+            checkoutReason: "monthly_exhausted",
+            checkoutLimitType: "monthly",
+          }),
+        }),
+      }),
+    );
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "checkout_started",
+      expect.objectContaining({
+        checkout_attempt_id: "ca_limit_pressure_123",
+        source: "limit_pressure",
+        surface: "rate_limit_warning",
+        reason: "monthly_exhausted",
+        limit_type: "monthly",
+      }),
+    );
+  });
 });

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -48,6 +48,10 @@ export const POST = async (req: NextRequest) => {
       createCheckoutAttemptId();
     const checkoutSource = normalizePaidFunnelLabel(body?.source);
     const checkoutSurface = normalizePaidFunnelLabel(body?.surface);
+    const checkoutReason = normalizePaidFunnelLabel(body?.reason);
+    const checkoutLimitType = normalizePaidFunnelLabel(
+      body?.limitType ?? body?.limit_type,
+    );
     const fromTier = paidFunnelTierFromUnknown(body?.fromTier);
     const posthogSessionId = req.headers.get("x-posthog-session-id");
     // Get user ID from authenticated session
@@ -306,6 +310,8 @@ export const POST = async (req: NextRequest) => {
         checkoutAttemptId,
         ...(checkoutSource && { checkoutSource }),
         ...(checkoutSurface && { checkoutSurface }),
+        ...(checkoutReason && { checkoutReason }),
+        ...(checkoutLimitType && { checkoutLimitType }),
         checkoutType: "new_subscription",
       },
       subscription_data: {
@@ -316,6 +322,8 @@ export const POST = async (req: NextRequest) => {
           checkoutAttemptId,
           ...(checkoutSource && { checkoutSource }),
           ...(checkoutSurface && { checkoutSurface }),
+          ...(checkoutReason && { checkoutReason }),
+          ...(checkoutLimitType && { checkoutLimitType }),
           checkoutType: "new_subscription",
         },
       },
@@ -383,6 +391,8 @@ export const POST = async (req: NextRequest) => {
         quantity,
         surface: checkoutSurface,
         source: checkoutSource,
+        reason: checkoutReason,
+        limit_type: checkoutLimitType,
         checkout_amount_dollars:
           selectedPrice.unit_amount != null
             ? (selectedPrice.unit_amount * quantity) / 100

--- a/app/api/subscription-details/__tests__/route.test.ts
+++ b/app/api/subscription-details/__tests__/route.test.ts
@@ -9,13 +9,23 @@ const mockListPrices = jest.fn();
 const mockListSubscriptions = jest.fn();
 const mockCreatePreview = jest.fn();
 const mockUpdateSubscription = jest.fn();
+const mockPostHogEvent = jest.fn();
+const mockPostHogFlush = jest.fn();
 
 jest.mock("next/server", () => ({
+  after: jest.fn((callback: () => void) => callback()),
   NextResponse: {
     json: jest.fn((body: unknown, init?: ResponseInit) => ({
       status: init?.status ?? 200,
       json: async () => body,
     })),
+  },
+}));
+
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: {
+    event: mockPostHogEvent,
+    flush: mockPostHogFlush,
   },
 }));
 
@@ -195,5 +205,106 @@ describe("POST /api/subscription-details", () => {
       status: "active",
       limit: 1,
     });
+  });
+
+  it("persists subscription-change attribution in metadata and analytics", async () => {
+    mockListPrices.mockResolvedValueOnce({
+      data: [
+        {
+          id: "price_ultra",
+          unit_amount: 10000,
+          recurring: { interval: "month", interval_count: 1 },
+          currency: "usd",
+        },
+      ],
+    } as never);
+    mockListSubscriptions.mockResolvedValueOnce({
+      data: [
+        {
+          id: "sub_123",
+          metadata: { existing: "metadata" },
+          default_payment_method: null,
+          items: {
+            data: [
+              {
+                id: "si_123",
+                price: {
+                  id: "price_pro",
+                  unit_amount: 2000,
+                  product: "prod_pro",
+                  recurring: { interval: "month" },
+                },
+              },
+            ],
+          },
+          current_period_start: 1_700_000_000,
+          current_period_end: 1_702_592_000,
+        },
+      ],
+    } as never);
+    mockCreatePreview.mockResolvedValueOnce({
+      amount_due: 8000,
+      lines: {
+        data: [{ amount: 10000 }, { amount: -2000 }],
+      },
+    } as never);
+    mockUpdateSubscription.mockResolvedValueOnce({
+      id: "sub_123",
+      latest_invoice: null,
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      makeRequest({
+        plan: "ultra-monthly-plan",
+        confirm: true,
+        checkoutAttemptId: "ca_paid_limit_123",
+        source: "limit_pressure",
+        surface: "pricing_dialog",
+        reason: "monthly_exhausted",
+        limitType: "monthly",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockUpdateSubscription).toHaveBeenCalledWith(
+      "sub_123",
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          existing: "metadata",
+          checkoutAttemptId: "ca_paid_limit_123",
+          checkoutSource: "limit_pressure",
+          checkoutSurface: "pricing_dialog",
+          checkoutReason: "monthly_exhausted",
+          checkoutLimitType: "monthly",
+          checkoutType: "subscription_change",
+        }),
+      }),
+    );
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "checkout_started",
+      expect.objectContaining({
+        checkout_attempt_id: "ca_paid_limit_123",
+        checkout_type: "subscription_change",
+        source: "limit_pressure",
+        surface: "pricing_dialog",
+        reason: "monthly_exhausted",
+        limit_type: "monthly",
+      }),
+    );
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "checkout_succeeded",
+      expect.objectContaining({
+        checkout_attempt_id: "ca_paid_limit_123",
+        checkout_type: "subscription_change",
+        source: "limit_pressure",
+        surface: "pricing_dialog",
+        reason: "monthly_exhausted",
+        limit_type: "monthly",
+      }),
+    );
   });
 });

--- a/app/api/subscription-details/route.ts
+++ b/app/api/subscription-details/route.ts
@@ -69,6 +69,10 @@ export const POST = async (req: NextRequest) => {
       createCheckoutAttemptId();
     const checkoutSource = normalizePaidFunnelLabel(body?.source);
     const checkoutSurface = normalizePaidFunnelLabel(body?.surface);
+    const checkoutReason = normalizePaidFunnelLabel(body?.reason);
+    const checkoutLimitType = normalizePaidFunnelLabel(
+      body?.limitType ?? body?.limit_type,
+    );
     const posthogSessionId = req.headers?.get("x-posthog-session-id");
 
     const allowedPlans = new Set([
@@ -337,6 +341,8 @@ export const POST = async (req: NextRequest) => {
               quantity,
               surface: checkoutSurface,
               source: checkoutSource,
+              reason: checkoutReason,
+              limit_type: checkoutLimitType,
               checkout_amount_dollars: totalDue,
               currency: targetPrice.currency,
               stripe_customer_id: matchingCustomer.id,
@@ -369,6 +375,8 @@ export const POST = async (req: NextRequest) => {
                 checkoutAttemptId,
                 ...(checkoutSource && { checkoutSource }),
                 ...(checkoutSurface && { checkoutSurface }),
+                ...(checkoutReason && { checkoutReason }),
+                ...(checkoutLimitType && { checkoutLimitType }),
                 checkoutType: "subscription_change",
               },
             },
@@ -435,6 +443,8 @@ export const POST = async (req: NextRequest) => {
               quantity,
               surface: checkoutSurface,
               source: checkoutSource,
+              reason: checkoutReason,
+              limit_type: checkoutLimitType,
               checkout_amount_dollars: totalDue,
               currency: targetPrice.currency,
               stripe_customer_id: matchingCustomer.id,

--- a/app/components/ChatInput/AgentUpgradeDialog.tsx
+++ b/app/components/ChatInput/AgentUpgradeDialog.tsx
@@ -32,7 +32,7 @@ export function AgentUpgradeDialog({
       surface: "agent_upgrade_dialog",
       source: "agent_mode_gate",
       from_tier: "free",
-      cta_text: "Upgrade",
+      cta_text: "Upgrade for cloud Agent",
     });
   }, [open]);
 
@@ -43,9 +43,10 @@ export function AgentUpgradeDialog({
         data-testid="agent-upgrade-dialog"
       >
         <DialogHeader>
-          <DialogTitle>Get Agent mode</DialogTitle>
+          <DialogTitle>Use Agent mode</DialogTitle>
           <DialogDescription>
-            Connect a local sandbox to use Agent mode for free.
+            Connect a local sandbox for free, or upgrade for cloud Agent mode
+            with higher limits.
           </DialogDescription>
         </DialogHeader>
 
@@ -66,7 +67,7 @@ export function AgentUpgradeDialog({
               <div className="flex-1 min-w-0">
                 <div className="text-sm font-medium">Desktop App</div>
                 <div className="text-xs text-muted-foreground">
-                  Download and run locally
+                  Free local Agent runs
                 </div>
               </div>
             </button>
@@ -84,7 +85,7 @@ export function AgentUpgradeDialog({
               <div className="flex-1 min-w-0">
                 <div className="text-sm font-medium">Remote Machine</div>
                 <div className="text-xs text-muted-foreground">
-                  Connect via the CLI package
+                  Free Agent on your own machine
                 </div>
               </div>
             </button>
@@ -109,7 +110,7 @@ export function AgentUpgradeDialog({
                 surface: "agent_upgrade_dialog",
                 source: "agent_mode_gate",
                 from_tier: "free",
-                cta_text: "Upgrade",
+                cta_text: "Upgrade for cloud Agent",
               });
             }}
             className="w-full flex items-center gap-3 p-3 rounded-lg border text-left hover:bg-muted/50 transition-colors"
@@ -119,9 +120,9 @@ export function AgentUpgradeDialog({
               <Cloud className="h-4 w-4 text-white" />
             </div>
             <div className="flex-1 min-w-0">
-              <div className="text-sm font-medium">Upgrade</div>
+              <div className="text-sm font-medium">Upgrade for cloud Agent</div>
               <div className="text-xs text-muted-foreground">
-                Cloud sandbox, custom models, higher limits
+                No local setup, stronger models, higher limits
               </div>
             </div>
           </button>

--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -13,6 +13,7 @@ import {
 import type { LimitCapReason } from "@/lib/limit-pressure";
 import {
   getExtraUsageLimitCta,
+  getLimitTypeForCapReason,
   shouldShowUpgradeCta,
 } from "@/lib/limit-pressure";
 
@@ -84,6 +85,12 @@ export const MessageErrorState = ({
   const isPaidUser = subscription !== "free";
   const canUpgrade = shouldShowUpgradeCta({ subscription, capReason });
   const extraUsageCta = getExtraUsageLimitCta({ subscription, capReason });
+  const limitType = getLimitTypeForCapReason(capReason);
+  const upgradeCtaText =
+    subscription === "free" &&
+    (limitType === "daily_requests" || limitType === "free_monthly")
+      ? "Keep going"
+      : "Upgrade Plan";
   const isSuspensionError = metadata?.suspensionCategory !== undefined;
 
   useEffect(() => {
@@ -96,9 +103,17 @@ export const MessageErrorState = ({
       source: "rate_limit_error",
       from_tier: subscription,
       cap_reason: capReason,
-      cta_text: "Upgrade Plan",
+      limit_type: limitType,
+      cta_text: upgradeCtaText,
     });
-  }, [canUpgrade, capReason, isRateLimitError, subscription]);
+  }, [
+    canUpgrade,
+    capReason,
+    isRateLimitError,
+    limitType,
+    subscription,
+    upgradeCtaText,
+  ]);
 
   useEffect(() => {
     if (
@@ -201,11 +216,12 @@ export const MessageErrorState = ({
                     source: "rate_limit_error",
                     from_tier: subscription,
                     reason: capReason,
-                    cta_text: "Upgrade Plan",
+                    limit_type: limitType,
+                    cta_text: upgradeCtaText,
                   })
                 }
               >
-                Upgrade Plan
+                {upgradeCtaText}
               </Button>
             )}
           </>

--- a/app/components/PricingDialog.tsx
+++ b/app/components/PricingDialog.tsx
@@ -61,7 +61,7 @@ type PricingIntentCopy = {
   ultraButtonText: string;
 };
 
-function getPricingIntentCopy(
+export function getPricingIntentCopy(
   context: PricingDialogContext | undefined,
   subscription: string,
 ): PricingIntentCopy | null {
@@ -70,27 +70,6 @@ function getPricingIntentCopy(
   const source = context?.source;
   const limitType = context?.limitType;
   const reason = context?.reason;
-
-  if (
-    source === "limit_pressure" ||
-    source === "rate_limit_error" ||
-    limitType === "free_monthly" ||
-    limitType === "daily_requests" ||
-    reason === "free_monthly_exhausted" ||
-    reason === "daily_requests_exhausted"
-  ) {
-    return {
-      title: "Keep Agent running",
-      description:
-        "Upgrade to continue today with higher usage limits, cloud agents, file uploads, and stronger models for heavier security work.",
-      proDescription: "Continue Agent runs with higher limits",
-      proPlusDescription: "More room for heavier Agent work",
-      ultraDescription: "Maximum usage for intensive testing",
-      proButtonText: "Continue with Pro",
-      proPlusButtonText: "Keep going with Pro+",
-      ultraButtonText: "Scale up with Ultra",
-    };
-  }
 
   if (source === "agent_mode_gate") {
     return {
@@ -103,6 +82,27 @@ function getPricingIntentCopy(
       proButtonText: "Use cloud Agent",
       proPlusButtonText: "Get more Agent usage",
       ultraButtonText: "Get Ultra",
+    };
+  }
+
+  if (
+    source === "limit_pressure" ||
+    source === "rate_limit_error" ||
+    limitType === "free_monthly" ||
+    limitType === "daily_requests" ||
+    reason === "free_monthly_exhausted" ||
+    reason === "daily_requests_exhausted"
+  ) {
+    return {
+      title: "Keep working",
+      description:
+        "Upgrade to continue today with higher usage limits, file uploads, and stronger models for heavier security work.",
+      proDescription: "Continue with higher limits",
+      proPlusDescription: "More room for heavier work",
+      ultraDescription: "Maximum usage for intensive testing",
+      proButtonText: "Continue with Pro",
+      proPlusButtonText: "Keep going with Pro+",
+      ultraButtonText: "Scale up with Ultra",
     };
   }
 
@@ -486,8 +486,10 @@ const PricingDialog: React.FC<PricingDialogProps> = ({
         planName={pendingUpgrade?.planName || ""}
         price={pendingUpgrade?.price || 0}
         targetPlan={pendingUpgrade?.plan || ""}
-        source="plan_card"
+        source={context?.source ?? "plan_card"}
         surface="pricing_dialog"
+        reason={context?.reason}
+        limitType={context?.limitType}
       />
 
       <Dialog open={isOpen} onOpenChange={onClose}>

--- a/app/components/PricingDialog.tsx
+++ b/app/components/PricingDialog.tsx
@@ -21,10 +21,12 @@ import {
 import BillingFrequencySelector from "./BillingFrequencySelector";
 import UpgradeConfirmationDialog from "./UpgradeConfirmationDialog";
 import { captureUpgradeCtaImpression } from "@/lib/analytics/client";
+import type { PricingDialogContext } from "../hooks/usePricingDialog";
 
 interface PricingDialogProps {
   isOpen: boolean;
   onClose: () => void;
+  context?: PricingDialogContext;
 }
 
 interface PlanCardProps {
@@ -46,6 +48,65 @@ interface PlanCardProps {
   badgeClassName?: string;
   footerNote?: string;
   featureHeader?: string | null;
+}
+
+type PricingIntentCopy = {
+  title: string;
+  description: string;
+  proDescription: string;
+  proPlusDescription: string;
+  ultraDescription: string;
+  proButtonText: string;
+  proPlusButtonText: string;
+  ultraButtonText: string;
+};
+
+function getPricingIntentCopy(
+  context: PricingDialogContext | undefined,
+  subscription: string,
+): PricingIntentCopy | null {
+  if (subscription !== "free") return null;
+
+  const source = context?.source;
+  const limitType = context?.limitType;
+  const reason = context?.reason;
+
+  if (
+    source === "limit_pressure" ||
+    source === "rate_limit_error" ||
+    limitType === "free_monthly" ||
+    limitType === "daily_requests" ||
+    reason === "free_monthly_exhausted" ||
+    reason === "daily_requests_exhausted"
+  ) {
+    return {
+      title: "Keep Agent running",
+      description:
+        "Upgrade to continue today with higher usage limits, cloud agents, file uploads, and stronger models for heavier security work.",
+      proDescription: "Continue Agent runs with higher limits",
+      proPlusDescription: "More room for heavier Agent work",
+      ultraDescription: "Maximum usage for intensive testing",
+      proButtonText: "Continue with Pro",
+      proPlusButtonText: "Keep going with Pro+",
+      ultraButtonText: "Scale up with Ultra",
+    };
+  }
+
+  if (source === "agent_mode_gate") {
+    return {
+      title: "Unlock cloud Agent mode",
+      description:
+        "Use Agent without connecting a local sandbox, with higher limits, file uploads, and stronger models included.",
+      proDescription: "Cloud agents and higher limits",
+      proPlusDescription: "More usage for repeated Agent runs",
+      ultraDescription: "Maximum room for serious workloads",
+      proButtonText: "Use cloud Agent",
+      proPlusButtonText: "Get more Agent usage",
+      ultraButtonText: "Get Ultra",
+    };
+  }
+
+  return null;
 }
 
 const PlanCard: React.FC<PlanCardProps> = ({
@@ -146,7 +207,11 @@ const PlanCard: React.FC<PlanCardProps> = ({
   );
 };
 
-const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
+const PricingDialog: React.FC<PricingDialogProps> = ({
+  isOpen,
+  onClose,
+  context,
+}) => {
   const { user } = useAuth();
   const { subscription, isCheckingProPlan, setTeamPricingDialogOpen } =
     useGlobalState();
@@ -159,6 +224,7 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
     planName: string;
     price: number;
   } | null>(null);
+  const pricingIntentCopy = getPricingIntentCopy(context, subscription);
 
   // Auto-close pricing dialog for ultra/team users (pro-plus can still upgrade to ultra)
   React.useEffect(() => {
@@ -177,11 +243,19 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
     capturedPricingCtaImpressionRef.current = true;
     captureUpgradeCtaImpression({
       surface: "pricing_dialog",
-      source: "plan_cards",
+      source: context?.source ?? "plan_cards",
       from_tier: subscription,
       cta_text: "plan_card_buttons",
+      ...(context?.reason && { reason: context.reason }),
+      ...(context?.limitType && { limit_type: context.limitType }),
     });
-  }, [isOpen, subscription]);
+  }, [
+    context?.limitType,
+    context?.reason,
+    context?.source,
+    isOpen,
+    subscription,
+  ]);
 
   const handleBillingChange = (value: "monthly" | "yearly") => {
     setIsYearly(value === "yearly");
@@ -202,8 +276,10 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
     if (subscription === "free") {
       try {
         await handleUpgrade(plan, undefined, undefined, subscription, {
-          source: "plan_card",
+          source: context?.source ?? "plan_card",
           surface: "pricing_dialog",
+          reason: context?.reason,
+          limit_type: context?.limitType,
         });
         // Don't close dialog on success - let the redirect happen
       } catch (error) {
@@ -288,7 +364,7 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
       };
     } else if (user) {
       return {
-        text: "Get Pro",
+        text: pricingIntentCopy?.proButtonText ?? "Get Pro",
         disabled: upgradeLoading,
         className: "",
         variant: "default" as const,
@@ -325,7 +401,9 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
       };
     } else if (user) {
       const buttonText =
-        subscription === "pro" ? "Upgrade to Pro+" : "Get Pro+";
+        subscription === "pro"
+          ? "Upgrade to Pro+"
+          : (pricingIntentCopy?.proPlusButtonText ?? "Get Pro+");
       return {
         text: buttonText,
         disabled: upgradeLoading,
@@ -367,7 +445,7 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
         text:
           subscription === "pro" || subscription === "pro-plus"
             ? "Upgrade to Ultra"
-            : "Get Ultra",
+            : (pricingIntentCopy?.ultraButtonText ?? "Get Ultra"),
         disabled: upgradeLoading,
         className: "font-semibold bg-[#615eeb] hover:bg-[#504bb8] text-white",
         variant: "default" as const,
@@ -422,8 +500,13 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
             <div></div>
             <div className="my-1 flex flex-col items-center justify-center md:mt-0 md:mb-0">
               <DialogTitle className="text-3xl font-semibold">
-                Upgrade your plan
+                {pricingIntentCopy?.title ?? "Upgrade your plan"}
               </DialogTitle>
+              {pricingIntentCopy && (
+                <p className="text-muted-foreground mt-2 max-w-2xl text-center text-sm">
+                  {pricingIntentCopy.description}
+                </p>
+              )}
             </div>
             <button
               onClick={onClose}
@@ -467,7 +550,10 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
               <PlanCard
                 planName="Pro"
                 price={isYearly ? PRICING.pro.yearly : PRICING.pro.monthly}
-                description="For everyday productivity"
+                description={
+                  pricingIntentCopy?.proDescription ??
+                  "For everyday productivity"
+                }
                 features={proFeatures}
                 buttonText={proButtonConfig.text}
                 buttonVariant={proButtonConfig.variant}
@@ -488,7 +574,10 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
                     ? PRICING["pro-plus"].yearly
                     : PRICING["pro-plus"].monthly
                 }
-                description="For power users who need more"
+                description={
+                  pricingIntentCopy?.proPlusDescription ??
+                  "For power users who need more"
+                }
                 features={proPlusFeatures}
                 buttonText={proPlusButtonConfig.text}
                 buttonVariant={proPlusButtonConfig.variant}
@@ -504,7 +593,10 @@ const PricingDialog: React.FC<PricingDialogProps> = ({ isOpen, onClose }) => {
               <PlanCard
                 planName="Ultra"
                 price={isYearly ? PRICING.ultra.yearly : PRICING.ultra.monthly}
-                description="Get the most out of HackerAI"
+                description={
+                  pricingIntentCopy?.ultraDescription ??
+                  "Get the most out of HackerAI"
+                }
                 features={ultraFeatures}
                 buttonText={ultraButtonConfig.text}
                 buttonVariant={ultraButtonConfig.variant}

--- a/app/components/RateLimitWarning.tsx
+++ b/app/components/RateLimitWarning.tsx
@@ -103,7 +103,7 @@ const getMessage = (data: RateLimitWarningData, timeString: string): string => {
   if (data.remainingPercent === 0) {
     if (data.cutOff) {
       if (data.subscription === "free") {
-        return `You've reached your free monthly usage limit and this response was cut off. Upgrade to keep Agent running with higher limits. Resets ${timeString}.`;
+        return `You've reached your free monthly usage limit and this response was cut off. Upgrade for higher limits. Resets ${timeString}.`;
       }
       if (data.capReason === "extra_usage_cap") {
         return `You've reached your extra usage spending limit and this response was cut off. Increase your limit to continue. Resets ${timeString}.`;
@@ -111,7 +111,7 @@ const getMessage = (data: RateLimitWarningData, timeString: string): string => {
       return `You've reached your monthly limit and this response was cut off. Add credits or upgrade to continue. Resets ${timeString}.`;
     }
     if (data.subscription === "free") {
-      return `You've reached your free monthly usage limit. Upgrade for higher Agent limits and cloud agents. Resets ${timeString}.`;
+      return `You've reached your free monthly usage limit. Upgrade for higher limits. Resets ${timeString}.`;
     }
 
     return `You've reached your monthly usage limit. It resets ${timeString}.`;

--- a/app/components/RateLimitWarning.tsx
+++ b/app/components/RateLimitWarning.tsx
@@ -86,9 +86,13 @@ const formatTimeUntil = (resetTime: Date): string => {
 
 const getMessage = (data: RateLimitWarningData, timeString: string): string => {
   if (data.warningType === "sliding-window") {
-    return data.remaining === 0
-      ? `You've used all your daily requests. Daily requests reset at midnight UTC.`
-      : `You have ${data.remaining} daily ${data.remaining === 1 ? "request" : "requests"} remaining today.`;
+    if (data.remaining === 0) {
+      return data.mode === "agent"
+        ? "You've used today's free Agent requests. Upgrade to keep running Agent today, or wait for the reset at midnight UTC."
+        : "You've used all your daily free requests. Upgrade to keep going today, or wait for the reset at midnight UTC.";
+    }
+
+    return `You have ${data.remaining} daily ${data.remaining === 1 ? "request" : "requests"} remaining today.`;
   }
 
   if (data.warningType === "extra-usage-active") {
@@ -99,13 +103,17 @@ const getMessage = (data: RateLimitWarningData, timeString: string): string => {
   if (data.remainingPercent === 0) {
     if (data.cutOff) {
       if (data.subscription === "free") {
-        return `You've reached your free monthly usage limit and this response was cut off. Upgrade to continue. Resets ${timeString}.`;
+        return `You've reached your free monthly usage limit and this response was cut off. Upgrade to keep Agent running with higher limits. Resets ${timeString}.`;
       }
       if (data.capReason === "extra_usage_cap") {
         return `You've reached your extra usage spending limit and this response was cut off. Increase your limit to continue. Resets ${timeString}.`;
       }
       return `You've reached your monthly limit and this response was cut off. Add credits or upgrade to continue. Resets ${timeString}.`;
     }
+    if (data.subscription === "free") {
+      return `You've reached your free monthly usage limit. Upgrade for higher Agent limits and cloud agents. Resets ${timeString}.`;
+    }
+
     return `You've reached your monthly usage limit. It resets ${timeString}.`;
   }
 
@@ -115,6 +123,20 @@ const getMessage = (data: RateLimitWarningData, timeString: string): string => {
   }
 
   return `You have ${data.remainingPercent}% of your monthly usage remaining. It resets ${timeString}.`;
+};
+
+const getUpgradeCtaText = (
+  data: RateLimitWarningData,
+  limitType: string,
+): string => {
+  if (
+    data.subscription === "free" &&
+    (limitType === "daily_requests" || limitType === "free_monthly")
+  ) {
+    return "Keep going";
+  }
+
+  return "Upgrade plan";
 };
 
 const WARNING_STYLES = "bg-input-chat border-black/8 dark:border-border";
@@ -152,6 +174,7 @@ export const RateLimitWarning = ({
     data.warningType === "token-bucket" && data.remainingPercent === 0
       ? "hit"
       : "warning";
+  const upgradeCtaText = getUpgradeCtaText(data, limitType);
 
   useEffect(() => {
     if (!showUpgrade || capturedUpgradeImpressionRef.current) return;
@@ -163,9 +186,16 @@ export const RateLimitWarning = ({
       limit_type: limitType,
       limit_severity: limitSeverity,
       cap_reason: capReason,
-      cta_text: "Upgrade plan",
+      cta_text: upgradeCtaText,
     });
-  }, [capReason, data.subscription, limitSeverity, limitType, showUpgrade]);
+  }, [
+    capReason,
+    data.subscription,
+    limitSeverity,
+    limitType,
+    showUpgrade,
+    upgradeCtaText,
+  ]);
 
   useEffect(() => {
     if (!extraUsageCta || capturedAddCreditImpressionRef.current) return;
@@ -218,14 +248,14 @@ export const RateLimitWarning = ({
                 from_tier: data.subscription,
                 limit_type: limitType,
                 reason: capReason,
-                cta_text: "Upgrade plan",
+                cta_text: upgradeCtaText,
               })
             }
             size="sm"
             variant="outline"
             className="h-7 px-3 text-xs font-medium border-black/8 dark:border-border"
           >
-            Upgrade plan
+            {upgradeCtaText}
           </Button>
         )}
       </div>

--- a/app/components/UpgradeConfirmationDialog.tsx
+++ b/app/components/UpgradeConfirmationDialog.tsx
@@ -19,6 +19,8 @@ interface UpgradeConfirmationDialogProps {
   quantity?: number;
   source?: string;
   surface?: string;
+  reason?: string;
+  limitType?: string;
 }
 
 // Safely validate and format unix seconds into a display date
@@ -50,6 +52,8 @@ const UpgradeConfirmationDialog: React.FC<UpgradeConfirmationDialogProps> = ({
   quantity,
   source,
   surface,
+  reason,
+  limitType,
 }) => {
   const [details, setDetails] = useState<SubscriptionDetails | null>(null);
   const [loadingDetails, setLoadingDetails] = useState(false);
@@ -89,6 +93,8 @@ const UpgradeConfirmationDialog: React.FC<UpgradeConfirmationDialogProps> = ({
             checkoutAttemptId,
             source,
             surface,
+            reason,
+            limitType,
           }),
         });
 
@@ -128,7 +134,17 @@ const UpgradeConfirmationDialog: React.FC<UpgradeConfirmationDialogProps> = ({
     };
 
     fetchDetails();
-  }, [isOpen, targetPlan, price, quantity, checkoutAttemptId, source, surface]);
+  }, [
+    isOpen,
+    targetPlan,
+    price,
+    quantity,
+    checkoutAttemptId,
+    source,
+    surface,
+    reason,
+    limitType,
+  ]);
 
   const proratedCredit = details?.proratedCredit || 0;
   const additionalCredit = (details as any)?.additionalCredit || 0;
@@ -157,6 +173,8 @@ const UpgradeConfirmationDialog: React.FC<UpgradeConfirmationDialogProps> = ({
           checkoutAttemptId,
           source,
           surface,
+          reason,
+          limitType,
           fromTier: details.currentPlan,
         }),
       });

--- a/app/components/__tests__/PricingDialog.intent-copy.test.ts
+++ b/app/components/__tests__/PricingDialog.intent-copy.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "@jest/globals";
+import { getPricingIntentCopy } from "../PricingDialog";
+
+describe("getPricingIntentCopy", () => {
+  it("uses generic copy for non-Agent limit pressure", () => {
+    const copy = getPricingIntentCopy(
+      {
+        source: "limit_pressure",
+        limitType: "free_monthly",
+        reason: "free_monthly_exhausted",
+      },
+      "free",
+    );
+
+    expect(copy).toEqual(
+      expect.objectContaining({
+        title: "Keep working",
+        description: expect.stringContaining("higher usage limits"),
+        proDescription: "Continue with higher limits",
+      }),
+    );
+    expect(copy?.title).not.toContain("Agent");
+    expect(copy?.description).not.toContain("Agent");
+    expect(copy?.proDescription).not.toContain("Agent");
+  });
+
+  it("keeps Agent-specific copy for the Agent gate", () => {
+    const copy = getPricingIntentCopy(
+      {
+        source: "agent_mode_gate",
+      },
+      "free",
+    );
+
+    expect(copy).toEqual(
+      expect.objectContaining({
+        title: "Unlock cloud Agent mode",
+        proButtonText: "Use cloud Agent",
+      }),
+    );
+  });
+});

--- a/app/components/__tests__/RateLimitWarning.test.tsx
+++ b/app/components/__tests__/RateLimitWarning.test.tsx
@@ -1,0 +1,61 @@
+import "@testing-library/jest-dom";
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import { RateLimitWarning } from "../RateLimitWarning";
+
+jest.mock("@/lib/analytics/client", () => ({
+  captureAddCreditCtaClick: jest.fn(),
+  captureAddCreditCtaImpression: jest.fn(),
+  captureUpgradeCtaImpression: jest.fn(),
+}));
+
+jest.mock("@/lib/utils/settings-dialog", () => ({
+  openSettingsDialog: jest.fn(),
+}));
+
+describe("RateLimitWarning", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses generic copy for free monthly exhaustion", () => {
+    render(
+      <RateLimitWarning
+        data={{
+          warningType: "token-bucket",
+          bucketType: "monthly",
+          remainingPercent: 0,
+          resetTime: new Date(Date.now() + 60_000),
+          subscription: "free",
+          capReason: "free_monthly_exhausted",
+        }}
+        onDismiss={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(/You've reached your free monthly usage limit/i),
+    ).toHaveTextContent("Upgrade for higher limits");
+    expect(screen.queryByText(/Agent/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /keep going/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps Agent-specific copy for exhausted Agent daily requests", () => {
+    render(
+      <RateLimitWarning
+        data={{
+          warningType: "sliding-window",
+          remaining: 0,
+          resetTime: new Date(Date.now() + 60_000),
+          mode: "agent",
+          subscription: "free",
+        }}
+        onDismiss={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/free Agent requests/i)).toBeInTheDocument();
+  });
+});

--- a/app/components/__tests__/UpgradeConfirmationDialog.test.tsx
+++ b/app/components/__tests__/UpgradeConfirmationDialog.test.tsx
@@ -214,6 +214,71 @@ describe("UpgradeConfirmationDialog", () => {
         fromTier: "pro",
       });
     });
+
+    it("should pass attribution context to preview and confirm APIs", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              proratedAmount: 80,
+              proratedCredit: 10,
+              totalDue: 70,
+              paymentMethod: "VISA *4242",
+              currentPlan: "pro",
+              quantity: 2,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ success: true }),
+        });
+
+      render(
+        <UpgradeConfirmationDialog
+          {...defaultProps}
+          source="limit_pressure"
+          surface="pricing_dialog"
+          reason="monthly_exhausted"
+          limitType="monthly"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("$70.00")).toBeInTheDocument();
+      });
+
+      const previewBody = JSON.parse(
+        (mockFetch.mock.calls[0]?.[1] as RequestInit).body as string,
+      );
+      expect(previewBody).toEqual(
+        expect.objectContaining({
+          source: "limit_pressure",
+          surface: "pricing_dialog",
+          reason: "monthly_exhausted",
+          limitType: "monthly",
+        }),
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /confirm and pay/i }));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+
+      const confirmBody = JSON.parse(
+        (mockFetch.mock.calls[1]?.[1] as RequestInit).body as string,
+      );
+      expect(confirmBody).toEqual(
+        expect.objectContaining({
+          source: "limit_pressure",
+          surface: "pricing_dialog",
+          reason: "monthly_exhausted",
+          limitType: "monthly",
+          fromTier: "pro",
+        }),
+      );
+    });
   });
 
   describe("Error handling", () => {

--- a/app/hooks/usePricingDialog.ts
+++ b/app/hooks/usePricingDialog.ts
@@ -14,8 +14,53 @@ type PricingRedirectAnalytics = {
   cta_text?: string;
 };
 
+export type PricingDialogContext = {
+  surface?: string;
+  source?: string;
+  fromTier?: SubscriptionTier;
+  reason?: string;
+  limitType?: string;
+};
+
+const PRICING_CONTEXT_PARAMS = {
+  surface: "pricing_surface",
+  source: "pricing_source",
+  fromTier: "pricing_from_tier",
+  reason: "pricing_reason",
+  limitType: "pricing_limit_type",
+} as const;
+
+const readPricingContext = (): PricingDialogContext => {
+  const params = new URLSearchParams(window.location.search);
+  const fromTier = params.get(PRICING_CONTEXT_PARAMS.fromTier);
+
+  return {
+    surface: params.get(PRICING_CONTEXT_PARAMS.surface) ?? undefined,
+    source: params.get(PRICING_CONTEXT_PARAMS.source) ?? undefined,
+    fromTier:
+      fromTier === "free" ||
+      fromTier === "pro" ||
+      fromTier === "pro-plus" ||
+      fromTier === "ultra" ||
+      fromTier === "team"
+        ? fromTier
+        : undefined,
+    reason: params.get(PRICING_CONTEXT_PARAMS.reason) ?? undefined,
+    limitType: params.get(PRICING_CONTEXT_PARAMS.limitType) ?? undefined,
+  };
+};
+
+const clearPricingContextParams = (url: URL) => {
+  for (const key of Object.values(PRICING_CONTEXT_PARAMS)) {
+    url.searchParams.delete(key);
+  }
+};
+
 export const usePricingDialog = (subscription?: SubscriptionTier) => {
   const [showPricing, setShowPricing] = useState(false);
+  const [pricingContext, setPricingContext] = useState<PricingDialogContext>(
+    {},
+  );
   const capturedPricingViewRef = useRef(false);
 
   useEffect(() => {
@@ -38,13 +83,22 @@ export const usePricingDialog = (subscription?: SubscriptionTier) => {
       setShowPricing(shouldShow);
       if (!shouldShow) {
         capturedPricingViewRef.current = false;
+        setPricingContext({});
         return;
       }
+
+      const context = readPricingContext();
+      setPricingContext(context);
 
       if (!capturedPricingViewRef.current) {
         if (
           captureAuthenticatedEvent("pricing_viewed", {
             subscription,
+            surface: context.surface,
+            source: context.source,
+            from_tier: context.fromTier,
+            reason: context.reason,
+            limit_type: context.limitType,
           })
         ) {
           capturedPricingViewRef.current = true;
@@ -67,12 +121,16 @@ export const usePricingDialog = (subscription?: SubscriptionTier) => {
     setShowPricing(false);
     // Remove hash from URL
     if (window.location.hash === "#pricing") {
+      const url = new URL(window.location.href);
+      clearPricingContextParams(url);
+      url.hash = "";
       window.history.replaceState(
         null,
         document.title || "",
-        window.location.pathname + window.location.search,
+        `${url.pathname}${url.search}`,
       );
     }
+    setPricingContext({});
   };
 
   const openPricing = () => {
@@ -80,13 +138,19 @@ export const usePricingDialog = (subscription?: SubscriptionTier) => {
     if (subscription === "ultra" || subscription === "team") {
       return;
     }
-    window.location.hash = "pricing";
+
+    const url = new URL(window.location.href);
+    clearPricingContextParams(url);
+    url.hash = "pricing";
+    window.history.pushState(null, document.title || "", url.toString());
+    window.dispatchEvent(new Event("hashchange"));
   };
 
   return {
     showPricing,
     handleClosePricing,
     openPricing,
+    pricingContext,
   };
 };
 
@@ -102,5 +166,29 @@ export const redirectToPricing = (analytics: PricingRedirectAnalytics = {}) => {
     ...(analytics.limit_type && { limit_type: analytics.limit_type }),
     ...(analytics.cta_text && { cta_text: analytics.cta_text }),
   });
-  window.location.hash = "pricing";
+
+  const url = new URL(window.location.href);
+  clearPricingContextParams(url);
+  if (analytics.surface) {
+    url.searchParams.set(PRICING_CONTEXT_PARAMS.surface, analytics.surface);
+  }
+  if (analytics.source) {
+    url.searchParams.set(PRICING_CONTEXT_PARAMS.source, analytics.source);
+  }
+  if (analytics.from_tier) {
+    url.searchParams.set(PRICING_CONTEXT_PARAMS.fromTier, analytics.from_tier);
+  }
+  if (analytics.reason) {
+    url.searchParams.set(PRICING_CONTEXT_PARAMS.reason, analytics.reason);
+  }
+  if (analytics.limit_type) {
+    url.searchParams.set(
+      PRICING_CONTEXT_PARAMS.limitType,
+      analytics.limit_type,
+    );
+  }
+  url.hash = "pricing";
+
+  window.history.pushState(null, document.title || "", url.toString());
+  window.dispatchEvent(new Event("hashchange"));
 };

--- a/app/hooks/useUpgrade.ts
+++ b/app/hooks/useUpgrade.ts
@@ -24,6 +24,8 @@ export const useUpgrade = () => {
     analyticsContext: {
       source?: string;
       surface?: string;
+      reason?: string;
+      limit_type?: string;
     } = {},
   ) => {
     e?.preventDefault();
@@ -51,12 +53,16 @@ export const useUpgrade = () => {
         checkoutAttemptId: string;
         source?: string;
         surface?: string;
+        reason?: string;
+        limitType?: string;
         fromTier?: string;
       } = {
         plan: selectedPlan,
         checkoutAttemptId,
         source: analyticsContext.source,
         surface: analyticsContext.surface,
+        reason: analyticsContext.reason,
+        limitType: analyticsContext.limit_type,
         fromTier: currentSubscription ?? "free",
       };
 
@@ -76,6 +82,8 @@ export const useUpgrade = () => {
           billing_interval: billingInterval,
           surface: analyticsContext.surface,
           source: analyticsContext.source,
+          reason: analyticsContext.reason,
+          limit_type: analyticsContext.limit_type,
           checkout_type: "new_subscription",
         });
 
@@ -109,6 +117,8 @@ export const useUpgrade = () => {
             billing_interval: billingInterval,
             surface: analyticsContext.surface,
             source: analyticsContext.source,
+            reason: analyticsContext.reason,
+            limit_type: analyticsContext.limit_type,
             checkout_type: "new_subscription",
           });
           window.location.href = url;
@@ -132,6 +142,8 @@ export const useUpgrade = () => {
           billing_interval: billingInterval,
           surface: analyticsContext.surface,
           source: analyticsContext.source,
+          reason: analyticsContext.reason,
+          limit_type: analyticsContext.limit_type,
           checkout_type: "subscription_change",
         });
 
@@ -148,6 +160,8 @@ export const useUpgrade = () => {
             checkoutAttemptId,
             source: analyticsContext.source,
             surface: analyticsContext.surface,
+            reason: analyticsContext.reason,
+            limitType: analyticsContext.limit_type,
             fromTier: currentSubscription,
           }),
         });


### PR DESCRIPTION
## What changed

- Preserves upgrade context from Agent/rate-limit CTAs through `#pricing`, `pricing_viewed`, checkout intent/redirect, server-side `checkout_started`, subscription-change success, and Stripe metadata.
- Uses generic pricing copy for free users who arrive from usage-limit pressure, so Ask/chat users are not incorrectly shown Agent-specific messaging.
- Keeps Agent-specific pricing copy for the Agent gate, where users are choosing between free local Agent and paid cloud Agent.
- Reframes free Agent limit and Agent gate copy around continuing work / cloud Agent / higher limits instead of generic upgrading.
- Adds focused coverage for checkout attribution metadata, subscription-change attribution, pricing intent copy, rate-limit copy, and upgrade confirmation API payloads.

## Why

The Agent-first data shows users are clicking upgrade more often, but checkout/subscription conversion is not yet moving. This PR focuses the monetization moment where the intent is highest and keeps the funnel attributable without adding extra noisy logs.

## Validation

- `prettier --check app/components/PricingDialog.tsx app/components/RateLimitWarning.tsx app/components/UpgradeConfirmationDialog.tsx app/components/__tests__/UpgradeConfirmationDialog.test.tsx app/components/__tests__/PricingDialog.intent-copy.test.ts app/components/__tests__/RateLimitWarning.test.tsx app/api/subscribe/__tests__/route.test.ts app/api/subscription-details/__tests__/route.test.ts`
- `jest app/components/__tests__/PricingDialog.intent-copy.test.ts app/components/__tests__/RateLimitWarning.test.tsx app/components/__tests__/UpgradeConfirmationDialog.test.tsx app/api/subscribe/__tests__/route.test.ts app/api/subscription-details/__tests__/route.test.ts --runInBand`
- `git diff --check`

Note: `pnpm typecheck` could not complete in this worktree because local dependencies are not installed here. With a temporary symlink to the main checkout install, typecheck reached an existing missing dependency error for `ws` in `packages/local/src/index.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced upgrade dialog messaging to emphasize cloud Agent capabilities and distinguish between local and cloud offerings.
  * Added context-aware messaging to pricing and rate-limit dialogs based on the upgrade source and limit type.
  * Improved error messages when rate limits are reached with specific guidance for agent vs. standard mode.

* **Improvements**
  * Better tracking of subscription upgrade context to improve funnel analysis and user attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->