### PR TITLE
Skip legacy PentestGPT subscription webhooks

### DIFF
--- a/app/api/migrate-pentestgpt/__tests__/route.test.ts
+++ b/app/api/migrate-pentestgpt/__tests__/route.test.ts
@@ -198,6 +198,51 @@ describe("POST /api/migrate-pentestgpt", () => {
     );
   });
 
+  it("migrates legacy PentestGPT Pro customers with old userId metadata to HackerAI Pro", async () => {
+    mockListCustomers.mockResolvedValueOnce({
+      data: [
+        {
+          id: "cus_legacy",
+          metadata: {
+            userId: "b8c832c4-3e1e-4a76-89c1-28a5b4f56302",
+          },
+          invoice_settings: {},
+        },
+      ],
+    } as never);
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, showTeamWelcome: false });
+    expect(mockListPrices).toHaveBeenCalledWith({
+      lookup_keys: ["pro-monthly-plan"],
+      expand: ["data.product"],
+    });
+    expect(mockUpdateCustomer).toHaveBeenCalledWith("cus_legacy", {
+      metadata: {
+        workOSOrganizationId: "org_new",
+        source: "pentestgpt-migrated",
+      },
+    });
+    expect(mockUpdateOrganization).toHaveBeenCalledWith({
+      organization: "org_new",
+      stripeCustomerId: "cus_legacy",
+    });
+    expect(mockCreateSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: "cus_legacy",
+        items: [{ price: "price_destination", quantity: 1 }],
+        default_payment_method: "pm_legacy",
+        trial_end: 4_102_444_800,
+        collection_method: "charge_automatically",
+        cancel_at_period_end: false,
+      }),
+    );
+    expect(mockCancelSubscription).toHaveBeenCalledWith("sub_legacy");
+  });
+
   it("does not create or delete WorkOS organizations when destination price is missing", async () => {
     mockListPrices.mockResolvedValueOnce({ data: [] } as never);
 

--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -12,6 +12,7 @@ const mockListPrices = jest.fn();
 const mockListCustomers = jest.fn();
 const mockCreateCustomer = jest.fn();
 const mockRetrieveCustomer = jest.fn();
+const mockUpdateCustomer = jest.fn();
 const mockCreateCheckoutSession = jest.fn();
 const mockPostHogEvent = jest.fn();
 const mockPostHogFlush = jest.fn();
@@ -56,6 +57,7 @@ jest.mock("@/app/api/stripe", () => ({
       list: mockListCustomers,
       create: mockCreateCustomer,
       retrieve: mockRetrieveCustomer,
+      update: mockUpdateCustomer,
     },
     checkout: {
       sessions: {
@@ -118,6 +120,16 @@ describe("POST /api/subscribe", () => {
       id: "cs_123",
       url: "https://stripe.example/checkout",
     } as never);
+    mockUpdateCustomer.mockImplementation(
+      async (
+        customerId: string,
+        params: { metadata?: Record<string, string> },
+      ) =>
+        ({
+          id: customerId,
+          metadata: params.metadata ?? {},
+        }) as never,
+    );
   });
 
   it("rejects existing organization members who are not billing admins", async () => {
@@ -178,6 +190,11 @@ describe("POST /api/subscribe", () => {
       checkoutAttemptId: expect.stringMatching(/^ca_/),
     });
     expect(mockRetrieveCustomer).toHaveBeenCalledWith("cus_existing_org");
+    expect(mockUpdateCustomer).toHaveBeenCalledWith("cus_existing_org", {
+      metadata: {
+        workOSOrganizationId: "org_team",
+      },
+    });
     expect(mockListCustomers).not.toHaveBeenCalled();
     expect(mockCreateCustomer).not.toHaveBeenCalled();
     expect(mockUpdateOrganization).not.toHaveBeenCalled();

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -246,6 +246,15 @@ export const POST = async (req: NextRequest) => {
           { status: 403 },
         );
       }
+
+      if (!customer.metadata.workOSOrganizationId) {
+        customer = await stripe.customers.update(customer.id, {
+          metadata: {
+            ...customer.metadata,
+            workOSOrganizationId: organization.id,
+          },
+        });
+      }
     }
 
     if (!customer) {

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -1,0 +1,318 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+
+const mockConstructEvent = jest.fn();
+const mockRetrieveCustomer = jest.fn();
+const mockRetrieveSubscription = jest.fn();
+const mockUpdateSubscription = jest.fn();
+const mockListMemberships = jest.fn();
+const mockConvexMutation = jest.fn();
+const mockResetRateLimitBuckets = jest.fn();
+const mockStashOldBucketRemaining = jest.fn();
+const mockPopOldBucketRemaining = jest.fn();
+const mockInitProratedBucket = jest.fn();
+const mockClearOrgRemovedUsage = jest.fn();
+const mockPostHogEvent = jest.fn();
+const mockPostHogWarn = jest.fn();
+const mockPostHogError = jest.fn();
+const mockPostHogFlush = jest.fn();
+
+jest.mock("next/server", () => ({
+  after: jest.fn((callback: () => void) => callback()),
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: ResponseInit) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("@/app/api/stripe", () => ({
+  stripe: {
+    webhooks: {
+      constructEvent: mockConstructEvent,
+    },
+    customers: {
+      retrieve: mockRetrieveCustomer,
+    },
+    subscriptions: {
+      retrieve: mockRetrieveSubscription,
+      update: mockUpdateSubscription,
+    },
+  },
+}));
+
+jest.mock("@/app/api/workos", () => ({
+  workos: {
+    userManagement: {
+      listOrganizationMemberships: mockListMemberships,
+    },
+  },
+}));
+
+jest.mock("@/lib/db/convex-client", () => ({
+  getConvexClient: () => ({
+    mutation: mockConvexMutation,
+  }),
+}));
+
+jest.mock("@/convex/_generated/api", () => ({
+  api: {
+    extraUsage: {
+      checkAndMarkWebhook: "extraUsage.checkAndMarkWebhook",
+    },
+    referrals: {
+      awardConversionReward: "referrals.awardConversionReward",
+      setReferralCodesPaidEligibility:
+        "referrals.setReferralCodesPaidEligibility",
+      recordReferralCheckoutSession: "referrals.recordReferralCheckoutSession",
+    },
+    unitEconomics: {
+      recordRevenueEvent: "unitEconomics.recordRevenueEvent",
+      recordPaidStartMix: "unitEconomics.recordPaidStartMix",
+    },
+    cancellationReasons: {
+      recordCancellation: "cancellationReasons.recordCancellation",
+      completeCancellationReason:
+        "cancellationReasons.completeCancellationReason",
+    },
+  },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  resetRateLimitBuckets: mockResetRateLimitBuckets,
+  stashOldBucketRemaining: mockStashOldBucketRemaining,
+  popOldBucketRemaining: mockPopOldBucketRemaining,
+  initProratedBucket: mockInitProratedBucket,
+  clearOrgRemovedUsage: mockClearOrgRemovedUsage,
+}));
+
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: {
+    event: mockPostHogEvent,
+    warn: mockPostHogWarn,
+    error: mockPostHogError,
+    flush: mockPostHogFlush,
+  },
+}));
+
+jest.mock("@/lib/referrals/config", () => ({
+  getReferralRewardConfig: () => ({
+    enabled: false,
+    referrerRewardDollars: 0,
+  }),
+}));
+
+function makeWebhookRequest() {
+  return {
+    text: jest.fn().mockResolvedValue("{}"),
+    headers: {
+      get: jest.fn((name: string) =>
+        name === "stripe-signature" ? "sig_test" : null,
+      ),
+    },
+  } as any;
+}
+
+describe("POST /api/subscription/webhook", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.STRIPE_SUBSCRIPTION_WEBHOOK_SECRET = "whsec_test";
+    process.env.CONVEX_SERVICE_ROLE_KEY = "service_key";
+
+    jest.spyOn(console, "info").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mockConvexMutation.mockResolvedValue({ alreadyProcessed: false } as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.STRIPE_SUBSCRIPTION_WEBHOOK_SECRET;
+    delete process.env.CONVEX_SERVICE_ROLE_KEY;
+  });
+
+  it("skips legacy PentestGPT invoices before resolving the old product as a HackerAI tier", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_invoice_paid_legacy",
+      type: "invoice.paid",
+      data: {
+        object: {
+          id: "in_legacy",
+          customer: "cus_legacy",
+          amount_paid: 2000,
+          currency: "usd",
+          billing_reason: "subscription_cycle",
+          parent: {
+            subscription_details: {
+              subscription: "sub_legacy",
+            },
+          },
+          status_transitions: {
+            paid_at: 1_719_504_000,
+          },
+        },
+      },
+    });
+    mockRetrieveCustomer.mockResolvedValue({
+      deleted: false,
+      id: "cus_legacy",
+      metadata: {
+        userId: "b8c832c4-3e1e-4a76-89c1-28a5b4f56302",
+      },
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(makeWebhookRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ received: true });
+    expect(mockRetrieveCustomer).toHaveBeenCalledWith("cus_legacy");
+    expect(mockRetrieveSubscription).not.toHaveBeenCalled();
+    expect(mockListMemberships).not.toHaveBeenCalled();
+    expect(mockResetRateLimitBuckets).not.toHaveBeenCalled();
+    expect(console.info).toHaveBeenCalledWith(
+      "[Subscription Webhook] invoice.paid: skipping legacy customer invoice in_legacy for customer cus_legacy",
+    );
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "extraUsage.checkAndMarkWebhook",
+      expect.objectContaining({
+        eventId: "evt_invoice_paid_legacy",
+        checkOnly: true,
+      }),
+    );
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "extraUsage.checkAndMarkWebhook",
+      expect.objectContaining({
+        eventId: "evt_invoice_paid_legacy",
+      }),
+    );
+  });
+
+  it("skips old PentestGPT subscription products even after the customer has WorkOS metadata", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_invoice_paid_migrated_legacy",
+      type: "invoice.paid",
+      data: {
+        object: {
+          id: "in_migrated_legacy",
+          customer: "cus_migrated",
+          amount_paid: 2000,
+          currency: "usd",
+          billing_reason: "subscription_cycle",
+          parent: {
+            subscription_details: {
+              subscription: "sub_legacy",
+            },
+          },
+          status_transitions: {
+            paid_at: 1_719_504_000,
+          },
+        },
+      },
+    });
+    mockRetrieveCustomer.mockResolvedValue({
+      deleted: false,
+      id: "cus_migrated",
+      metadata: {
+        workOSOrganizationId: "org_migrated",
+      },
+    } as never);
+    mockListMemberships.mockResolvedValue({
+      autoPagination: jest.fn().mockResolvedValue([{ userId: "user_current" }]),
+    } as never);
+    mockRetrieveSubscription.mockResolvedValue({
+      id: "sub_legacy",
+      metadata: {},
+      items: {
+        data: [
+          {
+            quantity: 1,
+            price: {
+              id: "price_legacy",
+              lookup_key: null,
+              recurring: { interval: "month", interval_count: 1 },
+              product: {
+                id: "prod_legacy",
+                name: "PentestGPT Pro Subscription",
+                metadata: {},
+              },
+            },
+          },
+        ],
+      },
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(makeWebhookRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ received: true });
+    expect(mockRetrieveSubscription).toHaveBeenCalledWith("sub_legacy", {
+      expand: ["items.data.price", "items.data.price.product"],
+    });
+    expect(mockResetRateLimitBuckets).not.toHaveBeenCalled();
+    expect(mockPostHogEvent).not.toHaveBeenCalledWith(
+      "subscription_started",
+      expect.anything(),
+    );
+    expect(console.info).toHaveBeenCalledWith(
+      "[Subscription Webhook] invoice.paid: skipping legacy PentestGPT subscription sub_legacy for invoice in_migrated_legacy",
+    );
+  });
+
+  it("skips deleted subscriptions that do not have a HackerAI price lookup key", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_subscription_deleted_legacy",
+      type: "customer.subscription.deleted",
+      data: {
+        object: {
+          id: "sub_legacy_deleted",
+          customer: "cus_migrated",
+          items: {
+            data: [
+              {
+                price: {
+                  id: "price_legacy",
+                  lookup_key: null,
+                },
+              },
+            ],
+          },
+          metadata: {},
+          cancellation_details: {
+            reason: "cancellation_requested",
+          },
+        },
+      },
+    });
+
+    const { POST } = await import("../route");
+
+    const response = await POST(makeWebhookRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ received: true });
+    expect(mockRetrieveCustomer).not.toHaveBeenCalled();
+    expect(mockListMemberships).not.toHaveBeenCalled();
+    expect(mockPostHogEvent).not.toHaveBeenCalledWith(
+      "subscription_cancelled",
+      expect.anything(),
+    );
+    expect(console.info).toHaveBeenCalledWith(
+      "[Subscription Webhook] subscription.deleted: skipping subscription sub_legacy_deleted without HackerAI price lookup_key for customer cus_migrated",
+    );
+  });
+});

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -76,11 +76,14 @@ jest.mock("@/convex/_generated/api", () => ({
     unitEconomics: {
       recordRevenueEvent: "unitEconomics.recordRevenueEvent",
       recordPaidStartMix: "unitEconomics.recordPaidStartMix",
+      recordPaidStartEvent: "unitEconomics.recordPaidStartEvent",
     },
     cancellationReasons: {
       recordCancellation: "cancellationReasons.recordCancellation",
       completeCancellationReason:
         "cancellationReasons.completeCancellationReason",
+      markCancellationCompleted:
+        "cancellationReasons.markCancellationCompleted",
     },
   },
 }));
