### PR TITLE
Reduce Vercel log noise for root posts

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -41,19 +41,25 @@ function createRequest({
   accept = "application/json",
   hasSession = false,
   userAgent = "BetterStack",
+  method = "GET",
+  headers = {},
 }: {
   pathname: string;
   accept?: string;
   hasSession?: boolean;
   userAgent?: string;
+  method?: string;
+  headers?: Record<string, string>;
 }): NextRequest {
   const url = new URL(pathname, "https://hackerai.co");
   return {
+    method,
     nextUrl: url,
     url: url.toString(),
     headers: new Headers({
       accept,
       "user-agent": userAgent,
+      ...headers,
     }),
     cookies: {
       has: jest.fn((name: string) => name === "wos-session" && hasSession),
@@ -85,6 +91,48 @@ describe("proxy", () => {
     expect(mockNextResponseNext).toHaveBeenCalledWith();
     expect(mockNextResponseJson).not.toHaveBeenCalled();
     expect(mockNextResponseRedirect).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-action root POSTs before AuthKit", async () => {
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/index",
+        method: "POST",
+      }),
+    );
+
+    expect(response).toMatchObject({ kind: "json" });
+    expect(mockAuthkit).not.toHaveBeenCalled();
+    expect(mockNextResponseJson).toHaveBeenCalledWith(
+      {
+        code: "method_not_allowed",
+        message: "POST is not supported for this route.",
+      },
+      { status: 405, headers: { Allow: "GET, HEAD" } },
+    );
+  });
+
+  it("lets root Server Action POSTs continue through AuthKit", async () => {
+    mockAuthkit.mockResolvedValue({
+      session: { user: { id: "user_123" } },
+      headers: new Headers(),
+      authorizationUrl: undefined,
+    });
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/",
+        method: "POST",
+        headers: { "next-action": "action-id" },
+      }),
+    );
+
+    expect(response).toMatchObject({ kind: "next" });
+    expect(mockAuthkit).toHaveBeenCalledTimes(1);
+    expect(mockNextResponseJson).not.toHaveBeenCalled();
   });
 
   it("still requires auth for protected API routes", async () => {

--- a/lib/auth/__tests__/expected-auth-errors.test.ts
+++ b/lib/auth/__tests__/expected-auth-errors.test.ts
@@ -27,6 +27,21 @@ describe("expected auth errors", () => {
     expect(isEndedSessionRefreshError(error)).toBe(true);
   });
 
+  it("matches inactivity-ended session refresh errors", () => {
+    const error = Object.assign(
+      new Error("Failed to refresh session: Error: invalid_grant"),
+      {
+        name: "TokenRefreshError",
+        cause: {
+          error: "invalid_grant",
+          errorDescription: "Session ended due to inactivity.",
+        },
+      },
+    );
+
+    expect(isEndedSessionRefreshError(error)).toBe(true);
+  });
+
   it("does not match unrelated invalid_grant refresh errors as ended sessions", () => {
     const error = Object.assign(new Error("Error: invalid_grant"), {
       error: "invalid_grant",

--- a/lib/auth/expected-auth-errors.ts
+++ b/lib/auth/expected-auth-errors.ts
@@ -1,5 +1,7 @@
 const INVALID_GRANT_ERROR = "invalid_grant";
 const SESSION_ENDED_MESSAGE = "session has already ended";
+const SESSION_ENDED_DUE_TO_INACTIVITY_MESSAGE =
+  "session ended due to inactivity";
 const INVALID_CODE_VERIFIER_MESSAGE = "invalid code verifier";
 const SIGN_IN_SESSION_UNVERIFIED_MESSAGE =
   "sign-in session could not be verified";
@@ -51,7 +53,8 @@ export const isEndedSessionRefreshError = (value: unknown): boolean => {
   const errorText = collectAuthErrorText(value).toLowerCase();
   return (
     errorText.includes(INVALID_GRANT_ERROR) &&
-    errorText.includes(SESSION_ENDED_MESSAGE)
+    (errorText.includes(SESSION_ENDED_MESSAGE) ||
+      errorText.includes(SESSION_ENDED_DUE_TO_INACTIVITY_MESSAGE))
   );
 };
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -10,6 +10,8 @@ import {
 } from "@/lib/referrals/config";
 
 const AUTHKIT_BYPASS_PATHS = new Set(["/api/health/trigger-agent-mode"]);
+const ROOT_PAGE_POST_PATHS = new Set(["/", "/index"]);
+const NEXT_ACTION_HEADER = "next-action";
 
 const UNAUTHENTICATED_PATHS = new Set([
   ...AUTHKIT_BYPASS_PATHS,
@@ -62,6 +64,17 @@ function isUnauthenticatedPath(pathname: string): boolean {
 
 function shouldBypassAuthkit(pathname: string): boolean {
   return AUTHKIT_BYPASS_PATHS.has(pathname);
+}
+
+function isUnsupportedRootPagePost(
+  request: NextRequest,
+  pathname: string,
+): boolean {
+  return (
+    request.method === "POST" &&
+    ROOT_PAGE_POST_PATHS.has(pathname) &&
+    !request.headers.has(NEXT_ACTION_HEADER)
+  );
 }
 
 function isBrowserRequest(request: NextRequest): boolean {
@@ -143,6 +156,16 @@ function buildEndedSessionResponse(
 
 export default async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
+
+  if (isUnsupportedRootPagePost(request, pathname)) {
+    return NextResponse.json(
+      {
+        code: "method_not_allowed",
+        message: "POST is not supported for this route.",
+      },
+      { status: 405, headers: { Allow: "GET, HEAD" } },
+    );
+  }
 
   if (shouldBypassAuthkit(pathname)) {
     return NextResponse.next();


### PR DESCRIPTION
## Summary
- reject unsupported non-Server-Action POSTs to `/` and `/index` in `proxy.ts` with a 405 before Next tries to parse scanner payloads
- keep real root Server Action POSTs flowing through AuthKit by requiring the `next-action` header for the guard
- classify AuthKit `invalid_grant` + "Session ended due to inactivity" as expected session lifecycle noise

## Production log triage
- 24h Vercel error sample: 50 unique errors, all `POST /` or `POST /index`
- 47 malformed JSON/parser errors and 2 malformed action-payload errors looked like automated scanner traffic
- 1 stale AuthKit session refresh error is expected lifecycle behavior
- warning sample contained stale Server Action IDs, treated as old-tab/deployment skew and left as warn-level

## Validation
- `./node_modules/.bin/jest __tests__/proxy.test.ts lib/auth/__tests__/expected-auth-errors.test.ts --runInBand`
- `./node_modules/.bin/prettier --check proxy.ts __tests__/proxy.test.ts lib/auth/expected-auth-errors.ts lib/auth/__tests__/expected-auth-errors.test.ts`
- `./node_modules/.bin/eslint proxy.ts __tests__/proxy.test.ts lib/auth/expected-auth-errors.ts lib/auth/__tests__/expected-auth-errors.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

## Manual verification
Automated validation is sufficient. No UI or browser-visible behavior changed beyond returning 405 for unsupported root POSTs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Root `POST` requests to `/` and `/index` are now rejected with a clear `405 Method Not Allowed` response when they aren’t valid app actions.
  * Requests with a `next-action` header can still proceed normally through authentication handling.
  * Session refresh errors are now more reliably recognized when a session has ended due to inactivity, improving error handling for expired sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->