### PR TITLE
Set DeepSeek Pro ask reasoning high

### DIFF
--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -189,10 +189,7 @@ describe("buildProviderOptions fallback chain", () => {
     expect(opts.openrouter).not.toHaveProperty("models");
   });
 
-  it.each([
-    "ask-model-free",
-    "model-deepseek-v4-flash",
-  ])(
+  it.each(["ask-model-free", "model-deepseek-v4-flash"])(
     "keeps reasoning disabled for free/flash ask mode model %s",
     (modelName) => {
       const opts = buildProviderOptions(false, "user-1", modelName, "ask");
@@ -212,7 +209,20 @@ describe("buildProviderOptions fallback chain", () => {
     },
   );
 
-  it.each(["model-deepseek-v4-pro", "model-sonnet-4.6", "model-opus-4.6"])(
+  it("enables high reasoning for DeepSeek Pro ask mode", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-deepseek-v4-pro",
+      "ask",
+    );
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+      effort: "high",
+    });
+  });
+
+  it.each(["model-sonnet-4.6", "model-opus-4.6"])(
     "enables medium reasoning for ask mode model %s",
     (modelName) => {
       const opts = buildProviderOptions(false, "user-1", modelName, "ask");

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -515,17 +515,24 @@ const ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN = [
   "fallback-grok-4.3",
 ] as const satisfies readonly ModelName[];
 
-const ASK_MEDIUM_REASONING_MODELS = [
-  "ask-model",
-  "model-gemini-3-flash",
-  "model-deepseek-v4-pro",
-  "model-sonnet-4.6",
-  "model-opus-4.6",
-] as const satisfies readonly ModelName[];
+type AskReasoningEffort = "high" | "medium";
 
-const isAskMediumReasoningModel = (modelName?: string): boolean =>
-  typeof modelName === "string" &&
-  (ASK_MEDIUM_REASONING_MODELS as readonly string[]).includes(modelName);
+const ASK_REASONING_EFFORT_BY_MODEL: Partial<
+  Record<ModelName, AskReasoningEffort>
+> = {
+  "ask-model": "medium",
+  "model-gemini-3-flash": "medium",
+  "model-deepseek-v4-pro": "high",
+  "model-sonnet-4.6": "medium",
+  "model-opus-4.6": "medium",
+};
+
+const getAskReasoningEffort = (
+  modelName?: string,
+): AskReasoningEffort | undefined =>
+  typeof modelName === "string"
+    ? ASK_REASONING_EFFORT_BY_MODEL[modelName as ModelName]
+    : undefined;
 
 type FallbackOptions = {
   hasMultimodalToolResults?: boolean;
@@ -605,15 +612,17 @@ export function buildProviderOptions(
   const isGemini3Flash =
     modelName === "ask-model" || modelName === "model-gemini-3-flash";
   const fallbackSlugs = getFallbackSlugs(modelName, mode, options);
+  const askReasoningEffort =
+    mode === "ask" ? getAskReasoningEffort(modelName) : undefined;
   const reasoning = isReasoningModel
     ? {
         enabled: true,
         ...(isDeepSeekV4 && { effort: "xhigh" }),
       }
-    : mode === "ask" && isAskMediumReasoningModel(modelName)
+    : askReasoningEffort
       ? {
           enabled: true,
-          effort: "medium",
+          effort: askReasoningEffort,
           ...(isGemini3Flash && { exclude: true }),
         }
       : { enabled: false };


### PR DESCRIPTION
## Summary
- set ask-mode DeepSeek V4 Pro reasoning effort to high
- replace the shared medium-only ask reasoning list with a per-model effort map
- add focused provider-options regression coverage

## Testing
- pnpm test -- lib/api/__tests__/chat-stream-helpers-fallback.test.ts --runInBand
- pnpm exec prettier --check lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts
- pnpm exec eslint lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts
- pnpm typecheck

## Manual verification
Automated validation is sufficient; this is backend OpenRouter provider-option configuration with no direct UI surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning effort configuration in ask mode across AI models, with enhanced reasoning intensity for DeepSeek Pro and refined handling for other reasoning-capable models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->