### PR TITLE
Harden stale client billing calls

### DIFF
--- a/app/api/billing/__tests__/routes.test.ts
+++ b/app/api/billing/__tests__/routes.test.ts
@@ -40,6 +40,14 @@ function request(body: unknown) {
   };
 }
 
+function unreadableJsonRequest() {
+  return {
+    json: async () => {
+      throw new SyntaxError("Invalid JSON");
+    },
+  };
+}
+
 describe("billing API routes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -133,5 +141,32 @@ describe("billing API routes", () => {
         reasonDetails: "Budget changed",
       },
     });
+  });
+
+  it("returns a validation error for malformed cancellation bodies", async () => {
+    const { POST } = await import("../cancel/route");
+    const malformedBodies = [
+      null,
+      {},
+      { cancellationReason: null },
+      { cancellationReason: [] },
+    ];
+
+    for (const body of malformedBodies) {
+      const response = await POST(request(body) as never);
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: "Please select the main cancellation reason",
+      });
+    }
+
+    const unreadableResponse = await POST(unreadableJsonRequest() as never);
+
+    expect(unreadableResponse.status).toBe(400);
+    await expect(unreadableResponse.json()).resolves.toEqual({
+      error: "Please select the main cancellation reason",
+    });
+    expect(mockCancelSubscription).not.toHaveBeenCalled();
   });
 });

--- a/app/api/billing/__tests__/routes.test.ts
+++ b/app/api/billing/__tests__/routes.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+
+const mockRedirectToBillingPortal = jest.fn();
+const mockGetSubscriptionCancellationStatus = jest.fn();
+const mockKeepSubscription = jest.fn();
+const mockCancelSubscription = jest.fn();
+
+jest.mock("@/lib/actions/billing-portal", () => ({
+  __esModule: true,
+  default: mockRedirectToBillingPortal,
+}));
+
+jest.mock("@/lib/actions/subscription-status", () => ({
+  __esModule: true,
+  default: mockGetSubscriptionCancellationStatus,
+}));
+
+jest.mock("@/lib/actions/keep-subscription", () => ({
+  __esModule: true,
+  default: mockKeepSubscription,
+}));
+
+jest.mock("@/lib/actions/cancel-subscription", () => ({
+  __esModule: true,
+  default: mockCancelSubscription,
+}));
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+function request(body: unknown) {
+  return {
+    json: async () => body,
+  };
+}
+
+describe("billing API routes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns a billing portal URL", async () => {
+    mockRedirectToBillingPortal.mockResolvedValue(
+      "https://billing.stripe.com/session" as never,
+    );
+    const { POST } = await import("../portal/route");
+
+    const response = await POST();
+
+    await expect(response.json()).resolves.toEqual({
+      url: "https://billing.stripe.com/session",
+    });
+    expect(response.status).toBe(200);
+  });
+
+  it("maps expected billing errors to JSON responses", async () => {
+    mockRedirectToBillingPortal.mockRejectedValue(
+      new Error("Only admins or owners can manage billing") as never,
+    );
+    const { POST } = await import("../portal/route");
+
+    const response = await POST();
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "Only admins or owners can manage billing",
+    });
+  });
+
+  it("returns subscription cancellation status", async () => {
+    mockGetSubscriptionCancellationStatus.mockResolvedValue({
+      hasActiveSubscription: true,
+      cancelAtPeriodEnd: true,
+      currentPeriodEnd: 1_782_444_800_000,
+    } as never);
+    const { GET } = await import("../subscription-status/route");
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      hasActiveSubscription: true,
+      cancelAtPeriodEnd: true,
+      currentPeriodEnd: 1_782_444_800_000,
+    });
+  });
+
+  it("keeps a subscription through a stable POST endpoint", async () => {
+    mockKeepSubscription.mockResolvedValue({
+      kept: true,
+      cancelAtPeriodEnd: false,
+      alreadyKept: false,
+    } as never);
+    const { POST } = await import("../keep/route");
+
+    const response = await POST();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      kept: true,
+      cancelAtPeriodEnd: false,
+      alreadyKept: false,
+    });
+  });
+
+  it("passes cancellation reason input to the cancellation action", async () => {
+    mockCancelSubscription.mockResolvedValue({
+      canceled: true,
+      cancelAtPeriodEnd: true,
+      alreadyScheduled: false,
+    } as never);
+    const { POST } = await import("../cancel/route");
+
+    const response = await POST(
+      request({
+        cancellationReason: {
+          reasonCategory: "too_expensive",
+          reasonDetails: "Budget changed",
+        },
+      }) as never,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockCancelSubscription).toHaveBeenCalledWith({
+      cancellationReason: {
+        reasonCategory: "too_expensive",
+        reasonDetails: "Budget changed",
+      },
+    });
+  });
+});

