### PR TITLE
Triage PostHog frontend error noise

### DIFF
--- a/app/components/CodeHighlight.tsx
+++ b/app/components/CodeHighlight.tsx
@@ -2,7 +2,10 @@ import type { ReactNode } from "react";
 import { memo, useState, useMemo } from "react";
 import ShikiHighlighter, { isInlineCode, type Element } from "react-shiki";
 import { CodeActionButtons } from "@/components/ui/code-action-buttons";
-import { isLanguageSupported, ShikiErrorBoundary } from "@/lib/utils/shiki";
+import {
+  shouldUseShikiHighlighter,
+  ShikiErrorBoundary,
+} from "@/lib/utils/shiki";
 
 interface CodeHighlightProps {
   className?: string | undefined;
@@ -28,7 +31,7 @@ const CodeHighlightImpl = ({
 
   // Check if language is supported by Shiki
   const shouldUsePlainText = useMemo(() => {
-    return !isLanguageSupported(language);
+    return !shouldUseShikiHighlighter(language);
   }, [language]);
 
   const handleToggleWrap = () => {

--- a/app/components/ComputerCodeBlock.tsx
+++ b/app/components/ComputerCodeBlock.tsx
@@ -2,7 +2,10 @@ import type { ReactNode } from "react";
 import { useState, useMemo } from "react";
 import { Download, Copy, Check, WrapText } from "lucide-react";
 import ShikiHighlighter from "react-shiki";
-import { isLanguageSupported, ShikiErrorBoundary } from "@/lib/utils/shiki";
+import {
+  shouldUseShikiHighlighter,
+  ShikiErrorBoundary,
+} from "@/lib/utils/shiki";
 import {
   Tooltip,
   TooltipTrigger,
@@ -29,7 +32,7 @@ export const ComputerCodeBlock = ({
 
   // Check if language is supported by Shiki
   const shouldUsePlainText = useMemo(() => {
-    return !isLanguageSupported(language);
+    return !shouldUseShikiHighlighter(language);
   }, [language]);
 
   const handleCopy = async () => {

--- a/app/components/TerminalCodeBlock.tsx
+++ b/app/components/TerminalCodeBlock.tsx
@@ -6,6 +6,7 @@ import { Terminal } from "lucide-react";
 import { codeToHtml } from "shiki";
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import { isInteractiveShellAction } from "@/app/components/tools/shell-tool-utils";
+import { isWebAssemblyAvailable } from "@/lib/utils/shiki";
 
 const XtermRenderer = dynamic(
   () => import("./XtermRenderer").then((m) => m.XtermRenderer),
@@ -48,6 +49,20 @@ const cleanCache = () => {
       ansiCache.delete(entries[i][0]);
     }
   }
+};
+
+const createPlainTextHtml = (codeToRender: string): string => {
+  const escapedCode = codeToRender.replace(/[&<>"']/g, (char) => {
+    const entities: Record<string, string> = {
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    };
+    return entities[char];
+  });
+  return `<pre><code>${escapedCode}</code></pre>`;
 };
 
 /**
@@ -108,6 +123,17 @@ const AnsiCodeBlock = ({
         setIsRendering(true);
 
         try {
+          if (!isWebAssemblyAvailable()) {
+            const fallbackHtml = createPlainTextHtml(codeToRender);
+            if (cacheKeyRef.current === cacheKey) {
+              setHtmlContent(fallbackHtml);
+              cleanCache();
+              ansiCache.set(cacheKey, fallbackHtml);
+              lastRenderedCodeRef.current = codeToRender;
+            }
+            return;
+          }
+
           const html = await codeToHtml(codeToRender, {
             lang: "ansi",
             theme: theme,
@@ -122,18 +148,7 @@ const AnsiCodeBlock = ({
           }
         } catch (error) {
           console.error("Failed to render ANSI code:", error);
-          // Fallback to plain text with proper escaping
-          const escapedCode = codeToRender.replace(/[&<>"']/g, (char) => {
-            const entities: Record<string, string> = {
-              "&": "&amp;",
-              "<": "&lt;",
-              ">": "&gt;",
-              '"': "&quot;",
-              "'": "&#39;",
-            };
-            return entities[char];
-          });
-          const fallbackHtml = `<pre><code>${escapedCode}</code></pre>`;
+          const fallbackHtml = createPlainTextHtml(codeToRender);
 
           if (cacheKeyRef.current === cacheKey) {
             setHtmlContent(fallbackHtml);

--- a/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
+++ b/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
@@ -72,14 +72,19 @@ describe("shouldDropExpectedFrontendException", () => {
   });
 
   it("drops exact manual chat stop aborts", () => {
-    expect(
-      shouldDropExpectedFrontendException({
-        event: "$exception",
-        properties: {
-          $exception_values: ["AbortError: Fetch is aborted"],
-        },
-      }),
-    ).toBe(true);
+    for (const value of [
+      "AbortError: Fetch is aborted",
+      "AbortError: signal is aborted without reason",
+    ]) {
+      expect(
+        shouldDropExpectedFrontendException({
+          event: "$exception",
+          properties: {
+            $exception_values: [value],
+          },
+        }),
+      ).toBe(true);
+    }
 
     expect(
       shouldDropExpectedFrontendException({
@@ -95,6 +100,7 @@ describe("shouldDropExpectedFrontendException", () => {
     for (const value of [
       "NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
       "NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+      "NotFoundError: The object can not be found here.",
     ]) {
       expect(
         shouldDropExpectedFrontendException({

--- a/lib/posthog/expected-frontend-exceptions.ts
+++ b/lib/posthog/expected-frontend-exceptions.ts
@@ -12,11 +12,13 @@ const RESIZE_OBSERVER_MESSAGES = new Set([
 
 const MANUAL_CHAT_STOP_ABORT_MESSAGES = new Set([
   "AbortError: Fetch is aborted",
+  "AbortError: signal is aborted without reason",
 ]);
 
 const REACT_DOM_MUTATION_MESSAGES = new Set([
   "NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
   "NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+  "NotFoundError: The object can not be found here.",
 ]);
 
 const OPAQUE_SYNTHETIC_MESSAGES = new Set([

--- a/lib/utils/__tests__/shiki.test.ts
+++ b/lib/utils/__tests__/shiki.test.ts
@@ -1,0 +1,24 @@
+import { isWebAssemblyAvailable, shouldUseShikiHighlighter } from "../shiki";
+
+describe("shiki utilities", () => {
+  const originalWebAssembly = globalThis.WebAssembly;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "WebAssembly", {
+      configurable: true,
+      value: originalWebAssembly,
+      writable: true,
+    });
+  });
+
+  it("disables Shiki highlighting when WebAssembly is unavailable", () => {
+    Object.defineProperty(globalThis, "WebAssembly", {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+
+    expect(isWebAssemblyAvailable()).toBe(false);
+    expect(shouldUseShikiHighlighter("js")).toBe(false);
+  });
+});

--- a/lib/utils/__tests__/todo-utils.test.ts
+++ b/lib/utils/__tests__/todo-utils.test.ts
@@ -8,6 +8,7 @@ import {
   computeReplaceAssistantTodos,
   getBaseTodosForRequest,
   areTodosEqual,
+  getTodoDisplayData,
   getTodoStats,
   getVisibleTodoBlockItems,
   getTodoPanelViewState,
@@ -329,6 +330,29 @@ describe("todo-utils", () => {
   });
 
   describe("todo view helpers", () => {
+    it("ignores malformed todo display payloads", () => {
+      const displayData = getTodoDisplayData({
+        id: "not-an-array",
+        content: "Invalid payload",
+        status: "pending",
+      });
+
+      expect(displayData.todos).toEqual([]);
+      expect(displayData.stats.total).toBe(0);
+    });
+
+    it("filters invalid todo display items", () => {
+      const displayData = getTodoDisplayData([
+        { id: "1", content: "Valid", status: "pending" },
+        { id: "2", status: "pending" },
+        { id: "3", content: "Invalid status", status: "unknown" },
+      ]);
+
+      expect(displayData.todos).toEqual([
+        { id: "1", content: "Valid", status: "pending" },
+      ]);
+    });
+
     it("treats cancelled as done for block visibility", () => {
       const todos: Todo[] = [
         { id: "1", content: "Completed", status: "completed" },

--- a/lib/utils/shiki.tsx
+++ b/lib/utils/shiki.tsx
@@ -11,6 +11,12 @@ export const isLanguageSupported = (lang: string | undefined): boolean => {
   return SUPPORTED_LANGUAGES.has(lang.toLowerCase());
 };
 
+export const isWebAssemblyAvailable = (): boolean =>
+  typeof globalThis.WebAssembly !== "undefined";
+
+export const shouldUseShikiHighlighter = (lang: string | undefined): boolean =>
+  isWebAssemblyAvailable() && isLanguageSupported(lang);
+
 interface ShikiBoundaryProps {
   fallback: ReactNode;
   children: ReactNode;

--- a/lib/utils/todo-utils.ts
+++ b/lib/utils/todo-utils.ts
@@ -1,4 +1,4 @@
-import type { Todo } from "@/types";
+import { TODO_STATUS_VALUES, type Todo } from "@/types";
 
 export class TodoUpdateError extends Error {
   constructor(message: string) {
@@ -58,12 +58,7 @@ const hasBlankContent = (candidate: TodoLike): boolean => {
   return candidate.content !== undefined && candidate.content.trim() === "";
 };
 
-const TODO_STATUSES = new Set<Todo["status"]>([
-  "pending",
-  "in_progress",
-  "completed",
-  "cancelled",
-]);
+const TODO_STATUSES = new Set<Todo["status"]>(TODO_STATUS_VALUES);
 
 const isTodoForDisplay = (candidate: unknown): candidate is Todo => {
   if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {

--- a/lib/utils/todo-utils.ts
+++ b/lib/utils/todo-utils.ts
@@ -58,6 +58,29 @@ const hasBlankContent = (candidate: TodoLike): boolean => {
   return candidate.content !== undefined && candidate.content.trim() === "";
 };
 
+const TODO_STATUSES = new Set<Todo["status"]>([
+  "pending",
+  "in_progress",
+  "completed",
+  "cancelled",
+]);
+
+const isTodoForDisplay = (candidate: unknown): candidate is Todo => {
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+    return false;
+  }
+
+  const todo = candidate as Partial<Todo>;
+  return (
+    typeof todo.id === "string" &&
+    typeof todo.content === "string" &&
+    TODO_STATUSES.has(todo.status as Todo["status"])
+  );
+};
+
+const normalizeTodosForDisplay = (todos: unknown): Todo[] =>
+  Array.isArray(todos) ? todos.filter(isTodoForDisplay) : [];
+
 export const dedupeTodosById = <T extends { id: string }>(
   todos: ReadonlyArray<T>,
 ): T[] => {
@@ -292,8 +315,8 @@ export const getTodoStats = (todos: Todo[]) => {
   };
 };
 
-export const getTodoDisplayData = (todos: Todo[]) => {
-  const uniqueTodos = dedupeTodosById(todos);
+export const getTodoDisplayData = (todos: unknown) => {
+  const uniqueTodos = dedupeTodosById(normalizeTodosForDisplay(todos));
   const byStatus = {
     completed: uniqueTodos.filter((t) => t.status === "completed"),
     inProgress: uniqueTodos.filter((t) => t.status === "in_progress"),
@@ -334,13 +357,14 @@ export const getVisibleTodoBlockItems = ({
   inputTodos,
   showAllTodos = false,
 }: {
-  todos: Todo[];
+  todos: unknown;
   inputTodos?: ReadonlyArray<TodoLike>;
   showAllTodos?: boolean;
 }): Todo[] => {
   const todoData = getTodoDisplayData(todos);
   const { stats, currentInProgress, lastDone } = todoData;
   const uniqueTodos = todoData.todos;
+  const inputTodoList = Array.isArray(inputTodos) ? inputTodos : [];
 
   if (stats.done === 0 || showAllTodos) {
     return uniqueTodos;
@@ -348,8 +372,8 @@ export const getVisibleTodoBlockItems = ({
 
   const visibleTodos: Todo[] = [];
 
-  if (inputTodos && inputTodos.length > 0) {
-    const inputTodoIds = new Set(inputTodos.map((t) => t.id));
+  if (inputTodoList.length > 0) {
+    const inputTodoIds = new Set(inputTodoList.map((t) => t.id));
     visibleTodos.push(
       ...uniqueTodos.filter((todo) => inputTodoIds.has(todo.id)),
     );

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -308,10 +308,19 @@ export const isSidebarSharedFiles = (
   return "requestedPaths" in content;
 };
 
+export const TODO_STATUS_VALUES = [
+  "pending",
+  "in_progress",
+  "completed",
+  "cancelled",
+] as const;
+
+export type TodoStatus = (typeof TODO_STATUS_VALUES)[number];
+
 export interface Todo {
   id: string;
   content: string;
-  status: "pending" | "in_progress" | "completed" | "cancelled";
+  status: TodoStatus;
   sourceMessageId?: string;
 }
 


### PR DESCRIPTION
## Summary
- suppress narrow expected frontend noise newly observed in PostHog: chat stop aborts and React DOM mutation cleanup errors
- fall back to plain-text code rendering when WebAssembly is unavailable so Shiki does not crash code blocks
- harden todo display helpers against malformed runtime payloads while keeping write/update validation strict

## Classification
- Fix: WebAssembly/Shiki crash and malformed todo display payload crash
- Code-ignore: exact chat abort and React DOM mutation cleanup signatures
- Not ignored: broad Next server-action fetch failures, generic browser network errors, chunk-load errors, React minified errors, and Convex server errors need more context or separate fixes

## Testing
- ./node_modules/.bin/jest lib/posthog/__tests__/expected-frontend-exceptions.test.ts lib/utils/__tests__/todo-utils.test.ts lib/utils/__tests__/shiki.test.ts app/components/__tests__/CodeHighlight.test.tsx --runInBand
- corepack pnpm exec tsc --noEmit --pretty false
- corepack pnpm exec eslint lib/posthog/expected-frontend-exceptions.ts lib/posthog/__tests__/expected-frontend-exceptions.test.ts lib/utils/todo-utils.ts lib/utils/__tests__/todo-utils.test.ts lib/utils/shiki.tsx lib/utils/__tests__/shiki.test.ts app/components/CodeHighlight.tsx app/components/ComputerCodeBlock.tsx app/components/TerminalCodeBlock.tsx
- corepack pnpm exec prettier --check lib/posthog/expected-frontend-exceptions.ts lib/posthog/__tests__/expected-frontend-exceptions.test.ts lib/utils/todo-utils.ts lib/utils/__tests__/todo-utils.test.ts lib/utils/shiki.tsx lib/utils/__tests__/shiki.test.ts app/components/CodeHighlight.tsx app/components/ComputerCodeBlock.tsx app/components/TerminalCodeBlock.tsx
- git diff --check

## Manual verification
- Open a chat with a code block in a browser/environment where WebAssembly is unavailable or disabled; the block should render as plain text instead of crashing.
- Open a chat containing malformed or partial todo display data; the todo block should skip invalid items instead of crashing the page.
- Stop or navigate away from an active chat stream; expected abort cleanup should not appear as a new PostHog frontend exception.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Code blocks now decide at runtime whether to use advanced highlighting, and fall back to plain text when unavailable.
  * Todo rendering now validates and normalizes incoming data more defensively.

* **Bug Fixes**
  * Expanded expected frontend exception message matching to avoid reporting additional harmless noise.
  * Improved terminal/ANSI code rendering fallback behavior when WebAssembly support is missing.

* **Tests**
  * Added tests covering highlighting availability and todo data validation, plus updated exception-dropping assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->