### PR TITLE
Add Trigger agent health endpoint

### DIFF
--- a/app/api/health/trigger-agent-mode/__tests__/route.test.ts
+++ b/app/api/health/trigger-agent-mode/__tests__/route.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+jest.mock("next/server", () => ({
+  NextResponse: class MockNextResponse {
+    status: number;
+    headers?: HeadersInit;
+    private body: unknown;
+
+    constructor(body?: unknown, init?: ResponseInit) {
+      this.body = body;
+      this.status = init?.status ?? 200;
+      this.headers = init?.headers;
+    }
+
+    static json(body: unknown, init?: ResponseInit) {
+      return new MockNextResponse(body, init);
+    }
+
+    async json() {
+      return this.body;
+    }
+  },
+}));
+
+const mockFetch = jest.fn();
+
+const triggerFeed = (
+  statuses: Partial<Record<"8931867" | "8931869" | "8649602", string>> = {},
+) => ({
+  included: [
+    {
+      id: "8931867",
+      type: "status_page_resource",
+      attributes: {
+        public_name: "Task execution",
+        status: statuses["8931867"] ?? "operational",
+      },
+    },
+    {
+      id: "8931869",
+      type: "status_page_resource",
+      attributes: {
+        public_name: "Task execution",
+        status: statuses["8931869"] ?? "operational",
+      },
+    },
+    {
+      id: "8649602",
+      type: "status_page_resource",
+      attributes: {
+        public_name: "Realtime",
+        status: statuses["8649602"] ?? "operational",
+      },
+    },
+    {
+      id: "8416312",
+      type: "status_page_resource",
+      attributes: {
+        public_name: "Dashboard",
+        status: "degraded",
+      },
+    },
+    {
+      id: "8416313",
+      type: "status_page_resource",
+      attributes: {
+        public_name: "API",
+        status: "degraded",
+      },
+    },
+  ],
+});
+
+const fetchResponse = ({
+  ok = true,
+  status = 200,
+  body = triggerFeed(),
+}: {
+  ok?: boolean;
+  status?: number;
+  body?: unknown;
+} = {}) => ({
+  ok,
+  status,
+  json: async () => body,
+});
+
+describe("GET /api/health/trigger-agent-mode", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    global.fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockResolvedValue(fetchResponse() as never);
+  });
+
+  it("returns 200 when the Agent-relevant Trigger resources are operational", async () => {
+    const { GET } = await import("../route");
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://status.trigger.dev/index.json",
+      expect.objectContaining({
+        cache: "no-store",
+        headers: { accept: "application/json" },
+      }),
+    );
+    expect(body).toMatchObject({
+      ok: true,
+      source: "https://status.trigger.dev/index.json",
+      resources: [
+        {
+          id: "8931867",
+          name: "US East task execution",
+          status: "operational",
+          operational: true,
+        },
+        {
+          id: "8931869",
+          name: "EU Central task execution",
+          status: "operational",
+          operational: true,
+        },
+        {
+          id: "8649602",
+          name: "Global realtime",
+          status: "operational",
+          operational: true,
+        },
+      ],
+    });
+  });
+
+  it("ignores unrelated degraded API and Dashboard resources", async () => {
+    const { GET } = await import("../route");
+    mockFetch.mockResolvedValueOnce(
+      fetchResponse({
+        body: triggerFeed(),
+      }) as never,
+    );
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+  });
+
+  it("returns 503 when a required Trigger resource is degraded", async () => {
+    const { GET } = await import("../route");
+    mockFetch.mockResolvedValueOnce(
+      fetchResponse({
+        body: triggerFeed({ "8931867": "degraded" }),
+      }) as never,
+    );
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      ok: false,
+      resources: expect.arrayContaining([
+        {
+          id: "8931867",
+          name: "US East task execution",
+          status: "degraded",
+          operational: false,
+        },
+      ]),
+    });
+  });
+
+  it("returns 503 when a required Trigger resource is missing", async () => {
+    const { GET } = await import("../route");
+    mockFetch.mockResolvedValueOnce(
+      fetchResponse({
+        body: {
+          included: triggerFeed().included.filter(
+            (resource) => resource.id !== "8931869",
+          ),
+        },
+      }) as never,
+    );
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      ok: false,
+      resources: expect.arrayContaining([
+        {
+          id: "8931869",
+          name: "EU Central task execution",
+          status: "missing",
+          operational: false,
+        },
+      ]),
+    });
+  });
+
+  it("returns 503 when Trigger's status feed is unavailable", async () => {
+    const { GET } = await import("../route");
+    mockFetch.mockResolvedValueOnce(
+      fetchResponse({ ok: false, status: 502 }) as never,
+    );
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      ok: false,
+      error: "trigger_status_unavailable",
+      sourceStatus: 502,
+    });
+  });
+
+  it("returns 503 when Trigger's status feed cannot be fetched", async () => {
+    const { GET } = await import("../route");
+    mockFetch.mockRejectedValueOnce(new Error("network failure") as never);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      ok: false,
+      error: "trigger_status_fetch_failed",
+      message: "network failure",
+    });
+  });
+});

