### PR TITLE
Harden browser health e2e follow-ups

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -65,6 +65,7 @@ import { HackingSuggestions } from "./HackingSuggestions";
 const AGENT_LONG_COMPLETION_POLL_DELAY_MS = 5_000;
 const AGENT_LONG_COMPLETION_POLL_INTERVAL_MS = 2_000;
 const AGENT_LONG_COMPLETION_QUIET_MS = 3_000;
+const AGENT_LONG_COMPLETION_STOP_GRACE_MS = 6_000;
 
 const getAgentLongPartFingerprint = (part: unknown): string => {
   if (typeof part !== "object" || part === null) return String(part);
@@ -442,6 +443,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const hasManuallyStoppedRef = useRef(false);
   const messagesRef = useRef<ChatMessage[]>([]);
   const isChatMountedRef = useRef(false);
+  const browserStreamFinishedRef = useRef(false);
   const activeChatIdRef = useRef(chatId);
   activeChatIdRef.current = chatId;
 
@@ -682,6 +684,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       }
     },
     onFinish: () => {
+      browserStreamFinishedRef.current = true;
       setIsAutoResuming(false);
       setAwaitingServerChat(false);
       dispatchStreaming({ type: "RESET_ON_FINISH" });
@@ -697,6 +700,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       }
     },
     onError: (error) => {
+      browserStreamFinishedRef.current = true;
       setIsAutoResuming(false);
       setAwaitingServerChat(false);
       dispatchStreaming({ type: "RESET_ON_FINISH" });
@@ -745,17 +749,76 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
           (chatDataForCurrentChat as any).default_model_slug === "agent" ||
           (chatDataForCurrentChat as any).default_model_slug ===
             "agent-long")));
+  const shouldUseAgentLongForCurrentChatRef = useRef(
+    shouldUseAgentLongForCurrentChat,
+  );
+  shouldUseAgentLongForCurrentChatRef.current =
+    shouldUseAgentLongForCurrentChat;
   const stopActiveBrowserStream = useCallback(() => {
     cancelAgentLongRealtimeStreams(activeChatIdRef.current);
+    const streamAlreadyFinished =
+      shouldUseAgentLongForCurrentChatRef.current &&
+      browserStreamFinishedRef.current;
     if (
-      statusRef.current === "streaming" ||
-      statusRef.current === "submitted"
+      !streamAlreadyFinished &&
+      (statusRef.current === "streaming" || statusRef.current === "submitted")
     ) {
       stopRef.current();
     }
     setDataStream([]);
     setIsAutoResuming(false);
   }, [setDataStream, setIsAutoResuming]);
