### PR TITLE
Batch account deletion cleanup

### DIFF
--- a/app/api/delete-account/__tests__/route.test.ts
+++ b/app/api/delete-account/__tests__/route.test.ts
@@ -113,7 +113,11 @@ describe("POST /api/delete-account", () => {
       freeQuotaSubject: "free_quota:v1:identity_hash",
     });
     mockDeleteUserRateLimitKeys.mockResolvedValue(undefined);
-    mockConvexMutation.mockResolvedValue(null);
+    mockConvexMutation.mockImplementation(async (functionReference) =>
+      functionReference === "userDeletion.deleteAllUserDataByService"
+        ? { hasMore: false }
+        : null,
+    );
     mockDeleteOrganizationMembership.mockResolvedValue(undefined as never);
     mockDeleteUser.mockResolvedValue(undefined as never);
     mockDeleteOrganization.mockResolvedValue(undefined as never);
@@ -323,6 +327,25 @@ describe("POST /api/delete-account", () => {
       mockDeleteUser.mock.invocationCallOrder[0],
     );
     expect(mockDeleteUser).toHaveBeenCalledWith("user_123");
+  });
+
+  it("does not delete external identity resources when Convex cleanup returns an unexpected shape", async () => {
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [],
+    } as never);
+    mockConvexMutation.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toContain("unexpected response");
+    expect(mockDeleteOrganizationMembership).not.toHaveBeenCalled();
+    expect(mockListSubscriptions).not.toHaveBeenCalled();
+    expect(mockDeleteCustomer).not.toHaveBeenCalled();
+    expect(mockDeleteOrganization).not.toHaveBeenCalled();
+    expect(mockDeleteUserRateLimitKeys).not.toHaveBeenCalled();
+    expect(mockDeleteUser).not.toHaveBeenCalled();
   });
 
   it("does not delete org billing when a shared-org admin deletes their account", async () => {

--- a/app/api/delete-account/__tests__/route.test.ts
+++ b/app/api/delete-account/__tests__/route.test.ts
@@ -282,6 +282,49 @@ describe("POST /api/delete-account", () => {
     expect(mockDeleteUser).not.toHaveBeenCalled();
   });
 
+  it("repeats Convex cleanup batches before deleting external identity resources", async () => {
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [],
+    } as never);
+    mockConvexMutation
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ hasMore: true })
+      .mockResolvedValueOnce({ hasMore: false });
+
+    const response = await POST(request() as any);
+
+    expect(response.status).toBe(200);
+    expect(mockConvexMutation).toHaveBeenNthCalledWith(
+      1,
+      "accountIdentities.markDeleted",
+      {
+        serviceKey: "service_key",
+        identityHash: "free_quota:v1:identity_hash",
+        userId: "user_123",
+      },
+    );
+    expect(mockConvexMutation).toHaveBeenNthCalledWith(
+      2,
+      "userDeletion.deleteAllUserDataByService",
+      {
+        serviceKey: "service_key",
+        userId: "user_123",
+      },
+    );
+    expect(mockConvexMutation).toHaveBeenNthCalledWith(
+      3,
+      "userDeletion.deleteAllUserDataByService",
+      {
+        serviceKey: "service_key",
+        userId: "user_123",
+      },
+    );
+    expect(mockConvexMutation.mock.invocationCallOrder[2]).toBeLessThan(
+      mockDeleteUser.mock.invocationCallOrder[0],
+    );
+    expect(mockDeleteUser).toHaveBeenCalledWith("user_123");
+  });
+
   it("does not delete org billing when a shared-org admin deletes their account", async () => {
     const callerMembership = {
       id: "membership_admin",

--- a/app/api/delete-account/route.ts
+++ b/app/api/delete-account/route.ts
@@ -17,6 +17,17 @@ type MembershipDeletionPlan = {
   blockReason?: string;
 };
 
+const MAX_CONVEX_ACCOUNT_CLEANUP_BATCHES = 50;
+
+function convexCleanupHasMore(result: unknown): boolean {
+  return (
+    !!result &&
+    typeof result === "object" &&
+    "hasMore" in result &&
+    (result as { hasMore?: unknown }).hasMore === true
+  );
+}
+
 async function removeMembership(membership: OrganizationMembership) {
   try {
     await workos.userManagement.deleteOrganizationMembership(membership.id);
@@ -98,12 +109,24 @@ async function markAccountIdentityDeleted(
 }
 
 async function deleteConvexUserData(userId: string, serviceKey: string) {
-  await getConvexClient().mutation(
-    api.userDeletion.deleteAllUserDataByService,
-    {
-      serviceKey,
-      userId,
-    },
+  const convex = getConvexClient();
+
+  for (let batch = 0; batch < MAX_CONVEX_ACCOUNT_CLEANUP_BATCHES; batch++) {
+    const result = await convex.mutation(
+      api.userDeletion.deleteAllUserDataByService,
+      {
+        serviceKey,
+        userId,
+      },
+    );
+
+    if (!convexCleanupHasMore(result)) {
+      return;
+    }
+  }
+
+  throw new Error(
+    "Account cleanup is taking longer than expected. Please contact support so we can finish deleting this account.",
   );
 }
 
@@ -232,8 +255,15 @@ export const POST = async (req: NextRequest) => {
     const message =
       error && typeof error === "object" && "message" in (error as any)
         ? (error as any).message
-        : "Failed to cancel subscriptions and remove organizations";
-    console.error("Failed to cancel subscriptions and remove orgs:", error);
+        : "Failed to delete account";
+    console.error(
+      "Failed to delete account:",
+      {
+        event: "account_deletion_failed",
+        error_message: message,
+      },
+      error,
+    );
     return NextResponse.json({ error: message }, { status: 500 });
   }
 };

--- a/app/api/delete-account/route.ts
+++ b/app/api/delete-account/route.ts
@@ -19,12 +19,17 @@ type MembershipDeletionPlan = {
 
 const MAX_CONVEX_ACCOUNT_CLEANUP_BATCHES = 50;
 
-function convexCleanupHasMore(result: unknown): boolean {
-  return (
-    !!result &&
+function parseConvexCleanupResult(result: unknown): { hasMore: boolean } {
+  if (
+    result &&
     typeof result === "object" &&
-    "hasMore" in result &&
-    (result as { hasMore?: unknown }).hasMore === true
+    typeof (result as { hasMore?: unknown }).hasMore === "boolean"
+  ) {
+    return { hasMore: (result as { hasMore: boolean }).hasMore };
+  }
+
+  throw new Error(
+    "Account cleanup returned an unexpected response. Please contact support so we can finish deleting this account.",
   );
 }
 
@@ -120,7 +125,7 @@ async function deleteConvexUserData(userId: string, serviceKey: string) {
       },
     );
 
-    if (!convexCleanupHasMore(result)) {
+    if (!parseConvexCleanupResult(result).hasMore) {
       return;
     }
   }

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -664,7 +664,7 @@ describe("userDeletion", () => {
     ).rejects.toThrow("processes one userId per mutation");
   });
 
-  it("fails before cleanup when an indexed query exceeds the bounded read limit", async () => {
+  it("reports remaining work and completes on a later batch when an indexed query exceeds the batch size", async () => {
     const { deleteAllUserData } = await import("../userDeletion");
     const tables = seedTables();
     tables.notes = Array.from({ length: 501 }, (_, index) => ({
@@ -674,10 +674,20 @@ describe("userDeletion", () => {
     }));
     const { ctx } = createMockCtx(tables);
 
-    await expect(deleteAllUserData.handler(ctx as any, {})).rejects.toThrow(
-      "matched more than 500 rows in notes.by_user_and_updated",
-    );
-    expect(row(tables, "chats", "chat-doc")).toBeTruthy();
+    const firstBatch = await deleteAllUserData.handler(ctx as any, {});
+
+    expect(firstBatch.hasMore).toBe(true);
+    expect(
+      tables.notes.filter((candidate) => candidate.user_id === "user_123"),
+    ).toHaveLength(1);
+    expect(row(tables, "chats", "chat-doc")).toBeUndefined();
+
+    const secondBatch = await deleteAllUserData.handler(ctx as any, {});
+
+    expect(secondBatch.hasMore).toBe(false);
+    expect(
+      tables.notes.filter((candidate) => candidate.user_id === "user_123"),
+    ).toHaveLength(0);
   });
 
   it("fails user deletion if S3 cleanup scheduling fails", async () => {

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -628,12 +628,23 @@ describe("userDeletion", () => {
     });
     const { ctx } = createMockCtx(tables);
 
+    const pagedDryRun = await cleanupDeletedUserResidue.handler(ctx as any, {
+      serviceKey: "service_key",
+      deleteOrphanChatSummaries: true,
+      orphanNumItems: 1,
+    });
+
+    expect(pagedDryRun.hasMore).toBe(true);
+    expect(pagedDryRun.orphanChatSummariesIsDone).toBe(false);
+    expect(pagedDryRun.orphanChatSummariesContinueCursor).toBe("1");
+
     const dryRun = await cleanupDeletedUserResidue.handler(ctx as any, {
       serviceKey: "service_key",
       deleteOrphanChatSummaries: true,
       orphanNumItems: 20,
     });
 
+    expect(dryRun.hasMore).toBe(false);
     expect(dryRun.orphanChatSummariesDeleted).toBe(2);
     expect(row(tables, "chat_summaries", "summary-orphan")).toBeTruthy();
     expect(row(tables, "chat_summaries", "summary-latest")).toBeTruthy();
@@ -645,6 +656,7 @@ describe("userDeletion", () => {
       orphanNumItems: 20,
     });
 
+    expect(execute.hasMore).toBe(false);
     expect(execute.orphanChatSummariesDeleted).toBe(2);
     expect(row(tables, "chat_summaries", "summary-orphan")).toBeUndefined();
     expect(row(tables, "chat_summaries", "summary-latest")).toBeUndefined();

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -131,13 +131,18 @@ async function collectByIndexBatch<T extends AnyDoc>(
   table: string,
   indexName: string,
   build: (q: any) => any,
+  limit = MAX_CLEANUP_DOCS_PER_INDEX,
 ): Promise<IndexedBatch<T>> {
+  if (limit <= 0) {
+    return { docs: [], hasMore: true };
+  }
+
   const rows = await (ctx.db.query(table as any) as any)
     .withIndex(indexName, build)
-    .take(MAX_CLEANUP_DOCS_PER_INDEX + 1);
+    .take(limit + 1);
 
-  const hasMore = rows.length > MAX_CLEANUP_DOCS_PER_INDEX;
-  const docs = hasMore ? rows.slice(0, MAX_CLEANUP_DOCS_PER_INDEX) : rows;
+  const hasMore = rows.length > limit;
+  const docs = hasMore ? rows.slice(0, limit) : rows;
 
   return { docs, hasMore };
 }
@@ -194,35 +199,53 @@ async function collectChatSummariesForChats(
   chats: Doc<"chats">[],
   stats: CleanupStats,
 ) {
-  const summariesByChat = await Promise.all(
-    chats.map(async (chat) => {
-      const batch = await collectByIndexBatch<Doc<"chat_summaries">>(
-        ctx,
-        "chat_summaries",
-        "by_chat_id",
-        (q) => q.eq("chat_id", chat.id),
-      );
-      if (batch.hasMore) stats.hasMore = true;
-      return { chatId: chat.id, ...batch };
-    }),
-  );
+  const summaries: Doc<"chat_summaries">[] = [];
+  const incompleteChatIds = new Set<string>();
+  let remainingSummaryReads = MAX_CLEANUP_DOCS_PER_INDEX;
 
-  const latestSummaries = await Promise.all(
-    chats.map((chat) =>
-      chat.latest_summary_id ? ctx.db.get(chat.latest_summary_id) : null,
-    ),
-  );
+  for (const chat of chats) {
+    if (remainingSummaryReads <= 0) {
+      stats.hasMore = true;
+      incompleteChatIds.add(chat.id);
+      continue;
+    }
+
+    const batch = await collectByIndexBatch<Doc<"chat_summaries">>(
+      ctx,
+      "chat_summaries",
+      "by_chat_id",
+      (q) => q.eq("chat_id", chat.id),
+      remainingSummaryReads,
+    );
+    summaries.push(...batch.docs);
+    remainingSummaryReads -= batch.docs.length;
+
+    if (batch.hasMore) {
+      stats.hasMore = true;
+      incompleteChatIds.add(chat.id);
+      continue;
+    }
+
+    if (!chat.latest_summary_id) {
+      continue;
+    }
+
+    if (remainingSummaryReads <= 0) {
+      stats.hasMore = true;
+      incompleteChatIds.add(chat.id);
+      continue;
+    }
+
+    const latestSummary = await ctx.db.get(chat.latest_summary_id);
+    remainingSummaryReads -= 1;
+    if (latestSummary) {
+      summaries.push(latestSummary);
+    }
+  }
 
   return {
-    summaries: uniqueDocs([
-      ...summariesByChat.flatMap((batch) => batch.docs),
-      ...latestSummaries,
-    ]),
-    incompleteChatIds: new Set(
-      summariesByChat
-        .filter((batch) => batch.hasMore)
-        .map((batch) => batch.chatId),
-    ),
+    summaries: uniqueDocs(summaries),
+    incompleteChatIds,
   };
 }
 
@@ -687,6 +710,7 @@ async function cleanupOrphanChatSummaries(
   stats.orphanChatSummariesScanned = page.page.length;
   stats.orphanChatSummariesIsDone = page.isDone;
   stats.orphanChatSummariesContinueCursor = page.continueCursor ?? undefined;
+  stats.hasMore = !page.isDone;
 
   const orphanSummaries: Doc<"chat_summaries">[] = [];
   for (const summary of page.page as Doc<"chat_summaries">[]) {

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -52,12 +52,30 @@ type CleanupStats = {
   deleted: Record<string, number>;
   anonymized: Record<string, number>;
   retained: Record<string, number>;
+  hasMore: boolean;
   orphanChatSummariesDeleted: number;
   orphanChatSummariesScanned: number;
   orphanChatSummariesIsDone: boolean;
   orphanChatSummariesContinueCursor?: string;
   s3ObjectsQueued: number;
 };
+
+type IndexedBatch<T extends AnyDoc> = {
+  docs: T[];
+  hasMore: boolean;
+};
+
+const cleanupStatsValidator = v.object({
+  deleted: v.any(),
+  anonymized: v.any(),
+  retained: v.any(),
+  hasMore: v.boolean(),
+  orphanChatSummariesDeleted: v.number(),
+  orphanChatSummariesScanned: v.number(),
+  orphanChatSummariesIsDone: v.boolean(),
+  orphanChatSummariesContinueCursor: v.optional(v.string()),
+  s3ObjectsQueued: v.number(),
+});
 
 function createStats(): CleanupStats {
   return {
@@ -66,6 +84,7 @@ function createStats(): CleanupStats {
     retained: Object.fromEntries(
       USER_DELETION_TABLE_POLICY.retain.map((table) => [table, 0]),
     ),
+    hasMore: false,
     orphanChatSummariesDeleted: 0,
     orphanChatSummariesScanned: 0,
     orphanChatSummariesIsDone: true,
@@ -89,6 +108,7 @@ function mergeStats(target: CleanupStats, source: CleanupStats) {
   for (const [table, count] of Object.entries(source.anonymized)) {
     increment(target.anonymized, table, count);
   }
+  target.hasMore ||= source.hasMore;
   target.orphanChatSummariesDeleted += source.orphanChatSummariesDeleted;
   target.orphanChatSummariesScanned += source.orphanChatSummariesScanned;
   target.s3ObjectsQueued += source.s3ObjectsQueued;
@@ -106,23 +126,20 @@ function uniqueDocs<T extends AnyDoc>(docs: Array<T | null | undefined>): T[] {
   return Array.from(byId.values());
 }
 
-async function collectByIndex<T extends AnyDoc>(
+async function collectByIndexBatch<T extends AnyDoc>(
   ctx: MutationCtx,
   table: string,
   indexName: string,
   build: (q: any) => any,
-): Promise<T[]> {
+): Promise<IndexedBatch<T>> {
   const rows = await (ctx.db.query(table as any) as any)
     .withIndex(indexName, build)
     .take(MAX_CLEANUP_DOCS_PER_INDEX + 1);
 
-  if (rows.length > MAX_CLEANUP_DOCS_PER_INDEX) {
-    throw new Error(
-      `Account cleanup matched more than ${MAX_CLEANUP_DOCS_PER_INDEX} rows in ${table}.${indexName}; run a narrower cleanup before deleting this account.`,
-    );
-  }
+  const hasMore = rows.length > MAX_CLEANUP_DOCS_PER_INDEX;
+  const docs = hasMore ? rows.slice(0, MAX_CLEANUP_DOCS_PER_INDEX) : rows;
 
-  return rows;
+  return { docs, hasMore };
 }
 
 async function firstByIndex<T extends AnyDoc>(
@@ -175,16 +192,19 @@ async function anonymizeDocs(
 async function collectChatSummariesForChats(
   ctx: MutationCtx,
   chats: Doc<"chats">[],
+  stats: CleanupStats,
 ) {
   const summariesByChat = await Promise.all(
-    chats.map((chat) =>
-      collectByIndex<Doc<"chat_summaries">>(
+    chats.map(async (chat) => {
+      const batch = await collectByIndexBatch<Doc<"chat_summaries">>(
         ctx,
         "chat_summaries",
         "by_chat_id",
         (q) => q.eq("chat_id", chat.id),
-      ),
-    ),
+      );
+      if (batch.hasMore) stats.hasMore = true;
+      return { chatId: chat.id, ...batch };
+    }),
   );
 
   const latestSummaries = await Promise.all(
@@ -193,7 +213,17 @@ async function collectChatSummariesForChats(
     ),
   );
 
-  return uniqueDocs([...summariesByChat.flat(), ...latestSummaries]);
+  return {
+    summaries: uniqueDocs([
+      ...summariesByChat.flatMap((batch) => batch.docs),
+      ...latestSummaries,
+    ]),
+    incompleteChatIds: new Set(
+      summariesByChat
+        .filter((batch) => batch.hasMore)
+        .map((batch) => batch.chatId),
+    ),
+  };
 }
 
 async function deleteFiles(
@@ -238,64 +268,73 @@ async function cleanupUserDataForUser(
   const now = Date.now();
 
   const [
-    chats,
-    files,
-    notes,
-    customization,
-    messages,
-    tempStreams,
-    localSandboxTokens,
-    localSandboxConnections,
-    extraUsage,
-    teamMemberUsage,
-    cancellationReasonDetails,
+    chatsBatch,
+    filesBatch,
+    notesBatch,
+    customizationBatch,
+    messagesBatch,
+    tempStreamsBatch,
+    localSandboxTokensBatch,
+    localSandboxConnectionsBatch,
+    extraUsageBatch,
+    teamMemberUsageBatch,
+    cancellationReasonDetailsBatch,
   ] = await Promise.all([
-    collectByIndex<Doc<"chats">>(ctx, "chats", "by_user_and_updated", (q) =>
+    collectByIndexBatch<Doc<"chats">>(
+      ctx,
+      "chats",
+      "by_user_and_updated",
+      (q) => q.eq("user_id", userId),
+    ),
+    collectByIndexBatch<Doc<"files">>(ctx, "files", "by_user_id", (q) =>
       q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"files">>(ctx, "files", "by_user_id", (q) =>
-      q.eq("user_id", userId),
+    collectByIndexBatch<Doc<"notes">>(
+      ctx,
+      "notes",
+      "by_user_and_updated",
+      (q) => q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"notes">>(ctx, "notes", "by_user_and_updated", (q) =>
-      q.eq("user_id", userId),
-    ),
-    collectByIndex<Doc<"user_customization">>(
+    collectByIndexBatch<Doc<"user_customization">>(
       ctx,
       "user_customization",
       "by_user_id",
       (q) => q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"messages">>(ctx, "messages", "by_user_id", (q) =>
+    collectByIndexBatch<Doc<"messages">>(ctx, "messages", "by_user_id", (q) =>
       q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"temp_streams">>(
+    collectByIndexBatch<Doc<"temp_streams">>(
       ctx,
       "temp_streams",
       "by_user_id",
       (q) => q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"local_sandbox_tokens">>(
+    collectByIndexBatch<Doc<"local_sandbox_tokens">>(
       ctx,
       "local_sandbox_tokens",
       "by_user_id",
       (q) => q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"local_sandbox_connections">>(
+    collectByIndexBatch<Doc<"local_sandbox_connections">>(
       ctx,
       "local_sandbox_connections",
       "by_user_id",
       (q) => q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"extra_usage">>(ctx, "extra_usage", "by_user_id", (q) =>
-      q.eq("user_id", userId),
+    collectByIndexBatch<Doc<"extra_usage">>(
+      ctx,
+      "extra_usage",
+      "by_user_id",
+      (q) => q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"team_member_usage">>(
+    collectByIndexBatch<Doc<"team_member_usage">>(
       ctx,
       "team_member_usage",
       "by_user_id",
       (q) => q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"cancellation_reason_details">>(
+    collectByIndexBatch<Doc<"cancellation_reason_details">>(
       ctx,
       "cancellation_reason_details",
       "by_user_id_and_created_at",
@@ -303,16 +342,50 @@ async function cleanupUserDataForUser(
     ),
   ]);
 
+  const deletionBatches = [
+    chatsBatch,
+    filesBatch,
+    notesBatch,
+    customizationBatch,
+    messagesBatch,
+    tempStreamsBatch,
+    localSandboxTokensBatch,
+    localSandboxConnectionsBatch,
+    extraUsageBatch,
+    teamMemberUsageBatch,
+    cancellationReasonDetailsBatch,
+  ];
+  stats.hasMore ||= deletionBatches.some((batch) => batch.hasMore);
+
+  const chats = chatsBatch.docs;
+  const files = filesBatch.docs;
+  const notes = notesBatch.docs;
+  const customization = customizationBatch.docs;
+  const messages = messagesBatch.docs;
+  const tempStreams = tempStreamsBatch.docs;
+  const localSandboxTokens = localSandboxTokensBatch.docs;
+  const localSandboxConnections = localSandboxConnectionsBatch.docs;
+  const extraUsage = extraUsageBatch.docs;
+  const teamMemberUsage = teamMemberUsageBatch.docs;
+  const cancellationReasonDetails = cancellationReasonDetailsBatch.docs;
+
   const feedbackIds = uniqueDocs(messages)
     .map((message) => message.feedback_id)
     .filter((id): id is Id<"feedback"> => !!id);
   const feedback = await Promise.all(feedbackIds.map((id) => ctx.db.get(id)));
-  const chatSummaries = await collectChatSummariesForChats(ctx, chats);
+  const { summaries: chatSummaries, incompleteChatIds } =
+    await collectChatSummariesForChats(ctx, chats, stats);
+  const chatsReadyToDelete = messagesBatch.hasMore
+    ? []
+    : chats.filter((chat) => !incompleteChatIds.has(chat.id));
+  if (chatsReadyToDelete.length < chats.length) {
+    stats.hasMore = true;
+  }
 
   await deleteDocs(ctx, stats, "feedback", feedback, mode);
   await deleteDocs(ctx, stats, "messages", messages, mode);
   await deleteDocs(ctx, stats, "chat_summaries", chatSummaries, mode);
-  await deleteDocs(ctx, stats, "chats", chats, mode);
+  await deleteDocs(ctx, stats, "chats", chatsReadyToDelete, mode);
   await deleteFiles(ctx, stats, files, mode);
   await deleteDocs(ctx, stats, "notes", notes, mode);
   await deleteDocs(ctx, stats, "user_customization", customization, mode);
@@ -342,110 +415,145 @@ async function cleanupUserDataForUser(
   );
 
   const [
-    cancellationReasons,
-    usageLogs,
-    referralCodes,
-    referredAttributions,
-    referrerAttributions,
-    referralRewardsByUser,
-    referralRewardsByReferrer,
-    referralRewardsByReferred,
-    userSuspensions,
-    revenueByUser,
-    revenueByEntity,
-    paidStartsByUser,
-    paidStartsByEntity,
-    unitEconomicsByUser,
-    unitEconomicsByEntity,
+    cancellationReasonsBatch,
+    usageLogsBatch,
+    referralCodesBatch,
+    referredAttributionsBatch,
+    referrerAttributionsBatch,
+    referralRewardsByUserBatch,
+    referralRewardsByReferrerBatch,
+    referralRewardsByReferredBatch,
+    userSuspensionsBatch,
+    revenueByUserBatch,
+    revenueByEntityBatch,
+    paidStartsByUserBatch,
+    paidStartsByEntityBatch,
+    unitEconomicsByUserBatch,
+    unitEconomicsByEntityBatch,
   ] = await Promise.all([
-    collectByIndex<Doc<"cancellation_reasons">>(
+    collectByIndexBatch<Doc<"cancellation_reasons">>(
       ctx,
       "cancellation_reasons",
       "by_user_started",
       (q) => q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"usage_logs">>(ctx, "usage_logs", "by_user", (q) =>
+    collectByIndexBatch<Doc<"usage_logs">>(ctx, "usage_logs", "by_user", (q) =>
       q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"referral_codes">>(
+    collectByIndexBatch<Doc<"referral_codes">>(
       ctx,
       "referral_codes",
       "by_user_id",
       (q) => q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"referral_attributions">>(
+    collectByIndexBatch<Doc<"referral_attributions">>(
       ctx,
       "referral_attributions",
       "by_referred_user_id",
       (q) => q.eq("referred_user_id", userId),
     ),
-    collectByIndex<Doc<"referral_attributions">>(
+    collectByIndexBatch<Doc<"referral_attributions">>(
       ctx,
       "referral_attributions",
       "by_referrer_user_id",
       (q) => q.eq("referrer_user_id", userId),
     ),
-    collectByIndex<Doc<"referral_rewards">>(
+    collectByIndexBatch<Doc<"referral_rewards">>(
       ctx,
       "referral_rewards",
       "by_user_id",
       (q) => q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"referral_rewards">>(
+    collectByIndexBatch<Doc<"referral_rewards">>(
       ctx,
       "referral_rewards",
       "by_referrer_user_id",
       (q) => q.eq("referrer_user_id", userId),
     ),
-    collectByIndex<Doc<"referral_rewards">>(
+    collectByIndexBatch<Doc<"referral_rewards">>(
       ctx,
       "referral_rewards",
       "by_referred_user_id",
       (q) => q.eq("referred_user_id", userId),
     ),
-    collectByIndex<Doc<"user_suspensions">>(
+    collectByIndexBatch<Doc<"user_suspensions">>(
       ctx,
       "user_suspensions",
       "by_user_id",
       (q) => q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"revenue_events">>(
+    collectByIndexBatch<Doc<"revenue_events">>(
       ctx,
       "revenue_events",
       "by_user_occurred",
       (q) => q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"revenue_events">>(
+    collectByIndexBatch<Doc<"revenue_events">>(
       ctx,
       "revenue_events",
       "by_entity_occurred",
       (q) => q.eq("entity_type", "user").eq("entity_id", userId),
     ),
-    collectByIndex<Doc<"paid_start_events">>(
+    collectByIndexBatch<Doc<"paid_start_events">>(
       ctx,
       "paid_start_events",
       "by_user_day",
       (q) => q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"paid_start_events">>(
+    collectByIndexBatch<Doc<"paid_start_events">>(
       ctx,
       "paid_start_events",
       "by_entity_day",
       (q) => q.eq("entity_type", "user").eq("entity_id", userId),
     ),
-    collectByIndex<Doc<"unit_economics_daily">>(
+    collectByIndexBatch<Doc<"unit_economics_daily">>(
       ctx,
       "unit_economics_daily",
       "by_user_day",
       (q) => q.eq("user_id", userId),
     ),
-    collectByIndex<Doc<"unit_economics_daily">>(
+    collectByIndexBatch<Doc<"unit_economics_daily">>(
       ctx,
       "unit_economics_daily",
       "by_entity_day",
       (q) => q.eq("entity_type", "user").eq("entity_id", userId),
     ),
   ]);
+
+  const anonymizeBatches = [
+    cancellationReasonsBatch,
+    usageLogsBatch,
+    referralCodesBatch,
+    referredAttributionsBatch,
+    referrerAttributionsBatch,
+    referralRewardsByUserBatch,
+    referralRewardsByReferrerBatch,
+    referralRewardsByReferredBatch,
+    userSuspensionsBatch,
+    revenueByUserBatch,
+    revenueByEntityBatch,
+    paidStartsByUserBatch,
+    paidStartsByEntityBatch,
+    unitEconomicsByUserBatch,
+    unitEconomicsByEntityBatch,
+  ];
+  stats.hasMore ||= anonymizeBatches.some((batch) => batch.hasMore);
+
+  const cancellationReasons = cancellationReasonsBatch.docs;
+  const usageLogs = usageLogsBatch.docs;
+  const referralCodes = referralCodesBatch.docs;
+  const referredAttributions = referredAttributionsBatch.docs;
+  const referrerAttributions = referrerAttributionsBatch.docs;
+  const referralRewardsByUser = referralRewardsByUserBatch.docs;
+  const referralRewardsByReferrer = referralRewardsByReferrerBatch.docs;
+  const referralRewardsByReferred = referralRewardsByReferredBatch.docs;
+  const userSuspensions = userSuspensionsBatch.docs;
+  const revenueByUser = revenueByUserBatch.docs;
+  const revenueByEntity = revenueByEntityBatch.docs;
+  const paidStartsByUser = paidStartsByUserBatch.docs;
+  const paidStartsByEntity = paidStartsByEntityBatch.docs;
+  const unitEconomicsByUser = unitEconomicsByUserBatch.docs;
+  const unitEconomicsByEntity = unitEconomicsByEntityBatch.docs;
 
   await anonymizeDocs(
     ctx,
@@ -604,15 +712,14 @@ async function cleanupOrphanChatSummaries(
  */
 export const deleteAllUserData = mutation({
   args: {},
-  returns: v.null(),
+  returns: cleanupStatsValidator,
   handler: async (ctx) => {
     const user = await ctx.auth.getUserIdentity();
     if (!user) {
       throw new Error("Unauthorized: User not authenticated");
     }
 
-    await cleanupUserDataForUser(ctx, user.subject, "execute");
-    return null;
+    return await cleanupUserDataForUser(ctx, user.subject, "execute");
   },
 });
 
@@ -621,11 +728,10 @@ export const deleteAllUserDataByService = mutation({
     serviceKey: v.string(),
     userId: v.string(),
   },
-  returns: v.null(),
+  returns: cleanupStatsValidator,
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
-    await cleanupUserDataForUser(ctx, args.userId, "execute");
-    return null;
+    return await cleanupUserDataForUser(ctx, args.userId, "execute");
   },
 });
 
@@ -638,16 +744,7 @@ export const cleanupDeletedUserResidue = mutation({
     orphanCursor: v.optional(v.union(v.string(), v.null())),
     orphanNumItems: v.optional(v.number()),
   },
-  returns: v.object({
-    deleted: v.any(),
-    anonymized: v.any(),
-    retained: v.any(),
-    orphanChatSummariesDeleted: v.number(),
-    orphanChatSummariesScanned: v.number(),
-    orphanChatSummariesIsDone: v.boolean(),
-    orphanChatSummariesContinueCursor: v.optional(v.string()),
-    s3ObjectsQueued: v.number(),
-  }),
+  returns: cleanupStatsValidator,
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
 


### PR DESCRIPTION
## Summary
- batch Convex account cleanup instead of failing when an index has more than 500 user rows
- have `/api/delete-account` repeat cleanup until `hasMore` is false before deleting WorkOS/Stripe resources
- make account-delete failure logging describe the account deletion phase and add regression coverage

## Why
The observed log came from the Convex mutation wrapper inside `/api/delete-account`. Heavy accounts could hit the cleanup read guard and throw `[Request ID: ...] Server Error`; the route then surfaced it as a subscription/org cleanup failure even though the Convex cleanup phase failed first.

## Validation
- `./node_modules/.bin/jest app/api/delete-account/__tests__/route.test.ts convex/__tests__/userDeletion.test.ts --runInBand`
- `./node_modules/.bin/prettier --check app/api/delete-account/route.ts app/api/delete-account/__tests__/route.test.ts convex/userDeletion.ts convex/__tests__/userDeletion.test.ts`
- `./node_modules/.bin/eslint app/api/delete-account/route.ts app/api/delete-account/__tests__/route.test.ts convex/userDeletion.ts convex/__tests__/userDeletion.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

## Manual verification
- Delete an account with more than 500 rows in a cleanup-indexed table, such as `notes.by_user_and_updated` or `messages.by_user_id`.
- Confirm `/api/delete-account` runs multiple Convex cleanup batches and only deletes WorkOS/Stripe resources after `hasMore` becomes false.
- Confirm failure logs use `account_deletion_failed` and preserve the original Convex request ID/error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account deletion now performs bounded, paginated cleanup in multiple batches for accounts with large data sets, improving completion reliability.

* **Bug Fixes**
  * Prevents cleanup from hard-failing when a single batch limit is reached by continuing across batches until complete.
  * Adds safer handling for unexpected cleanup responses, returning a clear server error and avoiding partial downstream deletion steps.
  * Improves error logging/details when account deletion fails.

* **Tests**
  * Expanded coverage for multi-batch deletion, continuation behavior, and error handling for unexpected cleanup responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->