### PR TITLE
Fix chat reload not-found flicker

### DIFF
--- a/__mocks__/convex-react.ts
+++ b/__mocks__/convex-react.ts
@@ -4,7 +4,13 @@ const mockAction = jest.fn();
 
 export const useMutation = () => mockMutation;
 
-export const useQuery = () => undefined;
+let mockQueryResult: unknown = undefined;
+
+export const setMockQueryResult = (next: unknown): void => {
+  mockQueryResult = next;
+};
+
+export const useQuery = () => mockQueryResult;
 
 export const useAction = () => mockAction;
 
@@ -38,7 +44,18 @@ const stablePaginatedResult = {
   isLoading: false,
 };
 
-export const usePaginatedQuery = () => stablePaginatedResult;
+let mockPaginatedResult: unknown = stablePaginatedResult;
+
+export const setMockPaginatedQueryResult = (next: unknown): void => {
+  mockPaginatedResult = next;
+};
+
+export const resetMockConvexQueries = (): void => {
+  mockQueryResult = undefined;
+  mockPaginatedResult = stablePaginatedResult;
+};
+
+export const usePaginatedQuery = () => mockPaginatedResult;
 
 // Create stable convex client mock
 const convexClientMock = {

--- a/app/components/__tests__/chat.integration.test.tsx
+++ b/app/components/__tests__/chat.integration.test.tsx
@@ -11,6 +11,7 @@ const mockSetMessages = jest.fn();
 const mockStop = jest.fn();
 const mockRegenerate = jest.fn();
 const mockResumeStream = jest.fn();
+let mockRouteParams: Record<string, string> = {};
 
 jest.mock("@ai-sdk/react", () => ({
   useChat: jest.fn(() => ({
@@ -26,7 +27,7 @@ jest.mock("@ai-sdk/react", () => ({
 }));
 
 jest.mock("next/navigation", () => ({
-  useParams: jest.fn(() => ({})),
+  useParams: jest.fn(() => mockRouteParams),
   useRouter: jest.fn(() => ({
     push: jest.fn(),
     replace: jest.fn(),
@@ -172,7 +173,7 @@ jest.mock("@/components/ui/sidebar", () => ({
 }));
 
 // ===== NOW import components =====
-import { Chat } from "../chat";
+import { Chat, getExistingChatLoadState } from "../chat";
 import { ChatLayout } from "../ChatLayout";
 import { TestWrapper } from "../testUtils";
 
@@ -181,8 +182,10 @@ describe("Chat Component Integration", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    const { useParams } = require("next/navigation");
-    useParams.mockReturnValue({});
+    const convexReact = require("convex/react");
+    convexReact.resetMockConvexAuth?.();
+    convexReact.resetMockConvexQueries?.();
+    mockRouteParams = {};
     const { useChat } = require("@ai-sdk/react");
     mockUseChat = useChat as jest.Mock;
 
@@ -210,8 +213,7 @@ describe("Chat Component Integration", () => {
     });
 
     it("should render with provided chatId", () => {
-      const { useParams } = require("next/navigation");
-      useParams.mockReturnValue({ id: "test-chat-123" });
+      mockRouteParams = { id: "test-chat-123" };
 
       const { container } = render(
         <TestWrapper>
@@ -222,6 +224,82 @@ describe("Chat Component Integration", () => {
       expect(
         container.querySelector(".flex.bg-background"),
       ).toBeInTheDocument();
+    });
+
+    it("keeps an existing chat loading while Convex auth is still loading", () => {
+      expect(
+        getExistingChatLoadState({
+          isExistingChat: true,
+          hasMessages: false,
+          isConvexAuthLoading: true,
+          isConvexAuthenticated: false,
+          shouldFetchMessages: false,
+          chatData: null,
+          paginationStatus: "Exhausted",
+          hasPaginatedMessageResults: false,
+          awaitingServerChat: false,
+        }),
+      ).toEqual({
+        isInitialExistingChatLoad: true,
+        isChatNotFound: false,
+      });
+    });
+
+    it("keeps an existing chat loading while the first message page is loading", () => {
+      expect(
+        getExistingChatLoadState({
+          isExistingChat: true,
+          hasMessages: false,
+          isConvexAuthLoading: false,
+          isConvexAuthenticated: true,
+          shouldFetchMessages: true,
+          chatData: null,
+          paginationStatus: "LoadingFirstPage",
+          hasPaginatedMessageResults: false,
+          awaitingServerChat: false,
+        }),
+      ).toEqual({
+        isInitialExistingChatLoad: true,
+        isChatNotFound: false,
+      });
+    });
+
+    it("does not show not found when messages resolved before chat metadata recovers", () => {
+      expect(
+        getExistingChatLoadState({
+          isExistingChat: true,
+          hasMessages: false,
+          isConvexAuthLoading: false,
+          isConvexAuthenticated: true,
+          shouldFetchMessages: true,
+          chatData: null,
+          paginationStatus: "Exhausted",
+          hasPaginatedMessageResults: true,
+          awaitingServerChat: false,
+        }),
+      ).toEqual({
+        isInitialExistingChatLoad: false,
+        isChatNotFound: false,
+      });
+    });
+
+    it("shows chat not found after auth and messages resolve empty", () => {
+      expect(
+        getExistingChatLoadState({
+          isExistingChat: true,
+          hasMessages: false,
+          isConvexAuthLoading: false,
+          isConvexAuthenticated: true,
+          shouldFetchMessages: true,
+          chatData: null,
+          paginationStatus: "Exhausted",
+          hasPaginatedMessageResults: false,
+          awaitingServerChat: false,
+        }),
+      ).toEqual({
+        isInitialExistingChatLoad: false,
+        isChatNotFound: true,
+      });
     });
   });
 

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -12,7 +12,12 @@ import {
   useMemo,
   type RefObject,
 } from "react";
-import { useQuery, usePaginatedQuery, useMutation } from "convex/react";
+import {
+  useQuery,
+  usePaginatedQuery,
+  useMutation,
+  useConvexAuth,
+} from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { FileDetails } from "@/types/file";
 import { Messages } from "./Messages";
@@ -67,6 +72,48 @@ const AGENT_LONG_COMPLETION_POLL_DELAY_MS = 5_000;
 const AGENT_LONG_COMPLETION_POLL_INTERVAL_MS = 2_000;
 const AGENT_LONG_COMPLETION_QUIET_MS = 3_000;
 const AGENT_LONG_COMPLETION_STOP_GRACE_MS = 6_000;
+type MessagePaginationStatus =
+  "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
+
+export function getExistingChatLoadState({
+  isExistingChat,
+  hasMessages,
+  isConvexAuthLoading,
+  isConvexAuthenticated,
+  shouldFetchMessages,
+  chatData,
+  paginationStatus,
+  hasPaginatedMessageResults,
+  awaitingServerChat,
+}: {
+  isExistingChat: boolean;
+  hasMessages: boolean;
+  isConvexAuthLoading: boolean;
+  isConvexAuthenticated: boolean;
+  shouldFetchMessages: boolean;
+  chatData: unknown;
+  paginationStatus?: MessagePaginationStatus;
+  hasPaginatedMessageResults: boolean;
+  awaitingServerChat: boolean;
+}) {
+  const isInitialExistingChatLoad =
+    isExistingChat &&
+    !hasMessages &&
+    (isConvexAuthLoading ||
+      !isConvexAuthenticated ||
+      (shouldFetchMessages &&
+        (chatData === undefined || paginationStatus === "LoadingFirstPage")));
+
+  const isChatNotFound =
+    isExistingChat &&
+    chatData === null &&
+    shouldFetchMessages &&
+    !awaitingServerChat &&
+    paginationStatus !== "LoadingFirstPage" &&
+    !hasPaginatedMessageResults;
+
+  return { isInitialExistingChatLoad, isChatNotFound };
+}
 
 const getAgentLongPartFingerprint = (part: unknown): string => {
   if (typeof part !== "object" || part === null) return String(part);
@@ -282,6 +329,10 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const router = useRouter();
   const isMobile = useIsMobile();
   const { setDataStream, setIsAutoResuming } = useDataStreamDispatch();
+  const {
+    isLoading: isConvexAuthLoading,
+    isAuthenticated: isConvexAuthenticated,
+  } = useConvexAuth();
   const [streamingState, dispatchStreaming] = useReducer(
     streamingReducer,
     initialStreamingState,
@@ -323,7 +374,8 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   // Track whether this is an existing chat (prop-driven initially, flips after first completion)
   const [isExistingChat, setIsExistingChat] = useState<boolean>(!!routeChatId);
   const wasNewChatRef = useRef(!routeChatId);
-  const shouldFetchMessages = isExistingChat;
+  const shouldFetchMessages =
+    isExistingChat && !isConvexAuthLoading && isConvexAuthenticated;
 
   // Refs to avoid stale closures in callbacks
   const isExistingChatRef = useLatestRef(isExistingChat);
@@ -416,8 +468,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
   // Use the shared local sandbox connection subscription when validating a saved non-E2B sandbox.
   const storedSandboxType = (chatDataForCurrentChat as any)?.sandbox_type as
-    | string
-    | undefined;
+    string | undefined;
 
   // Prefer the mid-stream title — the server seeds chatData.title with the
   // user's first message before generation completes, which would otherwise
@@ -425,8 +476,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const chatTitle = streamedTitle ?? chatDataForCurrentChat?.title ?? null;
   const activeTriggerRunRef = useLatestRef(
     (chatDataForCurrentChat as any)?.active_trigger_run_id as
-      | string
-      | undefined,
+      string | undefined,
   );
 
   // Convert paginated Convex messages to UI format for useChat and useAutoResume
@@ -1134,8 +1184,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     if (persistedPrefsRef.current === null) {
       const savedModel = (chatData as any).selected_model as string | undefined;
       const savedMode = (chatData as any).default_model_slug as
-        | string
-        | undefined;
+        string | undefined;
       persistedPrefsRef.current = {
         model: savedModel ?? selectedModel,
         mode: savedMode ?? chatMode,
@@ -1459,6 +1508,18 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
   const hasMessages = messages.length > 0;
   const showChatLayout = hasMessages || isExistingChat;
+  const { isInitialExistingChatLoad, isChatNotFound } =
+    getExistingChatLoadState({
+      isExistingChat,
+      hasMessages,
+      isConvexAuthLoading,
+      isConvexAuthenticated,
+      shouldFetchMessages,
+      chatData,
+      paginationStatus: paginatedMessages.status,
+      hasPaginatedMessageResults: !!paginatedMessageResults,
+      awaitingServerChat,
+    });
   const agentRunSpendCapWarning =
     rateLimitWarning?.warningType === "agent-run-spend-cap"
       ? rateLimitWarning
@@ -1471,13 +1532,6 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const branchedFromChatId = chatDataForCurrentChat?.branched_from_chat_id;
   const branchedFromChatTitle = (chatDataForCurrentChat as any)
     ?.branched_from_title;
-
-  // Check if we tried to load an existing chat but it doesn't exist or doesn't belong to user
-  const isChatNotFound =
-    isExistingChat &&
-    chatData === null &&
-    shouldFetchMessages &&
-    !awaitingServerChat;
 
   return (
     <ConvexErrorBoundary>
@@ -1524,7 +1578,11 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
             {/* Chat interface */}
             <div className="bg-background flex flex-col flex-1 relative min-h-0">
               {/* Messages area */}
-              {isChatNotFound ? (
+              {isInitialExistingChatLoad ? (
+                <div className="flex-1 flex items-center justify-center min-h-0">
+                  <Loading />
+                </div>
+              ) : isChatNotFound ? (
                 <div className="flex-1 flex flex-col items-center justify-center px-4 py-8 min-h-0">
                   <div className="w-full max-w-full sm:max-w-[768px] sm:min-w-[390px] flex flex-col items-center space-y-8">
                     <div className="text-center">
@@ -1626,6 +1684,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
               {/* Chat Input - Bottom placement (also for mobile new chats) */}
               {(hasMessages || isExistingChat || isMobile) &&
+                !isInitialExistingChatLoad &&
                 !isChatNotFound && (
                   <ChatInput
                     onSubmit={handleSubmit}

--- a/app/hooks/__tests__/useChats.test.tsx
+++ b/app/hooks/__tests__/useChats.test.tsx
@@ -1,0 +1,84 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { useChats } from "../useChats";
+
+const convexReact = require("convex/react");
+
+describe("useChats", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    convexReact.resetMockConvexAuth?.();
+    convexReact.resetMockConvexQueries?.();
+  });
+
+  it("keeps the sidebar history loading while Convex auth is loading", () => {
+    convexReact.setMockConvexAuth?.({
+      isLoading: true,
+      isAuthenticated: false,
+    });
+    convexReact.setMockPaginatedQueryResult?.({
+      results: [],
+      status: "Exhausted",
+      loadMore: jest.fn(),
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useChats());
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.status).toBe("LoadingFirstPage");
+  });
+
+  it("keeps the sidebar history loading when auth has not authenticated yet", () => {
+    convexReact.setMockConvexAuth?.({
+      isLoading: false,
+      isAuthenticated: false,
+    });
+    convexReact.setMockPaginatedQueryResult?.({
+      results: [],
+      status: "Exhausted",
+      loadMore: jest.fn(),
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useChats());
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.status).toBe("LoadingFirstPage");
+  });
+
+  it("preserves the chat query result once auth is ready", () => {
+    const loadMore = jest.fn();
+    convexReact.setMockPaginatedQueryResult?.({
+      results: [{ id: "chat-1", title: "Loaded chat" }],
+      status: "Exhausted",
+      loadMore,
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useChats());
+
+    expect(result.current.results).toEqual([
+      { id: "chat-1", title: "Loaded chat" },
+    ]);
+    expect(result.current.status).toBe("Exhausted");
+    expect(result.current.loadMore).toBe(loadMore);
+  });
+
+  it("does not force loading when fetching is intentionally skipped", () => {
+    convexReact.setMockConvexAuth?.({
+      isLoading: true,
+      isAuthenticated: false,
+    });
+    convexReact.setMockPaginatedQueryResult?.({
+      results: [],
+      status: "Exhausted",
+      loadMore: jest.fn(),
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useChats(false));
+
+    expect(result.current.status).toBe("Exhausted");
+  });
+});

--- a/app/hooks/useChats.ts
+++ b/app/hooks/useChats.ts
@@ -1,16 +1,33 @@
 "use client";
 
-import { usePaginatedQuery, useMutation } from "convex/react";
+import { usePaginatedQuery, useMutation, useConvexAuth } from "convex/react";
 import { api } from "@/convex/_generated/api";
 
 /**
  * Wrapper around usePaginatedQuery for user chats.
  * Auth is enforced server-side by Convex.
  */
-export const useChats = (shouldFetch = true) =>
-  usePaginatedQuery(api.chats.getUserChats, shouldFetch ? {} : "skip", {
-    initialNumItems: 28,
-  });
+export const useChats = (shouldFetch = true) => {
+  const { isLoading, isAuthenticated } = useConvexAuth();
+  const shouldRunQuery = shouldFetch && !isLoading && isAuthenticated;
+  const query = usePaginatedQuery(
+    api.chats.getUserChats,
+    shouldRunQuery ? {} : "skip",
+    {
+      initialNumItems: 28,
+    },
+  );
+
+  if (shouldFetch && (isLoading || !isAuthenticated)) {
+    return {
+      ...query,
+      results: [],
+      status: "LoadingFirstPage" as const,
+    };
+  }
+
+  return query;
+};
 
 export const usePinChat = () => useMutation(api.chats.pinChat);
 export const useUnpinChat = () => useMutation(api.chats.unpinChat);

--- a/app/hooks/useChats.ts
+++ b/app/hooks/useChats.ts
@@ -18,7 +18,7 @@ export const useChats = (shouldFetch = true) => {
     },
   );
 
-  if (shouldFetch && (isLoading || !isAuthenticated)) {
+  if (shouldFetch && !shouldRunQuery) {
     return {
       ...query,
       results: [],


### PR DESCRIPTION
## Summary
- wait for Convex auth before loading existing chat metadata/messages
- keep existing chat pages in a loading state until the first message page resolves
- keep sidebar chat history in its loading skeleton during auth refresh instead of briefly showing No chats yet
- only show Chat Not Found / empty sidebar states after auth is ready and the relevant query resolves empty
- add regression coverage for transient auth/message-loading states

## Testing
- ./node_modules/.bin/jest app/components/__tests__/chat.integration.test.tsx --runInBand
- ./node_modules/.bin/jest app/hooks/__tests__/useChats.test.tsx app/components/__tests__/SidebarHistory.test.tsx app/components/__tests__/chat.integration.test.tsx --runInBand
- ./node_modules/.bin/tsc --noEmit --pretty false
- ./node_modules/.bin/eslint app/hooks/useChats.ts app/hooks/__tests__/useChats.test.tsx app/components/chat.tsx app/components/__tests__/chat.integration.test.tsx __mocks__/convex-react.ts (passes with existing warnings in app/components/chat.tsx)
- ./node_modules/.bin/prettier --check app/hooks/useChats.ts app/hooks/__tests__/useChats.test.tsx app/components/chat.tsx app/components/__tests__/chat.integration.test.tsx __mocks__/convex-react.ts
- pre-commit hook after first commit: tsc --noEmit and full jest suite (199 suites / 2021 tests)
- pre-commit hook after sidebar follow-up: tsc --noEmit and full jest suite (200 suites / 2025 tests)
- pre-commit hook after CodeRabbit cleanup: tsc --noEmit and full jest suite (200 suites / 2025 tests)

## Manual verification
- Open an existing /c/:id chat while signed in.
- Reload the page.
- Confirm the page stays in loading state until messages render and does not flash Chat Not Found.
- Confirm the left chat sidebar keeps its loading skeleton during reload and does not flash No chats yet before chat history appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer existing-chat loading experience, including a dedicated loading screen while chat data resolves.
  * The chat input is now hidden during the initial existing-chat loading phase.
* **Bug Fixes**
  * Prevents existing chats from briefly appearing as missing while their data and recovery complete.
  * Improves auth-aware fetching so chat/message queries only run once authentication is ready.
* **Tests**
  * Expanded integration and hook coverage across loading, recovery, “chat not found,” and skip scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->