### PR TITLE
Handle expected auth and Redis timeout errors

### DIFF
--- a/app/api/sandbox/presence/route.ts
+++ b/app/api/sandbox/presence/route.ts
@@ -48,6 +48,7 @@ export async function GET(request: NextRequest) {
 
   let client: Centrifuge | null = null;
   const subscriptions: Subscription[] = [];
+  const probeStart = Date.now();
   try {
     const token = await generateCentrifugoToken(userId, 30);
     client = new Centrifuge(wsUrl, { token });
@@ -103,7 +104,14 @@ export async function GET(request: NextRequest) {
     await Promise.all(probes);
     presenceReliable = true;
   } catch (err) {
-    console.error("Centrifugo presence request failed:", err);
+    phLogger.warn("sandbox_presence_probe_unavailable", {
+      event: "sandbox.presence_probe_unavailable",
+      userId,
+      connection_count: connections.length,
+      online_connection_count: onlineConnectionIds.size,
+      duration_ms: Date.now() - probeStart,
+      error: err,
+    });
   } finally {
     for (const sub of subscriptions) {
       sub.removeAllListeners();

--- a/app/callback/route.ts
+++ b/app/callback/route.ts
@@ -7,6 +7,7 @@ import {
   isOauthCodeAlreadyExchangedError,
   withRecoverableAuthkitCallbackErrorSuppressed,
 } from "@/lib/auth/authkit-callback-logging";
+import { isInvalidCodeVerifierError } from "@/lib/auth/expected-auth-errors";
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -27,11 +28,15 @@ type RecoveryBucket =
   | "verifier_missing"
   | "cookie_missing"
   | "code_already_exchanged"
+  | "invalid_code_verifier"
   | "unknown";
 
 const classifyCallbackError = (error: unknown): RecoveryBucket => {
   if (isOauthCodeAlreadyExchangedError(error)) {
     return "code_already_exchanged";
+  }
+  if (isInvalidCodeVerifierError(error)) {
+    return "invalid_code_verifier";
   }
   if (isMissingRequiredAuthParameterError(error)) {
     return "missing_auth_parameter";

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,6 @@
 import { phLogger } from "@/lib/posthog/server";
 import { registerPostHogLogProvider } from "@/lib/posthog/logs";
+import { isEndedSessionRefreshError } from "@/lib/auth/expected-auth-errors";
 import type { Instrumentation } from "next";
 
 export function register() {
@@ -13,6 +14,19 @@ export const onRequestError: Instrumentation.onRequestError = (
   request,
   context,
 ) => {
+  if (isEndedSessionRefreshError(error)) {
+    phLogger.warn("auth_session_refresh_ended", {
+      event: "auth.session_refresh_ended",
+      error,
+      path: request.path,
+      method: request.method,
+      routePath: context.routePath,
+      routeType: context.routeType,
+      routerKind: context.routerKind,
+    });
+    return;
+  }
+
   phLogger.error("Next.js request error", {
     error,
     path: request.path,

--- a/lib/auth/__tests__/authkit-callback-logging.test.ts
+++ b/lib/auth/__tests__/authkit-callback-logging.test.ts
@@ -107,6 +107,27 @@ describe("authkit callback logging", () => {
     ).toBe(true);
   });
 
+  it("matches invalid code verifier callback errors", () => {
+    const error = Object.assign(
+      new Error(
+        "Error: invalid_grant\nError Description: Invalid code verifier.",
+      ),
+      {
+        status: 400,
+        error: "invalid_grant",
+        errorDescription: "Invalid code verifier.",
+        rawData: {
+          error: "invalid_grant",
+          error_description: "Invalid code verifier.",
+        },
+      },
+    );
+
+    expect(
+      isRecoverableAuthkitCallbackErrorLog(["[AuthKit callback error]", error]),
+    ).toBe(true);
+  });
+
   it("does not match other invalid_grant errors", () => {
     const error = Object.assign(new Error("Error: invalid_grant"), {
       error: "invalid_grant",
@@ -132,6 +153,12 @@ describe("authkit callback logging", () => {
         "[AuthKit callback error]",
         new Error(
           "Error: invalid_grant\nError Description: The code 'abc123' has already been exchanged.",
+        ),
+      );
+      console.error(
+        "[AuthKit callback error]",
+        new Error(
+          "Error: invalid_grant\nError Description: Invalid code verifier.",
         ),
       );
       console.error(

--- a/lib/auth/__tests__/expected-auth-errors.test.ts
+++ b/lib/auth/__tests__/expected-auth-errors.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  collectAuthErrorText,
+  isEndedSessionRefreshError,
+  isInvalidCodeVerifierError,
+} from "../expected-auth-errors";
+
+describe("expected auth errors", () => {
+  it("matches ended session refresh errors through nested causes", () => {
+    const error = Object.assign(
+      new Error("Failed to refresh session: Error: invalid_grant"),
+      {
+        name: "TokenRefreshError",
+        cause: {
+          error: "invalid_grant",
+          errorDescription: "Session has already ended.",
+          rawData: {
+            error: "invalid_grant",
+            error_description: "Session has already ended.",
+          },
+        },
+      },
+    );
+
+    expect(isEndedSessionRefreshError(error)).toBe(true);
+  });
+
+  it("does not match unrelated invalid_grant refresh errors as ended sessions", () => {
+    const error = Object.assign(new Error("Error: invalid_grant"), {
+      error: "invalid_grant",
+      errorDescription: "Invalid code verifier.",
+    });
+
+    expect(isEndedSessionRefreshError(error)).toBe(false);
+  });
+
+  it("matches invalid code verifier errors", () => {
+    const error = Object.assign(new Error("Error: invalid_grant"), {
+      status: 400,
+      error: "invalid_grant",
+      errorDescription: "Invalid code verifier.",
+      rawData: {
+        error: "invalid_grant",
+        error_description: "Invalid code verifier.",
+      },
+    });
+
+    expect(isInvalidCodeVerifierError(error)).toBe(true);
+  });
+
+  it("collects nested auth error text without looping on cycles", () => {
+    const error: Error & { cause?: unknown } = new Error("outer");
+    error.cause = error;
+
+    expect(collectAuthErrorText(error)).toContain("outer");
+  });
+});

--- a/lib/auth/authkit-callback-logging.ts
+++ b/lib/auth/authkit-callback-logging.ts
@@ -1,3 +1,8 @@
+import {
+  collectAuthErrorText,
+  isInvalidCodeVerifierError,
+} from "./expected-auth-errors";
+
 const AUTHKIT_CALLBACK_ERROR_PREFIX = "[AuthKit callback error]";
 const AUTH_COOKIE_MISSING_MESSAGE = "Auth cookie missing";
 const MISSING_REQUIRED_AUTH_PARAMETER_MESSAGE =
@@ -26,42 +31,8 @@ export const isAuthCookieMissingError = (value: unknown): boolean => {
   return false;
 };
 
-const getStringValue = (
-  value: Record<string, unknown>,
-  key: string,
-): string | null => {
-  const fieldValue = value[key];
-  return typeof fieldValue === "string" ? fieldValue : null;
-};
-
-const collectErrorText = (value: unknown): string => {
-  if (typeof value === "string") {
-    return value;
-  }
-
-  if (!value || typeof value !== "object") {
-    return "";
-  }
-
-  const record = value as Record<string, unknown>;
-  const rawData =
-    record.rawData && typeof record.rawData === "object"
-      ? (record.rawData as Record<string, unknown>)
-      : {};
-
-  return [
-    getStringValue(record, "message"),
-    getStringValue(record, "error"),
-    getStringValue(record, "errorDescription"),
-    getStringValue(rawData, "error"),
-    getStringValue(rawData, "error_description"),
-  ]
-    .filter((text): text is string => Boolean(text))
-    .join("\n");
-};
-
 export const isOauthCodeAlreadyExchangedError = (value: unknown): boolean => {
-  const errorText = collectErrorText(value).toLowerCase();
+  const errorText = collectAuthErrorText(value).toLowerCase();
   return (
     errorText.includes(INVALID_GRANT_ERROR) &&
     errorText.includes(CODE_ALREADY_EXCHANGED_MESSAGE)
@@ -71,13 +42,13 @@ export const isOauthCodeAlreadyExchangedError = (value: unknown): boolean => {
 export const isMissingRequiredAuthParameterError = (
   value: unknown,
 ): boolean => {
-  return collectErrorText(value)
+  return collectAuthErrorText(value)
     .toLowerCase()
     .includes(MISSING_REQUIRED_AUTH_PARAMETER_MESSAGE.toLowerCase());
 };
 
 export const isOAuthStateMismatchError = (value: unknown): boolean => {
-  return collectErrorText(value)
+  return collectAuthErrorText(value)
     .toLowerCase()
     .includes(OAUTH_STATE_MISMATCH_MESSAGE.toLowerCase());
 };
@@ -98,7 +69,7 @@ export const isAuthVerifierMissingError = (value: unknown): boolean => {
     }
   }
 
-  const errorText = collectErrorText(value);
+  const errorText = collectAuthErrorText(value);
   return VERIFIER_SCHEMA_KEYS.some(
     (key) =>
       errorText.includes(`Expected ${key}`) &&
@@ -110,6 +81,7 @@ export const isRecoverableAuthkitCallbackError = (value: unknown): boolean => {
   return (
     isAuthCookieMissingError(value) ||
     isOauthCodeAlreadyExchangedError(value) ||
+    isInvalidCodeVerifierError(value) ||
     isMissingRequiredAuthParameterError(value) ||
     isOAuthStateMismatchError(value) ||
     isAuthVerifierMissingError(value)

--- a/lib/auth/expected-auth-errors.ts
+++ b/lib/auth/expected-auth-errors.ts
@@ -1,0 +1,62 @@
+const INVALID_GRANT_ERROR = "invalid_grant";
+const SESSION_ENDED_MESSAGE = "session has already ended";
+const INVALID_CODE_VERIFIER_MESSAGE = "invalid code verifier";
+
+const getStringValue = (
+  value: Record<string, unknown>,
+  key: string,
+): string | null => {
+  const fieldValue = value[key];
+  return typeof fieldValue === "string" ? fieldValue : null;
+};
+
+export const collectAuthErrorText = (
+  value: unknown,
+  seen = new Set<unknown>(),
+  depth = 0,
+): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (!value || typeof value !== "object" || depth > 4 || seen.has(value)) {
+    return "";
+  }
+  seen.add(value);
+
+  const record = value as Record<string, unknown>;
+  const rawData =
+    record.rawData && typeof record.rawData === "object"
+      ? (record.rawData as Record<string, unknown>)
+      : {};
+
+  return [
+    getStringValue(record, "name"),
+    getStringValue(record, "message"),
+    getStringValue(record, "error"),
+    getStringValue(record, "errorDescription"),
+    getStringValue(record, "error_description"),
+    getStringValue(rawData, "error"),
+    getStringValue(rawData, "errorDescription"),
+    getStringValue(rawData, "error_description"),
+    collectAuthErrorText(record.cause, seen, depth + 1),
+  ]
+    .filter((text): text is string => Boolean(text))
+    .join("\n");
+};
+
+export const isEndedSessionRefreshError = (value: unknown): boolean => {
+  const errorText = collectAuthErrorText(value).toLowerCase();
+  return (
+    errorText.includes(INVALID_GRANT_ERROR) &&
+    errorText.includes(SESSION_ENDED_MESSAGE)
+  );
+};
+
+export const isInvalidCodeVerifierError = (value: unknown): boolean => {
+  const errorText = collectAuthErrorText(value).toLowerCase();
+  return (
+    errorText.includes(INVALID_GRANT_ERROR) &&
+    errorText.includes(INVALID_CODE_VERIFIER_MESSAGE)
+  );
+};

--- a/lib/auth/get-user-id.ts
+++ b/lib/auth/get-user-id.ts
@@ -6,6 +6,7 @@ import {
   parseEntitlements,
   resolveSubscriptionTier,
 } from "@/lib/auth/entitlements";
+import { isEndedSessionRefreshError } from "@/lib/auth/expected-auth-errors";
 
 const getSessionUserEmail = (session: unknown): string | undefined => {
   if (!session || typeof session !== "object") return undefined;
@@ -36,6 +37,9 @@ export const getUserID = async (req: NextRequest): Promise<string> => {
   } catch (error) {
     if (error instanceof ChatSDKError) {
       throw error;
+    }
+    if (isEndedSessionRefreshError(error)) {
+      throw new ChatSDKError("unauthorized:auth");
     }
 
     console.error("Failed to get user session:", error);
@@ -79,6 +83,9 @@ export const getUserIDAndPro = async (
   } catch (error) {
     if (error instanceof ChatSDKError) {
       throw error;
+    }
+    if (isEndedSessionRefreshError(error)) {
+      throw new ChatSDKError("unauthorized:auth");
     }
 
     console.error("Failed to get user session:", error);
@@ -137,6 +144,9 @@ export const getUserIDWithFreshLoginContext = async (
   } catch (error) {
     if (error instanceof ChatSDKError) {
       throw error;
+    }
+    if (isEndedSessionRefreshError(error)) {
+      throw new ChatSDKError("unauthorized:auth", "recent_login_required");
     }
 
     console.error("Failed to verify fresh login:", error);

--- a/lib/utils/__tests__/redis-pubsub.test.ts
+++ b/lib/utils/__tests__/redis-pubsub.test.ts
@@ -1,0 +1,68 @@
+import {
+  describe,
+  expect,
+  it,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+
+const mockCreateClient = jest.fn();
+
+jest.mock("redis", () => ({
+  createClient: mockCreateClient,
+}));
+
+describe("createRedisSubscriber", () => {
+  const originalRedisUrl = process.env.REDIS_URL;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.REDIS_URL = "redis://localhost:6379";
+  });
+
+  afterEach(() => {
+    process.env.REDIS_URL = originalRedisUrl;
+    jest.restoreAllMocks();
+  });
+
+  it("uses a default warning sink when no onError callback is provided", async () => {
+    const listeners = new Map<string, (error: unknown) => void>();
+    const client = {
+      on: jest.fn((event: string, listener: (error: unknown) => void) => {
+        listeners.set(event, listener);
+        return client;
+      }),
+      connect: jest.fn(async () => {}),
+    };
+    mockCreateClient.mockReturnValue(client);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { createRedisSubscriber } = await import("../redis-pubsub");
+    await createRedisSubscriber();
+
+    const error = new Error("read ETIMEDOUT");
+    listeners.get("error")?.(error);
+
+    expect(warnSpy).toHaveBeenCalledWith("Redis subscriber error:", error);
+  });
+
+  it("uses the supplied onError callback instead of the default warning sink", async () => {
+    const client = {
+      on: jest.fn(),
+      connect: jest.fn(async () => {
+        throw new Error("connect failed");
+      }),
+    };
+    mockCreateClient.mockReturnValue(client);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const onError = jest.fn();
+
+    const { createRedisSubscriber } = await import("../redis-pubsub");
+    const subscriber = await createRedisSubscriber({ onError });
+
+    expect(subscriber).toBeNull();
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/lib/utils/__tests__/stream-cancellation.test.ts
+++ b/lib/utils/__tests__/stream-cancellation.test.ts
@@ -1,0 +1,101 @@
+import {
+  describe,
+  expect,
+  it,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+
+const mockCreateRedisSubscriber = jest.fn();
+const mockGetCancellationStatus = jest.fn();
+const mockPhLoggerWarn = jest.fn();
+
+jest.mock("@/lib/utils/redis-pubsub", () => ({
+  createRedisSubscriber: mockCreateRedisSubscriber,
+  getCancelChannel: jest.fn((chatId: string) => `stream:cancel:${chatId}`),
+}));
+
+jest.mock("@/lib/db/actions", () => ({
+  getCancellationStatus: mockGetCancellationStatus,
+  getTempCancellationStatus: jest.fn(),
+}));
+
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: {
+    warn: mockPhLoggerWarn,
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe("createCancellationSubscriber", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("falls back to polling when a live Redis subscriber errors", async () => {
+    const { createCancellationSubscriber } =
+      await import("../stream-cancellation");
+    let runtimeError: ((error: unknown) => void) | undefined;
+    const redisSubscriber = {
+      subscribe: jest.fn(async () => {}),
+      unsubscribe: jest.fn(async () => {}),
+      quit: jest.fn(async () => {}),
+    };
+    mockCreateRedisSubscriber.mockImplementation(async (options) => {
+      runtimeError = options.onError;
+      return redisSubscriber;
+    });
+    mockGetCancellationStatus.mockResolvedValue({
+      canceled_at: Date.now(),
+    });
+
+    const abortController = new AbortController();
+    const onStop = jest.fn();
+
+    const subscriber = await createCancellationSubscriber({
+      chatId: "chat-123",
+      isTemporary: false,
+      abortController,
+      onStop,
+      pollIntervalMs: 10,
+    });
+
+    runtimeError?.(
+      Object.assign(new Error("read ETIMEDOUT"), {
+        code: "ETIMEDOUT",
+        syscall: "read",
+      }),
+    );
+
+    jest.advanceTimersByTime(10);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockPhLoggerWarn).toHaveBeenCalledWith(
+      "redis_pubsub_unavailable",
+      expect.objectContaining({
+        event: "redis.pubsub_unavailable",
+        chatId: "chat-123",
+        isTemporary: false,
+      }),
+    );
+    expect(redisSubscriber.unsubscribe).toHaveBeenCalledWith(
+      "stream:cancel:chat-123",
+    );
+    expect(redisSubscriber.quit).toHaveBeenCalled();
+    expect(mockGetCancellationStatus).toHaveBeenCalledWith({
+      chatId: "chat-123",
+    });
+    expect(abortController.signal.aborted).toBe(true);
+    expect(onStop).toHaveBeenCalledTimes(1);
+
+    await subscriber.stop();
+  });
+});

--- a/lib/utils/redis-pubsub.ts
+++ b/lib/utils/redis-pubsub.ts
@@ -1,10 +1,16 @@
 import { createClient } from "redis";
 
+type RedisSubscriberOptions = {
+  onError?: (error: unknown) => void;
+};
+
 /**
  * Create a dedicated subscriber client for a specific channel.
  * Each subscription needs its own client in Redis pub/sub.
  */
-export async function createRedisSubscriber() {
+export async function createRedisSubscriber(
+  options: RedisSubscriberOptions = {},
+) {
   const redisUrl = process.env.REDIS_URL;
 
   if (!redisUrl) {
@@ -14,12 +20,12 @@ export async function createRedisSubscriber() {
   try {
     const subscriber = createClient({ url: redisUrl });
     subscriber.on("error", (err) => {
-      console.error("Redis subscriber error:", err);
+      options.onError?.(err);
     });
     await subscriber.connect();
     return subscriber;
   } catch (error) {
-    console.warn("Failed to connect Redis subscriber:", error);
+    options.onError?.(error);
     return null;
   }
 }

--- a/lib/utils/redis-pubsub.ts
+++ b/lib/utils/redis-pubsub.ts
@@ -12,6 +12,11 @@ export async function createRedisSubscriber(
   options: RedisSubscriberOptions = {},
 ) {
   const redisUrl = process.env.REDIS_URL;
+  const onError =
+    options.onError ??
+    ((error: unknown) => {
+      console.warn("Redis subscriber error:", error);
+    });
 
   if (!redisUrl) {
     return null;
@@ -20,12 +25,12 @@ export async function createRedisSubscriber(
   try {
     const subscriber = createClient({ url: redisUrl });
     subscriber.on("error", (err) => {
-      options.onError?.(err);
+      onError(err);
     });
     await subscriber.connect();
     return subscriber;
   } catch (error) {
-    options.onError?.(error);
+    onError(error);
     return null;
   }
 }

--- a/lib/utils/stream-cancellation.ts
+++ b/lib/utils/stream-cancellation.ts
@@ -119,6 +119,7 @@ export const createCancellationSubscriber = async ({
   pollIntervalMs = 1000,
 }: PollOptions): Promise<CancellationSubscriberResult> => {
   let subscriber: Awaited<ReturnType<typeof createRedisSubscriber>> = null;
+  let fallbackPoller: CancellationSubscriberResult | null = null;
   let stopped = false;
   let onStopCalled = false;
   const channel = getCancelChannel(chatId);
@@ -141,8 +142,31 @@ export const createCancellationSubscriber = async ({
     }
   };
 
+  const startPollingFallback = (error: unknown) => {
+    if (stopped || fallbackPoller || abortController.signal.aborted) {
+      return;
+    }
+
+    phLogger.warn("redis_pubsub_unavailable", {
+      event: "redis.pubsub_unavailable",
+      chatId,
+      isTemporary,
+      error,
+    });
+    cleanupSubscriber();
+    fallbackPoller = createCancellationPoller({
+      chatId,
+      isTemporary,
+      abortController,
+      onStop: callOnStopOnce,
+      pollIntervalMs,
+    });
+  };
+
   try {
-    subscriber = await createRedisSubscriber();
+    subscriber = await createRedisSubscriber({
+      onError: startPollingFallback,
+    });
 
     if (subscriber) {
       // Track skipSave flag from cancellation message
@@ -173,6 +197,17 @@ export const createCancellationSubscriber = async ({
         }
       });
 
+      if (fallbackPoller) {
+        return {
+          stop: async () => {
+            stopped = true;
+            await fallbackPoller?.stop();
+          },
+          isUsingPubSub: false,
+          shouldSkipSave: () => fallbackPoller?.shouldSkipSave() ?? false,
+        };
+      }
+
       abortController.signal.addEventListener("abort", handleAbort, {
         once: true,
       });
@@ -182,14 +217,27 @@ export const createCancellationSubscriber = async ({
           stopped = true;
           abortController.signal.removeEventListener("abort", handleAbort);
           cleanupSubscriber();
+          await fallbackPoller?.stop();
         },
         isUsingPubSub: true,
-        shouldSkipSave: () => skipSave,
+        shouldSkipSave: () =>
+          skipSave || (fallbackPoller?.shouldSkipSave() ?? false),
       };
     }
   } catch (error) {
-    console.error("[Redis Pub/Sub] Subscription failed:", error);
+    startPollingFallback(error);
     cleanupSubscriber();
+  }
+
+  if (fallbackPoller) {
+    return {
+      stop: async () => {
+        stopped = true;
+        await fallbackPoller?.stop();
+      },
+      isUsingPubSub: false,
+      shouldSkipSave: () => fallbackPoller?.shouldSkipSave() ?? false,
+    };
   }
 
   // Fallback to polling when Redis is unavailable

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,7 @@
 import { authkit } from "@workos-inc/authkit-nextjs";
 import { NextResponse, type NextRequest } from "next/server";
 import { isRateLimitError } from "@/lib/api/response";
+import { isEndedSessionRefreshError } from "@/lib/auth/expected-auth-errors";
 import {
   REFERRAL_COOKIE_CREATED_AT_NAME,
   REFERRAL_COOKIE_NAME,
@@ -117,12 +118,38 @@ export default async function proxy(request: NextRequest) {
     redirectUri: getRedirectUri(),
     eagerAuth: true,
     onSessionRefreshError: ({ error }) => {
+      if (isEndedSessionRefreshError(error)) {
+        return;
+      }
+
       if (isRateLimitError(error)) {
         refreshHitRateLimit = true;
         console.warn(
-          "[Auth Proxy] WorkOS rate limit hit during session refresh",
+          JSON.stringify({
+            timestamp: new Date().toISOString(),
+            level: "warn",
+            event: "auth.session_refresh_rate_limited",
+            service: "hackerai-web",
+            environment:
+              process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+            pathname,
+          }),
         );
+        return;
       }
+
+      console.warn(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          level: "warn",
+          event: "auth.session_refresh_failed",
+          service: "hackerai-web",
+          environment:
+            process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+          pathname,
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      );
     },
   });
 


### PR DESCRIPTION
## Summary
- classify expected WorkOS session-ended refresh errors so they no longer surface as app errors
- recover AuthKit callback `invalid_grant` / invalid-code-verifier failures through the existing login retry path
- make Redis pub/sub cancellation subscriber failures fall back to polling, keep default Redis subscriber warning logs for callers without `onError`, and downgrade handled Centrifugo presence probe failures to structured warn telemetry

## Testing
- corepack pnpm test -- lib/auth/__tests__/expected-auth-errors.test.ts lib/auth/__tests__/authkit-callback-logging.test.ts lib/utils/__tests__/stream-cancellation.test.ts lib/utils/__tests__/redis-pubsub.test.ts --runInBand
- corepack pnpm typecheck
- corepack pnpm exec eslint lib/auth/expected-auth-errors.ts lib/auth/authkit-callback-logging.ts app/callback/route.ts instrumentation.ts proxy.ts lib/auth/get-user-id.ts lib/utils/redis-pubsub.ts lib/utils/stream-cancellation.ts app/api/sandbox/presence/route.ts lib/auth/__tests__/expected-auth-errors.test.ts lib/auth/__tests__/authkit-callback-logging.test.ts lib/utils/__tests__/stream-cancellation.test.ts lib/utils/__tests__/redis-pubsub.test.ts
- corepack pnpm exec prettier --check lib/auth/expected-auth-errors.ts lib/auth/authkit-callback-logging.ts app/callback/route.ts instrumentation.ts proxy.ts lib/auth/get-user-id.ts lib/utils/redis-pubsub.ts lib/utils/stream-cancellation.ts app/api/sandbox/presence/route.ts lib/auth/__tests__/expected-auth-errors.test.ts lib/auth/__tests__/authkit-callback-logging.test.ts lib/utils/__tests__/stream-cancellation.test.ts lib/utils/__tests__/redis-pubsub.test.ts
- git diff --check

## Manual verification
- For a revoked/ended WorkOS session, load the app and confirm it redirects or returns auth failure without a Next.js request error.
- Start a login flow that hits an invalid code verifier and confirm the callback redirects to retry login instead of `/auth-error?code=500`.
- During a chat stream, force the Redis subscriber connection to timeout and confirm stream cancellation still works through polling.

Visual verification is not needed; this is backend auth/error-handling and telemetry behavior.