### PR TITLE
Do not warn Ultra users about high-cost models

### DIFF
--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -71,6 +71,7 @@ const shouldWarnForPaidHighCostModel = (
   model: SelectedModel,
 ): boolean =>
   subscription !== "free" &&
+  subscription !== "ultra" &&
   (model === "hackerai-max" || model === "hackerai-pro");
 
 const AutoOptionButton = ({

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -109,8 +109,7 @@ describe("ModelSelector", () => {
     expect(onChange).toHaveBeenCalledWith("hackerai-pro");
   });
 
-  it("warns before selecting HackerAI Max on paid tiers above Pro", () => {
-    mockSubscription = "ultra";
+  it("warns before selecting HackerAI Max on Pro Plus", () => {
     const onChange = jest.fn();
     render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
 
@@ -120,6 +119,21 @@ describe("ModelSelector", () => {
     expect(onChange).not.toHaveBeenCalled();
     expect(screen.getByTestId("high-cost-model-warning")).toBeVisible();
     expect(screen.getByText(/HackerAI Max is powerful/i)).toBeVisible();
+  });
+
+  it("selects high-cost models without warning for Ultra users", () => {
+    mockSubscription = "ultra";
+    const onChange = jest.fn();
+    render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /HackerAI Max/i }));
+
+    expect(
+      screen.queryByTestId("high-cost-model-warning"),
+    ).not.toBeInTheDocument();
+    expect(mockDismissHighCostModelUsageNotice).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith("hackerai-max");
   });
 
   it("uses team-specific warning copy for team users", () => {


### PR DESCRIPTION
## Summary
- skip the high-cost model warning for Ultra subscribers when selecting Pro or Max
- keep warning behavior for Pro Plus and team accounts
- add ModelSelector coverage for Ultra selecting HackerAI Max immediately

## Validation
- ./node_modules/.bin/jest app/components/ModelSelector/__tests__/ModelSelector.test.tsx --runInBand
- ./node_modules/.bin/prettier --check app/components/ModelSelector.tsx app/components/ModelSelector/__tests__/ModelSelector.test.tsx
- git diff --check

## Manual verification
- Sign in as an Ultra user.
- Open the model selector in Ask or Agent mode and choose HackerAI Pro or HackerAI Max.
- The selection should apply immediately with no high-cost model warning dialog.
- Repeat as Pro Plus or Team and confirm the high-cost warning still appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * High-cost model warnings now skip the new “ultra” subscription tier.
  * Users on the “ultra” tier can select HackerAI Max in agent mode without seeing the warning dialog.
* **Tests**
  * Updated coverage for paid-tier warning behavior.
  * Added a test to confirm “ultra” users proceed directly when choosing HackerAI Max.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->