### PR TITLE
Fix extra usage reconciliation gaps

### DIFF
--- a/convex/__tests__/extraUsageActionsAuth.test.ts
+++ b/convex/__tests__/extraUsageActionsAuth.test.ts
@@ -72,10 +72,13 @@ jest.mock("stripe", () => {
 
 const ORIGINAL_STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
 const ORIGINAL_WORKOS_API_KEY = process.env.WORKOS_API_KEY;
+const ORIGINAL_SERVICE_KEY = process.env.CONVEX_SERVICE_ROLE_KEY;
+const SERVICE_KEY = "test-service-key";
 
 beforeAll(() => {
   process.env.STRIPE_SECRET_KEY = "sk_test";
   process.env.WORKOS_API_KEY = "workos_test";
+  process.env.CONVEX_SERVICE_ROLE_KEY = SERVICE_KEY;
 });
 
 afterAll(() => {
@@ -88,6 +91,11 @@ afterAll(() => {
     delete process.env.WORKOS_API_KEY;
   } else {
     process.env.WORKOS_API_KEY = ORIGINAL_WORKOS_API_KEY;
+  }
+  if (ORIGINAL_SERVICE_KEY === undefined) {
+    delete process.env.CONVEX_SERVICE_ROLE_KEY;
+  } else {
+    process.env.CONVEX_SERVICE_ROLE_KEY = ORIGINAL_SERVICE_KEY;
   }
 });
 
@@ -113,6 +121,17 @@ async function callCreateBillingPortalSession(ctx: any) {
   return (createBillingPortalSession as any).handler(ctx, {
     flow: "payment_method",
     baseUrl: "https://hackerai.example/settings",
+  });
+}
+
+async function callDeductWithAutoReload(
+  ctx: any,
+  args: { userId: string; amountPoints: number },
+) {
+  const { deductWithAutoReload } = await import("../extraUsageActions");
+  return (deductWithAutoReload as any).handler(ctx, {
+    serviceKey: SERVICE_KEY,
+    ...args,
   });
 }
 
@@ -250,6 +269,87 @@ describe("extraUsageActions billing authorization", () => {
     expect(result).toEqual({
       url: "https://checkout.stripe.test/session",
       checkoutSessionId: "cs_test",
+    });
+  });
+});
+
+describe("deductWithAutoReload", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("attempts auto-reload when the request is larger than the current balance", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({ data: [] } as never);
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        balanceDollars: 20,
+        balancePoints: 200_000,
+        enabled: true,
+        autoReloadEnabled: true,
+        autoReloadThresholdDollars: 1,
+        autoReloadThresholdPoints: 10_000,
+        autoReloadAmountDollars: 15,
+        monthlyRemainingDollars: 100,
+      })),
+      runMutation: jest.fn(async () => ({
+        success: false,
+        newBalancePoints: 200_000,
+        newBalanceDollars: 20,
+        insufficientFunds: true,
+        monthlyCapExceeded: false,
+      })),
+    };
+
+    const result = await callDeductWithAutoReload(ctx, {
+      userId: "user_member",
+      amountPoints: 300_000,
+    });
+
+    expect(mockListOrganizationMemberships).toHaveBeenCalledWith({
+      userId: "user_member",
+      statuses: ["active"],
+    });
+    expect(ctx.runMutation).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      success: false,
+      insufficientFunds: true,
+      autoReloadTriggered: true,
+      autoReloadResult: { success: false, reason: "no_stripe_customer" },
+    });
+  });
+
+  it("does not auto-reload when the monthly cap cannot cover the request", async () => {
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        balanceDollars: 0,
+        balancePoints: 0,
+        enabled: true,
+        autoReloadEnabled: true,
+        autoReloadThresholdDollars: 5,
+        autoReloadThresholdPoints: 50_000,
+        autoReloadAmountDollars: 50,
+        monthlyRemainingDollars: 1,
+      })),
+      runMutation: jest.fn(async () => ({
+        success: false,
+        newBalancePoints: 0,
+        newBalanceDollars: 0,
+        insufficientFunds: false,
+        monthlyCapExceeded: true,
+      })),
+    };
+
+    const result = await callDeductWithAutoReload(ctx, {
+      userId: "user_member",
+      amountPoints: 20_000,
+    });
+
+    expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
+    expect(ctx.runMutation).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      success: false,
+      monthlyCapExceeded: true,
+      autoReloadTriggered: false,
     });
   });
 });

--- a/convex/__tests__/extraUsageActionsAuth.test.ts
+++ b/convex/__tests__/extraUsageActionsAuth.test.ts
@@ -45,6 +45,12 @@ jest.mock("@workos-inc/node", () => ({
 
 const mockCheckoutSessionCreate = jest.fn();
 const mockBillingPortalSessionCreate = jest.fn();
+const mockCustomerRetrieve = jest.fn();
+const mockSubscriptionsList = jest.fn();
+const mockInvoicesCreate = jest.fn();
+const mockInvoiceItemsCreate = jest.fn();
+const mockInvoicesFinalize = jest.fn();
+const mockInvoicesPay = jest.fn();
 jest.mock("stripe", () => {
   const Stripe = jest.fn().mockImplementation(() => ({
     checkout: {
@@ -58,10 +64,18 @@ jest.mock("stripe", () => {
       },
     },
     customers: {
-      retrieve: jest.fn(),
+      retrieve: mockCustomerRetrieve,
     },
     subscriptions: {
-      list: jest.fn(),
+      list: mockSubscriptionsList,
+    },
+    invoices: {
+      create: mockInvoicesCreate,
+      finalizeInvoice: mockInvoicesFinalize,
+      pay: mockInvoicesPay,
+    },
+    invoiceItems: {
+      create: mockInvoiceItemsCreate,
     },
   }));
   (Stripe as any).errors = {
@@ -276,6 +290,25 @@ describe("extraUsageActions billing authorization", () => {
 describe("deductWithAutoReload", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCustomerRetrieve.mockResolvedValue({
+      deleted: false,
+      metadata: {},
+      invoice_settings: {},
+    } as never);
+    mockSubscriptionsList.mockResolvedValue({
+      data: [{ default_payment_method: "pm_card" }],
+    } as never);
+    mockInvoicesCreate.mockResolvedValue({ id: "in_auto" } as never);
+    mockInvoiceItemsCreate.mockResolvedValue({ id: "ii_auto" } as never);
+    mockInvoicesFinalize.mockResolvedValue({
+      id: "in_auto",
+      status: "open",
+    } as never);
+    mockInvoicesPay.mockResolvedValue({
+      id: "in_auto",
+      status: "paid",
+      payment_intent: "pi_auto",
+    } as never);
   });
 
   it("attempts auto-reload when the request is larger than the current balance", async () => {
@@ -350,6 +383,114 @@ describe("deductWithAutoReload", () => {
       success: false,
       monthlyCapExceeded: true,
       autoReloadTriggered: false,
+    });
+  });
+
+  it("charges enough to cover the requested deduction when it exceeds the reload target", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          status: "active",
+          role: { slug: "admin" },
+        },
+      ],
+    } as never);
+    mockGetOrganization.mockResolvedValue({
+      stripeCustomerId: "cus_team",
+    } as never);
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        balanceDollars: 20,
+        balancePoints: 200_000,
+        enabled: true,
+        autoReloadEnabled: true,
+        autoReloadThresholdDollars: 1,
+        autoReloadThresholdPoints: 10_000,
+        autoReloadAmountDollars: 15,
+        monthlyRemainingDollars: 100,
+      })),
+      runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
+        if ("amountDollars" in mutationArgs) return null;
+        if ("success" in mutationArgs && !("amountPoints" in mutationArgs)) {
+          return null;
+        }
+        return {
+          success: true,
+          newBalancePoints: 0,
+          newBalanceDollars: 0,
+          insufficientFunds: false,
+          monthlyCapExceeded: false,
+        };
+      }),
+    };
+
+    const result = await callDeductWithAutoReload(ctx, {
+      userId: "user_member",
+      amountPoints: 300_000,
+    });
+
+    expect(mockInvoiceItemsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 1000 }),
+    );
+    expect(result).toMatchObject({
+      success: true,
+      autoReloadTriggered: true,
+      autoReloadResult: { success: true, chargedAmountDollars: 10 },
+    });
+  });
+
+  it("uses the minimum charge when a request is underfunded by less than one dollar", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          status: "active",
+          role: { slug: "admin" },
+        },
+      ],
+    } as never);
+    mockGetOrganization.mockResolvedValue({
+      stripeCustomerId: "cus_team",
+    } as never);
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        balanceDollars: 29.5,
+        balancePoints: 295_000,
+        enabled: true,
+        autoReloadEnabled: true,
+        autoReloadThresholdDollars: 1,
+        autoReloadThresholdPoints: 10_000,
+        autoReloadAmountDollars: 15,
+        monthlyRemainingDollars: 100,
+      })),
+      runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
+        if ("amountDollars" in mutationArgs) return null;
+        if ("success" in mutationArgs && !("amountPoints" in mutationArgs)) {
+          return null;
+        }
+        return {
+          success: true,
+          newBalancePoints: 5_000,
+          newBalanceDollars: 0.5,
+          insufficientFunds: false,
+          monthlyCapExceeded: false,
+        };
+      }),
+    };
+
+    const result = await callDeductWithAutoReload(ctx, {
+      userId: "user_member",
+      amountPoints: 300_000,
+    });
+
+    expect(mockInvoiceItemsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 100 }),
+    );
+    expect(result).toMatchObject({
+      success: true,
+      autoReloadTriggered: true,
+      autoReloadResult: { success: true, chargedAmountDollars: 1 },
     });
   });
 });

