### PR TITLE
Fix Windows local sandbox attachment downloads

### DIFF
--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -604,6 +604,7 @@ describe("CentrifugoSandbox", () => {
       (sandbox as any).curlCaps = {
         retryAllErrors: true,
         retryConnrefused: true,
+        sslNoRevoke: true,
       };
       const runs: string[] = [];
       const runOptions: unknown[] = [];
@@ -627,6 +628,7 @@ describe("CentrifugoSandbox", () => {
       const cmd = runs[0];
       expect(cmd).toContain("mkdir -p '/c/temp/hackerai-upload'");
       expect(cmd).toContain("curl -fsSL");
+      expect(cmd).toContain("--ssl-no-revoke");
       expect(cmd).toContain("--retry 3");
       expect(cmd).toContain("--retry-delay 1");
       expect(cmd).toContain("--retry-all-errors");
@@ -638,6 +640,85 @@ describe("CentrifugoSandbox", () => {
         displayName: "Downloading: image.png",
         timeoutMs: 120000,
       });
+    });
+
+    it("downloadFromUrl omits --ssl-no-revoke when Windows curl lacks support", async () => {
+      const { sandbox, runs } = createWindowsBashSandbox();
+      (sandbox as any).curlCaps = {
+        retryAllErrors: true,
+        retryConnrefused: true,
+        sslNoRevoke: false,
+      };
+
+      await sandbox.files.downloadFromUrl(
+        "https://example.com/image.png",
+        "/tmp/hackerai-upload/image.png",
+      );
+
+      expect(runs[0]).toContain("curl -fsSL");
+      expect(runs[0]).not.toContain("--ssl-no-revoke");
+    });
+
+    it("uploadToUrl emits Windows curl with --ssl-no-revoke when supported", async () => {
+      const { sandbox, runs, runOptions } = createWindowsBashSandbox();
+
+      await sandbox.files.uploadToUrl(
+        "/tmp/hackerai-upload/report.txt",
+        "https://example.com/upload",
+        "text/plain",
+      );
+
+      expect(runs[0]).toContain("curl -fsSL --ssl-no-revoke -X PUT");
+      expect(runs[0]).toContain("-H 'Content-Type: text/plain'");
+      expect(runs[0]).toContain(
+        "--data-binary @'/c/temp/hackerai-upload/report.txt'",
+      );
+      expect(runOptions[0]).toMatchObject({
+        displayName: "Uploading: report.txt",
+        timeoutMs: 120000,
+      });
+    });
+
+    it("downloadFromUrl failure diagnostics do not list local directory contents", async () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      const { sandbox, runs } = createWindowsBashSandbox();
+      (sandbox as any).commands.run = jest.fn(async (cmd: string) => {
+        runs.push(cmd);
+        if (cmd.includes("target_dir_exists")) {
+          return {
+            stdout:
+              "target_dir_exists=true\ntarget_dir_writable=true\nFilesystem Size Used Avail Use% Mounted on\n",
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return {
+          stdout: "",
+          stderr: "curl: (35) schannel: CRYPT_E_NO_REVOCATION_CHECK",
+          exitCode: 35,
+        };
+      });
+
+      try {
+        const assertion = expect(
+          sandbox.files.downloadFromUrl(
+            "https://example.com/image.png",
+            "/tmp/hackerai-upload/image.png",
+          ),
+        ).rejects.toThrow("Failed to download file");
+        await jest.advanceTimersByTimeAsync(5_000);
+        await assertion;
+
+        const diagCmd = runs[runs.length - 1];
+        expect(diagCmd).toContain("target_dir_exists");
+        expect(diagCmd).toContain("target_dir_writable");
+        expect(diagCmd).not.toContain("ls -la");
+        expect(diagCmd).not.toContain("dir ");
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
     });
 
     it("downloadFromUrl retries local command wrapper timeouts", async () => {

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -618,6 +618,30 @@ describe("CentrifugoSandbox", () => {
       return { sandbox, runs, runOptions };
     }
 
+    function createWindowsCmdSandbox() {
+      const sandbox = createSandbox({
+        osInfo: {
+          platform: "win32",
+          arch: "x86_64",
+          release: "10.0.19045",
+          hostname: "WIN-DEV",
+        },
+      });
+      (sandbox as any).shellKind = "cmd";
+      (sandbox as any).httpClient = "curl";
+      (sandbox as any).curlCaps = {
+        retryAllErrors: true,
+        retryConnrefused: true,
+        sslNoRevoke: true,
+      };
+      const runs: string[] = [];
+      (sandbox as any).commands.run = jest.fn(async (cmd: string) => {
+        runs.push(cmd);
+        return { stdout: "", stderr: "", exitCode: 0 };
+      });
+      return { sandbox, runs };
+    }
+
     it("downloadFromUrl emits POSIX mkdir + curl with MSYS paths", async () => {
       const { sandbox, runs, runOptions } = createWindowsBashSandbox();
       // Mock validateDownloadUrl is real; use an https URL it accepts.
@@ -715,6 +739,47 @@ describe("CentrifugoSandbox", () => {
         expect(diagCmd).toContain("target_dir_exists");
         expect(diagCmd).toContain("target_dir_writable");
         expect(diagCmd).not.toContain("ls -la");
+        expect(diagCmd).not.toContain("dir ");
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
+    });
+
+    it("downloadFromUrl cmd diagnostics include writability without listing contents", async () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      const { sandbox, runs } = createWindowsCmdSandbox();
+      (sandbox as any).commands.run = jest.fn(async (cmd: string) => {
+        runs.push(cmd);
+        if (cmd.includes("target_dir_exists")) {
+          return {
+            stdout: "target_dir_exists=true\ntarget_dir_writable=true\n",
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return {
+          stdout: "",
+          stderr: "curl: (35) schannel: CRYPT_E_NO_REVOCATION_CHECK",
+          exitCode: 35,
+        };
+      });
+
+      try {
+        const assertion = expect(
+          sandbox.files.downloadFromUrl(
+            "https://example.com/image.png",
+            "/tmp/hackerai-upload/image.png",
+          ),
+        ).rejects.toThrow("Failed to download file");
+        await jest.advanceTimersByTimeAsync(5_000);
+        await assertion;
+
+        const diagCmd = runs[runs.length - 1];
+        expect(diagCmd).toContain("target_dir_exists");
+        expect(diagCmd).toContain("target_dir_writable");
+        expect(diagCmd).toContain("pushd");
         expect(diagCmd).not.toContain("dir ");
       } finally {
         consoleWarnSpy.mockRestore();

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -685,11 +685,13 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
   private curlCaps: {
     retryAllErrors: boolean;
     retryConnrefused: boolean;
+    sslNoRevoke: boolean;
   } | null = null;
 
   private async detectCurlCaps(): Promise<{
     retryAllErrors: boolean;
     retryConnrefused: boolean;
+    sslNoRevoke: boolean;
   }> {
     if (this.curlCaps) return this.curlCaps;
     try {
@@ -700,9 +702,14 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       this.curlCaps = {
         retryAllErrors: help.includes("--retry-all-errors"),
         retryConnrefused: help.includes("--retry-connrefused"),
+        sslNoRevoke: help.includes("--ssl-no-revoke"),
       };
     } catch {
-      this.curlCaps = { retryAllErrors: false, retryConnrefused: false };
+      this.curlCaps = {
+        retryAllErrors: false,
+        retryConnrefused: false,
+        sslNoRevoke: false,
+      };
     }
     return this.curlCaps;
   }
@@ -981,6 +988,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
         const caps = await this.detectCurlCaps();
         const curlFlags = [
           "-fsSL",
+          this.isWindows() && caps.sslNoRevoke ? "--ssl-no-revoke" : "",
           "--retry 3",
           "--retry-delay 1",
           caps.retryAllErrors ? "--retry-all-errors" : "",
@@ -1050,11 +1058,12 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       if (result.exitCode !== 0) {
         // Gather diagnostic info to help debug write failures (e.g. curl exit 23).
         // Fall back to the target's own directory context when the destination
-        // is a drive root and `dir` is empty.
+        // is a drive root and `dir` is empty. Avoid listing directory contents:
+        // this can be a user's local machine in desktop dangerous mode.
         const diagDir = escapedDir || (useBash ? "/" : '"."');
         const diagCmd = useBash
-          ? `ls -la ${diagDir} 2>&1; df -h /tmp 2>&1`
-          : `dir ${diagDir} 2>&1`;
+          ? `test -d ${diagDir} && echo target_dir_exists=true || echo target_dir_exists=false; test -w ${diagDir} && echo target_dir_writable=true || echo target_dir_writable=false; df -h /tmp 2>&1 | sed -n '1,2p'`
+          : `if exist ${diagDir} (echo target_dir_exists=true) else (echo target_dir_exists=false)`;
         const diag = await this.commands.run(diagCmd, { displayName: "" });
         throw new Error(
           `Failed to download file: ${result.stderr}\n` +
@@ -1092,10 +1101,21 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       const escapedPath = escapePath(path);
       const escapedUrl = escapeValue(uploadUrl);
       const escapedContentType = escapeValue(`Content-Type: ${contentType}`);
+      const curlUploadFlags =
+        httpClient === "curl"
+          ? [
+              "-fsSL",
+              this.isWindows() && (await this.detectCurlCaps()).sslNoRevoke
+                ? "--ssl-no-revoke"
+                : "",
+            ]
+              .filter(Boolean)
+              .join(" ")
+          : "";
 
       const command =
         httpClient === "curl"
-          ? `curl -fsSL -X PUT -H ${escapedContentType} --data-binary @${escapedPath} ${escapedUrl}`
+          ? `curl ${curlUploadFlags} -X PUT -H ${escapedContentType} --data-binary @${escapedPath} ${escapedUrl}`
           : `wget -q --method=PUT --header=${escapedContentType} --body-file=${escapedPath} -O - ${escapedUrl}`;
 
       const result = await this.commands.run(command, {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -1063,7 +1063,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
         const diagDir = escapedDir || (useBash ? "/" : '"."');
         const diagCmd = useBash
           ? `test -d ${diagDir} && echo target_dir_exists=true || echo target_dir_exists=false; test -w ${diagDir} && echo target_dir_writable=true || echo target_dir_writable=false; df -h /tmp 2>&1 | sed -n '1,2p'`
-          : `if exist ${diagDir} (echo target_dir_exists=true) else (echo target_dir_exists=false)`;
+          : `if exist ${diagDir} (echo target_dir_exists=true) else (echo target_dir_exists=false) & (pushd ${diagDir} >nul 2>nul && (copy /Y NUL .hackerai_write_probe.tmp >nul 2>nul && del /q .hackerai_write_probe.tmp >nul 2>nul && echo target_dir_writable=true || echo target_dir_writable=false) & popd >nul 2>nul) || echo target_dir_writable=false`;
         const diag = await this.commands.run(diagCmd, { displayName: "" });
         throw new Error(
           `Failed to download file: ${result.stderr}\n` +


### PR DESCRIPTION
## Summary
- add Windows-only curl --ssl-no-revoke support when local sandbox curl advertises the flag
- apply the same Schannel-compatible flag to local sandbox uploads back to signed URLs
- stop dumping local upload directory listings in attachment download failure diagnostics

## Why
Windows desktop/local sandbox attachment staging can fail before model generation with curl: (35) schannel: CRYPT_E_NO_REVOCATION_CHECK while downloading a HackerAI S3 attachment URL. Retrying the sandbox does not help because the same host curl/Schannel path fails certificate revocation lookup again.

## Validation
- ./node_modules/.bin/jest lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts --runInBand
- ./node_modules/.bin/prettier --check lib/ai/tools/utils/centrifugo-sandbox.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
- ./node_modules/.bin/eslint lib/ai/tools/utils/centrifugo-sandbox.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- git diff --check

## Manual verification
- On a Windows desktop/local sandbox connection, start an Agent run with an attached file that stages from a HackerAI S3 URL.
- Confirm the attachment stages successfully instead of failing with CRYPT_E_NO_REVOCATION_CHECK.
- If staging still fails, confirm diagnostics show target directory existence/writability only, not a full local directory listing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows file transfers by conditionally enabling secure `curl` behavior when supported, preventing transfer failures caused by unsupported SSL options.
  * Updated download failure diagnostics to focus on whether the target directory exists and is writable, avoiding unnecessary local directory listing.
  * Applied the same improved, capability-aware `curl` flag handling to both download and upload flows.
* **Tests**
  * Expanded the Windows sandbox test coverage to verify conditional `curl` flag generation and the updated diagnostics output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->