### PR TITLE
Limit Max mode to Ultra

### DIFF
--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -20,8 +20,12 @@ import {
 } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
 import {
+  canUseExtraUsage,
   canUseMaxModel,
+  normalizeMaxModelForSubscription,
   normalizeSelectedModelForSubscription,
   type ChatMode,
   type SelectedModel,
@@ -56,9 +60,10 @@ const isMaxModel = (model: SelectedModel): boolean => model === "hackerai-max";
 const isModelLockedForSubscription = (
   subscription: SubscriptionTier,
   model: SelectedModel,
+  extraUsageAvailable = false,
 ): boolean =>
   subscription === "free" ||
-  (isMaxModel(model) && !canUseMaxModel(subscription));
+  (isMaxModel(model) && !canUseMaxModel(subscription, { extraUsageAvailable }));
 
 const getLockedModelCta = (model: SelectedModel): string =>
   isMaxModel(model) ? "Upgrade to Ultra" : "Upgrade your plan";
@@ -205,6 +210,7 @@ const ModelOptionList = ({
   isAuto,
   isFreeUser,
   subscription,
+  maxModelExtraUsageAvailable,
   onAutoSelect,
   onSelect,
   onClose,
@@ -215,6 +221,7 @@ const ModelOptionList = ({
   isAuto: boolean;
   isFreeUser: boolean;
   subscription: SubscriptionTier;
+  maxModelExtraUsageAvailable: boolean;
   onAutoSelect: () => void;
   onSelect: (option: ModelOption) => void;
   onClose: () => void;
@@ -257,7 +264,11 @@ const ModelOptionList = ({
 
     {options.map((option) => {
       const isSelected = value === option.id;
-      const isLocked = isModelLockedForSubscription(subscription, option.id);
+      const isLocked = isModelLockedForSubscription(
+        subscription,
+        option.id,
+        maxModelExtraUsageAvailable,
+      );
       const showUpgradeTooltip = isLocked && !mobile;
 
       if (!showUpgradeTooltip) {
@@ -341,10 +352,38 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
   const isMobile = Boolean(useIsMobile());
 
   const isFreeUser = subscription === "free";
-  const displayValue = normalizeSelectedModelForSubscription(
+  const shouldCheckPersonalExtraUsage =
+    subscription === "pro" || subscription === "pro-plus";
+  const userCustomization = useQuery(
+    api.userCustomization.getUserCustomization,
+    shouldCheckPersonalExtraUsage ? undefined : "skip",
+  );
+  const extraUsageSettings = useQuery(
+    api.extraUsage.getExtraUsageSettings,
+    shouldCheckPersonalExtraUsage ? undefined : "skip",
+  );
+  const monthlyRemainingDollars =
+    extraUsageSettings?.monthlyCapDollars === undefined
+      ? undefined
+      : Math.max(
+          0,
+          extraUsageSettings.monthlyCapDollars -
+            (extraUsageSettings.monthlySpentDollars ?? 0),
+        );
+  const maxModelExtraUsageAvailable = canUseExtraUsage({
+    enabled: userCustomization?.extra_usage_enabled ?? false,
+    balanceDollars: extraUsageSettings?.balanceDollars,
+    autoReloadEnabled: extraUsageSettings?.autoReloadEnabled,
+    monthlyRemainingDollars,
+  });
+  const subscriptionValue = normalizeSelectedModelForSubscription(
     value,
     subscription,
   );
+  const displayValue =
+    normalizeMaxModelForSubscription(subscriptionValue, subscription, {
+      extraUsageAvailable: maxModelExtraUsageAvailable,
+    }) ?? "auto";
   const isAuto = displayValue === "auto";
 
   const options = isAgentMode(mode) ? AGENT_MODEL_OPTIONS : ASK_MODEL_OPTIONS;
@@ -373,7 +412,13 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
   };
 
   const handleModelSelect = (option: ModelOption) => {
-    if (isModelLockedForSubscription(subscription, option.id)) {
+    if (
+      isModelLockedForSubscription(
+        subscription,
+        option.id,
+        maxModelExtraUsageAvailable,
+      )
+    ) {
       setOpen(false);
       redirectLockedModelToPricing({
         mobile: isMobile,
@@ -421,6 +466,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
               isAuto={isAuto}
               isFreeUser={isFreeUser}
               subscription={subscription}
+              maxModelExtraUsageAvailable={maxModelExtraUsageAvailable}
               onAutoSelect={handleAutoSelect}
               onSelect={handleModelSelect}
               onClose={() => setOpen(false)}
@@ -443,6 +489,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
             isAuto={isAuto}
             isFreeUser={isFreeUser}
             subscription={subscription}
+            maxModelExtraUsageAvailable={maxModelExtraUsageAvailable}
             onAutoSelect={handleAutoSelect}
             onSelect={handleModelSelect}
             onClose={() => setOpen(false)}

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -63,6 +63,9 @@ const isModelLockedForSubscription = (
 const getLockedModelCta = (model: SelectedModel): string =>
   isMaxModel(model) ? "Upgrade to Ultra" : "Upgrade your plan";
 
+const getLockedModelAnnouncement = (model: SelectedModel): string =>
+  `${getLockedModelCta(model)}${isMaxModel(model) ? " for Max mode" : " to unlock"}`;
+
 const redirectLockedModelToPricing = ({
   mobile,
   option,
@@ -77,7 +80,7 @@ const redirectLockedModelToPricing = ({
     surface: mobile ? "model_selector_mobile" : "model_selector",
     source: maxLocked ? "max_model_gate" : "locked_model_option",
     from_tier: subscription,
-    cta_text: maxLocked ? "Upgrade to Ultra" : option.label,
+    cta_text: getLockedModelCta(option.id),
   });
 };
 
@@ -134,6 +137,11 @@ const ModelOptionButton = ({
       type="button"
       onClick={() => onSelect(option)}
       aria-pressed={isSelected}
+      aria-label={
+        isLocked
+          ? `${option.label}. ${getLockedModelAnnouncement(option.id)}.`
+          : undefined
+      }
       className={`group w-full flex items-center gap-2.5 px-2.5 rounded-lg text-left transition-colors select-none cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
         mobile ? "py-2.5" : "py-1.5"
       } ${isSelected ? "bg-accent" : "hover:bg-muted/50 active:bg-muted/50"}`}

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -35,6 +35,7 @@ import { isAgentMode } from "@/lib/utils/mode-helpers";
 import { useGlobalState } from "@/app/contexts/GlobalState";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { redirectToPricing } from "@/app/hooks/usePricingDialog";
+import { openSettingsDialog } from "@/lib/utils/settings-dialog";
 
 import { CostIndicator } from "./ModelSelector/CostIndicator";
 import {
@@ -57,6 +58,9 @@ const AUTO_MODEL_DESCRIPTION =
 
 const isMaxModel = (model: SelectedModel): boolean => model === "hackerai-max";
 
+const canUnlockMaxWithExtraUsage = (subscription: SubscriptionTier): boolean =>
+  subscription !== "free" && subscription !== "ultra";
+
 const isModelLockedForSubscription = (
   subscription: SubscriptionTier,
   model: SelectedModel,
@@ -65,13 +69,25 @@ const isModelLockedForSubscription = (
   subscription === "free" ||
   (isMaxModel(model) && !canUseMaxModel(subscription, { extraUsageAvailable }));
 
-const getLockedModelCta = (model: SelectedModel): string =>
-  isMaxModel(model) ? "Upgrade to Ultra" : "Upgrade your plan";
+const getLockedModelCta = (
+  model: SelectedModel,
+  subscription: SubscriptionTier,
+): string => {
+  if (isMaxModel(model) && canUnlockMaxWithExtraUsage(subscription)) {
+    return "Manage Extra Usage";
+  }
+  return isMaxModel(model) ? "Upgrade to Ultra" : "Upgrade your plan";
+};
 
-const getLockedModelAnnouncement = (model: SelectedModel): string =>
-  `${getLockedModelCta(model)}${isMaxModel(model) ? " for Max mode" : " to unlock"}`;
+const getLockedModelAnnouncement = (
+  model: SelectedModel,
+  subscription: SubscriptionTier,
+): string =>
+  `${getLockedModelCta(model, subscription)}${
+    isMaxModel(model) ? " for Max mode" : " to unlock"
+  }`;
 
-const redirectLockedModelToPricing = ({
+const handleLockedModelCta = ({
   mobile,
   option,
   subscription,
@@ -81,11 +97,16 @@ const redirectLockedModelToPricing = ({
   subscription: SubscriptionTier;
 }) => {
   const maxLocked = isMaxModel(option.id);
+  if (maxLocked && canUnlockMaxWithExtraUsage(subscription)) {
+    openSettingsDialog("Extra Usage");
+    return;
+  }
+
   redirectToPricing({
     surface: mobile ? "model_selector_mobile" : "model_selector",
     source: maxLocked ? "max_model_gate" : "locked_model_option",
     from_tier: subscription,
-    cta_text: getLockedModelCta(option.id),
+    cta_text: getLockedModelCta(option.id, subscription),
   });
 };
 
@@ -128,12 +149,14 @@ const ModelOptionButton = ({
   option,
   isSelected,
   isLocked,
+  subscription,
   onSelect,
   mobile = false,
 }: {
   option: ModelOption;
   isSelected: boolean;
   isLocked: boolean;
+  subscription: SubscriptionTier;
   onSelect: (option: ModelOption) => void;
   mobile?: boolean;
 }) => {
@@ -144,7 +167,10 @@ const ModelOptionButton = ({
       aria-pressed={isSelected}
       aria-label={
         isLocked
-          ? `${option.label}. ${getLockedModelAnnouncement(option.id)}.`
+          ? `${option.label}. ${getLockedModelAnnouncement(
+              option.id,
+              subscription,
+            )}.`
           : undefined
       }
       className={`group w-full flex items-center gap-2.5 px-2.5 rounded-lg text-left transition-colors select-none cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
@@ -278,6 +304,7 @@ const ModelOptionList = ({
               option={option}
               isSelected={isSelected}
               isLocked={isLocked}
+              subscription={subscription}
               onSelect={onSelect}
               mobile={mobile}
             />
@@ -293,6 +320,7 @@ const ModelOptionList = ({
                 option={option}
                 isSelected={isSelected}
                 isLocked={isLocked}
+                subscription={subscription}
                 onSelect={onSelect}
                 mobile={mobile}
               />
@@ -320,11 +348,16 @@ const ModelOptionList = ({
             )}
             <p className="text-xs text-muted-foreground leading-relaxed pt-1">
               <a
-                href="#pricing"
+                href={
+                  isMaxModel(option.id) &&
+                  canUnlockMaxWithExtraUsage(subscription)
+                    ? "#extra-usage"
+                    : "#pricing"
+                }
                 onClick={(event) => {
                   event.preventDefault();
                   onClose();
-                  redirectLockedModelToPricing({
+                  handleLockedModelCta({
                     mobile,
                     option,
                     subscription,
@@ -333,7 +366,7 @@ const ModelOptionList = ({
                 className="text-foreground underline underline-offset-2 hover:text-foreground/80"
                 tabIndex={0}
               >
-                {getLockedModelCta(option.id)}
+                {getLockedModelCta(option.id, subscription)}
               </a>
               {isMaxModel(option.id) ? " for Max mode." : " to unlock."}
             </p>
@@ -420,7 +453,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
       )
     ) {
       setOpen(false);
-      redirectLockedModelToPricing({
+      handleLockedModelCta({
         mobile: isMobile,
         option,
         subscription,

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  AlertTriangle,
-  Brain,
-  Check,
-  ChevronDown,
-  ChevronRight,
-  Lock,
-} from "lucide-react";
+import { Brain, Check, ChevronDown, ChevronRight, Lock } from "lucide-react";
 import {
   Popover,
   PopoverContent,
@@ -26,18 +19,14 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { useState } from "react";
-import type { ChatMode, SelectedModel, SubscriptionTier } from "@/types/chat";
+import {
+  canUseMaxModel,
+  normalizeSelectedModelForSubscription,
+  type ChatMode,
+  type SelectedModel,
+  type SubscriptionTier,
+} from "@/types/chat";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import { useGlobalState } from "@/app/contexts/GlobalState";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -50,10 +39,6 @@ import {
   getDefaultModelForMode,
   type ModelOption,
 } from "./ModelSelector/constants";
-import {
-  dismissHighCostModelUsageNotice,
-  isHighCostModelUsageNoticeDismissed,
-} from "@/lib/utils/pro-max-notice-cookie";
 
 // ── Shared sub-components ──────────────────────────────────────────
 
@@ -66,13 +51,35 @@ interface ModelSelectorProps {
 const AUTO_MODEL_DESCRIPTION =
   "Balanced quality and speed, recommended for most tasks";
 
-const shouldWarnForPaidHighCostModel = (
+const isMaxModel = (model: SelectedModel): boolean => model === "hackerai-max";
+
+const isModelLockedForSubscription = (
   subscription: SubscriptionTier,
   model: SelectedModel,
 ): boolean =>
-  subscription !== "free" &&
-  subscription !== "ultra" &&
-  model === "hackerai-max";
+  subscription === "free" ||
+  (isMaxModel(model) && !canUseMaxModel(subscription));
+
+const getLockedModelCta = (model: SelectedModel): string =>
+  isMaxModel(model) ? "Upgrade to Ultra" : "Upgrade your plan";
+
+const redirectLockedModelToPricing = ({
+  mobile,
+  option,
+  subscription,
+}: {
+  mobile: boolean;
+  option: ModelOption;
+  subscription: SubscriptionTier;
+}) => {
+  const maxLocked = isMaxModel(option.id);
+  redirectToPricing({
+    surface: mobile ? "model_selector_mobile" : "model_selector",
+    source: maxLocked ? "max_model_gate" : "locked_model_option",
+    from_tier: subscription,
+    cta_text: maxLocked ? "Upgrade to Ultra" : option.label,
+  });
+};
 
 const AutoOptionButton = ({
   isSelected,
@@ -112,16 +119,14 @@ const AutoOptionButton = ({
 const ModelOptionButton = ({
   option,
   isSelected,
-  isFreeUser,
+  isLocked,
   onSelect,
-  mode,
   mobile = false,
 }: {
   option: ModelOption;
   isSelected: boolean;
-  isFreeUser: boolean;
+  isLocked: boolean;
   onSelect: (option: ModelOption) => void;
-  mode: ChatMode;
   mobile?: boolean;
 }) => {
   const button = (
@@ -150,7 +155,7 @@ const ModelOptionButton = ({
           {option.id !== "auto" && <CostIndicator modelId={option.id} />}
         </div>
       </div>
-      {isFreeUser ? (
+      {isLocked ? (
         <Lock className="h-3.5 w-3.5 shrink-0 text-muted-foreground group-hover:text-foreground transition-colors" />
       ) : isSelected ? (
         <Check className="h-3.5 w-3.5 shrink-0" />
@@ -158,9 +163,9 @@ const ModelOptionButton = ({
     </button>
   );
 
-  // Free users get the upgrade tooltip from the parent ModelOptionList; skipping
+  // Locked options get the upgrade tooltip from the parent ModelOptionList; skipping
   // the inner one prevents a flicker where both nested tooltips race to render.
-  if (mobile || !option.description || isFreeUser) return button;
+  if (mobile || !option.description || isLocked) return button;
 
   return (
     <Tooltip delayDuration={150}>
@@ -191,7 +196,7 @@ const ModelOptionList = ({
   value,
   isAuto,
   isFreeUser,
-  mode,
+  subscription,
   onAutoSelect,
   onSelect,
   onClose,
@@ -201,7 +206,7 @@ const ModelOptionList = ({
   value: SelectedModel;
   isAuto: boolean;
   isFreeUser: boolean;
-  mode: ChatMode;
+  subscription: SubscriptionTier;
   onAutoSelect: () => void;
   onSelect: (option: ModelOption) => void;
   onClose: () => void;
@@ -219,13 +224,13 @@ const ModelOptionList = ({
               surface: mobile ? "model_selector_mobile" : "model_selector",
               source: "model_gate",
               from_tier: "free",
-              cta_text: "Get access to the top AI models",
+              cta_text: "Get access to paid models",
             });
           }}
           className="flex items-center justify-between rounded-lg border border-primary/40 bg-primary/10 px-2.5 py-2 transition-colors hover:bg-primary/20 cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         >
           <span className="text-sm font-semibold text-foreground">
-            Get access to the top AI models
+            Get access to paid models
           </span>
           <ChevronRight className="h-4 w-4 text-primary shrink-0" />
         </a>
@@ -244,7 +249,8 @@ const ModelOptionList = ({
 
     {options.map((option) => {
       const isSelected = value === option.id;
-      const showUpgradeTooltip = isFreeUser && !mobile;
+      const isLocked = isModelLockedForSubscription(subscription, option.id);
+      const showUpgradeTooltip = isLocked && !mobile;
 
       if (!showUpgradeTooltip) {
         return (
@@ -252,9 +258,8 @@ const ModelOptionList = ({
             <ModelOptionButton
               option={option}
               isSelected={isSelected}
-              isFreeUser={isFreeUser}
+              isLocked={isLocked}
               onSelect={onSelect}
-              mode={mode}
               mobile={mobile}
             />
           </div>
@@ -268,9 +273,8 @@ const ModelOptionList = ({
               <ModelOptionButton
                 option={option}
                 isSelected={isSelected}
-                isFreeUser={isFreeUser}
+                isLocked={isLocked}
                 onSelect={onSelect}
-                mode={mode}
                 mobile={mobile}
               />
             </div>
@@ -301,21 +305,18 @@ const ModelOptionList = ({
                 onClick={(event) => {
                   event.preventDefault();
                   onClose();
-                  redirectToPricing({
-                    surface: mobile
-                      ? "model_selector_mobile"
-                      : "model_selector",
-                    source: "locked_model_tooltip",
-                    from_tier: "free",
-                    cta_text: "Upgrade your plan",
+                  redirectLockedModelToPricing({
+                    mobile,
+                    option,
+                    subscription,
                   });
                 }}
                 className="text-foreground underline underline-offset-2 hover:text-foreground/80"
                 tabIndex={0}
               >
-                Upgrade your plan
-              </a>{" "}
-              to unlock.
+                {getLockedModelCta(option.id)}
+              </a>
+              {isMaxModel(option.id) ? " for Max mode." : " to unlock."}
             </p>
           </TooltipContent>
         </Tooltip>
@@ -328,13 +329,14 @@ const ModelOptionList = ({
 
 export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
-  const [pendingHighCostNotice, setPendingHighCostNotice] =
-    useState<ModelOption | null>(null);
   const { subscription } = useGlobalState();
-  const isMobile = useIsMobile();
+  const isMobile = Boolean(useIsMobile());
 
   const isFreeUser = subscription === "free";
-  const displayValue: SelectedModel = isFreeUser ? "auto" : value;
+  const displayValue = normalizeSelectedModelForSubscription(
+    value,
+    subscription,
+  );
   const isAuto = displayValue === "auto";
 
   const options = isAgentMode(mode) ? AGENT_MODEL_OPTIONS : ASK_MODEL_OPTIONS;
@@ -363,38 +365,17 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
   };
 
   const handleModelSelect = (option: ModelOption) => {
-    if (isFreeUser) {
+    if (isModelLockedForSubscription(subscription, option.id)) {
       setOpen(false);
-      redirectToPricing({
-        surface: isMobile ? "model_selector_mobile" : "model_selector",
-        source: "locked_model_option",
-        from_tier: "free",
-        cta_text: option.label,
+      redirectLockedModelToPricing({
+        mobile: isMobile,
+        option,
+        subscription,
       });
       return;
     }
 
-    if (
-      shouldWarnForPaidHighCostModel(subscription, option.id) &&
-      !isHighCostModelUsageNoticeDismissed()
-    ) {
-      setOpen(false);
-      setPendingHighCostNotice(option);
-      return;
-    }
-
     applyModelChoice(option);
-  };
-
-  const handleDismissHighCostNotice = () => {
-    setPendingHighCostNotice(null);
-  };
-
-  const handleConfirmHighCostModel = () => {
-    if (!pendingHighCostNotice) return;
-    dismissHighCostModelUsageNotice();
-    applyModelChoice(pendingHighCostNotice);
-    setPendingHighCostNotice(null);
   };
 
   const trigger = (
@@ -411,50 +392,10 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
     </Button>
   );
 
-  const usageLabel =
-    subscription === "team" ? "your team's usage" : "your usage";
-
-  const highCostUsageNoticeDialog = (
-    <AlertDialog
-      open={pendingHighCostNotice !== null}
-      onOpenChange={(nextOpen) => {
-        if (!nextOpen) handleDismissHighCostNotice();
-      }}
-    >
-      <AlertDialogContent
-        data-testid="high-cost-model-warning"
-        className="sm:max-w-[460px]"
-      >
-        <AlertDialogHeader className="gap-2">
-          <AlertDialogTitle className="flex items-center gap-2 text-lg">
-            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
-              <AlertTriangle className="h-4 w-4" />
-            </span>
-            <span>High-cost model</span>
-          </AlertDialogTitle>
-          <AlertDialogDescription className="text-left text-sm leading-relaxed text-foreground/80">
-            {pendingHighCostNotice?.label ?? "This model"} is powerful, but it
-            can use a lot more of {usageLabel} than Standard, and long requests
-            can use around $10 of usage.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel onClick={handleDismissHighCostNotice}>
-            Pick another model
-          </AlertDialogCancel>
-          <AlertDialogAction onClick={handleConfirmHighCostModel}>
-            Use {pendingHighCostNotice?.label ?? "model"}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  );
-
   if (isMobile) {
     return (
       <>
         {trigger}
-        {highCostUsageNoticeDialog}
         <Sheet open={open} onOpenChange={setOpen}>
           <SheetContent
             side="bottom"
@@ -471,7 +412,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
               value={displayValue}
               isAuto={isAuto}
               isFreeUser={isFreeUser}
-              mode={mode}
+              subscription={subscription}
               onAutoSelect={handleAutoSelect}
               onSelect={handleModelSelect}
               onClose={() => setOpen(false)}
@@ -485,7 +426,6 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
 
   return (
     <>
-      {highCostUsageNoticeDialog}
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>{trigger}</PopoverTrigger>
         <PopoverContent className="w-[270px] p-1.5 rounded-xl" align="start">
@@ -494,7 +434,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
             value={displayValue}
             isAuto={isAuto}
             isFreeUser={isFreeUser}
-            mode={mode}
+            subscription={subscription}
             onAutoSelect={handleAutoSelect}
             onSelect={handleModelSelect}
             onClose={() => setOpen(false)}

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Brain, Check, ChevronDown, ChevronRight, Lock } from "lucide-react";
+import {
+  Brain,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  Lock,
+} from "lucide-react";
 import {
   Popover,
   PopoverContent,
@@ -23,7 +30,6 @@ import { useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import {
-  canUseExtraUsage,
   canUseMaxModel,
   normalizeMaxModelForSubscription,
   normalizeSelectedModelForSubscription,
@@ -74,7 +80,7 @@ const getLockedModelCta = (
   subscription: SubscriptionTier,
 ): string => {
   if (isMaxModel(model) && canUnlockMaxWithExtraUsage(subscription)) {
-    return "Manage Extra Usage";
+    return "Set up Extra Usage";
   }
   return isMaxModel(model) ? "Upgrade to Ultra" : "Upgrade your plan";
 };
@@ -149,6 +155,7 @@ const ModelOptionButton = ({
   option,
   isSelected,
   isLocked,
+  isPending,
   subscription,
   onSelect,
   mobile = false,
@@ -156,6 +163,7 @@ const ModelOptionButton = ({
   option: ModelOption;
   isSelected: boolean;
   isLocked: boolean;
+  isPending: boolean;
   subscription: SubscriptionTier;
   onSelect: (option: ModelOption) => void;
   mobile?: boolean;
@@ -164,18 +172,28 @@ const ModelOptionButton = ({
     <button
       type="button"
       onClick={() => onSelect(option)}
+      disabled={isPending}
+      aria-busy={isPending || undefined}
       aria-pressed={isSelected}
       aria-label={
-        isLocked
-          ? `${option.label}. ${getLockedModelAnnouncement(
-              option.id,
-              subscription,
-            )}.`
-          : undefined
+        isPending
+          ? `${option.label}. Checking Extra Usage for Max mode.`
+          : isLocked
+            ? `${option.label}. ${getLockedModelAnnouncement(
+                option.id,
+                subscription,
+              )}.`
+            : undefined
       }
-      className={`group w-full flex items-center gap-2.5 px-2.5 rounded-lg text-left transition-colors select-none cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+      className={`group w-full flex items-center gap-2.5 px-2.5 rounded-lg text-left transition-colors select-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
         mobile ? "py-2.5" : "py-1.5"
-      } ${isSelected ? "bg-accent" : "hover:bg-muted/50 active:bg-muted/50"}`}
+      } ${
+        isPending
+          ? `cursor-wait opacity-80 ${isSelected ? "bg-accent" : ""}`
+          : isSelected
+            ? "cursor-pointer bg-accent"
+            : "cursor-pointer hover:bg-muted/50 active:bg-muted/50"
+      }`}
     >
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5">
@@ -194,7 +212,9 @@ const ModelOptionButton = ({
           {option.id !== "auto" && <CostIndicator modelId={option.id} />}
         </div>
       </div>
-      {isLocked ? (
+      {isPending ? (
+        <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+      ) : isLocked ? (
         <Lock className="h-3.5 w-3.5 shrink-0 text-muted-foreground group-hover:text-foreground transition-colors" />
       ) : isSelected ? (
         <Check className="h-3.5 w-3.5 shrink-0" />
@@ -237,6 +257,7 @@ const ModelOptionList = ({
   isFreeUser,
   subscription,
   maxModelExtraUsageAvailable,
+  maxModelEntitlementLoading,
   onAutoSelect,
   onSelect,
   onClose,
@@ -248,6 +269,7 @@ const ModelOptionList = ({
   isFreeUser: boolean;
   subscription: SubscriptionTier;
   maxModelExtraUsageAvailable: boolean;
+  maxModelEntitlementLoading: boolean;
   onAutoSelect: () => void;
   onSelect: (option: ModelOption) => void;
   onClose: () => void;
@@ -295,7 +317,11 @@ const ModelOptionList = ({
         option.id,
         maxModelExtraUsageAvailable,
       );
-      const showUpgradeTooltip = isLocked && !mobile;
+      const isPending = isMaxModel(option.id) && maxModelEntitlementLoading;
+      const showUpgradeTooltip =
+        isLocked &&
+        !mobile &&
+        !(isMaxModel(option.id) && maxModelEntitlementLoading);
 
       if (!showUpgradeTooltip) {
         return (
@@ -304,6 +330,7 @@ const ModelOptionList = ({
               option={option}
               isSelected={isSelected}
               isLocked={isLocked}
+              isPending={isPending}
               subscription={subscription}
               onSelect={onSelect}
               mobile={mobile}
@@ -320,6 +347,7 @@ const ModelOptionList = ({
                 option={option}
                 isSelected={isSelected}
                 isLocked={isLocked}
+                isPending={false}
                 subscription={subscription}
                 onSelect={onSelect}
                 mobile={mobile}
@@ -385,38 +413,27 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
   const isMobile = Boolean(useIsMobile());
 
   const isFreeUser = subscription === "free";
-  const shouldCheckPersonalExtraUsage =
-    subscription === "pro" || subscription === "pro-plus";
-  const userCustomization = useQuery(
-    api.userCustomization.getUserCustomization,
-    shouldCheckPersonalExtraUsage ? undefined : "skip",
+  const shouldCheckPersonalMaxExtraUsage =
+    (subscription === "pro" || subscription === "pro-plus") &&
+    (open || value === "hackerai-max");
+  const maxModelEntitlement = useQuery(
+    api.extraUsage.getMaxModelExtraUsageEntitlement,
+    shouldCheckPersonalMaxExtraUsage ? {} : "skip",
   );
-  const extraUsageSettings = useQuery(
-    api.extraUsage.getExtraUsageSettings,
-    shouldCheckPersonalExtraUsage ? undefined : "skip",
-  );
-  const monthlyRemainingDollars =
-    extraUsageSettings?.monthlyCapDollars === undefined
-      ? undefined
-      : Math.max(
-          0,
-          extraUsageSettings.monthlyCapDollars -
-            (extraUsageSettings.monthlySpentDollars ?? 0),
-        );
-  const maxModelExtraUsageAvailable = canUseExtraUsage({
-    enabled: userCustomization?.extra_usage_enabled ?? false,
-    balanceDollars: extraUsageSettings?.balanceDollars,
-    autoReloadEnabled: extraUsageSettings?.autoReloadEnabled,
-    monthlyRemainingDollars,
-  });
+  const maxModelEntitlementLoading =
+    shouldCheckPersonalMaxExtraUsage && maxModelEntitlement === undefined;
+  const maxModelExtraUsageAvailable =
+    maxModelEntitlement?.extraUsageAvailable ?? false;
   const subscriptionValue = normalizeSelectedModelForSubscription(
     value,
     subscription,
   );
   const displayValue =
-    normalizeMaxModelForSubscription(subscriptionValue, subscription, {
-      extraUsageAvailable: maxModelExtraUsageAvailable,
-    }) ?? "auto";
+    value === "hackerai-max" && maxModelEntitlementLoading
+      ? subscriptionValue
+      : (normalizeMaxModelForSubscription(subscriptionValue, subscription, {
+          extraUsageAvailable: maxModelExtraUsageAvailable,
+        }) ?? "auto");
   const isAuto = displayValue === "auto";
 
   const options = isAgentMode(mode) ? AGENT_MODEL_OPTIONS : ASK_MODEL_OPTIONS;
@@ -445,6 +462,10 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
   };
 
   const handleModelSelect = (option: ModelOption) => {
+    if (isMaxModel(option.id) && maxModelEntitlementLoading) {
+      return;
+    }
+
     if (
       isModelLockedForSubscription(
         subscription,
@@ -500,6 +521,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
               isFreeUser={isFreeUser}
               subscription={subscription}
               maxModelExtraUsageAvailable={maxModelExtraUsageAvailable}
+              maxModelEntitlementLoading={maxModelEntitlementLoading}
               onAutoSelect={handleAutoSelect}
               onSelect={handleModelSelect}
               onClose={() => setOpen(false)}
@@ -523,6 +545,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
             isFreeUser={isFreeUser}
             subscription={subscription}
             maxModelExtraUsageAvailable={maxModelExtraUsageAvailable}
+            maxModelEntitlementLoading={maxModelEntitlementLoading}
             onAutoSelect={handleAutoSelect}
             onSelect={handleModelSelect}
             onClose={() => setOpen(false)}

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -6,6 +6,7 @@ import type { SubscriptionTier } from "@/types/chat";
 let mockSubscription: SubscriptionTier;
 let mockQueryResult: unknown;
 const mockRedirectToPricing = jest.fn();
+const mockOpenSettingsDialog = jest.fn();
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({
@@ -19,6 +20,10 @@ jest.mock("@/hooks/use-mobile", () => ({
 
 jest.mock("@/app/hooks/usePricingDialog", () => ({
   redirectToPricing: (...args: unknown[]) => mockRedirectToPricing(...args),
+}));
+
+jest.mock("@/lib/utils/settings-dialog", () => ({
+  openSettingsDialog: (...args: unknown[]) => mockOpenSettingsDialog(...args),
 }));
 
 jest.mock("convex/react", () => ({
@@ -35,6 +40,7 @@ describe("ModelSelector", () => {
     mockSubscription = "pro-plus";
     mockQueryResult = undefined;
     mockRedirectToPricing.mockClear();
+    mockOpenSettingsDialog.mockClear();
   });
 
   it("shows model choices immediately while Auto is selected", () => {
@@ -98,20 +104,22 @@ describe("ModelSelector", () => {
     expect(onChange).toHaveBeenCalledWith("hackerai-pro");
   });
 
-  it("locks HackerAI Max on Pro Plus and routes to Ultra pricing", () => {
+  it("locks HackerAI Max on Pro Plus and opens Extra Usage settings", () => {
     const onChange = jest.fn();
     render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
 
     fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
-    fireEvent.click(screen.getByRole("button", { name: /HackerAI Max/i }));
+    const maxButton = screen.getByRole("button", { name: /HackerAI Max/i });
+
+    expect(maxButton).toHaveAccessibleName(
+      "HackerAI Max. Manage Extra Usage for Max mode.",
+    );
+
+    fireEvent.click(maxButton);
 
     expect(onChange).not.toHaveBeenCalled();
-    expect(mockRedirectToPricing).toHaveBeenCalledWith({
-      surface: "model_selector",
-      source: "max_model_gate",
-      from_tier: "pro-plus",
-      cta_text: "Upgrade to Ultra",
-    });
+    expect(mockOpenSettingsDialog).toHaveBeenCalledWith("Extra Usage");
+    expect(mockRedirectToPricing).not.toHaveBeenCalled();
   });
 
   it("selects HackerAI Max on Pro Plus when extra usage is available", () => {
@@ -151,12 +159,8 @@ describe("ModelSelector", () => {
     fireEvent.click(screen.getByRole("button", { name: /HackerAI Max/i }));
 
     expect(onChange).not.toHaveBeenCalled();
-    expect(mockRedirectToPricing).toHaveBeenCalledWith({
-      surface: "model_selector",
-      source: "max_model_gate",
-      from_tier: "team",
-      cta_text: "Upgrade to Ultra",
-    });
+    expect(mockOpenSettingsDialog).toHaveBeenCalledWith("Extra Usage");
+    expect(mockRedirectToPricing).not.toHaveBeenCalled();
   });
 
   it("does not display a stale paid model as selected for free users", () => {

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import type { SubscriptionTier } from "@/types/chat";
 
 let mockSubscription: SubscriptionTier;
+let mockQueryResult: unknown;
 const mockRedirectToPricing = jest.fn();
 
 jest.mock("@/app/contexts/GlobalState", () => ({
@@ -20,6 +21,11 @@ jest.mock("@/app/hooks/usePricingDialog", () => ({
   redirectToPricing: (...args: unknown[]) => mockRedirectToPricing(...args),
 }));
 
+jest.mock("convex/react", () => ({
+  useQuery: (_query: unknown, args: unknown) =>
+    args === "skip" ? undefined : mockQueryResult,
+}));
+
 const { ModelSelector } = jest.requireActual<
   typeof import("../../ModelSelector")
 >("../../ModelSelector");
@@ -27,6 +33,7 @@ const { ModelSelector } = jest.requireActual<
 describe("ModelSelector", () => {
   beforeEach(() => {
     mockSubscription = "pro-plus";
+    mockQueryResult = undefined;
     mockRedirectToPricing.mockClear();
   });
 
@@ -107,6 +114,23 @@ describe("ModelSelector", () => {
     });
   });
 
+  it("selects HackerAI Max on Pro Plus when extra usage is available", () => {
+    mockQueryResult = {
+      extra_usage_enabled: true,
+      balanceDollars: 10,
+      autoReloadEnabled: false,
+      monthlySpentDollars: 0,
+    };
+    const onChange = jest.fn();
+    render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /HackerAI Max/i }));
+
+    expect(onChange).toHaveBeenCalledWith("hackerai-max");
+    expect(mockRedirectToPricing).not.toHaveBeenCalled();
+  });
+
   it("selects HackerAI Max for Ultra users", () => {
     mockSubscription = "ultra";
     const onChange = jest.fn();
@@ -162,5 +186,28 @@ describe("ModelSelector", () => {
     expect(proButton).toBeDefined();
     expect(proButton).toHaveAttribute("aria-pressed", "true");
     expect(maxButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("displays stale Max as selected for Pro users with extra usage available", () => {
+    mockSubscription = "pro";
+    mockQueryResult = {
+      extra_usage_enabled: true,
+      balanceDollars: 0,
+      autoReloadEnabled: true,
+      monthlySpentDollars: 0,
+    };
+
+    render(
+      <ModelSelector value="hackerai-max" onChange={jest.fn()} mode="agent" />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /HackerAI Max/i }));
+
+    const maxButton = screen
+      .getAllByRole("button", { name: /HackerAI Max/i })
+      .find((button) => button.hasAttribute("aria-pressed"));
+
+    expect(maxButton).toBeDefined();
+    expect(maxButton).toHaveAttribute("aria-pressed", "true");
   });
 });

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -4,7 +4,11 @@ import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import type { SubscriptionTier } from "@/types/chat";
 
 let mockSubscription: SubscriptionTier;
-let mockQueryResult: unknown;
+let mockMaxEntitlement: unknown;
+const mockUseQuery = jest.fn(
+  (_query: unknown, args: unknown) =>
+    args === "skip" ? undefined : mockMaxEntitlement,
+);
 const mockRedirectToPricing = jest.fn();
 const mockOpenSettingsDialog = jest.fn();
 
@@ -27,8 +31,7 @@ jest.mock("@/lib/utils/settings-dialog", () => ({
 }));
 
 jest.mock("convex/react", () => ({
-  useQuery: (_query: unknown, args: unknown) =>
-    args === "skip" ? undefined : mockQueryResult,
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
 }));
 
 const { ModelSelector } = jest.requireActual<
@@ -38,9 +41,20 @@ const { ModelSelector } = jest.requireActual<
 describe("ModelSelector", () => {
   beforeEach(() => {
     mockSubscription = "pro-plus";
-    mockQueryResult = undefined;
+    mockMaxEntitlement = undefined;
+    mockUseQuery.mockClear();
     mockRedirectToPricing.mockClear();
     mockOpenSettingsDialog.mockClear();
+  });
+
+  it("skips the Max entitlement query until a paid user opens the selector", () => {
+    render(<ModelSelector value="auto" onChange={jest.fn()} mode="agent" />);
+
+    expect(mockUseQuery).toHaveBeenLastCalledWith(expect.anything(), "skip");
+
+    fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
+
+    expect(mockUseQuery).toHaveBeenLastCalledWith(expect.anything(), {});
   });
 
   it("shows model choices immediately while Auto is selected", () => {
@@ -105,6 +119,12 @@ describe("ModelSelector", () => {
   });
 
   it("locks HackerAI Max on Pro Plus and opens Extra Usage settings", () => {
+    mockMaxEntitlement = {
+      extraUsageAvailable: false,
+      reason: "disabled",
+      hasBalance: false,
+      autoReloadEnabled: false,
+    };
     const onChange = jest.fn();
     render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
 
@@ -112,7 +132,7 @@ describe("ModelSelector", () => {
     const maxButton = screen.getByRole("button", { name: /HackerAI Max/i });
 
     expect(maxButton).toHaveAccessibleName(
-      "HackerAI Max. Manage Extra Usage for Max mode.",
+      "HackerAI Max. Set up Extra Usage for Max mode.",
     );
 
     fireEvent.click(maxButton);
@@ -122,12 +142,30 @@ describe("ModelSelector", () => {
     expect(mockRedirectToPricing).not.toHaveBeenCalled();
   });
 
+  it("shows a checking state while lazy Max entitlement is loading", () => {
+    const onChange = jest.fn();
+    render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
+
+    const maxButton = screen.getByRole("button", { name: /HackerAI Max/i });
+    expect(maxButton).toHaveAccessibleName(
+      "HackerAI Max. Checking Extra Usage for Max mode.",
+    );
+    expect(maxButton).toBeDisabled();
+
+    fireEvent.click(maxButton);
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(mockOpenSettingsDialog).not.toHaveBeenCalled();
+  });
+
   it("selects HackerAI Max on Pro Plus when extra usage is available", () => {
-    mockQueryResult = {
-      extra_usage_enabled: true,
-      balanceDollars: 10,
+    mockMaxEntitlement = {
+      extraUsageAvailable: true,
+      reason: "available",
+      hasBalance: true,
       autoReloadEnabled: false,
-      monthlySpentDollars: 0,
     };
     const onChange = jest.fn();
     render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
@@ -175,6 +213,12 @@ describe("ModelSelector", () => {
 
   it("does not display stale Max as selected outside Ultra", () => {
     mockSubscription = "pro";
+    mockMaxEntitlement = {
+      extraUsageAvailable: false,
+      reason: "empty",
+      hasBalance: false,
+      autoReloadEnabled: false,
+    };
 
     render(
       <ModelSelector value="hackerai-max" onChange={jest.fn()} mode="agent" />,
@@ -194,11 +238,11 @@ describe("ModelSelector", () => {
 
   it("displays stale Max as selected for Pro users with extra usage available", () => {
     mockSubscription = "pro";
-    mockQueryResult = {
-      extra_usage_enabled: true,
-      balanceDollars: 0,
+    mockMaxEntitlement = {
+      extraUsageAvailable: true,
+      reason: "available",
+      hasBalance: false,
       autoReloadEnabled: true,
-      monthlySpentDollars: 0,
     };
 
     render(

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -152,6 +152,15 @@ describe("ModelSelector", () => {
       <ModelSelector value="hackerai-max" onChange={jest.fn()} mode="agent" />,
     );
 
-    expect(screen.getByRole("button", { name: /HackerAI Pro/i })).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: /HackerAI Pro/i }));
+
+    const proButton = screen
+      .getAllByRole("button", { name: /HackerAI Pro/i })
+      .find((button) => button.hasAttribute("aria-pressed"));
+    const maxButton = screen.getByRole("button", { name: /HackerAI Max/i });
+
+    expect(proButton).toBeDefined();
+    expect(proButton).toHaveAttribute("aria-pressed", "true");
+    expect(maxButton).toHaveAttribute("aria-pressed", "false");
   });
 });

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -4,8 +4,7 @@ import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import type { SubscriptionTier } from "@/types/chat";
 
 let mockSubscription: SubscriptionTier;
-const mockIsHighCostModelUsageNoticeDismissed = jest.fn();
-const mockDismissHighCostModelUsageNotice = jest.fn();
+const mockRedirectToPricing = jest.fn();
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({
@@ -17,10 +16,8 @@ jest.mock("@/hooks/use-mobile", () => ({
   useIsMobile: () => false,
 }));
 
-jest.mock("@/lib/utils/pro-max-notice-cookie", () => ({
-  isHighCostModelUsageNoticeDismissed: () =>
-    mockIsHighCostModelUsageNoticeDismissed(),
-  dismissHighCostModelUsageNotice: () => mockDismissHighCostModelUsageNotice(),
+jest.mock("@/app/hooks/usePricingDialog", () => ({
+  redirectToPricing: (...args: unknown[]) => mockRedirectToPricing(...args),
 }));
 
 const { ModelSelector } = jest.requireActual<
@@ -30,8 +27,7 @@ const { ModelSelector } = jest.requireActual<
 describe("ModelSelector", () => {
   beforeEach(() => {
     mockSubscription = "pro-plus";
-    mockIsHighCostModelUsageNoticeDismissed.mockReturnValue(false);
-    mockDismissHighCostModelUsageNotice.mockClear();
+    mockRedirectToPricing.mockClear();
   });
 
   it("shows model choices immediately while Auto is selected", () => {
@@ -79,7 +75,6 @@ describe("ModelSelector", () => {
     expect(
       screen.queryByTestId("high-cost-model-warning"),
     ).not.toBeInTheDocument();
-    expect(mockDismissHighCostModelUsageNotice).not.toHaveBeenCalled();
     expect(onChange).toHaveBeenCalledWith("hackerai-pro");
   });
 
@@ -93,11 +88,10 @@ describe("ModelSelector", () => {
     expect(
       screen.queryByTestId("high-cost-model-warning"),
     ).not.toBeInTheDocument();
-    expect(mockDismissHighCostModelUsageNotice).not.toHaveBeenCalled();
     expect(onChange).toHaveBeenCalledWith("hackerai-pro");
   });
 
-  it("warns before selecting HackerAI Max on Pro Plus", () => {
+  it("locks HackerAI Max on Pro Plus and routes to Ultra pricing", () => {
     const onChange = jest.fn();
     render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
 
@@ -105,11 +99,15 @@ describe("ModelSelector", () => {
     fireEvent.click(screen.getByRole("button", { name: /HackerAI Max/i }));
 
     expect(onChange).not.toHaveBeenCalled();
-    expect(screen.getByTestId("high-cost-model-warning")).toBeVisible();
-    expect(screen.getByText(/HackerAI Max is powerful/i)).toBeVisible();
+    expect(mockRedirectToPricing).toHaveBeenCalledWith({
+      surface: "model_selector",
+      source: "max_model_gate",
+      from_tier: "pro-plus",
+      cta_text: "Upgrade to Ultra",
+    });
   });
 
-  it("selects high-cost models without warning for Ultra users", () => {
+  it("selects HackerAI Max for Ultra users", () => {
     mockSubscription = "ultra";
     const onChange = jest.fn();
     render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
@@ -117,14 +115,10 @@ describe("ModelSelector", () => {
     fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
     fireEvent.click(screen.getByRole("button", { name: /HackerAI Max/i }));
 
-    expect(
-      screen.queryByTestId("high-cost-model-warning"),
-    ).not.toBeInTheDocument();
-    expect(mockDismissHighCostModelUsageNotice).not.toHaveBeenCalled();
     expect(onChange).toHaveBeenCalledWith("hackerai-max");
   });
 
-  it("uses team-specific warning copy for team users selecting Max", () => {
+  it("locks HackerAI Max for team users", () => {
     mockSubscription = "team";
     const onChange = jest.fn();
     render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
@@ -133,10 +127,12 @@ describe("ModelSelector", () => {
     fireEvent.click(screen.getByRole("button", { name: /HackerAI Max/i }));
 
     expect(onChange).not.toHaveBeenCalled();
-    expect(screen.getByText(/your team's usage/i)).toBeVisible();
-    expect(
-      screen.getByText(/long requests can use around \$10 of usage/i),
-    ).toBeVisible();
+    expect(mockRedirectToPricing).toHaveBeenCalledWith({
+      surface: "model_selector",
+      source: "max_model_gate",
+      from_tier: "team",
+      cta_text: "Upgrade to Ultra",
+    });
   });
 
   it("does not display a stale paid model as selected for free users", () => {
@@ -147,5 +143,15 @@ describe("ModelSelector", () => {
     );
 
     expect(screen.getByRole("button", { name: /^Auto$/i })).toBeVisible();
+  });
+
+  it("does not display stale Max as selected outside Ultra", () => {
+    mockSubscription = "pro";
+
+    render(
+      <ModelSelector value="hackerai-max" onChange={jest.fn()} mode="agent" />,
+    );
+
+    expect(screen.getByRole("button", { name: /HackerAI Pro/i })).toBeVisible();
   });
 });

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -19,6 +19,7 @@ import {
   type QueueBehavior,
   type SandboxPreference,
   isChatMode,
+  normalizeSelectedModelForSubscription,
 } from "@/types/chat";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import type { Todo } from "@/types";
@@ -463,6 +464,17 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   useEffect(() => {
     writeSelectedModel(selectedModel);
   }, [selectedModel]);
+
+  useEffect(() => {
+    if (!subscriptionResolved) return;
+    const normalizedModel = normalizeSelectedModelForSubscription(
+      selectedModel,
+      subscription,
+    );
+    if (normalizedModel !== selectedModel) {
+      setSelectedModelRaw(normalizedModel);
+    }
+  }, [selectedModel, subscription, subscriptionResolved]);
 
   const setSelectedModelState = useCallback((model: SelectedModel) => {
     setSelectedModelRaw(model);

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -18,6 +18,11 @@ type ExtraUsagePurchaseRoute =
   "checkout_action" | "confirm" | "webhook" | "repair";
 type ExtraUsagePurchaseResult =
   "created" | "paid_seen" | "credited" | "already_processed" | "failed";
+type MaxModelExtraUsageReason =
+  | "available"
+  | "disabled"
+  | "empty"
+  | "monthly_cap_exhausted";
 
 const MAX_PURCHASE_ERROR_LENGTH = 500;
 const PURCHASE_JSON_SECRET_PATTERN =
@@ -46,6 +51,20 @@ const sanitizePurchaseError = (error: string): string =>
     .split("\n", 1)[0]
     .trim()
     .slice(0, MAX_PURCHASE_ERROR_LENGTH);
+
+const currentMonthString = (): string => {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+};
+
+const getMonthlySpentPointsForCurrentMonth = (
+  settings: { monthly_reset_date?: string; monthly_spent_points?: number } | null,
+): number => {
+  if (!settings || settings.monthly_reset_date !== currentMonthString()) {
+    return 0;
+  }
+  return settings.monthly_spent_points ?? 0;
+};
 
 async function upsertExtraUsagePurchase(
   ctx: MutationCtx,
@@ -847,12 +866,7 @@ export const getExtraUsageBalanceForBackend = query({
 
     const balancePoints = settings?.balance_points ?? 0;
     const thresholdPoints = settings?.auto_reload_threshold_points;
-    const now = new Date();
-    const currentMonth = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
-    const monthlySpentPoints =
-      settings?.monthly_reset_date === currentMonth
-        ? (settings?.monthly_spent_points ?? 0)
-        : 0;
+    const monthlySpentPoints = getMonthlySpentPointsForCurrentMonth(settings);
     const monthlyCapPoints = settings?.monthly_cap_points;
     const monthlyRemainingPoints =
       monthlyCapPoints === undefined
@@ -874,6 +888,79 @@ export const getExtraUsageBalanceForBackend = query({
           ? undefined
           : pointsToDollars(monthlyCapPoints),
       monthlySpentDollars: pointsToDollars(monthlySpentPoints),
+      monthlyRemainingDollars:
+        monthlyRemainingPoints === undefined
+          ? undefined
+          : pointsToDollars(monthlyRemainingPoints),
+    };
+  },
+});
+
+/**
+ * Minimal frontend entitlement check for HackerAI Max on paid personal plans.
+ * The selector uses this instead of subscribing to broad customization and
+ * balance payloads just to answer whether Extra Usage can unlock Max.
+ */
+export const getMaxModelExtraUsageEntitlement = query({
+  args: {},
+  returns: v.union(
+    v.null(),
+    v.object({
+      extraUsageAvailable: v.boolean(),
+      reason: v.union(
+        v.literal("available"),
+        v.literal("disabled"),
+        v.literal("empty"),
+        v.literal("monthly_cap_exhausted"),
+      ),
+      hasBalance: v.boolean(),
+      autoReloadEnabled: v.boolean(),
+      monthlyRemainingDollars: v.optional(v.number()),
+    }),
+  ),
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      return null;
+    }
+
+    const [customization, settings] = await Promise.all([
+      ctx.db
+        .query("user_customization")
+        .withIndex("by_user_id", (q) => q.eq("user_id", identity.subject))
+        .first(),
+      ctx.db
+        .query("extra_usage")
+        .withIndex("by_user_id", (q) => q.eq("user_id", identity.subject))
+        .first(),
+    ]);
+
+    const enabled = customization?.extra_usage_enabled ?? false;
+    const hasBalance = (settings?.balance_points ?? 0) > 0;
+    const autoReloadEnabled = settings?.auto_reload_enabled ?? false;
+    const monthlySpentPoints = getMonthlySpentPointsForCurrentMonth(settings);
+    const monthlyCapPoints = settings?.monthly_cap_points;
+    const monthlyRemainingPoints =
+      monthlyCapPoints === undefined
+        ? undefined
+        : Math.max(0, monthlyCapPoints - monthlySpentPoints);
+    const monthlyCapExhausted =
+      monthlyRemainingPoints !== undefined && monthlyRemainingPoints <= 0;
+
+    let reason: MaxModelExtraUsageReason = "available";
+    if (!enabled) {
+      reason = "disabled";
+    } else if (monthlyCapExhausted) {
+      reason = "monthly_cap_exhausted";
+    } else if (!hasBalance && !autoReloadEnabled) {
+      reason = "empty";
+    }
+
+    return {
+      extraUsageAvailable: reason === "available",
+      reason,
+      hasBalance,
+      autoReloadEnabled,
       monthlyRemainingDollars:
         monthlyRemainingPoints === undefined
           ? undefined

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -4,6 +4,7 @@ import {
   query,
   type MutationCtx,
 } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { validateServiceKey } from "./lib/utils";
 import { convexLogger } from "./lib/logger";
@@ -58,7 +59,7 @@ const currentMonthString = (): string => {
 };
 
 const getMonthlySpentPointsForCurrentMonth = (
-  settings: { monthly_reset_date?: string; monthly_spent_points?: number } | null,
+  settings: Doc<"extra_usage"> | null,
 ): number => {
   if (!settings || settings.monthly_reset_date !== currentMonthString()) {
     return 0;

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -26,6 +26,7 @@ import type {
   SandboxBootInfo,
 } from "@/types";
 import {
+  canUseExtraUsage,
   coerceSelectedModel,
   isLimitRescueRequest,
   normalizeSelectedModelOverrideForSubscription,
@@ -369,6 +370,7 @@ export const createChatHandler = () => {
           subscription,
           uploadBasePath,
           modelOverride: selectedModelOverride,
+          extraUsageAvailable: canUseExtraUsage(extraUsageConfig),
           allowLocalDesktopFiles:
             isAgentMode(mode) && sandboxPreference === "desktop",
         });

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -29,6 +29,7 @@ import {
   canUseExtraUsage,
   coerceSelectedModel,
   isLimitRescueRequest,
+  normalizeMaxModelForSubscription,
   normalizeSelectedModelOverrideForSubscription,
 } from "@/types";
 import { getBaseTodosForRequest } from "@/lib/utils/todo-utils";
@@ -72,7 +73,6 @@ import {
   shutdownPostHog,
   type ChatLogger,
 } from "@/lib/api/chat-logger";
-import { resolveAgentRunSpendCapContinuationModel } from "@/lib/chat/agent-run-spend-cap";
 import {
   countFileAttachments,
   stripImageAttachments,
@@ -322,15 +322,11 @@ export const createChatHandler = () => {
         userCustomization,
         organizationId,
       });
-
-      selectedModelOverride = resolveAgentRunSpendCapContinuationModel({
-        finishReason: chat?.finish_reason,
-        isAutoContinue,
-        mode,
-        subscription,
-        selectedModelOverride,
-        extraUsageConfig,
-      });
+      const extraUsageAvailable = canUseExtraUsage(extraUsageConfig);
+      selectedModelOverride =
+        normalizeMaxModelForSubscription(selectedModelOverride, subscription, {
+          extraUsageAvailable,
+        }) ?? undefined;
 
       if (!temporary) {
         await handleInitialChatAndUserMessage({
@@ -370,7 +366,7 @@ export const createChatHandler = () => {
           subscription,
           uploadBasePath,
           modelOverride: selectedModelOverride,
-          extraUsageAvailable: canUseExtraUsage(extraUsageConfig),
+          extraUsageAvailable,
           allowLocalDesktopFiles:
             isAgentMode(mode) && sandboxPreference === "desktop",
         });

--- a/lib/chat/__tests__/agent-run-spend-cap.test.ts
+++ b/lib/chat/__tests__/agent-run-spend-cap.test.ts
@@ -111,7 +111,7 @@ describe("resolveAgentRunSpendCapContinuationModel", () => {
     ).toBe("hackerai-pro");
   });
 
-  it("keeps Max only for Ultra continuations", () => {
+  it("keeps Max for Ultra continuations", () => {
     expect(
       resolveAgentRunSpendCapContinuationModel({
         finishReason: "agent-run-spend-cap",
@@ -129,7 +129,7 @@ describe("resolveAgentRunSpendCapContinuationModel", () => {
     ).toBe("hackerai-max");
   });
 
-  it("downgrades Max outside Ultra even when extra usage is available", () => {
+  it("keeps Max outside Ultra when extra usage is available", () => {
     expect(
       resolveAgentRunSpendCapContinuationModel({
         finishReason: "agent-run-spend-cap",
@@ -142,6 +142,25 @@ describe("resolveAgentRunSpendCapContinuationModel", () => {
           hasBalance: true,
           balanceDollars: 10,
           autoReloadEnabled: false,
+        },
+      }),
+    ).toBe("hackerai-max");
+  });
+
+  it("downgrades Max outside Ultra when extra usage is unavailable", () => {
+    expect(
+      resolveAgentRunSpendCapContinuationModel({
+        finishReason: "agent-run-spend-cap",
+        isAutoContinue: true,
+        mode: "agent",
+        subscription: "pro",
+        selectedModelOverride: "hackerai-max",
+        extraUsageConfig: {
+          enabled: true,
+          hasBalance: true,
+          balanceDollars: 10,
+          autoReloadEnabled: false,
+          monthlyRemainingDollars: 0,
         },
       }),
     ).toBe("hackerai-pro");

--- a/lib/chat/__tests__/agent-run-spend-cap.test.ts
+++ b/lib/chat/__tests__/agent-run-spend-cap.test.ts
@@ -54,7 +54,7 @@ describe("canContinueProAgentRunWithPremium", () => {
 });
 
 describe("resolveAgentRunSpendCapContinuationModel", () => {
-  it("preserves Pro Agent spend-cap continuations without requiring extra usage", () => {
+  it("preserves non-Max Pro Agent spend-cap continuations", () => {
     expect(
       resolveAgentRunSpendCapContinuationModel({
         finishReason: "agent-run-spend-cap",
@@ -108,16 +108,16 @@ describe("resolveAgentRunSpendCapContinuationModel", () => {
         selectedModelOverride: "hackerai-max",
         extraUsageConfig: undefined,
       }),
-    ).toBe("hackerai-max");
+    ).toBe("hackerai-pro");
   });
 
-  it("keeps the selected model when extra usage or auto-reload can cover continuation", () => {
+  it("keeps Max only for Ultra continuations", () => {
     expect(
       resolveAgentRunSpendCapContinuationModel({
         finishReason: "agent-run-spend-cap",
         isAutoContinue: true,
         mode: "agent",
-        subscription: "pro",
+        subscription: "ultra",
         selectedModelOverride: "hackerai-max",
         extraUsageConfig: {
           enabled: true,
@@ -127,6 +127,24 @@ describe("resolveAgentRunSpendCapContinuationModel", () => {
         },
       }),
     ).toBe("hackerai-max");
+  });
+
+  it("downgrades Max outside Ultra even when extra usage is available", () => {
+    expect(
+      resolveAgentRunSpendCapContinuationModel({
+        finishReason: "agent-run-spend-cap",
+        isAutoContinue: true,
+        mode: "agent",
+        subscription: "pro",
+        selectedModelOverride: "hackerai-max",
+        extraUsageConfig: {
+          enabled: true,
+          hasBalance: true,
+          balanceDollars: 10,
+          autoReloadEnabled: false,
+        },
+      }),
+    ).toBe("hackerai-pro");
   });
 
   it("leaves Standard and non-spend-cap requests unchanged", () => {

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -255,6 +255,14 @@ describe("selectModel", () => {
       );
       expect(selectModel("ask", "team", "hackerai-max")).toBe("model-glm-5.2");
     });
+
+    it("should map HackerAI Max to Opus 4.6 for paid users with extra usage", () => {
+      expect(
+        selectModel("ask", "pro", "hackerai-max", false, false, {
+          extraUsageAvailable: true,
+        }),
+      ).toBe("model-opus-4.6");
+    });
   });
 
   // Agent mode — Standard resolves to MiniMax.
@@ -289,6 +297,14 @@ describe("selectModel", () => {
       expect(selectModel("agent", "team", "hackerai-max")).toBe(
         "model-glm-5.2",
       );
+    });
+
+    it("should map HackerAI Max to Opus 4.6 in agent mode for paid users with extra usage", () => {
+      expect(
+        selectModel("agent", "pro-plus", "hackerai-max", false, false, {
+          extraUsageAvailable: true,
+        }),
+      ).toBe("model-opus-4.6");
     });
 
     it("should default to agent-model when no model selected", () => {

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -242,8 +242,18 @@ describe("selectModel", () => {
       );
     });
 
-    it("should map HackerAI Max to Opus 4.6", () => {
-      expect(selectModel("ask", "pro", "hackerai-max")).toBe("model-opus-4.6");
+    it("should map HackerAI Max to Opus 4.6 for Ultra", () => {
+      expect(selectModel("ask", "ultra", "hackerai-max")).toBe(
+        "model-opus-4.6",
+      );
+    });
+
+    it("should downgrade HackerAI Max to Pro outside Ultra", () => {
+      expect(selectModel("ask", "pro", "hackerai-max")).toBe("model-glm-5.2");
+      expect(selectModel("ask", "pro-plus", "hackerai-max")).toBe(
+        "model-glm-5.2",
+      );
+      expect(selectModel("ask", "team", "hackerai-max")).toBe("model-glm-5.2");
     });
   });
 
@@ -265,9 +275,19 @@ describe("selectModel", () => {
       );
     });
 
-    it("should map HackerAI Max to Opus 4.6 in agent mode", () => {
-      expect(selectModel("agent", "pro", "hackerai-max")).toBe(
+    it("should map HackerAI Max to Opus 4.6 in agent mode for Ultra", () => {
+      expect(selectModel("agent", "ultra", "hackerai-max")).toBe(
         "model-opus-4.6",
+      );
+    });
+
+    it("should downgrade HackerAI Max to Pro in agent mode outside Ultra", () => {
+      expect(selectModel("agent", "pro", "hackerai-max")).toBe("model-glm-5.2");
+      expect(selectModel("agent", "pro-plus", "hackerai-max")).toBe(
+        "model-glm-5.2",
+      );
+      expect(selectModel("agent", "team", "hackerai-max")).toBe(
+        "model-glm-5.2",
       );
     });
 

--- a/lib/chat/agent-run-spend-cap.ts
+++ b/lib/chat/agent-run-spend-cap.ts
@@ -1,8 +1,9 @@
-import type {
-  ChatMode,
-  ExtraUsageConfig,
-  SelectedModel,
-  SubscriptionTier,
+import {
+  canUseMaxModel,
+  type ChatMode,
+  type ExtraUsageConfig,
+  type SelectedModel,
+  type SubscriptionTier,
 } from "@/types";
 
 export const AGENT_RUN_SPEND_CAP_REASON = "agent_run_spend_cap" as const;
@@ -58,5 +59,11 @@ export function resolveAgentRunSpendCapContinuationModel(args: {
   selectedModelOverride: SelectedModel | undefined;
   extraUsageConfig: ExtraUsageConfig | undefined;
 }): SelectedModel | undefined {
+  if (
+    args.selectedModelOverride === "hackerai-max" &&
+    !canUseMaxModel(args.subscription)
+  ) {
+    return "hackerai-pro";
+  }
   return args.selectedModelOverride;
 }

--- a/lib/chat/agent-run-spend-cap.ts
+++ b/lib/chat/agent-run-spend-cap.ts
@@ -1,4 +1,5 @@
 import {
+  canUseExtraUsage,
   normalizeMaxModelForSubscription,
   type ChatMode,
   type ExtraUsageConfig,
@@ -38,17 +39,7 @@ export function isAgentRunSpendCapBasis(
 export function canContinueProAgentRunWithPremium(
   extraUsageConfig: ExtraUsageConfig | undefined,
 ): boolean {
-  if (!extraUsageConfig?.enabled) return false;
-  if (
-    extraUsageConfig.monthlyRemainingDollars !== undefined &&
-    extraUsageConfig.monthlyRemainingDollars <= 0
-  ) {
-    return false;
-  }
-
-  return Boolean(
-    extraUsageConfig.hasBalance || extraUsageConfig.autoReloadEnabled,
-  );
+  return canUseExtraUsage(extraUsageConfig);
 }
 
 export function resolveAgentRunSpendCapContinuationModel(args: {
@@ -63,6 +54,11 @@ export function resolveAgentRunSpendCapContinuationModel(args: {
     normalizeMaxModelForSubscription(
       args.selectedModelOverride,
       args.subscription,
+      {
+        extraUsageAvailable: canContinueProAgentRunWithPremium(
+          args.extraUsageConfig,
+        ),
+      },
     ) ?? undefined
   );
 }

--- a/lib/chat/agent-run-spend-cap.ts
+++ b/lib/chat/agent-run-spend-cap.ts
@@ -1,5 +1,5 @@
 import {
-  canUseMaxModel,
+  normalizeMaxModelForSubscription,
   type ChatMode,
   type ExtraUsageConfig,
   type SelectedModel,
@@ -59,11 +59,10 @@ export function resolveAgentRunSpendCapContinuationModel(args: {
   selectedModelOverride: SelectedModel | undefined;
   extraUsageConfig: ExtraUsageConfig | undefined;
 }): SelectedModel | undefined {
-  if (
-    args.selectedModelOverride === "hackerai-max" &&
-    !canUseMaxModel(args.subscription)
-  ) {
-    return "hackerai-pro";
-  }
-  return args.selectedModelOverride;
+  return (
+    normalizeMaxModelForSubscription(
+      args.selectedModelOverride,
+      args.subscription,
+    ) ?? undefined
+  );
 }

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -1,5 +1,10 @@
 import { getModerationResult } from "@/lib/moderation";
-import type { ChatMode, SubscriptionTier, SelectedModel } from "@/types";
+import {
+  canUseMaxModel,
+  type ChatMode,
+  type SelectedModel,
+  type SubscriptionTier,
+} from "@/types";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import { UIMessage } from "ai";
 import { processMessageFiles } from "@/lib/utils/file-transform-utils";
@@ -53,6 +58,10 @@ export function selectModel(
   hasPdfAttachment?: boolean,
 ): ModelName {
   const isAgent = isAgentMode(mode);
+  const allowedSelectedModel =
+    selectedModel === "hackerai-max" && !canUseMaxModel(subscription)
+      ? "hackerai-pro"
+      : selectedModel;
   // DeepSeek ask routes are text-only, so image/PDF prompts promote to a
   // media-capable route unless the selected tier intentionally uses a
   // multimodal/file-capable model such as Kimi or Opus.
@@ -71,26 +80,30 @@ export function selectModel(
       ? "ask-model-free"
       : paidAskMediaModel;
 
-  // Free users always route through the auto router; paid users may pick a
-  // tier explicitly. The tier id is mode-aware via resolveTierToProviderKey.
-  if (!selectedModel || selectedModel === "auto" || subscription === "free") {
+  // Free users always route through the auto router; paid users may pick an
+  // entitled tier explicitly. The tier id is mode-aware via resolveTierToProviderKey.
+  if (
+    !allowedSelectedModel ||
+    allowedSelectedModel === "auto" ||
+    subscription === "free"
+  ) {
     return autoModel;
   }
 
   // Paid ASK Standard mirrors the auto-route split, but uses explicit keys so
   // any UI that reads `getModelDisplayName` shows the picked model rather than
   // the auto-router label.
-  if (selectedModel === "hackerai-standard" && !isAgent) {
+  if (allowedSelectedModel === "hackerai-standard" && !isAgent) {
     return hasAskImage || hasAskPdf
       ? "model-grok-4.3"
       : "model-deepseek-v4-pro";
   }
 
-  if (selectedModel === "hackerai-pro") {
+  if (allowedSelectedModel === "hackerai-pro") {
     return hasProProviderMedia ? "model-kimi-k2.7-code" : "model-glm-5.2";
   }
 
-  const providerKey = resolveTierToProviderKey(selectedModel, mode);
+  const providerKey = resolveTierToProviderKey(allowedSelectedModel, mode);
   return providerKey ?? autoModel;
 }
 

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -56,11 +56,13 @@ export function selectModel(
   selectedModel?: SelectedModel,
   hasImageAttachment?: boolean,
   hasPdfAttachment?: boolean,
+  options: { extraUsageAvailable?: boolean } = {},
 ): ModelName {
   const isAgent = isAgentMode(mode);
   const allowedSelectedModel = normalizeMaxModelForSubscription(
     selectedModel,
     subscription,
+    options,
   );
   // DeepSeek ask routes are text-only, so image/PDF prompts promote to a
   // media-capable route unless the selected tier intentionally uses a
@@ -666,6 +668,7 @@ export async function processChatMessages({
   subscription,
   uploadBasePath,
   modelOverride,
+  extraUsageAvailable = false,
   allowLocalDesktopFiles = false,
 }: {
   messages: UIMessage[];
@@ -674,6 +677,7 @@ export async function processChatMessages({
   subscription: SubscriptionTier;
   uploadBasePath?: string;
   modelOverride?: SelectedModel;
+  extraUsageAvailable?: boolean;
   allowLocalDesktopFiles?: boolean;
 }) {
   const messagesWithoutOpenRouterReasoningMetadata =
@@ -751,6 +755,7 @@ export async function processChatMessages({
     modelOverride,
     mediaAttachmentRouting.hasImage,
     mediaAttachmentRouting.hasPdf,
+    { extraUsageAvailable },
   );
 
   // Strip providerMetadata for Anthropic models to prevent cross-model signature errors.

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -1,6 +1,6 @@
 import { getModerationResult } from "@/lib/moderation";
 import {
-  canUseMaxModel,
+  normalizeMaxModelForSubscription,
   type ChatMode,
   type SelectedModel,
   type SubscriptionTier,
@@ -58,10 +58,10 @@ export function selectModel(
   hasPdfAttachment?: boolean,
 ): ModelName {
   const isAgent = isAgentMode(mode);
-  const allowedSelectedModel =
-    selectedModel === "hackerai-max" && !canUseMaxModel(subscription)
-      ? "hackerai-pro"
-      : selectedModel;
+  const allowedSelectedModel = normalizeMaxModelForSubscription(
+    selectedModel,
+    subscription,
+  );
   // DeepSeek ask routes are text-only, so image/PDF prompts promote to a
   // media-capable route unless the selected tier intentionally uses a
   // multimodal/file-capable model such as Kimi or Opus.

--- a/lib/pricing/features.ts
+++ b/lib/pricing/features.ts
@@ -46,7 +46,7 @@ export const freeFeatures: Array<PricingFeature> = [
 ];
 
 export const proFeatures: Array<PricingFeature> = [
-  { icon: Check, text: "Access to the best AI models for pentesting" },
+  { icon: Check, text: "Access to HackerAI Standard and Pro models" },
   { icon: Check, text: "Extended limits" },
   { icon: Check, text: "File uploads" },
   { icon: Check, text: "Cloud agents" },
@@ -58,6 +58,7 @@ export const proPlusFeatures: Array<PricingFeature> = [
 ];
 
 export const ultraFeatures: Array<PricingFeature> = [
+  { icon: Check, text: "Ultra-only HackerAI Max mode with Claude Opus" },
   { icon: Check, text: "10x more usage than Pro" },
   { icon: Check, text: "Priority access to new features" },
 ];

--- a/lib/pricing/features.ts
+++ b/lib/pricing/features.ts
@@ -46,7 +46,7 @@ export const freeFeatures: Array<PricingFeature> = [
 ];
 
 export const proFeatures: Array<PricingFeature> = [
-  { icon: Check, text: "Access to HackerAI Standard and Pro models" },
+  { icon: Check, text: "Access to the best AI models for pentesting" },
   { icon: Check, text: "Extended limits" },
   { icon: Check, text: "File uploads" },
   { icon: Check, text: "Cloud agents" },
@@ -58,7 +58,6 @@ export const proPlusFeatures: Array<PricingFeature> = [
 ];
 
 export const ultraFeatures: Array<PricingFeature> = [
-  { icon: Check, text: "Ultra-only HackerAI Max mode with Claude Opus" },
   { icon: Check, text: "10x more usage than Pro" },
   { icon: Check, text: "Priority access to new features" },
 ];

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -119,7 +119,7 @@ import type {
   SandboxBootInfo,
   ToolFailureLogEvent,
 } from "@/types";
-import { canUseExtraUsage } from "@/types";
+import { canUseExtraUsage, normalizeMaxModelForSubscription } from "@/types";
 import {
   createAgentStream,
   initAgentStreamState,
@@ -987,7 +987,7 @@ export const agentLongTask = task({
       messages,
       localDesktopAttachmentsPrepared,
       sandboxPreference,
-      selectedModel: selectedModelOverride,
+      selectedModel: rawSelectedModelOverride,
       userLocation,
       temporary,
       isAutoContinue,
@@ -995,6 +995,7 @@ export const agentLongTask = task({
       isNewChat,
       endpoint: payloadEndpoint,
     } = payload;
+    let selectedModelOverride = rawSelectedModelOverride;
     const endpoint = payloadEndpoint ?? LEGACY_AGENT_API_ENDPOINT;
     const freeUsageSubject = freeQuotaSubject ?? userId;
 
@@ -1094,6 +1095,11 @@ export const agentLongTask = task({
         userCustomization,
         organizationId,
       });
+      const extraUsageAvailable = canUseExtraUsage(extraUsageConfig);
+      selectedModelOverride =
+        normalizeMaxModelForSubscription(selectedModelOverride, subscription, {
+          extraUsageAvailable,
+        }) ?? undefined;
 
       const baseTodos: Todo[] = getBaseTodosForRequest(
         (chat?.todos as unknown as Todo[]) || [],
@@ -1118,7 +1124,7 @@ export const agentLongTask = task({
           subscription,
           uploadBasePath,
           modelOverride: selectedModelOverride,
-          extraUsageAvailable: canUseExtraUsage(extraUsageConfig),
+          extraUsageAvailable,
           allowLocalDesktopFiles: sandboxPreference === "desktop",
         });
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -119,6 +119,7 @@ import type {
   SandboxBootInfo,
   ToolFailureLogEvent,
 } from "@/types";
+import { canUseExtraUsage } from "@/types";
 import {
   createAgentStream,
   initAgentStreamState,
@@ -1087,6 +1088,12 @@ export const agentLongTask = task({
       ]);
       const { chat, fileTokens } = fetched;
       const truncatedMessages = fetched.truncatedMessages;
+      const extraUsageConfig = await buildExtraUsageConfig({
+        userId,
+        subscription,
+        userCustomization,
+        organizationId,
+      });
 
       const baseTodos: Todo[] = getBaseTodosForRequest(
         (chat?.todos as unknown as Todo[]) || [],
@@ -1111,6 +1118,7 @@ export const agentLongTask = task({
           subscription,
           uploadBasePath,
           modelOverride: selectedModelOverride,
+          extraUsageAvailable: canUseExtraUsage(extraUsageConfig),
           allowLocalDesktopFiles: sandboxPreference === "desktop",
         });
 
@@ -1189,7 +1197,6 @@ export const agentLongTask = task({
       // before agentUiStream.pipe() registered the stream, and the frontend
       // transport would only see a FAILED status with no error message.
       let rateLimitInfo: RateLimitInfo;
-      let extraUsageConfig: Awaited<ReturnType<typeof buildExtraUsageConfig>>;
 
       let streamError: unknown;
       const uiStream = createUIMessageStream({
@@ -1213,13 +1220,6 @@ export const agentLongTask = task({
               );
               releaseFreeRunLock = lock.release;
             }
-
-            extraUsageConfig = await buildExtraUsageConfig({
-              userId,
-              subscription,
-              userCustomization,
-              organizationId,
-            });
 
             rateLimitInfo = await checkRateLimit(
               userId,

--- a/types/__tests__/chat.test.ts
+++ b/types/__tests__/chat.test.ts
@@ -17,9 +17,24 @@ describe("normalizeSelectedModelForSubscription", () => {
     expect(normalizeSelectedModelForSubscription("hackerai-pro", "pro")).toBe(
       "hackerai-pro",
     );
+    expect(normalizeSelectedModelForSubscription("hackerai-max", "ultra")).toBe(
+      "hackerai-max",
+    );
     expect(normalizeSelectedModelForSubscription(null, "ultra")).toBe("auto");
     expect(normalizeSelectedModelForSubscription(undefined, "team")).toBe(
       "auto",
+    );
+  });
+
+  it("downgrades Max to Pro outside Ultra", () => {
+    expect(normalizeSelectedModelForSubscription("hackerai-max", "pro")).toBe(
+      "hackerai-pro",
+    );
+    expect(
+      normalizeSelectedModelForSubscription("hackerai-max", "pro-plus"),
+    ).toBe("hackerai-pro");
+    expect(normalizeSelectedModelForSubscription("hackerai-max", "team")).toBe(
+      "hackerai-pro",
     );
   });
 });
@@ -43,9 +58,15 @@ describe("normalizeSelectedModelOverrideForSubscription", () => {
     ).toBeUndefined();
   });
 
-  it("preserves explicit paid overrides", () => {
+  it("preserves explicit paid overrides except Max outside Ultra", () => {
+    expect(
+      normalizeSelectedModelOverrideForSubscription("hackerai-max", "ultra"),
+    ).toBe("hackerai-max");
     expect(
       normalizeSelectedModelOverrideForSubscription("hackerai-max", "team"),
-    ).toBe("hackerai-max");
+    ).toBe("hackerai-pro");
+    expect(
+      normalizeSelectedModelOverrideForSubscription("hackerai-pro", "team"),
+    ).toBe("hackerai-pro");
   });
 });

--- a/types/__tests__/chat.test.ts
+++ b/types/__tests__/chat.test.ts
@@ -1,4 +1,7 @@
 import {
+  canUseExtraUsage,
+  canUseMaxModel,
+  normalizeMaxModelForSubscription,
   normalizeSelectedModelForSubscription,
   normalizeSelectedModelOverrideForSubscription,
 } from "../chat";
@@ -26,15 +29,15 @@ describe("normalizeSelectedModelForSubscription", () => {
     );
   });
 
-  it("downgrades Max to Pro outside Ultra", () => {
+  it("preserves paid Max until entitlement-aware routing", () => {
     expect(normalizeSelectedModelForSubscription("hackerai-max", "pro")).toBe(
-      "hackerai-pro",
+      "hackerai-max",
     );
     expect(
       normalizeSelectedModelForSubscription("hackerai-max", "pro-plus"),
-    ).toBe("hackerai-pro");
+    ).toBe("hackerai-max");
     expect(normalizeSelectedModelForSubscription("hackerai-max", "team")).toBe(
-      "hackerai-pro",
+      "hackerai-max",
     );
   });
 });
@@ -58,15 +61,56 @@ describe("normalizeSelectedModelOverrideForSubscription", () => {
     ).toBeUndefined();
   });
 
-  it("preserves explicit paid overrides except Max outside Ultra", () => {
+  it("preserves explicit paid overrides until entitlement-aware routing", () => {
     expect(
       normalizeSelectedModelOverrideForSubscription("hackerai-max", "ultra"),
     ).toBe("hackerai-max");
     expect(
       normalizeSelectedModelOverrideForSubscription("hackerai-max", "team"),
-    ).toBe("hackerai-pro");
+    ).toBe("hackerai-max");
     expect(
       normalizeSelectedModelOverrideForSubscription("hackerai-pro", "team"),
+    ).toBe("hackerai-pro");
+  });
+});
+
+describe("Max model entitlement helpers", () => {
+  it("allows Max for Ultra users", () => {
+    expect(canUseMaxModel("ultra")).toBe(true);
+  });
+
+  it("allows Max for paid users with usable extra usage", () => {
+    const extraUsageConfig = {
+      enabled: true,
+      hasBalance: true,
+      balanceDollars: 10,
+      autoReloadEnabled: false,
+    };
+
+    expect(canUseExtraUsage(extraUsageConfig)).toBe(true);
+    expect(canUseMaxModel("pro", { extraUsageConfig })).toBe(true);
+    expect(
+      normalizeMaxModelForSubscription("hackerai-max", "pro", {
+        extraUsageConfig,
+      }),
+    ).toBe("hackerai-max");
+  });
+
+  it("downgrades Max for paid users without usable extra usage", () => {
+    expect(canUseMaxModel("pro")).toBe(false);
+    expect(normalizeMaxModelForSubscription("hackerai-max", "pro")).toBe(
+      "hackerai-pro",
+    );
+    expect(
+      normalizeMaxModelForSubscription("hackerai-max", "pro-plus", {
+        extraUsageConfig: {
+          enabled: true,
+          hasBalance: true,
+          balanceDollars: 10,
+          autoReloadEnabled: false,
+          monthlyRemainingDollars: 0,
+        },
+      }),
     ).toBe("hackerai-pro");
   });
 });

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -100,12 +100,26 @@ export function isSubscriptionTier(value: unknown): value is SubscriptionTier {
   );
 }
 
+export function canUseMaxModel(subscription: SubscriptionTier): boolean {
+  return subscription === "ultra";
+}
+
+const normalizeMaxModelForSubscription = (
+  model: SelectedModel | null | undefined,
+  subscription: SubscriptionTier,
+): SelectedModel | null | undefined => {
+  if (model === "hackerai-max" && !canUseMaxModel(subscription)) {
+    return "hackerai-pro";
+  }
+  return model;
+};
+
 export function normalizeSelectedModelForSubscription(
   model: SelectedModel | null | undefined,
   subscription: SubscriptionTier,
 ): SelectedModel {
   if (subscription === "free") return "auto";
-  return model ?? "auto";
+  return normalizeMaxModelForSubscription(model, subscription) ?? "auto";
 }
 
 export function normalizeSelectedModelOverrideForSubscription(
@@ -113,7 +127,7 @@ export function normalizeSelectedModelOverrideForSubscription(
   subscription: SubscriptionTier,
 ): SelectedModel | undefined {
   if (subscription === "free") return "auto";
-  return model ?? undefined;
+  return normalizeMaxModelForSubscription(model, subscription) ?? undefined;
 }
 
 export interface SidebarFile {

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -100,15 +100,54 @@ export function isSubscriptionTier(value: unknown): value is SubscriptionTier {
   );
 }
 
-export function canUseMaxModel(subscription: SubscriptionTier): boolean {
-  return subscription === "ultra";
+export type ExtraUsageAvailability = Pick<
+  ExtraUsageConfig,
+  | "enabled"
+  | "hasBalance"
+  | "balanceDollars"
+  | "monthlyRemainingDollars"
+  | "autoReloadEnabled"
+>;
+
+export function canUseExtraUsage(
+  extraUsageConfig: ExtraUsageAvailability | null | undefined,
+): boolean {
+  if (!extraUsageConfig?.enabled) return false;
+  if (
+    extraUsageConfig.monthlyRemainingDollars !== undefined &&
+    extraUsageConfig.monthlyRemainingDollars <= 0
+  ) {
+    return false;
+  }
+
+  const hasBalance =
+    extraUsageConfig.hasBalance ?? (extraUsageConfig.balanceDollars ?? 0) > 0;
+
+  return Boolean(hasBalance || extraUsageConfig.autoReloadEnabled);
+}
+
+type MaxModelEntitlementOptions = {
+  extraUsageAvailable?: boolean;
+  extraUsageConfig?: ExtraUsageAvailability | null;
+};
+
+export function canUseMaxModel(
+  subscription: SubscriptionTier,
+  options: MaxModelEntitlementOptions = {},
+): boolean {
+  if (subscription === "ultra") return true;
+  if (subscription === "free") return false;
+  return (
+    options.extraUsageAvailable ?? canUseExtraUsage(options.extraUsageConfig)
+  );
 }
 
 export const normalizeMaxModelForSubscription = (
   model: SelectedModel | null | undefined,
   subscription: SubscriptionTier,
+  options: MaxModelEntitlementOptions = {},
 ): SelectedModel | null | undefined => {
-  if (model === "hackerai-max" && !canUseMaxModel(subscription)) {
+  if (model === "hackerai-max" && !canUseMaxModel(subscription, options)) {
     return "hackerai-pro";
   }
   return model;
@@ -119,7 +158,7 @@ export function normalizeSelectedModelForSubscription(
   subscription: SubscriptionTier,
 ): SelectedModel {
   if (subscription === "free") return "auto";
-  return normalizeMaxModelForSubscription(model, subscription) ?? "auto";
+  return model ?? "auto";
 }
 
 export function normalizeSelectedModelOverrideForSubscription(
@@ -127,7 +166,7 @@ export function normalizeSelectedModelOverrideForSubscription(
   subscription: SubscriptionTier,
 ): SelectedModel | undefined {
   if (subscription === "free") return "auto";
-  return normalizeMaxModelForSubscription(model, subscription) ?? undefined;
+  return model ?? undefined;
 }
 
 export interface SidebarFile {

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -104,7 +104,7 @@ export function canUseMaxModel(subscription: SubscriptionTier): boolean {
   return subscription === "ultra";
 }
 
-const normalizeMaxModelForSubscription = (
+export const normalizeMaxModelForSubscription = (
   model: SelectedModel | null | undefined,
   subscription: SubscriptionTier,
 ): SelectedModel | null | undefined => {


### PR DESCRIPTION
## Summary
- make HackerAI Max / Claude Opus available only on Ultra
- normalize stale non-Ultra Max selections to HackerAI Pro on client and server request paths
- lock Max in the model selector outside Ultra and update pricing copy to state Max is Ultra-only

## Tests
- pnpm jest types/__tests__/chat.test.ts lib/chat/__tests__/chat-processor.test.ts lib/chat/__tests__/agent-run-spend-cap.test.ts app/components/ModelSelector/__tests__/ModelSelector.test.tsx app/contexts/__tests__/GlobalState.agent-default.test.tsx --runInBand
- pnpm typecheck
- pnpm exec eslint app/components/ModelSelector.tsx app/components/ModelSelector/__tests__/ModelSelector.test.tsx app/contexts/GlobalState.tsx lib/chat/chat-processor.ts lib/chat/__tests__/chat-processor.test.ts lib/chat/agent-run-spend-cap.ts lib/chat/__tests__/agent-run-spend-cap.test.ts lib/pricing/features.ts types/chat.ts types/__tests__/chat.test.ts

## Manual verification
- Open the model selector as a Pro or Pro+ user; HackerAI Max should show locked and route to Ultra pricing.
- Open the model selector as an Ultra user; HackerAI Max should be selectable.
- Confirm the pricing dialog lists Max mode only under Ultra.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model picker now gates the **“Max”** option by subscription tier and **Extra Usage** eligibility, with updated upgrade/announcement copy and smoother tooltip behavior (including mobile).
  * Selecting a locked model now opens **Extra Usage** settings when eligible, or routes to the **pricing** upgrade flow otherwise.
* **Bug Fixes**
  * Saved model selections are automatically normalized after subscription resolution.
  * Ask/agent routing and continuation model selection now consistently enforce Max entitlement rules.
* **Tests**
  * Updated and expanded coverage for Max gating, routing, and subscription/Extra Usage normalization across ask and agent modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->