### PR TITLE
Recover chat streams from provider pressure

### DIFF
--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -1098,7 +1098,13 @@ export const saveLatestSummary = mutation({
     summaryUpToMessageId: v.string(),
     metadata: v.optional(
       v.object({
-        reason: v.optional(v.string()),
+        reason: v.optional(
+          v.union(
+            v.literal("token_threshold"),
+            v.literal("provider_input_threshold"),
+            v.literal("provider_pressure"),
+          ),
+        ),
         promptVersion: v.optional(v.string()),
         model: v.optional(v.string()),
         status: v.optional(v.string()),

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -269,6 +269,39 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(fallbackIdx).toBeGreaterThan(retryModelIdx);
   });
 
+  test("/api/chat provider stream errors with reasoning-only output can retry on fallback", () => {
+    const helperImportIdx = chatHandlerSrc.indexOf(
+      "shouldRetryProviderStreamWithFallback",
+    );
+    const partsIdx = chatHandlerSrc.indexOf(
+      "const lastAssistantMessageParts",
+      helperImportIdx,
+    );
+    const retryDecisionIdx = chatHandlerSrc.indexOf(
+      "shouldRetryProviderStreamWithFallback(",
+      partsIdx,
+    );
+    const terminalProviderErrorIdx = chatHandlerSrc.indexOf(
+      "hasTerminalProviderStreamError:",
+      retryDecisionIdx,
+    );
+    const retryModelIdx = chatHandlerSrc.indexOf(
+      "const retryModel = shouldRetryWithoutImageToolResults",
+      terminalProviderErrorIdx,
+    );
+    const fallbackIdx = chatHandlerSrc.indexOf(
+      "const retryResult = await createStream(retryModel)",
+      terminalProviderErrorIdx,
+    );
+
+    expect(helperImportIdx).toBeGreaterThan(-1);
+    expect(partsIdx).toBeGreaterThan(helperImportIdx);
+    expect(retryDecisionIdx).toBeGreaterThan(partsIdx);
+    expect(terminalProviderErrorIdx).toBeGreaterThan(retryDecisionIdx);
+    expect(retryModelIdx).toBeGreaterThan(terminalProviderErrorIdx);
+    expect(fallbackIdx).toBeGreaterThan(retryModelIdx);
+  });
+
   test("outer catch checks live usage tracker before refunding", () => {
     const liveUsagePredicateIdx = taskSrc.indexOf(
       "const hasObservedUsage = () => !!observedUsageTracker?.hasUsage",

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -63,6 +63,7 @@ import {
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { getMaxTokensForSubscription } from "@/lib/token-utils";
 import { getSummarizationThresholdTokens } from "@/lib/chat/summarization/constants";
+import { getProviderPromptPressure } from "@/lib/chat/summarization/provider-pressure";
 import { getMaxStepsForUser } from "@/lib/chat/chat-processor";
 import { createPromptSerializationTools } from "@/lib/ai/tools/prompt-serialization";
 import {
@@ -461,6 +462,7 @@ export async function createAgentStream(
         }
 
         if (!ctx.temporary && !ctx.summarizationTracker.hasSummarized) {
+          const providerPromptPressure = getProviderPromptPressure(messages);
           const result = await runSummarizationStep({
             messages: state.finalMessages,
             modelMessages: messages,
@@ -481,6 +483,7 @@ export async function createAgentStream(
             tools: ctx.tools,
             providerOptions: getStepProviderOptions(),
             transcriptMessages: state.transcriptSourceMessages,
+            providerPromptPressure,
           });
 
           if (result.needsSummarization && result.summarizedMessages) {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -127,6 +127,7 @@ import {
   omitImageViewToolResultsForProviderRetry,
   omitTrailingStepStartAssistantMessage,
 } from "@/lib/chat/multimodal-tool-result-recovery";
+import { shouldRetryProviderStreamWithFallback } from "@/lib/chat/agent-long-provider-retry";
 import { FREE_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
 
 function getStreamContext() {
@@ -861,14 +862,20 @@ export const createChatHandler = () => {
                 onFinish: async ({ messages, isAborted }) => {
                   let retryScheduled = false;
                   try {
-                    // Check if stream finished with only step-start (indicates incomplete response)
                     const lastAssistantMessage = messages
                       .slice()
                       .reverse()
                       .find((m) => m.role === "assistant");
-                    const hasOnlyStepStart =
-                      lastAssistantMessage?.parts?.length === 1 &&
-                      lastAssistantMessage.parts[0]?.type === "step-start";
+                    const lastAssistantMessageParts =
+                      lastAssistantMessage?.parts ?? [];
+                    const shouldRetryWithFallback =
+                      shouldRetryProviderStreamWithFallback(
+                        lastAssistantMessageParts,
+                        {
+                          hasTerminalProviderStreamError:
+                            state.streamFinishReason === "error",
+                        },
+                      );
                     const imageRecovery =
                       state.providerRejectedMultimodalToolResults
                         ? omitImageViewToolResultsForProviderRetry(messages)
@@ -877,13 +884,15 @@ export const createChatHandler = () => {
                       imageRecovery.omittedCount > 0 && !isAborted;
 
                     if (
-                      hasOnlyStepStart ||
+                      shouldRetryWithFallback ||
                       shouldRetryWithoutImageToolResults
                     ) {
                       phLogger.warn(
                         shouldRetryWithoutImageToolResults
                           ? "Provider rejected image tool output - retrying without images"
-                          : "Stream finished incomplete - triggering fallback",
+                          : state.streamFinishReason === "error"
+                            ? "Provider stream errored before useful output - triggering fallback"
+                            : "Stream finished incomplete - triggering fallback",
                         {
                           chatId,
                           endpoint,
@@ -900,9 +909,10 @@ export const createChatHandler = () => {
                         },
                       );
 
-                      // Retry with fallback model for incomplete streams. For
-                      // image-tool rejection, retry the same selected model
-                      // after replacing image outputs with text placeholders.
+                      // Retry with fallback model for incomplete or reasoning-only
+                      // terminal provider streams. For image-tool rejection, retry
+                      // the same selected model after replacing image outputs with
+                      // text placeholders.
                       if (
                         !isRetryWithFallback &&
                         !isAborted &&

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -43,6 +43,7 @@ import {
   type EnsureSandbox,
   type SummarizationUsage,
 } from "@/lib/chat/summarization";
+import type { ProviderPromptPressure } from "@/lib/chat/summarization/provider-pressure";
 import { getNotes } from "@/lib/db/actions";
 import { generateNotesSection } from "@/lib/system-prompt/notes";
 import { logger } from "@/lib/logger";
@@ -359,6 +360,7 @@ export async function runSummarizationStep(options: {
   providerOptions?: Record<string, Record<string, unknown>>;
   modelMessages?: ModelMessage[];
   transcriptMessages?: UIMessage[];
+  providerPromptPressure?: ProviderPromptPressure | null;
 }): Promise<SummarizationStepResult> {
   const { needsSummarization, summarizedMessages, summarizationUsage } =
     await checkAndSummarizeIfNeeded({
@@ -380,6 +382,7 @@ export async function runSummarizationStep(options: {
       modelMessages: options.modelMessages,
       transcriptMessages: options.transcriptMessages,
       maxTokensOverride: options.ctxMaxTokens,
+      providerPromptPressure: options.providerPromptPressure,
     });
 
   if (!needsSummarization) {

--- a/lib/chat/agent-long-provider-retry.ts
+++ b/lib/chat/agent-long-provider-retry.ts
@@ -37,7 +37,7 @@ const isReasoningOnlyProviderOutput = (parts: unknown[]): boolean =>
   hasReasoningPart(parts) &&
   parts.every(isFallbackSafeProviderPart);
 
-export const shouldRetryAgentLongWithFallback = (
+export const shouldRetryProviderStreamWithFallback = (
   parts: unknown[],
   options: RetryDecisionOptions,
 ): boolean => {
@@ -52,3 +52,6 @@ export const shouldRetryAgentLongWithFallback = (
     isReasoningOnlyProviderOutput(parts)
   );
 };
+
+export const shouldRetryAgentLongWithFallback =
+  shouldRetryProviderStreamWithFallback;

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -7,6 +7,7 @@ import type {
   ToolSet,
 } from "ai";
 import type { ChatMode, SubscriptionTier, Todo } from "@/types";
+import type { ProviderPromptPressure } from "../provider-pressure";
 import {
   getSummarizationThresholdTokens,
   SUMMARIZATION_RESERVED_MAX_TOKENS,
@@ -102,6 +103,7 @@ const checkAndSummarizeForTest = (
   modelMessages?: ModelMessage[],
   transcriptMessages?: UIMessage[],
   maxTokensOverride?: number,
+  providerPromptPressure?: ProviderPromptPressure | null,
 ) =>
   checkAndSummarizeIfNeeded({
     uiMessages,
@@ -122,6 +124,7 @@ const checkAndSummarizeForTest = (
     modelMessages,
     transcriptMessages,
     maxTokensOverride,
+    providerPromptPressure,
   });
 
 /**
@@ -255,6 +258,39 @@ describe("checkAndSummarizeIfNeeded", () => {
 
     expect(result.needsSummarization).toBe(false);
     expect(result.summarizedMessages).toBe(fourMessages);
+  });
+
+  it("should summarize below-token prompts when provider pressure is high", async () => {
+    mockGenerateText.mockResolvedValue({ text: "Pressure summary" });
+
+    const result = await checkAndSummarizeIfNeeded({
+      uiMessages: fourMessages,
+      subscription: "pro",
+      languageModel: mockLanguageModel,
+      mode: "ask",
+      writer: mockWriter,
+      chatId: "chat-pressure",
+      chatSystemPrompt: "test-system-prompt",
+      providerPromptPressure: {
+        reason: "tool_result_count",
+        reasons: ["tool_result_count"],
+        toolResultCount: 101,
+        messageCount: 101,
+        summarizationMaxTokensOverride: 128_000,
+      },
+    });
+
+    expect(result.needsSummarization).toBe(true);
+    expect(result.summaryText).toBe("Pressure summary");
+    expect(mockSaveChatSummary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: "chat-pressure",
+        metadata: expect.objectContaining({
+          reason: "provider_pressure",
+          promptVersion: SUMMARY_PROMPT_VERSION,
+        }),
+      }),
+    );
   });
 
   it("should ignore a zero max token override instead of summarizing every free ask message", async () => {

--- a/lib/chat/summarization/__tests__/provider-pressure.test.ts
+++ b/lib/chat/summarization/__tests__/provider-pressure.test.ts
@@ -1,0 +1,77 @@
+import type { ModelMessage } from "ai";
+import {
+  getProviderPromptPressure,
+  PROVIDER_PRESSURE_MESSAGE_COUNT,
+  PROVIDER_PRESSURE_SERIALIZED_MESSAGE_BYTES,
+  PROVIDER_PRESSURE_SUMMARIZATION_MAX_TOKENS,
+  PROVIDER_PRESSURE_TOOL_RESULT_COUNT,
+} from "../provider-pressure";
+
+const toolResultMessage = (index: number, output: unknown): ModelMessage =>
+  ({
+    role: "tool",
+    content: [
+      {
+        type: "tool-result",
+        toolCallId: `call-${index}`,
+        toolName: "shell",
+        output,
+      },
+    ],
+  }) as unknown as ModelMessage;
+
+describe("getProviderPromptPressure", () => {
+  it("triggers for large tool-heavy provider prompts", () => {
+    const messages = Array.from(
+      { length: PROVIDER_PRESSURE_TOOL_RESULT_COUNT },
+      (_, index) => toolResultMessage(index, "x".repeat(5_000)),
+    );
+
+    const pressure = getProviderPromptPressure(messages);
+
+    expect(pressure).toMatchObject({
+      reason: "serialized_message_bytes",
+      toolResultCount: PROVIDER_PRESSURE_TOOL_RESULT_COUNT,
+      messageCount: PROVIDER_PRESSURE_TOOL_RESULT_COUNT,
+      summarizationMaxTokensOverride:
+        PROVIDER_PRESSURE_SUMMARIZATION_MAX_TOKENS,
+    });
+    expect(pressure?.reasons).toEqual([
+      "serialized_message_bytes",
+      "tool_result_count",
+    ]);
+    expect(pressure?.serializedMessageBytes).toBeGreaterThanOrEqual(
+      PROVIDER_PRESSURE_SERIALIZED_MESSAGE_BYTES,
+    );
+  });
+
+  it("triggers on provider message count even when content is small", () => {
+    const messages = Array.from(
+      { length: PROVIDER_PRESSURE_MESSAGE_COUNT },
+      (_, index) =>
+        ({
+          role: "user",
+          content: `small ${index}`,
+        }) as ModelMessage,
+    );
+
+    expect(getProviderPromptPressure(messages)).toMatchObject({
+      reason: "message_count",
+      reasons: ["message_count"],
+      toolResultCount: 0,
+      messageCount: PROVIDER_PRESSURE_MESSAGE_COUNT,
+    });
+  });
+
+  it("does not trigger for small prompts", () => {
+    const messages = [
+      {
+        role: "user",
+        content: "hello",
+      },
+      toolResultMessage(1, "short output"),
+    ] as ModelMessage[];
+
+    expect(getProviderPromptPressure(messages)).toBeNull();
+  });
+});

--- a/lib/chat/summarization/helpers.ts
+++ b/lib/chat/summarization/helpers.ts
@@ -45,7 +45,7 @@ export interface SummarizationUsage {
 }
 
 export interface SummaryPersistenceMetadata {
-  reason: "token_threshold" | "provider_input_threshold";
+  reason: "token_threshold" | "provider_input_threshold" | "provider_pressure";
   promptVersion: string;
   model?: string;
   status: "completed";
@@ -661,17 +661,20 @@ export const buildSummaryPersistenceMetadata = ({
   languageModel,
   usage,
   transcriptPath,
+  reason,
 }: {
   providerInputTokens: number;
   threshold: number;
   languageModel: LanguageModel;
   usage?: SummarizationUsage;
   transcriptPath?: string | null;
+  reason?: SummaryPersistenceMetadata["reason"];
 }): SummaryPersistenceMetadata => ({
   reason:
-    providerInputTokens > threshold
+    reason ??
+    (providerInputTokens > threshold
       ? "provider_input_threshold"
-      : "token_threshold",
+      : "token_threshold"),
   promptVersion: SUMMARY_PROMPT_VERSION,
   model: getLanguageModelIdentifier(languageModel),
   status: "completed",

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/utils/stream-writer-utils";
 import { isE2BSandbox } from "@/lib/ai/tools/utils/sandbox-types";
 import type { Id } from "@/convex/_generated/dataModel";
+import type { ProviderPromptPressure } from "./provider-pressure";
 
 import {
   MESSAGES_TO_KEEP_UNSUMMARIZED,
@@ -58,6 +59,7 @@ export interface CheckAndSummarizeOptions {
   modelMessages?: ModelMessage[];
   transcriptMessages?: UIMessage[];
   maxTokensOverride?: number;
+  providerPromptPressure?: ProviderPromptPressure | null;
 }
 
 /**
@@ -171,6 +173,7 @@ export const checkAndSummarizeIfNeeded = async ({
   modelMessages,
   transcriptMessages,
   maxTokensOverride,
+  providerPromptPressure,
 }: CheckAndSummarizeOptions): Promise<SummarizationResult> => {
   // Detect and separate synthetic summary message from real messages
   let realMessages: UIMessage[];
@@ -189,19 +192,22 @@ export const checkAndSummarizeIfNeeded = async ({
   }
 
   // Check token threshold on full messages (including summary) to determine need
+  const effectiveMaxTokensOverride =
+    providerPromptPressure?.summarizationMaxTokensOverride ?? maxTokensOverride;
   const maxTokens = resolveSummarizationMaxTokens(
     subscription,
-    maxTokensOverride,
+    effectiveMaxTokensOverride,
   );
   const summarizationThreshold = getSummarizationThresholdTokens(maxTokens);
   if (
+    !providerPromptPressure &&
     !isAboveTokenThreshold(
       uiMessages,
       subscription,
       fileTokens,
       systemPromptTokens,
       providerInputTokens,
-      maxTokens,
+      effectiveMaxTokensOverride,
     )
   ) {
     return NO_SUMMARIZATION(uiMessages);
@@ -270,6 +276,7 @@ export const checkAndSummarizeIfNeeded = async ({
       languageModel,
       usage: summarizationUsage,
       transcriptPath: savedPath,
+      reason: providerPromptPressure ? "provider_pressure" : undefined,
     });
 
     await persistSummary(chatId, finalSummaryText, cutoffMessageId, metadata);

--- a/lib/chat/summarization/provider-pressure.ts
+++ b/lib/chat/summarization/provider-pressure.ts
@@ -1,0 +1,83 @@
+import type { ModelMessage } from "ai";
+
+export const PROVIDER_PRESSURE_SERIALIZED_MESSAGE_BYTES = 450_000;
+export const PROVIDER_PRESSURE_TOOL_RESULT_COUNT = 100;
+export const PROVIDER_PRESSURE_MESSAGE_COUNT = 120;
+export const PROVIDER_PRESSURE_SUMMARIZATION_MAX_TOKENS = 128_000;
+
+export type ProviderPromptPressureReason =
+  | "serialized_message_bytes"
+  | "tool_result_count"
+  | "message_count";
+
+export interface ProviderPromptPressure {
+  reason: ProviderPromptPressureReason;
+  reasons: ProviderPromptPressureReason[];
+  serializedMessageBytes?: number;
+  toolResultCount: number;
+  messageCount: number;
+  summarizationMaxTokensOverride: number;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getSerializedBytes = (value: unknown): number | undefined => {
+  try {
+    return new TextEncoder().encode(JSON.stringify(value)).length;
+  } catch {
+    return undefined;
+  }
+};
+
+const countToolResultParts = (messages: ModelMessage[]): number => {
+  let count = 0;
+
+  for (const message of messages) {
+    const content = (message as Record<string, unknown>).content;
+    if (!Array.isArray(content)) continue;
+
+    for (const part of content) {
+      if (isRecord(part) && part.type === "tool-result") {
+        count++;
+      }
+    }
+  }
+
+  return count;
+};
+
+export const getProviderPromptPressure = (
+  messages: ModelMessage[],
+): ProviderPromptPressure | null => {
+  const serializedMessageBytes = getSerializedBytes(messages);
+  const toolResultCount = countToolResultParts(messages);
+  const messageCount = messages.length;
+  const reasons: ProviderPromptPressureReason[] = [];
+
+  if (
+    serializedMessageBytes != null &&
+    serializedMessageBytes >= PROVIDER_PRESSURE_SERIALIZED_MESSAGE_BYTES
+  ) {
+    reasons.push("serialized_message_bytes");
+  }
+
+  if (toolResultCount >= PROVIDER_PRESSURE_TOOL_RESULT_COUNT) {
+    reasons.push("tool_result_count");
+  }
+
+  if (messageCount >= PROVIDER_PRESSURE_MESSAGE_COUNT) {
+    reasons.push("message_count");
+  }
+
+  if (reasons.length === 0) return null;
+
+  return {
+    reason: reasons[0],
+    reasons,
+    serializedMessageBytes,
+    toolResultCount,
+    messageCount,
+    summarizationMaxTokensOverride: PROVIDER_PRESSURE_SUMMARIZATION_MAX_TOKENS,
+  };
+};

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -36,6 +36,10 @@ const MAX_DATABASE_ERROR_DATA_DEPTH = 3;
 const MAX_DATABASE_ERROR_DATA_ARRAY_LENGTH = 20;
 const LARGE_MESSAGE_SAVE_WARNING_BYTES = 850 * 1024;
 const REDACTED_ERROR_DATA_VALUE = "[Redacted]";
+type SummaryReason =
+  | "token_threshold"
+  | "provider_input_threshold"
+  | "provider_pressure";
 
 const sensitiveErrorDataKeys = new Set([
   "authorization",
@@ -1103,7 +1107,7 @@ export async function saveChatSummary({
   summaryText: string;
   summaryUpToMessageId: string;
   metadata?: {
-    reason?: string;
+    reason?: SummaryReason;
     promptVersion?: string;
     model?: string;
     status?: string;


### PR DESCRIPTION
## Summary
- retry `/api/chat` provider streams on fallback when a terminal provider error emitted only step-start/reasoning/metadata
- trigger summarization earlier for provider-hostile prompts with large serialized messages, many tool results, or high model-message counts
- add focused regression coverage for chat retry and provider-pressure summarization

## Validation
- `pnpm test -- lib/chat/__tests__/agent-long-provider-retry.test.ts lib/chat/summarization/__tests__/provider-pressure.test.ts lib/chat/summarization/__tests__/index.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `pnpm exec prettier --check lib/api/__tests__/agent-long-contracts.test.ts lib/api/agent-stream-runner.ts lib/api/chat-handler.ts lib/api/chat-stream-helpers.ts lib/chat/agent-long-provider-retry.ts lib/chat/summarization/__tests__/index.test.ts lib/chat/summarization/__tests__/provider-pressure.test.ts lib/chat/summarization/helpers.ts lib/chat/summarization/index.ts lib/chat/summarization/provider-pressure.ts`
- `pnpm exec eslint lib/api/__tests__/agent-long-contracts.test.ts lib/api/agent-stream-runner.ts lib/api/chat-handler.ts lib/api/chat-stream-helpers.ts lib/chat/agent-long-provider-retry.ts lib/chat/summarization/__tests__/index.test.ts lib/chat/summarization/__tests__/provider-pressure.test.ts lib/chat/summarization/helpers.ts lib/chat/summarization/index.ts lib/chat/summarization/provider-pressure.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- commit hook: `pnpm typecheck` and full `pnpm test` (146 suites / 1567 tests)

## Manual verification
- In Ask mode with Auto selected, continue a long tool-heavy chat until the provider prompt has many tool results; it should summarize before sending another very large provider step.
- Simulate or observe a terminal provider stream error after only reasoning/metadata output; `/api/chat` should retry on the fallback model instead of leaving the user with a broken partial answer.
- If visible text or tool output has already streamed, the run should not discard it for an unsafe fallback retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic conversation summarization now accounts for “provider prompt pressure” (e.g., tool-heavy inputs), adjusting when summaries trigger and annotating the persisted summary reason accordingly.

* **Bug Fixes**
  * Improved provider-stream fallback retry behavior: retries now trigger only after detecting terminal provider stream errors and incomplete or reasoning-only output, with updated warning/condition logic.

* **Tests**
  * Updated and added coverage for provider prompt pressure and the revised fallback-retry decision flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->