### PR TITLE
Revert actions/cache v6 desktop build bump

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -98,7 +98,7 @@ jobs:
         id: pnpm-cache
 
       - name: Setup pnpm cache
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('packages/desktop/pnpm-lock.yaml') }}


### PR DESCRIPTION
## Summary
- revert #751 / 31efe138 so the desktop build workflow uses actions/cache@v5 again

## Validation
- git diff --check origin/main..HEAD
- Verified .github/workflows/desktop-build.yml uses actions/cache@v5

## Manual verification
- Re-run the desktop build workflow on this branch; the pnpm cache step should use actions/cache@v5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop build workflow’s caching step to use a different cache action version. This should help keep builds running smoothly without affecting the app experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->