### PR TITLE
Guard local relay command dispatch with presence

### DIFF
--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -19,6 +19,13 @@ class MockSubscription extends EventEmitter {
   subscribe = jest.fn();
   unsubscribe = jest.fn();
   publish = jest.fn().mockResolvedValue(undefined);
+  presence = jest.fn().mockResolvedValue({
+    clients: {
+      "sandbox-client": {
+        connInfo: { connectionId: "conn-1" },
+      },
+    },
+  });
 }
 
 class MockCentrifugeClient extends EventEmitter {
@@ -247,6 +254,37 @@ describe("CentrifugoSandbox", () => {
       jest.advanceTimersByTime(timeoutMs + 5000 + 1);
 
       await expect(promise).rejects.toThrow("firstMsg: no");
+    });
+
+    it("fails before publishing when the target connection is absent from channel presence", async () => {
+      const sandbox = createSandbox();
+
+      const { promise } = startCommand(sandbox, "echo lost", {
+        timeoutMs: 1000,
+      });
+
+      await jest.advanceTimersByTimeAsync(0);
+
+      const sub = mockSubscriptions[0];
+      sub.presence.mockResolvedValueOnce({
+        clients: {
+          "probe-client": {
+            user: "user-1",
+          },
+        },
+      });
+
+      const rejection = expect(promise).rejects.toThrow(
+        "is not subscribed to the command relay",
+      );
+
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      await rejection;
+      expect(sub.publish).not.toHaveBeenCalled();
+      expect(sub.unsubscribe).toHaveBeenCalled();
+      expect(mockClients[0].disconnect).toHaveBeenCalled();
     });
   });
 

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -7,6 +7,7 @@ import {
   type CommandResponseMessage,
   type CommandMessage,
 } from "@/lib/centrifugo/types";
+import { presenceHasConnectionId } from "@/lib/centrifugo/presence";
 import { getPlatformDisplayName, escapeShellValue } from "./platform-utils";
 import type { ConnectionInfo } from "./sandbox-types";
 import { validateDownloadUrl } from "./path-validation";
@@ -415,55 +416,98 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
         subscription.on("subscribed", () => {
           if (settled) return;
           tSubscribed = Date.now();
-          const commandMessage: CommandMessage = {
-            type: "command",
-            commandId,
-            command,
-            env: opts?.envVars,
-            cwd: opts?.cwd,
-            timeout,
-            background: opts?.background,
-            displayName: opts?.displayName,
-            targetConnectionId: this.connectionInfo.connectionId,
-          };
 
-          commandPublishInFlight = true;
-          subscription!
-            .publish(commandMessage)
-            .then(() => {
-              commandPublishInFlight = false;
-              tPublished = Date.now();
-              publishedCommand = true;
-              if (cancelRequested || opts?.signal?.aborted) {
-                publishCancel();
-              }
-            })
-            .catch((err: unknown) => {
-              commandPublishInFlight = false;
-              if (cancelRequested || opts?.signal?.aborted) {
-                resolveCanceled();
-                return;
-              }
-              if (!settled) {
+          void (async () => {
+            try {
+              const presence = await subscription!.presence();
+              if (
+                !presenceHasConnectionId(
+                  presence,
+                  this.connectionInfo.connectionId,
+                )
+              ) {
+                if (settled) return;
                 settled = true;
                 cleanup();
                 reject(
                   new Error(
-                    `Failed to publish command: ${
-                      err instanceof Error
-                        ? err.message
-                        : (() => {
-                            try {
-                              return JSON.stringify(err);
-                            } catch {
-                              return String(err);
-                            }
-                          })()
-                    }`,
+                    `Local sandbox connection ${this.connectionInfo.connectionId} is not subscribed to the command relay. Reconnect the local runner or Desktop app, wait until it is ready, then try again.`,
                   ),
                 );
+                return;
               }
-            });
+            } catch (error) {
+              console.warn(
+                "[local-command]",
+                JSON.stringify({
+                  event: "local_command_presence_check_failed",
+                  service: "web",
+                  command_id: commandId,
+                  connection_id: this.connectionInfo.connectionId,
+                  message:
+                    error instanceof Error ? error.message : String(error),
+                }),
+              );
+            }
+
+            if (settled) return;
+            const commandMessage: CommandMessage = {
+              type: "command",
+              commandId,
+              command,
+              env: opts?.envVars,
+              cwd: opts?.cwd,
+              timeout,
+              background: opts?.background,
+              displayName: opts?.displayName,
+              targetConnectionId: this.connectionInfo.connectionId,
+            };
+
+            commandPublishInFlight = true;
+            subscription!
+              .publish(commandMessage)
+              .then(() => {
+                commandPublishInFlight = false;
+                tPublished = Date.now();
+                publishedCommand = true;
+                if (cancelRequested || opts?.signal?.aborted) {
+                  publishCancel();
+                }
+              })
+              .catch((err: unknown) => {
+                commandPublishInFlight = false;
+                if (cancelRequested || opts?.signal?.aborted) {
+                  resolveCanceled();
+                  return;
+                }
+                if (!settled) {
+                  settled = true;
+                  cleanup();
+                  reject(
+                    new Error(
+                      `Failed to publish command: ${
+                        err instanceof Error
+                          ? err.message
+                          : (() => {
+                              try {
+                                return JSON.stringify(err);
+                              } catch {
+                                return String(err);
+                              }
+                            })()
+                      }`,
+                    ),
+                  );
+                }
+              });
+          })().catch((err: unknown) => {
+            if (!settled) {
+              commandPublishInFlight = false;
+              settled = true;
+              cleanup();
+              reject(err instanceof Error ? err : new Error(String(err)));
+            }
+          });
         });
 
         subscription.subscribe();


### PR DESCRIPTION
## Summary
- verify the target local/Desktop runner is present in Centrifugo channel presence before publishing a command
- fail fast with a clear reconnect/wait error when the connection row exists but the runner is not actually subscribed
- add regression coverage for absent target presence so commands are not published into an empty relay channel

## Why
A local runner can create a Convex `connected` row before its Centrifugo command-channel subscription is ready. With Centrifugo history disabled, an immediate Agent command can be published before the runner is listening, so the CLI later reports no commands received while the backend waits through command timeouts/retries.

This keeps selected-local behavior honest without falling back to Cloud or guessing from prompt text/host paths.

## Validation
- `pnpm test -- lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts --runInBand`
- `pnpm test -- lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec prettier --check lib/ai/tools/utils/centrifugo-sandbox.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts`
- `pnpm exec eslint lib/ai/tools/utils/centrifugo-sandbox.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts`
- `git diff --check`

## Manual verification
- On Windows, start `npx @hackerai/local@latest --token <TOKEN>` and wait for the relay connection.
- In HackerAI Agent mode, choose Local execution and immediately send `run echo hello` or `run pwd`.
- Confirm the command either reaches the CLI and returns output, or the chat surfaces a clear local reconnect/wait error instead of spinning through lost-command timeouts.
- Confirm no selected-local run silently falls back to Cloud or another host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added connection validation during command execution; commands now fail gracefully with a reconnection prompt when the connection becomes unavailable.

* **Tests**
  * Added test case for command execution failure scenarios when target connections are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->