### PR TITLE
Fix authenticated chat hydration mismatch

### DIFF
--- a/app/(chat)/c/[id]/page.tsx
+++ b/app/(chat)/c/[id]/page.tsx
@@ -6,9 +6,9 @@ import Loading from "@/components/ui/loading";
 import PricingDialog from "../../../components/PricingDialog";
 import { usePricingDialog } from "../../../hooks/usePricingDialog";
 import { useGlobalState } from "../../../contexts/GlobalState";
-import { hasAuthenticatedBefore } from "@/lib/utils/client-storage";
 import { use, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useHasAuthenticatedBefore } from "@/app/hooks/useHasAuthenticatedBefore";
 
 export default function Page(props: { params: Promise<{ id: string }> }) {
   const params = use(props.params);
@@ -18,9 +18,9 @@ export default function Page(props: { params: Promise<{ id: string }> }) {
   const { showPricing, handleClosePricing, pricingContext } =
     usePricingDialog(subscription);
   const { isLoading, isAuthenticated } = useConvexAuth();
+  const hasAuthHint = useHasAuthenticatedBefore();
 
-  const shouldRenderChat =
-    isAuthenticated || (isLoading && hasAuthenticatedBefore());
+  const shouldRenderChat = isAuthenticated || (isLoading && hasAuthHint);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {

--- a/app/(chat)/layout.tsx
+++ b/app/(chat)/layout.tsx
@@ -3,7 +3,7 @@
 import { useConvexAuth } from "convex/react";
 import { ChatLayout } from "@/app/components/ChatLayout";
 import Loading from "@/components/ui/loading";
-import { hasAuthenticatedBefore } from "@/lib/utils/client-storage";
+import { useHasAuthenticatedBefore } from "@/app/hooks/useHasAuthenticatedBefore";
 
 const fullWidthShell = (
   <div className="h-dvh min-h-0 flex flex-col bg-background overflow-hidden">
@@ -25,8 +25,9 @@ export default function ChatRouteLayout({
   children: React.ReactNode;
 }) {
   const { isLoading, isAuthenticated } = useConvexAuth();
+  const hasAuthHint = useHasAuthenticatedBefore();
 
-  if (isAuthenticated || (isLoading && hasAuthenticatedBefore())) {
+  if (isAuthenticated || (isLoading && hasAuthHint)) {
     return (
       <div className="h-dvh min-h-0 flex flex-col bg-background overflow-hidden">
         <ChatLayout>{children}</ChatLayout>

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -16,11 +16,9 @@ import { useGlobalState } from "../contexts/GlobalState";
 import { usePentestgptMigration } from "../hooks/usePentestgptMigration";
 import { navigateToAuth } from "../hooks/useTauri";
 import { useTypingAnimation } from "../hooks/useTypingAnimation";
-import {
-  hasAuthenticatedBefore,
-  upsertDraft,
-} from "@/lib/utils/client-storage";
+import { upsertDraft } from "@/lib/utils/client-storage";
 import Loading from "@/components/ui/loading";
+import { useHasAuthenticatedBefore } from "../hooks/useHasAuthenticatedBefore";
 
 const LOGIN_TYPING_PREFIX = "Ask HackerAI to ";
 const LOGIN_TYPING_TAILS = [
@@ -134,6 +132,7 @@ export default function Page() {
   const { showPricing, handleClosePricing, pricingContext } =
     usePricingDialog(subscription);
   const { isLoading, isAuthenticated } = useConvexAuth();
+  const hasAuthHint = useHasAuthenticatedBefore();
 
   const { isMigrating, migrate } = usePentestgptMigration();
   const searchParams =
@@ -161,7 +160,7 @@ export default function Page() {
     return { initialSeats: seats, initialPlan: plan };
   }, [searchParams]);
 
-  if (isAuthenticated || (isLoading && hasAuthenticatedBefore())) {
+  if (isAuthenticated || (isLoading && hasAuthHint)) {
     return (
       <>
         <AuthenticatedContent />

--- a/app/hooks/__tests__/useAutoResume.test.ts
+++ b/app/hooks/__tests__/useAutoResume.test.ts
@@ -1,0 +1,54 @@
+import { mergeResumedMessage } from "../useAutoResume";
+import type { ChatMessage } from "@/types/chat";
+
+function message(id: string, role: "user" | "assistant"): ChatMessage {
+  return {
+    id,
+    role,
+    parts: [{ type: "text", text: id }],
+  } as ChatMessage;
+}
+
+describe("mergeResumedMessage", () => {
+  it("does not duplicate a resumed message already in current state", () => {
+    const currentMessages = [
+      message("user-1", "user"),
+      message("a-1", "assistant"),
+    ];
+    const result = mergeResumedMessage(
+      currentMessages,
+      [message("user-1", "user")],
+      message("a-1", "assistant"),
+    );
+
+    expect(result).toBe(currentMessages);
+  });
+
+  it("does not duplicate a resumed message already in initial messages", () => {
+    const initialMessages = [
+      message("user-1", "user"),
+      message("a-1", "assistant"),
+    ];
+    const result = mergeResumedMessage(
+      [message("user-1", "user")],
+      initialMessages,
+      message("a-1", "assistant"),
+    );
+
+    expect(result).toBe(initialMessages);
+  });
+
+  it("appends a new resumed message to the freshest message list", () => {
+    const currentMessages = [
+      message("user-1", "user"),
+      message("a-1", "assistant"),
+    ];
+    const result = mergeResumedMessage(
+      currentMessages,
+      [message("user-1", "user")],
+      message("a-2", "assistant"),
+    );
+
+    expect(result.map((item) => item.id)).toEqual(["user-1", "a-1", "a-2"]);
+  });
+});

--- a/app/hooks/__tests__/useAutoResume.test.ts
+++ b/app/hooks/__tests__/useAutoResume.test.ts
@@ -24,13 +24,13 @@ describe("mergeResumedMessage", () => {
     expect(result).toBe(currentMessages);
   });
 
-  it("does not duplicate a resumed message already in initial messages", () => {
+  it("does not duplicate a resumed message already in initial messages before current state exists", () => {
     const initialMessages = [
       message("user-1", "user"),
       message("a-1", "assistant"),
     ];
     const result = mergeResumedMessage(
-      [message("user-1", "user")],
+      [],
       initialMessages,
       message("a-1", "assistant"),
     );
@@ -38,7 +38,7 @@ describe("mergeResumedMessage", () => {
     expect(result).toBe(initialMessages);
   });
 
-  it("appends a new resumed message to the freshest message list", () => {
+  it("appends to current messages when current state has already hydrated", () => {
     const currentMessages = [
       message("user-1", "user"),
       message("a-1", "assistant"),
@@ -50,5 +50,16 @@ describe("mergeResumedMessage", () => {
     );
 
     expect(result.map((item) => item.id)).toEqual(["user-1", "a-1", "a-2"]);
+  });
+
+  it("keeps current messages as the source of truth even when initial messages contain the resumed id", () => {
+    const currentMessages = [message("user-1", "user")];
+    const result = mergeResumedMessage(
+      currentMessages,
+      [message("user-1", "user"), message("a-1", "assistant")],
+      message("a-1", "assistant"),
+    );
+
+    expect(result.map((item) => item.id)).toEqual(["user-1", "a-1"]);
   });
 });

--- a/app/hooks/__tests__/useHasAuthenticatedBefore.test.tsx
+++ b/app/hooks/__tests__/useHasAuthenticatedBefore.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import { hydrateRoot } from "react-dom/client";
 import { renderToString } from "react-dom/server";
 import { useHasAuthenticatedBefore } from "../useHasAuthenticatedBefore";
 import { hasAuthenticatedBefore } from "@/lib/utils/client-storage";
@@ -30,14 +31,22 @@ describe("useHasAuthenticatedBefore", () => {
     expect(mockHasAuthenticatedBefore).not.toHaveBeenCalled();
   });
 
-  it("reads the browser auth hint in the client snapshot", async () => {
+  it("corrects to the browser auth hint after hydrating server-rendered markup", async () => {
     mockHasAuthenticatedBefore.mockReturnValue(true);
 
-    render(<AuthHintProbe />);
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(<AuthHintProbe />);
+    document.body.appendChild(container);
+    const root = hydrateRoot(container, <AuthHintProbe />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId("auth-hint")).toHaveTextContent("yes");
-    });
-    expect(mockHasAuthenticatedBefore).toHaveBeenCalled();
+    try {
+      await waitFor(() => {
+        expect(screen.getByTestId("auth-hint")).toHaveTextContent("yes");
+      });
+      expect(mockHasAuthenticatedBefore).toHaveBeenCalled();
+    } finally {
+      root.unmount();
+      container.remove();
+    }
   });
 });

--- a/app/hooks/__tests__/useHasAuthenticatedBefore.test.tsx
+++ b/app/hooks/__tests__/useHasAuthenticatedBefore.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { useHasAuthenticatedBefore } from "../useHasAuthenticatedBefore";
+import { hasAuthenticatedBefore } from "@/lib/utils/client-storage";
+
+jest.mock("@/lib/utils/client-storage", () => ({
+  hasAuthenticatedBefore: jest.fn(),
+}));
+
+const mockHasAuthenticatedBefore =
+  hasAuthenticatedBefore as jest.MockedFunction<typeof hasAuthenticatedBefore>;
+
+function AuthHintProbe() {
+  return (
+    <div data-testid="auth-hint">
+      {useHasAuthenticatedBefore() ? "yes" : "no"}
+    </div>
+  );
+}
+
+describe("useHasAuthenticatedBefore", () => {
+  beforeEach(() => {
+    mockHasAuthenticatedBefore.mockReset();
+  });
+
+  it("does not use the browser-only auth hint during server render", () => {
+    mockHasAuthenticatedBefore.mockReturnValue(true);
+
+    expect(renderToString(<AuthHintProbe />)).toContain(">no<");
+    expect(mockHasAuthenticatedBefore).not.toHaveBeenCalled();
+  });
+
+  it("reads the browser auth hint in the client snapshot", async () => {
+    mockHasAuthenticatedBefore.mockReturnValue(true);
+
+    render(<AuthHintProbe />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-hint")).toHaveTextContent("yes");
+    });
+    expect(mockHasAuthenticatedBefore).toHaveBeenCalled();
+  });
+});

--- a/app/hooks/useAutoResume.ts
+++ b/app/hooks/useAutoResume.ts
@@ -27,19 +27,14 @@ export function mergeResumedMessage(
   initialMessages: ChatMessage[],
   resumedMessage: ChatMessage,
 ): ChatMessage[] {
-  if (currentMessages.some((message) => message.id === resumedMessage.id)) {
-    return currentMessages;
-  }
-  if (initialMessages.some((message) => message.id === resumedMessage.id)) {
-    return initialMessages;
+  const baseMessages =
+    currentMessages.length > 0 ? currentMessages : initialMessages;
+
+  if (baseMessages.some((message) => message.id === resumedMessage.id)) {
+    return baseMessages;
   }
 
-  return [
-    ...(currentMessages.length > initialMessages.length
-      ? currentMessages
-      : initialMessages),
-    resumedMessage,
-  ];
+  return [...baseMessages, resumedMessage];
 }
 
 export function useAutoResume({

--- a/app/hooks/useAutoResume.ts
+++ b/app/hooks/useAutoResume.ts
@@ -22,6 +22,26 @@ export interface UseAutoResumeParams {
   hasActiveStream: boolean | undefined;
 }
 
+export function mergeResumedMessage(
+  currentMessages: ChatMessage[],
+  initialMessages: ChatMessage[],
+  resumedMessage: ChatMessage,
+): ChatMessage[] {
+  if (currentMessages.some((message) => message.id === resumedMessage.id)) {
+    return currentMessages;
+  }
+  if (initialMessages.some((message) => message.id === resumedMessage.id)) {
+    return initialMessages;
+  }
+
+  return [
+    ...(currentMessages.length > initialMessages.length
+      ? currentMessages
+      : initialMessages),
+    resumedMessage,
+  ];
+}
+
 export function useAutoResume({
   chatId,
   autoResume,
@@ -71,7 +91,9 @@ export function useAutoResume({
     if (!dataPart) return;
     if (dataPart.type === "data-appendMessage") {
       const message = JSON.parse(dataPart.data);
-      setMessages([...initialMessages, message]);
+      setMessages((currentMessages) =>
+        mergeResumedMessage(currentMessages, initialMessages, message),
+      );
       // First message arrived, we can allow Stop button again
       setIsAutoResuming(false);
     }

--- a/app/hooks/useHasAuthenticatedBefore.ts
+++ b/app/hooks/useHasAuthenticatedBefore.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { hasAuthenticatedBefore } from "@/lib/utils/client-storage";
+
+const subscribeToAuthHint = () => () => {};
+const getServerAuthHint = () => false;
+
+export function useHasAuthenticatedBefore(): boolean {
+  return useSyncExternalStore(
+    subscribeToAuthHint,
+    hasAuthenticatedBefore,
+    getServerAuthHint,
+  );
+}

--- a/e2e/chat-files-pro.spec.ts
+++ b/e2e/chat-files-pro.spec.ts
@@ -34,12 +34,16 @@ async function writeJpegFixture(
   return outputPath;
 }
 
+async function setupFileChat(page: Page): Promise<ChatComponent> {
+  return setupChat(page, { refreshEntitlements: true });
+}
+
 test.describe("File Attachment Tests - Pro and Ultra Tiers", () => {
   test.describe("Pro Tier", () => {
     test.use({ storageState: AUTH_STORAGE_PATHS.pro });
 
     test("should attach text file and AI reads content", async ({ page }) => {
-      const chat = await setupChat(page);
+      const chat = await setupFileChat(page);
 
       await sendMessageWithFileAndVerifyContent(
         chat,
@@ -51,7 +55,7 @@ test.describe("File Attachment Tests - Pro and Ultra Tiers", () => {
     });
 
     test("should attach image and AI recognizes content", async ({ page }) => {
-      const chat = await setupChat(page);
+      const chat = await setupFileChat(page);
 
       await sendMessageWithFileAndVerifyContent(
         chat,
@@ -63,7 +67,7 @@ test.describe("File Attachment Tests - Pro and Ultra Tiers", () => {
     });
 
     test("should attach PDF and AI reads content", async ({ page }) => {
-      const chat = await setupChat(page);
+      const chat = await setupFileChat(page);
 
       await sendMessageWithFileAndVerifyContent(
         chat,
@@ -77,7 +81,7 @@ test.describe("File Attachment Tests - Pro and Ultra Tiers", () => {
     test("should attach markdown and CSV files and AI reads content", async ({
       page,
     }) => {
-      const chat = await setupChat(page);
+      const chat = await setupFileChat(page);
 
       const markdownFile = path.join(
         process.cwd(),
@@ -102,7 +106,7 @@ test.describe("File Attachment Tests - Pro and Ultra Tiers", () => {
     });
 
     test("should attach jpg and jpeg images", async ({ page }, testInfo) => {
-      const chat = await setupChat(page);
+      const chat = await setupFileChat(page);
 
       const jpgFile = await writeJpegFixture(
         page,
@@ -127,7 +131,7 @@ test.describe("File Attachment Tests - Pro and Ultra Tiers", () => {
     });
 
     test("should attach multiple files at once", async ({ page }) => {
-      const chat = await setupChat(page);
+      const chat = await setupFileChat(page);
 
       const textFile = path.join(process.cwd(), TEST_DATA.RESOURCES.TEXT_FILE);
       const imageFile = path.join(process.cwd(), TEST_DATA.RESOURCES.IMAGE);
@@ -140,7 +144,7 @@ test.describe("File Attachment Tests - Pro and Ultra Tiers", () => {
     });
 
     test("should remove attached file", async ({ page }) => {
-      const chat = await setupChat(page);
+      const chat = await setupFileChat(page);
 
       await attachTestFile(chat, "text");
       await chat.removeAttachedFile(0);
@@ -149,7 +153,7 @@ test.describe("File Attachment Tests - Pro and Ultra Tiers", () => {
     });
 
     test("should send message with file attachment", async ({ page }) => {
-      const chat = await setupChat(page);
+      const chat = await setupFileChat(page);
 
       await attachTestFile(chat, "text");
       await chat.expectSendButtonEnabled();
@@ -169,7 +173,7 @@ test.describe("File Attachment Tests - Pro and Ultra Tiers", () => {
     test.use({ storageState: AUTH_STORAGE_PATHS.ultra });
 
     test("should attach text file and AI reads content", async ({ page }) => {
-      const chat = await setupChat(page);
+      const chat = await setupFileChat(page);
 
       await sendMessageWithFileAndVerifyContent(
         chat,
@@ -181,7 +185,7 @@ test.describe("File Attachment Tests - Pro and Ultra Tiers", () => {
     });
 
     test("should attach image and AI recognizes content", async ({ page }) => {
-      const chat = await setupChat(page);
+      const chat = await setupFileChat(page);
 
       await sendMessageWithFileAndVerifyContent(
         chat,
@@ -193,7 +197,7 @@ test.describe("File Attachment Tests - Pro and Ultra Tiers", () => {
     });
 
     test("should attach PDF and AI reads content", async ({ page }) => {
-      const chat = await setupChat(page);
+      const chat = await setupFileChat(page);
 
       await sendMessageWithFileAndVerifyContent(
         chat,
@@ -205,7 +209,7 @@ test.describe("File Attachment Tests - Pro and Ultra Tiers", () => {
     });
 
     test("should attach multiple files at once", async ({ page }) => {
-      const chat = await setupChat(page);
+      const chat = await setupFileChat(page);
 
       const textFile = path.join(process.cwd(), TEST_DATA.RESOURCES.TEXT_FILE);
       const imageFile = path.join(process.cwd(), TEST_DATA.RESOURCES.IMAGE);

--- a/e2e/chat-free.spec.ts
+++ b/e2e/chat-free.spec.ts
@@ -46,9 +46,6 @@ test.describe("Free Tier Simple Chat Tests", () => {
       expect(sidebarTitle).toBeTruthy();
       expect(sidebarTitle).not.toBe("New Chat");
 
-      // Verify the chat is visible in sidebar
-      await sidebar.expectChatWithId(chatId);
-
       // Get the chat title from the header
       const headerTitle = await chat.getChatHeaderTitle();
 

--- a/e2e/chat-free.spec.ts
+++ b/e2e/chat-free.spec.ts
@@ -36,20 +36,18 @@ test.describe("Free Tier Simple Chat Tests", () => {
       const chatCount = await chatItems.count();
       expect(chatCount).toBeGreaterThan(0);
 
-      // Get the first chat item and verify it has a title (not empty or "New Chat")
-      const firstChat = chatItems.first();
-      const ariaLabel = await firstChat.getAttribute("aria-label");
+      const chatId = new URL(page.url()).pathname.replace(/^\/c\//, "");
+      expect(chatId).toBeTruthy();
 
-      // Extract title from aria-label (format: "Open chat: {title}")
-      const titleMatch = ariaLabel?.match(/^Open chat: (.+)$/);
-      const sidebarTitle = titleMatch ? titleMatch[1] : "";
+      await sidebar.expectChatWithId(chatId);
+      const sidebarTitle = await sidebar.getChatTitleById(chatId);
 
       // Verify title is set and not empty or "New Chat"
       expect(sidebarTitle).toBeTruthy();
       expect(sidebarTitle).not.toBe("New Chat");
 
       // Verify the chat is visible in sidebar
-      await expect(firstChat).toBeVisible();
+      await sidebar.expectChatWithId(chatId);
 
       // Get the chat title from the header
       const headerTitle = await chat.getChatHeaderTitle();

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -64,10 +64,21 @@ export async function attachTestFile(
 /**
  * Common setup for chat tests
  */
-export async function setupChat(page: Page): Promise<ChatComponent> {
-  await page.goto("/");
+export async function setupChat(
+  page: Page,
+  options: { refreshEntitlements?: boolean } = {},
+): Promise<ChatComponent> {
+  await page.goto(options.refreshEntitlements ? "/?refresh=entitlements" : "/");
   const chat = new ChatComponent(page);
   await chat.waitForHydrated();
+  if (options.refreshEntitlements) {
+    await page
+      .waitForURL((url) => url.searchParams.get("refresh") !== "entitlements", {
+        timeout: TIMEOUTS.MEDIUM,
+      })
+      .catch(() => {});
+    await chat.waitForHydrated();
+  }
   return chat;
 }
 
@@ -108,6 +119,7 @@ export async function createTwoChats(
     .catch(() => {});
 
   const chatB = new ChatComponent(page);
+  await chatB.waitForHydrated();
   await sendAndWaitForResponse(chatB, messageB, timeout);
 
   const urlB = page.url();

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -66,7 +66,9 @@ export async function attachTestFile(
  */
 export async function setupChat(page: Page): Promise<ChatComponent> {
   await page.goto("/");
-  return new ChatComponent(page);
+  const chat = new ChatComponent(page);
+  await chat.waitForHydrated();
+  return chat;
 }
 
 function chatIdFromUrl(url: string): string {

--- a/e2e/page-objects/ChatComponent.ts
+++ b/e2e/page-objects/ChatComponent.ts
@@ -118,6 +118,7 @@ export class ChatComponent {
   async attachFile(filePath: string): Promise<void> {
     const absolutePath = path.resolve(filePath);
     const fileName = filePath.split("/").pop() || "";
+    await this.waitForHydrated();
     await this.fileInput.setInputFiles(absolutePath);
 
     await this.waitForUploadComplete(fileName);
@@ -125,6 +126,7 @@ export class ChatComponent {
 
   async attachFiles(filePaths: string[]): Promise<void> {
     const absolutePaths = filePaths.map((p) => path.resolve(p));
+    await this.waitForHydrated();
     await this.fileInput.setInputFiles(absolutePaths);
 
     await this.waitForUploadComplete();
@@ -236,13 +238,40 @@ export class ChatComponent {
     text: string,
     timeout: number = TIMEOUTS.MEDIUM,
   ): Promise<void> {
-    await expect(
-      this.page
-        .locator(
-          `[data-testid="user-message"], [data-testid="assistant-message"]`,
-        )
-        .filter({ hasText: text }),
-    ).toBeVisible({ timeout });
+    const messages = this.page.locator(
+      `[data-testid="user-message"], [data-testid="assistant-message"]`,
+    );
+
+    await expect(async () => {
+      const textMatchVisible = await messages
+        .filter({ hasText: text })
+        .first()
+        .isVisible({ timeout: 1000 })
+        .catch(() => false);
+      if (textMatchVisible) return;
+
+      if (/^\d+$/.test(text)) {
+        const markerMatchVisible = await messages.evaluateAll(
+          (elements, expectedText) =>
+            elements.some((element) => {
+              const isVisible =
+                element instanceof HTMLElement && element.offsetParent !== null;
+              if (!isVisible) return false;
+
+              return Array.from(element.querySelectorAll("ol")).some((list) => {
+                const start = list.getAttribute("start") ?? "1";
+                return (
+                  start === expectedText && list.querySelector("li") !== null
+                );
+              });
+            }),
+          text,
+        );
+        if (markerMatchVisible) return;
+      }
+
+      throw new Error(`Message containing ${text} was not visible`);
+    }).toPass({ timeout });
   }
 
   async expectStreamingVisible(): Promise<void> {
@@ -332,8 +361,14 @@ export class ChatComponent {
     });
   }
 
+  async waitForHydrated(): Promise<void> {
+    await expect(this.chatInput).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
+    await expect(this.chatInput).toBeEditable({ timeout: TIMEOUTS.MEDIUM });
+    await expect(this.sendButton).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
+  }
+
   async expectChatInputVisible(): Promise<void> {
-    await expect(this.chatInput).toBeVisible();
+    await expect(this.chatInput).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
   }
 
   async expectSendButtonEnabled(): Promise<void> {

--- a/e2e/page-objects/ChatComponent.ts
+++ b/e2e/page-objects/ChatComponent.ts
@@ -119,6 +119,7 @@ export class ChatComponent {
     const absolutePath = path.resolve(filePath);
     const fileName = filePath.split("/").pop() || "";
     await this.waitForHydrated();
+    await expect(this.attachButton).toBeEnabled({ timeout: TIMEOUTS.MEDIUM });
     await this.fileInput.setInputFiles(absolutePath);
 
     await this.waitForUploadComplete(fileName);
@@ -127,6 +128,7 @@ export class ChatComponent {
   async attachFiles(filePaths: string[]): Promise<void> {
     const absolutePaths = filePaths.map((p) => path.resolve(p));
     await this.waitForHydrated();
+    await expect(this.attachButton).toBeEnabled({ timeout: TIMEOUTS.MEDIUM });
     await this.fileInput.setInputFiles(absolutePaths);
 
     await this.waitForUploadComplete();
@@ -238,9 +240,7 @@ export class ChatComponent {
     text: string,
     timeout: number = TIMEOUTS.MEDIUM,
   ): Promise<void> {
-    const messages = this.page.locator(
-      `[data-testid="user-message"], [data-testid="assistant-message"]`,
-    );
+    const messages = this.messages;
 
     await expect(async () => {
       const textMatchVisible = await messages
@@ -251,22 +251,21 @@ export class ChatComponent {
       if (textMatchVisible) return;
 
       if (/^\d+$/.test(text)) {
-        const markerMatchVisible = await messages.evaluateAll(
-          (elements, expectedText) =>
-            elements.some((element) => {
-              const isVisible =
-                element instanceof HTMLElement && element.offsetParent !== null;
-              if (!isVisible) return false;
+        const markerMatchVisible = await messages
+          .last()
+          .evaluate((element, expectedText) => {
+            const isVisible =
+              element instanceof HTMLElement && element.offsetParent !== null;
+            if (!isVisible) return false;
 
-              return Array.from(element.querySelectorAll("ol")).some((list) => {
-                const start = list.getAttribute("start") ?? "1";
-                return (
-                  start === expectedText && list.querySelector("li") !== null
-                );
-              });
-            }),
-          text,
-        );
+            return Array.from(element.querySelectorAll("ol")).some((list) => {
+              const start = list.getAttribute("start") ?? "1";
+              return (
+                start === expectedText && list.querySelector("li") !== null
+              );
+            });
+          }, text)
+          .catch(() => false);
         if (markerMatchVisible) return;
       }
 


### PR DESCRIPTION
## Summary
- gate the returning-user auth hint behind a hydration-safe `useSyncExternalStore` hook so `/` and `/c/[id]` render the same loading shell on the server and first client render
- dedupe replayed auto-resume assistant messages by id to avoid duplicate-key overlays when a finished stream is replayed during route settling
- tighten chat e2e readiness and brittle free-chat assertions around hydrated input, numeric Markdown list markers, and current-chat sidebar lookup

## Validation
- `corepack pnpm test -- app/hooks/__tests__/useHasAuthenticatedBefore.test.tsx app/hooks/__tests__/useAutoResume.test.ts --runInBand`
- `corepack pnpm exec prettier --check app/hooks/useHasAuthenticatedBefore.ts app/hooks/__tests__/useHasAuthenticatedBefore.test.tsx app/hooks/useAutoResume.ts app/hooks/__tests__/useAutoResume.test.ts app/(chat)/layout.tsx app/(chat)/page.tsx app/(chat)/c/[id]/page.tsx e2e/page-objects/ChatComponent.ts e2e/helpers/test-helpers.ts e2e/chat-free.spec.ts`
- `corepack pnpm exec eslint app/hooks/useHasAuthenticatedBefore.ts app/hooks/__tests__/useHasAuthenticatedBefore.test.tsx app/hooks/useAutoResume.ts app/hooks/__tests__/useAutoResume.test.ts app/(chat)/layout.tsx app/(chat)/page.tsx app/(chat)/c/[id]/page.tsx e2e/page-objects/ChatComponent.ts e2e/helpers/test-helpers.ts e2e/chat-free.spec.ts`
- `git diff --check`
- `corepack pnpm typecheck` fails on existing worktree dependency issue: `packages/local/src/index.ts(17,23): Cannot find module 'ws' or its corresponding type declarations.`\n- `corepack pnpm rate-limit:reset --all`\n- Authenticated Pro browser smoke against `corepack pnpm exec next dev --webpack`: desktop and mobile `/` loaded chat input with no Next overlay, page errors, console errors, or hydration mismatch text\n- `corepack pnpm test:e2e --project=chromium --no-deps --workers=1 e2e/chat-free.spec.ts`\n- `corepack pnpm test:e2e --project=chromium --no-deps --workers=1 e2e/chat-files-pro.spec.ts -g "Pro Tier.*should attach text file"`\n\n## Manual Verification\n- Start local dev with `corepack pnpm exec next dev --webpack`, load `/` as an authenticated Pro user on desktop and mobile, and confirm the chat shell appears without a React hydration overlay or console/page errors.\n- In Pro Ask mode, attach `e2e/resource/secret.txt`, confirm the preview appears, the send button enables, and the answer reads the secret word.\n- In a free account, send the two simple math prompts and confirm both responses render, the current chat row appears in the sidebar, and no duplicate-key overlay appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat authentication/loading behavior for returning users, ensuring the chat shows reliably while auth state is resolving.
  * Prevented duplicate “resumed” messages from reappearing in the conversation history.
  * Improved file upload interactions by waiting for the chat interface to finish loading before attaching files and sending prompts.
  * Enhanced end-to-end message visibility checks to reduce flaky assertions during ordered/numeric content rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->