### PR TITLE
Add inline preview for attached files

### DIFF
--- a/app/components/FileContentViewer.tsx
+++ b/app/components/FileContentViewer.tsx
@@ -1,0 +1,202 @@
+import { Download, FileText, Loader2, X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { isTextViewableFile } from "@/lib/utils/file-utils";
+import { LocalDesktopFile } from "@/types/file";
+
+const isBrowserFile = (file: File | LocalDesktopFile): file is File =>
+  typeof globalThis.File !== "undefined" && file instanceof globalThis.File;
+
+/** Guard against freezing the UI on very large text files */
+const MAX_PREVIEW_CHARS = 500_000;
+
+interface FileContentViewerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  file: File | LocalDesktopFile;
+  fileName: string;
+}
+
+export const FileContentViewer = ({
+  isOpen,
+  onClose,
+  file,
+  fileName,
+}: FileContentViewerProps) => {
+  const [content, setContent] = useState<string>("");
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [truncated, setTruncated] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    let cancelled = false;
+
+    const loadContent = async () => {
+      setIsLoading(true);
+      setError(null);
+      setTruncated(false);
+
+      if (!isBrowserFile(file) || !isTextViewableFile(file)) {
+        if (!cancelled) {
+          setError("Preview isn't available for this file type.");
+          setIsLoading(false);
+        }
+        return;
+      }
+
+      try {
+        const text = await file.text();
+        if (cancelled) return;
+
+        if (text.length > MAX_PREVIEW_CHARS) {
+          setContent(text.slice(0, MAX_PREVIEW_CHARS));
+          setTruncated(true);
+        } else {
+          setContent(text);
+        }
+      } catch {
+        if (!cancelled) setError("Failed to read file content.");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    loadContent();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, file]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  const handleDownload = useCallback(async () => {
+    if (!isBrowserFile(file)) return;
+
+    const blobUrl = URL.createObjectURL(file);
+    const link = document.createElement("a");
+    link.href = blobUrl;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(blobUrl);
+  }, [file, fileName]);
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  if (!isOpen) return null;
+
+  const canDownload = isBrowserFile(file);
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4"
+      onClick={handleBackdropClick}
+      role="presentation"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Preview of ${fileName}`}
+        className="pointer-events-auto flex h-[calc(100vh-32px)] w-[calc(100vw-32px)] max-w-[1200px] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-[0px_0px_8px_0px_rgba(0,0,0,0.02)] md:h-[calc(100vh-80px)] md:w-[calc(100vw-80px)]"
+      >
+        <header className="flex h-14 shrink-0 items-center justify-between gap-4 border-b border-border px-4 py-3">
+          <div className="flex min-w-0 flex-1 items-center gap-2 text-muted-foreground">
+            <div className="flex size-9 shrink-0 items-center justify-center">
+              <FileText className="size-5" aria-hidden="true" />
+            </div>
+            <span
+              className="truncate text-sm font-medium leading-5 text-foreground"
+              title={fileName}
+            >
+              {fileName}
+            </span>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-1">
+            {canDownload && (
+              <button
+                type="button"
+                onClick={handleDownload}
+                aria-label="Download file"
+                className="flex size-8 cursor-pointer items-center justify-center rounded-lg transition-colors hover:bg-accent"
+              >
+                <Download
+                  className="size-[18px] text-muted-foreground"
+                  aria-hidden="true"
+                />
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close file preview"
+              className="flex size-8 cursor-pointer items-center justify-center rounded-lg transition-colors hover:bg-accent"
+            >
+              <X
+                className="size-[18px] text-muted-foreground"
+                aria-hidden="true"
+              />
+            </button>
+          </div>
+        </header>
+
+        <div className="relative flex min-h-0 w-full flex-1">
+          {isLoading ? (
+            <div className="flex h-full w-full items-center justify-center">
+              <Loader2 className="size-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : error ? (
+            <div className="flex h-full w-full flex-col items-center justify-center gap-3 px-6 text-center">
+              <FileText
+                className="size-10 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <p className="text-sm text-muted-foreground">{error}</p>
+              {canDownload && (
+                <button
+                  type="button"
+                  onClick={handleDownload}
+                  className="inline-flex items-center gap-2 rounded-full border border-border px-3 py-1.5 text-sm text-foreground transition-colors hover:bg-accent"
+                >
+                  <Download className="size-4" aria-hidden="true" />
+                  Download
+                </button>
+              )}
+            </div>
+          ) : (
+            <div
+              className="w-full overflow-auto px-4 py-[15px] font-mono text-xs leading-[18px] text-foreground"
+              style={{
+                overflowWrap: "break-word",
+                wordBreak: "normal",
+                whiteSpace: "pre-wrap",
+              }}
+            >
+              <pre className="max-w-full whitespace-pre-wrap">{content}</pre>
+              {truncated && (
+                <p className="mt-4 text-xs italic text-muted-foreground">
+                  Preview truncated — download the file to view its full
+                  contents.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/components/FileContentViewer.tsx
+++ b/app/components/FileContentViewer.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useAction } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
-import { isTextViewableFile } from "@/lib/utils/file-utils";
+import { isPdfFile, isTextViewableFile } from "@/lib/utils/file-utils";
 import { LocalDesktopFile } from "@/types/file";
 import { useFileUrlCacheContext } from "../contexts/FileUrlCacheContext";
 
@@ -35,6 +35,7 @@ export const FileContentViewer = ({
   const getFileUrlAction = useAction(api.s3Actions.getFileUrlAction);
   const fileUrlCache = useFileUrlCacheContext();
   const [content, setContent] = useState<string>("");
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [truncated, setTruncated] = useState<boolean>(false);
@@ -55,16 +56,25 @@ export const FileContentViewer = ({
     if (!isOpen) return;
 
     let cancelled = false;
+    // Blob URL created for in-memory PDF previews; must be revoked on cleanup.
+    let createdBlobUrl: string | null = null;
 
     const loadContent = async () => {
       setIsLoading(true);
       setError(null);
       setTruncated(false);
+      setPdfUrl(null);
+      setContent("");
 
-      // Text-viewability is based on name/media type, so it works for both real
+      const pdf = isPdfFile(file);
+
+      // Previewability is based on name/media type, so it works for both real
       // browser Files and the metadata-only descriptor restored from a draft.
       // Without an in-memory File or an S3 file id there is nothing to read.
-      if (!isTextViewableFile(file) || (!isBrowserFile(file) && !fileId)) {
+      if (
+        (!pdf && !isTextViewableFile(file)) ||
+        (!isBrowserFile(file) && !fileId)
+      ) {
         if (!cancelled) {
           setError("Preview isn't available for this file type.");
           setIsLoading(false);
@@ -73,6 +83,28 @@ export const FileContentViewer = ({
       }
 
       try {
+        if (pdf) {
+          // Render via the browser's native PDF viewer. In-memory files use a
+          // blob URL; restored-from-draft files use a short-lived signed URL.
+          let url: string;
+          if (isBrowserFile(file)) {
+            createdBlobUrl = URL.createObjectURL(file);
+            url = createdBlobUrl;
+          } else {
+            const signedUrl = await resolveFileUrl(fileId!);
+            if (!signedUrl) throw new Error("Could not resolve file URL");
+            url = signedUrl;
+          }
+
+          if (cancelled) {
+            if (createdBlobUrl) URL.revokeObjectURL(createdBlobUrl);
+            return;
+          }
+
+          setPdfUrl(url);
+          return;
+        }
+
         let text: string;
 
         if (isBrowserFile(file)) {
@@ -109,6 +141,7 @@ export const FileContentViewer = ({
 
     return () => {
       cancelled = true;
+      if (createdBlobUrl) URL.revokeObjectURL(createdBlobUrl);
     };
   }, [isOpen, file, fileId, resolveFileUrl]);
 
@@ -226,6 +259,12 @@ export const FileContentViewer = ({
                 </button>
               )}
             </div>
+          ) : pdfUrl ? (
+            <iframe
+              src={pdfUrl}
+              title={`Preview of ${fileName}`}
+              className="h-full w-full border-0"
+            />
           ) : (
             <div
               className="w-full overflow-auto px-4 py-[15px] font-mono text-xs leading-[18px] text-foreground"

--- a/app/components/FileContentViewer.tsx
+++ b/app/components/FileContentViewer.tsx
@@ -1,7 +1,11 @@
 import { Download, FileText, Loader2, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { useAction } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
 import { isTextViewableFile } from "@/lib/utils/file-utils";
 import { LocalDesktopFile } from "@/types/file";
+import { useFileUrlCacheContext } from "../contexts/FileUrlCacheContext";
 
 const isBrowserFile = (file: File | LocalDesktopFile): file is File =>
   typeof globalThis.File !== "undefined" && file instanceof globalThis.File;
@@ -14,6 +18,11 @@ interface FileContentViewerProps {
   onClose: () => void;
   file: File | LocalDesktopFile;
   fileName: string;
+  /**
+   * S3 file id for attachments restored from a draft after reload, where the
+   * in-memory File (and its content) is no longer available.
+   */
+  fileId?: string;
 }
 
 export const FileContentViewer = ({
@@ -21,11 +30,26 @@ export const FileContentViewer = ({
   onClose,
   file,
   fileName,
+  fileId,
 }: FileContentViewerProps) => {
+  const getFileUrlAction = useAction(api.s3Actions.getFileUrlAction);
+  const fileUrlCache = useFileUrlCacheContext();
   const [content, setContent] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [truncated, setTruncated] = useState<boolean>(false);
+
+  const resolveFileUrl = useCallback(
+    async (id: string): Promise<string | null> => {
+      const cachedUrl = fileUrlCache?.getCachedUrl(id);
+      if (cachedUrl) return cachedUrl;
+
+      const url = await getFileUrlAction({ fileId: id as Id<"files"> });
+      if (url) fileUrlCache?.setCachedUrl(id, url);
+      return url;
+    },
+    [fileUrlCache, getFileUrlAction],
+  );
 
   useEffect(() => {
     if (!isOpen) return;
@@ -37,7 +61,10 @@ export const FileContentViewer = ({
       setError(null);
       setTruncated(false);
 
-      if (!isBrowserFile(file) || !isTextViewableFile(file)) {
+      // Text-viewability is based on name/media type, so it works for both real
+      // browser Files and the metadata-only descriptor restored from a draft.
+      // Without an in-memory File or an S3 file id there is nothing to read.
+      if (!isTextViewableFile(file) || (!isBrowserFile(file) && !fileId)) {
         if (!cancelled) {
           setError("Preview isn't available for this file type.");
           setIsLoading(false);
@@ -46,7 +73,23 @@ export const FileContentViewer = ({
       }
 
       try {
-        const text = await file.text();
+        let text: string;
+
+        if (isBrowserFile(file)) {
+          text = await file.text();
+        } else {
+          // Restored-from-draft attachment: fetch content from storage using a
+          // short-lived signed URL keyed by the file id.
+          const url = await resolveFileUrl(fileId!);
+          if (!url) throw new Error("Could not resolve file URL");
+
+          const response = await fetch(url);
+          if (!response.ok) {
+            throw new Error(`Failed to fetch file (${response.status})`);
+          }
+          text = await response.text();
+        }
+
         if (cancelled) return;
 
         if (text.length > MAX_PREVIEW_CHARS) {
@@ -67,7 +110,7 @@ export const FileContentViewer = ({
     return () => {
       cancelled = true;
     };
-  }, [isOpen, file]);
+  }, [isOpen, file, fileId, resolveFileUrl]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -81,17 +124,23 @@ export const FileContentViewer = ({
   }, [isOpen, onClose]);
 
   const handleDownload = useCallback(async () => {
-    if (!isBrowserFile(file)) return;
+    if (isBrowserFile(file)) {
+      const blobUrl = URL.createObjectURL(file);
+      const link = document.createElement("a");
+      link.href = blobUrl;
+      link.download = fileName;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(blobUrl);
+      return;
+    }
 
-    const blobUrl = URL.createObjectURL(file);
-    const link = document.createElement("a");
-    link.href = blobUrl;
-    link.download = fileName;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(blobUrl);
-  }, [file, fileName]);
+    if (fileId) {
+      const url = await resolveFileUrl(fileId);
+      if (url) window.open(url, "_blank", "noopener,noreferrer");
+    }
+  }, [file, fileName, fileId, resolveFileUrl]);
 
   const handleBackdropClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) onClose();
@@ -99,7 +148,7 @@ export const FileContentViewer = ({
 
   if (!isOpen) return null;
 
-  const canDownload = isBrowserFile(file);
+  const canDownload = isBrowserFile(file) || !!fileId;
 
   return (
     <div

--- a/app/components/FileUploadPreview.tsx
+++ b/app/components/FileUploadPreview.tsx
@@ -8,6 +8,7 @@ import {
   isImageFile,
 } from "@/lib/utils/file-utils";
 import { ImageViewer } from "./ImageViewer";
+import { FileContentViewer } from "./FileContentViewer";
 import {
   UploadedFileState,
   FileUploadPreviewProps,
@@ -26,6 +27,10 @@ export const FileUploadPreview = ({
   const [selectedImage, setSelectedImage] = useState<{
     src: string;
     alt: string;
+  } | null>(null);
+  const [selectedFile, setSelectedFile] = useState<{
+    file: File | LocalDesktopFile;
+    name: string;
   } | null>(null);
 
   // Use ref to store base64 previews to avoid regenerating them
@@ -97,6 +102,10 @@ export const FileUploadPreview = ({
 
   const handleImageClick = (preview: string, fileName: string) => {
     setSelectedImage({ src: preview, alt: fileName });
+  };
+
+  const handleFileClick = (file: File | LocalDesktopFile, fileName: string) => {
+    setSelectedFile({ file, name: fileName });
   };
 
   return (
@@ -186,7 +195,17 @@ export const FileUploadPreview = ({
                         )}
                       </button>
                     ) : (
-                      <div className="p-2 w-80">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          handleFileClick(
+                            filePreview.file,
+                            filePreview.file.name,
+                          )
+                        }
+                        className="w-80 p-2 text-left transition-colors hover:bg-accent"
+                        aria-label={`View ${filePreview.file.name}`}
+                      >
                         <div className="flex flex-row items-center gap-2">
                           <div
                             className={`relative h-10 w-10 shrink-0 overflow-hidden rounded-lg flex items-center justify-center ${
@@ -218,7 +237,7 @@ export const FileUploadPreview = ({
                             </div>
                           </div>
                         </div>
-                      </div>
+                      </button>
                     )}
                   </div>
                 </div>
@@ -249,6 +268,16 @@ export const FileUploadPreview = ({
           onClose={() => setSelectedImage(null)}
           imageSrc={selectedImage.src}
           imageAlt={selectedImage.alt}
+        />
+      )}
+
+      {/* File Content Viewer Modal */}
+      {selectedFile && (
+        <FileContentViewer
+          isOpen={!!selectedFile}
+          onClose={() => setSelectedFile(null)}
+          file={selectedFile.file}
+          fileName={selectedFile.name}
         />
       )}
     </>

--- a/app/components/FileUploadPreview.tsx
+++ b/app/components/FileUploadPreview.tsx
@@ -31,6 +31,7 @@ export const FileUploadPreview = ({
   const [selectedFile, setSelectedFile] = useState<{
     file: File | LocalDesktopFile;
     name: string;
+    fileId?: string;
   } | null>(null);
 
   // Use ref to store base64 previews to avoid regenerating them
@@ -119,8 +120,12 @@ export const FileUploadPreview = ({
     setSelectedImage({ src: preview, alt: fileName });
   };
 
-  const handleFileClick = (file: File | LocalDesktopFile, fileName: string) => {
-    setSelectedFile({ file, name: fileName });
+  const handleFileClick = (
+    file: File | LocalDesktopFile,
+    fileName: string,
+    fileId?: string,
+  ) => {
+    setSelectedFile({ file, name: fileName, fileId });
   };
 
   return (
@@ -216,6 +221,7 @@ export const FileUploadPreview = ({
                           handleFileClick(
                             filePreview.file,
                             filePreview.file.name,
+                            uploadedFiles[index]?.fileId,
                           )
                         }
                         className="w-80 p-2 text-left transition-colors hover:bg-accent"
@@ -293,6 +299,7 @@ export const FileUploadPreview = ({
           onClose={() => setSelectedFile(null)}
           file={selectedFile.file}
           fileName={selectedFile.name}
+          fileId={selectedFile.fileId}
         />
       )}
     </>

--- a/app/components/FileUploadPreview.tsx
+++ b/app/components/FileUploadPreview.tsx
@@ -94,6 +94,21 @@ export const FileUploadPreview = ({
     }
   }, [uploadedFiles, generateFileKey]);
 
+  // Close the content viewer when its underlying file is removed so it can't
+  // keep showing stale content for an attachment no longer in the list.
+  const handleRemoveFile = useCallback(
+    (index: number) => {
+      const removedFile = uploadedFiles[index]?.file;
+      if (removedFile) {
+        setSelectedFile((current) =>
+          current?.file === removedFile ? null : current,
+        );
+      }
+      onRemoveFile(index);
+    },
+    [uploadedFiles, onRemoveFile],
+  );
+
   if (!uploadedFiles || uploadedFiles.length === 0) {
     return null;
   }
@@ -245,7 +260,7 @@ export const FileUploadPreview = ({
                 <div className="absolute end-1.5 top-1.5 inline-flex gap-1">
                   <Button
                     type="button"
-                    onClick={() => onRemoveFile(index)}
+                    onClick={() => handleRemoveFile(index)}
                     variant="secondary"
                     size="sm"
                     className="transition-colors flex h-6 w-6 items-center justify-center rounded-full border-[rgba(0,0,0,0.1)] bg-black text-white dark:border-[rgba(255,255,255,0.1)] dark:bg-white dark:text-black p-0"

--- a/lib/utils/file-utils.ts
+++ b/lib/utils/file-utils.ts
@@ -122,6 +122,14 @@ const TEXT_VIEWABLE_EXTENSIONS = new Set([
 ]);
 
 /**
+ * Check if a file is a PDF (by media type, with an extension fallback)
+ */
+export function isPdfFile(file: File | LocalDesktopFile): boolean {
+  if (file.type?.toLowerCase() === "application/pdf") return true;
+  return file.name.split(".").pop()?.toLowerCase() === "pdf";
+}
+
+/**
  * Check if a file's content can be previewed as plain text.
  * Uses the media type first, then falls back to the file extension for
  * files that arrive with a generic/empty type.

--- a/lib/utils/file-utils.ts
+++ b/lib/utils/file-utils.ts
@@ -56,6 +56,85 @@ export function isImageFile(file: File | LocalDesktopFile): boolean {
   return file.type.startsWith("image/");
 }
 
+/** Media types (besides text/*) whose content can be shown as plain text */
+const TEXT_VIEWABLE_MEDIA_TYPES = new Set([
+  "application/json",
+  "application/xml",
+  "application/javascript",
+  "application/x-javascript",
+  "application/typescript",
+  "application/x-typescript",
+  "application/x-sh",
+  "application/x-yaml",
+  "application/yaml",
+  "application/csv",
+  "application/sql",
+]);
+
+/** File extensions whose content can be shown as plain text */
+const TEXT_VIEWABLE_EXTENSIONS = new Set([
+  "txt",
+  "md",
+  "markdown",
+  "mdx",
+  "csv",
+  "tsv",
+  "json",
+  "jsonl",
+  "xml",
+  "yaml",
+  "yml",
+  "toml",
+  "ini",
+  "env",
+  "log",
+  "js",
+  "jsx",
+  "ts",
+  "tsx",
+  "mjs",
+  "cjs",
+  "html",
+  "htm",
+  "css",
+  "scss",
+  "sass",
+  "less",
+  "py",
+  "rb",
+  "go",
+  "rs",
+  "java",
+  "kt",
+  "c",
+  "h",
+  "cpp",
+  "cc",
+  "hpp",
+  "cs",
+  "php",
+  "sh",
+  "bash",
+  "zsh",
+  "sql",
+  "graphql",
+  "gql",
+]);
+
+/**
+ * Check if a file's content can be previewed as plain text.
+ * Uses the media type first, then falls back to the file extension for
+ * files that arrive with a generic/empty type.
+ */
+export function isTextViewableFile(file: File | LocalDesktopFile): boolean {
+  const mediaType = file.type?.toLowerCase() ?? "";
+  if (mediaType.startsWith("text/")) return true;
+  if (TEXT_VIEWABLE_MEDIA_TYPES.has(mediaType)) return true;
+
+  const extension = file.name.split(".").pop()?.toLowerCase() ?? "";
+  return TEXT_VIEWABLE_EXTENSIONS.has(extension);
+}
+
 /**
  * Validate file for upload
  */


### PR DESCRIPTION
## Summary
- Add a `FileContentViewer` modal that shows the text contents of a non-image attachment when the user clicks its chip in the chat input.
- Make the non-image attachment chip clickable and add a `hover:bg-accent` hover affordance.
- Add an `isTextViewableFile` helper (media-type + extension based) to decide which attachments can be previewed as text.

## Details
- The viewer reads the local `File` via `file.text()`, renders it in a monospace, `whitespace-pre-wrap` block, and matches the app's design tokens (header with file name + download/close, Escape-to-close, backdrop click-to-close).
- Very large files (>500k chars) are truncated in the preview with a note to download for full contents.
- Binary / desktop-local attachments (no in-browser `File`) show a graceful "preview not available" fallback with a download option.
- Images continue to use the existing `ImageViewer`.

## Test plan
- [ ] Attach a `.txt` / `.md` / `.json` / code file and click the chip → content shows in the modal.
- [ ] Hover over an attachment chip → background highlight appears.
- [ ] Close via X, backdrop click, and Escape.
- [ ] Attach a PDF / binary file → "preview not available" fallback with Download.
- [ ] Images still open in the image viewer.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a non-image viewing modal with async text/PDF preview, loading/error handling, and truncated large text previews.
  * Extended preview and download behavior to support draft-restored files via an optional file identifier.
  * Improved plain-text preview eligibility using enhanced MIME/extension allowlists.
* **Bug Fixes**
  * Prevented the file preview modal from displaying stale content after removing an attachment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->