### PR TITLE
Default Ultra users to Agent mode

### DIFF
--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -50,8 +50,8 @@ import {
 } from "@/lib/utils/client-storage";
 import { captureAuthenticatedEvent } from "@/lib/analytics/client";
 import {
+  getAgentFirstDefaultDecision,
   normalizeAgentFirstSandboxType,
-  shouldDefaultFreeUserToAgent,
 } from "@/lib/activation/agent-first-default";
 
 interface GlobalStateType {
@@ -453,44 +453,59 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     const savedModePresent = initialSavedChatModeRef.current !== null;
     const userSelectedModeThisSession =
       hasUserSelectedModeThisSessionRef.current;
-    const sandboxType = normalizeAgentFirstSandboxType(
+    const agentDefaultDecision = getAgentFirstDefaultDecision({
+      chatMode,
       defaultLocalSandboxPreference,
-    );
+      hasLocalSandbox,
+      hasSavedChatMode: savedModePresent,
+      hasUserSelectedModeThisSession: userSelectedModeThisSession,
+      isCheckingProPlan,
+      isMobile,
+      subscription: selectedSubscription,
+      subscriptionResolved,
+      temporaryChatsEnabled,
+      userPresent: Boolean(user),
+    });
+
+    if (!agentDefaultDecision) {
+      return;
+    }
+
+    const localSandboxPreference = agentDefaultDecision.useDefaultLocalSandbox
+      ? defaultLocalSandboxPreference
+      : null;
 
     if (
-      !shouldDefaultFreeUserToAgent({
-        chatMode,
-        defaultLocalSandboxPreference,
-        hasLocalSandbox,
-        hasSavedChatMode: savedModePresent,
-        hasUserSelectedModeThisSession: userSelectedModeThisSession,
-        isCheckingProPlan,
-        isMobile,
-        subscription: selectedSubscription,
-        subscriptionResolved,
-        temporaryChatsEnabled,
-        userPresent: Boolean(user),
-      })
+      agentDefaultDecision.useDefaultLocalSandbox &&
+      !localSandboxPreference
     ) {
       return;
     }
 
+    const appliedSandboxPreference =
+      localSandboxPreference ?? sandboxPreference;
+    const sandboxType = normalizeAgentFirstSandboxType(
+      appliedSandboxPreference ?? null,
+    );
+
     agentFirstDefaultAppliedRef.current = true;
     setChatModeState("agent");
-    setSandboxPreference(defaultLocalSandboxPreference!);
+    if (localSandboxPreference) {
+      setSandboxPreference(localSandboxPreference);
+    }
     if (selectedModel !== "auto") {
       setSelectedModelRaw("auto");
     }
 
     const now = new Date().toISOString();
     const agentFirstProperties = {
-      experiment_key: "free_agent_first_v1",
+      experiment_key: agentDefaultDecision.experimentKey,
       first_experience_event_version: 2,
       variant: "agent_first",
       subscription: selectedSubscription,
-      eligible_subscription_tier: "free",
+      eligible_subscription_tier: agentDefaultDecision.eligibleSubscriptionTier,
       selected_subscription_tier: selectedSubscription,
-      selection_reason: "eligible_free_user_local_sandbox",
+      selection_reason: agentDefaultDecision.selectionReason,
       default_applied: true,
       has_local_sandbox: hasLocalSandbox,
       sandbox_type: sandboxType,
@@ -517,6 +532,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     hasLocalSandbox,
     isCheckingProPlan,
     isMobile,
+    sandboxPreference,
     selectedModel,
     setSandboxPreference,
     subscription,

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -1,0 +1,56 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { useAuth } from "@workos-inc/authkit-nextjs/components";
+import { GlobalStateProvider, useGlobalState } from "../GlobalState";
+
+const mockAuthUser = (entitlements: string[]) => {
+  jest.mocked(useAuth).mockReturnValue({
+    user: { id: "user_ultra" },
+    entitlements,
+    loading: false,
+    isAuthenticated: true,
+    signIn: jest.fn(),
+    signOut: jest.fn(),
+  } as ReturnType<typeof useAuth>);
+};
+
+function GlobalStateProbe() {
+  const { chatMode, sandboxPreference, selectedModel } = useGlobalState();
+
+  return (
+    <>
+      <div data-testid="chat-mode">{chatMode}</div>
+      <div data-testid="sandbox-preference">{sandboxPreference}</div>
+      <div data-testid="selected-model">{selectedModel}</div>
+    </>
+  );
+}
+
+describe("GlobalStateProvider agent defaults", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: false }),
+    ) as unknown as typeof fetch;
+    mockAuthUser([]);
+  });
+
+  it("defaults first-time Ultra users to Agent with the auto model and cloud sandbox", async () => {
+    window.localStorage.setItem("selected_model", "hackerai-max");
+    mockAuthUser(["ultra-plan"]);
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-mode")).toHaveTextContent("agent");
+    });
+
+    expect(screen.getByTestId("selected-model")).toHaveTextContent("auto");
+    expect(screen.getByTestId("sandbox-preference")).toHaveTextContent("e2b");
+  });
+});

