### PR TITLE
Improve provider content block logging

### DIFF
--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -328,18 +328,36 @@ describe("captureUsageCost", () => {
 });
 
 describe("createChatLogger provider stream termination", () => {
-  it("logs provider safety blocks as non-retryable content blocks", () => {
+  it("logs provider safety blocks as errors with provider and model context", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const phErrorSpy = jest
+      .spyOn(phLogger, "error")
+      .mockImplementation(() => {});
 
     try {
       const chatLogger = createChatLogger({
         chatId: "chat_content_blocked",
         endpoint: "/api/chat",
       });
-      const err = Object.assign(new Error("PROHIBITED_CONTENT"), {
-        statusCode: 403,
-      });
+      const err = Object.assign(
+        new Error("Output blocked by content filtering policy"),
+        {
+          statusCode: 403,
+          responseBody: JSON.stringify({
+            id: "gen-content-blocked",
+            error: {
+              code: 403,
+              message: "Provider returned error",
+              metadata: {
+                provider_name: "Anthropic Vertex",
+                raw: "Output blocked by content filtering policy",
+              },
+            },
+          }),
+        },
+      );
 
       chatLogger.recordProviderError(err, {
         mode: "ask",
@@ -348,11 +366,31 @@ describe("createChatLogger provider stream termination", () => {
       });
       chatLogger.emitUnexpectedError(err);
 
+      const warnOutput = warnSpy.mock.calls.flat().map(String).join("\n");
       const errorOutput = errorSpy.mock.calls.flat().map(String).join("\n");
       const wideEvent = JSON.parse(String(logSpy.mock.calls[0][0]));
 
+      expect(warnOutput).not.toContain("Provider content blocked");
       expect(errorOutput).toContain("Provider content blocked");
       expect(errorOutput).toContain("provider_content_blocked");
+      expect(errorOutput).toContain('"provider_name":"Anthropic Vertex"');
+      expect(errorOutput).toContain('"configured_model":"ask-model-free"');
+      expect(errorOutput).toContain(
+        '"requested_model_slug":"deepseek/deepseek-v4-flash"',
+      );
+      expect(phErrorSpy).toHaveBeenCalledWith(
+        "Provider content blocked",
+        expect.objectContaining({
+          event: "provider_content_blocked",
+          providerErrorCategory: "content_blocked",
+          provider_name: "Anthropic Vertex",
+          provider_name_source: "openrouter_error_metadata",
+          configured_model: "ask-model-free",
+          requested_model_slug: "deepseek/deepseek-v4-flash",
+          model_provider_slug: "deepseek",
+          openrouter_generation_id: "gen-content-blocked",
+        }),
+      );
       expect(wideEvent.error).toMatchObject({
         type: "ProviderContentBlocked",
         retriable: false,
@@ -361,10 +399,18 @@ describe("createChatLogger provider stream termination", () => {
         category: "content_blocked",
         status_code: 403,
         retriable: false,
+        provider_name: "Anthropic Vertex",
+        provider_name_source: "openrouter_error_metadata",
+        configured_model: "ask-model-free",
+        requested_model_slug: "deepseek/deepseek-v4-flash",
+        model_provider_slug: "deepseek",
+        openrouter_generation_id: "gen-content-blocked",
       });
     } finally {
+      warnSpy.mockRestore();
       errorSpy.mockRestore();
       logSpy.mockRestore();
+      phErrorSpy.mockRestore();
     }
   });
 

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -242,6 +242,16 @@ const isRetriableProviderCategory = (
   category === "stream_terminated" ||
   category === "timeout";
 
+const shouldCaptureProviderException = (
+  category: ProviderErrorCategory,
+): boolean => category !== "stream_terminated" && category !== "timeout";
+
+const nonEmptyString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+const getModelProviderSlug = (modelSlug: string | undefined) =>
+  modelSlug?.includes("/") ? modelSlug.split("/", 1)[0] : undefined;
+
 /**
  * Creates a chat logger instance for tracking wide events
  */
@@ -454,6 +464,29 @@ export function createChatLogger(config: ChatLoggerConfig) {
       const attempts = extractRetryAttempts(error);
       const category = getProviderErrorCategory(details);
       const providerStatusCode = getProviderStatusCode(details);
+      const providerName = nonEmptyString(details.providerName);
+      const configuredModel =
+        nonEmptyString(providerContext.model) ??
+        nonEmptyString(providerRequest?.model);
+      const requestedModelSlug =
+        nonEmptyString(providerContext.requestedModelSlug) ??
+        nonEmptyString(providerRequest?.requested_model_slug);
+      const modelProviderSlug = getModelProviderSlug(requestedModelSlug);
+      const openrouterGenerationId = nonEmptyString(
+        details.openrouterGenerationId,
+      );
+      const normalizedProviderContext = {
+        ...(providerName && {
+          provider_name: providerName,
+          provider_name_source: "openrouter_error_metadata",
+        }),
+        ...(configuredModel && { configured_model: configuredModel }),
+        ...(requestedModelSlug && { requested_model_slug: requestedModelSlug }),
+        ...(modelProviderSlug && { model_provider_slug: modelProviderSlug }),
+        ...(openrouterGenerationId && {
+          openrouter_generation_id: openrouterGenerationId,
+        }),
+      };
       lastProviderErrorCategory = category;
       lastProviderErrorStatusCode = providerStatusCode;
 
@@ -464,11 +497,12 @@ export function createChatLogger(config: ChatLoggerConfig) {
         provider_error_category: category,
         ...providerContext,
         ...details,
+        ...normalizedProviderContext,
         ...(attempts && { provider_attempts: attempts }),
         ...(providerRequest && { provider_request: providerRequest }),
       };
 
-      if (category === "stream_terminated" || category === "timeout") {
+      if (!shouldCaptureProviderException(category)) {
         logger.warn(providerErrorMessage(category), logContext);
       } else {
         logger.error(
@@ -485,11 +519,12 @@ export function createChatLogger(config: ChatLoggerConfig) {
         providerErrorCategory: category,
         ...providerContext,
         ...details,
+        ...normalizedProviderContext,
         ...(attempts && { provider_attempts: attempts }),
         ...(providerRequest && { provider_request: providerRequest }),
       };
 
-      if (category === "stream_terminated" || category === "timeout") {
+      if (!shouldCaptureProviderException(category)) {
         phLogger.warn(providerErrorMessage(category), phContext);
       } else {
         phLogger.error(providerErrorMessage(category), {
@@ -508,6 +543,14 @@ export function createChatLogger(config: ChatLoggerConfig) {
           typeof details.isRetryable === "boolean"
             ? details.isRetryable
             : isRetriableProviderCategory(category),
+        providerName,
+        providerNameSource: providerName
+          ? "openrouter_error_metadata"
+          : undefined,
+        configuredModel,
+        requestedModelSlug,
+        modelProviderSlug,
+        openrouterGenerationId,
         attempts,
       });
     },

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -228,6 +228,12 @@ export interface ChatWideEvent {
     reason?: string;
     message?: string;
     retriable?: boolean;
+    provider_name?: string;
+    provider_name_source?: string;
+    configured_model?: string;
+    requested_model_slug?: string;
+    model_provider_slug?: string;
+    openrouter_generation_id?: string;
     // Per-attempt breakdown when the SDK retried internally. Each entry is one
     // upstream call. Lets you tell consistent-500 from a mixed cascade and
     // gives you provider request IDs to file support tickets with.
@@ -236,6 +242,7 @@ export interface ChatWideEvent {
       message: string;
       error_name?: string;
       request_id?: string;
+      provider_name?: string;
     }>;
   };
 }
@@ -618,6 +625,12 @@ export class WideEventBuilder {
     reason?: string;
     message?: string;
     retriable?: boolean;
+    providerName?: string;
+    providerNameSource?: string;
+    configuredModel?: string;
+    requestedModelSlug?: string;
+    modelProviderSlug?: string;
+    openrouterGenerationId?: string;
     attempts?: NonNullable<ChatWideEvent["provider_error"]>["attempts"];
   }): this {
     this.event.had_provider_error = true;
@@ -628,6 +641,12 @@ export class WideEventBuilder {
       reason: details.reason,
       message: details.message,
       retriable: details.retriable,
+      provider_name: details.providerName,
+      provider_name_source: details.providerNameSource,
+      configured_model: details.configuredModel,
+      requested_model_slug: details.requestedModelSlug,
+      model_provider_slug: details.modelProviderSlug,
+      openrouter_generation_id: details.openrouterGenerationId,
       attempts: details.attempts,
     };
     return this;

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -400,6 +400,18 @@ describe("provider error classification", () => {
     expect(isProviderContentBlockedError(err)).toBe(true);
   });
 
+  it("classifies output blocks from content filtering policy", () => {
+    const err = apiCallError({
+      statusCode: 403,
+      message: "Output blocked by content filtering policy",
+    });
+
+    expect(getProviderErrorCategory(extractErrorDetails(err))).toBe(
+      "content_blocked",
+    );
+    expect(isProviderContentBlockedError(err)).toBe(true);
+  });
+
   it("does not classify moderation service failures as content blocks", () => {
     const err = apiCallError({
       statusCode: 503,

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -365,7 +365,7 @@ const getProviderMessageText = (details: Record<string, unknown>): string => {
 };
 
 const PROVIDER_CONTENT_BLOCK_PATTERN =
-  /\bPROHIBITED_CONTENT\b|\b(?:content[_ -]?(?:filter|policy)|safety policy|moderation policy|safety system|moderation system)\b.{0,80}\b(?:block(?:ed)?|flag(?:ged)?|reject(?:ed)?|prohibit(?:ed)?|violate(?:s|d|ion)?|unsafe|harmful)\b|\b(?:block(?:ed)?|flag(?:ged)?|reject(?:ed)?|prohibit(?:ed)?|violate(?:s|d|ion)?|unsafe|harmful)\b.{0,80}\b(?:content[_ -]?(?:filter|policy)|safety policy|moderation policy|safety system|moderation system)\b|\bblocked by (?:the )?(?:provider )?(?:safety|moderation)(?: system| filter)?\b|\b(?:unsafe|harmful) content\b/i;
+  /\bPROHIBITED_CONTENT\b|\b(?:content[_ -]?(?:filter(?:ing)?|policy)|safety policy|moderation policy|safety system|moderation system)\b.{0,80}\b(?:block(?:ed)?|flag(?:ged)?|reject(?:ed)?|prohibit(?:ed)?|violate(?:s|d|ion)?|unsafe|harmful)\b|\b(?:block(?:ed)?|flag(?:ged)?|reject(?:ed)?|prohibit(?:ed)?|violate(?:s|d|ion)?|unsafe|harmful)\b.{0,80}\b(?:content[_ -]?(?:filter(?:ing)?|policy)|safety policy|moderation policy|safety system|moderation system)\b|\bblocked by (?:the )?(?:provider )?(?:safety|moderation)(?: system| filter)?\b|\b(?:unsafe|harmful) content\b/i;
 
 export const isProviderContentBlockedDetails = (
   details: Record<string, unknown>,


### PR DESCRIPTION
## Summary
- classify `Output blocked by content filtering policy` as `content_blocked`
- keep provider content blocks at error severity while preserving timeout/terminated streams as warnings
- add normalized provider/model fields to provider error logs and wide events

## Validation
- pnpm test -- lib/api/__tests__/chat-logger.test.ts lib/utils/__tests__/error-utils.test.ts --runInBand
- pnpm typecheck
- pre-commit hook: pnpm typecheck and full pnpm test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of content filtering errors by expanding pattern matching to include filtering variants.

* **Chores**
  * Enhanced provider error telemetry with additional context including provider name, model, and request identifiers.
  * Expanded test coverage for content blocking error classification and provider error logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->