### PR TITLE
Harden empty terminal tool calls

### DIFF
--- a/app/components/tools/TerminalToolHandler.tsx
+++ b/app/components/tools/TerminalToolHandler.tsx
@@ -7,6 +7,7 @@ import { isSidebarTerminal } from "@/types/chat";
 import { useToolSidebar } from "../../hooks/useToolSidebar";
 import {
   computeShellTerminalBlock,
+  getTerminalFailureAction,
   getShellDisplayCommand,
   getStreamingTerminalOutput,
   type ShellToolInput,
@@ -170,9 +171,13 @@ export const TerminalToolHandler = memo(function TerminalToolHandler({
         <ToolBlock
           key={toolCallId}
           icon={<Terminal />}
-          action={isStoppedByUser ? "Stopped command" : blockAction(false)}
+          action={
+            isStoppedByUser
+              ? "Stopped command"
+              : getTerminalFailureAction(errorText)
+          }
           target={blockTarget}
-          isClickable
+          isClickable={!!sidebarContent}
           onClick={handleOpenInSidebar}
           onKeyDown={handleKeyDown}
         />

--- a/app/components/tools/__tests__/shell-tool-utils.test.ts
+++ b/app/components/tools/__tests__/shell-tool-utils.test.ts
@@ -41,4 +41,26 @@ describe("terminal shell tool display helpers", () => {
       toolCallId: "call-empty",
     });
   });
+
+  it("keeps non-validation empty terminal failures label-consistent", () => {
+    const errorText = "Sandbox is probably not running anymore";
+    const result = computeShellTerminalBlock({
+      isShellTool: false,
+      shellInput: undefined,
+      shellOutput: undefined,
+      errorText,
+      streamingOutput: "",
+      isExecuting: false,
+      hasResult: false,
+      toolCallId: "call-failed",
+      legacyCommand: undefined,
+    });
+
+    expect(result.blockAction(false)).toBe("Command failed");
+    expect(result.blockTarget).toBe("Command failed");
+    expect(result.sidebarContent).toMatchObject({
+      command: "Command failed",
+      output: errorText,
+    });
+  });
 });

--- a/app/components/tools/__tests__/shell-tool-utils.test.ts
+++ b/app/components/tools/__tests__/shell-tool-utils.test.ts
@@ -1,0 +1,44 @@
+import {
+  computeShellTerminalBlock,
+  getTerminalFailureAction,
+  isToolInputValidationError,
+} from "../shell-tool-utils";
+
+describe("terminal shell tool display helpers", () => {
+  const validationError =
+    "Invalid input for tool run_terminal_cmd: Type validation failed: Value: {}.";
+
+  it("classifies tool input validation errors as invalid commands", () => {
+    expect(isToolInputValidationError(validationError)).toBe(true);
+    expect(getTerminalFailureAction(validationError)).toBe("Invalid command");
+  });
+
+  it("classifies non-validation terminal errors as command failures", () => {
+    expect(
+      getTerminalFailureAction("Sandbox is probably not running anymore"),
+    ).toBe("Command failed");
+  });
+
+  it("keeps invalid empty terminal calls visible and sidebar-readable", () => {
+    const result = computeShellTerminalBlock({
+      isShellTool: false,
+      shellInput: undefined,
+      shellOutput: undefined,
+      errorText: validationError,
+      streamingOutput: "",
+      isExecuting: false,
+      hasResult: false,
+      toolCallId: "call-empty",
+      legacyCommand: undefined,
+    });
+
+    expect(result.blockAction(false)).toBe("Invalid command");
+    expect(result.blockTarget).toBe("Invalid command");
+    expect(result.finalOutput).toBe(validationError);
+    expect(result.sidebarContent).toMatchObject({
+      command: "Invalid command",
+      output: validationError,
+      toolCallId: "call-empty",
+    });
+  });
+});

--- a/app/components/tools/shell-tool-utils.ts
+++ b/app/components/tools/shell-tool-utils.ts
@@ -110,6 +110,20 @@ export function getShellDisplayCommand(
   return input?.command || input?.brief || "";
 }
 
