### PR TITLE
Fix Agent completion e2e status recovery

### DIFF
--- a/app/api/agent-long/resume/route.ts
+++ b/app/api/agent-long/resume/route.ts
@@ -74,7 +74,7 @@ export async function GET(req: NextRequest) {
       expirationTime: "6h",
     });
 
-    return NextResponse.json({ runId, publicAccessToken });
+    return NextResponse.json({ runId, publicAccessToken, chatId });
   } catch (error) {
     if (error instanceof ChatSDKError) return error.toResponse();
     console.error("[/api/agent-long/resume] failed:", error);

--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -247,6 +247,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({
       runId: handle.id,
       publicAccessToken,
+      chatId,
     });
   } catch (error) {
     if (error instanceof ChatSDKError) {

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -62,6 +62,44 @@ import Loading from "@/components/ui/loading";
 
 import { HackingSuggestions } from "./HackingSuggestions";
 
+const AGENT_LONG_COMPLETION_POLL_DELAY_MS = 5_000;
+const AGENT_LONG_COMPLETION_POLL_INTERVAL_MS = 2_000;
+const AGENT_LONG_COMPLETION_QUIET_MS = 3_000;
+
+const getAgentLongPartFingerprint = (part: unknown): string => {
+  if (typeof part !== "object" || part === null) return String(part);
+  const typedPart = part as {
+    type?: unknown;
+    text?: unknown;
+    delta?: unknown;
+    state?: unknown;
+  };
+  const type = typeof typedPart.type === "string" ? typedPart.type : "unknown";
+  const textLength =
+    typeof typedPart.text === "string" ? typedPart.text.length : undefined;
+  const deltaLength =
+    typeof typedPart.delta === "string" ? typedPart.delta.length : undefined;
+  if (textLength !== undefined || deltaLength !== undefined) {
+    return `${type}:${textLength ?? 0}:${deltaLength ?? 0}:${typedPart.state ?? ""}`;
+  }
+
+  try {
+    return `${type}:${JSON.stringify(part).length}`;
+  } catch {
+    return type;
+  }
+};
+
+const getAgentLongMessageFingerprint = (messages: ChatMessage[]): string =>
+  messages
+    .map(
+      (message) =>
+        `${message.id}:${message.role}:${(message.parts ?? [])
+          .map(getAgentLongPartFingerprint)
+          .join(",")}`,
+    )
+    .join("|");
+
 const ComputerSidebar = dynamic(
   () => import("./ComputerSidebar").then((m) => m.ComputerSidebar),
   { ssr: false },
@@ -271,6 +309,11 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     selectedModel,
     subscription,
   );
+  const shouldUseAgentLong = shouldUseAgentLongForAgent({
+    mode: chatMode,
+    subscription,
+    isTauri: isTauriEnvironment(),
+  });
   // Use ref for model selection to avoid stale closures in auto-send
   const requestSelectedModelRef = useLatestRef(requestSelectedModel);
 
@@ -635,6 +678,101 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   // changes, not on status transitions — avoiding the stale-data overwrite on stream stop.
   const statusRef = useRef(status);
   statusRef.current = status;
+
+  const agentLongMessageFingerprint = getAgentLongMessageFingerprint(messages);
+  const agentLongMessageFingerprintRef = useRef(agentLongMessageFingerprint);
+  const agentLongLastMessageChangeAtRef = useRef(Date.now());
+
+  useEffect(() => {
+    if (
+      agentLongMessageFingerprintRef.current === agentLongMessageFingerprint
+    ) {
+      return;
+    }
+    agentLongMessageFingerprintRef.current = agentLongMessageFingerprint;
+    agentLongLastMessageChangeAtRef.current = Date.now();
+  }, [agentLongMessageFingerprint]);
+
+  // Trigger.dev can finish and persist an Agent answer even if the realtime
+  // UI stream never delivers a terminal chunk to useChat. Reconcile against
+  // the app's authenticated resume endpoint so the first message in a new
+  // chat can leave "Working..." even before chatData is subscribed.
+  useEffect(() => {
+    if (
+      status !== "streaming" ||
+      !shouldUseAgentLong ||
+      temporaryChatsEnabled
+    ) {
+      return;
+    }
+
+    let stopped = false;
+    let pollInterval: ReturnType<typeof setInterval> | undefined;
+    const abortController = new AbortController();
+
+    const finishLocally = () => {
+      if (stopped) return;
+      stopped = true;
+      stop();
+      setIsAutoResuming(false);
+      setAwaitingServerChat(false);
+      dispatchStreaming({ type: "RESET_ON_FINISH" });
+
+      if (!isExistingChatRef.current) {
+        window.history.replaceState({}, "", `/c/${chatId}`);
+        removeDraft("new");
+        setIsExistingChat(true);
+      }
+    };
+
+    const checkRunCompletion = async () => {
+      if (
+        Date.now() - agentLongLastMessageChangeAtRef.current <
+        AGENT_LONG_COMPLETION_QUIET_MS
+      ) {
+        return;
+      }
+
+      try {
+        const response = await fetch(
+          `/api/agent-long/resume?chatId=${encodeURIComponent(chatId)}`,
+          { method: "GET", signal: abortController.signal },
+        );
+        if (response.status === 204) {
+          finishLocally();
+        }
+      } catch (error) {
+        if ((error as Error).name !== "AbortError") {
+          // Ignore transient polling failures; the underlying stream still owns
+          // the visible error state.
+        }
+      }
+    };
+
+    const pollDelay = setTimeout(() => {
+      void checkRunCompletion();
+      pollInterval = setInterval(() => {
+        void checkRunCompletion();
+      }, AGENT_LONG_COMPLETION_POLL_INTERVAL_MS);
+    }, AGENT_LONG_COMPLETION_POLL_DELAY_MS);
+
+    return () => {
+      stopped = true;
+      abortController.abort();
+      clearTimeout(pollDelay);
+      if (pollInterval !== undefined) {
+        clearInterval(pollInterval);
+      }
+    };
+  }, [
+    chatId,
+    isExistingChatRef,
+    setIsAutoResuming,
+    shouldUseAgentLong,
+    status,
+    stop,
+    temporaryChatsEnabled,
+  ]);
 
   // Ref bridge: StreamEffects exposes resetAutoContinueCount here
   const resetAutoContinueRef = useRef<(() => void) | null>(null);

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -37,6 +37,11 @@ const routeSrc = fs.readFileSync(
   "utf8",
 );
 
+const chatComponentSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../../app/components/chat.tsx"),
+  "utf8",
+);
+
 const taskSrc = fs.readFileSync(
   path.resolve(__dirname, "../../../trigger/agent-long.ts"),
   "utf8",
@@ -99,6 +104,41 @@ describe("agent-long-transport — direct UI stream reader", () => {
       /chunkType\s*===\s*"finish"[\s\S]{0,220}break;/,
     );
   });
+
+  test("completed runs drain briefly and then close normally when finish is missing", () => {
+    expect(transportSrc).toMatch(/COMPLETED_RUN_DRAIN_TIMEOUT_MS/);
+    expect(transportSrc).toMatch(/QUIET_STREAM_STATUS_POLL_INTERVAL_MS/);
+    expect(transportSrc).toMatch(/QUIET_STREAM_STATUS_POLL_AFTER_MS/);
+    expect(transportSrc).toMatch(/status\s*===\s*"COMPLETED"/);
+    expect(transportSrc).toMatch(/startCompletedRunDrainTimer\(\)/);
+    expect(transportSrc).toMatch(/runs\s*\.\s*retrieve\(runId\)/);
+    expect(transportSrc).toMatch(/pollResumeEndpointForTerminalRun/);
+    expect(transportSrc).toMatch(/\/api\/agent-long\/resume\?chatId=/);
+    expect(transportSrc).toMatch(/response\.status\s*===\s*204/);
+    expect(transportSrc).toMatch(/options\?\.chatId\s*\?\?\s*handle\.chatId/);
+    expect(transportSrc).toMatch(/completedRunDrainPromise/);
+    expect(transportSrc).toMatch(/completedRunDrainElapsed\s*=\s*true/);
+    expect(transportSrc).toMatch(/enqueueSyntheticFinish\(\)/);
+    expect(transportSrc).toMatch(
+      /completedRunDrainElapsed\s*=\s*true[\s\S]*enqueueSyntheticFinish\(\)[\s\S]*sawTerminalChunk\s*=\s*true[\s\S]*break;/,
+    );
+    expect(transportSrc).toMatch(
+      /userAborted\s*\|\|\s*timedOutAfterFinish\s*\|\|\s*completedRunDrainElapsed/,
+    );
+  });
+});
+
+describe("agent-long chat UI — completion reconciliation", () => {
+  test("polls the resume endpoint and clears useChat state after backend completion", () => {
+    expect(chatComponentSrc).toMatch(/AGENT_LONG_COMPLETION_POLL_DELAY_MS/);
+    expect(chatComponentSrc).toMatch(/AGENT_LONG_COMPLETION_QUIET_MS/);
+    expect(chatComponentSrc).toMatch(/\/api\/agent-long\/resume\?chatId=/);
+    expect(chatComponentSrc).toMatch(/response\.status\s*===\s*204/);
+    expect(chatComponentSrc).toMatch(/finishLocally\(\)/);
+    expect(chatComponentSrc).toMatch(/stop\(\)/);
+    expect(chatComponentSrc).toMatch(/window\.history\.replaceState/);
+    expect(chatComponentSrc).toMatch(/setIsExistingChat\(true\)/);
+  });
 });
 
 describe("agent-long cancel route — compare-and-clear idempotency", () => {
@@ -144,6 +184,12 @@ describe("agent-long resume route — 204 on terminal + self-heal on 404", () =>
   test("returns 204 when no active run ID is stored", () => {
     expect(resumeSrc).toMatch(/status:\s*204/);
   });
+
+  test("returns chat id with the public run handle", () => {
+    expect(resumeSrc).toMatch(
+      /NextResponse\.json\(\{\s*runId,\s*publicAccessToken,\s*chatId\s*\}\)/,
+    );
+  });
 });
 
 describe("agent-long task — Trigger.dev dashboard error visibility", () => {
@@ -188,6 +234,12 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(parallelIdx).toBeGreaterThan(-1);
     expect(tokenIdx).toBeGreaterThan(parallelIdx);
     expect(activeRunIdx).toBeGreaterThan(parallelIdx);
+  });
+
+  test("start route returns chat id with the public run handle", () => {
+    expect(routeSrc).toMatch(
+      /NextResponse\.json\(\{\s*runId:\s*handle\.id,\s*publicAccessToken,\s*chatId,/,
+    );
   });
 
   test("handled user rate limits are returned after the UI error chunk is flushed", () => {

--- a/lib/chat/agent-long-transport.ts
+++ b/lib/chat/agent-long-transport.ts
@@ -224,7 +224,7 @@ const buildSSEResponseFromRun = (
             if (!chatId) return;
             const response = await fetchWithErrorHandlers(
               `/api/agent-long/resume?chatId=${encodeURIComponent(chatId)}`,
-              { method: "GET" },
+              { method: "GET", signal: readAbortController?.signal },
             );
             if (response.status === 204) {
               handleRunStatus("COMPLETED");

--- a/lib/chat/agent-long-transport.ts
+++ b/lib/chat/agent-long-transport.ts
@@ -20,7 +20,11 @@ import { createToolInputDedupFilter } from "./agent-long-tool-input-dedup";
  * chunk from the beginning — useChat reconstructs the in-progress
  * assistant turn without needing a client-side cursor.
  */
-type RunHandle = { runId: string; publicAccessToken: string };
+type RunHandle = {
+  runId: string;
+  publicAccessToken: string;
+  chatId?: string;
+};
 
 const sseHeaders: HeadersInit = {
   "Content-Type": "text/event-stream",
@@ -49,12 +53,40 @@ const TERMINAL_RUN_STATUSES = new Set([
 const STREAM_TIMEOUT_MS = 5 * 60 * 1000;
 const STREAM_IDLE_TIMEOUT_SECONDS = STREAM_TIMEOUT_MS / 1000;
 const POST_FINISH_DRAIN_TIMEOUT_MS = 2_000;
+const COMPLETED_RUN_DRAIN_TIMEOUT_MS = 5_000;
+const QUIET_STREAM_STATUS_POLL_INTERVAL_MS = 2_000;
+const QUIET_STREAM_STATUS_POLL_AFTER_MS = 5_000;
+
+const getChatIdFromRequestInit = (
+  init: RequestInit | undefined,
+): string | undefined => {
+  if (typeof init?.body !== "string") return undefined;
+  try {
+    const body = JSON.parse(init.body) as { chatId?: unknown };
+    return typeof body.chatId === "string" ? body.chatId : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const getChatIdFromResumeUrl = (url: string): string | undefined => {
+  try {
+    const base =
+      typeof window === "undefined" ? "http://localhost" : window.location.href;
+    return new URL(url, base).searchParams.get("chatId") ?? undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 const buildSSEResponseFromRun = (
-  { runId, publicAccessToken }: RunHandle,
+  handle: RunHandle,
   signal?: AbortSignal,
+  options?: { chatId?: string },
 ): Response => {
+  const { runId, publicAccessToken } = handle;
   const encoder = new TextEncoder();
+  const chatId = options?.chatId ?? handle.chatId;
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       let closed = false;
@@ -123,6 +155,82 @@ const buildSSEResponseFromRun = (
             return;
           }
 
+          const completedRunDrainTimeout = Symbol(
+            "completed-run-drain-timeout",
+          );
+          let completedRunDrainTimer: ReturnType<typeof setTimeout> | undefined;
+          let resolveCompletedRunDrain:
+            | ((value: typeof completedRunDrainTimeout) => void)
+            | undefined;
+          const completedRunDrainPromise = new Promise<
+            typeof completedRunDrainTimeout
+          >((resolve) => {
+            resolveCompletedRunDrain = resolve;
+          });
+
+          let sawTerminalChunk = false;
+          let sawFinishChunk = false;
+          let timedOutAfterFinish = false;
+          let completedRunDrainElapsed = false;
+          let firstEventReceived = false;
+          let lastEventReceivedAt = Date.now();
+          let isPollingRunStatus = false;
+
+          const clearCompletedRunDrainTimer = () => {
+            if (completedRunDrainTimer === undefined) return;
+            clearTimeout(completedRunDrainTimer);
+            completedRunDrainTimer = undefined;
+          };
+
+          const startCompletedRunDrainTimer = () => {
+            if (
+              completedRunDrainTimer !== undefined ||
+              sawTerminalChunk ||
+              closed
+            ) {
+              return;
+            }
+
+            completedRunDrainTimer = setTimeout(() => {
+              resolveCompletedRunDrain?.(completedRunDrainTimeout);
+            }, COMPLETED_RUN_DRAIN_TIMEOUT_MS);
+          };
+
+          const enqueueSyntheticFinish = () => {
+            if (closed || sawFinishChunk) return;
+            try {
+              controller.enqueue(
+                encoder.encode(
+                  `data: ${JSON.stringify({ type: "finish" })}\n\n`,
+                ),
+              );
+            } catch {
+              // controller may already be closed
+            }
+            sawFinishChunk = true;
+          };
+
+          const handleRunStatus = (status: string | undefined) => {
+            if (status === "COMPLETED") {
+              startCompletedRunDrainTimer();
+              return;
+            }
+            if (status && TERMINAL_RUN_STATUSES.has(status)) {
+              readAbortController?.abort();
+            }
+          };
+
+          const pollResumeEndpointForTerminalRun = async () => {
+            if (!chatId) return;
+            const response = await fetchWithErrorHandlers(
+              `/api/agent-long/resume?chatId=${encodeURIComponent(chatId)}`,
+              { method: "GET" },
+            );
+            if (response.status === 204) {
+              handleRunStatus("COMPLETED");
+            }
+          };
+
           // Monitor run failure separately from the UI stream. Reading the
           // stream directly avoids a race where the mixed run+stream
           // subscription can discover the stream late and replay chunks only
@@ -135,8 +243,11 @@ const buildSSEResponseFromRun = (
               status?: string;
             }>) {
               const status = run.status;
-              if (status && TERMINAL_RUN_STATUSES.has(status)) {
-                readAbortController?.abort();
+              handleRunStatus(status);
+              if (
+                status === "COMPLETED" ||
+                (status && TERMINAL_RUN_STATUSES.has(status))
+              ) {
                 break;
               }
             }
@@ -150,6 +261,34 @@ const buildSSEResponseFromRun = (
               timeoutInSeconds: STREAM_IDLE_TIMEOUT_SECONDS,
             },
           );
+
+          const statusPollInterval = setInterval(() => {
+            if (
+              !firstEventReceived ||
+              sawTerminalChunk ||
+              closed ||
+              isPollingRunStatus ||
+              Date.now() - lastEventReceivedAt <
+                QUIET_STREAM_STATUS_POLL_AFTER_MS
+            ) {
+              return;
+            }
+
+            isPollingRunStatus = true;
+            void (async () => {
+              try {
+                const run = await runs.retrieve(runId);
+                handleRunStatus(run.status);
+              } catch {
+                // Fall back to the app's authenticated resume endpoint below.
+              }
+              if (!sawTerminalChunk) {
+                await pollResumeEndpointForTerminalRun().catch(() => undefined);
+              }
+            })().finally(() => {
+              isPollingRunStatus = false;
+            });
+          }, QUIET_STREAM_STATUS_POLL_INTERVAL_MS);
 
           // text-delta and reasoning-delta chunks are emitted per-token and
           // can number in the thousands for long tasks. Forwarding each one
@@ -201,14 +340,14 @@ const buildSSEResponseFromRun = (
             });
           });
 
-          let sawTerminalChunk = false;
-          let sawFinishChunk = false;
-          let timedOutAfterFinish = false;
-          let firstEventReceived = false;
           const iter = uiStream[Symbol.asyncIterator]();
           const readNextChunk = () => {
             if (!sawFinishChunk) {
-              return Promise.race([iter.next(), abortPromise]);
+              return Promise.race([
+                iter.next(),
+                abortPromise,
+                completedRunDrainPromise,
+              ]);
             }
 
             let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -225,6 +364,7 @@ const buildSSEResponseFromRun = (
               iter.next(),
               abortPromise,
               timeoutPromise,
+              completedRunDrainPromise,
             ]).finally(() => {
               if (timeoutId !== undefined) {
                 clearTimeout(timeoutId);
@@ -242,8 +382,15 @@ const buildSSEResponseFromRun = (
               timedOutAfterFinish = true;
               break;
             }
+            if (next === completedRunDrainTimeout) {
+              completedRunDrainElapsed = true;
+              enqueueSyntheticFinish();
+              sawTerminalChunk = true;
+              break;
+            }
             if (next.done) break;
             const chunk = next.value;
+            lastEventReceivedAt = Date.now();
 
             // Disarm the "no first event" timeout once the UI stream is
             // proven live. Without this, a run longer than STREAM_TIMEOUT_MS
@@ -311,6 +458,7 @@ const buildSSEResponseFromRun = (
               // The task writes a few data chunks after `finish`
               // (message-metadata, auto-continue).
               // Drain that short tail so the browser receives them.
+              clearCompletedRunDrainTimer();
               sawTerminalChunk = true;
               sawFinishChunk = true;
               continue;
@@ -318,6 +466,7 @@ const buildSSEResponseFromRun = (
 
             // abort / error are terminal and do not have useful trailing data.
             if (chunkType === "abort" || chunkType === "error") {
+              clearCompletedRunDrainTimer();
               sawTerminalChunk = true;
               break;
             }
@@ -326,7 +475,7 @@ const buildSSEResponseFromRun = (
           // Flush any deltas that didn't trigger a count- or timer-based flush.
           flushDeltaBuffers();
 
-          if (userAborted || timedOutAfterFinish) {
+          if (userAborted || timedOutAfterFinish || completedRunDrainElapsed) {
             // Release the trigger.dev subscription so it doesn't keep
             // streaming chunks into a dead controller.
             await iter.return?.(undefined).catch(() => undefined);
@@ -339,6 +488,8 @@ const buildSSEResponseFromRun = (
           }
 
           statusSubscription?.unsubscribe?.();
+          clearCompletedRunDrainTimer();
+          clearInterval(statusPollInterval);
           void statusMonitor;
         });
 
@@ -366,7 +517,9 @@ export const fetchAgentLongStream = async (
   if (!startResponse.ok) return startResponse;
 
   const handle: RunHandle = await startResponse.json();
-  return buildSSEResponseFromRun(handle, init?.signal ?? undefined);
+  return buildSSEResponseFromRun(handle, init?.signal ?? undefined, {
+    chatId: getChatIdFromRequestInit(init),
+  });
 };
 
 export const resumeAgentLongStream = async (
@@ -384,5 +537,7 @@ export const resumeAgentLongStream = async (
   if (!response.ok) return response;
 
   const handle: RunHandle = await response.json();
-  return buildSSEResponseFromRun(handle, init?.signal ?? undefined);
+  return buildSSEResponseFromRun(handle, init?.signal ?? undefined, {
+    chatId: getChatIdFromResumeUrl(url),
+  });
 };

--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -383,6 +383,43 @@ describe("processMessageFiles image size guards", () => {
     ]);
   });
 
+  it("falls back to legacy file URL action when metadata-aware action is not deployed", async () => {
+    mockConvexAction
+      .mockRejectedValueOnce(
+        new Error(
+          "Could not find public function for 's3Actions:getFileUrlInfosByFileIdsAction'.",
+        ),
+      )
+      .mockResolvedValueOnce(["https://storage.example/secret.txt"]);
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        fileId: "file_secret",
+        mediaType: "text/plain",
+        name: "secret.txt",
+        size: 100,
+        url: "https://client.example/secret.txt",
+      }),
+      "agent",
+      "user123",
+      "/home/user/upload",
+      "pro",
+    );
+
+    expect(mockConvexAction).toHaveBeenCalledTimes(2);
+    expect(result.sandboxFiles).toEqual([
+      {
+        kind: "url",
+        url: "https://storage.example/secret.txt",
+        localPath: "/home/user/upload/secret.txt",
+      },
+    ]);
+    expect(JSON.stringify(result.messages)).not.toContain(
+      "https://client.example/secret.txt",
+    );
+  });
+
   it("does not stage a client-supplied URL when storage resolution fails", async () => {
     mockConvexAction.mockResolvedValue([null]);
 

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -413,7 +413,28 @@ const fetchFileUrls = async (
               chunk_index: index,
               chunk_count: chunks.length,
             });
-            return chunk.map(() => null);
+
+            try {
+              return await getConvexClient().action(
+                api.s3Actions.getFileUrlsByFileIdsAction,
+                {
+                  serviceKey,
+                  userId,
+                  fileIds: chunk as Id<"files">[],
+                },
+              );
+            } catch (fallbackError) {
+              logger.warn("file_url_legacy_fetch_chunk_failed", {
+                event: "file_url_legacy_fetch_chunk_failed",
+                service: "chat-handler",
+                error: stringifyRedactedError(fallbackError),
+                file_count: fileIds.length,
+                chunk_file_count: chunk.length,
+                chunk_index: index,
+                chunk_count: chunks.length,
+              });
+              return chunk.map(() => null);
+            }
           }
         },
       ),


### PR DESCRIPTION
## Summary
- add Agent completion reconciliation so first-message Trigger-backed Agent runs leave Working/Stop after backend completion
- make the Agent transport drain completed runs and poll resume/run state on quiet streams
- include chatId in Agent run handles and fall back to legacy file URL resolution during Convex deploy skew
- add regression contracts for the completion path and file URL fallback

## Validation
- pnpm test -- --runInBand lib/api/__tests__/agent-long-contracts.test.ts lib/utils/__tests__/file-transform-utils.test.ts
- pnpm exec prettier --check app/components/chat.tsx lib/chat/agent-long-transport.ts app/api/agent-long/route.ts app/api/agent-long/resume/route.ts lib/api/__tests__/agent-long-contracts.test.ts lib/utils/file-transform-utils.ts lib/utils/__tests__/file-transform-utils.test.ts
- pnpm exec eslint app/components/chat.tsx lib/chat/agent-long-transport.ts app/api/agent-long/route.ts app/api/agent-long/resume/route.ts lib/api/__tests__/agent-long-contracts.test.ts lib/utils/file-transform-utils.ts lib/utils/__tests__/file-transform-utils.test.ts (passes with existing chat.tsx hook warnings)
- pnpm rate-limit:reset --all
- pnpm test:e2e --project=chromium --no-deps --workers=1 e2e/chat-agent.spec.ts -g "Pro Tier.*should accept file operations"
- pnpm typecheck
- pre-commit hook: typecheck + full jest (148 suites, 1592 tests)

## Notes
- Live e2e passed with Trigger worker 20260620.1 and backend Agent success logs.
- Playwright still prints an intermittent browser console TypeError about closing an errored ReadableStream after the UI recovers. It did not block the regression guard; treat as follow-up console polish, not the original stuck-state failure.

## Manual verification
- In a Pro account with Trigger dev running, attach secret.txt in Agent mode and ask it to read the word.
- Confirm the final answer renders, Working/Stop generation disappears, and the chat is usable for the next prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated reconnect/resume support for long-running agent chats by returning and using `chatId`.
  * Implemented completion reconciliation polling to ensure long responses finalize reliably.
* **Bug Fixes**
  * Improved long-running stream finalization behavior so terminal completion is delivered consistently.
  * Enhanced file URL resolution reliability with a legacy fallback when metadata-aware actions aren’t available.
* **Tests**
  * Added/expanded coverage for completion reconciliation, resume/start payloads (including `chatId`), and file URL legacy fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->