### PR TITLE
Triage frontend PostHog error noise

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -783,7 +783,11 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     const isAgentLongDoubleCloseNoise = (message: unknown) =>
       shouldUseAgentLongForCurrentChatRef.current &&
       typeof message === "string" &&
-      message.includes("Cannot close an errored readable stream");
+      (message.includes("Cannot close an errored readable stream") ||
+        message.includes(
+          "ReadableStreamDefaultController is not in a state where it can be closed",
+        ) ||
+        message.includes("Cannot close a stream that is already closed"));
 
     const suppressAgentLongDoubleCloseNoise = (event: ErrorEvent) => {
       if (isAgentLongDoubleCloseNoise(event.message)) {

--- a/app/hooks/__tests__/useChatHandlers.contracts.test.ts
+++ b/app/hooks/__tests__/useChatHandlers.contracts.test.ts
@@ -1,0 +1,26 @@
+import fs from "fs";
+import path from "path";
+
+const useChatHandlersSrc = fs.readFileSync(
+  path.resolve(__dirname, "../useChatHandlers.ts"),
+  "utf8",
+);
+
+describe("useChatHandlers chat action contracts", () => {
+  it("catches rejected chat action promises instead of leaving unhandled rejections", () => {
+    expect(useChatHandlersSrc).toMatch(/const runChatAction = /);
+    expect(useChatHandlersSrc).toMatch(/Promise\.resolve\(action\(\)\)\.catch/);
+
+    for (const description of [
+      "send message",
+      "send fallback message",
+      "regenerate response",
+      "retry response",
+      "regenerate edited message",
+      "continue response",
+      "send queued message",
+    ]) {
+      expect(useChatHandlersSrc).toContain(`runChatAction("${description}"`);
+    }
+  });
+});

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -38,9 +38,12 @@ import { sanitizeForConvexValue } from "@/lib/db/convex-value-sanitizer";
 interface UseChatHandlersProps {
   chatId: string;
   messages: ChatMessage[];
-  sendMessage: (message?: any, options?: { body?: any }) => void;
+  sendMessage: (
+    message?: any,
+    options?: { body?: any },
+  ) => void | Promise<void>;
   stop: () => void;
-  regenerate: (options?: { body?: any }) => void;
+  regenerate: (options?: { body?: any }) => void | Promise<void>;
   setMessages: (
     messages: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[]),
   ) => void;
@@ -115,6 +118,19 @@ export const useChatHandlers = ({
     (file.storage === "local-desktop"
       ? !!file.localAttachmentId && !!file.localPath
       : !!file.fileId);
+
+  const runChatAction = (
+    description: string,
+    action: () => void | Promise<void>,
+  ): void => {
+    try {
+      void Promise.resolve(action()).catch((error) => {
+        console.error(`Failed to ${description}:`, error);
+      });
+    } catch (error) {
+      console.error(`Failed to ${description}:`, error);
+    }
+  };
 
   const deleteLastAssistantMessage = useMutation(
     api.messages.deleteLastAssistantMessage,
@@ -346,38 +362,42 @@ export const useChatHandlers = ({
         .map(createFileMessagePartFromUploadedFile)
         .filter((part): part is NonNullable<typeof part> => part !== null);
 
-      sendMessage(
-        {
-          text: input.trim() || undefined,
-          files: validFiles.length > 0 ? validFiles : undefined,
-          metadata: { createdAt: Date.now() },
-        },
-        {
-          body: {
-            mode: currentChatMode,
-            todos,
-            temporary: temporaryChatsEnabled,
-            sandboxPreference,
-
-            selectedModel: requestSelectedModel,
+      runChatAction("send message", () =>
+        sendMessage(
+          {
+            text: input.trim() || undefined,
+            files: validFiles.length > 0 ? validFiles : undefined,
+            metadata: { createdAt: Date.now() },
           },
-        },
+          {
+            body: {
+              mode: currentChatMode,
+              todos,
+              temporary: temporaryChatsEnabled,
+              sandboxPreference,
+
+              selectedModel: requestSelectedModel,
+            },
+          },
+        ),
       );
     } catch (error) {
       console.error("Failed to process files:", error);
       // Fallback to text-only message if file processing fails
-      sendMessage(
-        { text: input, metadata: { createdAt: Date.now() } },
-        {
-          body: {
-            mode: currentChatMode,
-            todos,
-            temporary: temporaryChatsEnabled,
-            sandboxPreference,
+      runChatAction("send fallback message", () =>
+        sendMessage(
+          { text: input, metadata: { createdAt: Date.now() } },
+          {
+            body: {
+              mode: currentChatMode,
+              todos,
+              temporary: temporaryChatsEnabled,
+              sandboxPreference,
 
-            selectedModel: requestSelectedModel,
+              selectedModel: requestSelectedModel,
+            },
           },
-        },
+        ),
       );
     }
 
@@ -447,30 +467,35 @@ export const useChatHandlers = ({
         });
       }
       // For persisted chats, backend fetches from database - explicitly send no messages
-      regenerate({
-        body: {
-          mode: chatModeRef.current,
-          messages: persistentRegenerateMessages,
-          todos: cleanedTodos,
-          regenerate: true,
-          useClientMessagesForRegenerate: shouldSendClientMessagesForRegenerate,
-          temporary: false,
-          sandboxPreference,
-          selectedModel: requestSelectedModel,
-        },
-      });
+      runChatAction("regenerate response", () =>
+        regenerate({
+          body: {
+            mode: chatModeRef.current,
+            messages: persistentRegenerateMessages,
+            todos: cleanedTodos,
+            regenerate: true,
+            useClientMessagesForRegenerate:
+              shouldSendClientMessagesForRegenerate,
+            temporary: false,
+            sandboxPreference,
+            selectedModel: requestSelectedModel,
+          },
+        }),
+      );
     } else {
-      regenerate({
-        body: {
-          mode: chatModeRef.current,
-          messages: trimmedMessages,
-          todos: cleanedTodos,
-          regenerate: true,
-          temporary: true,
-          sandboxPreference,
-          selectedModel: requestSelectedModel,
-        },
-      });
+      runChatAction("regenerate response", () =>
+        regenerate({
+          body: {
+            mode: chatModeRef.current,
+            messages: trimmedMessages,
+            todos: cleanedTodos,
+            regenerate: true,
+            temporary: true,
+            sandboxPreference,
+            selectedModel: requestSelectedModel,
+          },
+        }),
+      );
     }
   };
 
@@ -503,32 +528,37 @@ export const useChatHandlers = ({
     if (!temporaryChatsEnabled) {
       // For persisted chats, backend fetches from database unless local desktop
       // attachments must be restaged from the client.
-      regenerate({
-        body: {
-          mode: chatModeRef.current,
-          messages: persistentRegenerateMessages,
-          todos: cleanedTodos,
-          regenerate: true,
-          useClientMessagesForRegenerate: shouldSendClientMessagesForRegenerate,
-          temporary: false,
-          sandboxPreference,
-          selectedModel: requestSelectedModel,
-          ...(options.limitRescue && { limitRescue: options.limitRescue }),
-        },
-      });
+      runChatAction("retry response", () =>
+        regenerate({
+          body: {
+            mode: chatModeRef.current,
+            messages: persistentRegenerateMessages,
+            todos: cleanedTodos,
+            regenerate: true,
+            useClientMessagesForRegenerate:
+              shouldSendClientMessagesForRegenerate,
+            temporary: false,
+            sandboxPreference,
+            selectedModel: requestSelectedModel,
+            ...(options.limitRescue && { limitRescue: options.limitRescue }),
+          },
+        }),
+      );
     } else {
-      regenerate({
-        body: {
-          mode: chatModeRef.current,
-          messages: messagesToLastUser,
-          todos: cleanedTodos,
-          regenerate: true,
-          temporary: true,
-          sandboxPreference,
-          selectedModel: requestSelectedModel,
-          ...(options.limitRescue && { limitRescue: options.limitRescue }),
-        },
-      });
+      runChatAction("retry response", () =>
+        regenerate({
+          body: {
+            mode: chatModeRef.current,
+            messages: messagesToLastUser,
+            todos: cleanedTodos,
+            regenerate: true,
+            temporary: true,
+            sandboxPreference,
+            selectedModel: requestSelectedModel,
+            ...(options.limitRescue && { limitRescue: options.limitRescue }),
+          },
+        }),
+      );
     }
   };
 
@@ -633,18 +663,20 @@ export const useChatHandlers = ({
     // For persisted chats, backend fetches from database
     // For temporary chats, send all messages up to and including the edited message
     if (!temporaryChatsEnabled) {
-      regenerate({
-        body: {
-          mode: chatModeRef.current,
-          messages: [],
-          todos: cleanedTodosForEdit,
-          regenerate: true,
-          temporary: false,
-          sandboxPreference,
+      runChatAction("regenerate edited message", () =>
+        regenerate({
+          body: {
+            mode: chatModeRef.current,
+            messages: [],
+            todos: cleanedTodosForEdit,
+            regenerate: true,
+            temporary: false,
+            sandboxPreference,
 
-          selectedModel: requestSelectedModel,
-        },
-      });
+            selectedModel: requestSelectedModel,
+          },
+        }),
+      );
     } else {
       // For temporary chats, send messages up to and including the edited message
       const messagesUpToEdit = messages.slice(0, editedMessageIndex + 1);
@@ -670,18 +702,20 @@ export const useChatHandlers = ({
         parts: updatedParts,
       };
 
-      regenerate({
-        body: {
-          mode: chatModeRef.current,
-          messages: messagesUpToEdit,
-          todos: cleanedTodosForEdit,
-          regenerate: true,
-          temporary: true,
-          sandboxPreference,
+      runChatAction("regenerate edited message", () =>
+        regenerate({
+          body: {
+            mode: chatModeRef.current,
+            messages: messagesUpToEdit,
+            todos: cleanedTodosForEdit,
+            regenerate: true,
+            temporary: true,
+            sandboxPreference,
 
-          selectedModel: requestSelectedModel,
-        },
-      });
+            selectedModel: requestSelectedModel,
+          },
+        }),
+      );
     }
   };
 
@@ -690,21 +724,23 @@ export const useChatHandlers = ({
     hasManuallyStoppedRef.current = false;
     const continuationSelectedModel =
       selectedModelOverride ?? requestSelectedModel;
-    sendMessage(
-      {
-        text: AUTO_CONTINUE_PROMPT,
-        metadata: { isAutoContinue: true },
-      },
-      {
-        body: {
-          mode: chatModeRef.current,
-          isAutoContinue: true,
-          todos,
-          temporary: temporaryChatsEnabled,
-          sandboxPreference,
-          selectedModel: continuationSelectedModel,
+    runChatAction("continue response", () =>
+      sendMessage(
+        {
+          text: AUTO_CONTINUE_PROMPT,
+          metadata: { isAutoContinue: true },
         },
-      },
+        {
+          body: {
+            mode: chatModeRef.current,
+            isAutoContinue: true,
+            todos,
+            temporary: temporaryChatsEnabled,
+            sandboxPreference,
+            selectedModel: continuationSelectedModel,
+          },
+        },
+      ),
     );
   };
 
@@ -742,16 +778,18 @@ export const useChatHandlers = ({
 
       messagePayload.metadata = { createdAt: message.timestamp };
 
-      sendMessage(messagePayload, {
-        body: {
-          mode: chatModeRef.current,
-          todos,
-          temporary: temporaryChatsEnabled,
-          sandboxPreference,
+      runChatAction("send queued message", () =>
+        sendMessage(messagePayload, {
+          body: {
+            mode: chatModeRef.current,
+            todos,
+            temporary: temporaryChatsEnabled,
+            sandboxPreference,
 
-          selectedModel: requestSelectedModel,
-        },
-      });
+            selectedModel: requestSelectedModel,
+          },
+        }),
+      );
     } catch (error) {
       console.error("Failed to send queued message:", error);
     } finally {

--- a/lib/__tests__/errors.test.ts
+++ b/lib/__tests__/errors.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "@jest/globals";
+import { ChatSDKError, isNetworkStreamError } from "../errors";
+
+describe("isNetworkStreamError", () => {
+  it("classifies common browser stream transport failures as reconnectable", () => {
+    for (const message of [
+      "Failed to fetch",
+      "Load failed",
+      "NetworkError when attempting to fetch resource.",
+      "connection closed",
+      "Error in input stream",
+    ]) {
+      expect(isNetworkStreamError(new Error(message))).toBe(true);
+    }
+  });
+
+  it("does not classify user aborts as reconnectable", () => {
+    expect(
+      isNetworkStreamError(new DOMException("Aborted", "AbortError")),
+    ).toBe(false);
+  });
+
+  it("uses ChatSDKError offline type for SDK errors", () => {
+    expect(isNetworkStreamError(new ChatSDKError("offline:stream"))).toBe(true);
+    expect(isNetworkStreamError(new ChatSDKError("bad_request:stream"))).toBe(
+      false,
+    );
+  });
+});

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -266,6 +266,12 @@ describe("agent-long chat UI — completion reconciliation", () => {
       /shouldUseAgentLongForCurrentChatRef\.current/,
     );
     expect(chatComponentSrc).toMatch(/Cannot close an errored readable stream/);
+    expect(chatComponentSrc).toMatch(
+      /ReadableStreamDefaultController is not in a state where it can be closed/,
+    );
+    expect(chatComponentSrc).toMatch(
+      /Cannot close a stream that is already closed/,
+    );
     expect(chatComponentSrc).toMatch(/event\.preventDefault\(\)/);
   });
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -138,6 +138,8 @@ export function isNetworkStreamError(error: unknown): boolean {
     msg.includes("failed to fetch") ||
     msg.includes("fetch failed") ||
     msg.includes("network") ||
+    msg.includes("connection closed") ||
+    msg.includes("error in input stream") ||
     msg.includes("load failed")
   );
 }

--- a/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
+++ b/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
@@ -220,6 +220,7 @@ describe("shouldDropExpectedFrontendException", () => {
   it("drops Trigger stream double-close noise only with Trigger stream frames", () => {
     for (const value of [
       "Failed to execute 'close' on 'ReadableStreamDefaultController': Cannot close an errored readable stream",
+      "Failed to execute 'close' on 'ReadableStreamDefaultController': ReadableStreamDefaultController is not in a state where it can be closed",
       "ReadableStreamDefaultController is not in a state where it can be closed",
       "ReadableStreamDefaultController.close: Cannot close a stream that is already closed.",
     ]) {

--- a/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
+++ b/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
@@ -216,4 +216,42 @@ describe("shouldDropExpectedFrontendException", () => {
       }),
     ).toBe(false);
   });
+
+  it("drops Trigger stream double-close noise only with Trigger stream frames", () => {
+    for (const value of [
+      "Failed to execute 'close' on 'ReadableStreamDefaultController': Cannot close an errored readable stream",
+      "ReadableStreamDefaultController is not in a state where it can be closed",
+      "ReadableStreamDefaultController.close: Cannot close a stream that is already closed.",
+    ]) {
+      expect(
+        shouldDropExpectedFrontendException({
+          event: "$exception",
+          properties: {
+            $exception_values: [value],
+            $exception_list: [
+              {
+                stacktrace: {
+                  frames: [
+                    {
+                      source:
+                        "turbopack:///[project]/node_modules/.pnpm/@trigger.dev+core@4.4.6/node_modules/@trigger.dev/core/src/v3/streams/asyncIterableStream.ts",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        }),
+      ).toBe(true);
+
+      expect(
+        shouldDropExpectedFrontendException({
+          event: "$exception",
+          properties: {
+            $exception_values: [value],
+          },
+        }),
+      ).toBe(false);
+    }
+  });
 });

--- a/lib/posthog/expected-frontend-exceptions.ts
+++ b/lib/posthog/expected-frontend-exceptions.ts
@@ -10,11 +10,11 @@ const RESIZE_OBSERVER_MESSAGES = new Set([
   "ResizeObserver loop limit exceeded",
 ]);
 
-const TRIGGER_STREAM_CLOSE_MESSAGES = new Set([
+const TRIGGER_STREAM_CLOSE_MESSAGE_FRAGMENTS = [
   "Failed to execute 'close' on 'ReadableStreamDefaultController': Cannot close an errored readable stream",
   "ReadableStreamDefaultController is not in a state where it can be closed",
   "ReadableStreamDefaultController.close: Cannot close a stream that is already closed.",
-]);
+];
 
 const collectStrings = (value: unknown, strings: string[] = []): string[] => {
   if (typeof value === "string") {
@@ -50,7 +50,7 @@ const hasResizeObserverMessage = (strings: string[]): boolean =>
   strings.some((value) => RESIZE_OBSERVER_MESSAGES.has(value));
 
 const hasTriggerStreamCloseMessage = (strings: string[]): boolean =>
-  strings.some((value) => TRIGGER_STREAM_CLOSE_MESSAGES.has(value));
+  includesAny(strings, TRIGGER_STREAM_CLOSE_MESSAGE_FRAGMENTS);
 
 type ExpectedFrontendPattern = {
   message: string;

--- a/lib/posthog/expected-frontend-exceptions.ts
+++ b/lib/posthog/expected-frontend-exceptions.ts
@@ -10,6 +10,12 @@ const RESIZE_OBSERVER_MESSAGES = new Set([
   "ResizeObserver loop limit exceeded",
 ]);
 
+const TRIGGER_STREAM_CLOSE_MESSAGES = new Set([
+  "Failed to execute 'close' on 'ReadableStreamDefaultController': Cannot close an errored readable stream",
+  "ReadableStreamDefaultController is not in a state where it can be closed",
+  "ReadableStreamDefaultController.close: Cannot close a stream that is already closed.",
+]);
+
 const collectStrings = (value: unknown, strings: string[] = []): string[] => {
   if (typeof value === "string") {
     strings.push(value);
@@ -42,6 +48,9 @@ const hasExactString = (strings: string[], expected: string): boolean =>
 
 const hasResizeObserverMessage = (strings: string[]): boolean =>
   strings.some((value) => RESIZE_OBSERVER_MESSAGES.has(value));
+
+const hasTriggerStreamCloseMessage = (strings: string[]): boolean =>
+  strings.some((value) => TRIGGER_STREAM_CLOSE_MESSAGES.has(value));
 
 type ExpectedFrontendPattern = {
   message: string;
@@ -79,6 +88,13 @@ const matchesExpectedFrontendPattern = (strings: string[]): boolean =>
       hasExactString(strings, message) && includesAny(strings, sourceFragments),
   );
 
+const matchesTriggerStreamClosePattern = (strings: string[]): boolean =>
+  hasTriggerStreamCloseMessage(strings) &&
+  includesAny(strings, [
+    "@trigger.dev/core/src/v3/streams/asyncIterableStream.ts",
+    "@trigger.dev+core",
+  ]);
+
 export function shouldDropExpectedFrontendException(event: PostHogEventLike) {
   if (event.event !== "$exception") {
     return false;
@@ -91,6 +107,8 @@ export function shouldDropExpectedFrontendException(event: PostHogEventLike) {
   const strings = collectStrings(event.properties);
 
   return (
-    hasResizeObserverMessage(strings) || matchesExpectedFrontendPattern(strings)
+    hasResizeObserverMessage(strings) ||
+    matchesExpectedFrontendPattern(strings) ||
+    matchesTriggerStreamClosePattern(strings)
   );
 }


### PR DESCRIPTION
## Summary
- catch chat send/regenerate promise rejections so handled UI transport failures do not become unhandled frontend exceptions
- narrowly suppress Trigger.dev ReadableStream double-close browser noise only when Trigger stream frames are present
- classify connection-closed/input-stream browser transport errors as reconnectable stream failures
- keep generic network, chunk-load, server-action, React/DOM, Convex websocket, and stackless rejection groups visible for source-specific follow-up

## Live PostHog triage
- Suppress/stop frontend logging: Trigger stream `ReadableStreamDefaultController` close variants with `@trigger.dev/core` stream frames.
- Fix in app: rejected chat action promises from `sendMessage` / `regenerate` command paths.
- Keep visible for now: generic `Failed to fetch`, `NetworkError`, `Load failed`, chunk-load failures, Next server-action unexpected responses, React #185/#310, DOM mutation errors, Convex websocket JSON parse, and stackless undefined rejections.

## Validation
- `/Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules/.bin/prettier --write app/components/chat.tsx app/hooks/useChatHandlers.ts lib/errors.ts lib/posthog/expected-frontend-exceptions.ts lib/posthog/__tests__/expected-frontend-exceptions.test.ts lib/__tests__/errors.test.ts app/hooks/__tests__/useChatHandlers.contracts.test.ts lib/api/__tests__/agent-long-contracts.test.ts`
- `env NODE_PATH=/Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules /Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules/.bin/jest lib/posthog/__tests__/expected-frontend-exceptions.test.ts lib/__tests__/errors.test.ts app/hooks/__tests__/useChatHandlers.contracts.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `./node_modules/.bin/eslint app/components/chat.tsx app/hooks/useChatHandlers.ts lib/errors.ts lib/posthog/expected-frontend-exceptions.ts lib/posthog/__tests__/expected-frontend-exceptions.test.ts lib/__tests__/errors.test.ts app/hooks/__tests__/useChatHandlers.contracts.test.ts lib/api/__tests__/agent-long-contracts.test.ts` (passes with existing warnings in `app/components/chat.tsx`)
- `./node_modules/.bin/tsc --noEmit --pretty false` (fails: existing `packages/local/src/index.ts(17,23): Cannot find module 'ws' or its corresponding type declarations.`)

## Manual verification
- Start an Agent run, navigate away/stop/resume while Trigger.dev UI stream subscriptions are active, and confirm known double-close errors no longer appear in PostHog.
- Force a browser network drop during chat streaming and confirm the message error state offers reconnect/retry instead of creating an unhandled frontend exception.
- Watch PostHog after deploy to confirm remaining generic network/chunk/React/DOM groups stay visible for follow-up triage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced noisy browser error reporting by expanding suppression for known stream-closure and “double close” issues.
  - Improved handling of chat actions so failed actions are caught and logged instead of surfacing as unhandled errors.
  - Broadened detection of network/stream failures to better recognize reconnectable errors.

- **Tests**
  - Added coverage for the new error-suppression and stream-failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->