### PR TITLE
Fix fallback model cost accounting

### DIFF
--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -418,6 +418,55 @@ describe("UsageTracker", () => {
       expect(usage.costSource).toBe("raw_token_estimate");
     });
 
+    it("uses served fallback model pricing when raw provider cost is absent", () => {
+      tracker.accumulateStep({
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+      });
+
+      const usage = tracker.createUsageCostRecord({
+        selectedModel: "agent-model-free",
+        accountingModel: "model-kimi-k2.7-code",
+        configuredModelId: "minimax/minimax-m3",
+        rateLimitInfo: {
+          remaining: 1000,
+          resetTime: new Date(),
+          limit: 250000,
+          pointsDeducted: 100,
+        },
+      });
+
+      expect(usage.model).toBe("auto");
+      expect(usage.modelCostDollars).toBe(4.95);
+      expect(usage.costDollars).toBe(4.95);
+      expect(usage.costSource).toBe("raw_token_estimate");
+    });
+
+    it("keeps raw provider cost ahead of served fallback token estimates", () => {
+      tracker.accumulateStep({
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+        raw: { cost: 0.42 },
+      });
+
+      const usage = tracker.createUsageCostRecord({
+        selectedModel: "agent-model-free",
+        accountingModel: "model-kimi-k2.7-code",
+        configuredModelId: "minimax/minimax-m3",
+        rateLimitInfo: {
+          remaining: 1000,
+          resetTime: new Date(),
+          limit: 250000,
+          pointsDeducted: 100,
+        },
+      });
+
+      expect(usage.model).toBe("auto");
+      expect(usage.modelCostDollars).toBe(0.42);
+      expect(usage.costDollars).toBe(0.42);
+      expect(usage.costSource).toBe("provider");
+    });
+
     it("labels post-run overflow as mixed when final deduction uses extra usage", () => {
       tracker.accumulateStep({
         inputTokens: 1_000_000,

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -10,6 +10,7 @@ import {
   buildProviderOptions,
   getRetryFallbackModel,
   isAutoModelSelectionForRetry,
+  resolveServedModelForCostAccounting,
 } from "@/lib/api/chat-stream-helpers";
 
 jest.mock("@/lib/db/actions", () => ({
@@ -409,4 +410,35 @@ describe("getRetryFallbackModel", () => {
       expect(getRetryFallbackModel(modelName, mode)).toBe("model-minimax-m3");
     },
   );
+});
+
+describe("resolveServedModelForCostAccounting", () => {
+  it("maps a Kimi provider slug served from free Agent fallback back to the local cost key", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "agent-model-free",
+        responseModel: KIMI_SLUG,
+        mode: "agent",
+      }),
+    ).toBe("model-kimi-k2.7-code");
+  });
+
+  it("maps a terminal Grok provider slug served from free Agent fallback back to the fallback cost key", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "agent-model-free",
+        responseModel: GROK_SLUG,
+        mode: "agent",
+      }),
+    ).toBe("fallback-grok-4.3");
+  });
+
+  it("falls back to the active model key when provider metadata is absent", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "agent-model-free",
+        mode: "agent",
+      }),
+    ).toBe("agent-model-free");
+  });
 });

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -79,6 +79,7 @@ import {
   estimatePreflightInputTokens,
   getRetryFallbackModel,
   isAutoModelSelectionForRetry,
+  resolveServedModelForCostAccounting,
 } from "@/lib/api/chat-stream-helpers";
 import { geolocation } from "@vercel/functions";
 import { NextRequest } from "next/server";
