### PR TITLE
Surface handled tool failures in Trigger logs

### DIFF
--- a/lib/ai/tools/__tests__/open-url.test.ts
+++ b/lib/ai/tools/__tests__/open-url.test.ts
@@ -45,6 +45,7 @@ describe("open_url", () => {
   });
 
   it("logs expected Jina network timeouts as warnings without raw error objects", async () => {
+    const onToolFailure = jest.fn();
     const timeoutError = Object.assign(new Error("connect ETIMEDOUT"), {
       code: "ETIMEDOUT",
     });
@@ -54,7 +55,7 @@ describe("open_url", () => {
     global.fetch = jest.fn().mockRejectedValue(fetchError);
 
     const result = await runTool(
-      createOpenUrlTool({ chatId: "chat-1", userID: "user-1" }),
+      createOpenUrlTool({ chatId: "chat-1", onToolFailure, userID: "user-1" }),
       {
         url: "https://example.com/private-path?token=secret",
         brief: "open example page",
@@ -77,23 +78,81 @@ describe("open_url", () => {
         userId: "user-1",
       }),
     );
-    expect(mockPhLoggerError).not.toHaveBeenCalled();
-    expect(JSON.stringify(mockPhLoggerWarn.mock.calls)).not.toContain(
-      "private-path",
+    expect(onToolFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        duration_ms: expect.any(Number),
+        error_code: "ETIMEDOUT",
+        error_message: "fetch failed",
+        error_name: "TypeError",
+        event: "open_url_fetch_failed",
+        provider: "jina",
+        tool_name: "open_url",
+        url_hostname: "example.com",
+      }),
     );
-    expect(JSON.stringify(mockPhLoggerWarn.mock.calls)).not.toContain("secret");
+    expect(mockPhLoggerError).not.toHaveBeenCalled();
+    const loggedPayloads = JSON.stringify([
+      mockPhLoggerWarn.mock.calls,
+      onToolFailure.mock.calls,
+    ]);
+    expect(loggedPayloads).not.toContain("private-path");
+    expect(loggedPayloads).not.toContain("secret");
+  });
+
+  it("reports non-OK Jina HTTP responses to the tool failure hook", async () => {
+    const onToolFailure = jest.fn();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      text: jest.fn(async () => "upstream down"),
+    });
+
+    const result = await runTool(
+      createOpenUrlTool({ chatId: "chat-1", onToolFailure, userID: "user-1" }),
+      {
+        url: "https://example.com/advisory",
+        brief: "open example page",
+      },
+    );
+
+    expect(result).toBe("Error: HTTP 502 - upstream down");
+    expect(onToolFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        duration_ms: expect.any(Number),
+        error_message: "HTTP 502",
+        event: "open_url_provider_failed",
+        provider: "jina",
+        status: 502,
+        status_text: "Bad Gateway",
+        tool_name: "open_url",
+        url_hostname: "example.com",
+      }),
+    );
   });
 
   it("keeps unexpected tool exceptions as errors", async () => {
+    const onToolFailure = jest.fn();
     global.fetch = jest.fn().mockRejectedValue(new Error("unexpected boom"));
 
-    const result = await runTool(createOpenUrlTool(), {
+    const result = await runTool(createOpenUrlTool({ onToolFailure }), {
       url: "not-a-url",
       brief: "open malformed page",
     });
 
     expect(result).toBe("Error opening URL: unexpected boom");
     expect(mockPhLoggerWarn).not.toHaveBeenCalled();
+    expect(onToolFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        duration_ms: expect.any(Number),
+        error_message: "unexpected boom",
+        error_name: "Error",
+        event: "open_url_tool_failed",
+        provider: "jina",
+        tool_name: "open_url",
+        url_hostname: "invalid_url",
+      }),
+    );
     expect(mockPhLoggerError).toHaveBeenCalledWith(
       "Open URL tool error",
       expect.objectContaining({

--- a/lib/ai/tools/__tests__/tool-failure.test.ts
+++ b/lib/ai/tools/__tests__/tool-failure.test.ts
@@ -1,0 +1,24 @@
+import { reportToolFailure } from "../tool-failure";
+
+const failure = {
+  event: "web_search_provider_failed",
+  tool_name: "web_search",
+  provider: "perplexity",
+};
+
+describe("reportToolFailure", () => {
+  test("dispatches failure reporting without awaiting the logger", () => {
+    const onToolFailure = jest.fn(() => new Promise<void>(() => {}));
+
+    expect(reportToolFailure(onToolFailure, failure)).toBeUndefined();
+    expect(onToolFailure).toHaveBeenCalledWith(failure);
+  });
+
+  test("swallows logger errors so tool results are unchanged", () => {
+    const onToolFailure = jest.fn(() => {
+      throw new Error("metadata unavailable");
+    });
+
+    expect(() => reportToolFailure(onToolFailure, failure)).not.toThrow();
+  });
+});

--- a/lib/ai/tools/__tests__/web-search.test.ts
+++ b/lib/ai/tools/__tests__/web-search.test.ts
@@ -19,10 +19,14 @@ const HTML_504 = `
   </body>
 </html>`;
 
-function makeContext(onToolCost = jest.fn()): ToolContext {
+function makeContext(
+  onToolCost = jest.fn(),
+  overrides: Partial<ToolContext> = {},
+): ToolContext {
   return {
     userLocation: { country: "US" },
     onToolCost,
+    ...overrides,
   } as unknown as ToolContext;
 }
 
@@ -98,18 +102,23 @@ describe("web_search", () => {
 
   it("returns a validation message for blank queries without calling Perplexity or logging", async () => {
     const onToolCost = jest.fn();
+    const onToolFailure = jest.fn();
     global.fetch = jest.fn();
 
-    const result = await runTool(createWebSearch(makeContext(onToolCost)), {
-      queries: ["", "   ", "\n"],
-      brief: "search with blank input",
-    });
+    const result = await runTool(
+      createWebSearch(makeContext(onToolCost, { onToolFailure })),
+      {
+        queries: ["", "   ", "\n"],
+        brief: "search with blank input",
+      },
+    );
 
     expect(result).toBe(
       "Error performing web search: Provide at least one non-empty query.",
     );
     expect(global.fetch).not.toHaveBeenCalled();
     expect(onToolCost).not.toHaveBeenCalled();
+    expect(onToolFailure).not.toHaveBeenCalled();
     expect(console.warn).not.toHaveBeenCalled();
     expect(console.error).not.toHaveBeenCalled();
   });
@@ -158,18 +167,23 @@ describe("web_search", () => {
 
   it("rejects overlong queries without calling Perplexity or logging", async () => {
     const onToolCost = jest.fn();
+    const onToolFailure = jest.fn();
     global.fetch = jest.fn();
 
-    const result = await runTool(createWebSearch(makeContext(onToolCost)), {
-      queries: ["x".repeat(8193)],
-      brief: "search with overlong input",
-    });
+    const result = await runTool(
+      createWebSearch(makeContext(onToolCost, { onToolFailure })),
+      {
+        queries: ["x".repeat(8193)],
+        brief: "search with overlong input",
+      },
+    );
 
     expect(result).toBe(
       "Error performing web search: Each query must be 8192 characters or fewer.",
     );
     expect(global.fetch).not.toHaveBeenCalled();
     expect(onToolCost).not.toHaveBeenCalled();
+    expect(onToolFailure).not.toHaveBeenCalled();
     expect(console.error).not.toHaveBeenCalled();
   });
 
@@ -236,6 +250,7 @@ describe("web_search", () => {
 
   it("returns a compact fallback message after repeated 504s", async () => {
     jest.useFakeTimers();
+    const onToolFailure = jest.fn();
 
     global.fetch = jest.fn().mockResolvedValue(
       response(HTML_504, {
@@ -245,10 +260,13 @@ describe("web_search", () => {
       }),
     );
 
-    const resultPromise = runTool(createWebSearch(makeContext()), {
-      queries: ["perplexity status"],
-      brief: "check provider status",
-    });
+    const resultPromise = runTool(
+      createWebSearch(makeContext(jest.fn(), { onToolFailure })),
+      {
+        queries: ["perplexity status"],
+        brief: "check provider status",
+      },
+    );
     await jest.runAllTimersAsync();
     const result = await resultPromise;
 
@@ -268,6 +286,18 @@ describe("web_search", () => {
         bodySummary: expect.stringContaining("Gateway time-out"),
       }),
     );
+    expect(onToolFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempts: 3,
+        body_summary: expect.stringContaining("Gateway time-out"),
+        event: "web_search_provider_failed",
+        provider: "perplexity",
+        retryable: true,
+        status: 504,
+        status_text: "Gateway Timeout",
+        tool_name: "web_search",
+      }),
+    );
     const loggedPayload = (console.error as jest.Mock).mock.calls[0][1] as {
       bodySummary: string;
     };
@@ -276,6 +306,7 @@ describe("web_search", () => {
   });
 
   it("does not retry authorization failures", async () => {
+    const onToolFailure = jest.fn();
     global.fetch = jest.fn().mockResolvedValue(
       response(JSON.stringify({ error: "invalid api key" }), {
         status: 401,
@@ -284,14 +315,29 @@ describe("web_search", () => {
       }),
     );
 
-    const result = await runTool(createWebSearch(makeContext()), {
-      queries: ["perplexity status"],
-      brief: "check provider status",
-    });
+    const result = await runTool(
+      createWebSearch(makeContext(jest.fn(), { onToolFailure })),
+      {
+        queries: ["perplexity status"],
+        brief: "check provider status",
+      },
+    );
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(result).toBe(
       "Error performing web search: Perplexity search is not authorized (HTTP 401 Unauthorized). Check the Perplexity API key or account access.",
+    );
+    expect(onToolFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempts: 1,
+        body_summary: expect.stringContaining("invalid api key"),
+        event: "web_search_provider_failed",
+        provider: "perplexity",
+        retryable: false,
+        status: 401,
+        status_text: "Unauthorized",
+        tool_name: "web_search",
+      }),
     );
   });
 

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -29,6 +29,7 @@ import type {
   AppendMetadataStreamFn,
   SubscriptionTier,
   SandboxBootInfo,
+  ToolFailureLogger,
 } from "@/types";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import type { Geo } from "@vercel/functions";
@@ -58,6 +59,7 @@ export const createTools = (
   subscription?: SubscriptionTier,
   onSandboxBoot?: (info: SandboxBootInfo) => void,
   modelName?: string,
+  onToolFailure?: ToolFailureLogger,
 ) => {
   let sandbox: AnySandbox | null = null;
   let sandboxFirstUsedAt: number | null = null;
@@ -123,6 +125,7 @@ export const createTools = (
     isE2BSandbox,
     appendMetadataStream,
     onToolCost,
+    onToolFailure,
   };
 
   const buildTools = (): ToolSet => {

--- a/lib/ai/tools/open-url.ts
+++ b/lib/ai/tools/open-url.ts
@@ -3,8 +3,9 @@ import { z } from "zod";
 import { phLogger } from "@/lib/posthog/server";
 import { truncateContent } from "@/lib/token-utils";
 import { stringifyRedactedError } from "@/lib/utils/error-redaction";
-import type { ToolContext, ToolFailureLogEvent } from "@/types";
+import type { ToolContext } from "@/types";
 import { toolBriefSchema } from "./tool-brief";
+import { reportToolFailure } from "./tool-failure";
 
 const NETWORK_ERROR_CODES = new Set([
   "ECONNREFUSED",
@@ -72,17 +73,6 @@ const isOpenUrlNetworkError = (error: unknown): boolean => {
   );
 };
 
-const reportToolFailure = async (
-  context: OpenUrlLogContext | undefined,
-  event: ToolFailureLogEvent,
-) => {
-  try {
-    await context?.onToolFailure?.(event);
-  } catch {
-    // Tool failure observability must not change the tool result.
-  }
-};
-
 /**
  * Open URL tool using Jina AI for content retrieval
  * Retrieves and returns the full contents of a webpage
@@ -122,7 +112,7 @@ export const createOpenUrlTool = (context?: OpenUrlLogContext) => {
 
         if (!response.ok) {
           const errorBody = await response.text();
-          await reportToolFailure(context, {
+          reportToolFailure(context?.onToolFailure, {
             event: "open_url_provider_failed",
             tool_name: "open_url",
             provider: "jina",
@@ -161,7 +151,7 @@ export const createOpenUrlTool = (context?: OpenUrlLogContext) => {
           error_name: getErrorName(error),
           error_message: errorMessage,
         };
-        await reportToolFailure(context, {
+        reportToolFailure(context?.onToolFailure, {
           event: logFields.event,
           tool_name: "open_url",
           provider: "jina",

--- a/lib/ai/tools/open-url.ts
+++ b/lib/ai/tools/open-url.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { phLogger } from "@/lib/posthog/server";
 import { truncateContent } from "@/lib/token-utils";
 import { stringifyRedactedError } from "@/lib/utils/error-redaction";
-import type { ToolContext } from "@/types";
+import type { ToolContext, ToolFailureLogEvent } from "@/types";
 import { toolBriefSchema } from "./tool-brief";
 
 const NETWORK_ERROR_CODES = new Set([
@@ -23,7 +23,9 @@ const NETWORK_ERROR_CODES = new Set([
 const NETWORK_ERROR_MESSAGE_PATTERN =
   /fetch failed|failed to fetch|network|timed?\s*out|timeout|connection (?:closed|reset|refused)|socket|getaddrinfo/i;
 
-type OpenUrlLogContext = Pick<ToolContext, "chatId" | "userID">;
+type OpenUrlLogContext = Partial<
+  Pick<ToolContext, "chatId" | "onToolFailure" | "userID">
+>;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -70,6 +72,17 @@ const isOpenUrlNetworkError = (error: unknown): boolean => {
   );
 };
 
+const reportToolFailure = async (
+  context: OpenUrlLogContext | undefined,
+  event: ToolFailureLogEvent,
+) => {
+  try {
+    await context?.onToolFailure?.(event);
+  } catch {
+    // Tool failure observability must not change the tool result.
+  }
+};
+
 /**
  * Open URL tool using Jina AI for content retrieval
  * Retrieves and returns the full contents of a webpage
@@ -109,6 +122,16 @@ export const createOpenUrlTool = (context?: OpenUrlLogContext) => {
 
         if (!response.ok) {
           const errorBody = await response.text();
+          await reportToolFailure(context, {
+            event: "open_url_provider_failed",
+            tool_name: "open_url",
+            provider: "jina",
+            status: response.status,
+            status_text: response.statusText,
+            duration_ms: Date.now() - startedAt,
+            url_hostname: getUrlHostname(url),
+            error_message: `HTTP ${response.status}`,
+          });
           return `Error: HTTP ${response.status} - ${errorBody}`;
         }
 
@@ -138,6 +161,16 @@ export const createOpenUrlTool = (context?: OpenUrlLogContext) => {
           error_name: getErrorName(error),
           error_message: errorMessage,
         };
+        await reportToolFailure(context, {
+          event: logFields.event,
+          tool_name: "open_url",
+          provider: "jina",
+          duration_ms: logFields.duration_ms,
+          url_hostname: logFields.url_hostname,
+          ...(errorCode && { error_code: errorCode }),
+          error_name: logFields.error_name,
+          error_message: errorMessage,
+        });
 
         if (isNetworkFailure) {
           phLogger.warn("Open URL provider fetch failed", logFields);

--- a/lib/ai/tools/open-url.ts
+++ b/lib/ai/tools/open-url.ts
@@ -138,28 +138,25 @@ export const createOpenUrlTool = (context?: OpenUrlLogContext) => {
         const isNetworkFailure = isOpenUrlNetworkError(error);
         const errorCode = getNestedErrorCode(error);
         const errorMessage = stringifyRedactedError(error);
-        const logFields = {
+        const toolFailureFields = {
           event: isNetworkFailure
             ? "open_url_fetch_failed"
             : "open_url_tool_failed",
           provider: "jina",
           url_hostname: getUrlHostname(url),
           duration_ms: Date.now() - startedAt,
-          ...(context?.chatId && { chat_id: context.chatId }),
-          ...(context?.userID && { userId: context.userID }),
           ...(errorCode && { error_code: errorCode }),
           error_name: getErrorName(error),
           error_message: errorMessage,
         };
+        const logFields = {
+          ...toolFailureFields,
+          ...(context?.chatId && { chat_id: context.chatId }),
+          ...(context?.userID && { userId: context.userID }),
+        };
         reportToolFailure(context?.onToolFailure, {
-          event: logFields.event,
+          ...toolFailureFields,
           tool_name: "open_url",
-          provider: "jina",
-          duration_ms: logFields.duration_ms,
-          url_hostname: logFields.url_hostname,
-          ...(errorCode && { error_code: errorCode }),
-          error_name: logFields.error_name,
-          error_message: errorMessage,
         });
 
         if (isNetworkFailure) {

--- a/lib/ai/tools/tool-failure.ts
+++ b/lib/ai/tools/tool-failure.ts
@@ -1,0 +1,14 @@
+import type { ToolFailureLogEvent, ToolFailureLogger } from "@/types";
+
+export const reportToolFailure = (
+  onToolFailure: ToolFailureLogger | undefined,
+  event: ToolFailureLogEvent,
+) => {
+  try {
+    void Promise.resolve(onToolFailure?.(event)).catch(() => {
+      // Tool failure observability must not change the tool result.
+    });
+  } catch {
+    // Tool failure observability must not change the tool result.
+  }
+};

--- a/lib/ai/tools/web-search.ts
+++ b/lib/ai/tools/web-search.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
-import type { ToolContext, ToolFailureLogEvent } from "@/types";
+import type { ToolContext } from "@/types";
 import { stringifyRedactedError } from "@/lib/utils/error-redaction";
 import {
   PerplexityApiError,
@@ -13,6 +13,7 @@ import {
   summarizePerplexityErrorBody,
 } from "./utils/perplexity";
 import { toolBriefSchema } from "./tool-brief";
+import { reportToolFailure } from "./tool-failure";
 
 /**
  * Web search tool using Perplexity Search API
@@ -184,17 +185,6 @@ const normalizeSearchQueries = (
   return { queries: queries.slice(0, 3) };
 };
 
-const reportToolFailure = async (
-  context: ToolContext,
-  event: ToolFailureLogEvent,
-) => {
-  try {
-    await context.onToolFailure?.(event);
-  } catch {
-    // Tool failure observability must not change the tool result.
-  }
-};
-
 export const createWebSearch = (context: ToolContext) => {
   const { userLocation, onToolCost } = context;
 
@@ -291,7 +281,7 @@ export const createWebSearch = (context: ToolContext) => {
             retryable: error.retryable,
             bodySummary: error.bodySummary,
           };
-          await reportToolFailure(context, {
+          reportToolFailure(context.onToolFailure, {
             event: "web_search_provider_failed",
             tool_name: "web_search",
             provider: "perplexity",
@@ -307,7 +297,7 @@ export const createWebSearch = (context: ToolContext) => {
         }
 
         const errorMessage = stringifyRedactedError(error);
-        await reportToolFailure(context, {
+        reportToolFailure(context.onToolFailure, {
           event: "web_search_tool_failed",
           tool_name: "web_search",
           provider: "perplexity",

--- a/lib/ai/tools/web-search.ts
+++ b/lib/ai/tools/web-search.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
-import { ToolContext } from "@/types";
+import type { ToolContext, ToolFailureLogEvent } from "@/types";
 import { stringifyRedactedError } from "@/lib/utils/error-redaction";
 import {
   PerplexityApiError,
@@ -184,6 +184,17 @@ const normalizeSearchQueries = (
   return { queries: queries.slice(0, 3) };
 };
 
+const reportToolFailure = async (
+  context: ToolContext,
+  event: ToolFailureLogEvent,
+) => {
+  try {
+    await context.onToolFailure?.(event);
+  } catch {
+    // Tool failure observability must not change the tool result.
+  }
+};
+
 export const createWebSearch = (context: ToolContext) => {
   const { userLocation, onToolCost } = context;
 
@@ -272,20 +283,37 @@ export const createWebSearch = (context: ToolContext) => {
         }
 
         if (error instanceof PerplexityApiError) {
-          console.error("Web search tool error:", {
+          const attempts = error.retryable ? WEB_SEARCH_MAX_ATTEMPTS : 1;
+          const logFields = {
             name: error.name,
             status: error.status,
             statusText: error.statusText,
             retryable: error.retryable,
             bodySummary: error.bodySummary,
+          };
+          await reportToolFailure(context, {
+            event: "web_search_provider_failed",
+            tool_name: "web_search",
+            provider: "perplexity",
+            status: error.status,
+            status_text: error.statusText,
+            retryable: error.retryable,
+            attempts,
+            error_name: error.name,
+            body_summary: error.bodySummary,
           });
-          return formatPerplexityFailureForTool(
-            error,
-            error.retryable ? WEB_SEARCH_MAX_ATTEMPTS : 1,
-          );
+          console.error("Web search tool error:", logFields);
+          return formatPerplexityFailureForTool(error, attempts);
         }
 
         const errorMessage = stringifyRedactedError(error);
+        await reportToolFailure(context, {
+          event: "web_search_tool_failed",
+          tool_name: "web_search",
+          provider: "perplexity",
+          error_name: error instanceof Error ? error.name : "UnknownError",
+          error_message: errorMessage,
+        });
         console.error("Web search tool error:", errorMessage);
         return `Error performing web search: ${errorMessage}`;
       }

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -391,6 +391,18 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(routeSrc).toMatch(/loginRequired:\s*false/);
   });
 
+  test("handled tool failures are visible in Trigger logs and metadata", () => {
+    expect(taskSrc).toMatch(/recordAgentLongHandledToolFailureForDashboard/);
+    expect(taskSrc).toMatch(/lastHandledToolFailureStatus/);
+    expect(taskSrc).toMatch(/handled_tool_failure/);
+    expect(taskSrc).toMatch(/buildTriggerTag\("tool_status_"/);
+    expect(taskSrc).toMatch(
+      /triggerLogger\.warn\("\[agent-long\] handled tool failure"/,
+    );
+    expect(taskSrc).toMatch(/const onToolFailure\s*=/);
+    expect(taskSrc).toMatch(/onToolFailure,\s*\)/);
+  });
+
   test("runs use small subscription-aware Trigger.dev priority offsets", () => {
     expect(routeSrc).toMatch(
       /AGENT_LONG_TRIGGER_PRIORITY_BY_SUBSCRIPTION:\s*Record<\s*SubscriptionTier,\s*number\s*>/,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -400,6 +400,13 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       /triggerLogger\.warn\("\[agent-long\] handled tool failure"/,
     );
     expect(taskSrc).toMatch(/const onToolFailure\s*=/);
+    expect(taskSrc).toMatch(
+      /void\s+recordAgentLongHandledToolFailureForDashboard/,
+    );
+    expect(taskSrc).not.toMatch(
+      /await\s+recordAgentLongHandledToolFailureForDashboard/,
+    );
+    expect(taskSrc).toMatch(/handled tool failure dashboard update failed/);
     expect(taskSrc).toMatch(/onToolFailure,\s*\)/);
   });
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1225,13 +1225,28 @@ export const agentLongTask = task({
 
             let uploadSandboxBootPath: SandboxBootInfo["path"] | null = null;
             let handledToolFailureCount = 0;
-            const onToolFailure = async (failure: ToolFailureLogEvent) => {
+            const onToolFailure = (failure: ToolFailureLogEvent) => {
               handledToolFailureCount += 1;
-              await recordAgentLongHandledToolFailureForDashboard(failure, {
+              void recordAgentLongHandledToolFailureForDashboard(failure, {
                 chatId,
                 userId,
                 runId: ctx.run.id,
                 handledToolFailureCount,
+              }).catch((error) => {
+                triggerLogger.warn(
+                  "[agent-long] handled tool failure dashboard update failed",
+                  {
+                    chatId,
+                    userId,
+                    runId: ctx.run.id,
+                    tool_name: failure.tool_name,
+                    provider: failure.provider,
+                    error_name:
+                      error instanceof Error ? error.name : "UnknownError",
+                    error_message:
+                      error instanceof Error ? error.message : String(error),
+                  },
+                );
               });
             };
             const {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -108,6 +108,7 @@ import type {
   SelectedModel,
   RateLimitInfo,
   SandboxBootInfo,
+  ToolFailureLogEvent,
 } from "@/types";
 import {
   createAgentStream,
@@ -754,6 +755,46 @@ const recordAgentLongHandledRateLimitForDashboard = async (
   await metadata.flush();
 };
 
+const recordAgentLongHandledToolFailureForDashboard = async (
+  failure: ToolFailureLogEvent,
+  context: {
+    chatId: string;
+    userId: string;
+    runId: string;
+    handledToolFailureCount: number;
+  },
+) => {
+  const failedAt = new Date().toISOString();
+  metadata
+    .set("handledToolFailureCount", context.handledToolFailureCount)
+    .set("lastHandledToolFailure", failure.tool_name)
+    .set("lastHandledToolFailureProvider", failure.provider)
+    .set("lastHandledToolFailureEvent", failure.event)
+    .set("lastHandledToolFailureAt", failedAt);
+  if (failure.status != null) {
+    metadata.set("lastHandledToolFailureStatus", failure.status);
+  }
+
+  await tags.add([
+    "handled_tool_failure",
+    buildTriggerTag("tool_", failure.tool_name),
+    buildTriggerTag("tool_provider_", failure.provider),
+    ...(failure.status != null
+      ? [buildTriggerTag("tool_status_", String(failure.status))]
+      : []),
+  ]);
+
+  triggerLogger.warn("[agent-long] handled tool failure", {
+    chatId: context.chatId,
+    userId: context.userId,
+    runId: context.runId,
+    handled_tool_failure_count: context.handledToolFailureCount,
+    ...failure,
+  });
+
+  await metadata.flush();
+};
+
 const withAgentLongStreamHeartbeat = (
   source: ReadableStream<AgentLongUiStreamPart>,
   signal: AbortSignal,
@@ -1183,6 +1224,16 @@ export const agentLongTask = task({
             });
 
             let uploadSandboxBootPath: SandboxBootInfo["path"] | null = null;
+            let handledToolFailureCount = 0;
+            const onToolFailure = async (failure: ToolFailureLogEvent) => {
+              handledToolFailureCount += 1;
+              await recordAgentLongHandledToolFailureForDashboard(failure, {
+                chatId,
+                userId,
+                runId: ctx.run.id,
+                handledToolFailureCount,
+              });
+            };
             const {
               tools,
               ensureSandbox,
@@ -1216,6 +1267,7 @@ export const agentLongTask = task({
                 chatLogger?.setSandboxBoot(info);
               },
               selectedModel,
+              onToolFailure,
             );
 
             const sendFileMetadataToStream = (

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -68,6 +68,7 @@ export type AppendMetadataStreamFn = (event: {
   data: { terminal: string; toolCallId: string };
 }) => Promise<void>;
 
+/** Provider/tool-scoped failure data. Host runtimes attach request/user context separately. */
 export type ToolFailureLogEvent = {
   event: string;
   tool_name: string;

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -68,6 +68,26 @@ export type AppendMetadataStreamFn = (event: {
   data: { terminal: string; toolCallId: string };
 }) => Promise<void>;
 
+export type ToolFailureLogEvent = {
+  event: string;
+  tool_name: string;
+  provider: string;
+  status?: number;
+  status_text?: string;
+  retryable?: boolean;
+  attempts?: number;
+  duration_ms?: number;
+  error_code?: string;
+  error_name?: string;
+  error_message?: string;
+  url_hostname?: string;
+  body_summary?: string;
+};
+
+export type ToolFailureLogger = (
+  event: ToolFailureLogEvent,
+) => void | Promise<void>;
+
 export interface ToolContext {
   sandboxManager: SandboxManager;
   writer: UIMessageStreamWriter;
@@ -91,4 +111,6 @@ export interface ToolContext {
   appendMetadataStream?: AppendMetadataStreamFn;
   /** Callback to report additional tool costs (in dollars) that should be added to the request's total cost. */
   onToolCost?: (costDollars: number) => void;
+  /** Callback to report handled provider/tool failures to the request's host runtime. */
+  onToolFailure?: ToolFailureLogger;
 }


### PR DESCRIPTION
## Summary
- add a shared handled tool failure callback for provider-backed tools
- report Perplexity web_search and Jina open_url failures into agent-long Trigger logs, tags, and metadata
- keep local terminal/file workflow errors out of Trigger failure telemetry and cover safe-field reporting in tests

## Testing
- ./node_modules/.bin/jest lib/ai/tools/__tests__/web-search.test.ts lib/ai/tools/__tests__/open-url.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/eslint types/agent.ts lib/ai/tools/index.ts lib/ai/tools/web-search.ts lib/ai/tools/open-url.ts trigger/agent-long.ts lib/ai/tools/__tests__/web-search.test.ts lib/ai/tools/__tests__/open-url.test.ts lib/api/__tests__/agent-long-contracts.test.ts
- ./node_modules/.bin/prettier --check types/agent.ts lib/ai/tools/index.ts lib/ai/tools/web-search.ts lib/ai/tools/open-url.ts trigger/agent-long.ts lib/ai/tools/__tests__/web-search.test.ts lib/ai/tools/__tests__/open-url.test.ts lib/api/__tests__/agent-long-contracts.test.ts

## Notes
- `pnpm jest ...` currently stops in this sparse worktree on pnpm ignored-build script approval, so validation used the local binaries after pnpm materialized dependencies.
- Ask-mode `/api/chat` requests still do not appear in Trigger because they do not create Trigger runs.

## Manual verification
- Run an Agent-mode prompt that calls `web_search` while Perplexity returns an API error, or `open_url` while Jina returns a fetch/HTTP failure.
- In the Trigger run, confirm the log line `[agent-long] handled tool failure` appears with provider/tool/status fields.
- Confirm run metadata/tags include handled tool failure fields such as `handledToolFailureCount`, `lastHandledToolFailureProvider`, `handled_tool_failure`, `tool_provider_*`, and optional `tool_status_*`.
- Confirm the user still receives the normal handled tool-result error instead of a failed Agent run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured, redacted tool-failure reporting for AI tools via an optional `onToolFailure` callback, including improved details for URL-opening and web-search provider failures.
  * Handled tool failures are now recorded in run metadata and surfaced in dashboard tags for easier troubleshooting.

* **Bug Fixes**
  * Improved failure event consistency across provider errors, timeouts/network issues, and unexpected exceptions (including richer HTTP status, retryability, and contextual metadata).
  * Expanded safety/redaction to avoid sensitive URL path/token data in failure payloads.

* **Tests**
  * Added/updated coverage to verify `onToolFailure` behavior and payload shapes across error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->