### PR TITLE
Add internal cancellation feedback export

### DIFF
--- a/convex/__tests__/cancellationReasons.test.ts
+++ b/convex/__tests__/cancellationReasons.test.ts
@@ -26,10 +26,42 @@ jest.mock("../lib/utils", () => ({
 }));
 
 function buildDetailsQuery(rows: Record<string, any>[]) {
-  return {
-    order: jest.fn<any>().mockReturnThis(),
-    take: jest.fn<any>().mockResolvedValue(rows),
+  let matches = [...rows];
+  const query: any = {
+    withIndex: jest.fn((_indexName: string, builder: any) => {
+      const gtes: Record<string, number> = {};
+      const ltes: Record<string, number> = {};
+      const captureQuery = {
+        gte: (field: string, value: number) => {
+          gtes[field] = value;
+          return captureQuery;
+        },
+        lte: (field: string, value: number) => {
+          ltes[field] = value;
+          return captureQuery;
+        },
+      };
+      builder(captureQuery);
+      matches = rows.filter((row) => {
+        const afterStart =
+          gtes.created_at === undefined || row.created_at >= gtes.created_at;
+        const beforeEnd =
+          ltes.created_at === undefined || row.created_at <= ltes.created_at;
+        return afterStart && beforeEnd;
+      });
+      return query;
+    }),
+    order: jest.fn<any>((direction: "asc" | "desc") => {
+      matches = [...matches].sort((a, b) =>
+        direction === "desc"
+          ? b.created_at - a.created_at
+          : a.created_at - b.created_at,
+      );
+      return query;
+    }),
+    take: jest.fn<any>(async (limit: number) => matches.slice(0, limit)),
   };
+  return query;
 }
 
 describe("cancellation reason feedback export", () => {
@@ -97,6 +129,10 @@ describe("cancellation reason feedback export", () => {
       },
     );
 
+    expect(detailsQuery.withIndex).toHaveBeenCalledWith(
+      "by_created_at",
+      expect.any(Function),
+    );
     expect(detailsQuery.order).toHaveBeenCalledWith("desc");
     expect(detailsQuery.take).toHaveBeenCalledWith(50);
     expect(ctx.db.get).toHaveBeenCalledWith("reason-1");
@@ -137,5 +173,77 @@ describe("cancellation reason feedback export", () => {
     });
 
     expect(detailsQuery.take).toHaveBeenCalledWith(10_000);
+  });
+
+  it("filters by creation date before applying the dashboard export limit", async () => {
+    const inWindowCreatedAt = Date.UTC(2026, 5, 20, 12);
+    const detailsQuery = buildDetailsQuery([
+      {
+        _id: "newer-out-of-window",
+        cancellation_reason_id: "newer-reason",
+        reason_details: "Too new for the requested window",
+        created_at: Date.UTC(2026, 5, 22, 12),
+      },
+      {
+        _id: "older-in-window",
+        cancellation_reason_id: "in-window-reason",
+        reason_details: "Missing the workflow I needed.",
+        created_at: inWindowCreatedAt,
+      },
+      {
+        _id: "oldest-in-window",
+        cancellation_reason_id: "oldest-reason",
+        reason_details: "Also in window but beyond limit",
+        created_at: Date.UTC(2026, 5, 19, 12),
+      },
+    ]);
+    const ctx: any = {
+      db: {
+        query: jest.fn(() => detailsQuery),
+        get: jest.fn(async (id: string) =>
+          id === "in-window-reason"
+            ? {
+                reason_category: "missing_feature",
+                subscription_tier: "pro-plus",
+                plan: "pro-plus",
+                status: "started",
+                source: "in_app",
+                recent_usage_segment: "light",
+                recent_usage_request_count: 3,
+                recent_usage_cost_dollars: 1.25,
+              }
+            : null,
+        ),
+      },
+    };
+
+    const { getCancellationFeedbackForAnalysis } =
+      await import("../cancellationReasons");
+    const result = await (getCancellationFeedbackForAnalysis as any).handler(
+      ctx,
+      {
+        limit: 1,
+        startAt: Date.UTC(2026, 5, 19),
+        endAt: Date.UTC(2026, 5, 20, 23, 59, 59),
+      },
+    );
+
+    expect(detailsQuery.take).toHaveBeenCalledWith(1);
+    expect(ctx.db.get).toHaveBeenCalledWith("in-window-reason");
+    expect(ctx.db.get).not.toHaveBeenCalledWith("newer-reason");
+    expect(result).toEqual([
+      {
+        createdAt: new Date(inWindowCreatedAt).toISOString(),
+        reasonCategory: "missing_feature",
+        subscriptionTier: "pro-plus",
+        plan: "pro-plus",
+        status: "started",
+        source: "in_app",
+        recentUsageSegment: "light",
+        recentUsageRequestCount: 3,
+        recentUsageCostDollars: 1.25,
+        feedback: "Missing the workflow I needed.",
+      },
+    ]);
   });
 });