+
+  useEffect(() => {
+    if (
+      shouldUseAgentLongForCurrentChat &&
+      (status === "streaming" || status === "submitted")
+    ) {
+      browserStreamFinishedRef.current = false;
+    }
+  }, [shouldUseAgentLongForCurrentChat, status]);
+
+  useEffect(() => {
+    const isAgentLongDoubleCloseNoise = (message: unknown) =>
+      shouldUseAgentLongForCurrentChatRef.current &&
+      typeof message === "string" &&
+      message.includes("Cannot close an errored readable stream");
+
+    const suppressAgentLongDoubleCloseNoise = (event: ErrorEvent) => {
+      if (isAgentLongDoubleCloseNoise(event.message)) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+      }
+    };
+
+    const previousOnError = window.onerror;
+    const suppressAgentLongDoubleCloseOnError: OnErrorEventHandler = (
+      message,
+      source,
+      lineno,
+      colno,
+      error,
+    ) => {
+      if (isAgentLongDoubleCloseNoise(message)) return true;
+      if (typeof previousOnError === "function") {
+        return previousOnError(message, source, lineno, colno, error);
+      }
+      return false;
+    };
+    window.onerror = suppressAgentLongDoubleCloseOnError;
+
+    window.addEventListener("error", suppressAgentLongDoubleCloseNoise, true);
+    return () => {
+      if (window.onerror === suppressAgentLongDoubleCloseOnError) {
+        window.onerror = previousOnError;
+      }
+      window.removeEventListener(
+        "error",
+        suppressAgentLongDoubleCloseNoise,
+        true,
+      );
+    };
+  }, []);
 
   useEffect(() => {
     setDataStream([]);
@@ -798,6 +861,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
     let stopped = false;
     let pollInterval: ReturnType<typeof setInterval> | undefined;
+    let finishTimeout: ReturnType<typeof setTimeout> | undefined;
     const abortController = new AbortController();
 
     const finishLocally = () => {
@@ -815,6 +879,23 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       }
     };
 
+    const scheduleFinishLocally = () => {
+      if (stopped || finishTimeout !== undefined) return;
+
+      // The transport also polls the resume endpoint and can deliver a
+      // synthetic finish after a terminal 204. Give it a brief chance to close
+      // normally before falling back to stop(), which aborts the active stream.
+      finishTimeout = setTimeout(() => {
+        finishTimeout = undefined;
+        if (
+          statusRef.current === "streaming" ||
+          statusRef.current === "submitted"
+        ) {
+          finishLocally();
+        }
+      }, AGENT_LONG_COMPLETION_STOP_GRACE_MS);
+    };
+
     const checkRunCompletion = async () => {
       if (
         Date.now() - agentLongLastMessageChangeAtRef.current <
@@ -829,7 +910,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
           { method: "GET", signal: abortController.signal },
         );
         if (response.status === 204) {
-          finishLocally();
+          scheduleFinishLocally();
         }
       } catch (error) {
         if ((error as Error).name !== "AbortError") {
@@ -850,6 +931,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       stopped = true;
       abortController.abort();
       clearTimeout(pollDelay);
+      if (finishTimeout !== undefined) {
+        clearTimeout(finishTimeout);
+      }
       if (pollInterval !== undefined) {
         clearInterval(pollInterval);
       }

--- a/e2e/chat-agent.spec.ts
+++ b/e2e/chat-agent.spec.ts
@@ -6,6 +6,19 @@ import {
 } from "./helpers/test-helpers";
 import { AUTH_STORAGE_PATHS } from "./fixtures/auth";
 import { TIMEOUTS, TEST_DATA } from "./constants";
+import fs from "fs";
+
+test.setTimeout(TIMEOUTS.AGENT_LONG);
+
+function writeLargeAgentOnlyFile(outputPath: string): string {
+  const targetBytes = 21 * 1024 * 1024;
+  fs.writeFileSync(outputPath, Buffer.alloc(targetBytes, "a"));
+  fs.appendFileSync(
+    outputPath,
+    `\nSECRET_MARKER=${TEST_DATA.SECRETS.AGENT_LARGE}\n`,
+  );
+  return outputPath;
+}
 
 test.describe("Agent Mode Tests - Pro and Ultra Tiers", () => {
   test.describe("Pro Tier", () => {
@@ -82,6 +95,29 @@ test.describe("Agent Mode Tests - Pro and Ultra Tiers", () => {
       );
 
       await chat.expectMessageContains(TEST_DATA.SECRETS.PDF);
+    });
+
+    test("should stage and read a large Agent-only file", async ({
+      page,
+    }, testInfo) => {
+      const chat = await setupChat(page);
+
+      await chat.switchToAgentMode();
+      await chat.expectMode("agent");
+
+      const largeFile = writeLargeAgentOnlyFile(
+        testInfo.outputPath("large-agent-only.txt"),
+      );
+      await chat.attachFile(largeFile);
+      await chat.expectFileAttached("large-agent-only.txt");
+
+      await sendAndWaitForResponse(
+        chat,
+        "Use terminal tools to inspect the attached large file. What is the SECRET_MARKER value?",
+        TIMEOUTS.AGENT_LONG,
+      );
+
+      await chat.expectMessageContains(TEST_DATA.SECRETS.AGENT_LARGE);
     });
 
     test("should handle multiple operations in Agent mode", async ({

--- a/e2e/chat-files-pro.spec.ts
+++ b/e2e/chat-files-pro.spec.ts
@@ -1,13 +1,38 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { ChatComponent } from "./page-objects";
 import {
   setupChat,
   sendMessageWithFileAndVerifyContent,
   attachTestFile,
+  sendAndWaitForResponse,
 } from "./helpers/test-helpers";
 import { AUTH_STORAGE_PATHS } from "./fixtures/auth";
 import { TIMEOUTS, TEST_DATA } from "./constants";
 import path from "path";
+import fs from "fs";
+
+test.setTimeout(TIMEOUTS.AGENT_LONG);
+
+async function writeJpegFixture(
+  page: Page,
+  outputPath: string,
+): Promise<string> {
+  const base64 = await page.evaluate(() => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 12;
+    canvas.height = 12;
+    const context = canvas.getContext("2d");
+    if (!context) throw new Error("Canvas context unavailable");
+    context.fillStyle = "#111827";
+    context.fillRect(0, 0, 12, 12);
+    context.fillStyle = "#22c55e";
+    context.fillRect(3, 3, 6, 6);
+    return canvas.toDataURL("image/jpeg", 0.9).split(",")[1];
+  });
+
+  fs.writeFileSync(outputPath, Buffer.from(base64, "base64"));
+  return outputPath;
+}
 
 test.describe("File Attachment Tests - Pro and Ultra Tiers", () => {
   test.describe("Pro Tier", () => {
@@ -45,6 +70,58 @@ test.describe("File Attachment Tests - Pro and Ultra Tiers", () => {
         "pdf",
         "What is the secret word in the file?",
         TEST_DATA.SECRETS.PDF,
+        TIMEOUTS.AGENT,
+      );
+    });
+
+    test("should attach markdown and CSV files and AI reads content", async ({
+      page,
+    }) => {
+      const chat = await setupChat(page);
+
+      const markdownFile = path.join(
+        process.cwd(),
+        TEST_DATA.RESOURCES.MARKDOWN_FILE,
+      );
+      const csvFile = path.join(process.cwd(), TEST_DATA.RESOURCES.CSV_FILE);
+
+      await chat.attachFiles([markdownFile, csvFile]);
+
+      await chat.expectAttachedFileCount(2);
+      await chat.expectFileAttached("secret.md");
+      await chat.expectFileAttached("secret.csv");
+
+      await sendAndWaitForResponse(
+        chat,
+        "What are the secret words in the attached markdown and CSV files?",
+        TIMEOUTS.AGENT,
+      );
+
+      await chat.expectMessageContains(TEST_DATA.SECRETS.MARKDOWN);
+      await chat.expectMessageContains(TEST_DATA.SECRETS.CSV);
+    });
+
+    test("should attach jpg and jpeg images", async ({ page }, testInfo) => {
+      const chat = await setupChat(page);
+
+      const jpgFile = await writeJpegFixture(
+        page,
+        testInfo.outputPath("sample.jpg"),
+      );
+      const jpegFile = await writeJpegFixture(
+        page,
+        testInfo.outputPath("sample.jpeg"),
+      );
+
+      await chat.attachFiles([jpgFile, jpegFile]);
+
+      await chat.expectAttachedFileCount(2);
+      await chat.expectFileAttached("sample.jpg");
+      await chat.expectFileAttached("sample.jpeg");
+
+      await sendAndWaitForResponse(
+        chat,
+        "Confirm the two attached images uploaded.",
         TIMEOUTS.AGENT,
       );
     });

--- a/e2e/chat-free.spec.ts
+++ b/e2e/chat-free.spec.ts
@@ -8,25 +8,24 @@ test.describe("Free Tier Simple Chat Tests", () => {
   test.use({ storageState: AUTH_STORAGE_PATHS.free });
 
   test("should handle multiple messages in conversation", async ({ page }) => {
+    test.setTimeout(TIMEOUTS.AGENT_LONG);
+
     const chat = await setupChat(page);
     const sidebar = new SidebarComponent(page);
 
     await sendAndWaitForResponse(
       chat,
       TEST_DATA.MESSAGES.MATH_SIMPLE,
-      TIMEOUTS.MEDIUM,
+      TIMEOUTS.LONG,
     );
+    await chat.expectMessageContains("4", TIMEOUTS.LONG);
 
     await sendAndWaitForResponse(
       chat,
       TEST_DATA.MESSAGES.MATH_NEXT,
-      TIMEOUTS.MEDIUM,
+      TIMEOUTS.LONG,
     );
-
-    await expect(async () => {
-      const messageCount = await chat.getMessageCount();
-      expect(messageCount).toBeGreaterThanOrEqual(4);
-    }).toPass({ timeout: TIMEOUTS.MEDIUM });
+    await chat.expectMessageContains("6", TIMEOUTS.LONG);
 
     // Ensure sidebar is expanded to see chat items
     await sidebar.expandIfCollapsed();

--- a/e2e/constants.ts
+++ b/e2e/constants.ts
@@ -27,6 +27,8 @@ export const TEST_DATA = {
     IMAGE: "e2e/resource/image.png",
     TEXT_FILE: "e2e/resource/secret.txt",
     PDF_FILE: "e2e/resource/secret.pdf",
+    MARKDOWN_FILE: "e2e/resource/secret.md",
+    CSV_FILE: "e2e/resource/secret.csv",
   },
 
   // Expected content in test files
@@ -34,6 +36,9 @@ export const TEST_DATA = {
     TEXT: "bazinga",
     PDF: "hippo",
     IMAGE_CONTENT: "duck",
+    MARKDOWN: "orion",
+    CSV: "violet",
+    AGENT_LARGE: "agent-large-marker",
   },
 
   // Common test messages

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -65,7 +65,7 @@ async function tryLoadFromStorageStateFile(
   );
   await page.context().addCookies(state.cookies);
   await page.goto("/");
-  return true;
+  return await isAuthenticatedUiVisible(page);
 }
 
 function isSessionValid(cache: SessionCache): boolean {
@@ -77,6 +77,20 @@ function isSessionValid(cache: SessionCache): boolean {
   return cache.cookies.some((cookie) => {
     return cookie.expires === -1 || cookie.expires > now / 1000;
   });
+}
+
+async function isAuthenticatedUiVisible(page: Page): Promise<boolean> {
+  const url = page.url();
+  const isWorkOSAuthPage =
+    /workos/i.test(url) && /sign[-_]?in|sign[-_]?up|auth/i.test(url);
+  if (isWorkOSAuthPage) return false;
+
+  const userMenuButton = page
+    .getByTestId("user-menu-button")
+    .or(page.getByTestId("user-menu-button-collapsed"));
+  return await userMenuButton
+    .isVisible({ timeout: TIMEOUTS.SHORT })
+    .catch(() => false);
 }
 
 export interface AuthOptions {
@@ -113,6 +127,8 @@ export async function authenticateUser(
         await page.context().storageState({ path: storagePath });
         return;
       }
+      sessionCache.delete(cacheKey);
+      await page.context().clearCookies();
     }
 
     // 2. Try in-memory session cache (same process only)
@@ -121,17 +137,13 @@ export async function authenticateUser(
       await page.context().addCookies(cached.cookies);
       await page.goto("/");
 
-      const userMenuButton = page
-        .getByTestId("user-menu-button")
-        .or(page.getByTestId("user-menu-button-collapsed"));
-      const isAuthenticated = await userMenuButton
-        .isVisible({ timeout: TIMEOUTS.SHORT })
-        .catch(() => false);
+      const isAuthenticated = await isAuthenticatedUiVisible(page);
       if (isAuthenticated) {
         await page.context().storageState({ path: getStorageStatePath(user) });
         return;
       }
       sessionCache.delete(cacheKey);
+      await page.context().clearCookies();
     }
   }
 

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -16,9 +16,19 @@ export async function sendAndWaitForResponse(
   message: string,
   timeout: number = TIMEOUTS.LONG,
 ): Promise<void> {
+  const assistantSnapshot = await chat.getAssistantMessageSnapshot();
+  const generationResponsePromise = chat.waitForGenerationResponse(timeout);
   await chat.sendMessage(message);
   await chat.expectStreamingVisible();
+  const generationResponse = await generationResponsePromise;
+  if (generationResponse) {
+    await Promise.race([
+      generationResponse.finished().catch(() => null),
+      chat.waitForAssistantMessageAfter(assistantSnapshot, timeout),
+    ]);
+  }
   await chat.expectStreamingNotVisible(timeout);
+  await chat.waitForAssistantMessageAfter(assistantSnapshot, timeout);
 }
 
 /**

--- a/e2e/page-objects/ChatComponent.ts
+++ b/e2e/page-objects/ChatComponent.ts
@@ -1,6 +1,11 @@
-import { Page, expect, Locator } from "@playwright/test";
+import { Page, expect, Locator, type Response } from "@playwright/test";
 import path from "path";
 import { TIMEOUTS } from "../constants";
+
+type AssistantMessageSnapshot = {
+  count: number;
+  lastText: string | null;
+};
 
 export class ChatComponent {
   constructor(private page: Page) {}
@@ -29,6 +34,10 @@ export class ChatComponent {
     return this.page.locator(
       '[data-testid="user-message"], [data-testid="assistant-message"]',
     );
+  }
+
+  private get assistantMessages(): Locator {
+    return this.page.getByTestId("assistant-message");
   }
 
   private get streamingIndicator(): Locator {
@@ -75,6 +84,23 @@ export class ChatComponent {
     await this.chatInput.fill(message);
     await expect(this.sendButton).toBeEnabled({ timeout: TIMEOUTS.MEDIUM });
     await this.sendButton.click();
+  }
+
+  waitForGenerationResponse(
+    timeout: number = TIMEOUTS.LONG,
+  ): Promise<Response | null> {
+    return this.page
+      .waitForResponse(
+        (response) => {
+          const method = response.request().method();
+          if (method !== "POST") return false;
+
+          const pathname = new URL(response.url()).pathname;
+          return pathname === "/api/chat" || pathname === "/api/agent-long";
+        },
+        { timeout },
+      )
+      .catch(() => null);
   }
 
   async typeMessage(message: string): Promise<void> {
@@ -149,9 +175,44 @@ export class ChatComponent {
       await this.stopButton.waitFor({ state: "hidden", timeout });
     }
 
-    await this.messages
+    await this.messages.last().waitFor({ state: "visible", timeout });
+  }
+
+  async waitForAssistantMessage(
+    timeout: number = TIMEOUTS.MEDIUM,
+  ): Promise<void> {
+    await this.assistantMessages.last().waitFor({ state: "visible", timeout });
+  }
+
+  async getAssistantMessageSnapshot(): Promise<AssistantMessageSnapshot> {
+    const count = await this.assistantMessages.count();
+    if (count === 0) {
+      return { count, lastText: null };
+    }
+
+    const lastText = await this.assistantMessages
       .last()
-      .waitFor({ state: "visible", timeout: TIMEOUTS.SHORT });
+      .innerText()
+      .catch(() => null);
+    return { count, lastText };
+  }
+
+  async waitForAssistantMessageAfter(
+    snapshot: AssistantMessageSnapshot,
+    timeout: number = TIMEOUTS.MEDIUM,
+  ): Promise<void> {
+    await expect(async () => {
+      const count = await this.assistantMessages.count();
+      expect(count).toBeGreaterThan(0);
+
+      const lastAssistant = this.assistantMessages.last();
+      await expect(lastAssistant).toBeVisible({ timeout: 1000 });
+
+      const lastText = await lastAssistant.innerText();
+      if (count <= snapshot.count && lastText === snapshot.lastText) {
+        throw new Error("Waiting for a new assistant message");
+      }
+    }).toPass({ timeout });
   }
 
   async getMessageCount(
@@ -198,16 +259,19 @@ export class ChatComponent {
   async expectStreamingNotVisible(
     timeout: number = TIMEOUTS.AGENT,
   ): Promise<void> {
-    const stopButtonHidden = await this.stopButton
-      .waitFor({ state: "hidden", timeout })
-      .then(() => true)
-      .catch(() => false);
-    const streamingHidden = await this.streamingIndicator
-      .waitFor({ state: "hidden", timeout })
-      .then(() => true)
-      .catch(() => false);
+    await expect(async () => {
+      const stopButtonVisible = await this.stopButton
+        .isVisible({ timeout: 1000 })
+        .catch(() => false);
+      const streamingVisible = await this.streamingIndicator
+        .isVisible({ timeout: 1000 })
+        .catch(() => false);
 
-    expect(stopButtonHidden || streamingHidden).toBe(true);
+      expect(stopButtonVisible).toBe(false);
+      expect(streamingVisible).toBe(false);
+    }).toPass({ timeout });
+
+    await expect(this.chatInput).toBeEditable({ timeout: TIMEOUTS.SHORT });
   }
 
   async expectUpgradeDialogVisible(): Promise<void> {

--- a/e2e/resource/secret.csv
+++ b/e2e/resource/secret.csv
@@ -1,0 +1,2 @@
+label,value
+secret_word,violet

--- a/e2e/resource/secret.md
+++ b/e2e/resource/secret.md
@@ -1,0 +1,3 @@
+# E2E Markdown Fixture
+
+The markdown secret word is orion.

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -161,6 +161,25 @@ describe("agent-long-transport — direct UI stream reader", () => {
       /cancel\(\)\s*\{[\s\S]*cancelConsumerRealtime\(\)/,
     );
   });
+
+  test("does not close an already errored browser stream controller", () => {
+    const abortAndCloseIdx = transportSrc.indexOf(
+      "const sendAbortAndClose = () =>",
+    );
+    const closeHelperIdx = transportSrc.indexOf("const close = () =>");
+
+    expect(abortAndCloseIdx).toBeGreaterThan(-1);
+    expect(closeHelperIdx).toBeGreaterThan(abortAndCloseIdx);
+    expect(transportSrc).toMatch(/controller\.desiredSize\s*===\s*null/);
+    const abortAndCloseSrc = transportSrc.slice(
+      abortAndCloseIdx,
+      closeHelperIdx,
+    );
+    expect(abortAndCloseSrc).toMatch(
+      /if\s*\(\s*!isControllerErrored\(\)\s*\)[\s\S]*controller\.enqueue\(/,
+    );
+    expect(abortAndCloseSrc).toMatch(/controller\.close\(\)/);
+  });
 });
 
 describe("agent stream runner — empty todo_write recovery", () => {
@@ -206,8 +225,10 @@ describe("agent-long chat UI — completion reconciliation", () => {
   test("polls the resume endpoint and clears useChat state after backend completion", () => {
     expect(chatComponentSrc).toMatch(/AGENT_LONG_COMPLETION_POLL_DELAY_MS/);
     expect(chatComponentSrc).toMatch(/AGENT_LONG_COMPLETION_QUIET_MS/);
+    expect(chatComponentSrc).toMatch(/AGENT_LONG_COMPLETION_STOP_GRACE_MS/);
     expect(chatComponentSrc).toMatch(/\/api\/agent-long\/resume\?chatId=/);
     expect(chatComponentSrc).toMatch(/response\.status\s*===\s*204/);
+    expect(chatComponentSrc).toMatch(/scheduleFinishLocally\(\)/);
     expect(chatComponentSrc).toMatch(/finishLocally\(\)/);
     expect(chatComponentSrc).toMatch(/stop\(\)/);
     expect(chatComponentSrc).toMatch(/window\.history\.replaceState/);
@@ -237,6 +258,15 @@ describe("agent-long chat UI — completion reconciliation", () => {
     );
     expect(globalStateSrc).toMatch(/optimisticChatId:\s*string\s*\|\s*null/);
     expect(globalStateSrc).toMatch(/setOptimisticChatId/);
+  });
+
+  test("suppresses only the known agent-long double-close browser noise", () => {
+    expect(chatComponentSrc).toMatch(/suppressAgentLongDoubleCloseNoise/);
+    expect(chatComponentSrc).toMatch(
+      /shouldUseAgentLongForCurrentChatRef\.current/,
+    );
+    expect(chatComponentSrc).toMatch(/Cannot close an errored readable stream/);
+    expect(chatComponentSrc).toMatch(/event\.preventDefault\(\)/);
   });
 
   test("guards auto-resume and stream data against stale chat switches", () => {

--- a/lib/chat/agent-long-transport.ts
+++ b/lib/chat/agent-long-transport.ts
@@ -169,6 +169,7 @@ const buildSSEResponseFromRun = (
       let statusSubscription: { unsubscribe?: () => void } | undefined;
       let streamIterator: AsyncIterator<unknown> | undefined;
       let userAborted = false;
+      const isControllerErrored = () => controller.desiredSize === null;
 
       cancelRealtimeSubscriptions = async () => {
         readAbortController?.abort();
@@ -181,17 +182,19 @@ const buildSSEResponseFromRun = (
       const sendAbortAndClose = () => {
         if (closed) return;
         closed = true;
-        try {
-          controller.enqueue(
-            encoder.encode(`data: ${JSON.stringify({ type: "abort" })}\n\n`),
-          );
-        } catch {
-          // controller may already be closed
-        }
-        try {
-          controller.close();
-        } catch {
-          // ignore if already closed
+        if (!isControllerErrored()) {
+          try {
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify({ type: "abort" })}\n\n`),
+            );
+          } catch {
+            // controller may already be closed
+          }
+          try {
+            controller.close();
+          } catch {
+            // ignore if already closed
+          }
         }
       };
       closeConsumerStream = sendAbortAndClose;
@@ -199,10 +202,12 @@ const buildSSEResponseFromRun = (
       const close = () => {
         if (closed) return;
         closed = true;
-        try {
-          controller.close();
-        } catch {
-          // already closed by sendAbortAndClose
+        if (!isControllerErrored()) {
+          try {
+            controller.close();
+          } catch {
+            // already closed by sendAbortAndClose
+          }
         }
       };
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "pnpm dev:next",
+    command: "corepack pnpm exec next dev --webpack",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120000,


### PR DESCRIPTION
## Summary
- validate cached e2e auth state against authenticated UI before reusing it, and fall through to real WorkOS login when stale
- harden chat e2e send waits around generation network responses, assistant rendering, and true idle state
- add focused upload coverage for markdown, CSV, JPG/JPEG, and a large Agent-only sandbox file
- make Playwright use `corepack pnpm exec next dev --webpack` for worktree reliability
- quiet the known Agent-long double-close browser noise while preserving the 204 completion fallback

## Validation
- `corepack pnpm jest lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `corepack pnpm typecheck`
- `corepack pnpm exec eslint app/components/chat.tsx e2e/fixtures/auth.ts e2e/page-objects/ChatComponent.ts e2e/helpers/test-helpers.ts e2e/constants.ts e2e/chat-free.spec.ts e2e/chat-files-pro.spec.ts e2e/chat-agent.spec.ts playwright.config.ts lib/chat/agent-long-transport.ts lib/api/__tests__/agent-long-contracts.test.ts` (passes with existing chat.tsx hook warnings)
- `node_modules/.bin/prettier --check app/components/chat.tsx e2e/fixtures/auth.ts e2e/page-objects/ChatComponent.ts e2e/helpers/test-helpers.ts e2e/constants.ts e2e/chat-free.spec.ts e2e/chat-files-pro.spec.ts e2e/chat-agent.spec.ts e2e/resource/secret.md playwright.config.ts lib/chat/agent-long-transport.ts lib/api/__tests__/agent-long-contracts.test.ts`
- Seeded stale `e2e/.auth/*.json`, then `corepack pnpm test:e2e --project=setup` passed and overwrote auth via real login
- `corepack pnpm test:e2e --project=chromium --no-deps --workers=1 e2e/chat-files-pro.spec.ts -g "Pro Tier.*should attach (markdown|jpg)"`
- `corepack pnpm test:e2e --project=chromium --no-deps --workers=1 e2e/chat-agent.spec.ts -g "Pro Tier.*(should accept file operations|should stage and read)"`
- `corepack pnpm test:e2e --project=chromium --no-deps --workers=1 e2e/chat-agent.spec.ts -g "Pro Tier.*should accept file operations"` after stream-noise fix, with no `Cannot close an errored readable stream` browser log

## Current live finding
- `corepack pnpm test:e2e --project=chromium --no-deps --workers=1 e2e/chat-free.spec.ts` no longer reproduces the previous second-turn 429 after the stricter helper changes, but currently fails earlier because the first free Ask turn generates a title and clears loading UI while no `assistant-message` mounts within 120s. This is now classified as a separate live simple-chat render/persistence issue, not the original active-request race. Latest artifact: `test-results/chat-free-Free-Tier-Simple-26f3a-le-messages-in-conversation-chromium/error-context.md`.

## Manual verification
- Run setup from deliberately stale `e2e/.auth/*.json`; expected: setup performs real login and overwrites storage state instead of passing from stale cookies.
- Run Pro upload smoke for `.md`, `.csv`, `.jpg`, `.jpeg`; expected: previews/uploads complete and markdown/CSV content is read.
- Run Pro Agent file-operation guard with Trigger dev running; expected: answer renders, Working/Stop clears, and no readable-stream double-close browser error is logged.
- Recheck Free Ask simple chat separately; expected issue to investigate: title appears but assistant message may not mount even after loading clears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chat handling for longer-running Agent sessions, with smoother completion behavior and less noisy error reporting.
  * Expanded file attachments support in chat, including richer handling for document, spreadsheet, and image uploads.

* **Bug Fixes**
  * Reduced cases where streams could stop too early or show misleading errors during Agent responses.
  * Improved authentication recovery so saved sessions are verified more reliably before reuse.

* **Tests**
  * Added broader end-to-end coverage for Agent mode, multi-file uploads, and longer conversation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->