### PR TITLE
Retry interrupted provider tool streams safely

### DIFF
--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -170,6 +170,7 @@ import {
 } from "@/lib/chat/multimodal-tool-result-recovery";
 import {
   detectAssistantContentLoopFromParts,
+  shouldRetryProviderStreamAfterInterruptedToolInput,
   shouldRetryProviderStreamWithFallback,
 } from "@/lib/chat/agent-long-provider-retry";
 import { FREE_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
@@ -1313,12 +1314,19 @@ export const createChatHandler = () => {
                     const stoppedDueToAssistantContentLoop =
                       state.stoppedDueToAssistantContentLoop ||
                       (!isAborted && assistantContentLoopDetection.detected);
+                    const hasTerminalProviderStreamError =
+                      state.streamFinishReason === "error";
+                    const shouldRetryInterruptedToolInput =
+                      shouldRetryProviderStreamAfterInterruptedToolInput(
+                        lastAssistantMessageParts,
+                        { hasTerminalProviderStreamError },
+                      );
                     const shouldRetryWithFallback =
                       shouldRetryProviderStreamWithFallback(
                         lastAssistantMessageParts,
                         {
                           hasTerminalProviderStreamError:
-                            state.streamFinishReason === "error",
+                            hasTerminalProviderStreamError,
                           stoppedDueToDoomLoop: state.stoppedDueToDoomLoop,
                           stoppedDueToAssistantContentLoop,
                           detectAssistantContentLoop: !isAborted,
@@ -1344,7 +1352,9 @@ export const createChatHandler = () => {
                           ? "assistant_content_loop"
                           : state.stoppedDueToDoomLoop
                             ? "doom_loop"
-                            : "incomplete_stream";
+                            : shouldRetryInterruptedToolInput
+                              ? "interrupted_tool_input"
+                              : "incomplete_stream";
                       phLogger.warn(
                         shouldRetryWithoutImageToolResults
                           ? "Provider rejected image tool output - retrying without images"
@@ -1352,9 +1362,11 @@ export const createChatHandler = () => {
                             ? "Assistant content loop detected - triggering fallback"
                             : retryReason === "doom_loop"
                               ? "Agent doom loop detected - triggering fallback"
-                              : state.streamFinishReason === "error"
-                                ? "Provider stream errored before useful output - triggering fallback"
-                                : "Stream finished incomplete - triggering fallback",
+                              : retryReason === "interrupted_tool_input"
+                                ? "Provider stream errored during tool input - triggering bounded fallback"
+                                : hasTerminalProviderStreamError
+                                  ? "Provider stream errored before useful output - triggering fallback"
+                                  : "Stream finished incomplete - triggering fallback",
                         {
                           chatId,
                           endpoint,
@@ -1373,6 +1385,7 @@ export const createChatHandler = () => {
                             assistantContentLoopDetection.detected
                               ? assistantContentLoopDetection
                               : undefined,
+                          shouldRetryInterruptedToolInput,
                           imageToolResultsOmitted: imageRecovery.omittedCount,
                         },
                       );
@@ -1386,7 +1399,8 @@ export const createChatHandler = () => {
                         (!isAborted || stoppedDueToAssistantContentLoop) &&
                         (isAutoModel ||
                           shouldRetryWithoutImageToolResults ||
-                          loopTriggeredRetry)
+                          loopTriggeredRetry ||
+                          shouldRetryInterruptedToolInput)
                       ) {
                         isRetryWithFallback = true;
                         state.lastStepInputTokens = 0;

--- a/lib/chat/__tests__/agent-long-provider-retry.test.ts
+++ b/lib/chat/__tests__/agent-long-provider-retry.test.ts
@@ -2,6 +2,7 @@ import {
   createAssistantContentLoopMonitor,
   detectAssistantContentLoopFromText,
   shouldRetryAgentLongWithFallback,
+  shouldRetryProviderStreamAfterInterruptedToolInput,
 } from "../agent-long-provider-retry";
 
 describe("shouldRetryAgentLongWithFallback", () => {
@@ -61,6 +62,85 @@ describe("shouldRetryAgentLongWithFallback", () => {
         ],
         { hasTerminalProviderStreamError: true },
       ),
+    ).toBe(false);
+  });
+
+  it("retries terminal provider errors during meaningful tool input streaming", () => {
+    const parts = [
+      { type: "step-start" },
+      { type: "text", text: "I'll update the file now." },
+      {
+        type: "tool-file",
+        toolCallId: "call_1",
+        state: "input-streaming",
+        input: {
+          action: "write",
+          path: "/repo/script.py",
+          text: "partial file body",
+        },
+      },
+    ];
+
+    expect(
+      shouldRetryAgentLongWithFallback(parts, {
+        hasTerminalProviderStreamError: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRetryProviderStreamAfterInterruptedToolInput(parts, {
+        hasTerminalProviderStreamError: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not retry interrupted tool input without meaningful input", () => {
+    expect(
+      shouldRetryAgentLongWithFallback(
+        [
+          { type: "step-start" },
+          {
+            type: "tool-file",
+            toolCallId: "call_1",
+            state: "input-streaming",
+            input: {},
+          },
+        ],
+        { hasTerminalProviderStreamError: true },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not replay an interrupted tool input after completed tool output", () => {
+    const parts = [
+      { type: "step-start" },
+      {
+        type: "tool-run_terminal_cmd",
+        toolCallId: "call_1",
+        state: "output-available",
+        input: { command: "npm test" },
+        output: { result: { exitCode: 0, output: "ok" } },
+      },
+      {
+        type: "tool-file",
+        toolCallId: "call_2",
+        state: "input-streaming",
+        input: {
+          action: "write",
+          path: "/repo/script.py",
+          text: "partial file body",
+        },
+      },
+    ];
+
+    expect(
+      shouldRetryAgentLongWithFallback(parts, {
+        hasTerminalProviderStreamError: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRetryProviderStreamAfterInterruptedToolInput(parts, {
+        hasTerminalProviderStreamError: true,
+      }),
     ).toBe(false);
   });
 

--- a/lib/chat/agent-long-provider-retry.ts
+++ b/lib/chat/agent-long-provider-retry.ts
@@ -1,6 +1,13 @@
+import { hasMeaningfulToolInput } from "@/lib/chat/tool-abort-utils";
+
 type MessagePartLike = {
   type?: unknown;
   text?: unknown;
+  state?: unknown;
+  input?: unknown;
+  output?: unknown;
+  result?: unknown;
+  errorText?: unknown;
 };
 
 type RetryDecisionOptions = {
@@ -20,6 +27,13 @@ export type AssistantContentLoopDetection = {
 const FALLBACK_SAFE_METADATA_PART_TYPES = new Set([
   "data-agent-heartbeat",
   "data-context-usage",
+]);
+
+const INTERRUPTED_TOOL_INPUT_SAFE_PART_TYPES = new Set([
+  "step-start",
+  "reasoning",
+  "text",
+  ...FALLBACK_SAFE_METADATA_PART_TYPES,
 ]);
 
 const NO_ASSISTANT_CONTENT_LOOP: AssistantContentLoopDetection = {
@@ -47,6 +61,46 @@ const getPartText = (part: unknown): string | undefined => {
   return typeof text === "string" ? text : undefined;
 };
 
+const getPartState = (part: unknown): string | undefined => {
+  if (!part || typeof part !== "object") return undefined;
+  const state = (part as MessagePartLike).state;
+  return typeof state === "string" ? state : undefined;
+};
+
+const isToolPart = (part: unknown): boolean =>
+  getPartType(part)?.startsWith("tool-") ?? false;
+
+const hasToolOutputOrError = (part: unknown): boolean => {
+  if (!part || typeof part !== "object") return false;
+  const candidate = part as MessagePartLike;
+  return (
+    candidate.output != null ||
+    candidate.result != null ||
+    candidate.errorText != null ||
+    candidate.state === "output-available" ||
+    candidate.state === "output-error"
+  );
+};
+
+const isRestartableInterruptedToolInput = (part: unknown): boolean => {
+  if (!isToolPart(part) || !part || typeof part !== "object") return false;
+  const candidate = part as MessagePartLike;
+  return (
+    getPartState(part) === "input-streaming" &&
+    !hasToolOutputOrError(part) &&
+    hasMeaningfulToolInput(candidate.input)
+  );
+};
+
+const isSafeInterruptedToolInputPart = (part: unknown): boolean => {
+  const type = getPartType(part);
+  if (!type) return false;
+  return (
+    INTERRUPTED_TOOL_INPUT_SAFE_PART_TYPES.has(type) ||
+    isRestartableInterruptedToolInput(part)
+  );
+};
+
 const isOnlyStepStart = (parts: unknown[]): boolean =>
   parts.length === 1 && getPartType(parts[0]) === "step-start";
 
@@ -66,6 +120,11 @@ const isReasoningOnlyProviderOutput = (parts: unknown[]): boolean =>
   parts.length > 0 &&
   hasReasoningPart(parts) &&
   parts.every(isFallbackSafeProviderPart);
+
+const isInterruptedToolInputOnlyProviderOutput = (parts: unknown[]): boolean =>
+  parts.length > 0 &&
+  parts.some(isRestartableInterruptedToolInput) &&
+  parts.every(isSafeInterruptedToolInputPart);
 
 const stripFencedCodeBlocks = (text: string): string =>
   text
@@ -207,9 +266,17 @@ export const shouldRetryProviderStreamWithFallback = (
   // safer than failing the whole run on a discarded provider socket.
   return (
     options.hasTerminalProviderStreamError &&
-    isReasoningOnlyProviderOutput(parts)
+    (isReasoningOnlyProviderOutput(parts) ||
+      isInterruptedToolInputOnlyProviderOutput(parts))
   );
 };
 
 export const shouldRetryAgentLongWithFallback =
   shouldRetryProviderStreamWithFallback;
+
+export const shouldRetryProviderStreamAfterInterruptedToolInput = (
+  parts: unknown[],
+  options: Pick<RetryDecisionOptions, "hasTerminalProviderStreamError">,
+): boolean =>
+  options.hasTerminalProviderStreamError &&
+  isInterruptedToolInputOnlyProviderOutput(parts);

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -142,6 +142,7 @@ import {
 } from "@/lib/chat/stop-conditions";
 import {
   detectAssistantContentLoopFromParts,
+  shouldRetryProviderStreamAfterInterruptedToolInput,
   shouldRetryAgentLongWithFallback,
 } from "@/lib/chat/agent-long-provider-retry";
 import {
@@ -1900,12 +1901,19 @@ export const agentLongTask = task({
                       const stoppedDueToAssistantContentLoop =
                         state.stoppedDueToAssistantContentLoop ||
                         (!isAborted && assistantContentLoopDetection.detected);
+                      const hasTerminalProviderStreamError =
+                        isTerminalProviderStreamError(state);
+                      const shouldRetryInterruptedToolInput =
+                        shouldRetryProviderStreamAfterInterruptedToolInput(
+                          lastAssistantMessageParts,
+                          { hasTerminalProviderStreamError },
+                        );
                       const shouldRetryWithFallback =
                         shouldRetryAgentLongWithFallback(
                           lastAssistantMessageParts,
                           {
                             hasTerminalProviderStreamError:
-                              isTerminalProviderStreamError(state),
+                              hasTerminalProviderStreamError,
                             stoppedDueToDoomLoop: state.stoppedDueToDoomLoop,
                             stoppedDueToAssistantContentLoop,
                             detectAssistantContentLoop: !isAborted,
@@ -1928,7 +1936,8 @@ export const agentLongTask = task({
                         (isAutoModel ||
                           shouldRetryWithoutImageToolResults ||
                           stoppedDueToAssistantContentLoop ||
-                          state.stoppedDueToDoomLoop)
+                          state.stoppedDueToDoomLoop ||
+                          shouldRetryInterruptedToolInput)
                       ) {
                         const retryReason = shouldRetryWithoutImageToolResults
                           ? "image_tool_result_rejection"
@@ -1936,7 +1945,9 @@ export const agentLongTask = task({
                             ? "assistant_content_loop"
                             : state.stoppedDueToDoomLoop
                               ? "doom_loop"
-                              : "incomplete_stream";
+                              : shouldRetryInterruptedToolInput
+                                ? "interrupted_tool_input"
+                                : "incomplete_stream";
                         phLogger.warn(
                           "[agent-long] Provider output triggered fallback retry",
                           {
@@ -1955,6 +1966,7 @@ export const agentLongTask = task({
                               assistantContentLoopDetection.detected
                                 ? assistantContentLoopDetection
                                 : undefined,
+                            shouldRetryInterruptedToolInput,
                             imageToolResultsOmitted: imageRecovery.omittedCount,
                           },
                         );


### PR DESCRIPTION
## Summary
- retry terminal provider stream failures when they die during meaningful tool-input streaming before tool output exists
- allow the bounded fallback retry even for pinned model selections in that safe interrupted-tool-input case
- keep completed tool outputs as a hard stop so we do not replay side-effectful tool calls
- add focused coverage for meaningful partial input, empty partial input, and completed-output replay blocking

## Verification
- pnpm test -- lib/chat/__tests__/agent-long-provider-retry.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand
- pnpm typecheck
- pnpm lint (passes with existing warnings outside this change)
- commit hook: pnpm typecheck && pnpm test (212 suites, 2133 tests)

## Manual Verification
Automated validation is sufficient; this is stream-retry control flow with no UI surface change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted tool input during streamed responses, so affected requests can recover more reliably.
  * Added clearer retry behavior for this failure case, reducing missed retries when a stream stops mid-input.
  * Updated retry logic to avoid replaying empty or already-completed tool input in recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->