### PR TITLE
Block chat access during fraud disputes

### DIFF
--- a/app/api/chat/[id]/__tests__/route.test.ts
+++ b/app/api/chat/[id]/__tests__/route.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { ChatSDKError } from "@/lib/errors";
 
 const mockGetUserID = jest.fn();
 const mockGetChatById = jest.fn();
 const mockDeleteChatForBackend = jest.fn();
 const mockRunsCancel = jest.fn();
+const mockAssertUserCanAccessChatHistory = jest.fn();
 
 jest.mock("next/server", () => ({
   NextResponse: class MockNextResponse {
@@ -46,10 +48,25 @@ jest.mock("@/lib/db/actions", () => ({
   deleteChatForBackend: mockDeleteChatForBackend,
 }));
 
+jest.mock("@/lib/suspensions", () => ({
+  assertUserCanAccessChatHistory: mockAssertUserCanAccessChatHistory,
+}));
+
 const request = {} as any;
 const paramsFor = (id = "chat-1") => ({
   params: Promise.resolve({ id }),
 });
+
+function installResponseShim() {
+  (globalThis as any).Response = {
+    json: (body: unknown, init?: ResponseInit) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+      text: async () =>
+        typeof body === "string" ? body : JSON.stringify(body ?? ""),
+    }),
+  };
+}
 
 const chat = (overrides: Record<string, unknown> = {}) => ({
   id: "chat-1",
@@ -62,9 +79,11 @@ describe("DELETE /api/chat/[id]", () => {
   let errorSpy: jest.SpiedFunction<typeof console.error>;
 
   beforeEach(() => {
+    installResponseShim();
     jest.clearAllMocks();
     errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     mockGetUserID.mockResolvedValue("user-1" as never);
+    mockAssertUserCanAccessChatHistory.mockResolvedValue(undefined as never);
     mockGetChatById.mockResolvedValue(chat() as never);
     mockRunsCancel.mockResolvedValue(undefined as never);
     mockDeleteChatForBackend.mockResolvedValue(undefined as never);
@@ -132,6 +151,25 @@ describe("DELETE /api/chat/[id]", () => {
     const response = await DELETE(request, paramsFor());
 
     expect(response.status).toBe(403);
+    expect(mockRunsCancel).not.toHaveBeenCalled();
+    expect(mockDeleteChatForBackend).not.toHaveBeenCalled();
+  });
+
+  it("does not delete chats while fraud-dispute chat access is suspended", async () => {
+    const { DELETE } = await import("../route");
+    mockAssertUserCanAccessChatHistory.mockRejectedValue(
+      new ChatSDKError("forbidden:chat", "Fraud dispute hold") as never,
+    );
+
+    const response = await DELETE(request, paramsFor());
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toMatchObject({
+      code: "forbidden:chat",
+      cause: "Fraud dispute hold",
+    });
+    expect(mockGetChatById).not.toHaveBeenCalled();
     expect(mockRunsCancel).not.toHaveBeenCalled();
     expect(mockDeleteChatForBackend).not.toHaveBeenCalled();
   });

--- a/app/api/chat/[id]/route.ts
+++ b/app/api/chat/[id]/route.ts
@@ -4,6 +4,7 @@ import { runs } from "@trigger.dev/sdk";
 import { getUserID } from "@/lib/auth/get-user-id";
 import { deleteChatForBackend, getChatById } from "@/lib/db/actions";
 import { ChatSDKError } from "@/lib/errors";
+import { assertUserCanAccessChatHistory } from "@/lib/suspensions";
 
 export const maxDuration = 30;
 
@@ -18,6 +19,7 @@ export async function DELETE(
     }
 
     const userId = await getUserID(req);
+    await assertUserCanAccessChatHistory(userId);
     const chat = await getChatById({ id: chatId });
 
     if (!chat) {

--- a/app/api/chat/[id]/stream/route.ts
+++ b/app/api/chat/[id]/stream/route.ts
@@ -20,12 +20,6 @@ export async function GET(
 ) {
   const { id: chatId } = await params;
 
-  const streamContext = getStreamContext();
-
-  if (!streamContext) {
-    return new Response(null, { status: 204 });
-  }
-
   if (!chatId) {
     return new ChatSDKError("bad_request:api").toResponse();
   }
@@ -63,6 +57,12 @@ export async function GET(
 
   if (chat.user_id !== userId) {
     return new ChatSDKError("forbidden:chat").toResponse();
+  }
+
+  const streamContext = getStreamContext();
+
+  if (!streamContext) {
+    return new Response(null, { status: 204 });
   }
 
   const recentStreamId: string | undefined = chat.active_stream_id;

--- a/app/api/chat/[id]/stream/route.ts
+++ b/app/api/chat/[id]/stream/route.ts
@@ -10,6 +10,7 @@ import {
   createPreemptiveTimeout,
 } from "@/lib/utils/stream-cancellation";
 import { phLogger } from "@/lib/posthog/server";
+import { assertUserCanAccessChatHistory } from "@/lib/suspensions";
 
 export const maxDuration = 800;
 
@@ -36,6 +37,12 @@ export async function GET(
     userId = await getUserID(req);
   } catch (error) {
     return new ChatSDKError("unauthorized:chat").toResponse();
+  }
+  try {
+    await assertUserCanAccessChatHistory(userId);
+  } catch (error) {
+    if (error instanceof ChatSDKError) return error.toResponse();
+    throw error;
   }
   const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 

--- a/app/api/chats/__tests__/route.test.ts
+++ b/app/api/chats/__tests__/route.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { ChatSDKError } from "@/lib/errors";
 
 const mockGetUserID = jest.fn();
 const mockGetActiveTriggerRunsForUser = jest.fn();
 const mockDeleteAllChatsForBackend = jest.fn();
 const mockRunsCancel = jest.fn();
+const mockAssertUserCanAccessChatHistory = jest.fn();
 
 jest.mock("next/server", () => ({
   NextResponse: class MockNextResponse {
@@ -46,7 +48,22 @@ jest.mock("@/lib/db/actions", () => ({
   deleteAllChatsForBackend: mockDeleteAllChatsForBackend,
 }));
 
+jest.mock("@/lib/suspensions", () => ({
+  assertUserCanAccessChatHistory: mockAssertUserCanAccessChatHistory,
+}));
+
 const request = {} as any;
+
+function installResponseShim() {
+  (globalThis as any).Response = {
+    json: (body: unknown, init?: ResponseInit) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+      text: async () =>
+        typeof body === "string" ? body : JSON.stringify(body ?? ""),
+    }),
+  };
+}
 
 const activeRuns = (...triggerRunIds: string[]) => ({
   runs: triggerRunIds.map((triggerRunId, index) => ({
@@ -60,9 +77,11 @@ describe("DELETE /api/chats", () => {
   let errorSpy: jest.SpiedFunction<typeof console.error>;
 
   beforeEach(() => {
+    installResponseShim();
     jest.clearAllMocks();
     errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     mockGetUserID.mockResolvedValue("user-1" as never);
+    mockAssertUserCanAccessChatHistory.mockResolvedValue(undefined as never);
     mockGetActiveTriggerRunsForUser.mockResolvedValue(
       activeRuns("run-1", "run-2") as never,
     );
@@ -142,6 +161,25 @@ describe("DELETE /api/chats", () => {
 
     expect(response.status).toBe(409);
     expect(text).toBe("Too many active chat runs to delete safely");
+    expect(mockRunsCancel).not.toHaveBeenCalled();
+    expect(mockDeleteAllChatsForBackend).not.toHaveBeenCalled();
+  });
+
+  it("does not delete chats while fraud-dispute chat access is suspended", async () => {
+    const { DELETE } = await import("../route");
+    mockAssertUserCanAccessChatHistory.mockRejectedValue(
+      new ChatSDKError("forbidden:chat", "Fraud dispute hold") as never,
+    );
+
+    const response = await DELETE(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toMatchObject({
+      code: "forbidden:chat",
+      cause: "Fraud dispute hold",
+    });
+    expect(mockGetActiveTriggerRunsForUser).not.toHaveBeenCalled();
     expect(mockRunsCancel).not.toHaveBeenCalled();
     expect(mockDeleteAllChatsForBackend).not.toHaveBeenCalled();
   });

--- a/app/api/chats/route.ts
+++ b/app/api/chats/route.ts
@@ -7,6 +7,7 @@ import {
   getActiveTriggerRunsForUser,
 } from "@/lib/db/actions";
 import { ChatSDKError } from "@/lib/errors";
+import { assertUserCanAccessChatHistory } from "@/lib/suspensions";
 
 export const maxDuration = 30;
 
@@ -22,6 +23,7 @@ async function cancelTriggerRuns(triggerRunIds: string[]) {
 export async function DELETE(req: NextRequest) {
   try {
     const userId = await getUserID(req);
+    await assertUserCanAccessChatHistory(userId);
     const activeTriggerRuns = await getActiveTriggerRunsForUser({ userId });
 
     if (activeTriggerRuns.hasMore) {

--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -48,6 +48,11 @@ jest.mock("../chats", () => ({
   ...(jest.requireActual("../chats") as Record<string, any>),
   validateServiceKey: jest.fn(),
 }));
+jest.mock("../lib/suspensionGuards", () => ({
+  assertUserCanAccessChatHistory: jest.fn<any>().mockResolvedValue(undefined),
+  isUserBlockedByActiveFraudDispute: jest.fn<any>().mockResolvedValue(false),
+  CHAT_ACCESS_SUSPENDED_CODE: "CHAT_ACCESS_SUSPENDED",
+}));
 
 const SERVICE_KEY = "test-service-key";
 process.env.CONVEX_SERVICE_ROLE_KEY = SERVICE_KEY;

--- a/convex/__tests__/messages.hidden.test.ts
+++ b/convex/__tests__/messages.hidden.test.ts
@@ -49,6 +49,11 @@ jest.mock("../_generated/api", () => ({
 jest.mock("../lib/utils", () => ({
   validateServiceKey: jest.fn(),
 }));
+jest.mock("../lib/suspensionGuards", () => ({
+  assertUserCanAccessChatHistory: jest.fn<any>().mockResolvedValue(undefined),
+  isUserBlockedByActiveFraudDispute: jest.fn<any>().mockResolvedValue(false),
+  CHAT_ACCESS_SUSPENDED_CODE: "CHAT_ACCESS_SUSPENDED",
+}));
 jest.mock("../fileAggregate", () => ({
   fileCountAggregate: {
     deleteIfExists: jest.fn<any>().mockResolvedValue(undefined),

--- a/convex/__tests__/suspensionGuards.test.ts
+++ b/convex/__tests__/suspensionGuards.test.ts
@@ -63,11 +63,12 @@ function makeMockCtx(rows: SuspensionRow[]) {
 
     return {
       order: jest.fn((direction: "asc" | "desc") => ({
-        collect: async () => {
+        first: async () => {
           const sorted = [...filteredRows()].sort(
             (a, b) => (a.source_created_at ?? 0) - (b.source_created_at ?? 0),
           );
-          return direction === "desc" ? sorted.reverse() : sorted;
+          if (direction === "desc") sorted.reverse();
+          return sorted[0] ?? null;
         },
       })),
     };
@@ -105,7 +106,7 @@ describe("suspensionGuards", () => {
       assertUserCanAccessChatHistory(ctx, "user_123"),
     ).resolves.toBeUndefined();
     expect(withIndex).toHaveBeenCalledWith(
-      "by_user_status_source_created",
+      "by_user_status_category_source_created",
       expect.any(Function),
     );
   });

--- a/convex/__tests__/suspensionGuards.test.ts
+++ b/convex/__tests__/suspensionGuards.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, jest } from "@jest/globals";
+
+jest.mock("convex/values", () => ({
+  ConvexError: class ConvexError extends Error {
+    data: any;
+    constructor(data: any) {
+      super(typeof data === "string" ? data : data.message);
+      this.data = data;
+      this.name = "ConvexError";
+    }
+  },
+}));
+
+type SuspensionRow = {
+  _id: string;
+  user_id: string;
+  status: "active" | "resolved";
+  category:
+    | "early_fraud_warning"
+    | "dispute_fraudulent"
+    | "dispute_billing_hold";
+  source: "stripe";
+  source_id: string;
+  stripe_customer_id: string;
+  created_at: number;
+  updated_at: number;
+  source_created_at?: number;
+};
+
+const makeSuspension = (
+  overrides: Partial<SuspensionRow> = {},
+): SuspensionRow => ({
+  _id: "suspension-1",
+  user_id: "user_123",
+  status: "active",
+  category: "dispute_fraudulent",
+  source: "stripe",
+  source_id: "dp_123",
+  stripe_customer_id: "cus_123",
+  created_at: 1_000,
+  updated_at: 1_000,
+  source_created_at: 1_000,
+  ...overrides,
+});
+
+function makeMockCtx(rows: SuspensionRow[]) {
+  const withIndex = jest.fn((_indexName: string, predicate: any) => {
+    const filters: Record<string, unknown> = {};
+    const q = {
+      eq: jest.fn((field: string, value: unknown) => {
+        filters[field] = value;
+        return q;
+      }),
+    };
+    predicate(q);
+
+    const filteredRows = () =>
+      rows.filter((row) =>
+        Object.entries(filters).every(
+          ([field, value]) => row[field as keyof SuspensionRow] === value,
+        ),
+      );
+
+    return {
+      order: jest.fn((direction: "asc" | "desc") => ({
+        collect: async () => {
+          const sorted = [...filteredRows()].sort(
+            (a, b) => (a.source_created_at ?? 0) - (b.source_created_at ?? 0),
+          );
+          return direction === "desc" ? sorted.reverse() : sorted;
+        },
+      })),
+    };
+  });
+
+  return {
+    ctx: {
+      __withIndex: withIndex,
+      db: {
+        query: jest.fn(() => ({ withIndex })),
+      },
+    } as any,
+    withIndex,
+  };
+}
+
+describe("suspensionGuards", () => {
+  it("allows chat history when the user has no active fraud dispute", async () => {
+    const { assertUserCanAccessChatHistory } =
+      await import("../lib/suspensionGuards");
+    const { ctx, withIndex } = makeMockCtx([
+      makeSuspension({
+        status: "active",
+        category: "dispute_billing_hold",
+        source_id: "dp_billing",
+      }),
+      makeSuspension({
+        status: "resolved",
+        category: "dispute_fraudulent",
+        source_id: "dp_resolved",
+      }),
+    ]);
+
+    await expect(
+      assertUserCanAccessChatHistory(ctx, "user_123"),
+    ).resolves.toBeUndefined();
+    expect(withIndex).toHaveBeenCalledWith(
+      "by_user_status_source_created",
+      expect.any(Function),
+    );
+  });
+
+  it("blocks chat history for any active fraudulent dispute", async () => {
+    const { assertUserCanAccessChatHistory } =
+      await import("../lib/suspensionGuards");
+    const { ctx } = makeMockCtx([
+      makeSuspension({
+        _id: "suspension-newer",
+        category: "dispute_billing_hold",
+        source_id: "dp_billing_newer",
+        source_created_at: 2_000,
+      }),
+      makeSuspension({
+        _id: "suspension-fraud",
+        category: "dispute_fraudulent",
+        source_id: "dp_fraud",
+        source_created_at: 1_000,
+      }),
+    ]);
+
+    await expect(
+      assertUserCanAccessChatHistory(ctx, "user_123"),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({
+        code: "CHAT_ACCESS_SUSPENDED",
+        message: expect.stringContaining("fraudulent payment dispute"),
+        suspensionCategory: "dispute_fraudulent",
+        suspensionSource: "stripe",
+      }),
+    });
+  });
+
+  it("reports whether public shared chat reads should be blocked", async () => {
+    const { isUserBlockedByActiveFraudDispute } =
+      await import("../lib/suspensionGuards");
+    const blocked = makeMockCtx([makeSuspension()]);
+    const allowed = makeMockCtx([
+      makeSuspension({ category: "early_fraud_warning" }),
+    ]);
+
+    await expect(
+      isUserBlockedByActiveFraudDispute(blocked.ctx, "user_123"),
+    ).resolves.toBe(true);
+    await expect(
+      isUserBlockedByActiveFraudDispute(allowed.ctx, "user_123"),
+    ).resolves.toBe(false);
+  });
+});

--- a/convex/__tests__/userSuspensions.test.ts
+++ b/convex/__tests__/userSuspensions.test.ts
@@ -75,6 +75,13 @@ function makeMockCtx(initialRows: SuspensionRow[] = []) {
 
     return {
       order: jest.fn((direction: "asc" | "desc") => ({
+        collect: async () => {
+          const sorted = [...filteredRows()].sort(
+            (a, b) => (a.source_created_at ?? 0) - (b.source_created_at ?? 0),
+          );
+          if (direction === "desc") sorted.reverse();
+          return sorted;
+        },
         first: async () => {
           const sorted = [...filteredRows()].sort(
             (a, b) => (a.source_created_at ?? 0) - (b.source_created_at ?? 0),
@@ -234,6 +241,59 @@ describe("userSuspensions", () => {
     });
 
     expect(result.source_id).toBe("dp_newer");
+    expect(ctx.__withIndex).toHaveBeenCalledWith(
+      "by_user_status_source_created",
+      expect.any(Function),
+    );
+  });
+
+  it("returns an active fraud dispute even when another suspension is newer", async () => {
+    const { getActiveFraudDisputeByUser } = await import("../userSuspensions");
+    const { ctx } = makeMockCtx([
+      {
+        _id: "id-1",
+        user_id: "user_123",
+        status: "active",
+        category: "dispute_fraudulent",
+        source: "stripe",
+        source_id: "dp_fraud",
+        stripe_customer_id: "cus_123",
+        created_at: 1_000,
+        updated_at: 1_000,
+        source_created_at: 1_000,
+      },
+      {
+        _id: "id-2",
+        user_id: "user_123",
+        status: "active",
+        category: "dispute_billing_hold",
+        source: "stripe",
+        source_id: "dp_billing_newer",
+        stripe_customer_id: "cus_123",
+        created_at: 2_000,
+        updated_at: 2_000,
+        source_created_at: 9_000,
+      },
+      {
+        _id: "id-3",
+        user_id: "user_123",
+        status: "resolved",
+        category: "dispute_fraudulent",
+        source: "stripe",
+        source_id: "dp_resolved",
+        stripe_customer_id: "cus_123",
+        created_at: 3_000,
+        updated_at: 3_000,
+        source_created_at: 10_000,
+      },
+    ]);
+
+    const result = await (getActiveFraudDisputeByUser as any).handler(ctx, {
+      serviceKey: SERVICE_KEY,
+      userId: "user_123",
+    });
+
+    expect(result.source_id).toBe("dp_fraud");
     expect(ctx.__withIndex).toHaveBeenCalledWith(
       "by_user_status_source_created",
       expect.any(Function),

--- a/convex/__tests__/userSuspensions.test.ts
+++ b/convex/__tests__/userSuspensions.test.ts
@@ -295,7 +295,7 @@ describe("userSuspensions", () => {
 
     expect(result.source_id).toBe("dp_fraud");
     expect(ctx.__withIndex).toHaveBeenCalledWith(
-      "by_user_status_source_created",
+      "by_user_status_category_source_created",
       expect.any(Function),
     );
   });

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -20,6 +20,7 @@ import {
   resolveSubscriptionTier,
 } from "../lib/auth/entitlements";
 import { convexLogger } from "./lib/logger";
+import { assertUserCanAccessChatHistory } from "./lib/suspensionGuards";
 
 const DELETE_ALL_CHATS_MESSAGE_BATCH_SIZE = 10;
 const DELETE_ALL_CHATS_SUMMARY_BATCH_SIZE = 25;
@@ -336,6 +337,7 @@ export const getChatByIdFromClient = query({
       if (!identity) {
         return null;
       }
+      await assertUserCanAccessChatHistory(ctx, identity.subject);
 
       const chat = await ctx.db
         .query("chats")
@@ -678,6 +680,7 @@ export const getUserChats = query({
         continueCursor: "",
       };
     }
+    await assertUserCanAccessChatHistory(ctx, identity.subject);
 
     try {
       const MAX_PINNED_CHATS = 100;
@@ -802,6 +805,7 @@ export const pinChat = mutation({
         message: "Unauthorized: User not authenticated",
       });
     }
+    await assertUserCanAccessChatHistory(ctx, identity.subject);
 
     const chat = await ctx.db
       .query("chats")
@@ -845,6 +849,7 @@ export const unpinChat = mutation({
         message: "Unauthorized: User not authenticated",
       });
     }
+    await assertUserCanAccessChatHistory(ctx, identity.subject);
 
     const chat = await ctx.db
       .query("chats")
@@ -889,6 +894,7 @@ export const deleteChat = mutation({
         message: "Unauthorized: User not authenticated",
       });
     }
+    await assertUserCanAccessChatHistory(ctx, user.subject);
 
     try {
       // Find the chat
@@ -969,6 +975,7 @@ export const renameChat = mutation({
         message: "Unauthorized: User not authenticated",
       });
     }
+    await assertUserCanAccessChatHistory(ctx, user.subject);
 
     try {
       // Find the chat
@@ -1042,6 +1049,7 @@ export const deleteAllChats = mutation({
         message: "Unauthorized: User not authenticated",
       });
     }
+    await assertUserCanAccessChatHistory(ctx, user.subject);
 
     try {
       await deleteNextUserChatBatch(ctx, user.subject);

--- a/convex/lib/suspensionGuards.ts
+++ b/convex/lib/suspensionGuards.ts
@@ -14,19 +14,16 @@ async function getActiveFraudDisputeSuspension(
   ctx: SuspensionReaderCtx,
   userId: string,
 ): Promise<Doc<"user_suspensions"> | null> {
-  const activeSuspensions = await ctx.db
+  return await ctx.db
     .query("user_suspensions")
-    .withIndex("by_user_status_source_created", (q) =>
-      q.eq("user_id", userId).eq("status", "active"),
+    .withIndex("by_user_status_category_source_created", (q) =>
+      q
+        .eq("user_id", userId)
+        .eq("status", "active")
+        .eq("category", "dispute_fraudulent"),
     )
     .order("desc")
-    .collect();
-
-  return (
-    activeSuspensions.find(
-      (suspension) => suspension.category === "dispute_fraudulent",
-    ) ?? null
-  );
+    .first();
 }
 
 export async function isUserBlockedByActiveFraudDispute(

--- a/convex/lib/suspensionGuards.ts
+++ b/convex/lib/suspensionGuards.ts
@@ -1,0 +1,54 @@
+import type { GenericDatabaseReader } from "convex/server";
+import { ConvexError } from "convex/values";
+
+import type { DataModel, Doc } from "../_generated/dataModel";
+import { getSuspensionMessage } from "../../lib/suspensionMessage";
+
+export const CHAT_ACCESS_SUSPENDED_CODE = "CHAT_ACCESS_SUSPENDED";
+
+type SuspensionReaderCtx = {
+  db: GenericDatabaseReader<DataModel>;
+};
+
+async function getActiveFraudDisputeSuspension(
+  ctx: SuspensionReaderCtx,
+  userId: string,
+): Promise<Doc<"user_suspensions"> | null> {
+  const activeSuspensions = await ctx.db
+    .query("user_suspensions")
+    .withIndex("by_user_status_source_created", (q) =>
+      q.eq("user_id", userId).eq("status", "active"),
+    )
+    .order("desc")
+    .collect();
+
+  return (
+    activeSuspensions.find(
+      (suspension) => suspension.category === "dispute_fraudulent",
+    ) ?? null
+  );
+}
+
+export async function isUserBlockedByActiveFraudDispute(
+  ctx: SuspensionReaderCtx,
+  userId: string,
+): Promise<boolean> {
+  return (await getActiveFraudDisputeSuspension(ctx, userId)) !== null;
+}
+
+export async function assertUserCanAccessChatHistory(
+  ctx: SuspensionReaderCtx,
+  userId: string,
+): Promise<void> {
+  const suspension = await getActiveFraudDisputeSuspension(ctx, userId);
+  if (!suspension) return;
+
+  throw new ConvexError({
+    code: CHAT_ACCESS_SUSPENDED_CODE,
+    message: getSuspensionMessage(
+      `${suspension.category}:${suspension.source_id}`,
+    ),
+    suspensionCategory: suspension.category,
+    suspensionSource: suspension.source,
+  });
+}

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -11,6 +11,10 @@ import { validateServiceKey, copyChatSummary } from "./lib/utils";
 import { fileCountAggregate } from "./fileAggregate";
 import { convexLogger } from "./lib/logger";
 import type { RetainedTailDoc } from "./lib/retainedTail";
+import {
+  assertUserCanAccessChatHistory,
+  isUserBlockedByActiveFraudDispute,
+} from "./lib/suspensionGuards";
 
 /**
  * Extract text content from message parts for search and display
@@ -910,6 +914,7 @@ export const getMessagesByChatId = query({
         continueCursor: "",
       };
     }
+    await assertUserCanAccessChatHistory(ctx, user.subject);
 
     try {
       await ctx.runQuery(internal.messages.verifyChatOwnership, {
@@ -1064,6 +1069,7 @@ export const saveAssistantMessage = mutation({
     if (!user) {
       throw new Error("Unauthorized: User not authenticated");
     }
+    await assertUserCanAccessChatHistory(ctx, user.subject);
 
     try {
       // Deduplicate by message id to avoid duplicates when stop is clicked multiple times
@@ -1145,6 +1151,7 @@ export const deleteLastAssistantMessage = mutation({
     if (!user) {
       throw new Error("Unauthorized: User not authenticated");
     }
+    await assertUserCanAccessChatHistory(ctx, user.subject);
 
     try {
       // Walk backwards from newest message and collect the entire trailing chain:
@@ -1438,6 +1445,7 @@ export const searchMessages = query({
     if (!user) {
       throw new Error("Unauthorized: User not authenticated");
     }
+    await assertUserCanAccessChatHistory(ctx, user.subject);
 
     const searchQuery = args.searchQuery.trim().replace(/\s+/g, " ");
     const MIN_SEARCH_QUERY_LENGTH = 3;
@@ -1697,6 +1705,7 @@ export const branchChat = mutation({
     if (!user) {
       throw new Error("Unauthorized: User not authenticated");
     }
+    await assertUserCanAccessChatHistory(ctx, user.subject);
 
     try {
       const message = await ctx.db
@@ -1833,6 +1842,7 @@ export const regenerateWithNewContent = mutation({
     if (!user) {
       throw new Error("Unauthorized: User not authenticated");
     }
+    await assertUserCanAccessChatHistory(ctx, user.subject);
 
     try {
       const message = await ctx.db
@@ -2056,6 +2066,9 @@ export const getSharedMessages = query({
       if (!chat || !chat.share_id || !chat.share_date) {
         return [];
       }
+      if (await isUserBlockedByActiveFraudDispute(ctx, chat.user_id)) {
+        return [];
+      }
 
       // Read the chat's messages via the existing per-chat index, then apply
       // the frozen-share cutoff locally to avoid a production-wide backfill.
@@ -2141,6 +2154,7 @@ export const getPreviewMessages = query({
     if (!identity) {
       return [];
     }
+    await assertUserCanAccessChatHistory(ctx, identity.subject);
 
     try {
       const chat = await ctx.db

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -430,6 +430,12 @@ export default defineSchema({
       "status",
       "source_created_at",
     ])
+    .index("by_user_status_category_source_created", [
+      "user_id",
+      "status",
+      "category",
+      "source_created_at",
+    ])
     .index("by_user_and_source", ["user_id", "source_id"])
     .index("by_customer_and_status", ["stripe_customer_id", "status"]),
 

--- a/convex/sharedChats.ts
+++ b/convex/sharedChats.ts
@@ -1,6 +1,10 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
 import { convexLogger } from "./lib/logger";
+import {
+  assertUserCanAccessChatHistory,
+  isUserBlockedByActiveFraudDispute,
+} from "./lib/suspensionGuards";
 
 /**
  * Share a chat by creating a public share link.
@@ -21,6 +25,7 @@ export const shareChat = mutation({
     if (!identity) {
       throw new Error("Unauthorized: User not authenticated");
     }
+    await assertUserCanAccessChatHistory(ctx, identity.subject);
 
     const chat = await ctx.db
       .query("chats")
@@ -99,6 +104,7 @@ export const updateShareDate = mutation({
     if (!identity) {
       throw new Error("Unauthorized: User not authenticated");
     }
+    await assertUserCanAccessChatHistory(ctx, identity.subject);
 
     const chat = await ctx.db
       .query("chats")
@@ -162,6 +168,7 @@ export const unshareChat = mutation({
     if (!identity) {
       throw new Error("Unauthorized: User not authenticated");
     }
+    await assertUserCanAccessChatHistory(ctx, identity.subject);
 
     const chat = await ctx.db
       .query("chats")
@@ -224,6 +231,9 @@ export const getSharedChat = query({
     if (!chat || !chat.share_id || !chat.share_date) {
       return null;
     }
+    if (await isUserBlockedByActiveFraudDispute(ctx, chat.user_id)) {
+      return null;
+    }
 
     // Return chat without user_id for anonymity
     return {
@@ -259,6 +269,7 @@ export const getUserSharedChats = query({
     if (!identity) {
       return [];
     }
+    await assertUserCanAccessChatHistory(ctx, identity.subject);
 
     const chats = await ctx.db
       .query("chats")
@@ -299,6 +310,7 @@ export const forkSharedChat = mutation({
     if (!identity) {
       throw new Error("Unauthorized: User not authenticated");
     }
+    await assertUserCanAccessChatHistory(ctx, identity.subject);
 
     // Validate UUID format
     const UUID_REGEX =
@@ -313,6 +325,9 @@ export const forkSharedChat = mutation({
       .first();
 
     if (!chat || !chat.share_id || !chat.share_date) {
+      throw new Error("Shared chat not found");
+    }
+    if (await isUserBlockedByActiveFraudDispute(ctx, chat.user_id)) {
       throw new Error("Shared chat not found");
     }
 
@@ -388,6 +403,7 @@ export const unshareAllChats = mutation({
     if (!identity) {
       throw new Error("Unauthorized: User not authenticated");
     }
+    await assertUserCanAccessChatHistory(ctx, identity.subject);
 
     const sharedChats = await ctx.db
       .query("chats")

--- a/convex/userSuspensions.ts
+++ b/convex/userSuspensions.ts
@@ -34,19 +34,16 @@ export const getActiveFraudDisputeByUser = query({
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
 
-    const activeSuspensions = await ctx.db
+    return await ctx.db
       .query("user_suspensions")
-      .withIndex("by_user_status_source_created", (q) =>
-        q.eq("user_id", args.userId).eq("status", "active"),
+      .withIndex("by_user_status_category_source_created", (q) =>
+        q
+          .eq("user_id", args.userId)
+          .eq("status", "active")
+          .eq("category", "dispute_fraudulent"),
       )
       .order("desc")
-      .collect();
-
-    return (
-      activeSuspensions.find(
-        (suspension) => suspension.category === "dispute_fraudulent",
-      ) ?? null
-    );
+      .first();
   },
 });
 

--- a/convex/userSuspensions.ts
+++ b/convex/userSuspensions.ts
@@ -26,6 +26,30 @@ export const getActiveByUser = query({
   },
 });
 
+export const getActiveFraudDisputeByUser = query({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const activeSuspensions = await ctx.db
+      .query("user_suspensions")
+      .withIndex("by_user_status_source_created", (q) =>
+        q.eq("user_id", args.userId).eq("status", "active"),
+      )
+      .order("desc")
+      .collect();
+
+    return (
+      activeSuspensions.find(
+        (suspension) => suspension.category === "dispute_fraudulent",
+      ) ?? null
+    );
+  },
+});
+
 export const upsertActive = mutation({
   args: {
     serviceKey: v.string(),

--- a/lib/__tests__/suspensions.test.ts
+++ b/lib/__tests__/suspensions.test.ts
@@ -9,6 +9,7 @@ jest.mock("@/convex/_generated/api", () => ({
   api: {
     userSuspensions: {
       getActiveByUser: "getActiveByUser",
+      getActiveFraudDisputeByUser: "getActiveFraudDisputeByUser",
     },
   },
 }));
@@ -87,5 +88,37 @@ describe("suspensions", () => {
       );
       expect((error as ChatSDKError).cause).not.toContain("dp_secret");
     }
+  });
+
+  it("blocks chat-history access only for fraudulent disputes", async () => {
+    const { assertUserCanAccessChatHistory } = await import("../suspensions");
+
+    mockQuery.mockResolvedValueOnce(null as never);
+    await expect(
+      assertUserCanAccessChatHistory("user_123"),
+    ).resolves.toBeUndefined();
+
+    mockQuery.mockResolvedValueOnce({
+      user_id: "user_123",
+      status: "active",
+      category: "dispute_fraudulent",
+      source: "stripe",
+      source_id: "dp_fraud",
+    } as never);
+    await expect(
+      assertUserCanAccessChatHistory("user_123"),
+    ).rejects.toMatchObject({
+      type: "forbidden",
+      surface: "chat",
+      cause: expect.stringContaining("fraudulent payment dispute"),
+      metadata: {
+        suspensionCategory: "dispute_fraudulent",
+        suspensionSource: "stripe",
+      },
+    });
+    expect(mockQuery).toHaveBeenLastCalledWith("getActiveFraudDisputeByUser", {
+      serviceKey: "test-service-key",
+      userId: "user_123",
+    });
   });
 });

--- a/lib/posthog/__tests__/expected-convex-errors.test.ts
+++ b/lib/posthog/__tests__/expected-convex-errors.test.ts
@@ -79,6 +79,16 @@ describe("shouldDropExpectedConvexException", () => {
         },
       }),
     ).toBe(true);
+
+    expect(
+      shouldDropExpectedConvexException({
+        event: "$exception",
+        properties: {
+          $exception_message:
+            'Uncaught ConvexError: {"code":"CHAT_ACCESS_SUSPENDED","message":"Your account has been suspended due to a fraudulent payment dispute (chargeback)."}',
+        },
+      }),
+    ).toBe(true);
   });
 
   it("drops Convex optimistic concurrency retries from file upload metadata", () => {

--- a/lib/posthog/expected-convex-errors.ts
+++ b/lib/posthog/expected-convex-errors.ts
@@ -10,6 +10,7 @@ const IGNORED_CONVEX_EXCEPTION_MESSAGES = [
   "PAID_PLAN_REQUIRED",
   "Paid plan required for file uploads",
   "CHAT_UNAUTHORIZED",
+  "CHAT_ACCESS_SUSPENDED",
   "Unauthorized: Chat does not belong to user",
   "OptimisticConcurrencyControlFailure",
   'Documents read from or written to the "btreeNode" table changed',

--- a/lib/suspensions.ts
+++ b/lib/suspensions.ts
@@ -14,8 +14,32 @@ export async function getActiveSuspensionForUser(userId: string) {
   });
 }
 
+export async function getActiveFraudDisputeSuspensionForUser(userId: string) {
+  return await getConvexClient().query(
+    api.userSuspensions.getActiveFraudDisputeByUser,
+    {
+      serviceKey,
+      userId,
+    },
+  );
+}
+
 export async function assertUserCanMakeCostIncurringRequest(userId: string) {
   const suspension = await getActiveSuspensionForUser(userId);
+  if (!suspension) return;
+
+  throw new ChatSDKError(
+    "forbidden:chat",
+    getSuspensionMessage(`${suspension.category}:${suspension.source_id}`),
+    {
+      suspensionCategory: suspension.category,
+      suspensionSource: suspension.source,
+    },
+  );
+}
+
+export async function assertUserCanAccessChatHistory(userId: string) {
+  const suspension = await getActiveFraudDisputeSuspensionForUser(userId);
   if (!suspension) return;
 
   throw new ChatSDKError(


### PR DESCRIPTION
## Summary
- add a fraud-dispute-specific chat history guard for active `dispute_fraudulent` suspensions
- block owned chat reads, message/search/share previews, shared-link access, chat mutation paths, REST delete routes, and stream resume while a fraudulent dispute is active
- keep non-fraud dispute holds read-only by only applying the chat-access lock to fraudulent disputes
- filter the expected `CHAT_ACCESS_SUSPENDED` Convex error from PostHog exception noise

## Validation
- `pnpm jest --runTestsByPath convex/__tests__/suspensionGuards.test.ts convex/__tests__/userSuspensions.test.ts convex/__tests__/chatSummaryFallback.test.ts convex/__tests__/messages.hidden.test.ts lib/__tests__/suspensions.test.ts lib/posthog/__tests__/expected-convex-errors.test.ts app/api/chats/__tests__/route.test.ts "app/api/chat/[id]/__tests__/route.test.ts" --runInBand`
- `pnpm typecheck`
- `pnpm exec prettier --check app/api/chats/route.ts app/api/chats/__tests__/route.test.ts "app/api/chat/[id]/route.ts" "app/api/chat/[id]/stream/route.ts" "app/api/chat/[id]/__tests__/route.test.ts" convex/chats.ts convex/messages.ts convex/sharedChats.ts convex/userSuspensions.ts convex/lib/suspensionGuards.ts convex/__tests__/suspensionGuards.test.ts convex/__tests__/userSuspensions.test.ts convex/__tests__/chatSummaryFallback.test.ts convex/__tests__/messages.hidden.test.ts lib/suspensions.ts lib/__tests__/suspensions.test.ts lib/posthog/expected-convex-errors.ts lib/posthog/__tests__/expected-convex-errors.test.ts`
- `pnpm lint` (passes with existing warnings)
- pre-commit hook: `pnpm typecheck` and full `pnpm test` (160 suites, 1723 tests)

## Manual verification
- Create or mark a user with an active `dispute_fraudulent` suspension. Open an existing chat, sidebar history, message search, shared links tab, an existing public share URL, and stream resume URL. The app/API should block or return no shared content with the suspension message/forbidden response rather than exposing chat content.
- Mark the fraudulent dispute suspension resolved and confirm existing chats, search, share previews, and share URLs load again.
- Create an active `dispute_billing_hold` suspension and confirm existing chat history remains readable while cost-incurring chat/Agent requests remain blocked by the existing suspension path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat history, message, sharing, chat preview, and related deletion actions now honor access restrictions for accounts with active fraud-dispute suspensions.
  * Shared chats may be hidden or treated as unavailable when the owner’s account is restricted.

* **Bug Fixes**
  * Chat deletion and streaming now stop earlier and return clearer forbidden responses when access is suspended.
  * Suspension-related error handling is more consistent, including improved recognition of expected suspension events for monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->