### PR TITLE
Show OpenRouter reasoning after tool calls

### DIFF
--- a/app/components/ReasoningHandler.tsx
+++ b/app/components/ReasoningHandler.tsx
@@ -33,13 +33,6 @@ const collectReasoningText = (
   return collected.join("");
 };
 
-const collectReasoningComparisonKey = (
-  parts: UIMessage["parts"],
-  startIndex: number,
-): string => {
-  return collectReasoningText(parts, startIndex);
-};
-
 // Hoist regex outside component to avoid recreation
 const REDACTED_PATTERN = /^(\[REDACTED\])+$/;
 
@@ -59,8 +52,8 @@ function areReasoningPropsEqual(
   if (prevPart?.type !== nextPart?.type) return false;
   if (prevPart?.type === "reasoning" && nextPart?.type === "reasoning") {
     return (
-      collectReasoningComparisonKey(prev.message.parts, prev.partIndex) ===
-      collectReasoningComparisonKey(next.message.parts, next.partIndex)
+      collectReasoningText(prev.message.parts, prev.partIndex) ===
+      collectReasoningText(next.message.parts, next.partIndex)
     );
   }
   return true;
@@ -78,22 +71,21 @@ export const ReasoningHandler = memo(function ReasoningHandler({
     [message.parts],
   );
   const currentPart = parts[partIndex];
+  const previousPart = parts[partIndex - 1];
+  const isPreviousReasoning = previousPart?.type === "reasoning";
 
   // Memoize combined text collection - only recompute when parts or index changes
   const combined = useMemo(() => {
     if (currentPart?.type !== "reasoning") return "";
-    // Skip if previous part is also reasoning (avoid duplicate renders)
-    const previousPart = parts[partIndex - 1];
-    if (previousPart?.type === "reasoning") return "";
+    if (isPreviousReasoning) return "";
     return collectReasoningText(parts, partIndex);
-  }, [parts, partIndex, currentPart?.type]);
+  }, [parts, partIndex, currentPart?.type, isPreviousReasoning]);
 
   // Early return for non-reasoning parts
   if (currentPart?.type !== "reasoning") return null;
 
   // Skip if previous part is also reasoning (avoid duplicate renders)
-  const previousPart = parts[partIndex - 1];
-  if (previousPart?.type === "reasoning") return null;
+  if (isPreviousReasoning) return null;
 
   // Don't show reasoning if empty or only contains [REDACTED] (encrypted reasoning from providers like Gemini)
   if (!combined || REDACTED_PATTERN.test(combined.trim())) return null;

--- a/app/components/ReasoningHandler.tsx
+++ b/app/components/ReasoningHandler.tsx
@@ -9,7 +9,6 @@ import {
   ReasoningContent,
   ReasoningTrigger,
 } from "@/components/ai-elements/reasoning";
-import { partHasOpenRouterReasoningDetails } from "@/lib/chat/provider-metadata-sanitizer";
 
 type ReasoningHandlerProps = {
   message: UIMessage;
@@ -25,10 +24,7 @@ const collectReasoningText = (
   const collected: string[] = [];
   for (let i = startIndex; i < parts.length; i++) {
     const part = parts[i];
-    if (
-      part?.type === "reasoning" &&
-      !partHasOpenRouterReasoningDetails(part)
-    ) {
+    if (part?.type === "reasoning") {
       collected.push(part.text ?? "");
     } else {
       break;
@@ -41,16 +37,7 @@ const collectReasoningComparisonKey = (
   parts: UIMessage["parts"],
   startIndex: number,
 ): string => {
-  const run: Array<{ hidden: boolean; text?: string }> = [];
-  for (let i = startIndex; i < parts.length; i++) {
-    const part = parts[i];
-    if (part?.type !== "reasoning") break;
-    run.push({
-      hidden: partHasOpenRouterReasoningDetails(part),
-      text: part.text,
-    });
-  }
-  return JSON.stringify(run);
+  return collectReasoningText(parts, startIndex);
 };
 
 // Hoist regex outside component to avoid recreation
@@ -71,14 +58,9 @@ function areReasoningPropsEqual(
   const nextPart = next.message.parts[next.partIndex];
   if (prevPart?.type !== nextPart?.type) return false;
   if (prevPart?.type === "reasoning" && nextPart?.type === "reasoning") {
-    const prevPreviousPart = prev.message.parts[prev.partIndex - 1];
-    const nextPreviousPart = next.message.parts[next.partIndex - 1];
     return (
       collectReasoningComparisonKey(prev.message.parts, prev.partIndex) ===
-        collectReasoningComparisonKey(next.message.parts, next.partIndex) &&
-      prevPreviousPart?.type === nextPreviousPart?.type &&
-      partHasOpenRouterReasoningDetails(prevPreviousPart) ===
-        partHasOpenRouterReasoningDetails(nextPreviousPart)
+      collectReasoningComparisonKey(next.message.parts, next.partIndex)
     );
   }
   return true;
@@ -102,27 +84,16 @@ export const ReasoningHandler = memo(function ReasoningHandler({
     if (currentPart?.type !== "reasoning") return "";
     // Skip if previous part is also reasoning (avoid duplicate renders)
     const previousPart = parts[partIndex - 1];
-    if (
-      previousPart?.type === "reasoning" &&
-      !partHasOpenRouterReasoningDetails(previousPart)
-    ) {
-      return "";
-    }
+    if (previousPart?.type === "reasoning") return "";
     return collectReasoningText(parts, partIndex);
   }, [parts, partIndex, currentPart?.type]);
 
   // Early return for non-reasoning parts
   if (currentPart?.type !== "reasoning") return null;
-  if (partHasOpenRouterReasoningDetails(currentPart)) return null;
 
   // Skip if previous part is also reasoning (avoid duplicate renders)
   const previousPart = parts[partIndex - 1];
-  if (
-    previousPart?.type === "reasoning" &&
-    !partHasOpenRouterReasoningDetails(previousPart)
-  ) {
-    return null;
-  }
+  if (previousPart?.type === "reasoning") return null;
 
   // Don't show reasoning if empty or only contains [REDACTED] (encrypted reasoning from providers like Gemini)
   if (!combined || REDACTED_PATTERN.test(combined.trim())) return null;

--- a/app/components/__tests__/ReasoningHandler.test.tsx
+++ b/app/components/__tests__/ReasoningHandler.test.tsx
@@ -1,0 +1,39 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import type { UIMessage } from "@ai-sdk/react";
+import { ReasoningHandler } from "../ReasoningHandler";
+
+describe("ReasoningHandler", () => {
+  it("renders OpenRouter reasoning parts with reasoning_details metadata", () => {
+    const message = {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "reasoning",
+          state: "done",
+          text: "Visible reasoning text",
+          providerMetadata: {
+            openrouter: {
+              reasoning_details: [
+                { type: "reasoning.text", text: "Visible reasoning text" },
+              ],
+            },
+          },
+        },
+      ],
+    } as unknown as UIMessage;
+
+    render(
+      <ReasoningHandler
+        message={message}
+        partIndex={0}
+        status="streaming"
+        isLastMessage
+      />,
+    );
+
+    expect(screen.getByText("Thinking...")).toBeInTheDocument();
+    expect(screen.getByText("Visible reasoning text")).toBeInTheDocument();
+  });
+});

--- a/components/ai-elements/__tests__/reasoning.test.tsx
+++ b/components/ai-elements/__tests__/reasoning.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { Reasoning, ReasoningContent, ReasoningTrigger } from "../reasoning";
 
 describe("Reasoning", () => {
@@ -21,5 +21,27 @@ describe("Reasoning", () => {
     expect(content).toHaveClass("overflow-x-hidden");
     expect(content).toHaveClass("break-words");
     expect(content).toHaveClass("[overflow-wrap:anywhere]");
+  });
+
+  it("keeps visible reasoning open after streaming stops", async () => {
+    const { rerender } = render(
+      <Reasoning isStreaming>
+        <ReasoningTrigger />
+        <ReasoningContent>Visible reasoning text</ReasoningContent>
+      </Reasoning>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Visible reasoning text")).toBeVisible();
+    });
+
+    rerender(
+      <Reasoning isStreaming={false}>
+        <ReasoningTrigger />
+        <ReasoningContent>Visible reasoning text</ReasoningContent>
+      </Reasoning>,
+    );
+
+    expect(screen.getByText("Visible reasoning text")).toBeVisible();
   });
 });

--- a/components/ai-elements/__tests__/reasoning.test.tsx
+++ b/components/ai-elements/__tests__/reasoning.test.tsx
@@ -23,7 +23,7 @@ describe("Reasoning", () => {
     expect(content).toHaveClass("[overflow-wrap:anywhere]");
   });
 
-  it("keeps visible reasoning open after streaming stops", async () => {
+  it("keeps the reasoning row visible but collapses content after streaming stops", async () => {
     const { rerender } = render(
       <Reasoning isStreaming>
         <ReasoningTrigger />
@@ -42,6 +42,9 @@ describe("Reasoning", () => {
       </Reasoning>,
     );
 
-    expect(screen.getByText("Visible reasoning text")).toBeVisible();
+    expect(screen.getByText("Reasoning")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Visible reasoning text"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/components/ai-elements/__tests__/reasoning.test.tsx
+++ b/components/ai-elements/__tests__/reasoning.test.tsx
@@ -43,8 +43,10 @@ describe("Reasoning", () => {
     );
 
     expect(screen.getByText("Reasoning")).toBeInTheDocument();
-    expect(
-      screen.queryByText("Visible reasoning text"),
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Visible reasoning text"),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/components/ai-elements/reasoning.tsx
+++ b/components/ai-elements/reasoning.tsx
@@ -47,7 +47,7 @@ export function Reasoning({
   });
 
   useEffect(() => {
-    setIsOpen(isStreaming);
+    if (isStreaming) setIsOpen(true);
   }, [isStreaming, setIsOpen]);
 
   const contextValue = useMemo(

--- a/components/ai-elements/reasoning.tsx
+++ b/components/ai-elements/reasoning.tsx
@@ -47,7 +47,7 @@ export function Reasoning({
   });
 
   useEffect(() => {
-    if (isStreaming) setIsOpen(true);
+    setIsOpen(isStreaming);
   }, [isStreaming, setIsOpen]);
 
   const contextValue = useMemo(

--- a/lib/chat/__tests__/provider-metadata-sanitizer.test.ts
+++ b/lib/chat/__tests__/provider-metadata-sanitizer.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../provider-metadata-sanitizer";
 
 describe("OpenRouter reasoning metadata sanitizer", () => {
-  it("drops OpenRouter-backed reasoning parts and strips reasoning_details from tool metadata", () => {
+  it("keeps reasoning parts and strips reasoning_details from metadata", () => {
     const message = {
       id: "assistant-1",
       role: "assistant",
@@ -60,18 +60,23 @@ describe("OpenRouter reasoning metadata sanitizer", () => {
     const sanitized = stripOpenRouterReasoningMetadataFromMessage(message);
 
     expect(sanitized).not.toBe(message);
-    expect(sanitized.parts).toHaveLength(1);
+    expect(sanitized.parts).toHaveLength(2);
     expect(sanitized.parts[0]).toMatchObject({
+      type: "reasoning",
+      state: "done",
+      text: "private chain of thought",
+    });
+    expect((sanitized.parts[0] as any).providerMetadata).toBeUndefined();
+    expect(sanitized.parts[1]).toMatchObject({
       type: "tool-run_terminal_cmd",
       providerMetadata: {
         openrouter: { generation_id: "gen-1" },
         google: { thought_signature: "gemini-signature" },
       },
     });
-    expect((sanitized.parts[0] as any).callProviderMetadata).toBeUndefined();
-    expect((sanitized.parts[0] as any).resultProviderMetadata).toBeUndefined();
+    expect((sanitized.parts[1] as any).callProviderMetadata).toBeUndefined();
+    expect((sanitized.parts[1] as any).resultProviderMetadata).toBeUndefined();
     expect(JSON.stringify(sanitized)).not.toContain("reasoning_details");
-    expect(JSON.stringify(sanitized)).not.toContain("private chain of thought");
   });
 
   it("preserves non-OpenRouter provider metadata unchanged", () => {

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -662,12 +662,12 @@ export async function processChatMessages({
   modelOverride?: SelectedModel;
   allowLocalDesktopFiles?: boolean;
 }) {
-  const messagesWithoutOpenRouterReasoning =
+  const messagesWithoutOpenRouterReasoningMetadata =
     stripOpenRouterReasoningMetadataFromMessages(messages);
 
   // Filter out UI-only parts (data-summarization) that AI providers don't understand
   const messagesWithoutUIOnlyParts =
-    messagesWithoutOpenRouterReasoning.map(filterUIOnlyParts);
+    messagesWithoutOpenRouterReasoningMetadata.map(filterUIOnlyParts);
 
   // Limit image parts before fetching URLs to avoid unnecessary S3 requests
   // Keep image attachment pruning aligned with the per-message upload cap.

--- a/lib/chat/provider-metadata-sanitizer.ts
+++ b/lib/chat/provider-metadata-sanitizer.ts
@@ -5,7 +5,6 @@ type MessageWithParts = {
 type SanitizePartResult = {
   part: unknown;
   changed: boolean;
-  drop: boolean;
 };
 
 const PROVIDER_METADATA_KEYS = [
@@ -19,23 +18,6 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
   Object.prototype.hasOwnProperty.call(value, key);
-
-function hasOpenRouterReasoningDetails(metadata: unknown): boolean {
-  if (!isRecord(metadata)) return false;
-  const openrouter = metadata.openrouter;
-  return (
-    isRecord(openrouter) &&
-    Array.isArray(openrouter.reasoning_details) &&
-    openrouter.reasoning_details.length > 0
-  );
-}
-
-export function partHasOpenRouterReasoningDetails(part: unknown): boolean {
-  if (!isRecord(part)) return false;
-  return PROVIDER_METADATA_KEYS.some((key) =>
-    hasOpenRouterReasoningDetails(part[key]),
-  );
-}
 
 function stripOpenRouterReasoningDetailsFromMetadata(metadata: unknown): {
   metadata: unknown;
@@ -62,11 +44,7 @@ function stripOpenRouterReasoningDetailsFromMetadata(metadata: unknown): {
 function sanitizeOpenRouterReasoningPartMetadata(
   part: unknown,
 ): SanitizePartResult {
-  if (!isRecord(part)) return { part, changed: false, drop: false };
-
-  if (part.type === "reasoning" && partHasOpenRouterReasoningDetails(part)) {
-    return { part, changed: true, drop: true };
-  }
+  if (!isRecord(part)) return { part, changed: false };
 
   let changed = false;
   const cleanedPart = { ...part };
@@ -90,9 +68,7 @@ function sanitizeOpenRouterReasoningPartMetadata(
     }
   }
 
-  return changed
-    ? { part: cleanedPart, changed, drop: false }
-    : { part, changed: false, drop: false };
+  return changed ? { part: cleanedPart, changed } : { part, changed: false };
 }
 
 export function stripOpenRouterReasoningMetadataFromParts<T extends unknown[]>(
@@ -103,10 +79,6 @@ export function stripOpenRouterReasoningMetadataFromParts<T extends unknown[]>(
 
   for (const part of parts) {
     const result = sanitizeOpenRouterReasoningPartMetadata(part);
-    if (result.drop) {
-      changed = true;
-      continue;
-    }
     if (result.changed) changed = true;
     nextParts.push(result.part);
   }

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -344,17 +344,20 @@ describe("saveMessage", () => {
       parts: Array<Record<string, unknown>>;
     };
 
-    expect(compactedMessage.parts).toHaveLength(1);
-    expect(compactedMessage.parts[0].type).toBe("tool-run_terminal_cmd");
-    expect(compactedMessage.parts[0].providerMetadata).toEqual({
+    expect(compactedMessage.parts).toHaveLength(2);
+    expect(compactedMessage.parts[0]).toMatchObject({
+      type: "reasoning",
+      state: "done",
+      text: "private chain of thought",
+    });
+    expect(compactedMessage.parts[0].providerMetadata).toBeUndefined();
+    expect(compactedMessage.parts[1].type).toBe("tool-run_terminal_cmd");
+    expect(compactedMessage.parts[1].providerMetadata).toEqual({
       google: { thought_signature: "gemini-signature" },
     });
-    expect(compactedMessage.parts[0].callProviderMetadata).toBeUndefined();
+    expect(compactedMessage.parts[1].callProviderMetadata).toBeUndefined();
     expect(JSON.stringify(compactedMessage.parts)).not.toContain(
       "reasoning_details",
-    );
-    expect(JSON.stringify(compactedMessage.parts)).not.toContain(
-      "private chain of thought",
     );
   });
 


### PR DESCRIPTION
## Summary
- keep OpenRouter reasoning parts visible instead of dropping them when reasoning_details metadata is present
- continue stripping nested OpenRouter reasoning_details metadata from saved/provider-bound parts
- keep the reasoning row visible while auto-collapsing its content when streaming/reasoning stops

## Testing
- ./node_modules/.bin/jest components/ai-elements/__tests__/reasoning.test.tsx app/components/__tests__/ReasoningHandler.test.tsx lib/chat/__tests__/provider-metadata-sanitizer.test.ts lib/db/__tests__/actions-save-message.test.ts --runInBand
- ./node_modules/.bin/eslint components/ai-elements/reasoning.tsx components/ai-elements/__tests__/reasoning.test.tsx app/components/ReasoningHandler.tsx app/components/__tests__/ReasoningHandler.test.tsx lib/chat/provider-metadata-sanitizer.ts lib/chat/__tests__/provider-metadata-sanitizer.test.ts lib/db/__tests__/actions-save-message.test.ts lib/chat/chat-processor.ts
- ./node_modules/.bin/prettier --check components/ai-elements/reasoning.tsx components/ai-elements/__tests__/reasoning.test.tsx app/components/ReasoningHandler.tsx app/components/__tests__/ReasoningHandler.test.tsx lib/chat/provider-metadata-sanitizer.ts lib/chat/__tests__/provider-metadata-sanitizer.test.ts lib/db/__tests__/actions-save-message.test.ts lib/chat/chat-processor.ts
- ./node_modules/.bin/tsc --noEmit
- pre-commit hook: tsc --noEmit and full jest suite (198 suites, 1993 tests)

## Manual verification
- Start an Agent run on an OpenRouter reasoning model that emits a reasoning block, then calls a tool.
- Confirm the reasoning row remains visible after the tool call appears and after streaming stops.
- Confirm the reasoning content auto-collapses when reasoning/streaming stops, and can be reopened from the row.
- Confirm persisted/reloaded messages do not contain nested openrouter.reasoning_details metadata blobs.