### PR TITLE
Clarify auto-reload charge copy

### DIFF
--- a/app/components/extra-usage/AutoReloadDialog.tsx
+++ b/app/components/extra-usage/AutoReloadDialog.tsx
@@ -146,9 +146,11 @@ const AutoReloadDialogContent = ({
           </div>
         </div>
         <p className="text-sm text-muted-foreground">
-          You agree that HackerAI will charge the card you have on file in the
-          amount above on a recurring basis whenever your balance reaches the
-          amount indicated. To cancel, turn off auto-reload.
+          By turning this on, you agree that HackerAI may charge your card on
+          file when your extra usage balance is low. Auto-reload usually tops
+          your balance up to the amount above; if a request costs more, it may
+          charge enough to cover that request. Set a monthly spending limit to
+          cap auto-reload charges. To cancel, turn off auto-reload.
         </p>
       </div>
       <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end">

--- a/app/components/extra-usage/__tests__/AutoReloadDialog.test.tsx
+++ b/app/components/extra-usage/__tests__/AutoReloadDialog.test.tsx
@@ -1,0 +1,34 @@
+import "@testing-library/jest-dom";
+import { describe, expect, it, jest } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import { AutoReloadDialog } from "../AutoReloadDialog";
+
+describe("AutoReloadDialog", () => {
+  it("explains that oversized requests can charge beyond the reload target", () => {
+    render(
+      <AutoReloadDialog
+        open={true}
+        onOpenChange={jest.fn()}
+        onSave={jest.fn(async () => {})}
+        onTurnOff={jest.fn(async () => {})}
+        onCancel={jest.fn()}
+        isLoading={false}
+        isEnabled={false}
+        currentThresholdDollars={5}
+        currentAmountDollars={15}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Auto-reload usually tops your balance up/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/if a request costs more, it may charge enough/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Set a monthly spending limit to cap auto-reload charges/i,
+      ),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- update auto-reload consent copy so it no longer promises the charge is always the configured reload amount
- explain that larger requests can charge enough to cover the request and point users to monthly spending limits
- add a focused regression test for the new dialog copy

## Testing
- ./node_modules/.bin/jest app/components/extra-usage/__tests__/AutoReloadDialog.test.tsx --runInBand
- ./node_modules/.bin/eslint app/components/extra-usage/AutoReloadDialog.tsx app/components/extra-usage/__tests__/AutoReloadDialog.test.tsx
- ./node_modules/.bin/prettier --check app/components/extra-usage/AutoReloadDialog.tsx app/components/extra-usage/__tests__/AutoReloadDialog.test.tsx
- ./node_modules/.bin/tsc --noEmit

## Manual verification
- Open Settings -> Extra usage -> Auto-reload.
- Confirm the dialog says auto-reload usually tops up to the configured amount, but larger requests may charge enough to cover the request.
- Confirm it tells users to set a monthly spending limit to cap auto-reload charges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the auto-reload settings notice with clearer billing and cancellation guidance.
  * Clarified that oversized requests may incur charges beyond the reload target.
  * Added coverage to ensure the updated explanatory text appears correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->