### PR TITLE
Fix stale auth and agent error logging

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -136,6 +136,7 @@ describe("proxy", () => {
   });
 
   it("treats callback-only ended-session refresh errors as logged-out requests", async () => {
+    const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
     const endedSessionError = Object.assign(
       new Error("Failed to refresh session: Error: invalid_grant"),
       {
@@ -150,28 +151,38 @@ describe("proxy", () => {
         },
       },
     );
-    mockAuthkit.mockImplementation((_request, options: any) => {
-      options.onSessionRefreshError({ error: endedSessionError });
-      return Promise.resolve({
-        session: { user: { id: "stale-user" } },
-        headers: new Headers(),
-        authorizationUrl: undefined,
+    try {
+      mockAuthkit.mockImplementation((_request, options: any) => {
+        options.onSessionRefreshError({ error: endedSessionError });
+        return Promise.resolve({
+          session: { user: { id: "stale-user" } },
+          headers: new Headers(),
+          authorizationUrl: undefined,
+        });
       });
-    });
-    const { default: proxy } = await import("../proxy");
+      const { default: proxy } = await import("../proxy");
 
-    const response = await proxy(
-      createRequest({
+      const response = await proxy(
+        createRequest({
+          pathname: "/share/d87274de-f182-4a3c-a821-c0949295af2d",
+          method: "POST",
+          hasSession: true,
+        }),
+      );
+
+      expect(response).toMatchObject({ kind: "next" });
+      expect(response.cookies.delete).toHaveBeenCalledWith("wos-session");
+      expect(mockNextResponseJson).not.toHaveBeenCalled();
+      expect(mockNextResponseRedirect).not.toHaveBeenCalled();
+      expect(JSON.parse(String(infoSpy.mock.calls[0][0]))).toMatchObject({
+        level: "info",
+        event: "auth.session_refresh_ended",
+        service: "hackerai-web",
         pathname: "/share/d87274de-f182-4a3c-a821-c0949295af2d",
-        method: "POST",
-        hasSession: true,
-      }),
-    );
-
-    expect(response).toMatchObject({ kind: "next" });
-    expect(response.cookies.delete).toHaveBeenCalledWith("wos-session");
-    expect(mockNextResponseJson).not.toHaveBeenCalled();
-    expect(mockNextResponseRedirect).not.toHaveBeenCalled();
+      });
+    } finally {
+      infoSpy.mockRestore();
+    }
   });
 
   it("still requires auth for protected API routes", async () => {

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -135,6 +135,45 @@ describe("proxy", () => {
     expect(mockNextResponseJson).not.toHaveBeenCalled();
   });
 
+  it("treats callback-only ended-session refresh errors as logged-out requests", async () => {
+    const endedSessionError = Object.assign(
+      new Error("Failed to refresh session: Error: invalid_grant"),
+      {
+        name: "TokenRefreshError",
+        cause: {
+          error: "invalid_grant",
+          errorDescription: "Session has already ended.",
+          rawData: {
+            error: "invalid_grant",
+            error_description: "Session has already ended.",
+          },
+        },
+      },
+    );
+    mockAuthkit.mockImplementation((_request, options: any) => {
+      options.onSessionRefreshError({ error: endedSessionError });
+      return Promise.resolve({
+        session: { user: { id: "stale-user" } },
+        headers: new Headers(),
+        authorizationUrl: undefined,
+      });
+    });
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/share/d87274de-f182-4a3c-a821-c0949295af2d",
+        method: "POST",
+        hasSession: true,
+      }),
+    );
+
+    expect(response).toMatchObject({ kind: "next" });
+    expect(response.cookies.delete).toHaveBeenCalledWith("wos-session");
+    expect(mockNextResponseJson).not.toHaveBeenCalled();
+    expect(mockNextResponseRedirect).not.toHaveBeenCalled();
+  });
+
   it("still requires auth for protected API routes", async () => {
     mockAuthkit.mockResolvedValue({
       session: { user: null },

--- a/lib/actions/__tests__/billing-context.test.ts
+++ b/lib/actions/__tests__/billing-context.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockWithAuth = jest.fn();
+const mockListOrganizationMemberships = jest.fn();
+
+jest.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: mockWithAuth,
+}));
+
+jest.mock("@/app/api/workos", () => ({
+  workos: {
+    baseURL: "https://api.workos.test",
+    userManagement: {
+      listOrganizationMemberships: mockListOrganizationMemberships,
+    },
+  },
+}));
+
+describe("getBillingActionContext", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockWithAuth.mockReset();
+    mockListOrganizationMemberships.mockReset();
+  });
+
+  it("normalizes ended-session refresh failures as unauthenticated billing context errors", async () => {
+    const endedSessionError = Object.assign(
+      new Error("Failed to refresh session: Error: invalid_grant"),
+      {
+        name: "TokenRefreshError",
+        cause: {
+          error: "invalid_grant",
+          errorDescription: "Session has already ended.",
+          rawData: {
+            error: "invalid_grant",
+            error_description: "Session has already ended.",
+          },
+        },
+      },
+    );
+    mockWithAuth.mockRejectedValue(endedSessionError as never);
+
+    const { getBillingActionContext } = await import("../billing-context");
+
+    await expect(getBillingActionContext()).rejects.toThrow(
+      "User not authenticated",
+    );
+    expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
+  });
+});

