### PR TITLE
Cancel active runs before deleting chats

### DIFF
--- a/app/api/chat/[id]/__tests__/route.test.ts
+++ b/app/api/chat/[id]/__tests__/route.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+const mockGetUserID = jest.fn();
+const mockGetChatById = jest.fn();
+const mockDeleteChatForBackend = jest.fn();
+const mockRunsCancel = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: class MockNextResponse {
+    status: number;
+    private body: unknown;
+
+    constructor(body?: unknown, init?: ResponseInit) {
+      this.body = body;
+      this.status = init?.status ?? 200;
+    }
+
+    static json(body: unknown, init?: ResponseInit) {
+      return new MockNextResponse(body, init);
+    }
+
+    async json() {
+      return this.body;
+    }
+
+    async text() {
+      return typeof this.body === "string"
+        ? this.body
+        : JSON.stringify(this.body ?? "");
+    }
+  },
+}));
+
+jest.mock("@trigger.dev/sdk", () => ({
+  runs: {
+    cancel: mockRunsCancel,
+  },
+}));
+
+jest.mock("@/lib/auth/get-user-id", () => ({
+  getUserID: mockGetUserID,
+}));
+
+jest.mock("@/lib/db/actions", () => ({
+  getChatById: mockGetChatById,
+  deleteChatForBackend: mockDeleteChatForBackend,
+}));
+
+const request = {} as any;
+const paramsFor = (id = "chat-1") => ({
+  params: Promise.resolve({ id }),
+});
+
+const chat = (overrides: Record<string, unknown> = {}) => ({
+  id: "chat-1",
+  user_id: "user-1",
+  active_trigger_run_id: "run-1",
+  ...overrides,
+});
+
+describe("DELETE /api/chat/[id]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUserID.mockResolvedValue("user-1" as never);
+    mockGetChatById.mockResolvedValue(chat() as never);
+    mockRunsCancel.mockResolvedValue(undefined as never);
+    mockDeleteChatForBackend.mockResolvedValue(undefined as never);
+  });
+
+  it("cancels an active Trigger run before deleting the chat", async () => {
+    const { DELETE } = await import("../route");
+    const calls: string[] = [];
+    mockRunsCancel.mockImplementation(async () => {
+      calls.push("cancel");
+    });
+    mockDeleteChatForBackend.mockImplementation(async () => {
+      calls.push("delete");
+    });
+
+    const response = await DELETE(request, paramsFor());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ deleted: true, canceledTriggerRun: true });
+    expect(mockRunsCancel).toHaveBeenCalledWith("run-1");
+    expect(mockDeleteChatForBackend).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      userId: "user-1",
+    });
+    expect(calls).toEqual(["cancel", "delete"]);
+  });
+
+  it("still deletes when the stored Trigger run is already terminal", async () => {
+    const { DELETE } = await import("../route");
+    mockRunsCancel.mockRejectedValue(new Error("already terminal") as never);
+
+    const response = await DELETE(request, paramsFor());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ deleted: true, canceledTriggerRun: false });
+    expect(mockDeleteChatForBackend).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      userId: "user-1",
+    });
+  });
+
+  it("deletes without calling Trigger when there is no active run", async () => {
+    const { DELETE } = await import("../route");
+    mockGetChatById.mockResolvedValue(
+      chat({ active_trigger_run_id: undefined }) as never,
+    );
+
+    const response = await DELETE(request, paramsFor());
+
+    expect(response.status).toBe(200);
+    expect(mockRunsCancel).not.toHaveBeenCalled();
+    expect(mockDeleteChatForBackend).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      userId: "user-1",
+    });
+  });
+
+  it("does not cancel or delete chats owned by another user", async () => {
+    const { DELETE } = await import("../route");
+    mockGetChatById.mockResolvedValue(chat({ user_id: "other-user" }) as never);
+
+    const response = await DELETE(request, paramsFor());
+
+    expect(response.status).toBe(403);
+    expect(mockRunsCancel).not.toHaveBeenCalled();
+    expect(mockDeleteChatForBackend).not.toHaveBeenCalled();
+  });
+
+  it("treats missing chats as already deleted", async () => {
+    const { DELETE } = await import("../route");
+    mockGetChatById.mockResolvedValue(null as never);
+
+    const response = await DELETE(request, paramsFor());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ deleted: true, reason: "not_found" });
+    expect(mockRunsCancel).not.toHaveBeenCalled();
+    expect(mockDeleteChatForBackend).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/chat/[id]/__tests__/route.test.ts
+++ b/app/api/chat/[id]/__tests__/route.test.ts
@@ -59,12 +59,19 @@ const chat = (overrides: Record<string, unknown> = {}) => ({
 });
 
 describe("DELETE /api/chat/[id]", () => {
+  let errorSpy: jest.SpiedFunction<typeof console.error>;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     mockGetUserID.mockResolvedValue("user-1" as never);
     mockGetChatById.mockResolvedValue(chat() as never);
     mockRunsCancel.mockResolvedValue(undefined as never);
     mockDeleteChatForBackend.mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
   });
 
   it("cancels an active Trigger run before deleting the chat", async () => {
@@ -90,19 +97,16 @@ describe("DELETE /api/chat/[id]", () => {
     expect(calls).toEqual(["cancel", "delete"]);
   });
 
-  it("still deletes when the stored Trigger run is already terminal", async () => {
+  it("does not delete when Trigger cancellation fails", async () => {
     const { DELETE } = await import("../route");
-    mockRunsCancel.mockRejectedValue(new Error("already terminal") as never);
+    mockRunsCancel.mockRejectedValue(
+      new Error("Trigger API unavailable") as never,
+    );
 
     const response = await DELETE(request, paramsFor());
-    const body = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(body).toEqual({ deleted: true, canceledTriggerRun: false });
-    expect(mockDeleteChatForBackend).toHaveBeenCalledWith({
-      chatId: "chat-1",
-      userId: "user-1",
-    });
+    expect(response.status).toBe(500);
+    expect(mockDeleteChatForBackend).not.toHaveBeenCalled();
   });
 
   it("deletes without calling Trigger when there is no active run", async () => {

--- a/app/api/chat/[id]/route.ts
+++ b/app/api/chat/[id]/route.ts
@@ -32,13 +32,8 @@ export async function DELETE(
     let canceledTriggerRun = false;
 
     if (triggerRunId) {
-      try {
-        await runs.cancel(triggerRunId);
-        canceledTriggerRun = true;
-      } catch {
-        // Best-effort: the run may already be terminal. Delete still proceeds
-        // while the chat row is present for ownership and run-id verification.
-      }
+      await runs.cancel(triggerRunId);
+      canceledTriggerRun = true;
     }
 
     await deleteChatForBackend({ chatId, userId });

--- a/app/api/chat/[id]/route.ts
+++ b/app/api/chat/[id]/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { runs } from "@trigger.dev/sdk";
+
+import { getUserID } from "@/lib/auth/get-user-id";
+import { deleteChatForBackend, getChatById } from "@/lib/db/actions";
+import { ChatSDKError } from "@/lib/errors";
+
+export const maxDuration = 30;
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id: chatId } = await params;
+    if (!chatId) {
+      return new NextResponse("chatId required", { status: 400 });
+    }
+
+    const userId = await getUserID(req);
+    const chat = await getChatById({ id: chatId });
+
+    if (!chat) {
+      return NextResponse.json({ deleted: true, reason: "not_found" });
+    }
+
+    if (chat.user_id !== userId) {
+      return new NextResponse("Forbidden", { status: 403 });
+    }
+
+    const triggerRunId = chat.active_trigger_run_id;
+    let canceledTriggerRun = false;
+
+    if (triggerRunId) {
+      try {
+        await runs.cancel(triggerRunId);
+        canceledTriggerRun = true;
+      } catch {
+        // Best-effort: the run may already be terminal. Delete still proceeds
+        // while the chat row is present for ownership and run-id verification.
+      }
+    }
+
+    await deleteChatForBackend({ chatId, userId });
+
+    return NextResponse.json({
+      deleted: true,
+      canceledTriggerRun,
+    });
+  } catch (error) {
+    if (error instanceof ChatSDKError) return error.toResponse();
+    console.error("[DELETE /api/chat/[id]] failed:", error);
+    return new NextResponse("Failed to delete chat", { status: 500 });
+  }
+}

--- a/app/api/chats/__tests__/route.test.ts
+++ b/app/api/chats/__tests__/route.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+const mockGetUserID = jest.fn();
+const mockGetActiveTriggerRunsForUser = jest.fn();
+const mockDeleteAllChatsForBackend = jest.fn();
+const mockRunsCancel = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: class MockNextResponse {
+    status: number;
+    private body: unknown;
+
+    constructor(body?: unknown, init?: ResponseInit) {
+      this.body = body;
+      this.status = init?.status ?? 200;
+    }
+
+    static json(body: unknown, init?: ResponseInit) {
+      return new MockNextResponse(body, init);
+    }
+
+    async json() {
+      return this.body;
+    }
+
+    async text() {
+      return typeof this.body === "string"
+        ? this.body
+        : JSON.stringify(this.body ?? "");
+    }
+  },
+}));
+
+jest.mock("@trigger.dev/sdk", () => ({
+  runs: {
+    cancel: mockRunsCancel,
+  },
+}));
+
+jest.mock("@/lib/auth/get-user-id", () => ({
+  getUserID: mockGetUserID,
+}));
+
+jest.mock("@/lib/db/actions", () => ({
+  getActiveTriggerRunsForUser: mockGetActiveTriggerRunsForUser,
+  deleteAllChatsForBackend: mockDeleteAllChatsForBackend,
+}));
+
+const request = {} as any;
+
+const activeRuns = (...triggerRunIds: string[]) => ({
+  runs: triggerRunIds.map((triggerRunId, index) => ({
+    chatId: `chat-${index + 1}`,
+    triggerRunId,
+  })),
+  hasMore: false,
+});
+
+describe("DELETE /api/chats", () => {
+  let errorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockGetUserID.mockResolvedValue("user-1" as never);
+    mockGetActiveTriggerRunsForUser.mockResolvedValue(
+      activeRuns("run-1", "run-2") as never,
+    );
+    mockRunsCancel.mockResolvedValue(undefined as never);
+    mockDeleteAllChatsForBackend.mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("cancels active Trigger runs before deleting chats", async () => {
+    const { DELETE } = await import("../route");
+    const calls: string[] = [];
+    mockRunsCancel.mockImplementation(async (triggerRunId) => {
+      calls.push(`cancel:${triggerRunId}`);
+    });
+    mockDeleteAllChatsForBackend.mockImplementation(async () => {
+      calls.push("delete");
+    });
+
+    const response = await DELETE(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ deleted: true, canceledTriggerRuns: 2 });
+    expect(mockGetActiveTriggerRunsForUser).toHaveBeenCalledWith({
+      userId: "user-1",
+    });
+    expect(mockRunsCancel).toHaveBeenNthCalledWith(1, "run-1");
+    expect(mockRunsCancel).toHaveBeenNthCalledWith(2, "run-2");
+    expect(mockDeleteAllChatsForBackend).toHaveBeenCalledWith({
+      userId: "user-1",
+    });
+    expect(calls).toEqual(["cancel:run-1", "cancel:run-2", "delete"]);
+  });
+
+  it("deduplicates stored Trigger run ids before cancellation", async () => {
+    const { DELETE } = await import("../route");
+    mockGetActiveTriggerRunsForUser.mockResolvedValue(
+      activeRuns("run-1", "run-1") as never,
+    );
+
+    const response = await DELETE(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ deleted: true, canceledTriggerRuns: 1 });
+    expect(mockRunsCancel).toHaveBeenCalledTimes(1);
+    expect(mockRunsCancel).toHaveBeenCalledWith("run-1");
+    expect(mockDeleteAllChatsForBackend).toHaveBeenCalledWith({
+      userId: "user-1",
+    });
+  });
+
+  it("does not delete chats when Trigger cancellation fails", async () => {
+    const { DELETE } = await import("../route");
+    mockRunsCancel.mockRejectedValue(
+      new Error("Trigger API unavailable") as never,
+    );
+
+    const response = await DELETE(request);
+
+    expect(response.status).toBe(500);
+    expect(mockDeleteAllChatsForBackend).not.toHaveBeenCalled();
+  });
+
+  it("does not delete chats when active runs exceed the safe lookup cap", async () => {
+    const { DELETE } = await import("../route");
+    mockGetActiveTriggerRunsForUser.mockResolvedValue({
+      ...activeRuns("run-1"),
+      hasMore: true,
+    } as never);
+
+    const response = await DELETE(request);
+    const text = await response.text();
+
+    expect(response.status).toBe(409);
+    expect(text).toBe("Too many active chat runs to delete safely");
+    expect(mockRunsCancel).not.toHaveBeenCalled();
+    expect(mockDeleteAllChatsForBackend).not.toHaveBeenCalled();
+  });
+
+  it("deletes without calling Trigger when there are no active runs", async () => {
+    const { DELETE } = await import("../route");
+    mockGetActiveTriggerRunsForUser.mockResolvedValue(activeRuns() as never);
+
+    const response = await DELETE(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ deleted: true, canceledTriggerRuns: 0 });
+    expect(mockRunsCancel).not.toHaveBeenCalled();
+    expect(mockDeleteAllChatsForBackend).toHaveBeenCalledWith({
+      userId: "user-1",
+    });
+  });
+});

