### PR TITLE
Refresh upload auth after entitlement sync

### DIFF
--- a/__mocks__/workos.ts
+++ b/__mocks__/workos.ts
@@ -6,8 +6,8 @@ export const useAuth = jest.fn(() => ({
   signOut: jest.fn(),
 }));
 
-export const useAccessToken = () => ({
+export const useAccessToken = jest.fn(() => ({
   getAccessToken: jest.fn().mockResolvedValue("mock-access-token"),
   accessToken: "mock-access-token",
   refresh: jest.fn().mockResolvedValue("mock-access-token"),
-});
+}));

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -10,7 +10,7 @@ import React, {
   useRef,
   ReactNode,
 } from "react";
-import { useAuth } from "@workos-inc/authkit-nextjs/components";
+import { useAccessToken, useAuth } from "@workos-inc/authkit-nextjs/components";
 import {
   type ChatMode,
   type SelectedModel,
@@ -33,6 +33,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useSandboxPreference } from "@/app/hooks/useSandboxPreference";
 import { isTauriEnvironment } from "@/app/hooks/useTauri";
 import { resolveSubscriptionTier } from "@/lib/auth/entitlements";
+import { clearSharedToken, setSharedToken } from "@/lib/auth/shared-token";
 import { chatSidebarStorage } from "@/lib/utils/sidebar-storage";
 import type { Id } from "@/convex/_generated/dataModel";
 import { useMutation, useQuery } from "convex/react";
@@ -195,7 +196,14 @@ interface LocalSandboxConnection {
 export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   children,
 }) => {
-  const { user, entitlements, loading: authLoading } = useAuth();
+  const {
+    user,
+    entitlements,
+    loading: authLoading,
+    organizationId,
+    refreshAuth,
+  } = useAuth();
+  const { refresh: refreshAccessToken } = useAccessToken();
   const isMobile = useIsMobile();
   const prevIsMobile = useRef(isMobile);
   const shownReferralRewardNotificationsRef = useRef(new Set<string>());
@@ -227,6 +235,28 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     if (!Array.isArray(entitlements)) return null;
     return resolveSubscriptionTier(entitlements);
   }, [entitlements]);
+  const refreshAuthTokenAfterEntitlementRefresh = useCallback(async () => {
+    clearSharedToken();
+
+    try {
+      if (refreshAuth) {
+        await refreshAuth(organizationId ? { organizationId } : undefined);
+      }
+    } catch {
+      // Keep going: the access-token refresh below may still pick up the
+      // sealed session written by /api/entitlements.
+    }
+
+    try {
+      const token = await refreshAccessToken();
+      if (token) {
+        setSharedToken(token);
+      }
+    } catch {
+      // Non-fatal. The UI still reflects /api/entitlements, and AuthKit will
+      // retry token refresh through its normal path.
+    }
+  }, [organizationId, refreshAccessToken, refreshAuth]);
 
   // Persist chat mode preference to localStorage on change
   useEffect(() => {
@@ -628,6 +658,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
         if (!response.ok) return;
 
         const data = await response.json();
+        await refreshAuthTokenAfterEntitlementRefresh();
         setSubscriptionWithNormalize(
           resolveSubscriptionTier(
             Array.isArray(data.entitlements) ? data.entitlements : [],
@@ -641,7 +672,12 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     };
 
     refreshDesktopEntitlements();
-  }, [user, entitlements, setSubscriptionWithNormalize]);
+  }, [
+    user,
+    entitlements,
+    refreshAuthTokenAfterEntitlementRefresh,
+    setSubscriptionWithNormalize,
+  ]);
 
   // Refresh entitlements only when explicitly requested via URL param
   useEffect(() => {
@@ -672,6 +708,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
 
         if (response.ok) {
           const data = await response.json();
+          await refreshAuthTokenAfterEntitlementRefresh();
           const tier = data.subscription as SubscriptionTier | undefined;
           setSubscription(
             tier === "ultra" ||
@@ -702,7 +739,11 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     };
 
     refreshFromUrl();
-  }, [user, setSubscriptionWithNormalize]);
+  }, [
+    user,
+    refreshAuthTokenAfterEntitlementRefresh,
+    setSubscriptionWithNormalize,
+  ]);
 
   // Listen for URL changes to sync temporary chat state
   useEffect(() => {

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -1,10 +1,14 @@
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
-import { useAuth } from "@workos-inc/authkit-nextjs/components";
+import { useAccessToken, useAuth } from "@workos-inc/authkit-nextjs/components";
 import { GlobalStateProvider, useGlobalState } from "../GlobalState";
+import { SHARED_TOKEN_KEY } from "@/lib/auth/shared-token";
 
-const mockAuthUser = (entitlements: string[]) => {
+const mockAuthUser = (
+  entitlements: string[],
+  overrides: Partial<ReturnType<typeof useAuth>> = {},
+) => {
   jest.mocked(useAuth).mockReturnValue({
     user: { id: "user_ultra" },
     entitlements,
@@ -12,24 +16,42 @@ const mockAuthUser = (entitlements: string[]) => {
     isAuthenticated: true,
     signIn: jest.fn(),
     signOut: jest.fn(),
+    organizationId: "org_ultra",
+    refreshAuth: jest.fn(),
+    ...overrides,
   } as ReturnType<typeof useAuth>);
 };
 
 function GlobalStateProbe() {
-  const { chatMode, sandboxPreference, selectedModel } = useGlobalState();
+  const {
+    chatMode,
+    isCheckingProPlan,
+    sandboxPreference,
+    selectedModel,
+    subscription,
+  } = useGlobalState();
 
   return (
     <>
       <div data-testid="chat-mode">{chatMode}</div>
+      <div data-testid="checking-pro-plan">{String(isCheckingProPlan)}</div>
       <div data-testid="sandbox-preference">{sandboxPreference}</div>
       <div data-testid="selected-model">{selectedModel}</div>
+      <div data-testid="subscription">{subscription}</div>
     </>
   );
 }
 
 describe("GlobalStateProvider agent defaults", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
+    window.history.pushState({}, "", "/");
     window.localStorage.clear();
+    jest.mocked(useAccessToken).mockReturnValue({
+      getAccessToken: jest.fn().mockResolvedValue("mock-access-token"),
+      accessToken: "mock-access-token",
+      refresh: jest.fn().mockResolvedValue("mock-access-token"),
+    } as ReturnType<typeof useAccessToken>);
     global.fetch = jest.fn(() =>
       Promise.resolve({ ok: false }),
     ) as unknown as typeof fetch;
@@ -52,5 +74,57 @@ describe("GlobalStateProvider agent defaults", () => {
 
     expect(screen.getByTestId("selected-model")).toHaveTextContent("auto");
     expect(screen.getByTestId("sandbox-preference")).toHaveTextContent("e2b");
+  });
+
+  it("refreshes AuthKit access token after checkout entitlement refresh before showing paid state", async () => {
+    const refreshAuth = jest.fn().mockResolvedValue(undefined);
+    const refreshAccessToken = jest.fn().mockResolvedValue("fresh-paid-token");
+
+    mockAuthUser([], { refreshAuth });
+    jest.mocked(useAccessToken).mockReturnValue({
+      getAccessToken: jest.fn().mockResolvedValue("old-free-token"),
+      accessToken: "old-free-token",
+      refresh: refreshAccessToken,
+    } as ReturnType<typeof useAccessToken>);
+    window.localStorage.setItem(
+      SHARED_TOKEN_KEY,
+      JSON.stringify({
+        token: "stale-free-token",
+        refreshedAt: Date.now(),
+      }),
+    );
+    window.history.pushState({}, "", "/?refresh=entitlements");
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            entitlements: ["pro-plan"],
+            subscription: "pro",
+          }),
+      }),
+    ) as unknown as typeof fetch;
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    });
+
+    expect(refreshAuth).toHaveBeenCalledWith({ organizationId: "org_ultra" });
+    expect(JSON.parse(window.localStorage.getItem(SHARED_TOKEN_KEY)!)).toEqual(
+      expect.objectContaining({ token: "fresh-paid-token" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("subscription")).toHaveTextContent("pro");
+      expect(screen.getByTestId("checking-pro-plan")).toHaveTextContent(
+        "false",
+      );
+    });
   });
 });

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -94,16 +94,31 @@ describe("GlobalStateProvider agent defaults", () => {
       }),
     );
     window.history.pushState({}, "", "/?refresh=entitlements");
