### PR TITLE
Downgrade open URL timeout logs

### DIFF
--- a/lib/ai/tools/__tests__/open-url.test.ts
+++ b/lib/ai/tools/__tests__/open-url.test.ts
@@ -1,0 +1,100 @@
+import { createOpenUrlTool } from "../open-url";
+
+async function runTool(
+  tool: ReturnType<typeof createOpenUrlTool>,
+  input: Record<string, unknown>,
+) {
+  const execute = (
+    tool as unknown as {
+      execute: (i: unknown, o: unknown) => Promise<unknown>;
+    }
+  ).execute;
+
+  return execute(input, {
+    toolCallId: "call-1",
+    abortSignal: undefined,
+    messages: [],
+  });
+}
+
+describe("open_url", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.JINA_API_KEY = "test-key";
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.JINA_API_KEY;
+    jest.restoreAllMocks();
+  });
+
+  it("logs expected Jina network timeouts as warnings without raw error objects", async () => {
+    const timeoutError = Object.assign(new Error("connect ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+    const fetchError = Object.assign(new TypeError("fetch failed"), {
+      cause: { errors: [timeoutError] },
+    });
+    global.fetch = jest.fn().mockRejectedValue(fetchError);
+
+    const result = await runTool(
+      createOpenUrlTool({ chatId: "chat-1", userID: "user-1" }),
+      {
+        url: "https://example.com/private-path?token=secret",
+        brief: "open example page",
+      },
+    );
+
+    expect(result).toBe(
+      "Error opening URL: The URL reader timed out or could not reach the page. Do not retry the same URL unless the user asks.",
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      "Open URL provider fetch failed",
+      expect.objectContaining({
+        chat_id: "chat-1",
+        error_code: "ETIMEDOUT",
+        error_message: "fetch failed",
+        error_name: "TypeError",
+        event: "open_url_fetch_failed",
+        level: "warn",
+        provider: "jina",
+        url_hostname: "example.com",
+        user_id: "user-1",
+      }),
+    );
+    expect(console.error).not.toHaveBeenCalled();
+    expect(
+      JSON.stringify((console.warn as jest.Mock).mock.calls),
+    ).not.toContain("private-path");
+    expect(
+      JSON.stringify((console.warn as jest.Mock).mock.calls),
+    ).not.toContain("secret");
+  });
+
+  it("keeps unexpected tool exceptions as errors", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("unexpected boom"));
+
+    const result = await runTool(createOpenUrlTool(), {
+      url: "not-a-url",
+      brief: "open malformed page",
+    });
+
+    expect(result).toBe("Error opening URL: unexpected boom");
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "Open URL tool error",
+      expect.objectContaining({
+        error_message: "unexpected boom",
+        error_name: "Error",
+        event: "open_url_tool_failed",
+        level: "error",
+        provider: "jina",
+        url_hostname: "invalid_url",
+      }),
+    );
+  });
+});

