### PR TITLE
Apply surcharge to extra usage balance accounting

### DIFF
--- a/convex/__tests__/extraUsageActionsAuth.test.ts
+++ b/convex/__tests__/extraUsageActionsAuth.test.ts
@@ -7,6 +7,7 @@ import {
   beforeEach,
   afterAll,
 } from "@jest/globals";
+import { extraUsagePointsToDollars } from "../lib/extraUsagePricing";
 
 jest.mock("../_generated/server", () => ({
   action: jest.fn((config: any) => config),
@@ -315,7 +316,7 @@ describe("deductWithAutoReload", () => {
     mockListOrganizationMemberships.mockResolvedValue({ data: [] } as never);
     const ctx: any = {
       runQuery: jest.fn(async () => ({
-        balanceDollars: 20,
+        balanceDollars: extraUsagePointsToDollars(200_000),
         balancePoints: 200_000,
         enabled: true,
         autoReloadEnabled: true,
@@ -401,7 +402,7 @@ describe("deductWithAutoReload", () => {
     } as never);
     const ctx: any = {
       runQuery: jest.fn(async () => ({
-        balanceDollars: 20,
+        balanceDollars: extraUsagePointsToDollars(200_000),
         balancePoints: 200_000,
         enabled: true,
         autoReloadEnabled: true,
@@ -431,12 +432,12 @@ describe("deductWithAutoReload", () => {
     });
 
     expect(mockInvoiceItemsCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ amount: 1000 }),
+      expect.objectContaining({ amount: 1150 }),
     );
     expect(result).toMatchObject({
       success: true,
       autoReloadTriggered: true,
-      autoReloadResult: { success: true, chargedAmountDollars: 10 },
+      autoReloadResult: { success: true, chargedAmountDollars: 11.5 },
     });
   });
 
@@ -455,7 +456,7 @@ describe("deductWithAutoReload", () => {
     } as never);
     const ctx: any = {
       runQuery: jest.fn(async () => ({
-        balanceDollars: 29.5,
+        balanceDollars: extraUsagePointsToDollars(295_000),
         balancePoints: 295_000,
         enabled: true,
         autoReloadEnabled: true,

--- a/convex/__tests__/extraUsagePurchases.test.ts
+++ b/convex/__tests__/extraUsagePurchases.test.ts
@@ -6,6 +6,7 @@ import {
   beforeEach,
   afterEach,
 } from "@jest/globals";
+import { extraUsageDollarsToPoints } from "../lib/extraUsagePricing";
 
 jest.mock("../_generated/server", () => ({
   mutation: jest.fn((config: any) => config),
@@ -222,11 +223,12 @@ describe("extra usage purchase ledger", () => {
 
     const result = await callAddCredits(ctx);
 
-    expect(result).toEqual({ newBalance: 50, alreadyProcessed: false });
+    expect(result.alreadyProcessed).toBe(false);
+    expect(result.newBalance).toBeCloseTo(50, 2);
     expect(tables.extra_usage).toMatchObject([
       {
         user_id: "user_123",
-        balance_points: 500_000,
+        balance_points: extraUsageDollarsToPoints(50),
         updated_at: 1_000_000,
       },
     ]);

--- a/convex/__tests__/teamExtraUsage.test.ts
+++ b/convex/__tests__/teamExtraUsage.test.ts
@@ -8,6 +8,10 @@ import {
   afterAll,
   afterEach,
 } from "@jest/globals";
+import {
+  extraUsageDollarsToPoints,
+  extraUsagePointsToDollars,
+} from "../lib/extraUsagePricing";
 
 jest.mock("../_generated/server", () => ({
   action: jest.fn((config: any) => config),
@@ -108,8 +112,6 @@ afterAll(() => {
 const ORG_ID = "org_123";
 const USER_ID = "user_abc";
 const OTHER_USER_ID = "user_xyz";
-
-const POINTS_PER_DOLLAR = 10_000;
 
 type TeamRow = {
   _id: string;
@@ -733,7 +735,7 @@ describe("deductWithAutoReloadForTeam", () => {
     const ctx: any = {
       runQuery: jest.fn(async () => ({
         enabled: true,
-        balanceDollars: 20,
+        balanceDollars: extraUsagePointsToDollars(200_000),
         balancePoints: 200_000,
         autoReloadEnabled: true,
         autoReloadThresholdDollars: 1,
@@ -775,7 +777,7 @@ describe("deductWithAutoReloadForTeam", () => {
     const ctx: any = {
       runQuery: jest.fn(async () => ({
         enabled: true,
-        balanceDollars: 20,
+        balanceDollars: extraUsagePointsToDollars(200_000),
         balancePoints: 200_000,
         autoReloadEnabled: true,
         autoReloadThresholdDollars: 1,
@@ -785,7 +787,7 @@ describe("deductWithAutoReloadForTeam", () => {
       })),
       runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
         if ("amountDollars" in mutationArgs) {
-          return { newBalance: 30 };
+          return { newBalance: 34.5 };
         }
         if ("success" in mutationArgs && !("amountPoints" in mutationArgs)) {
           return null;
@@ -822,12 +824,12 @@ describe("deductWithAutoReloadForTeam", () => {
     });
 
     expect(mockInvoiceItemsCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ amount: 1000 }),
+      expect.objectContaining({ amount: 1150 }),
     );
     expect(result).toMatchObject({
       success: true,
       autoReloadTriggered: true,
-      autoReloadResult: { success: true, chargedAmountDollars: 10 },
+      autoReloadResult: { success: true, chargedAmountDollars: 11.5 },
     });
   });
 });
@@ -928,9 +930,9 @@ describe("addTeamCredits idempotency", () => {
       amountDollars: 25,
     });
     expect(result.alreadyProcessed).toBe(false);
-    expect(result.newBalance).toBe(25);
+    expect(result.newBalance).toBeCloseTo(25, 2);
     expect(team).toHaveLength(1);
-    expect(team[0].balance_points).toBe(25 * POINTS_PER_DOLLAR);
+    expect(team[0].balance_points).toBe(extraUsageDollarsToPoints(25));
   });
 
   it("returns alreadyProcessed when the idempotency key was already seen", async () => {

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -8,36 +8,16 @@ import { v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 import { convexLogger } from "./lib/logger";
 import { recordRevenueEventInternal } from "./unitEconomicsLib";
-
-// =============================================================================
-// Currency Conversion Helpers
-// All monetary values are stored in POINTS internally for precision.
-// 1 point = $0.0001 (10,000 points = $1), matching the rate limiting system.
-// This avoids precision loss when deducting sub-cent amounts.
-// =============================================================================
-
-/** Points per dollar (1 point = $0.0001) - must match token-bucket.ts */
-const POINTS_PER_DOLLAR = 10_000;
-
-/** Convert dollars to points (for storage) */
-const dollarsToPoints = (dollars: number): number =>
-  Math.round(dollars * POINTS_PER_DOLLAR);
-
-/** Convert points to dollars (for API response) */
-const pointsToDollars = (points: number): number => points / POINTS_PER_DOLLAR;
+import {
+  extraUsageDollarsToPoints as dollarsToPoints,
+  extraUsagePointsToDollars as pointsToDollars,
+} from "./lib/extraUsagePricing";
 
 type ExtraUsagePurchaseStatus = "created" | "paid_seen" | "credited" | "failed";
 type ExtraUsagePurchaseRoute =
-  | "checkout_action"
-  | "confirm"
-  | "webhook"
-  | "repair";
+  "checkout_action" | "confirm" | "webhook" | "repair";
 type ExtraUsagePurchaseResult =
-  | "created"
-  | "paid_seen"
-  | "credited"
-  | "already_processed"
-  | "failed";
+  "created" | "paid_seen" | "credited" | "already_processed" | "failed";
 
 const MAX_PURCHASE_ERROR_LENGTH = 500;
 const PURCHASE_JSON_SECRET_PATTERN =

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -6,8 +6,10 @@ import { v } from "convex/values";
 import Stripe from "stripe";
 import { WorkOS } from "@workos-inc/node";
 import { convexLogger } from "./lib/logger";
-
-const POINTS_PER_DOLLAR = 10_000;
+import {
+  extraUsageDollarsToPoints,
+  extraUsagePointsToDollars,
+} from "./lib/extraUsagePricing";
 
 // =============================================================================
 // SDK Initialization (lazy, cached)
@@ -617,8 +619,10 @@ export const deductWithAutoReload = action({
     const monthlyRemainingPoints =
       settings.monthlyRemainingDollars === undefined
         ? undefined
-        : Math.round(settings.monthlyRemainingDollars * POINTS_PER_DOLLAR);
-    const requestedDeductionDollars = args.amountPoints / POINTS_PER_DOLLAR;
+        : extraUsageDollarsToPoints(settings.monthlyRemainingDollars);
+    const requestedDeductionDollars = extraUsagePointsToDollars(
+      args.amountPoints,
+    );
     const requestNeedsReload = settings.balancePoints < args.amountPoints;
     let autoReloadTriggered = false;
     let autoReloadResult:

--- a/convex/lib/extraUsagePricing.ts
+++ b/convex/lib/extraUsagePricing.ts
@@ -1,0 +1,14 @@
+export const EXTRA_USAGE_MULTIPLIER = 1.15;
+export const EXTRA_USAGE_POINTS_PER_DOLLAR = 10_000;
+
+export const extraUsageDollarsToPoints = (dollars: number): number =>
+  Number.isFinite(dollars) && dollars > 0
+    ? Math.floor(
+        (dollars / EXTRA_USAGE_MULTIPLIER) * EXTRA_USAGE_POINTS_PER_DOLLAR,
+      )
+    : 0;
+
+export const extraUsagePointsToDollars = (points: number): number =>
+  Number.isFinite(points) && points > 0
+    ? (points / EXTRA_USAGE_POINTS_PER_DOLLAR) * EXTRA_USAGE_MULTIPLIER
+    : 0;

--- a/convex/teamExtraUsage.ts
+++ b/convex/teamExtraUsage.ts
@@ -8,18 +8,10 @@ import { v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 import { convexLogger } from "./lib/logger";
 import { recordRevenueEventInternal } from "./unitEconomicsLib";
-
-// =============================================================================
-// Currency Conversion Helpers
-// Mirrors extraUsage.ts: 1 point = $0.0001, matching the rate limiting system.
-// =============================================================================
-
-const POINTS_PER_DOLLAR = 10_000;
-
-const dollarsToPoints = (dollars: number): number =>
-  Math.round(dollars * POINTS_PER_DOLLAR);
-
-const pointsToDollars = (points: number): number => points / POINTS_PER_DOLLAR;
+import {
+  extraUsageDollarsToPoints as dollarsToPoints,
+  extraUsagePointsToDollars as pointsToDollars,
+} from "./lib/extraUsagePricing";
 
 // =============================================================================
 // Internal helpers

--- a/convex/teamExtraUsageActions.ts
+++ b/convex/teamExtraUsageActions.ts
@@ -6,6 +6,10 @@ import { v } from "convex/values";
 import Stripe from "stripe";
 import { WorkOS } from "@workos-inc/node";
 import { convexLogger } from "./lib/logger";
+import {
+  extraUsageDollarsToPoints,
+  extraUsagePointsToDollars,
+} from "./lib/extraUsagePricing";
 
 // =============================================================================
 // SDK Initialization (lazy, cached)
@@ -13,7 +17,6 @@ import { convexLogger } from "./lib/logger";
 
 let stripeInstance: Stripe | null = null;
 let workosInstance: WorkOS | null = null;
-const POINTS_PER_DOLLAR = 10_000;
 
 function getStripe(): Stripe {
   if (!stripeInstance) {
@@ -366,7 +369,9 @@ export const deductWithAutoReloadForTeam = action({
 
     const thresholdPoints = state.autoReloadThresholdPoints ?? 0;
     const reloadAmount = state.autoReloadAmountDollars ?? 0;
-    const requestedDeductionDollars = args.amountPoints / POINTS_PER_DOLLAR;
+    const requestedDeductionDollars = extraUsagePointsToDollars(
+      args.amountPoints,
+    );
     const requestNeedsReload = state.balancePoints < args.amountPoints;
     const balanceForReloadPoints = deductResult.success
       ? deductResult.newBalancePoints
@@ -458,8 +463,8 @@ export const deductWithAutoReloadForTeam = action({
                   if (deductResult.success) {
                     deductResult = {
                       ...deductResult,
-                      newBalancePoints: Math.round(
-                        creditResult.newBalance * POINTS_PER_DOLLAR,
+                      newBalancePoints: extraUsageDollarsToPoints(
+                        creditResult.newBalance,
                       ),
                       newBalanceDollars: creditResult.newBalance,
                     };

--- a/lib/__tests__/extra-usage.test.ts
+++ b/lib/__tests__/extra-usage.test.ts
@@ -22,7 +22,7 @@ describe("extra-usage", () => {
 
     it("should preserve sub-cent precision", () => {
       // 1 point = $0.0001 base, * 1.15 = $0.000115
-      expect(pointsToDollars(1)).toBeCloseTo(0.000115);
+      expect(pointsToDollars(1)).toBeCloseTo(0.000115, 6);
       // 100 points = $0.01 base, * 1.15 = $0.0115
       expect(pointsToDollars(100)).toBe(0.0115);
     });

--- a/lib/__tests__/extra-usage.test.ts
+++ b/lib/__tests__/extra-usage.test.ts
@@ -20,11 +20,11 @@ describe("extra-usage", () => {
       expect(pointsToDollars(10000)).toBe(1.15);
     });
 
-    it("should round up to nearest cent", () => {
-      // 1 point = $0.0001 base, * 1.15 = $0.000115 -> rounds up to $0.01
-      expect(pointsToDollars(1)).toBe(0.01);
-      // 100 points = $0.01 base, * 1.15 = $0.0115 -> rounds up to $0.02
-      expect(pointsToDollars(100)).toBe(0.02);
+    it("should preserve sub-cent precision", () => {
+      // 1 point = $0.0001 base, * 1.15 = $0.000115
+      expect(pointsToDollars(1)).toBeCloseTo(0.000115);
+      // 100 points = $0.01 base, * 1.15 = $0.0115
+      expect(pointsToDollars(100)).toBe(0.0115);
     });
 
     it("should return 0 for 0 points", () => {
@@ -33,7 +33,7 @@ describe("extra-usage", () => {
 
     it("should handle large point values", () => {
       // 1M points = $100 base, * 1.15 = $115
-      expect(pointsToDollars(1_000_000)).toBe(115);
+      expect(pointsToDollars(1_000_000)).toBeCloseTo(115);
     });
 
     it("should apply EXTRA_USAGE_MULTIPLIER correctly", () => {

--- a/lib/extra-usage.ts
+++ b/lib/extra-usage.ts
@@ -1,11 +1,13 @@
-import { POINTS_PER_DOLLAR } from "@/lib/rate-limit/token-bucket";
+import {
+  EXTRA_USAGE_MULTIPLIER,
+  extraUsagePointsToDollars,
+} from "@/convex/lib/extraUsagePricing";
 import { getConvexClient } from "@/lib/db/convex-client";
 import { api } from "@/convex/_generated/api";
 import { phLogger } from "@/lib/posthog/server";
 import { stringifyRedactedError } from "@/lib/utils/error-redaction";
 
-/** Extra usage pricing multiplier */
-export const EXTRA_USAGE_MULTIPLIER = 1.15;
+export { EXTRA_USAGE_MULTIPLIER };
 
 const errorName = (error: unknown) =>
   error instanceof Error ? error.name : "UnknownError";
@@ -84,8 +86,7 @@ export interface DeductBalanceResult {
  * Points are internal units (1 point = $0.0001)
  */
 export function pointsToDollars(points: number): number {
-  const dollars = (points / POINTS_PER_DOLLAR) * EXTRA_USAGE_MULTIPLIER;
-  return Math.ceil(dollars * 100) / 100; // Round up to nearest cent
+  return extraUsagePointsToDollars(points);
 }
 
 /**

--- a/lib/rate-limit/usage-settlement.ts
+++ b/lib/rate-limit/usage-settlement.ts
@@ -1,4 +1,5 @@
 import type { ExtraUsageConfig, RateLimitInfo } from "@/types";
+import { extraUsageDollarsToPoints } from "@/convex/lib/extraUsagePricing";
 import {
   billableCostDollarsToPoints,
   POINTS_PER_DOLLAR,
@@ -60,7 +61,7 @@ export const createUsageSettlementState = (
     ),
     extraUsageBalanceAtStartPoints: Math.max(
       0,
-      costDollarsToPoints(extraUsageConfig?.balanceDollars ?? 0) -
+      extraUsageDollarsToPoints(extraUsageConfig?.balanceDollars ?? 0) -
         initialExtraUsagePointsDeducted,
     ),
     extraUsageMonthlyRemainingAtStartPoints:
@@ -68,8 +69,9 @@ export const createUsageSettlementState = (
         ? undefined
         : Math.max(
             0,
-            costDollarsToPoints(extraUsageConfig.monthlyRemainingDollars) -
-              initialExtraUsagePointsDeducted,
+            extraUsageDollarsToPoints(
+              extraUsageConfig.monthlyRemainingDollars,
+            ) - initialExtraUsagePointsDeducted,
           ),
   };
 };


### PR DESCRIPTION
## Summary
- apply the extra usage 1.15x surcharge in the Convex source-of-truth balance conversions
- share personal/team extra usage pricing helpers across purchase, balance, auto-reload, and settlement paths
- update personal/team purchase and auto-reload tests to assert surcharge-adjusted point accounting

## Verification
- pnpm test --runInBand lib/__tests__/extra-usage.test.ts convex/__tests__/extraUsagePurchases.test.ts convex/__tests__/teamExtraUsage.test.ts convex/__tests__/extraUsageActionsAuth.test.ts lib/rate-limit/__tests__/usage-settlement.test.ts
- pnpm typecheck
- pnpm lint
- full Jest suite via commit hook: 2107 passed

## Manual verification
- In staging, buy a fixed extra-usage amount and confirm displayed balance remains the purchased dollar amount while stored points equal amount / 1.15 * 10000.
- Trigger an auto-reload-backed extra-usage deduction and confirm Stripe charge covers the surcharge-adjusted customer-dollar shortfall.
- Confirm monthly extra-usage cap/spent values display in customer dollars and block at the configured cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared extra-usage pricing utility to standardize dollar↔point conversions across the system.

* **Bug Fixes**
  * Improved auto-reload and settlement calculations to use consistent conversion rules, aligning charged amounts and remaining credits with the new pricing behavior.
  * Preserved sub-cent precision to reduce rounding discrepancies.

* **Tests**
  * Updated purchase, team, and pricing unit tests to rely on the shared conversion helpers and revised expected values accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->