### PR TITLE
Gate subscribe referral attribution to free users

### DIFF
--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -102,6 +102,7 @@ describe("POST /api/subscribe", () => {
     jest.clearAllMocks();
     process.env.NEXT_PUBLIC_BASE_URL = "https://hackerai.example";
     process.env.CONVEX_SERVICE_ROLE_KEY = "service_key";
+    delete process.env.REFERRAL_PROGRAM_ENABLED;
 
     mockConvexMutation.mockResolvedValue(null);
 
@@ -359,6 +360,41 @@ describe("POST /api/subscribe", () => {
   });
 
   it("skips referral attribution and checkout linkage for paid users", async () => {
+    mockGetUserIDAndPro.mockResolvedValueOnce({
+      userId: "user_123",
+      subscription: "pro",
+      freeQuotaSubject: "free_quota_subject",
+    } as never);
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [],
+    } as never);
+    mockCreateOrganization.mockResolvedValue({
+      id: "org_new",
+    } as never);
+    mockCreateCustomer.mockResolvedValue({
+      id: "cus_new",
+      metadata: {},
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      makeRequest({ plan: "pro-monthly-plan" }, { hackerai_ref: "REF123" }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      url: "https://stripe.example/checkout",
+      checkoutAttemptId: expect.stringMatching(/^ca_/),
+    });
+    expect(mockConvexMutation).not.toHaveBeenCalled();
+    expect(mockResponseCookieDelete).toHaveBeenCalledWith("hackerai_ref");
+    expect(mockResponseCookieDelete).toHaveBeenCalledWith("hackerai_ref_at");
+  });
+
+  it("clears paid-user referral cookies when referral attribution is disabled", async () => {
+    process.env.REFERRAL_PROGRAM_ENABLED = "false";
     mockGetUserIDAndPro.mockResolvedValueOnce({
       userId: "user_123",
       subscription: "pro",

--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import { mockMutation as mockConvexMutation } from "convex/browser";
 
-const mockGetUserID = jest.fn();
+const mockGetUserIDAndPro = jest.fn();
 const mockGetUser = jest.fn();
 const mockListOrganizationMemberships = jest.fn();
 const mockCreateOrganizationMembership = jest.fn();
@@ -15,7 +15,9 @@ const mockRetrieveCustomer = jest.fn();
 const mockUpdateCustomer = jest.fn();
 const mockCreateCheckoutSession = jest.fn();
 const mockPostHogEvent = jest.fn();
+const mockPostHogWarn = jest.fn();
 const mockPostHogFlush = jest.fn();
+const mockResponseCookieDelete = jest.fn();
 
 jest.mock("next/server", () => {
   return {
@@ -24,13 +26,16 @@ jest.mock("next/server", () => {
       json: jest.fn((body: unknown, init?: ResponseInit) => ({
         status: init?.status ?? 200,
         json: async () => body,
+        cookies: {
+          delete: mockResponseCookieDelete,
+        },
       })),
     },
   };
 });
 
 jest.mock("@/lib/auth/get-user-id", () => ({
-  getUserID: mockGetUserID,
+  getUserIDAndPro: mockGetUserIDAndPro,
 }));
 
 jest.mock("@/app/api/workos", () => ({
@@ -70,6 +75,7 @@ jest.mock("@/app/api/stripe", () => ({
 jest.mock("@/lib/posthog/server", () => ({
   phLogger: {
     event: mockPostHogEvent,
+    warn: mockPostHogWarn,
     flush: mockPostHogFlush,
   },
 }));
@@ -99,12 +105,17 @@ describe("POST /api/subscribe", () => {
 
     mockConvexMutation.mockResolvedValue(null);
 
-    mockGetUserID.mockResolvedValue("user_123" as never);
+    mockGetUserIDAndPro.mockResolvedValue({
+      userId: "user_123",
+      subscription: "free",
+      freeQuotaSubject: "free_quota_subject",
+    } as never);
     mockGetUser.mockResolvedValue({
       id: "user_123",
       email: "user@example.com",
       firstName: "Ada",
       lastName: "Lovelace",
+      createdAt: "2026-06-30T12:00:00.000Z",
     } as never);
     mockListPrices.mockResolvedValue({
       data: [
@@ -292,6 +303,29 @@ describe("POST /api/subscribe", () => {
       url: "https://stripe.example/checkout",
       checkoutAttemptId: expect.stringMatching(/^ca_/),
     });
+    expect(mockConvexMutation).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        serviceKey: "service_key",
+        referredUserId: "user_123",
+        referralCode: "REF123",
+        starterBonusUnits: 0,
+        referredIdentityHash: "free_quota_subject",
+        source: "subscribe_route_referral_cookie",
+      }),
+    );
+    expect(mockConvexMutation).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.objectContaining({
+        serviceKey: "service_key",
+        referredUserId: "user_123",
+        stripeCustomerId: "cus_new",
+        stripeCheckoutSessionId: "cs_123",
+        requestedPlan: "pro-monthly-plan",
+      }),
+    );
     expect(mockCreateCheckoutSession).toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: expect.objectContaining({
@@ -322,6 +356,40 @@ describe("POST /api/subscribe", () => {
     expect(checkoutArgs.subscription_data.metadata).not.toHaveProperty(
       "referral_referred_user_id",
     );
+  });
+
+  it("skips referral attribution and checkout linkage for paid users", async () => {
+    mockGetUserIDAndPro.mockResolvedValueOnce({
+      userId: "user_123",
+      subscription: "pro",
+      freeQuotaSubject: "free_quota_subject",
+    } as never);
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [],
+    } as never);
+    mockCreateOrganization.mockResolvedValue({
+      id: "org_new",
+    } as never);
+    mockCreateCustomer.mockResolvedValue({
+      id: "cus_new",
+      metadata: {},
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      makeRequest({ plan: "pro-monthly-plan" }, { hackerai_ref: "REF123" }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      url: "https://stripe.example/checkout",
+      checkoutAttemptId: expect.stringMatching(/^ca_/),
+    });
+    expect(mockConvexMutation).not.toHaveBeenCalled();
+    expect(mockResponseCookieDelete).toHaveBeenCalledWith("hackerai_ref");
+    expect(mockResponseCookieDelete).toHaveBeenCalledWith("hackerai_ref_at");
   });
 
   it("persists checkout attribution in Stripe metadata and analytics", async () => {

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -76,53 +76,56 @@ export const POST = async (req: NextRequest) => {
     const orgName = buildWorkOSOrganizationName(user);
     const referralConfig = getReferralRewardConfig();
     const referralCode = req.cookies.get(REFERRAL_COOKIE_NAME)?.value;
+    const validReferralCode = isValidReferralCode(referralCode)
+      ? referralCode
+      : undefined;
     const canRecordReferralCheckoutSession = subscription === "free";
+
+    if (validReferralCode && subscription !== "free") {
+      shouldClearReferralCookies = true;
+    }
 
     if (
       referralConfig.enabled &&
-      referralCode &&
-      isValidReferralCode(referralCode)
+      validReferralCode &&
+      canRecordReferralCheckoutSession
     ) {
-      if (subscription !== "free") {
-        shouldClearReferralCookies = true;
-      } else {
-        try {
-          const attribution = await getConvexClient().mutation(
-            api.referrals.attributeReferredSignup,
-            {
-              serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
-              referredUserId: userId,
-              referralCode,
-              starterBonusUnits: 0,
-              referredIdentityHash: freeQuotaSubject,
-              userCreatedAtMs: parseCreatedAtMs(user.createdAt),
-              maxUserAgeDays: referralConfig.attributionMaxUserAgeDays,
-              source: "subscribe_route_referral_cookie",
-            },
-          );
+      try {
+        const attribution = await getConvexClient().mutation(
+          api.referrals.attributeReferredSignup,
+          {
+            serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+            referredUserId: userId,
+            referralCode: validReferralCode,
+            starterBonusUnits: 0,
+            referredIdentityHash: freeQuotaSubject,
+            userCreatedAtMs: parseCreatedAtMs(user.createdAt),
+            maxUserAgeDays: referralConfig.attributionMaxUserAgeDays,
+            source: "subscribe_route_referral_cookie",
+          },
+        );
 
-          if (attribution.status === "attributed") {
-            const referrerSubscriptionTier = (
-              attribution as { referrerSubscriptionTier?: string }
-            ).referrerSubscriptionTier;
+        if (attribution.status === "attributed") {
+          const referrerSubscriptionTier = (
+            attribution as { referrerSubscriptionTier?: string }
+          ).referrerSubscriptionTier;
 
-            phLogger.event("referred_signup_attributed", {
-              userId,
-              referrer_user_id: attribution.referrerUserId,
-              referrer_subscription_tier: referrerSubscriptionTier,
-              referral_code: referralCode,
-              starter_bonus_awarded: attribution.starterBonusAwarded,
-              starter_bonus_units: 0,
-              source: "subscribe_route",
-            });
-          }
-        } catch (error) {
-          phLogger.warn("referral_attribution_failed_before_checkout", {
+          phLogger.event("referred_signup_attributed", {
             userId,
-            referral_code: referralCode,
-            error: error instanceof Error ? error.message : String(error),
+            referrer_user_id: attribution.referrerUserId,
+            referrer_subscription_tier: referrerSubscriptionTier,
+            referral_code: validReferralCode,
+            starter_bonus_awarded: attribution.starterBonusAwarded,
+            starter_bonus_units: 0,
+            source: "subscribe_route",
           });
         }
+      } catch (error) {
+        phLogger.warn("referral_attribution_failed_before_checkout", {
+          userId,
+          referral_code: validReferralCode,
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
     }
     const allowedPlans = new Set([

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,14 +1,14 @@
 import { stripe } from "../stripe";
 import { workos } from "../workos";
-import { getUserID } from "@/lib/auth/get-user-id";
+import { getUserIDAndPro } from "@/lib/auth/get-user-id";
 import { buildWorkOSOrganizationName } from "@/lib/auth/workos-organization-name";
-import { createFreeQuotaSubject } from "@/lib/auth/free-quota-subject";
 import { NextRequest, NextResponse, after } from "next/server";
 import { getSuspensionMessage } from "@/lib/suspensionMessage";
 import { phLogger } from "@/lib/posthog/server";
 import { getConvexClient } from "@/lib/db/convex-client";
 import { api } from "@/convex/_generated/api";
 import {
+  REFERRAL_COOKIE_CREATED_AT_NAME,
   REFERRAL_COOKIE_NAME,
   getReferralRewardConfig,
   isValidReferralCode,
@@ -37,7 +37,21 @@ function parseCreatedAtMs(raw: unknown): number | undefined {
   return Number.isFinite(timestamp) ? timestamp : undefined;
 }
 
+function clearReferralCookies(response: NextResponse) {
+  response.cookies.delete(REFERRAL_COOKIE_NAME);
+  response.cookies.delete(REFERRAL_COOKIE_CREATED_AT_NAME);
+}
+
 export const POST = async (req: NextRequest) => {
+  let shouldClearReferralCookies = false;
+  const json = (body: unknown, init?: ResponseInit) => {
+    const response = NextResponse.json(body, init);
+    if (shouldClearReferralCookies) {
+      clearReferralCookies(response);
+    }
+    return response;
+  };
+
   try {
     const body = await req.json().catch(() => ({}));
     const requestedPlan: string | undefined = body?.plan;
@@ -53,57 +67,62 @@ export const POST = async (req: NextRequest) => {
     );
     const fromTier = paidFunnelTierFromUnknown(body?.fromTier);
     const posthogSessionId = req.headers.get("x-posthog-session-id");
-    // Get user ID from authenticated session
-    const userId = await getUserID(req);
+    // Get user ID and subscription state from authenticated session
+    const { userId, subscription, freeQuotaSubject } =
+      await getUserIDAndPro(req);
 
     // Get user details from WorkOS to create a personal organization.
     const user = await workos.userManagement.getUser(userId);
     const orgName = buildWorkOSOrganizationName(user);
-    const freeQuotaSubject = createFreeQuotaSubject(user.email);
     const referralConfig = getReferralRewardConfig();
     const referralCode = req.cookies.get(REFERRAL_COOKIE_NAME)?.value;
+    const canRecordReferralCheckoutSession = subscription === "free";
 
     if (
       referralConfig.enabled &&
       referralCode &&
       isValidReferralCode(referralCode)
     ) {
-      try {
-        const attribution = await getConvexClient().mutation(
-          api.referrals.attributeReferredSignup,
-          {
-            serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
-            referredUserId: userId,
-            referralCode,
-            starterBonusUnits: 0,
-            referredIdentityHash: freeQuotaSubject,
-            userCreatedAtMs: parseCreatedAtMs(user.createdAt),
-            maxUserAgeDays: referralConfig.attributionMaxUserAgeDays,
-            source: "subscribe_route_referral_cookie",
-          },
-        );
+      if (subscription !== "free") {
+        shouldClearReferralCookies = true;
+      } else {
+        try {
+          const attribution = await getConvexClient().mutation(
+            api.referrals.attributeReferredSignup,
+            {
+              serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
+              referredUserId: userId,
+              referralCode,
+              starterBonusUnits: 0,
+              referredIdentityHash: freeQuotaSubject,
+              userCreatedAtMs: parseCreatedAtMs(user.createdAt),
+              maxUserAgeDays: referralConfig.attributionMaxUserAgeDays,
+              source: "subscribe_route_referral_cookie",
+            },
+          );
 
-        if (attribution.status === "attributed") {
-          const referrerSubscriptionTier = (
-            attribution as { referrerSubscriptionTier?: string }
-          ).referrerSubscriptionTier;
+          if (attribution.status === "attributed") {
+            const referrerSubscriptionTier = (
+              attribution as { referrerSubscriptionTier?: string }
+            ).referrerSubscriptionTier;
 
-          phLogger.event("referred_signup_attributed", {
+            phLogger.event("referred_signup_attributed", {
+              userId,
+              referrer_user_id: attribution.referrerUserId,
+              referrer_subscription_tier: referrerSubscriptionTier,
+              referral_code: referralCode,
+              starter_bonus_awarded: attribution.starterBonusAwarded,
+              starter_bonus_units: 0,
+              source: "subscribe_route",
+            });
+          }
+        } catch (error) {
+          phLogger.warn("referral_attribution_failed_before_checkout", {
             userId,
-            referrer_user_id: attribution.referrerUserId,
-            referrer_subscription_tier: referrerSubscriptionTier,
             referral_code: referralCode,
-            starter_bonus_awarded: attribution.starterBonusAwarded,
-            starter_bonus_units: 0,
-            source: "subscribe_route",
+            error: error instanceof Error ? error.message : String(error),
           });
         }
-      } catch (error) {
-        phLogger.warn("referral_attribution_failed_before_checkout", {
-          userId,
-          referral_code: referralCode,
-          error: error instanceof Error ? error.message : String(error),
-        });
       }
     }
     const allowedPlans = new Set([
@@ -146,7 +165,7 @@ export const POST = async (req: NextRequest) => {
       // User already has an organization, use the first one
       const membership = existingMemberships.data[0];
       if (!canManageOrganizationBilling(membership)) {
-        return NextResponse.json(
+        return json(
           { error: "Only organization admins or owners can manage billing" },
           { status: 403 },
         );
@@ -182,7 +201,7 @@ export const POST = async (req: NextRequest) => {
         console.error(
           `No price found for lookup key: ${subscriptionLevel}. This is likely because the products and prices have not been created yet. Run the setup script \`pnpm run setup\` to automatically create them.`,
         );
-        return NextResponse.json(
+        return json(
           {
             error: "Subscription plan not found",
             details: `No price found for plan: ${subscriptionLevel}`,
@@ -195,7 +214,7 @@ export const POST = async (req: NextRequest) => {
         `Error retrieving price from Stripe for lookup key: ${subscriptionLevel}. This is likely because the products and prices have not been created yet. Run the setup script \`pnpm run setup\` to automatically create them.`,
         error,
       );
-      return NextResponse.json(
+      return json(
         { error: "Error retrieving price from Stripe" },
         { status: 500 },
       );
@@ -211,7 +230,7 @@ export const POST = async (req: NextRequest) => {
       );
 
       if ("deleted" in existingCustomer && existingCustomer.deleted) {
-        return NextResponse.json(
+        return json(
           { error: "Billing account is no longer available" },
           { status: 409 },
         );
@@ -239,7 +258,7 @@ export const POST = async (req: NextRequest) => {
     if (customer) {
       // Reject blocked customers (flagged by fraud webhook)
       if (customer.metadata.blocked === "true") {
-        return NextResponse.json(
+        return json(
           {
             error: getSuspensionMessage(customer.metadata.blocked_reason),
           },
@@ -280,7 +299,7 @@ export const POST = async (req: NextRequest) => {
 
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
     if (!baseUrl) {
-      return NextResponse.json(
+      return json(
         { error: "NEXT_PUBLIC_BASE_URL is not configured" },
         { status: 500 },
       );
@@ -345,7 +364,7 @@ export const POST = async (req: NextRequest) => {
       },
     });
 
-    if (referralConfig.enabled) {
+    if (referralConfig.enabled && canRecordReferralCheckoutSession) {
       try {
         const referralSession = await getConvexClient().mutation(
           api.referrals.recordReferralCheckoutSession,
@@ -420,11 +439,11 @@ export const POST = async (req: NextRequest) => {
     );
     after(() => phLogger.flush());
 
-    return NextResponse.json({ url: session.url, checkoutAttemptId });
+    return json({ url: session.url, checkoutAttemptId });
   } catch (error: unknown) {
     const errorMessage =
       error instanceof Error ? error.message : "An error occurred";
     console.error(errorMessage, error);
-    return NextResponse.json({ error: errorMessage }, { status: 500 });
+    return json({ error: errorMessage }, { status: 500 });
   }
 };


### PR DESCRIPTION
## Summary
- gate `/api/subscribe` referral attribution on `getUserIDAndPro` subscription state
- clear referral cookies for existing paid users with a valid referral cookie
- skip referral checkout-session linking for non-free users while preserving the free-user path

## Validation
- `corepack pnpm jest app/api/subscribe/__tests__/route.test.ts --runInBand`
- `corepack pnpm exec prettier --check app/api/subscribe/route.ts app/api/subscribe/__tests__/route.test.ts`
- `corepack pnpm exec eslint app/api/subscribe/route.ts app/api/subscribe/__tests__/route.test.ts`
- `corepack pnpm typecheck`

## Manual verification
- Paid/pro user: set valid `hackerai_ref` and `hackerai_ref_at` cookies, start checkout from `/api/subscribe`, and confirm checkout opens while referral cookies are cleared and no referral attribution or checkout-session referral record is created.
- Free user: set a valid referral cookie, start checkout from `/api/subscribe`, and confirm checkout opens while referral attribution and checkout-session referral linking are preserved.

Visual verification was not required because this is a backend checkout route and route-level tests cover the changed behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More reliable subscription checkout behavior for signed-in users, with improved referral attribution during signup and purchase flows when eligible.

* **Bug Fixes**
  * Referral cookies are now cleared automatically when users are no longer on a free plan.
  * Paid users no longer trigger referral attribution or checkout-linking actions, preventing duplicate/stale tracking.
  * When the referral program is disabled, referral tracking is skipped and related cookies are removed.

* **Bug Fixes**
  * Subscription-flow error responses are now handled more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->