### PR TITLE
Clarify active Ask and Agent mode prompts

### DIFF
--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -190,6 +190,65 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).not.toContain("interactsh-client: use for blind callback");
   });
 
+  it("adds paid ask-mode current-mode guidance", async () => {
+    const prompt = await systemPrompt(
+      "user_123",
+      "ask",
+      "pro",
+      "ask-model",
+      null,
+      false,
+      null,
+    );
+
+    expect(prompt).toContain("<current_mode>");
+    expect(prompt).toContain("You are in ASK MODE with limited tools.");
+    expect(prompt).toContain(
+      "inform them to switch to AGENT MODE for full access including file operations, terminal commands, and code execution.",
+    );
+  });
+
+  it("adds free ask-mode local sandbox guidance", async () => {
+    const prompt = await systemPrompt(
+      "user_123",
+      "ask",
+      "free",
+      "ask-model",
+      null,
+      false,
+      null,
+    );
+
+    expect(prompt).toContain("<current_mode>");
+    expect(prompt).toContain("You are in ASK MODE with limited tools.");
+    expect(prompt).toContain(
+      "AGENT MODE requires a connected local sandbox on the free plan, or Pro for cloud Agent access.",
+    );
+    expect(prompt).not.toContain(
+      "inform them to switch to AGENT MODE for full access",
+    );
+  });
+
+  it("adds agent-mode current-mode guidance", async () => {
+    const prompt = await systemPrompt(
+      "user_123",
+      "agent",
+      "pro",
+      "agent-model",
+      null,
+      false,
+      null,
+    );
+
+    expect(prompt).toContain("<current_mode>");
+    expect(prompt).toContain("You are in AGENT MODE.");
+    expect(prompt).toContain(
+      "Use the available tools to read files, edit code, run terminal commands, and execute code when useful.",
+    );
+    expect(prompt).toContain("Do not tell the user to switch to Agent mode.");
+    expect(prompt).not.toContain("You are in ASK MODE");
+  });
+
   it("does not claim cloud-only recipes or browser tools are installed on local hosts", async () => {
     const localHostContext = `You are executing commands on Linux 6.8 (x64) in DANGEROUS MODE.
 Commands run directly on the host OS "labbox" without Docker isolation.`;

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -193,7 +193,11 @@ const getAgentModeSection = (
       ? "If you've performed an edit that may partially fulfill the USER's query, but you're not confident, gather more information or use more tools before ending your turn.\n"
       : "";
 
-  return `<tool_calling>
+  return `<current_mode>
+You are in AGENT MODE. Use the available tools to read files, edit code, run terminal commands, and execute code when useful. Do not tell the user to switch to Agent mode.
+</current_mode>
+
+<tool_calling>
 You have tools at your disposal to solve the penetration testing task. Follow these rules regarding tool calls:
 1. ALWAYS follow the tool call schema exactly as specified and make sure to provide all necessary parameters.
 2. When a tool offers a \`brief\` parameter, include a concise one-sentence user-facing summary of the operation whenever possible. This helps the UI show what is happening without exposing tool names.
@@ -332,16 +336,16 @@ const getAskModeSection = (
 ): string => {
   const knowledgeCutOffDate = getModelCutoffDate(modelName);
   const notesCapability = notesEnabled ? " and manage notes" : "";
-  const modeReminder =
-    subscription !== "free"
-      ? `<current_mode>
+  const agentModeCTA =
+    subscription === "free"
+      ? "If the user needs these capabilities, explain that AGENT MODE requires a connected local sandbox on the free plan, or Pro for cloud Agent access."
+      : "If the user needs these capabilities, inform them to switch to AGENT MODE for full access including file operations, terminal commands, and code execution.";
+  const modeReminder = `<current_mode>
 You are in ASK MODE with limited tools. You can search the web${notesCapability}, but cannot read files, \
-edit code, run terminal commands, or execute code. If the user needs these capabilities, inform them to switch \
-to AGENT MODE for full access including file operations, terminal commands, and code execution.
+edit code, run terminal commands, or execute code. ${agentModeCTA}
 </current_mode>
 
-`
-      : "";
+`;
   return `${modeReminder}${getProductQuestionsSection()}
 
 <tone_and_formatting>


### PR DESCRIPTION
## Summary
- show Ask-mode current-mode guidance to both paid and free users, with Free-specific local sandbox/cloud Agent wording
- add an Agent-mode current-mode anchor so models do not tell users to switch to Agent mode after they already have
- add system-prompt tests for paid Ask, free Ask, and Agent guidance

## Testing
- `/Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules/.bin/prettier --check lib/system-prompt.ts lib/__tests__/system-prompt.test.ts`
- `/Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules/.bin/jest lib/__tests__/system-prompt.test.ts --runInBand`

Note: direct `pnpm` validation was blocked locally by existing lockfile minimum-release-age checks for unrelated packages, so I used the already-installed main-checkout binaries.

## Manual verification
- In Ask mode as a Free user, ask for a file/code execution task; the assistant should explain that Agent mode requires a connected local sandbox on Free, or Pro for cloud Agent access.
- In Ask mode as a paid user, ask for a file/code execution task; the assistant should tell the user to switch to Agent mode.
- In Agent mode, ask for file/code execution work; the assistant should use available tools and not claim it is still in Ask mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer current-mode guidance in the assistant prompt.
  * In Agent Mode, the prompt now explicitly states that the assistant is in Agent Mode and highlights available tool usage.
  * In Ask Mode, users now see a mode reminder with clearer direction on when Agent Mode is available based on their plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->