### PR TITLE
Use MiniMax M3 for Agent Standard

### DIFF
--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -146,9 +146,7 @@ const ModelOptionButton = ({
           {option.thinking && (
             <Brain className="h-3 w-3 text-muted-foreground/60" />
           )}
-          {option.id !== "auto" && (
-            <CostIndicator modelId={option.id} mode={mode} />
-          )}
+          {option.id !== "auto" && <CostIndicator modelId={option.id} />}
         </div>
       </div>
       {isFreeUser ? (

--- a/app/components/ModelSelector/CostIndicator.tsx
+++ b/app/components/ModelSelector/CostIndicator.tsx
@@ -3,17 +3,15 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import type { ChatMode } from "@/types/chat";
-import { isAgentMode } from "@/lib/utils/mode-helpers";
 
 type CostTier = "low" | "medium" | "high" | "very-high";
 
-// Cost tier per HackerAI tier id. Standard and Pro are mode-aware in ask;
-// Agent keeps the higher-cost coding/automation models, including Kimi K2.7 Code.
-export function getCostTier(modelId: string, mode?: ChatMode): CostTier {
+// Cost tier per HackerAI tier id. Standard stays low cost in both modes;
+// Pro and Max intentionally surface the higher-cost model choices.
+export function getCostTier(modelId: string): CostTier {
   switch (modelId) {
     case "hackerai-standard":
-      return mode && isAgentMode(mode) ? "medium" : "low";
+      return "low";
     case "hackerai-pro":
       return "high";
     case "hackerai-max":
@@ -52,14 +50,8 @@ const COST_CONFIG: Record<
 
 const MAX_DOLLARS = 3;
 
-export function CostIndicator({
-  modelId,
-  mode,
-}: {
-  modelId: string;
-  mode?: ChatMode;
-}) {
-  const tier = getCostTier(modelId, mode);
+export function CostIndicator({ modelId }: { modelId: string }) {
+  const tier = getCostTier(modelId);
   const config = COST_CONFIG[tier];
 
   return (

--- a/app/components/ModelSelector/__tests__/options-drift.test.ts
+++ b/app/components/ModelSelector/__tests__/options-drift.test.ts
@@ -36,7 +36,7 @@ describe("ModelSelector tier ↔ provider drift", () => {
       "model-deepseek-v4-pro",
     );
     expect(resolveTierToProviderKey("hackerai-standard", "agent")).toBe(
-      "model-kimi-k2.7-code",
+      "model-minimax-m3",
     );
   });
 

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -37,7 +37,7 @@ export const AGENT_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-standard",
     label: "HackerAI Standard",
     description: "Reliable agent for everyday automation",
-    poweredBy: "Moonshot Kimi K2.7 Code",
+    poweredBy: "MiniMax M3",
     thinking: true,
   },
   {

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -7,10 +7,17 @@ import {
 } from "@/lib/ai/providers";
 
 describe("provider registry", () => {
-  it("keeps paid Ask media and stale Kimi compatibility keys pointed at their active slugs", () => {
+  it("keeps paid Ask media, Agent Standard, and stale Kimi compatibility keys pointed at their active slugs", () => {
     expect(
       (myProvider.languageModel("ask-model") as { modelId: string }).modelId,
     ).toBe("x-ai/grok-4.3");
+    expect(
+      (myProvider.languageModel("agent-model") as { modelId: string }).modelId,
+    ).toBe("minimax/minimax-m3");
+    expect(
+      (myProvider.languageModel("model-minimax-m3") as { modelId: string })
+        .modelId,
+    ).toBe("minimax/minimax-m3");
     expect(
       (myProvider.languageModel("model-grok-4.3") as { modelId: string })
         .modelId,
@@ -29,6 +36,7 @@ describe("provider registry", () => {
         }
       ).modelId,
     ).toBe("moonshotai/kimi-k2.7-code:exacto");
+    expect(getModelDisplayName("model-minimax-m3")).toBe("MiniMax M3");
     expect(getModelDisplayName("model-grok-4.3")).toBe("xAI Grok 4.3");
     expect(getModelDisplayName("model-gemini-3-flash")).toBe("xAI Grok 4.3");
   });
@@ -250,9 +258,11 @@ describe("sanitizeOpenRouterRequestForGeminiFunctionResponses", () => {
 });
 
 describe("supportsMultimodalToolResults", () => {
-  it("allows Kimi registry keys and OpenRouter slugs for image tool result experiments", () => {
-    expect(supportsMultimodalToolResults("model-kimi-k2.7-code")).toBe(true);
+  it("allows MiniMax and Kimi registry keys and OpenRouter slugs for image tool result experiments", () => {
     expect(supportsMultimodalToolResults("agent-model")).toBe(true);
+    expect(supportsMultimodalToolResults("model-minimax-m3")).toBe(true);
+    expect(supportsMultimodalToolResults("minimax/minimax-m3")).toBe(true);
+    expect(supportsMultimodalToolResults("model-kimi-k2.7-code")).toBe(true);
     expect(
       supportsMultimodalToolResults("moonshotai/kimi-k2.7-code:exacto"),
     ).toBe(true);

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -246,13 +246,14 @@ const openrouter = createOpenRouter({
 type OpenRouterInstance = typeof openrouter;
 
 const KIMI_K2_7_CODE_SLUG = "moonshotai/kimi-k2.7-code:exacto";
+const MINIMAX_M3_SLUG = "minimax/minimax-m3";
 const GROK_4_3_SLUG = "x-ai/grok-4.3";
 
 const buildProviderMap = (or: OpenRouterInstance) =>
   ({
     "ask-model": or(GROK_4_3_SLUG),
     "ask-model-free": or("deepseek/deepseek-v4-flash"),
-    "agent-model": or(KIMI_K2_7_CODE_SLUG),
+    "agent-model": or(MINIMAX_M3_SLUG),
     "agent-model-free": or("deepseek/deepseek-v4-flash"),
     "model-sonnet-4.6": or("anthropic/claude-sonnet-4-6"),
     "model-grok-4.3": or(GROK_4_3_SLUG),
@@ -262,9 +263,10 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "model-deepseek-v4-flash": or("deepseek/deepseek-v4-flash"),
     "model-deepseek-v4-pro": or("deepseek/deepseek-v4-pro"),
     "model-opus-4.6": or("anthropic/claude-opus-4.6"),
+    "model-minimax-m3": or(MINIMAX_M3_SLUG),
     "model-kimi-k2.7-code": or(KIMI_K2_7_CODE_SLUG),
     // Compatibility alias for stale internal references persisted before the
-    // Kimi 2.7 Code rollout. New selections should use model-kimi-k2.7-code.
+    // Kimi 2.7 Code rollout. New Agent Standard selections use model-minimax-m3.
     "model-kimi-k2.6": or(KIMI_K2_7_CODE_SLUG),
     "fallback-agent-model": or("google/gemini-3-flash-preview"),
     "fallback-ask-model": or("google/gemini-3-flash-preview"),
@@ -282,7 +284,7 @@ export const modelCutoffDates: Record<ModelName, string> &
   Record<string, string> = {
   "ask-model": "April 2026",
   "ask-model-free": "May 2025",
-  "agent-model": "June 2025",
+  "agent-model": "May 2026",
   "agent-model-free": "May 2025",
   "model-sonnet-4.6": "May 2025",
   "model-grok-4.3": "April 2026",
@@ -290,6 +292,7 @@ export const modelCutoffDates: Record<ModelName, string> &
   "model-deepseek-v4-flash": "May 2025",
   "model-deepseek-v4-pro": "May 2025",
   "model-opus-4.6": "May 2025",
+  "model-minimax-m3": "May 2026",
   "model-kimi-k2.7-code": "June 2025",
   "model-kimi-k2.6": "June 2025",
   "fallback-agent-model": "January 2025",
@@ -311,6 +314,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-deepseek-v4-flash": "DeepSeek V4 Flash",
   "model-deepseek-v4-pro": "DeepSeek V4 Pro",
   "model-opus-4.6": "Anthropic Claude Opus 4.6",
+  "model-minimax-m3": "MiniMax M3",
   "model-kimi-k2.7-code": "Moonshot Kimi K2.7 Code",
   "model-kimi-k2.6": "Moonshot Kimi K2.7 Code",
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
@@ -344,11 +348,19 @@ export function isDeepSeekModel(modelName: string): boolean {
 export function isKimiModel(modelName: string): boolean {
   const normalized = modelName.toLowerCase();
   return (
-    normalized === "agent-model" ||
     normalized === "model-kimi-k2.7-code" ||
     normalized === "model-kimi-k2.6" ||
     normalized.includes("moonshotai/kimi") ||
     normalized.includes("kimi-")
+  );
+}
+
+export function isMiniMaxModel(modelName: string): boolean {
+  const normalized = modelName.toLowerCase();
+  return (
+    normalized === "agent-model" ||
+    normalized === "model-minimax-m3" ||
+    normalized.includes("minimax/minimax-m3")
   );
 }
 
@@ -360,6 +372,7 @@ export function supportsMultimodalToolResults(modelName?: string): boolean {
   return (
     normalized === "ask-model" ||
     isKimiModel(normalized) ||
+    isMiniMaxModel(normalized) ||
     normalized.includes("gemini") ||
     normalized.includes("google/") ||
     isAnthropicModel(normalized) ||
@@ -392,9 +405,7 @@ export function resolveTierToProviderKey(
   if (tier === "auto") return null;
   switch (tier) {
     case "hackerai-standard":
-      return isAgentMode(mode)
-        ? "model-kimi-k2.7-code"
-        : "model-deepseek-v4-pro";
+      return isAgentMode(mode) ? "model-minimax-m3" : "model-deepseek-v4-pro";
     case "hackerai-pro":
       return "model-sonnet-4.6";
     case "hackerai-max":

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -507,7 +507,7 @@ describe("createChatLogger provider stream termination", () => {
       chatLogger.recordProviderError(err, {
         mode: "agent",
         model: "agent-model",
-        requestedModelSlug: "moonshotai/kimi-k2.7-code:exacto",
+        requestedModelSlug: "minimax/minimax-m3",
       });
       chatLogger.emitUnexpectedError(err);
 
@@ -1101,7 +1101,7 @@ describe("createChatLogger provider stream timeout", () => {
       chatLogger.recordProviderError(err, {
         mode: "agent",
         model: "agent-model",
-        requestedModelSlug: "moonshotai/kimi-k2.7-code:exacto",
+        requestedModelSlug: "minimax/minimax-m3",
       });
       chatLogger.emitUnexpectedError(err);
 

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -35,7 +35,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("resolves Opus 4.6 text-only agent chain to MiniMax then Grok slugs", () => {
+  it("resolves Opus 4.6 text-only agent chain to MiniMax, Kimi, then Grok slugs", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -43,7 +43,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [MINIMAX_SLUG, GROK_SLUG],
+      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
@@ -75,7 +75,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("resolves Sonnet 4.6 text-only agent chain to MiniMax then Grok slugs", () => {
+  it("resolves Sonnet 4.6 text-only agent chain to MiniMax, Kimi, then Grok slugs", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -83,7 +83,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [MINIMAX_SLUG, GROK_SLUG],
+      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
@@ -102,7 +102,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("keeps Anthropic multimodal agent fallback off text-only MiniMax once image tool results exist", () => {
+  it("keeps Anthropic multimodal agent fallback off text-only MiniMax and Kimi once image tool results exist", () => {
     const opus = buildProviderOptions(
       false,
       "user-1",
@@ -124,17 +124,19 @@ describe("buildProviderOptions fallback chain", () => {
     expect(sonnet.openrouter.models).toEqual([GROK_SLUG]);
     expect(opus.openrouter.models).not.toContain(MINIMAX_SLUG);
     expect(sonnet.openrouter.models).not.toContain(MINIMAX_SLUG);
+    expect(opus.openrouter.models).not.toContain(KIMI_SLUG);
+    expect(sonnet.openrouter.models).not.toContain(KIMI_SLUG);
   });
 
-  it("falls back from auto agent MiniMax to Grok", () => {
+  it("falls back from auto agent MiniMax to Kimi then Grok", () => {
     const opts = buildProviderOptions(false, "user-1", "agent-model", "agent");
     expect(opts.openrouter).toMatchObject({
-      models: [GROK_SLUG],
+      models: [KIMI_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
 
-  it("falls back from explicit MiniMax to Grok", () => {
+  it("falls back from explicit MiniMax to Kimi then Grok", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -142,7 +144,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [GROK_SLUG],
+      models: [KIMI_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
@@ -277,7 +279,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(reasoning.openrouter).toMatchObject({
       reasoning: { enabled: true },
-      models: [MINIMAX_SLUG, GROK_SLUG],
+      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
     });
 
     const noReasoning = buildProviderOptions(
@@ -288,7 +290,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(noReasoning.openrouter).toMatchObject({
       reasoning: { enabled: false },
-      models: [MINIMAX_SLUG, GROK_SLUG],
+      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
     });
 
     const multimodal = buildProviderOptions(

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -23,6 +23,7 @@ jest.mock("@/lib/logger", () => ({
 // If the registry slug for a model changes, update both places intentionally.
 const GEMINI_PREVIEW_SLUG = "google/gemini-3-flash-preview";
 const GROK_SLUG = "x-ai/grok-4.3";
+const MINIMAX_SLUG = "minimax/minimax-m3";
 const KIMI_SLUG = "moonshotai/kimi-k2.7-code:exacto";
 
 describe("buildProviderOptions fallback chain", () => {
@@ -34,7 +35,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("resolves Opus 4.6 text-only agent chain to Kimi then Grok slugs", () => {
+  it("resolves Opus 4.6 text-only agent chain to MiniMax then Grok slugs", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -42,7 +43,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG, GROK_SLUG],
+      models: [MINIMAX_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
@@ -74,7 +75,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("resolves Sonnet 4.6 text-only agent chain to Kimi then Grok slugs", () => {
+  it("resolves Sonnet 4.6 text-only agent chain to MiniMax then Grok slugs", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -82,7 +83,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG, GROK_SLUG],
+      models: [MINIMAX_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
@@ -101,7 +102,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("keeps Anthropic multimodal agent fallback off text-only Kimi once image tool results exist", () => {
+  it("keeps Anthropic multimodal agent fallback off text-only MiniMax once image tool results exist", () => {
     const opus = buildProviderOptions(
       false,
       "user-1",
@@ -121,12 +122,25 @@ describe("buildProviderOptions fallback chain", () => {
 
     expect(opus.openrouter.models).toEqual([GROK_SLUG]);
     expect(sonnet.openrouter.models).toEqual([GROK_SLUG]);
-    expect(opus.openrouter.models).not.toContain(KIMI_SLUG);
-    expect(sonnet.openrouter.models).not.toContain(KIMI_SLUG);
+    expect(opus.openrouter.models).not.toContain(MINIMAX_SLUG);
+    expect(sonnet.openrouter.models).not.toContain(MINIMAX_SLUG);
   });
 
-  it("falls back from auto agent Kimi to Grok", () => {
+  it("falls back from auto agent MiniMax to Grok", () => {
     const opts = buildProviderOptions(false, "user-1", "agent-model", "agent");
+    expect(opts.openrouter).toMatchObject({
+      models: [GROK_SLUG],
+      user: "user-1",
+    });
+  });
+
+  it("falls back from explicit MiniMax to Grok", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-minimax-m3",
+      "agent",
+    );
     expect(opts.openrouter).toMatchObject({
       models: [GROK_SLUG],
       user: "user-1",
@@ -263,7 +277,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(reasoning.openrouter).toMatchObject({
       reasoning: { enabled: true },
-      models: [KIMI_SLUG, GROK_SLUG],
+      models: [MINIMAX_SLUG, GROK_SLUG],
     });
 
     const noReasoning = buildProviderOptions(
@@ -274,7 +288,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(noReasoning.openrouter).toMatchObject({
       reasoning: { enabled: false },
-      models: [KIMI_SLUG, GROK_SLUG],
+      models: [MINIMAX_SLUG, GROK_SLUG],
     });
 
     const multimodal = buildProviderOptions(

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -465,9 +465,9 @@ export class SummarizationTracker {
  * model's rate (response.modelId reflects what actually ran).
  *
  * Claude chats are repaired for Anthropic-compatible message shapes before
- * this fallback can fire. Claude agent calls use the cheaper MiniMax fallback
- * while the run is text-only, then switch to multimodal-capable fallbacks once
- * image tool results enter the context.
+ * this fallback can fire. Claude agent calls use the cheaper MiniMax and Kimi
+ * fallback chain while the run is text-only, then switch to multimodal-capable
+ * fallbacks once image tool results enter the context.
  *
  * Keys and values are registry names (see lib/ai/providers.ts) — the actual
  * OpenRouter slugs are resolved at request-build time so this stays in sync
@@ -479,10 +479,10 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "model-deepseek-v4-flash": ["fallback-ask-model"],
   "model-deepseek-v4-pro": ["fallback-ask-model"],
   "ask-model": ["fallback-ask-model"],
-  "agent-model": ["fallback-grok-4.3"],
+  "agent-model": ["model-kimi-k2.6", "fallback-grok-4.3"],
   "model-grok-4.3": ["fallback-ask-model"],
   "model-gemini-3-flash": ["fallback-ask-model"],
-  "model-minimax-m3": ["fallback-grok-4.3"],
+  "model-minimax-m3": ["model-kimi-k2.6", "fallback-grok-4.3"],
   "model-kimi-k2.7-code": ["fallback-grok-4.3"],
   "model-kimi-k2.6": ["fallback-grok-4.3"],
 };
@@ -510,7 +510,7 @@ export function isAutoModelSelectionForRetry({
 
 const ANTHROPIC_FALLBACK_CHAIN_BY_MODE: Record<ChatMode, readonly ModelName[]> =
   {
-    agent: ["model-minimax-m3", "fallback-grok-4.3"],
+    agent: ["model-minimax-m3", "model-kimi-k2.6", "fallback-grok-4.3"],
     ask: ["model-grok-4.3"],
   };
 

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -465,7 +465,7 @@ export class SummarizationTracker {
  * model's rate (response.modelId reflects what actually ran).
  *
  * Claude chats are repaired for Anthropic-compatible message shapes before
- * this fallback can fire. Claude agent calls use the cheaper Kimi fallback
+ * this fallback can fire. Claude agent calls use the cheaper MiniMax fallback
  * while the run is text-only, then switch to multimodal-capable fallbacks once
  * image tool results enter the context.
  *
@@ -482,6 +482,7 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "agent-model": ["fallback-grok-4.3"],
   "model-grok-4.3": ["fallback-ask-model"],
   "model-gemini-3-flash": ["fallback-ask-model"],
+  "model-minimax-m3": ["fallback-grok-4.3"],
   "model-kimi-k2.7-code": ["fallback-grok-4.3"],
   "model-kimi-k2.6": ["fallback-grok-4.3"],
 };
@@ -509,7 +510,7 @@ export function isAutoModelSelectionForRetry({
 
 const ANTHROPIC_FALLBACK_CHAIN_BY_MODE: Record<ChatMode, readonly ModelName[]> =
   {
-    agent: ["model-kimi-k2.7-code", "fallback-grok-4.3"],
+    agent: ["model-minimax-m3", "fallback-grok-4.3"],
     ask: ["model-grok-4.3"],
   };
 

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -245,11 +245,11 @@ describe("selectModel", () => {
     });
   });
 
-  // Agent mode — Standard resolves to Kimi instead of Gemini
+  // Agent mode — Standard resolves to MiniMax instead of Gemini
   describe("tier override in agent mode", () => {
-    it("should map HackerAI Standard to Kimi K2.7 Code in agent mode", () => {
+    it("should map HackerAI Standard to MiniMax M3 in agent mode", () => {
       expect(selectModel("agent", "pro", "hackerai-standard")).toBe(
-        "model-kimi-k2.7-code",
+        "model-minimax-m3",
       );
     });
 

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -409,6 +409,14 @@ describe("token-bucket", () => {
       ).toBe(11310);
     });
 
+    it.each(["agent-model", "model-minimax-m3"])(
+      "should use MiniMax M3 pricing for %s ($0.30/$1.20)",
+      (modelName) => {
+        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(3900);
+        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(15600);
+      },
+    );
+
     it.each([
       "ask-model",
       "model-grok-4.3",

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -36,12 +36,12 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   "fallback-gemini-3.5-flash": { input: 1.25, output: 2.5 },
   "fallback-grok-4.3": { input: 1.25, output: 2.5 },
   "model-opus-4.6": { input: 5.0, output: 25.0 },
-  // "agent-model" and "model-kimi-k2.7-code" route to
-  // moonshotai/kimi-k2.7-code:exacto via lib/ai/providers.ts. Rates from OpenRouter:
-  // $0.95 in / $4.00 out per 1M tokens. The old model-kimi-k2.6 key remains
-  // priced here as a compatibility alias. Cache-read discount ($0.16/M) applies
-  // when provider cost is available via usage.raw.cost.
-  "agent-model": { input: 0.95, output: 4.0 },
+  // "agent-model" and "model-minimax-m3" route to minimax/minimax-m3 via
+  // lib/ai/providers.ts. Rates from OpenRouter: $0.30 in / $1.20 out per 1M tokens.
+  "agent-model": { input: 0.3, output: 1.2 },
+  "model-minimax-m3": { input: 0.3, output: 1.2 },
+  // Kimi keys are retained as compatibility aliases for stale persisted routes.
+  // Rates from OpenRouter: $0.95 in / $4.00 out per 1M tokens.
   "agent-model-free": { input: 0.95, output: 4.0 },
   "model-kimi-k2.7-code": { input: 0.95, output: 4.0 },
   "model-kimi-k2.6": { input: 0.95, output: 4.0 },


### PR DESCRIPTION
## Summary
- route paid Agent auto (`agent-model`) and explicit Agent Standard (`model-minimax-m3`) to `minimax/minimax-m3`
- align Agent Standard UI copy, low-cost indicator, OpenRouter fallback chains, and token pricing with MiniMax M3
- keep Kimi registry keys as stale-route compatibility aliases and update tests for both active and legacy paths

## Validation
- `./node_modules/.bin/jest lib/ai/__tests__/providers.test.ts lib/chat/__tests__/chat-processor.test.ts app/components/ModelSelector/__tests__/options-drift.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/api/__tests__/chat-logger.test.ts lib/rate-limit/__tests__/token-bucket.test.ts --runInBand`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint app/components/ModelSelector.tsx app/components/ModelSelector/CostIndicator.tsx app/components/ModelSelector/constants.ts app/components/ModelSelector/__tests__/options-drift.test.ts lib/ai/providers.ts lib/ai/__tests__/providers.test.ts lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/api/__tests__/chat-logger.test.ts lib/chat/__tests__/chat-processor.test.ts lib/rate-limit/token-bucket.ts lib/rate-limit/__tests__/token-bucket.test.ts`
- `./node_modules/.bin/prettier --check app/components/ModelSelector.tsx app/components/ModelSelector/CostIndicator.tsx app/components/ModelSelector/constants.ts app/components/ModelSelector/__tests__/options-drift.test.ts lib/ai/providers.ts lib/ai/__tests__/providers.test.ts lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/api/__tests__/chat-logger.test.ts lib/chat/__tests__/chat-processor.test.ts lib/rate-limit/token-bucket.ts lib/rate-limit/__tests__/token-bucket.test.ts`

## Visual verification
- Started Next dev server on `http://localhost:3010` and opened chat with saved Pro auth state.
- Switched to Agent mode, opened the model selector, hovered HackerAI Standard, and verified the tooltip says `Powered by MiniMax M3` with the low-cost indicator and no console errors.

## Manual verification
- In a paid account, switch to Agent mode and leave model selection on Auto. Send a simple prompt and confirm request metadata/configured model resolves through `agent-model` to `minimax/minimax-m3`.
- In Agent mode, explicitly choose HackerAI Standard. Send a simple prompt and confirm the configured model resolves through `model-minimax-m3` to `minimax/minimax-m3`.
- Trigger or simulate a failed Claude Agent request before first tokens and confirm fallback routing includes MiniMax M3 before Grok for text-only runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switched agent-mode model selection to **MiniMax M3**, including updated “powered by” display.
  * Enabled MiniMax model routing and multimodal-tool compatibility, with updated display naming and pricing support.

* **Bug Fixes**
  * Corrected cost-tier rendering to be consistent across model options.
  * Updated fallback chains so agent text-only behavior prefers MiniMax before continuing with existing fallbacks.

* **Tests**
  * Refreshed model mapping, fallback-path, provider registry, and pricing assertions to match the MiniMax M3 changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->