--- a/convex/__tests__/cancellationReasons.test.ts
+++ b/convex/__tests__/cancellationReasons.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+jest.mock("../_generated/server", () => ({
+  internalQuery: jest.fn((config: any) => config),
+  mutation: jest.fn((config: any) => config),
+  query: jest.fn((config: any) => config),
+}));
+
+jest.mock("convex/values", () => ({
+  v: {
+    id: jest.fn(() => "id"),
+    string: jest.fn(() => "string"),
+    number: jest.fn(() => "number"),
+    boolean: jest.fn(() => "boolean"),
+    optional: jest.fn(() => "optional"),
+    object: jest.fn(() => "object"),
+    array: jest.fn(() => "array"),
+    union: jest.fn(() => "union"),
+    literal: jest.fn(() => "literal"),
+    null: jest.fn(() => "null"),
+  },
+}));
+
+jest.mock("../lib/utils", () => ({
+  validateServiceKey: jest.fn(),
+}));
+
+function buildDetailsQuery(rows: Record<string, any>[]) {
+  return {
+    order: jest.fn<any>().mockReturnThis(),
+    take: jest.fn<any>().mockResolvedValue(rows),
+  };
+}
+
+describe("cancellation reason feedback export", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("exports joined cancellation feedback through an internal query without sensitive ids", async () => {
+    const detailRows = [
+      {
+        _id: "detail-1",
+        cancellation_reason_id: "reason-1",
+        user_id: "user-1",
+        organization_id: "org-1",
+        stripe_subscription_id: "sub-1",
+        reason_details: "Agent was useful, but too expensive right now.",
+        created_at: Date.UTC(2026, 5, 21, 12),
+      },
+      {
+        _id: "detail-2",
+        cancellation_reason_id: "reason-2",
+        user_id: "user-2",
+        reason_details: "Outside filter window",
+        created_at: Date.UTC(2026, 5, 19, 12),
+      },
+    ];
+    const detailsQuery = buildDetailsQuery(detailRows);
+    const reasonRows: Record<string, any> = {
+      "reason-1": {
+        _id: "reason-1",
+        user_id: "user-1",
+        organization_id: "org-1",
+        stripe_customer_id: "cus-1",
+        stripe_subscription_id: "sub-1",
+        stripe_price_id: "price-1",
+        plan: "pro",
+        subscription_tier: "pro",
+        reason_category: "too_expensive",
+        status: "started",
+        source: "in_app",
+        recent_usage_segment: "moderate",
+        recent_usage_request_count: 24,
+        recent_usage_cost_dollars: 12.5,
+      },
+    };
+    const ctx: any = {
+      db: {
+        query: jest.fn((table: string) => {
+          if (table !== "cancellation_reason_details") {
+            throw new Error(`unexpected table: ${table}`);
+          }
+          return detailsQuery;
+        }),
+        get: jest.fn(async (id: string) => reasonRows[id] ?? null),
+      },
+    };
+
+    const { getCancellationFeedbackForAnalysis } =
+      await import("../cancellationReasons");
+    const result = await (getCancellationFeedbackForAnalysis as any).handler(
+      ctx,
+      {
+        limit: 50,
+        startAt: Date.UTC(2026, 5, 20),
+      },
+    );
+
+    expect(detailsQuery.order).toHaveBeenCalledWith("desc");
+    expect(detailsQuery.take).toHaveBeenCalledWith(50);
+    expect(ctx.db.get).toHaveBeenCalledWith("reason-1");
+    expect(ctx.db.get).not.toHaveBeenCalledWith("reason-2");
+    expect(result).toEqual([
+      {
+        createdAt: "2026-06-21T12:00:00.000Z",
+        reasonCategory: "too_expensive",
+        subscriptionTier: "pro",
+        plan: "pro",
+        status: "started",
+        source: "in_app",
+        recentUsageSegment: "moderate",
+        recentUsageRequestCount: 24,
+        recentUsageCostDollars: 12.5,
+        feedback: "Agent was useful, but too expensive right now.",
+      },
+    ]);
+    expect(result[0]).not.toHaveProperty("user_id");
+    expect(result[0]).not.toHaveProperty("organization_id");
+    expect(result[0]).not.toHaveProperty("stripe_customer_id");
+    expect(result[0]).not.toHaveProperty("stripe_subscription_id");
+  });
+
+  it("caps dashboard export size", async () => {
+    const detailsQuery = buildDetailsQuery([]);
+    const ctx: any = {
+      db: {
+        query: jest.fn(() => detailsQuery),
+        get: jest.fn(),
+      },
+    };
+
+    const { getCancellationFeedbackForAnalysis } =
+      await import("../cancellationReasons");
+    await (getCancellationFeedbackForAnalysis as any).handler(ctx, {
+      limit: 50_000,
+    });
+
+    expect(detailsQuery.take).toHaveBeenCalledWith(10_000);
+  });
+});

