### PR TITLE
Improve agent continuation after compaction

### DIFF
--- a/app/components/FinishReasonNotice.tsx
+++ b/app/components/FinishReasonNotice.tsx
@@ -9,7 +9,10 @@ import {
   AGENT_RUN_SPEND_CAP_REASON,
   AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL,
 } from "@/lib/chat/agent-run-spend-cap";
-import { BUDGET_EXHAUSTION_FINISH_REASON } from "@/lib/chat/stop-conditions";
+import {
+  BUDGET_EXHAUSTION_FINISH_REASON,
+  POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON,
+} from "@/lib/chat/stop-conditions";
 import type { SelectedModel } from "@/types/chat";
 
 interface FinishReasonNoticeProps {
@@ -38,7 +41,8 @@ export const FinishReasonNotice = ({
     (finishReason === "context-limit" ||
       finishReason === "length" ||
       finishReason === "preemptive-timeout" ||
-      finishReason === "tool-calls")
+      finishReason === "tool-calls" ||
+      finishReason === POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON)
   ) {
     return null;
   }
@@ -60,6 +64,10 @@ export const FinishReasonNotice = ({
 
     if (finishReason === "context-limit") {
       return <>Reached the context limit for this conversation.</>;
+    }
+
+    if (finishReason === POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON) {
+      return <>Paused after compacting the conversation.</>;
     }
 
     if (finishReason === AGENT_RUN_SPEND_CAP_FINISH_REASON) {

--- a/app/components/__tests__/FinishReasonNotice.test.tsx
+++ b/app/components/__tests__/FinishReasonNotice.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { FinishReasonNotice } from "../FinishReasonNotice";
 import { DataStreamProvider, useDataStream } from "../DataStreamProvider";
 import { MAX_AUTO_CONTINUES } from "@/app/hooks/useAutoContinue";
+import { POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON } from "@/lib/chat/stop-conditions";
 import type { ChatMode, SelectedModel } from "@/types/chat";
 
 function DataStreamSetter({
@@ -82,6 +83,14 @@ describe("FinishReasonNotice", () => {
       { finishReason: "tool-calls" as const, autoContinueCount: 2 },
       { finishReason: "tool-calls" as const, autoContinueCount: 4 },
       { finishReason: "preemptive-timeout" as const, autoContinueCount: 0 },
+      {
+        finishReason: POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON,
+        autoContinueCount: 0,
+      },
+      {
+        finishReason: POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON,
+        autoContinueCount: 4,
+      },
     ])(
       "returns null in agent mode when autoContinueCount=$autoContinueCount < MAX for finishReason=$finishReason",
       ({ finishReason, autoContinueCount }) => {
@@ -131,6 +140,10 @@ describe("FinishReasonNotice", () => {
       {
         finishReason: "budget-exhausted",
         expectedText: "Stopped at a usage guardrail for this run",
+      },
+      {
+        finishReason: POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON,
+        expectedText: "Paused after compacting the conversation",
       },
     ])(
       "renders notice for finishReason=$finishReason when autoContinueCount has reached MAX_AUTO_CONTINUES",
@@ -216,6 +229,7 @@ describe("FinishReasonNotice", () => {
       "context-limit",
       "preemptive-timeout",
       "agent-run-spend-cap",
+      POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON,
     ])("renders the Continue button for finishReason=%s", (finishReason) => {
       const onContinue = jest.fn();
       renderNotice(

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -40,6 +40,7 @@ import {
   DOOM_LOOP_FINISH_REASON,
   BUDGET_EXHAUSTION_FINISH_REASON,
   AGENT_RUN_SPEND_CAP_FINISH_REASON,
+  POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON,
 } from "@/lib/chat/stop-conditions";
 import {
   detectDoomLoop,
@@ -66,6 +67,10 @@ import { getMaxTokensForSubscription } from "@/lib/token-utils";
 import { getSummarizationThresholdTokens } from "@/lib/chat/summarization/constants";
 import { getProviderPromptPressure } from "@/lib/chat/summarization/provider-pressure";
 import { getMaxStepsForUser } from "@/lib/chat/chat-processor";
+import {
+  isIncompletePostSummarizationStop,
+  POST_SUMMARIZATION_CONTINUATION_PROMPT,
+} from "@/lib/chat/post-summarization-continuation";
 import { createPromptSerializationTools } from "@/lib/ai/tools/prompt-serialization";
 import {
   extractOpenRouterMetadata,
@@ -115,6 +120,10 @@ export type AgentStreamState = {
   stoppedDueToDoomLoop: boolean;
   stoppedDueToBudgetExhaustion: boolean;
   stoppedDueToAgentRunSpendCap: boolean;
+  stoppedDueToPostSummarizationIncomplete: boolean;
+  postSummarizationContinuationActive: boolean;
+  postSummarizationToolCallCount: number;
+  postSummarizationText: string;
   budgetAbortDetails: BudgetAbortDetails | undefined;
 };
 
@@ -136,6 +145,10 @@ export function initAgentStreamState(
     stoppedDueToDoomLoop: false,
     stoppedDueToBudgetExhaustion: false,
     stoppedDueToAgentRunSpendCap: false,
+    stoppedDueToPostSummarizationIncomplete: false,
+    postSummarizationContinuationActive: false,
+    postSummarizationToolCallCount: 0,
+    postSummarizationText: "",
     budgetAbortDetails: undefined,
   };
 }
@@ -598,12 +611,16 @@ export async function createAgentStream(
                 tools: createPromptSerializationTools(ctx.tools),
               },
             );
-            if (loopRecovery.nudge) {
-              summarizedModelMessages = [
-                ...summarizedModelMessages,
-                { role: "user", content: loopRecovery.nudge },
-              ];
-            }
+            state.postSummarizationContinuationActive = true;
+            state.postSummarizationToolCallCount = 0;
+            state.postSummarizationText = "";
+            const continuationPrompt = loopRecovery.nudge
+              ? `${POST_SUMMARIZATION_CONTINUATION_PROMPT}\n\n${loopRecovery.nudge}`
+              : POST_SUMMARIZATION_CONTINUATION_PROMPT;
+            summarizedModelMessages = [
+              ...summarizedModelMessages,
+              { role: "user", content: continuationPrompt },
+            ];
             const preparedMessages = prepareProviderMessages(
               summarizedModelMessages,
             );
@@ -702,7 +719,17 @@ export async function createAgentStream(
     ],
 
     onChunk: async (chunk) => {
+      if (
+        state.postSummarizationContinuationActive &&
+        chunk.chunk.type === "text-delta"
+      ) {
+        state.postSummarizationText += chunk.chunk.text;
+      }
+
       if (chunk.chunk.type === "tool-call") {
+        if (state.postSummarizationContinuationActive) {
+          state.postSummarizationToolCallCount++;
+        }
         ctx.chatLogger?.recordToolCall(
           chunk.chunk.toolName,
           ctx.sandboxManager.getSandboxType(chunk.chunk.toolName),
@@ -750,6 +777,27 @@ export async function createAgentStream(
     onFinish: async (finishResult) => {
       const { finishReason, usage, response } = finishResult;
       const hardReason = ctx.getHardTimeoutReason();
+      if (
+        hardReason === null &&
+        state.postSummarizationContinuationActive &&
+        isIncompletePostSummarizationStop({
+          finishReason,
+          text: state.postSummarizationText,
+          toolCallCount: state.postSummarizationToolCallCount,
+        })
+      ) {
+        state.stoppedDueToPostSummarizationIncomplete = true;
+        console.warn("[agent-stream] post-summarization continuation stalled", {
+          event: "post_summarization_continuation_incomplete",
+          chatId: ctx.chatId,
+          endpoint: ctx.endpoint,
+          mode: ctx.mode,
+          modelName,
+          requestedModel: requestedSlug,
+          textChars: state.postSummarizationText.length,
+          toolCallCount: state.postSummarizationToolCallCount,
+        });
+      }
       if (hardReason !== null) {
         state.streamFinishReason = hardReason;
       } else if (state.stoppedDueToElapsedTimeout) {
@@ -762,6 +810,8 @@ export async function createAgentStream(
         state.streamFinishReason = AGENT_RUN_SPEND_CAP_FINISH_REASON;
       } else if (state.stoppedDueToBudgetExhaustion) {
         state.streamFinishReason = BUDGET_EXHAUSTION_FINISH_REASON;
+      } else if (state.stoppedDueToPostSummarizationIncomplete) {
+        state.streamFinishReason = POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON;
       } else {
         state.streamFinishReason = finishReason;
       }

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1157,6 +1157,10 @@ export const createChatHandler = () => {
                 state.stoppedDueToDoomLoop = false;
                 state.stoppedDueToBudgetExhaustion = false;
                 state.stoppedDueToAgentRunSpendCap = false;
+                state.stoppedDueToPostSummarizationIncomplete = false;
+                state.postSummarizationContinuationActive = false;
+                state.postSummarizationToolCallCount = 0;
+                state.postSummarizationText = "";
                 state.budgetAbortDetails = undefined;
                 preFallbackCacheRead = usageTracker.cacheReadTokens;
                 preFallbackCacheWrite = usageTracker.cacheWriteTokens;
@@ -1260,6 +1264,10 @@ export const createChatHandler = () => {
                         state.stoppedDueToDoomLoop = false;
                         state.stoppedDueToBudgetExhaustion = false;
                         state.stoppedDueToAgentRunSpendCap = false;
+                        state.stoppedDueToPostSummarizationIncomplete = false;
+                        state.postSummarizationContinuationActive = false;
+                        state.postSummarizationToolCallCount = 0;
+                        state.postSummarizationText = "";
                         state.budgetAbortDetails = undefined;
                         const fallbackStartTime = Date.now();
                         preFallbackCacheRead = usageTracker.cacheReadTokens;
@@ -1879,6 +1887,7 @@ export const createChatHandler = () => {
                     if (
                       (state.stoppedDueToTokenExhaustion ||
                         state.stoppedDueToElapsedTimeout ||
+                        state.stoppedDueToPostSummarizationIncomplete ||
                         state.streamFinishReason === "tool-calls") &&
                       isAgentMode(mode) &&
                       !temporary

--- a/lib/chat/__tests__/post-summarization-continuation.test.ts
+++ b/lib/chat/__tests__/post-summarization-continuation.test.ts
@@ -38,6 +38,14 @@ describe("post-summarization continuation", () => {
     ).toBe(false);
   });
 
+  it("does not match bare continuation words inside short completions", () => {
+    expect(
+      isPostSummarizationFillerText(
+        "Done - the script will continue running in the background now.",
+      ),
+    ).toBe(false);
+  });
+
   it("does not flag long responses that merely mention continuing", () => {
     const text = `${"The task is complete. ".repeat(30)} I will include the details below.`;
 

--- a/lib/chat/__tests__/post-summarization-continuation.test.ts
+++ b/lib/chat/__tests__/post-summarization-continuation.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  isIncompletePostSummarizationStop,
+  isPostSummarizationFillerText,
+  POST_SUMMARIZATION_CONTINUATION_PROMPT,
+} from "../post-summarization-continuation";
+
+describe("post-summarization continuation", () => {
+  it("injects an action-oriented continuation reminder", () => {
+    expect(POST_SUMMARIZATION_CONTINUATION_PROMPT).toContain(
+      "Continue the interrupted task now",
+    );
+    expect(POST_SUMMARIZATION_CONTINUATION_PROMPT).toContain(
+      "Do not reply with an acknowledgement",
+    );
+    expect(POST_SUMMARIZATION_CONTINUATION_PROMPT).toContain(
+      "call the next required tool",
+    );
+  });
+
+  it("detects short English promise-only filler", () => {
+    expect(isPostSummarizationFillerText("I'll continue now:")).toBe(true);
+    expect(isPostSummarizationFillerText("Let me get to it.")).toBe(true);
+  });
+
+  it("detects short Persian promise-only filler from the incident pattern", () => {
+    expect(isPostSummarizationFillerText("**عذر میخوام!** میرم سراغش:")).toBe(
+      true,
+    );
+  });
+
+  it("does not treat meaningful output as filler", () => {
+    expect(
+      isPostSummarizationFillerText(
+        "I updated both files, ran the syntax checks, and here is the usage guide.",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not flag long responses that merely mention continuing", () => {
+    const text = `${"The task is complete. ".repeat(30)} I will include the details below.`;
+
+    expect(isPostSummarizationFillerText(text)).toBe(false);
+  });
+
+  it("requires a normal stop with no post-compaction tool call", () => {
+    expect(
+      isIncompletePostSummarizationStop({
+        finishReason: "stop",
+        text: "I'm going to continue:",
+        toolCallCount: 0,
+      }),
+    ).toBe(true);
+    expect(
+      isIncompletePostSummarizationStop({
+        finishReason: "stop",
+        text: "I'm going to continue:",
+        toolCallCount: 1,
+      }),
+    ).toBe(false);
+    expect(
+      isIncompletePostSummarizationStop({
+        finishReason: "length",
+        text: "I'm going to continue:",
+        toolCallCount: 0,
+      }),
+    ).toBe(false);
+  });
+});

--- a/lib/chat/post-summarization-continuation.ts
+++ b/lib/chat/post-summarization-continuation.ts
@@ -1,0 +1,45 @@
+export const POST_SUMMARIZATION_CONTINUATION_PROMPT =
+  "<system-reminder>\n" +
+  "The conversation was compacted so the agent can continue with a smaller context. " +
+  "Continue the interrupted task now. Do not reply with an acknowledgement, apology, " +
+  "or a promise that you will continue. If action is still needed, call the next required tool. " +
+  "If the task is complete, provide the final result or deliverable. Do not restart completed work.\n" +
+  "</system-reminder>";
+
+const MAX_FILLER_CHARS = 500;
+
+const ENGLISH_FILLER_RE =
+  /\b(?:i(?:'|\u2019)?ll|i will|let me|i am going to|i'm going to|i\u2019ll go|i will go|going to|go ahead|continue|proceed|start|work on|look into|fix this|get to it|take care of it)\b/i;
+
+const PERSIAN_FILLER_RE =
+  /(?:\u0639\u0630\u0631|\u0645\u06cc[\u200c\s]?\u062e\u0648\u0627\u0645|\u0645\u06cc\u0631\u0645|\u0633\u0631\u0627\u063a|\u0627\u062f\u0627\u0645\u0647|\u0628\u0630\u0627\u0631|\u0627\u0644\u0627\u0646|\u0628\u0627\u0634\u0647|\u0641\u06cc\u06a9\u0633|\u0628\u0631\u0631\u0633\u06cc)/u;
+
+const SETUP_ENDING_RE = /[:：]\s*$/;
+
+const normalizeText = (text: string): string =>
+  text.replace(/\s+/g, " ").trim();
+
+export const isPostSummarizationFillerText = (text: string): boolean => {
+  const normalized = normalizeText(text);
+  if (!normalized) return true;
+  if (normalized.length > MAX_FILLER_CHARS) return false;
+
+  const hasFillerPhrase =
+    ENGLISH_FILLER_RE.test(normalized) || PERSIAN_FILLER_RE.test(normalized);
+  if (!hasFillerPhrase) return false;
+
+  return normalized.length <= 280 || SETUP_ENDING_RE.test(normalized);
+};
+
+export const isIncompletePostSummarizationStop = ({
+  finishReason,
+  text,
+  toolCallCount,
+}: {
+  finishReason: string | undefined;
+  text: string;
+  toolCallCount: number;
+}): boolean =>
+  finishReason === "stop" &&
+  toolCallCount === 0 &&
+  isPostSummarizationFillerText(text);

--- a/lib/chat/post-summarization-continuation.ts
+++ b/lib/chat/post-summarization-continuation.ts
@@ -8,8 +8,10 @@ export const POST_SUMMARIZATION_CONTINUATION_PROMPT =
 
 const MAX_FILLER_CHARS = 500;
 
+const LEADING_MARKDOWN_RE = /^[\s*_`~>#.-]+/;
+
 const ENGLISH_FILLER_RE =
-  /\b(?:i(?:'|\u2019)?ll|i will|let me|i am going to|i'm going to|i\u2019ll go|i will go|going to|go ahead|continue|proceed|start|work on|look into|fix this|get to it|take care of it)\b/i;
+  /^(?:(?:sorry|apologies)[,!\s]+)?(?:i(?:'|\u2019)?ll|i will|let me|i am going to|i'm going to|going to)\s+(?:go\s+ahead\s+and\s+)?(?:continue|proceed|start|work\s+on|look\s+into|fix(?:\s+this)?|get\s+to|take\s+care\s+of|handle|check|review|try)\b/i;
 
 const PERSIAN_FILLER_RE =
   /(?:\u0639\u0630\u0631|\u0645\u06cc[\u200c\s]?\u062e\u0648\u0627\u0645|\u0645\u06cc\u0631\u0645|\u0633\u0631\u0627\u063a|\u0627\u062f\u0627\u0645\u0647|\u0628\u0630\u0627\u0631|\u0627\u0644\u0627\u0646|\u0628\u0627\u0634\u0647|\u0641\u06cc\u06a9\u0633|\u0628\u0631\u0631\u0633\u06cc)/u;
@@ -24,8 +26,9 @@ export const isPostSummarizationFillerText = (text: string): boolean => {
   if (!normalized) return true;
   if (normalized.length > MAX_FILLER_CHARS) return false;
 
+  const candidate = normalized.replace(LEADING_MARKDOWN_RE, "");
   const hasFillerPhrase =
-    ENGLISH_FILLER_RE.test(normalized) || PERSIAN_FILLER_RE.test(normalized);
+    ENGLISH_FILLER_RE.test(candidate) || PERSIAN_FILLER_RE.test(candidate);
   if (!hasFillerPhrase) return false;
 
   return normalized.length <= 280 || SETUP_ENDING_RE.test(normalized);

--- a/lib/chat/stop-conditions.ts
+++ b/lib/chat/stop-conditions.ts
@@ -44,6 +44,9 @@ export function elapsedTimeExceeds(state: {
 
 export const DOOM_LOOP_FINISH_REASON = "doom-loop";
 
+export const POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON =
+  "compaction-incomplete";
+
 export function doomLoopDetected(state: {
   onFired: () => void;
 }): StopCondition<any> {

--- a/lib/system-prompt/__tests__/resume.test.ts
+++ b/lib/system-prompt/__tests__/resume.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@jest/globals";
 
+import { POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON } from "@/lib/chat/stop-conditions";
 import { getResumeSection } from "../resume";
 
 describe("getResumeSection", () => {
@@ -17,5 +18,17 @@ describe("getResumeSection", () => {
     expect(section).toContain("user cost-control pause");
     expect(section).toContain("resume the task exactly where you left off");
     expect(section).toContain("without repeating completed work");
+  });
+
+  it("instructs compaction-incomplete continuations to act instead of acknowledging", () => {
+    const section = getResumeSection(
+      POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON,
+    );
+
+    expect(section).toContain(
+      "stopped immediately after conversation compaction",
+    );
+    expect(section).toContain("without acknowledging the compaction");
+    expect(section).toContain("Use tools when action is still needed");
   });
 });

--- a/lib/system-prompt/resume.ts
+++ b/lib/system-prompt/resume.ts
@@ -1,3 +1,5 @@
+import { POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON } from "@/lib/chat/stop-conditions";
+
 export const getResumeSection = (finishReason?: string): string => {
   if (finishReason === "tool-calls") {
     return `<resume_context>
@@ -42,6 +44,13 @@ resume the task exactly where you left off without repeating what was already do
 Your previous response was paused because the monthly usage budget or extra usage spending limit was reached. \
 This was a user cost-control pause, not a task failure. If the user says "continue" or similar, \
 resume the task exactly where you left off without repeating completed work or starting the task over.
+</resume_context>`;
+  } else if (finishReason === POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON) {
+    return `<resume_context>
+Your previous response stopped immediately after conversation compaction before completing the user's original request. \
+The context has been condensed. If the user says "continue" or similar, resume from the latest saved progress \
+without acknowledging the compaction, restarting completed work, or saying that you will continue. \
+Use tools when action is still needed; otherwise provide the final result or deliverable.
 </resume_context>`;
   }
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1730,6 +1730,10 @@ export const agentLongTask = task({
                 state.stoppedDueToDoomLoop = false;
                 state.stoppedDueToBudgetExhaustion = false;
                 state.stoppedDueToAgentRunSpendCap = false;
+                state.stoppedDueToPostSummarizationIncomplete = false;
+                state.postSummarizationContinuationActive = false;
+                state.postSummarizationToolCallCount = 0;
+                state.postSummarizationText = "";
                 state.budgetAbortDetails = undefined;
                 preFallbackCacheRead = usageTracker.cacheReadTokens;
                 preFallbackCacheWrite = usageTracker.cacheWriteTokens;
@@ -1813,6 +1817,10 @@ export const agentLongTask = task({
                         state.stoppedDueToDoomLoop = false;
                         state.stoppedDueToBudgetExhaustion = false;
                         state.stoppedDueToAgentRunSpendCap = false;
+                        state.stoppedDueToPostSummarizationIncomplete = false;
+                        state.postSummarizationContinuationActive = false;
+                        state.postSummarizationToolCallCount = 0;
+                        state.postSummarizationText = "";
                         state.budgetAbortDetails = undefined;
                         const fallbackStartTime = Date.now();
                         preFallbackCacheRead = usageTracker.cacheReadTokens;
@@ -2248,6 +2256,7 @@ export const agentLongTask = task({
                       // explicitly decide whether to continue.
                       if (
                         (state.stoppedDueToTokenExhaustion ||
+                          state.stoppedDueToPostSummarizationIncomplete ||
                           state.streamFinishReason === "tool-calls") &&
                         !temporary
                       ) {


### PR DESCRIPTION
## Summary
- add a synthetic post-summarization continuation reminder before the next provider call, matching the useful part of OpenCode's compaction handoff behavior
- detect provider stops that only produce acknowledgement/promise filler after compaction and mark them `compaction-incomplete` so Agent can auto-continue
- add resume/UI handling plus regressions for English and Persian filler patterns

## Why
Some Cloud Agent runs compacted the conversation, then the model replied with only a short acknowledgement/promise and stopped. That left the chat looking closed without completing the pending tool/file work.

OpenCode treats compaction as a transition and explicitly nudges the next model turn to continue the interrupted task. This PR keeps our existing summarization and retained-tail flow, but adds that continuation handoff plus a narrow recovery guard when the provider still stops on filler.

## Validation
- `./node_modules/.bin/jest lib/chat/__tests__/post-summarization-continuation.test.ts lib/system-prompt/__tests__/resume.test.ts app/components/__tests__/FinishReasonNotice.test.tsx --runInBand`
- `./node_modules/.bin/prettier --check lib/chat/post-summarization-continuation.ts lib/chat/__tests__/post-summarization-continuation.test.ts lib/chat/stop-conditions.ts lib/api/agent-stream-runner.ts lib/api/chat-handler.ts trigger/agent-long.ts lib/system-prompt/resume.ts lib/system-prompt/__tests__/resume.test.ts app/components/FinishReasonNotice.tsx app/components/__tests__/FinishReasonNotice.test.tsx`
- `./node_modules/.bin/eslint lib/chat/post-summarization-continuation.ts lib/chat/__tests__/post-summarization-continuation.test.ts lib/chat/stop-conditions.ts lib/api/agent-stream-runner.ts lib/api/chat-handler.ts trigger/agent-long.ts lib/system-prompt/resume.ts lib/system-prompt/__tests__/resume.test.ts app/components/FinishReasonNotice.tsx app/components/__tests__/FinishReasonNotice.test.tsx`
- `./node_modules/.bin/tsc --noEmit`
- pre-commit hook: full `tsc --noEmit`
- pre-commit hook: full `jest` (200 suites, 2023 tests passed)

## Manual Verification
- In Cloud Agent, run a chat large enough to trigger summarization. After compaction, the assistant should continue the pending task by calling the next needed tool or producing the final result, not a short acknowledgement.
- If a provider still stops after compaction with only filler text, the run should auto-continue while the Agent auto-continue budget remains.
- After the auto-continue budget is exhausted, the UI should show `Paused after compacting the conversation.` with a manual Continue button.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new interruption/stop finish reason for incomplete post-compaction, with tailored resume guidance and continuation behavior.
  * Updated the pause/finish notice to display “Paused after compacting the conversation.” and updated continue-button behavior accordingly.

* **Bug Fixes**
  * Prevented auto-continuation when the agent stops due to incomplete post-compaction.
  * Improved state resets during fallback/retry flows to avoid leaking post-compaction continuation tracking.

* **Tests**
  * Added/expanded Jest coverage for filler detection, incomplete-stop detection, resume guidance, and notice/continue rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->