+export function isToolInputValidationError(errorText?: string): boolean {
+  if (!errorText) return false;
+  return (
+    errorText.includes("Invalid input for tool") ||
+    errorText.includes("Type validation failed")
+  );
+}
+
+export function getTerminalFailureAction(errorText?: string): string {
+  return isToolInputValidationError(errorText)
+    ? "Invalid command"
+    : "Command failed";
+}
+
 // ---------------------------------------------------------------------------
 // Display input — format raw send input for display
 // ---------------------------------------------------------------------------
@@ -316,11 +330,12 @@ export function computeShellTerminalBlock(
 
   const shellAction = isShellTool ? shellInput?.action : undefined;
   const isInteractiveAction = isInteractiveShellAction(shellAction);
+  const errorDisplayCommand = errorText ? "Invalid command" : "";
 
   const displayCommand = isShellTool
     ? getShellDisplayCommand(shellInput) ||
-      (isInteractiveAction ? shellAction || "" : "")
-    : legacyCommand || "";
+      (isInteractiveAction ? shellAction || "" : errorDisplayCommand)
+    : legacyCommand || errorDisplayCommand;
   const displayTarget = isShellTool
     ? getShellDisplayTarget(shellInput) || displayCommand
     : displayCommand;
@@ -336,15 +351,17 @@ export function computeShellTerminalBlock(
     ((isShellTool && isInteractiveAction) ||
       (!isInteractiveAction && hasResult));
   const blockAction = (isActive: boolean) =>
-    useBriefOnly
-      ? briefText
-      : getShellActionLabel({
-          isShellTool,
-          action: shellAction,
-          isActive,
-          interactive: !isShellTool ? legacyInteractive : undefined,
-          isBackground: !isShellTool ? legacyIsBackground : undefined,
-        });
+    !isActive && errorText
+      ? getTerminalFailureAction(errorText)
+      : useBriefOnly
+        ? briefText
+        : getShellActionLabel({
+            isShellTool,
+            action: shellAction,
+            isActive,
+            interactive: !isShellTool ? legacyInteractive : undefined,
+            isBackground: !isShellTool ? legacyIsBackground : undefined,
+          });
   const blockTarget = useBriefOnly ? undefined : displayTarget;
 
   // sessionSnapshot is xterm-headless-cleaned — prefer it when present; fall

--- a/app/components/tools/shell-tool-utils.ts
+++ b/app/components/tools/shell-tool-utils.ts
@@ -330,7 +330,9 @@ export function computeShellTerminalBlock(
 
   const shellAction = isShellTool ? shellInput?.action : undefined;
   const isInteractiveAction = isInteractiveShellAction(shellAction);
-  const errorDisplayCommand = errorText ? "Invalid command" : "";
+  const errorDisplayCommand = errorText
+    ? getTerminalFailureAction(errorText)
+    : "";
 
   const displayCommand = isShellTool
     ? getShellDisplayCommand(shellInput) ||

--- a/app/share/[shareId]/components/SharedMessagePartHandler.tsx
+++ b/app/share/[shareId]/components/SharedMessagePartHandler.tsx
@@ -36,6 +36,7 @@ import { SharedTodoBlock } from "./SharedTodoBlock";
 import type { Todo } from "@/types";
 import {
   computeShellTerminalBlock,
+  getTerminalFailureAction,
   type ShellToolInput,
   type ShellToolOutput,
 } from "@/app/components/tools/shell-tool-utils";
@@ -211,7 +212,7 @@ function renderTerminalTool(
       isShellTool,
       shellInput: part.input as ShellToolInput | undefined,
       shellOutput: part.output as ShellToolOutput | undefined,
-      errorText: undefined,
+      errorText: part.errorText,
       streamingOutput: "",
       isExecuting: false,
       hasResult: part.state === "output-available",
@@ -236,7 +237,13 @@ function renderTerminalTool(
     <ToolBlock
       key={idx}
       icon={<Terminal aria-hidden="true" />}
-      action={blockAction(false)}
+      action={
+        part.state === "output-error"
+          ? isStoppedToolPart(part)
+            ? "Stopped command"
+            : getTerminalFailureAction(part.errorText)
+          : blockAction(false)
+      }
       target={blockTarget}
       isClickable={!!sidebarContent}
       onClick={sidebarContent ? handleOpenInSidebar : undefined}

--- a/app/share/[shareId]/components/SharedMessagePartHandler.tsx
+++ b/app/share/[shareId]/components/SharedMessagePartHandler.tsx
@@ -198,7 +198,9 @@ function renderTerminalTool(
     return null;
   }
 
-  const isShellTool = part.type === "tool-shell";
+  const isShellTool =
+    part.type === "tool-shell" ||
+    (part.input as { action?: string } | undefined)?.action !== undefined;
   const legacyInput = !isShellTool
     ? (part.input as {
         command?: string;

--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -7,6 +7,7 @@
  *  - structured errors for non-E2B sandboxes and missing sessions
  *  - that the legacy schema ({command, brief, is_background, timeout})
  *    still flows through and produces a shaped result.
+ *  - that command-only input works because `brief` is display metadata.
  *
  * PTY session action tests (send, wait, view, kill) are in
  * interact-terminal-session.test.ts.
@@ -358,7 +359,7 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
   });
 
   test("schema defaults action=exec and interactive=false when omitted", async () => {
-    // A bare `{command, brief}` must flow through the legacy path
+    // A bare `{command}` must flow through the legacy path
     // (action defaults to "exec", interactive to false) — no session/pid.
     const nonE2B = {
       sandboxKind: "centrifugo" as const,
@@ -373,7 +374,6 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     const tool = createRunTerminalCmd(context);
     const result = (await runTool(tool, {
       command: "true",
-      brief: "default dispatch",
     })) as { result: { session?: string; exitCode: number | null } };
     expect(result.result.session).toBeUndefined();
     expect(result.result.exitCode).toBe(0);

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -107,8 +107,9 @@ In using these tools, adhere to the following guidelines:
       command: z.string().describe("The shell command to execute"),
       brief: z
         .string()
+        .optional()
         .describe(
-          "A one-sentence preamble describing the purpose of this operation",
+          "Optional one-sentence preamble describing the purpose of this operation",
         ),
       is_background: z
         .boolean()

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -182,13 +182,13 @@ describe("agent-long-transport — direct UI stream reader", () => {
   });
 });
 
-describe("agent stream runner — empty todo_write recovery", () => {
-  test("temporarily excludes todo_write when the doom-loop detector requests it", () => {
+describe("agent stream runner — empty tool-input recovery", () => {
+  test("temporarily excludes tools when the doom-loop detector requests it", () => {
     expect(agentStreamRunnerSrc).toMatch(/activeToolExclusions/);
     expect(agentStreamRunnerSrc).toMatch(/getActiveToolsWithExclusions/);
     expect(agentStreamRunnerSrc).toMatch(/getActiveToolsForRecovery/);
     expect(agentStreamRunnerSrc).toMatch(
-      /event:\s*"empty_todo_write_loop_recovery"/,
+      /event:\s*"doom_loop_tool_exclusion_recovery"/,
     );
 
     const recoveryIdx = agentStreamRunnerSrc.indexOf(

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -418,7 +418,7 @@ export async function createAgentStream(
     if (loopCheck.activeToolExclusions?.length) {
       recovery.excludedTools = new Set(loopCheck.activeToolExclusions);
       console.warn("[doom-loop] Applying active tool exclusions", {
-        event: "empty_todo_write_loop_recovery",
+        event: "doom_loop_tool_exclusion_recovery",
         chatId: ctx.chatId,
         modelName,
         requestedModel: requestedSlug,

--- a/lib/chat/__tests__/doom-loop-detection.test.ts
+++ b/lib/chat/__tests__/doom-loop-detection.test.ts
@@ -6,6 +6,7 @@ import {
   DOOM_LOOP_WARNING_THRESHOLD,
   DOOM_LOOP_HALT_THRESHOLD,
   EMPTY_TODO_WRITE_INPUT_WARNING_THRESHOLD,
+  EMPTY_RUN_TERMINAL_CMD_INPUT_WARNING_THRESHOLD,
 } from "../doom-loop-detection";
 
 function makeStep(toolCalls: Array<{ toolName: string; input: unknown }>) {
@@ -127,6 +128,99 @@ describe("detectDoomLoop", () => {
     expect(result.activeToolExclusions).toEqual(["todo_write"]);
   });
 
+  it("returns a terminal-specific warning after repeated empty run_terminal_cmd calls", () => {
+    const step = makeStep([{ toolName: "run_terminal_cmd", input: {} }]);
+    const steps = Array(EMPTY_RUN_TERMINAL_CMD_INPUT_WARNING_THRESHOLD).fill(
+      step,
+    );
+
+    const result = detectDoomLoop(steps);
+
+    expect(result).toMatchObject({
+      severity: "warning",
+      reason: "empty_run_terminal_cmd_input",
+      toolNames: ["run_terminal_cmd"],
+      consecutiveCount: EMPTY_RUN_TERMINAL_CMD_INPUT_WARNING_THRESHOLD,
+      activeToolExclusions: ["run_terminal_cmd"],
+    });
+  });
+
+  it("treats missing run_terminal_cmd input as empty for recovery", () => {
+    const step = makeStep([{ toolName: "run_terminal_cmd", input: undefined }]);
+    const steps = Array(EMPTY_RUN_TERMINAL_CMD_INPUT_WARNING_THRESHOLD).fill(
+      step,
+    );
+
+    const result = detectDoomLoop(steps);
+
+    expect(result.reason).toBe("empty_run_terminal_cmd_input");
+    expect(result.activeToolExclusions).toEqual(["run_terminal_cmd"]);
+  });
+
+  it("warns after repeated empty run_terminal_cmd calls even with valid commands between them", () => {
+    const result = detectDoomLoop([
+      makeStep([{ toolName: "run_terminal_cmd", input: {} }]),
+      makeStep([
+        {
+          toolName: "run_terminal_cmd",
+          input: { command: "curl -I https://example.com" },
+        },
+      ]),
+      makeStep([{ toolName: "run_terminal_cmd", input: {} }]),
+    ]);
+
+    expect(result).toMatchObject({
+      severity: "warning",
+      reason: "empty_run_terminal_cmd_input",
+      toolNames: ["run_terminal_cmd"],
+      activeToolExclusions: ["run_terminal_cmd"],
+    });
+  });
+
+  it("counts empty run_terminal_cmd calls in mixed tool-call steps", () => {
+    const result = detectDoomLoop([
+      makeStep([
+        { toolName: "read_file", input: { path: "/tmp/a" } },
+        { toolName: "run_terminal_cmd", input: {} },
+      ]),
+      makeStep([
+        { toolName: "list_dir", input: { path: "/tmp" } },
+        { toolName: "run_terminal_cmd", input: undefined },
+      ]),
+    ]);
+
+    expect(result).toMatchObject({
+      severity: "warning",
+      reason: "empty_run_terminal_cmd_input",
+      activeToolExclusions: ["run_terminal_cmd"],
+    });
+  });
+
+  it("does not warn for old empty run_terminal_cmd calls outside the recent window", () => {
+    const oldEmpty = makeStep([{ toolName: "run_terminal_cmd", input: {} }]);
+    const valid = makeStep([
+      { toolName: "run_terminal_cmd", input: { command: "true" } },
+    ]);
+    const recentEmpty = makeStep([
+      { toolName: "run_terminal_cmd", input: undefined },
+    ]);
+
+    const result = detectDoomLoop([
+      oldEmpty,
+      valid,
+      valid,
+      valid,
+      valid,
+      valid,
+      valid,
+      valid,
+      valid,
+      recentEmpty,
+    ]);
+
+    expect(result.severity).toBe("none");
+  });
+
   it("does not apply todo recovery to other empty tool calls", () => {
     const step = makeStep([{ toolName: "list_notes", input: {} }]);
     const steps = Array(EMPTY_TODO_WRITE_INPUT_WARNING_THRESHOLD).fill(step);
@@ -161,6 +255,17 @@ describe("detectDoomLoop", () => {
     expect(result.severity).toBe("halt");
     expect(result.reason).toBe("empty_todo_write_input");
     expect(result.activeToolExclusions).toEqual(["todo_write"]);
+  });
+
+  it("still halts after enough repeated empty run_terminal_cmd calls", () => {
+    const step = makeStep([{ toolName: "run_terminal_cmd", input: {} }]);
+    const steps = Array(DOOM_LOOP_HALT_THRESHOLD).fill(step);
+
+    const result = detectDoomLoop(steps);
+
+    expect(result.severity).toBe("halt");
+    expect(result.reason).toBe("empty_run_terminal_cmd_input");
+    expect(result.activeToolExclusions).toEqual(["run_terminal_cmd"]);
   });
 
   it("returns halt above halt threshold", () => {
@@ -282,5 +387,20 @@ describe("generateDoomLoopNudge", () => {
     expect(nudge).toContain("[TODO UPDATE SKIPPED]");
     expect(nudge).toContain("todo_write is unavailable");
     expect(nudge).toContain("merge and todos");
+  });
+
+  it("gives specific recovery guidance for empty run_terminal_cmd calls", () => {
+    const nudge = generateDoomLoopNudge({
+      severity: "warning",
+      toolNames: ["run_terminal_cmd"],
+      consecutiveCount: 2,
+      reason: "empty_run_terminal_cmd_input",
+      activeToolExclusions: ["run_terminal_cmd"],
+    });
+
+    expect(nudge).toContain("[COMMAND SKIPPED]");
+    expect(nudge).toContain("In the recent steps");
+    expect(nudge).toContain("run_terminal_cmd is unavailable");
+    expect(nudge).toContain("required command field");
   });
 });

--- a/lib/chat/__tests__/doom-loop-detection.test.ts
+++ b/lib/chat/__tests__/doom-loop-detection.test.ts
@@ -177,6 +177,16 @@ describe("detectDoomLoop", () => {
     });
   });
 
+  it("does not reapply terminal recovery after the latest command is valid", () => {
+    const result = detectDoomLoop([
+      makeStep([{ toolName: "run_terminal_cmd", input: {} }]),
+      makeStep([{ toolName: "run_terminal_cmd", input: undefined }]),
+      makeStep([{ toolName: "run_terminal_cmd", input: { command: "true" } }]),
+    ]);
+
+    expect(result.severity).toBe("none");
+  });
+
   it("counts empty run_terminal_cmd calls in mixed tool-call steps", () => {
     const result = detectDoomLoop([
       makeStep([

--- a/lib/chat/doom-loop-detection.ts
+++ b/lib/chat/doom-loop-detection.ts
@@ -164,12 +164,20 @@ export function detectDoomLoop(steps: MinimalStep[]): DoomLoopResult {
     };
   }
 
+  const lastStepHasEmptyRunTerminalCmd =
+    steps
+      .at(-1)
+      ?.toolCalls?.some((toolCall) =>
+        isEmptyToolCall(toolCall, "run_terminal_cmd"),
+      ) ?? false;
+
   const emptyRunTerminalCmdCount = getRecentEmptyToolCallCount(
     steps,
     "run_terminal_cmd",
     EMPTY_RUN_TERMINAL_CMD_INPUT_WINDOW,
   );
   if (
+    lastStepHasEmptyRunTerminalCmd &&
     emptyRunTerminalCmdCount >= EMPTY_RUN_TERMINAL_CMD_INPUT_WARNING_THRESHOLD
   ) {
     return {

--- a/lib/chat/doom-loop-detection.ts
+++ b/lib/chat/doom-loop-detection.ts
@@ -13,9 +13,14 @@
 export const DOOM_LOOP_WARNING_THRESHOLD = 3;
 export const DOOM_LOOP_HALT_THRESHOLD = 5;
 export const EMPTY_TODO_WRITE_INPUT_WARNING_THRESHOLD = 2;
+export const EMPTY_RUN_TERMINAL_CMD_INPUT_WARNING_THRESHOLD = 2;
+const EMPTY_RUN_TERMINAL_CMD_INPUT_WINDOW = 8;
 
 export type DoomLoopSeverity = "none" | "warning" | "halt";
-export type DoomLoopReason = "repeated_tool_call" | "empty_todo_write_input";
+export type DoomLoopReason =
+  | "repeated_tool_call"
+  | "empty_todo_write_input"
+  | "empty_run_terminal_cmd_input";
 
 export interface DoomLoopResult {
   severity: DoomLoopSeverity;
@@ -54,18 +59,61 @@ function isEmptyToolInput(input: unknown): boolean {
   return Object.keys(input as Record<string, unknown>).length === 0;
 }
 
-function isEmptyTodoWriteStep(step: MinimalStep | undefined): boolean {
+function isEmptySingleToolStep(
+  step: MinimalStep | undefined,
+  toolName: string,
+): boolean {
   if (!step?.toolCalls || step.toolCalls.length !== 1) return false;
   const [toolCall] = step.toolCalls;
-  return toolCall.toolName === "todo_write" && isEmptyToolInput(toolCall.input);
+  return isEmptyToolCall(toolCall, toolName);
 }
 
-function getTrailingEmptyTodoWriteCount(steps: MinimalStep[]): number {
+function isEmptyToolCall(
+  toolCall: MinimalToolCall | undefined,
+  toolName: string,
+): boolean {
+  return toolCall?.toolName === toolName && isEmptyToolInput(toolCall.input);
+}
+
+function getTrailingEmptySingleToolCount(
+  steps: MinimalStep[],
+  toolName: string,
+): number {
   let count = 0;
 
   for (let i = steps.length - 1; i >= 0; i--) {
-    if (!isEmptyTodoWriteStep(steps[i])) break;
+    if (!isEmptySingleToolStep(steps[i], toolName)) break;
     count++;
+  }
+
+  return count;
+}
+
+function getRecentEmptySingleToolCount(
+  steps: MinimalStep[],
+  toolName: string,
+  windowSize: number,
+): number {
+  let count = 0;
+
+  for (const step of steps.slice(-windowSize)) {
+    if (isEmptySingleToolStep(step, toolName)) count++;
+  }
+
+  return count;
+}
+
+function getRecentEmptyToolCallCount(
+  steps: MinimalStep[],
+  toolName: string,
+  windowSize: number,
+): number {
+  let count = 0;
+
+  for (const step of steps.slice(-windowSize)) {
+    for (const toolCall of step.toolCalls ?? []) {
+      if (isEmptyToolCall(toolCall, toolName)) count++;
+    }
   }
 
   return count;
@@ -101,7 +149,10 @@ export function detectDoomLoop(steps: MinimalStep[]): DoomLoopResult {
     consecutiveCount: 0,
   };
 
-  const emptyTodoWriteCount = getTrailingEmptyTodoWriteCount(steps);
+  const emptyTodoWriteCount = getTrailingEmptySingleToolCount(
+    steps,
+    "todo_write",
+  );
   if (emptyTodoWriteCount >= EMPTY_TODO_WRITE_INPUT_WARNING_THRESHOLD) {
     return {
       severity:
@@ -110,6 +161,26 @@ export function detectDoomLoop(steps: MinimalStep[]): DoomLoopResult {
       consecutiveCount: emptyTodoWriteCount,
       reason: "empty_todo_write_input",
       activeToolExclusions: ["todo_write"],
+    };
+  }
+
+  const emptyRunTerminalCmdCount = getRecentEmptyToolCallCount(
+    steps,
+    "run_terminal_cmd",
+    EMPTY_RUN_TERMINAL_CMD_INPUT_WINDOW,
+  );
+  if (
+    emptyRunTerminalCmdCount >= EMPTY_RUN_TERMINAL_CMD_INPUT_WARNING_THRESHOLD
+  ) {
+    return {
+      severity:
+        emptyRunTerminalCmdCount >= DOOM_LOOP_HALT_THRESHOLD
+          ? "halt"
+          : "warning",
+      toolNames: ["run_terminal_cmd"],
+      consecutiveCount: emptyRunTerminalCmdCount,
+      reason: "empty_run_terminal_cmd_input",
+      activeToolExclusions: ["run_terminal_cmd"],
     };
   }
 
@@ -162,6 +233,14 @@ export function generateDoomLoopNudge(result: DoomLoopResult): string {
       `[TODO UPDATE SKIPPED] The last ${result.consecutiveCount} todo_write calls had empty arguments, so todo_write is unavailable for this step. ` +
       `Do NOT call todo_write again now. Continue the user's task with the current plan and other tools. ` +
       `Only try todo_write later if you can provide both top-level fields: merge and todos.`
+    );
+  }
+
+  if (result.reason === "empty_run_terminal_cmd_input") {
+    return (
+      `[COMMAND SKIPPED] In the recent steps, ${result.consecutiveCount} run_terminal_cmd calls had empty arguments, so run_terminal_cmd is unavailable for this step. ` +
+      `Do NOT call run_terminal_cmd again now. Continue with other tools, or explain the blocker if a terminal command is required. ` +
+      `Only try run_terminal_cmd later if you can provide the required command field.`
     );
   }
 


### PR DESCRIPTION
## Summary
- render invalid run_terminal_cmd input errors as visible Invalid command terminal blocks instead of empty Executed chips in live and shared views
- make run_terminal_cmd.brief optional while keeping command required
- extend doom-loop recovery to detect recent empty run_terminal_cmd calls, inject a command-specific nudge, and temporarily exclude the terminal tool

## Why
Traces showed invalid tool calls with rawInput: {} and validation errors for missing command and brief. That produced empty-looking terminal executions and could repeat. Making brief optional removes one unnecessary failure path, but {} still needs clearer UI and active recovery.

## Validation
- ./node_modules/.bin/jest lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/chat/__tests__/doom-loop-detection.test.ts lib/api/__tests__/agent-long-contracts.test.ts app/components/tools/__tests__/shell-tool-utils.test.ts --runInBand
- ./node_modules/.bin/prettier --check lib/ai/tools/run-terminal-cmd.ts lib/ai/tools/__tests__/run-terminal-cmd.test.ts app/components/tools/TerminalToolHandler.tsx app/components/tools/shell-tool-utils.ts app/share/[shareId]/components/SharedMessagePartHandler.tsx app/components/tools/__tests__/shell-tool-utils.test.ts lib/api/agent-stream-runner.ts lib/api/__tests__/agent-long-contracts.test.ts lib/chat/doom-loop-detection.ts lib/chat/__tests__/doom-loop-detection.test.ts
- ./node_modules/.bin/eslint lib/ai/tools/run-terminal-cmd.ts lib/ai/tools/__tests__/run-terminal-cmd.test.ts app/components/tools/TerminalToolHandler.tsx app/components/tools/shell-tool-utils.ts app/share/[shareId]/components/SharedMessagePartHandler.tsx app/components/tools/__tests__/shell-tool-utils.test.ts lib/api/agent-stream-runner.ts lib/api/__tests__/agent-long-contracts.test.ts lib/chat/doom-loop-detection.ts lib/chat/__tests__/doom-loop-detection.test.ts
- ./node_modules/.bin/tsc --noEmit

## Manual verification
- In an Agent transcript with invalid run_terminal_cmd input like {}, confirm the tool chip says Invalid command and the terminal sidebar shows the validation error.
- In Agent mode, induce repeated empty run_terminal_cmd calls and confirm the next prepare step applies the [COMMAND SKIPPED] nudge and hides run_terminal_cmd for that step so the model uses another path or explains the blocker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal command errors now present clearer, user-facing actions (e.g., “Invalid command”, “Command failed”, and “Stopped command” when applicable).
  * Empty `run_terminal_cmd` inputs are now recognized for doom-loop prevention, including updated guidance when commands should be skipped.
  * `brief` in terminal command tool input is now optional.

* **Bug Fixes**
  * Terminal tool blocks keep consistent labeling and remain visible/clickable when error details are available.
  * Failure labeling now works correctly when error text is provided.

* **Tests**
  * Expanded coverage for terminal display helpers, terminal command schema behavior, and doom-loop detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->