### PR TITLE
Add free Ask reasoning experiment

### DIFF
--- a/docs/free-ask-reasoning-experiment.md
+++ b/docs/free-ask-reasoning-experiment.md
@@ -12,8 +12,9 @@ Create a PostHog feature flag or experiment with:
   - `control`: no reasoning
   - `reasoning_medium`: DeepSeek V4 Flash with `reasoning.enabled=true` and
     `effort=medium`
-- Targeting: free users only. The server also enforces eligibility, so paid
-  users, Agent mode, non-Ask requests, and requests with files are excluded.
+- Targeting: free users on the `ask-model-free` path only. The server also
+  enforces eligibility, so paid users, Agent mode, non-Ask requests, other Ask
+  model selections, and requests with files are excluded.
 - Rollout: start with `reasoning_medium` at 10-20% of eligible traffic and keep
   the rest in `control`.
 

--- a/docs/free-ask-reasoning-experiment.md
+++ b/docs/free-ask-reasoning-experiment.md
@@ -1,0 +1,59 @@
+# Free Ask DeepSeek Reasoning Experiment
+
+Use this to test whether enabling medium reasoning on free text-only Ask
+requests improves activation enough to justify the added latency and cost.
+
+## PostHog setup
+
+Create a PostHog feature flag or experiment with:
+
+- Key: `free_ask_deepseek_reasoning_v1`
+- Variants:
+  - `control`: no reasoning
+  - `reasoning_medium`: DeepSeek V4 Flash with `reasoning.enabled=true` and
+    `effort=medium`
+- Targeting: free users only. The server also enforces eligibility, so paid
+  users, Agent mode, non-Ask requests, and requests with files are excluded.
+- Rollout: start with `reasoning_medium` at 10-20% of eligible traffic and keep
+  the rest in `control`.
+
+If the PostHog flag is not available yet, the server fallback env var
+`FREE_ASK_REASONING_EXPERIMENT_TREATMENT_PERCENTAGE=10` can assign 10% of
+eligible users to `reasoning_medium` and the rest to `control`.
+
+## Events and properties
+
+The experiment emits:
+
+- `free_ask_reasoning_experiment_exposed`
+- `free_ask_reasoning_experiment_result`
+- `hackerai-usage_cost` with the same experiment properties
+
+Filter or group by:
+
+- `experiment_key = free_ask_deepseek_reasoning_v1`
+- `variant` or `experiment_variant`
+- `$feature/free_ask_deepseek_reasoning_v1`
+- `reasoning_enabled`
+- `reasoning_effort`
+
+## Readout
+
+Primary readout:
+
+- Success rate: `free_ask_reasoning_experiment_result` where
+  `outcome = success`, divided by `free_ask_reasoning_experiment_exposed`.
+- Paid conversion: exposed users who later fire `checkout_started` or
+  `subscription_started`, grouped by variant.
+
+Guardrails:
+
+- Cost: sum `cost_dollars` on `hackerai-usage_cost`, grouped by variant.
+- Latency: average and p95 `generation_time_ms` on
+  `free_ask_reasoning_experiment_result`, grouped by variant.
+- Reliability: error/abort rate on `free_ask_reasoning_experiment_result`,
+  grouped by variant.
+
+Call `reasoning_medium` better only if it improves success or paid conversion
+without materially increasing cost, latency, or error rate. If conversion is
+flat and cost/latency are higher, keep free Ask on control.

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -344,6 +344,63 @@ describe("captureUsageCost", () => {
       }),
     });
   });
