### PR TITLE
Remove chat composer focus ring

### DIFF
--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -328,7 +328,7 @@ export const ChatInput = ({
         />
 
         <div
-          className={`order-2 sm:order-1 flex flex-col gap-3 transition-colors relative bg-input-chat py-3 max-h-[300px] min-w-0 overflow-hidden shadow-[0px_12px_32px_0px_rgba(0,0,0,0.02)] border border-black/8 dark:border-border focus-within:ring-2 focus-within:ring-ring/20 ${uploadedFiles && uploadedFiles.length > 0 ? "rounded-b-[22px] border-t-0" : "rounded-[22px]"}`}
+          className={`order-2 sm:order-1 flex flex-col gap-3 transition-colors relative bg-input-chat py-3 max-h-[300px] min-w-0 overflow-hidden shadow-[0px_12px_32px_0px_rgba(0,0,0,0.02)] border border-black/8 dark:border-border ${uploadedFiles && uploadedFiles.length > 0 ? "rounded-b-[22px] border-t-0" : "rounded-[22px]"}`}
         >
           <ChatInputTextarea
             draftId={draftId}


### PR DESCRIPTION
## Summary
- remove the chat composer focus-within ring so focusing the textarea no longer draws a lower-half outline when attachments are present
- keep the persistent composer border and existing button/menu focus states unchanged

## Validation
- ./node_modules/.bin/prettier --check app/components/ChatInput/ChatInput.tsx
- ./node_modules/.bin/eslint app/components/ChatInput/ChatInput.tsx
- git diff --check
- Visual verification on http://127.0.0.1:3000 with a focused textarea plus attached example.txt: no partial focus border and no console errors

## Manual verification
- Open a new chat in dark mode.
- Attach a file or restore a draft with an attachment.
- Click into the message textarea. The composer should keep its normal border without showing a partial lower-half focus outline.
- Tab through the toolbar controls and confirm buttons/menus still show their own focus state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the chat input layout to remove the extra focus ring styling around the textarea and toolbar container, resulting in a simpler appearance when the input is focused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->