### PR TITLE
Retry transient chat fetch failures

### DIFF
--- a/app/api/chat/[id]/stream/__tests__/route.test.ts
+++ b/app/api/chat/[id]/stream/__tests__/route.test.ts
@@ -25,6 +25,7 @@ jest.mock("@/lib/db/actions", () => ({
 jest.mock("@/lib/db/convex-client", () => ({
   getConvexClient: jest.fn(() => ({
     mutation: jest.fn(),
+    query: jest.fn(),
   })),
 }));
 

--- a/app/api/chat/[id]/stream/__tests__/route.test.ts
+++ b/app/api/chat/[id]/stream/__tests__/route.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { ChatSDKError } from "@/lib/errors";
+
+const mockGetUserID = jest.fn();
+const mockGetChatById = jest.fn();
+const mockAssertUserCanAccessChatHistory = jest.fn();
+
+jest.mock("ai", () => ({
+  createUIMessageStream: jest.fn(),
+  JsonToSseTransformStream: jest.fn(),
+}));
+
+jest.mock("@/lib/api/chat-handler", () => ({
+  getStreamContext: jest.fn(() => null),
+}));
+
+jest.mock("@/lib/auth/get-user-id", () => ({
+  getUserID: mockGetUserID,
+}));
+
+jest.mock("@/lib/db/actions", () => ({
+  getChatById: mockGetChatById,
+}));
+
+jest.mock("@/lib/db/convex-client", () => ({
+  getConvexClient: jest.fn(() => ({
+    mutation: jest.fn(),
+  })),
+}));
+
+jest.mock("@/convex/_generated/api", () => ({
+  api: {
+    chatStreams: {
+      prepareForNewStream: "prepareForNewStream",
+    },
+  },
+}));
+
+jest.mock("@/lib/utils/stream-cancellation", () => ({
+  createCancellationSubscriber: jest.fn(),
+  createPreemptiveTimeout: jest.fn(),
+}));
+
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: {
+    event: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/suspensions", () => ({
+  assertUserCanAccessChatHistory: mockAssertUserCanAccessChatHistory,
+}));
+
+const request = {} as any;
+const paramsFor = (id = "chat-1") => ({
+  params: Promise.resolve({ id }),
+});
+
+function installResponseShim() {
+  (globalThis as any).Response = {
+    json: (body: unknown, init?: ResponseInit) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+      text: async () =>
+        typeof body === "string" ? body : JSON.stringify(body ?? ""),
+    }),
+  };
+}
+
+describe("GET /api/chat/[id]/stream", () => {
+  let errorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    installResponseShim();
+    jest.clearAllMocks();
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockGetUserID.mockResolvedValue("user-1" as never);
+    mockAssertUserCanAccessChatHistory.mockResolvedValue(undefined as never);
+    mockGetChatById.mockResolvedValue({
+      id: "chat-1",
+      user_id: "user-1",
+    } as never);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("preserves transient database errors instead of returning chat not found", async () => {
+    const { GET } = await import("../route");
+    mockGetChatById.mockRejectedValue(
+      new ChatSDKError(
+        "offline:database",
+        "Database temporarily unavailable: chats.getChatById: fetch failed",
+      ) as never,
+    );
+
+    const response = await GET(request, paramsFor());
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toEqual({
+      code: "",
+      message: "Something went wrong. Please try again later.",
+    });
+  });
+
+  it("returns chat not found when the chat row is absent", async () => {
+    const { GET } = await import("../route");
+    mockGetChatById.mockResolvedValue(null as never);
+
+    const response = await GET(request, paramsFor());
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toMatchObject({
+      code: "not_found:chat",
+    });
+  });
+});

--- a/app/api/chat/[id]/stream/route.ts
+++ b/app/api/chat/[id]/stream/route.ts
@@ -3,6 +3,7 @@ import { createUIMessageStream, JsonToSseTransformStream } from "ai";
 import { ChatSDKError } from "@/lib/errors";
 import type { ChatMessage } from "@/types/chat";
 import { getStreamContext } from "@/lib/api/chat-handler";
