### PR TITLE
Fix canceled chat message save race

### DIFF
--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -293,34 +293,11 @@ export const useChatHandlers = ({
           clearUploadedFiles();
           return;
         } else if (queueBehavior === "stop-and-send") {
-          // Immediately stop current stream and send right away
-          stop();
-
           // Cancel the trigger.dev run for agent-long streams so the prior
           // run stops burning compute instead of finishing in the background.
           cancelTriggerRun();
 
-          // Cancel the stream in database and save current message state
-          if (!temporaryChatsEnabledRef.current) {
-            cancelStreamMutation({ chatId }).catch((error) => {
-              console.error("Failed to cancel stream:", error);
-            });
-
-            const lastMessage = messages[messages.length - 1];
-            if (lastMessage && lastMessage.role === "assistant") {
-              saveAssistantMessage({
-                id: lastMessage.id,
-                chatId,
-                role: lastMessage.role,
-                parts: getConvexSafeParts(lastMessage.parts),
-              }).catch((error) => {
-                console.error("Failed to save message on stop:", error);
-              });
-            }
-          } else {
-            // Temporary chats: signal cancel via temp stream coordination
-            cancelTempStreamMutation({ chatId }).catch(() => {});
-          }
+          await stopActiveStream();
           // Continue to send the new message immediately below (don't return)
         }
       }

--- a/convex/__tests__/messages.hidden.test.ts
+++ b/convex/__tests__/messages.hidden.test.ts
@@ -349,11 +349,12 @@ describe("saveMessage — is_hidden handling", () => {
     expect(console.error).not.toHaveBeenCalled();
   });
 
