### PR TITLE
Triage PostHog frontend error noise

### DIFF
--- a/app/components/ChunkLoadRecovery.tsx
+++ b/app/components/ChunkLoadRecovery.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect } from "react";
+
+const CHUNK_LOAD_RELOAD_STORAGE_KEY = "hackerai:chunk-load-reload-at";
+const CHUNK_LOAD_RELOAD_COOLDOWN_MS = 5 * 60 * 1_000;
+
+const CHUNK_LOAD_PATTERNS = [
+  /ChunkLoadError/i,
+  /Failed to load chunk/i,
+  /Loading chunk \d+ failed/i,
+  /error loading dynamically imported module/i,
+  /Importing a module script failed/i,
+];
+
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+function collectErrorStrings(value: unknown, strings: string[] = []): string[] {
+  if (typeof value === "string") {
+    strings.push(value);
+    return strings;
+  }
+
+  if (value instanceof Error) {
+    strings.push(value.name, value.message);
+    if (value.stack) strings.push(value.stack);
+    return strings;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectErrorStrings(item, strings);
+    }
+    return strings;
+  }
+
+  if (value && typeof value === "object") {
+    for (const nestedValue of Object.values(value)) {
+      collectErrorStrings(nestedValue, strings);
+    }
+  }
+
+  return strings;
+}
+
+export function isChunkLoadFailure(error: unknown): boolean {
+  const strings = collectErrorStrings(error);
+  return strings.some((value) =>
+    CHUNK_LOAD_PATTERNS.some((pattern) => pattern.test(value)),
+  );
+}
+
+export function maybeRecoverFromChunkLoadFailure(
+  error: unknown,
+  {
+    storage,
+    reload,
+    now = Date.now(),
+    cooldownMs = CHUNK_LOAD_RELOAD_COOLDOWN_MS,
+  }: {
+    storage: StorageLike;
+    reload: () => void;
+    now?: number;
+    cooldownMs?: number;
+  },
+): boolean {
+  if (!isChunkLoadFailure(error)) return false;
+
+  const storedReloadedAt = storage.getItem(CHUNK_LOAD_RELOAD_STORAGE_KEY);
+  const lastReloadedAt =
+    storedReloadedAt === null ? undefined : Number(storedReloadedAt);
+  if (
+    lastReloadedAt !== undefined &&
+    Number.isFinite(lastReloadedAt) &&
+    now - lastReloadedAt < cooldownMs
+  ) {
+    return false;
+  }
+
+  storage.setItem(CHUNK_LOAD_RELOAD_STORAGE_KEY, String(now));
+  reload();
+  return true;
+}
+
+export function ChunkLoadRecovery() {
+  useEffect(() => {
+    const recover = (error: unknown) => {
+      maybeRecoverFromChunkLoadFailure(error, {
+        storage: window.sessionStorage,
+        reload: () => window.location.reload(),
+      });
+    };
+
+    const onError = (event: ErrorEvent) => {
+      recover(event.error ?? event.message);
+    };
+
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      recover(event.reason);
+    };
+
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onUnhandledRejection);
+
+    return () => {
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onUnhandledRejection);
+    };
+  }, []);
+
+  return null;
+}

--- a/app/components/ChunkLoadRecovery.tsx
+++ b/app/components/ChunkLoadRecovery.tsx
@@ -11,32 +11,43 @@ const CHUNK_LOAD_PATTERNS = [
   /Loading chunk \d+ failed/i,
   /error loading dynamically imported module/i,
   /Importing a module script failed/i,
+  /Failed to fetch dynamically imported module/i,
 ];
 
 type StorageLike = Pick<Storage, "getItem" | "setItem">;
 