+import { getChatById } from "@/lib/db/actions";
 import { getConvexClient } from "@/lib/db/convex-client";
 import { api } from "@/convex/_generated/api";
 import {
@@ -43,12 +44,10 @@ export async function GET(
   // Load chat and enforce ownership
   let chat: any | null = null;
   try {
-    chat = await getConvexClient().query(api.chats.getChatById, {
-      serviceKey,
-      id: chatId,
-    });
-  } catch {
-    return new ChatSDKError("not_found:chat").toResponse();
+    chat = await getChatById({ id: chatId });
+  } catch (error) {
+    if (error instanceof ChatSDKError) return error.toResponse();
+    throw error;
   }
 
   if (!chat) {

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -40,10 +40,16 @@ const loadSaveMessageWithMocks = async () => {
     compactMessageForStorage: mockCompactMessageForStorage,
   }));
 
-  const { deleteChatForBackend, getMessagesByChatId, saveChat, saveMessage } =
-    await import("../actions");
+  const {
+    deleteChatForBackend,
+    getChatById,
+    getMessagesByChatId,
+    saveChat,
+    saveMessage,
+  } = await import("../actions");
   return {
     deleteChatForBackend,
+    getChatById,
     getMessagesByChatId,
     mockCompactMessageForStorage,
     mockMutation,
@@ -121,9 +127,9 @@ describe("saveChat", () => {
       }).catch((error) => error);
 
       expect(thrown).toMatchObject({
-        type: "bad_request",
+        type: "offline",
         surface: "database",
-        statusCode: 400,
+        statusCode: 503,
         metadata: expect.objectContaining({
           db_operation: "chats.saveChat",
           db_error_name: "ConvexError",
@@ -131,6 +137,7 @@ describe("saveChat", () => {
           db_request_id: "abc",
           db_error_code: "CHAT_SAVE_FAILED",
           db_failure_stage: "insert_chat",
+          db_retry_reason: "worker_overloaded",
           chat_id: "chat-1",
           user_id: "user-1",
           title_length: 100,
@@ -144,10 +151,97 @@ describe("saveChat", () => {
           db_request_id: "abc",
           db_error_code: "CHAT_SAVE_FAILED",
           db_failure_stage: "insert_chat",
+          db_retry_reason: "worker_overloaded",
           chat_id: "chat-1",
           user_id: "user-1",
           userId: "user-1",
           title_length: 100,
+        }),
+      );
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+});
+
+describe("getChatById", () => {
+  it("retries transient Convex fetch failures before returning a chat", async () => {
+    const { getChatById, mockQuery } = await loadSaveMessageWithMocks();
+    const fetchError = new TypeError("fetch failed");
+    mockQuery
+      .mockRejectedValueOnce(fetchError as never)
+      .mockRejectedValueOnce(fetchError as never)
+      .mockResolvedValueOnce({ id: "chat-1", user_id: "user-1" } as never);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await expect(getChatById({ id: "chat-1" })).resolves.toEqual({
+        id: "chat-1",
+        user_id: "user-1",
+      });
+
+      expect(mockQuery).toHaveBeenCalledTimes(3);
+      const retryEvents = warnSpy.mock.calls
+        .map(([line]) => JSON.parse(String(line)))
+        .filter((payload) => payload.event === "chat_fetch_retry_scheduled");
+
+      expect(retryEvents).toHaveLength(2);
+      expect(retryEvents[0]).toMatchObject({
+        retry_reason: "network_fetch_failed",
+        attempt: 1,
+        next_attempt: 2,
+        retry_delay_ms: 0,
+        chat_id: "chat-1",
+      });
+      expect(retryEvents[1]).toMatchObject({
+        retry_reason: "network_fetch_failed",
+        attempt: 2,
+        next_attempt: 3,
+        retry_delay_ms: 0,
+        chat_id: "chat-1",
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("classifies exhausted transient fetch failures as database availability errors", async () => {
+    const { getChatById, mockPhEvent, mockQuery } =
+      await loadSaveMessageWithMocks();
+    mockQuery.mockRejectedValue(new TypeError("fetch failed") as never);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const thrown = await getChatById({ id: "chat-1" }).catch(
+        (error) => error,
+      );
+
+      expect(thrown).toMatchObject({
+        type: "offline",
+        surface: "database",
+        statusCode: 503,
+        metadata: expect.objectContaining({
+          db_operation: "chats.getChatById",
+          db_error_name: "TypeError",
+          db_error_message: "fetch failed",
+          db_retry_reason: "network_fetch_failed",
+          chat_id: "chat-1",
+        }),
+      });
+      expect(mockQuery).toHaveBeenCalledTimes(3);
+      expect(mockPhEvent).toHaveBeenCalledWith(
+        "database_operation_failed",
+        expect.objectContaining({
+          db_operation: "chats.getChatById",
+          db_error_name: "TypeError",
+          db_error_message: "fetch failed",
+          db_retry_reason: "network_fetch_failed",
+          chat_id: "chat-1",
         }),
       );
       expect(errorSpy).toHaveBeenCalledTimes(1);

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -46,11 +46,11 @@ const SAVE_MESSAGE_RETRY_DELAYS_MS =
   process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
 const SAVE_CHAT_RETRY_DELAYS_MS =
   process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
+const GET_CHAT_RETRY_DELAYS_MS =
+  process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
 const REDACTED_ERROR_DATA_VALUE = "[Redacted]";
 type SummaryReason =
-  | "token_threshold"
-  | "provider_input_threshold"
-  | "provider_pressure";
+  "token_threshold" | "provider_input_threshold" | "provider_pressure";
 
 const sensitiveErrorDataKeys = new Set([
   "authorization",
@@ -251,6 +251,9 @@ const getRetryableDatabaseErrorReason = (
     .join(" ");
 
   if (/WorkerOverloaded/i.test(errorText)) return "worker_overloaded";
+  if (/failed to fetch|fetch failed/i.test(errorText)) {
+    return "network_fetch_failed";
+  }
   if (
     /ServiceUnavailable|temporarily unavailable|ECONNRESET|ETIMEDOUT/i.test(
       errorText,
@@ -265,6 +268,7 @@ const getRetryableDatabaseErrorReason = (
 };
 
 const getRetryableSaveMessageErrorReason = getRetryableDatabaseErrorReason;
+const getRetryableGetChatErrorReason = getRetryableDatabaseErrorReason;
 
 const getRetryableSaveChatErrorReason = (
   error: unknown,
@@ -348,6 +352,7 @@ const databaseError = (
   const isChatCanceled = isChatCanceledMessageSaveError(operation, dbErrorData);
   const isChatUnauthorized = isChatUnauthorizedError(dbErrorData);
   const isMessageTooLarge = isMessageTooLargeError(operation, dbErrorData);
+  const retryReason = getRetryableDatabaseErrorReason(error);
   const logLevel =
     isChatNotFound || isChatCanceled || isChatUnauthorized || isMessageTooLarge
       ? "warn"
@@ -369,7 +374,9 @@ const databaseError = (
         ? "forbidden:chat"
         : isMessageTooLarge
           ? "bad_request:api"
-          : "bad_request:database";
+          : retryReason
+            ? "offline:database"
+            : "bad_request:database";
   const errorMessage = isChatNotFound
     ? `Chat no longer exists while saving message: ${operation}: ${dbErrorMessage}`
     : isChatCanceled
@@ -378,7 +385,9 @@ const databaseError = (
         ? `Chat access denied while executing database operation: ${operation}: ${dbErrorMessage}`
         : isMessageTooLarge
           ? "Your message is too large to save. Please shorten it or attach the content as a file instead."
-          : `Database operation failed: ${operation}: ${dbErrorMessage}`;
+          : retryReason
+            ? `Database temporarily unavailable: ${operation}: ${dbErrorMessage}`
+            : `Database operation failed: ${operation}: ${dbErrorMessage}`;
   const diagnosticMetadata: Record<string, unknown> = {
     db_operation: operation,
     db_error_name: dbErrorName,
@@ -387,6 +396,7 @@ const databaseError = (
     db_error_code: getDatabaseErrorCode(dbErrorData),
     db_cause_error_code: getDatabaseCauseErrorCode(dbErrorData),
     db_failure_stage: getDatabaseFailureStage(dbErrorData),
+    db_retry_reason: retryReason,
     ...metadata,
   };
 
@@ -419,11 +429,38 @@ const databaseError = (
 
 export async function getChatById({ id }: { id: string }) {
   try {
-    const selectedChat = await getConvexClient().query(api.chats.getChatById, {
+    const queryArgs = {
       serviceKey,
       id,
-    });
-    return selectedChat;
+    };
+
+    for (let attemptIndex = 0; ; attemptIndex++) {
+      try {
+        return await getConvexClient().query(api.chats.getChatById, queryArgs);
+      } catch (error) {
+        const retryReason = getRetryableGetChatErrorReason(error);
+        const retryDelayMs = GET_CHAT_RETRY_DELAYS_MS[attemptIndex];
+        if (!retryReason || retryDelayMs === undefined) {
+          throw error;
+        }
+
+        console.warn(
+          JSON.stringify({
+            level: "warn",
+            event: "chat_fetch_retry_scheduled",
+            service: "chat-handler",
+            timestamp: new Date().toISOString(),
+            db_operation: "chats.getChatById",
+            retry_reason: retryReason,
+            attempt: attemptIndex + 1,
+            next_attempt: attemptIndex + 2,
+            retry_delay_ms: retryDelayMs,
+            chat_id: id,
+          }),
+        );
+        await waitForRetryDelay(retryDelayMs);
+      }
+    }
   } catch (error) {
     throw databaseError("chats.getChatById", error, { chat_id: id });
   }
@@ -654,8 +691,7 @@ export async function saveMessage({
       ...((extraFileIds || []).filter(Boolean) as string[]),
     ];
     const usageForSave = sanitizeForConvexValue(usage) as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
 
     const mutationArgs = {
       serviceKey,
@@ -1019,8 +1055,7 @@ export async function getMessagesByChatId({
             );
             const budgetForMessages = maxTokens - summaryTokens;
             const retainedTail = latestSummary.retained_tail as
-              | RetainedTailMetadata
-              | undefined;
+              RetainedTailMetadata | undefined;
             let truncatedAfterCutoff: UIMessage[] = [];
 
             if (budgetForMessages > 0 && retainedTail) {


### PR DESCRIPTION
## Summary
- retry transient Convex fetch failures when loading chat metadata through getChatById
- classify exhausted transient database failures as offline:database / 503 with db_retry_reason metadata
- route chat stream reconnects through getChatById so transient database outages no longer return misleading 404s

## Testing
- ./node_modules/.bin/jest --runTestsByPath lib/db/__tests__/actions-save-message.test.ts 'app/api/chat/[id]/stream/__tests__/route.test.ts' --runInBand
- ./node_modules/.bin/prettier --check lib/db/actions.ts lib/db/__tests__/actions-save-message.test.ts 'app/api/chat/[id]/stream/route.ts' 'app/api/chat/[id]/stream/__tests__/route.test.ts'
- ./node_modules/.bin/eslint lib/db/actions.ts lib/db/__tests__/actions-save-message.test.ts 'app/api/chat/[id]/stream/route.ts' 'app/api/chat/[id]/stream/__tests__/route.test.ts'
- ./node_modules/.bin/tsc --noEmit
- pre-commit hook: tsc --noEmit; full jest suite (191 suites, 1937 tests)

## Manual verification
- In a production-like environment, force Convex chats.getChatById to fail with TypeError: fetch failed twice, then recover. Starting a chat should succeed after retries and log chat_fetch_retry_scheduled.
- Force chats.getChatById to keep failing. Chat start and stream reconnect should return a generic 503 instead of a 400 or 404, with db_retry_reason=network_fetch_failed in server logs/PostHog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat loading reliability during temporary database/network issues by retrying transient failures before failing.
  * More consistent error responses when chat loading fails: temporary issues return a “try again later” message, while missing chats return a proper not-found response.
  * Updated diagnostics for transient database failures so they’re classified and reported more accurately.
* **Tests**
  * Added coverage for the chat streaming route’s success and failure scenarios, including offline/transient and missing-chat behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->