### PR TITLE
Handle user-correctable Trigger request errors

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -387,8 +387,40 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(/errorCategory/);
     expect(taskSrc).toMatch(/loginRequired/);
     expect(taskSrc).toMatch(/login_required/);
-    expect(taskSrc).toMatch(/error_\$\{summary\.category\}/);
+    expect(taskSrc).toMatch(/`error_\$\{summary\.category\}`/);
+    expect(taskSrc).toMatch(/`user_correctable_\$\{summary\.category\}`/);
     expect(taskSrc).toMatch(/metadata\.flush\(\)/);
+  });
+
+  test("user-correctable agent-long request errors complete without failing Trigger", () => {
+    expect(taskSrc).toMatch(/USER_CORRECTABLE_AGENT_LONG_ERROR_CATEGORIES/);
+    expect(taskSrc).toMatch(/isUserCorrectableAgentLongErrorCategory/);
+    expect(taskSrc).toMatch(/"user_correctable"/);
+    expect(taskSrc).toMatch(/userCorrectable/);
+    expect(taskSrc).toMatch(/user_correctable_code_/);
+
+    const recordedFailureIdx = taskSrc.indexOf(
+      "const recordedFailure = await recordAgentLongFailureForDashboard",
+    );
+    const syntheticFlushIdx = taskSrc.indexOf(
+      "await waitForErrorStream()",
+      recordedFailureIdx,
+    );
+    const handledReturnGuardIdx = taskSrc.indexOf(
+      "recordedFailure?.userCorrectable === true",
+      syntheticFlushIdx,
+    );
+    const returnIdx = taskSrc.indexOf(
+      "return { chatId, assistantMessageId }",
+      handledReturnGuardIdx,
+    );
+    const throwIdx = taskSrc.indexOf("throw error", returnIdx);
+
+    expect(recordedFailureIdx).toBeGreaterThan(-1);
+    expect(syntheticFlushIdx).toBeGreaterThan(recordedFailureIdx);
+    expect(handledReturnGuardIdx).toBeGreaterThan(syntheticFlushIdx);
+    expect(returnIdx).toBeGreaterThan(handledReturnGuardIdx);
+    expect(throwIdx).toBeGreaterThan(returnIdx);
   });
 
   test("empty rehydrated history is classified separately from oversized input", () => {
@@ -448,7 +480,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(/emptyAfterProcessing/);
     expect(taskSrc).toMatch(/processingInputMessageCount/);
     expect(taskSrc).toMatch(/processingInputUiOnlyPartCount/);
-    expect(taskSrc).toMatch(/isExpectedUserCorrectableError/);
+    expect(taskSrc).toMatch(/isUserCorrectableAgentLongErrorCategory/);
     expect(taskSrc).toMatch(/user-correctable request error/);
   });
 
@@ -458,7 +490,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(/sandboxFallbackReason/);
     expect(taskSrc).toMatch(/requestedPreference/);
     expect(taskSrc).toMatch(/actualSandbox/);
-    expect(taskSrc).toMatch(/isExpectedUserCorrectableError/);
+    expect(taskSrc).toMatch(/isUserCorrectableAgentLongErrorCategory/);
     expect(taskSrc).toMatch(/user-correctable request error/);
   });
 

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -389,15 +389,19 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(/login_required/);
     expect(taskSrc).toMatch(/`error_\$\{summary\.category\}`/);
     expect(taskSrc).toMatch(/`user_correctable_\$\{summary\.category\}`/);
