### PR TITLE
Update HackerAI Pro model routing

### DIFF
--- a/app/components/FinishReasonNotice.tsx
+++ b/app/components/FinishReasonNotice.tsx
@@ -7,7 +7,6 @@ import { captureAgentRunSpendCapContinueClick } from "@/lib/analytics/client";
 import {
   AGENT_RUN_SPEND_CAP_FINISH_REASON,
   AGENT_RUN_SPEND_CAP_REASON,
-  AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL,
 } from "@/lib/chat/agent-run-spend-cap";
 import {
   BUDGET_EXHAUSTION_FINISH_REASON,
@@ -71,7 +70,7 @@ export const FinishReasonNotice = ({
     }
 
     if (finishReason === AGENT_RUN_SPEND_CAP_FINISH_REASON) {
-      return <>Paused at the Pro Agent per-run safety cap.</>;
+      return <>Paused at a legacy Pro Agent per-run safety cap.</>;
     }
 
     if (finishReason === BUDGET_EXHAUSTION_FINISH_REASON) {
@@ -85,19 +84,12 @@ export const FinishReasonNotice = ({
 
   if (!content) return null;
 
-  const shouldContinueWithStandard =
-    finishReason === AGENT_RUN_SPEND_CAP_FINISH_REASON &&
-    agentRunSpendCapPremiumContinuationAllowed === false;
   const showContinue =
     onContinue &&
     !hasContinued &&
     finishReason !== BUDGET_EXHAUSTION_FINISH_REASON;
-  const continuationModel = shouldContinueWithStandard
-    ? AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL
-    : undefined;
-  const continueButtonLabel = shouldContinueWithStandard
-    ? "Continue with Standard"
-    : "Continue";
+  const continuationModel = undefined;
+  const continueButtonLabel = "Continue";
 
   return (
     <div className="mt-2 w-full">

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -72,7 +72,7 @@ const shouldWarnForPaidHighCostModel = (
 ): boolean =>
   subscription !== "free" &&
   subscription !== "ultra" &&
-  (model === "hackerai-max" || model === "hackerai-pro");
+  model === "hackerai-max";
 
 const AutoOptionButton = ({
   isSelected,

--- a/app/components/ModelSelector/CostIndicator.tsx
+++ b/app/components/ModelSelector/CostIndicator.tsx
@@ -7,13 +7,13 @@ import {
 type CostTier = "low" | "medium" | "high" | "very-high";
 
 // Cost tier per HackerAI tier id. Standard stays low cost in both modes;
-// Pro and Max intentionally surface the higher-cost model choices.
+// Pro reflects the GLM/Kimi route, while Max surfaces the highest-cost choice.
 export function getCostTier(modelId: string): CostTier {
   switch (modelId) {
     case "hackerai-standard":
       return "low";
     case "hackerai-pro":
-      return "high";
+      return "medium";
     case "hackerai-max":
       return "very-high";
     default:

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -69,43 +69,31 @@ describe("ModelSelector", () => {
     expect(onChange).toHaveBeenCalledWith("auto");
   });
 
-  it("warns before selecting HackerAI Pro in ask mode on paid plans", () => {
+  it("selects HackerAI Pro in ask mode without a high-cost warning", () => {
     const onChange = jest.fn();
     render(<ModelSelector value="auto" onChange={onChange} mode="ask" />);
 
     fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
     fireEvent.click(screen.getByRole("button", { name: /HackerAI Pro/i }));
 
-    expect(onChange).not.toHaveBeenCalled();
-    expect(screen.getByTestId("high-cost-model-warning")).toBeVisible();
-    expect(screen.getByText("High-cost model")).toBeVisible();
     expect(
-      screen.getByText(/long requests can use around \$10 of usage/i),
-    ).toBeVisible();
-
-    fireEvent.click(screen.getByRole("button", { name: /Use HackerAI Pro/i }));
-
-    expect(mockDismissHighCostModelUsageNotice).toHaveBeenCalledTimes(1);
+      screen.queryByTestId("high-cost-model-warning"),
+    ).not.toBeInTheDocument();
+    expect(mockDismissHighCostModelUsageNotice).not.toHaveBeenCalled();
     expect(onChange).toHaveBeenCalledWith("hackerai-pro");
   });
 
-  it("warns before selecting HackerAI Pro in agent mode on paid plans", () => {
+  it("selects HackerAI Pro in agent mode without a high-cost warning", () => {
     const onChange = jest.fn();
     render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
 
     fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
     fireEvent.click(screen.getByRole("button", { name: /HackerAI Pro/i }));
 
-    expect(onChange).not.toHaveBeenCalled();
-    expect(screen.getByTestId("high-cost-model-warning")).toBeVisible();
-    expect(screen.getByText("High-cost model")).toBeVisible();
     expect(
-      screen.getByText(/long requests can use around \$10 of usage/i),
-    ).toBeVisible();
-
-    fireEvent.click(screen.getByRole("button", { name: /Use HackerAI Pro/i }));
-
-    expect(mockDismissHighCostModelUsageNotice).toHaveBeenCalledTimes(1);
+      screen.queryByTestId("high-cost-model-warning"),
+    ).not.toBeInTheDocument();
+    expect(mockDismissHighCostModelUsageNotice).not.toHaveBeenCalled();
     expect(onChange).toHaveBeenCalledWith("hackerai-pro");
   });
 
@@ -136,13 +124,13 @@ describe("ModelSelector", () => {
     expect(onChange).toHaveBeenCalledWith("hackerai-max");
   });
 
-  it("uses team-specific warning copy for team users", () => {
+  it("uses team-specific warning copy for team users selecting Max", () => {
     mockSubscription = "team";
     const onChange = jest.fn();
     render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
 
     fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
-    fireEvent.click(screen.getByRole("button", { name: /HackerAI Pro/i }));
+    fireEvent.click(screen.getByRole("button", { name: /HackerAI Max/i }));
 
     expect(onChange).not.toHaveBeenCalled();
     expect(screen.getByText(/your team's usage/i)).toBeVisible();

--- a/app/components/ModelSelector/__tests__/options-drift.test.ts
+++ b/app/components/ModelSelector/__tests__/options-drift.test.ts
@@ -40,12 +40,12 @@ describe("ModelSelector tier ↔ provider drift", () => {
     );
   });
 
-  it("HackerAI Pro resolves to Sonnet in both modes", () => {
+  it("HackerAI Pro resolves to GLM in both modes", () => {
     expect(resolveTierToProviderKey("hackerai-pro", "ask")).toBe(
-      "model-sonnet-4.6",
+      "model-glm-5.2",
     );
     expect(resolveTierToProviderKey("hackerai-pro", "agent")).toBe(
-      "model-sonnet-4.6",
+      "model-glm-5.2",
     );
   });
 

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -22,7 +22,7 @@ export const ASK_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-pro",
     label: "HackerAI Pro",
     description: "Superior performance for most assignments",
-    poweredBy: "Claude Sonnet 4.6",
+    poweredBy: "Z.ai GLM 5.2 · Kimi K2.7 for vision",
   },
   {
     id: "hackerai-max",
@@ -44,7 +44,7 @@ export const AGENT_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-pro",
     label: "HackerAI Pro",
     description: "Superior performance for most assignments",
-    poweredBy: "Claude Sonnet 4.6",
+    poweredBy: "Z.ai GLM 5.2 · Kimi K2.7 for vision",
     thinking: true,
   },
   {

--- a/app/components/RateLimitWarning.tsx
+++ b/app/components/RateLimitWarning.tsx
@@ -117,11 +117,7 @@ const getMessage = (data: RateLimitWarningData, timeString: string): string => {
   }
 
   if (data.warningType === "agent-run-spend-cap") {
-    if (data.premiumContinuationAllowed) {
-      return `This Pro Agent run paused after using $${data.runCostDollars.toFixed(2)} of the $${data.runCapDollars.toFixed(2)} per-run safety cap. Continue to keep working with extra usage.`;
-    }
-
-    return `This Pro Agent run paused after using $${data.runCostDollars.toFixed(2)} of the $${data.runCapDollars.toFixed(2)} per-run safety cap. Continue with Standard to keep working without extra usage.`;
+    return `This Pro Agent run paused after using $${data.runCostDollars.toFixed(2)} of the $${data.runCapDollars.toFixed(2)} legacy per-run safety cap. Continue to keep working.`;
   }
 
   // Token bucket warning — show dollar amounts when available

--- a/app/components/__tests__/FinishReasonNotice.test.tsx
+++ b/app/components/__tests__/FinishReasonNotice.test.tsx
@@ -241,7 +241,7 @@ describe("FinishReasonNotice", () => {
       ).toBeInTheDocument();
     });
 
-    it("renders the Pro Agent run cap notice and continues with Standard when premium continuation is unavailable", () => {
+    it("renders the legacy Pro Agent run cap notice and keeps the current model when premium continuation is unavailable", () => {
       const onContinue = jest.fn();
       renderNotice(
         {
@@ -254,13 +254,11 @@ describe("FinishReasonNotice", () => {
       );
 
       expect(
-        screen.getByText(/Paused at the Pro Agent per-run safety cap/i),
+        screen.getByText(/Paused at a legacy Pro Agent per-run safety cap/i),
       ).toBeInTheDocument();
-      fireEvent.click(
-        screen.getByRole("button", { name: /continue with standard/i }),
-      );
+      fireEvent.click(screen.getByRole("button", { name: /^continue$/i }));
 
-      expect(onContinue).toHaveBeenCalledWith("hackerai-standard");
+      expect(onContinue).toHaveBeenCalledWith(undefined);
     });
 
     it("keeps the current selected model when spend-cap continuation eligibility is unknown", () => {

--- a/app/components/__tests__/RateLimitWarning.test.tsx
+++ b/app/components/__tests__/RateLimitWarning.test.tsx
@@ -60,7 +60,7 @@ describe("RateLimitWarning", () => {
     expect(screen.getByText(/free Agent requests/i)).toBeInTheDocument();
   });
 
-  it("renders Pro Agent run cap copy without upgrade or add-credit CTAs", () => {
+  it("renders legacy Pro Agent run cap copy without upgrade or add-credit CTAs", () => {
     render(
       <RateLimitWarning
         data={{
@@ -81,6 +81,9 @@ describe("RateLimitWarning", () => {
     expect(screen.getByText(/Pro Agent run paused/i)).toHaveTextContent(
       "$5.24",
     );
+    expect(screen.getByText(/legacy per-run safety cap/i)).toHaveTextContent(
+      "Continue to keep working",
+    );
     expect(
       screen.queryByRole("button", { name: /upgrade plan/i }),
     ).not.toBeInTheDocument();
@@ -89,7 +92,7 @@ describe("RateLimitWarning", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("points spend-cap continuation to Standard when premium continuation is unavailable", () => {
+  it("uses current-model continuation copy when premium continuation is unavailable", () => {
     render(
       <RateLimitWarning
         data={{
@@ -108,7 +111,7 @@ describe("RateLimitWarning", () => {
     );
 
     expect(screen.getByText(/Pro Agent run paused/i)).toHaveTextContent(
-      "Continue with Standard",
+      "Continue to keep working",
     );
   });
 

--- a/docs/paid-funnel-analytics.md
+++ b/docs/paid-funnel-analytics.md
@@ -19,12 +19,12 @@ Paid funnel events use stable snake_case event names. Most events include
 - `limit_hit`: a chat or agent request was blocked by a free or paid limit.
 - `monthly_cap_hit`: legacy paid-only monthly cap event kept for existing
   dashboards.
-- `agent_run_spend_cap_hit`: a Pro Agent run was paused by the per-run spend
-  cap.
-- `agent_run_spend_cap_impressed`: the client showed the per-run spend-cap
-  pause message.
-- `agent_run_spend_cap_continue_clicked`: the user explicitly continued after
-  a per-run spend-cap pause.
+- `agent_run_spend_cap_hit`: legacy event for a retired Pro Agent per-run
+  spend cap.
+- `agent_run_spend_cap_impressed`: legacy event for the retired per-run
+  spend-cap pause message.
+- `agent_run_spend_cap_continue_clicked`: legacy event for continuing after a
+  retired per-run spend-cap pause.
 - `add_credit_cta_impressed`: an add-credit prompt became visible.
 - `add_credit_cta_clicked`: a user clicked an add-credit prompt.
 - `add_credit_checkout_started`: an extra-usage credit checkout was created.
@@ -60,8 +60,8 @@ Paid funnel events use stable snake_case event names. Most events include
   in USD unless `currency` says otherwise.
 - `cap_reason`, `limit_type`, `reset_timestamp`: limit-pressure context.
 - `run_cost_dollars`, `run_cap_dollars`, `monthly_remaining_dollars`,
-  `cap_basis`: Pro Agent per-run spend-cap context.
-  `cap_basis` is currently `fixed_5_dollars`.
+  `cap_basis`: legacy Pro Agent per-run spend-cap context. Historical
+  `cap_basis` values used `fixed_5_dollars`.
 - `primary_cta`, `eligible_ctas`, `upgrade_available`,
   `add_credit_available`: monetization paths shown or available for that
   limit pressure moment.
@@ -101,8 +101,9 @@ Paid funnel events use stable snake_case event names. Most events include
 - Limit pressure to paid/add-credit: `limit_hit -> upgrade_cta_clicked` and
   `limit_hit -> add_credit_checkout_succeeded`, grouped by `primary_cta`,
   `eligible_ctas`, and `cap_reason`.
-- Pro Agent cap to churn: `agent_run_spend_cap_hit -> subscription_cancelled`,
-  grouped by `agent_run_spend_cap_continue_clicked`, `cap_basis`, and
+- Legacy Pro Agent cap to churn:
+  `agent_run_spend_cap_hit -> subscription_cancelled`, grouped by
+  `agent_run_spend_cap_continue_clicked`, `cap_basis`, and
   `cancellation_reason`.
 - Referral revenue:
   `referred_signup_attributed -> referred_user_paid_conversion`, grouped by

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -26,6 +26,10 @@ describe("provider registry", () => {
         .modelId,
     ).toBe("x-ai/grok-4.3");
     expect(
+      (myProvider.languageModel("model-glm-5.2") as { modelId: string })
+        .modelId,
+    ).toBe("z-ai/glm-5.2");
+    expect(
       (
         myProvider.languageModel("model-gemini-3-flash") as {
           modelId: string;
@@ -53,6 +57,7 @@ describe("provider registry", () => {
     ).toBe("x-ai/grok-4.3");
     expect(getModelDisplayName("model-minimax-m3")).toBe("MiniMax M3");
     expect(getModelDisplayName("model-grok-4.3")).toBe("xAI Grok 4.3");
+    expect(getModelDisplayName("model-glm-5.2")).toBe("Z.ai GLM 5.2");
     expect(getModelDisplayName("model-gemini-3-flash")).toBe("xAI Grok 4.3");
     expect(getModelDisplayName("title-generator-model")).toBe("xAI Grok 4.3");
   });

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -179,6 +179,7 @@ const openrouter = createOpenRouter({
 type OpenRouterInstance = typeof openrouter;
 
 export const KIMI_K2_7_CODE_SLUG = "moonshotai/kimi-k2.7-code:exacto";
+export const GLM_5_2_SLUG = "z-ai/glm-5.2";
 export const MINIMAX_M3_SLUG = "minimax/minimax-m3";
 export const GROK_4_3_SLUG = "x-ai/grok-4.3";
 
@@ -196,6 +197,7 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "model-deepseek-v4-flash": or("deepseek/deepseek-v4-flash"),
     "model-deepseek-v4-pro": or("deepseek/deepseek-v4-pro"),
     "model-opus-4.6": or("anthropic/claude-opus-4.6"),
+    "model-glm-5.2": or(GLM_5_2_SLUG),
     "model-minimax-m3": or(MINIMAX_M3_SLUG),
     "model-kimi-k2.7-code": or(KIMI_K2_7_CODE_SLUG),
     // Compatibility alias for stale internal references persisted before the
@@ -223,6 +225,7 @@ export const modelCutoffDates: Record<ModelName, string> &
   "model-deepseek-v4-flash": "May 2025",
   "model-deepseek-v4-pro": "May 2025",
   "model-opus-4.6": "May 2025",
+  "model-glm-5.2": "June 2026",
   "model-minimax-m3": "May 2026",
   "model-kimi-k2.7-code": "June 2025",
   "model-kimi-k2.6": "June 2025",
@@ -244,6 +247,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-deepseek-v4-flash": "DeepSeek V4 Flash",
   "model-deepseek-v4-pro": "DeepSeek V4 Pro",
   "model-opus-4.6": "Anthropic Claude Opus 4.6",
+  "model-glm-5.2": "Z.ai GLM 5.2",
   "model-minimax-m3": "MiniMax M3",
   "model-kimi-k2.7-code": "Moonshot Kimi K2.7 Code",
   "model-kimi-k2.6": "Moonshot Kimi K2.7 Code",
@@ -331,7 +335,7 @@ export function resolveTierToProviderKey(
     case "hackerai-standard":
       return isAgentMode(mode) ? "model-minimax-m3" : "model-deepseek-v4-pro";
     case "hackerai-pro":
-      return "model-sonnet-4.6";
+      return "model-glm-5.2";
     case "hackerai-max":
       return "model-opus-4.6";
   }

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -26,6 +26,7 @@ jest.mock("@/lib/logger", () => ({
 const GROK_SLUG = "x-ai/grok-4.3";
 const MINIMAX_SLUG = "minimax/minimax-m3";
 const KIMI_SLUG = "moonshotai/kimi-k2.7-code:exacto";
+const GLM_SLUG = "z-ai/glm-5.2";
 
 describe("buildProviderOptions fallback chain", () => {
   it("resolves Opus 4.6 ask chain to Grok", () => {
@@ -96,6 +97,19 @@ describe("buildProviderOptions fallback chain", () => {
       "model-sonnet-4.6",
       "agent",
       { hasMultimodalToolResults: true },
+    );
+    expect(opts.openrouter).toMatchObject({
+      models: [KIMI_SLUG, GROK_SLUG],
+      user: "user-1",
+    });
+  });
+
+  it("resolves GLM 5.2 to Kimi 2.7 Code then Grok", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-glm-5.2",
+      "agent",
     );
     expect(opts.openrouter).toMatchObject({
       models: [KIMI_SLUG, GROK_SLUG],
@@ -300,7 +314,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it.each(["model-sonnet-4.6", "model-opus-4.6"])(
+  it.each(["model-glm-5.2", "model-sonnet-4.6", "model-opus-4.6"])(
     "enables high reasoning for ask mode model %s",
     (modelName) => {
       const opts = buildProviderOptions(false, "user-1", modelName, "ask");
@@ -311,7 +325,7 @@ describe("buildProviderOptions fallback chain", () => {
     },
   );
 
-  it.each(["model-sonnet-4.6", "model-opus-4.6"])(
+  it.each(["model-glm-5.2", "model-sonnet-4.6", "model-opus-4.6"])(
     "enables high reasoning for agent mode model %s",
     (modelName) => {
       const opts = buildProviderOptions(true, "user-1", modelName, "agent");
@@ -386,7 +400,7 @@ describe("isAutoModelSelectionForRetry", () => {
     ).toBe(false);
     expect(
       isAutoModelSelectionForRetry({
-        selectedModel: "model-sonnet-4.6",
+        selectedModel: "model-glm-5.2",
         selectedModelOverride: "hackerai-pro",
       }),
     ).toBe(false);
@@ -485,6 +499,23 @@ describe("resolveServedModelForCostAccounting", () => {
         mode: "ask",
       }),
     ).toBe("model-sonnet-4.6");
+  });
+
+  it("maps GLM provider response slugs back to the local cost key", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "model-glm-5.2",
+        responseModel: GLM_SLUG,
+        mode: "agent",
+      }),
+    ).toBe("model-glm-5.2");
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "model-glm-5.2",
+        responseModel: "z-ai/glm-5.2-20260616",
+        mode: "ask",
+      }),
+    ).toBe("model-glm-5.2");
   });
 
   it("falls back to the active model key when provider metadata is absent", () => {

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -98,6 +98,8 @@ import type { createTrackedProvider } from "@/lib/ai/providers";
 import type { ProviderRequestDiagnostics } from "@/lib/logger";
 import type { ChatMode, SubscriptionTier } from "@/types";
 
+const GLM_AGENT_VISION_MODEL = "model-kimi-k2.7-code";
+
 // ---------------------------------------------------------------------------
 // Mutable state — the runner updates these in place; callers read them back.
 // ---------------------------------------------------------------------------
@@ -443,6 +445,7 @@ export async function createAgentStream(
   > => getActiveToolsWithExclusions();
   const requestedLanguageModel = ctx.trackedProvider.languageModel(modelName);
   const requestedSlug = requestedLanguageModel.modelId;
+  let lastRequestedSlug = requestedSlug;
   const assistantContentLoopMonitor = createAssistantContentLoopMonitor();
   const assistantContentLoopAbortController = new AbortController();
   const abortSignal = combineAbortSignals([
@@ -467,7 +470,7 @@ export async function createAgentStream(
       state.streamUsage = lastStep.usage as Record<string, unknown>;
     }
     state.responseModel = lastStep?.response?.modelId ?? state.responseModel;
-    state.responseModel ??= requestedSlug;
+    state.responseModel ??= lastRequestedSlug;
 
     const openRouterMetadata = lastStep
       ? extractOpenRouterMetadata({
@@ -545,24 +548,43 @@ export async function createAgentStream(
   let streamHasImageViewResults = uiMessagesContainImageViewResult(
     state.finalMessages,
   );
-  const getStepProviderOptions = () =>
+  const getEffectiveModelName = () =>
+    modelName === "model-glm-5.2" &&
+    ctx.mode === "agent" &&
+    streamHasImageViewResults
+      ? GLM_AGENT_VISION_MODEL
+      : modelName;
+  const getEffectiveModelInfo = () => {
+    const effectiveModelName = getEffectiveModelName();
+    const languageModel = ctx.trackedProvider.languageModel(effectiveModelName);
+    lastRequestedSlug = languageModel.modelId;
+    return {
+      modelName: effectiveModelName,
+      languageModel,
+      requestedSlug: languageModel.modelId,
+    };
+  };
+  const getStepProviderOptions = (
+    effectiveModelName = getEffectiveModelName(),
+  ) =>
     buildProviderOptions(
       ctx.isReasoningModel,
       ctx.userId,
-      modelName,
+      effectiveModelName,
       ctx.mode,
       {
         hasMultimodalToolResults: streamHasImageViewResults,
-        ...(ctx.providerReasoningOverride?.modelName === modelName && {
+        ...(ctx.providerReasoningOverride?.modelName === effectiveModelName && {
           reasoningOverride: ctx.providerReasoningOverride.reasoning,
         }),
       },
     );
   const prepareProviderMessages = (
     messages: ModelMessage[],
+    effectiveModelName = getEffectiveModelName(),
   ): ModelMessage[] => {
     const nonEmptyMessages = filterEmptyAssistantMessages(messages);
-    if (!isAnthropicModel(modelName)) return nonEmptyMessages;
+    if (!isAnthropicModel(effectiveModelName)) return nonEmptyMessages;
 
     const repair = repairAnthropicModelMessagesWithTelemetry(nonEmptyMessages);
     if (repair.action !== "none") {
@@ -570,13 +592,15 @@ export async function createAgentStream(
         action: repair.action,
         reason: repair.reason,
         trailingAssistantContentTypes: repair.trailingAssistantContentTypes,
-        model: modelName,
+        model: effectiveModelName,
       });
     }
     return repair.messages as ModelMessage[];
   };
   let latestProviderRequestDiagnostics: ProviderRequestDiagnostics | undefined;
   const recordProviderRequestDiagnostics = (args: {
+    modelName: string;
+    requestedSlug?: string;
     stepIndex: number;
     source: ProviderRequestDiagnostics["source"];
     messages: ModelMessage[];
@@ -584,8 +608,8 @@ export async function createAgentStream(
     activeTools: Array<keyof typeof ctx.tools> | undefined;
   }) => {
     latestProviderRequestDiagnostics = buildProviderRequestDiagnostics({
-      modelName,
-      requestedSlug,
+      modelName: args.modelName,
+      requestedSlug: args.requestedSlug,
       stepIndex: args.stepIndex,
       source: args.source,
       messages: args.messages,
@@ -602,14 +626,20 @@ export async function createAgentStream(
     );
     return latestProviderRequestDiagnostics;
   };
-  const initialProviderOptions = getStepProviderOptions();
+  const initialModelInfo = getEffectiveModelInfo();
+  const initialProviderOptions = getStepProviderOptions(
+    initialModelInfo.modelName,
+  );
   const promptSerializationTools = createPromptSerializationTools(ctx.tools);
   const initialModelMessages = prepareProviderMessages(
     await convertToModelMessages(state.finalMessages, {
       tools: promptSerializationTools,
     }),
+    initialModelInfo.modelName,
   );
   recordProviderRequestDiagnostics({
+    modelName: initialModelInfo.modelName,
+    requestedSlug: initialModelInfo.requestedSlug,
     stepIndex: 0,
     source: "initial",
     messages: initialModelMessages,
@@ -618,9 +648,12 @@ export async function createAgentStream(
   });
 
   return streamText({
-    model: requestedLanguageModel,
+    model: initialModelInfo.languageModel,
     maxOutputTokens,
-    system: buildSystemPrompt(ctx.currentSystemPrompt, modelName),
+    system: buildSystemPrompt(
+      ctx.currentSystemPrompt,
+      initialModelInfo.modelName,
+    ),
     messages: initialModelMessages,
     tools: ctx.tools,
     activeTools: initialActiveTools,
@@ -642,6 +675,7 @@ export async function createAgentStream(
         if (toolResultsContainImageViewResult(toolResults)) {
           streamHasImageViewResults = true;
         }
+        const effectiveModelInfo = getEffectiveModelInfo();
 
         const loopRecovery = getDoomLoopRecovery(steps, steps.length);
 
@@ -651,7 +685,7 @@ export async function createAgentStream(
             messages: state.finalMessages,
             modelMessages: messages,
             subscription: ctx.subscription,
-            languageModel: ctx.trackedProvider.languageModel(modelName),
+            languageModel: effectiveModelInfo.languageModel,
             mode: ctx.mode,
             writer: ctx.writer,
             chatId: ctx.chatId,
@@ -665,7 +699,9 @@ export async function createAgentStream(
             providerInputTokens: state.lastStepInputTokens,
             chatSystemPrompt: ctx.currentSystemPrompt,
             tools: ctx.tools,
-            providerOptions: getStepProviderOptions(),
+            providerOptions: getStepProviderOptions(
+              effectiveModelInfo.modelName,
+            ),
             transcriptMessages: state.transcriptSourceMessages,
             providerPromptPressure,
           });
@@ -681,7 +717,9 @@ export async function createAgentStream(
             }
             state.transcriptSourceMessages = undefined;
             const activeTools = await getActiveToolsForRecovery(loopRecovery);
-            const providerOptions = getStepProviderOptions();
+            const providerOptions = getStepProviderOptions(
+              effectiveModelInfo.modelName,
+            );
             let summarizedModelMessages = await convertToModelMessages(
               result.summarizedMessages,
               {
@@ -700,8 +738,11 @@ export async function createAgentStream(
             ];
             const preparedMessages = prepareProviderMessages(
               summarizedModelMessages,
+              effectiveModelInfo.modelName,
             );
             recordProviderRequestDiagnostics({
+              modelName: effectiveModelInfo.modelName,
+              requestedSlug: effectiveModelInfo.requestedSlug,
               stepIndex: steps.length + 1,
               source: "summarized_prepare_step",
               messages: preparedMessages,
@@ -709,6 +750,7 @@ export async function createAgentStream(
               activeTools,
             });
             return {
+              model: effectiveModelInfo.languageModel,
               activeTools,
               providerOptions,
               messages: preparedMessages,
@@ -735,14 +777,19 @@ export async function createAgentStream(
         }
 
         const activeTools = await getActiveToolsForRecovery(loopRecovery);
-        const providerOptions = getStepProviderOptions();
+        const providerOptions = getStepProviderOptions(
+          effectiveModelInfo.modelName,
+        );
         const preparedMessages = prepareProviderMessages(
           addCacheBreakpointToLastUserMessage(
             updatedMessages,
-            modelName,
+            effectiveModelInfo.modelName,
           ) as ModelMessage[],
+          effectiveModelInfo.modelName,
         ) as typeof messages;
         recordProviderRequestDiagnostics({
+          modelName: effectiveModelInfo.modelName,
+          requestedSlug: effectiveModelInfo.requestedSlug,
           stepIndex: steps.length + 1,
           source: "prepare_step",
           messages: preparedMessages as ModelMessage[],
@@ -750,6 +797,7 @@ export async function createAgentStream(
           activeTools,
         });
         return {
+          model: effectiveModelInfo.languageModel,
           activeTools,
           providerOptions,
           messages: preparedMessages,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -54,7 +54,6 @@ import {
 import {
   BudgetMonitor,
   captureBudgetSnapshot,
-  getProAgentRunSpendCap,
 } from "@/lib/chat/budget-monitor";
 import { UsageTracker } from "@/lib/usage-tracker";
 import {
@@ -72,7 +71,6 @@ import {
   shutdownPostHog,
   type ChatLogger,
 } from "@/lib/api/chat-logger";
-import { captureAgentRunSpendCapHit } from "@/lib/chat/agent-run-spend-cap-analytics";
 import { resolveAgentRunSpendCapContinuationModel } from "@/lib/chat/agent-run-spend-cap";
 import {
   countFileAttachments,
@@ -836,32 +834,13 @@ export const createChatHandler = () => {
             const streamStartTime = Date.now();
             const configuredModelId =
               trackedProvider.languageModel(selectedModel).modelId;
-            const agentRunSpendCap = getProAgentRunSpendCap({
-              snapshot: effectiveBudgetSnapshot,
-              subscription,
-              mode,
-            });
             const budgetMonitor = effectiveBudgetSnapshot
               ? new BudgetMonitor(
                   effectiveBudgetSnapshot,
                   writer,
                   subscription,
                   {
-                    agentRunSpendCap,
                     extraUsageConfig,
-                    onAgentRunSpendCapHit: (hit) => {
-                      captureAgentRunSpendCapHit({
-                        userId,
-                        subscription,
-                        mode,
-                        chatId,
-                        endpoint,
-                        selectedModel,
-                        selectedModelOverride,
-                        configuredModelSlug: configuredModelId,
-                        hit,
-                      });
-                    },
                   },
                 )
               : null;

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -488,6 +488,7 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "agent-model": MINIMAX_M3_FALLBACK_CHAIN,
   "model-grok-4.3": AGENT_TEXT_FALLBACK_CHAIN,
   "model-gemini-3-flash": AGENT_TEXT_FALLBACK_CHAIN,
+  "model-glm-5.2": MINIMAX_M3_FALLBACK_CHAIN,
   "model-minimax-m3": MINIMAX_M3_FALLBACK_CHAIN,
   "fallback-agent-model": MINIMAX_M3_FALLBACK_CHAIN,
   "fallback-ask-model": MINIMAX_M3_FALLBACK_CHAIN,
@@ -543,6 +544,7 @@ const isAskMediumReasoningModel = (modelName?: string): boolean =>
   (ASK_MEDIUM_REASONING_MODELS as readonly string[]).includes(modelName);
 
 const HIGH_REASONING_MODELS = [
+  "model-glm-5.2",
   "model-sonnet-4.6",
   "model-opus-4.6",
 ] as const satisfies readonly ModelName[];
@@ -638,6 +640,10 @@ const OPENROUTER_RESPONSE_MODEL_COST_KEYS: Record<string, ModelName> = {
   "anthropic/claude-opus-4.6": "model-opus-4.6",
   "anthropic/claude-sonnet-4-6": "model-sonnet-4.6",
   "anthropic/claude-sonnet-4.6": "model-sonnet-4.6",
+  "z-ai/glm-5.2": "model-glm-5.2",
+  "z-ai/glm-5.2-20260616": "model-glm-5.2",
+  "moonshotai/kimi-k2.7-code": "model-kimi-k2.7-code",
+  "moonshotai/kimi-k2.7-code:exacto": "model-kimi-k2.7-code",
 };
 
 function resolveOpenRouterResponseModelCostKey(

--- a/lib/chat/__tests__/agent-run-spend-cap.test.ts
+++ b/lib/chat/__tests__/agent-run-spend-cap.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
 import {
-  AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL,
   canContinueProAgentRunWithPremium,
   resolveAgentRunSpendCapContinuationModel,
 } from "../agent-run-spend-cap";
@@ -55,7 +54,7 @@ describe("canContinueProAgentRunWithPremium", () => {
 });
 
 describe("resolveAgentRunSpendCapContinuationModel", () => {
-  it("forces Pro Agent spend-cap continuations to Standard without extra usage", () => {
+  it("preserves Pro Agent spend-cap continuations without requiring extra usage", () => {
     expect(
       resolveAgentRunSpendCapContinuationModel({
         finishReason: "agent-run-spend-cap",
@@ -65,7 +64,7 @@ describe("resolveAgentRunSpendCapContinuationModel", () => {
         selectedModelOverride: "hackerai-pro",
         extraUsageConfig: undefined,
       }),
-    ).toBe(AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL);
+    ).toBe("hackerai-pro");
 
     expect(
       resolveAgentRunSpendCapContinuationModel({
@@ -76,7 +75,7 @@ describe("resolveAgentRunSpendCapContinuationModel", () => {
         selectedModelOverride: "auto",
         extraUsageConfig: undefined,
       }),
-    ).toBe(AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL);
+    ).toBe("auto");
 
     expect(
       resolveAgentRunSpendCapContinuationModel({
@@ -87,7 +86,7 @@ describe("resolveAgentRunSpendCapContinuationModel", () => {
         selectedModelOverride: undefined,
         extraUsageConfig: undefined,
       }),
-    ).toBe(AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL);
+    ).toBeUndefined();
 
     expect(
       resolveAgentRunSpendCapContinuationModel({
@@ -98,7 +97,7 @@ describe("resolveAgentRunSpendCapContinuationModel", () => {
         selectedModelOverride: "hackerai-pro",
         extraUsageConfig: undefined,
       }),
-    ).toBe(AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL);
+    ).toBe("hackerai-pro");
 
     expect(
       resolveAgentRunSpendCapContinuationModel({
@@ -109,10 +108,10 @@ describe("resolveAgentRunSpendCapContinuationModel", () => {
         selectedModelOverride: "hackerai-max",
         extraUsageConfig: undefined,
       }),
-    ).toBe(AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL);
+    ).toBe("hackerai-max");
   });
 
-  it("keeps the premium model when extra usage or auto-reload can cover continuation", () => {
+  it("keeps the selected model when extra usage or auto-reload can cover continuation", () => {
     expect(
       resolveAgentRunSpendCapContinuationModel({
         finishReason: "agent-run-spend-cap",

--- a/lib/chat/__tests__/budget-monitor.test.ts
+++ b/lib/chat/__tests__/budget-monitor.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, jest } from "@jest/globals";
 import {
   BudgetMonitor,
   captureBudgetSnapshot,
-  getProAgentRunSpendCap,
   type BudgetSnapshot,
 } from "../budget-monitor";
 import type { ExtraUsageConfig, RateLimitInfo } from "@/types";
@@ -117,13 +116,7 @@ describe("BudgetMonitor", () => {
       extraUsageBalanceAtStart: 1,
       extraUsageMonthlyRemainingAtStart: 1,
     };
-    const monitor = new BudgetMonitor(snapshot, writer, "pro", {
-      agentRunSpendCap: getProAgentRunSpendCap({
-        snapshot,
-        subscription: "pro",
-        mode: "agent",
-      }),
-    });
+    const monitor = new BudgetMonitor(snapshot, writer, "pro");
 
     const decision = monitor.checkAfterStep(0.002);
 
@@ -241,7 +234,7 @@ describe("BudgetMonitor", () => {
     );
   });
 
-  it("aborts Pro Agent runs when the per-run spend cap is crossed", () => {
+  it("aborts when an explicit agent run spend cap option is crossed", () => {
     const writer = makeWriter();
     const onAgentRunSpendCapHit = jest.fn();
     const monitor = new BudgetMonitor(
@@ -353,55 +346,5 @@ describe("captureBudgetSnapshot", () => {
       extraUsageAutoReload: true,
       extraUsageMonthlyRemainingAtStart: 3,
     });
-  });
-});
-
-describe("getProAgentRunSpendCap", () => {
-  it("uses the fixed five dollar cap when included monthly usage can cover it", () => {
-    const snapshot: BudgetSnapshot = {
-      ...baseSnapshot,
-      monthlyRemainingAtStart: 100_000,
-    };
-
-    expect(
-      getProAgentRunSpendCap({
-        snapshot,
-        subscription: "pro",
-        mode: "agent",
-      }),
-    ).toEqual({
-      capDollars: 5,
-      basis: "fixed_5_dollars",
-    });
-  });
-
-  it("does not cap when included monthly usage cannot cover the fixed cap", () => {
-    expect(
-      getProAgentRunSpendCap({
-        snapshot: {
-          ...baseSnapshot,
-          monthlyRemainingAtStart: 49_999,
-        },
-        subscription: "pro",
-        mode: "agent",
-      }),
-    ).toBeNull();
-  });
-
-  it("does not cap non-Pro tiers or Ask mode", () => {
-    expect(
-      getProAgentRunSpendCap({
-        snapshot: baseSnapshot,
-        subscription: "pro-plus",
-        mode: "agent",
-      }),
-    ).toBeNull();
-    expect(
-      getProAgentRunSpendCap({
-        snapshot: baseSnapshot,
-        subscription: "pro",
-        mode: "ask",
-      }),
-    ).toBeNull();
   });
 });

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -198,21 +198,23 @@ describe("selectModel", () => {
 
   // Tier override — Standard is content-aware in ask mode; Max maps to Opus in both modes
   describe("tier override for ask mode (paid users)", () => {
-    it("should map HackerAI Pro to Sonnet 4.6 for text-only ask mode", () => {
-      expect(selectModel("ask", "ultra", "hackerai-pro")).toBe(
-        "model-sonnet-4.6",
-      );
+    it("should map HackerAI Pro to GLM 5.2 for text-only ask mode", () => {
+      expect(selectModel("ask", "ultra", "hackerai-pro")).toBe("model-glm-5.2");
     });
 
-    it("should map HackerAI Pro to Sonnet 4.6 for team users", () => {
-      expect(selectModel("ask", "team", "hackerai-pro")).toBe(
-        "model-sonnet-4.6",
-      );
+    it("should map HackerAI Pro to GLM 5.2 for team users", () => {
+      expect(selectModel("ask", "team", "hackerai-pro")).toBe("model-glm-5.2");
     });
 
-    it("should keep HackerAI Pro on Sonnet 4.6 when an image is attached", () => {
+    it("should route HackerAI Pro to Kimi K2.7 when an image is attached", () => {
       expect(selectModel("ask", "pro", "hackerai-pro", true, false)).toBe(
-        "model-sonnet-4.6",
+        "model-kimi-k2.7-code",
+      );
+    });
+
+    it("should route HackerAI Pro to Kimi K2.7 when a PDF is attached", () => {
+      expect(selectModel("ask", "pro", "hackerai-pro", false, true)).toBe(
+        "model-kimi-k2.7-code",
       );
     });
 
@@ -253,9 +255,13 @@ describe("selectModel", () => {
       );
     });
 
-    it("should map HackerAI Pro to Sonnet 4.6 in agent mode", () => {
-      expect(selectModel("agent", "pro", "hackerai-pro")).toBe(
-        "model-sonnet-4.6",
+    it("should map HackerAI Pro to GLM 5.2 in text-only agent mode", () => {
+      expect(selectModel("agent", "pro", "hackerai-pro")).toBe("model-glm-5.2");
+    });
+
+    it("should route HackerAI Pro to Kimi K2.7 in agent mode when an image is attached", () => {
+      expect(selectModel("agent", "pro", "hackerai-pro", true, false)).toBe(
+        "model-kimi-k2.7-code",
       );
     });
 

--- a/lib/chat/agent-run-spend-cap.ts
+++ b/lib/chat/agent-run-spend-cap.ts
@@ -7,9 +7,6 @@ import type {
 
 export const AGENT_RUN_SPEND_CAP_REASON = "agent_run_spend_cap" as const;
 export const AGENT_RUN_SPEND_CAP_FINISH_REASON = "agent-run-spend-cap" as const;
-export const PRO_AGENT_RUN_SPEND_CAP_DOLLARS = 5;
-export const AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL =
-  "hackerai-standard" as const satisfies SelectedModel;
 
 export const AGENT_RUN_SPEND_CAP_BASES = ["fixed_5_dollars"] as const;
 
@@ -61,26 +58,5 @@ export function resolveAgentRunSpendCapContinuationModel(args: {
   selectedModelOverride: SelectedModel | undefined;
   extraUsageConfig: ExtraUsageConfig | undefined;
 }): SelectedModel | undefined {
-  const {
-    finishReason,
-    mode,
-    subscription,
-    selectedModelOverride,
-    extraUsageConfig,
-  } = args;
-
-  const isAlreadyStandardContinuation =
-    selectedModelOverride === AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL;
-
-  if (
-    finishReason !== AGENT_RUN_SPEND_CAP_FINISH_REASON ||
-    mode !== "agent" ||
-    subscription !== "pro" ||
-    isAlreadyStandardContinuation ||
-    canContinueProAgentRunWithPremium(extraUsageConfig)
-  ) {
-    return selectedModelOverride;
-  }
-
-  return AGENT_RUN_SPEND_CAP_STANDARD_CONTINUATION_MODEL;
+  return args.selectedModelOverride;
 }

--- a/lib/chat/budget-monitor.ts
+++ b/lib/chat/budget-monitor.ts
@@ -3,7 +3,6 @@ import "server-only";
 import type { UIMessageStreamWriter } from "ai";
 import type {
   ExtraUsageConfig,
-  ChatMode,
   RateLimitInfo,
   SubscriptionTier,
 } from "@/types";
@@ -16,7 +15,6 @@ import { writeRateLimitWarning } from "@/lib/utils/stream-writer-utils";
 import type { LimitCapReason } from "@/lib/limit-pressure";
 import {
   canContinueProAgentRunWithPremium,
-  PRO_AGENT_RUN_SPEND_CAP_DOLLARS,
   type AgentRunSpendCap,
   type AgentRunSpendCapHit,
 } from "@/lib/chat/agent-run-spend-cap";
@@ -100,24 +98,6 @@ export function captureBudgetSnapshot(args: {
     extraUsageAutoReload: extraUsageConfig?.autoReloadEnabled ?? false,
     extraUsageMonthlyRemainingAtStart:
       extraUsageConfig?.monthlyRemainingDollars,
-  };
-}
-
-export function getProAgentRunSpendCap(args: {
-  snapshot: BudgetSnapshot | null;
-  subscription: SubscriptionTier;
-  mode: ChatMode;
-}): AgentRunSpendCap | null {
-  const { snapshot, subscription, mode } = args;
-  if (!snapshot || subscription !== "pro" || mode !== "agent") return null;
-
-  const monthlyRemainingDollars =
-    snapshot.monthlyRemainingAtStart / POINTS_PER_DOLLAR;
-  if (monthlyRemainingDollars < PRO_AGENT_RUN_SPEND_CAP_DOLLARS) return null;
-
-  return {
-    capDollars: PRO_AGENT_RUN_SPEND_CAP_DOLLARS,
-    basis: "fixed_5_dollars",
   };
 }
 

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -40,9 +40,9 @@ export const getMaxStepsForUser = (
  * @param hasImageAttachment - Whether any message has an image attachment.
  * @param hasPdfAttachment - Whether any message has a PDF attachment.
  *   Paid ASK on the Standard/auto route normally uses DeepSeek V4 Pro
- *   (text-only, much cheaper than Claude); prompts with images or PDFs promote
- *   to Grok 4.3 for native media support. Free ASK stays on DeepSeek V4 Flash.
- *   Free Agent routes to MiniMax M3. Paid ASK Pro always uses Sonnet 4.6.
+ *   (text-only); prompts with images or PDFs promote to Grok 4.3 for native
+ *   media support. HackerAI Pro uses GLM 5.2 for text-only prompts and Kimi
+ *   K2.7 Code when provider-visible media is attached.
  * @returns Model name to use
  */
 export function selectModel(
@@ -55,10 +55,11 @@ export function selectModel(
   const isAgent = isAgentMode(mode);
   // DeepSeek ask routes are text-only, so image/PDF prompts promote to a
   // media-capable route unless the selected tier intentionally uses a
-  // multimodal/file-capable model such as Sonnet or Opus.
+  // multimodal/file-capable model such as Kimi or Opus.
   const isFreeAsk = !isAgent && subscription === "free";
   const hasAskImage = !isAgent && !!hasImageAttachment;
   const hasAskPdf = !isAgent && !!hasPdfAttachment;
+  const hasProProviderMedia = !!hasImageAttachment || hasAskPdf;
   const paidAskMediaModel: ModelName =
     hasAskImage || hasAskPdf ? "ask-model" : "model-deepseek-v4-pro";
 
@@ -85,8 +86,8 @@ export function selectModel(
       : "model-deepseek-v4-pro";
   }
 
-  if (selectedModel === "hackerai-pro" && !isAgent) {
-    return "model-sonnet-4.6";
+  if (selectedModel === "hackerai-pro") {
+    return hasProProviderMedia ? "model-kimi-k2.7-code" : "model-glm-5.2";
   }
 
   const providerKey = resolveTierToProviderKey(selectedModel, mode);

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -424,6 +424,15 @@ describe("token-bucket", () => {
       ).toBe(11310);
     });
 
+    it("should use GLM 5.2 pricing ($0.9086/$2.856)", () => {
+      expect(calculateTokenCost(1_000_000, "input", "model-glm-5.2")).toBe(
+        11812,
+      );
+      expect(calculateTokenCost(1_000_000, "output", "model-glm-5.2")).toBe(
+        37128,
+      );
+    });
+
     it.each(["agent-model", "agent-model-free", "model-minimax-m3"])(
       "should use MiniMax M3 pricing for %s ($0.30/$1.20)",
       (modelName) => {

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -36,6 +36,8 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   "model-deepseek-v4-pro": { input: 0.435, output: 0.87 },
   "fallback-grok-4.3": { input: 1.25, output: 2.5 },
   "model-opus-4.6": { input: 5.0, output: 25.0 },
+  // Rates from OpenRouter: $0.9086 in / $2.856 out per 1M tokens.
+  "model-glm-5.2": { input: 0.9086, output: 2.856 },
   // These keys route to minimax/minimax-m3 via lib/ai/providers.ts.
   // Rates from OpenRouter: $0.30 in / $1.20 out per 1M tokens.
   "agent-model": { input: 0.3, output: 1.2 },

--- a/lib/system-prompt/resume.ts
+++ b/lib/system-prompt/resume.ts
@@ -35,7 +35,7 @@ Resume the task exactly where you left off without repeating what was already do
 </resume_context>`;
   } else if (finishReason === "agent-run-spend-cap") {
     return `<resume_context>
-Your previous response was paused by the Pro Agent per-run spend cap. \
+Your previous response was paused by a legacy Pro Agent per-run spend cap. \
 This was a user cost-control pause, not a task failure. If the user says "continue" or similar, \
 resume the task exactly where you left off without repeating what was already done.
 </resume_context>`;

--- a/lib/utils/stream-writer-utils.ts
+++ b/lib/utils/stream-writer-utils.ts
@@ -132,7 +132,7 @@ export type RateLimitWarningData =
       midStream?: boolean;
     }
   | {
-      // Pro Agent users: per-run spend cap paused the current run.
+      // Legacy Pro Agent per-run spend-cap warning.
       warningType: "agent-run-spend-cap";
       resetTime: string;
       subscription: "pro";

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -43,9 +43,7 @@ import {
 import {
   BudgetMonitor,
   captureBudgetSnapshot,
-  getProAgentRunSpendCap,
 } from "@/lib/chat/budget-monitor";
-import { captureAgentRunSpendCapHit } from "@/lib/chat/agent-run-spend-cap-analytics";
 import { UsageTracker } from "@/lib/usage-tracker";
 import {
   acquireFreeRunConcurrencyLock,
@@ -1500,32 +1498,13 @@ export const agentLongTask = task({
             const streamStartTime = taskStartTime;
             const configuredModelId =
               trackedProvider.languageModel(selectedModel).modelId;
-            const agentRunSpendCap = getProAgentRunSpendCap({
-              snapshot: effectiveBudgetSnapshot,
-              subscription,
-              mode,
-            });
             const budgetMonitor = effectiveBudgetSnapshot
               ? new BudgetMonitor(
                   effectiveBudgetSnapshot,
                   writer,
                   subscription,
                   {
-                    agentRunSpendCap,
                     extraUsageConfig,
-                    onAgentRunSpendCapHit: (hit) => {
-                      captureAgentRunSpendCapHit({
-                        userId,
-                        subscription,
-                        mode,
-                        chatId,
-                        endpoint,
-                        selectedModel,
-                        selectedModelOverride,
-                        configuredModelSlug: configuredModelId,
-                        hit,
-                      });
-                    },
                   },
                 )
               : null;


### PR DESCRIPTION
## Summary
- Route HackerAI Pro text-only Ask and Agent requests to z-ai/glm-5.2, with Kimi K2.7 Code used for vision/media paths.
- Update provider, pricing, fallback, and model selector UI metadata for the new Pro routing.
- Remove the active Pro Agent per-run extra usage cap/downgrade path while keeping legacy cap messages marked as legacy.

## Verification
- pnpm test -- app/components/ModelSelector/__tests__/ModelSelector.test.tsx app/components/ModelSelector/__tests__/options-drift.test.ts lib/ai/__tests__/providers.test.ts lib/chat/__tests__/chat-processor.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/chat/__tests__/budget-monitor.test.ts lib/chat/__tests__/agent-run-spend-cap.test.ts lib/rate-limit/__tests__/token-bucket.test.ts app/components/__tests__/RateLimitWarning.test.tsx app/components/__tests__/FinishReasonNotice.test.tsx lib/api/__tests__/agent-long-contracts.test.ts lib/api/__tests__/chat-handler-pty-cleanup.test.ts
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- commit hook: pnpm typecheck and full pnpm test (210 suites, 2111 tests)

## Manual verification
- In the model selector, choose HackerAI Pro and confirm it shows GLM 5.2 with Kimi K2.7 for vision and no high-cost warning.
- Send a text-only Pro Ask and Agent request and confirm the configured model is GLM 5.2.
- Send a Pro request with image/media input and confirm the configured model is Kimi K2.7 Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Pro model routing to use Z.ai GLM 5.2 in more chat and agent scenarios, including media-aware selections.
  * Added pricing and cost tracking support for the new model.

* **Bug Fixes**
  * Simplified spend-cap continue flows to show clearer legacy cap messaging.
  * Reduced high-cost warnings so they only appear for the highest-cost model.
  * Adjusted model cost labels and provider details to match current behavior.

* **Documentation**
  * Updated paid-funnel analytics guidance for legacy spend-cap events and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->