-function collectErrorStrings(value: unknown, strings: string[] = []): string[] {
+function collectErrorStrings(
+  value: unknown,
+  strings: string[] = [],
+  seen: WeakSet<object> = new WeakSet(),
+): string[] {
   if (typeof value === "string") {
     strings.push(value);
     return strings;
   }
 
   if (value instanceof Error) {
+    if (seen.has(value)) return strings;
+    seen.add(value);
     strings.push(value.name, value.message);
     if (value.stack) strings.push(value.stack);
     return strings;
   }
 
   if (Array.isArray(value)) {
+    if (seen.has(value)) return strings;
+    seen.add(value);
     for (const item of value) {
-      collectErrorStrings(item, strings);
+      collectErrorStrings(item, strings, seen);
     }
     return strings;
   }
 
   if (value && typeof value === "object") {
+    if (seen.has(value)) return strings;
+    seen.add(value);
     for (const nestedValue of Object.values(value)) {
-      collectErrorStrings(nestedValue, strings);
+      collectErrorStrings(nestedValue, strings, seen);
     }
   }
 
@@ -66,18 +77,23 @@ export function maybeRecoverFromChunkLoadFailure(
 ): boolean {
   if (!isChunkLoadFailure(error)) return false;
 
-  const storedReloadedAt = storage.getItem(CHUNK_LOAD_RELOAD_STORAGE_KEY);
-  const lastReloadedAt =
-    storedReloadedAt === null ? undefined : Number(storedReloadedAt);
-  if (
-    lastReloadedAt !== undefined &&
-    Number.isFinite(lastReloadedAt) &&
-    now - lastReloadedAt < cooldownMs
-  ) {
-    return false;
+  try {
+    const storedReloadedAt = storage.getItem(CHUNK_LOAD_RELOAD_STORAGE_KEY);
+    const lastReloadedAt =
+      storedReloadedAt === null ? undefined : Number(storedReloadedAt);
+    if (
+      lastReloadedAt !== undefined &&
+      Number.isFinite(lastReloadedAt) &&
+      now - lastReloadedAt < cooldownMs
+    ) {
+      return false;
+    }
+
+    storage.setItem(CHUNK_LOAD_RELOAD_STORAGE_KEY, String(now));
+  } catch {
+    // Storage can be unavailable in restricted browser modes; still recover.
   }
 
-  storage.setItem(CHUNK_LOAD_RELOAD_STORAGE_KEY, String(now));
   reload();
   return true;
 }
@@ -99,11 +115,11 @@ export function ChunkLoadRecovery() {
       recover(event.reason);
     };
 
-    window.addEventListener("error", onError);
+    window.addEventListener("error", onError, true);
     window.addEventListener("unhandledrejection", onUnhandledRejection);
 
     return () => {
-      window.removeEventListener("error", onError);
+      window.removeEventListener("error", onError, true);
       window.removeEventListener("unhandledrejection", onUnhandledRejection);
     };
   }, []);

--- a/app/components/__tests__/ChunkLoadRecovery.test.ts
+++ b/app/components/__tests__/ChunkLoadRecovery.test.ts
@@ -1,0 +1,72 @@
+import {
+  isChunkLoadFailure,
+  maybeRecoverFromChunkLoadFailure,
+} from "../ChunkLoadRecovery";
+
+function createStorage(initial: Record<string, string> = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: jest.fn((key: string) => values.get(key) ?? null),
+    setItem: jest.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+  };
+}
+
+describe("ChunkLoadRecovery", () => {
+  it("detects stale Next chunk load failures", () => {
+    expect(
+      isChunkLoadFailure(
+        new Error(
+          "Failed to load chunk /_next/static/chunks/example.js from module 1",
+        ),
+      ),
+    ).toBe(true);
+
+    expect(
+      isChunkLoadFailure({
+        name: "ChunkLoadError",
+        message: "Loading chunk 123 failed.",
+      }),
+    ).toBe(true);
+
+    expect(isChunkLoadFailure(new Error("Failed to fetch"))).toBe(false);
+  });
+
+  it("reloads once for chunk load failures and records the attempt", () => {
+    const storage = createStorage();
+    const reload = jest.fn();
+
+    expect(
+      maybeRecoverFromChunkLoadFailure(new Error("ChunkLoadError"), {
+        storage,
+        reload,
+        now: 1_000,
+      }),
+    ).toBe(true);
+
+    expect(storage.setItem).toHaveBeenCalledWith(
+      "hackerai:chunk-load-reload-at",
+      "1000",
+    );
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload repeatedly inside the cooldown window", () => {
+    const storage = createStorage({
+      "hackerai:chunk-load-reload-at": "1000",
+    });
+    const reload = jest.fn();
+
+    expect(
+      maybeRecoverFromChunkLoadFailure(new Error("ChunkLoadError"), {
+        storage,
+        reload,
+        now: 2_000,
+        cooldownMs: 5_000,
+      }),
+    ).toBe(false);
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/__tests__/ChunkLoadRecovery.test.ts
+++ b/app/components/__tests__/ChunkLoadRecovery.test.ts
@@ -1,4 +1,7 @@
+import { render } from "@testing-library/react";
+import { createElement } from "react";
 import {
+  ChunkLoadRecovery,
   isChunkLoadFailure,
   maybeRecoverFromChunkLoadFailure,
 } from "../ChunkLoadRecovery";
@@ -30,7 +33,22 @@ describe("ChunkLoadRecovery", () => {
       }),
     ).toBe(true);
 
+    expect(
+      isChunkLoadFailure(
+        "Failed to fetch dynamically imported module: https://example.com/chunk.js",
+      ),
+    ).toBe(true);
+
     expect(isChunkLoadFailure(new Error("Failed to fetch"))).toBe(false);
+  });
+
+  it("handles cyclic rejection payloads while checking chunk load failures", () => {
+    const reason: { message: string; self?: unknown } = {
+      message: "ChunkLoadError",
+    };
+    reason.self = reason;
+
+    expect(isChunkLoadFailure(reason)).toBe(true);
   });
 
   it("reloads once for chunk load failures and records the attempt", () => {
@@ -68,5 +86,48 @@ describe("ChunkLoadRecovery", () => {
     ).toBe(false);
 
     expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("still reloads when storage is unavailable", () => {
+    const storage = {
+      getItem: jest.fn(() => {
+        throw new Error("Storage disabled");
+      }),
+      setItem: jest.fn(),
+    };
+    const reload = jest.fn();
+
+    expect(
+      maybeRecoverFromChunkLoadFailure(new Error("ChunkLoadError"), {
+        storage,
+        reload,
+      }),
+    ).toBe(true);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers the global error listener in capture mode", () => {
+    const addEventListener = jest.spyOn(window, "addEventListener");
+    const removeEventListener = jest.spyOn(window, "removeEventListener");
+
+    const { unmount } = render(createElement(ChunkLoadRecovery));
+
+    expect(addEventListener).toHaveBeenCalledWith(
+      "error",
+      expect.any(Function),
+      true,
+    );
+
+    unmount();
+
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "error",
+      expect.any(Function),
+      true,
+    );
+
+    addEventListener.mockRestore();
+    removeEventListener.mockRestore();
   });
 });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import { ConvexClientProvider } from "@/components/ConvexClientProvider";
 import { TodoBlockProvider } from "./contexts/TodoBlockContext";
 import { PostHogProvider } from "./providers";
 import { DataStreamProvider } from "./components/DataStreamProvider";
+import { ChunkLoadRecovery } from "./components/ChunkLoadRecovery";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -96,6 +97,7 @@ export default function RootLayout({
   const content = (
     <GlobalStateProvider>
       <PostHogProvider>
+        <ChunkLoadRecovery />
         <DataStreamProvider>
           <TodoBlockProvider>
             <TooltipProvider>

--- a/lib/actions/__tests__/billing-portal.test.ts
+++ b/lib/actions/__tests__/billing-portal.test.ts
@@ -77,4 +77,63 @@ describe("redirectToBillingPortal", () => {
       }),
     );
   });
+
+  it("does not log expected billing context failures", async () => {
+    const error = new Error("Only admins or owners can manage billing");
+    mockGetBillingActionContext.mockRejectedValue(error as never);
+
+    const { default: redirectToBillingPortal } =
+      await import("../billing-portal");
+
+    await expect(redirectToBillingPortal()).rejects.toThrow(
+      "Only admins or owners can manage billing",
+    );
+
+    expect(mockCreateBillingPortalSession).not.toHaveBeenCalled();
+    expect(mockPostHogError).not.toHaveBeenCalled();
+  });
+
+  it("logs unexpected billing context failures", async () => {
+    const error = new Error("Failed to fetch organization details");
+    mockGetBillingActionContext.mockRejectedValue(error as never);
+
+    const { default: redirectToBillingPortal } =
+      await import("../billing-portal");
+
+    await expect(redirectToBillingPortal()).rejects.toThrow(
+      "Failed to fetch organization details",
+    );
+
+    expect(mockPostHogError).toHaveBeenCalledWith(
+      "billing_portal_action_failed",
+      expect.objectContaining({
+        event: "billing_portal_action_failed",
+        stage: "billing_context",
+        error,
+      }),
+    );
+  });
+
+  it("logs the action stage when Stripe returns no portal URL", async () => {
+    mockCreateBillingPortalSession.mockResolvedValue({} as never);
+
+    const { default: redirectToBillingPortal } =
+      await import("../billing-portal");
+
+    await expect(redirectToBillingPortal()).rejects.toThrow(
+      "Failed to create billing portal session",
+    );
+
+    expect(mockPostHogError).toHaveBeenCalledWith(
+      "billing_portal_action_failed",
+      expect.objectContaining({
+        event: "billing_portal_action_failed",
+        stage: "missing_session_url",
+        userId: "user_123",
+        org_id: "org_123",
+        stripe_customer_id: "cus_123",
+        error: expect.any(Error),
+      }),
+    );
+  });
 });

