### PR TITLE
Add keep plan action for scheduled cancellations

### DIFF
--- a/app/components/AccountTab.tsx
+++ b/app/components/AccountTab.tsx
@@ -13,7 +13,14 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { usePentestgptMigration } from "@/app/hooks/usePentestgptMigration";
-import { CalendarClock, X, ChevronDown, Loader2, Sparkle } from "lucide-react";
+import {
+  CalendarClock,
+  X,
+  ChevronDown,
+  Loader2,
+  Sparkle,
+  Undo2,
+} from "lucide-react";
 import {
   proFeatures,
   proPlusFeatures,
@@ -26,6 +33,7 @@ import redirectToBillingPortalAction from "@/lib/actions/billing-portal";
 import getSubscriptionCancellationStatusAction, {
   type SubscriptionCancellationStatus,
 } from "@/lib/actions/subscription-status";
+import keepSubscriptionAction from "@/lib/actions/keep-subscription";
 import type { SubscriptionTier } from "@/types";
 
 type AccountCancellationStatus = SubscriptionCancellationStatus & {
@@ -46,6 +54,7 @@ const AccountTab = () => {
   const { subscription, setMigrateFromPentestgptDialogOpen } = useGlobalState();
   const [showDeleteAccount, setShowDeleteAccount] = useState(false);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [isKeepingPlan, setIsKeepingPlan] = useState(false);
   const [isTeamAdmin, setIsTeamAdmin] = useState<boolean | null>(null);
   const [cancellationStatus, setCancellationStatus] =
     useState<AccountCancellationStatus | null>(null);
@@ -137,6 +146,41 @@ const AccountTab = () => {
     setShowCancelDialog(true);
   };
 
+  const handleCancellationScheduled = ({
+    currentPeriodEnd,
+  }: {
+    currentPeriodEnd?: number;
+  }) => {
+    setCancellationStatus({
+      subscription,
+      hasActiveSubscription: true,
+      cancelAtPeriodEnd: true,
+      currentPeriodEnd,
+    });
+  };
+
+  const handleKeepPlan = async () => {
+    if (isKeepingPlan) return;
+
+    setIsKeepingPlan(true);
+    try {
+      const result = await keepSubscriptionAction();
+      setCancellationStatus({
+        subscription,
+        hasActiveSubscription: true,
+        cancelAtPeriodEnd: result.cancelAtPeriodEnd,
+        currentPeriodEnd: result.currentPeriodEnd,
+      });
+      toast.success("Cancellation removed. Your plan will renew as usual.");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to keep plan active",
+      );
+    } finally {
+      setIsKeepingPlan(false);
+    }
+  };
+
   const handleOpenMigrateConfirm = () => {
     if (isMigrating) return;
     setMigrateFromPentestgptDialogOpen(true);
@@ -188,10 +232,24 @@ const AccountTab = () => {
                     </>
                   )}
                   {cancellationScheduled ? (
-                    <DropdownMenuItem disabled>
-                      <CalendarClock className="h-4 w-4" />
-                      <span>Cancellation scheduled</span>
-                    </DropdownMenuItem>
+                    <>
+                      <DropdownMenuItem disabled>
+                        <CalendarClock className="h-4 w-4" />
+                        <span>Cancellation scheduled</span>
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onClick={handleKeepPlan}
+                        disabled={isKeepingPlan}
+                      >
+                        {isKeepingPlan ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Undo2 className="h-4 w-4" />
+                        )}
+                        <span>Keep plan</span>
+                      </DropdownMenuItem>
+                    </>
                   ) : noActiveSubscription ? (
                     <DropdownMenuItem disabled>
                       <CalendarClock className="h-4 w-4" />
@@ -341,6 +399,7 @@ const AccountTab = () => {
       <CancelSubscriptionDialog
         open={showCancelDialog}
         onOpenChange={setShowCancelDialog}
+        onCancellationScheduled={handleCancellationScheduled}
       />
     </div>
   );

--- a/app/components/AccountTab.tsx
+++ b/app/components/AccountTab.tsx
@@ -207,9 +207,23 @@ const AccountTab = () => {
             canManageBilling ? (
               <DropdownMenu modal={false}>
                 <DropdownMenuTrigger asChild>
-                  <Button type="button" variant="outline" size="sm">
-                    Manage
-                    <ChevronDown className="h-4 w-4" />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={isKeepingPlan}
+                  >
+                    {isKeepingPlan ? (
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        <span>Keeping...</span>
+                      </>
+                    ) : (
+                      <>
+                        <span>Manage</span>
+                        <ChevronDown className="h-4 w-4" />
+                      </>
+                    )}
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-56">

--- a/app/components/CancelSubscriptionDialog.tsx
+++ b/app/components/CancelSubscriptionDialog.tsx
@@ -43,6 +43,7 @@ import { cn } from "@/lib/utils";
 type CancelSubscriptionDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onCancellationScheduled?: (result: CancellationResult) => void;
 };
 
 type CancellationResult = {
@@ -99,6 +100,7 @@ function getPlanDisplayName(tier: SubscriptionTier) {
 export const CancelSubscriptionDialog = ({
   open,
   onOpenChange,
+  onCancellationScheduled,
 }: CancelSubscriptionDialogProps) => {
   const { subscription } = useGlobalState();
   const [isProcessing, setIsProcessing] = useState(false);
@@ -191,6 +193,10 @@ export const CancelSubscriptionDialog = ({
         currentPeriodEnd: result.currentPeriodEnd,
         alreadyScheduled: result.alreadyScheduled,
       });
+      onCancellationScheduled?.({
+        currentPeriodEnd: result.currentPeriodEnd,
+        alreadyScheduled: result.alreadyScheduled,
+      });
       toast.success(
         result.alreadyScheduled
           ? "Subscription already scheduled to cancel"
@@ -210,7 +216,7 @@ export const CancelSubscriptionDialog = ({
         setIsProcessing(false);
       }
     }
-  }, [reasonCategory, reasonDetails]);
+  }, [onCancellationScheduled, reasonCategory, reasonDetails]);
 
   const handleReasonCategoryChange = useCallback(
     (value: string) => {

--- a/app/components/__tests__/AccountTab.test.tsx
+++ b/app/components/__tests__/AccountTab.test.tsx
@@ -1,10 +1,15 @@
 import "@testing-library/jest-dom";
 import { describe, expect, it, jest, beforeEach } from "@jest/globals";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const mockGetSubscriptionCancellationStatus = jest.fn();
+const mockKeepSubscription = jest.fn();
 const mockSetMigrateFromPentestgptDialogOpen = jest.fn();
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+let mockOnCancellationScheduled:
+  ((result: { currentPeriodEnd?: number }) => void) | undefined;
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({
@@ -31,6 +36,18 @@ jest.mock("@/lib/actions/subscription-status", () => ({
   default: mockGetSubscriptionCancellationStatus,
 }));
 
+jest.mock("@/lib/actions/keep-subscription", () => ({
+  __esModule: true,
+  default: mockKeepSubscription,
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: mockToastSuccess,
+    error: mockToastError,
+  },
+}));
+
 jest.mock("../DeleteAccountDialog", () => ({
   __esModule: true,
   default: () => null,
@@ -38,7 +55,12 @@ jest.mock("../DeleteAccountDialog", () => ({
 
 jest.mock("../CancelSubscriptionDialog", () => ({
   __esModule: true,
-  default: () => null,
+  default: (props: {
+    onCancellationScheduled?: (result: { currentPeriodEnd?: number }) => void;
+  }) => {
+    mockOnCancellationScheduled = props.onCancellationScheduled;
+    return null;
+  },
 }));
 
 const AccountTab = require("../AccountTab")
@@ -47,6 +69,7 @@ const AccountTab = require("../AccountTab")
 describe("AccountTab", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockOnCancellationScheduled = undefined;
   });
 
   it("shows scheduled cancellation state instead of the cancel action", async () => {
@@ -76,6 +99,7 @@ describe("AccountTab", () => {
     await waitFor(() => {
       expect(screen.getByText("Cancellation scheduled")).toBeVisible();
     });
+    expect(screen.getByText("Keep plan")).toBeVisible();
     expect(screen.queryByText("Cancel subscription")).not.toBeInTheDocument();
   });
 
@@ -98,6 +122,82 @@ describe("AccountTab", () => {
     expect(
       screen.queryByText("Cancellation scheduled."),
     ).not.toBeInTheDocument();
+  });
+
+  it("updates the tab when cancellation is scheduled from the dialog", async () => {
+    const currentPeriodEnd = Date.UTC(2026, 6, 31, 12);
+    const expectedPeriodEnd = new Intl.DateTimeFormat(undefined, {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    }).format(new Date(currentPeriodEnd));
+
+    mockGetSubscriptionCancellationStatus.mockResolvedValue({
+      hasActiveSubscription: true,
+      cancelAtPeriodEnd: false,
+    } as never);
+
+    render(<AccountTab />);
+
+    await waitFor(() => {
+      expect(mockGetSubscriptionCancellationStatus).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      mockOnCancellationScheduled?.({ currentPeriodEnd });
+    });
+
+    expect(await screen.findByText("Cancellation scheduled.")).toBeVisible();
+    expect(
+      screen.getByText(`Your plan stays active until ${expectedPeriodEnd}.`),
+    ).toBeVisible();
+
+    const user = userEvent.setup();
+    await user.click(screen.getAllByRole("button", { name: /manage/i })[0]);
+
+    expect(screen.getByText("Cancellation scheduled")).toBeVisible();
+    expect(screen.getByText("Keep plan")).toBeVisible();
+    expect(screen.queryByText("Cancel subscription")).not.toBeInTheDocument();
+  });
+
+  it("keeps the plan and restores the cancel action from the manage menu", async () => {
+    const currentPeriodEnd = Date.UTC(2026, 6, 31, 12);
+
+    mockGetSubscriptionCancellationStatus.mockResolvedValue({
+      hasActiveSubscription: true,
+      cancelAtPeriodEnd: true,
+      currentPeriodEnd,
+    } as never);
+    mockKeepSubscription.mockResolvedValue({
+      kept: true,
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd,
+      alreadyKept: false,
+    } as never);
+
+    render(<AccountTab />);
+
+    expect(await screen.findByText("Cancellation scheduled.")).toBeVisible();
+
+    const user = userEvent.setup();
+    await user.click(screen.getAllByRole("button", { name: /manage/i })[0]);
+    await user.click(screen.getByText("Keep plan"));
+
+    await waitFor(() => {
+      expect(mockKeepSubscription).toHaveBeenCalledTimes(1);
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        "Cancellation removed. Your plan will renew as usual.",
+      );
+    });
+
+    expect(
+      screen.queryByText("Cancellation scheduled."),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getAllByRole("button", { name: /manage/i })[0]);
+
+    expect(screen.getByText("Cancel subscription")).toBeVisible();
+    expect(screen.queryByText("Keep plan")).not.toBeInTheDocument();
   });
 
   it("does not offer cancellation when no active subscription is found", async () => {

--- a/app/components/__tests__/AccountTab.test.tsx
+++ b/app/components/__tests__/AccountTab.test.tsx
@@ -200,6 +200,48 @@ describe("AccountTab", () => {
     expect(screen.queryByText("Keep plan")).not.toBeInTheDocument();
   });
 
+  it("leaves scheduled cancellation visible when keeping the plan fails", async () => {
+    const currentPeriodEnd = Date.UTC(2026, 6, 31, 12);
+    let rejectKeepPlan: (error: Error) => void = () => {};
+
+    mockGetSubscriptionCancellationStatus.mockResolvedValue({
+      hasActiveSubscription: true,
+      cancelAtPeriodEnd: true,
+      currentPeriodEnd,
+    } as never);
+    mockKeepSubscription.mockReturnValue(
+      new Promise((_, reject) => {
+        rejectKeepPlan = reject;
+      }) as never,
+    );
+
+    render(<AccountTab />);
+
+    expect(await screen.findByText("Cancellation scheduled.")).toBeVisible();
+
+    const user = userEvent.setup();
+    await user.click(screen.getAllByRole("button", { name: /manage/i })[0]);
+    await user.click(screen.getByText("Keep plan"));
+
+    expect(screen.getByRole("button", { name: /keeping/i })).toBeVisible();
+
+    act(() => {
+      rejectKeepPlan(new Error("Stripe update failed"));
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Stripe update failed");
+    });
+
+    expect(screen.getByText("Cancellation scheduled.")).toBeVisible();
+    expect(screen.getAllByRole("button", { name: /manage/i })[0]).toBeVisible();
+
+    await user.click(screen.getAllByRole("button", { name: /manage/i })[0]);
+
+    expect(screen.getByText("Keep plan")).toBeVisible();
+    expect(screen.queryByText("Cancel subscription")).not.toBeInTheDocument();
+  });
+
   it("does not offer cancellation when no active subscription is found", async () => {
     mockGetSubscriptionCancellationStatus.mockResolvedValue({
       hasActiveSubscription: false,

--- a/lib/actions/__tests__/keep-subscription.test.ts
+++ b/lib/actions/__tests__/keep-subscription.test.ts
@@ -6,6 +6,14 @@ const mockUpdateSubscription = jest.fn();
 const mockGetBillingActionContext = jest.fn();
 const mockPostHogEvent = jest.fn();
 
+function mockStripeSubscriptionsList(data: unknown[]) {
+  mockListSubscriptions.mockReturnValue({
+    async *[Symbol.asyncIterator]() {
+      yield* data;
+    },
+  } as never);
+}
+
 jest.mock("@/app/api/stripe", () => ({
   stripe: {
     subscriptions: {
@@ -38,26 +46,24 @@ describe("keepSubscriptionAction", () => {
   });
 
   it("removes scheduled cancellation from the active subscription", async () => {
-    mockListSubscriptions.mockResolvedValue({
-      data: [
-        {
-          id: "sub_123",
-          status: "active",
-          cancel_at_period_end: true,
-          current_period_end: 1_782_444_800,
-          items: {
-            data: [
-              {
-                price: {
-                  id: "price_pro",
-                  lookup_key: "pro-monthly-plan",
-                },
+    mockStripeSubscriptionsList([
+      {
+        id: "sub_123",
+        status: "active",
+        cancel_at_period_end: true,
+        current_period_end: 1_782_444_800,
+        items: {
+          data: [
+            {
+              price: {
+                id: "price_pro",
+                lookup_key: "pro-monthly-plan",
               },
-            ],
-          },
+            },
+          ],
         },
-      ],
-    } as never);
+      },
+    ]);
     mockUpdateSubscription.mockResolvedValue({
       id: "sub_123",
       cancel_at_period_end: false,
@@ -77,7 +83,7 @@ describe("keepSubscriptionAction", () => {
     expect(mockListSubscriptions).toHaveBeenCalledWith({
       customer: "cus_123",
       status: "all",
-      limit: 10,
+      limit: 100,
       expand: ["data.items.data.price"],
     });
     expect(mockUpdateSubscription).toHaveBeenCalledWith("sub_123", {
@@ -100,26 +106,24 @@ describe("keepSubscriptionAction", () => {
   });
 
   it("returns success without updating Stripe when cancellation is already removed", async () => {
-    mockListSubscriptions.mockResolvedValue({
-      data: [
-        {
-          id: "sub_123",
-          status: "active",
-          cancel_at_period_end: false,
-          current_period_end: 1_782_444_800,
-          items: {
-            data: [
-              {
-                price: {
-                  id: "price_pro",
-                  lookup_key: "pro-monthly-plan",
-                },
+    mockStripeSubscriptionsList([
+      {
+        id: "sub_123",
+        status: "active",
+        cancel_at_period_end: false,
+        current_period_end: 1_782_444_800,
+        items: {
+          data: [
+            {
+              price: {
+                id: "price_pro",
+                lookup_key: "pro-monthly-plan",
               },
-            ],
-          },
+            },
+          ],
         },
-      ],
-    } as never);
+      },
+    ]);
 
     const { default: keepSubscriptionAction } =
       await import("../keep-subscription");
@@ -136,16 +140,14 @@ describe("keepSubscriptionAction", () => {
   });
 
   it("throws when there is no active subscription to keep", async () => {
-    mockListSubscriptions.mockResolvedValue({
-      data: [
-        {
-          id: "sub_canceled",
-          status: "canceled",
-          cancel_at_period_end: false,
-          items: { data: [] },
-        },
-      ],
-    } as never);
+    mockStripeSubscriptionsList([
+      {
+        id: "sub_canceled",
+        status: "canceled",
+        cancel_at_period_end: false,
+        items: { data: [] },
+      },
+    ]);
 
     const { default: keepSubscriptionAction } =
       await import("../keep-subscription");

--- a/lib/actions/__tests__/keep-subscription.test.ts
+++ b/lib/actions/__tests__/keep-subscription.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
+
+const mockListSubscriptions = jest.fn();
+const mockUpdateSubscription = jest.fn();
+const mockGetBillingActionContext = jest.fn();
+const mockPostHogEvent = jest.fn();
+
+jest.mock("@/app/api/stripe", () => ({
+  stripe: {
+    subscriptions: {
+      list: mockListSubscriptions,
+      update: mockUpdateSubscription,
+    },
+  },
+}));
+
+jest.mock("@/lib/actions/billing-context", () => ({
+  getBillingActionContext: mockGetBillingActionContext,
+}));
+
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: {
+    event: mockPostHogEvent,
+  },
+}));
+
+describe("keepSubscriptionAction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetBillingActionContext.mockResolvedValue({
+      organizationId: "org_123",
+      user: {
+        id: "user_123",
+      },
+      stripeCustomerId: "cus_123",
+    } as never);
+  });
+
+  it("removes scheduled cancellation from the active subscription", async () => {
+    mockListSubscriptions.mockResolvedValue({
+      data: [
+        {
+          id: "sub_123",
+          status: "active",
+          cancel_at_period_end: true,
+          current_period_end: 1_782_444_800,
+          items: {
+            data: [
+              {
+                price: {
+                  id: "price_pro",
+                  lookup_key: "pro-monthly-plan",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } as never);
+    mockUpdateSubscription.mockResolvedValue({
+      id: "sub_123",
+      cancel_at_period_end: false,
+      current_period_end: 1_782_444_800,
+    } as never);
+
+    const { default: keepSubscriptionAction } =
+      await import("../keep-subscription");
+
+    await expect(keepSubscriptionAction()).resolves.toEqual({
+      kept: true,
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: 1_782_444_800_000,
+      alreadyKept: false,
+    });
+
+    expect(mockListSubscriptions).toHaveBeenCalledWith({
+      customer: "cus_123",
+      status: "all",
+      limit: 10,
+      expand: ["data.items.data.price"],
+    });
+    expect(mockUpdateSubscription).toHaveBeenCalledWith("sub_123", {
+      cancel_at_period_end: false,
+    });
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      PAID_FUNNEL_EVENTS.cancellationReversed,
+      expect.objectContaining({
+        userId: "user_123",
+        org_id: "org_123",
+        subscription_tier: "pro",
+        plan: "pro-monthly-plan",
+        cancellation_reversal_type: "in_app",
+        cancel_at_period_end: false,
+        stripe_customer_id: "cus_123",
+        stripe_subscription_id: "sub_123",
+        stripe_price_id: "price_pro",
+      }),
+    );
+  });
+
+  it("returns success without updating Stripe when cancellation is already removed", async () => {
+    mockListSubscriptions.mockResolvedValue({
+      data: [
+        {
+          id: "sub_123",
+          status: "active",
+          cancel_at_period_end: false,
+          current_period_end: 1_782_444_800,
+          items: {
+            data: [
+              {
+                price: {
+                  id: "price_pro",
+                  lookup_key: "pro-monthly-plan",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } as never);
+
+    const { default: keepSubscriptionAction } =
+      await import("../keep-subscription");
+
+    await expect(keepSubscriptionAction()).resolves.toEqual({
+      kept: true,
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: 1_782_444_800_000,
+      alreadyKept: true,
+    });
+
+    expect(mockUpdateSubscription).not.toHaveBeenCalled();
+    expect(mockPostHogEvent).not.toHaveBeenCalled();
+  });
+
+  it("throws when there is no active subscription to keep", async () => {
+    mockListSubscriptions.mockResolvedValue({
+      data: [
+        {
+          id: "sub_canceled",
+          status: "canceled",
+          cancel_at_period_end: false,
+          items: { data: [] },
+        },
+      ],
+    } as never);
+
+    const { default: keepSubscriptionAction } =
+      await import("../keep-subscription");
+
+    await expect(keepSubscriptionAction()).rejects.toThrow(
+      "No active subscription found",
+    );
+    expect(mockUpdateSubscription).not.toHaveBeenCalled();
+  });
+});

--- a/lib/actions/keep-subscription.ts
+++ b/lib/actions/keep-subscription.ts
@@ -8,6 +8,7 @@ import {
   paidFunnelProperties,
   planLookupKeyToTier,
 } from "@/lib/analytics/paid-funnel";
+import type Stripe from "stripe";
 import type { SubscriptionTier } from "@/types";
 
 type SubscriptionContext = {
@@ -45,15 +46,21 @@ function currentPeriodEndMs(subscription: unknown): number | undefined {
 async function getActiveSubscriptionContext(
   stripeCustomerId: string,
 ): Promise<SubscriptionContext> {
-  const subscriptions = await stripe.subscriptions.list({
+  const subscriptions = stripe.subscriptions.list({
     customer: stripeCustomerId,
     status: "all",
-    limit: 10,
+    limit: 100,
     expand: ["data.items.data.price"],
   });
-  const currentSubscription = subscriptions.data.find((subscription) =>
-    ["active", "trialing", "past_due", "unpaid"].includes(subscription.status),
-  );
+  let currentSubscription: Stripe.Subscription | undefined;
+  for await (const subscription of subscriptions) {
+    if (
+      ["active", "trialing", "past_due", "unpaid"].includes(subscription.status)
+    ) {
+      currentSubscription = subscription;
+      break;
+    }
+  }
 
   if (!currentSubscription) {
     throw new Error("No active subscription found");

--- a/lib/actions/keep-subscription.ts
+++ b/lib/actions/keep-subscription.ts
@@ -1,0 +1,119 @@
+"use server";
+
+import { stripe } from "../../app/api/stripe";
+import { getBillingActionContext } from "@/lib/actions/billing-context";
+import { phLogger } from "@/lib/posthog/server";
+import {
+  PAID_FUNNEL_EVENTS,
+  paidFunnelProperties,
+  planLookupKeyToTier,
+} from "@/lib/analytics/paid-funnel";
+import type { SubscriptionTier } from "@/types";
+
+type SubscriptionContext = {
+  id: string;
+  priceId?: string;
+  plan?: string;
+  tier?: SubscriptionTier;
+  currentPeriodEnd?: number;
+  cancelAtPeriodEnd: boolean;
+};
+
+export type KeepSubscriptionResult = {
+  kept: true;
+  cancelAtPeriodEnd: boolean;
+  currentPeriodEnd?: number;
+  alreadyKept: boolean;
+};
+
+function subscriptionTierFromLookupKey(
+  lookupKey: string | null | undefined,
+): SubscriptionTier | undefined {
+  return planLookupKeyToTier(lookupKey ?? undefined) ?? undefined;
+}
+
+function currentPeriodEndMs(subscription: unknown): number | undefined {
+  const currentPeriodEnd = (subscription as { current_period_end?: unknown })
+    .current_period_end;
+  return typeof currentPeriodEnd === "number" &&
+    Number.isFinite(currentPeriodEnd) &&
+    currentPeriodEnd > 0
+    ? currentPeriodEnd * 1000
+    : undefined;
+}
+
+async function getActiveSubscriptionContext(
+  stripeCustomerId: string,
+): Promise<SubscriptionContext> {
+  const subscriptions = await stripe.subscriptions.list({
+    customer: stripeCustomerId,
+    status: "all",
+    limit: 10,
+    expand: ["data.items.data.price"],
+  });
+  const currentSubscription = subscriptions.data.find((subscription) =>
+    ["active", "trialing", "past_due", "unpaid"].includes(subscription.status),
+  );
+
+  if (!currentSubscription) {
+    throw new Error("No active subscription found");
+  }
+
+  const price = currentSubscription.items.data[0]?.price;
+  return {
+    id: currentSubscription.id,
+    priceId: price?.id,
+    plan: price?.lookup_key ?? undefined,
+    tier: subscriptionTierFromLookupKey(price?.lookup_key),
+    currentPeriodEnd: currentPeriodEndMs(currentSubscription),
+    cancelAtPeriodEnd: currentSubscription.cancel_at_period_end === true,
+  };
+}
+
+export default async function keepSubscriptionAction(): Promise<KeepSubscriptionResult> {
+  const { organizationId, user, stripeCustomerId } =
+    await getBillingActionContext();
+  const subscriptionContext =
+    await getActiveSubscriptionContext(stripeCustomerId);
+
+  if (!subscriptionContext.cancelAtPeriodEnd) {
+    return {
+      kept: true,
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: subscriptionContext.currentPeriodEnd,
+      alreadyKept: true,
+    };
+  }
+
+  const updatedSubscription = await stripe.subscriptions.update(
+    subscriptionContext.id,
+    {
+      cancel_at_period_end: false,
+    },
+  );
+
+  phLogger.event(
+    PAID_FUNNEL_EVENTS.cancellationReversed,
+    paidFunnelProperties({
+      userId: user.id,
+      org_id: organizationId,
+      subscription_tier: subscriptionContext.tier,
+      plan: subscriptionContext.plan,
+      cancellation_reversal_type: "in_app",
+      cancel_at_period_end: updatedSubscription.cancel_at_period_end,
+      stripe_customer_id: stripeCustomerId,
+      stripe_subscription_id: subscriptionContext.id,
+      stripe_price_id: subscriptionContext.priceId,
+      $insert_id: `${PAID_FUNNEL_EVENTS.cancellationReversed}:${subscriptionContext.id}:in_app`,
+    }),
+  );
+
+  return {
+    kept: true,
+    cancelAtPeriodEnd: updatedSubscription.cancel_at_period_end === true,
+    currentPeriodEnd:
+      currentPeriodEndMs(updatedSubscription) ??
+      subscriptionContext.currentPeriodEnd,
+    alreadyKept: false,
+  };
+}

--- a/lib/analytics/paid-funnel.ts
+++ b/lib/analytics/paid-funnel.ts
@@ -13,6 +13,7 @@ export const PAID_FUNNEL_EVENTS = {
   cancellationReasonSelected: "cancellation_reason_selected",
   cancellationReasonSubmitted: "cancellation_reason_free_text_submitted",
   cancellationCompleted: "cancellation_completed",
+  cancellationReversed: "cancellation_reversed",
   limitHit: "limit_hit",
   paidDailyFreeAllowanceImpressed: "paid_daily_free_allowance_impressed",
   paidDailyFreeAllowanceClicked: "paid_daily_free_allowance_clicked",


### PR DESCRIPTION
## Summary
- refresh the Account tab immediately after an in-app cancellation is scheduled so the scheduled-cancellation banner appears without a page refresh
- add a Stripe-backed keep-plan server action that clears cancel_at_period_end and is idempotent if the cancellation was already removed
- add a Keep plan item under the Account Manage dropdown when cancellation is scheduled, plus analytics and focused regression coverage

## Testing
- ./node_modules/.bin/jest app/components/__tests__/AccountTab.test.tsx lib/actions/__tests__/keep-subscription.test.ts lib/actions/__tests__/cancel-subscription.test.ts lib/actions/__tests__/subscription-status.test.ts --runInBand
- ./node_modules/.bin/prettier --check app/components/AccountTab.tsx app/components/CancelSubscriptionDialog.tsx app/components/__tests__/AccountTab.test.tsx lib/actions/keep-subscription.ts lib/actions/__tests__/keep-subscription.test.ts lib/analytics/paid-funnel.ts
- ./node_modules/.bin/eslint app/components/AccountTab.tsx app/components/CancelSubscriptionDialog.tsx app/components/__tests__/AccountTab.test.tsx lib/actions/keep-subscription.ts lib/actions/__tests__/keep-subscription.test.ts lib/analytics/paid-funnel.ts
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/eslint app lib types __mocks__ --ext .ts,.tsx,.js,.jsx (passes with existing warnings)
- pre-commit hook: tsc --noEmit and full jest suite, 191 suites / 1953 tests passed

## Manual verification
- In a paid account with an active subscription, cancel from Settings -> Account and confirm the banner appears immediately without refreshing.
- Open Settings -> Account -> Manage while cancellation is scheduled, click Keep plan, and confirm the banner disappears and Cancel subscription returns.
- Confirm the Stripe subscription has cancel_at_period_end=false and future renewal remains active.

## Visual verification
- Local browser visual verification was not completed because the Account tab billing state requires an authenticated paid account with a scheduled Stripe cancellation. Component tests cover the menu/banner state transitions; manual verification above covers the real billing UI flow.