### PR TITLE
Handle deleted Stripe customers in subscription webhook

### DIFF
--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -1088,11 +1088,15 @@ async function handleSubscriptionDeleted(
   const lookupKey = subscription.items?.data[0]?.price?.lookup_key ?? null;
   const tier = lookupKey ? planLookupKeyToTier(lookupKey) : null;
 
-  const { userIds, orgId } = await resolveUserIdsFromCustomer(customerId);
+  const { userIds, orgId, reason } =
+    await resolveUserIdsFromCustomer(customerId);
   if (userIds.length === 0) {
-    console.error(
-      `[Subscription Webhook] subscription.deleted: could not resolve users for customer ${customerId}`,
-    );
+    const message = `[Subscription Webhook] subscription.deleted: could not resolve users for customer ${customerId} (${reason ?? "unknown"})`;
+    if (reason === "customer_deleted") {
+      console.info(`${message}; likely account deletion cleanup`);
+    } else {
+      console.error(message);
+    }
     return;
   }
 

--- a/lib/__tests__/resolve-customer-users.test.ts
+++ b/lib/__tests__/resolve-customer-users.test.ts
@@ -77,7 +77,59 @@ describe("resolveUserIdsFromCustomer", () => {
 
     const result = await resolveUserIdsFromCustomer("cus_123", "Test Webhook");
 
-    expect(result).toEqual({ userIds: [], orgId: null });
+    expect(result).toEqual({
+      userIds: [],
+      orgId: null,
+      reason: "missing_workos_organization_metadata",
+    });
     expect(mockListMemberships).not.toHaveBeenCalled();
+  });
+
+  it("returns a deleted-customer reason without querying WorkOS memberships", async () => {
+    mockRetrieveCustomer.mockResolvedValueOnce({
+      deleted: true,
+      id: "cus_deleted",
+    } as never);
+
+    const { resolveUserIdsFromCustomer } =
+      await import("../billing/resolve-customer-users");
+
+    const result = await resolveUserIdsFromCustomer(
+      "cus_deleted",
+      "Test Webhook",
+    );
+
+    expect(result).toEqual({
+      userIds: [],
+      orgId: null,
+      reason: "customer_deleted",
+    });
+    expect(mockListMemberships).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("returns a no-active-memberships reason when the org has no active users", async () => {
+    mockRetrieveCustomer.mockResolvedValueOnce({
+      deleted: false,
+      metadata: { workOSOrganizationId: "org_empty" },
+    } as never);
+    mockListMemberships.mockResolvedValueOnce({
+      data: [],
+      autoPagination: jest.fn().mockResolvedValue([]),
+    } as never);
+
+    const { resolveUserIdsFromCustomer } =
+      await import("../billing/resolve-customer-users");
+
+    const result = await resolveUserIdsFromCustomer(
+      "cus_empty",
+      "Test Webhook",
+    );
+
+    expect(result).toEqual({
+      userIds: [],
+      orgId: "org_empty",
+      reason: "no_active_memberships",
+    });
   });
 });

--- a/lib/billing/resolve-customer-users.ts
+++ b/lib/billing/resolve-customer-users.ts
@@ -2,13 +2,27 @@ import { stripe } from "@/app/api/stripe";
 import { workos } from "@/app/api/workos";
 import Stripe from "stripe";
 
+export type CustomerUserResolutionReason =
+  | "customer_deleted"
+  | "missing_workos_organization_metadata"
+  | "no_active_memberships"
+  | "lookup_failed";
+
+export type CustomerUserResolution = {
+  userIds: string[];
+  orgId: string | null;
+  reason?: CustomerUserResolutionReason;
+};
+
 export async function resolveUserIdsFromCustomer(
   customerId: string,
   logPrefix: string,
-): Promise<{ userIds: string[]; orgId: string | null }> {
+): Promise<CustomerUserResolution> {
   try {
     const customerData = await stripe.customers.retrieve(customerId);
-    if (customerData.deleted) return { userIds: [], orgId: null };
+    if (customerData.deleted) {
+      return { userIds: [], orgId: null, reason: "customer_deleted" };
+    }
 
     const customer = customerData as Stripe.Customer;
     const orgId = customer.metadata?.workOSOrganizationId ?? null;
@@ -16,7 +30,11 @@ export async function resolveUserIdsFromCustomer(
       console.error(
         `[${logPrefix}] Customer ${customerId} missing workOSOrganizationId metadata`,
       );
-      return { userIds: [], orgId: null };
+      return {
+        userIds: [],
+        orgId: null,
+        reason: "missing_workos_organization_metadata",
+      };
     }
 
     const memberships = await workos.userManagement.listOrganizationMemberships(
@@ -31,7 +49,7 @@ export async function resolveUserIdsFromCustomer(
 
     if (userIds.length === 0) {
       console.error(`[${logPrefix}] No active memberships for org ${orgId}`);
-      return { userIds: [], orgId };
+      return { userIds: [], orgId, reason: "no_active_memberships" };
     }
 
     return { userIds, orgId };
@@ -40,6 +58,6 @@ export async function resolveUserIdsFromCustomer(
       `[${logPrefix}] Failed to resolve users for customer ${customerId}:`,
       error,
     );
-    return { userIds: [], orgId: null };
+    return { userIds: [], orgId: null, reason: "lookup_failed" };
   }
 }

--- a/lib/billing/resolve-customer-users.ts
+++ b/lib/billing/resolve-customer-users.ts
@@ -2,18 +2,21 @@ import { stripe } from "@/app/api/stripe";
 import { workos } from "@/app/api/workos";
 import Stripe from "stripe";
 
+/** Why a Stripe customer could not be mapped to active WorkOS users. */
 export type CustomerUserResolutionReason =
   | "customer_deleted"
   | "missing_workos_organization_metadata"
   | "no_active_memberships"
   | "lookup_failed";
 
+/** Active WorkOS users for a Stripe customer, or a reason none were resolved. */
 export type CustomerUserResolution = {
   userIds: string[];
   orgId: string | null;
   reason?: CustomerUserResolutionReason;
 };
 
+/** Resolve active WorkOS user IDs for a Stripe customer. */
 export async function resolveUserIdsFromCustomer(
   customerId: string,
   logPrefix: string,


### PR DESCRIPTION
## Summary
- add typed resolution reasons when mapping Stripe customers to WorkOS users
- treat deleted Stripe customers during `customer.subscription.deleted` as expected account-deletion cleanup instead of error noise
- keep true metadata, membership, and lookup failures visible as errors

## Validation
- `pnpm jest lib/__tests__/resolve-customer-users.test.ts --runInBand`
- `pnpm exec eslint lib/billing/resolve-customer-users.ts app/api/subscription/webhook/route.ts lib/__tests__/resolve-customer-users.test.ts`
- `pnpm typecheck`
- `git diff --check`

## Manual verification
Automated validation is sufficient; this is a backend logging and resolver-contract change with no user-visible UI impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription deletion handling by capturing specific customer/user-resolution outcomes and adjusting logging behavior accordingly.
  * Enhanced billing user resolution to report clearer failure/short-circuit reasons (e.g., deleted customer, missing organization metadata, no active memberships), improving reliability of cancellation/deletion workflows.
* **Tests**
  * Expanded coverage for customer-to-user resolution edge cases, including missing metadata, deleted customers, and orgs with no active memberships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->