### PR TITLE
Resume budget-exhausted Agent runs in place

### DIFF
--- a/app/components/FinishReasonNotice.tsx
+++ b/app/components/FinishReasonNotice.tsx
@@ -65,6 +65,10 @@ export const FinishReasonNotice = ({
       return <>Paused at the Pro Agent per-run safety cap.</>;
     }
 
+    if (finishReason === "budget-exhausted") {
+      return <>Paused at the usage budget limit.</>;
+    }
+
     return null;
   };
 

--- a/app/components/__tests__/FinishReasonNotice.test.tsx
+++ b/app/components/__tests__/FinishReasonNotice.test.tsx
@@ -128,6 +128,10 @@ describe("FinishReasonNotice", () => {
         finishReason: "context-limit",
         expectedText: "Reached the context limit for this conversation",
       },
+      {
+        finishReason: "budget-exhausted",
+        expectedText: "Paused at the usage budget limit",
+      },
     ])(
       "renders notice for finishReason=$finishReason when autoContinueCount has reached MAX_AUTO_CONTINUES",
       ({ finishReason, expectedText }) => {
@@ -212,6 +216,7 @@ describe("FinishReasonNotice", () => {
       "context-limit",
       "preemptive-timeout",
       "agent-run-spend-cap",
+      "budget-exhausted",
     ])("renders the Continue button for finishReason=%s", (finishReason) => {
       const onContinue = jest.fn();
       renderNotice(

--- a/lib/system-prompt/__tests__/resume.test.ts
+++ b/lib/system-prompt/__tests__/resume.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { getResumeSection } from "../resume";
+
+describe("getResumeSection", () => {
+  it("instructs budget-exhausted continuations to resume without repeating work", () => {
+    const section = getResumeSection("budget-exhausted");
+
+    expect(section).toContain("user cost-control pause");
+    expect(section).toContain("resume the task exactly where you left off");
+    expect(section).toContain("without repeating completed work");
+  });
+});

--- a/lib/system-prompt/resume.ts
+++ b/lib/system-prompt/resume.ts
@@ -35,6 +35,12 @@ Your previous response was paused by the Pro Agent per-run spend cap. \
 This was a user cost-control pause, not a task failure. If the user says "continue" or similar, \
 resume the task exactly where you left off without repeating what was already done.
 </resume_context>`;
+  } else if (finishReason === "budget-exhausted") {
+    return `<resume_context>
+Your previous response was paused because the monthly usage budget or extra usage spending limit was reached. \
+This was a user cost-control pause, not a task failure. If the user says "continue" or similar, \
+resume the task exactly where you left off without repeating completed work or starting the task over.
+</resume_context>`;
   }
 
   return "";


### PR DESCRIPTION
## Summary
- add resume context for budget-exhausted Agent and long-run continuations
- show a finish-reason notice when a run pauses at the usage budget limit
- cover the new continuation and notice behavior with focused tests

## Why
When an Agent run was cut off by the monthly usage budget or extra-usage spending limit, the saved finish reason was budget-exhausted. Follow-up Continue messages did not receive the same resume instruction used for tool limits, context limits, timeouts, or Pro Agent spend-cap pauses, so the model could restart or repeat expensive work after the user raised credits or limits.

## Validation
- ./node_modules/.bin/jest app/components/__tests__/FinishReasonNotice.test.tsx lib/system-prompt/__tests__/resume.test.ts --runInBand
- ./node_modules/.bin/prettier --check app/components/FinishReasonNotice.tsx app/components/__tests__/FinishReasonNotice.test.tsx lib/system-prompt/resume.ts lib/system-prompt/__tests__/resume.test.ts

## Manual verification
- In Agent mode, trigger or simulate a run ending with finish_reason budget-exhausted.
- Confirm the saved chat shows a usage-budget pause notice with a Continue action.
- Click Continue after credits or limits are available and confirm the next prompt includes resume context to continue from the prior work instead of starting over.