+
+  it("attaches free Ask reasoning experiment properties to usage cost", () => {
+    const capture = jest.fn();
+
+    captureUsageCost({
+      posthog: { capture } as any,
+      userId: "user_123",
+      subscription: "free",
+      chatId: "chat_123",
+      endpoint: "/api/chat",
+      mode: "ask",
+      usage: {
+        model: "ask-model-free",
+        type: "subscription",
+        inputTokens: 1000,
+        outputTokens: 500,
+        totalTokens: 1500,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        costDollars: 0.01,
+        includedCostDollars: 0.01,
+        extraUsageCostDollars: 0,
+        includedPointsDeducted: 100,
+        extraUsagePointsDeducted: 0,
+        modelCostDollars: 0.01,
+        nonModelCostDollars: 0,
+        costSource: "provider",
+      },
+      freeAskReasoningExperiment: {
+        experimentKey: "free_ask_deepseek_reasoning_v1",
+        featureFlagKey: "free_ask_deepseek_reasoning_v1",
+        eventVersion: 1,
+        variant: "reasoning_medium",
+        source: "posthog",
+        reasoning: { enabled: true, effort: "medium" },
+      },
+    });
+
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      event: "hackerai-usage_cost",
+      properties: expect.objectContaining({
+        subscription: "free",
+        mode: "ask",
+        model: "ask-model-free",
+        experiment_key: "free_ask_deepseek_reasoning_v1",
+        feature_flag_key: "free_ask_deepseek_reasoning_v1",
+        variant: "reasoning_medium",
+        experiment_variant: "reasoning_medium",
+        experiment_source: "posthog",
+        experiment_event_version: 1,
+        reasoning_enabled: true,
+        reasoning_effort: "medium",
+        "$feature/free_ask_deepseek_reasoning_v1": "reasoning_medium",
+      }),
+    });
+  });
 });
 
 describe("createChatLogger provider stream termination", () => {

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -197,6 +197,24 @@ describe("buildProviderOptions fallback chain", () => {
     },
   );
 
+  it("allows a scoped reasoning override for the free Ask experiment", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "ask-model-free",
+      "ask",
+      {
+        reasoningOverride: { enabled: true, effort: "medium" },
+      },
+    );
+
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+      effort: "medium",
+    });
+    expect(opts.openrouter.models).toEqual([GEMINI_PREVIEW_SLUG]);
+  });
+
   it.each(["ask-model", "model-gemini-3-flash"])(
     "enables hidden minimal reasoning for Gemini 3.5 ask mode model %s",
     (modelName) => {

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -306,6 +306,14 @@ export type AgentStreamContext = {
   streamStartTime: number;
   contextUsageOn: boolean;
   isReasoningModel: boolean;
+  providerReasoningOverride?: {
+    modelName: string;
+    reasoning: {
+      enabled: boolean;
+      effort?: string;
+      exclude?: boolean;
+    };
+  };
   /** elapsedTimeExceeds threshold; callers supply their platform ceiling. */
   maxDurationMs: number;
 
@@ -377,6 +385,9 @@ export async function createAgentStream(
       ctx.mode,
       {
         hasMultimodalToolResults: streamHasImageViewResults,
+        ...(ctx.providerReasoningOverride?.modelName === modelName && {
+          reasoningOverride: ctx.providerReasoningOverride.reasoning,
+        }),
       },
     );
   const prepareProviderMessages = (

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -76,7 +76,10 @@ import { classifyProviderOverflowError } from "@/lib/utils/error-utils";
 import type { UsageTracker } from "@/lib/usage-tracker";
 import type { BudgetMonitor } from "@/lib/chat/budget-monitor";
 import type { UsageRefundTracker } from "@/lib/rate-limit";
-import type { SummarizationTracker } from "@/lib/api/chat-stream-helpers";
+import type {
+  ProviderReasoningOverride,
+  SummarizationTracker,
+} from "@/lib/api/chat-stream-helpers";
 import type { ChatLogger } from "@/lib/api/chat-logger";
 import type { createTrackedProvider } from "@/lib/ai/providers";
 import type { ProviderRequestDiagnostics } from "@/lib/logger";
@@ -308,11 +311,7 @@ export type AgentStreamContext = {
   isReasoningModel: boolean;
   providerReasoningOverride?: {
     modelName: string;
-    reasoning: {
-      enabled: boolean;
-      effort?: string;
-      exclude?: boolean;
-    };
+    reasoning: ProviderReasoningOverride;
   };
   /** elapsedTimeExceeds threshold; callers supply their platform ceiling. */
   maxDurationMs: number;

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -194,12 +194,40 @@ export const createChatHandler = () => {
       mode: ChatMode;
       selectedModel: string;
     } | null = null;
+    let freeAskReasoningResultRecorded = false;
     let releaseFreeRunLock: (() => Promise<void>) | undefined;
     const releaseFreeRunLockOnce = async () => {
       const release = releaseFreeRunLock;
       if (!release) return;
       releaseFreeRunLock = undefined;
       await release();
+    };
+    const captureFreeAskReasoningTerminalResult = ({
+      outcome,
+      generationTimeMs,
+      finishReason,
+    }: {
+      outcome: "success" | "aborted" | "error";
+      generationTimeMs?: number;
+      finishReason?: string;
+    }) => {
+      if (
+        !freeAskReasoningResultContext ||
+        !freeAskReasoningExperiment ||
+        freeAskReasoningResultRecorded
+      ) {
+        return;
+      }
+
+      captureFreeAskReasoningExperimentResult({
+        posthog,
+        ...freeAskReasoningResultContext,
+        assignment: freeAskReasoningExperiment,
+        outcome,
+        generationTimeMs,
+        finishReason,
+      });
+      freeAskReasoningResultRecorded = true;
     };
 
     try {
@@ -400,13 +428,16 @@ export const createChatHandler = () => {
       posthog = PostHogClient();
 
       const fileCounts = countFileAttachments(truncatedMessages);
+      const eligibilityFileCounts = countFileAttachments(
+        fetched.truncatedMessages,
+      );
       freeAskReasoningExperiment = await resolveFreeAskReasoningExperiment({
         posthog,
         userId,
         subscription,
         mode,
         selectedModel,
-        fileCount: fileCounts.totalFiles,
+        fileCount: eligibilityFileCounts.totalFiles,
       });
       freeAskReasoningResultContext = freeAskReasoningExperiment
         ? {
@@ -903,6 +934,11 @@ export const createChatHandler = () => {
             const fallbackModel = getRetryFallbackModel(selectedModel, mode);
             const fallbackModelId =
               trackedProvider.languageModel(fallbackModel).modelId;
+            const activeFreeAskReasoningExperiment =
+              selectedModel === "ask-model-free" &&
+              freeAskReasoningResultContext?.selectedModel === selectedModel
+                ? freeAskReasoningExperiment
+                : null;
 
             const usageTracker = new UsageTracker();
             let hasRecordedUsage = false;
@@ -1067,7 +1103,7 @@ export const createChatHandler = () => {
                   endpoint,
                   mode,
                   usage: usageCostRecord,
-                  freeAskReasoningExperiment,
+                  freeAskReasoningExperiment: activeFreeAskReasoningExperiment,
                   ...(paidDailyFreeAllowanceReservation && {
                     paidDailyFreeAllowance:
                       createPaidDailyFreeAllowanceUsageLogContext(
@@ -1099,10 +1135,10 @@ export const createChatHandler = () => {
               streamStartTime,
               contextUsageOn,
               isReasoningModel,
-              ...(freeAskReasoningExperiment?.reasoning.enabled && {
+              ...(activeFreeAskReasoningExperiment?.reasoning.enabled && {
                 providerReasoningOverride: {
                   modelName: selectedModel,
-                  reasoning: freeAskReasoningExperiment.reasoning,
+                  reasoning: activeFreeAskReasoningExperiment.reasoning,
                 },
               }),
               maxDurationMs: AGENT_MAX_STREAM_DURATION_MS,
@@ -1359,18 +1395,6 @@ export const createChatHandler = () => {
                                   outcome,
                                   chatLogger,
                                 });
-                                if (freeAskReasoningResultContext) {
-                                  captureFreeAskReasoningExperimentResult({
-                                    posthog,
-                                    ...freeAskReasoningResultContext,
-                                    assignment: freeAskReasoningExperiment,
-                                    outcome,
-                                    generationTimeMs:
-                                      Date.now() - fallbackStartTime,
-                                    finishReason: state.streamFinishReason,
-                                  });
-                                }
-                                shutdownPostHog(posthog);
                                 chatLogger!.emitSuccess({
                                   finishReason: state.streamFinishReason,
                                   wasAborted: retryAborted,
@@ -1506,6 +1530,13 @@ export const createChatHandler = () => {
 
                                 // Deduct accumulated usage (includes both original + retry streams)
                                 await deductAccumulatedUsage();
+                                captureFreeAskReasoningTerminalResult({
+                                  outcome,
+                                  generationTimeMs:
+                                    Date.now() - streamStartTime,
+                                  finishReason: state.streamFinishReason,
+                                });
+                                shutdownPostHog(posthog);
                               } finally {
                                 await releaseFreeRunLockOnce();
                               }
@@ -1591,17 +1622,6 @@ export const createChatHandler = () => {
                       outcome,
                       chatLogger,
                     });
-                    if (freeAskReasoningResultContext) {
-                      captureFreeAskReasoningExperimentResult({
-                        posthog,
-                        ...freeAskReasoningResultContext,
-                        assignment: freeAskReasoningExperiment,
-                        outcome,
-                        generationTimeMs: Date.now() - streamStartTime,
-                        finishReason: state.streamFinishReason,
-                      });
-                    }
-                    shutdownPostHog(posthog);
                     chatLogger!.emitSuccess({
                       finishReason: state.streamFinishReason,
                       wasAborted: isAborted,
@@ -1745,6 +1765,12 @@ export const createChatHandler = () => {
                           }),
                         );
                         await deductAccumulatedUsage();
+                        captureFreeAskReasoningTerminalResult({
+                          outcome,
+                          generationTimeMs: Date.now() - streamStartTime,
+                          finishReason: state.streamFinishReason,
+                        });
+                        shutdownPostHog(posthog);
                         return;
                       }
 
@@ -1879,6 +1905,12 @@ export const createChatHandler = () => {
                     }
 
                     await deductAccumulatedUsage();
+                    captureFreeAskReasoningTerminalResult({
+                      outcome,
+                      generationTimeMs: Date.now() - streamStartTime,
+                      finishReason: state.streamFinishReason,
+                    });
+                    shutdownPostHog(posthog);
                   } finally {
                     if (!retryScheduled) {
                       await releaseFreeRunLockOnce();
@@ -1929,14 +1961,7 @@ export const createChatHandler = () => {
       // Clear timeout if error occurs before onFinish
       preemptiveTimeout?.clear();
       await releaseFreeRunLockOnce();
-      if (freeAskReasoningResultContext) {
-        captureFreeAskReasoningExperimentResult({
-          posthog,
-          ...freeAskReasoningResultContext,
-          assignment: freeAskReasoningExperiment,
-          outcome: "error",
-        });
-      }
+      captureFreeAskReasoningTerminalResult({ outcome: "error" });
       shutdownPostHog(posthog);
 
       // Best-effort PTY cleanup — the stream may never have reached onFinish.

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -154,6 +154,11 @@ import {
 } from "@/lib/chat/multimodal-tool-result-recovery";
 import { shouldRetryProviderStreamWithFallback } from "@/lib/chat/agent-long-provider-retry";
 import { FREE_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
+import {
+  captureFreeAskReasoningExperimentExposure,
+  captureFreeAskReasoningExperimentResult,
+  resolveFreeAskReasoningExperiment,
+} from "@/lib/experiments/free-ask-reasoning";
 
 function getStreamContext() {
   try {
@@ -178,6 +183,17 @@ export const createChatHandler = () => {
     // Wide event logger for structured logging
     let chatLogger: ChatLogger | undefined;
     let outerChatId: string | undefined;
+    let posthog: ReturnType<typeof PostHogClient> = null;
+    let freeAskReasoningExperiment: Awaited<
+      ReturnType<typeof resolveFreeAskReasoningExperiment>
+    > = null;
+    let freeAskReasoningResultContext: {
+      userId: string;
+      chatId: string;
+      subscription: string;
+      mode: ChatMode;
+      selectedModel: string;
+    } | null = null;
     let releaseFreeRunLock: (() => Promise<void>) | undefined;
     const releaseFreeRunLockOnce = async () => {
       const release = releaseFreeRunLock;
@@ -380,7 +396,27 @@ export const createChatHandler = () => {
         truncatedMessages,
       });
 
+      // PostHog client for analytics and server-side experiment evaluation.
+      posthog = PostHogClient();
+
       const fileCounts = countFileAttachments(truncatedMessages);
+      freeAskReasoningExperiment = await resolveFreeAskReasoningExperiment({
+        posthog,
+        userId,
+        subscription,
+        mode,
+        selectedModel,
+        fileCount: fileCounts.totalFiles,
+      });
+      freeAskReasoningResultContext = freeAskReasoningExperiment
+        ? {
+            userId,
+            chatId,
+            subscription,
+            mode,
+            selectedModel,
+          }
+        : null;
       const chatLogContext = {
         messageCount: truncatedMessages.length,
         estimatedInputTokens,
@@ -390,6 +426,17 @@ export const createChatHandler = () => {
         notesEnabled,
       };
       chatLogger.setChat(chatLogContext, selectedModel);
+      captureFreeAskReasoningExperimentExposure({
+        posthog,
+        userId,
+        chatId,
+        subscription,
+        mode,
+        selectedModel,
+        assignment: freeAskReasoningExperiment,
+        estimatedInputTokens,
+        isNewChat,
+      });
 
       let paidDailyFreeAllowanceReservation:
         | PaidDailyFreeAllowanceReservation
@@ -517,9 +564,6 @@ export const createChatHandler = () => {
         },
         extraUsageConfig,
       );
-
-      // PostHog client for analytics (initialized once, used at end of request)
-      const posthog = PostHogClient();
 
       const assistantMessageId = uuidv4();
       chatLogger.getBuilder().setAssistantId(assistantMessageId);
@@ -1023,6 +1067,7 @@ export const createChatHandler = () => {
                   endpoint,
                   mode,
                   usage: usageCostRecord,
+                  freeAskReasoningExperiment,
                   ...(paidDailyFreeAllowanceReservation && {
                     paidDailyFreeAllowance:
                       createPaidDailyFreeAllowanceUsageLogContext(
@@ -1054,6 +1099,12 @@ export const createChatHandler = () => {
               streamStartTime,
               contextUsageOn,
               isReasoningModel,
+              ...(freeAskReasoningExperiment?.reasoning.enabled && {
+                providerReasoningOverride: {
+                  modelName: selectedModel,
+                  reasoning: freeAskReasoningExperiment.reasoning,
+                },
+              }),
               maxDurationMs: AGENT_MAX_STREAM_DURATION_MS,
               writer,
               abortController: userStopSignal,
@@ -1308,6 +1359,17 @@ export const createChatHandler = () => {
                                   outcome,
                                   chatLogger,
                                 });
+                                if (freeAskReasoningResultContext) {
+                                  captureFreeAskReasoningExperimentResult({
+                                    posthog,
+                                    ...freeAskReasoningResultContext,
+                                    assignment: freeAskReasoningExperiment,
+                                    outcome,
+                                    generationTimeMs:
+                                      Date.now() - fallbackStartTime,
+                                    finishReason: state.streamFinishReason,
+                                  });
+                                }
                                 shutdownPostHog(posthog);
                                 chatLogger!.emitSuccess({
                                   finishReason: state.streamFinishReason,
@@ -1529,6 +1591,16 @@ export const createChatHandler = () => {
                       outcome,
                       chatLogger,
                     });
+                    if (freeAskReasoningResultContext) {
+                      captureFreeAskReasoningExperimentResult({
+                        posthog,
+                        ...freeAskReasoningResultContext,
+                        assignment: freeAskReasoningExperiment,
+                        outcome,
+                        generationTimeMs: Date.now() - streamStartTime,
+                        finishReason: state.streamFinishReason,
+                      });
+                    }
                     shutdownPostHog(posthog);
                     chatLogger!.emitSuccess({
                       finishReason: state.streamFinishReason,
@@ -1857,6 +1929,15 @@ export const createChatHandler = () => {
       // Clear timeout if error occurs before onFinish
       preemptiveTimeout?.clear();
       await releaseFreeRunLockOnce();
+      if (freeAskReasoningResultContext) {
+        captureFreeAskReasoningExperimentResult({
+          posthog,
+          ...freeAskReasoningResultContext,
+          assignment: freeAskReasoningExperiment,
+          outcome: "error",
+        });
+      }
+      shutdownPostHog(posthog);
 
       // Best-effort PTY cleanup — the stream may never have reached onFinish.
       if (outerChatId) {

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -43,6 +43,10 @@ import {
   isPaidMonthlyCapHitReason,
   type LimitCapReason,
 } from "@/lib/limit-pressure";
+import {
+  getFreeAskReasoningExperimentProperties,
+  type FreeAskReasoningExperimentAssignment,
+} from "@/lib/experiments/free-ask-reasoning";
 
 export interface ChatLoggerConfig {
   chatId: string;
@@ -931,6 +935,7 @@ export function captureUsageCost({
   mode,
   usage,
   paidDailyFreeAllowance,
+  freeAskReasoningExperiment,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -947,6 +952,7 @@ export function captureUsageCost({
     costLimitDollars?: number;
     resetTimestamp?: number;
   };
+  freeAskReasoningExperiment?: FreeAskReasoningExperimentAssignment | null;
 }) {
   if (!posthog) return;
   posthog.capture({
@@ -975,6 +981,9 @@ export function captureUsageCost({
       cache_read_tokens: usage.cacheReadTokens ?? 0,
       cache_write_tokens: usage.cacheWriteTokens ?? 0,
       cost_source: usage.costSource,
+      ...(freeAskReasoningExperiment && {
+        ...getFreeAskReasoningExperimentProperties(freeAskReasoningExperiment),
+      }),
       ...(paidDailyFreeAllowance?.active && {
         limit_rescue_type: "paid_daily_free_allowance",
         paid_daily_free_allowance_active: true,

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -541,6 +541,11 @@ const isAskKimiReasoningModel = (modelName?: string): boolean =>
 
 type FallbackOptions = {
   hasMultimodalToolResults?: boolean;
+  reasoningOverride?: {
+    enabled: boolean;
+    effort?: string;
+    exclude?: boolean;
+  };
 };
 
 const getFallbackKeys = (
@@ -617,22 +622,24 @@ export function buildProviderOptions(
   const isGemini35Flash =
     modelId?.startsWith("google/gemini-3.5-flash") ?? false;
   const fallbackSlugs = getFallbackSlugs(modelName, mode, options);
-  const reasoning = isReasoningModel
-    ? {
-        enabled: true,
-        ...(isDeepSeekV4 && { effort: "xhigh" }),
-      }
-    : mode === "ask" && isAskKimiReasoningModel(modelName)
+  const reasoning =
+    options.reasoningOverride ??
+    (isReasoningModel
       ? {
           enabled: true,
+          ...(isDeepSeekV4 && { effort: "xhigh" }),
         }
-      : mode === "ask" && isAskMediumReasoningModel(modelName)
+      : mode === "ask" && isAskKimiReasoningModel(modelName)
         ? {
             enabled: true,
-            effort: isGemini35Flash ? "minimal" : "medium",
-            ...(isGemini35Flash && { exclude: true }),
           }
-        : { enabled: false };
+        : mode === "ask" && isAskMediumReasoningModel(modelName)
+          ? {
+              enabled: true,
+              effort: isGemini35Flash ? "minimal" : "medium",
+              ...(isGemini35Flash && { exclude: true }),
+            }
+          : { enabled: false });
 
   return {
     openrouter: {

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -541,11 +541,13 @@ const isAskKimiReasoningModel = (modelName?: string): boolean =>
 
 type FallbackOptions = {
   hasMultimodalToolResults?: boolean;
-  reasoningOverride?: {
-    enabled: boolean;
-    effort?: string;
-    exclude?: boolean;
-  };
+  reasoningOverride?: ProviderReasoningOverride;
+};
+
+export type ProviderReasoningOverride = {
+  enabled: boolean;
+  effort?: string;
+  exclude?: boolean;
 };
 
 const getFallbackKeys = (

--- a/lib/experiments/__tests__/free-ask-reasoning.test.ts
+++ b/lib/experiments/__tests__/free-ask-reasoning.test.ts
@@ -1,0 +1,188 @@
+import {
+  FREE_ASK_REASONING_EXPERIMENT_KEY,
+  captureFreeAskReasoningExperimentExposure,
+  captureFreeAskReasoningExperimentResult,
+  resolveFreeAskReasoningExperiment,
+} from "@/lib/experiments/free-ask-reasoning";
+
+const ORIGINAL_TREATMENT_PERCENTAGE =
+  process.env.FREE_ASK_REASONING_EXPERIMENT_TREATMENT_PERCENTAGE;
+
+afterEach(() => {
+  if (ORIGINAL_TREATMENT_PERCENTAGE === undefined) {
+    delete process.env.FREE_ASK_REASONING_EXPERIMENT_TREATMENT_PERCENTAGE;
+  } else {
+    process.env.FREE_ASK_REASONING_EXPERIMENT_TREATMENT_PERCENTAGE =
+      ORIGINAL_TREATMENT_PERCENTAGE;
+  }
+  jest.clearAllMocks();
+});
+
+describe("resolveFreeAskReasoningExperiment", () => {
+  it("does not assign users outside free text-only Ask", async () => {
+    const getFeatureFlag = jest.fn();
+
+    await expect(
+      resolveFreeAskReasoningExperiment({
+        posthog: { getFeatureFlag } as any,
+        userId: "user_123",
+        subscription: "pro",
+        mode: "ask",
+        selectedModel: "model-deepseek-v4-pro",
+        fileCount: 0,
+      }),
+    ).resolves.toBeNull();
+
+    await expect(
+      resolveFreeAskReasoningExperiment({
+        posthog: { getFeatureFlag } as any,
+        userId: "user_123",
+        subscription: "free",
+        mode: "ask",
+        selectedModel: "ask-model-free",
+        fileCount: 1,
+      }),
+    ).resolves.toBeNull();
+
+    expect(getFeatureFlag).not.toHaveBeenCalled();
+  });
+
+  it("uses the PostHog variant when the server flag returns one", async () => {
+    const getFeatureFlag = jest.fn().mockResolvedValue("reasoning_medium");
+
+    const assignment = await resolveFreeAskReasoningExperiment({
+      posthog: { getFeatureFlag } as any,
+      userId: "user_123",
+      subscription: "free",
+      mode: "ask",
+      selectedModel: "ask-model-free",
+      fileCount: 0,
+    });
+
+    expect(getFeatureFlag).toHaveBeenCalledWith(
+      FREE_ASK_REASONING_EXPERIMENT_KEY,
+      "user_123",
+      expect.objectContaining({
+        personProperties: expect.objectContaining({
+          subscription_tier: "free",
+          mode: "ask",
+          selected_model: "ask-model-free",
+        }),
+      }),
+    );
+    expect(assignment).toMatchObject({
+      variant: "reasoning_medium",
+      source: "posthog",
+      reasoning: { enabled: true, effort: "medium" },
+    });
+  });
+
+  it("falls back to deterministic env rollout when PostHog is unavailable", async () => {
+    process.env.FREE_ASK_REASONING_EXPERIMENT_TREATMENT_PERCENTAGE = "100";
+
+    const assignment = await resolveFreeAskReasoningExperiment({
+      posthog: null,
+      userId: "user_123",
+      subscription: "free",
+      mode: "ask",
+      selectedModel: "ask-model-free",
+      fileCount: 0,
+    });
+
+    expect(assignment).toMatchObject({
+      variant: "reasoning_medium",
+      source: "env",
+      treatmentPercentage: 100,
+      reasoning: { enabled: true, effort: "medium" },
+    });
+  });
+
+  it("stays disabled when neither PostHog nor env rollout is active", async () => {
+    delete process.env.FREE_ASK_REASONING_EXPERIMENT_TREATMENT_PERCENTAGE;
+
+    await expect(
+      resolveFreeAskReasoningExperiment({
+        posthog: null,
+        userId: "user_123",
+        subscription: "free",
+        mode: "ask",
+        selectedModel: "ask-model-free",
+        fileCount: 0,
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("free Ask reasoning PostHog events", () => {
+  const assignment = {
+    experimentKey: FREE_ASK_REASONING_EXPERIMENT_KEY,
+    featureFlagKey: FREE_ASK_REASONING_EXPERIMENT_KEY,
+    eventVersion: 1,
+    variant: "reasoning_medium" as const,
+    source: "posthog" as const,
+    reasoning: { enabled: true as const, effort: "medium" as const },
+  };
+
+  it("captures exposure with feature flag properties", () => {
+    const capture = jest.fn();
+
+    captureFreeAskReasoningExperimentExposure({
+      posthog: { capture } as any,
+      userId: "user_123",
+      chatId: "chat_123",
+      subscription: "free",
+      mode: "ask",
+      selectedModel: "ask-model-free",
+      assignment,
+      estimatedInputTokens: 123,
+      isNewChat: true,
+    });
+
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      event: "free_ask_reasoning_experiment_exposed",
+      properties: expect.objectContaining({
+        user_id: "user_123",
+        chat_id: "chat_123",
+        subscription_tier: "free",
+        selected_model: "ask-model-free",
+        estimated_input_tokens: 123,
+        experiment_key: FREE_ASK_REASONING_EXPERIMENT_KEY,
+        variant: "reasoning_medium",
+        reasoning_enabled: true,
+        reasoning_effort: "medium",
+        [`$feature/${FREE_ASK_REASONING_EXPERIMENT_KEY}`]: "reasoning_medium",
+      }),
+    });
+  });
+
+  it("captures result with outcome and timing", () => {
+    const capture = jest.fn();
+
+    captureFreeAskReasoningExperimentResult({
+      posthog: { capture } as any,
+      userId: "user_123",
+      chatId: "chat_123",
+      subscription: "free",
+      mode: "ask",
+      selectedModel: "ask-model-free",
+      assignment,
+      outcome: "success",
+      generationTimeMs: 456,
+      finishReason: "stop",
+    });
+
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      event: "free_ask_reasoning_experiment_result",
+      properties: expect.objectContaining({
+        outcome: "success",
+        generation_time_ms: 456,
+        finish_reason: "stop",
+        experiment_key: FREE_ASK_REASONING_EXPERIMENT_KEY,
+        variant: "reasoning_medium",
+        reasoning_enabled: true,
+      }),
+    });
+  });
+});

--- a/lib/experiments/free-ask-reasoning.ts
+++ b/lib/experiments/free-ask-reasoning.ts
@@ -1,0 +1,284 @@
+import type { ChatMode, SubscriptionTier } from "@/types";
+import type { ModelName } from "@/lib/ai/providers";
+import type { PostHog } from "posthog-node";
+
+export const FREE_ASK_REASONING_EXPERIMENT_KEY =
+  "free_ask_deepseek_reasoning_v1";
+export const FREE_ASK_REASONING_CONTROL_VARIANT = "control";
+export const FREE_ASK_REASONING_TREATMENT_VARIANT = "reasoning_medium";
+export const FREE_ASK_REASONING_EVENT_VERSION = 1;
+
+export type FreeAskReasoningVariant =
+  | typeof FREE_ASK_REASONING_CONTROL_VARIANT
+  | typeof FREE_ASK_REASONING_TREATMENT_VARIANT;
+
+export type FreeAskReasoningExperimentAssignment = {
+  experimentKey: typeof FREE_ASK_REASONING_EXPERIMENT_KEY;
+  featureFlagKey: typeof FREE_ASK_REASONING_EXPERIMENT_KEY;
+  eventVersion: typeof FREE_ASK_REASONING_EVENT_VERSION;
+  variant: FreeAskReasoningVariant;
+  source: "posthog" | "env";
+  reasoning: {
+    enabled: boolean;
+    effort?: "medium";
+  };
+  treatmentPercentage?: number;
+};
+
+type PostHogFeatureFlagClient = {
+  getFeatureFlag?: (
+    key: string,
+    distinctId: string,
+    options?: {
+      personProperties?: Record<string, unknown>;
+      groups?: Record<string, string>;
+      onlyEvaluateLocally?: boolean;
+    },
+  ) => Promise<unknown> | unknown;
+  capture?: PostHog["capture"];
+};
+
+type ResolveFreeAskReasoningExperimentArgs = {
+  posthog: PostHog | null;
+  userId: string;
+  subscription: SubscriptionTier;
+  mode: ChatMode;
+  selectedModel: ModelName;
+  fileCount: number;
+};
+
+type CaptureBaseArgs = {
+  posthog: PostHog | null;
+  userId: string;
+  chatId: string;
+  subscription: string;
+  mode: ChatMode;
+  selectedModel: string;
+  assignment: FreeAskReasoningExperimentAssignment | null;
+};
+
+const readTreatmentPercentage = (): number => {
+  const raw = process.env.FREE_ASK_REASONING_EXPERIMENT_TREATMENT_PERCENTAGE;
+  if (raw === undefined || raw.trim() === "") return 0;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100) return 0;
+  return parsed;
+};
+
+const hashToPercentage = (value: string): number => {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash << 5) - hash + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash) % 100;
+};
+
+const normalizeVariant = (value: unknown): FreeAskReasoningVariant | null => {
+  if (value === FREE_ASK_REASONING_CONTROL_VARIANT) {
+    return FREE_ASK_REASONING_CONTROL_VARIANT;
+  }
+  if (value === FREE_ASK_REASONING_TREATMENT_VARIANT) {
+    return FREE_ASK_REASONING_TREATMENT_VARIANT;
+  }
+  return null;
+};
+
+const assignmentForVariant = (
+  variant: FreeAskReasoningVariant,
+  source: FreeAskReasoningExperimentAssignment["source"],
+  treatmentPercentage?: number,
+): FreeAskReasoningExperimentAssignment => {
+  const treatment = variant === FREE_ASK_REASONING_TREATMENT_VARIANT;
+  return {
+    experimentKey: FREE_ASK_REASONING_EXPERIMENT_KEY,
+    featureFlagKey: FREE_ASK_REASONING_EXPERIMENT_KEY,
+    eventVersion: FREE_ASK_REASONING_EVENT_VERSION,
+    variant,
+    source,
+    reasoning: treatment
+      ? { enabled: true, effort: "medium" }
+      : { enabled: false },
+    ...(treatmentPercentage !== undefined && { treatmentPercentage }),
+  };
+};
+
+const getPostHogVariant = async ({
+  posthog,
+  userId,
+  subscription,
+  mode,
+  selectedModel,
+}: Omit<
+  ResolveFreeAskReasoningExperimentArgs,
+  "fileCount"
+>): Promise<FreeAskReasoningVariant | null> => {
+  const client = posthog as PostHogFeatureFlagClient | null;
+  if (!client?.getFeatureFlag) return null;
+
+  try {
+    const variant = await client.getFeatureFlag(
+      FREE_ASK_REASONING_EXPERIMENT_KEY,
+      userId,
+      {
+        personProperties: {
+          subscription_tier: subscription,
+          subscription,
+          mode,
+          selected_model: selectedModel,
+        },
+      },
+    );
+    return normalizeVariant(variant);
+  } catch {
+    return null;
+  }
+};
+
+const getEnvVariant = (
+  userId: string,
+): FreeAskReasoningExperimentAssignment | null => {
+  const treatmentPercentage = readTreatmentPercentage();
+  if (treatmentPercentage <= 0) return null;
+
+  const bucket = hashToPercentage(
+    `${FREE_ASK_REASONING_EXPERIMENT_KEY}:${userId}`,
+  );
+  const variant =
+    bucket < treatmentPercentage
+      ? FREE_ASK_REASONING_TREATMENT_VARIANT
+      : FREE_ASK_REASONING_CONTROL_VARIANT;
+
+  return assignmentForVariant(variant, "env", treatmentPercentage);
+};
+
+export async function resolveFreeAskReasoningExperiment({
+  posthog,
+  userId,
+  subscription,
+  mode,
+  selectedModel,
+  fileCount,
+}: ResolveFreeAskReasoningExperimentArgs): Promise<FreeAskReasoningExperimentAssignment | null> {
+  if (
+    subscription !== "free" ||
+    mode !== "ask" ||
+    selectedModel !== "ask-model-free" ||
+    fileCount > 0
+  ) {
+    return null;
+  }
+
+  const posthogVariant = await getPostHogVariant({
+    posthog,
+    userId,
+    subscription,
+    mode,
+    selectedModel,
+  });
+  if (posthogVariant) {
+    return assignmentForVariant(posthogVariant, "posthog");
+  }
+
+  return getEnvVariant(userId);
+}
+
+export function getFreeAskReasoningExperimentProperties(
+  assignment: FreeAskReasoningExperimentAssignment | null,
+) {
+  if (!assignment) return {};
+
+  return {
+    experiment_key: assignment.experimentKey,
+    feature_flag_key: assignment.featureFlagKey,
+    variant: assignment.variant,
+    experiment_variant: assignment.variant,
+    experiment_source: assignment.source,
+    experiment_event_version: assignment.eventVersion,
+    reasoning_enabled: assignment.reasoning.enabled,
+    ...(assignment.reasoning.effort && {
+      reasoning_effort: assignment.reasoning.effort,
+    }),
+    ...(assignment.treatmentPercentage !== undefined && {
+      treatment_percentage: assignment.treatmentPercentage,
+    }),
+    [`$feature/${assignment.featureFlagKey}`]: assignment.variant,
+  };
+}
+
+export function captureFreeAskReasoningExperimentExposure({
+  posthog,
+  userId,
+  chatId,
+  subscription,
+  mode,
+  selectedModel,
+  assignment,
+  estimatedInputTokens,
+  isNewChat,
+}: CaptureBaseArgs & {
+  estimatedInputTokens: number;
+  isNewChat: boolean;
+}) {
+  if (!posthog || !assignment) return;
+
+  const now = new Date().toISOString();
+  posthog.capture({
+    distinctId: userId,
+    event: "free_ask_reasoning_experiment_exposed",
+    properties: {
+      user_id: userId,
+      chat_id: chatId,
+      subscription,
+      subscription_tier: subscription,
+      mode,
+      selected_model: selectedModel,
+      estimated_input_tokens: estimatedInputTokens,
+      is_new_chat: isNewChat,
+      ...getFreeAskReasoningExperimentProperties(assignment),
+      $set_once: {
+        free_ask_reasoning_first_exposed_at: now,
+        free_ask_reasoning_first_variant: assignment.variant,
+      },
+    },
+  });
+}
+
+export function captureFreeAskReasoningExperimentResult({
+  posthog,
+  userId,
+  chatId,
+  subscription,
+  mode,
+  selectedModel,
+  assignment,
+  outcome,
+  generationTimeMs,
+  finishReason,
+}: CaptureBaseArgs & {
+  outcome: "success" | "aborted" | "error";
+  generationTimeMs?: number;
+  finishReason?: string;
+}) {
+  if (!posthog || !assignment) return;
+
+  posthog.capture({
+    distinctId: userId,
+    event: "free_ask_reasoning_experiment_result",
+    properties: {
+      user_id: userId,
+      chat_id: chatId,
+      subscription,
+      subscription_tier: subscription,
+      mode,
+      selected_model: selectedModel,
+      outcome,
+      ...(generationTimeMs !== undefined && {
+        generation_time_ms: generationTimeMs,
+      }),
+      ...(finishReason && { finish_reason: finishReason }),
+      ...getFreeAskReasoningExperimentProperties(assignment),
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add a PostHog-backed free Ask DeepSeek reasoning experiment with `control` and `reasoning_medium` variants
- apply the reasoning override only to eligible free text-only Ask requests on the primary `ask-model-free` leg
- emit exposure, result, and usage-cost properties so PostHog can compare success, conversion, cost, latency, and reliability by variant
- document the PostHog flag setup and readout criteria

## Testing
- pnpm jest lib/experiments/__tests__/free-ask-reasoning.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/api/__tests__/chat-logger.test.ts --runInBand
- pnpm typecheck
- pnpm exec eslint lib/experiments/free-ask-reasoning.ts lib/experiments/__tests__/free-ask-reasoning.test.ts lib/api/chat-handler.ts lib/api/chat-stream-helpers.ts lib/api/agent-stream-runner.ts lib/api/chat-logger.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/api/__tests__/chat-logger.test.ts
- pnpm exec prettier --check lib/experiments/free-ask-reasoning.ts lib/experiments/__tests__/free-ask-reasoning.test.ts lib/api/chat-handler.ts lib/api/chat-stream-helpers.ts lib/api/agent-stream-runner.ts lib/api/chat-logger.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/api/__tests__/chat-logger.test.ts docs/free-ask-reasoning-experiment.md

## Manual verification
- In PostHog project 144137, create/save `free_ask_deepseek_reasoning_v1` as a multivariate flag with `control` 90% and `reasoning_medium` 10%, release condition rollout 100%, no variant override, no required payload.
- After deploy, send a free text-only Ask request and confirm `free_ask_reasoning_experiment_exposed`, `free_ask_reasoning_experiment_result`, and `hackerai-usage_cost` include `variant` / `$feature/free_ask_deepseek_reasoning_v1`.
- Confirm paid users, Agent mode, and file-attachment Ask requests do not receive the experiment assignment.
- Compare `reasoning_medium` vs `control` on success rate, `checkout_started` / `subscription_started`, `cost_dollars`, `generation_time_ms`, and error/abort rate before shipping a winner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a free Ask reasoning experiment with rollout controls, fallback behavior, and analytics tracking.
  * Enabled reasoning for eligible free Ask chats with a medium-effort configuration when selected.

* **Bug Fixes**
  * Improved experiment handling so usage, exposure, and result events consistently include the right experiment details.
  * Added safeguards for users outside the eligible flow and for cases where the feature service is unavailable.

* **Tests**
  * Added coverage for experiment assignment, fallback rollout, and telemetry payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->