### PR TITLE
Refactor todo write state handling

### DIFF
--- a/app/components/TodoPanel.tsx
+++ b/app/components/TodoPanel.tsx
@@ -8,7 +8,7 @@ import {
   SharedTodoItem,
   getStatusIcon,
 } from "@/components/ui/shared-todo-item";
-import { getTodoStats } from "@/lib/utils/todo-utils";
+import { getTodoPanelViewState } from "@/lib/utils/todo-utils";
 
 interface TodoPanelProps {
   status?: ChatStatus;
@@ -23,18 +23,17 @@ export const TodoPanel = ({ status, placement = "chat" }: TodoPanelProps) => {
     sidebarOpen,
   } = useGlobalState();
 
-  // Deduplicate todos by id (keep last occurrence, consistent with backend)
-  const uniqueTodos = Array.from(
-    new Map(todos.map((todo) => [todo.id, todo])).values(),
-  );
-
-  const stats = getTodoStats(uniqueTodos);
-
-  // Don't show panel if no todos exist
-  const hasTodos = uniqueTodos.length > 0;
-
-  // Show panel only when there are active todos (hide when all are finished)
-  const hasActiveTodos = stats.inProgress > 0 || stats.pending > 0;
+  const viewState = getTodoPanelViewState(todos, status);
+  const {
+    todos: uniqueTodos,
+    stats,
+    hasTodos,
+    hasActiveTodos,
+    currentTodoIndex,
+    currentTodo,
+    isPaused,
+    currentTodoDisplayStatus,
+  } = viewState;
 
   // If panel is not visible, ensure global state is reset
   useEffect(() => {
@@ -62,31 +61,6 @@ export const TodoPanel = ({ status, placement = "chat" }: TodoPanelProps) => {
   const handleToggleExpand = () => {
     setIsTodoPanelExpanded(!isExpanded);
   };
-
-  // Find the "current" todo: prefer in-progress, otherwise the most recent
-  // completed/cancelled action. Pending-only is handled with a count fallback.
-  const currentTodoIndex = (() => {
-    const inProgressIdx = uniqueTodos.findIndex(
-      (t) => t.status === "in_progress",
-    );
-    if (inProgressIdx !== -1) return inProgressIdx;
-    for (let i = uniqueTodos.length - 1; i >= 0; i--) {
-      const s = uniqueTodos[i].status;
-      if (s === "completed" || s === "cancelled") return i;
-    }
-    return -1;
-  })();
-
-  const currentTodo =
-    currentTodoIndex !== -1 ? uniqueTodos[currentTodoIndex] : undefined;
-
-  // When the chat is idle but a todo is still in_progress, the user manually
-  // stopped the agent — surface the in_progress todo as paused.
-  const isPaused = status === "ready" && stats.inProgress > 0;
-  const currentTodoDisplayStatus =
-    currentTodo && isPaused && currentTodo.status === "in_progress"
-      ? "paused"
-      : currentTodo?.status;
 
   const headerText = isExpanded
     ? "Task progress"

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -47,7 +47,6 @@ import {
   type ChatMode,
 } from "@/types";
 import { coerceSelectedModel } from "@/types/chat";
-import { shouldTreatAsMerge } from "@/lib/utils/todo-utils";
 import { v4 as uuidv4 } from "uuid";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useParams, useRouter } from "next/navigation";
@@ -126,6 +125,37 @@ function streamingReducer(
   }
 }
 
+function getLatestTodoWriteOutput(messages: ChatMessage[]):
+  | {
+      key: string;
+      todos: Todo[];
+    }
+  | undefined {
+  for (
+    let messageIndex = messages.length - 1;
+    messageIndex >= 0;
+    messageIndex--
+  ) {
+    const message = messages[messageIndex];
+    const parts = message.parts || [];
+    for (let partIndex = parts.length - 1; partIndex >= 0; partIndex--) {
+      const part = parts[partIndex] as any;
+      const currentTodos = part?.output?.currentTodos;
+      if (
+        part?.type === "tool-todo_write" &&
+        part?.state === "output-available" &&
+        Array.isArray(currentTodos)
+      ) {
+        return {
+          key: `${message.id}:${part.toolCallId || partIndex}`,
+          todos: currentTodos as Todo[],
+        };
+      }
+    }
+  }
+  return undefined;
+}
+
 // Renderless component that isolates dataStream state subscriptions
 // (useAutoResume + useAutoContinue) from the Chat component.
 // Without this boundary, Chat subscribes to DataStreamStateContext
@@ -201,7 +231,8 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     streamingReducer,
     initialStreamingState,
   );
-  const { uploadStatus, summarizationStatus, rateLimitWarning } = streamingState;
+  const { uploadStatus, summarizationStatus, rateLimitWarning } =
+    streamingState;
 
   const {
     input,
@@ -211,9 +242,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     chatSidebarOpen,
     setChatSidebarOpen,
     initializeChat,
-    mergeTodos,
     setTodos,
-    replaceAssistantTodos,
     temporaryChatsEnabled,
     setChatReset,
     hasUserDismissedRateLimitWarning,
@@ -272,6 +301,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   );
   // Use ref for model selection to avoid stale closures in auto-send
   const requestSelectedModelRef = useLatestRef(requestSelectedModel);
+  const lastAppliedTodoOutputRef = useRef<string | null>(null);
 
   // Ensure we only initialize mode from server once per chat id
   const hasInitializedModeFromChatRef = useRef(false);
@@ -288,6 +318,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   // Sync local chat state from URL (single source of truth)
   useEffect(() => {
     setStreamedTitle(null);
+    lastAppliedTodoOutputRef.current = null;
     if (routeChatId) {
       setChatId(routeChatId);
       setIsExistingChat(true);
@@ -566,35 +597,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
         }
       }
     },
-    onToolCall: ({ toolCall }) => {
-      if (toolCall.toolName === "todo_write" && toolCall.input) {
-        const todoInput = toolCall.input as { merge?: boolean; todos: Todo[] };
-        if (!todoInput.todos) return;
-        // Determine last assistant message id to stamp/replace.
-        // Read via ref to avoid closing over the streaming messages array.
-        const currentMessages = messagesRef.current;
-        let lastAssistantId: string | undefined;
-        for (let i = currentMessages.length - 1; i >= 0; i--) {
-          if (currentMessages[i].role === "assistant") {
-            lastAssistantId = currentMessages[i].id;
-            break;
-          }
-        }
-
-        const treatAsMerge = shouldTreatAsMerge(
-          todoInput.merge,
-          todoInput.todos,
-        );
-
-        if (!treatAsMerge) {
-          // Fresh plan creation: replace assistant todos with new ones, stamp with current assistant id if present.
-          replaceAssistantTodos(todoInput.todos, lastAssistantId);
-        } else {
-          // Partial update: merge
-          mergeTodos(todoInput.todos);
-        }
-      }
-    },
     onFinish: () => {
       setIsAutoResuming(false);
       setAwaitingServerChat(false);
@@ -629,6 +631,21 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   // Keep refs in sync so closures read latest values
   setMessagesRef.current = setMessages;
   messagesRef.current = messages;
+
+  useEffect(() => {
+    const shouldApplyOutput =
+      status === "streaming" || status === "submitted" || !shouldFetchMessages;
+    if (!shouldApplyOutput) return;
+
+    const latestTodoOutput = getLatestTodoWriteOutput(
+      messages as ChatMessage[],
+    );
+    if (!latestTodoOutput) return;
+    if (lastAppliedTodoOutputRef.current === latestTodoOutput.key) return;
+
+    lastAppliedTodoOutputRef.current = latestTodoOutput.key;
+    setTodos(latestTodoOutput.todos);
+  }, [messages, setTodos, shouldFetchMessages, status]);
 
   // Ref (not state) so the Convex sync effect only fires when paginatedMessages.results
   // changes, not on status transitions — avoiding the stale-data overwrite on stream stop.

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -25,6 +25,7 @@ import type { Todo } from "@/types";
 import {
   mergeTodos as mergeTodosUtil,
   computeReplaceAssistantTodos,
+  type TodoLike,
 } from "@/lib/utils/todo-utils";
 import type { UploadedFileState } from "@/types/file";
 import type { FileMessagePart } from "@/types/file";
@@ -88,7 +89,7 @@ interface GlobalStateType {
   // Todos state
   todos: Todo[];
   setTodos: (todos: Todo[]) => void;
-  mergeTodos: (todos: Todo[]) => void;
+  mergeTodos: (todos: TodoLike[]) => void;
   replaceAssistantTodos: (todos: Todo[], sourceMessageId?: string) => void;
 
   // UI state
@@ -329,7 +330,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   );
   const [todos, setTodos] = useState<Todo[]>([]);
   const [isTodoPanelExpanded, setIsTodoPanelExpanded] = useState(false);
-  const mergeTodos = useCallback((newTodos: Todo[]) => {
+  const mergeTodos = useCallback((newTodos: TodoLike[]) => {
     setTodos((currentTodos) => mergeTodosUtil(currentTodos, newTodos));
   }, []);
   const replaceAssistantTodos = useCallback(

--- a/app/share/[shareId]/components/SharedTodoBlock.tsx
+++ b/app/share/[shareId]/components/SharedTodoBlock.tsx
@@ -4,6 +4,10 @@ import { useState, useMemo } from "react";
 import { ListTodo, CircleArrowRight, ChevronsUpDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SharedTodoItem } from "@/components/ui/shared-todo-item";
+import {
+  getTodoDisplayData,
+  getVisibleTodoBlockItems,
+} from "@/lib/utils/todo-utils";
 import type { Todo } from "@/types";
 
 interface SharedTodoBlockProps {
@@ -20,29 +24,11 @@ export const SharedTodoBlock = ({ todos, blockId }: SharedTodoBlockProps) => {
   const [showAllTodos, setShowAllTodos] = useState(false);
 
   const todoData = useMemo(() => {
-    const byStatus = {
-      completed: todos.filter((t) => t.status === "completed"),
-      inProgress: todos.filter((t) => t.status === "in_progress"),
-      pending: todos.filter((t) => t.status === "pending"),
-      cancelled: todos.filter((t) => t.status === "cancelled"),
-    };
-
-    const done = byStatus.completed.length;
-    const total = todos.length;
-    const currentInProgress = byStatus.inProgress[0];
-    const hasProgress = done > 0;
-
-    return {
-      byStatus,
-      done,
-      total,
-      currentInProgress,
-      hasProgress,
-    };
+    return getTodoDisplayData(todos);
   }, [todos]);
 
   const headerContent = useMemo(() => {
-    const { currentInProgress, done, total } = todoData;
+    const { currentInProgress, stats } = todoData;
 
     // When collapsed, show current in-progress task if available
     if (!isExpanded && currentInProgress) {
@@ -51,18 +37,20 @@ export const SharedTodoBlock = ({ todos, blockId }: SharedTodoBlockProps) => {
         icon: (
           <CircleArrowRight className="text-foreground" aria-hidden="true" />
         ),
-        showViewAll: total > 1 && done > 0,
+        showViewAll: stats.total > 1 && stats.done > 0,
       };
     }
 
     // When expanded OR no in-progress task, show list-todo icon with progress text
     const progressText =
-      done === 0 ? `To-dos (${total})` : `${done} of ${total} Done`;
+      stats.done === 0
+        ? `To-dos (${stats.total})`
+        : `${stats.done} of ${stats.total} Done`;
 
     return {
       text: progressText,
       icon: <ListTodo className="text-foreground" aria-hidden="true" />,
-      showViewAll: total > 1 && done > 0,
+      showViewAll: stats.total > 1 && stats.done > 0,
     };
   }, [todoData, isExpanded]);
 
@@ -78,55 +66,14 @@ export const SharedTodoBlock = ({ todos, blockId }: SharedTodoBlockProps) => {
     }
   };
 
-  const getVisibleTodos = () => {
-    const { hasProgress, done, currentInProgress, byStatus } = todoData;
-
-    if (!hasProgress || done === 0) {
-      return todos;
-    }
-
-    if (showAllTodos) {
-      return todos;
-    }
-
-    // Show collapsed view: last completed + current in-progress
-    const visibleTodos: Todo[] = [];
-
-    const lastCompleted = byStatus.completed[byStatus.completed.length - 1];
-    const lastCancelled = byStatus.cancelled[byStatus.cancelled.length - 1];
-
-    let mostRecentAction = null;
-    if (lastCompleted && lastCancelled) {
-      const completedIndex = todos.findIndex((t) => t.id === lastCompleted.id);
-      const cancelledIndex = todos.findIndex((t) => t.id === lastCancelled.id);
-      mostRecentAction =
-        completedIndex > cancelledIndex ? lastCompleted : lastCancelled;
-    } else {
-      mostRecentAction = lastCompleted || lastCancelled;
-    }
-
-    if (mostRecentAction) {
-      visibleTodos.push(mostRecentAction);
-    }
-
-    // Always show current in-progress task if not already included
-    if (
-      currentInProgress &&
-      !visibleTodos.some((t) => t.id === currentInProgress.id)
-    ) {
-      visibleTodos.push(currentInProgress);
-    }
-
-    // If no in-progress and no visible todos yet, show next pending
-    if (!currentInProgress && visibleTodos.length === 0) {
-      const nextPending = todos.find((todo) => todo.status === "pending");
-      if (nextPending) {
-        visibleTodos.push(nextPending);
-      }
-    }
-
-    return visibleTodos;
-  };
+  const visibleTodos = useMemo(
+    () =>
+      getVisibleTodoBlockItems({
+        todos,
+        showAllTodos,
+      }),
+    [showAllTodos, todos],
+  );
 
   return (
     <div className="flex-1 min-w-0">
@@ -167,7 +114,7 @@ export const SharedTodoBlock = ({ todos, blockId }: SharedTodoBlockProps) => {
         {/* Expanded list */}
         {isExpanded && (
           <div className="border-t border-border p-2 space-y-2">
-            {getVisibleTodos().map((todo) => (
+            {visibleTodos.map((todo) => (
               <SharedTodoItem key={todo.id} todo={todo} />
             ))}
           </div>

--- a/components/ui/shared-todo-item.tsx
+++ b/components/ui/shared-todo-item.tsx
@@ -22,7 +22,7 @@ export const getStatusIcon = (status: TodoDisplayStatus) =>
   STATUS_ICONS[status] || STATUS_ICONS.pending;
 
 export const getTextStyles = (status: TodoDisplayStatus) => {
-  if (status === "completed") {
+  if (status === "completed" || status === "cancelled") {
     return "line-through opacity-75 text-foreground";
   }
   if (status === "in_progress") {

--- a/components/ui/todo-block.tsx
+++ b/components/ui/todo-block.tsx
@@ -4,7 +4,10 @@ import { ListTodo, CircleArrowRight, ChevronsUpDown } from "lucide-react";
 import type { TodoBlockProps } from "@/types";
 import { useTodoBlockContext } from "@/app/contexts/TodoBlockContext";
 import { SharedTodoItem } from "@/components/ui/shared-todo-item";
-import { getTodoStats } from "@/lib/utils/todo-utils";
+import {
+  getTodoDisplayData,
+  getVisibleTodoBlockItems,
+} from "@/lib/utils/todo-utils";
 
 export const TodoBlock = ({
   todos,
@@ -26,28 +29,7 @@ export const TodoBlock = ({
   }, [messageId, blockId]); // Only depend on messageId and blockId to prevent infinite loops
 
   const todoData = useMemo(() => {
-    const byStatus = {
-      completed: todos.filter((t) => t.status === "completed"),
-      inProgress: todos.filter((t) => t.status === "in_progress"),
-      pending: todos.filter((t) => t.status === "pending"),
-      cancelled: todos.filter((t) => t.status === "cancelled"),
-    };
-
-    const stats = getTodoStats(todos);
-
-    const currentInProgress = byStatus.inProgress[0];
-    const lastCompleted = byStatus.completed[byStatus.completed.length - 1];
-    const hasProgress = stats.done > 0;
-    const allCompleted = stats.done === stats.total && stats.total > 0;
-
-    return {
-      byStatus,
-      stats,
-      currentInProgress,
-      lastCompleted,
-      hasProgress,
-      allCompleted,
-    };
+    return getTodoDisplayData(todos);
   }, [todos]);
 
   const headerContent = useMemo(() => {
@@ -89,69 +71,15 @@ export const TodoBlock = ({
     }
   };
 
-  const getVisibleTodos = () => {
-    const { hasProgress, stats, currentInProgress } = todoData;
-
-    if (!hasProgress || stats.done === 0) {
-      return todos;
-    }
-
-    if (showAllTodos) {
-      return todos;
-    }
-
-    // Show collapsed view: input todos + current in-progress
-    const visibleTodos = [];
-
-    // If we have inputTodos, show all of them (these are the todos being updated in this call)
-    if (inputTodos && inputTodos.length > 0) {
-      const inputTodoIds = new Set(inputTodos.map((t) => t.id));
-      const inputTodosFromCurrent = todos.filter((todo) =>
-        inputTodoIds.has(todo.id),
-      );
-      visibleTodos.push(...inputTodosFromCurrent);
-    } else {
-      // Fallback: show most recent completed/cancelled
-      const { lastCompleted, byStatus } = todoData;
-      const lastCancelled = byStatus.cancelled[byStatus.cancelled.length - 1];
-
-      let mostRecentAction = null;
-      if (lastCompleted && lastCancelled) {
-        const completedIndex = todos.findIndex(
-          (t) => t.id === lastCompleted.id,
-        );
-        const cancelledIndex = todos.findIndex(
-          (t) => t.id === lastCancelled.id,
-        );
-        mostRecentAction =
-          completedIndex > cancelledIndex ? lastCompleted : lastCancelled;
-      } else {
-        mostRecentAction = lastCompleted || lastCancelled;
-      }
-
-      if (mostRecentAction) {
-        visibleTodos.push(mostRecentAction);
-      }
-    }
-
-    // Always show current in-progress task if not already included
-    if (
-      currentInProgress &&
-      !visibleTodos.some((t) => t.id === currentInProgress.id)
-    ) {
-      visibleTodos.push(currentInProgress);
-    }
-
-    // If no in-progress and no visible todos yet, show next pending
-    if (!currentInProgress && visibleTodos.length === 0) {
-      const nextPending = todos.find((todo) => todo.status === "pending");
-      if (nextPending) {
-        visibleTodos.push(nextPending);
-      }
-    }
-
-    return visibleTodos;
-  };
+  const visibleTodos = useMemo(
+    () =>
+      getVisibleTodoBlockItems({
+        todos,
+        inputTodos,
+        showAllTodos,
+      }),
+    [inputTodos, showAllTodos, todos],
+  );
 
   return (
     <div className="flex-1 min-w-0">
@@ -199,7 +127,7 @@ export const TodoBlock = ({
         {/* Expanded list */}
         {isExpanded && (
           <div className="border-t border-border p-2 space-y-2">
-            {getVisibleTodos().map((todo) => (
+            {visibleTodos.map((todo) => (
               <SharedTodoItem key={todo.id} todo={todo} />
             ))}
           </div>

--- a/lib/ai/tools/__tests__/todo-write.test.ts
+++ b/lib/ai/tools/__tests__/todo-write.test.ts
@@ -97,6 +97,12 @@ describe("todo_write", () => {
         },
       ],
     });
+
+    const currentTodos = (
+      result as { currentTodos: Array<Record<string, unknown>> }
+    ).currentTodos;
+    expect(currentTodos[0].sourceMessageId).toBeUndefined();
+    expect(currentTodos[1]).toHaveProperty("sourceMessageId", "assistant-1");
   });
 
   it("returns a clear error for blank merge content", async () => {

--- a/lib/ai/tools/__tests__/todo-write.test.ts
+++ b/lib/ai/tools/__tests__/todo-write.test.ts
@@ -1,0 +1,88 @@
+import type { ToolContext } from "@/types";
+import { createTodoWrite } from "../todo-write";
+import { TodoManager } from "../utils/todo-manager";
+
+function makeContext(
+  initialTodos: ConstructorParameters<typeof TodoManager>[0] = [],
+) {
+  return {
+    todoManager: new TodoManager(initialTodos),
+    assistantMessageId: "assistant-1",
+  } as unknown as ToolContext;
+}
+
+async function runTool(
+  tool: ReturnType<typeof createTodoWrite>,
+  input: Record<string, unknown>,
+) {
+  const execute = (
+    tool as unknown as {
+      execute: (i: unknown, o: unknown) => Promise<unknown>;
+    }
+  ).execute;
+
+  return execute(input, {
+    toolCallId: "call-1",
+    abortSignal: undefined,
+    messages: [],
+  });
+}
+
+describe("todo_write", () => {
+  it("creates a full todo list and returns currentTodos", async () => {
+    const result = await runTool(createTodoWrite(makeContext()), {
+      merge: false,
+      todos: [
+        { id: "1", content: "Plan test", status: "in_progress" },
+        { id: "2", content: "Verify result", status: "pending" },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      counts: { completed: 0, total: 2 },
+      currentTodos: [
+        {
+          id: "1",
+          content: "Plan test",
+          status: "in_progress",
+          sourceMessageId: "assistant-1",
+        },
+        {
+          id: "2",
+          content: "Verify result",
+          status: "pending",
+          sourceMessageId: "assistant-1",
+        },
+      ],
+    });
+  });
+
+  it("allows partial merge updates for existing todos", async () => {
+    const result = await runTool(
+      createTodoWrite(
+        makeContext([{ id: "1", content: "Plan test", status: "in_progress" }]),
+      ),
+      {
+        merge: true,
+        todos: [{ id: "1", status: "completed" }],
+      },
+    );
+
+    expect(result).toMatchObject({
+      counts: { completed: 1, total: 1 },
+      currentTodos: [{ id: "1", content: "Plan test", status: "completed" }],
+    });
+  });
+
+  it("returns a clear error for partial new todos", async () => {
+    const result = await runTool(createTodoWrite(makeContext()), {
+      merge: true,
+      todos: [{ id: "missing-content", status: "pending" }],
+    });
+
+    expect(result).toEqual({
+      error:
+        'Failed to manage todos: Content and status are required for new todo "missing-content"',
+    });
+  });
+});

--- a/lib/ai/tools/__tests__/todo-write.test.ts
+++ b/lib/ai/tools/__tests__/todo-write.test.ts
@@ -74,6 +74,48 @@ describe("todo_write", () => {
     });
   });
 
+  it("stamps merge-created follow-up todos with the assistant message id", async () => {
+    const result = await runTool(
+      createTodoWrite(
+        makeContext([{ id: "1", content: "Plan test", status: "completed" }]),
+      ),
+      {
+        merge: true,
+        todos: [{ id: "2", content: "Follow up", status: "pending" }],
+      },
+    );
+
+    expect(result).toMatchObject({
+      counts: { completed: 1, total: 2 },
+      currentTodos: [
+        { id: "1", content: "Plan test", status: "completed" },
+        {
+          id: "2",
+          content: "Follow up",
+          status: "pending",
+          sourceMessageId: "assistant-1",
+        },
+      ],
+    });
+  });
+
+  it("returns a clear error for blank merge content", async () => {
+    const result = await runTool(
+      createTodoWrite(
+        makeContext([{ id: "1", content: "Plan test", status: "pending" }]),
+      ),
+      {
+        merge: true,
+        todos: [{ id: "1", content: "   " }],
+      },
+    );
+
+    expect(result).toEqual({
+      error:
+        'Failed to manage todos: Todo "1" is missing required content field',
+    });
+  });
+
   it("returns a clear error for partial new todos", async () => {
     const result = await runTool(createTodoWrite(makeContext()), {
       merge: true,

--- a/lib/ai/tools/todo-write.ts
+++ b/lib/ai/tools/todo-write.ts
@@ -142,6 +142,9 @@ When in doubt, use this tool. Systematic task management ensures comprehensive s
             id: z.string().describe("Unique identifier for the todo item"),
             content: z
               .string()
+              .refine((value) => value.trim().length > 0, {
+                message: "Todo content cannot be blank",
+              })
               .optional()
               .describe("The description/content of the todo item"),
             status: z
@@ -152,7 +155,7 @@ When in doubt, use this tool. Systematic task management ensures comprehensive s
         )
         .min(1)
         .describe(
-          "Array of todo items to write to the workspace. For merge=false, every item must include content and status. For merge=true, existing items may be patched with partial updates, but new items must include content and status.",
+          "Array of todo items to write to the workspace. For merge=false, every item must include content and status and replaces the assistant-generated plan while preserving manually created todos. For merge=true, existing items may be patched with partial updates, but new items must include content and status.",
         ),
     }),
     execute: async ({
@@ -178,12 +181,29 @@ When in doubt, use this tool. Systematic task management ensures comprehensive s
               t.status === null,
           );
 
+        const existingTodoIds = new Set(
+          todoManager.getAllTodos().map((todo) => todo.id),
+        );
+        const todosWithSourceMessageId: Array<Partial<Todo> & { id: string }> =
+          assistantMessageId
+            ? todos.map((todo) => {
+                const isNewCompleteMergeTodo =
+                  shouldMerge &&
+                  !existingTodoIds.has(todo.id) &&
+                  typeof todo.content === "string" &&
+                  todo.content.trim() !== "" &&
+                  todo.status !== undefined;
+                const shouldStamp = !shouldMerge || isNewCompleteMergeTodo;
+
+                return shouldStamp
+                  ? { ...todo, sourceMessageId: assistantMessageId }
+                  : todo;
+              })
+            : todos;
+
         // Update backend state first (TodoManager handles deduplication)
         const updatedTodos = todoManager.setTodos(
-          // When creating a plan (shouldMerge=false), stamp todos with assistantMessageId
-          shouldMerge || !assistantMessageId
-            ? todos
-            : todos.map((t) => ({ ...t, sourceMessageId: assistantMessageId })),
+          todosWithSourceMessageId,
           shouldMerge,
         );
 

--- a/lib/ai/tools/todo-write.ts
+++ b/lib/ai/tools/todo-write.ts
@@ -17,7 +17,7 @@ Use proactively for:
 2. Non-trivial vulnerability testing requiring systematic approach
 3. User explicitly requests todo list
 4. User provides multiple targets or attack vectors (numbered/comma-separated)
-5. After receiving new instructions - capture requirements as todos (use merge=false to add new ones)
+5. After receiving new instructions - capture requirements as todos (use merge=false to replace the assistant plan, or merge=true to patch the current plan)
 6. After completing tasks - mark complete with merge=true and add follow-ups
 7. When starting new tasks - mark as in_progress (ideally only one at a time)
 
@@ -142,14 +142,18 @@ When in doubt, use this tool. Systematic task management ensures comprehensive s
             id: z.string().describe("Unique identifier for the todo item"),
             content: z
               .string()
+              .optional()
               .describe("The description/content of the todo item"),
             status: z
               .enum(["pending", "in_progress", "completed", "cancelled"])
+              .optional()
               .describe("The current status of the todo item"),
           }),
         )
         .min(1)
-        .describe("Array of todo items to write to the workspace"),
+        .describe(
+          "Array of todo items to write to the workspace. For merge=false, every item must include content and status. For merge=true, existing items may be patched with partial updates, but new items must include content and status.",
+        ),
     }),
     execute: async ({
       merge,
@@ -159,26 +163,20 @@ When in doubt, use this tool. Systematic task management ensures comprehensive s
       todos: Array<{
         id: string;
         content?: string;
-        status: Todo["status"];
+        status?: Todo["status"];
       }>;
     }) => {
       try {
-        // Runtime validation for non-merge operations
-        if (!merge) {
-          for (let i = 0; i < todos.length; i++) {
-            const todo = todos[i];
-            if (!todo.content || todo.content.trim() === "") {
-              throw new Error(
-                `Todo at index ${i} is missing required content field`,
-              );
-            }
-          }
-        }
-
         // If incoming payload looks like partial updates (missing content fields), switch to merge to avoid replacing the whole plan.
         const shouldMerge =
           merge ||
-          todos.some((t) => t.content === undefined || t.content === null);
+          todos.some(
+            (t) =>
+              t.content === undefined ||
+              t.content === null ||
+              t.status === undefined ||
+              t.status === null,
+          );
 
         // Update backend state first (TodoManager handles deduplication)
         const updatedTodos = todoManager.setTodos(

--- a/lib/ai/tools/utils/todo-manager.ts
+++ b/lib/ai/tools/utils/todo-manager.ts
@@ -1,4 +1,5 @@
 import type { Todo } from "@/types/chat";
+import { applyTodoWriteUpdate } from "@/lib/utils/todo-utils";
 
 export interface TodoUpdate {
   id: string;
@@ -34,48 +35,16 @@ export class TodoManager {
     newTodos: (Partial<Todo> & { id: string })[],
     merge: boolean = false,
   ): Todo[] {
-    // Deduplicate incoming todos by id (keep last occurrence)
-    const uniqueTodos = Array.from(
-      new Map(newTodos.map((todo) => [todo.id, todo])).values(),
-    );
+    const result = applyTodoWriteUpdate({
+      currentTodos: this.todos,
+      incomingTodos: newTodos,
+      merge,
+    });
+
+    this.todos = result.todos;
 
     if (!merge) {
-      // Replace all assistant-sourced todos; preserve manual ones across runs
-      this.todos = this.todos.filter((t) => !t.sourceMessageId);
       this.hasCreatedPlanThisRun = true;
-    }
-
-    for (const todo of uniqueTodos) {
-      // Defensive check - should never happen with proper typing, but provides clear error
-      if (!todo.id) {
-        throw new Error("Todo must have an id");
-      }
-
-      const existingIndex = this.todos.findIndex((t) => t.id === todo.id);
-
-      if (existingIndex >= 0) {
-        // Update existing todo, preserve existing content if not provided
-        this.todos[existingIndex] = {
-          id: todo.id,
-          content: todo.content ?? this.todos[existingIndex].content,
-          status: todo.status ?? this.todos[existingIndex].status,
-          sourceMessageId:
-            todo.sourceMessageId ?? this.todos[existingIndex].sourceMessageId,
-        };
-      } else {
-        // Add new todo
-        // If it's the first time (not merge) and content is missing, throw error
-        if (!merge && !todo.content) {
-          throw new Error(`Content is required for new todos.`);
-        }
-
-        this.todos.push({
-          id: todo.id,
-          content: todo.content ?? "",
-          status: todo.status ?? "pending",
-          sourceMessageId: todo.sourceMessageId,
-        });
-      }
     }
 
     return this.getAllTodos();

--- a/lib/utils/__tests__/todo-utils.test.ts
+++ b/lib/utils/__tests__/todo-utils.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect } from "@jest/globals";
 import {
   mergeTodos,
+  applyTodoWriteUpdate,
+  TodoUpdateError,
   hasPartialTodos,
   shouldTreatAsMerge,
   computeReplaceAssistantTodos,
   getBaseTodosForRequest,
   areTodosEqual,
   getTodoStats,
+  getVisibleTodoBlockItems,
+  getTodoPanelViewState,
   removeTodosBySourceMessage,
   removeTodosBySourceMessages,
 } from "../todo-utils";
@@ -61,6 +65,87 @@ describe("todo-utils", () => {
       expect(result[0].content).toBe("Task 1");
       expect(result[0].status).toBe("completed");
       expect(result[0].sourceMessageId).toBe("msg1");
+    });
+  });
+
+  describe("applyTodoWriteUpdate", () => {
+    it("replaces assistant todos, preserves manual todos, and stamps source message ids", () => {
+      const currentTodos: Todo[] = [
+        { id: "manual", content: "Manual", status: "pending" },
+        {
+          id: "old",
+          content: "Old assistant",
+          status: "pending",
+          sourceMessageId: "msg-old",
+        },
+      ];
+
+      const result = applyTodoWriteUpdate({
+        currentTodos,
+        incomingTodos: [
+          { id: "new", content: "New assistant", status: "in_progress" },
+        ],
+        merge: false,
+        sourceMessageId: "msg-new",
+      });
+
+      expect(result.todos).toEqual([
+        {
+          id: "new",
+          content: "New assistant",
+          status: "in_progress",
+          sourceMessageId: "msg-new",
+        },
+        { id: "manual", content: "Manual", status: "pending" },
+      ]);
+      expect(result.changed).toBe(true);
+    });
+
+    it("allows partial merge updates for existing todos", () => {
+      const result = applyTodoWriteUpdate({
+        currentTodos: [{ id: "1", content: "Task 1", status: "in_progress" }],
+        incomingTodos: [{ id: "1", status: "completed" }],
+        merge: true,
+      });
+
+      expect(result.todos).toEqual([
+        { id: "1", content: "Task 1", status: "completed" },
+      ]);
+    });
+
+    it("rejects partial merge updates for new todos", () => {
+      expect(() =>
+        applyTodoWriteUpdate({
+          currentTodos: [],
+          incomingTodos: [{ id: "new", status: "pending" }],
+          merge: true,
+        }),
+      ).toThrow(TodoUpdateError);
+    });
+
+    it("rejects no-op partial merge updates", () => {
+      expect(() =>
+        applyTodoWriteUpdate({
+          currentTodos: [{ id: "1", content: "Task 1", status: "pending" }],
+          incomingTodos: [{ id: "1" }],
+          merge: true,
+        }),
+      ).toThrow('Todo "1" must include content or status to update');
+    });
+
+    it("deduplicates incoming todos by id and keeps the last payload", () => {
+      const result = applyTodoWriteUpdate({
+        currentTodos: [],
+        incomingTodos: [
+          { id: "1", content: "First", status: "pending" },
+          { id: "1", content: "Last", status: "completed" },
+        ],
+        merge: false,
+      });
+
+      expect(result.todos).toEqual([
+        { id: "1", content: "Last", status: "completed" },
+      ]);
     });
   });
 
@@ -228,6 +313,30 @@ describe("todo-utils", () => {
         total: 4,
         done: 2,
       });
+    });
+  });
+
+  describe("todo view helpers", () => {
+    it("treats cancelled as done for block visibility", () => {
+      const todos: Todo[] = [
+        { id: "1", content: "Completed", status: "completed" },
+        { id: "2", content: "Cancelled", status: "cancelled" },
+        { id: "3", content: "Current", status: "in_progress" },
+      ];
+
+      const visible = getVisibleTodoBlockItems({ todos });
+
+      expect(visible.map((todo) => todo.id)).toEqual(["2", "3"]);
+    });
+
+    it("marks an in-progress todo as paused when chat is ready", () => {
+      const state = getTodoPanelViewState(
+        [{ id: "1", content: "Current", status: "in_progress" }],
+        "ready",
+      );
+
+      expect(state.isPaused).toBe(true);
+      expect(state.currentTodoDisplayStatus).toBe("paused");
     });
   });
 

--- a/lib/utils/__tests__/todo-utils.test.ts
+++ b/lib/utils/__tests__/todo-utils.test.ts
@@ -133,17 +133,29 @@ describe("todo-utils", () => {
       ).toThrow('Todo "1" must include content or status to update');
     });
 
-    it("deduplicates incoming todos by id and keeps the last payload", () => {
+    it("rejects blank content in merge updates", () => {
+      expect(() =>
+        applyTodoWriteUpdate({
+          currentTodos: [{ id: "1", content: "Task 1", status: "pending" }],
+          incomingTodos: [{ id: "1", content: "   " }],
+          merge: true,
+        }),
+      ).toThrow('Todo "1" is missing required content field');
+    });
+
+    it("deduplicates incoming todos by id and preserves last occurrence order", () => {
       const result = applyTodoWriteUpdate({
         currentTodos: [],
         incomingTodos: [
           { id: "1", content: "First", status: "pending" },
+          { id: "2", content: "Second", status: "pending" },
           { id: "1", content: "Last", status: "completed" },
         ],
         merge: false,
       });
 
       expect(result.todos).toEqual([
+        { id: "2", content: "Second", status: "pending" },
         { id: "1", content: "Last", status: "completed" },
       ]);
     });

--- a/lib/utils/todo-utils.ts
+++ b/lib/utils/todo-utils.ts
@@ -1,5 +1,12 @@
 import type { Todo } from "@/types";
 
+export class TodoUpdateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TodoUpdateError";
+  }
+}
+
 /**
  * Efficiently merges new todos with existing ones.
  * Only creates a new array if there are actual changes to prevent unnecessary re-renders.
@@ -12,46 +19,14 @@ export const mergeTodos = (
   currentTodos: Todo[],
   newTodos: ReadonlyArray<TodoLike>,
 ): Todo[] => {
-  let hasChanges = false;
-  const updatedTodos = [...currentTodos];
+  const result = applyTodoWriteUpdate({
+    currentTodos,
+    incomingTodos: newTodos,
+    merge: true,
+    allowPartialNewTodos: false,
+  });
 
-  for (const newTodo of newTodos) {
-    const existingIndex = updatedTodos.findIndex((t) => t.id === newTodo.id);
-
-    if (existingIndex >= 0) {
-      // Check if the todo actually changed
-      const existing = updatedTodos[existingIndex];
-      const merged: Todo = {
-        ...existing,
-        // Preserve existing fields when incoming values are undefined
-        content:
-          newTodo.content !== undefined ? newTodo.content : existing.content,
-        status: newTodo.status !== undefined ? newTodo.status : existing.status,
-        sourceMessageId:
-          newTodo.sourceMessageId !== undefined
-            ? newTodo.sourceMessageId
-            : existing.sourceMessageId,
-      };
-
-      if (
-        existing.content !== merged.content ||
-        existing.status !== merged.status ||
-        existing.sourceMessageId !== merged.sourceMessageId
-      ) {
-        updatedTodos[existingIndex] = merged;
-        hasChanges = true;
-      }
-    } else {
-      // Add new todo
-      if (isCompleteTodoLike(newTodo)) {
-        updatedTodos.push(newTodo);
-        hasChanges = true;
-      }
-    }
-  }
-
-  // Only return new array if there were actual changes
-  return hasChanges ? updatedTodos : currentTodos;
+  return result.changed ? result.todos : currentTodos;
 };
 
 /**
@@ -69,6 +44,127 @@ export type TodoLike = {
  */
 const isCompleteTodoLike = (candidate: TodoLike): candidate is Todo => {
   return candidate.content !== undefined && candidate.status !== undefined;
+};
+
+const hasTodoPatch = (candidate: TodoLike): boolean => {
+  return (
+    candidate.content !== undefined ||
+    candidate.status !== undefined ||
+    candidate.sourceMessageId !== undefined
+  );
+};
+
+export const dedupeTodosById = <T extends { id: string }>(
+  todos: ReadonlyArray<T>,
+): T[] => Array.from(new Map(todos.map((todo) => [todo.id, todo])).values());
+
+export interface ApplyTodoWriteUpdateOptions {
+  currentTodos: Todo[];
+  incomingTodos: ReadonlyArray<TodoLike>;
+  merge: boolean;
+  sourceMessageId?: string;
+  preserveManualTodos?: boolean;
+  allowPartialNewTodos?: boolean;
+}
+
+export interface ApplyTodoWriteUpdateResult {
+  todos: Todo[];
+  stats: TodoStats;
+  changed: boolean;
+}
+
+export const applyTodoWriteUpdate = ({
+  currentTodos,
+  incomingTodos,
+  merge,
+  sourceMessageId,
+  preserveManualTodos = true,
+  allowPartialNewTodos = false,
+}: ApplyTodoWriteUpdateOptions): ApplyTodoWriteUpdateResult => {
+  const uniqueIncoming = dedupeTodosById(incomingTodos);
+
+  if (!merge) {
+    const fullTodos: Todo[] = uniqueIncoming.map((todo, index) => {
+      if (!todo.id) {
+        throw new TodoUpdateError(`Todo at index ${index} is missing id`);
+      }
+      if (!todo.content || todo.content.trim() === "") {
+        throw new TodoUpdateError(
+          `Todo at index ${index} is missing required content field`,
+        );
+      }
+      if (!todo.status) {
+        throw new TodoUpdateError(
+          `Todo at index ${index} is missing required status field`,
+        );
+      }
+      return {
+        id: todo.id,
+        content: todo.content,
+        status: todo.status,
+        sourceMessageId: sourceMessageId ?? todo.sourceMessageId,
+      };
+    });
+
+    const manualTodos = preserveManualTodos
+      ? currentTodos.filter((todo) => !todo.sourceMessageId)
+      : [];
+    const todos = [...fullTodos, ...manualTodos];
+
+    return {
+      todos,
+      stats: getTodoStats(todos),
+      changed: !areTodoListsEqual(currentTodos, todos),
+    };
+  }
+
+  const updatedTodos = [...currentTodos];
+
+  for (let i = 0; i < uniqueIncoming.length; i++) {
+    const newTodo = uniqueIncoming[i];
+    if (!newTodo.id) {
+      throw new TodoUpdateError(`Todo at index ${i} is missing id`);
+    }
+    if (!hasTodoPatch(newTodo)) {
+      throw new TodoUpdateError(
+        `Todo "${newTodo.id}" must include content or status to update`,
+      );
+    }
+
+    const existingIndex = updatedTodos.findIndex((t) => t.id === newTodo.id);
+
+    if (existingIndex >= 0) {
+      const existing = updatedTodos[existingIndex];
+      updatedTodos[existingIndex] = {
+        ...existing,
+        content:
+          newTodo.content !== undefined ? newTodo.content : existing.content,
+        status: newTodo.status !== undefined ? newTodo.status : existing.status,
+        sourceMessageId:
+          newTodo.sourceMessageId !== undefined
+            ? newTodo.sourceMessageId
+            : existing.sourceMessageId,
+      };
+      continue;
+    }
+
+    if (!isCompleteTodoLike(newTodo)) {
+      if (allowPartialNewTodos) {
+        continue;
+      }
+      throw new TodoUpdateError(
+        `Content and status are required for new todo "${newTodo.id}"`,
+      );
+    }
+
+    updatedTodos.push(newTodo);
+  }
+
+  return {
+    todos: updatedTodos,
+    stats: getTodoStats(updatedTodos),
+    changed: !areTodoListsEqual(currentTodos, updatedTodos),
+  };
 };
 
 /**
@@ -101,11 +197,12 @@ export const computeReplaceAssistantTodos = (
   incoming: Todo[],
   sourceMessageId?: string,
 ): Todo[] => {
-  const manual = currentTodos.filter((t) => !t.sourceMessageId);
-  const stamped = sourceMessageId
-    ? incoming.map((t) => ({ ...t, sourceMessageId }))
-    : incoming;
-  return [...stamped, ...manual];
+  return applyTodoWriteUpdate({
+    currentTodos,
+    incomingTodos: incoming,
+    merge: false,
+    sourceMessageId,
+  }).todos;
 };
 
 /**
@@ -127,15 +224,36 @@ export const getBaseTodosForRequest = (
 };
 
 /**
- * Checks if two todos are equal (same content and status)
+ * Checks if two todos have the same persisted display fields.
  */
 export const areTodosEqual = (todo1: Todo, todo2: Todo): boolean => {
-  return todo1.content === todo2.content && todo1.status === todo2.status;
+  return (
+    todo1.content === todo2.content &&
+    todo1.status === todo2.status &&
+    todo1.sourceMessageId === todo2.sourceMessageId
+  );
+};
+
+export const areTodoListsEqual = (todos1: Todo[], todos2: Todo[]): boolean => {
+  if (todos1.length !== todos2.length) return false;
+  return todos1.every(
+    (todo, index) =>
+      todo.id === todos2[index].id && areTodosEqual(todo, todos2[index]),
+  );
 };
 
 /**
  * Gets todo statistics for display purposes
  */
+export type TodoStats = {
+  completed: number;
+  inProgress: number;
+  pending: number;
+  cancelled: number;
+  total: number;
+  done: number;
+};
+
 export const getTodoStats = (todos: Todo[]) => {
   const completed = todos.filter((t) => t.status === "completed").length;
   const inProgress = todos.filter((t) => t.status === "in_progress").length;
@@ -151,6 +269,128 @@ export const getTodoStats = (todos: Todo[]) => {
     cancelled,
     total,
     done,
+  };
+};
+
+export const getTodoDisplayData = (todos: Todo[]) => {
+  const uniqueTodos = dedupeTodosById(todos);
+  const byStatus = {
+    completed: uniqueTodos.filter((t) => t.status === "completed"),
+    inProgress: uniqueTodos.filter((t) => t.status === "in_progress"),
+    pending: uniqueTodos.filter((t) => t.status === "pending"),
+    cancelled: uniqueTodos.filter((t) => t.status === "cancelled"),
+  };
+  const stats = getTodoStats(uniqueTodos);
+  const currentInProgress = byStatus.inProgress[0];
+  const lastCompleted = byStatus.completed[byStatus.completed.length - 1];
+  const lastCancelled = byStatus.cancelled[byStatus.cancelled.length - 1];
+  const lastDone = (() => {
+    if (!lastCompleted) return lastCancelled;
+    if (!lastCancelled) return lastCompleted;
+    const completedIndex = uniqueTodos.findIndex(
+      (todo) => todo.id === lastCompleted.id,
+    );
+    const cancelledIndex = uniqueTodos.findIndex(
+      (todo) => todo.id === lastCancelled.id,
+    );
+    return completedIndex > cancelledIndex ? lastCompleted : lastCancelled;
+  })();
+
+  return {
+    todos: uniqueTodos,
+    byStatus,
+    stats,
+    currentInProgress,
+    lastCompleted,
+    lastCancelled,
+    lastDone,
+    hasProgress: stats.done > 0,
+    allDone: stats.total > 0 && stats.done === stats.total,
+  };
+};
+
+export const getVisibleTodoBlockItems = ({
+  todos,
+  inputTodos,
+  showAllTodos = false,
+}: {
+  todos: Todo[];
+  inputTodos?: ReadonlyArray<TodoLike>;
+  showAllTodos?: boolean;
+}): Todo[] => {
+  const todoData = getTodoDisplayData(todos);
+  const { stats, currentInProgress, lastDone } = todoData;
+  const uniqueTodos = todoData.todos;
+
+  if (stats.done === 0 || showAllTodos) {
+    return uniqueTodos;
+  }
+
+  const visibleTodos: Todo[] = [];
+
+  if (inputTodos && inputTodos.length > 0) {
+    const inputTodoIds = new Set(inputTodos.map((t) => t.id));
+    visibleTodos.push(
+      ...uniqueTodos.filter((todo) => inputTodoIds.has(todo.id)),
+    );
+  } else if (lastDone) {
+    visibleTodos.push(lastDone);
+  }
+
+  if (
+    currentInProgress &&
+    !visibleTodos.some((todo) => todo.id === currentInProgress.id)
+  ) {
+    visibleTodos.push(currentInProgress);
+  }
+
+  if (!currentInProgress && visibleTodos.length === 0) {
+    const nextPending = uniqueTodos.find((todo) => todo.status === "pending");
+    if (nextPending) {
+      visibleTodos.push(nextPending);
+    }
+  }
+
+  return visibleTodos;
+};
+
+export const getTodoPanelViewState = (
+  todos: Todo[],
+  status?: "submitted" | "streaming" | "ready" | "error",
+) => {
+  const todoData = getTodoDisplayData(todos);
+  const { stats, todos: uniqueTodos } = todoData;
+  const hasTodos = uniqueTodos.length > 0;
+  const hasActiveTodos = stats.inProgress > 0 || stats.pending > 0;
+
+  const currentTodoIndex = (() => {
+    const inProgressIdx = uniqueTodos.findIndex(
+      (todo) => todo.status === "in_progress",
+    );
+    if (inProgressIdx !== -1) return inProgressIdx;
+    for (let i = uniqueTodos.length - 1; i >= 0; i--) {
+      const todoStatus = uniqueTodos[i].status;
+      if (todoStatus === "completed" || todoStatus === "cancelled") return i;
+    }
+    return -1;
+  })();
+
+  const currentTodo =
+    currentTodoIndex !== -1 ? uniqueTodos[currentTodoIndex] : undefined;
+  const isPaused = status === "ready" && stats.inProgress > 0;
+  const currentTodoDisplayStatus: Todo["status"] | "paused" | undefined =
+    currentTodo && isPaused && currentTodo.status === "in_progress"
+      ? "paused"
+      : currentTodo?.status;
+
+  return {
+    ...todoData,
+    hasTodos,
+    hasActiveTodos,
+    currentTodoIndex,
+    currentTodo,
+    isPaused,
+    currentTodoDisplayStatus,
   };
 };
 

--- a/lib/utils/todo-utils.ts
+++ b/lib/utils/todo-utils.ts
@@ -54,9 +54,24 @@ const hasTodoPatch = (candidate: TodoLike): boolean => {
   );
 };
 
+const hasBlankContent = (candidate: TodoLike): boolean => {
+  return candidate.content !== undefined && candidate.content.trim() === "";
+};
+
 export const dedupeTodosById = <T extends { id: string }>(
   todos: ReadonlyArray<T>,
-): T[] => Array.from(new Map(todos.map((todo) => [todo.id, todo])).values());
+): T[] => {
+  const seen = new Set<string>();
+  const deduped: T[] = [];
+
+  for (const todo of [...todos].reverse()) {
+    if (seen.has(todo.id)) continue;
+    seen.add(todo.id);
+    deduped.push(todo);
+  }
+
+  return deduped.reverse();
+};
 
 export interface ApplyTodoWriteUpdateOptions {
   currentTodos: Todo[];
@@ -128,6 +143,11 @@ export const applyTodoWriteUpdate = ({
     if (!hasTodoPatch(newTodo)) {
       throw new TodoUpdateError(
         `Todo "${newTodo.id}" must include content or status to update`,
+      );
+    }
+    if (hasBlankContent(newTodo)) {
+      throw new TodoUpdateError(
+        `Todo "${newTodo.id}" is missing required content field`,
       );
     }
 

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -306,14 +306,19 @@ export interface Todo {
 
 export interface TodoBlockProps {
   todos: Todo[];
-  inputTodos?: Todo[];
+  inputTodos?: TodoWriteInput["todos"];
   blockId: string;
   messageId: string;
 }
 
 export interface TodoWriteInput {
   merge?: boolean;
-  todos?: Todo[];
+  todos?: Array<{
+    id: string;
+    content?: string;
+    status?: Todo["status"];
+    sourceMessageId?: string;
+  }>;
 }
 
 export type ChatStatus = "submitted" | "streaming" | "ready" | "error";


### PR DESCRIPTION
## Summary
- centralize todo write merging/replacement, dedupe, stats, and display selectors in shared todo utilities
- allow `todo_write` to patch existing todos with partial merge payloads while requiring full fields for replacements/new todos
- apply live chat todo state from successful `todo_write` output instead of optimistic tool-call input
- reuse shared display helpers across chat, todo panel, and shared todo blocks so cancelled todos render consistently as done

## Validation
- `pnpm jest lib/utils/__tests__/todo-utils.test.ts lib/ai/tools/__tests__/todo-write.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec prettier --check ...`
- `pnpm exec eslint ...`
- `pnpm jest app/components/__tests__/chat.integration.test.tsx --runInBand`
- `pnpm jest --runTestsByPath 'app/share/[shareId]/__tests__/SharedMessages.test.tsx' --runInBand`
- commit hook: `pnpm typecheck` and full `pnpm test` (146 suites, 1572 tests)

## Manual verification
- In a live chat, ask the assistant to create a multi-step todo plan and confirm the panel updates after the `todo_write` result appears.
- Ask it to mark one existing todo complete with a partial merge update and confirm the original content is preserved.
- Open a shared/historical chat with todos and confirm cancelled/completed items count and render as done without duplicate todo display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for partial todo updates in tool-driven writes (optional fields per todo item), enabling safer merge vs. replace behavior.
  * Todo panels and todo blocks now share consistent logic for progress, stats, and “expanded” visibility.
* **Bug Fixes**
  * Cancelled todos now display with the completed text styling.
  * Improved paused/in-progress display for todo UI based on chat readiness.
* **Tests**
  * Expanded Jest coverage for todo write behavior, merge/replace validation, and todo display/visibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->