--- a/app/api/billing/cancel/route.ts
+++ b/app/api/billing/cancel/route.ts
@@ -1,0 +1,26 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import cancelSubscription from "@/lib/actions/cancel-subscription";
+import { billingRouteErrorResponse } from "@/lib/billing/api-response";
+import type { CancelSubscriptionInput } from "@/lib/billing/api-types";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  try {
+    const input = (await request
+      .json()
+      .catch(() => ({}))) as Partial<CancelSubscriptionInput>;
+    return NextResponse.json(
+      await cancelSubscription({
+        cancellationReason: {
+          reasonCategory: input.cancellationReason?.reasonCategory,
+          reasonDetails: input.cancellationReason?.reasonDetails,
+        },
+      } as CancelSubscriptionInput),
+    );
+  } catch (error) {
+    return billingRouteErrorResponse(error);
+  }
+}

--- a/app/api/billing/cancel/route.ts
+++ b/app/api/billing/cancel/route.ts
@@ -3,23 +3,40 @@ import { NextResponse } from "next/server";
 
 import cancelSubscription from "@/lib/actions/cancel-subscription";
 import { billingRouteErrorResponse } from "@/lib/billing/api-response";
-import type { CancelSubscriptionInput } from "@/lib/billing/api-types";
 
 export const dynamic = "force-dynamic";
 
+type CancelSubscriptionRouteInput = Parameters<typeof cancelSubscription>[0];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseCancelSubscriptionInput(
+  body: unknown,
+): CancelSubscriptionRouteInput | Error {
+  if (!isRecord(body) || !isRecord(body.cancellationReason)) {
+    return new Error("Please select the main cancellation reason");
+  }
+
+  return {
+    cancellationReason: {
+      reasonCategory: body.cancellationReason.reasonCategory,
+      reasonDetails: body.cancellationReason.reasonDetails,
+    },
+  };
+}
+
 export async function POST(request: NextRequest) {
   try {
-    const input = (await request
-      .json()
-      .catch(() => ({}))) as Partial<CancelSubscriptionInput>;
-    return NextResponse.json(
-      await cancelSubscription({
-        cancellationReason: {
-          reasonCategory: input.cancellationReason?.reasonCategory,
-          reasonDetails: input.cancellationReason?.reasonDetails,
-        },
-      } as CancelSubscriptionInput),
-    );
+    const body = await request.json().catch(() => null);
+    const input = parseCancelSubscriptionInput(body);
+
+    if (input instanceof Error) {
+      return billingRouteErrorResponse(input);
+    }
+
+    return NextResponse.json(await cancelSubscription(input));
   } catch (error) {
     return billingRouteErrorResponse(error);
   }

--- a/app/api/billing/keep/route.ts
+++ b/app/api/billing/keep/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+import keepSubscription from "@/lib/actions/keep-subscription";
+import { billingRouteErrorResponse } from "@/lib/billing/api-response";
+
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  try {
+    return NextResponse.json(await keepSubscription());
+  } catch (error) {
+    return billingRouteErrorResponse(error);
+  }
+}