--- a/app/api/chats/route.ts
+++ b/app/api/chats/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { runs } from "@trigger.dev/sdk";
+
+import { getUserID } from "@/lib/auth/get-user-id";
+import {
+  deleteAllChatsForBackend,
+  getActiveTriggerRunsForUser,
+} from "@/lib/db/actions";
+import { ChatSDKError } from "@/lib/errors";
+
+export const maxDuration = 30;
+
+const TRIGGER_CANCEL_CONCURRENCY = 4;
+
+async function cancelTriggerRuns(triggerRunIds: string[]) {
+  for (let i = 0; i < triggerRunIds.length; i += TRIGGER_CANCEL_CONCURRENCY) {
+    const chunk = triggerRunIds.slice(i, i + TRIGGER_CANCEL_CONCURRENCY);
+    await Promise.all(chunk.map((triggerRunId) => runs.cancel(triggerRunId)));
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const userId = await getUserID(req);
+    const activeTriggerRuns = await getActiveTriggerRunsForUser({ userId });
+
+    if (activeTriggerRuns.hasMore) {
+      return new NextResponse("Too many active chat runs to delete safely", {
+        status: 409,
+      });
+    }
+
+    const triggerRunIds = [
+      ...new Set(activeTriggerRuns.runs.map((run) => run.triggerRunId)),
+    ];
+
+    await cancelTriggerRuns(triggerRunIds);
+    await deleteAllChatsForBackend({ userId });
+
+    return NextResponse.json({
+      deleted: true,
+      canceledTriggerRuns: triggerRunIds.length,
+    });
+  } catch (error) {
+    if (error instanceof ChatSDKError) return error.toResponse();
+    console.error("[DELETE /api/chats] failed:", error);
+    return new NextResponse("Failed to delete all chats", { status: 500 });
+  }
+}

