### PR TITLE
Restore regular draft file attachments

### DIFF
--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -47,28 +47,40 @@ interface ChatInputProps {
   autoFocus?: boolean;
 }
 
+const isBrowserFile = (file: UploadedFileState["file"]): file is File =>
+  typeof globalThis.File !== "undefined" && file instanceof globalThis.File;
+
 const draftAttachmentToUploadedFile = (
   attachment: ConversationDraftAttachment,
-): UploadedFileState => ({
-  file: {
-    name: attachment.name,
-    type: attachment.mediaType,
-    size: attachment.size,
-    lastModified: attachment.timestamp,
-  },
-  uploading: false,
-  uploaded: true,
-  storage: "s3",
-  generatedSource: "pasted-text",
-  fileId: attachment.fileId,
-  tokens: attachment.tokens,
-});
+): UploadedFileState => {
+  const uploadedFile: UploadedFileState = {
+    file: {
+      name: attachment.name,
+      type: attachment.mediaType,
+      size: attachment.size,
+      lastModified: attachment.timestamp,
+    },
+    uploading: false,
+    uploaded: true,
+    storage: "s3",
+    fileId: attachment.fileId,
+    tokens: attachment.tokens,
+  };
+
+  if (
+    attachment.kind === "pasted-text" ||
+    attachment.generatedSource === "pasted-text"
+  ) {
+    uploadedFile.generatedSource = "pasted-text";
+  }
+
+  return uploadedFile;
+};
 
 const uploadedFileToDraftAttachment = (
   uploadedFile: UploadedFileState,
 ): ConversationDraftAttachment | null => {
   if (
-    uploadedFile.generatedSource !== "pasted-text" ||
     !uploadedFile.uploaded ||
     uploadedFile.uploading ||
     uploadedFile.error ||
@@ -79,17 +91,16 @@ const uploadedFileToDraftAttachment = (
   }
 
   return {
-    kind: "pasted-text",
+    kind:
+      uploadedFile.generatedSource === "pasted-text" ? "pasted-text" : "file",
     fileId: uploadedFile.fileId,
     name: uploadedFile.file.name,
-    mediaType: uploadedFile.file.type || "text/plain",
+    mediaType: uploadedFile.file.type || "application/octet-stream",
     size: uploadedFile.file.size,
     tokens: uploadedFile.tokens,
-    timestamp:
-      "lastModified" in uploadedFile.file &&
-      typeof uploadedFile.file.lastModified === "number"
-        ? uploadedFile.file.lastModified
-        : Date.now(),
+    timestamp: isBrowserFile(uploadedFile.file)
+      ? Date.now()
+      : uploadedFile.file.lastModified,
   };
 };
 
@@ -149,7 +160,7 @@ export const ChatInput = ({
       ? "new"
       : chatId || NULL_THREAD_DRAFT_ID;
   const skipNextAttachmentPersistRef = useRef(false);
-  const hasPersistedPastedTextDraftAttachmentsRef = useRef(false);
+  const hasPersistedDraftAttachmentsRef = useRef(false);
   const uploadedFilesRef = useRef(uploadedFiles);
   const prevDraftIdRef = useRef(draftId);
 
@@ -162,17 +173,17 @@ export const ChatInput = ({
     prevDraftIdRef.current = draftId;
 
     if (prevDraftId === "new" && draftId !== "new") {
-      const generatedPastedTextAttachments = uploadedFilesRef.current
+      const draftAttachments = uploadedFilesRef.current
         .map(uploadedFileToDraftAttachment)
         .filter(
           (attachment): attachment is NonNullable<typeof attachment> =>
             attachment !== null,
         );
 
-      if (generatedPastedTextAttachments.length > 0) {
-        upsertDraftAttachments(draftId, generatedPastedTextAttachments);
+      if (draftAttachments.length > 0) {
+        upsertDraftAttachments(draftId, draftAttachments);
         removeDraftAttachments("new");
-        hasPersistedPastedTextDraftAttachmentsRef.current = true;
+        hasPersistedDraftAttachmentsRef.current = true;
       }
 
       if (uploadedFilesRef.current.length > 0) {
@@ -182,8 +193,7 @@ export const ChatInput = ({
     }
 
     const draftAttachments = getDraftAttachmentsById(draftId);
-    hasPersistedPastedTextDraftAttachmentsRef.current =
-      draftAttachments.length > 0;
+    hasPersistedDraftAttachmentsRef.current = draftAttachments.length > 0;
     skipNextAttachmentPersistRef.current = true;
     setUploadedFiles(draftAttachments.map(draftAttachmentToUploadedFile));
   }, [draftId, setUploadedFiles]);
@@ -194,19 +204,19 @@ export const ChatInput = ({
       return;
     }
 
-    const generatedPastedTextAttachments = uploadedFiles
+    const draftAttachments = uploadedFiles
       .map(uploadedFileToDraftAttachment)
       .filter(
         (attachment): attachment is NonNullable<typeof attachment> =>
           attachment !== null,
       );
 
-    if (generatedPastedTextAttachments.length > 0) {
-      upsertDraftAttachments(draftId, generatedPastedTextAttachments);
-      hasPersistedPastedTextDraftAttachmentsRef.current = true;
-    } else if (hasPersistedPastedTextDraftAttachmentsRef.current) {
+    if (draftAttachments.length > 0) {
+      upsertDraftAttachments(draftId, draftAttachments);
+      hasPersistedDraftAttachmentsRef.current = true;
+    } else if (hasPersistedDraftAttachmentsRef.current) {
       removeDraftAttachments(draftId);
-      hasPersistedPastedTextDraftAttachmentsRef.current = false;
+      hasPersistedDraftAttachmentsRef.current = false;
     }
   }, [draftId, uploadedFiles]);
 

--- a/app/components/__tests__/ChatInput.integration.test.tsx
+++ b/app/components/__tests__/ChatInput.integration.test.tsx
@@ -1,11 +1,21 @@
 import "@testing-library/jest-dom";
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import { ChatInput } from "../ChatInput";
-import { GlobalStateProvider } from "../../contexts/GlobalState";
+import {
+  GlobalStateProvider,
+  useGlobalState,
+} from "../../contexts/GlobalState";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ReactNode } from "react";
 import { CONVERSATION_DRAFTS_STORAGE_KEY } from "@/lib/utils/client-storage";
+import type { UploadedFileState } from "@/types/file";
 
 // Mock only external dependencies, not contexts
 jest.mock("react-hotkeys-hook", () => ({
@@ -37,6 +47,22 @@ const TestWrapper = ({ children }: { children: ReactNode }) => {
     <GlobalStateProvider>
       <TooltipProvider>{children}</TooltipProvider>
     </GlobalStateProvider>
+  );
+};
+
+const UploadedFilesSetter = ({
+  files,
+  label,
+}: {
+  files: UploadedFileState[];
+  label: string;
+}) => {
+  const { setUploadedFiles } = useGlobalState();
+
+  return (
+    <button type="button" onClick={() => setUploadedFiles(files)}>
+      {label}
+    </button>
   );
 };
 
@@ -304,6 +330,114 @@ describe("ChatInput - Integration Tests", () => {
       );
 
       expect(await screen.findByText("pasted-text.txt")).toBeInTheDocument();
+    });
+
+    it("restores regular S3 draft attachments", async () => {
+      const draftAttachment = {
+        kind: "file" as const,
+        fileId: "file_regular",
+        name: "report.pdf",
+        mediaType: "application/pdf",
+        size: 1024,
+        tokens: 42,
+        timestamp: Date.now(),
+      };
+      window.localStorage.setItem(
+        CONVERSATION_DRAFTS_STORAGE_KEY,
+        JSON.stringify({
+          drafts: [
+            {
+              id: "chat-1",
+              content: "",
+              timestamp: Date.now(),
+              attachments: [draftAttachment],
+            },
+          ],
+        }),
+      );
+
+      render(
+        <TestWrapper>
+          <ChatInput
+            onSubmit={mockOnSubmit}
+            onStop={mockOnStop}
+            status="ready"
+            isNewChat={false}
+            chatId="chat-1"
+          />
+        </TestWrapper>,
+      );
+
+      expect(await screen.findByText("report.pdf")).toBeInTheDocument();
+    });
+
+    it("persists regular S3 uploaded files into draft attachments", async () => {
+      const browserFile = new File(["x".repeat(2048)], "report.pdf", {
+        type: "application/pdf",
+        lastModified: 123456,
+      });
+      const pendingFile: UploadedFileState = {
+        file: browserFile,
+        uploading: true,
+        uploaded: false,
+        storage: "s3",
+      };
+      const uploadedFile: UploadedFileState = {
+        file: browserFile,
+        uploading: false,
+        uploaded: true,
+        storage: "s3",
+        fileId: "file_regular",
+        tokens: 84,
+      };
+
+      render(
+        <TestWrapper>
+          <UploadedFilesSetter files={[pendingFile]} label="Start upload" />
+          <UploadedFilesSetter files={[uploadedFile]} label="Complete upload" />
+          <ChatInput
+            onSubmit={mockOnSubmit}
+            onStop={mockOnStop}
+            status="ready"
+            isNewChat={false}
+            chatId="chat-1"
+          />
+        </TestWrapper>,
+      );
+
+      await act(async () => {});
+      fireEvent.click(screen.getByText("Start upload"));
+      await waitFor(() => {
+        expect(screen.getByText("report.pdf")).toBeInTheDocument();
+      });
+      await act(async () => {});
+      const beforeCompletion = Date.now();
+      fireEvent.click(screen.getByText("Complete upload"));
+
+      await waitFor(() => {
+        const store = JSON.parse(
+          window.localStorage.getItem(CONVERSATION_DRAFTS_STORAGE_KEY) ?? "{}",
+        );
+        expect(store.drafts).toEqual([
+          expect.objectContaining({
+            id: "chat-1",
+            attachments: [
+              {
+                kind: "file",
+                fileId: "file_regular",
+                name: "report.pdf",
+                mediaType: "application/pdf",
+                size: 2048,
+                tokens: 84,
+                timestamp: expect.any(Number),
+              },
+            ],
+          }),
+        ]);
+        expect(store.drafts[0].attachments[0].timestamp).toBeGreaterThanOrEqual(
+          beforeCompletion,
+        );
+      });
     });
 
     it("keeps restored pasted-text drafts when submit is rejected", async () => {

--- a/lib/utils/__tests__/client-storage.test.ts
+++ b/lib/utils/__tests__/client-storage.test.ts
@@ -188,6 +188,34 @@ describe("client-storage draft attachments", () => {
     ]);
   });
 
+  it("persists regular S3 draft attachments without draft text", () => {
+    const timestamp = Date.now();
+    upsertDraftAttachments("chat-1", [
+      {
+        kind: "file",
+        fileId: "file_regular",
+        name: "report.pdf",
+        mediaType: "application/pdf",
+        size: 1024,
+        tokens: 42,
+        timestamp,
+      },
+    ]);
+
+    expect(hasDraftAttachmentsById("chat-1")).toBe(true);
+    expect(getDraftAttachmentsById("chat-1")).toEqual([
+      {
+        kind: "file",
+        fileId: "file_regular",
+        name: "report.pdf",
+        mediaType: "application/pdf",
+        size: 1024,
+        tokens: 42,
+        timestamp,
+      },
+    ]);
+  });
+
   it("preserves draft attachments when text autosave updates content", () => {
     upsertDraftAttachments("chat-1", [
       {

--- a/lib/utils/client-storage.ts
+++ b/lib/utils/client-storage.ts
@@ -184,11 +184,7 @@ const normalizeDraftAttachments = (
     (attachment): attachment is ConversationDraftAttachment => {
       if (!attachment || typeof attachment !== "object") return false;
       const value = attachment as Partial<ConversationDraftAttachment>;
-      const validKind =
-        value.kind === "file" ||
-        (value.kind === "pasted-text" &&
-          (typeof value.generatedSource === "undefined" ||
-            value.generatedSource === "pasted-text"));
+      const validKind = value.kind === "file" || value.kind === "pasted-text";
 
       return (
         validKind &&

--- a/lib/utils/client-storage.ts
+++ b/lib/utils/client-storage.ts
@@ -13,11 +13,12 @@ export type ConversationDraft = {
 };
 
 export type ConversationDraftAttachment = {
-  kind: "pasted-text";
+  kind: "file" | "pasted-text";
   fileId: string;
   name: string;
   mediaType: string;
   size: number;
+  generatedSource?: "pasted-text";
   tokens?: number;
   timestamp: number;
 };
@@ -183,8 +184,16 @@ const normalizeDraftAttachments = (
     (attachment): attachment is ConversationDraftAttachment => {
       if (!attachment || typeof attachment !== "object") return false;
       const value = attachment as Partial<ConversationDraftAttachment>;
+      const validKind =
+        value.kind === "file" ||
+        (value.kind === "pasted-text" &&
+          (typeof value.generatedSource === "undefined" ||
+            value.generatedSource === "pasted-text"));
+
       return (
-        value.kind === "pasted-text" &&
+        validKind &&
+        (typeof value.generatedSource === "undefined" ||
+          value.generatedSource === "pasted-text") &&
         typeof value.fileId === "string" &&
         value.fileId.length > 0 &&
         typeof value.name === "string" &&


### PR DESCRIPTION
## Summary
- persist regular S3 uploaded draft attachments with fileId metadata, not only generated pasted-text attachments
- restore regular S3 draft attachments back into ChatInput after reload
- use draft-save time for newly uploaded browser files so older local file modification dates do not immediately expire the 24h restore window

## Why
PR #732 restored generated pasted-text attachments, but normal S3 uploads were filtered out because draft persistence only accepted generatedSource=pasted-text and kind=pasted-text. Existing users could upload a file, receive a valid fileId from saveFile, reload, and see ChatInput reconstruct no attached files.

## Validation
- corepack pnpm test -- lib/utils/__tests__/client-storage.test.ts app/components/__tests__/ChatInput.integration.test.tsx --runInBand
- corepack pnpm typecheck
- corepack pnpm exec eslint app/components/ChatInput/ChatInput.tsx app/components/__tests__/ChatInput.integration.test.tsx lib/utils/client-storage.ts lib/utils/__tests__/client-storage.test.ts types/file.ts
- corepack pnpm exec prettier --check app/components/ChatInput/ChatInput.tsx app/components/__tests__/ChatInput.integration.test.tsx lib/utils/client-storage.ts lib/utils/__tests__/client-storage.test.ts types/file.ts

## Manual verification
- In a paid account, upload a normal S3-backed file in ChatInput and wait for upload completion.
- Reload before sending.
- Confirm the file card reappears in ChatInput and sending includes the stored fileId.
- Repeat with an older local file to confirm it is not immediately filtered out by the draft attachment TTL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft chat attachments now support regular file uploads in addition to pasted text.
  * Attached files can be persisted and restored for draft chats, including key metadata.

* **Bug Fixes**
  * Improved persistence when switching between new chats and existing draft chats.
  * More consistent handling of attachment timestamps and media types during save/reload.

* **Tests**
  * Added integration and client-storage tests covering “file” draft attachments and persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->