### PR TITLE
Add token-budgeted retained tail summaries

### DIFF
--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -61,6 +61,22 @@ const USER_ID = "user-123";
 const CHAT_DOC_ID = "chat-doc-id" as Id<"chats">;
 const SUMMARY_DOC_ID = "summary-doc-id" as Id<"chat_summaries">;
 
+function makeRetainedTail(
+  overrides: Record<string, any> = {},
+): Record<string, any> {
+  return {
+    start_message_id: "msg-tail-start",
+    start_part_index: 0,
+    budget_tokens: 8000,
+    retained_tokens: 1200,
+    retained_message_count: 2,
+    retained_part_count: 4,
+    projected_part_count: 0,
+    strategy: "token_budgeted_tail_v1",
+    ...overrides,
+  };
+}
+
 function makeSummaryDoc(
   overrides: Record<string, any> = {},
 ): Record<string, any> {
@@ -128,6 +144,93 @@ describe("copyChatSummary", () => {
         prompt_version: "test-prompt-v1",
       }),
     );
+  });
+
+  it("remaps retained tail metadata for copied summary messages", async () => {
+    const { copyChatSummary } = await import("../lib/utils");
+    const mockDb = {
+      get: jest.fn<any>().mockResolvedValue(
+        makeSummaryDoc({
+          summary_up_to_message_id: "source-cutoff",
+          retained_tail: makeRetainedTail({
+            start_message_id: "source-tail",
+            start_part_index: 3,
+          }),
+          previous_summaries: [
+            {
+              summary_text: "previous",
+              summary_up_to_message_id: "source-prev-cutoff",
+              retained_tail: makeRetainedTail({
+                start_message_id: "source-prev-tail",
+                start_part_index: 1,
+              }),
+            },
+          ],
+        }),
+      ),
+      insert: jest.fn<any>().mockResolvedValue("new-summary-id"),
+      patch: jest.fn<any>().mockResolvedValue(undefined),
+    };
+
+    await copyChatSummary(mockDb as any, {
+      sourceSummaryId: SUMMARY_DOC_ID,
+      targetChatDocId: "target-chat-doc-id" as Id<"chats">,
+      targetChatId: "target-chat-id",
+      messageIdMap: new Map([
+        ["source-cutoff", "target-cutoff"],
+        ["source-tail", "target-tail"],
+        ["source-prev-cutoff", "target-prev-cutoff"],
+        ["source-prev-tail", "target-prev-tail"],
+      ]),
+    });
+
+    expect(mockDb.insert).toHaveBeenCalledWith(
+      "chat_summaries",
+      expect.objectContaining({
+        summary_up_to_message_id: "target-cutoff",
+        retained_tail: expect.objectContaining({
+          start_message_id: "target-tail",
+          start_part_index: 3,
+        }),
+        previous_summaries: [
+          expect.objectContaining({
+            summary_up_to_message_id: "target-prev-cutoff",
+            retained_tail: expect.objectContaining({
+              start_message_id: "target-prev-tail",
+              start_part_index: 1,
+            }),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("drops only retained tail metadata when copied tail start cannot be remapped", async () => {
+    const { copyChatSummary } = await import("../lib/utils");
+    const mockDb = {
+      get: jest.fn<any>().mockResolvedValue(
+        makeSummaryDoc({
+          summary_up_to_message_id: "source-cutoff",
+          retained_tail: makeRetainedTail({
+            start_message_id: "source-tail-not-copied",
+          }),
+        }),
+      ),
+      insert: jest.fn<any>().mockResolvedValue("new-summary-id"),
+      patch: jest.fn<any>().mockResolvedValue(undefined),
+    };
+
+    await copyChatSummary(mockDb as any, {
+      sourceSummaryId: SUMMARY_DOC_ID,
+      targetChatDocId: "target-chat-doc-id" as Id<"chats">,
+      targetChatId: "target-chat-id",
+      messageIdMap: new Map([["source-cutoff", "target-cutoff"]]),
+    });
+
+    const insertedDoc = mockDb.insert.mock.calls[0][1];
+    expect(insertedDoc.summary_text).toBe("current summary");
+    expect(insertedDoc.summary_up_to_message_id).toBe("target-cutoff");
+    expect(insertedDoc.retained_tail).toBeUndefined();
   });
 });
 
@@ -244,6 +347,36 @@ describe("saveLatestSummary — previous_summaries chain", () => {
     );
   });
 
+  it("should persist retained tail metadata on the latest summary", async () => {
+    const chat = makeChatDoc({ latest_summary_id: undefined });
+    setupSaveSummaryQueries(chat);
+    const retainedTail = makeRetainedTail({
+      start_message_id: "msg-9",
+      start_part_index: 2,
+      projected_part_count: 1,
+    });
+
+    const { saveLatestSummary } = await import("../chats");
+
+    await saveLatestSummary.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      chatId: CHAT_ID,
+      summaryText: "new summary",
+      summaryUpToMessageId: "msg-8",
+      metadata: {
+        retainedTail,
+      },
+    });
+
+    expect(mockCtx.db.insert).toHaveBeenCalledWith(
+      "chat_summaries",
+      expect.objectContaining({
+        summary_up_to_message_id: "msg-8",
+        retained_tail: retainedTail,
+      }),
+    );
+  });
+
   it("should push old summary into previous_summaries[0] on second save", async () => {
     const chat = makeChatDoc();
     setupSaveSummaryQueries(chat);
@@ -278,6 +411,42 @@ describe("saveLatestSummary — previous_summaries chain", () => {
       }),
     );
     expect(mockCtx.db.delete).not.toHaveBeenCalledWith(SUMMARY_DOC_ID);
+  });
+
+  it("should preserve old retained tail metadata in previous_summaries", async () => {
+    const chat = makeChatDoc();
+    setupSaveSummaryQueries(chat);
+    const oldRetainedTail = makeRetainedTail({
+      start_message_id: "msg-6",
+      start_part_index: 4,
+    });
+
+    const oldSummary = makeSummaryDoc({
+      summary_text: "old text",
+      summary_up_to_message_id: "msg-5",
+      summary_up_to_message_creation_time: 5_000,
+      retained_tail: oldRetainedTail,
+      previous_summaries: [],
+    });
+    mockCtx.db.get.mockResolvedValue(oldSummary);
+
+    const { saveLatestSummary } = await import("../chats");
+
+    await saveLatestSummary.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      chatId: CHAT_ID,
+      summaryText: "new summary",
+      summaryUpToMessageId: "msg-10",
+    });
+
+    const insertedDoc = mockCtx.db.insert.mock.calls[0][1];
+    expect(insertedDoc.previous_summaries[0]).toEqual(
+      expect.objectContaining({
+        summary_text: "old text",
+        summary_up_to_message_id: "msg-5",
+        retained_tail: oldRetainedTail,
+      }),
+    );
   });
 
   it("should preserve the chain: [old, ...old_previous_summaries]", async () => {
@@ -716,6 +885,55 @@ describe("checkAndInvalidateSummary via deleteLastAssistantMessage", () => {
     });
   });
 
+  it("should preserve retained tail metadata when promoting a previous summary", async () => {
+    const assistantMsg = makeAssistantMessage({ _creationTime: 2000 });
+    const chatDoc = makeChatDoc();
+    const retainedTail = makeRetainedTail({
+      start_message_id: "msg-prev-1",
+      start_part_index: 2,
+    });
+    const summaryDoc = makeSummaryDoc({
+      summary_up_to_message_id: "msg-cutoff",
+      previous_summaries: [
+        {
+          summary_text: "fallback-text",
+          summary_up_to_message_id: "msg-prev-1",
+          retained_tail: retainedTail,
+        },
+      ],
+    });
+
+    const cutoffMsg = {
+      _id: "cutoff-doc",
+      id: "msg-cutoff",
+      _creationTime: 3000,
+    };
+    const prevCutoffMsg = {
+      _id: "prev-cutoff-doc",
+      id: "msg-prev-1",
+      _creationTime: 1000,
+    };
+
+    setupDbQueryChain({
+      assistantMessage: assistantMsg,
+      chatDoc,
+      cutoffMessage: cutoffMsg,
+      fallbackCutoffMessages: [prevCutoffMsg],
+    });
+    mockCtx.db.get.mockResolvedValue(summaryDoc);
+
+    const { deleteLastAssistantMessage } = await import("../messages");
+
+    await deleteLastAssistantMessage.handler(mockCtx, { chatId: CHAT_ID });
+
+    expect(mockCtx.db.patch).toHaveBeenCalledWith(SUMMARY_DOC_ID, {
+      summary_text: "fallback-text",
+      summary_up_to_message_id: "msg-prev-1",
+      retained_tail: retainedTail,
+      previous_summaries: [],
+    });
+  });
+
   it("should skip invalid previous entries and promote a deeper valid one", async () => {
     const assistantMsg = makeAssistantMessage({ _creationTime: 2000 });
     const chatDoc = makeChatDoc();
@@ -855,6 +1073,45 @@ describe("checkAndInvalidateSummary via deleteLastAssistantMessage", () => {
       expect.objectContaining({ latest_summary_id: undefined }),
     );
 
+    expect(mockCtx.db.delete).toHaveBeenCalledWith(SUMMARY_DOC_ID);
+  });
+
+  it("should invalidate a partial-message summary when deleting its tail-start message", async () => {
+    const assistantMsg = makeAssistantMessage({
+      id: CUTOFF_MSG_ID,
+      _creationTime: 5000,
+    });
+    const chatDoc = makeChatDoc();
+    const summaryDoc = makeSummaryDoc({
+      summary_up_to_message_id: CUTOFF_MSG_ID,
+      retained_tail: makeRetainedTail({
+        start_message_id: CUTOFF_MSG_ID,
+        start_part_index: 2,
+      }),
+      previous_summaries: [],
+    });
+    const cutoffMsg = {
+      _id: "cutoff-doc",
+      id: CUTOFF_MSG_ID,
+      _creationTime: 5000,
+    };
+
+    setupDbQueryChain({
+      assistantMessage: assistantMsg,
+      chatDoc,
+      cutoffMessage: cutoffMsg,
+      fallbackCutoffMessages: [],
+    });
+    mockCtx.db.get.mockResolvedValue(summaryDoc);
+
+    const { deleteLastAssistantMessage } = await import("../messages");
+
+    await deleteLastAssistantMessage.handler(mockCtx, { chatId: CHAT_ID });
+
+    expect(mockCtx.db.patch).toHaveBeenCalledWith(
+      CHAT_DOC_ID,
+      expect.objectContaining({ latest_summary_id: undefined }),
+    );
     expect(mockCtx.db.delete).toHaveBeenCalledWith(SUMMARY_DOC_ID);
   });
 

--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -60,6 +60,20 @@ const CHAT_ID = "chat-001";
 const USER_ID = "user-123";
 const CHAT_DOC_ID = "chat-doc-id" as Id<"chats">;
 const SUMMARY_DOC_ID = "summary-doc-id" as Id<"chat_summaries">;
+const SUMMARY_TELEMETRY_FIELDS = [
+  "input_tokens",
+  "output_tokens",
+  "cache_read_tokens",
+  "cache_write_tokens",
+  "cost",
+  "estimated_compacted_input_tokens",
+] as const;
+
+function expectNoSummaryTelemetry(doc: Record<string, any>): void {
+  for (const field of SUMMARY_TELEMETRY_FIELDS) {
+    expect(doc[field]).toBeUndefined();
+  }
+}
 
 function makeRetainedTail(
   overrides: Record<string, any> = {},
@@ -323,9 +337,6 @@ describe("saveLatestSummary — previous_summaries chain", () => {
         promptVersion: "test-prompt-v1",
         model: "test-model",
         status: "completed",
-        inputTokens: 100,
-        outputTokens: 20,
-        estimatedCompactedInputTokens: 90,
         transcriptPath: "/tmp/agent-transcripts/test.json",
       },
     });
@@ -339,12 +350,117 @@ describe("saveLatestSummary — previous_summaries chain", () => {
         prompt_version: "test-prompt-v1",
         model: "test-model",
         status: "completed",
-        input_tokens: 100,
-        output_tokens: 20,
-        estimated_compacted_input_tokens: 90,
         transcript_path: "/tmp/agent-transcripts/test.json",
       }),
     );
