### PR TITLE
Avoid assistant loop fallback for fenced code output

### DIFF
--- a/lib/chat/__tests__/agent-long-provider-retry.test.ts
+++ b/lib/chat/__tests__/agent-long-provider-retry.test.ts
@@ -184,4 +184,49 @@ describe("assistant content loop detection", () => {
 
     expect(detection.detected).toBe(false);
   });
+
+  it("does not flag repeated structural code inside fenced blocks", () => {
+    const xamlAnswer = [
+      "Here is the fixed SettingsPanel.xaml:",
+      "```xml",
+      "<Grid.RowDefinitions>",
+      '  <RowDefinition Height="Auto"/>',
+      '  <RowDefinition Height="Auto"/>',
+      '  <RowDefinition Height="Auto"/>',
+      '  <RowDefinition Height="Auto"/>',
+      '  <RowDefinition Height="Auto"/>',
+      '  <RowDefinition Height="Auto"/>',
+      "</Grid.RowDefinitions>",
+      "```",
+    ].join("\n");
+
+    const detection = detectAssistantContentLoopFromText(xamlAnswer);
+
+    expect(detection.detected).toBe(false);
+    expect(
+      shouldRetryAgentLongWithFallback(
+        [{ type: "step-start" }, { type: "text", text: xamlAnswer }],
+        { hasTerminalProviderStreamError: false },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not flag repeated structural code in an open fenced block while streaming", () => {
+    const monitor = createAssistantContentLoopMonitor();
+    let detected = false;
+
+    for (const delta of [
+      "```xml\n<Grid.RowDefinitions>\n",
+      '  <RowDefinition Height="Auto"/>\n',
+      '  <RowDefinition Height="Auto"/>\n',
+      '  <RowDefinition Height="Auto"/>\n',
+      '  <RowDefinition Height="Auto"/>\n',
+      '  <RowDefinition Height="Auto"/>\n',
+      '  <RowDefinition Height="Auto"/>\n',
+    ]) {
+      detected = monitor.appendDelta(delta).detected || detected;
+    }
+
+    expect(detected).toBe(false);
+  });
 });

--- a/lib/chat/agent-long-provider-retry.ts
+++ b/lib/chat/agent-long-provider-retry.ts
@@ -67,8 +67,13 @@ const isReasoningOnlyProviderOutput = (parts: unknown[]): boolean =>
   hasReasoningPart(parts) &&
   parts.every(isFallbackSafeProviderPart);
 
-const normalizeAssistantLoopText = (text: string): string =>
+const stripFencedCodeBlocks = (text: string): string =>
   text
+    .replace(/```[\s\S]*?(?:```|$)/g, " ")
+    .replace(/~~~[\s\S]*?(?:~~~|$)/g, " ");
+
+const normalizeAssistantLoopText = (text: string): string =>
+  stripFencedCodeBlocks(text)
     .toLowerCase()
     .replace(/\[[^\]]*tool[^\]]*\]/gi, " ")
     .replace(/\s+/g, " ")


### PR DESCRIPTION
## Summary
- Ignore fenced Markdown code blocks before assistant-content loop tokenization
- Cover repeated XAML structural lines in both completed and still-streaming code fences

## Validation
- corepack pnpm exec jest lib/chat/__tests__/agent-long-provider-retry.test.ts --runInBand
- corepack pnpm exec prettier --check lib/chat/agent-long-provider-retry.ts lib/chat/__tests__/agent-long-provider-retry.test.ts
- corepack pnpm lint (passes with existing warnings)
- corepack pnpm typecheck
- git diff --check

Visual verification: not needed; backend stream retry detection only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assistant loop detection so repeated text inside code blocks is less likely to trigger unnecessary retries.
  * Streaming responses with an unfinished fenced code block are now handled more accurately during loop checks.
* **Tests**
  * Added coverage for repeated code inside complete and in-progress fenced blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->