### PR TITLE
Add sandbox tool workflow recipes

### DIFF
--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -134,7 +134,7 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).toContain("<sandbox_tool_recipes>");
     expect(prompt).toContain("interactsh-client: use for blind callback proof");
     expect(prompt).toContain("blind SSRF, XXE, blind XSS");
-    expect(prompt).toContain("jwt_tool: use for JWT decoding");
+    expect(prompt).toContain("jwt-tool (jwt_tool): use for JWT decoding");
     expect(prompt).toContain("arjun: use after endpoints are known");
     expect(prompt).toContain(
       "dirsearch: use for scoped directory/file discovery",

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -120,6 +120,55 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).toContain("file tool's view action");
   });
 
+  it("adds compact cloud sandbox tool recipes for solo security workflows", async () => {
+    const prompt = await systemPrompt(
+      "user_123",
+      "agent",
+      "pro",
+      "agent-model",
+      null,
+      false,
+      null,
+    );
+
+    expect(prompt).toContain("<sandbox_tool_recipes>");
+    expect(prompt).toContain("interactsh-client: use for blind callback proof");
+    expect(prompt).toContain("blind SSRF, XXE, blind XSS");
+    expect(prompt).toContain("jwt_tool: use for JWT decoding");
+    expect(prompt).toContain("arjun: use after endpoints are known");
+    expect(prompt).toContain(
+      "dirsearch: use for scoped directory/file discovery",
+    );
+    expect(prompt).toContain("wafw00f: use early to fingerprint WAF/CDN");
+    expect(prompt).toContain("cvemap: use after identifying product names");
+    expect(prompt).toContain("Browser screenshot flow: use agent-browser");
+  });
+
+  it("clarifies cloud sandbox cannot directly reach local host aliases", async () => {
+    const prompt = await systemPrompt(
+      "user_123",
+      "agent",
+      "pro",
+      "agent-model",
+      null,
+      false,
+      null,
+    );
+
+    expect(prompt).toContain(
+      "localhost and 127.0.0.1 refer to the sandbox/container, not the user's laptop",
+    );
+    expect(prompt).toContain(
+      "Do not use host.docker.internal as a shortcut to the user's host from the cloud sandbox",
+    );
+    expect(prompt).toContain(
+      "use the HackerAI Desktop App, Remote Connection, or a user-provided reachable tunnel URL",
+    );
+    expect(prompt).toContain(
+      "Do not invent host aliases or imply the cloud sandbox can directly reach private/internal assets",
+    );
+  });
+
   it("does not describe a command sandbox in ask mode", async () => {
     const prompt = await systemPrompt(
       "user_123",
@@ -134,6 +183,30 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).toContain("This chat has no terminal command environment.");
     expect(prompt).not.toContain(
       "For the default cloud sandbox, commands run in an isolated container",
+    );
+    expect(prompt).not.toContain("<sandbox_tool_recipes>");
+    expect(prompt).not.toContain("interactsh-client: use for blind callback");
+  });
+
+  it("does not claim cloud-only recipes or browser tools are installed on local hosts", async () => {
+    const localHostContext = `You are executing commands on Linux 6.8 (x64) in DANGEROUS MODE.
+Commands run directly on the host OS "labbox" without Docker isolation.`;
+
+    const prompt = await systemPrompt(
+      "user_123",
+      "agent",
+      "pro",
+      "agent-model",
+      null,
+      false,
+      localHostContext,
+    );
+
+    expect(prompt).toContain(localHostContext);
+    expect(prompt).not.toContain("<sandbox_tool_recipes>");
+    expect(prompt).not.toContain("interactsh-client: use for blind callback");
+    expect(prompt).not.toContain(
+      "agent-browser is installed in the cloud sandbox",
     );
   });
 });

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -54,6 +54,17 @@ export const PREINSTALLED_PENTESTING_TOOLS = `Pre-installed Pentesting Tools:
 - Browser Automation: Chromium and agent-browser (headless browser CLI with accessibility snapshots, element refs, form interaction, screenshots, tabs, and network inspection)
 - Documents: reportlab, python-docx, openpyxl, python-pptx, pandas, pypandoc, pandoc, odfpy`;
 
