### PR TITLE
Fingerprint synthetic provider stream errors

### DIFF
--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -733,7 +733,7 @@ describe("createChatLogger provider stream termination", () => {
     }
   });
 
-  it("normalizes synthetic SSE JSON wrapper errors using provider status", () => {
+  it("normalizes and fingerprints synthetic SSE JSON wrapper errors using provider status", () => {
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
 
@@ -745,16 +745,27 @@ describe("createChatLogger provider stream termination", () => {
       const err = {
         name: "Error",
         message: "JSON error injected into SSE stream",
-        code: 429,
+        code: 502,
+        data: {
+          id: "gen-sse-json-wrapper",
+          error: {
+            code: 502,
+            metadata: {
+              provider_name: "Fireworks",
+            },
+          },
+        },
       };
 
       chatLogger.recordProviderError(err, {
         mode: "ask",
-        model: "ask-model",
-        requestedModelSlug: "x-ai/grok-4.3",
+        model: "ask-model-free",
+        requestedModelSlug: "deepseek/deepseek-v4-flash",
       });
       chatLogger.emitUnexpectedError(err);
 
+      const expectedFingerprint =
+        "provider_error|provider_5xx|status_502|provider_fireworks|model_deepseek/deepseek-v4-flash";
       const structuredErrorLog = errorSpy.mock.calls
         .map((call) => call[0])
         .find(
@@ -769,25 +780,37 @@ describe("createChatLogger provider stream termination", () => {
           call[1] !== null,
       );
       const fields = posthogErrorCall?.[1] as
-        | { error?: unknown; providerDiagnosticMessage?: unknown }
+        | {
+            error?: unknown;
+            providerDiagnosticMessage?: unknown;
+            providerErrorFingerprint?: unknown;
+          }
         | undefined;
       const capturedError = fields?.error as Error | undefined;
       const wideEvent = JSON.parse(String(logSpy.mock.calls[0][0]));
 
       expect(structuredErrorLog).toContain(
-        '"provider_diagnostic_message":"Provider rate limited (429)"',
+        '"provider_diagnostic_message":"Provider server error (502)"',
       );
-      expect(structuredErrorLog).toContain('"provider_status_code":429');
+      expect(structuredErrorLog).toContain('"provider_status_code":502');
+      expect(structuredErrorLog).toContain(
+        `"provider_error_fingerprint":"${expectedFingerprint}"`,
+      );
       expect(capturedError).toBeInstanceOf(Error);
-      expect(capturedError?.message).toBe("Provider rate limited (429)");
-      expect(fields?.providerDiagnosticMessage).toBe(
-        "Provider rate limited (429)",
+      expect(capturedError?.message).toBe(
+        `Provider server error (502) [${expectedFingerprint}]`,
       );
-      expect(wideEvent.error.message).toBe("Provider rate limited (429)");
+      expect(fields?.providerDiagnosticMessage).toBe(
+        "Provider server error (502)",
+      );
+      expect(fields?.providerErrorFingerprint).toBe(expectedFingerprint);
+      expect(wideEvent.error.message).toBe("Provider server error (502)");
       expect(wideEvent.provider_error).toMatchObject({
-        category: "rate_limited",
-        status_code: 429,
-        message: "Provider rate limited (429)",
+        category: "provider_5xx",
+        status_code: 502,
+        message: "Provider server error (502)",
+        provider_name: "Fireworks",
+        provider_error_fingerprint: expectedFingerprint,
       });
     } finally {
       errorSpy.mockRestore();

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -89,8 +89,12 @@ export interface StreamResult {
 function posthogProviderException(
   error: unknown,
   details: Record<string, unknown>,
+  providerErrorFingerprint?: string,
 ): Error {
-  const message = getProviderDiagnosticMessage(details);
+  const message = getPostHogProviderExceptionMessage(
+    details,
+    providerErrorFingerprint,
+  );
   if (!(error instanceof Error)) {
     const enriched = new Error(message);
     const errorName = details.errorName;
@@ -228,6 +232,36 @@ const providerErrorMessage = (category: ProviderErrorCategory): string =>
 
 const SYNTHETIC_SSE_JSON_ERROR_MESSAGE = "JSON error injected into SSE stream";
 
+const sanitizeProviderFingerprintPart = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._:/-]+/g, "_")
+    .slice(0, 160);
+
+const buildProviderErrorFingerprint = (details: {
+  category: ProviderErrorCategory;
+  statusCode?: number;
+  requestedModelSlug?: string;
+  modelProviderSlug?: string;
+  providerName?: string;
+}): string => {
+  const providerPart = details.providerName ?? details.modelProviderSlug;
+  return [
+    "provider_error",
+    details.category,
+    details.statusCode ? `status_${details.statusCode}` : undefined,
+    providerPart
+      ? `provider_${sanitizeProviderFingerprintPart(providerPart)}`
+      : undefined,
+    details.requestedModelSlug
+      ? `model_${sanitizeProviderFingerprintPart(details.requestedModelSlug)}`
+      : undefined,
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join("|");
+};
+
 const providerCategoryDiagnosticMessage = (
   category: ProviderErrorCategory,
   statusCode?: number,
@@ -290,6 +324,17 @@ const getProviderDiagnosticMessage = (
   }
 
   return "Provider streaming error";
+};
+
+const getPostHogProviderExceptionMessage = (
+  details: Record<string, unknown>,
+  providerErrorFingerprint?: string,
+): string => {
+  const message = getProviderDiagnosticMessage(details);
+  return details.errorMessage === SYNTHETIC_SSE_JSON_ERROR_MESSAGE &&
+    providerErrorFingerprint
+    ? `${message} [${providerErrorFingerprint}]`
+    : message;
 };
 
 const isRetriableProviderCategory = (
@@ -660,6 +705,13 @@ export function createChatLogger(config: ChatLoggerConfig) {
       const openrouterGenerationId = nonEmptyString(
         details.openrouterGenerationId,
       );
+      const providerErrorFingerprint = buildProviderErrorFingerprint({
+        category,
+        statusCode: providerStatusCode,
+        requestedModelSlug,
+        modelProviderSlug,
+        providerName,
+      });
       const normalizedProviderContext = {
         ...(providerName && {
           provider_name: providerName,
@@ -684,6 +736,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
         ...details,
         ...normalizedProviderContext,
         provider_diagnostic_message: diagnosticMessage,
+        provider_error_fingerprint: providerErrorFingerprint,
         ...(providerStatusCode && { provider_status_code: providerStatusCode }),
         ...(attempts && { provider_attempts: attempts }),
         ...(providerRequest && { provider_request: providerRequest }),
@@ -708,6 +761,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
         ...details,
         ...normalizedProviderContext,
         providerDiagnosticMessage: diagnosticMessage,
+        providerErrorFingerprint,
         ...(providerStatusCode && { providerStatusCode }),
         ...(attempts && { provider_attempts: attempts }),
         ...(providerRequest && { provider_request: providerRequest }),
@@ -717,7 +771,11 @@ export function createChatLogger(config: ChatLoggerConfig) {
         phLogger.warn(providerErrorMessage(category), phContext);
       } else {
         phLogger.error(providerErrorMessage(category), {
-          error: posthogProviderException(error, details),
+          error: posthogProviderException(
+            error,
+            details,
+            providerErrorFingerprint,
+          ),
           ...phContext,
         });
       }
@@ -740,6 +798,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
         requestedModelSlug,
         modelProviderSlug,
         openrouterGenerationId,
+        providerErrorFingerprint,
         attempts,
       });
     },

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -234,6 +234,7 @@ export interface ChatWideEvent {
     requested_model_slug?: string;
     model_provider_slug?: string;
     openrouter_generation_id?: string;
+    provider_error_fingerprint?: string;
     // Per-attempt breakdown when the SDK retried internally. Each entry is one
     // upstream call. Lets you tell consistent-500 from a mixed cascade and
     // gives you provider request IDs to file support tickets with.
@@ -631,6 +632,7 @@ export class WideEventBuilder {
     requestedModelSlug?: string;
     modelProviderSlug?: string;
     openrouterGenerationId?: string;
+    providerErrorFingerprint?: string;
     attempts?: NonNullable<ChatWideEvent["provider_error"]>["attempts"];
   }): this {
     this.event.had_provider_error = true;
@@ -647,6 +649,7 @@ export class WideEventBuilder {
       requested_model_slug: details.requestedModelSlug,
       model_provider_slug: details.modelProviderSlug,
       openrouter_generation_id: details.openrouterGenerationId,
+      provider_error_fingerprint: details.providerErrorFingerprint,
       attempts: details.attempts,
     };
     return this;


### PR DESCRIPTION
## Summary
- add a stable provider error fingerprint from category, status, provider, and requested model
- include the fingerprint in structured provider-error logs, PostHog context, and the wide event provider_error block
- fingerprint PostHog exception messages only for synthetic `JSON error injected into SSE stream` wrappers so real provider messages stay exact

## Testing
- `./node_modules/.bin/jest lib/api/__tests__/chat-logger.test.ts --runInBand`
- `./node_modules/.bin/prettier --check lib/api/chat-logger.ts lib/logger.ts lib/api/__tests__/chat-logger.test.ts`
- `./node_modules/.bin/eslint lib/api/chat-logger.ts lib/logger.ts lib/api/__tests__/chat-logger.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- pre-commit hook: `tsc --noEmit` and `jest` (169 suites, 1838 tests)

## Manual verification
- Trigger or inspect an Ask-mode provider 502 where the thrown message is `JSON error injected into SSE stream`.
- Confirm the event remains error-level with `provider_diagnostic_message=Provider server error (502)`.
- Confirm `provider_error_fingerprint` includes category/status/provider/model, e.g. `provider_error|provider_5xx|status_502|provider_fireworks|model_deepseek/deepseek-v4-flash`.
- Confirm non-synthetic provider messages still appear unchanged in the captured PostHog exception.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider error reporting for chat streams, making error details more consistent and easier to diagnose.
  * Added a stable error fingerprint to logs and analytics events, helping distinguish similar provider failures.
  * Enhanced captured error messages to include clearer context when stream responses fail in a specific wrapped-error format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->