### PR TITLE
Default Pro Plus users to Agent mode

### DIFF
--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -76,6 +76,25 @@ describe("GlobalStateProvider agent defaults", () => {
     expect(screen.getByTestId("sandbox-preference")).toHaveTextContent("e2b");
   });
 
+  it("defaults first-time Pro Plus users to Agent with the auto model and cloud sandbox", async () => {
+    window.localStorage.setItem("selected_model", "hackerai-max");
+    mockAuthUser(["pro-plus-plan"]);
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-mode")).toHaveTextContent("agent");
+    });
+
+    expect(screen.getByTestId("subscription")).toHaveTextContent("pro-plus");
+    expect(screen.getByTestId("selected-model")).toHaveTextContent("auto");
+    expect(screen.getByTestId("sandbox-preference")).toHaveTextContent("e2b");
+  });
+
   it("refreshes AuthKit access token after checkout entitlement refresh before showing paid state", async () => {
     const refreshAuth = jest.fn().mockResolvedValue(undefined);
     const refreshAccessToken = jest.fn().mockResolvedValue("fresh-paid-token");

--- a/lib/activation/__tests__/agent-first-default.test.ts
+++ b/lib/activation/__tests__/agent-first-default.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeAgentFirstSandboxType,
   type AgentFirstDefaultEligibility,
   shouldDefaultFreeUserToAgent,
+  shouldDefaultProPlusUserToAgent,
   shouldDefaultUltraUserToAgent,
 } from "../agent-first-default";
 
@@ -155,6 +156,61 @@ describe("shouldDefaultUltraUserToAgent", () => {
   });
 });
 
