### PR TITLE
Handle unavailable file URLs gracefully

### DIFF
--- a/app/components/AllFilesDialog.tsx
+++ b/app/components/AllFilesDialog.tsx
@@ -268,7 +268,8 @@ const AllFilesDialog = ({
       await Promise.all(
         filesToDownload.map(async ({ file, index }) => {
           try {
-            let url = fileUrls.get(index) || file.part.url;
+            let url: string | null | undefined =
+              fileUrls.get(index) || file.part.url;
 
             // Fetch URL if not already available
             if (!url) {

--- a/app/components/FilePartRenderer.tsx
+++ b/app/components/FilePartRenderer.tsx
@@ -96,6 +96,12 @@ const FilePartRendererComponent = ({
         setUrlError(null);
         try {
           const url = await getFileUrlAction({ fileId: part.fileId });
+          if (!url) {
+            setFileUrl(null);
+            setUrlError("File not available");
+            return;
+          }
+
           setFileUrl(url);
           // Cache the fetched URL
           if (cache) {

--- a/convex/__tests__/s3Actions.test.ts
+++ b/convex/__tests__/s3Actions.test.ts
@@ -546,7 +546,7 @@ describe("s3Actions", () => {
       ).rejects.toThrow("Unauthenticated");
     });
 
-    it("should throw error for file not found", async () => {
+    it("should return null for file not found", async () => {
       const { getFileUrlAction } = await import("../s3Actions");
 
       const mockCtx = {
@@ -562,10 +562,10 @@ describe("s3Actions", () => {
 
       await expect(
         getFileUrlAction.handler(mockCtx, { fileId: "file123" as any }),
-      ).rejects.toThrow("File not found");
+      ).resolves.toBeNull();
     });
 
-    it("should throw error for access denied", async () => {
+    it("should return null for access denied", async () => {
       const { getFileUrlAction } = await import("../s3Actions");
 
       const mockFileId = "file123" as any;
@@ -594,10 +594,10 @@ describe("s3Actions", () => {
 
       await expect(
         getFileUrlAction.handler(mockCtx, { fileId: mockFileId }),
-      ).rejects.toThrow("Access denied");
+      ).resolves.toBeNull();
     });
 
-    it("should throw error for file with no S3 storage reference", async () => {
+    it("should return null for file with no S3 storage reference", async () => {
       const { getFileUrlAction } = await import("../s3Actions");
 
       const mockFileId = "file123" as any;
@@ -626,7 +626,7 @@ describe("s3Actions", () => {
 
       await expect(
         getFileUrlAction.handler(mockCtx, { fileId: mockFileId }),
-      ).rejects.toThrow("File has no S3 storage reference");
+      ).resolves.toBeNull();
     });
 
     it("should handle S3 download URL generation errors", async () => {

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -218,15 +218,16 @@ export const generateS3UploadUrlAction = action({
  * - Authenticates the user via ctx.auth
  * - Fetches the file record from database
  * - Verifies user has access to the file (ownership check)
- * - Requires the file to have an S3 object reference
+ * - Returns null when the file is missing, inaccessible, or no longer has an
+ *   S3 object reference
  * - Returns a presigned URL (valid for 1 hour)
  */
 export const getFileUrlAction = action({
   args: {
     fileId: v.id("files"),
   },
-  returns: v.string(),
-  handler: async (ctx, args): Promise<string> => {
+  returns: v.union(v.string(), v.null()),
+  handler: async (ctx, args): Promise<string | null> => {
     // Authenticate user
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
@@ -245,18 +246,16 @@ export const getFileUrlAction = action({
       );
 
       if (!file) {
-        throw new Error("File not found");
+        return null;
       }
 
       // Verify user has access to this file
       if (file.user_id !== identity.subject) {
-        throw new Error(
-          "Access denied: You do not have permission to access this file",
-        );
+        return null;
       }
 
       if (!file.s3_key) {
-        throw new Error("File has no S3 storage reference");
+        return null;
       }
 
       // S3 file: Generate presigned download URL (valid for 1 hour)


### PR DESCRIPTION
## Summary
- return `null` from `getFileUrlAction` when a file row is missing, inaccessible, or no longer has an S3 object reference
- handle nullable URL fetches in file rendering and all-files batch download paths
- update S3 action tests so stale/unavailable file references are graceful misses instead of uncaught action errors

## Why
PostHog issue `019dd473-0265-7cf3-ba27-9e1bfa334a4d` grouped repeated Convex action errors from `getFileUrlAction`, including `Failed to get file URL: File has no S3 storage reference` and `File not found`. This correlates with removing legacy Convex file storage support: old message/file references can still exist after their old storage pointer is gone, so the client should render them as unavailable rather than causing Error Tracking noise.

## Validation
- `pnpm test -- convex/__tests__/s3Actions.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec prettier --check convex/s3Actions.ts convex/__tests__/s3Actions.test.ts app/components/FilePartRenderer.tsx app/components/AllFilesDialog.tsx`
- `pnpm exec eslint convex/s3Actions.ts convex/__tests__/s3Actions.test.ts app/components/FilePartRenderer.tsx app/components/AllFilesDialog.tsx`

## Manual verification
- Open a chat containing an old/deleted file reference whose `files` row is missing or has no `s3_key`.
- Confirm the message shows an unavailable file state instead of producing a Convex action error.
- Open the all-files dialog or attempt a batch download with the same stale reference and confirm available files still download while the stale file is skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for unavailable or inaccessible files with clearer user-facing error messages.

* **Tests**
  * Updated test cases to align with improved error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->