### PR TITLE
Normalize model selection for free users

### DIFF
--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -13,7 +13,10 @@ import {
 } from "@/lib/db/actions";
 import { assertFreeAgentGates } from "@/lib/api/chat-stream-helpers";
 import { getTriggerRegionForVercelRequest } from "@/lib/api/trigger-region";
-import { coerceSelectedModel } from "@/types";
+import {
+  coerceSelectedModel,
+  normalizeSelectedModelForSubscription,
+} from "@/types";
 import { ChatSDKError } from "@/lib/errors";
 import type { Todo, SandboxPreference, SelectedModel } from "@/types";
 import { HybridSandboxManager } from "@/lib/ai/tools/utils/hybrid-sandbox-manager";
@@ -51,10 +54,12 @@ export async function POST(req: NextRequest) {
       isAutoContinue?: boolean;
     } = await req.json();
 
-    const selectedModelOverride: SelectedModel | undefined =
-      coerceSelectedModel(rawSelectedModel ?? null) ?? undefined;
-
     const { userId, subscription, organizationId } = await getUserIDAndPro(req);
+    const selectedModelOverride: SelectedModel =
+      normalizeSelectedModelForSubscription(
+        coerceSelectedModel(rawSelectedModel ?? null),
+        subscription,
+      );
     await assertUserCanMakeCostIncurringRequest(userId);
     const userLocation = geolocation(req);
     const triggerRegion = getTriggerRegionForVercelRequest(req);
@@ -63,7 +68,6 @@ export async function POST(req: NextRequest) {
       mode: "agent",
       subscription,
       sandboxPreference,
-      rawSelectedModel,
     });
 
     const requestMessages = Array.isArray(messages) ? messages : [];

--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -15,7 +15,7 @@ import { assertFreeAgentGates } from "@/lib/api/chat-stream-helpers";
 import { getTriggerRegionForVercelRequest } from "@/lib/api/trigger-region";
 import {
   coerceSelectedModel,
-  normalizeSelectedModelForSubscription,
+  normalizeSelectedModelOverrideForSubscription,
 } from "@/types";
 import { ChatSDKError } from "@/lib/errors";
 import type { Todo, SandboxPreference, SelectedModel } from "@/types";
@@ -55,8 +55,8 @@ export async function POST(req: NextRequest) {
     } = await req.json();
 
     const { userId, subscription, organizationId } = await getUserIDAndPro(req);
-    const selectedModelOverride: SelectedModel =
-      normalizeSelectedModelForSubscription(
+    const selectedModelOverride: SelectedModel | undefined =
+      normalizeSelectedModelOverrideForSubscription(
         coerceSelectedModel(rawSelectedModel ?? null),
         subscription,
       );

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -334,12 +334,13 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
   const { subscription } = useGlobalState();
   const isMobile = useIsMobile();
 
-  const isAuto = value === "auto";
   const isFreeUser = subscription === "free";
+  const displayValue: SelectedModel = isFreeUser ? "auto" : value;
+  const isAuto = displayValue === "auto";
 
   const options = isAgentMode(mode) ? AGENT_MODEL_OPTIONS : ASK_MODEL_OPTIONS;
 
-  const effectiveValue = isAuto ? getDefaultModelForMode(mode) : value;
+  const effectiveValue = isAuto ? getDefaultModelForMode(mode) : displayValue;
   const selected =
     options.find((opt) => opt.id === effectiveValue) ?? options[0];
 
@@ -468,7 +469,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
             </SheetHeader>
             <ModelOptionList
               options={options}
-              value={value}
+              value={displayValue}
               isAuto={isAuto}
               isFreeUser={isFreeUser}
               mode={mode}
@@ -491,7 +492,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
         <PopoverContent className="w-[270px] p-1.5 rounded-xl" align="start">
           <ModelOptionList
             options={options}
-            value={value}
+            value={displayValue}
             isAuto={isAuto}
             isFreeUser={isFreeUser}
             mode={mode}

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -136,4 +136,14 @@ describe("ModelSelector", () => {
       screen.getByText(/long requests can use around \$10 of usage/i),
     ).toBeVisible();
   });
