### PR TITLE
Fix production subscription error bursts

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -114,6 +114,27 @@ describe("proxy", () => {
     );
   });
 
+  it("rejects nonstandard root methods before AuthKit", async () => {
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/",
+        method: "GESP",
+      }),
+    );
+
+    expect(response).toMatchObject({ kind: "json" });
+    expect(mockAuthkit).not.toHaveBeenCalled();
+    expect(mockNextResponseJson).toHaveBeenCalledWith(
+      {
+        code: "method_not_allowed",
+        message: "GESP is not supported for this route.",
+      },
+      { status: 405, headers: { Allow: "GET, HEAD, POST" } },
+    );
+  });
+
   it("lets root Server Action POSTs continue through AuthKit", async () => {
     mockAuthkit.mockResolvedValue({
       session: { user: { id: "user_123" } },

--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -15,6 +15,7 @@ const mockCreateCustomer = jest.fn();
 const mockRetrieveCustomer = jest.fn();
 const mockUpdateCustomer = jest.fn();
 const mockListCheckoutSessions = jest.fn();
+const mockUpdateCheckoutSession = jest.fn();
 const mockCreateCheckoutSession = jest.fn();
 const mockPostHogEvent = jest.fn();
 const mockPostHogWarn = jest.fn();
@@ -69,6 +70,7 @@ jest.mock("@/app/api/stripe", () => ({
     checkout: {
       sessions: {
         list: mockListCheckoutSessions,
+        update: mockUpdateCheckoutSession,
         create: mockCreateCheckoutSession,
       },
     },
@@ -136,6 +138,17 @@ describe("POST /api/subscribe", () => {
       url: "https://stripe.example/checkout",
     } as never);
     mockListCheckoutSessions.mockResolvedValue({ data: [] } as never);
+    mockUpdateCheckoutSession.mockImplementation(
+      async (
+        sessionId: string,
+        params: { metadata?: Record<string, string> },
+      ) =>
+        ({
+          id: sessionId,
+          url: "https://stripe.example/existing-checkout",
+          metadata: params.metadata ?? {},
+        }) as never,
+    );
     mockUpdateCustomer.mockImplementation(
       async (
         customerId: string,
@@ -219,19 +232,34 @@ describe("POST /api/subscribe", () => {
       id: "cus_existing_org",
       metadata: { workOSOrganizationId: "org_team" },
     } as never);
-    mockListCheckoutSessions.mockResolvedValue({
-      data: [
-        {
-          id: "cs_open",
-          url: "https://stripe.example/existing-checkout",
-          metadata: {
-            workOSOrganizationId: "org_team",
-            requestedPlan: "pro-monthly-plan",
-            checkoutAttemptId: "ca_original",
+    mockListCheckoutSessions
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: "cs_other_plan",
+            url: "https://stripe.example/other-checkout",
+            metadata: {
+              workOSOrganizationId: "org_team",
+              requestedPlan: "team-monthly-plan",
+            },
           },
-        },
-      ],
-    } as never);
+        ],
+        has_more: true,
+      } as never)
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: "cs_open",
+            url: "https://stripe.example/existing-checkout",
+            metadata: {
+              workOSOrganizationId: "org_team",
+              requestedPlan: "pro-monthly-plan",
+              checkoutAttemptId: "ca_original",
+            },
+          },
+        ],
+        has_more: false,
+      } as never);
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
     try {
@@ -250,10 +278,26 @@ describe("POST /api/subscribe", () => {
         url: "https://stripe.example/existing-checkout",
         checkoutAttemptId: "ca_retry_123",
       });
-      expect(mockListCheckoutSessions).toHaveBeenCalledWith({
+      expect(mockListCheckoutSessions).toHaveBeenNthCalledWith(1, {
         customer: "cus_existing_org",
         status: "open",
-        limit: 10,
+        limit: 100,
+      });
+      expect(mockListCheckoutSessions).toHaveBeenNthCalledWith(2, {
+        customer: "cus_existing_org",
+        status: "open",
+        limit: 100,
+        starting_after: "cs_other_plan",
+      });
+      expect(mockUpdateCheckoutSession).toHaveBeenCalledWith("cs_open", {
+        metadata: {
+          workOSOrganizationId: "org_team",
+          requestedPlan: "pro-monthly-plan",
+          checkoutAttemptId: "ca_retry_123",
+          userId: "user_123",
+          checkoutQuantity: "1",
+          checkoutType: "new_subscription",
+        },
       });
       expect(mockCreateCheckoutSession).not.toHaveBeenCalled();
       expect(warnSpy).toHaveBeenCalledTimes(1);
@@ -264,6 +308,7 @@ describe("POST /api/subscribe", () => {
         stripe_customer_id: "cus_existing_org",
         stripe_checkout_session_id: "cs_open",
         checkout_attempt_id: "ca_retry_123",
+        previous_checkout_attempt_id: "ca_original",
       });
       expect(mockPostHogEvent).toHaveBeenCalledWith(
         "checkout_started",

--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import { mockMutation as mockConvexMutation } from "convex/browser";
+import { ChatSDKError } from "@/lib/errors";
 
 const mockGetUserIDAndPro = jest.fn();
 const mockGetUser = jest.fn();
@@ -13,6 +14,7 @@ const mockListCustomers = jest.fn();
 const mockCreateCustomer = jest.fn();
 const mockRetrieveCustomer = jest.fn();
 const mockUpdateCustomer = jest.fn();
+const mockListCheckoutSessions = jest.fn();
 const mockCreateCheckoutSession = jest.fn();
 const mockPostHogEvent = jest.fn();
 const mockPostHogWarn = jest.fn();
@@ -66,6 +68,7 @@ jest.mock("@/app/api/stripe", () => ({
     },
     checkout: {
       sessions: {
+        list: mockListCheckoutSessions,
         create: mockCreateCheckoutSession,
       },
     },
@@ -132,6 +135,7 @@ describe("POST /api/subscribe", () => {
       id: "cs_123",
       url: "https://stripe.example/checkout",
     } as never);
+    mockListCheckoutSessions.mockResolvedValue({ data: [] } as never);
     mockUpdateCustomer.mockImplementation(
       async (
         customerId: string,
@@ -171,6 +175,160 @@ describe("POST /api/subscribe", () => {
     expect(mockCreateCustomer).not.toHaveBeenCalled();
     expect(mockUpdateOrganization).not.toHaveBeenCalled();
     expect(mockCreateCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it("returns unauthenticated requests as 401 responses", async () => {
+    mockGetUserIDAndPro.mockRejectedValueOnce(
+      new ChatSDKError("unauthorized:auth") as never,
+    );
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const { POST } = await import("../route");
+
+      const response = await POST(makeRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body).toEqual({
+        error: "You need to sign in before continuing.",
+        code: "unauthorized:auth",
+      });
+      expect(mockListCheckoutSessions).not.toHaveBeenCalled();
+      expect(mockCreateCheckoutSession).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("reuses a matching legacy open Checkout Session", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          role: { slug: "admin" },
+        },
+      ],
+    } as never);
+    mockGetOrganization.mockResolvedValue({
+      id: "org_team",
+      stripeCustomerId: "cus_existing_org",
+    } as never);
+    mockRetrieveCustomer.mockResolvedValue({
+      id: "cus_existing_org",
+      metadata: { workOSOrganizationId: "org_team" },
+    } as never);
+    mockListCheckoutSessions.mockResolvedValue({
+      data: [
+        {
+          id: "cs_open",
+          url: "https://stripe.example/existing-checkout",
+          metadata: {
+            workOSOrganizationId: "org_team",
+            requestedPlan: "pro-monthly-plan",
+            checkoutAttemptId: "ca_original",
+          },
+        },
+      ],
+    } as never);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const { POST } = await import("../route");
+
+      const response = await POST(
+        makeRequest({
+          plan: "pro-monthly-plan",
+          checkoutAttemptId: "ca_retry_123",
+        }),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({
+        url: "https://stripe.example/existing-checkout",
+        checkoutAttemptId: "ca_retry_123",
+      });
+      expect(mockListCheckoutSessions).toHaveBeenCalledWith({
+        customer: "cus_existing_org",
+        status: "open",
+        limit: 10,
+      });
+      expect(mockCreateCheckoutSession).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(String(warnSpy.mock.calls[0]?.[0]))).toMatchObject({
+        event: "billing.checkout_session_reused",
+        service: "hackerai-web",
+        route: "/api/subscribe",
+        stripe_customer_id: "cus_existing_org",
+        stripe_checkout_session_id: "cs_open",
+        checkout_attempt_id: "ca_retry_123",
+      });
+      expect(mockPostHogEvent).toHaveBeenCalledWith(
+        "checkout_started",
+        expect.objectContaining({
+          checkout_attempt_id: "ca_retry_123",
+          stripe_checkout_session_id: "cs_open",
+          stripe_checkout_session_reused: true,
+        }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("returns a safe conflict response when Stripe's pending-session limit is reached", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          role: { slug: "admin" },
+        },
+      ],
+    } as never);
+    mockGetOrganization.mockResolvedValue({
+      id: "org_team",
+      stripeCustomerId: "cus_existing_org",
+    } as never);
+    mockRetrieveCustomer.mockResolvedValue({
+      id: "cus_existing_org",
+      metadata: { workOSOrganizationId: "org_team" },
+    } as never);
+    const stripeError = Object.assign(
+      new Error("Customer reached the pending Checkout Session limit"),
+      {
+        code: "customer_max_subscriptions",
+        requestId: "req_stripe_123",
+      },
+    );
+    mockCreateCheckoutSession.mockRejectedValueOnce(stripeError as never);
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const { POST } = await import("../route");
+
+      const response = await POST(makeRequest({ plan: "pro-monthly-plan" }));
+      const body = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(body).toEqual({
+        error:
+          "A checkout is already pending. Please resume it or contact support if the problem continues.",
+      });
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const log = JSON.parse(String(errorSpy.mock.calls[0]?.[0]));
+      expect(log).toMatchObject({
+        event: "billing.subscribe_request_failed",
+        service: "hackerai-web",
+        route: "/api/subscribe",
+        stripe_error_code: "customer_max_subscriptions",
+        stripe_request_id: "req_stripe_123",
+      });
+      expect(log).not.toHaveProperty("customer_id");
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("uses an existing organization Stripe customer instead of replacing it", async () => {
@@ -215,7 +373,11 @@ describe("POST /api/subscribe", () => {
         customer: "cus_existing_org",
         metadata: expect.objectContaining({
           workOSOrganizationId: "org_team",
+          checkoutQuantity: "1",
           checkoutAttemptId: body.checkoutAttemptId,
+        }),
+        subscription_data: expect.objectContaining({
+          metadata: expect.objectContaining({ checkoutQuantity: "1" }),
         }),
       }),
     );

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -77,6 +77,47 @@ function getEnvironment(): string {
   return process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown";
 }
 
+const CHECKOUT_SESSION_PAGE_SIZE = 100;
+const MAX_CHECKOUT_SESSION_PAGES = 5;
+
+async function findReusableCheckoutSession({
+  customerId,
+  organizationId,
+  requestedPlan,
+  quantity,
+}: {
+  customerId: string;
+  organizationId: string;
+  requestedPlan: string;
+  quantity: number;
+}): Promise<Stripe.Checkout.Session | undefined> {
+  let startingAfter: string | undefined;
+
+  for (let page = 0; page < MAX_CHECKOUT_SESSION_PAGES; page += 1) {
+    const sessions = await stripe.checkout.sessions.list({
+      customer: customerId,
+      status: "open",
+      limit: CHECKOUT_SESSION_PAGE_SIZE,
+      ...(startingAfter && { starting_after: startingAfter }),
+    });
+    const reusableSession = sessions.data.find((candidate) =>
+      isReusableCheckoutSession(candidate, {
+        organizationId,
+        requestedPlan,
+        quantity,
+      }),
+    );
+
+    if (reusableSession) return reusableSession;
+    if (!sessions.has_more) return undefined;
+
+    startingAfter = sessions.data.at(-1)?.id;
+    if (!startingAfter) return undefined;
+  }
+
+  return undefined;
+}
+
 export const POST = async (req: NextRequest) => {
   let shouldClearReferralCookies = false;
   const json = (body: unknown, init?: ResponseInit) => {
@@ -358,18 +399,12 @@ export const POST = async (req: NextRequest) => {
 
     const cancelUrl = new URL(baseUrl);
 
-    const openSessions = await stripe.checkout.sessions.list({
-      customer: customer.id,
-      status: "open",
-      limit: 10,
+    let session = await findReusableCheckoutSession({
+      customerId: customer.id,
+      organizationId: organization.id,
+      requestedPlan: subscriptionLevel,
+      quantity,
     });
-    let session = openSessions.data.find((candidate) =>
-      isReusableCheckoutSession(candidate, {
-        organizationId: organization.id,
-        requestedPlan: subscriptionLevel,
-        quantity,
-      }),
-    );
     const reusedCheckoutSession = Boolean(session);
 
     if (!session) {
@@ -419,6 +454,22 @@ export const POST = async (req: NextRequest) => {
         },
       });
     } else {
+      const previousCheckoutAttemptId = session.metadata?.checkoutAttemptId;
+      session = await stripe.checkout.sessions.update(session.id, {
+        metadata: {
+          ...session.metadata,
+          userId,
+          workOSOrganizationId: organization.id,
+          requestedPlan: subscriptionLevel,
+          checkoutQuantity: String(quantity),
+          checkoutAttemptId,
+          ...(checkoutSource && { checkoutSource }),
+          ...(checkoutSurface && { checkoutSurface }),
+          ...(checkoutReason && { checkoutReason }),
+          ...(checkoutLimitType && { checkoutLimitType }),
+          checkoutType: "new_subscription",
+        },
+      });
       logger.warn("Reused an open Stripe Checkout Session", {
         event: "billing.checkout_session_reused",
         request_id: req.headers.get("x-vercel-id") ?? "unknown",
@@ -430,6 +481,7 @@ export const POST = async (req: NextRequest) => {
         checkout_attempt_id: checkoutAttemptId,
         stripe_customer_id: customer.id,
         stripe_checkout_session_id: session.id,
+        previous_checkout_attempt_id: previousCheckoutAttemptId,
         requested_plan: subscriptionLevel,
         quantity,
         checkout_source: checkoutSource,

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -5,8 +5,11 @@ import { buildWorkOSOrganizationName } from "@/lib/auth/workos-organization-name
 import { NextRequest, NextResponse, after } from "next/server";
 import { getSuspensionMessage } from "@/lib/suspensionMessage";
 import { phLogger } from "@/lib/posthog/server";
+import { logger } from "@/lib/logger";
+import { ChatSDKError } from "@/lib/errors";
 import { getConvexClient } from "@/lib/db/convex-client";
 import { api } from "@/convex/_generated/api";
+import type Stripe from "stripe";
 import {
   REFERRAL_COOKIE_CREATED_AT_NAME,
   REFERRAL_COOKIE_NAME,
@@ -40,6 +43,38 @@ function parseCreatedAtMs(raw: unknown): number | undefined {
 function clearReferralCookies(response: NextResponse) {
   response.cookies.delete(REFERRAL_COOKIE_NAME);
   response.cookies.delete(REFERRAL_COOKIE_CREATED_AT_NAME);
+}
+
+function isReusableCheckoutSession(
+  session: Stripe.Checkout.Session,
+  {
+    organizationId,
+    requestedPlan,
+    quantity,
+  }: {
+    organizationId: string;
+    requestedPlan: string;
+    quantity: number;
+  },
+): boolean {
+  if (!session.url) return false;
+  if (session.metadata?.workOSOrganizationId !== organizationId) return false;
+  if (session.metadata?.requestedPlan !== requestedPlan) return false;
+
+  const checkoutQuantity = session.metadata?.checkoutQuantity;
+  return checkoutQuantity
+    ? checkoutQuantity === String(quantity)
+    : quantity === 1;
+}
+
+function getErrorString(error: unknown, key: string): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const value = (error as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function getEnvironment(): string {
+  return process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown";
 }
 
 export const POST = async (req: NextRequest) => {
@@ -323,34 +358,38 @@ export const POST = async (req: NextRequest) => {
 
     const cancelUrl = new URL(baseUrl);
 
-    const session = await stripe.checkout.sessions.create({
+    const openSessions = await stripe.checkout.sessions.list({
       customer: customer.id,
-      billing_address_collection: "auto",
-      line_items: [
-        {
-          price: price.data[0].id,
-          quantity: quantity,
-        },
-      ],
-      mode: "subscription",
-      success_url: successUrl.toString(),
-      cancel_url: cancelUrl.toString(),
-      metadata: {
-        userId,
-        workOSOrganizationId: organization.id,
+      status: "open",
+      limit: 10,
+    });
+    let session = openSessions.data.find((candidate) =>
+      isReusableCheckoutSession(candidate, {
+        organizationId: organization.id,
         requestedPlan: subscriptionLevel,
-        checkoutAttemptId,
-        ...(checkoutSource && { checkoutSource }),
-        ...(checkoutSurface && { checkoutSurface }),
-        ...(checkoutReason && { checkoutReason }),
-        ...(checkoutLimitType && { checkoutLimitType }),
-        checkoutType: "new_subscription",
-      },
-      subscription_data: {
+        quantity,
+      }),
+    );
+    const reusedCheckoutSession = Boolean(session);
+
+    if (!session) {
+      session = await stripe.checkout.sessions.create({
+        customer: customer.id,
+        billing_address_collection: "auto",
+        line_items: [
+          {
+            price: price.data[0].id,
+            quantity: quantity,
+          },
+        ],
+        mode: "subscription",
+        success_url: successUrl.toString(),
+        cancel_url: cancelUrl.toString(),
         metadata: {
           userId,
           workOSOrganizationId: organization.id,
           requestedPlan: subscriptionLevel,
+          checkoutQuantity: String(quantity),
           checkoutAttemptId,
           ...(checkoutSource && { checkoutSource }),
           ...(checkoutSurface && { checkoutSurface }),
@@ -358,16 +397,53 @@ export const POST = async (req: NextRequest) => {
           ...(checkoutLimitType && { checkoutLimitType }),
           checkoutType: "new_subscription",
         },
-      },
-      custom_text: {
-        submit: {
-          message:
-            "Renews monthly until cancelled. Cancel anytime in Settings.",
+        subscription_data: {
+          metadata: {
+            userId,
+            workOSOrganizationId: organization.id,
+            requestedPlan: subscriptionLevel,
+            checkoutQuantity: String(quantity),
+            checkoutAttemptId,
+            ...(checkoutSource && { checkoutSource }),
+            ...(checkoutSurface && { checkoutSurface }),
+            ...(checkoutReason && { checkoutReason }),
+            ...(checkoutLimitType && { checkoutLimitType }),
+            checkoutType: "new_subscription",
+          },
         },
-      },
-    });
+        custom_text: {
+          submit: {
+            message:
+              "Renews monthly until cancelled. Cancel anytime in Settings.",
+          },
+        },
+      });
+    } else {
+      logger.warn("Reused an open Stripe Checkout Session", {
+        event: "billing.checkout_session_reused",
+        request_id: req.headers.get("x-vercel-id") ?? "unknown",
+        service: "hackerai-web",
+        environment: getEnvironment(),
+        route: "/api/subscribe",
+        user_id: userId,
+        organization_id: organization.id,
+        checkout_attempt_id: checkoutAttemptId,
+        stripe_customer_id: customer.id,
+        stripe_checkout_session_id: session.id,
+        requested_plan: subscriptionLevel,
+        quantity,
+        checkout_source: checkoutSource,
+        checkout_surface: checkoutSurface,
+        checkout_reason: checkoutReason,
+        checkout_limit_type: checkoutLimitType,
+      });
+    }
 
-    if (referralConfig.enabled && canRecordReferralCheckoutSession) {
+    if (
+      !reusedCheckoutSession &&
+      referralConfig.enabled &&
+      canRecordReferralCheckoutSession
+    ) {
       try {
         const referralSession = await getConvexClient().mutation(
           api.referrals.recordReferralCheckoutSession,
@@ -432,6 +508,7 @@ export const POST = async (req: NextRequest) => {
         currency: selectedPrice.currency,
         stripe_customer_id: customer.id,
         stripe_checkout_session_id: session.id,
+        stripe_checkout_session_reused: reusedCheckoutSession,
         stripe_price_id: selectedPrice.id,
         $session_id: posthogSessionId ?? undefined,
         $insert_id: `${PAID_FUNNEL_EVENTS.checkoutStarted}:${checkoutAttemptId}`,
@@ -444,9 +521,44 @@ export const POST = async (req: NextRequest) => {
 
     return json({ url: session.url, checkoutAttemptId });
   } catch (error: unknown) {
+    if (error instanceof ChatSDKError) {
+      return json(
+        {
+          error: error.message,
+          code: `${error.type}:${error.surface}`,
+        },
+        { status: error.statusCode },
+      );
+    }
+
     const errorMessage =
       error instanceof Error ? error.message : "An error occurred";
-    console.error(errorMessage, error);
+    const stripeErrorCode = getErrorString(error, "code");
+    const stripeRequestId = getErrorString(error, "requestId");
+    logger.error(
+      "Subscription checkout request failed",
+      error instanceof Error ? error : undefined,
+      {
+        event: "billing.subscribe_request_failed",
+        request_id: req.headers.get("x-vercel-id") ?? "unknown",
+        service: "hackerai-web",
+        environment: getEnvironment(),
+        route: "/api/subscribe",
+        stripe_error_code: stripeErrorCode,
+        stripe_request_id: stripeRequestId,
+      },
+    );
+
+    if (stripeErrorCode === "customer_max_subscriptions") {
+      return json(
+        {
+          error:
+            "A checkout is already pending. Please resume it or contact support if the problem continues.",
+        },
+        { status: 409 },
+      );
+    }
+
     return json({ error: errorMessage }, { status: 500 });
   }
 };

--- a/proxy.ts
+++ b/proxy.ts
@@ -66,14 +66,15 @@ function shouldBypassAuthkit(pathname: string): boolean {
   return AUTHKIT_BYPASS_PATHS.has(pathname);
 }
 
-function isUnsupportedRootPagePost(
+function isUnsupportedRootPageRequest(
   request: NextRequest,
   pathname: string,
 ): boolean {
-  return (
-    request.method === "POST" &&
-    ROOT_PAGE_POST_PATHS.has(pathname) &&
-    !request.headers.has(NEXT_ACTION_HEADER)
+  if (!ROOT_PAGE_POST_PATHS.has(pathname)) return false;
+  if (request.method === "GET" || request.method === "HEAD") return false;
+
+  return !(
+    request.method === "POST" && request.headers.has(NEXT_ACTION_HEADER)
   );
 }
 
@@ -157,13 +158,18 @@ function buildEndedSessionResponse(
 export default async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
-  if (isUnsupportedRootPagePost(request, pathname)) {
+  if (isUnsupportedRootPageRequest(request, pathname)) {
     return NextResponse.json(
       {
         code: "method_not_allowed",
-        message: "POST is not supported for this route.",
+        message: `${request.method} is not supported for this route.`,
       },
-      { status: 405, headers: { Allow: "GET, HEAD" } },
+      {
+        status: 405,
+        headers: {
+          Allow: request.method === "POST" ? "GET, HEAD" : "GET, HEAD, POST",
+        },
+      },
     );
   }
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -14,7 +14,7 @@ const AUTHKIT_BYPASS_PATHS = new Set([
   "/robots.txt",
   "/sitemap.xml",
 ]);
-const ROOT_PAGE_POST_PATHS = new Set(["/", "/index"]);
+const ROOT_PAGE_PATHS = new Set(["/", "/index"]);
 const NEXT_ACTION_HEADER = "next-action";
 
 const UNAUTHENTICATED_PATHS = new Set([
@@ -74,7 +74,7 @@ function isUnsupportedRootPageRequest(
   request: NextRequest,
   pathname: string,
 ): boolean {
-  if (!ROOT_PAGE_POST_PATHS.has(pathname)) return false;
+  if (!ROOT_PAGE_PATHS.has(pathname)) return false;
   if (request.method === "GET" || request.method === "HEAD") return false;
 
   return !(


### PR DESCRIPTION
## Summary
- reuse matching open Stripe Checkout Sessions across the full 500-session pending cap, updating retry metadata before redirect and emitting structured correlation logs
- return expected authentication failures from `/api/subscribe` as 401s and map Stripe's pending-session cap to a safe 409 response
- reject unsupported root methods before AuthKit to prevent 300-second middleware timeouts

## Root cause
A rapid authenticated `/api/subscribe` burst kept creating Checkout Sessions until one Stripe customer reached the 500 pending-session limit. The same burst exhausted WorkOS session refresh capacity, and the route flattened resulting authentication failures into 500s. Separately, nonstandard methods such as `GESP` and `XBFY` reached AuthKit on the root route and timed out after 300 seconds.

## Validation
- latest full commit-hook suite: 219 suites / 2,207 tests
- focused suite: `./node_modules/.bin/jest __tests__/proxy.test.ts app/api/subscribe/__tests__/route.test.ts --runInBand` (21 tests)
- `./node_modules/.bin/tsc --noEmit`
- focused ESLint and Prettier checks
- `git diff --check`

## Manual verification
- As a free user, start Checkout and retry the same plan and quantity; the second request should redirect to the existing open session, update its `checkoutAttemptId`, and emit `billing.checkout_session_reused`.
- Send an unauthenticated `POST /api/subscribe`; it should return 401 without an error-level log.
- Send an unsupported method to `/`; it should return 405 promptly rather than entering AuthKit.
- After deployment, scan the last 15 minutes of production Vercel errors and confirm the subscription and root-timeout buckets stop recurring.