--- a/lib/actions/__tests__/billing-portal.test.ts
+++ b/lib/actions/__tests__/billing-portal.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+
+const mockCreateBillingPortalSession = jest.fn();
+const mockGetBillingActionContext = jest.fn();
+const mockPostHogError = jest.fn();
+
+jest.mock("@/app/api/stripe", () => ({
+  stripe: {
+    billingPortal: {
+      sessions: {
+        create: mockCreateBillingPortalSession,
+      },
+    },
+  },
+}));
+
+jest.mock("@/lib/actions/billing-context", () => ({
+  getBillingActionContext: mockGetBillingActionContext,
+}));
+
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: {
+    error: mockPostHogError,
+  },
+}));
+
+describe("redirectToBillingPortal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_BASE_URL = "https://hackerai.co";
+    mockGetBillingActionContext.mockResolvedValue({
+      organizationId: "org_123",
+      user: { id: "user_123" },
+      stripeCustomerId: "cus_123",
+    } as never);
+  });
+
+  it("returns the Stripe billing portal URL", async () => {
+    mockCreateBillingPortalSession.mockResolvedValue({
+      url: "https://billing.stripe.com/session",
+    } as never);
+
+    const { default: redirectToBillingPortal } =
+      await import("../billing-portal");
+
+    await expect(redirectToBillingPortal()).resolves.toBe(
+      "https://billing.stripe.com/session",
+    );
+
+    expect(mockCreateBillingPortalSession).toHaveBeenCalledWith({
+      customer: "cus_123",
+      return_url: "https://hackerai.co",
+    });
+    expect(mockPostHogError).not.toHaveBeenCalled();
+  });
+
+  it("logs the action stage when Stripe session creation fails", async () => {
+    const error = new Error("Stripe unavailable");
+    mockCreateBillingPortalSession.mockRejectedValue(error as never);
+
+    const { default: redirectToBillingPortal } =
+      await import("../billing-portal");
+
+    await expect(redirectToBillingPortal()).rejects.toThrow(
+      "Stripe unavailable",
+    );
+
+    expect(mockPostHogError).toHaveBeenCalledWith(
+      "billing_portal_action_failed",
+      expect.objectContaining({
+        event: "billing_portal_action_failed",
+        stage: "stripe_session_create",
+        userId: "user_123",
+        org_id: "org_123",
+        stripe_customer_id: "cus_123",
+        error,
+      }),
+    );
+  });
+});

--- a/lib/actions/__tests__/cancel-subscription.test.ts
+++ b/lib/actions/__tests__/cancel-subscription.test.ts
@@ -12,6 +12,7 @@ const mockListSubscriptions = jest.fn();
 const mockUpdateSubscription = jest.fn();
 const mockGetBillingActionContext = jest.fn();
 const mockPostHogEvent = jest.fn();
