### PR TITLE
Add public status page links

### DIFF
--- a/app/components/SidebarUserNav.tsx
+++ b/app/components/SidebarUserNav.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { useAction, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import {
+  Activity,
   LogOut,
   Sparkle,
   LifeBuoy,
@@ -48,6 +49,8 @@ import { ReferralRewardDialog } from "./ReferralRewardDialog";
 
 const NEXT_PUBLIC_HELP_CENTER_URL =
   process.env.NEXT_PUBLIC_HELP_CENTER_URL || "https://help.hackerai.co/en/";
+
+const STATUS_PAGE_URL = "https://status.hackerai.co/";
 
 const REFERRAL_CARD_DISMISSED_COOKIE = "referral_sidebar_dismissed";
 
@@ -320,6 +323,17 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
 
   const handleTrustPage = () => {
     const newWindow = window.open("/trust", "_blank", "noopener,noreferrer");
+    if (newWindow) {
+      newWindow.opener = null;
+    }
+  };
+
+  const handleStatusPage = () => {
+    const newWindow = window.open(
+      STATUS_PAGE_URL,
+      "_blank",
+      "noopener,noreferrer",
+    );
     if (newWindow) {
       newWindow.opener = null;
     }
@@ -633,6 +647,10 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
               <DropdownMenuItem onClick={handleHelpCenter} className="py-1.5">
                 <LifeBuoy className="mr-2 h-4 w-4 text-foreground" />
                 <span>Help Center</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handleStatusPage} className="py-1.5">
+                <Activity className="mr-2 h-4 w-4 text-foreground" />
+                <span>Status Page</span>
               </DropdownMenuItem>
               <DropdownMenuItem onClick={handleTrustPage} className="py-1.5">
                 <ShieldCheck className="mr-2 h-4 w-4 text-foreground" />

--- a/app/trust/page.tsx
+++ b/app/trust/page.tsx
@@ -36,10 +36,12 @@ export const metadata: Metadata = {
 
 export const dynamic = "force-static";
 
-const LAST_UPDATED = "June 10, 2026";
+const LAST_UPDATED = "June 24, 2026";
 
 const HELP_CENTER_URL =
   process.env.NEXT_PUBLIC_HELP_CENTER_URL || "https://help.hackerai.co/en/";
+
+const STATUS_PAGE_URL = "https://status.hackerai.co/";
 
 interface Subprocessor {
   name: string;
@@ -334,9 +336,12 @@ export default function TrustPage() {
 
             <Section icon={Activity} title="Incident communication">
               <p>
-                We don&apos;t yet operate a public status page. If an incident
-                affects your data, we notify affected users through the service
-                and the help center.
+                For availability updates and scheduled maintenance, check the{" "}
+                <InlineLink href={STATUS_PAGE_URL}>
+                  public status page
+                </InlineLink>
+                . If an incident affects your data, we notify affected users
+                through the service and the help center.
               </p>
             </Section>
           </div>
@@ -374,11 +379,12 @@ export default function TrustPage() {
 
         {/* Related documents */}
         <footer className="mt-12">
-          <div className="grid gap-4 sm:grid-cols-3">
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             {[
               { href: "/privacy-policy", label: "Privacy Policy" },
               { href: "/terms-of-service", label: "Terms of Service" },
               { href: HELP_CENTER_URL, label: "Help center" },
+              { href: STATUS_PAGE_URL, label: "Status Page" },
             ].map((link) => (
               <a
                 key={link.href}


### PR DESCRIPTION
## Summary
- add the public HackerAI status page to the user menu Help dropdown
- update the Security & Trust incident communication section to point to the public status page
- include Status Page in the trust page related links and update the trust page timestamp

## Validation
- pnpm exec prettier --check app/components/SidebarUserNav.tsx app/trust/page.tsx
- pnpm exec eslint app/components/SidebarUserNav.tsx app/trust/page.tsx
- git diff --check
- git commit hook: pnpm typecheck
- git commit hook: pnpm test
- /usr/bin/curl -I --max-time 10 https://status.hackerai.co/ returned HTTP 200
- local Next dev server returned HTTP 200 for /trust and rendered the status page link/copy

## Manual verification
- In the authenticated app, open the user menu, expand Help, and click Status Page. It should open https://status.hackerai.co/ in a new tab.
- Visit /trust and confirm the Incident communication section links to the public status page.
- Confirm the trust page footer includes Status Page alongside Privacy Policy, Terms of Service, and Help center.

## Visual verification
- Browser screenshot automation was not available in this local environment because the bundled Playwright browser is not installed and system Chrome aborted under Playwright. The rendered /trust route was verified through the local Next server response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Status Page** option in the Help dropdown for quick access to service updates.
  * Added a **Status Page** link to the Trust page’s related resources.

* **Documentation**
  * Updated the Trust page’s “Last updated” date.
  * Clarified incident communication messaging to point users to the public status page for availability and maintenance updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->