### PR TITLE
Harden agent image retry and cleanup races

### DIFF
--- a/app/api/delete-sandboxes/__tests__/route.test.ts
+++ b/app/api/delete-sandboxes/__tests__/route.test.ts
@@ -1,0 +1,109 @@
+import { Sandbox } from "@e2b/code-interpreter";
+import { getUserIDAndPro } from "@/lib/auth/get-user-id";
+import { POST } from "../route";
+
+jest.mock("@e2b/code-interpreter", () => ({
+  Sandbox: {
+    list: jest.fn(),
+    kill: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/auth/get-user-id", () => ({
+  getUserIDAndPro: jest.fn(),
+}));
+
+const mockSandboxList = Sandbox.list as jest.MockedFunction<
+  typeof Sandbox.list
+>;
+const mockSandboxKill = Sandbox.kill as jest.MockedFunction<
+  typeof Sandbox.kill
+>;
+const mockGetUserIDAndPro = getUserIDAndPro as jest.MockedFunction<
+  typeof getUserIDAndPro
+>;
+
+const mockSandboxes = (sandboxIds: string[]) => {
+  mockSandboxList.mockReturnValue({
+    nextItems: jest
+      .fn()
+      .mockResolvedValue(sandboxIds.map((sandboxId) => ({ sandboxId }))),
+  } as never);
+};
+
+describe("POST /api/delete-sandboxes", () => {
+  let debugSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    global.Response = class TestResponse {
+      status: number;
+      private body: string;
+
+      constructor(body: string, init?: ResponseInit) {
+        this.body = body;
+        this.status = init?.status ?? 200;
+      }
+
+      async json() {
+        return JSON.parse(this.body);
+      }
+    } as unknown as typeof Response;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockGetUserIDAndPro.mockResolvedValue({
+      userId: "user_123",
+      subscription: "pro",
+    } as never);
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("treats already-gone sandbox kills as successful delete progress", async () => {
+    mockSandboxes(["sbx_live", "sbx_missing"]);
+    mockSandboxKill
+      .mockResolvedValueOnce(undefined as never)
+      .mockRejectedValueOnce(
+        Object.assign(new Error("sandbox not_found"), { status: 404 }),
+      );
+
+    const response = await POST({} as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      total: 2,
+      killed: 1,
+      alreadyGone: 1,
+    });
+    expect(mockSandboxKill).toHaveBeenCalledWith("sbx_live");
+    expect(mockSandboxKill).toHaveBeenCalledWith("sbx_missing");
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("Failed to kill sandbox"),
+      expect.anything(),
+    );
+  });
+
+  it("still fails on unexpected kill errors", async () => {
+    mockSandboxes(["sbx_denied"]);
+    mockSandboxKill.mockRejectedValueOnce(new Error("permission denied"));
+
+    const response = await POST({} as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({ error: "Failed to delete sandboxes" });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Failed to kill sandbox sbx_denied:",
+      expect.any(Error),
+    );
+  });
+});

--- a/app/api/delete-sandboxes/__tests__/route.test.ts
+++ b/app/api/delete-sandboxes/__tests__/route.test.ts
@@ -106,4 +106,21 @@ describe("POST /api/delete-sandboxes", () => {
       expect.any(Error),
     );
   });
+
+  it("does not count transport-closure failures as deleted sandboxes", async () => {
+    mockSandboxes(["sbx_unknown"]);
+    mockSandboxKill.mockRejectedValueOnce(
+      new Error("kill transport channel already closed"),
+    );
+
+    const response = await POST({} as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({ error: "Failed to delete sandboxes" });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Failed to kill sandbox sbx_unknown:",
+      expect.any(Error),
+    );
+  });
 });

--- a/app/api/delete-sandboxes/route.ts
+++ b/app/api/delete-sandboxes/route.ts
@@ -1,7 +1,7 @@
 import { Sandbox } from "@e2b/code-interpreter";
 import { getUserIDAndPro } from "@/lib/auth/get-user-id";
 import { NextRequest } from "next/server";
-import { isExpectedAlreadyGoneCleanupError } from "@/lib/utils/cleanup-errors";
+import { isExpectedMissingResourceCleanupError } from "@/lib/utils/cleanup-errors";
 
 export const maxDuration = 60;
 
