### PR TITLE
Fix extra usage limit warning

### DIFF
--- a/app/components/__tests__/RateLimitWarning.test.tsx
+++ b/app/components/__tests__/RateLimitWarning.test.tsx
@@ -58,4 +58,29 @@ describe("RateLimitWarning", () => {
 
     expect(screen.getByText(/free Agent requests/i)).toBeInTheDocument();
   });
+
+  it("uses extra usage copy when paid overflow credits are active", () => {
+    render(
+      <RateLimitWarning
+        data={{
+          warningType: "extra-usage-active",
+          bucketType: "monthly",
+          resetTime: new Date(Date.now() + 60_000),
+          subscription: "pro",
+          capReason: "extra_usage_active",
+        }}
+        onDismiss={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(/You're now using extra usage credits/i),
+    ).toHaveTextContent("Your monthly limit resets");
+    expect(
+      screen.queryByText(/You've reached your monthly usage limit/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /view usage/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/lib/api/__tests__/chat-stream-helpers-rate-limit.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-rate-limit.test.ts
@@ -1,0 +1,101 @@
+import { sendRateLimitWarnings } from "@/lib/api/chat-stream-helpers";
+
+jest.mock("@/lib/db/actions", () => ({
+  getNotes: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
+const makeWriter = () =>
+  ({
+    write: jest.fn(),
+  }) as any;
+
+describe("sendRateLimitWarnings", () => {
+  const resetTime = new Date("2026-06-30T00:00:00.000Z");
+  const emptyMonthlyBucket = {
+    remaining: 0,
+    limit: 100,
+    resetTime,
+    monthly: {
+      remaining: 0,
+      limit: 100,
+      resetTime,
+    },
+  };
+
+  it("shows extra usage active when the included bucket is empty and credits can cover overflow", () => {
+    const writer = makeWriter();
+
+    sendRateLimitWarnings(writer, {
+      subscription: "pro",
+      mode: "ask",
+      rateLimitInfo: emptyMonthlyBucket,
+      extraUsageConfig: {
+        enabled: true,
+        hasBalance: true,
+        balanceDollars: 10,
+        autoReloadEnabled: false,
+      },
+    });
+
+    expect(writer.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "data-rate-limit-warning",
+        data: expect.objectContaining({
+          warningType: "extra-usage-active",
+          capReason: "extra_usage_active",
+        }),
+      }),
+    );
+  });
+
+  it("keeps the monthly-limit warning when extra usage is unavailable", () => {
+    const writer = makeWriter();
+
+    sendRateLimitWarnings(writer, {
+      subscription: "pro",
+      mode: "ask",
+      rateLimitInfo: emptyMonthlyBucket,
+    });
+
+    expect(writer.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "data-rate-limit-warning",
+        data: expect.objectContaining({
+          warningType: "token-bucket",
+          remainingPercent: 0,
+        }),
+      }),
+    );
+  });
+
+  it("does not show extra usage active when the extra-usage monthly cap is exhausted", () => {
+    const writer = makeWriter();
+
+    sendRateLimitWarnings(writer, {
+      subscription: "pro",
+      mode: "ask",
+      rateLimitInfo: emptyMonthlyBucket,
+      extraUsageConfig: {
+        enabled: true,
+        hasBalance: true,
+        balanceDollars: 10,
+        monthlyRemainingDollars: 0,
+        autoReloadEnabled: false,
+      },
+    });
+
+    expect(writer.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "data-rate-limit-warning",
+        data: expect.objectContaining({
+          warningType: "token-bucket",
+          remainingPercent: 0,
+        }),
+      }),
+    );
+  });
+});

--- a/lib/api/__tests__/chat-stream-helpers-rate-limit.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-rate-limit.test.ts
@@ -52,6 +52,32 @@ describe("sendRateLimitWarnings", () => {
     );
   });
 
+  it("shows extra usage active when auto-reload can cover overflow without prepaid balance", () => {
+    const writer = makeWriter();
+
+    sendRateLimitWarnings(writer, {
+      subscription: "pro",
+      mode: "ask",
+      rateLimitInfo: emptyMonthlyBucket,
+      extraUsageConfig: {
+        enabled: true,
+        hasBalance: false,
+        balanceDollars: 0,
+        autoReloadEnabled: true,
+      },
+    });
+
+    expect(writer.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "data-rate-limit-warning",
+        data: expect.objectContaining({
+          warningType: "extra-usage-active",
+          capReason: "extra_usage_active",
+        }),
+      }),
+    );
+  });
+
   it("keeps the monthly-limit warning when extra usage is unavailable", () => {
     const writer = makeWriter();
 

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -415,6 +415,7 @@ export const createChatHandler = () => {
               subscription,
               mode,
               rateLimitInfo,
+              extraUsageConfig,
             });
 
             let uploadSandboxBootPath: SandboxBootInfo["path"] | null = null;

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -134,9 +134,10 @@ export function sendRateLimitWarnings(
       extraUsagePointsDeducted?: number;
       rateLimitSkipped?: boolean;
     };
+    extraUsageConfig?: ExtraUsageConfig;
   },
 ): void {
-  const { subscription, mode, rateLimitInfo } = options;
+  const { subscription, mode, rateLimitInfo, extraUsageConfig } = options;
 
   if (subscription === "free") {
     // Warn when roughly 30% of daily limit remains (minimum threshold of 1)
@@ -154,16 +155,27 @@ export function sendRateLimitWarnings(
       });
     }
   } else if (rateLimitInfo.monthly) {
-    // Paid users with extra usage: warn when extra usage is being used
+    const canUseExtraUsage =
+      !!extraUsageConfig?.enabled &&
+      (extraUsageConfig.hasBalance || extraUsageConfig.autoReloadEnabled) &&
+      (extraUsageConfig.monthlyRemainingDollars === undefined ||
+        extraUsageConfig.monthlyRemainingDollars > 0);
+    const isUsingExtraUsage =
+      !!rateLimitInfo.extraUsagePointsDeducted &&
+      rateLimitInfo.extraUsagePointsDeducted > 0;
+
+    // Paid users with extra usage: warn when credits are being used, including
+    // the edge case where the included bucket is empty before output starts.
     if (
-      rateLimitInfo.extraUsagePointsDeducted &&
-      rateLimitInfo.extraUsagePointsDeducted > 0
+      isUsingExtraUsage ||
+      (rateLimitInfo.monthly.remaining <= 0 && canUseExtraUsage)
     ) {
       writeRateLimitWarning(writer, {
         warningType: "extra-usage-active",
         bucketType: "monthly",
         resetTime: rateLimitInfo.monthly.resetTime.toISOString(),
         subscription,
+        capReason: "extra_usage_active",
       });
     } else {
       // Paid users without extra usage: warn at 75% and 90%

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1089,6 +1089,7 @@ export const agentLongTask = task({
               subscription,
               mode,
               rateLimitInfo,
+              extraUsageConfig,
             });
 
             let uploadSandboxBootPath: SandboxBootInfo["path"] | null = null;


### PR DESCRIPTION
## Summary
- pass extra usage availability into rate-limit warning emission for chat and long-agent streams
- emit the existing extra-usage-active warning when paid users have exhausted included usage but can continue with extra credits or auto-reload
- add stream-level and UI regression tests for the extra usage warning copy

## Testing
- pnpm test -- lib/api/__tests__/chat-stream-helpers-rate-limit.test.ts app/components/__tests__/RateLimitWarning.test.tsx
- pnpm exec eslint lib/api/chat-stream-helpers.ts lib/api/chat-handler.ts trigger/agent-long.ts app/components/RateLimitWarning.tsx lib/api/__tests__/chat-stream-helpers-rate-limit.test.ts app/components/__tests__/RateLimitWarning.test.tsx
- pnpm exec prettier --check lib/api/chat-stream-helpers.ts lib/api/chat-handler.ts trigger/agent-long.ts app/components/__tests__/RateLimitWarning.test.tsx lib/api/__tests__/chat-stream-helpers-rate-limit.test.ts
- pnpm typecheck (fails: packages/local/src/index.ts(17,23): Cannot find module 'ws' or its corresponding type declarations)

## Manual verification
- In a paid account with extra usage credits or auto-reload available, exhaust included monthly usage and start/continue a chat or Agent run.
- Confirm the banner says: "You're now using extra usage credits. Your monthly limit resets ..."
- Confirm no hard monthly-limit warning appears while extra usage can continue covering overflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced rate limit warnings for paid users with extra usage credits enabled. When monthly quotas are exhausted but extra usage is available, users now see targeted messaging about available credits instead of generic limit warnings.

* **Tests**
  * Added comprehensive test coverage for rate limit warning logic and component display across different subscription scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->