### PR TITLE
Restore service file URL action compatibility

### DIFF
--- a/convex/__tests__/s3Actions.test.ts
+++ b/convex/__tests__/s3Actions.test.ts
@@ -1227,8 +1227,48 @@ describe("s3Actions", () => {
 
       expect(mockValidateServiceKey).toHaveBeenCalledWith("test-service-key");
       expect(result).toEqual([
-        serviceUrlInfo("https://s3.amazonaws.com/file1-url", mockFile1),
-        serviceUrlInfo("https://s3.amazonaws.com/file2-url", mockFile2),
+        "https://s3.amazonaws.com/file1-url",
+        "https://s3.amazonaws.com/file2-url",
+      ]);
+    });
+
+    it("should generate URL metadata for service callers that request file info", async () => {
+      const { generateS3DownloadUrl } = await import("../s3Utils");
+      const mockGenerateS3DownloadUrl =
+        generateS3DownloadUrl as jest.MockedFunction<
+          typeof generateS3DownloadUrl
+        >;
+
+      mockGenerateS3DownloadUrl.mockResolvedValue(
+        "https://s3.amazonaws.com/file1-url",
+      );
+
+      const { getFileUrlInfosByFileIdsAction } = await import("../s3Actions");
+      const mockFileId = "file1" as any;
+      const mockFile = {
+        _id: mockFileId,
+        s3_key: "users/user123/file1.pdf",
+        user_id: "user123",
+        name: "file1.pdf",
+        media_type: "application/pdf",
+        size: 1024,
+        file_token_size: 100,
+        is_attached: true,
+        _creationTime: Date.now(),
+      };
+
+      const mockCtx = {
+        runQuery: jest.fn().mockResolvedValue(mockFile),
+      } as any;
+
+      const result = await getFileUrlInfosByFileIdsAction.handler(mockCtx, {
+        serviceKey: "test-service-key",
+        userId: "user123",
+        fileIds: [mockFileId],
+      });
+
+      expect(result).toEqual([
+        serviceUrlInfo("https://s3.amazonaws.com/file1-url", mockFile),
       ]);
     });
 
@@ -1321,10 +1361,7 @@ describe("s3Actions", () => {
         fileIds: [mockFile1Id, mockFile2Id],
       });
 
