### PR TITLE
Reduce redundant Agent image view calls

### DIFF
--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -118,6 +118,8 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).toContain("agent-browser set viewport 1920 1080");
     expect(prompt).toContain("/home/user/agent-browser-screenshots");
     expect(prompt).toContain("file tool's view action");
+    expect(prompt).toContain("Inline image attachments are already visible");
+    expect(prompt).toContain("do not call the file view action");
   });
 
   it("adds compact cloud sandbox tool recipes for solo security workflows", async () => {

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -205,6 +205,7 @@ System Environment:
 - User: \`root\` (with sudo privileges)
 - Home directory: /home/user
 - User attachments are available in /home/user/upload. If a specific file is not found, ask the user to re-upload and resend their message with the file attached
+- Inline image attachments are already visible in the conversation. If an \`inline_image_attachment\` also lists a sandbox path, use that path only for file-system operations such as metadata extraction, conversion, or scripting; do not call the file view action just to describe the image.
 - VPN connectivity is not available due to missing TUN/TAP device support in the sandbox environment
 
 Development Environment:

--- a/lib/utils/__tests__/file-transform-utils.test.ts
+++ b/lib/utils/__tests__/file-transform-utils.test.ts
@@ -308,6 +308,57 @@ describe("processMessageFiles image size guards", () => {
     });
   });
 
+  it("marks small Agent images as already visible while still staging a sandbox copy", async () => {
+    mockConvexAction.mockResolvedValue([
+      fileUrlInfo("https://storage.example/small.png", {
+        sizeBytes: 2 * 1024 * 1024,
+        name: "small.png",
+      }),
+    ]);
+    global.fetch = jest.fn(async () => {
+      return responseLike({
+        headers: { "content-length": String(VALID_PNG_BYTES.byteLength) },
+        body: streamBody(VALID_PNG_BYTES),
+      });
+    }) as any;
+
+    const result = await processMessageFiles(
+      makeMessage({
+        type: "file",
+        mediaType: "image/png",
+        fileId: "file_small",
+        name: "small.png",
+        url: "https://example.com/small.png",
+      }),
+      "agent",
+      "user123",
+      "/home/user/upload",
+      "pro",
+    );
+
+    expect(result.sandboxFiles).toEqual([
+      {
+        kind: "url",
+        url: "https://storage.example/small.png",
+        localPath: "/home/user/upload/small.png",
+      },
+    ]);
+    expect(result.messages[0].parts).toEqual([
+      { type: "text", text: "what is this?" },
+      expect.objectContaining({
+        type: "file",
+        mediaType: "image/png",
+        name: "small.png",
+        url: "https://storage.example/small.png",
+        size: 2 * 1024 * 1024,
+      }),
+      {
+        type: "text",
+        text: '<inline_image_attachment filename="small.png" sandbox_path="/home/user/upload/small.png" already_visible_to_model="true" use_sandbox_path_for="file_operations_only" />',
+      },
+    ]);
+  });
+
   it("omits stored images whose storage URL does not return valid image bytes", async () => {
     const notImageBytes = new TextEncoder().encode("<html>not an image</html>");
     mockConvexAction.mockResolvedValue([

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -725,6 +725,26 @@ const removeFilePartsWithoutUrls = (messages: UIMessage[]) => {
   });
 };
 
+const isProviderVisibleAgentImagePart = (part: any): boolean => {
+  if (part?.type !== "file") return false;
+  if (providerUnsafeImageParts.has(part)) return false;
+  const mediaType = part.mediaType ?? "";
+  if (!isSupportedImageMediaType(mediaType)) return false;
+
+  const size =
+    typeof part.size === "number"
+      ? part.size
+      : typeof part.sizeBytes === "number"
+        ? part.sizeBytes
+        : 0;
+
+  return !isSandboxOnlyAgentUpload({
+    mode: "agent",
+    size,
+    mediaType,
+  });
+};
+
 const applyModeSpecificTransforms = async (
   messages: UIMessage[],
   mode: ChatMode,
@@ -739,6 +759,8 @@ const applyModeSpecificTransforms = async (
   if (mode === "agent") {
     collectSandboxFiles(messages, sandboxFiles, uploadBasePath, {
       allowLocalDesktopFiles,
+      getAttachmentTagKind: (part) =>
+        isProviderVisibleAgentImagePart(part) ? "inline-image" : "attachment",
     });
     removeNonMediaAndOversizedImageFileParts(messages);
   } else {

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -58,6 +58,13 @@ type UploadSandboxFilesOptions = {
   retryWithFreshSandboxOnTransientFailure?: boolean | (() => boolean);
 };
 
+type SandboxAttachmentTagKind = "attachment" | "inline-image";
+
+type CollectSandboxFilesOptions = {
+  allowLocalDesktopFiles?: boolean;
+  getAttachmentTagKind?: (part: any) => SandboxAttachmentTagKind;
+};
+
 const MAX_UPLOAD_FAILURE_CAUSE_LENGTH = 1000;
 
 const logLocalAttachmentDebug = (
@@ -172,6 +179,27 @@ const getLastUserMessageIndex = (messages: UIMessage[]): number => {
   return -1;
 };
 
+const formatSandboxAttachmentTag = (
+  sanitizedName: string,
+  localPath: string,
+): string =>
+  `<attachment filename="${sanitizedName}" local_path="${localPath}" />`;
+
+const formatInlineImageAttachmentTag = (
+  sanitizedName: string,
+  localPath: string,
+): string =>
+  `<inline_image_attachment filename="${sanitizedName}" sandbox_path="${localPath}" already_visible_to_model="true" use_sandbox_path_for="file_operations_only" />`;
+
+const formatSandboxFileTag = (
+  kind: SandboxAttachmentTagKind,
+  sanitizedName: string,
+  localPath: string,
+): string =>
+  kind === "inline-image"
+    ? formatInlineImageAttachmentTag(sanitizedName, localPath)
+    : formatSandboxAttachmentTag(sanitizedName, localPath);
+
 export const sanitizeFilenameForTerminal = (filename: string): string => {
   const basename = filename.split(/[/\\]/g).pop() ?? "file";
   const lastDotIndex = basename.lastIndexOf(".");
@@ -209,7 +237,7 @@ export const collectSandboxFiles = (
   updatedMessages: UIMessage[],
   sandboxFiles: SandboxFile[],
   uploadBasePath: string = getUploadBasePath(undefined),
-  options: { allowLocalDesktopFiles?: boolean } = {},
+  options: CollectSandboxFilesOptions = {},
 ): void => {
   const lastUserIdx = getLastUserMessageIndex(updatedMessages);
   if (lastUserIdx === -1) return;
@@ -239,9 +267,7 @@ export const collectSandboxFiles = (
             localPath,
           });
         }
-        tags.push(
-          `<attachment filename="${sanitizedName}" local_path="${localPath}" />`,
-        );
+        tags.push(formatSandboxAttachmentTag(sanitizedName, localPath));
         return;
       }
 
@@ -255,7 +281,11 @@ export const collectSandboxFiles = (
           sandboxFiles.push({ kind: "url", url: part.url, localPath });
         }
         tags.push(
-          `<attachment filename="${sanitizedName}" local_path="${localPath}" />`,
+          formatSandboxFileTag(
+            options.getAttachmentTagKind?.(part) ?? "attachment",
+            sanitizedName,
+            localPath,
+          ),
         );
       }
     });
@@ -363,9 +393,7 @@ export const prepareLocalDesktopAttachmentsForTrigger = (
           localPath,
         });
       }
-      tags.push(
-        `<attachment filename="${sanitizedName}" local_path="${localPath}" />`,
-      );
+      tags.push(formatSandboxAttachmentTag(sanitizedName, localPath));
     });
 
     if (tags.length > 0) {


### PR DESCRIPTION
## Summary
- mark provider-visible Agent image attachments as `inline_image_attachment` instead of generic sandbox-only attachments
- keep sandbox staging for those images, but describe the sandbox path as file-operations-only so the model can answer from the inline image without re-viewing it
- add Agent prompt guidance and regression coverage for small image attachments

## Testing
- `./node_modules/.bin/jest lib/utils/__tests__/file-transform-utils.test.ts lib/__tests__/system-prompt.test.ts --runInBand`
- `./node_modules/.bin/prettier --check lib/utils/sandbox-file-utils.ts lib/utils/file-transform-utils.ts lib/system-prompt.ts lib/utils/__tests__/file-transform-utils.test.ts lib/__tests__/system-prompt.test.ts`
- `./node_modules/.bin/eslint lib/utils/sandbox-file-utils.ts lib/utils/file-transform-utils.ts lib/system-prompt.ts lib/utils/__tests__/file-transform-utils.test.ts lib/__tests__/system-prompt.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint app lib types __mocks__ --ext .ts,.tsx,.js,.jsx` (passes with existing warnings)

## Manual verification
- In Agent mode, attach a small valid screenshot and ask what is in the image.
- Confirm the model answers from the image without first calling the file view action just to inspect it.
- Ask for a filesystem operation on the same image, such as metadata extraction, and confirm the sandbox path is still available for tool use.
