### PR TITLE
Gate Pro Agent spend-cap continuation

### DIFF
--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -8,10 +8,14 @@ import { getUserIDAndPro } from "@/lib/auth/get-user-id";
 import { assertUserCanMakeCostIncurringRequest } from "@/lib/suspensions";
 import {
   getChatById,
+  getUserCustomization,
   handleInitialChatAndUserMessage,
   setActiveTriggerRun,
 } from "@/lib/db/actions";
-import { assertFreeAgentGates } from "@/lib/api/chat-stream-helpers";
+import {
+  assertFreeAgentGates,
+  buildExtraUsageConfig,
+} from "@/lib/api/chat-stream-helpers";
 import { getTriggerRegionForVercelRequest } from "@/lib/api/trigger-region";
 import {
   coerceSelectedModel,
@@ -19,6 +23,7 @@ import {
 } from "@/types";
 import { ChatSDKError } from "@/lib/errors";
 import type { Todo, SandboxPreference, SelectedModel } from "@/types";
+import { resolveAgentRunSpendCapContinuationModel } from "@/lib/chat/agent-run-spend-cap";
 import { HybridSandboxManager } from "@/lib/ai/tools/utils/hybrid-sandbox-manager";
 import { assertLocalSandboxFallbackAllowed } from "@/lib/ai/tools/utils/sandbox-fallback";
 import {
@@ -56,7 +61,7 @@ export async function POST(req: NextRequest) {
     } = await req.json();
 
     const { userId, subscription, organizationId } = await getUserIDAndPro(req);
-    const selectedModelOverride: SelectedModel | undefined =
+    let selectedModelOverride: SelectedModel | undefined =
       normalizeSelectedModelOverrideForSubscription(
         coerceSelectedModel(rawSelectedModel ?? null),
         subscription,
@@ -101,6 +106,21 @@ export async function POST(req: NextRequest) {
     const existingChat = temporary ? null : await getChatById({ id: chatId });
     const isNewChat =
       !temporary && !existingChat && !regenerate && !isAutoContinue;
+    const userCustomization = await getUserCustomization({ userId });
+    const extraUsageConfig = await buildExtraUsageConfig({
+      userId,
+      subscription,
+      userCustomization,
+      organizationId,
+    });
+    selectedModelOverride = resolveAgentRunSpendCapContinuationModel({
+      finishReason: existingChat?.finish_reason,
+      isAutoContinue,
+      mode: "agent",
+      subscription,
+      selectedModelOverride,
+      extraUsageConfig,
+    });
 
     let messagesForPersistence = stripLocalDesktopSourcePaths(requestMessages);
     let messagesForTrigger = messagesForPersistence;

--- a/app/components/CancelSubscriptionDialog.tsx
+++ b/app/components/CancelSubscriptionDialog.tsx
@@ -56,6 +56,7 @@ const visibleCancellationReasonValues: CancellationReasonCategory[] = [
   "too_expensive",
   "not_using_enough",
   "missing_feature",
+  "hit_usage_limits",
   "too_slow_or_unreliable",
   "other",
 ];

--- a/app/components/FinishReasonNotice.tsx
+++ b/app/components/FinishReasonNotice.tsx
@@ -21,7 +21,7 @@ interface FinishReasonNoticeProps {
 export const FinishReasonNotice = ({
   finishReason,
   mode,
-  agentRunSpendCapPremiumContinuationAllowed = false,
+  agentRunSpendCapPremiumContinuationAllowed,
   onContinue,
 }: FinishReasonNoticeProps) => {
   const { isAutoResuming, autoContinueCount } = useDataStreamState();
@@ -74,7 +74,7 @@ export const FinishReasonNotice = ({
 
   const shouldContinueWithStandard =
     finishReason === AGENT_RUN_SPEND_CAP_FINISH_REASON &&
-    !agentRunSpendCapPremiumContinuationAllowed;
+    agentRunSpendCapPremiumContinuationAllowed === false;
   const continuationModel = shouldContinueWithStandard
     ? AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL
     : undefined;

--- a/app/components/FinishReasonNotice.tsx
+++ b/app/components/FinishReasonNotice.tsx
@@ -4,17 +4,24 @@ import { useDataStreamState } from "@/app/components/DataStreamProvider";
 import { MAX_AUTO_CONTINUES } from "@/app/hooks/useAutoContinue";
 import { Button } from "@/components/ui/button";
 import { captureAgentRunSpendCapContinueClick } from "@/lib/analytics/client";
-import { AGENT_RUN_SPEND_CAP_REASON } from "@/lib/chat/agent-run-spend-cap";
+import {
+  AGENT_RUN_SPEND_CAP_FINISH_REASON,
+  AGENT_RUN_SPEND_CAP_REASON,
+  AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL,
+} from "@/lib/chat/agent-run-spend-cap";
+import type { SelectedModel } from "@/types/chat";
 
 interface FinishReasonNoticeProps {
   finishReason?: string;
   mode?: ChatMode;
-  onContinue?: () => void;
+  agentRunSpendCapPremiumContinuationAllowed?: boolean;
+  onContinue?: (selectedModelOverride?: SelectedModel) => void;
 }
 
 export const FinishReasonNotice = ({
   finishReason,
   mode,
+  agentRunSpendCapPremiumContinuationAllowed = false,
   onContinue,
 }: FinishReasonNoticeProps) => {
   const { isAutoResuming, autoContinueCount } = useDataStreamState();
@@ -54,7 +61,7 @@ export const FinishReasonNotice = ({
       return <>Reached the context limit for this conversation.</>;
     }
 
-    if (finishReason === "agent-run-spend-cap") {
+    if (finishReason === AGENT_RUN_SPEND_CAP_FINISH_REASON) {
       return <>Paused at the Pro Agent per-run safety cap.</>;
     }
 
@@ -64,6 +71,16 @@ export const FinishReasonNotice = ({
   const content = getNoticeContent();
 
   if (!content) return null;
+
+  const shouldContinueWithStandard =
+    finishReason === AGENT_RUN_SPEND_CAP_FINISH_REASON &&
+    !agentRunSpendCapPremiumContinuationAllowed;
+  const continuationModel = shouldContinueWithStandard
+    ? AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL
+    : undefined;
+  const continueButtonLabel = shouldContinueWithStandard
+    ? "Continue with Standard"
+    : "Continue";
 
   return (
     <div className="mt-2 w-full">
@@ -76,19 +93,23 @@ export const FinishReasonNotice = ({
             variant="outline"
             onClick={() => {
               setHasContinued(true);
-              if (finishReason === "agent-run-spend-cap") {
+              if (finishReason === AGENT_RUN_SPEND_CAP_FINISH_REASON) {
                 captureAgentRunSpendCapContinueClick({
                   surface: "finish_reason_notice",
                   source: AGENT_RUN_SPEND_CAP_REASON,
                   finish_reason: finishReason,
                   mode: mode ?? "agent",
                   cap_reason: AGENT_RUN_SPEND_CAP_REASON,
+                  premium_continuation_allowed:
+                    agentRunSpendCapPremiumContinuationAllowed,
+                  continuation_model:
+                    continuationModel ?? "current_selected_model",
                 });
               }
-              onContinue();
+              onContinue(continuationModel);
             }}
           >
-            Continue
+            {continueButtonLabel}
           </Button>
         )}
       </div>

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -20,7 +20,8 @@ import {
   extractWebSourcesFromMessage,
 } from "@/lib/utils/message-utils";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
-import type { ChatStatus, ChatMessage, ChatMode } from "@/types";
+import type { ChatStatus, ChatMessage, ChatMode, SelectedModel } from "@/types";
+import type { RateLimitWarningData } from "./RateLimitWarning";
 import type { FileDetails } from "@/types/file";
 
 const USER_MESSAGE_PREVIEW_LINE_LIMIT = 20;
@@ -69,7 +70,11 @@ interface MessageItemProps {
   onSaveEdit: (newContent: string, remainingFileIds: string[]) => Promise<void>;
   onCancelEdit: () => void;
   onRegenerate: () => void | Promise<void>;
-  onContinue?: () => void;
+  agentRunSpendCapWarning?: Extract<
+    RateLimitWarningData,
+    { warningType: "agent-run-spend-cap" }
+  >;
+  onContinue?: (selectedModelOverride?: SelectedModel) => void;
   onBranchMessage?: (messageId: string) => void;
   onFeedback: (messageId: string, type: "positive" | "negative") => void;
   onFeedbackSubmit: (details: string) => Promise<void>;
@@ -94,6 +99,8 @@ function areMessageItemPropsEqual(
     return false;
   if (prev.finishReason !== next.finishReason) return false;
   if (prev.mode !== next.mode) return false;
+  if (prev.agentRunSpendCapWarning !== next.agentRunSpendCapWarning)
+    return false;
   if (prev.showingLoadingIndicator !== next.showingLoadingIndicator)
     return false;
   if (prev.summarizationStatus?.status !== next.summarizationStatus?.status)
@@ -161,6 +168,7 @@ export const MessageItem = memo(function MessageItem({
   getCachedUrl,
   showingLoadingIndicator,
   summarizationStatus,
+  agentRunSpendCapWarning,
 }: MessageItemProps) {
   const [isHovered, setIsHovered] = useState(false);
   const [isUserMessageExpanded, setIsUserMessageExpanded] = useState(false);
@@ -622,6 +630,9 @@ export const MessageItem = memo(function MessageItem({
           <FinishReasonNotice
             finishReason={finishReason}
             mode={mode}
+            agentRunSpendCapPremiumContinuationAllowed={
+              agentRunSpendCapWarning?.premiumContinuationAllowed ?? false
+            }
             onContinue={onContinue}
           />
         )}

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -631,7 +631,7 @@ export const MessageItem = memo(function MessageItem({
             finishReason={finishReason}
             mode={mode}
             agentRunSpendCapPremiumContinuationAllowed={
-              agentRunSpendCapWarning?.premiumContinuationAllowed ?? false
+              agentRunSpendCapWarning?.premiumContinuationAllowed
             }
             onContinue={onContinue}
           />

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -23,13 +23,15 @@ import { toast } from "sonner";
 import DotsSpinner from "@/components/ui/dots-spinner";
 import { hasTextContent } from "@/lib/utils/message-utils";
 import { useDataStreamState } from "./DataStreamProvider";
+import type { RateLimitWarningData } from "./RateLimitWarning";
+import type { SelectedModel } from "@/types";
 
 interface MessagesProps {
   messages: ChatMessage[];
   setMessages: Dispatch<SetStateAction<ChatMessage[]>>;
   onRegenerate: () => void | Promise<void>;
   onRetry: () => void;
-  onContinue?: () => void;
+  onContinue?: (selectedModelOverride?: SelectedModel) => void;
   onReconnect?: () => void;
   onEditMessage: (
     messageId: string,
@@ -57,6 +59,10 @@ interface MessagesProps {
     message: string;
   } | null;
   mode?: import("@/types").ChatMode;
+  agentRunSpendCapWarning?: Extract<
+    RateLimitWarningData,
+    { warningType: "agent-run-spend-cap" }
+  >;
   chatTitle?: string | null;
   branchedFromChatId?: string;
   branchedFromChatTitle?: string;
@@ -84,6 +90,7 @@ export const Messages = ({
   uploadStatus,
   summarizationStatus,
   mode,
+  agentRunSpendCapWarning,
   chatTitle,
   branchedFromChatId,
   branchedFromChatTitle,
@@ -302,6 +309,7 @@ export const Messages = ({
               tempChatFileDetails={tempChatFileDetails}
               finishReason={finishReason}
               mode={mode}
+              agentRunSpendCapWarning={agentRunSpendCapWarning}
               isTemporaryChat={isTemporaryChat}
               branchedFromChatId={branchedFromChatId}
               branchedFromChatTitle={branchedFromChatTitle}

--- a/app/components/RateLimitWarning.tsx
+++ b/app/components/RateLimitWarning.tsx
@@ -60,6 +60,7 @@ export type RateLimitWarningData =
       runCapDollars: number;
       monthlyRemainingDollars: number;
       capBasis: AgentRunSpendCapBasis;
+      premiumContinuationAllowed: boolean;
       midStream?: boolean;
     };
 
@@ -116,7 +117,11 @@ const getMessage = (data: RateLimitWarningData, timeString: string): string => {
   }
 
   if (data.warningType === "agent-run-spend-cap") {
-    return `This Pro Agent run paused after using $${data.runCostDollars.toFixed(2)} of the $${data.runCapDollars.toFixed(2)} per-run safety cap. Continue to keep working.`;
+    if (data.premiumContinuationAllowed) {
+      return `This Pro Agent run paused after using $${data.runCostDollars.toFixed(2)} of the $${data.runCapDollars.toFixed(2)} per-run safety cap. Continue to keep working with extra usage.`;
+    }
+
+    return `This Pro Agent run paused after using $${data.runCostDollars.toFixed(2)} of the $${data.runCapDollars.toFixed(2)} per-run safety cap. Continue with Standard to keep working without extra usage.`;
   }
 
   // Token bucket warning — show dollar amounts when available
@@ -218,6 +223,7 @@ export const RateLimitWarning = ({
       run_cap_dollars: data.runCapDollars,
       monthly_remaining_dollars: data.monthlyRemainingDollars,
       cap_basis: data.capBasis,
+      premium_continuation_allowed: data.premiumContinuationAllowed,
     });
   }, [data]);
 

--- a/app/components/__tests__/CancelSubscriptionDialog.test.tsx
+++ b/app/components/__tests__/CancelSubscriptionDialog.test.tsx
@@ -1,0 +1,38 @@
+import "@testing-library/jest-dom";
+import { describe, expect, it, jest } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("@/app/contexts/GlobalState", () => ({
+  useGlobalState: () => ({
+    subscription: "pro",
+  }),
+}));
+
+jest.mock("@/lib/actions/cancel-subscription", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("@/lib/analytics/client", () => ({
+  captureAuthenticatedEvent: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+const CancelSubscriptionDialog = require("../CancelSubscriptionDialog")
+  .default as typeof import("../CancelSubscriptionDialog").default;
+
+describe("CancelSubscriptionDialog", () => {
+  it("shows usage limits as a cancellation reason", () => {
+    render(<CancelSubscriptionDialog open={true} onOpenChange={jest.fn()} />);
+
+    expect(
+      screen.getByRole("radio", { name: /hit usage limits too often/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/components/__tests__/FinishReasonNotice.test.tsx
+++ b/app/components/__tests__/FinishReasonNotice.test.tsx
@@ -6,7 +6,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { FinishReasonNotice } from "../FinishReasonNotice";
 import { DataStreamProvider, useDataStream } from "../DataStreamProvider";
 import { MAX_AUTO_CONTINUES } from "@/app/hooks/useAutoContinue";
-import type { ChatMode } from "@/types/chat";
+import type { ChatMode, SelectedModel } from "@/types/chat";
 
 function DataStreamSetter({
   isAutoResuming,
@@ -36,7 +36,8 @@ function DataStreamSetter({
 interface RenderNoticeProps {
   finishReason?: string;
   mode?: ChatMode;
-  onContinue?: () => void;
+  agentRunSpendCapPremiumContinuationAllowed?: boolean;
+  onContinue?: (selectedModelOverride?: SelectedModel) => void;
 }
 
 function renderNotice(
@@ -222,7 +223,7 @@ describe("FinishReasonNotice", () => {
       ).toBeInTheDocument();
     });
 
-    it("renders the Pro Agent run cap notice and invokes Continue", () => {
+    it("renders the Pro Agent run cap notice and continues with Standard when premium continuation is unavailable", () => {
       const onContinue = jest.fn();
       renderNotice(
         {
@@ -236,9 +237,28 @@ describe("FinishReasonNotice", () => {
       expect(
         screen.getByText(/Paused at the Pro Agent per-run safety cap/i),
       ).toBeInTheDocument();
-      fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+      fireEvent.click(
+        screen.getByRole("button", { name: /continue with standard/i }),
+      );
 
-      expect(onContinue).toHaveBeenCalledTimes(1);
+      expect(onContinue).toHaveBeenCalledWith("hackerai-standard");
+    });
+
+    it("continues the current premium model when spend-cap continuation is backed by extra usage", () => {
+      const onContinue = jest.fn();
+      renderNotice(
+        {
+          finishReason: "agent-run-spend-cap",
+          mode: "agent",
+          agentRunSpendCapPremiumContinuationAllowed: true,
+          onContinue,
+        },
+        { isAutoResuming: false, autoContinueCount: 0 },
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /^continue$/i }));
+
+      expect(onContinue).toHaveBeenCalledWith(undefined);
     });
   });
 

--- a/app/components/__tests__/FinishReasonNotice.test.tsx
+++ b/app/components/__tests__/FinishReasonNotice.test.tsx
@@ -229,6 +229,7 @@ describe("FinishReasonNotice", () => {
         {
           finishReason: "agent-run-spend-cap",
           mode: "agent",
+          agentRunSpendCapPremiumContinuationAllowed: false,
           onContinue,
         },
         { isAutoResuming: false, autoContinueCount: 0 },
@@ -242,6 +243,22 @@ describe("FinishReasonNotice", () => {
       );
 
       expect(onContinue).toHaveBeenCalledWith("hackerai-standard");
+    });
+
+    it("keeps the current selected model when spend-cap continuation eligibility is unknown", () => {
+      const onContinue = jest.fn();
+      renderNotice(
+        {
+          finishReason: "agent-run-spend-cap",
+          mode: "agent",
+          onContinue,
+        },
+        { isAutoResuming: false, autoContinueCount: 0 },
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /^continue$/i }));
+
+      expect(onContinue).toHaveBeenCalledWith(undefined);
     });
 
     it("continues the current premium model when spend-cap continuation is backed by extra usage", () => {

--- a/app/components/__tests__/RateLimitWarning.test.tsx
+++ b/app/components/__tests__/RateLimitWarning.test.tsx
@@ -72,6 +72,7 @@ describe("RateLimitWarning", () => {
           runCapDollars: 5,
           monthlyRemainingDollars: 20,
           capBasis: "fixed_5_dollars",
+          premiumContinuationAllowed: true,
         }}
         onDismiss={jest.fn()}
       />,
@@ -86,6 +87,29 @@ describe("RateLimitWarning", () => {
     expect(
       screen.queryByRole("button", { name: /add credits/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("points spend-cap continuation to Standard when premium continuation is unavailable", () => {
+    render(
+      <RateLimitWarning
+        data={{
+          warningType: "agent-run-spend-cap",
+          resetTime: new Date(Date.now() + 60_000),
+          subscription: "pro",
+          mode: "agent",
+          runCostDollars: 5.24,
+          runCapDollars: 5,
+          monthlyRemainingDollars: 20,
+          capBasis: "fixed_5_dollars",
+          premiumContinuationAllowed: false,
+        }}
+        onDismiss={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Pro Agent run paused/i)).toHaveTextContent(
+      "Continue with Standard",
+    );
   });
 
   it("uses extra usage copy when paid overflow credits are active", () => {

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1293,6 +1293,10 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
   const hasMessages = messages.length > 0;
   const showChatLayout = hasMessages || isExistingChat;
+  const agentRunSpendCapWarning =
+    rateLimitWarning?.warningType === "agent-run-spend-cap"
+      ? rateLimitWarning
+      : undefined;
 
   // UI-level temporary chat flag
   const isTempChat = !isExistingChat && temporaryChatsEnabled;
@@ -1385,6 +1389,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
                   isMobile={isMobile}
                   tempChatFileDetails={tempChatFileDetails}
                   finishReason={chatData?.finish_reason}
+                  agentRunSpendCapWarning={agentRunSpendCapWarning}
                   uploadStatus={uploadStatus}
                   summarizationStatus={summarizationStatus}
                   mode={chatMode ?? (chatData as any)?.default_model_slug}

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -10,6 +10,7 @@ import {
   normalizeSelectedModelForSubscription,
   type ChatMessage,
   type ChatStatus,
+  type SelectedModel,
 } from "@/types";
 import { Id } from "@/convex/_generated/dataModel";
 import {
@@ -696,9 +697,11 @@ export const useChatHandlers = ({
     }
   };
 
-  const handleContinue = () => {
+  const handleContinue = (selectedModelOverride?: SelectedModel) => {
     if (status === "streaming") return;
     hasManuallyStoppedRef.current = false;
+    const continuationSelectedModel =
+      selectedModelOverride ?? requestSelectedModel;
     sendMessage(
       { text: "continue", metadata: { isAutoContinue: true } },
       {
@@ -708,7 +711,7 @@ export const useChatHandlers = ({
           todos,
           temporary: temporaryChatsEnabled,
           sandboxPreference,
-          selectedModel: requestSelectedModel,
+          selectedModel: continuationSelectedModel,
         },
       },
     );

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -55,6 +55,7 @@ import {
   type ChatLogger,
 } from "@/lib/api/chat-logger";
 import { captureAgentRunSpendCapHit } from "@/lib/chat/agent-run-spend-cap-analytics";
+import { resolveAgentRunSpendCapContinuationModel } from "@/lib/chat/agent-run-spend-cap";
 import {
   countFileAttachments,
   stripImageAttachments,
@@ -204,7 +205,7 @@ export const createChatHandler = () => {
 
       const { userId, subscription, organizationId } =
         await getUserIDAndPro(req);
-      const selectedModelOverride: SelectedModel | undefined =
+      let selectedModelOverride: SelectedModel | undefined =
         normalizeSelectedModelOverrideForSubscription(
           coerceSelectedModel(rawSelectedModel ?? null),
           subscription,
@@ -267,6 +268,22 @@ export const createChatHandler = () => {
         Array.isArray(todos) ? todos : [],
         { isTemporary: !!temporary, regenerate },
       );
+
+      const extraUsageConfig = await buildExtraUsageConfig({
+        userId,
+        subscription,
+        userCustomization,
+        organizationId,
+      });
+
+      selectedModelOverride = resolveAgentRunSpendCapContinuationModel({
+        finishReason: chat?.finish_reason,
+        isAutoContinue,
+        mode,
+        subscription,
+        selectedModelOverride,
+        extraUsageConfig,
+      });
 
       if (!temporary) {
         await handleInitialChatAndUserMessage({
@@ -341,13 +358,6 @@ export const createChatHandler = () => {
         },
         selectedModel,
       );
-
-      const extraUsageConfig = await buildExtraUsageConfig({
-        userId,
-        subscription,
-        userCustomization,
-        organizationId,
-      });
 
       const rateLimitInfo: RateLimitInfo =
         freeAskRateLimitInfo ??
@@ -687,6 +697,7 @@ export const createChatHandler = () => {
                   subscription,
                   {
                     agentRunSpendCap,
+                    extraUsageConfig,
                     onAgentRunSpendCapHit: (hit) => {
                       captureAgentRunSpendCapHit({
                         userId,

--- a/lib/chat/__tests__/agent-run-spend-cap-analytics.test.ts
+++ b/lib/chat/__tests__/agent-run-spend-cap-analytics.test.ts
@@ -22,6 +22,7 @@ describe("captureAgentRunSpendCapHit", () => {
           runCapDollars: 5,
           monthlyRemainingDollars: 18,
           capBasis: "fixed_5_dollars",
+          premiumContinuationAllowed: true,
         },
       });
 
@@ -42,6 +43,7 @@ describe("captureAgentRunSpendCapHit", () => {
           run_cap_dollars: 5,
           monthly_remaining_dollars: 18,
           cap_basis: "fixed_5_dollars",
+          premium_continuation_allowed: true,
           $set: expect.objectContaining({
             subscription_tier: "pro",
             last_agent_run_spend_cap_hit_at: expect.any(String),

--- a/lib/chat/__tests__/agent-run-spend-cap.test.ts
+++ b/lib/chat/__tests__/agent-run-spend-cap.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL,
+  canContinueProAgentRunWithPremium,
+  resolveAgentRunSpendCapContinuationModel,
+} from "../agent-run-spend-cap";
+import type { ExtraUsageConfig } from "@/types";
+
+describe("canContinueProAgentRunWithPremium", () => {
+  it("allows premium continuation with extra usage balance", () => {
+    expect(
+      canContinueProAgentRunWithPremium({
+        enabled: true,
+        hasBalance: true,
+        balanceDollars: 2,
+        autoReloadEnabled: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("allows premium continuation with auto-reload", () => {
+    expect(
+      canContinueProAgentRunWithPremium({
+        enabled: true,
+        hasBalance: false,
+        balanceDollars: 0,
+        autoReloadEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks premium continuation when extra usage is unavailable", () => {
+    expect(canContinueProAgentRunWithPremium(undefined)).toBe(false);
+    expect(
+      canContinueProAgentRunWithPremium({
+        enabled: false,
+        hasBalance: true,
+        balanceDollars: 2,
+        autoReloadEnabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks premium continuation when the extra-usage monthly cap is exhausted", () => {
+    const config: ExtraUsageConfig = {
+      enabled: true,
+      hasBalance: true,
+      balanceDollars: 2,
+      autoReloadEnabled: false,
+      monthlyRemainingDollars: 0,
+    };
+
+    expect(canContinueProAgentRunWithPremium(config)).toBe(false);
+  });
+});
+
+describe("resolveAgentRunSpendCapContinuationModel", () => {
+  it("forces Pro Agent spend-cap auto-continues to Standard without extra usage", () => {
+    expect(
+      resolveAgentRunSpendCapContinuationModel({
+        finishReason: "agent-run-spend-cap",
+        isAutoContinue: true,
+        mode: "agent",
+        subscription: "pro",
+        selectedModelOverride: "hackerai-pro",
+        extraUsageConfig: undefined,
+      }),
+    ).toBe(AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL);
+  });
+
+  it("keeps the premium model when extra usage or auto-reload can cover continuation", () => {
+    expect(
+      resolveAgentRunSpendCapContinuationModel({
+        finishReason: "agent-run-spend-cap",
+        isAutoContinue: true,
+        mode: "agent",
+        subscription: "pro",
+        selectedModelOverride: "hackerai-max",
+        extraUsageConfig: {
+          enabled: true,
+          hasBalance: false,
+          balanceDollars: 0,
+          autoReloadEnabled: true,
+        },
+      }),
+    ).toBe("hackerai-max");
+  });
+
+  it("leaves Standard and non-spend-cap requests unchanged", () => {
+    expect(
+      resolveAgentRunSpendCapContinuationModel({
+        finishReason: "agent-run-spend-cap",
+        isAutoContinue: true,
+        mode: "agent",
+        subscription: "pro",
+        selectedModelOverride: "hackerai-standard",
+        extraUsageConfig: undefined,
+      }),
+    ).toBe("hackerai-standard");
+
+    expect(
+      resolveAgentRunSpendCapContinuationModel({
+        finishReason: "tool-calls",
+        isAutoContinue: true,
+        mode: "agent",
+        subscription: "pro",
+        selectedModelOverride: "hackerai-pro",
+        extraUsageConfig: undefined,
+      }),
+    ).toBe("hackerai-pro");
+  });
+});

--- a/lib/chat/__tests__/agent-run-spend-cap.test.ts
+++ b/lib/chat/__tests__/agent-run-spend-cap.test.ts
@@ -66,6 +66,28 @@ describe("resolveAgentRunSpendCapContinuationModel", () => {
         extraUsageConfig: undefined,
       }),
     ).toBe(AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL);
+
+    expect(
+      resolveAgentRunSpendCapContinuationModel({
+        finishReason: "agent-run-spend-cap",
+        isAutoContinue: true,
+        mode: "agent",
+        subscription: "pro",
+        selectedModelOverride: "auto",
+        extraUsageConfig: undefined,
+      }),
+    ).toBe(AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL);
+
+    expect(
+      resolveAgentRunSpendCapContinuationModel({
+        finishReason: "agent-run-spend-cap",
+        isAutoContinue: true,
+        mode: "agent",
+        subscription: "pro",
+        selectedModelOverride: undefined,
+        extraUsageConfig: undefined,
+      }),
+    ).toBe(AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL);
   });
 
   it("keeps the premium model when extra usage or auto-reload can cover continuation", () => {

--- a/lib/chat/__tests__/budget-monitor.test.ts
+++ b/lib/chat/__tests__/budget-monitor.test.ts
@@ -154,6 +154,7 @@ describe("BudgetMonitor", () => {
       runCapDollars: 1,
       monthlyRemainingDollars: 10,
       capBasis: "fixed_5_dollars",
+      premiumContinuationAllowed: false,
     });
     expect(writer.write).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -165,6 +166,42 @@ describe("BudgetMonitor", () => {
           runCostDollars: 1.25,
           runCapDollars: 1,
           capBasis: "fixed_5_dollars",
+          premiumContinuationAllowed: false,
+        }),
+      }),
+    );
+  });
+
+  it("marks Pro Agent run cap premium continuation as allowed when extra usage is available", () => {
+    const writer = makeWriter();
+    const monitor = new BudgetMonitor(
+      {
+        ...baseSnapshot,
+        monthlyLimitPoints: 200_000,
+        monthlyRemainingAtStart: 100_000,
+      },
+      writer,
+      "pro",
+      {
+        agentRunSpendCap: { capDollars: 1, basis: "fixed_5_dollars" },
+        extraUsageConfig: {
+          enabled: true,
+          hasBalance: false,
+          balanceDollars: 0,
+          autoReloadEnabled: true,
+        },
+      },
+    );
+
+    const decision = monitor.checkAfterStep(1.25);
+
+    expect(decision).toBe("abort-agent-run-spend-cap");
+    expect(writer.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "data-rate-limit-warning",
+        data: expect.objectContaining({
+          warningType: "agent-run-spend-cap",
+          premiumContinuationAllowed: true,
         }),
       }),
     );

--- a/lib/chat/agent-run-spend-cap-analytics.ts
+++ b/lib/chat/agent-run-spend-cap-analytics.ts
@@ -46,6 +46,7 @@ export function captureAgentRunSpendCapHit({
       run_cap_dollars: hit.runCapDollars,
       monthly_remaining_dollars: hit.monthlyRemainingDollars,
       cap_basis: hit.capBasis,
+      premium_continuation_allowed: hit.premiumContinuationAllowed,
       $set: {
         subscription_tier: subscription,
         last_agent_run_spend_cap_hit_at: new Date().toISOString(),

--- a/lib/chat/agent-run-spend-cap.ts
+++ b/lib/chat/agent-run-spend-cap.ts
@@ -1,5 +1,15 @@
+import type {
+  ChatMode,
+  ExtraUsageConfig,
+  SelectedModel,
+  SubscriptionTier,
+} from "@/types";
+
 export const AGENT_RUN_SPEND_CAP_REASON = "agent_run_spend_cap" as const;
+export const AGENT_RUN_SPEND_CAP_FINISH_REASON = "agent-run-spend-cap" as const;
 export const PRO_AGENT_RUN_SPEND_CAP_DOLLARS = 5;
+export const AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL =
+  "hackerai-standard" as const satisfies SelectedModel;
 
 export const AGENT_RUN_SPEND_CAP_BASES = ["fixed_5_dollars"] as const;
 
@@ -15,6 +25,7 @@ export interface AgentRunSpendCapHit {
   runCapDollars: number;
   monthlyRemainingDollars: number;
   capBasis: AgentRunSpendCapBasis;
+  premiumContinuationAllowed: boolean;
 }
 
 export function isAgentRunSpendCapBasis(
@@ -24,4 +35,57 @@ export function isAgentRunSpendCapBasis(
     typeof value === "string" &&
     (AGENT_RUN_SPEND_CAP_BASES as readonly string[]).includes(value)
   );
+}
+
+export function canContinueProAgentRunWithPremium(
+  extraUsageConfig: ExtraUsageConfig | undefined,
+): boolean {
+  if (!extraUsageConfig?.enabled) return false;
+  if (
+    extraUsageConfig.monthlyRemainingDollars !== undefined &&
+    extraUsageConfig.monthlyRemainingDollars <= 0
+  ) {
+    return false;
+  }
+
+  return Boolean(
+    extraUsageConfig.hasBalance || extraUsageConfig.autoReloadEnabled,
+  );
+}
+
+export function isPremiumAgentContinuationModel(
+  selectedModel: SelectedModel | undefined,
+): boolean {
+  return selectedModel === "hackerai-pro" || selectedModel === "hackerai-max";
+}
+
+export function resolveAgentRunSpendCapContinuationModel(args: {
+  finishReason: string | null | undefined;
+  isAutoContinue: boolean | undefined;
+  mode: ChatMode;
+  subscription: SubscriptionTier;
+  selectedModelOverride: SelectedModel | undefined;
+  extraUsageConfig: ExtraUsageConfig | undefined;
+}): SelectedModel | undefined {
+  const {
+    finishReason,
+    isAutoContinue,
+    mode,
+    subscription,
+    selectedModelOverride,
+    extraUsageConfig,
+  } = args;
+
+  if (
+    finishReason !== AGENT_RUN_SPEND_CAP_FINISH_REASON ||
+    !isAutoContinue ||
+    mode !== "agent" ||
+    subscription !== "pro" ||
+    !isPremiumAgentContinuationModel(selectedModelOverride) ||
+    canContinueProAgentRunWithPremium(extraUsageConfig)
+  ) {
+    return selectedModelOverride;
+  }
+
+  return AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL;
 }

--- a/lib/chat/agent-run-spend-cap.ts
+++ b/lib/chat/agent-run-spend-cap.ts
@@ -53,12 +53,6 @@ export function canContinueProAgentRunWithPremium(
   );
 }
 
-export function isPremiumAgentContinuationModel(
-  selectedModel: SelectedModel | undefined,
-): boolean {
-  return selectedModel === "hackerai-pro" || selectedModel === "hackerai-max";
-}
-
 export function resolveAgentRunSpendCapContinuationModel(args: {
   finishReason: string | null | undefined;
   isAutoContinue: boolean | undefined;
@@ -76,12 +70,15 @@ export function resolveAgentRunSpendCapContinuationModel(args: {
     extraUsageConfig,
   } = args;
 
+  const isAlreadyStandardContinuation =
+    selectedModelOverride === AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL;
+
   if (
     finishReason !== AGENT_RUN_SPEND_CAP_FINISH_REASON ||
     !isAutoContinue ||
     mode !== "agent" ||
     subscription !== "pro" ||
-    !isPremiumAgentContinuationModel(selectedModelOverride) ||
+    isAlreadyStandardContinuation ||
     canContinueProAgentRunWithPremium(extraUsageConfig)
   ) {
     return selectedModelOverride;

--- a/lib/chat/budget-monitor.ts
+++ b/lib/chat/budget-monitor.ts
@@ -15,6 +15,7 @@ import {
 import { writeRateLimitWarning } from "@/lib/utils/stream-writer-utils";
 import type { LimitCapReason } from "@/lib/limit-pressure";
 import {
+  canContinueProAgentRunWithPremium,
   PRO_AGENT_RUN_SPEND_CAP_DOLLARS,
   type AgentRunSpendCap,
   type AgentRunSpendCapHit,
@@ -103,6 +104,7 @@ export class BudgetMonitor {
     private readonly subscription: SubscriptionTier,
     private readonly options: {
       agentRunSpendCap?: AgentRunSpendCap | null;
+      extraUsageConfig?: ExtraUsageConfig;
       onAgentRunSpendCapHit?: (hit: AgentRunSpendCapHit) => void;
     } = {},
   ) {
@@ -136,6 +138,9 @@ export class BudgetMonitor {
         monthlyRemainingDollars:
           Math.round(monthlyRemainingDollars * 100) / 100,
         capBasis: agentRunSpendCap.basis,
+        premiumContinuationAllowed: canContinueProAgentRunWithPremium(
+          this.options.extraUsageConfig,
+        ),
       };
       writeRateLimitWarning(this.writer, {
         warningType: "agent-run-spend-cap",
@@ -146,6 +151,7 @@ export class BudgetMonitor {
         runCapDollars: hit.runCapDollars,
         monthlyRemainingDollars: hit.monthlyRemainingDollars,
         capBasis: hit.capBasis,
+        premiumContinuationAllowed: hit.premiumContinuationAllowed,
         midStream: true,
       });
       this.options.onAgentRunSpendCapHit?.(hit);

--- a/lib/chat/stop-conditions.ts
+++ b/lib/chat/stop-conditions.ts
@@ -3,12 +3,11 @@ import {
   detectDoomLoop,
   type MinimalStep,
 } from "@/lib/chat/doom-loop-detection";
+export { AGENT_RUN_SPEND_CAP_FINISH_REASON } from "@/lib/chat/agent-run-spend-cap";
 
 export const TOKEN_EXHAUSTION_FINISH_REASON = "context-limit";
 
 export const BUDGET_EXHAUSTION_FINISH_REASON = "budget-exhausted";
-
-export const AGENT_RUN_SPEND_CAP_FINISH_REASON = "agent-run-spend-cap";
 
 export function tokenExhaustedAfterSummarization(state: {
   threshold: number;

--- a/lib/utils/__tests__/parse-rate-limit-warning.test.ts
+++ b/lib/utils/__tests__/parse-rate-limit-warning.test.ts
@@ -13,6 +13,7 @@ describe("parseRateLimitWarning", () => {
         runCapDollars: 5,
         monthlyRemainingDollars: 18,
         capBasis: "fixed_5_dollars",
+        premiumContinuationAllowed: true,
         midStream: true,
       },
       { hasUserDismissed: false },
@@ -26,6 +27,7 @@ describe("parseRateLimitWarning", () => {
       runCapDollars: 5,
       monthlyRemainingDollars: 18,
       capBasis: "fixed_5_dollars",
+      premiumContinuationAllowed: true,
       midStream: true,
     });
   });
@@ -42,6 +44,7 @@ describe("parseRateLimitWarning", () => {
           runCapDollars: 5,
           monthlyRemainingDollars: 18,
           capBasis: "fixed_5_dollars",
+          premiumContinuationAllowed: true,
         },
         { hasUserDismissed: false },
       ),
@@ -60,6 +63,7 @@ describe("parseRateLimitWarning", () => {
           runCapDollars: 5,
           monthlyRemainingDollars: 18,
           capBasis: "fixed_5_dollars",
+          premiumContinuationAllowed: true,
         },
         { hasUserDismissed: false },
       ),
@@ -76,6 +80,8 @@ describe("parseRateLimitWarning", () => {
     { runCostDollars: Number.NaN },
     { runCapDollars: Number.POSITIVE_INFINITY },
     { monthlyRemainingDollars: Number.NEGATIVE_INFINITY },
+    { premiumContinuationAllowed: undefined },
+    { premiumContinuationAllowed: "true" },
   ])("rejects invalid spend-cap payload: %o", (overrides) => {
     expect(
       parseRateLimitWarning(
@@ -88,6 +94,7 @@ describe("parseRateLimitWarning", () => {
           runCapDollars: 5,
           monthlyRemainingDollars: 18,
           capBasis: "fixed_5_dollars",
+          premiumContinuationAllowed: true,
           ...overrides,
         },
         { hasUserDismissed: false },

--- a/lib/utils/parse-rate-limit-warning.ts
+++ b/lib/utils/parse-rate-limit-warning.ts
@@ -92,6 +92,7 @@ export function parseRateLimitWarning(
     const runCapDollars = rawData.runCapDollars;
     const monthlyRemainingDollars = rawData.monthlyRemainingDollars;
     const capBasis = rawData.capBasis;
+    const premiumContinuationAllowed = rawData.premiumContinuationAllowed;
     if (
       subscription !== "pro" ||
       rawData.mode !== "agent" ||
@@ -101,7 +102,8 @@ export function parseRateLimitWarning(
       runCapDollars < 0 ||
       !isNumber(monthlyRemainingDollars) ||
       monthlyRemainingDollars < 0 ||
-      !isAgentRunSpendCapBasis(capBasis)
+      !isAgentRunSpendCapBasis(capBasis) ||
+      typeof premiumContinuationAllowed !== "boolean"
     ) {
       return null;
     }
@@ -115,6 +117,7 @@ export function parseRateLimitWarning(
       runCapDollars,
       monthlyRemainingDollars,
       capBasis,
+      premiumContinuationAllowed,
       ...(midStream && { midStream: true }),
     };
   }

--- a/lib/utils/stream-writer-utils.ts
+++ b/lib/utils/stream-writer-utils.ts
@@ -140,6 +140,7 @@ export type RateLimitWarningData =
       runCapDollars: number;
       monthlyRemainingDollars: number;
       capBasis: AgentRunSpendCapBasis;
+      premiumContinuationAllowed: boolean;
       midStream?: boolean;
     };
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1332,6 +1332,7 @@ export const agentLongTask = task({
                   subscription,
                   {
                     agentRunSpendCap,
+                    extraUsageConfig,
                     onAgentRunSpendCapHit: (hit) => {
                       captureAgentRunSpendCapHit({
                         userId,


### PR DESCRIPTION
## Summary
- require extra usage balance or auto-reload to continue a Pro Agent run on the same premium model after the  per-run safety cap
- route no-extra-usage spend-cap resumes to HackerAI Standard/Kimi from both UI and server entrypoints
- add spend-cap continuation analytics fields and expose the hit_usage_limits cancellation reason
- cover policy, warning parsing, finish notice, rate warning, analytics, and cancellation dialog behavior with focused tests

## Validation
- pnpm jest lib/chat/__tests__/agent-run-spend-cap.test.ts lib/chat/__tests__/budget-monitor.test.ts lib/chat/__tests__/agent-run-spend-cap-analytics.test.ts lib/utils/__tests__/parse-rate-limit-warning.test.ts app/components/__tests__/FinishReasonNotice.test.tsx app/components/__tests__/RateLimitWarning.test.tsx app/components/__tests__/CancelSubscriptionDialog.test.tsx --runInBand
- pnpm typecheck
- pnpm exec eslint app/api/agent-long/route.ts app/components/CancelSubscriptionDialog.tsx app/components/FinishReasonNotice.tsx app/components/MessageItem.tsx app/components/Messages.tsx app/components/RateLimitWarning.tsx app/components/chat.tsx app/hooks/useChatHandlers.ts lib/api/chat-handler.ts lib/chat/agent-run-spend-cap.ts lib/chat/budget-monitor.ts lib/chat/agent-run-spend-cap-analytics.ts lib/chat/stop-conditions.ts lib/utils/parse-rate-limit-warning.ts lib/utils/stream-writer-utils.ts trigger/agent-long.ts lib/chat/__tests__/agent-run-spend-cap.test.ts lib/chat/__tests__/budget-monitor.test.ts lib/chat/__tests__/agent-run-spend-cap-analytics.test.ts lib/utils/__tests__/parse-rate-limit-warning.test.ts app/components/__tests__/FinishReasonNotice.test.tsx app/components/__tests__/RateLimitWarning.test.tsx app/components/__tests__/CancelSubscriptionDialog.test.tsx
- pnpm exec prettier --check app/api/agent-long/route.ts app/components/CancelSubscriptionDialog.tsx app/components/FinishReasonNotice.tsx app/components/MessageItem.tsx app/components/Messages.tsx app/components/RateLimitWarning.tsx app/components/chat.tsx app/hooks/useChatHandlers.ts lib/api/chat-handler.ts lib/chat/agent-run-spend-cap.ts lib/chat/budget-monitor.ts lib/chat/agent-run-spend-cap-analytics.ts lib/chat/stop-conditions.ts lib/utils/parse-rate-limit-warning.ts lib/utils/stream-writer-utils.ts trigger/agent-long.ts lib/chat/__tests__/agent-run-spend-cap.test.ts lib/chat/__tests__/budget-monitor.test.ts lib/chat/__tests__/agent-run-spend-cap-analytics.test.ts lib/utils/__tests__/parse-rate-limit-warning.test.ts app/components/__tests__/FinishReasonNotice.test.tsx app/components/__tests__/RateLimitWarning.test.tsx app/components/__tests__/CancelSubscriptionDialog.test.tsx
- pnpm lint (passes with existing warnings)

## Manual verification
- In Agent mode on a Pro account with HackerAI Pro or Max selected and no extra usage balance/auto-reload, hit the Pro Agent per-run safety cap. The finish notice should offer Continue with Standard, and the resumed request should use Standard/Kimi.
- Repeat with extra usage credits or auto-reload enabled. The finish notice should keep the normal Continue action and resume on the selected premium model.
- Open the cancellation dialog from account settings and confirm Hit usage limits too often appears as a selectable reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Pro Agent runs can now continue with a premium continuation model when extra usage balance is available
  * Added “hit usage limits too often” as a visible cancellation reason

* **Improvements**
  * Spend-cap continuation CTAs now adapt based on premium continuation eligibility (including “Continue with Standard” when not allowed)
  * Updated spend-cap analytics to record whether premium continuation was permitted

* **Tests**
  * Expanded coverage for premium continuation eligibility and continuation button behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->