### PR TITLE
Downgrade expected auth session failures

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -19,6 +19,7 @@ function mockCreateResponse(kind: string, body?: unknown, init?: unknown) {
     init,
     cookies: {
       set: jest.fn(),
+      delete: jest.fn(),
     },
   };
 }
@@ -102,6 +103,71 @@ describe("proxy", () => {
     );
 
     expect(mockAuthkit).toHaveBeenCalledTimes(1);
+    expect(mockNextResponseJson).toHaveBeenCalledWith(
+      {
+        code: "unauthorized:auth",
+        message: "You need to sign in before continuing.",
+        cause: "Session expired or invalid",
+      },
+      expect.objectContaining({ status: 401 }),
+    );
+  });
+
+  it("treats thrown ended-session refresh errors as unauthenticated home requests", async () => {
+    const endedSessionError = Object.assign(
+      new Error("Failed to refresh session: Error: invalid_grant"),
+      {
+        name: "TokenRefreshError",
+        cause: {
+          error: "invalid_grant",
+          errorDescription: "Session has already ended.",
+          rawData: {
+            error: "invalid_grant",
+            error_description: "Session has already ended.",
+          },
+        },
+      },
+    );
+    mockAuthkit.mockRejectedValue(endedSessionError);
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/",
+        accept: "text/html",
+        hasSession: true,
+      }),
+    );
+
+    expect(response).toMatchObject({ kind: "next" });
+    expect(response.cookies.delete).toHaveBeenCalledWith("wos-session");
+    expect(mockNextResponseJson).not.toHaveBeenCalled();
+    expect(mockNextResponseRedirect).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when protected APIs hit thrown ended-session refresh errors", async () => {
+    const endedSessionError = Object.assign(
+      new Error("Failed to refresh session: Error: invalid_grant"),
+      {
+        name: "TokenRefreshError",
+        cause: {
+          error: "invalid_grant",
+          errorDescription: "Session has already ended.",
+        },
+      },
+    );
+    mockAuthkit.mockRejectedValue(endedSessionError);
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/api/subscription-details",
+        hasSession: true,
+      }),
+    );
+
+    expect(response).toMatchObject({ kind: "json" });
+    expect(response.cookies.delete).toHaveBeenCalledWith("wos-session");
     expect(mockNextResponseJson).toHaveBeenCalledWith(
       {
         code: "unauthorized:auth",

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -177,4 +177,33 @@ describe("proxy", () => {
       expect.objectContaining({ status: 401 }),
     );
   });
+
+  it("redirects to login when protected browser requests hit thrown ended-session refresh errors", async () => {
+    const endedSessionError = Object.assign(
+      new Error("Failed to refresh session: Error: invalid_grant"),
+      {
+        name: "TokenRefreshError",
+        cause: {
+          error: "invalid_grant",
+          errorDescription: "Session has already ended.",
+        },
+      },
+    );
+    mockAuthkit.mockRejectedValue(endedSessionError);
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/dashboard",
+        accept: "text/html",
+        hasSession: true,
+      }),
+    );
+
+    expect(response).toMatchObject({ kind: "redirect" });
+    expect(response.cookies.delete).toHaveBeenCalledWith("wos-session");
+    expect(mockNextResponseRedirect).toHaveBeenCalledWith(
+      new URL("/login", "https://hackerai.co/dashboard"),
+    );
+  });
 });

--- a/app/callback/route.ts
+++ b/app/callback/route.ts
@@ -7,7 +7,10 @@ import {
   isOauthCodeAlreadyExchangedError,
   withRecoverableAuthkitCallbackErrorSuppressed,
 } from "@/lib/auth/authkit-callback-logging";
-import { isInvalidCodeVerifierError } from "@/lib/auth/expected-auth-errors";
+import {
+  isUnverifiedSignInSessionError,
+  isInvalidCodeVerifierError,
+} from "@/lib/auth/expected-auth-errors";
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -29,6 +32,7 @@ type RecoveryBucket =
   | "cookie_missing"
   | "code_already_exchanged"
   | "invalid_code_verifier"
