### PR TITLE
Add Codex worktree env include list

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+.env.local
+.env.e2e


### PR DESCRIPTION
## Summary
- Add `.worktreeinclude` so Codex-managed worktrees copy ignored env setup files
- Include `.env.local` and `.env.e2e` only; no secrets are committed

## Tests
- `tsc --noEmit`
- `jest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development configuration for worktree management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->