### PR TITLE
Save partial Agent output after crashed Trigger runs

### DIFF
--- a/app/api/agent/partial-save/route.ts
+++ b/app/api/agent/partial-save/route.ts
@@ -1,0 +1,5 @@
+import { createAgentPartialSavePost } from "@/lib/api/agent-partial-save-route";
+
+export const maxDuration = 30;
+
+export const POST = createAgentPartialSavePost();

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -45,11 +45,16 @@ import {
   shouldUseAgentLongForAgent,
 } from "@/lib/chat/agent-routing";
 import {
+  AGENT_PARTIAL_SAVE_ENDPOINT,
   AGENT_RESUME_ENDPOINT,
   LEGACY_AGENT_RESUME_ENDPOINT,
 } from "@/lib/api/agent-endpoints";
 import { isTauriEnvironment } from "@/app/hooks/useTauri";
-import { stripAgentLongHeartbeatPartsFromMessages } from "@/lib/chat/agent-long-heartbeat";
+import {
+  stripAgentLongHeartbeatParts,
+  stripAgentLongHeartbeatPartsFromMessages,
+} from "@/lib/chat/agent-long-heartbeat";
+import { hasVisibleAssistantContent } from "@/lib/chat/abort-persistence";
 import { toast } from "sonner";
 import { captureUpgradeCtaImpression } from "@/lib/analytics/client";
 import {
@@ -126,6 +131,52 @@ export function getExistingChatLoadState({
 
   return { isInitialExistingChatLoad, isChatNotFound };
 }
+
+type AgentLongPartialSaveMessage = {
+  id: string;
+  role: "assistant";
+  parts: ChatMessage["parts"];
+  generationStartedAt?: number;
+  generationTimeMs?: number;
+};
+
+const getLatestAgentLongAssistantMessageForPartialSave = (
+  messages: ChatMessage[],
+): AgentLongPartialSaveMessage | undefined => {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message?.role !== "assistant") continue;
+
+    const stripped = stripAgentLongHeartbeatParts(message);
+    if (!stripped.parts || stripped.parts.length === 0) continue;
+    if (!hasVisibleAssistantContent([stripped])) continue;
+
+    const metadata = (
+      stripped as ChatMessage & {
+        metadata?: {
+          generationStartedAt?: unknown;
+          generationTimeMs?: unknown;
+        };
+      }
+    ).metadata;
+
+    return {
+      id: stripped.id,
+      role: "assistant",
+      parts: stripped.parts,
+      generationStartedAt:
+        typeof metadata?.generationStartedAt === "number"
+          ? metadata.generationStartedAt
+          : undefined,
+      generationTimeMs:
+        typeof metadata?.generationTimeMs === "number"
+          ? metadata.generationTimeMs
+          : undefined,
+    };
+  }
+
+  return undefined;
+};
 
 const getAgentLongPartFingerprint = (part: unknown): string => {
   if (typeof part !== "object" || part === null) return String(part);
@@ -509,6 +560,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const browserStreamFinishedRef = useRef(false);
   const activeChatIdRef = useRef(chatId);
   const shownFreeAgentValueNudgeChatsRef = useRef<Set<string>>(new Set());
+  const agentLongPartialSaveKeysRef = useRef<Set<string>>(new Set());
   activeChatIdRef.current = chatId;
 
   useEffect(() => {
@@ -862,6 +914,40 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     setIsAutoResuming(false);
   }, [setDataStream, setIsAutoResuming]);
 
+  const saveAgentLongPartialSnapshot = useCallback(
+    (clientReason: string) => {
+      const partialMessage = getLatestAgentLongAssistantMessageForPartialSave(
+        messagesRef.current,
+      );
+      if (!partialMessage) return;
+
+      const saveKey = `${chatId}:${partialMessage.id}`;
+      if (agentLongPartialSaveKeysRef.current.has(saveKey)) return;
+      agentLongPartialSaveKeysRef.current.add(saveKey);
+
+      void fetch(AGENT_PARTIAL_SAVE_ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chatId,
+          message: partialMessage,
+          generationStartedAt: partialMessage.generationStartedAt,
+          generationTimeMs: partialMessage.generationTimeMs,
+          clientReason,
+        }),
+      })
+        .then((response) => {
+          if (!response.ok) {
+            agentLongPartialSaveKeysRef.current.delete(saveKey);
+          }
+        })
+        .catch(() => {
+          agentLongPartialSaveKeysRef.current.delete(saveKey);
+        });
+    },
+    [chatId],
+  );
+
   useEffect(() => {
     if (
       shouldUseAgentLongForCurrentChat &&
@@ -978,6 +1064,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
     const scheduleFinishLocally = () => {
       if (stopped || finishTimeout !== undefined) return;
+      saveAgentLongPartialSnapshot("resume_terminal_204");
 
       // The transport also polls the resume endpoint and can deliver a
       // synthetic finish after a terminal 204. Give it a brief chance to close
@@ -1039,6 +1126,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     chatId,
     isExistingChatRef,
     setIsAutoResuming,
+    saveAgentLongPartialSnapshot,
     shouldUseAgentLongForCurrentChat,
     status,
     stop,

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -143,39 +143,35 @@ type AgentLongPartialSaveMessage = {
 const getLatestAgentLongAssistantMessageForPartialSave = (
   messages: ChatMessage[],
 ): AgentLongPartialSaveMessage | undefined => {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const message = messages[index];
-    if (message?.role !== "assistant") continue;
+  const message = messages.at(-1);
+  if (message?.role !== "assistant") return undefined;
 
-    const stripped = stripAgentLongHeartbeatParts(message);
-    if (!stripped.parts || stripped.parts.length === 0) continue;
-    if (!hasVisibleAssistantContent([stripped])) continue;
+  const stripped = stripAgentLongHeartbeatParts(message);
+  if (!stripped.parts || stripped.parts.length === 0) return undefined;
+  if (!hasVisibleAssistantContent([stripped])) return undefined;
 
-    const metadata = (
-      stripped as ChatMessage & {
-        metadata?: {
-          generationStartedAt?: unknown;
-          generationTimeMs?: unknown;
-        };
-      }
-    ).metadata;
+  const metadata = (
+    stripped as ChatMessage & {
+      metadata?: {
+        generationStartedAt?: unknown;
+        generationTimeMs?: unknown;
+      };
+    }
+  ).metadata;
 
-    return {
-      id: stripped.id,
-      role: "assistant",
-      parts: stripped.parts,
-      generationStartedAt:
-        typeof metadata?.generationStartedAt === "number"
-          ? metadata.generationStartedAt
-          : undefined,
-      generationTimeMs:
-        typeof metadata?.generationTimeMs === "number"
-          ? metadata.generationTimeMs
-          : undefined,
-    };
-  }
-
-  return undefined;
+  return {
+    id: stripped.id,
+    role: "assistant",
+    parts: stripped.parts,
+    generationStartedAt:
+      typeof metadata?.generationStartedAt === "number"
+        ? metadata.generationStartedAt
+        : undefined,
+    generationTimeMs:
+      typeof metadata?.generationTimeMs === "number"
+        ? metadata.generationTimeMs
+        : undefined,
+  };
 };
 
 const getAgentLongPartFingerprint = (part: unknown): string => {

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -62,6 +62,11 @@ const agentRouteErrorsSrc = fs.readFileSync(
   "utf8",
 );
 
+const agentPartialSaveRouteSrc = fs.readFileSync(
+  path.resolve(__dirname, "../agent-partial-save-route.ts"),
+  "utf8",
+);
+
 const chatComponentSrc = fs.readFileSync(
   path.resolve(__dirname, "../../../app/components/chat.tsx"),
   "utf8",
@@ -376,9 +381,40 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(chatComponentSrc).toMatch(/response\.status\s*===\s*204/);
     expect(chatComponentSrc).toMatch(/scheduleFinishLocally\(\)/);
     expect(chatComponentSrc).toMatch(/finishLocally\(\)/);
+    expect(chatComponentSrc).toMatch(/AGENT_PARTIAL_SAVE_ENDPOINT/);
+    expect(chatComponentSrc).toMatch(/saveAgentLongPartialSnapshot/);
+    expect(chatComponentSrc).toMatch(
+      /saveAgentLongPartialSnapshot\("resume_terminal_204"\)/,
+    );
+    expect(chatComponentSrc).toMatch(
+      /getLatestAgentLongAssistantMessageForPartialSave/,
+    );
     expect(chatComponentSrc).toMatch(/stop\(\)/);
     expect(chatComponentSrc).toMatch(/window\.history\.replaceState/);
     expect(chatComponentSrc).toMatch(/setIsExistingChat\(true\)/);
+  });
+
+  test("client partial-save endpoint is authenticated and assistant-only", () => {
+    expect(agentEndpointsSrc).toMatch(
+      /AGENT_PARTIAL_SAVE_ENDPOINT\s*=\s*"\/api\/agent\/partial-save"/,
+    );
+    expect(agentPartialSaveRouteSrc).toMatch(/getUserID\(req\)/);
+    expect(agentPartialSaveRouteSrc).toMatch(
+      /assertUserCanAccessChatHistory\(userId\)/,
+    );
+    expect(agentPartialSaveRouteSrc).toMatch(
+      /getChatById\(\{\s*id:\s*body\.chatId\s*\}\)/,
+    );
+    expect(agentPartialSaveRouteSrc).toMatch(/chat\.user_id\s*!==\s*userId/);
+    expect(agentPartialSaveRouteSrc).toMatch(
+      /message\.role\s*!==\s*"assistant"/,
+    );
+    expect(agentPartialSaveRouteSrc).toMatch(/hasVisibleAssistantContent/);
+    expect(agentPartialSaveRouteSrc).toMatch(/saveMessage\(\{/);
+    expect(agentPartialSaveRouteSrc).toMatch(
+      /finishReason:\s*CLIENT_SAVED_FINISH_REASON/,
+    );
+    expect(agentPartialSaveRouteSrc).toMatch(/updateChat\(\{/);
   });
 
   test("stops the local stream when a streaming chat unmounts", () => {

--- a/lib/api/__tests__/agent-partial-save-route.test.ts
+++ b/lib/api/__tests__/agent-partial-save-route.test.ts
@@ -102,12 +102,14 @@ const chat = (overrides: Record<string, unknown> = {}) => ({
 describe("createAgentPartialSavePost", () => {
   let errorSpy: jest.SpiedFunction<typeof console.error>;
   let infoSpy: jest.SpiedFunction<typeof console.info>;
+  let warnSpy: jest.SpiedFunction<typeof console.warn>;
 
   beforeEach(() => {
     installResponseShim();
     jest.clearAllMocks();
     errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     mockGetUserID.mockResolvedValue("user-1" as never);
     mockAssertUserCanAccessChatHistory.mockResolvedValue(undefined as never);
     mockCreateRedisClient.mockReturnValue(null);
@@ -119,6 +121,7 @@ describe("createAgentPartialSavePost", () => {
   afterEach(() => {
     errorSpy.mockRestore();
     infoSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
   it("saves a valid assistant partial snapshot for the owning user", async () => {
@@ -211,8 +214,7 @@ describe("createAgentPartialSavePost", () => {
     const { createAgentPartialSavePost } =
       await import("@/lib/api/agent-partial-save-route");
     const redis = {
-      incr: jest.fn().mockResolvedValue(61 as never),
-      expire: jest.fn(),
+      eval: jest.fn().mockResolvedValue(0 as never),
     };
     mockCreateRedisClient.mockReturnValue(redis);
     const req = request();
@@ -226,10 +228,35 @@ describe("createAgentPartialSavePost", () => {
       cause:
         "Too many partial-save requests. Please wait a moment and try again.",
     });
-    expect(redis.incr).toHaveBeenCalledWith("agent_partial_save:user-1");
+    expect(redis.eval).toHaveBeenCalledWith(
+      expect.stringContaining('redis.call("INCR", key)'),
+      ["agent_partial_save:user-1"],
+      [60, 600],
+    );
     expect(req.text).not.toHaveBeenCalled();
     expect(mockGetChatById).not.toHaveBeenCalled();
     expect(mockSaveMessage).not.toHaveBeenCalled();
+  });
+
+  it("continues the partial save when Redis rate limiting is unavailable", async () => {
+    const { createAgentPartialSavePost } =
+      await import("@/lib/api/agent-partial-save-route");
+    const redis = {
+      eval: jest.fn().mockRejectedValue(new Error("redis down") as never),
+    };
+    mockCreateRedisClient.mockReturnValue(redis);
+
+    const response = await createAgentPartialSavePost()(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ saved: true });
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[agent-partial-save] rate limit unavailable, continuing partial save:",
+      expect.any(Error),
+    );
+    expect(mockSaveMessage).toHaveBeenCalled();
+    expect(mockUpdateChat).toHaveBeenCalled();
   });
 
   it("returns chat access suspension errors before rate limiting", async () => {

--- a/lib/api/__tests__/agent-partial-save-route.test.ts
+++ b/lib/api/__tests__/agent-partial-save-route.test.ts
@@ -167,6 +167,26 @@ describe("createAgentPartialSavePost", () => {
     });
   });
 
+  it("does not overwrite an existing chat finish reason", async () => {
+    const { createAgentPartialSavePost } =
+      await import("@/lib/api/agent-partial-save-route");
+    mockGetChatById.mockResolvedValue(chat({ finish_reason: "stop" }) as never);
+
+    const response = await createAgentPartialSavePost()(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ saved: true });
+    expect(mockSaveMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: "chat-1",
+        userId: "user-1",
+        finishReason: "trigger_crashed_client_saved",
+      }),
+    );
+    expect(mockUpdateChat).not.toHaveBeenCalled();
+  });
+
   it("rejects cross-user chats before writing", async () => {
     const { createAgentPartialSavePost } =
       await import("@/lib/api/agent-partial-save-route");

--- a/lib/api/__tests__/agent-partial-save-route.test.ts
+++ b/lib/api/__tests__/agent-partial-save-route.test.ts
@@ -93,6 +93,18 @@ const request = (
   } as any;
 };
 
+const streamingRequest = (text: string) =>
+  ({
+    headers: new Headers(),
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(text));
+        controller.close();
+      },
+    }),
+    text: jest.fn().mockResolvedValue(text as never),
+  }) as any;
+
 const chat = (overrides: Record<string, unknown> = {}) => ({
   id: "chat-1",
   user_id: "user-1",
@@ -196,6 +208,24 @@ describe("createAgentPartialSavePost", () => {
     const req = request(validBody, {
       "content-length": `${4 * 1024 * 1024 + 1}`,
     });
+
+    const response = await createAgentPartialSavePost()(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({
+      code: "bad_request:api",
+      cause: "Partial save payload is too large.",
+    });
+    expect(req.text).not.toHaveBeenCalled();
+    expect(mockGetChatById).not.toHaveBeenCalled();
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized streamed requests without a content-length header", async () => {
+    const { createAgentPartialSavePost } =
+      await import("@/lib/api/agent-partial-save-route");
+    const req = streamingRequest("x".repeat(4 * 1024 * 1024 + 1));
 
     const response = await createAgentPartialSavePost()(req);
     const body = await response.json();

--- a/lib/api/__tests__/agent-partial-save-route.test.ts
+++ b/lib/api/__tests__/agent-partial-save-route.test.ts
@@ -1,0 +1,254 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import { ChatSDKError } from "@/lib/errors";
+
+const mockGetUserID = jest.fn();
+const mockGetChatById = jest.fn();
+const mockSaveMessage = jest.fn();
+const mockUpdateChat = jest.fn();
+const mockAssertUserCanAccessChatHistory = jest.fn();
+const mockCreateRedisClient = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: class MockNextResponse {
+    status: number;
+    private body: unknown;
+
+    constructor(body?: unknown, init?: ResponseInit) {
+      this.body = body;
+      this.status = init?.status ?? 200;
+    }
+
+    static json(body: unknown, init?: ResponseInit) {
+      return new MockNextResponse(body, init);
+    }
+
+    async json() {
+      return this.body;
+    }
+
+    async text() {
+      return typeof this.body === "string"
+        ? this.body
+        : JSON.stringify(this.body ?? "");
+    }
+  },
+}));
+
+jest.mock("@/lib/auth/get-user-id", () => ({
+  getUserID: mockGetUserID,
+}));
+
+jest.mock("@/lib/db/actions", () => ({
+  getChatById: mockGetChatById,
+  saveMessage: mockSaveMessage,
+  updateChat: mockUpdateChat,
+}));
+
+jest.mock("@/lib/suspensions", () => ({
+  assertUserCanAccessChatHistory: mockAssertUserCanAccessChatHistory,
+}));
+
+jest.mock("@/lib/rate-limit/redis", () => ({
+  createRedisClient: mockCreateRedisClient,
+}));
+
+function installResponseShim() {
+  (globalThis as any).Response = {
+    json: (body: unknown, init?: ResponseInit) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+      text: async () =>
+        typeof body === "string" ? body : JSON.stringify(body ?? ""),
+    }),
+  };
+}
+
+const validBody = {
+  chatId: "chat-1",
+  message: {
+    id: "message-1",
+    role: "assistant",
+    parts: [{ type: "text", text: "partial assistant output" }],
+  },
+  generationStartedAt: 100,
+  generationTimeMs: 250,
+  clientReason: "resume_terminal_204",
+};
+
+const request = (
+  body: unknown = validBody,
+  headers: Record<string, string> = {},
+) => {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return {
+    headers: new Headers(headers),
+    text: jest.fn().mockResolvedValue(text as never),
+  } as any;
+};
+
+const chat = (overrides: Record<string, unknown> = {}) => ({
+  id: "chat-1",
+  user_id: "user-1",
+  ...overrides,
+});
+
+describe("createAgentPartialSavePost", () => {
+  let errorSpy: jest.SpiedFunction<typeof console.error>;
+  let infoSpy: jest.SpiedFunction<typeof console.info>;
+
+  beforeEach(() => {
+    installResponseShim();
+    jest.clearAllMocks();
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+    mockGetUserID.mockResolvedValue("user-1" as never);
+    mockAssertUserCanAccessChatHistory.mockResolvedValue(undefined as never);
+    mockCreateRedisClient.mockReturnValue(null);
+    mockGetChatById.mockResolvedValue(chat() as never);
+    mockSaveMessage.mockResolvedValue(undefined as never);
+    mockUpdateChat.mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    infoSpy.mockRestore();
+  });
+
+  it("saves a valid assistant partial snapshot for the owning user", async () => {
+    const { createAgentPartialSavePost } =
+      await import("@/lib/api/agent-partial-save-route");
+
+    const response = await createAgentPartialSavePost()(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ saved: true });
+    expect(mockGetUserID).toHaveBeenCalled();
+    expect(mockAssertUserCanAccessChatHistory).toHaveBeenCalledWith("user-1");
+    expect(mockGetChatById).toHaveBeenCalledWith({ id: "chat-1" });
+    expect(mockSaveMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: "chat-1",
+        userId: "user-1",
+        message: validBody.message,
+        mode: "agent",
+        generationStartedAt: 100,
+        generationTimeMs: 250,
+        finishReason: "trigger_crashed_client_saved",
+        wasAborted: true,
+      }),
+    );
+    expect(mockUpdateChat).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      finishReason: "trigger_crashed_client_saved",
+      defaultModelSlug: "agent",
+    });
+  });
+
+  it("rejects cross-user chats before writing", async () => {
+    const { createAgentPartialSavePost } =
+      await import("@/lib/api/agent-partial-save-route");
+    mockGetChatById.mockResolvedValue(chat({ user_id: "user-2" }) as never);
+
+    const response = await createAgentPartialSavePost()(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toMatchObject({ code: "forbidden:chat" });
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+    expect(mockUpdateChat).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-assistant messages before looking up the chat", async () => {
+    const { createAgentPartialSavePost } =
+      await import("@/lib/api/agent-partial-save-route");
+
+    const response = await createAgentPartialSavePost()(
+      request({
+        ...validBody,
+        message: { ...validBody.message, role: "user" },
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({
+      code: "bad_request:api",
+      cause: "Only assistant messages can be partially saved.",
+    });
+    expect(mockGetChatById).not.toHaveBeenCalled();
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized requests from metadata before reading the body", async () => {
+    const { createAgentPartialSavePost } =
+      await import("@/lib/api/agent-partial-save-route");
+    const req = request(validBody, {
+      "content-length": `${4 * 1024 * 1024 + 1}`,
+    });
+
+    const response = await createAgentPartialSavePost()(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({
+      code: "bad_request:api",
+      cause: "Partial save payload is too large.",
+    });
+    expect(req.text).not.toHaveBeenCalled();
+    expect(mockGetChatById).not.toHaveBeenCalled();
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+  });
+
+  it("rate limits repeated partial-save writes before reading the body", async () => {
+    const { createAgentPartialSavePost } =
+      await import("@/lib/api/agent-partial-save-route");
+    const redis = {
+      incr: jest.fn().mockResolvedValue(61 as never),
+      expire: jest.fn(),
+    };
+    mockCreateRedisClient.mockReturnValue(redis);
+    const req = request();
+
+    const response = await createAgentPartialSavePost()(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(body).toMatchObject({
+      code: "rate_limit:chat",
+      cause:
+        "Too many partial-save requests. Please wait a moment and try again.",
+    });
+    expect(redis.incr).toHaveBeenCalledWith("agent_partial_save:user-1");
+    expect(req.text).not.toHaveBeenCalled();
+    expect(mockGetChatById).not.toHaveBeenCalled();
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns chat access suspension errors before rate limiting", async () => {
+    const { createAgentPartialSavePost } =
+      await import("@/lib/api/agent-partial-save-route");
+    mockAssertUserCanAccessChatHistory.mockRejectedValue(
+      new ChatSDKError("forbidden:chat", "Fraud dispute hold") as never,
+    );
+
+    const response = await createAgentPartialSavePost()(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toMatchObject({
+      code: "forbidden:chat",
+      cause: "Fraud dispute hold",
+    });
+    expect(mockCreateRedisClient).not.toHaveBeenCalled();
+    expect(mockGetChatById).not.toHaveBeenCalled();
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+  });
+});

--- a/lib/api/agent-endpoints.ts
+++ b/lib/api/agent-endpoints.ts
@@ -2,6 +2,7 @@ export const CHAT_API_ENDPOINT = "/api/chat" as const;
 export const AGENT_API_ENDPOINT = "/api/agent" as const;
 export const AGENT_RESUME_ENDPOINT = "/api/agent/resume" as const;
 export const AGENT_CANCEL_ENDPOINT = "/api/agent/cancel" as const;
+export const AGENT_PARTIAL_SAVE_ENDPOINT = "/api/agent/partial-save" as const;
 
 export const LEGACY_AGENT_API_ENDPOINT = "/api/agent-long" as const;
 export const LEGACY_AGENT_RESUME_ENDPOINT = "/api/agent-long/resume" as const;

--- a/lib/api/agent-partial-save-route.ts
+++ b/lib/api/agent-partial-save-route.ts
@@ -6,9 +6,12 @@ import { getChatById, saveMessage, updateChat } from "@/lib/db/actions";
 import { ChatSDKError } from "@/lib/errors";
 import { hasVisibleAssistantContent } from "@/lib/chat/abort-persistence";
 import { assertUserCanAccessChatHistory } from "@/lib/suspensions";
+import { createRedisClient } from "@/lib/rate-limit/redis";
 
 const CLIENT_SAVED_FINISH_REASON = "trigger_crashed_client_saved";
 const MAX_PARTIAL_SAVE_BODY_BYTES = 4 * 1024 * 1024;
+const PARTIAL_SAVE_RATE_LIMIT_MAX_REQUESTS = 60;
+const PARTIAL_SAVE_RATE_LIMIT_WINDOW_SECONDS = 10 * 60;
 
 type PartialSaveBody = {
   chatId: string;
@@ -25,16 +28,93 @@ type PartialSaveBody = {
 const getOptionalFiniteNumber = (value: unknown): number | undefined =>
   typeof value === "number" && Number.isFinite(value) ? value : undefined;
 
+const throwPartialSavePayloadTooLarge = (): never => {
+  throw new ChatSDKError(
+    "bad_request:api",
+    "Partial save payload is too large.",
+  );
+};
+
+const assertPartialSaveContentLengthWithinLimit = (req: NextRequest) => {
+  const contentLength = req.headers.get("content-length");
+  if (!contentLength) return;
+
+  const bytes = Number(contentLength);
+  if (Number.isFinite(bytes) && bytes > MAX_PARTIAL_SAVE_BODY_BYTES) {
+    throwPartialSavePayloadTooLarge();
+  }
+};
+
+const readRequestTextWithLimit = async (req: NextRequest): Promise<string> => {
+  assertPartialSaveContentLengthWithinLimit(req);
+
+  if (!req.body) {
+    const text = await req.text();
+    if (Buffer.byteLength(text, "utf8") > MAX_PARTIAL_SAVE_BODY_BYTES) {
+      throwPartialSavePayloadTooLarge();
+    }
+    return text;
+  }
+
+  const reader = req.body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  let byteLength = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    byteLength += value.byteLength;
+    if (byteLength > MAX_PARTIAL_SAVE_BODY_BYTES) {
+      await reader.cancel();
+      throwPartialSavePayloadTooLarge();
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+
+  text += decoder.decode();
+  return text;
+};
+
+const assertPartialSaveRateLimit = async (userId: string) => {
+  const redis = createRedisClient();
+  if (!redis) {
+    if (process.env.NODE_ENV === "production") {
+      throw new ChatSDKError(
+        "rate_limit:chat",
+        "Rate limiting service is not configured",
+      );
+    }
+    return;
+  }
+
+  const key = `agent_partial_save:${userId}`;
+  try {
+    const count = await redis.incr(key);
+    if (count === 1) {
+      await redis.expire(key, PARTIAL_SAVE_RATE_LIMIT_WINDOW_SECONDS);
+    }
+    if (count > PARTIAL_SAVE_RATE_LIMIT_MAX_REQUESTS) {
+      throw new ChatSDKError(
+        "rate_limit:chat",
+        "Too many partial-save requests. Please wait a moment and try again.",
+      );
+    }
+  } catch (error) {
+    if (error instanceof ChatSDKError) throw error;
+    throw new ChatSDKError(
+      "rate_limit:chat",
+      `Rate limiting service unavailable: ${
+        error instanceof Error ? error.message : "Unknown error"
+      }`,
+    );
+  }
+};
+
 const parsePartialSaveBody = async (
   req: NextRequest,
 ): Promise<PartialSaveBody> => {
-  const text = await req.text();
-  if (Buffer.byteLength(text, "utf8") > MAX_PARTIAL_SAVE_BODY_BYTES) {
-    throw new ChatSDKError(
-      "bad_request:api",
-      "Partial save payload is too large.",
-    );
-  }
+  const text = await readRequestTextWithLimit(req);
 
   let rawBody: unknown;
   try {
@@ -105,6 +185,7 @@ export const createAgentPartialSavePost =
     try {
       const userId = await getUserID(req);
       await assertUserCanAccessChatHistory(userId);
+      await assertPartialSaveRateLimit(userId);
 
       const body = await parsePartialSaveBody(req);
       const chat = await getChatById({ id: body.chatId });

--- a/lib/api/agent-partial-save-route.ts
+++ b/lib/api/agent-partial-save-route.ts
@@ -12,6 +12,22 @@ const CLIENT_SAVED_FINISH_REASON = "trigger_crashed_client_saved";
 const MAX_PARTIAL_SAVE_BODY_BYTES = 4 * 1024 * 1024;
 const PARTIAL_SAVE_RATE_LIMIT_MAX_REQUESTS = 60;
 const PARTIAL_SAVE_RATE_LIMIT_WINDOW_SECONDS = 10 * 60;
+const PARTIAL_SAVE_RATE_LIMIT_SCRIPT = `
+local key = KEYS[1]
+local limit = tonumber(ARGV[1])
+local ttlSeconds = tonumber(ARGV[2])
+
+local count = redis.call("INCR", key)
+if count == 1 then
+  redis.call("EXPIRE", key, ttlSeconds)
+end
+
+if count > limit then
+  return 0
+end
+
+return 1
+`;
 
 type PartialSaveBody = {
   chatId: string;
@@ -78,23 +94,19 @@ const readRequestTextWithLimit = async (req: NextRequest): Promise<string> => {
 
 const assertPartialSaveRateLimit = async (userId: string) => {
   const redis = createRedisClient();
-  if (!redis) {
-    if (process.env.NODE_ENV === "production") {
-      throw new ChatSDKError(
-        "rate_limit:chat",
-        "Rate limiting service is not configured",
-      );
-    }
-    return;
-  }
+  if (!redis) return;
 
   const key = `agent_partial_save:${userId}`;
   try {
-    const count = await redis.incr(key);
-    if (count === 1) {
-      await redis.expire(key, PARTIAL_SAVE_RATE_LIMIT_WINDOW_SECONDS);
-    }
-    if (count > PARTIAL_SAVE_RATE_LIMIT_MAX_REQUESTS) {
+    const result = await redis.eval(
+      PARTIAL_SAVE_RATE_LIMIT_SCRIPT,
+      [key],
+      [
+        PARTIAL_SAVE_RATE_LIMIT_MAX_REQUESTS,
+        PARTIAL_SAVE_RATE_LIMIT_WINDOW_SECONDS,
+      ],
+    );
+    if (Number(result) !== 1) {
       throw new ChatSDKError(
         "rate_limit:chat",
         "Too many partial-save requests. Please wait a moment and try again.",
@@ -102,11 +114,9 @@ const assertPartialSaveRateLimit = async (userId: string) => {
     }
   } catch (error) {
     if (error instanceof ChatSDKError) throw error;
-    throw new ChatSDKError(
-      "rate_limit:chat",
-      `Rate limiting service unavailable: ${
-        error instanceof Error ? error.message : "Unknown error"
-      }`,
+    console.warn(
+      "[agent-partial-save] rate limit unavailable, continuing partial save:",
+      error,
     );
   }
 };

--- a/lib/api/agent-partial-save-route.ts
+++ b/lib/api/agent-partial-save-route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { UIMessagePart } from "ai";
+
+import { getUserID } from "@/lib/auth/get-user-id";
+import { getChatById, saveMessage, updateChat } from "@/lib/db/actions";
+import { ChatSDKError } from "@/lib/errors";
+import { hasVisibleAssistantContent } from "@/lib/chat/abort-persistence";
+import { assertUserCanAccessChatHistory } from "@/lib/suspensions";
+
+const CLIENT_SAVED_FINISH_REASON = "trigger_crashed_client_saved";
+const MAX_PARTIAL_SAVE_BODY_BYTES = 4 * 1024 * 1024;
+
+type PartialSaveBody = {
+  chatId: string;
+  message: {
+    id: string;
+    role: "assistant";
+    parts: UIMessagePart<any, any>[];
+  };
+  generationStartedAt?: number;
+  generationTimeMs?: number;
+  clientReason?: string;
+};
+
+const getOptionalFiniteNumber = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+const parsePartialSaveBody = async (
+  req: NextRequest,
+): Promise<PartialSaveBody> => {
+  const text = await req.text();
+  if (Buffer.byteLength(text, "utf8") > MAX_PARTIAL_SAVE_BODY_BYTES) {
+    throw new ChatSDKError(
+      "bad_request:api",
+      "Partial save payload is too large.",
+    );
+  }
+
+  let rawBody: unknown;
+  try {
+    rawBody = JSON.parse(text);
+  } catch {
+    throw new ChatSDKError("bad_request:api", "Invalid JSON body");
+  }
+
+  if (typeof rawBody !== "object" || rawBody === null) {
+    throw new ChatSDKError("bad_request:api", "Invalid JSON body");
+  }
+
+  const body = rawBody as Record<string, unknown>;
+  const chatId = body.chatId;
+  const rawMessage = body.message;
+
+  if (typeof chatId !== "string" || chatId.length === 0) {
+    throw new ChatSDKError("bad_request:api", "chatId required");
+  }
+  if (
+    typeof rawMessage !== "object" ||
+    rawMessage === null ||
+    Array.isArray(rawMessage)
+  ) {
+    throw new ChatSDKError("bad_request:api", "assistant message required");
+  }
+
+  const message = rawMessage as Record<string, unknown>;
+  if (typeof message.id !== "string" || message.id.length === 0) {
+    throw new ChatSDKError("bad_request:api", "message.id required");
+  }
+  if (message.role !== "assistant") {
+    throw new ChatSDKError(
+      "bad_request:api",
+      "Only assistant messages can be partially saved.",
+    );
+  }
+  if (!Array.isArray(message.parts) || message.parts.length === 0) {
+    throw new ChatSDKError("bad_request:api", "message.parts required");
+  }
+
+  const parsed: PartialSaveBody = {
+    chatId,
+    message: {
+      id: message.id,
+      role: "assistant",
+      parts: message.parts as UIMessagePart<any, any>[],
+    },
+    generationStartedAt: getOptionalFiniteNumber(body.generationStartedAt),
+    generationTimeMs: getOptionalFiniteNumber(body.generationTimeMs),
+    clientReason:
+      typeof body.clientReason === "string" ? body.clientReason : undefined,
+  };
+
+  if (!hasVisibleAssistantContent([parsed.message])) {
+    throw new ChatSDKError(
+      "bad_request:api",
+      "No visible assistant content to save.",
+    );
+  }
+
+  return parsed;
+};
+
+export const createAgentPartialSavePost =
+  () =>
+  async (req: NextRequest): Promise<Response> => {
+    try {
+      const userId = await getUserID(req);
+      await assertUserCanAccessChatHistory(userId);
+
+      const body = await parsePartialSaveBody(req);
+      const chat = await getChatById({ id: body.chatId });
+      if (!chat || chat.user_id !== userId) {
+        throw new ChatSDKError("forbidden:chat");
+      }
+
+      await saveMessage({
+        chatId: body.chatId,
+        userId,
+        message: body.message,
+        mode: "agent",
+        generationStartedAt: body.generationStartedAt,
+        generationTimeMs: body.generationTimeMs,
+        finishReason: CLIENT_SAVED_FINISH_REASON,
+        wasAborted: true,
+      });
+
+      await updateChat({
+        chatId: body.chatId,
+        finishReason: CLIENT_SAVED_FINISH_REASON,
+        defaultModelSlug: "agent",
+      });
+
+      console.info(
+        JSON.stringify({
+          level: "info",
+          event: "agent_long_client_partial_saved",
+          service: "chat-handler",
+          timestamp: new Date().toISOString(),
+          chat_id: body.chatId,
+          user_id: userId,
+          message_id: body.message.id,
+          client_reason: body.clientReason,
+          part_count: body.message.parts.length,
+        }),
+      );
+
+      return NextResponse.json({ saved: true });
+    } catch (error) {
+      if (error instanceof ChatSDKError) return error.toResponse();
+      console.error("[agent-partial-save] failed:", error);
+      return NextResponse.json(
+        { saved: false, message: "Failed to save partial response" },
+        { status: 500 },
+      );
+    }
+  };

--- a/lib/api/agent-partial-save-route.ts
+++ b/lib/api/agent-partial-save-route.ts
@@ -214,11 +214,13 @@ export const createAgentPartialSavePost =
         wasAborted: true,
       });
 
-      await updateChat({
-        chatId: body.chatId,
-        finishReason: CLIENT_SAVED_FINISH_REASON,
-        defaultModelSlug: "agent",
-      });
+      if (!chat.finish_reason) {
+        await updateChat({
+          chatId: body.chatId,
+          finishReason: CLIENT_SAVED_FINISH_REASON,
+          defaultModelSlug: "agent",
+        });
+      }
 
       console.info(
         JSON.stringify({


### PR DESCRIPTION
## Summary
- add an authenticated Agent partial-save endpoint for client-held assistant output
- when the resume endpoint reports a terminal Trigger run, save the latest visible assistant message before clearing the stream UI
- add structural coverage for the terminal-run salvage path and endpoint guardrails

## Validation
- pnpm test -- lib/api/__tests__/agent-long-contracts.test.ts --runInBand
- pnpm typecheck
- pnpm exec eslint lib/api/agent-partial-save-route.ts app/api/agent/partial-save/route.ts app/components/chat.tsx lib/api/agent-endpoints.ts lib/api/__tests__/agent-long-contracts.test.ts (0 errors; existing chat.tsx hook warnings remain)
- pre-commit hook: pnpm typecheck and full pnpm test (207 suites, 2088 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist long-running assistant progress as partial snapshots, including resume support for “terminal 204”.
  * Added a dedicated partial-save API endpoint and client-side deduplication to avoid repeated snapshot writes per chat.
* **Bug Fixes**
  * Improved completion reconciliation to restore state from the latest saved partial snapshot.
* **Tests**
  * Added route and client reconciliation coverage for authorization, payload/content validation (including size limits), assistant-only visibility rules, and Redis rate-limiting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->