### PR TITLE
Prioritize paid Agent Trigger runs

### DIFF
--- a/app/api/agent-long/route.ts
+++ b/app/api/agent-long/route.ts
@@ -22,7 +22,12 @@ import {
   normalizeSelectedModelOverrideForSubscription,
 } from "@/types";
 import { ChatSDKError } from "@/lib/errors";
-import type { Todo, SandboxPreference, SelectedModel } from "@/types";
+import type {
+  Todo,
+  SandboxPreference,
+  SelectedModel,
+  SubscriptionTier,
+} from "@/types";
 import { resolveAgentRunSpendCapContinuationModel } from "@/lib/chat/agent-run-spend-cap";
 import { HybridSandboxManager } from "@/lib/ai/tools/utils/hybrid-sandbox-manager";
 import {
@@ -39,6 +44,20 @@ import {
 } from "@/lib/utils/sandbox-file-utils";
 
 export const maxDuration = 30;
+
+const AGENT_LONG_TRIGGER_PRIORITY_BY_SUBSCRIPTION: Record<
+  SubscriptionTier,
+  number
+> = {
+  free: 0,
+  pro: 5,
+  "pro-plus": 5,
+  ultra: 10,
+  team: 5,
+};
+
+const getAgentLongTriggerPriority = (subscription: SubscriptionTier) =>
+  AGENT_LONG_TRIGGER_PRIORITY_BY_SUBSCRIPTION[subscription];
 
 export async function POST(req: NextRequest) {
   const routeStartedAt = Date.now();
@@ -211,6 +230,7 @@ export async function POST(req: NextRequest) {
       temporary || localDesktopAttachmentsPrepared ? messagesForTrigger : [];
 
     const triggerRequestedAt = Date.now();
+    const triggerPriority = getAgentLongTriggerPriority(subscription);
     const handle = await tasks.trigger<typeof agentLongTask>(
       "agent-long",
       {
@@ -236,6 +256,7 @@ export async function POST(req: NextRequest) {
         },
       },
       {
+        ...(triggerPriority > 0 ? { priority: triggerPriority } : {}),
         tags: triggerTags,
         ...(triggerRegion ? { region: triggerRegion } : {}),
         metadata: {
@@ -246,6 +267,7 @@ export async function POST(req: NextRequest) {
           loginRequired: false,
           routeStartedAt,
           triggerRequestedAt,
+          triggerPriority,
           triggerPayloadMessageCount: messagesForPayload.length,
         },
       },

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -375,6 +375,21 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(routeSrc).toMatch(/loginRequired:\s*false/);
   });
 
+  test("runs use small subscription-aware Trigger.dev priority offsets", () => {
+    expect(routeSrc).toMatch(
+      /AGENT_LONG_TRIGGER_PRIORITY_BY_SUBSCRIPTION:\s*Record<\s*SubscriptionTier,\s*number\s*>/,
+    );
+    expect(routeSrc).toMatch(/free:\s*0/);
+    expect(routeSrc).toMatch(/pro:\s*5/);
+    expect(routeSrc).toMatch(/"pro-plus":\s*5/);
+    expect(routeSrc).toMatch(/ultra:\s*10/);
+    expect(routeSrc).toMatch(/team:\s*5/);
+    expect(routeSrc).toMatch(
+      /\.\.\.\(triggerPriority\s*>\s*0\s*\?\s*{\s*priority:\s*triggerPriority\s*}\s*:\s*{}\)/,
+    );
+    expect(routeSrc).toMatch(/triggerPriority/);
+  });
+
   test("persisted chats send a trimmed Trigger payload and retain attachment exceptions", () => {
     expect(routeSrc).toMatch(
       /const messagesForPayload\s*=\s*temporary\s*\|\|\s*localDesktopAttachmentsPrepared\s*\?\s*messagesForTrigger\s*:\s*\[\]/s,


### PR DESCRIPTION
## Summary
- add small subscription-aware Trigger.dev priority offsets for Agent runs
- keep free runs at no priority, Pro/Pro Plus/Team at 5s, and Ultra at 10s
- include the selected priority in Trigger metadata and cover the mapping in the Agent contract test

## Validation
- `./node_modules/.bin/jest lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `./node_modules/.bin/prettier --check app/api/agent-long/route.ts lib/api/__tests__/agent-long-contracts.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint app/api/agent-long/route.ts lib/api/__tests__/agent-long-contracts.test.ts`
- commit hook: `tsc --noEmit` and `jest` (190 suites / 1934 tests)

## Manual verification
- In a Trigger environment with queued Agent runs, start runs as free, Pro, Pro Plus, Team, and Ultra users.
- Confirm free runs have no Trigger priority, Pro/Pro Plus/Team runs use priority 5, and Ultra runs use priority 10.
- Confirm Trigger metadata shows `triggerPriority` and existing `taskStartLatencyMs` remains available for rollout monitoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription-based priority handling for agent-long requests, so higher tiers can receive faster trigger processing.
  * Priority details are now included in task metadata for better visibility.

* **Tests**
  * Added coverage to verify subscription priority levels and conditional priority behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->