### PR TITLE
Use OpenRouter upstream BYOK cost

### DIFF
--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -251,6 +251,7 @@ describe("UsageTracker", () => {
         outputTokens: 500,
         raw: {
           cost: 0,
+          cost_details: {},
           costDetails: {
             upstreamInferenceCost: 0.002,
           },

--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -191,6 +191,75 @@ describe("UsageTracker", () => {
       expect(tracker.computeCostDollars("model-default")).toBe(0.05);
     });
 
+    it("should use OpenRouter upstream inference cost from raw cost details when raw cost is zero", () => {
+      tracker.accumulateStep({
+        inputTokens: 5264,
+        outputTokens: 18,
+        raw: {
+          cost: 0,
+          cost_details: {
+            upstream_inference_cost: 0.0030955,
+          },
+        },
+      });
+
+      expect(tracker.hasAuthoritativeModelCost).toBe(true);
+      expect(tracker.modelProviderCost).toBeCloseTo(0.0030955);
+      expect(tracker.computeModelCostDollars("model-opus-4.6")).toBeCloseTo(
+        0.0030955,
+      );
+      expect(tracker.computeCostDollars("model-opus-4.6")).toBeCloseTo(
+        0.0030955,
+      );
+    });
+
+    it("should prefer OpenRouter upstream inference cost over raw provider cost", () => {
+      tracker.accumulateStep({
+        inputTokens: 1000,
+        outputTokens: 500,
+        raw: {
+          cost: 0.001,
+          cost_details: {
+            upstream_inference_cost: 0.003,
+          },
+        },
+      });
+
+      expect(tracker.modelProviderCost).toBeCloseTo(0.003);
+      expect(tracker.computeCostDollars("model-default")).toBeCloseTo(0.003);
+    });
+
+    it("should fall back to raw provider cost when OpenRouter upstream inference cost is not positive", () => {
+      tracker.accumulateStep({
+        inputTokens: 1000,
+        outputTokens: 500,
+        raw: {
+          cost: 0.001,
+          cost_details: {
+            upstream_inference_cost: 0,
+            upstreamInferenceCost: Number.NaN,
+          },
+        },
+      });
+
+      expect(tracker.computeCostDollars("model-default")).toBeCloseTo(0.001);
+    });
+
+    it("should accept camelCase OpenRouter upstream inference cost from raw cost details", () => {
+      tracker.accumulateStep({
+        inputTokens: 1000,
+        outputTokens: 500,
+        raw: {
+          cost: 0,
+          costDetails: {
+            upstreamInferenceCost: 0.002,
+          },
+        },
+      });
+
+      expect(tracker.computeCostDollars("model-default")).toBeCloseTo(0.002);
+    });
+
     it("should use authoritative model cost from provider metadata when raw cost is missing", () => {
       const stepCostIndex = tracker.accumulateStep({
         inputTokens: 12,

--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -191,6 +191,86 @@ describe("UsageTracker", () => {
       expect(tracker.computeCostDollars("model-default")).toBe(0.05);
     });
 
+    it("should use authoritative model cost from provider metadata when raw cost is missing", () => {
+      const stepCostIndex = tracker.accumulateStep({
+        inputTokens: 12,
+        outputTokens: 4,
+        raw: { cost: 0 },
+      });
+      tracker.setAuthoritativeModelCostForStep(stepCostIndex, 0.00016);
+
+      expect(tracker.computeModelCostDollars("model-default")).toBe(0.00016);
+      expect(tracker.computeCostDollars("model-default")).toBe(0.00016);
+    });
+
+    it("should sum authoritative metadata costs across model steps", () => {
+      const firstStepCostIndex = tracker.accumulateStep({
+        inputTokens: 12,
+        outputTokens: 4,
+        raw: { cost: 0 },
+      });
+      const secondStepCostIndex = tracker.accumulateStep({
+        inputTokens: 20,
+        outputTokens: 5,
+        raw: { cost: 0 },
+      });
+
+      tracker.setAuthoritativeModelCostForStep(firstStepCostIndex, 0.00016);
+      tracker.setAuthoritativeModelCostForStep(secondStepCostIndex, 0.0002);
+
+      expect(tracker.computeModelCostDollars("model-default")).toBeCloseTo(
+        0.00036,
+      );
+      expect(tracker.computeCostDollars("model-default")).toBeCloseTo(0.00036);
+    });
+
+    it("should use token estimates when any model step lacks authoritative cost", () => {
+      const firstStepCostIndex = tracker.accumulateStep({
+        inputTokens: 500_000,
+        outputTokens: 0,
+        raw: { cost: 0 },
+      });
+      tracker.accumulateStep({
+        inputTokens: 500_000,
+        outputTokens: 0,
+        raw: { cost: 0 },
+      });
+
+      tracker.setAuthoritativeModelCostForStep(firstStepCostIndex, 0.00016);
+
+      expect(tracker.computeCostDollars("model-default")).toBe(0.5);
+    });
+
+    it("should prefer authoritative metadata cost over raw provider cost while preserving non-model spend", () => {
+      const stepCostIndex = tracker.accumulateStep({
+        inputTokens: 1000,
+        outputTokens: 500,
+        raw: { cost: 0.05 },
+      });
+      tracker.providerCost += 0.01;
+      tracker.nonModelCost = 0.01;
+      tracker.setAuthoritativeModelCostForStep(stepCostIndex, 0.00016);
+
+      expect(tracker.modelProviderCost).toBeCloseTo(0.00016);
+      expect(tracker.computeModelCostDollars("model-default")).toBeCloseTo(
+        0.00016,
+      );
+      expect(tracker.computeCostDollars("model-default")).toBeCloseTo(0.01016);
+    });
+
+    it("should ignore non-positive metadata cost", () => {
+      const stepCostIndex = tracker.accumulateStep({
+        inputTokens: 1000,
+        outputTokens: 500,
+        raw: { cost: 0.05 },
+      });
+
+      tracker.setAuthoritativeModelCostForStep(stepCostIndex, 0);
+      tracker.setAuthoritativeModelCostForStep(stepCostIndex, Number.NaN);
+
+      expect(tracker.computeCostDollars("model-default")).toBe(0.05);
+    });
+
     it("should fall back to token calculation when no provider cost", () => {
       tracker.accumulateStep({ inputTokens: 1_000_000, outputTokens: 0 });
 
@@ -531,6 +611,31 @@ describe("UsageTracker", () => {
       expect(usage.model).toBe("auto");
       expect(usage.modelCostDollars).toBe(0.42);
       expect(usage.costDollars).toBe(0.42);
+      expect(usage.costSource).toBe("provider");
+    });
+
+    it("keeps upstream metadata cost ahead of token estimates when raw cost is zero", () => {
+      const stepCostIndex = tracker.accumulateStep({
+        inputTokens: 12,
+        outputTokens: 4,
+        raw: { cost: 0 },
+      });
+      tracker.setAuthoritativeModelCostForStep(stepCostIndex, 0.00016);
+
+      const usage = tracker.createUsageCostRecord({
+        selectedModel: "model-opus-4.6",
+        accountingModel: "model-opus-4.6",
+        configuredModelId: "anthropic/claude-4.6-opus-20260205",
+        rateLimitInfo: {
+          remaining: 1000,
+          resetTime: new Date(),
+          limit: 250000,
+          pointsDeducted: 100,
+        },
+      });
+
+      expect(usage.modelCostDollars).toBe(0.00016);
+      expect(usage.costDollars).toBe(0.00016);
       expect(usage.costSource).toBe("provider");
     });
 

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -1181,6 +1181,61 @@ describe("createChatLogger OpenRouter metadata", () => {
       logSpy.mockRestore();
     }
   });
+
+  it("uses OpenRouter upstream inference cost from raw usage cost details in wide events", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_provider_usage_cost_details",
+        endpoint: "/api/chat",
+      });
+      chatLogger.setRequestDetails({
+        mode: "ask",
+        isTemporary: false,
+        isRegenerate: false,
+      });
+      chatLogger.setUser({ id: "user_123", subscription: "pro" });
+      chatLogger.setChat(
+        {
+          messageCount: 1,
+          estimatedInputTokens: 100,
+          isNewChat: false,
+          notesEnabled: false,
+        },
+        "model-opus-4.6",
+      );
+      chatLogger.setStreamResponse(
+        "anthropic/claude-opus-4.6",
+        {
+          inputTokens: 5264,
+          outputTokens: 18,
+          raw: {
+            cost: 0,
+            cost_details: {
+              upstream_inference_cost: 0.0030955,
+            },
+          },
+        },
+        {
+          provider_name: "Google",
+          openrouter_generation_id: "gen-123",
+          openrouter_is_byok: true,
+        },
+      );
+      chatLogger.emitSuccess({
+        finishReason: "stop",
+        wasAborted: false,
+        wasPreemptiveTimeout: false,
+        hadSummarization: false,
+      });
+
+      const wideEvent = JSON.parse(String(logSpy.mock.calls[0][0]));
+      expect(wideEvent.usage.total_cost).toBeCloseTo(0.0030955);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
 });
 
 describe("createChatLogger provider stream timeout", () => {

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -1156,6 +1156,7 @@ describe("createChatLogger OpenRouter metadata", () => {
           openrouter_generation_id: "gen-123",
           openrouter_request_id: "req-123",
           openrouter_strategy: "direct",
+          openrouter_upstream_inference_cost: 0.00016,
         },
       );
       chatLogger.emitSuccess({
@@ -1173,6 +1174,7 @@ describe("createChatLogger OpenRouter metadata", () => {
         openrouter_generation_id: "gen-123",
         openrouter_request_id: "req-123",
         openrouter_strategy: "direct",
+        openrouter_upstream_inference_cost: 0.00016,
       });
       expect(wideEvent.model).not.toHaveProperty("provider_gateway");
     } finally {

--- a/lib/api/__tests__/openrouter-metadata.test.ts
+++ b/lib/api/__tests__/openrouter-metadata.test.ts
@@ -72,6 +72,7 @@ describe("OpenRouter metadata extraction", () => {
             is_byok: true,
             router: "openrouter/auto",
             upstream_id: "chatcmpl-upstream",
+            upstream_inference_cost: 0.00016,
           },
         }),
       } as Response;
@@ -90,6 +91,7 @@ describe("OpenRouter metadata extraction", () => {
       openrouter_is_byok: true,
       openrouter_router: "openrouter/auto",
       openrouter_upstream_id: "chatcmpl-upstream",
+      openrouter_upstream_inference_cost: 0.00016,
     });
 
     const [url, init] = fetchImpl.mock.calls[0];
@@ -107,6 +109,7 @@ describe("OpenRouter metadata extraction", () => {
       providerMetadata: {
         openrouter: {
           provider: "Google Vertex",
+          upstreamInferenceCost: 0.00016,
           usage: {
             promptTokens: 10,
             completionTokens: 1,
@@ -119,6 +122,25 @@ describe("OpenRouter metadata extraction", () => {
     expect(metadata).toEqual({
       provider_name: "Google Vertex",
       openrouter_generation_id: "gen-sdk-provider",
+      openrouter_upstream_inference_cost: 0.00016,
+    });
+  });
+
+  it("extracts camelCase upstream cost from direct OpenRouter SDK metadata", () => {
+    const metadata = extractOpenRouterMetadata({
+      response: {
+        id: "gen-sdk-cost-only",
+      },
+      providerMetadata: {
+        openrouter: {
+          upstreamInferenceCost: 0.00016,
+        },
+      },
+    });
+
+    expect(metadata).toEqual({
+      openrouter_generation_id: "gen-sdk-cost-only",
+      openrouter_upstream_inference_cost: 0.00016,
     });
   });
 
@@ -134,6 +156,7 @@ describe("OpenRouter metadata extraction", () => {
         provider_name: "Google",
         openrouter_request_id: "req-123",
         openrouter_router: "openrouter/auto",
+        openrouter_upstream_inference_cost: 0.00016,
       },
     );
 
@@ -143,6 +166,32 @@ describe("OpenRouter metadata extraction", () => {
       openrouter_strategy: "direct",
       openrouter_request_id: "req-123",
       openrouter_router: "openrouter/auto",
+      openrouter_upstream_inference_cost: 0.00016,
+    });
+  });
+
+  it("ignores non-positive upstream inference costs", async () => {
+    const fetchImpl = jest.fn(async () => {
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            provider_name: "Anthropic",
+            upstream_inference_cost: 0,
+          },
+        }),
+      } as Response;
+    });
+
+    const metadata = await fetchOpenRouterGenerationMetadata("gen-zero-cost", {
+      apiKey: "sk-test",
+      fetchImpl,
+      timeoutMs: 100,
+    });
+
+    expect(metadata).toEqual({
+      provider_name: "Anthropic",
+      openrouter_generation_id: "gen-zero-cost",
     });
   });
 

--- a/lib/api/__tests__/openrouter-metadata.test.ts
+++ b/lib/api/__tests__/openrouter-metadata.test.ts
@@ -1,6 +1,5 @@
 import {
   extractOpenRouterMetadata,
-  fetchOpenRouterGenerationMetadata,
   mergeOpenRouterMetadata,
 } from "../openrouter-metadata";
 
@@ -61,46 +60,6 @@ describe("OpenRouter metadata extraction", () => {
     });
   });
 
-  it("uses generation API metadata when stream metadata is incomplete", async () => {
-    const fetchImpl = jest.fn(async () => {
-      return {
-        ok: true,
-        json: async () => ({
-          data: {
-            provider_name: "Azure",
-            request_id: "req-openrouter",
-            is_byok: true,
-            router: "openrouter/auto",
-            upstream_id: "chatcmpl-upstream",
-            upstream_inference_cost: 0.00016,
-          },
-        }),
-      } as Response;
-    });
-
-    const metadata = await fetchOpenRouterGenerationMetadata("gen-123", {
-      apiKey: "sk-test",
-      fetchImpl,
-      timeoutMs: 100,
-    });
-
-    expect(metadata).toEqual({
-      provider_name: "Azure",
-      openrouter_generation_id: "gen-123",
-      openrouter_request_id: "req-openrouter",
-      openrouter_is_byok: true,
-      openrouter_router: "openrouter/auto",
-      openrouter_upstream_id: "chatcmpl-upstream",
-      openrouter_upstream_inference_cost: 0.00016,
-    });
-
-    const [url, init] = fetchImpl.mock.calls[0];
-    expect(String(url)).toContain("id=gen-123");
-    expect((init?.headers as Record<string, string>).Authorization).toBe(
-      "Bearer sk-test",
-    );
-  });
-
   it("extracts the direct provider field exposed by the OpenRouter SDK", () => {
     const metadata = extractOpenRouterMetadata({
       response: {
@@ -144,6 +103,26 @@ describe("OpenRouter metadata extraction", () => {
     });
   });
 
+  it("ignores non-positive upstream inference costs from provider metadata", () => {
+    const metadata = extractOpenRouterMetadata({
+      response: {
+        id: "gen-zero-cost",
+      },
+      providerMetadata: {
+        openrouter: {
+          provider: "Anthropic",
+          upstream_inference_cost: 0,
+          upstreamInferenceCost: Number.NaN,
+        },
+      },
+    });
+
+    expect(metadata).toEqual({
+      provider_name: "Anthropic",
+      openrouter_generation_id: "gen-zero-cost",
+    });
+  });
+
   it("merges generation metadata without overwriting response metadata", () => {
     const merged = mergeOpenRouterMetadata(
       {
@@ -167,31 +146,6 @@ describe("OpenRouter metadata extraction", () => {
       openrouter_request_id: "req-123",
       openrouter_router: "openrouter/auto",
       openrouter_upstream_inference_cost: 0.00016,
-    });
-  });
-
-  it("ignores non-positive upstream inference costs", async () => {
-    const fetchImpl = jest.fn(async () => {
-      return {
-        ok: true,
-        json: async () => ({
-          data: {
-            provider_name: "Anthropic",
-            upstream_inference_cost: 0,
-          },
-        }),
-      } as Response;
-    });
-
-    const metadata = await fetchOpenRouterGenerationMetadata("gen-zero-cost", {
-      apiKey: "sk-test",
-      fetchImpl,
-      timeoutMs: 100,
-    });
-
-    expect(metadata).toEqual({
-      provider_name: "Anthropic",
-      openrouter_generation_id: "gen-zero-cost",
     });
   });
 

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -69,10 +69,9 @@ import { getMaxStepsForUser } from "@/lib/chat/chat-processor";
 import { createPromptSerializationTools } from "@/lib/ai/tools/prompt-serialization";
 import {
   extractOpenRouterMetadata,
-  fetchOpenRouterGenerationMetadata,
   mergeOpenRouterMetadata,
-  type OpenRouterModelMetadata,
 } from "@/lib/api/openrouter-metadata";
+import { getOpenRouterUpstreamInferenceCostFromUsageRaw } from "@/lib/provider-usage-cost";
 import { classifyProviderOverflowError } from "@/lib/utils/error-utils";
 import type { UsageTracker } from "@/lib/usage-tracker";
 import type {
@@ -356,37 +355,6 @@ export async function createAgentStream(
   state: AgentStreamState,
 ) {
   const stepUsageCostIndexes: Array<number | undefined> = [];
-  const generationMetadataById = new Map<
-    string,
-    Promise<OpenRouterModelMetadata | undefined>
-  >();
-  const fetchGenerationMetadataOnce = (
-    generationId: string,
-  ): Promise<OpenRouterModelMetadata | undefined> => {
-    const existing = generationMetadataById.get(generationId);
-    if (existing) return existing;
-
-    const pending = fetchOpenRouterGenerationMetadata(generationId);
-    generationMetadataById.set(generationId, pending);
-    return pending;
-  };
-  const hydrateOpenRouterMetadata = async (
-    metadata: OpenRouterModelMetadata,
-  ): Promise<OpenRouterModelMetadata> => {
-    if (
-      !metadata.openrouter_generation_id ||
-      (metadata.provider_name &&
-        metadata.openrouter_upstream_inference_cost !== undefined)
-    ) {
-      return metadata;
-    }
-
-    return mergeOpenRouterMetadata(
-      metadata,
-      await fetchGenerationMetadataOnce(metadata.openrouter_generation_id),
-    );
-  };
-
   const getActiveToolsWithExclusions = async (
     excludedToolNames: ReadonlySet<string> = new Set(),
   ): Promise<Array<keyof typeof ctx.tools> | undefined> => {
@@ -808,15 +776,11 @@ export async function createAgentStream(
         }>;
       };
       const stepOpenRouterMetadatas = Array.isArray(finishMetadata.steps)
-        ? await Promise.all(
-            finishMetadata.steps.map((step) =>
-              hydrateOpenRouterMetadata(
-                extractOpenRouterMetadata({
-                  response: step.response,
-                  providerMetadata: step.providerMetadata,
-                }),
-              ),
-            ),
+        ? finishMetadata.steps.map((step) =>
+            extractOpenRouterMetadata({
+              response: step.response,
+              providerMetadata: step.providerMetadata,
+            }),
           )
         : [];
       for (const [index, metadata] of stepOpenRouterMetadatas.entries()) {
@@ -829,11 +793,18 @@ export async function createAgentStream(
         response,
         providerMetadata: finishMetadata.providerMetadata,
       });
-      const openRouterMetadata = await hydrateOpenRouterMetadata(
-        mergeOpenRouterMetadata(
-          finishOpenRouterMetadata,
-          stepOpenRouterMetadatas.at(-1),
-        ),
+      const rawUpstreamInferenceCost =
+        getOpenRouterUpstreamInferenceCostFromUsageRaw(
+          (usage as { raw?: unknown } | undefined)?.raw,
+        );
+      const openRouterMetadata = mergeOpenRouterMetadata(
+        {
+          ...finishOpenRouterMetadata,
+          openrouter_upstream_inference_cost:
+            finishOpenRouterMetadata.openrouter_upstream_inference_cost ??
+            rawUpstreamInferenceCost,
+        },
+        stepOpenRouterMetadatas.at(-1),
       );
 
       ctx.usageTracker.setAuthoritativeModelCostForStep(

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -71,6 +71,7 @@ import {
   extractOpenRouterMetadata,
   fetchOpenRouterGenerationMetadata,
   mergeOpenRouterMetadata,
+  type OpenRouterModelMetadata,
 } from "@/lib/api/openrouter-metadata";
 import { classifyProviderOverflowError } from "@/lib/utils/error-utils";
 import type { UsageTracker } from "@/lib/usage-tracker";
@@ -245,8 +246,7 @@ const buildProviderRequestDiagnostics = (args: {
   }
 
   const lastMessage = args.messages.at(-1) as
-    | Record<string, unknown>
-    | undefined;
+    Record<string, unknown> | undefined;
   const serializedBytes = getSerializedBytes(args.messages);
   const contextUsedPercent =
     args.contextUsage.maxTokens > 0
@@ -355,6 +355,38 @@ export async function createAgentStream(
   ctx: AgentStreamContext,
   state: AgentStreamState,
 ) {
+  const stepUsageCostIndexes: Array<number | undefined> = [];
+  const generationMetadataById = new Map<
+    string,
+    Promise<OpenRouterModelMetadata | undefined>
+  >();
+  const fetchGenerationMetadataOnce = (
+    generationId: string,
+  ): Promise<OpenRouterModelMetadata | undefined> => {
+    const existing = generationMetadataById.get(generationId);
+    if (existing) return existing;
+
+    const pending = fetchOpenRouterGenerationMetadata(generationId);
+    generationMetadataById.set(generationId, pending);
+    return pending;
+  };
+  const hydrateOpenRouterMetadata = async (
+    metadata: OpenRouterModelMetadata,
+  ): Promise<OpenRouterModelMetadata> => {
+    if (
+      !metadata.openrouter_generation_id ||
+      (metadata.provider_name &&
+        metadata.openrouter_upstream_inference_cost !== undefined)
+    ) {
+      return metadata;
+    }
+
+    return mergeOpenRouterMetadata(
+      metadata,
+      await fetchGenerationMetadataOnce(metadata.openrouter_generation_id),
+    );
+  };
+
   const getActiveToolsWithExclusions = async (
     excludedToolNames: ReadonlySet<string> = new Set(),
   ): Promise<Array<keyof typeof ctx.tools> | undefined> => {
@@ -710,13 +742,24 @@ export async function createAgentStream(
       }
     },
 
-    onStepFinish: async ({ usage }) => {
+    onStepFinish: async ({ usage, response, providerMetadata }) => {
+      let stepUsageCostIndex: number | undefined;
       if (usage) {
-        ctx.usageTracker.accumulateStep(
+        stepUsageCostIndex = ctx.usageTracker.accumulateStep(
           usage as Parameters<typeof ctx.usageTracker.accumulateStep>[0],
         );
         state.lastStepInputTokens = usage.inputTokens || 0;
       }
+      stepUsageCostIndexes.push(stepUsageCostIndex);
+
+      const stepOpenRouterMetadata = extractOpenRouterMetadata({
+        response,
+        providerMetadata,
+      });
+      ctx.usageTracker.setAuthoritativeModelCostForStep(
+        stepUsageCostIndex,
+        stepOpenRouterMetadata.openrouter_upstream_inference_cost,
+      );
 
       const budgetDecision = ctx.budgetMonitor?.checkAfterStep(
         ctx.usageTracker.computeCostDollars(modelName),
@@ -759,34 +802,44 @@ export async function createAgentStream(
 
       const finishMetadata = finishResult as {
         providerMetadata?: unknown;
-        steps?: Array<{ providerMetadata?: unknown }>;
+        steps?: Array<{
+          response?: typeof response;
+          providerMetadata?: unknown;
+        }>;
       };
-      const stepProviderMetadata = Array.isArray(finishMetadata.steps)
-        ? finishMetadata.steps.at(-1)?.providerMetadata
-        : undefined;
+      const stepOpenRouterMetadatas = Array.isArray(finishMetadata.steps)
+        ? await Promise.all(
+            finishMetadata.steps.map((step) =>
+              hydrateOpenRouterMetadata(
+                extractOpenRouterMetadata({
+                  response: step.response,
+                  providerMetadata: step.providerMetadata,
+                }),
+              ),
+            ),
+          )
+        : [];
+      for (const [index, metadata] of stepOpenRouterMetadatas.entries()) {
+        ctx.usageTracker.setAuthoritativeModelCostForStep(
+          stepUsageCostIndexes[index],
+          metadata.openrouter_upstream_inference_cost,
+        );
+      }
       const finishOpenRouterMetadata = extractOpenRouterMetadata({
         response,
         providerMetadata: finishMetadata.providerMetadata,
       });
-      const stepOpenRouterMetadata = extractOpenRouterMetadata({
-        providerMetadata: stepProviderMetadata,
-      });
-      let openRouterMetadata = mergeOpenRouterMetadata(
-        finishOpenRouterMetadata,
-        stepOpenRouterMetadata,
+      const openRouterMetadata = await hydrateOpenRouterMetadata(
+        mergeOpenRouterMetadata(
+          finishOpenRouterMetadata,
+          stepOpenRouterMetadatas.at(-1),
+        ),
       );
-      if (
-        ctx.chatLogger &&
-        !openRouterMetadata.provider_name &&
-        openRouterMetadata.openrouter_generation_id
-      ) {
-        openRouterMetadata = mergeOpenRouterMetadata(
-          openRouterMetadata,
-          await fetchOpenRouterGenerationMetadata(
-            openRouterMetadata.openrouter_generation_id,
-          ),
-        );
-      }
+
+      ctx.usageTracker.setAuthoritativeModelCostForStep(
+        stepUsageCostIndexes.at(-1),
+        openRouterMetadata.openrouter_upstream_inference_cost,
+      );
 
       const fallbackSlugs = getFallbackSlugs(modelName, ctx.mode, {
         hasMultimodalToolResults: streamHasImageViewResults,

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -773,15 +773,22 @@ export async function createAgentStream(
         steps?: Array<{
           response?: typeof response;
           providerMetadata?: unknown;
+          usage?: { raw?: unknown };
         }>;
       };
       const stepOpenRouterMetadatas = Array.isArray(finishMetadata.steps)
-        ? finishMetadata.steps.map((step) =>
-            extractOpenRouterMetadata({
+        ? finishMetadata.steps.map((step) => {
+            const metadata = extractOpenRouterMetadata({
               response: step.response,
               providerMetadata: step.providerMetadata,
-            }),
-          )
+            });
+            return {
+              ...metadata,
+              openrouter_upstream_inference_cost:
+                metadata.openrouter_upstream_inference_cost ??
+                getOpenRouterUpstreamInferenceCostFromUsageRaw(step.usage?.raw),
+            };
+          })
         : [];
       for (const [index, metadata] of stepOpenRouterMetadatas.entries()) {
         ctx.usageTracker.setAuthoritativeModelCostForStep(
@@ -793,17 +800,8 @@ export async function createAgentStream(
         response,
         providerMetadata: finishMetadata.providerMetadata,
       });
-      const rawUpstreamInferenceCost =
-        getOpenRouterUpstreamInferenceCostFromUsageRaw(
-          (usage as { raw?: unknown } | undefined)?.raw,
-        );
       const openRouterMetadata = mergeOpenRouterMetadata(
-        {
-          ...finishOpenRouterMetadata,
-          openrouter_upstream_inference_cost:
-            finishOpenRouterMetadata.openrouter_upstream_inference_cost ??
-            rawUpstreamInferenceCost,
-        },
+        finishOpenRouterMetadata,
         stepOpenRouterMetadatas.at(-1),
       );
 

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -903,18 +903,13 @@ export const createChatHandler = () => {
                 let usageCostRecord =
                   usageTracker.createUsageCostRecord(usageRecordArgs);
 
-                // Trust accumulated provider cost (sum of per-step usage.raw.cost) even on
-                // non-clean streams. Each completed step reports authoritative cost with
-                // cache discounts baked in, so summing them is more accurate than the
-                // token-based fallback (which ignores cache reads and overcharges).
-                // Gate on modelProviderCost (not providerCost) because providerCost also
-                // includes tool/sandbox spend — if the model never reported raw.cost,
-                // tool/sandbox cost alone would incorrectly suppress the token fallback
-                // and drop the model portion entirely.
-                const providerCost =
-                  usageTracker.modelProviderCost > 0
-                    ? usageTracker.providerCost
-                    : undefined;
+                // Trust accumulated provider cost only when every model step has
+                // an authoritative cost. providerCost also includes tool/sandbox
+                // spend; if any model step is missing cost, keep token fallback
+                // for the model portion and add nonModelCost separately.
+                const providerCost = usageTracker.hasAuthoritativeModelCost
+                  ? usageTracker.providerCost
+                  : undefined;
 
                 if (paidDailyFreeAllowanceReservation) {
                   const allowanceCostRecord =

--- a/lib/api/openrouter-metadata.ts
+++ b/lib/api/openrouter-metadata.ts
@@ -25,8 +25,6 @@ type ResponseLike = {
   headers?: unknown;
 };
 
-const OPENROUTER_GENERATION_URL = "https://openrouter.ai/api/v1/generation";
-const GENERATION_FETCH_TIMEOUT_MS = 1500;
 const MAX_ATTEMPTS_TO_LOG = 8;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -198,17 +196,6 @@ const metadataFromRouterPayload = (
   };
 };
 
-const metadataFromGenerationPayload = (
-  data: Record<string, unknown>,
-): Partial<OpenRouterModelMetadata> => ({
-  provider_name: pickString(data.provider_name),
-  openrouter_request_id: pickString(data.request_id),
-  openrouter_is_byok: pickBoolean(data.is_byok),
-  openrouter_router: pickString(data.router),
-  openrouter_upstream_id: pickString(data.upstream_id),
-  openrouter_upstream_inference_cost: pickUpstreamInferenceCost(data),
-});
-
 export function extractOpenRouterMetadata(args: {
   response?: ResponseLike;
   providerMetadata?: unknown;
@@ -256,51 +243,4 @@ function compactOpenRouterMetadata(
   }
 
   return compact;
-}
-
-export async function fetchOpenRouterGenerationMetadata(
-  generationId: string | undefined,
-  options: {
-    apiKey?: string;
-    fetchImpl?: typeof fetch;
-    timeoutMs?: number;
-  } = {},
-): Promise<OpenRouterModelMetadata | undefined> {
-  if (!generationId) return undefined;
-
-  const apiKey = options.apiKey ?? process.env.OPENROUTER_API_KEY;
-  if (!apiKey) return undefined;
-
-  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
-  const controller = new AbortController();
-  const timeout = setTimeout(
-    () => controller.abort(),
-    options.timeoutMs ?? GENERATION_FETCH_TIMEOUT_MS,
-  );
-
-  try {
-    const url = new URL(OPENROUTER_GENERATION_URL);
-    url.searchParams.set("id", generationId);
-
-    const response = await fetchImpl(url, {
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-      },
-      signal: controller.signal,
-    });
-
-    if (!response.ok) return undefined;
-
-    const payload = (await response.json()) as unknown;
-    if (!isRecord(payload) || !isRecord(payload.data)) return undefined;
-
-    return compactOpenRouterMetadata({
-      openrouter_generation_id: generationId,
-      ...metadataFromGenerationPayload(payload.data),
-    });
-  } catch {
-    return undefined;
-  } finally {
-    clearTimeout(timeout);
-  }
 }

--- a/lib/api/openrouter-metadata.ts
+++ b/lib/api/openrouter-metadata.ts
@@ -15,6 +15,7 @@ export type OpenRouterModelMetadata = {
   openrouter_region?: string;
   openrouter_attempt?: number;
   openrouter_upstream_id?: string;
+  openrouter_upstream_inference_cost?: number;
   openrouter_selected_model?: string;
   openrouter_attempts?: OpenRouterAttemptMetadata[];
 };
@@ -37,8 +38,19 @@ const pickString = (value: unknown): string | undefined =>
 const pickNumber = (value: unknown): number | undefined =>
   typeof value === "number" && Number.isFinite(value) ? value : undefined;
 
+const pickPositiveNumber = (value: unknown): number | undefined => {
+  const number = pickNumber(value);
+  return number !== undefined && number > 0 ? number : undefined;
+};
+
 const pickBoolean = (value: unknown): boolean | undefined =>
   typeof value === "boolean" ? value : undefined;
+
+const pickUpstreamInferenceCost = (
+  metadata: Record<string, unknown>,
+): number | undefined =>
+  pickPositiveNumber(metadata.upstream_inference_cost) ??
+  pickPositiveNumber(metadata.upstreamInferenceCost);
 
 const normalizeHeaders = (headers: unknown): Record<string, string> => {
   if (!headers) return {};
@@ -106,6 +118,7 @@ const findOpenRouterMetadata = (source: unknown): Record<string, unknown> => {
     typeof openrouter.provider === "string" ||
     typeof openrouter.requested === "string" ||
     typeof openrouter.strategy === "string" ||
+    pickUpstreamInferenceCost(openrouter) !== undefined ||
     isRecord(openrouter.endpoints) ||
     Array.isArray(openrouter.attempts)
   ) {
@@ -177,6 +190,7 @@ const metadataFromRouterPayload = (
     openrouter_strategy: pickString(metadata.strategy),
     openrouter_region: pickString(metadata.region),
     openrouter_attempt: pickNumber(metadata.attempt),
+    openrouter_upstream_inference_cost: pickUpstreamInferenceCost(metadata),
     openrouter_selected_model:
       pickString(selectedEndpoint?.model) ??
       pickString(successfulAttempt?.model),
@@ -192,6 +206,7 @@ const metadataFromGenerationPayload = (
   openrouter_is_byok: pickBoolean(data.is_byok),
   openrouter_router: pickString(data.router),
   openrouter_upstream_id: pickString(data.upstream_id),
+  openrouter_upstream_inference_cost: pickUpstreamInferenceCost(data),
 });
 
 export function extractOpenRouterMetadata(args: {
@@ -223,6 +238,9 @@ export function mergeOpenRouterMetadata(
     openrouter_router: primary.openrouter_router ?? secondary.openrouter_router,
     openrouter_upstream_id:
       primary.openrouter_upstream_id ?? secondary.openrouter_upstream_id,
+    openrouter_upstream_inference_cost:
+      primary.openrouter_upstream_inference_cost ??
+      secondary.openrouter_upstream_inference_cost,
   });
 }
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -108,6 +108,7 @@ export interface ChatWideEvent {
     openrouter_region?: string;
     openrouter_attempt?: number;
     openrouter_upstream_id?: string;
+    openrouter_upstream_inference_cost?: number;
     openrouter_selected_model?: string;
     openrouter_attempts?: OpenRouterModelMetadata["openrouter_attempts"];
     fallback_triggered?: boolean;
@@ -119,9 +120,7 @@ export interface ChatWideEvent {
       count: number;
       last_action: "appended_continue" | "trimmed";
       last_reason:
-        | "useful_assistant_tail"
-        | "no_useful_content"
-        | "dangling_tool_call";
+        "useful_assistant_tail" | "no_useful_content" | "dangling_tool_call";
       last_content_types?: string[];
     };
   };
@@ -398,9 +397,7 @@ export class WideEventBuilder {
   recordAnthropicPromptRepair(repair: {
     action: "appended_continue" | "trimmed";
     reason:
-      | "useful_assistant_tail"
-      | "no_useful_content"
-      | "dangling_tool_call";
+      "useful_assistant_tail" | "no_useful_content" | "dangling_tool_call";
     trailingAssistantContentTypes?: string[];
   }): this {
     this.anthropicPromptRepairCount += 1;
@@ -504,8 +501,7 @@ export class WideEventBuilder {
         reasoning_tokens: (usage.reasoningTokens as number) || undefined,
         cache_read_tokens: usage.cacheReadInputTokens as number | undefined,
         cache_write_tokens: usage.cacheCreationInputTokens as
-          | number
-          | undefined,
+          number | undefined,
         total_cost: rawCost,
       };
     }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -219,6 +219,38 @@ export interface ChatWideEvent {
   };
 }
 
+const isPositiveFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value > 0;
+
+const getProviderUsageCost = (
+  usage: Record<string, unknown>,
+): number | undefined => {
+  const raw = usage.raw;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return undefined;
+  }
+
+  const rawRecord = raw as Record<string, unknown>;
+  const costDetails = rawRecord.cost_details ?? rawRecord.costDetails;
+  if (
+    typeof costDetails === "object" &&
+    costDetails !== null &&
+    !Array.isArray(costDetails)
+  ) {
+    const costDetailsRecord = costDetails as Record<string, unknown>;
+    const upstreamInferenceCost =
+      costDetailsRecord.upstream_inference_cost ??
+      costDetailsRecord.upstreamInferenceCost;
+    if (isPositiveFiniteNumber(upstreamInferenceCost)) {
+      return upstreamInferenceCost;
+    }
+  }
+
+  return typeof rawRecord.cost === "number" && Number.isFinite(rawRecord.cost)
+    ? rawRecord.cost
+    : undefined;
+};
+
 /**
  * Builder for constructing wide events throughout the request lifecycle
  */
@@ -489,8 +521,7 @@ export class WideEventBuilder {
    */
   setUsage(usage: Record<string, unknown> | undefined): this {
     if (usage) {
-      // Extract provider cost if available (e.g., from OpenRouter)
-      const rawCost = (usage as { raw?: { cost?: number } }).raw?.cost;
+      const providerCost = getProviderUsageCost(usage);
 
       this.event.usage = {
         input_tokens: usage.inputTokens as number | undefined,
@@ -502,7 +533,7 @@ export class WideEventBuilder {
         cache_read_tokens: usage.cacheReadInputTokens as number | undefined,
         cache_write_tokens: usage.cacheCreationInputTokens as
           number | undefined,
-        total_cost: rawCost,
+        total_cost: providerCost,
       };
     }
     return this;

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -9,6 +9,7 @@
 
 import type { ChatMode, ExtraUsageConfig } from "@/types";
 import type { OpenRouterModelMetadata } from "@/lib/api/openrouter-metadata";
+import { getProviderUsageRawModelCost } from "@/lib/provider-usage-cost";
 
 export interface ProviderRequestDiagnostics {
   model: string;
@@ -218,38 +219,6 @@ export interface ChatWideEvent {
     }>;
   };
 }
-
-const isPositiveFiniteNumber = (value: unknown): value is number =>
-  typeof value === "number" && Number.isFinite(value) && value > 0;
-
-const getProviderUsageCost = (
-  usage: Record<string, unknown>,
-): number | undefined => {
-  const raw = usage.raw;
-  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-    return undefined;
-  }
-
-  const rawRecord = raw as Record<string, unknown>;
-  const costDetails = rawRecord.cost_details ?? rawRecord.costDetails;
-  if (
-    typeof costDetails === "object" &&
-    costDetails !== null &&
-    !Array.isArray(costDetails)
-  ) {
-    const costDetailsRecord = costDetails as Record<string, unknown>;
-    const upstreamInferenceCost =
-      costDetailsRecord.upstream_inference_cost ??
-      costDetailsRecord.upstreamInferenceCost;
-    if (isPositiveFiniteNumber(upstreamInferenceCost)) {
-      return upstreamInferenceCost;
-    }
-  }
-
-  return typeof rawRecord.cost === "number" && Number.isFinite(rawRecord.cost)
-    ? rawRecord.cost
-    : undefined;
-};
 
 /**
  * Builder for constructing wide events throughout the request lifecycle
@@ -521,7 +490,7 @@ export class WideEventBuilder {
    */
   setUsage(usage: Record<string, unknown> | undefined): this {
     if (usage) {
-      const providerCost = getProviderUsageCost(usage);
+      const providerCost = getProviderUsageRawModelCost(usage.raw);
 
       this.event.usage = {
         input_tokens: usage.inputTokens as number | undefined,

--- a/lib/provider-usage-cost.ts
+++ b/lib/provider-usage-cost.ts
@@ -30,7 +30,5 @@ export const getProviderUsageRawModelCost = (
   if (upstreamInferenceCost !== undefined) return upstreamInferenceCost;
 
   if (!isRecord(raw)) return undefined;
-  return typeof raw.cost === "number" && Number.isFinite(raw.cost)
-    ? raw.cost
-    : undefined;
+  return isPositiveFiniteNumber(raw.cost) ? raw.cost : undefined;
 };

--- a/lib/provider-usage-cost.ts
+++ b/lib/provider-usage-cost.ts
@@ -1,0 +1,36 @@
+export const isPositiveFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value > 0;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const getOpenRouterUpstreamInferenceCostFromUsageRaw = (
+  raw: unknown,
+): number | undefined => {
+  if (!isRecord(raw)) return undefined;
+
+  for (const costDetails of [raw.cost_details, raw.costDetails]) {
+    if (!isRecord(costDetails)) continue;
+
+    const upstreamInferenceCost =
+      costDetails.upstream_inference_cost ?? costDetails.upstreamInferenceCost;
+    if (isPositiveFiniteNumber(upstreamInferenceCost)) {
+      return upstreamInferenceCost;
+    }
+  }
+
+  return undefined;
+};
+
+export const getProviderUsageRawModelCost = (
+  raw: unknown,
+): number | undefined => {
+  const upstreamInferenceCost =
+    getOpenRouterUpstreamInferenceCostFromUsageRaw(raw);
+  if (upstreamInferenceCost !== undefined) return upstreamInferenceCost;
+
+  if (!isRecord(raw)) return undefined;
+  return typeof raw.cost === "number" && Number.isFinite(raw.cost)
+    ? raw.cost
+    : undefined;
+};

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -572,8 +572,9 @@ export const checkTokenBucketLimit = async (
  * If extra usage was used for input (bucket at 0), also deducts output from extra usage.
  * If we over-estimated input cost, refunds the difference back to the bucket.
  *
- * @param providerCostDollars - If provided (from usage.raw.cost), uses this instead of token calculation.
- *   On clean completions this includes model + sandbox + tool costs.
+ * @param providerCostDollars - If provided (from authoritative provider cost),
+ *   uses this instead of token calculation. On clean completions this includes
+ *   model + sandbox + tool costs.
  *   On non-clean completions this is undefined; nonModelCostDollars covers sandbox/tool costs.
  * @param nonModelCostDollars - Sandbox session and tool costs (always accurate). When providerCostDollars
  *   is undefined (non-clean streams), this is added on top of token-based model cost.

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -11,11 +11,35 @@ interface StepUsage {
     cacheReadTokens?: number;
     cacheWriteTokens?: number;
   };
-  raw?: { cost?: number };
+  raw?: {
+    cost?: number;
+    cost_details?: {
+      upstream_inference_cost?: number;
+      upstreamInferenceCost?: number;
+    };
+    costDetails?: {
+      upstream_inference_cost?: number;
+      upstreamInferenceCost?: number;
+    };
+  };
 }
 
 const isPositiveFiniteNumber = (value: unknown): value is number =>
   typeof value === "number" && Number.isFinite(value) && value > 0;
+
+const getRawModelCost = (usage: StepUsage): number | undefined => {
+  const upstreamInferenceCost =
+    usage.raw?.cost_details?.upstream_inference_cost ??
+    usage.raw?.cost_details?.upstreamInferenceCost ??
+    usage.raw?.costDetails?.upstream_inference_cost ??
+    usage.raw?.costDetails?.upstreamInferenceCost;
+
+  if (isPositiveFiniteNumber(upstreamInferenceCost)) {
+    return upstreamInferenceCost;
+  }
+
+  return usage.raw?.cost;
+};
 
 type ModelStepCost = {
   rawCost: number;
@@ -73,10 +97,10 @@ export class UsageTracker {
   cacheReadTokens = 0;
   cacheWriteTokens = 0;
   providerCost = 0;
-  /** Model-only cost from usage.raw.cost or authoritative provider metadata
-   * (excludes tool/sandbox spend). Used to decide whether the provider reported
-   * an authoritative model cost; if zero, fall back to token-based model cost
-   * calculation. */
+  /** Model-only cost from usage.raw.cost, OpenRouter upstream cost details, or
+   * authoritative provider metadata (excludes tool/sandbox spend). Used to
+   * decide whether the provider reported an authoritative model cost; if zero,
+   * fall back to token-based model cost calculation. */
   modelProviderCost = 0;
   private modelStepCosts: ModelStepCost[] = [];
   /** Costs from sandbox sessions and tool usage (always accurate, even on non-clean streams) */
@@ -112,7 +136,7 @@ export class UsageTracker {
     this.lastStepInputTokens = usage.inputTokens || 0;
     this.cacheReadTokens += usage.inputTokenDetails?.cacheReadTokens || 0;
     this.cacheWriteTokens += usage.inputTokenDetails?.cacheWriteTokens || 0;
-    const stepCost = usage.raw?.cost;
+    const stepCost = getRawModelCost(usage);
     const rawCost = isPositiveFiniteNumber(stepCost) ? stepCost : 0;
     const stepCostIndex = this.modelStepCosts.push({ rawCost }) - 1;
     if (isPositiveFiniteNumber(stepCost)) {
@@ -176,7 +200,8 @@ export class UsageTracker {
     accountingModel?: string,
   ): number {
     // Use authoritative provider cost only when the model itself reported one
-    // via raw.cost or OpenRouter metadata (tracked in modelProviderCost).
+    // via raw.cost, OpenRouter upstream cost details, or OpenRouter metadata
+    // (tracked in modelProviderCost).
     // providerCost also includes sandbox/tool spend and summarization cost, so
     // subtract nonModelCost to isolate the model portion.
     if (this.hasAuthoritativeModelCost) {

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -1,4 +1,8 @@
 import { logUsageRecord } from "@/lib/db/actions";
+import {
+  getProviderUsageRawModelCost,
+  isPositiveFiniteNumber,
+} from "@/lib/provider-usage-cost";
 import { calculateRawTokenCost, POINTS_PER_DOLLAR } from "@/lib/rate-limit";
 import type { UsageDeductionFailureReason } from "@/lib/rate-limit";
 import type { ChatMode, RateLimitInfo, SubscriptionTier } from "@/types";
@@ -23,23 +27,6 @@ interface StepUsage {
     };
   };
 }
-
-const isPositiveFiniteNumber = (value: unknown): value is number =>
-  typeof value === "number" && Number.isFinite(value) && value > 0;
-
-const getRawModelCost = (usage: StepUsage): number | undefined => {
-  const upstreamInferenceCost =
-    usage.raw?.cost_details?.upstream_inference_cost ??
-    usage.raw?.cost_details?.upstreamInferenceCost ??
-    usage.raw?.costDetails?.upstream_inference_cost ??
-    usage.raw?.costDetails?.upstreamInferenceCost;
-
-  if (isPositiveFiniteNumber(upstreamInferenceCost)) {
-    return upstreamInferenceCost;
-  }
-
-  return usage.raw?.cost;
-};
 
 type ModelStepCost = {
   rawCost: number;
@@ -136,7 +123,7 @@ export class UsageTracker {
     this.lastStepInputTokens = usage.inputTokens || 0;
     this.cacheReadTokens += usage.inputTokenDetails?.cacheReadTokens || 0;
     this.cacheWriteTokens += usage.inputTokenDetails?.cacheWriteTokens || 0;
-    const stepCost = getRawModelCost(usage);
+    const stepCost = getProviderUsageRawModelCost(usage.raw);
     const rawCost = isPositiveFiniteNumber(stepCost) ? stepCost : 0;
     const stepCostIndex = this.modelStepCosts.push({ rawCost }) - 1;
     if (isPositiveFiniteNumber(stepCost)) {

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -14,6 +14,14 @@ interface StepUsage {
   raw?: { cost?: number };
 }
 
+const isPositiveFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value > 0;
+
+type ModelStepCost = {
+  rawCost: number;
+  authoritativeCost?: number;
+};
+
 export type UsageBillingType = "included" | "extra" | "mixed";
 
 export interface UsageBillingBreakdown {
@@ -65,10 +73,12 @@ export class UsageTracker {
   cacheReadTokens = 0;
   cacheWriteTokens = 0;
   providerCost = 0;
-  /** Model-only cost from per-step usage.raw.cost (excludes tool/sandbox spend). Used to
-   * decide whether the provider reported an authoritative model cost; if zero, fall back
-   * to token-based model cost calculation. */
+  /** Model-only cost from usage.raw.cost or authoritative provider metadata
+   * (excludes tool/sandbox spend). Used to decide whether the provider reported
+   * an authoritative model cost; if zero, fall back to token-based model cost
+   * calculation. */
   modelProviderCost = 0;
+  private modelStepCosts: ModelStepCost[] = [];
   /** Costs from sandbox sessions and tool usage (always accurate, even on non-clean streams) */
   nonModelCost = 0;
   lastStepInputTokens = 0;
@@ -92,9 +102,10 @@ export class UsageTracker {
     this.lastStepInputTokens = 0;
     this.cacheReadTokens = 0;
     this.cacheWriteTokens = 0;
+    this.modelStepCosts = [];
   }
 
-  accumulateStep(usage: StepUsage) {
+  accumulateStep(usage: StepUsage): number {
     this.inputTokens += usage.inputTokens || 0;
     this.outputTokens += usage.outputTokens || 0;
     this.totalTokens += usage.totalTokens || 0;
@@ -102,10 +113,39 @@ export class UsageTracker {
     this.cacheReadTokens += usage.inputTokenDetails?.cacheReadTokens || 0;
     this.cacheWriteTokens += usage.inputTokenDetails?.cacheWriteTokens || 0;
     const stepCost = usage.raw?.cost;
-    if (stepCost) {
+    const rawCost = isPositiveFiniteNumber(stepCost) ? stepCost : 0;
+    const stepCostIndex = this.modelStepCosts.push({ rawCost }) - 1;
+    if (isPositiveFiniteNumber(stepCost)) {
       this.providerCost += stepCost;
       this.modelProviderCost += stepCost;
     }
+    return stepCostIndex;
+  }
+
+  setAuthoritativeModelCostForStep(
+    stepCostIndex: number | undefined,
+    costDollars: number | undefined,
+  ) {
+    if (!isPositiveFiniteNumber(costDollars) || stepCostIndex === undefined) {
+      return;
+    }
+
+    const stepCost = this.modelStepCosts[stepCostIndex];
+    if (!stepCost) return;
+
+    const previousCost = stepCost.authoritativeCost ?? stepCost.rawCost;
+    stepCost.authoritativeCost = costDollars;
+    this.providerCost += costDollars - previousCost;
+    this.modelProviderCost += costDollars - previousCost;
+  }
+
+  get hasAuthoritativeModelCost(): boolean {
+    return (
+      this.modelStepCosts.length > 0 &&
+      this.modelStepCosts.every((stepCost) =>
+        isPositiveFiniteNumber(stepCost.authoritativeCost ?? stepCost.rawCost),
+      )
+    );
   }
 
   /** Output tokens from the streamed response only (excludes summarization) */
@@ -135,11 +175,11 @@ export class UsageTracker {
     selectedModel: string,
     accountingModel?: string,
   ): number {
-    // Use authoritative per-step provider cost only when the model itself
-    // reported one via raw.cost (tracked in modelProviderCost). providerCost
-    // also includes sandbox/tool spend and summarization cost, so subtract
-    // nonModelCost to isolate the model portion.
-    if (this.modelProviderCost > 0) {
+    // Use authoritative provider cost only when the model itself reported one
+    // via raw.cost or OpenRouter metadata (tracked in modelProviderCost).
+    // providerCost also includes sandbox/tool spend and summarization cost, so
+    // subtract nonModelCost to isolate the model portion.
+    if (this.hasAuthoritativeModelCost) {
       return this.providerCost - this.nonModelCost;
     }
     const modelForEstimate = accountingModel ?? selectedModel;
@@ -152,10 +192,11 @@ export class UsageTracker {
 
   computeCostDollars(selectedModel: string, accountingModel?: string): number {
     // Mirror deductUsage's gate: providerCost is only authoritative for the
-    // total when modelProviderCost > 0. After resetModelLeg() (fallback retry)
-    // providerCost can be positive from nonModelCost alone, which would
-    // underreport the fallback's model tokens if we used it directly.
-    if (this.modelProviderCost > 0) return this.providerCost;
+    // total when every model step has authoritative cost. After resetModelLeg()
+    // (fallback retry), providerCost can be positive from nonModelCost alone,
+    // which would underreport the fallback's model tokens if we used it
+    // directly.
+    if (this.hasAuthoritativeModelCost) return this.providerCost;
     return (
       this.computeModelCostDollars(selectedModel, accountingModel) +
       this.nonModelCost
@@ -326,8 +367,9 @@ export class UsageTracker {
       costDollars,
       modelCostDollars,
       nonModelCostDollars: this.nonModelCost,
-      costSource:
-        this.modelProviderCost > 0 ? "provider" : "raw_token_estimate",
+      costSource: this.hasAuthoritativeModelCost
+        ? "provider"
+        : "raw_token_estimate",
     };
   }
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1471,10 +1471,9 @@ export const agentLongTask = task({
                 };
                 let usageCostRecord =
                   usageTracker.createUsageCostRecord(usageRecordArgs);
-                const providerCost =
-                  usageTracker.modelProviderCost > 0
-                    ? usageTracker.providerCost
-                    : undefined;
+                const providerCost = usageTracker.hasAuthoritativeModelCost
+                  ? usageTracker.providerCost
+                  : undefined;
                 if (subscription === "free") {
                   await recordFreeMonthlyCost(
                     freeUsageSubject,


### PR DESCRIPTION
## Summary
- use positive OpenRouter upstream inference cost from provider metadata and Vercel AI SDK `usage.raw.cost_details.upstream_inference_cost` / `costDetails.upstreamInferenceCost` as authoritative BYOK model cost when available
- remove the OpenRouter `/generation` metadata fetch from the agent stream path; no hot-path follow-up request is made for generation IDs
- preserve fallback order when upstream cost is zero, absent, or invalid: positive `usage.raw.cost`, then token estimate with the served/accounting model
- keep per-step accounting bounded to step-owned metadata/raw usage so final usage data is not pinned to an unrelated step

## Validation
- `./node_modules/.bin/jest lib/api/__tests__/openrouter-metadata.test.ts lib/__tests__/usage-tracker.test.ts lib/api/__tests__/chat-logger.test.ts --runInBand`
- `./node_modules/.bin/eslint lib/api/agent-stream-runner.ts lib/api/openrouter-metadata.ts lib/api/__tests__/openrouter-metadata.test.ts lib/provider-usage-cost.ts lib/usage-tracker.ts lib/logger.ts lib/__tests__/usage-tracker.test.ts lib/api/__tests__/chat-logger.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/prettier --check lib/api/agent-stream-runner.ts lib/api/openrouter-metadata.ts lib/api/__tests__/openrouter-metadata.test.ts lib/provider-usage-cost.ts lib/usage-tracker.ts lib/logger.ts lib/__tests__/usage-tracker.test.ts lib/api/__tests__/chat-logger.test.ts`
- commit hooks on `61069e0d` and `42c177ee`: `tsc --noEmit` and full Jest suite, 197 suites / 2003 tests passing
- remote PR checks: GitHub tests, Trigger.dev preview deploy, Vercel, Vercel Preview Comments, and CodeRabbit all passing

## Manual verification
- In local dev, send a BYOK OpenRouter Claude/Opus request where OpenRouter credit `total_cost` and `usage.raw.cost` are `0`, but `usage.raw.cost_details.upstream_inference_cost` is positive. The usage ledger should record a non-zero model cost matching the upstream inference cost.
- Confirm no `openrouter_generation_metadata_fetch_observed` event or `/api/v1/generation` fetch appears for the request.
- Send an OpenRouter request where upstream cost is absent or zero. Accounting should still use positive `usage.raw.cost` when present, otherwise the served-model token estimate.