+const mockPostHogError = jest.fn();
 
 jest.mock("@/app/api/stripe", () => ({
   stripe: {
@@ -32,7 +33,7 @@ jest.mock("@/lib/db/convex-client", () => ({
 
 jest.mock("@/lib/posthog/server", () => ({
   phLogger: {
-    error: jest.fn(),
+    error: mockPostHogError,
     warn: jest.fn(),
     event: mockPostHogEvent,
   },
@@ -172,6 +173,56 @@ describe("cancelSubscriptionAction", () => {
       2,
       PAID_FUNNEL_EVENTS.cancellationCompleted,
       expect.any(Object),
+    );
+  });
+
+  it("logs the action stage when Stripe cancellation update fails", async () => {
+    mockListSubscriptions.mockResolvedValue({
+      data: [
+        {
+          id: "sub_123",
+          status: "active",
+          cancel_at_period_end: false,
+          current_period_end: 1_782_444_800,
+          items: {
+            data: [
+              {
+                price: {
+                  id: "price_pro",
+                  lookup_key: "pro-monthly-plan",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } as never);
+    const error = new Error("Stripe unavailable");
+    mockUpdateSubscription.mockRejectedValue(error as never);
+
+    const { default: cancelSubscriptionAction } =
+      await import("../cancel-subscription");
+
+    await expect(
+      cancelSubscriptionAction({
+        cancellationReason: {
+          reasonCategory: "other",
+          reasonDetails: "Done for now",
+        },
+      }),
+    ).rejects.toThrow("Stripe unavailable");
+
+    expect(mockPostHogError).toHaveBeenCalledWith(
+      "billing_subscription_cancellation_action_failed",
+      expect.objectContaining({
+        event: "billing_subscription_cancellation_action_failed",
+        stage: "stripe_subscription_update",
+        userId: "user_123",
+        org_id: "org_123",
+        stripe_customer_id: "cus_123",
+        stripe_subscription_id: "sub_123",
+        error,
+      }),
     );
   });
 });

--- a/lib/actions/__tests__/cancel-subscription.test.ts
+++ b/lib/actions/__tests__/cancel-subscription.test.ts
@@ -225,4 +225,83 @@ describe("cancelSubscriptionAction", () => {
       }),
     );
   });
+
+  it("does not log expected billing context failures", async () => {
+    const error = new Error("User not authenticated");
+    mockGetBillingActionContext.mockRejectedValue(error as never);
+
+    const { default: cancelSubscriptionAction } =
+      await import("../cancel-subscription");
+
+    await expect(
+      cancelSubscriptionAction({
+        cancellationReason: {
+          reasonCategory: "other",
+          reasonDetails: "Done for now",
+        },
+      }),
+    ).rejects.toThrow("User not authenticated");
+
+    expect(mockListSubscriptions).not.toHaveBeenCalled();
+    expect(mockPostHogError).not.toHaveBeenCalled();
+  });
+
+  it("does not log when there is no active subscription to cancel", async () => {
+    mockListSubscriptions.mockResolvedValue({
+      data: [
+        {
+          id: "sub_canceled",
+          status: "canceled",
+          cancel_at_period_end: false,
+          items: { data: [] },
+        },
+      ],
+    } as never);
+
+    const { default: cancelSubscriptionAction } =
+      await import("../cancel-subscription");
+
+    await expect(
+      cancelSubscriptionAction({
+        cancellationReason: {
+          reasonCategory: "other",
+          reasonDetails: "Done for now",
+        },
+      }),
+    ).rejects.toThrow("No active subscription found");
+
+    expect(mockPostHogError).not.toHaveBeenCalledWith(
+      "billing_subscription_cancellation_action_failed",
+      expect.anything(),
+    );
+  });
+
+  it("logs the action stage when Stripe subscription lookup fails", async () => {
+    const error = new Error("Stripe unavailable");
+    mockListSubscriptions.mockRejectedValue(error as never);
+
+    const { default: cancelSubscriptionAction } =
+      await import("../cancel-subscription");
+
+    await expect(
+      cancelSubscriptionAction({
+        cancellationReason: {
+          reasonCategory: "other",
+          reasonDetails: "Done for now",
+        },
+      }),
+    ).rejects.toThrow("Stripe unavailable");
+
+    expect(mockPostHogError).toHaveBeenCalledWith(
+      "billing_subscription_cancellation_action_failed",
+      expect.objectContaining({
+        event: "billing_subscription_cancellation_action_failed",
+        stage: "stripe_subscription_lookup",
+        userId: "user_123",
+        org_id: "org_123",
+        stripe_customer_id: "cus_123",
+        error,
+      }),
+    );
+  });
 });

--- a/lib/actions/__tests__/subscription-status.test.ts
+++ b/lib/actions/__tests__/subscription-status.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, jest, beforeEach } from "@jest/globals";
 
 const mockListSubscriptions = jest.fn();
 const mockGetBillingActionContext = jest.fn();
+const mockPostHogError = jest.fn();
 
 jest.mock("@/app/api/stripe", () => ({
   stripe: {
@@ -15,10 +16,18 @@ jest.mock("@/lib/actions/billing-context", () => ({
   getBillingActionContext: mockGetBillingActionContext,
 }));
 
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: {
+    error: mockPostHogError,
+  },
+}));
+
 describe("getSubscriptionCancellationStatusAction", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetBillingActionContext.mockResolvedValue({
+      organizationId: "org_123",
+      user: { id: "user_123" },
       stripeCustomerId: "cus_123",
     } as never);
   });
@@ -68,5 +77,29 @@ describe("getSubscriptionCancellationStatusAction", () => {
       hasActiveSubscription: false,
       cancelAtPeriodEnd: false,
     });
+  });
+
+  it("logs the action stage when Stripe subscription lookup fails", async () => {
+    const error = new Error("Stripe unavailable");
+    mockListSubscriptions.mockRejectedValue(error as never);
+
+    const { default: getSubscriptionCancellationStatusAction } =
+      await import("../subscription-status");
+
+    await expect(getSubscriptionCancellationStatusAction()).rejects.toThrow(
+      "Stripe unavailable",
+    );
+
+    expect(mockPostHogError).toHaveBeenCalledWith(
+      "billing_subscription_status_action_failed",
+      expect.objectContaining({
+        event: "billing_subscription_status_action_failed",
+        stage: "stripe_subscription_list",
+        userId: "user_123",
+        org_id: "org_123",
+        stripe_customer_id: "cus_123",
+        error,
+      }),
+    );
   });
 });

--- a/lib/actions/__tests__/subscription-status.test.ts
+++ b/lib/actions/__tests__/subscription-status.test.ts
@@ -102,4 +102,40 @@ describe("getSubscriptionCancellationStatusAction", () => {
       }),
     );
   });
