### PR TITLE
Filter expected Convex error noise

### DIFF
--- a/app/components/ConvexErrorBoundary.tsx
+++ b/app/components/ConvexErrorBoundary.tsx
@@ -3,6 +3,7 @@
 import React, { Component, ReactNode } from "react";
 import { ConvexError } from "convex/values";
 import { toast } from "sonner";
+import { isExpectedConvexErrorCode } from "@/lib/utils/expected-convex-errors";
 
 interface Props {
   children: ReactNode;
@@ -25,11 +26,12 @@ export class ConvexErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error("ConvexErrorBoundary caught an error:", error, errorInfo);
-
     // Handle ConvexError with toast
     if (error instanceof ConvexError) {
       const errorData = error.data as { code?: string; message?: string };
+      if (!isExpectedConvexErrorCode(errorData?.code)) {
+        console.error("ConvexErrorBoundary caught an error:", error, errorInfo);
+      }
 
       // Note: CHAT_NOT_FOUND is now handled gracefully in the query itself
       // by returning empty results, so we don't need to handle it here
@@ -43,6 +45,7 @@ export class ConvexErrorBoundary extends Component<Props, State> {
         });
       }
     } else {
+      console.error("ConvexErrorBoundary caught an error:", error, errorInfo);
       toast.error("Something went wrong", {
         description: "Please try refreshing the page.",
       });

--- a/app/components/__tests__/ConvexErrorBoundary.test.tsx
+++ b/app/components/__tests__/ConvexErrorBoundary.test.tsx
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import type { ErrorInfo } from "react";
+import { ConvexError } from "convex/values";
+
+jest.mock("sonner", () => ({
+  toast: {
+    error: jest.fn(),
+  },
+}));
+
+const { ConvexErrorBoundary } =
+  require("../ConvexErrorBoundary") as typeof import("../ConvexErrorBoundary");
+const errorInfo = { componentStack: "" } as ErrorInfo;
+
+const createBoundary = () => new ConvexErrorBoundary({ children: null });
+const { toast } = jest.requireMock<typeof import("sonner")>("sonner");
+
+describe("ConvexErrorBoundary", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("does not log expected Convex errors", () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    createBoundary().componentDidCatch(
+      new ConvexError({
+        code: "CHAT_ACCESS_SUSPENDED",
+        message: "Your account has been suspended.",
+      }),
+      errorInfo,
+    );
+
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith("Error", {
+      description: "Your account has been suspended.",
+    });
+  });
+
+  it("logs unknown Convex errors", () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const error = new ConvexError({
+      code: "NEW_UNHANDLED_CONVEX_ERROR",
+      message: "Something changed.",
+    });
+
+    createBoundary().componentDidCatch(error, errorInfo);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "ConvexErrorBoundary caught an error:",
+      error,
+      errorInfo,
+    );
+  });
+
+  it("logs non-Convex errors", () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const error = new Error("render failed");
+
+    createBoundary().componentDidCatch(error, errorInfo);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "ConvexErrorBoundary caught an error:",
+      error,
+      errorInfo,
+    );
+  });
+});

