### PR TITLE
Improve auto-reload failure message

### DIFF
--- a/app/components/ExtraUsageSection.tsx
+++ b/app/components/ExtraUsageSection.tsx
@@ -11,6 +11,7 @@ import {
   BuyExtraUsageDialog,
   AdjustSpendingLimitDialog,
   AutoReloadDialog,
+  AutoReloadDisabledAlert,
 } from "@/app/components/extra-usage";
 import {
   captureAddCreditCtaClick,
@@ -352,14 +353,7 @@ const ExtraUsageSection = () => {
                   </button>
                 </p>
                 {!autoReloadEnabled && autoReloadDisabledReason && (
-                  <div
-                    role="alert"
-                    className="mt-2 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-500"
-                  >
-                    Auto-reload was turned off because your card kept failing
-                    {`: ${autoReloadDisabledReason}`}. Update your payment
-                    method, then turn auto-reload back on.
-                  </div>
+                  <AutoReloadDisabledAlert reason={autoReloadDisabledReason} />
                 )}
               </div>
               <Button

--- a/app/components/TeamExtraUsageSection.tsx
+++ b/app/components/TeamExtraUsageSection.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import {
   AdjustSpendingLimitDialog,
   AutoReloadDialog,
+  AutoReloadDisabledAlert,
   BuyExtraUsageDialog,
 } from "@/app/components/extra-usage";
 import {
@@ -378,14 +379,10 @@ export const TeamExtraUsageSection = () => {
                   </button>
                 </p>
                 {!pool.autoReloadEnabled && pool.autoReloadDisabledReason && (
-                  <div
-                    role="alert"
-                    className="mt-2 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-500"
-                  >
-                    Auto-reload was turned off because the card kept failing:{" "}
-                    {pool.autoReloadDisabledReason}. Update your payment method
-                    in the billing portal, then turn auto-reload back on.
-                  </div>
+                  <AutoReloadDisabledAlert
+                    reason={pool.autoReloadDisabledReason}
+                    updateInBillingPortal
+                  />
                 )}
               </div>
               <Button

--- a/app/components/extra-usage/AutoReloadDisabledAlert.tsx
+++ b/app/components/extra-usage/AutoReloadDisabledAlert.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+const normalizeFailureReason = (reason: string): string => {
+  const trimmed = reason.trim().replace(/[.!?]+$/u, "");
+
+  if (!trimmed || trimmed === "payment_failed") {
+    return "Payment failed";
+  }
+
+  return trimmed;
+};
+
+type AutoReloadDisabledAlertProps = {
+  reason: string;
+  updateInBillingPortal?: boolean;
+};
+
+export const AutoReloadDisabledAlert = ({
+  reason,
+  updateInBillingPortal = false,
+}: AutoReloadDisabledAlertProps) => {
+  const displayReason = normalizeFailureReason(reason);
+  const updateCopy = updateInBillingPortal
+    ? "Update your payment method in the billing portal"
+    : "Update your payment method";
+
+  return (
+    <div
+      role="alert"
+      className="mt-2 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-500"
+    >
+      Auto-reload was turned off after failed payment attempts. {displayReason}.{" "}
+      {updateCopy}, then turn auto-reload back on.
+    </div>
+  );
+};

--- a/app/components/extra-usage/__tests__/AutoReloadDisabledAlert.test.tsx
+++ b/app/components/extra-usage/__tests__/AutoReloadDisabledAlert.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { AutoReloadDisabledAlert } from "../AutoReloadDisabledAlert";
+
+describe("AutoReloadDisabledAlert", () => {
+  it("renders Stripe decline reasons without repeated card wording or duplicate punctuation", () => {
+    render(
+      <AutoReloadDisabledAlert reason="Your card was declined for making repeated attempts too frequently or exceeding its amount limit." />,
+    );
+
+    const alert = screen.getByRole("alert");
+
+    expect(alert).toHaveTextContent(
+      "Auto-reload was turned off after failed payment attempts. Your card was declined for making repeated attempts too frequently or exceeding its amount limit. Update your payment method, then turn auto-reload back on.",
+    );
+    expect(alert).not.toHaveTextContent("card kept failing");
+    expect(alert).not.toHaveTextContent("..");
+  });
+
+  it("uses billing portal copy for team payment methods", () => {
+    render(
+      <AutoReloadDisabledAlert reason="Payment failed" updateInBillingPortal />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Update your payment method in the billing portal, then turn auto-reload back on.",
+    );
+  });
+
+  it("normalizes fallback failure codes", () => {
+    render(<AutoReloadDisabledAlert reason="payment_failed" />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Payment failed.");
+  });
+});

--- a/app/components/extra-usage/index.ts
+++ b/app/components/extra-usage/index.ts
@@ -2,4 +2,5 @@ export { TurnOffExtraUsageDialog } from "./TurnOffExtraUsageDialog";
 export { BuyExtraUsageDialog } from "./BuyExtraUsageDialog";
 export { AdjustSpendingLimitDialog } from "./AdjustSpendingLimitDialog";
 export { AutoReloadDialog } from "./AutoReloadDialog";
+export { AutoReloadDisabledAlert } from "./AutoReloadDisabledAlert";
 export { ExtraUsagePurchaseToast } from "./ExtraUsagePurchaseToast";


### PR DESCRIPTION
## Summary
- Replace repetitive auto-reload decline copy with a shared alert for individual and team extra usage settings.
- Normalize stored failure reasons before display so Stripe sentences do not render with duplicate punctuation.
- Add focused coverage for Stripe decline copy, team billing portal copy, and fallback failure codes.

## Validation
- `pnpm exec prettier --check app/components/extra-usage/AutoReloadDisabledAlert.tsx app/components/extra-usage/__tests__/AutoReloadDisabledAlert.test.tsx app/components/extra-usage/index.ts app/components/ExtraUsageSection.tsx app/components/TeamExtraUsageSection.tsx`
- `pnpm exec eslint app/components/extra-usage/AutoReloadDisabledAlert.tsx app/components/extra-usage/__tests__/AutoReloadDisabledAlert.test.tsx app/components/extra-usage/index.ts app/components/ExtraUsageSection.tsx app/components/TeamExtraUsageSection.tsx --ext .ts,.tsx`
- `pnpm typecheck`
- `pnpm test -- app/components/extra-usage/__tests__/AutoReloadDisabledAlert.test.tsx --runInBand`
- Pre-commit hook also ran full `pnpm typecheck` and full `pnpm test` successfully.

## Manual Verification
- Go to Settings > Extra usage with auto-reload disabled by repeated payment failure.
- Confirm the alert says auto-reload was turned off after failed payment attempts, includes the card decline reason once, and has no duplicate period.
- For team extra usage, confirm the same alert points admins to the billing portal before turning auto-reload back on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the auto-reload disabled alert UI with better handling of payment failure reasons and contextual call-to-action messaging across different sections.

* **Tests**
  * Added comprehensive test coverage for the auto-reload disabled alert component, including failure reason normalization and copy variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->