+
+  it("does not log expected billing context failures", async () => {
+    const error = new Error("No billing account found for this organization");
+    mockGetBillingActionContext.mockRejectedValue(error as never);
+
+    const { default: getSubscriptionCancellationStatusAction } =
+      await import("../subscription-status");
+
+    await expect(getSubscriptionCancellationStatusAction()).rejects.toThrow(
+      "No billing account found for this organization",
+    );
+
+    expect(mockListSubscriptions).not.toHaveBeenCalled();
+    expect(mockPostHogError).not.toHaveBeenCalled();
+  });
+
+  it("logs unexpected billing context failures", async () => {
+    const error = new Error("Failed to fetch organization details");
+    mockGetBillingActionContext.mockRejectedValue(error as never);
+
+    const { default: getSubscriptionCancellationStatusAction } =
+      await import("../subscription-status");
+
+    await expect(getSubscriptionCancellationStatusAction()).rejects.toThrow(
+      "Failed to fetch organization details",
+    );
+
+    expect(mockPostHogError).toHaveBeenCalledWith(
+      "billing_subscription_status_action_failed",
+      expect.objectContaining({
+        event: "billing_subscription_status_action_failed",
+        stage: "billing_context",
+        error,
+      }),
+    );
+  });
 });

--- a/lib/actions/billing-action-errors.ts
+++ b/lib/actions/billing-action-errors.ts
@@ -1,0 +1,32 @@
+const EXPECTED_BILLING_CONTEXT_ERROR_MESSAGES = new Set([
+  "User not authenticated",
+  "No organization found",
+  "User is not a member of this organization",
+  "Only admins or owners can manage billing",
+  "No billing account found for this organization",
+]);
+
+const EXPECTED_SUBSCRIPTION_LOOKUP_ERROR_MESSAGES = new Set([
+  "No active subscription found",
+]);
+
+function hasExpectedErrorMessage(
+  error: unknown,
+  messages: Set<string>,
+): boolean {
+  return error instanceof Error && messages.has(error.message);
+}
+
+export function isExpectedBillingContextError(error: unknown): boolean {
+  return hasExpectedErrorMessage(
+    error,
+    EXPECTED_BILLING_CONTEXT_ERROR_MESSAGES,
+  );
+}
+
+export function isExpectedSubscriptionLookupError(error: unknown): boolean {
+  return hasExpectedErrorMessage(
+    error,
+    EXPECTED_SUBSCRIPTION_LOOKUP_ERROR_MESSAGES,
+  );
+}

--- a/lib/actions/billing-portal.ts
+++ b/lib/actions/billing-portal.ts
@@ -2,18 +2,56 @@
 
 import { stripe } from "../../app/api/stripe";
 import { getBillingActionContext } from "@/lib/actions/billing-context";
+import { phLogger } from "@/lib/posthog/server";
 
 export default async function redirectToBillingPortal() {
-  const { stripeCustomerId } = await getBillingActionContext();
+  const startedAt = Date.now();
+  const context = await getBillingActionContext().catch((error) => {
+    phLogger.error("billing_portal_action_failed", {
+      event: "billing_portal_action_failed",
+      stage: "billing_context",
+      duration_ms: Date.now() - startedAt,
+      error,
+    });
+    throw error;
+  });
+  const stripeCustomerId = context.stripeCustomerId;
+  const billingFields = {
+    userId: context.user.id,
+    org_id: context.organizationId,
+    stripe_customer_id: stripeCustomerId,
+  };
 
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
-  const billingPortalSession = await stripe.billingPortal.sessions.create({
-    customer: stripeCustomerId,
-    return_url: `${baseUrl}`,
-  });
+  let billingPortalSession:
+    | Awaited<ReturnType<typeof stripe.billingPortal.sessions.create>>
+    | undefined;
+  try {
+    billingPortalSession = await stripe.billingPortal.sessions.create({
+      customer: stripeCustomerId,
+      return_url: `${baseUrl}`,
+    });
+  } catch (error) {
+    phLogger.error("billing_portal_action_failed", {
+      event: "billing_portal_action_failed",
+      ...billingFields,
+      stage: "stripe_session_create",
+      duration_ms: Date.now() - startedAt,
+      error,
+    });
+    throw error;
+  }
 
   if (!billingPortalSession?.url) {
-    throw new Error("Failed to create billing portal session");
+    const error = new Error("Failed to create billing portal session");
+    phLogger.error("billing_portal_action_failed", {
+      event: "billing_portal_action_failed",
+      ...billingFields,
+      stage: "missing_session_url",
+      duration_ms: Date.now() - startedAt,
+      error,
+    });
+    throw error;
   }
   return billingPortalSession.url;
 }

