### PR TITLE
Route Trigger agent runs by user region

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -990,9 +990,8 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
   });
 
   test("agent-long only passes explicit Trigger.dev region when mapped", () => {
-    const routingIdx = routeSrc.indexOf(
-      "getTriggerRegionForVercelRequest(req)",
-    );
+    const routingIdx = routeSrc.indexOf("getTriggerRegionForVercelRequest(");
+    const userLocationIdx = routeSrc.indexOf("userLocation", routingIdx);
     const triggerIdx = routeSrc.indexOf("tasks.trigger", routingIdx);
     const regionOptionIdx = routeSrc.indexOf(
       "...(triggerRegion ? { region: triggerRegion } : {})",
@@ -1000,6 +999,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     );
 
     expect(routingIdx).toBeGreaterThan(-1);
+    expect(userLocationIdx).toBeGreaterThan(routingIdx);
     expect(triggerIdx).toBeGreaterThan(routingIdx);
     expect(regionOptionIdx).toBeGreaterThan(triggerIdx);
     expect(routeSrc).not.toMatch(/vercelIpContinent|vercelIpCountry/);

--- a/lib/api/__tests__/trigger-region.test.ts
+++ b/lib/api/__tests__/trigger-region.test.ts
@@ -21,19 +21,12 @@ describe("getTriggerRegionForVercelRequest", () => {
     ).toBe("eu-central-1");
   });
 
-  test("routes European parsed locations to eu-central-1", () => {
-    expect(
-      getTriggerRegionForVercelRequest(requestWithHeaders({}), {
-        country: "DE",
-      }),
-    ).toBe("eu-central-1");
-  });
-
   test("routes US east requests to us-east-1", () => {
     expect(
       getTriggerRegionForVercelRequest(requestWithHeaders({}), {
         country: "US",
-        countryRegion: "NY",
+        latitude: "40.7128",
+        longitude: "-74.006",
       }),
     ).toBe("us-east-1");
   });
@@ -42,7 +35,8 @@ describe("getTriggerRegionForVercelRequest", () => {
     expect(
       getTriggerRegionForVercelRequest(requestWithHeaders({}), {
         country: "US",
-        countryRegion: "CA",
+        latitude: "37.7749",
+        longitude: "-122.4194",
       }),
     ).toBe("us-west-2");
   });
@@ -51,7 +45,8 @@ describe("getTriggerRegionForVercelRequest", () => {
     expect(
       getTriggerRegionForVercelRequest(requestWithHeaders({}), {
         country: "CA",
-        countryRegion: "ON",
+        latitude: "43.6532",
+        longitude: "-79.3832",
       }),
     ).toBe("us-east-1");
   });
@@ -60,26 +55,39 @@ describe("getTriggerRegionForVercelRequest", () => {
     expect(
       getTriggerRegionForVercelRequest(requestWithHeaders({}), {
         country: "CA",
-        countryRegion: "BC",
+        latitude: "49.2827",
+        longitude: "-123.1207",
       }),
     ).toBe("us-west-2");
   });
 
-  test("uses coordinates before coarse subdivisions", () => {
-    expect(
-      getTriggerRegionForVercelRequest(requestWithHeaders({}), {
-        country: "US",
-        countryRegion: "NY",
-        latitude: "47.6062",
-        longitude: "-122.3321",
-      }),
-    ).toBe("us-west-2");
-  });
-
-  test("uses the Vercel request region when user geography is unavailable", () => {
+  test("uses Vercel coordinate headers before edge-region fallback", () => {
     expect(
       getTriggerRegionForVercelRequest(
         requestWithHeaders({
+          "x-vercel-id": "iad1::iad1::abc123",
+          "x-vercel-ip-continent": "NA",
+          "x-vercel-ip-latitude": "47.6062",
+          "x-vercel-ip-longitude": "-122.3321",
+        }),
+      ),
+    ).toBe("us-west-2");
+  });
+
+  test("uses the Vercel request region when coordinates are unavailable", () => {
+    expect(
+      getTriggerRegionForVercelRequest(requestWithHeaders({}), {
+        country: "US",
+        region: "pdx1",
+      }),
+    ).toBe("us-west-2");
+  });
+
+  test("uses x-vercel-id when coordinates and parsed location are unavailable", () => {
+    expect(
+      getTriggerRegionForVercelRequest(
+        requestWithHeaders({
+          "x-vercel-ip-continent": "NA",
           "x-vercel-id": "pdx1::iad1::abc123",
         }),
       ),

--- a/lib/api/__tests__/trigger-region.test.ts
+++ b/lib/api/__tests__/trigger-region.test.ts
@@ -47,6 +47,24 @@ describe("getTriggerRegionForVercelRequest", () => {
     ).toBe("us-west-2");
   });
 
+  test("routes Canadian east requests to us-east-1", () => {
+    expect(
+      getTriggerRegionForVercelRequest(requestWithHeaders({}), {
+        country: "CA",
+        countryRegion: "ON",
+      }),
+    ).toBe("us-east-1");
+  });
+
+  test("routes Canadian west requests to us-west-2", () => {
+    expect(
+      getTriggerRegionForVercelRequest(requestWithHeaders({}), {
+        country: "CA",
+        countryRegion: "BC",
+      }),
+    ).toBe("us-west-2");
+  });
+
   test("uses coordinates before coarse subdivisions", () => {
     expect(
       getTriggerRegionForVercelRequest(requestWithHeaders({}), {
@@ -68,7 +86,7 @@ describe("getTriggerRegionForVercelRequest", () => {
     ).toBe("us-west-2");
   });
 
-  test("uses the dashboard default for non-European, non-North-American locations", () => {
+  test("returns undefined for non-European, non-North-American locations", () => {
     expect(
       getTriggerRegionForVercelRequest(requestWithHeaders({}), {
         country: "IN",

--- a/lib/api/__tests__/trigger-region.test.ts
+++ b/lib/api/__tests__/trigger-region.test.ts
@@ -21,13 +21,61 @@ describe("getTriggerRegionForVercelRequest", () => {
     ).toBe("eu-central-1");
   });
 
-  test("uses the dashboard default region for North American requests", () => {
+  test("routes European parsed locations to eu-central-1", () => {
+    expect(
+      getTriggerRegionForVercelRequest(requestWithHeaders({}), {
+        country: "DE",
+      }),
+    ).toBe("eu-central-1");
+  });
+
+  test("routes US east requests to us-east-1", () => {
+    expect(
+      getTriggerRegionForVercelRequest(requestWithHeaders({}), {
+        country: "US",
+        countryRegion: "NY",
+      }),
+    ).toBe("us-east-1");
+  });
+
+  test("routes US west requests to us-west-2", () => {
+    expect(
+      getTriggerRegionForVercelRequest(requestWithHeaders({}), {
+        country: "US",
+        countryRegion: "CA",
+      }),
+    ).toBe("us-west-2");
+  });
+
+  test("uses coordinates before coarse subdivisions", () => {
+    expect(
+      getTriggerRegionForVercelRequest(requestWithHeaders({}), {
+        country: "US",
+        countryRegion: "NY",
+        latitude: "47.6062",
+        longitude: "-122.3321",
+      }),
+    ).toBe("us-west-2");
+  });
+
+  test("uses the Vercel request region when user geography is unavailable", () => {
     expect(
       getTriggerRegionForVercelRequest(
         requestWithHeaders({
-          "x-vercel-ip-continent": "NA",
+          "x-vercel-id": "pdx1::iad1::abc123",
         }),
       ),
+    ).toBe("us-west-2");
+  });
+
+  test("uses the dashboard default for non-European, non-North-American locations", () => {
+    expect(
+      getTriggerRegionForVercelRequest(requestWithHeaders({}), {
+        country: "IN",
+        latitude: "19.076",
+        longitude: "72.8777",
+        region: "pdx1",
+      }),
     ).toBeUndefined();
   });
 

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -198,7 +198,7 @@ export const createAgentTriggerPost =
         );
       await assertUserCanMakeCostIncurringRequest(userId);
       const userLocation = geolocation(req);
-      const triggerRegion = getTriggerRegionForVercelRequest(req);
+      const triggerRegion = getTriggerRegionForVercelRequest(req, userLocation);
 
       assertFreeAgentGates({
         mode: "agent",

--- a/lib/api/trigger-region.ts
+++ b/lib/api/trigger-region.ts
@@ -1,16 +1,327 @@
-export type TriggerRunRegion = "eu-central-1";
+export type TriggerRunRegion = "eu-central-1" | "us-east-1" | "us-west-2";
 
-function normalizeVercelHeader(value: string | null): string | null {
+type VercelGeoLocation = {
+  country?: string;
+  countryRegion?: string;
+  region?: string;
+  latitude?: string;
+  longitude?: string;
+};
+
+const EUROPEAN_COUNTRY_CODES = new Set([
+  "AD",
+  "AL",
+  "AT",
+  "AX",
+  "BA",
+  "BE",
+  "BG",
+  "BY",
+  "CH",
+  "CY",
+  "CZ",
+  "DE",
+  "DK",
+  "EE",
+  "ES",
+  "FI",
+  "FO",
+  "FR",
+  "GB",
+  "GG",
+  "GI",
+  "GR",
+  "HR",
+  "HU",
+  "IE",
+  "IM",
+  "IS",
+  "IT",
+  "JE",
+  "LI",
+  "LT",
+  "LU",
+  "LV",
+  "MC",
+  "MD",
+  "ME",
+  "MK",
+  "MT",
+  "NL",
+  "NO",
+  "PL",
+  "PT",
+  "RO",
+  "RS",
+  "SE",
+  "SI",
+  "SJ",
+  "SK",
+  "SM",
+  "TR",
+  "UA",
+  "VA",
+  "XK",
+]);
+
+const NORTH_AMERICAN_COUNTRY_CODES = new Set(["CA", "MX", "US"]);
+
+const WESTERN_US_SUBDIVISIONS = new Set([
+  "AK",
+  "AS",
+  "AZ",
+  "CA",
+  "CO",
+  "GU",
+  "HI",
+  "ID",
+  "MP",
+  "MT",
+  "NM",
+  "NV",
+  "OR",
+  "UT",
+  "WA",
+  "WY",
+]);
+
+const US_SUBDIVISIONS = new Set([
+  "AK",
+  "AL",
+  "AR",
+  "AS",
+  "AZ",
+  "CA",
+  "CO",
+  "CT",
+  "DC",
+  "DE",
+  "FL",
+  "GA",
+  "GU",
+  "HI",
+  "IA",
+  "ID",
+  "IL",
+  "IN",
+  "KS",
+  "KY",
+  "LA",
+  "MA",
+  "MD",
+  "ME",
+  "MI",
+  "MN",
+  "MO",
+  "MP",
+  "MS",
+  "MT",
+  "NC",
+  "ND",
+  "NE",
+  "NH",
+  "NJ",
+  "NM",
+  "NV",
+  "NY",
+  "OH",
+  "OK",
+  "OR",
+  "PA",
+  "PR",
+  "RI",
+  "SC",
+  "SD",
+  "TN",
+  "TX",
+  "UM",
+  "UT",
+  "VA",
+  "VI",
+  "VT",
+  "WA",
+  "WI",
+  "WV",
+  "WY",
+]);
+
+const WESTERN_CANADA_SUBDIVISIONS = new Set([
+  "AB",
+  "BC",
+  "NT",
+  "NU",
+  "SK",
+  "YT",
+]);
+
+const CANADA_SUBDIVISIONS = new Set([
+  "AB",
+  "BC",
+  "MB",
+  "NB",
+  "NL",
+  "NS",
+  "NT",
+  "NU",
+  "ON",
+  "PE",
+  "QC",
+  "SK",
+  "YT",
+]);
+
+const VERCEL_REGION_TO_US_TRIGGER_REGION = new Map<string, TriggerRunRegion>([
+  ["CLE1", "us-east-1"],
+  ["IAD1", "us-east-1"],
+  ["YUL1", "us-east-1"],
+  ["PDX1", "us-west-2"],
+  ["SFO1", "us-west-2"],
+]);
+
+const US_EAST_1_COORDINATES = { latitude: 39.0438, longitude: -77.4874 };
+const US_WEST_2_COORDINATES = { latitude: 45.8399, longitude: -119.7006 };
+
+function normalizeVercelValue(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed.toUpperCase() : null;
 }
 
-export function getTriggerRegionForVercelRequest(request: {
-  headers: Headers;
-}): TriggerRunRegion | undefined {
-  const continent = normalizeVercelHeader(
+function parseCoordinate(value: string | null | undefined): number | null {
+  const parsed = Number.parseFloat(value ?? "");
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+function distanceKm(
+  from: { latitude: number; longitude: number },
+  to: { latitude: number; longitude: number },
+): number {
+  const earthRadiusKm = 6371;
+  const latitudeDelta = toRadians(to.latitude - from.latitude);
+  const longitudeDelta = toRadians(to.longitude - from.longitude);
+  const fromLatitude = toRadians(from.latitude);
+  const toLatitude = toRadians(to.latitude);
+
+  const haversine =
+    Math.sin(latitudeDelta / 2) ** 2 +
+    Math.cos(fromLatitude) *
+      Math.cos(toLatitude) *
+      Math.sin(longitudeDelta / 2) ** 2;
+
+  return (
+    2 *
+    earthRadiusKm *
+    Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine))
+  );
+}
+
+function getClosestUsTriggerRegion(
+  latitude: number | null,
+  longitude: number | null,
+): TriggerRunRegion | undefined {
+  if (latitude === null || longitude === null) return undefined;
+
+  const userCoordinates = { latitude, longitude };
+  const eastDistance = distanceKm(userCoordinates, US_EAST_1_COORDINATES);
+  const westDistance = distanceKm(userCoordinates, US_WEST_2_COORDINATES);
+
+  return eastDistance <= westDistance ? "us-east-1" : "us-west-2";
+}
+
+function getUsTriggerRegionForSubdivision(
+  country: string | null,
+  subdivision: string | null,
+): TriggerRunRegion | undefined {
+  if (!country || !subdivision) return undefined;
+
+  if (country === "US" && US_SUBDIVISIONS.has(subdivision)) {
+    return WESTERN_US_SUBDIVISIONS.has(subdivision) ? "us-west-2" : "us-east-1";
+  }
+
+  if (country === "CA" && CANADA_SUBDIVISIONS.has(subdivision)) {
+    return WESTERN_CANADA_SUBDIVISIONS.has(subdivision)
+      ? "us-west-2"
+      : "us-east-1";
+  }
+
+  return undefined;
+}
+
+function getVercelRegionFromId(value: string | null): string | null {
+  const normalizedSegments = value
+    ?.split("::")
+    .map((segment) => normalizeVercelValue(segment));
+
+  return (
+    normalizedSegments?.find(
+      (segment): segment is string =>
+        !!segment && VERCEL_REGION_TO_US_TRIGGER_REGION.has(segment),
+    ) ?? null
+  );
+}
+
+function shouldRouteToUsTriggerRegion(
+  continent: string | null,
+  country: string | null,
+): boolean {
+  return (
+    continent === "NA" ||
+    (!!country && NORTH_AMERICAN_COUNTRY_CODES.has(country))
+  );
+}
+
+export function getTriggerRegionForVercelRequest(
+  request: {
+    headers: Headers;
+  },
+  userLocation?: VercelGeoLocation,
+): TriggerRunRegion | undefined {
+  const continent = normalizeVercelValue(
     request.headers.get("x-vercel-ip-continent"),
   );
+  const country = normalizeVercelValue(
+    userLocation?.country ?? request.headers.get("x-vercel-ip-country"),
+  );
 
-  return continent === "EU" ? "eu-central-1" : undefined;
+  if (continent === "EU" || (country && EUROPEAN_COUNTRY_CODES.has(country))) {
+    return "eu-central-1";
+  }
+
+  if (shouldRouteToUsTriggerRegion(continent, country)) {
+    const latitude = parseCoordinate(
+      userLocation?.latitude ?? request.headers.get("x-vercel-ip-latitude"),
+    );
+    const longitude = parseCoordinate(
+      userLocation?.longitude ?? request.headers.get("x-vercel-ip-longitude"),
+    );
+    const coordinateRegion = getClosestUsTriggerRegion(latitude, longitude);
+    if (coordinateRegion) return coordinateRegion;
+
+    const countryRegion = normalizeVercelValue(
+      userLocation?.countryRegion ??
+        request.headers.get("x-vercel-ip-country-region"),
+    );
+    const subdivisionRegion = getUsTriggerRegionForSubdivision(
+      country,
+      countryRegion,
+    );
+    if (subdivisionRegion) return subdivisionRegion;
+  }
+
+  const vercelRegion =
+    normalizeVercelValue(userLocation?.region) ??
+    getVercelRegionFromId(request.headers.get("x-vercel-id"));
+
+  if (!vercelRegion) return undefined;
+  if (
+    !shouldRouteToUsTriggerRegion(continent, country) &&
+    (continent || country)
+  ) {
+    return undefined;
+  }
+
+  return VERCEL_REGION_TO_US_TRIGGER_REGION.get(vercelRegion);
 }

--- a/lib/api/trigger-region.ts
+++ b/lib/api/trigger-region.ts
@@ -1,176 +1,22 @@
+import type { Geo } from "@vercel/functions";
+
 export type TriggerRunRegion = "eu-central-1" | "us-east-1" | "us-west-2";
 
-type VercelGeoLocation = {
-  country?: string;
-  countryRegion?: string;
-  region?: string;
-  latitude?: string;
-  longitude?: string;
+type VercelGeoLocation = Pick<
+  Geo,
+  "country" | "region" | "latitude" | "longitude"
+>;
+
+type Coordinates = {
+  latitude: number;
+  longitude: number;
 };
 
-const EUROPEAN_COUNTRY_CODES = new Set([
-  "AD",
-  "AL",
-  "AT",
-  "AX",
-  "BA",
-  "BE",
-  "BG",
-  "BY",
-  "CH",
-  "CY",
-  "CZ",
-  "DE",
-  "DK",
-  "EE",
-  "ES",
-  "FI",
-  "FO",
-  "FR",
-  "GB",
-  "GG",
-  "GI",
-  "GR",
-  "HR",
-  "HU",
-  "IE",
-  "IM",
-  "IS",
-  "IT",
-  "JE",
-  "LI",
-  "LT",
-  "LU",
-  "LV",
-  "MC",
-  "MD",
-  "ME",
-  "MK",
-  "MT",
-  "NL",
-  "NO",
-  "PL",
-  "PT",
-  "RO",
-  "RS",
-  "SE",
-  "SI",
-  "SJ",
-  "SK",
-  "SM",
-  "TR",
-  "UA",
-  "VA",
-  "XK",
-]);
+type UsTriggerRunRegion = Exclude<TriggerRunRegion, "eu-central-1">;
 
 const NORTH_AMERICAN_COUNTRY_CODES = new Set(["CA", "MX", "US"]);
 
-const WESTERN_US_SUBDIVISIONS = new Set([
-  "AK",
-  "AS",
-  "AZ",
-  "CA",
-  "CO",
-  "GU",
-  "HI",
-  "ID",
-  "MP",
-  "MT",
-  "NM",
-  "NV",
-  "OR",
-  "UT",
-  "WA",
-  "WY",
-]);
-
-const US_SUBDIVISIONS = new Set([
-  "AK",
-  "AL",
-  "AR",
-  "AS",
-  "AZ",
-  "CA",
-  "CO",
-  "CT",
-  "DC",
-  "DE",
-  "FL",
-  "GA",
-  "GU",
-  "HI",
-  "IA",
-  "ID",
-  "IL",
-  "IN",
-  "KS",
-  "KY",
-  "LA",
-  "MA",
-  "MD",
-  "ME",
-  "MI",
-  "MN",
-  "MO",
-  "MP",
-  "MS",
-  "MT",
-  "NC",
-  "ND",
-  "NE",
-  "NH",
-  "NJ",
-  "NM",
-  "NV",
-  "NY",
-  "OH",
-  "OK",
-  "OR",
-  "PA",
-  "PR",
-  "RI",
-  "SC",
-  "SD",
-  "TN",
-  "TX",
-  "UM",
-  "UT",
-  "VA",
-  "VI",
-  "VT",
-  "WA",
-  "WI",
-  "WV",
-  "WY",
-]);
-
-const WESTERN_CANADA_SUBDIVISIONS = new Set([
-  "AB",
-  "BC",
-  "NT",
-  "NU",
-  "SK",
-  "YT",
-]);
-
-const CANADA_SUBDIVISIONS = new Set([
-  "AB",
-  "BC",
-  "MB",
-  "NB",
-  "NL",
-  "NS",
-  "NT",
-  "NU",
-  "ON",
-  "PE",
-  "QC",
-  "SK",
-  "YT",
-]);
-
-const VERCEL_REGION_TO_US_TRIGGER_REGION = new Map<string, TriggerRunRegion>([
+const VERCEL_REGION_TO_US_TRIGGER_REGION = new Map<string, UsTriggerRunRegion>([
   ["CLE1", "us-east-1"],
   ["IAD1", "us-east-1"],
   ["YUL1", "us-east-1"],
@@ -178,8 +24,10 @@ const VERCEL_REGION_TO_US_TRIGGER_REGION = new Map<string, TriggerRunRegion>([
   ["SFO1", "us-west-2"],
 ]);
 
-const US_EAST_1_COORDINATES = { latitude: 39.0438, longitude: -77.4874 };
-const US_WEST_2_COORDINATES = { latitude: 45.8399, longitude: -119.7006 };
+const US_TRIGGER_REGION_COORDINATES: Record<UsTriggerRunRegion, Coordinates> = {
+  "us-east-1": { latitude: 39.0438, longitude: -77.4874 },
+  "us-west-2": { latitude: 45.8399, longitude: -119.7006 },
+};
 
 function normalizeVercelValue(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
@@ -191,14 +39,27 @@ function parseCoordinate(value: string | null | undefined): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function getCoordinates(
+  request: { headers: Headers },
+  userLocation?: VercelGeoLocation,
+): Coordinates | null {
+  const latitude = parseCoordinate(
+    userLocation?.latitude ?? request.headers.get("x-vercel-ip-latitude"),
+  );
+  const longitude = parseCoordinate(
+    userLocation?.longitude ?? request.headers.get("x-vercel-ip-longitude"),
+  );
+
+  return latitude === null || longitude === null
+    ? null
+    : { latitude, longitude };
+}
+
 function toRadians(degrees: number): number {
   return (degrees * Math.PI) / 180;
 }
 
-function distanceKm(
-  from: { latitude: number; longitude: number },
-  to: { latitude: number; longitude: number },
-): number {
+function distanceKm(from: Coordinates, to: Coordinates): number {
   const earthRadiusKm = 6371;
   const latitudeDelta = toRadians(to.latitude - from.latitude);
   const longitudeDelta = toRadians(to.longitude - from.longitude);
@@ -219,51 +80,33 @@ function distanceKm(
 }
 
 function getClosestUsTriggerRegion(
-  latitude: number | null,
-  longitude: number | null,
-): TriggerRunRegion | undefined {
-  if (latitude === null || longitude === null) return undefined;
-
-  const userCoordinates = { latitude, longitude };
-  const eastDistance = distanceKm(userCoordinates, US_EAST_1_COORDINATES);
-  const westDistance = distanceKm(userCoordinates, US_WEST_2_COORDINATES);
+  coordinates: Coordinates,
+): UsTriggerRunRegion {
+  const eastDistance = distanceKm(
+    coordinates,
+    US_TRIGGER_REGION_COORDINATES["us-east-1"],
+  );
+  const westDistance = distanceKm(
+    coordinates,
+    US_TRIGGER_REGION_COORDINATES["us-west-2"],
+  );
 
   return eastDistance <= westDistance ? "us-east-1" : "us-west-2";
 }
 
-function getUsTriggerRegionForSubdivision(
-  country: string | null,
-  subdivision: string | null,
-): TriggerRunRegion | undefined {
-  if (!country || !subdivision) return undefined;
-
-  if (country === "US" && US_SUBDIVISIONS.has(subdivision)) {
-    return WESTERN_US_SUBDIVISIONS.has(subdivision) ? "us-west-2" : "us-east-1";
-  }
-
-  if (country === "CA" && CANADA_SUBDIVISIONS.has(subdivision)) {
-    return WESTERN_CANADA_SUBDIVISIONS.has(subdivision)
-      ? "us-west-2"
-      : "us-east-1";
-  }
-
-  return undefined;
-}
-
 function getVercelRegionFromId(value: string | null): string | null {
-  const normalizedSegments = value
-    ?.split("::")
-    .map((segment) => normalizeVercelValue(segment));
-
   return (
-    normalizedSegments?.find(
-      (segment): segment is string =>
-        !!segment && VERCEL_REGION_TO_US_TRIGGER_REGION.has(segment),
-    ) ?? null
+    value
+      ?.split("::")
+      .map((segment) => normalizeVercelValue(segment))
+      .find(
+        (segment): segment is string =>
+          !!segment && VERCEL_REGION_TO_US_TRIGGER_REGION.has(segment),
+      ) ?? null
   );
 }
 
-function shouldRouteToUsTriggerRegion(
+function isNorthAmericanRequest(
   continent: string | null,
   country: string | null,
 ): boolean {
@@ -282,46 +125,23 @@ export function getTriggerRegionForVercelRequest(
   const continent = normalizeVercelValue(
     request.headers.get("x-vercel-ip-continent"),
   );
+  if (continent === "EU") return "eu-central-1";
+
   const country = normalizeVercelValue(
     userLocation?.country ?? request.headers.get("x-vercel-ip-country"),
   );
-
-  if (continent === "EU" || (country && EUROPEAN_COUNTRY_CODES.has(country))) {
-    return "eu-central-1";
+  if (!isNorthAmericanRequest(continent, country)) {
+    return undefined;
   }
 
-  if (shouldRouteToUsTriggerRegion(continent, country)) {
-    const latitude = parseCoordinate(
-      userLocation?.latitude ?? request.headers.get("x-vercel-ip-latitude"),
-    );
-    const longitude = parseCoordinate(
-      userLocation?.longitude ?? request.headers.get("x-vercel-ip-longitude"),
-    );
-    const coordinateRegion = getClosestUsTriggerRegion(latitude, longitude);
-    if (coordinateRegion) return coordinateRegion;
-
-    const countryRegion = normalizeVercelValue(
-      userLocation?.countryRegion ??
-        request.headers.get("x-vercel-ip-country-region"),
-    );
-    const subdivisionRegion = getUsTriggerRegionForSubdivision(
-      country,
-      countryRegion,
-    );
-    if (subdivisionRegion) return subdivisionRegion;
-  }
+  const coordinates = getCoordinates(request, userLocation);
+  if (coordinates) return getClosestUsTriggerRegion(coordinates);
 
   const vercelRegion =
     normalizeVercelValue(userLocation?.region) ??
     getVercelRegionFromId(request.headers.get("x-vercel-id"));
 
-  if (!vercelRegion) return undefined;
-  if (
-    !shouldRouteToUsTriggerRegion(continent, country) &&
-    (continent || country)
-  ) {
-    return undefined;
-  }
-
-  return VERCEL_REGION_TO_US_TRIGGER_REGION.get(vercelRegion);
+  return vercelRegion
+    ? VERCEL_REGION_TO_US_TRIGGER_REGION.get(vercelRegion)
+    : undefined;
 }


### PR DESCRIPTION
## Summary
- expand Trigger.dev region routing to support eu-central-1, us-east-1, and us-west-2
- pass Vercel geolocation into the Trigger region mapper before queuing agent-long runs
- add tests for EU, US east/west, coordinate precedence, Vercel region fallback, and out-of-scope default behavior

## Validation
- pnpm test -- lib/api/__tests__/trigger-region.test.ts --runInBand
- pnpm test -- lib/api/__tests__/agent-long-contracts.test.ts --runInBand
- pnpm typecheck
- pnpm exec eslint lib/api/trigger-region.ts lib/api/__tests__/trigger-region.test.ts lib/api/agent-trigger-route.ts lib/api/__tests__/agent-long-contracts.test.ts
- pre-commit hook: pnpm typecheck && pnpm test

## Manual verification
- Automated validation is sufficient; this is backend-only routing logic and has no UI surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added geo-aware execution region routing that selects among EU and multiple US regions, choosing the closest US region when coordinates are available.
* **Bug Fixes**
  * Improved region resolution by prioritizing Vercel geo headers and incorporating user-provided location to reach correct region decisions, with safer fallback behavior when geo data is missing or invalid.
* **Tests**
  * Expanded unit test coverage for header precedence, coordinate-based routing, and “no region” outcomes across additional geographic scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->