-      expect(result).toEqual([
-        serviceUrlInfo("https://s3.amazonaws.com/file1-url", mockFile1),
-        null,
-      ]);
+      expect(result).toEqual(["https://s3.amazonaws.com/file1-url", null]);
     });
 
     it("should return null for files not found", async () => {
@@ -1457,9 +1494,9 @@ describe("s3Actions", () => {
 
       // File2 should return null due to error
       expect(result).toEqual([
-        serviceUrlInfo("https://s3.amazonaws.com/file1-url", mockFile1),
+        "https://s3.amazonaws.com/file1-url",
         null,
-        serviceUrlInfo("https://s3.amazonaws.com/file3-url", mockFile3),
+        "https://s3.amazonaws.com/file3-url",
       ]);
     });
 

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -34,6 +34,8 @@ type ServiceFileUrlInfo = {
   name: string;
 };
 
+const MAX_SERVICE_FILE_URL_BATCH_SIZE = 50;
+
 const getIdentityEntitlements = (identity: unknown) => {
   if (
     !identity ||
@@ -283,8 +285,12 @@ export const getFileUrlAction = action({
  * - Authenticates via service key (for backend use)
  * - Accepts array of file IDs (max 50 files)
  * - Generates S3 presigned URLs
- * - Returns array of URL metadata (matching order of fileIds, null for missing files)
+ * - Returns array of URLs (matching order of fileIds, null for missing files)
  * - Handles partial failures gracefully
+ *
+ * Keep this return shape string-only for deploy skew compatibility with older
+ * workers. New callers that need file metadata should use
+ * getFileUrlInfosByFileIdsAction.
  */
 export const getFileUrlsByFileIdsAction = action({
   args: {
@@ -292,8 +298,8 @@ export const getFileUrlsByFileIdsAction = action({
     userId: v.optional(v.string()),
     fileIds: v.array(v.id("files")),
   },
-  returns: v.array(v.union(serviceFileUrlInfoValidator, v.null())),
-  handler: async (ctx, args): Promise<Array<ServiceFileUrlInfo | null>> => {
+  returns: v.array(v.union(v.string(), v.null())),
+  handler: async (ctx, args): Promise<Array<string | null>> => {
     // Verify service role key
     validateServiceKey(args.serviceKey);
     if (!args.userId) {
@@ -301,16 +307,15 @@ export const getFileUrlsByFileIdsAction = action({
     }
 
     // Enforce batch size limit
-    const MAX_BATCH_SIZE = 50;
-    if (args.fileIds.length > MAX_BATCH_SIZE) {
+    if (args.fileIds.length > MAX_SERVICE_FILE_URL_BATCH_SIZE) {
       throw new Error(
-        `Batch size exceeds limit: Maximum ${MAX_BATCH_SIZE} files allowed per request (requested: ${args.fileIds.length})`,
+        `Batch size exceeds limit: Maximum ${MAX_SERVICE_FILE_URL_BATCH_SIZE} files allowed per request (requested: ${args.fileIds.length})`,
       );
     }
 
     // Get file records and generate URLs
-    const urls: Array<ServiceFileUrlInfo | null> = await Promise.all(
-      args.fileIds.map(async (fileId): Promise<ServiceFileUrlInfo | null> => {
+    const urls: Array<string | null> = await Promise.all(
+      args.fileIds.map(async (fileId): Promise<string | null> => {
         try {
           // Get file record using internal query
           const file: FileRecord = await ctx.runQuery(
@@ -333,12 +338,7 @@ export const getFileUrlsByFileIdsAction = action({
           }
 
           if (file.s3_key) {
-            return {
-              url: await generateS3DownloadUrl(file.s3_key),
-              sizeBytes: file.size,
-              mediaType: file.media_type,
-              name: file.name,
-            };
+            return await generateS3DownloadUrl(file.s3_key);
           }
 
           return null;
@@ -349,6 +349,69 @@ export const getFileUrlsByFileIdsAction = action({
             error:
               error instanceof Error
                 ? { name: error.name, message: error.message }
+                : String(error),
+          });
+          return null;
+        }
+      }),
+    );
+
+    return urls;
+  },
+});
+
+/**
+ * Metadata-aware service URL lookup for workers that need trusted DB file
+ * attributes before sending provider-visible media URLs.
+ */
+export const getFileUrlInfosByFileIdsAction = action({
+  args: {
+    serviceKey: v.string(),
+    userId: v.optional(v.string()),
+    fileIds: v.array(v.id("files")),
+  },
+  returns: v.array(v.union(serviceFileUrlInfoValidator, v.null())),
+  handler: async (ctx, args): Promise<Array<ServiceFileUrlInfo | null>> => {
+    validateServiceKey(args.serviceKey);
+    if (!args.userId) {
+      throw new Error("Missing userId for service file URL fetch");
+    }
+
+    if (args.fileIds.length > MAX_SERVICE_FILE_URL_BATCH_SIZE) {
+      throw new Error(
+        `Batch size exceeds limit: Maximum ${MAX_SERVICE_FILE_URL_BATCH_SIZE} files allowed per request (requested: ${args.fileIds.length})`,
+      );
+    }
+
+    const urls: Array<ServiceFileUrlInfo | null> = await Promise.all(
+      args.fileIds.map(async (fileId): Promise<ServiceFileUrlInfo | null> => {
+        try {
+          const file: FileRecord = await ctx.runQuery(
+            internal.fileStorage.getFileById,
+            { fileId },
+          );
+
+          if (!file || file.user_id !== args.userId) {
+            return null;
+          }
+
+          if (file.s3_key) {
+            return {
+              url: await generateS3DownloadUrl(file.s3_key),
+              sizeBytes: file.size,
+              mediaType: file.media_type,
+              name: file.name,
+            };
+          }
+
+          return null;
+        } catch (error) {
+          convexLogger.error("file_batch_url_info_generation_failed", {
+            fileId,
+            caller: "service",
+            error:
+              error instanceof Error
+                ? { message: error.message, name: error.name }
                 : String(error),
           });
           return null;

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -323,17 +323,7 @@ export const getFileUrlsByFileIdsAction = action({
             { fileId },
           );
 
-          // Return null if file not found
           if (!file || file.user_id !== args.userId) {
-            return null;
-          }
-
-          if (file.user_id !== args.userId) {
-            convexLogger.warn("file_batch_url_access_denied", {
-              fileId,
-              caller: "service",
-              userId: args.userId,
-            });
             return null;
           }
 
@@ -451,10 +441,9 @@ export const getFileUrlsBatchAction = action({
     }
 
     // Enforce batch size limit
-    const MAX_BATCH_SIZE = 50;
-    if (args.fileIds.length > MAX_BATCH_SIZE) {
+    if (args.fileIds.length > MAX_SERVICE_FILE_URL_BATCH_SIZE) {
       throw new Error(
-        `Batch size exceeds limit: Maximum ${MAX_BATCH_SIZE} files allowed per request (requested: ${args.fileIds.length})`,
+        `Batch size exceeds limit: Maximum ${MAX_SERVICE_FILE_URL_BATCH_SIZE} files allowed per request (requested: ${args.fileIds.length})`,
       );
     }
 

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -396,7 +396,7 @@ const fetchFileUrls = async (
         ): Promise<(ResolvedFileUrlInfo | string | null)[]> => {
           try {
             return await getConvexClient().action(
-              api.s3Actions.getFileUrlsByFileIdsAction,
+              api.s3Actions.getFileUrlInfosByFileIdsAction,
               {
                 serviceKey,
                 userId,


### PR DESCRIPTION
## Summary
- keep `getFileUrlsByFileIdsAction` string-only for deploy-skew compatibility with older workers
- add `getFileUrlInfosByFileIdsAction` for the new trusted file-size metadata flow
- update provider prep to call the metadata-aware action and cover both contracts in tests

## Why
A dev error appeared after #693 changed `getFileUrlsByFileIdsAction` from `(string | null)[]` to `({ url, sizeBytes, mediaType, name } | null)[]`. Older agent/chat workers still call the old validator and can crash with `url2.split is not a function` when they receive the new object shape.

## Validation
- `pnpm jest convex/__tests__/s3Actions.test.ts lib/utils/__tests__/file-transform-utils.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm exec prettier --check convex/s3Actions.ts convex/__tests__/s3Actions.test.ts lib/utils/file-transform-utils.ts`

## Manual verification
- Regenerate an agent/ask request that resolves stored file URLs while an older worker may still be active. The legacy action should return strings and no longer crash in `redactUrlForLog`.
- Send an ask-mode prompt with a stored image from #693 flow. New provider prep should still receive trusted `sizeBytes` through `getFileUrlInfosByFileIdsAction`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added metadata-aware file URL lookup that returns, per file, the download URL plus `sizeBytes`, `mediaType`, and `name` when available.

* **Refactor**
  * Updated batch file URL retrieval to return a simple list of URL strings (or `null` for unavailable files), with per-file failures handled independently.
  * Unified batch size enforcement for service-key and user-authenticated requests.

* **Tests**
  * Revised and expanded test coverage to match the new URL-only vs metadata-aware behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->