### PR TITLE
Guard agent realtime stream chunk size

### DIFF
--- a/lib/chat/__tests__/agent-long-realtime-sanitizer.test.ts
+++ b/lib/chat/__tests__/agent-long-realtime-sanitizer.test.ts
@@ -82,9 +82,36 @@ describe("sanitizeAgentLongRealtimeChunk", () => {
     const sanitized = sanitizeAgentLongRealtimeChunk(chunk);
 
     expect(sanitized.length).toBeGreaterThan(1);
-    expect(sanitized.map((part) => getBytes(part))).toEqual(
-      expect.arrayContaining([expect.any(Number)]),
+    expect(
+      sanitized.every(
+        (part) => getBytes(part) < AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES,
+      ),
+    ).toBe(true);
+    expect(
+      sanitized
+        .map((part) => (part.data as { terminal: string }).terminal)
+        .join(""),
+    ).toBe(terminal);
+  });
+
+  it("accounts for JSON escaping when splitting terminal data", () => {
+    const terminal = "\x1b".repeat(200_000);
+    const chunk = {
+      type: "data-terminal",
+      id: "terminal-escape",
+      data: {
+        terminal,
+        toolCallId: "call_4",
+      },
+    };
+
+    expect(getBytes(chunk)).toBeGreaterThan(
+      AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES,
     );
+
+    const sanitized = sanitizeAgentLongRealtimeChunk(chunk);
+
+    expect(sanitized.length).toBeGreaterThan(1);
     expect(
       sanitized.every(
         (part) => getBytes(part) < AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES,

--- a/lib/chat/__tests__/agent-long-realtime-sanitizer.test.ts
+++ b/lib/chat/__tests__/agent-long-realtime-sanitizer.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES,
+  sanitizeAgentLongRealtimeChunk,
+} from "../agent-long-realtime-sanitizer";
+
+const getBytes = (value: unknown) =>
+  new TextEncoder().encode(JSON.stringify(value)).byteLength;
+
+describe("sanitizeAgentLongRealtimeChunk", () => {
+  it("keeps small chunks by reference", () => {
+    const chunk = { type: "text-delta", id: "t1", delta: "hello" };
+
+    expect(sanitizeAgentLongRealtimeChunk(chunk)).toEqual([chunk]);
+  });
+
+  it("compacts oversized tool-input-error chunks", () => {
+    const command = "curl https://example.test ".repeat(70_000);
+    const chunk = {
+      type: "tool-input-error",
+      toolCallId: "call_1",
+      toolName: "run_terminal_cmd",
+      input: {
+        command,
+        interactive: false,
+        is_background: false,
+      },
+      errorText: `Invalid input for tool run_terminal_cmd: ${command}`,
+    };
+
+    expect(getBytes(chunk)).toBeGreaterThan(
+      AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES,
+    );
+
+    const [sanitized] = sanitizeAgentLongRealtimeChunk(chunk);
+
+    expect(sanitized.type).toBe("tool-input-error");
+    expect(getBytes(sanitized)).toBeLessThan(
+      AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES,
+    );
+    expect(
+      ((sanitized.input as Record<string, unknown>).command as string).length,
+    ).toBeLessThan(command.length);
+    expect((sanitized.errorText as string).length).toBeLessThan(
+      chunk.errorText.length,
+    );
+  });
+
+  it("compacts oversized tool outputs", () => {
+    const html = "<main>payload</main>".repeat(90_000);
+    const chunk = {
+      type: "tool-output-available",
+      toolCallId: "call_2",
+      output: {
+        html,
+        status: 200,
+      },
+    };
+
+    const [sanitized] = sanitizeAgentLongRealtimeChunk(chunk);
+
+    expect(sanitized.type).toBe("tool-output-available");
+    expect(getBytes(sanitized)).toBeLessThan(
+      AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES,
+    );
+    expect(
+      ((sanitized.output as Record<string, unknown>).html as string).length,
+    ).toBeLessThan(html.length);
+  });
+
+  it("splits oversized terminal data chunks", () => {
+    const terminal = "a".repeat(1_100_000);
+    const chunk = {
+      type: "data-terminal",
+      id: "terminal-1",
+      data: {
+        terminal,
+        toolCallId: "call_3",
+      },
+    };
+
+    const sanitized = sanitizeAgentLongRealtimeChunk(chunk);
+
+    expect(sanitized.length).toBeGreaterThan(1);
+    expect(sanitized.map((part) => getBytes(part))).toEqual(
+      expect.arrayContaining([expect.any(Number)]),
+    );
+    expect(
+      sanitized.every(
+        (part) => getBytes(part) < AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES,
+      ),
+    ).toBe(true);
+    expect(
+      sanitized
+        .map((part) => (part.data as { terminal: string }).terminal)
+        .join(""),
+    ).toBe(terminal);
+  });
+});

--- a/lib/chat/agent-long-realtime-sanitizer.ts
+++ b/lib/chat/agent-long-realtime-sanitizer.ts
@@ -1,0 +1,308 @@
+type AgentLongStreamChunk = Record<string, unknown> & {
+  type?: string;
+  id?: string;
+};
+
+const encoder = new TextEncoder();
+
+// Trigger's realtime stream rejects records just under 1 MiB. Keep a buffer for
+// JSON/envelope overhead before chunks are piped to agentUiStream.
+export const AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES = 900_000;
+export const AGENT_LONG_REALTIME_STRING_SLICE_CHARS = 8_000;
+export const AGENT_LONG_REALTIME_DELTA_SLICE_CHARS = 180_000;
+
+const TRUNCATED_MARKER = "[truncated for realtime stream]";
+
+const getSerializedBytes = (value: unknown): number => {
+  try {
+    return encoder.encode(JSON.stringify(value)).byteLength;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+};
+
+const safeStringify = (value: unknown): string => {
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const truncateMiddle = (
+  value: string,
+  maxChars = AGENT_LONG_REALTIME_STRING_SLICE_CHARS,
+): string => {
+  if (value.length <= maxChars) return value;
+  const head = Math.floor(maxChars * 0.7);
+  const tail = Math.max(0, maxChars - head);
+  const omittedChars = value.length - maxChars;
+  const notice = `...${TRUNCATED_MARKER} ${omittedChars} chars omitted...`;
+  return `${value.slice(0, head)}\n${notice}\n${value.slice(-tail)}`;
+};
+
+const makeRealtimePlaceholder = (
+  value: unknown,
+  context: string,
+): Record<string, unknown> => {
+  const originalBytes = getSerializedBytes(value);
+  const preview =
+    typeof value === "string"
+      ? truncateMiddle(value)
+      : truncateMiddle(safeStringify(value));
+
+  return {
+    __hackeraiRealtimeTruncated: true,
+    context,
+    originalBytes,
+    preview,
+  };
+};
+
+const compactValueForRealtime = (
+  value: unknown,
+  context: string,
+  depth = 0,
+  seen = new WeakSet<object>(),
+): unknown => {
+  if (typeof value === "string") {
+    return truncateMiddle(value);
+  }
+
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return "[circular]";
+  }
+  seen.add(value);
+
+  if (depth >= 4) {
+    return makeRealtimePlaceholder(value, `${context}.depth`);
+  }
+
+  if (Array.isArray(value)) {
+    const maxItems = 25;
+    const compacted = value
+      .slice(0, maxItems)
+      .map((item, index) =>
+        compactValueForRealtime(item, `${context}[${index}]`, depth + 1, seen),
+      );
+    if (value.length > maxItems) {
+      compacted.push({
+        __hackeraiRealtimeTruncated: true,
+        omittedItems: value.length - maxItems,
+      });
+    }
+    return compacted;
+  }
+
+  const compacted: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    compacted[key] = compactValueForRealtime(
+      child,
+      `${context}.${key}`,
+      depth + 1,
+      seen,
+    );
+  }
+
+  if (
+    getSerializedBytes(compacted) >
+    AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES / 2
+  ) {
+    return makeRealtimePlaceholder(value, context);
+  }
+
+  return compacted;
+};
+
+const compactErrorText = (value: unknown): unknown =>
+  typeof value === "string" ? truncateMiddle(value, 4_000) : value;
+
+const splitString = (value: string): string[] => {
+  if (
+    encoder.encode(value).byteLength <= AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES
+  ) {
+    return [value];
+  }
+
+  const parts: string[] = [];
+  for (
+    let index = 0;
+    index < value.length;
+    index += AGENT_LONG_REALTIME_DELTA_SLICE_CHARS
+  ) {
+    parts.push(
+      value.slice(index, index + AGENT_LONG_REALTIME_DELTA_SLICE_CHARS),
+    );
+  }
+  return parts;
+};
+
+const withSplitStringField = (
+  chunk: AgentLongStreamChunk,
+  field: string,
+): AgentLongStreamChunk[] | null => {
+  const value = chunk[field];
+  if (typeof value !== "string") return null;
+
+  const parts = splitString(value);
+  if (parts.length === 1) return null;
+
+  return parts.map((part) => ({
+    ...chunk,
+    [field]: part,
+  }));
+};
+
+const withSplitNestedStringField = (
+  chunk: AgentLongStreamChunk,
+  containerField: string,
+  field: string,
+): AgentLongStreamChunk[] | null => {
+  const container = chunk[containerField];
+  if (!container || typeof container !== "object" || Array.isArray(container)) {
+    return null;
+  }
+
+  const value = (container as Record<string, unknown>)[field];
+  if (typeof value !== "string") return null;
+
+  const parts = splitString(value);
+  if (parts.length === 1) return null;
+
+  const baseId = typeof chunk.id === "string" ? chunk.id : chunk.type;
+  return parts.map((part, index) => ({
+    ...chunk,
+    id: `${baseId}-${index + 1}`,
+    [containerField]: {
+      ...container,
+      [field]: part,
+    },
+  }));
+};
+
+const compactKnownOversizedChunk = (
+  chunk: AgentLongStreamChunk,
+): AgentLongStreamChunk => {
+  switch (chunk.type) {
+    case "tool-input-error":
+      return {
+        ...chunk,
+        input: compactValueForRealtime(chunk.input, "tool-input-error.input"),
+        errorText: compactErrorText(chunk.errorText),
+      };
+    case "tool-input-available":
+      return {
+        ...chunk,
+        input: compactValueForRealtime(
+          chunk.input,
+          "tool-input-available.input",
+        ),
+      };
+    case "tool-output-available":
+      return {
+        ...chunk,
+        output: compactValueForRealtime(
+          chunk.output,
+          "tool-output-available.output",
+        ),
+      };
+    case "tool-output-error":
+    case "error":
+      return {
+        ...chunk,
+        errorText: compactErrorText(chunk.errorText),
+        error: compactErrorText(chunk.error),
+      };
+    default:
+      return {
+        type: "data-agent-stream-warning",
+        data: makeRealtimePlaceholder(chunk, "ui-chunk"),
+        transient: true,
+      };
+  }
+};
+
+const minimalKnownChunk = (
+  chunk: AgentLongStreamChunk,
+  originalBytes: number,
+): AgentLongStreamChunk => {
+  const base = {
+    type: chunk.type,
+    toolCallId: chunk.toolCallId,
+    toolName: chunk.toolName,
+    dynamic: chunk.dynamic,
+  };
+  const placeholder = {
+    __hackeraiRealtimeTruncated: true,
+    originalBytes,
+    message:
+      "This payload was too large for the realtime stream and was compacted.",
+  };
+
+  switch (chunk.type) {
+    case "tool-input-error":
+      return {
+        ...base,
+        input: placeholder,
+        errorText:
+          "Tool input was too large to stream in full and was compacted.",
+      };
+    case "tool-input-available":
+      return {
+        ...base,
+        input: placeholder,
+      };
+    case "tool-output-available":
+      return {
+        ...base,
+        output: placeholder,
+      };
+    case "tool-output-error":
+      return {
+        ...base,
+        errorText:
+          "Tool error payload was too large to stream in full and was compacted.",
+      };
+    default:
+      return {
+        type: "data-agent-stream-warning",
+        data: placeholder,
+        transient: true,
+      };
+  }
+};
+
+export const sanitizeAgentLongRealtimeChunk = (
+  chunk: AgentLongStreamChunk,
+): AgentLongStreamChunk[] => {
+  const splitDelta =
+    (chunk.type === "text-delta" || chunk.type === "reasoning-delta") &&
+    withSplitStringField(chunk, "delta");
+  if (splitDelta) return splitDelta;
+
+  const splitToolInput =
+    chunk.type === "tool-input-delta" &&
+    withSplitStringField(chunk, "inputTextDelta");
+  if (splitToolInput) return splitToolInput;
+
+  const splitTerminal =
+    chunk.type === "data-terminal" &&
+    withSplitNestedStringField(chunk, "data", "terminal");
+  if (splitTerminal) return splitTerminal;
+
+  const originalBytes = getSerializedBytes(chunk);
+  if (originalBytes <= AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES) {
+    return [chunk];
+  }
+
+  const compacted = compactKnownOversizedChunk(chunk);
+  if (getSerializedBytes(compacted) <= AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES) {
+    return [compacted];
+  }
+
+  return [minimalKnownChunk(chunk, originalBytes)];
+};

--- a/lib/chat/agent-long-realtime-sanitizer.ts
+++ b/lib/chat/agent-long-realtime-sanitizer.ts
@@ -1,4 +1,4 @@
-type AgentLongStreamChunk = Record<string, unknown> & {
+export type AgentLongStreamChunk = Record<string, unknown> & {
   type?: string;
   id?: string;
 };
@@ -121,22 +121,40 @@ const compactValueForRealtime = (
 const compactErrorText = (value: unknown): unknown =>
   typeof value === "string" ? truncateMiddle(value, 4_000) : value;
 
-const splitString = (value: string): string[] => {
-  if (
-    encoder.encode(value).byteLength <= AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES
-  ) {
+const splitString = (
+  value: string,
+  getCandidateBytes?: (candidate: string) => number,
+): string[] | null => {
+  const candidateFits = (candidate: string) => {
+    const bytes =
+      getCandidateBytes?.(candidate) ?? encoder.encode(candidate).byteLength;
+    return bytes <= AGENT_LONG_REALTIME_SAFE_CHUNK_BYTES;
+  };
+
+  if (candidateFits(value)) {
     return [value];
   }
 
   const parts: string[] = [];
-  for (
-    let index = 0;
-    index < value.length;
-    index += AGENT_LONG_REALTIME_DELTA_SLICE_CHARS
-  ) {
-    parts.push(
-      value.slice(index, index + AGENT_LONG_REALTIME_DELTA_SLICE_CHARS),
+  let index = 0;
+  while (index < value.length) {
+    let end = Math.min(
+      value.length,
+      index + AGENT_LONG_REALTIME_DELTA_SLICE_CHARS,
     );
+    let part = value.slice(index, end);
+
+    while (part.length > 1 && !candidateFits(part)) {
+      end = index + Math.max(1, Math.floor(part.length * 0.8));
+      part = value.slice(index, end);
+    }
+
+    if (!candidateFits(part)) {
+      return null;
+    }
+
+    parts.push(part);
+    index = end;
   }
   return parts;
 };
@@ -148,7 +166,10 @@ const withSplitStringField = (
   const value = chunk[field];
   if (typeof value !== "string") return null;
 
-  const parts = splitString(value);
+  const parts = splitString(value, (candidate) =>
+    getSerializedBytes({ ...chunk, [field]: candidate }),
+  );
+  if (!parts) return null;
   if (parts.length === 1) return null;
 
   return parts.map((part) => ({
@@ -170,7 +191,16 @@ const withSplitNestedStringField = (
   const value = (container as Record<string, unknown>)[field];
   if (typeof value !== "string") return null;
 
-  const parts = splitString(value);
+  const parts = splitString(value, (candidate) =>
+    getSerializedBytes({
+      ...chunk,
+      [containerField]: {
+        ...container,
+        [field]: candidate,
+      },
+    }),
+  );
+  if (!parts) return null;
   if (parts.length === 1) return null;
 
   const baseId = typeof chunk.id === "string" ? chunk.id : chunk.type;

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -137,6 +137,7 @@ import {
   AGENT_LONG_HEARTBEAT_PART_TYPE,
   stripAgentLongHeartbeatParts,
 } from "@/lib/chat/agent-long-heartbeat";
+import { sanitizeAgentLongRealtimeChunk } from "@/lib/chat/agent-long-realtime-sanitizer";
 import {
   BUDGET_EXHAUSTION_FINISH_REASON,
   PREEMPTIVE_TIMEOUT_FINISH_REASON,
@@ -889,7 +890,11 @@ const withAgentLongStreamHeartbeat = (
               safeClose();
               return;
             }
-            safeEnqueue(value);
+            for (const part of sanitizeAgentLongRealtimeChunk(
+              value as Record<string, unknown> & { type?: string },
+            )) {
+              safeEnqueue(part as AgentLongUiStreamPart);
+            }
           }
         } catch (error) {
           safeError(error);

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -137,7 +137,10 @@ import {
   AGENT_LONG_HEARTBEAT_PART_TYPE,
   stripAgentLongHeartbeatParts,
 } from "@/lib/chat/agent-long-heartbeat";
-import { sanitizeAgentLongRealtimeChunk } from "@/lib/chat/agent-long-realtime-sanitizer";
+import {
+  sanitizeAgentLongRealtimeChunk,
+  type AgentLongStreamChunk,
+} from "@/lib/chat/agent-long-realtime-sanitizer";
 import {
   BUDGET_EXHAUSTION_FINISH_REASON,
   PREEMPTIVE_TIMEOUT_FINISH_REASON,
@@ -891,7 +894,7 @@ const withAgentLongStreamHeartbeat = (
               return;
             }
             for (const part of sanitizeAgentLongRealtimeChunk(
-              value as Record<string, unknown> & { type?: string },
+              value as AgentLongStreamChunk,
             )) {
               safeEnqueue(part as AgentLongUiStreamPart);
             }


### PR DESCRIPTION
## Summary
- add an agent-long realtime chunk sanitizer before piping UI chunks to Trigger streams
- compact oversized tool input/error/output payloads and split oversized text/terminal deltas
- validate split candidates by serialized chunk size so escaped terminal/control bytes stay under the realtime record cap
- cover the oversized `tool-input-error` repro path plus output, terminal, and JSON-escaping split cases

## Verification
- `pnpm test -- lib/chat/__tests__/agent-long-realtime-sanitizer.test.ts`
- `pnpm exec prettier --check lib/chat/agent-long-realtime-sanitizer.ts lib/chat/__tests__/agent-long-realtime-sanitizer.test.ts trigger/agent-long.ts`
- `pnpm exec eslint lib/chat/agent-long-realtime-sanitizer.ts lib/chat/__tests__/agent-long-realtime-sanitizer.test.ts trigger/agent-long.ts`
- `pnpm typecheck`
- pre-commit hook: `pnpm typecheck` and full `pnpm test` (216 suites, 2185 tests)

## Manual Verification
- In Agent mode, trigger a tool call with an oversized invalid terminal input.
- The chat stream should continue instead of failing with `ChatChunkTooLargeError`.
- The rendered tool error should show a compacted/truncated input payload rather than the full oversized body.