### PR TITLE
Route Ask image prompts to MiniMax M3

### DIFF
--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -16,7 +16,7 @@ export const ASK_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-standard",
     label: "HackerAI Standard",
     description: "Reliable performance for everyday tasks",
-    poweredBy: "DeepSeek V4 Pro · Grok 4.3 for images and PDFs",
+    poweredBy: "DeepSeek V4 Pro · MiniMax M3 for images · Grok 4.3 for PDFs",
   },
   {
     id: "hackerai-pro",

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -6,10 +6,10 @@ import {
 } from "@/lib/ai/providers";
 
 describe("provider registry", () => {
-  it("keeps paid Ask media, Agent Standard, and stale Kimi compatibility keys pointed at their active slugs", () => {
+  it("keeps paid Ask image, Agent Standard, and stale Kimi compatibility keys pointed at their active slugs", () => {
     expect(
       (myProvider.languageModel("ask-model") as { modelId: string }).modelId,
-    ).toBe("x-ai/grok-4.3");
+    ).toBe("minimax/minimax-m3");
     expect(
       (myProvider.languageModel("agent-model") as { modelId: string }).modelId,
     ).toBe("minimax/minimax-m3");
@@ -196,6 +196,7 @@ describe("supportsMultimodalToolResults", () => {
   it("allows MiniMax and Kimi registry keys and OpenRouter slugs for image tool result experiments", () => {
     expect(supportsMultimodalToolResults("agent-model")).toBe(true);
     expect(supportsMultimodalToolResults("agent-model-free")).toBe(true);
+    expect(supportsMultimodalToolResults("ask-model")).toBe(true);
     expect(supportsMultimodalToolResults("model-minimax-m3")).toBe(true);
     expect(supportsMultimodalToolResults("minimax/minimax-m3")).toBe(true);
     expect(supportsMultimodalToolResults("model-kimi-k2.7-code")).toBe(true);

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -185,14 +185,14 @@ export const GROK_4_3_SLUG = "x-ai/grok-4.3";
 
 const buildProviderMap = (or: OpenRouterInstance) =>
   ({
-    "ask-model": or(GROK_4_3_SLUG),
+    "ask-model": or(MINIMAX_M3_SLUG),
     "ask-model-free": or("deepseek/deepseek-v4-flash"),
     "agent-model": or(MINIMAX_M3_SLUG),
     "agent-model-free": or(MINIMAX_M3_SLUG),
     "model-sonnet-4.6": or("anthropic/claude-sonnet-4-6"),
     "model-grok-4.3": or(GROK_4_3_SLUG),
     // Compatibility alias for stale internal references persisted before the
-    // paid Ask media route settled on Grok 4.3.
+    // paid Ask PDF route settled on Grok 4.3.
     "model-gemini-3-flash": or(GROK_4_3_SLUG),
     "model-deepseek-v4-flash": or("deepseek/deepseek-v4-flash"),
     "model-deepseek-v4-pro": or("deepseek/deepseek-v4-pro"),
@@ -215,7 +215,7 @@ export type ModelName = keyof typeof baseProviders;
 
 export const modelCutoffDates: Record<ModelName, string> &
   Record<string, string> = {
-  "ask-model": "April 2026",
+  "ask-model": "May 2026",
   "ask-model-free": "May 2025",
   "agent-model": "May 2026",
   "agent-model-free": "May 2026",
@@ -292,6 +292,7 @@ export function isMiniMaxModel(modelName: string): boolean {
   return (
     normalized === "agent-model" ||
     normalized === "agent-model-free" ||
+    normalized === "ask-model" ||
     normalized === "model-minimax-m3" ||
     normalized.includes("minimax/minimax-m3")
   );
@@ -303,7 +304,6 @@ export function supportsMultimodalToolResults(modelName?: string): boolean {
   const normalized = modelName.toLowerCase();
 
   return (
-    normalized === "ask-model" ||
     normalized === "model-gemini-3-flash" ||
     isKimiModel(normalized) ||
     isMiniMaxModel(normalized) ||

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -215,16 +215,21 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it.each(["ask-model", "model-grok-4.3"] as const)(
-    "falls back from paid Ask media route %s through MiniMax, Kimi, then Grok",
-    (modelName) => {
-      const opts = buildProviderOptions(false, "user-1", modelName, "ask");
-      expect(opts.openrouter).toMatchObject({
-        models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
-        user: "user-1",
-      });
-    },
-  );
+  it("falls back from paid Ask image auto route through Kimi then Grok", () => {
+    const opts = buildProviderOptions(false, "user-1", "ask-model", "ask");
+    expect(opts.openrouter).toMatchObject({
+      models: [KIMI_SLUG, GROK_SLUG],
+      user: "user-1",
+    });
+  });
+
+  it("falls back from paid Ask PDF Grok route through MiniMax, Kimi, then Grok", () => {
+    const opts = buildProviderOptions(false, "user-1", "model-grok-4.3", "ask");
+    expect(opts.openrouter).toMatchObject({
+      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
+      user: "user-1",
+    });
+  });
 
   it("keeps the stale media route alias on the active Ask fallback chain", () => {
     const opts = buildProviderOptions(false, "user-1", "model-gemini-3-flash");
@@ -304,6 +309,7 @@ describe("buildProviderOptions fallback chain", () => {
   it.each([
     "model-deepseek-v4-pro",
     "ask-model",
+    "model-minimax-m3",
     "model-grok-4.3",
     "model-gemini-3-flash",
   ])("enables medium reasoning for ask mode model %s", (modelName) => {
@@ -433,9 +439,12 @@ describe("getRetryFallbackModel", () => {
     );
   });
 
+  it("keeps paid Ask image MiniMax app-side retry on the terminal Grok fallback", () => {
+    expect(getRetryFallbackModel("ask-model", "ask")).toBe("fallback-grok-4.3");
+  });
+
   it.each([
     ["model-deepseek-v4-pro", "ask"],
-    ["ask-model", "ask"],
     ["model-grok-4.3", "ask"],
     ["model-gemini-3-flash", "ask"],
   ] as const)(

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -484,7 +484,7 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "agent-model-free": MINIMAX_M3_FALLBACK_CHAIN,
   "model-deepseek-v4-flash": AGENT_TEXT_FALLBACK_CHAIN,
   "model-deepseek-v4-pro": AGENT_TEXT_FALLBACK_CHAIN,
-  "ask-model": AGENT_TEXT_FALLBACK_CHAIN,
+  "ask-model": MINIMAX_M3_FALLBACK_CHAIN,
   "agent-model": MINIMAX_M3_FALLBACK_CHAIN,
   "model-grok-4.3": AGENT_TEXT_FALLBACK_CHAIN,
   "model-gemini-3-flash": AGENT_TEXT_FALLBACK_CHAIN,
@@ -525,12 +525,13 @@ const ANTHROPIC_FALLBACK_CHAIN_BY_MODE: Record<ChatMode, readonly ModelName[]> =
 
 const ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN = MINIMAX_M3_FALLBACK_CHAIN;
 
-// Standard Ask can route text-only prompts to DeepSeek and media prompts to
-// Grok. Keep those route keys and their persisted Grok alias on one effort
-// level so they do not drift.
+// Standard Ask can route text-only prompts to DeepSeek, image prompts to
+// MiniMax, and PDF prompts to Grok. Keep those route keys and their persisted
+// Grok alias on one effort level so they do not drift.
 const ASK_STANDARD_REASONING_MODELS = [
   "model-deepseek-v4-pro",
   "ask-model",
+  "model-minimax-m3",
   "model-grok-4.3",
   "model-gemini-3-flash",
 ] as const satisfies readonly ModelName[];
@@ -596,7 +597,6 @@ export function getRetryFallbackModel(
     modelName === "ask-model-free" ||
     modelName === "model-deepseek-v4-flash" ||
     modelName === "model-deepseek-v4-pro" ||
-    modelName === "ask-model" ||
     modelName === "model-grok-4.3" ||
     modelName === "model-gemini-3-flash"
   ) {

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -165,21 +165,21 @@ describe("selectModel", () => {
       expect(selectModel("ask", "pro")).toBe("model-deepseek-v4-pro");
     });
 
-    it("should return ask-model (Grok) for paid ask when an image is attached", () => {
+    it("should return ask-model (MiniMax) for paid ask when an image is attached", () => {
       expect(selectModel("ask", "pro", undefined, true, false)).toBe(
         "ask-model",
       );
     });
 
-    it("should return ask-model (Grok) for paid ask when a PDF is attached", () => {
+    it("should return Grok 4.3 for paid ask when a PDF is attached", () => {
       expect(selectModel("ask", "pro", undefined, false, true)).toBe(
-        "ask-model",
+        "model-grok-4.3",
       );
     });
 
-    it("should prefer ask-model (Grok) when paid ask has both image and PDF attachments", () => {
+    it("should prefer Grok 4.3 when paid ask has both image and PDF attachments", () => {
       expect(selectModel("ask", "pro", undefined, true, true)).toBe(
-        "ask-model",
+        "model-grok-4.3",
       );
     });
 
@@ -224,9 +224,9 @@ describe("selectModel", () => {
       );
     });
 
-    it("should promote HackerAI Standard to Grok 4.3 when an image is attached", () => {
+    it("should promote HackerAI Standard to MiniMax M3 when an image is attached", () => {
       expect(selectModel("ask", "pro", "hackerai-standard", true, false)).toBe(
-        "model-grok-4.3",
+        "model-minimax-m3",
       );
     });
 
@@ -342,12 +342,14 @@ describe("selectModel", () => {
       expect(selectModel("ask", "pro", "auto")).toBe("model-deepseek-v4-pro");
     });
 
-    it("should treat 'auto' as no override in ask mode with image -> Grok", () => {
+    it("should treat 'auto' as no override in ask mode with image -> MiniMax", () => {
       expect(selectModel("ask", "pro", "auto", true, false)).toBe("ask-model");
     });
 
     it("should treat 'auto' as no override in ask mode with PDF -> Grok", () => {
-      expect(selectModel("ask", "pro", "auto", false, true)).toBe("ask-model");
+      expect(selectModel("ask", "pro", "auto", false, true)).toBe(
+        "model-grok-4.3",
+      );
     });
   });
 
@@ -362,7 +364,7 @@ describe("selectModel", () => {
         "ask-model",
       );
       expect(selectModel("ask", "pro", undefined, false, true)).toBe(
-        "ask-model",
+        "model-grok-4.3",
       );
     });
   });

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -283,6 +283,12 @@ describe("selectModel", () => {
       );
     });
 
+    it("should route HackerAI Pro to Kimi K2.7 in agent mode when a PDF is attached", () => {
+      expect(selectModel("agent", "pro", "hackerai-pro", false, true)).toBe(
+        "model-kimi-k2.7-code",
+      );
+    });
+
     it("should map HackerAI Max to Opus 4.6 in agent mode for Ultra", () => {
       expect(selectModel("agent", "ultra", "hackerai-max")).toBe(
         "model-opus-4.6",

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -72,7 +72,7 @@ export function selectModel(
   const isFreeAsk = !isAgent && subscription === "free";
   const hasAskImage = !isAgent && !!hasImageAttachment;
   const hasAskPdf = !isAgent && !!hasPdfAttachment;
-  const hasProProviderMedia = !!hasImageAttachment || hasAskPdf;
+  const hasProProviderMedia = !!hasImageAttachment || !!hasPdfAttachment;
   const paidAskMediaModel: ModelName = hasAskPdf
     ? "model-grok-4.3"
     : hasAskImage

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -45,9 +45,10 @@ export const getMaxStepsForUser = (
  * @param hasImageAttachment - Whether any message has an image attachment.
  * @param hasPdfAttachment - Whether any message has a PDF attachment.
  *   Paid ASK on the Standard/auto route normally uses DeepSeek V4 Pro
- *   (text-only); prompts with images or PDFs promote to Grok 4.3 for native
- *   media support. HackerAI Pro uses GLM 5.2 for text-only prompts and Kimi
- *   K2.7 Code when provider-visible media is attached.
+ *   (text-only); image-only prompts promote to MiniMax M3, while PDF prompts
+ *   stay on Grok 4.3 for native document support. HackerAI Pro uses GLM 5.2
+ *   for text-only prompts and Kimi K2.7 Code when provider-visible media is
+ *   attached.
  * @returns Model name to use
  */
 export function selectModel(
@@ -66,13 +67,17 @@ export function selectModel(
   );
   // DeepSeek ask routes are text-only, so image/PDF prompts promote to a
   // media-capable route unless the selected tier intentionally uses a
-  // multimodal/file-capable model such as Kimi or Opus.
+  // multimodal/file-capable model such as Kimi or Opus. PDFs take precedence
+  // when mixed with images because the MiniMax ask route is image-scoped.
   const isFreeAsk = !isAgent && subscription === "free";
   const hasAskImage = !isAgent && !!hasImageAttachment;
   const hasAskPdf = !isAgent && !!hasPdfAttachment;
   const hasProProviderMedia = !!hasImageAttachment || hasAskPdf;
-  const paidAskMediaModel: ModelName =
-    hasAskImage || hasAskPdf ? "ask-model" : "model-deepseek-v4-pro";
+  const paidAskMediaModel: ModelName = hasAskPdf
+    ? "model-grok-4.3"
+    : hasAskImage
+      ? "ask-model"
+      : "model-deepseek-v4-pro";
 
   const autoModel: ModelName = isAgent
     ? subscription === "free"
@@ -96,9 +101,11 @@ export function selectModel(
   // any UI that reads `getModelDisplayName` shows the picked model rather than
   // the auto-router label.
   if (allowedSelectedModel === "hackerai-standard" && !isAgent) {
-    return hasAskImage || hasAskPdf
+    return hasAskPdf
       ? "model-grok-4.3"
-      : "model-deepseek-v4-pro";
+      : hasAskImage
+        ? "model-minimax-m3"
+        : "model-deepseek-v4-pro";
   }
 
   if (allowedSelectedModel === "hackerai-pro") {

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -433,23 +433,23 @@ describe("token-bucket", () => {
       );
     });
 
-    it.each(["agent-model", "agent-model-free", "model-minimax-m3"])(
-      "should use MiniMax M3 pricing for %s ($0.30/$1.20)",
-      (modelName) => {
-        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(4200);
-        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(16800);
-      },
-    );
-
     it.each([
       "ask-model",
-      "model-grok-4.3",
-      "model-gemini-3-flash",
-      "fallback-grok-4.3",
-    ])("should use Grok 4.3 pricing for %s ($1.25/$2.50)", (modelName) => {
-      expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(17500);
-      expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(35000);
+      "agent-model",
+      "agent-model-free",
+      "model-minimax-m3",
+    ])("should use MiniMax M3 pricing for %s ($0.30/$1.20)", (modelName) => {
+      expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(4200);
+      expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(16800);
     });
+
+    it.each(["model-grok-4.3", "model-gemini-3-flash", "fallback-grok-4.3"])(
+      "should use Grok 4.3 pricing for %s ($1.25/$2.50)",
+      (modelName) => {
+        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(17500);
+        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(35000);
+      },
+    );
 
     it("expensive models should deplete budget faster", () => {
       const monthlyBudget = getBudgetLimits("pro").monthly;

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -29,7 +29,6 @@ export { isUserRateLimitKey } from "./key-cleanup";
 /** Model pricing: $/1M tokens per model. */
 const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   default: { input: 0.5, output: 3.0 },
-  "ask-model": { input: 1.25, output: 2.5 },
   "model-sonnet-4.6": { input: 3.0, output: 15.0 },
   "model-grok-4.3": { input: 1.25, output: 2.5 },
   "model-gemini-3-flash": { input: 1.25, output: 2.5 },
@@ -40,6 +39,7 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   "model-glm-5.2": { input: 0.9086, output: 2.856 },
   // These keys route to minimax/minimax-m3 via lib/ai/providers.ts.
   // Rates from OpenRouter: $0.30 in / $1.20 out per 1M tokens.
+  "ask-model": { input: 0.3, output: 1.2 },
   "agent-model": { input: 0.3, output: 1.2 },
   "agent-model-free": { input: 0.3, output: 1.2 },
   "model-minimax-m3": { input: 0.3, output: 1.2 },


### PR DESCRIPTION
## Summary
- Route paid Ask image-only prompts to MiniMax M3 instead of Grok 4.3
- Keep paid Ask PDF and mixed image+PDF prompts on Grok 4.3 for document support
- Update provider mapping, fallback/retry behavior, model pricing, selector copy, and focused tests
- Fix Pro agent PDF attachment routing to use the provider-visible media path

## Automated verification
- `pnpm test -- lib/chat/__tests__/chat-processor.test.ts lib/ai/__tests__/providers.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/rate-limit/__tests__/token-bucket.test.ts`
- `pnpm test -- lib/chat/__tests__/chat-processor.test.ts`
- `pnpm exec prettier --check app/components/ModelSelector/constants.ts lib/ai/providers.ts lib/ai/__tests__/providers.test.ts lib/api/chat-stream-helpers.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/chat/chat-processor.ts lib/chat/__tests__/chat-processor.test.ts lib/rate-limit/token-bucket.ts lib/rate-limit/__tests__/token-bucket.test.ts`
- `pnpm exec prettier --check lib/chat/chat-processor.ts lib/chat/__tests__/chat-processor.test.ts`
- `git diff --check`
- Pre-commit after initial commit: `tsc --noEmit` and full `jest` suite, 215 suites / 2181 tests passed
- Pre-commit after CodeRabbit fix: `tsc --noEmit` and full `jest` suite, 215 suites / 2182 tests passed

## Manual verification
- In Ask mode as a paid user, send an image-only prompt; it should route through MiniMax M3.
- In Ask mode as a paid user, send a PDF prompt or mixed image+PDF prompt; it should route through Grok 4.3.
- In Agent mode with HackerAI Pro, send a PDF attachment; it should route through Kimi K2.7.
- Open the model selector hover for HackerAI Standard; it should mention MiniMax M3 for images and Grok 4.3 for PDFs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Ask-flow model routing with clearer precedence for text-only, image, and PDF attachments.
  * Paid Ask image/PDF handling now uses updated model choices for improved multimodal behavior.

* **Bug Fixes**
  * Corrected fallback and retry behavior for paid Ask image and PDF routes to align with the new routing.
  * Updated multimodal tool-result support for Ask so image handling is recognized consistently.

* **Pricing & Display**
  * Adjusted token pricing for the Ask image model.
  * Updated the “powered by” label for the related model option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->