--- a/lib/ai/tools/__tests__/open-url.test.ts
+++ b/lib/ai/tools/__tests__/open-url.test.ts
@@ -1,3 +1,11 @@
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+import { phLogger } from "@/lib/posthog/server";
 import { createOpenUrlTool } from "../open-url";
 
 async function runTool(
@@ -19,17 +27,21 @@ async function runTool(
 
 describe("open_url", () => {
   const originalFetch = global.fetch;
+  const mockPhLoggerWarn = phLogger.warn as jest.MockedFunction<
+    typeof phLogger.warn
+  >;
+  const mockPhLoggerError = phLogger.error as jest.MockedFunction<
+    typeof phLogger.error
+  >;
 
   beforeEach(() => {
     process.env.JINA_API_KEY = "test-key";
-    jest.spyOn(console, "warn").mockImplementation(() => undefined);
-    jest.spyOn(console, "error").mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
     delete process.env.JINA_API_KEY;
-    jest.restoreAllMocks();
+    jest.clearAllMocks();
   });
 
   it("logs expected Jina network timeouts as warnings without raw error objects", async () => {
@@ -52,7 +64,7 @@ describe("open_url", () => {
     expect(result).toBe(
       "Error opening URL: The URL reader timed out or could not reach the page. Do not retry the same URL unless the user asks.",
     );
-    expect(console.warn).toHaveBeenCalledWith(
+    expect(mockPhLoggerWarn).toHaveBeenCalledWith(
       "Open URL provider fetch failed",
       expect.objectContaining({
         chat_id: "chat-1",
@@ -60,19 +72,16 @@ describe("open_url", () => {
         error_message: "fetch failed",
         error_name: "TypeError",
         event: "open_url_fetch_failed",
-        level: "warn",
         provider: "jina",
         url_hostname: "example.com",
-        user_id: "user-1",
+        userId: "user-1",
       }),
     );
-    expect(console.error).not.toHaveBeenCalled();
-    expect(
-      JSON.stringify((console.warn as jest.Mock).mock.calls),
-    ).not.toContain("private-path");
-    expect(
-      JSON.stringify((console.warn as jest.Mock).mock.calls),
-    ).not.toContain("secret");
+    expect(mockPhLoggerError).not.toHaveBeenCalled();
+    expect(JSON.stringify(mockPhLoggerWarn.mock.calls)).not.toContain(
+      "private-path",
+    );
+    expect(JSON.stringify(mockPhLoggerWarn.mock.calls)).not.toContain("secret");
   });
 
   it("keeps unexpected tool exceptions as errors", async () => {
@@ -84,14 +93,13 @@ describe("open_url", () => {
     });
 
     expect(result).toBe("Error opening URL: unexpected boom");
-    expect(console.warn).not.toHaveBeenCalled();
-    expect(console.error).toHaveBeenCalledWith(
+    expect(mockPhLoggerWarn).not.toHaveBeenCalled();
+    expect(mockPhLoggerError).toHaveBeenCalledWith(
       "Open URL tool error",
       expect.objectContaining({
         error_message: "unexpected boom",
         error_name: "Error",
         event: "open_url_tool_failed",
-        level: "error",
         provider: "jina",
         url_hostname: "invalid_url",
       }),

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -146,7 +146,7 @@ export const createTools = (
         web_search: createWebSearch(context),
       }),
       ...(process.env.JINA_API_KEY && {
-        open_url: createOpenUrlTool(),
+        open_url: createOpenUrlTool(context),
       }),
     };
 
@@ -164,7 +164,7 @@ export const createTools = (
             web_search: createWebSearch(context),
           }),
           ...(process.env.JINA_API_KEY && {
-            open_url: createOpenUrlTool(),
+            open_url: createOpenUrlTool(context),
           }),
         }
       : allTools;

--- a/lib/ai/tools/open-url.ts
+++ b/lib/ai/tools/open-url.ts
@@ -1,13 +1,85 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { truncateContent } from "@/lib/token-utils";
+import { stringifyRedactedError } from "@/lib/utils/error-redaction";
+import type { ToolContext } from "@/types";
 import { toolBriefSchema } from "./tool-brief";
+
+const NETWORK_ERROR_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ETIMEDOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+const NETWORK_ERROR_MESSAGE_PATTERN =
+  /fetch failed|failed to fetch|network|timed?\s*out|timeout|connection (?:closed|reset|refused)|socket|getaddrinfo/i;
+
+type OpenUrlLogContext = Pick<ToolContext, "chatId" | "userID">;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const getNestedErrorCode = (
+  error: unknown,
+  seen = new Set<unknown>(),
+): string | undefined => {
+  if (!isRecord(error) || seen.has(error)) return undefined;
+  seen.add(error);
+
+  if (typeof error.code === "string") return error.code;
+
+  const causeCode = getNestedErrorCode(error.cause, seen);
+  if (causeCode) return causeCode;
+
+  if (Array.isArray(error.errors)) {
+    for (const nestedError of error.errors) {
+      const nestedCode = getNestedErrorCode(nestedError, seen);
+      if (nestedCode) return nestedCode;
+    }
+  }
+
+  return undefined;
+};
+
+const getErrorName = (error: unknown): string =>
+  error instanceof Error ? error.name : "UnknownError";
+
+const getUrlHostname = (url: string): string => {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return "invalid_url";
+  }
+};
+
+const getEnvironment = (): string =>
+  process.env.VERCEL_ENV ??
+  process.env.NODE_ENV ??
+  process.env.ENVIRONMENT ??
+  "unknown";
+
+const isOpenUrlNetworkError = (error: unknown): boolean => {
+  const errorCode = getNestedErrorCode(error);
+  if (errorCode && NETWORK_ERROR_CODES.has(errorCode)) return true;
+
+  return (
+    error instanceof Error && NETWORK_ERROR_MESSAGE_PATTERN.test(error.message)
+  );
+};
 
 /**
  * Open URL tool using Jina AI for content retrieval
  * Retrieves and returns the full contents of a webpage
  */
-export const createOpenUrlTool = () => {
+export const createOpenUrlTool = (context?: OpenUrlLogContext) => {
   return tool({
     description: `Retrieve the full contents of a specific webpage by URL.
 
@@ -22,6 +94,8 @@ export const createOpenUrlTool = () => {
       brief: toolBriefSchema,
     }),
     execute: async ({ url }: { url: string }, { abortSignal }) => {
+      const startedAt = Date.now();
+
       try {
         // Construct the Jina AI reader URL with proper encoding
         const jinaUrl = `https://r.jina.ai/${encodeURIComponent(url)}`;
@@ -52,9 +126,34 @@ export const createOpenUrlTool = () => {
         if (error instanceof Error && error.name === "AbortError") {
           return "Error: Operation aborted";
         }
-        console.error("Open URL tool error:", error);
-        const errorMessage =
-          error instanceof Error ? error.message : "Unknown error occurred";
+
+        const isNetworkFailure = isOpenUrlNetworkError(error);
+        const errorCode = getNestedErrorCode(error);
+        const errorMessage = stringifyRedactedError(error);
+        const logFields = {
+          timestamp: new Date().toISOString(),
+          level: isNetworkFailure ? "warn" : "error",
+          event: isNetworkFailure
+            ? "open_url_fetch_failed"
+            : "open_url_tool_failed",
+          service: process.env.POSTHOG_LOG_SERVICE_NAME ?? "hackerai-web",
+          environment: getEnvironment(),
+          provider: "jina",
+          url_hostname: getUrlHostname(url),
+          duration_ms: Date.now() - startedAt,
+          ...(context?.chatId && { chat_id: context.chatId }),
+          ...(context?.userID && { user_id: context.userID }),
+          ...(errorCode && { error_code: errorCode }),
+          error_name: getErrorName(error),
+          error_message: errorMessage,
+        };
+
+        if (isNetworkFailure) {
+          console.warn("Open URL provider fetch failed", logFields);
+          return "Error opening URL: The URL reader timed out or could not reach the page. Do not retry the same URL unless the user asks.";
+        }
+
+        console.error("Open URL tool error", logFields);
         return `Error opening URL: ${errorMessage}`;
       }
     },

--- a/lib/ai/tools/open-url.ts
+++ b/lib/ai/tools/open-url.ts
@@ -1,5 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { phLogger } from "@/lib/posthog/server";
 import { truncateContent } from "@/lib/token-utils";
 import { stringifyRedactedError } from "@/lib/utils/error-redaction";
 import type { ToolContext } from "@/types";
@@ -59,12 +60,6 @@ const getUrlHostname = (url: string): string => {
     return "invalid_url";
   }
 };
-
-const getEnvironment = (): string =>
-  process.env.VERCEL_ENV ??
-  process.env.NODE_ENV ??
-  process.env.ENVIRONMENT ??
-  "unknown";
 
 const isOpenUrlNetworkError = (error: unknown): boolean => {
   const errorCode = getNestedErrorCode(error);
@@ -131,29 +126,25 @@ export const createOpenUrlTool = (context?: OpenUrlLogContext) => {
         const errorCode = getNestedErrorCode(error);
         const errorMessage = stringifyRedactedError(error);
         const logFields = {
-          timestamp: new Date().toISOString(),
-          level: isNetworkFailure ? "warn" : "error",
           event: isNetworkFailure
             ? "open_url_fetch_failed"
             : "open_url_tool_failed",
-          service: process.env.POSTHOG_LOG_SERVICE_NAME ?? "hackerai-web",
-          environment: getEnvironment(),
           provider: "jina",
           url_hostname: getUrlHostname(url),
           duration_ms: Date.now() - startedAt,
           ...(context?.chatId && { chat_id: context.chatId }),
-          ...(context?.userID && { user_id: context.userID }),
+          ...(context?.userID && { userId: context.userID }),
           ...(errorCode && { error_code: errorCode }),
           error_name: getErrorName(error),
           error_message: errorMessage,
         };
 
         if (isNetworkFailure) {
-          console.warn("Open URL provider fetch failed", logFields);
+          phLogger.warn("Open URL provider fetch failed", logFields);
           return "Error opening URL: The URL reader timed out or could not reach the page. Do not retry the same URL unless the user asks.";
         }
 
-        console.error("Open URL tool error", logFields);
+        phLogger.error("Open URL tool error", logFields);
         return `Error opening URL: ${errorMessage}`;
       }
     },


### PR DESCRIPTION
## Summary
- classify expected Jina/open_url network failures as structured warnings instead of raw console errors
- pass chat/user context into open_url logging while only recording the URL hostname
- tell the model not to retry the same URL after a reader timeout and add regression tests

## Testing
- `./node_modules/.bin/jest lib/ai/tools/__tests__/open-url.test.ts --runInBand`
- `./node_modules/.bin/prettier --check lib/ai/tools/open-url.ts lib/ai/tools/index.ts lib/ai/tools/__tests__/open-url.test.ts`
- `./node_modules/.bin/eslint lib/ai/tools/open-url.ts lib/ai/tools/index.ts lib/ai/tools/__tests__/open-url.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

## Manual verification
- Trigger an ask-mode `open_url` call where Jina times out or returns a fetch timeout.
- Confirm the chat continues with a tool result and the Vercel error log is not polluted by the raw `AggregateError`.
- Confirm unexpected tool exceptions still emit an error log.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Open URL tool error handling for timeouts and network failures with clearer, safer user messages.
  * Enhanced failure logging with structured details and request timing, while reducing exposure of sensitive information.
  * More consistent telemetry by including shared request context when available.
* **Tests**
  * Added Jest coverage for Open URL timeout handling, error redaction, and logging behavior for unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->