### PR TITLE
Fallback on assistant output loops

### DIFF
--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -432,6 +432,38 @@ export async function createAgentStream(
     ctx.abortController.signal,
     assistantContentLoopAbortController.signal,
   ]);
+  type AbortStepLike = {
+    usage?: unknown;
+    response?: Parameters<typeof extractOpenRouterMetadata>[0]["response"] & {
+      modelId?: string;
+    };
+    providerMetadata?: unknown;
+  };
+  const recordAssistantContentLoopAbortState = (
+    steps?: readonly AbortStepLike[],
+  ) => {
+    if (!state.stoppedDueToAssistantContentLoop) return;
+
+    const lastStep = steps?.at(-1);
+    state.streamFinishReason = DOOM_LOOP_FINISH_REASON;
+    if (lastStep?.usage) {
+      state.streamUsage = lastStep.usage as Record<string, unknown>;
+    }
+    state.responseModel = lastStep?.response?.modelId ?? state.responseModel;
+    state.responseModel ??= requestedSlug;
+
+    const openRouterMetadata = lastStep
+      ? extractOpenRouterMetadata({
+          response: lastStep.response,
+          providerMetadata: lastStep.providerMetadata,
+        })
+      : undefined;
+    ctx.chatLogger?.setStreamResponse(
+      state.responseModel,
+      state.streamUsage,
+      openRouterMetadata,
+    );
+  };
 
   type DoomLoopRecovery = {
     nudge?: string;
@@ -766,6 +798,7 @@ export async function createAgentStream(
             repeatedText: loopDetection.repeatedText,
             repeatCount: loopDetection.repeatCount,
           });
+          recordAssistantContentLoopAbortState();
           assistantContentLoopAbortController.abort();
         }
       }
@@ -949,7 +982,8 @@ export async function createAgentStream(
         );
     },
 
