### PR TITLE
Update ask mode model routing

### DIFF
--- a/app/components/ModelSelector/CostIndicator.tsx
+++ b/app/components/ModelSelector/CostIndicator.tsx
@@ -15,7 +15,7 @@ export function getCostTier(modelId: string, mode?: ChatMode): CostTier {
     case "hackerai-standard":
       return mode && isAgentMode(mode) ? "medium" : "low";
     case "hackerai-pro":
-      return mode && isAgentMode(mode) ? "high" : "medium";
+      return "high";
     case "hackerai-max":
       return "very-high";
     default:

--- a/app/components/ModelSelector/__tests__/options-drift.test.ts
+++ b/app/components/ModelSelector/__tests__/options-drift.test.ts
@@ -33,16 +33,16 @@ describe("ModelSelector tier ↔ provider drift", () => {
 
   it("HackerAI Standard resolves to different providers per mode", () => {
     expect(resolveTierToProviderKey("hackerai-standard", "ask")).toBe(
-      "model-gemini-3-flash",
+      "model-deepseek-v4-pro",
     );
     expect(resolveTierToProviderKey("hackerai-standard", "agent")).toBe(
       "model-kimi-k2.7-code",
     );
   });
 
-  it("HackerAI Pro resolves to DeepSeek in ask mode and Sonnet in agent mode", () => {
+  it("HackerAI Pro resolves to Sonnet in both modes", () => {
     expect(resolveTierToProviderKey("hackerai-pro", "ask")).toBe(
-      "model-deepseek-v4-pro",
+      "model-sonnet-4.6",
     );
     expect(resolveTierToProviderKey("hackerai-pro", "agent")).toBe(
       "model-sonnet-4.6",

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -17,14 +17,13 @@ export const ASK_MODEL_OPTIONS: ModelOption[] = [
     label: "HackerAI Standard",
     description: "Reliable performance for everyday tasks",
     poweredBy:
-      "DeepSeek V4 Flash · switches to Gemini 3 Flash for images & PDFs",
+      "DeepSeek V4 Pro · switches to Gemini 3 Flash for images & PDFs",
   },
   {
     id: "hackerai-pro",
     label: "HackerAI Pro",
     description: "Superior performance for most assignments",
-    poweredBy:
-      "DeepSeek V4 Pro · switches to Claude Sonnet 4.6 for images & PDFs",
+    poweredBy: "Claude Sonnet 4.6",
   },
   {
     id: "hackerai-max",

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -387,9 +387,9 @@ export function resolveTierToProviderKey(
     case "hackerai-standard":
       return isAgentMode(mode)
         ? "model-kimi-k2.7-code"
-        : "model-gemini-3-flash";
+        : "model-deepseek-v4-pro";
     case "hackerai-pro":
-      return isAgentMode(mode) ? "model-sonnet-4.6" : "model-deepseek-v4-pro";
+      return "model-sonnet-4.6";
     case "hackerai-max":
       return "model-opus-4.6";
   }

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -6,7 +6,10 @@
  * that the function fails closed (no fallback, no throw) for unknown keys.
  */
 
-import { buildProviderOptions } from "@/lib/api/chat-stream-helpers";
+import {
+  buildProviderOptions,
+  isAutoModelSelectionForRetry,
+} from "@/lib/api/chat-stream-helpers";
 
 jest.mock("@/lib/db/actions", () => ({
   getNotes: jest.fn(),
@@ -186,8 +189,11 @@ describe("buildProviderOptions fallback chain", () => {
     expect(opts.openrouter).not.toHaveProperty("models");
   });
 
-  it.each(["ask-model-free", "model-deepseek-v4-flash"])(
-    "keeps reasoning disabled for auto/standard ask mode model %s",
+  it.each([
+    "ask-model-free",
+    "model-deepseek-v4-flash",
+  ])(
+    "keeps reasoning disabled for free/flash ask mode model %s",
     (modelName) => {
       const opts = buildProviderOptions(false, "user-1", modelName, "ask");
       expect(opts.openrouter.reasoning).toEqual({ enabled: false });
@@ -251,5 +257,48 @@ describe("buildProviderOptions fallback chain", () => {
       reasoning: { enabled: true },
       models: [GEMINI_3_5_SLUG, GROK_SLUG],
     });
+  });
+});
+
+describe("isAutoModelSelectionForRetry", () => {
+  it("keeps paid ask Auto retryable after it resolves to explicit DeepSeek Pro", () => {
+    expect(
+      isAutoModelSelectionForRetry({
+        selectedModel: "model-deepseek-v4-pro",
+        selectedModelOverride: "auto",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats missing paid model override as Auto even with an explicit provider key", () => {
+    expect(
+      isAutoModelSelectionForRetry({
+        selectedModel: "model-deepseek-v4-pro",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat explicit paid Standard or Pro selections as Auto", () => {
+    expect(
+      isAutoModelSelectionForRetry({
+        selectedModel: "model-deepseek-v4-pro",
+        selectedModelOverride: "hackerai-standard",
+      }),
+    ).toBe(false);
+    expect(
+      isAutoModelSelectionForRetry({
+        selectedModel: "model-sonnet-4.6",
+        selectedModelOverride: "hackerai-pro",
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves retry behavior for legacy auto-router model keys", () => {
+    expect(
+      isAutoModelSelectionForRetry({
+        selectedModel: "ask-model-free",
+        selectedModelOverride: "hackerai-standard",
+      }),
+    ).toBe(true);
   });
 });

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -67,6 +67,7 @@ import {
   buildExtraUsageConfig,
   estimatePreflightInputTokens,
   getRetryFallbackModel,
+  isAutoModelSelectionForRetry,
 } from "@/lib/api/chat-stream-helpers";
 import { geolocation } from "@vercel/functions";
 import { NextRequest } from "next/server";
@@ -640,12 +641,10 @@ export const createChatHandler = () => {
               trackedProvider.languageModel(selectedModel).modelId;
 
             let isRetryWithFallback = false;
-            const isAutoModel = [
-              "ask-model",
-              "ask-model-free",
-              "agent-model",
-              "agent-model-free",
-            ].includes(selectedModel);
+            const isAutoModel = isAutoModelSelectionForRetry({
+              selectedModel,
+              selectedModelOverride,
+            });
             const fallbackModel = getRetryFallbackModel(selectedModel, mode);
             const fallbackModelId =
               trackedProvider.languageModel(fallbackModel).modelId;

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -17,6 +17,7 @@ import type {
   ChatMode,
   ExtraUsageConfig,
   SandboxPreference,
+  SelectedModel,
   SubscriptionTier,
   Todo,
   UserCustomization,
@@ -469,6 +470,27 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "model-kimi-k2.7-code": ["fallback-grok-4.3"],
   "model-kimi-k2.6": ["fallback-grok-4.3"],
 };
+
+const AUTO_MODEL_KEYS = new Set<string>([
+  "ask-model",
+  "ask-model-free",
+  "agent-model",
+  "agent-model-free",
+]);
+
+export function isAutoModelSelectionForRetry({
+  selectedModel,
+  selectedModelOverride,
+}: {
+  selectedModel: string;
+  selectedModelOverride?: SelectedModel | null;
+}): boolean {
+  return (
+    !selectedModelOverride ||
+    selectedModelOverride === "auto" ||
+    AUTO_MODEL_KEYS.has(selectedModel)
+  );
+}
 
 const ANTHROPIC_FALLBACK_CHAIN_BY_MODE: Record<ChatMode, readonly ModelName[]> =
   {

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -161,8 +161,8 @@ describe("selectModel", () => {
       expect(selectModel("agent", "pro")).toBe("agent-model");
     });
 
-    it("should return ask-model-free (DeepSeek) for paid ask with no image/PDF", () => {
-      expect(selectModel("ask", "pro")).toBe("ask-model-free");
+    it("should return DeepSeek V4 Pro for paid ask with no image/PDF", () => {
+      expect(selectModel("ask", "pro")).toBe("model-deepseek-v4-pro");
     });
 
     it("should return ask-model (Gemini) for paid ask when an image/PDF is attached", () => {
@@ -173,26 +173,26 @@ describe("selectModel", () => {
       expect(selectModel("ask", "free")).toBe("ask-model-free");
     });
 
-    it("should return ask-model-free for ultra subscription with no image/PDF", () => {
-      expect(selectModel("ask", "ultra")).toBe("ask-model-free");
+    it("should return DeepSeek V4 Pro for ultra subscription with no image/PDF", () => {
+      expect(selectModel("ask", "ultra")).toBe("model-deepseek-v4-pro");
     });
 
-    it("should return ask-model-free for team subscription with no image/PDF", () => {
-      expect(selectModel("ask", "team")).toBe("ask-model-free");
+    it("should return DeepSeek V4 Pro for team subscription with no image/PDF", () => {
+      expect(selectModel("ask", "team")).toBe("model-deepseek-v4-pro");
     });
   });
 
-  // Tier override — Pro is mode/content-aware; Max maps to Opus in both modes
+  // Tier override — Standard is content-aware in ask mode; Max maps to Opus in both modes
   describe("tier override for ask mode (paid users)", () => {
-    it("should map HackerAI Pro to DeepSeek V4 Pro for text-only ask mode", () => {
+    it("should map HackerAI Pro to Sonnet 4.6 for text-only ask mode", () => {
       expect(selectModel("ask", "ultra", "hackerai-pro")).toBe(
-        "model-deepseek-v4-pro",
+        "model-sonnet-4.6",
       );
     });
 
-    it("should map HackerAI Pro to DeepSeek V4 Pro for team users", () => {
+    it("should map HackerAI Pro to Sonnet 4.6 for team users", () => {
       expect(selectModel("ask", "team", "hackerai-pro")).toBe(
-        "model-deepseek-v4-pro",
+        "model-sonnet-4.6",
       );
     });
 
@@ -202,9 +202,9 @@ describe("selectModel", () => {
       );
     });
 
-    it("should map HackerAI Standard to DeepSeek V4 Flash when no image/PDF", () => {
+    it("should map HackerAI Standard to DeepSeek V4 Pro when no image/PDF", () => {
       expect(selectModel("ask", "pro", "hackerai-standard")).toBe(
-        "model-deepseek-v4-flash",
+        "model-deepseek-v4-pro",
       );
     });
 
@@ -256,6 +256,12 @@ describe("selectModel", () => {
     it("should ignore tier override for free users in ask mode", () => {
       expect(selectModel("ask", "free", "hackerai-pro")).toBe("ask-model-free");
     });
+
+    it("should keep free ask Standard on the free DeepSeek route", () => {
+      expect(selectModel("ask", "free", "hackerai-standard")).toBe(
+        "ask-model-free",
+      );
+    });
   });
 
   // "auto" override
@@ -264,8 +270,8 @@ describe("selectModel", () => {
       expect(selectModel("agent", "pro", "auto")).toBe("agent-model");
     });
 
-    it("should treat 'auto' as no override in ask mode (text-only → DeepSeek)", () => {
-      expect(selectModel("ask", "pro", "auto")).toBe("ask-model-free");
+    it("should treat 'auto' as no override in paid ask mode (text-only → DeepSeek Pro)", () => {
+      expect(selectModel("ask", "pro", "auto")).toBe("model-deepseek-v4-pro");
     });
 
     it("should treat 'auto' as no override in ask mode with image/PDF → Gemini", () => {
@@ -277,7 +283,9 @@ describe("selectModel", () => {
   describe("undefined override", () => {
     it("should use default when override is undefined", () => {
       expect(selectModel("agent", "pro", undefined)).toBe("agent-model");
-      expect(selectModel("ask", "pro", undefined)).toBe("ask-model-free");
+      expect(selectModel("ask", "pro", undefined)).toBe(
+        "model-deepseek-v4-pro",
+      );
       expect(selectModel("ask", "pro", undefined, true)).toBe("ask-model");
     });
   });

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -37,11 +37,10 @@ export const getMaxStepsForUser = (
  * Selects the appropriate model based on mode and subscription.
  * @param mode - Chat mode (ask or agent)
  * @param hasImageOrPdf - Whether any message has an image or PDF attachment.
- *   Paid ASK on the Standard/auto route normally uses DeepSeek V4 Flash
- *   (text-only, much cheaper); when an image or PDF is present we promote to
- *   Gemini 3 Flash so vision/document parts are actually understood. Paid ASK
- *   Pro mirrors that shape with DeepSeek V4 Pro for text and Sonnet 4.6 for
- *   image/PDF prompts.
+ *   Paid ASK on the Standard/auto route normally uses DeepSeek V4 Pro
+ *   (text-only, much cheaper than Claude); when an image or PDF is present we
+ *   promote to Gemini 3 Flash so vision/document parts are actually understood.
+ *   Free ASK stays on DeepSeek V4 Flash. Paid ASK Pro always uses Sonnet 4.6.
  * @returns Model name to use
  */
 export function selectModel(
@@ -51,19 +50,21 @@ export function selectModel(
   hasImageOrPdf?: boolean,
 ): ModelName {
   const isAgent = isAgentMode(mode);
-  // ASK takes the cheap DeepSeek text path for free users (always) and for
-  // paid users only when no image/PDF is attached — DeepSeek is text-only,
-  // so we promote to Gemini 3 Flash when vision/document parts are present.
-  const askUsesDeepSeek =
-    !isAgent && (subscription === "free" || !hasImageOrPdf);
+  // DeepSeek ask routes are text-only, so image/PDF prompts promote to Gemini
+  // unless the selected tier intentionally uses a multimodal model such as
+  // Sonnet or Opus.
+  const isFreeAsk = !isAgent && subscription === "free";
+  const isPaidAskText = !isAgent && subscription !== "free" && !hasImageOrPdf;
 
   const autoModel: ModelName = isAgent
     ? subscription === "free"
       ? "agent-model-free"
       : "agent-model"
-    : askUsesDeepSeek
+    : isFreeAsk
       ? "ask-model-free"
-      : "ask-model";
+      : isPaidAskText
+        ? "model-deepseek-v4-pro"
+        : "ask-model";
 
   // Free users always route through the auto router; paid users may pick a
   // tier explicitly. The tier id is mode-aware via resolveTierToProviderKey.
@@ -71,16 +72,15 @@ export function selectModel(
     return autoModel;
   }
 
-  // Paid ASK Standard mirrors the auto-route split, but uses the explicit
-  // `model-deepseek-v4-flash` / `model-gemini-3-flash` keys so any UI that
-  // reads `getModelDisplayName` shows the picked model rather than the
-  // auto-router label.
+  // Paid ASK Standard mirrors the auto-route split, but uses explicit keys so
+  // any UI that reads `getModelDisplayName` shows the picked model rather than
+  // the auto-router label.
   if (selectedModel === "hackerai-standard" && !isAgent) {
-    return askUsesDeepSeek ? "model-deepseek-v4-flash" : "model-gemini-3-flash";
+    return hasImageOrPdf ? "model-gemini-3-flash" : "model-deepseek-v4-pro";
   }
 
   if (selectedModel === "hackerai-pro" && !isAgent) {
-    return hasImageOrPdf ? "model-sonnet-4.6" : "model-deepseek-v4-pro";
+    return "model-sonnet-4.6";
   }
 
   const providerKey = resolveTierToProviderKey(selectedModel, mode);
@@ -89,7 +89,7 @@ export function selectModel(
 
 /**
  * True if any message has an image or PDF file part. Used by selectModel
- * to decide whether the cheaper DeepSeek V4 Flash text route is viable.
+ * to decide whether the text-only DeepSeek ask route is viable.
  */
 function hasImageOrPdfAttachment(messages: UIMessage[]): boolean {
   return messages.some((msg) =>


### PR DESCRIPTION
## Summary
- route paid ask Standard/Auto text-only requests to DeepSeek V4 Pro while keeping free ask on the free DeepSeek route
- route ask Pro directly to Claude Sonnet 4.6 and update selector copy/cost indicator
- add retry-guard coverage so paid Auto remains retryable after resolving to an explicit provider key

## Verification
- pnpm test -- lib/chat/__tests__/chat-processor.test.ts app/components/ModelSelector/__tests__/options-drift.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts app/components/ModelSelector/__tests__/ModelSelector.test.tsx --runInBand
- pnpm lint (passes with existing warnings)
- Browser smoke on http://localhost:3001 using pro auth: Ask model selector opens, Standard tooltip shows DeepSeek V4 Pro, Pro tooltip shows Claude Sonnet 4.6, no console errors, no Next error overlay

## Known local validation note
- pnpm typecheck is blocked locally by the existing packages/local/src/index.ts ws type-resolution issue: Cannot find module 'ws' or its corresponding type declarations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced retry logic with automatic fallback models to improve reliability during API disruptions.

* **Updates**
  * Updated AI model routing for HackerAI tiers: Standard now uses DeepSeek V4 Pro for text-only prompts, and Pro uses Claude Sonnet 4.6 consistently.
  * Refined model selection to better distinguish text-only versus image/PDF (multimodal) requests.
  * Simplified HackerAI Pro cost tier behavior to remove mode-based switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->