### PR TITLE
Use high reasoning for Claude tiers

### DIFF
--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -292,8 +292,6 @@ describe("buildProviderOptions fallback chain", () => {
     "ask-model",
     "model-grok-4.3",
     "model-gemini-3-flash",
-    "model-sonnet-4.6",
-    "model-opus-4.6",
   ])("enables medium reasoning for ask mode model %s", (modelName) => {
     const opts = buildProviderOptions(false, "user-1", modelName, "ask");
     expect(opts.openrouter.reasoning).toEqual({
@@ -301,6 +299,28 @@ describe("buildProviderOptions fallback chain", () => {
       effort: "medium",
     });
   });
+
+  it.each(["model-sonnet-4.6", "model-opus-4.6"])(
+    "enables high reasoning for ask mode model %s",
+    (modelName) => {
+      const opts = buildProviderOptions(false, "user-1", modelName, "ask");
+      expect(opts.openrouter.reasoning).toEqual({
+        enabled: true,
+        effort: "high",
+      });
+    },
+  );
+
+  it.each(["model-sonnet-4.6", "model-opus-4.6"])(
+    "enables high reasoning for agent mode model %s",
+    (modelName) => {
+      const opts = buildProviderOptions(true, "user-1", modelName, "agent");
+      expect(opts.openrouter.reasoning).toEqual({
+        enabled: true,
+        effort: "high",
+      });
+    },
+  );
 
   it("includes reasoning settings independent of fallback chain", () => {
     const reasoning = buildProviderOptions(
@@ -310,19 +330,19 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(reasoning.openrouter).toMatchObject({
-      reasoning: { enabled: true },
+      reasoning: { enabled: true, effort: "high" },
       models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
     });
 
     const noReasoning = buildProviderOptions(
       false,
       "user-1",
-      "model-opus-4.6",
+      "agent-model",
       "agent",
     );
     expect(noReasoning.openrouter).toMatchObject({
       reasoning: { enabled: false },
-      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
+      models: [KIMI_SLUG, GROK_SLUG],
     });
 
     const multimodal = buildProviderOptions(
@@ -333,7 +353,7 @@ describe("buildProviderOptions fallback chain", () => {
       { hasMultimodalToolResults: true },
     );
     expect(multimodal.openrouter).toMatchObject({
-      reasoning: { enabled: true },
+      reasoning: { enabled: true, effort: "high" },
       models: [KIMI_SLUG, GROK_SLUG],
     });
   });

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -671,19 +671,15 @@ export function buildProviderOptions(
   const fallbackSlugs = getFallbackSlugs(modelName, mode, options);
   const reasoning =
     options.reasoningOverride ??
-    (isReasoningModel
+    (isHighReasoningModel(modelName)
       ? {
           enabled: true,
-          ...(isDeepSeekV4
-            ? { effort: "xhigh" }
-            : isHighReasoningModel(modelName)
-              ? { effort: "high" }
-              : {}),
+          effort: "high",
         }
-      : isHighReasoningModel(modelName)
+      : isReasoningModel
         ? {
             enabled: true,
-            effort: "high",
+            ...(isDeepSeekV4 ? { effort: "xhigh" } : {}),
           }
         : mode === "ask" && isAskKimiReasoningModel(modelName)
           ? {

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -534,13 +534,20 @@ const ASK_STANDARD_REASONING_MODELS = [
 
 const ASK_MEDIUM_REASONING_MODELS = [
   ...ASK_STANDARD_REASONING_MODELS,
-  "model-sonnet-4.6",
-  "model-opus-4.6",
 ] as const satisfies readonly ModelName[];
 
 const isAskMediumReasoningModel = (modelName?: string): boolean =>
   typeof modelName === "string" &&
   (ASK_MEDIUM_REASONING_MODELS as readonly string[]).includes(modelName);
+
+const HIGH_REASONING_MODELS = [
+  "model-sonnet-4.6",
+  "model-opus-4.6",
+] as const satisfies readonly ModelName[];
+
+const isHighReasoningModel = (modelName?: string): boolean =>
+  typeof modelName === "string" &&
+  (HIGH_REASONING_MODELS as readonly string[]).includes(modelName);
 
 const ASK_KIMI_REASONING_MODELS = [
   "model-kimi-k2.7-code",
@@ -667,18 +674,27 @@ export function buildProviderOptions(
     (isReasoningModel
       ? {
           enabled: true,
-          ...(isDeepSeekV4 && { effort: "xhigh" }),
+          ...(isDeepSeekV4
+            ? { effort: "xhigh" }
+            : isHighReasoningModel(modelName)
+              ? { effort: "high" }
+              : {}),
         }
-      : mode === "ask" && isAskKimiReasoningModel(modelName)
+      : isHighReasoningModel(modelName)
         ? {
             enabled: true,
+            effort: "high",
           }
-        : mode === "ask" && isAskMediumReasoningModel(modelName)
+        : mode === "ask" && isAskKimiReasoningModel(modelName)
           ? {
               enabled: true,
-              effort: "medium",
             }
-          : { enabled: false });
+          : mode === "ask" && isAskMediumReasoningModel(modelName)
+            ? {
+                enabled: true,
+                effort: "medium",
+              }
+            : { enabled: false });
 
   return {
     openrouter: {


### PR DESCRIPTION
## Summary
- send explicit OpenRouter high reasoning for Sonnet 4.6 and Opus 4.6
- apply the high-effort setting in both Ask and Agent provider option paths
- add focused coverage for Claude high reasoning while keeping other route efforts unchanged

## Validation
- ./node_modules/.bin/jest lib/api/__tests__/chat-stream-helpers-fallback.test.ts --runInBand
- ./node_modules/.bin/prettier --check lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts
- ./node_modules/.bin/eslint lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts
- commit hook: tsc --noEmit
- commit hook: jest

## Manual verification
- Send Ask Pro/Max and Agent Pro/Max requests and confirm the OpenRouter request has reasoning effort high for Sonnet/Opus.
- Confirm Standard Ask remains medium and DeepSeek V4 reasoning remains xhigh.

## Visual verification
- Not needed; provider-options only, no UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected model reasoning effort selection so supported models now use the intended reasoning level in both ask and agent modes.
  * Adjusted fallback and multimodal reasoning behavior to consistently apply higher effort where expected.
* **Tests**
  * Expanded automated coverage to validate reasoning and fallback settings across additional model/mode combinations, including updated high-effort expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->