--- a/convex/__tests__/teamExtraUsage.test.ts
+++ b/convex/__tests__/teamExtraUsage.test.ts
@@ -671,6 +671,47 @@ describe("deductWithAutoReloadForTeam", () => {
       autoReloadTriggered: false,
     });
   });
+
+  it("checks auto-reload when the request is larger than the current balance", async () => {
+    mockGetOrganization.mockResolvedValue({ stripeCustomerId: null });
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        enabled: true,
+        balanceDollars: 20,
+        balancePoints: 200_000,
+        autoReloadEnabled: true,
+        autoReloadThresholdDollars: 1,
+        autoReloadThresholdPoints: 10_000,
+        autoReloadAmountDollars: 15,
+        memberDisabled: false,
+      })),
+      runMutation: jest.fn(async () => ({
+        success: false,
+        newBalancePoints: 200_000,
+        newBalanceDollars: 20,
+        insufficientFunds: true,
+        monthlyCapExceeded: false,
+        memberCapExceeded: false,
+        memberDisabled: false,
+        poolDisabled: false,
+      })),
+    };
+
+    const result = await callDeductWithAutoReloadForTeam(ctx, {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      amountPoints: 300_000,
+    });
+
+    expect(mockGetOrganization).toHaveBeenCalledWith(ORG_ID);
+    expect(ctx.runMutation).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      success: false,
+      insufficientFunds: true,
+      autoReloadTriggered: true,
+      autoReloadResult: { success: false, reason: "no_stripe_customer" },
+    });
+  });
 });
 
 describe("refundTeamPoints", () => {

--- a/convex/__tests__/teamExtraUsage.test.ts
+++ b/convex/__tests__/teamExtraUsage.test.ts
@@ -24,6 +24,34 @@ jest.mock("@workos-inc/node", () => ({
     },
   })),
 }));
+const mockCustomerRetrieve = jest.fn();
+const mockSubscriptionsList = jest.fn();
+const mockInvoicesCreate = jest.fn();
+const mockInvoiceItemsCreate = jest.fn();
+const mockInvoicesFinalize = jest.fn();
+const mockInvoicesPay = jest.fn();
+jest.mock("stripe", () => {
+  const Stripe = jest.fn().mockImplementation(() => ({
+    customers: {
+      retrieve: mockCustomerRetrieve,
+    },
+    subscriptions: {
+      list: mockSubscriptionsList,
+    },
+    invoices: {
+      create: mockInvoicesCreate,
+      finalizeInvoice: mockInvoicesFinalize,
+      pay: mockInvoicesPay,
+    },
+    invoiceItems: {
+      create: mockInvoiceItemsCreate,
+    },
+  }));
+  (Stripe as any).errors = {
+    StripeError: class StripeError extends Error {},
+  };
+  return { __esModule: true, default: Stripe };
+});
 jest.mock("convex/values", () => ({
   v: {
     id: jest.fn(() => "id"),
@@ -53,9 +81,11 @@ jest.mock("../lib/logger", () => ({
 const SERVICE_KEY = "test-service-key";
 const ORIGINAL_SERVICE_KEY = process.env.CONVEX_SERVICE_ROLE_KEY;
 const ORIGINAL_WORKOS_API_KEY = process.env.WORKOS_API_KEY;
+const ORIGINAL_STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
 beforeAll(() => {
   process.env.CONVEX_SERVICE_ROLE_KEY = SERVICE_KEY;
   process.env.WORKOS_API_KEY = "test-workos-key";
+  process.env.STRIPE_SECRET_KEY = "sk_test";
 });
 afterAll(() => {
   if (ORIGINAL_SERVICE_KEY === undefined) {
@@ -67,6 +97,11 @@ afterAll(() => {
     delete process.env.WORKOS_API_KEY;
   } else {
     process.env.WORKOS_API_KEY = ORIGINAL_WORKOS_API_KEY;
+  }
+  if (ORIGINAL_STRIPE_SECRET_KEY === undefined) {
+    delete process.env.STRIPE_SECRET_KEY;
+  } else {
+    process.env.STRIPE_SECRET_KEY = ORIGINAL_STRIPE_SECRET_KEY;
   }
 });
 
@@ -590,7 +625,28 @@ describe("deductTeamPoints", () => {
 });
 
 describe("deductWithAutoReloadForTeam", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCustomerRetrieve.mockResolvedValue({
+      deleted: false,
+      metadata: {},
+      invoice_settings: {},
+    } as never);
+    mockSubscriptionsList.mockResolvedValue({
+      data: [{ default_payment_method: "pm_card" }],
+    } as never);
+    mockInvoicesCreate.mockResolvedValue({ id: "in_team_auto" } as never);
+    mockInvoiceItemsCreate.mockResolvedValue({ id: "ii_team_auto" } as never);
+    mockInvoicesFinalize.mockResolvedValue({
+      id: "in_team_auto",
+      status: "open",
+    } as never);
+    mockInvoicesPay.mockResolvedValue({
+      id: "in_team_auto",
+      status: "paid",
+      payment_intent: "pi_team_auto",
+    } as never);
+  });
 
   it("checks auto-reload after a successful deduction crosses the threshold", async () => {
     mockGetOrganization.mockResolvedValue({ stripeCustomerId: null });
@@ -710,6 +766,68 @@ describe("deductWithAutoReloadForTeam", () => {
       insufficientFunds: true,
       autoReloadTriggered: true,
       autoReloadResult: { success: false, reason: "no_stripe_customer" },
+    });
+  });
+
+  it("charges enough to cover a team deduction when it exceeds the reload target", async () => {
+    mockGetOrganization.mockResolvedValue({ stripeCustomerId: "cus_team" });
+    let deductAttempts = 0;
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        enabled: true,
+        balanceDollars: 20,
+        balancePoints: 200_000,
+        autoReloadEnabled: true,
+        autoReloadThresholdDollars: 1,
+        autoReloadThresholdPoints: 10_000,
+        autoReloadAmountDollars: 15,
+        memberDisabled: false,
+      })),
+      runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
+        if ("amountDollars" in mutationArgs) {
+          return { newBalance: 30 };
+        }
+        if ("success" in mutationArgs && !("amountPoints" in mutationArgs)) {
+          return null;
+        }
+        deductAttempts++;
+        return deductAttempts === 1
+          ? {
+              success: false,
+              newBalancePoints: 200_000,
+              newBalanceDollars: 20,
+              insufficientFunds: true,
+              monthlyCapExceeded: false,
+              memberCapExceeded: false,
+              memberDisabled: false,
+              poolDisabled: false,
+            }
+          : {
+              success: true,
+              newBalancePoints: 0,
+              newBalanceDollars: 0,
+              insufficientFunds: false,
+              monthlyCapExceeded: false,
+              memberCapExceeded: false,
+              memberDisabled: false,
+              poolDisabled: false,
+            };
+      }),
+    };
+
+    const result = await callDeductWithAutoReloadForTeam(ctx, {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      amountPoints: 300_000,
+    });
+
+    expect(mockInvoiceItemsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 1000 }),
+    );
+    expect(result).toMatchObject({
+      success: true,
+      autoReloadTriggered: true,
+      autoReloadResult: { success: true, chargedAmountDollars: 10 },
     });
   });
 });