+const SANDBOX_TOOL_RECIPES_SECTION = `<sandbox_tool_recipes>
+Use established tools before writing custom scripts when they fit the task. Pick tools based on the current evidence and scope:
+- interactsh-client: use for blind callback proof such as blind SSRF, XXE, blind XSS, webhook delivery, or DNS/HTTP/OOB interaction validation. Start a listener before sending payloads and preserve the callback evidence.
+- jwt_tool: use for JWT decoding and targeted checks around alg confusion, weak signing, claim tampering, key confusion, expiry/audience/issuer issues, and verification bypass hypotheses.
+- arjun: use after endpoints are known to discover hidden parameters on forms, APIs, and query/body inputs. Feed confirmed endpoints from crawling, proxy history, or manual mapping.
+- dirsearch: use for scoped directory/file discovery against mapped web roots. Keep wordlists and extensions aligned to the detected stack and avoid broad scans before scope is clear.
+- wafw00f: use early to fingerprint WAF/CDN behavior before noisy payload scans, then tune rate, headers, and payload strategy from the result.
+- cvemap: use after identifying product names and versions to map plausible CVEs. Treat output as leads; manually validate exploitability before reporting.
+- Browser screenshot flow: use agent-browser for visual, authenticated, JavaScript-heavy, or evidence-driven workflows. Open the page, take an interactive snapshot, perform the action, capture a screenshot, then view the screenshot file for visual confirmation.
+</sandbox_tool_recipes>`;
+
 const AGENT_BROWSER_SECTION = `<agent_browser>
 agent-browser is installed in the cloud sandbox for headless Chromium automation through terminal commands.
 
@@ -183,6 +194,12 @@ If the user wants to connect HackerAI to their local machine, they have two opti
 2. Set up a Remote Connection — connects the agent to their machine for internal pentesting
 Direct them to: https://help.hackerai.co/en/articles/12961920-connecting-a-hackerai-agent-to-your-local-machine for setup instructions.
 
+Local/internal target access:
+- In the cloud sandbox, localhost and 127.0.0.1 refer to the sandbox/container, not the user's laptop, private LAN, or local development server.
+- Do not use host.docker.internal as a shortcut to the user's host from the cloud sandbox; it may not resolve, and it is not a supported path to the user's machine.
+- For local or internal targets, use the HackerAI Desktop App, Remote Connection, or a user-provided reachable tunnel URL.
+- Do not invent host aliases or imply the cloud sandbox can directly reach private/internal assets unless the user has provided a reachable route.
+
 System Environment:
 - OS: Debian GNU/Linux 12 linux/amd64 (with internet access)
 - User: \`root\` (with sudo privileges)
@@ -196,6 +213,8 @@ Development Environment:
 - Golang 1.24.2 (commands: go)
 
 ${PREINSTALLED_PENTESTING_TOOLS}
+
+${SANDBOX_TOOL_RECIPES_SECTION}
 
 ${AGENT_BROWSER_SECTION}
 

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -50,14 +50,14 @@ export const PREINSTALLED_PENTESTING_TOOLS = `Pre-installed Pentesting Tools:
 - Vulnerability Assessment: nuclei (vulnerability scanner with templates), trivy (container/dependency scanner), zaproxy (OWASP ZAP), vulnx/cvemap (CVE vulnerability mapping)
 - Forensics: binwalk, foremost (file carving)
 - Utilities: gobuster, socat, proxychains4, hashid, libimage-exiftool-perl (exiftool), cewl
-- Specialized: jwt_tool (JWT manipulation), interactsh-client (OOB interaction testing), SecLists (/home/user/SecLists or /usr/share/seclists)
+- Specialized: jwt-tool (wrapper for jwt_tool; JWT manipulation), interactsh-client (OOB interaction testing), SecLists (/home/user/SecLists or /usr/share/seclists)
 - Browser Automation: Chromium and agent-browser (headless browser CLI with accessibility snapshots, element refs, form interaction, screenshots, tabs, and network inspection)
 - Documents: reportlab, python-docx, openpyxl, python-pptx, pandas, pypandoc, pandoc, odfpy`;
 
 const SANDBOX_TOOL_RECIPES_SECTION = `<sandbox_tool_recipes>
 Use established tools before writing custom scripts when they fit the task. Pick tools based on the current evidence and scope:
 - interactsh-client: use for blind callback proof such as blind SSRF, XXE, blind XSS, webhook delivery, or DNS/HTTP/OOB interaction validation. Start a listener before sending payloads and preserve the callback evidence.
-- jwt_tool: use for JWT decoding and targeted checks around alg confusion, weak signing, claim tampering, key confusion, expiry/audience/issuer issues, and verification bypass hypotheses.
+- jwt-tool (jwt_tool): use for JWT decoding and targeted checks around alg confusion, weak signing, claim tampering, key confusion, expiry/audience/issuer issues, and verification bypass hypotheses.
 - arjun: use after endpoints are known to discover hidden parameters on forms, APIs, and query/body inputs. Feed confirmed endpoints from crawling, proxy history, or manual mapping.
 - dirsearch: use for scoped directory/file discovery against mapped web roots. Keep wordlists and extensions aligned to the detected stack and avoid broad scans before scope is clear.
 - wafw00f: use early to fingerprint WAF/CDN behavior before noisy payload scans, then tune rate, headers, and payload strategy from the result.


### PR DESCRIPTION
## Summary
- add compact cloud-sandbox recipes for interactsh-client, jwt_tool, arjun, dirsearch, wafw00f, cvemap, and agent-browser screenshots
- clarify that cloud localhost/127.0.0.1 are sandbox-local and host.docker.internal is not a supported shortcut to the user's host
- keep recipes out of Ask mode and dangerous local/remote host contexts where installed tools depend on the user's machine

## Strix context
- Strix's commit page shows late-May tool-surface/docs work, including tool surface consistency and SDK tool documentation. This PR adapts the useful behavior pattern: teach when to use existing tools instead of changing HackerAI's runtime.

## Validation
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- pnpm jest --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sandbox tool-recipes guidance to direct agents toward established tools for common security workflows.

* **Documentation**
  * Clarified that `localhost`/`127.0.0.1` in sandbox environments refer to the sandbox container, not the user’s machine.
  * Added guidance against unsupported host shortcuts and explained how to reach local/internal targets safely.

* **Tests**
  * Expanded prompt-generation test coverage for agent-mode sandbox behavior and mode-specific (ask vs. agent) prompt differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->