### PR TITLE
Proxy Trigger run status polling

### DIFF
--- a/app/api/agent-long/status/route.ts
+++ b/app/api/agent-long/status/route.ts
@@ -1,0 +1,8 @@
+import { createAgentStatusPost } from "@/lib/api/agent-status-route";
+import { LEGACY_AGENT_API_ENDPOINT } from "@/lib/api/agent-endpoints";
+
+export const maxDuration = 30;
+
+export const POST = createAgentStatusPost({
+  endpoint: LEGACY_AGENT_API_ENDPOINT,
+});

--- a/app/api/agent/status/route.ts
+++ b/app/api/agent/status/route.ts
@@ -1,0 +1,8 @@
+import { createAgentStatusPost } from "@/lib/api/agent-status-route";
+import { AGENT_API_ENDPOINT } from "@/lib/api/agent-endpoints";
+
+export const maxDuration = 30;
+
+export const POST = createAgentStatusPost({
+  endpoint: AGENT_API_ENDPOINT,
+});

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -260,6 +260,9 @@ describe("agent-long-transport — direct UI stream reader", () => {
     expect(triggerBrowserRealtimeSrc).not.toMatch(/\/api\/v1\/runs/);
     expect(transportSrc).toMatch(/statusEndpoint/);
     expect(statusSrc).toMatch(/runs\.retrieve\(runId\)/);
+    expect(statusSrc).toMatch(/ApiError/);
+    expect(statusSrc).toMatch(/MISSING_RUN_STATUSES/);
+    expect(statusSrc).toMatch(/Run not found/);
     expect(statusSrc).toMatch(/metadata\.chatId\s*===\s*expected\.chatId/);
     expect(statusSrc).toMatch(/metadata\.userId\s*===\s*expected\.userId/);
     expect(statusSrc).not.toMatch(/\/api\/v1\/runs/);

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -37,6 +37,11 @@ const resumeSrc = fs.readFileSync(
   "utf8",
 );
 
+const statusSrc = fs.readFileSync(
+  path.resolve(__dirname, "../agent-status-route.ts"),
+  "utf8",
+);
+
 const routeSrc = fs.readFileSync(
   path.resolve(__dirname, "../agent-trigger-route.ts"),
   "utf8",
@@ -47,8 +52,18 @@ const agentRouteSrc = fs.readFileSync(
   "utf8",
 );
 
+const agentStatusRouteSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../../app/api/agent/status/route.ts"),
+  "utf8",
+);
+
 const legacyAgentRouteSrc = fs.readFileSync(
   path.resolve(__dirname, "../../../app/api/agent-long/route.ts"),
+  "utf8",
+);
+
+const legacyAgentStatusRouteSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../../app/api/agent-long/status/route.ts"),
   "utf8",
 );
 
@@ -237,6 +252,19 @@ describe("agent-long-transport — direct UI stream reader", () => {
     expect(transportSrc).toMatch(/pollRunStatusForTerminalRun/);
     expect(transportSrc).toMatch(/TERMINAL_RUN_STATUSES\.has\(status\)/);
     expect(transportSrc).toMatch(/readAbortController\?\.abort\(\)/);
+  });
+
+  test("proxies run status polling through same-origin routes", () => {
+    expect(triggerBrowserRealtimeSrc).toMatch(/AGENT_STATUS_ENDPOINT/);
+    expect(triggerBrowserRealtimeSrc).toMatch(/method:\s*"POST"/);
+    expect(triggerBrowserRealtimeSrc).not.toMatch(/\/api\/v1\/runs/);
+    expect(transportSrc).toMatch(/statusEndpoint/);
+    expect(statusSrc).toMatch(/runs\.retrieve\(runId\)/);
+    expect(statusSrc).toMatch(/metadata\.chatId\s*===\s*expected\.chatId/);
+    expect(statusSrc).toMatch(/metadata\.userId\s*===\s*expected\.userId/);
+    expect(statusSrc).not.toMatch(/\/api\/v1\/runs/);
+    expect(agentStatusRouteSrc).toMatch(/createAgentStatusPost/);
+    expect(legacyAgentStatusRouteSrc).toMatch(/createAgentStatusPost/);
   });
 
   test("setTimeout aborts the stream reader and closes the SSE", () => {
@@ -536,7 +564,13 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       /AGENT_API_ENDPOINT\s*=\s*"\/api\/agent"/,
     );
     expect(agentEndpointsSrc).toMatch(
+      /AGENT_STATUS_ENDPOINT\s*=\s*"\/api\/agent\/status"/,
+    );
+    expect(agentEndpointsSrc).toMatch(
       /LEGACY_AGENT_API_ENDPOINT\s*=\s*"\/api\/agent-long"/,
+    );
+    expect(agentEndpointsSrc).toMatch(
+      /LEGACY_AGENT_STATUS_ENDPOINT\s*=\s*"\/api\/agent-long\/status"/,
     );
     expect(agentEndpointsSrc).toMatch(
       /AGENT_TRIGGER_TASK_ID\s*=\s*"agent-long"/,

--- a/lib/api/agent-endpoints.ts
+++ b/lib/api/agent-endpoints.ts
@@ -2,11 +2,13 @@ export const CHAT_API_ENDPOINT = "/api/chat" as const;
 export const AGENT_API_ENDPOINT = "/api/agent" as const;
 export const AGENT_RESUME_ENDPOINT = "/api/agent/resume" as const;
 export const AGENT_CANCEL_ENDPOINT = "/api/agent/cancel" as const;
+export const AGENT_STATUS_ENDPOINT = "/api/agent/status" as const;
 export const AGENT_PARTIAL_SAVE_ENDPOINT = "/api/agent/partial-save" as const;
 
 export const LEGACY_AGENT_API_ENDPOINT = "/api/agent-long" as const;
 export const LEGACY_AGENT_RESUME_ENDPOINT = "/api/agent-long/resume" as const;
 export const LEGACY_AGENT_CANCEL_ENDPOINT = "/api/agent-long/cancel" as const;
+export const LEGACY_AGENT_STATUS_ENDPOINT = "/api/agent-long/status" as const;
 
 // Keep the Trigger task id stable until old Vercel clients and Trigger deploys
 // can no longer race against the renamed API route.

--- a/lib/api/agent-route-errors.ts
+++ b/lib/api/agent-route-errors.ts
@@ -74,7 +74,7 @@ export function handleAgentRouteError({
 }: {
   error: unknown;
   endpoint: AgentApiEndpoint;
-  action: "start" | "resume" | "cancel";
+  action: "start" | "resume" | "cancel" | "status";
   fallbackMessage: string;
   context?: AgentRouteErrorContext;
 }) {

--- a/lib/api/agent-status-route.ts
+++ b/lib/api/agent-status-route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { runs } from "@trigger.dev/sdk";
+import { ApiError, runs } from "@trigger.dev/sdk";
 
 import { getUserIDAndPro } from "@/lib/auth/get-user-id";
 import { handleAgentRouteError } from "@/lib/api/agent-route-errors";
@@ -14,6 +14,13 @@ type TriggerRunStatus = {
   metadata?: unknown;
   status?: string;
 };
+
+const MISSING_RUN_STATUSES = new Set([400, 404, 410, 422]);
+
+const isMissingTriggerRunError = (error: unknown): boolean =>
+  error instanceof ApiError &&
+  error.status !== undefined &&
+  MISSING_RUN_STATUSES.has(error.status);
 
 const runBelongsToChatOwner = (
   run: TriggerRunStatus,
@@ -65,6 +72,10 @@ export const createAgentStatusPost =
 
       return NextResponse.json({ status: run.status });
     } catch (error) {
+      if (isMissingTriggerRunError(error)) {
+        return new NextResponse("Run not found", { status: 404 });
+      }
+
       return handleAgentRouteError({
         error,
         endpoint,

--- a/lib/api/agent-status-route.ts
+++ b/lib/api/agent-status-route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { runs } from "@trigger.dev/sdk";
+
+import { getUserIDAndPro } from "@/lib/auth/get-user-id";
+import { handleAgentRouteError } from "@/lib/api/agent-route-errors";
+import type { AgentApiEndpoint } from "@/lib/api/agent-endpoints";
+
+type AgentStatusRequestBody = {
+  chatId?: unknown;
+  runId?: unknown;
+};
+
+type TriggerRunStatus = {
+  metadata?: unknown;
+  status?: string;
+};
+
+const runBelongsToChatOwner = (
+  run: TriggerRunStatus,
+  expected: { chatId: string; userId: string },
+): boolean => {
+  if (!run.metadata || typeof run.metadata !== "object") return false;
+  const metadata = run.metadata as Record<string, unknown>;
+  return (
+    metadata.chatId === expected.chatId && metadata.userId === expected.userId
+  );
+};
+
+export const createAgentStatusPost =
+  ({ endpoint }: { endpoint: AgentApiEndpoint }) =>
+  async (req: NextRequest) => {
+    let userId: string | undefined;
+    let chatId: string | undefined;
+    let runId: string | undefined;
+    const requestId =
+      req.headers.get("x-request-id") ??
+      req.headers.get("x-vercel-id") ??
+      undefined;
+
+    try {
+      let body: AgentStatusRequestBody;
+      try {
+        body = (await req.json()) as AgentStatusRequestBody;
+      } catch {
+        return new NextResponse("Invalid JSON body", { status: 400 });
+      }
+
+      chatId = typeof body.chatId === "string" ? body.chatId : undefined;
+      runId = typeof body.runId === "string" ? body.runId : undefined;
+
+      if (!chatId) {
+        return new NextResponse("chatId required", { status: 400 });
+      }
+      if (!runId) {
+        return new NextResponse("runId required", { status: 400 });
+      }
+
+      const authContext = await getUserIDAndPro(req);
+      userId = authContext.userId;
+
+      const run = (await runs.retrieve(runId)) as TriggerRunStatus;
+      if (!runBelongsToChatOwner(run, { chatId, userId })) {
+        return new NextResponse("Forbidden", { status: 403 });
+      }
+
+      return NextResponse.json({ status: run.status });
+    } catch (error) {
+      return handleAgentRouteError({
+        error,
+        endpoint,
+        action: "status",
+        fallbackMessage: "Failed to retrieve run status",
+        context: {
+          requestId,
+          userId,
+          chatId,
+          runId,
+        },
+      });
+    }
+  };

--- a/lib/chat/agent-long-transport.ts
+++ b/lib/chat/agent-long-transport.ts
@@ -1,6 +1,11 @@
 import { fetchWithErrorHandlers } from "@/lib/utils";
 import { AGENT_UI_STREAM_ID } from "@/trigger/stream-ids";
-import { AGENT_API_ENDPOINT } from "@/lib/api/agent-endpoints";
+import {
+  AGENT_API_ENDPOINT,
+  AGENT_STATUS_ENDPOINT,
+  LEGACY_AGENT_RESUME_ENDPOINT,
+  LEGACY_AGENT_STATUS_ENDPOINT,
+} from "@/lib/api/agent-endpoints";
 import { createToolInputDedupFilter } from "./agent-long-tool-input-dedup";
 import {
   readTriggerRunStream,
@@ -145,14 +150,28 @@ const getChatIdFromResumeUrl = (url: string): string | undefined => {
   }
 };
 
+const getStatusEndpointFromResumeUrl = (url: string): string => {
+  try {
+    const base =
+      typeof window === "undefined" ? "http://localhost" : window.location.href;
+    const pathname = new URL(url, base).pathname;
+    return pathname === LEGACY_AGENT_RESUME_ENDPOINT
+      ? LEGACY_AGENT_STATUS_ENDPOINT
+      : AGENT_STATUS_ENDPOINT;
+  } catch {
+    return AGENT_STATUS_ENDPOINT;
+  }
+};
+
 const buildSSEResponseFromRun = (
   handle: RunHandle,
   signal?: AbortSignal,
-  options?: { chatId?: string },
+  options?: { chatId?: string; statusEndpoint?: string },
 ): Response => {
   const { runId, publicAccessToken } = handle;
   const encoder = new TextEncoder();
   const chatId = options?.chatId ?? handle.chatId;
+  const statusEndpoint = options?.statusEndpoint ?? AGENT_STATUS_ENDPOINT;
   let cancelRealtimeSubscriptions: (() => Promise<void> | void) | undefined;
   let closeConsumerStream: (() => void) | undefined;
   let consumerCanceled = false;
@@ -312,11 +331,11 @@ const buildSSEResponseFromRun = (
         };
 
         const pollRunStatusForTerminalRun = async () => {
-          const status = await retrieveTriggerRunStatus(
-            runId,
-            publicAccessToken,
-            readAbortController?.signal,
-          );
+          const status = await retrieveTriggerRunStatus(runId, {
+            chatId,
+            signal: readAbortController?.signal,
+            statusEndpoint,
+          });
           handleRunStatus(status);
         };
 
@@ -628,6 +647,7 @@ export const fetchAgentLongStream = async (
     const handle: RunHandle = await startResponse.json();
     return buildSSEResponseFromRun(handle, init?.signal ?? undefined, {
       chatId,
+      statusEndpoint: AGENT_STATUS_ENDPOINT,
     });
   } finally {
     unregisterStartCancel?.();
@@ -660,6 +680,7 @@ export const resumeAgentLongStream = async (
     const handle: RunHandle = await response.json();
     return buildSSEResponseFromRun(handle, init?.signal ?? undefined, {
       chatId,
+      statusEndpoint: getStatusEndpointFromResumeUrl(url),
     });
   } finally {
     unregisterStartCancel?.();

--- a/lib/chat/trigger-browser-realtime.ts
+++ b/lib/chat/trigger-browser-realtime.ts
@@ -1,3 +1,5 @@
+import { AGENT_STATUS_ENDPOINT } from "@/lib/api/agent-endpoints";
+
 type TriggerStreamRecord = {
   seq_num?: number | string;
   timestamp?: number;
@@ -17,6 +19,12 @@ type ParsedSSEEvent = {
 
 type TriggerRunStatusResponse = {
   status?: string;
+};
+
+type RetrieveTriggerRunStatusOptions = {
+  chatId?: string;
+  signal?: AbortSignal;
+  statusEndpoint?: string;
 };
 
 type ReadTriggerRunStreamOptions = {
@@ -57,18 +65,6 @@ const getTriggerStreamHeaders = (
 
   return headers;
 };
-
-const getTriggerJsonHeaders = (
-  accessToken: string,
-): Record<string, string> => ({
-  Authorization: `Bearer ${accessToken}`,
-  "Content-Type": "application/json",
-  "trigger-version": TRIGGER_VERSION,
-  "x-trigger-api-version": TRIGGER_API_VERSION,
-  "x-trigger-client": "browser",
-  "x-trigger-realtime-streams-version": "v2",
-  "x-trigger-source": "sdk",
-});
 
 const linkAbort = (
   parent: AbortSignal | undefined,
@@ -223,14 +219,20 @@ async function* readSSEEvents(
 
 export async function retrieveTriggerRunStatus(
   runId: string,
-  accessToken: string,
-  signal?: AbortSignal,
+  options: RetrieveTriggerRunStatusOptions,
 ): Promise<string | undefined> {
   const response = await fetch(
-    `${TRIGGER_API_BASE_URL}/api/v1/runs/${encodeURIComponent(runId)}`,
+    options.statusEndpoint ?? AGENT_STATUS_ENDPOINT,
     {
-      headers: getTriggerJsonHeaders(accessToken),
-      signal,
+      body: JSON.stringify({
+        chatId: options.chatId,
+        runId,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+      signal: options.signal,
     },
   );
 


### PR DESCRIPTION
## Summary
- route Trigger run status polling through same-origin Next.js endpoints
- use `runs.retrieve(runId)` server-side instead of browser-direct `/api/v1/runs/:id` calls
- verify run ownership with Trigger metadata before returning status and keep legacy agent-long status route compatibility

## Validation
- `pnpm exec jest lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `pnpm exec prettier --check lib/api/agent-status-route.ts app/api/agent/status/route.ts app/api/agent-long/status/route.ts lib/chat/trigger-browser-realtime.ts lib/chat/agent-long-transport.ts lib/api/__tests__/agent-long-contracts.test.ts lib/api/agent-endpoints.ts lib/api/agent-route-errors.ts`
- `pnpm exec tsc --noEmit`

## Manual verification
- In production or preview, start an Agent-mode chat and watch Network for `/api/agent/status` returning 200 instead of browser `OPTIONS https://api.trigger.dev/api/v1/runs/:id` returning 405.
- Let a run go quiet or complete; the stream should keep updating and exit cleanly without CORS errors from Trigger run-status polling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated agent run status support via same-origin POST routes, returning the current run status.
  * Status polling now selects the correct current or legacy endpoint automatically.
* **Bug Fixes**
  * Improved reliability by validating request IDs and ensuring the run belongs to the authenticated chat/user before returning status.
  * Updated status error handling to provide consistent “run not found” responses when appropriate.
* **Chores**
  * Enhanced long-running stream requests with additional optional connection headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->