### PR TITLE
Enforce sandbox, spend-cap, and canceled-chat guards

### DIFF
--- a/convex/__tests__/messages.hidden.test.ts
+++ b/convex/__tests__/messages.hidden.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import type { Id } from "../_generated/dataModel";
-import { ConvexError } from "convex/values";
 
 jest.mock("../_generated/server", () => ({
   mutation: jest.fn((config: any) => config),
@@ -103,11 +102,38 @@ describe("saveMessage — is_hidden handling", () => {
     };
   });
 
-  function setupExistingMessage(msg: Record<string, any> | null): void {
-    const withIndexMock = jest.fn().mockReturnValue({
-      first: jest.fn<any>().mockResolvedValue(msg),
+  function setupExistingMessage(
+    msg: Record<string, any> | null,
+    chat: Record<string, any> | null = {
+      _id: "chat-doc-1",
+      id: CHAT_ID,
+      user_id: USER_ID,
+      canceled_at: undefined,
+    },
+  ): void {
+    mockCtx.db.query.mockImplementation((table: string) => {
+      if (table === "messages") {
+        return {
+          withIndex: jest.fn().mockReturnValue({
+            first: jest.fn<any>().mockResolvedValue(msg),
+          }),
+        };
+      }
+
+      if (table === "chats") {
+        return {
+          withIndex: jest.fn().mockReturnValue({
+            first: jest.fn<any>().mockResolvedValue(chat),
+          }),
+        };
+      }
+
+      return {
+        withIndex: jest.fn().mockReturnValue({
+          first: jest.fn<any>().mockResolvedValue(null),
+        }),
+      };
     });
-    mockCtx.db.query.mockReturnValue({ withIndex: withIndexMock });
   }
 
   it("should store is_hidden: true on insert", async () => {
@@ -267,13 +293,7 @@ describe("saveMessage — is_hidden handling", () => {
   });
 
   it("skips assistant inserts when the chat was deleted before save", async () => {
-    setupExistingMessage(null);
-    mockCtx.runQuery.mockRejectedValue(
-      new ConvexError({
-        code: "CHAT_NOT_FOUND",
-        message: "This chat doesn't exist",
-      }),
-    );
+    setupExistingMessage(null, null);
 
     const { saveMessage } = await import("../messages");
 
@@ -294,6 +314,66 @@ describe("saveMessage — is_hidden handling", () => {
       expect.stringContaining("convex_message_save_skipped_chat_not_found"),
     );
     expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("skips assistant inserts when the chat is already canceled", async () => {
+    setupExistingMessage(null, {
+      _id: "chat-doc-1",
+      id: CHAT_ID,
+      user_id: USER_ID,
+      canceled_at: Date.now(),
+    });
+
+    const { saveMessage } = await import("../messages");
+
+    await expect(
+      saveMessage.handler(mockCtx, {
+        serviceKey: SERVICE_KEY,
+        id: "msg-assistant-canceled",
+        chatId: CHAT_ID,
+        userId: USER_ID,
+        role: "assistant" as const,
+        parts: [{ type: "text", text: "late result" }],
+      }),
+    ).resolves.toBeNull();
+
+    expect(mockCtx.db.insert).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("convex_message_save_skipped_chat_canceled"),
+    );
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("rejects user inserts when the chat is already canceled", async () => {
+    setupExistingMessage(null, {
+      _id: "chat-doc-1",
+      id: CHAT_ID,
+      user_id: USER_ID,
+      canceled_at: Date.now(),
+    });
+
+    const { saveMessage } = await import("../messages");
+
+    await expect(
+      saveMessage.handler(mockCtx, {
+        serviceKey: SERVICE_KEY,
+        id: "msg-user-canceled",
+        chatId: CHAT_ID,
+        userId: USER_ID,
+        role: "user" as const,
+        parts: [{ type: "text", text: "late user message" }],
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({
+        code: "MESSAGE_SAVE_FAILED",
+        failureStage: "verify_chat_writable_for_insert",
+        causeData: expect.objectContaining({
+          code: "CHAT_CANCELED",
+        }),
+      }),
+    });
+
+    expect(mockCtx.db.insert).not.toHaveBeenCalled();
   });
 
   it("rejects unowned file IDs before inserting a new message", async () => {

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -441,6 +441,38 @@ export const verifyChatOwnership = internalQuery({
   },
 });
 
+async function ensureChatWritableForMessageInsert(
+  ctx: MutationCtx,
+  chatId: string,
+  userId: string,
+): Promise<void> {
+  const chat = await ctx.db
+    .query("chats")
+    .withIndex("by_chat_id", (q) => q.eq("id", chatId))
+    .first();
+
+  if (!chat) {
+    throw new ConvexError({
+      code: "CHAT_NOT_FOUND",
+      message: "This chat doesn't exist",
+    });
+  }
+
+  if (chat.user_id !== userId) {
+    throw new ConvexError({
+      code: "CHAT_UNAUTHORIZED",
+      message: "You don't have permission to access this chat",
+    });
+  }
+
+  if (chat.canceled_at !== undefined) {
+    throw new ConvexError({
+      code: "CHAT_CANCELED",
+      message: "This chat is no longer accepting new messages",
+    });
+  }
+}
+
 /**
  * Save a single message to a chat
  */
@@ -608,18 +640,8 @@ export const saveMessage = mutation({
           return null;
         }
 
-        failureStage = "verify_chat_ownership";
-        const chatExists: boolean = await ctx.runQuery(
-          internal.messages.verifyChatOwnership,
-          {
-            chatId: args.chatId,
-            userId: args.userId,
-          },
-        );
-
-        if (!chatExists) {
-          throw new Error("Chat not found");
-        }
+        failureStage = "verify_chat_writable_for_insert";
+        await ensureChatWritableForMessageInsert(ctx, args.chatId, args.userId);
       }
 
       let newMessageFiles: Doc<"files">[] = [];
@@ -756,14 +778,19 @@ export const saveMessage = mutation({
       }
 
       if (
-        failureStage === "verify_chat_ownership" &&
+        failureStage === "verify_chat_writable_for_insert" &&
         args.role === "assistant" &&
-        getConvexErrorCode(causeData) === "CHAT_NOT_FOUND"
+        (getConvexErrorCode(causeData) === "CHAT_NOT_FOUND" ||
+          getConvexErrorCode(causeData) === "CHAT_CANCELED")
       ) {
+        const convexErrorCode = getConvexErrorCode(causeData);
         console.warn(
           JSON.stringify({
             level: "warn",
-            event: "convex_message_save_skipped_chat_not_found",
+            event:
+              convexErrorCode === "CHAT_CANCELED"
+                ? "convex_message_save_skipped_chat_canceled"
+                : "convex_message_save_skipped_chat_not_found",
             service: "convex",
             timestamp: new Date().toISOString(),
             db_operation: "messages.saveMessage",
@@ -778,7 +805,7 @@ export const saveMessage = mutation({
             update_only: args.updateOnly === true,
             hidden: args.isHidden === true,
             file_count: args.fileIds?.length ?? 0,
-            convex_error_code: "CHAT_NOT_FOUND",
+            convex_error_code: convexErrorCode,
             ...getMessageSaveDiagnostics(args.parts),
           }),
         );

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -420,32 +420,16 @@ export const verifyChatOwnership = internalQuery({
   },
   returns: v.boolean(),
   handler: async (ctx, args) => {
-    const chat = await ctx.db
-      .query("chats")
-      .withIndex("by_chat_id", (q) => q.eq("id", args.chatId))
-      .first();
-
-    if (!chat) {
-      throw new ConvexError({
-        code: "CHAT_NOT_FOUND",
-        message: "This chat doesn't exist",
-      });
-    } else if (chat.user_id !== args.userId) {
-      throw new ConvexError({
-        code: "CHAT_UNAUTHORIZED",
-        message: "You don't have permission to access this chat",
-      });
-    }
-
+    await loadOwnedChat(ctx, args.chatId, args.userId);
     return true;
   },
 });
 
-async function ensureChatWritableForMessageInsert(
-  ctx: MutationCtx,
+async function loadOwnedChat(
+  ctx: { db: GenericDatabaseReader<DataModel> },
   chatId: string,
   userId: string,
-): Promise<void> {
+): Promise<Doc<"chats">> {
   const chat = await ctx.db
     .query("chats")
     .withIndex("by_chat_id", (q) => q.eq("id", chatId))
@@ -464,6 +448,16 @@ async function ensureChatWritableForMessageInsert(
       message: "You don't have permission to access this chat",
     });
   }
+
+  return chat;
+}
+
+async function ensureChatWritableForMessageInsert(
+  ctx: MutationCtx,
+  chatId: string,
+  userId: string,
+): Promise<void> {
+  const chat = await loadOwnedChat(ctx, chatId, userId);
 
   if (chat.canceled_at !== undefined) {
     throw new ConvexError({

--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -379,6 +379,78 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     expect(result.result.exitCode).toBe(0);
   });
 
+  test("blocks non-interactive execution when a selected local sandbox falls back", async () => {
+    const e2b = makeFakeE2BSandbox();
+    const { context, sandboxManager, writerWrites } = makeContext({
+      sandbox: e2b,
+    });
+    sandboxManager.consumeFallbackInfo.mockReturnValueOnce({
+      occurred: true,
+      reason: "no_local_connections",
+      requestedPreference: "desktop",
+      actualSandbox: "e2b",
+      actualSandboxName: "Cloud",
+    });
+    const tool = createRunTerminalCmd(context);
+
+    const result = (await runTool(tool, {
+      command: "rm -rf ~/project",
+      brief: "run command",
+      is_background: false,
+      timeout: 5,
+    })) as { result: { error?: string; exitCode: number } };
+
+    expect(e2b.commands.run).not.toHaveBeenCalled();
+    expect(result.result.exitCode).toBe(1);
+    expect(result.result.error).toContain("request couldn't be processed");
+    expect(writerWrites).toContainEqual(
+      expect.objectContaining({
+        type: "data-sandbox-fallback",
+        data: expect.objectContaining({
+          actualSandbox: "e2b",
+          requestedPreference: "desktop",
+        }),
+      }),
+    );
+  });
+
+  test("blocks interactive PTY creation when a selected local sandbox falls back", async () => {
+    const e2b = makeFakeE2BSandbox();
+    const { context, sandboxManager, writerWrites } = makeContext({
+      sandbox: e2b,
+    });
+    sandboxManager.consumeFallbackInfo.mockReturnValueOnce({
+      occurred: true,
+      reason: "connection_unavailable",
+      requestedPreference: "desktop",
+      actualSandbox: "other-local",
+      actualSandboxName: "Other Mac",
+    });
+    const tool = createRunTerminalCmd(context);
+
+    const result = (await runTool(tool, {
+      action: "exec",
+      command: "sh",
+      brief: "open shell",
+      is_background: false,
+      interactive: true,
+      timeout: 1,
+    })) as { result: { error?: string; exitCode: number } };
+
+    expect(mockCreateE2BPtyHandle).not.toHaveBeenCalled();
+    expect(result.result.exitCode).toBe(1);
+    expect(result.result.error).toContain("request couldn't be processed");
+    expect(writerWrites).toContainEqual(
+      expect.objectContaining({
+        type: "data-sandbox-fallback",
+        data: expect.objectContaining({
+          actualSandbox: "other-local",
+          requestedPreference: "desktop",
+        }),
+      }),
+    );
+  });
+
   test("exec + interactive=true on Centrifugo sandbox invokes createCentrifugoPtyHandle", async () => {
     const fakeHandle = makeFakeHandle();
     mockCreateCentrifugoPtyHandle.mockResolvedValue(fakeHandle);

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -33,7 +33,10 @@ import {
   type PtySession,
 } from "./utils/pty-session-manager";
 import { getSessionSnapshots } from "./utils/pty-output-formatter";
-import { writeSandboxFallbackEvent } from "./utils/sandbox-fallback";
+import {
+  assertLocalSandboxFallbackAllowed,
+  writeSandboxFallbackEvent,
+} from "./utils/sandbox-fallback";
 import {
   waitForOutput,
   capOutput,
@@ -221,6 +224,7 @@ In using these tools, adhere to the following guidelines:
               fallbackInfo,
               `sandbox-fallback-${toolCallId}`,
             );
+            assertLocalSandboxFallbackAllowed({ fallbackInfo });
           }
           const isCentrifugo = isCentrifugoSandbox(sandbox);
           const isE2B = isE2BSandbox(sandbox);
@@ -374,6 +378,7 @@ In using these tools, adhere to the following guidelines:
             fallbackInfo,
             `sandbox-fallback-${toolCallId}`,
           );
+          assertLocalSandboxFallbackAllowed({ fallbackInfo });
         }
 
         // Bail early if sandbox was already marked unavailable by any tool

--- a/lib/chat/__tests__/agent-run-spend-cap.test.ts
+++ b/lib/chat/__tests__/agent-run-spend-cap.test.ts
@@ -55,7 +55,7 @@ describe("canContinueProAgentRunWithPremium", () => {
 });
 
 describe("resolveAgentRunSpendCapContinuationModel", () => {
-  it("forces Pro Agent spend-cap auto-continues to Standard without extra usage", () => {
+  it("forces Pro Agent spend-cap continuations to Standard without extra usage", () => {
     expect(
       resolveAgentRunSpendCapContinuationModel({
         finishReason: "agent-run-spend-cap",
@@ -85,6 +85,28 @@ describe("resolveAgentRunSpendCapContinuationModel", () => {
         mode: "agent",
         subscription: "pro",
         selectedModelOverride: undefined,
+        extraUsageConfig: undefined,
+      }),
+    ).toBe(AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL);
+
+    expect(
+      resolveAgentRunSpendCapContinuationModel({
+        finishReason: "agent-run-spend-cap",
+        isAutoContinue: false,
+        mode: "agent",
+        subscription: "pro",
+        selectedModelOverride: "hackerai-pro",
+        extraUsageConfig: undefined,
+      }),
+    ).toBe(AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL);
+
+    expect(
+      resolveAgentRunSpendCapContinuationModel({
+        finishReason: "agent-run-spend-cap",
+        isAutoContinue: undefined,
+        mode: "agent",
+        subscription: "pro",
+        selectedModelOverride: "hackerai-max",
         extraUsageConfig: undefined,
       }),
     ).toBe(AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL);

--- a/lib/chat/agent-run-spend-cap.ts
+++ b/lib/chat/agent-run-spend-cap.ts
@@ -63,7 +63,6 @@ export function resolveAgentRunSpendCapContinuationModel(args: {
 }): SelectedModel | undefined {
   const {
     finishReason,
-    isAutoContinue,
     mode,
     subscription,
     selectedModelOverride,
@@ -75,7 +74,6 @@ export function resolveAgentRunSpendCapContinuationModel(args: {
 
   if (
     finishReason !== AGENT_RUN_SPEND_CAP_FINISH_REASON ||
-    !isAutoContinue ||
     mode !== "agent" ||
     subscription !== "pro" ||
     isAlreadyStandardContinuation ||


### PR DESCRIPTION
## Summary
- block terminal command execution when a selected local sandbox falls back after Agent setup
- enforce Pro Agent spend-cap Standard continuation from persisted capped-run state, not the client auto-continue flag
- prevent new message inserts into chats that are already canceled/deleting while allowing late assistant cleanup to no-op

## Testing
- `pnpm test -- lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/chat/__tests__/agent-run-spend-cap.test.ts convex/__tests__/messages.hidden.test.ts --runInBand`
- `pnpm exec eslint lib/ai/tools/run-terminal-cmd.ts lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/chat/agent-run-spend-cap.ts lib/chat/__tests__/agent-run-spend-cap.test.ts convex/messages.ts convex/__tests__/messages.hidden.test.ts`
- `pnpm exec prettier --check lib/ai/tools/run-terminal-cmd.ts lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/chat/agent-run-spend-cap.ts lib/chat/__tests__/agent-run-spend-cap.test.ts convex/messages.ts convex/__tests__/messages.hidden.test.ts`
- `pnpm typecheck`

## Manual verification
- Start an Agent run with Desktop or a specific Remote Connection selected, disconnect it after setup, then trigger a terminal command. The command should fail closed instead of running on Cloud or another local sandbox.
- Continue a Pro Agent run paused with `agent-run-spend-cap` while extra usage cannot cover premium continuation. Manual and auto continuation should use Standard.
- Delete all chats while a stream is in flight. Late assistant saves after `canceled_at` should not insert new message rows.

## Notes
This PR fixes the three confirmed findings from the weekly Codex Security diff scan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent inserting messages into canceled chats: assistant-role saves are skipped, and user-role saves fail with the appropriate `MESSAGE_SAVE_FAILED` handling.
  * Block terminal command execution when a local sandbox fallback occurs, enforcing whether local fallback is allowed for both interactive and non-interactive runs.

* **Tests**
  * Added chat cancellation coverage for message saving.
  * Added sandbox-fallback tests to verify blocking and fallback event emission.
  * Expanded spend-cap continuation model test coverage and updated expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->