### PR TITLE
Bypass auth for Trigger health endpoint

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { NextRequest } from "next/server";
+
+const mockAuthkit = jest.fn();
+const mockNextResponseNext = jest.fn((init?: unknown) =>
+  mockCreateResponse("next", undefined, init),
+);
+const mockNextResponseJson = jest.fn((body: unknown, init?: unknown) =>
+  mockCreateResponse("json", body, init),
+);
+const mockNextResponseRedirect = jest.fn((url: URL, init?: unknown) =>
+  mockCreateResponse("redirect", url, init),
+);
+
+function mockCreateResponse(kind: string, body?: unknown, init?: unknown) {
+  return {
+    kind,
+    body,
+    init,
+    cookies: {
+      set: jest.fn(),
+    },
+  };
+}
+
+jest.mock("@workos-inc/authkit-nextjs", () => ({
+  authkit: mockAuthkit,
+}));
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    next: mockNextResponseNext,
+    json: mockNextResponseJson,
+    redirect: mockNextResponseRedirect,
+  },
+}));
+
+function createRequest({
+  pathname,
+  accept = "application/json",
+  hasSession = false,
+  userAgent = "BetterStack",
+}: {
+  pathname: string;
+  accept?: string;
+  hasSession?: boolean;
+  userAgent?: string;
+}): NextRequest {
+  const url = new URL(pathname, "https://hackerai.co");
+  return {
+    nextUrl: url,
+    url: url.toString(),
+    headers: new Headers({
+      accept,
+      "user-agent": userAgent,
+    }),
+    cookies: {
+      has: jest.fn((name: string) => name === "wos-session" && hasSession),
+    },
+  } as unknown as NextRequest;
+}
+
+describe("proxy", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockAuthkit.mockReset();
+    mockNextResponseNext.mockClear();
+    mockNextResponseJson.mockClear();
+    mockNextResponseRedirect.mockClear();
+  });
+
+  it("bypasses AuthKit for the Trigger Agent health endpoint", async () => {
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/api/health/trigger-agent-mode",
+        hasSession: true,
+      }),
+    );
+
+    expect(response).toMatchObject({ kind: "next" });
+    expect(mockAuthkit).not.toHaveBeenCalled();
+    expect(mockNextResponseNext).toHaveBeenCalledWith();
+    expect(mockNextResponseJson).not.toHaveBeenCalled();
+    expect(mockNextResponseRedirect).not.toHaveBeenCalled();
+  });
+
+  it("still requires auth for protected API routes", async () => {
+    mockAuthkit.mockResolvedValue({
+      session: { user: null },
+      headers: new Headers(),
+      authorizationUrl: "https://auth.hackerai.co/login",
+    });
+    const { default: proxy } = await import("../proxy");
+
+    await proxy(
+      createRequest({
+        pathname: "/api/subscription-details",
+        hasSession: true,
+      }),
+    );
+
+    expect(mockAuthkit).toHaveBeenCalledTimes(1);
+    expect(mockNextResponseJson).toHaveBeenCalledWith(
+      {
+        code: "unauthorized:auth",
+        message: "You need to sign in before continuing.",
+        cause: "Session expired or invalid",
+      },
+      expect.objectContaining({ status: 401 }),
+    );
+  });
+});

--- a/proxy.ts
+++ b/proxy.ts
@@ -9,7 +9,10 @@ import {
   isValidReferralCode,
 } from "@/lib/referrals/config";
 
+const AUTHKIT_BYPASS_PATHS = new Set(["/api/health/trigger-agent-mode"]);
+
 const UNAUTHENTICATED_PATHS = new Set([
+  ...AUTHKIT_BYPASS_PATHS,
   "/",
   "/login",
   "/signup",
@@ -57,6 +60,10 @@ function isUnauthenticatedPath(pathname: string): boolean {
   return false;
 }
 
+function shouldBypassAuthkit(pathname: string): boolean {
+  return AUTHKIT_BYPASS_PATHS.has(pathname);
+}
+
 function isBrowserRequest(request: NextRequest): boolean {
   const accept = request.headers.get("accept") ?? "";
   return accept.includes("text/html");
@@ -96,6 +103,10 @@ function withReferralCookie(
 
 export default async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
+
+  if (shouldBypassAuthkit(pathname)) {
+    return NextResponse.next();
+  }
 
   // Desktop app: redirect unauthenticated users to desktop-specific error page
   if (isDesktopApp(request)) {


### PR DESCRIPTION
## Summary
- bypass AuthKit in `proxy.ts` for `/api/health/trigger-agent-mode` before session refresh or API auth handling runs
- keep the health route listed as unauthenticated for consistency
- add proxy regression coverage that verifies the health endpoint never calls AuthKit while protected API routes still return `unauthorized:auth`

## Why
After the health endpoint landed on `main`, requests could still be intercepted by the global proxy. A signed-in browser with an expired WorkOS session, or a monitor request without a valid session, could receive `{ "code": "unauthorized:auth", "message": "You need to sign in before continuing.", "cause": "Session expired or invalid" }` before the health route handler ran.

## Validation
- `./node_modules/.bin/jest __tests__/proxy.test.ts app/api/health/trigger-agent-mode/__tests__/route.test.ts --runInBand`
- `./node_modules/.bin/prettier --check proxy.ts __tests__/proxy.test.ts app/api/health/trigger-agent-mode/route.ts app/api/health/trigger-agent-mode/__tests__/route.test.ts`
- `./node_modules/.bin/eslint proxy.ts __tests__/proxy.test.ts app/api/health/trigger-agent-mode/route.ts app/api/health/trigger-agent-mode/__tests__/route.test.ts`
- `./node_modules/.bin/tsc --noEmit`

## Manual verification
- After deployment, request `https://hackerai.co/api/health/trigger-agent-mode` without cookies.
- Confirm it returns the health JSON with `ok: true` or a Trigger-specific `503`, never `unauthorized:auth`.
- In BetterStack, monitor `https://hackerai.co/api/health/trigger-agent-mode` with `URL doesn't contain keyword` and keyword `"ok":true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Certain routes now bypass authentication checks and continue directly, improving access to health/trigger endpoints and other exempt paths.

* **Bug Fixes**
  * Protected API routes still enforce authentication and return a clear unauthorized response when session access is missing.
  * Added test coverage for bypass and unauthorized flows to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->