@@ -183,18 +186,22 @@ describe("POST /api/subscription/webhook", () => {
     expect(console.info).toHaveBeenCalledWith(
       "[Subscription Webhook] invoice.paid: skipping legacy customer invoice in_legacy for customer cus_legacy",
     );
-    expect(mockConvexMutation).toHaveBeenCalledWith(
+    expect(mockConvexMutation).toHaveBeenNthCalledWith(
+      1,
       "extraUsage.checkAndMarkWebhook",
-      expect.objectContaining({
+      {
+        serviceKey: "service_key",
         eventId: "evt_invoice_paid_legacy",
         checkOnly: true,
-      }),
+      },
     );
-    expect(mockConvexMutation).toHaveBeenCalledWith(
+    expect(mockConvexMutation).toHaveBeenNthCalledWith(
+      2,
       "extraUsage.checkAndMarkWebhook",
-      expect.objectContaining({
+      {
+        serviceKey: "service_key",
         eventId: "evt_invoice_paid_legacy",
-      }),
+      },
     );
   });
 
@@ -239,7 +246,7 @@ describe("POST /api/subscription/webhook", () => {
             quantity: 1,
             price: {
               id: "price_legacy",
-              lookup_key: null,
+              lookup_key: "pro-monthly-plan",
               recurring: { interval: "month", interval_count: 1 },
               product: {
                 id: "prod_legacy",

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -123,11 +123,21 @@ function tierFromProductName(name: string): SubscriptionTier | null {
   return null;
 }
 
+type SubscriptionResolution =
+  | {
+      kind: "resolved";
+      tier: SubscriptionTier;
+      subscription: Stripe.Subscription;
+    }
+  | {
+      kind: "legacy_pentestgpt";
+      subscription: Stripe.Subscription;
+    };
+
 /** Resolve subscription tier and object from a Stripe subscription ID. */
-async function resolveSubscription(subscriptionId: string): Promise<{
-  tier: SubscriptionTier;
-  subscription: Stripe.Subscription;
-} | null> {
+async function resolveSubscription(
+  subscriptionId: string,
+): Promise<SubscriptionResolution | null> {
   try {
     const subscription = await stripe.subscriptions.retrieve(subscriptionId, {
       expand: ["items.data.price", "items.data.price.product"],
@@ -138,7 +148,7 @@ async function resolveSubscription(subscriptionId: string): Promise<{
 
     if (lookupKey) {
       const tier = planLookupKeyToTier(lookupKey);
-      return tier ? { tier, subscription } : null;
+      return tier ? { kind: "resolved", tier, subscription } : null;
     }
 
     // Fallback: infer tier from product name or metadata when lookup_key is missing
@@ -148,6 +158,13 @@ async function resolveSubscription(subscriptionId: string): Promise<{
         ? (product as Stripe.Product)
         : null;
 
+    if (productObj?.name?.toLowerCase().includes("pentestgpt")) {
+      console.info(
+        `[Subscription Webhook] Subscription ${subscriptionId} uses legacy PentestGPT product; skipping HackerAI subscription handling`,
+      );
+      return { kind: "legacy_pentestgpt", subscription };
+    }
+
     const tier =
       (productObj?.metadata?.tier as SubscriptionTier | undefined) ??
       (productObj?.name ? tierFromProductName(productObj.name) : null);
@@ -156,7 +173,7 @@ async function resolveSubscription(subscriptionId: string): Promise<{
       console.warn(
         `[Subscription Webhook] Subscription ${subscriptionId} missing price lookup_key, resolved tier "${tier}" from product fallback`,
       );
-      return { tier, subscription };
+      return { kind: "resolved", tier, subscription };
     }
 
     console.error(
@@ -490,16 +507,33 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
   }
 
   const resetMode = getInvoicePaidBucketResetMode(invoice);
-  const [customerResult, resolved] = await Promise.all([
-    resolveUserIdsFromCustomer(customerId),
-    resolveSubscription(subscriptionId),
-  ]);
-
+  const customerResult = await resolveUserIdsFromCustomer(customerId);
   const { userIds, orgId } = customerResult;
 
-  if (userIds.length === 0 || !resolved) {
+  if (customerResult.reason === "legacy_user_metadata") {
+    console.info(
+      `[Subscription Webhook] invoice.paid: skipping legacy customer invoice ${invoice.id} for customer ${customerId}`,
+    );
+    return;
+  }
+
+  if (userIds.length === 0) {
     console.error(
-      `[Subscription Webhook] Could not resolve users (${userIds.length}) or subscription for invoice ${invoice.id}`,
+      `[Subscription Webhook] Could not resolve users (${customerResult.reason ?? "unknown"}) for invoice ${invoice.id}`,
+    );
+    return;
+  }
+
+  const resolved = await resolveSubscription(subscriptionId);
+  if (!resolved) {
+    console.error(
+      `[Subscription Webhook] Could not resolve subscription ${subscriptionId} for invoice ${invoice.id}`,
+    );
+    return;
+  }
+  if (resolved.kind === "legacy_pentestgpt") {
+    console.info(
+      `[Subscription Webhook] invoice.paid: skipping legacy PentestGPT subscription ${subscriptionId} for invoice ${invoice.id}`,
     );
     return;
   }
@@ -798,6 +832,12 @@ async function handleCheckoutSessionCompleted(
 
   const resolved = await resolveSubscription(subscriptionId);
   if (!resolved) return;
+  if (resolved.kind === "legacy_pentestgpt") {
+    console.info(
+      `[Subscription Webhook] checkout.session.completed: skipping legacy PentestGPT subscription ${subscriptionId}`,
+    );
+    return;
+  }
 
   const price = resolved.subscription.items?.data[0]?.price;
   const existingMetadata = resolved.subscription.metadata ?? {};
@@ -1086,7 +1126,20 @@ async function handleSubscriptionDeleted(
   if (!customerId) return;
 
   const lookupKey = subscription.items?.data[0]?.price?.lookup_key ?? null;
-  const tier = lookupKey ? planLookupKeyToTier(lookupKey) : null;
+  if (!lookupKey) {
+    console.info(
+      `[Subscription Webhook] subscription.deleted: skipping subscription ${subscription.id} without HackerAI price lookup_key for customer ${customerId}`,
+    );
+    return;
+  }
+
+  const tier = planLookupKeyToTier(lookupKey);
+  if (!tier) {
+    console.error(
+      `[Subscription Webhook] subscription.deleted: unknown price lookup_key "${lookupKey}" for subscription ${subscription.id}`,
+    );
+    return;
+  }
 
   const { userIds, orgId, reason } =
     await resolveUserIdsFromCustomer(customerId);

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -146,11 +146,6 @@ async function resolveSubscription(
     const price = subscription.items?.data[0]?.price;
     const lookupKey = price?.lookup_key ?? null;
 
-    if (lookupKey) {
-      const tier = planLookupKeyToTier(lookupKey);
-      return tier ? { kind: "resolved", tier, subscription } : null;
-    }
-
     // Fallback: infer tier from product name or metadata when lookup_key is missing
     const product = price?.product;
     const productObj =
@@ -163,6 +158,11 @@ async function resolveSubscription(
         `[Subscription Webhook] Subscription ${subscriptionId} uses legacy PentestGPT product; skipping HackerAI subscription handling`,
       );
       return { kind: "legacy_pentestgpt", subscription };
+    }
+
+    if (lookupKey) {
+      const tier = planLookupKeyToTier(lookupKey);
+      return tier ? { kind: "resolved", tier, subscription } : null;
     }
 
     const tier =

--- a/lib/__tests__/resolve-customer-users.test.ts
+++ b/lib/__tests__/resolve-customer-users.test.ts
@@ -30,6 +30,7 @@ describe("resolveUserIdsFromCustomer", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -83,6 +84,33 @@ describe("resolveUserIdsFromCustomer", () => {
       reason: "missing_workos_organization_metadata",
     });
     expect(mockListMemberships).not.toHaveBeenCalled();
+  });
+
+  it("classifies legacy user metadata separately from broken WorkOS metadata", async () => {
+    mockRetrieveCustomer.mockResolvedValueOnce({
+      deleted: false,
+      metadata: { userId: "b8c832c4-3e1e-4a76-89c1-28a5b4f56302" },
+    } as never);
+
+    const { resolveUserIdsFromCustomer } =
+      await import("../billing/resolve-customer-users");
+
+    const result = await resolveUserIdsFromCustomer(
+      "cus_legacy",
+      "Test Webhook",
+    );
+
+    expect(result).toEqual({
+      userIds: [],
+      orgId: null,
+      reason: "legacy_user_metadata",
+      legacyUserId: "b8c832c4-3e1e-4a76-89c1-28a5b4f56302",
+    });
+    expect(mockListMemberships).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
+      "[Test Webhook] Customer cus_legacy has legacy user metadata but no workOSOrganizationId metadata",
+    );
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it("returns a deleted-customer reason without querying WorkOS memberships", async () => {

--- a/lib/billing/resolve-customer-users.ts
+++ b/lib/billing/resolve-customer-users.ts
@@ -5,6 +5,7 @@ import Stripe from "stripe";
 /** Why a Stripe customer could not be mapped to active WorkOS users. */
 export type CustomerUserResolutionReason =
   | "customer_deleted"
+  | "legacy_user_metadata"
   | "missing_workos_organization_metadata"
   | "no_active_memberships"
   | "lookup_failed";
@@ -14,7 +15,20 @@ export type CustomerUserResolution = {
   userIds: string[];
   orgId: string | null;
   reason?: CustomerUserResolutionReason;
+  legacyUserId?: string;
 };
+
+const LEGACY_USER_METADATA_KEYS = ["userId", "firebaseUID"] as const;
+
+function legacyUserIdFromMetadata(
+  metadata: Stripe.Metadata | null | undefined,
+): string | null {
+  for (const key of LEGACY_USER_METADATA_KEYS) {
+    const value = metadata?.[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return null;
+}
 
 /** Resolve active WorkOS user IDs for a Stripe customer. */
 export async function resolveUserIdsFromCustomer(
@@ -30,6 +44,19 @@ export async function resolveUserIdsFromCustomer(
     const customer = customerData as Stripe.Customer;
     const orgId = customer.metadata?.workOSOrganizationId ?? null;
     if (!orgId) {
+      const legacyUserId = legacyUserIdFromMetadata(customer.metadata);
+      if (legacyUserId) {
+        console.warn(
+          `[${logPrefix}] Customer ${customerId} has legacy user metadata but no workOSOrganizationId metadata`,
+        );
+        return {
+          userIds: [],
+          orgId: null,
+          reason: "legacy_user_metadata",
+          legacyUserId,
+        };
+      }
+
       console.error(
         `[${logPrefix}] Customer ${customerId} missing workOSOrganizationId metadata`,
       );


### PR DESCRIPTION
## Summary
- classify Stripe customers with legacy `userId`/`firebaseUID` metadata separately from broken HackerAI customer mappings
- skip old PentestGPT subscription webhook events so they do not reset HackerAI usage, record HackerAI paid-start/revenue, or emit false cancellation analytics
- backfill `workOSOrganizationId` on reused HackerAI checkout customers and cover the PentestGPT Pro to HackerAI Pro migration path

## Why
Old PentestGPT Pro subscriptions can still emit Stripe events with products like `PentestGPT Pro Subscription` and only legacy customer metadata. The HackerAI subscription webhook was treating those events as HackerAI Pro because the product name contained `Pro`, then logging missing `workOSOrganizationId`. Those old subscription events should be ignored by HackerAI billing webhooks, while `/api/migrate-pentestgpt` must still migrate eligible users into HackerAI Pro.

## Validation
- `./node_modules/.bin/jest app/api/migrate-pentestgpt/__tests__/route.test.ts lib/__tests__/resolve-customer-users.test.ts app/api/subscribe/__tests__/route.test.ts app/api/subscription/webhook/__tests__/route.test.ts --runInBand`
- `./node_modules/.bin/eslint app/api/migrate-pentestgpt/__tests__/route.test.ts lib/billing/resolve-customer-users.ts lib/__tests__/resolve-customer-users.test.ts app/api/subscription/webhook/route.ts app/api/subscription/webhook/__tests__/route.test.ts app/api/subscribe/route.ts app/api/subscribe/__tests__/route.test.ts`
- `./node_modules/.bin/prettier --check app/api/migrate-pentestgpt/__tests__/route.test.ts lib/billing/resolve-customer-users.ts lib/__tests__/resolve-customer-users.test.ts app/api/subscription/webhook/route.ts app/api/subscription/webhook/__tests__/route.test.ts app/api/subscribe/route.ts app/api/subscribe/__tests__/route.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`

Note: this worktree had no local `node_modules`; validation used temporary symlinks to the main checkout dependency install and removed them afterward. Commit hooks were skipped for the same reason.

## Manual verification
- Replay or send an `invoice.paid` event for an old PentestGPT Pro subscription with only `userId` or `firebaseUID` customer metadata. It should return success and skip HackerAI usage/revenue/paid-start side effects.
- Run `/api/migrate-pentestgpt` as an eligible free HackerAI user whose email owns an active PentestGPT Pro subscription. It should create a HackerAI Pro subscription, link the Stripe customer to the new WorkOS org, and cancel the old PentestGPT subscription.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of legacy billing customers during subscription and migration flows.
  * Existing Stripe customers now retain organization linkage when missing metadata is detected.

* **Bug Fixes**
  * Legacy PentestGPT accounts are now skipped more reliably in billing webhooks, avoiding incorrect downstream billing and analytics actions.
  * Webhook processing now better handles customers with older metadata formats, reducing failed or noisy lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->