@@ -44,7 +44,7 @@ export async function POST(req: NextRequest) {
         await Sandbox.kill(sandbox.sandboxId);
         killed++;
       } catch (error) {
-        if (isExpectedAlreadyGoneCleanupError(error)) {
+        if (isExpectedMissingResourceCleanupError(error)) {
           alreadyGone++;
           console.debug(
             `Sandbox ${sandbox.sandboxId} was already gone during delete`,

--- a/app/api/delete-sandboxes/route.ts
+++ b/app/api/delete-sandboxes/route.ts
@@ -1,6 +1,7 @@
 import { Sandbox } from "@e2b/code-interpreter";
 import { getUserIDAndPro } from "@/lib/auth/get-user-id";
 import { NextRequest } from "next/server";
+import { isExpectedAlreadyGoneCleanupError } from "@/lib/utils/cleanup-errors";
 
 export const maxDuration = 60;
 
@@ -34,20 +35,40 @@ export async function POST(req: NextRequest) {
 
     const sandboxes = await paginator.nextItems();
 
-    // Kill each sandbox
+    // Kill each sandbox. Treat terminal-state races as success so a refresh,
+    // auto-pause, or concurrent cleanup does not fail the whole request.
+    let killed = 0;
+    let alreadyGone = 0;
     for (const sandbox of sandboxes) {
       try {
         await Sandbox.kill(sandbox.sandboxId);
+        killed++;
       } catch (error) {
+        if (isExpectedAlreadyGoneCleanupError(error)) {
+          alreadyGone++;
+          console.debug(
+            `Sandbox ${sandbox.sandboxId} was already gone during delete`,
+            error,
+          );
+          continue;
+        }
         console.error(`Failed to kill sandbox ${sandbox.sandboxId}:`, error);
         throw error;
       }
     }
 
-    return new Response(JSON.stringify({ success: true }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({
+        success: true,
+        total: sandboxes.length,
+        killed,
+        alreadyGone,
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   } catch (error) {
     console.error("Error deleting sandboxes:", error);
     return new Response(

--- a/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
+++ b/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
@@ -181,3 +181,49 @@ describe("HybridSandboxManager browser automation prompt", () => {
     expect(context).not.toContain("command -v agent-browser");
   });
 });
+
+describe("HybridSandboxManager reset cleanup", () => {
+  let warnSpy: jest.SpyInstance;
+  let debugSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+
+  it("downgrades already-gone E2B sandbox reset failures", async () => {
+    const manager = new HybridSandboxManager(
+      "user-1",
+      jest.fn(),
+      "e2b",
+      "service-key",
+      null,
+      "pro",
+    );
+    const sandbox = {
+      kill: jest
+        .fn()
+        .mockRejectedValue(
+          Object.assign(new Error("sandbox not_found"), { status: 404 }),
+        ),
+    };
+
+    manager.setSandbox(sandbox as any);
+    await manager.resetSandbox("test");
+
+    expect(sandbox.kill).toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to kill E2B sandbox during reset"),
+      expect.any(Error),
+    );
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("Failed to kill E2B sandbox during reset"),
+      expect.anything(),
+    );
+  });
+});

--- a/lib/ai/tools/utils/__tests__/pty-session-manager.test.ts
+++ b/lib/ai/tools/utils/__tests__/pty-session-manager.test.ts
@@ -436,6 +436,44 @@ describe("PtySessionManager", () => {
       expect(manager.get("chat-a", s2.sessionId)).toBeUndefined();
       expect(manager.get("chat-b", s3.sessionId)).toBe(s3);
     });
+
+    it("treats already-gone kill failures as successful cleanup", async () => {
+      const errorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const debugSpy = jest
+        .spyOn(console, "debug")
+        .mockImplementation(() => {});
+      const handle = makeFakeHandle();
+      handle.kill.mockRejectedValueOnce(
+        Object.assign(new Error("no such process"), { code: "ESRCH" }),
+      );
+      const session = await manager.create("chat-a", {
+        createHandle: makeCreateHandleFactory(handle),
+        cols: 80,
+        rows: 24,
+      });
+
+      const closeAllPromise = manager.closeAll("chat-a");
+      await Promise.resolve();
+      await Promise.resolve();
+      jest.advanceTimersByTime(2100);
+      await closeAllPromise;
+
+      expect(handle.kill).toHaveBeenCalled();
+      expect(manager.get("chat-a", session.sessionId)).toBeUndefined();
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining("session already gone"),
+        expect.any(Error),
+      );
+      expect(errorSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("[pty-session-manager] kill failed"),
+        expect.anything(),
+      );
+
+      debugSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
   });
 
   describe("constants", () => {

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -16,6 +16,7 @@ import { getPlatformDisplayName } from "./platform-utils";
 import { generateCentrifugoToken } from "@/lib/centrifugo/jwt";
 import { sandboxConnectionChannel } from "@/lib/centrifugo/types";
 import { presenceHasConnectionId } from "@/lib/centrifugo/presence";
+import { isExpectedAlreadyGoneCleanupError } from "@/lib/utils/cleanup-errors";
 
 type SandboxInstance = Sandbox | CentrifugoSandbox;
 
@@ -292,7 +293,11 @@ export class HybridSandboxManager implements SandboxManager {
   private async closeCurrentSandbox(): Promise<void> {
     if (this.sandbox instanceof CentrifugoSandbox) {
       await this.sandbox.close().catch((err) => {
-        console.warn(`[${this.userID}] Failed to close sandbox:`, err);
+        if (isExpectedAlreadyGoneCleanupError(err)) {
+          console.debug(`[${this.userID}] Sandbox was already closed:`, err);
+        } else {
+          console.warn(`[${this.userID}] Failed to close sandbox:`, err);
+        }
       });
     }
   }
@@ -602,10 +607,12 @@ export class HybridSandboxManager implements SandboxManager {
 
     if (sandbox instanceof CentrifugoSandbox) {
       await sandbox.close().catch((error) => {
-        console.warn(
-          `[${this.userID}] Failed to close local sandbox during reset${reason ? ` (${reason})` : ""}:`,
-          error,
-        );
+        const message = `[${this.userID}] Failed to close local sandbox during reset${reason ? ` (${reason})` : ""}:`;
+        if (isExpectedAlreadyGoneCleanupError(error)) {
+          console.debug(message, error);
+        } else {
+          console.warn(message, error);
+        }
       });
       return;
     }
@@ -613,10 +620,12 @@ export class HybridSandboxManager implements SandboxManager {
     try {
       await sandbox.kill();
     } catch (error) {
-      console.warn(
-        `[${this.userID}] Failed to kill E2B sandbox during reset${reason ? ` (${reason})` : ""}:`,
-        error,
-      );
+      const message = `[${this.userID}] Failed to kill E2B sandbox during reset${reason ? ` (${reason})` : ""}:`;
+      if (isExpectedAlreadyGoneCleanupError(error)) {
+        console.debug(message, error);
+      } else {
+        console.warn(message, error);
+      }
     }
   }
 

--- a/lib/ai/tools/utils/pty-session-manager.ts
+++ b/lib/ai/tools/utils/pty-session-manager.ts
@@ -10,6 +10,7 @@
  */
 
 import type { PtyHandle } from "./e2b-pty-adapter";
+import { isExpectedAlreadyGoneCleanupError } from "@/lib/utils/cleanup-errors";
 
 export const MAX_CONCURRENT_PTYS_PER_CHAT = 10;
 export const SESSION_IDLE_TIMEOUT_MS = 10 * 60_000;
@@ -180,6 +181,13 @@ export class PtySessionManager {
       try {
         await handle.kill();
       } catch (killErr) {
+        if (isExpectedAlreadyGoneCleanupError(killErr)) {
+          console.debug(
+            "[pty-session-manager] orphan already gone pid=" + handle.pid + ":",
+            killErr,
+          );
+          throw wiringErr;
+        }
         console.error(
           "[pty-session-manager] orphan kill failed pid=" + handle.pid + ":",
           killErr,
@@ -340,10 +348,17 @@ export class PtySessionManager {
     try {
       await session.handle.kill();
     } catch (err) {
-      console.error(
-        "[pty-session-manager] kill failed pid=" + session.pid + ":",
-        err,
-      );
+      if (isExpectedAlreadyGoneCleanupError(err)) {
+        console.debug(
+          "[pty-session-manager] session already gone pid=" + session.pid + ":",
+          err,
+        );
+      } else {
+        console.error(
+          "[pty-session-manager] kill failed pid=" + session.pid + ":",
+          err,
+        );
+      }
     }
 
     await Promise.race([

--- a/lib/ai/tools/utils/sandbox-manager.ts
+++ b/lib/ai/tools/utils/sandbox-manager.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/types";
 import { ensureSandboxConnection } from "./sandbox";
 import { SANDBOX_ENVIRONMENT_TOOLS } from "./sandbox-tools";
+import { isExpectedAlreadyGoneCleanupError } from "@/lib/utils/cleanup-errors";
 
 const MAX_SANDBOX_HEALTH_FAILURES = 5;
 
@@ -93,10 +94,12 @@ export class DefaultSandboxManager implements SandboxManager {
     try {
       await sandbox.kill();
     } catch (error) {
-      console.warn(
-        `[${this.userID}] Failed to kill sandbox during reset${reason ? ` (${reason})` : ""}:`,
-        error,
-      );
+      const message = `[${this.userID}] Failed to kill sandbox during reset${reason ? ` (${reason})` : ""}:`;
+      if (isExpectedAlreadyGoneCleanupError(error)) {
+        console.debug(message, error);
+      } else {
+        console.warn(message, error);
+      }
     }
   }
 }

--- a/lib/ai/tools/utils/sandbox.ts
+++ b/lib/ai/tools/utils/sandbox.ts
@@ -1,6 +1,7 @@
 import { Sandbox } from "@e2b/code-interpreter";
 import type { SandboxBootInfo, SandboxContext } from "@/types";
 import { NotFoundError, getUserFacingE2BErrorMessage } from "./e2b-errors";
+import { isExpectedAlreadyGoneCleanupError } from "@/lib/utils/cleanup-errors";
 
 type SandboxReadyPath = SandboxBootInfo["path"];
 
@@ -10,6 +11,18 @@ const BASH_SANDBOX_AUTOPAUSE_TIMEOUT = 7 * 60 * 1000; // 7 minutes auto-pause in
 // Retry config for E2B 429 rate limits
 const RATE_LIMIT_COOLDOWN_MS = 1_000;
 const MAX_CREATE_RETRIES = 3;
+
+const logSandboxKillFailure = (
+  userID: string,
+  message: string,
+  error: unknown,
+): void => {
+  if (isExpectedAlreadyGoneCleanupError(error)) {
+    console.debug(`[${userID}] ${message}:`, error);
+  } else {
+    console.warn(`[${userID}] ${message}:`, error);
+  }
+};
 
 /**
  * Current sandbox version identifier.
@@ -86,7 +99,7 @@ export const ensureSandboxConnection = async (
       try {
         await Sandbox.kill(existingSandbox.sandboxId);
       } catch (killError) {
-        console.warn(`[${userID}] Failed to kill old sandbox:`, killError);
+        logSandboxKillFailure(userID, "Failed to kill old sandbox", killError);
       }
       createPath = "create_after_version_mismatch";
       // Skip to creating new sandbox
@@ -115,8 +128,9 @@ export const ensureSandboxConnection = async (
           try {
             await Sandbox.kill(existingSandbox.sandboxId);
           } catch (killError) {
-            console.warn(
-              `[${userID}] Failed to clean up expired sandbox:`,
+            logSandboxKillFailure(
+              userID,
+              "Failed to clean up expired sandbox",
               killError,
             );
           }
@@ -130,8 +144,9 @@ export const ensureSandboxConnection = async (
           try {
             await Sandbox.kill(existingSandbox.sandboxId);
           } catch (killError) {
-            console.warn(
-              `[${userID}] Failed to clean up broken sandbox:`,
+            logSandboxKillFailure(
+              userID,
+              "Failed to clean up broken sandbox",
               killError,
             );
           }

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -252,8 +252,12 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       "hasTerminalProviderStreamError:",
       retryDecisionIdx,
     );
+    const retryModelIdx = taskSrc.indexOf(
+      "const retryModel = shouldRetryWithoutImageToolResults",
+      terminalProviderErrorIdx,
+    );
     const fallbackIdx = taskSrc.indexOf(
-      "const retryResult = await createStream(fallbackModel)",
+      "const retryResult = await createStream(retryModel)",
       terminalProviderErrorIdx,
     );
 
@@ -261,7 +265,8 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(partsIdx).toBeGreaterThan(helperImportIdx);
     expect(retryDecisionIdx).toBeGreaterThan(partsIdx);
     expect(terminalProviderErrorIdx).toBeGreaterThan(retryDecisionIdx);
-    expect(fallbackIdx).toBeGreaterThan(terminalProviderErrorIdx);
+    expect(retryModelIdx).toBeGreaterThan(terminalProviderErrorIdx);
+    expect(fallbackIdx).toBeGreaterThan(retryModelIdx);
   });
 
   test("outer catch checks live usage tracker before refunding", () => {

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -51,6 +51,11 @@ import {
   pruneToolOutputs,
   pruneModelMessages,
 } from "@/lib/chat/compaction/prune-tool-outputs";
+import {
+  isProviderMultimodalToolResultRejectionError,
+  toolResultsContainImageViewResult,
+  uiMessagesContainImageViewResult,
+} from "@/lib/chat/multimodal-tool-result-recovery";
 import { isAnthropicModel } from "@/lib/ai/providers";
 import {
   FREE_MAX_OUTPUT_TOKENS,
@@ -94,6 +99,8 @@ export type AgentStreamState = {
   responseModel: string | undefined;
   /** Original provider/AI SDK error captured from streamText.onError. */
   providerError: unknown;
+  /** True when a provider rejected an image-bearing tool result. */
+  providerRejectedMultimodalToolResults: boolean;
   /** Stop-condition flags set by the respective onFired callbacks. */
   stoppedDueToTokenExhaustion: boolean;
   /** Maps to stoppedDueToPreemptiveTimeout in chat-handler, stoppedDueToElapsedTimeout in agent-long. */
@@ -114,6 +121,7 @@ export function initAgentStreamState(
     streamUsage: undefined,
     responseModel: undefined,
     providerError: undefined,
+    providerRejectedMultimodalToolResults: false,
     stoppedDueToTokenExhaustion: false,
     stoppedDueToElapsedTimeout: false,
     stoppedDueToDoomLoop: false,
@@ -123,31 +131,6 @@ export function initAgentStreamState(
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
-
-const isImageViewOutput = (output: unknown): boolean => {
-  if (!isRecord(output)) return false;
-
-  return (
-    output.action === "view" &&
-    output.kind === "image" &&
-    typeof output.mediaType === "string" &&
-    output.mediaType.startsWith("image/")
-  );
-};
-
-const uiMessagesContainImageViewResult = (messages: UIMessage[]): boolean =>
-  messages.some((message) =>
-    message.parts?.some((part) => {
-      if (!isRecord(part) || part.type !== "tool-file") return false;
-      return isImageViewOutput(part.output);
-    }),
-  );
-
-const toolResultsContainImageViewResult = (toolResults: unknown[]): boolean =>
-  toolResults.some((toolResult) => {
-    if (!isRecord(toolResult) || toolResult.toolName !== "file") return false;
-    return isImageViewOutput(toolResult.output);
-  });
 
 const ESTIMATED_BYTES_PER_TOKEN = 4;
 
@@ -733,6 +716,12 @@ export async function createAgentStream(
 
     onError: async ({ error }) => {
       state.providerError = error;
+      if (
+        streamHasImageViewResults &&
+        isProviderMultimodalToolResultRejectionError(error)
+      ) {
+        state.providerRejectedMultimodalToolResults = true;
+      }
       const overflowKind = classifyProviderOverflowError(error);
       if (overflowKind) {
         state.stoppedDueToTokenExhaustion = true;

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -123,7 +123,10 @@ import {
   initAgentStreamState,
   type AgentStreamContext,
 } from "@/lib/api/agent-stream-runner";
-import { omitImageViewToolResultsForProviderRetry } from "@/lib/chat/multimodal-tool-result-recovery";
+import {
+  omitImageViewToolResultsForProviderRetry,
+  omitTrailingStepStartAssistantMessage,
+} from "@/lib/chat/multimodal-tool-result-recovery";
 import { FREE_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
 
 function getStreamContext() {
@@ -922,7 +925,10 @@ export const createChatHandler = () => {
                           ? selectedModel
                           : fallbackModel;
                         if (shouldRetryWithoutImageToolResults) {
-                          state.finalMessages = imageRecovery.messages;
+                          state.finalMessages =
+                            omitTrailingStepStartAssistantMessage(
+                              imageRecovery.messages,
+                            );
                         } else {
                           // Discard the failed primary leg's model usage so the
                           // user is only billed for the fallback. Non-model spend

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -123,6 +123,7 @@ import {
   initAgentStreamState,
   type AgentStreamContext,
 } from "@/lib/api/agent-stream-runner";
+import { omitImageViewToolResultsForProviderRetry } from "@/lib/chat/multimodal-tool-result-recovery";
 import { FREE_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
 
 function getStreamContext() {
@@ -865,10 +866,21 @@ export const createChatHandler = () => {
                     const hasOnlyStepStart =
                       lastAssistantMessage?.parts?.length === 1 &&
                       lastAssistantMessage.parts[0]?.type === "step-start";
+                    const imageRecovery =
+                      state.providerRejectedMultimodalToolResults
+                        ? omitImageViewToolResultsForProviderRetry(messages)
+                        : { messages, omittedCount: 0 };
+                    const shouldRetryWithoutImageToolResults =
+                      imageRecovery.omittedCount > 0 && !isAborted;
 
-                    if (hasOnlyStepStart) {
+                    if (
+                      hasOnlyStepStart ||
+                      shouldRetryWithoutImageToolResults
+                    ) {
                       phLogger.warn(
-                        "Stream finished incomplete - triggering fallback",
+                        shouldRetryWithoutImageToolResults
+                          ? "Provider rejected image tool output - retrying without images"
+                          : "Stream finished incomplete - triggering fallback",
                         {
                           chatId,
                           endpoint,
@@ -881,13 +893,23 @@ export const createChatHandler = () => {
                           parts: lastAssistantMessage?.parts,
                           isRetryWithFallback,
                           assistantMessageId,
+                          imageToolResultsOmitted: imageRecovery.omittedCount,
                         },
                       );
 
-                      // Retry with fallback model if not already retrying (only for auto models)
-                      if (!isRetryWithFallback && !isAborted && isAutoModel) {
+                      // Retry with fallback model for incomplete streams. For
+                      // image-tool rejection, retry the same selected model
+                      // after replacing image outputs with text placeholders.
+                      if (
+                        !isRetryWithFallback &&
+                        !isAborted &&
+                        (isAutoModel || shouldRetryWithoutImageToolResults)
+                      ) {
                         isRetryWithFallback = true;
                         state.lastStepInputTokens = 0;
+                        state.streamFinishReason = undefined;
+                        state.providerError = undefined;
+                        state.providerRejectedMultimodalToolResults = false;
                         state.stoppedDueToTokenExhaustion = false;
                         state.stoppedDueToElapsedTimeout = false;
                         state.stoppedDueToDoomLoop = false;
@@ -896,12 +918,19 @@ export const createChatHandler = () => {
                         preFallbackCacheRead = usageTracker.cacheReadTokens;
                         preFallbackCacheWrite = usageTracker.cacheWriteTokens;
 
-                        // Discard the failed primary leg's model usage so the
-                        // user is only billed for the fallback. Non-model spend
-                        // (sandbox/tools) is preserved.
-                        usageTracker.resetModelLeg();
+                        const retryModel = shouldRetryWithoutImageToolResults
+                          ? selectedModel
+                          : fallbackModel;
+                        if (shouldRetryWithoutImageToolResults) {
+                          state.finalMessages = imageRecovery.messages;
+                        } else {
+                          // Discard the failed primary leg's model usage so the
+                          // user is only billed for the fallback. Non-model spend
+                          // (sandbox/tools) is preserved.
+                          usageTracker.resetModelLeg();
+                        }
 
-                        const retryResult = await createStream(fallbackModel);
+                        const retryResult = await createStream(retryModel);
                         const retryMessageId = generateId();
 
                         writer.merge(
@@ -1082,7 +1111,7 @@ export const createChatHandler = () => {
                                   originalModel: selectedModel,
                                   originalAssistantMessageId:
                                     assistantMessageId,
-                                  fallbackModel,
+                                  fallbackModel: retryModel,
                                   fallbackAssistantMessageId: retryMessageId,
                                   fallbackDurationMs:
                                     Date.now() - fallbackStartTime,
@@ -1105,6 +1134,12 @@ export const createChatHandler = () => {
                                   isTemporary: temporary,
                                   paidAskMode:
                                     mode === "ask" && subscription !== "free",
+                                  retryReason:
+                                    shouldRetryWithoutImageToolResults
+                                      ? "image_tool_result_rejection"
+                                      : "incomplete_stream",
+                                  imageToolResultsOmitted:
+                                    imageRecovery.omittedCount,
                                 });
 
                                 // Deduct accumulated usage (includes both original + retry streams)

--- a/lib/chat/__tests__/multimodal-tool-result-recovery.test.ts
+++ b/lib/chat/__tests__/multimodal-tool-result-recovery.test.ts
@@ -3,6 +3,7 @@ import {
   getImageToolResultOmittedText,
   isProviderMultimodalToolResultRejectionError,
   omitImageViewToolResultsForProviderRetry,
+  omitTrailingStepStartAssistantMessage,
   toolResultsContainImageViewResult,
   uiMessagesContainImageViewResult,
 } from "../multimodal-tool-result-recovery";
@@ -99,6 +100,22 @@ describe("multimodal tool result recovery", () => {
 
     expect(result.omittedCount).toBe(0);
     expect(result.messages).toBe(messages);
+  });
+
+  it("removes a trailing transient step-start assistant message", () => {
+    const messages = [
+      makeImageViewMessage(),
+      {
+        id: "assistant-step",
+        role: "assistant",
+        parts: [{ type: "step-start" }],
+      },
+    ] as unknown as UIMessage[];
+
+    const trimmed = omitTrailingStepStartAssistantMessage(messages);
+
+    expect(trimmed).toHaveLength(1);
+    expect(trimmed[0]).toBe(messages[0]);
   });
 
   it("classifies provider 4xx image tool-output rejections", () => {

--- a/lib/chat/__tests__/multimodal-tool-result-recovery.test.ts
+++ b/lib/chat/__tests__/multimodal-tool-result-recovery.test.ts
@@ -1,0 +1,135 @@
+import type { UIMessage } from "ai";
+import {
+  getImageToolResultOmittedText,
+  isProviderMultimodalToolResultRejectionError,
+  omitImageViewToolResultsForProviderRetry,
+  toolResultsContainImageViewResult,
+  uiMessagesContainImageViewResult,
+} from "../multimodal-tool-result-recovery";
+
+const makeImageViewMessage = (): UIMessage =>
+  ({
+    id: "assistant-1",
+    role: "assistant",
+    parts: [
+      {
+        type: "tool-file",
+        toolCallId: "call-file-1",
+        state: "output-available",
+        output: {
+          action: "view",
+          kind: "image",
+          mediaType: "image/png",
+          data: "base64-image-data",
+          previewFiles: [{ fileName: "screen.png" }],
+        },
+      },
+    ],
+  }) as unknown as UIMessage;
+
+describe("multimodal tool result recovery", () => {
+  it("detects image view tool results in UI messages and tool results", () => {
+    const message = makeImageViewMessage();
+
+    expect(uiMessagesContainImageViewResult([message])).toBe(true);
+    expect(
+      toolResultsContainImageViewResult([
+        {
+          toolName: "file",
+          output: {
+            action: "view",
+            kind: "image",
+            mediaType: "image/jpeg",
+          },
+        },
+      ]),
+    ).toBe(true);
+    expect(
+      toolResultsContainImageViewResult([
+        {
+          toolName: "file",
+          output: {
+            action: "read",
+            kind: "text",
+            mediaType: "text/plain",
+          },
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it("replaces image view outputs with text placeholders for retry", () => {
+    const message = makeImageViewMessage();
+    const originalMessages = [message];
+    const { messages, omittedCount } =
+      omitImageViewToolResultsForProviderRetry(originalMessages);
+
+    expect(omittedCount).toBe(1);
+    expect(messages).not.toBe(originalMessages);
+    expect(uiMessagesContainImageViewResult(messages)).toBe(false);
+
+    const output = (messages[0]?.parts?.[0] as any)?.output;
+    expect(output.content).toBe(getImageToolResultOmittedText());
+    expect(output.error).toBe(getImageToolResultOmittedText());
+    expect(output.imageOmittedAfterProviderRejection).toBe(true);
+    expect(output.data).toBeUndefined();
+    expect(output.previewFiles).toBeUndefined();
+  });
+
+  it("leaves non-image file tool outputs unchanged", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-file",
+            output: {
+              action: "read",
+              kind: "text",
+              mediaType: "text/plain",
+              content: "hello",
+            },
+          },
+        ],
+      },
+    ] as unknown as UIMessage[];
+
+    const result = omitImageViewToolResultsForProviderRetry(messages);
+
+    expect(result.omittedCount).toBe(0);
+    expect(result.messages).toBe(messages);
+  });
+
+  it("classifies provider 4xx image tool-output rejections", () => {
+    const error = Object.assign(
+      new Error("Provider rejected image-data in tool output"),
+      {
+        name: "AI_APICallError",
+        statusCode: 400,
+      },
+    );
+
+    expect(isProviderMultimodalToolResultRejectionError(error)).toBe(true);
+  });
+
+  it("does not treat media size or retryable provider errors as image rejection", () => {
+    expect(
+      isProviderMultimodalToolResultRejectionError(
+        Object.assign(new Error("image file too large"), {
+          name: "AI_APICallError",
+          statusCode: 400,
+        }),
+      ),
+    ).toBe(false);
+
+    expect(
+      isProviderMultimodalToolResultRejectionError(
+        Object.assign(new Error("Provider unavailable for image input"), {
+          name: "AI_APICallError",
+          statusCode: 503,
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/lib/chat/multimodal-tool-result-recovery.ts
+++ b/lib/chat/multimodal-tool-result-recovery.ts
@@ -88,6 +88,21 @@ export function omitImageViewToolResultsForProviderRetry(
   };
 }
 
+export const omitTrailingStepStartAssistantMessage = (
+  messages: UIMessage[],
+): UIMessage[] => {
+  const lastMessage = messages.at(-1);
+  if (
+    lastMessage?.role !== "assistant" ||
+    lastMessage.parts?.length !== 1 ||
+    lastMessage.parts[0]?.type !== "step-start"
+  ) {
+    return messages;
+  }
+
+  return messages.slice(0, -1);
+};
+
 const MULTIMODAL_REJECTION_PATTERNS = [
   /image[-_\s]?data/i,
   /input[_\s-]?image/i,

--- a/lib/chat/multimodal-tool-result-recovery.ts
+++ b/lib/chat/multimodal-tool-result-recovery.ts
@@ -1,0 +1,149 @@
+import type { UIMessage } from "ai";
+import {
+  extractErrorDetails,
+  getProviderErrorCategory,
+  getProviderStatusCode,
+} from "@/lib/utils/error-utils";
+
+const TOOL_FILE_PART_TYPE = "tool-file";
+
+const IMAGE_TOOL_RESULT_OMITTED_TEXT =
+  "[Image view omitted because the model provider rejected image tool output. Continue without visual inspection. Use text extraction, browser snapshot refs, or ask the user to switch to a vision-capable model if visual inspection is required.]";
+
+type ImageViewOutput = {
+  action?: unknown;
+  kind?: unknown;
+  mediaType?: unknown;
+  imageOmittedAfterProviderRejection?: unknown;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const isImageViewToolOutput = (
+  output: unknown,
+): output is Record<string, unknown> & ImageViewOutput => {
+  if (!isRecord(output)) return false;
+  return (
+    output.action === "view" &&
+    output.kind === "image" &&
+    typeof output.mediaType === "string" &&
+    output.mediaType.startsWith("image/") &&
+    output.imageOmittedAfterProviderRejection !== true
+  );
+};
+
+export const uiMessagesContainImageViewResult = (
+  messages: UIMessage[],
+): boolean =>
+  messages.some((message) =>
+    message.parts?.some((part) => {
+      if (!isRecord(part) || part.type !== TOOL_FILE_PART_TYPE) return false;
+      return isImageViewToolOutput(part.output);
+    }),
+  );
+
+export const toolResultsContainImageViewResult = (
+  toolResults: unknown[],
+): boolean =>
+  toolResults.some((toolResult) => {
+    if (!isRecord(toolResult) || toolResult.toolName !== "file") return false;
+    return isImageViewToolOutput(toolResult.output);
+  });
+
+export function omitImageViewToolResultsForProviderRetry(
+  messages: UIMessage[],
+): { messages: UIMessage[]; omittedCount: number } {
+  let omittedCount = 0;
+
+  const nextMessages = messages.map((message) => {
+    let changed = false;
+    const parts = message.parts?.map((part) => {
+      if (!isRecord(part) || part.type !== TOOL_FILE_PART_TYPE) return part;
+      if (!isImageViewToolOutput(part.output)) return part;
+
+      omittedCount++;
+      changed = true;
+      const output = part.output;
+
+      return {
+        ...part,
+        output: {
+          ...output,
+          error: IMAGE_TOOL_RESULT_OMITTED_TEXT,
+          content: IMAGE_TOOL_RESULT_OMITTED_TEXT,
+          previewFiles: undefined,
+          data: undefined,
+          imageOmittedAfterProviderRejection: true,
+        },
+      };
+    });
+
+    return changed ? ({ ...message, parts } as UIMessage) : message;
+  });
+
+  return {
+    messages: omittedCount > 0 ? nextMessages : messages,
+    omittedCount,
+  };
+}
+
+const MULTIMODAL_REJECTION_PATTERNS = [
+  /image[-_\s]?data/i,
+  /input[_\s-]?image/i,
+  /image(?:\s+content|\s+input|\s+part|\s+block|\s+tool|\s+output)/i,
+  /(?:vision|multimodal).{0,80}(?:not supported|unsupported|reject|invalid|disabled|unavailable)/i,
+  /(?:not supported|unsupported|reject|invalid).{0,80}(?:vision|multimodal|image)/i,
+  /model does not support images/i,
+  /image.*(?:must be|should be).*(?:url|text)/i,
+  /content.*image.*not.*allowed/i,
+] as const;
+
+const MEDIA_OVERFLOW_PATTERN =
+  /image(?: file)? too large|media(?: file)? too large|base64.*too large/i;
+
+const detailsToSearchText = (details: Record<string, unknown>): string =>
+  [
+    details.errorMessage,
+    details.providerErrorMessage,
+    details.providerRawError,
+    details.cause,
+    details.responseBody,
+    details.errorCode,
+    details.providerErrorCode,
+  ]
+    .filter((value) => typeof value === "string" || typeof value === "number")
+    .join(" ");
+
+export const isProviderMultimodalToolResultRejectionError = (
+  error: unknown,
+): boolean => {
+  const details = extractErrorDetails(error);
+  const category = getProviderErrorCategory(details);
+  const statusCode = getProviderStatusCode(details);
+
+  if (
+    category !== "provider_4xx" &&
+    category !== "unknown" &&
+    category !== "stream_terminated"
+  ) {
+    return false;
+  }
+
+  if (
+    statusCode != null &&
+    statusCode !== 400 &&
+    statusCode !== 404 &&
+    statusCode !== 422
+  ) {
+    return false;
+  }
+
+  const text = detailsToSearchText(details);
+  if (!text || MEDIA_OVERFLOW_PATTERN.test(text)) return false;
+
+  return MULTIMODAL_REJECTION_PATTERNS.some((pattern) => pattern.test(text));
+};
+
+export const getImageToolResultOmittedText = () =>
+  IMAGE_TOOL_RESULT_OMITTED_TEXT;

--- a/lib/utils/__tests__/cleanup-errors.test.ts
+++ b/lib/utils/__tests__/cleanup-errors.test.ts
@@ -55,4 +55,15 @@ describe("isExpectedAlreadyGoneCleanupError", () => {
       isExpectedAlreadyGoneCleanupError(new Error("network timeout")),
     ).toBe(false);
   });
+
+  it("does not treat generic not-found errors as missing cleanup resources", () => {
+    expect(
+      isExpectedMissingResourceCleanupError(new Error("project not found")),
+    ).toBe(false);
+    expect(
+      isExpectedMissingResourceCleanupError(
+        new Error("api key does not exist"),
+      ),
+    ).toBe(false);
+  });
 });

--- a/lib/utils/__tests__/cleanup-errors.test.ts
+++ b/lib/utils/__tests__/cleanup-errors.test.ts
@@ -1,0 +1,40 @@
+import { isExpectedAlreadyGoneCleanupError } from "../cleanup-errors";
+
+describe("isExpectedAlreadyGoneCleanupError", () => {
+  it("matches nested process and sandbox terminal-state errors", () => {
+    expect(
+      isExpectedAlreadyGoneCleanupError({
+        message: "cleanup failed",
+        cause: Object.assign(new Error("no such process"), { code: "ESRCH" }),
+      }),
+    ).toBe(true);
+
+    expect(
+      isExpectedAlreadyGoneCleanupError({
+        name: "NotFoundError",
+        status: 404,
+        responseBody: "sandbox not_found",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches already closed transport cleanup races", () => {
+    expect(
+      isExpectedAlreadyGoneCleanupError(
+        new Error("WebSocket channel already closed"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match permission, auth, or generic network errors", () => {
+    expect(
+      isExpectedAlreadyGoneCleanupError(new Error("permission denied")),
+    ).toBe(false);
+    expect(isExpectedAlreadyGoneCleanupError(new Error("unauthorized"))).toBe(
+      false,
+    );
+    expect(
+      isExpectedAlreadyGoneCleanupError(new Error("network timeout")),
+    ).toBe(false);
+  });
+});

--- a/lib/utils/__tests__/cleanup-errors.test.ts
+++ b/lib/utils/__tests__/cleanup-errors.test.ts
@@ -1,4 +1,7 @@
-import { isExpectedAlreadyGoneCleanupError } from "../cleanup-errors";
+import {
+  isExpectedAlreadyGoneCleanupError,
+  isExpectedMissingResourceCleanupError,
+} from "../cleanup-errors";
 
 describe("isExpectedAlreadyGoneCleanupError", () => {
   it("matches nested process and sandbox terminal-state errors", () => {
@@ -23,6 +26,21 @@ describe("isExpectedAlreadyGoneCleanupError", () => {
       isExpectedAlreadyGoneCleanupError(
         new Error("WebSocket channel already closed"),
       ),
+    ).toBe(true);
+    expect(
+      isExpectedMissingResourceCleanupError(
+        new Error("WebSocket channel already closed"),
+      ),
+    ).toBe(false);
+  });
+
+  it("distinguishes missing resources from generic closed transports", () => {
+    expect(
+      isExpectedMissingResourceCleanupError({
+        name: "NotFoundError",
+        status: 404,
+        responseBody: "sandbox not_found",
+      }),
     ).toBe(true);
   });
 

--- a/lib/utils/cleanup-errors.ts
+++ b/lib/utils/cleanup-errors.ts
@@ -1,0 +1,52 @@
+const CLEANUP_ALREADY_GONE_PATTERNS = [
+  /\bnot[_\s-]?found\b/i,
+  /\bno such (?:process|file|session|container|sandbox)\b/i,
+  /\bdoes not exist\b/i,
+  /\balready (?:closed|deleted|exited|gone|killed|removed|stopped)\b/i,
+  /\b(?:process|session|container|sandbox).{0,60}(?:not found|closed|deleted|exited|gone|killed|removed|stopped)\b/i,
+  /\b(?:connection|channel|socket|stream).{0,40}(?:closed|ended|gone|lost)\b/i,
+  /\bESRCH\b/i,
+] as const;
+
+const collectCleanupErrorText = (
+  error: unknown,
+  seen = new WeakSet<object>(),
+  depth = 0,
+): string[] => {
+  if (typeof error === "string") return [error];
+  if (typeof error === "number") return [String(error)];
+  if (!error || typeof error !== "object") return [];
+  if (seen.has(error) || depth > 3) return [];
+  seen.add(error);
+
+  const record = error as Record<string, unknown>;
+  const texts: string[] = [];
+  for (const key of [
+    "name",
+    "message",
+    "code",
+    "status",
+    "statusText",
+    "responseBody",
+  ] as const) {
+    const value = record[key];
+    if (typeof value === "string" || typeof value === "number") {
+      texts.push(String(value));
+    }
+  }
+
+  for (const key of ["cause", "error"] as const) {
+    const nested = record[key];
+    if (nested !== undefined) {
+      texts.push(...collectCleanupErrorText(nested, seen, depth + 1));
+    }
+  }
+
+  return texts;
+};
+
+export const isExpectedAlreadyGoneCleanupError = (error: unknown): boolean => {
+  const text = collectCleanupErrorText(error).join(" ");
+  if (!text) return false;
+  return CLEANUP_ALREADY_GONE_PATTERNS.some((pattern) => pattern.test(text));
+};

--- a/lib/utils/cleanup-errors.ts
+++ b/lib/utils/cleanup-errors.ts
@@ -8,6 +8,13 @@ const CLEANUP_ALREADY_GONE_PATTERNS = [
   /\bESRCH\b/i,
 ] as const;
 
+const CLEANUP_MISSING_RESOURCE_PATTERNS = [
+  /\bnot[_\s-]?found\b/i,
+  /\bno such (?:process|file|session|container|sandbox)\b/i,
+  /\bdoes not exist\b/i,
+  /\b(?:process|session|container|sandbox).{0,60}(?:not found|deleted|gone|removed)\b/i,
+] as const;
+
 const collectCleanupErrorText = (
   error: unknown,
   seen = new WeakSet<object>(),
@@ -49,4 +56,14 @@ export const isExpectedAlreadyGoneCleanupError = (error: unknown): boolean => {
   const text = collectCleanupErrorText(error).join(" ");
   if (!text) return false;
   return CLEANUP_ALREADY_GONE_PATTERNS.some((pattern) => pattern.test(text));
+};
+
+export const isExpectedMissingResourceCleanupError = (
+  error: unknown,
+): boolean => {
+  const text = collectCleanupErrorText(error).join(" ");
+  if (!text) return false;
+  return CLEANUP_MISSING_RESOURCE_PATTERNS.some((pattern) =>
+    pattern.test(text),
+  );
 };

--- a/lib/utils/cleanup-errors.ts
+++ b/lib/utils/cleanup-errors.ts
@@ -9,10 +9,9 @@ const CLEANUP_ALREADY_GONE_PATTERNS = [
 ] as const;
 
 const CLEANUP_MISSING_RESOURCE_PATTERNS = [
-  /\bnot[_\s-]?found\b/i,
   /\bno such (?:process|file|session|container|sandbox)\b/i,
-  /\bdoes not exist\b/i,
-  /\b(?:process|session|container|sandbox).{0,60}(?:not found|deleted|gone|removed)\b/i,
+  /\b(?:process|file|session|container|sandbox).{0,60}(?:not[_\s-]?found|does not exist|deleted|gone|removed)\b/i,
+  /\b(?:not[_\s-]?found|does not exist|deleted|gone|removed).{0,60}(?:process|file|session|container|sandbox)\b/i,
 ] as const;
 
 const collectCleanupErrorText = (

--- a/packages/local/src/__tests__/process-runner.test.ts
+++ b/packages/local/src/__tests__/process-runner.test.ts
@@ -1,0 +1,77 @@
+const mockSpawn = jest.fn();
+
+jest.mock(
+  "node-pty",
+  () => ({
+    spawn: (...args: unknown[]) => mockSpawn(...args),
+  }),
+  { virtual: true },
+);
+
+import { ProcessRunner } from "../process-runner";
+
+type ExitListener = (event: { exitCode?: number }) => void;
+
+const makePtyProcess = () => {
+  let exitListener: ExitListener | undefined;
+  return {
+    pid: 1234,
+    write: jest.fn(),
+    resize: jest.fn(),
+    kill: jest.fn(),
+    onData: jest.fn(),
+    onExit: jest.fn((listener: ExitListener) => {
+      exitListener = listener;
+    }),
+    __exit: (exitCode = 0) => exitListener?.({ exitCode }),
+  };
+};
+
+describe("ProcessRunner cleanup", () => {
+  let setIntervalSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setIntervalSpy = jest
+      .spyOn(global, "setInterval")
+      .mockReturnValue({ unref: jest.fn() } as unknown as NodeJS.Timeout);
+    mockSpawn.mockReset();
+  });
+
+  afterEach(() => {
+    setIntervalSpy.mockRestore();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("treats ESRCH during stop as an already-stopped process", () => {
+    const proc = makePtyProcess();
+    proc.kill.mockImplementationOnce(() => {
+      throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+    });
+    mockSpawn.mockReturnValue(proc);
+
+    const runner = new ProcessRunner();
+    runner.run("session-1", "echo hi");
+
+    expect(runner.stop("session-1")).toBe(false);
+    expect(runner.isRunning("session-1")).toBe(false);
+    runner.dispose();
+  });
+
+  it("drops local tracking after SIGKILL escalation", () => {
+    const proc = makePtyProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const runner = new ProcessRunner();
+    runner.run("session-1", "sleep 10");
+
+    expect(runner.stop("session-1")).toBe(true);
+    jest.advanceTimersByTime(5_000);
+
+    expect(proc.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+    expect(proc.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+    expect(runner.isRunning("session-1")).toBe(false);
+    runner.dispose();
+  });
+});

--- a/packages/local/src/__tests__/process-runner.test.ts
+++ b/packages/local/src/__tests__/process-runner.test.ts
@@ -74,4 +74,25 @@ describe("ProcessRunner cleanup", () => {
     expect(runner.isRunning("session-1")).toBe(false);
     runner.dispose();
   });
+
+  it("catches unexpected SIGKILL errors during escalation", () => {
+    const proc = makePtyProcess();
+    proc.kill.mockImplementation((signal?: string) => {
+      if (signal === "SIGKILL") {
+        throw new Error("permission denied");
+      }
+    });
+    mockSpawn.mockReturnValue(proc);
+    const errorListener = jest.fn();
+
+    const runner = new ProcessRunner();
+    runner.on("error", errorListener);
+    runner.run("session-1", "sleep 10");
+
+    expect(runner.stop("session-1")).toBe(true);
+    expect(() => jest.advanceTimersByTime(5_000)).not.toThrow();
+
+    expect(errorListener).toHaveBeenCalledWith("session-1", expect.any(Error));
+    runner.dispose();
+  });
 });

--- a/packages/local/src/process-runner.ts
+++ b/packages/local/src/process-runner.ts
@@ -199,12 +199,20 @@ export class ProcessRunner {
     }
 
     const timer = setTimeout(() => {
-      if (this.activeProcesses.has(sessionId)) {
+      if (!this.activeProcesses.has(sessionId)) {
+        this.clearKillTimer(sessionId);
+        return;
+      }
+
+      try {
         if (this.killProcess(sessionId, proc, "SIGKILL")) {
           this.activeProcesses.delete(sessionId);
           this.outputBuffers.delete(sessionId);
-          this.clearKillTimer(sessionId);
         }
+      } catch {
+        // killProcess already emitted the error event.
+      } finally {
+        this.clearKillTimer(sessionId);
       }
     }, SIGTERM_GRACE_MS);
     this.killTimers.set(sessionId, timer);

--- a/packages/local/src/process-runner.ts
+++ b/packages/local/src/process-runner.ts
@@ -54,6 +54,17 @@ const SIGTERM_GRACE_MS = 5_000;
 export const NODE_PTY_UNAVAILABLE_MESSAGE =
   "Interactive terminal sessions are unavailable because node-pty could not be loaded. Non-interactive commands still work.";
 
+const isExpectedAlreadyStoppedKillError = (error: unknown): boolean => {
+  if (!error || typeof error !== "object") return false;
+  const record = error as Record<string, unknown>;
+  const text = [record.name, record.message, record.code]
+    .filter((value) => typeof value === "string" || typeof value === "number")
+    .join(" ");
+  return /\b(?:ESRCH|already (?:exited|gone|killed|stopped)|no such process|not[_\s-]?found)\b/i.test(
+    text,
+  );
+};
+
 export function isPtyAvailable(): boolean {
   try {
     require("node-pty");
@@ -183,13 +194,17 @@ export class ProcessRunner {
       return false;
     }
 
-    proc.kill("SIGTERM");
+    if (!this.killProcess(sessionId, proc, "SIGTERM")) {
+      return false;
+    }
 
     const timer = setTimeout(() => {
       if (this.activeProcesses.has(sessionId)) {
-        proc.kill("SIGKILL");
-        this.activeProcesses.delete(sessionId);
-        this.outputBuffers.delete(sessionId);
+        if (this.killProcess(sessionId, proc, "SIGKILL")) {
+          this.activeProcesses.delete(sessionId);
+          this.outputBuffers.delete(sessionId);
+          this.clearKillTimer(sessionId);
+        }
       }
     }, SIGTERM_GRACE_MS);
     this.killTimers.set(sessionId, timer);
@@ -247,6 +262,31 @@ export class ProcessRunner {
   private flushAll(): void {
     for (const sessionId of this.outputBuffers.keys()) {
       this.flush(sessionId);
+    }
+  }
+
+  private killProcess(
+    sessionId: string,
+    proc: PtyProcess,
+    signal: string,
+  ): boolean {
+    try {
+      proc.kill(signal);
+      return true;
+    } catch (error) {
+      if (!isExpectedAlreadyStoppedKillError(error)) {
+        this.emit(
+          "error",
+          sessionId,
+          error instanceof Error ? error : new Error(String(error)),
+        );
+        throw error;
+      }
+
+      this.activeProcesses.delete(sessionId);
+      this.outputBuffers.delete(sessionId);
+      this.clearKillTimer(sessionId);
+      return false;
     }
   }
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -114,6 +114,7 @@ import {
 } from "@/lib/chat/agent-long-heartbeat";
 import { PREEMPTIVE_TIMEOUT_FINISH_REASON } from "@/lib/chat/stop-conditions";
 import { shouldRetryAgentLongWithFallback } from "@/lib/chat/agent-long-provider-retry";
+import { omitImageViewToolResultsForProviderRetry } from "@/lib/chat/multimodal-tool-result-recovery";
 import { FREE_AGENT_LONG_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
 
 const AGENT_LONG_FREE_MAX_DURATION_SECONDS = 60 * 60;
@@ -1513,15 +1514,27 @@ export const agentLongTask = task({
                               isTerminalProviderStreamError(state),
                           },
                         );
+                      const imageRecovery =
+                        state.providerRejectedMultimodalToolResults
+                          ? omitImageViewToolResultsForProviderRetry(
+                              finishedMessages,
+                            )
+                          : { messages: finishedMessages, omittedCount: 0 };
+                      const shouldRetryWithoutImageToolResults =
+                        imageRecovery.omittedCount > 0 && !isAborted;
 
                       if (
-                        shouldRetryWithFallback &&
+                        (shouldRetryWithFallback ||
+                          shouldRetryWithoutImageToolResults) &&
                         !isRetryWithFallback &&
                         !isAborted &&
-                        isAutoModel
+                        (isAutoModel || shouldRetryWithoutImageToolResults)
                       ) {
                         isRetryWithFallback = true;
                         state.lastStepInputTokens = 0;
+                        state.streamFinishReason = undefined;
+                        state.providerError = undefined;
+                        state.providerRejectedMultimodalToolResults = false;
                         state.stoppedDueToTokenExhaustion = false;
                         state.stoppedDueToElapsedTimeout = false;
                         state.stoppedDueToDoomLoop = false;
@@ -1529,8 +1542,15 @@ export const agentLongTask = task({
                         const fallbackStartTime = Date.now();
                         preFallbackCacheRead = usageTracker.cacheReadTokens;
                         preFallbackCacheWrite = usageTracker.cacheWriteTokens;
-                        usageTracker.resetModelLeg();
-                        const retryResult = await createStream(fallbackModel);
+                        const retryModel = shouldRetryWithoutImageToolResults
+                          ? selectedModel
+                          : fallbackModel;
+                        if (shouldRetryWithoutImageToolResults) {
+                          state.finalMessages = imageRecovery.messages;
+                        } else {
+                          usageTracker.resetModelLeg();
+                        }
+                        const retryResult = await createStream(retryModel);
                         const retryMessageId = generateId();
 
                         writer.merge(

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -114,7 +114,10 @@ import {
 } from "@/lib/chat/agent-long-heartbeat";
 import { PREEMPTIVE_TIMEOUT_FINISH_REASON } from "@/lib/chat/stop-conditions";
 import { shouldRetryAgentLongWithFallback } from "@/lib/chat/agent-long-provider-retry";
-import { omitImageViewToolResultsForProviderRetry } from "@/lib/chat/multimodal-tool-result-recovery";
+import {
+  omitImageViewToolResultsForProviderRetry,
+  omitTrailingStepStartAssistantMessage,
+} from "@/lib/chat/multimodal-tool-result-recovery";
 import { FREE_AGENT_LONG_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
 
 const AGENT_LONG_FREE_MAX_DURATION_SECONDS = 60 * 60;
@@ -1546,7 +1549,21 @@ export const agentLongTask = task({
                           ? selectedModel
                           : fallbackModel;
                         if (shouldRetryWithoutImageToolResults) {
-                          state.finalMessages = imageRecovery.messages;
+                          const normalizedRetryMessages = imageRecovery.messages
+                            .map((message) =>
+                              message.role === "assistant"
+                                ? stripAgentLongHeartbeatParts(message)
+                                : message,
+                            )
+                            .filter(
+                              (message) =>
+                                message.role !== "assistant" ||
+                                (message.parts?.length ?? 0) > 0,
+                            );
+                          state.finalMessages =
+                            omitTrailingStepStartAssistantMessage(
+                              normalizedRetryMessages,
+                            );
                         } else {
                           usageTracker.resetModelLeg();
                         }


### PR DESCRIPTION
## Summary
- retry once with text placeholders when providers reject persisted file.view image tool outputs
- classify expected already-gone cleanup races for sandbox/PTX/local stop paths and keep unexpected failures noisy
- add focused tests for image recovery, cleanup classification, delete-sandboxes, PTY cleanup, hybrid reset, and local process runner stop races

## Validation
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- pnpm jest --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery when providers reject image-view tool results, retrying the conversation without those images.
* **Bug Fixes**
  * Improved cleanup/termination reliability across sandboxes, PTY sessions, and process stopping by treating “already gone/not found/closed” outcomes as successful cleanup.
  * Hardened multimodal retry logic and error classification to avoid incorrect failure paths.
* **Enhancements**
  * Updated the sandboxes deletion endpoint to return detailed stats (total, killed, already-gone).
* **Tests**
  * Expanded Jest coverage for multimodal recovery and cleanup error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->