+
+  it("does not display a stale paid model as selected for free users", () => {
+    mockSubscription = "free";
+
+    render(
+      <ModelSelector value="hackerai-pro" onChange={jest.fn()} mode="agent" />,
+    );
+
+    expect(screen.getByRole("button", { name: /^Auto$/i })).toBeVisible();
+  });
 });

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -40,7 +40,12 @@ import {
 import { isTauriEnvironment } from "@/app/hooks/useTauri";
 import { stripAgentLongHeartbeatPartsFromMessages } from "@/lib/chat/agent-long-heartbeat";
 import { toast } from "sonner";
-import type { Todo, ChatMessage, ChatMode } from "@/types";
+import {
+  normalizeSelectedModelForSubscription,
+  type Todo,
+  type ChatMessage,
+  type ChatMode,
+} from "@/types";
 import { coerceSelectedModel } from "@/types/chat";
 import type { ContextUsageData } from "./ContextUsageIndicator";
 import { shouldTreatAsMerge } from "@/lib/utils/todo-utils";
@@ -268,8 +273,12 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const todosRef = useLatestRef(todos);
   // Use ref for sandbox preference to avoid stale closures in auto-send
   const sandboxPreferenceRef = useLatestRef(sandboxPreference);
+  const requestSelectedModel = normalizeSelectedModelForSubscription(
+    selectedModel,
+    subscription,
+  );
   // Use ref for model selection to avoid stale closures in auto-send
-  const selectedModelRef = useLatestRef(selectedModel);
+  const requestSelectedModelRef = useLatestRef(requestSelectedModel);
 
   // Ensure we only initialize mode from server once per chat id
   const hasInitializedModeFromChatRef = useRef(false);
@@ -1036,7 +1045,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
                 todos: todosRef.current,
                 temporary: temporaryChatsEnabledRef.current,
                 sandboxPreference: sandboxPreferenceRef.current,
-                selectedModel: selectedModelRef.current,
+                selectedModel: requestSelectedModelRef.current,
               },
             },
           );
@@ -1062,7 +1071,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     todosRef,
     temporaryChatsEnabledRef,
     sandboxPreferenceRef,
-    selectedModelRef,
+    requestSelectedModelRef,
   ]);
 
   // Chat handlers
@@ -1175,7 +1184,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
         todos={todos}
         temporaryChatsEnabled={temporaryChatsEnabled}
         sandboxPreference={sandboxPreference}
-        selectedModel={selectedModel}
+        selectedModel={requestSelectedModel}
         resetRef={resetAutoContinueRef}
         hasActiveStream={
           chatData === undefined

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -6,7 +6,11 @@ import { useLatestRef } from "@/app/hooks/useLatestRef";
 import { isTauriEnvironment } from "@/app/hooks/useTauri";
 import { shouldUseAgentLongForAgent } from "@/lib/chat/agent-routing";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
-import type { ChatMessage, ChatStatus } from "@/types";
+import {
+  normalizeSelectedModelForSubscription,
+  type ChatMessage,
+  type ChatStatus,
+} from "@/types";
 import { Id } from "@/convex/_generated/dataModel";
 import {
   countInputTokens,
@@ -78,6 +82,10 @@ export const useChatHandlers = ({
     sandboxPreference,
     selectedModel,
   } = useGlobalState();
+  const requestSelectedModel = normalizeSelectedModelForSubscription(
+    selectedModel,
+    subscription,
+  );
 
   // Avoid stale closure on temporary flag
   const temporaryChatsEnabledRef = useRef(temporaryChatsEnabled);
@@ -364,7 +372,7 @@ export const useChatHandlers = ({
               temporary: temporaryChatsEnabled,
               sandboxPreference,
 
-              selectedModel,
+              selectedModel: requestSelectedModel,
             },
           },
         );
@@ -380,7 +388,7 @@ export const useChatHandlers = ({
               temporary: temporaryChatsEnabled,
               sandboxPreference,
 
-              selectedModel,
+              selectedModel: requestSelectedModel,
             },
           },
         );
@@ -461,7 +469,7 @@ export const useChatHandlers = ({
           useClientMessagesForRegenerate: shouldSendClientMessagesForRegenerate,
           temporary: false,
           sandboxPreference,
-          selectedModel,
+          selectedModel: requestSelectedModel,
         },
       });
     } else {
@@ -473,7 +481,7 @@ export const useChatHandlers = ({
           regenerate: true,
           temporary: true,
           sandboxPreference,
-          selectedModel,
+          selectedModel: requestSelectedModel,
         },
       });
     }
