### PR TITLE
Make subscription cancellation idempotent

### DIFF
--- a/app/components/CancelSubscriptionDialog.tsx
+++ b/app/components/CancelSubscriptionDialog.tsx
@@ -47,6 +47,7 @@ type CancelSubscriptionDialogProps = {
 
 type CancellationResult = {
   currentPeriodEnd?: number;
+  alreadyScheduled?: boolean;
 };
 
 type CancellationStep = "feedback" | "confirm";
@@ -188,8 +189,13 @@ export const CancelSubscriptionDialog = ({
       }
       setCancellationResult({
         currentPeriodEnd: result.currentPeriodEnd,
+        alreadyScheduled: result.alreadyScheduled,
       });
-      toast.success("Subscription scheduled to cancel");
+      toast.success(
+        result.alreadyScheduled
+          ? "Subscription already scheduled to cancel"
+          : "Subscription scheduled to cancel",
+      );
     } catch (error) {
       if (!openRef.current || requestIdRef.current !== requestId) {
         return;

--- a/lib/actions/__tests__/cancel-subscription.test.ts
+++ b/lib/actions/__tests__/cancel-subscription.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import {
+  describe,
+  expect,
+  it,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
 
 const mockListSubscriptions = jest.fn();
 const mockUpdateSubscription = jest.fn();
@@ -31,6 +39,8 @@ jest.mock("@/lib/posthog/server", () => ({
 }));
 
 describe("cancelSubscriptionAction", () => {
+  const originalConvexServiceRoleKey = process.env.CONVEX_SERVICE_ROLE_KEY;
+
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.CONVEX_SERVICE_ROLE_KEY;
@@ -43,6 +53,14 @@ describe("cancelSubscriptionAction", () => {
       },
       stripeCustomerId: "cus_123",
     } as never);
+  });
+
+  afterEach(() => {
+    if (originalConvexServiceRoleKey === undefined) {
+      delete process.env.CONVEX_SERVICE_ROLE_KEY;
+    } else {
+      process.env.CONVEX_SERVICE_ROLE_KEY = originalConvexServiceRoleKey;
+    }
   });
 
   it("returns success without updating Stripe when cancellation is already scheduled", async () => {
@@ -145,6 +163,15 @@ describe("cancelSubscriptionAction", () => {
         feedback: "other",
       },
     });
-    expect(mockPostHogEvent).toHaveBeenCalledTimes(2);
+    expect(mockPostHogEvent).toHaveBeenNthCalledWith(
+      1,
+      PAID_FUNNEL_EVENTS.cancellationReasonSubmitted,
+      expect.any(Object),
+    );
+    expect(mockPostHogEvent).toHaveBeenNthCalledWith(
+      2,
+      PAID_FUNNEL_EVENTS.cancellationCompleted,
+      expect.any(Object),
+    );
   });
 });

