### PR TITLE
Suppress expected storage quota upload errors

### DIFF
--- a/app/hooks/__tests__/useFileUpload.local-desktop.test.tsx
+++ b/app/hooks/__tests__/useFileUpload.local-desktop.test.tsx
@@ -6,6 +6,7 @@ import {
   pickLocalFiles,
   readLocalFile,
 } from "@/app/hooks/useTauri";
+import { toast } from "sonner";
 
 const addUploadedFile = jest.fn();
 const updateUploadedFile = jest.fn();
@@ -41,6 +42,13 @@ jest.mock("@/app/hooks/useTauri", () => ({
   pickLocalFiles: jest.fn(),
   getLocalFileMetadata: jest.fn(),
   readLocalFile: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    error: jest.fn(),
+    warning: jest.fn(),
+  },
 }));
 
 describe("useFileUpload desktop-local agent attachments", () => {
@@ -223,6 +231,44 @@ describe("useFileUpload desktop-local agent attachments", () => {
       );
     });
     expect(saveFile).not.toHaveBeenCalled();
+  });
+
+  it("shows storage quota errors without logging an unexpected upload failure", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const message =
+      "Storage limit exceeded. You are using 10.00 GB of 10 GB and this file requires 37.94 MB. Please delete some files to upload new ones.";
+    generateS3UploadUrlAction.mockRejectedValueOnce(
+      new ConvexError({
+        code: "STORAGE_LIMIT_EXCEEDED",
+        message,
+      }),
+    );
+    const file = new File(["hello"], "report.txt", { type: "text/plain" });
+    const { result } = renderHook(() => useFileUpload("ask"));
+
+    await act(async () => {
+      await result.current.handleFileUploadEvent({
+        target: { files: [file] },
+      } as any);
+    });
+
+    await waitFor(() => {
+      expect(updateUploadedFile).toHaveBeenCalledWith(
+        0,
+        expect.objectContaining({
+          uploading: false,
+          uploaded: false,
+          error: message,
+        }),
+      );
+    });
+    expect(toast.error).toHaveBeenCalledWith(message);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(saveFile).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
   });
 
   it("keeps the S3 upload path outside desktop Agent mode", async () => {

--- a/app/hooks/useFileUpload.ts
+++ b/app/hooks/useFileUpload.ts
@@ -60,6 +60,7 @@ const isExpectedFileUploadError = (error: unknown): boolean => {
   return (
     code === "FILE_TOKEN_LIMIT_EXCEEDED" ||
     code === "FILE_UPLOAD_RATE_LIMIT" ||
+    code === "STORAGE_LIMIT_EXCEEDED" ||
     code === "PAID_PLAN_REQUIRED"
   );
 };

--- a/lib/posthog/__tests__/expected-convex-errors.test.ts
+++ b/lib/posthog/__tests__/expected-convex-errors.test.ts
@@ -47,6 +47,18 @@ describe("shouldDropExpectedConvexException", () => {
     ).toBe(true);
   });
 
+  it("drops file storage quota errors", () => {
+    expect(
+      shouldDropExpectedConvexException({
+        event: "$exception",
+        properties: {
+          $exception_message:
+            'Uncaught ConvexError: {"code":"STORAGE_LIMIT_EXCEEDED","message":"Storage limit exceeded. You are using 10.00 GB of 10 GB and this file requires 37.94 MB. Please delete some files to upload new ones."}',
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("drops expected upload validation errors", () => {
     expect(
       shouldDropExpectedConvexException({

--- a/lib/posthog/expected-convex-errors.ts
+++ b/lib/posthog/expected-convex-errors.ts
@@ -3,6 +3,7 @@ const IGNORED_CONVEX_EXCEPTION_MESSAGES = [
   "Invalid arguments provided",
   "FILE_TOKEN_LIMIT_EXCEEDED",
   "FILE_UPLOAD_RATE_LIMIT",
+  "STORAGE_LIMIT_EXCEEDED",
   "exceeds the maximum token limit",
   "cloud file upload limit",
   "INVALID_FILE_SIZE",


### PR DESCRIPTION
## Summary
- classify STORAGE_LIMIT_EXCEEDED as an expected Convex upload exception for PostHog filtering
- keep the storage quota message visible to users through upload state/toast while avoiding unexpected client console errors
- add regression coverage for the PostHog filter and upload hook behavior

## Testing
- env CI=true corepack pnpm jest lib/posthog/__tests__/expected-convex-errors.test.ts app/hooks/__tests__/useFileUpload.local-desktop.test.tsx --runInBand
- env CI=true corepack pnpm exec prettier --check app/hooks/useFileUpload.ts app/hooks/__tests__/useFileUpload.local-desktop.test.tsx lib/posthog/expected-convex-errors.ts lib/posthog/__tests__/expected-convex-errors.test.ts
- env CI=true corepack pnpm exec eslint app/hooks/useFileUpload.ts app/hooks/__tests__/useFileUpload.local-desktop.test.tsx lib/posthog/expected-convex-errors.ts lib/posthog/__tests__/expected-convex-errors.test.ts
- env CI=true corepack pnpm typecheck

## Manual verification
- In an account at the 10 GB storage cap, upload a file that exceeds remaining storage.
- Confirm the upload item/toast shows the storage limit message and asks the user to delete files.
- Confirm PostHog no longer receives a $exception for STORAGE_LIMIT_EXCEEDED.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for file upload quota/storage limit errors so they are treated as expected failures.
  * Users now see a clear error message when storage limits are exceeded, without unnecessary console noise.
  * Uploads that fail due to storage limits no longer continue as if they succeeded.
* **Tests**
  * Added coverage for storage limit exceeded upload errors and their expected handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->