### PR TITLE
Fix agent resume leak on fast chat switches

### DIFF
--- a/app/components/DataStreamProvider.tsx
+++ b/app/components/DataStreamProvider.tsx
@@ -9,16 +9,20 @@ import React, {
 } from "react";
 import type { DataUIPart } from "ai";
 
+export type ScopedDataUIPart = DataUIPart<any> & {
+  __chatId?: string;
+};
+
 // --- State context (changes frequently during streaming) ---
 interface DataStreamStateValue {
-  dataStream: DataUIPart<any>[];
+  dataStream: ScopedDataUIPart[];
   isAutoResuming: boolean;
   autoContinueCount: number;
 }
 
 // --- Dispatch context (stable references, never causes re-renders) ---
 interface DataStreamDispatchValue {
-  setDataStream: React.Dispatch<React.SetStateAction<DataUIPart<any>[]>>;
+  setDataStream: React.Dispatch<React.SetStateAction<ScopedDataUIPart[]>>;
   setIsAutoResuming: React.Dispatch<React.SetStateAction<boolean>>;
   setAutoContinueCount: React.Dispatch<React.SetStateAction<number>>;
 }
@@ -33,7 +37,7 @@ export function DataStreamProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [dataStream, setDataStream] = useState<DataUIPart<any>[]>([]);
+  const [dataStream, setDataStream] = useState<ScopedDataUIPart[]>([]);
   const [isAutoResuming, setIsAutoResuming] = useState<boolean>(false);
   const [autoContinueCount, setAutoContinueCount] = useState<number>(0);
 

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -406,8 +406,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     paginatedMessages.results &&
     paginatedMessages.results.length > 0 &&
     paginatedMessages.results.every(
-      (message: any) =>
-        message.chat_id === undefined || message.chat_id === chatId,
+      (message: any) => message.chat_id === chatId,
     )
       ? paginatedMessages.results
       : undefined;

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -129,7 +129,8 @@ type StreamingAction =
       type: "SET_RATE_LIMIT_WARNING";
       payload: StreamingEphemeralState["rateLimitWarning"];
     }
-  | { type: "RESET_ON_FINISH" };
+  | { type: "RESET_ON_FINISH" }
+  | { type: "RESET_ON_CHAT_CHANGE" };
 
 const initialStreamingState: StreamingEphemeralState = {
   uploadStatus: null,
@@ -158,6 +159,15 @@ function streamingReducer(
         uploadStatus: null,
         summarizationStatus: null,
       };
+    case "RESET_ON_CHAT_CHANGE":
+      if (
+        state.uploadStatus === null &&
+        state.summarizationStatus === null &&
+        state.rateLimitWarning === null
+      ) {
+        return state;
+      }
+      return initialStreamingState;
     default:
       return state;
   }
