### PR TITLE
Default Agent mode for paid plans

### DIFF
--- a/lib/activation/__tests__/agent-first-default.test.ts
+++ b/lib/activation/__tests__/agent-first-default.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeAgentFirstSandboxType,
   type AgentFirstDefaultEligibility,
   shouldDefaultFreeUserToAgent,
+  shouldDefaultPaidUserToAgent,
   shouldDefaultProPlusUserToAgent,
   shouldDefaultUltraUserToAgent,
 } from "../agent-first-default";
@@ -211,6 +212,60 @@ describe("shouldDefaultProPlusUserToAgent", () => {
   });
 });
 
+describe("shouldDefaultPaidUserToAgent", () => {
+  const paidEligibility: AgentFirstDefaultEligibility = {
+    ...baseEligibility,
+    defaultLocalSandboxPreference: null,
+    hasLocalSandbox: false,
+  };
+
+  it.each(["pro", "pro-plus", "ultra", "team"] as const)(
+    "defaults eligible first-time %s users to Agent without requiring a local sandbox",
+    (subscription) => {
+      expect(
+        shouldDefaultPaidUserToAgent({
+          ...paidEligibility,
+          subscription,
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it("does not treat the free local-sandbox default as a paid default", () => {
+    expect(shouldDefaultPaidUserToAgent(baseEligibility)).toBe(false);
+  });
+
+  it("does not override a saved mode preference", () => {
+    expect(
+      shouldDefaultPaidUserToAgent({
+        ...paidEligibility,
+        subscription: "pro",
+        hasSavedChatMode: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not override a mode selected during the current session", () => {
+    expect(
+      shouldDefaultPaidUserToAgent({
+        ...paidEligibility,
+        subscription: "pro",
+        hasUserSelectedModeThisSession: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not default temporary chats to Agent", () => {
+    expect(
+      shouldDefaultPaidUserToAgent({
+        ...paidEligibility,
+        subscription: "pro",
+        temporaryChatsEnabled: true,
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("getAgentFirstDefaultDecision", () => {
   it("returns the free-user decision with the local sandbox requirement", () => {
     expect(getAgentFirstDefaultDecision(baseEligibility)).toEqual({
@@ -218,6 +273,22 @@ describe("getAgentFirstDefaultDecision", () => {
       experimentKey: "free_agent_first_v1",
       selectionReason: "eligible_free_user_local_sandbox",
       useDefaultLocalSandbox: true,
+    });
+  });
+
+  it("returns the Pro decision without the local sandbox requirement", () => {
+    expect(
+      getAgentFirstDefaultDecision({
+        ...baseEligibility,
+        defaultLocalSandboxPreference: null,
+        hasLocalSandbox: false,
+        subscription: "pro",
+      }),
+    ).toEqual({
+      eligibleSubscriptionTier: "pro",
+      experimentKey: "pro_agent_default_v1",
+      selectionReason: "eligible_pro_user",
+      useDefaultLocalSandbox: false,
     });
   });
 
@@ -249,6 +320,22 @@ describe("getAgentFirstDefaultDecision", () => {
       eligibleSubscriptionTier: "pro-plus",
       experimentKey: "pro_plus_agent_default_v1",
       selectionReason: "eligible_pro_plus_user",
+      useDefaultLocalSandbox: false,
+    });
+  });
+
+  it("returns the Team decision without the local sandbox requirement", () => {
+    expect(
+      getAgentFirstDefaultDecision({
+        ...baseEligibility,
+        defaultLocalSandboxPreference: null,
+        hasLocalSandbox: false,
+        subscription: "team",
+      }),
+    ).toEqual({
+      eligibleSubscriptionTier: "team",
+      experimentKey: "team_agent_default_v1",
+      selectionReason: "eligible_team_user",
       useDefaultLocalSandbox: false,
     });
   });

--- a/lib/activation/agent-first-default.ts
+++ b/lib/activation/agent-first-default.ts
@@ -18,18 +18,57 @@ export type AgentFirstDefaultEligibility = {
   userPresent: boolean;
 };
 
+type PaidAgentFirstDefaultTier = Exclude<SubscriptionTier, "free">;
+
 export type AgentFirstDefaultDecision = {
-  eligibleSubscriptionTier: "free" | "pro-plus" | "ultra";
+  eligibleSubscriptionTier: SubscriptionTier;
   experimentKey:
     | "free_agent_first_v1"
+    | "pro_agent_default_v1"
     | "pro_plus_agent_default_v1"
-    | "ultra_agent_default_v1";
+    | "ultra_agent_default_v1"
+    | "team_agent_default_v1";
   selectionReason:
     | "eligible_free_user_local_sandbox"
+    | "eligible_pro_user"
     | "eligible_pro_plus_user"
-    | "eligible_ultra_user";
+    | "eligible_ultra_user"
+    | "eligible_team_user";
   useDefaultLocalSandbox: boolean;
 };
+
+const PAID_AGENT_FIRST_DEFAULTS = {
+  pro: {
+    eligibleSubscriptionTier: "pro",
+    experimentKey: "pro_agent_default_v1",
+    selectionReason: "eligible_pro_user",
+    useDefaultLocalSandbox: false,
+  },
+  "pro-plus": {
+    eligibleSubscriptionTier: "pro-plus",
+    experimentKey: "pro_plus_agent_default_v1",
+    selectionReason: "eligible_pro_plus_user",
+    useDefaultLocalSandbox: false,
+  },
+  ultra: {
+    eligibleSubscriptionTier: "ultra",
+    experimentKey: "ultra_agent_default_v1",
+    selectionReason: "eligible_ultra_user",
+    useDefaultLocalSandbox: false,
+  },
+  team: {
+    eligibleSubscriptionTier: "team",
+    experimentKey: "team_agent_default_v1",
+    selectionReason: "eligible_team_user",
+    useDefaultLocalSandbox: false,
+  },
+} satisfies Record<PaidAgentFirstDefaultTier, AgentFirstDefaultDecision>;
+
+function isPaidAgentFirstDefaultTier(
+  subscription: SubscriptionTier,
+): subscription is PaidAgentFirstDefaultTier {
+  return subscription !== "free";
+}
 
 export function normalizeAgentFirstSandboxType(
   preference: SandboxPreference | null,
@@ -78,22 +117,8 @@ export function getAgentFirstDefaultDecision({
     };
   }
 
-  if (subscription === "ultra") {
-    return {
-      eligibleSubscriptionTier: "ultra",
-      experimentKey: "ultra_agent_default_v1",
-      selectionReason: "eligible_ultra_user",
-      useDefaultLocalSandbox: false,
-    };
-  }
-
-  if (subscription === "pro-plus") {
-    return {
-      eligibleSubscriptionTier: "pro-plus",
-      experimentKey: "pro_plus_agent_default_v1",
-      selectionReason: "eligible_pro_plus_user",
-      useDefaultLocalSandbox: false,
-    };
+  if (isPaidAgentFirstDefaultTier(subscription)) {
+    return PAID_AGENT_FIRST_DEFAULTS[subscription];
   }
 
   return null;
@@ -124,4 +149,12 @@ export function shouldDefaultProPlusUserToAgent(
     getAgentFirstDefaultDecision(eligibility)?.eligibleSubscriptionTier ===
     "pro-plus"
   );
+}
+
+export function shouldDefaultPaidUserToAgent(
+  eligibility: AgentFirstDefaultEligibility,
+): boolean {
+  const tier =
+    getAgentFirstDefaultDecision(eligibility)?.eligibleSubscriptionTier;
+  return tier !== undefined && tier !== "free";
 }


### PR DESCRIPTION
## Summary
- make the Agent-first default apply to every non-free subscription tier instead of only Pro Plus and Ultra
- keep the existing first-time-only guards: saved mode, current-session mode choice, temporary chats, and free local-sandbox requirements still prevent automatic switching
- add regression coverage for Pro, Pro Plus, Ultra, and Team paid defaults

## Testing
- ./node_modules/.bin/jest lib/activation/__tests__/agent-first-default.test.ts --runInBand
- ./node_modules/.bin/prettier --check lib/activation/agent-first-default.ts lib/activation/__tests__/agent-first-default.test.ts
- ./node_modules/.bin/eslint lib/activation/agent-first-default.ts lib/activation/__tests__/agent-first-default.test.ts
- ./node_modules/.bin/tsc --noEmit
- pre-commit hook: tsc --noEmit and full jest suite, 202 suites / 2045 tests passed

## Manual verification
- Sign in as a first-time Pro user with no saved chat mode and open a new chat. It should start in Agent mode with selected model Auto and the cloud sandbox preference unchanged.
- Repeat for Pro Plus, Ultra, and Team accounts. They should also start in Agent mode.
- Set Ask mode manually or use an account with a saved Ask preference, then reload. The app should preserve the saved/user-selected mode instead of forcing Agent mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded automatic Agent defaults to cover additional paid subscription tiers, including Pro and Team.
  * Added support for determining when paid users should default to Agent.

* **Bug Fixes**
  * Improved default-selection behavior so saved mode choices, same-session selections, and temporary chats no longer trigger automatic defaults.
  * Updated eligibility handling so paid users can default without requiring a local sandbox in supported cases.

* **Tests**
  * Added coverage for paid-user default behavior across multiple subscription tiers and decision paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->