### PR TITLE
Fix agent attachment upload handshake timeouts

### DIFF
--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -185,7 +185,13 @@ export const createTools = (
   const tools = buildTools();
 
   const getSandbox = () => sandbox;
-  const ensureSandbox = async () => {
+  const ensureSandbox = async (options?: {
+    refresh?: boolean;
+    reason?: string;
+  }) => {
+    if (options?.refresh) {
+      await sandboxManager.resetSandbox?.(options.reason);
+    }
     const { sandbox: ensured } = await sandboxManager.getSandbox();
     return ensured;
   };

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -591,6 +591,35 @@ export class HybridSandboxManager implements SandboxManager {
     this.setSandboxCallback(sandbox);
   }
 
+  async resetSandbox(reason?: string): Promise<void> {
+    const sandbox = this.sandbox;
+    this.sandbox = null;
+    this.isLocal = false;
+    this.currentConnectionId = null;
+    this.currentConnectionName = null;
+
+    if (!sandbox) return;
+
+    if (sandbox instanceof CentrifugoSandbox) {
+      await sandbox.close().catch((error) => {
+        console.warn(
+          `[${this.userID}] Failed to close local sandbox during reset${reason ? ` (${reason})` : ""}:`,
+          error,
+        );
+      });
+      return;
+    }
+
+    try {
+      await sandbox.kill();
+    } catch (error) {
+      console.warn(
+        `[${this.userID}] Failed to kill E2B sandbox during reset${reason ? ` (${reason})` : ""}:`,
+        error,
+      );
+    }
+  }
+
   /**
    * Get expected sandbox context for the system prompt based on preference
    * without initializing the sandbox. Returns null for E2B (uses default prompt).

--- a/lib/ai/tools/utils/sandbox-manager.ts
+++ b/lib/ai/tools/utils/sandbox-manager.ts
@@ -84,4 +84,19 @@ export class DefaultSandboxManager implements SandboxManager {
     this.sandbox = sandbox;
     this.setSandboxCallback(sandbox);
   }
+
+  async resetSandbox(reason?: string): Promise<void> {
+    const sandbox = this.sandbox;
+    this.sandbox = null;
+    if (!sandbox) return;
+
+    try {
+      await sandbox.kill();
+    } catch (error) {
+      console.warn(
+        `[${this.userID}] Failed to kill sandbox during reset${reason ? ` (${reason})` : ""}:`,
+        error,
+      );
+    }
+  }
 }

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -19,6 +19,7 @@ import type {
   SandboxPreference,
   SelectedModel,
   RateLimitInfo,
+  SandboxBootInfo,
 } from "@/types";
 import {
   coerceSelectedModel,
@@ -90,6 +91,7 @@ import { processChatMessages, selectModel } from "@/lib/chat/chat-processor";
 import { summarizeIncompleteToolParts } from "@/lib/chat/tool-abort-utils";
 import { createTrackedProvider } from "@/lib/ai/providers";
 import {
+  getSandboxUploadFailureMetadata,
   uploadSandboxFiles,
   getUploadBasePath,
   rewriteSandboxFilePathsInMessages,
@@ -412,6 +414,7 @@ export const createChatHandler = () => {
               rateLimitInfo,
             });
 
+            let uploadSandboxBootPath: SandboxBootInfo["path"] | null = null;
             const {
               tools,
               getSandbox,
@@ -446,7 +449,10 @@ export const createChatHandler = () => {
                 chatLogger?.getBuilder().addToolCost(costDollars);
               },
               subscription,
-              (info) => chatLogger?.setSandboxBoot(info),
+              (info) => {
+                uploadSandboxBootPath ??= info.path;
+                chatLogger?.setSandboxBoot(info);
+              },
               (info) => chatLogger?.setCaidoReady(info),
               selectedModel,
             );
@@ -508,6 +514,10 @@ export const createChatHandler = () => {
                 uploadResult = await uploadSandboxFiles(
                   sandboxFiles,
                   ensureSandbox,
+                  {
+                    retryWithFreshSandboxOnTransientFailure: () =>
+                      uploadSandboxBootPath === "reuse_existing",
+                  },
                 );
               } finally {
                 writeUploadCompleteStatus(writer);
@@ -518,6 +528,7 @@ export const createChatHandler = () => {
                 const uploadError = new ChatSDKError(
                   "bad_request:stream",
                   `Failed to upload ${uploadResult.failedCount} ${noun} to the computer. Please try again.`,
+                  getSandboxUploadFailureMetadata(uploadResult),
                 );
                 // Errors thrown from execute are caught by createUIMessageStream's
                 // onError and never reach the outer catch, so refund / timeout

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -170,6 +170,12 @@ const COMPACT_CHAT_ERROR_METADATA_KEYS = [
   "providerErrorCategory",
   "providerStatusCode",
   "providerErrorRetriable",
+  "upload_failure_kind",
+  "upload_failure_cause",
+  "upload_failure_transient_sandbox_command",
+  "upload_failure_protocol",
+  "upload_failure_url_length",
+  "upload_retried_with_fresh_sandbox",
 ] as const;
 
 const compactChatErrorMetadata = (

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -264,6 +264,7 @@ describe("desktop-local sandbox file helpers", () => {
   });
 
   it("retries transient E2B command-channel handshake timeouts", async () => {
+    jest.useFakeTimers();
     const consoleWarnSpy = jest
       .spyOn(console, "warn")
       .mockImplementation(() => {});
@@ -278,7 +279,7 @@ describe("desktop-local sandbox file helpers", () => {
       .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
 
     try {
-      const result = await uploadSandboxFiles(
+      const pendingResult = uploadSandboxFiles(
         [
           {
             kind: "url",
@@ -290,15 +291,19 @@ describe("desktop-local sandbox file helpers", () => {
           commands: { run },
         }),
       );
+      await jest.advanceTimersByTimeAsync(5_000);
+      const result = await pendingResult;
 
       expect(result).toEqual({ failedCount: 0, pathRewrites: [] });
       expect(run).toHaveBeenCalledTimes(3);
     } finally {
+      jest.useRealTimers();
       consoleWarnSpy.mockRestore();
     }
   });
 
   it("refreshes the sandbox once after exhausted transient upload command failures", async () => {
+    jest.useFakeTimers();
     const consoleWarnSpy = jest
       .spyOn(console, "warn")
       .mockImplementation(() => {});
@@ -318,7 +323,7 @@ describe("desktop-local sandbox file helpers", () => {
     }));
 
     try {
-      const result = await uploadSandboxFiles(
+      const pendingResult = uploadSandboxFiles(
         [
           {
             kind: "url",
@@ -329,6 +334,8 @@ describe("desktop-local sandbox file helpers", () => {
         ensureSandbox,
         { retryWithFreshSandboxOnTransientFailure: true },
       );
+      await jest.advanceTimersByTimeAsync(5_000);
+      const result = await pendingResult;
 
       expect(result).toEqual({
         failedCount: 0,
@@ -343,12 +350,14 @@ describe("desktop-local sandbox file helpers", () => {
         reason: "attachment_staging_transient_command_failure",
       });
     } finally {
+      jest.useRealTimers();
       consoleWarnSpy.mockRestore();
       consoleErrorSpy.mockRestore();
     }
   });
 
   it("returns redacted metadata for transient upload command failures", async () => {
+    jest.useFakeTimers();
     const consoleWarnSpy = jest
       .spyOn(console, "warn")
       .mockImplementation(() => {});
@@ -362,7 +371,7 @@ describe("desktop-local sandbox file helpers", () => {
       );
 
     try {
-      const result = await uploadSandboxFiles(
+      const pendingResult = uploadSandboxFiles(
         [
           {
             kind: "url",
@@ -374,6 +383,8 @@ describe("desktop-local sandbox file helpers", () => {
           commands: { run },
         }),
       );
+      await jest.advanceTimersByTimeAsync(5_000);
+      const result = await pendingResult;
 
       expect(result.failedCount).toBe(1);
       expect(getSandboxUploadFailureMetadata(result)).toMatchObject({
@@ -385,7 +396,51 @@ describe("desktop-local sandbox file helpers", () => {
         String(getSandboxUploadFailureMetadata(result)?.upload_failure_cause),
       ).toContain("Request handshake timed out");
     } finally {
+      jest.useRealTimers();
       consoleWarnSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("does not refresh the sandbox for wrapped curl download timeouts", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const run = jest.fn(async (command: string) => {
+      if (command.includes("df -h /home/user")) {
+        return {
+          exitCode: 0,
+          stdout: "Filesystem Size Used Avail Use% Mounted on\n",
+          stderr: "",
+        };
+      }
+
+      return { exitCode: 28, stdout: "", stderr: "curl: (28) ETIMEDOUT" };
+    });
+    const ensureSandbox = jest.fn(async () => ({
+      commands: { run },
+    }));
+
+    try {
+      const result = await uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "https://example.com/screenshot.png",
+            localPath: "/home/user/upload/screenshot.png",
+          },
+        ],
+        ensureSandbox,
+        { retryWithFreshSandboxOnTransientFailure: true },
+      );
+
+      expect(result.failedCount).toBe(1);
+      expect(ensureSandbox).toHaveBeenCalledTimes(1);
+      expect(getSandboxUploadFailureMetadata(result)).toMatchObject({
+        upload_failure_kind: "url",
+        upload_failure_transient_sandbox_command: false,
+      });
+    } finally {
       consoleErrorSpy.mockRestore();
     }
   });

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -2,6 +2,7 @@ jest.mock("server-only", () => ({}), { virtual: true });
 
 import type { UIMessage } from "ai";
 import {
+  getSandboxUploadFailureMetadata,
   prepareLocalDesktopAttachmentsForTrigger,
   rewriteSandboxFilePathsInMessages,
   stripLocalDesktopSourcePaths,
@@ -259,6 +260,133 @@ describe("desktop-local sandbox file helpers", () => {
       expect(fallbackCurlAttempts).toHaveLength(1);
     } finally {
       consoleWarnSpy.mockRestore();
+    }
+  });
+
+  it("retries transient E2B command-channel handshake timeouts", async () => {
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const run = jest
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("2: [unknown] Request handshake timed out after 60000ms"),
+      )
+      .mockRejectedValueOnce(
+        new Error("2: [unknown] Request handshake timed out after 60000ms"),
+      )
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
+
+    try {
+      const result = await uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "https://example.com/screenshot.png",
+            localPath: "/home/user/upload/screenshot.png",
+          },
+        ],
+        async () => ({
+          commands: { run },
+        }),
+      );
+
+      expect(result).toEqual({ failedCount: 0, pathRewrites: [] });
+      expect(run).toHaveBeenCalledTimes(3);
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
+  it("refreshes the sandbox once after exhausted transient upload command failures", async () => {
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const firstRun = jest
+      .fn()
+      .mockRejectedValue(
+        new Error("2: [unknown] Request handshake timed out after 60000ms"),
+      );
+    const refreshedRun = jest
+      .fn()
+      .mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const ensureSandbox = jest.fn(async (options?: { refresh?: boolean }) => ({
+      commands: { run: options?.refresh ? refreshedRun : firstRun },
+    }));
+
+    try {
+      const result = await uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "https://example.com/screenshot.png",
+            localPath: "/home/user/upload/screenshot.png",
+          },
+        ],
+        ensureSandbox,
+        { retryWithFreshSandboxOnTransientFailure: true },
+      );
+
+      expect(result).toEqual({
+        failedCount: 0,
+        pathRewrites: [],
+        retriedWithFreshSandbox: true,
+      });
+      expect(firstRun).toHaveBeenCalledTimes(3);
+      expect(refreshedRun).toHaveBeenCalledTimes(1);
+      expect(ensureSandbox).toHaveBeenCalledTimes(2);
+      expect(ensureSandbox.mock.calls[1][0]).toMatchObject({
+        refresh: true,
+        reason: "attachment_staging_transient_command_failure",
+      });
+    } finally {
+      consoleWarnSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("returns redacted metadata for transient upload command failures", async () => {
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const run = jest
+      .fn()
+      .mockRejectedValue(
+        new Error("2: [unknown] Request handshake timed out after 60000ms"),
+      );
+
+    try {
+      const result = await uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "https://example.com/screenshot.png?X-Amz-Signature=secret",
+            localPath: "/home/user/upload/screenshot.png",
+          },
+        ],
+        async () => ({
+          commands: { run },
+        }),
+      );
+
+      expect(result.failedCount).toBe(1);
+      expect(getSandboxUploadFailureMetadata(result)).toMatchObject({
+        upload_failure_kind: "url",
+        upload_failure_transient_sandbox_command: true,
+        upload_failure_protocol: "https",
+      });
+      expect(
+        String(getSandboxUploadFailureMetadata(result)?.upload_failure_cause),
+      ).toContain("Request handshake timed out");
+    } finally {
+      consoleWarnSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
     }
   });
 

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -103,15 +103,20 @@ const commandErrorToResult = (error: unknown): SandboxCommandResult | null => {
 };
 
 const TRANSIENT_SANDBOX_COMMAND_ERROR_PATTERN =
-  /request handshake timed out|handshake timed out after \d+ms|connection reset|socket hang up|ECONNRESET|ETIMEDOUT/i;
+  /\b(?:request handshake timed out(?: after \d+ms)?|sandbox command(?: request| channel| transport)? timed out|command (?:channel|transport) timed out)\b/i;
+const WRAPPED_FILE_TRANSFER_ERROR_PATTERN =
+  /\bfailed to (?:download|copy) file:|curl:\s*\(|\bexitCode:\s*\d+\b/i;
 const SANDBOX_COMMAND_MAX_ATTEMPTS = 3;
 const SANDBOX_COMMAND_RETRY_BASE_DELAY_MS = 750;
 
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
-const isTransientSandboxCommandError = (error: unknown): boolean =>
-  TRANSIENT_SANDBOX_COMMAND_ERROR_PATTERN.test(errorMessage(error));
+const isTransientSandboxCommandError = (error: unknown): boolean => {
+  const message = errorMessage(error);
+  if (WRAPPED_FILE_TRANSFER_ERROR_PATTERN.test(message)) return false;
+  return TRANSIENT_SANDBOX_COMMAND_ERROR_PATTERN.test(message);
+};
 
 const delay = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -26,6 +26,8 @@ export type SandboxFilePathRewrite = {
 type SandboxUploadResult = {
   failedCount: number;
   pathRewrites: SandboxFilePathRewrite[];
+  failureDetails?: SandboxUploadFailureDetail[];
+  retriedWithFreshSandbox?: boolean;
 };
 
 type SandboxCommandResult = {
@@ -34,6 +36,29 @@ type SandboxCommandResult = {
   exitCode: number;
   error?: string;
 };
+
+type SandboxUploadFailureDetail = {
+  kind: SandboxFile["kind"];
+  localPath: string;
+  error: string;
+  transientSandboxCommand: boolean;
+  url?: string;
+  urlLength?: number;
+  protocol?: string;
+};
+
+type SandboxRefreshOptions = {
+  refresh?: boolean;
+  reason?: string;
+};
+
+type EnsureSandboxForUpload = (options?: SandboxRefreshOptions) => Promise<any>;
+
+type UploadSandboxFilesOptions = {
+  retryWithFreshSandboxOnTransientFailure?: boolean | (() => boolean);
+};
+
+const MAX_UPLOAD_FAILURE_CAUSE_LENGTH = 1000;
 
 const logLocalAttachmentDebug = (
   event: string,
@@ -77,22 +102,51 @@ const commandErrorToResult = (error: unknown): SandboxCommandResult | null => {
   };
 };
 
+const TRANSIENT_SANDBOX_COMMAND_ERROR_PATTERN =
+  /request handshake timed out|handshake timed out after \d+ms|connection reset|socket hang up|ECONNRESET|ETIMEDOUT/i;
+const SANDBOX_COMMAND_MAX_ATTEMPTS = 3;
+const SANDBOX_COMMAND_RETRY_BASE_DELAY_MS = 750;
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const isTransientSandboxCommandError = (error: unknown): boolean =>
+  TRANSIENT_SANDBOX_COMMAND_ERROR_PATTERN.test(errorMessage(error));
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 const runSandboxCommand = async (
   sandbox: any,
   command: string,
 ): Promise<SandboxCommandResult> => {
-  try {
-    const result = await sandbox.commands.run(command);
-    return {
-      stdout: result?.stdout ?? "",
-      stderr: result?.stderr ?? "",
-      exitCode: typeof result?.exitCode === "number" ? result.exitCode : 0,
-    };
-  } catch (error) {
-    const commandResult = commandErrorToResult(error);
-    if (commandResult) return commandResult;
-    throw error;
+  for (let attempt = 1; attempt <= SANDBOX_COMMAND_MAX_ATTEMPTS; attempt++) {
+    try {
+      const result = await sandbox.commands.run(command);
+      return {
+        stdout: result?.stdout ?? "",
+        stderr: result?.stderr ?? "",
+        exitCode: typeof result?.exitCode === "number" ? result.exitCode : 0,
+      };
+    } catch (error) {
+      const commandResult = commandErrorToResult(error);
+      if (commandResult) return commandResult;
+
+      if (
+        attempt === SANDBOX_COMMAND_MAX_ATTEMPTS ||
+        !isTransientSandboxCommandError(error)
+      ) {
+        throw error;
+      }
+
+      console.warn(
+        `[sandbox-command] transient command channel failure on attempt ${attempt}/${SANDBOX_COMMAND_MAX_ATTEMPTS}, retrying: ${errorMessage(error)}`,
+      );
+      await delay(SANDBOX_COMMAND_RETRY_BASE_DELAY_MS * attempt);
+    }
   }
+
+  throw new Error("Sandbox command failed without returning a result");
 };
 
 /**
@@ -560,43 +614,38 @@ const describeSandboxFileForLog = (file: SandboxFile) => {
   };
 };
 
-const redactSandboxUploadError = (
+const summarizeSandboxUploadFailure = (
   file: SandboxFile,
   error: unknown,
-): string => {
-  const message = error instanceof Error ? error.message : String(error);
-  if (file.kind !== "localPath") return message;
-  return message.split(file.path).join("[redacted-local-path]");
-};
+): SandboxUploadFailureDetail => {
+  const summary: SandboxUploadFailureDetail = {
+    kind: file.kind,
+    localPath: file.localPath,
+    error: redactSandboxUploadError(file, error),
+    transientSandboxCommand: isTransientSandboxCommandError(error),
+  };
 
-/**
- * Uploads files to the sandbox environment in parallel
- * - Downloads files directly from S3 URLs using curl in the sandbox
- * - Avoids Convex size limits by not piping data through mutations
- * - Returns the exact count of failed uploads; sandbox-acquisition failures
- *   count as all-files-failed since nothing can be downloaded
- */
-export const uploadSandboxFiles = async (
-  sandboxFiles: SandboxFile[],
-  ensureSandbox: () => Promise<any>,
-): Promise<SandboxUploadResult> => {
-  if (sandboxFiles.length === 0) return { failedCount: 0, pathRewrites: [] };
-
-  logLocalAttachmentDebug("sandbox-staging-start", {
-    totalCount: sandboxFiles.length,
-    localPathCount: sandboxFiles.filter((file) => file.kind === "localPath")
-      .length,
-    urlCount: sandboxFiles.filter((file) => file.kind === "url").length,
-  });
-
-  let sandbox: any;
-  try {
-    sandbox = await ensureSandbox();
-  } catch (e) {
-    console.error("Failed to acquire sandbox for upload:", e);
-    return { failedCount: sandboxFiles.length, pathRewrites: [] };
+  if (file.kind === "url") {
+    summary.url = safeUrlForLog(file.url);
+    summary.urlLength = file.url.length;
+    summary.protocol = file.url.split("://")[0];
   }
 
+  return summary;
+};
+
+const shouldRetryWithFreshSandbox = (
+  options: UploadSandboxFilesOptions | undefined,
+): boolean => {
+  const value = options?.retryWithFreshSandboxOnTransientFailure;
+  if (typeof value === "function") return value();
+  return value === true;
+};
+
+const uploadSandboxFilesOnce = async (
+  sandboxFiles: SandboxFile[],
+  sandbox: any,
+): Promise<SandboxUploadResult> => {
   const results = await Promise.allSettled(
     sandboxFiles.map((file) => stageSandboxFile(sandbox, file)),
   );
@@ -622,6 +671,135 @@ export const uploadSandboxFiles = async (
   const pathRewrites = results.flatMap((result) =>
     result.status === "fulfilled" && result.value ? [result.value] : [],
   );
+  const failureDetails = failedIndices.map((i) =>
+    summarizeSandboxUploadFailure(
+      sandboxFiles[i],
+      (results[i] as PromiseRejectedResult).reason,
+    ),
+  );
 
-  return { failedCount: failedIndices.length, pathRewrites };
+  return {
+    failedCount: failedIndices.length,
+    pathRewrites,
+    ...(failureDetails.length > 0 ? { failureDetails } : {}),
+  };
+};
+
+const hasTransientSandboxCommandFailure = (
+  result: SandboxUploadResult,
+): boolean =>
+  result.failureDetails?.some((detail) => detail.transientSandboxCommand) ??
+  false;
+
+export const getSandboxUploadFailureMetadata = (
+  result: SandboxUploadResult,
+): Record<string, unknown> | undefined => {
+  const failure = result.failureDetails?.[0];
+  if (!failure && !result.retriedWithFreshSandbox) return undefined;
+
+  const cause = failure?.error
+    ? failure.error.length > MAX_UPLOAD_FAILURE_CAUSE_LENGTH
+      ? `${failure.error.slice(0, MAX_UPLOAD_FAILURE_CAUSE_LENGTH)}...`
+      : failure.error
+    : undefined;
+
+  return {
+    ...(failure?.kind ? { upload_failure_kind: failure.kind } : {}),
+    ...(cause ? { upload_failure_cause: cause } : {}),
+    ...(failure?.transientSandboxCommand !== undefined
+      ? {
+          upload_failure_transient_sandbox_command:
+            failure.transientSandboxCommand,
+        }
+      : {}),
+    ...(failure?.protocol ? { upload_failure_protocol: failure.protocol } : {}),
+    ...(typeof failure?.urlLength === "number"
+      ? { upload_failure_url_length: failure.urlLength }
+      : {}),
+    ...(result.retriedWithFreshSandbox !== undefined
+      ? {
+          upload_retried_with_fresh_sandbox: result.retriedWithFreshSandbox,
+        }
+      : {}),
+  };
+};
+
+const redactSandboxUploadError = (
+  file: SandboxFile,
+  error: unknown,
+): string => {
+  const message = error instanceof Error ? error.message : String(error);
+  if (file.kind !== "localPath") return message;
+  return message.split(file.path).join("[redacted-local-path]");
+};
+
+/**
+ * Uploads files to the sandbox environment in parallel
+ * - Downloads files directly from S3 URLs using curl in the sandbox
+ * - Avoids Convex size limits by not piping data through mutations
+ * - Returns the exact count of failed uploads; sandbox-acquisition failures
+ *   count as all-files-failed since nothing can be downloaded
+ */
+export const uploadSandboxFiles = async (
+  sandboxFiles: SandboxFile[],
+  ensureSandbox: EnsureSandboxForUpload,
+  options?: UploadSandboxFilesOptions,
+): Promise<SandboxUploadResult> => {
+  if (sandboxFiles.length === 0) return { failedCount: 0, pathRewrites: [] };
+
+  logLocalAttachmentDebug("sandbox-staging-start", {
+    totalCount: sandboxFiles.length,
+    localPathCount: sandboxFiles.filter((file) => file.kind === "localPath")
+      .length,
+    urlCount: sandboxFiles.filter((file) => file.kind === "url").length,
+  });
+
+  let sandbox: any;
+  try {
+    sandbox = await ensureSandbox();
+  } catch (e) {
+    console.error("Failed to acquire sandbox for upload:", e);
+    return {
+      failedCount: sandboxFiles.length,
+      pathRewrites: [],
+      failureDetails: sandboxFiles.map((file) =>
+        summarizeSandboxUploadFailure(file, e),
+      ),
+    };
+  }
+
+  const firstResult = await uploadSandboxFilesOnce(sandboxFiles, sandbox);
+
+  if (
+    firstResult.failedCount > 0 &&
+    hasTransientSandboxCommandFailure(firstResult) &&
+    shouldRetryWithFreshSandbox(options)
+  ) {
+    console.warn(
+      "[sandbox-upload] transient command channel failure while staging attachments; refreshing sandbox and retrying all attachments",
+    );
+    try {
+      const refreshedSandbox = await ensureSandbox({
+        refresh: true,
+        reason: "attachment_staging_transient_command_failure",
+      });
+      const retryResult = await uploadSandboxFilesOnce(
+        sandboxFiles,
+        refreshedSandbox,
+      );
+      return { ...retryResult, retriedWithFreshSandbox: true };
+    } catch (error) {
+      console.error("Failed to refresh sandbox for upload retry:", error);
+      return {
+        failedCount: sandboxFiles.length,
+        pathRewrites: [],
+        failureDetails: sandboxFiles.map((file) =>
+          summarizeSandboxUploadFailure(file, error),
+        ),
+        retriedWithFreshSandbox: true,
+      };
+    }
+  }
+
+  return firstResult;
 };

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -69,6 +69,7 @@ import {
   writeUploadCompleteStatus,
 } from "@/lib/utils/stream-writer-utils";
 import {
+  getSandboxUploadFailureMetadata,
   uploadSandboxFiles,
   getUploadBasePath,
   rewriteSandboxFilePathsInMessages,
@@ -98,6 +99,7 @@ import type {
   SandboxPreference,
   SelectedModel,
   RateLimitInfo,
+  SandboxBootInfo,
 } from "@/types";
 import {
   createAgentStream,
@@ -157,6 +159,14 @@ const getNumberMetadata = (
 ) => {
   const value = metadata?.[key];
   return typeof value === "number" ? value : undefined;
+};
+
+const getBooleanMetadata = (
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+) => {
+  const value = metadata?.[key];
+  return typeof value === "boolean" ? value : undefined;
 };
 
 type TriggerMetadataPrimitive = boolean | number | string;
@@ -294,6 +304,12 @@ type AgentLongErrorSummary = {
   largestFileToken?: number;
   emptyAfterProcessing?: boolean;
   emptyAfterProcessingMetadata?: Record<string, TriggerMetadataPrimitive>;
+  uploadFailureKind?: string;
+  uploadFailureCause?: string;
+  uploadFailureTransientSandboxCommand?: boolean;
+  uploadFailureProtocol?: string;
+  uploadFailureUrlLength?: number;
+  uploadRetriedWithFreshSandbox?: boolean;
 };
 
 const isHandledUserRateLimitError = (error: unknown): error is ChatSDKError => {
@@ -426,6 +442,30 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
         errorMetadata?.empty_after_processing === true || undefined,
       emptyAfterProcessingMetadata:
         getEmptyAfterProcessingTriggerMetadata(errorMetadata),
+      uploadFailureKind: getStringMetadata(
+        errorMetadata,
+        "upload_failure_kind",
+      ),
+      uploadFailureCause: getStringMetadata(
+        errorMetadata,
+        "upload_failure_cause",
+      ),
+      uploadFailureTransientSandboxCommand: getBooleanMetadata(
+        errorMetadata,
+        "upload_failure_transient_sandbox_command",
+      ),
+      uploadFailureProtocol: getStringMetadata(
+        errorMetadata,
+        "upload_failure_protocol",
+      ),
+      uploadFailureUrlLength: getNumberMetadata(
+        errorMetadata,
+        "upload_failure_url_length",
+      ),
+      uploadRetriedWithFreshSandbox: getBooleanMetadata(
+        errorMetadata,
+        "upload_retried_with_fresh_sandbox",
+      ),
     };
   }
 
@@ -532,6 +572,26 @@ const recordAgentLongFailureForDashboard = async (
     )) {
       metadata.set(key, value);
     }
+  }
+  if (summary.uploadFailureKind)
+    metadata.set("uploadFailureKind", summary.uploadFailureKind);
+  if (summary.uploadFailureCause)
+    metadata.set("uploadFailureCause", summary.uploadFailureCause);
+  if (summary.uploadFailureTransientSandboxCommand != null) {
+    metadata.set(
+      "uploadFailureTransientSandboxCommand",
+      summary.uploadFailureTransientSandboxCommand,
+    );
+  }
+  if (summary.uploadFailureProtocol)
+    metadata.set("uploadFailureProtocol", summary.uploadFailureProtocol);
+  if (summary.uploadFailureUrlLength != null)
+    metadata.set("uploadFailureUrlLength", summary.uploadFailureUrlLength);
+  if (summary.uploadRetriedWithFreshSandbox != null) {
+    metadata.set(
+      "uploadRetriedWithFreshSandbox",
+      summary.uploadRetriedWithFreshSandbox,
+    );
   }
 
   const errorTags = [`error_${summary.category}`];
@@ -1028,6 +1088,7 @@ export const agentLongTask = task({
               rateLimitInfo,
             });
 
+            let uploadSandboxBootPath: SandboxBootInfo["path"] | null = null;
             const {
               tools,
               ensureSandbox,
@@ -1059,7 +1120,10 @@ export const agentLongTask = task({
                 chatLogger?.getBuilder().addToolCost(costDollars);
               },
               subscription,
-              (info) => chatLogger?.setSandboxBoot(info),
+              (info) => {
+                uploadSandboxBootPath ??= info.path;
+                chatLogger?.setSandboxBoot(info);
+              },
               undefined,
               selectedModel,
             );
@@ -1114,6 +1178,10 @@ export const agentLongTask = task({
                 uploadResult = await uploadSandboxFiles(
                   sandboxFiles,
                   ensureSandbox,
+                  {
+                    retryWithFreshSandboxOnTransientFailure: () =>
+                      uploadSandboxBootPath === "reuse_existing",
+                  },
                 );
               } finally {
                 writeUploadCompleteStatus(writer);
@@ -1124,6 +1192,7 @@ export const agentLongTask = task({
                 const uploadError = new ChatSDKError(
                   "bad_request:stream",
                   `Failed to upload ${uploadResult.failedCount} ${noun} to the computer. Please try again.`,
+                  getSandboxUploadFailureMetadata(uploadResult),
                 );
                 await usageRefundTracker.refund();
                 chatLogger?.emitChatError(uploadError);

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -25,6 +25,7 @@ export interface SandboxInfo {
 export interface SandboxManager {
   getSandbox(): Promise<{ sandbox: AnySandbox }>;
   setSandbox(sandbox: AnySandbox): void;
+  resetSandbox?(reason?: string): Promise<void>;
   getSandboxType(toolName: string): SandboxType | undefined;
   getSandboxInfo(): SandboxInfo | null;
   // Optional: only HybridSandboxManager implements this


### PR DESCRIPTION
## Summary
- retry transient sandbox command-channel handshake timeouts while staging attachments
- retry all attachment staging once after refreshing a reused sandbox when the transient failure persists
- add redacted upload failure metadata to chat logs and Trigger run metadata

## Validation
- pnpm jest lib/utils/__tests__/sandbox-file-utils.test.ts --runInBand
- pnpm jest lib/api/__tests__/chat-logger.test.ts --runInBand
- pnpm lint (existing warnings only)
- pnpm typecheck
- pre-commit hook: pnpm typecheck && pnpm test (139 suites, 1516 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added sandbox reset support with an optional reason, enabling recovery flows.
  * Introduced optional retry of attachment staging using a fresh sandbox after transient command-channel failures.

* **Bug Fixes**
  * Improved sandbox upload retry decisioning and enhanced transient failure classification.

* **Enhanced Diagnostics**
  * Expanded structured upload-related error metadata for clearer analytics and logging.

* **Tests**
  * Added coverage for transient handshake and upload failures, including verification of fresh-sandbox retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->