### PR TITLE
Improve usage warnings and Gemini ask reasoning

### DIFF
--- a/app/components/RateLimitWarning.tsx
+++ b/app/components/RateLimitWarning.tsx
@@ -136,6 +136,7 @@ export const RateLimitWarning = ({
           capReason,
         })
       : null;
+  const showUsageCta = data.warningType === "extra-usage-active";
   const showUpgrade =
     data.warningType !== "extra-usage-active" &&
     shouldShowUpgradeCta({
@@ -207,6 +208,16 @@ export const RateLimitWarning = ({
             className="h-7 px-3 text-xs font-medium border-black/8 dark:border-border"
           >
             {extraUsageCta.label}
+          </Button>
+        )}
+        {showUsageCta && (
+          <Button
+            onClick={() => openSettingsDialog("Usage")}
+            size="sm"
+            variant="outline"
+            className="h-7 px-3 text-xs font-medium border-black/8 dark:border-border"
+          >
+            View Usage
           </Button>
         )}
         {showUpgrade && (

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -163,15 +163,25 @@ describe("buildProviderOptions fallback chain", () => {
   });
 
   it.each([
-    "ask-model",
     "ask-model-free",
-    "model-gemini-3-flash",
     "model-deepseek-v4-flash",
   ])(
     "keeps reasoning disabled for auto/standard ask mode model %s",
     (modelName) => {
       const opts = buildProviderOptions(false, "user-1", modelName, "ask");
       expect(opts.openrouter.reasoning).toEqual({ enabled: false });
+    },
+  );
+
+  it.each(["ask-model", "model-gemini-3-flash"])(
+    "enables hidden medium reasoning for Gemini ask mode model %s",
+    (modelName) => {
+      const opts = buildProviderOptions(false, "user-1", modelName, "ask");
+      expect(opts.openrouter.reasoning).toEqual({
+        enabled: true,
+        effort: "medium",
+        exclude: true,
+      });
     },
   );
 

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -167,12 +167,12 @@ export function sendRateLimitWarnings(
         subscription,
       });
     } else {
-      // Paid users without extra usage: warn at 80% and 95%
+      // Paid users without extra usage: warn at 75% and 90%
       const usedPercent =
         100 -
         (rateLimitInfo.monthly.remaining / rateLimitInfo.monthly.limit) * 100;
 
-      if (usedPercent >= 80) {
+      if (usedPercent >= 75) {
         emitTokenBucketThresholdWarning(writer, {
           usedPercent,
           projectedUsedPoints:
@@ -216,7 +216,7 @@ export function emitTokenBucketThresholdWarning(
 ): void {
   const remainingPercent = Math.max(0, Math.round(100 - ctx.usedPercent));
   const severity: "info" | "warning" =
-    ctx.usedPercent >= 95 ? "warning" : "info";
+    ctx.usedPercent >= 90 ? "warning" : "info";
   writeRateLimitWarning(writer, {
     warningType: "token-bucket",
     bucketType: "monthly",
@@ -492,6 +492,8 @@ const ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN = [
 ] as const satisfies readonly ModelName[];
 
 const ASK_MEDIUM_REASONING_MODELS = [
+  "ask-model",
+  "model-gemini-3-flash",
   "model-deepseek-v4-pro",
   "model-sonnet-4.6",
   "model-opus-4.6",
@@ -576,6 +578,8 @@ export function buildProviderOptions(
 ) {
   const modelId = modelName ? resolveSlug(modelName) : undefined;
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
+  const isGemini3Flash =
+    modelName === "ask-model" || modelName === "model-gemini-3-flash";
   const fallbackSlugs = getFallbackSlugs(modelName, mode, options);
   const reasoning = isReasoningModel
     ? {
@@ -583,7 +587,11 @@ export function buildProviderOptions(
         ...(isDeepSeekV4 && { effort: "xhigh" }),
       }
     : mode === "ask" && isAskMediumReasoningModel(modelName)
-      ? { enabled: true, effort: "medium" }
+      ? {
+          enabled: true,
+          effort: "medium",
+          ...(isGemini3Flash && { exclude: true }),
+        }
       : { enabled: false };
 
   return {

--- a/lib/chat/__tests__/budget-monitor.test.ts
+++ b/lib/chat/__tests__/budget-monitor.test.ts
@@ -20,6 +20,58 @@ const baseSnapshot: BudgetSnapshot = {
 };
 
 describe("BudgetMonitor", () => {
+  it("emits the first budget warning at 75% usage", () => {
+    const writer = makeWriter();
+    const monitor = new BudgetMonitor(
+      {
+        ...baseSnapshot,
+        monthlyRemainingAtStart: 30,
+      },
+      writer,
+      "pro",
+    );
+
+    const decision = monitor.checkAfterStep(0.0005);
+
+    expect(decision).toBe("continue");
+    expect(writer.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "data-rate-limit-warning",
+        data: expect.objectContaining({
+          warningType: "token-bucket",
+          remainingPercent: 25,
+          severity: "info",
+        }),
+      }),
+    );
+  });
+
+  it("emits the stronger budget warning at 90% usage", () => {
+    const writer = makeWriter();
+    const monitor = new BudgetMonitor(
+      {
+        ...baseSnapshot,
+        monthlyRemainingAtStart: 15,
+      },
+      writer,
+      "pro",
+    );
+
+    const decision = monitor.checkAfterStep(0.0005);
+
+    expect(decision).toBe("continue");
+    expect(writer.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "data-rate-limit-warning",
+        data: expect.objectContaining({
+          warningType: "token-bucket",
+          remainingPercent: 10,
+          severity: "warning",
+        }),
+      }),
+    );
+  });
+
   it("aborts with extra_usage_cap when overflow would exceed the monthly extra-usage cap", () => {
     const writer = makeWriter();
     const monitor = new BudgetMonitor(

--- a/lib/chat/budget-monitor.ts
+++ b/lib/chat/budget-monitor.ts
@@ -15,11 +15,10 @@ import { writeRateLimitWarning } from "@/lib/utils/stream-writer-utils";
 import type { LimitCapReason } from "@/lib/limit-pressure";
 
 // 50% is intentionally omitted: at the halfway mark there's no actionable
-// signal for the user, so an in-product banner is noise. The ladder matches
-// the codebase's pre-existing 80/95 warnings, plus 100% which drives the
-// abort. (Anthropic's Console alerts include 50% but deliver it via email,
-// not an in-product disruption — we don't have that channel.)
-export const BUDGET_THRESHOLDS = [80, 95, 100] as const;
+// signal for the user, so an in-product banner is noise. The ladder gives an
+// early heads-up at 75%, a stronger warning at 90%, and uses 100% for the
+// cutoff or extra-usage transition.
+export const BUDGET_THRESHOLDS = [75, 90, 100] as const;
 
 export interface BudgetSnapshot {
   monthlyLimitPoints: number;

--- a/lib/utils/parse-rate-limit-warning.ts
+++ b/lib/utils/parse-rate-limit-warning.ts
@@ -29,8 +29,8 @@ const TOKEN_BUCKET_WARNING_KEY_PREFIX = "tokenBucketWarningShownAt_";
 
 /** Dedup interval per severity: show each tier at most once per this many hours */
 const SEVERITY_DEDUP_HOURS: Record<string, number> = {
-  info: 168, // 80% warning: once per week (effectively once per billing cycle)
-  warning: 0, // 95% warning: always show
+  info: 168, // 75% warning: once per week (effectively once per billing cycle)
+  warning: 0, // 90% warning: always show
 };
 
 /**

--- a/lib/utils/stream-writer-utils.ts
+++ b/lib/utils/stream-writer-utils.ts
@@ -115,7 +115,7 @@ export type RateLimitWarningData =
       limitDollars?: number;
       capReason?: LimitCapReason;
       // Mid-stream emits bypass localStorage dedup so threshold escalations
-      // (50→80→95→100) within a single stream always reach the client.
+      // (75→90→100) within a single stream always reach the client.
       midStream?: boolean;
       // Set when the response was cut off mid-stream because the bucket hit 0.
       cutOff?: boolean;


### PR DESCRIPTION
## Summary
- enable hidden medium reasoning for Gemini 3 Flash in Ask mode
- move monthly usage warning thresholds from 80/95/100 to 75/90/100
- add focused budget monitor coverage for 75% and 90%
- add a `View Usage` action when extra usage starts in-chat

## Tests
- `NODE_PATH=/Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules /Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules/.bin/jest app/components/__tests__/ChatInput.integration.test.tsx lib/chat/__tests__/budget-monitor.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts --runInBand`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Adjusted paid monthly rate-limit warnings to trigger at 75% usage (info) and escalate at 90% usage (warning), enabling earlier notice.
  * Added a “View Usage” button to the rate-limit warning UI for extra-usage active alerts, taking you to the Usage tab in settings.
  * Expanded “ask mode” medium reasoning support to additional models, with Gemini 3 Flash treated as hidden medium reasoning.
* **Tests**
  * Updated and added coverage for budget warning thresholds and reasoning configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->