### PR TITLE
Improve Agent budget abort reliability

### DIFF
--- a/app/components/FinishReasonNotice.tsx
+++ b/app/components/FinishReasonNotice.tsx
@@ -9,9 +9,8 @@ import {
   AGENT_RUN_SPEND_CAP_REASON,
   AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL,
 } from "@/lib/chat/agent-run-spend-cap";
+import { BUDGET_EXHAUSTION_FINISH_REASON } from "@/lib/chat/stop-conditions";
 import type { SelectedModel } from "@/types/chat";
-
-const BUDGET_EXHAUSTION_FINISH_REASON = "budget-exhausted";
 
 interface FinishReasonNoticeProps {
   finishReason?: string;

--- a/app/components/FinishReasonNotice.tsx
+++ b/app/components/FinishReasonNotice.tsx
@@ -11,6 +11,8 @@ import {
 } from "@/lib/chat/agent-run-spend-cap";
 import type { SelectedModel } from "@/types/chat";
 
+const BUDGET_EXHAUSTION_FINISH_REASON = "budget-exhausted";
+
 interface FinishReasonNoticeProps {
   finishReason?: string;
   mode?: ChatMode;
@@ -65,6 +67,10 @@ export const FinishReasonNotice = ({
       return <>Paused at the Pro Agent per-run safety cap.</>;
     }
 
+    if (finishReason === BUDGET_EXHAUSTION_FINISH_REASON) {
+      return <>Stopped at a usage guardrail for this run.</>;
+    }
+
     return null;
   };
 
@@ -75,6 +81,10 @@ export const FinishReasonNotice = ({
   const shouldContinueWithStandard =
     finishReason === AGENT_RUN_SPEND_CAP_FINISH_REASON &&
     agentRunSpendCapPremiumContinuationAllowed === false;
+  const showContinue =
+    onContinue &&
+    !hasContinued &&
+    finishReason !== BUDGET_EXHAUSTION_FINISH_REASON;
   const continuationModel = shouldContinueWithStandard
     ? AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL
     : undefined;
@@ -86,7 +96,7 @@ export const FinishReasonNotice = ({
     <div className="mt-2 w-full">
       <div className="bg-muted text-muted-foreground rounded-lg px-3 py-2 border border-border flex items-center justify-between gap-3 flex-wrap">
         <span>{content}</span>
-        {onContinue && !hasContinued && (
+        {showContinue && (
           <Button
             type="button"
             size="sm"

--- a/app/components/__tests__/FinishReasonNotice.test.tsx
+++ b/app/components/__tests__/FinishReasonNotice.test.tsx
@@ -277,6 +277,25 @@ describe("FinishReasonNotice", () => {
 
       expect(onContinue).toHaveBeenCalledWith(undefined);
     });
+
+    it("renders a usage guardrail notice without a Continue button for budget exhaustion", () => {
+      const onContinue = jest.fn();
+      renderNotice(
+        {
+          finishReason: "budget-exhausted",
+          mode: "agent",
+          onContinue,
+        },
+        { isAutoResuming: false, autoContinueCount: MAX_AUTO_CONTINUES },
+      );
+
+      expect(
+        screen.getByText(/Stopped at a usage guardrail for this run/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /continue/i }),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("correct styling", () => {

--- a/app/components/__tests__/RateLimitWarning.test.tsx
+++ b/app/components/__tests__/RateLimitWarning.test.tsx
@@ -136,4 +136,31 @@ describe("RateLimitWarning", () => {
       screen.getByRole("button", { name: /view usage/i }),
     ).toBeInTheDocument();
   });
+
+  it("names the spending limit when extra usage balance exists but the monthly cap is hit", () => {
+    render(
+      <RateLimitWarning
+        data={{
+          warningType: "token-bucket",
+          bucketType: "monthly",
+          remainingPercent: 0,
+          resetTime: new Date(Date.now() + 60_000),
+          subscription: "ultra",
+          capReason: "extra_usage_cap",
+          cutOff: true,
+        }}
+        onDismiss={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/extra usage spending limit/i)).toHaveTextContent(
+      "Increase your limit to continue",
+    );
+    expect(
+      screen.queryByText(/extra usage balance is empty/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /increase limit/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/app/hooks/__tests__/useAutoContinue.test.ts
+++ b/app/hooks/__tests__/useAutoContinue.test.ts
@@ -5,7 +5,11 @@ import {
   DataStreamProvider,
   useDataStream,
 } from "@/app/components/DataStreamProvider";
-import { useAutoContinue, MAX_AUTO_CONTINUES } from "../useAutoContinue";
+import {
+  AUTO_CONTINUE_PROMPT,
+  useAutoContinue,
+  MAX_AUTO_CONTINUES,
+} from "../useAutoContinue";
 import type { UseAutoContinueParams } from "../useAutoContinue";
 
 type DataStreamEntry = { type: string; data?: unknown; __chatId?: string };
@@ -125,7 +129,10 @@ describe("useAutoContinue", () => {
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith(
-      { text: "continue", metadata: { isAutoContinue: true } },
+      {
+        text: AUTO_CONTINUE_PROMPT,
+        metadata: { isAutoContinue: true },
+      },
       {
         body: {
           mode: "agent",
@@ -159,7 +166,10 @@ describe("useAutoContinue", () => {
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith(
-      { text: "continue", metadata: { isAutoContinue: true } },
+      {
+        text: AUTO_CONTINUE_PROMPT,
+        metadata: { isAutoContinue: true },
+      },
       {
         body: expect.objectContaining({
           isAutoContinue: true,

--- a/app/hooks/useAutoContinue.ts
+++ b/app/hooks/useAutoContinue.ts
@@ -10,6 +10,8 @@ import {
 import { useLatestRef } from "./useLatestRef";
 
 export const MAX_AUTO_CONTINUES = 5;
+export const AUTO_CONTINUE_PROMPT =
+  "Continue from the latest saved progress. Do not restart the original task or repeat completed work.";
 
 export interface UseAutoContinueParams {
   chatId: string;
@@ -87,7 +89,10 @@ export function useAutoContinue({
 
     const timeout = setTimeout(() => {
       sendMessageRef.current(
-        { text: "continue", metadata: { isAutoContinue: true } },
+        {
+          text: AUTO_CONTINUE_PROMPT,
+          metadata: { isAutoContinue: true },
+        },
         {
           body: {
             mode: chatMode,

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -22,6 +22,7 @@ import {
 import { toast } from "sonner";
 import { removeTodosBySourceMessages } from "@/lib/utils/todo-utils";
 import { useDataStreamDispatch } from "@/app/components/DataStreamProvider";
+import { AUTO_CONTINUE_PROMPT } from "@/app/hooks/useAutoContinue";
 import { normalizeMessages } from "@/lib/utils/message-processor";
 import {
   getAutoContinueChainAssistantIds,
@@ -690,7 +691,10 @@ export const useChatHandlers = ({
     const continuationSelectedModel =
       selectedModelOverride ?? requestSelectedModel;
     sendMessage(
-      { text: "continue", metadata: { isAutoContinue: true } },
+      {
+        text: AUTO_CONTINUE_PROMPT,
+        metadata: { isAutoContinue: true },
+      },
       {
         body: {
           mode: chatModeRef.current,

--- a/lib/api/__tests__/build-extra-usage-config.test.ts
+++ b/lib/api/__tests__/build-extra-usage-config.test.ts
@@ -169,7 +169,7 @@ describe("buildExtraUsageConfig — team users", () => {
     });
   });
 
-  it("returns undefined when team pool has no balance and no auto-reload", async () => {
+  it("keeps disabled-for-overflow telemetry when team pool has no balance and no auto-reload", async () => {
     mockGetTeamState.mockResolvedValue({
       enabled: true,
       balanceDollars: 0,
@@ -183,7 +183,12 @@ describe("buildExtraUsageConfig — team users", () => {
       userCustomization: null,
       organizationId: ORG_ID,
     });
-    expect(config).toBeUndefined();
+    expect(config).toEqual({
+      enabled: true,
+      hasBalance: false,
+      balanceDollars: 0,
+      autoReloadEnabled: false,
+    });
   });
 });
 
@@ -262,6 +267,34 @@ describe("buildExtraUsageConfig — individual paid users (pro / pro-plus / ultr
       enabled: true,
       hasBalance: true,
       autoReloadEnabled: false,
+    });
+  });
+
+  it("keeps enabled-but-empty balance context for billing telemetry", async () => {
+    mockGetUserBalance.mockResolvedValue({
+      balanceDollars: 0,
+      balancePoints: 0,
+      enabled: true,
+      autoReloadEnabled: false,
+      monthlyCapDollars: 25,
+      monthlySpentDollars: 0,
+      monthlyRemainingDollars: 25,
+    });
+
+    const config = await buildExtraUsageConfig({
+      userId: USER_ID,
+      subscription: "ultra",
+      userCustomization: { extra_usage_enabled: true } as any,
+    });
+
+    expect(config).toEqual({
+      enabled: true,
+      hasBalance: false,
+      balanceDollars: 0,
+      autoReloadEnabled: false,
+      monthlyCapDollars: 25,
+      monthlySpentDollars: 0,
+      monthlyRemainingDollars: 25,
     });
   });
 });

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -1057,6 +1057,56 @@ describe("createChatLogger ChatSDKError metadata", () => {
     }
   });
 
+  it("emits agent billing-stop extra-usage metadata without setRateLimit", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const eventSpy = jest.spyOn(phLogger, "event").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_preflight_empty_extra",
+        endpoint: "/api/agent-long",
+      });
+      chatLogger.setRequestDetails({
+        mode: "agent",
+        isTemporary: false,
+        isRegenerate: false,
+      });
+      chatLogger.setUser({ id: "user_123", subscription: "ultra" });
+
+      chatLogger.emitChatError(
+        new ChatSDKError("rate_limit:chat", "Monthly limit hit", {
+          capReason: "monthly_exhausted",
+          resetTimestamp: 1_800_000_000_000,
+          extraUsageEnabled: true,
+          extraUsageHasBalance: false,
+          extraUsageBalanceDollars: 0,
+          extraUsageAutoReloadEnabled: false,
+          extraUsageMonthlyRemainingDollars: 25,
+        }),
+      );
+
+      expect(eventSpy).toHaveBeenCalledWith(
+        "agent_billing_stop",
+        expect.objectContaining({
+          chat_id: "chat_preflight_empty_extra",
+          endpoint: "/api/agent-long",
+          mode: "agent",
+          cap_reason: "monthly_exhausted",
+          billing_stop_reason: "extra_usage_balance_empty",
+          extra_usage_enabled: true,
+          extra_usage_has_balance: false,
+          extra_usage_balance_dollars: 0,
+          extra_usage_auto_reload_enabled: false,
+          extra_usage_monthly_remaining_dollars: 25,
+          monthly_spending_cap_remaining_dollars: 25,
+        }),
+      );
+    } finally {
+      eventSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+
   it("does not emit monthly_cap_hit for paid billing service outages", () => {
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     const eventSpy = jest.spyOn(phLogger, "event").mockImplementation(() => {});

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, jest } from "@jest/globals";
 (globalThis as any).Headers = class Headers {};
 
 const {
+  captureAgentBudgetAbort,
   createChatLogger,
   captureAgentCompletionAnalytics,
   captureAgentRun,
@@ -112,6 +113,67 @@ describe("captureAgentRun", () => {
     });
 
     expect(capture).not.toHaveBeenCalled();
+  });
+});
+
+describe("captureAgentBudgetAbort", () => {
+  it("captures mid-stream Agent budget abort reason and extra-usage state", () => {
+    const capture = jest.fn();
+    const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+
+    try {
+      captureAgentBudgetAbort({
+        posthog: { capture } as any,
+        userId: "user_123",
+        subscription: "ultra",
+        chatId: "chat_123",
+        endpoint: "/api/agent-long",
+        mode: "agent",
+        selectedModel: "agent-model",
+        selectedModelOverride: "hackerai-max",
+        configuredModelId: "anthropic/claude-opus",
+        responseModel: "anthropic/claude-opus",
+        isAutoContinue: true,
+        details: {
+          model: "agent-model",
+          capReason: "extra_usage_cap",
+          billingStopReason: "monthly_extra_usage_spending_cap_hit",
+          midStream: true,
+          projectedCostDollars: 108.42,
+          overflowDollars: 8.42,
+          monthlyLimitDollars: 200,
+          monthlyRemainingDollarsAtStart: 2,
+          extraUsageEnabled: true,
+          extraUsageHasBalance: true,
+          extraUsageBalanceDollars: 50,
+          extraUsageAutoReloadEnabled: false,
+          extraUsageMonthlyRemainingDollars: 0,
+          extraUsageAvailable: false,
+        },
+      });
+
+      expect(capture).toHaveBeenCalledWith({
+        distinctId: "user_123",
+        event: "agent_mid_stream_budget_aborted",
+        properties: expect.objectContaining({
+          chat_id: "chat_123",
+          endpoint: "/api/agent-long",
+          mode: "agent",
+          subscription_tier: "ultra",
+          cap_reason: "extra_usage_cap",
+          billing_stop_reason: "monthly_extra_usage_spending_cap_hit",
+          mid_stream: true,
+          monthly_spending_cap_remaining_dollars: 0,
+          extra_usage_balance_dollars: 50,
+          is_auto_continue: true,
+        }),
+      });
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining("agent_mid_stream_budget_aborted"),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
   });
 });
 
@@ -978,6 +1040,17 @@ describe("createChatLogger ChatSDKError metadata", () => {
           eligible_ctas: ["add_credits", "upgrade_plan"],
         }),
       );
+      expect(eventSpy).toHaveBeenCalledWith(
+        "agent_billing_stop",
+        expect.objectContaining({
+          chat_id: "chat_limit",
+          endpoint: "/api/chat",
+          mode: "agent",
+          cap_reason: "monthly_exhausted",
+          billing_stop_reason: "monthly_included_exhausted",
+          mid_stream: false,
+        }),
+      );
     } finally {
       eventSpy.mockRestore();
       logSpy.mockRestore();
@@ -1017,6 +1090,14 @@ describe("createChatLogger ChatSDKError metadata", () => {
       expect(eventSpy).not.toHaveBeenCalledWith(
         "monthly_cap_hit",
         expect.anything(),
+      );
+      expect(eventSpy).toHaveBeenCalledWith(
+        "agent_billing_stop",
+        expect.objectContaining({
+          cap_reason: "billing_unavailable",
+          billing_stop_reason: "billing_unavailable",
+          mid_stream: false,
+        }),
       );
     } finally {
       eventSpy.mockRestore();

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -74,7 +74,10 @@ import {
 } from "@/lib/api/openrouter-metadata";
 import { classifyProviderOverflowError } from "@/lib/utils/error-utils";
 import type { UsageTracker } from "@/lib/usage-tracker";
-import type { BudgetMonitor } from "@/lib/chat/budget-monitor";
+import type {
+  BudgetAbortDetails,
+  BudgetMonitor,
+} from "@/lib/chat/budget-monitor";
 import type { UsageRefundTracker } from "@/lib/rate-limit";
 import type {
   ProviderReasoningOverride,
@@ -112,6 +115,7 @@ export type AgentStreamState = {
   stoppedDueToDoomLoop: boolean;
   stoppedDueToBudgetExhaustion: boolean;
   stoppedDueToAgentRunSpendCap: boolean;
+  budgetAbortDetails: BudgetAbortDetails | undefined;
 };
 
 export function initAgentStreamState(
@@ -132,6 +136,7 @@ export function initAgentStreamState(
     stoppedDueToDoomLoop: false,
     stoppedDueToBudgetExhaustion: false,
     stoppedDueToAgentRunSpendCap: false,
+    budgetAbortDetails: undefined,
   };
 }
 
@@ -292,6 +297,7 @@ export type AgentStreamContext = {
   currentSystemPrompt: string;
   tools: ToolSet;
   mode: ChatMode;
+  endpoint: "/api/chat" | "/api/agent-long";
   userId: string;
   subscription: SubscriptionTier;
   chatId: string;
@@ -330,6 +336,7 @@ export type AgentStreamContext = {
   ensureSandbox: import("@/lib/chat/summarization").EnsureSandbox;
   chatLogger: ChatLogger | undefined;
   usageRefundTracker: UsageRefundTracker;
+  onBudgetAbort?: (details: BudgetAbortDetails & { model: string }) => void;
 
   /**
    * Platform-specific: return a finish-reason string if a hard platform
@@ -714,11 +721,13 @@ export async function createAgentStream(
       const budgetDecision = ctx.budgetMonitor?.checkAfterStep(
         ctx.usageTracker.computeCostDollars(modelName),
       );
-      if (budgetDecision === "abort-agent-run-spend-cap") {
+      if (budgetDecision?.type === "abort-agent-run-spend-cap") {
         state.stoppedDueToAgentRunSpendCap = true;
         ctx.abortController.abort();
-      } else if (budgetDecision === "abort") {
+      } else if (budgetDecision?.type === "abort") {
         state.stoppedDueToBudgetExhaustion = true;
+        state.budgetAbortDetails = budgetDecision.details;
+        ctx.onBudgetAbort?.({ ...budgetDecision.details, model: modelName });
         ctx.abortController.abort();
       }
     },

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -727,8 +727,12 @@ export async function createAgentStream(
       } else if (budgetDecision?.type === "abort") {
         state.stoppedDueToBudgetExhaustion = true;
         state.budgetAbortDetails = budgetDecision.details;
-        ctx.onBudgetAbort?.({ ...budgetDecision.details, model: modelName });
         ctx.abortController.abort();
+        try {
+          ctx.onBudgetAbort?.({ ...budgetDecision.details, model: modelName });
+        } catch (error) {
+          console.error("[agent-stream] onBudgetAbort failed:", error);
+        }
       }
     },
 

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1619,7 +1619,12 @@ export const createChatHandler = () => {
 
                     // Clear finish reason for user-initiated aborts (not pre-emptive timeouts)
                     // This prevents showing "going off course" message when user clicks stop
-                    if (isAborted && !isPreemptiveAbort) {
+                    if (
+                      isAborted &&
+                      !isPreemptiveAbort &&
+                      !state.stoppedDueToBudgetExhaustion &&
+                      !state.stoppedDueToAgentRunSpendCap
+                    ) {
                       state.streamFinishReason = undefined;
                     }
 

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -54,6 +54,7 @@ import {
 import { ChatSDKError } from "@/lib/errors";
 import PostHogClient from "@/app/posthog";
 import {
+  captureAgentBudgetAbort,
   captureAgentCompletionAnalytics,
   captureToolCalls,
   captureUsageCost,
@@ -1125,6 +1126,7 @@ export const createChatHandler = () => {
               currentSystemPrompt,
               tools,
               mode,
+              endpoint,
               userId,
               subscription,
               chatId,
@@ -1154,6 +1156,21 @@ export const createChatHandler = () => {
               ensureSandbox,
               chatLogger,
               usageRefundTracker,
+              onBudgetAbort: (details) =>
+                captureAgentBudgetAbort({
+                  posthog,
+                  userId,
+                  subscription,
+                  chatId,
+                  endpoint,
+                  mode,
+                  selectedModel,
+                  selectedModelOverride,
+                  configuredModelId,
+                  responseModel: state.responseModel,
+                  isAutoContinue,
+                  details,
+                }),
               getHardTimeoutReason: () =>
                 preemptiveTimeout?.isPreemptive() ? "timeout" : null,
             };
@@ -1198,6 +1215,7 @@ export const createChatHandler = () => {
                 state.stoppedDueToDoomLoop = false;
                 state.stoppedDueToBudgetExhaustion = false;
                 state.stoppedDueToAgentRunSpendCap = false;
+                state.budgetAbortDetails = undefined;
                 preFallbackCacheRead = usageTracker.cacheReadTokens;
                 preFallbackCacheWrite = usageTracker.cacheWriteTokens;
                 // Discard the failed primary leg's model usage so the user is
@@ -1300,6 +1318,7 @@ export const createChatHandler = () => {
                         state.stoppedDueToDoomLoop = false;
                         state.stoppedDueToBudgetExhaustion = false;
                         state.stoppedDueToAgentRunSpendCap = false;
+                        state.budgetAbortDetails = undefined;
                         const fallbackStartTime = Date.now();
                         preFallbackCacheRead = usageTracker.cacheReadTokens;
                         preFallbackCacheWrite = usageTracker.cacheWriteTokens;
@@ -1396,6 +1415,8 @@ export const createChatHandler = () => {
                                   sandboxInfo,
                                   outcome,
                                   chatLogger,
+                                  finishReason: state.streamFinishReason,
+                                  budgetAbortDetails: state.budgetAbortDetails,
                                 });
                                 chatLogger!.emitSuccess({
                                   finishReason: state.streamFinishReason,
@@ -1623,6 +1644,8 @@ export const createChatHandler = () => {
                       sandboxInfo,
                       outcome,
                       chatLogger,
+                      finishReason: state.streamFinishReason,
+                      budgetAbortDetails: state.budgetAbortDetails,
                     });
                     chatLogger!.emitSuccess({
                       finishReason: state.streamFinishReason,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -324,6 +324,85 @@ type ExtraUsageTelemetryContext = {
   autoReloadEnabled?: boolean;
 };
 
+const numberMetadata = (
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+): number | undefined => {
+  const value = metadata?.[key];
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+};
+
+const booleanMetadata = (
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+): boolean | undefined => {
+  const value = metadata?.[key];
+  return typeof value === "boolean" ? value : undefined;
+};
+
+const extraUsageTelemetryFromConfig = (
+  extraUsageConfig: ExtraUsageConfig | undefined,
+): ExtraUsageTelemetryContext | undefined =>
+  extraUsageConfig
+    ? {
+        enabled: extraUsageConfig.enabled,
+        hasBalance: extraUsageConfig.hasBalance,
+        balanceDollars: extraUsageConfig.balanceDollars,
+        monthlyCapDollars: extraUsageConfig.monthlyCapDollars,
+        monthlySpentDollars: extraUsageConfig.monthlySpentDollars,
+        monthlyRemainingDollars: extraUsageConfig.monthlyRemainingDollars,
+        autoReloadEnabled: extraUsageConfig.autoReloadEnabled,
+      }
+    : undefined;
+
+const extraUsageTelemetryFromMetadata = (
+  metadata: Record<string, unknown> | undefined,
+): ExtraUsageTelemetryContext | undefined => {
+  const enabled = booleanMetadata(metadata, "extraUsageEnabled");
+  const hasBalance = booleanMetadata(metadata, "extraUsageHasBalance");
+  const autoReloadEnabled = booleanMetadata(
+    metadata,
+    "extraUsageAutoReloadEnabled",
+  );
+  const balanceDollars = numberMetadata(metadata, "extraUsageBalanceDollars");
+  const monthlyCapDollars = numberMetadata(
+    metadata,
+    "extraUsageMonthlyCapDollars",
+  );
+  const monthlySpentDollars = numberMetadata(
+    metadata,
+    "extraUsageMonthlySpentDollars",
+  );
+  const monthlyRemainingDollars = numberMetadata(
+    metadata,
+    "extraUsageMonthlyRemainingDollars",
+  );
+
+  if (
+    enabled === undefined &&
+    hasBalance === undefined &&
+    autoReloadEnabled === undefined &&
+    balanceDollars === undefined &&
+    monthlyCapDollars === undefined &&
+    monthlySpentDollars === undefined &&
+    monthlyRemainingDollars === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    enabled,
+    hasBalance,
+    balanceDollars,
+    monthlyCapDollars,
+    monthlySpentDollars,
+    monthlyRemainingDollars,
+    autoReloadEnabled,
+  };
+};
+
 const getAgentBillingStopReason = (
   capReason: LimitCapReason,
   extraUsage: ExtraUsageTelemetryContext | undefined,
@@ -420,17 +499,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
         freeRemaining:
           context.subscription === "free" ? context.remaining : undefined,
       });
-      extraUsageTelemetry = extraUsageConfig
-        ? {
-            enabled: extraUsageConfig.enabled,
-            hasBalance: extraUsageConfig.hasBalance,
-            balanceDollars: extraUsageConfig.balanceDollars,
-            monthlyCapDollars: extraUsageConfig.monthlyCapDollars,
-            monthlySpentDollars: extraUsageConfig.monthlySpentDollars,
-            monthlyRemainingDollars: extraUsageConfig.monthlyRemainingDollars,
-            autoReloadEnabled: extraUsageConfig.autoReloadEnabled,
-          }
-        : undefined;
+      extraUsageTelemetry = extraUsageTelemetryFromConfig(extraUsageConfig);
     },
 
     /**
@@ -741,6 +810,9 @@ export function createChatLogger(config: ChatLoggerConfig) {
           typeof error.metadata.paidDailyFreeAllowance === "object"
             ? (error.metadata.paidDailyFreeAllowance as Record<string, unknown>)
             : undefined;
+        const rateLimitExtraUsageTelemetry =
+          extraUsageTelemetry ??
+          extraUsageTelemetryFromMetadata(error.metadata);
 
         phLogger.event(
           PAID_FUNNEL_EVENTS.limitHit,
@@ -794,7 +866,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
             limit_type: pressure.limitType,
             billing_stop_reason: getAgentBillingStopReason(
               capReason,
-              extraUsageTelemetry,
+              rateLimitExtraUsageTelemetry,
             ),
             mid_stream: false,
             monthly_remaining_percent: monthlyRemainingPercent,
@@ -803,15 +875,16 @@ export function createChatLogger(config: ChatLoggerConfig) {
             add_credit_available: pressure.addCreditAvailable,
             primary_cta: pressure.primaryCta,
             eligible_ctas: pressure.eligibleCtas,
-            extra_usage_enabled: extraUsageTelemetry?.enabled,
-            extra_usage_has_balance: extraUsageTelemetry?.hasBalance,
-            extra_usage_balance_dollars: extraUsageTelemetry?.balanceDollars,
+            extra_usage_enabled: rateLimitExtraUsageTelemetry?.enabled,
+            extra_usage_has_balance: rateLimitExtraUsageTelemetry?.hasBalance,
+            extra_usage_balance_dollars:
+              rateLimitExtraUsageTelemetry?.balanceDollars,
             extra_usage_auto_reload_enabled:
-              extraUsageTelemetry?.autoReloadEnabled,
+              rateLimitExtraUsageTelemetry?.autoReloadEnabled,
             extra_usage_monthly_remaining_dollars:
-              extraUsageTelemetry?.monthlyRemainingDollars,
+              rateLimitExtraUsageTelemetry?.monthlyRemainingDollars,
             monthly_spending_cap_remaining_dollars:
-              extraUsageTelemetry?.monthlyRemainingDollars,
+              rateLimitExtraUsageTelemetry?.monthlyRemainingDollars,
             $set: {
               subscription_tier: subscription,
               last_agent_billing_stop_at: new Date().toISOString(),

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -29,6 +29,7 @@ import {
   paidFunnelProperties,
 } from "@/lib/analytics/paid-funnel";
 import type { UsageCostRecord } from "@/lib/usage-tracker";
+import type { BudgetAbortDetails } from "@/lib/chat/budget-monitor";
 import type { OpenRouterModelMetadata } from "@/lib/api/openrouter-metadata";
 import {
   extractErrorDetails,
@@ -313,6 +314,51 @@ const nonEmptyString = (value: unknown): string | undefined =>
 const getModelProviderSlug = (modelSlug: string | undefined) =>
   modelSlug?.includes("/") ? modelSlug.split("/", 1)[0] : undefined;
 
+type ExtraUsageTelemetryContext = {
+  enabled?: boolean;
+  hasBalance?: boolean;
+  balanceDollars?: number;
+  monthlyCapDollars?: number;
+  monthlySpentDollars?: number;
+  monthlyRemainingDollars?: number;
+  autoReloadEnabled?: boolean;
+};
+
+const getAgentBillingStopReason = (
+  capReason: LimitCapReason,
+  extraUsage: ExtraUsageTelemetryContext | undefined,
+):
+  | "monthly_included_exhausted"
+  | "extra_usage_balance_empty"
+  | "extra_usage_balance_insufficient"
+  | "monthly_extra_usage_spending_cap_hit"
+  | "auto_reload_failed"
+  | "billing_unavailable"
+  | "team_extra_usage_guardrail"
+  | "unknown" => {
+  if (capReason === "extra_usage_cap") {
+    return "monthly_extra_usage_spending_cap_hit";
+  }
+  if (capReason === "auto_reload_failed") return "auto_reload_failed";
+  if (capReason === "billing_unavailable") return "billing_unavailable";
+  if (
+    capReason === "team_member_cap" ||
+    capReason === "team_member_disabled" ||
+    capReason === "team_pool_disabled"
+  ) {
+    return "team_extra_usage_guardrail";
+  }
+  if (capReason === "monthly_exhausted") {
+    if (extraUsage?.enabled && !extraUsage.autoReloadEnabled) {
+      return (extraUsage.balanceDollars ?? 0) > 0
+        ? "extra_usage_balance_insufficient"
+        : "extra_usage_balance_empty";
+    }
+    return "monthly_included_exhausted";
+  }
+  return "unknown";
+};
+
 /**
  * Creates a chat logger instance for tracking wide events
  */
@@ -326,6 +372,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
   let subscription: string | undefined;
   let mode: ChatMode | undefined;
   let monthlyRemainingPercent: number | undefined;
+  let extraUsageTelemetry: ExtraUsageTelemetryContext | undefined;
   let lastProviderErrorCategory: ProviderErrorCategory | undefined;
   let lastProviderErrorStatusCode: number | undefined;
 
@@ -373,6 +420,17 @@ export function createChatLogger(config: ChatLoggerConfig) {
         freeRemaining:
           context.subscription === "free" ? context.remaining : undefined,
       });
+      extraUsageTelemetry = extraUsageConfig
+        ? {
+            enabled: extraUsageConfig.enabled,
+            hasBalance: extraUsageConfig.hasBalance,
+            balanceDollars: extraUsageConfig.balanceDollars,
+            monthlyCapDollars: extraUsageConfig.monthlyCapDollars,
+            monthlySpentDollars: extraUsageConfig.monthlySpentDollars,
+            monthlyRemainingDollars: extraUsageConfig.monthlyRemainingDollars,
+            autoReloadEnabled: extraUsageConfig.autoReloadEnabled,
+          }
+        : undefined;
     },
 
     /**
@@ -722,6 +780,44 @@ export function createChatLogger(config: ChatLoggerConfig) {
             },
           }),
         );
+
+        if (mode === "agent" && subscription !== "free") {
+          phLogger.event("agent_billing_stop", {
+            userId,
+            user_id: userId,
+            subscription,
+            subscription_tier: subscription,
+            mode,
+            endpoint: config.endpoint,
+            chat_id: config.chatId,
+            cap_reason: capReason,
+            limit_type: pressure.limitType,
+            billing_stop_reason: getAgentBillingStopReason(
+              capReason,
+              extraUsageTelemetry,
+            ),
+            mid_stream: false,
+            monthly_remaining_percent: monthlyRemainingPercent,
+            reset_timestamp: resetTimestamp,
+            cost_guardrail: pressure.costGuardrail,
+            add_credit_available: pressure.addCreditAvailable,
+            primary_cta: pressure.primaryCta,
+            eligible_ctas: pressure.eligibleCtas,
+            extra_usage_enabled: extraUsageTelemetry?.enabled,
+            extra_usage_has_balance: extraUsageTelemetry?.hasBalance,
+            extra_usage_balance_dollars: extraUsageTelemetry?.balanceDollars,
+            extra_usage_auto_reload_enabled:
+              extraUsageTelemetry?.autoReloadEnabled,
+            extra_usage_monthly_remaining_dollars:
+              extraUsageTelemetry?.monthlyRemainingDollars,
+            monthly_spending_cap_remaining_dollars:
+              extraUsageTelemetry?.monthlyRemainingDollars,
+            $set: {
+              subscription_tier: subscription,
+              last_agent_billing_stop_at: new Date().toISOString(),
+            },
+          });
+        }
       }
 
       // Fire a discrete PostHog event when a paid user is blocked at the
@@ -815,6 +911,89 @@ export function createChatLogger(config: ChatLoggerConfig) {
 
 export type ChatLogger = ReturnType<typeof createChatLogger>;
 
+export function captureAgentBudgetAbort({
+  posthog,
+  userId,
+  subscription,
+  chatId,
+  endpoint,
+  mode,
+  selectedModel,
+  selectedModelOverride,
+  configuredModelId,
+  responseModel,
+  isAutoContinue,
+  details,
+}: {
+  posthog: PostHog | null;
+  userId: string;
+  subscription: string;
+  chatId: string;
+  endpoint: "/api/chat" | "/api/agent-long";
+  mode: ChatMode;
+  selectedModel: string;
+  selectedModelOverride?: string;
+  configuredModelId?: string;
+  responseModel?: string;
+  isAutoContinue?: boolean;
+  details: BudgetAbortDetails & { model?: string };
+}) {
+  if (mode !== "agent") return;
+
+  const properties = {
+    user_id: userId,
+    subscription,
+    subscription_tier: subscription,
+    chat_id: chatId,
+    endpoint,
+    mode,
+    model: selectedModel,
+    selected_model: selectedModel,
+    selected_model_override: selectedModelOverride,
+    configured_model: configuredModelId,
+    response_model: responseModel,
+    active_model: details.model,
+    is_auto_continue: isAutoContinue === true,
+    cap_reason: details.capReason,
+    billing_stop_reason: details.billingStopReason,
+    mid_stream: true,
+    projected_cost_dollars: details.projectedCostDollars,
+    overflow_dollars: details.overflowDollars,
+    monthly_limit_dollars: details.monthlyLimitDollars,
+    monthly_remaining_dollars_at_start: details.monthlyRemainingDollarsAtStart,
+    extra_usage_enabled: details.extraUsageEnabled,
+    extra_usage_has_balance: details.extraUsageHasBalance,
+    extra_usage_balance_dollars: details.extraUsageBalanceDollars,
+    extra_usage_auto_reload_enabled: details.extraUsageAutoReloadEnabled,
+    extra_usage_monthly_remaining_dollars:
+      details.extraUsageMonthlyRemainingDollars,
+    monthly_spending_cap_remaining_dollars:
+      details.extraUsageMonthlyRemainingDollars,
+    extra_usage_available: details.extraUsageAvailable,
+    $set: {
+      subscription_tier: subscription,
+      last_agent_billing_stop_at: new Date().toISOString(),
+    },
+  };
+
+  posthog?.capture({
+    distinctId: userId,
+    event: "agent_mid_stream_budget_aborted",
+    properties,
+  });
+
+  console.info(
+    JSON.stringify({
+      level: "info",
+      event: "agent_mid_stream_budget_aborted",
+      service: "chat-handler",
+      timestamp: new Date().toISOString(),
+      ...properties,
+      $set: undefined,
+    }),
+  );
+}
+
 /**
  * Capture aggregated tool usage to PostHog at end of request.
  * One event is emitted per tool to keep analytics useful while
@@ -875,6 +1054,8 @@ type AgentCompletionAnalyticsArgs = {
   sandboxInfo: SandboxInfo | null;
   outcome: AgentRunOutcome;
   chatLogger: ChatLogger | undefined;
+  finishReason?: string;
+  budgetAbortDetails?: BudgetAbortDetails;
 };
 
 export function captureAgentRun({
@@ -884,6 +1065,8 @@ export function captureAgentRun({
   subscription,
   sandboxInfo,
   outcome,
+  finishReason,
+  budgetAbortDetails,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -891,6 +1074,8 @@ export function captureAgentRun({
   subscription: string;
   sandboxInfo: SandboxInfo | null;
   outcome: AgentRunOutcome;
+  finishReason?: string;
+  budgetAbortDetails?: BudgetAbortDetails;
 }) {
   if (!posthog || mode !== "agent") return;
   posthog.capture({
@@ -904,6 +1089,12 @@ export function captureAgentRun({
       ...(sandboxInfo?.type && {
         sandboxType: sandboxInfo.type,
         sandbox_type: sandboxInfo.type,
+      }),
+      ...(finishReason && { finish_reason: finishReason }),
+      ...(budgetAbortDetails && {
+        budget_abort_cap_reason: budgetAbortDetails.capReason,
+        budget_abort_billing_stop_reason: budgetAbortDetails.billingStopReason,
+        budget_abort_mid_stream: budgetAbortDetails.midStream,
       }),
     },
   });
@@ -972,6 +1163,8 @@ export function captureAgentCompletionAnalytics(
     subscription,
     sandboxInfo,
     outcome,
+    finishReason: args.finishReason,
+    budgetAbortDetails: args.budgetAbortDetails,
   });
   captureFreeAgentValueReached(args);
 }

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -998,24 +998,21 @@ export async function buildExtraUsageConfig(args: {
       return { enabled: true, hasBalance: true, autoReloadEnabled: false };
     }
     if (!state.enabled || state.memberDisabled) return undefined;
-    if (state.balanceDollars > 0 || state.autoReloadEnabled) {
-      return {
-        enabled: true,
-        hasBalance: state.balanceDollars > 0,
-        balanceDollars: state.balanceDollars,
-        autoReloadEnabled: state.autoReloadEnabled,
-        ...(state.monthlyCapDollars !== undefined && {
-          monthlyCapDollars: state.monthlyCapDollars,
-        }),
-        ...(state.monthlySpentDollars !== undefined && {
-          monthlySpentDollars: state.monthlySpentDollars,
-        }),
-        ...(state.monthlyRemainingDollars !== undefined && {
-          monthlyRemainingDollars: state.monthlyRemainingDollars,
-        }),
-      };
-    }
-    return undefined;
+    return {
+      enabled: true,
+      hasBalance: state.balanceDollars > 0,
+      balanceDollars: state.balanceDollars,
+      autoReloadEnabled: state.autoReloadEnabled,
+      ...(state.monthlyCapDollars !== undefined && {
+        monthlyCapDollars: state.monthlyCapDollars,
+      }),
+      ...(state.monthlySpentDollars !== undefined && {
+        monthlySpentDollars: state.monthlySpentDollars,
+      }),
+      ...(state.monthlyRemainingDollars !== undefined && {
+        monthlyRemainingDollars: state.monthlyRemainingDollars,
+      }),
+    };
   }
 
   if (!(userCustomization?.extra_usage_enabled ?? false)) return undefined;
@@ -1029,24 +1026,21 @@ export async function buildExtraUsageConfig(args: {
     return { enabled: true, hasBalance: true, autoReloadEnabled: false };
   }
 
-  if (balanceInfo.balanceDollars > 0 || balanceInfo.autoReloadEnabled) {
-    return {
-      enabled: true,
-      hasBalance: balanceInfo.balanceDollars > 0,
-      balanceDollars: balanceInfo.balanceDollars,
-      autoReloadEnabled: balanceInfo.autoReloadEnabled,
-      ...(balanceInfo.monthlyCapDollars !== undefined && {
-        monthlyCapDollars: balanceInfo.monthlyCapDollars,
-      }),
-      ...(balanceInfo.monthlySpentDollars !== undefined && {
-        monthlySpentDollars: balanceInfo.monthlySpentDollars,
-      }),
-      ...(balanceInfo.monthlyRemainingDollars !== undefined && {
-        monthlyRemainingDollars: balanceInfo.monthlyRemainingDollars,
-      }),
-    };
-  }
-  return undefined;
+  return {
+    enabled: true,
+    hasBalance: balanceInfo.balanceDollars > 0,
+    balanceDollars: balanceInfo.balanceDollars,
+    autoReloadEnabled: balanceInfo.autoReloadEnabled,
+    ...(balanceInfo.monthlyCapDollars !== undefined && {
+      monthlyCapDollars: balanceInfo.monthlyCapDollars,
+    }),
+    ...(balanceInfo.monthlySpentDollars !== undefined && {
+      monthlySpentDollars: balanceInfo.monthlySpentDollars,
+    }),
+    ...(balanceInfo.monthlyRemainingDollars !== undefined && {
+      monthlyRemainingDollars: balanceInfo.monthlyRemainingDollars,
+    }),
+  };
 }
 
 /**

--- a/lib/api/paid-daily-free-allowance-rescue.ts
+++ b/lib/api/paid-daily-free-allowance-rescue.ts
@@ -47,6 +47,8 @@ export function createPaidDailyFreeAllowanceBudgetSnapshot(
     monthlyLimitPoints: reservation.status.costLimitPoints,
     monthlyRemainingAtStart: reservation.status.costRemainingPoints,
     monthlyResetTime: reservation.status.resetTime,
+    extraUsageEnabledAtStart: false,
+    extraUsageHasBalanceAtStart: false,
     extraUsageBalanceAtStart: 0,
     extraUsageAutoReload: false,
     extraUsageOverflowAllowed: false,

--- a/lib/chat/__tests__/budget-monitor.test.ts
+++ b/lib/chat/__tests__/budget-monitor.test.ts
@@ -166,6 +166,41 @@ describe("BudgetMonitor", () => {
     });
   });
 
+  it("aborts when extra usage is disabled even if balance remains", () => {
+    const writer = makeWriter();
+    const monitor = new BudgetMonitor(
+      {
+        ...baseSnapshot,
+        extraUsageEnabledAtStart: false,
+        extraUsageAutoReload: false,
+        extraUsageBalanceAtStart: 10,
+        extraUsageMonthlyRemainingAtStart: 20,
+      },
+      writer,
+      "ultra",
+    );
+
+    const decision = monitor.checkAfterStep(0.002);
+
+    expect(decision).toMatchObject({
+      type: "abort",
+      details: {
+        capReason: "monthly_exhausted",
+        billingStopReason: "extra_usage_disabled",
+        extraUsageAvailable: false,
+        extraUsageBalanceDollars: 10,
+        extraUsageMonthlyRemainingDollars: 20,
+      },
+    });
+    expect(writer.write).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          warningType: "extra-usage-active",
+        }),
+      }),
+    );
+  });
+
   it("aborts with the paid daily free allowance cap reason when overflow is disabled", () => {
     const writer = makeWriter();
     const monitor = new BudgetMonitor(

--- a/lib/chat/__tests__/budget-monitor.test.ts
+++ b/lib/chat/__tests__/budget-monitor.test.ts
@@ -16,6 +16,8 @@ const baseSnapshot: BudgetSnapshot = {
   monthlyLimitPoints: 100,
   monthlyRemainingAtStart: 10,
   monthlyResetTime: new Date("2026-06-30T00:00:00.000Z"),
+  extraUsageEnabledAtStart: true,
+  extraUsageHasBalanceAtStart: true,
   extraUsageBalanceAtStart: 100,
   extraUsageAutoReload: true,
 };
@@ -34,7 +36,7 @@ describe("BudgetMonitor", () => {
 
     const decision = monitor.checkAfterStep(0.0005);
 
-    expect(decision).toBe("continue");
+    expect(decision.type).toBe("continue");
     expect(writer.write).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "data-rate-limit-warning",
@@ -60,7 +62,7 @@ describe("BudgetMonitor", () => {
 
     const decision = monitor.checkAfterStep(0.0005);
 
-    expect(decision).toBe("continue");
+    expect(decision.type).toBe("continue");
     expect(writer.write).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "data-rate-limit-warning",
@@ -86,7 +88,15 @@ describe("BudgetMonitor", () => {
 
     const decision = monitor.checkAfterStep(0.002);
 
-    expect(decision).toBe("abort");
+    expect(decision).toMatchObject({
+      type: "abort",
+      details: {
+        capReason: "extra_usage_cap",
+        billingStopReason: "monthly_extra_usage_spending_cap_hit",
+        extraUsageAvailable: false,
+        extraUsageMonthlyRemainingDollars: 0,
+      },
+    });
     expect(writer.write).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "data-rate-limit-warning",
@@ -117,7 +127,7 @@ describe("BudgetMonitor", () => {
 
     const decision = monitor.checkAfterStep(0.002);
 
-    expect(decision).toBe("continue");
+    expect(decision.type).toBe("continue");
     expect(writer.write).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "data-rate-limit-warning",
@@ -129,6 +139,33 @@ describe("BudgetMonitor", () => {
     );
   });
 
+  it("classifies empty extra-usage balance separately from spending-cap hits", () => {
+    const writer = makeWriter();
+    const monitor = new BudgetMonitor(
+      {
+        ...baseSnapshot,
+        extraUsageAutoReload: false,
+        extraUsageHasBalanceAtStart: false,
+        extraUsageBalanceAtStart: 0,
+        extraUsageMonthlyRemainingAtStart: 20,
+      },
+      writer,
+      "ultra",
+    );
+
+    const decision = monitor.checkAfterStep(0.002);
+
+    expect(decision).toMatchObject({
+      type: "abort",
+      details: {
+        capReason: "monthly_exhausted",
+        billingStopReason: "extra_usage_balance_empty",
+        extraUsageAvailable: false,
+        extraUsageMonthlyRemainingDollars: 20,
+      },
+    });
+  });
+
   it("aborts with the paid daily free allowance cap reason when overflow is disabled", () => {
     const writer = makeWriter();
     const monitor = new BudgetMonitor(
@@ -136,6 +173,8 @@ describe("BudgetMonitor", () => {
         monthlyLimitPoints: 1000,
         monthlyRemainingAtStart: 100,
         monthlyResetTime: new Date("2026-06-12T00:00:00.000Z"),
+        extraUsageEnabledAtStart: false,
+        extraUsageHasBalanceAtStart: false,
         extraUsageBalanceAtStart: 0,
         extraUsageAutoReload: false,
         extraUsageOverflowAllowed: false,
@@ -147,7 +186,13 @@ describe("BudgetMonitor", () => {
 
     const decision = monitor.checkAfterStep(0.02);
 
-    expect(decision).toBe("abort");
+    expect(decision).toMatchObject({
+      type: "abort",
+      details: {
+        capReason: "paid_daily_free_allowance_cut_off",
+        billingStopReason: "extra_usage_overflow_disabled",
+      },
+    });
     expect(writer.write).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "data-rate-limit-warning",
@@ -180,7 +225,7 @@ describe("BudgetMonitor", () => {
 
     const decision = monitor.checkAfterStep(1.25);
 
-    expect(decision).toBe("abort-agent-run-spend-cap");
+    expect(decision.type).toBe("abort-agent-run-spend-cap");
     expect(onAgentRunSpendCapHit).toHaveBeenCalledWith({
       runCostDollars: 1.25,
       runCapDollars: 1,
@@ -227,7 +272,7 @@ describe("BudgetMonitor", () => {
 
     const decision = monitor.checkAfterStep(1.25);
 
-    expect(decision).toBe("abort-agent-run-spend-cap");
+    expect(decision.type).toBe("abort-agent-run-spend-cap");
     expect(writer.write).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "data-rate-limit-warning",
@@ -267,6 +312,8 @@ describe("captureBudgetSnapshot", () => {
         subscription: "pro",
       }),
     ).toMatchObject({
+      extraUsageEnabledAtStart: true,
+      extraUsageHasBalanceAtStart: true,
       extraUsageBalanceAtStart: 25,
       extraUsageAutoReload: true,
       extraUsageMonthlyRemainingAtStart: 3,

--- a/lib/chat/budget-monitor.ts
+++ b/lib/chat/budget-monitor.ts
@@ -218,6 +218,7 @@ export class BudgetMonitor {
           snapshot.extraUsageBalanceAtStart >= overflowDollars;
         const hasExtraCushion =
           snapshot.extraUsageOverflowAllowed !== false &&
+          snapshot.extraUsageEnabledAtStart &&
           guardrailAllowsOverflow &&
           balanceAllowsOverflow;
 

--- a/lib/chat/budget-monitor.ts
+++ b/lib/chat/budget-monitor.ts
@@ -31,12 +31,43 @@ export interface BudgetSnapshot {
   monthlyLimitPoints: number;
   monthlyRemainingAtStart: number;
   monthlyResetTime: Date;
+  extraUsageEnabledAtStart: boolean;
+  extraUsageHasBalanceAtStart: boolean;
   extraUsageBalanceAtStart: number;
   extraUsageAutoReload: boolean;
   extraUsageMonthlyRemainingAtStart?: number;
   capReasonOnExhaustion?: LimitCapReason;
   extraUsageOverflowAllowed?: boolean;
 }
+
+export type BudgetBillingStopReason =
+  | "monthly_included_exhausted"
+  | "extra_usage_disabled"
+  | "extra_usage_balance_empty"
+  | "extra_usage_balance_insufficient"
+  | "monthly_extra_usage_spending_cap_hit"
+  | "extra_usage_overflow_disabled";
+
+export interface BudgetAbortDetails {
+  capReason: LimitCapReason;
+  billingStopReason: BudgetBillingStopReason;
+  midStream: true;
+  projectedCostDollars: number;
+  overflowDollars: number;
+  monthlyLimitDollars: number;
+  monthlyRemainingDollarsAtStart: number;
+  extraUsageEnabled: boolean;
+  extraUsageHasBalance: boolean;
+  extraUsageBalanceDollars: number;
+  extraUsageAutoReloadEnabled: boolean;
+  extraUsageMonthlyRemainingDollars?: number;
+  extraUsageAvailable: boolean;
+}
+
+export type BudgetCheckDecision =
+  | { type: "continue" }
+  | { type: "abort"; details: BudgetAbortDetails }
+  | { type: "abort-agent-run-spend-cap"; hit: AgentRunSpendCapHit };
 
 /**
  * Captures the per-request budget snapshot used by BudgetMonitor.
@@ -63,6 +94,8 @@ export function captureBudgetSnapshot(args: {
     monthlyLimitPoints,
     monthlyRemainingAtStart: rateLimitInfo.monthly!.remaining,
     monthlyResetTime: monthlyResetTime!,
+    extraUsageEnabledAtStart: extraUsageConfig?.enabled ?? false,
+    extraUsageHasBalanceAtStart: extraUsageConfig?.hasBalance ?? false,
     extraUsageBalanceAtStart: extraUsageConfig?.balanceDollars ?? 0,
     extraUsageAutoReload: extraUsageConfig?.autoReloadEnabled ?? false,
     extraUsageMonthlyRemainingAtStart:
@@ -93,8 +126,8 @@ export function getProAgentRunSpendCap(args: {
  * in chat-handler stays thin.
  *
  * Each call to `checkAfterStep` emits at most one warning (per crossed
- * threshold) and returns "abort" only when the bucket is exhausted with no
- * extra-usage cushion. The caller owns the AbortController.
+ * threshold) and returns an abort decision only when the bucket is exhausted
+ * with no extra-usage cushion. The caller owns the AbortController.
  */
 export class BudgetMonitor {
   private highestThresholdEmitted: number;
@@ -118,9 +151,7 @@ export class BudgetMonitor {
       BUDGET_THRESHOLDS.filter((t) => startUsedPercent >= t).pop() ?? 0;
   }
 
-  checkAfterStep(
-    currentCostDollars: number,
-  ): "continue" | "abort" | "abort-agent-run-spend-cap" {
+  checkAfterStep(currentCostDollars: number): BudgetCheckDecision {
     const { snapshot } = this;
     const usedSinceStartPoints = Math.ceil(
       currentCostDollars * POINTS_PER_DOLLAR,
@@ -157,7 +188,7 @@ export class BudgetMonitor {
         midStream: true,
       });
       this.options.onAgentRunSpendCapHit?.(hit);
-      return "abort-agent-run-spend-cap";
+      return { type: "abort-agent-run-spend-cap", hit };
     }
 
     const projectedUsedPoints =
@@ -167,7 +198,7 @@ export class BudgetMonitor {
     const usedPercent =
       (projectedUsedPoints / snapshot.monthlyLimitPoints) * 100;
 
-    let decision: "continue" | "abort" = "continue";
+    let abortDetails: BudgetAbortDetails | null = null;
 
     for (const threshold of BUDGET_THRESHOLDS) {
       if (usedPercent < threshold) {
@@ -211,13 +242,17 @@ export class BudgetMonitor {
               : !guardrailAllowsOverflow
                 ? "extra_usage_cap"
                 : "monthly_exhausted");
+          abortDetails = this.buildAbortDetails({
+            capReason,
+            overflowDollars,
+            projectedUsedPoints,
+          });
           this.emit({
             usedPercent: 100,
             projectedUsedPoints: snapshot.monthlyLimitPoints,
             cutOff: true,
             capReason,
           });
-          decision = "abort";
         }
       } else {
         if (threshold <= this.highestThresholdEmitted) {
@@ -228,7 +263,82 @@ export class BudgetMonitor {
       }
     }
 
-    return decision;
+    return abortDetails
+      ? { type: "abort", details: abortDetails }
+      : { type: "continue" };
+  }
+
+  private buildAbortDetails(args: {
+    capReason: LimitCapReason;
+    overflowDollars: number;
+    projectedUsedPoints: number;
+  }): BudgetAbortDetails {
+    const monthlyLimitDollars =
+      this.snapshot.monthlyLimitPoints / POINTS_PER_DOLLAR;
+    const monthlyRemainingDollarsAtStart =
+      this.snapshot.monthlyRemainingAtStart / POINTS_PER_DOLLAR;
+    const extraUsageMonthlyRemainingDollars =
+      this.snapshot.extraUsageMonthlyRemainingAtStart;
+    const extraUsageAvailable =
+      this.snapshot.extraUsageOverflowAllowed !== false &&
+      this.snapshot.extraUsageEnabledAtStart &&
+      (this.snapshot.extraUsageAutoReload ||
+        this.snapshot.extraUsageBalanceAtStart > 0) &&
+      (extraUsageMonthlyRemainingDollars === undefined ||
+        extraUsageMonthlyRemainingDollars > 0);
+
+    return {
+      capReason: args.capReason,
+      billingStopReason: this.getBillingStopReason({
+        capReason: args.capReason,
+        overflowDollars: args.overflowDollars,
+      }),
+      midStream: true,
+      projectedCostDollars:
+        Math.round((args.projectedUsedPoints / POINTS_PER_DOLLAR) * 100) / 100,
+      overflowDollars: Math.round(args.overflowDollars * 100) / 100,
+      monthlyLimitDollars,
+      monthlyRemainingDollarsAtStart:
+        Math.round(monthlyRemainingDollarsAtStart * 100) / 100,
+      extraUsageEnabled: this.snapshot.extraUsageEnabledAtStart,
+      extraUsageHasBalance: this.snapshot.extraUsageHasBalanceAtStart,
+      extraUsageBalanceDollars:
+        Math.round(this.snapshot.extraUsageBalanceAtStart * 100) / 100,
+      extraUsageAutoReloadEnabled: this.snapshot.extraUsageAutoReload,
+      ...(extraUsageMonthlyRemainingDollars !== undefined && {
+        extraUsageMonthlyRemainingDollars:
+          Math.round(extraUsageMonthlyRemainingDollars * 100) / 100,
+      }),
+      extraUsageAvailable,
+    };
+  }
+
+  private getBillingStopReason(args: {
+    capReason: LimitCapReason;
+    overflowDollars: number;
+  }): BudgetBillingStopReason {
+    if (this.snapshot.extraUsageOverflowAllowed === false) {
+      return "extra_usage_overflow_disabled";
+    }
+    if (args.capReason === "extra_usage_cap") {
+      return "monthly_extra_usage_spending_cap_hit";
+    }
+    if (!this.snapshot.extraUsageEnabledAtStart) {
+      return "extra_usage_disabled";
+    }
+    if (
+      !this.snapshot.extraUsageAutoReload &&
+      this.snapshot.extraUsageBalanceAtStart <= 0
+    ) {
+      return "extra_usage_balance_empty";
+    }
+    if (
+      !this.snapshot.extraUsageAutoReload &&
+      this.snapshot.extraUsageBalanceAtStart < args.overflowDollars
+    ) {
+      return "extra_usage_balance_insufficient";
+    }
+    return "monthly_included_exhausted";
   }
 
   private emit(args: {

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -119,6 +119,56 @@ describe("saveMessage", () => {
     });
   });
 
+  it("retries transient Convex WorkerOverloaded save failures before surfacing an error", async () => {
+    const { saveMessage, mockMutation } = await loadSaveMessageWithMocks();
+    const convexError = new Error("[Request ID: abc] Server Error") as Error & {
+      data?: unknown;
+    };
+    convexError.name = "ConvexError";
+    convexError.data = {
+      code: "MESSAGE_SAVE_FAILED",
+      message: "Failed to save message",
+      failureStage: "insert_message",
+      causeName: "WorkerOverloaded",
+      causeMessage: "Worker overloaded",
+    };
+    mockMutation
+      .mockRejectedValueOnce(convexError as never)
+      .mockRejectedValueOnce(convexError as never)
+      .mockResolvedValueOnce({ id: "message-1" } as never);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await expect(
+        saveMessage({
+          chatId: "chat-1",
+          userId: "user-1",
+          message: {
+            id: "message-1",
+            role: "assistant",
+            parts: [{ type: "text", text: "done" }],
+          },
+        }),
+      ).resolves.toEqual({ id: "message-1" });
+
+      expect(mockMutation).toHaveBeenCalledTimes(3);
+      const retryEvents = warnSpy.mock.calls
+        .map(([line]) => JSON.parse(String(line)))
+        .filter((payload) => payload.event === "message_save_retry_scheduled");
+      expect(retryEvents).toHaveLength(2);
+      expect(retryEvents[0]).toMatchObject({
+        retry_reason: "worker_overloaded",
+        attempt: 1,
+        next_attempt: 2,
+        chat_id: "chat-1",
+        message_id: "message-1",
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("maps Convex message-size rejections to a user-facing bad request", async () => {
     const { saveMessage, mockMutation } = await loadSaveMessageWithMocks();
     const convexError = new Error("[Request ID: abc] Server Error") as Error & {

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -161,6 +161,15 @@ describe("saveMessage", () => {
         retry_reason: "worker_overloaded",
         attempt: 1,
         next_attempt: 2,
+        retry_delay_ms: 0,
+        chat_id: "chat-1",
+        message_id: "message-1",
+      });
+      expect(retryEvents[1]).toMatchObject({
+        retry_reason: "worker_overloaded",
+        attempt: 2,
+        next_attempt: 3,
+        retry_delay_ms: 0,
         chat_id: "chat-1",
         message_id: "message-1",
       });

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -40,6 +40,8 @@ const MAX_DATABASE_ERROR_DATA_BYTES = 4 * 1024;
 const MAX_DATABASE_ERROR_DATA_DEPTH = 3;
 const MAX_DATABASE_ERROR_DATA_ARRAY_LENGTH = 20;
 const LARGE_MESSAGE_SAVE_WARNING_BYTES = 850 * 1024;
+const SAVE_MESSAGE_RETRY_DELAYS_MS =
+  process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
 const REDACTED_ERROR_DATA_VALUE = "[Redacted]";
 type SummaryReason =
   | "token_threshold"
@@ -222,6 +224,39 @@ const hasDatabaseErrorCode = (data: unknown, code: string): boolean =>
 
 const getDatabaseFailureStage = (data: unknown): string | undefined =>
   getObjectString(data, "failureStage");
+
+const getRetryableSaveMessageErrorReason = (
+  error: unknown,
+): string | undefined => {
+  const dbErrorData = getErrorData(error);
+  const errorText = [
+    error instanceof Error ? error.name : undefined,
+    stringifyError(error),
+    getDatabaseErrorCode(dbErrorData),
+    getDatabaseCauseErrorCode(dbErrorData),
+    getObjectString(dbErrorData, "causeName"),
+    getObjectString(dbErrorData, "causeMessage"),
+    getObjectString(dbErrorData, "message"),
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  if (/WorkerOverloaded/i.test(errorText)) return "worker_overloaded";
+  if (
+    /ServiceUnavailable|temporarily unavailable|ECONNRESET|ETIMEDOUT/i.test(
+      errorText,
+    )
+  ) {
+    return "transient_service_unavailable";
+  }
+  if (/TooManyRequests|rate.?limit|429/i.test(errorText)) {
+    return "convex_rate_limited";
+  }
+  return undefined;
+};
+
+const waitForRetryDelay = (delayMs: number) =>
+  new Promise((resolve) => setTimeout(resolve, delayMs));
 
 const ACCESS_DENIED_ERROR_CODE = "ACCESS_DENIED";
 const CHAT_CANCELED_ERROR_CODE = "CHAT_CANCELED";
@@ -549,7 +584,7 @@ export async function saveMessage({
       | Record<string, unknown>
       | undefined;
 
-    return await getConvexClient().mutation(api.messages.saveMessage, {
+    const mutationArgs = {
       serviceKey,
       id: message.id,
       chatId,
@@ -565,7 +600,47 @@ export async function saveMessage({
       usage: usageForSave,
       updateOnly,
       isHidden,
-    });
+    };
+
+    for (let attemptIndex = 0; ; attemptIndex++) {
+      try {
+        return await getConvexClient().mutation(
+          api.messages.saveMessage,
+          mutationArgs,
+        );
+      } catch (error) {
+        const retryReason = getRetryableSaveMessageErrorReason(error);
+        const retryDelayMs = SAVE_MESSAGE_RETRY_DELAYS_MS[attemptIndex];
+        if (!retryReason || retryDelayMs === undefined) {
+          throw error;
+        }
+
+        console.warn(
+          JSON.stringify({
+            level: "warn",
+            event: "message_save_retry_scheduled",
+            service: "chat-handler",
+            timestamp: new Date().toISOString(),
+            db_operation: "messages.saveMessage",
+            retry_reason: retryReason,
+            attempt: attemptIndex + 1,
+            next_attempt: attemptIndex + 2,
+            retry_delay_ms: retryDelayMs,
+            chat_id: chatId,
+            user_id: userId,
+            message_id: message.id,
+            message_role: message.role,
+            mode,
+            model,
+            finish_reason: finishReason,
+            update_only: updateOnly === true,
+            hidden: isHidden === true,
+            ...persistenceDiagnostics,
+          }),
+        );
+        await waitForRetryDelay(retryDelayMs);
+      }
+    }
   } catch (error) {
     throw databaseError("messages.saveMessage", error, {
       chat_id: chatId,

--- a/lib/rate-limit/free-monthly-cost.ts
+++ b/lib/rate-limit/free-monthly-cost.ts
@@ -25,6 +25,8 @@ export interface FreeMonthlyCostSnapshot {
   monthlyLimitPoints: number;
   monthlyRemainingAtStart: number;
   monthlyResetTime: Date;
+  extraUsageEnabledAtStart: false;
+  extraUsageHasBalanceAtStart: false;
   extraUsageBalanceAtStart: 0;
   extraUsageAutoReload: false;
   rateLimitSkipped?: boolean;
@@ -72,6 +74,8 @@ export async function checkFreeMonthlyCostLimit(
         monthlyLimitPoints: limitPoints,
         monthlyRemainingAtStart: limitPoints,
         monthlyResetTime: new Date(reset),
+        extraUsageEnabledAtStart: false,
+        extraUsageHasBalanceAtStart: false,
         extraUsageBalanceAtStart: 0,
         extraUsageAutoReload: false,
         rateLimitSkipped: true,
@@ -105,6 +109,8 @@ export async function checkFreeMonthlyCostLimit(
     monthlyLimitPoints: limitPoints,
     monthlyRemainingAtStart: remainingPoints,
     monthlyResetTime: new Date(reset),
+    extraUsageEnabledAtStart: false,
+    extraUsageHasBalanceAtStart: false,
     extraUsageBalanceAtStart: 0,
     extraUsageAutoReload: false,
   };

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -321,6 +321,22 @@ export const checkTokenBucketLimit = async (
       resetTimestamp: reset,
       subscription,
       capReason,
+      extraUsageEnabled: extraUsageConfig?.enabled ?? false,
+      extraUsageHasBalance: extraUsageConfig?.hasBalance ?? false,
+      extraUsageAutoReloadEnabled: extraUsageConfig?.autoReloadEnabled ?? false,
+      ...(extraUsageConfig?.balanceDollars !== undefined && {
+        extraUsageBalanceDollars: extraUsageConfig.balanceDollars,
+      }),
+      ...(extraUsageConfig?.monthlyCapDollars !== undefined && {
+        extraUsageMonthlyCapDollars: extraUsageConfig.monthlyCapDollars,
+      }),
+      ...(extraUsageConfig?.monthlySpentDollars !== undefined && {
+        extraUsageMonthlySpentDollars: extraUsageConfig.monthlySpentDollars,
+      }),
+      ...(extraUsageConfig?.monthlyRemainingDollars !== undefined && {
+        extraUsageMonthlyRemainingDollars:
+          extraUsageConfig.monthlyRemainingDollars,
+      }),
       ...getLimitPressureContext({ subscription, capReason }),
       ...extra,
     });

--- a/lib/system-prompt/__tests__/resume.test.ts
+++ b/lib/system-prompt/__tests__/resume.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { getResumeSection } from "../resume";
+
+describe("getResumeSection", () => {
+  it("tells context-limit resumes not to restart completed work", () => {
+    const resumeSection = getResumeSection("context-limit");
+
+    expect(resumeSection).toContain("Do not restart the original task");
+    expect(resumeSection).toContain("repeat completed tool work");
+    expect(resumeSection).toContain("current sandbox state");
+  });
+});

--- a/lib/system-prompt/resume.ts
+++ b/lib/system-prompt/resume.ts
@@ -20,7 +20,9 @@ one step at a time rather than trying to output everything at once.
 Your previous response was stopped because the conversation's accumulated token usage exceeded \
 the context limit, even after earlier messages were summarized. The context has been condensed \
 but you may be missing details from the earlier conversation. If the user says "continue" or similar, \
-resume the task where you left off. Consult the transcript file on the sandbox if you need to recover \
+resume the task where you left off. Do not restart the original task or repeat completed tool work. \
+First inspect the latest assistant progress, todos, files, and current sandbox state when needed, then continue \
+with only the remaining work. Consult the transcript file on the sandbox if you need to recover \
 specific details from the earlier conversation.
 </resume_context>`;
   } else if (finishReason === "preemptive-timeout") {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -80,6 +80,7 @@ import {
   getEmptyProcessedMessagesMetadata,
 } from "@/lib/utils/local-attachment-messages";
 import {
+  captureAgentBudgetAbort,
   captureAgentCompletionAnalytics,
   captureToolCalls,
   captureUsageCost,
@@ -1529,6 +1530,7 @@ export const agentLongTask = task({
               currentSystemPrompt,
               tools,
               mode,
+              endpoint: "/api/agent-long",
               userId,
               subscription,
               chatId,
@@ -1552,6 +1554,21 @@ export const agentLongTask = task({
               ensureSandbox,
               chatLogger,
               usageRefundTracker,
+              onBudgetAbort: (details) =>
+                captureAgentBudgetAbort({
+                  posthog,
+                  userId,
+                  subscription,
+                  chatId,
+                  endpoint: "/api/agent-long",
+                  mode,
+                  selectedModel,
+                  selectedModelOverride,
+                  configuredModelId,
+                  responseModel: state.responseModel,
+                  isAutoContinue,
+                  details,
+                }),
               getHardTimeoutReason: () =>
                 agentLongDurationExceeded
                   ? PREEMPTIVE_TIMEOUT_FINISH_REASON
@@ -1596,6 +1613,7 @@ export const agentLongTask = task({
                 state.stoppedDueToDoomLoop = false;
                 state.stoppedDueToBudgetExhaustion = false;
                 state.stoppedDueToAgentRunSpendCap = false;
+                state.budgetAbortDetails = undefined;
                 preFallbackCacheRead = usageTracker.cacheReadTokens;
                 preFallbackCacheWrite = usageTracker.cacheWriteTokens;
                 usageTracker.resetModelLeg();
@@ -1678,6 +1696,7 @@ export const agentLongTask = task({
                         state.stoppedDueToDoomLoop = false;
                         state.stoppedDueToBudgetExhaustion = false;
                         state.stoppedDueToAgentRunSpendCap = false;
+                        state.budgetAbortDetails = undefined;
                         const fallbackStartTime = Date.now();
                         preFallbackCacheRead = usageTracker.cacheReadTokens;
                         preFallbackCacheWrite = usageTracker.cacheWriteTokens;
@@ -1775,6 +1794,9 @@ export const agentLongTask = task({
                                     sandboxInfo,
                                     outcome,
                                     chatLogger,
+                                    finishReason: state.streamFinishReason,
+                                    budgetAbortDetails:
+                                      state.budgetAbortDetails,
                                   });
                                   if (!isTerminalProviderStreamError(state)) {
                                     chatLogger?.emitSuccess({
@@ -1900,6 +1922,8 @@ export const agentLongTask = task({
                         sandboxInfo,
                         outcome,
                         chatLogger,
+                        finishReason: state.streamFinishReason,
+                        budgetAbortDetails: state.budgetAbortDetails,
                       });
                       if (!isTerminalProviderStreamError(state)) {
                         chatLogger?.emitSuccess({


### PR DESCRIPTION
## Summary
- add structured mid-stream Agent budget-abort decisions and telemetry for `agent_mid_stream_budget_aborted` / `agent_billing_stop`, including cap reason, extra-usage balance, monthly spending-cap remaining, auto-reload state, model, endpoint, chat, and user ids
- keep extra-usage spending-limit copy explicit and add a persisted `budget-exhausted` finish notice that does not offer a blind Continue button
- retry transient `messages.saveMessage` Convex failures such as `WorkerOverloaded` with bounded backoff before surfacing the existing database error
- strengthen hidden auto-continue/resume prompts so Agent resumes from saved progress after compaction instead of restarting completed work

## Validation
- `./node_modules/.bin/jest lib/chat/__tests__/budget-monitor.test.ts lib/api/__tests__/chat-logger.test.ts lib/db/__tests__/actions-save-message.test.ts app/hooks/__tests__/useAutoContinue.test.ts app/components/__tests__/RateLimitWarning.test.tsx app/components/__tests__/FinishReasonNotice.test.tsx lib/system-prompt/__tests__/resume.test.ts --runInBand`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint app/components/FinishReasonNotice.tsx app/components/__tests__/FinishReasonNotice.test.tsx app/components/__tests__/RateLimitWarning.test.tsx app/hooks/useAutoContinue.ts app/hooks/useChatHandlers.ts app/hooks/__tests__/useAutoContinue.test.ts lib/api/chat-logger.ts lib/api/agent-stream-runner.ts lib/api/chat-handler.ts lib/api/paid-daily-free-allowance-rescue.ts lib/api/__tests__/chat-logger.test.ts lib/chat/budget-monitor.ts lib/chat/__tests__/budget-monitor.test.ts lib/db/actions.ts lib/db/__tests__/actions-save-message.test.ts lib/rate-limit/free-monthly-cost.ts lib/system-prompt/resume.ts lib/system-prompt/__tests__/resume.test.ts trigger/agent-long.ts`
- `./node_modules/.bin/prettier --check app/components/FinishReasonNotice.tsx app/components/__tests__/FinishReasonNotice.test.tsx app/components/__tests__/RateLimitWarning.test.tsx app/hooks/useAutoContinue.ts app/hooks/useChatHandlers.ts app/hooks/__tests__/useAutoContinue.test.ts lib/api/chat-logger.ts lib/api/agent-stream-runner.ts lib/api/chat-handler.ts lib/api/paid-daily-free-allowance-rescue.ts lib/api/__tests__/chat-logger.test.ts lib/chat/budget-monitor.ts lib/chat/__tests__/budget-monitor.test.ts lib/db/actions.ts lib/db/__tests__/actions-save-message.test.ts lib/rate-limit/free-monthly-cost.ts lib/system-prompt/resume.ts lib/system-prompt/__tests__/resume.test.ts trigger/agent-long.ts`

## Visual verification
- Temporary local route rendered `RateLimitWarning` and `FinishReasonNotice` at `http://127.0.0.1:3100/codex-visual-budget-check` after adding a temporary unauthenticated allowlist entry, both removed before commit.
- Playwright verified status 200, spending-limit copy visible, `Increase Limit` CTA visible, budget guardrail notice visible, zero `Continue` buttons for `budget-exhausted`, and no console/page errors. Screenshot was written to `/tmp/hackerai-budget-visual-check.png`.

## Manual verification
- Run an Ultra Agent request that crosses included usage while extra usage has balance but the monthly extra-usage spending cap is exhausted. The stream warning should say extra usage spending limit / Increase Limit, and PostHog should capture `agent_mid_stream_budget_aborted` with `cap_reason=extra_usage_cap` and `billing_stop_reason=monthly_extra_usage_spending_cap_hit`.
- Run an Agent request that hits included monthly exhaustion with no extra-usage balance. The same event should use `billing_stop_reason=extra_usage_balance_empty` instead of the spending-cap reason.
- Simulate a transient Convex `WorkerOverloaded` on `messages.saveMessage`; the save should retry before surfacing any database error, preserving long Agent output when the retry succeeds.
- Trigger auto-continue after context compaction and confirm the hidden continuation asks Agent to continue from latest saved progress without repeating completed tool work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer end-of-run guidance for runs stopped at a usage guardrail, including updated messaging and improved resume instructions for context-limit scenarios.

* **Bug Fixes**
  * Hid the “Continue” button when runs stop due to budget exhaustion, while keeping the guardrail notice visible.
  * Updated monthly spending cap warnings to show the correct “increase your limit” messaging and action.
  * Improved message saving reliability by retrying temporary overload/network failures instead of failing immediately.

* **Tests**
  * Expanded/updated coverage for the new guardrail, continue, and rate-limit scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->