### PR TITLE
Add extra usage purchase observability

### DIFF
--- a/app/api/extra-usage/confirm/route.ts
+++ b/app/api/extra-usage/confirm/route.ts
@@ -7,6 +7,22 @@ import {
   PAID_FUNNEL_EVENTS,
   paidFunnelProperties,
 } from "@/lib/analytics/paid-funnel";
+import { logExtraUsagePurchase } from "@/lib/billing/extra-usage-purchase-logging";
+
+const ROUTE = "/api/extra-usage/confirm" as const;
+
+function stripeObjectId(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && "id" in value) {
+    const id = (value as { id?: unknown }).id;
+    return typeof id === "string" ? id : undefined;
+  }
+  return undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 /**
  * GET /api/extra-usage/confirm?session_id=cs_xxx
@@ -37,14 +53,34 @@ export async function GET(req: NextRequest) {
     const amountDollars = session.metadata.amountDollars
       ? parseFloat(session.metadata.amountDollars)
       : parseInt(session.metadata.amountCents ?? "0", 10) / 100;
+    const stripeCustomerId = stripeObjectId(session.customer);
+    const stripePaymentIntentId = stripeObjectId(session.payment_intent);
+    const stripeInvoiceId = stripeObjectId(session.invoice);
 
     if (!userId || isNaN(amountDollars) || amountDollars <= 0) {
-      console.error(
-        "[Extra Usage Confirm] Invalid metadata on session:",
-        session.id,
-      );
+      logExtraUsagePurchase("warn", "extra_usage_purchase_invalid_metadata", {
+        route: ROUTE,
+        requestHeaders: req.headers,
+        stripeCheckoutSessionId: session.id,
+        stripePaymentIntentId,
+        stripeInvoiceId,
+        paymentStatus: session.payment_status,
+        reason: "invalid_session_metadata",
+      });
       return NextResponse.redirect(origin, { status: 303 });
     }
+
+    logExtraUsagePurchase("info", "extra_usage_purchase_session_seen", {
+      route: ROUTE,
+      requestHeaders: req.headers,
+      userId,
+      amountDollars,
+      stripeCheckoutSessionId: session.id,
+      stripePaymentIntentId,
+      stripeInvoiceId,
+      paymentStatus: session.payment_status,
+      result: "session_seen",
+    });
 
     const redirectUrl = new URL(origin);
     redirectUrl.searchParams.set("extra-usage-purchased", "true");
@@ -54,26 +90,113 @@ export async function GET(req: NextRequest) {
     // credit when Stripe sends `checkout.session.async_payment_succeeded` or
     // an eventual `checkout.session.completed` with `payment_status: paid`.
     if (session.payment_status !== "paid") {
+      logExtraUsagePurchase("info", "extra_usage_purchase_payment_pending", {
+        route: ROUTE,
+        requestHeaders: req.headers,
+        userId,
+        amountDollars,
+        stripeCheckoutSessionId: session.id,
+        stripePaymentIntentId,
+        stripeInvoiceId,
+        paymentStatus: session.payment_status,
+        result: "payment_pending",
+      });
       redirectUrl.searchParams.set("extra-usage-pending", "true");
       return NextResponse.redirect(redirectUrl, { status: 303 });
     }
 
-    await getConvexClient().mutation(api.extraUsage.addCredits, {
-      serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
-      userId,
-      amountDollars,
-      idempotencyKey: `cs_${session.id}`,
-      revenueSource: "extra_usage_purchase",
-      stripeCustomerId:
-        typeof session.customer === "string"
-          ? session.customer
-          : session.customer?.id,
-      stripeCheckoutSessionId: session.id,
-      stripePaymentIntentId:
-        typeof session.payment_intent === "string"
-          ? session.payment_intent
-          : session.payment_intent?.id,
-    });
+    const convex = getConvexClient();
+    let result: { alreadyProcessed: boolean };
+    try {
+      await convex.mutation(api.extraUsage.recordPurchasePaidSeen, {
+        serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+        userId,
+        amountDollars,
+        stripeCheckoutSessionId: session.id,
+        stripePaymentIntentId,
+        stripeInvoiceId,
+        route: "confirm",
+      });
+
+      result = await convex.mutation(api.extraUsage.addCredits, {
+        serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+        userId,
+        amountDollars,
+        idempotencyKey: `cs_${session.id}`,
+        revenueSource: "extra_usage_purchase",
+        stripeCustomerId,
+        stripeCheckoutSessionId: session.id,
+        stripePaymentIntentId,
+        stripeInvoiceId,
+        purchaseRoute: "confirm",
+      });
+    } catch (error) {
+      try {
+        await convex.mutation(api.extraUsage.recordPurchaseFailed, {
+          serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+          userId,
+          amountDollars,
+          stripeCheckoutSessionId: session.id,
+          stripePaymentIntentId,
+          stripeInvoiceId,
+          route: "confirm",
+          lastError: errorMessage(error),
+        });
+      } catch (recordError) {
+        logExtraUsagePurchase(
+          "error",
+          "extra_usage_purchase_failure_record_failed",
+          {
+            route: ROUTE,
+            requestHeaders: req.headers,
+            userId,
+            amountDollars,
+            stripeCheckoutSessionId: session.id,
+            stripePaymentIntentId,
+            stripeInvoiceId,
+            paymentStatus: session.payment_status,
+            result: "failure_record_failed",
+            error: recordError,
+          },
+        );
+      }
+
+      logExtraUsagePurchase("error", "extra_usage_purchase_credit_failed", {
+        route: ROUTE,
+        requestHeaders: req.headers,
+        userId,
+        amountDollars,
+        stripeCheckoutSessionId: session.id,
+        stripePaymentIntentId,
+        stripeInvoiceId,
+        paymentStatus: session.payment_status,
+        result: "failed",
+        error,
+      });
+
+      const fallback = new URL(origin);
+      fallback.searchParams.set("extra-usage-purchased", "true");
+      return NextResponse.redirect(fallback, { status: 303 });
+    }
+
+    logExtraUsagePurchase(
+      "info",
+      result.alreadyProcessed
+        ? "extra_usage_purchase_credit_skipped"
+        : "extra_usage_purchase_credit_succeeded",
+      {
+        route: ROUTE,
+        requestHeaders: req.headers,
+        userId,
+        amountDollars,
+        stripeCheckoutSessionId: session.id,
+        stripePaymentIntentId,
+        stripeInvoiceId,
+        paymentStatus: session.payment_status,
+        result: result.alreadyProcessed ? "already_processed" : "credited",
+      },
+    );
+
     phLogger.event(
       PAID_FUNNEL_EVENTS.addCreditCheckoutSucceeded,
       paidFunnelProperties({
@@ -81,15 +204,9 @@ export async function GET(req: NextRequest) {
         checkout_attempt_id: session.metadata.checkoutAttemptId,
         checkout_type: "extra_usage_purchase",
         amount_dollars: amountDollars,
-        stripe_customer_id:
-          typeof session.customer === "string"
-            ? session.customer
-            : session.customer?.id,
+        stripe_customer_id: stripeCustomerId,
         stripe_checkout_session_id: session.id,
-        stripe_payment_intent_id:
-          typeof session.payment_intent === "string"
-            ? session.payment_intent
-            : session.payment_intent?.id,
+        stripe_payment_intent_id: stripePaymentIntentId,
         payment_status: session.payment_status,
         $insert_id: `${PAID_FUNNEL_EVENTS.addCreditCheckoutSucceeded}:${session.id}`,
       }),
@@ -98,7 +215,13 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.redirect(redirectUrl, { status: 303 });
   } catch (err) {
-    console.error("[Extra Usage Confirm] Failed to confirm session:", err);
+    logExtraUsagePurchase("error", "extra_usage_purchase_confirm_failed", {
+      route: ROUTE,
+      requestHeaders: req.headers,
+      stripeCheckoutSessionId: sessionId,
+      result: "confirm_failed",
+      error: err,
+    });
     // Webhook is the safety net — don't block the user on confirm failures.
     const fallback = new URL(origin);
     fallback.searchParams.set("extra-usage-purchased", "true");

--- a/app/api/extra-usage/confirm/route.ts
+++ b/app/api/extra-usage/confirm/route.ts
@@ -197,21 +197,36 @@ export async function GET(req: NextRequest) {
       },
     );
 
-    phLogger.event(
-      PAID_FUNNEL_EVENTS.addCreditCheckoutSucceeded,
-      paidFunnelProperties({
+    try {
+      phLogger.event(
+        PAID_FUNNEL_EVENTS.addCreditCheckoutSucceeded,
+        paidFunnelProperties({
+          userId,
+          checkout_attempt_id: session.metadata.checkoutAttemptId,
+          checkout_type: "extra_usage_purchase",
+          amount_dollars: amountDollars,
+          stripe_customer_id: stripeCustomerId,
+          stripe_checkout_session_id: session.id,
+          stripe_payment_intent_id: stripePaymentIntentId,
+          payment_status: session.payment_status,
+          $insert_id: `${PAID_FUNNEL_EVENTS.addCreditCheckoutSucceeded}:${session.id}`,
+        }),
+      );
+      after(() => phLogger.flush());
+    } catch (analyticsError) {
+      logExtraUsagePurchase("warn", "extra_usage_purchase_analytics_failed", {
+        route: ROUTE,
+        requestHeaders: req.headers,
         userId,
-        checkout_attempt_id: session.metadata.checkoutAttemptId,
-        checkout_type: "extra_usage_purchase",
-        amount_dollars: amountDollars,
-        stripe_customer_id: stripeCustomerId,
-        stripe_checkout_session_id: session.id,
-        stripe_payment_intent_id: stripePaymentIntentId,
-        payment_status: session.payment_status,
-        $insert_id: `${PAID_FUNNEL_EVENTS.addCreditCheckoutSucceeded}:${session.id}`,
-      }),
-    );
-    after(() => phLogger.flush());
+        amountDollars,
+        stripeCheckoutSessionId: session.id,
+        stripePaymentIntentId,
+        stripeInvoiceId,
+        paymentStatus: session.payment_status,
+        result: result.alreadyProcessed ? "already_processed" : "credited",
+        error: analyticsError,
+      });
+    }
 
     return NextResponse.redirect(redirectUrl, { status: 303 });
   } catch (err) {

--- a/app/api/extra-usage/webhook/route.ts
+++ b/app/api/extra-usage/webhook/route.ts
@@ -247,21 +247,42 @@ export async function POST(req: NextRequest) {
             result: result.alreadyProcessed ? "already_processed" : "credited",
           },
         );
-        phLogger.event(
-          PAID_FUNNEL_EVENTS.addCreditCheckoutSucceeded,
-          paidFunnelProperties({
-            userId,
-            checkout_attempt_id: session.metadata.checkoutAttemptId,
-            checkout_type: "extra_usage_purchase",
-            amount_dollars: amountDollars,
-            stripe_customer_id: stripeCustomerId,
-            stripe_checkout_session_id: session.id,
-            stripe_payment_intent_id: stripePaymentIntentId,
-            payment_status: session.payment_status,
-            $insert_id: `${PAID_FUNNEL_EVENTS.addCreditCheckoutSucceeded}:${session.id}`,
-          }),
-        );
-        after(() => phLogger.flush());
+        try {
+          phLogger.event(
+            PAID_FUNNEL_EVENTS.addCreditCheckoutSucceeded,
+            paidFunnelProperties({
+              userId,
+              checkout_attempt_id: session.metadata.checkoutAttemptId,
+              checkout_type: "extra_usage_purchase",
+              amount_dollars: amountDollars,
+              stripe_customer_id: stripeCustomerId,
+              stripe_checkout_session_id: session.id,
+              stripe_payment_intent_id: stripePaymentIntentId,
+              payment_status: session.payment_status,
+              $insert_id: `${PAID_FUNNEL_EVENTS.addCreditCheckoutSucceeded}:${session.id}`,
+            }),
+          );
+          after(() => phLogger.flush());
+        } catch (analyticsError) {
+          logExtraUsagePurchase(
+            "warn",
+            "extra_usage_purchase_analytics_failed",
+            {
+              route: WEBHOOK_LOG_CONTEXT.route,
+              requestHeaders: req.headers,
+              userId,
+              amountDollars,
+              stripeCheckoutSessionId: session.id,
+              stripePaymentIntentId,
+              stripeInvoiceId,
+              paymentStatus: session.payment_status,
+              result: result.alreadyProcessed
+                ? "already_processed"
+                : "credited",
+              error: analyticsError,
+            },
+          );
+        }
       } catch (error) {
         try {
           await convex.mutation(api.extraUsage.recordPurchaseFailed, {

--- a/app/api/extra-usage/webhook/route.ts
+++ b/app/api/extra-usage/webhook/route.ts
@@ -40,7 +40,8 @@ function errorMessage(error: unknown): string {
  * Configure this webhook in Stripe Dashboard:
  * - Endpoint URL: https://your-domain.com/api/extra-usage/webhook
  * - Events to listen: checkout.session.completed,
- *   checkout.session.async_payment_succeeded
+ *   checkout.session.async_payment_succeeded,
+ *   checkout.session.async_payment_failed
  */
 export async function POST(req: NextRequest) {
   const body = await req.text();
@@ -93,7 +94,8 @@ export async function POST(req: NextRequest) {
   // Handle the event
   switch (event.type) {
     case "checkout.session.completed":
-    case "checkout.session.async_payment_succeeded": {
+    case "checkout.session.async_payment_succeeded":
+    case "checkout.session.async_payment_failed": {
       const session = event.data.object as Stripe.Checkout.Session;
       // Only process extra usage purchases
       if (session.metadata?.type !== "extra_usage_purchase") {
@@ -119,10 +121,7 @@ export async function POST(req: NextRequest) {
           paymentStatus: session.payment_status,
           reason: "invalid_session_metadata",
         });
-        return NextResponse.json(
-          { error: "Invalid session metadata" },
-          { status: 400 },
-        );
+        return NextResponse.json({ received: true });
       }
 
       logExtraUsagePurchase("info", "extra_usage_purchase_session_seen", {
@@ -136,6 +135,57 @@ export async function POST(req: NextRequest) {
         paymentStatus: session.payment_status,
         result: "session_seen",
       });
+
+      const convex = getConvexClient();
+      if (event.type === "checkout.session.async_payment_failed") {
+        try {
+          await convex.mutation(api.extraUsage.recordPurchaseFailed, {
+            serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+            userId,
+            amountDollars,
+            stripeCheckoutSessionId: session.id,
+            stripePaymentIntentId,
+            stripeInvoiceId,
+            route: "webhook",
+            lastError: "stripe_async_payment_failed",
+          });
+        } catch (recordError) {
+          logExtraUsagePurchase(
+            "error",
+            "extra_usage_purchase_failure_record_failed",
+            {
+              route: WEBHOOK_LOG_CONTEXT.route,
+              requestHeaders: req.headers,
+              userId,
+              amountDollars,
+              stripeCheckoutSessionId: session.id,
+              stripePaymentIntentId,
+              stripeInvoiceId,
+              paymentStatus: session.payment_status,
+              result: "failure_record_failed",
+              error: recordError,
+            },
+          );
+          return NextResponse.json(
+            { error: "Failed to record payment failure" },
+            { status: 500 },
+          );
+        }
+
+        logExtraUsagePurchase("warn", "extra_usage_purchase_payment_failed", {
+          route: WEBHOOK_LOG_CONTEXT.route,
+          requestHeaders: req.headers,
+          userId,
+          amountDollars,
+          stripeCheckoutSessionId: session.id,
+          stripePaymentIntentId,
+          stripeInvoiceId,
+          paymentStatus: session.payment_status,
+          result: "failed",
+          reason: "stripe_async_payment_failed",
+        });
+        return NextResponse.json({ received: true });
+      }
 
       if (session.payment_status !== "paid") {
         logExtraUsagePurchase("info", "extra_usage_purchase_payment_pending", {
@@ -155,7 +205,6 @@ export async function POST(req: NextRequest) {
       // Add credits to user's balance. Idempotency key is scoped to the Checkout
       // Session so this path and the post-checkout confirm redirect (which uses
       // the same key) can race without double-crediting.
-      const convex = getConvexClient();
       try {
         await convex.mutation(api.extraUsage.recordPurchasePaidSeen, {
           serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,

--- a/app/api/extra-usage/webhook/route.ts
+++ b/app/api/extra-usage/webhook/route.ts
@@ -12,12 +12,26 @@ import {
   logStripeWebhookMissingSignature,
   logStripeWebhookSignatureVerificationFailed,
 } from "@/lib/billing/stripe-webhook-logging";
+import { logExtraUsagePurchase } from "@/lib/billing/extra-usage-purchase-logging";
 
 const WEBHOOK_LOG_PREFIX = "[Extra Usage Webhook]";
 const WEBHOOK_LOG_CONTEXT = {
   webhook: "extra_usage",
   route: "/api/extra-usage/webhook",
-};
+} as const;
+
+function stripeObjectId(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && "id" in value) {
+    const id = (value as { id?: unknown }).id;
+    return typeof id === "string" ? id : undefined;
+  }
+  return undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 /**
  * POST /api/extra-usage/webhook
@@ -25,7 +39,8 @@ const WEBHOOK_LOG_CONTEXT = {
  *
  * Configure this webhook in Stripe Dashboard:
  * - Endpoint URL: https://your-domain.com/api/extra-usage/webhook
- * - Events to listen: checkout.session.completed
+ * - Events to listen: checkout.session.completed,
+ *   checkout.session.async_payment_succeeded
  */
 export async function POST(req: NextRequest) {
   const body = await req.text();
@@ -77,7 +92,8 @@ export async function POST(req: NextRequest) {
 
   // Handle the event
   switch (event.type) {
-    case "checkout.session.completed": {
+    case "checkout.session.completed":
+    case "checkout.session.async_payment_succeeded": {
       const session = event.data.object as Stripe.Checkout.Session;
       // Only process extra usage purchases
       if (session.metadata?.type !== "extra_usage_purchase") {
@@ -89,48 +105,99 @@ export async function POST(req: NextRequest) {
       const amountDollars = session.metadata.amountDollars
         ? parseFloat(session.metadata.amountDollars)
         : parseInt(session.metadata.amountCents, 10) / 100;
+      const stripeCustomerId = stripeObjectId(session.customer);
+      const stripePaymentIntentId = stripeObjectId(session.payment_intent);
+      const stripeInvoiceId = stripeObjectId(session.invoice);
 
-      if (!userId || isNaN(amountDollars)) {
-        console.error(
-          "[Extra Usage Webhook] Invalid metadata in checkout session:",
-          session.id,
-        );
+      if (!userId || isNaN(amountDollars) || amountDollars <= 0) {
+        logExtraUsagePurchase("warn", "extra_usage_purchase_invalid_metadata", {
+          route: WEBHOOK_LOG_CONTEXT.route,
+          requestHeaders: req.headers,
+          stripeCheckoutSessionId: session.id,
+          stripePaymentIntentId,
+          stripeInvoiceId,
+          paymentStatus: session.payment_status,
+          reason: "invalid_session_metadata",
+        });
         return NextResponse.json(
           { error: "Invalid session metadata" },
           { status: 400 },
         );
       }
 
+      logExtraUsagePurchase("info", "extra_usage_purchase_session_seen", {
+        route: WEBHOOK_LOG_CONTEXT.route,
+        requestHeaders: req.headers,
+        userId,
+        amountDollars,
+        stripeCheckoutSessionId: session.id,
+        stripePaymentIntentId,
+        stripeInvoiceId,
+        paymentStatus: session.payment_status,
+        result: "session_seen",
+      });
+
+      if (session.payment_status !== "paid") {
+        logExtraUsagePurchase("info", "extra_usage_purchase_payment_pending", {
+          route: WEBHOOK_LOG_CONTEXT.route,
+          requestHeaders: req.headers,
+          userId,
+          amountDollars,
+          stripeCheckoutSessionId: session.id,
+          stripePaymentIntentId,
+          stripeInvoiceId,
+          paymentStatus: session.payment_status,
+          result: "payment_pending",
+        });
+        return NextResponse.json({ received: true });
+      }
+
       // Add credits to user's balance. Idempotency key is scoped to the Checkout
       // Session so this path and the post-checkout confirm redirect (which uses
       // the same key) can race without double-crediting.
+      const convex = getConvexClient();
       try {
-        const result = await getConvexClient().mutation(
-          api.extraUsage.addCredits,
+        await convex.mutation(api.extraUsage.recordPurchasePaidSeen, {
+          serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+          userId,
+          amountDollars,
+          stripeCheckoutSessionId: session.id,
+          stripePaymentIntentId,
+          stripeInvoiceId,
+          route: "webhook",
+        });
+
+        const result = await convex.mutation(api.extraUsage.addCredits, {
+          serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+          userId,
+          amountDollars,
+          idempotencyKey: `cs_${session.id}`,
+          legacyIdempotencyKey: event.id, // Guards retries of pre-deploy webhooks that stored `evt_<id>`
+          revenueSource: "extra_usage_purchase",
+          stripeCustomerId,
+          stripeCheckoutSessionId: session.id,
+          stripePaymentIntentId,
+          stripeInvoiceId,
+          purchaseRoute: "webhook",
+        });
+
+        logExtraUsagePurchase(
+          "info",
+          result.alreadyProcessed
+            ? "extra_usage_purchase_credit_skipped"
+            : "extra_usage_purchase_credit_succeeded",
           {
-            serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+            route: WEBHOOK_LOG_CONTEXT.route,
+            requestHeaders: req.headers,
             userId,
             amountDollars,
-            idempotencyKey: `cs_${session.id}`,
-            legacyIdempotencyKey: event.id, // Guards retries of pre-deploy webhooks that stored `evt_<id>`
-            revenueSource: "extra_usage_purchase",
-            stripeCustomerId:
-              typeof session.customer === "string"
-                ? session.customer
-                : session.customer?.id,
             stripeCheckoutSessionId: session.id,
-            stripePaymentIntentId:
-              typeof session.payment_intent === "string"
-                ? session.payment_intent
-                : session.payment_intent?.id,
+            stripePaymentIntentId,
+            stripeInvoiceId,
+            paymentStatus: session.payment_status,
+            result: result.alreadyProcessed ? "already_processed" : "credited",
           },
         );
-
-        if (result.alreadyProcessed) {
-          console.log(
-            `[Extra Usage Webhook] Checkout session ${session.id} already processed, skipping`,
-          );
-        }
         phLogger.event(
           PAID_FUNNEL_EVENTS.addCreditCheckoutSucceeded,
           paidFunnelProperties({
@@ -138,22 +205,57 @@ export async function POST(req: NextRequest) {
             checkout_attempt_id: session.metadata.checkoutAttemptId,
             checkout_type: "extra_usage_purchase",
             amount_dollars: amountDollars,
-            stripe_customer_id:
-              typeof session.customer === "string"
-                ? session.customer
-                : session.customer?.id,
+            stripe_customer_id: stripeCustomerId,
             stripe_checkout_session_id: session.id,
-            stripe_payment_intent_id:
-              typeof session.payment_intent === "string"
-                ? session.payment_intent
-                : session.payment_intent?.id,
+            stripe_payment_intent_id: stripePaymentIntentId,
             payment_status: session.payment_status,
             $insert_id: `${PAID_FUNNEL_EVENTS.addCreditCheckoutSucceeded}:${session.id}`,
           }),
         );
         after(() => phLogger.flush());
       } catch (error) {
-        console.error("[Extra Usage Webhook] FAILED to add credits:", error);
+        try {
+          await convex.mutation(api.extraUsage.recordPurchaseFailed, {
+            serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+            userId,
+            amountDollars,
+            stripeCheckoutSessionId: session.id,
+            stripePaymentIntentId,
+            stripeInvoiceId,
+            route: "webhook",
+            lastError: errorMessage(error),
+          });
+        } catch (recordError) {
+          logExtraUsagePurchase(
+            "error",
+            "extra_usage_purchase_failure_record_failed",
+            {
+              route: WEBHOOK_LOG_CONTEXT.route,
+              requestHeaders: req.headers,
+              userId,
+              amountDollars,
+              stripeCheckoutSessionId: session.id,
+              stripePaymentIntentId,
+              stripeInvoiceId,
+              paymentStatus: session.payment_status,
+              result: "failure_record_failed",
+              error: recordError,
+            },
+          );
+        }
+
+        logExtraUsagePurchase("error", "extra_usage_purchase_credit_failed", {
+          route: WEBHOOK_LOG_CONTEXT.route,
+          requestHeaders: req.headers,
+          userId,
+          amountDollars,
+          stripeCheckoutSessionId: session.id,
+          stripePaymentIntentId,
+          stripeInvoiceId,
+          paymentStatus: session.payment_status,
+          result: "failed",
+          error,
+        });
         // Return 500 so Stripe retries
         return NextResponse.json(
           { error: "Failed to add credits" },

--- a/convex/__tests__/extraUsageActionsAuth.test.ts
+++ b/convex/__tests__/extraUsageActionsAuth.test.ts
@@ -96,6 +96,7 @@ function makeCtx(userId = "user_member") {
     auth: {
       getUserIdentity: jest.fn(async () => ({ subject: userId })),
     },
+    runMutation: jest.fn(async () => null),
   };
 }
 
@@ -193,6 +194,34 @@ describe("extraUsageActions billing authorization", () => {
         metadata: expect.objectContaining({
           userId: "user_admin",
         }),
+      }),
+    );
+    expect(result).toEqual({
+      url: "https://checkout.stripe.test/session",
+      checkoutSessionId: "cs_test",
+    });
+  });
+
+  it("records the purchase row after creating a Checkout session", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          status: "active",
+          role: { slug: "admin" },
+        },
+      ],
+    } as never);
+
+    const ctx = makeCtx("user_admin");
+    const result = await callCreatePurchaseSession(ctx);
+
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        userId: "user_admin",
+        amountDollars: 15,
+        stripeCheckoutSessionId: "cs_test",
       }),
     );
     expect(result).toEqual({

--- a/convex/__tests__/extraUsageActionsAuth.test.ts
+++ b/convex/__tests__/extraUsageActionsAuth.test.ts
@@ -215,15 +215,38 @@ describe("extraUsageActions billing authorization", () => {
 
     const ctx = makeCtx("user_admin");
     const result = await callCreatePurchaseSession(ctx);
+    const { internal } = await import("../_generated/api");
 
     expect(ctx.runMutation).toHaveBeenCalledWith(
-      expect.anything(),
+      internal.extraUsage.recordPurchaseCreated,
       expect.objectContaining({
         userId: "user_admin",
         amountDollars: 15,
         stripeCheckoutSessionId: "cs_test",
       }),
     );
+    expect(result).toEqual({
+      url: "https://checkout.stripe.test/session",
+      checkoutSessionId: "cs_test",
+    });
+  });
+
+  it("still returns the Checkout session when purchase recording fails", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          status: "active",
+          role: { slug: "admin" },
+        },
+      ],
+    } as never);
+
+    const ctx = makeCtx("user_admin");
+    ctx.runMutation.mockRejectedValueOnce(new Error("Convex unavailable"));
+
+    const result = await callCreatePurchaseSession(ctx);
+
     expect(result).toEqual({
       url: "https://checkout.stripe.test/session",
       checkoutSessionId: "cs_test",

--- a/convex/__tests__/extraUsagePurchases.test.ts
+++ b/convex/__tests__/extraUsagePurchases.test.ts
@@ -46,6 +46,20 @@ type Row = { _id: string; [key: string]: any };
 type Tables = Record<string, Row[]>;
 
 const SERVICE_KEY = "service_key";
+const INDEX_FIELDS: Record<string, Record<string, string[]>> = {
+  extra_usage: {
+    by_user_id: ["user_id"],
+  },
+  extra_usage_purchases: {
+    by_stripe_checkout_session_id: ["stripe_checkout_session_id"],
+  },
+  processed_checkout_sessions: {
+    by_session_key: ["session_key"],
+  },
+  processed_webhooks: {
+    by_event_id: ["event_id"],
+  },
+};
 
 function createQueryResult(rows: Row[]) {
   return {
@@ -67,15 +81,20 @@ function createQueryBuilder(tables: Tables, table: string) {
     );
 
   return {
-    withIndex: jest.fn((_indexName: string, build: (q: any) => any) => {
+    withIndex: jest.fn((indexName: string, build: (q: any) => any) => {
+      const expectedFields = INDEX_FIELDS[table]?.[indexName];
+      expect(expectedFields).toBeDefined();
+
       const filters: Array<{ field: string; value: any }> = [];
       const q = {
         eq: (field: string, value: any) => {
+          expect(field).toBe(expectedFields![filters.length]);
           filters.push({ field, value });
           return q;
         },
       };
       build(q);
+      expect(filters.map(({ field }) => field)).toEqual(expectedFields);
       return createQueryResult(filterRows(filters));
     }),
   };

--- a/convex/__tests__/extraUsagePurchases.test.ts
+++ b/convex/__tests__/extraUsagePurchases.test.ts
@@ -1,0 +1,311 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+
+jest.mock("../_generated/server", () => ({
+  mutation: jest.fn((config: any) => config),
+  internalMutation: jest.fn((config: any) => config),
+  query: jest.fn((config: any) => config),
+}));
+
+jest.mock("convex/values", () => ({
+  v: new Proxy(
+    {},
+    {
+      get: () => jest.fn(() => "validator"),
+    },
+  ),
+}));
+
+jest.mock("../lib/utils", () => ({
+  validateServiceKey: jest.fn(),
+}));
+
+jest.mock("../lib/logger", () => ({
+  convexLogger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockRecordRevenueEventInternal = jest.fn(async () => ({
+  alreadyRecorded: false,
+}));
+
+jest.mock("../unitEconomicsLib", () => ({
+  recordRevenueEventInternal: mockRecordRevenueEventInternal,
+}));
+
+type Row = { _id: string; [key: string]: any };
+type Tables = Record<string, Row[]>;
+
+const SERVICE_KEY = "service_key";
+
+function createQueryResult(rows: Row[]) {
+  return {
+    first: jest.fn(async () => rows[0] ?? null),
+    unique: jest.fn(async () => {
+      if (rows.length > 1) {
+        throw new Error(`Expected one row, found ${rows.length}`);
+      }
+      return rows[0] ?? null;
+    }),
+  };
+}
+
+function createQueryBuilder(tables: Tables, table: string) {
+  const tableRows = () => tables[table] ?? [];
+  const filterRows = (filters: Array<{ field: string; value: any }>) =>
+    tableRows().filter((row) =>
+      filters.every(({ field, value }) => row[field] === value),
+    );
+
+  return {
+    withIndex: jest.fn((_indexName: string, build: (q: any) => any) => {
+      const filters: Array<{ field: string; value: any }> = [];
+      const q = {
+        eq: (field: string, value: any) => {
+          filters.push({ field, value });
+          return q;
+        },
+      };
+      build(q);
+      return createQueryResult(filterRows(filters));
+    }),
+  };
+}
+
+function createMockCtx(initialTables: Partial<Tables> = {}) {
+  const tables: Tables = {
+    extra_usage: [],
+    extra_usage_purchases: [],
+    processed_checkout_sessions: [],
+    processed_webhooks: [],
+    ...initialTables,
+  };
+
+  const db = {
+    query: jest.fn((table: string) => createQueryBuilder(tables, table)),
+    insert: jest.fn(async (table: string, doc: Record<string, any>) => {
+      const row = { _id: `${table}-${tables[table]?.length ?? 0}`, ...doc };
+      tables[table] ??= [];
+      tables[table].push(row);
+      return row._id;
+    }),
+    patch: jest.fn(async (id: string, patch: Record<string, any>) => {
+      for (const rows of Object.values(tables)) {
+        const row = rows.find((candidate) => candidate._id === id);
+        if (!row) continue;
+        for (const [key, value] of Object.entries(patch)) {
+          if (value === undefined) {
+            delete row[key];
+          } else {
+            row[key] = value;
+          }
+        }
+      }
+    }),
+  };
+
+  return { ctx: { db }, tables, db };
+}
+
+async function callRecordPurchaseCreated(ctx: any) {
+  const { recordPurchaseCreated } = await import("../extraUsage");
+  return (recordPurchaseCreated as any).handler(ctx, {
+    userId: "user_123",
+    amountDollars: 50,
+    stripeCheckoutSessionId: "cs_test",
+  });
+}
+
+async function callRecordPurchaseFailed(ctx: any) {
+  const { recordPurchaseFailed } = await import("../extraUsage");
+  return (recordPurchaseFailed as any).handler(ctx, {
+    serviceKey: SERVICE_KEY,
+    userId: "user_123",
+    amountDollars: 50,
+    stripeCheckoutSessionId: "cs_test",
+    stripePaymentIntentId: "pi_test",
+    stripeInvoiceId: "in_test",
+    route: "webhook",
+    lastError: "serviceKey: secret-value\nsecond line",
+  });
+}
+
+async function callAddCredits(ctx: any) {
+  const { addCredits } = await import("../extraUsage");
+  return (addCredits as any).handler(ctx, {
+    serviceKey: SERVICE_KEY,
+    userId: "user_123",
+    amountDollars: 50,
+    idempotencyKey: "cs_cs_test",
+    legacyIdempotencyKey: "evt_test",
+    revenueSource: "extra_usage_purchase",
+    stripeCustomerId: "cus_test",
+    stripeCheckoutSessionId: "cs_test",
+    stripePaymentIntentId: "pi_test",
+    stripeInvoiceId: "in_test",
+    purchaseRoute: "confirm",
+  });
+}
+
+describe("extra usage purchase ledger", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, "now").mockReturnValue(1_000_000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("records a created purchase row at Checkout session creation", async () => {
+    const { ctx, tables } = createMockCtx();
+
+    await callRecordPurchaseCreated(ctx);
+
+    expect(tables.extra_usage_purchases).toHaveLength(1);
+    expect(tables.extra_usage_purchases[0]).toMatchObject({
+      user_id: "user_123",
+      amount_dollars: 50,
+      stripe_checkout_session_id: "cs_test",
+      status: "created",
+      last_route: "checkout_action",
+      last_result: "created",
+      created_at: 1_000_000,
+      updated_at: 1_000_000,
+    });
+  });
+
+  it("marks a newly credited purchase after balance and revenue writes succeed", async () => {
+    const { ctx, tables } = createMockCtx({
+      extra_usage_purchases: [
+        {
+          _id: "purchase-1",
+          user_id: "user_123",
+          amount_dollars: 50,
+          stripe_checkout_session_id: "cs_test",
+          status: "paid_seen",
+          last_route: "confirm",
+          last_result: "paid_seen",
+          created_at: 900_000,
+          updated_at: 900_000,
+        },
+      ],
+    });
+
+    const result = await callAddCredits(ctx);
+
+    expect(result).toEqual({ newBalance: 50, alreadyProcessed: false });
+    expect(tables.extra_usage).toMatchObject([
+      {
+        user_id: "user_123",
+        balance_points: 500_000,
+        updated_at: 1_000_000,
+      },
+    ]);
+    expect(tables.processed_checkout_sessions).toMatchObject([
+      { session_key: "cs_cs_test", processed_at: 1_000_000 },
+    ]);
+    expect(tables.processed_webhooks).toMatchObject([
+      { event_id: "cs_cs_test", processed_at: 1_000_000 },
+    ]);
+    expect(tables.extra_usage_purchases[0]).toMatchObject({
+      status: "credited",
+      last_route: "confirm",
+      last_result: "credited",
+      stripe_payment_intent_id: "pi_test",
+      stripe_invoice_id: "in_test",
+      credited_at: 1_000_000,
+      updated_at: 1_000_000,
+    });
+    expect(mockRecordRevenueEventInternal).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        source: "extra_usage",
+        stripeCheckoutSessionId: "cs_test",
+        stripePaymentIntentId: "pi_test",
+        stripeInvoiceId: "in_test",
+        grossRevenueDollars: 50,
+      }),
+    );
+  });
+
+  it("marks duplicate Checkout sessions as credited but already processed", async () => {
+    const { ctx, tables } = createMockCtx({
+      extra_usage: [
+        {
+          _id: "extra-1",
+          user_id: "user_123",
+          balance_points: 1_000,
+          updated_at: 900_000,
+        },
+      ],
+      extra_usage_purchases: [
+        {
+          _id: "purchase-1",
+          user_id: "user_123",
+          amount_dollars: 50,
+          stripe_checkout_session_id: "cs_test",
+          status: "paid_seen",
+          created_at: 900_000,
+          updated_at: 900_000,
+        },
+      ],
+      processed_checkout_sessions: [
+        {
+          _id: "processed-1",
+          session_key: "cs_cs_test",
+          processed_at: 950_000,
+        },
+      ],
+    });
+
+    const result = await callAddCredits(ctx);
+
+    expect(result).toEqual({ newBalance: 0, alreadyProcessed: true });
+    expect(tables.extra_usage[0].balance_points).toBe(1_000);
+    expect(tables.extra_usage_purchases[0]).toMatchObject({
+      status: "credited",
+      last_route: "confirm",
+      last_result: "already_processed",
+      credited_at: 950_000,
+    });
+    expect(mockRecordRevenueEventInternal).not.toHaveBeenCalled();
+  });
+
+  it("records sanitized failed credit attempts without sensitive error text", async () => {
+    const { ctx, tables } = createMockCtx({
+      extra_usage_purchases: [
+        {
+          _id: "purchase-1",
+          user_id: "user_123",
+          amount_dollars: 50,
+          stripe_checkout_session_id: "cs_test",
+          status: "paid_seen",
+          created_at: 900_000,
+          updated_at: 900_000,
+        },
+      ],
+    });
+
+    await callRecordPurchaseFailed(ctx);
+
+    expect(tables.extra_usage_purchases[0]).toMatchObject({
+      status: "failed",
+      last_route: "webhook",
+      last_result: "failed",
+      stripe_payment_intent_id: "pi_test",
+      stripe_invoice_id: "in_test",
+      last_error: "serviceKey: [redacted]",
+      updated_at: 1_000_000,
+    });
+  });
+});

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -427,6 +427,26 @@ function seedTables(userId = "user_123", otherUserId = "user_other"): Tables {
         source: "subscription",
       },
     ],
+    extra_usage_purchases: [
+      {
+        _id: "purchase-user",
+        user_id: userId,
+        amount_dollars: 50,
+        stripe_checkout_session_id: "cs_user",
+        status: "credited",
+        created_at: 1,
+        updated_at: 1,
+      },
+      {
+        _id: "purchase-other",
+        user_id: otherUserId,
+        amount_dollars: 50,
+        stripe_checkout_session_id: "cs_other",
+        status: "credited",
+        created_at: 1,
+        updated_at: 1,
+      },
+    ],
     paid_start_events: [
       {
         _id: "paid-user-entity",
@@ -558,6 +578,16 @@ describe("userDeletion", () => {
     expect(
       row(tables, "revenue_events", "revenue-org-with-user")?.user_id,
     ).toBeUndefined();
+    expect(row(tables, "extra_usage_purchases", "purchase-user")).toMatchObject(
+      {
+        user_id: DELETED_USER_ID,
+      },
+    );
+    expect(
+      row(tables, "extra_usage_purchases", "purchase-other"),
+    ).toMatchObject({
+      user_id: "user_other",
+    });
     expect(row(tables, "paid_start_events", "paid-user-entity")).toMatchObject({
       entity_id: DELETED_USER_ID,
     });

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -40,12 +40,25 @@ type ExtraUsagePurchaseResult =
   | "failed";
 
 const MAX_PURCHASE_ERROR_LENGTH = 500;
-const PURCHASE_ERROR_SECRET_PATTERN =
-  /\b(?:serviceKey|service_key|apiKey|api_key|authorization|bearer|cookie|password|secret|token)\b\s*[:=]\s*("[^"]*"|'[^']*'|[^\s,}]+)/gi;
+const PURCHASE_JSON_SECRET_PATTERN =
+  /(["'])(serviceKey|service_key|apiKey|api_key|authorization|cookie|password|secret|token)\1\s*:\s*(["'])(?:(?!\3).)*\3/gi;
+const PURCHASE_ASSIGNMENT_SECRET_PATTERN =
+  /\b(serviceKey|service_key|apiKey|api_key|cookie|password|secret|token)\b\s*[:=]\s*("[^"]*"|'[^']*'|[^\s,}]+)/gi;
+const PURCHASE_AUTHORIZATION_BEARER_PATTERN =
+  /\bAuthorization\s*[:=]\s*Bearer\s+[^\s,}]+/gi;
+const PURCHASE_BEARER_TOKEN_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
 
 const sanitizePurchaseError = (error: string): string =>
   error
-    .replace(PURCHASE_ERROR_SECRET_PATTERN, (match) => {
+    .replace(
+      PURCHASE_AUTHORIZATION_BEARER_PATTERN,
+      "Authorization: Bearer [redacted]",
+    )
+    .replace(PURCHASE_JSON_SECRET_PATTERN, (_match, quote, key) => {
+      return `${quote}${key}${quote}: "[redacted]"`;
+    })
+    .replace(PURCHASE_BEARER_TOKEN_PATTERN, "Bearer [redacted]")
+    .replace(PURCHASE_ASSIGNMENT_SECRET_PATTERN, (match) => {
       const separatorIndex = Math.max(match.indexOf(":"), match.indexOf("="));
       if (separatorIndex === -1) return "[redacted]";
       return `${match.slice(0, separatorIndex + 1)} [redacted]`;
@@ -75,7 +88,7 @@ async function upsertExtraUsagePurchase(
     .withIndex("by_stripe_checkout_session_id", (q) =>
       q.eq("stripe_checkout_session_id", args.stripeCheckoutSessionId),
     )
-    .first();
+    .unique();
 
   const keepCredited =
     existing?.status === "credited" && args.status !== "credited";

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -1,4 +1,9 @@
-import { internalMutation, mutation, query } from "./_generated/server";
+import {
+  internalMutation,
+  mutation,
+  query,
+  type MutationCtx,
+} from "./_generated/server";
 import { v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 import { convexLogger } from "./lib/logger";
@@ -20,6 +25,98 @@ const dollarsToPoints = (dollars: number): number =>
 
 /** Convert points to dollars (for API response) */
 const pointsToDollars = (points: number): number => points / POINTS_PER_DOLLAR;
+
+type ExtraUsagePurchaseStatus = "created" | "paid_seen" | "credited" | "failed";
+type ExtraUsagePurchaseRoute =
+  | "checkout_action"
+  | "confirm"
+  | "webhook"
+  | "repair";
+type ExtraUsagePurchaseResult =
+  | "created"
+  | "paid_seen"
+  | "credited"
+  | "already_processed"
+  | "failed";
+
+const MAX_PURCHASE_ERROR_LENGTH = 500;
+const PURCHASE_ERROR_SECRET_PATTERN =
+  /\b(?:serviceKey|service_key|apiKey|api_key|authorization|bearer|cookie|password|secret|token)\b\s*[:=]\s*("[^"]*"|'[^']*'|[^\s,}]+)/gi;
+
+const sanitizePurchaseError = (error: string): string =>
+  error
+    .replace(PURCHASE_ERROR_SECRET_PATTERN, (match) => {
+      const separatorIndex = Math.max(match.indexOf(":"), match.indexOf("="));
+      if (separatorIndex === -1) return "[redacted]";
+      return `${match.slice(0, separatorIndex + 1)} [redacted]`;
+    })
+    .split("\n", 1)[0]
+    .trim()
+    .slice(0, MAX_PURCHASE_ERROR_LENGTH);
+
+async function upsertExtraUsagePurchase(
+  ctx: MutationCtx,
+  args: {
+    userId: string;
+    amountDollars: number;
+    stripeCheckoutSessionId: string;
+    stripePaymentIntentId?: string;
+    stripeInvoiceId?: string;
+    status: ExtraUsagePurchaseStatus;
+    route: ExtraUsagePurchaseRoute;
+    result: ExtraUsagePurchaseResult;
+    lastError?: string | null;
+    creditedAt?: number;
+  },
+) {
+  const now = Date.now();
+  const existing = await ctx.db
+    .query("extra_usage_purchases")
+    .withIndex("by_stripe_checkout_session_id", (q) =>
+      q.eq("stripe_checkout_session_id", args.stripeCheckoutSessionId),
+    )
+    .first();
+
+  const keepCredited =
+    existing?.status === "credited" && args.status !== "credited";
+  const next: Record<string, unknown> = {
+    user_id: args.userId,
+    amount_dollars: args.amountDollars,
+    stripe_checkout_session_id: args.stripeCheckoutSessionId,
+    stripe_payment_intent_id:
+      args.stripePaymentIntentId ?? existing?.stripe_payment_intent_id,
+    stripe_invoice_id: args.stripeInvoiceId ?? existing?.stripe_invoice_id,
+    status: keepCredited ? "credited" : args.status,
+    last_route: keepCredited ? existing?.last_route : args.route,
+    last_result: keepCredited ? existing?.last_result : args.result,
+    updated_at: now,
+  };
+
+  if (!keepCredited) {
+    if (args.lastError !== undefined) {
+      next.last_error =
+        args.lastError === null
+          ? undefined
+          : sanitizePurchaseError(args.lastError);
+    } else if (args.status !== "failed") {
+      next.last_error = undefined;
+    }
+  }
+
+  if (args.status === "credited") {
+    next.credited_at = existing?.credited_at ?? args.creditedAt ?? now;
+  }
+
+  if (existing) {
+    await ctx.db.patch(existing._id, next);
+    return existing._id;
+  }
+
+  return await ctx.db.insert("extra_usage_purchases", {
+    ...next,
+    created_at: now,
+  } as any);
+}
 
 // =============================================================================
 // Webhook Idempotency
@@ -217,6 +314,106 @@ export const finalizeWebhookProcessing = mutation({
 // =============================================================================
 
 /**
+ * Record the Stripe Checkout session as soon as it is created. Internal because
+ * authenticated Convex actions are the only callers at creation time.
+ */
+export const recordPurchaseCreated = internalMutation({
+  args: {
+    userId: v.string(),
+    amountDollars: v.number(),
+    stripeCheckoutSessionId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await upsertExtraUsagePurchase(ctx, {
+      userId: args.userId,
+      amountDollars: args.amountDollars,
+      stripeCheckoutSessionId: args.stripeCheckoutSessionId,
+      status: "created",
+      route: "checkout_action",
+      result: "created",
+      lastError: null,
+    });
+    return null;
+  },
+});
+
+/**
+ * Mark that a trusted Stripe route observed payment_status=paid before the
+ * actual balance-credit mutation runs.
+ */
+export const recordPurchasePaidSeen = mutation({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+    amountDollars: v.number(),
+    stripeCheckoutSessionId: v.string(),
+    stripePaymentIntentId: v.optional(v.string()),
+    stripeInvoiceId: v.optional(v.string()),
+    route: v.union(
+      v.literal("confirm"),
+      v.literal("webhook"),
+      v.literal("repair"),
+    ),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    await upsertExtraUsagePurchase(ctx, {
+      userId: args.userId,
+      amountDollars: args.amountDollars,
+      stripeCheckoutSessionId: args.stripeCheckoutSessionId,
+      stripePaymentIntentId: args.stripePaymentIntentId,
+      stripeInvoiceId: args.stripeInvoiceId,
+      status: "paid_seen",
+      route: args.route,
+      result: "paid_seen",
+      lastError: null,
+    });
+    return null;
+  },
+});
+
+/**
+ * Persist credit failures separately from addCredits so thrown transaction
+ * failures do not erase the support trail.
+ */
+export const recordPurchaseFailed = mutation({
+  args: {
+    serviceKey: v.string(),
+    userId: v.string(),
+    amountDollars: v.number(),
+    stripeCheckoutSessionId: v.string(),
+    stripePaymentIntentId: v.optional(v.string()),
+    stripeInvoiceId: v.optional(v.string()),
+    route: v.union(
+      v.literal("confirm"),
+      v.literal("webhook"),
+      v.literal("repair"),
+    ),
+    lastError: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    await upsertExtraUsagePurchase(ctx, {
+      userId: args.userId,
+      amountDollars: args.amountDollars,
+      stripeCheckoutSessionId: args.stripeCheckoutSessionId,
+      stripePaymentIntentId: args.stripePaymentIntentId,
+      stripeInvoiceId: args.stripeInvoiceId,
+      status: "failed",
+      route: args.route,
+      result: "failed",
+      lastError: args.lastError,
+    });
+    return null;
+  },
+});
+
+/**
  * Add credits to user balance (after successful Stripe payment).
  * Idempotent via optional idempotencyKey (Stripe event ID).
  */
@@ -236,6 +433,10 @@ export const addCredits = mutation({
     stripeCustomerId: v.optional(v.string()),
     stripeCheckoutSessionId: v.optional(v.string()),
     stripePaymentIntentId: v.optional(v.string()),
+    stripeInvoiceId: v.optional(v.string()),
+    purchaseRoute: v.optional(
+      v.union(v.literal("confirm"), v.literal("webhook"), v.literal("repair")),
+    ),
   },
   returns: v.object({
     newBalance: v.number(), // Returns dollars
@@ -243,6 +444,26 @@ export const addCredits = mutation({
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
+
+    const markPurchaseCredited = async (
+      result: "credited" | "already_processed",
+      creditedAt?: number,
+    ) => {
+      if (!args.stripeCheckoutSessionId) return;
+
+      await upsertExtraUsagePurchase(ctx, {
+        userId: args.userId,
+        amountDollars: args.amountDollars,
+        stripeCheckoutSessionId: args.stripeCheckoutSessionId,
+        stripePaymentIntentId: args.stripePaymentIntentId,
+        stripeInvoiceId: args.stripeInvoiceId,
+        status: "credited",
+        route: args.purchaseRoute ?? "repair",
+        result,
+        lastError: null,
+        creditedAt,
+      });
+    };
 
     // Idempotency: skip if already processed (prevents double-credit on webhook retries
     // and across both the post-checkout confirm path and the async webhook path)
@@ -253,6 +474,10 @@ export const addCredits = mutation({
         .withIndex("by_session_key", (q) => q.eq("session_key", sessionKey))
         .unique();
       if (durableExisting) {
+        await markPurchaseCredited(
+          "already_processed",
+          durableExisting.processed_at,
+        );
         return { newBalance: 0, alreadyProcessed: true };
       }
     }
@@ -267,6 +492,7 @@ export const addCredits = mutation({
         .first();
 
       if (existing) {
+        await markPurchaseCredited("already_processed", existing.processed_at);
         return { newBalance: 0, alreadyProcessed: true };
       }
     }
@@ -332,10 +558,13 @@ export const addCredits = mutation({
       currency: "usd",
       attributionStrategy: "direct",
       stripeCustomerId: args.stripeCustomerId,
+      stripeInvoiceId: args.stripeInvoiceId,
       stripeCheckoutSessionId: args.stripeCheckoutSessionId,
       stripePaymentIntentId: args.stripePaymentIntentId,
       description: args.revenueSource ?? "extra_usage_purchase",
     });
+
+    await markPurchaseCredited("credited");
 
     convexLogger.info("credits_added", {
       user_id: args.userId,
@@ -344,6 +573,10 @@ export const addCredits = mutation({
       new_balance_points: newBalancePoints,
       new_balance_dollars: pointsToDollars(newBalancePoints),
       idempotency_key: args.idempotencyKey,
+      stripe_checkout_session_id: args.stripeCheckoutSessionId,
+      stripe_payment_intent_id: args.stripePaymentIntentId,
+      stripe_invoice_id: args.stripeInvoiceId,
+      purchase_route: args.purchaseRoute,
     });
 
     return {

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -422,11 +422,20 @@ export const createPurchaseSession = action({
         cancel_url: args.baseUrl,
       });
 
-      await ctx.runMutation(internal.extraUsage.recordPurchaseCreated, {
-        userId: identity.subject,
-        amountDollars: args.amountDollars,
-        stripeCheckoutSessionId: session.id,
-      });
+      try {
+        await ctx.runMutation(internal.extraUsage.recordPurchaseCreated, {
+          userId: identity.subject,
+          amountDollars: args.amountDollars,
+          stripeCheckoutSessionId: session.id,
+        });
+      } catch (error) {
+        convexLogger.warn("purchase_session_record_failed", {
+          user_id: identity.subject,
+          amount_dollars: args.amountDollars,
+          session_id: session.id,
+          error: serializeErrorForLog(error),
+        });
+      }
 
       convexLogger.info("purchase_session_created", {
         user_id: identity.subject,

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -422,6 +422,12 @@ export const createPurchaseSession = action({
         cancel_url: args.baseUrl,
       });
 
+      await ctx.runMutation(internal.extraUsage.recordPurchaseCreated, {
+        userId: identity.subject,
+        amountDollars: args.amountDollars,
+        stripeCheckoutSessionId: session.id,
+      });
+
       convexLogger.info("purchase_session_created", {
         user_id: identity.subject,
         amount_dollars: args.amountDollars,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -256,6 +256,48 @@ export default defineSchema({
     updated_at: v.number(),
   }).index("by_user_id", ["user_id"]),
 
+  // Durable support ledger for personal extra-usage Checkout purchases. This
+  // complements processed_checkout_sessions: the processed table is only a
+  // dedupe guard, while this row explains the observed purchase lifecycle.
+  extra_usage_purchases: defineTable({
+    user_id: v.string(),
+    amount_dollars: v.number(),
+    stripe_checkout_session_id: v.string(),
+    stripe_payment_intent_id: v.optional(v.string()),
+    stripe_invoice_id: v.optional(v.string()),
+    status: v.union(
+      v.literal("created"),
+      v.literal("paid_seen"),
+      v.literal("credited"),
+      v.literal("failed"),
+    ),
+    last_route: v.optional(
+      v.union(
+        v.literal("checkout_action"),
+        v.literal("confirm"),
+        v.literal("webhook"),
+        v.literal("repair"),
+      ),
+    ),
+    last_result: v.optional(
+      v.union(
+        v.literal("created"),
+        v.literal("paid_seen"),
+        v.literal("credited"),
+        v.literal("already_processed"),
+        v.literal("failed"),
+      ),
+    ),
+    last_error: v.optional(v.string()),
+    credited_at: v.optional(v.number()),
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_user_created_at", ["user_id", "created_at"])
+    .index("by_stripe_checkout_session_id", ["stripe_checkout_session_id"])
+    .index("by_stripe_payment_intent_id", ["stripe_payment_intent_id"])
+    .index("by_stripe_invoice_id", ["stripe_invoice_id"]),
+
   // Team-shared extra usage pool. Admin funds it; any member of the org draws
   // from it for overflow once the team subscription bucket is exhausted.
   // Same units as extra_usage (points; auto-reload amount in dollars).

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -30,6 +30,7 @@ export const USER_DELETION_TABLE_POLICY = {
     "referral_attributions",
     "referral_rewards",
     "revenue_events",
+    "extra_usage_purchases",
     "paid_start_events",
     "unit_economics_daily",
     "user_suspensions",
@@ -353,6 +354,7 @@ async function cleanupUserDataForUser(
     userSuspensions,
     revenueByUser,
     revenueByEntity,
+    extraUsagePurchases,
     paidStartsByUser,
     paidStartsByEntity,
     unitEconomicsByUser,
@@ -420,6 +422,12 @@ async function cleanupUserDataForUser(
       "revenue_events",
       "by_entity_occurred",
       (q) => q.eq("entity_type", "user").eq("entity_id", userId),
+    ),
+    collectByIndex<Doc<"extra_usage_purchases">>(
+      ctx,
+      "extra_usage_purchases",
+      "by_user_created_at",
+      (q) => q.eq("user_id", userId),
     ),
     collectByIndex<Doc<"paid_start_events">>(
       ctx,
@@ -540,6 +548,14 @@ async function cleanupUserDataForUser(
     "revenue_events",
     [...revenueByUser, ...revenueByEntity],
     anonymizeEntityLedger,
+    mode,
+  );
+  await anonymizeDocs(
+    ctx,
+    stats,
+    "extra_usage_purchases",
+    extraUsagePurchases,
+    () => ({ user_id: DELETED_USER_ID, updated_at: now }),
     mode,
   );
   await anonymizeDocs(

--- a/lib/billing/__tests__/extra-usage-purchase-logging.test.ts
+++ b/lib/billing/__tests__/extra-usage-purchase-logging.test.ts
@@ -70,4 +70,21 @@ describe("extra usage purchase logging", () => {
       }),
     );
   });
+
+  it("redacts bearer tokens and JSON-style secrets", () => {
+    logExtraUsagePurchase("error", "extra_usage_purchase_credit_failed", {
+      route: "/api/extra-usage/webhook",
+      requestHeaders: new Headers(),
+      error: new Error(
+        'Authorization: Bearer sk_live_123 {"serviceKey":"abc"}',
+      ),
+    });
+
+    const serializedFields = JSON.stringify(
+      (console.error as jest.Mock).mock.calls[0][1],
+    );
+    expect(serializedFields).toContain("Authorization: Bearer [redacted]");
+    expect(serializedFields).not.toContain("sk_live_123");
+    expect(serializedFields).not.toContain('"serviceKey":"abc"');
+  });
 });

--- a/lib/billing/__tests__/extra-usage-purchase-logging.test.ts
+++ b/lib/billing/__tests__/extra-usage-purchase-logging.test.ts
@@ -1,0 +1,73 @@
+import { logExtraUsagePurchase } from "../extra-usage-purchase-logging";
+
+describe("extra usage purchase logging", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "info").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("logs queryable purchase context without raw secrets", () => {
+    logExtraUsagePurchase("error", "extra_usage_purchase_credit_failed", {
+      route: "/api/extra-usage/confirm",
+      requestHeaders: new Headers({ "x-vercel-id": "iad1::abc123" }),
+      userId: "user_123",
+      amountDollars: 50,
+      stripeCheckoutSessionId: "cs_test",
+      stripePaymentIntentId: "pi_test",
+      stripeInvoiceId: "in_test",
+      paymentStatus: "paid",
+      result: "failed",
+      error: new Error("serviceKey: secret-value\nsecond line"),
+    });
+
+    expect(console.error).toHaveBeenCalledWith(
+      "[Extra Usage Purchase]",
+      expect.objectContaining({
+        event: "extra_usage_purchase_credit_failed",
+        level: "error",
+        service: "hackerai-web",
+        route: "/api/extra-usage/confirm",
+        request_id: "iad1::abc123",
+        user_id: "user_123",
+        amount_dollars: 50,
+        stripe_checkout_session_id: "cs_test",
+        stripe_payment_intent_id: "pi_test",
+        stripe_invoice_id: "in_test",
+        payment_status: "paid",
+        result: "failed",
+        error_name: "Error",
+        error_message: "serviceKey: [redacted]",
+      }),
+    );
+
+    const serializedFields = JSON.stringify(
+      (console.error as jest.Mock).mock.calls[0][1],
+    );
+    expect(serializedFields).not.toContain("secret-value");
+    expect(serializedFields).not.toContain("second line");
+  });
+
+  it("uses info logs for handled route decisions", () => {
+    logExtraUsagePurchase("info", "extra_usage_purchase_credit_skipped", {
+      route: "/api/extra-usage/webhook",
+      requestHeaders: new Headers(),
+      userId: "user_123",
+      stripeCheckoutSessionId: "cs_test",
+      result: "already_processed",
+    });
+
+    expect(console.info).toHaveBeenCalledWith(
+      "[Extra Usage Purchase]",
+      expect.objectContaining({
+        event: "extra_usage_purchase_credit_skipped",
+        level: "info",
+        route: "/api/extra-usage/webhook",
+        result: "already_processed",
+      }),
+    );
+  });
+});

--- a/lib/billing/extra-usage-purchase-logging.ts
+++ b/lib/billing/extra-usage-purchase-logging.ts
@@ -1,0 +1,92 @@
+type ExtraUsagePurchaseLogLevel = "info" | "warn" | "error";
+
+type ExtraUsagePurchaseLogArgs = {
+  route: "/api/extra-usage/confirm" | "/api/extra-usage/webhook";
+  requestHeaders: Headers;
+  userId?: string;
+  amountDollars?: number;
+  stripeCheckoutSessionId?: string;
+  stripePaymentIntentId?: string;
+  stripeInvoiceId?: string;
+  paymentStatus?: string | null;
+  result?: string;
+  reason?: string;
+  error?: unknown;
+};
+
+const MAX_ERROR_MESSAGE_LENGTH = 300;
+const SENSITIVE_ERROR_PATTERN =
+  /\b(?:serviceKey|service_key|apiKey|api_key|authorization|bearer|cookie|password|secret|token)\b\s*[:=]\s*("[^"]*"|'[^']*'|[^\s,}]+)/gi;
+
+function requestId(headers: Headers): string | undefined {
+  return (
+    headers.get("x-vercel-id") ??
+    headers.get("x-request-id") ??
+    headers.get("cf-ray") ??
+    undefined
+  );
+}
+
+function sanitizeErrorMessage(message: string): string | undefined {
+  const sanitized = message
+    .replace(SENSITIVE_ERROR_PATTERN, (match) => {
+      const separatorIndex = Math.max(match.indexOf(":"), match.indexOf("="));
+      if (separatorIndex === -1) return "[redacted]";
+      return `${match.slice(0, separatorIndex + 1)} [redacted]`;
+    })
+    .split("\n", 1)[0]
+    .trim();
+
+  return sanitized ? sanitized.slice(0, MAX_ERROR_MESSAGE_LENGTH) : undefined;
+}
+
+function errorDetails(error: unknown): {
+  error_name?: string;
+  error_message?: string;
+} {
+  if (!error) return {};
+
+  if (error instanceof Error) {
+    return {
+      error_name: error.name || undefined,
+      error_message: sanitizeErrorMessage(error.message),
+    };
+  }
+
+  return {
+    error_message: sanitizeErrorMessage(String(error)),
+  };
+}
+
+export function logExtraUsagePurchase(
+  level: ExtraUsagePurchaseLogLevel,
+  event: string,
+  args: ExtraUsagePurchaseLogArgs,
+): void {
+  const logFields = {
+    timestamp: new Date().toISOString(),
+    level,
+    event,
+    service: "hackerai-web",
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+    route: args.route,
+    request_id: requestId(args.requestHeaders),
+    user_id: args.userId,
+    amount_dollars: args.amountDollars,
+    stripe_checkout_session_id: args.stripeCheckoutSessionId,
+    stripe_payment_intent_id: args.stripePaymentIntentId,
+    stripe_invoice_id: args.stripeInvoiceId,
+    payment_status: args.paymentStatus,
+    result: args.result,
+    reason: args.reason,
+    ...errorDetails(args.error),
+  };
+
+  if (level === "error") {
+    console.error("[Extra Usage Purchase]", logFields);
+  } else if (level === "warn") {
+    console.warn("[Extra Usage Purchase]", logFields);
+  } else {
+    console.info("[Extra Usage Purchase]", logFields);
+  }
+}

--- a/lib/billing/extra-usage-purchase-logging.ts
+++ b/lib/billing/extra-usage-purchase-logging.ts
@@ -15,8 +15,13 @@ type ExtraUsagePurchaseLogArgs = {
 };
 
 const MAX_ERROR_MESSAGE_LENGTH = 300;
-const SENSITIVE_ERROR_PATTERN =
-  /\b(?:serviceKey|service_key|apiKey|api_key|authorization|bearer|cookie|password|secret|token)\b\s*[:=]\s*("[^"]*"|'[^']*'|[^\s,}]+)/gi;
+const JSON_SECRET_PATTERN =
+  /(["'])(serviceKey|service_key|apiKey|api_key|authorization|cookie|password|secret|token)\1\s*:\s*(["'])(?:(?!\3).)*\3/gi;
+const ASSIGNMENT_SECRET_PATTERN =
+  /\b(serviceKey|service_key|apiKey|api_key|cookie|password|secret|token)\b\s*[:=]\s*("[^"]*"|'[^']*'|[^\s,}]+)/gi;
+const AUTHORIZATION_BEARER_PATTERN =
+  /\bAuthorization\s*[:=]\s*Bearer\s+[^\s,}]+/gi;
+const BEARER_TOKEN_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
 
 function requestId(headers: Headers): string | undefined {
   return (
@@ -29,7 +34,12 @@ function requestId(headers: Headers): string | undefined {
 
 function sanitizeErrorMessage(message: string): string | undefined {
   const sanitized = message
-    .replace(SENSITIVE_ERROR_PATTERN, (match) => {
+    .replace(AUTHORIZATION_BEARER_PATTERN, "Authorization: Bearer [redacted]")
+    .replace(JSON_SECRET_PATTERN, (_match, quote, key) => {
+      return `${quote}${key}${quote}: "[redacted]"`;
+    })
+    .replace(BEARER_TOKEN_PATTERN, "Bearer [redacted]")
+    .replace(ASSIGNMENT_SECRET_PATTERN, (match) => {
       const separatorIndex = Math.max(match.indexOf(":"), match.indexOf("="));
       if (separatorIndex === -1) return "[redacted]";
       return `${match.slice(0, separatorIndex + 1)} [redacted]`;


### PR DESCRIPTION
## Summary
- add an `extra_usage_purchases` support ledger with user/session/payment lookup indexes and `created` → `paid_seen` → `credited`/`failed` lifecycle state
- record Checkout session creation, then update the row from confirm/webhook routes for paid, credited, already-processed, and failed outcomes
- add structured route logs for support diagnosis and anonymize the new ledger during account deletion

## Validation
- `./node_modules/.bin/jest convex/__tests__/extraUsagePurchases.test.ts convex/__tests__/extraUsageActionsAuth.test.ts convex/__tests__/userDeletion.test.ts lib/billing/__tests__/extra-usage-purchase-logging.test.ts --runInBand`
- `./node_modules/.bin/jest convex/__tests__/unitEconomicsReportingWindow.test.ts convex/__tests__/unitEconomicsPaidStarts.test.ts --runInBand`
- `./node_modules/.bin/eslint app/api/extra-usage/confirm/route.ts app/api/extra-usage/webhook/route.ts lib/billing/extra-usage-purchase-logging.ts lib/billing/__tests__/extra-usage-purchase-logging.test.ts convex/extraUsage.ts convex/extraUsageActions.ts convex/schema.ts convex/userDeletion.ts convex/__tests__/extraUsageActionsAuth.test.ts convex/__tests__/extraUsagePurchases.test.ts convex/__tests__/userDeletion.test.ts`
- `./node_modules/.bin/prettier --check convex/schema.ts convex/extraUsage.ts convex/extraUsageActions.ts app/api/extra-usage/confirm/route.ts app/api/extra-usage/webhook/route.ts lib/billing/extra-usage-purchase-logging.ts lib/billing/__tests__/extra-usage-purchase-logging.test.ts convex/userDeletion.ts convex/__tests__/extraUsageActionsAuth.test.ts convex/__tests__/extraUsagePurchases.test.ts convex/__tests__/userDeletion.test.ts`
- `./node_modules/.bin/tsc --noEmit` *(fails on existing worktree issue: `packages/local/src/index.ts(17,23): error TS2307: Cannot find module 'ws' or its corresponding type declarations.`)*

## Manual verification
- In a test billing environment, start a personal extra-usage Checkout purchase and confirm `extra_usage_purchases` is created with `status: "created"`, the user id, amount, and Checkout session id.
- Complete payment and return through `/api/extra-usage/confirm`; confirm the row moves to `credited`, contains payment/invoice ids when Stripe provides them, and `revenue_events` still records the money.
- Replay the confirm URL or webhook for the same session; confirm the row remains `credited` with `last_result: "already_processed"` and no duplicate balance or revenue credit.
- Simulate a paid session where crediting throws; confirm the route logs `extra_usage_purchase_credit_failed`, the purchase row becomes `failed` with a sanitized `last_error`, and the webhook returns 500 for Stripe retry.

## Notes
- This intentionally does not add a broad support repair tool. A repair helper should verify Stripe paid state first and use the existing session idempotency key before crediting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an extra-usage purchase ledger to track Stripe checkout lifecycle with persistent status states.
  * Expanded webhook handling for additional async payment events and introduced structured, contextual logging with sensitive redaction.
* **Bug Fixes**
  * Improved confirmation/webhook resilience with stricter session metadata validation, enhanced idempotency, and safer pending/non-`paid` handling.
  * Improved failure recording and analytics/error logging so failures don’t break the payment flow.
  * Extended account deletion to anonymize extra-usage purchase records.
* **Tests**
  * Added coverage for purchase recording/crediting, duplicate handling, logging/redaction, and deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->