@@ -744,6 +754,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   useEffect(() => {
     setDataStream([]);
     setIsAutoResuming(false);
+    dispatchStreaming({ type: "RESET_ON_CHAT_CHANGE" });
   }, [chatId, setDataStream, setIsAutoResuming]);
 
   useEffect(() => {
@@ -1094,12 +1105,12 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     ) {
       return;
     }
-    if (!paginatedMessages.results || paginatedMessages.results.length === 0) {
+    if (!paginatedMessageResults || paginatedMessageResults.length === 0) {
       return;
     }
 
     const uiMessages = convertToUIMessages(
-      [...paginatedMessages.results].reverse(),
+      [...paginatedMessageResults].reverse(),
     );
 
     // Skip if useChat already has the same messages (same IDs, same part count).
@@ -1149,7 +1160,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     if (isExistingChat) {
       setMessages(uiMessages);
     }
-  }, [paginatedMessages.results, setMessages, isExistingChat, chatId]);
+  }, [paginatedMessageResults, setMessages, isExistingChat, chatId]);
 
   const { scrollRef, contentRef, scrollToBottom, isAtBottom } =
     useMessageScroll();

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -199,6 +199,7 @@ function getLatestTodoWriteOutput(messages: ChatMessage[]):
 // Without this boundary, Chat subscribes to DataStreamStateContext
 // through these hooks and re-renders on every stream chunk.
 function StreamEffects({
+  chatId,
   autoResume,
   serverMessages,
   resumeStream,
@@ -214,6 +215,7 @@ function StreamEffects({
   resetRef,
   hasActiveStream,
 }: {
+  chatId: string;
   autoResume: boolean;
   serverMessages: ChatMessage[];
   resumeStream: UseChatHelpers<ChatMessage>["resumeStream"];
@@ -233,6 +235,7 @@ function StreamEffects({
   hasActiveStream: boolean | undefined;
 }) {
   useAutoResume({
+    chatId,
     autoResume,
     initialMessages: serverMessages,
     resumeStream,
@@ -241,6 +244,7 @@ function StreamEffects({
   });
 
   const { resetAutoContinueCount } = useAutoContinue({
+    chatId,
     status,
     chatMode,
     sendMessage,
@@ -386,24 +390,38 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     shouldFetchMessages ? { id: chatId } : "skip",
   );
 
+  const chatDataForCurrentChat =
+    chatData && (chatData as any).id === chatId ? chatData : undefined;
+  const paginatedMessageResults =
+    paginatedMessages.results &&
+    paginatedMessages.results.length > 0 &&
+    paginatedMessages.results.every(
+      (message: any) =>
+        message.chat_id === undefined || message.chat_id === chatId,
+    )
+      ? paginatedMessages.results
+      : undefined;
+
   // Use the shared local sandbox connection subscription when validating a saved non-E2B sandbox.
-  const storedSandboxType = (chatData as any)?.sandbox_type as
+  const storedSandboxType = (chatDataForCurrentChat as any)?.sandbox_type as
     | string
     | undefined;
 
   // Prefer the mid-stream title — the server seeds chatData.title with the
   // user's first message before generation completes, which would otherwise
   // flicker into the header on abort.
-  const chatTitle = streamedTitle ?? chatData?.title ?? null;
+  const chatTitle = streamedTitle ?? chatDataForCurrentChat?.title ?? null;
   const activeTriggerRunRef = useLatestRef(
-    (chatData as any)?.active_trigger_run_id as string | undefined,
+    (chatDataForCurrentChat as any)?.active_trigger_run_id as
+      | string
+      | undefined,
   );
 
   // Convert paginated Convex messages to UI format for useChat and useAutoResume
   // Messages come from server in descending order (newest first from pagination); reverse for chronological order
   const serverMessages: ChatMessage[] =
-    paginatedMessages.results && paginatedMessages.results.length > 0
-      ? convertToUIMessages([...paginatedMessages.results].reverse())
+    paginatedMessageResults && paginatedMessageResults.length > 0
+      ? convertToUIMessages([...paginatedMessageResults].reverse())
       : [];
 
   // State to prevent double-processing of queue
@@ -413,6 +431,16 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   // Ref to track if user manually stopped - prevents auto-processing until new message submitted
   const hasManuallyStoppedRef = useRef(false);
   const messagesRef = useRef<ChatMessage[]>([]);
+  const isChatMountedRef = useRef(false);
+  const activeChatIdRef = useRef(chatId);
+  activeChatIdRef.current = chatId;
+
+  useEffect(() => {
+    isChatMountedRef.current = true;
+    return () => {
+      isChatMountedRef.current = false;
+    };
+  }, []);
 
   // Ref for setMessages — needed by DefaultChatTransport which is created before useChat returns
   const setMessagesRef = useRef<(messages: any[]) => void>(() => {});
@@ -545,7 +573,10 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     transport: transportRef.current,
 
     onData: (dataPart) => {
-      setDataStream((ds) => (ds ? [...ds, dataPart] : []));
+      if (!isChatMountedRef.current || activeChatIdRef.current !== chatId) {
+        return;
+      }
+      setDataStream((ds) => [...ds, { ...dataPart, __chatId: chatId }]);
       switch (dataPart.type) {
         case "data-upload-status": {
           const uploadData = dataPart.data as {
@@ -694,6 +725,39 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   // changes, not on status transitions — avoiding the stale-data overwrite on stream stop.
   const statusRef = useRef(status);
   statusRef.current = status;
+  const stopRef = useRef(stop);
+  stopRef.current = stop;
+  const shouldUseAgentLongForCurrentChat =
+    shouldUseAgentLong &&
+    (!isExistingChat ||
+      (!!chatDataForCurrentChat &&
+        (!!chatDataForCurrentChat.active_trigger_run_id ||
+          (chatDataForCurrentChat as any).default_model_slug === "agent" ||
+          (chatDataForCurrentChat as any).default_model_slug ===
+            "agent-long")));
+  const shouldUseAgentLongForCurrentChatRef = useRef(
+    shouldUseAgentLongForCurrentChat,
+  );
+  shouldUseAgentLongForCurrentChatRef.current =
+    shouldUseAgentLongForCurrentChat;
+
+  useEffect(() => {
+    setDataStream([]);
+    setIsAutoResuming(false);
+  }, [chatId, setDataStream, setIsAutoResuming]);
+
+  useEffect(() => {
+    return () => {
+      if (
+        shouldUseAgentLongForCurrentChatRef.current &&
+        (statusRef.current === "streaming" || statusRef.current === "submitted")
+      ) {
+        stopRef.current();
+      }
+      setDataStream([]);
+      setIsAutoResuming(false);
+    };
+  }, [setDataStream, setIsAutoResuming]);
 
   const agentLongMessageFingerprint = getAgentLongMessageFingerprint(messages);
   const agentLongMessageFingerprintRef = useRef(agentLongMessageFingerprint);
@@ -716,7 +780,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   useEffect(() => {
     if (
       status !== "streaming" ||
-      !shouldUseAgentLong ||
+      !shouldUseAgentLongForCurrentChat ||
       temporaryChatsEnabled
     ) {
       return;
@@ -784,7 +848,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     chatId,
     isExistingChatRef,
     setIsAutoResuming,
-    shouldUseAgentLong,
+    shouldUseAgentLongForCurrentChat,
     status,
     stop,
     temporaryChatsEnabled,
@@ -1302,8 +1366,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const isTempChat = !isExistingChat && temporaryChatsEnabled;
 
   // Get branched chat info directly from chatData (no additional query needed)
-  const branchedFromChatId = chatData?.branched_from_chat_id;
-  const branchedFromChatTitle = (chatData as any)?.branched_from_title;
+  const branchedFromChatId = chatDataForCurrentChat?.branched_from_chat_id;
+  const branchedFromChatTitle = (chatDataForCurrentChat as any)
+    ?.branched_from_title;
 
   // Check if we tried to load an existing chat but it doesn't exist or doesn't belong to user
   const isChatNotFound =
@@ -1316,6 +1381,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     <ConvexErrorBoundary>
       <StreamEffects
         key={chatId}
+        chatId={chatId}
         autoResume={autoResume}
         serverMessages={serverMessages}
         resumeStream={resumeStream}
@@ -1330,9 +1396,10 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
         selectedModel={requestSelectedModel}
         resetRef={resetAutoContinueRef}
         hasActiveStream={
-          chatData === undefined
+          chatData === undefined || (chatData && !chatDataForCurrentChat)
             ? undefined
-            : !!chatData?.active_stream_id || !!chatData?.active_trigger_run_id
+            : !!chatDataForCurrentChat?.active_stream_id ||
+              !!chatDataForCurrentChat?.active_trigger_run_id
         }
       />
       <div className="flex min-h-0 flex-1 w-full flex-col bg-background overflow-hidden">
@@ -1345,7 +1412,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
               hasActiveChat={isExistingChat}
               chatTitle={chatTitle}
               id={chatId}
-              chatData={chatData}
+              chatData={chatDataForCurrentChat}
               chatSidebarOpen={chatSidebarOpen}
               isExistingChat={isExistingChat}
               isChatNotFound={isChatNotFound}
@@ -1388,11 +1455,14 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
                   isTemporaryChat={isTempChat}
                   isMobile={isMobile}
                   tempChatFileDetails={tempChatFileDetails}
-                  finishReason={chatData?.finish_reason}
+                  finishReason={chatDataForCurrentChat?.finish_reason}
                   agentRunSpendCapWarning={agentRunSpendCapWarning}
                   uploadStatus={uploadStatus}
                   summarizationStatus={summarizationStatus}
-                  mode={chatMode ?? (chatData as any)?.default_model_slug}
+                  mode={
+                    chatMode ??
+                    (chatDataForCurrentChat as any)?.default_model_slug
+                  }
                   chatTitle={chatTitle}
                   branchedFromChatId={branchedFromChatId}
                   branchedFromChatTitle={branchedFromChatTitle}

--- a/app/hooks/__tests__/useAutoContinue.test.ts
+++ b/app/hooks/__tests__/useAutoContinue.test.ts
@@ -8,7 +8,7 @@ import {
 import { useAutoContinue, MAX_AUTO_CONTINUES } from "../useAutoContinue";
 import type { UseAutoContinueParams } from "../useAutoContinue";
 
-type DataStreamEntry = { type: string; data?: unknown };
+type DataStreamEntry = { type: string; data?: unknown; __chatId?: string };
 
 function useTestHarness(params: UseAutoContinueParams) {
   const autoContinue = useAutoContinue(params);
@@ -26,6 +26,7 @@ function buildParams(
   overrides: Partial<UseAutoContinueParams> = {},
 ): UseAutoContinueParams {
   return {
+    chatId: "chat-1",
     status: "ready",
     chatMode: "agent",
     sendMessage: jest.fn(),
@@ -69,6 +70,31 @@ describe("useAutoContinue", () => {
     pushAutoContinue(result);
 
     expect(result.current.isAutoResuming).toBe(true);
+  });
+
+  it("ignores data-auto-continue from another chat", () => {
+    const sendMessage = jest.fn();
+    let params = buildParams({ status: "streaming", sendMessage });
+    const { result, rerender } = renderHook(
+      (p: UseAutoContinueParams) => useTestHarness(p),
+      { initialProps: params, wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.setDataStream([
+        { type: "data-auto-continue", data: {}, __chatId: "other-chat" },
+      ] as any);
+    });
+
+    expect(result.current.isAutoResuming).toBe(false);
+
+    params = { ...params, status: "ready" };
+    rerender(params);
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it("sends message with full body when signal arrives during streaming then status becomes ready", () => {

--- a/app/hooks/useAutoContinue.ts
+++ b/app/hooks/useAutoContinue.ts
@@ -5,12 +5,14 @@ import type { ChatStatus, MessageMetadata, Todo } from "@/types";
 import {
   useDataStreamState,
   useDataStreamDispatch,
+  type ScopedDataUIPart,
 } from "@/app/components/DataStreamProvider";
 import { useLatestRef } from "./useLatestRef";
 
 export const MAX_AUTO_CONTINUES = 5;
 
 export interface UseAutoContinueParams {
+  chatId: string;
   status: ChatStatus;
   chatMode: string;
   sendMessage: (
@@ -25,6 +27,7 @@ export interface UseAutoContinueParams {
 }
 
 export function useAutoContinue({
+  chatId,
   status,
   chatMode,
   sendMessage,
@@ -45,16 +48,25 @@ export function useAutoContinue({
   const temporaryChatsEnabledRef = useLatestRef(temporaryChatsEnabled);
   const sandboxPreferenceRef = useLatestRef(sandboxPreference);
   const selectedModelRef = useLatestRef(selectedModel);
+  const isPartForCurrentChat = (part: ScopedDataUIPart) =>
+    part.__chatId === undefined || part.__chatId === chatId;
+
+  useEffect(() => {
+    pendingAutoContinueRef.current = false;
+    lastProcessedIndexRef.current = 0;
+  }, [chatId]);
 
   // Detect data-auto-continue signal and immediately mark pending
   useEffect(() => {
     if (!dataStream?.length) return;
-    const newParts = dataStream.slice(lastProcessedIndexRef.current);
+    const currentChatDataStream = dataStream.filter(isPartForCurrentChat);
+    const newParts = currentChatDataStream.slice(lastProcessedIndexRef.current);
     if (newParts.some((part) => part.type === "data-auto-continue")) {
       pendingAutoContinueRef.current = true;
       setIsAutoResuming(true);
     }
-    lastProcessedIndexRef.current = dataStream.length;
+    lastProcessedIndexRef.current = currentChatDataStream.length;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataStream, setIsAutoResuming]);
 
   // Fire auto-continue when status is ready and signal was detected.
@@ -95,6 +107,7 @@ export function useAutoContinue({
     dataStream,
     chatMode,
     hasManuallyStoppedRef,
+    setAutoContinueCount,
     setIsAutoResuming,
     sendMessageRef,
     todosRef,

--- a/app/hooks/useAutoResume.ts
+++ b/app/hooks/useAutoResume.ts
@@ -6,9 +6,11 @@ import type { ChatMessage } from "@/types/chat";
 import {
   useDataStreamState,
   useDataStreamDispatch,
+  type ScopedDataUIPart,
 } from "@/app/components/DataStreamProvider";
 
 export interface UseAutoResumeParams {
+  chatId: string;
   autoResume: boolean;
   initialMessages: ChatMessage[];
   resumeStream: UseChatHelpers<ChatMessage>["resumeStream"];
@@ -21,6 +23,7 @@ export interface UseAutoResumeParams {
 }
 
 export function useAutoResume({
+  chatId,
   autoResume,
   initialMessages,
   resumeStream,
@@ -30,6 +33,13 @@ export function useAutoResume({
   const { dataStream } = useDataStreamState();
   const { setIsAutoResuming } = useDataStreamDispatch();
   const hasAutoResumedRef = useRef(false);
+
+  const isPartForCurrentChat = (part: ScopedDataUIPart) =>
+    part.__chatId === undefined || part.__chatId === chatId;
+
+  useEffect(() => {
+    hasAutoResumedRef.current = false;
+  }, [chatId]);
 
   useEffect(() => {
     if (!autoResume || hasAutoResumedRef.current) return;
@@ -50,10 +60,12 @@ export function useAutoResume({
   }, [autoResume, initialMessages.length > 0, hasActiveStream]);
 
   useEffect(() => {
+    if (!autoResume || !hasAutoResumedRef.current) return;
     if (!dataStream) return;
     if (dataStream.length === 0) return;
 
-    const dataPart = dataStream[0];
+    const dataPart = dataStream.find(isPartForCurrentChat);
+    if (!dataPart) return;
     if (dataPart.type === "data-appendMessage") {
       const message = JSON.parse(dataPart.data);
       setMessages([...initialMessages, message]);
@@ -61,5 +73,5 @@ export function useAutoResume({
       setIsAutoResuming(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataStream, initialMessages, setMessages]);
+  }, [autoResume, dataStream, initialMessages, setMessages]);
 }

--- a/app/hooks/useAutoResume.ts
+++ b/app/hooks/useAutoResume.ts
@@ -64,7 +64,10 @@ export function useAutoResume({
     if (!dataStream) return;
     if (dataStream.length === 0) return;
 
-    const dataPart = dataStream.find(isPartForCurrentChat);
+    const dataPart = dataStream.find(
+      (part) =>
+        isPartForCurrentChat(part) && part.type === "data-appendMessage",
+    );
     if (!dataPart) return;
     if (dataPart.type === "data-appendMessage") {
       const message = JSON.parse(dataPart.data);

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -881,6 +881,7 @@ export const getMessagesByChatId = query({
     page: v.array(
       v.object({
         id: v.string(),
+        chat_id: v.string(),
         role: v.union(
           v.literal("user"),
           v.literal("assistant"),
@@ -1007,6 +1008,7 @@ export const getMessagesByChatId = query({
 
         enhancedMessages.push({
           id: message.id,
+          chat_id: message.chat_id,
           role: message.role,
           parts: message.parts,
           created_at: message._creationTime,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -42,6 +42,11 @@ const chatComponentSrc = fs.readFileSync(
   "utf8",
 );
 
+const convexMessagesSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../../convex/messages.ts"),
+  "utf8",
+);
+
 const taskSrc = fs.readFileSync(
   path.resolve(__dirname, "../../../trigger/agent-long.ts"),
   "utf8",
@@ -138,6 +143,23 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(chatComponentSrc).toMatch(/stop\(\)/);
     expect(chatComponentSrc).toMatch(/window\.history\.replaceState/);
     expect(chatComponentSrc).toMatch(/setIsExistingChat\(true\)/);
+  });
+
+  test("guards auto-resume and stream data against stale chat switches", () => {
+    expect(chatComponentSrc).toMatch(/chatDataForCurrentChat/);
+    expect(chatComponentSrc).toMatch(
+      /chatDataForCurrentChat\?\.active_stream_id/,
+    );
+    expect(chatComponentSrc).toMatch(
+      /chatDataForCurrentChat\?\.active_trigger_run_id/,
+    );
+    expect(chatComponentSrc).toMatch(/paginatedMessageResults/);
+    expect(chatComponentSrc).toMatch(/message\.chat_id\s*===\s*chatId/);
+    expect(chatComponentSrc).toMatch(/__chatId:\s*chatId/);
+    expect(chatComponentSrc).toMatch(/activeChatIdRef\.current\s*!==\s*chatId/);
+    expect(chatComponentSrc).toMatch(/shouldUseAgentLongForCurrentChat/);
+    expect(convexMessagesSrc).toMatch(/chat_id:\s*v\.string\(\)/);
+    expect(convexMessagesSrc).toMatch(/chat_id:\s*message\.chat_id/);
   });
 });
 

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -157,6 +157,7 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(chatComponentSrc).not.toMatch(
       /\[\.\.\.paginatedMessages\.results\]\.reverse\(\)/,
     );
+    expect(chatComponentSrc).not.toMatch(/message\.chat_id\s*===\s*undefined/);
     expect(chatComponentSrc).toMatch(/message\.chat_id\s*===\s*chatId/);
     expect(chatComponentSrc).toMatch(/__chatId:\s*chatId/);
     expect(chatComponentSrc).toMatch(/activeChatIdRef\.current\s*!==\s*chatId/);

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -154,6 +154,9 @@ describe("agent-long chat UI — completion reconciliation", () => {
       /chatDataForCurrentChat\?\.active_trigger_run_id/,
     );
     expect(chatComponentSrc).toMatch(/paginatedMessageResults/);
+    expect(chatComponentSrc).not.toMatch(
+      /\[\.\.\.paginatedMessages\.results\]\.reverse\(\)/,
+    );
     expect(chatComponentSrc).toMatch(/message\.chat_id\s*===\s*chatId/);
     expect(chatComponentSrc).toMatch(/__chatId:\s*chatId/);
     expect(chatComponentSrc).toMatch(/activeChatIdRef\.current\s*!==\s*chatId/);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -7,6 +7,7 @@ import { Id } from "@/convex/_generated/dataModel";
 
 export interface MessageRecord {
   id: string;
+  chat_id?: string;
   role: "user" | "assistant" | "system";
   parts: UIMessagePart<any, any>[];
   created_at?: number;


### PR DESCRIPTION
## Summary
- scope chatData/message hydration to the current route chat id during fast sidebar switches
- tag stream data with the emitting chat id and ignore stale Agent resume/auto-continue chunks in other chats
- gate Agent-long completion polling on current-chat Agent evidence and cover the race with regression tests

## Why
A fast switch from a still-loading Agent run back to a normal Ask chat could briefly reuse stale Convex chat data/global stream state. That let the normal chat see the Agent chat's `active_trigger_run_id`, call `resumeStream()`, and start `/api/agent-long/resume` polling while showing streaming UI.

## Validation
- `./node_modules/.bin/jest app/hooks/__tests__/useAutoContinue.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `./node_modules/.bin/prettier --check app/components/chat.tsx app/hooks/useAutoResume.ts app/hooks/useAutoContinue.ts app/components/DataStreamProvider.tsx convex/messages.ts lib/utils.ts app/hooks/__tests__/useAutoContinue.test.ts lib/api/__tests__/agent-long-contracts.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint app/components/chat.tsx app/hooks/useAutoResume.ts app/hooks/useAutoContinue.ts app/components/DataStreamProvider.tsx convex/messages.ts lib/utils.ts app/hooks/__tests__/useAutoContinue.test.ts lib/api/__tests__/agent-long-contracts.test.ts` (passes with existing chat.tsx hook-deps warnings)

## Manual verification
- Open a normal Ask chat and reload the page.
- Switch to a chat with an active streaming Agent run, then quickly switch back before that Agent chat finishes loading content.
- Confirm the normal Ask chat does not show streaming state and no `/api/agent-long/resume` requests are started for it.
- Confirm returning to the Agent chat can still resume/display the in-flight run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming, auto-resume, and auto-continue are now scoped to the currently active conversation to keep behavior consistent across navigation.

* **Bug Fixes**
  * Fixed an issue where streamed content or “data-auto-continue” signals from a different conversation could affect the current chat.
  * Improved reconciliation for long-running agent flows to prevent stale chat updates after switching conversations.

* **Tests**
  * Added/updated coverage to ensure chat-scoped auto-resume/auto-continue and message reconciliation behave correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->