### PR TITLE
Improve agent-long fast-start streaming

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -429,6 +429,42 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     );
   });
 
+  test("emits hidden fast-start heartbeats before setup and model streaming can go quiet", () => {
+    expect(taskSrc).toMatch(/createAgentLongHeartbeatPart/);
+    expect(taskSrc).toMatch(/phase:\s*"setup"\s*\|\s*"model_stream"/);
+    expect(taskSrc).toMatch(/transient:\s*true/);
+
+    const executeIdx = taskSrc.indexOf("execute: async ({ writer })");
+    const fastStartIdx = taskSrc.indexOf(
+      'writeAgentLongFastStart(writer, "setup")',
+      executeIdx,
+    );
+    const costCheckIdx = taskSrc.indexOf(
+      "await assertUserCanMakeCostIncurringRequest(userId)",
+      executeIdx,
+    );
+
+    expect(executeIdx).toBeGreaterThan(-1);
+    expect(fastStartIdx).toBeGreaterThan(executeIdx);
+    expect(costCheckIdx).toBeGreaterThan(fastStartIdx);
+
+    const heartbeatWrapperIdx = taskSrc.indexOf(
+      "const withAgentLongStreamHeartbeat",
+    );
+    const immediateModelHeartbeatIdx = taskSrc.indexOf(
+      'safeEnqueue(createAgentLongHeartbeatPart("model_stream"))',
+      heartbeatWrapperIdx,
+    );
+    const readerLoopIdx = taskSrc.indexOf(
+      "void (async () =>",
+      heartbeatWrapperIdx,
+    );
+
+    expect(heartbeatWrapperIdx).toBeGreaterThan(-1);
+    expect(immediateModelHeartbeatIdx).toBeGreaterThan(heartbeatWrapperIdx);
+    expect(readerLoopIdx).toBeGreaterThan(immediateModelHeartbeatIdx);
+  });
+
   test("handled user rate limits are returned after the UI error chunk is flushed", () => {
     const waitIdx = taskSrc.indexOf("await waitUntilComplete()");
     const streamErrorIdx = taskSrc.indexOf("if (terminalStreamError)", waitIdx);

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -156,6 +156,22 @@ const getAgentLongMaxDurationMs = (subscription: SubscriptionTier) =>
 
 type AgentLongUiStreamPart = Parameters<UIMessageStreamWriter["write"]>[0];
 
+const createAgentLongHeartbeatPart = (
+  phase: "setup" | "model_stream",
+): AgentLongUiStreamPart =>
+  ({
+    type: AGENT_LONG_HEARTBEAT_PART_TYPE,
+    data: { at: Date.now(), phase },
+    transient: true,
+  }) as AgentLongUiStreamPart;
+
+const writeAgentLongFastStart = (
+  writer: UIMessageStreamWriter,
+  phase: "setup" | "model_stream",
+): void => {
+  writer.write(createAgentLongHeartbeatPart(phase));
+};
+
 const MAX_TRIGGER_ERROR_MESSAGE_LENGTH = 500;
 const TRIGGER_TAG_MAX_LENGTH = 64;
 
@@ -801,14 +817,14 @@ const withAgentLongStreamHeartbeat = (
           return;
         }
 
-        safeEnqueue({
-          type: AGENT_LONG_HEARTBEAT_PART_TYPE,
-          data: { at: Date.now() },
-        } as AgentLongUiStreamPart);
+        safeEnqueue(createAgentLongHeartbeatPart("model_stream"));
       }, AGENT_LONG_HEARTBEAT_INTERVAL_MS);
 
       signal.addEventListener("abort", stop, { once: true });
       if (signal.aborted) stop();
+      if (!stopped) {
+        safeEnqueue(createAgentLongHeartbeatPart("model_stream"));
+      }
 
       void (async () => {
         try {
@@ -1130,6 +1146,7 @@ export const agentLongTask = task({
         },
         execute: async ({ writer }) => {
           try {
+            writeAgentLongFastStart(writer, "setup");
             await assertUserCanMakeCostIncurringRequest(userId);
             if (subscription === "free") {
               const lock = await acquireFreeRunConcurrencyLock(


### PR DESCRIPTION
## Summary
- emit a transient hidden agent-long heartbeat as soon as task setup enters the UI stream
- emit the first model-stream heartbeat immediately instead of waiting for the 25s interval
- add a structural contract test so future refactors keep the quiet-start guard

## Why
The attached Trigger.dev fast-start docs recommend avoiding quiet first-turn startup windows. HackerAI currently uses a custom `agent-long` Trigger task rather than `chat.agent`, so true Trigger Head Start is a larger migration. This PR improves the current path by making the existing stream become live earlier without changing user-visible content, persistence, or task protocol.

## Validation
- `./node_modules/.bin/jest lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `./node_modules/.bin/prettier --check trigger/agent-long.ts lib/api/__tests__/agent-long-contracts.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/eslint trigger/agent-long.ts lib/api/__tests__/agent-long-contracts.test.ts`
- commit hook: `tsc --noEmit`
- commit hook: `jest` (197 suites / 1992 tests)

## Manual verification
- Start a new Agent-mode chat that routes through `/api/agent-long`.
- Confirm the browser stream leaves the initial quiet state earlier while the hidden heartbeat is not rendered as assistant content.
- Let the run finish or reload the chat, then confirm no `data-agent-heartbeat` parts are persisted in the saved assistant message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long-running agent tasks now show an immediate progress update sooner, reducing the chance of a silent pause at startup.
  * Streaming status updates are now emitted more consistently during setup and model streaming, improving perceived responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->