### PR TITLE
Harden provider image attachment prep

### DIFF
--- a/app/components/FilePartRenderer.tsx
+++ b/app/components/FilePartRenderer.tsx
@@ -505,7 +505,9 @@ export const FilePartRenderer = memo(
       prevProps.part.s3Key === nextProps.part.s3Key &&
       prevProps.part.name === nextProps.part.name &&
       prevProps.part.filename === nextProps.part.filename &&
-      prevProps.part.mediaType === nextProps.part.mediaType
+      prevProps.part.mediaType === nextProps.part.mediaType &&
+      prevProps.part.size === nextProps.part.size &&
+      prevProps.part.sizeBytes === nextProps.part.sizeBytes
     );
   },
 );

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -559,6 +559,7 @@ export const MessageItem = memo(function MessageItem({
                       name: savedFiles[savedFiles.length - 1].name,
                       filename: savedFiles[savedFiles.length - 1].name,
                       mediaType: savedFiles[savedFiles.length - 1].mediaType,
+                      sizeBytes: savedFiles[savedFiles.length - 1].sizeBytes,
                     }}
                     partIndex={savedFiles.length - 1}
                     messageId={message.id}
@@ -594,6 +595,7 @@ export const MessageItem = memo(function MessageItem({
                       name: file.name,
                       filename: file.name,
                       mediaType: file.mediaType,
+                      sizeBytes: file.sizeBytes,
                     }}
                     partIndex={fileIndex}
                     messageId={message.id}

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -219,6 +219,8 @@ export const Messages = ({
             name: file.name,
             filename: file.name,
             mediaType: file.mediaType,
+            size: file.sizeBytes,
+            sizeBytes: file.sizeBytes,
           },
           partIndex: fileIndex,
           messageId: message.id,

--- a/app/components/ShareDialog.tsx
+++ b/app/components/ShareDialog.tsx
@@ -319,6 +319,7 @@ export const ShareDialog = ({
                                         name: file.name,
                                         filename: file.name,
                                         mediaType: file.mediaType,
+                                        sizeBytes: file.sizeBytes,
                                       }}
                                       partIndex={fileIndex}
                                       messageId={message.id}

--- a/app/components/tools/GetTerminalFilesHandler.tsx
+++ b/app/components/tools/GetTerminalFilesHandler.tsx
@@ -63,6 +63,7 @@ export const GetTerminalFilesHandler = memo(function GetTerminalFilesHandler({
         mediaType: f.mediaType,
         fileId: f.fileId as string,
         s3Key: f.s3Key,
+        sizeBytes: f.sizeBytes,
       }),
     );
 

--- a/convex/__tests__/s3Actions.test.ts
+++ b/convex/__tests__/s3Actions.test.ts
@@ -1158,6 +1158,16 @@ describe("s3Actions", () => {
   });
 
   describe("getFileUrlsByFileIdsAction", () => {
+    const serviceUrlInfo = (
+      url: string,
+      file: { size: number; media_type: string; name: string },
+    ) => ({
+      url,
+      sizeBytes: file.size,
+      mediaType: file.media_type,
+      name: file.name,
+    });
+
     it("should generate URLs for multiple S3 files using service key", async () => {
       const { generateS3DownloadUrl } = await import("../s3Utils");
       const { validateServiceKey } = await import("../lib/utils");
@@ -1217,8 +1227,8 @@ describe("s3Actions", () => {
 
       expect(mockValidateServiceKey).toHaveBeenCalledWith("test-service-key");
       expect(result).toEqual([
-        "https://s3.amazonaws.com/file1-url",
-        "https://s3.amazonaws.com/file2-url",
+        serviceUrlInfo("https://s3.amazonaws.com/file1-url", mockFile1),
+        serviceUrlInfo("https://s3.amazonaws.com/file2-url", mockFile2),
       ]);
     });
 
@@ -1311,7 +1321,10 @@ describe("s3Actions", () => {
         fileIds: [mockFile1Id, mockFile2Id],
       });
 
-      expect(result).toEqual(["https://s3.amazonaws.com/file1-url", null]);
+      expect(result).toEqual([
+        serviceUrlInfo("https://s3.amazonaws.com/file1-url", mockFile1),
+        null,
+      ]);
     });
 
     it("should return null for files not found", async () => {
@@ -1444,9 +1457,9 @@ describe("s3Actions", () => {
 
       // File2 should return null due to error
       expect(result).toEqual([
-        "https://s3.amazonaws.com/file1-url",
+        serviceUrlInfo("https://s3.amazonaws.com/file1-url", mockFile1),
         null,
-        "https://s3.amazonaws.com/file3-url",
+        serviceUrlInfo("https://s3.amazonaws.com/file3-url", mockFile3),
       ]);
     });
 

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -809,6 +809,7 @@ export const getMessagesByChatId = query({
               mediaType: v.optional(v.string()),
               url: v.optional(v.union(v.string(), v.null())),
               s3Key: v.optional(v.string()),
+              sizeBytes: v.optional(v.number()),
             }),
           ),
         ),
@@ -877,6 +878,7 @@ export const getMessagesByChatId = query({
             mediaType: file.media_type,
             // url: removed - generate on-demand to avoid caching expired URLs
             s3Key: file.s3_key,
+            sizeBytes: file.size,
           });
         }
       });
@@ -2048,6 +2050,7 @@ export const getPreviewMessages = query({
             name: v.string(),
             mediaType: v.optional(v.string()),
             s3Key: v.optional(v.string()),
+            sizeBytes: v.optional(v.number()),
           }),
         ),
       ),