+    expect(taskSrc).toMatch(/TRIGGER_TAG_MAX_LENGTH\s*=\s*64/);
+    expect(taskSrc).toMatch(/buildTriggerTag/);
     expect(taskSrc).toMatch(/metadata\.flush\(\)/);
   });
 
   test("user-correctable agent-long request errors complete without failing Trigger", () => {
     expect(taskSrc).toMatch(/USER_CORRECTABLE_AGENT_LONG_ERROR_CATEGORIES/);
     expect(taskSrc).toMatch(/isUserCorrectableAgentLongErrorCategory/);
+    expect(taskSrc).toMatch(/"login_required"/);
     expect(taskSrc).toMatch(/"user_correctable"/);
     expect(taskSrc).toMatch(/userCorrectable/);
     expect(taskSrc).toMatch(/user_correctable_code_/);
+    expect(taskSrc).toMatch(/caughtErrorUserCorrectable/);
 
     const recordedFailureIdx = taskSrc.indexOf(
       "const recordedFailure = await recordAgentLongFailureForDashboard",
@@ -407,7 +411,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       recordedFailureIdx,
     );
     const handledReturnGuardIdx = taskSrc.indexOf(
-      "recordedFailure?.userCorrectable === true",
+      "recordedFailure.userCorrectable === true",
       syntheticFlushIdx,
     );
     const returnIdx = taskSrc.indexOf(

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -147,14 +147,21 @@ const getAgentLongMaxDurationMs = (subscription: SubscriptionTier) =>
 type AgentLongUiStreamPart = Parameters<UIMessageStreamWriter["write"]>[0];
 
 const MAX_TRIGGER_ERROR_MESSAGE_LENGTH = 500;
+const TRIGGER_TAG_MAX_LENGTH = 64;
 
 const truncateForTriggerMetadata = (value: string) =>
   value.length > MAX_TRIGGER_ERROR_MESSAGE_LENGTH
     ? `${value.slice(0, MAX_TRIGGER_ERROR_MESSAGE_LENGTH)}...`
     : value;
 
-const sanitizeTriggerTagValue = (value: string) =>
-  value.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 80);
+const sanitizeTriggerTagValue = (value: string, maxLength: number) =>
+  value.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, maxLength);
+
+const buildTriggerTag = (prefix: string, value: string) =>
+  `${prefix}${sanitizeTriggerTagValue(
+    value,
+    Math.max(0, TRIGGER_TAG_MAX_LENGTH - prefix.length),
+  )}`;
 
 const getStringMetadata = (
   metadata: Record<string, unknown> | undefined,
@@ -346,6 +353,7 @@ const isChatNotFoundError = (error: ChatSDKError): boolean => {
 
 const USER_CORRECTABLE_AGENT_LONG_ERROR_CATEGORIES = new Set([
   "chat_not_found",
+  "login_required",
   "empty_prompt",
   "input_too_large",
   "empty_after_processing",
@@ -669,8 +677,8 @@ const recordAgentLongFailureForDashboard = async (
   if (summary.code) {
     terminalTags.push(
       isExpectedUserCorrectableError
-        ? `user_correctable_code_${sanitizeTriggerTagValue(summary.code)}`
-        : `error_code_${sanitizeTriggerTagValue(summary.code)}`,
+        ? buildTriggerTag("user_correctable_code_", summary.code)
+        : buildTriggerTag("error_code_", summary.code),
     );
   }
   await tags.add(terminalTags);
@@ -725,7 +733,7 @@ const recordAgentLongHandledRateLimitForDashboard = async (
 
   await tags.add([
     "rate_limited",
-    `blocked_code_${sanitizeTriggerTagValue(summary.code ?? "rate_limit_chat")}`,
+    buildTriggerTag("blocked_code_", summary.code ?? "rate_limit_chat"),
   ]);
 
   triggerLogger.info("[agent-long] run rate limited", {
@@ -2174,18 +2182,29 @@ export const agentLongTask = task({
         streamPiped &&
         error instanceof ChatSDKError &&
         isChatNotFoundError(error);
+      const caughtErrorSummary = classifyAgentLongError(error);
+      const caughtErrorUserCorrectable =
+        isUserCorrectableAgentLongErrorCategory(caughtErrorSummary.category);
       const recordedFailure = await recordAgentLongFailureForDashboard(error, {
         chatId,
         userId,
         runId: ctx.run.id,
         phase: streamPiped ? "streaming" : "setup",
-      }).catch((metadataError): RecordedAgentLongFailure | undefined => {
-        metadata.set("status", "failed");
+      }).catch((metadataError): RecordedAgentLongFailure => {
+        metadata
+          .set(
+            "status",
+            getAgentLongErrorRunStatus(caughtErrorSummary.category),
+          )
+          .set("errorCategory", caughtErrorSummary.category);
+        if (caughtErrorUserCorrectable) {
+          metadata.set("userCorrectable", true);
+        }
         console.error(
           "[agent-long] failed to record run error metadata:",
           metadataError,
         );
-        return undefined;
+        return { userCorrectable: caughtErrorUserCorrectable };
       });
       if (!hasObservedUsage()) {
         await usageRefundTracker.refund().catch(() => {});
@@ -2234,7 +2253,7 @@ export const agentLongTask = task({
 
       await phLogger.flush().catch(() => {});
       if (
-        (chatMissingAfterStream || recordedFailure?.userCorrectable === true) &&
+        (chatMissingAfterStream || recordedFailure.userCorrectable === true) &&
         userVisibleErrorStreamFlushed
       ) {
         return { chatId, assistantMessageId };

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -344,6 +344,25 @@ const isChatNotFoundError = (error: ChatSDKError): boolean => {
   );
 };
 
+const USER_CORRECTABLE_AGENT_LONG_ERROR_CATEGORIES = new Set([
+  "chat_not_found",
+  "empty_prompt",
+  "input_too_large",
+  "empty_after_processing",
+  "local_sandbox_fallback_blocked",
+]);
+
+const isUserCorrectableAgentLongErrorCategory = (category: string): boolean =>
+  USER_CORRECTABLE_AGENT_LONG_ERROR_CATEGORIES.has(category);
+
+const getAgentLongErrorRunStatus = (category: string): string => {
+  if (category === "chat_not_found") return "chat_not_found";
+  if (isUserCorrectableAgentLongErrorCategory(category)) {
+    return "user_correctable";
+  }
+  return "failed";
+};
+
 const TRIGGER_REALTIME_TRANSPORT_ERROR_PATTERNS = [
   /@s2-dev\/streamstore/i,
   /S2AppendSession/i,
@@ -535,6 +554,10 @@ const isTerminalProviderStreamError = (
     | undefined,
 ): boolean => state?.streamFinishReason === "error";
 
+type RecordedAgentLongFailure = {
+  userCorrectable: boolean;
+};
+
 const recordAgentLongFailureForDashboard = async (
   error: unknown,
   context: {
@@ -543,18 +566,25 @@ const recordAgentLongFailureForDashboard = async (
     runId: string;
     phase: "setup" | "streaming";
   },
-) => {
+): Promise<RecordedAgentLongFailure> => {
   const summary = classifyAgentLongError(error);
-  const runStatus =
-    summary.category === "chat_not_found" ? "chat_not_found" : "failed";
+  const runStatus = getAgentLongErrorRunStatus(summary.category);
+  const isExpectedUserCorrectableError =
+    isUserCorrectableAgentLongErrorCategory(summary.category);
+  const terminalAt = new Date().toISOString();
+
   metadata
     .set("status", runStatus)
     .set("errorCategory", summary.category)
     .set("errorName", summary.name)
     .set("errorMessage", summary.message)
     .set("loginRequired", summary.loginRequired)
-    .set("failedPhase", context.phase)
-    .set("failedAt", new Date().toISOString());
+    .set("terminalPhase", context.phase);
+  if (isExpectedUserCorrectableError) {
+    metadata.set("userCorrectable", true).set("endedAt", terminalAt);
+  } else {
+    metadata.set("failedPhase", context.phase).set("failedAt", terminalAt);
+  }
 
   if (summary.code) metadata.set("errorCode", summary.code);
   if (summary.statusCode) metadata.set("errorStatusCode", summary.statusCode);
@@ -631,11 +661,19 @@ const recordAgentLongFailureForDashboard = async (
     );
   }
 
-  const errorTags = [`error_${summary.category}`];
+  const terminalTags = [
+    isExpectedUserCorrectableError
+      ? `user_correctable_${summary.category}`
+      : `error_${summary.category}`,
+  ];
   if (summary.code) {
-    errorTags.push(`error_code_${sanitizeTriggerTagValue(summary.code)}`);
+    terminalTags.push(
+      isExpectedUserCorrectableError
+        ? `user_correctable_code_${sanitizeTriggerTagValue(summary.code)}`
+        : `error_code_${sanitizeTriggerTagValue(summary.code)}`,
+    );
   }
-  await tags.add(errorTags);
+  await tags.add(terminalTags);
 
   const { emptyAfterProcessingMetadata, ...summaryLogFields } = summary;
   const logFields = {
@@ -646,12 +684,6 @@ const recordAgentLongFailureForDashboard = async (
     ...summaryLogFields,
     ...emptyAfterProcessingMetadata,
   };
-  const isExpectedUserCorrectableError =
-    summary.category === "chat_not_found" ||
-    summary.category === "empty_prompt" ||
-    summary.category === "input_too_large" ||
-    summary.category === "empty_after_processing" ||
-    summary.category === "local_sandbox_fallback_blocked";
 
   if (isExpectedUserCorrectableError) {
     triggerLogger.warn(
@@ -668,6 +700,9 @@ const recordAgentLongFailureForDashboard = async (
   }
 
   await metadata.flush();
+  return {
+    userCorrectable: isExpectedUserCorrectableError,
+  };
 };
 
 const recordAgentLongHandledRateLimitForDashboard = async (
@@ -2139,17 +2174,18 @@ export const agentLongTask = task({
         streamPiped &&
         error instanceof ChatSDKError &&
         isChatNotFoundError(error);
-      await recordAgentLongFailureForDashboard(error, {
+      const recordedFailure = await recordAgentLongFailureForDashboard(error, {
         chatId,
         userId,
         runId: ctx.run.id,
         phase: streamPiped ? "streaming" : "setup",
-      }).catch((metadataError) => {
+      }).catch((metadataError): RecordedAgentLongFailure | undefined => {
         metadata.set("status", "failed");
         console.error(
           "[agent-long] failed to record run error metadata:",
           metadataError,
         );
+        return undefined;
       });
       if (!hasObservedUsage()) {
         await usageRefundTracker.refund().catch(() => {});
@@ -2165,16 +2201,12 @@ export const agentLongTask = task({
           console.error("[agent-long] PTY closeAll (outer catch) failed:", err),
         );
 
-      if (chatMissingAfterStream) {
-        await phLogger.flush().catch(() => {});
-        return { chatId, assistantMessageId };
-      }
-
       // Pre-stream setup failed (DB fetch, message processing, etc.). Emit a
       // one-shot UI stream whose onError converts the caught error into the
       // same friendly error chunk format useChat expects. Without this, the
       // frontend transport only sees the run go to FAILED and emits a silent
       // abort, leaving the user stuck on a Stop button with no message.
+      let userVisibleErrorStreamFlushed = streamPiped;
       if (!streamPiped) {
         try {
           const errorStream = createUIMessageStream({
@@ -2191,6 +2223,7 @@ export const agentLongTask = task({
           const { waitUntilComplete: waitForErrorStream } =
             agentUiStream.pipe(errorStream);
           await waitForErrorStream();
+          userVisibleErrorStreamFlushed = true;
         } catch (pipeErr) {
           console.error(
             "[agent-long] Failed to emit synthetic error stream:",
@@ -2200,6 +2233,13 @@ export const agentLongTask = task({
       }
 
       await phLogger.flush().catch(() => {});
+      if (
+        (chatMissingAfterStream || recordedFailure?.userCorrectable === true) &&
+        userVisibleErrorStreamFlushed
+      ) {
+        return { chatId, assistantMessageId };
+      }
+
       throw error;
     } finally {
       if (agentLongTimeout) clearTimeout(agentLongTimeout);


### PR DESCRIPTION
## Summary
- classify expected agent-long request failures as user-correctable terminal outcomes in Trigger metadata and tags
- complete the Trigger task after the UI error chunk is flushed instead of rethrowing these handled request errors
- keep unexpected and provider failures on failed/error status and tags

## Testing
- pnpm test -- lib/api/__tests__/agent-long-contracts.test.ts --runInBand
- pnpm typecheck
- pnpm exec eslint trigger/agent-long.ts lib/api/__tests__/agent-long-contracts.test.ts
- pnpm exec prettier --check trigger/agent-long.ts lib/api/__tests__/agent-long-contracts.test.ts
- pnpm lint (passes with existing warnings in unrelated files)

## Manual verification
- In Agent mode, trigger a regenerate/run whose processed message history is empty.
- Confirm the chat receives the friendly empty-content error message.
- Confirm the Trigger run completes with `status=user_correctable` and `user_correctable_empty_after_processing` metadata/tagging instead of a failed operational error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded agent-long error categorization to mark additional failures as user-correctable.
  * Updated dashboard metadata and trigger tags to more clearly distinguish chat-not-found, user-correctable, and failed terminal states.

* **Bug Fixes**
  * Prevented certain user-correctable failures from leaving the UI stuck by ensuring the user-visible error stream is flushed before suppressing rethrows.
  * Improved timing of visible error updates during failure handling.

* **Tests**
  * Enhanced structural contract checks for dashboard error visibility, including new user-correctable ordering assertions.
  * Updated diagnostics expectations for user-correctable classification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->