### PR TITLE
Remove legacy guardrails cleanup

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -222,10 +222,6 @@ export default defineSchema({
     // pass validation. New code writes include_notes and uses this only as a
     // fallback when returning older customization rows.
     include_memory_entries: v.optional(v.boolean()),
-    // Legacy terminal guardrails preference retained on historical rows. The
-    // feature was removed and nothing reads or writes this anymore — kept in
-    // the schema so old rows still pass validation until the field is cleared.
-    guardrails_config: v.optional(v.string()),
     caido_enabled: v.optional(v.boolean()),
     caido_port: v.optional(v.number()),
     extra_usage_enabled: v.optional(v.boolean()),

--- a/convex/userCustomization.ts
+++ b/convex/userCustomization.ts
@@ -1,6 +1,5 @@
 import { mutation, query } from "./_generated/server";
 import { v, ConvexError } from "convex/values";
-import { paginationOptsValidator } from "convex/server";
 import { validateServiceKey } from "./lib/utils";
 
 const shouldIncludeNotes = (customization: {
@@ -8,10 +7,6 @@ const shouldIncludeNotes = (customization: {
   include_memory_entries?: boolean;
 }) =>
   customization.include_notes ?? customization.include_memory_entries ?? true;
-
-const hasLegacyGuardrailsConfig = (customization: unknown) =>
-  (customization as { guardrails_config?: unknown }).guardrails_config !==
-  undefined;
 
 /**
  * Save or update user customization data
@@ -253,57 +248,5 @@ export const getUserCustomizationForBackend = query({
       console.error("Failed to get user customization:", error);
       return null;
     }
-  },
-});
-
-/**
- * One-off cleanup for the removed terminal guardrails customization field.
- *
- * Run from the Convex dashboard with dryRun=true to count matching pages.
- * Do not reuse a dry-run cursor for the real cleanup. Start the patch run
- * with dryRun=false and cursor=null, then continue with cursors returned by
- * that patch run until isDone is true. After all legacy rows are patched,
- * guardrails_config can be removed from schema.ts.
- */
-export const cleanupLegacyGuardrailsConfig = mutation({
-  args: {
-    serviceKey: v.string(),
-    paginationOpts: paginationOptsValidator,
-    dryRun: v.optional(v.boolean()),
-  },
-  returns: v.object({
-    scanned: v.number(),
-    matched: v.number(),
-    patched: v.number(),
-    isDone: v.boolean(),
-    continueCursor: v.string(),
-  }),
-  handler: async (ctx, args) => {
-    validateServiceKey(args.serviceKey);
-
-    const result = await ctx.db
-      .query("user_customization")
-      .order("asc")
-      .paginate(args.paginationOpts);
-
-    let matched = 0;
-    let patched = 0;
-    for (const customization of result.page) {
-      if (!hasLegacyGuardrailsConfig(customization)) continue;
-
-      matched++;
-      if (args.dryRun === true) continue;
-
-      await ctx.db.patch(customization._id, { guardrails_config: undefined });
-      patched++;
-    }
-
-    return {
-      scanned: result.page.length,
-      matched,
-      patched,
-      isDone: result.isDone,
-      continueCursor: result.continueCursor,
-    };
   },
 });


### PR DESCRIPTION
## Summary
- remove the temporary `guardrails_config` allowance from the `user_customization` schema
- delete the one-off `cleanupLegacyGuardrailsConfig` dashboard mutation and cleanup helper

## Validation
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint convex/userCustomization.ts convex/schema.ts`
- `./node_modules/.bin/prettier --check convex/userCustomization.ts convex/schema.ts`

## Manual verification
- Before deploying this PR, rerun `userCustomization:cleanupLegacyGuardrailsConfig` with `dryRun: true` from `cursor: null` through all pages.
- Confirm every page reports `matched: 0`; otherwise Convex schema validation can still fail on old rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated user customization behavior so note inclusion now follows the latest preference settings, with a sensible default when no setting is available.
  * Removed support for an older customization setting and aligned the app with the newer memory-related option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->