--- a/convex/cancellationReasons.ts
+++ b/convex/cancellationReasons.ts
@@ -1,4 +1,9 @@
-import { mutation, query, type MutationCtx } from "./_generated/server";
+import {
+  internalQuery,
+  mutation,
+  query,
+  type MutationCtx,
+} from "./_generated/server";
 import { v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 
@@ -8,6 +13,7 @@ const MAX_REASON_DETAILS_LENGTH = 2_000;
 const MAX_RECENT_USAGE_LOGS = 5_000;
 const MAX_COMPLETION_CANDIDATES = 100;
 const MAX_REPORT_ROWS = 10_000;
+const MAX_FEEDBACK_EXPORT_ROWS = 10_000;
 
 const subscriptionTierValidator = v.union(
   v.literal("free"),
@@ -317,5 +323,70 @@ export const getCancellationReasonReport = query({
       if (segmentCompare !== 0) return segmentCompare;
       return b.startedCount - a.startedCount;
     });
+  },
+});
+
+export const getCancellationFeedbackForAnalysis = internalQuery({
+  args: {
+    limit: v.optional(v.number()),
+    startAt: v.optional(v.number()),
+    endAt: v.optional(v.number()),
+  },
+  returns: v.array(
+    v.object({
+      createdAt: v.string(),
+      reasonCategory: v.union(reasonCategoryValidator, v.null()),
+      subscriptionTier: v.union(subscriptionTierValidator, v.null()),
+      plan: v.union(v.string(), v.null()),
+      status: v.union(v.literal("started"), v.literal("completed"), v.null()),
+      source: v.union(sourceValidator, v.null()),
+      recentUsageSegment: v.union(usageSegmentValidator, v.null()),
+      recentUsageRequestCount: v.union(v.number(), v.null()),
+      recentUsageCostDollars: v.union(v.number(), v.null()),
+      feedback: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const limit = Math.max(
+      0,
+      Math.min(
+        args.limit ?? MAX_FEEDBACK_EXPORT_ROWS,
+        MAX_FEEDBACK_EXPORT_ROWS,
+      ),
+    );
+
+    const details = await ctx.db
+      .query("cancellation_reason_details")
+      .order("desc")
+      .take(limit);
+
+    const filteredDetails = details.filter((detail) => {
+      if (args.startAt !== undefined && detail.created_at < args.startAt) {
+        return false;
+      }
+      if (args.endAt !== undefined && detail.created_at > args.endAt) {
+        return false;
+      }
+      return true;
+    });
+
+    return Promise.all(
+      filteredDetails.map(async (detail) => {
+        const reason = await ctx.db.get(detail.cancellation_reason_id);
+
+        return {
+          createdAt: new Date(detail.created_at).toISOString(),
+          reasonCategory: reason?.reason_category ?? null,
+          subscriptionTier: reason?.subscription_tier ?? null,
+          plan: reason?.plan ?? null,
+          status: reason?.status ?? null,
+          source: reason?.source ?? null,
+          recentUsageSegment: reason?.recent_usage_segment ?? null,
+          recentUsageRequestCount: reason?.recent_usage_request_count ?? null,
+          recentUsageCostDollars: reason?.recent_usage_cost_dollars ?? null,
+          feedback: detail.reason_details,
+        };
+      }),
+    );
   },
 });

--- a/convex/cancellationReasons.ts
+++ b/convex/cancellationReasons.ts
@@ -357,21 +357,25 @@ export const getCancellationFeedbackForAnalysis = internalQuery({
 
     const details = await ctx.db
       .query("cancellation_reason_details")
+      .withIndex("by_created_at", (q) => {
+        if (args.startAt !== undefined && args.endAt !== undefined) {
+          return q
+            .gte("created_at", args.startAt)
+            .lte("created_at", args.endAt);
+        }
+        if (args.startAt !== undefined) {
+          return q.gte("created_at", args.startAt);
+        }
+        if (args.endAt !== undefined) {
+          return q.lte("created_at", args.endAt);
+        }
+        return q;
+      })
       .order("desc")
       .take(limit);
 
-    const filteredDetails = details.filter((detail) => {
-      if (args.startAt !== undefined && detail.created_at < args.startAt) {
-        return false;
-      }
-      if (args.endAt !== undefined && detail.created_at > args.endAt) {
-        return false;
-      }
-      return true;
-    });
-
     return Promise.all(
-      filteredDetails.map(async (detail) => {
+      details.map(async (detail) => {
         const reason = await ctx.db.get(detail.cancellation_reason_id);
 
         return {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -195,6 +195,7 @@ export default defineSchema({
     created_at: v.number(),
   })
     .index("by_cancellation_reason_id", ["cancellation_reason_id"])
+    .index("by_created_at", ["created_at"])
     .index("by_user_id_and_created_at", ["user_id", "created_at"])
     .index("by_stripe_subscription_id_and_created_at", [
       "stripe_subscription_id",


### PR DESCRIPTION
## Summary
- add an internal Convex dashboard query for cancellation feedback analysis
- return joined cancellation metadata while omitting user, org, customer, and subscription identifiers
- add focused tests for the export join, date filtering, sensitive-field omission, and row cap

## Testing
- pnpm test -- convex/__tests__/cancellationReasons.test.ts --runInBand
- pnpm exec prettier --check convex/cancellationReasons.ts convex/__tests__/cancellationReasons.test.ts
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- pre-commit: pnpm typecheck && pnpm test

## Manual verification
- In Convex Dashboard, open Functions and run `cancellationReasons:getCancellationFeedbackForAnalysis`.
- Optionally pass `{ "limit": 1000 }` or `{ "startAt": <ms>, "endAt": <ms> }`.
- Confirm rows include feedback and cancellation context, but no user, organization, Stripe customer, or Stripe subscription identifiers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal cancellation feedback export for analysis with optional date range filtering and pagination.
  * Introduced a hard cap on exported feedback rows to prevent large exports.

* **Bug Fixes**
  * Missing cancellation reason records are now handled gracefully by returning null metadata instead of failing.

* **Tests**
  * Added Jest coverage for export behavior, including pagination size limits, joined export output, and date-window filtering.

* **Chores**
  * Added a `created_at` index to support efficient time-based exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->