### PR TITLE
Guard repeated empty todo writes

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -57,6 +57,11 @@ const chatHandlerSrc = fs.readFileSync(
   "utf8",
 );
 
+const agentStreamRunnerSrc = fs.readFileSync(
+  path.resolve(__dirname, "../agent-stream-runner.ts"),
+  "utf8",
+);
+
 describe("agent-long-transport — direct UI stream reader", () => {
   test("reads the Trigger.dev ui stream directly instead of using withStreams", () => {
     expect(transportSrc).toMatch(/streams\.read<unknown>\(/);
@@ -124,6 +129,20 @@ describe("agent-long-transport — direct UI stream reader", () => {
     );
     expect(transportSrc).toMatch(
       /userAborted\s*\|\|\s*timedOutAfterFinish\s*\|\|\s*completedRunDrainElapsed/,
+    );
+  });
+});
+
+describe("agent stream runner — empty todo_write recovery", () => {
+  test("temporarily excludes todo_write when the doom-loop detector requests it", () => {
+    expect(agentStreamRunnerSrc).toMatch(/activeToolExclusions/);
+    expect(agentStreamRunnerSrc).toMatch(/getActiveToolsWithExclusions/);
+    expect(agentStreamRunnerSrc).toMatch(/excludedToolsForStep/);
+    expect(agentStreamRunnerSrc).toMatch(
+      /event:\s*"empty_todo_write_loop_recovery"/,
+    );
+    expect(agentStreamRunnerSrc).toMatch(
+      /await getActiveToolsWithExclusions\(excludedToolsForStep\)/,
     );
   });
 });

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -137,12 +137,37 @@ describe("agent stream runner — empty todo_write recovery", () => {
   test("temporarily excludes todo_write when the doom-loop detector requests it", () => {
     expect(agentStreamRunnerSrc).toMatch(/activeToolExclusions/);
     expect(agentStreamRunnerSrc).toMatch(/getActiveToolsWithExclusions/);
-    expect(agentStreamRunnerSrc).toMatch(/excludedToolsForStep/);
+    expect(agentStreamRunnerSrc).toMatch(/getActiveToolsForRecovery/);
     expect(agentStreamRunnerSrc).toMatch(
       /event:\s*"empty_todo_write_loop_recovery"/,
     );
+
+    const recoveryIdx = agentStreamRunnerSrc.indexOf(
+      "const loopRecovery = getDoomLoopRecovery(steps, steps.length)",
+    );
+    const summarizationIdx = agentStreamRunnerSrc.indexOf(
+      "runSummarizationStep({",
+    );
+    const summarizedActiveToolsIdx = agentStreamRunnerSrc.indexOf(
+      "const activeTools = await getActiveToolsForRecovery(loopRecovery)",
+      summarizationIdx,
+    );
+    const normalActiveToolsIdx = agentStreamRunnerSrc.indexOf(
+      "const activeTools = await getActiveToolsForRecovery(loopRecovery)",
+      summarizedActiveToolsIdx + 1,
+    );
+    const summarizedNudgeIdx = agentStreamRunnerSrc.indexOf(
+      "loopRecovery.nudge",
+      summarizationIdx,
+    );
+
+    expect(recoveryIdx).toBeGreaterThan(-1);
+    expect(summarizationIdx).toBeGreaterThan(recoveryIdx);
+    expect(summarizedActiveToolsIdx).toBeGreaterThan(summarizationIdx);
+    expect(normalActiveToolsIdx).toBeGreaterThan(summarizedActiveToolsIdx);
+    expect(summarizedNudgeIdx).toBeGreaterThan(summarizationIdx);
     expect(agentStreamRunnerSrc).toMatch(
-      /await getActiveToolsWithExclusions\(excludedToolsForStep\)/,
+      /getActiveToolsWithExclusions\(recovery\.excludedTools\)/,
     );
   });
 });

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -348,24 +348,40 @@ export async function createAgentStream(
   ctx: AgentStreamContext,
   state: AgentStreamState,
 ) {
-  const getActiveTools = async (): Promise<
-    Array<keyof typeof ctx.tools> | undefined
-  > => {
+  const getActiveToolsWithExclusions = async (
+    excludedToolNames: ReadonlySet<string> = new Set(),
+  ): Promise<Array<keyof typeof ctx.tools> | undefined> => {
+    const hasExclusions = excludedToolNames.size > 0;
+    const withoutExcludedTools = (toolName: string) =>
+      !excludedToolNames.has(toolName);
     let supportsPty: boolean | undefined;
     try {
       supportsPty = await ctx.sandboxManager.supportsInteractivePty?.();
     } catch (error) {
       console.warn("[agent-stream] PTY capability probe failed:", error);
-      return undefined;
+      return hasExclusions
+        ? (Object.keys(ctx.tools).filter(withoutExcludedTools) as Array<
+            keyof typeof ctx.tools
+          >)
+        : undefined;
     }
     if (supportsPty !== false) {
-      return undefined;
+      return hasExclusions
+        ? (Object.keys(ctx.tools).filter(withoutExcludedTools) as Array<
+            keyof typeof ctx.tools
+          >)
+        : undefined;
     }
 
     return Object.keys(ctx.tools).filter(
-      (toolName) => toolName !== "interact_terminal_session",
+      (toolName) =>
+        toolName !== "interact_terminal_session" &&
+        withoutExcludedTools(toolName),
     ) as Array<keyof typeof ctx.tools>;
   };
+  const getActiveTools = async (): Promise<
+    Array<keyof typeof ctx.tools> | undefined
+  > => getActiveToolsWithExclusions();
   const initialActiveTools = await getActiveTools();
   const requestedLanguageModel = ctx.trackedProvider.languageModel(modelName);
   const requestedSlug = requestedLanguageModel.modelId;
@@ -545,9 +561,10 @@ export async function createAgentStream(
         const loopCheck = detectDoomLoop(
           steps as unknown as Parameters<typeof detectDoomLoop>[0],
         );
+        let excludedToolsForStep: ReadonlySet<string> | undefined;
         if (loopCheck.severity !== "none") {
           console.log(
-            `[doom-loop] severity=${loopCheck.severity} tools=${loopCheck.toolNames.join(",")} count=${loopCheck.consecutiveCount} step=${steps.length}`,
+            `[doom-loop] severity=${loopCheck.severity} reason=${loopCheck.reason ?? "unknown"} tools=${loopCheck.toolNames.join(",")} count=${loopCheck.consecutiveCount} step=${steps.length}`,
           );
           if (loopCheck.severity === "warning") {
             const nudge = generateDoomLoopNudge(loopCheck);
@@ -556,10 +573,28 @@ export async function createAgentStream(
               ...updatedMessages,
               { role: "user", content: nudge },
             ] as typeof updatedMessages;
+
+            if (loopCheck.activeToolExclusions?.length) {
+              excludedToolsForStep = new Set(loopCheck.activeToolExclusions);
+              console.warn("[doom-loop] Applying active tool exclusions", {
+                event: "empty_todo_write_loop_recovery",
+                chatId: ctx.chatId,
+                modelName,
+                requestedModel: requestedSlug,
+                responseModel: state.responseModel,
+                reason: loopCheck.reason,
+                consecutiveCount: loopCheck.consecutiveCount,
+                rawInput: {},
+                excludedTools: loopCheck.activeToolExclusions,
+              });
+            }
           }
         }
 
-        const activeTools = await getActiveTools();
+        const activeTools =
+          excludedToolsForStep && excludedToolsForStep.size > 0
+            ? await getActiveToolsWithExclusions(excludedToolsForStep)
+            : await getActiveTools();
         const providerOptions = getStepProviderOptions();
         const preparedMessages = prepareProviderMessages(
           addCacheBreakpointToLastUserMessage(

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -382,9 +382,65 @@ export async function createAgentStream(
   const getActiveTools = async (): Promise<
     Array<keyof typeof ctx.tools> | undefined
   > => getActiveToolsWithExclusions();
-  const initialActiveTools = await getActiveTools();
   const requestedLanguageModel = ctx.trackedProvider.languageModel(modelName);
   const requestedSlug = requestedLanguageModel.modelId;
+
+  type DoomLoopRecovery = {
+    nudge?: string;
+    excludedTools?: ReadonlySet<string>;
+  };
+
+  const getDoomLoopRecovery = (
+    steps: unknown[],
+    stepNumber: number,
+  ): DoomLoopRecovery => {
+    const loopCheck = detectDoomLoop(
+      steps as Parameters<typeof detectDoomLoop>[0],
+    );
+
+    if (loopCheck.severity === "none") {
+      return {};
+    }
+
+    console.log(
+      `[doom-loop] severity=${loopCheck.severity} reason=${loopCheck.reason ?? "unknown"} tools=${loopCheck.toolNames.join(",")} count=${loopCheck.consecutiveCount} step=${stepNumber}`,
+    );
+
+    if (loopCheck.severity !== "warning") {
+      return {};
+    }
+
+    const recovery: DoomLoopRecovery = {
+      nudge: generateDoomLoopNudge(loopCheck),
+    };
+    console.log("[doom-loop] Injecting nudge as last user message");
+
+    if (loopCheck.activeToolExclusions?.length) {
+      recovery.excludedTools = new Set(loopCheck.activeToolExclusions);
+      console.warn("[doom-loop] Applying active tool exclusions", {
+        event: "empty_todo_write_loop_recovery",
+        chatId: ctx.chatId,
+        modelName,
+        requestedModel: requestedSlug,
+        responseModel: state.responseModel,
+        reason: loopCheck.reason,
+        consecutiveCount: loopCheck.consecutiveCount,
+        rawInput: {},
+        excludedTools: loopCheck.activeToolExclusions,
+      });
+    }
+
+    return recovery;
+  };
+
+  const getActiveToolsForRecovery = async (
+    recovery: DoomLoopRecovery,
+  ): Promise<Array<keyof typeof ctx.tools> | undefined> =>
+    recovery.excludedTools && recovery.excludedTools.size > 0
+      ? getActiveToolsWithExclusions(recovery.excludedTools)
+      : getActiveTools();
+
+  const initialActiveTools = await getActiveTools();
   const maxOutputTokens =
     ctx.subscription === "free"
       ? FREE_MAX_OUTPUT_TOKENS
@@ -490,6 +546,8 @@ export async function createAgentStream(
           streamHasImageViewResults = true;
         }
 
+        const loopRecovery = getDoomLoopRecovery(steps, steps.length);
+
         if (!ctx.temporary && !ctx.summarizationTracker.hasSummarized) {
           const providerPromptPressure = getProviderPromptPressure(messages);
           const result = await runSummarizationStep({
@@ -525,12 +583,22 @@ export async function createAgentStream(
               state.ctxUsage = result.contextUsage;
             }
             state.transcriptSourceMessages = undefined;
-            const activeTools = await getActiveTools();
+            const activeTools = await getActiveToolsForRecovery(loopRecovery);
             const providerOptions = getStepProviderOptions();
-            const preparedMessages = prepareProviderMessages(
-              await convertToModelMessages(result.summarizedMessages, {
+            let summarizedModelMessages = await convertToModelMessages(
+              result.summarizedMessages,
+              {
                 tools: createPromptSerializationTools(ctx.tools),
-              }),
+              },
+            );
+            if (loopRecovery.nudge) {
+              summarizedModelMessages = [
+                ...summarizedModelMessages,
+                { role: "user", content: loopRecovery.nudge },
+              ];
+            }
+            const preparedMessages = prepareProviderMessages(
+              summarizedModelMessages,
             );
             recordProviderRequestDiagnostics({
               stepIndex: steps.length + 1,
@@ -558,43 +626,14 @@ export async function createAgentStream(
           noteInjectionOpts: ctx.noteInjectionOpts,
         });
 
-        const loopCheck = detectDoomLoop(
-          steps as unknown as Parameters<typeof detectDoomLoop>[0],
-        );
-        let excludedToolsForStep: ReadonlySet<string> | undefined;
-        if (loopCheck.severity !== "none") {
-          console.log(
-            `[doom-loop] severity=${loopCheck.severity} reason=${loopCheck.reason ?? "unknown"} tools=${loopCheck.toolNames.join(",")} count=${loopCheck.consecutiveCount} step=${steps.length}`,
-          );
-          if (loopCheck.severity === "warning") {
-            const nudge = generateDoomLoopNudge(loopCheck);
-            console.log("[doom-loop] Injecting nudge as last user message");
-            updatedMessages = [
-              ...updatedMessages,
-              { role: "user", content: nudge },
-            ] as typeof updatedMessages;
-
-            if (loopCheck.activeToolExclusions?.length) {
-              excludedToolsForStep = new Set(loopCheck.activeToolExclusions);
-              console.warn("[doom-loop] Applying active tool exclusions", {
-                event: "empty_todo_write_loop_recovery",
-                chatId: ctx.chatId,
-                modelName,
-                requestedModel: requestedSlug,
-                responseModel: state.responseModel,
-                reason: loopCheck.reason,
-                consecutiveCount: loopCheck.consecutiveCount,
-                rawInput: {},
-                excludedTools: loopCheck.activeToolExclusions,
-              });
-            }
-          }
+        if (loopRecovery.nudge) {
+          updatedMessages = [
+            ...updatedMessages,
+            { role: "user", content: loopRecovery.nudge },
+          ] as typeof updatedMessages;
         }
 
-        const activeTools =
-          excludedToolsForStep && excludedToolsForStep.size > 0
-            ? await getActiveToolsWithExclusions(excludedToolsForStep)
-            : await getActiveTools();
+        const activeTools = await getActiveToolsForRecovery(loopRecovery);
         const providerOptions = getStepProviderOptions();
         const preparedMessages = prepareProviderMessages(
           addCacheBreakpointToLastUserMessage(

--- a/lib/chat/__tests__/doom-loop-detection.test.ts
+++ b/lib/chat/__tests__/doom-loop-detection.test.ts
@@ -5,6 +5,7 @@ import {
   generateDoomLoopNudge,
   DOOM_LOOP_WARNING_THRESHOLD,
   DOOM_LOOP_HALT_THRESHOLD,
+  EMPTY_TODO_WRITE_INPUT_WARNING_THRESHOLD,
 } from "../doom-loop-detection";
 
 function makeStep(toolCalls: Array<{ toolName: string; input: unknown }>) {
@@ -98,6 +99,39 @@ describe("detectDoomLoop", () => {
     expect(result.severity).toBe("warning");
     expect(result.toolNames).toEqual(["file"]);
     expect(result.consecutiveCount).toBe(DOOM_LOOP_WARNING_THRESHOLD);
+    expect(result.reason).toBe("repeated_tool_call");
+  });
+
+  it("returns a todo-specific warning after repeated empty todo_write calls", () => {
+    const step = makeStep([{ toolName: "todo_write", input: {} }]);
+    const steps = Array(EMPTY_TODO_WRITE_INPUT_WARNING_THRESHOLD).fill(step);
+
+    const result = detectDoomLoop(steps);
+
+    expect(result).toMatchObject({
+      severity: "warning",
+      reason: "empty_todo_write_input",
+      toolNames: ["todo_write"],
+      consecutiveCount: EMPTY_TODO_WRITE_INPUT_WARNING_THRESHOLD,
+      activeToolExclusions: ["todo_write"],
+    });
+  });
+
+  it("treats missing todo_write input as empty for recovery", () => {
+    const step = makeStep([{ toolName: "todo_write", input: undefined }]);
+    const steps = Array(EMPTY_TODO_WRITE_INPUT_WARNING_THRESHOLD).fill(step);
+
+    const result = detectDoomLoop(steps);
+
+    expect(result.reason).toBe("empty_todo_write_input");
+    expect(result.activeToolExclusions).toEqual(["todo_write"]);
+  });
+
+  it("does not apply todo recovery to other empty tool calls", () => {
+    const step = makeStep([{ toolName: "list_notes", input: {} }]);
+    const steps = Array(EMPTY_TODO_WRITE_INPUT_WARNING_THRESHOLD).fill(step);
+
+    expect(detectDoomLoop(steps).severity).toBe("none");
   });
 
   it("returns warning between warning and halt thresholds", () => {
@@ -116,6 +150,17 @@ describe("detectDoomLoop", () => {
     const result = detectDoomLoop(steps);
     expect(result.severity).toBe("halt");
     expect(result.consecutiveCount).toBe(DOOM_LOOP_HALT_THRESHOLD);
+  });
+
+  it("still halts after enough repeated empty todo_write calls", () => {
+    const step = makeStep([{ toolName: "todo_write", input: {} }]);
+    const steps = Array(DOOM_LOOP_HALT_THRESHOLD).fill(step);
+
+    const result = detectDoomLoop(steps);
+
+    expect(result.severity).toBe("halt");
+    expect(result.reason).toBe("empty_todo_write_input");
+    expect(result.activeToolExclusions).toEqual(["todo_write"]);
   });
 
   it("returns halt above halt threshold", () => {
@@ -223,5 +268,19 @@ describe("generateDoomLoopNudge", () => {
     expect(nudge).toContain("file");
     expect(nudge).toContain("run_terminal_cmd");
     expect(nudge).toContain("4 times");
+  });
+
+  it("gives specific recovery guidance for empty todo_write calls", () => {
+    const nudge = generateDoomLoopNudge({
+      severity: "warning",
+      toolNames: ["todo_write"],
+      consecutiveCount: 2,
+      reason: "empty_todo_write_input",
+      activeToolExclusions: ["todo_write"],
+    });
+
+    expect(nudge).toContain("[TODO UPDATE SKIPPED]");
+    expect(nudge).toContain("todo_write is unavailable");
+    expect(nudge).toContain("merge and todos");
   });
 });

--- a/lib/chat/doom-loop-detection.ts
+++ b/lib/chat/doom-loop-detection.ts
@@ -12,13 +12,17 @@
 
 export const DOOM_LOOP_WARNING_THRESHOLD = 3;
 export const DOOM_LOOP_HALT_THRESHOLD = 5;
+export const EMPTY_TODO_WRITE_INPUT_WARNING_THRESHOLD = 2;
 
 export type DoomLoopSeverity = "none" | "warning" | "halt";
+export type DoomLoopReason = "repeated_tool_call" | "empty_todo_write_input";
 
 export interface DoomLoopResult {
   severity: DoomLoopSeverity;
   toolNames: string[];
   consecutiveCount: number;
+  reason?: DoomLoopReason;
+  activeToolExclusions?: string[];
 }
 
 interface MinimalToolCall {
@@ -42,6 +46,29 @@ function stripCosmeticFields(input: unknown): unknown {
     ([key]) => !COSMETIC_INPUT_FIELDS.has(key),
   );
   return Object.fromEntries(entries);
+}
+
+function isEmptyToolInput(input: unknown): boolean {
+  if (input === undefined || input === null) return true;
+  if (Array.isArray(input) || typeof input !== "object") return false;
+  return Object.keys(input as Record<string, unknown>).length === 0;
+}
+
+function isEmptyTodoWriteStep(step: MinimalStep | undefined): boolean {
+  if (!step?.toolCalls || step.toolCalls.length !== 1) return false;
+  const [toolCall] = step.toolCalls;
+  return toolCall.toolName === "todo_write" && isEmptyToolInput(toolCall.input);
+}
+
+function getTrailingEmptyTodoWriteCount(steps: MinimalStep[]): number {
+  let count = 0;
+
+  for (let i = steps.length - 1; i >= 0; i--) {
+    if (!isEmptyTodoWriteStep(steps[i])) break;
+    count++;
+  }
+
+  return count;
 }
 
 /**
@@ -73,6 +100,18 @@ export function detectDoomLoop(steps: MinimalStep[]): DoomLoopResult {
     toolNames: [],
     consecutiveCount: 0,
   };
+
+  const emptyTodoWriteCount = getTrailingEmptyTodoWriteCount(steps);
+  if (emptyTodoWriteCount >= EMPTY_TODO_WRITE_INPUT_WARNING_THRESHOLD) {
+    return {
+      severity:
+        emptyTodoWriteCount >= DOOM_LOOP_HALT_THRESHOLD ? "halt" : "warning",
+      toolNames: ["todo_write"],
+      consecutiveCount: emptyTodoWriteCount,
+      reason: "empty_todo_write_input",
+      activeToolExclusions: ["todo_write"],
+    };
+  }
 
   if (steps.length < DOOM_LOOP_WARNING_THRESHOLD) {
     return none;
@@ -107,6 +146,7 @@ export function detectDoomLoop(steps: MinimalStep[]): DoomLoopResult {
     severity: count >= DOOM_LOOP_HALT_THRESHOLD ? "halt" : "warning",
     toolNames,
     consecutiveCount: count,
+    reason: "repeated_tool_call",
   };
 }
 
@@ -116,6 +156,14 @@ export function detectDoomLoop(steps: MinimalStep[]): DoomLoopResult {
  */
 export function generateDoomLoopNudge(result: DoomLoopResult): string {
   const toolList = result.toolNames.join(", ");
+
+  if (result.reason === "empty_todo_write_input") {
+    return (
+      `[TODO UPDATE SKIPPED] The last ${result.consecutiveCount} todo_write calls had empty arguments, so todo_write is unavailable for this step. ` +
+      `Do NOT call todo_write again now. Continue the user's task with the current plan and other tools. ` +
+      `Only try todo_write later if you can provide both top-level fields: merge and todos.`
+    );
+  }
 
   return (
     `[LOOP DETECTED] You have called ${toolList} ${result.consecutiveCount} times in a row with identical arguments. ` +


### PR DESCRIPTION
## Summary
- detect repeated empty `todo_write` tool inputs after two consecutive attempts
- inject a todo-specific recovery nudge and temporarily remove `todo_write` from active tools for the next provider step
- log `empty_todo_write_loop_recovery` with chat/model context and a raw empty-input marker

## Validation
- `node_modules/.bin/jest lib/chat/__tests__/doom-loop-detection.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/eslint lib/api/agent-stream-runner.ts lib/api/__tests__/agent-long-contracts.test.ts lib/chat/doom-loop-detection.ts lib/chat/__tests__/doom-loop-detection.test.ts`
- `node_modules/.bin/prettier --check lib/api/agent-stream-runner.ts lib/api/__tests__/agent-long-contracts.test.ts lib/chat/doom-loop-detection.ts lib/chat/__tests__/doom-loop-detection.test.ts`
- `node_modules/.bin/jest convex/__tests__/unitEconomicsReportingWindow.test.ts --runInBand`

Note: the pre-commit hook also ran the full Jest suite; one Jest worker segfaulted in `convex/__tests__/unitEconomicsReportingWindow.test.ts` after 163 suites had passed. The same suite passed when rerun in-band.

## Manual verification
- Start an Agent run or replay that produces repeated empty `todo_write` calls.
- Confirm that after the second empty todo call, the next provider step receives the todo-specific recovery nudge and `todo_write` is absent from active tools.
- Confirm the run continues with other tools instead of burning all five doom-loop attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter loop detection for repeated empty todo updates, with clearer recovery guidance when this pattern is detected.
  * Improved step handling so tool availability can be adjusted automatically during recovery.

* **Bug Fixes**
  * Reduced repeated empty todo update loops by temporarily excluding the affected tool when needed.
  * Improved fallback behavior when checking interactive terminal support, making tool selection more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->