### PR TITLE
Enable frontend PostHog exception capture

### DIFF
--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import { render, waitFor } from "@testing-library/react";
+
+jest.mock("@workos-inc/authkit-nextjs/components", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("../contexts/GlobalState", () => ({
+  useGlobalState: jest.fn(() => ({
+    subscription: "pro",
+  })),
+}));
+
+jest.mock("@/lib/analytics/client", () => ({
+  getPostHogClient: jest.fn(() => null),
+  loadPostHogClient: jest.fn(),
+}));
+
+process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
+process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://us.i.posthog.com";
+
+const { useAuth } = jest.requireMock<
+  typeof import("@workos-inc/authkit-nextjs/components")
+>("@workos-inc/authkit-nextjs/components");
+const { loadPostHogClient } = jest.requireMock<
+  typeof import("@/lib/analytics/client")
+>("@/lib/analytics/client");
+const { PostHogProvider } =
+  require("../providers") as typeof import("../providers");
+
+const mockUseAuth = useAuth as jest.Mock;
+const mockLoadPostHogClient = loadPostHogClient as jest.Mock;
+
+describe("PostHogProvider", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
+    process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://us.i.posthog.com";
+
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: "user-123",
+        email: "user@example.com",
+        firstName: "Test",
+        lastName: "User",
+      },
+    });
+  });
+
+  it("enables only unhandled browser exception autocapture", async () => {
+    const posthog = {
+      __loaded: false,
+      init: jest.fn(),
+      opt_in_capturing: jest.fn(),
+      identify: jest.fn(),
+      sessionRecordingStarted: jest.fn(() => false),
+      startSessionRecording: jest.fn(),
+      stopSessionRecording: jest.fn(),
+      reset: jest.fn(),
+      opt_out_capturing: jest.fn(),
+    };
+    mockLoadPostHogClient.mockResolvedValue(posthog);
+
+    render(
+      <PostHogProvider>
+        <div>child</div>
+      </PostHogProvider>,
+    );
+
+    await waitFor(() => expect(posthog.init).toHaveBeenCalledTimes(1));
+
+    expect(posthog.init).toHaveBeenCalledWith(
+      "phc_test",
+      expect.objectContaining({
+        capture_exceptions: {
+          capture_unhandled_errors: true,
+          capture_unhandled_rejections: true,
+          capture_console_errors: false,
+        },
+        capture_pageview: false,
+        autocapture: false,
+      }),
+    );
+  });
+});

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -40,6 +40,11 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
               "https://us.i.posthog.com",
             capture_pageview: false, // Disable automatic pageview capture, as we capture manually
             autocapture: false, // Disable automatic event capture, as we capture manually
+            capture_exceptions: {
+              capture_unhandled_errors: true,
+              capture_unhandled_rejections: true,
+              capture_console_errors: false,
+            },
             disable_session_recording: true,
             before_send: (event) => {
               if (!event || shouldDropExpectedConvexException(event)) {


### PR DESCRIPTION
## Summary
- enable PostHog frontend Error Tracking for unhandled browser errors and unhandled promise rejections
- explicitly keep `capture_console_errors: false` so login/auth `console.error` paths do not become exception issues
- add a provider regression test that locks the intended PostHog exception-capture policy

## Why
The current frontend PostHog provider initializes analytics only for authenticated browser users, but it did not opt into browser exception capture. The PostHog audit found no `posthog-js` `$exception` events over the last 30 days despite high product activity.

This keeps the capture surface intentionally narrow:
- capture unexpected unhandled frontend bugs that users hit
- do not capture expected login/auth states or routine handled errors
- do not capture `console.error`, which would add noise from handled cloud/auth/file-upload paths

Relevant official docs:
- https://posthog.com/docs/error-tracking/installation/web
- https://posthog.com/docs/error-tracking/capture
- https://posthog.com/docs/libraries/js/config

## PostHog dashboard
No dashboard toggle is required for this PR. The code explicitly enables `capture_exceptions` locally and pins console-error capture off.

After deploy, the useful dashboard check is to trigger one controlled authenticated frontend unhandled error and verify a `$exception` issue appears with `library=posthog-js`. Do not enable console-error capture in the dashboard unless we intentionally want handled `console.error` calls to create exception events.

## Testing
- `./node_modules/.bin/jest app/__tests__/providers.test.tsx lib/posthog/__tests__/expected-convex-errors.test.ts --runInBand`
- `./node_modules/.bin/prettier --check app/providers.tsx app/__tests__/providers.test.tsx`
- `./node_modules/.bin/eslint app/providers.tsx app/__tests__/providers.test.tsx`
- `./node_modules/.bin/tsc --noEmit`

Note: `pnpm jest ...` and the Husky pre-commit hook hit pnpm's dependency-status install check in a non-interactive shell before running project checks. The equivalent local-binary checks above passed.

## Manual verification
- In an authenticated production or preview session after deployment, trigger a known non-sensitive unhandled browser error and confirm it appears in PostHog Error Tracking as a `posthog-js` `$exception`.
- Exercise normal login retry/cancel/expired-state flows and confirm they do not create frontend `$exception` issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics error reporting so unhandled errors and unhandled promise rejections are captured more reliably.
  * Kept console-error tracking disabled, avoiding extra noise while preserving key exception events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->