### PR TITLE
Fix Windows desktop file operations

### DIFF
--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -193,6 +193,7 @@ interface LocalSandboxConnection {
   capabilities: {
     commands: boolean;
     pty: boolean;
+    files?: boolean;
   };
 }
 

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -368,6 +368,53 @@ describe("native desktop file relay", () => {
       requestId: "file-req-2",
     });
   });
+
+  it("passes base64 append requests through to the local file server", async () => {
+    const config = buildConfig();
+    const bridge = new DesktopSandboxBridge(config);
+    await bridge.start();
+
+    const handler = getPublicationHandler();
+
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "get_cmd_server_info") {
+        return { port: 49152, token: "file-token" };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as Response);
+
+    handler({
+      data: {
+        type: "file_append",
+        requestId: "file-req-3",
+        path: "C:\\repo\\asset.bin",
+        content: "AAEC",
+        isBase64: true,
+        targetConnectionId: "conn-123",
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:49152/files/append",
+      expect.objectContaining({
+        body: JSON.stringify({
+          path: "C:\\repo\\asset.bin",
+          content: "AAEC",
+          is_base64: true,
+        }),
+      }),
+    );
+    expect(mockSubscription.publish).toHaveBeenCalledWith({
+      type: "file_ok",
+      requestId: "file-req-3",
+    });
+  });
 });
 
 // ── extractUserIdFromToken ────────────────────────────────────────────

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -27,6 +27,7 @@ let mockInvokeHandler: (
   args?: Record<string, unknown>,
 ) => Promise<unknown>;
 let capturedChannel: { onmessage?: (event: unknown) => void } | null = null;
