### PR TITLE
Fix zero extra usage spending limits

### DIFF
--- a/app/components/ExtraUsageSection.tsx
+++ b/app/components/ExtraUsageSection.tsx
@@ -185,7 +185,9 @@ const ExtraUsageSection = () => {
         monthlyCapDollars: limitDollars,
       });
       toast.success(
-        limitDollars ? "Spending limit updated" : "Spending limit removed",
+        limitDollars === null
+          ? "Spending limit removed"
+          : "Spending limit updated",
       );
       setShowSpendingLimitDialog(false);
     } catch (error) {

--- a/app/components/TeamExtraUsageSection.tsx
+++ b/app/components/TeamExtraUsageSection.tsx
@@ -206,9 +206,9 @@ export const TeamExtraUsageSection = () => {
     if (!ok) return;
     setShowSpendingLimitDialog(false);
     toast.success(
-      limitDollars
-        ? "Team spending limit updated"
-        : "Team spending limit removed",
+      limitDollars === null
+        ? "Team spending limit removed"
+        : "Team spending limit updated",
     );
   };
 

--- a/app/components/extra-usage/AdjustSpendingLimitDialog.tsx
+++ b/app/components/extra-usage/AdjustSpendingLimitDialog.tsx
@@ -35,7 +35,7 @@ const AdjustSpendingLimitDialogContent = ({
 
   const handleSetLimit = async () => {
     const limit = parseFloat(inputValue);
-    if (isNaN(limit) || limit < 0) return;
+    if (isNaN(limit) || limit < 1) return;
     await onSave(limit);
   };
 
@@ -44,7 +44,7 @@ const AdjustSpendingLimitDialogContent = ({
   };
 
   const parsedLimit = parseFloat(inputValue);
-  const isValidLimit = !isNaN(parsedLimit) && parsedLimit >= 0;
+  const isValidLimit = !isNaN(parsedLimit) && parsedLimit >= 1;
 
   return (
     <>
@@ -67,7 +67,7 @@ const AdjustSpendingLimitDialogContent = ({
             aria-label="Monthly spending limit"
           />
           <p className="text-xs mt-3 text-muted-foreground">
-            This spending limit goes into effect immediately
+            Enter at least $1, or set the limit to unlimited.
           </p>
         </div>
         <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">

--- a/app/components/extra-usage/__tests__/AdjustSpendingLimitDialog.test.tsx
+++ b/app/components/extra-usage/__tests__/AdjustSpendingLimitDialog.test.tsx
@@ -1,0 +1,44 @@
+import "@testing-library/jest-dom";
+import { describe, expect, it, jest } from "@jest/globals";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { AdjustSpendingLimitDialog } from "../AdjustSpendingLimitDialog";
+
+describe("AdjustSpendingLimitDialog", () => {
+  it("shows an existing zero-dollar limit but prevents saving it again", () => {
+    const onSave = jest.fn(async () => {});
+
+    render(
+      <AdjustSpendingLimitDialog
+        open={true}
+        onOpenChange={jest.fn()}
+        onSave={onSave}
+        isLoading={false}
+        currentLimitDollars={0}
+      />,
+    );
+
+    expect(screen.getByLabelText("Monthly spending limit")).toHaveValue("$0");
+    expect(
+      screen.getByRole("button", { name: "Set spending limit" }),
+    ).toBeDisabled();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("clears the cap by saving null when set to unlimited", async () => {
+    const onSave = jest.fn(async () => {});
+
+    render(
+      <AdjustSpendingLimitDialog
+        open={true}
+        onOpenChange={jest.fn()}
+        onSave={onSave}
+        isLoading={false}
+        currentLimitDollars={0}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Set to unlimited" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith(null));
+  });
+});

--- a/app/components/usage/OnDemandUsageCard.tsx
+++ b/app/components/usage/OnDemandUsageCard.tsx
@@ -37,7 +37,7 @@ const OnDemandUsageCard = ({ subscription }: OnDemandUsageCardProps) => {
             <span className="text-2xl font-semibold tabular-nums">
               ${monthlySpentDollars.toFixed(2)}
             </span>
-            {monthlyCapDollars ? (
+            {monthlyCapDollars != null ? (
               <span className="text-sm text-muted-foreground">
                 / ${monthlyCapDollars.toFixed(2)}
               </span>

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -12,6 +12,7 @@ import {
   extraUsageDollarsToPoints as dollarsToPoints,
   extraUsagePointsToDollars as pointsToDollars,
 } from "./lib/extraUsagePricing";
+import { validateMonthlyCapDollars } from "./lib/extraUsageValidation";
 
 type ExtraUsagePurchaseStatus = "created" | "paid_seen" | "credited" | "failed";
 type ExtraUsagePurchaseRoute =
@@ -988,13 +989,7 @@ export const updateExtraUsageSettings = mutation({
     ) {
       throw new Error("Reload amount must be at least $10 more than threshold");
     }
-    if (
-      args.monthlyCapDollars !== undefined &&
-      args.monthlyCapDollars !== null &&
-      (!Number.isFinite(args.monthlyCapDollars) || args.monthlyCapDollars < 1)
-    ) {
-      throw new Error("Monthly spending limit must be at least $1");
-    }
+    validateMonthlyCapDollars(args.monthlyCapDollars);
 
     const settings = await ctx.db
       .query("extra_usage")

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -924,9 +924,10 @@ export const getExtraUsageSettings = query({
         ? pointsToDollars(settings.auto_reload_threshold_points)
         : undefined,
       autoReloadAmountDollars: settings.auto_reload_amount_dollars,
-      monthlyCapDollars: settings.monthly_cap_points
-        ? pointsToDollars(settings.monthly_cap_points)
-        : undefined,
+      monthlyCapDollars:
+        settings.monthly_cap_points === undefined
+          ? undefined
+          : pointsToDollars(settings.monthly_cap_points),
       monthlySpentDollars: pointsToDollars(settings.monthly_spent_points ?? 0),
       autoReloadDisabledReason: settings.auto_reload_disabled_reason,
     };
@@ -986,6 +987,13 @@ export const updateExtraUsageSettings = mutation({
       args.autoReloadAmountDollars < args.autoReloadThresholdDollars + 10
     ) {
       throw new Error("Reload amount must be at least $10 more than threshold");
+    }
+    if (
+      args.monthlyCapDollars !== undefined &&
+      args.monthlyCapDollars !== null &&
+      (!Number.isFinite(args.monthlyCapDollars) || args.monthlyCapDollars < 1)
+    ) {
+      throw new Error("Monthly spending limit must be at least $1");
     }
 
     const settings = await ctx.db

--- a/convex/lib/extraUsageValidation.ts
+++ b/convex/lib/extraUsageValidation.ts
@@ -1,0 +1,11 @@
+export const validateMonthlyCapDollars = (
+  monthlyCapDollars: number | null | undefined,
+) => {
+  if (
+    monthlyCapDollars !== undefined &&
+    monthlyCapDollars !== null &&
+    (!Number.isFinite(monthlyCapDollars) || monthlyCapDollars < 1)
+  ) {
+    throw new Error("Monthly spending limit must be at least $1");
+  }
+};

--- a/convex/teamExtraUsage.ts
+++ b/convex/teamExtraUsage.ts
@@ -635,9 +635,10 @@ export const getTeamExtraUsageAdminView = query({
         ? pointsToDollars(team.auto_reload_threshold_points)
         : undefined,
       autoReloadAmountDollars: team?.auto_reload_amount_dollars,
-      monthlyCapDollars: team?.monthly_cap_points
-        ? pointsToDollars(team.monthly_cap_points)
-        : undefined,
+      monthlyCapDollars:
+        team?.monthly_cap_points === undefined
+          ? undefined
+          : pointsToDollars(team.monthly_cap_points),
       monthlySpentDollars: pointsToDollars(teamMonthlySpent),
       autoReloadDisabledReason: team?.auto_reload_disabled_reason,
       members: members.map((m) => {
@@ -707,6 +708,13 @@ export const updateTeamExtraUsageSettings = mutation({
       args.autoReloadAmountDollars < args.autoReloadThresholdDollars + 10
     ) {
       throw new Error("Reload amount must be at least $10 more than threshold");
+    }
+    if (
+      args.monthlyCapDollars !== undefined &&
+      args.monthlyCapDollars !== null &&
+      (!Number.isFinite(args.monthlyCapDollars) || args.monthlyCapDollars < 1)
+    ) {
+      throw new Error("Monthly spending limit must be at least $1");
     }
 
     const row = await ensureTeamRow(ctx, args.organizationId);

--- a/convex/teamExtraUsage.ts
+++ b/convex/teamExtraUsage.ts
@@ -12,6 +12,7 @@ import {
   extraUsageDollarsToPoints as dollarsToPoints,
   extraUsagePointsToDollars as pointsToDollars,
 } from "./lib/extraUsagePricing";
+import { validateMonthlyCapDollars } from "./lib/extraUsageValidation";
 
 // =============================================================================
 // Internal helpers
@@ -709,13 +710,7 @@ export const updateTeamExtraUsageSettings = mutation({
     ) {
       throw new Error("Reload amount must be at least $10 more than threshold");
     }
-    if (
-      args.monthlyCapDollars !== undefined &&
-      args.monthlyCapDollars !== null &&
-      (!Number.isFinite(args.monthlyCapDollars) || args.monthlyCapDollars < 1)
-    ) {
-      throw new Error("Monthly spending limit must be at least $1");
-    }
+    validateMonthlyCapDollars(args.monthlyCapDollars);
 
     const row = await ensureTeamRow(ctx, args.organizationId);
 


### PR DESCRIPTION
## Summary
- show stored $0 monthly extra-usage caps as $0.00 instead of treating them as no limit
- require monthly extra-usage spending limits to be at least $1, with unlimited represented by null/unset
- add regression coverage for the spending-limit dialog zero-cap path

## Verification
- pnpm test app/components/extra-usage/__tests__/AdjustSpendingLimitDialog.test.tsx --runInBand
- pnpm typecheck
- pnpm lint -- app/components/extra-usage/AdjustSpendingLimitDialog.tsx app/components/extra-usage/__tests__/AdjustSpendingLimitDialog.test.tsx app/components/ExtraUsageSection.tsx app/components/TeamExtraUsageSection.tsx app/components/usage/OnDemandUsageCard.tsx convex/extraUsage.ts convex/teamExtraUsage.ts (0 errors; existing unrelated warnings)
- pnpm prettier --check app/components/extra-usage/AdjustSpendingLimitDialog.tsx app/components/extra-usage/__tests__/AdjustSpendingLimitDialog.test.tsx app/components/ExtraUsageSection.tsx app/components/TeamExtraUsageSection.tsx app/components/usage/OnDemandUsageCard.tsx convex/extraUsage.ts convex/teamExtraUsage.ts
- pre-commit hook: pnpm typecheck
- pre-commit hook: pnpm test

## Manual verification
- In Settings > Extra Usage, an existing $0 monthly cap should display as $0.00 and the Set spending limit button should be disabled until the value is at least $1.
- Click Set to unlimited and confirm the cap is cleared, so the UI returns to Unlimited/No limit and extra usage can use available balance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cases where a saved `$0` monthly spending limit was treated as “unlimited”/no limit, improving cap display across usage views.
  * Updated success messaging to accurately distinguish “Spending limit removed” (`null`) from “Spending limit updated” (including `0`).
  * Enforced monthly spending limits to be **at least $1** when set; **unlimited** still uses `null`.

* **Tests**
  * Added coverage for `$0` input disabling and “set to unlimited” saving behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->