### PR TITLE
Fix Claude served-slug cost accounting

### DIFF
--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -433,6 +433,26 @@ describe("resolveServedModelForCostAccounting", () => {
     ).toBe("fallback-grok-4.3");
   });
 
+  it("maps dated Opus provider response slugs back to the local cost key", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "model-opus-4.6",
+        responseModel: "anthropic/claude-4.6-opus-20260205",
+        mode: "agent",
+      }),
+    ).toBe("model-opus-4.6");
+  });
+
+  it("maps dated Sonnet provider response slugs back to the local cost key", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "model-sonnet-4.6",
+        responseModel: "anthropic/claude-4.6-sonnet-20260217",
+        mode: "ask",
+      }),
+    ).toBe("model-sonnet-4.6");
+  });
+
   it("falls back to the active model key when provider metadata is absent", () => {
     expect(
       resolveServedModelForCostAccounting({

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -441,6 +441,13 @@ describe("resolveServedModelForCostAccounting", () => {
         mode: "agent",
       }),
     ).toBe("model-opus-4.6");
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "model-opus-4.6",
+        responseModel: "anthropic/claude-4.6-opus-20261231",
+        mode: "agent",
+      }),
+    ).toBe("model-opus-4.6");
   });
 
   it("maps dated Sonnet provider response slugs back to the local cost key", () => {
@@ -448,6 +455,13 @@ describe("resolveServedModelForCostAccounting", () => {
       resolveServedModelForCostAccounting({
         modelName: "model-sonnet-4.6",
         responseModel: "anthropic/claude-4.6-sonnet-20260217",
+        mode: "ask",
+      }),
+    ).toBe("model-sonnet-4.6");
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "model-sonnet-4.6",
+        responseModel: "anthropic/claude-4.6-sonnet-20261231",
         mode: "ask",
       }),
     ).toBe("model-sonnet-4.6");

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -625,6 +625,13 @@ export function getFallbackSlugs(
   );
 }
 
+const OPENROUTER_RESPONSE_MODEL_COST_KEYS: Record<string, ModelName> = {
+  "anthropic/claude-opus-4.6": "model-opus-4.6",
+  "anthropic/claude-4.6-opus-20260205": "model-opus-4.6",
+  "anthropic/claude-sonnet-4-6": "model-sonnet-4.6",
+  "anthropic/claude-4.6-sonnet-20260217": "model-sonnet-4.6",
+};
+
 export function resolveServedModelForCostAccounting({
   modelName,
   responseModel,
@@ -646,7 +653,11 @@ export function resolveServedModelForCostAccounting({
     (key) => resolveSlug(key) === responseModel,
   );
 
-  return matchedKey ?? responseModel;
+  return (
+    matchedKey ??
+    OPENROUTER_RESPONSE_MODEL_COST_KEYS[responseModel] ??
+    responseModel
+  );
 }
 
 /**

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -627,10 +627,23 @@ export function getFallbackSlugs(
 
 const OPENROUTER_RESPONSE_MODEL_COST_KEYS: Record<string, ModelName> = {
   "anthropic/claude-opus-4.6": "model-opus-4.6",
-  "anthropic/claude-4.6-opus-20260205": "model-opus-4.6",
   "anthropic/claude-sonnet-4-6": "model-sonnet-4.6",
-  "anthropic/claude-4.6-sonnet-20260217": "model-sonnet-4.6",
+  "anthropic/claude-sonnet-4.6": "model-sonnet-4.6",
 };
+
+function resolveOpenRouterResponseModelCostKey(
+  responseModel: string,
+): ModelName | undefined {
+  const exactKey = OPENROUTER_RESPONSE_MODEL_COST_KEYS[responseModel];
+  if (exactKey) return exactKey;
+  if (/^anthropic\/claude-4\.6-opus-\d{8}$/.test(responseModel)) {
+    return "model-opus-4.6";
+  }
+  if (/^anthropic\/claude-4\.6-sonnet-\d{8}$/.test(responseModel)) {
+    return "model-sonnet-4.6";
+  }
+  return undefined;
+}
 
 export function resolveServedModelForCostAccounting({
   modelName,
@@ -655,7 +668,7 @@ export function resolveServedModelForCostAccounting({
 
   return (
     matchedKey ??
-    OPENROUTER_RESPONSE_MODEL_COST_KEYS[responseModel] ??
+    resolveOpenRouterResponseModelCostKey(responseModel) ??
     responseModel
   );
 }

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -636,6 +636,8 @@ function resolveOpenRouterResponseModelCostKey(
 ): ModelName | undefined {
   const exactKey = OPENROUTER_RESPONSE_MODEL_COST_KEYS[responseModel];
   if (exactKey) return exactKey;
+  // Scope Claude response aliases to the priced generation. Families like
+  // Opus, Sonnet, and Haiku do not share one stable rate across versions.
   if (/^anthropic\/claude-4\.6-opus-\d{8}$/.test(responseModel)) {
     return "model-opus-4.6";
   }


### PR DESCRIPTION
## Summary
- map OpenRouter Claude 4.6 response aliases back to local Opus/Sonnet cost keys before token-estimated accounting
- keep the served-model fallback accounting from #789 intact for real fallback routes
- add regression coverage for dated Opus and Sonnet provider response slugs

## Why
After #789, cost accounting correctly started using the actual served provider model when `usage.raw.cost` is unavailable. For Claude 4.6 primary routes, OpenRouter can report dated response slugs such as `anthropic/claude-4.6-opus-20260205`. Those slugs were not local pricing keys, so token-estimated accounting fell back to default pricing and undercounted Opus spend in PostHog starting July 1.

## Validation
- `./node_modules/.bin/jest lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/__tests__/usage-tracker.test.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts --runInBand`
- `./node_modules/.bin/prettier --check lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts`
- `./node_modules/.bin/eslint lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- commit hook: `tsc --noEmit` and full `jest` (197 suites / 1993 tests passed)

## Manual verification
- Run an Ask/Agent request that serves Claude Opus 4.6 and returns `anthropic/claude-4.6-opus-20260205` as `responseModel` while `usage.raw.cost` is absent.
- Confirm the generated `hackerai-usage_cost` row still logs the served model but computes token-estimated cost using Opus pricing instead of default pricing.
- Repeat with Sonnet 4.6 dated response slug to confirm it maps to Sonnet pricing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model matching for cost accounting so dated Claude Opus and Sonnet responses are correctly grouped under their expected model names.
  * Enhanced handling of OpenRouter response model mappings to ensure consistent resolution.
* **Tests**
  * Added automated coverage for dated Claude Opus and Sonnet variants to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->