+describe("shouldDefaultProPlusUserToAgent", () => {
+  const proPlusEligibility: AgentFirstDefaultEligibility = {
+    ...baseEligibility,
+    defaultLocalSandboxPreference: null,
+    hasLocalSandbox: false,
+    subscription: "pro-plus",
+  };
+
+  it("defaults an eligible first-time Pro Plus user to Agent without requiring a local sandbox", () => {
+    expect(shouldDefaultProPlusUserToAgent(proPlusEligibility)).toBe(true);
+  });
+
+  it("does not override a saved mode preference", () => {
+    expect(
+      shouldDefaultProPlusUserToAgent({
+        ...proPlusEligibility,
+        hasSavedChatMode: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not override a mode selected during the current session", () => {
+    expect(
+      shouldDefaultProPlusUserToAgent({
+        ...proPlusEligibility,
+        hasUserSelectedModeThisSession: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not default Pro or Ultra users through the Pro Plus default", () => {
+    expect(
+      shouldDefaultProPlusUserToAgent({
+        ...proPlusEligibility,
+        subscription: "pro",
+      }),
+    ).toBe(false);
+    expect(
+      shouldDefaultProPlusUserToAgent({
+        ...proPlusEligibility,
+        subscription: "ultra",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not default temporary chats to Agent", () => {
+    expect(
+      shouldDefaultProPlusUserToAgent({
+        ...proPlusEligibility,
+        temporaryChatsEnabled: true,
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("getAgentFirstDefaultDecision", () => {
   it("returns the free-user decision with the local sandbox requirement", () => {
     expect(getAgentFirstDefaultDecision(baseEligibility)).toEqual({
@@ -177,6 +233,22 @@ describe("getAgentFirstDefaultDecision", () => {
       eligibleSubscriptionTier: "ultra",
       experimentKey: "ultra_agent_default_v1",
       selectionReason: "eligible_ultra_user",
+      useDefaultLocalSandbox: false,
+    });
+  });
+
+  it("returns the Pro Plus decision without the local sandbox requirement", () => {
+    expect(
+      getAgentFirstDefaultDecision({
+        ...baseEligibility,
+        defaultLocalSandboxPreference: null,
+        hasLocalSandbox: false,
+        subscription: "pro-plus",
+      }),
+    ).toEqual({
+      eligibleSubscriptionTier: "pro-plus",
+      experimentKey: "pro_plus_agent_default_v1",
+      selectionReason: "eligible_pro_plus_user",
       useDefaultLocalSandbox: false,
     });
   });

--- a/lib/activation/agent-first-default.ts
+++ b/lib/activation/agent-first-default.ts
@@ -2,10 +2,7 @@ import type { ChatMode, SandboxPreference } from "@/types/chat";
 import type { SubscriptionTier } from "@/types";
 
 export type AgentFirstSandboxType =
-  | "desktop"
-  | "remote-connection"
-  | "e2b"
-  | "none";
+  "desktop" | "remote-connection" | "e2b" | "none";
 
 export type AgentFirstDefaultEligibility = {
   chatMode: ChatMode;
@@ -22,9 +19,15 @@ export type AgentFirstDefaultEligibility = {
 };
 
 export type AgentFirstDefaultDecision = {
-  eligibleSubscriptionTier: "free" | "ultra";
-  experimentKey: "free_agent_first_v1" | "ultra_agent_default_v1";
-  selectionReason: "eligible_free_user_local_sandbox" | "eligible_ultra_user";
+  eligibleSubscriptionTier: "free" | "pro-plus" | "ultra";
+  experimentKey:
+    | "free_agent_first_v1"
+    | "pro_plus_agent_default_v1"
+    | "ultra_agent_default_v1";
+  selectionReason:
+    | "eligible_free_user_local_sandbox"
+    | "eligible_pro_plus_user"
+    | "eligible_ultra_user";
   useDefaultLocalSandbox: boolean;
 };
 
@@ -84,6 +87,15 @@ export function getAgentFirstDefaultDecision({
     };
   }
 
+  if (subscription === "pro-plus") {
+    return {
+      eligibleSubscriptionTier: "pro-plus",
+      experimentKey: "pro_plus_agent_default_v1",
+      selectionReason: "eligible_pro_plus_user",
+      useDefaultLocalSandbox: false,
+    };
+  }
+
   return null;
 }
 
@@ -102,5 +114,14 @@ export function shouldDefaultUltraUserToAgent(
   return (
     getAgentFirstDefaultDecision(eligibility)?.eligibleSubscriptionTier ===
     "ultra"
+  );
+}
+
+export function shouldDefaultProPlusUserToAgent(
+  eligibility: AgentFirstDefaultEligibility,
+): boolean {
+  return (
+    getAgentFirstDefaultDecision(eligibility)?.eligibleSubscriptionTier ===
+    "pro-plus"
   );
 }


### PR DESCRIPTION
## Summary
- include Pro Plus in the paid Agent-first default decision path
- keep Pro unchanged while Pro Plus and Ultra default first-time users to Agent with cloud sandbox behavior
- add helper and GlobalState regression coverage for Pro Plus defaults

## Testing
- ./node_modules/.bin/jest lib/activation/__tests__/agent-first-default.test.ts app/contexts/__tests__/GlobalState.agent-default.test.tsx --runInBand
- ./node_modules/.bin/eslint lib/activation/agent-first-default.ts lib/activation/__tests__/agent-first-default.test.ts app/contexts/__tests__/GlobalState.agent-default.test.tsx
- ./node_modules/.bin/prettier --check lib/activation/agent-first-default.ts lib/activation/__tests__/agent-first-default.test.ts app/contexts/__tests__/GlobalState.agent-default.test.tsx
- ./node_modules/.bin/tsc --noEmit
- commit hook: tsc --noEmit and full jest suite, 190 suites / 1954 tests passed

## Manual verification
- Sign in as a Pro Plus user with no saved chat mode and no mode selected in the current session.
- Open a new chat.
- Confirm the chat starts in Agent mode, selected model is Auto, and the sandbox preference remains the cloud sandbox.
- Confirm a Pro user still starts in Ask mode unless they have an existing saved Agent preference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pro Plus users who are new to the experience now default to Agent chat mode.
  * The default setup now prefers the Auto model and cloud sandbox option for eligible first-time Pro Plus users.

* **Tests**
  * Added coverage to verify the new default behavior and ensure it does not override existing user choices or apply to other plan types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->