### PR TITLE
Persist generated pasted text attachments across reload

### DIFF
--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -29,7 +29,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import type { UploadedFileState } from "@/types/file";
 
 interface ChatInputProps {
-  onSubmit: (e: React.FormEvent) => void;
+  onSubmit: (e: React.FormEvent) => void | boolean | Promise<void | boolean>;
   onStop: () => void;
   onSendNow: (messageId: string) => void;
   status: ChatStatus;
@@ -144,11 +144,43 @@ export const ChatInput = ({
   const isGenerating = status === "submitted" || status === "streaming";
   const isAgent = isAgentMode(chatMode);
 
-  const draftId = isNewChat ? "new" : chatId || NULL_THREAD_DRAFT_ID;
+  const draftId =
+    isNewChat && (!hasMessages || temporaryChatsEnabled)
+      ? "new"
+      : chatId || NULL_THREAD_DRAFT_ID;
   const skipNextAttachmentPersistRef = useRef(false);
   const hasPersistedPastedTextDraftAttachmentsRef = useRef(false);
+  const uploadedFilesRef = useRef(uploadedFiles);
+  const prevDraftIdRef = useRef(draftId);
 
   useEffect(() => {
+    uploadedFilesRef.current = uploadedFiles;
+  });
+
+  useEffect(() => {
+    const prevDraftId = prevDraftIdRef.current;
+    prevDraftIdRef.current = draftId;
+
+    if (prevDraftId === "new" && draftId !== "new") {
+      const generatedPastedTextAttachments = uploadedFilesRef.current
+        .map(uploadedFileToDraftAttachment)
+        .filter(
+          (attachment): attachment is NonNullable<typeof attachment> =>
+            attachment !== null,
+        );
+
+      if (generatedPastedTextAttachments.length > 0) {
+        upsertDraftAttachments(draftId, generatedPastedTextAttachments);
+        removeDraftAttachments("new");
+        hasPersistedPastedTextDraftAttachmentsRef.current = true;
+      }
+
+      if (uploadedFilesRef.current.length > 0) {
+        skipNextAttachmentPersistRef.current = true;
+        return;
+      }
+    }
+
     const draftAttachments = getDraftAttachmentsById(draftId);
     hasPersistedPastedTextDraftAttachmentsRef.current =
       draftAttachments.length > 0;
@@ -226,7 +258,7 @@ export const ChatInput = ({
     }
   }, [temporaryChatsEnabled, chatMode, setChatMode]);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const canSubmit =
       (status === "ready" || status === "streaming") &&
@@ -234,8 +266,8 @@ export const ChatInput = ({
       (input.trim() || uploadedFiles.length > 0);
 
     if (canSubmit) {
-      onSubmit(e);
-      if (clearDraftOnSubmit) {
+      const accepted = await onSubmit(e);
+      if (clearDraftOnSubmit && accepted !== false) {
         removeDraft(draftId);
         setTimeout(() => setInput(""), 0);
       }

--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -8,7 +8,13 @@ import { FileUploadPreview } from "../FileUploadPreview";
 import { QueuedMessagesPanel } from "../QueuedMessagesPanel";
 import { ScrollToBottomButton } from "../ScrollToBottomButton";
 import { useFileUpload } from "@/app/hooks/useFileUpload";
-import { removeDraft } from "@/lib/utils/client-storage";
+import {
+  getDraftAttachmentsById,
+  removeDraft,
+  removeDraftAttachments,
+  upsertDraftAttachments,
+  type ConversationDraftAttachment,
+} from "@/lib/utils/client-storage";
 import {
   RateLimitWarning,
   type RateLimitWarningData,
@@ -20,6 +26,7 @@ import { SandboxSelector } from "../SandboxSelector";
 import { ChatInputTextarea } from "./ChatInputTextarea";
 import { ChatInputToolbar } from "./ChatInputToolbar";
 import { useIsMobile } from "@/hooks/use-mobile";
+import type { UploadedFileState } from "@/types/file";
 
 interface ChatInputProps {
   onSubmit: (e: React.FormEvent) => void;
@@ -39,6 +46,52 @@ interface ChatInputProps {
   placeholder?: string;
   autoFocus?: boolean;
 }
+
+const draftAttachmentToUploadedFile = (
+  attachment: ConversationDraftAttachment,
+): UploadedFileState => ({
+  file: {
+    name: attachment.name,
+    type: attachment.mediaType,
+    size: attachment.size,
+    lastModified: attachment.timestamp,
+  },
+  uploading: false,
+  uploaded: true,
+  storage: "s3",
+  generatedSource: "pasted-text",
+  fileId: attachment.fileId,
+  tokens: attachment.tokens,
+});
+
+const uploadedFileToDraftAttachment = (
+  uploadedFile: UploadedFileState,
+): ConversationDraftAttachment | null => {
+  if (
+    uploadedFile.generatedSource !== "pasted-text" ||
+    !uploadedFile.uploaded ||
+    uploadedFile.uploading ||
+    uploadedFile.error ||
+    !uploadedFile.fileId ||
+    uploadedFile.storage === "local-desktop"
+  ) {
+    return null;
+  }
+
+  return {
+    kind: "pasted-text",
+    fileId: uploadedFile.fileId,
+    name: uploadedFile.file.name,
+    mediaType: uploadedFile.file.type || "text/plain",
+    size: uploadedFile.file.size,
+    tokens: uploadedFile.tokens,
+    timestamp:
+      "lastModified" in uploadedFile.file &&
+      typeof uploadedFile.file.lastModified === "number"
+        ? uploadedFile.file.lastModified
+        : Date.now(),
+  };
+};
 
 export const ChatInput = ({
   onSubmit,
@@ -64,6 +117,7 @@ export const ChatInput = ({
     chatMode,
     setChatMode,
     uploadedFiles,
+    setUploadedFiles,
     isUploadingFiles,
     messageQueue,
     removeQueuedMessage,
@@ -91,6 +145,33 @@ export const ChatInput = ({
   const isAgent = isAgentMode(chatMode);
 
   const draftId = isNewChat ? "new" : chatId || NULL_THREAD_DRAFT_ID;
+  const skipNextAttachmentPersistRef = useRef(false);
+
+  useEffect(() => {
+    const draftAttachments = getDraftAttachmentsById(draftId);
+    skipNextAttachmentPersistRef.current = true;
+    setUploadedFiles(draftAttachments.map(draftAttachmentToUploadedFile));
+  }, [draftId, setUploadedFiles]);
+
+  useEffect(() => {
+    if (skipNextAttachmentPersistRef.current) {
+      skipNextAttachmentPersistRef.current = false;
+      return;
+    }
+
+    const generatedPastedTextAttachments = uploadedFiles
+      .map(uploadedFileToDraftAttachment)
+      .filter(
+        (attachment): attachment is NonNullable<typeof attachment> =>
+          attachment !== null,
+      );
+
+    if (generatedPastedTextAttachments.length > 0) {
+      upsertDraftAttachments(draftId, generatedPastedTextAttachments);
+    } else {
+      removeDraftAttachments(draftId);
+    }
+  }, [draftId, uploadedFiles]);
 
   // Free agent mode constraints:
   // 1. Requires local sandbox — fall back to ask mode if disconnected

--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -146,9 +146,12 @@ export const ChatInput = ({
 
   const draftId = isNewChat ? "new" : chatId || NULL_THREAD_DRAFT_ID;
   const skipNextAttachmentPersistRef = useRef(false);
+  const hasPersistedPastedTextDraftAttachmentsRef = useRef(false);
 
   useEffect(() => {
     const draftAttachments = getDraftAttachmentsById(draftId);
+    hasPersistedPastedTextDraftAttachmentsRef.current =
+      draftAttachments.length > 0;
     skipNextAttachmentPersistRef.current = true;
     setUploadedFiles(draftAttachments.map(draftAttachmentToUploadedFile));
   }, [draftId, setUploadedFiles]);
@@ -168,8 +171,10 @@ export const ChatInput = ({
 
     if (generatedPastedTextAttachments.length > 0) {
       upsertDraftAttachments(draftId, generatedPastedTextAttachments);
-    } else {
+      hasPersistedPastedTextDraftAttachmentsRef.current = true;
+    } else if (hasPersistedPastedTextDraftAttachmentsRef.current) {
       removeDraftAttachments(draftId);
+      hasPersistedPastedTextDraftAttachmentsRef.current = false;
     }
   }, [draftId, uploadedFiles]);
 

--- a/app/components/ChatInput/ChatInputTextarea.tsx
+++ b/app/components/ChatInput/ChatInputTextarea.tsx
@@ -6,6 +6,7 @@ import { useGlobalState } from "@/app/contexts/GlobalState";
 import { useFileUpload } from "@/app/hooks/useFileUpload";
 import {
   getDraftContentById,
+  hasDraftAttachmentsById,
   upsertDraft,
   removeDraft,
 } from "@/lib/utils/client-storage";
@@ -36,7 +37,8 @@ export function ChatInputTextarea({
   autoFocus = true,
 }: ChatInputTextareaProps) {
   const { input, setInput, subscription } = useGlobalState();
-  const { handlePasteEvent } = useFileUpload(chatMode);
+  const { handlePasteEvent, handlePastedTextAttachment } =
+    useFileUpload(chatMode);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const inputRef = useRef(input);
   const prevDraftIdRef = useRef(draftId);
@@ -67,6 +69,8 @@ export function ChatInputTextarea({
     const handle = window.setTimeout(() => {
       if (input.trim()) {
         upsertDraft(draftId, input);
+      } else if (hasDraftAttachmentsById(draftId)) {
+        upsertDraft(draftId, "");
       } else {
         removeDraft(draftId);
       }
@@ -85,6 +89,14 @@ export function ChatInputTextarea({
         return;
       }
 
+      const hasClipboardFiles = Array.from(clipboardData.items ?? []).some(
+        (item) => item.kind === "file",
+      );
+      if (hasClipboardFiles) {
+        await handlePasteEvent(e);
+        return;
+      }
+
       const pastedText = clipboardData.getData("text");
       if (!pastedText) {
         await handlePasteEvent(e);
@@ -97,6 +109,11 @@ export function ChatInputTextarea({
       });
       if (tokenCount > maxTokens) {
         e.preventDefault();
+        if (subscription !== "free") {
+          await handlePastedTextAttachment(pastedText);
+          return;
+        }
+
         const planText = subscription !== "free" ? "" : " (Free plan limit)";
         toast.error("Content is too long to paste", {
           description: `The content you're trying to paste is too large (${tokenCount.toLocaleString()} tokens). Please copy a smaller amount${planText}.`,
@@ -108,7 +125,7 @@ export function ChatInputTextarea({
     };
     document.addEventListener("paste", handlePaste);
     return () => document.removeEventListener("paste", handlePaste);
-  }, [handlePasteEvent, subscription]);
+  }, [chatMode, handlePasteEvent, handlePastedTextAttachment, subscription]);
 
   return (
     <div className="overflow-y-auto pl-4 pr-2">

--- a/app/components/ChatInput/SubmitStopButton.tsx
+++ b/app/components/ChatInput/SubmitStopButton.tsx
@@ -41,7 +41,7 @@ export interface SubmitStopButtonProps {
   isGenerating: boolean;
   hideStop: boolean;
   onStop: () => void;
-  onSubmit: (e: React.FormEvent) => void;
+  onSubmit: (e: React.FormEvent) => void | Promise<void>;
   status: ChatStatus;
   isUploadingFiles: boolean;
   input: string;

--- a/app/components/__tests__/ChatInput.integration.test.tsx
+++ b/app/components/__tests__/ChatInput.integration.test.tsx
@@ -5,21 +5,11 @@ import { ChatInput } from "../ChatInput";
 import { GlobalStateProvider } from "../../contexts/GlobalState";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ReactNode } from "react";
+import { CONVERSATION_DRAFTS_STORAGE_KEY } from "@/lib/utils/client-storage";
 
 // Mock only external dependencies, not contexts
 jest.mock("react-hotkeys-hook", () => ({
   useHotkeys: jest.fn(),
-}));
-
-jest.mock("@/lib/utils/client-storage", () => ({
-  NULL_THREAD_DRAFT_ID: "null-thread",
-  getDraftContentById: jest.fn(() => null),
-  getDraftAttachmentsById: jest.fn(() => []),
-  hasDraftAttachmentsById: jest.fn(() => false),
-  upsertDraft: jest.fn(),
-  upsertDraftAttachments: jest.fn(),
-  removeDraftAttachments: jest.fn(),
-  removeDraft: jest.fn(),
 }));
 
 // Mock Convex hooks used by useFileUpload
@@ -56,6 +46,7 @@ describe("ChatInput - Integration Tests", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    window.localStorage.clear();
   });
 
   describe("Ask Mode Integration", () => {
@@ -204,6 +195,170 @@ describe("ChatInput - Integration Tests", () => {
   });
 
   describe("Submit Behavior Integration", () => {
+    it("migrates restored pasted-text attachments when a new chat gets its real id", async () => {
+      const draftAttachment = {
+        kind: "pasted-text" as const,
+        fileId: "file_123",
+        name: "pasted-text.txt",
+        mediaType: "text/plain",
+        size: 512,
+        tokens: 120,
+        timestamp: Date.now(),
+      };
+      window.localStorage.setItem(
+        CONVERSATION_DRAFTS_STORAGE_KEY,
+        JSON.stringify({
+          drafts: [
+            {
+              id: "new",
+              content: "",
+              timestamp: Date.now(),
+              attachments: [draftAttachment],
+            },
+          ],
+        }),
+      );
+
+      const { rerender } = render(
+        <TestWrapper>
+          <ChatInput
+            onSubmit={mockOnSubmit}
+            onStop={mockOnStop}
+            status="ready"
+            isNewChat={true}
+            chatId="chat-1"
+          />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText("pasted-text.txt")).toBeInTheDocument();
+
+      rerender(
+        <TestWrapper>
+          <ChatInput
+            onSubmit={mockOnSubmit}
+            onStop={mockOnStop}
+            status="ready"
+            isNewChat={false}
+            chatId="chat-1"
+          />
+        </TestWrapper>,
+      );
+
+      await waitFor(() => {
+        const store = JSON.parse(
+          window.localStorage.getItem(CONVERSATION_DRAFTS_STORAGE_KEY) ?? "{}",
+        );
+        expect(store.drafts).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: "chat-1",
+              attachments: [draftAttachment],
+            }),
+          ]),
+        );
+      });
+      const store = JSON.parse(
+        window.localStorage.getItem(CONVERSATION_DRAFTS_STORAGE_KEY) ?? "{}",
+      );
+      expect(
+        store.drafts.some((draft: { id: string }) => draft.id === "new"),
+      ).toBe(false);
+      expect(screen.getByText("pasted-text.txt")).toBeInTheDocument();
+    });
+
+    it("uses the real chat draft once a persistent new chat has messages", async () => {
+      const draftAttachment = {
+        kind: "pasted-text" as const,
+        fileId: "file_123",
+        name: "pasted-text.txt",
+        mediaType: "text/plain",
+        size: 512,
+        timestamp: Date.now(),
+      };
+      window.localStorage.setItem(
+        CONVERSATION_DRAFTS_STORAGE_KEY,
+        JSON.stringify({
+          drafts: [
+            {
+              id: "chat-1",
+              content: "",
+              timestamp: Date.now(),
+              attachments: [draftAttachment],
+            },
+          ],
+        }),
+      );
+
+      render(
+        <TestWrapper>
+          <ChatInput
+            onSubmit={mockOnSubmit}
+            onStop={mockOnStop}
+            status="ready"
+            isNewChat={true}
+            hasMessages={true}
+            chatId="chat-1"
+          />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText("pasted-text.txt")).toBeInTheDocument();
+    });
+
+    it("keeps restored pasted-text drafts when submit is rejected", async () => {
+      const rejectedSubmit = jest.fn(() => false);
+      const draftAttachment = {
+        kind: "pasted-text" as const,
+        fileId: "file_123",
+        name: "pasted-text.txt",
+        mediaType: "text/plain",
+        size: 512,
+        timestamp: Date.now(),
+      };
+      window.localStorage.setItem(
+        CONVERSATION_DRAFTS_STORAGE_KEY,
+        JSON.stringify({
+          drafts: [
+            {
+              id: "chat-1",
+              content: "",
+              timestamp: Date.now(),
+              attachments: [draftAttachment],
+            },
+          ],
+        }),
+      );
+
+      render(
+        <TestWrapper>
+          <ChatInput
+            onSubmit={rejectedSubmit}
+            onStop={mockOnStop}
+            status="ready"
+            isNewChat={false}
+            chatId="chat-1"
+          />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText("pasted-text.txt")).toBeInTheDocument();
+      fireEvent.click(screen.getByLabelText("Send message"));
+
+      await waitFor(() => expect(rejectedSubmit).toHaveBeenCalledTimes(1));
+      const store = JSON.parse(
+        window.localStorage.getItem(CONVERSATION_DRAFTS_STORAGE_KEY) ?? "{}",
+      );
+      expect(store.drafts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "chat-1",
+            attachments: [draftAttachment],
+          }),
+        ]),
+      );
+    });
+
     it("should disable submit when no input", () => {
       render(
         <TestWrapper>

--- a/app/components/__tests__/ChatInput.integration.test.tsx
+++ b/app/components/__tests__/ChatInput.integration.test.tsx
@@ -14,7 +14,11 @@ jest.mock("react-hotkeys-hook", () => ({
 jest.mock("@/lib/utils/client-storage", () => ({
   NULL_THREAD_DRAFT_ID: "null-thread",
   getDraftContentById: jest.fn(() => null),
+  getDraftAttachmentsById: jest.fn(() => []),
+  hasDraftAttachmentsById: jest.fn(() => false),
   upsertDraft: jest.fn(),
+  upsertDraftAttachments: jest.fn(),
+  removeDraftAttachments: jest.fn(),
   removeDraft: jest.fn(),
 }));
 
@@ -33,6 +37,7 @@ jest.mock("../../hooks/useFileUpload", () => ({
     handleRemoveFile: jest.fn(),
     handleAttachClick: jest.fn(),
     handlePasteEvent: jest.fn(),
+    handlePastedTextAttachment: jest.fn(),
   }),
 }));
 

--- a/app/components/__tests__/chat.integration.test.tsx
+++ b/app/components/__tests__/chat.integration.test.tsx
@@ -48,7 +48,11 @@ jest.mock("@/hooks/use-mobile", () => ({
 jest.mock("@/lib/utils/client-storage", () => ({
   NULL_THREAD_DRAFT_ID: "null-thread",
   getDraftContentById: jest.fn(() => null),
+  getDraftAttachmentsById: jest.fn(() => []),
+  hasDraftAttachmentsById: jest.fn(() => false),
   upsertDraft: jest.fn(),
+  upsertDraftAttachments: jest.fn(),
+  removeDraftAttachments: jest.fn(),
   removeDraft: jest.fn(),
 }));
 
@@ -59,6 +63,7 @@ jest.mock("../../hooks/useFileUpload", () => ({
     handleRemoveFile: jest.fn(),
     handleAttachClick: jest.fn(),
     handlePasteEvent: jest.fn(),
+    handlePastedTextAttachment: jest.fn(),
     isDragOver: false,
     showDragOverlay: false,
     handleDragEnter: jest.fn(),

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -113,7 +113,7 @@ export const useChatHandlers = ({
     !file.error &&
     (file.storage === "local-desktop"
       ? !!file.localAttachmentId && !!file.localPath
-      : !!file.url && !!file.fileId);
+      : !!file.fileId);
 
   const deleteLastAssistantMessage = useMutation(
     api.messages.deleteLastAssistantMessage,

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -239,7 +239,7 @@ export const useChatHandlers = ({
     return normalizedMessages;
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent): Promise<boolean> => {
     e.preventDefault();
 
     setIsAutoResuming(false);
@@ -250,136 +250,139 @@ export const useChatHandlers = ({
 
     // Prevent submission if files are still uploading
     if (isUploadingFiles) {
-      return;
+      return false;
     }
     // Allow submission if there's text input or uploaded files
     const hasValidFiles = uploadedFiles.some(isSendableUploadedFile);
-    if (input.trim() || hasValidFiles) {
-      const maxFilesLimit = getMaxFilesLimitForMode(chatMode);
-      if (uploadedFiles.length > maxFilesLimit) {
-        toast.error("Cannot send files in this mode", {
-          description: `Maximum ${maxFilesLimit} files allowed. Please remove some files or switch modes.`,
-        });
-        return;
-      }
-
-      const currentChatMode = chatModeRef.current;
-      const hasLocalDesktopFiles = uploadedFiles.some(
-        (file) => file.storage === "local-desktop",
-      );
-      if (
-        hasLocalDesktopFiles &&
-        (!isAgentMode(currentChatMode) ||
-          sandboxPreferenceRef.current !== "desktop")
-      ) {
-        toast.error("Local attachments require desktop Agent mode", {
-          description:
-            "Switch back to Agent mode with the desktop sandbox or reattach the file for upload.",
-        });
-        return;
-      }
-
-      // If streaming in Agent mode, check queue behavior
-      if (status === "streaming") {
-        const validFiles = uploadedFiles
-          .filter(isSendableUploadedFile)
-          .map(createFileMessagePartFromUploadedFile)
-          .filter((part): part is NonNullable<typeof part> => part !== null);
-
-        if (queueBehavior === "queue") {
-          // Queue the message - will auto-send after current response completes
-          queueMessage(input, validFiles);
-          clearInput();
-          clearUploadedFiles();
-          return;
-        } else if (queueBehavior === "stop-and-send") {
-          // Cancel the trigger.dev run for agent-long streams so the prior
-          // run stops burning compute instead of finishing in the background.
-          cancelTriggerRun();
-
-          await stopActiveStream();
-          // Continue to send the new message immediately below (don't return)
-        }
-      }
-      // Check token limit before sending based on user plan
-      const tokenCount = countInputTokens(input, uploadedFiles);
-      const maxTokens = getMaxTokensForSubscription(subscription, {
-        mode: currentChatMode,
-      });
-
-      // Additional validation for Ask mode: ensure files don't exceed Ask mode token limits
-      // This prevents uploading files in Agent mode then switching to Ask mode to send them
-      if (currentChatMode === "ask" && uploadedFiles.length > 0) {
-        const fileTokens = uploadedFiles.reduce(
-          (total, file) => total + (file.tokens || 0),
-          0,
-        );
-        const maxFileTokens = getMaxFileTokens(subscription);
-        if (fileTokens > maxFileTokens) {
-          toast.error("Cannot send files in Ask mode", {
-            description: `Files exceed Ask mode token limit (${fileTokens.toLocaleString()}/${maxFileTokens.toLocaleString()} tokens). Tip: Switch to Agent mode or remove large files.`,
-          });
-          return;
-        }
-      }
-
-      if (tokenCount > maxTokens) {
-        const hasFiles = uploadedFiles.length > 0;
-        const planText = subscription !== "free" ? "" : " (Free plan limit)";
-        toast.error("Message is too long", {
-          description: `Your message is too large (${tokenCount.toLocaleString()} tokens). Please make it shorter${hasFiles ? " or remove some files" : ""}${planText}.`,
-        });
-        return;
-      }
-      if (!isExistingChat && !temporaryChatsEnabledRef.current) {
-        window.history.replaceState({}, "", `/c/${chatId}`);
-      }
-
-      try {
-        // Get file objects from uploaded files - URLs are already resolved in global state
-        const validFiles = uploadedFiles
-          .filter(isSendableUploadedFile)
-          .map(createFileMessagePartFromUploadedFile)
-          .filter((part): part is NonNullable<typeof part> => part !== null);
-
-        sendMessage(
-          {
-            text: input.trim() || undefined,
-            files: validFiles.length > 0 ? validFiles : undefined,
-            metadata: { createdAt: Date.now() },
-          },
-          {
-            body: {
-              mode: currentChatMode,
-              todos,
-              temporary: temporaryChatsEnabled,
-              sandboxPreference,
-
-              selectedModel: requestSelectedModel,
-            },
-          },
-        );
-      } catch (error) {
-        console.error("Failed to process files:", error);
-        // Fallback to text-only message if file processing fails
-        sendMessage(
-          { text: input, metadata: { createdAt: Date.now() } },
-          {
-            body: {
-              mode: currentChatMode,
-              todos,
-              temporary: temporaryChatsEnabled,
-              sandboxPreference,
-
-              selectedModel: requestSelectedModel,
-            },
-          },
-        );
-      }
-
-      clearInput();
-      clearUploadedFiles();
+    if (!input.trim() && !hasValidFiles) {
+      return false;
     }
+
+    const maxFilesLimit = getMaxFilesLimitForMode(chatMode);
+    if (uploadedFiles.length > maxFilesLimit) {
+      toast.error("Cannot send files in this mode", {
+        description: `Maximum ${maxFilesLimit} files allowed. Please remove some files or switch modes.`,
+      });
+      return false;
+    }
+
+    const currentChatMode = chatModeRef.current;
+    const hasLocalDesktopFiles = uploadedFiles.some(
+      (file) => file.storage === "local-desktop",
+    );
+    if (
+      hasLocalDesktopFiles &&
+      (!isAgentMode(currentChatMode) ||
+        sandboxPreferenceRef.current !== "desktop")
+    ) {
+      toast.error("Local attachments require desktop Agent mode", {
+        description:
+          "Switch back to Agent mode with the desktop sandbox or reattach the file for upload.",
+      });
+      return false;
+    }
+
+    // If streaming in Agent mode, check queue behavior
+    if (status === "streaming") {
+      const validFiles = uploadedFiles
+        .filter(isSendableUploadedFile)
+        .map(createFileMessagePartFromUploadedFile)
+        .filter((part): part is NonNullable<typeof part> => part !== null);
+
+      if (queueBehavior === "queue") {
+        // Queue the message - will auto-send after current response completes
+        queueMessage(input, validFiles);
+        clearInput();
+        clearUploadedFiles();
+        return true;
+      } else if (queueBehavior === "stop-and-send") {
+        // Cancel the trigger.dev run for agent-long streams so the prior
+        // run stops burning compute instead of finishing in the background.
+        cancelTriggerRun();
+
+        await stopActiveStream();
+        // Continue to send the new message immediately below (don't return)
+      }
+    }
+    // Check token limit before sending based on user plan
+    const tokenCount = countInputTokens(input, uploadedFiles);
+    const maxTokens = getMaxTokensForSubscription(subscription, {
+      mode: currentChatMode,
+    });
+
+    // Additional validation for Ask mode: ensure files don't exceed Ask mode token limits
+    // This prevents uploading files in Agent mode then switching to Ask mode to send them
+    if (currentChatMode === "ask" && uploadedFiles.length > 0) {
+      const fileTokens = uploadedFiles.reduce(
+        (total, file) => total + (file.tokens || 0),
+        0,
+      );
+      const maxFileTokens = getMaxFileTokens(subscription);
+      if (fileTokens > maxFileTokens) {
+        toast.error("Cannot send files in Ask mode", {
+          description: `Files exceed Ask mode token limit (${fileTokens.toLocaleString()}/${maxFileTokens.toLocaleString()} tokens). Tip: Switch to Agent mode or remove large files.`,
+        });
+        return false;
+      }
+    }
+
+    if (tokenCount > maxTokens) {
+      const hasFiles = uploadedFiles.length > 0;
+      const planText = subscription !== "free" ? "" : " (Free plan limit)";
+      toast.error("Message is too long", {
+        description: `Your message is too large (${tokenCount.toLocaleString()} tokens). Please make it shorter${hasFiles ? " or remove some files" : ""}${planText}.`,
+      });
+      return false;
+    }
+    if (!isExistingChat && !temporaryChatsEnabledRef.current) {
+      window.history.replaceState({}, "", `/c/${chatId}`);
+    }
+
+    try {
+      // Get file objects from uploaded files - URLs are already resolved in global state
+      const validFiles = uploadedFiles
+        .filter(isSendableUploadedFile)
+        .map(createFileMessagePartFromUploadedFile)
+        .filter((part): part is NonNullable<typeof part> => part !== null);
+
+      sendMessage(
+        {
+          text: input.trim() || undefined,
+          files: validFiles.length > 0 ? validFiles : undefined,
+          metadata: { createdAt: Date.now() },
+        },
+        {
+          body: {
+            mode: currentChatMode,
+            todos,
+            temporary: temporaryChatsEnabled,
+            sandboxPreference,
+
+            selectedModel: requestSelectedModel,
+          },
+        },
+      );
+    } catch (error) {
+      console.error("Failed to process files:", error);
+      // Fallback to text-only message if file processing fails
+      sendMessage(
+        { text: input, metadata: { createdAt: Date.now() } },
+        {
+          body: {
+            mode: currentChatMode,
+            todos,
+            temporary: temporaryChatsEnabled,
+            sandboxPreference,
+
+            selectedModel: requestSelectedModel,
+          },
+        },
+      );
+    }
+
+    clearInput();
+    clearUploadedFiles();
+    return true;
   };
 
   const handleStop = async () => {

--- a/app/hooks/useFileUpload.ts
+++ b/app/hooks/useFileUpload.ts
@@ -248,6 +248,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
       uploadIndex: number,
       options: {
         fallbackLocalFile?: LocalDesktopFile & { path: string };
+        generatedSource?: "pasted-text";
       } = {},
     ) => {
       try {
@@ -393,7 +394,12 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
 
   // Helper function to start file uploads
   const startFileUploads = useCallback(
-    (files: File[]) => {
+    (
+      files: File[],
+      options: {
+        generatedSource?: "pasted-text";
+      } = {},
+    ) => {
       const startingIndex = uploadedFiles.length;
 
       files.forEach((file, index) => {
@@ -402,10 +408,16 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
           file,
           uploading: true,
           uploaded: false,
+          storage: "s3",
+          ...(options.generatedSource
+            ? { generatedSource: options.generatedSource }
+            : {}),
         });
 
         // Start upload in background with correct index
-        uploadFileToS3(file, startingIndex + index);
+        uploadFileToS3(file, startingIndex + index, {
+          generatedSource: options.generatedSource,
+        });
       });
     },
     [uploadedFiles.length, addUploadedFile, uploadFileToS3],
@@ -596,11 +608,17 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
 
   // Unified file processing function
   const processFiles = useCallback(
-    async (files: File[], source: FileSource) => {
+    async (
+      files: File[],
+      source: FileSource,
+      options: {
+        generatedSource?: "pasted-text";
+      } = {},
+    ): Promise<boolean> => {
       // Check if user has pro plan for file uploads
       if (subscription === "free") {
         toast.error("Upgrade plan to upload files.");
-        return;
+        return false;
       }
 
       const result = await validateAndFilterFiles(files);
@@ -615,8 +633,11 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
 
       // Start uploads for valid files
       if (result.validFiles.length > 0 && hasRemainingSlots) {
-        startFileUploads(result.validFiles);
+        startFileUploads(result.validFiles, options);
+        return true;
       }
+
+      return false;
     },
     [
       subscription,
@@ -690,6 +711,27 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
     }
     fileInputRef.current?.click();
   };
+
+  const handlePastedTextAttachment = useCallback(
+    async (text: string): Promise<boolean> => {
+      if (!text.trim()) return false;
+
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const file = new File([text], `pasted-text-${timestamp}.txt`, {
+        type: "text/plain",
+        lastModified: Date.now(),
+      });
+
+      const started = await processFiles([file], "paste", {
+        generatedSource: "pasted-text",
+      });
+      if (started) {
+        toast.info("Pasted text added as an attachment");
+      }
+      return started;
+    },
+    [processFiles],
+  );
 
   const handlePasteEvent = async (event: ClipboardEvent): Promise<boolean> => {
     const items = event.clipboardData?.items;
@@ -796,6 +838,7 @@ export const useFileUpload = (mode: ChatMode = "ask") => {
     handleRemoveFile,
     handleAttachClick,
     handlePasteEvent,
+    handlePastedTextAttachment,
     getUploadedFileMessageParts,
     allFilesUploaded,
     anyFilesUploading,

--- a/lib/utils/__tests__/client-storage.test.ts
+++ b/lib/utils/__tests__/client-storage.test.ts
@@ -161,6 +161,7 @@ describe("client-storage draft attachments", () => {
   });
 
   it("persists generated pasted-text attachments without draft text", () => {
+    const timestamp = Date.now();
     upsertDraftAttachments("chat-1", [
       {
         kind: "pasted-text",
@@ -169,7 +170,7 @@ describe("client-storage draft attachments", () => {
         mediaType: "text/plain",
         size: 512,
         tokens: 120,
-        timestamp: 123456,
+        timestamp,
       },
     ]);
 
@@ -182,7 +183,7 @@ describe("client-storage draft attachments", () => {
         mediaType: "text/plain",
         size: 512,
         tokens: 120,
-        timestamp: 123456,
+        timestamp,
       },
     ]);
   });
@@ -195,7 +196,7 @@ describe("client-storage draft attachments", () => {
         name: "pasted-text.txt",
         mediaType: "text/plain",
         size: 512,
-        timestamp: 123456,
+        timestamp: Date.now(),
       },
     ]);
 
@@ -212,12 +213,28 @@ describe("client-storage draft attachments", () => {
         name: "pasted-text.txt",
         mediaType: "text/plain",
         size: 512,
-        timestamp: 123456,
+        timestamp: Date.now(),
       },
     ]);
 
     removeDraftAttachments("chat-1");
 
+    expect(hasDraftAttachmentsById("chat-1")).toBe(false);
+  });
+
+  it("does not restore pasted-text attachments older than the orphan file purge window", () => {
+    upsertDraftAttachments("chat-1", [
+      {
+        kind: "pasted-text",
+        fileId: "file_123",
+        name: "pasted-text.txt",
+        mediaType: "text/plain",
+        size: 512,
+        timestamp: Date.now() - 25 * 60 * 60 * 1000,
+      },
+    ]);
+
+    expect(getDraftAttachmentsById("chat-1")).toEqual([]);
     expect(hasDraftAttachmentsById("chat-1")).toBe(false);
   });
 });

--- a/lib/utils/__tests__/client-storage.test.ts
+++ b/lib/utils/__tests__/client-storage.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, beforeEach } from "@jest/globals";
 import {
+  getDraftAttachmentsById,
   readSelectedModel,
+  removeDraftAttachments,
   writeSelectedModel,
   clearSelectedModelFromStorage,
   hasAuthenticatedBefore,
+  hasDraftAttachmentsById,
   markHasAuthenticatedBefore,
+  upsertDraft,
+  upsertDraftAttachments,
 } from "../client-storage";
 
 const STORAGE_KEY = "selected_model";
@@ -147,5 +152,72 @@ describe("client-storage auth marker", () => {
   it("persists that this browser has authenticated before", () => {
     markHasAuthenticatedBefore();
     expect(hasAuthenticatedBefore()).toBe(true);
+  });
+});
+
+describe("client-storage draft attachments", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("persists generated pasted-text attachments without draft text", () => {
+    upsertDraftAttachments("chat-1", [
+      {
+        kind: "pasted-text",
+        fileId: "file_123",
+        name: "pasted-text.txt",
+        mediaType: "text/plain",
+        size: 512,
+        tokens: 120,
+        timestamp: 123456,
+      },
+    ]);
+
+    expect(hasDraftAttachmentsById("chat-1")).toBe(true);
+    expect(getDraftAttachmentsById("chat-1")).toEqual([
+      {
+        kind: "pasted-text",
+        fileId: "file_123",
+        name: "pasted-text.txt",
+        mediaType: "text/plain",
+        size: 512,
+        tokens: 120,
+        timestamp: 123456,
+      },
+    ]);
+  });
+
+  it("preserves draft attachments when text autosave updates content", () => {
+    upsertDraftAttachments("chat-1", [
+      {
+        kind: "pasted-text",
+        fileId: "file_123",
+        name: "pasted-text.txt",
+        mediaType: "text/plain",
+        size: 512,
+        timestamp: 123456,
+      },
+    ]);
+
+    upsertDraft("chat-1", "follow-up question", 234567);
+
+    expect(getDraftAttachmentsById("chat-1")).toHaveLength(1);
+  });
+
+  it("removes an attachment-only draft when attachments are cleared", () => {
+    upsertDraftAttachments("chat-1", [
+      {
+        kind: "pasted-text",
+        fileId: "file_123",
+        name: "pasted-text.txt",
+        mediaType: "text/plain",
+        size: 512,
+        timestamp: 123456,
+      },
+    ]);
+
+    removeDraftAttachments("chat-1");
+
+    expect(hasDraftAttachmentsById("chat-1")).toBe(false);
   });
 });

--- a/lib/utils/client-storage.ts
+++ b/lib/utils/client-storage.ts
@@ -30,6 +30,7 @@ export type ConversationDraftStore = {
 export const CONVERSATION_DRAFTS_STORAGE_KEY = "conversation_drafts";
 export const NULL_THREAD_DRAFT_ID = "null_thread";
 export const CHAT_MODE_STORAGE_KEY = "chat_mode";
+const DRAFT_ATTACHMENT_RESTORE_TTL_MS = 24 * 60 * 60 * 1000;
 const HAS_AUTHENTICATED_BEFORE_STORAGE_KEY = "hackerai_has_authed_before";
 const SELECTED_MODEL_STORAGE_KEY = "selected_model";
 
@@ -176,6 +177,7 @@ const normalizeDraftAttachments = (
   attachments: unknown,
 ): ConversationDraftAttachment[] => {
   if (!Array.isArray(attachments)) return [];
+  const cutoff = Date.now() - DRAFT_ATTACHMENT_RESTORE_TTL_MS;
 
   return attachments.filter(
     (attachment): attachment is ConversationDraftAttachment => {
@@ -189,7 +191,8 @@ const normalizeDraftAttachments = (
         value.name.length > 0 &&
         typeof value.mediaType === "string" &&
         typeof value.size === "number" &&
-        typeof value.timestamp === "number"
+        typeof value.timestamp === "number" &&
+        value.timestamp > cutoff
       );
     },
   );

--- a/lib/utils/client-storage.ts
+++ b/lib/utils/client-storage.ts
@@ -9,6 +9,17 @@ export type ConversationDraft = {
   id: string;
   content: string;
   timestamp: number;
+  attachments?: Array<ConversationDraftAttachment>;
+};
+
+export type ConversationDraftAttachment = {
+  kind: "pasted-text";
+  fileId: string;
+  name: string;
+  mediaType: string;
+  size: number;
+  tokens?: number;
+  timestamp: number;
 };
 
 export type ConversationDraftStore = {
@@ -161,6 +172,40 @@ export const getDraftContentById = (id: string): string | null => {
   return entry ? entry.content : null;
 };
 
+const normalizeDraftAttachments = (
+  attachments: unknown,
+): ConversationDraftAttachment[] => {
+  if (!Array.isArray(attachments)) return [];
+
+  return attachments.filter(
+    (attachment): attachment is ConversationDraftAttachment => {
+      if (!attachment || typeof attachment !== "object") return false;
+      const value = attachment as Partial<ConversationDraftAttachment>;
+      return (
+        value.kind === "pasted-text" &&
+        typeof value.fileId === "string" &&
+        value.fileId.length > 0 &&
+        typeof value.name === "string" &&
+        value.name.length > 0 &&
+        typeof value.mediaType === "string" &&
+        typeof value.size === "number" &&
+        typeof value.timestamp === "number"
+      );
+    },
+  );
+};
+
+export const getDraftAttachmentsById = (
+  id: string,
+): ConversationDraftAttachment[] => {
+  const store = readDraftStore();
+  const entry = store.drafts.find((d) => d.id === id);
+  return normalizeDraftAttachments(entry?.attachments);
+};
+
+export const hasDraftAttachmentsById = (id: string): boolean =>
+  getDraftAttachmentsById(id).length > 0;
+
 export const upsertDraft = (
   id: string,
   content: string,
@@ -168,16 +213,64 @@ export const upsertDraft = (
 ): void => {
   const store = readDraftStore();
   const idx = store.drafts.findIndex((d) => d.id === id);
+  const existing = idx >= 0 ? store.drafts[idx] : undefined;
+  const attachments = normalizeDraftAttachments(existing?.attachments);
   const entry: ConversationDraft = {
     id,
     content,
     timestamp: typeof timestamp === "number" ? timestamp : Date.now(),
+    ...(attachments.length > 0 ? { attachments } : {}),
   };
   if (idx >= 0) {
     store.drafts[idx] = entry;
   } else {
     store.drafts.push(entry);
   }
+  writeDraftStore(store);
+};
+
+export const upsertDraftAttachments = (
+  id: string,
+  attachments: ConversationDraftAttachment[],
+  timestamp?: number,
+): void => {
+  const normalizedAttachments = normalizeDraftAttachments(attachments);
+  const store = readDraftStore();
+  const idx = store.drafts.findIndex((d) => d.id === id);
+  const existing = idx >= 0 ? store.drafts[idx] : undefined;
+  const entry: ConversationDraft = {
+    id,
+    content: existing?.content ?? "",
+    timestamp: typeof timestamp === "number" ? timestamp : Date.now(),
+    ...(normalizedAttachments.length > 0
+      ? { attachments: normalizedAttachments }
+      : {}),
+  };
+
+  if (idx >= 0) {
+    store.drafts[idx] = entry;
+  } else if (entry.content.trim() || normalizedAttachments.length > 0) {
+    store.drafts.push(entry);
+  }
+  writeDraftStore(store);
+};
+
+export const removeDraftAttachments = (id: string): void => {
+  const store = readDraftStore();
+  const idx = store.drafts.findIndex((d) => d.id === id);
+  if (idx < 0) return;
+
+  const existing = store.drafts[idx];
+  if (existing.content.trim()) {
+    store.drafts[idx] = {
+      id: existing.id,
+      content: existing.content,
+      timestamp: Date.now(),
+    };
+  } else {
+    store.drafts.splice(idx, 1);
+  }
+
   writeDraftStore(store);
 };
 

--- a/lib/utils/file-utils.ts
+++ b/lib/utils/file-utils.ts
@@ -159,6 +159,9 @@ export function createFileMessagePartFromUploadedFile(
     name: uploadedFile.file.name,
     size: uploadedFile.file.size,
     storage: "s3",
+    ...(uploadedFile.generatedSource
+      ? { generatedSource: uploadedFile.generatedSource }
+      : {}),
   };
 }
 

--- a/types/file.ts
+++ b/types/file.ts
@@ -7,6 +7,7 @@ export interface FileMessagePart {
   name: string;
   size: number;
   storage?: "s3" | "local-desktop";
+  generatedSource?: "pasted-text";
   localAttachmentId?: string;
   /**
    * Transient source path for desktop-local agent attachments.
@@ -31,6 +32,7 @@ export interface UploadedFileState {
   uploaded: boolean;
   error?: string;
   storage?: "s3" | "local-desktop";
+  generatedSource?: "pasted-text";
   localAttachmentId?: string;
   localPath?: string;
   fileId?: string; // Database file ID for backend operations


### PR DESCRIPTION
## Summary
- convert paid over-limit plain-text paste into generated text attachments through the existing upload path
- persist durable metadata for generated pasted-text draft attachments and restore them after reload
- allow restored S3 attachment state to send with fileId-only metadata

## Validation
- pnpm test -- lib/utils/__tests__/client-storage.test.ts app/components/__tests__/ChatInput.integration.test.tsx app/components/__tests__/chat.integration.test.tsx app/hooks/__tests__/useFileUpload.local-desktop.test.tsx --runInBand
- pnpm typecheck
- pnpm exec eslint app/components/ChatInput/ChatInput.tsx app/components/ChatInput/ChatInputTextarea.tsx app/hooks/useFileUpload.ts app/hooks/useChatHandlers.ts lib/utils/client-storage.ts lib/utils/file-utils.ts types/file.ts app/components/__tests__/ChatInput.integration.test.tsx app/components/__tests__/chat.integration.test.tsx lib/utils/__tests__/client-storage.test.ts
- pnpm exec prettier --check app/components/ChatInput/ChatInput.tsx app/components/ChatInput/ChatInputTextarea.tsx app/hooks/useFileUpload.ts app/hooks/useChatHandlers.ts lib/utils/client-storage.ts lib/utils/file-utils.ts types/file.ts app/components/__tests__/ChatInput.integration.test.tsx app/components/__tests__/chat.integration.test.tsx lib/utils/__tests__/client-storage.test.ts

## Manual verification
- In a paid account, paste text over the chat text limit into the chat input.
- Confirm HackerAI creates a `pasted-text-*.txt` attachment card instead of losing the paste.
- Reload the page before sending and confirm the generated attachment card is still present.
- Send the message and confirm the pasted-text attachment is included in the request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drafts now persist attachments, including pasted-text attachments, across chat sessions.
  * Pasted text is supported as a file-like attachment and flows through the same sending pipeline (with generated-source metadata).

* **Bug Fixes**
  * Improved draft behavior so attachment drafts aren’t removed when the message text is cleared.
  * Fixed sendability rules for local-desktop uploads to require full identification.

* **Tests**
  * Expanded mocks and added coverage for draft-attachment persistence and pasted-text attachment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->