### PR TITLE
Set chat sidebar width to 300px

### DIFF
--- a/app/components/ChatLayout.tsx
+++ b/app/components/ChatLayout.tsx
@@ -126,7 +126,7 @@ export function ChatLayout({ children }: { children: React.ReactNode }) {
         <div
           data-testid="sidebar"
           className={`relative z-10 min-w-0 shrink-0 overflow-hidden bg-sidebar transition-all duration-300 ${
-            chatSidebarOpen ? "w-72" : "w-12"
+            chatSidebarOpen ? "w-[300px]" : "w-12"
           }`}
         >
           <SidebarProvider

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -56,7 +56,7 @@ const DesktopSidebarContent: FC<{
     <Sidebar
       side="left"
       collapsible="icon"
-      className={`${isMobile ? "w-full" : "w-72"}`}
+      className={`${isMobile ? "w-full" : "w-[300px]"}`}
     >
       <SidebarHeader>
         <SidebarHeaderContent

--- a/app/share/[shareId]/SharedChatView.tsx
+++ b/app/share/[shareId]/SharedChatView.tsx
@@ -254,7 +254,9 @@ export function SharedChatView({ shareId }: SharedChatViewProps) {
           {!isMobile && !authLoading && user && (
             <div
               className={`transition-all duration-300 ${
-                chatSidebarOpen ? "w-72 flex-shrink-0" : "w-12 flex-shrink-0"
+                chatSidebarOpen
+                  ? "w-[300px] flex-shrink-0"
+                  : "w-12 flex-shrink-0"
               }`}
             >
               <SidebarProvider

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/components/ui/tooltip";
 
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = "16rem";
+const SIDEBAR_WIDTH = "300px";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "s";


### PR DESCRIPTION
## Summary
- set the expanded left chat sidebar width to 300px in the main chat layout
- align the shared chat view and sidebar primitive default width with the same 300px value
- leave collapsed, mobile, and right tool sidebar sizing unchanged

## Validation
- git diff --check
- /Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules/.bin/prettier --check app/components/ChatLayout.tsx app/components/Sidebar.tsx 'app/share/[shareId]/SharedChatView.tsx' components/ui/sidebar.tsx
- /Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules/.bin/eslint app/components/ChatLayout.tsx app/components/Sidebar.tsx 'app/share/[shareId]/SharedChatView.tsx' components/ui/sidebar.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized the desktop sidebar width to 300px across chat, shared chat, and sidebar layouts.
  * Kept mobile behavior and collapsed sidebar sizes unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->