### PR TITLE
Track subscription payment failure causes

### DIFF
--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -710,6 +710,10 @@ describe("POST /api/subscription/webhook", () => {
 
     expect(response.status).toBe(200);
     expect(body).toEqual({ received: true });
+    expect(mockRetrieveInvoice).toHaveBeenCalledWith(
+      "in_deleted_payment_failed",
+      { expand: ["payment_intent", "payment_intent.latest_charge"] },
+    );
     expect(mockPostHogEvent).toHaveBeenCalledWith(
       "subscription_cancelled",
       expect.objectContaining({

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -11,6 +11,7 @@ const mockConstructEvent = jest.fn();
 const mockRetrieveCustomer = jest.fn();
 const mockRetrieveSubscription = jest.fn();
 const mockUpdateSubscription = jest.fn();
+const mockRetrieveInvoice = jest.fn();
 const mockListMemberships = jest.fn();
 const mockConvexMutation = jest.fn();
 const mockResetRateLimitBuckets = jest.fn();
@@ -45,6 +46,9 @@ jest.mock("@/app/api/stripe", () => ({
     subscriptions: {
       retrieve: mockRetrieveSubscription,
       update: mockUpdateSubscription,
+    },
+    invoices: {
+      retrieve: mockRetrieveInvoice,
     },
   },
 }));
@@ -464,6 +468,285 @@ describe("POST /api/subscription/webhook", () => {
     );
     expect(console.warn).toHaveBeenCalledWith(
       '[Subscription Webhook] Subscription sub_hackerai_deleted missing price lookup_key, resolved tier "pro-plus" from product fallback',
+    );
+  });
+
+  it("captures classified billing failure analytics for subscription invoice failures", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_invoice_payment_failed",
+      type: "invoice.payment_failed",
+      data: {
+        object: {
+          id: "in_payment_failed",
+          customer: "cus_payment_failed",
+          amount_due: 6000,
+          amount_remaining: 6000,
+          currency: "usd",
+          status: "open",
+          collection_method: "charge_automatically",
+          billing_reason: "subscription_update",
+          attempt_count: 2,
+          next_payment_attempt: 1_782_000_000,
+          parent: {
+            subscription_details: {
+              subscription: "sub_payment_failed",
+            },
+          },
+        },
+      },
+    });
+    mockRetrieveCustomer.mockResolvedValue({
+      deleted: false,
+      id: "cus_payment_failed",
+      metadata: {
+        workOSOrganizationId: "org_payment_failed",
+      },
+    } as never);
+    mockListMemberships.mockResolvedValue({
+      autoPagination: jest
+        .fn()
+        .mockResolvedValue([{ userId: "user_payment_failed" }]),
+    } as never);
+    mockRetrieveSubscription.mockResolvedValue({
+      id: "sub_payment_failed",
+      metadata: {},
+      items: {
+        data: [
+          {
+            quantity: 1,
+            price: {
+              id: "price_pro_plus",
+              lookup_key: "pro-plus-monthly-plan",
+              recurring: { interval: "month", interval_count: 1 },
+              product: {
+                id: "prod_pro_plus",
+                name: "HackerAI Pro Plus",
+                metadata: {},
+              },
+            },
+          },
+        ],
+      },
+    } as never);
+    mockRetrieveInvoice.mockResolvedValue({
+      id: "in_payment_failed",
+      customer: "cus_payment_failed",
+      amount_due: 6000,
+      amount_remaining: 6000,
+      currency: "usd",
+      status: "open",
+      collection_method: "charge_automatically",
+      billing_reason: "subscription_update",
+      attempt_count: 2,
+      next_payment_attempt: 1_782_000_000,
+      parent: {
+        subscription_details: {
+          subscription: "sub_payment_failed",
+        },
+      },
+      payment_intent: {
+        id: "pi_payment_failed",
+        last_payment_error: {
+          code: "card_declined",
+          decline_code: "insufficient_funds",
+          charge: "ch_payment_failed",
+          payment_method: { type: "card" },
+        },
+        latest_charge: {
+          id: "ch_payment_failed",
+          failure_code: "card_declined",
+          outcome: {
+            type: "issuer_declined",
+            reason: "insufficient_funds",
+            network_status: "declined_by_network",
+            network_decline_code: "51",
+            risk_level: "normal",
+          },
+          payment_method_details: {
+            type: "card",
+            card: {
+              brand: "visa",
+              country: "US",
+              funding: "debit",
+            },
+          },
+        },
+      },
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(makeWebhookRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ received: true });
+    expect(mockRetrieveInvoice).toHaveBeenCalledWith("in_payment_failed", {
+      expand: ["payment_intent", "payment_intent.latest_charge"],
+    });
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "billing_payment_failed",
+      expect.objectContaining({
+        userId: "user_payment_failed",
+        org_id: "org_payment_failed",
+        subscription_tier: "pro-plus",
+        plan: "pro-plus-monthly-plan",
+        billing_failure_lifecycle: "invoice_payment_failed",
+        billing_failure_stage: "subscription_update",
+        billing_failure_group: "insufficient_funds",
+        billing_reason: "subscription_update",
+        attempt_count: 2,
+        next_payment_attempt_present: true,
+        amount_due_dollars: 60,
+        amount_remaining_dollars: 60,
+        stripe_customer_id: "cus_payment_failed",
+        stripe_subscription_id: "sub_payment_failed",
+        stripe_invoice_id: "in_payment_failed",
+        stripe_payment_intent_id: "pi_payment_failed",
+        stripe_charge_id: "ch_payment_failed",
+        failure_code: "card_declined",
+        decline_code: "insufficient_funds",
+        outcome_type: "issuer_declined",
+        outcome_reason: "insufficient_funds",
+        network_decline_code: "51",
+        payment_method_type: "card",
+        card_brand: "visa",
+        card_country: "US",
+        card_funding: "debit",
+        paid_funnel_event_version: 1,
+      }),
+    );
+  });
+
+  it("enriches payment-failed subscription cancellations with billing failure classification", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_subscription_deleted_payment_failed",
+      type: "customer.subscription.deleted",
+      data: {
+        object: {
+          id: "sub_deleted_payment_failed",
+          customer: "cus_deleted_payment_failed",
+          latest_invoice: "in_deleted_payment_failed",
+          items: {
+            data: [
+              {
+                price: {
+                  id: "price_ultra",
+                  lookup_key: "ultra-monthly-plan",
+                  recurring: { interval: "month", interval_count: 1 },
+                },
+              },
+            ],
+          },
+          metadata: {},
+          cancellation_details: {
+            reason: "payment_failed",
+          },
+        },
+      },
+    });
+    mockRetrieveCustomer.mockResolvedValue({
+      deleted: false,
+      id: "cus_deleted_payment_failed",
+      metadata: {
+        workOSOrganizationId: "org_deleted_payment_failed",
+      },
+    } as never);
+    mockListMemberships.mockResolvedValue({
+      autoPagination: jest
+        .fn()
+        .mockResolvedValue([{ userId: "user_deleted_payment_failed" }]),
+    } as never);
+    mockRetrieveInvoice.mockResolvedValue({
+      id: "in_deleted_payment_failed",
+      customer: "cus_deleted_payment_failed",
+      amount_due: 20000,
+      amount_remaining: 20000,
+      currency: "usd",
+      status: "open",
+      collection_method: "charge_automatically",
+      billing_reason: "subscription_cycle",
+      attempt_count: 4,
+      next_payment_attempt: null,
+      parent: {
+        subscription_details: {
+          subscription: "sub_deleted_payment_failed",
+        },
+      },
+      payment_intent: {
+        id: "pi_deleted_payment_failed",
+        last_payment_error: {
+          code: "card_declined",
+          decline_code: "transaction_not_allowed",
+          charge: "ch_deleted_payment_failed",
+          payment_method: { type: "card" },
+        },
+        latest_charge: {
+          id: "ch_deleted_payment_failed",
+          failure_code: "card_declined",
+          outcome: {
+            type: "issuer_declined",
+            reason: "transaction_not_allowed",
+            network_status: "declined_by_network",
+            network_decline_code: "57",
+            risk_level: "normal",
+          },
+          payment_method_details: {
+            type: "card",
+            card: {
+              brand: "mastercard",
+              country: "MA",
+              funding: "debit",
+            },
+          },
+        },
+      },
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(makeWebhookRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ received: true });
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "subscription_cancelled",
+      expect.objectContaining({
+        userId: "user_deleted_payment_failed",
+        org_id: "org_deleted_payment_failed",
+        tier: "ultra",
+        cancellation_reason: "payment_failed",
+        billing_failure_lifecycle: "subscription_deleted",
+        billing_failure_stage: "renewal",
+        billing_failure_group: "transaction_not_allowed",
+        billing_reason: "subscription_cycle",
+        attempt_count: 4,
+        next_payment_attempt_present: false,
+        amount_due_dollars: 200,
+        stripe_invoice_id: "in_deleted_payment_failed",
+        stripe_payment_intent_id: "pi_deleted_payment_failed",
+        stripe_charge_id: "ch_deleted_payment_failed",
+        decline_code: "transaction_not_allowed",
+        network_decline_code: "57",
+        card_country: "MA",
+        $set: { subscription_tier: "free" },
+      }),
+    );
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "billing_payment_failed",
+      expect.objectContaining({
+        userId: "user_deleted_payment_failed",
+        org_id: "org_deleted_payment_failed",
+        subscription_tier: "ultra",
+        plan: "ultra-monthly-plan",
+        billing_failure_lifecycle: "subscription_deleted",
+        billing_failure_stage: "renewal",
+        billing_failure_group: "transaction_not_allowed",
+        stripe_customer_id: "cus_deleted_payment_failed",
+        stripe_subscription_id: "sub_deleted_payment_failed",
+        stripe_invoice_id: "in_deleted_payment_failed",
+      }),
     );
   });
 

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -27,6 +27,12 @@ import {
   logStripeWebhookMissingSignature,
   logStripeWebhookSignatureVerificationFailed,
 } from "@/lib/billing/stripe-webhook-logging";
