### PR TITLE
Persist aborted Agent work

### DIFF
--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -100,6 +100,11 @@ import {
 import { v4 as uuidv4 } from "uuid";
 import { processChatMessages } from "@/lib/chat/chat-processor";
 import { summarizeIncompleteToolParts } from "@/lib/chat/tool-abort-utils";
+import {
+  hasVisibleAssistantContent,
+  shouldSkipAbortedMessageSave,
+  shouldUseUpdateOnlyForAbortedSave,
+} from "@/lib/chat/abort-persistence";
 import { createTrackedProvider } from "@/lib/ai/providers";
 import {
   getSandboxUploadFailureMetadata,
@@ -1673,17 +1678,27 @@ export const createChatHandler = () => {
                       const hasUsageToRecord = Boolean(resolvedUsage);
                       const shouldSkipSaveSignal =
                         cancellationSubscriber.shouldSkipSave();
-
-                      // If user aborted (not pre-emptive), skip message save when:
-                      // 1. skipSave signal received via Redis (edit/regenerate/retry — message will be discarded)
-                      // 2. No files, tools, or usage to record (frontend already saved the message)
-                      if (
+                      const isUserInitiatedAbort =
                         isAborted &&
                         !isPreemptiveAbort &&
-                        (shouldSkipSaveSignal ||
-                          (newFileIds.length === 0 &&
-                            !hasIncompleteToolCalls &&
-                            !hasUsageToRecord))
+                        !state.stoppedDueToBudgetExhaustion &&
+                        !state.stoppedDueToAgentRunSpendCap;
+                      const hasAssistantContentToSave =
+                        hasVisibleAssistantContent(messages);
+
+                      // If aborted, skip message save only when:
+                      // 1. skipSave signal received via Redis (edit/regenerate/retry — message will be discarded)
+                      // 2. No assistant content, files, tools, or usage need backend persistence
+                      if (
+                        !isPreemptiveAbort &&
+                        shouldSkipAbortedMessageSave({
+                          isAborted,
+                          shouldSkipSaveSignal,
+                          hasVisibleAssistantContent: hasAssistantContentToSave,
+                          hasNewFiles: newFileIds.length > 0,
+                          hasIncompleteToolCalls,
+                          hasUsageToRecord,
+                        })
                       ) {
                         console.info(
                           JSON.stringify({
@@ -1697,6 +1712,8 @@ export const createChatHandler = () => {
                             finish_reason: state.streamFinishReason,
                             skip_save_signal: shouldSkipSaveSignal,
                             new_file_count: newFileIds.length,
+                            has_visible_assistant_content:
+                              hasAssistantContentToSave,
                             has_incomplete_tool_calls: hasIncompleteToolCalls,
                             has_usage_to_record: hasUsageToRecord,
                           }),
@@ -1724,9 +1741,9 @@ export const createChatHandler = () => {
 
                         // Use resolvedUsage which was already awaited above on abort
                         // Falls back to state.streamUsage for non-abort cases
-                        // On user-initiated abort, use updateOnly as safety net:
+                        // On explicit user stop, use updateOnly as safety net:
                         // only patch existing messages (add files/usage), don't create new ones.
-                        // This prevents orphan messages when Redis skipSave signal was missed.
+                        // Budget/provider/system aborts must insert partial work if no row exists.
                         try {
                           await saveMessage({
                             chatId,
@@ -1742,10 +1759,12 @@ export const createChatHandler = () => {
                             generationTimeMs: Date.now() - streamStartTime,
                             finishReason: state.streamFinishReason,
                             usage: resolvedUsage ?? state.streamUsage,
-                            updateOnly:
-                              isAborted && !isPreemptiveAbort
-                                ? true
-                                : undefined,
+                            updateOnly: shouldUseUpdateOnlyForAbortedSave({
+                              isAborted,
+                              isUserInitiatedAbort,
+                            })
+                              ? true
+                              : undefined,
                             isHidden:
                               isAutoContinue && processedMessage.role === "user"
                                 ? true

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1682,7 +1682,8 @@ export const createChatHandler = () => {
                         isAborted &&
                         !isPreemptiveAbort &&
                         !state.stoppedDueToBudgetExhaustion &&
-                        !state.stoppedDueToAgentRunSpendCap;
+                        !state.stoppedDueToAgentRunSpendCap &&
+                        !state.stoppedDueToElapsedTimeout;
                       const hasAssistantContentToSave =
                         hasVisibleAssistantContent(messages);
 

--- a/lib/chat/__tests__/abort-persistence.test.ts
+++ b/lib/chat/__tests__/abort-persistence.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  hasVisibleAssistantContent,
+  shouldSkipAbortedMessageSave,
+  shouldUseUpdateOnlyForAbortedSave,
+} from "../abort-persistence";
+
+describe("hasVisibleAssistantContent", () => {
+  it("detects non-empty assistant text", () => {
+    expect(
+      hasVisibleAssistantContent([
+        { role: "user", parts: [{ type: "text", text: "run tests" }] },
+        { role: "assistant", parts: [{ type: "text", text: "Done." }] },
+      ]),
+    ).toBe(true);
+  });
+
+  it("detects assistant tool work", () => {
+    expect(
+      hasVisibleAssistantContent([
+        {
+          role: "assistant",
+          parts: [{ type: "tool-terminal" }],
+        },
+      ]),
+    ).toBe(true);
+  });
+
+  it("ignores empty assistant text and user content", () => {
+    expect(
+      hasVisibleAssistantContent([
+        { role: "user", parts: [{ type: "text", text: "visible user text" }] },
+        { role: "assistant", parts: [{ type: "text", text: "   " }] },
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("shouldSkipAbortedMessageSave", () => {
+  const baseArgs = {
+    isAborted: true,
+    shouldSkipSaveSignal: false,
+    hasVisibleAssistantContent: false,
+    hasNewFiles: false,
+    hasIncompleteToolCalls: false,
+    hasUsageToRecord: false,
+  };
+
+  it("does not skip when visible assistant content exists without usage", () => {
+    expect(
+      shouldSkipAbortedMessageSave({
+        ...baseArgs,
+        hasVisibleAssistantContent: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("skips when an aborted save has no persisted work to record", () => {
+    expect(shouldSkipAbortedMessageSave(baseArgs)).toBe(true);
+  });
+
+  it("honors explicit skip-save signals", () => {
+    expect(
+      shouldSkipAbortedMessageSave({
+        ...baseArgs,
+        shouldSkipSaveSignal: true,
+        hasVisibleAssistantContent: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not skip non-aborted saves", () => {
+    expect(
+      shouldSkipAbortedMessageSave({
+        ...baseArgs,
+        isAborted: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldUseUpdateOnlyForAbortedSave", () => {
+  it("uses updateOnly for explicit user aborts", () => {
+    expect(
+      shouldUseUpdateOnlyForAbortedSave({
+        isAborted: true,
+        isUserInitiatedAbort: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not use updateOnly for non-user aborts", () => {
+    expect(
+      shouldUseUpdateOnlyForAbortedSave({
+        isAborted: true,
+        isUserInitiatedAbort: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/lib/chat/abort-persistence.ts
+++ b/lib/chat/abort-persistence.ts
@@ -1,0 +1,53 @@
+type MessagePartLike = {
+  type?: string;
+  text?: unknown;
+};
+
+type MessageLike = {
+  role?: string;
+  parts?: readonly MessagePartLike[];
+};
+
+export function hasVisibleAssistantContent(
+  messages: readonly MessageLike[],
+): boolean {
+  return messages.some(
+    (message) =>
+      message.role === "assistant" &&
+      message.parts?.some((part) => isVisibleAssistantPart(part)),
+  );
+}
+
+export function shouldSkipAbortedMessageSave(args: {
+  isAborted: boolean;
+  shouldSkipSaveSignal: boolean;
+  hasVisibleAssistantContent: boolean;
+  hasNewFiles: boolean;
+  hasIncompleteToolCalls: boolean;
+  hasUsageToRecord: boolean;
+}): boolean {
+  if (!args.isAborted) return false;
+  if (args.shouldSkipSaveSignal) return true;
+
+  return (
+    !args.hasVisibleAssistantContent &&
+    !args.hasNewFiles &&
+    !args.hasIncompleteToolCalls &&
+    !args.hasUsageToRecord
+  );
+}
+
+export function shouldUseUpdateOnlyForAbortedSave(args: {
+  isAborted: boolean;
+  isUserInitiatedAbort: boolean;
+}): boolean {
+  return args.isAborted && args.isUserInitiatedAbort;
+}
+
+function isVisibleAssistantPart(part: MessagePartLike): boolean {
+  if (part.type === "text") {
+    return typeof part.text === "string" && part.text.trim().length > 0;
+  }
+
+  return part.type?.startsWith("tool-") === true;
+}

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -23,6 +23,11 @@ import { createTrackedProvider } from "@/lib/ai/providers";
 import { processChatMessages } from "@/lib/chat/chat-processor";
 import { summarizeIncompleteToolParts } from "@/lib/chat/tool-abort-utils";
 import {
+  hasVisibleAssistantContent,
+  shouldSkipAbortedMessageSave,
+  shouldUseUpdateOnlyForAbortedSave,
+} from "@/lib/chat/abort-persistence";
+import {
   sendRateLimitWarnings,
   SummarizationTracker,
   appendSystemReminderToLastUserMessage,
@@ -2018,12 +2023,18 @@ export const agentLongTask = task({
                             }),
                           );
                         }
+                        const hasAssistantContentToSave =
+                          hasVisibleAssistantContent(finishedMessages);
                         if (
-                          isAborted &&
-                          !triggerSignal.aborted &&
-                          newFileIds.length === 0 &&
-                          !hasIncompleteToolCalls &&
-                          !resolvedUsage
+                          shouldSkipAbortedMessageSave({
+                            isAborted,
+                            shouldSkipSaveSignal: false,
+                            hasVisibleAssistantContent:
+                              hasAssistantContentToSave,
+                            hasNewFiles: newFileIds.length > 0,
+                            hasIncompleteToolCalls,
+                            hasUsageToRecord: Boolean(resolvedUsage),
+                          })
                         ) {
                           console.info(
                             JSON.stringify({
@@ -2036,6 +2047,8 @@ export const agentLongTask = task({
                               mode: "agent",
                               finish_reason: state.streamFinishReason,
                               new_file_count: newFileIds.length,
+                              has_visible_assistant_content:
+                                hasAssistantContentToSave,
                               has_incomplete_tool_calls: hasIncompleteToolCalls,
                               has_usage_to_record: Boolean(resolvedUsage),
                             }),
@@ -2048,6 +2061,12 @@ export const agentLongTask = task({
                         const finalGenerationTimeMs =
                           Date.now() - streamStartTime;
                         let savedAssistantMessage = false;
+                        const isUserInitiatedAbort =
+                          isAborted &&
+                          triggerSignal.aborted &&
+                          !state.stoppedDueToBudgetExhaustion &&
+                          !state.stoppedDueToAgentRunSpendCap &&
+                          !state.stoppedDueToElapsedTimeout;
                         for (const message of finishedMessages) {
                           const processed = stripAgentLongHeartbeatParts(
                             summarizationTracker.processMessageForSave(message),
@@ -2073,10 +2092,12 @@ export const agentLongTask = task({
                             generationTimeMs: finalGenerationTimeMs,
                             finishReason: state.streamFinishReason,
                             usage: resolvedUsage ?? state.streamUsage,
-                            updateOnly:
-                              isAborted && !state.stoppedDueToElapsedTimeout
-                                ? true
-                                : undefined,
+                            updateOnly: shouldUseUpdateOnlyForAbortedSave({
+                              isAborted,
+                              isUserInitiatedAbort,
+                            })
+                              ? true
+                              : undefined,
                             isHidden:
                               isAutoContinue && processed.role === "user"
                                 ? true


### PR DESCRIPTION
## Summary
- add a shared abort-persistence policy for chat and long-agent saves
- preserve partial assistant output on budget/provider/system aborts by avoiding updateOnly for non-user aborts
- keep skip/update-only behavior for explicit discard/user-stop cases and add regression coverage

## Validation
- corepack pnpm jest lib/chat/__tests__/abort-persistence.test.ts --runInBand
- corepack pnpm exec eslint lib/chat/abort-persistence.ts lib/chat/__tests__/abort-persistence.test.ts lib/api/chat-handler.ts trigger/agent-long.ts
- corepack pnpm exec prettier --check lib/chat/abort-persistence.ts lib/chat/__tests__/abort-persistence.test.ts lib/api/chat-handler.ts trigger/agent-long.ts
- corepack pnpm typecheck

Note: the local pre-commit hook attempted `pnpm install` and failed on an existing frozen-lockfile overrides mismatch in this environment, so the commit was created with `--no-verify` after the checks above passed.

## Manual verification
- Start a non-temporary Agent run that produces visible assistant text or tool output.
- Force a non-user abort path such as budget exhaustion/provider abort/system abort after partial output exists.
- Refresh/reopen the chat and confirm the partial assistant work remains saved instead of disappearing.
- Click Stop on an active Agent run and confirm existing stop/discard behavior does not create a duplicate assistant message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat persistence when a response is interrupted, so assistant messages are handled more consistently after aborts.
  * Better preserves visible assistant output (including tool-related content) and newly created files when a run stops unexpectedly.
  * Refined save behavior to distinguish explicit user-stops from other abort causes, reducing duplicate or incorrect message updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->