### PR TITLE
Use newly selected model when regenerating

### DIFF
--- a/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
@@ -1,0 +1,94 @@
+import { act, renderHook } from "@testing-library/react";
+import { jest } from "@jest/globals";
+import type { ChatMessage, SelectedModel } from "@/types";
+
+const mockRegenerate = jest.fn();
+const mockSetMessages = jest.fn();
+let mockSelectedModel: SelectedModel = "hackerai-standard";
+
+jest.mock("convex/react", () => ({
+  useMutation: () => jest.fn(async () => undefined),
+}));
+
+jest.mock("@/app/contexts/GlobalState", () => ({
+  useGlobalState: () => ({
+    input: "",
+    uploadedFiles: [],
+    chatMode: "ask",
+    clearInput: jest.fn(),
+    clearUploadedFiles: jest.fn(),
+    todos: [],
+    setTodos: jest.fn(),
+    isUploadingFiles: false,
+    subscription: "pro",
+    temporaryChatsEnabled: true,
+    queueMessage: jest.fn(),
+    messageQueue: [],
+    removeQueuedMessage: jest.fn(),
+    queueBehavior: "queue",
+    sandboxPreference: "e2b",
+    selectedModel: mockSelectedModel,
+  }),
+}));
+
+jest.mock("@/app/components/DataStreamProvider", () => ({
+  useDataStreamDispatch: () => ({ setIsAutoResuming: jest.fn() }),
+}));
+
+jest.mock("@/app/hooks/useTauri", () => ({
+  isTauriEnvironment: () => false,
+}));
+
+const { useChatHandlers } =
+  require("../useChatHandlers") as typeof import("../useChatHandlers");
+
+const messages = [
+  {
+    id: "user-1",
+    role: "user",
+    parts: [{ type: "text", text: "Question" }],
+  },
+  {
+    id: "assistant-1",
+    role: "assistant",
+    parts: [{ type: "text", text: "Old answer" }],
+  },
+] as ChatMessage[];
+
+describe("useChatHandlers regenerate model", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSelectedModel = "hackerai-standard";
+  });
+
+  it("uses the latest chat input model from a previously rendered regenerate callback", async () => {
+    const { result, rerender } = renderHook(() =>
+      useChatHandlers({
+        chatId: "chat-1",
+        messages,
+        sendMessage: jest.fn(),
+        stop: jest.fn(),
+        regenerate: mockRegenerate,
+        setMessages: mockSetMessages,
+        isExistingChat: false,
+        status: "ready",
+        isSendingNowRef: { current: false },
+        hasManuallyStoppedRef: { current: false },
+      }),
+    );
+    const regenerateFromRenderedMessage = result.current.handleRegenerate;
+
+    mockSelectedModel = "hackerai-max";
+    rerender();
+
+    await act(async () => {
+      await regenerateFromRenderedMessage();
+    });
+
+    expect(mockRegenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ selectedModel: "hackerai-max" }),
+      }),
+    );
+  });
+});

--- a/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
@@ -3,8 +3,10 @@ import { jest } from "@jest/globals";
 import type { ChatMessage, SelectedModel } from "@/types";
 
 const mockRegenerate = jest.fn();
+const mockSendMessage = jest.fn();
 const mockSetMessages = jest.fn();
 let mockSelectedModel: SelectedModel = "hackerai-standard";
