### PR TITLE
Fix unsafe attachment PDF previews

### DIFF
--- a/app/components/FileContentViewer.tsx
+++ b/app/components/FileContentViewer.tsx
@@ -12,6 +12,12 @@ const isBrowserFile = (file: File | LocalDesktopFile): file is File =>
 
 /** Guard against freezing the UI on very large text files */
 const MAX_PREVIEW_CHARS = 500_000;
+const PDF_MAGIC_BYTES = "%PDF-";
+
+async function hasPdfMagicBytes(file: File): Promise<boolean> {
+  const header = await file.slice(0, PDF_MAGIC_BYTES.length).text();
+  return header === PDF_MAGIC_BYTES;
+}
 
 interface FileContentViewerProps {
   isOpen: boolean;
@@ -88,6 +94,9 @@ export const FileContentViewer = ({
           // blob URL; restored-from-draft files use a short-lived signed URL.
           let url: string;
           if (isBrowserFile(file)) {
+            if (!(await hasPdfMagicBytes(file))) {
+              throw new Error("Invalid PDF signature");
+            }
             createdBlobUrl = URL.createObjectURL(file);
             url = createdBlobUrl;
           } else {
@@ -263,6 +272,7 @@ export const FileContentViewer = ({
             <iframe
               src={pdfUrl}
               title={`Preview of ${fileName}`}
+              sandbox="allow-downloads"
               className="h-full w-full border-0"
             />
           ) : (

--- a/app/components/FileContentViewer.tsx
+++ b/app/components/FileContentViewer.tsx
@@ -269,10 +269,11 @@ export const FileContentViewer = ({
               )}
             </div>
           ) : pdfUrl ? (
+            // Chromium's PDF viewer can fail inside sandboxed iframes. The PDF
+            // path is gated above by MIME type and magic bytes before blob URL creation.
             <iframe
               src={pdfUrl}
               title={`Preview of ${fileName}`}
-              sandbox="allow-downloads"
               className="h-full w-full border-0"
             />
           ) : (

--- a/app/components/__tests__/FileContentViewer.test.tsx
+++ b/app/components/__tests__/FileContentViewer.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { FileUrlCacheProvider } from "@/app/contexts/FileUrlCacheContext";
+import { FileContentViewer } from "../FileContentViewer";
+
+describe("FileContentViewer", () => {
+  let createObjectURL: jest.Mock;
+  let revokeObjectURL: jest.Mock;
+
+  function makeFile(contents: string, name: string, type: string): File {
+    const file = new File([contents], name, { type });
+
+    Object.defineProperty(file, "text", {
+      configurable: true,
+      value: jest.fn(async () => contents),
+    });
+    Object.defineProperty(file, "slice", {
+      configurable: true,
+      value: jest.fn((start = 0, end = contents.length) => ({
+        text: jest.fn(async () => contents.slice(start, end)),
+      })),
+    });
+
+    return file;
+  }
+
+  beforeEach(() => {
+    createObjectURL = jest.fn(() => "blob:preview-pdf");
+    revokeObjectURL = jest.fn();
+
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+  });
+
+  function renderViewer(file: File) {
+    return render(
+      <FileUrlCacheProvider
+        getCachedUrl={() => null}
+        setCachedUrl={() => undefined}
+      >
+        <FileContentViewer
+          isOpen
+          onClose={() => undefined}
+          file={file}
+          fileName={file.name}
+        />
+      </FileUrlCacheProvider>,
+    );
+  }
+
+  it("renders valid in-memory PDFs in a sandboxed iframe", async () => {
+    const file = makeFile("%PDF-1.7\n1 0 obj\n", "safe.pdf", "application/pdf");
+
+    const { container } = renderViewer(file);
+
+    await waitFor(() => {
+      expect(container.querySelector("iframe")).toBeInTheDocument();
+    });
+
+    const iframe = container.querySelector("iframe");
+    expect(createObjectURL).toHaveBeenCalledWith(file);
+    expect(iframe).toHaveAttribute("src", "blob:preview-pdf");
+    expect(iframe).toHaveAttribute("sandbox", "allow-downloads");
+  });
+
+  it("shows crafted HTML .pdf files as escaped text instead of iframe PDFs", async () => {
+    const file = makeFile(
+      "<script>window.__attachmentPreviewPoc = true;</script>",
+      "poc.pdf",
+      "text/html",
+    );
+
+    const { container } = renderViewer(file);
+
+    expect(
+      await screen.findByText(
+        "<script>window.__attachmentPreviewPoc = true;</script>",
+      ),
+    ).toBeInTheDocument();
+    expect(createObjectURL).not.toHaveBeenCalled();
+    expect(container.querySelector("iframe")).not.toBeInTheDocument();
+  });
+
+  it("rejects application/pdf browser files without a PDF signature", async () => {
+    const file = makeFile(
+      "<html><script>alert(1)</script></html>",
+      "poc.pdf",
+      "application/pdf",
+    );
+
+    const { container } = renderViewer(file);
+
+    expect(
+      await screen.findByText("Failed to read file content."),
+    ).toBeInTheDocument();
+    expect(createObjectURL).not.toHaveBeenCalled();
+    expect(container.querySelector("iframe")).not.toBeInTheDocument();
+  });
+});

--- a/app/components/__tests__/FileContentViewer.test.tsx
+++ b/app/components/__tests__/FileContentViewer.test.tsx
@@ -53,7 +53,7 @@ describe("FileContentViewer", () => {
     );
   }
 
-  it("renders valid in-memory PDFs in a sandboxed iframe", async () => {
+  it("renders valid in-memory PDFs in the native PDF iframe", async () => {
     const file = makeFile("%PDF-1.7\n1 0 obj\n", "safe.pdf", "application/pdf");
 
     const { container } = renderViewer(file);
@@ -65,7 +65,7 @@ describe("FileContentViewer", () => {
     const iframe = container.querySelector("iframe");
     expect(createObjectURL).toHaveBeenCalledWith(file);
     expect(iframe).toHaveAttribute("src", "blob:preview-pdf");
-    expect(iframe).toHaveAttribute("sandbox", "allow-downloads");
+    expect(iframe).not.toHaveAttribute("sandbox");
   });
 
   it("shows crafted HTML .pdf files as escaped text instead of iframe PDFs", async () => {

--- a/lib/utils/__tests__/file-utils.test.ts
+++ b/lib/utils/__tests__/file-utils.test.ts
@@ -1,0 +1,22 @@
+import { isPdfFile, isTextViewableFile } from "../file-utils";
+
+describe("file-utils preview classification", () => {
+  it("treats application/pdf files as PDFs", () => {
+    const file = new File(["%PDF-1.7"], "report.pdf", {
+      type: "application/pdf",
+    });
+
+    expect(isPdfFile(file)).toBe(true);
+  });
+
+  it("does not classify .pdf filenames as PDFs without the PDF media type", () => {
+    const htmlFile = new File(["<script>alert(1)</script>"], "report.pdf", {
+      type: "text/html",
+    });
+    const unknownFile = new File(["%PDF-1.7"], "report.pdf");
+
+    expect(isPdfFile(htmlFile)).toBe(false);
+    expect(isPdfFile(unknownFile)).toBe(false);
+    expect(isTextViewableFile(htmlFile)).toBe(true);
+  });
+});

--- a/lib/utils/file-utils.ts
+++ b/lib/utils/file-utils.ts
@@ -122,11 +122,11 @@ const TEXT_VIEWABLE_EXTENSIONS = new Set([
 ]);
 
 /**
- * Check if a file is a PDF (by media type, with an extension fallback)
+ * Check if a file is a PDF by media type only.
+ * Extension-only detection can route active content into the PDF iframe preview.
  */
 export function isPdfFile(file: File | LocalDesktopFile): boolean {
-  if (file.type?.toLowerCase() === "application/pdf") return true;
-  return file.name.split(".").pop()?.toLowerCase() === "pdf";
+  return file.type?.split(";")[0]?.trim().toLowerCase() === "application/pdf";
 }
 
 /**


### PR DESCRIPTION
## Summary
- require the PDF media type before selecting attachment iframe preview
- verify in-memory PDF files start with `%PDF-` before creating blob preview URLs
- keep native PDF iframe rendering for browser compatibility, with a code comment documenting why sandboxed PDF iframes are avoided

## Security validation
- crafted `text/html` content named `poc.pdf` now renders through escaped text preview instead of a blob iframe
- `application/pdf` browser files without a PDF signature are rejected before `URL.createObjectURL`
- valid in-memory PDFs still render through the native PDF preview path

## Tests
- `corepack pnpm exec jest app/components/__tests__/FileContentViewer.test.tsx lib/utils/__tests__/file-utils.test.ts --runInBand`
- `corepack pnpm exec eslint app/components/FileContentViewer.tsx app/components/__tests__/FileContentViewer.test.tsx lib/utils/file-utils.ts lib/utils/__tests__/file-utils.test.ts`
- `corepack pnpm exec prettier --check app/components/FileContentViewer.tsx app/components/__tests__/FileContentViewer.test.tsx lib/utils/file-utils.ts lib/utils/__tests__/file-utils.test.ts`
- `corepack pnpm typecheck`
- pre-commit hook after each commit: `pnpm lint-staged && pnpm typecheck && pnpm test` (212 suites, 2116 tests)