### PR TITLE
Show scheduled subscription cancellation in settings

### DIFF
--- a/app/components/AccountTab.tsx
+++ b/app/components/AccountTab.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { usePentestgptMigration } from "@/app/hooks/usePentestgptMigration";
-import { X, ChevronDown, Sparkle } from "lucide-react";
+import { CalendarClock, X, ChevronDown, Loader2, Sparkle } from "lucide-react";
 import {
   proFeatures,
   proPlusFeatures,
@@ -23,12 +23,32 @@ import {
 import DeleteAccountDialog from "./DeleteAccountDialog";
 import CancelSubscriptionDialog from "./CancelSubscriptionDialog";
 import redirectToBillingPortalAction from "@/lib/actions/billing-portal";
+import getSubscriptionCancellationStatusAction, {
+  type SubscriptionCancellationStatus,
+} from "@/lib/actions/subscription-status";
+import type { SubscriptionTier } from "@/types";
+
+type AccountCancellationStatus = SubscriptionCancellationStatus & {
+  subscription: SubscriptionTier;
+};
+
+function formatCancellationDate(currentPeriodEnd?: number) {
+  if (!currentPeriodEnd) return null;
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(currentPeriodEnd));
+}
 
 const AccountTab = () => {
   const { subscription, setMigrateFromPentestgptDialogOpen } = useGlobalState();
   const [showDeleteAccount, setShowDeleteAccount] = useState(false);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [isTeamAdmin, setIsTeamAdmin] = useState<boolean | null>(null);
+  const [cancellationStatus, setCancellationStatus] =
+    useState<AccountCancellationStatus | null>(null);
   const { isMigrating } = usePentestgptMigration();
 
   // Fetch admin status for team subscriptions
@@ -55,6 +75,42 @@ const AccountTab = () => {
       : subscription === "pro-plus"
         ? proPlusFeatures
         : proFeatures;
+  const hasCurrentCancellationStatus =
+    canManageBilling && cancellationStatus?.subscription === subscription;
+  const currentCancellationStatus = hasCurrentCancellationStatus
+    ? cancellationStatus
+    : null;
+  const cancellationEndDate = formatCancellationDate(
+    currentCancellationStatus?.currentPeriodEnd,
+  );
+  const cancellationScheduled =
+    currentCancellationStatus?.cancelAtPeriodEnd === true;
+  const isCheckingCancellationStatus =
+    canManageBilling && !hasCurrentCancellationStatus;
+
+  useEffect(() => {
+    if (!canManageBilling || hasCurrentCancellationStatus) return;
+
+    let ignore = false;
+
+    getSubscriptionCancellationStatusAction()
+      .then((status) => {
+        if (!ignore) setCancellationStatus({ ...status, subscription });
+      })
+      .catch(() => {
+        if (!ignore) {
+          setCancellationStatus({
+            subscription,
+            hasActiveSubscription: false,
+            cancelAtPeriodEnd: false,
+          });
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [canManageBilling, hasCurrentCancellationStatus, subscription]);
 
   const redirectToBillingPortal = async () => {
     try {
@@ -125,13 +181,25 @@ const AccountTab = () => {
                       <DropdownMenuSeparator />
                     </>
                   )}
-                  <DropdownMenuItem
-                    variant="destructive"
-                    onClick={handleCancelSubscription}
-                  >
-                    <X className="h-4 w-4" />
-                    <span>Cancel subscription</span>
-                  </DropdownMenuItem>
+                  {cancellationScheduled ? (
+                    <DropdownMenuItem disabled>
+                      <CalendarClock className="h-4 w-4" />
+                      <span>Cancellation scheduled</span>
+                    </DropdownMenuItem>
+                  ) : isCheckingCancellationStatus ? (
+                    <DropdownMenuItem disabled>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <span>Checking subscription</span>
+                    </DropdownMenuItem>
+                  ) : (
+                    <DropdownMenuItem
+                      variant="destructive"
+                      onClick={handleCancelSubscription}
+                    >
+                      <X className="h-4 w-4" />
+                      <span>Cancel subscription</span>
+                    </DropdownMenuItem>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : null
@@ -153,6 +221,17 @@ const AccountTab = () => {
             </Button>
           )}
         </div>
+
+        {cancellationScheduled && (
+          <div className="mt-3 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">
+              Cancellation scheduled.
+            </span>{" "}
+            {cancellationEndDate
+              ? `Your plan stays active until ${cancellationEndDate}.`
+              : "Your plan stays active until the end of the current billing period."}
+          </div>
+        )}
 
         <div className="mt-2 rounded-lg bg-transparent px-0">
           <span className="text-sm font-semibold inline-block pb-4">

--- a/app/components/AccountTab.tsx
+++ b/app/components/AccountTab.tsx
@@ -83,6 +83,8 @@ const AccountTab = () => {
   const cancellationEndDate = formatCancellationDate(
     currentCancellationStatus?.currentPeriodEnd,
   );
+  const noActiveSubscription =
+    currentCancellationStatus?.hasActiveSubscription === false;
   const cancellationScheduled =
     currentCancellationStatus?.cancelAtPeriodEnd === true;
   const isCheckingCancellationStatus =
@@ -97,8 +99,12 @@ const AccountTab = () => {
       .then((status) => {
         if (!ignore) setCancellationStatus({ ...status, subscription });
       })
-      .catch(() => {
+      .catch((error) => {
         if (!ignore) {
+          console.warn(
+            "Failed to load subscription cancellation status",
+            error,
+          );
           setCancellationStatus({
             subscription,
             hasActiveSubscription: false,
@@ -185,6 +191,11 @@ const AccountTab = () => {
                     <DropdownMenuItem disabled>
                       <CalendarClock className="h-4 w-4" />
                       <span>Cancellation scheduled</span>
+                    </DropdownMenuItem>
+                  ) : noActiveSubscription ? (
+                    <DropdownMenuItem disabled>
+                      <CalendarClock className="h-4 w-4" />
+                      <span>No active subscription</span>
                     </DropdownMenuItem>
                   ) : isCheckingCancellationStatus ? (
                     <DropdownMenuItem disabled>

--- a/app/components/__tests__/AccountTab.test.tsx
+++ b/app/components/__tests__/AccountTab.test.tsx
@@ -1,0 +1,95 @@
+import "@testing-library/jest-dom";
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockGetSubscriptionCancellationStatus = jest.fn();
+const mockSetMigrateFromPentestgptDialogOpen = jest.fn();
+
+jest.mock("@/app/contexts/GlobalState", () => ({
+  useGlobalState: () => ({
+    subscription: "pro",
+    setMigrateFromPentestgptDialogOpen: mockSetMigrateFromPentestgptDialogOpen,
+  }),
+}));
+
+jest.mock("@/app/hooks/usePentestgptMigration", () => ({
+  usePentestgptMigration: () => ({ isMigrating: false }),
+}));
+
+jest.mock("@/app/hooks/usePricingDialog", () => ({
+  redirectToPricing: jest.fn(),
+}));
+
+jest.mock("@/lib/actions/billing-portal", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("@/lib/actions/subscription-status", () => ({
+  __esModule: true,
+  default: mockGetSubscriptionCancellationStatus,
+}));
+
+jest.mock("../DeleteAccountDialog", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("../CancelSubscriptionDialog", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const AccountTab = require("../AccountTab")
+  .AccountTab as typeof import("../AccountTab").AccountTab;
+
+describe("AccountTab", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows scheduled cancellation state instead of the cancel action", async () => {
+    mockGetSubscriptionCancellationStatus.mockResolvedValue({
+      hasActiveSubscription: true,
+      cancelAtPeriodEnd: true,
+      currentPeriodEnd: Date.UTC(2026, 6, 31, 12),
+    } as never);
+
+    render(<AccountTab />);
+
+    expect(await screen.findByText("Cancellation scheduled.")).toBeVisible();
+    expect(
+      screen.getByText("Your plan stays active until July 31, 2026."),
+    ).toBeVisible();
+
+    const user = userEvent.setup();
+    await user.click(screen.getAllByRole("button", { name: /manage/i })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Cancellation scheduled")).toBeVisible();
+    });
+    expect(screen.queryByText("Cancel subscription")).not.toBeInTheDocument();
+  });
+
+  it("keeps the cancel action when cancellation is not scheduled", async () => {
+    mockGetSubscriptionCancellationStatus.mockResolvedValue({
+      hasActiveSubscription: true,
+      cancelAtPeriodEnd: false,
+    } as never);
+
+    render(<AccountTab />);
+
+    await waitFor(() => {
+      expect(mockGetSubscriptionCancellationStatus).toHaveBeenCalledTimes(1);
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getAllByRole("button", { name: /manage/i })[0]);
+
+    expect(screen.getByText("Cancel subscription")).toBeVisible();
+    expect(
+      screen.queryByText("Cancellation scheduled."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/components/__tests__/AccountTab.test.tsx
+++ b/app/components/__tests__/AccountTab.test.tsx
@@ -50,17 +50,24 @@ describe("AccountTab", () => {
   });
 
   it("shows scheduled cancellation state instead of the cancel action", async () => {
+    const currentPeriodEnd = Date.UTC(2026, 6, 31, 12);
+    const expectedPeriodEnd = new Intl.DateTimeFormat(undefined, {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    }).format(new Date(currentPeriodEnd));
+
     mockGetSubscriptionCancellationStatus.mockResolvedValue({
       hasActiveSubscription: true,
       cancelAtPeriodEnd: true,
-      currentPeriodEnd: Date.UTC(2026, 6, 31, 12),
+      currentPeriodEnd,
     } as never);
 
     render(<AccountTab />);
 
     expect(await screen.findByText("Cancellation scheduled.")).toBeVisible();
     expect(
-      screen.getByText("Your plan stays active until July 31, 2026."),
+      screen.getByText(`Your plan stays active until ${expectedPeriodEnd}.`),
     ).toBeVisible();
 
     const user = userEvent.setup();
@@ -91,5 +98,24 @@ describe("AccountTab", () => {
     expect(
       screen.queryByText("Cancellation scheduled."),
     ).not.toBeInTheDocument();
+  });
+
+  it("does not offer cancellation when no active subscription is found", async () => {
+    mockGetSubscriptionCancellationStatus.mockResolvedValue({
+      hasActiveSubscription: false,
+      cancelAtPeriodEnd: false,
+    } as never);
+
+    render(<AccountTab />);
+
+    await waitFor(() => {
+      expect(mockGetSubscriptionCancellationStatus).toHaveBeenCalledTimes(1);
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getAllByRole("button", { name: /manage/i })[0]);
+
+    expect(screen.getByText("No active subscription")).toBeVisible();
+    expect(screen.queryByText("Cancel subscription")).not.toBeInTheDocument();
   });
 });

--- a/lib/actions/__tests__/subscription-status.test.ts
+++ b/lib/actions/__tests__/subscription-status.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+
+const mockListSubscriptions = jest.fn();
+const mockGetBillingActionContext = jest.fn();
+
+jest.mock("@/app/api/stripe", () => ({
+  stripe: {
+    subscriptions: {
+      list: mockListSubscriptions,
+    },
+  },
+}));
+
+jest.mock("@/lib/actions/billing-context", () => ({
+  getBillingActionContext: mockGetBillingActionContext,
+}));
+
+describe("getSubscriptionCancellationStatusAction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetBillingActionContext.mockResolvedValue({
+      stripeCustomerId: "cus_123",
+    } as never);
+  });
+
+  it("returns scheduled cancellation status for active subscriptions", async () => {
+    mockListSubscriptions.mockResolvedValue({
+      data: [
+        {
+          id: "sub_123",
+          status: "active",
+          cancel_at_period_end: true,
+          current_period_end: 1_782_444_800,
+        },
+      ],
+    } as never);
+
+    const { default: getSubscriptionCancellationStatusAction } =
+      await import("../subscription-status");
+
+    await expect(getSubscriptionCancellationStatusAction()).resolves.toEqual({
+      hasActiveSubscription: true,
+      cancelAtPeriodEnd: true,
+      currentPeriodEnd: 1_782_444_800_000,
+    });
+    expect(mockListSubscriptions).toHaveBeenCalledWith({
+      customer: "cus_123",
+      status: "all",
+      limit: 10,
+    });
+  });
+
+  it("returns an inactive status when Stripe has no current subscription", async () => {
+    mockListSubscriptions.mockResolvedValue({
+      data: [
+        {
+          id: "sub_canceled",
+          status: "canceled",
+          cancel_at_period_end: false,
+        },
+      ],
+    } as never);
+
+    const { default: getSubscriptionCancellationStatusAction } =
+      await import("../subscription-status");
+
+    await expect(getSubscriptionCancellationStatusAction()).resolves.toEqual({
+      hasActiveSubscription: false,
+      cancelAtPeriodEnd: false,
+    });
+  });
+});

--- a/lib/actions/subscription-status.ts
+++ b/lib/actions/subscription-status.ts
@@ -1,0 +1,45 @@
+"use server";
+
+import { stripe } from "../../app/api/stripe";
+import { getBillingActionContext } from "@/lib/actions/billing-context";
+
+export type SubscriptionCancellationStatus = {
+  hasActiveSubscription: boolean;
+  cancelAtPeriodEnd: boolean;
+  currentPeriodEnd?: number;
+};
+
+function currentPeriodEndMs(subscription: unknown): number | undefined {
+  const currentPeriodEnd = (subscription as { current_period_end?: unknown })
+    .current_period_end;
+  return typeof currentPeriodEnd === "number" &&
+    Number.isFinite(currentPeriodEnd) &&
+    currentPeriodEnd > 0
+    ? currentPeriodEnd * 1000
+    : undefined;
+}
+
+export default async function getSubscriptionCancellationStatusAction(): Promise<SubscriptionCancellationStatus> {
+  const { stripeCustomerId } = await getBillingActionContext();
+  const subscriptions = await stripe.subscriptions.list({
+    customer: stripeCustomerId,
+    status: "all",
+    limit: 10,
+  });
+  const currentSubscription = subscriptions.data.find((subscription) =>
+    ["active", "trialing", "past_due", "unpaid"].includes(subscription.status),
+  );
+
+  if (!currentSubscription) {
+    return {
+      hasActiveSubscription: false,
+      cancelAtPeriodEnd: false,
+    };
+  }
+
+  return {
+    hasActiveSubscription: true,
+    cancelAtPeriodEnd: currentSubscription.cancel_at_period_end === true,
+    currentPeriodEnd: currentPeriodEndMs(currentSubscription),
+  };
+}


### PR DESCRIPTION
## Summary
- add a billing-status server action for the current Stripe subscription cancellation state
- show a scheduled-cancellation notice in Account settings when `cancel_at_period_end` is true
- replace the duplicate destructive cancel menu item with disabled status items for `Cancellation scheduled`, `Checking subscription`, and `No active subscription` states while keeping billing management available
- cover scheduled, unscheduled, and missing-active-subscription states with focused tests

## Testing
- `./node_modules/.bin/jest app/components/__tests__/AccountTab.test.tsx lib/actions/__tests__/subscription-status.test.ts --runInBand`
- `./node_modules/.bin/prettier --check app/components/AccountTab.tsx app/components/__tests__/AccountTab.test.tsx lib/actions/subscription-status.ts lib/actions/__tests__/subscription-status.test.ts`
- `./node_modules/.bin/eslint app/components/AccountTab.tsx app/components/__tests__/AccountTab.test.tsx lib/actions/subscription-status.ts lib/actions/__tests__/subscription-status.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- pre-commit hook after final commit: `tsc --noEmit` and full `jest` (188 suites / 1906 tests)
- GitHub checks: `test (20.x)`, Trigger.dev preview deployment, Vercel, Vercel Preview Comments, and CodeRabbit all passed

## Manual verification
- In Account settings for a paid user whose Stripe subscription has `cancel_at_period_end=true`, open the Manage menu.
- Confirm the settings panel says `Cancellation scheduled` with the period-end date when available.
- Confirm the Manage menu no longer offers `Cancel subscription` and instead shows disabled `Cancellation scheduled`.
- Confirm a stale/local paid tier with no active Stripe subscription does not expose `Cancel subscription` and shows disabled `No active subscription`.
- Confirm the Payment `Manage` button still opens the billing portal.