### PR TITLE
Stop retained-tail tool placeholders leaking

### DIFF
--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -441,8 +441,8 @@ describe("checkAndSummarizeIfNeeded", () => {
     expect(serializedSummaryInput).not.toContain("[msg-4]");
   });
 
-  it("should not summarize the original payload for a tail-only projected oversized part", async () => {
-    mockGenerateText.mockResolvedValue({ text: "Projected-only summary" });
+  it("should not retain a placeholder for a tail-only oversized tool part", async () => {
+    mockGenerateText.mockResolvedValue({ text: "Oversized tool summary" });
 
     const hugeOutput = Array.from(
       { length: 20_000 },
@@ -492,24 +492,25 @@ describe("checkAndSummarizeIfNeeded", () => {
 
     expect(result.needsSummarization).toBe(true);
     expect(result.cutoffMessageId).toBe("assistant-huge");
-    expect(result.summarizedMessages).toHaveLength(2);
-    expect(result.summarizedMessages[1].id).toBe("assistant-huge");
+    expect(result.summarizedMessages).toHaveLength(1);
 
     const serializedSummaryInput = JSON.stringify(
       mockGenerateText.mock.calls[0][0].messages,
     );
-    expect(serializedSummaryInput).not.toContain("unique-projected-tail-line");
+    expect(serializedSummaryInput).toContain(
+      "[run_terminal_cmd output preview:",
+    );
+    expect(serializedSummaryInput).not.toContain("retained tail");
     expect(JSON.stringify(result.summarizedMessages)).not.toContain(hugeOutput);
+    expect(JSON.stringify(result.summarizedMessages)).not.toContain(
+      "retained tail",
+    );
     expect(mockSaveChatSummary).toHaveBeenCalledWith(
       expect.objectContaining({
         chatId: "chat-tail-only",
         summaryUpToMessageId: "assistant-huge",
-        metadata: expect.objectContaining({
-          retainedTail: expect.objectContaining({
-            start_message_id: "assistant-huge",
-            start_part_index: 0,
-            projected_part_count: 1,
-          }),
+        metadata: expect.not.objectContaining({
+          retainedTail: expect.anything(),
         }),
       }),
     );
@@ -758,7 +759,8 @@ describe("checkAndSummarizeIfNeeded", () => {
     const saveSummaryCall =
       mockSaveChatSummary.mock.calls[mockSaveChatSummary.mock.calls.length - 1];
     const persistedMetadata = saveSummaryCall?.[0].metadata as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     expect(persistedMetadata?.inputTokens).toBeUndefined();
     expect(persistedMetadata?.outputTokens).toBeUndefined();
     expect(persistedMetadata?.cacheReadTokens).toBeUndefined();

--- a/lib/chat/summarization/__tests__/retained-tail.test.ts
+++ b/lib/chat/summarization/__tests__/retained-tail.test.ts
@@ -75,7 +75,7 @@ describe("retained tail selection", () => {
     expect(result.tailMessages[0].parts).toHaveLength(2);
   });
 
-  it("projects an oversized latest tool part without storing payload in metadata", () => {
+  it("omits an oversized latest tool part from the retained tail", () => {
     const hugeOutput = "secret-output ".repeat(10_000);
     const messages: UIMessage[] = [
       {
@@ -97,11 +97,60 @@ describe("retained tail selection", () => {
     });
 
     expect(result.cutoffMessageId).toBe("assistant-1");
-    expect(result.headMessages).toEqual([]);
+    expect(result.headMessages).toEqual(messages);
+    expect(result.retainedTail).toBeUndefined();
+    expect(result.tailMessages).toEqual([]);
+  });
+
+  it("keeps later text without converting oversized tool output to text", () => {
+    const hugeOutput = "secret-output ".repeat(10_000);
+    const messages: UIMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-run_terminal_cmd",
+            input: { command: "cat large.log" },
+            state: "output-available",
+            output: hugeOutput,
+          } as any,
+          { type: "text", text: "latest result" },
+        ],
+      },
+    ];
+
+    const result = selectRetainedTailForSummarization(messages, {
+      budgetTokens: safeCountTokens("latest result"),
+    });
+
+    expect(result.retainedTail).toMatchObject({
+      start_message_id: "assistant-1",
+      start_part_index: 1,
+      projected_part_count: 0,
+    });
+    expect(result.headMessages[0].parts).toEqual(messages[0].parts.slice(0, 1));
+    expect(result.tailMessages[0].parts).toEqual([
+      { type: "text", text: "latest result" },
+    ]);
+    expect(JSON.stringify(result.tailMessages)).not.toContain("secret-output");
+    expect(JSON.stringify(result.tailMessages)).not.toContain("retained tail");
+  });
+
+  it("uses neutral wording when shortening oversized text", () => {
+    const messages = [
+      textMessage("assistant-1", "assistant", "important detail ".repeat(500)),
+    ];
+
+    const result = selectRetainedTailForSummarization(messages, {
+      budgetTokens: 64,
+    });
+    const retainedText = (result.tailMessages[0].parts[0] as { text: string })
+      .text;
+
     expect(result.retainedTail?.projected_part_count).toBe(1);
-    expect(JSON.stringify(result.retainedTail)).not.toContain("secret-output");
-    expect(JSON.stringify(result.tailMessages)).not.toContain(hugeOutput);
-    expect(JSON.stringify(result.tailMessages)).toContain("retained tail");
+    expect(retainedText).toContain("Earlier text shortened");
+    expect(retainedText).not.toContain("retained tail");
   });
 
   it("omits reasoning and status-only parts from the retained tail", () => {

--- a/lib/chat/summarization/retained-tail.ts
+++ b/lib/chat/summarization/retained-tail.ts
@@ -129,11 +129,7 @@ const projectPartToBudget = (
   }
 
   let projectedTokens = estimatePartTokens(projected, fileTokens);
-  if (
-    projectedTokens > maxTokens &&
-    projected.type === "text" &&
-    "text" in projected
-  ) {
+  if (projectedTokens > maxTokens) {
     projected = {
       ...projected,
       text: truncateContent(

--- a/lib/chat/summarization/retained-tail.ts
+++ b/lib/chat/summarization/retained-tail.ts
@@ -102,64 +102,6 @@ const estimatePartsTokens = (
 ): number =>
   parts.reduce((sum, part) => sum + estimatePartTokens(part, fileTokens), 0);
 
-const textPart = (text: string): UIMessage["parts"][number] =>
-  ({ type: "text", text }) as UIMessage["parts"][number];
-
-const compactFilePart = (
-  part: UIMessage["parts"][number],
-): UIMessage["parts"][number] => {
-  const record = part as Record<string, unknown>;
-  const mediaType =
-    typeof record.mediaType === "string"
-      ? record.mediaType
-      : typeof record.mimeType === "string"
-        ? record.mimeType
-        : "file";
-  const name =
-    typeof record.filename === "string"
-      ? record.filename
-      : typeof record.name === "string"
-        ? record.name
-        : "file";
-  return textPart(
-    `[Attached ${mediaType}: ${name} omitted from retained tail]`,
-  );
-};
-
-const compactToolPart = (
-  part: UIMessage["parts"][number],
-  maxTokens: number,
-): UIMessage["parts"][number] => {
-  const record = part as Record<string, unknown>;
-  const type = typeof record.type === "string" ? record.type : "tool";
-  const toolName = type.startsWith("tool-") ? type.slice("tool-".length) : type;
-  const output = record.output;
-  const outputText =
-    output == null
-      ? ""
-      : truncateContent(
-          stringifyForTokens(output),
-          "\n[Tool output shortened for retained tail]\n",
-          Math.max(1, maxTokens - 64),
-        );
-
-  const compacted = {
-    ...record,
-    output:
-      outputText.length > 0
-        ? `[${toolName} output preview for retained tail]\n${outputText}`
-        : `[${toolName} output omitted for retained tail]`,
-  } as UIMessage["parts"][number];
-
-  if (safeCountTokens(stringifyForTokens(compacted)) <= maxTokens) {
-    return compacted;
-  }
-
-  return textPart(
-    `[Tool: ${toolName} completed; details omitted from retained tail]`,
-  );
-};
-
 const projectPartToBudget = (
   part: UIMessage["parts"][number],
   maxTokens: number,
@@ -178,18 +120,12 @@ const projectPartToBudget = (
       ...part,
       text: truncateContent(
         (part as { text?: string }).text ?? "",
-        "\n[Retained tail text shortened]\n",
+        "\n[Earlier text shortened]\n",
         maxTokens,
       ),
     } as UIMessage["parts"][number];
-  } else if (part.type === "file") {
-    projected = compactFilePart(part);
-  } else if (typeof part.type === "string" && part.type.startsWith("tool-")) {
-    projected = compactToolPart(part, maxTokens);
   } else {
-    projected = textPart(
-      `[${part.type || "message part"} omitted from retained tail: ${currentTokens} tokens]`,
-    );
+    return null;
   }
 
   let projectedTokens = estimatePartTokens(projected, fileTokens);
@@ -202,7 +138,7 @@ const projectPartToBudget = (
       ...projected,
       text: truncateContent(
         (projected as { text?: string }).text ?? "",
-        "\n[Retained tail placeholder shortened]\n",
+        "\n[Earlier text shortened]\n",
         maxTokens,
       ),
     } as UIMessage["parts"][number];


### PR DESCRIPTION
## Summary
- drop oversized non-text retained-tail parts instead of converting them into assistant text placeholders
- keep real later text in the continuation tail and use neutral wording when text must be shortened
- update summarization tests so oversized tool output is summarized through bounded preview but not retained as model-visible placeholder text

## Why
A reported Agent run compacted context under provider pressure, then MiniMax continued from synthetic retained-tail text like `[Tool: run_terminal_cmd completed; details omitted from retained tail]`. Those placeholders were meant for internal budgeting, but because they were normal assistant text parts they could leak into visible output and derail continuation.

## Validation
- `./node_modules/.bin/jest lib/chat/summarization/__tests__/retained-tail.test.ts lib/chat/summarization/__tests__/index.test.ts convex/__tests__/chatSummaryFallback.test.ts --runInBand`
- `./node_modules/.bin/prettier --check lib/chat/summarization/retained-tail.ts lib/chat/summarization/__tests__/retained-tail.test.ts lib/chat/summarization/__tests__/index.test.ts`
- `./node_modules/.bin/eslint lib/chat/summarization/retained-tail.ts lib/chat/summarization/__tests__/retained-tail.test.ts lib/chat/summarization/__tests__/index.test.ts`
- `./node_modules/.bin/tsc --noEmit`

## Manual verification
- Re-run an Agent conversation that triggers provider-pressure compaction with many large tool results.
- Confirm the next model call does not receive `[Tool: ... retained tail]` or `[Attached ... retained tail]` as assistant text.
- Confirm recent real assistant text after an oversized tool result is still retained when it fits the retained-tail budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Oversized tool output handling in chat summarization/retained-tail now avoids adding extra “retained tail” text and no longer includes oversized payloads in serialized results.
  * Tool output previews are incorporated into prompts more consistently, while any “retained tail” markers are excluded from stored/visible tail content.
  * Tail text shortening now uses the clearer “earlier text shortened” wording.

* **Tests**
  * Updated retained-tail and summarization tests to match the new text-only truncation expectations and persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->