### PR TITLE
Show ellipsis for sidebar chat titles

### DIFF
--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -119,6 +119,9 @@ const ChatItem: React.FC<ChatItemProps> = ({
   // During a route transition, prefer the clicked chat immediately so a busy
   // streaming chat does not keep the old row highlighted until navigation commits.
   const isCurrentlyActive = selectedChatId === id;
+  const showActions = Boolean(
+    isHovered || isCurrentlyActive || isDropdownOpen || isMobile,
+  );
 
   useEffect(() => {
     if (optimisticChatId && optimisticChatId === routeChatId) {
@@ -337,14 +340,12 @@ const ChatItem: React.FC<ChatItemProps> = ({
       data-testid={`chat-item-${id}`}
     >
       <div
-        className={`mr-2 min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm font-medium ${
-          isHovered || isCurrentlyActive || isDropdownOpen || isMobile
-            ? "[-webkit-mask-image:var(--sidebar-mask-active)] [mask-image:var(--sidebar-mask-active)]"
-            : "[-webkit-mask-image:var(--sidebar-mask)] [mask-image:var(--sidebar-mask)]"
+        className={`mr-2 min-w-0 flex-1 overflow-hidden text-sm font-medium ${
+          showActions ? "pr-7" : ""
         }`}
         dir="auto"
       >
-        <span className="flex items-center gap-1.5">
+        <span className="flex min-w-0 items-center gap-1.5">
           {isStreaming && (
             <LoaderCircle
               className="size-3 flex-shrink-0 animate-spin text-muted-foreground"
@@ -369,15 +370,13 @@ const ChatItem: React.FC<ChatItemProps> = ({
               </Tooltip>
             </TooltipProvider>
           )}
-          {title}
+          <span className="min-w-0 truncate">{title}</span>
         </span>
       </div>
 
       <div
         className={`absolute right-2 opacity-0 transition-opacity ${
-          isHovered || isCurrentlyActive || isDropdownOpen || isMobile
-            ? "opacity-100"
-            : ""
+          showActions ? "opacity-100" : ""
         }`}
       >
         <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>

--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -376,8 +376,9 @@ const ChatItem: React.FC<ChatItemProps> = ({
 
       <div
         className={`absolute right-2 opacity-0 transition-opacity ${
-          showActions ? "opacity-100" : ""
+          showActions ? "opacity-100" : "pointer-events-none"
         }`}
+        aria-hidden={!showActions}
       >
         <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
           <DropdownMenuTrigger asChild>
@@ -385,6 +386,7 @@ const ChatItem: React.FC<ChatItemProps> = ({
               variant="ghost"
               size="sm"
               className="h-6 w-6 p-0 hover:bg-sidebar-accent"
+              tabIndex={showActions ? 0 : -1}
               onClick={(e) => {
                 e.stopPropagation();
                 e.preventDefault();

--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -119,9 +119,7 @@ const ChatItem: React.FC<ChatItemProps> = ({
   // During a route transition, prefer the clicked chat immediately so a busy
   // streaming chat does not keep the old row highlighted until navigation commits.
   const isCurrentlyActive = selectedChatId === id;
-  const showActions = Boolean(
-    isHovered || isCurrentlyActive || isDropdownOpen || isMobile,
-  );
+  const showActions = Boolean(isHovered || isDropdownOpen || isMobile);
 
   useEffect(() => {
     if (optimisticChatId && optimisticChatId === routeChatId) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -99,22 +99,6 @@
   --scrollbar-track: var(--background);
   --scrollbar-thumb: rgba(0, 0, 0, 0.2);
   --scrollbar-thumb-hover: rgba(0, 0, 0, 0.3);
-
-  /* Sidebar text mask for truncation */
-  --sidebar-mask: linear-gradient(
-    90deg,
-    #000 0%,
-    #000 95%,
-    transparent 100%,
-    transparent 100%
-  );
-  --sidebar-mask-active: linear-gradient(
-    90deg,
-    #000 0%,
-    #000 88%,
-    transparent 93%,
-    transparent 100%
-  );
 }
 
 .dark {
@@ -165,22 +149,6 @@
   --scrollbar-track: var(--background);
   --scrollbar-thumb: rgba(255, 255, 255, 0.2);
   --scrollbar-thumb-hover: rgba(255, 255, 255, 0.3);
-
-  /* Sidebar text mask for truncation */
-  --sidebar-mask: linear-gradient(
-    90deg,
-    #000 0%,
-    #000 95%,
-    transparent 100%,
-    transparent 100%
-  );
-  --sidebar-mask-active: linear-gradient(
-    90deg,
-    #000 0%,
-    #000 88%,
-    transparent 93%,
-    transparent 100%
-  );
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- replace the left chat history title fade mask with native `text-overflow: ellipsis`
- reserve action-button space only when row actions are visible so hover controls do not overlap truncated titles
- remove now-unused sidebar mask CSS variables

## Verification
- `git diff --check origin/main..HEAD`
- `/Users/hackerai/Developer/github.com/hackerai-tech/hackerai/node_modules/.bin/prettier --check app/components/ChatItem.tsx app/globals.css`
- `./node_modules/.bin/eslint app/components/ChatItem.tsx`
- local Playwright visual check at `http://localhost:3310` with a temporary long-title pro test chat: verified `text-overflow: ellipsis`, no mask image, visible `...` in normal state, and no overlap with the options button on hover

## Notes
PR #831 was merged before this follow-up commit could attach to it, so this PR carries only the title truncation fix on top of current `main`. The 300px width from #831 widens the sidebar wrapper; the existing flex title area receives that extra room automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat item title truncation and spacing so it remains readable and doesn’t interfere with action controls.
  * Fixed chat item actions dropdown visibility and interaction across hover, active, dropdown-open, and mobile states.
* **Refactor**
  * Streamlined chat item rendering logic for consistent layout and accessibility behavior.
* **Style**
  * Updated sidebar gradient masking styles by removing custom theme mask variables for both light and dark modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->