### PR TITLE
Triage frontend exception noise

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -3,7 +3,7 @@
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { useEffect } from "react";
 import { useGlobalState } from "./contexts/GlobalState";
-import { shouldDropExpectedConvexException } from "@/lib/posthog/expected-convex-errors";
+import { shouldDropExpectedFrontendException } from "@/lib/posthog/expected-frontend-exceptions";
 import { getPostHogClient, loadPostHogClient } from "@/lib/analytics/client";
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
@@ -47,7 +47,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
             },
             disable_session_recording: true,
             before_send: (event) => {
-              if (!event || shouldDropExpectedConvexException(event)) {
+              if (!event || shouldDropExpectedFrontendException(event)) {
                 return null;
               }
 

--- a/components/ui/__tests__/sidebar.test.tsx
+++ b/components/ui/__tests__/sidebar.test.tsx
@@ -1,0 +1,38 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { describe, expect, it, jest } from "@jest/globals";
+import { SidebarProvider } from "../sidebar";
+
+jest.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+jest.mock("@/lib/utils/sidebar-storage", () => ({
+  STORAGE_KEYS: {
+    MAIN_SIDEBAR: "main-sidebar",
+  },
+  mainSidebarStorage: {
+    get: jest.fn(() => true),
+    save: jest.fn(),
+  },
+}));
+
+describe("SidebarProvider", () => {
+  it("ignores keydown events without a string key", () => {
+    const onOpenChange = jest.fn();
+
+    render(
+      <SidebarProvider open={true} onOpenChange={onOpenChange}>
+        <div>content</div>
+      </SidebarProvider>,
+    );
+
+    expect(() => {
+      act(() => {
+        window.dispatchEvent(new Event("keydown"));
+      });
+    }).not.toThrow();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -106,8 +106,10 @@ function SidebarProvider({
   // Adds a keyboard shortcut to toggle the sidebar.
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      const key = typeof event.key === "string" ? event.key.toLowerCase() : "";
+
       if (
-        event.key.toLowerCase() === SIDEBAR_KEYBOARD_SHORTCUT &&
+        key === SIDEBAR_KEYBOARD_SHORTCUT &&
         event.shiftKey &&
         (event.metaKey || event.ctrlKey) &&
         !event.altKey

--- a/convex/__tests__/chats.getUserChats.test.ts
+++ b/convex/__tests__/chats.getUserChats.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+jest.mock("../_generated/server", () => ({
+  mutation: jest.fn((config: any) => config),
+  internalMutation: jest.fn((config: any) => config),
+  query: jest.fn((config: any) => config),
+}));
+jest.mock("convex/values", () => ({
+  v: {
+    id: jest.fn(() => "id"),
+    null: jest.fn(() => "null"),
+    string: jest.fn(() => "string"),
+    number: jest.fn(() => "number"),
+    optional: jest.fn(() => "optional"),
+    object: jest.fn(() => "object"),
+    union: jest.fn(() => "union"),
+    array: jest.fn(() => "array"),
+    boolean: jest.fn(() => "boolean"),
+    literal: jest.fn(() => "literal"),
+    any: jest.fn(() => "any"),
+  },
+  ConvexError: class ConvexError extends Error {
+    data: any;
+    constructor(data: any) {
+      super(typeof data === "string" ? data : data.message);
+      this.data = data;
+      this.name = "ConvexError";
+    }
+  },
+}));
+jest.mock("../_generated/api", () => ({
+  internal: {
+    chats: {},
+    messages: {},
+    redisPubsub: {},
+    s3Cleanup: {},
+  },
+}));
+jest.mock("../fileAggregate", () => ({
+  fileCountAggregate: {
+    deleteIfExists: jest.fn<any>().mockResolvedValue(undefined),
+  },
+}));
+jest.mock("../lib/utils", () => ({
+  validateServiceKey: jest.fn(),
+}));
+jest.mock("convex/server", () => ({
+  paginationOptsValidator: "paginationOptsValidator",
+}));
+jest.mock("../lib/suspensionGuards", () => ({
+  CHAT_ACCESS_SUSPENDED_CODE: "CHAT_ACCESS_SUSPENDED",
+  assertUserCanAccessChatHistory: jest.fn<any>().mockResolvedValue(undefined),
+}));
+
+const { ConvexError } =
+  jest.requireMock<typeof import("convex/values")>("convex/values");
+const { assertUserCanAccessChatHistory } = jest.requireMock<
+  typeof import("../lib/suspensionGuards")
+>("../lib/suspensionGuards");
+const { getUserChats } = require("../chats") as typeof import("../chats");
+
+const emptyPage = {
+  page: [],
+  isDone: true,
+  continueCursor: "",
+};
+
+describe("getUserChats", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns an empty page when chat history is suspended", async () => {
+    jest.mocked(assertUserCanAccessChatHistory).mockRejectedValueOnce(
+      new ConvexError({
+        code: "CHAT_ACCESS_SUSPENDED",
+        message: "Suspended",
+      }),
+    );
+
+    const ctx = {
+      auth: {
+        getUserIdentity: jest.fn<any>().mockResolvedValue({
+          subject: "user-123",
+        }),
+      },
+      db: {
+        query: jest.fn(),
+      },
+    };
+
+    await expect(
+      getUserChats.handler(ctx as any, {
+        paginationOpts: { numItems: 20, cursor: null },
+      }),
+    ).resolves.toEqual(emptyPage);
+    expect(ctx.db.query).not.toHaveBeenCalled();
+  });
+
+  it("continues surfacing unexpected access guard errors", async () => {
+    jest
+      .mocked(assertUserCanAccessChatHistory)
+      .mockRejectedValueOnce(new Error("unexpected"));
+
+    const ctx = {
+      auth: {
+        getUserIdentity: jest.fn<any>().mockResolvedValue({
+          subject: "user-123",
+        }),
+      },
+      db: {
+        query: jest.fn(),
+      },
+    };
+
+    await expect(
+      getUserChats.handler(ctx as any, {
+        paginationOpts: { numItems: 20, cursor: null },
+      }),
+    ).rejects.toThrow("unexpected");
+  });
+});

--- a/convex/__tests__/chats.getUserChats.test.ts
+++ b/convex/__tests__/chats.getUserChats.test.ts
@@ -70,6 +70,25 @@ describe("getUserChats", () => {
     jest.clearAllMocks();
   });
 
+  it("returns an empty page when the user is unauthenticated", async () => {
+    const ctx = {
+      auth: {
+        getUserIdentity: jest.fn<any>().mockResolvedValue(null),
+      },
+      db: {
+        query: jest.fn(),
+      },
+    };
+
+    await expect(
+      getUserChats.handler(ctx as any, {
+        paginationOpts: { numItems: 20, cursor: null },
+      }),
+    ).resolves.toEqual(emptyPage);
+    expect(assertUserCanAccessChatHistory).not.toHaveBeenCalled();
+    expect(ctx.db.query).not.toHaveBeenCalled();
+  });
+
   it("returns an empty page when chat history is suspended", async () => {
     jest.mocked(assertUserCanAccessChatHistory).mockRejectedValueOnce(
       new ConvexError({

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -20,7 +20,10 @@ import {
   resolveSubscriptionTier,
 } from "../lib/auth/entitlements";
 import { convexLogger } from "./lib/logger";
-import { assertUserCanAccessChatHistory } from "./lib/suspensionGuards";
+import {
+  CHAT_ACCESS_SUSPENDED_CODE,
+  assertUserCanAccessChatHistory,
+} from "./lib/suspensionGuards";
 
 const DELETE_ALL_CHATS_MESSAGE_BATCH_SIZE = 10;
 const DELETE_ALL_CHATS_SUMMARY_BATCH_SIZE = 25;
@@ -85,6 +88,12 @@ const CHAT_SUMMARY_TELEMETRY_CLEAR_PATCH = {
   cost: undefined,
   estimated_compacted_input_tokens: undefined,
 };
+
+const emptyChatsPage = () => ({
+  page: [],
+  isDone: true,
+  continueCursor: "",
+});
 
 async function getMessageCreationTimeById(
   ctx: MutationCtx,
@@ -738,13 +747,21 @@ export const getUserChats = query({
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
-      return {
-        page: [],
-        isDone: true,
-        continueCursor: "",
-      };
+      return emptyChatsPage();
     }
-    await assertUserCanAccessChatHistory(ctx, identity.subject);
+
+    try {
+      await assertUserCanAccessChatHistory(ctx, identity.subject);
+    } catch (error) {
+      if (
+        getConvexErrorCode(getConvexErrorData(error)) ===
+        CHAT_ACCESS_SUSPENDED_CODE
+      ) {
+        return emptyChatsPage();
+      }
+
+      throw error;
+    }
 
     try {
       const MAX_PINNED_CHATS = 100;
@@ -844,11 +861,7 @@ export const getUserChats = query({
             ? { name: error.name, message: error.message }
             : String(error),
       });
-      return {
-        page: [],
-        isDone: true,
-        continueCursor: "",
-      };
+      return emptyChatsPage();
     }
   },
 });

--- a/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
+++ b/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
@@ -1,0 +1,198 @@
+import { shouldDropExpectedFrontendException } from "../expected-frontend-exceptions";
+
+describe("shouldDropExpectedFrontendException", () => {
+  it("keeps non-exception events", () => {
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "chat_error",
+        properties: {
+          message:
+            "ResizeObserver loop completed with undelivered notifications.",
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps unexpected frontend exceptions", () => {
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_values: ["Cannot read properties of undefined"],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps generic network and chunk-load failures", () => {
+    for (const value of [
+      "Failed to fetch",
+      "Load failed",
+      "NetworkError when attempting to fetch resource.",
+      "network error",
+      "Failed to load chunk /_next/static/chunks/example.js from module 1",
+    ]) {
+      expect(
+        shouldDropExpectedFrontendException({
+          event: "$exception",
+          properties: {
+            $exception_values: [value],
+          },
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("drops expected Convex exceptions through the shared Convex classifier", () => {
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_message:
+            'Uncaught ConvexError: {"code":"CHAT_ACCESS_SUSPENDED","message":"Suspended"}',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("drops browser ResizeObserver notifications", () => {
+    for (const value of [
+      "ResizeObserver loop completed with undelivered notifications.",
+      "ResizeObserver loop limit exceeded",
+    ]) {
+      expect(
+        shouldDropExpectedFrontendException({
+          event: "$exception",
+          properties: {
+            $exception_values: [value],
+          },
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("drops manual chat stop aborts only when the stack is app-owned", () => {
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_values: ["AbortError: Fetch is aborted"],
+          $exception_list: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    source:
+                      "turbopack:///[project]/app/hooks/useChatHandlers.ts",
+                    resolved_name: "handleStop",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_values: ["AbortError: Fetch is aborted"],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("drops expected auth refresh failures only with auth stack sources", () => {
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_values: ["Failed to refresh access token"],
+          $exception_list: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    source:
+                      "turbopack:///[project]/lib/auth/cross-tab-mutex.ts",
+                  },
+                  {
+                    source:
+                      "turbopack:///[project]/node_modules/.pnpm/@workos-inc+authkit-nextjs@4.1.4/node_modules/@workos-inc/authkit-nextjs/src/components/tokenStore.ts",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_values: ["Failed to refresh access token"],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("drops PostHog SDK transport timeouts only with PostHog request frames", () => {
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_values: ["PostHog request timed out after 3000ms"],
+          $exception_list: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    source:
+                      "turbopack:///[project]/node_modules/.pnpm/posthog-js@1.396.2/node_modules/posthog-js/src/request.ts",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_values: ["PostHog request timed out after 3000ms"],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("drops Monaco editor cancellations by source", () => {
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_types: ["Canceled"],
+          $exception_values: ["Canceled"],
+          $exception_list: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    source:
+                      "/npm/monaco-editor@0.55.1/min/vs/editor.api-CalNCsUg.js",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
+});

--- a/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
+++ b/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
@@ -194,5 +194,26 @@ describe("shouldDropExpectedFrontendException", () => {
         },
       }),
     ).toBe(true);
+
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_types: ["Canceled"],
+          $exception_values: ["Canceled"],
+          $exception_list: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    source: "turbopack:///[project]/app/components/chat.tsx",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/lib/posthog/expected-frontend-exceptions.ts
+++ b/lib/posthog/expected-frontend-exceptions.ts
@@ -43,27 +43,41 @@ const hasExactString = (strings: string[], expected: string): boolean =>
 const hasResizeObserverMessage = (strings: string[]): boolean =>
   strings.some((value) => RESIZE_OBSERVER_MESSAGES.has(value));
 
-const isExpectedManualChatStopAbort = (strings: string[]): boolean =>
-  hasExactString(strings, "AbortError: Fetch is aborted") &&
-  includesAny(strings, ["app/hooks/useChatHandlers.ts"]);
+type ExpectedFrontendPattern = {
+  message: string;
+  sourceFragments: string[];
+};
 
-const isExpectedAuthRefreshFailure = (strings: string[]): boolean =>
-  hasExactString(strings, "Failed to refresh access token") &&
-  includesAny(strings, [
-    "@workos-inc/authkit-nextjs",
-    "convex/dist/esm/browser/sync/authentication_manager.js",
-    "lib/auth/shared-token.ts",
-    "lib/auth/use-auth-from-authkit.ts",
-    "lib/auth/cross-tab-mutex.ts",
-  ]);
+const EXPECTED_FRONTEND_PATTERNS: ExpectedFrontendPattern[] = [
+  {
+    message: "AbortError: Fetch is aborted",
+    sourceFragments: ["app/hooks/useChatHandlers.ts"],
+  },
+  {
+    message: "Failed to refresh access token",
+    sourceFragments: [
+      "@workos-inc/authkit-nextjs",
+      "convex/dist/esm/browser/sync/authentication_manager.js",
+      "lib/auth/shared-token.ts",
+      "lib/auth/use-auth-from-authkit.ts",
+      "lib/auth/cross-tab-mutex.ts",
+    ],
+  },
+  {
+    message: "PostHog request timed out after 3000ms",
+    sourceFragments: ["posthog-js/src/request.ts"],
+  },
+  {
+    message: "Canceled",
+    sourceFragments: ["monaco-editor@"],
+  },
+];
 
-const isPostHogTransportTimeout = (strings: string[]): boolean =>
-  hasExactString(strings, "PostHog request timed out after 3000ms") &&
-  includesAny(strings, ["posthog-js/src/request.ts"]);
-
-const isMonacoCancellation = (strings: string[]): boolean =>
-  hasExactString(strings, "Canceled") &&
-  includesAny(strings, ["monaco-editor@"]);
+const matchesExpectedFrontendPattern = (strings: string[]): boolean =>
+  EXPECTED_FRONTEND_PATTERNS.some(
+    ({ message, sourceFragments }) =>
+      hasExactString(strings, message) && includesAny(strings, sourceFragments),
+  );
 
 export function shouldDropExpectedFrontendException(event: PostHogEventLike) {
   if (event.event !== "$exception") {
@@ -77,10 +91,6 @@ export function shouldDropExpectedFrontendException(event: PostHogEventLike) {
   const strings = collectStrings(event.properties);
 
   return (
-    hasResizeObserverMessage(strings) ||
-    isExpectedManualChatStopAbort(strings) ||
-    isExpectedAuthRefreshFailure(strings) ||
-    isPostHogTransportTimeout(strings) ||
-    isMonacoCancellation(strings)
+    hasResizeObserverMessage(strings) || matchesExpectedFrontendPattern(strings)
   );
 }

--- a/lib/posthog/expected-frontend-exceptions.ts
+++ b/lib/posthog/expected-frontend-exceptions.ts
@@ -1,0 +1,86 @@
+import { shouldDropExpectedConvexException } from "@/lib/posthog/expected-convex-errors";
+
+type PostHogEventLike = {
+  event?: string;
+  properties?: Record<string, unknown>;
+};
+
+const RESIZE_OBSERVER_MESSAGES = new Set([
+  "ResizeObserver loop completed with undelivered notifications.",
+  "ResizeObserver loop limit exceeded",
+]);
+
+const collectStrings = (value: unknown, strings: string[] = []): string[] => {
+  if (typeof value === "string") {
+    strings.push(value);
+    return strings;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectStrings(item, strings);
+    }
+    return strings;
+  }
+
+  if (value && typeof value === "object") {
+    for (const nestedValue of Object.values(value)) {
+      collectStrings(nestedValue, strings);
+    }
+  }
+
+  return strings;
+};
+
+const includesAny = (strings: string[], fragments: string[]): boolean =>
+  strings.some((value) =>
+    fragments.some((fragment) => value.includes(fragment)),
+  );
+
+const hasExactString = (strings: string[], expected: string): boolean =>
+  strings.some((value) => value === expected);
+
+const hasResizeObserverMessage = (strings: string[]): boolean =>
+  strings.some((value) => RESIZE_OBSERVER_MESSAGES.has(value));
+
+const isExpectedManualChatStopAbort = (strings: string[]): boolean =>
+  hasExactString(strings, "AbortError: Fetch is aborted") &&
+  includesAny(strings, ["app/hooks/useChatHandlers.ts"]);
+
+const isExpectedAuthRefreshFailure = (strings: string[]): boolean =>
+  hasExactString(strings, "Failed to refresh access token") &&
+  includesAny(strings, [
+    "@workos-inc/authkit-nextjs",
+    "convex/dist/esm/browser/sync/authentication_manager.js",
+    "lib/auth/shared-token.ts",
+    "lib/auth/use-auth-from-authkit.ts",
+    "lib/auth/cross-tab-mutex.ts",
+  ]);
+
+const isPostHogTransportTimeout = (strings: string[]): boolean =>
+  hasExactString(strings, "PostHog request timed out after 3000ms") &&
+  includesAny(strings, ["posthog-js/src/request.ts"]);
+
+const isMonacoCancellation = (strings: string[]): boolean =>
+  hasExactString(strings, "Canceled") &&
+  includesAny(strings, ["monaco-editor@"]);
+
+export function shouldDropExpectedFrontendException(event: PostHogEventLike) {
+  if (event.event !== "$exception") {
+    return false;
+  }
+
+  if (shouldDropExpectedConvexException(event)) {
+    return true;
+  }
+
+  const strings = collectStrings(event.properties);
+
+  return (
+    hasResizeObserverMessage(strings) ||
+    isExpectedManualChatStopAbort(strings) ||
+    isExpectedAuthRefreshFailure(strings) ||
+    isPostHogTransportTimeout(strings) ||
+    isMonacoCancellation(strings)
+  );
+}


### PR DESCRIPTION
## Summary

- query fresh frontend `$exception` Error Tracking groups after PR #780 and classify the new browser SDK issues
- add a source-aware PostHog `before_send` filter for expected frontend noise while preserving unknown errors and `capture_console_errors: false`
- fix two app-owned paths: sidebar key handling for undefined `event.key`, and `getUserChats` returning an empty sidebar page for expected `CHAT_ACCESS_SUSPENDED`
- suppress verified expected-noise PostHog issues at issue level; leave broad/uncertain groups active

## Issue classifications

PostHog note: `library=posthog-js` returned no rows; raw events from frontend SDK capture are stored with `$lib=web`.

Fixed or filtered:
- `019f1aaf-ef1e-7213-a13d-bc385d6e0aef` `Cannot read properties of undefined (reading 'toLowerCase')` - unexpected app bug in `components/ui/sidebar.tsx`; fixed.
- `019f1a4a-f472-7c93-9e2f-a2b252c9df44` `AbortError: Fetch is aborted` - expected manual chat Stop cancellation from `app/hooks/useChatHandlers.ts`; source-aware filtered and issue suppressed.
- `019f1a79-435a-71b2-ab45-9dc32b72b234`, `019f1a81-9755-7522-8f09-aad90f75379a` `Failed to refresh access token` - expected WorkOS/AuthKit expired or unauthenticated refresh state; source-aware filtered and issues suppressed.
- `0c1c32fe-4ead-4d8b-ac15-6c8fb95878fa`, `220ab893-bd1b-4dc0-90b1-6dbaf6059a53` ResizeObserver notifications - browser layout noise; exact-message filtered and issues suppressed.
- `019f1aae-f020-78d3-b7fc-bcb71325ba8d` `PostHog request timed out after 3000ms` - PostHog SDK self-transport noise; source-aware filtered and issue suppressed.
- `019f1a64-784b-74e2-b847-d6f1ffe4b03c` Monaco `Canceled` - third-party editor cancellation; source-aware filtered and issue suppressed.
- `7cd73497-0330-4a17-831d-6dbe5297cc19` `Script error.` - opaque cross-origin/browser noise; issue suppressed only, no app-wide message filter.

Left active, not broadly suppressed:
- generic browser/network groups: `Failed to fetch`, `Load failed`, `NetworkError when attempting to fetch resource.`, `network error`, `timeout`, `Error in input stream`
- DOM mutation/React placement groups: `insertBefore` / `removeChild` `NotFoundError`
- Trigger stream runtime close groups: `ReadableStreamDefaultController...close`
- React minified `#185` and `#310` groups; stacks stop in React/Next internals and co-occur with network/chunk/DOM errors
- chunk-load deploy asset mismatch group
- generic `ConvexError` from `chats:getUserChats`; this PR fixes the expected suspension throw path but the sampled event did not expose a structured code, so the issue stays active
- Next server-action `An unexpected response was received from the server`

## Validation

- `corepack pnpm jest lib/posthog/__tests__/expected-frontend-exceptions.test.ts components/ui/__tests__/sidebar.test.tsx convex/__tests__/chats.getUserChats.test.ts app/__tests__/providers.test.tsx lib/posthog/__tests__/expected-convex-errors.test.ts --runInBand`
- `corepack pnpm exec prettier --check app/providers.tsx components/ui/sidebar.tsx convex/chats.ts lib/posthog/expected-frontend-exceptions.ts lib/posthog/__tests__/expected-frontend-exceptions.test.ts components/ui/__tests__/sidebar.test.tsx convex/__tests__/chats.getUserChats.test.ts`
- `corepack pnpm exec eslint app/providers.tsx components/ui/sidebar.tsx convex/chats.ts lib/posthog/expected-frontend-exceptions.ts lib/posthog/__tests__/expected-frontend-exceptions.test.ts components/ui/__tests__/sidebar.test.tsx convex/__tests__/chats.getUserChats.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm lint` passes with existing warnings

## Manual verification

- In PostHog Error Tracking, verify the suppressed issue IDs remain hidden and generic network/React/DOM/Convex issues remain active.
- In a deployed build, click Stop during an active chat stream; the chat should stop normally and no new `$exception` should be captured for the `useChatHandlers.ts` abort path.
- Dispatch or reproduce a keyboard event with no string `key` while the sidebar provider is mounted; the sidebar should not throw.
- For a fraud-dispute suspended account, load the sidebar; it should render an empty chat list instead of throwing `CHAT_ACCESS_SUSPENDED`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar keyboard shortcut handling so it no longer errors when a key event is missing a key value.
  * Chat history now consistently shows an empty state for unauthenticated users and when access is suspended, avoiding error screens.
  * Reduced noisy analytics by filtering additional expected frontend exceptions before they’re recorded.

* **Tests**
  * Added tests for sidebar keyboard handling, chat history access/pagination scenarios, and expected frontend exception filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->