-  it("rejects user inserts when the chat is already canceled", async () => {
+  it("clears stale cancellation state for new user inserts", async () => {
     setupExistingMessage(null, {
       _id: "chat-doc-1",
       id: CHAT_ID,
       user_id: USER_ID,
+      active_stream_id: "old-stream",
       canceled_at: Date.now(),
     });
 
@@ -368,17 +369,21 @@ describe("saveMessage — is_hidden handling", () => {
         role: "user" as const,
         parts: [{ type: "text", text: "late user message" }],
       }),
-    ).rejects.toMatchObject({
-      data: expect.objectContaining({
-        code: "MESSAGE_SAVE_FAILED",
-        failureStage: "verify_chat_writable_for_insert",
-        causeData: expect.objectContaining({
-          code: "CHAT_CANCELED",
-        }),
-      }),
-    });
+    ).resolves.toBeNull();
 
-    expect(mockCtx.db.insert).not.toHaveBeenCalled();
+    expect(mockCtx.db.patch).toHaveBeenCalledWith("chat-doc-1", {
+      active_stream_id: undefined,
+      canceled_at: undefined,
+    });
+    expect(mockCtx.db.insert).toHaveBeenCalledWith(
+      "messages",
+      expect.objectContaining({
+        id: "msg-user-canceled",
+        role: "user",
+        content: "late user message",
+      }),
+    );
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it("rejects unowned file IDs before inserting a new message", async () => {

--- a/convex/__tests__/messages.hidden.test.ts
+++ b/convex/__tests__/messages.hidden.test.ts
@@ -372,7 +372,6 @@ describe("saveMessage — is_hidden handling", () => {
     ).resolves.toBeNull();
 
     expect(mockCtx.db.patch).toHaveBeenCalledWith("chat-doc-1", {
-      active_stream_id: undefined,
       canceled_at: undefined,
     });
     expect(mockCtx.db.insert).toHaveBeenCalledWith(

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -467,7 +467,6 @@ async function ensureChatWritableForMessageInsert(
   if (chat.canceled_at !== undefined) {
     if (role === "user") {
       await ctx.db.patch(chat._id, {
-        active_stream_id: undefined,
         canceled_at: undefined,
       });
       return;

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -460,10 +460,19 @@ async function ensureChatWritableForMessageInsert(
   ctx: MutationCtx,
   chatId: string,
   userId: string,
+  role: "user" | "assistant" | "system",
 ): Promise<void> {
   const chat = await loadOwnedChat(ctx, chatId, userId);
 
   if (chat.canceled_at !== undefined) {
+    if (role === "user") {
+      await ctx.db.patch(chat._id, {
+        active_stream_id: undefined,
+        canceled_at: undefined,
+      });
+      return;
+    }
+
     throw new ConvexError({
       code: "CHAT_CANCELED",
       message: "This chat is no longer accepting new messages",
@@ -639,7 +648,12 @@ export const saveMessage = mutation({
         }
 
         failureStage = "verify_chat_writable_for_insert";
-        await ensureChatWritableForMessageInsert(ctx, args.chatId, args.userId);
+        await ensureChatWritableForMessageInsert(
+          ctx,
+          args.chatId,
+          args.userId,
+          args.role,
+        );
       }
 
       let newMessageFiles: Doc<"files">[] = [];

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -689,6 +689,7 @@ describe("createChatLogger ChatSDKError metadata", () => {
           db_error_name: "ConvexError",
           db_error_message: "[Request ID: abc] Server Error",
           db_error_code: "CHAT_NOT_FOUND",
+          db_cause_error_code: "CHAT_NOT_FOUND",
           db_failure_stage: "verify_chat_ownership",
           db_error_data: {
             code: "MESSAGE_SAVE_FAILED",
@@ -729,6 +730,7 @@ describe("createChatLogger ChatSDKError metadata", () => {
         db_error_name: "ConvexError",
         db_error_message: "[Request ID: abc] Server Error",
         db_error_code: "CHAT_NOT_FOUND",
+        db_cause_error_code: "CHAT_NOT_FOUND",
         db_failure_stage: "verify_chat_ownership",
         parts_size_kb: 551,
         part_count: 288,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -109,6 +109,7 @@ const COMPACT_CHAT_ERROR_METADATA_KEYS = [
   "db_error_name",
   "db_error_message",
   "db_error_code",
+  "db_cause_error_code",
   "db_failure_stage",
   "finish_reason",
   "message_role",

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -167,6 +167,63 @@ describe("saveMessage", () => {
       errorSpy.mockRestore();
     }
   });
+
+  it("treats wrapped canceled-chat message saves as warnings", async () => {
+    const { saveMessage, mockMutation } = await loadSaveMessageWithMocks();
+    const convexError = new Error("[Request ID: abc] Server Error") as Error & {
+      data?: unknown;
+    };
+    convexError.name = "ConvexError";
+    convexError.data = {
+      code: "MESSAGE_SAVE_FAILED",
+      message: "Failed to save message",
+      failureStage: "verify_chat_writable_for_insert",
+      causeData: {
+        code: "CHAT_CANCELED",
+        message: "This chat is no longer accepting new messages",
+      },
+    };
+    mockMutation.mockRejectedValueOnce(convexError as never);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(
+        saveMessage({
+          chatId: "chat-1",
+          userId: "user-1",
+          message: {
+            id: "message-1",
+            role: "user",
+            parts: [{ type: "text", text: "next prompt" }],
+          },
+        }),
+      ).rejects.toMatchObject({
+        type: "bad_request",
+        surface: "chat",
+        statusCode: 400,
+        cause:
+          "This chat was stopped before your message could be saved. Please send it again.",
+        metadata: expect.objectContaining({
+          db_operation: "messages.saveMessage",
+          db_error_code: "MESSAGE_SAVE_FAILED",
+          db_cause_error_code: "CHAT_CANCELED",
+          db_failure_stage: "verify_chat_writable_for_insert",
+        }),
+      });
+
+      const warnEvents = warnSpy.mock.calls.map(([line]) => {
+        const payload = JSON.parse(String(line));
+        return payload.event;
+      });
+      expect(warnEvents).toContain("message_save_rejected_chat_canceled");
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
 });
 
 describe("getMessagesByChatId", () => {

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -207,13 +207,23 @@ const getNestedObject = (
     : undefined;
 };
 
-const getDatabaseErrorCode = (data: unknown): string | undefined =>
-  getObjectString(data, "code") ??
+const getDatabasePrimaryErrorCode = (data: unknown): string | undefined =>
+  getObjectString(data, "code");
+
+const getDatabaseCauseErrorCode = (data: unknown): string | undefined =>
   getObjectString(getNestedObject(data, "causeData"), "code");
+
+const getDatabaseErrorCode = (data: unknown): string | undefined =>
+  getDatabasePrimaryErrorCode(data) ?? getDatabaseCauseErrorCode(data);
+
+const hasDatabaseErrorCode = (data: unknown, code: string): boolean =>
+  getDatabasePrimaryErrorCode(data) === code ||
+  getDatabaseCauseErrorCode(data) === code;
 
 const getDatabaseFailureStage = (data: unknown): string | undefined =>
   getObjectString(data, "failureStage");
 
+const CHAT_CANCELED_ERROR_CODE = "CHAT_CANCELED";
 const CHAT_UNAUTHORIZED_ERROR_CODE = "CHAT_UNAUTHORIZED";
 const MESSAGE_TOO_LARGE_ERROR_CODE = "MESSAGE_TOO_LARGE";
 
@@ -222,17 +232,24 @@ const isChatNotFoundMessageSaveError = (
   dbErrorData: unknown,
 ): boolean =>
   operation === "messages.saveMessage" &&
-  getDatabaseErrorCode(dbErrorData) === "CHAT_NOT_FOUND";
+  hasDatabaseErrorCode(dbErrorData, "CHAT_NOT_FOUND");
+
+const isChatCanceledMessageSaveError = (
+  operation: string,
+  dbErrorData: unknown,
+): boolean =>
+  operation === "messages.saveMessage" &&
+  hasDatabaseErrorCode(dbErrorData, CHAT_CANCELED_ERROR_CODE);
 
 const isChatUnauthorizedError = (dbErrorData: unknown): boolean =>
-  getDatabaseErrorCode(dbErrorData) === CHAT_UNAUTHORIZED_ERROR_CODE;
+  hasDatabaseErrorCode(dbErrorData, CHAT_UNAUTHORIZED_ERROR_CODE);
 
 const isMessageTooLargeError = (
   operation: string,
   dbErrorData: unknown,
 ): boolean =>
   operation === "messages.saveMessage" &&
-  getDatabaseErrorCode(dbErrorData) === MESSAGE_TOO_LARGE_ERROR_CODE;
+  hasDatabaseErrorCode(dbErrorData, MESSAGE_TOO_LARGE_ERROR_CODE);
 
 const logChatMessagePreparationFailure = (
   event: string,
@@ -263,39 +280,47 @@ const databaseError = (
   const dbErrorMessage = truncateDiagnosticString(stringifyError(error));
   const dbErrorData = getErrorData(error);
   const isChatNotFound = isChatNotFoundMessageSaveError(operation, dbErrorData);
+  const isChatCanceled = isChatCanceledMessageSaveError(operation, dbErrorData);
   const isChatUnauthorized = isChatUnauthorizedError(dbErrorData);
   const isMessageTooLarge = isMessageTooLargeError(operation, dbErrorData);
   const logLevel =
-    isChatNotFound || isChatUnauthorized || isMessageTooLarge
+    isChatNotFound || isChatCanceled || isChatUnauthorized || isMessageTooLarge
       ? "warn"
       : "error";
   const event = isChatNotFound
     ? "database_operation_skipped_chat_not_found"
-    : isChatUnauthorized
-      ? "chat_access_denied"
-      : isMessageTooLarge
-        ? "message_save_rejected_too_large"
-        : "database_operation_failed";
+    : isChatCanceled
+      ? "message_save_rejected_chat_canceled"
+      : isChatUnauthorized
+        ? "chat_access_denied"
+        : isMessageTooLarge
+          ? "message_save_rejected_too_large"
+          : "database_operation_failed";
   const errorCode = isChatNotFound
     ? "not_found:chat"
-    : isChatUnauthorized
-      ? "forbidden:chat"
-      : isMessageTooLarge
-        ? "bad_request:api"
-        : "bad_request:database";
+    : isChatCanceled
+      ? "bad_request:chat"
+      : isChatUnauthorized
+        ? "forbidden:chat"
+        : isMessageTooLarge
+          ? "bad_request:api"
+          : "bad_request:database";
   const errorMessage = isChatNotFound
     ? `Chat no longer exists while saving message: ${operation}: ${dbErrorMessage}`
-    : isChatUnauthorized
-      ? `Chat access denied while executing database operation: ${operation}: ${dbErrorMessage}`
-      : isMessageTooLarge
-        ? "Your message is too large to save. Please shorten it or attach the content as a file instead."
-        : `Database operation failed: ${operation}: ${dbErrorMessage}`;
+    : isChatCanceled
+      ? "This chat was stopped before your message could be saved. Please send it again."
+      : isChatUnauthorized
+        ? `Chat access denied while executing database operation: ${operation}: ${dbErrorMessage}`
+        : isMessageTooLarge
+          ? "Your message is too large to save. Please shorten it or attach the content as a file instead."
+          : `Database operation failed: ${operation}: ${dbErrorMessage}`;
   const diagnosticMetadata = {
     db_operation: operation,
     db_error_name: dbErrorName,
     db_error_message: dbErrorMessage,
     db_error_data: dbErrorData,
     db_error_code: getDatabaseErrorCode(dbErrorData),
+    db_cause_error_code: getDatabaseCauseErrorCode(dbErrorData),
     db_failure_stage: getDatabaseFailureStage(dbErrorData),
     ...metadata,
   };

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -98,6 +98,8 @@ export function getMessageByErrorCode(errorCode: ErrorCode): string {
 
     case "rate_limit:chat":
       return "You have exceeded your maximum number of messages for the day. Please try again later.";
+    case "bad_request:chat":
+      return "The chat couldn't accept that message. Please try again.";
     case "not_found:chat":
       return "The requested chat was not found. Please check the chat ID and try again.";
     case "forbidden:chat":


### PR DESCRIPTION
## Summary
- clear stale stream cancellation state when a new user message is inserted into an existing chat
- classify wrapped `MESSAGE_SAVE_FAILED` / `CHAT_CANCELED` save failures as warning-level chat rejections instead of database incidents
- make stop-and-send wait for the existing stop helper before submitting the next prompt

## Why
Production logs showed many `/api/chat` and `/api/agent-long` `database_operation_failed` events from `messages.saveMessage` where Convex wrapped `CHAT_CANCELED` as `MESSAGE_SAVE_FAILED`. `canceled_at` is stream state, not a permanent closed-chat state, so a follow-up user prompt should reopen the chat path instead of failing as a database error.

## Validation
- `pnpm test -- convex/__tests__/messages.hidden.test.ts lib/db/__tests__/actions-save-message.test.ts lib/api/__tests__/chat-logger.test.ts --runInBand`
- `pnpm exec prettier --check convex/messages.ts convex/__tests__/messages.hidden.test.ts lib/db/actions.ts lib/db/__tests__/actions-save-message.test.ts lib/errors.ts lib/api/chat-logger.ts lib/api/__tests__/chat-logger.test.ts app/hooks/useChatHandlers.ts`
- `pnpm exec eslint convex/messages.ts convex/__tests__/messages.hidden.test.ts lib/db/actions.ts lib/db/__tests__/actions-save-message.test.ts lib/errors.ts lib/api/chat-logger.ts lib/api/__tests__/chat-logger.test.ts app/hooks/useChatHandlers.ts`
- `pnpm typecheck`

## Manual verification
- In a persisted chat, start a streaming response, choose Stop & send right away, and send the next prompt.
- Confirm the new prompt saves and streams normally.
- Confirm Vercel no longer emits error-level `database_operation_failed` for nested `CHAT_CANCELED`; deploy-skew leftovers should appear as warn-level `message_save_rejected_chat_canceled`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of canceled chats when sending messages, allowing new user messages to be accepted after stale cancellation state is cleared.
  * Added clearer feedback when a message can’t be sent because the chat is canceled.
  * Improved error reporting so cancellation-related issues are logged and surfaced more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->