@@ -176,8 +177,7 @@ export const createChatHandler = () => {
   return async (req: NextRequest) => {
     const endpoint = "/api/chat" as const;
     let preemptiveTimeout:
-      | ReturnType<typeof createPreemptiveTimeout>
-      | undefined;
+      ReturnType<typeof createPreemptiveTimeout> | undefined;
 
     // Track usage deductions for refund on error
     const usageRefundTracker = new UsageRefundTracker();
@@ -404,8 +404,7 @@ export const createChatHandler = () => {
       chatLogger.setChat(chatLogContext, selectedModel);
 
       let paidDailyFreeAllowanceReservation:
-        | PaidDailyFreeAllowanceReservation
-        | undefined;
+        PaidDailyFreeAllowanceReservation | undefined;
       let rateLimitInfo: RateLimitInfo;
 
       try {
@@ -862,6 +861,7 @@ export const createChatHandler = () => {
             const fallbackModel = getRetryFallbackModel(selectedModel, mode);
             const fallbackModelId =
               trackedProvider.languageModel(fallbackModel).modelId;
+            let activeModelName = selectedModel;
 
             const usageTracker = new UsageTracker();
             let hasRecordedUsage = false;
@@ -890,6 +890,11 @@ export const createChatHandler = () => {
                   selectedModelOverride,
                   responseModel: state.responseModel,
                   configuredModelId,
+                  accountingModel: resolveServedModelForCostAccounting({
+                    modelName: activeModelName,
+                    responseModel: state.responseModel,
+                    mode,
+                  }),
                   rateLimitInfo,
                 };
                 let usageCostRecord =
@@ -941,6 +946,7 @@ export const createChatHandler = () => {
                     selectedModelOverride,
                     responseModel: state.responseModel,
                     configuredModelId,
+                    accountingModel: usageRecordArgs.accountingModel,
                     rateLimitInfo,
                   });
                   const cutOff = state.stoppedDueToBudgetExhaustion;
@@ -992,6 +998,7 @@ export const createChatHandler = () => {
                     usageTracker.nonModelCost,
                     organizationId,
                     rateLimitInfo,
+                    usageRecordArgs.accountingModel,
                   );
                   const billingBreakdown =
                     deductionResult.includedPointsDeducted > 0 ||
@@ -1013,6 +1020,7 @@ export const createChatHandler = () => {
                     selectedModelOverride,
                     responseModel: state.responseModel,
                     configuredModelId,
+                    accountingModel: usageRecordArgs.accountingModel,
                     rateLimitInfo,
                     billingBreakdown,
                   });
@@ -1089,6 +1097,7 @@ export const createChatHandler = () => {
             };
 
             const createStream = (modelName: string) => {
+              activeModelName = modelName;
               streamCtx.tools = getToolsForModel(modelName);
               setCurrentModelName(modelName);
               return createAgentStream(modelName, streamCtx, state);

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -625,6 +625,30 @@ export function getFallbackSlugs(
   );
 }
 
+export function resolveServedModelForCostAccounting({
+  modelName,
+  responseModel,
+  mode,
+  options = {},
+}: {
+  modelName: string;
+  responseModel?: string;
+  mode?: ChatMode;
+  options?: FallbackOptions;
+}): string {
+  if (!responseModel) return modelName;
+
+  const candidateKeys = [
+    modelName as ModelName,
+    ...(getFallbackKeys(modelName, mode, options) ?? []),
+  ];
+  const matchedKey = candidateKeys.find(
+    (key) => resolveSlug(key) === responseModel,
+  );
+
+  return matchedKey ?? responseModel;
+}
+
 /**
  * Build provider options for streamText
  */

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -579,6 +579,119 @@ describe("token-bucket async functions", () => {
       // Should charge additional via limiter
       expect(mockLimitFn).toHaveBeenCalled();
     });
+
+    it("should use served fallback model pricing for actual token cost when provider cost is absent", async () => {
+      const { deductUsage, calculateTokenCost } = getIsolatedModule();
+
+      const estimatedInputTokens = 1_000_000;
+      const actualInputTokens = 1_000_000;
+      const actualOutputTokens = 1_000_000;
+      const selectedModel = "agent-model-free";
+      const servedModel = "model-kimi-k2.7-code";
+      const initialDeduction = calculateTokenCost(
+        estimatedInputTokens,
+        "input",
+        selectedModel,
+      );
+      const expectedActualCost =
+        calculateTokenCost(actualInputTokens, "input", servedModel) +
+        calculateTokenCost(actualOutputTokens, "output", servedModel);
+      const expectedAdditional = expectedActualCost - initialDeduction;
+
+      mockLimitFn
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 100_000,
+          reset: Date.now() + 3600000,
+          limit: 250000,
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 100_000 - expectedAdditional,
+          reset: Date.now() + 3600000,
+          limit: 250000,
+        });
+
+      const result = await deductUsage(
+        "user-123",
+        "pro",
+        estimatedInputTokens,
+        actualInputTokens,
+        actualOutputTokens,
+        undefined,
+        undefined,
+        selectedModel,
+        0,
+        undefined,
+        { pointsDeducted: initialDeduction },
+        servedModel,
+      );
+
+      expect(expectedAdditional).toBe(60_450);
+      expect(mockLimitFn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ rate: expectedAdditional }),
+      );
+      expect(result).toEqual({
+        includedPointsDeducted: expectedActualCost,
+        extraUsagePointsDeducted: 0,
+      });
+    });
+
+    it("should prefer raw provider cost over served fallback token pricing", async () => {
+      const { deductUsage, calculateTokenCost } = getIsolatedModule();
+
+      const estimatedInputTokens = 1_000_000;
+      const selectedModel = "agent-model-free";
+      const servedModel = "model-kimi-k2.7-code";
+      const providerCostDollars = 0.42;
+      const initialDeduction = calculateTokenCost(
+        estimatedInputTokens,
+        "input",
+        selectedModel,
+      );
+      const expectedProviderCost = Math.ceil(providerCostDollars * 10_000);
+      const expectedAdditional = expectedProviderCost - initialDeduction;
+
+      mockLimitFn
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 100_000,
+          reset: Date.now() + 3600000,
+          limit: 250000,
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 100_000 - expectedAdditional,
+          reset: Date.now() + 3600000,
+          limit: 250000,
+        });
+
+      const result = await deductUsage(
+        "user-123",
+        "pro",
+        estimatedInputTokens,
+        1_000_000,
+        1_000_000,
+        undefined,
+        providerCostDollars,
+        selectedModel,
+        0,
+        undefined,
+        { pointsDeducted: initialDeduction },
+        servedModel,
+      );
+
+      expect(expectedAdditional).toBe(300);
+      expect(mockLimitFn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ rate: expectedAdditional }),
+      );
+      expect(result).toEqual({
+        includedPointsDeducted: expectedProviderCost,
+        extraUsagePointsDeducted: 0,
+      });
+    });
   });
 
   describe("refundUsage", () => {

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -565,6 +565,7 @@ export const deductUsage = async (
     RateLimitInfo,
     "pointsDeducted" | "extraUsagePointsDeducted"
   >,
+  actualModelName?: string,
 ): Promise<UsageDeductionResult> => {
   const redis = createRedisClient();
   if (!redis) {
@@ -625,15 +626,16 @@ export const deductUsage = async (
     if (providerCostDollars !== undefined && providerCostDollars > 0) {
       actualCostPoints = Math.ceil(providerCostDollars * POINTS_PER_DOLLAR);
     } else {
+      const modelForActualCost = actualModelName ?? modelName;
       const actualInputCost = calculateTokenCost(
         actualInputTokens,
         "input",
-        modelName,
+        modelForActualCost,
       );
       const outputCost = calculateTokenCost(
         actualOutputTokens,
         "output",
-        modelName,
+        modelForActualCost,
       );
       const nonModelCostPoints =
         nonModelCostDollars > 0

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -115,7 +115,10 @@ export class UsageTracker {
     );
   }
 
-  computeModelCostDollars(selectedModel: string): number {
+  computeModelCostDollars(
+    selectedModel: string,
+    accountingModel?: string,
+  ): number {
     // Use authoritative per-step provider cost only when the model itself
     // reported one via raw.cost (tracked in modelProviderCost). providerCost
     // also includes sandbox/tool spend and summarization cost, so subtract
@@ -123,20 +126,24 @@ export class UsageTracker {
     if (this.modelProviderCost > 0) {
       return this.providerCost - this.nonModelCost;
     }
+    const modelForEstimate = accountingModel ?? selectedModel;
     return (
-      (calculateRawTokenCost(this.inputTokens, "input", selectedModel) +
-        calculateRawTokenCost(this.outputTokens, "output", selectedModel)) /
+      (calculateRawTokenCost(this.inputTokens, "input", modelForEstimate) +
+        calculateRawTokenCost(this.outputTokens, "output", modelForEstimate)) /
       POINTS_PER_DOLLAR
     );
   }
 
-  computeCostDollars(selectedModel: string): number {
+  computeCostDollars(selectedModel: string, accountingModel?: string): number {
     // Mirror deductUsage's gate: providerCost is only authoritative for the
     // total when modelProviderCost > 0. After resetModelLeg() (fallback retry)
     // providerCost can be positive from nonModelCost alone, which would
     // underreport the fallback's model tokens if we used it directly.
     if (this.modelProviderCost > 0) return this.providerCost;
-    return this.computeModelCostDollars(selectedModel) + this.nonModelCost;
+    return (
+      this.computeModelCostDollars(selectedModel, accountingModel) +
+      this.nonModelCost
+    );
   }
 
   getBillingBreakdown(
@@ -236,6 +243,7 @@ export class UsageTracker {
     selectedModelOverride,
     responseModel,
     configuredModelId,
+    accountingModel,
     rateLimitInfo,
     billingBreakdown,
   }: {
@@ -243,6 +251,7 @@ export class UsageTracker {
     selectedModelOverride?: string | null;
     responseModel?: string;
     configuredModelId: string;
+    accountingModel?: string;
     rateLimitInfo: RateLimitInfo;
     billingBreakdown?: UsageBillingBreakdown;
   }): UsageCostRecord {
@@ -252,7 +261,10 @@ export class UsageTracker {
       configuredModelId,
       selectedModel,
     });
-    const modelCostDollars = this.computeModelCostDollars(selectedModel);
+    const modelCostDollars = this.computeModelCostDollars(
+      selectedModel,
+      accountingModel,
+    );
     const costDollars = modelCostDollars + this.nonModelCost;
     const costBreakdown = this.resolveCostBreakdown(
       costDollars,
@@ -287,6 +299,7 @@ export class UsageTracker {
     selectedModelOverride?: string | null;
     responseModel?: string;
     configuredModelId: string;
+    accountingModel?: string;
     rateLimitInfo: RateLimitInfo;
     billingBreakdown?: UsageBillingBreakdown;
   }) {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -38,6 +38,7 @@ import {
   isProviderApiError,
   injectNotesIntoMessages,
   getRetryFallbackModel,
+  resolveServedModelForCostAccounting,
 } from "@/lib/api/chat-stream-helpers";
 import {
   BudgetMonitor,
@@ -546,8 +547,7 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
 
 const getTerminalProviderStreamError = (
   state:
-    | Pick<AgentStreamState, "streamFinishReason" | "providerError">
-    | undefined,
+    Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
 ): unknown | undefined => {
   if (!state) return undefined;
   if (state.streamFinishReason !== "error") return undefined;
@@ -564,8 +564,7 @@ const getTerminalProviderStreamError = (
 
 const isTerminalProviderStreamError = (
   state:
-    | Pick<AgentStreamState, "streamFinishReason" | "providerError">
-    | undefined,
+    Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
 ): boolean => state?.streamFinishReason === "error";
 
 type RecordedAgentLongFailure = {
@@ -1436,6 +1435,7 @@ export const agentLongTask = task({
             const fallbackModel = getRetryFallbackModel(selectedModel, mode);
             const fallbackModelId =
               trackedProvider.languageModel(fallbackModel).modelId;
+            let activeModelName = selectedModel;
 
             const usageTracker = new UsageTracker();
             observedUsageTracker = usageTracker;
@@ -1459,6 +1459,11 @@ export const agentLongTask = task({
                   selectedModelOverride,
                   responseModel: state.responseModel,
                   configuredModelId,
+                  accountingModel: resolveServedModelForCostAccounting({
+                    modelName: activeModelName,
+                    responseModel: state.responseModel,
+                    mode,
+                  }),
                   rateLimitInfo,
                 };
                 let usageCostRecord =
@@ -1485,6 +1490,7 @@ export const agentLongTask = task({
                     usageTracker.nonModelCost,
                     organizationId,
                     rateLimitInfo,
+                    usageRecordArgs.accountingModel,
                   );
                   const billingBreakdown =
                     deductionResult.includedPointsDeducted > 0 ||
@@ -1506,6 +1512,7 @@ export const agentLongTask = task({
                     selectedModelOverride,
                     responseModel: state.responseModel,
                     configuredModelId,
+                    accountingModel: usageRecordArgs.accountingModel,
                     rateLimitInfo,
                     billingBreakdown,
                   });
@@ -1577,6 +1584,7 @@ export const agentLongTask = task({
             };
 
             const createStream = (modelName: string) => {
+              activeModelName = modelName;
               streamCtx.tools = getToolsForModel(modelName);
               setCurrentModelName(modelName);
               return createAgentStream(modelName, streamCtx, state);


### PR DESCRIPTION
## Summary
- resolve served OpenRouter fallback slugs back to local model keys for cost accounting
- keep the selected model for preflight deduction while using the served model for final token estimates when raw provider cost is absent
- add regression coverage for free Agent fallback estimates and raw provider cost precedence

## Validation
- `corepack pnpm jest lib/__tests__/usage-tracker.test.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts --runInBand`
- `corepack pnpm exec prettier --check lib/usage-tracker.ts lib/rate-limit/token-bucket.ts lib/api/chat-stream-helpers.ts lib/api/chat-handler.ts trigger/agent-long.ts lib/__tests__/usage-tracker.test.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts`
- `corepack pnpm exec eslint lib/usage-tracker.ts lib/rate-limit/token-bucket.ts lib/api/chat-stream-helpers.ts lib/api/chat-handler.ts trigger/agent-long.ts lib/__tests__/usage-tracker.test.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm lint` (passes with existing warnings outside this change)

## Manual verification
- In a paid account, run Agent with Auto/free-Agent routing where OpenRouter serves a Kimi or Grok fallback and omits `usage.raw.cost`.
- Confirm `hackerai-usage_cost`, monthly bucket deduction, and extra-usage deduction use the served fallback model estimate while UI/model display remains Auto.
- Repeat with provider raw cost present and confirm raw cost takes precedence over token estimates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage and billing calculations when requests fall back to alternate models, so charges now better match the model actually served.
  * When provider-reported cost is available, it now takes priority over estimated token-based pricing.
  * Fixed rate-limit deductions to use the served model for pricing when needed, reducing mismatches in point charges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->