### PR TITLE
Add retry handling and frontend exception enrichment

### DIFF
--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -257,6 +257,42 @@ describe("getChatById", () => {
     }
   });
 
+  it("retries Convex queue saturation failures before returning a chat", async () => {
+    const { getChatById, mockQuery } = await loadSaveMessageWithMocks();
+    const queueError = new Error(
+      "ExpiredInQueue: Too many concurrent requests",
+    );
+    mockQuery
+      .mockRejectedValueOnce(queueError as never)
+      .mockRejectedValueOnce(queueError as never)
+      .mockResolvedValueOnce({ id: "chat-1", user_id: "user-1" } as never);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await expect(getChatById({ id: "chat-1" })).resolves.toEqual({
+        id: "chat-1",
+        user_id: "user-1",
+      });
+
+      expect(mockQuery).toHaveBeenCalledTimes(3);
+      const retryEvents = warnSpy.mock.calls
+        .map(([line]) => JSON.parse(String(line)))
+        .filter((payload) => payload.event === "chat_fetch_retry_scheduled");
+
+      expect(retryEvents).toHaveLength(2);
+      expect(retryEvents[0]).toMatchObject({
+        retry_reason: "convex_queue_saturated",
+        attempt: 1,
+        next_attempt: 2,
+        retry_delay_ms: 0,
+        chat_id: "chat-1",
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("classifies exhausted transient fetch failures as database availability errors", async () => {
     const { getChatById, mockPhEvent, mockQuery } =
       await loadSaveMessageWithMocks();
@@ -797,6 +833,69 @@ describe("getMessagesByChatId", () => {
     } finally {
       warnSpy.mockRestore();
       errorSpy.mockRestore();
+    }
+  });
+
+  it("retries transient chat history page fetches before falling back", async () => {
+    const { getMessagesByChatId, mockQuery } = await loadSaveMessageWithMocks();
+    const existingMessage = {
+      id: "existing-message-1",
+      role: "user" as const,
+      parts: [{ type: "text" as const, text: "previous prompt" }],
+    };
+    const newMessage = {
+      id: "new-message-1",
+      role: "user" as const,
+      parts: [{ type: "text" as const, text: "next prompt" }],
+    };
+    const convexError = new Error(
+      "InternalServerError: Your request couldn't be completed. Try again later",
+    );
+
+    mockQuery
+      .mockResolvedValueOnce({ id: "chat-1", user_id: "user-1" })
+      .mockRejectedValueOnce(convexError)
+      .mockResolvedValueOnce({
+        page: [existingMessage],
+        isDone: true,
+        continueCursor: null,
+      });
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const result = await getMessagesByChatId({
+        chatId: "chat-1",
+        userId: "user-1",
+        subscription: "free",
+        newMessages: [newMessage],
+        isTemporary: false,
+        mode: "ask",
+      });
+
+      expect(result.truncatedMessages).toEqual([existingMessage, newMessage]);
+      expect(mockQuery).toHaveBeenCalledTimes(3);
+
+      const retryEvents = warnSpy.mock.calls
+        .map(([line]) => JSON.parse(String(line)))
+        .filter(
+          (payload) => payload.event === "chat_history_fetch_retry_scheduled",
+        );
+
+      expect(retryEvents).toHaveLength(1);
+      expect(retryEvents[0]).toMatchObject({
+        db_operation: "messages.getMessagesPageForBackend",
+        retry_reason: "convex_server_error",
+        attempt: 1,
+        next_attempt: 2,
+        retry_delay_ms: 0,
+        chat_id: "chat-1",
+        user_id: "user-1",
+        page_size: 24,
+        cursor_present: false,
+      });
+    } finally {
+      warnSpy.mockRestore();
     }
   });
 

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -50,6 +50,8 @@ const SAVE_CHAT_RETRY_DELAYS_MS =
   process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
 const GET_CHAT_RETRY_DELAYS_MS =
   process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
+const GET_MESSAGES_PAGE_RETRY_DELAYS_MS =
+  process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
 const REDACTED_ERROR_DATA_VALUE = "[Redacted]";
 type SummaryReason =
   "token_threshold" | "provider_input_threshold" | "provider_pressure";
@@ -240,11 +242,13 @@ const getRetryableDatabaseErrorReason = (
   error: unknown,
 ): string | undefined => {
   const dbErrorData = getErrorData(error);
+  const dbErrorCode = getDatabaseErrorCode(dbErrorData);
+  const dbCauseErrorCode = getDatabaseCauseErrorCode(dbErrorData);
   const errorText = [
     error instanceof Error ? error.name : undefined,
     stringifyError(error),
-    getDatabaseErrorCode(dbErrorData),
-    getDatabaseCauseErrorCode(dbErrorData),
+    dbErrorCode,
+    dbCauseErrorCode,
     getObjectString(dbErrorData, "causeName"),
     getObjectString(dbErrorData, "causeMessage"),
     getObjectString(dbErrorData, "message"),
@@ -253,6 +257,17 @@ const getRetryableDatabaseErrorReason = (
     .join(" ");
 
   if (/WorkerOverloaded/i.test(errorText)) return "worker_overloaded";
+  if (/ExpiredInQueue|Too many concurrent requests/i.test(errorText)) {
+    return "convex_queue_saturated";
+  }
+  if (
+    /InternalServerError|Your request couldn't be completed\.? Try again later|Try again later/i.test(
+      errorText,
+    ) ||
+    (!dbErrorCode && /\[Request ID:\s*[^\]]+\]\s+Server Error/i.test(errorText))
+  ) {
+    return "convex_server_error";
+  }
   if (/failed to fetch|fetch failed/i.test(errorText)) {
     return "network_fetch_failed";
   }
@@ -348,7 +363,7 @@ const logChatMessagePreparationFailure = (
   if (level === "warn") {
     console.warn(line);
   } else {
-    console.error(line);
+    console.error(event, line);
   }
 };
 
@@ -424,7 +439,7 @@ const databaseError = (
   if (logLevel === "warn") {
     console.warn(logLine);
   } else {
-    console.error(logLine);
+    console.error(event, logLine);
     phLogger.event(event, {
       ...diagnosticMetadata,
       service: "chat-handler",
@@ -437,6 +452,75 @@ const databaseError = (
   }
 
   return new ChatSDKError(errorCode, errorMessage, diagnosticMetadata);
+};
+
+type MessagesPageForBackendResult = {
+  page: UIMessage[];
+  isDone: boolean;
+  continueCursor: string | null;
+};
+
+const getMessagesPageForBackendWithRetry = async ({
+  chatId,
+  userId,
+  paginationOpts,
+  mode,
+  isTemporary,
+  regenerate,
+  newMessagesCount,
+}: {
+  chatId: string;
+  userId: string;
+  paginationOpts: { numItems: number; cursor: string | null };
+  mode?: ChatMode;
+  isTemporary: boolean;
+  regenerate: boolean;
+  newMessagesCount: number;
+}): Promise<MessagesPageForBackendResult> => {
+  const queryArgs = {
+    serviceKey,
+    chatId,
+    userId,
+    paginationOpts,
+  };
+
+  for (let attemptIndex = 0; ; attemptIndex++) {
+    try {
+      return await getConvexClient().query(
+        api.messages.getMessagesPageForBackend,
+        queryArgs,
+      );
+    } catch (error) {
+      const retryReason = getRetryableDatabaseErrorReason(error);
+      const retryDelayMs = GET_MESSAGES_PAGE_RETRY_DELAYS_MS[attemptIndex];
+      if (!retryReason || retryDelayMs === undefined) {
+        throw error;
+      }
+
+      console.warn(
+        JSON.stringify({
+          level: "warn",
+          event: "chat_history_fetch_retry_scheduled",
+          service: "chat-handler",
+          timestamp: new Date().toISOString(),
+          db_operation: "messages.getMessagesPageForBackend",
+          retry_reason: retryReason,
+          attempt: attemptIndex + 1,
+          next_attempt: attemptIndex + 2,
+          retry_delay_ms: retryDelayMs,
+          chat_id: chatId,
+          user_id: userId,
+          mode,
+          is_temporary: isTemporary,
+          regenerate,
+          new_messages_count: newMessagesCount,
+          page_size: paginationOpts.numItems,
+          cursor_present: paginationOpts.cursor !== null,
+        }),
+      );
+      await waitForRetryDelay(retryDelayMs);
+    }
+  }
 };
 
 export async function getChatById({ id }: { id: string }) {
@@ -957,15 +1041,15 @@ export async function getMessagesByChatId({
             page: UIMessage[];
             isDone: boolean;
             continueCursor: string | null;
-          } = await getConvexClient().query(
-            api.messages.getMessagesPageForBackend,
-            {
-              serviceKey,
-              chatId,
-              userId,
-              paginationOpts: { numItems: PAGE_SIZE, cursor },
-            },
-          );
+          } = await getMessagesPageForBackendWithRetry({
+            chatId,
+            userId,
+            paginationOpts: { numItems: PAGE_SIZE, cursor },
+            mode,
+            isTemporary: !!isTemporary,
+            regenerate: !!regenerate,
+            newMessagesCount: newMessages.length,
+          });
           const { page, isDone, continueCursor: nextCursor } = pageResult;
 
           fetchedDesc = fetchedDesc.concat(page);
@@ -1143,6 +1227,7 @@ export async function getMessagesByChatId({
           new_messages_count: newMessages.length,
           error_name: error instanceof Error ? error.name : typeof error,
           error_message: truncateDiagnosticString(stringifyError(error)),
+          db_retry_reason: getRetryableDatabaseErrorReason(error),
           db_error_data: getErrorData(error),
         });
 

--- a/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
+++ b/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
@@ -103,6 +103,29 @@ describe("shouldDropExpectedFrontendException", () => {
       shouldDropExpectedFrontendException({
         event: "$exception",
         properties: {
+          $exception_values: ["Failed to fetch"],
+          $exception_list: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    raw_frame: {
+                      filename:
+                        "https://hackerai.co/_next/static/chunks/27au5l1vw34oq.js?dpl=dpl_2ruEPyNtAD3Yc4qkCoAN2J7ReZk7",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
           $exception_types: ["UnrecognizedActionError"],
           $exception_values: [
             'Server Action "00b3ff60fce156a3bb78260aa8fa56550dc48b7f77" was not found on the server. Read more: https://nextjs.org/docs/messages/failed-to-find-server-action',
@@ -468,11 +491,26 @@ describe("shouldDropExpectedFrontendException", () => {
         $exception_values: [
           "Minified React error #185; visit https://react.dev/errors/185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.",
         ],
+        $exception_list: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  raw_frame: {
+                    filename:
+                      "https://hackerai.co/_next/static/chunks/react.js?dpl=dpl_G8NpYMgn7xvPfdr4XW6jYBmeC4yB",
+                  },
+                },
+              ],
+            },
+          },
+        ],
       },
     });
 
     expect(event.properties).toMatchObject({
       hackerai_exception_category: "react_max_update_depth",
+      hackerai_exception_deployment_id: "dpl_G8NpYMgn7xvPfdr4XW6jYBmeC4yB",
       hackerai_route_kind: "chat",
     });
   });

--- a/lib/posthog/expected-frontend-exceptions.ts
+++ b/lib/posthog/expected-frontend-exceptions.ts
@@ -63,6 +63,10 @@ const NEXT_SERVER_ACTION_SOURCE_FRAGMENTS = [
   "/docs/messages/failed-to-find-server-action",
 ];
 
+const NEXT_GENERATED_CHUNK_SOURCE_PATTERN =
+  /^(?:https?:\/\/[^/]+)?\/_next\/static\/chunks\/[^?\s]+\.js(?:\?[^#\s]*)?(?::\d+){0,2}$/i;
+const VERCEL_DEPLOYMENT_ID_PATTERN = /[?&]dpl=(dpl_[A-Za-z0-9]+)/;
+
 const STALE_SERVER_ACTION_MESSAGE_FRAGMENTS = [
   "Failed to find Server Action",
   "was not found on the server",
@@ -162,6 +166,18 @@ const hasOnlyNextServerActionFrames = (frameSources: string[]): boolean =>
     ),
   );
 
+const hasOnlyNextGeneratedChunkFrames = (frameSources: string[]): boolean =>
+  frameSources.length > 0 &&
+  frameSources.every((source) =>
+    NEXT_GENERATED_CHUNK_SOURCE_PATTERN.test(source),
+  );
+
+const hasOnlyExpectedNextServerActionFrames = (
+  frameSources: string[],
+): boolean =>
+  hasOnlyNextServerActionFrames(frameSources) ||
+  hasOnlyNextGeneratedChunkFrames(frameSources);
+
 const hasStackOverflowMessage = (strings: string[]): boolean =>
   hasExactStringFrom(strings, STACK_OVERFLOW_MESSAGES);
 
@@ -216,14 +232,15 @@ const matchesNextServerActionTransportPattern = (
   frameSources: string[],
 ): boolean =>
   hasBrowserFetchTransportMessage(strings) &&
-  hasOnlyNextServerActionFrames(frameSources);
+  hasOnlyExpectedNextServerActionFrames(frameSources);
 
 const matchesStaleServerActionPattern = (
   strings: string[],
   frameSources: string[],
 ): boolean =>
   hasStaleServerActionMessage(strings) &&
-  (frameSources.length === 0 || hasOnlyNextServerActionFrames(frameSources));
+  (frameSources.length === 0 ||
+    hasOnlyExpectedNextServerActionFrames(frameSources));
 
 const getExceptionCategory = (strings: string[]): FrontendExceptionCategory => {
   if (includesAny(strings, [REACT_MAX_UPDATE_DEPTH_MESSAGE_FRAGMENT])) {
@@ -275,6 +292,16 @@ const getRouteKind = (currentUrl: unknown): string | undefined => {
   }
 };
 
+const getDeploymentIdFromFrameSources = (
+  frameSources: string[],
+): string | undefined => {
+  for (const source of frameSources) {
+    const match = source.match(VERCEL_DEPLOYMENT_ID_PATTERN);
+    if (match?.[1]) return match[1];
+  }
+  return undefined;
+};
+
 function getBrowserNetworkDetails() {
   if (typeof navigator === "undefined") return {};
 
@@ -305,13 +332,16 @@ export function enrichFrontendExceptionEvent<T extends PostHogEventLike>(
 
   const properties = event.properties ?? {};
   const strings = collectStrings(properties);
+  const frameSources = collectStackFrameSources(properties);
   const category = getExceptionCategory(strings);
   const routeKind = getRouteKind(properties.$current_url);
+  const deploymentId = getDeploymentIdFromFrameSources(frameSources);
 
   event.properties = {
     ...properties,
     hackerai_exception_category: category,
     ...(routeKind ? { hackerai_route_kind: routeKind } : {}),
+    ...(deploymentId ? { hackerai_exception_deployment_id: deploymentId } : {}),
     ...(typeof document !== "undefined"
       ? { hackerai_visibility_state: document.visibilityState }
       : {}),


### PR DESCRIPTION
## Summary
- retry Convex queue/server transient failures across chat fetch/save/history reads
- add retry logging for paginated chat history reads and stable database error grouping in Vercel logs
- suppress stale Next server-action transport exceptions from unresolved PostHog chunk frames and enrich retained exceptions with deployment ids

## Verification
- pnpm exec jest lib/posthog/__tests__/expected-frontend-exceptions.test.ts lib/db/__tests__/actions-save-message.test.ts --runInBand
- pnpm exec eslint lib/db/actions.ts lib/db/__tests__/actions-save-message.test.ts lib/posthog/expected-frontend-exceptions.ts lib/posthog/__tests__/expected-frontend-exceptions.test.ts
- git diff --check

## Notes
- Full `pnpm exec tsc --noEmit` currently stops on existing `packages/local/src/index.ts` missing `ws` types/module resolution, outside this PR.
- No visual verification needed; this is backend logging/retry plus analytics filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading chats and message history by retrying transient database/queue saturation failures instead of failing immediately.
  * Better handling of expected frontend exceptions, reducing noise from harmless errors.
  * Enhanced error reporting for frontend exceptions and message-processing failures with more useful diagnostic details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->