### PR TITLE
Add public robots and sitemap routes

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -93,6 +93,21 @@ describe("proxy", () => {
     expect(mockNextResponseRedirect).not.toHaveBeenCalled();
   });
 
+  it.each(["/robots.txt", "/sitemap.xml"])(
+    "bypasses AuthKit for the public SEO route %s",
+    async (pathname) => {
+      const { default: proxy } = await import("../proxy");
+
+      const response = await proxy(createRequest({ pathname }));
+
+      expect(response).toMatchObject({ kind: "next" });
+      expect(mockAuthkit).not.toHaveBeenCalled();
+      expect(mockNextResponseNext).toHaveBeenCalledWith();
+      expect(mockNextResponseJson).not.toHaveBeenCalled();
+      expect(mockNextResponseRedirect).not.toHaveBeenCalled();
+    },
+  );
+
   it("rejects non-action root POSTs before AuthKit", async () => {
     const { default: proxy } = await import("../proxy");
 

--- a/app/robots.txt/__tests__/route.test.ts
+++ b/app/robots.txt/__tests__/route.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "@jest/globals";
+import { GET } from "../route";
+
+class TestResponse {
+  readonly headers: Headers;
+  readonly status: number;
+
+  constructor(
+    private readonly body: string,
+    init: ResponseInit = {},
+  ) {
+    this.headers = new Headers(init.headers);
+    this.status = init.status ?? 200;
+  }
+
+  async text() {
+    return this.body;
+  }
+}
+
+Object.defineProperty(globalThis, "Response", {
+  configurable: true,
+  value: TestResponse,
+});
+
+describe("GET /robots.txt", () => {
+  it("returns crawl rules and the canonical sitemap URL as plain text", async () => {
+    const response = GET();
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/plain; charset=utf-8",
+    );
+    expect(body).toContain("User-agent: *");
+    expect(body).toContain("Allow: /");
+    expect(body).toContain("Disallow: /api/");
+    expect(body).toContain("Disallow: /c/");
+    expect(body).toContain("Sitemap: https://hackerai.co/sitemap.xml");
+  });
+});

--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -1,0 +1,26 @@
+const ROBOTS_CONTENT = `User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /c/
+Disallow: /share/
+Disallow: /invite/
+Disallow: /login
+Disallow: /signup
+Disallow: /logout
+Disallow: /callback
+Disallow: /desktop-login
+Disallow: /desktop-callback
+Disallow: /auth-error
+
+Sitemap: https://hackerai.co/sitemap.xml
+`;
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return new Response(ROBOTS_CONTENT, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/app/sitemap.xml/__tests__/route.test.ts
+++ b/app/sitemap.xml/__tests__/route.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "@jest/globals";
+import { GET } from "../route";
+
+class TestResponse {
+  readonly headers: Headers;
+  readonly status: number;
+
+  constructor(
+    private readonly body: string,
+    init: ResponseInit = {},
+  ) {
+    this.headers = new Headers(init.headers);
+    this.status = init.status ?? 200;
+  }
+
+  async text() {
+    return this.body;
+  }
+}
+
+Object.defineProperty(globalThis, "Response", {
+  configurable: true,
+  value: TestResponse,
+});
+
+describe("GET /sitemap.xml", () => {
+  it("returns the canonical public URLs as XML", async () => {
+    const response = GET();
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/xml; charset=utf-8",
+    );
+    expect(body).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    );
+    expect(body).toContain("<loc>https://hackerai.co/</loc>");
+    expect(body).toContain("<loc>https://hackerai.co/download</loc>");
+    expect(body).toContain("<loc>https://hackerai.co/trust</loc>");
+    expect(body).toContain("<loc>https://hackerai.co/privacy-policy</loc>");
+    expect(body).toContain("<loc>https://hackerai.co/terms-of-service</loc>");
+    expect(body).not.toContain("http://hackerai.co");
+  });
+});

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,0 +1,19 @@
+const SITEMAP_CONTENT = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://hackerai.co/</loc></url>
+  <url><loc>https://hackerai.co/download</loc></url>
+  <url><loc>https://hackerai.co/trust</loc></url>
+  <url><loc>https://hackerai.co/privacy-policy</loc></url>
+  <url><loc>https://hackerai.co/terms-of-service</loc></url>
+</urlset>
+`;
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return new Response(SITEMAP_CONTENT, {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+    },
+  });
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -9,7 +9,11 @@ import {
   isValidReferralCode,
 } from "@/lib/referrals/config";
 
-const AUTHKIT_BYPASS_PATHS = new Set(["/api/health/trigger-agent-mode"]);
+const AUTHKIT_BYPASS_PATHS = new Set([
+  "/api/health/trigger-agent-mode",
+  "/robots.txt",
+  "/sitemap.xml",
+]);
 const ROOT_PAGE_POST_PATHS = new Set(["/", "/index"]);
 const NEXT_ACTION_HEADER = "next-action";
 


### PR DESCRIPTION
## Summary
- add static App Router handlers for `/robots.txt` and `/sitemap.xml` with explicit crawlable content types
- publish canonical `https://hackerai.co` URLs and a robots `Sitemap` directive
- bypass WorkOS AuthKit for both crawler endpoints and cover the behavior with focused tests

## Testing
- `./node_modules/.bin/jest __tests__/proxy.test.ts app/robots.txt/__tests__/route.test.ts app/sitemap.xml/__tests__/route.test.ts --runInBand`
- `./node_modules/.bin/eslint proxy.ts __tests__/proxy.test.ts app/robots.txt/route.ts app/robots.txt/__tests__/route.test.ts app/sitemap.xml/route.ts app/sitemap.xml/__tests__/route.test.ts`
- `./node_modules/.bin/prettier --check proxy.ts __tests__/proxy.test.ts app/robots.txt/route.ts app/robots.txt/__tests__/route.test.ts app/sitemap.xml/route.ts app/sitemap.xml/__tests__/route.test.ts`
- `./node_modules/.bin/next typegen`
- `./node_modules/.bin/tsc --noEmit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public `robots.txt` and `sitemap.xml` routes for better search engine discovery.
  * The sitemap now includes the main site pages and uses secure canonical URLs.

* **Bug Fixes**
  * Ensured the proxy allows unauthenticated access to the new SEO files so they can be served publicly.

* **Tests**
  * Added coverage for the new routes and proxy bypass behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->