### PR TITLE
Fix file URL batch timeout

### DIFF
--- a/app/components/AllFilesDialog.tsx
+++ b/app/components/AllFilesDialog.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { X, Download, Circle, CircleCheck, File } from "lucide-react";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { useAction } from "convex/react";
 import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
 import { useFileUrlCacheContext } from "@/app/contexts/FileUrlCacheContext";
 import type { FilePart } from "@/types/file";
 import JSZip from "jszip";
@@ -23,12 +29,12 @@ interface AllFilesDialogProps {
   chatTitle?: string | null;
 }
 
+type DialogFile = AllFilesDialogProps["files"][number];
+
+const FILE_URL_BATCH_SIZE = 50;
+
 interface FileItemProps {
-  file: {
-    part: FilePart;
-    partIndex: number;
-    messageId: string;
-  };
+  file: DialogFile;
   isSelected: boolean;
   selectionMode: boolean;
   onToggle: () => void;
@@ -142,12 +148,88 @@ const AllFilesDialog = ({
   files,
   chatTitle,
 }: AllFilesDialogProps) => {
-  const getFileUrlAction = useAction(api.s3Actions.getFileUrlAction);
+  const getFileUrlsBatchAction = useAction(
+    api.s3Actions.getFileUrlsBatchAction,
+  );
   const fileUrlCache = useFileUrlCacheContext();
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
   const [fileUrls, setFileUrls] = useState<Map<number, string>>(new Map());
   const [isLoadingUrls, setIsLoadingUrls] = useState(false);
+
+  const resolveFileUrls = useCallback(
+    async (
+      items: Array<{
+        file: DialogFile;
+        index: number;
+      }>,
+    ): Promise<Map<number, string>> => {
+      const urlMap = new Map<number, string>();
+      const pendingByFileId = new Map<
+        string,
+        { fileId: Id<"files">; indexes: number[] }
+      >();
+
+      for (const { file, index } of items) {
+        if (file.part.url) {
+          urlMap.set(index, file.part.url);
+          continue;
+        }
+
+        if (!file.part.fileId) {
+          continue;
+        }
+
+        const cachedUrl = fileUrlCache?.getCachedUrl(file.part.fileId);
+        if (cachedUrl) {
+          urlMap.set(index, cachedUrl);
+          continue;
+        }
+
+        const existing = pendingByFileId.get(file.part.fileId);
+        if (existing) {
+          existing.indexes.push(index);
+        } else {
+          pendingByFileId.set(file.part.fileId, {
+            fileId: file.part.fileId as Id<"files">,
+            indexes: [index],
+          });
+        }
+      }
+
+      const pendingFiles = Array.from(pendingByFileId.values());
+      for (
+        let start = 0;
+        start < pendingFiles.length;
+        start += FILE_URL_BATCH_SIZE
+      ) {
+        const chunk = pendingFiles.slice(start, start + FILE_URL_BATCH_SIZE);
+
+        try {
+          const batchUrls = await getFileUrlsBatchAction({
+            fileIds: chunk.map(({ fileId }) => fileId),
+          });
+
+          for (const { fileId, indexes } of chunk) {
+            const url = batchUrls[fileId];
+            if (!url) {
+              continue;
+            }
+
+            for (const index of indexes) {
+              urlMap.set(index, url);
+            }
+            fileUrlCache?.setCachedUrl(fileId, url);
+          }
+        } catch (error) {
+          console.error("Failed to fetch file URL batch:", error);
+        }
+      }
+
+      return urlMap;
+    },
+    [fileUrlCache, getFileUrlsBatchAction],
+  );
 
   const handleOpenChange = (newOpen: boolean) => {
     if (!newOpen) {
@@ -170,44 +252,8 @@ const AllFilesDialog = ({
     async function fetchAllUrls() {
       if (cancelled) return;
       setIsLoadingUrls(true);
-      const urlMap = new Map<number, string>();
-
-      // Fetch URLs in parallel
-      await Promise.all(
-        files.map(async (file, index) => {
-          // If already has URL, use it
-          if (file.part.url) {
-            urlMap.set(index, file.part.url);
-            return;
-          }
-
-          // Check cache first for fileId
-          if (file.part.fileId && fileUrlCache) {
-            const cachedUrl = fileUrlCache.getCachedUrl(file.part.fileId);
-            if (cachedUrl) {
-              urlMap.set(index, cachedUrl);
-              return;
-            }
-          }
-
-          try {
-            let url: string | null = null;
-
-            if (file.part.fileId) {
-              url = await getFileUrlAction({ fileId: file.part.fileId });
-              // Cache it
-              if (url && fileUrlCache) {
-                fileUrlCache.setCachedUrl(file.part.fileId, url);
-              }
-            }
-
-            if (url) {
-              urlMap.set(index, url);
-            }
-          } catch (error) {
-            console.error(`Failed to fetch URL for file ${index}:`, error);
-          }
-        }),
+      const urlMap = await resolveFileUrls(
+        files.map((file, index) => ({ file, index })),
       );
 
       if (!cancelled) {
@@ -221,7 +267,7 @@ const AllFilesDialog = ({
     return () => {
       cancelled = true;
     };
-  }, [open, files, getFileUrlAction, fileUrlCache]);
+  }, [open, files, resolveFileUrls]);
 
   const handleEnterSelectionMode = () => {
     setSelectionMode(true);
@@ -263,20 +309,32 @@ const AllFilesDialog = ({
 
     try {
       const zip = new JSZip();
+      let downloadUrls = new Map(fileUrls);
+      const missingUrlFiles = filesToDownload.filter(({ file, index }) => {
+        return !downloadUrls.get(index) && !file.part.url;
+      });
+
+      if (missingUrlFiles.length > 0) {
+        const resolvedUrls = await resolveFileUrls(missingUrlFiles);
+        downloadUrls = new Map(downloadUrls);
+        for (const [index, url] of resolvedUrls.entries()) {
+          downloadUrls.set(index, url);
+        }
+        setFileUrls((current) => {
+          const next = new Map(current);
+          for (const [index, url] of resolvedUrls.entries()) {
+            next.set(index, url);
+          }
+          return next;
+        });
+      }
 
       // Use already fetched URLs or fetch missing ones
       await Promise.all(
         filesToDownload.map(async ({ file, index }) => {
           try {
             let url: string | null | undefined =
-              fileUrls.get(index) || file.part.url;
-
-            // Fetch URL if not already available
-            if (!url) {
-              if (file.part.fileId) {
-                url = await getFileUrlAction({ fileId: file.part.fileId });
-              }
-            }
+              downloadUrls.get(index) || file.part.url;
 
             if (url) {
               const response = await fetch(url);
@@ -351,6 +409,9 @@ const AllFilesDialog = ({
         showCloseButton={false}
       >
         <DialogTitle className="sr-only">All files in this chat</DialogTitle>
+        <DialogDescription className="sr-only">
+          Download files attached to this chat.
+        </DialogDescription>
         {selectionMode ? (
           <header className="flex items-center justify-between pt-6 pr-6 pl-6 pb-2.5">
             <Button

--- a/app/components/__tests__/AllFilesDialog.test.tsx
+++ b/app/components/__tests__/AllFilesDialog.test.tsx
@@ -1,0 +1,92 @@
+import "@testing-library/jest-dom";
+import { render, waitFor } from "@testing-library/react";
+import { useAction } from "convex/react";
+import { FileUrlCacheProvider } from "@/app/contexts/FileUrlCacheContext";
+import { AllFilesDialog } from "../AllFilesDialog";
+
+jest.mock("@/convex/_generated/api", () => ({
+  api: {
+    s3Actions: {
+      getFileUrlsBatchAction: "s3Actions.getFileUrlsBatchAction",
+    },
+  },
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+jest.mock("@/app/hooks/useTauri", () => ({
+  isTauriEnvironment: jest.fn(() => false),
+  openDownloadsFolder: jest.fn(),
+}));
+
+describe("AllFilesDialog", () => {
+  let mockGetFileUrlsBatchAction: jest.Mock;
+  let cache: Map<string, string>;
+
+  beforeEach(() => {
+    mockGetFileUrlsBatchAction = useAction({} as any) as unknown as jest.Mock;
+    mockGetFileUrlsBatchAction.mockReset();
+    cache = new Map();
+  });
+
+  function renderWithCache(
+    files: React.ComponentProps<typeof AllFilesDialog>["files"],
+  ) {
+    return render(
+      <FileUrlCacheProvider
+        getCachedUrl={(fileId) => cache.get(fileId) ?? null}
+        setCachedUrl={(fileId, url) => cache.set(fileId, url)}
+      >
+        <AllFilesDialog
+          open={true}
+          onOpenChange={jest.fn()}
+          files={files}
+          chatTitle="Files"
+        />
+      </FileUrlCacheProvider>,
+    );
+  }
+
+  it("fetches dialog file URLs in 50-file batches instead of per-file actions", async () => {
+    mockGetFileUrlsBatchAction.mockImplementation(
+      async ({ fileIds }: { fileIds: string[] }) => {
+        return Object.fromEntries(
+          fileIds.map((fileId) => [fileId, `https://files.example/${fileId}`]),
+        );
+      },
+    );
+
+    const files = Array.from({ length: 51 }, (_, index) => {
+      const fileId = `file-${index}`;
+      return {
+        part: {
+          fileId: fileId as any,
+          name: `${fileId}.txt`,
+          mediaType: "text/plain",
+          s3Key: `uploads/${fileId}.txt`,
+        },
+        partIndex: index,
+        messageId: "message-1",
+      };
+    });
+
+    renderWithCache(files);
+
+    await waitFor(() => {
+      expect(mockGetFileUrlsBatchAction).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockGetFileUrlsBatchAction.mock.calls[0][0].fileIds).toHaveLength(
+      50,
+    );
+    expect(mockGetFileUrlsBatchAction.mock.calls[1][0].fileIds).toEqual([
+      "file-50",
+    ]);
+    expect(cache.size).toBe(51);
+  });
+});

--- a/app/components/__tests__/AllFilesDialog.test.tsx
+++ b/app/components/__tests__/AllFilesDialog.test.tsx
@@ -79,6 +79,7 @@ describe("AllFilesDialog", () => {
 
     await waitFor(() => {
       expect(mockGetFileUrlsBatchAction).toHaveBeenCalledTimes(2);
+      expect(cache.size).toBe(51);
     });
 
     expect(mockGetFileUrlsBatchAction.mock.calls[0][0].fileIds).toHaveLength(
@@ -87,6 +88,5 @@ describe("AllFilesDialog", () => {
     expect(mockGetFileUrlsBatchAction.mock.calls[1][0].fileIds).toEqual([
       "file-50",
     ]);
-    expect(cache.size).toBe(51);
   });
 });

--- a/convex/__tests__/s3Actions.test.ts
+++ b/convex/__tests__/s3Actions.test.ts
@@ -7,6 +7,7 @@ jest.mock("../s3Utils");
 jest.mock("../_generated/server", () => ({
   action: jest.fn((config) => config),
   query: jest.fn((config) => config),
+  internalQuery: jest.fn((config) => config),
 }));
 
 // Mock chats module to avoid circular dependency
@@ -26,6 +27,7 @@ jest.mock("../_generated/api", () => ({
     fileStorage: {
       getUserStorageUsage: "internal.fileStorage.getUserStorageUsage",
       createPendingS3File: "internal.fileStorage.createPendingS3File",
+      getFilesByIds: "internal.fileStorage.getFilesByIds",
     },
   },
 }));
@@ -737,9 +739,7 @@ describe("s3Actions", () => {
         },
         runQuery: jest
           .fn()
-          .mockResolvedValueOnce(mockFile1)
-          .mockResolvedValueOnce(mockFile2)
-          .mockResolvedValueOnce(mockFile3),
+          .mockResolvedValue([mockFile1, mockFile2, mockFile3]),
       } as any;
 
       const result = await getFileUrlsBatchAction.handler(mockCtx, {
@@ -751,6 +751,7 @@ describe("s3Actions", () => {
         file2: "https://s3.amazonaws.com/file2-url",
         file3: "https://s3.amazonaws.com/file3-url",
       });
+      expect(mockCtx.runQuery).toHaveBeenCalledTimes(1);
     });
 
     it("should skip files without S3 keys", async () => {
@@ -801,10 +802,7 @@ describe("s3Actions", () => {
             entitlements: ["pro-plan"],
           }),
         },
-        runQuery: jest
-          .fn()
-          .mockResolvedValueOnce(mockFile1)
-          .mockResolvedValueOnce(mockFile2),
+        runQuery: jest.fn().mockResolvedValue([mockFile1, mockFile2]),
       } as any;
 
       const result = await getFileUrlsBatchAction.handler(mockCtx, {
@@ -864,10 +862,7 @@ describe("s3Actions", () => {
             entitlements: ["pro-plan"],
           }),
         },
-        runQuery: jest
-          .fn()
-          .mockResolvedValueOnce(mockFile1)
-          .mockResolvedValueOnce(mockFile2),
+        runQuery: jest.fn().mockResolvedValue([mockFile1, mockFile2]),
       } as any;
 
       const result = await getFileUrlsBatchAction.handler(mockCtx, {
@@ -917,10 +912,7 @@ describe("s3Actions", () => {
             entitlements: ["pro-plan"],
           }),
         },
-        runQuery: jest
-          .fn()
-          .mockResolvedValueOnce(mockFile1)
-          .mockResolvedValueOnce(null), // File not found
+        runQuery: jest.fn().mockResolvedValue([mockFile1, null]), // File not found
       } as any;
 
       const result = await getFileUrlsBatchAction.handler(mockCtx, {
@@ -959,7 +951,7 @@ describe("s3Actions", () => {
             entitlements: ["pro-plan"],
           }),
         },
-        runQuery: jest.fn().mockResolvedValue(mockFile1),
+        runQuery: jest.fn().mockResolvedValue([mockFile1]),
       } as any;
 
       const result = await getFileUrlsBatchAction.handler(mockCtx, {
@@ -1033,9 +1025,7 @@ describe("s3Actions", () => {
         },
         runQuery: jest
           .fn()
-          .mockResolvedValueOnce(mockFile1)
-          .mockResolvedValueOnce(mockFile2)
-          .mockResolvedValueOnce(mockFile3),
+          .mockResolvedValue([mockFile1, mockFile2, mockFile3]),
       } as any;
 
       const result = await getFileUrlsBatchAction.handler(mockCtx, {
@@ -1143,10 +1133,7 @@ describe("s3Actions", () => {
             entitlements: ["pro-plan"],
           }),
         },
-        runQuery: jest
-          .fn()
-          .mockResolvedValueOnce(mockFile1)
-          .mockResolvedValueOnce(mockFile2),
+        runQuery: jest.fn().mockResolvedValue([mockFile1, mockFile2]),
       } as any;
 
       const result = await getFileUrlsBatchAction.handler(mockCtx, {
@@ -1213,10 +1200,7 @@ describe("s3Actions", () => {
       };
 
       const mockCtx = {
-        runQuery: jest
-          .fn()
-          .mockResolvedValueOnce(mockFile1)
-          .mockResolvedValueOnce(mockFile2),
+        runQuery: jest.fn().mockResolvedValue([mockFile1, mockFile2]),
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
@@ -1230,6 +1214,7 @@ describe("s3Actions", () => {
         "https://s3.amazonaws.com/file1-url",
         "https://s3.amazonaws.com/file2-url",
       ]);
+      expect(mockCtx.runQuery).toHaveBeenCalledTimes(1);
     });
 
     it("should generate URL metadata for service callers that request file info", async () => {
@@ -1258,7 +1243,7 @@ describe("s3Actions", () => {
       };
 
       const mockCtx = {
-        runQuery: jest.fn().mockResolvedValue(mockFile),
+        runQuery: jest.fn().mockResolvedValue([mockFile]),
       } as any;
 
       const result = await getFileUrlInfosByFileIdsAction.handler(mockCtx, {
@@ -1295,7 +1280,7 @@ describe("s3Actions", () => {
       };
 
       const mockCtx = {
-        runQuery: jest.fn().mockResolvedValue(mockFile),
+        runQuery: jest.fn().mockResolvedValue([mockFile]),
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
@@ -1349,10 +1334,7 @@ describe("s3Actions", () => {
       };
 
       const mockCtx = {
-        runQuery: jest
-          .fn()
-          .mockResolvedValueOnce(mockFile1)
-          .mockResolvedValueOnce(mockFile2),
+        runQuery: jest.fn().mockResolvedValue([mockFile1, mockFile2]),
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
@@ -1371,10 +1353,7 @@ describe("s3Actions", () => {
       const mockFile2Id = "file2" as any;
 
       const mockCtx = {
-        runQuery: jest
-          .fn()
-          .mockResolvedValueOnce(null)
-          .mockResolvedValueOnce(null),
+        runQuery: jest.fn().mockResolvedValue([null, null]),
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
@@ -1481,9 +1460,7 @@ describe("s3Actions", () => {
       const mockCtx = {
         runQuery: jest
           .fn()
-          .mockResolvedValueOnce(mockFile1)
-          .mockResolvedValueOnce(mockFile2)
-          .mockResolvedValueOnce(mockFile3),
+          .mockResolvedValue([mockFile1, mockFile2, mockFile3]),
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
@@ -1522,7 +1499,7 @@ describe("s3Actions", () => {
       };
 
       const mockCtx = {
-        runQuery: jest.fn().mockResolvedValue(mockFile),
+        runQuery: jest.fn().mockResolvedValue([mockFile]),
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
@@ -1557,7 +1534,7 @@ describe("s3Actions", () => {
       };
 
       const mockCtx = {
-        runQuery: jest.fn().mockResolvedValue(mockFile),
+        runQuery: jest.fn().mockResolvedValue([mockFile]),
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {
@@ -1602,7 +1579,7 @@ describe("s3Actions", () => {
       };
 
       const mockCtx = {
-        runQuery: jest.fn().mockResolvedValue(mockFile1),
+        runQuery: jest.fn().mockResolvedValue([mockFile1]),
       } as any;
 
       const result = await getFileUrlsByFileIdsAction.handler(mockCtx, {

--- a/convex/fileStorage.ts
+++ b/convex/fileStorage.ts
@@ -244,6 +244,22 @@ export const purgeExpiredUnattachedFiles = internalMutation({
   },
 });
 
+const fileForStorageLookupValidator = v.union(
+  v.object({
+    _id: v.id("files"),
+    s3_key: v.optional(v.string()),
+    user_id: v.string(),
+    name: v.string(),
+    media_type: v.string(),
+    size: v.number(),
+    file_token_size: v.number(),
+    content: v.optional(v.string()),
+    is_attached: v.boolean(),
+    _creationTime: v.number(),
+  }),
+  v.null(),
+);
+
 /**
  * Internal query to get a file by ID
  * Used by actions that need to verify file existence and ownership
@@ -252,24 +268,24 @@ export const getFileById = internalQuery({
   args: {
     fileId: v.id("files"),
   },
-  returns: v.union(
-    v.object({
-      _id: v.id("files"),
-      s3_key: v.optional(v.string()),
-      user_id: v.string(),
-      name: v.string(),
-      media_type: v.string(),
-      size: v.number(),
-      file_token_size: v.number(),
-      content: v.optional(v.string()),
-      is_attached: v.boolean(),
-      _creationTime: v.number(),
-    }),
-    v.null(),
-  ),
+  returns: fileForStorageLookupValidator,
   handler: async (ctx, args) => {
     const file = await ctx.db.get(args.fileId);
     return file;
+  },
+});
+
+/**
+ * Internal query to get files by ID in one action system call.
+ * Used by URL-generation actions to avoid one ctx.runQuery per file.
+ */
+export const getFilesByIds = internalQuery({
+  args: {
+    fileIds: v.array(v.id("files")),
+  },
+  returns: v.array(fileForStorageLookupValidator),
+  handler: async (ctx, args) => {
+    return await Promise.all(args.fileIds.map((fileId) => ctx.db.get(fileId)));
   },
 });
 

--- a/convex/s3Actions.ts
+++ b/convex/s3Actions.ts
@@ -311,16 +311,32 @@ export const getFileUrlsByFileIdsAction = action({
         `Batch size exceeds limit: Maximum ${MAX_SERVICE_FILE_URL_BATCH_SIZE} files allowed per request (requested: ${args.fileIds.length})`,
       );
     }
+    if (args.fileIds.length === 0) {
+      return [];
+    }
+
+    let files: FileRecord[];
+    try {
+      files = await ctx.runQuery(internal.fileStorage.getFilesByIds, {
+        fileIds: args.fileIds,
+      });
+    } catch (error) {
+      convexLogger.error("file_batch_lookup_failed", {
+        caller: "service",
+        fileCount: args.fileIds.length,
+        error:
+          error instanceof Error
+            ? { name: error.name, message: error.message }
+            : String(error),
+      });
+      return args.fileIds.map(() => null);
+    }
 
     // Get file records and generate URLs
     const urls: Array<string | null> = await Promise.all(
-      args.fileIds.map(async (fileId): Promise<string | null> => {
+      args.fileIds.map(async (fileId, index): Promise<string | null> => {
         try {
-          // Get file record using internal query
-          const file: FileRecord = await ctx.runQuery(
-            internal.fileStorage.getFileById,
-            { fileId },
-          );
+          const file = files[index];
 
           if (!file || file.user_id !== args.userId) {
             return null;
@@ -371,41 +387,60 @@ export const getFileUrlInfosByFileIdsAction = action({
         `Batch size exceeds limit: Maximum ${MAX_SERVICE_FILE_URL_BATCH_SIZE} files allowed per request (requested: ${args.fileIds.length})`,
       );
     }
+    if (args.fileIds.length === 0) {
+      return [];
+    }
+
+    let files: FileRecord[];
+    try {
+      files = await ctx.runQuery(internal.fileStorage.getFilesByIds, {
+        fileIds: args.fileIds,
+      });
+    } catch (error) {
+      convexLogger.error("file_batch_lookup_failed", {
+        caller: "service-info",
+        fileCount: args.fileIds.length,
+        error:
+          error instanceof Error
+            ? { name: error.name, message: error.message }
+            : String(error),
+      });
+      return args.fileIds.map(() => null);
+    }
 
     const urls: Array<ServiceFileUrlInfo | null> = await Promise.all(
-      args.fileIds.map(async (fileId): Promise<ServiceFileUrlInfo | null> => {
-        try {
-          const file: FileRecord = await ctx.runQuery(
-            internal.fileStorage.getFileById,
-            { fileId },
-          );
+      args.fileIds.map(
+        async (fileId, index): Promise<ServiceFileUrlInfo | null> => {
+          try {
+            const file = files[index];
 
-          if (!file || file.user_id !== args.userId) {
+            if (!file || file.user_id !== args.userId) {
+              return null;
+            }
+
+            if (file.s3_key) {
+              return {
+                url: await generateS3DownloadUrl(file.s3_key),
+                sizeBytes: file.size,
+                mediaType: file.media_type,
+                name: file.name,
+              };
+            }
+
+            return null;
+          } catch (error) {
+            convexLogger.error("file_batch_url_info_generation_failed", {
+              fileId,
+              caller: "service",
+              error:
+                error instanceof Error
+                  ? { message: error.message, name: error.name }
+                  : String(error),
+            });
             return null;
           }
-
-          if (file.s3_key) {
-            return {
-              url: await generateS3DownloadUrl(file.s3_key),
-              sizeBytes: file.size,
-              mediaType: file.media_type,
-              name: file.name,
-            };
-          }
-
-          return null;
-        } catch (error) {
-          convexLogger.error("file_batch_url_info_generation_failed", {
-            fileId,
-            caller: "service",
-            error:
-              error instanceof Error
-                ? { message: error.message, name: error.name }
-                : String(error),
-          });
-          return null;
-        }
-      }),
+        },
+      ),
     );
 
     return urls;
@@ -445,19 +480,35 @@ export const getFileUrlsBatchAction = action({
         `Batch size exceeds limit: Maximum ${MAX_SERVICE_FILE_URL_BATCH_SIZE} files allowed per request (requested: ${args.fileIds.length})`,
       );
     }
+    if (args.fileIds.length === 0) {
+      return {};
+    }
 
     const urlMap: Record<string, string> = {};
 
+    let files: FileRecord[];
+    try {
+      files = await ctx.runQuery(internal.fileStorage.getFilesByIds, {
+        fileIds: args.fileIds,
+      });
+    } catch (error) {
+      convexLogger.error("file_batch_lookup_failed", {
+        userId: identity.subject,
+        caller: "user",
+        fileCount: args.fileIds.length,
+        error:
+          error instanceof Error
+            ? { name: error.name, message: error.message }
+            : String(error),
+      });
+      return urlMap;
+    }
+
     // Process each file - access control per file
-    for (const fileId of args.fileIds) {
+    for (let index = 0; index < args.fileIds.length; index++) {
+      const fileId = args.fileIds[index];
       try {
-        // Get file record using internal query
-        const file: FileRecord = await ctx.runQuery(
-          internal.fileStorage.getFileById,
-          {
-            fileId,
-          },
-        );
+        const file = files[index];
 
         // Skip if file not found
         if (!file) {


### PR DESCRIPTION
## Summary
- add a batched internal file lookup for URL generation actions so batches use one Convex query call instead of one per file
- switch the all-files dialog to resolve URLs through `getFileUrlsBatchAction` in 50-file chunks instead of firing one single-file action per attachment
- cover the 51-file dialog case and update S3 action tests for the new batched lookup contract

## Root cause
PostHog issue 019dd473-0265-7cf3-ba27-9e1bfa334a4d included clustered `Failed to get file URL: Your request timed out performing too many system operations` events. The dialog path was fanning out many `getFileUrlAction` calls in parallel, and the server batch URL actions still performed one internal file query per file.

## Validation
- `pnpm jest convex/__tests__/s3Actions.test.ts app/components/__tests__/AllFilesDialog.test.tsx --runInBand`
- `pnpm exec eslint convex/fileStorage.ts convex/s3Actions.ts convex/__tests__/s3Actions.test.ts app/components/AllFilesDialog.tsx app/components/__tests__/AllFilesDialog.test.tsx`
- `pnpm typecheck`
- pre-commit hook: `pnpm typecheck` and full `pnpm test` (158 suites, 1703 tests)

## Manual verification
- Open a chat with many stored file attachments, including more than 50 files.
- Open “All files in this chat”.
- Confirm the dialog loads download URLs without Convex timeout errors and still allows individual and batch ZIP downloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved the All Files dialog to resolve file URLs in batches, reducing per-file lookups and speeding up dialog loading and download preparation.
* **Accessibility**
  * Added a screen-reader description for the file download dialog content.
* **Bug Fixes**
  * Improved handling when batch file lookups fail, falling back gracefully without breaking the workflow.
* **Tests**
  * Added/updated tests to verify batch behavior (including correct batching for 51 files) and adjusted mocks for batch query shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->