### PR TITLE
Retry compaction summaries on malformed provider JSON

### DIFF
--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -26,6 +26,9 @@ import { MAX_TOKENS_PAID, safeCountTokens } from "@/lib/token-utils";
 
 const mockGenerateText = jest.fn<() => Promise<any>>();
 const mockSaveChatSummary = jest.fn<() => Promise<void>>();
+const mockProviderLanguageModel = jest.fn(
+  (modelName: string) => ({ modelId: modelName }) as unknown as LanguageModel,
+);
 
 jest.doMock("server-only", () => ({}));
 jest.doMock("ai", () => ({
@@ -37,7 +40,7 @@ jest.doMock("@/lib/db/actions", () => ({
 }));
 jest.doMock("@/lib/ai/providers", () => ({
   myProvider: {
-    languageModel: () => ({}) as LanguageModel,
+    languageModel: mockProviderLanguageModel,
   },
 }));
 
@@ -169,6 +172,8 @@ describe("checkAndSummarizeIfNeeded", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, "info").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
     mockSaveChatSummary.mockResolvedValue(undefined);
     mockWriter = createMockWriter();
   });
@@ -804,6 +809,7 @@ describe("checkAndSummarizeIfNeeded", () => {
 
     expect(result.needsSummarization).toBe(false);
     expect(result.summaryText).toBeNull();
+    expect(mockGenerateText).toHaveBeenCalledTimes(1);
 
     const writeCalls = (mockWriter.write as jest.Mock).mock.calls;
     const completedWrite = writeCalls.find(
@@ -812,6 +818,153 @@ describe("checkAndSummarizeIfNeeded", () => {
         call[0]?.data?.status === "completed",
     );
     expect(completedWrite).toBeDefined();
+  });
+
+  it("retries malformed provider JSON with the fallback summarization model", async () => {
+    const malformedJsonError = Object.assign(
+      new Error("Invalid JSON response"),
+      {
+        statusCode: 200,
+        responseBody: "\n         \n\n",
+        responseHeaders: {
+          "x-generation-id": "gen-primary",
+        },
+      },
+    );
+    mockGenerateText
+      .mockRejectedValueOnce(malformedJsonError)
+      .mockResolvedValueOnce({
+        text: "Fallback summary",
+        usage: { inputTokens: 10, outputTokens: 3 },
+      });
+
+    const result = await checkAndSummarizeForTest(
+      fourMessagesAboveThreshold,
+      "free",
+      mockLanguageModel,
+      "ask",
+      mockWriter,
+      "chat-retry",
+      {},
+      [],
+      undefined,
+      undefined,
+      0,
+      0,
+      "test-system-prompt",
+      {
+        runCommand: {
+          description: "run a command",
+          inputSchema: {} as any,
+          execute: jest.fn(),
+        },
+      } as unknown as ToolSet,
+      {
+        openrouter: {
+          user: "user_123",
+          reasoning: { enabled: false },
+          models: ["minimax/minimax-m3"],
+        },
+      },
+    );
+
+    expect(result.needsSummarization).toBe(true);
+    expect(result.summaryText).toBe("Fallback summary");
+    expect(mockGenerateText).toHaveBeenCalledTimes(2);
+    expect(mockProviderLanguageModel).toHaveBeenCalledWith(
+      "fallback-ask-model",
+    );
+
+    const retryCall = mockGenerateText.mock.calls[1][0];
+    expect(retryCall.model).toMatchObject({ modelId: "fallback-ask-model" });
+    expect(retryCall.tools).toBeUndefined();
+    expect(retryCall.providerOptions).toEqual({
+      openrouter: {
+        user: "user_123",
+        reasoning: { enabled: false },
+      },
+    });
+
+    const retryLogCall = (console.warn as jest.Mock).mock.calls.find((call) =>
+      String(call[0]).includes('"event":"chat_context_compaction_retrying"'),
+    );
+    expect(retryLogCall).toBeTruthy();
+
+    const retryLog = JSON.parse(String(retryLogCall?.[0]));
+    expect(retryLog).toMatchObject({
+      level: "warn",
+      event: "chat_context_compaction_retrying",
+      service: "chat-handler",
+      chat_id: "chat-retry",
+      mode: "ask",
+      subscription: "free",
+      summarization_attempt: "primary",
+      retry_model_name: "fallback-ask-model",
+      retry_without_tools: true,
+      provider_status_code: 200,
+      openrouter_generation_id: "gen-primary",
+      response_body_empty: true,
+    });
+
+    expect(mockSaveChatSummary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: "chat-retry",
+        metadata: expect.objectContaining({
+          model: "fallback-ask-model",
+        }),
+      }),
+    );
+  });
+
+  it("logs structured compaction failure when malformed JSON retry also fails", async () => {
+    const malformedJsonError = Object.assign(
+      new Error("Invalid JSON response"),
+      {
+        statusCode: 200,
+        responseBody: "\n\n",
+      },
+    );
+    mockGenerateText
+      .mockRejectedValueOnce(malformedJsonError)
+      .mockRejectedValueOnce(new Error("Fallback provider unavailable"));
+
+    const result = await checkAndSummarizeForTest(
+      fourMessagesAboveThreshold,
+      "free",
+      mockLanguageModel,
+      "ask",
+      mockWriter,
+      "chat-retry-failed",
+      {},
+      [],
+      undefined,
+      undefined,
+      0,
+      0,
+      "test-system-prompt",
+    );
+
+    expect(result.needsSummarization).toBe(false);
+    expect(mockGenerateText).toHaveBeenCalledTimes(2);
+
+    const failedLogCall = (console.error as jest.Mock).mock.calls.find((call) =>
+      String(call[0]).includes('"event":"chat_context_compaction_failed"'),
+    );
+    expect(failedLogCall).toBeTruthy();
+
+    const failedLog = JSON.parse(String(failedLogCall?.[0]));
+    expect(failedLog).toMatchObject({
+      level: "error",
+      event: "chat_context_compaction_failed",
+      service: "chat-handler",
+      chat_id: "chat-retry-failed",
+      mode: "ask",
+      subscription: "free",
+      summarization_attempt: "fallback",
+      model_id: "fallback-ask-model",
+      fallback_result: "no_summarization",
+      error_message: "Fallback provider unavailable",
+    });
   });
 
   it("should write summarization completed even when database save fails", async () => {

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -916,6 +916,51 @@ describe("checkAndSummarizeIfNeeded", () => {
     );
   });
 
+  it("retries malformed provider JSON nested in retry wrapper errors", async () => {
+    const malformedJsonError = Object.assign(
+      new Error("JSON parsing failed: Unexpected end of JSON input"),
+      {
+        statusCode: 200,
+        responseBody: "   \n\n",
+      },
+    );
+    const retryWrapperError = Object.assign(
+      new Error("AI retry attempts exhausted"),
+      {
+        errors: [malformedJsonError],
+      },
+    );
+    mockGenerateText
+      .mockRejectedValueOnce(retryWrapperError)
+      .mockResolvedValueOnce({
+        text: "Nested fallback summary",
+        usage: { inputTokens: 10, outputTokens: 3 },
+      });
+
+    const result = await checkAndSummarizeForTest(
+      fourMessagesAboveThreshold,
+      "free",
+      mockLanguageModel,
+      "ask",
+      mockWriter,
+      "chat-nested-retry",
+      {},
+      [],
+      undefined,
+      undefined,
+      0,
+      0,
+      "test-system-prompt",
+    );
+
+    expect(result.needsSummarization).toBe(true);
+    expect(result.summaryText).toBe("Nested fallback summary");
+    expect(mockGenerateText).toHaveBeenCalledTimes(2);
+    expect(mockProviderLanguageModel).toHaveBeenCalledWith(
+      "fallback-ask-model",
+    );
+  });
+
   it("logs structured compaction failure when malformed JSON retry also fails", async () => {
     const malformedJsonError = Object.assign(
       new Error("Invalid JSON response"),

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -16,6 +16,7 @@ import {
 } from "@/lib/utils/stream-writer-utils";
 import { isE2BSandbox } from "@/lib/ai/tools/utils/sandbox-types";
 import type { Id } from "@/convex/_generated/dataModel";
+import { myProvider } from "@/lib/ai/providers";
 import type { ProviderPromptPressure } from "./provider-pressure";
 
 import {
@@ -48,6 +49,227 @@ type CompactionLogReason =
   | "provider_pressure"
   | "provider_input_tokens"
   | "estimated_token_threshold";
+
+type SummarizationAttempt = "primary" | "fallback";
+
+const SUMMARIZATION_RETRY_MODEL_BY_MODE: Record<ChatMode, string> = {
+  ask: "fallback-ask-model",
+  agent: "fallback-agent-model",
+};
+const SUMMARIZATION_ATTEMPT_ERROR_KEY = "__hackeraiSummarizationAttempt";
+
+const getLanguageModelId = (
+  languageModel: LanguageModel,
+): string | undefined => {
+  const modelId = (languageModel as { modelId?: unknown }).modelId;
+  return typeof modelId === "string" && modelId.length > 0
+    ? modelId
+    : undefined;
+};
+
+const getErrorRecord = (error: unknown): Record<string, unknown> | null =>
+  typeof error === "object" && error !== null
+    ? (error as Record<string, unknown>)
+    : null;
+
+const getHeaderValue = (
+  headers: unknown,
+  headerName: string,
+): string | undefined => {
+  if (!headers) return undefined;
+  if (headers instanceof Headers) {
+    return (
+      headers.get(headerName) ??
+      headers.get(headerName.toLowerCase()) ??
+      undefined
+    );
+  }
+  if (typeof headers !== "object" || headers === null) return undefined;
+
+  const lowerHeaderName = headerName.toLowerCase();
+  for (const [key, value] of Object.entries(
+    headers as Record<string, unknown>,
+  )) {
+    if (key.toLowerCase() !== lowerHeaderName) continue;
+    return typeof value === "string" ? value : undefined;
+  }
+
+  return undefined;
+};
+
+const getBoundedErrorMessage = (error: unknown): string | undefined => {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.length > 300 ? `${message.slice(0, 300)}...` : message;
+};
+
+const getBoundedErrorStack = (error: unknown): string | undefined => {
+  if (!(error instanceof Error) || !error.stack) return undefined;
+  return error.stack.length > 1200
+    ? `${error.stack.slice(0, 1200)}...`
+    : error.stack;
+};
+
+const markSummarizationAttemptError = (
+  error: unknown,
+  attempt: SummarizationAttempt,
+) => {
+  const record = getErrorRecord(error);
+  if (record) {
+    record[SUMMARIZATION_ATTEMPT_ERROR_KEY] = attempt;
+  }
+};
+
+const getSummarizationAttemptFromError = (
+  error: unknown,
+): SummarizationAttempt => {
+  const record = getErrorRecord(error);
+  return record?.[SUMMARIZATION_ATTEMPT_ERROR_KEY] === "fallback"
+    ? "fallback"
+    : "primary";
+};
+
+const summarizeSummarizationErrorForLog = (error: unknown) => {
+  const record = getErrorRecord(error);
+  const responseBody =
+    typeof record?.responseBody === "string" ? record.responseBody : undefined;
+
+  return {
+    error_name:
+      error instanceof Error && error.name ? error.name : typeof error,
+    error_message: getBoundedErrorMessage(error),
+    error_stack: getBoundedErrorStack(error),
+    provider_status_code:
+      typeof record?.statusCode === "number" ? record.statusCode : undefined,
+    openrouter_generation_id: getHeaderValue(
+      record?.responseHeaders,
+      "x-generation-id",
+    ),
+    response_body_empty:
+      responseBody !== undefined ? responseBody.trim().length === 0 : undefined,
+    response_body_length: responseBody?.length,
+  };
+};
+
+const isMalformedProviderJsonError = (
+  error: unknown,
+  depth: number = 0,
+): boolean => {
+  if (depth > 4) return false;
+
+  const message = error instanceof Error ? error.message : String(error);
+  const record = getErrorRecord(error);
+  const responseBody =
+    typeof record?.responseBody === "string" ? record.responseBody : undefined;
+  const statusCode =
+    typeof record?.statusCode === "number" ? record.statusCode : undefined;
+
+  if (
+    message.includes("Invalid JSON response") ||
+    message.includes("JSON parsing failed") ||
+    (error instanceof Error && error.name === "AI_JSONParseError") ||
+    (statusCode === 200 &&
+      responseBody !== undefined &&
+      responseBody.trim().length === 0)
+  ) {
+    return true;
+  }
+
+  return record?.cause !== undefined
+    ? isMalformedProviderJsonError(record.cause, depth + 1)
+    : false;
+};
+
+const buildSummarizationRetryProviderOptions = (
+  providerOptions?: Record<string, Record<string, unknown>>,
+): Record<string, Record<string, unknown>> | undefined => {
+  if (!providerOptions) return undefined;
+
+  const retryProviderOptions: Record<string, Record<string, unknown>> = {};
+  for (const [providerName, options] of Object.entries(providerOptions)) {
+    retryProviderOptions[providerName] = { ...options };
+  }
+
+  if (retryProviderOptions.openrouter) {
+    delete retryProviderOptions.openrouter.models;
+  }
+
+  return retryProviderOptions;
+};
+
+const logContextCompactionRetrying = ({
+  chatId,
+  mode,
+  subscription,
+  reason,
+  attempt,
+  languageModel,
+  retryModelName,
+  error,
+}: {
+  chatId: string | null;
+  mode: ChatMode;
+  subscription: SubscriptionTier;
+  reason: CompactionLogReason;
+  attempt: SummarizationAttempt;
+  languageModel: LanguageModel;
+  retryModelName: string;
+  error: unknown;
+}) => {
+  console.warn(
+    JSON.stringify({
+      level: "warn",
+      event: "chat_context_compaction_retrying",
+      service: "chat-handler",
+      timestamp: new Date().toISOString(),
+      chat_id: chatId ?? undefined,
+      mode,
+      subscription,
+      reason,
+      summarization_attempt: attempt,
+      model_id: getLanguageModelId(languageModel),
+      retry_model_name: retryModelName,
+      retry_without_tools: true,
+      ...summarizeSummarizationErrorForLog(error),
+    }),
+  );
+};
+
+const logContextCompactionFailed = ({
+  chatId,
+  mode,
+  subscription,
+  reason,
+  attempt,
+  languageModel,
+  fallbackResult,
+  error,
+}: {
+  chatId: string | null;
+  mode: ChatMode;
+  subscription: SubscriptionTier;
+  reason: CompactionLogReason;
+  attempt: SummarizationAttempt;
+  languageModel: LanguageModel;
+  fallbackResult: "no_summarization";
+  error: unknown;
+}) => {
+  console.error(
+    JSON.stringify({
+      level: "error",
+      event: "chat_context_compaction_failed",
+      service: "chat-handler",
+      timestamp: new Date().toISOString(),
+      chat_id: chatId ?? undefined,
+      mode,
+      subscription,
+      reason,
+      summarization_attempt: attempt,
+      model_id: getLanguageModelId(languageModel),
+      fallback_result: fallbackResult,
+      ...summarizeSummarizationErrorForLog(error),
+    }),
+  );
+};
 
 export interface CheckAndSummarizeOptions {
   uiMessages: UIMessage[];
@@ -190,6 +412,102 @@ const logContextCompactionStarted = ({
       retained_tail_projected_part_count: retainedTail?.projected_part_count,
     }),
   );
+};
+
+const generateSummaryTextWithRetry = async ({
+  messagesToSummarize,
+  languageModel,
+  mode,
+  chatSystemPrompt,
+  hasExistingSummary,
+  tools,
+  providerOptions,
+  abortSignal,
+  summaryInputMaxTokens,
+  chatId,
+  subscription,
+  reason,
+}: {
+  messagesToSummarize: UIMessage[];
+  languageModel: LanguageModel;
+  mode: ChatMode;
+  chatSystemPrompt: string;
+  hasExistingSummary: boolean;
+  tools?: ToolSet;
+  providerOptions?: Record<string, Record<string, unknown>>;
+  abortSignal?: AbortSignal;
+  summaryInputMaxTokens: number;
+  chatId: string | null;
+  subscription: SubscriptionTier;
+  reason: CompactionLogReason;
+}): Promise<
+  Awaited<ReturnType<typeof generateSummaryText>> & {
+    languageModel: LanguageModel;
+    attempt: SummarizationAttempt;
+  }
+> => {
+  try {
+    const result = await generateSummaryText(
+      messagesToSummarize,
+      languageModel,
+      mode,
+      chatSystemPrompt,
+      hasExistingSummary,
+      tools,
+      providerOptions,
+      abortSignal,
+      undefined,
+      summaryInputMaxTokens,
+    );
+
+    return {
+      ...result,
+      languageModel,
+      attempt: "primary",
+    };
+  } catch (error) {
+    if (abortSignal?.aborted || !isMalformedProviderJsonError(error)) {
+      throw error;
+    }
+
+    const retryModelName = SUMMARIZATION_RETRY_MODEL_BY_MODE[mode];
+    const retryLanguageModel = myProvider.languageModel(retryModelName);
+    logContextCompactionRetrying({
+      chatId,
+      mode,
+      subscription,
+      reason,
+      attempt: "primary",
+      languageModel,
+      retryModelName,
+      error,
+    });
+
+    let result: Awaited<ReturnType<typeof generateSummaryText>>;
+    try {
+      result = await generateSummaryText(
+        messagesToSummarize,
+        retryLanguageModel,
+        mode,
+        chatSystemPrompt,
+        hasExistingSummary,
+        undefined,
+        buildSummarizationRetryProviderOptions(providerOptions),
+        abortSignal,
+        undefined,
+        summaryInputMaxTokens,
+      );
+    } catch (retryError) {
+      markSummarizationAttemptError(retryError, "fallback");
+      throw retryError;
+    }
+
+    return {
+      ...result,
+      languageModel: retryLanguageModel,
+      attempt: "fallback",
+    };
+  }
 };
 
 /**
@@ -358,15 +676,16 @@ export const checkAndSummarizeIfNeeded = async ({
     : tailSelection.headMessages;
 
   const cutoffMessageId = tailSelection.cutoffMessageId;
+  const compactionReason = getCompactionLogReason({
+    providerPromptPressure,
+    providerInputTokens,
+    summarizationThreshold,
+  });
   logContextCompactionStarted({
     chatId,
     mode,
     subscription,
-    reason: getCompactionLogReason({
-      providerPromptPressure,
-      providerInputTokens,
-      summarizationThreshold,
-    }),
+    reason: compactionReason,
     totalEstimatedTokens,
     systemPromptTokens,
     providerInputTokens,
@@ -383,18 +702,20 @@ export const checkAndSummarizeIfNeeded = async ({
   try {
     // Run summary generation and transcript saving in parallel — they are
     // independent (transcript is formatted from raw messages, not the summary).
-    const summaryPromise = generateSummaryText(
+    const summaryPromise = generateSummaryTextWithRetry({
       messagesToSummarize,
       languageModel,
       mode,
       chatSystemPrompt,
-      !!existingSummaryText,
+      hasExistingSummary: !!existingSummaryText,
       tools,
       providerOptions,
       abortSignal,
-      undefined,
-      getSummaryInputMaxTokens(maxTokens),
-    );
+      summaryInputMaxTokens: getSummaryInputMaxTokens(maxTokens),
+      chatId,
+      subscription,
+      reason: compactionReason,
+    });
 
     // In agent modes, save the full transcript of summarized messages to the sandbox
     // so the agent can consult the raw conversation later if context is lost
@@ -422,7 +743,11 @@ export const checkAndSummarizeIfNeeded = async ({
       transcriptPromise,
     ]);
 
-    const { text: summaryText, usage: summarizationUsage } = summaryResult;
+    const {
+      text: summaryText,
+      usage: summarizationUsage,
+      languageModel: summaryLanguageModel,
+    } = summaryResult;
     let finalSummaryText = summaryText;
     if (savedPath) {
       finalSummaryText += buildTranscriptNotice(savedPath);
@@ -432,7 +757,7 @@ export const checkAndSummarizeIfNeeded = async ({
     const metadata = buildSummaryPersistenceMetadata({
       providerInputTokens,
       threshold: summarizationThreshold,
-      languageModel,
+      languageModel: summaryLanguageModel,
       transcriptPath: savedPath,
       retainedTail: tailSelection.retainedTail,
       reason: providerPromptPressure ? "provider_pressure" : undefined,
@@ -451,7 +776,20 @@ export const checkAndSummarizeIfNeeded = async ({
     if (abortSignal?.aborted) {
       throw error;
     }
-    console.error("[Summarization] Failed:", error);
+    const failedAttempt = getSummarizationAttemptFromError(error);
+    logContextCompactionFailed({
+      chatId,
+      mode,
+      subscription,
+      reason: compactionReason,
+      attempt: failedAttempt,
+      languageModel:
+        failedAttempt === "fallback"
+          ? myProvider.languageModel(SUMMARIZATION_RETRY_MODEL_BY_MODE[mode])
+          : languageModel,
+      fallbackResult: "no_summarization",
+      error,
+    });
     return NO_SUMMARIZATION(uiMessages);
   } finally {
     if (!abortSignal?.aborted) {

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -174,6 +174,12 @@ const isMalformedProviderJsonError = (
     return true;
   }
 
+  if (Array.isArray(record?.errors)) {
+    return record.errors.some((nestedError) =>
+      isMalformedProviderJsonError(nestedError, depth + 1),
+    );
+  }
+
   return record?.cause !== undefined
     ? isMalformedProviderJsonError(record.cause, depth + 1)
     : false;


### PR DESCRIPTION
## Summary
- retry context compaction summarization once when the provider returns malformed or empty JSON
- route the retry through the fallback summary model without tools or the original OpenRouter fallback chain
- add structured retry/failure logs with bounded error metadata and update summary metadata to record the model that actually produced the summary
- cover malformed-JSON retry success, exhausted retry failure logging, and generic non-retry failures

## Validation
- ./node_modules/.bin/jest lib/chat/summarization/__tests__/index.test.ts --runInBand
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/eslint lib/chat/summarization/index.ts lib/chat/summarization/__tests__/index.test.ts
- ./node_modules/.bin/prettier --check lib/chat/summarization/index.ts lib/chat/summarization/__tests__/index.test.ts
- pre-commit hook: tsc --noEmit
- pre-commit hook: jest (178 suites, 1882 tests)

## Manual verification
- In Ask mode, use or simulate a long chat that triggers `chat_context_compaction_started`.
- Force the primary summarization request to return HTTP 200 with an empty/whitespace JSON body.
- Confirm `chat_context_compaction_retrying` is logged, the retry uses `fallback-ask-model` without tool definitions, and the chat continues with `had_summarization: true` when the retry succeeds.
- Force both primary and fallback summarization to fail and confirm `chat_context_compaction_failed` is logged with `fallback_result: no_summarization` while the existing chat fallback path remains graceful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat summarization reliability by automatically retrying with a fallback model when the initial provider output is malformed or empty.
  * Ensured the saved chat summary metadata reflects the model that produced the final result.
  * Added clearer, structured retry/failure handling so summarization failures are recorded consistently when both attempts fail.
* **Tests**
  * Expanded coverage for retry behavior, including malformed provider responses, correct retry model selection, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->