--- a/lib/actions/billing-portal.ts
+++ b/lib/actions/billing-portal.ts
@@ -1,12 +1,17 @@
 "use server";
 
 import { stripe } from "../../app/api/stripe";
+import { isExpectedBillingContextError } from "@/lib/actions/billing-action-errors";
 import { getBillingActionContext } from "@/lib/actions/billing-context";
 import { phLogger } from "@/lib/posthog/server";
 
 export default async function redirectToBillingPortal() {
   const startedAt = Date.now();
   const context = await getBillingActionContext().catch((error) => {
+    if (isExpectedBillingContextError(error)) {
+      throw error;
+    }
+
     phLogger.error("billing_portal_action_failed", {
       event: "billing_portal_action_failed",
       stage: "billing_context",

--- a/lib/actions/cancel-subscription.ts
+++ b/lib/actions/cancel-subscription.ts
@@ -130,10 +130,36 @@ export default async function cancelSubscriptionAction(
   const cancellationReason = parseCancellationReasonInput(
     input.cancellationReason,
   );
-  const { organizationId, user, stripeCustomerId } =
-    await getBillingActionContext();
-  const subscriptionContext =
-    await getActiveSubscriptionContext(stripeCustomerId);
+  const startedAt = Date.now();
+  const context = await getBillingActionContext().catch((error) => {
+    phLogger.error("billing_subscription_cancellation_action_failed", {
+      event: "billing_subscription_cancellation_action_failed",
+      stage: "billing_context",
+      duration_ms: Date.now() - startedAt,
+      error,
+    });
+    throw error;
+  });
+  const { organizationId, user, stripeCustomerId } = context;
+  const billingFields = {
+    userId: user.id,
+    org_id: organizationId,
+    stripe_customer_id: stripeCustomerId,
+  };
+
+  let subscriptionContext: SubscriptionContext;
+  try {
+    subscriptionContext = await getActiveSubscriptionContext(stripeCustomerId);
+  } catch (error) {
+    phLogger.error("billing_subscription_cancellation_action_failed", {
+      event: "billing_subscription_cancellation_action_failed",
+      ...billingFields,
+      stage: "stripe_subscription_lookup",
+      duration_ms: Date.now() - startedAt,
+      error,
+    });
+    throw error;
+  }
 
   if (subscriptionContext.cancelAtPeriodEnd) {
     return {
@@ -191,15 +217,32 @@ export default async function cancelSubscriptionAction(
     });
   }
 
-  const updatedSubscription = await stripe.subscriptions.update(
-    subscriptionContext.id,
-    {
-      cancel_at_period_end: true,
-      cancellation_details: {
-        feedback: stripeCancellationFeedback(cancellationReason.reasonCategory),
+  let updatedSubscription: Awaited<
+    ReturnType<typeof stripe.subscriptions.update>
+  >;
+  try {
+    updatedSubscription = await stripe.subscriptions.update(
+      subscriptionContext.id,
+      {
+        cancel_at_period_end: true,
+        cancellation_details: {
+          feedback: stripeCancellationFeedback(
+            cancellationReason.reasonCategory,
+          ),
+        },
       },
-    },
-  );
+    );
+  } catch (error) {
+    phLogger.error("billing_subscription_cancellation_action_failed", {
+      event: "billing_subscription_cancellation_action_failed",
+      ...billingFields,
+      stage: "stripe_subscription_update",
+      stripe_subscription_id: subscriptionContext.id,
+      duration_ms: Date.now() - startedAt,
+      error,
+    });
+    throw error;
+  }
 
   const completedAt = updatedSubscription.canceled_at
     ? updatedSubscription.canceled_at * 1000

--- a/lib/actions/cancel-subscription.ts
+++ b/lib/actions/cancel-subscription.ts
@@ -2,6 +2,10 @@
 
 import { stripe } from "../../app/api/stripe";
 import { api } from "@/convex/_generated/api";
+import {
+  isExpectedBillingContextError,
+  isExpectedSubscriptionLookupError,
+} from "@/lib/actions/billing-action-errors";
 import { getBillingActionContext } from "@/lib/actions/billing-context";
 import {
   isCancellationReasonCategory,
@@ -132,6 +136,10 @@ export default async function cancelSubscriptionAction(
   );
   const startedAt = Date.now();
   const context = await getBillingActionContext().catch((error) => {
+    if (isExpectedBillingContextError(error)) {
+      throw error;
+    }
+
     phLogger.error("billing_subscription_cancellation_action_failed", {
       event: "billing_subscription_cancellation_action_failed",
       stage: "billing_context",
@@ -151,6 +159,10 @@ export default async function cancelSubscriptionAction(
   try {
     subscriptionContext = await getActiveSubscriptionContext(stripeCustomerId);
   } catch (error) {
+    if (isExpectedSubscriptionLookupError(error)) {
+      throw error;
+    }
+
     phLogger.error("billing_subscription_cancellation_action_failed", {
       event: "billing_subscription_cancellation_action_failed",
       ...billingFields,

--- a/lib/actions/subscription-status.ts
+++ b/lib/actions/subscription-status.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { stripe } from "../../app/api/stripe";
+import { isExpectedBillingContextError } from "@/lib/actions/billing-action-errors";
 import { getBillingActionContext } from "@/lib/actions/billing-context";
 import { phLogger } from "@/lib/posthog/server";
 
@@ -23,6 +24,10 @@ function currentPeriodEndMs(subscription: unknown): number | undefined {
 export default async function getSubscriptionCancellationStatusAction(): Promise<SubscriptionCancellationStatus> {
   const startedAt = Date.now();
   const context = await getBillingActionContext().catch((error) => {
+    if (isExpectedBillingContextError(error)) {
+      throw error;
+    }
+
     phLogger.error("billing_subscription_status_action_failed", {
       event: "billing_subscription_status_action_failed",
       stage: "billing_context",

--- a/lib/actions/subscription-status.ts
+++ b/lib/actions/subscription-status.ts
@@ -2,6 +2,7 @@
 
 import { stripe } from "../../app/api/stripe";
 import { getBillingActionContext } from "@/lib/actions/billing-context";
+import { phLogger } from "@/lib/posthog/server";
 
 export type SubscriptionCancellationStatus = {
   hasActiveSubscription: boolean;
@@ -20,12 +21,40 @@ function currentPeriodEndMs(subscription: unknown): number | undefined {
 }
 
 export default async function getSubscriptionCancellationStatusAction(): Promise<SubscriptionCancellationStatus> {
-  const { stripeCustomerId } = await getBillingActionContext();
-  const subscriptions = await stripe.subscriptions.list({
-    customer: stripeCustomerId,
-    status: "all",
-    limit: 10,
+  const startedAt = Date.now();
+  const context = await getBillingActionContext().catch((error) => {
+    phLogger.error("billing_subscription_status_action_failed", {
+      event: "billing_subscription_status_action_failed",
+      stage: "billing_context",
+      duration_ms: Date.now() - startedAt,
+      error,
+    });
+    throw error;
   });
+  const stripeCustomerId = context.stripeCustomerId;
+  const billingFields = {
+    userId: context.user.id,
+    org_id: context.organizationId,
+    stripe_customer_id: stripeCustomerId,
+  };
+
+  let subscriptions: Awaited<ReturnType<typeof stripe.subscriptions.list>>;
+  try {
+    subscriptions = await stripe.subscriptions.list({
+      customer: stripeCustomerId,
+      status: "all",
+      limit: 10,
+    });
+  } catch (error) {
+    phLogger.error("billing_subscription_status_action_failed", {
+      event: "billing_subscription_status_action_failed",
+      ...billingFields,
+      stage: "stripe_subscription_list",
+      duration_ms: Date.now() - startedAt,
+      error,
+    });
+    throw error;
+  }
   const currentSubscription = subscriptions.data.find((subscription) =>
     ["active", "trialing", "past_due", "unpaid"].includes(subscription.status),
   );

--- a/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
+++ b/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
@@ -71,25 +71,12 @@ describe("shouldDropExpectedFrontendException", () => {
     }
   });
 
-  it("drops manual chat stop aborts only when the stack is app-owned", () => {
+  it("drops exact manual chat stop aborts", () => {
     expect(
       shouldDropExpectedFrontendException({
         event: "$exception",
         properties: {
           $exception_values: ["AbortError: Fetch is aborted"],
-          $exception_list: [
-            {
-              stacktrace: {
-                frames: [
-                  {
-                    source:
-                      "turbopack:///[project]/app/hooks/useChatHandlers.ts",
-                    resolved_name: "handleStop",
-                  },
-                ],
-              },
-            },
-          ],
         },
       }),
     ).toBe(true);
@@ -98,10 +85,44 @@ describe("shouldDropExpectedFrontendException", () => {
       shouldDropExpectedFrontendException({
         event: "$exception",
         properties: {
-          $exception_values: ["AbortError: Fetch is aborted"],
+          $exception_values: ["AbortError: The user aborted a request."],
         },
       }),
     ).toBe(false);
+  });
+
+  it("drops exact React DOM mutation noise", () => {
+    for (const value of [
+      "NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
+      "NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+    ]) {
+      expect(
+        shouldDropExpectedFrontendException({
+          event: "$exception",
+          properties: {
+            $exception_types: ["DOMException"],
+            $exception_values: [value],
+          },
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("drops exact opaque synthetic browser exceptions", () => {
+    for (const value of [
+      "Event captured as exception with keys: isTrusted",
+      "'Error' captured as exception with message: 'Aa'",
+      "'TypeError' captured as exception with message: 'undefined is not an object (evaluating 'a.J')'",
+    ]) {
+      expect(
+        shouldDropExpectedFrontendException({
+          event: "$exception",
+          properties: {
+            $exception_values: [value],
+          },
+        }),
+      ).toBe(true);
+    }
   });
 
   it("drops expected auth refresh failures only with auth stack sources", () => {
@@ -217,7 +238,7 @@ describe("shouldDropExpectedFrontendException", () => {
     ).toBe(false);
   });
 
-  it("drops Trigger stream double-close noise only with Trigger stream frames", () => {
+  it("drops exact Trigger stream double-close noise", () => {
     for (const value of [
       "Failed to execute 'close' on 'ReadableStreamDefaultController': Cannot close an errored readable stream",
       "Failed to execute 'close' on 'ReadableStreamDefaultController': ReadableStreamDefaultController is not in a state where it can be closed",
@@ -244,15 +265,6 @@ describe("shouldDropExpectedFrontendException", () => {
           },
         }),
       ).toBe(true);
-
-      expect(
-        shouldDropExpectedFrontendException({
-          event: "$exception",
-          properties: {
-            $exception_values: [value],
-          },
-        }),
-      ).toBe(false);
     }
   });
 });

--- a/lib/posthog/expected-frontend-exceptions.ts
+++ b/lib/posthog/expected-frontend-exceptions.ts
@@ -10,6 +10,21 @@ const RESIZE_OBSERVER_MESSAGES = new Set([
   "ResizeObserver loop limit exceeded",
 ]);
 
+const MANUAL_CHAT_STOP_ABORT_MESSAGES = new Set([
+  "AbortError: Fetch is aborted",
+]);
+
+const REACT_DOM_MUTATION_MESSAGES = new Set([
+  "NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
+  "NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+]);
+
+const OPAQUE_SYNTHETIC_MESSAGES = new Set([
+  "Event captured as exception with keys: isTrusted",
+  "'Error' captured as exception with message: 'Aa'",
+  "'TypeError' captured as exception with message: 'undefined is not an object (evaluating 'a.J')'",
+]);
+
 const TRIGGER_STREAM_CLOSE_MESSAGE_FRAGMENTS = [
   "Failed to execute 'close' on 'ReadableStreamDefaultController': Cannot close an errored readable stream",
   "ReadableStreamDefaultController is not in a state where it can be closed",
@@ -46,6 +61,11 @@ const includesAny = (strings: string[], fragments: string[]): boolean =>
 const hasExactString = (strings: string[], expected: string): boolean =>
   strings.some((value) => value === expected);
 
+const hasExactStringFrom = (
+  strings: string[],
+  expected: Set<string>,
+): boolean => strings.some((value) => expected.has(value));
+
 const hasResizeObserverMessage = (strings: string[]): boolean =>
   strings.some((value) => RESIZE_OBSERVER_MESSAGES.has(value));
 
@@ -58,10 +78,6 @@ type ExpectedFrontendPattern = {
 };
 
 const EXPECTED_FRONTEND_PATTERNS: ExpectedFrontendPattern[] = [
-  {
-    message: "AbortError: Fetch is aborted",
-    sourceFragments: ["app/hooks/useChatHandlers.ts"],
-  },
   {
     message: "Failed to refresh access token",
     sourceFragments: [
@@ -89,11 +105,7 @@ const matchesExpectedFrontendPattern = (strings: string[]): boolean =>
   );
 
 const matchesTriggerStreamClosePattern = (strings: string[]): boolean =>
-  hasTriggerStreamCloseMessage(strings) &&
-  includesAny(strings, [
-    "@trigger.dev/core/src/v3/streams/asyncIterableStream.ts",
-    "@trigger.dev+core",
-  ]);
+  hasTriggerStreamCloseMessage(strings);
 
 export function shouldDropExpectedFrontendException(event: PostHogEventLike) {
   if (event.event !== "$exception") {
@@ -108,6 +120,9 @@ export function shouldDropExpectedFrontendException(event: PostHogEventLike) {
 
   return (
     hasResizeObserverMessage(strings) ||
+    hasExactStringFrom(strings, MANUAL_CHAT_STOP_ABORT_MESSAGES) ||
+    hasExactStringFrom(strings, REACT_DOM_MUTATION_MESSAGES) ||
+    hasExactStringFrom(strings, OPAQUE_SYNTHETIC_MESSAGES) ||
     matchesExpectedFrontendPattern(strings) ||
     matchesTriggerStreamClosePattern(strings)
   );


### PR DESCRIPTION
## Summary
- add a one-time chunk-load recovery listener so stale Next chunks reload instead of leaving users stuck
- tighten frontend Error Tracking filtering for exact expected abort, Trigger stream-close, React DOM mutation, and opaque synthetic browser noise
- add structured failure-stage logging around billing server actions that currently surface as generic `fetchServerAction` browser errors

## Notes
- intentionally does not handle the xAI inline-file preflight in this PR
- generic network/server-action failures stay visible in Error Tracking; the new billing logs add backend context instead of suppressing those browser errors

## Testing
- `./node_modules/.bin/jest lib/posthog/__tests__/expected-frontend-exceptions.test.ts app/components/__tests__/ChunkLoadRecovery.test.ts lib/actions/__tests__/billing-portal.test.ts lib/actions/__tests__/subscription-status.test.ts lib/actions/__tests__/cancel-subscription.test.ts --runInBand`
- `./node_modules/.bin/prettier --check lib/posthog/expected-frontend-exceptions.ts lib/posthog/__tests__/expected-frontend-exceptions.test.ts app/components/ChunkLoadRecovery.tsx app/components/__tests__/ChunkLoadRecovery.test.ts app/layout.tsx lib/actions/billing-portal.ts lib/actions/subscription-status.ts lib/actions/cancel-subscription.ts lib/actions/__tests__/billing-portal.test.ts lib/actions/__tests__/subscription-status.test.ts lib/actions/__tests__/cancel-subscription.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint app lib types __mocks__ --ext .ts,.tsx,.js,.jsx` (passes with existing warnings)
- commit hook: `tsc --noEmit`
- commit hook: full `jest` (192 suites, 1,942 tests)

## Manual verification
- Open an old deployed HackerAI tab after a fresh deployment and navigate until a stale chunk fails. The app should reload once and then stop retrying for the cooldown window.
- Trigger billing portal or cancellation-status failures in a staging environment. PostHog logs should include `billing_portal_action_failed` or `billing_subscription_status_action_failed` with a `stage`, `duration_ms`, and available user/org/customer IDs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for certain app-loading failures by refreshing the page when a broken load is detected.

* **Bug Fixes**
  * Improved billing and subscription error handling so failures are reported more reliably and with better context.
  * Expanded frontend error filtering to ignore more expected browser noise and reduce false error reports.

* **Tests**
  * Added coverage for the new recovery behavior and billing/subscription failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->