### PR TITLE
Fix OpenRouter reasoning leak and file share recovery

### DIFF
--- a/app/components/ReasoningHandler.tsx
+++ b/app/components/ReasoningHandler.tsx
@@ -9,6 +9,7 @@ import {
   ReasoningContent,
   ReasoningTrigger,
 } from "@/components/ai-elements/reasoning";
+import { partHasOpenRouterReasoningDetails } from "@/lib/chat/provider-metadata-sanitizer";
 
 type ReasoningHandlerProps = {
   message: UIMessage;
@@ -24,7 +25,10 @@ const collectReasoningText = (
   const collected: string[] = [];
   for (let i = startIndex; i < parts.length; i++) {
     const part = parts[i];
-    if (part?.type === "reasoning") {
+    if (
+      part?.type === "reasoning" &&
+      !partHasOpenRouterReasoningDetails(part)
+    ) {
       collected.push(part.text ?? "");
     } else {
       break;
@@ -51,7 +55,16 @@ function areReasoningPropsEqual(
   const nextPart = next.message.parts[next.partIndex];
   if (prevPart?.type !== nextPart?.type) return false;
   if (prevPart?.type === "reasoning" && nextPart?.type === "reasoning") {
-    return prevPart.text === nextPart.text;
+    const prevPreviousPart = prev.message.parts[prev.partIndex - 1];
+    const nextPreviousPart = next.message.parts[next.partIndex - 1];
+    return (
+      prevPart.text === nextPart.text &&
+      partHasOpenRouterReasoningDetails(prevPart) ===
+        partHasOpenRouterReasoningDetails(nextPart) &&
+      prevPreviousPart?.type === nextPreviousPart?.type &&
+      partHasOpenRouterReasoningDetails(prevPreviousPart) ===
+        partHasOpenRouterReasoningDetails(nextPreviousPart)
+    );
   }
   return true;
 }
@@ -74,16 +87,27 @@ export const ReasoningHandler = memo(function ReasoningHandler({
     if (currentPart?.type !== "reasoning") return "";
     // Skip if previous part is also reasoning (avoid duplicate renders)
     const previousPart = parts[partIndex - 1];
-    if (previousPart?.type === "reasoning") return "";
+    if (
+      previousPart?.type === "reasoning" &&
+      !partHasOpenRouterReasoningDetails(previousPart)
+    ) {
+      return "";
+    }
     return collectReasoningText(parts, partIndex);
   }, [parts, partIndex, currentPart?.type]);
 
   // Early return for non-reasoning parts
   if (currentPart?.type !== "reasoning") return null;
+  if (partHasOpenRouterReasoningDetails(currentPart)) return null;
 
   // Skip if previous part is also reasoning (avoid duplicate renders)
   const previousPart = parts[partIndex - 1];
-  if (previousPart?.type === "reasoning") return null;
+  if (
+    previousPart?.type === "reasoning" &&
+    !partHasOpenRouterReasoningDetails(previousPart)
+  ) {
+    return null;
+  }
 
   // Don't show reasoning if empty or only contains [REDACTED] (encrypted reasoning from providers like Gemini)
   if (!combined || REDACTED_PATTERN.test(combined.trim())) return null;

--- a/app/components/ReasoningHandler.tsx
+++ b/app/components/ReasoningHandler.tsx
@@ -37,6 +37,22 @@ const collectReasoningText = (
   return collected.join("");
 };
 
+const collectReasoningComparisonKey = (
+  parts: UIMessage["parts"],
+  startIndex: number,
+): string => {
+  const run: Array<{ hidden: boolean; text?: string }> = [];
+  for (let i = startIndex; i < parts.length; i++) {
+    const part = parts[i];
+    if (part?.type !== "reasoning") break;
+    run.push({
+      hidden: partHasOpenRouterReasoningDetails(part),
+      text: part.text,
+    });
+  }
+  return JSON.stringify(run);
+};
+
 // Hoist regex outside component to avoid recreation
 const REDACTED_PATTERN = /^(\[REDACTED\])+$/;
 
@@ -58,9 +74,8 @@ function areReasoningPropsEqual(
     const prevPreviousPart = prev.message.parts[prev.partIndex - 1];
     const nextPreviousPart = next.message.parts[next.partIndex - 1];
     return (
-      prevPart.text === nextPart.text &&
-      partHasOpenRouterReasoningDetails(prevPart) ===
-        partHasOpenRouterReasoningDetails(nextPart) &&
+      collectReasoningComparisonKey(prev.message.parts, prev.partIndex) ===
+        collectReasoningComparisonKey(next.message.parts, next.partIndex) &&
       prevPreviousPart?.type === nextPreviousPart?.type &&
       partHasOpenRouterReasoningDetails(prevPreviousPart) ===
         partHasOpenRouterReasoningDetails(nextPreviousPart)

--- a/app/components/tools/GetTerminalFilesHandler.tsx
+++ b/app/components/tools/GetTerminalFilesHandler.tsx
@@ -22,6 +22,7 @@ interface TerminalFilesPart {
   output?: {
     result: string;
     files?: Array<{ path: string }>;
+    failedFiles?: Array<{ path: string; reason?: string }>;
     // Legacy support for old messages
     fileUrls?: Array<{ path: string; downloadUrl?: string }>;
   };
@@ -93,7 +94,9 @@ export const GetTerminalFilesHandler = memo(function GetTerminalFilesHandler({
   // Mirror the shell/file pattern: when the model supplies a `brief` and the
   // call didn't error, the brief stands alone as the block label.
   const briefText = input?.brief?.trim() || "";
-  const useBriefOnly = !!briefText && state !== "output-error";
+  const failedFileCount = output?.failedFiles?.length || 0;
+  const useBriefOnly =
+    !!briefText && state !== "output-error" && failedFileCount === 0;
   const briefLabel = (fallback: string) =>
     useBriefOnly ? briefText : fallback;
   const briefTarget = (fallback: string | undefined) =>
@@ -126,15 +129,20 @@ export const GetTerminalFilesHandler = memo(function GetTerminalFilesHandler({
 
     case "output-available": {
       const fileCount = output?.files?.length || output?.fileUrls?.length || 0;
+      const totalFileCount = fileCount + failedFileCount;
       const fileNames = getFileNames(requestedPaths);
+      const fallbackAction =
+        failedFileCount > 0
+          ? fileCount > 0
+            ? `Shared ${fileCount} of ${totalFileCount} files`
+            : "Failed to share"
+          : `Shared ${fileCount} file${fileCount !== 1 ? "s" : ""}`;
 
       return (
         <ToolBlock
           key={toolCallId}
           icon={<FileDown />}
-          action={briefLabel(
-            `Shared ${fileCount} file${fileCount !== 1 ? "s" : ""}`,
-          )}
+          action={briefLabel(fallbackAction)}
           target={briefTarget(fileNames)}
           isClickable={isClickable}
           onClick={handleOpenInSidebar}

--- a/app/components/tools/GetTerminalFilesHandler.tsx
+++ b/app/components/tools/GetTerminalFilesHandler.tsx
@@ -128,9 +128,14 @@ export const GetTerminalFilesHandler = memo(function GetTerminalFilesHandler({
       );
 
     case "output-available": {
-      const fileCount = output?.files?.length || output?.fileUrls?.length || 0;
+      const successfulPaths = [
+        ...(output?.files?.map((file) => file.path) || []),
+        ...(output?.fileUrls?.map((file) => file.path) || []),
+      ];
+      const fileCount = successfulPaths.length;
       const totalFileCount = fileCount + failedFileCount;
-      const fileNames = getFileNames(requestedPaths);
+      const displayPaths = fileCount > 0 ? successfulPaths : requestedPaths;
+      const fileNames = getFileNames(displayPaths);
       const fallbackAction =
         failedFileCount > 0
           ? fileCount > 0

--- a/app/components/tools/__tests__/GetTerminalFilesHandler.test.tsx
+++ b/app/components/tools/__tests__/GetTerminalFilesHandler.test.tsx
@@ -1,0 +1,42 @@
+import "@testing-library/jest-dom";
+import { describe, expect, it, jest } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("@/app/hooks/useToolSidebar", () => ({
+  useToolSidebar: () => ({
+    handleOpenInSidebar: jest.fn(),
+    handleKeyDown: jest.fn(),
+  }),
+}));
+
+const { GetTerminalFilesHandler } =
+  require("../GetTerminalFilesHandler") as typeof import("../GetTerminalFilesHandler");
+
+describe("GetTerminalFilesHandler", () => {
+  it("targets only successfully shared files when an upload partially fails", () => {
+    render(
+      <GetTerminalFilesHandler
+        status="ready"
+        part={{
+          toolCallId: "call-1",
+          state: "output-available",
+          input: {
+            brief: "Deliver both packages",
+            files: ["/home/user/server.zip", "/home/user/client.zip"],
+          },
+          output: {
+            result: "Partially provided 1 of 2 file(s)",
+            files: [{ path: "/home/user/server.zip" }],
+            failedFiles: [
+              { path: "/home/user/client.zip", reason: "upload failed" },
+            ],
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Shared 1 of 2 files")).toBeInTheDocument();
+    expect(screen.getByText("server.zip")).toBeInTheDocument();
+    expect(screen.queryByText("client.zip")).not.toBeInTheDocument();
+  });
+});

--- a/app/share/[shareId]/__tests__/SharedMessages.test.tsx
+++ b/app/share/[shareId]/__tests__/SharedMessages.test.tsx
@@ -161,6 +161,41 @@ describe("SharedMessages", () => {
       expect(screen.getByText("Executed")).toBeInTheDocument();
       expect(screen.getByText("ls -la")).toBeInTheDocument();
     });
+
+    it("should target only successfully shared files when a terminal file upload partially fails", () => {
+      const messages = [
+        {
+          id: "1",
+          role: "assistant" as const,
+          parts: [
+            {
+              type: "tool-get_terminal_files",
+              state: "output-available",
+              input: {
+                brief: "Deliver both packages",
+                files: ["/home/user/server.zip", "/home/user/client.zip"],
+              },
+              output: {
+                result: "Partially provided 1 of 2 file(s)",
+                files: [{ path: "/home/user/server.zip" }],
+                failedFiles: [
+                  { path: "/home/user/client.zip", reason: "upload failed" },
+                ],
+              },
+            },
+          ],
+          update_time: mockShareDate,
+        },
+      ];
+
+      renderWithContext(
+        <SharedMessages messages={messages} shareDate={mockShareDate} />,
+      );
+
+      expect(screen.getByText("Shared 1 of 2 files")).toBeInTheDocument();
+      expect(screen.getByText("server.zip")).toBeInTheDocument();
+      expect(screen.queryByText("client.zip")).not.toBeInTheDocument();
+    });
   });
 
   describe("Tool Execution - File Operations", () => {

--- a/app/share/[shareId]/components/SharedMessagePartHandler.tsx
+++ b/app/share/[shareId]/components/SharedMessagePartHandler.tsx
@@ -626,6 +626,7 @@ function renderGetTerminalFilesTool(part: MessagePart, idx: number) {
   const filesInput = part.input as { files?: string[]; brief?: string };
   const filesOutput = part.output as {
     files?: Array<{ path: string }>;
+    failedFiles?: Array<{ path: string; reason?: string }>;
     fileUrls?: Array<{ path: string }>;
   };
 
@@ -650,15 +651,21 @@ function renderGetTerminalFilesTool(part: MessagePart, idx: number) {
   if (part.state === "output-available") {
     const fileCount =
       filesOutput?.files?.length || filesOutput?.fileUrls?.length || 0;
+    const failedFileCount = filesOutput?.failedFiles?.length || 0;
+    const totalFileCount = fileCount + failedFileCount;
+    const fallbackAction =
+      failedFileCount > 0
+        ? fileCount > 0
+          ? `Shared ${fileCount} of ${totalFileCount} files`
+          : "Failed to share"
+        : `Shared ${fileCount} file${fileCount !== 1 ? "s" : ""}`;
 
     return (
       <ToolBlock
         key={idx}
         icon={<FileDown aria-hidden="true" />}
-        action={
-          brief || `Shared ${fileCount} file${fileCount !== 1 ? "s" : ""}`
-        }
-        target={brief ? undefined : fileNames}
+        action={failedFileCount === 0 && brief ? brief : fallbackAction}
+        target={failedFileCount === 0 && brief ? undefined : fileNames}
       />
     );
   }

--- a/app/share/[shareId]/components/SharedMessagePartHandler.tsx
+++ b/app/share/[shareId]/components/SharedMessagePartHandler.tsx
@@ -649,10 +649,16 @@ function renderGetTerminalFilesTool(part: MessagePart, idx: number) {
   }
 
   if (part.state === "output-available") {
-    const fileCount =
-      filesOutput?.files?.length || filesOutput?.fileUrls?.length || 0;
+    const successfulPaths = [
+      ...(filesOutput?.files?.map((file) => file.path) || []),
+      ...(filesOutput?.fileUrls?.map((file) => file.path) || []),
+    ];
+    const fileCount = successfulPaths.length;
     const failedFileCount = filesOutput?.failedFiles?.length || 0;
     const totalFileCount = fileCount + failedFileCount;
+    const displayPaths =
+      fileCount > 0 ? successfulPaths : filesInput?.files || [];
+    const displayFileNames = getFileNames(displayPaths);
     const fallbackAction =
       failedFileCount > 0
         ? fileCount > 0
@@ -665,7 +671,7 @@ function renderGetTerminalFilesTool(part: MessagePart, idx: number) {
         key={idx}
         icon={<FileDown aria-hidden="true" />}
         action={failedFileCount === 0 && brief ? brief : fallbackAction}
-        target={failedFileCount === 0 && brief ? undefined : fileNames}
+        target={failedFileCount === 0 && brief ? undefined : displayFileNames}
       />
     );
   }

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -15,6 +15,7 @@ import {
   assertUserCanAccessChatHistory,
   isUserBlockedByActiveFraudDispute,
 } from "./lib/suspensionGuards";
+import { stripOpenRouterReasoningMetadataFromParts } from "../lib/chat/provider-metadata-sanitizer";
 
 /**
  * Extract text content from message parts for search and display
@@ -2111,20 +2112,22 @@ export const getSharedMessages = query({
         content: msg.content,
         update_time: msg.update_time,
         // Process parts to replace files/images with placeholders
-        parts: msg.parts.map((part: any) => {
-          // Replace file references with placeholder
-          if (part.type === "file") {
-            // Determine if it's an image based on mediaType
-            const isImage = part.mediaType?.startsWith("image/");
-            return {
-              type: isImage ? "image" : "file",
-              placeholder: true,
-              // SECURITY: Do NOT include url, file_id, name, or mediaType
-            };
-          }
-          // Keep text parts as-is
-          return part;
-        }),
+        parts: stripOpenRouterReasoningMetadataFromParts(msg.parts).map(
+          (part: any) => {
+            // Replace file references with placeholder
+            if (part.type === "file") {
+              // Determine if it's an image based on mediaType
+              const isImage = part.mediaType?.startsWith("image/");
+              return {
+                type: isImage ? "image" : "file",
+                placeholder: true,
+                // SECURITY: Do NOT include url, file_id, name, or mediaType
+              };
+            }
+            // Keep text parts as-is
+            return part;
+          },
+        ),
         // SECURITY: user_id is NOT included in response (anonymity)
       }));
     } catch (error) {
@@ -2234,7 +2237,7 @@ export const getPreviewMessages = query({
           id: m.id,
           role: m.role,
           content: m.content,
-          parts: m.parts,
+          parts: stripOpenRouterReasoningMetadataFromParts(m.parts),
           fileDetails,
         };
       });

--- a/convex/sharedChats.ts
+++ b/convex/sharedChats.ts
@@ -5,6 +5,7 @@ import {
   assertUserCanAccessChatHistory,
   isUserBlockedByActiveFraudDispute,
 } from "./lib/suspensionGuards";
+import { stripOpenRouterReasoningMetadataFromParts } from "../lib/chat/provider-metadata-sanitizer";
 
 /**
  * Share a chat by creating a public share link.
@@ -365,9 +366,9 @@ export const forkSharedChat = mutation({
       // Remove file/image parts entirely — the forking user doesn't own the
       // original files, signed URLs will expire, and placeholder parts render
       // as broken "Unknown file" cards in the regular chat view.
-      const sanitizedParts = msg.parts.filter(
-        (part: any) => part.type !== "file",
-      );
+      const sanitizedParts = stripOpenRouterReasoningMetadataFromParts(
+        msg.parts,
+      ).filter((part: any) => part.type !== "file");
       await ctx.db.insert("messages", {
         id: newMessageId,
         chat_id: newChatId,

--- a/lib/ai/tools/__tests__/get-terminal-files.test.ts
+++ b/lib/ai/tools/__tests__/get-terminal-files.test.ts
@@ -1,0 +1,124 @@
+jest.mock("../utils/sandbox-file-uploader", () => ({
+  uploadSandboxFileToConvex: jest.fn(),
+}));
+
+import { createGetTerminalFiles } from "../get-terminal-files";
+import { uploadSandboxFileToConvex } from "../utils/sandbox-file-uploader";
+import type { ToolContext } from "@/types";
+
+const mockUploadSandboxFileToConvex =
+  uploadSandboxFileToConvex as jest.MockedFunction<
+    typeof uploadSandboxFileToConvex
+  >;
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    sandboxManager: {
+      getSandbox: jest.fn(async () => ({ sandbox: { id: "sandbox-1" } })),
+      setSandbox: jest.fn(),
+      getSandboxType: jest.fn(),
+      getSandboxInfo: jest.fn(() => null),
+      getEffectivePreference: jest.fn(() => "e2b"),
+      recordHealthFailure: jest.fn(() => false),
+      resetHealthFailures: jest.fn(),
+      isSandboxUnavailable: jest.fn(() => false),
+    },
+    backgroundProcessTracker: {
+      hasActiveProcessesForFiles: jest.fn(async () => ({
+        active: false,
+        processes: [],
+      })),
+    },
+    fileAccumulator: {
+      add: jest.fn(),
+      getAll: jest.fn(() => []),
+      clear: jest.fn(),
+    },
+    writer: { write: jest.fn() } as never,
+    userLocation: {} as never,
+    todoManager: {} as never,
+    userID: "user-1",
+    chatId: "chat-1",
+    assistantMessageId: "assistant-1",
+    ptySessionManager: {} as never,
+    mode: "agent",
+    modelName: "model-minimax-m3",
+    subscription: "pro",
+    isE2BSandbox: (() => true) as never,
+    caidoEnabled: false,
+    ...overrides,
+  } as ToolContext;
+}
+
+async function runTool(
+  tool: ReturnType<typeof createGetTerminalFiles>,
+  input: Record<string, unknown>,
+) {
+  const execute = (
+    tool as unknown as {
+      execute: (i: unknown, o: unknown) => Promise<unknown>;
+    }
+  ).execute;
+  return execute(input, {
+    toolCallId: "call-1",
+    abortSignal: undefined,
+    messages: [],
+  });
+}
+
+describe("get_terminal_files", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("reports partial upload failures without claiming every file was sent", async () => {
+    mockUploadSandboxFileToConvex
+      .mockResolvedValueOnce({
+        url: "https://files.example/server.zip",
+        fileId: "file_server" as never,
+        tokens: 0,
+        name: "server.zip",
+        mediaType: "application/zip",
+        s3Key: "users/u1/server.zip",
+        sizeBytes: 1024,
+      })
+      .mockRejectedValueOnce(
+        new Error(
+          "Failed to upload file /home/user/client.zip: curl: (22) The requested URL returned error: 403",
+        ),
+      );
+
+    const context = makeContext();
+    const tool = createGetTerminalFiles(context);
+
+    const result = (await runTool(tool, {
+      brief: "Deliver both packages",
+      files: ["/home/user/server.zip", "/home/user/client.zip"],
+    })) as {
+      result: string;
+      files: Array<{ path: string }>;
+      failedFiles: Array<{ path: string; reason: string }>;
+    };
+
+    expect(result.files).toEqual([{ path: "/home/user/server.zip" }]);
+    expect(result.failedFiles).toHaveLength(1);
+    expect(result.failedFiles[0]).toMatchObject({
+      path: "/home/user/client.zip",
+      reason: expect.stringContaining("403"),
+    });
+    expect(result.result).toContain("Partially provided 1 of 2 file(s)");
+    expect(result.result).toContain(
+      "Do not tell the user failed files were sent",
+    );
+    expect(result.result).not.toContain("Successfully provided 2");
+    expect(context.fileAccumulator.add).toHaveBeenCalledTimes(1);
+    expect(context.writer.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "data-file-metadata",
+        data: expect.objectContaining({
+          messageId: "assistant-1",
+        }),
+      }),
+    );
+  });
+});

--- a/lib/ai/tools/get-terminal-files.ts
+++ b/lib/ai/tools/get-terminal-files.ts
@@ -129,27 +129,32 @@ Usage:
         }
 
         let result = "";
-        if (providedFiles.length > 0) {
-          result += `Successfully provided ${providedFiles.length} file(s) to the user`;
-        }
         if (blockedFiles.length > 0) {
           const blockedDetails = blockedFiles
             .map((f) => `${f.path}: ${f.reason}`)
             .join("; ");
-          result +=
-            (result ? ". " : "") +
-            `${blockedFiles.length} file(s) could not be retrieved: ${blockedDetails}`;
+          result =
+            providedFiles.length > 0
+              ? `Partially provided ${providedFiles.length} of ${files.length} file(s) to the user. ${blockedFiles.length} file(s) could not be retrieved: ${blockedDetails}. Do not tell the user failed files were sent; retry only the failed file paths if the error is transient, otherwise explain the upload problem.`
+              : `Failed to provide ${blockedFiles.length} file(s) to the user: ${blockedDetails}. Do not tell the user these files were sent; verify the paths or explain the upload problem before retrying.`;
+        } else if (providedFiles.length > 0) {
+          result = `Successfully provided ${providedFiles.length} file(s) to the user`;
         }
 
         return {
           result: result || "No files were retrieved",
           files: providedFiles,
+          failedFiles: blockedFiles,
         };
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error);
         return {
-          result: `Error providing files: ${errorMsg}`,
+          result: `Failed to provide files to the user: ${errorMsg}. Do not tell the user these files were sent; explain the upload problem before retrying.`,
           files: [],
+          failedFiles: files.map((path) => ({
+            path,
+            reason: errorMsg,
+          })),
         };
       }
     },

--- a/lib/chat/__tests__/provider-metadata-sanitizer.test.ts
+++ b/lib/chat/__tests__/provider-metadata-sanitizer.test.ts
@@ -1,0 +1,96 @@
+import {
+  stripOpenRouterReasoningMetadataFromMessage,
+  stripOpenRouterReasoningMetadataFromMessages,
+  stripOpenRouterReasoningMetadataFromParts,
+} from "../provider-metadata-sanitizer";
+
+describe("OpenRouter reasoning metadata sanitizer", () => {
+  it("drops OpenRouter-backed reasoning parts and strips reasoning_details from tool metadata", () => {
+    const message = {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "reasoning",
+          state: "done",
+          text: "private chain of thought",
+          providerMetadata: {
+            openrouter: {
+              reasoning_details: [
+                { type: "reasoning.text", text: "private chain of thought" },
+              ],
+            },
+          },
+        },
+        {
+          type: "tool-run_terminal_cmd",
+          toolCallId: "call-1",
+          state: "output-available",
+          input: { command: "echo hi" },
+          output: { result: { exitCode: 0, output: "hi" } },
+          providerMetadata: {
+            openrouter: {
+              generation_id: "gen-1",
+              reasoning_details: [
+                { type: "reasoning.text", text: "tool-call thought" },
+              ],
+            },
+            google: {
+              thought_signature: "gemini-signature",
+            },
+          },
+          callProviderMetadata: {
+            openrouter: {
+              reasoning_details: [
+                { type: "reasoning.text", text: "call thought" },
+              ],
+            },
+          },
+          resultProviderMetadata: {
+            openrouter: {
+              reasoning_details: [
+                { type: "reasoning.text", text: "result thought" },
+              ],
+            },
+          },
+        },
+      ],
+    };
+
+    const sanitized = stripOpenRouterReasoningMetadataFromMessage(message);
+
+    expect(sanitized).not.toBe(message);
+    expect(sanitized.parts).toHaveLength(1);
+    expect(sanitized.parts[0]).toMatchObject({
+      type: "tool-run_terminal_cmd",
+      providerMetadata: {
+        openrouter: { generation_id: "gen-1" },
+        google: { thought_signature: "gemini-signature" },
+      },
+    });
+    expect((sanitized.parts[0] as any).callProviderMetadata).toBeUndefined();
+    expect((sanitized.parts[0] as any).resultProviderMetadata).toBeUndefined();
+    expect(JSON.stringify(sanitized)).not.toContain("reasoning_details");
+    expect(JSON.stringify(sanitized)).not.toContain("private chain of thought");
+  });
+
+  it("preserves non-OpenRouter provider metadata unchanged", () => {
+    const parts = [
+      {
+        type: "tool-run_terminal_cmd",
+        toolCallId: "call-1",
+        state: "output-available",
+        providerMetadata: {
+          google: {
+            thought_signature: "gemini-signature",
+          },
+        },
+      },
+    ];
+
+    expect(stripOpenRouterReasoningMetadataFromParts(parts)).toBe(parts);
+    expect(stripOpenRouterReasoningMetadataFromMessages([{ parts }])).toEqual([
+      { parts },
+    ]);
+  });
+});

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -20,6 +20,7 @@ import {
   ABORTED_TOOL_ERROR_TEXT,
   hasMeaningfulToolInput,
 } from "@/lib/chat/tool-abort-utils";
+import { stripOpenRouterReasoningMetadataFromMessages } from "@/lib/chat/provider-metadata-sanitizer";
 /**
  * Get maximum steps allowed for a user based on mode and subscription.
  * Agent mode: 100 steps (all tiers).
@@ -661,8 +662,12 @@ export async function processChatMessages({
   modelOverride?: SelectedModel;
   allowLocalDesktopFiles?: boolean;
 }) {
+  const messagesWithoutOpenRouterReasoning =
+    stripOpenRouterReasoningMetadataFromMessages(messages);
+
   // Filter out UI-only parts (data-summarization) that AI providers don't understand
-  const messagesWithoutUIOnlyParts = messages.map(filterUIOnlyParts);
+  const messagesWithoutUIOnlyParts =
+    messagesWithoutOpenRouterReasoning.map(filterUIOnlyParts);
 
   // Limit image parts before fetching URLs to avoid unnecessary S3 requests
   // Keep image attachment pruning aligned with the per-message upload cap.

--- a/lib/chat/provider-metadata-sanitizer.ts
+++ b/lib/chat/provider-metadata-sanitizer.ts
@@ -1,0 +1,137 @@
+type MessageWithParts = {
+  parts?: unknown[];
+};
+
+type SanitizePartResult = {
+  part: unknown;
+  changed: boolean;
+  drop: boolean;
+};
+
+const PROVIDER_METADATA_KEYS = [
+  "providerMetadata",
+  "callProviderMetadata",
+  "resultProviderMetadata",
+] as const;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+function hasOpenRouterReasoningDetails(metadata: unknown): boolean {
+  if (!isRecord(metadata)) return false;
+  const openrouter = metadata.openrouter;
+  return (
+    isRecord(openrouter) &&
+    Array.isArray(openrouter.reasoning_details) &&
+    openrouter.reasoning_details.length > 0
+  );
+}
+
+export function partHasOpenRouterReasoningDetails(part: unknown): boolean {
+  if (!isRecord(part)) return false;
+  return PROVIDER_METADATA_KEYS.some((key) =>
+    hasOpenRouterReasoningDetails(part[key]),
+  );
+}
+
+function stripOpenRouterReasoningDetailsFromMetadata(metadata: unknown): {
+  metadata: unknown;
+  changed: boolean;
+} {
+  if (!isRecord(metadata)) return { metadata, changed: false };
+
+  const openrouter = metadata.openrouter;
+  if (!isRecord(openrouter) || !hasOwn(openrouter, "reasoning_details")) {
+    return { metadata, changed: false };
+  }
+
+  const { reasoning_details, ...openrouterRest } = openrouter;
+  const cleanedMetadata = { ...metadata };
+  if (Object.keys(openrouterRest).length > 0) {
+    cleanedMetadata.openrouter = openrouterRest;
+  } else {
+    delete cleanedMetadata.openrouter;
+  }
+
+  return { metadata: cleanedMetadata, changed: true };
+}
+
+function sanitizeOpenRouterReasoningPartMetadata(
+  part: unknown,
+): SanitizePartResult {
+  if (!isRecord(part)) return { part, changed: false, drop: false };
+
+  if (part.type === "reasoning" && partHasOpenRouterReasoningDetails(part)) {
+    return { part, changed: true, drop: true };
+  }
+
+  let changed = false;
+  const cleanedPart = { ...part };
+
+  for (const key of PROVIDER_METADATA_KEYS) {
+    if (!hasOwn(cleanedPart, key)) continue;
+
+    const result = stripOpenRouterReasoningDetailsFromMetadata(
+      cleanedPart[key],
+    );
+    if (!result.changed) continue;
+
+    changed = true;
+    if (
+      isRecord(result.metadata) &&
+      Object.keys(result.metadata).length === 0
+    ) {
+      delete cleanedPart[key];
+    } else {
+      cleanedPart[key] = result.metadata;
+    }
+  }
+
+  return changed
+    ? { part: cleanedPart, changed, drop: false }
+    : { part, changed: false, drop: false };
+}
+
+export function stripOpenRouterReasoningMetadataFromParts<T extends unknown[]>(
+  parts: T,
+): T {
+  let changed = false;
+  const nextParts: unknown[] = [];
+
+  for (const part of parts) {
+    const result = sanitizeOpenRouterReasoningPartMetadata(part);
+    if (result.drop) {
+      changed = true;
+      continue;
+    }
+    if (result.changed) changed = true;
+    nextParts.push(result.part);
+  }
+
+  return changed ? (nextParts as T) : parts;
+}
+
+export function stripOpenRouterReasoningMetadataFromMessage<
+  T extends MessageWithParts,
+>(message: T): T {
+  if (!Array.isArray(message.parts)) return message;
+
+  const parts = stripOpenRouterReasoningMetadataFromParts(message.parts);
+  return parts === message.parts ? message : { ...message, parts };
+}
+
+export function stripOpenRouterReasoningMetadataFromMessages<
+  T extends MessageWithParts,
+>(messages: T[]): T[] {
+  let changed = false;
+  const nextMessages = messages.map((message) => {
+    const sanitized = stripOpenRouterReasoningMetadataFromMessage(message);
+    if (sanitized !== message) changed = true;
+    return sanitized;
+  });
+
+  return changed ? nextMessages : messages;
+}

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -196,6 +196,74 @@ describe("saveMessage", () => {
     expect(() => JSON.stringify(compactedMessage.parts)).not.toThrow();
   });
 
+  it("removes OpenRouter reasoning metadata before storage compaction", async () => {
+    const { saveMessage, mockCompactMessageForStorage } =
+      await loadSaveMessageWithMocks();
+
+    await expect(
+      saveMessage({
+        chatId: "chat-1",
+        userId: "user-1",
+        message: {
+          id: "message-1",
+          role: "assistant",
+          parts: [
+            {
+              type: "reasoning",
+              state: "done",
+              text: "private chain of thought",
+              providerMetadata: {
+                openrouter: {
+                  reasoning_details: [
+                    {
+                      type: "reasoning.text",
+                      text: "private chain of thought",
+                    },
+                  ],
+                },
+              },
+            },
+            {
+              type: "tool-run_terminal_cmd",
+              state: "output-available",
+              toolCallId: "call-1",
+              input: { command: "echo hi" },
+              output: { result: { exitCode: 0, output: "hi" } },
+              callProviderMetadata: {
+                openrouter: {
+                  reasoning_details: [
+                    { type: "reasoning.text", text: "private tool thought" },
+                  ],
+                },
+              },
+              providerMetadata: {
+                google: { thought_signature: "gemini-signature" },
+              },
+            },
+          ],
+        },
+      }),
+    ).resolves.toBeDefined();
+
+    const compactedMessage = mockCompactMessageForStorage.mock
+      .calls[0]?.[0] as {
+      parts: Array<Record<string, unknown>>;
+    };
+
+    expect(compactedMessage.parts).toHaveLength(1);
+    expect(compactedMessage.parts[0].type).toBe("tool-run_terminal_cmd");
+    expect(compactedMessage.parts[0].providerMetadata).toEqual({
+      google: { thought_signature: "gemini-signature" },
+    });
+    expect(compactedMessage.parts[0].callProviderMetadata).toBeUndefined();
+    expect(JSON.stringify(compactedMessage.parts)).not.toContain(
+      "reasoning_details",
+    );
+    expect(JSON.stringify(compactedMessage.parts)).not.toContain(
+      "private chain of thought",
+    );
+  });
+
   it("sanitizes usage metadata before saving", async () => {
     const { saveMessage, mockMutation } = await loadSaveMessageWithMocks();
     const invalidUsageKey = "$provider\nraw";

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -33,6 +33,7 @@ import { getMessagePersistenceDiagnostics } from "./message-persistence-diagnost
 import { sanitizeForConvexValue } from "./convex-value-sanitizer";
 import { stringifyRedactedError } from "@/lib/utils/error-redaction";
 import { phLogger } from "@/lib/posthog/server";
+import { stripOpenRouterReasoningMetadataFromParts } from "@/lib/chat/provider-metadata-sanitizer";
 
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 const MAX_DATABASE_ERROR_MESSAGE_LENGTH = 500;
@@ -595,6 +596,10 @@ export async function saveMessage({
             },
           })
         : message.parts;
+    fixedParts =
+      message.role === "assistant"
+        ? stripOpenRouterReasoningMetadataFromParts(fixedParts)
+        : fixedParts;
     const convexSafeParts = sanitizeForConvexValue(fixedParts) as UIMessagePart<
       any,
       any

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,6 +4,7 @@ import { ChatSDKError, ErrorCode } from "./errors";
 import { ChatMessage, type ChatMode } from "@/types/chat";
 import { UIMessagePart } from "ai";
 import { Id } from "@/convex/_generated/dataModel";
+import { stripOpenRouterReasoningMetadataFromParts } from "@/lib/chat/provider-metadata-sanitizer";
 
 export interface MessageRecord {
   id: string;
@@ -63,13 +64,15 @@ export function convertToUIMessages(messages: MessageRecord[]): ChatMessage[] {
       : {}),
     // Sanitize parts: remove any old URLs that may be stored in database
     // URLs expire, so we always fetch fresh ones via fileId
-    parts: message.parts.map((part: any) => {
-      if (part.type === "file" && part.url) {
-        const { url, ...partWithoutUrl } = part;
-        return partWithoutUrl;
-      }
-      return part;
-    }),
+    parts: stripOpenRouterReasoningMetadataFromParts(message.parts).map(
+      (part: any) => {
+        if (part.type === "file" && part.url) {
+          const { url, ...partWithoutUrl } = part;
+          return partWithoutUrl;
+        }
+        return part;
+      },
+    ),
     sourceMessageId: message.source_message_id,
     metadata:
       message.feedback ||


### PR DESCRIPTION
## Summary
- strip OpenRouter `reasoning_details` from live rendering, provider replay, persistence, reload, shared-chat, preview, and fork paths while preserving non-OpenRouter metadata such as Gemini thought signatures
- add a reusable provider-metadata sanitizer and regression coverage for OpenRouter-backed reasoning/tool metadata
- make `get_terminal_files` partial upload failures explicit with `failedFiles`, clearer model guidance, and UI/shared-card labels for partial sends

## Why
A support transcript showed plaintext OpenRouter reasoning stored in `providerMetadata.openrouter.reasoning_details`, `callProviderMetadata.openrouter.reasoning_details`, and `resultProviderMetadata.openrouter.reasoning_details` around terminal/tool calls. The same transcript showed a partial `get_terminal_files` send where one zip uploaded and another failed with `curl: (22) ... 403`, but the tool still returned `output-available`, making it easy for the assistant to claim the missing file had been sent and retry confusingly.

## Validation
- `NODE_PATH=/Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules /Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules/.bin/jest lib/chat/__tests__/provider-metadata-sanitizer.test.ts lib/ai/tools/__tests__/get-terminal-files.test.ts lib/db/__tests__/actions-save-message.test.ts --runInBand`
- `/Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules/.bin/prettier --check app/components/ReasoningHandler.tsx lib/chat/provider-metadata-sanitizer.ts lib/chat/__tests__/provider-metadata-sanitizer.test.ts lib/ai/tools/get-terminal-files.ts lib/ai/tools/__tests__/get-terminal-files.test.ts app/components/tools/GetTerminalFilesHandler.tsx app/share/[shareId]/components/SharedMessagePartHandler.tsx lib/chat/chat-processor.ts lib/db/actions.ts lib/db/__tests__/actions-save-message.test.ts lib/utils.ts convex/messages.ts convex/sharedChats.ts`
- `./node_modules/.bin/eslint app/components/ReasoningHandler.tsx lib/chat/provider-metadata-sanitizer.ts lib/chat/__tests__/provider-metadata-sanitizer.test.ts lib/ai/tools/get-terminal-files.ts lib/ai/tools/__tests__/get-terminal-files.test.ts app/components/tools/GetTerminalFilesHandler.tsx app/share/[shareId]/components/SharedMessagePartHandler.tsx lib/chat/chat-processor.ts lib/db/actions.ts lib/db/__tests__/actions-save-message.test.ts lib/utils.ts convex/messages.ts convex/sharedChats.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false` (fails on existing unrelated `packages/local/src/index.ts(17,23): Cannot find module 'ws' or its corresponding type declarations`)

## Manual verification
- In Agent mode with an OpenRouter reasoning route, run a tool-using task and confirm provider-private reasoning text does not appear live, after reload, or in a shared chat.
- Generate two sandbox artifacts and force one `get_terminal_files` upload to fail; confirm the tool result and card show a partial/failed share and the assistant does not claim the failed file was sent.
- Retry only the failed file path and confirm a later successful upload shows the normal shared-file card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File-sharing now surfaces partial outcomes: shows “Shared X of Y files”, “Failed to share”, and includes per-file failure reasons when available.

* **Bug Fixes**
  * Shared chats, share previews, and saved messages now better remove internal reasoning details from displayed conversation parts and related tool/provider metadata, preventing duplicate or incorrect reasoning from appearing in shared views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->