--- a/app/api/billing/portal/route.ts
+++ b/app/api/billing/portal/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+import redirectToBillingPortal from "@/lib/actions/billing-portal";
+import { billingRouteErrorResponse } from "@/lib/billing/api-response";
+
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  try {
+    const url = await redirectToBillingPortal();
+    return NextResponse.json({ url });
+  } catch (error) {
+    return billingRouteErrorResponse(error);
+  }
+}

--- a/app/api/billing/subscription-status/route.ts
+++ b/app/api/billing/subscription-status/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+import getSubscriptionCancellationStatus from "@/lib/actions/subscription-status";
+import { billingRouteErrorResponse } from "@/lib/billing/api-response";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    return NextResponse.json(await getSubscriptionCancellationStatus());
+  } catch (error) {
+    return billingRouteErrorResponse(error);
+  }
+}

--- a/app/components/AccountTab.tsx
+++ b/app/components/AccountTab.tsx
@@ -29,11 +29,12 @@ import {
 } from "@/lib/pricing/features";
 import DeleteAccountDialog from "./DeleteAccountDialog";
 import CancelSubscriptionDialog from "./CancelSubscriptionDialog";
-import redirectToBillingPortalAction from "@/lib/actions/billing-portal";
-import getSubscriptionCancellationStatusAction, {
-  type SubscriptionCancellationStatus,
-} from "@/lib/actions/subscription-status";
-import keepSubscriptionAction from "@/lib/actions/keep-subscription";
+import {
+  getSubscriptionCancellationStatus,
+  keepSubscription,
+  redirectToBillingPortal as openBillingPortal,
+} from "@/lib/billing/client";
+import type { SubscriptionCancellationStatus } from "@/lib/billing/api-types";
 import type { SubscriptionTier } from "@/types";
 
 type AccountCancellationStatus = SubscriptionCancellationStatus & {
@@ -104,7 +105,7 @@ const AccountTab = () => {
 
     let ignore = false;
 
-    getSubscriptionCancellationStatusAction()
+    getSubscriptionCancellationStatus()
       .then((status) => {
         if (!ignore) setCancellationStatus({ ...status, subscription });
       })
@@ -129,7 +130,7 @@ const AccountTab = () => {
 
   const redirectToBillingPortal = async () => {
     try {
-      const url = await redirectToBillingPortalAction();
+      const url = await openBillingPortal();
       if (url) {
         window.location.href = url;
       }
@@ -164,7 +165,7 @@ const AccountTab = () => {
 
     setIsKeepingPlan(true);
     try {
-      const result = await keepSubscriptionAction();
+      const result = await keepSubscription();
       setCancellationStatus({
         subscription,
         hasActiveSubscription: true,

--- a/app/components/CancelSubscriptionDialog.tsx
+++ b/app/components/CancelSubscriptionDialog.tsx
@@ -13,7 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useGlobalState } from "@/app/contexts/GlobalState";
-import cancelSubscriptionAction from "@/lib/actions/cancel-subscription";
+import { cancelSubscription } from "@/lib/billing/client";
 import { toast } from "sonner";
 import {
   CheckCircle2,
@@ -180,7 +180,7 @@ export const CancelSubscriptionDialog = ({
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
     try {
-      const result = await cancelSubscriptionAction({
+      const result = await cancelSubscription({
         cancellationReason: {
           reasonCategory,
           reasonDetails: trimmedReasonDetails,

--- a/app/components/ChunkLoadRecovery.tsx
+++ b/app/components/ChunkLoadRecovery.tsx
@@ -14,6 +14,11 @@ const CHUNK_LOAD_PATTERNS = [
   /Failed to fetch dynamically imported module/i,
 ];
 
+const STALE_SERVER_ACTION_PATTERNS = [
+  /Failed to find Server Action/i,
+  /older or newer deployment/i,
+];
+
 type StorageLike = Pick<Storage, "getItem" | "setItem">;
 
 function collectErrorStrings(
@@ -61,7 +66,18 @@ export function isChunkLoadFailure(error: unknown): boolean {
   );
 }
 
-export function maybeRecoverFromChunkLoadFailure(
+export function isStaleServerActionFailure(error: unknown): boolean {
+  const strings = collectErrorStrings(error);
+  return strings.some((value) =>
+    STALE_SERVER_ACTION_PATTERNS.some((pattern) => pattern.test(value)),
+  );
+}
+
+export function isRecoverableClientStalenessFailure(error: unknown): boolean {
+  return isChunkLoadFailure(error) || isStaleServerActionFailure(error);
+}
+
+export function maybeRecoverFromClientStalenessFailure(
   error: unknown,
   {
     storage,
@@ -75,7 +91,7 @@ export function maybeRecoverFromChunkLoadFailure(
     cooldownMs?: number;
   },
 ): boolean {
-  if (!isChunkLoadFailure(error)) return false;
+  if (!isRecoverableClientStalenessFailure(error)) return false;
 
   try {
     const storedReloadedAt = storage.getItem(CHUNK_LOAD_RELOAD_STORAGE_KEY);
@@ -98,21 +114,27 @@ export function maybeRecoverFromChunkLoadFailure(
   return true;
 }
 
+export const maybeRecoverFromChunkLoadFailure =
+  maybeRecoverFromClientStalenessFailure;
+
 export function ChunkLoadRecovery() {
   useEffect(() => {
-    const recover = (error: unknown) => {
-      maybeRecoverFromChunkLoadFailure(error, {
+    const recover = (error: unknown) =>
+      maybeRecoverFromClientStalenessFailure(error, {
         storage: window.sessionStorage,
         reload: () => window.location.reload(),
       });
-    };
 
     const onError = (event: ErrorEvent) => {
-      recover(event.error ?? event.message);
+      if (recover(event.error ?? event.message)) {
+        event.preventDefault();
+      }
     };
 
     const onUnhandledRejection = (event: PromiseRejectionEvent) => {
-      recover(event.reason);
+      if (recover(event.reason)) {
+        event.preventDefault();
+      }
     };
 
     window.addEventListener("error", onError, true);

--- a/app/components/__tests__/AccountTab.test.tsx
+++ b/app/components/__tests__/AccountTab.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 
 const mockGetSubscriptionCancellationStatus = jest.fn();
 const mockKeepSubscription = jest.fn();
+const mockRedirectToBillingPortal = jest.fn();
 const mockSetMigrateFromPentestgptDialogOpen = jest.fn();
 const mockToastSuccess = jest.fn();
 const mockToastError = jest.fn();
@@ -29,7 +30,7 @@ jest.mock("@/app/hooks/usePricingDialog", () => ({
 jest.mock("@/lib/billing/client", () => ({
   getSubscriptionCancellationStatus: mockGetSubscriptionCancellationStatus,
   keepSubscription: mockKeepSubscription,
-  redirectToBillingPortal: jest.fn(),
+  redirectToBillingPortal: mockRedirectToBillingPortal,
 }));
 
 jest.mock("sonner", () => ({
@@ -61,6 +62,7 @@ describe("AccountTab", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockOnCancellationScheduled = undefined;
+    window.history.replaceState(null, "", "/");
   });
 
   it("shows scheduled cancellation state instead of the cancel action", async () => {
@@ -113,6 +115,28 @@ describe("AccountTab", () => {
     expect(
       screen.queryByText("Cancellation scheduled."),
     ).not.toBeInTheDocument();
+  });
+
+  it("opens the billing portal from the payment manage action", async () => {
+    mockGetSubscriptionCancellationStatus.mockResolvedValue({
+      hasActiveSubscription: true,
+      cancelAtPeriodEnd: false,
+    } as never);
+    mockRedirectToBillingPortal.mockResolvedValue("#billing" as never);
+
+    render(<AccountTab />);
+
+    await waitFor(() => {
+      expect(mockGetSubscriptionCancellationStatus).toHaveBeenCalledTimes(1);
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getAllByRole("button", { name: /^manage$/i })[1]);
+
+    await waitFor(() => {
+      expect(mockRedirectToBillingPortal).toHaveBeenCalledTimes(1);
+    });
+    expect(window.location.hash).toBe("#billing");
   });
 
   it("updates the tab when cancellation is scheduled from the dialog", async () => {

--- a/app/components/__tests__/AccountTab.test.tsx
+++ b/app/components/__tests__/AccountTab.test.tsx
@@ -26,19 +26,10 @@ jest.mock("@/app/hooks/usePricingDialog", () => ({
   redirectToPricing: jest.fn(),
 }));
 
-jest.mock("@/lib/actions/billing-portal", () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
-
-jest.mock("@/lib/actions/subscription-status", () => ({
-  __esModule: true,
-  default: mockGetSubscriptionCancellationStatus,
-}));
-
-jest.mock("@/lib/actions/keep-subscription", () => ({
-  __esModule: true,
-  default: mockKeepSubscription,
+jest.mock("@/lib/billing/client", () => ({
+  getSubscriptionCancellationStatus: mockGetSubscriptionCancellationStatus,
+  keepSubscription: mockKeepSubscription,
+  redirectToBillingPortal: jest.fn(),
 }));
 
 jest.mock("sonner", () => ({

--- a/app/components/__tests__/CancelSubscriptionDialog.test.tsx
+++ b/app/components/__tests__/CancelSubscriptionDialog.test.tsx
@@ -8,9 +8,8 @@ jest.mock("@/app/contexts/GlobalState", () => ({
   }),
 }));
 
-jest.mock("@/lib/actions/cancel-subscription", () => ({
-  __esModule: true,
-  default: jest.fn(),
+jest.mock("@/lib/billing/client", () => ({
+  cancelSubscription: jest.fn(),
 }));
 
 jest.mock("@/lib/analytics/client", () => ({

--- a/app/components/__tests__/ChunkLoadRecovery.test.ts
+++ b/app/components/__tests__/ChunkLoadRecovery.test.ts
@@ -3,6 +3,7 @@ import { createElement } from "react";
 import {
   ChunkLoadRecovery,
   isChunkLoadFailure,
+  isStaleServerActionFailure,
   maybeRecoverFromChunkLoadFailure,
 } from "../ChunkLoadRecovery";
 
@@ -51,6 +52,26 @@ describe("ChunkLoadRecovery", () => {
     expect(isChunkLoadFailure(reason)).toBe(true);
   });
 
+  it("detects stale Server Action deployment failures", () => {
+    expect(
+      isStaleServerActionFailure(
+        new Error(
+          'Failed to find Server Action "008d652c1c1a320304c0f5508bce36145a66bf6c11". This request might be from an older or newer deployment.',
+        ),
+      ),
+    ).toBe(true);
+
+    expect(
+      isStaleServerActionFailure({
+        message: "This request might be from an older or newer deployment.",
+      }),
+    ).toBe(true);
+
+    expect(isStaleServerActionFailure(new Error("Failed to fetch"))).toBe(
+      false,
+    );
+  });
+
   it("reloads once for chunk load failures and records the attempt", () => {
     const storage = createStorage();
     const reload = jest.fn();
@@ -66,6 +87,28 @@ describe("ChunkLoadRecovery", () => {
     expect(storage.setItem).toHaveBeenCalledWith(
       "hackerai:chunk-load-reload-at",
       "1000",
+    );
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads once for stale Server Action failures", () => {
+    const storage = createStorage();
+    const reload = jest.fn();
+
+    expect(
+      maybeRecoverFromChunkLoadFailure(
+        new Error("Failed to find Server Action"),
+        {
+          storage,
+          reload,
+          now: 1_500,
+        },
+      ),
+    ).toBe(true);
+
+    expect(storage.setItem).toHaveBeenCalledWith(
+      "hackerai:chunk-load-reload-at",
+      "1500",
     );
     expect(reload).toHaveBeenCalledTimes(1);
   });

--- a/lib/actions/cancel-subscription.ts
+++ b/lib/actions/cancel-subscription.ts
@@ -22,12 +22,17 @@ import {
 import type { SubscriptionTier } from "@/types";
 
 type CancellationReasonInput = {
-  reasonCategory: CancellationReasonCategory;
-  reasonDetails: string;
+  reasonCategory?: unknown;
+  reasonDetails?: unknown;
 };
 
 type CancelSubscriptionInput = {
-  cancellationReason: CancellationReasonInput;
+  cancellationReason?: CancellationReasonInput;
+};
+
+type ParsedCancellationReasonInput = {
+  reasonCategory: CancellationReasonCategory;
+  reasonDetails: string;
 };
 
 type SubscriptionContext = {
@@ -41,7 +46,7 @@ type SubscriptionContext = {
 
 function parseCancellationReasonInput(
   value: CancelSubscriptionInput["cancellationReason"],
-): CancellationReasonInput {
+): ParsedCancellationReasonInput {
   const reasonCategory = value?.reasonCategory;
   const reasonDetails = normalizeCancellationReasonDetails(
     value?.reasonDetails,

--- a/lib/billing/__tests__/client.test.ts
+++ b/lib/billing/__tests__/client.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+import {
+  cancelSubscription,
+  redirectToBillingPortal,
+} from "@/lib/billing/client";
+
+const originalFetch = globalThis.fetch;
+
+function installFetchMock() {
+  const fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
+
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    writable: true,
+    value: fetchMock,
+  });
+
+  return fetchMock;
+}
+
+describe("billing client", () => {
+  afterEach(() => {
+    if (originalFetch) {
+      Object.defineProperty(globalThis, "fetch", {
+        configurable: true,
+        writable: true,
+        value: originalFetch,
+      });
+    } else {
+      Reflect.deleteProperty(globalThis, "fetch");
+    }
+
+    jest.restoreAllMocks();
+  });
+
+  it("turns aborted billing requests into a retryable timeout message", async () => {
+    installFetchMock().mockRejectedValue(
+      Object.assign(new Error("Request timed out"), {
+        name: "TimeoutError",
+      }) as never,
+    );
+
+    await expect(redirectToBillingPortal()).rejects.toThrow(
+      "Billing request timed out. Please try again.",
+    );
+  });
+
+  it("sends billing writes through no-store JSON requests", async () => {
+    const input = {
+      cancellationReason: {
+        reasonCategory: "other",
+        reasonDetails: "Testing the cancellation flow",
+      },
+    } as const;
+    const fetchMock = installFetchMock().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        canceled: true,
+        cancelAtPeriodEnd: true,
+        alreadyScheduled: false,
+      }),
+    } as Response);
+
+    await cancelSubscription(input);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/billing/cancel",
+      expect.objectContaining({
+        method: "POST",
+        cache: "no-store",
+        body: JSON.stringify(input),
+        headers: expect.objectContaining({
+          "content-type": "application/json",
+        }),
+      }),
+    );
+  });
+});

--- a/lib/billing/api-response.ts
+++ b/lib/billing/api-response.ts
@@ -16,5 +16,9 @@ export function billingRouteErrorResponse(error: unknown) {
     error instanceof Error ? error.message : "Billing request failed";
   const status = BILLING_ERROR_STATUSES.get(message) ?? 500;
 
+  if (status === 500) {
+    console.error("Unhandled billing route error", error);
+  }
+
   return NextResponse.json({ error: message }, { status });
 }

--- a/lib/billing/api-response.ts
+++ b/lib/billing/api-response.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+const BILLING_ERROR_STATUSES = new Map<string, number>([
+  ["User not authenticated", 401],
+  ["No organization found", 404],
+  ["User is not a member of this organization", 403],
+  ["Only admins or owners can manage billing", 403],
+  ["No billing account found for this organization", 404],
+  ["No active subscription found", 404],
+  ["Please select the main cancellation reason", 400],
+  ["Please write a cancellation reason before continuing", 400],
+]);
+
+export function billingRouteErrorResponse(error: unknown) {
+  const message =
+    error instanceof Error ? error.message : "Billing request failed";
+  const status = BILLING_ERROR_STATUSES.get(message) ?? 500;
+
+  return NextResponse.json({ error: message }, { status });
+}

--- a/lib/billing/api-types.ts
+++ b/lib/billing/api-types.ts
@@ -1,0 +1,30 @@
+import type { CancellationReasonCategory } from "@/lib/billing/cancellation-reasons";
+
+export type SubscriptionCancellationStatus = {
+  hasActiveSubscription: boolean;
+  cancelAtPeriodEnd: boolean;
+  currentPeriodEnd?: number;
+};
+
+export type KeepSubscriptionResult = {
+  kept: true;
+  cancelAtPeriodEnd: boolean;
+  currentPeriodEnd?: number;
+  alreadyKept: boolean;
+};
+
+export type CancellationReasonInput = {
+  reasonCategory: CancellationReasonCategory;
+  reasonDetails: string;
+};
+
+export type CancelSubscriptionInput = {
+  cancellationReason: CancellationReasonInput;
+};
+
+export type CancelSubscriptionResult = {
+  canceled: true;
+  cancelAtPeriodEnd: boolean;
+  currentPeriodEnd?: number;
+  alreadyScheduled: boolean;
+};

--- a/lib/billing/client.ts
+++ b/lib/billing/client.ts
@@ -5,6 +5,34 @@ import type {
   SubscriptionCancellationStatus,
 } from "@/lib/billing/api-types";
 
+const BILLING_REQUEST_TIMEOUT_MS = 15_000;
+const BILLING_REQUEST_TIMEOUT_MESSAGE =
+  "Billing request timed out. Please try again.";
+
+function billingRequestSignal(
+  signal: RequestInit["signal"],
+): RequestInit["signal"] {
+  if (signal) return signal;
+  if (typeof AbortSignal === "undefined") return undefined;
+
+  const timeout = (
+    AbortSignal as typeof AbortSignal & {
+      timeout?: (milliseconds: number) => AbortSignal;
+    }
+  ).timeout;
+
+  return timeout?.(BILLING_REQUEST_TIMEOUT_MS);
+}
+
+function isAbortLikeError(error: unknown) {
+  const name =
+    error && typeof error === "object" && "name" in error
+      ? String((error as { name?: unknown }).name)
+      : "";
+
+  return name === "AbortError" || name === "TimeoutError";
+}
+
 async function readBillingError(response: Response): Promise<string> {
   const fallback = `Billing request failed (${response.status})`;
 
@@ -24,14 +52,25 @@ async function billingFetchJson<T>(
   path: string,
   init: RequestInit = {},
 ): Promise<T> {
-  const response = await fetch(path, {
-    ...init,
-    cache: "no-store",
-    headers: {
-      ...(init.body ? { "content-type": "application/json" } : {}),
-      ...init.headers,
-    },
-  });
+  let response: Response;
+
+  try {
+    response = await fetch(path, {
+      ...init,
+      cache: "no-store",
+      signal: billingRequestSignal(init.signal),
+      headers: {
+        ...(init.body ? { "content-type": "application/json" } : {}),
+        ...init.headers,
+      },
+    });
+  } catch (error) {
+    if (isAbortLikeError(error)) {
+      throw new Error(BILLING_REQUEST_TIMEOUT_MESSAGE);
+    }
+
+    throw error;
+  }
 
   if (!response.ok) {
     throw new Error(await readBillingError(response));

--- a/lib/billing/client.ts
+++ b/lib/billing/client.ts
@@ -1,0 +1,75 @@
+import type {
+  CancelSubscriptionInput,
+  CancelSubscriptionResult,
+  KeepSubscriptionResult,
+  SubscriptionCancellationStatus,
+} from "@/lib/billing/api-types";
+
+async function readBillingError(response: Response): Promise<string> {
+  const fallback = `Billing request failed (${response.status})`;
+
+  try {
+    const body = (await response.json()) as {
+      error?: unknown;
+      message?: unknown;
+    };
+    if (typeof body.error === "string" && body.error) return body.error;
+    if (typeof body.message === "string" && body.message) return body.message;
+  } catch {}
+
+  return fallback;
+}
+
+async function billingFetchJson<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const response = await fetch(path, {
+    ...init,
+    cache: "no-store",
+    headers: {
+      ...(init.body ? { "content-type": "application/json" } : {}),
+      ...init.headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(await readBillingError(response));
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function getSubscriptionCancellationStatus(): Promise<SubscriptionCancellationStatus> {
+  return billingFetchJson<SubscriptionCancellationStatus>(
+    "/api/billing/subscription-status",
+  );
+}
+
+export async function redirectToBillingPortal(): Promise<string> {
+  const { url } = await billingFetchJson<{ url?: unknown }>(
+    "/api/billing/portal",
+    { method: "POST" },
+  );
+
+  if (typeof url !== "string" || !url) {
+    throw new Error("Failed to open billing portal");
+  }
+
+  return url;
+}
+
+export async function keepSubscription(): Promise<KeepSubscriptionResult> {
+  return billingFetchJson<KeepSubscriptionResult>("/api/billing/keep", {
+    method: "POST",
+  });
+}
+
+export async function cancelSubscription(
+  input: CancelSubscriptionInput,
+): Promise<CancelSubscriptionResult> {
+  return billingFetchJson<CancelSubscriptionResult>("/api/billing/cancel", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}


### PR DESCRIPTION
## Summary
- Move account billing client flows off direct Server Action calls and onto stable `/api/billing/*` route handlers.
- Add a typed browser billing client for portal, cancellation status, keep-plan, and cancel-plan calls.
- Extend client staleness recovery to reload once for stale Server Action deployment errors and suppress the handled browser error.

## Verification
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm test -- app/components/__tests__/AccountTab.test.tsx app/components/__tests__/CancelSubscriptionDialog.test.tsx app/components/__tests__/ChunkLoadRecovery.test.ts app/api/billing/__tests__/routes.test.ts lib/billing/__tests__/client.test.ts --runInBand`
- `pnpm test -- lib/actions/__tests__/billing-portal.test.ts lib/actions/__tests__/subscription-status.test.ts lib/actions/__tests__/cancel-subscription.test.ts lib/actions/__tests__/keep-subscription.test.ts --runInBand`
- Commit hook after CodeRabbit fixes ran `pnpm typecheck` and full Jest: 212 suites / 2122 tests passing.
- PR checks after the final push: GitHub test, Vercel, Trigger.dev preview deployment, Vercel Preview Comments, and CodeRabbit all passed.

## Manual Verification
- In production or preview account settings, open Manage Billing and confirm Stripe portal navigation still works.
- For a paid test account, open the cancel dialog, submit a cancellation reason, and confirm the scheduled-cancellation state appears.
- For an account with cancellation scheduled, click Keep plan and confirm the cancel action returns.
- Leave an old tab open across a deploy, trigger an old Server Action path if available, and confirm the page refreshes instead of leaving the tab broken.

## CodeRabbit Follow-up
- Addressed the malformed cancellation body handling comment in `app/api/billing/cancel/route.ts`.
- Added the requested regression coverage for `null`/malformed cancel request bodies.
- Added bounded billing client fetches, unmapped billing error logging, and a payment Manage button test.