### PR TITLE
Route free DeepSeek fallback through paid Agent chain

### DIFF
--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -264,7 +264,6 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "model-deepseek-v4-pro": or("deepseek/deepseek-v4-pro"),
     "model-opus-4.6": or("anthropic/claude-opus-4.6"),
     "model-minimax-m3": or(MINIMAX_M3_SLUG),
-    "fallback-minimax-m3": or(MINIMAX_M3_SLUG),
     "model-kimi-k2.7-code": or(KIMI_K2_7_CODE_SLUG),
     // Compatibility alias for stale internal references persisted before the
     // Kimi 2.7 Code rollout. New Agent Standard selections use model-minimax-m3.
@@ -294,7 +293,6 @@ export const modelCutoffDates: Record<ModelName, string> &
   "model-deepseek-v4-pro": "May 2025",
   "model-opus-4.6": "May 2025",
   "model-minimax-m3": "May 2026",
-  "fallback-minimax-m3": "May 2026",
   "model-kimi-k2.7-code": "June 2025",
   "model-kimi-k2.6": "June 2025",
   "fallback-agent-model": "January 2025",
@@ -317,7 +315,6 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-deepseek-v4-pro": "DeepSeek V4 Pro",
   "model-opus-4.6": "Anthropic Claude Opus 4.6",
   "model-minimax-m3": "MiniMax M3",
-  "fallback-minimax-m3": "Auto, an intelligent model router built by HackerAI",
   "model-kimi-k2.7-code": "Moonshot Kimi K2.7 Code",
   "model-kimi-k2.6": "Moonshot Kimi K2.7 Code",
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
@@ -363,7 +360,6 @@ export function isMiniMaxModel(modelName: string): boolean {
   return (
     normalized === "agent-model" ||
     normalized === "model-minimax-m3" ||
-    normalized === "fallback-minimax-m3" ||
     normalized.includes("minimax/minimax-m3")
   );
 }

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -264,6 +264,7 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "model-deepseek-v4-pro": or("deepseek/deepseek-v4-pro"),
     "model-opus-4.6": or("anthropic/claude-opus-4.6"),
     "model-minimax-m3": or(MINIMAX_M3_SLUG),
+    "fallback-minimax-m3": or(MINIMAX_M3_SLUG),
     "model-kimi-k2.7-code": or(KIMI_K2_7_CODE_SLUG),
     // Compatibility alias for stale internal references persisted before the
     // Kimi 2.7 Code rollout. New Agent Standard selections use model-minimax-m3.
@@ -293,6 +294,7 @@ export const modelCutoffDates: Record<ModelName, string> &
   "model-deepseek-v4-pro": "May 2025",
   "model-opus-4.6": "May 2025",
   "model-minimax-m3": "May 2026",
+  "fallback-minimax-m3": "May 2026",
   "model-kimi-k2.7-code": "June 2025",
   "model-kimi-k2.6": "June 2025",
   "fallback-agent-model": "January 2025",
@@ -315,6 +317,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-deepseek-v4-pro": "DeepSeek V4 Pro",
   "model-opus-4.6": "Anthropic Claude Opus 4.6",
   "model-minimax-m3": "MiniMax M3",
