### PR TITLE
Add legacy guardrails cleanup mutation

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -222,6 +222,10 @@ export default defineSchema({
     // pass validation. New code writes include_notes and uses this only as a
     // fallback when returning older customization rows.
     include_memory_entries: v.optional(v.boolean()),
+    // Legacy terminal guardrails preference retained on historical rows. The
+    // feature was removed and nothing reads or writes this anymore — kept in
+    // the schema so old rows still pass validation until the field is cleared.
+    guardrails_config: v.optional(v.string()),
     caido_enabled: v.optional(v.boolean()),
     caido_port: v.optional(v.number()),
     extra_usage_enabled: v.optional(v.boolean()),

--- a/convex/userCustomization.ts
+++ b/convex/userCustomization.ts
@@ -259,9 +259,11 @@ export const getUserCustomizationForBackend = query({
 /**
  * One-off cleanup for the removed terminal guardrails customization field.
  *
- * Run from the Convex dashboard with dryRun=true first, then rerun with
- * dryRun=false using the returned cursor until isDone is true. After all
- * legacy rows are patched, guardrails_config can be removed from schema.ts.
+ * Run from the Convex dashboard with dryRun=true to count matching pages.
+ * Do not reuse a dry-run cursor for the real cleanup. Start the patch run
+ * with dryRun=false and cursor=null, then continue with cursors returned by
+ * that patch run until isDone is true. After all legacy rows are patched,
+ * guardrails_config can be removed from schema.ts.
  */
 export const cleanupLegacyGuardrailsConfig = mutation({
   args: {

--- a/convex/userCustomization.ts
+++ b/convex/userCustomization.ts
@@ -1,5 +1,6 @@
 import { mutation, query } from "./_generated/server";
 import { v, ConvexError } from "convex/values";
+import { paginationOptsValidator } from "convex/server";
 import { validateServiceKey } from "./lib/utils";
 
 const shouldIncludeNotes = (customization: {
@@ -7,6 +8,10 @@ const shouldIncludeNotes = (customization: {
   include_memory_entries?: boolean;
 }) =>
   customization.include_notes ?? customization.include_memory_entries ?? true;
+
+const hasLegacyGuardrailsConfig = (customization: unknown) =>
+  (customization as { guardrails_config?: unknown }).guardrails_config !==
+  undefined;
 
 /**
  * Save or update user customization data
@@ -248,5 +253,55 @@ export const getUserCustomizationForBackend = query({
       console.error("Failed to get user customization:", error);
       return null;
     }
+  },
+});
+
+/**
+ * One-off cleanup for the removed terminal guardrails customization field.
+ *
+ * Run from the Convex dashboard with dryRun=true first, then rerun with
+ * dryRun=false using the returned cursor until isDone is true. After all
+ * legacy rows are patched, guardrails_config can be removed from schema.ts.
+ */
+export const cleanupLegacyGuardrailsConfig = mutation({
+  args: {
+    serviceKey: v.string(),
+    paginationOpts: paginationOptsValidator,
+    dryRun: v.optional(v.boolean()),
+  },
+  returns: v.object({
+    scanned: v.number(),
+    matched: v.number(),
+    patched: v.number(),
+    isDone: v.boolean(),
+    continueCursor: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const result = await ctx.db
+      .query("user_customization")
+      .order("asc")
+      .paginate(args.paginationOpts);
+
+    let matched = 0;
+    let patched = 0;
+    for (const customization of result.page) {
+      if (!hasLegacyGuardrailsConfig(customization)) continue;
+
+      matched++;
+      if (args.dryRun === true) continue;
+
+      await ctx.db.patch(customization._id, { guardrails_config: undefined });
+      patched++;
+    }
+
+    return {
+      scanned: result.page.length,
+      matched,
+      patched,
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
   },
 });


### PR DESCRIPTION
## Summary
- add `userCustomization.cleanupLegacyGuardrailsConfig` for dashboard cleanup of historical `guardrails_config` values
- temporarily restore `guardrails_config` as a schema-only legacy field so deploy validation passes while rows are being cleaned

## Validation
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint convex/userCustomization.ts convex/schema.ts`
- `./node_modules/.bin/prettier --check convex/userCustomization.ts convex/schema.ts`

## Dashboard usage
Dry-run from the beginning to count matches:

```json
{
  "serviceKey": "<CONVEX_SERVICE_ROLE_KEY>",
  "paginationOpts": { "numItems": 500, "cursor": null },
  "dryRun": true
}
```

For the real cleanup, restart from `cursor: null` instead of reusing a dry-run cursor:

```json
{
  "serviceKey": "<CONVEX_SERVICE_ROLE_KEY>",
  "paginationOpts": { "numItems": 500, "cursor": null },
  "dryRun": false
}
```

If `isDone` is false during the real cleanup, rerun with `paginationOpts.cursor` set to the `continueCursor` returned by that same `dryRun: false` flow until `isDone` is true.

## Manual verification
- Run the mutation from the Convex dashboard with `dryRun: true` and confirm `matched` reports expected legacy rows.
- Start the real cleanup from `cursor: null` with `dryRun: false`, continue only with cursors returned by the real cleanup, then rerun dry-run from `cursor: null` and confirm `matched: 0`.

## Follow-up
After cleanup reports no matches, remove the schema-only `guardrails_config` allowance in a separate deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional user customization setting for guardrails configuration.
* **Bug Fixes**
  * Performed a one-off cleanup of existing user customization records to remove/standardize legacy guardrails configuration values.
  * Cleanup is paginated, includes progress reporting, and supports a dry-run mode before applying changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->