--- a/lib/actions/__tests__/billing-context.test.ts
+++ b/lib/actions/__tests__/billing-context.test.ts
@@ -47,4 +47,14 @@ describe("getBillingActionContext", () => {
     );
     expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
   });
+
+  it("rethrows non-ended-session auth failures unchanged", async () => {
+    const genericError = new Error("network failure");
+    mockWithAuth.mockRejectedValue(genericError as never);
+
+    const { getBillingActionContext } = await import("../billing-context");
+
+    await expect(getBillingActionContext()).rejects.toBe(genericError);
+    expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
+  });
 });

--- a/lib/actions/billing-context.ts
+++ b/lib/actions/billing-context.ts
@@ -16,7 +16,7 @@ export async function getBillingActionContext(): Promise<BillingActionContext> {
     authResult = await withAuth();
   } catch (error) {
     if (isEndedSessionRefreshError(error)) {
-      throw new Error("User not authenticated");
+      throw new Error("User not authenticated", { cause: error });
     }
     throw error;
   }

--- a/lib/actions/billing-context.ts
+++ b/lib/actions/billing-context.ts
@@ -2,6 +2,7 @@
 
 import { workos } from "@/app/api/workos";
 import { withAuth } from "@workos-inc/authkit-nextjs";
+import { isEndedSessionRefreshError } from "@/lib/auth/expected-auth-errors";
 
 export type BillingActionContext = {
   organizationId: string;
@@ -10,7 +11,17 @@ export type BillingActionContext = {
 };
 
 export async function getBillingActionContext(): Promise<BillingActionContext> {
-  const { organizationId, user } = await withAuth();
+  let authResult: Awaited<ReturnType<typeof withAuth>>;
+  try {
+    authResult = await withAuth();
+  } catch (error) {
+    if (isEndedSessionRefreshError(error)) {
+      throw new Error("User not authenticated");
+    }
+    throw error;
+  }
+
+  const { organizationId, user } = authResult;
 
   if (!user?.id) {
     throw new Error("User not authenticated");

--- a/lib/api/__tests__/agent-route-errors.test.ts
+++ b/lib/api/__tests__/agent-route-errors.test.ts
@@ -68,14 +68,36 @@ describe("handleAgentRouteError", () => {
       endpoint: "agent",
       action: "start",
       fallbackMessage: "Failed to start agent",
+      context: {
+        requestId: "iad1::abc",
+        userId: "user_123",
+        chatId: "chat_123",
+        runId: "run_123",
+        stage: "trigger_task",
+      },
     });
 
     expect(response.status).toBe(500);
     expect(await response.text()).toBe("Failed to start agent");
-    expect(console.error).toHaveBeenCalledWith(
-      "[agent] failed to trigger task:",
-      error,
+    const payload = JSON.parse(
+      String((console.error as jest.Mock).mock.calls[0][0]),
     );
+    expect(payload).toMatchObject({
+      level: "error",
+      event: "agent_route_failed",
+      service: "hackerai-web",
+      endpoint: "agent",
+      action: "start",
+      log_message: "[agent] failed to trigger task",
+      request_id: "iad1::abc",
+      user_id: "user_123",
+      chat_id: "chat_123",
+      trigger_run_id: "run_123",
+      stage: "trigger_task",
+      error_name: "Error",
+      error_message: "queue unavailable",
+    });
+    expect(payload.timestamp).toEqual(expect.any(String));
   });
 
   test("logs non-start actions with the action-specific label", async () => {
@@ -89,9 +111,17 @@ describe("handleAgentRouteError", () => {
 
     expect(response.status).toBe(500);
     expect(await response.text()).toBe("Failed to cancel agent task");
-    expect(console.error).toHaveBeenCalledWith(
-      "[agent-long] cancel failed:",
-      error,
+    const payload = JSON.parse(
+      String((console.error as jest.Mock).mock.calls[0][0]),
     );
+    expect(payload).toMatchObject({
+      level: "error",
+      event: "agent_route_failed",
+      endpoint: "agent-long",
+      action: "cancel",
+      log_message: "[agent-long] cancel failed",
+      error_name: "Error",
+      error_message: "cancel failed",
+    });
   });
 });

--- a/lib/api/__tests__/agent-route-errors.test.ts
+++ b/lib/api/__tests__/agent-route-errors.test.ts
@@ -124,4 +124,25 @@ describe("handleAgentRouteError", () => {
       error_message: "cancel failed",
     });
   });
+
+  test("preserves plain object error details in structured logs", async () => {
+    const error = { code: "trigger_unavailable", detail: "API outage" };
+    const response = handleAgentRouteError({
+      error,
+      endpoint: "agent",
+      action: "resume",
+      fallbackMessage: "Failed to resume run",
+    });
+
+    expect(response.status).toBe(500);
+    const payload = JSON.parse(
+      String((console.error as jest.Mock).mock.calls[0][0]),
+    );
+    expect(payload).toMatchObject({
+      event: "agent_route_failed",
+      error_name: "object",
+      error_message: JSON.stringify(error),
+      error_code: "trigger_unavailable",
+    });
+  });
 });