--- a/lib/posthog/__tests__/expected-convex-errors.test.ts
+++ b/lib/posthog/__tests__/expected-convex-errors.test.ts
@@ -1,4 +1,7 @@
-import { shouldDropExpectedConvexException } from "../expected-convex-errors";
+import {
+  isExpectedConvexErrorCode,
+  shouldDropExpectedConvexException,
+} from "../expected-convex-errors";
 
 describe("shouldDropExpectedConvexException", () => {
   it("drops paid-plan upload errors from nested exception values", () => {
@@ -97,10 +100,51 @@ describe("shouldDropExpectedConvexException", () => {
         event: "$exception",
         properties: {
           $exception_message:
-            'Uncaught ConvexError: {"code":"CHAT_ACCESS_SUSPENDED","message":"Your account has been suspended due to a fraudulent payment dispute (chargeback)."}',
+            'Uncaught ConvexError: {"code":"CHAT_ACCESS_SUSPENDED","message":"Your account has been suspended due to a fraudulent payment dispute (chargeback). Please contact support via chat at https://help.hackerai.co/ if you believe this is a mistake.","suspensionCategory":"dispute_fraudulent","suspensionSource":"stripe"}',
         },
       }),
     ).toBe(true);
+  });
+
+  it("drops expected Convex exceptions by code even when the message changes", () => {
+    expect(
+      shouldDropExpectedConvexException({
+        event: "$exception",
+        properties: {
+          $exception_message:
+            'Uncaught ConvexError: {"code":"IMAGE_SIZE_EXCEEDED","message":"The image copy can change without updating this filter."}',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("drops expected Convex exceptions when the JSON payload is escaped", () => {
+    expect(
+      shouldDropExpectedConvexException({
+        event: "$exception",
+        properties: {
+          $exception_message:
+            'Uncaught ConvexError: {\\"code\\":\\"FILE_SIZE_EXCEEDED\\",\\"message\\":\\"Too large\\"}',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps Convex exceptions with unknown codes", () => {
+    expect(
+      shouldDropExpectedConvexException({
+        event: "$exception",
+        properties: {
+          $exception_message:
+            'Uncaught ConvexError: {"code":"NEW_UNHANDLED_CONVEX_ERROR","message":"Something changed"}',
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("classifies expected Convex error codes", () => {
+    expect(isExpectedConvexErrorCode("CHAT_ACCESS_SUSPENDED")).toBe(true);
+    expect(isExpectedConvexErrorCode("NEW_UNHANDLED_CONVEX_ERROR")).toBe(false);
   });
 
   it("drops Convex optimistic concurrency retries from file upload metadata", () => {

--- a/lib/posthog/expected-convex-errors.ts
+++ b/lib/posthog/expected-convex-errors.ts
@@ -1,17 +1,17 @@
+import {
+  getConvexErrorCodeFromText,
+  isExpectedConvexErrorCode,
+} from "@/lib/utils/expected-convex-errors";
+
+export { isExpectedConvexErrorCode };
+
 const IGNORED_CONVEX_EXCEPTION_MESSAGES = [
   "Unauthorized: User not authenticated",
   "Invalid arguments provided",
-  "FILE_TOKEN_LIMIT_EXCEEDED",
-  "FILE_UPLOAD_RATE_LIMIT",
-  "STORAGE_LIMIT_EXCEEDED",
   "exceeds the maximum token limit",
   "cloud file upload limit",
-  "INVALID_FILE_SIZE",
   "Batch size exceeds limit",
-  "PAID_PLAN_REQUIRED",
   "Paid plan required for file uploads",
-  "CHAT_UNAUTHORIZED",
-  "CHAT_ACCESS_SUSPENDED",
   "Unauthorized: Chat does not belong to user",
   "OptimisticConcurrencyControlFailure",
   'Documents read from or written to the "btreeNode" table changed',
@@ -44,14 +44,21 @@ const collectStrings = (value: unknown, strings: string[] = []): string[] => {
   return strings;
 };
 
+const shouldDropExpectedConvexMessage = (message: string): boolean => {
+  const code = getConvexErrorCodeFromText(message);
+  if (isExpectedConvexErrorCode(code)) {
+    return true;
+  }
+
+  return IGNORED_CONVEX_EXCEPTION_MESSAGES.some((ignoredMessage) =>
+    message.includes(ignoredMessage),
+  );
+};
+
 export function shouldDropExpectedConvexException(event: PostHogEventLike) {
   if (event.event !== "$exception") {
     return false;
   }
 
-  return collectStrings(event.properties).some((message) =>
-    IGNORED_CONVEX_EXCEPTION_MESSAGES.some((ignoredMessage) =>
-      message.includes(ignoredMessage),
-    ),
-  );
+  return collectStrings(event.properties).some(shouldDropExpectedConvexMessage);
 }

--- a/lib/utils/expected-convex-errors.ts
+++ b/lib/utils/expected-convex-errors.ts
@@ -1,0 +1,35 @@
+const EXPECTED_CONVEX_ERROR_CODES = new Set([
+  "CHAT_ACCESS_SUSPENDED",
+  "CHAT_UNAUTHORIZED",
+  "FILE_SIZE_EXCEEDED",
+  "FILE_TOKEN_LIMIT_EXCEEDED",
+  "FILE_UPLOAD_RATE_LIMIT",
+  "IMAGE_SIZE_EXCEEDED",
+  "INVALID_FILE_SIZE",
+  "INVALID_IMAGE_BYTES",
+  "PAID_PLAN_REQUIRED",
+  "STORAGE_LIMIT_EXCEEDED",
+]);
+
+export function getConvexErrorCodeFromText(value: string): string | undefined {
+  const start = value.indexOf("{");
+  const end = value.lastIndexOf("}");
+  if (start === -1 || end <= start) return undefined;
+
+  try {
+    const parsed = JSON.parse(value.slice(start, end + 1));
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const code = (parsed as { code?: unknown }).code;
+      return typeof code === "string" ? code : undefined;
+    }
+  } catch {
+    const match = value.replace(/\\"/g, '"').match(/"code"\s*:\s*"([^"]+)"/);
+    return match?.[1];
+  }
+
+  return undefined;
+}
+
+export function isExpectedConvexErrorCode(code: unknown): boolean {
+  return typeof code === "string" && EXPECTED_CONVEX_ERROR_CODES.has(code);
+}


### PR DESCRIPTION
## Summary
- centralize expected Convex error-code classification for handled user-facing states
- drop expected Convex `$exception` events by machine-readable `code`, including the full `CHAT_ACCESS_SUSPENDED` suspension payload
- suppress `ConvexErrorBoundary` console noise for expected Convex codes while preserving logs for unknown Convex and non-Convex failures

## Testing
- `node node_modules/jest/bin/jest.js lib/posthog/__tests__/expected-convex-errors.test.ts app/components/__tests__/ConvexErrorBoundary.test.tsx --runInBand`
- `node_modules/.bin/eslint app/components/ConvexErrorBoundary.tsx app/components/__tests__/ConvexErrorBoundary.test.tsx lib/posthog/expected-convex-errors.ts lib/posthog/__tests__/expected-convex-errors.test.ts lib/utils/expected-convex-errors.ts`
- `node_modules/.bin/prettier --check app/components/ConvexErrorBoundary.tsx app/components/__tests__/ConvexErrorBoundary.test.tsx lib/posthog/expected-convex-errors.ts lib/posthog/__tests__/expected-convex-errors.test.ts lib/utils/expected-convex-errors.ts`
- `node_modules/.bin/tsc --noEmit`

## Manual verification
- Sign in as an account blocked by an active fraudulent dispute and open an affected chat/history path.
- Confirm the user still sees the handled suspension message/toast.
- Confirm no PostHog `$exception` or boundary `console.error` is emitted for `CHAT_ACCESS_SUSPENDED`.
- Trigger or simulate an unknown Convex error code and confirm it still logs/reports as an exception.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling so expected Convex errors are treated more quietly, while unexpected errors are still logged for troubleshooting.
  * Reduced unnecessary console noise when known error conditions occur.
  * Expanded test coverage for error classification and logging behavior, including edge cases with formatted error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->