### PR TITLE
Retry attachment uploads after command deadline timeouts

### DIFF
--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -65,6 +65,9 @@ const defaultConnection = {
   name: "test-sandbox",
 };
 
+const PRODUCTION_COMMAND_TIMEOUT_MESSAGE =
+  "[deadline_exceeded] the operation timed out: This error is likely due to exceeding 'timeoutMs' - the total time a long running request (like command execution or directory watch) can be active.";
+
 function createSandbox(
   overrides?: Partial<typeof defaultConnection>,
 ): CentrifugoSandbox {
@@ -635,6 +638,39 @@ describe("CentrifugoSandbox", () => {
           timeoutMs: 120000,
         }),
       );
+    });
+
+    it("downloadFromUrl retries thrown command deadline timeouts", async () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      const { sandbox } = createWindowsBashSandbox();
+      (sandbox as any).commands.run = jest
+        .fn()
+        .mockRejectedValueOnce(new Error(PRODUCTION_COMMAND_TIMEOUT_MESSAGE))
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+
+      try {
+        const promise = sandbox.files.downloadFromUrl(
+          "https://example.com/large.har",
+          "/tmp/hackerai-upload/large.har",
+        );
+
+        await jest.advanceTimersByTimeAsync(500);
+        await promise;
+
+        expect((sandbox as any).commands.run).toHaveBeenCalledTimes(2);
+        expect((sandbox as any).commands.run).toHaveBeenNthCalledWith(
+          2,
+          expect.stringContaining("curl -fsSL"),
+          expect.objectContaining({
+            displayName: "Downloading: large.har (retry 1)",
+            timeoutMs: 120000,
+          }),
+        );
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
     });
 
     it("ensureDirectory emits mkdir -p with MSYS path", async () => {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -32,6 +32,14 @@ const IGNORED_MESSAGE_TYPES = new Set([
 ]);
 
 const FILE_DOWNLOAD_TIMEOUT_MS = 120000;
+const TRANSIENT_COMMAND_TIMEOUT_ERROR_PATTERN =
+  /\b(?:deadline_exceeded|operation timed out:.*\btimeoutMs\b|exceeding ['"]?timeoutMs['"]?|Command timeout after \d+ms)\b/i;
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const isTransientCommandTimeoutError = (error: unknown): boolean =>
+  TRANSIENT_COMMAND_TIMEOUT_ERROR_PATTERN.test(getErrorMessage(error));
 
 export function parseSandboxMessage(
   data: unknown,
@@ -955,11 +963,30 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       const TRANSIENT_EXIT_CODES = new Set([7, 18, 23, 28, 35, 56, 92, 124]);
       const MAX_ATTEMPTS = 3;
 
-      let result = await this.commands.run(command, {
-        displayName: `Downloading: ${fileName}`,
-        timeoutMs: FILE_DOWNLOAD_TIMEOUT_MS,
-      });
+      let result: Awaited<ReturnType<typeof this.commands.run>> | null = null;
       for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+          result = await this.commands.run(command, {
+            displayName:
+              attempt === 1
+                ? `Downloading: ${fileName}`
+                : `Downloading: ${fileName} (retry ${attempt - 1})`,
+            timeoutMs: FILE_DOWNLOAD_TIMEOUT_MS,
+          });
+        } catch (error) {
+          if (
+            attempt === MAX_ATTEMPTS ||
+            !isTransientCommandTimeoutError(error)
+          ) {
+            throw error;
+          }
+          console.warn(
+            `[centrifugo-download] command timeout on attempt ${attempt}/${MAX_ATTEMPTS} for ${path}, retrying: ${getErrorMessage(error)}`,
+          );
+          await new Promise((r) => setTimeout(r, 500 * attempt));
+          continue;
+        }
+
         if (result.exitCode === 0) break;
         if (
           attempt === MAX_ATTEMPTS ||
@@ -971,10 +998,10 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           `[centrifugo-download] ${httpClient} exit ${result.exitCode} on attempt ${attempt}/${MAX_ATTEMPTS} for ${path}, retrying`,
         );
         await new Promise((r) => setTimeout(r, 500 * attempt));
-        result = await this.commands.run(command, {
-          displayName: `Downloading: ${fileName} (retry ${attempt})`,
-          timeoutMs: FILE_DOWNLOAD_TIMEOUT_MS,
-        });
+        continue;
+      }
+      if (!result) {
+        throw new Error("Download command failed without returning a result");
       }
       if (result.exitCode !== 0) {
         // Gather diagnostic info to help debug write failures (e.g. curl exit 23).

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -9,6 +9,9 @@ import {
   uploadSandboxFiles,
 } from "../sandbox-file-utils";
 
+const PRODUCTION_COMMAND_TIMEOUT_MESSAGE =
+  "[deadline_exceeded] the operation timed out: This error is likely due to exceeding 'timeoutMs' - the total time a long running request (like command execution or directory watch) can be active.";
+
 const makeLocalMessage = (): UIMessage =>
   ({
     id: "m1",
@@ -356,6 +359,54 @@ describe("desktop-local sandbox file helpers", () => {
     }
   });
 
+  it("refreshes the sandbox after production deadline_exceeded upload command timeouts", async () => {
+    jest.useFakeTimers();
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const firstRun = jest
+      .fn()
+      .mockRejectedValue(new Error(PRODUCTION_COMMAND_TIMEOUT_MESSAGE));
+    const refreshedRun = jest
+      .fn()
+      .mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const ensureSandbox = jest.fn(async (options?: { refresh?: boolean }) => ({
+      commands: { run: options?.refresh ? refreshedRun : firstRun },
+    }));
+
+    try {
+      const pendingResult = uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "https://example.com/screenshot.png",
+            localPath: "/home/user/upload/screenshot.png",
+          },
+        ],
+        ensureSandbox,
+        { retryWithFreshSandboxOnTransientFailure: true },
+      );
+      await jest.advanceTimersByTimeAsync(5_000);
+      const result = await pendingResult;
+
+      expect(result).toEqual({
+        failedCount: 0,
+        pathRewrites: [],
+        retriedWithFreshSandbox: true,
+      });
+      expect(firstRun).toHaveBeenCalledTimes(3);
+      expect(refreshedRun).toHaveBeenCalledTimes(1);
+      expect(ensureSandbox).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+      consoleWarnSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it("returns redacted metadata for transient upload command failures", async () => {
     jest.useFakeTimers();
     const consoleWarnSpy = jest
@@ -395,6 +446,50 @@ describe("desktop-local sandbox file helpers", () => {
       expect(
         String(getSandboxUploadFailureMetadata(result)?.upload_failure_cause),
       ).toContain("Request handshake timed out");
+    } finally {
+      jest.useRealTimers();
+      consoleWarnSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("marks production deadline_exceeded upload command timeouts as transient", async () => {
+    jest.useFakeTimers();
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const run = jest
+      .fn()
+      .mockRejectedValue(new Error(PRODUCTION_COMMAND_TIMEOUT_MESSAGE));
+
+    try {
+      const pendingResult = uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "https://example.com/screenshot.png?X-Amz-Signature=secret",
+            localPath: "/home/user/upload/screenshot.png",
+          },
+        ],
+        async () => ({
+          commands: { run },
+        }),
+      );
+      await jest.advanceTimersByTimeAsync(5_000);
+      const result = await pendingResult;
+
+      expect(result.failedCount).toBe(1);
+      expect(getSandboxUploadFailureMetadata(result)).toMatchObject({
+        upload_failure_kind: "url",
+        upload_failure_transient_sandbox_command: true,
+        upload_failure_protocol: "https",
+      });
+      expect(
+        String(getSandboxUploadFailureMetadata(result)?.upload_failure_cause),
+      ).toContain("[deadline_exceeded]");
     } finally {
       jest.useRealTimers();
       consoleWarnSpy.mockRestore();

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -103,7 +103,7 @@ const commandErrorToResult = (error: unknown): SandboxCommandResult | null => {
 };
 
 const TRANSIENT_SANDBOX_COMMAND_ERROR_PATTERN =
-  /\b(?:request handshake timed out(?: after \d+ms)?|sandbox command(?: request| channel| transport)? timed out|command (?:channel|transport) timed out)\b/i;
+  /\b(?:request handshake timed out(?: after \d+ms)?|sandbox command(?: request| channel| transport)? timed out|command (?:channel|transport) timed out|deadline_exceeded|operation timed out:.*\btimeoutMs\b|exceeding ['"]?timeoutMs['"]?|Command timeout after \d+ms)\b/i;
 const WRAPPED_FILE_TRANSFER_ERROR_PATTERN =
   /\bfailed to (?:download|copy) file:|curl:\s*\(|\bexitCode:\s*\d+\b/i;
 const SANDBOX_COMMAND_MAX_ATTEMPTS = 3;


### PR DESCRIPTION
## Summary
- classify sandbox command deadline/timeouts (`deadline_exceeded`, `timeoutMs`, command timeout) as transient upload failures
- retry local sandbox attachment downloads when the command bridge throws a transient deadline timeout
- add regressions for the production timeout wording and fresh-sandbox retry path

## Validation
- pnpm test -- lib/utils/__tests__/sandbox-file-utils.test.ts --runInBand
- pnpm test -- lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts --runInBand
- pnpm exec prettier --check lib/utils/sandbox-file-utils.ts lib/utils/__tests__/sandbox-file-utils.test.ts lib/ai/tools/utils/centrifugo-sandbox.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
- pnpm exec eslint lib/utils/sandbox-file-utils.ts lib/utils/__tests__/sandbox-file-utils.test.ts lib/ai/tools/utils/centrifugo-sandbox.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
- pnpm typecheck (after temporarily linking existing main-checkout node_modules and packages/local/node_modules into this worktree)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced timeout error detection and retry logic for file operations, including automatic recovery with exponential backoff delays for transient timeout errors.

* **Tests**
  * Added test coverage for timeout retry scenarios and production deadline exceeded errors during file downloads and uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->