--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -94,7 +94,6 @@ const ChatItem: React.FC<ChatItemProps> = ({
     initializeChat,
   } = useGlobalState();
   const isMobile = useIsMobile();
-  const deleteChat = useMutation(api.chats.deleteChat);
   const renameChat = useMutation(api.chats.renameChat);
   const pinChat = usePinChat();
   const unpinChat = useUnpinChat();
@@ -140,7 +139,14 @@ const ChatItem: React.FC<ChatItemProps> = ({
     setIsDeleting(true);
 
     try {
-      await deleteChat({ chatId: id });
+      const response = await fetch(`/api/chat/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "");
+        throw new Error(errorText || "Failed to delete chat");
+      }
 
       // Remove draft from localStorage immediately after successful deletion
       removeDraft(id);

--- a/app/components/DataControlsTab.tsx
+++ b/app/components/DataControlsTab.tsx
@@ -2,9 +2,6 @@
 
 import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { useMutation } from "convex/react";
-import { ConvexError } from "convex/values";
-import { api } from "@/convex/_generated/api";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -27,25 +24,25 @@ const DataControlsTab = () => {
   const [isDeletingSandboxes, setIsDeletingSandboxes] = useState(false);
   const [showManageSharedChats, setShowManageSharedChats] = useState(false);
 
-  const deleteAllChats = useMutation(api.chats.deleteAllChats);
-
   const handleDeleteAllChats = async () => {
     if (isDeletingChats) return;
     setIsDeletingChats(true);
     try {
-      await deleteAllChats();
+      const response = await fetch("/api/chats", {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        const errorMessage = await response.text();
+        throw new Error(errorMessage || "Failed to delete all chats");
+      }
+
       setShowDeleteChats(false);
       window.location.href = "/";
     } catch (error) {
       console.error("Failed to delete all chats:", error);
       const errorMessage =
-        error instanceof ConvexError
-          ? (error.data as { message?: string })?.message ||
-            error.message ||
-            "Failed to delete all chats"
-          : error instanceof Error
-            ? error.message
-            : "Failed to delete all chats";
+        error instanceof Error ? error.message : "Failed to delete all chats";
       toast.error(errorMessage);
       setShowDeleteChats(false);
     } finally {

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -19,6 +19,7 @@ import { convexLogger } from "./lib/logger";
 
 const DELETE_ALL_CHATS_MESSAGE_BATCH_SIZE = 10;
 const DELETE_ALL_CHATS_SUMMARY_BATCH_SIZE = 25;
+const MAX_ACTIVE_TRIGGER_RUNS_TO_RETURN = 100;
 
 async function getMessageCreationTimeById(
   ctx: MutationCtx,
@@ -52,10 +53,29 @@ async function publishDeletionCancellation(ctx: MutationCtx, chatId: string) {
   }
 }
 
-async function deleteChatDocument(ctx: MutationCtx, chat: Doc<"chats">) {
+async function prepareChatForDeletion(ctx: MutationCtx, chat: Doc<"chats">) {
+  if (
+    chat.active_stream_id === undefined &&
+    chat.active_trigger_run_id === undefined &&
+    chat.canceled_at !== undefined
+  ) {
+    return;
+  }
+
   // Publish even when active_stream_id is not set yet; fast deletes can race
   // stream registration, and a no-listener cancellation message is harmless.
   await publishDeletionCancellation(ctx, chat.id);
+
+  await ctx.db.patch(chat._id, {
+    active_stream_id: undefined,
+    active_trigger_run_id: undefined,
+    canceled_at: Date.now(),
+    finish_reason: undefined,
+  });
+}
+
+async function deleteChatDocument(ctx: MutationCtx, chat: Doc<"chats">) {
+  await prepareChatForDeletion(ctx, chat);
 
   // Delete all messages and their associated files
   const messages = await ctx.db
@@ -148,6 +168,8 @@ async function deleteNextUserChatBatch(ctx: MutationCtx, userId: string) {
   if (!chat) {
     return false;
   }
+
+  await prepareChatForDeletion(ctx, chat);
 
   const messages = await ctx.db
     .query("messages")
@@ -1052,6 +1074,71 @@ export const getActiveTriggerRun = query({
       .withIndex("by_chat_id", (q) => q.eq("id", args.chatId))
       .first();
     return chat?.active_trigger_run_id ?? null;
+  },
+});
+
+export const getActiveTriggerRunsForUser = query({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+    limit: v.optional(v.number()),
+  },
+  returns: v.object({
+    runs: v.array(
+      v.object({
+        chatId: v.string(),
+        triggerRunId: v.string(),
+      }),
+    ),
+    hasMore: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    const requestedLimit = Math.floor(
+      args.limit ?? MAX_ACTIVE_TRIGGER_RUNS_TO_RETURN,
+    );
+    const limit = Math.min(
+      Math.max(Number.isFinite(requestedLimit) ? requestedLimit : 1, 1),
+      MAX_ACTIVE_TRIGGER_RUNS_TO_RETURN,
+    );
+
+    const chats = await ctx.db
+      .query("chats")
+      .withIndex("by_user_and_active_trigger_run", (q) =>
+        q.eq("user_id", args.userId).gt("active_trigger_run_id", ""),
+      )
+      .take(limit + 1);
+
+    return {
+      runs: chats.slice(0, limit).flatMap((chat) =>
+        chat.active_trigger_run_id
+          ? [
+              {
+                chatId: chat.id,
+                triggerRunId: chat.active_trigger_run_id,
+              },
+            ]
+          : [],
+      ),
+      hasMore: chats.length > limit,
+    };
+  },
+});
+
+/**
+ * Delete all chats for the authenticated backend user using the same bounded
+ * batch deleter as the client mutation.
+ */
+export const deleteAllChatsForBackend = mutation({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    await deleteNextUserChatBatch(ctx, args.userId);
+    return null;
   },
 });
 

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -1,5 +1,6 @@
 import { query, mutation, internalMutation } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
 import { v, ConvexError } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { internal } from "./_generated/api";
@@ -35,6 +36,107 @@ async function scheduleDeleteAllChatsBatch(ctx: MutationCtx, userId: string) {
   await ctx.scheduler.runAfter(0, internal.chats.deleteAllChatsBatch, {
     userId,
   });
+}
+
+async function publishDeletionCancellation(ctx: MutationCtx, chatId: string) {
+  try {
+    await ctx.scheduler.runAfter(0, internal.redisPubsub.publishCancellation, {
+      chatId,
+      skipSave: true,
+    });
+  } catch (error) {
+    console.error(
+      `Failed to publish cancellation for deleted chat ${chatId}:`,
+      error,
+    );
+  }
+}
+
+async function deleteChatDocument(ctx: MutationCtx, chat: Doc<"chats">) {
+  // Publish even when active_stream_id is not set yet; fast deletes can race
+  // stream registration, and a no-listener cancellation message is harmless.
+  await publishDeletionCancellation(ctx, chat.id);
+
+  // Delete all messages and their associated files
+  const messages = await ctx.db
+    .query("messages")
+    .withIndex("by_chat_id", (q) => q.eq("chat_id", chat.id))
+    .collect();
+
+  for (const message of messages) {
+    // Skip deleting files for copied messages (they reference original chat files)
+    if (!message.source_message_id) {
+      // Clean up files associated with this message
+      if (message.file_ids && message.file_ids.length > 0) {
+        for (const fileId of message.file_ids) {
+          try {
+            const file = await ctx.db.get(fileId);
+            if (file) {
+              if (file.s3_key) {
+                await ctx.scheduler.runAfter(
+                  0,
+                  internal.s3Cleanup.deleteS3ObjectAction,
+                  { s3Key: file.s3_key },
+                );
+              }
+              // Delete from aggregate
+              await fileCountAggregate.deleteIfExists(ctx, file);
+              await ctx.db.delete(file._id);
+            }
+          } catch (error) {
+            console.error(`Failed to delete file ${fileId}:`, error);
+            // Continue with deletion even if file cleanup fails
+          }
+        }
+      }
+    }
+
+    // Clean up feedback associated with this message
+    if (message.feedback_id) {
+      try {
+        await ctx.db.delete(message.feedback_id);
+      } catch (error) {
+        console.error(
+          `Failed to delete feedback ${message.feedback_id}:`,
+          error,
+        );
+        // Continue with deletion even if feedback cleanup fails
+      }
+    }
+
+    await ctx.db.delete(message._id);
+  }
+
+  // Delete chat summaries
+  if (chat.latest_summary_id) {
+    try {
+      await ctx.db.delete(chat.latest_summary_id);
+    } catch (error) {
+      console.error(
+        `Failed to delete summary ${chat.latest_summary_id}:`,
+        error,
+      );
+      // Continue with deletion even if summary cleanup fails
+    }
+  }
+
+  // Delete all historical summaries for this chat
+  const summaries = await ctx.db
+    .query("chat_summaries")
+    .withIndex("by_chat_id", (q) => q.eq("chat_id", chat.id))
+    .collect();
+
+  for (const summary of summaries) {
+    try {
+      await ctx.db.delete(summary._id);
+    } catch (error) {
+      console.error(`Failed to delete summary ${summary._id}:`, error);
+      // Continue with deletion even if summary cleanup fails
+    }
+  }
+
+  // Delete the chat itself
+  await ctx.db.delete(chat._id);
 }
 
 async function deleteNextUserChatBatch(ctx: MutationCtx, userId: string) {
@@ -739,86 +841,7 @@ export const deleteChat = mutation({
         });
       }
 
-      // Delete all messages and their associated files
-      const messages = await ctx.db
-        .query("messages")
-        .withIndex("by_chat_id", (q) => q.eq("chat_id", args.chatId))
-        .collect();
-
-      for (const message of messages) {
-        // Skip deleting files for copied messages (they reference original chat files)
-        if (!message.source_message_id) {
-          // Clean up files associated with this message
-          if (message.file_ids && message.file_ids.length > 0) {
-            for (const fileId of message.file_ids) {
-              try {
-                const file = await ctx.db.get(fileId);
-                if (file) {
-                  if (file.s3_key) {
-                    await ctx.scheduler.runAfter(
-                      0,
-                      internal.s3Cleanup.deleteS3ObjectAction,
-                      { s3Key: file.s3_key },
-                    );
-                  }
-                  // Delete from aggregate
-                  await fileCountAggregate.deleteIfExists(ctx, file);
-                  await ctx.db.delete(file._id);
-                }
-              } catch (error) {
-                console.error(`Failed to delete file ${fileId}:`, error);
-                // Continue with deletion even if file cleanup fails
-              }
-            }
-          }
-        }
-
-        // Clean up feedback associated with this message
-        if (message.feedback_id) {
-          try {
-            await ctx.db.delete(message.feedback_id);
-          } catch (error) {
-            console.error(
-              `Failed to delete feedback ${message.feedback_id}:`,
-              error,
-            );
-            // Continue with deletion even if feedback cleanup fails
-          }
-        }
-
-        await ctx.db.delete(message._id);
-      }
-
-      // Delete chat summaries
-      if (chat.latest_summary_id) {
-        try {
-          await ctx.db.delete(chat.latest_summary_id);
-        } catch (error) {
-          console.error(
-            `Failed to delete summary ${chat.latest_summary_id}:`,
-            error,
-          );
-          // Continue with deletion even if summary cleanup fails
-        }
-      }
-
-      // Delete all historical summaries for this chat
-      const summaries = await ctx.db
-        .query("chat_summaries")
-        .withIndex("by_chat_id", (q) => q.eq("chat_id", args.chatId))
-        .collect();
-
-      for (const summary of summaries) {
-        try {
-          await ctx.db.delete(summary._id);
-        } catch (error) {
-          console.error(`Failed to delete summary ${summary._id}:`, error);
-          // Continue with deletion even if summary cleanup fails
-        }
-      }
-
-      // Delete the chat itself
-      await ctx.db.delete(chat._id);
+      await deleteChatDocument(ctx, chat);
 
       return null;
     } catch (error) {
@@ -826,6 +849,40 @@ export const deleteChat = mutation({
       // Avoid surfacing errors to the client; treat as a no-op
       return null;
     }
+  },
+});
+
+/**
+ * Delete a chat from a trusted server route after ownership is verified.
+ */
+export const deleteChatForBackend = mutation({
+  args: {
+    serviceKey: v.string(),
+    chatId: v.string(),
+    userId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const chat = await ctx.db
+      .query("chats")
+      .withIndex("by_chat_id", (q) => q.eq("id", args.chatId))
+      .first();
+
+    if (!chat) {
+      return null;
+    }
+
+    if (chat.user_id !== args.userId) {
+      throw new ConvexError({
+        code: "ACCESS_DENIED",
+        message: "Unauthorized: Chat does not belong to user",
+      });
+    }
+
+    await deleteChatDocument(ctx, chat);
+    return null;
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -44,6 +44,10 @@ export default defineSchema({
   })
     .index("by_chat_id", ["id"])
     .index("by_user_and_updated", ["user_id", "update_time"])
+    .index("by_user_and_active_trigger_run", [
+      "user_id",
+      "active_trigger_run_id",
+    ])
     .index("by_user_and_pinned", ["user_id", "pinned_at"])
     .index("by_share_id", ["share_id"])
     .searchIndex("search_title", {

--- a/lib/api/__tests__/chat-delete-contracts.test.ts
+++ b/lib/api/__tests__/chat-delete-contracts.test.ts
@@ -1,0 +1,64 @@
+import fs from "fs";
+import path from "path";
+
+const convexChatsSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../../convex/chats.ts"),
+  "utf8",
+);
+
+const chatDeleteRouteSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../../app/api/chat/[id]/route.ts"),
+  "utf8",
+);
+
+describe("chat deletion cancellation contracts", () => {
+  test("server delete route cancels Trigger runs before deleting the chat row", () => {
+    const runIdIdx = chatDeleteRouteSrc.indexOf(
+      "const triggerRunId = chat.active_trigger_run_id",
+    );
+    const cancelIdx = chatDeleteRouteSrc.indexOf(
+      "runs.cancel(triggerRunId)",
+      runIdIdx,
+    );
+    const deleteIdx = chatDeleteRouteSrc.indexOf(
+      "deleteChatForBackend({",
+      cancelIdx,
+    );
+
+    expect(runIdIdx).toBeGreaterThan(-1);
+    expect(cancelIdx).toBeGreaterThan(runIdIdx);
+    expect(deleteIdx).toBeGreaterThan(cancelIdx);
+  });
+
+  test("Convex chat deletion publishes stream cancellation before deleting the chat row", () => {
+    const publishHelperIdx = convexChatsSrc.indexOf(
+      "async function publishDeletionCancellation",
+    );
+    const redisPublishIdx = convexChatsSrc.indexOf(
+      "internal.redisPubsub.publishCancellation",
+      publishHelperIdx,
+    );
+    const skipSaveIdx = convexChatsSrc.indexOf(
+      "skipSave: true",
+      redisPublishIdx,
+    );
+    const helperIdx = convexChatsSrc.indexOf(
+      "async function deleteChatDocument",
+    );
+    const publishCallIdx = convexChatsSrc.indexOf(
+      "await publishDeletionCancellation(ctx, chat.id)",
+      helperIdx,
+    );
+    const deleteChatRowIdx = convexChatsSrc.indexOf(
+      "await ctx.db.delete(chat._id)",
+      helperIdx,
+    );
+
+    expect(publishHelperIdx).toBeGreaterThan(-1);
+    expect(redisPublishIdx).toBeGreaterThan(publishHelperIdx);
+    expect(skipSaveIdx).toBeGreaterThan(redisPublishIdx);
+    expect(helperIdx).toBeGreaterThan(-1);
+    expect(publishCallIdx).toBeGreaterThan(helperIdx);
+    expect(deleteChatRowIdx).toBeGreaterThan(publishCallIdx);
+  });
+});

--- a/lib/api/__tests__/chat-delete-contracts.test.ts
+++ b/lib/api/__tests__/chat-delete-contracts.test.ts
@@ -11,6 +11,16 @@ const chatDeleteRouteSrc = fs.readFileSync(
   "utf8",
 );
 
+const chatsDeleteRouteSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../../app/api/chats/route.ts"),
+  "utf8",
+);
+
+const dataControlsTabSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../../app/components/DataControlsTab.tsx"),
+  "utf8",
+);
+
 describe("chat deletion cancellation contracts", () => {
   test("server delete route cancels Trigger runs before deleting the chat row", () => {
     const runIdIdx = chatDeleteRouteSrc.indexOf(
@@ -30,6 +40,29 @@ describe("chat deletion cancellation contracts", () => {
     expect(deleteIdx).toBeGreaterThan(cancelIdx);
   });
 
+  test("settings delete-all route cancels Trigger runs before deleting chats", () => {
+    const lookupIdx = chatsDeleteRouteSrc.indexOf(
+      "getActiveTriggerRunsForUser({ userId })",
+    );
+    const cancelIdx = chatsDeleteRouteSrc.indexOf(
+      "await cancelTriggerRuns(triggerRunIds)",
+      lookupIdx,
+    );
+    const deleteIdx = chatsDeleteRouteSrc.indexOf(
+      "deleteAllChatsForBackend({ userId })",
+      cancelIdx,
+    );
+
+    expect(lookupIdx).toBeGreaterThan(-1);
+    expect(cancelIdx).toBeGreaterThan(lookupIdx);
+    expect(deleteIdx).toBeGreaterThan(cancelIdx);
+  });
+
+  test("settings delete-all UI uses the cancellation-aware server route", () => {
+    expect(dataControlsTabSrc).toContain('fetch("/api/chats"');
+    expect(dataControlsTabSrc).not.toContain("api.chats.deleteAllChats");
+  });
+
   test("Convex chat deletion publishes stream cancellation before deleting the chat row", () => {
     const publishHelperIdx = convexChatsSrc.indexOf(
       "async function publishDeletionCancellation",
@@ -42,11 +75,18 @@ describe("chat deletion cancellation contracts", () => {
       "skipSave: true",
       redisPublishIdx,
     );
-    const helperIdx = convexChatsSrc.indexOf(
-      "async function deleteChatDocument",
+    const prepareHelperIdx = convexChatsSrc.indexOf(
+      "async function prepareChatForDeletion",
     );
     const publishCallIdx = convexChatsSrc.indexOf(
       "await publishDeletionCancellation(ctx, chat.id)",
+      prepareHelperIdx,
+    );
+    const helperIdx = convexChatsSrc.indexOf(
+      "async function deleteChatDocument",
+    );
+    const prepareCallIdx = convexChatsSrc.indexOf(
+      "await prepareChatForDeletion(ctx, chat)",
       helperIdx,
     );
     const deleteChatRowIdx = convexChatsSrc.indexOf(
@@ -57,8 +97,28 @@ describe("chat deletion cancellation contracts", () => {
     expect(publishHelperIdx).toBeGreaterThan(-1);
     expect(redisPublishIdx).toBeGreaterThan(publishHelperIdx);
     expect(skipSaveIdx).toBeGreaterThan(redisPublishIdx);
+    expect(prepareHelperIdx).toBeGreaterThan(-1);
+    expect(publishCallIdx).toBeGreaterThan(prepareHelperIdx);
     expect(helperIdx).toBeGreaterThan(-1);
-    expect(publishCallIdx).toBeGreaterThan(helperIdx);
-    expect(deleteChatRowIdx).toBeGreaterThan(publishCallIdx);
+    expect(prepareCallIdx).toBeGreaterThan(helperIdx);
+    expect(deleteChatRowIdx).toBeGreaterThan(prepareCallIdx);
+  });
+
+  test("Convex delete-all batches prepare each chat for cancellation before deleting messages", () => {
+    const batchHelperIdx = convexChatsSrc.indexOf(
+      "async function deleteNextUserChatBatch",
+    );
+    const prepareCallIdx = convexChatsSrc.indexOf(
+      "await prepareChatForDeletion(ctx, chat)",
+      batchHelperIdx,
+    );
+    const messagesQueryIdx = convexChatsSrc.indexOf(
+      '.query("messages")',
+      batchHelperIdx,
+    );
+
+    expect(batchHelperIdx).toBeGreaterThan(-1);
+    expect(prepareCallIdx).toBeGreaterThan(batchHelperIdx);
+    expect(messagesQueryIdx).toBeGreaterThan(prepareCallIdx);
   });
 });

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -325,6 +325,27 @@ export async function getChatById({ id }: { id: string }) {
   }
 }
 
+export async function deleteChatForBackend({
+  chatId,
+  userId,
+}: {
+  chatId: string;
+  userId: string;
+}) {
+  try {
+    await getConvexClient().mutation(api.chats.deleteChatForBackend, {
+      serviceKey,
+      chatId,
+      userId,
+    });
+  } catch (error) {
+    throw databaseError("chats.deleteChatForBackend", error, {
+      chat_id: chatId,
+      user_id: userId,
+    });
+  }
+}
+
 export async function saveChat({
   id,
   userId,

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -346,6 +346,39 @@ export async function deleteChatForBackend({
   }
 }
 
+export async function getActiveTriggerRunsForUser({
+  userId,
+}: {
+  userId: string;
+}) {
+  try {
+    return await getConvexClient().query(
+      api.chats.getActiveTriggerRunsForUser,
+      {
+        serviceKey,
+        userId,
+      },
+    );
+  } catch (error) {
+    throw databaseError("chats.getActiveTriggerRunsForUser", error, {
+      user_id: userId,
+    });
+  }
+}
+
+export async function deleteAllChatsForBackend({ userId }: { userId: string }) {
+  try {
+    await getConvexClient().mutation(api.chats.deleteAllChatsForBackend, {
+      serviceKey,
+      userId,
+    });
+  } catch (error) {
+    throw databaseError("chats.deleteAllChatsForBackend", error, {
+      user_id: userId,
+    });
+  }
+}
+
 export async function saveChat({
   id,
   userId,


### PR DESCRIPTION
## Summary
- route sidebar chat deletion through a server DELETE endpoint so active Trigger Agent runs are cancelled before the chat row is removed
- publish the Ask stream cancellation signal with skipSave before Convex deletes chat records
- add route and contract coverage for cancellation-before-delete behavior

## Testing
- pnpm jest --runTestsByPath 'app/api/chat/[id]/__tests__/route.test.ts' lib/api/__tests__/chat-delete-contracts.test.ts --runInBand
- pnpm typecheck
- pnpm exec eslint app/components/ChatItem.tsx 'app/api/chat/[id]/route.ts' 'app/api/chat/[id]/__tests__/route.test.ts' lib/db/actions.ts lib/api/__tests__/chat-delete-contracts.test.ts
- pnpm exec eslint convex/chats.ts
- pnpm exec prettier --check app/components/ChatItem.tsx 'app/api/chat/[id]/route.ts' 'app/api/chat/[id]/__tests__/route.test.ts' convex/chats.ts lib/db/actions.ts lib/api/__tests__/chat-delete-contracts.test.ts
- pnpm lint (passes with existing warnings)

## Manual verification
- Start an Ask response, delete that chat from the sidebar, and confirm the stream stops and no assistant save is recreated after deletion.
- Start an Agent run, delete that chat from the sidebar, and confirm the Trigger run receives cancellation instead of continuing after the chat row disappears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deleting a chat now cancels any active background runs before the chat is removed.
  * Deleting all chats cancels active runs first, with safeguards to prevent unsafe deletion when there are too many active runs.
  * Deleting a missing chat returns a successful “not found” result.
* **Bug Fixes**
  * Improved permission handling for deletion to prevent cross-user access.
* **Refactor**
  * Updated the UI to delete chats via the REST delete endpoints.
* **Tests**
  * Expanded test coverage, including cancellation-before-deletion contract checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->