### PR TITLE
Harden noisy terminal timeouts

### DIFF
--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -398,7 +398,86 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
         output_truncated: true,
         pid: 123,
         termination_attempted: true,
+        termination_succeeded: true,
       });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("does not report noisy timeout termination when PID discovery fails", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const noisyOutput = "line with repeated output\n".repeat(20_000);
+    const pendingCommand = new Promise<never>(() => {});
+    const nonE2B = {
+      sandboxKind: "centrifugo" as const,
+      isWindows: () => false,
+      commands: {
+        run: jest.fn(
+          (
+            command: string,
+            opts?: { onStdout?: (s: string) => void },
+          ): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
+            if (command.startsWith("pgrep -f")) {
+              return Promise.resolve({
+                stdout: "",
+                stderr: "",
+                exitCode: 1,
+              });
+            }
+
+            opts?.onStdout?.(noisyOutput);
+            return pendingCommand;
+          },
+        ),
+      },
+    };
+
+    try {
+      const { context } = makeContext({ sandbox: nonE2B });
+      const tool = createRunTerminalCmd(context);
+
+      const result = (await runTool(tool, {
+        command: "yes",
+        brief: "run noisy command",
+        is_background: false,
+        timeout: 0.01,
+      })) as {
+        result: {
+          output: string;
+          exitCode: number | null;
+          terminatedOnTimeout?: boolean;
+        };
+      };
+
+      expect(result.result.exitCode).toBeNull();
+      expect(result.result.terminatedOnTimeout).toBeUndefined();
+      expect(result.result.output).toContain("continues in background");
+      expect(result.result.output).not.toContain(
+        "noisy foreground process was terminated",
+      );
+      expect(nonE2B.commands.run).not.toHaveBeenCalledWith("kill -9 123", {});
+
+      const noisyTimeoutLog = warnSpy.mock.calls
+        .map(([line]) => {
+          try {
+            return JSON.parse(String(line));
+          } catch {
+            return null;
+          }
+        })
+        .find((line) => line?.event === "agent_terminal_noisy_timeout");
+
+      expect(noisyTimeoutLog).toMatchObject({
+        event: "agent_terminal_noisy_timeout",
+        chat_id: "chat-1",
+        user_id: "u1",
+        tool_call_id: "call-1",
+        output_truncated: true,
+        termination_attempted: false,
+        termination_succeeded: false,
+      });
+      expect(noisyTimeoutLog?.pid).toBeUndefined();
     } finally {
       warnSpy.mockRestore();
     }

--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -322,6 +322,88 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     ).toContain("rm -rf /");
   });
 