+const originalFetch = global.fetch;
 
 jest.mock("@tauri-apps/api/core", () => ({
   invoke: jest.fn((...args: unknown[]) => {
@@ -80,6 +81,7 @@ function getPublicationHandler(): (ctx: { data: unknown }) => void {
 beforeEach(() => {
   jest.clearAllMocks();
   capturedChannel = null;
+  global.fetch = originalFetch;
 
   mockInvokeHandler = async (cmd: string) => {
     if (cmd === "execute_command") {
@@ -94,6 +96,26 @@ beforeEach(() => {
     }
     throw new Error(`Unknown command: ${cmd}`);
   };
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+// ── desktop capability registration ───────────────────────────────────
+
+describe("desktop capability registration", () => {
+  it("advertises native file relay support for updated desktop builds", async () => {
+    const config = buildConfig();
+    const bridge = new DesktopSandboxBridge(config);
+    await bridge.start();
+
+    expect(config.connectDesktop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capabilities: { commands: true, pty: true, files: true },
+      }),
+    );
+  });
 });
 
 // ── targetConnectionId filtering ──────────────────────────────────────
@@ -223,6 +245,128 @@ describe("targetConnectionId filtering", () => {
       "execute_pty_create",
       expect.anything(),
     );
+  });
+});
+
+// ── native desktop file relay ─────────────────────────────────────────
+
+describe("native desktop file relay", () => {
+  it("handles file_read with the local desktop file server", async () => {
+    const config = buildConfig();
+    const bridge = new DesktopSandboxBridge(config);
+    await bridge.start();
+
+    const handler = getPublicationHandler();
+
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "get_cmd_server_info") {
+        return { port: 49152, token: "file-token" };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        path: "C:\\repo\\app.ts",
+        sizeBytes: 12,
+        totalLines: 1,
+        content: "hello world\n",
+        startLine: 1,
+        truncated: false,
+      }),
+    } as Response);
+
+    handler({
+      data: {
+        type: "file_read",
+        requestId: "file-req-1",
+        path: "C:\\repo\\app.ts",
+        range: [1, 1],
+        maxFullBytes: 1024,
+        maxResultBytes: 1024,
+        targetConnectionId: "conn-123",
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:49152/files/read",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer file-token",
+        }),
+        body: JSON.stringify({
+          path: "C:\\repo\\app.ts",
+          range_start: 1,
+          range_end: 1,
+          max_full_bytes: 1024,
+          max_result_bytes: 1024,
+        }),
+      }),
+    );
+    expect(mockSubscription.publish).toHaveBeenCalledWith({
+      type: "file_read_result",
+      requestId: "file-req-1",
+      path: "C:\\repo\\app.ts",
+      sizeBytes: 12,
+      totalLines: 1,
+      content: "hello world\n",
+      startLine: 1,
+    });
+  });
+
+  it("handles file_write without executing a shell command", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const config = buildConfig();
+    const bridge = new DesktopSandboxBridge(config);
+    await bridge.start();
+
+    const handler = getPublicationHandler();
+    (invoke as jest.Mock).mockClear();
+
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "get_cmd_server_info") {
+        return { port: 49152, token: "file-token" };
+      }
+      throw new Error(`Unexpected command: ${cmd}`);
+    };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as Response);
+
+    handler({
+      data: {
+        type: "file_write",
+        requestId: "file-req-2",
+        path: "C:\\repo\\app.ts",
+        content: "updated",
+        targetConnectionId: "conn-123",
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(invoke).not.toHaveBeenCalledWith(
+      "execute_stream_command",
+      expect.anything(),
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:49152/files/write",
+      expect.objectContaining({
+        body: JSON.stringify({
+          path: "C:\\repo\\app.ts",
+          content: "updated",
+          is_base64: false,
+        }),
+      }),
+    );
+    expect(mockSubscription.publish).toHaveBeenCalledWith({
+      type: "file_ok",
+      requestId: "file-req-2",
+    });
   });
 });
 

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -635,11 +635,12 @@ export class DesktopSandboxBridge {
   }
 
   private async handleFileAppend(message: FileAppendMessage): Promise<void> {
-    const { requestId, path, content } = message;
+    const { requestId, path, content, isBase64 } = message;
     try {
       await this.callLocalFileServer("/files/append", {
         path,
         content,
+        is_base64: Boolean(isBase64),
       });
       await this.publishResult({ type: "file_ok", requestId });
     } catch (error) {

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -9,6 +9,13 @@ import {
   type PtyInputMessage,
   type PtyResizeMessage,
   type PtyKillMessage,
+  type FileRequestMessage,
+  type FileStatMessage,
+  type FileReadMessage,
+  type FileWriteMessage,
+  type FileAppendMessage,
+  type FileRemoveMessage,
+  type FileListMessage,
 } from "@/lib/centrifugo/types";
 import {
   DEFAULT_PTY_COLS,
@@ -21,9 +28,7 @@ type RefreshTokenResult =
       ok: false;
       terminated: true;
       reason:
-        | "connection_not_found"
-        | "ownership_mismatch"
-        | "connection_inactive";
+        "connection_not_found" | "ownership_mismatch" | "connection_inactive";
       connectionId: string;
       clientVersion: string | null;
       status: string | null;
@@ -49,6 +54,7 @@ interface StreamChunk {
 type TargetedIncomingMessage =
   | CommandMessage
   | CommandCancelMessage
+  | FileRequestMessage
   | PtyCreateMessage
   | PtyInputMessage
   | PtyResizeMessage
@@ -68,6 +74,12 @@ function isTargetedIncomingMessage(
     typeof targetConnectionId === "string" &&
     (type === "command" ||
       type === "command_cancel" ||
+      type === "file_stat" ||
+      type === "file_read" ||
+      type === "file_write" ||
+      type === "file_append" ||
+      type === "file_remove" ||
+      type === "file_list" ||
       type === "pty_create" ||
       type === "pty_input" ||
       type === "pty_resize" ||
@@ -93,6 +105,11 @@ interface DesktopBridgeConfig {
       arch: string;
       release: string;
       hostname: string;
+    };
+    capabilities?: {
+      commands: boolean;
+      pty: boolean;
+      files?: boolean;
     };
   }) => Promise<{
     connectionId: string;
@@ -140,6 +157,7 @@ export class DesktopSandboxBridge {
       await this.config.connectDesktop({
         connectionName: osInfo?.hostname || "Desktop",
         osInfo,
+        capabilities: { commands: true, pty: true, files: true },
       });
 
     this.connectionId = connectionId;
@@ -239,6 +257,42 @@ export class DesktopSandboxBridge {
               );
             },
           );
+          break;
+
+        case "file_stat":
+          this.handleFileStat(message as FileStatMessage).catch((err) => {
+            console.error("[DesktopSandboxBridge] File stat failed:", err);
+          });
+          break;
+
+        case "file_read":
+          this.handleFileRead(message as FileReadMessage).catch((err) => {
+            console.error("[DesktopSandboxBridge] File read failed:", err);
+          });
+          break;
+
+        case "file_write":
+          this.handleFileWrite(message as FileWriteMessage).catch((err) => {
+            console.error("[DesktopSandboxBridge] File write failed:", err);
+          });
+          break;
+
+        case "file_append":
+          this.handleFileAppend(message as FileAppendMessage).catch((err) => {
+            console.error("[DesktopSandboxBridge] File append failed:", err);
+          });
+          break;
+
+        case "file_remove":
+          this.handleFileRemove(message as FileRemoveMessage).catch((err) => {
+            console.error("[DesktopSandboxBridge] File remove failed:", err);
+          });
+          break;
+
+        case "file_list":
+          this.handleFileList(message as FileListMessage).catch((err) => {
+            console.error("[DesktopSandboxBridge] File list failed:", err);
+          });
           break;
 
         case "pty_create":
@@ -391,6 +445,232 @@ export class DesktopSandboxBridge {
       });
     } finally {
       this.activeCommands.delete(commandId);
+    }
+  }
+
+  private getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  private async publishFileError(
+    requestId: string,
+    error: unknown,
+  ): Promise<void> {
+    await this.publishResult({
+      type: "file_error",
+      requestId,
+      message: this.getErrorMessage(error),
+    });
+  }
+
+  private async callLocalFileServer<T>(
+    route: string,
+    body: Record<string, unknown>,
+  ): Promise<T> {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const info = await invoke<{ port: number; token: string }>(
+      "get_cmd_server_info",
+    );
+    if (!info.port || !info.token) {
+      throw new Error("Desktop file server is not ready");
+    }
+
+    const response = await fetch(`http://127.0.0.1:${info.port}${route}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${info.token}`,
+      },
+      body: JSON.stringify(body),
+    });
+    const payload = await response.json().catch(() => null);
+    if (!response.ok) {
+      throw new Error(
+        typeof payload?.error === "string"
+          ? payload.error
+          : `Desktop file server request failed: ${response.status}`,
+      );
+    }
+    return payload as T;
+  }
+
+  private countLines(content: string): number {
+    if (content.length === 0) return 0;
+    return content.endsWith("\n")
+      ? content.split("\n").length - 1
+      : content.split("\n").length;
+  }
+
+  private normalizeReadPayload(
+    path: string,
+    payload: unknown,
+    range?: [number, number],
+  ): {
+    path: string;
+    sizeBytes: number;
+    totalLines: number;
+    content?: string;
+    startLine?: number;
+    tooLarge?: boolean;
+    truncated?: boolean;
+  } {
+    const data =
+      typeof payload === "object" && payload !== null
+        ? (payload as Record<string, unknown>)
+        : {};
+    const content = typeof data.content === "string" ? data.content : undefined;
+
+    if (typeof data.sizeBytes === "number") {
+      return {
+        path: typeof data.path === "string" ? data.path : path,
+        sizeBytes: data.sizeBytes,
+        totalLines:
+          typeof data.totalLines === "number"
+            ? data.totalLines
+            : content !== undefined
+              ? this.countLines(content)
+              : 0,
+        ...(content !== undefined ? { content } : {}),
+        ...(typeof data.startLine === "number"
+          ? { startLine: data.startLine }
+          : range
+            ? { startLine: range[0] }
+            : {}),
+        ...(data.tooLarge === true ? { tooLarge: true } : {}),
+        ...(data.truncated === true ? { truncated: true } : {}),
+      };
+    }
+
+    if (content === undefined) {
+      throw new Error("Desktop file server returned an invalid read payload");
+    }
+
+    const lines = content.split("\n");
+    const selectedContent = range
+      ? lines
+          .slice(range[0] - 1, range[1] === -1 ? undefined : range[1])
+          .join("\n")
+      : content;
+
+    return {
+      path,
+      sizeBytes: new TextEncoder().encode(content).byteLength,
+      totalLines: this.countLines(content),
+      content: selectedContent,
+      startLine: range?.[0] ?? 1,
+    };
+  }
+
+  private async handleFileStat(message: FileStatMessage): Promise<void> {
+    const { requestId, path } = message;
+    try {
+      const { invoke } = await import("@tauri-apps/api/core");
+      const metadata = await invoke<{ path: string; size: number }>(
+        "get_local_file_metadata",
+        { path },
+      );
+      await this.publishResult({
+        type: "file_stat_result",
+        requestId,
+        kind: "file",
+        path: metadata.path,
+        sizeBytes: metadata.size,
+      });
+    } catch (error) {
+      const msg = this.getErrorMessage(error);
+      if (msg.includes("Selected path is not a file")) {
+        await this.publishResult({
+          type: "file_stat_result",
+          requestId,
+          kind: "not_file",
+          path,
+        });
+        return;
+      }
+      if (msg.includes("Metadata error")) {
+        await this.publishResult({
+          type: "file_stat_result",
+          requestId,
+          kind: "missing",
+          path,
+        });
+        return;
+      }
+      await this.publishFileError(requestId, error);
+    }
+  }
+
+  private async handleFileRead(message: FileReadMessage): Promise<void> {
+    const { requestId, path, range, maxFullBytes, maxResultBytes } = message;
+    try {
+      const payload = await this.callLocalFileServer<unknown>("/files/read", {
+        path,
+        range_start: range?.[0],
+        range_end: range?.[1],
+        max_full_bytes: maxFullBytes,
+        max_result_bytes: maxResultBytes,
+      });
+      await this.publishResult({
+        type: "file_read_result",
+        requestId,
+        ...this.normalizeReadPayload(path, payload, range),
+      });
+    } catch (error) {
+      await this.publishFileError(requestId, error);
+    }
+  }
+
+  private async handleFileWrite(message: FileWriteMessage): Promise<void> {
+    const { requestId, path, content, isBase64 } = message;
+    try {
+      await this.callLocalFileServer("/files/write", {
+        path,
+        content,
+        is_base64: Boolean(isBase64),
+      });
+      await this.publishResult({ type: "file_ok", requestId });
+    } catch (error) {
+      await this.publishFileError(requestId, error);
+    }
+  }
+
+  private async handleFileAppend(message: FileAppendMessage): Promise<void> {
+    const { requestId, path, content } = message;
+    try {
+      await this.callLocalFileServer("/files/append", {
+        path,
+        content,
+      });
+      await this.publishResult({ type: "file_ok", requestId });
+    } catch (error) {
+      await this.publishFileError(requestId, error);
+    }
+  }
+
+  private async handleFileRemove(message: FileRemoveMessage): Promise<void> {
+    const { requestId, path } = message;
+    try {
+      await this.callLocalFileServer("/files/remove", { path });
+      await this.publishResult({ type: "file_ok", requestId });
+    } catch (error) {
+      await this.publishFileError(requestId, error);
+    }
+  }
+
+  private async handleFileList(message: FileListMessage): Promise<void> {
+    const { requestId, path } = message;
+    try {
+      const entries = await this.callLocalFileServer<Array<{ name: string }>>(
+        "/files/list",
+        { path },
+      );
+      await this.publishResult({
+        type: "file_list_result",
+        requestId,
+        entries,
+      });
+    } catch (error) {
+      await this.publishFileError(requestId, error);
     }
   }
 