@@ -505,7 +513,7 @@ export const useChatHandlers = ({
           regenerate: true,
           temporary: false,
           sandboxPreference,
-          selectedModel,
+          selectedModel: requestSelectedModel,
         },
       });
     } else {
@@ -529,7 +537,7 @@ export const useChatHandlers = ({
           temporary: true,
           sandboxPreference,
 
-          selectedModel,
+          selectedModel: requestSelectedModel,
         },
       });
     }
@@ -645,7 +653,7 @@ export const useChatHandlers = ({
           temporary: false,
           sandboxPreference,
 
-          selectedModel,
+          selectedModel: requestSelectedModel,
         },
       });
     } else {
@@ -682,7 +690,7 @@ export const useChatHandlers = ({
           temporary: true,
           sandboxPreference,
 
-          selectedModel,
+          selectedModel: requestSelectedModel,
         },
       });
     }
@@ -700,7 +708,7 @@ export const useChatHandlers = ({
           todos,
           temporary: temporaryChatsEnabled,
           sandboxPreference,
-          selectedModel,
+          selectedModel: requestSelectedModel,
         },
       },
     );
@@ -747,7 +755,7 @@ export const useChatHandlers = ({
           temporary: temporaryChatsEnabled,
           sandboxPreference,
 
-          selectedModel,
+          selectedModel: requestSelectedModel,
         },
       });
     } catch (error) {

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -6,7 +6,14 @@ import { internal } from "./_generated/api";
 import { fileCountAggregate } from "./fileAggregate";
 import { MAX_PREVIOUS_SUMMARIES } from "./constants";
 import { validateServiceKey } from "./lib/utils";
-import { coerceSelectedModel } from "../types/chat";
+import {
+  coerceSelectedModel,
+  normalizeSelectedModelForSubscription,
+} from "../types/chat";
+import {
+  parseEntitlements,
+  resolveSubscriptionTier,
+} from "../lib/auth/entitlements";
 import { convexLogger } from "./lib/logger";
 
 const DELETE_ALL_CHATS_MESSAGE_BATCH_SIZE = 10;
@@ -348,8 +355,14 @@ export const updateChatPreferences = mutation({
       // with a value the load path will silently rewrite later. Unknown ids
       // are dropped (skipped) rather than written verbatim.
       const coerced = coerceSelectedModel(args.selectedModel);
-      if (coerced !== null) {
-        patch.selected_model = coerced;
+      const subscription = resolveSubscriptionTier(
+        parseEntitlements(user.entitlements),
+      );
+      if (coerced !== null || subscription === "free") {
+        patch.selected_model = normalizeSelectedModelForSubscription(
+          coerced,
+          subscription,
+        );
       }
     }
     if (args.mode !== undefined) {

--- a/lib/api/__tests__/chat-stream-helpers-free-gates.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-free-gates.test.ts
@@ -1,0 +1,32 @@
+import { assertFreeAgentGates } from "@/lib/api/chat-stream-helpers";
+import { ChatSDKError } from "@/lib/errors";
+
+jest.mock("@/lib/db/actions", () => ({
+  getNotes: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
+describe("assertFreeAgentGates", () => {
+  it("allows free agent mode with a local sandbox", () => {
+    expect(() =>
+      assertFreeAgentGates({
+        mode: "agent",
+        subscription: "free",
+        sandboxPreference: "desktop",
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects free agent mode with the cloud sandbox", () => {
+    expect(() =>
+      assertFreeAgentGates({
+        mode: "agent",
+        subscription: "free",
+        sandboxPreference: "e2b",
+      }),
+    ).toThrow(ChatSDKError);
+  });
+});

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -20,7 +20,10 @@ import type {
   SelectedModel,
   RateLimitInfo,
 } from "@/types";
-import { coerceSelectedModel } from "@/types";
+import {
+  coerceSelectedModel,
+  normalizeSelectedModelForSubscription,
+} from "@/types";
 import { getBaseTodosForRequest } from "@/lib/utils/todo-utils";
 import {
   acquireFreeRunConcurrencyLock,
@@ -174,9 +177,6 @@ export const createChatHandler = () => {
       } = await req.json();
       outerChatId = chatId;
 
-      const selectedModelOverride: SelectedModel | undefined =
-        coerceSelectedModel(rawSelectedModel ?? null) ?? undefined;
-
       chatLogger = createChatLogger({ chatId, endpoint });
       chatLogger.setRequestDetails({
         mode,
@@ -186,6 +186,11 @@ export const createChatHandler = () => {
 
       const { userId, subscription, organizationId } =
         await getUserIDAndPro(req);
+      const selectedModelOverride: SelectedModel =
+        normalizeSelectedModelForSubscription(
+          coerceSelectedModel(rawSelectedModel ?? null),
+          subscription,
+        );
       await assertUserCanMakeCostIncurringRequest(userId);
       usageRefundTracker.setUser(userId, subscription, organizationId);
       if (subscription === "free") {
@@ -208,7 +213,6 @@ export const createChatHandler = () => {
         mode,
         subscription,
         sandboxPreference,
-        rawSelectedModel,
       });
 
       // Pre-emptive abort fires before Vercel's hard request timeout so we

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -22,7 +22,7 @@ import type {
 } from "@/types";
 import {
   coerceSelectedModel,
-  normalizeSelectedModelForSubscription,
+  normalizeSelectedModelOverrideForSubscription,
 } from "@/types";
 import { getBaseTodosForRequest } from "@/lib/utils/todo-utils";
 import {
@@ -186,8 +186,8 @@ export const createChatHandler = () => {
 
       const { userId, subscription, organizationId } =
         await getUserIDAndPro(req);
-      const selectedModelOverride: SelectedModel =
-        normalizeSelectedModelForSubscription(
+      const selectedModelOverride: SelectedModel | undefined =
+        normalizeSelectedModelOverrideForSubscription(
           coerceSelectedModel(rawSelectedModel ?? null),
           subscription,
         );

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -892,16 +892,16 @@ export async function applyPrepareStepReminders(
 }
 
 /**
- * Free-tier agent mode is restricted to the local sandbox + auto model.
- * Throws ChatSDKError("forbidden:chat") if either gate fails.
+ * Free-tier agent mode is restricted to the local sandbox.
+ * Model overrides are normalized to auto before stream setup.
+ * Throws ChatSDKError("forbidden:chat") if the sandbox gate fails.
  */
 export function assertFreeAgentGates(args: {
   mode: ChatMode;
   subscription: SubscriptionTier;
   sandboxPreference: SandboxPreference | undefined;
-  rawSelectedModel: string | undefined;
 }): void {
-  const { mode, subscription, sandboxPreference, rawSelectedModel } = args;
+  const { mode, subscription, sandboxPreference } = args;
   if (!isAgentMode(mode) || subscription !== "free") return;
 
   const isLocalSandbox = sandboxPreference && sandboxPreference !== "e2b";
@@ -909,13 +909,6 @@ export function assertFreeAgentGates(args: {
     throw new ChatSDKError(
       "forbidden:chat",
       "Agent mode on the free plan requires a local sandbox. Install the desktop app or upgrade to Pro for cloud access.",
-    );
-  }
-
-  if (rawSelectedModel && rawSelectedModel !== "auto") {
-    throw new ChatSDKError(
-      "forbidden:chat",
-      "Custom model selection in agent mode requires a Pro plan. Free agent mode uses the default model.",
     );
   }
 }

--- a/types/__tests__/chat.test.ts
+++ b/types/__tests__/chat.test.ts
@@ -1,0 +1,22 @@
+import { normalizeSelectedModelForSubscription } from "../chat";
+
+describe("normalizeSelectedModelForSubscription", () => {
+  it("forces free users to auto even when a paid model is stored", () => {
+    expect(normalizeSelectedModelForSubscription("hackerai-pro", "free")).toBe(
+      "auto",
+    );
+    expect(normalizeSelectedModelForSubscription("hackerai-max", "free")).toBe(
+      "auto",
+    );
+  });
+
+  it("preserves paid users' selected model and defaults missing values to auto", () => {
+    expect(normalizeSelectedModelForSubscription("hackerai-pro", "pro")).toBe(
+      "hackerai-pro",
+    );
+    expect(normalizeSelectedModelForSubscription(null, "ultra")).toBe("auto");
+    expect(normalizeSelectedModelForSubscription(undefined, "team")).toBe(
+      "auto",
+    );
+  });
+});

--- a/types/__tests__/chat.test.ts
+++ b/types/__tests__/chat.test.ts
@@ -1,4 +1,7 @@
-import { normalizeSelectedModelForSubscription } from "../chat";
+import {
+  normalizeSelectedModelForSubscription,
+  normalizeSelectedModelOverrideForSubscription,
+} from "../chat";
 
 describe("normalizeSelectedModelForSubscription", () => {
   it("forces free users to auto even when a paid model is stored", () => {
@@ -18,5 +21,31 @@ describe("normalizeSelectedModelForSubscription", () => {
     expect(normalizeSelectedModelForSubscription(undefined, "team")).toBe(
       "auto",
     );
+  });
+});
+
+describe("normalizeSelectedModelOverrideForSubscription", () => {
+  it("forces free users to auto even when no override was sent", () => {
+    expect(normalizeSelectedModelOverrideForSubscription(null, "free")).toBe(
+      "auto",
+    );
+    expect(
+      normalizeSelectedModelOverrideForSubscription(undefined, "free"),
+    ).toBe("auto");
+  });
+
+  it("preserves missing paid overrides as undefined", () => {
+    expect(
+      normalizeSelectedModelOverrideForSubscription(undefined, "pro"),
+    ).toBeUndefined();
+    expect(
+      normalizeSelectedModelOverrideForSubscription(null, "ultra"),
+    ).toBeUndefined();
+  });
+
+  it("preserves explicit paid overrides", () => {
+    expect(
+      normalizeSelectedModelOverrideForSubscription("hackerai-max", "team"),
+    ).toBe("hackerai-max");
   });
 });

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -97,6 +97,14 @@ export function normalizeSelectedModelForSubscription(
   return model ?? "auto";
 }
 
+export function normalizeSelectedModelOverrideForSubscription(
+  model: SelectedModel | null | undefined,
+  subscription: SubscriptionTier,
+): SelectedModel | undefined {
+  if (subscription === "free") return "auto";
+  return model ?? undefined;
+}
+
 export interface SidebarFile {
   path: string;
   content: string;

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -89,6 +89,14 @@ export function isSubscriptionTier(value: unknown): value is SubscriptionTier {
   );
 }
 
+export function normalizeSelectedModelForSubscription(
+  model: SelectedModel | null | undefined,
+  subscription: SubscriptionTier,
+): SelectedModel {
+  if (subscription === "free") return "auto";
+  return model ?? "auto";
+}
+
 export interface SidebarFile {
   path: string;
   content: string;


### PR DESCRIPTION
## Summary
- Normalize selected model overrides to auto for free users at chat/agent-long server ingress.
- Prevent stale paid model state from being sent by client chat flows or displayed as selected for free users.
- Coerce Convex chat model preferences back to auto for free users and cover the free Agent gate with tests.

## Tests
- pnpm test -- types/__tests__/chat.test.ts lib/api/__tests__/chat-stream-helpers-free-gates.test.ts app/components/ModelSelector/__tests__/ModelSelector.test.tsx lib/chat/__tests__/chat-processor.test.ts app/hooks/__tests__/useAutoContinue.test.ts app/components/__tests__/RemoteControlTab.test.tsx
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- pre-commit: pnpm typecheck && pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Free-tier users now consistently see and use automatic model selection across the model picker, chat UI, and related API flows.
  * Subscription-aware model normalization is applied when sending, retrying, regenerating, and streaming chat requests.
  * Free agent mode now enforces only the sandbox requirement (local vs cloud), with consistent forbidden behavior when violated.

* **Tests**
  * Added/extended coverage for free-tier model normalization and free-agent sandbox gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->