+  | "session_unverified"
   | "unknown";
 
 const classifyCallbackError = (error: unknown): RecoveryBucket => {
@@ -37,6 +41,9 @@ const classifyCallbackError = (error: unknown): RecoveryBucket => {
   }
   if (isInvalidCodeVerifierError(error)) {
     return "invalid_code_verifier";
+  }
+  if (isUnverifiedSignInSessionError(error)) {
+    return "session_unverified";
   }
   if (isMissingRequiredAuthParameterError(error)) {
     return "missing_auth_parameter";
@@ -109,8 +116,8 @@ const buildRecoveryResponse = async (
   }
 
   // Recoverable cases (stale flow, multi-tab, scanner prefetch, ITP,
-  // cross-device link, embedded webview, missing cookie, duplicate callback):
-  // one-click recovery.
+  // cross-device link, embedded webview, missing cookie, duplicate callback,
+  // expired sign-in session): one-click recovery.
   // Preserve post_login_redirect intent so the retry lands where they wanted.
   const loginUrl = new URL("/login", request.url);
   const loginResponse = NextResponse.redirect(loginUrl);

--- a/app/callback/route.ts
+++ b/app/callback/route.ts
@@ -1,16 +1,9 @@
 import { handleAuth } from "@workos-inc/authkit-nextjs";
 import {
-  isAuthVerifierMissingError,
-  isAuthCookieMissingError,
-  isMissingRequiredAuthParameterError,
-  isOAuthStateMismatchError,
-  isOauthCodeAlreadyExchangedError,
+  getRecoverableAuthkitCallbackErrorBucket,
+  type RecoverableAuthkitCallbackErrorBucket,
   withRecoverableAuthkitCallbackErrorSuppressed,
 } from "@/lib/auth/authkit-callback-logging";
-import {
-  isUnverifiedSignInSessionError,
-  isInvalidCodeVerifierError,
-} from "@/lib/auth/expected-auth-errors";
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -25,39 +18,10 @@ const PKCE_COOKIE_PREFIX = "wos-auth-verifier";
 const hasPkceCookie = (request: NextRequest): boolean =>
   request.cookies.getAll().some((c) => c.name.startsWith(PKCE_COOKIE_PREFIX));
 
-type RecoveryBucket =
-  | "missing_auth_parameter"
-  | "state_mismatch"
-  | "verifier_missing"
-  | "cookie_missing"
-  | "code_already_exchanged"
-  | "invalid_code_verifier"
-  | "session_unverified"
-  | "unknown";
+type RecoveryBucket = RecoverableAuthkitCallbackErrorBucket | "unknown";
 
 const classifyCallbackError = (error: unknown): RecoveryBucket => {
-  if (isOauthCodeAlreadyExchangedError(error)) {
-    return "code_already_exchanged";
-  }
-  if (isInvalidCodeVerifierError(error)) {
-    return "invalid_code_verifier";
-  }
-  if (isUnverifiedSignInSessionError(error)) {
-    return "session_unverified";
-  }
-  if (isMissingRequiredAuthParameterError(error)) {
-    return "missing_auth_parameter";
-  }
-  if (isAuthCookieMissingError(error)) {
-    return "cookie_missing";
-  }
-  if (isAuthVerifierMissingError(error)) {
-    return "verifier_missing";
-  }
-  if (isOAuthStateMismatchError(error)) {
-    return "state_mismatch";
-  }
-  return "unknown";
+  return getRecoverableAuthkitCallbackErrorBucket(error) ?? "unknown";
 };
 
 const buildRecoveryResponse = async (

--- a/lib/auth/__tests__/authkit-callback-logging.test.ts
+++ b/lib/auth/__tests__/authkit-callback-logging.test.ts
@@ -128,6 +128,16 @@ describe("authkit callback logging", () => {
     ).toBe(true);
   });
 
+  it("matches unverified sign-in session callback errors", () => {
+    const error = new Error(
+      "Sign-in session could not be verified. Please try signing in again.",
+    );
+
+    expect(
+      isRecoverableAuthkitCallbackErrorLog(["[AuthKit callback error]", error]),
+    ).toBe(true);
+  });
+
   it("does not match other invalid_grant errors", () => {
     const error = Object.assign(new Error("Error: invalid_grant"), {
       error: "invalid_grant",
@@ -159,6 +169,12 @@ describe("authkit callback logging", () => {
         "[AuthKit callback error]",
         new Error(
           "Error: invalid_grant\nError Description: Invalid code verifier.",
+        ),
+      );
+      console.error(
+        "[AuthKit callback error]",
+        new Error(
+          "Sign-in session could not be verified. Please try signing in again.",
         ),
       );
       console.error(

--- a/lib/auth/__tests__/expected-auth-errors.test.ts
+++ b/lib/auth/__tests__/expected-auth-errors.test.ts
@@ -4,6 +4,7 @@ import {
   collectAuthErrorText,
   isEndedSessionRefreshError,
   isInvalidCodeVerifierError,
+  isUnverifiedSignInSessionError,
 } from "../expected-auth-errors";
 
 describe("expected auth errors", () => {
@@ -47,6 +48,14 @@ describe("expected auth errors", () => {
     });
 
     expect(isInvalidCodeVerifierError(error)).toBe(true);
+  });
+
+  it("matches unverified sign-in session errors", () => {
+    const error = new Error(
+      "Sign-in session could not be verified. Please try signing in again.",
+    );
+
+    expect(isUnverifiedSignInSessionError(error)).toBe(true);
   });
 
   it("collects nested auth error text without looping on cycles", () => {

--- a/lib/auth/authkit-callback-logging.ts
+++ b/lib/auth/authkit-callback-logging.ts
@@ -1,6 +1,7 @@
 import {
   collectAuthErrorText,
   isInvalidCodeVerifierError,
+  isUnverifiedSignInSessionError,
 } from "./expected-auth-errors";
 
 const AUTHKIT_CALLBACK_ERROR_PREFIX = "[AuthKit callback error]";
@@ -82,6 +83,7 @@ export const isRecoverableAuthkitCallbackError = (value: unknown): boolean => {
     isAuthCookieMissingError(value) ||
     isOauthCodeAlreadyExchangedError(value) ||
     isInvalidCodeVerifierError(value) ||
+    isUnverifiedSignInSessionError(value) ||
     isMissingRequiredAuthParameterError(value) ||
     isOAuthStateMismatchError(value) ||
     isAuthVerifierMissingError(value)

--- a/lib/auth/authkit-callback-logging.ts
+++ b/lib/auth/authkit-callback-logging.ts
@@ -13,6 +13,15 @@ const INVALID_GRANT_ERROR = "invalid_grant";
 const CODE_ALREADY_EXCHANGED_MESSAGE = "already been exchanged";
 const VERIFIER_SCHEMA_KEYS = ['"nonce"', '"codeVerifier"'];
 
+export type RecoverableAuthkitCallbackErrorBucket =
+  | "missing_auth_parameter"
+  | "state_mismatch"
+  | "verifier_missing"
+  | "cookie_missing"
+  | "code_already_exchanged"
+  | "invalid_code_verifier"
+  | "session_unverified";
+
 let activeSuppressions = 0;
 let originalConsoleError: typeof console.error | null = null;
 
@@ -78,16 +87,52 @@ export const isAuthVerifierMissingError = (value: unknown): boolean => {
   );
 };
 
-export const isRecoverableAuthkitCallbackError = (value: unknown): boolean => {
+const RECOVERABLE_AUTHKIT_CALLBACK_ERROR_BUCKETS: Array<{
+  bucket: RecoverableAuthkitCallbackErrorBucket;
+  isMatch: (value: unknown) => boolean;
+}> = [
+  {
+    bucket: "code_already_exchanged",
+    isMatch: isOauthCodeAlreadyExchangedError,
+  },
+  {
+    bucket: "invalid_code_verifier",
+    isMatch: isInvalidCodeVerifierError,
+  },
+  {
+    bucket: "session_unverified",
+    isMatch: isUnverifiedSignInSessionError,
+  },
+  {
+    bucket: "missing_auth_parameter",
+    isMatch: isMissingRequiredAuthParameterError,
+  },
+  {
+    bucket: "cookie_missing",
+    isMatch: isAuthCookieMissingError,
+  },
+  {
+    bucket: "verifier_missing",
+    isMatch: isAuthVerifierMissingError,
+  },
+  {
+    bucket: "state_mismatch",
+    isMatch: isOAuthStateMismatchError,
+  },
+];
+
+export const getRecoverableAuthkitCallbackErrorBucket = (
+  value: unknown,
+): RecoverableAuthkitCallbackErrorBucket | null => {
   return (
-    isAuthCookieMissingError(value) ||
-    isOauthCodeAlreadyExchangedError(value) ||
-    isInvalidCodeVerifierError(value) ||
-    isUnverifiedSignInSessionError(value) ||
-    isMissingRequiredAuthParameterError(value) ||
-    isOAuthStateMismatchError(value) ||
-    isAuthVerifierMissingError(value)
+    RECOVERABLE_AUTHKIT_CALLBACK_ERROR_BUCKETS.find(({ isMatch }) =>
+      isMatch(value),
+    )?.bucket ?? null
   );
+};
+
+export const isRecoverableAuthkitCallbackError = (value: unknown): boolean => {
+  return getRecoverableAuthkitCallbackErrorBucket(value) !== null;
 };
 
 export const isRecoverableAuthkitCallbackErrorLog = (

--- a/lib/auth/expected-auth-errors.ts
+++ b/lib/auth/expected-auth-errors.ts
@@ -1,6 +1,8 @@
 const INVALID_GRANT_ERROR = "invalid_grant";
 const SESSION_ENDED_MESSAGE = "session has already ended";
 const INVALID_CODE_VERIFIER_MESSAGE = "invalid code verifier";
+const SIGN_IN_SESSION_UNVERIFIED_MESSAGE =
+  "sign-in session could not be verified";
 
 const getStringValue = (
   value: Record<string, unknown>,
@@ -59,4 +61,10 @@ export const isInvalidCodeVerifierError = (value: unknown): boolean => {
     errorText.includes(INVALID_GRANT_ERROR) &&
     errorText.includes(INVALID_CODE_VERIFIER_MESSAGE)
   );
+};
+
+export const isUnverifiedSignInSessionError = (value: unknown): boolean => {
+  return collectAuthErrorText(value)
+    .toLowerCase()
+    .includes(SIGN_IN_SESSION_UNVERIFIED_MESSAGE);
 };

--- a/proxy.ts
+++ b/proxy.ts
@@ -101,6 +101,46 @@ function withReferralCookie(
   return response;
 }
 
+function withSessionCookieCleared(response: NextResponse): NextResponse {
+  response.cookies.delete("wos-session");
+  return response;
+}
+
+function buildEndedSessionResponse(
+  request: NextRequest,
+  pathname: string,
+): NextResponse {
+  if (isUnauthenticatedPath(pathname)) {
+    return withSessionCookieCleared(
+      withReferralCookie(request, NextResponse.next()),
+    );
+  }
+
+  if (!isBrowserRequest(request)) {
+    return withSessionCookieCleared(
+      withReferralCookie(
+        request,
+        NextResponse.json(
+          {
+            code: "unauthorized:auth",
+            message: "You need to sign in before continuing.",
+            cause: "Session expired or invalid",
+          },
+          { status: 401 },
+        ),
+      ),
+    );
+  }
+
+  const redirectUrl = isDesktopApp(request)
+    ? new URL("/desktop-callback?error=unauthenticated", request.url)
+    : new URL("/login", request.url);
+
+  return withSessionCookieCleared(
+    withReferralCookie(request, NextResponse.redirect(redirectUrl)),
+  );
+}
+
 export default async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
@@ -125,44 +165,54 @@ export default async function proxy(request: NextRequest) {
   let refreshHitRateLimit = false;
   const hadSessionCookie = request.cookies.has("wos-session");
 
-  const { session, headers, authorizationUrl } = await authkit(request, {
-    redirectUri: getRedirectUri(),
-    eagerAuth: true,
-    onSessionRefreshError: ({ error }) => {
-      if (isEndedSessionRefreshError(error)) {
-        return;
-      }
+  let authkitResult: Awaited<ReturnType<typeof authkit>>;
+  try {
+    authkitResult = await authkit(request, {
+      redirectUri: getRedirectUri(),
+      eagerAuth: true,
+      onSessionRefreshError: ({ error }) => {
+        if (isEndedSessionRefreshError(error)) {
+          return;
+        }
 
-      if (isRateLimitError(error)) {
-        refreshHitRateLimit = true;
+        if (isRateLimitError(error)) {
+          refreshHitRateLimit = true;
+          console.warn(
+            JSON.stringify({
+              timestamp: new Date().toISOString(),
+              level: "warn",
+              event: "auth.session_refresh_rate_limited",
+              service: "hackerai-web",
+              environment:
+                process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+              pathname,
+            }),
+          );
+          return;
+        }
+
         console.warn(
           JSON.stringify({
             timestamp: new Date().toISOString(),
             level: "warn",
-            event: "auth.session_refresh_rate_limited",
+            event: "auth.session_refresh_failed",
             service: "hackerai-web",
             environment:
               process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
             pathname,
+            error: error instanceof Error ? error.message : String(error),
           }),
         );
-        return;
-      }
+      },
+    });
+  } catch (error) {
+    if (isEndedSessionRefreshError(error)) {
+      return buildEndedSessionResponse(request, pathname);
+    }
+    throw error;
+  }
 
-      console.warn(
-        JSON.stringify({
-          timestamp: new Date().toISOString(),
-          level: "warn",
-          event: "auth.session_refresh_failed",
-          service: "hackerai-web",
-          environment:
-            process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
-          pathname,
-          error: error instanceof Error ? error.message : String(error),
-        }),
-      );
-    },
-  });
+  const { session, headers, authorizationUrl } = authkitResult;
 
   const requestHeaders = buildRequestHeaders(request, headers);
   const responseHeaders = buildResponseHeaders(headers);


### PR DESCRIPTION
## Summary
- classify AuthKit "Sign-in session could not be verified" callback errors as recoverable `session_unverified` failures instead of unknown 500s
- suppress AuthKit's duplicate error-level callback log for that recoverable message while keeping unknown callback errors at error level
- catch thrown ended-session refresh errors in `proxy.ts`, clear the stale `wos-session` cookie, and return normal unauthenticated responses for `/` and protected APIs

## Validation
- `./node_modules/.bin/jest lib/auth/__tests__/expected-auth-errors.test.ts lib/auth/__tests__/authkit-callback-logging.test.ts __tests__/proxy.test.ts --runInBand`
- `./node_modules/.bin/prettier --check app/callback/route.ts proxy.ts lib/auth/expected-auth-errors.ts lib/auth/authkit-callback-logging.ts lib/auth/__tests__/expected-auth-errors.test.ts lib/auth/__tests__/authkit-callback-logging.test.ts __tests__/proxy.test.ts`
- `./node_modules/.bin/eslint app/callback/route.ts proxy.ts lib/auth/expected-auth-errors.ts lib/auth/authkit-callback-logging.ts lib/auth/__tests__/expected-auth-errors.test.ts lib/auth/__tests__/authkit-callback-logging.test.ts __tests__/proxy.test.ts`
- `./node_modules/.bin/tsc --noEmit` *(fails on existing `packages/local/src/index.ts(17,23): Cannot find module 'ws' or its corresponding type declarations.`)*

## Manual verification
- Visit an expired or already-used `/callback` URL that returns "Sign-in session could not be verified". It should redirect to `/login`, log a structured `auth.callback_invalid` recovery event with `bucket: "session_unverified"`, and avoid `[AuthKit callback error]` / `[callback] unrecoverable` error logs.
- Load `/` with a stale `wos-session` cookie that produces `TokenRefreshError invalid_grant / Session has already ended`. The homepage should render unauthenticated, clear `wos-session`, and avoid a Next route error log.
- Call a protected API with the same stale session cookie. It should return `401 unauthorized:auth`, clear `wos-session`, and avoid error-level logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for ended/expired session refresh during authentication across HTML and API requests.
  * Clear the session cookie in these recovery cases, preventing repeated failures.
  * Browser requests now redirect to the appropriate login flow, while API requests return an explicit 401 unauthorized payload.
  * Expanded recoverable error recognition to include “unverified sign-in session”, reducing expected auth failures and improving callback logging suppression.
* **Tests**
  * Added/updated coverage for the new ended-session proxy responses and the unverified sign-in error classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->