### PR TITLE
Sanitize Stripe webhook signature logs

### DIFF
--- a/app/api/extra-usage/webhook/route.ts
+++ b/app/api/extra-usage/webhook/route.ts
@@ -8,6 +8,16 @@ import {
   PAID_FUNNEL_EVENTS,
   paidFunnelProperties,
 } from "@/lib/analytics/paid-funnel";
+import {
+  logStripeWebhookMissingSignature,
+  logStripeWebhookSignatureVerificationFailed,
+} from "@/lib/billing/stripe-webhook-logging";
+
+const WEBHOOK_LOG_PREFIX = "[Extra Usage Webhook]";
+const WEBHOOK_LOG_CONTEXT = {
+  webhook: "extra_usage",
+  route: "/api/extra-usage/webhook",
+};
 
 /**
  * POST /api/extra-usage/webhook
@@ -22,7 +32,13 @@ export async function POST(req: NextRequest) {
   const signature = req.headers.get("stripe-signature");
 
   if (!signature) {
-    console.error("[Extra Usage Webhook] Missing stripe-signature header");
+    logStripeWebhookMissingSignature({
+      logPrefix: WEBHOOK_LOG_PREFIX,
+      ...WEBHOOK_LOG_CONTEXT,
+      requestHeaders: req.headers,
+      body,
+      signature,
+    });
     return NextResponse.json(
       { error: "Missing stripe-signature header" },
       { status: 400 },
@@ -45,7 +61,14 @@ export async function POST(req: NextRequest) {
   try {
     event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
   } catch (err) {
-    console.error("[Extra Usage Webhook] Signature verification failed:", err);
+    logStripeWebhookSignatureVerificationFailed({
+      logPrefix: WEBHOOK_LOG_PREFIX,
+      ...WEBHOOK_LOG_CONTEXT,
+      requestHeaders: req.headers,
+      body,
+      signature,
+      error: err,
+    });
     return NextResponse.json(
       { error: "Webhook signature verification failed" },
       { status: 400 },

--- a/app/api/fraud/webhook/route.ts
+++ b/app/api/fraud/webhook/route.ts
@@ -4,6 +4,16 @@ import { getConvexClient } from "@/lib/db/convex-client";
 import { api } from "@/convex/_generated/api";
 import Stripe from "stripe";
 import { resolveUserIdsFromCustomer as resolveStripeCustomerUsers } from "@/lib/billing/resolve-customer-users";
+import {
+  logStripeWebhookMissingSignature,
+  logStripeWebhookSignatureVerificationFailed,
+} from "@/lib/billing/stripe-webhook-logging";
+
+const WEBHOOK_LOG_PREFIX = "[Fraud Webhook]";
+const WEBHOOK_LOG_CONTEXT = {
+  webhook: "fraud",
+  route: "/api/fraud/webhook",
+};
 
 type SuspensionCategory =
   | "early_fraud_warning"
@@ -410,7 +420,13 @@ export async function POST(req: NextRequest) {
   const signature = req.headers.get("stripe-signature");
 
   if (!signature) {
-    console.error("[Fraud Webhook] Missing stripe-signature header");
+    logStripeWebhookMissingSignature({
+      logPrefix: WEBHOOK_LOG_PREFIX,
+      ...WEBHOOK_LOG_CONTEXT,
+      requestHeaders: req.headers,
+      body,
+      signature,
+    });
     return NextResponse.json(
       { error: "Missing stripe-signature header" },
       { status: 400 },
@@ -433,7 +449,14 @@ export async function POST(req: NextRequest) {
   try {
     event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
   } catch (err) {
-    console.error("[Fraud Webhook] Signature verification failed:", err);
+    logStripeWebhookSignatureVerificationFailed({
+      logPrefix: WEBHOOK_LOG_PREFIX,
+      ...WEBHOOK_LOG_CONTEXT,
+      requestHeaders: req.headers,
+      body,
+      signature,
+      error: err,
+    });
     return NextResponse.json(
       { error: "Webhook signature verification failed" },
       { status: 400 },

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -112,12 +112,15 @@ jest.mock("@/lib/referrals/config", () => ({
   }),
 }));
 
-function makeWebhookRequest() {
+function makeWebhookRequest({
+  body = "{}",
+  signature = "sig_test",
+}: { body?: string; signature?: string | null } = {}) {
   return {
-    text: jest.fn().mockResolvedValue("{}"),
+    text: jest.fn().mockResolvedValue(body),
     headers: {
       get: jest.fn((name: string) =>
-        name === "stripe-signature" ? "sig_test" : null,
+        name === "stripe-signature" ? signature : null,
       ),
     },
   } as any;
@@ -140,6 +143,58 @@ describe("POST /api/subscription/webhook", () => {
     jest.restoreAllMocks();
     delete process.env.STRIPE_SUBSCRIPTION_WEBHOOK_SECRET;
     delete process.env.CONVEX_SERVICE_ROLE_KEY;
+  });
+
+  it("rejects invalid signatures with a sanitized warning before side effects", async () => {
+    const rawBody =
+      '{"id":"evt_test_reset_001","metadata":{"userId":"user_secret"}}';
+    const rawSignature =
+      "t=1782534490,v1=24cdc6311e7ea9669746b0e1cd1e8ac53b51ad96070e7919be7172b1dc1e9f30";
+    const signatureError = Object.assign(
+      new Error("No signatures found matching the expected signature"),
+      {
+        type: "StripeSignatureVerificationError",
+        header: rawSignature,
+        payload: rawBody,
+      },
+    );
+    mockConstructEvent.mockImplementation(() => {
+      throw signatureError;
+    });
+
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      makeWebhookRequest({ body: rawBody, signature: rawSignature }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({ error: "Webhook signature verification failed" });
+    expect(mockConvexMutation).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
+      "[Subscription Webhook] Signature verification failed",
+      expect.objectContaining({
+        event: "stripe_webhook_signature_verification_failed",
+        webhook: "subscription",
+        route: "/api/subscription/webhook",
+        payload_bytes: rawBody.length,
+        signature_header_present: true,
+        signature_timestamp: 1782534490,
+        signature_has_v1: true,
+        error_type: "StripeSignatureVerificationError",
+      }),
+    );
+
+    const logFields = (console.warn as jest.Mock).mock.calls[0][1];
+    const serializedLogFields = JSON.stringify(logFields);
+    expect(serializedLogFields).not.toContain(rawBody);
+    expect(serializedLogFields).not.toContain(rawSignature);
+    expect(serializedLogFields).not.toContain("user_secret");
+    expect(serializedLogFields).not.toContain(
+      "24cdc6311e7ea9669746b0e1cd1e8ac53b51ad96070e7919be7172b1dc1e9f30",
+    );
   });
 
   it("skips legacy PentestGPT invoices before resolving the old product as a HackerAI tier", async () => {

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -147,7 +147,8 @@ describe("POST /api/subscription/webhook", () => {
 
   it("rejects invalid signatures with a sanitized warning before side effects", async () => {
     const rawBody =
-      '{"id":"evt_test_reset_001","metadata":{"userId":"user_secret"}}';
+      '{"id":"evt_test_reset_001","metadata":{"label":"über","userId":"user_secret"}}';
+    const expectedPayloadBytes = new TextEncoder().encode(rawBody).byteLength;
     const rawSignature =
       "t=1782534490,v1=24cdc6311e7ea9669746b0e1cd1e8ac53b51ad96070e7919be7172b1dc1e9f30";
     const signatureError = Object.assign(
@@ -179,7 +180,7 @@ describe("POST /api/subscription/webhook", () => {
         event: "stripe_webhook_signature_verification_failed",
         webhook: "subscription",
         route: "/api/subscription/webhook",
-        payload_bytes: rawBody.length,
+        payload_bytes: expectedPayloadBytes,
         signature_header_present: true,
         signature_timestamp: 1782534490,
         signature_has_v1: true,

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -23,6 +23,16 @@ import {
   PAID_FUNNEL_EVENTS,
   paidFunnelProperties,
 } from "@/lib/analytics/paid-funnel";
+import {
+  logStripeWebhookMissingSignature,
+  logStripeWebhookSignatureVerificationFailed,
+} from "@/lib/billing/stripe-webhook-logging";
+
+const WEBHOOK_LOG_PREFIX = "[Subscription Webhook]";
+const WEBHOOK_LOG_CONTEXT = {
+  webhook: "subscription",
+  route: "/api/subscription/webhook",
+};
 
 // Linear ranking used to label tier transitions as upgrade/downgrade. Team is
 // pinned at the top because moves between team and individual plans are rare
@@ -1203,7 +1213,13 @@ export async function POST(req: NextRequest) {
   const signature = req.headers.get("stripe-signature");
 
   if (!signature) {
-    console.error("[Subscription Webhook] Missing stripe-signature header");
+    logStripeWebhookMissingSignature({
+      logPrefix: WEBHOOK_LOG_PREFIX,
+      ...WEBHOOK_LOG_CONTEXT,
+      requestHeaders: req.headers,
+      body,
+      signature,
+    });
     return NextResponse.json(
       { error: "Missing stripe-signature header" },
       { status: 400 },
@@ -1226,7 +1242,14 @@ export async function POST(req: NextRequest) {
   try {
     event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
   } catch (err) {
-    console.error("[Subscription Webhook] Signature verification failed:", err);
+    logStripeWebhookSignatureVerificationFailed({
+      logPrefix: WEBHOOK_LOG_PREFIX,
+      ...WEBHOOK_LOG_CONTEXT,
+      requestHeaders: req.headers,
+      body,
+      signature,
+      error: err,
+    });
     return NextResponse.json(
       { error: "Webhook signature verification failed" },
       { status: 400 },

--- a/app/api/team/extra-usage/webhook/route.ts
+++ b/app/api/team/extra-usage/webhook/route.ts
@@ -8,6 +8,16 @@ import {
   PAID_FUNNEL_EVENTS,
   paidFunnelProperties,
 } from "@/lib/analytics/paid-funnel";
+import {
+  logStripeWebhookMissingSignature,
+  logStripeWebhookSignatureVerificationFailed,
+} from "@/lib/billing/stripe-webhook-logging";
+
+const WEBHOOK_LOG_PREFIX = "[Team Extra Usage Webhook]";
+const WEBHOOK_LOG_CONTEXT = {
+  webhook: "team_extra_usage",
+  route: "/api/team/extra-usage/webhook",
+};
 
 /**
  * POST /api/team/extra-usage/webhook
@@ -22,7 +32,13 @@ export async function POST(req: NextRequest) {
   const signature = req.headers.get("stripe-signature");
 
   if (!signature) {
-    console.error("[Team Extra Usage Webhook] Missing stripe-signature header");
+    logStripeWebhookMissingSignature({
+      logPrefix: WEBHOOK_LOG_PREFIX,
+      ...WEBHOOK_LOG_CONTEXT,
+      requestHeaders: req.headers,
+      body,
+      signature,
+    });
     return NextResponse.json(
       { error: "Missing stripe-signature header" },
       { status: 400 },
@@ -46,10 +62,14 @@ export async function POST(req: NextRequest) {
   try {
     event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
   } catch (err) {
-    console.error(
-      "[Team Extra Usage Webhook] Signature verification failed:",
-      err,
-    );
+    logStripeWebhookSignatureVerificationFailed({
+      logPrefix: WEBHOOK_LOG_PREFIX,
+      ...WEBHOOK_LOG_CONTEXT,
+      requestHeaders: req.headers,
+      body,
+      signature,
+      error: err,
+    });
     return NextResponse.json(
       { error: "Webhook signature verification failed" },
       { status: 400 },

--- a/lib/billing/__tests__/stripe-webhook-logging.test.ts
+++ b/lib/billing/__tests__/stripe-webhook-logging.test.ts
@@ -14,7 +14,8 @@ describe("stripe webhook logging", () => {
 
   it("logs signature failures without the raw payload or signature header", () => {
     const rawBody =
-      '{"id":"evt_test_credit_001","metadata":{"userId":"user_secret"}}';
+      '{"id":"evt_test_credit_001","metadata":{"label":"über","userId":"user_secret"}}';
+    const expectedPayloadBytes = new TextEncoder().encode(rawBody).byteLength;
     const rawSignature =
       "t=1782534490,v1=fd2db5102f05f92772c0a9e2d0b07c314dde57f8352696e0318217c95ff5e527";
     const error = Object.assign(new Error("No signatures found matching"), {
@@ -42,7 +43,7 @@ describe("stripe webhook logging", () => {
         webhook: "extra_usage",
         route: "/api/extra-usage/webhook",
         request_id: "iad1::abc123",
-        payload_bytes: rawBody.length,
+        payload_bytes: expectedPayloadBytes,
         signature_header_present: true,
         signature_timestamp: 1782534490,
         signature_has_v1: true,
@@ -63,12 +64,15 @@ describe("stripe webhook logging", () => {
   });
 
   it("logs missing signatures as handled rejected webhook traffic", () => {
+    const body = "{}";
+    const expectedPayloadBytes = new TextEncoder().encode(body).byteLength;
+
     logStripeWebhookMissingSignature({
       logPrefix: "[Fraud Webhook]",
       webhook: "fraud",
       route: "/api/fraud/webhook",
       requestHeaders: new Headers(),
-      body: "{}",
+      body,
       signature: null,
     });
 
@@ -78,7 +82,7 @@ describe("stripe webhook logging", () => {
         event: "stripe_webhook_missing_signature",
         level: "warn",
         webhook: "fraud",
-        payload_bytes: 2,
+        payload_bytes: expectedPayloadBytes,
         signature_header_present: false,
         signature_has_v1: false,
       }),

--- a/lib/billing/__tests__/stripe-webhook-logging.test.ts
+++ b/lib/billing/__tests__/stripe-webhook-logging.test.ts
@@ -1,0 +1,87 @@
+import {
+  logStripeWebhookMissingSignature,
+  logStripeWebhookSignatureVerificationFailed,
+} from "../stripe-webhook-logging";
+
+describe("stripe webhook logging", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("logs signature failures without the raw payload or signature header", () => {
+    const rawBody =
+      '{"id":"evt_test_credit_001","metadata":{"userId":"user_secret"}}';
+    const rawSignature =
+      "t=1782534490,v1=fd2db5102f05f92772c0a9e2d0b07c314dde57f8352696e0318217c95ff5e527";
+    const error = Object.assign(new Error("No signatures found matching"), {
+      type: "StripeSignatureVerificationError",
+      header: rawSignature,
+      payload: rawBody,
+    });
+
+    logStripeWebhookSignatureVerificationFailed({
+      logPrefix: "[Extra Usage Webhook]",
+      webhook: "extra_usage",
+      route: "/api/extra-usage/webhook",
+      requestHeaders: new Headers({ "x-vercel-id": "iad1::abc123" }),
+      body: rawBody,
+      signature: rawSignature,
+      error,
+    });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      "[Extra Usage Webhook] Signature verification failed",
+      expect.objectContaining({
+        event: "stripe_webhook_signature_verification_failed",
+        level: "warn",
+        service: "hackerai-web",
+        webhook: "extra_usage",
+        route: "/api/extra-usage/webhook",
+        request_id: "iad1::abc123",
+        payload_bytes: rawBody.length,
+        signature_header_present: true,
+        signature_timestamp: 1782534490,
+        signature_has_v1: true,
+        error_type: "StripeSignatureVerificationError",
+        error_message: "No signatures found matching",
+      }),
+    );
+
+    const serializedLogFields = JSON.stringify(
+      (console.warn as jest.Mock).mock.calls[0][1],
+    );
+    expect(serializedLogFields).not.toContain(rawBody);
+    expect(serializedLogFields).not.toContain(rawSignature);
+    expect(serializedLogFields).not.toContain("user_secret");
+    expect(serializedLogFields).not.toContain(
+      "fd2db5102f05f92772c0a9e2d0b07c314dde57f8352696e0318217c95ff5e527",
+    );
+  });
+
+  it("logs missing signatures as handled rejected webhook traffic", () => {
+    logStripeWebhookMissingSignature({
+      logPrefix: "[Fraud Webhook]",
+      webhook: "fraud",
+      route: "/api/fraud/webhook",
+      requestHeaders: new Headers(),
+      body: "{}",
+      signature: null,
+    });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      "[Fraud Webhook] Missing stripe-signature header",
+      expect.objectContaining({
+        event: "stripe_webhook_missing_signature",
+        level: "warn",
+        webhook: "fraud",
+        payload_bytes: 2,
+        signature_header_present: false,
+        signature_has_v1: false,
+      }),
+    );
+  });
+});

--- a/lib/billing/stripe-webhook-logging.ts
+++ b/lib/billing/stripe-webhook-logging.ts
@@ -1,0 +1,137 @@
+type StripeWebhookLogArgs = {
+  logPrefix: string;
+  webhook: string;
+  route: string;
+  requestHeaders: Headers;
+  body: string;
+  signature: string | null;
+};
+
+type StripeWebhookSignatureFailureLogArgs = StripeWebhookLogArgs & {
+  error: unknown;
+};
+
+type StripeWebhookLogFields = {
+  timestamp: string;
+  level: "warn";
+  event:
+    | "stripe_webhook_missing_signature"
+    | "stripe_webhook_signature_verification_failed";
+  service: "hackerai-web";
+  environment: string;
+  webhook: string;
+  route: string;
+  request_id?: string;
+  payload_bytes: number;
+  signature_header_present: boolean;
+  signature_timestamp?: number;
+  signature_has_v1: boolean;
+  error_name?: string;
+  error_type?: string;
+  error_message?: string;
+};
+
+const MAX_ERROR_MESSAGE_LENGTH = 300;
+
+function payloadBytes(body: string): number {
+  return new TextEncoder().encode(body).byteLength;
+}
+
+function requestId(headers: Headers): string | undefined {
+  return (
+    headers.get("x-vercel-id") ??
+    headers.get("x-request-id") ??
+    headers.get("cf-ray") ??
+    undefined
+  );
+}
+
+function signatureSummary(signature: string | null): {
+  signature_timestamp?: number;
+  signature_has_v1: boolean;
+} {
+  if (!signature) {
+    return { signature_has_v1: false };
+  }
+
+  let signatureTimestamp: number | undefined;
+  let signatureHasV1 = false;
+
+  for (const part of signature.split(",")) {
+    const [key, value] = part.split("=", 2);
+    if (key === "t") {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        signatureTimestamp = parsed;
+      }
+    } else if (key === "v1") {
+      signatureHasV1 = true;
+    }
+  }
+
+  return {
+    signature_timestamp: signatureTimestamp,
+    signature_has_v1: signatureHasV1,
+  };
+}
+
+function errorString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const firstLine = value.split("\n", 1)[0]?.trim();
+  if (!firstLine) return undefined;
+  return firstLine.slice(0, MAX_ERROR_MESSAGE_LENGTH);
+}
+
+function errorDetails(
+  error: unknown,
+): Pick<StripeWebhookLogFields, "error_name" | "error_type" | "error_message"> {
+  if (!(error instanceof Error)) {
+    return {
+      error_message: errorString(String(error)),
+    };
+  }
+
+  const errorWithType = error as Error & { type?: unknown };
+  return {
+    error_name: error.name || undefined,
+    error_type:
+      typeof errorWithType.type === "string" ? errorWithType.type : undefined,
+    error_message: errorString(error.message),
+  };
+}
+
+function baseFields(
+  args: StripeWebhookLogArgs,
+  event: StripeWebhookLogFields["event"],
+): StripeWebhookLogFields {
+  return {
+    timestamp: new Date().toISOString(),
+    level: "warn",
+    event,
+    service: "hackerai-web",
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+    webhook: args.webhook,
+    route: args.route,
+    request_id: requestId(args.requestHeaders),
+    payload_bytes: payloadBytes(args.body),
+    signature_header_present: Boolean(args.signature),
+    ...signatureSummary(args.signature),
+  };
+}
+
+export function logStripeWebhookMissingSignature(
+  args: StripeWebhookLogArgs,
+): void {
+  console.warn(`${args.logPrefix} Missing stripe-signature header`, {
+    ...baseFields(args, "stripe_webhook_missing_signature"),
+  });
+}
+
+export function logStripeWebhookSignatureVerificationFailed(
+  args: StripeWebhookSignatureFailureLogArgs,
+): void {
+  console.warn(`${args.logPrefix} Signature verification failed`, {
+    ...baseFields(args, "stripe_webhook_signature_verification_failed"),
+    ...errorDetails(args.error),
+  });
+}


### PR DESCRIPTION
## Summary
- route Stripe webhook missing-signature and invalid-signature cases through a shared sanitized warning helper
- preserve 400 rejection behavior while avoiding raw payload/signature logging
- add tests for sanitized log fields and the subscription webhook no-side-effects path

## Testing
- NODE_PATH=/Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules /Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules/.bin/jest lib/billing/__tests__/stripe-webhook-logging.test.ts app/api/subscription/webhook/__tests__/route.test.ts --runInBand
- ./node_modules/.bin/eslint app/api/extra-usage/webhook/route.ts app/api/team/extra-usage/webhook/route.ts app/api/subscription/webhook/route.ts app/api/fraud/webhook/route.ts app/api/subscription/webhook/__tests__/route.test.ts lib/billing/stripe-webhook-logging.ts lib/billing/__tests__/stripe-webhook-logging.test.ts
- ./node_modules/.bin/tsc --noEmit (with temporary main-checkout dependency symlinks for the sparse worktree)
- /Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules/.bin/prettier --check app/api/extra-usage/webhook/route.ts app/api/team/extra-usage/webhook/route.ts app/api/subscription/webhook/route.ts app/api/fraud/webhook/route.ts app/api/subscription/webhook/__tests__/route.test.ts lib/billing/stripe-webhook-logging.ts lib/billing/__tests__/stripe-webhook-logging.test.ts
- git diff --check

## Manual verification
- Send an unsigned or badly signed request to /api/extra-usage/webhook, /api/subscription/webhook, or /api/fraud/webhook. It should still return 400, log a warn-level `stripe_webhook_*` event, and not include the raw payload, user metadata, or Stripe signature value.
- Deliver a valid signed Stripe webhook from the Dashboard or Stripe CLI. It should continue past signature verification and process normally.

Visual verification is not needed because this is backend logging/error handling only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe webhook failure handling with consistent, structured warnings for missing or invalid signature checks.
  * Reduced the chance of sensitive request data (such as raw payload/signature values) appearing in logs during verification failures.
  * Kept webhook responses and control flow the same for signature-related errors.
* **Tests**
  * Added/expanded automated coverage to confirm invalid signatures return `400` with the expected error message and produce sanitized log output without triggering side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->