### PR TITLE
Apply billing multiplier to provider cost deductions

### DIFF
--- a/lib/rate-limit/__tests__/index.test.ts
+++ b/lib/rate-limit/__tests__/index.test.ts
@@ -11,6 +11,8 @@ describe("checkRateLimit", () => {
   const mockEvalFn = jest.fn();
   const mockCheckTokenBucketLimit = jest.fn();
   const mockCreateRedisClient = jest.fn();
+  const mockPointsPerDollar = 10_000;
+  const mockUsageMultiplier = 1.3;
 
   beforeEach(() => {
     jest.resetModules();
@@ -36,8 +38,8 @@ describe("checkRateLimit", () => {
       }));
 
       jest.doMock("../token-bucket", () => ({
-        POINTS_PER_DOLLAR: 10_000,
-        NORMAL_USAGE_MULTIPLIER: 1.3,
+        POINTS_PER_DOLLAR: mockPointsPerDollar,
+        NORMAL_USAGE_MULTIPLIER: mockUsageMultiplier,
         checkTokenBucketLimit: mockCheckTokenBucketLimit,
         deductUsage: jest.fn(),
         refundUsage: jest.fn(),
@@ -48,7 +50,15 @@ describe("checkRateLimit", () => {
           Number.isFinite(costDollars) && costDollars > 0
             ? Math.max(
                 1,
-                Math.ceil(Number((costDollars * 10_000 * 1.3).toFixed(6))),
+                Math.ceil(
+                  Number(
+                    (
+                      costDollars *
+                      mockPointsPerDollar *
+                      mockUsageMultiplier
+                    ).toFixed(6),
+                  ),
+                ),
               )
             : 0,
       }));

--- a/lib/rate-limit/__tests__/index.test.ts
+++ b/lib/rate-limit/__tests__/index.test.ts
@@ -36,12 +36,21 @@ describe("checkRateLimit", () => {
       }));
 
       jest.doMock("../token-bucket", () => ({
+        POINTS_PER_DOLLAR: 10_000,
+        NORMAL_USAGE_MULTIPLIER: 1.3,
         checkTokenBucketLimit: mockCheckTokenBucketLimit,
         deductUsage: jest.fn(),
         refundUsage: jest.fn(),
         calculateTokenCost: jest.fn(),
         getBudgetLimits: jest.fn(),
         getSubscriptionPrice: jest.fn(),
+        billableCostDollarsToPoints: (costDollars: number) =>
+          Number.isFinite(costDollars) && costDollars > 0
+            ? Math.max(
+                1,
+                Math.ceil(Number((costDollars * 10_000 * 1.3).toFixed(6))),
+              )
+            : 0,
       }));
 
       isolatedModule = require("../index");

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -412,13 +412,14 @@ describe("token-bucket async functions", () => {
     });
 
     it("should refund when provider cost is less than estimated (over-estimation)", async () => {
-      const { deductUsage, calculateTokenCost } = getIsolatedModule();
+      const { deductUsage, calculateTokenCost, billableCostDollarsToPoints } =
+        getIsolatedModule();
 
-      // Estimate: 10000 input tokens = 50 points
+      // Estimate: 10000 input tokens = 65 billable points
       const estimatedInputTokens = 10000;
       const estimatedCost = calculateTokenCost(estimatedInputTokens, "input");
 
-      // Actual provider cost: $0.002 = 20 points (less than 50)
+      // Actual provider cost: $0.002 = 26 billable points
       const providerCostDollars = 0.002;
 
       await deductUsage(
@@ -431,9 +432,9 @@ describe("token-bucket async functions", () => {
         providerCostDollars,
       );
 
-      // Should refund the difference (50 - 20 = 30 points)
+      // Should refund the difference (65 - 26 = 39 points)
       const expectedRefund =
-        estimatedCost - Math.ceil(providerCostDollars * 10000);
+        estimatedCost - billableCostDollarsToPoints(providerCostDollars);
       expect(mockHincrbyFn).toHaveBeenCalledWith(
         expect.stringContaining("usage:monthly"),
         "tokens",
@@ -447,7 +448,7 @@ describe("token-bucket async functions", () => {
       const { deductUsage, calculateTokenCost } = getIsolatedModule();
       const estimatedInputTokens = 7600;
       const estimatedCost = calculateTokenCost(estimatedInputTokens, "input");
-      const providerCostDollars = 0.004;
+      const providerCostDollars = 0.003;
 
       expect(estimatedCost).toBe(50);
 
@@ -468,11 +469,11 @@ describe("token-bucket async functions", () => {
         },
       );
 
-      expect(mockRefundToBalance).toHaveBeenCalledWith("user-123", 10);
+      expect(mockRefundToBalance).toHaveBeenCalledWith("user-123", 11);
       expect(mockHincrbyFn).not.toHaveBeenCalled();
       expect(result).toEqual({
         includedPointsDeducted: 17,
-        extraUsagePointsDeducted: 23,
+        extraUsagePointsDeducted: 22,
         uncoveredPoints: 0,
         usageDeductionFailed: false,
       });
@@ -511,7 +512,7 @@ describe("token-bucket async functions", () => {
       expect(result).toEqual({
         includedPointsDeducted: 17,
         extraUsagePointsDeducted: 33,
-        uncoveredPoints: 10,
+        uncoveredPoints: 28,
         usageDeductionFailed: true,
         usageDeductionFailureReason: "deduction_failed",
       });
@@ -521,11 +522,11 @@ describe("token-bucket async functions", () => {
     it("should refund when token-based actual cost is less than estimated", async () => {
       const { deductUsage, calculateTokenCost } = getIsolatedModule();
 
-      // Estimate: 10000 input tokens = 50 points (pre-deducted)
+      // Estimate: 10000 input tokens = 65 billable points (pre-deducted)
       const estimatedInputTokens = 10000;
       const estimatedCost = calculateTokenCost(estimatedInputTokens, "input");
 
-      // Actual: 2000 input + 500 output = 10 + 15 = 25 points
+      // Actual: 2000 input + 500 output = 13 + 20 = 33 billable points
       const actualInputTokens = 2000;
       const actualOutputTokens = 500;
       const actualCost =
@@ -542,7 +543,7 @@ describe("token-bucket async functions", () => {
         undefined, // no provider cost, use token calculation
       );
 
-      // Should refund the difference (50 - 25 = 25 points)
+      // Should refund the difference (65 - 33 = 32 points)
       const expectedRefund = estimatedCost - actualCost;
       expect(mockHincrbyFn).toHaveBeenCalledWith(
         expect.stringContaining("usage:monthly"),
@@ -552,14 +553,13 @@ describe("token-bucket async functions", () => {
     });
 
     it("should not refund or charge when actual cost equals estimated", async () => {
-      const { deductUsage, calculateTokenCost } = getIsolatedModule();
+      const { deductUsage } = getIsolatedModule();
 
-      // Estimate: 1000 input tokens = 5 points
-      const estimatedInputTokens = 1000;
-      const estimatedCost = calculateTokenCost(estimatedInputTokens, "input");
+      // Estimate: 10000 input tokens = 65 billable points
+      const estimatedInputTokens = 10000;
 
-      // Actual provider cost exactly matches: $0.0005 = 5 points
-      const providerCostDollars = estimatedCost / 10000;
+      // Actual provider cost exactly matches after applying the billable multiplier.
+      const providerCostDollars = 0.005;
 
       await deductUsage(
         "user-123",
@@ -577,12 +577,12 @@ describe("token-bucket async functions", () => {
     });
 
     it("should charge additional when actual cost exceeds estimated", async () => {
-      const { deductUsage, calculateTokenCost } = getIsolatedModule();
+      const { deductUsage } = getIsolatedModule();
 
-      // Estimate: 1000 input tokens = 5 points (pre-deducted)
+      // Estimate: 1000 input tokens = 7 billable points (pre-deducted)
       const estimatedInputTokens = 1000;
 
-      // Actual provider cost: $0.005 = 50 points (much more than 5)
+      // Actual provider cost: $0.005 = 65 billable points (much more than 7)
       const providerCostDollars = 0.005;
 
       await deductUsage(
@@ -662,7 +662,8 @@ describe("token-bucket async functions", () => {
     });
 
     it("should prefer raw provider cost over served fallback token pricing", async () => {
-      const { deductUsage, calculateTokenCost } = getIsolatedModule();
+      const { deductUsage, calculateTokenCost, billableCostDollarsToPoints } =
+        getIsolatedModule();
 
       const estimatedInputTokens = 1_000_000;
       const selectedModel = "agent-model-free";
@@ -673,7 +674,8 @@ describe("token-bucket async functions", () => {
         "input",
         selectedModel,
       );
-      const expectedProviderCost = Math.ceil(providerCostDollars * 10_000);
+      const expectedProviderCost =
+        billableCostDollarsToPoints(providerCostDollars);
       const expectedAdditional = expectedProviderCost - initialDeduction;
 
       mockLimitFn
@@ -705,7 +707,7 @@ describe("token-bucket async functions", () => {
         servedModel,
       );
 
-      expect(expectedAdditional).toBe(300);
+      expect(expectedAdditional).toBe(1_560);
       expect(mockLimitFn).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ rate: expectedAdditional }),
@@ -874,9 +876,9 @@ describe("token-bucket async functions", () => {
         limit: 250000,
       });
 
-      // Estimated 1000 input = 7 points (with 1.3x), actual provider cost = $0.005 = 50 points
-      // Difference = 50 - 7 = 43 additional needed
-      // Bucket has 10, so fromBucket=10, fromExtraUsage=33
+      // Estimated 1000 input = 7 points, actual provider cost = $0.005 = 65 billable points.
+      // Difference = 65 - 7 = 58 additional needed.
+      // Bucket has 10, so fromBucket=10, fromExtraUsage=48.
       const result = await deductUsage(
         "user-123",
         "pro",
@@ -896,11 +898,11 @@ describe("token-bucket async functions", () => {
         expect.any(String),
         expect.objectContaining({ rate: 10 }),
       );
-      // Should deduct the overflow (33) from extra usage
-      expect(mockDeductFromBalance).toHaveBeenCalledWith("user-123", 33);
+      // Should deduct the overflow (48) from extra usage
+      expect(mockDeductFromBalance).toHaveBeenCalledWith("user-123", 48);
       expect(result).toEqual({
         includedPointsDeducted: 17,
-        extraUsagePointsDeducted: 33,
+        extraUsagePointsDeducted: 48,
         uncoveredPoints: 0,
         usageDeductionFailed: false,
       });
@@ -938,11 +940,11 @@ describe("token-bucket async functions", () => {
         0.005,
       );
 
-      expect(mockDeductFromBalance).toHaveBeenCalledWith("user-123", 33);
+      expect(mockDeductFromBalance).toHaveBeenCalledWith("user-123", 48);
       expect(result).toEqual({
         includedPointsDeducted: 17,
         extraUsagePointsDeducted: 0,
-        uncoveredPoints: 33,
+        uncoveredPoints: 48,
         usageDeductionFailed: true,
         usageDeductionFailureReason: "insufficient_funds",
       });
@@ -984,7 +986,7 @@ describe("token-bucket async functions", () => {
       expect(result).toEqual({
         includedPointsDeducted: 17,
         extraUsagePointsDeducted: 0,
-        uncoveredPoints: 33,
+        uncoveredPoints: 48,
         usageDeductionFailed: true,
         usageDeductionFailureReason: "monthly_cap_exceeded",
       });
@@ -1028,7 +1030,7 @@ describe("token-bucket async functions", () => {
       expect(result).toEqual({
         includedPointsDeducted: 17,
         extraUsagePointsDeducted: 0,
-        uncoveredPoints: 33,
+        uncoveredPoints: 48,
         usageDeductionFailed: true,
         usageDeductionFailureReason: "auto_reload_failed",
       });
@@ -1076,12 +1078,12 @@ describe("token-bucket async functions", () => {
       expect(mockDeductFromTeamBalance).toHaveBeenCalledWith(
         "org-123",
         "user-123",
-        33,
+        48,
       );
       expect(result).toEqual({
         includedPointsDeducted: 17,
         extraUsagePointsDeducted: 0,
-        uncoveredPoints: 33,
+        uncoveredPoints: 48,
         usageDeductionFailed: true,
         usageDeductionFailureReason: "member_cap_exceeded",
       });
@@ -1284,13 +1286,13 @@ describe("token-bucket async functions", () => {
         undefined,
         0,
         undefined,
-        { pointsDeducted: 17, extraUsagePointsDeducted: 33 },
+        { pointsDeducted: 32, extraUsagePointsDeducted: 33 },
       );
 
       expect(mockLimitFn).not.toHaveBeenCalled();
       expect(mockDeductFromBalance).not.toHaveBeenCalled();
       expect(result).toEqual({
-        includedPointsDeducted: 17,
+        includedPointsDeducted: 32,
         extraUsagePointsDeducted: 33,
         uncoveredPoints: 0,
         usageDeductionFailed: false,
@@ -1356,18 +1358,18 @@ describe("token-bucket async functions", () => {
 
   describe("provider cost vs token cost paths", () => {
     it("should produce different deductions when provider cost differs from token calculation", async () => {
-      const { deductUsage, calculateTokenCost } = getIsolatedModule();
+      const { deductUsage, calculateTokenCost, billableCostDollarsToPoints } =
+        getIsolatedModule();
 
       const estimatedInput = 10000;
-      const estimatedCost = calculateTokenCost(estimatedInput, "input");
 
       // Path 1: token-based (actual = 10000 input + 1000 output)
       const tokenActualCost =
         calculateTokenCost(10000, "input") + calculateTokenCost(1000, "output");
 
-      // Path 2: provider cost ($0.01 = 100 points)
+      // Path 2: provider cost ($0.01 = 130 billable points)
       const providerCost = 0.01;
-      const providerCostPoints = Math.ceil(providerCost * 10000);
+      const providerCostPoints = billableCostDollarsToPoints(providerCost);
 
       // These should differ
       expect(tokenActualCost).not.toBe(providerCostPoints);

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "@jest/globals";
 
 import {
+  billableCostDollarsToPoints,
   calculateTokenCost,
   calculateRawTokenCost,
   calculateProratedCredits,
@@ -187,6 +188,19 @@ describe("token-bucket", () => {
   describe("POINTS_PER_DOLLAR", () => {
     it("should be 10000 (1 point = $0.0001)", () => {
       expect(POINTS_PER_DOLLAR).toBe(10_000);
+    });
+  });
+
+  describe("billableCostDollarsToPoints", () => {
+    it("applies the normal usage multiplier to raw provider and tool cost", () => {
+      expect(billableCostDollarsToPoints(1)).toBe(13_000);
+      expect(billableCostDollarsToPoints(0.005)).toBe(65);
+    });
+
+    it("returns 0 for non-positive or invalid cost", () => {
+      expect(billableCostDollarsToPoints(0)).toBe(0);
+      expect(billableCostDollarsToPoints(-1)).toBe(0);
+      expect(billableCostDollarsToPoints(Number.NaN)).toBe(0);
     });
   });
 

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -195,6 +195,7 @@ describe("token-bucket", () => {
     it("applies the normal usage multiplier to raw provider and tool cost", () => {
       expect(billableCostDollarsToPoints(1)).toBe(13_000);
       expect(billableCostDollarsToPoints(0.005)).toBe(65);
+      expect(billableCostDollarsToPoints(0.000000000001)).toBe(1);
     });
 
     it("returns 0 for non-positive or invalid cost", () => {

--- a/lib/rate-limit/__tests__/usage-settlement.test.ts
+++ b/lib/rate-limit/__tests__/usage-settlement.test.ts
@@ -68,7 +68,7 @@ describe("usage-settlement", () => {
         currentCostDollars: 8.71,
       }),
     ).toBe(true);
-    expect(getUnsettledUsagePoints(state, 8.71)).toBe(86_100);
+    expect(getUnsettledUsagePoints(state, 8.71)).toBe(112_230);
   });
 
   it("updates cumulative settled totals after a mid-run deduction", () => {

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -39,6 +39,7 @@ export {
   addOrgRemovedUsage,
   clearOrgRemovedUsage,
   applyTeamSeatDebt,
+  billableCostDollarsToPoints,
   calculateTokenCost,
   calculateRawTokenCost,
   getBudgetLimits,

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -61,6 +61,18 @@ export const POINTS_PER_DOLLAR = 10_000;
  */
 export const NORMAL_USAGE_MULTIPLIER = 1.3;
 
+/** Convert raw provider/tool spend into billable user-balance points. */
+export const billableCostDollarsToPoints = (costDollars: number): number =>
+  Number.isFinite(costDollars) && costDollars > 0
+    ? Math.ceil(
+        Number(
+          (costDollars * POINTS_PER_DOLLAR * NORMAL_USAGE_MULTIPLIER).toFixed(
+            6,
+          ),
+        ),
+      )
+    : 0;
+
 /** 30 days in seconds — used for Redis TTLs aligned with billing cycles. */
 const THIRTY_DAYS_SECONDS = 30 * 24 * 60 * 60;
 const REDIS_SCAN_COUNT = 500;
@@ -815,11 +827,12 @@ export const deductUsage = async (
     });
     lastKnownDeductionResult = buildDeductionResult();
 
-    // Calculate actual cost - prefer provider cost if available.
+    // Calculate actual billable cost - prefer provider cost if available.
     // Provider cost already includes non-model costs (sandbox/tools) when present.
-    // When absent (non-clean streams), add non-model costs on top of token-based estimate.
+    // When absent (non-clean streams), add billable non-model costs on top of
+    // token-based model pricing.
     if (providerCostDollars !== undefined && providerCostDollars > 0) {
-      actualCostPoints = Math.ceil(providerCostDollars * POINTS_PER_DOLLAR);
+      actualCostPoints = billableCostDollarsToPoints(providerCostDollars);
     } else {
       const modelForActualCost = actualModelName ?? modelName;
       const actualInputCost = calculateTokenCost(
@@ -834,7 +847,7 @@ export const deductUsage = async (
       );
       const nonModelCostPoints =
         nonModelCostDollars > 0
-          ? Math.ceil(nonModelCostDollars * POINTS_PER_DOLLAR)
+          ? billableCostDollarsToPoints(nonModelCostDollars)
           : 0;
       actualCostPoints = actualInputCost + outputCost + nonModelCostPoints;
     }

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -64,10 +64,13 @@ export const NORMAL_USAGE_MULTIPLIER = 1.3;
 /** Convert raw provider/tool spend into billable user-balance points. */
 export const billableCostDollarsToPoints = (costDollars: number): number =>
   Number.isFinite(costDollars) && costDollars > 0
-    ? Math.ceil(
-        Number(
-          (costDollars * POINTS_PER_DOLLAR * NORMAL_USAGE_MULTIPLIER).toFixed(
-            6,
+    ? Math.max(
+        1,
+        Math.ceil(
+          Number(
+            (costDollars * POINTS_PER_DOLLAR * NORMAL_USAGE_MULTIPLIER).toFixed(
+              6,
+            ),
           ),
         ),
       )

--- a/lib/rate-limit/usage-settlement.ts
+++ b/lib/rate-limit/usage-settlement.ts
@@ -7,8 +7,8 @@ import {
 } from "./token-bucket";
 
 export const MID_RUN_SETTLEMENT_MIN_DELTA_DOLLARS = 0.5;
-export const MID_RUN_SETTLEMENT_MIN_DELTA_POINTS = Math.ceil(
-  MID_RUN_SETTLEMENT_MIN_DELTA_DOLLARS * POINTS_PER_DOLLAR,
+export const MID_RUN_SETTLEMENT_MIN_DELTA_POINTS = billableCostDollarsToPoints(
+  MID_RUN_SETTLEMENT_MIN_DELTA_DOLLARS,
 );
 
 export type UsageSettlementState = {

--- a/lib/rate-limit/usage-settlement.ts
+++ b/lib/rate-limit/usage-settlement.ts
@@ -1,5 +1,6 @@
 import type { ExtraUsageConfig, RateLimitInfo } from "@/types";
 import {
+  billableCostDollarsToPoints,
   POINTS_PER_DOLLAR,
   type UsageDeductionFailureReason,
   type UsageDeductionResult,
@@ -122,7 +123,8 @@ export const getUnsettledUsagePoints = (
 ): number =>
   Math.max(
     0,
-    costDollarsToPoints(currentCostDollars) - getSettledUsagePoints(state),
+    billableCostDollarsToPoints(currentCostDollars) -
+      getSettledUsagePoints(state),
   );
 
 export const shouldSettleUsageMidRun = ({


### PR DESCRIPTION
## Summary
- add a shared conversion helper for raw provider/tool dollars to billable user-balance points
- apply the 1.3x normal usage multiplier when reconciling authoritative provider costs and non-model costs
- apply the same billable conversion to selective mid-run settlement while keeping raw usage/unit-economics cost fields unchanged

## Testing
- ./node_modules/.bin/jest lib/rate-limit/__tests__/token-bucket.test.ts lib/rate-limit/__tests__/usage-settlement.test.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts --runInBand
- ./node_modules/.bin/eslint lib/rate-limit/token-bucket.ts lib/rate-limit/usage-settlement.ts lib/rate-limit/index.ts lib/rate-limit/__tests__/token-bucket.test.ts lib/rate-limit/__tests__/usage-settlement.test.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts
- ./node_modules/.bin/prettier --check lib/rate-limit/token-bucket.ts lib/rate-limit/usage-settlement.ts lib/rate-limit/index.ts lib/rate-limit/__tests__/token-bucket.test.ts lib/rate-limit/__tests__/usage-settlement.test.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts
- ./node_modules/.bin/tsc --noEmit

## Manual verification
- In a paid account with provider-reported cost, run a request that reports authoritative model cost and/or tool cost.
- Confirm the user monthly bucket or extra usage balance is deducted by billable points equal to raw total cost * 1.3.
- Confirm usage logs and unit economics still show raw model/non-model/total cost, not billable markup.

No visual verification needed: backend-only billing/rate-limit settlement change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `billableCostDollarsToPoints` to convert billable dollar amounts into points with consistent rounding and safe handling for zero/negative/invalid inputs.
  * Re-exported the helper from the rate-limit module for external use.
* **Bug Fixes**
  * Improved accuracy of token-bucket accounting for cost/refunds/charges, including split deductions and unsettled usage/settlement outcomes.
* **Tests**
  * Added unit tests for the new conversion helper.
  * Updated token-bucket and usage-settlement test expectations to align with revised point computations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->