### PR TITLE
Harden account deletion cleanup

### DIFF
--- a/app/api/delete-account/__tests__/route.test.ts
+++ b/app/api/delete-account/__tests__/route.test.ts
@@ -4,6 +4,8 @@ import { deleteUserRateLimitKeys } from "@/lib/rate-limit/token-bucket";
 import { stripe } from "../../stripe";
 import { workos } from "../../workos";
 
+const mockConvexMutation = jest.fn();
+
 jest.mock("next/server", () => ({
   NextResponse: {
     json: jest.fn((body: unknown, init?: { status?: number }) => ({
@@ -19,6 +21,20 @@ jest.mock("@/lib/auth/get-user-id", () => ({
 
 jest.mock("@/lib/rate-limit/token-bucket", () => ({
   deleteUserRateLimitKeys: jest.fn(),
+}));
+
+jest.mock("@/lib/db/convex-client", () => ({
+  getConvexClient: jest.fn(() => ({
+    mutation: mockConvexMutation,
+  })),
+}));
+
+jest.mock("@/convex/_generated/api", () => ({
+  api: {
+    userDeletion: {
+      deleteAllUserDataByService: "userDeletion.deleteAllUserDataByService",
+    },
+  },
 }));
 
 jest.mock("../../stripe", () => ({
@@ -87,8 +103,10 @@ const request = () => ({ url: "https://hackerai.test/api/delete-account" });
 
 describe("POST /api/delete-account", () => {
   beforeEach(() => {
+    process.env.CONVEX_SERVICE_ROLE_KEY = "service_key";
     mockGetUserIDWithFreshLogin.mockResolvedValue("user_123");
     mockDeleteUserRateLimitKeys.mockResolvedValue(undefined);
+    mockConvexMutation.mockResolvedValue(null);
     mockDeleteOrganizationMembership.mockResolvedValue(undefined as never);
     mockDeleteUser.mockResolvedValue(undefined as never);
     mockDeleteOrganization.mockResolvedValue(undefined as never);
@@ -121,6 +139,13 @@ describe("POST /api/delete-account", () => {
     const response = await POST(request() as any);
 
     expect(response.status).toBe(200);
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "userDeletion.deleteAllUserDataByService",
+      {
+        serviceKey: "service_key",
+        userId: "user_123",
+      },
+    );
     expect(mockDeleteOrganizationMembership).toHaveBeenCalledWith(
       "membership_user",
     );
@@ -130,6 +155,12 @@ describe("POST /api/delete-account", () => {
     expect(mockDeleteCustomer).not.toHaveBeenCalled();
     expect(mockDeleteOrganization).not.toHaveBeenCalled();
     expect(mockDeleteUser).toHaveBeenCalledWith("user_123");
+    expect(mockConvexMutation.mock.invocationCallOrder[0]).toBeLessThan(
+      mockDeleteOrganizationMembership.mock.invocationCallOrder[0],
+    );
+    expect(mockConvexMutation.mock.invocationCallOrder[0]).toBeLessThan(
+      mockDeleteUser.mock.invocationCallOrder[0],
+    );
   });
 
   it("deletes billing and organization resources for a solo admin organization", async () => {
@@ -154,6 +185,13 @@ describe("POST /api/delete-account", () => {
     const response = await POST(request() as any);
 
     expect(response.status).toBe(200);
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "userDeletion.deleteAllUserDataByService",
+      {
+        serviceKey: "service_key",
+        userId: "user_123",
+      },
+    );
     expect(mockListSubscriptions).toHaveBeenCalledWith({
       customer: "cus_123",
       status: "all",
@@ -165,6 +203,47 @@ describe("POST /api/delete-account", () => {
     expect(mockDeleteOrganization).toHaveBeenCalledWith("org_solo");
     expect(mockDeleteOrganizationMembership).not.toHaveBeenCalled();
     expect(mockDeleteUser).toHaveBeenCalledWith("user_123");
+  });
+
+  it("runs Convex cleanup before deleting a WorkOS user with no memberships", async () => {
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [],
+    } as never);
+
+    const response = await POST(request() as any);
+
+    expect(response.status).toBe(200);
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "userDeletion.deleteAllUserDataByService",
+      {
+        serviceKey: "service_key",
+        userId: "user_123",
+      },
+    );
+    expect(mockConvexMutation.mock.invocationCallOrder[0]).toBeLessThan(
+      mockDeleteUser.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not delete WorkOS or billing resources if Convex cleanup fails", async () => {
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [],
+    } as never);
+    mockConvexMutation.mockRejectedValueOnce(
+      new Error("Convex cleanup failed"),
+    );
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("Convex cleanup failed");
+    expect(mockDeleteOrganizationMembership).not.toHaveBeenCalled();
+    expect(mockListSubscriptions).not.toHaveBeenCalled();
+    expect(mockDeleteCustomer).not.toHaveBeenCalled();
+    expect(mockDeleteOrganization).not.toHaveBeenCalled();
+    expect(mockDeleteUserRateLimitKeys).not.toHaveBeenCalled();
+    expect(mockDeleteUser).not.toHaveBeenCalled();
   });
 
   it("does not delete org billing when a shared-org admin deletes their account", async () => {
@@ -205,6 +284,13 @@ describe("POST /api/delete-account", () => {
     expect(mockDeleteCustomer).not.toHaveBeenCalled();
     expect(mockDeleteOrganization).not.toHaveBeenCalled();
     expect(mockDeleteUser).toHaveBeenCalledWith("user_123");
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "userDeletion.deleteAllUserDataByService",
+      {
+        serviceKey: "service_key",
+        userId: "user_123",
+      },
+    );
   });
 
   it("blocks deletion when the caller is the last admin of a shared organization", async () => {
@@ -237,6 +323,7 @@ describe("POST /api/delete-account", () => {
     expect(mockDeleteOrganizationMembership).not.toHaveBeenCalled();
     expect(mockListSubscriptions).not.toHaveBeenCalled();
     expect(mockDeleteOrganization).not.toHaveBeenCalled();
+    expect(mockConvexMutation).not.toHaveBeenCalled();
     expect(mockDeleteUser).not.toHaveBeenCalled();
   });
 });

--- a/app/api/delete-account/route.ts
+++ b/app/api/delete-account/route.ts
@@ -4,6 +4,8 @@ import { workos } from "../workos";
 import { getUserIDWithFreshLogin } from "@/lib/auth/get-user-id";
 import { deleteUserRateLimitKeys } from "@/lib/rate-limit/token-bucket";
 import { ChatSDKError } from "@/lib/errors";
+import { getConvexClient } from "@/lib/db/convex-client";
+import { api } from "@/convex/_generated/api";
 
 type OrganizationMembership = Awaited<
   ReturnType<typeof workos.userManagement.listOrganizationMemberships>
@@ -73,6 +75,21 @@ async function getMembershipDeletionPlan(
   }
 }
 
+async function deleteConvexUserData(userId: string) {
+  const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY;
+  if (!serviceKey) {
+    throw new Error("CONVEX_SERVICE_ROLE_KEY is not set");
+  }
+
+  await getConvexClient().mutation(
+    api.userDeletion.deleteAllUserDataByService,
+    {
+      serviceKey,
+      userId,
+    },
+  );
+}
+
 export const POST = async (req: NextRequest) => {
   try {
     // Enforce recent login (10-minute window) before any destructive action
@@ -99,6 +116,10 @@ export const POST = async (req: NextRequest) => {
         { status: 400 },
       );
     }
+
+    // Own app-data cleanup on the server so account deletion does not depend
+    // on the browser successfully running a Convex mutation before this route.
+    await deleteConvexUserData(userId);
 
     // Process each organization from memberships. Only delete org-level billing
     // and identity resources after proving this user is the sole active admin.

--- a/app/components/DeleteAccountDialog.tsx
+++ b/app/components/DeleteAccountDialog.tsx
@@ -2,8 +2,6 @@
 
 import React, { useEffect, useMemo, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
-import { useMutation } from "convex/react";
-import { api } from "@/convex/_generated/api";
 import {
   Dialog,
   DialogContent,
@@ -28,7 +26,6 @@ export const DeleteAccountDialog = ({
   onOpenChange,
 }: DeleteAccountDialogProps) => {
   const { user } = useAuth();
-  const deleteAllUserData = useMutation(api.userDeletion.deleteAllUserData);
   const [isDeleting, setIsDeleting] = useState(false);
   const [emailInput, setEmailInput] = useState("");
   const [confirmInput, setConfirmInput] = useState("");
@@ -79,15 +76,14 @@ export const DeleteAccountDialog = ({
     if (isDeleting || !canDelete) return;
     setIsDeleting(true);
     try {
-      // 1) Delete all Convex data first
-      await deleteAllUserData({});
-      // 2) Cancel Stripe subs, remove WorkOS org(s), and delete WorkOS user server-side
+      // Delete Convex data, cancel Stripe subs, remove WorkOS org(s), and
+      // delete the WorkOS user server-side.
       const res = await fetch("/api/delete-account", { method: "POST" });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         throw new Error(data?.error || "Failed to cancel subscriptions");
       }
-      // 3) Clear HttpOnly auth cookies on the server, then redirect home
+      // Clear HttpOnly auth cookies on the server, then redirect home
       try {
         await fetch("/api/clear-auth-cookies", { method: "POST" });
       } catch {}

--- a/app/components/__tests__/DeleteAccountDialog.test.tsx
+++ b/app/components/__tests__/DeleteAccountDialog.test.tsx
@@ -4,22 +4,8 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import DeleteAccountDialog from "../DeleteAccountDialog";
 
-const mockDeleteAllUserData = jest.fn();
-
 jest.mock("@workos-inc/authkit-nextjs/components", () => ({
   useAuth: jest.fn(),
-}));
-
-jest.mock("convex/react", () => ({
-  useMutation: () => mockDeleteAllUserData,
-}));
-
-jest.mock("@/convex/_generated/api", () => ({
-  api: {
-    userDeletion: {
-      deleteAllUserData: "userDeletion.deleteAllUserData",
-    },
-  },
 }));
 
 jest.mock("sonner", () => ({
@@ -48,7 +34,6 @@ describe("DeleteAccountDialog", () => {
         lastSignInAt: new Date().toISOString(),
       },
     } as ReturnType<typeof useAuth>);
-    mockDeleteAllUserData.mockReset();
   });
 
   it("keeps the delete button visible but disabled before confirmation", () => {

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -7,15 +7,19 @@ import {
   afterEach,
 } from "@jest/globals";
 
-// Mock dependencies
 jest.mock("../_generated/server", () => ({
   mutation: jest.fn((config) => config),
 }));
+
 jest.mock("convex/values", () => ({
-  v: {
-    null: jest.fn(() => "null"),
-  },
+  v: new Proxy(
+    {},
+    {
+      get: () => jest.fn(() => "validator"),
+    },
+  ),
 }));
+
 jest.mock("../_generated/api", () => ({
   internal: {
     s3Cleanup: {
@@ -32,9 +36,451 @@ jest.mock("../fileAggregate", () => ({
   fileCountAggregate: mockFileCountAggregate,
 }));
 
+type Row = { _id: string; [key: string]: any };
+type Tables = Record<string, Row[]>;
+
+function createQueryResult(rows: Row[]) {
+  return {
+    collect: jest.fn(async () => rows),
+    first: jest.fn(async () => rows[0] ?? null),
+    unique: jest.fn(async () => rows[0] ?? null),
+    take: jest.fn(async (limit: number) => rows.slice(0, limit)),
+    order: jest.fn(() => createQueryResult(rows)),
+  };
+}
+
+function createQueryBuilder(tables: Tables, table: string) {
+  const tableRows = () => tables[table] ?? [];
+
+  const filterRows = (filters: Array<{ field: string; value: any }>) =>
+    tableRows().filter((row) =>
+      filters.every(({ field, value }) => row[field] === value),
+    );
+
+  return {
+    withIndex: jest.fn((_indexName: string, build: (q: any) => any) => {
+      const filters: Array<{ field: string; value: any }> = [];
+      const q = {
+        eq: (field: string, value: any) => {
+          filters.push({ field, value });
+          return q;
+        },
+        gte: () => q,
+        lte: () => q,
+      };
+      build(q);
+      return createQueryResult(filterRows(filters));
+    }),
+    collect: jest.fn(async () => tableRows()),
+    take: jest.fn(async (limit: number) => tableRows().slice(0, limit)),
+    paginate: jest.fn(
+      async ({
+        cursor,
+        numItems,
+      }: {
+        cursor: string | null;
+        numItems: number;
+      }) => {
+        const start = cursor ? Number(cursor) : 0;
+        const page = tableRows().slice(start, start + numItems);
+        const next = start + page.length;
+        return {
+          page,
+          isDone: next >= tableRows().length,
+          continueCursor: next >= tableRows().length ? null : String(next),
+        };
+      },
+    ),
+  };
+}
+
+function createMockCtx(tables: Tables, subject = "user_123") {
+  const deletedIds: string[] = [];
+  const patches: Array<{ id: string; patch: Record<string, any> }> = [];
+  const scheduler = {
+    runAfter: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const db = {
+    query: jest.fn((table: string) => createQueryBuilder(tables, table)),
+    get: jest.fn(async (id: string) => {
+      for (const rows of Object.values(tables)) {
+        const row = rows.find((candidate) => candidate._id === id);
+        if (row) return row;
+      }
+      return null;
+    }),
+    delete: jest.fn(async (id: string) => {
+      deletedIds.push(id);
+      for (const [table, rows] of Object.entries(tables)) {
+        const next = rows.filter((row) => row._id !== id);
+        if (next.length !== rows.length) {
+          tables[table] = next;
+        }
+      }
+    }),
+    patch: jest.fn(async (id: string, patch: Record<string, any>) => {
+      patches.push({ id, patch });
+      for (const rows of Object.values(tables)) {
+        const row = rows.find((candidate) => candidate._id === id);
+        if (!row) continue;
+        for (const [key, value] of Object.entries(patch)) {
+          if (value === undefined) {
+            delete row[key];
+          } else {
+            row[key] = value;
+          }
+        }
+      }
+    }),
+  };
+
+  return {
+    ctx: {
+      auth: {
+        getUserIdentity: jest.fn().mockResolvedValue({ subject }),
+      },
+      db,
+      scheduler,
+    },
+    db,
+    scheduler,
+    deletedIds,
+    patches,
+  };
+}
+
+function seedTables(userId = "user_123", otherUserId = "user_other"): Tables {
+  return {
+    chats: [
+      {
+        _id: "chat-doc",
+        id: "chat-1",
+        user_id: userId,
+        title: "User chat",
+        latest_summary_id: "summary-latest",
+        update_time: 1,
+      },
+      {
+        _id: "chat-other",
+        id: "chat-other-id",
+        user_id: otherUserId,
+        title: "Other chat",
+        update_time: 1,
+      },
+    ],
+    chat_summaries: [
+      {
+        _id: "summary-by-chat",
+        chat_id: "chat-1",
+        summary_text: "delete",
+        summary_up_to_message_id: "msg-1",
+      },
+      {
+        _id: "summary-latest",
+        chat_id: "legacy-chat-id",
+        summary_text: "delete by latest ref",
+        summary_up_to_message_id: "msg-1",
+      },
+      {
+        _id: "summary-other",
+        chat_id: "chat-other-id",
+        summary_text: "keep",
+        summary_up_to_message_id: "msg-other",
+      },
+    ],
+    messages: [
+      {
+        _id: "message-user",
+        id: "msg-1",
+        chat_id: "chat-1",
+        user_id: userId,
+        role: "user",
+        parts: [],
+        feedback_id: "feedback-user",
+        update_time: 1,
+      },
+      {
+        _id: "message-other",
+        id: "msg-other",
+        chat_id: "chat-other-id",
+        user_id: otherUserId,
+        role: "user",
+        parts: [],
+        feedback_id: "feedback-other",
+        update_time: 1,
+      },
+    ],
+    feedback: [
+      { _id: "feedback-user", feedback_type: "positive" },
+      { _id: "feedback-other", feedback_type: "negative" },
+    ],
+    files: [
+      {
+        _id: "file-user",
+        user_id: userId,
+        s3_key: "users/user_123/file.pdf",
+        name: "file.pdf",
+        media_type: "application/pdf",
+        size: 1,
+        file_token_size: 1,
+        is_attached: true,
+      },
+      {
+        _id: "file-other",
+        user_id: otherUserId,
+        name: "other.txt",
+        media_type: "text/plain",
+        size: 1,
+        file_token_size: 1,
+        is_attached: false,
+      },
+    ],
+    notes: [
+      { _id: "note-user", user_id: userId, note_id: "note-1" },
+      { _id: "note-other", user_id: otherUserId, note_id: "note-2" },
+    ],
+    user_customization: [
+      { _id: "custom-user", user_id: userId, updated_at: 1 },
+      { _id: "custom-other", user_id: otherUserId, updated_at: 1 },
+    ],
+    extra_usage: [
+      {
+        _id: "extra-user",
+        user_id: userId,
+        balance_points: 100,
+        updated_at: 1,
+      },
+      {
+        _id: "extra-other",
+        user_id: otherUserId,
+        balance_points: 100,
+        updated_at: 1,
+      },
+    ],
+    team_member_usage: [
+      {
+        _id: "team-member-user",
+        organization_id: "org_team",
+        user_id: userId,
+        updated_at: 1,
+      },
+      {
+        _id: "team-member-other",
+        organization_id: "org_team",
+        user_id: otherUserId,
+        updated_at: 1,
+      },
+    ],
+    temp_streams: [
+      { _id: "stream-user", chat_id: "chat-1", user_id: userId },
+      { _id: "stream-other", chat_id: "chat-other-id", user_id: otherUserId },
+    ],
+    local_sandbox_tokens: [
+      { _id: "token-user", user_id: userId, token: "secret" },
+      { _id: "token-other", user_id: otherUserId, token: "keep" },
+    ],
+    local_sandbox_connections: [
+      { _id: "connection-user", user_id: userId, connection_id: "conn-1" },
+      {
+        _id: "connection-other",
+        user_id: otherUserId,
+        connection_id: "conn-2",
+      },
+    ],
+    cancellation_reason_details: [
+      {
+        _id: "cancel-detail-user",
+        cancellation_reason_id: "cancel-user",
+        user_id: userId,
+        reason_details: "personal freeform text",
+        created_at: 1,
+      },
+      {
+        _id: "cancel-detail-other",
+        cancellation_reason_id: "cancel-other",
+        user_id: otherUserId,
+        reason_details: "keep",
+        created_at: 1,
+      },
+    ],
+    cancellation_reasons: [
+      {
+        _id: "cancel-user",
+        user_id: userId,
+        reason_details_id: "cancel-detail-user",
+        updated_at: 1,
+      },
+      {
+        _id: "cancel-other",
+        user_id: otherUserId,
+        reason_details_id: "cancel-detail-other",
+        updated_at: 1,
+      },
+    ],
+    usage_logs: [
+      {
+        _id: "usage-user",
+        user_id: userId,
+        chat_id: "chat-1",
+        model: "model",
+        total_tokens: 10,
+      },
+      {
+        _id: "usage-other",
+        user_id: otherUserId,
+        chat_id: "chat-other-id",
+        model: "model",
+        total_tokens: 10,
+      },
+    ],
+    referral_codes: [
+      {
+        _id: "ref-code-user",
+        user_id: userId,
+        code: "ABC1234",
+        status: "active",
+        updated_at: 1,
+      },
+      {
+        _id: "ref-code-other",
+        user_id: otherUserId,
+        code: "XYZ1234",
+        status: "active",
+        updated_at: 1,
+      },
+    ],
+    referral_attributions: [
+      {
+        _id: "ref-attr-referred",
+        referred_user_id: userId,
+        referrer_user_id: otherUserId,
+        referral_code: "XYZ1234",
+        status: "attributed",
+        updated_at: 1,
+      },
+      {
+        _id: "ref-attr-referrer",
+        referred_user_id: otherUserId,
+        referrer_user_id: userId,
+        referral_code: "ABC1234",
+        status: "converted",
+        updated_at: 1,
+      },
+    ],
+    referral_rewards: [
+      {
+        _id: "ref-reward-user",
+        idempotency_key: "reward:user",
+        reward_type: "referred_signup",
+        status: "awarded",
+        user_id: userId,
+        amount_dollars: 1,
+        created_at: 1,
+      },
+      {
+        _id: "ref-reward-referrer",
+        idempotency_key: "reward:referrer",
+        reward_type: "referrer_conversion",
+        status: "awarded",
+        referrer_user_id: userId,
+        referred_user_id: otherUserId,
+        amount_dollars: 1,
+        created_at: 1,
+      },
+      {
+        _id: "ref-reward-referred",
+        idempotency_key: "reward:referred",
+        reward_type: "referred_signup",
+        status: "awarded",
+        referrer_user_id: otherUserId,
+        referred_user_id: userId,
+        amount_dollars: 1,
+        created_at: 1,
+      },
+    ],
+    user_suspensions: [
+      { _id: "suspension-user", user_id: userId, updated_at: 1 },
+      { _id: "suspension-other", user_id: otherUserId, updated_at: 1 },
+    ],
+    revenue_events: [
+      {
+        _id: "revenue-user-entity",
+        entity_type: "user",
+        entity_id: userId,
+        user_id: userId,
+        source: "subscription",
+      },
+      {
+        _id: "revenue-org-with-user",
+        entity_type: "organization",
+        entity_id: "org_team",
+        user_id: userId,
+        organization_id: "org_team",
+        source: "team_extra_usage",
+      },
+      {
+        _id: "revenue-other",
+        entity_type: "user",
+        entity_id: otherUserId,
+        user_id: otherUserId,
+        source: "subscription",
+      },
+    ],
+    paid_start_events: [
+      {
+        _id: "paid-user-entity",
+        entity_type: "user",
+        entity_id: userId,
+        user_id: userId,
+        day: "2026-06-21",
+      },
+      {
+        _id: "paid-org-with-user",
+        entity_type: "organization",
+        entity_id: "org_team",
+        user_id: userId,
+        organization_id: "org_team",
+        day: "2026-06-21",
+      },
+    ],
+    unit_economics_daily: [
+      {
+        _id: "unit-user-entity",
+        entity_type: "user",
+        entity_id: userId,
+        user_id: userId,
+        day: "2026-06-21",
+        updated_at: 1,
+      },
+      {
+        _id: "unit-org-with-user",
+        entity_type: "organization",
+        entity_id: "org_team",
+        user_id: userId,
+        organization_id: "org_team",
+        day: "2026-06-21",
+        updated_at: 1,
+      },
+    ],
+    team_extra_usage: [
+      { _id: "team-extra", organization_id: "org_team", balance_points: 1 },
+    ],
+    paid_start_mix_daily: [
+      { _id: "paid-mix", day: "2026-06-21", tier: "pro", plan: "pro" },
+    ],
+    processed_webhooks: [{ _id: "webhook", event_id: "evt_1" }],
+    processed_checkout_sessions: [{ _id: "checkout", session_key: "cs_1" }],
+  };
+}
+
+const row = (tables: Tables, table: string, id: string) =>
+  tables[table]?.find((candidate) => candidate._id === id);
+
 describe("userDeletion", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.CONVEX_SERVICE_ROLE_KEY = "service_key";
     jest.spyOn(console, "log").mockImplementation(() => {});
     jest.spyOn(console, "error").mockImplementation(() => {});
     jest.spyOn(console, "warn").mockImplementation(() => {});
@@ -44,432 +490,190 @@ describe("userDeletion", () => {
     jest.restoreAllMocks();
   });
 
-  describe("deleteAllUserData", () => {
-    it("should delete S3 files using batch deletion", async () => {
-      const { deleteAllUserData } = await import("../userDeletion");
+  it("deletes product data, anonymizes ledgers, and retains aggregate tables", async () => {
+    const { deleteAllUserData, DELETED_USER_ID, USER_DELETION_TABLE_POLICY } =
+      await import("../userDeletion");
+    const tables = seedTables();
+    const { ctx, scheduler, deletedIds } = createMockCtx(tables);
 
-      const mockScheduler = {
-        runAfter: jest.fn(),
-      };
+    await deleteAllUserData.handler(ctx as any, {});
 
-      const mockDb = {
-        query: jest.fn(),
-        delete: jest.fn(),
-      };
+    for (const table of USER_DELETION_TABLE_POLICY.delete) {
+      expect(
+        (tables[table] ?? []).some((candidate) =>
+          Object.values(candidate).includes("user_123"),
+        ),
+      ).toBe(false);
+    }
 
-      const mockAuth = {
-        getUserIdentity: jest.fn().mockResolvedValue({
-          subject: "user123",
-        }),
-      };
+    expect(row(tables, "chats", "chat-other")).toBeTruthy();
+    expect(row(tables, "feedback", "feedback-other")).toBeTruthy();
+    expect(row(tables, "files", "file-other")).toBeTruthy();
 
-      // Mock files with S3 objects and one DB-only file row.
-      const mockFiles = [
-        {
-          _id: "file1",
-          s3_key: "users/user123/file1.pdf",
-          user_id: "user123",
-          name: "file1.pdf",
-          media_type: "application/pdf",
-          size: 1000,
-          file_token_size: 100,
-          is_attached: true,
-        },
-        {
-          _id: "file2",
-          s3_key: "users/user123/file2.jpg",
-          user_id: "user123",
-          name: "file2.jpg",
-          media_type: "image/jpeg",
-          size: 2000,
-          file_token_size: 200,
-          is_attached: true,
-        },
-        {
-          _id: "file3",
-          user_id: "user123",
-          name: "file3.txt",
-          media_type: "text/plain",
-          size: 500,
-          file_token_size: 50,
-          is_attached: true,
-        },
-      ];
-
-      // Setup query mocks
-      const mockQueryBuilder = {
-        withIndex: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        collect: jest.fn(),
-        first: jest.fn(),
-      };
-
-      mockDb.query.mockReturnValue(mockQueryBuilder);
-
-      // Mock query results
-      mockQueryBuilder.collect
-        .mockResolvedValueOnce([]) // chats
-        .mockResolvedValueOnce(mockFiles) // files
-        .mockResolvedValueOnce([]) // notes
-        .mockResolvedValueOnce([]); // messages
-
-      mockQueryBuilder.first.mockResolvedValue(null); // user_customization
-
-      const mockCtx = {
-        auth: mockAuth,
-        db: mockDb,
-        scheduler: mockScheduler,
-      };
-
-      await deleteAllUserData.handler(mockCtx, {});
-
-      // Verify S3 files were collected and scheduled for batch deletion
-      expect(mockScheduler.runAfter).toHaveBeenCalledWith(
-        0,
-        "deleteS3ObjectsBatchAction",
-        {
-          s3Keys: ["users/user123/file1.pdf", "users/user123/file2.jpg"],
-        },
-      );
-
-      // Verify all file records were deleted
-      expect(mockDb.delete).toHaveBeenCalledWith("file1");
-      expect(mockDb.delete).toHaveBeenCalledWith("file2");
-      expect(mockDb.delete).toHaveBeenCalledWith("file3");
-
-      // Verify success log
-      expect(console.log).toHaveBeenCalledWith(
-        "Scheduled deletion of 2 S3 objects for user user123",
-      );
+    expect(row(tables, "cancellation_reasons", "cancel-user")).toMatchObject({
+      user_id: DELETED_USER_ID,
+    });
+    expect(
+      row(tables, "cancellation_reasons", "cancel-user")?.reason_details_id,
+    ).toBeUndefined();
+    expect(row(tables, "usage_logs", "usage-user")).toMatchObject({
+      user_id: DELETED_USER_ID,
+    });
+    expect(row(tables, "usage_logs", "usage-user")?.chat_id).toBeUndefined();
+    expect(row(tables, "referral_codes", "ref-code-user")).toMatchObject({
+      user_id: DELETED_USER_ID,
+      status: "deactivated",
+      deactivated_reason: "account_deleted",
+    });
+    expect(
+      row(tables, "referral_attributions", "ref-attr-referred"),
+    ).toMatchObject({
+      referred_user_id: DELETED_USER_ID,
+      referrer_user_id: "user_other",
+    });
+    expect(
+      row(tables, "referral_attributions", "ref-attr-referrer"),
+    ).toMatchObject({
+      referred_user_id: "user_other",
+      referrer_user_id: DELETED_USER_ID,
+    });
+    expect(
+      row(tables, "referral_rewards", "ref-reward-user")?.user_id,
+    ).toBeUndefined();
+    expect(
+      row(tables, "referral_rewards", "ref-reward-referrer")?.referrer_user_id,
+    ).toBeUndefined();
+    expect(
+      row(tables, "referral_rewards", "ref-reward-referred")?.referred_user_id,
+    ).toBeUndefined();
+    expect(row(tables, "user_suspensions", "suspension-user")).toMatchObject({
+      user_id: DELETED_USER_ID,
+    });
+    expect(row(tables, "revenue_events", "revenue-user-entity")).toMatchObject({
+      entity_id: DELETED_USER_ID,
+    });
+    expect(
+      row(tables, "revenue_events", "revenue-user-entity")?.user_id,
+    ).toBeUndefined();
+    expect(
+      row(tables, "revenue_events", "revenue-org-with-user")?.user_id,
+    ).toBeUndefined();
+    expect(row(tables, "paid_start_events", "paid-user-entity")).toMatchObject({
+      entity_id: DELETED_USER_ID,
+    });
+    expect(
+      row(tables, "unit_economics_daily", "unit-user-entity"),
+    ).toMatchObject({
+      entity_id: DELETED_USER_ID,
     });
 
-    it("should handle file rows without S3 keys", async () => {
-      const { deleteAllUserData } = await import("../userDeletion");
+    for (const table of USER_DELETION_TABLE_POLICY.retain) {
+      expect(tables[table]).toHaveLength(1);
+    }
 
-      const mockScheduler = {
-        runAfter: jest.fn(),
-      };
+    expect(mockFileCountAggregate.deleteIfExists).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ _id: "file-user" }),
+    );
+    expect(scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      "deleteS3ObjectsBatchAction",
+      { s3Keys: ["users/user_123/file.pdf"] },
+    );
 
-      const mockDb = {
-        query: jest.fn(),
-        delete: jest.fn(),
-      };
+    expect(deletedIds.indexOf("feedback-user")).toBeLessThan(
+      deletedIds.indexOf("message-user"),
+    );
+    expect(deletedIds.indexOf("summary-by-chat")).toBeLessThan(
+      deletedIds.indexOf("chat-doc"),
+    );
+  });
 
-      const mockAuth = {
-        getUserIdentity: jest.fn().mockResolvedValue({
-          subject: "user123",
-        }),
-      };
+  it("deletes user data through the service-key mutation without auth", async () => {
+    const { deleteAllUserDataByService } = await import("../userDeletion");
+    const tables = seedTables("service_user");
+    const { ctx } = createMockCtx(tables, "ignored-auth-user");
 
-      const mockFiles = [
-        {
-          _id: "file1",
-          user_id: "user123",
-          name: "file1.txt",
-          media_type: "text/plain",
-          size: 500,
-          file_token_size: 50,
-          is_attached: true,
-        },
-      ];
-
-      const mockQueryBuilder = {
-        withIndex: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        collect: jest.fn(),
-        first: jest.fn(),
-      };
-
-      mockDb.query.mockReturnValue(mockQueryBuilder);
-
-      mockQueryBuilder.collect
-        .mockResolvedValueOnce([]) // chats
-        .mockResolvedValueOnce(mockFiles) // files
-        .mockResolvedValueOnce([]) // notes
-        .mockResolvedValueOnce([]); // messages
-
-      mockQueryBuilder.first.mockResolvedValue(null);
-
-      const mockCtx = {
-        auth: mockAuth,
-        db: mockDb,
-        scheduler: mockScheduler,
-      };
-
-      await deleteAllUserData.handler(mockCtx, {});
-
-      // Verify S3 batch deletion was NOT scheduled (no S3 files)
-      expect(mockScheduler.runAfter).not.toHaveBeenCalled();
-
-      // Verify file record was deleted
-      expect(mockDb.delete).toHaveBeenCalledWith("file1");
+    await deleteAllUserDataByService.handler(ctx as any, {
+      serviceKey: "service_key",
+      userId: "service_user",
     });
 
-    it("should handle only S3 files", async () => {
-      const { deleteAllUserData } = await import("../userDeletion");
+    expect(row(tables, "chats", "chat-doc")).toBeUndefined();
+  });
 
-      const mockScheduler = {
-        runAfter: jest.fn(),
-      };
+  it("rejects service-key cleanup with an invalid key", async () => {
+    const { deleteAllUserDataByService } = await import("../userDeletion");
+    const tables = seedTables();
+    const { ctx } = createMockCtx(tables);
 
-      const mockDb = {
-        query: jest.fn(),
-        delete: jest.fn(),
-      };
+    await expect(
+      deleteAllUserDataByService.handler(ctx as any, {
+        serviceKey: "wrong",
+        userId: "user_123",
+      }),
+    ).rejects.toThrow("Unauthorized: Invalid service key");
 
-      const mockAuth = {
-        getUserIdentity: jest.fn().mockResolvedValue({
-          subject: "user456",
-        }),
-      };
+    expect(row(tables, "chats", "chat-doc")).toBeTruthy();
+  });
 
-      const mockFiles = [
-        {
-          _id: "file1",
-          s3_key: "users/user456/file1.pdf",
-          user_id: "user456",
-          name: "file1.pdf",
-          media_type: "application/pdf",
-          size: 1000,
-          file_token_size: 100,
-          is_attached: true,
-        },
-      ];
+  it("dry-runs and executes orphan chat summary residue cleanup", async () => {
+    const { cleanupDeletedUserResidue } = await import("../userDeletion");
+    const tables = seedTables();
+    tables.chat_summaries.push({
+      _id: "summary-orphan",
+      chat_id: "missing-chat",
+      summary_text: "orphan",
+      summary_up_to_message_id: "msg-missing",
+    });
+    const { ctx } = createMockCtx(tables);
 
-      const mockQueryBuilder = {
-        withIndex: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        collect: jest.fn(),
-        first: jest.fn(),
-      };
-
-      mockDb.query.mockReturnValue(mockQueryBuilder);
-
-      mockQueryBuilder.collect
-        .mockResolvedValueOnce([]) // chats
-        .mockResolvedValueOnce(mockFiles) // files
-        .mockResolvedValueOnce([]) // notes
-        .mockResolvedValueOnce([]); // messages
-
-      mockQueryBuilder.first.mockResolvedValue(null);
-
-      const mockCtx = {
-        auth: mockAuth,
-        db: mockDb,
-        scheduler: mockScheduler,
-      };
-
-      await deleteAllUserData.handler(mockCtx, {});
-
-      // Verify S3 batch deletion was scheduled
-      expect(mockScheduler.runAfter).toHaveBeenCalledWith(
-        0,
-        "deleteS3ObjectsBatchAction",
-        { s3Keys: ["users/user456/file1.pdf"] },
-      );
-
-      // Verify file record was deleted
-      expect(mockDb.delete).toHaveBeenCalledWith("file1");
+    const dryRun = await cleanupDeletedUserResidue.handler(ctx as any, {
+      serviceKey: "service_key",
+      deleteOrphanChatSummaries: true,
+      orphanNumItems: 20,
     });
 
-    it("should not fail user deletion if S3 cleanup scheduling fails", async () => {
-      const { deleteAllUserData } = await import("../userDeletion");
+    expect(dryRun.orphanChatSummariesDeleted).toBe(1);
+    expect(row(tables, "chat_summaries", "summary-orphan")).toBeTruthy();
+    expect(row(tables, "chat_summaries", "summary-latest")).toBeTruthy();
 
-      const mockScheduler = {
-        runAfter: jest.fn().mockRejectedValue(new Error("Scheduler error")),
-      };
-
-      const mockDb = {
-        query: jest.fn(),
-        delete: jest.fn(),
-      };
-
-      const mockAuth = {
-        getUserIdentity: jest.fn().mockResolvedValue({
-          subject: "user789",
-        }),
-      };
-
-      const mockFiles = [
-        {
-          _id: "file1",
-          s3_key: "users/user789/file1.pdf",
-          user_id: "user789",
-          name: "file1.pdf",
-          media_type: "application/pdf",
-          size: 1000,
-          file_token_size: 100,
-          is_attached: true,
-        },
-      ];
-
-      const mockQueryBuilder = {
-        withIndex: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        collect: jest.fn(),
-        first: jest.fn(),
-      };
-
-      mockDb.query.mockReturnValue(mockQueryBuilder);
-
-      mockQueryBuilder.collect
-        .mockResolvedValueOnce([]) // chats
-        .mockResolvedValueOnce(mockFiles) // files
-        .mockResolvedValueOnce([]) // notes
-        .mockResolvedValueOnce([]); // messages
-
-      mockQueryBuilder.first.mockResolvedValue(null);
-
-      const mockCtx = {
-        auth: mockAuth,
-        db: mockDb,
-        scheduler: mockScheduler,
-      };
-
-      // Should not throw even if S3 cleanup scheduling fails
-      await expect(
-        deleteAllUserData.handler(mockCtx, {}),
-      ).resolves.not.toThrow();
-
-      // Verify error was logged
-      expect(console.error).toHaveBeenCalledWith(
-        "Failed to schedule S3 batch deletion:",
-        expect.any(Error),
-      );
-
-      // Verify file record was still deleted
-      expect(mockDb.delete).toHaveBeenCalledWith("file1");
+    const execute = await cleanupDeletedUserResidue.handler(ctx as any, {
+      serviceKey: "service_key",
+      deleteOrphanChatSummaries: true,
+      dryRun: false,
+      orphanNumItems: 20,
     });
 
-    it("should handle empty file list", async () => {
-      const { deleteAllUserData } = await import("../userDeletion");
+    expect(execute.orphanChatSummariesDeleted).toBe(1);
+    expect(row(tables, "chat_summaries", "summary-orphan")).toBeUndefined();
+    expect(row(tables, "chat_summaries", "summary-latest")).toBeTruthy();
+    expect(row(tables, "chat_summaries", "summary-other")).toBeTruthy();
+  });
 
-      const mockScheduler = {
-        runAfter: jest.fn(),
-      };
+  it("does not fail user deletion if S3 cleanup scheduling fails", async () => {
+    const { deleteAllUserData } = await import("../userDeletion");
+    const tables = seedTables();
+    const { ctx, scheduler } = createMockCtx(tables);
+    scheduler.runAfter.mockRejectedValueOnce(new Error("Scheduler error"));
 
-      const mockDb = {
-        query: jest.fn(),
-        delete: jest.fn(),
-      };
+    await expect(deleteAllUserData.handler(ctx as any, {})).resolves.toBeNull();
 
-      const mockAuth = {
-        getUserIdentity: jest.fn().mockResolvedValue({
-          subject: "user000",
-        }),
-      };
+    expect(console.error).toHaveBeenCalledWith(
+      "Failed to schedule S3 batch deletion:",
+      expect.any(Error),
+    );
+    expect(row(tables, "files", "file-user")).toBeUndefined();
+  });
 
-      const mockQueryBuilder = {
-        withIndex: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        collect: jest.fn(),
-        first: jest.fn(),
-      };
+  it("throws if the public mutation has no authenticated user", async () => {
+    const { deleteAllUserData } = await import("../userDeletion");
+    const tables = seedTables();
+    const { ctx } = createMockCtx(tables);
+    ctx.auth.getUserIdentity.mockResolvedValueOnce(null);
 
-      mockDb.query.mockReturnValue(mockQueryBuilder);
-
-      mockQueryBuilder.collect
-        .mockResolvedValueOnce([]) // chats
-        .mockResolvedValueOnce([]) // files - empty
-        .mockResolvedValueOnce([]) // notes
-        .mockResolvedValueOnce([]); // messages
-
-      mockQueryBuilder.first.mockResolvedValue(null);
-
-      const mockCtx = {
-        auth: mockAuth,
-        db: mockDb,
-        scheduler: mockScheduler,
-      };
-
-      await deleteAllUserData.handler(mockCtx, {});
-
-      // Verify S3 batch deletion was NOT scheduled (no files)
-      expect(mockScheduler.runAfter).not.toHaveBeenCalled();
-    });
-
-    it("should delete chat summaries before deleting chats", async () => {
-      const { deleteAllUserData } = await import("../userDeletion");
-
-      const mockScheduler = {
-        runAfter: jest.fn(),
-      };
-
-      const mockChats = [
-        {
-          _id: "chat-doc-1",
-          id: "chat-1",
-          user_id: "user123",
-          title: "Chat 1",
-          update_time: 1000,
-          latest_summary_id: "summary-1",
-        },
-      ];
-      const mockSummaries = [
-        { _id: "summary-1", chat_id: "chat-1" },
-        { _id: "summary-2", chat_id: "chat-1" },
-      ];
-
-      const mockDb = {
-        query: jest.fn((table: string) => ({
-          withIndex: jest.fn().mockReturnValue({
-            collect: jest
-              .fn()
-              .mockResolvedValue(
-                table === "chats"
-                  ? mockChats
-                  : table === "chat_summaries"
-                    ? mockSummaries
-                    : [],
-              ),
-            first: jest.fn().mockResolvedValue(null),
-          }),
-        })),
-        delete: jest.fn(),
-      };
-
-      const mockAuth = {
-        getUserIdentity: jest.fn().mockResolvedValue({
-          subject: "user123",
-        }),
-      };
-
-      const mockCtx = {
-        auth: mockAuth,
-        db: mockDb,
-        scheduler: mockScheduler,
-      };
-
-      await deleteAllUserData.handler(mockCtx, {});
-
-      expect(mockDb.query).toHaveBeenCalledWith("chat_summaries");
-      expect(mockDb.delete).toHaveBeenCalledWith("summary-1");
-      expect(mockDb.delete).toHaveBeenCalledWith("summary-2");
-      expect(mockDb.delete).toHaveBeenCalledWith("chat-doc-1");
-
-      const deleteOrder = mockDb.delete.mock.calls.map(([id]) => id);
-      expect(deleteOrder.indexOf("summary-1")).toBeLessThan(
-        deleteOrder.indexOf("chat-doc-1"),
-      );
-      expect(deleteOrder.indexOf("summary-2")).toBeLessThan(
-        deleteOrder.indexOf("chat-doc-1"),
-      );
-    });
-
-    it("should throw error if user is not authenticated", async () => {
-      const { deleteAllUserData } = await import("../userDeletion");
-
-      const mockAuth = {
-        getUserIdentity: jest.fn().mockResolvedValue(null),
-      };
-
-      const mockCtx = {
-        auth: mockAuth,
-      };
-
-      await expect(deleteAllUserData.handler(mockCtx, {})).rejects.toThrow(
-        "Unauthorized: User not authenticated",
-      );
-    });
+    await expect(deleteAllUserData.handler(ctx as any, {})).rejects.toThrow(
+      "Unauthorized: User not authenticated",
+    );
   });
 });

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -651,19 +651,50 @@ describe("userDeletion", () => {
     expect(row(tables, "chat_summaries", "summary-other")).toBeTruthy();
   });
 
-  it("does not fail user deletion if S3 cleanup scheduling fails", async () => {
+  it("rejects bulk deleted-user residue cleanup in one transaction", async () => {
+    const { cleanupDeletedUserResidue } = await import("../userDeletion");
+    const tables = seedTables();
+    const { ctx } = createMockCtx(tables);
+
+    await expect(
+      cleanupDeletedUserResidue.handler(ctx as any, {
+        serviceKey: "service_key",
+        userIds: ["user_123", "user_other"],
+      }),
+    ).rejects.toThrow("processes one userId per mutation");
+  });
+
+  it("fails before cleanup when an indexed query exceeds the bounded read limit", async () => {
+    const { deleteAllUserData } = await import("../userDeletion");
+    const tables = seedTables();
+    tables.notes = Array.from({ length: 501 }, (_, index) => ({
+      _id: `note-user-${index}`,
+      user_id: "user_123",
+      note_id: `note-${index}`,
+    }));
+    const { ctx } = createMockCtx(tables);
+
+    await expect(deleteAllUserData.handler(ctx as any, {})).rejects.toThrow(
+      "matched more than 500 rows in notes.by_user_and_updated",
+    );
+    expect(row(tables, "chats", "chat-doc")).toBeTruthy();
+  });
+
+  it("fails user deletion if S3 cleanup scheduling fails", async () => {
     const { deleteAllUserData } = await import("../userDeletion");
     const tables = seedTables();
     const { ctx, scheduler } = createMockCtx(tables);
     scheduler.runAfter.mockRejectedValueOnce(new Error("Scheduler error"));
 
-    await expect(deleteAllUserData.handler(ctx as any, {})).resolves.toBeNull();
-
-    expect(console.error).toHaveBeenCalledWith(
-      "Failed to schedule S3 batch deletion:",
-      expect.any(Error),
+    await expect(deleteAllUserData.handler(ctx as any, {})).rejects.toThrow(
+      "Scheduler error",
     );
-    expect(row(tables, "files", "file-user")).toBeUndefined();
+
+    expect(scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      "deleteS3ObjectsBatchAction",
+      { s3Keys: ["users/user_123/file.pdf"] },
+    );
   });
 
   it("throws if the public mutation has no authenticated user", async () => {

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -634,7 +634,7 @@ describe("userDeletion", () => {
       orphanNumItems: 20,
     });
 
-    expect(dryRun.orphanChatSummariesDeleted).toBe(1);
+    expect(dryRun.orphanChatSummariesDeleted).toBe(2);
     expect(row(tables, "chat_summaries", "summary-orphan")).toBeTruthy();
     expect(row(tables, "chat_summaries", "summary-latest")).toBeTruthy();
 
@@ -645,9 +645,9 @@ describe("userDeletion", () => {
       orphanNumItems: 20,
     });
 
-    expect(execute.orphanChatSummariesDeleted).toBe(1);
+    expect(execute.orphanChatSummariesDeleted).toBe(2);
     expect(row(tables, "chat_summaries", "summary-orphan")).toBeUndefined();
-    expect(row(tables, "chat_summaries", "summary-latest")).toBeTruthy();
+    expect(row(tables, "chat_summaries", "summary-latest")).toBeUndefined();
     expect(row(tables, "chat_summaries", "summary-other")).toBeTruthy();
   });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -50,6 +50,7 @@ export default defineSchema({
     ])
     .index("by_user_and_pinned", ["user_id", "pinned_at"])
     .index("by_share_id", ["share_id"])
+    .index("by_latest_summary_id", ["latest_summary_id"])
     .searchIndex("search_title", {
       searchField: "title",
       filterFields: ["user_id"],
@@ -289,7 +290,8 @@ export default defineSchema({
     updated_at: v.number(),
   })
     .index("by_org", ["organization_id"])
-    .index("by_org_user", ["organization_id", "user_id"]),
+    .index("by_org_user", ["organization_id", "user_id"])
+    .index("by_user_id", ["user_id"]),
 
   referral_codes: defineTable({
     user_id: v.string(),
@@ -387,6 +389,7 @@ export default defineSchema({
     notification_seen_at: v.optional(v.number()),
   })
     .index("by_idempotency_key", ["idempotency_key"])
+    .index("by_user_id", ["user_id"])
     .index("by_referrer_user_id", ["referrer_user_id"])
     .index("by_referrer_notification", [
       "referrer_user_id",
@@ -417,6 +420,7 @@ export default defineSchema({
     resolved_at: v.optional(v.number()),
     resolved_reason: v.optional(v.string()),
   })
+    .index("by_user_id", ["user_id"])
     .index("by_user_and_status", ["user_id", "status"])
     .index("by_user_status_source_created", [
       "user_id",
@@ -453,7 +457,9 @@ export default defineSchema({
   temp_streams: defineTable({
     chat_id: v.string(),
     user_id: v.string(),
-  }).index("by_chat_id", ["chat_id"]),
+  })
+    .index("by_chat_id", ["chat_id"])
+    .index("by_user_id", ["user_id"]),
 
   // Local Sandbox Tables
   local_sandbox_tokens: defineTable({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -50,7 +50,6 @@ export default defineSchema({
     ])
     .index("by_user_and_pinned", ["user_id", "pinned_at"])
     .index("by_share_id", ["share_id"])
-    .index("by_latest_summary_id", ["latest_summary_id"])
     .searchIndex("search_title", {
       searchField: "title",
       filterFields: ["user_id"],

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -582,15 +582,13 @@ async function cleanupOrphanChatSummaries(
 
   const orphanSummaries: Doc<"chat_summaries">[] = [];
   for (const summary of page.page as Doc<"chat_summaries">[]) {
-    const [chatByChatId, chatByLatestSummary] = await Promise.all([
-      firstByIndex<Doc<"chats">>(ctx, "chats", "by_chat_id", (q) =>
-        q.eq("id", summary.chat_id),
-      ),
-      firstByIndex<Doc<"chats">>(ctx, "chats", "by_latest_summary_id", (q) =>
-        q.eq("latest_summary_id", summary._id),
-      ),
-    ]);
-    if (!chatByChatId && !chatByLatestSummary) {
+    const chat = await firstByIndex<Doc<"chats">>(
+      ctx,
+      "chats",
+      "by_chat_id",
+      (q) => q.eq("id", summary.chat_id),
+    );
+    if (!chat) {
       orphanSummaries.push(summary);
     }
   }

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -45,6 +45,9 @@ export const USER_DELETION_TABLE_POLICY = {
 type AnyDoc = { _id: Id<any>; [key: string]: any };
 type CleanupMode = "execute" | "dryRun";
 
+const MAX_CLEANUP_DOCS_PER_INDEX = 500;
+const MAX_RESIDUE_USER_IDS_PER_MUTATION = 1;
+
 type CleanupStats = {
   deleted: Record<string, number>;
   anonymized: Record<string, number>;
@@ -109,9 +112,17 @@ async function collectByIndex<T extends AnyDoc>(
   indexName: string,
   build: (q: any) => any,
 ): Promise<T[]> {
-  return await (ctx.db.query(table as any) as any)
+  const rows = await (ctx.db.query(table as any) as any)
     .withIndex(indexName, build)
-    .collect();
+    .take(MAX_CLEANUP_DOCS_PER_INDEX + 1);
+
+  if (rows.length > MAX_CLEANUP_DOCS_PER_INDEX) {
+    throw new Error(
+      `Account cleanup matched more than ${MAX_CLEANUP_DOCS_PER_INDEX} rows in ${table}.${indexName}; run a narrower cleanup before deleting this account.`,
+    );
+  }
+
+  return rows;
 }
 
 async function firstByIndex<T extends AnyDoc>(
@@ -207,18 +218,14 @@ async function deleteFiles(
   }
 
   if (s3Keys.length > 0) {
-    try {
-      await ctx.scheduler.runAfter(
-        0,
-        internal.s3Cleanup.deleteS3ObjectsBatchAction,
-        { s3Keys },
-      );
-      console.log(
-        `Scheduled deletion of ${s3Keys.length} S3 objects for deleted user data cleanup`,
-      );
-    } catch (error) {
-      console.error("Failed to schedule S3 batch deletion:", error);
-    }
+    await ctx.scheduler.runAfter(
+      0,
+      internal.s3Cleanup.deleteS3ObjectsBatchAction,
+      { s3Keys },
+    );
+    console.log(
+      `Scheduled deletion of ${s3Keys.length} S3 objects for deleted user data cleanup`,
+    );
   }
 }
 
@@ -653,6 +660,12 @@ export const cleanupDeletedUserResidue = mutation({
     if (userIds.length === 0 && !args.deleteOrphanChatSummaries) {
       throw new Error(
         "Pass at least one userId or enable deleteOrphanChatSummaries",
+      );
+    }
+
+    if (userIds.length > MAX_RESIDUE_USER_IDS_PER_MUTATION) {
+      throw new Error(
+        "cleanupDeletedUserResidue processes one userId per mutation to keep Convex transactions bounded",
       );
     }
 

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -1,23 +1,601 @@
-import { mutation } from "./_generated/server";
+import { mutation, type MutationCtx } from "./_generated/server";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
+import type { Doc, Id } from "./_generated/dataModel";
 import { fileCountAggregate } from "./fileAggregate";
+import { validateServiceKey } from "./lib/utils";
+
+export const DELETED_USER_ID = "__deleted_user__";
+
+export const USER_DELETION_TABLE_POLICY = {
+  delete: [
+    "chats",
+    "chat_summaries",
+    "messages",
+    "files",
+    "feedback",
+    "notes",
+    "user_customization",
+    "extra_usage",
+    "team_member_usage",
+    "temp_streams",
+    "local_sandbox_tokens",
+    "local_sandbox_connections",
+    "cancellation_reason_details",
+  ],
+  anonymize: [
+    "usage_logs",
+    "cancellation_reasons",
+    "referral_codes",
+    "referral_attributions",
+    "referral_rewards",
+    "revenue_events",
+    "paid_start_events",
+    "unit_economics_daily",
+    "user_suspensions",
+  ],
+  retain: [
+    "team_extra_usage",
+    "paid_start_mix_daily",
+    "processed_webhooks",
+    "processed_checkout_sessions",
+  ],
+} as const;
+
+type AnyDoc = { _id: Id<any>; [key: string]: any };
+type CleanupMode = "execute" | "dryRun";
+
+type CleanupStats = {
+  deleted: Record<string, number>;
+  anonymized: Record<string, number>;
+  retained: Record<string, number>;
+  orphanChatSummariesDeleted: number;
+  orphanChatSummariesScanned: number;
+  orphanChatSummariesIsDone: boolean;
+  orphanChatSummariesContinueCursor?: string;
+  s3ObjectsQueued: number;
+};
+
+function createStats(): CleanupStats {
+  return {
+    deleted: {},
+    anonymized: {},
+    retained: Object.fromEntries(
+      USER_DELETION_TABLE_POLICY.retain.map((table) => [table, 0]),
+    ),
+    orphanChatSummariesDeleted: 0,
+    orphanChatSummariesScanned: 0,
+    orphanChatSummariesIsDone: true,
+    s3ObjectsQueued: 0,
+  };
+}
+
+function increment(
+  target: Record<string, number>,
+  table: string,
+  count: number,
+) {
+  if (count === 0) return;
+  target[table] = (target[table] ?? 0) + count;
+}
+
+function mergeStats(target: CleanupStats, source: CleanupStats) {
+  for (const [table, count] of Object.entries(source.deleted)) {
+    increment(target.deleted, table, count);
+  }
+  for (const [table, count] of Object.entries(source.anonymized)) {
+    increment(target.anonymized, table, count);
+  }
+  target.orphanChatSummariesDeleted += source.orphanChatSummariesDeleted;
+  target.orphanChatSummariesScanned += source.orphanChatSummariesScanned;
+  target.s3ObjectsQueued += source.s3ObjectsQueued;
+  target.orphanChatSummariesIsDone = source.orphanChatSummariesIsDone;
+  target.orphanChatSummariesContinueCursor =
+    source.orphanChatSummariesContinueCursor;
+}
+
+function uniqueDocs<T extends AnyDoc>(docs: Array<T | null | undefined>): T[] {
+  const byId = new Map<string, T>();
+  for (const doc of docs) {
+    if (!doc) continue;
+    byId.set(String(doc._id), doc);
+  }
+  return Array.from(byId.values());
+}
+
+async function collectByIndex<T extends AnyDoc>(
+  ctx: MutationCtx,
+  table: string,
+  indexName: string,
+  build: (q: any) => any,
+): Promise<T[]> {
+  return await (ctx.db.query(table as any) as any)
+    .withIndex(indexName, build)
+    .collect();
+}
+
+async function firstByIndex<T extends AnyDoc>(
+  ctx: MutationCtx,
+  table: string,
+  indexName: string,
+  build: (q: any) => any,
+): Promise<T | null> {
+  return await (ctx.db.query(table as any) as any)
+    .withIndex(indexName, build)
+    .first();
+}
+
+async function deleteDocs(
+  ctx: MutationCtx,
+  stats: CleanupStats,
+  table: string,
+  docs: Array<AnyDoc | null | undefined>,
+  mode: CleanupMode,
+) {
+  const unique = uniqueDocs(docs);
+  increment(stats.deleted, table, unique.length);
+  if (mode === "dryRun") return;
+
+  for (const doc of unique) {
+    await ctx.db.delete(doc._id);
+  }
+}
+
+async function anonymizeDocs(
+  ctx: MutationCtx,
+  stats: CleanupStats,
+  table: string,
+  docs: AnyDoc[],
+  patchForDoc: (doc: AnyDoc) => Record<string, any>,
+  mode: CleanupMode,
+) {
+  const unique = uniqueDocs(docs);
+  increment(stats.anonymized, table, unique.length);
+  if (mode === "dryRun") return;
+
+  for (const doc of unique) {
+    const patch = patchForDoc(doc);
+    if (Object.keys(patch).length > 0) {
+      await ctx.db.patch(doc._id, patch);
+    }
+  }
+}
+
+async function collectChatSummariesForChats(
+  ctx: MutationCtx,
+  chats: Doc<"chats">[],
+) {
+  const summariesByChat = await Promise.all(
+    chats.map((chat) =>
+      collectByIndex<Doc<"chat_summaries">>(
+        ctx,
+        "chat_summaries",
+        "by_chat_id",
+        (q) => q.eq("chat_id", chat.id),
+      ),
+    ),
+  );
+
+  const latestSummaries = await Promise.all(
+    chats.map((chat) =>
+      chat.latest_summary_id ? ctx.db.get(chat.latest_summary_id) : null,
+    ),
+  );
+
+  return uniqueDocs([...summariesByChat.flat(), ...latestSummaries]);
+}
+
+async function deleteFiles(
+  ctx: MutationCtx,
+  stats: CleanupStats,
+  files: Doc<"files">[],
+  mode: CleanupMode,
+) {
+  const unique = uniqueDocs(files);
+  increment(stats.deleted, "files", unique.length);
+
+  const s3Keys = unique
+    .map((file) => file.s3_key)
+    .filter((key): key is string => typeof key === "string" && key.length > 0);
+  stats.s3ObjectsQueued += s3Keys.length;
+
+  if (mode === "dryRun") return;
+
+  for (const file of unique) {
+    await fileCountAggregate.deleteIfExists(ctx, file);
+    await ctx.db.delete(file._id);
+  }
+
+  if (s3Keys.length > 0) {
+    try {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.s3Cleanup.deleteS3ObjectsBatchAction,
+        { s3Keys },
+      );
+      console.log(
+        `Scheduled deletion of ${s3Keys.length} S3 objects for deleted user data cleanup`,
+      );
+    } catch (error) {
+      console.error("Failed to schedule S3 batch deletion:", error);
+    }
+  }
+}
+
+async function cleanupUserDataForUser(
+  ctx: MutationCtx,
+  userId: string,
+  mode: CleanupMode,
+) {
+  const stats = createStats();
+  const now = Date.now();
+
+  const [
+    chats,
+    files,
+    notes,
+    customization,
+    messages,
+    tempStreams,
+    localSandboxTokens,
+    localSandboxConnections,
+    extraUsage,
+    teamMemberUsage,
+    cancellationReasonDetails,
+  ] = await Promise.all([
+    collectByIndex<Doc<"chats">>(ctx, "chats", "by_user_and_updated", (q) =>
+      q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"files">>(ctx, "files", "by_user_id", (q) =>
+      q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"notes">>(ctx, "notes", "by_user_and_updated", (q) =>
+      q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"user_customization">>(
+      ctx,
+      "user_customization",
+      "by_user_id",
+      (q) => q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"messages">>(ctx, "messages", "by_user_id", (q) =>
+      q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"temp_streams">>(
+      ctx,
+      "temp_streams",
+      "by_user_id",
+      (q) => q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"local_sandbox_tokens">>(
+      ctx,
+      "local_sandbox_tokens",
+      "by_user_id",
+      (q) => q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"local_sandbox_connections">>(
+      ctx,
+      "local_sandbox_connections",
+      "by_user_id",
+      (q) => q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"extra_usage">>(ctx, "extra_usage", "by_user_id", (q) =>
+      q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"team_member_usage">>(
+      ctx,
+      "team_member_usage",
+      "by_user_id",
+      (q) => q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"cancellation_reason_details">>(
+      ctx,
+      "cancellation_reason_details",
+      "by_user_id_and_created_at",
+      (q) => q.eq("user_id", userId),
+    ),
+  ]);
+
+  const feedbackIds = uniqueDocs(messages)
+    .map((message) => message.feedback_id)
+    .filter((id): id is Id<"feedback"> => !!id);
+  const feedback = await Promise.all(feedbackIds.map((id) => ctx.db.get(id)));
+  const chatSummaries = await collectChatSummariesForChats(ctx, chats);
+
+  await deleteDocs(ctx, stats, "feedback", feedback, mode);
+  await deleteDocs(ctx, stats, "messages", messages, mode);
+  await deleteDocs(ctx, stats, "chat_summaries", chatSummaries, mode);
+  await deleteDocs(ctx, stats, "chats", chats, mode);
+  await deleteFiles(ctx, stats, files, mode);
+  await deleteDocs(ctx, stats, "notes", notes, mode);
+  await deleteDocs(ctx, stats, "user_customization", customization, mode);
+  await deleteDocs(ctx, stats, "temp_streams", tempStreams, mode);
+  await deleteDocs(
+    ctx,
+    stats,
+    "local_sandbox_tokens",
+    localSandboxTokens,
+    mode,
+  );
+  await deleteDocs(
+    ctx,
+    stats,
+    "local_sandbox_connections",
+    localSandboxConnections,
+    mode,
+  );
+  await deleteDocs(ctx, stats, "extra_usage", extraUsage, mode);
+  await deleteDocs(ctx, stats, "team_member_usage", teamMemberUsage, mode);
+  await deleteDocs(
+    ctx,
+    stats,
+    "cancellation_reason_details",
+    cancellationReasonDetails,
+    mode,
+  );
+
+  const [
+    cancellationReasons,
+    usageLogs,
+    referralCodes,
+    referredAttributions,
+    referrerAttributions,
+    referralRewardsByUser,
+    referralRewardsByReferrer,
+    referralRewardsByReferred,
+    userSuspensions,
+    revenueByUser,
+    revenueByEntity,
+    paidStartsByUser,
+    paidStartsByEntity,
+    unitEconomicsByUser,
+    unitEconomicsByEntity,
+  ] = await Promise.all([
+    collectByIndex<Doc<"cancellation_reasons">>(
+      ctx,
+      "cancellation_reasons",
+      "by_user_started",
+      (q) => q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"usage_logs">>(ctx, "usage_logs", "by_user", (q) =>
+      q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"referral_codes">>(
+      ctx,
+      "referral_codes",
+      "by_user_id",
+      (q) => q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"referral_attributions">>(
+      ctx,
+      "referral_attributions",
+      "by_referred_user_id",
+      (q) => q.eq("referred_user_id", userId),
+    ),
+    collectByIndex<Doc<"referral_attributions">>(
+      ctx,
+      "referral_attributions",
+      "by_referrer_user_id",
+      (q) => q.eq("referrer_user_id", userId),
+    ),
+    collectByIndex<Doc<"referral_rewards">>(
+      ctx,
+      "referral_rewards",
+      "by_user_id",
+      (q) => q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"referral_rewards">>(
+      ctx,
+      "referral_rewards",
+      "by_referrer_user_id",
+      (q) => q.eq("referrer_user_id", userId),
+    ),
+    collectByIndex<Doc<"referral_rewards">>(
+      ctx,
+      "referral_rewards",
+      "by_referred_user_id",
+      (q) => q.eq("referred_user_id", userId),
+    ),
+    collectByIndex<Doc<"user_suspensions">>(
+      ctx,
+      "user_suspensions",
+      "by_user_id",
+      (q) => q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"revenue_events">>(
+      ctx,
+      "revenue_events",
+      "by_user_occurred",
+      (q) => q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"revenue_events">>(
+      ctx,
+      "revenue_events",
+      "by_entity_occurred",
+      (q) => q.eq("entity_type", "user").eq("entity_id", userId),
+    ),
+    collectByIndex<Doc<"paid_start_events">>(
+      ctx,
+      "paid_start_events",
+      "by_user_day",
+      (q) => q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"paid_start_events">>(
+      ctx,
+      "paid_start_events",
+      "by_entity_day",
+      (q) => q.eq("entity_type", "user").eq("entity_id", userId),
+    ),
+    collectByIndex<Doc<"unit_economics_daily">>(
+      ctx,
+      "unit_economics_daily",
+      "by_user_day",
+      (q) => q.eq("user_id", userId),
+    ),
+    collectByIndex<Doc<"unit_economics_daily">>(
+      ctx,
+      "unit_economics_daily",
+      "by_entity_day",
+      (q) => q.eq("entity_type", "user").eq("entity_id", userId),
+    ),
+  ]);
+
+  await anonymizeDocs(
+    ctx,
+    stats,
+    "cancellation_reasons",
+    cancellationReasons,
+    () => ({
+      user_id: DELETED_USER_ID,
+      reason_details_id: undefined,
+      updated_at: now,
+    }),
+    mode,
+  );
+  await anonymizeDocs(
+    ctx,
+    stats,
+    "usage_logs",
+    usageLogs,
+    () => ({ user_id: DELETED_USER_ID, chat_id: undefined }),
+    mode,
+  );
+  await anonymizeDocs(
+    ctx,
+    stats,
+    "referral_codes",
+    referralCodes,
+    (code) => ({
+      user_id: DELETED_USER_ID,
+      status: "deactivated",
+      deactivated_at: code.deactivated_at ?? now,
+      deactivated_reason: "account_deleted",
+      updated_at: now,
+    }),
+    mode,
+  );
+  await anonymizeDocs(
+    ctx,
+    stats,
+    "referral_attributions",
+    [...referredAttributions, ...referrerAttributions],
+    (attribution) => ({
+      referred_user_id:
+        attribution.referred_user_id === userId
+          ? DELETED_USER_ID
+          : attribution.referred_user_id,
+      referrer_user_id:
+        attribution.referrer_user_id === userId
+          ? DELETED_USER_ID
+          : attribution.referrer_user_id,
+      updated_at: now,
+    }),
+    mode,
+  );
+  await anonymizeDocs(
+    ctx,
+    stats,
+    "referral_rewards",
+    [
+      ...referralRewardsByUser,
+      ...referralRewardsByReferrer,
+      ...referralRewardsByReferred,
+    ],
+    (reward) => ({
+      ...(reward.user_id === userId ? { user_id: undefined } : {}),
+      ...(reward.referrer_user_id === userId
+        ? { referrer_user_id: undefined }
+        : {}),
+      ...(reward.referred_user_id === userId
+        ? { referred_user_id: undefined }
+        : {}),
+    }),
+    mode,
+  );
+  await anonymizeDocs(
+    ctx,
+    stats,
+    "user_suspensions",
+    userSuspensions,
+    () => ({ user_id: DELETED_USER_ID, updated_at: now }),
+    mode,
+  );
+
+  const anonymizeEntityLedger = (row: AnyDoc) => ({
+    ...(row.entity_type === "user" && row.entity_id === userId
+      ? { entity_id: DELETED_USER_ID }
+      : {}),
+    ...(row.user_id === userId ? { user_id: undefined } : {}),
+  });
+  await anonymizeDocs(
+    ctx,
+    stats,
+    "revenue_events",
+    [...revenueByUser, ...revenueByEntity],
+    anonymizeEntityLedger,
+    mode,
+  );
+  await anonymizeDocs(
+    ctx,
+    stats,
+    "paid_start_events",
+    [...paidStartsByUser, ...paidStartsByEntity],
+    anonymizeEntityLedger,
+    mode,
+  );
+  await anonymizeDocs(
+    ctx,
+    stats,
+    "unit_economics_daily",
+    [...unitEconomicsByUser, ...unitEconomicsByEntity],
+    (row) => ({
+      ...anonymizeEntityLedger(row),
+      updated_at: now,
+    }),
+    mode,
+  );
+
+  return stats;
+}
+
+async function cleanupOrphanChatSummaries(
+  ctx: MutationCtx,
+  mode: CleanupMode,
+  opts: { cursor?: string | null; numItems: number },
+) {
+  const stats = createStats();
+  const page = await (ctx.db.query("chat_summaries") as any).paginate({
+    cursor: opts.cursor ?? null,
+    numItems: opts.numItems,
+  });
+
+  stats.orphanChatSummariesScanned = page.page.length;
+  stats.orphanChatSummariesIsDone = page.isDone;
+  stats.orphanChatSummariesContinueCursor = page.continueCursor ?? undefined;
+
+  const orphanSummaries: Doc<"chat_summaries">[] = [];
+  for (const summary of page.page as Doc<"chat_summaries">[]) {
+    const [chatByChatId, chatByLatestSummary] = await Promise.all([
+      firstByIndex<Doc<"chats">>(ctx, "chats", "by_chat_id", (q) =>
+        q.eq("id", summary.chat_id),
+      ),
+      firstByIndex<Doc<"chats">>(ctx, "chats", "by_latest_summary_id", (q) =>
+        q.eq("latest_summary_id", summary._id),
+      ),
+    ]);
+    if (!chatByChatId && !chatByLatestSummary) {
+      orphanSummaries.push(summary);
+    }
+  }
+
+  stats.orphanChatSummariesDeleted = orphanSummaries.length;
+  await deleteDocs(ctx, stats, "chat_summaries", orphanSummaries, mode);
+  return stats;
+}
 
 /**
- * Delete all data for the authenticated user in correct dependency order.
- *
- * Deletion order (respects foreign key constraints):
- * 1) Feedback records (referenced by messages)
- * 2) Messages (owned by user, reference chats and files)
- * 3) Chat summaries (referenced by chats)
- * 4) Chats (owned by user)
- * 5) Files + S3 objects (owned by user, may be referenced by messages)
- *    - S3 objects: Batch deleted using scheduled action
- * 6) Notes (owned by user)
- * 7) User customization (owned by user)
- *
- * Uses parallel queries and deletions for optimal performance.
- * S3 cleanup is scheduled asynchronously and errors don't block user deletion.
+ * Delete all data for the authenticated user in the same policy path used by
+ * the server-side account deletion route.
  */
 export const deleteAllUserData = mutation({
   args: {},
@@ -28,165 +606,70 @@ export const deleteAllUserData = mutation({
       throw new Error("Unauthorized: User not authenticated");
     }
 
-    try {
-      // Fetch all user data in parallel using indexed queries
-      const [chats, files, notes, customization, messagesByUser] =
-        await Promise.all([
-          ctx.db
-            .query("chats")
-            .withIndex("by_user_and_updated", (q) =>
-              q.eq("user_id", user.subject),
-            )
-            .collect(),
-          ctx.db
-            .query("files")
-            .withIndex("by_user_id", (q) => q.eq("user_id", user.subject))
-            .collect(),
-          ctx.db
-            .query("notes")
-            .withIndex("by_user_and_updated", (q) =>
-              q.eq("user_id", user.subject),
-            )
-            .collect(),
-          ctx.db
-            .query("user_customization")
-            .withIndex("by_user_id", (q) => q.eq("user_id", user.subject))
-            .first(),
-          ctx.db
-            .query("messages")
-            .withIndex("by_user_id", (q) => q.eq("user_id", user.subject))
-            .collect(),
-        ]);
+    await cleanupUserDataForUser(ctx, user.subject, "execute");
+    return null;
+  },
+});
 
-      // All user-owned messages (assistant/system messages also have user_id in this app)
-      const allMessages = messagesByUser;
+export const deleteAllUserDataByService = mutation({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+    await cleanupUserDataForUser(ctx, args.userId, "execute");
+    return null;
+  },
+});
 
-      // Step 1: Delete feedback records (no dependencies)
-      const feedbackIds = allMessages
-        .map((m) => m.feedback_id)
-        .filter((id): id is NonNullable<typeof id> => !!id);
+export const cleanupDeletedUserResidue = mutation({
+  args: {
+    serviceKey: v.string(),
+    userIds: v.optional(v.array(v.string())),
+    dryRun: v.optional(v.boolean()),
+    deleteOrphanChatSummaries: v.optional(v.boolean()),
+    orphanCursor: v.optional(v.union(v.string(), v.null())),
+    orphanNumItems: v.optional(v.number()),
+  },
+  returns: v.object({
+    deleted: v.any(),
+    anonymized: v.any(),
+    retained: v.any(),
+    orphanChatSummariesDeleted: v.number(),
+    orphanChatSummariesScanned: v.number(),
+    orphanChatSummariesIsDone: v.boolean(),
+    orphanChatSummariesContinueCursor: v.optional(v.string()),
+    s3ObjectsQueued: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
 
-      await Promise.all(
-        feedbackIds.map(async (feedbackId) => {
-          try {
-            await ctx.db.delete(feedbackId);
-          } catch (error) {
-            console.error(`Failed to delete feedback ${feedbackId}:`, error);
-          }
-        }),
-      );
+    const mode: CleanupMode = args.dryRun === false ? "execute" : "dryRun";
+    const stats = createStats();
+    const userIds = args.userIds ?? [];
 
-      // Step 2: Delete messages (now safe since feedback is gone)
-      await Promise.all(
-        allMessages.map(async (message) => {
-          try {
-            await ctx.db.delete(message._id);
-          } catch (error) {
-            console.error(`Failed to delete message ${message._id}:`, error);
-          }
-        }),
-      );
-
-      // Step 3: Delete chat summaries before deleting the chats that reference them
-      const summariesByChat = await Promise.all(
-        chats.map((chat) =>
-          ctx.db
-            .query("chat_summaries")
-            .withIndex("by_chat_id", (q) => q.eq("chat_id", chat.id))
-            .collect(),
-        ),
-      );
-
-      await Promise.all(
-        summariesByChat.flat().map(async (summary) => {
-          try {
-            await ctx.db.delete(summary._id);
-          } catch (error) {
-            console.error(`Failed to delete summary ${summary._id}:`, error);
-          }
-        }),
-      );
-
-      // Step 4: Delete chats (now safe since messages and summaries are gone)
-      await Promise.all(
-        chats.map(async (chat) => {
-          try {
-            await ctx.db.delete(chat._id);
-          } catch (error) {
-            console.error(`Failed to delete chat ${chat._id}:`, error);
-          }
-        }),
-      );
-
-      // Step 5: Delete files and S3 objects (safe since messages no longer reference them)
-
-      // Collect S3 keys for batch deletion
-      const s3Keys: string[] = [];
-
-      await Promise.all(
-        files.map(async (file) => {
-          try {
-            if (file.s3_key) {
-              s3Keys.push(file.s3_key);
-            }
-
-            // Delete from aggregate
-            await fileCountAggregate.deleteIfExists(ctx, file);
-
-            // Delete database record
-            await ctx.db.delete(file._id);
-          } catch (error) {
-            console.error(`Failed to delete file record ${file._id}:`, error);
-          }
-        }),
-      );
-
-      // Batch delete all S3 files for efficiency
-      if (s3Keys.length > 0) {
-        try {
-          await ctx.scheduler.runAfter(
-            0,
-            internal.s3Cleanup.deleteS3ObjectsBatchAction,
-            { s3Keys },
-          );
-          console.log(
-            `Scheduled deletion of ${s3Keys.length} S3 objects for user ${user.subject}`,
-          );
-        } catch (error) {
-          console.error("Failed to schedule S3 batch deletion:", error);
-          // Don't fail user deletion on S3 cleanup errors
-        }
-      }
-
-      // Step 6: Delete notes (independent of other data)
-      await Promise.all(
-        notes.map(async (note) => {
-          try {
-            await ctx.db.delete(note._id);
-          } catch (error) {
-            console.error(`Failed to delete note ${note._id}:`, error);
-          }
-        }),
-      );
-
-      // Step 7: Delete user customization (independent of other data)
-      if (customization) {
-        try {
-          await ctx.db.delete(customization._id);
-        } catch (error) {
-          console.error(
-            `Failed to delete user customization ${customization._id}:`,
-            error,
-          );
-        }
-      }
-
-      return null;
-    } catch (error) {
-      console.error("Failed to delete user data:", error);
+    if (userIds.length === 0 && !args.deleteOrphanChatSummaries) {
       throw new Error(
-        "Account deletion failed. Please try again or contact support.",
+        "Pass at least one userId or enable deleteOrphanChatSummaries",
       );
     }
+
+    for (const userId of userIds) {
+      mergeStats(stats, await cleanupUserDataForUser(ctx, userId, mode));
+    }
+
+    if (args.deleteOrphanChatSummaries) {
+      mergeStats(
+        stats,
+        await cleanupOrphanChatSummaries(ctx, mode, {
+          cursor: args.orphanCursor,
+          numItems: Math.min(Math.max(args.orphanNumItems ?? 500, 1), 1000),
+        }),
+      );
+    }
+
+    return stats;
   },
 });

--- a/scripts/cleanup-deleted-user-residue.ts
+++ b/scripts/cleanup-deleted-user-residue.ts
@@ -6,7 +6,7 @@ import { ConvexHttpClient } from "convex/browser";
 import { api } from "../convex/_generated/api";
 
 config({ path: resolve(process.cwd(), ".env.e2e") });
-config({ path: resolve(process.cwd(), ".env.local") });
+config({ path: resolve(process.cwd(), ".env.local"), override: true });
 
 type Options = {
   userIds: string[];
@@ -28,7 +28,7 @@ Usage:
   pnpm exec tsx scripts/cleanup-deleted-user-residue.ts --user <id> --orphans --execute
 
 Options:
-  --user <id>       Deleted WorkOS user id to clean. Repeat for multiple users.
+  --user <id>       Deleted WorkOS user id to clean. Run once per user id.
   --orphans         Include orphan chat_summaries cleanup.
   --cursor <cursor> Continue an orphan chat_summaries scan from a prior result.
   --limit <number>  Orphan chat_summaries page size. Default 500, max 1000.
@@ -103,6 +103,10 @@ function parseArgs(argv: string[]): Options {
 
   if (!Number.isFinite(options.orphanNumItems)) {
     throw new Error("--limit must be a number");
+  }
+
+  if (options.userIds.length > 1) {
+    throw new Error("Run this script once per --user to keep cleanup bounded");
   }
 
   options.orphanNumItems = Math.min(

--- a/scripts/cleanup-deleted-user-residue.ts
+++ b/scripts/cleanup-deleted-user-residue.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env tsx
+
+import { config } from "dotenv";
+import { resolve } from "path";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../convex/_generated/api";
+
+config({ path: resolve(process.cwd(), ".env.e2e") });
+config({ path: resolve(process.cwd(), ".env.local") });
+
+type Options = {
+  userIds: string[];
+  execute: boolean;
+  deleteOrphanChatSummaries: boolean;
+  orphanCursor?: string;
+  orphanNumItems: number;
+};
+
+function printUsage() {
+  console.log(`
+Clean deleted-user residue from Convex.
+
+Dry-run is the default. Pass --execute to apply the cleanup.
+
+Usage:
+  pnpm exec tsx scripts/cleanup-deleted-user-residue.ts --user <workos_user_id>
+  pnpm exec tsx scripts/cleanup-deleted-user-residue.ts --orphans
+  pnpm exec tsx scripts/cleanup-deleted-user-residue.ts --user <id> --orphans --execute
+
+Options:
+  --user <id>       Deleted WorkOS user id to clean. Repeat for multiple users.
+  --orphans         Include orphan chat_summaries cleanup.
+  --cursor <cursor> Continue an orphan chat_summaries scan from a prior result.
+  --limit <number>  Orphan chat_summaries page size. Default 500, max 1000.
+  --execute         Apply changes. Omit for dry-run.
+  --help            Show this message.
+`);
+}
+
+function parseArgs(argv: string[]): Options {
+  const options: Options = {
+    userIds: [],
+    execute: false,
+    deleteOrphanChatSummaries: false,
+    orphanNumItems: 500,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    }
+
+    if (arg === "--execute") {
+      options.execute = true;
+      continue;
+    }
+
+    if (arg === "--orphans") {
+      options.deleteOrphanChatSummaries = true;
+      continue;
+    }
+
+    if (arg === "--user") {
+      const value = argv[++i];
+      if (!value) throw new Error("--user requires a value");
+      options.userIds.push(value);
+      continue;
+    }
+
+    if (arg.startsWith("--user=")) {
+      options.userIds.push(arg.slice("--user=".length));
+      continue;
+    }
+
+    if (arg === "--cursor") {
+      const value = argv[++i];
+      if (!value) throw new Error("--cursor requires a value");
+      options.orphanCursor = value;
+      continue;
+    }
+
+    if (arg.startsWith("--cursor=")) {
+      options.orphanCursor = arg.slice("--cursor=".length);
+      continue;
+    }
+
+    if (arg === "--limit") {
+      const value = argv[++i];
+      if (!value) throw new Error("--limit requires a value");
+      options.orphanNumItems = Number(value);
+      continue;
+    }
+
+    if (arg.startsWith("--limit=")) {
+      options.orphanNumItems = Number(arg.slice("--limit=".length));
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!Number.isFinite(options.orphanNumItems)) {
+    throw new Error("--limit must be a number");
+  }
+
+  options.orphanNumItems = Math.min(
+    Math.max(Math.round(options.orphanNumItems), 1),
+    1000,
+  );
+
+  return options;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.userIds.length === 0 && !options.deleteOrphanChatSummaries) {
+    printUsage();
+    process.exit(1);
+  }
+
+  const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+  const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY;
+  if (!convexUrl || !serviceKey) {
+    throw new Error(
+      "NEXT_PUBLIC_CONVEX_URL and CONVEX_SERVICE_ROLE_KEY must be set",
+    );
+  }
+
+  const client = new ConvexHttpClient(convexUrl);
+  const result = await client.mutation(
+    api.userDeletion.cleanupDeletedUserResidue,
+    {
+      serviceKey,
+      userIds: options.userIds.length > 0 ? options.userIds : undefined,
+      dryRun: !options.execute,
+      deleteOrphanChatSummaries: options.deleteOrphanChatSummaries,
+      orphanCursor: options.orphanCursor,
+      orphanNumItems: options.orphanNumItems,
+    },
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        mode: options.execute ? "execute" : "dry-run",
+        ...result,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (
+    options.deleteOrphanChatSummaries &&
+    result.orphanChatSummariesContinueCursor
+  ) {
+    console.log(
+      `Next orphan cursor: ${result.orphanChatSummariesContinueCursor}`,
+    );
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- move account-deletion data cleanup into `/api/delete-account` through a service-key Convex mutation before WorkOS user deletion
- centralize user-deletion table policy: delete product/live settings data, anonymize retained billing/security/accounting ledgers, and retain non-user aggregates
- add missing cleanup for chat summaries, temp streams, local sandbox records, extra usage, and team member usage
- add a dry-run-first residue cleanup script for deleted-user rows and orphan chat summaries

## Ledger policy
- delete user-owned product data and live settings
- delete freeform cancellation details
- anonymize retained `usage_logs`, `referral_*`, `cancellation_reasons`, `revenue_events`, `paid_start_events`, `unit_economics_daily`, and `user_suspensions` user references
- retain org/global aggregate tables that do not expose the deleted user id

## Validation
- `pnpm jest convex/__tests__/userDeletion.test.ts app/api/delete-account/__tests__/route.test.ts app/components/__tests__/DeleteAccountDialog.test.tsx --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint convex/userDeletion.ts convex/__tests__/userDeletion.test.ts convex/schema.ts app/api/delete-account/route.ts app/api/delete-account/__tests__/route.test.ts app/components/DeleteAccountDialog.tsx app/components/__tests__/DeleteAccountDialog.test.tsx scripts/cleanup-deleted-user-residue.ts`
- `pnpm exec prettier --check app/components/__tests__/DeleteAccountDialog.test.tsx app/components/DeleteAccountDialog.tsx app/api/delete-account/route.ts app/api/delete-account/__tests__/route.test.ts convex/userDeletion.ts convex/__tests__/userDeletion.test.ts convex/schema.ts scripts/cleanup-deleted-user-residue.ts`
- `git diff --check`

## Manual verification
- In a disposable test account with chats, files, summaries, notes, local sandbox connection, extra usage, referrals, and usage logs, delete the account from Settings.
- Confirm `/api/delete-account` completes and WorkOS/Stripe cleanup still behaves as expected for the account/org shape.
- Confirm no personal app data remains and retained ledgers no longer expose the deleted WorkOS user id where the deletion policy anonymizes it.
- Run `pnpm exec tsx scripts/cleanup-deleted-user-residue.ts --orphans` first as a dry run before using `--execute` for orphan summary cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added server-side “deleted user residue” cleanup with optional orphaned chat summary cleanup.
  - Introduced a CLI tool to run residue cleanup (dry-run or execute).

- **Bug Fixes**
  - Improved account deletion ordering: user data cleanup now completes before external deletion and rate-limit cleanup.
  - If cleanup fails, the deletion process stops early and returns an error.

- **Performance**
  - Added additional database indexes to speed up user-scoped cleanup queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->