+    const insertedDoc = mockCtx.db.insert.mock.calls[0][1];
+    expectNoSummaryTelemetry(insertedDoc);
+  });
+
+  it("should accept legacy summary telemetry metadata without writing it", async () => {
+    const chat = makeChatDoc({ latest_summary_id: undefined });
+    setupSaveSummaryQueries(chat);
+
+    const { saveLatestSummary } = await import("../chats");
+
+    await saveLatestSummary.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      chatId: CHAT_ID,
+      summaryText: "new summary",
+      summaryUpToMessageId: "msg-10",
+      metadata: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 10,
+        cacheWriteTokens: 5,
+        cost: 0.01,
+        estimatedCompactedInputTokens: 90,
+      },
+    });
+
+    const insertedDoc = mockCtx.db.insert.mock.calls[0][1];
+    expectNoSummaryTelemetry(insertedDoc);
+  });
+
+  it("should remove legacy summary telemetry fields in cleanup batches", async () => {
+    const paginate = jest.fn<any>().mockResolvedValue({
+      page: [
+        makeSummaryDoc({
+          _id: "summary-with-telemetry" as Id<"chat_summaries">,
+          input_tokens: 100,
+          output_tokens: 20,
+          cache_read_tokens: 10,
+          cache_write_tokens: 5,
+          cost: 0.01,
+          estimated_compacted_input_tokens: 90,
+        }),
+        makeSummaryDoc({
+          _id: "summary-without-telemetry" as Id<"chat_summaries">,
+        }),
+      ],
+      isDone: false,
+      continueCursor: "next-cursor",
+    });
+    const order = jest.fn().mockReturnValue({ paginate });
+    mockCtx.db.query.mockReturnValue({ order });
+
+    const { cleanupChatSummaryTelemetry } = await import("../chats");
+    const result = await cleanupChatSummaryTelemetry.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      paginationOpts: { numItems: 2, cursor: null },
+    });
+
+    expect(mockCtx.db.query).toHaveBeenCalledWith("chat_summaries");
+    expect(order).toHaveBeenCalledWith("asc");
+    expect(paginate).toHaveBeenCalledWith({ numItems: 2, cursor: null });
+    expect(mockCtx.db.patch).toHaveBeenCalledWith("summary-with-telemetry", {
+      input_tokens: undefined,
+      output_tokens: undefined,
+      cache_read_tokens: undefined,
+      cache_write_tokens: undefined,
+      cost: undefined,
+      estimated_compacted_input_tokens: undefined,
+    });
+    expect(mockCtx.db.patch).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      scanned: 2,
+      matched: 1,
+      patched: 1,
+      isDone: false,
+      continueCursor: "next-cursor",
+    });
+  });
+
+  it("should support dry-run telemetry cleanup without patching rows", async () => {
+    const paginate = jest.fn<any>().mockResolvedValue({
+      page: [
+        makeSummaryDoc({
+          _id: "summary-with-telemetry" as Id<"chat_summaries">,
+          input_tokens: 100,
+        }),
+      ],
+      isDone: true,
+      continueCursor: "",
+    });
+    mockCtx.db.query.mockReturnValue({
+      order: jest.fn().mockReturnValue({ paginate }),
+    });
+
+    const { cleanupChatSummaryTelemetry } = await import("../chats");
+    const result = await cleanupChatSummaryTelemetry.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      paginationOpts: { numItems: 1, cursor: null },
+      dryRun: true,
+    });
+
+    expect(mockCtx.db.patch).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      scanned: 1,
+      matched: 1,
+      patched: 0,
+      isDone: true,
+      continueCursor: "",
+    });
   });
 
   it("should persist retained tail metadata on the latest summary", async () => {

--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -881,6 +881,7 @@ describe("checkAndInvalidateSummary via deleteLastAssistantMessage", () => {
     expect(mockCtx.db.patch).toHaveBeenCalledWith(SUMMARY_DOC_ID, {
       summary_text: "fallback-text",
       summary_up_to_message_id: "msg-prev-1",
+      summary_up_to_message_creation_time: 1000,
       previous_summaries: [],
     });
   });
@@ -929,6 +930,7 @@ describe("checkAndInvalidateSummary via deleteLastAssistantMessage", () => {
     expect(mockCtx.db.patch).toHaveBeenCalledWith(SUMMARY_DOC_ID, {
       summary_text: "fallback-text",
       summary_up_to_message_id: "msg-prev-1",
+      summary_up_to_message_creation_time: 1000,
       retained_tail: retainedTail,
       previous_summaries: [],
     });
@@ -976,6 +978,7 @@ describe("checkAndInvalidateSummary via deleteLastAssistantMessage", () => {
     expect(mockCtx.db.patch).toHaveBeenCalledWith(SUMMARY_DOC_ID, {
       summary_text: "prev-1-text",
       summary_up_to_message_id: "msg-prev-1",
+      summary_up_to_message_creation_time: 500,
       previous_summaries: [],
     });
   });
@@ -1020,6 +1023,7 @@ describe("checkAndInvalidateSummary via deleteLastAssistantMessage", () => {
     expect(mockCtx.db.patch).toHaveBeenCalledWith(SUMMARY_DOC_ID, {
       summary_text: "first summary",
       summary_up_to_message_id: "msg-5",
+      summary_up_to_message_creation_time: 2000,
       previous_summaries: [],
     });
 

--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -32,6 +32,10 @@ jest.mock("convex/values", () => ({
 }));
 jest.mock("../_generated/api", () => ({
   internal: {
+    chats: {
+      cleanupChatSummaryTelemetryBatch:
+        "internal.chats.cleanupChatSummaryTelemetryBatch",
+    },
     messages: {
       verifyChatOwnership: "internal.messages.verifyChatOwnership",
     },
@@ -267,6 +271,9 @@ describe("saveLatestSummary — previous_summaries chain", () => {
         patch: jest.fn<any>().mockResolvedValue(undefined),
         delete: jest.fn<any>().mockResolvedValue(undefined),
       },
+      scheduler: {
+        runAfter: jest.fn<any>().mockResolvedValue(undefined),
+      },
     };
 
     const withIndexMock = jest.fn().mockReturnValue({
@@ -461,6 +468,137 @@ describe("saveLatestSummary — previous_summaries chain", () => {
       isDone: true,
       continueCursor: "",
     });
+  });
+
+  it("should schedule async summary telemetry cleanup for large datasets", async () => {
+    const { startChatSummaryTelemetryCleanup } = await import("../chats");
+
+    const result = await startChatSummaryTelemetryCleanup.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      batchSize: 2_000,
+    });
+
+    expect(result).toEqual({
+      scheduled: true,
+      batchSize: 1000,
+      dryRun: false,
+    });
+    expect(mockCtx.scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      "internal.chats.cleanupChatSummaryTelemetryBatch",
+      expect.objectContaining({
+        cursor: null,
+        batchSize: 1000,
+        dryRun: false,
+        scannedSoFar: 0,
+        matchedSoFar: 0,
+        patchedSoFar: 0,
+        batchCount: 0,
+      }),
+    );
+  });
+
+  it("should process and reschedule async telemetry cleanup batches", async () => {
+    const paginate = jest.fn<any>().mockResolvedValue({
+      page: [
+        makeSummaryDoc({
+          _id: "summary-with-telemetry" as Id<"chat_summaries">,
+          input_tokens: 100,
+        }),
+        makeSummaryDoc({
+          _id: "summary-without-telemetry" as Id<"chat_summaries">,
+        }),
+      ],
+      isDone: false,
+      continueCursor: "next-cursor",
+    });
+    mockCtx.db.query.mockReturnValue({
+      order: jest.fn().mockReturnValue({ paginate }),
+    });
+
+    const { cleanupChatSummaryTelemetryBatch } = await import("../chats");
+    const result = await cleanupChatSummaryTelemetryBatch.handler(mockCtx, {
+      cursor: "current-cursor",
+      batchSize: 500,
+      scannedSoFar: 10,
+      matchedSoFar: 4,
+      patchedSoFar: 4,
+      batchCount: 1,
+      startedAt: Date.now(),
+    });
+
+    expect(paginate).toHaveBeenCalledWith({
+      numItems: 500,
+      cursor: "current-cursor",
+    });
+    expect(mockCtx.db.patch).toHaveBeenCalledWith(
+      "summary-with-telemetry",
+      expect.objectContaining({
+        input_tokens: undefined,
+        estimated_compacted_input_tokens: undefined,
+      }),
+    );
+    expect(mockCtx.scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      "internal.chats.cleanupChatSummaryTelemetryBatch",
+      expect.objectContaining({
+        cursor: "next-cursor",
+        batchSize: 500,
+        scannedSoFar: 12,
+        matchedSoFar: 5,
+        patchedSoFar: 5,
+        batchCount: 2,
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        scanned: 2,
+        matched: 1,
+        patched: 1,
+        totalScanned: 12,
+        totalMatched: 5,
+        totalPatched: 5,
+        isDone: false,
+        continueCursor: "next-cursor",
+      }),
+    );
+  });
+
+  it("should finish async telemetry cleanup without rescheduling", async () => {
+    const paginate = jest.fn<any>().mockResolvedValue({
+      page: [
+        makeSummaryDoc({
+          _id: "summary-with-telemetry" as Id<"chat_summaries">,
+          input_tokens: 100,
+        }),
+      ],
+      isDone: true,
+      continueCursor: "",
+    });
+    mockCtx.db.query.mockReturnValue({
+      order: jest.fn().mockReturnValue({ paginate }),
+    });
+
+    const { cleanupChatSummaryTelemetryBatch } = await import("../chats");
+    const result = await cleanupChatSummaryTelemetryBatch.handler(mockCtx, {
+      cursor: null,
+      batchSize: 500,
+      dryRun: true,
+    });
+
+    expect(mockCtx.db.patch).not.toHaveBeenCalled();
+    expect(mockCtx.scheduler.runAfter).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({
+        scanned: 1,
+        matched: 1,
+        patched: 0,
+        totalScanned: 1,
+        totalMatched: 1,
+        totalPatched: 0,
+        isDone: true,
+      }),
+    );
   });
 
   it("should persist retained tail metadata on the latest summary", async () => {

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as fileActions from "../fileActions.js";
 import type * as fileAggregate from "../fileAggregate.js";
 import type * as fileStorage from "../fileStorage.js";
 import type * as lib_logger from "../lib/logger.js";
+import type * as lib_retainedTail from "../lib/retainedTail.js";
 import type * as lib_utils from "../lib/utils.js";
 import type * as localSandbox from "../localSandbox.js";
 import type * as messages from "../messages.js";
@@ -60,6 +61,7 @@ declare const fullApi: ApiFromModules<{
   fileAggregate: typeof fileAggregate;
   fileStorage: typeof fileStorage;
   "lib/logger": typeof lib_logger;
+  "lib/retainedTail": typeof lib_retainedTail;
   "lib/utils": typeof lib_utils;
   localSandbox: typeof localSandbox;
   messages: typeof messages;

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -22,6 +22,8 @@ import { convexLogger } from "./lib/logger";
 
 const DELETE_ALL_CHATS_MESSAGE_BATCH_SIZE = 10;
 const DELETE_ALL_CHATS_SUMMARY_BATCH_SIZE = 25;
+const CHAT_SUMMARY_TELEMETRY_CLEANUP_DEFAULT_BATCH_SIZE = 500;
+const CHAT_SUMMARY_TELEMETRY_CLEANUP_MAX_BATCH_SIZE = 1000;
 const CHAT_SUMMARY_TELEMETRY_FIELDS = [
   "input_tokens",
   "output_tokens",
@@ -30,6 +32,35 @@ const CHAT_SUMMARY_TELEMETRY_FIELDS = [
   "cost",
   "estimated_compacted_input_tokens",
 ] as const;
+
+function normalizeTelemetryCleanupBatchSize(batchSize?: number): number {
+  if (!Number.isFinite(batchSize) || !batchSize) {
+    return CHAT_SUMMARY_TELEMETRY_CLEANUP_DEFAULT_BATCH_SIZE;
+  }
+  return Math.min(
+    CHAT_SUMMARY_TELEMETRY_CLEANUP_MAX_BATCH_SIZE,
+    Math.max(1, Math.floor(batchSize)),
+  );
+}
+
+function hasChatSummaryTelemetry(
+  summary: Partial<
+    Record<(typeof CHAT_SUMMARY_TELEMETRY_FIELDS)[number], unknown>
+  >,
+): boolean {
+  return CHAT_SUMMARY_TELEMETRY_FIELDS.some(
+    (field) => summary[field] !== undefined,
+  );
+}
+
+const CHAT_SUMMARY_TELEMETRY_CLEAR_PATCH = {
+  input_tokens: undefined,
+  output_tokens: undefined,
+  cache_read_tokens: undefined,
+  cache_write_tokens: undefined,
+  cost: undefined,
+  estimated_compacted_input_tokens: undefined,
+};
 
 async function getMessageCreationTimeById(
   ctx: MutationCtx,
@@ -1352,22 +1383,12 @@ export const cleanupChatSummaryTelemetry = mutation({
     let matched = 0;
     let patched = 0;
     for (const summary of result.page) {
-      const hasTelemetry = CHAT_SUMMARY_TELEMETRY_FIELDS.some(
-        (field) => summary[field] !== undefined,
-      );
-      if (!hasTelemetry) continue;
+      if (!hasChatSummaryTelemetry(summary)) continue;
 
       matched++;
       if (args.dryRun === true) continue;
 
-      await ctx.db.patch(summary._id, {
-        input_tokens: undefined,
-        output_tokens: undefined,
-        cache_read_tokens: undefined,
-        cache_write_tokens: undefined,
-        cost: undefined,
-        estimated_compacted_input_tokens: undefined,
-      });
+      await ctx.db.patch(summary._id, CHAT_SUMMARY_TELEMETRY_CLEAR_PATCH);
       patched++;
     }
 
@@ -1375,6 +1396,148 @@ export const cleanupChatSummaryTelemetry = mutation({
       scanned: result.page.length,
       matched,
       patched,
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});
+
+/**
+ * Starts an async cleanup job for large production datasets.
+ *
+ * This schedules internal batches so a 250k-row cleanup does not require
+ * hundreds of manual cursor calls.
+ */
+export const startChatSummaryTelemetryCleanup = mutation({
+  args: {
+    serviceKey: v.string(),
+    batchSize: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  returns: v.object({
+    scheduled: v.boolean(),
+    batchSize: v.number(),
+    dryRun: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const batchSize = normalizeTelemetryCleanupBatchSize(args.batchSize);
+    const dryRun = args.dryRun === true;
+    await ctx.scheduler.runAfter(
+      0,
+      internal.chats.cleanupChatSummaryTelemetryBatch,
+      {
+        cursor: null,
+        batchSize,
+        dryRun,
+        scannedSoFar: 0,
+        matchedSoFar: 0,
+        patchedSoFar: 0,
+        batchCount: 0,
+        startedAt: Date.now(),
+      },
+    );
+
+    return { scheduled: true, batchSize, dryRun };
+  },
+});
+
+export const cleanupChatSummaryTelemetryBatch = internalMutation({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    batchSize: v.number(),
+    dryRun: v.optional(v.boolean()),
+    scannedSoFar: v.optional(v.number()),
+    matchedSoFar: v.optional(v.number()),
+    patchedSoFar: v.optional(v.number()),
+    batchCount: v.optional(v.number()),
+    startedAt: v.optional(v.number()),
+  },
+  returns: v.object({
+    scanned: v.number(),
+    matched: v.number(),
+    patched: v.number(),
+    totalScanned: v.number(),
+    totalMatched: v.number(),
+    totalPatched: v.number(),
+    isDone: v.boolean(),
+    continueCursor: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const batchSize = normalizeTelemetryCleanupBatchSize(args.batchSize);
+    const result = await ctx.db
+      .query("chat_summaries")
+      .order("asc")
+      .paginate({ numItems: batchSize, cursor: args.cursor });
+
+    let matched = 0;
+    let patched = 0;
+    for (const summary of result.page) {
+      if (!hasChatSummaryTelemetry(summary)) continue;
+
+      matched++;
+      if (args.dryRun === true) continue;
+
+      await ctx.db.patch(summary._id, CHAT_SUMMARY_TELEMETRY_CLEAR_PATCH);
+      patched++;
+    }
+
+    const totalScanned = (args.scannedSoFar ?? 0) + result.page.length;
+    const totalMatched = (args.matchedSoFar ?? 0) + matched;
+    const totalPatched = (args.patchedSoFar ?? 0) + patched;
+    const batchCount = (args.batchCount ?? 0) + 1;
+    const startedAt = args.startedAt ?? Date.now();
+
+    if (result.isDone) {
+      convexLogger.info("chat_summary_telemetry_cleanup_completed", {
+        service: "convex",
+        environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+        dry_run: args.dryRun === true,
+        batch_size: batchSize,
+        batch_count: batchCount,
+        scanned: totalScanned,
+        matched: totalMatched,
+        patched: totalPatched,
+        duration_ms: Date.now() - startedAt,
+      });
+    } else {
+      if (batchCount % 25 === 0) {
+        convexLogger.info("chat_summary_telemetry_cleanup_progress", {
+          service: "convex",
+          environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+          dry_run: args.dryRun === true,
+          batch_size: batchSize,
+          batch_count: batchCount,
+          scanned: totalScanned,
+          matched: totalMatched,
+          patched: totalPatched,
+        });
+      }
+
+      await ctx.scheduler.runAfter(
+        0,
+        internal.chats.cleanupChatSummaryTelemetryBatch,
+        {
+          cursor: result.continueCursor,
+          batchSize,
+          dryRun: args.dryRun === true,
+          scannedSoFar: totalScanned,
+          matchedSoFar: totalMatched,
+          patchedSoFar: totalPatched,
+          batchCount,
+          startedAt,
+        },
+      );
+    }
+
+    return {
+      scanned: result.page.length,
+      matched,
+      patched,
+      totalScanned,
+      totalMatched,
+      totalPatched,
       isDone: result.isDone,
       continueCursor: result.continueCursor,
     };

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -22,6 +22,14 @@ import { convexLogger } from "./lib/logger";
 
 const DELETE_ALL_CHATS_MESSAGE_BATCH_SIZE = 10;
 const DELETE_ALL_CHATS_SUMMARY_BATCH_SIZE = 25;
+const CHAT_SUMMARY_TELEMETRY_FIELDS = [
+  "input_tokens",
+  "output_tokens",
+  "cache_read_tokens",
+  "cache_write_tokens",
+  "cost",
+  "estimated_compacted_input_tokens",
+] as const;
 
 async function getMessageCreationTimeById(
   ctx: MutationCtx,
@@ -1113,6 +1121,8 @@ export const saveLatestSummary = mutation({
         model: v.optional(v.string()),
         status: v.optional(v.string()),
         error: v.optional(v.string()),
+        // Accepted for deploy-skew compatibility with older workers, but no
+        // longer persisted on chat_summaries.
         inputTokens: v.optional(v.number()),
         outputTokens: v.optional(v.number()),
         cacheReadTokens: v.optional(v.number()),
@@ -1265,13 +1275,6 @@ export const saveLatestSummary = mutation({
           model: args.metadata?.model,
           status: args.metadata?.status ?? "completed",
           error: args.metadata?.error,
-          input_tokens: args.metadata?.inputTokens,
-          output_tokens: args.metadata?.outputTokens,
-          cache_read_tokens: args.metadata?.cacheReadTokens,
-          cache_write_tokens: args.metadata?.cacheWriteTokens,
-          cost: args.metadata?.cost,
-          estimated_compacted_input_tokens:
-            args.metadata?.estimatedCompactedInputTokens,
           transcript_path: args.metadata?.transcriptPath,
           retained_tail: args.metadata?.retainedTail,
         }).filter(([, value]) => value !== undefined),
@@ -1315,6 +1318,66 @@ export const saveLatestSummary = mutation({
       });
       throw error;
     }
+  },
+});
+
+/**
+ * Batch cleanup for legacy summary telemetry fields.
+ *
+ * Run repeatedly in production with the returned cursor until isDone is true,
+ * then the optional telemetry columns can be removed from the schema in a
+ * follow-up deploy.
+ */
+export const cleanupChatSummaryTelemetry = mutation({
+  args: {
+    serviceKey: v.string(),
+    paginationOpts: paginationOptsValidator,
+    dryRun: v.optional(v.boolean()),
+  },
+  returns: v.object({
+    scanned: v.number(),
+    matched: v.number(),
+    patched: v.number(),
+    isDone: v.boolean(),
+    continueCursor: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const result = await ctx.db
+      .query("chat_summaries")
+      .order("asc")
+      .paginate(args.paginationOpts);
+
+    let matched = 0;
+    let patched = 0;
+    for (const summary of result.page) {
+      const hasTelemetry = CHAT_SUMMARY_TELEMETRY_FIELDS.some(
+        (field) => summary[field] !== undefined,
+      );
+      if (!hasTelemetry) continue;
+
+      matched++;
+      if (args.dryRun === true) continue;
+
+      await ctx.db.patch(summary._id, {
+        input_tokens: undefined,
+        output_tokens: undefined,
+        cache_read_tokens: undefined,
+        cache_write_tokens: undefined,
+        cost: undefined,
+        estimated_compacted_input_tokens: undefined,
+      });
+      patched++;
+    }
+
+    return {
+      scanned: result.page.length,
+      matched,
+      patched,
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
   },
 });
 

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -19,6 +19,28 @@ import { convexLogger } from "./lib/logger";
 const DELETE_ALL_CHATS_MESSAGE_BATCH_SIZE = 10;
 const DELETE_ALL_CHATS_SUMMARY_BATCH_SIZE = 25;
 
+const retainedTailValidator = v.object({
+  start_message_id: v.string(),
+  start_part_index: v.number(),
+  budget_tokens: v.number(),
+  retained_tokens: v.number(),
+  retained_message_count: v.number(),
+  retained_part_count: v.number(),
+  projected_part_count: v.number(),
+  strategy: v.literal("token_budgeted_tail_v1"),
+});
+
+type RetainedTailDoc = {
+  start_message_id: string;
+  start_part_index: number;
+  budget_tokens: number;
+  retained_tokens: number;
+  retained_message_count: number;
+  retained_part_count: number;
+  projected_part_count: number;
+  strategy: "token_budgeted_tail_v1";
+};
+
 async function getMessageCreationTimeById(
   ctx: MutationCtx,
   messageId: string,
@@ -1116,6 +1138,7 @@ export const saveLatestSummary = mutation({
         cost: v.optional(v.number()),
         estimatedCompactedInputTokens: v.optional(v.number()),
         transcriptPath: v.optional(v.string()),
+        retainedTail: v.optional(retainedTailValidator),
       }),
     ),
   },
@@ -1169,6 +1192,7 @@ export const saveLatestSummary = mutation({
         summary_text: string;
         summary_up_to_message_id: string;
         summary_up_to_message_creation_time?: number;
+        retained_tail?: RetainedTailDoc;
       }[] = [];
 
       if (chat.latest_summary_id) {
@@ -1213,6 +1237,7 @@ export const saveLatestSummary = mutation({
             {
               summary_text: oldSummary.summary_text,
               summary_up_to_message_id: oldSummary.summary_up_to_message_id,
+              retained_tail: oldSummary.retained_tail,
               ...(previousSummaryCutoffCreationTime !== null
                 ? {
                     summary_up_to_message_creation_time:
@@ -1266,6 +1291,7 @@ export const saveLatestSummary = mutation({
           estimated_compacted_input_tokens:
             args.metadata?.estimatedCompactedInputTokens,
           transcript_path: args.metadata?.transcriptPath,
+          retained_tail: args.metadata?.retainedTail,
         }).filter(([, value]) => value !== undefined),
       );
 
@@ -1323,6 +1349,7 @@ export const getLatestSummaryForBackend = query({
     v.object({
       summary_text: v.string(),
       summary_up_to_message_id: v.string(),
+      retained_tail: v.optional(retainedTailValidator),
     }),
     v.null(),
   ),
@@ -1350,6 +1377,7 @@ export const getLatestSummaryForBackend = query({
       return {
         summary_text: summary.summary_text,
         summary_up_to_message_id: summary.summary_up_to_message_id,
+        retained_tail: summary.retained_tail,
       };
     } catch (error) {
       console.error("Failed to get latest summary:", error);

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -7,6 +7,10 @@ import { fileCountAggregate } from "./fileAggregate";
 import { MAX_PREVIOUS_SUMMARIES } from "./constants";
 import { validateServiceKey } from "./lib/utils";
 import {
+  retainedTailValidator,
+  type RetainedTailDoc,
+} from "./lib/retainedTail";
+import {
   coerceSelectedModel,
   normalizeSelectedModelForSubscription,
 } from "../types/chat";
@@ -18,28 +22,6 @@ import { convexLogger } from "./lib/logger";
 
 const DELETE_ALL_CHATS_MESSAGE_BATCH_SIZE = 10;
 const DELETE_ALL_CHATS_SUMMARY_BATCH_SIZE = 25;
-
-const retainedTailValidator = v.object({
-  start_message_id: v.string(),
-  start_part_index: v.number(),
-  budget_tokens: v.number(),
-  retained_tokens: v.number(),
-  retained_message_count: v.number(),
-  retained_part_count: v.number(),
-  projected_part_count: v.number(),
-  strategy: v.literal("token_budgeted_tail_v1"),
-});
-
-type RetainedTailDoc = {
-  start_message_id: string;
-  start_part_index: number;
-  budget_tokens: number;
-  retained_tokens: number;
-  retained_message_count: number;
-  retained_part_count: number;
-  projected_part_count: number;
-  strategy: "token_budgeted_tail_v1";
-};
 
 async function getMessageCreationTimeById(
   ctx: MutationCtx,

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -256,6 +256,7 @@ export const getFileById = internalQuery({
     v.object({
       _id: v.id("files"),
       s3_key: v.optional(v.string()),
+      storage_id: v.optional(v.string()),
       user_id: v.string(),
       name: v.string(),
       media_type: v.string(),

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -256,7 +256,6 @@ export const getFileById = internalQuery({
     v.object({
       _id: v.id("files"),
       s3_key: v.optional(v.string()),
-      storage_id: v.optional(v.string()),
       user_id: v.string(),
       name: v.string(),
       media_type: v.string(),

--- a/convex/lib/retainedTail.ts
+++ b/convex/lib/retainedTail.ts
@@ -1,0 +1,23 @@
+import { v } from "convex/values";
+
+export const retainedTailValidator = v.object({
+  start_message_id: v.string(),
+  start_part_index: v.number(),
+  budget_tokens: v.number(),
+  retained_tokens: v.number(),
+  retained_message_count: v.number(),
+  retained_part_count: v.number(),
+  projected_part_count: v.number(),
+  strategy: v.literal("token_budgeted_tail_v1"),
+});
+
+export type RetainedTailDoc = {
+  start_message_id: string;
+  start_part_index: number;
+  budget_tokens: number;
+  retained_tokens: number;
+  retained_message_count: number;
+  retained_part_count: number;
+  projected_part_count: number;
+  strategy: "token_budgeted_tail_v1";
+};

--- a/convex/lib/utils.ts
+++ b/convex/lib/utils.ts
@@ -69,13 +69,6 @@ export async function copyChatSummary(
         model: summary.model,
         status: summary.status,
         error: summary.error,
-        input_tokens: summary.input_tokens,
-        output_tokens: summary.output_tokens,
-        cache_read_tokens: summary.cache_read_tokens,
-        cache_write_tokens: summary.cache_write_tokens,
-        cost: summary.cost,
-        estimated_compacted_input_tokens:
-          summary.estimated_compacted_input_tokens,
         transcript_path: summary.transcript_path,
         retained_tail: remapRetainedTail(
           summary.retained_tail as RetainedTailDoc | undefined,

--- a/convex/lib/utils.ts
+++ b/convex/lib/utils.ts
@@ -8,6 +8,34 @@ export function validateServiceKey(serviceKey: string): void {
   }
 }
 
+type RetainedTailDoc = {
+  start_message_id: string;
+  start_part_index: number;
+  budget_tokens: number;
+  retained_tokens: number;
+  retained_message_count: number;
+  retained_part_count: number;
+  projected_part_count: number;
+  strategy: "token_budgeted_tail_v1";
+};
+
+const remapRetainedTail = (
+  retainedTail: RetainedTailDoc | undefined,
+  messageIdMap: Map<string, string>,
+): RetainedTailDoc | undefined => {
+  if (!retainedTail) return undefined;
+
+  const remappedStartMessageId = messageIdMap.get(
+    retainedTail.start_message_id,
+  );
+  if (!remappedStartMessageId) return undefined;
+
+  return {
+    ...retainedTail,
+    start_message_id: remappedStartMessageId,
+  };
+};
+
 /**
  * Copy a chat's summary to a new chat, remapping message IDs.
  * No-ops gracefully if the summary doesn't exist or doesn't cover copied messages.
@@ -30,12 +58,19 @@ export async function copyChatSummary(
 
     const remappedPrevious = (summary.previous_summaries ?? [])
       .filter((s) => opts.messageIdMap.has(s.summary_up_to_message_id))
-      .map((s) => ({
-        summary_text: s.summary_text,
-        summary_up_to_message_id: opts.messageIdMap.get(
-          s.summary_up_to_message_id,
-        )!,
-      }));
+      .map((s) => {
+        const retainedTail = remapRetainedTail(
+          s.retained_tail as RetainedTailDoc | undefined,
+          opts.messageIdMap,
+        );
+        return {
+          summary_text: s.summary_text,
+          summary_up_to_message_id: opts.messageIdMap.get(
+            s.summary_up_to_message_id,
+          )!,
+          ...(retainedTail ? { retained_tail: retainedTail } : {}),
+        };
+      });
 
     const metadata = Object.fromEntries(
       Object.entries({
@@ -52,6 +87,10 @@ export async function copyChatSummary(
         estimated_compacted_input_tokens:
           summary.estimated_compacted_input_tokens,
         transcript_path: summary.transcript_path,
+        retained_tail: remapRetainedTail(
+          summary.retained_tail as RetainedTailDoc | undefined,
+          opts.messageIdMap,
+        ),
       }).filter(([, value]) => value !== undefined),
     );
 

--- a/convex/lib/utils.ts
+++ b/convex/lib/utils.ts
@@ -1,23 +1,13 @@
 import { GenericDatabaseWriter } from "convex/server";
 import type { DataModel } from "../_generated/dataModel";
 import { Id } from "../_generated/dataModel";
+import type { RetainedTailDoc } from "./retainedTail";
 
 export function validateServiceKey(serviceKey: string): void {
   if (serviceKey !== process.env.CONVEX_SERVICE_ROLE_KEY) {
     throw new Error("Unauthorized: Invalid service key");
   }
 }
-
-type RetainedTailDoc = {
-  start_message_id: string;
-  start_part_index: number;
-  budget_tokens: number;
-  retained_tokens: number;
-  retained_message_count: number;
-  retained_part_count: number;
-  projected_part_count: number;
-  strategy: "token_budgeted_tail_v1";
-};
 
 const remapRetainedTail = (
   retainedTail: RetainedTailDoc | undefined,

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1,4 +1,5 @@
 import { query, mutation, internalQuery } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
 import { v, ConvexError, getDocumentSize, type Value } from "convex/values";
 import { internal } from "./_generated/api";
 import type { DataModel, Doc, Id } from "./_generated/dataModel";
@@ -9,6 +10,7 @@ import {
 import { validateServiceKey, copyChatSummary } from "./lib/utils";
 import { fileCountAggregate } from "./fileAggregate";
 import { convexLogger } from "./lib/logger";
+import type { RetainedTailDoc } from "./lib/retainedTail";
 
 /**
  * Extract text content from message parts for search and display
@@ -88,17 +90,6 @@ const getJsonSize = (value: unknown): number => {
 const CONVEX_DOCUMENT_MAX_BYTES = 1024 * 1024;
 const MESSAGE_DOCUMENT_TARGET_BYTES = 960 * 1024;
 const MIN_SEARCH_CONTENT_CHARS = 256;
-
-type RetainedTailDoc = {
-  start_message_id: string;
-  start_part_index: number;
-  budget_tokens: number;
-  retained_tokens: number;
-  retained_message_count: number;
-  retained_part_count: number;
-  projected_part_count: number;
-  strategy: "token_budgeted_tail_v1";
-};
 
 const getMessageDocumentSize = (document: Record<string, unknown>): number =>
   getDocumentSize(document as Record<string, Value>);
@@ -223,11 +214,12 @@ const getConvexErrorCode = (data: Value | undefined): string | undefined => {
  * Clears latest_summary_id if the summary's cutoff message was deleted
  */
 const tryFallbackSummary = async (
-  ctx: any,
+  ctx: MutationCtx,
   summaryId: Id<"chat_summaries">,
   previousSummaries: {
     summary_text: string;
     summary_up_to_message_id: string;
+    summary_up_to_message_creation_time?: number;
     retained_tail?: RetainedTailDoc;
   }[],
   earliestDeletedTime: number,
@@ -237,7 +229,7 @@ const tryFallbackSummary = async (
     previousSummaries.map((s) =>
       ctx.db
         .query("messages")
-        .withIndex("by_message_id", (q: any) =>
+        .withIndex("by_message_id", (q) =>
           q.eq("id", s.summary_up_to_message_id),
         )
         .first(),
@@ -254,7 +246,7 @@ const tryFallbackSummary = async (
       retainedTailStartId === previousSummaries[i].summary_up_to_message_id ||
       !!(await ctx.db
         .query("messages")
-        .withIndex("by_message_id", (q: any) => q.eq("id", retainedTailStartId))
+        .withIndex("by_message_id", (q) => q.eq("id", retainedTailStartId))
         .first());
 
     if (
@@ -265,6 +257,7 @@ const tryFallbackSummary = async (
       await ctx.db.patch(summaryId, {
         summary_text: previousSummaries[i].summary_text,
         summary_up_to_message_id: previousSummaries[i].summary_up_to_message_id,
+        summary_up_to_message_creation_time: cutoffMsg._creationTime,
         retained_tail: previousSummaries[i].retained_tail,
         previous_summaries: previousSummaries.slice(i + 1),
       });
@@ -275,7 +268,7 @@ const tryFallbackSummary = async (
 };
 
 const checkAndInvalidateSummary = async (
-  ctx: any,
+  ctx: MutationCtx,
   chatId: string,
   deletedMessages: { id: string; creationTime: number }[],
 ) => {
@@ -284,7 +277,7 @@ const checkAndInvalidateSummary = async (
   try {
     const chat = await ctx.db
       .query("chats")
-      .withIndex("by_chat_id", (q: any) => q.eq("id", chatId))
+      .withIndex("by_chat_id", (q) => q.eq("id", chatId))
       .first();
 
     if (!chat || !chat.latest_summary_id) return;
@@ -295,6 +288,7 @@ const checkAndInvalidateSummary = async (
     const previousSummaries: {
       summary_text: string;
       summary_up_to_message_id: string;
+      summary_up_to_message_creation_time?: number;
       retained_tail?: RetainedTailDoc;
     }[] = summary.previous_summaries ?? [];
 
@@ -304,7 +298,7 @@ const checkAndInvalidateSummary = async (
 
     const cutoffMessage = await ctx.db
       .query("messages")
-      .withIndex("by_message_id", (q: any) =>
+      .withIndex("by_message_id", (q) =>
         q.eq("id", summary.summary_up_to_message_id),
       )
       .first();
@@ -335,7 +329,7 @@ const checkAndInvalidateSummary = async (
       retainedTailStartMessageId !== summary.summary_up_to_message_id
         ? await ctx.db
             .query("messages")
-            .withIndex("by_message_id", (q: any) =>
+            .withIndex("by_message_id", (q) =>
               q.eq("id", retainedTailStartMessageId),
             )
             .first()

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -89,6 +89,17 @@ const CONVEX_DOCUMENT_MAX_BYTES = 1024 * 1024;
 const MESSAGE_DOCUMENT_TARGET_BYTES = 960 * 1024;
 const MIN_SEARCH_CONTENT_CHARS = 256;
 
+type RetainedTailDoc = {
+  start_message_id: string;
+  start_part_index: number;
+  budget_tokens: number;
+  retained_tokens: number;
+  retained_message_count: number;
+  retained_part_count: number;
+  projected_part_count: number;
+  strategy: "token_budgeted_tail_v1";
+};
+
 const getMessageDocumentSize = (document: Record<string, unknown>): number =>
   getDocumentSize(document as Record<string, Value>);
 
@@ -217,6 +228,7 @@ const tryFallbackSummary = async (
   previousSummaries: {
     summary_text: string;
     summary_up_to_message_id: string;
+    retained_tail?: RetainedTailDoc;
   }[],
   earliestDeletedTime: number,
 ): Promise<boolean> => {
@@ -235,10 +247,25 @@ const tryFallbackSummary = async (
   // Find the first candidate whose cutoff message still exists and predates the deletion
   for (let i = 0; i < previousSummaries.length; i++) {
     const cutoffMsg = cutoffMessages[i];
-    if (cutoffMsg && cutoffMsg._creationTime < earliestDeletedTime) {
+    const retainedTailStartId =
+      previousSummaries[i].retained_tail?.start_message_id;
+    const retainedTailStartExists =
+      !retainedTailStartId ||
+      retainedTailStartId === previousSummaries[i].summary_up_to_message_id ||
+      !!(await ctx.db
+        .query("messages")
+        .withIndex("by_message_id", (q: any) => q.eq("id", retainedTailStartId))
+        .first());
+
+    if (
+      cutoffMsg &&
+      retainedTailStartExists &&
+      cutoffMsg._creationTime < earliestDeletedTime
+    ) {
       await ctx.db.patch(summaryId, {
         summary_text: previousSummaries[i].summary_text,
         summary_up_to_message_id: previousSummaries[i].summary_up_to_message_id,
+        retained_tail: previousSummaries[i].retained_tail,
         previous_summaries: previousSummaries.slice(i + 1),
       });
       return true;
@@ -268,6 +295,7 @@ const checkAndInvalidateSummary = async (
     const previousSummaries: {
       summary_text: string;
       summary_up_to_message_id: string;
+      retained_tail?: RetainedTailDoc;
     }[] = summary.previous_summaries ?? [];
 
     const earliestDeletedTime = Math.min(
@@ -301,8 +329,45 @@ const checkAndInvalidateSummary = async (
       return;
     }
 
+    const retainedTailStartMessageId = summary.retained_tail?.start_message_id;
+    const retainedTailStartMessage =
+      retainedTailStartMessageId &&
+      retainedTailStartMessageId !== summary.summary_up_to_message_id
+        ? await ctx.db
+            .query("messages")
+            .withIndex("by_message_id", (q: any) =>
+              q.eq("id", retainedTailStartMessageId),
+            )
+            .first()
+        : retainedTailStartMessageId === summary.summary_up_to_message_id
+          ? cutoffMessage
+          : null;
+
+    if (retainedTailStartMessageId && !retainedTailStartMessage) {
+      const found = await tryFallbackSummary(
+        ctx,
+        chat.latest_summary_id,
+        previousSummaries,
+        earliestDeletedTime,
+      );
+      if (found) return;
+
+      await ctx.db.patch(chat._id, {
+        latest_summary_id: undefined,
+      });
+      try {
+        await ctx.db.delete(chat.latest_summary_id);
+      } catch (error) {
+        console.error("[Messages] Failed to delete stale summary:", error);
+      }
+      return;
+    }
+
     const shouldInvalidate = deletedMessages.some(
-      (msg) => msg.creationTime <= cutoffMessage._creationTime,
+      (msg) =>
+        msg.creationTime <= cutoffMessage._creationTime ||
+        (retainedTailStartMessageId != null &&
+          msg.id === retainedTailStartMessageId),
     );
 
     if (shouldInvalidate) {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -116,6 +116,8 @@ export default defineSchema({
 
   files: defineTable({
     s3_key: v.optional(v.string()),
+    // Legacy Convex storage reference retained for existing rows.
+    storage_id: v.optional(v.string()),
     user_id: v.string(),
     name: v.string(),
     media_type: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -116,8 +116,6 @@ export default defineSchema({
 
   files: defineTable({
     s3_key: v.optional(v.string()),
-    // Legacy Convex storage reference retained for existing rows.
-    storage_id: v.optional(v.string()),
     user_id: v.string(),
     name: v.string(),
     media_type: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,6 +1,17 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
+const retainedTailValidator = v.object({
+  start_message_id: v.string(),
+  start_part_index: v.number(),
+  budget_tokens: v.number(),
+  retained_tokens: v.number(),
+  retained_message_count: v.number(),
+  retained_part_count: v.number(),
+  projected_part_count: v.number(),
+  strategy: v.literal("token_budgeted_tail_v1"),
+});
+
 export default defineSchema({
   chats: defineTable({
     id: v.string(),
@@ -68,12 +79,14 @@ export default defineSchema({
     cost: v.optional(v.number()),
     estimated_compacted_input_tokens: v.optional(v.number()),
     transcript_path: v.optional(v.string()),
+    retained_tail: v.optional(retainedTailValidator),
     previous_summaries: v.optional(
       v.array(
         v.object({
           summary_text: v.string(),
           summary_up_to_message_id: v.string(),
           summary_up_to_message_creation_time: v.optional(v.number()),
+          retained_tail: v.optional(retainedTailValidator),
         }),
       ),
     ),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,16 +1,6 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
-
-const retainedTailValidator = v.object({
-  start_message_id: v.string(),
-  start_part_index: v.number(),
-  budget_tokens: v.number(),
-  retained_tokens: v.number(),
-  retained_message_count: v.number(),
-  retained_part_count: v.number(),
-  projected_part_count: v.number(),
-  strategy: v.literal("token_budgeted_tail_v1"),
-});
+import { retainedTailValidator } from "./lib/retainedTail";
 
 export default defineSchema({
   chats: defineTable({

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -664,9 +664,6 @@ describe("checkAndSummarizeIfNeeded", () => {
           promptVersion: SUMMARY_PROMPT_VERSION,
           model: "test-model",
           status: "completed",
-          inputTokens: 0,
-          outputTokens: 0,
-          estimatedCompactedInputTokens: expect.any(Number),
           retainedTail: expect.objectContaining({
             start_message_id: "msg-4",
             start_part_index: 0,
@@ -675,6 +672,17 @@ describe("checkAndSummarizeIfNeeded", () => {
         }),
       }),
     );
+    const saveSummaryCall =
+      mockSaveChatSummary.mock.calls[mockSaveChatSummary.mock.calls.length - 1];
+    const persistedMetadata = saveSummaryCall?.[0].metadata as
+      | Record<string, unknown>
+      | undefined;
+    expect(persistedMetadata?.inputTokens).toBeUndefined();
+    expect(persistedMetadata?.outputTokens).toBeUndefined();
+    expect(persistedMetadata?.cacheReadTokens).toBeUndefined();
+    expect(persistedMetadata?.cacheWriteTokens).toBeUndefined();
+    expect(persistedMetadata?.cost).toBeUndefined();
+    expect(persistedMetadata?.estimatedCompactedInputTokens).toBeUndefined();
   });
 
   it("should skip database persistence for temporary chats", async () => {

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -341,14 +341,95 @@ describe("checkAndSummarizeIfNeeded", () => {
 
     expect(result.needsSummarization).toBe(true);
     expect(result.summaryText).toBe("Test summary content");
-    expect(result.cutoffMessageId).toBe("msg-4");
+    expect(result.cutoffMessageId).toBe("msg-3");
 
-    // summary message + 0 kept messages = 1 total (just the summary message)
-    expect(result.summarizedMessages).toHaveLength(1);
+    // summary message + projected retained tail
+    expect(result.summarizedMessages).toHaveLength(2);
     expect(result.summarizedMessages[0].parts[0]).toEqual({
       type: "text",
       text: "<context_summary>\nTest summary content\n</context_summary>",
     });
+    expect(result.summarizedMessages[1].id).toBe("msg-4");
+
+    const serializedSummaryInput = JSON.stringify(
+      mockGenerateText.mock.calls[0][0].messages,
+    );
+    expect(serializedSummaryInput).toContain("[msg-3]");
+    expect(serializedSummaryInput).not.toContain("[msg-4]");
+  });
+
+  it("should not summarize the original payload for a tail-only projected oversized part", async () => {
+    mockGenerateText.mockResolvedValue({ text: "Projected-only summary" });
+
+    const hugeOutput = Array.from(
+      { length: 20_000 },
+      (_, index) => `unique-projected-tail-line-${index}`,
+    ).join("\n");
+    const messages: UIMessage[] = [
+      {
+        id: "assistant-huge",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-run_terminal_cmd",
+            state: "output-available",
+            output: hugeOutput,
+          } as any,
+        ],
+      },
+    ];
+
+    const result = await checkAndSummarizeForTest(
+      messages,
+      "free",
+      mockLanguageModel,
+      "agent",
+      mockWriter,
+      "chat-tail-only",
+      {},
+      [],
+      undefined,
+      undefined,
+      0,
+      0,
+      "test-system-prompt",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        reason: "tool_result_count",
+        reasons: ["tool_result_count"],
+        toolResultCount: 1,
+        messageCount: 1,
+        summarizationMaxTokensOverride: 128_000,
+      },
+    );
+
+    expect(result.needsSummarization).toBe(true);
+    expect(result.cutoffMessageId).toBe("assistant-huge");
+    expect(result.summarizedMessages).toHaveLength(2);
+    expect(result.summarizedMessages[1].id).toBe("assistant-huge");
+
+    const serializedSummaryInput = JSON.stringify(
+      mockGenerateText.mock.calls[0][0].messages,
+    );
+    expect(serializedSummaryInput).not.toContain("unique-projected-tail-line");
+    expect(JSON.stringify(result.summarizedMessages)).not.toContain(hugeOutput);
+    expect(mockSaveChatSummary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: "chat-tail-only",
+        summaryUpToMessageId: "assistant-huge",
+        metadata: expect.objectContaining({
+          retainedTail: expect.objectContaining({
+            start_message_id: "assistant-huge",
+            start_part_index: 0,
+            projected_part_count: 1,
+          }),
+        }),
+      }),
+    );
   });
 
   it("should use agent prompt when mode is agent", async () => {
@@ -421,26 +502,9 @@ describe("checkAndSummarizeIfNeeded", () => {
       },
     ] as unknown as ModelMessage[];
 
-    await checkAndSummarizeForTest(
-      fourMessagesAboveThreshold,
-      "free",
-      mockLanguageModel,
-      "agent",
-      mockWriter,
-      null,
-      {},
-      [],
-      undefined,
-      undefined,
-      0,
-      0,
-      "test-system-prompt",
-      undefined,
-      undefined,
+    const callMessages = compactModelMessagesForSummarization(
       modelMessages,
-    );
-
-    const callMessages = mockGenerateText.mock.calls[0][0].messages as Array<{
+    ) as Array<{
       role: string;
       content: Array<{
         type: string;
@@ -511,27 +575,8 @@ describe("checkAndSummarizeIfNeeded", () => {
       },
     ] as unknown as ModelMessage[];
 
-    await checkAndSummarizeForTest(
-      fourMessagesAboveThreshold,
-      "free",
-      mockLanguageModel,
-      "agent",
-      mockWriter,
-      null,
-      {},
-      [],
-      undefined,
-      undefined,
-      0,
-      0,
-      "test-system-prompt",
-      undefined,
-      undefined,
-      modelMessages,
-    );
-
     const serializedMessages = JSON.stringify(
-      mockGenerateText.mock.calls[0][0].messages,
+      compactModelMessagesForSummarization(modelMessages),
     );
 
     expect(serializedMessages).toContain("[Attached image/png: page.png]");
@@ -613,7 +658,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       expect.objectContaining({
         chatId: "chat-123",
         summaryText: "Summary",
-        summaryUpToMessageId: "msg-4",
+        summaryUpToMessageId: "msg-3",
         metadata: expect.objectContaining({
           reason: "token_threshold",
           promptVersion: SUMMARY_PROMPT_VERSION,
@@ -622,6 +667,11 @@ describe("checkAndSummarizeIfNeeded", () => {
           inputTokens: 0,
           outputTokens: 0,
           estimatedCompactedInputTokens: expect.any(Number),
+          retainedTail: expect.objectContaining({
+            start_message_id: "msg-4",
+            start_part_index: 0,
+            strategy: "token_budgeted_tail_v1",
+          }),
         }),
       }),
     );
@@ -933,7 +983,7 @@ describe("checkAndSummarizeIfNeeded", () => {
     );
 
     expect(result.needsSummarization).toBe(true);
-    expect(result.cutoffMessageId).toBe("real-4");
+    expect(result.cutoffMessageId).toBe("real-3");
     expect(result.cutoffMessageId).not.toBe("synthetic-uuid-not-in-db");
   });
 
@@ -1064,7 +1114,7 @@ describe("checkAndSummarizeIfNeeded", () => {
     );
 
     expect(result1.needsSummarization).toBe(true);
-    expect(result1.cutoffMessageId).toBe("msg-4");
+    expect(result1.cutoffMessageId).toBe("msg-3");
 
     const newMessages = [
       createMessageWithTokens("msg-5", "user", TOKENS_PER_ABOVE_MSG),
@@ -1095,12 +1145,12 @@ describe("checkAndSummarizeIfNeeded", () => {
     expect(mockSaveChatSummary).toHaveBeenCalledTimes(2);
     expect(mockSaveChatSummary).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ summaryUpToMessageId: "msg-4" }),
+      expect.objectContaining({ summaryUpToMessageId: "msg-3" }),
     );
     expect(mockSaveChatSummary).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        summaryUpToMessageId: expect.not.stringMatching(/^msg-4$/),
+        summaryUpToMessageId: "msg-7",
       }),
     );
 
@@ -1132,17 +1182,18 @@ describe("checkAndSummarizeIfNeeded", () => {
             .join("");
     expect(secondLastContent).toContain("INCREMENTAL summarization");
 
-    // First call: msg-1..msg-4 converted + 1 summarization prompt = 5
+    // First call: msg-1..msg-3 converted + 1 summarization prompt = 4
     const firstCallMessages = mockGenerateText.mock.calls[0][0].messages;
-    expect(firstCallMessages).toHaveLength(5);
-    // Second call: 1 summary message + msg-5..msg-8 converted + 1 summarization prompt = 6
+    expect(firstCallMessages).toHaveLength(4);
+    // Second call: 1 summary message + retained msg-4 + msg-5..msg-7 + 1 summarization prompt = 6
     expect(secondCallMessages).toHaveLength(6);
 
-    expect(result2.summarizedMessages).toHaveLength(1);
+    expect(result2.summarizedMessages).toHaveLength(2);
     expect(isSummaryMessage(result2.summarizedMessages[0])).toBe(true);
     expect(extractSummaryText(result2.summarizedMessages[0])).toBe(
       "Second summary",
     );
+    expect(result2.summarizedMessages[1].id).toBe("msg-8");
   });
 
   it("should pass every message up to the last cutoff through generateText at least once", async () => {
@@ -1173,7 +1224,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       0,
       "test-system-prompt",
     );
-    expect(result1.cutoffMessageId).toBe("msg-4");
+    expect(result1.cutoffMessageId).toBe("msg-3");
 
     // Round 2: result1 + msg-5..msg-8
     const round2Input = [
@@ -1199,7 +1250,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       0,
       "test-system-prompt",
     );
-    expect(result2.cutoffMessageId).toBe("msg-8");
+    expect(result2.cutoffMessageId).toBe("msg-7");
 
     // Round 3: result2 + msg-9..msg-12
     const round3Input = [
@@ -1225,15 +1276,17 @@ describe("checkAndSummarizeIfNeeded", () => {
       0,
       "test-system-prompt",
     );
-    expect(result3.cutoffMessageId).toBe("msg-12");
+    expect(result3.cutoffMessageId).toBe("msg-11");
 
     // Collect all message IDs that were passed to generateText across all 3 calls
     const summarizedIds = collectMessageIdsFromGenerateCalls(mockGenerateText);
 
-    // Every message up to msg-12 must have been summarized
-    for (let i = 1; i <= 12; i++) {
+    // Every message up to the cutoff must have been summarized. The latest
+    // retained-tail message remains unsummarized until the next compaction.
+    for (let i = 1; i <= 11; i++) {
       expect(summarizedIds).toContain(`msg-${i}`);
     }
+    expect(summarizedIds).not.toContain("msg-12");
   });
 
   it("should handle normal first-time summarization unchanged", async () => {
@@ -1256,7 +1309,7 @@ describe("checkAndSummarizeIfNeeded", () => {
     );
 
     expect(result.needsSummarization).toBe(true);
-    expect(result.cutoffMessageId).toBe("msg-4");
+    expect(result.cutoffMessageId).toBe("msg-3");
 
     const callArgs = mockGenerateText.mock.calls[0][0];
     // System should be the chat system prompt

--- a/lib/chat/summarization/__tests__/retained-tail.test.ts
+++ b/lib/chat/summarization/__tests__/retained-tail.test.ts
@@ -127,6 +127,36 @@ describe("retained tail selection", () => {
     ]);
   });
 
+  it("does not retain older parts past the contiguous suffix budget", () => {
+    const messages: UIMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "older candidate" },
+          {
+            type: "custom-large-part",
+            payload: "huge ".repeat(10_000),
+          } as any,
+          { type: "text", text: "latest" },
+        ],
+      },
+    ];
+
+    const result = selectRetainedTailForSummarization(messages, {
+      budgetTokens: safeCountTokens("latest"),
+    });
+
+    expect(result.retainedTail).toMatchObject({
+      start_message_id: "assistant-1",
+      start_part_index: 2,
+    });
+    expect(result.headMessages[0].parts).toEqual(messages[0].parts.slice(0, 2));
+    expect(result.tailMessages[0].parts).toEqual([
+      { type: "text", text: "latest" },
+    ]);
+  });
+
   it("reconstructs a persisted tail from start message and part index", () => {
     const messages: UIMessage[] = [
       textMessage("msg-1", "user", "summary-covered"),

--- a/lib/chat/summarization/__tests__/retained-tail.test.ts
+++ b/lib/chat/summarization/__tests__/retained-tail.test.ts
@@ -194,42 +194,4 @@ describe("retained tail selection", () => {
       { type: "text", text: "retained part" },
     ]);
   });
-
-  it("caps reconstructed retained tails to the persisted metadata budget", () => {
-    const hugeOutput = "raw-output ".repeat(10_000);
-    const messages: UIMessage[] = [
-      {
-        id: "assistant-1",
-        role: "assistant",
-        parts: [
-          {
-            type: "tool-run_terminal_cmd",
-            state: "output-available",
-            output: hugeOutput,
-          } as any,
-        ],
-      },
-    ];
-
-    const projected = projectRetainedTailFromMessages(
-      messages,
-      {
-        start_message_id: "assistant-1",
-        start_part_index: 0,
-        budget_tokens: 128,
-        retained_tokens: 128,
-        retained_message_count: 1,
-        retained_part_count: 1,
-        projected_part_count: 1,
-        strategy: "token_budgeted_tail_v1",
-      },
-      { budgetTokens: 50_000 },
-    );
-
-    expect(projected).toHaveLength(1);
-    const [projectedPart] = projected[0].parts as any[];
-    expect(projectedPart.output).not.toBe(hugeOutput);
-    expect(JSON.stringify(projected)).not.toContain(hugeOutput);
-    expect(JSON.stringify(projected)).toContain("retained tail");
-  });
 });

--- a/lib/chat/summarization/__tests__/retained-tail.test.ts
+++ b/lib/chat/summarization/__tests__/retained-tail.test.ts
@@ -194,4 +194,42 @@ describe("retained tail selection", () => {
       { type: "text", text: "retained part" },
     ]);
   });
+
+  it("caps reconstructed retained tails to the persisted metadata budget", () => {
+    const hugeOutput = "raw-output ".repeat(10_000);
+    const messages: UIMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-run_terminal_cmd",
+            state: "output-available",
+            output: hugeOutput,
+          } as any,
+        ],
+      },
+    ];
+
+    const projected = projectRetainedTailFromMessages(
+      messages,
+      {
+        start_message_id: "assistant-1",
+        start_part_index: 0,
+        budget_tokens: 128,
+        retained_tokens: 128,
+        retained_message_count: 1,
+        retained_part_count: 1,
+        projected_part_count: 1,
+        strategy: "token_budgeted_tail_v1",
+      },
+      { budgetTokens: 50_000 },
+    );
+
+    expect(projected).toHaveLength(1);
+    const [projectedPart] = projected[0].parts as any[];
+    expect(projectedPart.output).not.toBe(hugeOutput);
+    expect(JSON.stringify(projected)).not.toContain(hugeOutput);
+    expect(JSON.stringify(projected)).toContain("retained tail");
+  });
 });

--- a/lib/chat/summarization/__tests__/retained-tail.test.ts
+++ b/lib/chat/summarization/__tests__/retained-tail.test.ts
@@ -1,0 +1,167 @@
+import type { UIMessage } from "ai";
+import {
+  projectRetainedTailFromMessages,
+  selectRetainedTailForSummarization,
+} from "../retained-tail";
+import { safeCountTokens } from "@/lib/token-utils";
+
+const textMessage = (
+  id: string,
+  role: "user" | "assistant",
+  text: string,
+): UIMessage => ({
+  id,
+  role,
+  parts: [{ type: "text", text }],
+});
+
+describe("retained tail selection", () => {
+  it("keeps recent whole messages under the token budget", () => {
+    const messages = [
+      textMessage("msg-1", "user", "old ".repeat(300)),
+      textMessage("msg-2", "assistant", "middle"),
+      textMessage("msg-3", "user", "latest"),
+    ];
+
+    const result = selectRetainedTailForSummarization(messages, {
+      budgetTokens: safeCountTokens("middle") + safeCountTokens("latest"),
+    });
+
+    expect(result.headMessages.map((message) => message.id)).toEqual(["msg-1"]);
+    expect(result.tailMessages.map((message) => message.id)).toEqual([
+      "msg-2",
+      "msg-3",
+    ]);
+    expect(result.retainedTail).toMatchObject({
+      start_message_id: "msg-2",
+      start_part_index: 0,
+      strategy: "token_budgeted_tail_v1",
+    });
+  });
+
+  it("splits a single large assistant message by part index", () => {
+    const messages: UIMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-run_terminal_cmd",
+            state: "output-available",
+            output: "old ".repeat(800),
+          } as any,
+          {
+            type: "tool-run_terminal_cmd",
+            state: "output-available",
+            output: "middle",
+          } as any,
+          { type: "text", text: "latest result" },
+        ],
+      },
+    ];
+
+    const result = selectRetainedTailForSummarization(messages, {
+      budgetTokens: 20,
+    });
+
+    expect(result.cutoffMessageId).toBe("assistant-1");
+    expect(result.retainedTail).toMatchObject({
+      start_message_id: "assistant-1",
+      start_part_index: 1,
+    });
+    expect(result.headMessages).toHaveLength(1);
+    expect(result.headMessages[0].parts).toHaveLength(1);
+    expect(result.tailMessages).toHaveLength(1);
+    expect(result.tailMessages[0].parts).toHaveLength(2);
+  });
+
+  it("projects an oversized latest tool part without storing payload in metadata", () => {
+    const hugeOutput = "secret-output ".repeat(10_000);
+    const messages: UIMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-run_terminal_cmd",
+            input: { command: "cat large.log" },
+            state: "output-available",
+            output: hugeOutput,
+          } as any,
+        ],
+      },
+    ];
+
+    const result = selectRetainedTailForSummarization(messages, {
+      budgetTokens: 128,
+    });
+
+    expect(result.cutoffMessageId).toBe("assistant-1");
+    expect(result.headMessages).toEqual([]);
+    expect(result.retainedTail?.projected_part_count).toBe(1);
+    expect(JSON.stringify(result.retainedTail)).not.toContain("secret-output");
+    expect(JSON.stringify(result.tailMessages)).not.toContain(hugeOutput);
+    expect(JSON.stringify(result.tailMessages)).toContain("retained tail");
+  });
+
+  it("omits reasoning and status-only parts from the retained tail", () => {
+    const messages: UIMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "step-start" } as any,
+          { type: "reasoning", text: "private reasoning" } as any,
+          { type: "data-summarization", data: { status: "completed" } } as any,
+          { type: "text", text: "visible result" },
+        ],
+      },
+    ];
+
+    const result = selectRetainedTailForSummarization(messages, {
+      budgetTokens: 50,
+    });
+
+    expect(result.tailMessages[0].parts).toEqual([
+      { type: "text", text: "visible result" },
+    ]);
+  });
+
+  it("reconstructs a persisted tail from start message and part index", () => {
+    const messages: UIMessage[] = [
+      textMessage("msg-1", "user", "summary-covered"),
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "old part" },
+          { type: "text", text: "retained part" },
+        ],
+      },
+      textMessage("msg-3", "user", "new followup"),
+    ];
+
+    const projected = projectRetainedTailFromMessages(
+      messages,
+      {
+        start_message_id: "assistant-1",
+        start_part_index: 1,
+        budget_tokens: 100,
+        retained_tokens: 0,
+        retained_message_count: 0,
+        retained_part_count: 0,
+        projected_part_count: 0,
+        strategy: "token_budgeted_tail_v1",
+      },
+      { budgetTokens: 100 },
+    );
+
+    expect(projected.map((message) => message.id)).toEqual([
+      "assistant-1",
+      "msg-3",
+    ]);
+    expect(projected[0].parts).toEqual([
+      { type: "text", text: "retained part" },
+    ]);
+  });
+});

--- a/lib/chat/summarization/helpers.ts
+++ b/lib/chat/summarization/helpers.ts
@@ -50,12 +50,6 @@ export interface SummaryPersistenceMetadata {
   promptVersion: string;
   model?: string;
   status: "completed";
-  inputTokens?: number;
-  outputTokens?: number;
-  cacheReadTokens?: number;
-  cacheWriteTokens?: number;
-  cost?: number;
-  estimatedCompactedInputTokens?: number;
   transcriptPath?: string;
   retainedTail?: RetainedTailMetadata;
 }
@@ -661,7 +655,6 @@ export const buildSummaryPersistenceMetadata = ({
   providerInputTokens,
   threshold,
   languageModel,
-  usage,
   transcriptPath,
   retainedTail,
   reason,
@@ -669,7 +662,6 @@ export const buildSummaryPersistenceMetadata = ({
   providerInputTokens: number;
   threshold: number;
   languageModel: LanguageModel;
-  usage?: SummarizationUsage;
   transcriptPath?: string | null;
   retainedTail?: RetainedTailMetadata;
   reason?: SummaryPersistenceMetadata["reason"];
@@ -682,12 +674,6 @@ export const buildSummaryPersistenceMetadata = ({
   promptVersion: SUMMARY_PROMPT_VERSION,
   model: getLanguageModelIdentifier(languageModel),
   status: "completed",
-  inputTokens: usage?.inputTokens,
-  outputTokens: usage?.outputTokens,
-  cacheReadTokens: usage?.cacheReadTokens,
-  cacheWriteTokens: usage?.cacheWriteTokens,
-  cost: usage?.cost,
-  estimatedCompactedInputTokens: usage?.estimatedCompactedInputTokens,
   transcriptPath: transcriptPath ?? undefined,
   retainedTail,
 });

--- a/lib/chat/summarization/helpers.ts
+++ b/lib/chat/summarization/helpers.ts
@@ -34,6 +34,7 @@ import {
   AGENT_SUMMARIZATION_PROMPT,
   ASK_SUMMARIZATION_PROMPT,
 } from "./prompts";
+import type { RetainedTailMetadata } from "./retained-tail";
 
 export interface SummarizationUsage {
   inputTokens: number;
@@ -56,6 +57,7 @@ export interface SummaryPersistenceMetadata {
   cost?: number;
   estimatedCompactedInputTokens?: number;
   transcriptPath?: string;
+  retainedTail?: RetainedTailMetadata;
 }
 
 export interface SummarizationResult {
@@ -661,6 +663,7 @@ export const buildSummaryPersistenceMetadata = ({
   languageModel,
   usage,
   transcriptPath,
+  retainedTail,
   reason,
 }: {
   providerInputTokens: number;
@@ -668,6 +671,7 @@ export const buildSummaryPersistenceMetadata = ({
   languageModel: LanguageModel;
   usage?: SummarizationUsage;
   transcriptPath?: string | null;
+  retainedTail?: RetainedTailMetadata;
   reason?: SummaryPersistenceMetadata["reason"];
 }): SummaryPersistenceMetadata => ({
   reason:
@@ -685,6 +689,7 @@ export const buildSummaryPersistenceMetadata = ({
   cost: usage?.cost,
   estimatedCompactedInputTokens: usage?.estimatedCompactedInputTokens,
   transcriptPath: transcriptPath ?? undefined,
+  retainedTail,
 });
 
 export const buildSummaryMessage = (

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -25,7 +25,6 @@ import {
 import {
   NO_SUMMARIZATION,
   isAboveTokenThreshold,
-  splitMessages,
   generateSummaryText,
   buildSummaryMessage,
   persistSummary,
@@ -35,6 +34,10 @@ import {
   resolveSummarizationMaxTokens,
 } from "./helpers";
 import type { SummarizationResult } from "./helpers";
+import {
+  getRetainedTailBudgetTokens,
+  selectRetainedTailForSummarization,
+} from "./retained-tail";
 
 export type { SummarizationResult, SummarizationUsage } from "./helpers";
 
@@ -178,10 +181,12 @@ export const checkAndSummarizeIfNeeded = async ({
   // Detect and separate synthetic summary message from real messages
   let realMessages: UIMessage[];
   let existingSummaryText: string | null = null;
+  let existingSummaryMessage: UIMessage | null = null;
 
   if (uiMessages.length > 0 && isSummaryMessage(uiMessages[0])) {
     realMessages = uiMessages.slice(1);
     existingSummaryText = extractSummaryText(uiMessages[0]);
+    existingSummaryMessage = uiMessages[0];
   } else {
     realMessages = uiMessages;
   }
@@ -213,11 +218,40 @@ export const checkAndSummarizeIfNeeded = async ({
     return NO_SUMMARIZATION(uiMessages);
   }
 
-  // Split only real messages so cutoff always references a DB message
-  const { messagesToSummarize, lastMessages } = splitMessages(realMessages);
+  const retainedTailBudget = getRetainedTailBudgetTokens(
+    summarizationThreshold,
+  );
+  let tailSelection = selectRetainedTailForSummarization(realMessages, {
+    budgetTokens: retainedTailBudget,
+    fileTokens,
+  });
 
-  const cutoffMessageId =
-    messagesToSummarize[messagesToSummarize.length - 1].id;
+  if (
+    tailSelection.headMessages.length === 0 &&
+    providerPromptPressure &&
+    !tailSelection.retainedTail?.projected_part_count
+  ) {
+    tailSelection = {
+      headMessages: realMessages,
+      tailMessages: [],
+      cutoffMessageId: realMessages.at(-1)?.id ?? null,
+    };
+  }
+
+  const hasSummarizableHead =
+    tailSelection.headMessages.length > 0 ||
+    existingSummaryMessage !== null ||
+    (tailSelection.retainedTail?.projected_part_count ?? 0) > 0;
+
+  if (!hasSummarizableHead || !tailSelection.cutoffMessageId) {
+    return NO_SUMMARIZATION(uiMessages);
+  }
+
+  const messagesToSummarize = existingSummaryMessage
+    ? [existingSummaryMessage, ...tailSelection.headMessages]
+    : tailSelection.headMessages;
+
+  const cutoffMessageId = tailSelection.cutoffMessageId;
 
   writeSummarizationStarted(writer);
 
@@ -225,7 +259,7 @@ export const checkAndSummarizeIfNeeded = async ({
     // Run summary generation and transcript saving in parallel — they are
     // independent (transcript is formatted from raw messages, not the summary).
     const summaryPromise = generateSummaryText(
-      uiMessages,
+      messagesToSummarize,
       languageModel,
       mode,
       chatSystemPrompt,
@@ -233,7 +267,7 @@ export const checkAndSummarizeIfNeeded = async ({
       tools,
       providerOptions,
       abortSignal,
-      modelMessages,
+      undefined,
       getSummaryInputMaxTokens(maxTokens),
     );
 
@@ -244,7 +278,7 @@ export const checkAndSummarizeIfNeeded = async ({
         ? ensureSandbox()
             .then((sandbox) =>
               saveTranscriptToSandbox(
-                transcriptMessages ?? messagesToSummarize,
+                transcriptMessages ?? tailSelection.headMessages,
                 sandbox,
                 modelMessages,
               ),
@@ -276,6 +310,7 @@ export const checkAndSummarizeIfNeeded = async ({
       languageModel,
       usage: summarizationUsage,
       transcriptPath: savedPath,
+      retainedTail: tailSelection.retainedTail,
       reason: providerPromptPressure ? "provider_pressure" : undefined,
     });
 
@@ -283,7 +318,7 @@ export const checkAndSummarizeIfNeeded = async ({
 
     return {
       needsSummarization: true,
-      summarizedMessages: [summaryMessage, ...lastMessages],
+      summarizedMessages: [summaryMessage, ...tailSelection.tailMessages],
       cutoffMessageId,
       summaryText: finalSummaryText,
       summarizationUsage,

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -308,7 +308,6 @@ export const checkAndSummarizeIfNeeded = async ({
       providerInputTokens,
       threshold: summarizationThreshold,
       languageModel,
-      usage: summarizationUsage,
       transcriptPath: savedPath,
       retainedTail: tailSelection.retainedTail,
       reason: providerPromptPressure ? "provider_pressure" : undefined,

--- a/lib/chat/summarization/retained-tail.ts
+++ b/lib/chat/summarization/retained-tail.ts
@@ -265,7 +265,7 @@ const projectNewestTail = (
       if (!isUsefulTailPart(part)) continue;
 
       const projected = projectPartToBudget(part, remaining, fileTokens);
-      if (!projected) continue;
+      if (!projected) break;
 
       retainedParts.unshift(projected.part);
       retainedTokens += projected.tokens;

--- a/lib/chat/summarization/retained-tail.ts
+++ b/lib/chat/summarization/retained-tail.ts
@@ -1,0 +1,428 @@
+import type { UIMessage } from "ai";
+import type { Id } from "@/convex/_generated/dataModel";
+import { safeCountTokens, truncateContent } from "@/lib/token-utils";
+
+export const RETAINED_TAIL_STRATEGY = "token_budgeted_tail_v1" as const;
+export const RETAINED_TAIL_MIN_TOKENS = 2_000;
+export const RETAINED_TAIL_MAX_TOKENS = 8_000;
+export const RETAINED_TAIL_BUDGET_PERCENTAGE = 0.25;
+
+export interface RetainedTailMetadata {
+  start_message_id: string;
+  start_part_index: number;
+  budget_tokens: number;
+  retained_tokens: number;
+  retained_message_count: number;
+  retained_part_count: number;
+  projected_part_count: number;
+  strategy: typeof RETAINED_TAIL_STRATEGY;
+}
+
+export interface RetainedTailSelection {
+  headMessages: UIMessage[];
+  tailMessages: UIMessage[];
+  retainedTail?: RetainedTailMetadata;
+  cutoffMessageId: string | null;
+}
+
+type FileTokens = Record<Id<"files">, number>;
+
+type ProjectedPart = {
+  part: UIMessage["parts"][number];
+  tokens: number;
+  projected: boolean;
+};
+
+type TailProjection = {
+  messages: UIMessage[];
+  retainedTokens: number;
+  retainedPartCount: number;
+  projectedPartCount: number;
+  startMessageIndex: number | null;
+  startPartIndex: number;
+};
+
+const RETAINED_TAIL_OMITTED_PART_TYPES = new Set([
+  "step-start",
+  "reasoning",
+  "redacted-reasoning",
+  "data-summarization",
+]);
+
+const stringifyForTokens = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const fileTokenCount = (
+  part: UIMessage["parts"][number],
+  fileTokens: FileTokens,
+): number | null => {
+  const fileId = (part as { fileId?: Id<"files"> }).fileId;
+  if (!fileId) return null;
+  return fileTokens[fileId] ?? null;
+};
+
+const isUsefulTailPart = (part: UIMessage["parts"][number]): boolean => {
+  if (!part || typeof part !== "object") return false;
+  const type = (part as { type?: unknown }).type;
+  if (typeof type !== "string") return true;
+  if (RETAINED_TAIL_OMITTED_PART_TYPES.has(type)) return false;
+  if (type.startsWith("data-")) return false;
+  return true;
+};
+
+const estimatePartTokens = (
+  part: UIMessage["parts"][number],
+  fileTokens: FileTokens,
+): number => {
+  if (!isUsefulTailPart(part)) return 0;
+
+  if (part.type === "text" && "text" in part) {
+    return safeCountTokens((part as { text?: string }).text ?? "");
+  }
+
+  if (part.type === "file") {
+    return (
+      fileTokenCount(part, fileTokens) ??
+      safeCountTokens(stringifyForTokens(part))
+    );
+  }
+
+  return safeCountTokens(stringifyForTokens(part));
+};
+
+const estimatePartsTokens = (
+  parts: UIMessage["parts"],
+  fileTokens: FileTokens,
+): number =>
+  parts.reduce((sum, part) => sum + estimatePartTokens(part, fileTokens), 0);
+
+const textPart = (text: string): UIMessage["parts"][number] =>
+  ({ type: "text", text }) as UIMessage["parts"][number];
+
+const compactFilePart = (
+  part: UIMessage["parts"][number],
+): UIMessage["parts"][number] => {
+  const record = part as Record<string, unknown>;
+  const mediaType =
+    typeof record.mediaType === "string"
+      ? record.mediaType
+      : typeof record.mimeType === "string"
+        ? record.mimeType
+        : "file";
+  const name =
+    typeof record.filename === "string"
+      ? record.filename
+      : typeof record.name === "string"
+        ? record.name
+        : "file";
+  return textPart(
+    `[Attached ${mediaType}: ${name} omitted from retained tail]`,
+  );
+};
+
+const compactToolPart = (
+  part: UIMessage["parts"][number],
+  maxTokens: number,
+): UIMessage["parts"][number] => {
+  const record = part as Record<string, unknown>;
+  const type = typeof record.type === "string" ? record.type : "tool";
+  const toolName = type.startsWith("tool-") ? type.slice("tool-".length) : type;
+  const output = record.output;
+  const outputText =
+    output == null
+      ? ""
+      : truncateContent(
+          stringifyForTokens(output),
+          "\n[Tool output shortened for retained tail]\n",
+          Math.max(1, maxTokens - 64),
+        );
+
+  const compacted = {
+    ...record,
+    output:
+      outputText.length > 0
+        ? `[${toolName} output preview for retained tail]\n${outputText}`
+        : `[${toolName} output omitted for retained tail]`,
+  } as UIMessage["parts"][number];
+
+  if (safeCountTokens(stringifyForTokens(compacted)) <= maxTokens) {
+    return compacted;
+  }
+
+  return textPart(
+    `[Tool: ${toolName} completed; details omitted from retained tail]`,
+  );
+};
+
+const projectPartToBudget = (
+  part: UIMessage["parts"][number],
+  maxTokens: number,
+  fileTokens: FileTokens,
+): ProjectedPart | null => {
+  if (maxTokens <= 0 || !isUsefulTailPart(part)) return null;
+
+  const currentTokens = estimatePartTokens(part, fileTokens);
+  if (currentTokens <= maxTokens) {
+    return { part, tokens: currentTokens, projected: false };
+  }
+
+  let projected: UIMessage["parts"][number];
+  if (part.type === "text" && "text" in part) {
+    projected = {
+      ...part,
+      text: truncateContent(
+        (part as { text?: string }).text ?? "",
+        "\n[Retained tail text shortened]\n",
+        maxTokens,
+      ),
+    } as UIMessage["parts"][number];
+  } else if (part.type === "file") {
+    projected = compactFilePart(part);
+  } else if (typeof part.type === "string" && part.type.startsWith("tool-")) {
+    projected = compactToolPart(part, maxTokens);
+  } else {
+    projected = textPart(
+      `[${part.type || "message part"} omitted from retained tail: ${currentTokens} tokens]`,
+    );
+  }
+
+  let projectedTokens = estimatePartTokens(projected, fileTokens);
+  if (
+    projectedTokens > maxTokens &&
+    projected.type === "text" &&
+    "text" in projected
+  ) {
+    projected = {
+      ...projected,
+      text: truncateContent(
+        (projected as { text?: string }).text ?? "",
+        "\n[Retained tail placeholder shortened]\n",
+        maxTokens,
+      ),
+    } as UIMessage["parts"][number];
+    projectedTokens = estimatePartTokens(projected, fileTokens);
+  }
+
+  if (projectedTokens > maxTokens) {
+    return null;
+  }
+
+  return { part: projected, tokens: projectedTokens, projected: true };
+};
+
+const projectNewestTail = (
+  messages: UIMessage[],
+  budgetTokens: number,
+  fileTokens: FileTokens,
+): TailProjection => {
+  let remaining = Math.max(0, Math.floor(budgetTokens));
+  let retainedTokens = 0;
+  let retainedPartCount = 0;
+  let projectedPartCount = 0;
+  let startMessageIndex: number | null = null;
+  let startPartIndex = 0;
+  const reversedTail: UIMessage[] = [];
+
+  for (
+    let messageIndex = messages.length - 1;
+    messageIndex >= 0;
+    messageIndex--
+  ) {
+    if (remaining <= 0) break;
+
+    const message = messages[messageIndex];
+    const usefulParts = message.parts.filter(isUsefulTailPart);
+    if (usefulParts.length === 0) continue;
+
+    const wholeTokens = estimatePartsTokens(usefulParts, fileTokens);
+    if (wholeTokens <= remaining) {
+      reversedTail.push({ ...message, parts: usefulParts });
+      retainedTokens += wholeTokens;
+      retainedPartCount += usefulParts.length;
+      remaining -= wholeTokens;
+      startMessageIndex = messageIndex;
+      startPartIndex = 0;
+      continue;
+    }
+
+    const retainedParts: UIMessage["parts"] = [];
+    let partialStartPartIndex: number | null = null;
+
+    for (
+      let partIndex = message.parts.length - 1;
+      partIndex >= 0;
+      partIndex--
+    ) {
+      if (remaining <= 0) break;
+
+      const part = message.parts[partIndex];
+      if (!isUsefulTailPart(part)) continue;
+
+      const projected = projectPartToBudget(part, remaining, fileTokens);
+      if (!projected) continue;
+
+      retainedParts.unshift(projected.part);
+      retainedTokens += projected.tokens;
+      retainedPartCount++;
+      if (projected.projected) projectedPartCount++;
+      remaining -= projected.tokens;
+      partialStartPartIndex = partIndex;
+    }
+
+    if (retainedParts.length > 0 && partialStartPartIndex !== null) {
+      reversedTail.push({ ...message, parts: retainedParts });
+      startMessageIndex = messageIndex;
+      startPartIndex = partialStartPartIndex;
+    }
+    break;
+  }
+
+  return {
+    messages: reversedTail.reverse(),
+    retainedTokens,
+    retainedPartCount,
+    projectedPartCount,
+    startMessageIndex,
+    startPartIndex,
+  };
+};
+
+const buildHeadMessages = (
+  messages: UIMessage[],
+  startMessageIndex: number,
+  startPartIndex: number,
+): UIMessage[] => {
+  if (startPartIndex <= 0) return messages.slice(0, startMessageIndex);
+
+  const partialHeadParts = messages[startMessageIndex].parts.slice(
+    0,
+    startPartIndex,
+  );
+  return [
+    ...messages.slice(0, startMessageIndex),
+    ...(partialHeadParts.length > 0
+      ? [{ ...messages[startMessageIndex], parts: partialHeadParts }]
+      : []),
+  ];
+};
+
+const buildMetadata = (
+  tail: TailProjection,
+  budgetTokens: number,
+  sourceMessages: UIMessage[],
+): RetainedTailMetadata | undefined => {
+  if (tail.startMessageIndex === null || tail.messages.length === 0)
+    return undefined;
+
+  return {
+    start_message_id: sourceMessages[tail.startMessageIndex].id,
+    start_part_index: tail.startPartIndex,
+    budget_tokens: Math.floor(budgetTokens),
+    retained_tokens: tail.retainedTokens,
+    retained_message_count: tail.messages.length,
+    retained_part_count: tail.retainedPartCount,
+    projected_part_count: tail.projectedPartCount,
+    strategy: RETAINED_TAIL_STRATEGY,
+  };
+};
+
+export const getRetainedTailBudgetTokens = (thresholdTokens: number): number =>
+  Math.min(
+    RETAINED_TAIL_MAX_TOKENS,
+    Math.max(
+      RETAINED_TAIL_MIN_TOKENS,
+      Math.floor(
+        Math.max(0, thresholdTokens) * RETAINED_TAIL_BUDGET_PERCENTAGE,
+      ),
+    ),
+  );
+
+export const selectRetainedTailForSummarization = (
+  messages: UIMessage[],
+  {
+    budgetTokens,
+    fileTokens = {} as FileTokens,
+  }: {
+    budgetTokens: number;
+    fileTokens?: FileTokens;
+  },
+): RetainedTailSelection => {
+  const tail = projectNewestTail(messages, budgetTokens, fileTokens);
+  const retainedTail = buildMetadata(tail, budgetTokens, messages);
+
+  if (tail.startMessageIndex === null || !retainedTail) {
+    return {
+      headMessages: messages,
+      tailMessages: [],
+      cutoffMessageId: messages.at(-1)?.id ?? null,
+    };
+  }
+
+  const headMessages = buildHeadMessages(
+    messages,
+    tail.startMessageIndex,
+    tail.startPartIndex,
+  );
+  const cutoffMessageId =
+    headMessages.at(-1)?.id ??
+    (tail.projectedPartCount > 0 ? retainedTail.start_message_id : null);
+
+  return {
+    headMessages,
+    tailMessages: tail.messages,
+    retainedTail,
+    cutoffMessageId,
+  };
+};
+
+export const projectMessagesToTokenBudget = (
+  messages: UIMessage[],
+  {
+    budgetTokens,
+    fileTokens = {} as FileTokens,
+  }: {
+    budgetTokens: number;
+    fileTokens?: FileTokens;
+  },
+): UIMessage[] =>
+  projectNewestTail(messages, budgetTokens, fileTokens).messages;
+
+export const projectRetainedTailFromMessages = (
+  messages: UIMessage[],
+  retainedTail: RetainedTailMetadata,
+  {
+    budgetTokens = retainedTail.budget_tokens,
+    fileTokens = {} as FileTokens,
+  }: {
+    budgetTokens?: number;
+    fileTokens?: FileTokens;
+  } = {},
+): UIMessage[] => {
+  if (retainedTail.strategy !== RETAINED_TAIL_STRATEGY) return [];
+
+  const startIndex = messages.findIndex(
+    (message) => message.id === retainedTail.start_message_id,
+  );
+  if (startIndex < 0) return [];
+
+  const firstMessage = messages[startIndex];
+  const startPartIndex = Math.max(
+    0,
+    Math.min(retainedTail.start_part_index, firstMessage.parts.length),
+  );
+  const candidates = [
+    { ...firstMessage, parts: firstMessage.parts.slice(startPartIndex) },
+    ...messages.slice(startIndex + 1),
+  ].filter((message) => message.parts.length > 0);
+
+  return projectMessagesToTokenBudget(candidates, {
+    budgetTokens,
+    fileTokens,
+  });
+};

--- a/lib/chat/summarization/retained-tail.ts
+++ b/lib/chat/summarization/retained-tail.ts
@@ -406,6 +406,11 @@ export const projectRetainedTailFromMessages = (
 ): UIMessage[] => {
   if (retainedTail.strategy !== RETAINED_TAIL_STRATEGY) return [];
 
+  const effectiveBudgetTokens = Math.min(
+    Math.max(0, Math.floor(budgetTokens)),
+    Math.max(0, Math.floor(retainedTail.budget_tokens)),
+  );
+
   const startIndex = messages.findIndex(
     (message) => message.id === retainedTail.start_message_id,
   );
@@ -422,7 +427,7 @@ export const projectRetainedTailFromMessages = (
   ].filter((message) => message.parts.length > 0);
 
   return projectMessagesToTokenBudget(candidates, {
-    budgetTokens,
+    budgetTokens: effectiveBudgetTokens,
     fileTokens,
   });
 };

--- a/lib/chat/summarization/retained-tail.ts
+++ b/lib/chat/summarization/retained-tail.ts
@@ -406,11 +406,6 @@ export const projectRetainedTailFromMessages = (
 ): UIMessage[] => {
   if (retainedTail.strategy !== RETAINED_TAIL_STRATEGY) return [];
 
-  const effectiveBudgetTokens = Math.min(
-    Math.max(0, Math.floor(budgetTokens)),
-    Math.max(0, Math.floor(retainedTail.budget_tokens)),
-  );
-
   const startIndex = messages.findIndex(
     (message) => message.id === retainedTail.start_message_id,
   );
@@ -427,7 +422,7 @@ export const projectRetainedTailFromMessages = (
   ].filter((message) => message.parts.length > 0);
 
   return projectMessagesToTokenBudget(candidates, {
-    budgetTokens: effectiveBudgetTokens,
+    budgetTokens,
     fileTokens,
   });
 };

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -21,6 +21,11 @@ import type { SubscriptionTier, NoteCategory } from "@/types";
 import type { Id } from "@/convex/_generated/dataModel";
 import { v4 as uuidv4 } from "uuid";
 import { AGENT_RESUME_PREAMBLE } from "@/lib/chat/summarization/prompts";
+import {
+  projectMessagesToTokenBudget,
+  projectRetainedTailFromMessages,
+  type RetainedTailMetadata,
+} from "@/lib/chat/summarization/retained-tail";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import { hasRestageableLocalDesktopAttachments } from "@/lib/utils/local-attachment-messages";
 import type { ChatMode } from "@/types/chat";
@@ -756,17 +761,9 @@ export async function getMessagesByChatId({
           // deleted assistant response must not leak back into the new run.
           if (latestSummary && !regenerate) {
             const summaryUpToId = latestSummary.summary_up_to_message_id;
-
-            // Find cutoff index once
-            const cutoffIndex = truncatedFromLoop.findIndex(
-              (m) => m.id === summaryUpToId,
-            );
-
-            // Keep messages that come after the cutoff
-            const messagesAfterCutoff =
-              cutoffIndex >= 0
-                ? truncatedFromLoop.slice(cutoffIndex + 1)
-                : truncatedFromLoop;
+            const availableChrono = [...fetchedDesc]
+              .reverse()
+              .concat(newMessages);
 
             // Create summary message, prepending resume preamble for agent modes
             const summaryPrefix =
@@ -791,14 +788,46 @@ export async function getMessagesByChatId({
               fileTokensFromLoop,
             );
             const budgetForMessages = maxTokens - summaryTokens;
-            const truncatedAfterCutoff =
-              budgetForMessages > 0
-                ? truncateMessagesToTokenLimit(
-                    messagesAfterCutoff,
-                    fileTokensFromLoop,
-                    budgetForMessages,
-                  )
-                : [];
+            const retainedTail = latestSummary.retained_tail as
+              | RetainedTailMetadata
+              | undefined;
+            let truncatedAfterCutoff: UIMessage[] = [];
+
+            if (budgetForMessages > 0 && retainedTail) {
+              truncatedAfterCutoff = projectRetainedTailFromMessages(
+                availableChrono,
+                retainedTail,
+                {
+                  budgetTokens: budgetForMessages,
+                  fileTokens: fileTokensFromLoop,
+                },
+              );
+
+              if (truncatedAfterCutoff.length === 0) {
+                truncatedAfterCutoff = projectMessagesToTokenBudget(
+                  availableChrono,
+                  {
+                    budgetTokens: budgetForMessages,
+                    fileTokens: fileTokensFromLoop,
+                  },
+                );
+              }
+            } else if (budgetForMessages > 0) {
+              // Legacy summaries only have a whole-message cutoff.
+              const cutoffIndex = truncatedFromLoop.findIndex(
+                (m) => m.id === summaryUpToId,
+              );
+              const messagesAfterCutoff =
+                cutoffIndex >= 0
+                  ? truncatedFromLoop.slice(cutoffIndex + 1)
+                  : truncatedFromLoop;
+              truncatedAfterCutoff = truncateMessagesToTokenLimit(
+                messagesAfterCutoff,
+                fileTokensFromLoop,
+                budgetForMessages,
+              );
+            }
+
             const truncatedWithSummary: UIMessage[] = [
               summaryMessage,
               ...truncatedAfterCutoff,
@@ -1119,6 +1148,7 @@ export async function saveChatSummary({
     cost?: number;
     estimatedCompactedInputTokens?: number;
     transcriptPath?: string;
+    retainedTail?: RetainedTailMetadata;
   };
 }) {
   try {

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -1148,12 +1148,6 @@ export async function saveChatSummary({
     model?: string;
     status?: string;
     error?: string;
-    inputTokens?: number;
-    outputTokens?: number;
-    cacheReadTokens?: number;
-    cacheWriteTokens?: number;
-    cost?: number;
-    estimatedCompactedInputTokens?: number;
     transcriptPath?: string;
     retainedTail?: RetainedTailMetadata;
   };

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -804,8 +804,15 @@ export async function getMessagesByChatId({
               );
 
               if (truncatedAfterCutoff.length === 0) {
+                const cutoffIndex = availableChrono.findIndex(
+                  (m) => m.id === summaryUpToId,
+                );
+                const messagesAfterCutoff =
+                  cutoffIndex >= 0
+                    ? availableChrono.slice(cutoffIndex + 1)
+                    : availableChrono;
                 truncatedAfterCutoff = projectMessagesToTokenBudget(
-                  availableChrono,
+                  messagesAfterCutoff,
                   {
                     budgetTokens: budgetForMessages,
                     fileTokens: fileTokensFromLoop,


### PR DESCRIPTION
## Summary
- add token-budgeted retained-tail selection with part-level message suffix projection
- summarize only the head while returning provider context as summary plus retained tail
- persist Convex retained_tail metadata across save, reload, fallback promotion, and branch copy paths
- rebuild post-summary history from metadata without storing retained tail payloads in chat_summaries

## Testing
- pnpm test -- lib/chat/summarization/__tests__/retained-tail.test.ts lib/chat/summarization/__tests__/index.test.ts convex/__tests__/chatSummaryFallback.test.ts lib/chat/compaction/__tests__/prune-tool-outputs.test.ts --runInBand
- pnpm typecheck
- pnpm exec eslint lib/chat/summarization/retained-tail.ts lib/chat/summarization/helpers.ts lib/chat/summarization/index.ts lib/chat/summarization/__tests__/retained-tail.test.ts lib/chat/summarization/__tests__/index.test.ts convex/schema.ts convex/chats.ts convex/messages.ts convex/lib/utils.ts convex/__tests__/chatSummaryFallback.test.ts lib/db/actions.ts
- pnpm exec prettier --check lib/chat/summarization/retained-tail.ts lib/chat/summarization/helpers.ts lib/chat/summarization/index.ts lib/chat/summarization/__tests__/retained-tail.test.ts lib/chat/summarization/__tests__/index.test.ts convex/schema.ts convex/chats.ts convex/messages.ts convex/lib/utils.ts convex/__tests__/chatSummaryFallback.test.ts lib/db/actions.ts

## Manual verification
- In a long chat with large tool-output parts, continue after summarization.
- Confirm the new provider context starts with the context summary and retains only the bounded recent tail.
- Confirm chat reload reconstructs the same bounded tail from persisted message rows and retained_tail metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token-budgeted “retained tail” metadata to chat summaries, including persisted reconstruction and carry-forward across summarization cycles.
  * Extended chat summary schemas and APIs to read/write optional retained-tail data, including nested previous summaries.

* **Bug Fixes**
  * Improved summary copy, persistence, and promotion/fallback to remap retained-tail start points when possible, preserve retained-tail metadata, and clear/delete the latest summary when the start can’t be found.
  * Enhanced invalidation to account for retained-tail start message deletion.

* **Tests**
  * Expanded retained-tail selection/projection/persistence, invalidation edge cases, and legacy telemetry cleanup coverage.

* **Chores**
  * Added scheduled, paginated legacy telemetry cleanup with dry-run support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->