### PR TITLE
Improve chat save failure diagnostics

### DIFF
--- a/convex/__tests__/chats.saveChat.test.ts
+++ b/convex/__tests__/chats.saveChat.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+jest.mock("../_generated/server", () => ({
+  mutation: jest.fn((config: any) => config),
+  internalMutation: jest.fn((config: any) => config),
+  query: jest.fn((config: any) => config),
+}));
+
+jest.mock("convex/values", () => ({
+  v: {
+    id: jest.fn(() => "id"),
+    null: jest.fn(() => "null"),
+    string: jest.fn(() => "string"),
+    number: jest.fn(() => "number"),
+    optional: jest.fn(() => "optional"),
+    object: jest.fn(() => "object"),
+    union: jest.fn(() => "union"),
+    array: jest.fn(() => "array"),
+    boolean: jest.fn(() => "boolean"),
+    literal: jest.fn(() => "literal"),
+    any: jest.fn(() => "any"),
+  },
+  ConvexError: class ConvexError extends Error {
+    data: any;
+    constructor(data: any) {
+      super(typeof data === "string" ? data : data.message);
+      this.data = data;
+      this.name = "ConvexError";
+    }
+  },
+}));
+
+jest.mock("convex/server", () => ({
+  paginationOptsValidator: "paginationOptsValidator",
+}));
+
+jest.mock("../_generated/api", () => ({
+  internal: {
+    chats: {
+      cleanupChatSummaryTelemetryBatch:
+        "internal.chats.cleanupChatSummaryTelemetryBatch",
+    },
+  },
+}));
+
+jest.mock("../fileAggregate", () => ({
+  fileCountAggregate: {
+    deleteIfExists: jest.fn<any>().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock("../lib/utils", () => ({
+  validateServiceKey: jest.fn(),
+}));
+
+jest.mock("../lib/suspensionGuards", () => ({
+  assertUserCanAccessChatHistory: jest.fn<any>().mockResolvedValue(undefined),
+}));
+
+const SERVICE_KEY = "test-service-key";
+process.env.CONVEX_SERVICE_ROLE_KEY = SERVICE_KEY;
+
+const saveChatArgs = {
+  serviceKey: SERVICE_KEY,
+  id: "chat-1",
+  userId: "user-1",
+  title: "hello",
+};
+
+const makeCtx = ({
+  existingChat,
+  insertResult = "chat-doc-1",
+}: {
+  existingChat?: Record<string, unknown> | null;
+  insertResult?: string;
+}) => {
+  const unique = jest.fn<any>().mockResolvedValue(existingChat ?? null);
+  const first = jest.fn<any>().mockResolvedValue(existingChat ?? null);
+  const withIndex = jest.fn((_indexName: string, build: (q: any) => any) => {
+    const q = {
+      eq: jest.fn(() => q),
+    };
+    build(q);
+    return { first, unique };
+  });
+  const query = jest.fn(() => ({ withIndex }));
+  const insert = jest.fn<any>().mockResolvedValue(insertResult);
+
+  return {
+    ctx: {
+      db: {
+        query,
+        insert,
+      },
+    } as any,
+    first,
+    insert,
+    query,
+    unique,
+    withIndex,
+  };
+};
+
+describe("saveChat", () => {
+  it("uses unique chat id lookup before inserting", async () => {
+    const { saveChat } = await import("../chats");
+    const { ctx, first, insert, unique } = makeCtx({});
+
+    await expect(saveChat.handler(ctx, saveChatArgs)).resolves.toBe(
+      "chat-doc-1",
+    );
+
+    expect(unique).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+    expect(insert).toHaveBeenCalledWith("chats", {
+      id: "chat-1",
+      title: "hello",
+      user_id: "user-1",
+      update_time: expect.any(Number),
+    });
+  });
+
+  it("rethrows existing-chat ownership denials without wrapping them", async () => {
+    const { saveChat } = await import("../chats");
+    const { ctx, insert } = makeCtx({
+      existingChat: {
+        _id: "chat-doc-1",
+        id: "chat-1",
+        user_id: "other-user",
+      },
+    });
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const thrown = await saveChat
+        .handler(ctx, saveChatArgs)
+        .catch((error: unknown) => error);
+
+      expect(thrown).toMatchObject({
+        name: "ConvexError",
+        data: {
+          code: "CHAT_UNAUTHORIZED",
+          message: "Chat id belongs to another user",
+          operation: "chats.saveChat",
+          chatId: "chat-1",
+        },
+      });
+      expect(insert).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/convex/__tests__/chats.saveChat.test.ts
+++ b/convex/__tests__/chats.saveChat.test.ts
@@ -179,6 +179,17 @@ describe("saveChat", () => {
           titleLength: 5,
         }),
       });
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const [logLine] = errorSpy.mock.calls[0] ?? [];
+      expect(JSON.parse(String(logLine))).toMatchObject({
+        event: "convex_chat_save_failed",
+        db_operation: "chats.saveChat",
+        failure_stage: "insert_chat",
+        convex_error_data: {
+          code: "DB_WRITE_FAILED",
+          requestId: "req-123",
+        },
+      });
     } finally {
       errorSpy.mockRestore();
     }

--- a/convex/__tests__/chats.saveChat.test.ts
+++ b/convex/__tests__/chats.saveChat.test.ts
@@ -152,6 +152,38 @@ describe("saveChat", () => {
     }
   });
 
+  it("preserves structured Convex cause metadata on insert failures", async () => {
+    const { ConvexError } = await import("convex/values");
+    const { saveChat } = await import("../chats");
+    const { ctx, insert } = makeCtx({});
+    insert.mockRejectedValueOnce(
+      new ConvexError({
+        code: "DB_WRITE_FAILED",
+        requestId: "req-123",
+      }),
+    );
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(saveChat.handler(ctx, saveChatArgs)).rejects.toMatchObject({
+        name: "ConvexError",
+        data: expect.objectContaining({
+          code: "CHAT_SAVE_FAILED",
+          failureStage: "insert_chat",
+          causeData: {
+            code: "DB_WRITE_FAILED",
+            requestId: "req-123",
+          },
+          operation: "chats.saveChat",
+          chatId: "chat-1",
+          titleLength: 5,
+        }),
+      });
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it("rethrows existing-chat ownership denials without wrapping them", async () => {
     const { saveChat } = await import("../chats");
     const { ctx, indexEq, insert, withIndex } = makeCtx({

--- a/convex/__tests__/chats.saveChat.test.ts
+++ b/convex/__tests__/chats.saveChat.test.ts
@@ -76,9 +76,13 @@ const makeCtx = ({
 }) => {
   const unique = jest.fn<any>().mockResolvedValue(existingChat ?? null);
   const first = jest.fn<any>().mockResolvedValue(existingChat ?? null);
+  const indexEq = jest.fn();
   const withIndex = jest.fn((_indexName: string, build: (q: any) => any) => {
     const q = {
-      eq: jest.fn(() => q),
+      eq: jest.fn((field: string, value: unknown) => {
+        indexEq(field, value);
+        return q;
+      }),
     };
     build(q);
     return { first, unique };
@@ -94,6 +98,7 @@ const makeCtx = ({
       },
     } as any,
     first,
+    indexEq,
     insert,
     query,
     unique,
@@ -104,12 +109,14 @@ const makeCtx = ({
 describe("saveChat", () => {
   it("uses unique chat id lookup before inserting", async () => {
     const { saveChat } = await import("../chats");
-    const { ctx, first, insert, unique } = makeCtx({});
+    const { ctx, first, indexEq, insert, unique, withIndex } = makeCtx({});
 
     await expect(saveChat.handler(ctx, saveChatArgs)).resolves.toBe(
       "chat-doc-1",
     );
 
+    expect(withIndex).toHaveBeenCalledWith("by_chat_id", expect.any(Function));
+    expect(indexEq).toHaveBeenCalledWith("id", "chat-1");
     expect(unique).toHaveBeenCalledTimes(1);
     expect(first).not.toHaveBeenCalled();
     expect(insert).toHaveBeenCalledWith("chats", {
@@ -120,9 +127,34 @@ describe("saveChat", () => {
     });
   });
 
+  it("wraps unexpected insert failures with chat save metadata", async () => {
+    const { saveChat } = await import("../chats");
+    const { ctx, insert } = makeCtx({});
+    insert.mockRejectedValueOnce(new Error("write failed"));
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(saveChat.handler(ctx, saveChatArgs)).rejects.toMatchObject({
+        name: "ConvexError",
+        data: expect.objectContaining({
+          code: "CHAT_SAVE_FAILED",
+          message: "Failed to save chat",
+          failureStage: "insert_chat",
+          causeName: "Error",
+          causeMessage: "write failed",
+          operation: "chats.saveChat",
+          chatId: "chat-1",
+          titleLength: 5,
+        }),
+      });
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it("rethrows existing-chat ownership denials without wrapping them", async () => {
     const { saveChat } = await import("../chats");
-    const { ctx, insert } = makeCtx({
+    const { ctx, indexEq, insert, withIndex } = makeCtx({
       existingChat: {
         _id: "chat-doc-1",
         id: "chat-1",
@@ -145,6 +177,11 @@ describe("saveChat", () => {
           chatId: "chat-1",
         },
       });
+      expect(withIndex).toHaveBeenCalledWith(
+        "by_chat_id",
+        expect.any(Function),
+      );
+      expect(indexEq).toHaveBeenCalledWith("id", "chat-1");
       expect(insert).not.toHaveBeenCalled();
       expect(errorSpy).not.toHaveBeenCalled();
     } finally {

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -48,6 +48,15 @@ const getConvexErrorData = (error: unknown): Value | undefined => {
   return data === undefined ? undefined : (data as Value);
 };
 
+const getConvexErrorCode = (data: Value | undefined): string | undefined => {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return undefined;
+  }
+
+  const code = (data as Record<string, unknown>).code;
+  return typeof code === "string" ? code : undefined;
+};
+
 function normalizeTelemetryCleanupBatchSize(batchSize?: number): number {
   if (!Number.isFinite(batchSize) || !batchSize) {
     return CHAT_SUMMARY_TELEMETRY_CLEANUP_DEFAULT_BATCH_SIZE;
@@ -473,7 +482,7 @@ export const saveChat = mutation({
       const existingChat = await ctx.db
         .query("chats")
         .withIndex("by_chat_id", (q) => q.eq("id", args.id))
-        .first();
+        .unique();
 
       if (existingChat) {
         if (existingChat.user_id !== args.userId) {
@@ -499,6 +508,10 @@ export const saveChat = mutation({
       return chatId;
     } catch (error) {
       const causeData = getConvexErrorData(error);
+      if (getConvexErrorCode(causeData) === "CHAT_UNAUTHORIZED") {
+        throw error;
+      }
+
       console.error(
         JSON.stringify({
           level: "error",

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -1,7 +1,7 @@
 import { query, mutation, internalMutation } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
 import type { Doc } from "./_generated/dataModel";
-import { v, ConvexError } from "convex/values";
+import { v, ConvexError, type Value } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { internal } from "./_generated/api";
 import { fileCountAggregate } from "./fileAggregate";
@@ -35,6 +35,18 @@ const CHAT_SUMMARY_TELEMETRY_FIELDS = [
   "cost",
   "estimated_compacted_input_tokens",
 ] as const;
+
+const getErrorName = (error: unknown): string =>
+  error instanceof Error ? error.name : typeof error;
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const getConvexErrorData = (error: unknown): Value | undefined => {
+  if (!error || typeof error !== "object") return undefined;
+  const data = (error as { data?: unknown }).data;
+  return data === undefined ? undefined : (data as Value);
+};
 
 function normalizeTelemetryCleanupBatchSize(batchSize?: number): number {
   if (!Number.isFinite(batchSize) || !batchSize) {
@@ -454,8 +466,29 @@ export const saveChat = mutation({
   handler: async (ctx, args) => {
     // Verify service role key
     validateServiceKey(args.serviceKey);
+    let failureStage = "start";
 
     try {
+      failureStage = "find_existing_chat";
+      const existingChat = await ctx.db
+        .query("chats")
+        .withIndex("by_chat_id", (q) => q.eq("id", args.id))
+        .first();
+
+      if (existingChat) {
+        if (existingChat.user_id !== args.userId) {
+          throw new ConvexError({
+            code: "CHAT_UNAUTHORIZED",
+            message: "Chat id belongs to another user",
+            operation: "chats.saveChat",
+            chatId: args.id,
+          });
+        }
+
+        return existingChat._id;
+      }
+
+      failureStage = "insert_chat";
       const chatId = await ctx.db.insert("chats", {
         id: args.id,
         title: args.title,
@@ -465,8 +498,34 @@ export const saveChat = mutation({
 
       return chatId;
     } catch (error) {
-      console.error("Failed to save chat:", error);
-      throw new Error("Failed to save chat");
+      const causeData = getConvexErrorData(error);
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "convex_chat_save_failed",
+          service: "convex",
+          timestamp: new Date().toISOString(),
+          db_operation: "chats.saveChat",
+          failure_stage: failureStage,
+          chat_id: args.id,
+          user_id: args.userId,
+          title_length: args.title.length,
+          error_name: getErrorName(error),
+          error_message: getErrorMessage(error),
+          convex_error_data: causeData,
+        }),
+      );
+      throw new ConvexError({
+        code: "CHAT_SAVE_FAILED",
+        message: "Failed to save chat",
+        failureStage,
+        causeName: getErrorName(error),
+        causeMessage: getErrorMessage(error),
+        causeData,
+        operation: "chats.saveChat",
+        chatId: args.id,
+        titleLength: args.title.length,
+      });
     }
   },
 });

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -6,6 +6,7 @@ const loadSaveMessageWithMocks = async () => {
 
   const mockMutation = jest.fn().mockResolvedValue({ id: "message-1" });
   const mockQuery = jest.fn();
+  const mockPhEvent = jest.fn();
   const mockCompactMessageForStorage = jest.fn((message: any) => {
     const sizeBytes = JSON.stringify(message.parts).length;
     return {
@@ -26,21 +27,136 @@ const loadSaveMessageWithMocks = async () => {
       action = jest.fn();
     },
   }));
+  jest.doMock("@/lib/posthog/server", () => ({
+    phLogger: {
+      event: mockPhEvent,
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      flush: jest.fn(),
+    },
+  }));
   jest.doMock("@/lib/chat/compaction/prune-tool-outputs", () => ({
     compactMessageForStorage: mockCompactMessageForStorage,
   }));
 
-  const { deleteChatForBackend, getMessagesByChatId, saveMessage } =
+  const { deleteChatForBackend, getMessagesByChatId, saveChat, saveMessage } =
     await import("../actions");
   return {
     deleteChatForBackend,
     getMessagesByChatId,
     mockCompactMessageForStorage,
     mockMutation,
+    mockPhEvent,
     mockQuery,
+    saveChat,
     saveMessage,
   };
 };
+
+describe("saveChat", () => {
+  it("retries generic Convex server errors before saving a new chat", async () => {
+    const { saveChat, mockMutation } = await loadSaveMessageWithMocks();
+    const convexError = new Error("[Request ID: abc] Server Error");
+    mockMutation
+      .mockRejectedValueOnce(convexError as never)
+      .mockRejectedValueOnce(convexError as never)
+      .mockResolvedValueOnce("chat-doc-1" as never);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await expect(
+        saveChat({
+          id: "chat-1",
+          userId: "user-1",
+          title: "hello",
+        }),
+      ).resolves.toBe("chat-doc-1");
+
+      expect(mockMutation).toHaveBeenCalledTimes(3);
+      const retryEvents = warnSpy.mock.calls
+        .map(([line]) => JSON.parse(String(line)))
+        .filter((payload) => payload.event === "chat_save_retry_scheduled");
+
+      expect(retryEvents).toHaveLength(2);
+      expect(retryEvents[0]).toMatchObject({
+        retry_reason: "convex_server_error",
+        attempt: 1,
+        next_attempt: 2,
+        retry_delay_ms: 0,
+        chat_id: "chat-1",
+        user_id: "user-1",
+        title_length: 5,
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("emits queryable PostHog metadata when chat creation still fails", async () => {
+    const { saveChat, mockMutation, mockPhEvent } =
+      await loadSaveMessageWithMocks();
+    const convexError = new Error("[Request ID: abc] Server Error") as Error & {
+      data?: unknown;
+    };
+    convexError.name = "ConvexError";
+    convexError.data = {
+      code: "CHAT_SAVE_FAILED",
+      message: "Failed to save chat",
+      failureStage: "insert_chat",
+      causeName: "WorkerOverloaded",
+      causeMessage: "Worker overloaded",
+    };
+    mockMutation.mockRejectedValue(convexError as never);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const thrown = await saveChat({
+        id: "chat-1",
+        userId: "user-1",
+        title: "x".repeat(100),
+      }).catch((error) => error);
+
+      expect(thrown).toMatchObject({
+        type: "bad_request",
+        surface: "database",
+        statusCode: 400,
+        metadata: expect.objectContaining({
+          db_operation: "chats.saveChat",
+          db_error_name: "ConvexError",
+          db_error_message: "[Request ID: abc] Server Error",
+          db_request_id: "abc",
+          db_error_code: "CHAT_SAVE_FAILED",
+          db_failure_stage: "insert_chat",
+          chat_id: "chat-1",
+          user_id: "user-1",
+          title_length: 100,
+        }),
+      });
+
+      expect(mockPhEvent).toHaveBeenCalledWith(
+        "database_operation_failed",
+        expect.objectContaining({
+          db_operation: "chats.saveChat",
+          db_request_id: "abc",
+          db_error_code: "CHAT_SAVE_FAILED",
+          db_failure_stage: "insert_chat",
+          chat_id: "chat-1",
+          user_id: "user-1",
+          userId: "user-1",
+          title_length: 100,
+        }),
+      );
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+});
 
 describe("saveMessage", () => {
   it("sanitizes assistant parts before storage compaction", async () => {

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -32,6 +32,7 @@ import type { ChatMode } from "@/types/chat";
 import { getMessagePersistenceDiagnostics } from "./message-persistence-diagnostics";
 import { sanitizeForConvexValue } from "./convex-value-sanitizer";
 import { stringifyRedactedError } from "@/lib/utils/error-redaction";
+import { phLogger } from "@/lib/posthog/server";
 
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 const MAX_DATABASE_ERROR_MESSAGE_LENGTH = 500;
@@ -41,6 +42,8 @@ const MAX_DATABASE_ERROR_DATA_DEPTH = 3;
 const MAX_DATABASE_ERROR_DATA_ARRAY_LENGTH = 20;
 const LARGE_MESSAGE_SAVE_WARNING_BYTES = 850 * 1024;
 const SAVE_MESSAGE_RETRY_DELAYS_MS =
+  process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
+const SAVE_CHAT_RETRY_DELAYS_MS =
   process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
 const REDACTED_ERROR_DATA_VALUE = "[Redacted]";
 type SummaryReason =
@@ -188,6 +191,11 @@ const truncateDiagnosticString = (value: string): string =>
     ? `${value.slice(0, MAX_DATABASE_ERROR_MESSAGE_LENGTH)}...`
     : value;
 
+const getConvexRequestIdFromMessage = (message: string): string | undefined => {
+  const match = message.match(/\[Request ID:\s*([^\]\s]+)\]/i);
+  return match?.[1];
+};
+
 const getObjectString = (value: unknown, key: string): string | undefined => {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return undefined;
@@ -225,7 +233,7 @@ const hasDatabaseErrorCode = (data: unknown, code: string): boolean =>
 const getDatabaseFailureStage = (data: unknown): string | undefined =>
   getObjectString(data, "failureStage");
 
-const getRetryableSaveMessageErrorReason = (
+const getRetryableDatabaseErrorReason = (
   error: unknown,
 ): string | undefined => {
   const dbErrorData = getErrorData(error);
@@ -252,6 +260,23 @@ const getRetryableSaveMessageErrorReason = (
   if (/TooManyRequests|rate.?limit|429/i.test(errorText)) {
     return "convex_rate_limited";
   }
+  return undefined;
+};
+
+const getRetryableSaveMessageErrorReason = getRetryableDatabaseErrorReason;
+
+const getRetryableSaveChatErrorReason = (
+  error: unknown,
+): string | undefined => {
+  const retryReason = getRetryableDatabaseErrorReason(error);
+  if (retryReason) return retryReason;
+
+  // Older deployed Convex functions can flatten transient failures to this
+  // generic shape before richer error data reaches the Next.js worker.
+  if (/\[Request ID:\s*[^\]]+\]\s+Server Error/i.test(stringifyError(error))) {
+    return "convex_server_error";
+  }
+
   return undefined;
 };
 
@@ -353,10 +378,11 @@ const databaseError = (
         : isMessageTooLarge
           ? "Your message is too large to save. Please shorten it or attach the content as a file instead."
           : `Database operation failed: ${operation}: ${dbErrorMessage}`;
-  const diagnosticMetadata = {
+  const diagnosticMetadata: Record<string, unknown> = {
     db_operation: operation,
     db_error_name: dbErrorName,
     db_error_message: dbErrorMessage,
+    db_request_id: getConvexRequestIdFromMessage(dbErrorMessage),
     db_error_code: getDatabaseErrorCode(dbErrorData),
     db_cause_error_code: getDatabaseCauseErrorCode(dbErrorData),
     db_failure_stage: getDatabaseFailureStage(dbErrorData),
@@ -376,6 +402,15 @@ const databaseError = (
     console.warn(logLine);
   } else {
     console.error(logLine);
+    phLogger.event(event, {
+      ...diagnosticMetadata,
+      service: "chat-handler",
+      level: logLevel,
+      userId:
+        typeof diagnosticMetadata.user_id === "string"
+          ? diagnosticMetadata.user_id
+          : undefined,
+    });
   }
 
   return new ChatSDKError(errorCode, errorMessage, diagnosticMetadata);
@@ -456,13 +491,46 @@ export async function saveChat({
   userId: string;
   title: string;
 }) {
+  const mutationArgs = {
+    serviceKey,
+    id,
+    userId,
+    title,
+  };
+
   try {
-    return await getConvexClient().mutation(api.chats.saveChat, {
-      serviceKey,
-      id,
-      userId,
-      title,
-    });
+    for (let attemptIndex = 0; ; attemptIndex++) {
+      try {
+        return await getConvexClient().mutation(
+          api.chats.saveChat,
+          mutationArgs,
+        );
+      } catch (error) {
+        const retryReason = getRetryableSaveChatErrorReason(error);
+        const retryDelayMs = SAVE_CHAT_RETRY_DELAYS_MS[attemptIndex];
+        if (!retryReason || retryDelayMs === undefined) {
+          throw error;
+        }
+
+        console.warn(
+          JSON.stringify({
+            level: "warn",
+            event: "chat_save_retry_scheduled",
+            service: "chat-handler",
+            timestamp: new Date().toISOString(),
+            db_operation: "chats.saveChat",
+            retry_reason: retryReason,
+            attempt: attemptIndex + 1,
+            next_attempt: attemptIndex + 2,
+            retry_delay_ms: retryDelayMs,
+            chat_id: id,
+            user_id: userId,
+            title_length: title.length,
+          }),
+        );
+        await waitForRetryDelay(retryDelayMs);
+      }
+    }
   } catch (error) {
     throw databaseError("chats.saveChat", error, {
       chat_id: id,


### PR DESCRIPTION
## Summary
- preserve Convex cause metadata for `chats.saveChat` failures instead of flattening to a generic error
- make new chat creation idempotent for same-user retries and retry transient/generic Convex server errors
- emit sanitized PostHog-queryable `database_operation_failed` metadata for unknown DB failures, including Convex request id when present

## Why
The recent `chats.saveChat` failure only existed in runtime logs and PostHog could not find the incident. The old Convex mutation discarded the original cause by throwing `Error("Failed to save chat")`, so the API could only log `[Request ID: ...] Server Error` without stage/cause context.

## Validation
- `jest lib/db/__tests__/actions-save-message.test.ts --runInBand`
- `prettier --check lib/db/actions.ts convex/chats.ts lib/db/__tests__/actions-save-message.test.ts`
- `eslint lib/db/actions.ts convex/chats.ts lib/db/__tests__/actions-save-message.test.ts`
- `tsc --noEmit`

## Manual verification
- Trigger a new non-temporary Ask chat while Convex chat insertion fails or is forced to fail.
- Confirm runtime logs include `convex_chat_save_failed` with `failure_stage`, `chat_id`, `user_id`, and `title_length` but no raw title or prompt.
- Confirm PostHog has `database_operation_failed` with `db_operation = chats.saveChat`, `db_request_id` when present, `db_failure_stage`, `chat_id`, and `user_id`.
- Retry the same chat id after a partial insert and confirm same-user save returns the existing chat instead of creating a duplicate or failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat saving reliability by adding bounded retries for transient backend failures.
  * Returned more consistent, structured failure information when chat saves fail, including clearer error codes and stage details.
  * Strengthened ownership/permission enforcement so unauthorized chat saves are correctly blocked with the right error.
  * Enhanced diagnostic logging context to make failed chat save attempts easier to investigate.
* **Tests**
  * Added/expanded automated coverage for successful saves, retry behavior, unauthorized handling, and structured failure outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->