### PR TITLE
Classify local sandbox fallback blocks

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -452,6 +452,16 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(/user-correctable request error/);
   });
 
+  test("blocked local sandbox fallback errors are user-correctable diagnostics", () => {
+    expect(taskSrc).toMatch(/localSandboxFallbackBlocked/);
+    expect(taskSrc).toMatch(/"local_sandbox_fallback_blocked"/);
+    expect(taskSrc).toMatch(/sandboxFallbackReason/);
+    expect(taskSrc).toMatch(/requestedPreference/);
+    expect(taskSrc).toMatch(/actualSandbox/);
+    expect(taskSrc).toMatch(/isExpectedUserCorrectableError/);
+    expect(taskSrc).toMatch(/user-correctable request error/);
+  });
+
   test("agent-long only passes explicit Trigger.dev region when mapped", () => {
     const routingIdx = routeSrc.indexOf(
       "getTriggerRegionForVercelRequest(req)",

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -754,6 +754,42 @@ describe("createChatLogger ChatSDKError metadata", () => {
     }
   });
 
+  it("keeps local sandbox fallback metadata queryable", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_local_fallback",
+        endpoint: "/api/agent-long",
+      });
+
+      chatLogger.emitChatError(
+        new ChatSDKError(
+          "bad_request:api",
+          "The selected local sandbox is unavailable.",
+          {
+            localSandboxFallbackBlocked: true,
+            sandboxFallbackReason: "selected_unavailable",
+            requestedPreference: "desktop",
+            actualSandbox: "remote-connection-1",
+            actualSandboxName: "Lab VM",
+          },
+        ),
+      );
+
+      const wideEvent = JSON.parse(String(logSpy.mock.calls[0][0]));
+      expect(wideEvent.error.metadata).toEqual({
+        localSandboxFallbackBlocked: true,
+        sandboxFallbackReason: "selected_unavailable",
+        requestedPreference: "desktop",
+        actualSandbox: "remote-connection-1",
+      });
+      expect(wideEvent.error.metadata).not.toHaveProperty("actualSandboxName");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
   it("emits limit pressure funnel properties for paid monthly exhaustion", () => {
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     const eventSpy = jest.spyOn(phLogger, "event").mockImplementation(() => {});

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -177,6 +177,10 @@ const COMPACT_CHAT_ERROR_METADATA_KEYS = [
   "upload_failure_protocol",
   "upload_failure_url_length",
   "upload_retried_with_fresh_sandbox",
+  "localSandboxFallbackBlocked",
+  "sandboxFallbackReason",
+  "requestedPreference",
+  "actualSandbox",
 ] as const;
 
 const compactChatErrorMetadata = (

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -315,6 +315,10 @@ type AgentLongErrorSummary = {
   largestFileToken?: number;
   emptyAfterProcessing?: boolean;
   emptyAfterProcessingMetadata?: Record<string, TriggerMetadataPrimitive>;
+  localSandboxFallbackBlocked?: boolean;
+  sandboxFallbackReason?: string;
+  requestedPreference?: string;
+  actualSandbox?: string;
   uploadFailureKind?: string;
   uploadFailureCause?: string;
   uploadFailureTransientSandboxCommand?: boolean;
@@ -413,7 +417,9 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
                 ? "input_too_large"
                 : errorMetadata?.empty_after_processing === true
                   ? "empty_after_processing"
-                  : "chat_error",
+                  : errorMetadata?.localSandboxFallbackBlocked === true
+                    ? "local_sandbox_fallback_blocked"
+                    : "chat_error",
       code,
       name: "ChatSDKError",
       message: errorMessage,
@@ -453,6 +459,17 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
         errorMetadata?.empty_after_processing === true || undefined,
       emptyAfterProcessingMetadata:
         getEmptyAfterProcessingTriggerMetadata(errorMetadata),
+      localSandboxFallbackBlocked:
+        errorMetadata?.localSandboxFallbackBlocked === true || undefined,
+      sandboxFallbackReason: getStringMetadata(
+        errorMetadata,
+        "sandboxFallbackReason",
+      ),
+      requestedPreference: getStringMetadata(
+        errorMetadata,
+        "requestedPreference",
+      ),
+      actualSandbox: getStringMetadata(errorMetadata, "actualSandbox"),
       uploadFailureKind: getStringMetadata(
         errorMetadata,
         "upload_failure_kind",
@@ -584,6 +601,15 @@ const recordAgentLongFailureForDashboard = async (
       metadata.set(key, value);
     }
   }
+  if (summary.localSandboxFallbackBlocked) {
+    metadata.set("localSandboxFallbackBlocked", true);
+  }
+  if (summary.sandboxFallbackReason)
+    metadata.set("sandboxFallbackReason", summary.sandboxFallbackReason);
+  if (summary.requestedPreference)
+    metadata.set("requestedPreference", summary.requestedPreference);
+  if (summary.actualSandbox)
+    metadata.set("actualSandbox", summary.actualSandbox);
   if (summary.uploadFailureKind)
     metadata.set("uploadFailureKind", summary.uploadFailureKind);
   if (summary.uploadFailureCause)
@@ -624,7 +650,8 @@ const recordAgentLongFailureForDashboard = async (
     summary.category === "chat_not_found" ||
     summary.category === "empty_prompt" ||
     summary.category === "input_too_large" ||
-    summary.category === "empty_after_processing";
+    summary.category === "empty_after_processing" ||
+    summary.category === "local_sandbox_fallback_blocked";
 
   if (isExpectedUserCorrectableError) {
     triggerLogger.warn(


### PR DESCRIPTION
## Summary
- classify blocked local-sandbox fallback ChatSDKError cases as `local_sandbox_fallback_blocked` instead of generic `chat_error`
- record filterable sandbox fallback metadata in Trigger.dev run metadata and compact chat logs
- treat this category as user-correctable so Trigger logging uses the existing warn path instead of creating noisy error issues

## Testing
- `pnpm test -- lib/api/__tests__/agent-long-contracts.test.ts lib/api/__tests__/chat-logger.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint trigger/agent-long.ts lib/api/chat-logger.ts lib/api/__tests__/agent-long-contracts.test.ts lib/api/__tests__/chat-logger.test.ts`
- `pnpm exec prettier --check trigger/agent-long.ts lib/api/chat-logger.ts lib/api/__tests__/agent-long-contracts.test.ts lib/api/__tests__/chat-logger.test.ts`

## Manual verification
- In Agent mode, select a local sandbox/remote connection that is unavailable while another sandbox fallback would otherwise be possible.
- Send a message that would use Agent commands.
- Confirm the user sees the existing reconnect/select-right-sandbox message, usage is refunded, and Trigger.dev shows `local_sandbox_fallback_blocked` metadata with a warning log rather than a generic unresolved `chat_error` error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for blocked local sandbox fallback scenarios, now correctly classified as user-correctable issues rather than system failures.
  * Enhanced error metadata tracking to capture sandbox preference and fallback reason details.

* **Tests**
  * Added test coverage for sandbox fallback error detection and metadata validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->