--- a/lib/api/agent-resume-route.ts
+++ b/lib/api/agent-resume-route.ts
@@ -23,26 +23,40 @@ const TERMINAL_STATUSES = new Set([
 export const createAgentResumeGet =
   ({ endpoint }: { endpoint: AgentApiEndpoint }) =>
   async (req: NextRequest) => {
-    try {
-      const { userId } = await getUserIDAndPro(req);
+    let stage = "authenticate";
+    let userId: string | undefined;
+    let chatId: string | undefined;
+    let runId: string | undefined;
+    const requestId =
+      req.headers.get("x-request-id") ??
+      req.headers.get("x-vercel-id") ??
+      undefined;
 
-      const chatId = req.nextUrl.searchParams.get("chatId");
+    try {
+      const authContext = await getUserIDAndPro(req);
+      userId = authContext.userId;
+
+      stage = "validate_request";
+      chatId = req.nextUrl.searchParams.get("chatId") ?? undefined;
       if (!chatId) {
         return new NextResponse("chatId required", { status: 400 });
       }
 
+      stage = "get_chat";
       const chat = await getChatById({ id: chatId });
       if (!chat || chat.user_id !== userId) {
         return new NextResponse("Forbidden", { status: 403 });
       }
 
-      const runId = await getActiveTriggerRun({ chatId });
+      stage = "get_active_trigger_run";
+      runId = (await getActiveTriggerRun({ chatId })) ?? undefined;
       if (!runId) {
         return new NextResponse(null, { status: 204 });
       }
 
       let runStatus: string | undefined;
       try {
+        stage = "retrieve_trigger_run";
         const run = await runs.retrieve(runId);
         runStatus = run.status;
       } catch (err) {
@@ -56,6 +70,7 @@ export const createAgentResumeGet =
       }
 
       if (runStatus && TERMINAL_STATUSES.has(runStatus)) {
+        stage = "clear_terminal_trigger_run";
         await setActiveTriggerRun({
           chatId,
           triggerRunId: null,
@@ -64,6 +79,7 @@ export const createAgentResumeGet =
         return new NextResponse(null, { status: 204 });
       }
 
+      stage = "create_public_token";
       const publicAccessToken = await auth.createPublicToken({
         scopes: { read: { runs: [runId] } },
         expirationTime: "6h",
@@ -76,6 +92,13 @@ export const createAgentResumeGet =
         endpoint,
         action: "resume",
         fallbackMessage: "Failed to resume run",
+        context: {
+          requestId,
+          userId,
+          chatId,
+          runId,
+          stage,
+        },
       });
     }
   };

--- a/lib/api/agent-route-errors.ts
+++ b/lib/api/agent-route-errors.ts
@@ -43,7 +43,13 @@ const serializeRouteError = (error: unknown) => {
       ? error.message
       : typeof error === "string"
         ? error
-        : String(error);
+        : (() => {
+            try {
+              return JSON.stringify(error);
+            } catch {
+              return String(error);
+            }
+          })();
 
   return {
     error_name: error instanceof Error ? error.name : typeof error,

--- a/lib/api/agent-route-errors.ts
+++ b/lib/api/agent-route-errors.ts
@@ -3,21 +3,96 @@ import { NextResponse } from "next/server";
 import { ChatSDKError } from "@/lib/errors";
 import type { AgentApiEndpoint } from "@/lib/api/agent-endpoints";
 
+const MAX_ERROR_FIELD_LENGTH = 1000;
+const MAX_STACK_FIELD_LENGTH = 2000;
+
+type AgentRouteErrorContext = {
+  requestId?: string;
+  userId?: string;
+  chatId?: string;
+  runId?: string;
+  stage?: string;
+};
+
+const truncate = (value: string, maxLength: number): string =>
+  value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+
+const getErrorStringField = (
+  error: unknown,
+  key: string,
+): string | undefined => {
+  if (!error || typeof error !== "object") return undefined;
+  const value = (error as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+};
+
+const getErrorNumberField = (
+  error: unknown,
+  key: string,
+): number | undefined => {
+  if (!error || typeof error !== "object") return undefined;
+  const value = (error as Record<string, unknown>)[key];
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+};
+
+const serializeRouteError = (error: unknown) => {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : String(error);
+
+  return {
+    error_name: error instanceof Error ? error.name : typeof error,
+    error_message: truncate(message, MAX_ERROR_FIELD_LENGTH),
+    error_status:
+      getErrorNumberField(error, "status") ??
+      getErrorNumberField(error, "statusCode"),
+    error_code: getErrorStringField(error, "code"),
+    error_stack:
+      error instanceof Error && error.stack
+        ? truncate(error.stack, MAX_STACK_FIELD_LENGTH)
+        : undefined,
+  };
+};
+
 export function handleAgentRouteError({
   error,
   endpoint,
   action,
   fallbackMessage,
+  context = {},
 }: {
   error: unknown;
   endpoint: AgentApiEndpoint;
   action: "start" | "resume" | "cancel";
   fallbackMessage: string;
+  context?: AgentRouteErrorContext;
 }) {
   if (error instanceof ChatSDKError) return error.toResponse();
 
   const logSuffix =
     action === "start" ? "failed to trigger task" : `${action} failed`;
-  console.error(`[${endpoint}] ${logSuffix}:`, error);
+  console.error(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level: "error",
+      event: "agent_route_failed",
+      service: "hackerai-web",
+      environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+      endpoint,
+      action,
+      log_message: `[${endpoint}] ${logSuffix}`,
+      request_id: context.requestId,
+      user_id: context.userId,
+      chat_id: context.chatId,
+      trigger_run_id: context.runId,
+      stage: context.stage,
+      ...serializeRouteError(error),
+    }),
+  );
   return new NextResponse(fallbackMessage, { status: 500 });
 }

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -100,6 +100,55 @@ describe("saveChat", () => {
     }
   });
 
+  it("classifies exhausted generic Convex server errors as transient database failures", async () => {
+    const { saveChat, mockMutation, mockPhEvent } =
+      await loadSaveMessageWithMocks();
+    const convexError = new Error("[Request ID: abc] Server Error");
+    mockMutation.mockRejectedValue(convexError as never);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const thrown = await saveChat({
+        id: "chat-1",
+        userId: "user-1",
+        title: "hello",
+      }).catch((error) => error);
+
+      expect(thrown).toMatchObject({
+        type: "offline",
+        surface: "database",
+        statusCode: 503,
+        metadata: expect.objectContaining({
+          db_operation: "chats.saveChat",
+          db_error_name: "Error",
+          db_error_message: "[Request ID: abc] Server Error",
+          db_request_id: "abc",
+          db_retry_reason: "convex_server_error",
+          chat_id: "chat-1",
+          user_id: "user-1",
+          title_length: 5,
+        }),
+      });
+      expect(mockMutation).toHaveBeenCalledTimes(3);
+      expect(mockPhEvent).toHaveBeenCalledWith(
+        "database_operation_failed",
+        expect.objectContaining({
+          db_operation: "chats.saveChat",
+          db_retry_reason: "convex_server_error",
+          chat_id: "chat-1",
+          user_id: "user-1",
+          userId: "user-1",
+        }),
+      );
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
   it("emits queryable PostHog metadata when chat creation still fails", async () => {
     const { saveChat, mockMutation, mockPhEvent } =
       await loadSaveMessageWithMocks();

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -287,6 +287,16 @@ const getRetryableSaveChatErrorReason = (
   return undefined;
 };
 
+const getRetryableReasonForDatabaseOperation = (
+  operation: string,
+  error: unknown,
+): string | undefined => {
+  if (operation === "chats.saveChat") {
+    return getRetryableSaveChatErrorReason(error);
+  }
+  return getRetryableDatabaseErrorReason(error);
+};
+
 const waitForRetryDelay = (delayMs: number) =>
   new Promise((resolve) => setTimeout(resolve, delayMs));
 
@@ -354,7 +364,7 @@ const databaseError = (
   const isChatCanceled = isChatCanceledMessageSaveError(operation, dbErrorData);
   const isChatUnauthorized = isChatUnauthorizedError(dbErrorData);
   const isMessageTooLarge = isMessageTooLargeError(operation, dbErrorData);
-  const retryReason = getRetryableDatabaseErrorReason(error);
+  const retryReason = getRetryableReasonForDatabaseOperation(operation, error);
   const logLevel =
     isChatNotFound || isChatCanceled || isChatUnauthorized || isMessageTooLarge
       ? "warn"

--- a/proxy.ts
+++ b/proxy.ts
@@ -186,6 +186,7 @@ export default async function proxy(request: NextRequest) {
   }
 
   let refreshHitRateLimit = false;
+  let refreshEndedSession = false;
   const hadSessionCookie = request.cookies.has("wos-session");
 
   let authkitResult: Awaited<ReturnType<typeof authkit>>;
@@ -195,6 +196,7 @@ export default async function proxy(request: NextRequest) {
       eagerAuth: true,
       onSessionRefreshError: ({ error }) => {
         if (isEndedSessionRefreshError(error)) {
+          refreshEndedSession = true;
           return;
         }
 
@@ -236,6 +238,10 @@ export default async function proxy(request: NextRequest) {
   }
 
   const { session, headers, authorizationUrl } = authkitResult;
+
+  if (refreshEndedSession) {
+    return buildEndedSessionResponse(request, pathname);
+  }
 
   const requestHeaders = buildRequestHeaders(request, headers);
   const responseHeaders = buildResponseHeaders(headers);

--- a/proxy.ts
+++ b/proxy.ts
@@ -197,6 +197,17 @@ export default async function proxy(request: NextRequest) {
       onSessionRefreshError: ({ error }) => {
         if (isEndedSessionRefreshError(error)) {
           refreshEndedSession = true;
+          console.info(
+            JSON.stringify({
+              timestamp: new Date().toISOString(),
+              level: "info",
+              event: "auth.session_refresh_ended",
+              service: "hackerai-web",
+              environment:
+                process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+              pathname,
+            }),
+          );
           return;
         }
 


### PR DESCRIPTION
Summary
- Treat WorkOS ended-session refresh callbacks as logged-out in proxy and billing actions to avoid stale-cookie 500s.
- Classify exhausted generic Convex saveChat server errors as transient database failures.
- Add structured JSON logging for Agent route failures with request/chat/run/stage context.

Verification
- pnpm test -- __tests__/proxy.test.ts lib/actions/__tests__/billing-context.test.ts lib/db/__tests__/actions-save-message.test.ts lib/api/__tests__/agent-route-errors.test.ts
- pnpm test -- lib/api/__tests__/agent-long-contracts.test.ts
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- Commit hook: full pnpm test passed (209 suites, 2095 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of expired/ended sessions so requests are treated as logged out: session cookies are cleared and the user is not routed through the normal redirect/rate-limit flow.
  - Enhanced agent route failure handling with consistent structured error logging (including action and request context).
  - Improved chat save reliability by surfacing transient database issues more consistently as retryable failures with clearer metadata.
- **Tests**
  - Added/updated Jest coverage for ended-session refresh handling, billing authentication failure paths, agent route error logging, and transient database retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->