### PR TITLE
Add provider and tool failure regression tests

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -228,6 +228,15 @@ describe("supportsMultimodalToolResults", () => {
     ).toBe(true);
   });
 
+  it("allows multimodal fallback keys and slugs used after image tool results", () => {
+    expect(supportsMultimodalToolResults("fallback-gemini-3.5-flash")).toBe(
+      true,
+    );
+    expect(supportsMultimodalToolResults("google/gemini-3.5-flash")).toBe(true);
+    expect(supportsMultimodalToolResults("fallback-grok-4.3")).toBe(true);
+    expect(supportsMultimodalToolResults("x-ai/grok-4.3")).toBe(true);
+  });
+
   it("still rejects text-only DeepSeek routes", () => {
     expect(supportsMultimodalToolResults("agent-model-free")).toBe(false);
     expect(supportsMultimodalToolResults("model-deepseek-v4-flash")).toBe(

--- a/lib/ai/tools/__tests__/web-search.test.ts
+++ b/lib/ai/tools/__tests__/web-search.test.ts
@@ -294,4 +294,52 @@ describe("web_search", () => {
       "Error performing web search: Perplexity search is not authorized (HTTP 401 Unauthorized). Check the Perplexity API key or account access.",
     );
   });
+
+  it("sanitizes non-retry provider failure details before logging or returning", async () => {
+    const esc = String.fromCharCode(0x1b);
+    const bell = String.fromCharCode(0x07);
+    const rawBody = JSON.stringify({
+      error: `${esc}[31mapi_key=provider-secret${bell} from 54.81.73.203 Ray ID: a0611dc9caa93928`,
+    });
+
+    global.fetch = jest.fn().mockResolvedValue(
+      response(rawBody, {
+        status: 400,
+        statusText: "Bad Request",
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const result = await runTool(createWebSearch(makeContext()), {
+      queries: ["perplexity status"],
+      brief: "check provider status",
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(result).toBe(
+      "Error performing web search: Perplexity search failed (HTTP 400 Bad Request).",
+    );
+    expect(result).not.toContain("provider-secret");
+    expect(result).not.toContain("54.81.73.203");
+    expect(result).not.toContain("a0611dc9caa93928");
+
+    expect(console.error).toHaveBeenCalledWith(
+      "Web search tool error:",
+      expect.objectContaining({
+        name: "PerplexityApiError",
+        status: 400,
+        retryable: false,
+      }),
+    );
+    const loggedPayload = (console.error as jest.Mock).mock.calls[0][1] as {
+      bodySummary: string;
+    };
+    expect(loggedPayload.bodySummary).toContain('api_key="[Redacted]"');
+    expect(loggedPayload.bodySummary).toContain("[Redacted IP]");
+    expect(loggedPayload.bodySummary).toContain("Ray ID: [Redacted]");
+    expect(loggedPayload.bodySummary).not.toContain(esc);
+    expect(loggedPayload.bodySummary).not.toContain(bell);
+    expect(loggedPayload.bodySummary).not.toContain("provider-secret");
+    expect(loggedPayload.bodySummary).not.toContain("54.81.73.203");
+  });
 });

--- a/lib/ai/tools/utils/perplexity.ts
+++ b/lib/ai/tools/utils/perplexity.ts
@@ -1,3 +1,5 @@
+import { redactSensitiveErrorMessage } from "@/lib/utils/error-redaction";
+
 // Max tokens per search result content field
 export const SEARCH_RESULT_CONTENT_MAX_TOKENS = 250;
 
@@ -153,7 +155,11 @@ export const summarizePerplexityErrorBody = (
     summary = trimmed;
   }
 
-  return truncateSummary(redactNetworkDetails(normalizeWhitespace(summary)));
+  return truncateSummary(
+    redactSensitiveErrorMessage(
+      redactNetworkDetails(normalizeWhitespace(summary)),
+    ),
+  );
 };
 
 export interface FormattedSearchResult {

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -99,6 +99,30 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
+  it("keeps Anthropic multimodal agent fallback off text-only Kimi once image tool results exist", () => {
+    const opus = buildProviderOptions(
+      false,
+      "user-1",
+      "model-opus-4.6",
+      "agent",
+      {
+        hasMultimodalToolResults: true,
+      },
+    );
+    const sonnet = buildProviderOptions(
+      false,
+      "user-1",
+      "model-sonnet-4.6",
+      "agent",
+      { hasMultimodalToolResults: true },
+    );
+
+    expect(opus.openrouter.models).toEqual([GEMINI_3_5_SLUG, GROK_SLUG]);
+    expect(sonnet.openrouter.models).toEqual([GEMINI_3_5_SLUG, GROK_SLUG]);
+    expect(opus.openrouter.models).not.toContain(KIMI_SLUG);
+    expect(sonnet.openrouter.models).not.toContain(KIMI_SLUG);
+  });
+
   it("falls back from auto agent Kimi to Grok", () => {
     const opts = buildProviderOptions(false, "user-1", "agent-model", "agent");
     expect(opts.openrouter).toMatchObject({
@@ -162,10 +186,7 @@ describe("buildProviderOptions fallback chain", () => {
     expect(opts.openrouter).not.toHaveProperty("models");
   });
 
-  it.each([
-    "ask-model-free",
-    "model-deepseek-v4-flash",
-  ])(
+  it.each(["ask-model-free", "model-deepseek-v4-flash"])(
     "keeps reasoning disabled for auto/standard ask mode model %s",
     (modelName) => {
       const opts = buildProviderOptions(false, "user-1", modelName, "ask");

--- a/lib/api/__tests__/chat-stream-helpers-free-gates.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-free-gates.test.ts
@@ -1,4 +1,8 @@
-import { assertFreeAgentGates } from "@/lib/api/chat-stream-helpers";
+import {
+  assertFreeAgentGates,
+  countFileAttachments,
+  stripImageAttachments,
+} from "@/lib/api/chat-stream-helpers";
 import { ChatSDKError } from "@/lib/errors";
 
 jest.mock("@/lib/db/actions", () => ({
@@ -28,5 +32,74 @@ describe("assertFreeAgentGates", () => {
         sandboxPreference: "e2b",
       }),
     ).toThrow(ChatSDKError);
+  });
+});
+
+describe("free-tier image attachment helpers", () => {
+  it("counts image files separately from other attachments", () => {
+    expect(
+      countFileAttachments([
+        {
+          parts: [
+            { type: "text" },
+            { type: "file", mediaType: "image/png" },
+            { type: "file", mediaType: "application/pdf" },
+          ],
+        },
+        {
+          parts: [
+            { type: "file", mediaType: "image/jpeg" },
+            { type: "tool-result" },
+          ],
+        },
+      ]),
+    ).toEqual({ totalFiles: 3, imageCount: 2 });
+  });
+
+  it("replaces image-only messages with a text placeholder and preserves non-image parts", () => {
+    const messages = [
+      {
+        id: "mixed",
+        parts: [
+          { type: "text", text: "Please inspect these files." },
+          {
+            type: "file",
+            mediaType: "image/png",
+            url: "data:image/png;base64,a",
+          },
+          { type: "file", mediaType: "application/pdf", url: "file.pdf" },
+        ],
+      },
+      {
+        id: "image-only",
+        parts: [
+          {
+            type: "file",
+            mediaType: "image/jpeg",
+            url: "data:image/jpeg;base64,b",
+          },
+        ],
+      },
+    ];
+
+    const stripped = stripImageAttachments(messages);
+
+    expect(stripped[0]).toEqual({
+      id: "mixed",
+      parts: [
+        { type: "text", text: "Please inspect these files." },
+        { type: "file", mediaType: "application/pdf", url: "file.pdf" },
+      ],
+    });
+    expect(stripped[1]).toEqual({
+      id: "image-only",
+      parts: [
+        {
+          type: "text",
+          text: "[Image attachment hidden — image attachments are a paid-plan feature and aren't available on the free plan.]",
+        },
+      ],
+    });
+    expect(messages[0].parts).toHaveLength(3);
   });
 });

--- a/lib/utils/__tests__/error-redaction.test.ts
+++ b/lib/utils/__tests__/error-redaction.test.ts
@@ -1,6 +1,7 @@
 import {
   redactSensitiveErrorMessage,
   stringifyRedactedError,
+  stripControlSequencesFromErrorMessage,
 } from "../error-redaction";
 
 describe("error redaction", () => {
@@ -37,5 +38,21 @@ describe("error redaction", () => {
     expect(redacted).toContain('STRIPE_SECRET_KEY="[Redacted]"');
     expect(redacted).not.toContain("super-secret");
     expect(redacted).not.toContain("stripe-secret");
+  });
+
+  it("strips ANSI escapes and control bytes before redacting secrets", () => {
+    const esc = String.fromCharCode(0x1b);
+    const bell = String.fromCharCode(0x07);
+    const message = `${esc}[31mtoken=secret-value${bell}`;
+
+    expect(stripControlSequencesFromErrorMessage(message)).toBe(
+      "token=secret-value",
+    );
+
+    const redacted = redactSensitiveErrorMessage(message);
+    expect(redacted).toBe('token="[Redacted]"');
+    expect(redacted).not.toContain(esc);
+    expect(redacted).not.toContain(bell);
+    expect(redacted).not.toContain("secret-value");
   });
 });

--- a/lib/utils/error-redaction.ts
+++ b/lib/utils/error-redaction.ts
@@ -6,8 +6,22 @@ const SENSITIVE_FIELD_PATTERN =
 const ENV_SECRET_PATTERN =
   /(["']?\b(?:CONVEX_SERVICE_ROLE_KEY|POSTHOG_API_KEY|STRIPE_SECRET_KEY)\b["']?)(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,}]+)/gi;
 
-export const redactSensitiveErrorMessage = (message: string): string =>
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional ANSI/control-sequence cleanup for model/log-facing errors
+const ANSI_ESCAPE_PATTERN =
+  /\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1B]*(?:\x07|\x1B\\)|[@-Z\\-_])/g;
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional control-byte cleanup for model/log-facing errors
+const CONTROL_CHARACTER_PATTERN = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+
+export const stripControlSequencesFromErrorMessage = (
+  message: string,
+): string =>
   message
+    .replace(ANSI_ESCAPE_PATTERN, "")
+    .replace(CONTROL_CHARACTER_PATTERN, "");
+
+export const redactSensitiveErrorMessage = (message: string): string =>
+  stripControlSequencesFromErrorMessage(message)
     .replace(SENSITIVE_FIELD_PATTERN, (_match, key, separator) => {
       return `${key}${separator}"${REDACTED_VALUE}"`;
     })


### PR DESCRIPTION
## Summary
- add multimodal fallback regression coverage for provider capability checks, Anthropic agent fallback routing, and free-plan image attachment stripping
- add web_search regression coverage for sanitized non-retry provider failures
- strip ANSI/control sequences in shared error redaction before secret redaction and apply that to Perplexity error summaries

## Verification
- pnpm exec jest lib/ai/__tests__/providers.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/api/__tests__/chat-stream-helpers-free-gates.test.ts lib/ai/tools/__tests__/web-search.test.ts lib/utils/__tests__/error-redaction.test.ts --runInBand
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- pnpm exec jest --runInBand
- pre-commit hook: pnpm typecheck and pnpm test

## Visual / Manual Verification
- Visual verification not needed: no UI, route, chat rendering, file/image display, onboarding, pricing, or frontend component change.
- Manual verification not needed: automated validation covers the changed provider/tool-helper behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error message redaction to sanitize control sequences and prevent leakage of sensitive credentials, IP addresses, and identifiers in API error logs.
  * Improved image attachment handling for free-tier accounts, including proper counting and filtering of attachments.

* **New Features**
  * Added support for additional model variants (Gemini 3.5 Flash, Grok 4.3) with multimodal tool results capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->