--- a/convex/__tests__/usageLogs.test.ts
+++ b/convex/__tests__/usageLogs.test.ts
@@ -16,6 +16,7 @@ jest.mock("convex/values", () => ({
     string: jest.fn(() => "string"),
     number: jest.fn(() => "number"),
     optional: jest.fn(() => "optional"),
+    boolean: jest.fn(() => "boolean"),
     union: jest.fn(() => "union"),
     literal: jest.fn(() => "literal"),
     null: jest.fn(() => "null"),
@@ -54,8 +55,12 @@ describe("usageLogs", () => {
       output_tokens: 50,
       total_tokens: 150,
       cost_dollars: 15,
-      included_cost_dollars: 9,
+      included_cost_dollars: 6,
       extra_usage_cost_dollars: 6,
+      uncovered_cost_dollars: 3,
+      uncovered_points: 30000,
+      usage_deduction_failed: true,
+      usage_deduction_failure_reason: "insufficient_funds",
       model_cost_dollars: 13,
       non_model_cost_dollars: 2,
       cost_source: "token_estimate",
@@ -68,15 +73,19 @@ describe("usageLogs", () => {
       non_model_cost_dollars: 2,
       cost_source: "raw_token_estimate",
     });
-    expect(inserted.included_cost_dollars).toBeCloseTo(7.2);
+    expect(inserted.included_cost_dollars).toBeCloseTo(4.8);
     expect(inserted.extra_usage_cost_dollars).toBeCloseTo(4.8);
+    expect(inserted.uncovered_cost_dollars).toBeCloseTo(2.4);
+    expect(inserted.uncovered_points).toBe(30000);
+    expect(inserted.usage_deduction_failed).toBe(true);
+    expect(inserted.usage_deduction_failure_reason).toBe("insufficient_funds");
 
     const unitEconomicsDelta = mockApplyUnitEconomicsDelta.mock.calls[0][1];
     expect(unitEconomicsDelta).toMatchObject({
       modelCostDollars: 10,
       nonModelCostDollars: 2,
     });
-    expect(unitEconomicsDelta.includedUsageCostDollars).toBeCloseTo(7.2);
+    expect(unitEconomicsDelta.includedUsageCostDollars).toBeCloseTo(4.8);
     expect(unitEconomicsDelta.extraUsageCostDollars).toBeCloseTo(4.8);
   });
 

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -7,6 +7,8 @@ import Stripe from "stripe";
 import { WorkOS } from "@workos-inc/node";
 import { convexLogger } from "./lib/logger";
 
+const POINTS_PER_DOLLAR = 10_000;
+
 // =============================================================================
 // SDK Initialization (lazy, cached)
 // =============================================================================
@@ -586,6 +588,7 @@ export const deductWithAutoReload = action({
       autoReloadThresholdDollars?: number;
       autoReloadThresholdPoints?: number;
       autoReloadAmountDollars?: number;
+      monthlyRemainingDollars?: number;
     };
     const balanceLookupStartedAt = Date.now();
     try {
@@ -611,23 +614,34 @@ export const deductWithAutoReload = action({
     // Use points for threshold comparison (more precise)
     const thresholdPoints: number = settings.autoReloadThresholdPoints ?? 0;
     const reloadAmount: number = settings.autoReloadAmountDollars ?? 0;
+    const monthlyRemainingPoints =
+      settings.monthlyRemainingDollars === undefined
+        ? undefined
+        : Math.round(settings.monthlyRemainingDollars * POINTS_PER_DOLLAR);
+    const requestedDeductionDollars = args.amountPoints / POINTS_PER_DOLLAR;
+    const requestNeedsReload = settings.balancePoints < args.amountPoints;
     let autoReloadTriggered = false;
     let autoReloadResult:
       | { success: boolean; chargedAmountDollars?: number; reason?: string }
       | undefined;
 
-    // Check auto-reload conditions individually for debugging
-    // Auto-reload triggers when balance drops to/below threshold, not when balance can't cover request
+    // Check auto-reload conditions individually for debugging.
     const autoReloadConditions = {
       auto_reload_enabled: settings.autoReloadEnabled,
       balance_at_or_below_threshold: settings.balancePoints <= thresholdPoints,
+      balance_cannot_cover_request: requestNeedsReload,
       reload_amount_configured: reloadAmount > 0,
+      monthly_cap_can_cover_request:
+        monthlyRemainingPoints === undefined ||
+        args.amountPoints <= monthlyRemainingPoints,
     };
 
     const allConditionsMet =
       autoReloadConditions.auto_reload_enabled &&
-      autoReloadConditions.balance_at_or_below_threshold &&
-      autoReloadConditions.reload_amount_configured;
+      (autoReloadConditions.balance_at_or_below_threshold ||
+        autoReloadConditions.balance_cannot_cover_request) &&
+      autoReloadConditions.reload_amount_configured &&
+      autoReloadConditions.monthly_cap_can_cover_request;
 
     // Check if auto-reload is needed (compare in points for precision)
     if (allConditionsMet) {
@@ -674,17 +688,26 @@ export const deductWithAutoReload = action({
                 reason: "no_default_payment_method",
               };
             } else {
-              // Calculate how much to charge to reach target balance
-              // reloadAmount is the TARGET balance, not the amount to add
+              // Charge enough to satisfy this deduction, or restore the
+              // configured target balance, whichever is larger.
               const currentBalanceDollars = settings.balanceDollars;
-              const targetBalanceDollars = reloadAmount;
-              const amountToCharge = Math.max(
+              const targetBalanceDollars = Math.max(
+                reloadAmount,
+                requestedDeductionDollars,
+              );
+              const rawAmountToCharge = Math.max(
                 0,
                 targetBalanceDollars - currentBalanceDollars,
               );
 
               // Minimum charge of $1 to avoid tiny transactions
               const MIN_CHARGE_DOLLARS = 1;
+              const amountToCharge =
+                requestNeedsReload &&
+                rawAmountToCharge > 0 &&
+                rawAmountToCharge < MIN_CHARGE_DOLLARS
+                  ? MIN_CHARGE_DOLLARS
+                  : rawAmountToCharge;
               if (amountToCharge < MIN_CHARGE_DOLLARS) {
                 autoReloadResult = {
                   success: false,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2,6 +2,17 @@ import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 import { retainedTailValidator } from "./lib/retainedTail";
 
+const usageDeductionFailureReasonValidator = v.union(
+  v.literal("extra_usage_unavailable"),
+  v.literal("insufficient_funds"),
+  v.literal("monthly_cap_exceeded"),
+  v.literal("member_cap_exceeded"),
+  v.literal("member_disabled"),
+  v.literal("pool_disabled"),
+  v.literal("auto_reload_failed"),
+  v.literal("deduction_failed"),
+);
+
 export default defineSchema({
   chats: defineTable({
     id: v.string(),
@@ -607,7 +618,9 @@ export default defineSchema({
     extra_usage_points_deducted: v.optional(v.number()),
     uncovered_points: v.optional(v.number()),
     usage_deduction_failed: v.optional(v.boolean()),
-    usage_deduction_failure_reason: v.optional(v.string()),
+    usage_deduction_failure_reason: v.optional(
+      usageDeductionFailureReasonValidator,
+    ),
     model_cost_dollars: v.optional(v.number()),
     non_model_cost_dollars: v.optional(v.number()),
     cost_source: v.optional(

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -602,8 +602,12 @@ export default defineSchema({
     cost_dollars: v.number(),
     included_cost_dollars: v.optional(v.number()),
     extra_usage_cost_dollars: v.optional(v.number()),
+    uncovered_cost_dollars: v.optional(v.number()),
     included_points_deducted: v.optional(v.number()),
     extra_usage_points_deducted: v.optional(v.number()),
+    uncovered_points: v.optional(v.number()),
+    usage_deduction_failed: v.optional(v.boolean()),
+    usage_deduction_failure_reason: v.optional(v.string()),
     model_cost_dollars: v.optional(v.number()),
     non_model_cost_dollars: v.optional(v.number()),
     cost_source: v.optional(

--- a/convex/teamExtraUsageActions.ts
+++ b/convex/teamExtraUsageActions.ts
@@ -366,6 +366,8 @@ export const deductWithAutoReloadForTeam = action({
 
     const thresholdPoints = state.autoReloadThresholdPoints ?? 0;
     const reloadAmount = state.autoReloadAmountDollars ?? 0;
+    const requestedDeductionDollars = args.amountPoints / POINTS_PER_DOLLAR;
+    const requestNeedsReload = state.balancePoints < args.amountPoints;
     const balanceForReloadPoints = deductResult.success
       ? deductResult.newBalancePoints
       : state.balancePoints;
@@ -381,7 +383,7 @@ export const deductWithAutoReloadForTeam = action({
       state.enabled &&
       !state.memberDisabled &&
       state.autoReloadEnabled &&
-      balanceForReloadPoints <= thresholdPoints &&
+      (balanceForReloadPoints <= thresholdPoints || requestNeedsReload) &&
       reloadAmount > 0;
 
     if (allConditionsMet) {
@@ -411,13 +413,22 @@ export const deductWithAutoReloadForTeam = action({
               };
             } else {
               const currentBalanceDollars = balanceForReloadDollars;
-              const targetBalanceDollars = reloadAmount;
-              const amountToCharge = Math.max(
+              const targetBalanceDollars = Math.max(
+                reloadAmount,
+                requestNeedsReload ? requestedDeductionDollars : 0,
+              );
+              const rawAmountToCharge = Math.max(
                 0,
                 targetBalanceDollars - currentBalanceDollars,
               );
 
               const MIN_CHARGE_DOLLARS = 1;
+              const amountToCharge =
+                requestNeedsReload &&
+                rawAmountToCharge > 0 &&
+                rawAmountToCharge < MIN_CHARGE_DOLLARS
+                  ? MIN_CHARGE_DOLLARS
+                  : rawAmountToCharge;
               if (amountToCharge < MIN_CHARGE_DOLLARS) {
                 autoReloadResult = {
                   success: false,

--- a/convex/usageLogs.ts
+++ b/convex/usageLogs.ts
@@ -13,6 +13,16 @@ const typeValidator = v.union(
   v.literal("extra"),
   v.literal("mixed"),
 );
+const usageDeductionFailureReasonValidator = v.union(
+  v.literal("extra_usage_unavailable"),
+  v.literal("insufficient_funds"),
+  v.literal("monthly_cap_exceeded"),
+  v.literal("member_cap_exceeded"),
+  v.literal("member_disabled"),
+  v.literal("pool_disabled"),
+  v.literal("auto_reload_failed"),
+  v.literal("deduction_failed"),
+);
 
 const cleanModelName = (model: string): string =>
   model
@@ -51,7 +61,9 @@ export const logUsage = mutation({
     extra_usage_points_deducted: v.optional(v.number()),
     uncovered_points: v.optional(v.number()),
     usage_deduction_failed: v.optional(v.boolean()),
-    usage_deduction_failure_reason: v.optional(v.string()),
+    usage_deduction_failure_reason: v.optional(
+      usageDeductionFailureReasonValidator,
+    ),
     model_cost_dollars: v.optional(v.number()),
     non_model_cost_dollars: v.optional(v.number()),
     cost_source: v.optional(

--- a/convex/usageLogs.ts
+++ b/convex/usageLogs.ts
@@ -46,8 +46,12 @@ export const logUsage = mutation({
     cost_dollars: v.number(),
     included_cost_dollars: v.optional(v.number()),
     extra_usage_cost_dollars: v.optional(v.number()),
+    uncovered_cost_dollars: v.optional(v.number()),
     included_points_deducted: v.optional(v.number()),
     extra_usage_points_deducted: v.optional(v.number()),
+    uncovered_points: v.optional(v.number()),
+    usage_deduction_failed: v.optional(v.boolean()),
+    usage_deduction_failure_reason: v.optional(v.string()),
     model_cost_dollars: v.optional(v.number()),
     non_model_cost_dollars: v.optional(v.number()),
     cost_source: v.optional(
@@ -87,6 +91,9 @@ export const logUsage = mutation({
     const extraCostDollars = Number.isFinite(args.extra_usage_cost_dollars)
       ? args.extra_usage_cost_dollars! * costBreakdownScale
       : undefined;
+    const uncoveredCostDollars = Number.isFinite(args.uncovered_cost_dollars)
+      ? args.uncovered_cost_dollars! * costBreakdownScale
+      : undefined;
 
     if (
       args.type === "mixed" &&
@@ -109,6 +116,7 @@ export const logUsage = mutation({
         : args.type === "extra"
           ? costDollars
           : 0;
+    const uncoveredUsageCostDollars = uncoveredCostDollars ?? 0;
     const costSource =
       args.cost_source === "token_estimate"
         ? "raw_token_estimate"
@@ -132,8 +140,14 @@ export const logUsage = mutation({
       cost_dollars: costDollars,
       included_cost_dollars: includedUsageCostDollars,
       extra_usage_cost_dollars: extraUsageCostDollars,
+      uncovered_cost_dollars: uncoveredUsageCostDollars,
       included_points_deducted: args.included_points_deducted,
       extra_usage_points_deducted: args.extra_usage_points_deducted,
+      uncovered_points: args.uncovered_points,
+      usage_deduction_failed:
+        args.usage_deduction_failed === true ||
+        (args.uncovered_points ?? 0) > 0,
+      usage_deduction_failure_reason: args.usage_deduction_failure_reason,
       model_cost_dollars: modelCostDollars,
       non_model_cost_dollars: nonModelCostDollars,
       cost_source: costSource,
@@ -270,8 +284,12 @@ export const getUserUsageLogs = query({
         extra_usage_cost_dollars:
           log.extra_usage_cost_dollars ??
           (log.type === "extra" ? log.cost_dollars : 0),
+        uncovered_cost_dollars: log.uncovered_cost_dollars ?? 0,
         included_points_deducted: log.included_points_deducted,
         extra_usage_points_deducted: log.extra_usage_points_deducted,
+        uncovered_points: log.uncovered_points,
+        usage_deduction_failed: log.usage_deduction_failed,
+        usage_deduction_failure_reason: log.usage_deduction_failure_reason,
         model_cost_dollars: log.model_cost_dollars,
         non_model_cost_dollars: log.non_model_cost_dollars,
         cost_source: log.cost_source,

--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -287,6 +287,35 @@ describe("UsageTracker", () => {
       });
       expect(result.includedCostDollars).toBeCloseTo(2);
       expect(result.extraUsageCostDollars).toBeCloseTo(1);
+      expect(result.uncoveredCostDollars).toBeCloseTo(0);
+      expect(result.uncoveredPoints).toBe(0);
+      expect(result.usageDeductionFailed).toBe(false);
+    });
+
+    it("splits uncovered cost away from paid extra usage", () => {
+      const result = tracker.resolveCostBreakdown(
+        10,
+        {
+          remaining: 0,
+          resetTime: new Date(),
+          limit: 250000,
+          pointsDeducted: 0,
+        },
+        {
+          includedPointsDeducted: 0,
+          extraUsagePointsDeducted: 50_000,
+          uncoveredPoints: 50_000,
+          usageDeductionFailed: true,
+          usageDeductionFailureReason: "insufficient_funds",
+        },
+      );
+
+      expect(result.includedCostDollars).toBeCloseTo(0);
+      expect(result.extraUsageCostDollars).toBeCloseTo(5);
+      expect(result.uncoveredCostDollars).toBeCloseTo(5);
+      expect(result.uncoveredPoints).toBe(50_000);
+      expect(result.usageDeductionFailed).toBe(true);
+      expect(result.usageDeductionFailureReason).toBe("insufficient_funds");
     });
   });
 
@@ -386,8 +415,12 @@ describe("UsageTracker", () => {
         type: "included",
         includedCostDollars: 0.01,
         extraUsageCostDollars: 0,
+        uncoveredCostDollars: 0,
         includedPointsDeducted: 100,
         extraUsagePointsDeducted: 0,
+        uncoveredPoints: 0,
+        usageDeductionFailed: false,
+        usageDeductionFailureReason: undefined,
         inputTokens: 1000,
         outputTokens: 500,
         totalTokens: 1500,

--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -263,6 +263,40 @@ describe("UsageTracker", () => {
       });
       expect(result).toBe("included");
     });
+
+    it("should return 'extra' when only uncovered usage remains", () => {
+      const result = tracker.resolveUsageType(
+        {
+          remaining: 0,
+          resetTime: new Date(),
+          limit: 250000,
+          pointsDeducted: 0,
+        },
+        {
+          includedPointsDeducted: 0,
+          extraUsagePointsDeducted: 0,
+          uncoveredPoints: 50,
+        },
+      );
+      expect(result).toBe("extra");
+    });
+
+    it("should return 'mixed' when included and uncovered usage were both used", () => {
+      const result = tracker.resolveUsageType(
+        {
+          remaining: 0,
+          resetTime: new Date(),
+          limit: 250000,
+          pointsDeducted: 50,
+        },
+        {
+          includedPointsDeducted: 50,
+          extraUsagePointsDeducted: 0,
+          uncoveredPoints: 50,
+        },
+      );
+      expect(result).toBe("mixed");
+    });
   });
 
   describe("resolveCostBreakdown", () => {

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -352,8 +352,11 @@ describe("captureUsageCost", () => {
         costDollars: 0.42,
         includedCostDollars: 0.1,
         extraUsageCostDollars: 0.32,
+        uncoveredCostDollars: 0,
         includedPointsDeducted: 1000,
         extraUsagePointsDeducted: 3200,
+        uncoveredPoints: 0,
+        usageDeductionFailed: false,
         modelCostDollars: 0.3,
         nonModelCostDollars: 0.12,
         costSource: "provider",
@@ -719,8 +722,7 @@ describe("createChatLogger provider stream termination", () => {
       );
       const fields = posthogErrorCall?.[1] as { error?: unknown } | undefined;
       const capturedError = fields?.error as
-        | (Error & { cause?: unknown })
-        | undefined;
+        (Error & { cause?: unknown }) | undefined;
 
       expect(capturedError).toBeInstanceOf(Error);
       expect(capturedError?.name).toBe("AI_APICallError");

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -7,7 +7,10 @@ import {
 } from "ai";
 import { systemPrompt } from "@/lib/system-prompt";
 import { getResumeSection } from "@/lib/system-prompt/resume";
-import { AGENT_MAX_STREAM_DURATION_MS } from "@/lib/chat/stop-conditions";
+import {
+  AGENT_MAX_STREAM_DURATION_MS,
+  BUDGET_EXHAUSTION_FINISH_REASON,
+} from "@/lib/chat/stop-conditions";
 import { createTools } from "@/lib/ai/tools";
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { generateTitleFromUserMessageWithWriter } from "@/lib/actions";
@@ -176,8 +179,7 @@ export const createChatHandler = () => {
   return async (req: NextRequest) => {
     const endpoint = "/api/chat" as const;
     let preemptiveTimeout:
-      | ReturnType<typeof createPreemptiveTimeout>
-      | undefined;
+      ReturnType<typeof createPreemptiveTimeout> | undefined;
 
     // Track usage deductions for refund on error
     const usageRefundTracker = new UsageRefundTracker();
@@ -404,8 +406,7 @@ export const createChatHandler = () => {
       chatLogger.setChat(chatLogContext, selectedModel);
 
       let paidDailyFreeAllowanceReservation:
-        | PaidDailyFreeAllowanceReservation
-        | undefined;
+        PaidDailyFreeAllowanceReservation | undefined;
       let rateLimitInfo: RateLimitInfo;
 
       try {
@@ -993,9 +994,26 @@ export const createChatHandler = () => {
                     organizationId,
                     rateLimitInfo,
                   );
+                  if (deductionResult.uncoveredPoints > 0) {
+                    state.stoppedDueToBudgetExhaustion = true;
+                    state.streamFinishReason = BUDGET_EXHAUSTION_FINISH_REASON;
+                    phLogger.warn("Usage deduction left uncovered cost", {
+                      chatId,
+                      endpoint,
+                      mode,
+                      userId,
+                      organizationId,
+                      subscription,
+                      selectedModel,
+                      uncoveredPoints: deductionResult.uncoveredPoints,
+                      usageDeductionFailureReason:
+                        deductionResult.usageDeductionFailureReason,
+                    });
+                  }
                   const billingBreakdown =
                     deductionResult.includedPointsDeducted > 0 ||
-                    deductionResult.extraUsagePointsDeducted > 0
+                    deductionResult.extraUsagePointsDeducted > 0 ||
+                    deductionResult.uncoveredPoints > 0
                       ? deductionResult
                       : undefined;
                   usageCostRecord = usageTracker.createUsageCostRecord({

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1005,7 +1005,10 @@ export const createChatHandler = () => {
                   );
                   if (deductionResult.uncoveredPoints > 0) {
                     state.stoppedDueToBudgetExhaustion = true;
-                    state.streamFinishReason = BUDGET_EXHAUSTION_FINISH_REASON;
+                    if (state.streamFinishReason !== "error") {
+                      state.streamFinishReason =
+                        BUDGET_EXHAUSTION_FINISH_REASON;
+                    }
                     phLogger.warn("Usage deduction left uncovered cost", {
                       chatId,
                       endpoint,
@@ -1022,7 +1025,9 @@ export const createChatHandler = () => {
                   const billingBreakdown =
                     deductionResult.includedPointsDeducted > 0 ||
                     deductionResult.extraUsagePointsDeducted > 0 ||
-                    deductionResult.uncoveredPoints > 0
+                    deductionResult.uncoveredPoints > 0 ||
+                    deductionResult.usageDeductionFailed ||
+                    !!deductionResult.usageDeductionFailureReason
                       ? deductionResult
                       : undefined;
                   usageCostRecord = usageTracker.createUsageCostRecord({

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1344,6 +1344,10 @@ export const createChatHandler = () => {
                                   userId,
                                   mode,
                                 });
+                                // Final reconciliation can change the finish
+                                // reason to budget-exhausted; do it before
+                                // analytics and persistence consume state.
+                                await deductAccumulatedUsage();
                                 const outcome = retryAborted
                                   ? "aborted"
                                   : "success";
@@ -1493,8 +1497,6 @@ export const createChatHandler = () => {
                                     imageRecovery.omittedCount,
                                 });
 
-                                // Deduct accumulated usage (includes both original + retry streams)
-                                await deductAccumulatedUsage();
                                 shutdownPostHog(posthog);
                               } finally {
                                 await releaseFreeRunLockOnce();
@@ -1574,6 +1576,10 @@ export const createChatHandler = () => {
                       cacheWriteTokens: usageTracker.cacheWriteTokens,
                     });
                     captureToolCalls({ posthog, chatLogger, userId, mode });
+                    // Final reconciliation can change the finish reason to
+                    // budget-exhausted; do it before analytics and persistence
+                    // consume state.
+                    await deductAccumulatedUsage();
                     const outcome = isAborted ? "aborted" : "success";
                     captureAgentCompletionAnalytics({
                       posthog,
@@ -1879,8 +1885,6 @@ export const createChatHandler = () => {
                     ) {
                       writeAutoContinue(writer);
                     }
-
-                    await deductAccumulatedUsage();
                     shutdownPostHog(posthog);
                   } finally {
                     if (!retryScheduled) {

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -595,9 +595,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
     recordAnthropicPromptRepair(repair: {
       action: "appended_continue" | "trimmed";
       reason:
-        | "useful_assistant_tail"
-        | "no_useful_content"
-        | "dangling_tool_call";
+        "useful_assistant_tail" | "no_useful_content" | "dangling_tool_call";
       trailingAssistantContentTypes?: string[];
       model: string;
     }) {
@@ -833,8 +831,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
           (error.metadata?.capReason as LimitCapReason | undefined) ??
           "unknown";
         const resetTimestamp = error.metadata?.resetTimestamp as
-          | number
-          | undefined;
+          number | undefined;
         const subscriptionTier = isSubscriptionTier(subscription)
           ? subscription
           : undefined;
@@ -1338,8 +1335,12 @@ export function captureUsageCost({
       cost_dollars: usage.costDollars,
       included_cost_dollars: usage.includedCostDollars,
       extra_usage_cost_dollars: usage.extraUsageCostDollars,
+      uncovered_cost_dollars: usage.uncoveredCostDollars,
       included_points_deducted: usage.includedPointsDeducted,
       extra_usage_points_deducted: usage.extraUsagePointsDeducted,
+      uncovered_points: usage.uncoveredPoints,
+      usage_deduction_failed: usage.usageDeductionFailed,
+      usage_deduction_failure_reason: usage.usageDeductionFailureReason,
       model_cost_dollars: usage.modelCostDollars,
       non_model_cost_dollars: usage.nonModelCostDollars,
       input_tokens: usage.inputTokens,

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -48,9 +48,7 @@ const SAVE_CHAT_RETRY_DELAYS_MS =
   process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
 const REDACTED_ERROR_DATA_VALUE = "[Redacted]";
 type SummaryReason =
-  | "token_threshold"
-  | "provider_input_threshold"
-  | "provider_pressure";
+  "token_threshold" | "provider_input_threshold" | "provider_pressure";
 
 const sensitiveErrorDataKeys = new Set([
   "authorization",
@@ -654,8 +652,7 @@ export async function saveMessage({
       ...((extraFileIds || []).filter(Boolean) as string[]),
     ];
     const usageForSave = sanitizeForConvexValue(usage) as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
 
     const mutationArgs = {
       serviceKey,
@@ -1019,8 +1016,7 @@ export async function getMessagesByChatId({
             );
             const budgetForMessages = maxTokens - summaryTokens;
             const retainedTail = latestSummary.retained_tail as
-              | RetainedTailMetadata
-              | undefined;
+              RetainedTailMetadata | undefined;
             let truncatedAfterCutoff: UIMessage[] = [];
 
             if (budgetForMessages > 0 && retainedTail) {
@@ -1592,8 +1588,12 @@ export async function logUsageRecord({
   type,
   includedCostDollars,
   extraUsageCostDollars,
+  uncoveredCostDollars,
   includedPointsDeducted,
   extraUsagePointsDeducted,
+  uncoveredPoints,
+  usageDeductionFailed,
+  usageDeductionFailureReason,
   inputTokens,
   outputTokens,
   totalTokens,
@@ -1614,8 +1614,12 @@ export async function logUsageRecord({
   type: "included" | "extra" | "mixed";
   includedCostDollars?: number;
   extraUsageCostDollars?: number;
+  uncoveredCostDollars?: number;
   includedPointsDeducted?: number;
   extraUsagePointsDeducted?: number;
+  uncoveredPoints?: number;
+  usageDeductionFailed?: boolean;
+  usageDeductionFailureReason?: string;
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
@@ -1639,8 +1643,12 @@ export async function logUsageRecord({
       type,
       included_cost_dollars: includedCostDollars,
       extra_usage_cost_dollars: extraUsageCostDollars,
+      uncovered_cost_dollars: uncoveredCostDollars,
       included_points_deducted: includedPointsDeducted,
       extra_usage_points_deducted: extraUsagePointsDeducted,
+      uncovered_points: uncoveredPoints,
+      usage_deduction_failed: usageDeductionFailed,
+      usage_deduction_failure_reason: usageDeductionFailureReason,
       input_tokens: inputTokens,
       output_tokens: outputTokens,
       cache_read_tokens: cacheReadTokens,

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -34,6 +34,7 @@ import { sanitizeForConvexValue } from "./convex-value-sanitizer";
 import { stringifyRedactedError } from "@/lib/utils/error-redaction";
 import { phLogger } from "@/lib/posthog/server";
 import { stripOpenRouterReasoningMetadataFromParts } from "@/lib/chat/provider-metadata-sanitizer";
+import type { UsageDeductionFailureReason } from "@/lib/rate-limit";
 
 const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY!;
 const MAX_DATABASE_ERROR_MESSAGE_LENGTH = 500;
@@ -1619,7 +1620,7 @@ export async function logUsageRecord({
   extraUsagePointsDeducted?: number;
   uncoveredPoints?: number;
   usageDeductionFailed?: boolean;
-  usageDeductionFailureReason?: string;
+  usageDeductionFailureReason?: UsageDeductionFailureReason;
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -348,6 +348,8 @@ describe("token-bucket async functions", () => {
       ).resolves.toEqual({
         includedPointsDeducted: 0,
         extraUsagePointsDeducted: 0,
+        uncoveredPoints: 0,
+        usageDeductionFailed: false,
       });
       expect(mockLimitFn).not.toHaveBeenCalled();
     });
@@ -457,6 +459,8 @@ describe("token-bucket async functions", () => {
       expect(result).toEqual({
         includedPointsDeducted: 17,
         extraUsagePointsDeducted: 23,
+        uncoveredPoints: 0,
+        usageDeductionFailed: false,
       });
     });
 
@@ -493,6 +497,9 @@ describe("token-bucket async functions", () => {
       expect(result).toEqual({
         includedPointsDeducted: 17,
         extraUsagePointsDeducted: 33,
+        uncoveredPoints: 10,
+        usageDeductionFailed: true,
+        usageDeductionFailureReason: "deduction_failed",
       });
       consoleSpy.mockRestore();
     });
@@ -763,6 +770,50 @@ describe("token-bucket async functions", () => {
       expect(result).toEqual({
         includedPointsDeducted: 17,
         extraUsagePointsDeducted: 33,
+        uncoveredPoints: 0,
+        usageDeductionFailed: false,
+      });
+    });
+
+    it("reports uncovered points when overflow extra usage deduction fails", async () => {
+      const { deductUsage } = getIsolatedModule();
+
+      mockLimitFn.mockResolvedValueOnce({
+        success: true,
+        remaining: 10,
+        reset: Date.now() + 3600000,
+        limit: 250000,
+      });
+      mockLimitFn.mockResolvedValueOnce({
+        success: true,
+        remaining: 0,
+        reset: Date.now() + 3600000,
+        limit: 250000,
+      });
+      mockDeductFromBalance.mockResolvedValueOnce({
+        success: false,
+        newBalanceDollars: 0,
+        insufficientFunds: true,
+        monthlyCapExceeded: false,
+      });
+
+      const result = await deductUsage(
+        "user-123",
+        "pro",
+        1000,
+        5000,
+        1000,
+        { enabled: true, hasBalance: true, autoReloadEnabled: false },
+        0.005,
+      );
+
+      expect(mockDeductFromBalance).toHaveBeenCalledWith("user-123", 33);
+      expect(result).toEqual({
+        includedPointsDeducted: 17,
+        extraUsagePointsDeducted: 0,
+        uncoveredPoints: 33,
+        usageDeductionFailed: true,
+        usageDeductionFailureReason: "insufficient_funds",
       });
     });
 

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -642,6 +642,8 @@ describe("token-bucket async functions", () => {
       expect(result).toEqual({
         includedPointsDeducted: expectedActualCost,
         extraUsagePointsDeducted: 0,
+        uncoveredPoints: 0,
+        usageDeductionFailed: false,
       });
     });
 
@@ -697,6 +699,8 @@ describe("token-bucket async functions", () => {
       expect(result).toEqual({
         includedPointsDeducted: expectedProviderCost,
         extraUsagePointsDeducted: 0,
+        uncoveredPoints: 0,
+        usageDeductionFailed: false,
       });
     });
   });

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -25,6 +25,8 @@ describe("token-bucket async functions", () => {
   const mockScanFn = jest.fn();
   const mockDeductFromBalance = jest.fn();
   const mockRefundToBalance = jest.fn();
+  const mockDeductFromTeamBalance = jest.fn();
+  const mockRefundToTeamBalance = jest.fn();
   const originalNodeEnv = process.env.NODE_ENV;
 
   beforeEach(() => {
@@ -50,6 +52,16 @@ describe("token-bucket async functions", () => {
       monthlyCapExceeded: false,
     });
     mockRefundToBalance.mockResolvedValue({
+      success: true,
+      newBalanceDollars: 10,
+    });
+    mockDeductFromTeamBalance.mockResolvedValue({
+      success: true,
+      newBalanceDollars: 10,
+      insufficientFunds: false,
+      monthlyCapExceeded: false,
+    });
+    mockRefundToTeamBalance.mockResolvedValue({
       success: true,
       newBalanceDollars: 10,
     });
@@ -103,6 +115,8 @@ describe("token-bucket async functions", () => {
       jest.doMock("../../extra-usage", () => ({
         deductFromBalance: mockDeductFromBalance,
         refundToBalance: mockRefundToBalance,
+        deductFromTeamBalance: mockDeductFromTeamBalance,
+        refundToTeamBalance: mockRefundToTeamBalance,
       }));
 
       // Now require the module with fresh mocks
@@ -931,6 +945,145 @@ describe("token-bucket async functions", () => {
         uncoveredPoints: 33,
         usageDeductionFailed: true,
         usageDeductionFailureReason: "insufficient_funds",
+      });
+    });
+
+    it("reports monthly cap failures when overflow extra usage deduction fails", async () => {
+      const { deductUsage } = getIsolatedModule();
+
+      mockLimitFn
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 10,
+          reset: Date.now() + 3600000,
+          limit: 250000,
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 0,
+          reset: Date.now() + 3600000,
+          limit: 250000,
+        });
+      mockDeductFromBalance.mockResolvedValueOnce({
+        success: false,
+        newBalanceDollars: 20,
+        insufficientFunds: true,
+        monthlyCapExceeded: true,
+      });
+
+      const result = await deductUsage(
+        "user-123",
+        "pro",
+        1000,
+        5000,
+        1000,
+        { enabled: true, hasBalance: true, autoReloadEnabled: false },
+        0.005,
+      );
+
+      expect(result).toEqual({
+        includedPointsDeducted: 17,
+        extraUsagePointsDeducted: 0,
+        uncoveredPoints: 33,
+        usageDeductionFailed: true,
+        usageDeductionFailureReason: "monthly_cap_exceeded",
+      });
+    });
+
+    it("reports auto-reload failures when overflow extra usage deduction fails", async () => {
+      const { deductUsage } = getIsolatedModule();
+
+      mockLimitFn
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 10,
+          reset: Date.now() + 3600000,
+          limit: 250000,
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 0,
+          reset: Date.now() + 3600000,
+          limit: 250000,
+        });
+      mockDeductFromBalance.mockResolvedValueOnce({
+        success: false,
+        newBalanceDollars: 0,
+        insufficientFunds: true,
+        monthlyCapExceeded: false,
+        autoReloadTriggered: true,
+        autoReloadResult: { success: false, reason: "payment_failed" },
+      });
+
+      const result = await deductUsage(
+        "user-123",
+        "pro",
+        1000,
+        5000,
+        1000,
+        { enabled: true, hasBalance: false, autoReloadEnabled: true },
+        0.005,
+      );
+
+      expect(result).toEqual({
+        includedPointsDeducted: 17,
+        extraUsagePointsDeducted: 0,
+        uncoveredPoints: 33,
+        usageDeductionFailed: true,
+        usageDeductionFailureReason: "auto_reload_failed",
+      });
+    });
+
+    it("reports team member cap failures when team overflow deduction fails", async () => {
+      const { deductUsage } = getIsolatedModule();
+
+      mockLimitFn
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 10,
+          reset: Date.now() + 3600000,
+          limit: 250000,
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 0,
+          reset: Date.now() + 3600000,
+          limit: 250000,
+        });
+      mockDeductFromTeamBalance.mockResolvedValueOnce({
+        success: false,
+        newBalanceDollars: 20,
+        insufficientFunds: true,
+        monthlyCapExceeded: false,
+        memberCapExceeded: true,
+        memberDisabled: false,
+        poolDisabled: false,
+      });
+
+      const result = await deductUsage(
+        "user-123",
+        "team",
+        1000,
+        5000,
+        1000,
+        { enabled: true, hasBalance: true, autoReloadEnabled: false },
+        0.005,
+        undefined,
+        0,
+        "org-123",
+      );
+
+      expect(mockDeductFromTeamBalance).toHaveBeenCalledWith(
+        "org-123",
+        "user-123",
+        33,
+      );
+      expect(result).toEqual({
+        includedPointsDeducted: 17,
+        extraUsagePointsDeducted: 0,
+        uncoveredPoints: 33,
+        usageDeductionFailed: true,
+        usageDeductionFailureReason: "member_cap_exceeded",
       });
     });
 

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -45,6 +45,8 @@ export {
   getMonthlyBucketKey,
   getCycleExpireSeconds,
   POINTS_PER_DOLLAR,
+  type UsageDeductionFailureReason,
+  type UsageDeductionResult,
 } from "./token-bucket";
 
 // Re-export sliding window functions

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -75,17 +75,22 @@ const throwRateLimitServiceNotConfigured = (): never => {
 
 type RedisClient = NonNullable<ReturnType<typeof createRedisClient>>;
 
+export type UsageDeductionFailureReason =
+  | "extra_usage_unavailable"
+  | "insufficient_funds"
+  | "monthly_cap_exceeded"
+  | "member_cap_exceeded"
+  | "member_disabled"
+  | "pool_disabled"
+  | "auto_reload_failed"
+  | "deduction_failed";
+
 export interface UsageDeductionResult {
   includedPointsDeducted: number;
   extraUsagePointsDeducted: number;
   uncoveredPoints: number;
   usageDeductionFailed: boolean;
-  usageDeductionFailureReason?:
-    | "extra_usage_unavailable"
-    | "insufficient_funds"
-    | "monthly_cap_exceeded"
-    | "auto_reload_failed"
-    | "deduction_failed";
+  usageDeductionFailureReason?: UsageDeductionFailureReason;
 }
 
 const emptyUsageDeductionResult = (): UsageDeductionResult => ({
@@ -102,10 +107,13 @@ const nonNegativePoints = (value: number | undefined): number =>
 
 const getDeductionFailureReason = (
   result: DeductBalanceResult,
-): UsageDeductionResult["usageDeductionFailureReason"] => {
+): UsageDeductionFailureReason => {
   if (result.monthlyCapExceeded) return "monthly_cap_exceeded";
-  if (result.insufficientFunds) return "insufficient_funds";
+  if (result.memberCapExceeded) return "member_cap_exceeded";
+  if (result.memberDisabled) return "member_disabled";
+  if (result.poolDisabled) return "pool_disabled";
   if (result.autoReloadResult?.success === false) return "auto_reload_failed";
+  if (result.insufficientFunds) return "insufficient_funds";
   return "deduction_failed";
 };
 

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -11,6 +11,7 @@ import {
   refundToBalance,
   deductFromTeamBalance,
   refundToTeamBalance,
+  type DeductBalanceResult,
 } from "@/lib/extra-usage";
 import { getSuspensionMessage } from "@/lib/suspensionMessage";
 import {
@@ -77,17 +78,36 @@ type RedisClient = NonNullable<ReturnType<typeof createRedisClient>>;
 export interface UsageDeductionResult {
   includedPointsDeducted: number;
   extraUsagePointsDeducted: number;
+  uncoveredPoints: number;
+  usageDeductionFailed: boolean;
+  usageDeductionFailureReason?:
+    | "extra_usage_unavailable"
+    | "insufficient_funds"
+    | "monthly_cap_exceeded"
+    | "auto_reload_failed"
+    | "deduction_failed";
 }
 
 const emptyUsageDeductionResult = (): UsageDeductionResult => ({
   includedPointsDeducted: 0,
   extraUsagePointsDeducted: 0,
+  uncoveredPoints: 0,
+  usageDeductionFailed: false,
 });
 
 const nonNegativePoints = (value: number | undefined): number =>
   typeof value === "number" && Number.isFinite(value)
     ? Math.max(0, Math.round(value))
     : 0;
+
+const getDeductionFailureReason = (
+  result: DeductBalanceResult,
+): UsageDeductionResult["usageDeductionFailureReason"] => {
+  if (result.monthlyCapExceeded) return "monthly_cap_exceeded";
+  if (result.insufficientFunds) return "insufficient_funds";
+  if (result.autoReloadResult?.success === false) return "auto_reload_failed";
+  return "deduction_failed";
+};
 
 const scanRedisKeys = async (
   redis: RedisClient,
@@ -575,6 +595,22 @@ export const deductUsage = async (
   }
 
   let lastKnownDeductionResult = emptyUsageDeductionResult();
+  let actualCostPoints = 0;
+
+  const withFinalCoverage = (
+    result: UsageDeductionResult,
+    failureReason?: UsageDeductionResult["usageDeductionFailureReason"],
+  ): UsageDeductionResult => {
+    const coveredPoints =
+      result.includedPointsDeducted + result.extraUsagePointsDeducted;
+    const uncoveredPoints = Math.max(0, actualCostPoints - coveredPoints);
+    return {
+      ...result,
+      uncoveredPoints,
+      usageDeductionFailed: uncoveredPoints > 0 || !!failureReason,
+      ...(failureReason && { usageDeductionFailureReason: failureReason }),
+    };
+  };
 
   try {
     const { monthly, monthlyLimit } = createRateLimiter(
@@ -614,14 +650,14 @@ export const deductUsage = async (
           nonNegativePoints(extraUsageDeltaPoints) -
           nonNegativePoints(extraUsageRefundPoints),
       ),
+      uncoveredPoints: 0,
+      usageDeductionFailed: false,
     });
     lastKnownDeductionResult = buildDeductionResult();
 
     // Calculate actual cost - prefer provider cost if available.
     // Provider cost already includes non-model costs (sandbox/tools) when present.
     // When absent (non-clean streams), add non-model costs on top of token-based estimate.
-    let actualCostPoints: number;
-
     if (providerCostDollars !== undefined && providerCostDollars > 0) {
       actualCostPoints = Math.ceil(providerCostDollars * POINTS_PER_DOLLAR);
     } else {
@@ -693,7 +729,8 @@ export const deductUsage = async (
     }
 
     // If actual cost equals estimate, nothing more to do
-    if (costDifference === 0) return lastKnownDeductionResult;
+    if (costDifference === 0)
+      return withFinalCoverage(lastKnownDeductionResult);
 
     // Otherwise, we need to charge the additional cost.
     // First, peek at remaining balance to avoid going negative.
@@ -712,27 +749,34 @@ export const deductUsage = async (
 
     // Send overflow to extra usage if enabled
     let extraUsageDeducted = 0;
-    if (
-      fromExtraUsage > 0 &&
-      extraUsageConfig?.enabled &&
-      (extraUsageConfig.hasBalance || extraUsageConfig.autoReloadEnabled)
-    ) {
-      const isTeamPool = subscription === "team" && !!organizationId;
-      const deductResult = isTeamPool
-        ? await deductFromTeamBalance(organizationId!, userId, fromExtraUsage)
-        : await deductFromBalance(userId, fromExtraUsage);
-      if (deductResult.success) {
-        extraUsageDeducted = fromExtraUsage;
-        lastKnownDeductionResult = buildDeductionResult(
-          fromBucket,
-          extraUsageDeducted,
-        );
+    let failureReason:
+      UsageDeductionResult["usageDeductionFailureReason"] | undefined;
+    if (fromExtraUsage > 0) {
+      if (
+        extraUsageConfig?.enabled &&
+        (extraUsageConfig.hasBalance || extraUsageConfig.autoReloadEnabled)
+      ) {
+        const isTeamPool = subscription === "team" && !!organizationId;
+        const deductResult = isTeamPool
+          ? await deductFromTeamBalance(organizationId!, userId, fromExtraUsage)
+          : await deductFromBalance(userId, fromExtraUsage);
+        if (deductResult.success) {
+          extraUsageDeducted = fromExtraUsage;
+          lastKnownDeductionResult = buildDeductionResult(
+            fromBucket,
+            extraUsageDeducted,
+          );
+        } else {
+          failureReason = getDeductionFailureReason(deductResult);
+        }
+      } else {
+        failureReason = "extra_usage_unavailable";
       }
     }
-    return lastKnownDeductionResult;
+    return withFinalCoverage(lastKnownDeductionResult, failureReason);
   } catch (error) {
     console.error("Failed to deduct usage:", error);
-    return lastKnownDeductionResult;
+    return withFinalCoverage(lastKnownDeductionResult, "deduction_failed");
   }
 };
 

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -1,5 +1,6 @@
 import { logUsageRecord } from "@/lib/db/actions";
 import { calculateRawTokenCost, POINTS_PER_DOLLAR } from "@/lib/rate-limit";
+import type { UsageDeductionFailureReason } from "@/lib/rate-limit";
 import type { ChatMode, RateLimitInfo, SubscriptionTier } from "@/types";
 
 interface StepUsage {
@@ -20,7 +21,7 @@ export interface UsageBillingBreakdown {
   extraUsagePointsDeducted: number;
   uncoveredPoints?: number;
   usageDeductionFailed?: boolean;
-  usageDeductionFailureReason?: string;
+  usageDeductionFailureReason?: UsageDeductionFailureReason;
 }
 
 interface ResolvedUsageBillingBreakdown extends UsageBillingBreakdown {
@@ -28,6 +29,7 @@ interface ResolvedUsageBillingBreakdown extends UsageBillingBreakdown {
   extraUsagePointsDeducted: number;
   uncoveredPoints: number;
   usageDeductionFailed: boolean;
+  usageDeductionFailureReason?: UsageDeductionFailureReason;
 }
 
 export interface UsageCostRecord {
@@ -40,7 +42,7 @@ export interface UsageCostRecord {
   extraUsagePointsDeducted: number;
   uncoveredPoints: number;
   usageDeductionFailed: boolean;
-  usageDeductionFailureReason?: string;
+  usageDeductionFailureReason?: UsageDeductionFailureReason;
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
@@ -190,12 +192,20 @@ export class UsageTracker {
     rateLimitInfo: RateLimitInfo,
     billingBreakdown?: UsageBillingBreakdown,
   ): UsageBillingType {
-    const { includedPointsDeducted, extraUsagePointsDeducted } =
-      this.getBillingBreakdown(rateLimitInfo, billingBreakdown);
+    const {
+      includedPointsDeducted,
+      extraUsagePointsDeducted,
+      uncoveredPoints,
+    } = this.getBillingBreakdown(rateLimitInfo, billingBreakdown);
     if (includedPointsDeducted > 0 && extraUsagePointsDeducted > 0) {
       return "mixed";
     }
-    return extraUsagePointsDeducted > 0 ? "extra" : "included";
+    if (includedPointsDeducted > 0 && uncoveredPoints > 0) {
+      return "mixed";
+    }
+    return extraUsagePointsDeducted > 0 || uncoveredPoints > 0
+      ? "extra"
+      : "included";
   }
 
   resolveCostBreakdown(

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -18,6 +18,16 @@ export type UsageBillingType = "included" | "extra" | "mixed";
 export interface UsageBillingBreakdown {
   includedPointsDeducted: number;
   extraUsagePointsDeducted: number;
+  uncoveredPoints?: number;
+  usageDeductionFailed?: boolean;
+  usageDeductionFailureReason?: string;
+}
+
+interface ResolvedUsageBillingBreakdown extends UsageBillingBreakdown {
+  includedPointsDeducted: number;
+  extraUsagePointsDeducted: number;
+  uncoveredPoints: number;
+  usageDeductionFailed: boolean;
 }
 
 export interface UsageCostRecord {
@@ -25,8 +35,12 @@ export interface UsageCostRecord {
   type: UsageBillingType;
   includedCostDollars: number;
   extraUsageCostDollars: number;
+  uncoveredCostDollars: number;
   includedPointsDeducted: number;
   extraUsagePointsDeducted: number;
+  uncoveredPoints: number;
+  usageDeductionFailed: boolean;
+  usageDeductionFailureReason?: string;
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
@@ -142,7 +156,7 @@ export class UsageTracker {
   getBillingBreakdown(
     rateLimitInfo: RateLimitInfo,
     billingBreakdown?: UsageBillingBreakdown,
-  ): UsageBillingBreakdown {
+  ): ResolvedUsageBillingBreakdown {
     return {
       includedPointsDeducted: Math.max(
         0,
@@ -156,6 +170,12 @@ export class UsageTracker {
           rateLimitInfo.extraUsagePointsDeducted ??
           0,
       ),
+      uncoveredPoints: Math.max(0, billingBreakdown?.uncoveredPoints ?? 0),
+      usageDeductionFailed:
+        billingBreakdown?.usageDeductionFailed === true ||
+        (billingBreakdown?.uncoveredPoints ?? 0) > 0,
+      usageDeductionFailureReason:
+        billingBreakdown?.usageDeductionFailureReason,
     };
   }
 
@@ -179,38 +199,51 @@ export class UsageTracker {
     UsageCostRecord,
     | "includedCostDollars"
     | "extraUsageCostDollars"
+    | "uncoveredCostDollars"
     | "includedPointsDeducted"
     | "extraUsagePointsDeducted"
+    | "uncoveredPoints"
+    | "usageDeductionFailed"
+    | "usageDeductionFailureReason"
   > {
-    const { includedPointsDeducted, extraUsagePointsDeducted } =
-      this.getBillingBreakdown(rateLimitInfo, billingBreakdown);
-    const totalPoints = includedPointsDeducted + extraUsagePointsDeducted;
+    const {
+      includedPointsDeducted,
+      extraUsagePointsDeducted,
+      uncoveredPoints,
+      usageDeductionFailed,
+      usageDeductionFailureReason,
+    } = this.getBillingBreakdown(rateLimitInfo, billingBreakdown);
+    const totalPoints =
+      includedPointsDeducted + extraUsagePointsDeducted + uncoveredPoints;
 
-    if (extraUsagePointsDeducted <= 0 || totalPoints <= 0) {
+    if (totalPoints <= 0) {
       return {
         includedCostDollars: costDollars,
         extraUsageCostDollars: 0,
+        uncoveredCostDollars: 0,
         includedPointsDeducted,
         extraUsagePointsDeducted,
+        uncoveredPoints,
+        usageDeductionFailed,
+        usageDeductionFailureReason,
       };
     }
 
-    if (includedPointsDeducted <= 0) {
-      return {
-        includedCostDollars: 0,
-        extraUsageCostDollars: costDollars,
-        includedPointsDeducted,
-        extraUsagePointsDeducted,
-      };
-    }
-
+    const includedCostDollars =
+      costDollars * (includedPointsDeducted / totalPoints);
     const extraUsageCostDollars =
       costDollars * (extraUsagePointsDeducted / totalPoints);
+    const uncoveredCostDollars =
+      costDollars - includedCostDollars - extraUsageCostDollars;
     return {
-      includedCostDollars: costDollars - extraUsageCostDollars,
+      includedCostDollars,
       extraUsageCostDollars,
+      uncoveredCostDollars,
       includedPointsDeducted,
       extraUsagePointsDeducted,
+      uncoveredPoints,
+      usageDeductionFailed,
+      usageDeductionFailureReason,
     };
   }
 
@@ -304,6 +337,10 @@ export class UsageTracker {
       extraUsageCostDollars: usage.extraUsageCostDollars,
       includedPointsDeducted: usage.includedPointsDeducted,
       extraUsagePointsDeducted: usage.extraUsagePointsDeducted,
+      uncoveredCostDollars: usage.uncoveredCostDollars,
+      uncoveredPoints: usage.uncoveredPoints,
+      usageDeductionFailed: usage.usageDeductionFailed,
+      usageDeductionFailureReason: usage.usageDeductionFailureReason,
       inputTokens: usage.inputTokens,
       outputTokens: usage.outputTokens,
       totalTokens: usage.totalTokens,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1497,7 +1497,10 @@ export const agentLongTask = task({
                   );
                   if (deductionResult.uncoveredPoints > 0) {
                     state.stoppedDueToBudgetExhaustion = true;
-                    state.streamFinishReason = BUDGET_EXHAUSTION_FINISH_REASON;
+                    if (state.streamFinishReason !== "error") {
+                      state.streamFinishReason =
+                        BUDGET_EXHAUSTION_FINISH_REASON;
+                    }
                     phLogger.warn("Usage deduction left uncovered cost", {
                       chatId,
                       endpoint: "/api/agent-long",
@@ -1514,7 +1517,9 @@ export const agentLongTask = task({
                   const billingBreakdown =
                     deductionResult.includedPointsDeducted > 0 ||
                     deductionResult.extraUsagePointsDeducted > 0 ||
-                    deductionResult.uncoveredPoints > 0
+                    deductionResult.uncoveredPoints > 0 ||
+                    deductionResult.usageDeductionFailed ||
+                    !!deductionResult.usageDeductionFailureReason
                       ? deductionResult
                       : undefined;
                   usageCostRecord = usageTracker.createUsageCostRecord({

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -125,7 +125,10 @@ import {
   AGENT_LONG_HEARTBEAT_PART_TYPE,
   stripAgentLongHeartbeatParts,
 } from "@/lib/chat/agent-long-heartbeat";
-import { PREEMPTIVE_TIMEOUT_FINISH_REASON } from "@/lib/chat/stop-conditions";
+import {
+  BUDGET_EXHAUSTION_FINISH_REASON,
+  PREEMPTIVE_TIMEOUT_FINISH_REASON,
+} from "@/lib/chat/stop-conditions";
 import { shouldRetryAgentLongWithFallback } from "@/lib/chat/agent-long-provider-retry";
 import {
   omitImageViewToolResultsForProviderRetry,
@@ -546,8 +549,7 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
 
 const getTerminalProviderStreamError = (
   state:
-    | Pick<AgentStreamState, "streamFinishReason" | "providerError">
-    | undefined,
+    Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
 ): unknown | undefined => {
   if (!state) return undefined;
   if (state.streamFinishReason !== "error") return undefined;
@@ -564,8 +566,7 @@ const getTerminalProviderStreamError = (
 
 const isTerminalProviderStreamError = (
   state:
-    | Pick<AgentStreamState, "streamFinishReason" | "providerError">
-    | undefined,
+    Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
 ): boolean => state?.streamFinishReason === "error";
 
 type RecordedAgentLongFailure = {
@@ -1486,9 +1487,26 @@ export const agentLongTask = task({
                     organizationId,
                     rateLimitInfo,
                   );
+                  if (deductionResult.uncoveredPoints > 0) {
+                    state.stoppedDueToBudgetExhaustion = true;
+                    state.streamFinishReason = BUDGET_EXHAUSTION_FINISH_REASON;
+                    phLogger.warn("Usage deduction left uncovered cost", {
+                      chatId,
+                      endpoint: "/api/agent-long",
+                      mode,
+                      userId,
+                      organizationId,
+                      subscription,
+                      selectedModel,
+                      uncoveredPoints: deductionResult.uncoveredPoints,
+                      usageDeductionFailureReason:
+                        deductionResult.usageDeductionFailureReason,
+                    });
+                  }
                   const billingBreakdown =
                     deductionResult.includedPointsDeducted > 0 ||
-                    deductionResult.extraUsagePointsDeducted > 0
+                    deductionResult.extraUsagePointsDeducted > 0 ||
+                    deductionResult.uncoveredPoints > 0
                       ? deductionResult
                       : undefined;
                   usageCostRecord = usageTracker.createUsageCostRecord({

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1808,6 +1808,10 @@ export const agentLongTask = task({
                                     userId,
                                     mode,
                                   });
+                                  // Final reconciliation can change the finish
+                                  // reason to budget-exhausted; do it before
+                                  // analytics and persistence consume state.
+                                  await deductAccumulatedUsage();
                                   const outcome = retryAborted
                                     ? "aborted"
                                     : isTerminalProviderStreamError(state)
@@ -1903,7 +1907,6 @@ export const agentLongTask = task({
                                     });
                                     sendFileMetadataToStream(accumulatedFiles);
                                   }
-                                  await deductAccumulatedUsage();
                                   posthog?.shutdown();
                                 } finally {
                                   await releaseFreeRunLockOnce();
@@ -1936,6 +1939,10 @@ export const agentLongTask = task({
                         cacheWriteTokens: usageTracker.cacheWriteTokens,
                       });
                       captureToolCalls({ posthog, chatLogger, userId, mode });
+                      // Final reconciliation can change the finish reason to
+                      // budget-exhausted; do it before analytics and
+                      // persistence consume state.
+                      await deductAccumulatedUsage();
                       const outcome = isAborted
                         ? "aborted"
                         : isTerminalProviderStreamError(state)
@@ -2158,8 +2165,6 @@ export const agentLongTask = task({
                       ) {
                         writeAutoContinue(writer);
                       }
-
-                      await deductAccumulatedUsage();
                       posthog?.shutdown();
                     } finally {
                       if (!retryScheduled) {


### PR DESCRIPTION
## Summary
- make auto-reload charge enough to cover the current deduction when the request is larger than the existing extra-usage balance
- skip auto-reload charges when the monthly cap would still block the deduction
- track uncovered usage and deduction failure reasons separately in usage logs and PostHog instead of folding them into paid extra usage
- mark chat and long-agent runs as budget-exhausted when final reconciliation leaves uncovered points, while preserving provider-error finish reasons and failure-only deduction metadata

## Testing
- ./node_modules/.bin/jest lib/rate-limit/__tests__/token-bucket.integration.test.ts lib/__tests__/usage-tracker.test.ts lib/api/__tests__/chat-logger.test.ts convex/__tests__/usageLogs.test.ts convex/__tests__/extraUsageActionsAuth.test.ts convex/__tests__/teamExtraUsage.test.ts --runInBand
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/eslint convex/extraUsageActions.ts convex/teamExtraUsageActions.ts convex/usageLogs.ts convex/schema.ts lib/rate-limit/token-bucket.ts lib/rate-limit/index.ts lib/usage-tracker.ts lib/api/chat-handler.ts lib/api/chat-logger.ts lib/db/actions.ts trigger/agent-long.ts convex/__tests__/extraUsageActionsAuth.test.ts convex/__tests__/teamExtraUsage.test.ts convex/__tests__/usageLogs.test.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts lib/__tests__/usage-tracker.test.ts lib/api/__tests__/chat-logger.test.ts
- ./node_modules/.bin/prettier --check convex/extraUsageActions.ts convex/teamExtraUsageActions.ts convex/usageLogs.ts convex/schema.ts lib/rate-limit/token-bucket.ts lib/rate-limit/index.ts lib/usage-tracker.ts lib/api/chat-handler.ts lib/api/chat-logger.ts lib/db/actions.ts trigger/agent-long.ts convex/__tests__/extraUsageActionsAuth.test.ts convex/__tests__/teamExtraUsage.test.ts convex/__tests__/usageLogs.test.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts lib/__tests__/usage-tracker.test.ts lib/api/__tests__/chat-logger.test.ts
- pre-commit hook after final follow-up: tsc --noEmit; jest (190 suites, 1946 tests)
- Remote after final push: GitHub test (20.x), Trigger.dev preview deployment, Vercel, Vercel Preview Comments, and CodeRabbit all passed

## Manual verification
- For an account with auto-reload enabled, set extra usage balance below the final deduction amount but with monthly cap available, then run an expensive Agent request. Auto-reload should charge enough to cover the deduction before the balance is deducted.
- For an account whose monthly extra-usage cap is already lower than the final deduction amount, run the same path. It should not attempt a card charge, should record uncovered usage, and the saved finish reason should be budget-exhausted unless the run already ended with a provider error.
- In PostHog, inspect hackerai-usage_cost for the run. cost_dollars should keep total observed cost, extra_usage_cost_dollars should only show paid extra usage, and uncovered_cost_dollars / uncovered_points should show the unbilled remainder when reconciliation fails.