### PR TITLE
Fix sandbox attachment upload timeouts

### DIFF
--- a/lib/__tests__/errors.test.ts
+++ b/lib/__tests__/errors.test.ts
@@ -27,3 +27,11 @@ describe("isNetworkStreamError", () => {
     );
   });
 });
+
+describe("ChatSDKError messages", () => {
+  it("uses a sandbox-specific message for attachment upload failures", () => {
+    expect(new ChatSDKError("bad_request:sandbox").message).toBe(
+      "The computer attachment upload failed.",
+    );
+  });
+});

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -859,6 +859,66 @@ describe("CentrifugoSandbox", () => {
       });
     });
 
+    it("uploadToUrl retries transient command relay timeouts during wget setup probes", async () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      const sandbox = createSandbox({
+        osInfo: {
+          platform: "linux",
+          arch: "x64",
+          release: "6.1",
+          hostname: "devbox",
+        },
+      });
+      (sandbox as any).httpClient = "wget";
+      const run = jest
+        .fn()
+        .mockRejectedValueOnce(
+          new Error(
+            "Command timeout after 35000ms [connected: 75ms, subscribed: 75ms, published: 104ms, firstMsg: no] connectionId=conn-1",
+          ),
+        )
+        .mockResolvedValueOnce({
+          stdout: "GNU Wget 1.21.4\n",
+          stderr: "",
+          exitCode: 0,
+        })
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+      (sandbox as any).commands.run = run;
+
+      try {
+        const promise = sandbox.files.uploadToUrl(
+          "/tmp/hackerai-upload/report.txt",
+          "https://example.com/upload",
+          "text/plain",
+        );
+
+        await jest.advanceTimersByTimeAsync(500);
+        await promise;
+
+        expect(run).toHaveBeenCalledTimes(3);
+        expect(run).toHaveBeenNthCalledWith(1, "wget 2>&1 | head -1", {
+          displayName: "",
+          timeoutMs: 30000,
+        });
+        expect(run).toHaveBeenNthCalledWith(2, "wget 2>&1 | head -1", {
+          displayName: "",
+          timeoutMs: 30000,
+        });
+        expect(run).toHaveBeenNthCalledWith(
+          3,
+          expect.stringContaining("wget -q --method=PUT"),
+          {
+            displayName: "Uploading: report.txt",
+            timeoutMs: 120000,
+          },
+        );
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
+    });
+
     it("downloadFromUrl failure diagnostics do not list local directory contents", async () => {
       const consoleWarnSpy = jest
         .spyOn(console, "warn")

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -1013,6 +1013,69 @@ describe("CentrifugoSandbox", () => {
       }
     });
 
+    it("downloadFromUrl retries transient command relay timeouts during setup probes", async () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      const sandbox = createSandbox({
+        osInfo: {
+          platform: "linux",
+          arch: "x64",
+          release: "6.1",
+          hostname: "devbox",
+        },
+      });
+      const run = jest
+        .fn()
+        .mockRejectedValueOnce(
+          new Error(
+            "Command timeout after 35000ms [connected: 75ms, subscribed: 75ms, published: 104ms, firstMsg: no] connectionId=conn-1",
+          ),
+        )
+        .mockResolvedValueOnce({
+          stdout: "/usr/bin/curl\n",
+          stderr: "",
+          exitCode: 0,
+        })
+        .mockResolvedValueOnce({
+          stdout: "--retry-all-errors --retry-connrefused\n",
+          stderr: "",
+          exitCode: 0,
+        })
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+      (sandbox as any).commands.run = run;
+
+      try {
+        const promise = sandbox.files.downloadFromUrl(
+          "https://example.com/image.png",
+          "/tmp/hackerai-upload/image.png",
+        );
+
+        await jest.advanceTimersByTimeAsync(500);
+        await promise;
+
+        expect(run).toHaveBeenCalledTimes(4);
+        expect(run).toHaveBeenNthCalledWith(1, "command -v curl || true", {
+          displayName: "",
+          timeoutMs: 30000,
+        });
+        expect(run).toHaveBeenNthCalledWith(2, "command -v curl || true", {
+          displayName: "",
+          timeoutMs: 30000,
+        });
+        expect(run).toHaveBeenNthCalledWith(
+          4,
+          expect.stringContaining("curl -fsSL"),
+          {
+            displayName: "Downloading: image.png",
+            timeoutMs: 120000,
+          },
+        );
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
+    });
+
     it("ensureDirectory emits mkdir -p with MSYS path", async () => {
       const { sandbox, runs } = createWindowsBashSandbox();
       await (sandbox as any).ensureDirectory("C:\\temp\\hackerai-upload");

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -50,6 +50,9 @@ const IGNORED_MESSAGE_TYPES = new Set([
 ]);
 
 const FILE_DOWNLOAD_TIMEOUT_MS = 120000;
+const SETUP_COMMAND_TIMEOUT_MS = 30000;
+const SETUP_COMMAND_MAX_ATTEMPTS = 2;
+const SETUP_COMMAND_RETRY_DELAY_MS = 500;
 const TRANSIENT_COMMAND_TIMEOUT_ERROR_PATTERN =
   /\b(?:deadline_exceeded|operation timed out:.*\btimeoutMs\b|exceeding ['"]?timeoutMs['"]?|Command timeout after \d+ms)\b/i;
 
@@ -58,6 +61,9 @@ const getErrorMessage = (error: unknown): string =>
 
 const isTransientCommandTimeoutError = (error: unknown): boolean =>
   TRANSIENT_COMMAND_TIMEOUT_ERROR_PATTERN.test(getErrorMessage(error));
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
 
 export function parseSandboxMessage(
   data: unknown,
@@ -850,11 +856,38 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       this.shellKind = "bash";
       return "bash";
     }
-    const probe = await this.commands.run("echo $BASH_VERSION", {
+    const probe = await this.runSetupCommand("echo $BASH_VERSION", {
       displayName: "",
     });
     this.shellKind = /^\d/.test(probe.stdout.trim()) ? "bash" : "cmd";
     return this.shellKind;
+  }
+
+  private async runSetupCommand(
+    command: string,
+    options: { displayName?: string; timeoutMs?: number } = {},
+  ): Promise<CommandResult> {
+    for (let attempt = 1; attempt <= SETUP_COMMAND_MAX_ATTEMPTS; attempt++) {
+      try {
+        return await this.commands.run(command, {
+          timeoutMs: options.timeoutMs ?? SETUP_COMMAND_TIMEOUT_MS,
+          displayName: options.displayName ?? "",
+        });
+      } catch (error) {
+        if (
+          attempt === SETUP_COMMAND_MAX_ATTEMPTS ||
+          !isTransientCommandTimeoutError(error)
+        ) {
+          throw error;
+        }
+        console.warn(
+          `[centrifugo-setup] command timeout on attempt ${attempt}/${SETUP_COMMAND_MAX_ATTEMPTS}, retrying: ${getErrorMessage(error)}`,
+        );
+        await delay(SETUP_COMMAND_RETRY_DELAY_MS * attempt);
+      }
+    }
+
+    throw new Error("Setup command failed without returning a result");
   }
 
   /**
@@ -927,7 +960,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
   }> {
     if (this.curlCaps) return this.curlCaps;
     try {
-      const probe = await this.commands.run("curl --help all 2>&1", {
+      const probe = await this.runSetupCommand("curl --help all 2>&1", {
         displayName: "",
       });
       const help = probe.stdout || "";
@@ -963,7 +996,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       return "curl";
     }
 
-    const curlCheck = await this.commands.run("command -v curl || true", {
+    const curlCheck = await this.runSetupCommand("command -v curl || true", {
       displayName: "",
     });
     if (curlCheck.stdout.includes("curl")) {
@@ -971,7 +1004,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       return "curl";
     }
 
-    const wgetCheck = await this.commands.run("command -v wget || true", {
+    const wgetCheck = await this.runSetupCommand("command -v wget || true", {
       displayName: "",
     });
     if (wgetCheck.stdout.includes("wget")) {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -1531,7 +1531,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       const httpClient = await this.detectHttpClient();
 
       if (httpClient === "wget") {
-        const versionCheck = await this.commands.run("wget 2>&1 | head -1", {
+        const versionCheck = await this.runSetupCommand("wget 2>&1 | head -1", {
           displayName: "",
         });
         if (versionCheck.stdout.toLowerCase().includes("busybox")) {

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -989,6 +989,17 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(/user-correctable request error/);
   });
 
+  test("sandbox attachment upload failures are retried and classified separately", () => {
+    expect(taskSrc).toMatch(/retryWithFreshSandboxOnTransientFailure:\s*true/);
+    expect(chatHandlerSrc).toMatch(
+      /retryWithFreshSandboxOnTransientFailure:\s*true/,
+    );
+    expect(taskSrc).toMatch(/"bad_request:sandbox"/);
+    expect(chatHandlerSrc).toMatch(/"bad_request:sandbox"/);
+    expect(taskSrc).toMatch(/"sandbox_upload_failure"/);
+    expect(taskSrc).toMatch(/upload_failure_kind/);
+  });
+
   test("agent-long only passes explicit Trigger.dev region when mapped", () => {
     const routingIdx = routeSrc.indexOf("getTriggerRegionForVercelRequest(");
     const userLocationIdx = routeSrc.indexOf("userLocation", routingIdx);

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -998,6 +998,8 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(chatHandlerSrc).toMatch(/"bad_request:sandbox"/);
     expect(taskSrc).toMatch(/"sandbox_upload_failure"/);
     expect(taskSrc).toMatch(/upload_failure_kind/);
+    expect(taskSrc).toMatch(/isSandboxUploadError/);
+    expect(taskSrc).toMatch(/alreadyEmittedFromStream/);
   });
 
   test("agent-long only passes explicit Trigger.dev region when mapped", () => {

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -955,6 +955,51 @@ describe("createChatLogger ChatSDKError metadata", () => {
     }
   });
 
+  it("marks transient sandbox upload failures retriable", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const chatLogger = createChatLogger({
+        chatId: "chat_upload_timeout",
+        endpoint: "/api/agent",
+      });
+
+      chatLogger.emitChatError(
+        new ChatSDKError(
+          "bad_request:sandbox",
+          "Failed to upload 1 attachment to the computer. Please try again.",
+          {
+            upload_failure_kind: "url",
+            upload_failure_cause:
+              "Command timeout after 35000ms [firstMsg: no]",
+            upload_failure_transient_sandbox_command: true,
+            upload_failure_protocol: "https",
+            upload_failure_url_length: 512,
+            ignored_detail: "too noisy",
+          },
+        ),
+      );
+
+      const wideEvent = JSON.parse(String(logSpy.mock.calls[0][0]));
+      expect(wideEvent.error).toMatchObject({
+        code: "bad_request:sandbox",
+        message: "The computer attachment upload failed.",
+        cause:
+          "Failed to upload 1 attachment to the computer. Please try again.",
+        retriable: true,
+      });
+      expect(wideEvent.error.metadata).toEqual({
+        upload_failure_kind: "url",
+        upload_failure_cause: "Command timeout after 35000ms [firstMsg: no]",
+        upload_failure_transient_sandbox_command: true,
+        upload_failure_protocol: "https",
+        upload_failure_url_length: 512,
+      });
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
   it("emits limit pressure funnel properties for paid monthly exhaustion", () => {
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     const eventSpy = jest.spyOn(phLogger, "event").mockImplementation(() => {});

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -23,7 +23,6 @@ import type {
   SandboxPreference,
   SelectedModel,
   RateLimitInfo,
-  SandboxBootInfo,
 } from "@/types";
 import {
   canUseExtraUsage,
@@ -585,7 +584,6 @@ export const createChatHandler = () => {
               extraUsageConfig,
             });
 
-            let uploadSandboxBootPath: SandboxBootInfo["path"] | null = null;
             const {
               tools,
               getSandbox,
@@ -616,7 +614,6 @@ export const createChatHandler = () => {
               },
               subscription,
               (info) => {
-                uploadSandboxBootPath ??= info.path;
                 chatLogger?.setSandboxBoot(info);
               },
               selectedModel,
@@ -702,10 +699,7 @@ export const createChatHandler = () => {
                 uploadResult = await uploadSandboxFiles(
                   sandboxFiles,
                   ensureSandbox,
-                  {
-                    retryWithFreshSandboxOnTransientFailure: () =>
-                      uploadSandboxBootPath === "reuse_existing",
-                  },
+                  { retryWithFreshSandboxOnTransientFailure: true },
                 );
               } finally {
                 writeUploadCompleteStatus(writer);
@@ -714,7 +708,7 @@ export const createChatHandler = () => {
                 const noun =
                   uploadResult.failedCount === 1 ? "attachment" : "attachments";
                 const uploadError = new ChatSDKError(
-                  "bad_request:stream",
+                  "bad_request:sandbox",
                   `Failed to upload ${uploadResult.failedCount} ${noun} to the computer. Please try again.`,
                   getSandboxUploadFailureMetadata(uploadResult),
                 );

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -216,6 +216,11 @@ const compactChatErrorMetadata = (
   return Object.keys(compact).length > 0 ? compact : undefined;
 };
 
+const isRetriableChatSDKError = (error: ChatSDKError): boolean =>
+  error.type === "rate_limit" ||
+  error.metadata?.providerErrorRetriable === true ||
+  error.metadata?.upload_failure_transient_sandbox_command === true;
+
 const providerErrorEventName = (category: ProviderErrorCategory): string =>
   category === "content_blocked"
     ? "provider_content_blocked"
@@ -824,7 +829,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
         message: error.message,
         cause,
         statusCode: error.statusCode,
-        retriable: error.type === "rate_limit",
+        retriable: isRetriableChatSDKError(error),
         metadata: compactChatErrorMetadata(error.metadata),
       });
       logger.info(builder.build());

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -15,6 +15,7 @@ export type Surface =
   | "history"
   | "vote"
   | "document"
+  | "sandbox"
   | "suggestions";
 
 export type ErrorCode = `${ErrorType}:${Surface}`;
@@ -30,6 +31,7 @@ export const visibilityBySurface: Record<Surface, ErrorVisibility> = {
   history: "response",
   vote: "response",
   document: "response",
+  sandbox: "response",
   suggestions: "response",
 };
 
@@ -111,6 +113,8 @@ export function getMessageByErrorCode(errorCode: ErrorCode): string {
 
     case "bad_request:stream":
       return "The model provider returned an error.";
+    case "bad_request:sandbox":
+      return "The computer attachment upload failed.";
     case "forbidden:stream":
       return "The model provider blocked this request.";
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -116,7 +116,6 @@ import type {
   SandboxPreference,
   SelectedModel,
   RateLimitInfo,
-  SandboxBootInfo,
   ToolFailureLogEvent,
 } from "@/types";
 import { canUseExtraUsage, normalizeMaxModelForSubscription } from "@/types";
@@ -487,7 +486,9 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
                   ? "empty_after_processing"
                   : errorMetadata?.localSandboxFallbackBlocked === true
                     ? "local_sandbox_fallback_blocked"
-                    : "chat_error",
+                    : errorMetadata?.upload_failure_kind
+                      ? "sandbox_upload_failure"
+                      : "chat_error",
       code,
       name: "ChatSDKError",
       message: errorMessage,
@@ -1263,7 +1264,6 @@ export const agentLongTask = task({
               extraUsageConfig,
             });
 
-            let uploadSandboxBootPath: SandboxBootInfo["path"] | null = null;
             let handledToolFailureCount = 0;
             const onToolFailure = (failure: ToolFailureLogEvent) => {
               handledToolFailureCount += 1;
@@ -1318,7 +1318,6 @@ export const agentLongTask = task({
               },
               subscription,
               (info) => {
-                uploadSandboxBootPath ??= info.path;
                 chatLogger?.setSandboxBoot(info);
               },
               selectedModel,
@@ -1395,10 +1394,7 @@ export const agentLongTask = task({
                 uploadResult = await uploadSandboxFiles(
                   sandboxFiles,
                   ensureSandbox,
-                  {
-                    retryWithFreshSandboxOnTransientFailure: () =>
-                      uploadSandboxBootPath === "reuse_existing",
-                  },
+                  { retryWithFreshSandboxOnTransientFailure: true },
                 );
               } finally {
                 writeUploadCompleteStatus(writer);
@@ -1407,7 +1403,7 @@ export const agentLongTask = task({
                 const noun =
                   uploadResult.failedCount === 1 ? "attachment" : "attachments";
                 const uploadError = new ChatSDKError(
-                  "bad_request:stream",
+                  "bad_request:sandbox",
                   `Failed to upload ${uploadResult.failedCount} ${noun} to the computer. Please try again.`,
                   getSandboxUploadFailureMetadata(uploadResult),
                 );

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -391,6 +391,11 @@ const isChatNotFoundError = (error: ChatSDKError): boolean => {
   );
 };
 
+const isSandboxUploadError = (error: ChatSDKError): boolean =>
+  error.type === "bad_request" &&
+  error.surface === "sandbox" &&
+  !!error.metadata?.upload_failure_kind;
+
 const USER_CORRECTABLE_AGENT_LONG_ERROR_CATEGORIES = new Set([
   "chat_not_found",
   "login_required",
@@ -2554,7 +2559,11 @@ export const agentLongTask = task({
         await usageRefundTracker.refund().catch(() => {});
       }
       if (error instanceof ChatSDKError) {
-        chatLogger?.emitChatError(error);
+        const alreadyEmittedFromStream =
+          streamPiped && isSandboxUploadError(error);
+        if (!alreadyEmittedFromStream) {
+          chatLogger?.emitChatError(error);
+        }
       } else {
         chatLogger?.emitUnexpectedError(error);
       }


### PR DESCRIPTION
## Summary
- retry transient local sandbox command-relay timeouts during attachment setup probes
- retry sandbox attachment uploads with a fresh sandbox for transient command-channel failures
- classify upload failures as sandbox errors instead of generic provider stream errors
- mark transient sandbox upload failures retriable in chat-wide logs

## Verification
- pnpm typecheck
- pnpm test -- lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts lib/api/__tests__/chat-logger.test.ts lib/api/__tests__/agent-long-contracts.test.ts lib/__tests__/errors.test.ts --runInBand
- pnpm lint (passes with existing warnings)

## Manual verification
- In Agent mode with a local/remote sandbox, attach an image and send a message.
- If the command relay has a one-off setup timeout, the attachment upload should retry instead of failing immediately.
- If upload still fails, the UI/logs should identify it as a computer attachment upload failure rather than a model provider error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved computer attachment upload reliability by retrying transient sandbox command-timeout failures.
  * Standardized sandbox upload failure handling with clearer `bad_request:sandbox` messaging and consistent error classification.
  * Expanded retriable error detection so transient sandbox upload failures are marked retriable.
* **Tests**
  * Added Jest coverage for sandbox upload retry and command retry behavior, plus updated assertions for the sandbox-specific user-facing error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->