+let mockTemporaryChatsEnabled = true;
 
 jest.mock("convex/react", () => ({
   useMutation: () => jest.fn(async () => undefined),
@@ -21,7 +23,7 @@ jest.mock("@/app/contexts/GlobalState", () => ({
     setTodos: jest.fn(),
     isUploadingFiles: false,
     subscription: "pro",
-    temporaryChatsEnabled: true,
+    temporaryChatsEnabled: mockTemporaryChatsEnabled,
     queueMessage: jest.fn(),
     messageQueue: [],
     removeQueuedMessage: jest.fn(),
@@ -59,14 +61,53 @@ describe("useChatHandlers regenerate model", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSelectedModel = "hackerai-standard";
+    mockTemporaryChatsEnabled = true;
   });
 
-  it("uses the latest chat input model from a previously rendered regenerate callback", async () => {
+  it.each([
+    ["temporary", true],
+    ["persisted", false],
+  ])(
+    "uses the latest chat input model for %s chats from a previously rendered regenerate callback",
+    async (_chatType, temporaryChatsEnabled) => {
+      mockTemporaryChatsEnabled = temporaryChatsEnabled;
+      const { result, rerender } = renderHook(() =>
+        useChatHandlers({
+          chatId: "chat-1",
+          messages,
+          sendMessage: mockSendMessage,
+          stop: jest.fn(),
+          regenerate: mockRegenerate,
+          setMessages: mockSetMessages,
+          isExistingChat: false,
+          status: "ready",
+          isSendingNowRef: { current: false },
+          hasManuallyStoppedRef: { current: false },
+        }),
+      );
+      const regenerateFromRenderedMessage = result.current.handleRegenerate;
+
+      mockSelectedModel = "hackerai-max";
+      rerender();
+
+      await act(async () => {
+        await regenerateFromRenderedMessage();
+      });
+
+      expect(mockRegenerate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({ selectedModel: "hackerai-max" }),
+        }),
+      );
+    },
+  );
+
+  it("uses the latest chat input model from a previously rendered continue callback", () => {
     const { result, rerender } = renderHook(() =>
       useChatHandlers({
         chatId: "chat-1",
         messages,
-        sendMessage: jest.fn(),
+        sendMessage: mockSendMessage,
         stop: jest.fn(),
         regenerate: mockRegenerate,
         setMessages: mockSetMessages,
@@ -76,16 +117,17 @@ describe("useChatHandlers regenerate model", () => {
         hasManuallyStoppedRef: { current: false },
       }),
     );
-    const regenerateFromRenderedMessage = result.current.handleRegenerate;
+    const continueFromRenderedMessage = result.current.handleContinue;
 
     mockSelectedModel = "hackerai-max";
     rerender();
 
-    await act(async () => {
-      await regenerateFromRenderedMessage();
+    act(() => {
+      continueFromRenderedMessage();
     });
 
-    expect(mockRegenerate).toHaveBeenCalledWith(
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      expect.any(Object),
       expect.objectContaining({
         body: expect.objectContaining({ selectedModel: "hackerai-max" }),
       }),

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -97,6 +97,9 @@ export const useChatHandlers = ({
     selectedModel,
     subscription,
   );
+  // MessageItem intentionally ignores callback identity in its memo comparator,
+  // so a rendered Regenerate button can retain an older handler closure.
+  const requestSelectedModelRef = useLatestRef(requestSelectedModel);
 
   // Avoid stale closure on temporary flag
   const temporaryChatsEnabledRef = useRef(temporaryChatsEnabled);
@@ -479,7 +482,7 @@ export const useChatHandlers = ({
               shouldSendClientMessagesForRegenerate,
             temporary: false,
             sandboxPreference,
-            selectedModel: requestSelectedModel,
+            selectedModel: requestSelectedModelRef.current,
           },
         }),
       );
@@ -493,7 +496,7 @@ export const useChatHandlers = ({
             regenerate: true,
             temporary: true,
             sandboxPreference,
-            selectedModel: requestSelectedModel,
+            selectedModel: requestSelectedModelRef.current,
           },
         }),
       );

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -727,7 +727,7 @@ export const useChatHandlers = ({
     if (status === "streaming") return;
     hasManuallyStoppedRef.current = false;
     const continuationSelectedModel =
-      selectedModelOverride ?? requestSelectedModel;
+      selectedModelOverride ?? requestSelectedModelRef.current;
     runChatAction("continue response", () =>
       sendMessage(
         {


### PR DESCRIPTION
## Summary
- read the latest normalized chat-input model when Regenerate is clicked
- preserve message memoization by using a stable latest-value ref instead of forcing message re-renders
- add a regression test for a previously rendered Regenerate callback after the model picker changes

## Root cause
`MessageItem` intentionally ignores callback identity in its memo comparator. Changing only the model picker re-rendered the parent chat but not the existing message item, so its Regenerate button could invoke a handler that had closed over the model used for the previous response.

## Validation
- `./node_modules/.bin/jest app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx app/hooks/__tests__/useChatHandlers.contracts.test.ts --runInBand`
- `./node_modules/.bin/eslint app/hooks/useChatHandlers.ts app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/prettier --check app/hooks/useChatHandlers.ts app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx`

## Manual verification
1. Generate a response in an existing chat.
2. Select a different model in the chat input, then click Regenerate on the last response.
3. Confirm the regenerate request body uses the newly selected model and the regenerated response runs with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regenerate and continue actions to use the most up-to-date model selected in the app, even after UI changes.
  * Improved consistency of retry/regenerate behavior so it no longer reuses an outdated model selection.
* **Tests**
  * Expanded React hook coverage to verify that regenerate/continue actions always reference the latest model for both temporary and persisted chat modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->