### PR TITLE
Avoid image payloads triggering provider pressure compaction

### DIFF
--- a/lib/chat/summarization/__tests__/provider-pressure.test.ts
+++ b/lib/chat/summarization/__tests__/provider-pressure.test.ts
@@ -63,6 +63,44 @@ describe("getProviderPromptPressure", () => {
     });
   });
 
+  it("does not trigger serialized pressure for a single image tool result", () => {
+    const messages = [
+      toolResultMessage(1, {
+        type: "content",
+        value: [
+          { type: "text", text: "Viewing image file: screenshot.png" },
+          {
+            type: "image-data",
+            data: "a".repeat(PROVIDER_PRESSURE_SERIALIZED_MESSAGE_BYTES + 1),
+            mediaType: "image/png",
+          },
+        ],
+      }),
+    ] as ModelMessage[];
+
+    expect(getProviderPromptPressure(messages)).toBeNull();
+  });
+
+  it("does not trigger serialized pressure for a single image data URL", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "describe this screenshot" },
+          {
+            type: "file",
+            mediaType: "image/png",
+            url: `data:image/png;base64,${"a".repeat(
+              PROVIDER_PRESSURE_SERIALIZED_MESSAGE_BYTES + 1,
+            )}`,
+          },
+        ],
+      },
+    ] as unknown as ModelMessage[];
+
+    expect(getProviderPromptPressure(messages)).toBeNull();
+  });
+
   it("does not trigger for small prompts", () => {
     const messages = [
       {

--- a/lib/chat/summarization/provider-pressure.ts
+++ b/lib/chat/summarization/provider-pressure.ts
@@ -22,9 +22,65 @@ export interface ProviderPromptPressure {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const isImageMediaType = (value: unknown): boolean =>
+  typeof value === "string" && value.toLowerCase().startsWith("image/");
+
+const isImageDataUrl = (value: unknown): boolean =>
+  typeof value === "string" && /^data:image\//i.test(value);
+
+const isImageLikeRecord = (value: Record<string, unknown>): boolean =>
+  value.type === "image" ||
+  value.type === "image-data" ||
+  value.kind === "image" ||
+  isImageMediaType(value.mediaType) ||
+  isImageMediaType(value.mimeType) ||
+  isImageMediaType(value.mime);
+
+const compactImagePayload = (value: unknown): string => {
+  if (typeof value === "string") {
+    return `[image data omitted: ${value.length} chars]`;
+  }
+
+  if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
+    return `[image data omitted: ${value.byteLength} bytes]`;
+  }
+
+  return "[image data omitted]";
+};
+
+const sanitizeForSerializedByteEstimate = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeForSerializedByteEstimate);
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const imageLike = isImageLikeRecord(value);
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, childValue] of Object.entries(value)) {
+    if (
+      (imageLike && (key === "data" || key === "image")) ||
+      ((key === "data" || key === "image" || key === "url") &&
+        isImageDataUrl(childValue))
+    ) {
+      sanitized[key] = compactImagePayload(childValue);
+      continue;
+    }
+
+    sanitized[key] = sanitizeForSerializedByteEstimate(childValue);
+  }
+
+  return sanitized;
+};
+
 const getSerializedBytes = (value: unknown): number | undefined => {
   try {
-    return new TextEncoder().encode(JSON.stringify(value)).length;
+    return new TextEncoder().encode(
+      JSON.stringify(sanitizeForSerializedByteEstimate(value)),
+    ).length;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- ignore raw image/base64 payloads when estimating serialized-message provider pressure
- keep provider-pressure safeguards for many messages, many tool results, and genuinely large non-image prompt payloads
- add regressions for image tool-result output and `data:image/...` attachment URLs

## Why
A single uploaded screenshot in Agent mode can be represented both as an image attachment and as `image-data` from the file `view` tool. The raw base64 payload can push the serialized-message byte estimate over the provider-pressure threshold, causing automatic context compaction for a simple "describe this image" request.

## Testing
- `pnpm test -- lib/chat/summarization/__tests__/provider-pressure.test.ts --runInBand`
- `pnpm exec eslint lib/chat/summarization/provider-pressure.ts lib/chat/summarization/__tests__/provider-pressure.test.ts`
- `pnpm exec prettier --check lib/chat/summarization/provider-pressure.ts lib/chat/summarization/__tests__/provider-pressure.test.ts`
- `pnpm typecheck`
- pre-commit hook also ran full `pnpm typecheck` and full `pnpm test` (`158` suites, `1706` tests)

## Manual verification
- In Agent mode, attach a normal screenshot and ask the agent to describe it.
- Confirm the agent can inspect/answer without immediately showing `Context automatically compacted` solely because of the image payload.
- Confirm compaction can still happen for true prompt pressure such as many messages or many tool results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test cases to validate correct handling of large image payloads in messages.

* **Improvements**
  * Enhanced serialization logic for messages containing images to provide more accurate byte size estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->