@@ -2105,6 +2108,7 @@ export const getPreviewMessages = query({
             name: file.name,
             mediaType: file.media_type,
             s3Key: file.s3_key,
+            sizeBytes: file.size,
           });
         }
       });

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -20,6 +20,20 @@ type StorageUsage = {
 /** File record returned by internal.fileStorage.getFileById */
 type FileRecord = Doc<"files"> | null;
 
+const serviceFileUrlInfoValidator = v.object({
+  url: v.string(),
+  sizeBytes: v.number(),
+  mediaType: v.string(),
+  name: v.string(),
+});
+
+type ServiceFileUrlInfo = {
+  url: string;
+  sizeBytes: number;
+  mediaType: string;
+  name: string;
+};
+
 const getIdentityEntitlements = (identity: unknown) => {
   if (
     !identity ||
@@ -269,7 +283,7 @@ export const getFileUrlAction = action({
  * - Authenticates via service key (for backend use)
  * - Accepts array of file IDs (max 50 files)
  * - Generates S3 presigned URLs
- * - Returns array of URLs (matching order of fileIds, null for missing files)
+ * - Returns array of URL metadata (matching order of fileIds, null for missing files)
  * - Handles partial failures gracefully
  */
 export const getFileUrlsByFileIdsAction = action({
@@ -278,8 +292,8 @@ export const getFileUrlsByFileIdsAction = action({
     userId: v.optional(v.string()),
     fileIds: v.array(v.id("files")),
   },
-  returns: v.array(v.union(v.string(), v.null())),
-  handler: async (ctx, args): Promise<Array<string | null>> => {
+  returns: v.array(v.union(serviceFileUrlInfoValidator, v.null())),
+  handler: async (ctx, args): Promise<Array<ServiceFileUrlInfo | null>> => {
     // Verify service role key
     validateServiceKey(args.serviceKey);
     if (!args.userId) {
@@ -295,8 +309,8 @@ export const getFileUrlsByFileIdsAction = action({
     }
 
     // Get file records and generate URLs
-    const urls: Array<string | null> = await Promise.all(
-      args.fileIds.map(async (fileId): Promise<string | null> => {
+    const urls: Array<ServiceFileUrlInfo | null> = await Promise.all(
+      args.fileIds.map(async (fileId): Promise<ServiceFileUrlInfo | null> => {
         try {
           // Get file record using internal query
           const file: FileRecord = await ctx.runQuery(
@@ -319,7 +333,12 @@ export const getFileUrlsByFileIdsAction = action({
           }
 
           if (file.s3_key) {
-            return await generateS3DownloadUrl(file.s3_key);
+            return {
+              url: await generateS3DownloadUrl(file.s3_key),
+              sizeBytes: file.size,
+              mediaType: file.media_type,
+              name: file.name,
+            };
           }
 
           return null;

--- a/lib/ai/tools/get-terminal-files.ts
+++ b/lib/ai/tools/get-terminal-files.ts
@@ -89,6 +89,7 @@ Usage:
                 name: saved.name,
                 mediaType: saved.mediaType,
                 s3Key: saved.s3Key,
+                sizeBytes: saved.sizeBytes,
               });
 
               // Stream file metadata immediately so the client can show the file card
@@ -104,6 +105,7 @@ Usage:
                         name: saved.name,
                         mediaType: saved.mediaType,
                         s3Key: saved.s3Key,
+                        sizeBytes: saved.sizeBytes,
                       },
                     ],
                   },

--- a/lib/ai/tools/utils/file-accumulator.ts
+++ b/lib/ai/tools/utils/file-accumulator.ts
@@ -5,6 +5,7 @@ export interface AccumulatedFileMetadata {
   name: string;
   mediaType: string;
   s3Key?: string;
+  sizeBytes?: number;
 }
 
 export class FileAccumulator {

--- a/lib/ai/tools/utils/sandbox-file-uploader.ts
+++ b/lib/ai/tools/utils/sandbox-file-uploader.ts
@@ -27,6 +27,7 @@ export type UploadedFileInfo = {
   name: string;
   mediaType: string;
   s3Key?: string;
+  sizeBytes: number;
 };
 
 /**
@@ -500,6 +501,7 @@ export async function uploadSandboxFileToConvex(args: {
       name,
       mediaType,
       s3Key,
+      sizeBytes: fileSize,
     } as UploadedFileInfo;
   } catch (error) {
     logger.error(

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -468,6 +468,7 @@ export const createChatHandler = () => {
                 name: string;
                 mediaType: string;
                 s3Key?: string;
+                sizeBytes?: number;
               }>,
             ) => {
               if (!fileMetadata || fileMetadata.length === 0) return;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -20,7 +20,10 @@ export interface MessageRecord {
   fileDetails?: Array<{
     fileId: Id<"files">;
     name: string;
-    url: string | null;
+    mediaType?: string;
+    url?: string | null;
+    s3Key?: string;
+    sizeBytes?: number;
   }>;
 }
 

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -467,6 +467,20 @@ describe("provider error classification", () => {
     expect(getUserFriendlyProviderError(err)).toContain("attached media");
   });
 
+  it("classifies OpenRouter downloaded image size failures as media overflow", () => {
+    const err = apiCallError({
+      statusCode: 413,
+      responseBody: JSON.stringify({
+        error: {
+          message: "Downloaded image content cannot exceed 30MB",
+        },
+      }),
+    });
+
+    expect(classifyProviderOverflowError(err)).toBe("media");
+    expect(getUserFriendlyProviderError(err)).toContain("attached media");
+  });
+
   it("does not classify generic payload overflow as media-only", () => {
     const err = apiCallError({
       statusCode: 413,

--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -49,6 +49,20 @@ const streamBody = (...chunks: Uint8Array[]) => ({
   },
 });
 
+const fileUrlInfo = (
+  url: string,
+  overrides: Partial<{
+    sizeBytes: number;
+    mediaType: string;
+    name: string;
+  }> = {},
+) => ({
+  url,
+  sizeBytes: overrides.sizeBytes ?? 2 * 1024 * 1024,
+  mediaType: overrides.mediaType ?? "image/png",
+  name: overrides.name ?? "image.png",
+});
+
 describe("processMessageFiles image size guards", () => {
   const originalFetch = global.fetch;
   let consoleWarnSpy: jest.SpyInstance;
@@ -64,16 +78,15 @@ describe("processMessageFiles image size guards", () => {
     consoleWarnSpy.mockRestore();
   });
 
-  it("omits URL-backed images when HEAD shows provider download size over 30 MB", async () => {
-    mockConvexAction.mockResolvedValue(["https://storage.example/huge.png"]);
-    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
-      if (init?.method === "HEAD") {
-        return responseLike({
-          headers: { "content-length": String(40 * 1024 * 1024) },
-        });
-      }
-
-      throw new Error("Range probe should not run when HEAD has a size");
+  it("omits stored images when trusted file size is over the provider download limit", async () => {
+    mockConvexAction.mockResolvedValue([
+      fileUrlInfo("https://storage.example/huge.png", {
+        sizeBytes: 40 * 1024 * 1024,
+        name: "huge.png",
+      }),
+    ]);
+    global.fetch = jest.fn(async () => {
+      throw new Error("Trusted file size should avoid network probes");
     }) as any;
 
     const result = await processMessageFiles(
@@ -99,18 +112,15 @@ describe("processMessageFiles image size guards", () => {
     ]);
   });
 
-  it("omits images when resolved storage size exceeds stale message metadata", async () => {
+  it("omits images when trusted file size exceeds stale message metadata", async () => {
     mockConvexAction.mockResolvedValue([
-      "https://storage.example/stale-metadata.png",
+      fileUrlInfo("https://storage.example/stale-metadata.png", {
+        sizeBytes: 40 * 1024 * 1024,
+        name: "stale-metadata.png",
+      }),
     ]);
-    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
-      if (init?.method === "HEAD") {
-        return responseLike({
-          headers: { "content-length": String(40 * 1024 * 1024) },
-        });
-      }
-
-      throw new Error("Range probe should not run when HEAD has a size");
+    global.fetch = jest.fn(async () => {
+      throw new Error("Trusted file size should avoid network probes");
     }) as any;
 
     const result = await processMessageFiles(
@@ -136,16 +146,13 @@ describe("processMessageFiles image size guards", () => {
 
   it("keeps stored images when resolved storage size is within limit despite stale oversized metadata", async () => {
     mockConvexAction.mockResolvedValue([
-      "https://storage.example/actually-small.png",
+      fileUrlInfo("https://storage.example/actually-small.png", {
+        sizeBytes: 2 * 1024 * 1024,
+        name: "actually-small.png",
+      }),
     ]);
-    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
-      if (init?.method === "HEAD") {
-        return responseLike({
-          headers: { "content-length": String(2 * 1024 * 1024) },
-        });
-      }
-
-      throw new Error("Range probe should not run when HEAD has a size");
+    global.fetch = jest.fn(async () => {
+      throw new Error("Trusted file size should avoid network probes");
     }) as any;
 
     const result = await processMessageFiles(
@@ -173,7 +180,11 @@ describe("processMessageFiles image size guards", () => {
 
   it("omits URL-backed images when headers are inconclusive but the range probe exceeds 5 MB", async () => {
     mockConvexAction.mockResolvedValue([
-      "https://storage.example/unknown-size.png",
+      {
+        url: "https://storage.example/unknown-size.png",
+        mediaType: "image/png",
+        name: "unknown-size.png",
+      },
     ]);
     global.fetch = jest.fn(async (_url, init?: RequestInit) => {
       if (init?.method === "HEAD") {
@@ -206,12 +217,54 @@ describe("processMessageFiles image size guards", () => {
     });
   });
 
-  it("keeps URL-backed images when content-length is within the image limit", async () => {
-    mockConvexAction.mockResolvedValue(["https://storage.example/small.png"]);
+  it("omits stored images when trusted size is missing and probing is inconclusive", async () => {
+    mockConvexAction.mockResolvedValue([
+      {
+        url: "https://storage.example/no-size.png",
+        mediaType: "image/png",
+        name: "no-size.png",
+      },
+    ]);
+    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
+      if (init?.method === "HEAD") {
+        return responseLike({});
+      }
+
+      return responseLike({ status: 200 });
+    }) as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        mediaType: "image/png",
+        fileId: "file_no_size",
+        name: "no-size.png",
+        url: "https://example.com/no-size.png",
+      }),
+      "ask",
+      "user123",
+      undefined,
+      "pro",
+    );
+
+    expect(JSON.stringify(result.messages)).not.toContain(
+      "https://storage.example/no-size.png",
+    );
+    expect(result.messages[0].parts[1]).toEqual({
+      type: "text",
+      text: '[Image "no-size.png" omitted: could not verify the image size before sending it to the model. Please reattach a smaller image or use Agent mode for large images.]',
+    });
+  });
+
+  it("keeps stored images when trusted file size is within the image limit", async () => {
+    mockConvexAction.mockResolvedValue([
+      fileUrlInfo("https://storage.example/small.png", {
+        sizeBytes: 2 * 1024 * 1024,
+        name: "small.png",
+      }),
+    ]);
     global.fetch = jest.fn(async () => {
-      return responseLike({
-        headers: { "content-length": String(2 * 1024 * 1024) },
-      });
+      throw new Error("Trusted file size should avoid network probes");
     }) as any;
 
     const result = await processMessageFiles(
@@ -289,7 +342,12 @@ describe("processMessageFiles image size guards", () => {
   });
 
   it("stages oversized Agent images into the sandbox instead of sending them inline", async () => {
-    mockConvexAction.mockResolvedValue(["https://storage.example/large.png"]);
+    mockConvexAction.mockResolvedValue([
+      fileUrlInfo("https://storage.example/large.png", {
+        sizeBytes: 8 * 1024 * 1024,
+        name: "large.png",
+      }),
+    ]);
     global.fetch = jest.fn(async () => {
       throw new Error("Agent image with declared size should not be probed");
     }) as any;
@@ -348,7 +406,13 @@ describe("processMessageFiles image size guards", () => {
   });
 
   it("fetches ask-mode PDFs from the storage-resolved URL, not the client URL", async () => {
-    mockConvexAction.mockResolvedValue(["https://storage.example/trusted.pdf"]);
+    mockConvexAction.mockResolvedValue([
+      fileUrlInfo("https://storage.example/trusted.pdf", {
+        sizeBytes: 100,
+        mediaType: "application/pdf",
+        name: "trusted.pdf",
+      }),
+    ]);
     const fetchSpy = jest.fn(async () => ({
       ok: true,
       arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -174,6 +174,8 @@ const PROVIDER_CONTEXT_OVERFLOW_PATTERNS = [
 ] as const;
 
 const PROVIDER_MEDIA_OVERFLOW_PATTERNS = [
+  /downloaded image content cannot exceed/i,
+  /image content cannot exceed/i,
   /image(?: file)? too large/i,
   /media(?: file)? too large/i,
   /attachment(?: file)? too large/i,

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -27,12 +27,20 @@ type FileToProcess = {
   fileId?: string;
   url?: string;
   mediaType?: string;
+  sizeBytes?: number;
   positions: Array<{ messageIndex: number; partIndex: number }>;
+};
+
+type ResolvedFileUrlInfo = {
+  url: string;
+  sizeBytes?: number;
+  mediaType?: string;
+  name?: string;
 };
 
 type SizeProbeResult = {
   bytes: number;
-  source: "content_length" | "content_range" | "download_probe";
+  source: "file_record" | "content_length" | "content_range" | "download_probe";
 };
 
 const redactUrlForLog = (url: string): string => {
@@ -44,15 +52,42 @@ const redactUrlForLog = (url: string): string => {
   }
 };
 
-const validateResolvedFileUrl = (
-  url: string | null | undefined,
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getFiniteSizeBytes = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+
+const validateResolvedFileUrlInfo = (
+  info: ResolvedFileUrlInfo | string | null | undefined,
   fileId: string,
-): string | null => {
+): ResolvedFileUrlInfo | null => {
+  const url =
+    typeof info === "string"
+      ? info
+      : isRecord(info) && typeof info.url === "string"
+        ? info.url
+        : null;
   if (!url) return null;
 
   try {
     validateDownloadUrl(url);
-    return url;
+    if (typeof info === "string") {
+      return { url };
+    }
+    if (!isRecord(info)) {
+      return { url };
+    }
+
+    return {
+      url,
+      sizeBytes: getFiniteSizeBytes(info.sizeBytes),
+      mediaType:
+        typeof info.mediaType === "string" ? info.mediaType : undefined,
+      name: typeof info.name === "string" ? info.name : undefined,
+    };
   } catch (error) {
     logger.warn("resolved_file_url_rejected", {
       event: "resolved_file_url_rejected",
@@ -215,6 +250,9 @@ const imageOmittedText = (
 const untrustedImageUrlOmittedText = (name: unknown) =>
   `[Image "${typeof name === "string" && name.length > 0 ? name : "unnamed"}" omitted: URL-backed image attachments must be reattached before they can be sent to the model]`;
 
+const unverifiedImageOmittedText = (name: unknown) =>
+  `[Image "${typeof name === "string" && name.length > 0 ? name : "unnamed"}" omitted: could not verify the image size before sending it to the model. Please reattach a smaller image or use Agent mode for large images.]`;
+
 /**
  * Replace non-stored image file parts whose declared size exceeds Anthropic's
  * 5 MiB per-image limit with a short text note. Stored `fileId` images are
@@ -333,7 +371,7 @@ const collectFilesToProcess = (
 const fetchFileUrls = async (
   fileIds: string[],
   userId: string | undefined,
-): Promise<(string | null)[]> => {
+): Promise<(ResolvedFileUrlInfo | string | null)[]> => {
   if (!fileIds.length) return [];
   if (!userId) {
     logger.warn("file_url_fetch_skipped_missing_user_id", {
@@ -351,29 +389,34 @@ const fetchFileUrls = async (
     }
 
     const chunkResults = await Promise.all(
-      chunks.map(async (chunk, index): Promise<(string | null)[]> => {
-        try {
-          return await getConvexClient().action(
-            api.s3Actions.getFileUrlsByFileIdsAction,
-            {
-              serviceKey,
-              userId,
-              fileIds: chunk as Id<"files">[],
-            },
-          );
-        } catch (error) {
-          logger.warn("file_url_fetch_chunk_failed", {
-            event: "file_url_fetch_chunk_failed",
-            service: "chat-handler",
-            error: stringifyRedactedError(error),
-            file_count: fileIds.length,
-            chunk_file_count: chunk.length,
-            chunk_index: index,
-            chunk_count: chunks.length,
-          });
-          return chunk.map(() => null);
-        }
-      }),
+      chunks.map(
+        async (
+          chunk,
+          index,
+        ): Promise<(ResolvedFileUrlInfo | string | null)[]> => {
+          try {
+            return await getConvexClient().action(
+              api.s3Actions.getFileUrlsByFileIdsAction,
+              {
+                serviceKey,
+                userId,
+                fileIds: chunk as Id<"files">[],
+              },
+            );
+          } catch (error) {
+            logger.warn("file_url_fetch_chunk_failed", {
+              event: "file_url_fetch_chunk_failed",
+              service: "chat-handler",
+              error: stringifyRedactedError(error),
+              file_count: fileIds.length,
+              chunk_file_count: chunk.length,
+              chunk_index: index,
+              chunk_count: chunks.length,
+            });
+            return chunk.map(() => null);
+          }
+        },
+      ),
     );
 
     return chunkResults.flat();
@@ -402,12 +445,18 @@ const applyUrlsToFileParts = async (
   const fetchedUrls = await fetchFileUrls(fileIdsNeedingUrls, userId);
 
   filesNeedingUrls.forEach((file, index) => {
-    const resolvedUrl = validateResolvedFileUrl(
+    const resolved = validateResolvedFileUrlInfo(
       fetchedUrls[index],
       file.fileId!,
     );
-    if (resolvedUrl) {
-      file.url = resolvedUrl;
+    if (resolved) {
+      file.url = resolved.url;
+      if (typeof resolved.sizeBytes === "number") {
+        file.sizeBytes = resolved.sizeBytes;
+      }
+      if (!file.mediaType && resolved.mediaType) {
+        file.mediaType = resolved.mediaType;
+      }
     }
   });
 
@@ -423,34 +472,33 @@ const applyUrlsToFileParts = async (
           )
         : file.url;
 
-    const firstPart = file.positions.length
-      ? (messages[file.positions[0].messageIndex].parts![
-          file.positions[0].partIndex
-        ] as any)
-      : null;
     const isSupportedImage = isSupportedImageMediaType(file.mediaType ?? "");
-    // The storage URL is the provider-visible payload. Probe it even when the
-    // message has size metadata so stale or incorrect client/DB metadata can't
-    // leak an oversized image into OpenRouter and trigger a provider 413.
+    const trustedImageSize =
+      typeof file.sizeBytes === "number"
+        ? ({ bytes: file.sizeBytes, source: "file_record" } as const)
+        : null;
     const shouldProbeImageSize =
-      isSupportedImage && file.url && mode !== "agent";
+      isSupportedImage && file.url && mode !== "agent" && !trustedImageSize;
     const probedImageSize = shouldProbeImageSize
       ? await probeImageSize(file.url, MAX_IMAGE_SIZE)
       : null;
-    const declaredImageSize =
-      typeof firstPart?.size === "number" ? firstPart.size : null;
-    const effectiveImageSize = probedImageSize?.bytes ?? declaredImageSize;
+    const effectiveImageSize = trustedImageSize ?? probedImageSize;
     const imageLimit =
-      effectiveImageSize != null &&
-      effectiveImageSize > MAX_PROVIDER_IMAGE_DOWNLOAD_SIZE
+      effectiveImageSize &&
+      effectiveImageSize.bytes > MAX_PROVIDER_IMAGE_DOWNLOAD_SIZE
         ? MAX_PROVIDER_IMAGE_DOWNLOAD_SIZE
         : MAX_IMAGE_SIZE;
     const shouldOmitImage =
       isSupportedImage &&
       effectiveImageSize != null &&
-      effectiveImageSize > imageLimit;
+      effectiveImageSize.bytes > imageLimit;
+    const shouldOmitUnverifiedImage =
+      isSupportedImage &&
+      mode !== "agent" &&
+      !!file.url &&
+      effectiveImageSize == null;
 
-    if (shouldOmitImage && mode !== "agent") {
+    if ((shouldOmitImage || shouldOmitUnverifiedImage) && mode !== "agent") {
       logger.warn("image_attachment_omitted_before_provider_call", {
         event: "image_attachment_omitted_before_provider_call",
         service: "chat-handler",
@@ -458,11 +506,10 @@ const applyUrlsToFileParts = async (
         file_ref: file.fileId ? "file_id" : "inline_url",
         file_key: file.fileId ? fileKey : undefined,
         media_type: file.mediaType,
-        size_bytes: effectiveImageSize,
+        size_bytes: effectiveImageSize?.bytes,
         limit_bytes: imageLimit,
-        size_source:
-          probedImageSize?.source ??
-          (declaredImageSize != null ? "message_part" : undefined),
+        size_source: effectiveImageSize?.source,
+        reason: shouldOmitImage ? "size_exceeded" : "size_unverified",
         mode,
       });
     }
@@ -475,9 +522,14 @@ const applyUrlsToFileParts = async (
           type: "text",
           text: imageOmittedText(
             filePart.name,
-            effectiveImageSize!,
+            effectiveImageSize!.bytes,
             imageLimit,
           ),
+        };
+      } else if (shouldOmitUnverifiedImage) {
+        messages[messageIndex].parts![partIndex] = {
+          type: "text",
+          text: unverifiedImageOmittedText(filePart.name),
         };
       } else {
         filePart.url = finalUrl;

--- a/lib/utils/sidebar-utils.ts
+++ b/lib/utils/sidebar-utils.ts
@@ -622,6 +622,7 @@ export function extractSidebarContentFromMessage(
         mediaType: f.mediaType,
         fileId: f.fileId,
         s3Key: f.s3Key,
+        sizeBytes: typeof f.sizeBytes === "number" ? f.sizeBytes : undefined,
       }));
 
       contentList.push({

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1137,6 +1137,7 @@ export const agentLongTask = task({
                 name: string;
                 mediaType: string;
                 s3Key?: string;
+                sizeBytes?: number;
               }>,
             ) => {
               if (!fileMetadata || fileMetadata.length === 0) return;

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -246,6 +246,7 @@ export interface SidebarSharedFiles {
     mediaType?: string;
     fileId?: string;
     s3Key?: string;
+    sizeBytes?: number;
   }>;
   requestedPaths: string[];
   isExecuting: boolean;

--- a/types/file.ts
+++ b/types/file.ts
@@ -48,6 +48,8 @@ export interface FilePart {
   storage?: "s3" | "local-desktop";
   localAttachmentId?: string;
   s3Key?: string; // S3 key for on-demand URL fetching (S3 files)
+  size?: number;
+  sizeBytes?: number;
 }
 
 // Props for FilePartRenderer component
@@ -105,6 +107,7 @@ export interface FileDetails {
   mediaType?: string;
   url?: string | null;
   s3Key?: string;
+  sizeBytes?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- propagate trusted `sizeBytes` metadata for sandbox-generated files through fileDetails, sidebar/file-card rendering, and Convex message queries
- return size/media metadata from the service file URL action and use it during provider-prep image checks
- fail closed for ask-mode stored images when size cannot be verified, and classify OpenRouter downloaded-image 413s as media overflow

## Validation
- `pnpm jest lib/utils/__tests__/file-transform-utils.test.ts lib/utils/__tests__/error-utils.test.ts convex/__tests__/s3Actions.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm exec prettier --check ...` on touched files

## Manual verification
- In ask mode, attach or reuse a stored image larger than the provider image limit and send a follow-up prompt. It should be replaced with an omitted-image text note instead of failing the provider call.
- Reopen a chat with `get_terminal_files` generated artifacts. File cards/sidebar entries should still show and preserve size metadata when available.

Visual verification was not run because this change only passes existing file-size metadata through existing file card/sidebar UI without layout or style changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file size information tracking throughout the system for better visibility into uploaded files.

* **Bug Fixes**
  * Improved detection of oversized media and clearer error messaging when files exceed provider limits.
  * Enhanced image size verification to prevent sending oversized images to AI providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->