### PR TITLE
Route Ask media to Gemini 3.5 Flash

### DIFF
--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -16,8 +16,7 @@ export const ASK_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-standard",
     label: "HackerAI Standard",
     description: "Reliable performance for everyday tasks",
-    poweredBy:
-      "DeepSeek V4 Pro · Kimi K2.7 Code for images · Gemini 3 Flash for PDFs",
+    poweredBy: "DeepSeek V4 Pro · Gemini 3.5 Flash for images and PDFs",
   },
   {
     id: "hackerai-pro",

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -10,14 +10,14 @@ describe("provider registry", () => {
   it("keeps Gemini and stale Kimi compatibility keys pointed at their active slugs", () => {
     expect(
       (myProvider.languageModel("ask-model") as { modelId: string }).modelId,
-    ).toBe("google/gemini-3-flash-preview");
+    ).toBe("google/gemini-3.5-flash");
     expect(
       (
         myProvider.languageModel("model-gemini-3-flash") as {
           modelId: string;
         }
       ).modelId,
-    ).toBe("google/gemini-3-flash-preview");
+    ).toBe("google/gemini-3.5-flash");
     expect(
       (
         myProvider.languageModel("model-kimi-k2.6") as {
@@ -26,7 +26,7 @@ describe("provider registry", () => {
       ).modelId,
     ).toBe("moonshotai/kimi-k2.7-code:exacto");
     expect(getModelDisplayName("model-gemini-3-flash")).toBe(
-      "Google Gemini 3 Flash",
+      "Google Gemini 3.5 Flash",
     );
   });
 });

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -246,15 +246,16 @@ const openrouter = createOpenRouter({
 type OpenRouterInstance = typeof openrouter;
 
 const KIMI_K2_7_CODE_SLUG = "moonshotai/kimi-k2.7-code:exacto";
+const GEMINI_3_5_FLASH_SLUG = "google/gemini-3.5-flash";
 
 const buildProviderMap = (or: OpenRouterInstance) =>
   ({
-    "ask-model": or("google/gemini-3-flash-preview"),
+    "ask-model": or(GEMINI_3_5_FLASH_SLUG),
     "ask-model-free": or("deepseek/deepseek-v4-flash"),
     "agent-model": or(KIMI_K2_7_CODE_SLUG),
     "agent-model-free": or("deepseek/deepseek-v4-flash"),
     "model-sonnet-4.6": or("anthropic/claude-sonnet-4-6"),
-    "model-gemini-3-flash": or("google/gemini-3-flash-preview"),
+    "model-gemini-3-flash": or(GEMINI_3_5_FLASH_SLUG),
     "model-deepseek-v4-flash": or("deepseek/deepseek-v4-flash"),
     "model-deepseek-v4-pro": or("deepseek/deepseek-v4-pro"),
     "model-opus-4.6": or("anthropic/claude-opus-4.6"),
@@ -300,7 +301,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "agent-model": "Auto, an intelligent model router built by HackerAI",
   "agent-model-free": "Auto, an intelligent model router built by HackerAI",
   "model-sonnet-4.6": "Anthropic Claude Sonnet 4.6",
-  "model-gemini-3-flash": "Google Gemini 3 Flash",
+  "model-gemini-3-flash": "Google Gemini 3.5 Flash",
   "model-deepseek-v4-flash": "DeepSeek V4 Flash",
   "model-deepseek-v4-pro": "DeepSeek V4 Pro",
   "model-opus-4.6": "Anthropic Claude Opus 4.6",

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -21,7 +21,7 @@ jest.mock("@/lib/logger", () => ({
 
 // Slugs the test asserts against. These match the registry in lib/ai/providers.ts.
 // If the registry slug for a model changes, update both places intentionally.
-const GEMINI_SLUG = "google/gemini-3-flash-preview";
+const GEMINI_PREVIEW_SLUG = "google/gemini-3-flash-preview";
 const GEMINI_3_5_SLUG = "google/gemini-3.5-flash";
 const GROK_SLUG = "x-ai/grok-4.3";
 const KIMI_SLUG = "moonshotai/kimi-k2.7-code:exacto";
@@ -30,7 +30,7 @@ describe("buildProviderOptions fallback chain", () => {
   it("resolves Opus 4.6 ask chain to Gemini", () => {
     const opts = buildProviderOptions(false, "user-1", "model-opus-4.6", "ask");
     expect(opts.openrouter).toMatchObject({
-      models: [GEMINI_SLUG],
+      models: [GEMINI_3_5_SLUG],
       user: "user-1",
     });
   });
@@ -70,7 +70,7 @@ describe("buildProviderOptions fallback chain", () => {
       "ask",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [GEMINI_SLUG],
+      models: [GEMINI_3_5_SLUG],
       user: "user-1",
     });
   });
@@ -150,7 +150,7 @@ describe("buildProviderOptions fallback chain", () => {
   it("falls back from free DeepSeek agent model to Gemini", () => {
     const opts = buildProviderOptions(false, "user-1", "agent-model-free");
     expect(opts.openrouter).toMatchObject({
-      models: [GEMINI_SLUG],
+      models: [GEMINI_PREVIEW_SLUG],
       user: "user-1",
     });
   });
@@ -163,12 +163,12 @@ describe("buildProviderOptions fallback chain", () => {
       "ask",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [GEMINI_SLUG],
+      models: [GEMINI_PREVIEW_SLUG],
       user: "user-1",
     });
   });
 
-  it("falls back from the Gemini PDF route to Grok", () => {
+  it("falls back from the Gemini media route to Grok", () => {
     const opts = buildProviderOptions(false, "user-1", "model-gemini-3-flash");
     expect(opts.openrouter).toMatchObject({
       models: [GROK_SLUG],
@@ -198,12 +198,12 @@ describe("buildProviderOptions fallback chain", () => {
   );
 
   it.each(["ask-model", "model-gemini-3-flash"])(
-    "enables hidden medium reasoning for Gemini ask mode model %s",
+    "enables hidden minimal reasoning for Gemini 3.5 ask mode model %s",
     (modelName) => {
       const opts = buildProviderOptions(false, "user-1", modelName, "ask");
       expect(opts.openrouter.reasoning).toEqual({
         enabled: true,
-        effort: "medium",
+        effort: "minimal",
         exclude: true,
       });
     },

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -614,7 +614,8 @@ export function buildProviderOptions(
 ) {
   const modelId = modelName ? resolveSlug(modelName) : undefined;
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
-  const isGemini3Flash = modelId?.startsWith("google/gemini-3-flash") ?? false;
+  const isGemini35Flash =
+    modelId?.startsWith("google/gemini-3.5-flash") ?? false;
   const fallbackSlugs = getFallbackSlugs(modelName, mode, options);
   const reasoning = isReasoningModel
     ? {
@@ -628,8 +629,8 @@ export function buildProviderOptions(
       : mode === "ask" && isAskMediumReasoningModel(modelName)
         ? {
             enabled: true,
-            effort: "medium",
-            ...(isGemini3Flash && { exclude: true }),
+            effort: isGemini35Flash ? "minimal" : "medium",
+            ...(isGemini35Flash && { exclude: true }),
           }
         : { enabled: false };
 

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -165,9 +165,9 @@ describe("selectModel", () => {
       expect(selectModel("ask", "pro")).toBe("model-deepseek-v4-pro");
     });
 
-    it("should return Kimi K2.7 Code for paid ask when an image is attached", () => {
+    it("should return ask-model (Gemini) for paid ask when an image is attached", () => {
       expect(selectModel("ask", "pro", undefined, true, false)).toBe(
-        "model-kimi-k2.7-code",
+        "ask-model",
       );
     });
 
@@ -222,19 +222,19 @@ describe("selectModel", () => {
       );
     });
 
-    it("should promote HackerAI Standard to Kimi K2.7 Code when an image is attached", () => {
+    it("should promote HackerAI Standard to Gemini 3.5 Flash when an image is attached", () => {
       expect(selectModel("ask", "pro", "hackerai-standard", true, false)).toBe(
-        "model-kimi-k2.7-code",
+        "model-gemini-3-flash",
       );
     });
 
-    it("should promote HackerAI Standard to Gemini 3 Flash when a PDF is attached", () => {
+    it("should promote HackerAI Standard to Gemini 3.5 Flash when a PDF is attached", () => {
       expect(selectModel("ask", "pro", "hackerai-standard", false, true)).toBe(
         "model-gemini-3-flash",
       );
     });
 
-    it("should prefer Gemini 3 Flash for HackerAI Standard when image and PDF are both attached", () => {
+    it("should prefer Gemini 3.5 Flash for HackerAI Standard when image and PDF are both attached", () => {
       expect(selectModel("ask", "pro", "hackerai-standard", true, true)).toBe(
         "model-gemini-3-flash",
       );
@@ -300,10 +300,8 @@ describe("selectModel", () => {
       expect(selectModel("ask", "pro", "auto")).toBe("model-deepseek-v4-pro");
     });
 
-    it("should treat 'auto' as no override in ask mode with image -> Kimi K2.7 Code", () => {
-      expect(selectModel("ask", "pro", "auto", true, false)).toBe(
-        "model-kimi-k2.7-code",
-      );
+    it("should treat 'auto' as no override in ask mode with image -> Gemini", () => {
+      expect(selectModel("ask", "pro", "auto", true, false)).toBe("ask-model");
     });
 
     it("should treat 'auto' as no override in ask mode with PDF -> Gemini", () => {
@@ -319,7 +317,7 @@ describe("selectModel", () => {
         "model-deepseek-v4-pro",
       );
       expect(selectModel("ask", "pro", undefined, true, false)).toBe(
-        "model-kimi-k2.7-code",
+        "ask-model",
       );
       expect(selectModel("ask", "pro", undefined, false, true)).toBe(
         "ask-model",

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -39,10 +39,9 @@ export const getMaxStepsForUser = (
  * @param hasImageAttachment - Whether any message has an image attachment.
  * @param hasPdfAttachment - Whether any message has a PDF attachment.
  *   Paid ASK on the Standard/auto route normally uses DeepSeek V4 Pro
- *   (text-only, much cheaper than Claude); image-only prompts promote to Kimi
- *   K2.7 Code, while prompts with PDFs promote to Gemini 3 Flash Preview for
- *   native file support. Free ASK stays on DeepSeek V4 Flash. Paid ASK Pro
- *   always uses Sonnet 4.6.
+ *   (text-only, much cheaper than Claude); prompts with images or PDFs promote
+ *   to Gemini 3.5 Flash for native media support. Free ASK stays on DeepSeek
+ *   V4 Flash. Paid ASK Pro always uses Sonnet 4.6.
  * @returns Model name to use
  */
 export function selectModel(
@@ -55,17 +54,12 @@ export function selectModel(
   const isAgent = isAgentMode(mode);
   // DeepSeek ask routes are text-only, so image/PDF prompts promote to a
   // media-capable route unless the selected tier intentionally uses a
-  // multimodal/file-capable model such as Sonnet or Opus. PDF wins over image
-  // when both are present because Kimi K2.7 Code is image-capable but not
-  // declared as file/PDF-capable by OpenRouter.
+  // multimodal/file-capable model such as Sonnet or Opus.
   const isFreeAsk = !isAgent && subscription === "free";
   const hasAskImage = !isAgent && !!hasImageAttachment;
   const hasAskPdf = !isAgent && !!hasPdfAttachment;
-  const paidAskMediaModel: ModelName = hasAskPdf
-    ? "ask-model"
-    : hasAskImage
-      ? "model-kimi-k2.7-code"
-      : "model-deepseek-v4-pro";
+  const paidAskMediaModel: ModelName =
+    hasAskImage || hasAskPdf ? "ask-model" : "model-deepseek-v4-pro";
 
   const autoModel: ModelName = isAgent
     ? subscription === "free"
@@ -85,11 +79,9 @@ export function selectModel(
   // any UI that reads `getModelDisplayName` shows the picked model rather than
   // the auto-router label.
   if (selectedModel === "hackerai-standard" && !isAgent) {
-    return hasAskPdf
+    return hasAskImage || hasAskPdf
       ? "model-gemini-3-flash"
-      : hasAskImage
-        ? "model-kimi-k2.7-code"
-        : "model-deepseek-v4-pro";
+      : "model-deepseek-v4-pro";
   }
 
   if (selectedModel === "hackerai-pro" && !isAgent) {

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -409,6 +409,14 @@ describe("token-bucket", () => {
       ).toBe(11310);
     });
 
+    it.each(["ask-model", "model-gemini-3-flash"])(
+      "should use Gemini 3.5 Flash pricing for %s ($1.50/$9.00)",
+      (modelName) => {
+        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(19500);
+        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(117000);
+      },
+    );
+
     it("expensive models should deplete budget faster", () => {
       const monthlyBudget = getBudgetLimits("pro").monthly;
       // Typical conversation: 2000 input + 500 output tokens

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -25,11 +25,12 @@ export { isUserRateLimitKey } from "./key-cleanup";
 // Configuration
 // =============================================================================
 
-/** Model pricing: $/1M tokens per model (default used for ask models + gemini 3 flash agent) */
+/** Model pricing: $/1M tokens per model. */
 const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   default: { input: 0.5, output: 3.0 },
+  "ask-model": { input: 1.5, output: 9.0 },
   "model-sonnet-4.6": { input: 3.0, output: 15.0 },
-  "model-gemini-3-flash": { input: 0.5, output: 3.0 },
+  "model-gemini-3-flash": { input: 1.5, output: 9.0 },
   "model-deepseek-v4-pro": { input: 0.435, output: 0.87 },
   "fallback-gemini-3.5-flash": { input: 1.5, output: 9.0 },
   "model-opus-4.6": { input: 5.0, output: 25.0 },


### PR DESCRIPTION
## Summary
- route paid Ask image and PDF prompts to Gemini 3.5 Flash instead of the Kimi/Gemini split
- repoint the Gemini registry keys to `google/gemini-3.5-flash` and use hidden minimal reasoning for Ask media
- update Standard model copy, Gemini pricing, and regression coverage for routing/provider options

## Validation
- `pnpm test -- lib/chat/__tests__/chat-processor.test.ts lib/ai/__tests__/providers.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/rate-limit/__tests__/token-bucket.test.ts --runInBand`
- `pnpm exec prettier --check app/components/ModelSelector/constants.ts lib/ai/providers.ts lib/api/chat-stream-helpers.ts lib/chat/chat-processor.ts lib/rate-limit/token-bucket.ts lib/ai/__tests__/providers.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/chat/__tests__/chat-processor.test.ts lib/rate-limit/__tests__/token-bucket.test.ts`
- `pnpm typecheck`
- `pnpm exec eslint app/components/ModelSelector/constants.ts lib/ai/providers.ts lib/api/chat-stream-helpers.ts lib/chat/chat-processor.ts lib/rate-limit/token-bucket.ts lib/ai/__tests__/providers.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/chat/__tests__/chat-processor.test.ts lib/rate-limit/__tests__/token-bucket.test.ts`
- `git diff --check`

## Manual verification
- In Ask mode as a paid user, attach an image and send a question. The request should route to Gemini 3.5 Flash and complete normally.
- In Ask mode as a paid user, attach a PDF and send a question. The request should route to Gemini 3.5 Flash and complete normally.
- In Ask mode as a paid user with no image/PDF, send a text-only prompt. Standard/Auto should remain on DeepSeek V4 Pro.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated model versions: Gemini 3.5 Flash replaces older Gemini preview variants across the platform.
  * Modified model selection for paid ask mode with attachments to use Gemini 3.5 Flash instead of previous routing.
  * Updated token pricing for Gemini 3.5 Flash models to reflect new rates.
  * Adjusted reasoning configuration for improved performance with Gemini 3.5 Flash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->