### PR TITLE
Clean up stale chat summaries

### DIFF
--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -277,7 +277,47 @@ describe("saveLatestSummary — previous_summaries chain", () => {
         ],
       }),
     );
-    expect(mockCtx.db.delete).not.toHaveBeenCalledWith(SUMMARY_DOC_ID);
+    expect(mockCtx.db.delete).toHaveBeenCalledWith(SUMMARY_DOC_ID);
+  });
+
+  it("should still save the new summary if old summary cleanup fails", async () => {
+    const chat = makeChatDoc();
+    setupSaveSummaryQueries(chat);
+
+    const oldSummary = makeSummaryDoc({
+      summary_text: "old text",
+      summary_up_to_message_id: "msg-5",
+      summary_up_to_message_creation_time: 5_000,
+      previous_summaries: [],
+    });
+    mockCtx.db.get.mockResolvedValue(oldSummary);
+    mockCtx.db.delete.mockRejectedValueOnce(new Error("cleanup failed"));
+
+    const { saveLatestSummary } = await import("../chats");
+
+    await saveLatestSummary.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      chatId: CHAT_ID,
+      summaryText: "new summary",
+      summaryUpToMessageId: "msg-10",
+    });
+
+    expect(mockCtx.db.insert).toHaveBeenCalledWith(
+      "chat_summaries",
+      expect.objectContaining({
+        previous_summaries: [
+          {
+            summary_text: "old text",
+            summary_up_to_message_id: "msg-5",
+            summary_up_to_message_creation_time: 5_000,
+          },
+        ],
+      }),
+    );
+    expect(mockCtx.db.patch).toHaveBeenCalledWith(CHAT_DOC_ID, {
+      latest_summary_id: "new-summary-id",
+    });
+    expect(mockCtx.db.delete).toHaveBeenCalledWith(SUMMARY_DOC_ID);
   });
 
   it("should preserve the chain: [old, ...old_previous_summaries]", async () => {
@@ -376,6 +416,7 @@ describe("saveLatestSummary — previous_summaries chain", () => {
 
     expect(mockCtx.db.insert).not.toHaveBeenCalled();
     expect(mockCtx.db.patch).not.toHaveBeenCalled();
+    expect(mockCtx.db.delete).not.toHaveBeenCalled();
   });
 
   it("should save a different cutoff message with the same creation time", async () => {
@@ -408,6 +449,7 @@ describe("saveLatestSummary — previous_summaries chain", () => {
     expect(mockCtx.db.patch).toHaveBeenCalledWith(CHAT_DOC_ID, {
       latest_summary_id: "new-summary-id",
     });
+    expect(mockCtx.db.delete).toHaveBeenCalledWith(SUMMARY_DOC_ID);
   });
 
   it("should skip saves when the incoming cutoff message was deleted", async () => {

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -388,6 +388,74 @@ describe("userDeletion", () => {
       expect(mockScheduler.runAfter).not.toHaveBeenCalled();
     });
 
+    it("should delete chat summaries before deleting chats", async () => {
+      const { deleteAllUserData } = await import("../userDeletion");
+
+      const mockScheduler = {
+        runAfter: jest.fn(),
+      };
+
+      const mockChats = [
+        {
+          _id: "chat-doc-1",
+          id: "chat-1",
+          user_id: "user123",
+          title: "Chat 1",
+          update_time: 1000,
+          latest_summary_id: "summary-1",
+        },
+      ];
+      const mockSummaries = [
+        { _id: "summary-1", chat_id: "chat-1" },
+        { _id: "summary-2", chat_id: "chat-1" },
+      ];
+
+      const mockDb = {
+        query: jest.fn((table: string) => ({
+          withIndex: jest.fn().mockReturnValue({
+            collect: jest
+              .fn()
+              .mockResolvedValue(
+                table === "chats"
+                  ? mockChats
+                  : table === "chat_summaries"
+                    ? mockSummaries
+                    : [],
+              ),
+            first: jest.fn().mockResolvedValue(null),
+          }),
+        })),
+        delete: jest.fn(),
+      };
+
+      const mockAuth = {
+        getUserIdentity: jest.fn().mockResolvedValue({
+          subject: "user123",
+        }),
+      };
+
+      const mockCtx = {
+        auth: mockAuth,
+        db: mockDb,
+        scheduler: mockScheduler,
+      };
+
+      await deleteAllUserData.handler(mockCtx, {});
+
+      expect(mockDb.query).toHaveBeenCalledWith("chat_summaries");
+      expect(mockDb.delete).toHaveBeenCalledWith("summary-1");
+      expect(mockDb.delete).toHaveBeenCalledWith("summary-2");
+      expect(mockDb.delete).toHaveBeenCalledWith("chat-doc-1");
+
+      const deleteOrder = mockDb.delete.mock.calls.map(([id]) => id);
+      expect(deleteOrder.indexOf("summary-1")).toBeLessThan(
+        deleteOrder.indexOf("chat-doc-1"),
+      );
+      expect(deleteOrder.indexOf("summary-2")).toBeLessThan(
+        deleteOrder.indexOf("chat-doc-1"),
+      );
+    });
+
     it("should throw error if user is not authenticated", async () => {
       const { deleteAllUserData } = await import("../userDeletion");
 

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -1171,9 +1171,13 @@ export const saveLatestSummary = mutation({
         summary_up_to_message_creation_time?: number;
       }[] = [];
 
-      if (chat.latest_summary_id) {
-        const oldSummary = await ctx.db.get(chat.latest_summary_id);
+      const previousSummaryId = chat.latest_summary_id;
+      let shouldDeletePreviousSummary = false;
+
+      if (previousSummaryId) {
+        const oldSummary = await ctx.db.get(previousSummaryId);
         if (oldSummary) {
+          shouldDeletePreviousSummary = true;
           const oldSummaryWithCreationTime = oldSummary as typeof oldSummary & {
             summary_up_to_message_creation_time?: number;
           };
@@ -1200,7 +1204,7 @@ export const saveLatestSummary = mutation({
               incoming_summary_up_to_message_id: args.summaryUpToMessageId,
               incoming_summary_up_to_message_creation_time:
                 incomingCutoffCreationTime,
-              current_summary_id: chat.latest_summary_id,
+              current_summary_id: previousSummaryId,
               current_summary_up_to_message_id:
                 oldSummary.summary_up_to_message_id,
               current_summary_up_to_message_creation_time:
@@ -1227,7 +1231,7 @@ export const saveLatestSummary = mutation({
             service: "convex",
             environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
             chat_id: args.chatId,
-            latest_summary_id: chat.latest_summary_id,
+            latest_summary_id: previousSummaryId,
           });
         }
       }
@@ -1284,6 +1288,27 @@ export const saveLatestSummary = mutation({
         latest_summary_id: summaryId,
       });
 
+      let deletedPreviousSummary = false;
+      if (
+        shouldDeletePreviousSummary &&
+        previousSummaryId &&
+        previousSummaryId !== summaryId
+      ) {
+        try {
+          await ctx.db.delete(previousSummaryId);
+          deletedPreviousSummary = true;
+        } catch (error) {
+          convexLogger.warn("chat_summary_previous_cleanup_failed", {
+            service: "convex",
+            environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+            chat_id: args.chatId,
+            previous_summary_id: previousSummaryId,
+            new_summary_id: summaryId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
       convexLogger.info("chat_summary_saved", {
         service: "convex",
         environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
@@ -1291,8 +1316,9 @@ export const saveLatestSummary = mutation({
         summary_id: summaryId,
         summary_up_to_message_id: args.summaryUpToMessageId,
         summary_up_to_message_creation_time: incomingCutoffCreationTime,
-        previous_summary_id: chat.latest_summary_id,
+        previous_summary_id: previousSummaryId,
         previous_summaries_count: previousSummaries.length,
+        deleted_previous_summary: deletedPreviousSummary,
       });
 
       return null;

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -9,11 +9,12 @@ import { fileCountAggregate } from "./fileAggregate";
  * Deletion order (respects foreign key constraints):
  * 1) Feedback records (referenced by messages)
  * 2) Messages (owned by user, reference chats and files)
- * 3) Chats (owned by user)
- * 4) Files + S3 objects (owned by user, may be referenced by messages)
+ * 3) Chat summaries (referenced by chats)
+ * 4) Chats (owned by user)
+ * 5) Files + S3 objects (owned by user, may be referenced by messages)
  *    - S3 objects: Batch deleted using scheduled action
- * 5) Notes (owned by user)
- * 6) User customization (owned by user)
+ * 6) Notes (owned by user)
+ * 7) User customization (owned by user)
  *
  * Uses parallel queries and deletions for optimal performance.
  * S3 cleanup is scheduled asynchronously and errors don't block user deletion.
@@ -86,7 +87,27 @@ export const deleteAllUserData = mutation({
         }),
       );
 
-      // Step 3: Delete chats (now safe since messages are gone)
+      // Step 3: Delete chat summaries before deleting the chats that reference them
+      const summariesByChat = await Promise.all(
+        chats.map((chat) =>
+          ctx.db
+            .query("chat_summaries")
+            .withIndex("by_chat_id", (q) => q.eq("chat_id", chat.id))
+            .collect(),
+        ),
+      );
+
+      await Promise.all(
+        summariesByChat.flat().map(async (summary) => {
+          try {
+            await ctx.db.delete(summary._id);
+          } catch (error) {
+            console.error(`Failed to delete summary ${summary._id}:`, error);
+          }
+        }),
+      );
+
+      // Step 4: Delete chats (now safe since messages and summaries are gone)
       await Promise.all(
         chats.map(async (chat) => {
           try {
@@ -97,7 +118,7 @@ export const deleteAllUserData = mutation({
         }),
       );
 
-      // Step 4: Delete files and S3 objects (safe since messages no longer reference them)
+      // Step 5: Delete files and S3 objects (safe since messages no longer reference them)
 
       // Collect S3 keys for batch deletion
       const s3Keys: string[] = [];
@@ -137,7 +158,7 @@ export const deleteAllUserData = mutation({
         }
       }
 
-      // Step 5: Delete notes (independent of other data)
+      // Step 6: Delete notes (independent of other data)
       await Promise.all(
         notes.map(async (note) => {
           try {
@@ -148,7 +169,7 @@ export const deleteAllUserData = mutation({
         }),
       );
 
-      // Step 6: Delete user customization (independent of other data)
+      // Step 7: Delete user customization (independent of other data)
       if (customization) {
         try {
           await ctx.db.delete(customization._id);


### PR DESCRIPTION
## Summary
- delete the superseded `chat_summaries` row after a newer summary is safely inserted and referenced
- include `chat_summaries` cleanup in account deletion before deleting chat rows
- add regression tests for summary replacement cleanup and account deletion ordering

## Validation
- `pnpm test -- convex/__tests__/chatSummaryFallback.test.ts convex/__tests__/userDeletion.test.ts --runInBand`
- `pnpm exec prettier --check convex/chats.ts convex/userDeletion.ts convex/__tests__/chatSummaryFallback.test.ts convex/__tests__/userDeletion.test.ts`
- `pnpm exec eslint convex/chats.ts convex/userDeletion.ts convex/__tests__/chatSummaryFallback.test.ts convex/__tests__/userDeletion.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)

## Manual verification
- In a chat that has already compacted once, send enough additional context to create a newer summary. Confirm the chat continues normally and only the current summary row remains queryable by `latest_summary_id`; the old summary text is still available inside the new row's `previous_summaries`.
- Delete an account that owns summarized chats. Confirm `chat_summaries` rows for those chats are removed before the auth user deletion completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of chat summary updates to ensure proper cleanup when summaries are replaced.
  * Enhanced account deletion workflow to ensure correct data cleanup order and integrity.

* **Tests**
  * Added test coverage for chat summary replacement scenarios and account deletion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->