### PR TITLE
Show sidebar loading state for agent runs

### DIFF
--- a/app/components/SidebarHistory.tsx
+++ b/app/components/SidebarHistory.tsx
@@ -106,7 +106,7 @@ const SidebarHistory: React.FC<SidebarHistoryProps> = ({
           shareId={chat.share_id}
           shareDate={chat.share_date}
           isPinned={chat.pinned_at != null}
-          isStreaming={!!chat.active_stream_id}
+          isStreaming={!!chat.active_stream_id || !!chat.active_trigger_run_id}
         />
       ))}
 

--- a/app/components/__tests__/SidebarHistory.test.tsx
+++ b/app/components/__tests__/SidebarHistory.test.tsx
@@ -1,0 +1,61 @@
+import "@testing-library/jest-dom";
+import { describe, expect, it, jest } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import type SidebarHistoryType from "../SidebarHistory";
+
+jest.mock("../ChatItem", () => ({
+  __esModule: true,
+  default: ({ id, title, isStreaming }: any) => (
+    <div data-testid={`chat-item-${id}`}>
+      <span>{title}</span>
+      {isStreaming ? (
+        <span data-testid={`streaming-${id}`}>loading</span>
+      ) : null}
+    </div>
+  ),
+}));
+
+const SidebarHistory = require("../SidebarHistory")
+  .default as typeof SidebarHistoryType;
+
+const chat = (overrides: Record<string, unknown>) => ({
+  _id: overrides.id,
+  id: overrides.id,
+  title: "Chat",
+  ...overrides,
+});
+
+describe("SidebarHistory", () => {
+  it("marks chats with active ask streams as streaming", () => {
+    render(
+      <SidebarHistory
+        chats={[chat({ id: "ask-chat", active_stream_id: "stream-1" })]}
+        paginationStatus="Exhausted"
+      />,
+    );
+
+    expect(screen.getByTestId("streaming-ask-chat")).toBeInTheDocument();
+  });
+
+  it("marks chats with active agent trigger runs as streaming", () => {
+    render(
+      <SidebarHistory
+        chats={[chat({ id: "agent-chat", active_trigger_run_id: "run-1" })]}
+        paginationStatus="Exhausted"
+      />,
+    );
+
+    expect(screen.getByTestId("streaming-agent-chat")).toBeInTheDocument();
+  });
+
+  it("does not mark idle chats as streaming", () => {
+    render(
+      <SidebarHistory
+        chats={[chat({ id: "idle-chat" })]}
+        paginationStatus="Exhausted"
+      />,
+    );
+
+    expect(screen.queryByTestId("streaming-idle-chat")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Treat chats with active Trigger agent runs as streaming in the sidebar
- Add SidebarHistory regression coverage for ask streams, agent Trigger runs, and idle chats

## Testing
- pnpm test -- app/components/__tests__/SidebarHistory.test.tsx --runInBand
- pnpm exec prettier --check app/components/SidebarHistory.tsx app/components/__tests__/SidebarHistory.test.tsx
- pnpm exec eslint app/components/SidebarHistory.tsx app/components/__tests__/SidebarHistory.test.tsx
- pnpm typecheck
- Pre-commit hook: prettier --write, eslint --fix, pnpm typecheck, pnpm test

## Manual verification
- Automated validation is sufficient for this state-mapping fix; the existing ChatItem spinner rendering is reused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved streaming status detection in chat history sidebar to recognize additional active conditions.

* **Tests**
  * Added comprehensive test coverage for streaming status detection in chat history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->