### PR TITLE
Hide empty worked-for expand affordance

### DIFF
--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -6,7 +6,10 @@ import { MessageEditor, EditableFile } from "./MessageEditor";
 import { FeedbackInput } from "./FeedbackInput";
 import { BranchIndicator } from "./BranchIndicator";
 import { FinishReasonNotice } from "./FinishReasonNotice";
-import { splitWorkedForParts } from "./worked-for-parts";
+import {
+  isExpandableWorkedForPart,
+  splitWorkedForParts,
+} from "./worked-for-parts";
 import { SummarizationStatusDivider } from "./SummarizationStatusDivider";
 import {
   WorkedFor,
@@ -202,6 +205,10 @@ export const MessageItem = memo(function MessageItem({
   const { fileParts, nonFileParts, workParts, trailingTextParts } = useMemo(
     () => splitWorkedForParts(message.parts),
     [message.parts],
+  );
+  const hasExpandableWork = useMemo(
+    () => workParts.some(isExpandableWorkedForPart),
+    [workParts],
   );
 
   const shouldCollapseUserMessage =
@@ -455,7 +462,7 @@ export const MessageItem = memo(function MessageItem({
                     {workParts.length > 0 && (
                       <WorkedFor
                         key="work"
-                        hasWork
+                        hasWork={hasExpandableWork}
                         defaultOpen
                         isTiming={shouldShowWorkingTimer}
                       >
@@ -503,7 +510,7 @@ export const MessageItem = memo(function MessageItem({
                     {workParts.length > 0 && (
                       <WorkedFor
                         key="work"
-                        hasWork
+                        hasWork={hasExpandableWork}
                         isTiming={shouldShowWorkingTimer}
                       >
                         <WorkedForTrigger durationMs={generationTimeMs} />

--- a/app/components/__tests__/MessageItem.worked-for.test.tsx
+++ b/app/components/__tests__/MessageItem.worked-for.test.tsx
@@ -189,6 +189,38 @@ describe("MessageItem WorkedFor rendering", () => {
     expect(screen.getByText("regenerated final answer")).toBeInTheDocument();
   });
 
+  it("does not show an expand icon when there are no expandable work parts", () => {
+    renderMessageItem({
+      mode: "agent",
+      message: {
+        ...assistantMessage,
+        parts: [
+          {
+            type: "step-start",
+          },
+          {
+            type: "text",
+            text: "final answer",
+          },
+        ],
+        metadata: {
+          mode: "agent",
+          generationTimeMs: 2_500,
+        },
+      } as unknown as ChatMessage,
+    });
+
+    const trigger = screen.getByRole("button", { name: /worked for 3s/i });
+
+    expect(trigger).toBeDisabled();
+    expect(trigger.querySelector("svg")).not.toBeInTheDocument();
+    expect(screen.getByText("final answer")).toBeInTheDocument();
+
+    fireEvent.click(trigger);
+
+    expect(screen.queryByTestId("part-step-start")).not.toBeInTheDocument();
+  });
+
   it("keeps saved message mode stable when the current picker mode changes", () => {
     const { rerender } = renderMessageItem({ mode: "ask" });
 

--- a/app/components/__tests__/MessageItem.worked-for.test.tsx
+++ b/app/components/__tests__/MessageItem.worked-for.test.tsx
@@ -221,6 +221,38 @@ describe("MessageItem WorkedFor rendering", () => {
     expect(screen.queryByTestId("part-step-start")).not.toBeInTheDocument();
   });
 
+  it("does not show an expand icon for reasoning-only work", () => {
+    renderMessageItem({
+      mode: "agent",
+      message: {
+        ...assistantMessage,
+        parts: [
+          {
+            type: "step-start",
+          },
+          {
+            type: "reasoning",
+            text: "thinking",
+          },
+          {
+            type: "text",
+            text: "final answer",
+          },
+        ],
+        metadata: {
+          mode: "agent",
+          generationTimeMs: 2_500,
+        },
+      } as unknown as ChatMessage,
+    });
+
+    const trigger = screen.getByRole("button", { name: /worked for 3s/i });
+
+    expect(trigger).toBeDisabled();
+    expect(trigger.querySelector("svg")).not.toBeInTheDocument();
+    expect(screen.getByText("final answer")).toBeInTheDocument();
+  });
+
   it("keeps saved message mode stable when the current picker mode changes", () => {
     const { rerender } = renderMessageItem({ mode: "ask" });
 

--- a/app/components/__tests__/worked-for-parts.test.ts
+++ b/app/components/__tests__/worked-for-parts.test.ts
@@ -1,4 +1,7 @@
-import { splitWorkedForParts } from "../worked-for-parts";
+import {
+  isExpandableWorkedForPart,
+  splitWorkedForParts,
+} from "../worked-for-parts";
 import type { ChatMessage } from "@/types";
 
 const part = (
@@ -66,5 +69,23 @@ describe("splitWorkedForParts", () => {
     expect(result.nonFileParts).toEqual([tool, text]);
     expect(result.workParts).toEqual([tool]);
     expect(result.trailingTextParts).toEqual([text]);
+  });
+});
+
+describe("isExpandableWorkedForPart", () => {
+  it("treats tool parts and rendered tool output as expandable work", () => {
+    expect(isExpandableWorkedForPart(part("tool-shell"))).toBe(true);
+    expect(
+      isExpandableWorkedForPart(
+        part("data-terminal", {
+          data: { terminal: "output", toolCallId: "tool-1" },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat stream metadata as expandable work", () => {
+    expect(isExpandableWorkedForPart(part("step-start"))).toBe(false);
+    expect(isExpandableWorkedForPart(part("data-context-usage"))).toBe(false);
   });
 });

--- a/app/components/__tests__/worked-for-parts.test.ts
+++ b/app/components/__tests__/worked-for-parts.test.ts
@@ -82,12 +82,12 @@ describe("isExpandableWorkedForPart", () => {
         }),
       ),
     ).toBe(true);
-    expect(isExpandableWorkedForPart(part("data-summarization"))).toBe(true);
-    expect(isExpandableWorkedForPart(part("reasoning"))).toBe(true);
   });
 
-  it("does not treat stream metadata as expandable work", () => {
+  it("does not treat stream metadata or non-tool work as expandable work", () => {
     expect(isExpandableWorkedForPart(part("step-start"))).toBe(false);
     expect(isExpandableWorkedForPart(part("data-context-usage"))).toBe(false);
+    expect(isExpandableWorkedForPart(part("data-summarization"))).toBe(false);
+    expect(isExpandableWorkedForPart(part("reasoning"))).toBe(false);
   });
 });

--- a/app/components/__tests__/worked-for-parts.test.ts
+++ b/app/components/__tests__/worked-for-parts.test.ts
@@ -82,6 +82,8 @@ describe("isExpandableWorkedForPart", () => {
         }),
       ),
     ).toBe(true);
+    expect(isExpandableWorkedForPart(part("data-summarization"))).toBe(true);
+    expect(isExpandableWorkedForPart(part("reasoning"))).toBe(true);
   });
 
   it("does not treat stream metadata as expandable work", () => {

--- a/app/components/worked-for-parts.ts
+++ b/app/components/worked-for-parts.ts
@@ -18,6 +18,12 @@ const TRAILING_METADATA_PART_TYPES = new Set([
   "step-start",
 ]);
 
+const EXPANDABLE_WORK_PART_TYPES = new Set([
+  "data-summarization",
+  "data-terminal",
+  "reasoning",
+]);
+
 export type WorkedForParts = {
   fileParts: FilePart[];
   nonFileParts: MessagePart[];
@@ -28,6 +34,13 @@ export type WorkedForParts = {
 const isTrailingMetadataPart = (part: MessagePart) => {
   const type = (part as { type?: string }).type;
   return !!type && TRAILING_METADATA_PART_TYPES.has(type);
+};
+
+export const isExpandableWorkedForPart = (part: MessagePart) => {
+  const type = (part as { type?: string }).type;
+  return (
+    !!type && (type.startsWith("tool-") || EXPANDABLE_WORK_PART_TYPES.has(type))
+  );
 };
 
 export function splitWorkedForParts(

--- a/app/components/worked-for-parts.ts
+++ b/app/components/worked-for-parts.ts
@@ -18,11 +18,7 @@ const TRAILING_METADATA_PART_TYPES = new Set([
   "step-start",
 ]);
 
-const EXPANDABLE_WORK_PART_TYPES = new Set([
-  "data-summarization",
-  "data-terminal",
-  "reasoning",
-]);
+const EXPANDABLE_WORK_PART_TYPES = new Set(["data-terminal"]);
 
 export type WorkedForParts = {
   fileParts: FilePart[];


### PR DESCRIPTION
## Summary
- Only enable the Worked for disclosure when hidden work contains tool-backed content
- Keep metadata-only and reasoning-only Agent answers from showing an empty chevron/toggle
- Add regression coverage for metadata-only and reasoning-only worked-for rows, while preserving tool output expansion

## Tests
- pnpm test -- app/components/__tests__/worked-for-parts.test.ts app/components/__tests__/MessageItem.worked-for.test.tsx --runInBand
- pnpm exec eslint app/components/worked-for-parts.ts app/components/MessageItem.tsx app/components/__tests__/worked-for-parts.test.ts app/components/__tests__/MessageItem.worked-for.test.tsx
- pnpm typecheck
- full Jest suite via commit hook

## Visual verification
- Vercel preview, Pro test user, Agent mode no-tools prompt
- Settled no-tool response showed "Worked for 5s" with the trigger disabled and 0 chevron icons