+import {
+  invoiceSubscriptionId,
+  stripeObjectId,
+  subscriptionPaymentFailureProperties,
+  type BillingFailureProperties,
+} from "@/lib/billing/subscription-payment-failure";
 
 const WEBHOOK_LOG_PREFIX = "[Subscription Webhook]";
 const WEBHOOK_LOG_CONTEXT = {
@@ -120,6 +126,22 @@ function monthlyUsagePeriodEndSeconds(
   if (priceBillingInterval(price) !== "month") return undefined;
   if ((price?.recurring?.interval_count ?? 1) !== 1) return undefined;
   return subscriptionCurrentPeriodEndSeconds(subscription);
+}
+
+async function retrieveInvoiceForFailureAnalytics(
+  invoiceId: string,
+): Promise<Stripe.Invoice | null> {
+  try {
+    return await stripe.invoices.retrieve(invoiceId, {
+      expand: ["payment_intent", "payment_intent.latest_charge"],
+    });
+  } catch (error) {
+    phLogger.warn("subscription_payment_failure_invoice_retrieve_failed", {
+      stripe_invoice_id: invoiceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
 }
 
 /** Infer subscription tier from a Stripe product name (fallback when lookup_key is missing). */
@@ -486,6 +508,50 @@ async function recordPaidStartMix({
   });
 }
 
+async function emitBillingPaymentFailed(args: {
+  invoice: Stripe.Invoice;
+  customerId: string;
+  userIds: string[];
+  orgId?: string;
+  tier?: SubscriptionTier | null;
+  price?: Stripe.Price;
+  lifecycle: BillingFailureProperties["billing_failure_lifecycle"];
+}) {
+  if (args.userIds.length === 0) return;
+
+  const failureProperties = subscriptionPaymentFailureProperties({
+    invoice: args.invoice,
+    lifecycle: args.lifecycle,
+  });
+
+  for (const uid of args.userIds) {
+    phLogger.event(
+      PAID_FUNNEL_EVENTS.billingPaymentFailed,
+      paidFunnelProperties({
+        userId: uid,
+        org_id: args.orgId,
+        subscription_tier: args.tier,
+        plan: args.price?.lookup_key,
+        billing_interval: priceBillingInterval(args.price),
+        billing_interval_count: args.price?.recurring?.interval_count,
+        stripe_customer_id: args.customerId,
+        stripe_subscription_id:
+          invoiceSubscriptionId(args.invoice) ??
+          stripeObjectId(
+            (
+              args.invoice as unknown as {
+                subscription?: string | { id?: string } | null;
+              }
+            ).subscription,
+          ),
+        stripe_price_id: args.price?.id,
+        ...failureProperties,
+        $insert_id: `${PAID_FUNNEL_EVENTS.billingPaymentFailed}:${args.lifecycle}:${args.invoice.id}:${uid}`,
+      }),
+    );
+  }
+}
+
 // =============================================================================
 // Event Handlers
 // =============================================================================
@@ -778,6 +844,69 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
   if (tier === "team" && orgId) {
     await clearOrgRemovedUsage(orgId);
   }
+}
+
+async function handleInvoicePaymentFailed(
+  invoice: Stripe.Invoice,
+): Promise<void> {
+  const subscriptionId = invoiceSubscriptionId(invoice);
+  if (!subscriptionId) return;
+
+  const customerId =
+    typeof invoice.customer === "string"
+      ? invoice.customer
+      : invoice.customer?.id;
+
+  if (!customerId) {
+    console.error(
+      "[Subscription Webhook] invoice.payment_failed missing customer ID:",
+      invoice.id,
+    );
+    return;
+  }
+
+  const customerResult = await resolveUserIdsFromCustomer(customerId);
+  const { userIds, orgId } = customerResult;
+
+  if (customerResult.reason === "legacy_user_metadata") {
+    console.info(
+      `[Subscription Webhook] invoice.payment_failed: skipping legacy customer invoice ${invoice.id} for customer ${customerId}`,
+    );
+    return;
+  }
+
+  if (userIds.length === 0) {
+    console.error(
+      `[Subscription Webhook] Could not resolve users (${customerResult.reason ?? "unknown"}) for failed invoice ${invoice.id}`,
+    );
+    return;
+  }
+
+  const resolved = await resolveSubscription(subscriptionId);
+  if (resolved?.kind === "legacy_pentestgpt") {
+    console.info(
+      `[Subscription Webhook] invoice.payment_failed: skipping legacy PentestGPT subscription ${subscriptionId} for invoice ${invoice.id}`,
+    );
+    return;
+  }
+
+  const expandedInvoice = (invoice as unknown as { payment_intent?: unknown })
+    .payment_intent
+    ? invoice
+    : ((await retrieveInvoiceForFailureAnalytics(invoice.id)) ?? invoice);
+  const subscription =
+    resolved?.kind === "resolved" ? resolved.subscription : undefined;
+  const price = subscription?.items?.data[0]?.price;
+
+  await emitBillingPaymentFailed({
+    invoice: expandedInvoice,
+    customerId,
+    userIds,
+    orgId: orgId ?? undefined,
+    tier: resolved?.kind === "resolved" ? resolved.tier : undefined,
+    price,
+    lifecycle: "invoice_payment_failed",
+  });
 }
 
 /** Handle checkout.session.completed — attach Checkout Session IDs to saved referral attribution. */
@@ -1180,6 +1309,17 @@ async function handleSubscriptionDeleted(
   }
 
   const cancellationReason = subscription.cancellation_details?.reason ?? null;
+  const latestInvoiceId = stripeObjectId(subscription.latest_invoice);
+  const failureInvoice =
+    cancellationReason === "payment_failed" && latestInvoiceId
+      ? await retrieveInvoiceForFailureAnalytics(latestInvoiceId)
+      : null;
+  const failureProperties = failureInvoice
+    ? subscriptionPaymentFailureProperties({
+        invoice: failureInvoice,
+        lifecycle: "subscription_deleted",
+      })
+    : undefined;
 
   console.log(
     `[Subscription Webhook] subscription.deleted: tier ${tier ?? "unknown"} cancelled for ${userIds.length} user(s) (reason: ${cancellationReason ?? "none"})`,
@@ -1201,7 +1341,20 @@ async function handleSubscriptionDeleted(
       tier,
       org_id: orgId,
       cancellation_reason: cancellationReason,
+      ...(failureProperties ?? {}),
       $set: { subscription_tier: "free" },
+    });
+  }
+
+  if (failureInvoice) {
+    await emitBillingPaymentFailed({
+      invoice: failureInvoice,
+      customerId,
+      userIds,
+      orgId: orgId ?? undefined,
+      tier,
+      price,
+      lifecycle: "subscription_deleted",
     });
   }
 
@@ -1222,7 +1375,8 @@ async function handleSubscriptionDeleted(
  * Configure in Stripe Dashboard:
  * - Endpoint URL: https://your-domain.com/api/subscription/webhook
  * - Events: checkout.session.completed, invoice.paid,
- *   customer.subscription.updated, customer.subscription.deleted
+ *   invoice.payment_failed, customer.subscription.updated,
+ *   customer.subscription.deleted
  */
 export async function POST(req: NextRequest) {
   const body = await req.text();
@@ -1319,12 +1473,15 @@ export async function POST(req: NextRequest) {
       await handleInvoicePaid(event.data.object as Stripe.Invoice);
       break;
     }
+    case "invoice.payment_failed": {
+      await handleInvoicePaymentFailed(event.data.object as Stripe.Invoice);
+      break;
+    }
     case "customer.subscription.updated": {
       await handleSubscriptionUpdated(
         event.data.object as Stripe.Subscription,
         event.data.previous_attributes as
-          | Partial<Stripe.Subscription>
-          | undefined,
+          Partial<Stripe.Subscription> | undefined,
       );
       break;
     }

--- a/docs/paid-funnel-analytics.md
+++ b/docs/paid-funnel-analytics.md
@@ -16,6 +16,10 @@ Paid funnel events use stable snake_case event names. Most events include
 - `subscription_started`: Stripe confirmed a new paid subscription invoice.
 - `subscription_changed`: Stripe confirmed a tier change on an existing
   subscription.
+- `billing_payment_failed`: Stripe confirmed a subscription invoice payment
+  failure or a payment-failed subscription deletion. Use this to separate
+  renewal quality, bank declines, Radar blocks, subscription updates, and
+  other involuntary churn causes.
 - `limit_hit`: a chat or agent request was blocked by a free or paid limit.
 - `monthly_cap_hit`: legacy paid-only monthly cap event kept for existing
   dashboards.
@@ -69,6 +73,15 @@ Paid funnel events use stable snake_case event names. Most events include
   or payment guardrail rather than the included monthly bucket alone.
 - `paid_monthly_exhaustion`: true for paid users whose included monthly bucket
   is exhausted and can be resolved through add-credit/upgrade flow.
+- Billing-failure events include `billing_failure_lifecycle`
+  (`invoice_payment_failed` or `subscription_deleted`),
+  `billing_failure_stage` (`first_payment`, `renewal`,
+  `subscription_update`, etc.), `billing_failure_group`
+  (`insufficient_funds`, `transaction_not_allowed`, `stripe_risk_block`,
+  `authentication_failed`, etc.), Stripe invoice/payment ids, attempt count,
+  amount fields, decline/outcome codes, and coarse payment method metadata
+  such as card country/funding. Do not log last4, emails, names, or billing
+  addresses.
 - Agent-first onboarding events include `first_experience_event_version`,
   `eligible_subscription_tier`, `selected_subscription_tier`,
   `selection_reason`, `default_applied`, `saved_mode_present`,
@@ -105,6 +118,10 @@ Paid funnel events use stable snake_case event names. Most events include
   `agent_run_spend_cap_hit -> subscription_cancelled`, grouped by
   `agent_run_spend_cap_continue_clicked`, `cap_basis`, and
   `cancellation_reason`.
+- Involuntary churn:
+  `billing_payment_failed -> subscription_cancelled`, grouped by
+  `billing_failure_stage`, `billing_failure_group`, `billing_reason`,
+  `card_country`, `subscription_tier`, and `attempt_count`.
 - Referral revenue:
   `referred_signup_attributed -> referred_user_paid_conversion`, grouped by
   `referral_code`.

--- a/lib/analytics/paid-funnel.ts
+++ b/lib/analytics/paid-funnel.ts
@@ -14,6 +14,7 @@ export const PAID_FUNNEL_EVENTS = {
   cancellationReasonSubmitted: "cancellation_reason_free_text_submitted",
   cancellationCompleted: "cancellation_completed",
   cancellationReversed: "cancellation_reversed",
+  billingPaymentFailed: "billing_payment_failed",
   limitHit: "limit_hit",
   paidDailyFreeAllowanceImpressed: "paid_daily_free_allowance_impressed",
   paidDailyFreeAllowanceClicked: "paid_daily_free_allowance_clicked",

--- a/lib/billing/subscription-payment-failure.ts
+++ b/lib/billing/subscription-payment-failure.ts
@@ -1,0 +1,212 @@
+import type Stripe from "stripe";
+
+export type BillingFailureLifecycle =
+  "invoice_payment_failed" | "subscription_deleted";
+
+export type BillingFailureProperties = {
+  billing_failure_lifecycle: BillingFailureLifecycle;
+  billing_failure_stage: string;
+  billing_failure_group: string;
+  billing_reason?: string;
+  invoice_status?: string | null;
+  collection_method?: string | null;
+  attempt_count?: number;
+  next_payment_attempt_present?: boolean;
+  amount_due_dollars?: number;
+  amount_remaining_dollars?: number;
+  currency?: string | null;
+  stripe_invoice_id: string;
+  stripe_payment_intent_id?: string;
+  stripe_charge_id?: string;
+  failure_code?: string | null;
+  decline_code?: string | null;
+  outcome_type?: string | null;
+  outcome_reason?: string | null;
+  network_status?: string | null;
+  network_decline_code?: string | null;
+  risk_level?: string | null;
+  payment_method_type?: string;
+  card_brand?: string | null;
+  card_country?: string | null;
+  card_funding?: string | null;
+};
+
+const centsToDollars = (
+  amount: number | null | undefined,
+): number | undefined =>
+  typeof amount === "number" && Number.isFinite(amount)
+    ? amount / 100
+    : undefined;
+
+export function stripeObjectId(
+  value: string | { id?: string | null } | null | undefined,
+): string | undefined {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (
+    value &&
+    typeof value === "object" &&
+    typeof value.id === "string" &&
+    value.id.length > 0
+  ) {
+    return value.id;
+  }
+  return undefined;
+}
+
+export function invoiceSubscriptionId(
+  invoice: Stripe.Invoice,
+): string | undefined {
+  const parentSubscription = invoice.parent?.subscription_details?.subscription;
+  const parentSubscriptionId = stripeObjectId(parentSubscription);
+  if (parentSubscriptionId) return parentSubscriptionId;
+
+  return stripeObjectId(
+    (invoice as unknown as { subscription?: string | { id?: string } | null })
+      .subscription,
+  );
+}
+
+function expandedPaymentIntent(
+  invoice: Stripe.Invoice,
+): Stripe.PaymentIntent | undefined {
+  const paymentIntent = (
+    invoice as unknown as {
+      payment_intent?: string | Stripe.PaymentIntent | null;
+    }
+  ).payment_intent;
+
+  return paymentIntent && typeof paymentIntent === "object"
+    ? paymentIntent
+    : undefined;
+}
+
+function paymentIntentId(invoice: Stripe.Invoice): string | undefined {
+  const paymentIntent = (
+    invoice as unknown as {
+      payment_intent?: string | Stripe.PaymentIntent | null;
+    }
+  ).payment_intent;
+
+  return stripeObjectId(paymentIntent);
+}
+
+function latestCharge(
+  paymentIntent: Stripe.PaymentIntent | undefined,
+): Stripe.Charge | undefined {
+  const charge = paymentIntent?.latest_charge;
+  return charge && typeof charge === "object" ? charge : undefined;
+}
+
+function normalizedBillingStage(invoice: Stripe.Invoice): string {
+  const reason = invoice.billing_reason;
+  if (reason === "subscription_create") return "first_payment";
+  if (reason === "subscription_cycle") return "renewal";
+  if (reason === "subscription_update") return "subscription_update";
+  if (reason === "subscription_threshold") return "subscription_threshold";
+  if (reason === "manual") return "manual_invoice";
+  return reason ?? "unknown";
+}
+
+function failureGroup(args: {
+  failureCode?: string | null;
+  declineCode?: string | null;
+  outcomeType?: string | null;
+  outcomeReason?: string | null;
+}): string {
+  const values = [
+    args.failureCode,
+    args.declineCode,
+    args.outcomeType,
+    args.outcomeReason,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .map((value) => value.toLowerCase());
+
+  if (
+    values.includes("blocked") ||
+    values.includes("highest_risk_level") ||
+    values.includes("elevated_risk_level")
+  ) {
+    return "stripe_risk_block";
+  }
+  if (values.includes("insufficient_funds")) return "insufficient_funds";
+  if (values.includes("transaction_not_allowed")) {
+    return "transaction_not_allowed";
+  }
+  if (values.includes("do_not_honor")) return "do_not_honor";
+  if (
+    values.includes("authentication_required") ||
+    values.includes("payment_intent_authentication_failure")
+  ) {
+    return "authentication_failed";
+  }
+  if (values.includes("expired_card")) return "expired_card";
+  if (values.includes("incorrect_number")) return "incorrect_card_details";
+  if (values.includes("generic_decline")) return "generic_decline";
+  if (
+    values.includes("link_connection_closed") ||
+    values.includes("payment_method_unactivated") ||
+    values.includes("payment_method_provider_decline")
+  ) {
+    return "payment_method_unavailable";
+  }
+  if (values.includes("card_declined")) return "card_declined";
+  return "unknown";
+}
+
+export function subscriptionPaymentFailureProperties({
+  invoice,
+  lifecycle,
+}: {
+  invoice: Stripe.Invoice;
+  lifecycle: BillingFailureLifecycle;
+}): BillingFailureProperties {
+  const paymentIntent = expandedPaymentIntent(invoice);
+  const charge = latestCharge(paymentIntent);
+  const lastPaymentError = paymentIntent?.last_payment_error;
+  const card = charge?.payment_method_details?.card;
+  const paymentMethodType =
+    charge?.payment_method_details?.type ??
+    lastPaymentError?.payment_method?.type ??
+    undefined;
+  const failureCode = charge?.failure_code ?? lastPaymentError?.code;
+  const declineCode =
+    lastPaymentError?.decline_code ??
+    (charge as Stripe.Charge | undefined)?.outcome?.network_decline_code ??
+    undefined;
+  const outcome = charge?.outcome;
+
+  return {
+    billing_failure_lifecycle: lifecycle,
+    billing_failure_stage: normalizedBillingStage(invoice),
+    billing_failure_group: failureGroup({
+      failureCode,
+      declineCode,
+      outcomeType: outcome?.type,
+      outcomeReason: outcome?.reason,
+    }),
+    billing_reason: invoice.billing_reason ?? undefined,
+    invoice_status: invoice.status,
+    collection_method: invoice.collection_method,
+    attempt_count: invoice.attempt_count ?? undefined,
+    next_payment_attempt_present: Boolean(invoice.next_payment_attempt),
+    amount_due_dollars: centsToDollars(invoice.amount_due),
+    amount_remaining_dollars: centsToDollars(invoice.amount_remaining),
+    currency: invoice.currency,
+    stripe_invoice_id: invoice.id,
+    stripe_payment_intent_id: paymentIntentId(invoice),
+    stripe_charge_id:
+      stripeObjectId(charge) ?? stripeObjectId(lastPaymentError?.charge),
+    failure_code: failureCode,
+    decline_code: declineCode,
+    outcome_type: outcome?.type,
+    outcome_reason: outcome?.reason,
+    network_status: outcome?.network_status,
+    network_decline_code: outcome?.network_decline_code,
+    risk_level: outcome?.risk_level,
+    payment_method_type: paymentMethodType,
+    card_brand: card?.brand,
+    card_country: card?.country,
+    card_funding: card?.funding,
+  };
+}


### PR DESCRIPTION
## Summary
- add classified billing failure analytics for subscription invoice failures and payment-failed subscription deletions
- enrich payment-failed subscription churn with invoice/payment intent/charge outcome fields for PostHog analysis
- document the new `billing_payment_failed` event and add webhook regression coverage

## Verification
- pnpm typecheck
- pnpm jest app/api/subscription/webhook/__tests__/route.test.ts --runInBand
- pnpm exec eslint app/api/subscription/webhook/route.ts app/api/subscription/webhook/__tests__/route.test.ts lib/billing/subscription-payment-failure.ts lib/analytics/paid-funnel.ts
- pnpm exec prettier --check app/api/subscription/webhook/route.ts app/api/subscription/webhook/__tests__/route.test.ts lib/billing/subscription-payment-failure.ts lib/analytics/paid-funnel.ts docs/paid-funnel-analytics.md
- pre-commit hook: full pnpm typecheck and full pnpm test (213 suites, 2157 tests)

## Manual / Ops
- Confirm the Stripe subscription webhook endpoint is subscribed to `invoice.payment_failed`.
- After deploy, verify PostHog receives `billing_payment_failed` grouped by `billing_failure_stage` and `billing_failure_group`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new paid-funnel analytics event for Stripe-confirmed billing payment failures.
  * Extended webhook analytics to classify invoice payment failures and payment-failed subscription cancellations with detailed billing-failure context.

* **Bug Fixes**
  * Ensures subscription cancellation analytics are enriched with the correct billing-failure attribution when the cancellation reason is payment-related.

* **Documentation**
  * Updated paid-funnel analytics documentation with the new billing failure semantics, properties, and involuntary churn readout mapping.

* **Tests**
  * Expanded webhook test coverage for additional Stripe failure analytics scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->