+  "fallback-minimax-m3": "Auto, an intelligent model router built by HackerAI",
   "model-kimi-k2.7-code": "Moonshot Kimi K2.7 Code",
   "model-kimi-k2.6": "Moonshot Kimi K2.7 Code",
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
@@ -360,6 +363,7 @@ export function isMiniMaxModel(modelName: string): boolean {
   return (
     normalized === "agent-model" ||
     normalized === "model-minimax-m3" ||
+    normalized === "fallback-minimax-m3" ||
     normalized.includes("minimax/minimax-m3")
   );
 }

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -168,11 +168,11 @@ describe("buildProviderOptions fallback chain", () => {
     ["agent-model-free", "agent"],
     ["model-deepseek-v4-flash", "ask"],
   ] as const)(
-    "falls back from free DeepSeek route %s to MiniMax then Grok",
+    "falls back from free DeepSeek route %s through the paid Agent chain",
     (modelName, mode) => {
       const opts = buildProviderOptions(false, "user-1", modelName, mode);
       expect(opts.openrouter).toMatchObject({
-        models: [MINIMAX_SLUG, GROK_SLUG],
+        models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
         user: "user-1",
       });
     },
@@ -243,7 +243,11 @@ describe("buildProviderOptions fallback chain", () => {
       enabled: true,
       effort: "medium",
     });
-    expect(opts.openrouter.models).toEqual([MINIMAX_SLUG, GROK_SLUG]);
+    expect(opts.openrouter.models).toEqual([
+      MINIMAX_SLUG,
+      KIMI_SLUG,
+      GROK_SLUG,
+    ]);
   });
 
   it.each(["model-kimi-k2.7-code", "model-kimi-k2.6"])(
@@ -357,11 +361,9 @@ describe("getRetryFallbackModel", () => {
     ["agent-model-free", "agent"],
     ["model-deepseek-v4-flash", "ask"],
   ] as const)(
-    "uses MiniMax M3 for app-side retry after free DeepSeek route %s fails",
+    "uses the paid Agent fallback chain for app-side retry after free DeepSeek route %s fails",
     (modelName, mode) => {
-      expect(getRetryFallbackModel(modelName, mode)).toBe(
-        "fallback-minimax-m3",
-      );
+      expect(getRetryFallbackModel(modelName, mode)).toBe("model-minimax-m3");
     },
   );
 

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -36,7 +36,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("resolves Opus 4.6 text-only agent chain to MiniMax, Kimi, then Grok slugs", () => {
+  it("resolves Opus 4.6 text-only agent chain to MiniMax, Kimi 2.7 Code, then Grok slugs", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -76,7 +76,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("resolves Sonnet 4.6 text-only agent chain to MiniMax, Kimi, then Grok slugs", () => {
+  it("resolves Sonnet 4.6 text-only agent chain to MiniMax, Kimi 2.7 Code, then Grok slugs", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -129,7 +129,7 @@ describe("buildProviderOptions fallback chain", () => {
     expect(sonnet.openrouter.models).not.toContain(KIMI_SLUG);
   });
 
-  it("falls back from auto agent MiniMax to Kimi then Grok", () => {
+  it("falls back from auto agent MiniMax to Kimi 2.7 Code then Grok", () => {
     const opts = buildProviderOptions(false, "user-1", "agent-model", "agent");
     expect(opts.openrouter).toMatchObject({
       models: [KIMI_SLUG, GROK_SLUG],
@@ -137,7 +137,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("falls back from explicit MiniMax to Kimi then Grok", () => {
+  it("falls back from explicit MiniMax to Kimi 2.7 Code then Grok", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -150,7 +150,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("falls back from explicit Kimi to Grok", () => {
+  it("falls back from explicit Kimi 2.7 Code to Grok", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -168,7 +168,7 @@ describe("buildProviderOptions fallback chain", () => {
     ["agent-model-free", "agent"],
     ["model-deepseek-v4-flash", "ask"],
   ] as const)(
-    "falls back from free DeepSeek route %s through the paid Agent chain",
+    "falls back from free DeepSeek route %s through the paid Agent chain with Kimi 2.7 Code",
     (modelName, mode) => {
       const opts = buildProviderOptions(false, "user-1", modelName, mode);
       expect(opts.openrouter).toMatchObject({
@@ -250,15 +250,29 @@ describe("buildProviderOptions fallback chain", () => {
     ]);
   });
 
-  it.each(["model-kimi-k2.7-code", "model-kimi-k2.6"])(
-    "enables reasoning for Kimi ask mode route %s",
-    (modelName) => {
-      const opts = buildProviderOptions(false, "user-1", modelName, "ask");
-      expect(opts.openrouter.reasoning).toEqual({
-        enabled: true,
-      });
-    },
-  );
+  it("enables reasoning for the current Kimi 2.7 Code ask route", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-kimi-k2.7-code",
+      "ask",
+    );
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+    });
+  });
+
+  it("keeps reasoning enabled for the legacy Kimi 2.6 alias", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-kimi-k2.6",
+      "ask",
+    );
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+    });
+  });
 
   it.each([
     "model-deepseek-v4-pro",

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -8,6 +8,7 @@
 
 import {
   buildProviderOptions,
+  getRetryFallbackModel,
   isAutoModelSelectionForRetry,
 } from "@/lib/api/chat-stream-helpers";
 
@@ -162,13 +163,20 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("falls back from free DeepSeek agent model to Gemini", () => {
-    const opts = buildProviderOptions(false, "user-1", "agent-model-free");
-    expect(opts.openrouter).toMatchObject({
-      models: [GEMINI_PREVIEW_SLUG],
-      user: "user-1",
-    });
-  });
+  it.each([
+    ["ask-model-free", "ask"],
+    ["agent-model-free", "agent"],
+    ["model-deepseek-v4-flash", "ask"],
+  ] as const)(
+    "falls back from free DeepSeek route %s to MiniMax then Grok",
+    (modelName, mode) => {
+      const opts = buildProviderOptions(false, "user-1", modelName, mode);
+      expect(opts.openrouter).toMatchObject({
+        models: [MINIMAX_SLUG, GROK_SLUG],
+        user: "user-1",
+      });
+    },
+  );
 
   it("falls back from explicit DeepSeek Pro ask model to Gemini", () => {
     const opts = buildProviderOptions(
@@ -235,7 +243,7 @@ describe("buildProviderOptions fallback chain", () => {
       enabled: true,
       effort: "medium",
     });
-    expect(opts.openrouter.models).toEqual([GEMINI_PREVIEW_SLUG]);
+    expect(opts.openrouter.models).toEqual([MINIMAX_SLUG, GROK_SLUG]);
   });
 
   it.each(["model-kimi-k2.7-code", "model-kimi-k2.6"])(
@@ -340,5 +348,26 @@ describe("isAutoModelSelectionForRetry", () => {
         selectedModelOverride: "hackerai-standard",
       }),
     ).toBe(true);
+  });
+});
+
+describe("getRetryFallbackModel", () => {
+  it.each([
+    ["ask-model-free", "ask"],
+    ["agent-model-free", "agent"],
+    ["model-deepseek-v4-flash", "ask"],
+  ] as const)(
+    "uses MiniMax M3 for app-side retry after free DeepSeek route %s fails",
+    (modelName, mode) => {
+      expect(getRetryFallbackModel(modelName, mode)).toBe(
+        "fallback-minimax-m3",
+      );
+    },
+  );
+
+  it("keeps paid DeepSeek Pro ask retry on the existing ask fallback", () => {
+    expect(getRetryFallbackModel("model-deepseek-v4-pro", "ask")).toBe(
+      "fallback-ask-model",
+    );
   });
 });

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -473,16 +473,22 @@ export class SummarizationTracker {
  * OpenRouter slugs are resolved at request-build time so this stays in sync
  * with the registry.
  */
+const FREE_DEEPSEEK_FALLBACK_CHAIN = [
+  "fallback-minimax-m3",
+  "fallback-grok-4.3",
+] as const satisfies readonly ModelName[];
+
 const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
-  "ask-model-free": ["fallback-ask-model"],
-  "agent-model-free": ["fallback-agent-model"],
-  "model-deepseek-v4-flash": ["fallback-ask-model"],
+  "ask-model-free": FREE_DEEPSEEK_FALLBACK_CHAIN,
+  "agent-model-free": FREE_DEEPSEEK_FALLBACK_CHAIN,
+  "model-deepseek-v4-flash": FREE_DEEPSEEK_FALLBACK_CHAIN,
   "model-deepseek-v4-pro": ["fallback-ask-model"],
   "ask-model": ["fallback-ask-model"],
   "agent-model": ["model-kimi-k2.6", "fallback-grok-4.3"],
   "model-grok-4.3": ["fallback-ask-model"],
   "model-gemini-3-flash": ["fallback-ask-model"],
   "model-minimax-m3": ["model-kimi-k2.6", "fallback-grok-4.3"],
+  "fallback-minimax-m3": ["fallback-grok-4.3"],
   "model-kimi-k2.7-code": ["fallback-grok-4.3"],
   "model-kimi-k2.6": ["fallback-grok-4.3"],
 };
@@ -577,6 +583,13 @@ export function getRetryFallbackModel(
   modelName: ModelName,
   mode: ChatMode,
 ): ModelName {
+  if (
+    modelName === "ask-model-free" ||
+    modelName === "agent-model-free" ||
+    modelName === "model-deepseek-v4-flash"
+  ) {
+    return "fallback-minimax-m3";
+  }
   if (isDeepSeekModel(modelName)) {
     return mode === "agent" ? "fallback-agent-model" : "fallback-ask-model";
   }

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -473,22 +473,26 @@ export class SummarizationTracker {
  * OpenRouter slugs are resolved at request-build time so this stays in sync
  * with the registry.
  */
-const FREE_DEEPSEEK_FALLBACK_CHAIN = [
-  "model-minimax-m3",
-  "model-kimi-k2.6",
+const MINIMAX_M3_FALLBACK_CHAIN = [
+  "model-kimi-k2.7-code",
   "fallback-grok-4.3",
 ] as const satisfies readonly ModelName[];
 
+const AGENT_TEXT_FALLBACK_CHAIN = [
+  "model-minimax-m3",
+  ...MINIMAX_M3_FALLBACK_CHAIN,
+] as const satisfies readonly ModelName[];
+
 const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
-  "ask-model-free": FREE_DEEPSEEK_FALLBACK_CHAIN,
-  "agent-model-free": FREE_DEEPSEEK_FALLBACK_CHAIN,
-  "model-deepseek-v4-flash": FREE_DEEPSEEK_FALLBACK_CHAIN,
+  "ask-model-free": AGENT_TEXT_FALLBACK_CHAIN,
+  "agent-model-free": AGENT_TEXT_FALLBACK_CHAIN,
+  "model-deepseek-v4-flash": AGENT_TEXT_FALLBACK_CHAIN,
   "model-deepseek-v4-pro": ["fallback-ask-model"],
   "ask-model": ["fallback-ask-model"],
-  "agent-model": ["model-kimi-k2.6", "fallback-grok-4.3"],
+  "agent-model": MINIMAX_M3_FALLBACK_CHAIN,
   "model-grok-4.3": ["fallback-ask-model"],
   "model-gemini-3-flash": ["fallback-ask-model"],
-  "model-minimax-m3": ["model-kimi-k2.6", "fallback-grok-4.3"],
+  "model-minimax-m3": MINIMAX_M3_FALLBACK_CHAIN,
   "model-kimi-k2.7-code": ["fallback-grok-4.3"],
   "model-kimi-k2.6": ["fallback-grok-4.3"],
 };
@@ -516,7 +520,7 @@ export function isAutoModelSelectionForRetry({
 
 const ANTHROPIC_FALLBACK_CHAIN_BY_MODE: Record<ChatMode, readonly ModelName[]> =
   {
-    agent: ["model-minimax-m3", "model-kimi-k2.6", "fallback-grok-4.3"],
+    agent: AGENT_TEXT_FALLBACK_CHAIN,
     ask: ["model-grok-4.3"],
   };
 

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -474,7 +474,8 @@ export class SummarizationTracker {
  * with the registry.
  */
 const FREE_DEEPSEEK_FALLBACK_CHAIN = [
-  "fallback-minimax-m3",
+  "model-minimax-m3",
+  "model-kimi-k2.6",
   "fallback-grok-4.3",
 ] as const satisfies readonly ModelName[];
 
@@ -488,7 +489,6 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "model-grok-4.3": ["fallback-ask-model"],
   "model-gemini-3-flash": ["fallback-ask-model"],
   "model-minimax-m3": ["model-kimi-k2.6", "fallback-grok-4.3"],
-  "fallback-minimax-m3": ["fallback-grok-4.3"],
   "model-kimi-k2.7-code": ["fallback-grok-4.3"],
   "model-kimi-k2.6": ["fallback-grok-4.3"],
 };
@@ -588,7 +588,7 @@ export function getRetryFallbackModel(
     modelName === "agent-model-free" ||
     modelName === "model-deepseek-v4-flash"
   ) {
-    return "fallback-minimax-m3";
+    return "model-minimax-m3";
   }
   if (isDeepSeekModel(modelName)) {
     return mode === "agent" ? "fallback-agent-model" : "fallback-ask-model";


### PR DESCRIPTION
## Summary
- route free DeepSeek Flash OpenRouter fallback chains through the existing paid Agent fallback path: MiniMax M3, Kimi 2.7 Code, then Grok 4.3
- make app-side provider retries after free DeepSeek failures retry on model-minimax-m3, so they inherit the same paid Agent fallback chain
- update active fallback chain keys to use model-kimi-k2.7-code while keeping model-kimi-k2.6 only as a legacy compatibility alias
- cover free Ask, free Agent, explicit Flash fallback, and retry behavior in unit tests

## Testing
- ./node_modules/.bin/jest lib/api/__tests__/chat-stream-helpers-fallback.test.ts --runInBand
- ./node_modules/.bin/jest lib/ai/__tests__/providers.test.ts --runInBand
- ./node_modules/.bin/eslint lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/ai/providers.ts lib/ai/__tests__/providers.test.ts
- ./node_modules/.bin/prettier --check lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/ai/providers.ts lib/ai/__tests__/providers.test.ts
- ./node_modules/.bin/tsc --noEmit (fails: packages/local/src/index.ts(17,23): Cannot find module 'ws' or its corresponding type declarations.)

## Manual verification
- Start a free Ask request that routes through ask-model-free and force/observe a DeepSeek Flash provider failure before tokens stream.
- Confirm fallback_model_slugs include minimax/minimax-m3, then moonshotai/kimi-k2.7-code:exacto, then x-ai/grok-4.3, and no Gemini fallback is used for the free Flash route.
- Repeat for free Agent/agent-model-free; confirm the app-side provider retry logs fallbackModelSlug as minimax/minimax-m3 when the retry branch is used.