--- a/lib/activation/__tests__/agent-first-default.test.ts
+++ b/lib/activation/__tests__/agent-first-default.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "@jest/globals";
 import {
+  getAgentFirstDefaultDecision,
   normalizeAgentFirstSandboxType,
   type AgentFirstDefaultEligibility,
   shouldDefaultFreeUserToAgent,
+  shouldDefaultUltraUserToAgent,
 } from "../agent-first-default";
 
 const baseEligibility: AgentFirstDefaultEligibility = {
@@ -95,6 +97,88 @@ describe("shouldDefaultFreeUserToAgent", () => {
         temporaryChatsEnabled: true,
       }),
     ).toBe(false);
+  });
+});
+
+describe("shouldDefaultUltraUserToAgent", () => {
+  const ultraEligibility: AgentFirstDefaultEligibility = {
+    ...baseEligibility,
+    defaultLocalSandboxPreference: null,
+    hasLocalSandbox: false,
+    subscription: "ultra",
+  };
+
+  it("defaults an eligible first-time Ultra user to Agent without requiring a local sandbox", () => {
+    expect(shouldDefaultUltraUserToAgent(ultraEligibility)).toBe(true);
+  });
+
+  it("does not override a saved mode preference", () => {
+    expect(
+      shouldDefaultUltraUserToAgent({
+        ...ultraEligibility,
+        hasSavedChatMode: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not override a mode selected during the current session", () => {
+    expect(
+      shouldDefaultUltraUserToAgent({
+        ...ultraEligibility,
+        hasUserSelectedModeThisSession: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not default Pro or Pro Plus users through the Ultra default", () => {
+    expect(
+      shouldDefaultUltraUserToAgent({
+        ...ultraEligibility,
+        subscription: "pro",
+      }),
+    ).toBe(false);
+    expect(
+      shouldDefaultUltraUserToAgent({
+        ...ultraEligibility,
+        subscription: "pro-plus",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not default temporary chats to Agent", () => {
+    expect(
+      shouldDefaultUltraUserToAgent({
+        ...ultraEligibility,
+        temporaryChatsEnabled: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("getAgentFirstDefaultDecision", () => {
+  it("returns the free-user decision with the local sandbox requirement", () => {
+    expect(getAgentFirstDefaultDecision(baseEligibility)).toEqual({
+      eligibleSubscriptionTier: "free",
+      experimentKey: "free_agent_first_v1",
+      selectionReason: "eligible_free_user_local_sandbox",
+      useDefaultLocalSandbox: true,
+    });
+  });
+
+  it("returns the Ultra decision without the local sandbox requirement", () => {
+    expect(
+      getAgentFirstDefaultDecision({
+        ...baseEligibility,
+        defaultLocalSandboxPreference: null,
+        hasLocalSandbox: false,
+        subscription: "ultra",
+      }),
+    ).toEqual({
+      eligibleSubscriptionTier: "ultra",
+      experimentKey: "ultra_agent_default_v1",
+      selectionReason: "eligible_ultra_user",
+      useDefaultLocalSandbox: false,
+    });
   });
 });
 

--- a/lib/activation/agent-first-default.ts
+++ b/lib/activation/agent-first-default.ts
@@ -21,6 +21,13 @@ export type AgentFirstDefaultEligibility = {
   userPresent: boolean;
 };
 
+export type AgentFirstDefaultDecision = {
+  eligibleSubscriptionTier: "free" | "ultra";
+  experimentKey: "free_agent_first_v1" | "ultra_agent_default_v1";
+  selectionReason: "eligible_free_user_local_sandbox" | "eligible_ultra_user";
+  useDefaultLocalSandbox: boolean;
+};
+
 export function normalizeAgentFirstSandboxType(
   preference: SandboxPreference | null,
 ): AgentFirstSandboxType {
@@ -30,7 +37,7 @@ export function normalizeAgentFirstSandboxType(
   return "remote-connection";
 }
 
-export function shouldDefaultFreeUserToAgent({
+export function getAgentFirstDefaultDecision({
   chatMode,
   defaultLocalSandboxPreference,
   hasLocalSandbox,
@@ -42,18 +49,58 @@ export function shouldDefaultFreeUserToAgent({
   subscriptionResolved,
   temporaryChatsEnabled,
   userPresent,
-}: AgentFirstDefaultEligibility): boolean {
-  return (
+}: AgentFirstDefaultEligibility): AgentFirstDefaultDecision | null {
+  const baseEligible =
     userPresent &&
     subscriptionResolved &&
-    subscription === "free" &&
     !isCheckingProPlan &&
-    isMobile === false &&
     !temporaryChatsEnabled &&
     chatMode === "ask" &&
     !hasSavedChatMode &&
-    !hasUserSelectedModeThisSession &&
+    !hasUserSelectedModeThisSession;
+
+  if (!baseEligible) return null;
+
+  if (
+    subscription === "free" &&
+    isMobile === false &&
     hasLocalSandbox &&
     Boolean(defaultLocalSandboxPreference)
+  ) {
+    return {
+      eligibleSubscriptionTier: "free",
+      experimentKey: "free_agent_first_v1",
+      selectionReason: "eligible_free_user_local_sandbox",
+      useDefaultLocalSandbox: true,
+    };
+  }
+
+  if (subscription === "ultra") {
+    return {
+      eligibleSubscriptionTier: "ultra",
+      experimentKey: "ultra_agent_default_v1",
+      selectionReason: "eligible_ultra_user",
+      useDefaultLocalSandbox: false,
+    };
+  }
+
+  return null;
+}
+
+export function shouldDefaultFreeUserToAgent(
+  eligibility: AgentFirstDefaultEligibility,
+): boolean {
+  return (
+    getAgentFirstDefaultDecision(eligibility)?.eligibleSubscriptionTier ===
+    "free"
+  );
+}
+
+export function shouldDefaultUltraUserToAgent(
+  eligibility: AgentFirstDefaultEligibility,
+): boolean {
+  return (
+    getAgentFirstDefaultDecision(eligibility)?.eligibleSubscriptionTier ===
+    "ultra"
   );
 }


### PR DESCRIPTION
## Summary
- add an Ultra-specific Agent default decision alongside the existing free local-sandbox Agent default
- apply the default only when there is no saved chat-mode preference and no mode selected in the current session
- reset automatic Agent defaults to the auto/standard model and preserve cloud sandbox for Ultra users
- add helper and provider tests for the Ultra default behavior

## Validation
- pnpm jest lib/activation/__tests__/agent-first-default.test.ts app/contexts/__tests__/GlobalState.agent-default.test.tsx --runInBand
- pnpm typecheck
- pnpm exec eslint app/contexts/GlobalState.tsx app/contexts/__tests__/GlobalState.agent-default.test.tsx lib/activation/agent-first-default.ts lib/activation/__tests__/agent-first-default.test.ts
- pnpm exec prettier --check app/contexts/GlobalState.tsx app/contexts/__tests__/GlobalState.agent-default.test.tsx lib/activation/agent-first-default.ts lib/activation/__tests__/agent-first-default.test.ts

## UI verification
- Added a React provider render test that verifies first-time Ultra state resolves to Agent mode, auto model, and cloud sandbox.
- Browser e2e was not run locally because this worktree had no saved Ultra auth storage; manual verification below covers the live authenticated path.

## Manual verification
- Sign in as an Ultra user with no `chat_mode` value in localStorage and open a new chat.
- Confirm the mode selector shows Agent, the selected model is Auto/Standard, and sandbox preference remains Cloud.
- Switch to Ask, reload, and confirm Ask remains selected because the saved preference is respected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded automatic “agent” defaults for eligible first-time users, including support for Ultra accounts.
  * Updated the default setup to choose a matching sandbox option and reset the model to automatic when needed.

* **Bug Fixes**
  * Improved consistency in how default chat mode, sandbox preference, and model selection are applied on first use.
  * Refined tracking data for default-applied events to better reflect the user’s actual eligibility and selection path.

* **Tests**
  * Added coverage for first-time default behavior across Free and Ultra eligibility cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->