### PR TITLE
Use medium reasoning for Grok ask routes

### DIFF
--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -222,17 +222,6 @@ describe("buildProviderOptions fallback chain", () => {
     expect(opts.openrouter.models).toEqual([GEMINI_PREVIEW_SLUG]);
   });
 
-  it.each(["ask-model", "model-grok-4.3", "model-gemini-3-flash"])(
-    "enables low reasoning for Grok ask mode model %s",
-    (modelName) => {
-      const opts = buildProviderOptions(false, "user-1", modelName, "ask");
-      expect(opts.openrouter.reasoning).toEqual({
-        enabled: true,
-        effort: "low",
-      });
-    },
-  );
-
   it.each(["model-kimi-k2.7-code", "model-kimi-k2.6"])(
     "enables reasoning for Kimi ask mode route %s",
     (modelName) => {
@@ -243,16 +232,20 @@ describe("buildProviderOptions fallback chain", () => {
     },
   );
 
-  it.each(["model-deepseek-v4-pro", "model-sonnet-4.6", "model-opus-4.6"])(
-    "enables medium reasoning for ask mode model %s",
-    (modelName) => {
-      const opts = buildProviderOptions(false, "user-1", modelName, "ask");
-      expect(opts.openrouter.reasoning).toEqual({
-        enabled: true,
-        effort: "medium",
-      });
-    },
-  );
+  it.each([
+    "model-deepseek-v4-pro",
+    "ask-model",
+    "model-grok-4.3",
+    "model-gemini-3-flash",
+    "model-sonnet-4.6",
+    "model-opus-4.6",
+  ])("enables medium reasoning for ask mode model %s", (modelName) => {
+    const opts = buildProviderOptions(false, "user-1", modelName, "ask");
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+      effort: "medium",
+    });
+  });
 
   it("includes reasoning settings independent of fallback chain", () => {
     const reasoning = buildProviderOptions(

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -517,8 +517,18 @@ const ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN = [
   "fallback-grok-4.3",
 ] as const satisfies readonly ModelName[];
 
-const ASK_MEDIUM_REASONING_MODELS = [
+// Standard Ask can route text-only prompts to DeepSeek and media prompts to
+// Grok. Keep those route keys and their persisted Grok alias on one effort
+// level so they do not drift.
+const ASK_STANDARD_REASONING_MODELS = [
   "model-deepseek-v4-pro",
+  "ask-model",
+  "model-grok-4.3",
+  "model-gemini-3-flash",
+] as const satisfies readonly ModelName[];
+
+const ASK_MEDIUM_REASONING_MODELS = [
+  ...ASK_STANDARD_REASONING_MODELS,
   "model-sonnet-4.6",
   "model-opus-4.6",
 ] as const satisfies readonly ModelName[];
@@ -526,16 +536,6 @@ const ASK_MEDIUM_REASONING_MODELS = [
 const isAskMediumReasoningModel = (modelName?: string): boolean =>
   typeof modelName === "string" &&
   (ASK_MEDIUM_REASONING_MODELS as readonly string[]).includes(modelName);
-
-const ASK_GROK_REASONING_MODELS = [
-  "ask-model",
-  "model-grok-4.3",
-  "model-gemini-3-flash",
-] as const satisfies readonly ModelName[];
-
-const isAskGrokReasoningModel = (modelName?: string): boolean =>
-  typeof modelName === "string" &&
-  (ASK_GROK_REASONING_MODELS as readonly string[]).includes(modelName);
 
 const ASK_KIMI_REASONING_MODELS = [
   "model-kimi-k2.7-code",
@@ -644,17 +644,12 @@ export function buildProviderOptions(
         ? {
             enabled: true,
           }
-        : mode === "ask" && isAskGrokReasoningModel(modelName)
+        : mode === "ask" && isAskMediumReasoningModel(modelName)
           ? {
               enabled: true,
-              effort: "low",
+              effort: "medium",
             }
-          : mode === "ask" && isAskMediumReasoningModel(modelName)
-            ? {
-                enabled: true,
-                effort: "medium",
-              }
-            : { enabled: false });
+          : { enabled: false });
 
   return {
     openrouter: {


### PR DESCRIPTION
## Summary
- move Grok-backed Ask routes from low to medium OpenRouter reasoning effort
- keep DeepSeek text-only Ask and Grok media Ask on one shared Standard Ask reasoning policy
- update provider-option coverage so DeepSeek, Grok, and the persisted Grok alias all assert medium reasoning

## Testing
- ./node_modules/.bin/jest lib/api/__tests__/chat-stream-helpers-fallback.test.ts --runInBand
- ./node_modules/.bin/prettier --check lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts
- git diff --check

## Manual verification
- In paid Ask Standard/Auto with text only, confirm provider diagnostics still show DeepSeek Pro with reasoning effort medium.
- In paid Ask Standard/Auto with an image or PDF, confirm provider diagnostics show Grok 4.3 with reasoning effort medium.
- Confirm free Ask remains on the DeepSeek Flash route with reasoning disabled unless the free Ask experiment overrides it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ask mode now applies the correct reasoning level for a wider set of models.
  * Some models that previously used lower reasoning settings now use medium reasoning for more consistent responses.
  * Updated automated checks to match the revised behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->