### PR TITLE
Route paid Ask fallbacks through MiniMax

### DIFF
--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -22,7 +22,6 @@ jest.mock("@/lib/logger", () => ({
 
 // Slugs the test asserts against. These match the registry in lib/ai/providers.ts.
 // If the registry slug for a model changes, update both places intentionally.
-const GEMINI_PREVIEW_SLUG = "google/gemini-3-flash-preview";
 const GROK_SLUG = "x-ai/grok-4.3";
 const MINIMAX_SLUG = "minimax/minimax-m3";
 const KIMI_SLUG = "moonshotai/kimi-k2.7-code:exacto";
@@ -49,7 +48,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("resolves Opus 4.6 multimodal agent chain to Grok", () => {
+  it("resolves Opus 4.6 multimodal agent chain to Kimi 2.7 Code then Grok", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -58,7 +57,7 @@ describe("buildProviderOptions fallback chain", () => {
       { hasMultimodalToolResults: true },
     );
     expect(opts.openrouter).toMatchObject({
-      models: [GROK_SLUG],
+      models: [KIMI_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
@@ -89,7 +88,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("resolves Sonnet 4.6 multimodal agent chain to Grok", () => {
+  it("resolves Sonnet 4.6 multimodal agent chain to Kimi 2.7 Code then Grok", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -98,12 +97,12 @@ describe("buildProviderOptions fallback chain", () => {
       { hasMultimodalToolResults: true },
     );
     expect(opts.openrouter).toMatchObject({
-      models: [GROK_SLUG],
+      models: [KIMI_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
 
-  it("keeps Anthropic multimodal agent fallback off text-only MiniMax and Kimi once image tool results exist", () => {
+  it("keeps Anthropic multimodal agent fallback off MiniMax once image tool results exist", () => {
     const opus = buildProviderOptions(
       false,
       "user-1",
@@ -121,12 +120,10 @@ describe("buildProviderOptions fallback chain", () => {
       { hasMultimodalToolResults: true },
     );
 
-    expect(opus.openrouter.models).toEqual([GROK_SLUG]);
-    expect(sonnet.openrouter.models).toEqual([GROK_SLUG]);
+    expect(opus.openrouter.models).toEqual([KIMI_SLUG, GROK_SLUG]);
+    expect(sonnet.openrouter.models).toEqual([KIMI_SLUG, GROK_SLUG]);
     expect(opus.openrouter.models).not.toContain(MINIMAX_SLUG);
     expect(sonnet.openrouter.models).not.toContain(MINIMAX_SLUG);
-    expect(opus.openrouter.models).not.toContain(KIMI_SLUG);
-    expect(sonnet.openrouter.models).not.toContain(KIMI_SLUG);
   });
 
   it("falls back from auto agent MiniMax to Kimi 2.7 Code then Grok", () => {
@@ -190,7 +187,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("falls back from explicit DeepSeek Pro ask model to Gemini", () => {
+  it("falls back from explicit DeepSeek Pro ask model through MiniMax, Kimi, then Grok", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -198,23 +195,26 @@ describe("buildProviderOptions fallback chain", () => {
       "ask",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [GEMINI_PREVIEW_SLUG],
+      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
 
-  it("falls back from the Grok media route to Gemini preview", () => {
-    const opts = buildProviderOptions(false, "user-1", "model-grok-4.3");
-    expect(opts.openrouter).toMatchObject({
-      models: [GEMINI_PREVIEW_SLUG],
-      user: "user-1",
-    });
-  });
+  it.each(["ask-model", "model-grok-4.3"] as const)(
+    "falls back from paid Ask media route %s through MiniMax, Kimi, then Grok",
+    (modelName) => {
+      const opts = buildProviderOptions(false, "user-1", modelName, "ask");
+      expect(opts.openrouter).toMatchObject({
+        models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
+        user: "user-1",
+      });
+    },
+  );
 
-  it("keeps the stale Gemini media route alias on the Grok fallback chain", () => {
+  it("keeps the stale Gemini media route alias on the active Ask fallback chain", () => {
     const opts = buildProviderOptions(false, "user-1", "model-gemini-3-flash");
     expect(opts.openrouter).toMatchObject({
-      models: [GEMINI_PREVIEW_SLUG],
+      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
@@ -333,7 +333,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(multimodal.openrouter).toMatchObject({
       reasoning: { enabled: true },
-      models: [GROK_SLUG],
+      models: [KIMI_SLUG, GROK_SLUG],
     });
   });
 });
@@ -398,9 +398,15 @@ describe("getRetryFallbackModel", () => {
     );
   });
 
-  it("keeps paid DeepSeek Pro ask retry on the existing ask fallback", () => {
-    expect(getRetryFallbackModel("model-deepseek-v4-pro", "ask")).toBe(
-      "fallback-ask-model",
-    );
-  });
+  it.each([
+    ["model-deepseek-v4-pro", "ask"],
+    ["ask-model", "ask"],
+    ["model-grok-4.3", "ask"],
+    ["model-gemini-3-flash", "ask"],
+  ] as const)(
+    "uses the paid Agent fallback chain for app-side retry after paid Ask route %s fails",
+    (modelName, mode) => {
+      expect(getRetryFallbackModel(modelName, mode)).toBe("model-minimax-m3");
+    },
+  );
 });

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -22,11 +22,7 @@ import type {
   Todo,
   UserCustomization,
 } from "@/types";
-import {
-  isAnthropicModel,
-  isDeepSeekModel,
-  myProvider,
-} from "@/lib/ai/providers";
+import { isAnthropicModel, myProvider } from "@/lib/ai/providers";
 import type { ModelName } from "@/lib/ai/providers";
 import type { Id } from "@/convex/_generated/dataModel";
 import type { UIMessagePart } from "ai";
@@ -487,11 +483,11 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "ask-model-free": AGENT_TEXT_FALLBACK_CHAIN,
   "agent-model-free": MINIMAX_M3_FALLBACK_CHAIN,
   "model-deepseek-v4-flash": AGENT_TEXT_FALLBACK_CHAIN,
-  "model-deepseek-v4-pro": ["fallback-ask-model"],
-  "ask-model": ["fallback-ask-model"],
+  "model-deepseek-v4-pro": AGENT_TEXT_FALLBACK_CHAIN,
+  "ask-model": AGENT_TEXT_FALLBACK_CHAIN,
   "agent-model": MINIMAX_M3_FALLBACK_CHAIN,
-  "model-grok-4.3": ["fallback-ask-model"],
-  "model-gemini-3-flash": ["fallback-ask-model"],
+  "model-grok-4.3": AGENT_TEXT_FALLBACK_CHAIN,
+  "model-gemini-3-flash": AGENT_TEXT_FALLBACK_CHAIN,
   "model-minimax-m3": MINIMAX_M3_FALLBACK_CHAIN,
   "model-kimi-k2.7-code": ["fallback-grok-4.3"],
   "model-kimi-k2.6": ["fallback-grok-4.3"],
@@ -524,9 +520,7 @@ const ANTHROPIC_FALLBACK_CHAIN_BY_MODE: Record<ChatMode, readonly ModelName[]> =
     ask: ["model-grok-4.3"],
   };
 
-const ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN = [
-  "fallback-grok-4.3",
-] as const satisfies readonly ModelName[];
+const ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN = MINIMAX_M3_FALLBACK_CHAIN;
 
 // Standard Ask can route text-only prompts to DeepSeek and media prompts to
 // Grok. Keep those route keys and their persisted Grok alias on one effort
@@ -585,23 +579,17 @@ const getFallbackKeys = (
 
 export function getRetryFallbackModel(
   modelName: ModelName,
-  mode: ChatMode,
+  _mode: ChatMode,
 ): ModelName {
   if (
     modelName === "ask-model-free" ||
-    modelName === "model-deepseek-v4-flash"
-  ) {
-    return "model-minimax-m3";
-  }
-  if (isDeepSeekModel(modelName)) {
-    return mode === "agent" ? "fallback-agent-model" : "fallback-ask-model";
-  }
-  if (
+    modelName === "model-deepseek-v4-flash" ||
+    modelName === "model-deepseek-v4-pro" ||
     modelName === "ask-model" ||
     modelName === "model-grok-4.3" ||
     modelName === "model-gemini-3-flash"
   ) {
-    return "fallback-ask-model";
+    return "model-minimax-m3";
   }
   return "fallback-grok-4.3";
 }


### PR DESCRIPTION
## Summary
- route paid Ask text and media fallback chains through MiniMax M3, Kimi 2.7 Code, then Grok 4.3 instead of Gemini 3 Flash Preview
- route Anthropic Agent multimodal fallback through Kimi 2.7 Code, then Grok 4.3
- update focused fallback-chain and app-side retry tests

## Validation
- ./node_modules/.bin/jest lib/ai/__tests__/providers.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/chat/__tests__/chat-processor.test.ts --runInBand
- ./node_modules/.bin/prettier --check lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts
- ./node_modules/.bin/eslint lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts

## Manual verification
- Start paid Ask Standard/Auto text request and confirm OpenRouter configured fallbacks are MiniMax M3, Kimi 2.7 Code, then Grok 4.3.
- Start paid Ask Standard/Auto image or PDF request and confirm the same configured fallback chain while the primary route remains Grok 4.3.
- Start paid Agent Pro/Max after multimodal tool results enter context and confirm configured fallbacks are Kimi 2.7 Code, then Grok 4.3.