-    global.fetch = jest.fn(() =>
-      Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            entitlements: ["pro-plan"],
-            subscription: "pro",
-          }),
-      }),
-    ) as unknown as typeof fetch;
+    global.fetch = jest.fn((input) => {
+      const url = String(input);
+      if (url === "/api/entitlements") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              entitlements: ["pro-plan"],
+              subscription: "pro",
+            }),
+        });
+      }
+
+      if (url === "/api/referrals/attribution") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({}),
+        });
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({}),
+      });
+    }) as unknown as typeof fetch;
 
     render(
       <GlobalStateProvider>


### PR DESCRIPTION
## Summary
- refresh the AuthKit session/access token after `/api/entitlements` returns updated plan state
- clear and replace the shared Convex auth token cache so uploads do not reuse stale free-tier claims after checkout
- add regression coverage for returning from checkout with `refresh=entitlements` while a stale shared token exists

## Why
A newly upgraded Pro user could see paid UI state in the sidebar/model selector while file upload still failed with `PAID_PLAN_REQUIRED`. The UI was updated from `/api/entitlements`, but Convex upload authorization reads entitlements from the access token claims used by Convex. If that token was stale, upload URL generation still saw the user as free.

## Validation
- `./node_modules/.bin/jest app/contexts/__tests__/GlobalState.agent-default.test.tsx --runInBand`
- `./node_modules/.bin/prettier --check app/contexts/GlobalState.tsx app/contexts/__tests__/GlobalState.agent-default.test.tsx __mocks__/workos.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`

Note: `pnpm jest ...` attempted to install missing worktree dependencies and hit restricted-network DNS. I temporarily linked the main checkout `node_modules`/`packages/local/node_modules` to run the validation above, then removed the links.

## Manual verification
- Upgrade a free account to Pro from checkout.
- Return to the app at the success URL with `refresh=entitlements`.
- Immediately attach a file in Ask mode.
- The file should upload successfully without `Paid plan required for file uploads`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entitlement refresh so authentication access tokens are refreshed immediately after subscription/entitlement updates, keeping UI and account state in sync.
  * Persist refreshed access tokens during the entitlement refresh flow to reduce stale authentication behavior.
* **Tests**
  * Expanded and added automated coverage for entitlement refresh triggered by a URL action, validating token refresh and subsequent auth refresh before showing paid subscription state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->