--- a/convex/localSandbox.ts
+++ b/convex/localSandbox.ts
@@ -204,6 +204,7 @@ export const connect = mutation({
       v.object({
         commands: v.boolean(),
         pty: v.boolean(),
+        files: v.optional(v.boolean()),
       }),
     ),
   },
@@ -423,6 +424,13 @@ export const connectDesktop = mutation({
         hostname: v.string(),
       }),
     ),
+    capabilities: v.optional(
+      v.object({
+        commands: v.boolean(),
+        pty: v.boolean(),
+        files: v.optional(v.boolean()),
+      }),
+    ),
   },
   returns: v.object({
     connectionId: v.string(),
@@ -468,7 +476,7 @@ export const connectDesktop = mutation({
       client_version: "desktop",
       mode: "dangerous",
       os_info: args.osInfo,
-      capabilities: { commands: true, pty: true },
+      capabilities: args.capabilities ?? { commands: true, pty: true },
       last_heartbeat: Date.now(),
       status: "connected",
       created_at: Date.now(),
@@ -614,6 +622,7 @@ export const listConnections = query({
       capabilities: v.object({
         commands: v.boolean(),
         pty: v.boolean(),
+        files: v.optional(v.boolean()),
       }),
     }),
   ),
@@ -665,6 +674,7 @@ export const listConnectionsForBackend = query({
       capabilities: v.object({
         commands: v.boolean(),
         pty: v.boolean(),
+        files: v.optional(v.boolean()),
       }),
     }),
   ),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -565,6 +565,7 @@ export default defineSchema({
       v.object({
         commands: v.boolean(),
         pty: v.boolean(),
+        files: v.optional(v.boolean()),
       }),
     ),
     last_heartbeat: v.number(),

--- a/lib/ai/tools/__tests__/file.test.ts
+++ b/lib/ai/tools/__tests__/file.test.ts
@@ -114,6 +114,39 @@ function makeSandbox(
   };
 }
 
+function makeNativeDesktopSandbox() {
+  const commandRun = jest.fn<Promise<FakeCommandResult>, [string, any?]>();
+  return {
+    sandbox: {
+      sandboxKind: "centrifugo" as const,
+      isWindows: () => true,
+      supportsNativeFileRelay: () => true,
+      commands: { run: commandRun },
+      files: {
+        stat: jest.fn(async () => ({
+          kind: "file" as const,
+          path: "C:\\repo\\app.ts",
+          sizeBytes: 18,
+        })),
+        readText: jest.fn(async () => ({
+          path: "C:\\repo\\app.ts",
+          sizeBytes: 18,
+          totalLines: 2,
+          content: "line one\nline two\n",
+          startLine: 1,
+          truncated: false,
+        })),
+        append: jest.fn(async () => undefined),
+        read: jest.fn(async () => "line one\nline two\n"),
+        write: jest.fn(async () => undefined),
+        remove: jest.fn(async () => undefined),
+        list: jest.fn(),
+      },
+    },
+    commandRun,
+  };
+}
+
 describe("file tool large text safety", () => {
   test("blocks file operations when a selected local sandbox falls back", async () => {
     const commandRun = jest.fn(async () => ({
@@ -344,6 +377,67 @@ describe("file tool large text safety", () => {
     expect(result.content).toContain("   500|line 500");
     expect(result.content).toContain("   501|line 501");
     expect(sandbox.files.read).not.toHaveBeenCalled();
+  });
+
+  test("uses native desktop readText for Windows desktop reads", async () => {
+    const { sandbox, commandRun } = makeNativeDesktopSandbox();
+    const tool = createFile(makeContext(sandbox));
+
+    const result = (await runTool(tool, {
+      action: "read",
+      path: "C:\\repo\\app.ts",
+      brief: "Read through native desktop bridge",
+    })) as { content: string };
+
+    expect(result.content).toContain("     1|line one");
+    expect(result.content).toContain("     2|line two");
+    expect(sandbox.files.readText).toHaveBeenCalledWith("C:\\repo\\app.ts", {
+      maxFullBytes: 1024 * 1024,
+      maxResultBytes: 1024 * 1024,
+    });
+    expect(commandRun).not.toHaveBeenCalled();
+  });
+
+  test("normalizes edit strings to the existing CRLF line endings", async () => {
+    const commandRun = jest.fn(async () => ({
+      stdout: JSON.stringify({
+        kind: "file",
+        path: "C:\\repo\\app.ts",
+        sizeBytes: 32,
+      }),
+      stderr: "",
+      exitCode: 0,
+    }));
+    const write = jest.fn(async () => undefined);
+    const sandbox = {
+      commands: { run: commandRun },
+      files: {
+        read: jest.fn(async () => "const a = 1;\r\nconst b = 2;\r\n"),
+        write,
+        remove: jest.fn(async () => undefined),
+        list: jest.fn(),
+      },
+    };
+    const tool = createFile(makeContext(sandbox));
+
+    const result = (await runTool(tool, {
+      action: "edit",
+      path: "C:\\repo\\app.ts",
+      brief: "Edit CRLF file",
+      edits: [
+        {
+          find: "const a = 1;\nconst b = 2;",
+          replace: "const a = 1;\nconst b = 3;",
+        },
+      ],
+    })) as { content: string };
+
+    expect(result.content).toContain("Multi-edit completed");
+    expect(write).toHaveBeenCalledWith(
+      "C:\\repo\\app.ts",
+      "const a = 1;\r\nconst b = 3;\r\n",
+      { user: "user" },
+    );
   });
 
   test("oversized append on Windows does not use POSIX cat/rm commands", async () => {

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -661,6 +661,19 @@ function formatBytes(bytes: number): string {
   return `${value.toFixed(value >= 10 ? 1 : 2)} ${units[unitIndex]}`;
 }
 
+function normalizeLineEndings(text: string): string {
+  return text.replace(/\r\n/g, "\n");
+}
+
+function detectLineEnding(text: string): "\n" | "\r\n" {
+  return text.includes("\r\n") ? "\r\n" : "\n";
+}
+
+function convertToLineEnding(text: string, lineEnding: "\n" | "\r\n"): string {
+  const normalized = normalizeLineEndings(text);
+  return lineEnding === "\r\n" ? normalized.replace(/\n/g, "\r\n") : normalized;
+}
+
 async function runSandboxCommand(
   sandbox: AnySandbox,
   command: string,
@@ -701,6 +714,32 @@ function getWindowsNativePath(path: string): string {
 
 function getPythonPathForSandbox(sandbox: AnySandbox, path: string): string {
   return isWindowsSandbox(sandbox) ? getWindowsNativePath(path) : path;
+}
+
+type NativeDesktopFiles = {
+  stat?: (path: string) => Promise<SandboxFileState>;
+  readText?: (
+    path: string,
+    options?: {
+      range?: [number, number];
+      maxFullBytes?: number;
+      maxResultBytes?: number;
+    },
+  ) => Promise<SandboxTextReadPayload>;
+  append?: (path: string, content: string) => Promise<void>;
+};
+
+function getNativeDesktopFiles(sandbox: AnySandbox): NativeDesktopFiles | null {
+  if (!isCentrifugoSandbox(sandbox)) return null;
+
+  const maybeSandbox = sandbox as unknown as {
+    supportsNativeFileRelay?: () => boolean;
+    files?: NativeDesktopFiles;
+  };
+  if (maybeSandbox.supportsNativeFileRelay?.() !== true) {
+    return null;
+  }
+  return maybeSandbox.files ?? null;
 }
 
 function toWindowsBashPath(path: string): string {
@@ -769,6 +808,11 @@ async function getSandboxFileState(
   sandbox: AnySandbox,
   path: string,
 ): Promise<SandboxFileState> {
+  const nativeFiles = getNativeDesktopFiles(sandbox);
+  if (nativeFiles?.stat) {
+    return nativeFiles.stat(path);
+  }
+
   const pythonPath = getPythonPathForSandbox(sandbox, path);
   const result = await runPythonScript(
     sandbox,
@@ -854,6 +898,15 @@ async function readSandboxTextFile(
   path: string,
   range?: number[],
 ): Promise<SandboxTextReadPayload> {
+  const nativeFiles = getNativeDesktopFiles(sandbox);
+  if (nativeFiles?.readText) {
+    return nativeFiles.readText(path, {
+      ...(range ? { range: [range[0], range[1]] } : {}),
+      maxFullBytes: MAX_TEXT_FILE_READ_BYTES,
+      maxResultBytes: MAX_TEXT_READ_RESULT_BYTES,
+    });
+  }
+
   const pythonPath = getPythonPathForSandbox(sandbox, path);
   const envVars = {
     HACKERAI_FILE_READ_PATH: pythonPath,
@@ -984,6 +1037,12 @@ async function appendSandboxTextFile(
   path: string,
   text: string,
 ): Promise<void> {
+  const nativeFiles = getNativeDesktopFiles(sandbox);
+  if (nativeFiles?.append) {
+    await nativeFiles.append(path, text);
+    return;
+  }
+
   const tempPath = `/tmp/hackerai_append_${Date.now()}_${Math.random().toString(36).slice(2)}.tmp`;
   await sandbox.files.write(tempPath, text, {
     user: "user" as const,
@@ -1337,7 +1396,10 @@ export const createFile = (context: ToolContext) => {
             }
 
             // Append directly without adding extra newline - agent controls exact content
-            const newContent = existingContent + text;
+            const appendText = existingContent
+              ? convertToLineEnding(text, detectLineEnding(existingContent))
+              : text;
+            const newContent = existingContent + appendText;
 
             await sandbox.files.write(path, newContent, {
               user: "user" as const,
@@ -1395,9 +1457,15 @@ export const createFile = (context: ToolContext) => {
             }
 
             // Validate all find strings exist before applying any edits (atomic behavior)
+            const lineEnding = detectLineEnding(originalContent);
+            const normalizedEdits = edits.map((edit) => ({
+              ...edit,
+              find: convertToLineEnding(edit.find, lineEnding),
+              replace: convertToLineEnding(edit.replace, lineEnding),
+            }));
             const missingFinds: { index: number; find: string }[] = [];
-            for (let i = 0; i < edits.length; i++) {
-              if (!originalContent.includes(edits[i].find)) {
+            for (let i = 0; i < normalizedEdits.length; i++) {
+              if (!originalContent.includes(normalizedEdits[i].find)) {
                 missingFinds.push({ index: i + 1, find: edits[i].find });
               }
             }
@@ -1418,7 +1486,7 @@ export const createFile = (context: ToolContext) => {
             let content = originalContent;
             let totalReplacements = 0;
 
-            for (const edit of edits) {
+            for (const edit of normalizedEdits) {
               const { find, replace, all = false } = edit;
 
               if (all) {
@@ -1437,7 +1505,7 @@ export const createFile = (context: ToolContext) => {
             });
 
             // Format content with line numbers for model output (padded format with pipe separator)
-            const lines = content.split("\n");
+            const lines = normalizeLineEndings(content).split("\n");
             const numberedLines = lines
               .map(
                 (line, index) =>

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -583,6 +583,67 @@ describe("CentrifugoSandbox", () => {
 
       await expect(promise).resolves.toBeUndefined();
     });
+
+    it("chunks large native writes into file_write then file_append requests", async () => {
+      const sandbox = createDesktopSandbox();
+      const content = "x".repeat(70 * 1024);
+      const promise = sandbox.files.write("C:\\repo\\large.txt", content);
+
+      await jest.advanceTimersByTimeAsync(0);
+      const firstSub = mockSubscriptions[0];
+      firstSub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      const firstRequest = (firstSub.publish as jest.Mock).mock.calls[0][0] as {
+        type: string;
+        requestId: string;
+        content: string;
+        isBase64?: boolean;
+      };
+      expect(firstRequest).toEqual(
+        expect.objectContaining({
+          type: "file_write",
+          path: "C:\\repo\\large.txt",
+          isBase64: true,
+          targetConnectionId: "conn-1",
+        }),
+      );
+      firstSub.emit("publication", {
+        data: { type: "file_ok", requestId: firstRequest.requestId },
+      });
+
+      await jest.advanceTimersByTimeAsync(0);
+      const secondSub = mockSubscriptions[1];
+      secondSub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      const secondRequest = (secondSub.publish as jest.Mock).mock
+        .calls[0][0] as {
+        type: string;
+        requestId: string;
+        content: string;
+        isBase64?: boolean;
+      };
+      expect(secondRequest).toEqual(
+        expect.objectContaining({
+          type: "file_append",
+          path: "C:\\repo\\large.txt",
+          isBase64: true,
+          targetConnectionId: "conn-1",
+        }),
+      );
+      secondSub.emit("publication", {
+        data: { type: "file_ok", requestId: secondRequest.requestId },
+      });
+
+      await expect(promise).resolves.toBeUndefined();
+      expect(
+        Buffer.from(
+          firstRequest.content + secondRequest.content,
+          "base64",
+        ).toString("utf8"),
+      ).toBe(content);
+    });
   });
 
   describe("close()", () => {

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -85,6 +85,19 @@ function createSandbox(
   );
 }
 
+function createDesktopSandbox(): CentrifugoSandbox {
+  return createSandbox({
+    isDesktop: true,
+    capabilities: { commands: true, pty: true, files: true },
+    osInfo: {
+      platform: "win32",
+      arch: "x64",
+      release: "10.0.22631",
+      hostname: "WIN-DEV",
+    },
+  });
+}
+
 /**
  * Helper: starts a command, then simulates publication messages from the sandbox client.
  * Returns the promise and the subscription so the caller can emit messages.
@@ -487,6 +500,88 @@ describe("CentrifugoSandbox", () => {
 
       expect(result.stdout).toBe("mine\n");
       expect(result.stdout).not.toContain("not mine");
+    });
+  });
+
+  describe("native desktop file relay", () => {
+    it("requires the desktop files capability before enabling the native relay", () => {
+      const sandbox = createSandbox({
+        isDesktop: true,
+        capabilities: { commands: true, pty: true },
+        osInfo: {
+          platform: "win32",
+          arch: "x64",
+          release: "10.0.22631",
+          hostname: "WIN-OLD",
+        },
+      });
+
+      expect(sandbox.supportsNativeFileRelay()).toBe(false);
+    });
+
+    it("files.read publishes a targeted file_read request for desktop connections", async () => {
+      const sandbox = createDesktopSandbox();
+      const promise = sandbox.files.read("C:\\repo\\app.ts");
+
+      await jest.advanceTimersByTimeAsync(0);
+      const sub = mockSubscriptions[0];
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(sub.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "file_read",
+          path: "C:\\repo\\app.ts",
+          targetConnectionId: "conn-1",
+          requestId: expect.any(String),
+        }),
+      );
+
+      const request = (sub.publish as jest.Mock).mock.calls[0][0] as {
+        requestId: string;
+      };
+      sub.emit("publication", {
+        data: {
+          type: "file_read_result",
+          requestId: request.requestId,
+          path: "C:\\repo\\app.ts",
+          sizeBytes: 12,
+          totalLines: 1,
+          content: "hello world\n",
+          startLine: 1,
+        },
+      });
+
+      await expect(promise).resolves.toBe("hello world\n");
+    });
+
+    it("files.write publishes file_write instead of shell heredoc for desktop connections", async () => {
+      const sandbox = createDesktopSandbox();
+      const promise = sandbox.files.write("C:\\repo\\app.ts", "updated");
+
+      await jest.advanceTimersByTimeAsync(0);
+      const sub = mockSubscriptions[0];
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(sub.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "file_write",
+          path: "C:\\repo\\app.ts",
+          content: "updated",
+          targetConnectionId: "conn-1",
+          requestId: expect.any(String),
+        }),
+      );
+
+      const request = (sub.publish as jest.Mock).mock.calls[0][0] as {
+        requestId: string;
+      };
+      sub.emit("publication", {
+        data: { type: "file_ok", requestId: request.requestId },
+      });
+
+      await expect(promise).resolves.toBeUndefined();
     });
   });
 

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -775,6 +775,10 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
   // Max chunk size ~500KB base64 to stay under size limits (bash path)
   private static readonly MAX_CHUNK_SIZE = 500 * 1024;
 
+  // Keep native file relay messages comfortably below common WebSocket frame
+  // limits after JSON overhead. Base64 chunks must stay divisible by 4.
+  private static readonly MAX_NATIVE_FILE_MESSAGE_CHARS = 48 * 1024;
+
   // cmd.exe has an ~8191 character command line limit. Reserve room for
   // `echo `, redirect operator, and file path — keep data under 7000 chars.
   private static readonly MAX_CMD_CHUNK_SIZE = 7000;
@@ -1018,24 +1022,64 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     rawPath: string,
     content: string | Buffer | ArrayBuffer,
   ): Promise<void> {
-    const isBase64 = typeof content !== "string";
+    if (
+      typeof content === "string" &&
+      Buffer.byteLength(content, "utf8") <=
+        CentrifugoSandbox.MAX_NATIVE_FILE_MESSAGE_CHARS
+    ) {
+      await this.runFileRequest<FileOkMessage>(
+        {
+          type: "file_write",
+          path: rawPath,
+          content,
+        },
+        new Set(["file_ok"]),
+        120000,
+      );
+      return;
+    }
+
     const encodedContent =
       typeof content === "string"
-        ? content
+        ? Buffer.from(content, "utf8").toString("base64")
         : content instanceof ArrayBuffer
           ? Buffer.from(content).toString("base64")
           : content.toString("base64");
 
-    await this.runFileRequest<FileOkMessage>(
-      {
-        type: "file_write",
-        path: rawPath,
-        content: encodedContent,
-        ...(isBase64 ? { isBase64: true } : {}),
-      },
-      new Set(["file_ok"]),
-      120000,
-    );
+    if (encodedContent.length === 0) {
+      await this.runFileRequest<FileOkMessage>(
+        {
+          type: "file_write",
+          path: rawPath,
+          content: "",
+          isBase64: true,
+        },
+        new Set(["file_ok"]),
+        120000,
+      );
+      return;
+    }
+
+    for (
+      let offset = 0;
+      offset < encodedContent.length;
+      offset += CentrifugoSandbox.MAX_NATIVE_FILE_MESSAGE_CHARS
+    ) {
+      const chunk = encodedContent.slice(
+        offset,
+        offset + CentrifugoSandbox.MAX_NATIVE_FILE_MESSAGE_CHARS,
+      );
+      await this.runFileRequest<FileOkMessage>(
+        {
+          type: offset === 0 ? "file_write" : "file_append",
+          path: rawPath,
+          content: chunk,
+          isBase64: true,
+        },
+        new Set(["file_ok"]),
+        120000,
+      );
+    }
   }
 
   private async appendNativeTextFile(

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -6,6 +6,12 @@ import {
   sandboxConnectionChannel,
   type CommandResponseMessage,
   type CommandMessage,
+  type FileRequestMessage,
+  type FileResponseMessage,
+  type FileOkMessage,
+  type FileStatResultMessage,
+  type FileReadResultMessage,
+  type FileListResultMessage,
 } from "@/lib/centrifugo/types";
 import { presenceHasConnectionId } from "@/lib/centrifugo/presence";
 import { getPlatformDisplayName, escapeShellValue } from "./platform-utils";
@@ -22,6 +28,17 @@ const VALID_MESSAGE_TYPES = new Set([
 ]);
 
 const IGNORED_MESSAGE_TYPES = new Set([
+  "file_stat",
+  "file_read",
+  "file_write",
+  "file_append",
+  "file_remove",
+  "file_list",
+  "file_ok",
+  "file_error",
+  "file_stat_result",
+  "file_read_result",
+  "file_list_result",
   "pty_create",
   "pty_input",
   "pty_resize",
@@ -99,12 +116,67 @@ export function parseSandboxMessage(
   return data as CommandResponseMessage;
 }
 
+const VALID_FILE_RESPONSE_TYPES = new Set([
+  "file_ok",
+  "file_error",
+  "file_stat_result",
+  "file_read_result",
+  "file_list_result",
+]);
+
+function parseFileResponseMessage(data: unknown): FileResponseMessage | null {
+  if (typeof data !== "object" || data === null) return null;
+
+  const msg = data as Record<string, unknown>;
+  if (
+    typeof msg.type !== "string" ||
+    !VALID_FILE_RESPONSE_TYPES.has(msg.type)
+  ) {
+    return null;
+  }
+  if (typeof msg.requestId !== "string") return null;
+
+  switch (msg.type) {
+    case "file_error":
+      return typeof msg.message === "string"
+        ? (data as FileResponseMessage)
+        : null;
+    case "file_stat_result":
+      return (msg.kind === "file" ||
+        msg.kind === "missing" ||
+        msg.kind === "not_file") &&
+        typeof msg.path === "string"
+        ? (data as FileResponseMessage)
+        : null;
+    case "file_read_result":
+      return typeof msg.path === "string" &&
+        typeof msg.sizeBytes === "number" &&
+        typeof msg.totalLines === "number"
+        ? (data as FileResponseMessage)
+        : null;
+    case "file_list_result":
+      return Array.isArray(msg.entries) ? (data as FileResponseMessage) : null;
+    case "file_ok":
+      return data as FileResponseMessage;
+    default:
+      return null;
+  }
+}
+
 interface CommandResult {
   stdout: string;
   stderr: string;
   exitCode: number;
   pid?: number;
 }
+
+type DistributiveOmit<T, K extends keyof any> = T extends unknown
+  ? Omit<T, K>
+  : never;
+type FileRequestInput = DistributiveOmit<
+  FileRequestMessage,
+  "requestId" | "targetConnectionId"
+>;
 
 export interface CentrifugoConfig {
   wsUrl: string;
@@ -137,6 +209,13 @@ export class CentrifugoSandbox extends EventEmitter {
 
   supportsPty(): boolean {
     return this.connectionInfo.capabilities?.pty !== false;
+  }
+
+  supportsNativeFileRelay(): boolean {
+    return (
+      this.connectionInfo.isDesktop === true &&
+      this.connectionInfo.capabilities?.files === true
+    );
   }
 
   getUserId(): string {
@@ -191,6 +270,155 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
    */
   getOsContext(): string | null {
     return this.getSandboxContext();
+  }
+
+  private async runFileRequest<T extends FileResponseMessage>(
+    input: FileRequestInput,
+    expectedTypes: Set<string>,
+    timeoutMs = 30000,
+  ): Promise<T> {
+    if (!this.supportsNativeFileRelay()) {
+      throw new Error("Native desktop file relay is not available.");
+    }
+
+    const requestId = crypto.randomUUID();
+    const channel = sandboxConnectionChannel(
+      this.userId,
+      this.connectionInfo.connectionId,
+    );
+    const tokenExpSeconds = Math.ceil(timeoutMs / 1000) + 30;
+    const token = await generateCentrifugoToken(this.userId, tokenExpSeconds);
+    const client = new Centrifuge(this.config.wsUrl, { token });
+    this.activeClients.push(client);
+
+    return new Promise<T>((resolve, reject) => {
+      let settled = false;
+      let timeoutId: NodeJS.Timeout | undefined;
+      let subscription: Subscription | undefined;
+
+      const cleanup = () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = undefined;
+        }
+        if (subscription) {
+          try {
+            subscription.unsubscribe();
+            subscription.removeAllListeners();
+          } catch {
+            // Ignore cleanup errors.
+          }
+        }
+        try {
+          client.disconnect();
+        } catch {
+          // Ignore disconnect errors.
+        }
+        const idx = this.activeClients.indexOf(client);
+        if (idx !== -1) {
+          this.activeClients.splice(idx, 1);
+        }
+      };
+
+      const fail = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      };
+
+      timeoutId = setTimeout(() => {
+        fail(
+          new Error(
+            `Desktop file request timed out after ${timeoutMs}ms connectionId=${this.connectionInfo.connectionId}`,
+          ),
+        );
+      }, timeoutMs + 5000);
+
+      subscription = client.newSubscription(channel);
+      subscription.on("publication", (ctx) => {
+        if (settled) return;
+
+        const message = parseFileResponseMessage(ctx.data);
+        if (!message || message.requestId !== requestId) return;
+
+        if (message.type === "file_error") {
+          fail(new Error(message.message));
+          return;
+        }
+        if (!expectedTypes.has(message.type)) {
+          return;
+        }
+
+        settled = true;
+        cleanup();
+        resolve(message as T);
+      });
+
+      subscription.on("error", (ctx) => {
+        fail(
+          new Error(
+            `Centrifugo file subscription error: ${ctx.error?.message ?? "unknown"}`,
+          ),
+        );
+      });
+
+      subscription.on("subscribed", () => {
+        if (settled || !subscription) return;
+
+        void (async () => {
+          try {
+            const presence = await subscription!.presence();
+            if (
+              !presenceHasConnectionId(
+                presence,
+                this.connectionInfo.connectionId,
+              )
+            ) {
+              fail(
+                new Error(
+                  `Local sandbox connection ${this.connectionInfo.connectionId} is not subscribed to the file relay. Reconnect the Desktop app, wait until it is ready, then try again.`,
+                ),
+              );
+              return;
+            }
+          } catch (error) {
+            console.warn(
+              "[local-file]",
+              JSON.stringify({
+                event: "local_file_presence_check_failed",
+                service: "web",
+                request_id: requestId,
+                connection_id: this.connectionInfo.connectionId,
+                message: error instanceof Error ? error.message : String(error),
+              }),
+            );
+          }
+
+          if (settled || !subscription) return;
+          const request = {
+            ...input,
+            requestId,
+            targetConnectionId: this.connectionInfo.connectionId,
+          } as FileRequestMessage;
+
+          try {
+            await subscription.publish(request);
+          } catch (error) {
+            fail(
+              new Error(
+                `Failed to publish desktop file request: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              ),
+            );
+          }
+        })();
+      });
+
+      subscription.subscribe();
+      client.connect();
+    });
   }
 
   commands = {
@@ -751,11 +979,134 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     return "curl";
   }
 
+  private async statNativeFile(
+    rawPath: string,
+  ): Promise<FileStatResultMessage> {
+    return this.runFileRequest<FileStatResultMessage>(
+      { type: "file_stat", path: rawPath },
+      new Set(["file_stat_result"]),
+      30000,
+    );
+  }
+
+  private async readNativeTextFile(
+    rawPath: string,
+    options: {
+      range?: [number, number];
+      maxFullBytes?: number;
+      maxResultBytes?: number;
+    } = {},
+  ): Promise<FileReadResultMessage> {
+    return this.runFileRequest<FileReadResultMessage>(
+      {
+        type: "file_read",
+        path: rawPath,
+        ...(options.range ? { range: options.range } : {}),
+        ...(typeof options.maxFullBytes === "number"
+          ? { maxFullBytes: options.maxFullBytes }
+          : {}),
+        ...(typeof options.maxResultBytes === "number"
+          ? { maxResultBytes: options.maxResultBytes }
+          : {}),
+      },
+      new Set(["file_read_result"]),
+      120000,
+    );
+  }
+
+  private async writeNativeFile(
+    rawPath: string,
+    content: string | Buffer | ArrayBuffer,
+  ): Promise<void> {
+    const isBase64 = typeof content !== "string";
+    const encodedContent =
+      typeof content === "string"
+        ? content
+        : content instanceof ArrayBuffer
+          ? Buffer.from(content).toString("base64")
+          : content.toString("base64");
+
+    await this.runFileRequest<FileOkMessage>(
+      {
+        type: "file_write",
+        path: rawPath,
+        content: encodedContent,
+        ...(isBase64 ? { isBase64: true } : {}),
+      },
+      new Set(["file_ok"]),
+      120000,
+    );
+  }
+
+  private async appendNativeTextFile(
+    rawPath: string,
+    content: string,
+  ): Promise<void> {
+    await this.runFileRequest<FileOkMessage>(
+      {
+        type: "file_append",
+        path: rawPath,
+        content,
+      },
+      new Set(["file_ok"]),
+      120000,
+    );
+  }
+
+  private async removeNativeFile(rawPath: string): Promise<void> {
+    await this.runFileRequest<FileOkMessage>(
+      { type: "file_remove", path: rawPath },
+      new Set(["file_ok"]),
+      30000,
+    );
+  }
+
+  private async listNativeFiles(
+    rawPath: string,
+  ): Promise<Array<{ name: string }>> {
+    const result = await this.runFileRequest<FileListResultMessage>(
+      { type: "file_list", path: rawPath },
+      new Set(["file_list_result"]),
+      30000,
+    );
+    return result.entries;
+  }
+
   files = {
+    stat: async (rawPath: string): Promise<FileStatResultMessage> => {
+      return this.statNativeFile(rawPath);
+    },
+
+    readText: async (
+      rawPath: string,
+      options?: {
+        range?: [number, number];
+        maxFullBytes?: number;
+        maxResultBytes?: number;
+      },
+    ): Promise<FileReadResultMessage> => {
+      return this.readNativeTextFile(rawPath, options);
+    },
+
+    append: async (rawPath: string, content: string): Promise<void> => {
+      if (this.supportsNativeFileRelay()) {
+        await this.appendNativeTextFile(rawPath, content);
+        return;
+      }
+
+      const existingContent = await this.files.read(rawPath).catch(() => "");
+      await this.files.write(rawPath, existingContent + content);
+    },
+
     write: async (
       rawPath: string,
       content: string | Buffer | ArrayBuffer,
     ): Promise<void> => {
+      if (this.supportsNativeFileRelay()) {
+        await this.writeNativeFile(rawPath, content);
+        return;
+      }
+
       const { useBash, path, escapePath } = await this.shellContext(rawPath);
       const fileName = path.split(/[/\\]/).pop() || "file";
 
@@ -871,6 +1222,14 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     },
 
     read: async (rawPath: string): Promise<string> => {
+      if (this.supportsNativeFileRelay()) {
+        const payload = await this.readNativeTextFile(rawPath);
+        if (payload.tooLarge) {
+          throw new Error(`File is too large to read in full: ${rawPath}`);
+        }
+        return payload.content ?? "";
+      }
+
       const { useBash, path, escapePath } = await this.shellContext(rawPath);
       const fileName = path.split(/[/\\]/).pop() || "file";
       const escaped = escapePath(path);
@@ -914,6 +1273,11 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     },
 
     remove: async (rawPath: string): Promise<void> => {
+      if (this.supportsNativeFileRelay()) {
+        await this.removeNativeFile(rawPath);
+        return;
+      }
+
       const { useBash, path, escapePath } = await this.shellContext(rawPath);
       const fileName = path.split(/[/\\]/).pop() || "file";
       const escaped = escapePath(path);
@@ -931,6 +1295,10 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     },
 
     list: async (rawPath: string = "/"): Promise<{ name: string }[]> => {
+      if (this.supportsNativeFileRelay()) {
+        return this.listNativeFiles(rawPath);
+      }
+
       const { useBash, path, escapePath } = await this.shellContext(rawPath);
       const dirName = path.split(/[/\\]/).pop() || path;
       const escaped = escapePath(path);

--- a/lib/ai/tools/utils/sandbox-types.ts
+++ b/lib/ai/tools/utils/sandbox-types.ts
@@ -18,6 +18,7 @@ export interface ConnectionInfo {
   capabilities?: {
     commands: boolean;
     pty: boolean;
+    files?: boolean;
   };
 }
 

--- a/lib/centrifugo/types.ts
+++ b/lib/centrifugo/types.ts
@@ -41,6 +41,95 @@ export interface ErrorMessage {
   message: string;
 }
 
+// -- Native desktop file relay messages (server -> desktop bridge) ----------
+
+export interface FileStatMessage {
+  type: "file_stat";
+  requestId: string;
+  path: string;
+  targetConnectionId: string;
+}
+
+export interface FileReadMessage {
+  type: "file_read";
+  requestId: string;
+  path: string;
+  range?: [number, number];
+  maxFullBytes?: number;
+  maxResultBytes?: number;
+  targetConnectionId: string;
+}
+
+export interface FileWriteMessage {
+  type: "file_write";
+  requestId: string;
+  path: string;
+  content: string;
+  isBase64?: boolean;
+  targetConnectionId: string;
+}
+
+export interface FileAppendMessage {
+  type: "file_append";
+  requestId: string;
+  path: string;
+  content: string;
+  targetConnectionId: string;
+}
+
+export interface FileRemoveMessage {
+  type: "file_remove";
+  requestId: string;
+  path: string;
+  targetConnectionId: string;
+}
+
+export interface FileListMessage {
+  type: "file_list";
+  requestId: string;
+  path: string;
+  targetConnectionId: string;
+}
+
+// -- Native desktop file relay messages (desktop bridge -> server) ----------
+
+export interface FileOkMessage {
+  type: "file_ok";
+  requestId: string;
+}
+
+export interface FileErrorMessage {
+  type: "file_error";
+  requestId: string;
+  message: string;
+}
+
+export interface FileStatResultMessage {
+  type: "file_stat_result";
+  requestId: string;
+  kind: "file" | "missing" | "not_file";
+  path: string;
+  sizeBytes?: number;
+}
+
+export interface FileReadResultMessage {
+  type: "file_read_result";
+  requestId: string;
+  path: string;
+  sizeBytes: number;
+  totalLines: number;
+  content?: string;
+  startLine?: number;
+  tooLarge?: boolean;
+  truncated?: boolean;
+}
+
+export interface FileListResultMessage {
+  type: "file_list_result";
+  requestId: string;
+  entries: Array<{ name: string }>;
+}
+
 // ── PTY incoming messages (server → local runner / desktop bridge) ────
 
 export interface PtyCreateMessage {
@@ -110,9 +199,26 @@ export type CommandResponseMessage =
   | ExitMessage
   | ErrorMessage;
 
+export type FileRequestMessage =
+  | FileStatMessage
+  | FileReadMessage
+  | FileWriteMessage
+  | FileAppendMessage
+  | FileRemoveMessage
+  | FileListMessage;
+
+export type FileResponseMessage =
+  | FileOkMessage
+  | FileErrorMessage
+  | FileStatResultMessage
+  | FileReadResultMessage
+  | FileListResultMessage;
+
 /** Full union of all messages that travel over the sandbox Centrifugo channel. */
 export type SandboxMessage =
   | CommandResponseMessage
+  | FileRequestMessage
+  | FileResponseMessage
   | PtyCreateMessage
   | PtyInputMessage
   | PtyResizeMessage

--- a/lib/centrifugo/types.ts
+++ b/lib/centrifugo/types.ts
@@ -74,6 +74,7 @@ export interface FileAppendMessage {
   requestId: string;
   path: string;
   content: string;
+  isBase64?: boolean;
   targetConnectionId: string;
 }
 

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::Manager;
 use tauri_plugin_updater::UpdaterExt;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
 const DESKTOP_AUTH_STATE_TTL: Duration = Duration::from_secs(5 * 60);
@@ -304,6 +304,10 @@ async fn wait_with_output_or_kill_on_timeout(
 #[derive(Deserialize)]
 struct FileReadRequest {
     path: String,
+    range_start: Option<u64>,
+    range_end: Option<i64>,
+    max_full_bytes: Option<u64>,
+    max_result_bytes: Option<usize>,
 }
 
 #[derive(Deserialize)]
@@ -320,7 +324,18 @@ struct FileRemoveRequest {
 }
 
 #[derive(Deserialize)]
+struct FileAppendRequest {
+    path: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
 struct FileListRequest {
+    path: String,
+}
+
+#[derive(Deserialize)]
+struct FileStatRequest {
     path: String,
 }
 
@@ -524,8 +539,10 @@ async fn handle_cmd_request(
 
     let result = match (method.as_str(), route_path) {
         ("POST", "/execute") => handle_execute(&body).await,
+        ("POST", "/files/stat") => handle_file_stat(&body).await,
         ("POST", "/files/read") => handle_file_read(&body).await,
         ("POST", "/files/write") => handle_file_write(&body).await,
+        ("POST", "/files/append") => handle_file_append(&body).await,
         ("POST", "/files/remove") => handle_file_remove(&body).await,
         ("POST", "/files/list") => handle_file_list(&body).await,
         (_, "/health") => Ok(r#"{"status":"ok"}"#.to_string()),
@@ -713,13 +730,162 @@ async fn write_chunk(stream: &mut tokio::net::TcpStream, data: &str) {
     let _ = stream.flush().await;
 }
 
+async fn count_file_lines(path: &std::path::Path, file_size: u64) -> Result<u64, String> {
+    if file_size == 0 {
+        return Ok(0);
+    }
+
+    let mut file = tokio::fs::File::open(path)
+        .await
+        .map_err(|e| format!("Open error: {}", e))?;
+    let mut buf = [0u8; 64 * 1024];
+    let mut lines = 0u64;
+    let mut last_byte = 0u8;
+
+    loop {
+        let n = file
+            .read(&mut buf)
+            .await
+            .map_err(|e| format!("Read error: {}", e))?;
+        if n == 0 {
+            break;
+        }
+        lines += buf[..n].iter().filter(|&&b| b == b'\n').count() as u64;
+        last_byte = buf[n - 1];
+    }
+
+    if last_byte != b'\n' {
+        lines += 1;
+    }
+
+    Ok(lines)
+}
+
+async fn handle_file_stat(body: &str) -> Result<String, String> {
+    let req: FileStatRequest =
+        serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
+    let path = std::path::Path::new(&req.path);
+
+    let payload = match tokio::fs::metadata(path).await {
+        Ok(metadata) if metadata.is_file() => serde_json::json!({
+            "kind": "file",
+            "path": req.path,
+            "sizeBytes": metadata.len(),
+        }),
+        Ok(_) => serde_json::json!({
+            "kind": "not_file",
+            "path": req.path,
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => serde_json::json!({
+            "kind": "missing",
+            "path": req.path,
+        }),
+        Err(error) => return Err(format!("Metadata error: {}", error)),
+    };
+
+    serde_json::to_string(&payload).map_err(|e| e.to_string())
+}
+
 async fn handle_file_read(body: &str) -> Result<String, String> {
     let req: FileReadRequest =
         serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
-    let content = tokio::fs::read_to_string(&req.path)
+    let path = std::path::Path::new(&req.path);
+    let metadata = tokio::fs::metadata(path)
         .await
-        .map_err(|e| format!("Read error: {}", e))?;
-    serde_json::to_string(&serde_json::json!({ "content": content })).map_err(|e| e.to_string())
+        .map_err(|e| format!("Metadata error: {}", e))?;
+    if !metadata.is_file() {
+        return Err("Selected path is not a file".to_string());
+    }
+
+    let range_start = req.range_start.unwrap_or(0);
+    let range_end = req.range_end.unwrap_or(-1);
+    let max_full_bytes = req.max_full_bytes.unwrap_or(1024 * 1024);
+    let max_result_bytes = req.max_result_bytes.unwrap_or(1024 * 1024);
+    let size_bytes = metadata.len();
+    let total_lines = count_file_lines(path, size_bytes).await?;
+
+    if range_start == 0 && size_bytes > max_full_bytes {
+        return serde_json::to_string(&serde_json::json!({
+            "path": req.path,
+            "sizeBytes": size_bytes,
+            "totalLines": total_lines,
+            "tooLarge": true,
+        }))
+        .map_err(|e| e.to_string());
+    }
+
+    if range_start > 0 {
+        if range_end != -1 && range_end < range_start as i64 {
+            return Err(format!(
+                "Invalid range: start_line ({}) cannot be greater than end_line ({}).",
+                range_start, range_end
+            ));
+        }
+        if range_start > total_lines {
+            return Err(format!(
+                "Invalid start_line: {}. File has {} lines (1-indexed).",
+                range_start, total_lines
+            ));
+        }
+        if range_end != -1 && range_end as u64 > total_lines {
+            return Err(format!(
+                "Invalid end_line: {}. File has {} lines (1-indexed).",
+                range_end, total_lines
+            ));
+        }
+    }
+
+    let file = tokio::fs::File::open(path)
+        .await
+        .map_err(|e| format!("Open error: {}", e))?;
+    let mut reader = tokio::io::BufReader::new(file);
+    let mut line = Vec::<u8>::new();
+    let mut line_no = 0u64;
+    let mut selected = Vec::<u8>::new();
+    let mut truncated = false;
+    let start_line = if range_start > 0 { range_start } else { 1 };
+
+    loop {
+        line.clear();
+        let bytes_read = reader
+            .read_until(b'\n', &mut line)
+            .await
+            .map_err(|e| format!("Read error: {}", e))?;
+        if bytes_read == 0 {
+            break;
+        }
+        line_no += 1;
+
+        if range_start > 0 && line_no < range_start {
+            continue;
+        }
+        if range_start > 0 && range_end != -1 && line_no > range_end as u64 {
+            break;
+        }
+
+        let remaining = max_result_bytes.saturating_sub(selected.len());
+        if remaining == 0 {
+            truncated = true;
+            break;
+        }
+        if line.len() > remaining {
+            selected.extend_from_slice(&line[..remaining]);
+            truncated = true;
+            break;
+        }
+        selected.extend_from_slice(&line);
+    }
+
+    let content = String::from_utf8_lossy(&selected).to_string();
+    serde_json::to_string(&serde_json::json!({
+        "path": req.path,
+        "sizeBytes": size_bytes,
+        "totalLines": total_lines,
+        "content": content,
+        "startLine": start_line,
+        "truncated": truncated,
+    }))
+    .map_err(|e| e.to_string())
 }
 
 async fn handle_file_write(body: &str) -> Result<String, String> {
@@ -746,6 +912,32 @@ async fn handle_file_write(body: &str) -> Result<String, String> {
             .await
             .map_err(|e| format!("Write error: {}", e))?;
     }
+
+    Ok(r#"{"ok":true}"#.to_string())
+}
+
+async fn handle_file_append(body: &str) -> Result<String, String> {
+    let req: FileAppendRequest =
+        serde_json::from_str(body).map_err(|e| format!("Invalid JSON: {}", e))?;
+
+    if let Some(parent) = std::path::Path::new(&req.path).parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("Mkdir error: {}", e))?;
+    }
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&req.path)
+        .await
+        .map_err(|e| format!("Open error: {}", e))?;
+    file.write_all(req.content.as_bytes())
+        .await
+        .map_err(|e| format!("Append error: {}", e))?;
+    file.flush()
+        .await
+        .map_err(|e| format!("Flush error: {}", e))?;
 
     Ok(r#"{"ok":true}"#.to_string())
 }

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -327,6 +327,8 @@ struct FileRemoveRequest {
 struct FileAppendRequest {
     path: String,
     content: String,
+    #[serde(default)]
+    is_base64: bool,
 }
 
 #[derive(Deserialize)]
@@ -802,7 +804,12 @@ async fn handle_file_read(body: &str) -> Result<String, String> {
     let max_full_bytes = req.max_full_bytes.unwrap_or(1024 * 1024);
     let max_result_bytes = req.max_result_bytes.unwrap_or(1024 * 1024);
     let size_bytes = metadata.len();
-    let total_lines = count_file_lines(path, size_bytes).await?;
+    let should_count_lines = range_start == 0 || size_bytes <= max_full_bytes;
+    let total_lines = if should_count_lines {
+        count_file_lines(path, size_bytes).await?
+    } else {
+        0
+    };
 
     if range_start == 0 && size_bytes > max_full_bytes {
         return serde_json::to_string(&serde_json::json!({
@@ -814,7 +821,7 @@ async fn handle_file_read(body: &str) -> Result<String, String> {
         .map_err(|e| e.to_string());
     }
 
-    if range_start > 0 {
+    if range_start > 0 && should_count_lines {
         if range_end != -1 && range_end < range_start as i64 {
             return Err(format!(
                 "Invalid range: start_line ({}) cannot be greater than end_line ({}).",
@@ -932,9 +939,19 @@ async fn handle_file_append(body: &str) -> Result<String, String> {
         .open(&req.path)
         .await
         .map_err(|e| format!("Open error: {}", e))?;
-    file.write_all(req.content.as_bytes())
-        .await
-        .map_err(|e| format!("Append error: {}", e))?;
+    if req.is_base64 {
+        use base64::Engine;
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&req.content)
+            .map_err(|e| format!("Base64 decode error: {}", e))?;
+        file.write_all(&bytes)
+            .await
+            .map_err(|e| format!("Append error: {}", e))?;
+    } else {
+        file.write_all(req.content.as_bytes())
+            .await
+            .map_err(|e| format!("Append error: {}", e))?;
+    }
     file.flush()
         .await
         .map_err(|e| format!("Flush error: {}", e))?;


### PR DESCRIPTION
## Summary

- Add a native Desktop file relay for stat/read/write/append/remove/list so updated Windows Desktop Agent mode bypasses shell/Python file operations.
- Gate the relay behind an optional `files: true` connection capability so older desktop builds keep the existing fallback instead of timing out.
- Add bounded Rust file read/stat/append endpoints and preserve CRLF line endings during append/edit flows.

## Verification

- `pnpm typecheck`
- `pnpm test -- --runTestsByPath lib/ai/tools/__tests__/file.test.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts app/services/__tests__/desktop-sandbox-bridge.test.ts`
- `pnpm exec eslint app/services/desktop-sandbox-bridge.ts app/services/__tests__/desktop-sandbox-bridge.test.ts app/contexts/GlobalState.tsx lib/ai/tools/file.ts lib/ai/tools/__tests__/file.test.ts lib/ai/tools/utils/centrifugo-sandbox.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts lib/ai/tools/utils/sandbox-types.ts lib/centrifugo/types.ts convex/localSandbox.ts convex/schema.ts`
- `git diff --check`
- Pre-commit hook: Prettier, ESLint, `pnpm typecheck`, full Jest: 213 suites / 2163 tests passed

Not run locally: Rust `cargo`/`rustfmt`, because this container does not have those binaries installed.

## Manual Verification

- Where: Updated HackerAI Desktop app on Windows, connected as the local Desktop sandbox in Agent mode.
- What to do: Ask Agent mode to read, edit, append, and write a CRLF text file such as `C:\repo\app.ts`.
- Expected: File operations complete through the native Desktop relay without shell/Python temp-file failures, and CRLF files keep CRLF after edits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native desktop file relay for stat, read, write, append, delete, and list operations.
  * Updated desktop connection capability reporting to advertise file support.
* **Bug Fixes**
  * Improved native file reading with safer large-file handling, truncation limits, and accurate line-range behavior.
  * Normalized line endings during text edits and appends for consistent cross-platform results.
* **Tests**
  * Added and expanded coverage for native desktop file relay behavior, capability gating/reporting, and large-text/edit safety scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->