+  test("terminates noisy foreground commands on stream timeout", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const noisyOutput = "line with repeated output\n".repeat(20_000);
+    const pendingCommand = new Promise<never>(() => {});
+    const nonE2B = {
+      sandboxKind: "centrifugo" as const,
+      isWindows: () => false,
+      commands: {
+        run: jest.fn(
+          (
+            command: string,
+            opts?: { onStdout?: (s: string) => void },
+          ): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
+            if (command.startsWith("pgrep -f")) {
+              return Promise.resolve({
+                stdout: "123\n",
+                stderr: "",
+                exitCode: 0,
+              });
+            }
+            if (command === "kill -9 123") {
+              return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+            }
+            if (command === "ps -p 123") {
+              return Promise.resolve({ stdout: "", stderr: "", exitCode: 1 });
+            }
+
+            opts?.onStdout?.(noisyOutput);
+            return pendingCommand;
+          },
+        ),
+      },
+    };
+
+    try {
+      const { context } = makeContext({ sandbox: nonE2B });
+      const tool = createRunTerminalCmd(context);
+
+      const result = (await runTool(tool, {
+        command: "yes",
+        brief: "run noisy command",
+        is_background: false,
+        timeout: 0.01,
+      })) as {
+        result: {
+          output: string;
+          exitCode: number | null;
+          terminatedOnTimeout?: boolean;
+        };
+      };
+
+      expect(result.result.exitCode).toBe(124);
+      expect(result.result.terminatedOnTimeout).toBe(true);
+      expect(result.result.output).toContain(
+        "noisy foreground process was terminated",
+      );
+      expect(nonE2B.commands.run).toHaveBeenCalledWith("kill -9 123", {});
+
+      const noisyTimeoutLog = warnSpy.mock.calls
+        .map(([line]) => {
+          try {
+            return JSON.parse(String(line));
+          } catch {
+            return null;
+          }
+        })
+        .find((line) => line?.event === "agent_terminal_noisy_timeout");
+
+      expect(noisyTimeoutLog).toMatchObject({
+        event: "agent_terminal_noisy_timeout",
+        chat_id: "chat-1",
+        user_id: "u1",
+        tool_call_id: "call-1",
+        output_truncated: true,
+        pid: 123,
+        termination_attempted: true,
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   test("logs sanitized agent-browser terminal usage to PostHog", async () => {
     const nonE2B = {
       sandboxKind: "centrifugo" as const,

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -437,6 +437,7 @@ In using these tools, adhere to the following guidelines:
 
             const logNoisyTimeout = (fields: {
               terminationAttempted: boolean;
+              terminationSucceeded: boolean;
               processId: number | null;
               terminationError?: unknown;
             }) => {
@@ -460,6 +461,7 @@ In using these tools, adhere to the following guidelines:
                     sandboxManager.getSandboxType("run_terminal_cmd"),
                   pid: fields.processId ?? undefined,
                   termination_attempted: fields.terminationAttempted,
+                  termination_succeeded: fields.terminationSucceeded,
                   termination_error:
                     fields.terminationError instanceof Error
                       ? fields.terminationError.message
@@ -578,6 +580,7 @@ In using these tools, adhere to the following guidelines:
                   }
 
                   let terminationAttempted = false;
+                  let terminationSucceeded = false;
                   let terminationError: unknown;
                   if (terminateNoisyCommand) {
                     terminationAttempted = Boolean(
@@ -585,7 +588,7 @@ In using these tools, adhere to the following guidelines:
                     );
                     try {
                       if (terminationAttempted) {
-                        await terminateProcessReliably(
+                        terminationSucceeded = await terminateProcessReliably(
                           sandboxInstance,
                           execution,
                           processId,
@@ -596,12 +599,15 @@ In using these tools, adhere to the following guidelines:
                     }
                     logNoisyTimeout({
                       terminationAttempted,
+                      terminationSucceeded,
                       processId,
                       terminationError,
                     });
                   }
 
-                  const timeoutMessage = terminateNoisyCommand
+                  const commandTerminated =
+                    terminateNoisyCommand && terminationSucceeded;
+                  const timeoutMessage = commandTerminated
                     ? TERMINATED_TIMEOUT_MESSAGE(
                         effectiveStreamTimeout,
                         processId ?? undefined,
@@ -626,8 +632,8 @@ In using these tools, adhere to the following guidelines:
                   resolve({
                     result: {
                       output: result.output,
-                      exitCode: terminateNoisyCommand ? 124 : null,
-                      ...(terminateNoisyCommand && {
+                      exitCode: commandTerminated ? 124 : null,
+                      ...(commandTerminated && {
                         terminatedOnTimeout: true,
                       }),
                     },

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -41,11 +41,17 @@ import { captureAgentBrowserUsage } from "./utils/agent-browser-usage";
 
 const DEFAULT_STREAM_TIMEOUT_SECONDS = 60;
 const MAX_TIMEOUT_SECONDS = 600;
+const NOISY_TIMEOUT_MIN_BUFFERED_CHARS = 256 * 1024;
 // Once an interactive PTY emits its first bytes, treat `quietMs` of silence
 // as "settled" (prompt drew, REPL banner finished, etc.). Lets `bash`/`python3`
 // return in ~half a second instead of blocking the user-supplied timeout
 // ceiling. The agent can follow up with action=wait/send.
 const INTERACTIVE_QUIET_WINDOW_MS = 500;
+
+const TERMINATED_TIMEOUT_MESSAGE = (seconds: number, pid?: number) =>
+  pid
+    ? `\n\nCommand output paused after ${seconds} seconds and the noisy foreground process was terminated (PID: ${pid}).`
+    : `\n\nCommand output paused after ${seconds} seconds and the noisy foreground process was terminated.`;
 
 export const createRunTerminalCmd = (context: ToolContext) => {
   const {
@@ -97,7 +103,7 @@ In using these tools, adhere to the following guidelines:
         .optional()
         .default(DEFAULT_STREAM_TIMEOUT_SECONDS)
         .describe(
-          `Timeout in seconds to wait for command output before returning. For interactive=false, the command keeps running in background on timeout. Capped at ${MAX_TIMEOUT_SECONDS} seconds. Defaults to ${DEFAULT_STREAM_TIMEOUT_SECONDS} seconds.`,
+          `Timeout in seconds to wait for command output before returning. For interactive=false, quiet foreground commands can keep running in background on timeout; noisy foreground commands that already produced truncated output may be terminated to protect the session. Capped at ${MAX_TIMEOUT_SECONDS} seconds. Defaults to ${DEFAULT_STREAM_TIMEOUT_SECONDS} seconds.`,
         ),
       interactive: z
         .boolean()
@@ -419,6 +425,49 @@ In using these tools, adhere to the following guidelines:
             let handler: ReturnType<typeof createTerminalHandler> | null = null;
             let processId: number | null = null; // Store PID for all processes
 
+            const shouldTerminateNoisyTimedOutCommand = () => {
+              if (is_background || !handler) return false;
+              return (
+                handler.wasTruncated() ||
+                handler.wasFullOutputCapped() ||
+                handler.getBufferedCharCount() >=
+                  NOISY_TIMEOUT_MIN_BUFFERED_CHARS
+              );
+            };
+
+            const logNoisyTimeout = (fields: {
+              terminationAttempted: boolean;
+              processId: number | null;
+              terminationError?: unknown;
+            }) => {
+              console.warn(
+                JSON.stringify({
+                  level: "warn",
+                  event: "agent_terminal_noisy_timeout",
+                  service: "chat-handler",
+                  timestamp: new Date().toISOString(),
+                  chat_id: chatId,
+                  user_id: context.userID,
+                  mode: context.mode,
+                  subscription: context.subscription,
+                  tool_call_id: toolCallId,
+                  timeout_seconds: effectiveStreamTimeout,
+                  output_chars_buffered: handler?.getBufferedCharCount() ?? 0,
+                  output_truncated: handler?.wasTruncated() ?? false,
+                  output_full_output_capped:
+                    handler?.wasFullOutputCapped() ?? false,
+                  sandbox_type:
+                    sandboxManager.getSandboxType("run_terminal_cmd"),
+                  pid: fields.processId ?? undefined,
+                  termination_attempted: fields.terminationAttempted,
+                  termination_error:
+                    fields.terminationError instanceof Error
+                      ? fields.terminationError.message
+                      : undefined,
+                }),
+              );
+            };
+
             // Handle abort signal
             const onAbort = async () => {
               if (resolved) {
@@ -517,29 +566,71 @@ In using these tools, adhere to the following guidelines:
                     processId = (execution as any).pid;
                   }
 
-                  // For foreground commands on stream timeout, try to discover PID for user reference
-                  // DO NOT kill the process - it may still be working and saving to files
-                  // The process has its own MAX_COMMAND_EXECUTION_TIME timeout via commonOptions
+                  const terminateNoisyCommand =
+                    shouldTerminateNoisyTimedOutCommand();
+
+                  // For foreground commands on stream timeout, try to discover
+                  // PID for user reference and, for noisy truncated output,
+                  // terminate the process before the sandbox transport keeps
+                  // buffering output until MAX_COMMAND_EXECUTION_TIME.
                   if (!processId && !is_background) {
                     processId = await findProcessPid(sandboxInstance, command);
                   }
 
-                  await createTerminalWriter(
-                    TIMEOUT_MESSAGE(
-                      effectiveStreamTimeout,
-                      processId ?? undefined,
-                    ),
-                  );
+                  let terminationAttempted = false;
+                  let terminationError: unknown;
+                  if (terminateNoisyCommand) {
+                    terminationAttempted = Boolean(
+                      (execution && execution.kill) || processId,
+                    );
+                    try {
+                      if (terminationAttempted) {
+                        await terminateProcessReliably(
+                          sandboxInstance,
+                          execution,
+                          processId,
+                        );
+                      }
+                    } catch (error) {
+                      terminationError = error;
+                    }
+                    logNoisyTimeout({
+                      terminationAttempted,
+                      processId,
+                      terminationError,
+                    });
+                  }
+
+                  const timeoutMessage = terminateNoisyCommand
+                    ? TERMINATED_TIMEOUT_MESSAGE(
+                        effectiveStreamTimeout,
+                        processId ?? undefined,
+                      )
+                    : TIMEOUT_MESSAGE(
+                        effectiveStreamTimeout,
+                        processId ?? undefined,
+                      );
+
+                  await createTerminalWriter(timeoutMessage);
 
                   resolved = true;
+                  abortSignal?.removeEventListener("abort", onAbort);
                   const result = handler
-                    ? handler.getResult(processId ?? undefined)
+                    ? handler.getResult(processId ?? undefined, {
+                        timeoutMessage,
+                      })
                     : { output: "" };
                   if (handler) {
                     handler.cleanup();
                   }
                   resolve({
-                    result: { output: result.output, exitCode: null },
+                    result: {
+                      output: result.output,
+                      exitCode: terminateNoisyCommand ? 124 : null,
+                      ...(terminateNoisyCommand && {
+                        terminatedOnTimeout: true,
+                      }),
+                    },
                   });
                 },
               },

--- a/lib/ai/tools/utils/process-termination.ts
+++ b/lib/ai/tools/utils/process-termination.ts
@@ -89,13 +89,13 @@ export async function forceKillProcess(
  * @param sandbox - The sandbox instance (E2B or CentrifugoSandbox)
  * @param execution - The execution object with kill() method (optional for foreground commands)
  * @param pid - Process ID (if available)
- * @returns Promise<void>
+ * @returns Promise<boolean> - true if termination succeeded or the process is gone
  */
 export async function terminateProcessReliably(
   sandbox: AnySandbox,
   execution: { kill?: () => Promise<void> } | null,
   pid: number | null | undefined,
-): Promise<void> {
+): Promise<boolean> {
   // If we have PID but no execution object (foreground commands during abort), use direct kill
   if (pid && (!execution || !execution.kill)) {
     await forceKillProcess(sandbox, pid);
@@ -105,12 +105,12 @@ export async function terminateProcessReliably(
         `[Process Termination] PID ${pid}: Process still running after direct kill!`,
       );
     }
-    return;
+    return finalCheck;
   }
 
   // If no way to kill, nothing to do
   if (!execution || !execution.kill) {
-    return;
+    return false;
   }
 
   try {
@@ -120,23 +120,27 @@ export async function terminateProcessReliably(
     // Step 2: If we have a PID, verify termination
     if (pid) {
       const isTerminated = await verifyProcessTerminated(sandbox, pid);
+      if (isTerminated) {
+        return true;
+      }
 
       // Step 3: If still running, force kill
-      if (!isTerminated) {
-        console.warn(
-          `[Process Termination] PID ${pid}: Graceful kill failed, using force kill`,
-        );
-        await forceKillProcess(sandbox, pid);
+      console.warn(
+        `[Process Termination] PID ${pid}: Graceful kill failed, using force kill`,
+      );
+      await forceKillProcess(sandbox, pid);
 
-        // Final verification after force kill
-        const finalCheck = await verifyProcessTerminated(sandbox, pid, 2, 150);
-        if (!finalCheck) {
-          console.error(
-            `[Process Termination] PID ${pid}: Process still running after force kill!`,
-          );
-        }
+      // Final verification after force kill
+      const finalCheck = await verifyProcessTerminated(sandbox, pid, 2, 150);
+      if (!finalCheck) {
+        console.error(
+          `[Process Termination] PID ${pid}: Process still running after force kill!`,
+        );
       }
+      return finalCheck;
     }
+
+    return true;
   } catch (error) {
     console.error(
       `[Process Termination] ${pid ? `PID ${pid}` : "Unknown PID"}: Error during termination:`,
@@ -147,6 +151,7 @@ export async function terminateProcessReliably(
     if (pid) {
       try {
         await forceKillProcess(sandbox, pid);
+        return await verifyProcessTerminated(sandbox, pid, 2, 150);
       } catch (forceError) {
         console.error(
           `[Process Termination] PID ${pid}: Force kill also failed:`,
@@ -155,4 +160,6 @@ export async function terminateProcessReliably(
       }
     }
   }
+
+  return false;
 }

--- a/lib/utils/__tests__/terminal-executor.test.ts
+++ b/lib/utils/__tests__/terminal-executor.test.ts
@@ -1,0 +1,28 @@
+import { createTerminalHandler } from "../terminal-executor";
+
+describe("createTerminalHandler", () => {
+  test("does not buffer output that arrives after timeout", async () => {
+    const writes: string[] = [];
+    const onTimeout = jest.fn();
+    const handler = createTerminalHandler(
+      (output) => {
+        writes.push(output);
+      },
+      {
+        timeoutSeconds: 0.01,
+        onTimeout,
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    handler.stdout("late noisy output\n");
+
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(writes).toEqual([]);
+    expect(handler.getBufferedCharCount()).toBe(0);
+    expect(handler.getFullOutput()).toBe("");
+
+    handler.cleanup();
+  });
+});

--- a/lib/utils/terminal-executor.ts
+++ b/lib/utils/terminal-executor.ts
@@ -52,6 +52,10 @@ export const createTerminalHandler = (
   }
 
   const handleOutput = async (output: string) => {
+    // Once the caller has timed out, ignore late output. Some sandbox command
+    // transports can keep delivering bytes until the underlying process exits.
+    if (timedOut) return;
+
     // Accumulate output in chronological order, up to the memory cap
     if (!fullOutputCapped) {
       if (totalChars + output.length > MAX_FULL_OUTPUT_CHARS) {
@@ -64,8 +68,8 @@ export const createTerminalHandler = (
       }
     }
 
-    // Don't stream if truncated or timed out
-    if (truncated || timedOut) return;
+    // Don't stream if truncated
+    if (truncated) return;
 
     const tokens = safeCountTokens(output);
     if (totalTokens + tokens > maxTokens) {
@@ -96,9 +100,12 @@ export const createTerminalHandler = (
   return {
     stdout: (output: string) => void handleOutput(output),
     stderr: (output: string) => void handleOutput(output),
-    getResult: (pid?: number): TerminalResult => {
+    getResult: (
+      pid?: number,
+      opts?: { timeoutMessage?: string },
+    ): TerminalResult => {
       const timeoutMsg = timedOut
-        ? TIMEOUT_MESSAGE(timeoutSeconds || 0, pid)
+        ? (opts?.timeoutMessage ?? TIMEOUT_MESSAGE(timeoutSeconds || 0, pid))
         : "";
       let finalOutput = outputChunks.join("");
       if (timeoutMsg) {
@@ -114,6 +121,8 @@ export const createTerminalHandler = (
     wasTruncated: (): boolean => truncated,
     /** Returns the full buffered output (for saving to file). May be capped at 5MB. */
     getFullOutput: (): string => outputChunks.join(""),
+    /** Returns buffered character count without joining chunks. */
+    getBufferedCharCount: (): number => totalChars,
     /** Returns true if the full output exceeded the memory cap and was itself truncated */
     wasFullOutputCapped: (): boolean => fullOutputCapped,
     cleanup: () => {


### PR DESCRIPTION
## Summary
- stop buffering terminal output after the stream timeout fires
- terminate foreground commands that already produced noisy/truncated output on timeout instead of letting them keep running until sandbox hard timeout
- add a structured `agent_terminal_noisy_timeout` log and regression tests for the OOM-prone path

## Why
A Trigger `agent-long` run was OOM-killed after a foreground terminal command got into a repeated-output loop. Keeping `small-1x` is still the right cost tradeoff; this patch targets the runaway-output class instead of increasing machine size for every run.

## Validation
- `corepack pnpm jest lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/utils/__tests__/terminal-executor.test.ts --runInBand`
- `corepack pnpm exec prettier --check lib/ai/tools/run-terminal-cmd.ts lib/utils/terminal-executor.ts lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/utils/__tests__/terminal-executor.test.ts`
- `corepack pnpm exec eslint lib/ai/tools/run-terminal-cmd.ts lib/utils/terminal-executor.ts lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/utils/__tests__/terminal-executor.test.ts`
- `corepack pnpm typecheck`

## Manual verification
- In Agent mode, run a foreground command that prints continuously and times out after terminal output truncates, such as a controlled `yes`/loop command.
- Confirm the tool returns truncated output, `exitCode: 124`, and `terminatedOnTimeout: true` instead of leaving the process running.
- Confirm quiet long-running or explicitly background commands still keep their existing timeout behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal timeouts so noisy commands can be stopped more reliably when output keeps streaming past the limit.
  * Late output received after a timeout is now ignored, preventing extra text from appearing in results.
  * Timeout results now report clearer “terminated” details (including termination messaging and standard timeout exit code) when termination is attempted.
  * Noisy-command detection is more robust via buffered output thresholds.
* **Tests**
  * Added coverage for noisy stdout timeouts and late-output filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->