### PR TITLE
Fix file view telemetry outcomes

### DIFF
--- a/lib/ai/tools/__tests__/file.test.ts
+++ b/lib/ai/tools/__tests__/file.test.ts
@@ -12,6 +12,7 @@ jest.mock("@/lib/logger", () => ({
 
 import { createFile } from "../file";
 import { uploadSandboxFileToConvex } from "../utils/sandbox-file-uploader";
+import { phLogger } from "@/lib/posthog/server";
 import type { ToolContext } from "@/types";
 
 type FakeCommandResult = {
@@ -24,6 +25,9 @@ const mockUploadSandboxFileToConvex =
   uploadSandboxFileToConvex as jest.MockedFunction<
     typeof uploadSandboxFileToConvex
   >;
+const mockPhEvent = phLogger.event as jest.MockedFunction<
+  typeof phLogger.event
+>;
 
 const VALID_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAXpeqz8AAAAASUVORK5CYII=";
@@ -353,6 +357,7 @@ describe("file tool large text safety", () => {
 describe("file tool image view", () => {
   beforeEach(() => {
     mockUploadSandboxFileToConvex.mockReset();
+    mockPhEvent.mockReset();
   });
 
   test("allows Kimi to view sandbox images as multimodal tool output", async () => {
@@ -421,6 +426,71 @@ describe("file tool image view", () => {
         },
       ],
     });
+
+    expect(mockPhEvent).toHaveBeenCalledTimes(1);
+    expect(mockPhEvent).toHaveBeenCalledWith(
+      "file_view_image_used",
+      expect.objectContaining({
+        user_id: "user-1",
+        chat_id: "chat-1",
+        stage: "model_output",
+        outcome: "success",
+        success: true,
+        media_type: "image/png",
+        size_bytes: 68,
+        preview_upload_succeeded: true,
+        file_extension: "png",
+        path_prefix_class: "tmp",
+        path_is_absolute: true,
+        path_has_extension: true,
+        path_depth: 2,
+        path_length: "/tmp/screenshot.png".length,
+        path_fingerprint: expect.any(String),
+      }),
+    );
+    expect(mockPhEvent.mock.calls[0][1]).not.toHaveProperty("path");
+  });
+
+  test("logs initial inspection failures with safe path diagnostics", async () => {
+    const commandRun = jest.fn(async () => ({
+      stdout: JSON.stringify({
+        error: "File not found or is not a regular file: /tmp/missing",
+      }),
+      stderr: "",
+      exitCode: 2,
+    }));
+    const sandbox = makeSandbox(commandRun);
+    const tool = createFile(makeContext(sandbox));
+
+    const result = await runTool(tool, {
+      action: "view",
+      path: "/tmp/missing",
+      brief: "Inspect a missing image",
+    });
+
+    expect(result).toEqual({
+      error: "File not found or is not a regular file: /tmp/missing",
+    });
+    expect(mockPhEvent).toHaveBeenCalledWith(
+      "file_view_image_used",
+      expect.objectContaining({
+        stage: "initial_inspection",
+        outcome: "inspection_failed",
+        success: false,
+        failure_reason: "file_not_found",
+        failure_detail: "file_not_found",
+        error_name: "Error",
+        error_message_hash: expect.any(String),
+        file_extension: undefined,
+        path_prefix_class: "tmp",
+        path_is_absolute: true,
+        path_has_extension: false,
+        path_depth: 2,
+        path_length: "/tmp/missing".length,
+        path_fingerprint: expect.any(String),
+      }),
+    );
+    expect(mockPhEvent.mock.calls[0][1]).not.toHaveProperty("path");
   });
 
   test("returns a text error instead of invalid image-data for corrupt sandbox images", async () => {
@@ -458,5 +528,22 @@ describe("file tool image view", () => {
       value:
         "Error: View inspection found invalid image data (missing_png_ihdr).",
     });
+
+    expect(mockPhEvent).toHaveBeenCalledWith(
+      "file_view_image_used",
+      expect.objectContaining({
+        stage: "model_output",
+        outcome: "inspection_failed",
+        success: false,
+        failure_reason: "inspection_error",
+        failure_detail: "invalid_image_data",
+        error_name: "Error",
+        error_message_hash: expect.any(String),
+        media_type: "image/png",
+        size_bytes: 8,
+        file_extension: "png",
+        path_prefix_class: "tmp",
+      }),
+    );
   });
 });

--- a/lib/ai/tools/__tests__/file.test.ts
+++ b/lib/ai/tools/__tests__/file.test.ts
@@ -493,6 +493,56 @@ describe("file tool image view", () => {
     expect(mockPhEvent.mock.calls[0][1]).not.toHaveProperty("path");
   });
 
+  test("keeps successful image handoff when success telemetry throws", async () => {
+    mockPhEvent.mockImplementationOnce(() => {
+      throw new Error("PostHog unavailable");
+    });
+
+    const commandRun = jest.fn(async (_command, opts) => {
+      expect(opts.envVars.HACKERAI_FILE_VIEW_INCLUDE_DATA).toBe("1");
+      return {
+        stdout: JSON.stringify({
+          path: "/tmp/screenshot.png",
+          mediaType: "image/png",
+          sizeBytes: 68,
+          kind: "image",
+          data: VALID_PNG_BASE64,
+        }),
+        stderr: "",
+        exitCode: 0,
+      };
+    });
+    const sandbox = makeSandbox(commandRun);
+    const tool = createFile(
+      makeContext(sandbox, { modelName: "model-kimi-k2.7-code" }),
+    );
+
+    await expect(
+      runToModelOutput(tool, {
+        action: "view",
+        content: "Viewing image file: screenshot.png (image/png, 68 bytes).",
+        path: "/tmp/screenshot.png",
+        filename: "screenshot.png",
+        mediaType: "image/png",
+        sizeBytes: 68,
+        kind: "image",
+      }),
+    ).resolves.toEqual({
+      type: "content",
+      value: [
+        {
+          type: "text",
+          text: "Viewing image file: screenshot.png (image/png, 68 bytes).",
+        },
+        {
+          type: "image-data",
+          data: VALID_PNG_BASE64,
+          mediaType: "image/png",
+        },
+      ],
+    });
+  });
+
   test("returns a text error instead of invalid image-data for corrupt sandbox images", async () => {
     const commandRun = jest.fn(async (_command, opts) => {
       expect(opts.envVars.HACKERAI_FILE_VIEW_INCLUDE_DATA).toBe("1");

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -1,5 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { createHash } from "crypto";
 import type { AnySandbox, ToolContext } from "@/types";
 import { truncateOutput } from "@/lib/token-utils";
 import { supportsMultimodalToolResults } from "@/lib/ai/providers";
@@ -44,6 +45,7 @@ type ViewMetadata = {
   mediaType: string;
   sizeBytes: number;
   kind: ViewKind;
+  previewUploadSucceeded?: boolean;
   previewFiles?: ViewPreviewFile[];
   previewError?: string;
 };
@@ -60,6 +62,15 @@ type FileViewImageUsageOutcome =
   | "success"
   | "unsupported_model"
   | "inspection_failed";
+
+type FileViewStage = "initial_inspection" | "model_output";
+
+type FileViewErrorClassification = {
+  failureReason: string;
+  failureDetail: string;
+  errorName?: string;
+  errorMessageHash: string;
+};
 
 const VIEW_FILE_SCRIPT = String.raw`
 import base64
@@ -284,49 +295,155 @@ function getActiveModelName(context: ToolContext): string | undefined {
   return context.getCurrentModelName?.() ?? context.modelName;
 }
 
-function classifyFileViewError(error: unknown): string {
+function hashTelemetryValue(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+function getPathPrefixClass(path: string): string {
+  const normalizedPath = path.replace(/\\/g, "/");
+  const lowerPath = normalizedPath.toLowerCase();
+
+  if (path.trim() === "") return "empty";
+  if (lowerPath.startsWith("/tmp/") || lowerPath.startsWith("c:/temp/")) {
+    return "tmp";
+  }
+  if (lowerPath.startsWith("/home/") || lowerPath.startsWith("c:/users/")) {
+    return "home";
+  }
+  if (lowerPath.startsWith("/workspace/") || lowerPath.includes("/workdir/")) {
+    return "workspace";
+  }
+  if (normalizedPath.startsWith("/") || /^[a-z]:\//i.test(normalizedPath)) {
+    return "absolute_other";
+  }
+  return "relative";
+}
+
+function getPathDepth(path: string): number {
+  return path
+    .replace(/\\/g, "/")
+    .split("/")
+    .filter((part) => part.length > 0).length;
+}
+
+function getPathTelemetry(path: string, userId: string) {
+  return {
+    path_fingerprint: hashTelemetryValue(`${userId}:${path}`),
+    path_prefix_class: getPathPrefixClass(path),
+    path_is_absolute: path.startsWith("/") || /^[a-z]:[\\/]/i.test(path),
+    path_has_extension: Boolean(getFileExtension(path)),
+    path_depth: getPathDepth(path),
+    path_length: path.length,
+  };
+}
+
+function classifyFileViewError(error: unknown): FileViewErrorClassification {
   const message = error instanceof Error ? error.message : String(error);
+  const base = {
+    errorName: error instanceof Error ? error.name : undefined,
+    errorMessageHash: hashTelemetryValue(message),
+  };
 
   if (message.includes("Unsupported media type")) {
-    return "unsupported_media_type";
+    return {
+      ...base,
+      failureReason: "unsupported_media_type",
+      failureDetail: "unsupported_media_type",
+    };
   }
   if (message.includes("too large")) {
-    return "file_too_large";
+    return {
+      ...base,
+      failureReason: "file_too_large",
+      failureDetail: "file_too_large",
+    };
   }
   if (message.includes("File not found")) {
-    return "file_not_found";
+    return {
+      ...base,
+      failureReason: "file_not_found",
+      failureDetail: "file_not_found",
+    };
   }
   if (message.includes("Windows local sandboxes")) {
-    return "unsupported_sandbox";
+    return {
+      ...base,
+      failureReason: "unsupported_sandbox",
+      failureDetail: "windows_local_sandbox",
+    };
   }
   if (message.includes("SVG files")) {
-    return "unsupported_svg";
+    return {
+      ...base,
+      failureReason: "unsupported_svg",
+      failureDetail: "unsupported_svg",
+    };
+  }
+  if (message.includes("Failed to inspect file for view")) {
+    return {
+      ...base,
+      failureReason: "inspection_error",
+      failureDetail: "invalid_inspection_output",
+    };
+  }
+  if (message.includes("View inspection returned an invalid payload")) {
+    return {
+      ...base,
+      failureReason: "inspection_error",
+      failureDetail: "invalid_payload",
+    };
+  }
+  if (message.includes("View inspection did not return image data")) {
+    return {
+      ...base,
+      failureReason: "inspection_error",
+      failureDetail: "missing_image_data",
+    };
+  }
+  if (message.includes("View inspection found invalid image data")) {
+    return {
+      ...base,
+      failureReason: "inspection_error",
+      failureDetail: "invalid_image_data",
+    };
   }
 
-  return "inspection_error";
+  return {
+    ...base,
+    failureReason: "inspection_error",
+    failureDetail: "inspection_error",
+  };
 }
 
 function captureFileViewImageUsage(args: {
   context: ToolContext;
   sandbox: any;
   path: string;
+  stage: FileViewStage;
   outcome: FileViewImageUsageOutcome;
   durationMs: number;
   mediaType?: string;
   sizeBytes?: number;
   previewUploadSucceeded?: boolean;
   failureReason?: string;
+  failureDetail?: string;
+  errorName?: string;
+  errorMessageHash?: string;
 }) {
   const {
     context,
     sandbox,
     path,
+    stage,
     outcome,
     durationMs,
     mediaType,
     sizeBytes,
     previewUploadSucceeded,
     failureReason,
+    failureDetail,
+    errorName,
+    errorMessageHash,
   } = args;
 
   phLogger.event("file_view_image_used", {
@@ -340,15 +457,20 @@ function captureFileViewImageUsage(args: {
     configured_model: context.modelName,
     sandbox_type: getViewSandboxType(sandbox),
     file_extension: getFileExtension(path),
+    stage,
     outcome,
     success: outcome === "success",
     duration_ms: durationMs,
+    ...getPathTelemetry(path, context.userID),
     ...(mediaType && { media_type: mediaType }),
     ...(typeof sizeBytes === "number" && { size_bytes: sizeBytes }),
     ...(typeof previewUploadSucceeded === "boolean" && {
       preview_upload_succeeded: previewUploadSucceeded,
     }),
     ...(failureReason && { failure_reason: failureReason }),
+    ...(failureDetail && { failure_detail: failureDetail }),
+    ...(errorName && { error_name: errorName }),
+    ...(errorMessageHash && { error_message_hash: errorMessageHash }),
   });
 }
 
@@ -1047,9 +1169,11 @@ ${instructionsDescription}`,
                 context,
                 sandbox,
                 path,
+                stage: "initial_inspection",
                 outcome: "unsupported_model",
                 durationMs: Date.now() - viewStartedAt,
                 failureReason: "unsupported_model",
+                failureDetail: "unsupported_model",
               });
               return { error: MULTIMODAL_UPGRADE_MESSAGE };
             }
@@ -1058,13 +1182,18 @@ ${instructionsDescription}`,
             try {
               viewPayload = await readSandboxFileForView(sandbox, path, false);
             } catch (error) {
+              const classification = classifyFileViewError(error);
               captureFileViewImageUsage({
                 context,
                 sandbox,
                 path,
+                stage: "initial_inspection",
                 outcome: "inspection_failed",
                 durationMs: Date.now() - viewStartedAt,
-                failureReason: classifyFileViewError(error),
+                failureReason: classification.failureReason,
+                failureDetail: classification.failureDetail,
+                errorName: classification.errorName,
+                errorMessageHash: classification.errorMessageHash,
               });
               throw error;
             }
@@ -1100,17 +1229,6 @@ ${instructionsDescription}`,
               );
             }
 
-            captureFileViewImageUsage({
-              context,
-              sandbox,
-              path,
-              outcome: "success",
-              durationMs: Date.now() - viewStartedAt,
-              mediaType: viewPayload.mediaType,
-              sizeBytes: viewPayload.sizeBytes,
-              previewUploadSucceeded: !previewUploadError,
-            });
-
             return {
               action: "view",
               content: `Viewing image file: ${filename} (${viewPayload.mediaType}, ${viewPayload.sizeBytes} bytes).`,
@@ -1119,6 +1237,7 @@ ${instructionsDescription}`,
               mediaType: viewPayload.mediaType,
               sizeBytes: viewPayload.sizeBytes,
               kind: viewPayload.kind,
+              previewUploadSucceeded: !previewUploadError,
               previewFiles,
               ...(previewUploadError
                 ? { previewError: previewUploadError }
@@ -1371,13 +1490,28 @@ ${instructionsDescription}`,
             };
           }
 
+          const viewStartedAt = Date.now();
+          let outputSandbox: any | undefined;
           try {
             const { sandbox } = await sandboxManager.getSandbox();
+            outputSandbox = sandbox;
             const viewPayload = await readSandboxFileForView(
               sandbox,
               viewOutput.path,
               true,
             );
+
+            captureFileViewImageUsage({
+              context,
+              sandbox,
+              path: viewOutput.path,
+              stage: "model_output",
+              outcome: "success",
+              durationMs: Date.now() - viewStartedAt,
+              mediaType: viewPayload.mediaType,
+              sizeBytes: viewPayload.sizeBytes,
+              previewUploadSucceeded: viewOutput.previewUploadSucceeded,
+            });
 
             return {
               type: "content" as const,
@@ -1391,6 +1525,28 @@ ${instructionsDescription}`,
               ],
             };
           } catch (error) {
+            try {
+              const sandbox =
+                outputSandbox ?? (await sandboxManager.getSandbox()).sandbox;
+              const classification = classifyFileViewError(error);
+              captureFileViewImageUsage({
+                context,
+                sandbox,
+                path: viewOutput.path,
+                stage: "model_output",
+                outcome: "inspection_failed",
+                durationMs: Date.now() - viewStartedAt,
+                mediaType: viewOutput.mediaType,
+                sizeBytes: viewOutput.sizeBytes,
+                previewUploadSucceeded: viewOutput.previewUploadSucceeded,
+                failureReason: classification.failureReason,
+                failureDetail: classification.failureDetail,
+                errorName: classification.errorName,
+                errorMessageHash: classification.errorMessageHash,
+              });
+            } catch {
+              // Preserve the model-visible error if telemetry capture itself fails.
+            }
             return {
               type: "text" as const,
               value: `Error: ${

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -1501,17 +1501,21 @@ ${instructionsDescription}`,
               true,
             );
 
-            captureFileViewImageUsage({
-              context,
-              sandbox,
-              path: viewOutput.path,
-              stage: "model_output",
-              outcome: "success",
-              durationMs: Date.now() - viewStartedAt,
-              mediaType: viewPayload.mediaType,
-              sizeBytes: viewPayload.sizeBytes,
-              previewUploadSucceeded: viewOutput.previewUploadSucceeded,
-            });
+            try {
+              captureFileViewImageUsage({
+                context,
+                sandbox,
+                path: viewOutput.path,
+                stage: "model_output",
+                outcome: "success",
+                durationMs: Date.now() - viewStartedAt,
+                mediaType: viewPayload.mediaType,
+                sizeBytes: viewPayload.sizeBytes,
+                previewUploadSucceeded: viewOutput.previewUploadSucceeded,
+              });
+            } catch {
+              // Telemetry must never break a successful image handoff.
+            }
 
             return {
               type: "content" as const,


### PR DESCRIPTION
## Summary
- log file view success only after image data is actually handed to the model
- add stage, failure_detail, hashed path diagnostics, and model-output failure telemetry for file-view image usage
- cover success, missing-file, and invalid-image telemetry contracts in focused tests

## Why
PostHog showed a Jun 24 spike in `file_view_image_used` failures, mostly `file_not_found`, concentrated in a few long Agent runs. The previous telemetry also counted success after the first sandbox inspection, before the final model-visible image-data handoff, so a later conversion failure could look successful.

## Validation
- `pnpm jest lib/ai/tools/__tests__/file.test.ts --runInBand`
- `pnpm exec prettier --check lib/ai/tools/file.ts lib/ai/tools/__tests__/file.test.ts`
- `pnpm exec eslint lib/ai/tools/file.ts lib/ai/tools/__tests__/file.test.ts`
- `pnpm typecheck`
- commit hook: `pnpm typecheck` and full `pnpm test` (161 suites / 1737 tests)

## Manual verification
- In Agent mode, view a valid PNG/JPG from the sandbox. PostHog should record `file_view_image_used` with `stage=model_output`, `outcome=success`, and no raw `path`.
- Try viewing a missing sandbox path. PostHog should record `stage=initial_inspection`, `outcome=inspection_failed`, `failure_reason=file_not_found`, plus safe path-shape diagnostics.
- For the dashboard, filter true success rate to `stage=model_output`, or split by `stage` to distinguish initial inspection from model-visible image delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image file viewing to make preview generation and inspection outcomes more consistent.
  * Enhanced handling for unreadable/invalid images so failures are classified more accurately and visible output is less likely to be impacted.
  * Added staged handling for image inspection vs model-output processing to improve reliability in edge cases.
* **Tests**
  * Expanded automated coverage to validate emitted telemetry for successful views and inspection failures, including resilience when telemetry logging fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->