### PR TITLE
Validate image bytes before provider calls

### DIFF
--- a/convex/__tests__/fileActions.upload-policy.test.ts
+++ b/convex/__tests__/fileActions.upload-policy.test.ts
@@ -324,6 +324,32 @@ describe("fileActions saveFile upload policy", () => {
     expect(ctx.runMutation).not.toHaveBeenCalled();
   });
 
+  it("rejects invalid Ask image uploads declared with a media-type alias", async () => {
+    const { saveFile } = await import("../fileActions");
+    const ctx = makeCtx();
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      blob: async () => ({
+        arrayBuffer: async () => new TextEncoder().encode("not a jpeg").buffer,
+      }),
+    })) as any;
+
+    await expect(
+      saveFile.handler(ctx, {
+        s3Key: "users/user123/broken.jpg",
+        name: "broken.jpg",
+        mediaType: "image/jpg",
+        size: 1024,
+        mode: "ask",
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({ code: "INVALID_IMAGE_BYTES" }),
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith("https://s3.example/download");
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
   it("accepts oversized Agent files as sandbox-only metadata without parsing", async () => {
     const { saveFile } = await import("../fileActions");
     const ctx = makeCtx();

--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -34,7 +34,10 @@ import {
   isSupportedImageMediaType,
   validateUploadPolicy,
 } from "../lib/utils/upload-policy";
-import { validateImageBytes } from "../lib/utils/image-validation";
+import {
+  normalizeImageMediaType,
+  validateImageBytes,
+} from "../lib/utils/image-validation";
 import {
   FILE_TOKEN_PERCENT,
   MAX_TOKENS_PAID,
@@ -854,15 +857,17 @@ export const saveFile = action({
         }
 
         const file = await response.blob();
-        if (isSupportedImageMediaType(args.mediaType)) {
+        const normalizedMediaType =
+          normalizeImageMediaType(args.mediaType) ?? args.mediaType;
+        if (isSupportedImageMediaType(normalizedMediaType)) {
           const validation = validateImageBytes(
             new Uint8Array(await file.arrayBuffer()),
-            args.mediaType,
+            normalizedMediaType,
           );
           if (!validation.valid) {
             throw new ConvexError({
               code: "INVALID_IMAGE_BYTES",
-              message: `Image "${args.name}" could not be uploaded because it is not a valid ${args.mediaType} file.`,
+              message: `Image "${args.name}" could not be uploaded because it is not a valid ${normalizedMediaType} file.`,
             });
           }
         }

--- a/convex/fileActions.ts
+++ b/convex/fileActions.ts
@@ -34,6 +34,7 @@ import {
   isSupportedImageMediaType,
   validateUploadPolicy,
 } from "../lib/utils/upload-policy";
+import { validateImageBytes } from "../lib/utils/image-validation";
 import {
   FILE_TOKEN_PERCENT,
   MAX_TOKENS_PAID,
@@ -853,6 +854,18 @@ export const saveFile = action({
         }
 
         const file = await response.blob();
+        if (isSupportedImageMediaType(args.mediaType)) {
+          const validation = validateImageBytes(
+            new Uint8Array(await file.arrayBuffer()),
+            args.mediaType,
+          );
+          if (!validation.valid) {
+            throw new ConvexError({
+              code: "INVALID_IMAGE_BYTES",
+              message: `Image "${args.name}" could not be uploaded because it is not a valid ${args.mediaType} file.`,
+            });
+          }
+        }
 
         // Compute file token limit based on subscription (all paid tiers use MAX_TOKENS_PAID)
         const maxFileTokens = Math.floor(MAX_TOKENS_PAID * FILE_TOKEN_PERCENT);

--- a/lib/ai/tools/__tests__/file.test.ts
+++ b/lib/ai/tools/__tests__/file.test.ts
@@ -25,6 +25,9 @@ const mockUploadSandboxFileToConvex =
     typeof uploadSandboxFileToConvex
   >;
 
+const VALID_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAXpeqz8AAAAASUVORK5CYII=";
+
 function makeContext(
   sandbox: unknown,
   overrides: Partial<ToolContext> = {},
@@ -382,7 +385,7 @@ describe("file tool image view", () => {
             mediaType: "image/png",
             sizeBytes: 68,
             kind: "image",
-            data: "iVBORw0KGgo=",
+            data: VALID_PNG_BASE64,
           }),
           stderr: "",
           exitCode: 0,
@@ -413,10 +416,47 @@ describe("file tool image view", () => {
         },
         {
           type: "image-data",
-          data: "iVBORw0KGgo=",
+          data: VALID_PNG_BASE64,
           mediaType: "image/png",
         },
       ],
+    });
+  });
+
+  test("returns a text error instead of invalid image-data for corrupt sandbox images", async () => {
+    const commandRun = jest.fn(async (_command, opts) => {
+      expect(opts.envVars.HACKERAI_FILE_VIEW_INCLUDE_DATA).toBe("1");
+      return {
+        stdout: JSON.stringify({
+          path: "/tmp/broken.png",
+          mediaType: "image/png",
+          sizeBytes: 8,
+          kind: "image",
+          data: "iVBORw0KGgo=",
+        }),
+        stderr: "",
+        exitCode: 0,
+      };
+    });
+    const sandbox = makeSandbox(commandRun);
+    const tool = createFile(
+      makeContext(sandbox, { modelName: "model-kimi-k2.7-code" }),
+    );
+
+    await expect(
+      runToModelOutput(tool, {
+        action: "view",
+        content: "Viewing image file: broken.png (image/png, 8 bytes).",
+        path: "/tmp/broken.png",
+        filename: "broken.png",
+        mediaType: "image/png",
+        sizeBytes: 8,
+        kind: "image",
+      }),
+    ).resolves.toEqual({
+      type: "text",
+      value:
+        "Error: View inspection found invalid image data (missing_png_ihdr).",
     });
   });
 });

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -9,6 +9,7 @@ import { uploadSandboxFileToConvex } from "./utils/sandbox-file-uploader";
 import type { Id } from "@/convex/_generated/dataModel";
 import { logger } from "@/lib/logger";
 import { phLogger } from "@/lib/posthog/server";
+import { validateImageBytes } from "@/lib/utils/image-validation";
 
 const MAX_VIEW_FILE_BYTES = 10 * 1024 * 1024;
 const MAX_TEXT_FILE_READ_BYTES = 1024 * 1024;
@@ -886,6 +887,19 @@ async function readSandboxFileForView(
 
   if (includeData && !payload.data) {
     throw new Error("View inspection did not return image data.");
+  }
+
+  if (includeData && payload.data) {
+    const validation = validateImageBytes(
+      Buffer.from(payload.data, "base64"),
+      payload.mediaType,
+    );
+    if (!validation.valid) {
+      throw new Error(
+        `View inspection found invalid image data (${validation.reason}).`,
+      );
+    }
+    payload.mediaType = validation.mediaType;
   }
 
   return payload as SandboxViewPayload;

--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -345,6 +345,43 @@ describe("processMessageFiles image size guards", () => {
     });
   });
 
+  it("omits non-streaming image responses without a content length before reading bytes", async () => {
+    const arrayBuffer = jest.fn(async () => VALID_PNG_BYTES.buffer);
+    mockConvexAction.mockResolvedValue([
+      fileUrlInfo("https://storage.example/no-length.png", {
+        name: "no-length.png",
+      }),
+    ]);
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: {
+        get: () => null,
+      },
+      body: null,
+      arrayBuffer,
+    })) as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        mediaType: "image/png",
+        fileId: "file_no_length",
+        name: "no-length.png",
+      }),
+      "ask",
+      "user123",
+      undefined,
+      "pro",
+    );
+
+    expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(result.messages[0].parts[1]).toEqual({
+      type: "text",
+      text: '[Image "no-length.png" omitted: could not verify valid image bytes before sending it to the model. Please reattach or regenerate the image.]',
+    });
+  });
+
   it("corrects stored image media type when storage bytes disagree with stale metadata", async () => {
     mockConvexAction.mockResolvedValue([
       fileUrlInfo("https://storage.example/photo.jpg", {

--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -19,6 +19,19 @@ const makeMessage = (part: Record<string, unknown>) =>
     },
   ] as any;
 
+const VALID_PNG_BYTES = Uint8Array.from(
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAXpeqz8AAAAASUVORK5CYII=",
+    "base64",
+  ),
+);
+
+const MINIMAL_JPEG_BYTES = Uint8Array.from([
+  0xff, 0xd8, 0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x01, 0x00, 0x01, 0x03, 0x01,
+  0x11, 0x00, 0x02, 0x11, 0x00, 0x03, 0x11, 0x00, 0xff, 0xda, 0x00, 0x0c, 0x03,
+  0x01, 0x00, 0x02, 0x11, 0x03, 0x11, 0x00, 0x3f, 0x00, 0x00, 0xff, 0xd9,
+]);
+
 const responseLike = ({
   status = 200,
   headers = {},
@@ -152,7 +165,10 @@ describe("processMessageFiles image size guards", () => {
       }),
     ]);
     global.fetch = jest.fn(async () => {
-      throw new Error("Trusted file size should avoid network probes");
+      return responseLike({
+        headers: { "content-length": String(VALID_PNG_BYTES.byteLength) },
+        body: streamBody(VALID_PNG_BYTES),
+      });
     }) as any;
 
     const result = await processMessageFiles(
@@ -264,7 +280,10 @@ describe("processMessageFiles image size guards", () => {
       }),
     ]);
     global.fetch = jest.fn(async () => {
-      throw new Error("Trusted file size should avoid network probes");
+      return responseLike({
+        headers: { "content-length": String(VALID_PNG_BYTES.byteLength) },
+        body: streamBody(VALID_PNG_BYTES),
+      });
     }) as any;
 
     const result = await processMessageFiles(
@@ -287,6 +306,122 @@ describe("processMessageFiles image size guards", () => {
       name: "small.png",
       url: "https://storage.example/small.png",
     });
+  });
+
+  it("omits stored images whose storage URL does not return valid image bytes", async () => {
+    const notImageBytes = new TextEncoder().encode("<html>not an image</html>");
+    mockConvexAction.mockResolvedValue([
+      fileUrlInfo("https://storage.example/not-image.png", {
+        sizeBytes: notImageBytes.byteLength,
+        name: "not-image.png",
+      }),
+    ]);
+    global.fetch = jest.fn(async () => {
+      return responseLike({
+        headers: { "content-length": String(notImageBytes.byteLength) },
+        body: streamBody(notImageBytes),
+      });
+    }) as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        mediaType: "image/png",
+        fileId: "file_not_image",
+        name: "not-image.png",
+      }),
+      "ask",
+      "user123",
+      undefined,
+      "pro",
+    );
+
+    expect(JSON.stringify(result.messages)).not.toContain(
+      "https://storage.example/not-image.png",
+    );
+    expect(result.messages[0].parts[1]).toEqual({
+      type: "text",
+      text: '[Image "not-image.png" omitted: could not verify valid image bytes before sending it to the model. Please reattach or regenerate the image.]',
+    });
+  });
+
+  it("corrects stored image media type when storage bytes disagree with stale metadata", async () => {
+    mockConvexAction.mockResolvedValue([
+      fileUrlInfo("https://storage.example/photo.jpg", {
+        sizeBytes: MINIMAL_JPEG_BYTES.byteLength,
+        mediaType: "image/png",
+        name: "photo.jpg",
+      }),
+    ]);
+    global.fetch = jest.fn(async () => {
+      return responseLike({
+        headers: { "content-length": String(MINIMAL_JPEG_BYTES.byteLength) },
+        body: streamBody(MINIMAL_JPEG_BYTES),
+      });
+    }) as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        mediaType: "image/png",
+        fileId: "file_jpeg",
+        name: "photo.jpg",
+      }),
+      "ask",
+      "user123",
+      undefined,
+      "pro",
+    );
+
+    expect(result.messages[0].parts[1]).toMatchObject({
+      type: "file",
+      mediaType: "image/jpeg",
+      url: "https://storage.example/photo.jpg",
+    });
+  });
+
+  it("stages invalid Agent images into the sandbox without sending them inline to the provider", async () => {
+    const notImageBytes = new TextEncoder().encode("not a png");
+    mockConvexAction.mockResolvedValue([
+      fileUrlInfo("https://storage.example/broken.png", {
+        sizeBytes: notImageBytes.byteLength,
+        name: "broken.png",
+      }),
+    ]);
+    global.fetch = jest.fn(async () => {
+      return responseLike({
+        headers: { "content-length": String(notImageBytes.byteLength) },
+        body: streamBody(notImageBytes),
+      });
+    }) as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        fileId: "file_broken",
+        mediaType: "image/png",
+        name: "broken.png",
+      }),
+      "agent",
+      "user123",
+      "/home/user/upload",
+      "pro",
+    );
+
+    expect(result.sandboxFiles).toEqual([
+      {
+        kind: "url",
+        url: "https://storage.example/broken.png",
+        localPath: "/home/user/upload/broken.png",
+      },
+    ]);
+    expect(result.messages[0].parts).toEqual([
+      { type: "text", text: "what is this?" },
+      {
+        type: "text",
+        text: '<attachment filename="broken.png" local_path="/home/user/upload/broken.png" />',
+      },
+    ]);
   });
 
   it("does not probe or convert inline URL file parts without fileId", async () => {

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -252,6 +252,10 @@ const readResponseBytesWithLimit = async (
   limitBytes: number,
 ): Promise<Uint8Array | null> => {
   if (!response.body) {
+    const contentLength = parseContentLength(
+      response.headers.get("content-length"),
+    );
+    if (contentLength == null || contentLength > limitBytes) return null;
     if (typeof response.arrayBuffer !== "function") return null;
     const bytes = new Uint8Array(await response.arrayBuffer());
     return bytes.byteLength > limitBytes ? null : bytes;
@@ -571,7 +575,11 @@ const applyUrlsToFileParts = async (
           )
         : file.url;
 
-    const isSupportedImage = isSupportedImageMediaType(file.mediaType ?? "");
+    const normalizedMediaType =
+      normalizeImageMediaType(file.mediaType) ?? file.mediaType;
+    const isSupportedImage = isSupportedImageMediaType(
+      normalizedMediaType ?? "",
+    );
     const trustedImageSize =
       typeof file.sizeBytes === "number"
         ? ({ bytes: file.sizeBytes, source: "file_record" } as const)
@@ -602,7 +610,7 @@ const applyUrlsToFileParts = async (
       !shouldOmitImage &&
       !shouldOmitUnverifiedImage;
     const imageValidation = shouldValidateImage
-      ? await validateImageUrl(file.url, file.mediaType, imageLimit)
+      ? await validateImageUrl(file.url, normalizedMediaType, imageLimit)
       : null;
     const shouldOmitInvalidImage = imageValidation?.valid === false;
 

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -18,6 +18,11 @@ import type { SubscriptionTier } from "@/types";
 import { logger } from "@/lib/logger";
 import { validateDownloadUrl } from "@/lib/ai/tools/utils/path-validation";
 import { stringifyRedactedError } from "@/lib/utils/error-redaction";
+import {
+  normalizeImageMediaType,
+  validateImageBytes,
+  type ImageValidationResult,
+} from "@/lib/utils/image-validation";
 
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 const MAX_PROVIDER_IMAGE_DOWNLOAD_SIZE = 30 * 1024 * 1024;
@@ -42,6 +47,8 @@ type SizeProbeResult = {
   bytes: number;
   source: "file_record" | "content_length" | "content_range" | "download_probe";
 };
+
+const providerUnsafeImageParts = new WeakSet<object>();
 
 const redactUrlForLog = (url: string): string => {
   try {
@@ -240,6 +247,95 @@ const probeImageSize = async (
 ): Promise<SizeProbeResult | null> =>
   (await probeContentLength(url)) ?? (await probeDownloadSize(url, limitBytes));
 
+const readResponseBytesWithLimit = async (
+  response: Response,
+  limitBytes: number,
+): Promise<Uint8Array | null> => {
+  if (!response.body) {
+    if (typeof response.arrayBuffer !== "function") return null;
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    return bytes.byteLength > limitBytes ? null : bytes;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    totalBytes += value.byteLength;
+    if (totalBytes > limitBytes) {
+      await reader.cancel().catch(() => undefined);
+      return null;
+    }
+    chunks.push(value);
+  }
+
+  const buffer = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return buffer;
+};
+
+const validateImageUrl = async (
+  url: string,
+  mediaType: string | undefined,
+  limitBytes: number,
+): Promise<ImageValidationResult> => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30000);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      return {
+        valid: false,
+        reason: `image_validation_download_failed_${response.status}`,
+      };
+    }
+
+    const contentLength = parseContentLength(
+      response.headers.get("content-length"),
+    );
+    if (contentLength != null && contentLength > limitBytes) {
+      return { valid: false, reason: "image_validation_size_exceeded" };
+    }
+
+    const bytes = await readResponseBytesWithLimit(response, limitBytes);
+    if (!bytes) {
+      return { valid: false, reason: "image_validation_size_exceeded" };
+    }
+
+    const validation = validateImageBytes(bytes, mediaType);
+    if (
+      !validation.valid &&
+      validation.reason === "declared_media_type_mismatch" &&
+      validation.detectedMediaType &&
+      isSupportedImageMediaType(validation.detectedMediaType)
+    ) {
+      return { valid: true, mediaType: validation.detectedMediaType };
+    }
+
+    return validation;
+  } catch (error) {
+    return {
+      valid: false,
+      reason:
+        error instanceof DOMException && error.name === "AbortError"
+          ? "image_validation_download_timeout"
+          : "image_validation_download_failed",
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};
+
 const imageOmittedText = (
   name: unknown,
   sizeBytes: number,
@@ -252,6 +348,9 @@ const untrustedImageUrlOmittedText = (name: unknown) =>
 
 const unverifiedImageOmittedText = (name: unknown) =>
   `[Image "${typeof name === "string" && name.length > 0 ? name : "unnamed"}" omitted: could not verify the image size before sending it to the model. Please reattach a smaller image or use Agent mode for large images.]`;
+
+const invalidImageOmittedText = (name: unknown) =>
+  `[Image "${typeof name === "string" && name.length > 0 ? name : "unnamed"}" omitted: could not verify valid image bytes before sending it to the model. Please reattach or regenerate the image.]`;
 
 /**
  * Replace non-stored image file parts whose declared size exceeds Anthropic's
@@ -497,8 +596,26 @@ const applyUrlsToFileParts = async (
       mode !== "agent" &&
       !!file.url &&
       effectiveImageSize == null;
+    const shouldValidateImage =
+      isSupportedImage &&
+      !!file.url &&
+      !shouldOmitImage &&
+      !shouldOmitUnverifiedImage;
+    const imageValidation = shouldValidateImage
+      ? await validateImageUrl(file.url, file.mediaType, imageLimit)
+      : null;
+    const shouldOmitInvalidImage = imageValidation?.valid === false;
 
-    if ((shouldOmitImage || shouldOmitUnverifiedImage) && mode !== "agent") {
+    if (imageValidation?.valid) {
+      file.mediaType = imageValidation.mediaType;
+    }
+
+    if (
+      (shouldOmitImage ||
+        shouldOmitUnverifiedImage ||
+        shouldOmitInvalidImage) &&
+      mode !== "agent"
+    ) {
       logger.warn("image_attachment_omitted_before_provider_call", {
         event: "image_attachment_omitted_before_provider_call",
         service: "chat-handler",
@@ -509,7 +626,19 @@ const applyUrlsToFileParts = async (
         size_bytes: effectiveImageSize?.bytes,
         limit_bytes: imageLimit,
         size_source: effectiveImageSize?.source,
-        reason: shouldOmitImage ? "size_exceeded" : "size_unverified",
+        reason: shouldOmitImage
+          ? "size_exceeded"
+          : shouldOmitUnverifiedImage
+            ? "size_unverified"
+            : "invalid_image",
+        validation_reason:
+          imageValidation && !imageValidation.valid
+            ? imageValidation.reason
+            : undefined,
+        detected_media_type:
+          imageValidation && !imageValidation.valid
+            ? imageValidation.detectedMediaType
+            : undefined,
         mode,
       });
     }
@@ -517,7 +646,18 @@ const applyUrlsToFileParts = async (
     file.positions.forEach(({ messageIndex, partIndex }) => {
       const filePart = messages[messageIndex].parts![partIndex] as any;
       if (filePart.type !== "file") return;
-      if (shouldOmitImage && mode !== "agent") {
+      if (typeof file.sizeBytes === "number") {
+        filePart.size = file.sizeBytes;
+      }
+      if (file.mediaType) {
+        filePart.mediaType =
+          normalizeImageMediaType(file.mediaType) ?? file.mediaType;
+      }
+
+      if ((shouldOmitImage || shouldOmitInvalidImage) && mode === "agent") {
+        filePart.url = finalUrl;
+        providerUnsafeImageParts.add(filePart);
+      } else if (shouldOmitImage && mode !== "agent") {
         messages[messageIndex].parts![partIndex] = {
           type: "text",
           text: imageOmittedText(
@@ -530,6 +670,11 @@ const applyUrlsToFileParts = async (
         messages[messageIndex].parts![partIndex] = {
           type: "text",
           text: unverifiedImageOmittedText(filePart.name),
+        };
+      } else if (shouldOmitInvalidImage) {
+        messages[messageIndex].parts![partIndex] = {
+          type: "text",
+          text: invalidImageOmittedText(filePart.name),
         };
       } else {
         filePart.url = finalUrl;
@@ -806,10 +951,16 @@ const removeNonMediaAndOversizedImageFileParts = (messages: UIMessage[]) => {
     if (!msg.parts) return;
     msg.parts = msg.parts.filter((part: any) => {
       if (part?.type !== "file") return true;
+      if (providerUnsafeImageParts.has(part)) return false;
       if (!isSupportedImageMediaType(part.mediaType ?? "")) return false;
       return !isSandboxOnlyAgentUpload({
         mode: "agent",
-        size: typeof part.size === "number" ? part.size : 0,
+        size:
+          typeof part.size === "number"
+            ? part.size
+            : typeof part.sizeBytes === "number"
+              ? part.sizeBytes
+              : 0,
         mediaType: part.mediaType ?? "",
       });
     });

--- a/lib/utils/image-validation.ts
+++ b/lib/utils/image-validation.ts
@@ -1,0 +1,343 @@
+import { inflateSync } from "node:zlib";
+
+const PNG_SIGNATURE = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+const MAX_PNG_DECOMPRESSED_BYTES = 64 * 1024 * 1024;
+
+export type ImageValidationResult =
+  | { valid: true; mediaType: string }
+  | { valid: false; reason: string; detectedMediaType?: string };
+
+const MEDIA_TYPE_ALIASES: Record<string, string> = {
+  "image/jpg": "image/jpeg",
+};
+
+export const normalizeImageMediaType = (
+  mediaType: string | undefined,
+): string | undefined => {
+  if (!mediaType) return undefined;
+  const normalized = mediaType.toLowerCase();
+  return MEDIA_TYPE_ALIASES[normalized] ?? normalized;
+};
+
+const startsWithBytes = (bytes: Uint8Array, signature: Uint8Array): boolean => {
+  if (bytes.length < signature.length) return false;
+  return signature.every((byte, index) => bytes[index] === byte);
+};
+
+const readUInt16BE = (bytes: Uint8Array, offset: number): number =>
+  (bytes[offset] << 8) | bytes[offset + 1];
+
+const readUInt32BE = (bytes: Uint8Array, offset: number): number =>
+  (((bytes[offset] * 0x100 + bytes[offset + 1]) * 0x100 + bytes[offset + 2]) *
+    0x100 +
+    bytes[offset + 3]) >>>
+  0;
+
+const readUInt32LE = (bytes: Uint8Array, offset: number): number =>
+  (bytes[offset] |
+    (bytes[offset + 1] << 8) |
+    (bytes[offset + 2] << 16) |
+    (bytes[offset + 3] << 24)) >>>
+  0;
+
+const readAscii = (bytes: Uint8Array, offset: number, length: number): string =>
+  String.fromCharCode(...bytes.subarray(offset, offset + length));
+
+let crcTable: Uint32Array | undefined;
+
+const getCrcTable = (): Uint32Array => {
+  if (crcTable) return crcTable;
+
+  crcTable = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let crc = i;
+    for (let j = 0; j < 8; j++) {
+      crc = crc & 1 ? 0xedb88320 ^ (crc >>> 1) : crc >>> 1;
+    }
+    crcTable[i] = crc >>> 0;
+  }
+  return crcTable;
+};
+
+const crc32 = (bytes: Uint8Array): number => {
+  const table = getCrcTable();
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = table[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+};
+
+const detectImageMediaType = (bytes: Uint8Array): string | undefined => {
+  if (startsWithBytes(bytes, PNG_SIGNATURE)) return "image/png";
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8) {
+    return "image/jpeg";
+  }
+  if (
+    bytes.length >= 6 &&
+    (readAscii(bytes, 0, 6) === "GIF87a" || readAscii(bytes, 0, 6) === "GIF89a")
+  ) {
+    return "image/gif";
+  }
+  if (
+    bytes.length >= 12 &&
+    readAscii(bytes, 0, 4) === "RIFF" &&
+    readAscii(bytes, 8, 4) === "WEBP"
+  ) {
+    return "image/webp";
+  }
+  return undefined;
+};
+
+const validPngBitDepth = (colorType: number, bitDepth: number): boolean => {
+  switch (colorType) {
+    case 0:
+      return [1, 2, 4, 8, 16].includes(bitDepth);
+    case 2:
+    case 4:
+    case 6:
+      return [8, 16].includes(bitDepth);
+    case 3:
+      return [1, 2, 4, 8].includes(bitDepth);
+    default:
+      return false;
+  }
+};
+
+const validatePng = (bytes: Uint8Array): string | null => {
+  if (!startsWithBytes(bytes, PNG_SIGNATURE)) return "missing_png_signature";
+
+  let offset = PNG_SIGNATURE.length;
+  let seenIhdr = false;
+  let seenIdat = false;
+  let seenIend = false;
+  const idatChunks: Buffer[] = [];
+
+  while (offset < bytes.length) {
+    if (offset + 12 > bytes.length) return "truncated_png_chunk";
+
+    const length = readUInt32BE(bytes, offset);
+    const type = readAscii(bytes, offset + 4, 4);
+    const dataStart = offset + 8;
+    const dataEnd = dataStart + length;
+    const crcOffset = dataEnd;
+
+    if (dataEnd + 4 > bytes.length) return "truncated_png_chunk_data";
+
+    const expectedCrc = readUInt32BE(bytes, crcOffset);
+    const actualCrc = crc32(bytes.subarray(offset + 4, dataEnd));
+    if (actualCrc !== expectedCrc) return `invalid_png_${type}_crc`;
+
+    if (type === "IHDR") {
+      if (seenIhdr || offset !== PNG_SIGNATURE.length)
+        return "invalid_png_ihdr";
+      if (length !== 13) return "invalid_png_ihdr_length";
+      const width = readUInt32BE(bytes, dataStart);
+      const height = readUInt32BE(bytes, dataStart + 4);
+      const bitDepth = bytes[dataStart + 8];
+      const colorType = bytes[dataStart + 9];
+      const compression = bytes[dataStart + 10];
+      const filter = bytes[dataStart + 11];
+      const interlace = bytes[dataStart + 12];
+      if (width === 0 || height === 0) return "invalid_png_dimensions";
+      if (!validPngBitDepth(colorType, bitDepth)) {
+        return "invalid_png_color_type";
+      }
+      if (compression !== 0 || filter !== 0 || interlace > 1) {
+        return "invalid_png_header";
+      }
+      seenIhdr = true;
+    } else if (type === "IDAT") {
+      if (!seenIhdr || seenIend) return "invalid_png_idat_order";
+      seenIdat = true;
+      if (length > 0) {
+        idatChunks.push(Buffer.from(bytes.subarray(dataStart, dataEnd)));
+      }
+    } else if (type === "IEND") {
+      if (length !== 0) return "invalid_png_iend_length";
+      seenIend = true;
+      offset = crcOffset + 4;
+      break;
+    }
+
+    offset = crcOffset + 4;
+  }
+
+  if (!seenIhdr) return "missing_png_ihdr";
+  if (!seenIdat || idatChunks.length === 0) return "missing_png_idat";
+  if (!seenIend) return "missing_png_iend";
+  if (bytes.subarray(offset).some((byte) => byte !== 0)) {
+    return "unexpected_png_trailing_data";
+  }
+
+  try {
+    inflateSync(Buffer.concat(idatChunks), {
+      maxOutputLength: MAX_PNG_DECOMPRESSED_BYTES,
+    });
+  } catch {
+    return "invalid_png_image_data";
+  }
+
+  return null;
+};
+
+const isJpegSofMarker = (marker: number): boolean =>
+  [
+    0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce,
+    0xcf,
+  ].includes(marker);
+
+const validateJpeg = (bytes: Uint8Array): string | null => {
+  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) {
+    return "missing_jpeg_signature";
+  }
+  if (bytes[bytes.length - 2] !== 0xff || bytes[bytes.length - 1] !== 0xd9) {
+    return "missing_jpeg_eoi";
+  }
+
+  let offset = 2;
+  let sawFrame = false;
+
+  while (offset + 1 < bytes.length) {
+    if (bytes[offset] !== 0xff) {
+      offset++;
+      continue;
+    }
+
+    while (bytes[offset] === 0xff) offset++;
+    const marker = bytes[offset++];
+
+    if (marker === 0xd9) break;
+    if (marker === 0xda) return sawFrame ? null : "missing_jpeg_frame";
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) continue;
+    if (offset + 2 > bytes.length) return "truncated_jpeg_segment";
+
+    const segmentLength = readUInt16BE(bytes, offset);
+    if (segmentLength < 2 || offset + segmentLength > bytes.length) {
+      return "invalid_jpeg_segment_length";
+    }
+
+    if (isJpegSofMarker(marker)) {
+      if (segmentLength < 7) return "invalid_jpeg_frame";
+      const height = readUInt16BE(bytes, offset + 3);
+      const width = readUInt16BE(bytes, offset + 5);
+      if (width === 0 || height === 0) return "invalid_jpeg_dimensions";
+      sawFrame = true;
+    }
+
+    offset += segmentLength;
+  }
+
+  return sawFrame ? null : "missing_jpeg_frame";
+};
+
+const validateGif = (bytes: Uint8Array): string | null => {
+  if (
+    bytes.length < 14 ||
+    (readAscii(bytes, 0, 6) !== "GIF87a" && readAscii(bytes, 0, 6) !== "GIF89a")
+  ) {
+    return "missing_gif_signature";
+  }
+  const width = bytes[6] | (bytes[7] << 8);
+  const height = bytes[8] | (bytes[9] << 8);
+  if (width === 0 || height === 0) return "invalid_gif_dimensions";
+  if (bytes[bytes.length - 1] !== 0x3b) return "missing_gif_trailer";
+  return null;
+};
+
+const validateWebp = (bytes: Uint8Array): string | null => {
+  if (
+    bytes.length < 20 ||
+    readAscii(bytes, 0, 4) !== "RIFF" ||
+    readAscii(bytes, 8, 4) !== "WEBP"
+  ) {
+    return "missing_webp_signature";
+  }
+
+  const riffSize = readUInt32LE(bytes, 4);
+  if (riffSize + 8 > bytes.length) return "truncated_webp";
+
+  let offset = 12;
+  while (offset + 8 <= bytes.length) {
+    const chunkType = readAscii(bytes, offset, 4);
+    const chunkSize = readUInt32LE(bytes, offset + 4);
+    const dataStart = offset + 8;
+    const dataEnd = dataStart + chunkSize;
+    if (dataEnd > bytes.length) return "truncated_webp_chunk";
+
+    if (chunkType === "VP8 ") {
+      if (chunkSize < 10) return "invalid_webp_vp8_chunk";
+      if (
+        bytes[dataStart + 3] !== 0x9d ||
+        bytes[dataStart + 4] !== 0x01 ||
+        bytes[dataStart + 5] !== 0x2a
+      ) {
+        return "invalid_webp_vp8_start_code";
+      }
+      return null;
+    }
+
+    if (chunkType === "VP8L") {
+      return chunkSize >= 5 && bytes[dataStart] === 0x2f
+        ? null
+        : "invalid_webp_vp8l_chunk";
+    }
+
+    if (chunkType === "VP8X") {
+      if (chunkSize < 10) return "invalid_webp_vp8x_chunk";
+      const width =
+        1 +
+        bytes[dataStart + 4] +
+        (bytes[dataStart + 5] << 8) +
+        (bytes[dataStart + 6] << 16);
+      const height =
+        1 +
+        bytes[dataStart + 7] +
+        (bytes[dataStart + 8] << 8) +
+        (bytes[dataStart + 9] << 16);
+      if (width === 0 || height === 0) return "invalid_webp_dimensions";
+    }
+
+    offset = dataEnd + (chunkSize % 2);
+  }
+
+  return "missing_webp_image_chunk";
+};
+
+export function validateImageBytes(
+  input: Uint8Array,
+  expectedMediaType?: string,
+): ImageValidationResult {
+  if (input.byteLength === 0) return { valid: false, reason: "empty_image" };
+
+  const detectedMediaType = detectImageMediaType(input);
+  if (!detectedMediaType) {
+    return { valid: false, reason: "unrecognized_image_bytes" };
+  }
+
+  const expected = normalizeImageMediaType(expectedMediaType);
+  if (expected && expected !== detectedMediaType) {
+    return {
+      valid: false,
+      reason: "declared_media_type_mismatch",
+      detectedMediaType,
+    };
+  }
+
+  const reason =
+    detectedMediaType === "image/png"
+      ? validatePng(input)
+      : detectedMediaType === "image/jpeg"
+        ? validateJpeg(input)
+        : detectedMediaType === "image/gif"
+          ? validateGif(input)
+          : detectedMediaType === "image/webp"
+            ? validateWebp(input)
+            : "unsupported_image_type";
+
+  return reason
+    ? { valid: false, reason, detectedMediaType }
+    : { valid: true, mediaType: detectedMediaType };
+}


### PR DESCRIPTION
## Summary
- add a shared image byte validator for PNG, JPEG, GIF, and WebP attachments
- validate stored images before sending them to providers, omit invalid Ask-mode images, and keep invalid Agent images sandbox-only
- reject invalid Ask-mode image uploads and block corrupt sandbox `file.view` image-data outputs

## Why
PostHog issue: https://us.posthog.com/error_tracking/019ec641-ffc0-7f30-a06f-dfa9bd76ef57

Existing guards checked source, MIME type, and size, but still allowed corrupt or mislabeled image bytes to reach providers. xAI rejects those payloads with `Invalid PNG image`, so the provider call failed after we had already built the prompt.

## Validation
- `pnpm test -- lib/utils/__tests__/file-transform-utils.test.ts lib/ai/tools/__tests__/file.test.ts convex/__tests__/fileActions.upload-policy.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint lib/utils/image-validation.ts lib/utils/file-transform-utils.ts lib/utils/__tests__/file-transform-utils.test.ts lib/ai/tools/file.ts lib/ai/tools/__tests__/file.test.ts convex/fileActions.ts`
- `pnpm exec prettier --check lib/utils/image-validation.ts lib/utils/file-transform-utils.ts lib/utils/__tests__/file-transform-utils.test.ts lib/ai/tools/file.ts lib/ai/tools/__tests__/file.test.ts convex/fileActions.ts`

## Manual verification
- Upload a corrupt `.png` in Ask mode. It should be rejected before the prompt reaches the provider.
- Attach a stored corrupt image to an Ask request. It should be omitted with a user-visible text note instead of causing provider failure.
- In Agent mode, attach a corrupt stored image. It should still be available to the sandbox as a file, but not sent inline to the model provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added byte-level image validation for uploads and file/image viewing, including support for common media-type aliases (for example `image/jpg`).

* **Bug Fixes**
  * Rejects Ask-mode image uploads with invalid image bytes using a clear `INVALID_IMAGE_BYTES` error.
  * Improves stored-image handling by omitting invalid/corrupted images with a more specific reason and correcting detected media types when bytes don’t match prior metadata.
  * Ensures agent-mode pruning skips unsafe invalid/oversized image parts.

* **Tests**
  * Updated and expanded coverage for valid/invalid image fixtures and expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->