### PR TITLE
Stop stale Trigger realtime streams on chat switch

### DIFF
--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { ConvexError } from "convex/values";
 import { useGlobalState } from "../contexts/GlobalState";
@@ -52,6 +52,7 @@ import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { removeDraft } from "@/lib/utils/client-storage";
 import { openSettingsDialog } from "@/lib/utils/settings-dialog";
+import { cancelAgentLongRealtimeStreams } from "@/lib/chat/agent-long-transport";
 import { ShareDialog } from "./ShareDialog";
 import { usePinChat, useUnpinChat } from "../hooks/useChats";
 
@@ -65,6 +66,17 @@ interface ChatItemProps {
   isPinned?: boolean;
   isStreaming?: boolean;
 }
+
+const getRouteChatIdFromPathname = (pathname: string | null): string | null => {
+  const match = pathname?.match(/^\/c\/([^/?#]+)/);
+  const routeChatId = match?.[1];
+  if (!routeChatId) return null;
+  try {
+    return decodeURIComponent(routeChatId);
+  } catch {
+    return routeChatId;
+  }
+};
 
 const ChatItem: React.FC<ChatItemProps> = ({
   id,
@@ -92,14 +104,27 @@ const ChatItem: React.FC<ChatItemProps> = ({
     setChatSidebarOpen,
     initializeNewChat,
     initializeChat,
+    optimisticChatId,
+    setOptimisticChatId,
   } = useGlobalState();
   const isMobile = useIsMobile();
   const renameChat = useMutation(api.chats.renameChat);
   const pinChat = usePinChat();
   const unpinChat = useUnpinChat();
 
-  // Check if this chat is currently active based on URL (usePathname so we re-render when route changes)
-  const isCurrentlyActive = pathname === `/c/${id}`;
+  const routeChatId = getRouteChatIdFromPathname(pathname);
+  const selectedChatId = optimisticChatId ?? routeChatId;
+
+  // Check if this chat is currently active based on URL (usePathname so we re-render when route changes).
+  // During a route transition, prefer the clicked chat immediately so a busy
+  // streaming chat does not keep the old row highlighted until navigation commits.
+  const isCurrentlyActive = selectedChatId === id;
+
+  useEffect(() => {
+    if (optimisticChatId && optimisticChatId === routeChatId) {
+      setOptimisticChatId(null);
+    }
+  }, [optimisticChatId, routeChatId, setOptimisticChatId]);
 
   const handleClick = () => {
     // Don't navigate if dialog is open or dropdown is open
@@ -115,6 +140,10 @@ const ChatItem: React.FC<ChatItemProps> = ({
 
     // Clear input and transient state only when switching to a different chat
     if (!isCurrentlyActive) {
+      setOptimisticChatId(id);
+      if (routeChatId && routeChatId !== id) {
+        cancelAgentLongRealtimeStreams(routeChatId);
+      }
       initializeChat(id);
     }
 

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -29,6 +29,7 @@ import { normalizeMessages } from "@/lib/utils/message-processor";
 import { ChatSDKError } from "@/lib/errors";
 import { fetchWithErrorHandlers, convertToUIMessages } from "@/lib/utils";
 import {
+  cancelAgentLongRealtimeStreams,
   fetchAgentLongStream,
   resumeAgentLongStream,
 } from "@/lib/chat/agent-long-transport";
@@ -744,11 +745,17 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
           (chatDataForCurrentChat as any).default_model_slug === "agent" ||
           (chatDataForCurrentChat as any).default_model_slug ===
             "agent-long")));
-  const shouldUseAgentLongForCurrentChatRef = useRef(
-    shouldUseAgentLongForCurrentChat,
-  );
-  shouldUseAgentLongForCurrentChatRef.current =
-    shouldUseAgentLongForCurrentChat;
+  const stopActiveBrowserStream = useCallback(() => {
+    cancelAgentLongRealtimeStreams(activeChatIdRef.current);
+    if (
+      statusRef.current === "streaming" ||
+      statusRef.current === "submitted"
+    ) {
+      stopRef.current();
+    }
+    setDataStream([]);
+    setIsAutoResuming(false);
+  }, [setDataStream, setIsAutoResuming]);
 
   useEffect(() => {
     setDataStream([]);
@@ -758,16 +765,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
   useEffect(() => {
     return () => {
-      if (
-        shouldUseAgentLongForCurrentChatRef.current &&
-        (statusRef.current === "streaming" || statusRef.current === "submitted")
-      ) {
-        stopRef.current();
-      }
-      setDataStream([]);
-      setIsAutoResuming(false);
+      stopActiveBrowserStream();
     };
-  }, [setDataStream, setIsAutoResuming]);
+  }, [stopActiveBrowserStream]);
 
   const agentLongMessageFingerprint = getAgentLongMessageFingerprint(messages);
   const agentLongMessageFingerprintRef = useRef(agentLongMessageFingerprint);
@@ -873,6 +873,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   // Register a reset function with global state so initializeNewChat can call it
   useEffect(() => {
     const reset = () => {
+      stopActiveBrowserStream();
       setMessages([]);
       setChatId(uuidv4());
       setIsExistingChat(false);
@@ -881,16 +882,18 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       setStreamedTitle(null);
       setAwaitingServerChat(false);
       dispatchStreaming({ type: "RESET_ON_FINISH" });
-      // Clear DataStreamProvider state so stale parts from the previous chat
-      // don't feed into useAutoResume/useAutoContinue in the next conversation.
-      setDataStream([]);
-      setIsAutoResuming(false);
       setHasUserDismissedRateLimitWarning(false);
       resetAutoContinueCount();
     };
     setChatReset(reset);
     return () => setChatReset(null);
-  }, [setChatReset, setMessages, setTodos, resetAutoContinueCount]);
+  }, [
+    setChatReset,
+    setMessages,
+    setTodos,
+    resetAutoContinueCount,
+    stopActiveBrowserStream,
+  ]);
 
   // Reset the one-time initializer when chat changes (must come before chatData effect to handle cached data)
   useEffect(() => {

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -694,6 +694,19 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   // changes, not on status transitions — avoiding the stale-data overwrite on stream stop.
   const statusRef = useRef(status);
   statusRef.current = status;
+  const stopRef = useLatestRef(stop);
+
+  useEffect(() => {
+    const stopCurrentStream = stopRef.current;
+    return () => {
+      if (
+        statusRef.current === "streaming" ||
+        statusRef.current === "submitted"
+      ) {
+        stopCurrentStream();
+      }
+    };
+  }, [stopRef]);
 
   const agentLongMessageFingerprint = getAgentLongMessageFingerprint(messages);
   const agentLongMessageFingerprintRef = useRef(agentLongMessageFingerprint);

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -88,6 +88,8 @@ interface GlobalStateType {
   // Chat sidebar state (left side)
   chatSidebarOpen: boolean;
   setChatSidebarOpen: (open: boolean) => void;
+  optimisticChatId: string | null;
+  setOptimisticChatId: (chatId: string | null) => void;
 
   // Todos state
   todos: Todo[];
@@ -335,6 +337,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   const [chatSidebarOpen, setChatSidebarOpen] = useState(() =>
     chatSidebarStorage.get(isMobile ?? false),
   );
+  const [optimisticChatId, setOptimisticChatId] = useState<string | null>(null);
   const [todos, setTodos] = useState<Todo[]>([]);
   const [isTodoPanelExpanded, setIsTodoPanelExpanded] = useState(false);
   const mergeTodos = useCallback((newTodos: TodoLike[]) => {
@@ -968,6 +971,8 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     setSidebarContent,
     chatSidebarOpen,
     setChatSidebarOpen,
+    optimisticChatId,
+    setOptimisticChatId,
     todos,
     setTodos,
     mergeTodos,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -126,6 +126,15 @@ describe("agent-long-transport — direct UI stream reader", () => {
       /userAborted\s*\|\|\s*timedOutAfterFinish\s*\|\|\s*completedRunDrainElapsed/,
     );
   });
+
+  test("browser stream cancellation releases Trigger realtime subscriptions", () => {
+    expect(transportSrc).toMatch(/cancelRealtimeSubscriptions/);
+    expect(transportSrc).toMatch(/statusSubscription\?\.unsubscribe\?\.\(\)/);
+    expect(transportSrc).toMatch(/streamIterator\?\.return\?\.\(undefined\)/);
+    expect(transportSrc).toMatch(
+      /cancel\(\)\s*\{\s*consumerCanceled\s*=\s*true;[\s\S]*cancelRealtimeSubscriptions\?\.\(\)/,
+    );
+  });
 });
 
 describe("agent-long chat UI — completion reconciliation", () => {
@@ -138,6 +147,13 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(chatComponentSrc).toMatch(/stop\(\)/);
     expect(chatComponentSrc).toMatch(/window\.history\.replaceState/);
     expect(chatComponentSrc).toMatch(/setIsExistingChat\(true\)/);
+  });
+
+  test("stops the local stream when a streaming chat unmounts", () => {
+    expect(chatComponentSrc).toMatch(/const stopRef = useLatestRef\(stop\)/);
+    expect(chatComponentSrc).toMatch(
+      /const stopCurrentStream = stopRef\.current[\s\S]*statusRef\.current\s*===\s*"streaming"[\s\S]*statusRef\.current\s*===\s*"submitted"[\s\S]*stopCurrentStream\(\)/,
+    );
   });
 });
 

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -42,6 +42,16 @@ const chatComponentSrc = fs.readFileSync(
   "utf8",
 );
 
+const chatItemSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../../app/components/ChatItem.tsx"),
+  "utf8",
+);
+
+const globalStateSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../../app/contexts/GlobalState.tsx"),
+  "utf8",
+);
+
 const convexMessagesSrc = fs.readFileSync(
   path.resolve(__dirname, "../../../convex/messages.ts"),
   "utf8",
@@ -139,10 +149,16 @@ describe("agent-long-transport — direct UI stream reader", () => {
 
   test("browser stream cancellation releases Trigger realtime subscriptions", () => {
     expect(transportSrc).toMatch(/cancelRealtimeSubscriptions/);
+    expect(transportSrc).toMatch(/activeAgentLongRealtimeCancels/);
+    expect(transportSrc).toMatch(/cancelAgentLongRealtimeStreams/);
+    expect(transportSrc).toMatch(/registerAgentLongRealtimeCancel/);
     expect(transportSrc).toMatch(/statusSubscription\?\.unsubscribe\?\.\(\)/);
     expect(transportSrc).toMatch(/streamIterator\?\.return\?\.\(undefined\)/);
     expect(transportSrc).toMatch(
-      /cancel\(\)\s*\{\s*consumerCanceled\s*=\s*true;[\s\S]*cancelRealtimeSubscriptions\?\.\(\)/,
+      /cancelConsumerRealtime[\s\S]*consumerCanceled\s*=\s*true/,
+    );
+    expect(transportSrc).toMatch(
+      /cancel\(\)\s*\{[\s\S]*cancelConsumerRealtime\(\)/,
     );
   });
 });
@@ -200,9 +216,27 @@ describe("agent-long chat UI — completion reconciliation", () => {
 
   test("stops the local stream when a streaming chat unmounts", () => {
     expect(chatComponentSrc).toMatch(/const stopRef = useRef\(stop\)/);
+    expect(chatComponentSrc).toMatch(/stopActiveBrowserStream/);
     expect(chatComponentSrc).toMatch(
-      /shouldUseAgentLongForCurrentChatRef\.current[\s\S]*statusRef\.current\s*===\s*"streaming"[\s\S]*statusRef\.current\s*===\s*"submitted"[\s\S]*stopRef\.current\(\)/,
+      /cancelAgentLongRealtimeStreams\(activeChatIdRef\.current\)/,
     );
+    expect(chatComponentSrc).toMatch(
+      /statusRef\.current\s*===\s*"streaming"[\s\S]*statusRef\.current\s*===\s*"submitted"[\s\S]*stopRef\.current\(\)/,
+    );
+    expect(chatComponentSrc).toMatch(
+      /return\s*\(\)\s*=>\s*\{\s*stopActiveBrowserStream\(\);[\s\S]*\}/,
+    );
+  });
+
+  test("sidebar navigation cancels stale agent-long realtime before route commit", () => {
+    expect(chatItemSrc).toMatch(/cancelAgentLongRealtimeStreams/);
+    expect(chatItemSrc).toMatch(/setOptimisticChatId\(id\)/);
+    expect(chatItemSrc).toMatch(/optimisticChatId\s*\?\?\s*routeChatId/);
+    expect(chatItemSrc).toMatch(
+      /routeChatId\s*&&\s*routeChatId\s*!==\s*id[\s\S]*cancelAgentLongRealtimeStreams\(routeChatId\)/,
+    );
+    expect(globalStateSrc).toMatch(/optimisticChatId:\s*string\s*\|\s*null/);
+    expect(globalStateSrc).toMatch(/setOptimisticChatId/);
   });
 
   test("guards auto-resume and stream data against stale chat switches", () => {

--- a/lib/chat/agent-long-transport.ts
+++ b/lib/chat/agent-long-transport.ts
@@ -26,6 +26,67 @@ type RunHandle = {
   chatId?: string;
 };
 
+type AgentLongRealtimeCancel = () => Promise<void> | void;
+
+const activeAgentLongRealtimeCancels = new Map<
+  string,
+  Set<AgentLongRealtimeCancel>
+>();
+
+const registerAgentLongRealtimeCancel = (
+  chatId: string | undefined,
+  cancel: AgentLongRealtimeCancel,
+): (() => void) | undefined => {
+  if (!chatId) return undefined;
+
+  let cancels = activeAgentLongRealtimeCancels.get(chatId);
+  if (!cancels) {
+    cancels = new Set();
+    activeAgentLongRealtimeCancels.set(chatId, cancels);
+  }
+  cancels.add(cancel);
+
+  return () => {
+    const currentCancels = activeAgentLongRealtimeCancels.get(chatId);
+    if (!currentCancels) return;
+    currentCancels.delete(cancel);
+    if (currentCancels.size === 0) {
+      activeAgentLongRealtimeCancels.delete(chatId);
+    }
+  };
+};
+
+export const cancelAgentLongRealtimeStreams = (chatId?: string): void => {
+  const cancels =
+    chatId === undefined
+      ? Array.from(activeAgentLongRealtimeCancels.values()).flatMap((set) =>
+          Array.from(set),
+        )
+      : Array.from(activeAgentLongRealtimeCancels.get(chatId) ?? []);
+
+  for (const cancel of cancels) {
+    void Promise.resolve(cancel()).catch(() => undefined);
+  }
+};
+
+const createLinkedAbortController = (
+  signal: AbortSignal | undefined,
+): { controller: AbortController; cleanup: () => void } => {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+
+  if (signal?.aborted) {
+    abort();
+  } else {
+    signal?.addEventListener("abort", abort, { once: true });
+  }
+
+  return {
+    controller,
+    cleanup: () => signal?.removeEventListener("abort", abort),
+  };
+};
+
 const sseHeaders: HeadersInit = {
   "Content-Type": "text/event-stream",
   "Cache-Control": "no-cache, no-transform",
@@ -88,7 +149,19 @@ const buildSSEResponseFromRun = (
   const encoder = new TextEncoder();
   const chatId = options?.chatId ?? handle.chatId;
   let cancelRealtimeSubscriptions: (() => Promise<void> | void) | undefined;
+  let closeConsumerStream: (() => void) | undefined;
   let consumerCanceled = false;
+  let unregisterRealtimeCancel: (() => void) | undefined;
+  const cancelConsumerRealtime = async () => {
+    consumerCanceled = true;
+    closeConsumerStream?.();
+    await cancelRealtimeSubscriptions?.();
+    unregisterRealtimeCancel?.();
+  };
+  unregisterRealtimeCancel = registerAgentLongRealtimeCancel(
+    chatId,
+    cancelConsumerRealtime,
+  );
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       let closed = false;
@@ -121,6 +194,7 @@ const buildSSEResponseFromRun = (
           // ignore if already closed
         }
       };
+      closeConsumerStream = sendAbortAndClose;
 
       const close = () => {
         if (closed) return;
@@ -516,11 +590,14 @@ const buildSSEResponseFromRun = (
         signal?.removeEventListener("abort", onAbort);
         statusSubscription?.unsubscribe?.();
         cancelRealtimeSubscriptions = undefined;
+        closeConsumerStream = undefined;
+        unregisterRealtimeCancel?.();
       }
     },
     cancel() {
-      consumerCanceled = true;
-      return cancelRealtimeSubscriptions?.();
+      return cancelConsumerRealtime().finally(() => {
+        unregisterRealtimeCancel?.();
+      });
     },
   });
 
@@ -530,31 +607,57 @@ const buildSSEResponseFromRun = (
 export const fetchAgentLongStream = async (
   init: RequestInit | undefined,
 ): Promise<Response> => {
-  const startResponse = await fetchWithErrorHandlers("/api/agent-long", init);
-  if (!startResponse.ok) return startResponse;
-
-  const handle: RunHandle = await startResponse.json();
-  return buildSSEResponseFromRun(handle, init?.signal ?? undefined, {
-    chatId: getChatIdFromRequestInit(init),
+  const chatId = getChatIdFromRequestInit(init);
+  const linkedAbort = createLinkedAbortController(init?.signal ?? undefined);
+  const unregisterStartCancel = registerAgentLongRealtimeCancel(chatId, () => {
+    linkedAbort.controller.abort();
   });
+
+  try {
+    const startResponse = await fetchWithErrorHandlers("/api/agent-long", {
+      ...init,
+      signal: linkedAbort.controller.signal,
+    });
+    if (!startResponse.ok) return startResponse;
+
+    const handle: RunHandle = await startResponse.json();
+    return buildSSEResponseFromRun(handle, init?.signal ?? undefined, {
+      chatId,
+    });
+  } finally {
+    unregisterStartCancel?.();
+    linkedAbort.cleanup();
+  }
 };
 
 export const resumeAgentLongStream = async (
   url: string,
   init: RequestInit | undefined,
 ): Promise<Response> => {
+  const chatId = getChatIdFromResumeUrl(url);
+  const linkedAbort = createLinkedAbortController(init?.signal ?? undefined);
+  const unregisterStartCancel = registerAgentLongRealtimeCancel(chatId, () => {
+    linkedAbort.controller.abort();
+  });
+
   // useChat's reconnectToStream signals "nothing to resume" by treating a
   // 204 as null. /api/agent-long/resume returns 204 when the chat has no
   // active run (or the stored run hit a terminal state); pass that through.
-  const response = await fetchWithErrorHandlers(url, {
-    ...init,
-    method: "GET",
-  });
-  if (response.status === 204) return response;
-  if (!response.ok) return response;
+  try {
+    const response = await fetchWithErrorHandlers(url, {
+      ...init,
+      method: "GET",
+      signal: linkedAbort.controller.signal,
+    });
+    if (response.status === 204) return response;
+    if (!response.ok) return response;
 
-  const handle: RunHandle = await response.json();
-  return buildSSEResponseFromRun(handle, init?.signal ?? undefined, {
-    chatId: getChatIdFromResumeUrl(url),
-  });
+    const handle: RunHandle = await response.json();
+    return buildSSEResponseFromRun(handle, init?.signal ?? undefined, {
+      chatId,
+    });
+  } finally {
+    unregisterStartCancel?.();
+    linkedAbort.cleanup();
+  }
 };

--- a/lib/chat/agent-long-transport.ts
+++ b/lib/chat/agent-long-transport.ts
@@ -87,12 +87,21 @@ const buildSSEResponseFromRun = (
   const { runId, publicAccessToken } = handle;
   const encoder = new TextEncoder();
   const chatId = options?.chatId ?? handle.chatId;
+  let cancelRealtimeSubscriptions: (() => Promise<void> | void) | undefined;
+  let consumerCanceled = false;
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       let closed = false;
       let readAbortController: AbortController | undefined;
       let statusSubscription: { unsubscribe?: () => void } | undefined;
+      let streamIterator: AsyncIterator<unknown> | undefined;
       let userAborted = false;
+
+      cancelRealtimeSubscriptions = async () => {
+        readAbortController?.abort();
+        statusSubscription?.unsubscribe?.();
+        await streamIterator?.return?.(undefined).catch(() => undefined);
+      };
 
       // Always close with an abort rather than controller.error() so useChat
       // reliably exits streaming state even when subscription throws.
@@ -131,7 +140,7 @@ const buildSSEResponseFromRun = (
       }, STREAM_TIMEOUT_MS);
 
       // Short-circuit if the consumer already aborted before we got here.
-      if (signal?.aborted) {
+      if (signal?.aborted || consumerCanceled) {
         clearTimeout(timeoutId);
         sendAbortAndClose();
         return;
@@ -149,7 +158,7 @@ const buildSSEResponseFromRun = (
 
         await auth.withAuth({ accessToken: publicAccessToken }, async () => {
           readAbortController = new AbortController();
-          if (signal?.aborted) {
+          if (signal?.aborted || consumerCanceled) {
             userAborted = true;
             readAbortController.abort();
             return;
@@ -341,6 +350,7 @@ const buildSSEResponseFromRun = (
           });
 
           const iter = uiStream[Symbol.asyncIterator]();
+          streamIterator = iter;
           const readNextChunk = () => {
             if (!sawFinishChunk) {
               return Promise.race([
@@ -478,7 +488,7 @@ const buildSSEResponseFromRun = (
           if (userAborted || timedOutAfterFinish || completedRunDrainElapsed) {
             // Release the trigger.dev subscription so it doesn't keep
             // streaming chunks into a dead controller.
-            await iter.return?.(undefined).catch(() => undefined);
+            await cancelRealtimeSubscriptions?.();
           }
 
           if (!sawTerminalChunk) {
@@ -499,11 +509,18 @@ const buildSSEResponseFromRun = (
       } catch {
         clearTimeout(timeoutId);
         // Always send an abort on error so useChat cleans up.
-        sendAbortAndClose();
+        if (!consumerCanceled) {
+          sendAbortAndClose();
+        }
       } finally {
         signal?.removeEventListener("abort", onAbort);
         statusSubscription?.unsubscribe?.();
+        cancelRealtimeSubscriptions = undefined;
       }
+    },
+    cancel() {
+      consumerCanceled = true;
+      return cancelRealtimeSubscriptions?.();
     },
   });
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,31 @@ if (
 const nextConfig: NextConfig = {
   devIndicators: false,
   productionBrowserSourceMaps: posthogSourceMapsEnabled,
+  async headers() {
+    const iconCacheHeaders = [
+      {
+        key: "Cache-Control",
+        value: "public, max-age=86400, stale-while-revalidate=604800",
+      },
+    ];
+
+    return [
+      {
+        source: "/manifest.json",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=3600, stale-while-revalidate=86400",
+          },
+        ],
+      },
+      { source: "/favicon.ico", headers: iconCacheHeaders },
+      { source: "/apple-touch-icon.png", headers: iconCacheHeaders },
+      { source: "/icon-192x192.png", headers: iconCacheHeaders },
+      { source: "/icon-256x256.png", headers: iconCacheHeaders },
+      { source: "/icon-512x512.png", headers: iconCacheHeaders },
+    ];
+  },
   experimental: {
     optimizePackageImports: ["lucide-react", "date-fns"],
   },


### PR DESCRIPTION
## Summary
- stop local chat streams when a streaming/submitted chat unmounts or resets during route changes
- release Trigger.dev realtime run/status subscriptions on browser cancel and sidebar fast-switch navigation
- make sidebar chat selection optimistic so the clicked chat is selected before route commit
- add cache headers for the manifest and app icons to reduce repeated 304 revalidation noise
- extend agent-long structural contract coverage for the cleanup behavior

## Testing
- `./node_modules/.bin/jest lib/api/__tests__/agent-long-contracts.test.ts app/components/__tests__/chat.integration.test.tsx app/components/__tests__/SidebarHistory.test.tsx --runInBand`
- `./node_modules/.bin/prettier --check app/components/ChatItem.tsx app/components/chat.tsx app/contexts/GlobalState.tsx lib/chat/agent-long-transport.ts lib/api/__tests__/agent-long-contracts.test.ts`
- `./node_modules/.bin/eslint app/components/ChatItem.tsx app/components/chat.tsx app/contexts/GlobalState.tsx lib/chat/agent-long-transport.ts lib/api/__tests__/agent-long-contracts.test.ts` (passes with existing warnings in `app/components/chat.tsx`)
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

## Manual verification
- Start an Agent-mode response that streams through Trigger.dev.
- Switch to a different chat while the run is active, including a fast click from the streaming chat to a normal chat.
- Confirm the clicked chat becomes selected in the sidebar immediately.
- Confirm the old `https://api.trigger.dev/realtime/...` request is closed in DevTools Network and the new chat does not keep receiving the old stream.
- Switch back to the original chat and confirm it resumes through `/api/agent-long/resume` if the run is still active.
- Switch chats and confirm `manifest.json` / app icon requests are no longer revalidated on every switch within the cache window.
