### PR TITLE
Guard selected-local sandbox fallback across tools

### DIFF
--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -25,7 +25,10 @@ import { ChatSDKError } from "@/lib/errors";
 import type { Todo, SandboxPreference, SelectedModel } from "@/types";
 import { resolveAgentRunSpendCapContinuationModel } from "@/lib/chat/agent-run-spend-cap";
 import { HybridSandboxManager } from "@/lib/ai/tools/utils/hybrid-sandbox-manager";
-import { assertLocalSandboxFallbackAllowed } from "@/lib/ai/tools/utils/sandbox-fallback";
+import {
+  assertLocalSandboxFallbackAllowed,
+  getSandboxWithFallbackGuard,
+} from "@/lib/ai/tools/utils/sandbox-fallback";
 import {
   getUploadBasePath,
   hasLocalDesktopSourcePaths,
@@ -159,7 +162,10 @@ export async function POST(req: NextRequest) {
         let uploadResult: Awaited<ReturnType<typeof uploadSandboxFiles>>;
         try {
           uploadResult = await uploadSandboxFiles(sandboxFiles, async () => {
-            const { sandbox } = await sandboxManager.getSandbox();
+            const { sandbox } = await getSandboxWithFallbackGuard({
+              sandboxManager,
+              requireLocalSandbox: true,
+            });
             stagedSandbox = sandbox;
             return sandbox;
           });

--- a/lib/ai/tools/__tests__/file.test.ts
+++ b/lib/ai/tools/__tests__/file.test.ts
@@ -115,6 +115,52 @@ function makeSandbox(
 }
 
 describe("file tool large text safety", () => {
+  test("blocks file operations when a selected local sandbox falls back", async () => {
+    const commandRun = jest.fn(async () => ({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    }));
+    const sandbox = makeSandbox(commandRun);
+    const writerWrites: unknown[] = [];
+    const context = makeContext(sandbox, {
+      sandboxManager: {
+        getSandbox: jest.fn(async () => ({ sandbox })),
+        setSandbox: jest.fn(),
+        getSandboxType: jest.fn(),
+        getSandboxInfo: jest.fn(() => null),
+        getEffectivePreference: jest.fn(() => "e2b"),
+        recordHealthFailure: jest.fn(() => false),
+        resetHealthFailures: jest.fn(),
+        isSandboxUnavailable: jest.fn(() => false),
+        consumeFallbackInfo: jest.fn(() => ({
+          occurred: true,
+          reason: "no_local_connections",
+          requestedPreference: "desktop",
+          actualSandbox: "e2b",
+          actualSandboxName: "Cloud",
+        })),
+      } as never,
+      writer: {
+        write: (part: unknown) => writerWrites.push(part),
+      } as never,
+    });
+    const tool = createFile(context);
+
+    const result = (await runTool(tool, {
+      action: "read",
+      path: "/home/user/report.txt",
+      brief: "Read file",
+    })) as { error: string };
+
+    expect(result.error).toContain("HackerAI did not switch this run to Cloud");
+    expect(sandbox.files.read).not.toHaveBeenCalled();
+    expect(commandRun).not.toHaveBeenCalled();
+    expect(writerWrites).not.toContainEqual(
+      expect.objectContaining({ type: "data-sandbox-fallback" }),
+    );
+  });
+
   test("does not load oversized files for full reads", async () => {
     const commandRun = jest.fn(async () => ({
       stdout: JSON.stringify({

--- a/lib/ai/tools/__tests__/get-terminal-files.test.ts
+++ b/lib/ai/tools/__tests__/get-terminal-files.test.ts
@@ -70,6 +70,54 @@ describe("get_terminal_files", () => {
     jest.clearAllMocks();
   });
 
+  it("blocks file delivery when a selected local sandbox falls back", async () => {
+    const writerWrites: unknown[] = [];
+    const context = makeContext({
+      sandboxManager: {
+        getSandbox: jest.fn(async () => ({ sandbox: { id: "cloud" } })),
+        setSandbox: jest.fn(),
+        getSandboxType: jest.fn(),
+        getSandboxInfo: jest.fn(() => null),
+        getEffectivePreference: jest.fn(() => "e2b"),
+        recordHealthFailure: jest.fn(() => false),
+        resetHealthFailures: jest.fn(),
+        isSandboxUnavailable: jest.fn(() => false),
+        consumeFallbackInfo: jest.fn(() => ({
+          occurred: true,
+          reason: "no_local_connections",
+          requestedPreference: "desktop",
+          actualSandbox: "e2b",
+          actualSandboxName: "Cloud",
+        })),
+      } as never,
+      writer: {
+        write: (part: unknown) => writerWrites.push(part),
+      } as never,
+    });
+    const tool = createGetTerminalFiles(context);
+
+    const result = (await runTool(tool, {
+      brief: "Deliver report",
+      files: ["/home/user/report.txt"],
+    })) as {
+      result: string;
+      files: Array<{ path: string }>;
+      failedFiles: Array<{ path: string; reason: string }>;
+    };
+
+    expect(mockUploadSandboxFileToConvex).not.toHaveBeenCalled();
+    expect(result.files).toEqual([]);
+    expect(result.failedFiles[0]?.reason).toContain(
+      "HackerAI did not switch this run to Cloud",
+    );
+    expect(result.result).toContain(
+      "HackerAI did not switch this run to Cloud",
+    );
+    expect(writerWrites).not.toContainEqual(
+      expect.objectContaining({ type: "data-sandbox-fallback" }),
+    );
+  });
+
   it("reports partial upload failures without claiming every file was sent", async () => {
     mockUploadSandboxFileToConvex
       .mockResolvedValueOnce({

--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -419,14 +419,12 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
 
     expect(e2b.commands.run).not.toHaveBeenCalled();
     expect(result.result.exitCode).toBe(1);
-    expect(result.result.error).toContain("request couldn't be processed");
-    expect(writerWrites).toContainEqual(
+    expect(result.result.error).toContain(
+      "HackerAI did not switch this run to Cloud",
+    );
+    expect(writerWrites).not.toContainEqual(
       expect.objectContaining({
         type: "data-sandbox-fallback",
-        data: expect.objectContaining({
-          actualSandbox: "e2b",
-          requestedPreference: "desktop",
-        }),
       }),
     );
   });
@@ -456,14 +454,12 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
 
     expect(mockCreateE2BPtyHandle).not.toHaveBeenCalled();
     expect(result.result.exitCode).toBe(1);
-    expect(result.result.error).toContain("request couldn't be processed");
-    expect(writerWrites).toContainEqual(
+    expect(result.result.error).toContain(
+      "commands would run on the wrong host",
+    );
+    expect(writerWrites).not.toContainEqual(
       expect.objectContaining({
         type: "data-sandbox-fallback",
-        data: expect.objectContaining({
-          actualSandbox: "other-local",
-          requestedPreference: "desktop",
-        }),
       }),
     );
   });

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -13,8 +13,8 @@ import { phLogger } from "@/lib/posthog/server";
 import { validateImageBytes } from "@/lib/utils/image-validation";
 import { toolBriefSchema } from "./tool-brief";
 import {
-  getSandboxFallbackErrorMessage,
   getSandboxWithFallbackGuard,
+  resolveToolErrorMessage,
 } from "./utils/sandbox-fallback";
 
 const MAX_VIEW_FILE_BYTES = 10 * 1024 * 1024;
@@ -1460,9 +1460,7 @@ ${instructionsDescription}`,
         }
       } catch (error) {
         return {
-          error:
-            getSandboxFallbackErrorMessage(error) ??
-            (error instanceof Error ? error.message : String(error)),
+          error: resolveToolErrorMessage(error),
         };
       }
     },
@@ -1558,10 +1556,7 @@ ${instructionsDescription}`,
             }
             return {
               type: "text" as const,
-              value: `Error: ${
-                getSandboxFallbackErrorMessage(error) ??
-                (error instanceof Error ? error.message : String(error))
-              }`,
+              value: `Error: ${resolveToolErrorMessage(error)}`,
             };
           }
         }

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -12,6 +12,10 @@ import { logger } from "@/lib/logger";
 import { phLogger } from "@/lib/posthog/server";
 import { validateImageBytes } from "@/lib/utils/image-validation";
 import { toolBriefSchema } from "./tool-brief";
+import {
+  getSandboxFallbackErrorMessage,
+  getSandboxWithFallbackGuard,
+} from "./utils/sandbox-fallback";
 
 const MAX_VIEW_FILE_BYTES = 10 * 1024 * 1024;
 const MAX_TEXT_FILE_READ_BYTES = 1024 * 1024;
@@ -60,9 +64,7 @@ type SandboxViewPayload = {
 };
 
 type FileViewImageUsageOutcome =
-  | "success"
-  | "unsupported_model"
-  | "inspection_failed";
+  "success" | "unsupported_model" | "inspection_failed";
 
 type FileViewStage = "initial_inspection" | "model_output";
 
@@ -1069,6 +1071,10 @@ const editSchema = z.object({
 
 export const createFile = (context: ToolContext) => {
   const { sandboxManager, modelName, getCurrentModelName } = context;
+  const getSandboxForFileTool = () =>
+    getSandboxWithFallbackGuard({
+      sandboxManager,
+    });
   const canViewMultimodalFiles = () =>
     supportsMultimodalToolResults(getCurrentModelName?.() ?? modelName);
   const supportsViewInSchema = canViewMultimodalFiles();
@@ -1155,7 +1161,7 @@ ${instructionsDescription}`,
     }),
     execute: async ({ action, path, text, range, edits }) => {
       try {
-        const { sandbox } = await sandboxManager.getSandbox();
+        const { sandbox } = await getSandboxForFileTool();
 
         switch (action) {
           case "view": {
@@ -1454,7 +1460,9 @@ ${instructionsDescription}`,
         }
       } catch (error) {
         return {
-          error: error instanceof Error ? error.message : String(error),
+          error:
+            getSandboxFallbackErrorMessage(error) ??
+            (error instanceof Error ? error.message : String(error)),
         };
       }
     },
@@ -1490,7 +1498,7 @@ ${instructionsDescription}`,
           const viewStartedAt = Date.now();
           let outputSandbox: any | undefined;
           try {
-            const { sandbox } = await sandboxManager.getSandbox();
+            const { sandbox } = await getSandboxForFileTool();
             outputSandbox = sandbox;
             const viewPayload = await readSandboxFileForView(
               sandbox,
@@ -1528,7 +1536,7 @@ ${instructionsDescription}`,
           } catch (error) {
             try {
               const sandbox =
-                outputSandbox ?? (await sandboxManager.getSandbox()).sandbox;
+                outputSandbox ?? (await getSandboxForFileTool()).sandbox;
               const classification = classifyFileViewError(error);
               captureFileViewImageUsage({
                 context,
@@ -1551,7 +1559,8 @@ ${instructionsDescription}`,
             return {
               type: "text" as const,
               value: `Error: ${
-                error instanceof Error ? error.message : String(error)
+                getSandboxFallbackErrorMessage(error) ??
+                (error instanceof Error ? error.message : String(error))
               }`,
             };
           }

--- a/lib/ai/tools/get-terminal-files.ts
+++ b/lib/ai/tools/get-terminal-files.ts
@@ -3,6 +3,10 @@ import { z } from "zod";
 import type { ToolContext } from "@/types";
 import { uploadSandboxFileToConvex } from "./utils/sandbox-file-uploader";
 import { toolBriefSchema } from "./tool-brief";
+import {
+  getSandboxFallbackErrorMessage,
+  getSandboxWithFallbackGuard,
+} from "./utils/sandbox-fallback";
 
 export const createGetTerminalFiles = (context: ToolContext) => {
   const { sandboxManager, backgroundProcessTracker } = context;
@@ -27,7 +31,9 @@ Usage:
     }),
     execute: async ({ files }: { files: string[] }) => {
       try {
-        const { sandbox } = await sandboxManager.getSandbox();
+        const { sandbox } = await getSandboxWithFallbackGuard({
+          sandboxManager,
+        });
 
         const providedFiles: Array<{ path: string }> = [];
         const blockedFiles: Array<{ path: string; reason: string }> = [];
@@ -147,7 +153,9 @@ Usage:
           failedFiles: blockedFiles,
         };
       } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error);
+        const errorMsg =
+          getSandboxFallbackErrorMessage(error) ??
+          (error instanceof Error ? error.message : String(error));
         return {
           result: `Failed to provide files to the user: ${errorMsg}. Do not tell the user these files were sent; explain the upload problem before retrying.`,
           files: [],

--- a/lib/ai/tools/get-terminal-files.ts
+++ b/lib/ai/tools/get-terminal-files.ts
@@ -4,8 +4,8 @@ import type { ToolContext } from "@/types";
 import { uploadSandboxFileToConvex } from "./utils/sandbox-file-uploader";
 import { toolBriefSchema } from "./tool-brief";
 import {
-  getSandboxFallbackErrorMessage,
   getSandboxWithFallbackGuard,
+  resolveToolErrorMessage,
 } from "./utils/sandbox-fallback";
 
 export const createGetTerminalFiles = (context: ToolContext) => {
@@ -153,9 +153,7 @@ Usage:
           failedFiles: blockedFiles,
         };
       } catch (error) {
-        const errorMsg =
-          getSandboxFallbackErrorMessage(error) ??
-          (error instanceof Error ? error.message : String(error));
+        const errorMsg = resolveToolErrorMessage(error);
         return {
           result: `Failed to provide files to the user: ${errorMsg}. Do not tell the user these files were sent; explain the upload problem before retrying.`,
           files: [],

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -36,6 +36,7 @@ import { FileAccumulator } from "./utils/file-accumulator";
 import { BackgroundProcessTracker } from "./utils/background-process-tracker";
 import { ptySessionManager } from "./utils/pty-session-manager";
 import { isE2BSandbox } from "./utils/sandbox-types";
+import { getSandboxWithFallbackGuard } from "./utils/sandbox-fallback";
 
 export { isE2BSandbox };
 
@@ -179,7 +180,9 @@ export const createTools = (
     if (options?.refresh) {
       await sandboxManager.resetSandbox?.(options.reason);
     }
-    const { sandbox: ensured } = await sandboxManager.getSandbox();
+    const { sandbox: ensured } = await getSandboxWithFallbackGuard({
+      sandboxManager,
+    });
     return ensured;
   };
   const getTodoManager = () => todoManager;

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -28,8 +28,8 @@ import {
 } from "./utils/pty-session-manager";
 import { getSessionSnapshots } from "./utils/pty-output-formatter";
 import {
-  getSandboxFallbackErrorMessage,
   getSandboxWithFallbackGuard,
+  resolveToolErrorMessage,
 } from "./utils/sandbox-fallback";
 import {
   waitForOutput,
@@ -292,10 +292,9 @@ In using these tools, adhere to the following guidelines:
               output: "",
               exitCode: 1,
               error:
-                getSandboxFallbackErrorMessage(err) ??
-                (err instanceof Error
-                  ? err.message
-                  : "Failed to create interactive PTY session."),
+                err instanceof Error
+                  ? resolveToolErrorMessage(err)
+                  : "Failed to create interactive PTY session.",
             },
           };
         }
@@ -762,9 +761,7 @@ In using these tools, adhere to the following guidelines:
           result: {
             exitCode: error instanceof CommandExitError ? error.exitCode : 1,
             output: "",
-            error:
-              getSandboxFallbackErrorMessage(error) ??
-              (error instanceof Error ? error.message : String(error)),
+            error: resolveToolErrorMessage(error),
           },
         };
       }

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -291,10 +291,7 @@ In using these tools, adhere to the following guidelines:
             result: {
               output: "",
               exitCode: 1,
-              error:
-                err instanceof Error
-                  ? resolveToolErrorMessage(err)
-                  : "Failed to create interactive PTY session.",
+              error: resolveToolErrorMessage(err),
             },
           };
         }

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -28,8 +28,8 @@ import {
 } from "./utils/pty-session-manager";
 import { getSessionSnapshots } from "./utils/pty-output-formatter";
 import {
-  assertLocalSandboxFallbackAllowed,
-  writeSandboxFallbackEvent,
+  getSandboxFallbackErrorMessage,
+  getSandboxWithFallbackGuard,
 } from "./utils/sandbox-fallback";
 import {
   waitForOutput,
@@ -177,16 +177,9 @@ In using these tools, adhere to the following guidelines:
       // ─── Interactive PTY exec branch ─────────────────────────────────
       if (interactive) {
         try {
-          const { sandbox } = await sandboxManager.getSandbox();
-          const fallbackInfo = sandboxManager.consumeFallbackInfo?.();
-          if (fallbackInfo?.occurred) {
-            writeSandboxFallbackEvent(
-              writer,
-              fallbackInfo,
-              `sandbox-fallback-${toolCallId}`,
-            );
-            assertLocalSandboxFallbackAllowed({ fallbackInfo });
-          }
+          const { sandbox } = await getSandboxWithFallbackGuard({
+            sandboxManager,
+          });
           const isCentrifugo = isCentrifugoSandbox(sandbox);
           const isE2B = isE2BSandbox(sandbox);
 
@@ -299,9 +292,10 @@ In using these tools, adhere to the following guidelines:
               output: "",
               exitCode: 1,
               error:
-                err instanceof Error
+                getSandboxFallbackErrorMessage(err) ??
+                (err instanceof Error
                   ? err.message
-                  : "Failed to create interactive PTY session.",
+                  : "Failed to create interactive PTY session."),
             },
           };
         }
@@ -309,18 +303,9 @@ In using these tools, adhere to the following guidelines:
 
       try {
         // Get fresh sandbox and verify it's ready
-        const { sandbox } = await sandboxManager.getSandbox();
-
-        // Check for sandbox fallback and notify frontend
-        const fallbackInfo = sandboxManager.consumeFallbackInfo?.();
-        if (fallbackInfo?.occurred) {
-          writeSandboxFallbackEvent(
-            writer,
-            fallbackInfo,
-            `sandbox-fallback-${toolCallId}`,
-          );
-          assertLocalSandboxFallbackAllowed({ fallbackInfo });
-        }
+        const { sandbox } = await getSandboxWithFallbackGuard({
+          sandboxManager,
+        });
 
         // Bail early if sandbox was already marked unavailable by any tool
         if (sandboxManager.isSandboxUnavailable()) {
@@ -375,7 +360,11 @@ In using these tools, adhere to the following guidelines:
 
             // Reset cached instance to force ensureSandboxConnection to create a fresh one
             sandboxManager.setSandbox(null as any);
-            const { sandbox: freshSandbox } = await sandboxManager.getSandbox();
+            const { sandbox: freshSandbox } = await getSandboxWithFallbackGuard(
+              {
+                sandboxManager,
+              },
+            );
 
             // Verify the fresh sandbox is ready
             try {
@@ -773,7 +762,9 @@ In using these tools, adhere to the following guidelines:
           result: {
             exitCode: error instanceof CommandExitError ? error.exitCode : 1,
             output: "",
-            error: error instanceof Error ? error.message : String(error),
+            error:
+              getSandboxFallbackErrorMessage(error) ??
+              (error instanceof Error ? error.message : String(error)),
           },
         };
       }

--- a/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
+++ b/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
@@ -19,14 +19,18 @@ import {
 } from "../hybrid-sandbox-manager";
 import {
   assertLocalSandboxFallbackAllowed,
+  getSandboxFallbackErrorMessage,
   getSandboxFallbackPromptReminder,
+  getSandboxWithFallbackGuard,
   prepareSandboxContextForPrompt,
+  resolveToolErrorMessage,
 } from "../sandbox-fallback";
 import {
   getConnectionIdFromPresenceClient,
   presenceHasConnectionId,
 } from "@/lib/centrifugo/presence";
 import type { ConnectionInfo } from "../sandbox-types";
+import { ChatSDKError } from "@/lib/errors";
 
 const baseConnection: ConnectionInfo = {
   connectionId: "conn-online",
@@ -446,6 +450,90 @@ describe("HybridSandboxManager prompt-time fallback", () => {
       fallbackInfo,
     });
     expect(writer.write).not.toHaveBeenCalled();
+  });
+
+  it("blocks fallback through guarded sandbox acquisition without consuming fallback info", async () => {
+    const fallbackInfo = {
+      occurred: true,
+      reason: "no_local_connections" as const,
+      requestedPreference: "desktop" as const,
+      actualSandbox: "e2b" as const,
+      actualSandboxName: "Cloud",
+    };
+    const sandboxManager = {
+      getSandbox: jest.fn().mockResolvedValue({ sandbox: { id: "cloud" } }),
+      peekFallbackInfo: jest.fn(() => fallbackInfo),
+      consumeFallbackInfo: jest.fn(),
+      resetSandbox: jest.fn().mockResolvedValue(undefined),
+      clearFallbackInfo: jest.fn(),
+    };
+
+    await expect(
+      getSandboxWithFallbackGuard({ sandboxManager }),
+    ).rejects.toThrow(
+      "The request couldn't be processed. Please check your input and try again.",
+    );
+
+    expect(sandboxManager.getSandbox).toHaveBeenCalledTimes(1);
+    expect(sandboxManager.peekFallbackInfo).toHaveBeenCalledTimes(1);
+    expect(sandboxManager.consumeFallbackInfo).not.toHaveBeenCalled();
+    expect(sandboxManager.resetSandbox).toHaveBeenCalledWith(
+      "blocked_local_sandbox_fallback",
+    );
+    expect(sandboxManager.clearFallbackInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the local-attachment block message for guarded local-only acquisition", async () => {
+    const sandboxManager = {
+      getSandbox: jest.fn().mockResolvedValue({ sandbox: { id: "cloud" } }),
+      peekFallbackInfo: jest.fn(() => ({
+        occurred: true,
+        reason: "no_local_connections" as const,
+        requestedPreference: "desktop" as const,
+        actualSandbox: "e2b" as const,
+        actualSandboxName: "Cloud",
+      })),
+      resetSandbox: jest.fn().mockResolvedValue(undefined),
+      clearFallbackInfo: jest.fn(),
+    };
+
+    let error: unknown;
+    try {
+      await getSandboxWithFallbackGuard({
+        sandboxManager,
+        requireLocalSandbox: true,
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(getSandboxFallbackErrorMessage(error)).toContain(
+      "Desktop-local attachments require the Desktop sandbox",
+    );
+    expect(sandboxManager.resetSandbox).toHaveBeenCalledWith(
+      "blocked_local_sandbox_fallback",
+    );
+  });
+
+  it("resolves fallback tool error messages only for fallback metadata", () => {
+    const fallbackError = new ChatSDKError(
+      "bad_request:api",
+      "fallback cause",
+      { localSandboxFallbackBlocked: true },
+    );
+    const genericChatError = new ChatSDKError(
+      "bad_request:api",
+      "generic cause",
+    );
+
+    expect(getSandboxFallbackErrorMessage(fallbackError)).toBe(
+      "fallback cause",
+    );
+    expect(getSandboxFallbackErrorMessage(genericChatError)).toBeNull();
+    expect(resolveToolErrorMessage(fallbackError)).toBe("fallback cause");
+    expect(resolveToolErrorMessage(new Error("plain error"))).toBe(
+      "plain error",
+    );
   });
 });
 

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -317,9 +317,8 @@ export class HybridSandboxManager implements SandboxManager {
   }
 
   /**
-   * Get and clear any pending fallback info.
+   * Peek at any pending fallback info without clearing it.
    * Returns null if no fallback occurred, otherwise returns the fallback details.
-   * Clears the info after returning so it's only reported once.
    */
   peekFallbackInfo(): SandboxFallbackInfo | null {
     return this.pendingFallbackInfo;
@@ -329,6 +328,11 @@ export class HybridSandboxManager implements SandboxManager {
     this.pendingFallbackInfo = null;
   }
 
+  /**
+   * Get and clear any pending fallback info.
+   * Returns null if no fallback occurred, otherwise returns the fallback details.
+   * Clears the info after returning so it's only reported once.
+   */
   consumeFallbackInfo(): SandboxFallbackInfo | null {
     const info = this.pendingFallbackInfo;
     this.pendingFallbackInfo = null;

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -321,6 +321,14 @@ export class HybridSandboxManager implements SandboxManager {
    * Returns null if no fallback occurred, otherwise returns the fallback details.
    * Clears the info after returning so it's only reported once.
    */
+  peekFallbackInfo(): SandboxFallbackInfo | null {
+    return this.pendingFallbackInfo;
+  }
+
+  clearFallbackInfo(): void {
+    this.pendingFallbackInfo = null;
+  }
+
   consumeFallbackInfo(): SandboxFallbackInfo | null {
     const info = this.pendingFallbackInfo;
     this.pendingFallbackInfo = null;

--- a/lib/ai/tools/utils/sandbox-fallback.ts
+++ b/lib/ai/tools/utils/sandbox-fallback.ts
@@ -8,6 +8,11 @@ type SandboxContextForPromptManager = {
   consumeFallbackInfo?: () => SandboxFallbackInfo | null;
 };
 
+type SandboxAcquisitionManager<TSandbox> = {
+  getSandbox: () => Promise<{ sandbox: TSandbox }>;
+  consumeFallbackInfo?: () => SandboxFallbackInfo | null;
+};
+
 const escapePromptText = (value: string): string =>
   value
     .replaceAll("&", "&amp;")
@@ -70,6 +75,39 @@ export function writeSandboxFallbackEvent(
     id,
     data: fallbackInfo,
   });
+}
+
+export async function getSandboxWithFallbackGuard<TSandbox>({
+  sandboxManager,
+  requireLocalSandbox = false,
+}: {
+  sandboxManager: SandboxAcquisitionManager<TSandbox>;
+  requireLocalSandbox?: boolean;
+}): Promise<{ sandbox: TSandbox }> {
+  const result = await sandboxManager.getSandbox();
+  const fallbackInfo = sandboxManager.consumeFallbackInfo?.() ?? null;
+
+  if (fallbackInfo?.occurred) {
+    assertLocalSandboxFallbackAllowed({
+      fallbackInfo,
+      requireLocalSandbox,
+    });
+  }
+
+  return result;
+}
+
+export function getSandboxFallbackErrorMessage(error: unknown): string | null {
+  if (
+    error instanceof ChatSDKError &&
+    typeof error.cause === "string" &&
+    (error.metadata?.localSandboxFallbackBlocked ||
+      error.metadata?.localSandboxRequired)
+  ) {
+    return error.cause;
+  }
+
+  return null;
 }
 
 export async function prepareSandboxContextForPrompt({

--- a/lib/ai/tools/utils/sandbox-fallback.ts
+++ b/lib/ai/tools/utils/sandbox-fallback.ts
@@ -10,7 +10,10 @@ type SandboxContextForPromptManager = {
 
 type SandboxAcquisitionManager<TSandbox> = {
   getSandbox: () => Promise<{ sandbox: TSandbox }>;
+  resetSandbox?: (reason?: string) => Promise<void>;
+  peekFallbackInfo?: () => SandboxFallbackInfo | null;
   consumeFallbackInfo?: () => SandboxFallbackInfo | null;
+  clearFallbackInfo?: () => void;
 };
 
 const escapePromptText = (value: string): string =>
@@ -85,13 +88,29 @@ export async function getSandboxWithFallbackGuard<TSandbox>({
   requireLocalSandbox?: boolean;
 }): Promise<{ sandbox: TSandbox }> {
   const result = await sandboxManager.getSandbox();
-  const fallbackInfo = sandboxManager.consumeFallbackInfo?.() ?? null;
+  const fallbackInfo =
+    sandboxManager.peekFallbackInfo?.() ??
+    sandboxManager.consumeFallbackInfo?.() ??
+    null;
 
   if (fallbackInfo?.occurred) {
-    assertLocalSandboxFallbackAllowed({
-      fallbackInfo,
-      requireLocalSandbox,
-    });
+    try {
+      assertLocalSandboxFallbackAllowed({
+        fallbackInfo,
+        requireLocalSandbox,
+      });
+    } catch (error) {
+      try {
+        await sandboxManager.resetSandbox?.("blocked_local_sandbox_fallback");
+      } catch (cleanupError) {
+        console.warn(
+          "[sandbox-fallback] Failed to reset blocked fallback sandbox:",
+          cleanupError,
+        );
+      }
+      sandboxManager.clearFallbackInfo?.();
+      throw error;
+    }
   }
 
   return result;
@@ -108,6 +127,13 @@ export function getSandboxFallbackErrorMessage(error: unknown): string | null {
   }
 
   return null;
+}
+
+export function resolveToolErrorMessage(error: unknown): string {
+  return (
+    getSandboxFallbackErrorMessage(error) ??
+    (error instanceof Error ? error.message : String(error))
+  );
 }
 
 export async function prepareSandboxContextForPrompt({

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -29,7 +29,9 @@ export interface SandboxManager {
   getSandboxType(toolName: string): SandboxType | undefined;
   getSandboxInfo(): SandboxInfo | null;
   // Optional: only HybridSandboxManager implements this
+  peekFallbackInfo?(): SandboxFallbackInfo | null;
   consumeFallbackInfo?(): SandboxFallbackInfo | null;
+  clearFallbackInfo?(): void;
   /** Get the effective sandbox preference after any fallbacks (e.g. "e2b" or connectionId). */
   getEffectivePreference(): string;
   /** Track consecutive sandbox health failures across all tools. Returns true if the limit has been exceeded. */


### PR DESCRIPTION
## Summary
- add a shared guarded sandbox acquisition helper so selected Local/Remote fallback is asserted after `getSandbox()`
- route terminal, file, generated-file delivery, attachment upload, and long-agent desktop staging through the guard
- keep blocked selected-local runs from emitting fallback UI state and add regressions for terminal, file, and file-delivery paths

## Why
Agent startup already blocked Local -> Cloud fallback during prompt-context preflight, but mid-run non-terminal tools could acquire a fallback sandbox after Local disconnected and ignore the pending fallback info. That made a selected Local run vulnerable to silently using Cloud for file/upload work after the initial guard.

## Validation
- `./node_modules/.bin/jest lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/ai/tools/__tests__/file.test.ts lib/ai/tools/__tests__/get-terminal-files.test.ts lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts --runInBand`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint app/api/agent-long/route.ts lib/ai/tools/utils/sandbox-fallback.ts lib/ai/tools/index.ts lib/ai/tools/run-terminal-cmd.ts lib/ai/tools/file.ts lib/ai/tools/get-terminal-files.ts lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/ai/tools/__tests__/file.test.ts lib/ai/tools/__tests__/get-terminal-files.test.ts`
- `./node_modules/.bin/prettier --check app/api/agent-long/route.ts lib/ai/tools/utils/sandbox-fallback.ts lib/ai/tools/index.ts lib/ai/tools/run-terminal-cmd.ts lib/ai/tools/file.ts lib/ai/tools/get-terminal-files.ts lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/ai/tools/__tests__/file.test.ts lib/ai/tools/__tests__/get-terminal-files.test.ts`
- pre-commit hook: full `jest` suite, 186 suites / 1903 tests passed

## Manual verification
- Start an Agent run with the Desktop sandbox selected, then disconnect Desktop before a terminal/file/upload step.
- Confirm the run blocks with the selected-local fallback message instead of switching to Cloud.
- Confirm the sandbox selector does not change to Cloud for that blocked run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a local sandbox falls back to Cloud: terminal commands (interactive and non-interactive), PTY sessions, and file uploads are now blocked from running/uploading in the wrong environment.
  * Standardized user-visible error messaging for fallback-related failures and ensured blocked fallback prevents subsequent file view/transfer output.

* **Tests**
  * Added and updated coverage to verify fallback blocking behavior, absence of fallback UI/writer output, and exact user-facing error text across file and terminal tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->