--- a/lib/actions/__tests__/cancel-subscription.test.ts
+++ b/lib/actions/__tests__/cancel-subscription.test.ts
@@ -33,6 +33,7 @@ jest.mock("@/lib/posthog/server", () => ({
 describe("cancelSubscriptionAction", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    delete process.env.CONVEX_SERVICE_ROLE_KEY;
 
     mockGetBillingActionContext.mockResolvedValue({
       organizationId: "org_123",
@@ -91,5 +92,59 @@ describe("cancelSubscriptionAction", () => {
     });
     expect(mockUpdateSubscription).not.toHaveBeenCalled();
     expect(mockPostHogEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns alreadyScheduled false after scheduling a new cancellation", async () => {
+    mockListSubscriptions.mockResolvedValue({
+      data: [
+        {
+          id: "sub_123",
+          status: "active",
+          cancel_at_period_end: false,
+          current_period_end: 1_782_444_800,
+          items: {
+            data: [
+              {
+                price: {
+                  id: "price_pro",
+                  lookup_key: "pro-monthly-plan",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } as never);
+    mockUpdateSubscription.mockResolvedValue({
+      id: "sub_123",
+      cancel_at_period_end: true,
+      current_period_end: 1_782_444_800,
+      cancellation_details: {},
+    } as never);
+
+    const { default: cancelSubscriptionAction } =
+      await import("../cancel-subscription");
+
+    await expect(
+      cancelSubscriptionAction({
+        cancellationReason: {
+          reasonCategory: "other",
+          reasonDetails: "Done for now",
+        },
+      }),
+    ).resolves.toEqual({
+      canceled: true,
+      cancelAtPeriodEnd: true,
+      currentPeriodEnd: 1_782_444_800_000,
+      alreadyScheduled: false,
+    });
+
+    expect(mockUpdateSubscription).toHaveBeenCalledWith("sub_123", {
+      cancel_at_period_end: true,
+      cancellation_details: {
+        feedback: "other",
+      },
+    });
+    expect(mockPostHogEvent).toHaveBeenCalledTimes(2);
   });
 });

--- a/lib/actions/__tests__/cancel-subscription.test.ts
+++ b/lib/actions/__tests__/cancel-subscription.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+
+const mockListSubscriptions = jest.fn();
+const mockUpdateSubscription = jest.fn();
+const mockGetBillingActionContext = jest.fn();
+const mockPostHogEvent = jest.fn();
+
+jest.mock("@/app/api/stripe", () => ({
+  stripe: {
+    subscriptions: {
+      list: mockListSubscriptions,
+      update: mockUpdateSubscription,
+    },
+  },
+}));
+
+jest.mock("@/lib/actions/billing-context", () => ({
+  getBillingActionContext: mockGetBillingActionContext,
+}));
+
+jest.mock("@/lib/db/convex-client", () => ({
+  getConvexClient: jest.fn(),
+}));
+
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    event: mockPostHogEvent,
+  },
+}));
+
+describe("cancelSubscriptionAction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetBillingActionContext.mockResolvedValue({
+      organizationId: "org_123",
+      user: {
+        id: "user_123",
+        createdAt: "2026-06-01T00:00:00.000Z",
+      },
+      stripeCustomerId: "cus_123",
+    } as never);
+  });
+
+  it("returns success without updating Stripe when cancellation is already scheduled", async () => {
+    mockListSubscriptions.mockResolvedValue({
+      data: [
+        {
+          id: "sub_123",
+          status: "active",
+          cancel_at_period_end: true,
+          current_period_end: 1_782_444_800,
+          items: {
+            data: [
+              {
+                price: {
+                  id: "price_pro",
+                  lookup_key: "pro-monthly-plan",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } as never);
+
+    const { default: cancelSubscriptionAction } =
+      await import("../cancel-subscription");
+
+    await expect(
+      cancelSubscriptionAction({
+        cancellationReason: {
+          reasonCategory: "other",
+          reasonDetails: "Already handled",
+        },
+      }),
+    ).resolves.toEqual({
+      canceled: true,
+      cancelAtPeriodEnd: true,
+      currentPeriodEnd: 1_782_444_800_000,
+      alreadyScheduled: true,
+    });
+
+    expect(mockListSubscriptions).toHaveBeenCalledWith({
+      customer: "cus_123",
+      status: "all",
+      limit: 10,
+      expand: ["data.items.data.price"],
+    });
+    expect(mockUpdateSubscription).not.toHaveBeenCalled();
+    expect(mockPostHogEvent).not.toHaveBeenCalled();
+  });
+});

--- a/lib/actions/cancel-subscription.ts
+++ b/lib/actions/cancel-subscription.ts
@@ -269,5 +269,6 @@ export default async function cancelSubscriptionAction(
     currentPeriodEnd:
       currentPeriodEndMs(updatedSubscription) ??
       subscriptionContext.currentPeriodEnd,
+    alreadyScheduled: false,
   };
 }

--- a/lib/actions/cancel-subscription.ts
+++ b/lib/actions/cancel-subscription.ts
@@ -32,6 +32,7 @@ type SubscriptionContext = {
   plan?: string;
   tier?: SubscriptionTier;
   currentPeriodEnd?: number;
+  cancelAtPeriodEnd: boolean;
 };
 
 function parseCancellationReasonInput(
@@ -102,10 +103,6 @@ async function getActiveSubscriptionContext(
     throw new Error("No active subscription found");
   }
 
-  if (currentSubscription.cancel_at_period_end) {
-    throw new Error("Your subscription is already scheduled to cancel");
-  }
-
   const price = currentSubscription.items.data[0]?.price;
   return {
     id: currentSubscription.id,
@@ -113,6 +110,7 @@ async function getActiveSubscriptionContext(
     plan: price?.lookup_key ?? undefined,
     tier: subscriptionTierFromLookupKey(price?.lookup_key),
     currentPeriodEnd: currentPeriodEndMs(currentSubscription),
+    cancelAtPeriodEnd: currentSubscription.cancel_at_period_end === true,
   };
 }
 
@@ -136,6 +134,15 @@ export default async function cancelSubscriptionAction(
     await getBillingActionContext();
   const subscriptionContext =
     await getActiveSubscriptionContext(stripeCustomerId);
+
+  if (subscriptionContext.cancelAtPeriodEnd) {
+    return {
+      canceled: true,
+      cancelAtPeriodEnd: true,
+      currentPeriodEnd: subscriptionContext.currentPeriodEnd,
+      alreadyScheduled: true,
+    };
+  }
 
   const now = Date.now();
   const accountCreatedAt = parseCreatedAtMs(user);


### PR DESCRIPTION
## Summary
- return a successful no-op when Stripe already has `cancel_at_period_end=true` instead of throwing a Server Action error
- surface an "already scheduled" success toast for repeat cancellation attempts
- add an action-level regression test that proves the already-scheduled path does not call Stripe subscription update or emit duplicate cancellation analytics

## Why
A repeat cancel attempt for a subscription already scheduled to cancel currently throws `Your subscription is already scheduled to cancel`, which Vercel records as a 500 on `/`. The Stripe state is valid; our action should be idempotent and return the existing cancellation status.

## Validation
- `./node_modules/.bin/jest lib/actions/__tests__/cancel-subscription.test.ts app/components/__tests__/CancelSubscriptionDialog.test.tsx --runInBand`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint lib/actions/cancel-subscription.ts app/components/CancelSubscriptionDialog.tsx lib/actions/__tests__/cancel-subscription.test.ts`
- `./node_modules/.bin/prettier --check lib/actions/cancel-subscription.ts app/components/CancelSubscriptionDialog.tsx lib/actions/__tests__/cancel-subscription.test.ts`

## Manual verification
- In an account whose Stripe subscription already has `cancel_at_period_end=true`, open Settings -> Account -> Manage -> Cancel subscription.
- Submit the dialog.
- Confirm the request does not log a 500 and the UI shows that the subscription is already scheduled to cancel.
- In an account with an active subscription that is not scheduled to cancel, submit the dialog and confirm Stripe is updated with `cancel_at_period_end=true` as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription cancellation handling when a cancellation was already scheduled.
  * Updated the cancellation flow to return a clear “already scheduled” outcome without running the full cancellation pipeline.
  * Updated the confirmation toast to show the correct message when the subscription is already set to end.
* **Tests**
  * Added Jest coverage for cancellation behavior for both “already scheduled” and “not yet scheduled” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->