### PR TITLE
Add free Agent value upgrade nudge

### DIFF
--- a/app/components/PricingDialog.tsx
+++ b/app/components/PricingDialog.tsx
@@ -71,20 +71,6 @@ export function getPricingIntentCopy(
   const limitType = context?.limitType;
   const reason = context?.reason;
 
-  if (source === "free_agent_value_reached") {
-    return {
-      title: "Keep Agent running in the cloud",
-      description:
-        "You just ran Agent locally. Upgrade for cloud Agent, longer runs, stronger models, file uploads, and higher limits.",
-      proDescription: "Cloud Agent with higher limits",
-      proPlusDescription: "More room for repeated Agent runs",
-      ultraDescription: "Maximum room for serious workloads",
-      proButtonText: "Use cloud Agent",
-      proPlusButtonText: "Get more Agent usage",
-      ultraButtonText: "Get Ultra",
-    };
-  }
-
   if (source === "agent_mode_gate") {
     return {
       title: "Unlock cloud Agent mode",

--- a/app/components/PricingDialog.tsx
+++ b/app/components/PricingDialog.tsx
@@ -71,6 +71,20 @@ export function getPricingIntentCopy(
   const limitType = context?.limitType;
   const reason = context?.reason;
 
+  if (source === "free_agent_value_reached") {
+    return {
+      title: "Keep Agent running in the cloud",
+      description:
+        "You just ran Agent locally. Upgrade for cloud Agent, longer runs, stronger models, file uploads, and higher limits.",
+      proDescription: "Cloud Agent with higher limits",
+      proPlusDescription: "More room for repeated Agent runs",
+      ultraDescription: "Maximum room for serious workloads",
+      proButtonText: "Use cloud Agent",
+      proPlusButtonText: "Get more Agent usage",
+      ultraButtonText: "Get Ultra",
+    };
+  }
+
   if (source === "agent_mode_gate") {
     return {
       title: "Unlock cloud Agent mode",

--- a/app/components/__tests__/PricingDialog.intent-copy.test.ts
+++ b/app/components/__tests__/PricingDialog.intent-copy.test.ts
@@ -40,7 +40,7 @@ describe("getPricingIntentCopy", () => {
     );
   });
 
-  it("uses post-value Agent copy for free Agent success nudges", () => {
+  it("does not use custom pricing copy for free Agent success nudges", () => {
     const copy = getPricingIntentCopy(
       {
         source: "free_agent_value_reached",
@@ -49,12 +49,6 @@ describe("getPricingIntentCopy", () => {
       "free",
     );
 
-    expect(copy).toEqual(
-      expect.objectContaining({
-        title: "Keep Agent running in the cloud",
-        description: expect.stringContaining("You just ran Agent locally"),
-        proButtonText: "Use cloud Agent",
-      }),
-    );
+    expect(copy).toBeNull();
   });
 });

--- a/app/components/__tests__/PricingDialog.intent-copy.test.ts
+++ b/app/components/__tests__/PricingDialog.intent-copy.test.ts
@@ -39,4 +39,22 @@ describe("getPricingIntentCopy", () => {
       }),
     );
   });
+
+  it("uses post-value Agent copy for free Agent success nudges", () => {
+    const copy = getPricingIntentCopy(
+      {
+        source: "free_agent_value_reached",
+        reason: "post_success_agent_run",
+      },
+      "free",
+    );
+
+    expect(copy).toEqual(
+      expect.objectContaining({
+        title: "Keep Agent running in the cloud",
+        description: expect.stringContaining("You just ran Agent locally"),
+        proButtonText: "Use cloud Agent",
+      }),
+    );
+  });
 });

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -55,6 +55,7 @@ import { captureUpgradeCtaImpression } from "@/lib/analytics/client";
 import {
   FREE_AGENT_VALUE_NUDGE_ANALYTICS,
   FREE_AGENT_VALUE_NUDGE_PART_TYPE,
+  FREE_AGENT_VALUE_NUDGE_STORAGE_PREFIX,
 } from "@/lib/chat/free-agent-value-nudge";
 import { redirectToPricing } from "@/app/hooks/usePricingDialog";
 import {
@@ -82,6 +83,38 @@ const AGENT_LONG_COMPLETION_POLL_DELAY_MS = 5_000;
 const AGENT_LONG_COMPLETION_POLL_INTERVAL_MS = 2_000;
 const AGENT_LONG_COMPLETION_QUIET_MS = 3_000;
 const AGENT_LONG_COMPLETION_STOP_GRACE_MS = 6_000;
+const getFreeAgentValueNudgeStorageKey = (chatId: string) =>
+  `${FREE_AGENT_VALUE_NUDGE_STORAGE_PREFIX}${chatId}`;
+
+const hasShownFreeAgentValueNudge = (
+  shownChatIds: Set<string>,
+  chatId: string,
+) => {
+  if (shownChatIds.has(chatId)) return true;
+  if (typeof window === "undefined") return false;
+  try {
+    return (
+      window.localStorage.getItem(getFreeAgentValueNudgeStorageKey(chatId)) ===
+      "1"
+    );
+  } catch {
+    return false;
+  }
+};
+
+const markFreeAgentValueNudgeShown = (
+  shownChatIds: Set<string>,
+  chatId: string,
+) => {
+  shownChatIds.add(chatId);
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(getFreeAgentValueNudgeStorageKey(chatId), "1");
+  } catch {
+    // Losing localStorage only means the nudge can reappear after a reload.
+  }
+};
+
 type MessagePaginationStatus =
   "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
 
@@ -655,11 +688,19 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       setDataStream((ds) => [...ds, { ...dataPart, __chatId: chatId }]);
       switch (dataPart.type) {
         case FREE_AGENT_VALUE_NUDGE_PART_TYPE: {
-          if (shownFreeAgentValueNudgeChatsRef.current.has(chatId)) {
+          if (
+            hasShownFreeAgentValueNudge(
+              shownFreeAgentValueNudgeChatsRef.current,
+              chatId,
+            )
+          ) {
             break;
           }
 
-          shownFreeAgentValueNudgeChatsRef.current.add(chatId);
+          markFreeAgentValueNudgeShown(
+            shownFreeAgentValueNudgeChatsRef.current,
+            chatId,
+          );
           captureUpgradeCtaImpression(FREE_AGENT_VALUE_NUDGE_ANALYTICS);
           toast.info("Agent worked locally", {
             description:

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -51,6 +51,12 @@ import {
 import { isTauriEnvironment } from "@/app/hooks/useTauri";
 import { stripAgentLongHeartbeatPartsFromMessages } from "@/lib/chat/agent-long-heartbeat";
 import { toast } from "sonner";
+import { captureUpgradeCtaImpression } from "@/lib/analytics/client";
+import {
+  FREE_AGENT_VALUE_NUDGE_ANALYTICS,
+  FREE_AGENT_VALUE_NUDGE_PART_TYPE,
+} from "@/lib/chat/free-agent-value-nudge";
+import { redirectToPricing } from "@/app/hooks/usePricingDialog";
 import {
   normalizeSelectedModelForSubscription,
   type Todo,
@@ -500,6 +506,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const isChatMountedRef = useRef(false);
   const browserStreamFinishedRef = useRef(false);
   const activeChatIdRef = useRef(chatId);
+  const shownFreeAgentValueNudgeChatsRef = useRef<Set<string>>(new Set());
   activeChatIdRef.current = chatId;
 
   useEffect(() => {
@@ -647,6 +654,25 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       }
       setDataStream((ds) => [...ds, { ...dataPart, __chatId: chatId }]);
       switch (dataPart.type) {
+        case FREE_AGENT_VALUE_NUDGE_PART_TYPE: {
+          if (shownFreeAgentValueNudgeChatsRef.current.has(chatId)) {
+            break;
+          }
+
+          shownFreeAgentValueNudgeChatsRef.current.add(chatId);
+          captureUpgradeCtaImpression(FREE_AGENT_VALUE_NUDGE_ANALYTICS);
+          toast.info("Agent worked locally", {
+            description:
+              "Upgrade for cloud Agent, longer runs, stronger models, files, and higher limits.",
+            duration: 10000,
+            action: {
+              label: "Upgrade",
+              onClick: () =>
+                redirectToPricing(FREE_AGENT_VALUE_NUDGE_ANALYTICS),
+            },
+          });
+          break;
+        }
         case "data-upload-status": {
           const uploadData = dataPart.data as {
             message: string;

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -55,7 +55,8 @@ import { captureUpgradeCtaImpression } from "@/lib/analytics/client";
 import {
   FREE_AGENT_VALUE_NUDGE_ANALYTICS,
   FREE_AGENT_VALUE_NUDGE_PART_TYPE,
-  FREE_AGENT_VALUE_NUDGE_STORAGE_PREFIX,
+  hasShownFreeAgentValueNudge,
+  markFreeAgentValueNudgeShown,
 } from "@/lib/chat/free-agent-value-nudge";
 import { redirectToPricing } from "@/app/hooks/usePricingDialog";
 import {
@@ -83,38 +84,6 @@ const AGENT_LONG_COMPLETION_POLL_DELAY_MS = 5_000;
 const AGENT_LONG_COMPLETION_POLL_INTERVAL_MS = 2_000;
 const AGENT_LONG_COMPLETION_QUIET_MS = 3_000;
 const AGENT_LONG_COMPLETION_STOP_GRACE_MS = 6_000;
-const getFreeAgentValueNudgeStorageKey = (chatId: string) =>
-  `${FREE_AGENT_VALUE_NUDGE_STORAGE_PREFIX}${chatId}`;
-
-const hasShownFreeAgentValueNudge = (
-  shownChatIds: Set<string>,
-  chatId: string,
-) => {
-  if (shownChatIds.has(chatId)) return true;
-  if (typeof window === "undefined") return false;
-  try {
-    return (
-      window.localStorage.getItem(getFreeAgentValueNudgeStorageKey(chatId)) ===
-      "1"
-    );
-  } catch {
-    return false;
-  }
-};
-
-const markFreeAgentValueNudgeShown = (
-  shownChatIds: Set<string>,
-  chatId: string,
-) => {
-  shownChatIds.add(chatId);
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(getFreeAgentValueNudgeStorageKey(chatId), "1");
-  } catch {
-    // Losing localStorage only means the nudge can reappear after a reload.
-  }
-};
-
 type MessagePaginationStatus =
   "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
 

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, jest } from "@jest/globals";
+import { FREE_AGENT_VALUE_NUDGE_PART_TYPE } from "../../chat/free-agent-value-nudge";
 
 (globalThis as any).Request = class Request {};
 (globalThis as any).Response = class Response {};
@@ -15,10 +16,6 @@ const {
 } = require("../chat-logger");
 const { ChatSDKError } = require("../../errors");
 const { phLogger } = require("../../posthog/server");
-const {
-  FREE_AGENT_VALUE_NUDGE_PART_TYPE,
-} = require("../../chat/free-agent-value-nudge");
-
 describe("captureToolCalls", () => {
   it("aggregates repeated tool calls by tool before sending PostHog events", () => {
     const capture = jest.fn();

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -15,6 +15,9 @@ const {
 } = require("../chat-logger");
 const { ChatSDKError } = require("../../errors");
 const { phLogger } = require("../../posthog/server");
+const {
+  FREE_AGENT_VALUE_NUDGE_PART_TYPE,
+} = require("../../chat/free-agent-value-nudge");
 
 describe("captureToolCalls", () => {
   it("aggregates repeated tool calls by tool before sending PostHog events", () => {
@@ -180,9 +183,11 @@ describe("captureAgentBudgetAbort", () => {
 describe("captureFreeAgentValueReached", () => {
   it("captures a free successful agent value event with user properties", () => {
     const capture = jest.fn();
+    const writer = { write: jest.fn() };
 
     captureFreeAgentValueReached({
       posthog: { capture } as any,
+      writer: writer as any,
       userId: "user_123",
       chatId: "chat_123",
       endpoint: "/api/agent-long",
@@ -217,6 +222,11 @@ describe("captureFreeAgentValueReached", () => {
           last_free_agent_value_reached_at: expect.any(String),
         }),
       }),
+    });
+    expect(writer.write).toHaveBeenCalledWith({
+      type: FREE_AGENT_VALUE_NUDGE_PART_TYPE,
+      data: { reached: true },
+      transient: true,
     });
   });
 
@@ -258,9 +268,11 @@ describe("captureFreeAgentValueReached", () => {
 describe("captureAgentCompletionAnalytics", () => {
   it("captures both agent completion and free value events for successful free agent runs", () => {
     const capture = jest.fn();
+    const writer = { write: jest.fn() };
 
     captureAgentCompletionAnalytics({
       posthog: { capture } as any,
+      writer: writer as any,
       userId: "user_123",
       chatId: "chat_123",
       endpoint: "/api/agent-long",
@@ -295,6 +307,11 @@ describe("captureAgentCompletionAnalytics", () => {
         outcome: "success",
         tool_call_count: 1,
       }),
+    });
+    expect(writer.write).toHaveBeenCalledWith({
+      type: FREE_AGENT_VALUE_NUDGE_PART_TYPE,
+      data: { reached: true },
+      transient: true,
     });
   });
 

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1518,6 +1518,7 @@ export const createChatHandler = () => {
                                   : "success";
                                 captureAgentCompletionAnalytics({
                                   posthog,
+                                  writer,
                                   userId,
                                   chatId,
                                   endpoint,
@@ -1745,6 +1746,7 @@ export const createChatHandler = () => {
                     const outcome = isAborted ? "aborted" : "success";
                     captureAgentCompletionAnalytics({
                       posthog,
+                      writer,
                       userId,
                       chatId,
                       endpoint,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -30,6 +30,8 @@ import {
 } from "@/lib/analytics/paid-funnel";
 import type { UsageCostRecord } from "@/lib/usage-tracker";
 import type { BudgetAbortDetails } from "@/lib/chat/budget-monitor";
+import type { UIMessageStreamWriter } from "ai";
+import { writeFreeAgentValueNudge } from "@/lib/utils/stream-writer-utils";
 import type { OpenRouterModelMetadata } from "@/lib/api/openrouter-metadata";
 import {
   extractErrorDetails,
@@ -1164,6 +1166,7 @@ export type AgentRunOutcome = "success" | "aborted" | "error";
 
 type AgentCompletionAnalyticsArgs = {
   posthog: PostHog | null;
+  writer?: UIMessageStreamWriter;
   userId: string;
   chatId: string;
   endpoint: ChatApiEndpoint;
@@ -1220,6 +1223,7 @@ export function captureAgentRun({
 
 export function captureFreeAgentValueReached({
   posthog,
+  writer,
   userId,
   chatId,
   endpoint,
@@ -1230,6 +1234,7 @@ export function captureFreeAgentValueReached({
   chatLogger,
 }: {
   posthog: PostHog | null;
+  writer?: UIMessageStreamWriter;
   userId: string;
   chatId: string;
   endpoint: ChatApiEndpoint;
@@ -1239,8 +1244,14 @@ export function captureFreeAgentValueReached({
   outcome: AgentRunOutcome;
   chatLogger: ChatLogger | undefined;
 }) {
-  if (!posthog || mode !== "agent" || subscription !== "free") return;
+  if (mode !== "agent" || subscription !== "free") return;
   if (outcome !== "success") return;
+
+  if (writer) {
+    writeFreeAgentValueNudge(writer);
+  }
+
+  if (!posthog) return;
 
   const now = new Date().toISOString();
   const toolCallCount = chatLogger?.getToolCalls().length ?? 0;

--- a/lib/chat/__tests__/free-agent-value-nudge.test.ts
+++ b/lib/chat/__tests__/free-agent-value-nudge.test.ts
@@ -40,4 +40,29 @@ describe("free Agent value nudge", () => {
       true,
     );
   });
+
+  it("falls back when browser localStorage access throws", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("storage blocked");
+      },
+    });
+
+    try {
+      const shownChatIds = new Set<string>();
+      const chatId = "chat-free-agent-value";
+
+      expect(hasShownFreeAgentValueNudge(shownChatIds, chatId)).toBe(false);
+
+      markFreeAgentValueNudgeShown(shownChatIds, chatId);
+
+      expect(hasShownFreeAgentValueNudge(shownChatIds, chatId)).toBe(true);
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(window, "localStorage", descriptor);
+      }
+    }
+  });
 });

--- a/lib/chat/__tests__/free-agent-value-nudge.test.ts
+++ b/lib/chat/__tests__/free-agent-value-nudge.test.ts
@@ -1,0 +1,43 @@
+import {
+  getFreeAgentValueNudgeStorageKey,
+  hasShownFreeAgentValueNudge,
+  markFreeAgentValueNudgeShown,
+} from "../free-agent-value-nudge";
+
+describe("free Agent value nudge", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("marks a nudge as shown in memory and localStorage", () => {
+    const shownChatIds = new Set<string>();
+    const chatId = "chat-free-agent-value";
+
+    expect(hasShownFreeAgentValueNudge(shownChatIds, chatId)).toBe(false);
+
+    markFreeAgentValueNudgeShown(shownChatIds, chatId);
+
+    expect(hasShownFreeAgentValueNudge(shownChatIds, chatId)).toBe(true);
+    expect(
+      window.localStorage.getItem(getFreeAgentValueNudgeStorageKey(chatId)),
+    ).toBe("1");
+  });
+
+  it("uses localStorage to dedupe after a remount clears memory", () => {
+    const chatId = "chat-free-agent-value";
+    window.localStorage.setItem(getFreeAgentValueNudgeStorageKey(chatId), "1");
+
+    expect(hasShownFreeAgentValueNudge(new Set<string>(), chatId)).toBe(true);
+  });
+
+  it("keeps in-memory dedupe when localStorage is unavailable", () => {
+    const shownChatIds = new Set<string>();
+    const chatId = "chat-free-agent-value";
+
+    markFreeAgentValueNudgeShown(shownChatIds, chatId, undefined);
+
+    expect(hasShownFreeAgentValueNudge(shownChatIds, chatId, undefined)).toBe(
+      true,
+    );
+  });
+});

--- a/lib/chat/free-agent-value-nudge.ts
+++ b/lib/chat/free-agent-value-nudge.ts
@@ -1,0 +1,10 @@
+export const FREE_AGENT_VALUE_NUDGE_PART_TYPE =
+  "data-free-agent-value-nudge" as const;
+
+export const FREE_AGENT_VALUE_NUDGE_ANALYTICS = {
+  surface: "free_agent_value_nudge",
+  source: "free_agent_value_reached",
+  reason: "post_success_agent_run",
+  from_tier: "free",
+  cta_text: "Upgrade for cloud Agent",
+} as const;

--- a/lib/chat/free-agent-value-nudge.ts
+++ b/lib/chat/free-agent-value-nudge.ts
@@ -9,7 +9,11 @@ export const getFreeAgentValueNudgeStorageKey = (chatId: string) =>
 
 const getBrowserStorage = () => {
   if (typeof window === "undefined") return undefined;
-  return window.localStorage;
+  try {
+    return window.localStorage;
+  } catch {
+    return undefined;
+  }
 };
 
 export const hasShownFreeAgentValueNudge = (

--- a/lib/chat/free-agent-value-nudge.ts
+++ b/lib/chat/free-agent-value-nudge.ts
@@ -4,6 +4,42 @@ export const FREE_AGENT_VALUE_NUDGE_PART_TYPE =
 export const FREE_AGENT_VALUE_NUDGE_STORAGE_PREFIX =
   "free-agent-value-nudge:" as const;
 
+export const getFreeAgentValueNudgeStorageKey = (chatId: string) =>
+  `${FREE_AGENT_VALUE_NUDGE_STORAGE_PREFIX}${chatId}`;
+
+const getBrowserStorage = () => {
+  if (typeof window === "undefined") return undefined;
+  return window.localStorage;
+};
+
+export const hasShownFreeAgentValueNudge = (
+  shownChatIds: Set<string>,
+  chatId: string,
+  storage: Storage | undefined = getBrowserStorage(),
+) => {
+  if (shownChatIds.has(chatId)) return true;
+  if (!storage) return false;
+  try {
+    return storage.getItem(getFreeAgentValueNudgeStorageKey(chatId)) === "1";
+  } catch {
+    return false;
+  }
+};
+
+export const markFreeAgentValueNudgeShown = (
+  shownChatIds: Set<string>,
+  chatId: string,
+  storage: Storage | undefined = getBrowserStorage(),
+) => {
+  shownChatIds.add(chatId);
+  if (!storage) return;
+  try {
+    storage.setItem(getFreeAgentValueNudgeStorageKey(chatId), "1");
+  } catch {
+    // Losing localStorage only means the nudge can reappear after a reload.
+  }
+};
+
 export const FREE_AGENT_VALUE_NUDGE_ANALYTICS = {
   surface: "free_agent_value_nudge",
   source: "free_agent_value_reached",

--- a/lib/chat/free-agent-value-nudge.ts
+++ b/lib/chat/free-agent-value-nudge.ts
@@ -1,6 +1,9 @@
 export const FREE_AGENT_VALUE_NUDGE_PART_TYPE =
   "data-free-agent-value-nudge" as const;
 
+export const FREE_AGENT_VALUE_NUDGE_STORAGE_PREFIX =
+  "free-agent-value-nudge:" as const;
+
 export const FREE_AGENT_VALUE_NUDGE_ANALYTICS = {
   surface: "free_agent_value_nudge",
   source: "free_agent_value_reached",

--- a/lib/utils/stream-writer-utils.ts
+++ b/lib/utils/stream-writer-utils.ts
@@ -4,6 +4,7 @@ import { UIMessagePart, UIMessageStreamWriter } from "ai";
 import type { ChatMode, SubscriptionTier } from "@/types";
 import type { LimitCapReason } from "@/lib/limit-pressure";
 import type { AgentRunSpendCapBasis } from "@/lib/chat/agent-run-spend-cap";
+import { FREE_AGENT_VALUE_NUDGE_PART_TYPE } from "@/lib/chat/free-agent-value-nudge";
 
 // Upload status notifications
 export const writeUploadStartStatus = (
@@ -160,5 +161,15 @@ export const writeAutoContinue = (writer: UIMessageStreamWriter): void => {
   writer.write({
     type: "data-auto-continue",
     data: { shouldContinue: true },
+  });
+};
+
+export const writeFreeAgentValueNudge = (
+  writer: UIMessageStreamWriter,
+): void => {
+  writer.write({
+    type: FREE_AGENT_VALUE_NUDGE_PART_TYPE,
+    data: { reached: true },
+    transient: true,
   });
 };

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2089,6 +2089,7 @@ export const agentLongTask = task({
                                       : "success";
                                   captureAgentCompletionAnalytics({
                                     posthog,
+                                    writer,
                                     userId,
                                     chatId,
                                     endpoint,
@@ -2220,6 +2221,7 @@ export const agentLongTask = task({
                           : "success";
                       captureAgentCompletionAnalytics({
                         posthog,
+                        writer,
                         userId,
                         chatId,
                         endpoint,


### PR DESCRIPTION
## Summary
- emit a transient stream part when a successful free Agent run records `hackerai-free_agent_value_reached`
- show a one-time per-chat post-success upgrade nudge that uses `surface=free_agent_value_nudge`, `source=free_agent_value_reached`, and `reason=post_success_agent_run`
- keep the pricing dialog on its default copy for this post-success source while preserving pricing analytics context

## Validation
- `./node_modules/.bin/jest app/components/__tests__/PricingDialog.intent-copy.test.ts lib/api/__tests__/chat-logger.test.ts lib/chat/__tests__/free-agent-value-nudge.test.ts --runInBand`
- `./node_modules/.bin/prettier --check app/components/PricingDialog.tsx app/components/__tests__/PricingDialog.intent-copy.test.ts lib/chat/free-agent-value-nudge.ts app/components/chat.tsx lib/api/__tests__/chat-logger.test.ts lib/chat/__tests__/free-agent-value-nudge.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint app lib types __mocks__ --ext .ts,.tsx,.js,.jsx` (passes with existing warnings)
- commit hook: `tsc --noEmit` and full `jest` suite passed

## Manual verification
- As a free user with a local sandbox connected, complete a successful Agent run.
- Confirm a post-success toast appears once for that chat with an Upgrade action.
- Click Upgrade and confirm the pricing dialog opens with the normal pricing copy.
- Confirm PostHog receives `upgrade_cta_impressed`, `upgrade_cta_clicked`, and `pricing_viewed` with `surface=free_agent_value_nudge`, `source=free_agent_value_reached`, and `reason=post_success_agent_run`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-time “Agent worked locally” nudge when a free agent run reaches value, with an **Upgrade** action that opens pricing.
  * The nudge is deduplicated per chat so users won’t see it repeatedly.
  * Added support for preserving this behavior across page reloads when available.
* **Bug Fixes**
  * Improved handling so the nudge still works even if browser storage is unavailable or errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->