### PR TITLE
Filter noisy production errors and improve recovery logging

### DIFF
--- a/app/api/delete-account/route.ts
+++ b/app/api/delete-account/route.ts
@@ -6,6 +6,7 @@ import { deleteUserRateLimitKeys } from "@/lib/rate-limit/token-bucket";
 import { ChatSDKError } from "@/lib/errors";
 import { getConvexClient } from "@/lib/db/convex-client";
 import { api } from "@/convex/_generated/api";
+import { logger } from "@/lib/logger";
 
 type OrganizationMembership = Awaited<
   ReturnType<typeof workos.userManagement.listOrganizationMemberships>
@@ -277,10 +278,10 @@ export const POST = async (req: NextRequest) => {
         ? (error as any).message
         : "Failed to delete account";
     const errorName = error instanceof Error ? error.name : "UnknownError";
-    console.error(
-      JSON.stringify({
-        timestamp: new Date().toISOString(),
-        level: "error",
+    logger.error(
+      "account_deletion_failed",
+      error instanceof Error ? error : undefined,
+      {
         event: "account_deletion_failed",
         service: "hackerai-web",
         environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
@@ -290,8 +291,7 @@ export const POST = async (req: NextRequest) => {
         free_quota_subject_present: freeQuotaSubjectPresent,
         error_name: errorName,
         error_message: message,
-      }),
-      error,
+      },
     );
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/app/api/delete-account/route.ts
+++ b/app/api/delete-account/route.ts
@@ -136,19 +136,29 @@ async function deleteConvexUserData(userId: string, serviceKey: string) {
 }
 
 export const POST = async (req: NextRequest) => {
+  let stage = "authenticate";
+  let userIdForLog: string | undefined;
+  let membershipCount: number | undefined;
+  let freeQuotaSubjectPresent: boolean | undefined;
+
   try {
     // Enforce recent login (10-minute window) before any destructive action
     const { userId, freeQuotaSubject } =
       await getUserIDWithFreshLoginContext(req);
+    userIdForLog = userId;
+    freeQuotaSubjectPresent = Boolean(freeQuotaSubject);
 
     // List all org memberships for this user
     // NOTE: Pagination not required - users can only have one organization (max 2 if something goes wrong)
+    stage = "list_memberships";
     const memberships = await workos.userManagement.listOrganizationMemberships(
       {
         userId,
       },
     );
+    membershipCount = memberships.data.length;
 
+    stage = "plan_membership_deletions";
     const membershipDeletionPlans = await Promise.all(
       memberships.data.map(getMembershipDeletionPlan),
     );
@@ -164,14 +174,17 @@ export const POST = async (req: NextRequest) => {
     }
 
     const serviceKey = getConvexServiceKey();
+    stage = "mark_account_identity_deleted";
     await markAccountIdentityDeleted(userId, freeQuotaSubject, serviceKey);
 
     // Own app-data cleanup on the server so account deletion does not depend
     // on the browser successfully running a Convex mutation before this route.
+    stage = "delete_convex_user_data";
     await deleteConvexUserData(userId, serviceKey);
 
     // Process each organization from memberships. Only delete org-level billing
     // and identity resources after proving this user is the sole active admin.
+    stage = "delete_memberships_and_organizations";
     await Promise.all(
       membershipDeletionPlans.map(
         async ({ membership, deleteOrganization }) => {
@@ -242,6 +255,7 @@ export const POST = async (req: NextRequest) => {
 
     // Purge Redis rate-limit keys. Best-effort: WorkOS user deletion proceeds
     // even if this fails so the account is not left in a half-deleted state.
+    stage = "delete_rate_limit_keys";
     await deleteUserRateLimitKeys(userId).catch((err) => {
       console.warn(
         "Failed to clear Redis rate-limit keys during account deletion:",
@@ -250,6 +264,7 @@ export const POST = async (req: NextRequest) => {
     });
 
     // Finally, delete the WorkOS user
+    stage = "delete_workos_user";
     await workos.userManagement.deleteUser(userId);
 
     return NextResponse.json({ ok: true });
@@ -261,12 +276,21 @@ export const POST = async (req: NextRequest) => {
       error && typeof error === "object" && "message" in (error as any)
         ? (error as any).message
         : "Failed to delete account";
+    const errorName = error instanceof Error ? error.name : "UnknownError";
     console.error(
-      "Failed to delete account:",
-      {
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: "error",
         event: "account_deletion_failed",
+        service: "hackerai-web",
+        environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+        stage,
+        user_id: userIdForLog,
+        membership_count: membershipCount,
+        free_quota_subject_present: freeQuotaSubjectPresent,
+        error_name: errorName,
         error_message: message,
-      },
+      }),
       error,
     );
     return NextResponse.json({ error: message }, { status: 500 });

--- a/app/api/health/trigger-agent-mode/__tests__/route.test.ts
+++ b/app/api/health/trigger-agent-mode/__tests__/route.test.ts
@@ -118,6 +118,7 @@ describe("GET /api/health/trigger-agent-mode", () => {
       "https://status.trigger.dev/index.json",
       expect.objectContaining({
         cache: "no-store",
+        signal: expect.anything(),
         headers: { accept: "application/json" },
       }),
     );

--- a/app/api/health/trigger-agent-mode/route.ts
+++ b/app/api/health/trigger-agent-mode/route.ts
@@ -5,6 +5,7 @@ export const revalidate = 0;
 export const maxDuration = 10;
 
 const TRIGGER_STATUS_URL = "https://status.trigger.dev/index.json";
+const TRIGGER_STATUS_FETCH_TIMEOUT_MS = 8_000;
 const OPERATIONAL_STATUS = "operational";
 
 const REQUIRED_TRIGGER_RESOURCES = [
@@ -102,10 +103,22 @@ function json(
   });
 }
 
+function getTriggerStatusFetchSignal(): AbortSignal | undefined {
+  if (typeof AbortSignal === "undefined") return undefined;
+  const timeout = (
+    AbortSignal as typeof AbortSignal & {
+      timeout?: (milliseconds: number) => AbortSignal;
+    }
+  ).timeout;
+
+  return timeout?.(TRIGGER_STATUS_FETCH_TIMEOUT_MS);
+}
+
 export async function GET() {
   try {
     const response = await fetch(TRIGGER_STATUS_URL, {
       cache: "no-store",
+      signal: getTriggerStatusFetchSignal(),
       headers: {
         accept: "application/json",
       },
@@ -140,6 +153,7 @@ export async function GET() {
         service: "hackerai",
         timestamp: checkedAt,
         source: TRIGGER_STATUS_URL,
+        timeout_ms: TRIGGER_STATUS_FETCH_TIMEOUT_MS,
         error_name: error instanceof Error ? error.name : "UnknownError",
         error_message: error instanceof Error ? error.message : "Unknown error",
         environment: process.env.VERCEL_ENV,
@@ -154,6 +168,7 @@ export async function GET() {
         checkedAt,
         error: "trigger_status_fetch_failed",
         message: "Failed to fetch Trigger status feed.",
+        timeoutMs: TRIGGER_STATUS_FETCH_TIMEOUT_MS,
       },
       { status: 503 },
     );

--- a/app/components/ChunkLoadRecovery.tsx
+++ b/app/components/ChunkLoadRecovery.tsx
@@ -16,6 +16,8 @@ const CHUNK_LOAD_PATTERNS = [
 
 const STALE_SERVER_ACTION_PATTERNS = [
   /Failed to find Server Action/i,
+  /Server Action\s+"[^"]+"\s+was not found on the server/i,
+  /failed-to-find-server-action/i,
   /older or newer deployment/i,
 ];
 

--- a/app/components/__tests__/ChunkLoadRecovery.test.ts
+++ b/app/components/__tests__/ChunkLoadRecovery.test.ts
@@ -62,6 +62,14 @@ describe("ChunkLoadRecovery", () => {
     ).toBe(true);
 
     expect(
+      isStaleServerActionFailure(
+        new Error(
+          'Server Action "00b3ff60fce156a3bb78260aa8fa56550dc48b7f77" was not found on the server. Read more: https://nextjs.org/docs/messages/failed-to-find-server-action',
+        ),
+      ),
+    ).toBe(true);
+
+    expect(
       isStaleServerActionFailure({
         message: "This request might be from an older or newer deployment.",
       }),

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -980,7 +980,11 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     ) => {
       if (isAgentLongDoubleCloseNoise(message)) return true;
       if (typeof previousOnError === "function") {
-        return previousOnError(message, source, lineno, colno, error);
+        try {
+          return previousOnError(message, source, lineno, colno, error);
+        } catch {
+          return false;
+        }
       }
       return false;
     };

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -485,6 +485,7 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(chatComponentSrc).toMatch(
       /Cannot close a stream that is already closed/,
     );
+    expect(chatComponentSrc).toMatch(/previousOnError[\s\S]*try[\s\S]*catch/);
     expect(chatComponentSrc).toMatch(/event\.preventDefault\(\)/);
   });
 

--- a/lib/chat/__tests__/multimodal-tool-result-recovery.test.ts
+++ b/lib/chat/__tests__/multimodal-tool-result-recovery.test.ts
@@ -128,6 +128,20 @@ describe("multimodal tool result recovery", () => {
     );
 
     expect(isProviderMultimodalToolResultRejectionError(error)).toBe(true);
+
+    expect(
+      isProviderMultimodalToolResultRejectionError(
+        Object.assign(
+          new Error(
+            "Received 404 status code when fetching image from URL: https://example.com/missing.png",
+          ),
+          {
+            name: "AI_APICallError",
+            statusCode: 400,
+          },
+        ),
+      ),
+    ).toBe(true);
   });
 
   it("does not treat media size or retryable provider errors as image rejection", () => {

--- a/lib/chat/multimodal-tool-result-recovery.ts
+++ b/lib/chat/multimodal-tool-result-recovery.ts
@@ -111,6 +111,7 @@ const MULTIMODAL_REJECTION_PATTERNS = [
   /(?:not supported|unsupported|reject|invalid).{0,80}(?:vision|multimodal|image)/i,
   /model does not support images/i,
   /image.*(?:must be|should be).*(?:url|text)/i,
+  /fetching image from URL/i,
   /content.*image.*not.*allowed/i,
 ] as const;
 

--- a/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
+++ b/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
@@ -158,6 +158,28 @@ describe("shouldDropExpectedFrontendException", () => {
     ).toBe(false);
   });
 
+  it("keeps stale-looking server action messages with app stack frames", () => {
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_values: ["Checkout session was not found on the server"],
+          $exception_list: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    source: "turbopack:///[project]/app/actions/billing.ts",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
+  });
+
   it("drops chunk load failures even with Next runtime frames", () => {
     expect(
       shouldDropExpectedFrontendException({

--- a/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
+++ b/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
@@ -33,6 +33,7 @@ describe("shouldDropExpectedFrontendException", () => {
       "Load failed",
       "NetworkError when attempting to fetch resource.",
       "network error",
+      "Error in input stream",
       "timeout",
       "connection closed",
       "An unexpected response was received from the server.",
@@ -65,6 +66,92 @@ describe("shouldDropExpectedFrontendException", () => {
                 ],
               },
             },
+          ],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("drops Next server action transport and stale deployment failures", () => {
+    for (const value of [
+      "Failed to fetch",
+      "An unexpected response was received from the server.",
+    ]) {
+      expect(
+        shouldDropExpectedFrontendException({
+          event: "$exception",
+          properties: {
+            $exception_values: [value],
+            $exception_list: [
+              {
+                stacktrace: {
+                  frames: [
+                    {
+                      source:
+                        "turbopack:///[project]/node_modules/.pnpm/next@16.2.9/node_modules/next/src/client/components/router-reducer/reducers/server-action-reducer.ts",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        }),
+      ).toBe(true);
+    }
+
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_types: ["UnrecognizedActionError"],
+          $exception_values: [
+            'Server Action "00b3ff60fce156a3bb78260aa8fa56550dc48b7f77" was not found on the server. Read more: https://nextjs.org/docs/messages/failed-to-find-server-action',
+          ],
+          $exception_list: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    source: "/docs/messages/failed-to-find-server-action",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps generic network failures when a server action failure has app frames", () => {
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_values: ["Failed to fetch"],
+          $exception_list: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    source: "turbopack:///[project]/app/actions/example.ts",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps non-stale server action failures", () => {
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_values: [
+            "Server Action failed while creating a checkout session",
           ],
         },
       }),
@@ -173,6 +260,8 @@ describe("shouldDropExpectedFrontendException", () => {
       "Event captured as exception with keys: isTrusted",
       "'Error' captured as exception with message: 'Aa'",
       "'TypeError' captured as exception with message: 'undefined is not an object (evaluating 'a.J')'",
+      "'Error' captured as exception with message: 'Invalid call to runtime.sendMessage(). Tab not found.'",
+      "Cannot read properties of undefined (reading 'CoinType')",
     ]) {
       expect(
         shouldDropExpectedFrontendException({

--- a/lib/posthog/expected-frontend-exceptions.ts
+++ b/lib/posthog/expected-frontend-exceptions.ts
@@ -18,6 +18,7 @@ const BROWSER_FETCH_TRANSPORT_MESSAGES = new Set([
   "Load failed",
   "NetworkError when attempting to fetch resource.",
   "network error",
+  "Error in input stream",
   "timeout",
   "connection closed",
   "An unexpected response was received from the server.",
@@ -38,6 +39,8 @@ const OPAQUE_SYNTHETIC_MESSAGES = new Set([
   "Event captured as exception with keys: isTrusted",
   "'Error' captured as exception with message: 'Aa'",
   "'TypeError' captured as exception with message: 'undefined is not an object (evaluating 'a.J')'",
+  "'Error' captured as exception with message: 'Invalid call to runtime.sendMessage(). Tab not found.'",
+  "Cannot read properties of undefined (reading 'CoinType')",
 ]);
 
 const TRIGGER_STREAM_CLOSE_MESSAGE_FRAGMENTS = [
@@ -53,6 +56,18 @@ const CHUNK_LOAD_MESSAGE_FRAGMENTS = [
   "error loading dynamically imported module",
   "Importing a module script failed",
   "Failed to fetch dynamically imported module",
+];
+
+const NEXT_SERVER_ACTION_SOURCE_FRAGMENTS = [
+  "next/src/client/components/router-reducer/reducers/server-action-reducer.ts",
+  "/docs/messages/failed-to-find-server-action",
+];
+
+const STALE_SERVER_ACTION_MESSAGE_FRAGMENTS = [
+  "Failed to find Server Action",
+  "was not found on the server",
+  "failed-to-find-server-action",
+  "older or newer deployment",
 ];
 
 const REACT_MAX_UPDATE_DEPTH_MESSAGE_FRAGMENT = "Minified React error #185";
@@ -136,6 +151,17 @@ const hasBrowserFetchTransportMessage = (strings: string[]): boolean =>
 const hasChunkLoadMessage = (strings: string[]): boolean =>
   includesAny(strings, CHUNK_LOAD_MESSAGE_FRAGMENTS);
 
+const hasStaleServerActionMessage = (strings: string[]): boolean =>
+  includesAny(strings, STALE_SERVER_ACTION_MESSAGE_FRAGMENTS);
+
+const hasOnlyNextServerActionFrames = (frameSources: string[]): boolean =>
+  frameSources.length > 0 &&
+  frameSources.every((source) =>
+    NEXT_SERVER_ACTION_SOURCE_FRAGMENTS.some((fragment) =>
+      source.includes(fragment),
+    ),
+  );
+
 const hasStackOverflowMessage = (strings: string[]): boolean =>
   hasExactStringFrom(strings, STACK_OVERFLOW_MESSAGES);
 
@@ -185,6 +211,13 @@ const matchesBareBrowserTransportPattern = (
 ): boolean =>
   hasBrowserFetchTransportMessage(strings) && frameSources.length === 0;
 
+const matchesNextServerActionTransportPattern = (
+  strings: string[],
+  frameSources: string[],
+): boolean =>
+  hasBrowserFetchTransportMessage(strings) &&
+  hasOnlyNextServerActionFrames(frameSources);
+
 const getExceptionCategory = (strings: string[]): FrontendExceptionCategory => {
   if (includesAny(strings, [REACT_MAX_UPDATE_DEPTH_MESSAGE_FRAGMENT])) {
     return "react_max_update_depth";
@@ -208,6 +241,8 @@ export function shouldDropExpectedFrontendException(event: PostHogEventLike) {
   return (
     hasResizeObserverMessage(strings) ||
     matchesBareBrowserTransportPattern(strings, frameSources) ||
+    matchesNextServerActionTransportPattern(strings, frameSources) ||
+    hasStaleServerActionMessage(strings) ||
     hasChunkLoadMessage(strings) ||
     hasExactStringFrom(strings, MANUAL_CHAT_STOP_ABORT_MESSAGES) ||
     hasExactStringFrom(strings, REACT_DOM_MUTATION_MESSAGES) ||

--- a/lib/posthog/expected-frontend-exceptions.ts
+++ b/lib/posthog/expected-frontend-exceptions.ts
@@ -218,6 +218,13 @@ const matchesNextServerActionTransportPattern = (
   hasBrowserFetchTransportMessage(strings) &&
   hasOnlyNextServerActionFrames(frameSources);
 
+const matchesStaleServerActionPattern = (
+  strings: string[],
+  frameSources: string[],
+): boolean =>
+  hasStaleServerActionMessage(strings) &&
+  (frameSources.length === 0 || hasOnlyNextServerActionFrames(frameSources));
+
 const getExceptionCategory = (strings: string[]): FrontendExceptionCategory => {
   if (includesAny(strings, [REACT_MAX_UPDATE_DEPTH_MESSAGE_FRAGMENT])) {
     return "react_max_update_depth";
@@ -242,7 +249,7 @@ export function shouldDropExpectedFrontendException(event: PostHogEventLike) {
     hasResizeObserverMessage(strings) ||
     matchesBareBrowserTransportPattern(strings, frameSources) ||
     matchesNextServerActionTransportPattern(strings, frameSources) ||
-    hasStaleServerActionMessage(strings) ||
+    matchesStaleServerActionPattern(strings, frameSources) ||
     hasChunkLoadMessage(strings) ||
     hasExactStringFrom(strings, MANUAL_CHAT_STOP_ABORT_MESSAGES) ||
     hasExactStringFrom(strings, REACT_DOM_MUTATION_MESSAGES) ||


### PR DESCRIPTION
## Summary
- filter confirmed false-positive PostHog frontend noise: stale Next Server Action transport errors, bare browser transport failures, chunk-load recovery cases, and extension/wallet synthetic exceptions
- improve real recovery paths for provider image URL rejection, Trigger status health timeouts, and Firefox `window.onerror` permission errors
- add structured stage logging to account deletion so future Vercel failures identify where deletion stopped

## Investigation notes
- Closed in PostHog as false positives: stale Next Server Action `UnrecognizedActionError`, generic browser `Failed to fetch` / `Unexpected response` / `NetworkError` transport issues without app frames, chunk-load deployment noise, WorkOS token refresh expiry, extension `runtime.sendMessage` tab errors, wallet `CoinType` synthetic errors, and Safari/Firefox bare transport failures.
- Fixed in code: S3/image URL provider rejection now retries without image tool output, Trigger status health check aborts after 8s instead of hitting Vercel maxDuration, and the chat `window.onerror` wrapper no longer rethrows cross-origin handler failures.
- Needs continued monitoring rather than immediate code changes: React #185/#310 loops without useful app stacks, Convex server/base-version errors, provider 5xx/upstream idle timeout, and `/api/agent` timeout occurrences.

## Verification
- `pnpm test -- lib/posthog/__tests__/expected-frontend-exceptions.test.ts app/components/__tests__/ChunkLoadRecovery.test.ts lib/chat/__tests__/multimodal-tool-result-recovery.test.ts app/api/health/trigger-agent-mode/__tests__/route.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm lint -- app/components/ChunkLoadRecovery.tsx app/components/chat.tsx app/api/health/trigger-agent-mode/route.ts app/api/delete-account/route.ts lib/posthog/expected-frontend-exceptions.ts lib/chat/multimodal-tool-result-recovery.ts` (warnings only in existing unrelated/shared lint targets)
- pre-commit hook: full `pnpm test` passed, 212 suites / 2,137 tests

## Manual verification
- After deploy, check PostHog Error Tracking for no new active issues matching stale Next Server Action transport, bare browser transport, extension tab, or wallet `CoinType` fingerprints.
- If Trigger status is slow/unavailable, call `/api/health/trigger-agent-mode` and confirm it returns a 503 JSON response with `timeoutMs` instead of a Vercel runtime timeout.

Visual verification not required: this is backend/logging/error-filtering work with no meaningful UI rendering change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from additional chat/server-action staleness and “not found” deployment failures, reducing broken UI states.
  * Expanded multimodal image tool error matching so more recoverable failures are classified correctly.
  * Added a request timeout to the agent-mode health check, preventing hangs and returning more informative errors.
  * Improved account-deletion failure logging with stage/context details for faster troubleshooting (behavior unchanged).
* **Tests**
  * Updated and extended coverage for the above error-detection and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->