-    onAbort: async () => {
+    onAbort: async ({ steps }) => {
+      recordAssistantContentLoopAbortState(steps);
       await ptySessionManager
         .closeAll(ctx.chatId)
         .catch((err) =>

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -46,6 +46,10 @@ import {
   generateDoomLoopNudge,
 } from "@/lib/chat/doom-loop-detection";
 import {
+  createAssistantContentLoopMonitor,
+  type AssistantContentLoopDetection,
+} from "@/lib/chat/agent-long-provider-retry";
+import {
   filterEmptyAssistantMessages,
   repairAnthropicModelMessagesWithTelemetry,
   pruneToolOutputs,
@@ -113,6 +117,8 @@ export type AgentStreamState = {
   /** Maps to stoppedDueToPreemptiveTimeout in chat-handler, stoppedDueToElapsedTimeout in agent-long. */
   stoppedDueToElapsedTimeout: boolean;
   stoppedDueToDoomLoop: boolean;
+  stoppedDueToAssistantContentLoop: boolean;
+  assistantContentLoopDetection: AssistantContentLoopDetection | undefined;
   stoppedDueToBudgetExhaustion: boolean;
   stoppedDueToAgentRunSpendCap: boolean;
   budgetAbortDetails: BudgetAbortDetails | undefined;
@@ -134,6 +140,8 @@ export function initAgentStreamState(
     stoppedDueToTokenExhaustion: false,
     stoppedDueToElapsedTimeout: false,
     stoppedDueToDoomLoop: false,
+    stoppedDueToAssistantContentLoop: false,
+    assistantContentLoopDetection: undefined,
     stoppedDueToBudgetExhaustion: false,
     stoppedDueToAgentRunSpendCap: false,
     budgetAbortDetails: undefined,
@@ -183,6 +191,32 @@ const addContentPartCounts = (
 const contentHasToolCall = (content: unknown): boolean =>
   Array.isArray(content) &&
   content.some((part) => isRecord(part) && part.type === "tool-call");
+
+const combineAbortSignals = (signals: AbortSignal[]): AbortSignal => {
+  const abortSignalAny = (
+    AbortSignal as typeof AbortSignal & {
+      any?: (signals: AbortSignal[]) => AbortSignal;
+    }
+  ).any;
+  if (typeof abortSignalAny === "function") {
+    return abortSignalAny(signals);
+  }
+
+  const controller = new AbortController();
+  const abort = () => {
+    if (!controller.signal.aborted) controller.abort();
+  };
+
+  for (const signal of signals) {
+    if (signal.aborted) {
+      abort();
+      break;
+    }
+    signal.addEventListener("abort", abort, { once: true });
+  }
+
+  return controller.signal;
+};
 
 const summarizeProviderOptions = (
   providerOptions: unknown,
@@ -245,7 +279,8 @@ const buildProviderRequestDiagnostics = (args: {
   }
 
   const lastMessage = args.messages.at(-1) as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
   const serializedBytes = getSerializedBytes(args.messages);
   const contextUsedPercent =
     args.contextUsage.maxTokens > 0
@@ -391,6 +426,12 @@ export async function createAgentStream(
   > => getActiveToolsWithExclusions();
   const requestedLanguageModel = ctx.trackedProvider.languageModel(modelName);
   const requestedSlug = requestedLanguageModel.modelId;
+  const assistantContentLoopMonitor = createAssistantContentLoopMonitor();
+  const assistantContentLoopAbortController = new AbortController();
+  const abortSignal = combineAbortSignals([
+    ctx.abortController.signal,
+    assistantContentLoopAbortController.signal,
+  ]);
 
   type DoomLoopRecovery = {
     nudge?: string;
@@ -534,7 +575,7 @@ export async function createAgentStream(
     messages: initialModelMessages,
     tools: ctx.tools,
     activeTools: initialActiveTools,
-    abortSignal: ctx.abortController.signal,
+    abortSignal,
     providerOptions: initialProviderOptions,
 
     prepareStep: async ({ steps, messages }) => {
@@ -702,6 +743,33 @@ export async function createAgentStream(
     ],
 
     onChunk: async (chunk) => {
+      if (chunk.chunk.type === "text-delta") {
+        const loopDetection = assistantContentLoopMonitor.appendDelta(
+          chunk.chunk.text,
+        );
+        if (
+          loopDetection.detected &&
+          !state.stoppedDueToAssistantContentLoop &&
+          !ctx.abortController.signal.aborted
+        ) {
+          state.stoppedDueToAssistantContentLoop = true;
+          state.assistantContentLoopDetection = loopDetection;
+          console.warn("[agent-stream] assistant content loop detected", {
+            event: "assistant_content_loop_detected",
+            chatId: ctx.chatId,
+            endpoint: ctx.endpoint,
+            mode: ctx.mode,
+            modelName,
+            requestedModel: requestedSlug,
+            responseModel: state.responseModel,
+            reason: loopDetection.reason,
+            repeatedText: loopDetection.repeatedText,
+            repeatCount: loopDetection.repeatCount,
+          });
+          assistantContentLoopAbortController.abort();
+        }
+      }
+
       if (chunk.chunk.type === "tool-call") {
         ctx.chatLogger?.recordToolCall(
           chunk.chunk.toolName,
@@ -757,6 +825,8 @@ export async function createAgentStream(
       } else if (state.stoppedDueToTokenExhaustion) {
         state.streamFinishReason = TOKEN_EXHAUSTION_FINISH_REASON;
       } else if (state.stoppedDueToDoomLoop) {
+        state.streamFinishReason = DOOM_LOOP_FINISH_REASON;
+      } else if (state.stoppedDueToAssistantContentLoop) {
         state.streamFinishReason = DOOM_LOOP_FINISH_REASON;
       } else if (state.stoppedDueToAgentRunSpendCap) {
         state.streamFinishReason = AGENT_RUN_SPEND_CAP_FINISH_REASON;

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1209,12 +1209,14 @@ export const createChatHandler = () => {
                       lastAssistantMessage?.parts ?? [];
                     const assistantContentLoopDetection =
                       state.assistantContentLoopDetection ??
-                      detectAssistantContentLoopFromParts(
-                        lastAssistantMessageParts,
-                      );
+                      (isAborted
+                        ? { detected: false as const }
+                        : detectAssistantContentLoopFromParts(
+                            lastAssistantMessageParts,
+                          ));
                     const stoppedDueToAssistantContentLoop =
                       state.stoppedDueToAssistantContentLoop ||
-                      assistantContentLoopDetection.detected;
+                      (!isAborted && assistantContentLoopDetection.detected);
                     const shouldRetryWithFallback =
                       shouldRetryProviderStreamWithFallback(
                         lastAssistantMessageParts,
@@ -1223,6 +1225,7 @@ export const createChatHandler = () => {
                             state.streamFinishReason === "error",
                           stoppedDueToDoomLoop: state.stoppedDueToDoomLoop,
                           stoppedDueToAssistantContentLoop,
+                          detectAssistantContentLoop: !isAborted,
                         },
                       );
                     const imageRecovery =

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -163,7 +163,10 @@ import {
   omitImageViewToolResultsForProviderRetry,
   omitTrailingStepStartAssistantMessage,
 } from "@/lib/chat/multimodal-tool-result-recovery";
-import { shouldRetryProviderStreamWithFallback } from "@/lib/chat/agent-long-provider-retry";
+import {
+  detectAssistantContentLoopFromParts,
+  shouldRetryProviderStreamWithFallback,
+} from "@/lib/chat/agent-long-provider-retry";
 import { FREE_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
 
 function getStreamContext() {
@@ -180,7 +183,8 @@ export const createChatHandler = () => {
   return async (req: NextRequest) => {
     const endpoint = "/api/chat" as const;
     let preemptiveTimeout:
-      ReturnType<typeof createPreemptiveTimeout> | undefined;
+      | ReturnType<typeof createPreemptiveTimeout>
+      | undefined;
 
     // Track usage deductions for refund on error
     const usageRefundTracker = new UsageRefundTracker();
@@ -407,7 +411,8 @@ export const createChatHandler = () => {
       chatLogger.setChat(chatLogContext, selectedModel);
 
       let paidDailyFreeAllowanceReservation:
-        PaidDailyFreeAllowanceReservation | undefined;
+        | PaidDailyFreeAllowanceReservation
+        | undefined;
       let rateLimitInfo: RateLimitInfo;
 
       try {
@@ -1155,6 +1160,8 @@ export const createChatHandler = () => {
                 state.stoppedDueToTokenExhaustion = false;
                 state.stoppedDueToElapsedTimeout = false;
                 state.stoppedDueToDoomLoop = false;
+                state.stoppedDueToAssistantContentLoop = false;
+                state.assistantContentLoopDetection = undefined;
                 state.stoppedDueToBudgetExhaustion = false;
                 state.stoppedDueToAgentRunSpendCap = false;
                 state.budgetAbortDetails = undefined;
@@ -1200,12 +1207,22 @@ export const createChatHandler = () => {
                       .find((m) => m.role === "assistant");
                     const lastAssistantMessageParts =
                       lastAssistantMessage?.parts ?? [];
+                    const assistantContentLoopDetection =
+                      state.assistantContentLoopDetection ??
+                      detectAssistantContentLoopFromParts(
+                        lastAssistantMessageParts,
+                      );
+                    const stoppedDueToAssistantContentLoop =
+                      state.stoppedDueToAssistantContentLoop ||
+                      assistantContentLoopDetection.detected;
                     const shouldRetryWithFallback =
                       shouldRetryProviderStreamWithFallback(
                         lastAssistantMessageParts,
                         {
                           hasTerminalProviderStreamError:
                             state.streamFinishReason === "error",
+                          stoppedDueToDoomLoop: state.stoppedDueToDoomLoop,
+                          stoppedDueToAssistantContentLoop,
                         },
                       );
                     const imageRecovery =
@@ -1219,12 +1236,26 @@ export const createChatHandler = () => {
                       shouldRetryWithFallback ||
                       shouldRetryWithoutImageToolResults
                     ) {
+                      const loopTriggeredRetry =
+                        stoppedDueToAssistantContentLoop ||
+                        state.stoppedDueToDoomLoop;
+                      const retryReason = shouldRetryWithoutImageToolResults
+                        ? "image_tool_result_rejection"
+                        : stoppedDueToAssistantContentLoop
+                          ? "assistant_content_loop"
+                          : state.stoppedDueToDoomLoop
+                            ? "doom_loop"
+                            : "incomplete_stream";
                       phLogger.warn(
                         shouldRetryWithoutImageToolResults
                           ? "Provider rejected image tool output - retrying without images"
-                          : state.streamFinishReason === "error"
-                            ? "Provider stream errored before useful output - triggering fallback"
-                            : "Stream finished incomplete - triggering fallback",
+                          : retryReason === "assistant_content_loop"
+                            ? "Assistant content loop detected - triggering fallback"
+                            : retryReason === "doom_loop"
+                              ? "Agent doom loop detected - triggering fallback"
+                              : state.streamFinishReason === "error"
+                                ? "Provider stream errored before useful output - triggering fallback"
+                                : "Stream finished incomplete - triggering fallback",
                         {
                           chatId,
                           endpoint,
@@ -1237,6 +1268,12 @@ export const createChatHandler = () => {
                           parts: lastAssistantMessage?.parts,
                           isRetryWithFallback,
                           assistantMessageId,
+                          retryReason,
+                          stoppedDueToDoomLoop: state.stoppedDueToDoomLoop,
+                          assistantContentLoop:
+                            assistantContentLoopDetection.detected
+                              ? assistantContentLoopDetection
+                              : undefined,
                           imageToolResultsOmitted: imageRecovery.omittedCount,
                         },
                       );
@@ -1247,8 +1284,10 @@ export const createChatHandler = () => {
                       // text placeholders.
                       if (
                         !isRetryWithFallback &&
-                        !isAborted &&
-                        (isAutoModel || shouldRetryWithoutImageToolResults)
+                        (!isAborted || stoppedDueToAssistantContentLoop) &&
+                        (isAutoModel ||
+                          shouldRetryWithoutImageToolResults ||
+                          loopTriggeredRetry)
                       ) {
                         isRetryWithFallback = true;
                         state.lastStepInputTokens = 0;
@@ -1258,6 +1297,8 @@ export const createChatHandler = () => {
                         state.stoppedDueToTokenExhaustion = false;
                         state.stoppedDueToElapsedTimeout = false;
                         state.stoppedDueToDoomLoop = false;
+                        state.stoppedDueToAssistantContentLoop = false;
+                        state.assistantContentLoopDetection = undefined;
                         state.stoppedDueToBudgetExhaustion = false;
                         state.stoppedDueToAgentRunSpendCap = false;
                         state.budgetAbortDetails = undefined;
@@ -1489,10 +1530,7 @@ export const createChatHandler = () => {
                                   isTemporary: temporary,
                                   paidAskMode:
                                     mode === "ask" && subscription !== "free",
-                                  retryReason:
-                                    shouldRetryWithoutImageToolResults
-                                      ? "image_tool_result_rejection"
-                                      : "incomplete_stream",
+                                  retryReason,
                                   imageToolResultsOmitted:
                                     imageRecovery.omittedCount,
                                 });

--- a/lib/chat/__tests__/agent-long-provider-retry.test.ts
+++ b/lib/chat/__tests__/agent-long-provider-retry.test.ts
@@ -107,6 +107,13 @@ describe("shouldRetryAgentLongWithFallback", () => {
     expect(
       shouldRetryAgentLongWithFallback(
         [{ type: "step-start" }, { type: "text", text: repeatedLoop }],
+        { hasTerminalProviderStreamError: false },
+      ),
+    ).toBe(true);
+
+    expect(
+      shouldRetryAgentLongWithFallback(
+        [{ type: "step-start" }, { type: "text", text: repeatedLoop }],
         {
           hasTerminalProviderStreamError: false,
           detectAssistantContentLoop: false,

--- a/lib/chat/__tests__/agent-long-provider-retry.test.ts
+++ b/lib/chat/__tests__/agent-long-provider-retry.test.ts
@@ -1,4 +1,8 @@
-import { shouldRetryAgentLongWithFallback } from "../agent-long-provider-retry";
+import {
+  createAssistantContentLoopMonitor,
+  detectAssistantContentLoopFromText,
+  shouldRetryAgentLongWithFallback,
+} from "../agent-long-provider-retry";
 
 describe("shouldRetryAgentLongWithFallback", () => {
   it("preserves the legacy retry for streams that only emitted step-start", () => {
@@ -60,6 +64,40 @@ describe("shouldRetryAgentLongWithFallback", () => {
     ).toBe(false);
   });
 
+  it("retries repeated assistant content loops even when visible text exists", () => {
+    const repeatedLoop = Array.from(
+      { length: 5 },
+      () =>
+        "create the zip: [Tool: run_terminal_cmd] Files are there. Let me create the zip:",
+    ).join(" ");
+
+    expect(
+      shouldRetryAgentLongWithFallback(
+        [{ type: "step-start" }, { type: "text", text: repeatedLoop }],
+        { hasTerminalProviderStreamError: false },
+      ),
+    ).toBe(true);
+  });
+
+  it("retries when the agent doom-loop stop fired even with tool output", () => {
+    expect(
+      shouldRetryAgentLongWithFallback(
+        [
+          { type: "step-start" },
+          {
+            type: "tool-shell",
+            toolCallId: "call_1",
+            state: "output-available",
+          },
+        ],
+        {
+          hasTerminalProviderStreamError: false,
+          stoppedDueToDoomLoop: true,
+        },
+      ),
+    ).toBe(true);
+  });
+
   it("does not discard tool calls or tool output when a provider stream fails", () => {
     expect(
       shouldRetryAgentLongWithFallback(
@@ -92,5 +130,34 @@ describe("shouldRetryAgentLongWithFallback", () => {
         hasTerminalProviderStreamError: true,
       }),
     ).toBe(false);
+  });
+});
+
+describe("assistant content loop detection", () => {
+  it("detects repeated text that arrives incrementally", () => {
+    const monitor = createAssistantContentLoopMonitor();
+    let detected = false;
+
+    for (const delta of Array.from(
+      { length: 6 },
+      () => "Sorry. Single clean command now: ",
+    )) {
+      detected = monitor.appendDelta(delta).detected || detected;
+    }
+
+    expect(detected).toBe(true);
+  });
+
+  it("does not flag ordinary repeated task wording", () => {
+    const detection = detectAssistantContentLoopFromText(
+      [
+        "I found the files and will create the archive.",
+        "First I will verify the directory.",
+        "Then I will run the zip command once.",
+        "After that I will report the path.",
+      ].join(" "),
+    );
+
+    expect(detection.detected).toBe(false);
   });
 });

--- a/lib/chat/__tests__/agent-long-provider-retry.test.ts
+++ b/lib/chat/__tests__/agent-long-provider-retry.test.ts
@@ -98,6 +98,23 @@ describe("shouldRetryAgentLongWithFallback", () => {
     ).toBe(true);
   });
 
+  it("can disable fresh repeated-text detection for aborted streams", () => {
+    const repeatedLoop = Array.from(
+      { length: 5 },
+      () => "Sorry. Single clean command now:",
+    ).join(" ");
+
+    expect(
+      shouldRetryAgentLongWithFallback(
+        [{ type: "step-start" }, { type: "text", text: repeatedLoop }],
+        {
+          hasTerminalProviderStreamError: false,
+          detectAssistantContentLoop: false,
+        },
+      ),
+    ).toBe(false);
+  });
+
   it("does not discard tool calls or tool output when a provider stream fails", () => {
     expect(
       shouldRetryAgentLongWithFallback(

--- a/lib/chat/agent-long-provider-retry.ts
+++ b/lib/chat/agent-long-provider-retry.ts
@@ -1,9 +1,19 @@
 type MessagePartLike = {
   type?: unknown;
+  text?: unknown;
 };
 
 type RetryDecisionOptions = {
   hasTerminalProviderStreamError: boolean;
+  stoppedDueToDoomLoop?: boolean;
+  stoppedDueToAssistantContentLoop?: boolean;
+};
+
+export type AssistantContentLoopDetection = {
+  detected: boolean;
+  reason?: "repeated_text";
+  repeatedText?: string;
+  repeatCount?: number;
 };
 
 const FALLBACK_SAFE_METADATA_PART_TYPES = new Set([
@@ -11,10 +21,29 @@ const FALLBACK_SAFE_METADATA_PART_TYPES = new Set([
   "data-context-usage",
 ]);
 
+const NO_ASSISTANT_CONTENT_LOOP: AssistantContentLoopDetection = {
+  detected: false,
+};
+
+const MIN_ASSISTANT_LOOP_CHARS = 120;
+const MIN_ASSISTANT_LOOP_TOKENS = 24;
+const MIN_REPEATED_PHRASE_TOKENS = 3;
+const MAX_REPEATED_PHRASE_TOKENS = 16;
+const MIN_REPEATED_PHRASE_CHARS = 18;
+const MIN_REPEATED_PHRASE_COUNT = 4;
+const MAX_LOOP_MONITOR_CHARS = 6000;
+const LOOP_MONITOR_CHECK_INTERVAL_CHARS = 48;
+
 const getPartType = (part: unknown): string | undefined => {
   if (!part || typeof part !== "object") return undefined;
   const type = (part as MessagePartLike).type;
   return typeof type === "string" ? type : undefined;
+};
+
+const getPartText = (part: unknown): string | undefined => {
+  if (!part || typeof part !== "object") return undefined;
+  const text = (part as MessagePartLike).text;
+  return typeof text === "string" ? text : undefined;
 };
 
 const isOnlyStepStart = (parts: unknown[]): boolean =>
@@ -37,12 +66,132 @@ const isReasoningOnlyProviderOutput = (parts: unknown[]): boolean =>
   hasReasoningPart(parts) &&
   parts.every(isFallbackSafeProviderPart);
 
+const normalizeAssistantLoopText = (text: string): string =>
+  text
+    .toLowerCase()
+    .replace(/\[[^\]]*tool[^\]]*\]/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const tokenizeAssistantLoopText = (text: string): string[] =>
+  normalizeAssistantLoopText(text).match(/[a-z0-9_./:-]+/g) ?? [];
+
+const tokenSliceEquals = (
+  tokens: string[],
+  leftStart: number,
+  rightStart: number,
+  length: number,
+): boolean => {
+  for (let offset = 0; offset < length; offset++) {
+    if (tokens[leftStart + offset] !== tokens[rightStart + offset]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+export const detectAssistantContentLoopFromText = (
+  text: string,
+): AssistantContentLoopDetection => {
+  const normalized = normalizeAssistantLoopText(text);
+  if (normalized.length < MIN_ASSISTANT_LOOP_CHARS) {
+    return NO_ASSISTANT_CONTENT_LOOP;
+  }
+
+  const tokens = tokenizeAssistantLoopText(normalized);
+  if (tokens.length < MIN_ASSISTANT_LOOP_TOKENS) {
+    return NO_ASSISTANT_CONTENT_LOOP;
+  }
+
+  for (
+    let phraseLength = MIN_REPEATED_PHRASE_TOKENS;
+    phraseLength <= MAX_REPEATED_PHRASE_TOKENS;
+    phraseLength++
+  ) {
+    for (let start = 0; start + phraseLength * 2 <= tokens.length; start++) {
+      if (
+        !tokenSliceEquals(tokens, start, start + phraseLength, phraseLength)
+      ) {
+        continue;
+      }
+
+      let repeatCount = 2;
+      let nextStart = start + phraseLength * 2;
+      while (
+        nextStart + phraseLength <= tokens.length &&
+        tokenSliceEquals(tokens, start, nextStart, phraseLength)
+      ) {
+        repeatCount++;
+        nextStart += phraseLength;
+      }
+
+      const repeatedText = tokens.slice(start, start + phraseLength).join(" ");
+      if (
+        repeatCount >= MIN_REPEATED_PHRASE_COUNT &&
+        repeatedText.length >= MIN_REPEATED_PHRASE_CHARS
+      ) {
+        return {
+          detected: true,
+          reason: "repeated_text",
+          repeatedText,
+          repeatCount,
+        };
+      }
+    }
+  }
+
+  return NO_ASSISTANT_CONTENT_LOOP;
+};
+
+export const detectAssistantContentLoopFromParts = (
+  parts: unknown[],
+): AssistantContentLoopDetection => {
+  const text = parts.map(getPartText).filter(Boolean).join(" ");
+  if (!text.trim()) return NO_ASSISTANT_CONTENT_LOOP;
+  return detectAssistantContentLoopFromText(text);
+};
+
+export const createAssistantContentLoopMonitor = () => {
+  let buffer = "";
+  let charsSinceCheck = 0;
+
+  return {
+    appendDelta(delta: string): AssistantContentLoopDetection {
+      if (!delta) return NO_ASSISTANT_CONTENT_LOOP;
+
+      buffer = (buffer + delta).slice(-MAX_LOOP_MONITOR_CHARS);
+      charsSinceCheck += delta.length;
+
+      if (
+        buffer.length < MIN_ASSISTANT_LOOP_CHARS ||
+        charsSinceCheck < LOOP_MONITOR_CHECK_INTERVAL_CHARS
+      ) {
+        return NO_ASSISTANT_CONTENT_LOOP;
+      }
+
+      charsSinceCheck = 0;
+      return detectAssistantContentLoopFromText(buffer);
+    },
+  };
+};
+
 export const shouldRetryProviderStreamWithFallback = (
   parts: unknown[],
   options: RetryDecisionOptions,
 ): boolean => {
   // Preserve the older guard for streams that never got past the first step.
   if (isOnlyStepStart(parts)) return true;
+
+  if (
+    options.stoppedDueToDoomLoop ||
+    options.stoppedDueToAssistantContentLoop
+  ) {
+    return true;
+  }
+
+  if (detectAssistantContentLoopFromParts(parts).detected) {
+    return true;
+  }
 
   // If the provider stream dies after emitting only reasoning/metadata, there
   // is no text, tool call, or tool output to preserve. Retrying on fallback is

--- a/lib/chat/agent-long-provider-retry.ts
+++ b/lib/chat/agent-long-provider-retry.ts
@@ -7,6 +7,7 @@ type RetryDecisionOptions = {
   hasTerminalProviderStreamError: boolean;
   stoppedDueToDoomLoop?: boolean;
   stoppedDueToAssistantContentLoop?: boolean;
+  detectAssistantContentLoop?: boolean;
 };
 
 export type AssistantContentLoopDetection = {
@@ -189,7 +190,10 @@ export const shouldRetryProviderStreamWithFallback = (
     return true;
   }
 
-  if (detectAssistantContentLoopFromParts(parts).detected) {
+  if (
+    (options.detectAssistantContentLoop ?? true) &&
+    detectAssistantContentLoopFromParts(parts).detected
+  ) {
     return true;
   }
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -131,7 +131,10 @@ import {
   BUDGET_EXHAUSTION_FINISH_REASON,
   PREEMPTIVE_TIMEOUT_FINISH_REASON,
 } from "@/lib/chat/stop-conditions";
-import { shouldRetryAgentLongWithFallback } from "@/lib/chat/agent-long-provider-retry";
+import {
+  detectAssistantContentLoopFromParts,
+  shouldRetryAgentLongWithFallback,
+} from "@/lib/chat/agent-long-provider-retry";
 import {
   omitImageViewToolResultsForProviderRetry,
   omitTrailingStepStartAssistantMessage,
@@ -567,7 +570,8 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
 
 const getTerminalProviderStreamError = (
   state:
-    Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
+    | Pick<AgentStreamState, "streamFinishReason" | "providerError">
+    | undefined,
 ): unknown | undefined => {
   if (!state) return undefined;
   if (state.streamFinishReason !== "error") return undefined;
@@ -584,7 +588,8 @@ const getTerminalProviderStreamError = (
 
 const isTerminalProviderStreamError = (
   state:
-    Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
+    | Pick<AgentStreamState, "streamFinishReason" | "providerError">
+    | undefined,
 ): boolean => state?.streamFinishReason === "error";
 
 type RecordedAgentLongFailure = {
@@ -1728,6 +1733,8 @@ export const agentLongTask = task({
                 state.stoppedDueToTokenExhaustion = false;
                 state.stoppedDueToElapsedTimeout = false;
                 state.stoppedDueToDoomLoop = false;
+                state.stoppedDueToAssistantContentLoop = false;
+                state.assistantContentLoopDetection = undefined;
                 state.stoppedDueToBudgetExhaustion = false;
                 state.stoppedDueToAgentRunSpendCap = false;
                 state.budgetAbortDetails = undefined;
@@ -1779,12 +1786,22 @@ export const agentLongTask = task({
                         stripAgentLongHeartbeatParts(
                           lastAssistantMessage ?? { parts: [] },
                         ).parts ?? [];
+                      const assistantContentLoopDetection =
+                        state.assistantContentLoopDetection ??
+                        detectAssistantContentLoopFromParts(
+                          lastAssistantMessageParts,
+                        );
+                      const stoppedDueToAssistantContentLoop =
+                        state.stoppedDueToAssistantContentLoop ||
+                        assistantContentLoopDetection.detected;
                       const shouldRetryWithFallback =
                         shouldRetryAgentLongWithFallback(
                           lastAssistantMessageParts,
                           {
                             hasTerminalProviderStreamError:
                               isTerminalProviderStreamError(state),
+                            stoppedDueToDoomLoop: state.stoppedDueToDoomLoop,
+                            stoppedDueToAssistantContentLoop,
                           },
                         );
                       const imageRecovery =
@@ -1800,9 +1817,40 @@ export const agentLongTask = task({
                         (shouldRetryWithFallback ||
                           shouldRetryWithoutImageToolResults) &&
                         !isRetryWithFallback &&
-                        !isAborted &&
-                        (isAutoModel || shouldRetryWithoutImageToolResults)
+                        (!isAborted || stoppedDueToAssistantContentLoop) &&
+                        (isAutoModel ||
+                          shouldRetryWithoutImageToolResults ||
+                          stoppedDueToAssistantContentLoop ||
+                          state.stoppedDueToDoomLoop)
                       ) {
+                        const retryReason = shouldRetryWithoutImageToolResults
+                          ? "image_tool_result_rejection"
+                          : stoppedDueToAssistantContentLoop
+                            ? "assistant_content_loop"
+                            : state.stoppedDueToDoomLoop
+                              ? "doom_loop"
+                              : "incomplete_stream";
+                        phLogger.warn(
+                          "[agent-long] Provider output triggered fallback retry",
+                          {
+                            chatId,
+                            mode,
+                            originalModel: selectedModel,
+                            requestedModelSlug: configuredModelId,
+                            fallbackModel,
+                            fallbackModelSlug: fallbackModelId,
+                            userId,
+                            subscription,
+                            retryReason,
+                            isAborted,
+                            stoppedDueToDoomLoop: state.stoppedDueToDoomLoop,
+                            assistantContentLoop:
+                              assistantContentLoopDetection.detected
+                                ? assistantContentLoopDetection
+                                : undefined,
+                            imageToolResultsOmitted: imageRecovery.omittedCount,
+                          },
+                        );
                         isRetryWithFallback = true;
                         state.lastStepInputTokens = 0;
                         state.streamFinishReason = undefined;
@@ -1811,6 +1859,8 @@ export const agentLongTask = task({
                         state.stoppedDueToTokenExhaustion = false;
                         state.stoppedDueToElapsedTimeout = false;
                         state.stoppedDueToDoomLoop = false;
+                        state.stoppedDueToAssistantContentLoop = false;
+                        state.assistantContentLoopDetection = undefined;
                         state.stoppedDueToBudgetExhaustion = false;
                         state.stoppedDueToAgentRunSpendCap = false;
                         state.budgetAbortDetails = undefined;

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1788,12 +1788,14 @@ export const agentLongTask = task({
                         ).parts ?? [];
                       const assistantContentLoopDetection =
                         state.assistantContentLoopDetection ??
-                        detectAssistantContentLoopFromParts(
-                          lastAssistantMessageParts,
-                        );
+                        (isAborted
+                          ? { detected: false as const }
+                          : detectAssistantContentLoopFromParts(
+                              lastAssistantMessageParts,
+                            ));
                       const stoppedDueToAssistantContentLoop =
                         state.stoppedDueToAssistantContentLoop ||
-                        assistantContentLoopDetection.detected;
+                        (!isAborted && assistantContentLoopDetection.detected);
                       const shouldRetryWithFallback =
                         shouldRetryAgentLongWithFallback(
                           lastAssistantMessageParts,
@@ -1802,6 +1804,7 @@ export const agentLongTask = task({
                               isTerminalProviderStreamError(state),
                             stoppedDueToDoomLoop: state.stoppedDueToDoomLoop,
                             stoppedDueToAssistantContentLoop,
+                            detectAssistantContentLoop: !isAborted,
                           },
                         );
                       const imageRecovery =


### PR DESCRIPTION
## Summary
- detect repeated assistant text loops, including MiniMax-style repeated tool-call phrasing
- stop only the bad provider leg with an internal abort signal and retry through the existing fallback model path
- apply the behavior to both `/api/chat` and Trigger agent-long streams, with focused regression coverage

## Why
MiniMax can sometimes return a technically successful stream that repeats the same assistant text/tool-call marker instead of making progress. Provider HTTP fallback does not fire for that shape because there is no provider error. This change classifies those assistant-output loops as fallback-worthy, resets the failed primary model leg, and lets the next model in the fallback path continue.

## Validation
- `./node_modules/.bin/jest lib/chat/__tests__/agent-long-provider-retry.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `./node_modules/.bin/prettier --check lib/chat/agent-long-provider-retry.ts lib/chat/__tests__/agent-long-provider-retry.test.ts lib/api/agent-stream-runner.ts lib/api/chat-handler.ts trigger/agent-long.ts`
- `./node_modules/.bin/eslint lib/chat/agent-long-provider-retry.ts lib/chat/__tests__/agent-long-provider-retry.test.ts lib/api/agent-stream-runner.ts lib/api/chat-handler.ts trigger/agent-long.ts`
- `./node_modules/.bin/tsc --noEmit`

Note: `pnpm jest ...` and the local Husky pre-commit hook hit pnpm's non-TTY module purge guard in this checkout, so validation used repo-local binaries.

## Manual verification
- In Agent mode using MiniMax/Auto, reproduce a prompt that starts repeating the same assistant text/tool marker.
- Confirm the bad primary leg stops, fallback model output continues, and the final saved message is from the fallback attempt.
- Confirm usage is billed against the fallback leg rather than the repeated primary model leg when provider raw cost is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of repeated assistant text “content loops” during streaming, with structured stop/telemetry details.
  * Enhanced fallback/retry behavior to treat assistant-content loop stops as a first-class retry trigger and to clear related loop state before retrying.
* **Bug Fixes**
  * Prevents runaway assistant repetition and improves finish-reason classification for loop vs doom-loop vs incomplete streams.
  * Refines retry gating so user-aborted runs only trigger fallback when the abort is associated with assistant-content loop detection.
* **Tests**
  * Expanded coverage for detection, retry triggers, and opt-out behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->