### PR TITLE
Fix deleted subscription referral eligibility

### DIFF
--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -22,6 +22,7 @@ const mockPostHogEvent = jest.fn();
 const mockPostHogWarn = jest.fn();
 const mockPostHogError = jest.fn();
 const mockPostHogFlush = jest.fn();
+const mockGetReferralRewardConfig = jest.fn();
 
 jest.mock("next/server", () => ({
   after: jest.fn((callback: () => void) => callback()),
@@ -106,10 +107,7 @@ jest.mock("@/lib/posthog/server", () => ({
 }));
 
 jest.mock("@/lib/referrals/config", () => ({
-  getReferralRewardConfig: () => ({
-    enabled: false,
-    referrerRewardDollars: 0,
-  }),
+  getReferralRewardConfig: mockGetReferralRewardConfig,
 }));
 
 function makeWebhookRequest({
@@ -137,6 +135,10 @@ describe("POST /api/subscription/webhook", () => {
     jest.spyOn(console, "error").mockImplementation(() => {});
 
     mockConvexMutation.mockResolvedValue({ alreadyProcessed: false } as never);
+    mockGetReferralRewardConfig.mockReturnValue({
+      enabled: false,
+      referrerRewardDollars: 0,
+    });
   });
 
   afterEach(() => {
@@ -335,7 +337,109 @@ describe("POST /api/subscription/webhook", () => {
     );
   });
 
-  it("skips deleted subscriptions that do not have a HackerAI price lookup key", async () => {
+  it("deactivates referral paid eligibility for deleted HackerAI subscriptions resolved from product fallback", async () => {
+    mockGetReferralRewardConfig.mockReturnValue({
+      enabled: true,
+      referrerRewardDollars: 10,
+    });
+    mockConstructEvent.mockReturnValue({
+      id: "evt_subscription_deleted_hackerai_fallback",
+      type: "customer.subscription.deleted",
+      data: {
+        object: {
+          id: "sub_hackerai_deleted",
+          customer: "cus_hackerai",
+          items: {
+            data: [
+              {
+                price: {
+                  id: "price_hackerai_no_lookup",
+                  lookup_key: null,
+                },
+              },
+            ],
+          },
+          metadata: {},
+          cancellation_details: {
+            reason: "cancellation_requested",
+          },
+        },
+      },
+    });
+    mockRetrieveSubscription.mockResolvedValue({
+      id: "sub_hackerai_deleted",
+      metadata: {},
+      items: {
+        data: [
+          {
+            quantity: 1,
+            price: {
+              id: "price_hackerai_no_lookup",
+              lookup_key: null,
+              recurring: { interval: "month", interval_count: 1 },
+              product: {
+                id: "prod_hackerai_pro_plus",
+                name: "HackerAI Pro Plus",
+                metadata: {},
+              },
+            },
+          },
+        ],
+      },
+    } as never);
+    mockRetrieveCustomer.mockResolvedValue({
+      deleted: false,
+      id: "cus_hackerai",
+      metadata: {
+        workOSOrganizationId: "org_hackerai",
+      },
+    } as never);
+    mockListMemberships.mockResolvedValue({
+      autoPagination: jest.fn().mockResolvedValue([{ userId: "user_paid" }]),
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(makeWebhookRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ received: true });
+    expect(mockRetrieveSubscription).toHaveBeenCalledWith(
+      "sub_hackerai_deleted",
+      {
+        expand: ["items.data.price", "items.data.price.product"],
+      },
+    );
+    expect(mockRetrieveCustomer).toHaveBeenCalledWith("cus_hackerai");
+    expect(mockListMemberships).toHaveBeenCalledWith({
+      organizationId: "org_hackerai",
+      statuses: ["active"],
+    });
+    expect(mockConvexMutation).toHaveBeenCalledWith(
+      "referrals.setReferralCodesPaidEligibility",
+      {
+        serviceKey: "service_key",
+        userIds: ["user_paid"],
+        active: false,
+        subscriptionTier: "free",
+      },
+    );
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "subscription_cancelled",
+      expect.objectContaining({
+        userId: "user_paid",
+        tier: "pro-plus",
+        org_id: "org_hackerai",
+        $set: { subscription_tier: "free" },
+      }),
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      '[Subscription Webhook] Subscription sub_hackerai_deleted missing price lookup_key, resolved tier "pro-plus" from product fallback',
+    );
+  });
+
+  it("skips deleted legacy PentestGPT subscriptions that do not have a HackerAI price lookup key", async () => {
     mockConstructEvent.mockReturnValue({
       id: "evt_subscription_deleted_legacy",
       type: "customer.subscription.deleted",
@@ -360,6 +464,27 @@ describe("POST /api/subscription/webhook", () => {
         },
       },
     });
+    mockRetrieveSubscription.mockResolvedValue({
+      id: "sub_legacy_deleted",
+      metadata: {},
+      items: {
+        data: [
+          {
+            quantity: 1,
+            price: {
+              id: "price_legacy",
+              lookup_key: null,
+              recurring: { interval: "month", interval_count: 1 },
+              product: {
+                id: "prod_legacy",
+                name: "PentestGPT Pro Subscription",
+                metadata: {},
+              },
+            },
+          },
+        ],
+      },
+    } as never);
 
     const { POST } = await import("../route");
 
@@ -368,6 +493,12 @@ describe("POST /api/subscription/webhook", () => {
 
     expect(response.status).toBe(200);
     expect(body).toEqual({ received: true });
+    expect(mockRetrieveSubscription).toHaveBeenCalledWith(
+      "sub_legacy_deleted",
+      {
+        expand: ["items.data.price", "items.data.price.product"],
+      },
+    );
     expect(mockRetrieveCustomer).not.toHaveBeenCalled();
     expect(mockListMemberships).not.toHaveBeenCalled();
     expect(mockPostHogEvent).not.toHaveBeenCalledWith(
@@ -375,7 +506,11 @@ describe("POST /api/subscription/webhook", () => {
       expect.anything(),
     );
     expect(console.info).toHaveBeenCalledWith(
-      "[Subscription Webhook] subscription.deleted: skipping subscription sub_legacy_deleted without HackerAI price lookup_key for customer cus_migrated",
+      "[Subscription Webhook] subscription.deleted: skipping legacy PentestGPT subscription sub_legacy_deleted for customer cus_migrated",
+    );
+    expect(mockConvexMutation).not.toHaveBeenCalledWith(
+      "referrals.setReferralCodesPaidEligibility",
+      expect.anything(),
     );
   });
 });

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -1135,20 +1135,36 @@ async function handleSubscriptionDeleted(
       : subscription.customer?.id;
   if (!customerId) return;
 
-  const lookupKey = subscription.items?.data[0]?.price?.lookup_key ?? null;
-  if (!lookupKey) {
-    console.info(
-      `[Subscription Webhook] subscription.deleted: skipping subscription ${subscription.id} without HackerAI price lookup_key for customer ${customerId}`,
-    );
-    return;
-  }
+  let price = subscription.items?.data[0]?.price;
+  const lookupKey = price?.lookup_key ?? null;
+  let tier: SubscriptionTier | null = null;
 
-  const tier = planLookupKeyToTier(lookupKey);
-  if (!tier) {
-    console.error(
-      `[Subscription Webhook] subscription.deleted: unknown price lookup_key "${lookupKey}" for subscription ${subscription.id}`,
-    );
-    return;
+  if (!lookupKey) {
+    const resolved = await resolveSubscription(subscription.id);
+    if (!resolved) {
+      console.info(
+        `[Subscription Webhook] subscription.deleted: skipping subscription ${subscription.id} without HackerAI price lookup_key or product fallback for customer ${customerId}`,
+      );
+      return;
+    }
+
+    if (resolved.kind === "legacy_pentestgpt") {
+      console.info(
+        `[Subscription Webhook] subscription.deleted: skipping legacy PentestGPT subscription ${subscription.id} for customer ${customerId}`,
+      );
+      return;
+    }
+
+    tier = resolved.tier;
+    price = resolved.subscription.items?.data[0]?.price ?? price;
+  } else {
+    tier = planLookupKeyToTier(lookupKey);
+    if (!tier) {
+      console.error(
+        `[Subscription Webhook] subscription.deleted: unknown price lookup_key "${lookupKey}" for subscription ${subscription.id}`,
+      );
+      return;
+    }
   }
 
   const { userIds, orgId, reason } =
@@ -1175,7 +1191,7 @@ async function handleSubscriptionDeleted(
     userIds,
     orgId: orgId ?? undefined,
     tier,
-    price: subscription.items?.data[0]?.price,
+    price,
     completionType: "deleted",
   });
 


### PR DESCRIPTION
## Summary
- resolve `customer.subscription.deleted` subscriptions that lack a price `lookup_key` through the existing Stripe subscription/product fallback before skipping
- preserve legacy PentestGPT and unresolved non-HackerAI skip behavior
- add focused webhook coverage proving fallback-resolved HackerAI deletions deactivate referral paid eligibility

## Validation
- `./node_modules/.bin/jest app/api/subscription/webhook/__tests__/route.test.ts --runInBand`
- `./node_modules/.bin/prettier --check app/api/subscription/webhook/route.ts app/api/subscription/webhook/__tests__/route.test.ts`
- `./node_modules/.bin/eslint app/api/subscription/webhook/route.ts app/api/subscription/webhook/__tests__/route.test.ts`
- `git diff --check`
- `./node_modules/.bin/tsc --noEmit` fails on existing unrelated issue: `packages/local/src/index.ts(17,23): error TS2307: Cannot find module 'ws' or its corresponding type declarations.`
- Initial `pnpm jest app/api/subscription/webhook/__tests__/route.test.ts --runInBand` did not reach Jest because pnpm stopped on minimum-release-age lockfile policy for recently published packages. The focused Jest run above used the main checkout dependency tree symlinked into this worktree.

## Manual verification
- In Stripe test mode, send `customer.subscription.deleted` for a HackerAI subscription whose price has no `lookup_key` but whose product name or metadata resolves to a paid tier; the mapped user's referral code paid eligibility should become inactive.
- Send the same event for a legacy PentestGPT product with no HackerAI lookup key; the handler should skip without resolving users or mutating referral eligibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cancelled subscriptions when billing data is incomplete, ensuring the correct plan tier is still detected.
  * Fixed cases where cancellations could be missed for active subscriptions, so account status and paid-access eligibility update more reliably.
  * Cancellation events now reflect the correct plan downgrade to free when applicable, improving reporting accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->