--- a/app/api/health/trigger-agent-mode/__tests__/route.test.ts
+++ b/app/api/health/trigger-agent-mode/__tests__/route.test.ts
@@ -1,4 +1,11 @@
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 
 jest.mock("next/server", () => ({
   NextResponse: class MockNextResponse {
@@ -86,11 +93,18 @@ const fetchResponse = ({
 });
 
 describe("GET /api/health/trigger-agent-mode", () => {
+  let warnSpy: jest.SpiedFunction<typeof console.warn>;
+
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     global.fetch = mockFetch as unknown as typeof fetch;
     mockFetch.mockResolvedValue(fetchResponse() as never);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
   });
 
   it("returns 200 when the Agent-relevant Trigger resources are operational", async () => {
@@ -230,7 +244,15 @@ describe("GET /api/health/trigger-agent-mode", () => {
     expect(body).toMatchObject({
       ok: false,
       error: "trigger_status_fetch_failed",
-      message: "network failure",
+      message: "Failed to fetch Trigger status feed.",
     });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '"event":"trigger_agent_health_status_fetch_failed"',
+      ),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"error_message":"network failure"'),
+    );
   });
 });

--- a/app/api/health/trigger-agent-mode/route.ts
+++ b/app/api/health/trigger-agent-mode/route.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const maxDuration = 10;
+
+const TRIGGER_STATUS_URL = "https://status.trigger.dev/index.json";
+const OPERATIONAL_STATUS = "operational";
+
+const REQUIRED_TRIGGER_RESOURCES = [
+  {
+    id: "8931867",
+    name: "US East task execution",
+  },
+  {
+    id: "8931869",
+    name: "EU Central task execution",
+  },
+  {
+    id: "8649602",
+    name: "Global realtime",
+  },
+] as const;
+
+type RequiredTriggerResource = (typeof REQUIRED_TRIGGER_RESOURCES)[number];
+
+type TriggerResourceCheck = {
+  id: RequiredTriggerResource["id"];
+  name: RequiredTriggerResource["name"];
+  status: string;
+  operational: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getStatusPageResource(
+  feed: unknown,
+  resourceId: RequiredTriggerResource["id"],
+): Record<string, unknown> | null {
+  if (!isRecord(feed) || !Array.isArray(feed.included)) return null;
+
+  for (const item of feed.included) {
+    if (!isRecord(item)) continue;
+    if (item.id !== resourceId || item.type !== "status_page_resource") {
+      continue;
+    }
+    return item;
+  }
+
+  return null;
+}
+
+function getResourceStatus(
+  feed: unknown,
+  resource: RequiredTriggerResource,
+): TriggerResourceCheck {
+  const item = getStatusPageResource(feed, resource.id);
+  if (!item) {
+    return {
+      id: resource.id,
+      name: resource.name,
+      status: "missing",
+      operational: false,
+    };
+  }
+
+  const attributes = isRecord(item.attributes) ? item.attributes : null;
+  const status =
+    typeof attributes?.status === "string" ? attributes.status : "unknown";
+
+  return {
+    id: resource.id,
+    name: resource.name,
+    status,
+    operational: status === OPERATIONAL_STATUS,
+  };
+}
+
+function buildHealthResponse(resources: TriggerResourceCheck[]) {
+  const ok = resources.every((resource) => resource.operational);
+
+  return {
+    ok,
+    source: TRIGGER_STATUS_URL,
+    checkedAt: new Date().toISOString(),
+    resources,
+  };
+}
+
+function json(
+  body: Record<string, unknown>,
+  init?: ResponseInit,
+): NextResponse<Record<string, unknown>> {
+  const headers = new Headers(init?.headers);
+  headers.set("Cache-Control", "no-store");
+
+  return NextResponse.json(body, {
+    ...init,
+    headers,
+  });
+}
+
+export async function GET() {
+  try {
+    const response = await fetch(TRIGGER_STATUS_URL, {
+      cache: "no-store",
+      headers: {
+        accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      return json(
+        {
+          ok: false,
+          source: TRIGGER_STATUS_URL,
+          checkedAt: new Date().toISOString(),
+          error: "trigger_status_unavailable",
+          sourceStatus: response.status,
+        },
+        { status: 503 },
+      );
+    }
+
+    const feed = await response.json();
+    const resources = REQUIRED_TRIGGER_RESOURCES.map((resource) =>
+      getResourceStatus(feed, resource),
+    );
+    const body = buildHealthResponse(resources);
+
+    return json(body, { status: body.ok ? 200 : 503 });
+  } catch (error) {
+    return json(
+      {
+        ok: false,
+        source: TRIGGER_STATUS_URL,
+        checkedAt: new Date().toISOString(),
+        error: "trigger_status_fetch_failed",
+        message: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 503 },
+    );
+  }
+}

--- a/app/api/health/trigger-agent-mode/route.ts
+++ b/app/api/health/trigger-agent-mode/route.ts
@@ -132,13 +132,28 @@ export async function GET() {
 
     return json(body, { status: body.ok ? 200 : 503 });
   } catch (error) {
+    const checkedAt = new Date().toISOString();
+    console.warn(
+      JSON.stringify({
+        level: "warn",
+        event: "trigger_agent_health_status_fetch_failed",
+        service: "hackerai",
+        timestamp: checkedAt,
+        source: TRIGGER_STATUS_URL,
+        error_name: error instanceof Error ? error.name : "UnknownError",
+        error_message: error instanceof Error ? error.message : "Unknown error",
+        environment: process.env.VERCEL_ENV,
+        vercel_region: process.env.VERCEL_REGION,
+      }),
+    );
+
     return json(
       {
         ok: false,
         source: TRIGGER_STATUS_URL,
-        checkedAt: new Date().toISOString(),
+        checkedAt,
         error: "trigger_status_fetch_failed",
-        message: error instanceof Error ? error.message : "Unknown error",
+        message: "Failed to fetch Trigger status feed.",
       },
       { status: 503 },
     );


### PR DESCRIPTION
## Summary
- add `/api/health/trigger-agent-mode` for BetterStack to monitor HackerAI Agent mode through a simple availability check
- check only Trigger resources that affect Agent mode: US East task execution, EU Central task execution, and Global Realtime
- return `200` only when those resources are operational, otherwise `503` with component details
- cover healthy, degraded, missing, upstream unavailable, and fetch-failure cases

## Testing
- `./node_modules/.bin/jest app/api/health/trigger-agent-mode/__tests__/route.test.ts --runInBand`
- `./node_modules/.bin/eslint app/api/health/trigger-agent-mode/route.ts app/api/health/trigger-agent-mode/__tests__/route.test.ts`
- `./node_modules/.bin/prettier --check app/api/health/trigger-agent-mode/route.ts app/api/health/trigger-agent-mode/__tests__/route.test.ts`
- `./node_modules/.bin/tsc --noEmit`

## Manual verification
- After deployment, configure BetterStack with alert condition `URL becomes unavailable`.
- Monitor `https://hackerai.co/api/health/trigger-agent-mode`.
- Confirm no keyword check is configured; the endpoint should handle Trigger component parsing and status code selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new health-check endpoint that reports the status of key Trigger resources.
  * The endpoint returns overall availability, a source link, a check timestamp, and per-resource status details.

* **Bug Fixes**
  * Returns a clear unavailable response when required resources are degraded or missing.
  * Handles upstream status feed failures and network errors gracefully with a 503 response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->