### PR TITLE
Make Agent context compaction durable across long runs

### DIFF
--- a/app/components/FinishReasonNotice.tsx
+++ b/app/components/FinishReasonNotice.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { ChatMode } from "@/types/chat";
 import { useDataStreamState } from "@/app/components/DataStreamProvider";
-import { MAX_AUTO_CONTINUES } from "@/app/hooks/useAutoContinue";
 import { Button } from "@/components/ui/button";
 import { captureAgentRunSpendCapContinueClick } from "@/lib/analytics/client";
 import {
@@ -27,24 +26,11 @@ export const FinishReasonNotice = ({
   agentRunSpendCapPremiumContinuationAllowed,
   onContinue,
 }: FinishReasonNoticeProps) => {
-  const { isAutoResuming, autoContinueCount } = useDataStreamState();
+  const { isAutoResuming } = useDataStreamState();
   const [hasContinued, setHasContinued] = useState(false);
 
   if (isAutoResuming) return null;
   if (hasContinued) return null;
-
-  // Suppress for auto-continuable reasons in agent mode when more auto-continues will fire
-  if (
-    mode === "agent" &&
-    autoContinueCount < MAX_AUTO_CONTINUES &&
-    (finishReason === "context-limit" ||
-      finishReason === "length" ||
-      finishReason === "preemptive-timeout" ||
-      finishReason === "tool-calls" ||
-      finishReason === POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON)
-  ) {
-    return null;
-  }
 
   if (!finishReason) return null;
 

--- a/app/components/__tests__/FinishReasonNotice.test.tsx
+++ b/app/components/__tests__/FinishReasonNotice.test.tsx
@@ -72,36 +72,6 @@ describe("FinishReasonNotice", () => {
       },
     );
 
-    it.each([
-      { finishReason: "context-limit" as const, autoContinueCount: 0 },
-      { finishReason: "context-limit" as const, autoContinueCount: 2 },
-      { finishReason: "context-limit" as const, autoContinueCount: 4 },
-      { finishReason: "length" as const, autoContinueCount: 0 },
-      { finishReason: "length" as const, autoContinueCount: 3 },
-      { finishReason: "length" as const, autoContinueCount: 4 },
-      { finishReason: "tool-calls" as const, autoContinueCount: 0 },
-      { finishReason: "tool-calls" as const, autoContinueCount: 2 },
-      { finishReason: "tool-calls" as const, autoContinueCount: 4 },
-      { finishReason: "preemptive-timeout" as const, autoContinueCount: 0 },
-      {
-        finishReason: POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON,
-        autoContinueCount: 0,
-      },
-      {
-        finishReason: POST_SUMMARIZATION_INCOMPLETE_FINISH_REASON,
-        autoContinueCount: 4,
-      },
-    ])(
-      "returns null in agent mode when autoContinueCount=$autoContinueCount < MAX for finishReason=$finishReason",
-      ({ finishReason, autoContinueCount }) => {
-        const { container } = renderNotice(
-          { finishReason, mode: "agent" },
-          { isAutoResuming: false, autoContinueCount },
-        );
-        expect(container.innerHTML).toBe("");
-      },
-    );
-
     it("returns null when finishReason is undefined", () => {
       const { container } = renderNotice(
         { finishReason: undefined, mode: "agent" },
@@ -146,11 +116,11 @@ describe("FinishReasonNotice", () => {
         expectedText: "Paused after compacting the conversation",
       },
     ])(
-      "renders notice for finishReason=$finishReason when autoContinueCount has reached MAX_AUTO_CONTINUES",
+      "renders notice for finishReason=$finishReason when no auto-continuation is pending",
       ({ finishReason, expectedText }) => {
         renderNotice(
           { finishReason, mode: "agent" },
-          { isAutoResuming: false, autoContinueCount: MAX_AUTO_CONTINUES },
+          { isAutoResuming: false, autoContinueCount: 0 },
         );
         expect(screen.getByText(new RegExp(expectedText))).toBeInTheDocument();
       },

--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -752,6 +752,27 @@ describe("UsageTracker", () => {
       expect(usage.costSource).toBe("provider");
     });
 
+    it("preserves summarization usage across fallback reset", () => {
+      tracker.inputTokens = 1_200;
+      tracker.summarizationInputTokens = 200;
+      tracker.outputTokens = 140;
+      tracker.summarizationOutputTokens = 40;
+      tracker.totalTokens = 1_340;
+      tracker.cacheReadTokens = 90;
+      tracker.summarizationCacheReadTokens = 20;
+      tracker.cacheWriteTokens = 50;
+      tracker.summarizationCacheWriteTokens = 10;
+
+      tracker.resetModelLeg();
+
+      expect(tracker.inputTokens).toBe(200);
+      expect(tracker.outputTokens).toBe(40);
+      expect(tracker.totalTokens).toBe(240);
+      expect(tracker.cacheReadTokens).toBe(20);
+      expect(tracker.cacheWriteTokens).toBe(10);
+      expect(tracker.streamOutputTokens).toBe(0);
+    });
+
     it("labels post-run overflow as mixed when final deduction uses extra usage", () => {
       tracker.accumulateStep({
         inputTokens: 1_000_000,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -781,6 +781,14 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(throwIdx).toBeGreaterThan(terminalErrorIdx);
   });
 
+  test("direct context-limit finish reasons trigger auto-continue in both agent paths", () => {
+    for (const source of [taskSrc, chatHandlerSrc]) {
+      expect(source).toMatch(/getAgentAutoContinueStopSource\(\{/);
+      expect(source).toMatch(/autoContinueStopSource/);
+      expect(source).toMatch(/agent_auto_continue_signaled/);
+    }
+  });
+
   test("provider stream errors with reasoning-only output can retry on fallback", () => {
     const helperImportIdx = taskSrc.indexOf("shouldRetryAgentLongWithFallback");
     const partsIdx = taskSrc.indexOf(

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -156,6 +156,7 @@ describe("createAgentStream repeated compaction", () => {
       "ineffective ".repeat(4_000),
     );
     mockRunSummarizationStep.mockResolvedValue({
+      summarizationAttempted: true,
       needsSummarization: true,
       summarizedMessages: [summary1],
     });
@@ -187,10 +188,14 @@ describe("createAgentStream repeated compaction", () => {
     };
     const usageTracker = {
       inputTokens: 0,
+      summarizationInputTokens: 0,
       outputTokens: 0,
+      totalTokens: 0,
       summarizationOutputTokens: 0,
       cacheReadTokens: 0,
+      summarizationCacheReadTokens: 0,
       cacheWriteTokens: 0,
+      summarizationCacheWriteTokens: 0,
       providerCost: 0,
     };
     const original = uiMessage("original", "old ".repeat(2_000));
@@ -330,7 +335,10 @@ describe("createAgentStream repeated compaction", () => {
   });
 
   it("stops cleanly when the attempt budget is exhausted with no accepted summary", async () => {
-    mockRunSummarizationStep.mockResolvedValue({ needsSummarization: false });
+    mockRunSummarizationStep.mockResolvedValue({
+      summarizationAttempted: true,
+      needsSummarization: false,
+    });
     mockCompactModelMessagesInRun.mockResolvedValue(null);
     mockGetProviderPromptPressure.mockReturnValue({
       reason: "serialized_message_bytes",
@@ -378,7 +386,7 @@ describe("createAgentStream repeated compaction", () => {
     }
 
     expect(mockCompactModelMessagesInRun).toHaveBeenCalledTimes(
-      MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM,
+      MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM - 1,
     );
     expect(tracker.summarizationCount).toBe(0);
     expect(tracker.recordSummarization).not.toHaveBeenCalled();

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -1,0 +1,401 @@
+import type { ModelMessage, UIMessage } from "ai";
+
+const mockStreamText = jest.fn();
+const mockRunSummarizationStep = jest.fn();
+const mockCompactModelMessagesInRun = jest.fn();
+const mockGetProviderPromptPressure = jest.fn();
+
+jest.mock("server-only", () => ({}));
+jest.mock("ai", () => ({
+  convertToModelMessages: jest.fn(async (messages: UIMessage[]) =>
+    messages.map((message) => ({
+      role: message.role,
+      content: message.parts
+        .filter((part) => part.type === "text")
+        .map((part) => part.text)
+        .join("\n"),
+    })),
+  ),
+  stepCountIs: jest.fn(() => () => false),
+  streamText: mockStreamText,
+}));
+jest.mock("@/lib/api/chat-stream-helpers", () => ({
+  addCacheBreakpointToLastUserMessage: (messages: ModelMessage[]) => messages,
+  applyPrepareStepReminders: async (messages: ModelMessage[]) => messages,
+  buildProviderOptions: () => ({}),
+  buildSystemPrompt: (prompt: string) => prompt,
+  getFallbackSlugs: () => [],
+  isXaiSafetyError: () => false,
+  runSummarizationStep: mockRunSummarizationStep,
+}));
+jest.mock("@/lib/chat/summarization", () => ({
+  compactModelMessagesInRun: mockCompactModelMessagesInRun,
+}));
+jest.mock("@/lib/chat/summarization/provider-pressure", () => ({
+  getProviderPromptPressure: mockGetProviderPromptPressure,
+}));
+jest.mock("@/lib/chat/doom-loop-detection", () => ({
+  detectDoomLoop: () => ({
+    severity: "none",
+    toolNames: [],
+    consecutiveCount: 0,
+  }),
+  generateDoomLoopNudge: () => "",
+}));
+jest.mock("@/lib/chat/agent-long-provider-retry", () => ({
+  createAssistantContentLoopMonitor: () => ({
+    appendDelta: () => ({ detected: false }),
+  }),
+}));
+jest.mock("@/lib/chat/compaction/prune-tool-outputs", () => ({
+  filterEmptyAssistantMessages: (messages: ModelMessage[]) => messages,
+  repairAnthropicModelMessagesWithTelemetry: (messages: ModelMessage[]) => ({
+    action: "none",
+    messages,
+  }),
+  pruneToolOutputs: (messages: UIMessage[]) => ({
+    messages,
+    prunedCount: 0,
+  }),
+  pruneModelMessages: (messages: ModelMessage[]) => ({
+    messages,
+    prunedCount: 0,
+  }),
+}));
+jest.mock("@/lib/chat/multimodal-tool-result-recovery", () => ({
+  isProviderMultimodalToolResultRejectionError: () => false,
+  toolResultsContainImageViewResult: () => false,
+  uiMessagesContainImageViewResult: () => false,
+}));
+jest.mock("@/lib/ai/providers", () => ({
+  isAnthropicModel: () => false,
+}));
+jest.mock("@/lib/ai/tools/utils/pty-session-manager", () => ({
+  ptySessionManager: { closeAllSessions: jest.fn() },
+}));
+jest.mock("@/lib/ai/tools/prompt-serialization", () => ({
+  createPromptSerializationTools: () => ({}),
+}));
+jest.mock("@/lib/api/openrouter-metadata", () => ({
+  extractOpenRouterMetadata: () => ({}),
+  mergeOpenRouterMetadata: () => ({}),
+}));
+jest.mock("@/lib/provider-usage-cost", () => ({
+  getOpenRouterUpstreamInferenceCostFromUsageRaw: () => undefined,
+}));
+jest.mock("@/lib/utils/error-utils", () => ({
+  classifyProviderOverflowError: () => null,
+}));
+
+const {
+  createAgentStream,
+  initAgentStreamState,
+}: typeof import("@/lib/api/agent-stream-runner") = require("@/lib/api/agent-stream-runner");
+
+const uiMessage = (id: string, text: string): UIMessage => ({
+  id,
+  role: "user",
+  parts: [{ type: "text", text }],
+});
+
+describe("createAgentStream repeated compaction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStreamText.mockImplementation((options) => options);
+  });
+
+  it("rebases every later prepareStep onto the latest in-run summary", async () => {
+    const summary1 = uiMessage("summary-1", "summary 1");
+    const summary2 = uiMessage("summary-2", "summary 2");
+    const ineffectiveSummary = uiMessage(
+      "ineffective-summary",
+      "ineffective ".repeat(4_000),
+    );
+    mockRunSummarizationStep.mockResolvedValue({
+      needsSummarization: true,
+      summarizedMessages: [summary1],
+    });
+    mockCompactModelMessagesInRun
+      .mockResolvedValueOnce({
+        summaryMessage: ineffectiveSummary,
+        summaryText: "ineffective",
+        summarizationUsage: { inputTokens: 10, outputTokens: 2 },
+      })
+      .mockResolvedValue({
+        summaryMessage: summary2,
+        summaryText: "summary 2",
+        summarizationUsage: { inputTokens: 10, outputTokens: 2 },
+      });
+    mockGetProviderPromptPressure
+      .mockReturnValueOnce({ reason: "serialized_message_bytes", reasons: [] })
+      .mockReturnValueOnce({ reason: "serialized_message_bytes", reasons: [] })
+      .mockReturnValueOnce({ reason: "serialized_message_bytes", reasons: [] })
+      .mockReturnValueOnce(null);
+
+    const tracker = {
+      hasSummarized: false,
+      summarizationCount: 0,
+      recordSummarization() {
+        this.hasSummarized = true;
+        this.summarizationCount++;
+      },
+      recordSummarizationUsage: jest.fn(),
+    };
+    const usageTracker = {
+      inputTokens: 0,
+      outputTokens: 0,
+      summarizationOutputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      providerCost: 0,
+    };
+    const original = uiMessage("original", "old ".repeat(2_000));
+    const writer = { write: jest.fn() };
+    const state = initAgentStreamState([original], {
+      usedTokens: 120_000,
+      maxTokens: 128_000,
+    });
+    const stream = (await createAgentStream(
+      "test-model",
+      {
+        trackedProvider: {
+          languageModel: () => ({ modelId: "test-model" }),
+        },
+        currentSystemPrompt: "system",
+        tools: {},
+        mode: "agent",
+        endpoint: "agent",
+        userId: "user",
+        subscription: "pro",
+        chatId: "chat",
+        temporary: false,
+        fileTokens: {},
+        noteInjectionOpts: {
+          userId: "user",
+          subscription: "pro",
+          shouldIncludeNotes: false,
+          isTemporary: false,
+        },
+        systemPromptTokens: 100,
+        ctxSystemTokens: 100,
+        ctxMaxTokens: 128_000,
+        streamStartTime: Date.now(),
+        contextUsageOn: true,
+        isReasoningModel: false,
+        maxDurationMs: 60_000,
+        writer,
+        abortController: new AbortController(),
+        summarizationTracker: tracker,
+        usageTracker,
+        budgetMonitor: null,
+        sandboxManager: {
+          getSandboxType: () => undefined,
+          supportsInteractivePty: async () => true,
+        },
+        getTodoManager: () => ({ getAllTodos: () => [] }),
+        ensureSandbox: jest.fn(),
+        chatLogger: undefined,
+        usageRefundTracker: {},
+        getHardTimeoutReason: () => null,
+      } as any,
+      state,
+    )) as any;
+
+    const initialRaw: ModelMessage[] = [
+      { role: "user", content: "old ".repeat(2_000) },
+    ];
+    const first = await stream.prepareStep({
+      steps: [],
+      messages: initialRaw,
+    });
+    expect(first.messages[0].content).toBe("summary 1");
+    state.lastStepInputTokens = 300_000;
+    expect(stream.stopWhen[1]()).toBe(false);
+
+    const step1: ModelMessage = {
+      role: "assistant",
+      content: "tool step 1 ".repeat(1_000),
+    };
+    const second = await stream.prepareStep({
+      steps: [{ toolResults: [], response: { messages: [step1] } }],
+      messages: [...initialRaw, step1],
+    });
+    expect(mockCompactModelMessagesInRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelMessages: expect.arrayContaining([
+          expect.objectContaining({ content: "summary 1" }),
+          step1,
+        ]),
+        transcriptModelMessages: [...initialRaw, step1],
+        compactionIndex: 2,
+      }),
+    );
+    expect(second.messages[0].content).toBe("summary 1");
+    expect(writer.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "data-summarization",
+        id: "summarization-status-2",
+        data: { status: "completed", message: "" },
+        transient: true,
+      }),
+    );
+    expect(tracker.summarizationCount).toBe(1);
+    expect(tracker.recordSummarizationUsage).toHaveBeenCalledTimes(1);
+
+    const step2: ModelMessage = {
+      role: "assistant",
+      content: "tool step 2 ".repeat(1_000),
+    };
+    const third = await stream.prepareStep({
+      steps: [
+        { toolResults: [], response: { messages: [step1] } },
+        { toolResults: [], response: { messages: [step2] } },
+      ],
+      messages: [...initialRaw, step1, step2],
+    });
+    expect(third.messages[0].content).toBe("summary 2");
+    expect(tracker.summarizationCount).toBe(2);
+
+    state.lastStepInputTokens = 0;
+    const step3: ModelMessage = { role: "assistant", content: "tool step 3" };
+    const fourth = await stream.prepareStep({
+      steps: [
+        { toolResults: [], response: { messages: [step1] } },
+        { toolResults: [], response: { messages: [step2] } },
+        { toolResults: [], response: { messages: [step3] } },
+      ],
+      messages: [...initialRaw, step1, step2, step3],
+    });
+    expect(fourth.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ content: "summary 2" }),
+        step3,
+      ]),
+    );
+    expect(fourth.messages).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ content: initialRaw[0].content }),
+      ]),
+    );
+    expect(mockCompactModelMessagesInRun).toHaveBeenCalledTimes(2);
+
+    mockGetProviderPromptPressure.mockReturnValue({
+      reason: "serialized_message_bytes",
+      reasons: [],
+    });
+    const accumulatedRaw = [...initialRaw, step1, step2, step3];
+    const accumulatedSteps = [
+      { toolResults: [], response: { messages: [step1] } },
+      { toolResults: [], response: { messages: [step2] } },
+      { toolResults: [], response: { messages: [step3] } },
+    ];
+    for (let index = 4; index <= 8; index++) {
+      const nextStep: ModelMessage = {
+        role: "assistant",
+        content: `large tool step ${index} `.repeat(1_000),
+      };
+      accumulatedRaw.push(nextStep);
+      accumulatedSteps.push({
+        toolResults: [],
+        response: { messages: [nextStep] },
+      });
+      await stream.prepareStep({
+        steps: accumulatedSteps,
+        messages: accumulatedRaw,
+      });
+    }
+
+    expect(tracker.summarizationCount).toBe(7);
+    expect(mockCompactModelMessagesInRun).toHaveBeenCalledTimes(7);
+    state.lastStepInputTokens = 300_000;
+    expect(stream.stopWhen[1]()).toBe(true);
+    expect(state.stoppedDueToTokenExhaustion).toBe(true);
+  });
+
+  it("stops cleanly when the attempt budget is exhausted with no accepted summary", async () => {
+    mockRunSummarizationStep.mockResolvedValue({ needsSummarization: false });
+    mockCompactModelMessagesInRun.mockResolvedValue(null);
+    mockGetProviderPromptPressure.mockReturnValue({
+      reason: "serialized_message_bytes",
+      reasons: [],
+    });
+    const tracker = {
+      hasSummarized: false,
+      summarizationCount: 0,
+      recordSummarization: jest.fn(),
+      recordSummarizationUsage: jest.fn(),
+    };
+    const initialRaw: ModelMessage[] = [
+      { role: "user", content: "oversized initial history" },
+    ];
+    const state = initAgentStreamState(
+      [uiMessage("original-failure", "oversized initial history")],
+      { usedTokens: 200_000, maxTokens: 200_000 },
+    );
+    const stream = (await createAgentStream(
+      "test-model",
+      {
+        trackedProvider: {
+          languageModel: () => ({ modelId: "test-model" }),
+        },
+        currentSystemPrompt: "system",
+        tools: {},
+        mode: "agent",
+        endpoint: "agent",
+        userId: "user",
+        subscription: "pro",
+        chatId: "chat-failure",
+        temporary: false,
+        fileTokens: {},
+        noteInjectionOpts: {
+          userId: "user",
+          subscription: "pro",
+          shouldIncludeNotes: false,
+          isTemporary: false,
+        },
+        systemPromptTokens: 100,
+        ctxSystemTokens: 100,
+        ctxMaxTokens: 200_000,
+        streamStartTime: Date.now(),
+        contextUsageOn: true,
+        isReasoningModel: false,
+        maxDurationMs: 60_000,
+        writer: { write: jest.fn() },
+        abortController: new AbortController(),
+        summarizationTracker: tracker,
+        usageTracker: {},
+        budgetMonitor: null,
+        sandboxManager: {
+          getSandboxType: () => undefined,
+          supportsInteractivePty: async () => true,
+        },
+        getTodoManager: () => ({ getAllTodos: () => [] }),
+        ensureSandbox: jest.fn(),
+        chatLogger: undefined,
+        usageRefundTracker: {},
+        getHardTimeoutReason: () => null,
+      } as any,
+      state,
+    )) as any;
+
+    await stream.prepareStep({ steps: [], messages: initialRaw });
+    const rawMessages = [...initialRaw];
+    const steps: Array<Record<string, unknown>> = [];
+    for (let index = 1; index <= 8; index++) {
+      const step: ModelMessage = {
+        role: "assistant",
+        content: `failed compaction step ${index}`,
+      };
+      rawMessages.push(step);
+      steps.push({ toolResults: [], response: { messages: [step] } });
+      await stream.prepareStep({ steps, messages: rawMessages });
+    }
+
+    expect(mockCompactModelMessagesInRun).toHaveBeenCalledTimes(8);
+    expect(tracker.summarizationCount).toBe(0);
+    expect(tracker.recordSummarization).not.toHaveBeenCalled();
+    state.lastStepInputTokens = 300_000;
+    expect(stream.stopWhen[1]()).toBe(true);
+    expect(state.stoppedDueToTokenExhaustion).toBe(true);
+  });
+});

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -334,6 +334,146 @@ describe("createAgentStream repeated compaction", () => {
     expect(state.stoppedDueToTokenExhaustion).toBe(true);
   });
 
+  it("retains the latest completed tool pair across rolling compaction", async () => {
+    const summary = uiMessage(
+      "summary-tool-pair",
+      "Continue the remaining rounds.",
+    );
+    mockCompactModelMessagesInRun.mockResolvedValue({
+      summaryMessage: summary,
+      summaryText: "Continue the remaining rounds.",
+      summarizationUsage: { inputTokens: 10, outputTokens: 2 },
+    });
+    mockGetProviderPromptPressure
+      .mockReturnValueOnce({
+        reason: "serialized_message_bytes",
+        reasons: [],
+      })
+      .mockReturnValue(null);
+
+    const tracker = {
+      hasSummarized: true,
+      summarizationCount: 1,
+      recordSummarization() {
+        this.summarizationCount++;
+      },
+      recordSummarizationUsage: jest.fn(),
+    };
+    const largeOldUserContent = "old context ".repeat(4_000);
+    const initialRaw: ModelMessage[] = [
+      { role: "user", content: largeOldUserContent },
+    ];
+    const toolCall = {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "round-1",
+          toolName: "run_terminal_cmd",
+          input: { command: "printf 'ROUND_1_BEGIN\\nROUND_1_END\\n'" },
+        },
+      ],
+    } as ModelMessage;
+    const toolResult = {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "round-1",
+          toolName: "run_terminal_cmd",
+          output: {
+            type: "text",
+            value: "ROUND_1_BEGIN\nROUND_1_END",
+          },
+        },
+      ],
+    } as ModelMessage;
+    const state = initAgentStreamState(
+      [uiMessage("original-tool-pair", largeOldUserContent)],
+      { usedTokens: 120_000, maxTokens: 128_000 },
+    );
+    state.lastStepInputTokens = 300_000;
+    const stream = (await createAgentStream(
+      "test-model",
+      createTestStreamContext({
+        chatId: "chat-tool-pair",
+        summarizationTracker: tracker,
+        usageTracker: {},
+      }) as any,
+      state,
+    )) as any;
+
+    const countToolParts = (
+      messages: ModelMessage[],
+      type: "tool-call" | "tool-result",
+    ) =>
+      messages.reduce((count, message) => {
+        if (!Array.isArray(message.content)) return count;
+        return (
+          count +
+          message.content.filter((part) => {
+            const record = part as Record<string, unknown>;
+            return record.type === type && record.toolCallId === "round-1";
+          }).length
+        );
+      }, 0);
+    const findToolPartMessageIndex = (
+      messages: ModelMessage[],
+      type: "tool-call" | "tool-result",
+    ) =>
+      messages.findIndex(
+        (message) =>
+          Array.isArray(message.content) &&
+          message.content.some((part) => {
+            const record = part as Record<string, unknown>;
+            return record.type === type && record.toolCallId === "round-1";
+          }),
+      );
+
+    const compacted = await stream.prepareStep({
+      steps: [
+        {
+          toolResults: [],
+          response: { messages: [toolCall, toolResult] },
+        },
+      ],
+      messages: [...initialRaw, toolCall, toolResult],
+    });
+
+    expect(countToolParts(compacted.messages, "tool-call")).toBe(1);
+    expect(countToolParts(compacted.messages, "tool-result")).toBe(1);
+    expect(findToolPartMessageIndex(compacted.messages, "tool-result")).toBe(
+      findToolPartMessageIndex(compacted.messages, "tool-call") + 1,
+    );
+    expect(JSON.stringify(compacted.messages)).toContain("ROUND_1_END");
+    expect(compacted.messages.at(-1)?.role).toBe("user");
+
+    state.lastStepInputTokens = 0;
+    const newerAssistantMessage: ModelMessage = {
+      role: "assistant",
+      content: "Round 1 is complete; continue with Round 2.",
+    };
+    const rebased = await stream.prepareStep({
+      steps: [
+        {
+          toolResults: [],
+          response: { messages: [toolCall, toolResult] },
+        },
+        {
+          toolResults: [],
+          response: { messages: [newerAssistantMessage] },
+        },
+      ],
+      messages: [...initialRaw, toolCall, toolResult, newerAssistantMessage],
+    });
+
+    expect(countToolParts(rebased.messages, "tool-call")).toBe(1);
+    expect(countToolParts(rebased.messages, "tool-result")).toBe(1);
+    expect(rebased.messages).toContainEqual(newerAssistantMessage);
+    expect(JSON.stringify(rebased.messages)).not.toContain(largeOldUserContent);
+    expect(mockCompactModelMessagesInRun).toHaveBeenCalledTimes(1);
+  });
+
   it("stops cleanly when the attempt budget is exhausted with no accepted summary", async () => {
     mockRunSummarizationStep.mockResolvedValue({
       summarizationAttempted: true,

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -1,4 +1,5 @@
 import type { ModelMessage, UIMessage } from "ai";
+import { MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM } from "@/lib/chat/summarization/constants";
 
 const mockStreamText = jest.fn();
 const mockRunSummarizationStep = jest.fn();
@@ -98,6 +99,49 @@ const uiMessage = (id: string, text: string): UIMessage => ({
   parts: [{ type: "text", text }],
 });
 
+const createTestStreamContext = (
+  overrides: Record<string, unknown>,
+): Record<string, unknown> => ({
+  trackedProvider: {
+    languageModel: () => ({ modelId: "test-model" }),
+  },
+  currentSystemPrompt: "system",
+  tools: {},
+  mode: "agent",
+  endpoint: "agent",
+  userId: "user",
+  subscription: "pro",
+  chatId: "chat",
+  temporary: false,
+  fileTokens: {},
+  noteInjectionOpts: {
+    userId: "user",
+    subscription: "pro",
+    shouldIncludeNotes: false,
+    isTemporary: false,
+  },
+  systemPromptTokens: 100,
+  ctxSystemTokens: 100,
+  ctxMaxTokens: 128_000,
+  streamStartTime: Date.now(),
+  contextUsageOn: true,
+  isReasoningModel: false,
+  maxDurationMs: 60_000,
+  writer: { write: jest.fn() },
+  abortController: new AbortController(),
+  budgetMonitor: null,
+  sandboxManager: {
+    getSandboxType: () => undefined,
+    supportsInteractivePty: async () => true,
+  },
+  getTodoManager: () => ({ getAllTodos: () => [] }),
+  ensureSandbox: jest.fn(),
+  chatLogger: undefined,
+  usageRefundTracker: {},
+  getHardTimeoutReason: () => null,
+  ...overrides,
+});
+
 describe("createAgentStream repeated compaction", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -157,47 +201,12 @@ describe("createAgentStream repeated compaction", () => {
     });
     const stream = (await createAgentStream(
       "test-model",
-      {
-        trackedProvider: {
-          languageModel: () => ({ modelId: "test-model" }),
-        },
-        currentSystemPrompt: "system",
-        tools: {},
-        mode: "agent",
-        endpoint: "agent",
-        userId: "user",
-        subscription: "pro",
+      createTestStreamContext({
         chatId: "chat",
-        temporary: false,
-        fileTokens: {},
-        noteInjectionOpts: {
-          userId: "user",
-          subscription: "pro",
-          shouldIncludeNotes: false,
-          isTemporary: false,
-        },
-        systemPromptTokens: 100,
-        ctxSystemTokens: 100,
-        ctxMaxTokens: 128_000,
-        streamStartTime: Date.now(),
-        contextUsageOn: true,
-        isReasoningModel: false,
-        maxDurationMs: 60_000,
         writer,
-        abortController: new AbortController(),
         summarizationTracker: tracker,
         usageTracker,
-        budgetMonitor: null,
-        sandboxManager: {
-          getSandboxType: () => undefined,
-          supportsInteractivePty: async () => true,
-        },
-        getTodoManager: () => ({ getAllTodos: () => [] }),
-        ensureSandbox: jest.fn(),
-        chatLogger: undefined,
-        usageRefundTracker: {},
-        getHardTimeoutReason: () => null,
-      } as any,
+      }) as any,
       state,
     )) as any;
 
@@ -289,7 +298,11 @@ describe("createAgentStream repeated compaction", () => {
       { toolResults: [], response: { messages: [step2] } },
       { toolResults: [], response: { messages: [step3] } },
     ];
-    for (let index = 4; index <= 8; index++) {
+    for (
+      let index = 4;
+      index <= MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM;
+      index++
+    ) {
       const nextStep: ModelMessage = {
         role: "assistant",
         content: `large tool step ${index} `.repeat(1_000),
@@ -305,8 +318,12 @@ describe("createAgentStream repeated compaction", () => {
       });
     }
 
-    expect(tracker.summarizationCount).toBe(7);
-    expect(mockCompactModelMessagesInRun).toHaveBeenCalledTimes(7);
+    expect(tracker.summarizationCount).toBe(
+      MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM - 1,
+    );
+    expect(mockCompactModelMessagesInRun).toHaveBeenCalledTimes(
+      MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM - 1,
+    );
     state.lastStepInputTokens = 300_000;
     expect(stream.stopWhen[1]()).toBe(true);
     expect(state.stoppedDueToTokenExhaustion).toBe(true);
@@ -334,54 +351,23 @@ describe("createAgentStream repeated compaction", () => {
     );
     const stream = (await createAgentStream(
       "test-model",
-      {
-        trackedProvider: {
-          languageModel: () => ({ modelId: "test-model" }),
-        },
-        currentSystemPrompt: "system",
-        tools: {},
-        mode: "agent",
-        endpoint: "agent",
-        userId: "user",
-        subscription: "pro",
+      createTestStreamContext({
         chatId: "chat-failure",
-        temporary: false,
-        fileTokens: {},
-        noteInjectionOpts: {
-          userId: "user",
-          subscription: "pro",
-          shouldIncludeNotes: false,
-          isTemporary: false,
-        },
-        systemPromptTokens: 100,
-        ctxSystemTokens: 100,
         ctxMaxTokens: 200_000,
-        streamStartTime: Date.now(),
-        contextUsageOn: true,
-        isReasoningModel: false,
-        maxDurationMs: 60_000,
-        writer: { write: jest.fn() },
-        abortController: new AbortController(),
         summarizationTracker: tracker,
         usageTracker: {},
-        budgetMonitor: null,
-        sandboxManager: {
-          getSandboxType: () => undefined,
-          supportsInteractivePty: async () => true,
-        },
-        getTodoManager: () => ({ getAllTodos: () => [] }),
-        ensureSandbox: jest.fn(),
-        chatLogger: undefined,
-        usageRefundTracker: {},
-        getHardTimeoutReason: () => null,
-      } as any,
+      }) as any,
       state,
     )) as any;
 
     await stream.prepareStep({ steps: [], messages: initialRaw });
     const rawMessages = [...initialRaw];
     const steps: Array<Record<string, unknown>> = [];
-    for (let index = 1; index <= 8; index++) {
+    for (
+      let index = 1;
+      index <= MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM;
+      index++
+    ) {
       const step: ModelMessage = {
         role: "assistant",
         content: `failed compaction step ${index}`,
@@ -391,7 +377,9 @@ describe("createAgentStream repeated compaction", () => {
       await stream.prepareStep({ steps, messages: rawMessages });
     }
 
-    expect(mockCompactModelMessagesInRun).toHaveBeenCalledTimes(8);
+    expect(mockCompactModelMessagesInRun).toHaveBeenCalledTimes(
+      MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM,
+    );
     expect(tracker.summarizationCount).toBe(0);
     expect(tracker.recordSummarization).not.toHaveBeenCalled();
     state.lastStepInputTokens = 300_000;

--- a/lib/api/__tests__/agent-stream-runner-rolling-context.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-rolling-context.test.ts
@@ -1,0 +1,73 @@
+import type { ModelMessage } from "ai";
+import {
+  buildRollingModelMessages,
+  isRollingCompactionEffective,
+  type RollingModelContextCheckpoint,
+} from "@/lib/api/agent-stream-runner";
+
+jest.mock("@/lib/db/actions", () => ({}));
+
+const user = (content: string): ModelMessage => ({ role: "user", content });
+const assistant = (content: string): ModelMessage => ({
+  role: "assistant",
+  content,
+});
+
+describe("rolling agent model context", () => {
+  it("keeps the first compacted base and appends only newer SDK messages", () => {
+    const initial = user("original history");
+    const firstStep = assistant("first tool step");
+    const secondStep = assistant("second tool step");
+    const summary = user("summary 1");
+    const continuation = user("continue");
+    const rawMessages = [initial, firstStep, secondStep];
+    const checkpoint: RollingModelContextCheckpoint = {
+      baseMessages: [summary, continuation],
+      rawMessageCursor: 2,
+    };
+
+    expect(buildRollingModelMessages(rawMessages, checkpoint)).toEqual([
+      summary,
+      continuation,
+      secondStep,
+    ]);
+  });
+
+  it("supports two compactions without restoring the original history", () => {
+    const original = user("original history");
+    const step1 = assistant("step 1");
+    const step2 = assistant("step 2");
+    const step3 = assistant("step 3");
+    const summary1 = user("summary 1");
+    const summary2 = user("summary 2");
+
+    const rawAfterStep2 = [original, step1, step2];
+    const firstCheckpoint: RollingModelContextCheckpoint = {
+      baseMessages: [summary1],
+      rawMessageCursor: 2,
+    };
+    expect(buildRollingModelMessages(rawAfterStep2, firstCheckpoint)).toEqual([
+      summary1,
+      step2,
+    ]);
+
+    const secondCheckpoint: RollingModelContextCheckpoint = {
+      baseMessages: [summary2],
+      rawMessageCursor: rawAfterStep2.length,
+    };
+    expect(
+      buildRollingModelMessages([...rawAfterStep2, step3], secondCheckpoint),
+    ).toEqual([summary2, step3]);
+  });
+
+  it("rejects compactions that do not reduce serialized context by 10 percent", () => {
+    const previous = [user("x".repeat(1_000))];
+
+    expect(isRollingCompactionEffective(previous, [user("summary")])).toBe(
+      true,
+    );
+    expect(
+      isRollingCompactionEffective(previous, [user("y".repeat(950))]),
+    ).toBe(false);
+  });
+});

--- a/lib/api/__tests__/chat-stream-helpers-summarization.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-summarization.test.ts
@@ -1,0 +1,166 @@
+import { SummarizationTracker } from "@/lib/api/chat-stream-helpers";
+
+jest.mock("@/lib/db/actions", () => ({
+  getNotes: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
+const makeUsageTracker = () => ({
+  inputTokens: 0,
+  outputTokens: 0,
+  summarizationOutputTokens: 0,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+  providerCost: 0,
+});
+
+describe("SummarizationTracker", () => {
+  it("tracks and bills every summarization round", () => {
+    const tracker = new SummarizationTracker();
+    const usageTracker = makeUsageTracker();
+
+    tracker.recordSummarization(
+      1,
+      {
+        inputTokens: 100,
+        outputTokens: 10,
+        cacheReadTokens: 7,
+        cacheWriteTokens: 3,
+        cost: 0.001,
+      },
+      usageTracker as any,
+    );
+    tracker.recordSummarization(
+      3,
+      {
+        inputTokens: 200,
+        outputTokens: 20,
+        cacheReadTokens: 9,
+        cacheWriteTokens: 4,
+        cost: 0.002,
+      },
+      usageTracker as any,
+    );
+
+    expect(tracker.hasSummarized).toBe(true);
+    expect(tracker.summarizationCount).toBe(2);
+    expect(usageTracker).toEqual({
+      inputTokens: 300,
+      outputTokens: 30,
+      summarizationOutputTokens: 30,
+      cacheReadTokens: 16,
+      cacheWriteTokens: 7,
+      providerCost: 0.003,
+    });
+  });
+
+  it("accounts for rejected summary usage without recording a compaction", () => {
+    const tracker = new SummarizationTracker();
+    const usageTracker = makeUsageTracker();
+
+    tracker.recordSummarizationUsage(
+      { inputTokens: 50, outputTokens: 5, cost: 0.001 },
+      usageTracker as any,
+    );
+
+    expect(tracker.hasSummarized).toBe(false);
+    expect(tracker.summarizationCount).toBe(0);
+    expect(usageTracker.inputTokens).toBe(50);
+    expect(usageTracker.outputTokens).toBe(5);
+    expect(usageTracker.summarizationOutputTokens).toBe(5);
+    expect(usageTracker.providerCost).toBe(0.001);
+  });
+
+  it("inserts each completed badge at its own step boundary", () => {
+    const tracker = new SummarizationTracker();
+    const usageTracker = makeUsageTracker();
+
+    tracker.recordSummarization(1, undefined, usageTracker as any);
+    tracker.recordSummarization(3, undefined, usageTracker as any);
+
+    const message = {
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        { type: "text", text: "step 0" },
+        { type: "step-start" },
+        { type: "text", text: "step 1" },
+        { type: "step-start" },
+        { type: "text", text: "step 2" },
+        { type: "step-start" },
+        { type: "text", text: "step 3" },
+      ],
+    };
+
+    const processed = tracker.processMessageForSave(message);
+
+    expect(processed.parts.map((part) => part.type)).toEqual([
+      "step-start",
+      "text",
+      "data-summarization",
+      "step-start",
+      "text",
+      "step-start",
+      "text",
+      "data-summarization",
+      "step-start",
+      "text",
+    ]);
+    expect(
+      processed.parts
+        .filter((part) => part.type === "data-summarization")
+        .map((part) => part.id),
+    ).toEqual(["summarization-status-1", "summarization-status-2"]);
+    expect(
+      processed.parts
+        .filter((part) => part.type === "data-summarization")
+        .map((part) => part.data),
+    ).toEqual([
+      {
+        status: "completed",
+        message: "Context automatically compacted",
+      },
+      {
+        status: "completed",
+        message: "Context automatically compacted",
+      },
+    ]);
+  });
+
+  it("preserves record order for multiple summaries at one step", () => {
+    const tracker = new SummarizationTracker();
+    const usageTracker = makeUsageTracker();
+
+    tracker.recordSummarization(1, undefined, usageTracker as any);
+    tracker.recordSummarization(1, undefined, usageTracker as any);
+
+    const processed = tracker.processMessageForSave({
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        { type: "text", text: "step 0" },
+        { type: "step-start" },
+      ],
+    });
+
+    expect(
+      processed.parts
+        .filter((part) => part.type === "data-summarization")
+        .map((part) => part.id),
+    ).toEqual(["summarization-status-1", "summarization-status-2"]);
+  });
+
+  it("leaves non-assistant messages unchanged", () => {
+    const tracker = new SummarizationTracker();
+    tracker.recordSummarization(1, undefined, makeUsageTracker() as any);
+    const message = {
+      role: "user",
+      parts: [{ type: "text", text: "hello" }],
+    };
+
+    expect(tracker.processMessageForSave(message)).toBe(message);
+  });
+});

--- a/lib/api/__tests__/chat-stream-helpers-summarization.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-summarization.test.ts
@@ -10,10 +10,14 @@ jest.mock("@/lib/logger", () => ({
 
 const makeUsageTracker = () => ({
   inputTokens: 0,
+  summarizationInputTokens: 0,
   outputTokens: 0,
+  totalTokens: 0,
   summarizationOutputTokens: 0,
   cacheReadTokens: 0,
+  summarizationCacheReadTokens: 0,
   cacheWriteTokens: 0,
+  summarizationCacheWriteTokens: 0,
   providerCost: 0,
 });
 
@@ -49,10 +53,14 @@ describe("SummarizationTracker", () => {
     expect(tracker.summarizationCount).toBe(2);
     expect(usageTracker).toEqual({
       inputTokens: 300,
+      summarizationInputTokens: 300,
       outputTokens: 30,
+      totalTokens: 330,
       summarizationOutputTokens: 30,
       cacheReadTokens: 16,
+      summarizationCacheReadTokens: 16,
       cacheWriteTokens: 7,
+      summarizationCacheWriteTokens: 7,
       providerCost: 0.003,
     });
   });
@@ -69,7 +77,9 @@ describe("SummarizationTracker", () => {
     expect(tracker.hasSummarized).toBe(false);
     expect(tracker.summarizationCount).toBe(0);
     expect(usageTracker.inputTokens).toBe(50);
+    expect(usageTracker.summarizationInputTokens).toBe(50);
     expect(usageTracker.outputTokens).toBe(5);
+    expect(usageTracker.totalTokens).toBe(55);
     expect(usageTracker.summarizationOutputTokens).toBe(5);
     expect(usageTracker.providerCost).toBe(0.001);
   });

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -71,6 +71,7 @@ import { getMaxTokensForSubscription } from "@/lib/token-utils";
 import {
   getSummarizationThresholdTokens,
   MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM,
+  ROLLING_COMPACTION_MAX_SIZE_RATIO,
 } from "@/lib/chat/summarization/constants";
 import { compactModelMessagesInRun } from "@/lib/chat/summarization";
 import { getProviderPromptPressure } from "@/lib/chat/summarization/provider-pressure";
@@ -135,7 +136,7 @@ export const isRollingCompactionEffective = (
   const previousBytes = getSerializedBytes(previousMessages);
   const compactedBytes = getSerializedBytes(compactedMessages);
   if (previousBytes === undefined || compactedBytes === undefined) return true;
-  return compactedBytes < previousBytes * 0.9;
+  return compactedBytes < previousBytes * ROLLING_COMPACTION_MAX_SIZE_RATIO;
 };
 
 // ---------------------------------------------------------------------------

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -74,6 +74,7 @@ import {
   ROLLING_COMPACTION_MAX_SIZE_RATIO,
 } from "@/lib/chat/summarization/constants";
 import { compactModelMessagesInRun } from "@/lib/chat/summarization";
+import { getLatestCompletedToolTransaction } from "@/lib/chat/summarization/helpers";
 import { getProviderPromptPressure } from "@/lib/chat/summarization/provider-pressure";
 import { getMaxStepsForUser } from "@/lib/chat/chat-processor";
 import {
@@ -334,8 +335,7 @@ const buildProviderRequestDiagnostics = (args: {
   }
 
   const lastMessage = args.messages.at(-1) as
-    | Record<string, unknown>
-    | undefined;
+    Record<string, unknown> | undefined;
   const serializedBytes = getSerializedBytes(args.messages);
   const contextUsedPercent =
     args.contextUsage.maxTokens > 0
@@ -883,8 +883,17 @@ export async function createAgentStream(
               const continuationPrompt = loopRecovery.nudge
                 ? `${POST_SUMMARIZATION_CONTINUATION_PROMPT}\n\n${loopRecovery.nudge}`
                 : POST_SUMMARIZATION_CONTINUATION_PROMPT;
+              const lastStepResponseMessages =
+                (
+                  lastStep as
+                    { response?: { messages?: ModelMessage[] } } | undefined
+                )?.response?.messages ?? [];
+              const retainedToolTransaction = getLatestCompletedToolTransaction(
+                lastStepResponseMessages,
+              );
               const nextBaseMessages: ModelMessage[] = [
                 ...compactedModelMessages,
+                ...retainedToolTransaction,
                 { role: "user", content: continuationPrompt },
               ];
               const effectiveCompaction = isRollingCompactionEffective(
@@ -939,6 +948,7 @@ export async function createAgentStream(
                       ctx.summarizationTracker.summarizationCount,
                     persistence: "run_scoped",
                     raw_message_count: rawModelMessages.length,
+                    retained_tool_message_count: retainedToolTransaction.length,
                   }),
                 );
                 rollingContextCheckpoint = {

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -772,6 +772,11 @@ export async function createAgentStream(
               providerPromptPressure,
             });
 
+            if (result.summarizationAttempted) {
+              compactionAttemptCount++;
+              lastCompactionRawMessageCount = rawModelMessages.length;
+            }
+
             if (result.needsSummarization && result.summarizedMessages) {
               ctx.summarizationTracker.recordSummarization(
                 steps.length,
@@ -807,8 +812,6 @@ export async function createAgentStream(
                 baseMessages: summarizedModelMessages,
                 rawMessageCursor: rawModelMessages.length,
               };
-              compactionAttemptCount++;
-              lastCompactionRawMessageCount = rawModelMessages.length;
               const preparedMessages = prepareProviderMessages(
                 summarizedModelMessages,
                 effectiveModelInfo.modelName,

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -68,7 +68,11 @@ import {
 } from "@/lib/rate-limit/free-config";
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { getMaxTokensForSubscription } from "@/lib/token-utils";
-import { getSummarizationThresholdTokens } from "@/lib/chat/summarization/constants";
+import {
+  getSummarizationThresholdTokens,
+  MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM,
+} from "@/lib/chat/summarization/constants";
+import { compactModelMessagesInRun } from "@/lib/chat/summarization";
 import { getProviderPromptPressure } from "@/lib/chat/summarization/provider-pressure";
 import { getMaxStepsForUser } from "@/lib/chat/chat-processor";
 import {
@@ -76,6 +80,10 @@ import {
   POST_SUMMARIZATION_CONTINUATION_PROMPT,
 } from "@/lib/chat/post-summarization-continuation";
 import { createPromptSerializationTools } from "@/lib/ai/tools/prompt-serialization";
+import {
+  writeSummarizationCleared,
+  writeSummarizationCompleted,
+} from "@/lib/utils/stream-writer-utils";
 import {
   extractOpenRouterMetadata,
   mergeOpenRouterMetadata,
@@ -99,6 +107,36 @@ import type { ProviderRequestDiagnostics } from "@/lib/logger";
 import type { ChatMode, SubscriptionTier } from "@/types";
 
 const GLM_AGENT_VISION_MODEL = "model-kimi-k2.7-code";
+
+export type RollingModelContextCheckpoint = {
+  /** Latest compacted provider context, excluding later raw SDK responses. */
+  baseMessages: ModelMessage[];
+  /** Number of raw SDK messages covered by baseMessages. */
+  rawMessageCursor: number;
+};
+
+/**
+ * AI SDK prepareStep overrides apply to one request only. Rebase its cumulative
+ * raw history onto our latest compacted checkpoint for every later request.
+ */
+export const buildRollingModelMessages = (
+  rawMessages: ModelMessage[],
+  checkpoint?: RollingModelContextCheckpoint,
+): ModelMessage[] => {
+  if (!checkpoint) return rawMessages;
+  const cursor = Math.min(checkpoint.rawMessageCursor, rawMessages.length);
+  return [...checkpoint.baseMessages, ...rawMessages.slice(cursor)];
+};
+
+export const isRollingCompactionEffective = (
+  previousMessages: ModelMessage[],
+  compactedMessages: ModelMessage[],
+): boolean => {
+  const previousBytes = getSerializedBytes(previousMessages);
+  const compactedBytes = getSerializedBytes(compactedMessages);
+  if (previousBytes === undefined || compactedBytes === undefined) return true;
+  return compactedBytes < previousBytes * 0.9;
+};
 
 // ---------------------------------------------------------------------------
 // Mutable state — the runner updates these in place; callers read them back.
@@ -295,7 +333,8 @@ const buildProviderRequestDiagnostics = (args: {
   }
 
   const lastMessage = args.messages.at(-1) as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
   const serializedBytes = getSerializedBytes(args.messages);
   const contextUsedPercent =
     args.contextUsage.maxTokens > 0
@@ -452,6 +491,15 @@ export async function createAgentStream(
     ctx.abortController.signal,
     assistantContentLoopAbortController.signal,
   ]);
+  const summarizationThreshold = getSummarizationThresholdTokens(
+    getMaxTokensForSubscription(ctx.subscription, { mode: ctx.mode }),
+  );
+  let rollingContextCheckpoint: RollingModelContextCheckpoint | undefined;
+  let compactionAttemptCount = 0;
+  let lastCompactionRawMessageCount = -1;
+  const canSummarizeAgain = () =>
+    !ctx.temporary &&
+    compactionAttemptCount < MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM;
   type AbortStepLike = {
     usage?: unknown;
     response?: Parameters<typeof extractOpenRouterMetadata>[0]["response"] & {
@@ -661,6 +709,11 @@ export async function createAgentStream(
     providerOptions: initialProviderOptions,
 
     prepareStep: async ({ steps, messages }) => {
+      const rawModelMessages = messages as ModelMessage[];
+      let rollingModelMessages = buildRollingModelMessages(
+        rawModelMessages,
+        rollingContextCheckpoint,
+      );
       try {
         const pruneResult = pruneToolOutputs(state.finalMessages);
         if (pruneResult.prunedCount > 0) {
@@ -678,87 +731,253 @@ export async function createAgentStream(
         const effectiveModelInfo = getEffectiveModelInfo();
 
         const loopRecovery = getDoomLoopRecovery(steps, steps.length);
+        const providerPromptPressure =
+          getProviderPromptPressure(rollingModelMessages);
+        const shouldCheckDurableSummary =
+          ctx.summarizationTracker.summarizationCount === 0 &&
+          steps.length === 0;
+        const shouldCompactInRun =
+          !shouldCheckDurableSummary &&
+          (providerPromptPressure !== null ||
+            state.lastStepInputTokens > summarizationThreshold);
 
-        if (!ctx.temporary && !ctx.summarizationTracker.hasSummarized) {
-          const providerPromptPressure = getProviderPromptPressure(messages);
-          const result = await runSummarizationStep({
-            messages: state.finalMessages,
-            modelMessages: messages,
-            subscription: ctx.subscription,
-            languageModel: effectiveModelInfo.languageModel,
-            mode: ctx.mode,
-            writer: ctx.writer,
-            chatId: ctx.chatId,
-            fileTokens: ctx.fileTokens,
-            todos: ctx.getTodoManager().getAllTodos(),
-            abortSignal: ctx.abortController.signal,
-            ensureSandbox: ctx.ensureSandbox,
-            systemPromptTokens: ctx.systemPromptTokens,
-            ctxSystemTokens: ctx.ctxSystemTokens,
-            ctxMaxTokens: ctx.ctxMaxTokens,
-            providerInputTokens: state.lastStepInputTokens,
-            chatSystemPrompt: ctx.currentSystemPrompt,
-            tools: ctx.tools,
-            providerOptions: getStepProviderOptions(
-              effectiveModelInfo.modelName,
-            ),
-            transcriptMessages: state.transcriptSourceMessages,
-            providerPromptPressure,
-          });
-
-          if (result.needsSummarization && result.summarizedMessages) {
-            ctx.summarizationTracker.recordSummarization(
-              steps.length,
-              result.summarizationUsage,
-              ctx.usageTracker,
-            );
-            if (result.contextUsage) {
-              state.ctxUsage = result.contextUsage;
-            }
-            state.transcriptSourceMessages = undefined;
-            const activeTools = await getActiveToolsForRecovery(loopRecovery);
-            const providerOptions = getStepProviderOptions(
-              effectiveModelInfo.modelName,
-            );
-            let summarizedModelMessages = await convertToModelMessages(
-              result.summarizedMessages,
-              {
-                tools: createPromptSerializationTools(ctx.tools),
-              },
-            );
-            state.postSummarizationContinuationActive = true;
-            state.postSummarizationToolCallCount = 0;
-            state.postSummarizationText = "";
-            const continuationPrompt = loopRecovery.nudge
-              ? `${POST_SUMMARIZATION_CONTINUATION_PROMPT}\n\n${loopRecovery.nudge}`
-              : POST_SUMMARIZATION_CONTINUATION_PROMPT;
-            summarizedModelMessages = [
-              ...summarizedModelMessages,
-              { role: "user", content: continuationPrompt },
-            ];
-            const preparedMessages = prepareProviderMessages(
-              summarizedModelMessages,
-              effectiveModelInfo.modelName,
-            );
-            recordProviderRequestDiagnostics({
-              modelName: effectiveModelInfo.modelName,
-              requestedSlug: effectiveModelInfo.requestedSlug,
-              stepIndex: steps.length + 1,
-              source: "summarized_prepare_step",
-              messages: preparedMessages,
-              providerOptions,
-              activeTools,
+        if (
+          canSummarizeAgain() &&
+          (shouldCheckDurableSummary || shouldCompactInRun)
+        ) {
+          if (shouldCheckDurableSummary) {
+            const result = await runSummarizationStep({
+              messages: state.finalMessages,
+              modelMessages: rawModelMessages,
+              subscription: ctx.subscription,
+              languageModel: effectiveModelInfo.languageModel,
+              mode: ctx.mode,
+              writer: ctx.writer,
+              chatId: ctx.chatId,
+              fileTokens: ctx.fileTokens,
+              todos: ctx.getTodoManager().getAllTodos(),
+              abortSignal: ctx.abortController.signal,
+              ensureSandbox: ctx.ensureSandbox,
+              systemPromptTokens: ctx.systemPromptTokens,
+              ctxSystemTokens: ctx.ctxSystemTokens,
+              ctxMaxTokens: ctx.ctxMaxTokens,
+              providerInputTokens: state.lastStepInputTokens,
+              chatSystemPrompt: ctx.currentSystemPrompt,
+              tools: ctx.tools,
+              providerOptions: getStepProviderOptions(
+                effectiveModelInfo.modelName,
+              ),
+              transcriptMessages: state.transcriptSourceMessages,
+              providerPromptPressure,
             });
-            return {
-              model: effectiveModelInfo.languageModel,
-              activeTools,
-              providerOptions,
-              messages: preparedMessages,
-            };
+
+            if (result.needsSummarization && result.summarizedMessages) {
+              ctx.summarizationTracker.recordSummarization(
+                steps.length,
+                result.summarizationUsage,
+                ctx.usageTracker,
+              );
+              if (result.contextUsage) {
+                state.ctxUsage = result.contextUsage;
+              }
+              state.finalMessages = result.summarizedMessages;
+              state.transcriptSourceMessages = undefined;
+              const activeTools = await getActiveToolsForRecovery(loopRecovery);
+              const providerOptions = getStepProviderOptions(
+                effectiveModelInfo.modelName,
+              );
+              let summarizedModelMessages = await convertToModelMessages(
+                result.summarizedMessages,
+                {
+                  tools: createPromptSerializationTools(ctx.tools),
+                },
+              );
+              state.postSummarizationContinuationActive = true;
+              state.postSummarizationToolCallCount = 0;
+              state.postSummarizationText = "";
+              const continuationPrompt = loopRecovery.nudge
+                ? `${POST_SUMMARIZATION_CONTINUATION_PROMPT}\n\n${loopRecovery.nudge}`
+                : POST_SUMMARIZATION_CONTINUATION_PROMPT;
+              summarizedModelMessages = [
+                ...summarizedModelMessages,
+                { role: "user", content: continuationPrompt },
+              ];
+              rollingContextCheckpoint = {
+                baseMessages: summarizedModelMessages,
+                rawMessageCursor: rawModelMessages.length,
+              };
+              compactionAttemptCount++;
+              lastCompactionRawMessageCount = rawModelMessages.length;
+              const preparedMessages = prepareProviderMessages(
+                summarizedModelMessages,
+                effectiveModelInfo.modelName,
+              );
+              recordProviderRequestDiagnostics({
+                modelName: effectiveModelInfo.modelName,
+                requestedSlug: effectiveModelInfo.requestedSlug,
+                stepIndex: steps.length + 1,
+                source: "summarized_prepare_step",
+                messages: preparedMessages,
+                providerOptions,
+                activeTools,
+              });
+              return {
+                model: effectiveModelInfo.languageModel,
+                activeTools,
+                providerOptions,
+                messages: preparedMessages,
+              };
+            }
+          } else if (
+            rawModelMessages.length === lastCompactionRawMessageCount
+          ) {
+            // Never repeatedly summarize the same raw source cursor. A later
+            // provider step advances the cursor and can become eligible again.
+          } else {
+            compactionAttemptCount++;
+            lastCompactionRawMessageCount = rawModelMessages.length;
+            const inRunResult = await compactModelMessagesInRun({
+              modelMessages: rollingModelMessages,
+              transcriptModelMessages: rawModelMessages,
+              subscription: ctx.subscription,
+              languageModel: effectiveModelInfo.languageModel,
+              mode: ctx.mode,
+              writer: ctx.writer,
+              chatId: ctx.chatId,
+              todos: ctx.getTodoManager().getAllTodos(),
+              abortSignal: ctx.abortController.signal,
+              ensureSandbox: ctx.ensureSandbox,
+              systemPromptTokens: ctx.systemPromptTokens,
+              providerInputTokens: state.lastStepInputTokens,
+              chatSystemPrompt: ctx.currentSystemPrompt,
+              tools: ctx.tools,
+              providerOptions: getStepProviderOptions(
+                effectiveModelInfo.modelName,
+              ),
+              maxTokens: ctx.ctxMaxTokens,
+              providerPromptPressure,
+              compactionIndex: ctx.summarizationTracker.summarizationCount + 1,
+              hasExistingSummary:
+                ctx.summarizationTracker.hasSummarized ||
+                state.finalMessages.some((message) =>
+                  message.parts.some(
+                    (part) =>
+                      part.type === "text" &&
+                      part.text.includes("<context_summary>"),
+                  ),
+                ),
+            });
+
+            if (!inRunResult) {
+              // The helper clears its transient UI state. A later raw cursor
+              // may retry while the bounded attempt budget remains.
+            } else {
+              const compactedModelMessages = await convertToModelMessages(
+                [inRunResult.summaryMessage],
+                { tools: createPromptSerializationTools(ctx.tools) },
+              );
+              const continuationPrompt = loopRecovery.nudge
+                ? `${POST_SUMMARIZATION_CONTINUATION_PROMPT}\n\n${loopRecovery.nudge}`
+                : POST_SUMMARIZATION_CONTINUATION_PROMPT;
+              const nextBaseMessages: ModelMessage[] = [
+                ...compactedModelMessages,
+                { role: "user", content: continuationPrompt },
+              ];
+              const effectiveCompaction = isRollingCompactionEffective(
+                rollingModelMessages,
+                nextBaseMessages,
+              );
+
+              if (!effectiveCompaction) {
+                ctx.summarizationTracker.recordSummarizationUsage(
+                  inRunResult.summarizationUsage,
+                  ctx.usageTracker,
+                );
+                writeSummarizationCleared(
+                  ctx.writer,
+                  ctx.summarizationTracker.summarizationCount + 1,
+                );
+                console.warn(
+                  JSON.stringify({
+                    level: "warn",
+                    event: "agent_in_run_context_compaction_ineffective",
+                    service: "chat-handler",
+                    timestamp: new Date().toISOString(),
+                    chat_id: ctx.chatId ?? undefined,
+                    mode: ctx.mode,
+                    compaction_attempt: compactionAttemptCount,
+                    summarization_count:
+                      ctx.summarizationTracker.summarizationCount,
+                    raw_message_count: rawModelMessages.length,
+                  }),
+                );
+              } else {
+                ctx.summarizationTracker.recordSummarization(
+                  steps.length,
+                  inRunResult.summarizationUsage,
+                  ctx.usageTracker,
+                );
+                writeSummarizationCompleted(
+                  ctx.writer,
+                  ctx.summarizationTracker.summarizationCount,
+                );
+                console.info(
+                  JSON.stringify({
+                    level: "info",
+                    event: "agent_in_run_context_compaction_completed",
+                    service: "chat-handler",
+                    timestamp: new Date().toISOString(),
+                    chat_id: ctx.chatId ?? undefined,
+                    mode: ctx.mode,
+                    subscription: ctx.subscription,
+                    compaction_attempt: compactionAttemptCount,
+                    summarization_count:
+                      ctx.summarizationTracker.summarizationCount,
+                    persistence: "run_scoped",
+                    raw_message_count: rawModelMessages.length,
+                  }),
+                );
+                rollingContextCheckpoint = {
+                  baseMessages: nextBaseMessages,
+                  rawMessageCursor: rawModelMessages.length,
+                };
+                rollingModelMessages = nextBaseMessages;
+                state.postSummarizationContinuationActive = true;
+                state.postSummarizationToolCallCount = 0;
+                state.postSummarizationText = "";
+
+                const activeTools =
+                  await getActiveToolsForRecovery(loopRecovery);
+                const providerOptions = getStepProviderOptions(
+                  effectiveModelInfo.modelName,
+                );
+                const preparedMessages = prepareProviderMessages(
+                  nextBaseMessages,
+                  effectiveModelInfo.modelName,
+                );
+                recordProviderRequestDiagnostics({
+                  modelName: effectiveModelInfo.modelName,
+                  requestedSlug: effectiveModelInfo.requestedSlug,
+                  stepIndex: steps.length + 1,
+                  source: "summarized_prepare_step",
+                  messages: preparedMessages,
+                  providerOptions,
+                  activeTools,
+                });
+                return {
+                  model: effectiveModelInfo.languageModel,
+                  activeTools,
+                  providerOptions,
+                  messages: preparedMessages,
+                };
+              }
+            }
           }
         }
 
-        let currentMessages = messages as Array<Record<string, unknown>>;
+        let currentMessages = rollingModelMessages as Array<
+          Record<string, unknown>
+        >;
         const modelPrune = pruneModelMessages(currentMessages);
         if (modelPrune.prunedCount > 0) {
           currentMessages = modelPrune.messages;
@@ -808,23 +1027,28 @@ export async function createAgentStream(
         } else {
           console.error("[agent-stream] prepareStep error:", error);
         }
-        return ctx.currentSystemPrompt
-          ? {
-              providerOptions: getStepProviderOptions(),
-              system: ctx.currentSystemPrompt,
-            }
-          : {};
+        const providerOptions = getStepProviderOptions();
+        const fallbackMessages = prepareProviderMessages(
+          rollingModelMessages,
+        ) as typeof messages;
+        return {
+          providerOptions,
+          messages: fallbackMessages,
+          ...(ctx.currentSystemPrompt
+            ? { system: ctx.currentSystemPrompt }
+            : undefined),
+        };
       }
     },
 
     stopWhen: [
       stepCountIs(getMaxStepsForUser(ctx.mode, ctx.subscription)),
       tokenExhaustedAfterSummarization({
-        threshold: getSummarizationThresholdTokens(
-          getMaxTokensForSubscription(ctx.subscription, { mode: ctx.mode }),
-        ),
+        threshold: summarizationThreshold,
         getLastStepInputTokens: () => state.lastStepInputTokens,
-        getHasSummarized: () => ctx.summarizationTracker.hasSummarized,
+        getHasSummarized: () =>
+          ctx.summarizationTracker.hasSummarized || compactionAttemptCount > 0,
+        getCanSummarizeAgain: canSummarizeAgain,
         onFired: () => {
           state.stoppedDueToTokenExhaustion = true;
         },
@@ -894,6 +1118,12 @@ export async function createAgentStream(
           usage as Parameters<typeof ctx.usageTracker.accumulateStep>[0],
         );
         state.lastStepInputTokens = usage.inputTokens || 0;
+        if (usage.inputTokens) {
+          state.ctxUsage = {
+            ...state.ctxUsage,
+            usedTokens: usage.inputTokens,
+          };
+        }
       }
       stepUsageCostIndexes.push(stepUsageCostIndex);
 

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -10,6 +10,7 @@ import { getResumeSection } from "@/lib/system-prompt/resume";
 import {
   AGENT_MAX_STREAM_DURATION_MS,
   BUDGET_EXHAUSTION_FINISH_REASON,
+  getAgentAutoContinueStopSource,
 } from "@/lib/chat/stop-conditions";
 import { createTools } from "@/lib/ai/tools";
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
@@ -2025,15 +2026,31 @@ export const createChatHandler = () => {
                       await phLogger.flush();
                     }
 
+                    const autoContinueStopSource =
+                      getAgentAutoContinueStopSource({
+                        finishReason: state.streamFinishReason,
+                        stoppedDueToTokenExhaustion:
+                          state.stoppedDueToTokenExhaustion,
+                        stoppedDueToElapsedTimeout:
+                          state.stoppedDueToElapsedTimeout,
+                        stoppedDueToPostSummarizationIncomplete:
+                          state.stoppedDueToPostSummarizationIncomplete,
+                      });
                     if (
-                      (state.stoppedDueToTokenExhaustion ||
-                        state.stoppedDueToElapsedTimeout ||
-                        state.stoppedDueToPostSummarizationIncomplete ||
-                        state.streamFinishReason === "tool-calls") &&
+                      autoContinueStopSource &&
                       isAgentMode(mode) &&
                       !temporary
                     ) {
                       writeAutoContinue(writer);
+                      phLogger.info("Agent auto-continue signaled", {
+                        event: "agent_auto_continue_signaled",
+                        chat_id: chatId,
+                        assistant_id: assistantMessageId,
+                        finish_reason: state.streamFinishReason,
+                        stop_source: autoContinueStopSource,
+                        last_step_input_tokens: state.lastStepInputTokens,
+                        had_summarization: summarizationTracker.hasSummarized,
+                      });
                     }
                     shutdownPostHog(posthog);
                   } finally {

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -438,7 +438,7 @@ export class SummarizationTracker {
     this.recordSummarizationUsage(usage, usageTracker);
   }
 
-  /** Account for a generated summary that was rejected as ineffective. */
+  /** Account for generated-summary usage, whether accepted or rejected. */
   recordSummarizationUsage(
     usage: SummarizationUsage | undefined,
     usageTracker: UsageTracker,

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -329,6 +329,7 @@ export function isContextUsageEnabled(
 }
 
 export interface SummarizationStepResult {
+  summarizationAttempted: boolean;
   needsSummarization: boolean;
   summarizedMessages?: UIMessage[];
   contextUsage?: ContextUsageData;
@@ -357,31 +358,35 @@ export async function runSummarizationStep(options: {
   transcriptMessages?: UIMessage[];
   providerPromptPressure?: ProviderPromptPressure | null;
 }): Promise<SummarizationStepResult> {
-  const { needsSummarization, summarizedMessages, summarizationUsage } =
-    await checkAndSummarizeIfNeeded({
-      uiMessages: options.messages,
-      subscription: options.subscription,
-      languageModel: options.languageModel,
-      mode: options.mode,
-      writer: options.writer,
-      chatId: options.chatId,
-      fileTokens: options.fileTokens,
-      todos: options.todos,
-      abortSignal: options.abortSignal,
-      ensureSandbox: options.ensureSandbox,
-      systemPromptTokens: options.systemPromptTokens,
-      providerInputTokens: options.providerInputTokens ?? 0,
-      chatSystemPrompt: options.chatSystemPrompt,
-      tools: options.tools,
-      providerOptions: options.providerOptions,
-      modelMessages: options.modelMessages,
-      transcriptMessages: options.transcriptMessages,
-      maxTokensOverride: options.ctxMaxTokens,
-      providerPromptPressure: options.providerPromptPressure,
-    });
+  const {
+    summarizationAttempted,
+    needsSummarization,
+    summarizedMessages,
+    summarizationUsage,
+  } = await checkAndSummarizeIfNeeded({
+    uiMessages: options.messages,
+    subscription: options.subscription,
+    languageModel: options.languageModel,
+    mode: options.mode,
+    writer: options.writer,
+    chatId: options.chatId,
+    fileTokens: options.fileTokens,
+    todos: options.todos,
+    abortSignal: options.abortSignal,
+    ensureSandbox: options.ensureSandbox,
+    systemPromptTokens: options.systemPromptTokens,
+    providerInputTokens: options.providerInputTokens ?? 0,
+    chatSystemPrompt: options.chatSystemPrompt,
+    tools: options.tools,
+    providerOptions: options.providerOptions,
+    modelMessages: options.modelMessages,
+    transcriptMessages: options.transcriptMessages,
+    maxTokensOverride: options.ctxMaxTokens,
+    providerPromptPressure: options.providerPromptPressure,
+  });
 
   if (!needsSummarization) {
-    return { needsSummarization: false };
+    return { summarizationAttempted, needsSummarization: false };
   }
 
   const contextUsage = isContextUsageEnabled(options.subscription, options.mode)
@@ -394,6 +399,7 @@ export async function runSummarizationStep(options: {
     : undefined;
 
   return {
+    summarizationAttempted,
     needsSummarization: true,
     summarizedMessages,
     contextUsage,
@@ -445,10 +451,16 @@ export class SummarizationTracker {
   ): void {
     if (usage) {
       usageTracker.inputTokens += usage.inputTokens;
+      usageTracker.summarizationInputTokens += usage.inputTokens;
       usageTracker.outputTokens += usage.outputTokens;
       usageTracker.summarizationOutputTokens += usage.outputTokens;
-      usageTracker.cacheReadTokens += usage.cacheReadTokens || 0;
-      usageTracker.cacheWriteTokens += usage.cacheWriteTokens || 0;
+      usageTracker.totalTokens += usage.inputTokens + usage.outputTokens;
+      const cacheReadTokens = usage.cacheReadTokens || 0;
+      const cacheWriteTokens = usage.cacheWriteTokens || 0;
+      usageTracker.cacheReadTokens += cacheReadTokens;
+      usageTracker.summarizationCacheReadTokens += cacheReadTokens;
+      usageTracker.cacheWriteTokens += cacheWriteTokens;
+      usageTracker.summarizationCacheWriteTokens += cacheWriteTokens;
       if (usage.cost) {
         usageTracker.providerCost += usage.cost;
       }

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -407,8 +407,14 @@ export async function runSummarizationStep(options: {
  */
 export class SummarizationTracker {
   hasSummarized = false;
-  private parts: UIMessagePart<any, any>[] = [];
-  private atStep: number | undefined;
+  private records: Array<{
+    part: UIMessagePart<any, any>;
+    atStep: number;
+  }> = [];
+
+  get summarizationCount(): number {
+    return this.records.length;
+  }
 
   /**
    * Record that summarization completed at the given step and accumulate
@@ -420,9 +426,23 @@ export class SummarizationTracker {
     usageTracker: UsageTracker,
   ): void {
     this.hasSummarized = true;
-    this.atStep = stepNumber;
-    this.parts.push(createSummarizationCompletedPart());
+    const part = createSummarizationCompletedPart();
+    this.records.push({
+      part: {
+        ...part,
+        id: `summarization-status-${this.records.length + 1}`,
+      } as UIMessagePart<any, any>,
+      atStep: stepNumber,
+    });
 
+    this.recordSummarizationUsage(usage, usageTracker);
+  }
+
+  /** Account for a generated summary that was rejected as ineffective. */
+  recordSummarizationUsage(
+    usage: SummarizationUsage | undefined,
+    usageTracker: UsageTracker,
+  ): void {
     if (usage) {
       usageTracker.inputTokens += usage.inputTokens;
       usageTracker.outputTokens += usage.outputTokens;
@@ -443,12 +463,27 @@ export class SummarizationTracker {
   processMessageForSave<T extends { role: string; parts: any[] }>(
     message: T,
   ): T {
-    if (message.role !== "assistant" || this.parts.length === 0) {
+    if (message.role !== "assistant" || this.records.length === 0) {
       return message;
     }
     const parts = [...message.parts];
-    const idx = findSummarizationInsertIndex(parts, this.atStep ?? 0);
-    parts.splice(idx, 0, ...this.parts);
+    const insertions = this.records
+      .map((record, recordIndex) => ({
+        ...record,
+        recordIndex,
+        insertionIndex: findSummarizationInsertIndex(
+          message.parts,
+          record.atStep,
+        ),
+      }))
+      .sort(
+        (a, b) =>
+          b.insertionIndex - a.insertionIndex || b.recordIndex - a.recordIndex,
+      );
+
+    for (const insertion of insertions) {
+      parts.splice(insertion.insertionIndex, 0, insertion.part);
+    }
     return { ...message, parts };
   }
 }

--- a/lib/chat/__tests__/stop-conditions.test.ts
+++ b/lib/chat/__tests__/stop-conditions.test.ts
@@ -16,6 +16,7 @@ function makeState(overrides: {
   threshold: number;
   lastStepInputTokens: number;
   hasSummarized: boolean;
+  canSummarizeAgain?: boolean;
 }) {
   const onFired = jest.fn();
   return {
@@ -23,6 +24,9 @@ function makeState(overrides: {
       threshold: overrides.threshold,
       getLastStepInputTokens: () => overrides.lastStepInputTokens,
       getHasSummarized: () => overrides.hasSummarized,
+      ...(overrides.canSummarizeAgain !== undefined
+        ? { getCanSummarizeAgain: () => overrides.canSummarizeAgain! }
+        : {}),
       onFired,
     },
     onFired,
@@ -107,6 +111,51 @@ describe("tokenExhaustedAfterSummarization", () => {
       expect(condition()).toBe(true);
       expect(onFired).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("returns false when another in-run compaction is available", () => {
+    const { state, onFired } = makeState({
+      threshold: 14400,
+      lastStepInputTokens: 20000,
+      hasSummarized: true,
+      canSummarizeAgain: true,
+    });
+
+    const condition = tokenExhaustedAfterSummarization(state);
+
+    expect(condition()).toBe(false);
+    expect(onFired).not.toHaveBeenCalled();
+  });
+
+  it("returns true when the repeated-compaction budget is exhausted", () => {
+    const { state, onFired } = makeState({
+      threshold: 14400,
+      lastStepInputTokens: 20000,
+      hasSummarized: true,
+      canSummarizeAgain: false,
+    });
+
+    const condition = tokenExhaustedAfterSummarization(state);
+
+    expect(condition()).toBe(true);
+    expect(onFired).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-evaluates repeated-compaction availability on every invocation", () => {
+    let canSummarizeAgain = true;
+    const onFired = jest.fn();
+    const condition = tokenExhaustedAfterSummarization({
+      threshold: 14400,
+      getLastStepInputTokens: () => 20000,
+      getHasSummarized: () => true,
+      getCanSummarizeAgain: () => canSummarizeAgain,
+      onFired,
+    });
+
+    expect(condition()).toBe(false);
+    canSummarizeAgain = false;
+    expect(condition()).toBe(true);
+    expect(onFired).toHaveBeenCalledTimes(1);
   });
 
   it("does not call onFired on repeated invocations that return false", () => {

--- a/lib/chat/__tests__/stop-conditions.test.ts
+++ b/lib/chat/__tests__/stop-conditions.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   tokenExhaustedAfterSummarization,
   elapsedTimeExceeds,
+  getAgentAutoContinueStopSource,
 } from "../stop-conditions";
 
 function makeState(overrides: {
@@ -131,6 +132,51 @@ describe("tokenExhaustedAfterSummarization", () => {
     condition();
     condition();
     expect(onFired).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("getAgentAutoContinueStopSource", () => {
+  const baseState = {
+    finishReason: "stop",
+    stoppedDueToTokenExhaustion: false,
+    stoppedDueToElapsedTimeout: false,
+    stoppedDueToPostSummarizationIncomplete: false,
+  };
+
+  it.each([
+    {
+      scenario: "post-summarization token exhaustion",
+      overrides: { stoppedDueToTokenExhaustion: true },
+      expected: "post_summarization_token_exhaustion",
+    },
+    {
+      scenario: "elapsed timeout when enabled by the caller",
+      overrides: { stoppedDueToElapsedTimeout: true },
+      expected: "elapsed_timeout",
+    },
+    {
+      scenario: "incomplete post-summarization continuation",
+      overrides: { stoppedDueToPostSummarizationIncomplete: true },
+      expected: "post_summarization_incomplete",
+    },
+    {
+      scenario: "provider-direct context-limit finish reason",
+      overrides: { finishReason: "context-limit" },
+      expected: "context_limit_finish_reason",
+    },
+    {
+      scenario: "tool-call step limit",
+      overrides: { finishReason: "tool-calls" },
+      expected: "tool_calls_finish_reason",
+    },
+  ])("returns the stop source for $scenario", ({ overrides, expected }) => {
+    expect(getAgentAutoContinueStopSource({ ...baseState, ...overrides })).toBe(
+      expected,
+    );
+  });
+
+  it("does not auto-continue unrelated finish reasons", () => {
+    expect(getAgentAutoContinueStopSource(baseState)).toBeNull();
   });
 });
 

--- a/lib/chat/stop-conditions.ts
+++ b/lib/chat/stop-conditions.ts
@@ -45,12 +45,20 @@ export function tokenExhaustedAfterSummarization(state: {
   threshold: number;
   getLastStepInputTokens: () => number;
   getHasSummarized: () => boolean;
+  /**
+   * Whether prepareStep can compact the rolling context again before the next
+   * provider request. Omitted for backward compatibility with callers that
+   * still support only one compaction per stream.
+   */
+  getCanSummarizeAgain?: () => boolean;
   onFired: () => void;
 }): StopCondition<any> {
   return () => {
     const lastStepInput = state.getLastStepInputTokens();
     const hasSummarized = state.getHasSummarized();
-    const shouldStop = hasSummarized && lastStepInput > state.threshold;
+    const canSummarizeAgain = state.getCanSummarizeAgain?.() ?? false;
+    const shouldStop =
+      hasSummarized && !canSummarizeAgain && lastStepInput > state.threshold;
     if (shouldStop) {
       state.onFired();
     }

--- a/lib/chat/stop-conditions.ts
+++ b/lib/chat/stop-conditions.ts
@@ -17,9 +17,9 @@ export type AgentAutoContinueStopSource =
   | "tool_calls_finish_reason";
 
 /**
- * Returns why a completed Agent turn should ask the client to start a fresh
- * continuation run. Callers opt into elapsed-time continuation by passing the
- * corresponding stop flag.
+ * Returns why a completed Agent turn should signal the connected client to
+ * start a fresh continuation run. Callers opt into elapsed-time continuation
+ * by passing the corresponding stop flag.
  */
 export function getAgentAutoContinueStopSource(state: {
   finishReason: string | undefined;

--- a/lib/chat/stop-conditions.ts
+++ b/lib/chat/stop-conditions.ts
@@ -16,6 +16,11 @@ export type AgentAutoContinueStopSource =
   | "context_limit_finish_reason"
   | "tool_calls_finish_reason";
 
+/**
+ * Returns why a completed Agent turn should ask the client to start a fresh
+ * continuation run. Callers opt into elapsed-time continuation by passing the
+ * corresponding stop flag.
+ */
 export function getAgentAutoContinueStopSource(state: {
   finishReason: string | undefined;
   stoppedDueToTokenExhaustion: boolean;

--- a/lib/chat/stop-conditions.ts
+++ b/lib/chat/stop-conditions.ts
@@ -9,6 +9,33 @@ export const TOKEN_EXHAUSTION_FINISH_REASON = "context-limit";
 
 export const BUDGET_EXHAUSTION_FINISH_REASON = "budget-exhausted";
 
+export type AgentAutoContinueStopSource =
+  | "post_summarization_token_exhaustion"
+  | "elapsed_timeout"
+  | "post_summarization_incomplete"
+  | "context_limit_finish_reason"
+  | "tool_calls_finish_reason";
+
+export function getAgentAutoContinueStopSource(state: {
+  finishReason: string | undefined;
+  stoppedDueToTokenExhaustion: boolean;
+  stoppedDueToElapsedTimeout?: boolean;
+  stoppedDueToPostSummarizationIncomplete: boolean;
+}): AgentAutoContinueStopSource | null {
+  if (state.stoppedDueToTokenExhaustion) {
+    return "post_summarization_token_exhaustion";
+  }
+  if (state.stoppedDueToElapsedTimeout) return "elapsed_timeout";
+  if (state.stoppedDueToPostSummarizationIncomplete) {
+    return "post_summarization_incomplete";
+  }
+  if (state.finishReason === TOKEN_EXHAUSTION_FINISH_REASON) {
+    return "context_limit_finish_reason";
+  }
+  if (state.finishReason === "tool-calls") return "tool_calls_finish_reason";
+  return null;
+}
+
 export function tokenExhaustedAfterSummarization(state: {
   threshold: number;
   getLastStepInputTokens: () => number;

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -46,7 +46,7 @@ jest.doMock("@/lib/ai/providers", () => ({
   },
 }));
 
-const { checkAndSummarizeIfNeeded } =
+const { checkAndSummarizeIfNeeded, compactModelMessagesInRun } =
   require("../index") as typeof import("../index");
 const {
   isSummaryMessage,
@@ -189,6 +189,85 @@ describe("checkAndSummarizeIfNeeded", () => {
     expect(getSummarizationThresholdTokens(400_000)).toBe(
       400_000 - SUMMARIZATION_RESERVED_MAX_TOKENS,
     );
+  });
+
+  it("compacts live model history without persisting an in-flight cutoff", async () => {
+    mockGenerateText.mockResolvedValue({
+      text: "Runtime summary",
+      usage: { inputTokens: 120, outputTokens: 20 },
+    });
+    const modelMessages: ModelMessage[] = [
+      { role: "user", content: "durable user request" },
+      { role: "assistant", content: "new in-flight tool work" },
+    ];
+
+    const result = await compactModelMessagesInRun({
+      modelMessages,
+      transcriptModelMessages: modelMessages,
+      subscription: "pro",
+      languageModel: mockLanguageModel,
+      mode: "agent",
+      writer: mockWriter,
+      chatId: "chat-runtime-compaction",
+      maxTokens: 128_000,
+      compactionIndex: 2,
+      hasExistingSummary: true,
+    });
+
+    expect(result?.summaryText).toBe("Runtime summary");
+    expect(mockSaveChatSummary).not.toHaveBeenCalled();
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining(modelMessages),
+      }),
+    );
+    expect((mockWriter.write as jest.Mock).mock.calls).toEqual([
+      [
+        expect.objectContaining({
+          type: "data-summarization",
+          id: "summarization-status-2",
+          data: expect.objectContaining({ status: "started" }),
+        }),
+      ],
+    ]);
+  });
+
+  it("clears the transient in-run status when summary generation fails", async () => {
+    mockGenerateText.mockRejectedValue(new Error("provider failed"));
+    const modelMessages: ModelMessage[] = [
+      { role: "user", content: "live context" },
+    ];
+
+    const result = await compactModelMessagesInRun({
+      modelMessages,
+      transcriptModelMessages: modelMessages,
+      subscription: "pro",
+      languageModel: mockLanguageModel,
+      mode: "agent",
+      writer: mockWriter,
+      chatId: "chat-runtime-failure",
+      maxTokens: 128_000,
+      compactionIndex: 3,
+      hasExistingSummary: false,
+    });
+
+    expect(result).toBeNull();
+    expect((mockWriter.write as jest.Mock).mock.calls).toEqual([
+      [
+        expect.objectContaining({
+          id: "summarization-status-3",
+          data: expect.objectContaining({ status: "started" }),
+        }),
+      ],
+      [
+        expect.objectContaining({
+          id: "summarization-status-3",
+          data: { status: "completed", message: "" },
+          transient: true,
+        }),
+      ],
+    ]);
+    expect(mockSaveChatSummary).not.toHaveBeenCalled();
   });
 
   it("should allow a lower summarization threshold in development", () => {

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -331,6 +331,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       "test-system-prompt",
     );
 
+    expect(result.summarizationAttempted).toBe(false);
     expect(result.needsSummarization).toBe(false);
     expect(result.summarizedMessages).toBe(messages);
     expect(result.cutoffMessageId).toBeNull();
@@ -354,6 +355,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       "test-system-prompt",
     );
 
+    expect(result.summarizationAttempted).toBe(false);
     expect(result.needsSummarization).toBe(false);
     expect(result.summarizedMessages).toBe(fourMessages);
   });
@@ -378,6 +380,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       },
     });
 
+    expect(result.summarizationAttempted).toBe(true);
     expect(result.needsSummarization).toBe(true);
     expect(result.summaryText).toBe("Pressure summary");
     expect(mockSaveChatSummary).toHaveBeenCalledWith(
@@ -477,6 +480,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       0,
     );
 
+    expect(result.summarizationAttempted).toBe(false);
     expect(result.needsSummarization).toBe(false);
     expect(result.summarizedMessages).toBe(fourMessages);
     expect(mockGenerateText).not.toHaveBeenCalled();
@@ -1072,6 +1076,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       "test-system-prompt",
     );
 
+    expect(result.summarizationAttempted).toBe(true);
     expect(result.needsSummarization).toBe(false);
     expect(mockGenerateText).toHaveBeenCalledTimes(2);
 

--- a/lib/chat/summarization/constants.ts
+++ b/lib/chat/summarization/constants.ts
@@ -55,6 +55,12 @@ export const SUMMARY_INPUT_MAX_TOKENS = 64_000;
 export const SUMMARY_OVERFLOW_TEXT_PART_MAX_TOKENS = 1024;
 export const SUMMARY_OVERFLOW_TOOL_OUTPUT_MAX_TOKENS = 512;
 
+// A single Agent stream may compact repeatedly as tool work grows. Keep this
+// bounded so a provider whose fixed prompt/tool overhead cannot be reduced does
+// not enter an endless summarize/retry loop. Once exhausted, the existing
+// context-limit continuation starts a fresh backend run.
+export const MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM = 8;
+
 export const getSummaryInputMaxTokens = (maxTokens: number): number =>
   Math.min(
     SUMMARY_INPUT_MAX_TOKENS,

--- a/lib/chat/summarization/constants.ts
+++ b/lib/chat/summarization/constants.ts
@@ -61,6 +61,9 @@ export const SUMMARY_OVERFLOW_TOOL_OUTPUT_MAX_TOKENS = 512;
 // context-limit continuation starts a fresh backend run.
 export const MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM = 8;
 
+// A replacement checkpoint must remove at least 10% of serialized context.
+export const ROLLING_COMPACTION_MAX_SIZE_RATIO = 0.9;
+
 export const getSummaryInputMaxTokens = (maxTokens: number): number =>
   Math.min(
     SUMMARY_INPUT_MAX_TOKENS,

--- a/lib/chat/summarization/constants.ts
+++ b/lib/chat/summarization/constants.ts
@@ -58,7 +58,8 @@ export const SUMMARY_OVERFLOW_TOOL_OUTPUT_MAX_TOKENS = 512;
 // A single Agent stream may compact repeatedly as tool work grows. Keep this
 // bounded so a provider whose fixed prompt/tool overhead cannot be reduced does
 // not enter an endless summarize/retry loop. Once exhausted, the existing
-// context-limit continuation starts a fresh backend run.
+// client-driven context-limit continuation can request a fresh backend run
+// while the web client remains connected.
 export const MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM = 8;
 
 // A replacement checkpoint must remove at least 10% of serialized context.

--- a/lib/chat/summarization/helpers.ts
+++ b/lib/chat/summarization/helpers.ts
@@ -404,6 +404,80 @@ export const compactModelMessagesForSummarization = <T extends ModelMessage>(
   return changed ? compacted : messages;
 };
 
+const getToolPartIds = (
+  message: ModelMessage,
+  partType: "tool-call" | "tool-result",
+): string[] => {
+  if (!Array.isArray(message.content)) return [];
+
+  return message.content.flatMap((part) => {
+    const partRecord = part as Record<string, unknown>;
+    return partRecord.type === partType &&
+      typeof partRecord.toolCallId === "string"
+      ? [partRecord.toolCallId]
+      : [];
+  });
+};
+
+/**
+ * Return the newest complete assistant tool-call plus matching tool-result
+ * transaction. Keeping this structure beside a generated summary prevents a
+ * model from repeating successful work when the summary omits its completion.
+ */
+export const getLatestCompletedToolTransaction = (
+  messages: ModelMessage[],
+): ModelMessage[] => {
+  for (
+    let assistantIndex = messages.length - 1;
+    assistantIndex >= 0;
+    assistantIndex--
+  ) {
+    const assistantMessage = messages[assistantIndex];
+    if (assistantMessage.role !== "assistant") continue;
+
+    const toolCallIds = getToolPartIds(assistantMessage, "tool-call");
+    if (toolCallIds.length === 0) continue;
+
+    const expectedToolCallIds = new Set(toolCallIds);
+    const completedToolCallIds = new Set<string>();
+    const toolMessages: ModelMessage[] = [];
+
+    for (
+      let messageIndex = assistantIndex + 1;
+      messageIndex < messages.length;
+      messageIndex++
+    ) {
+      const message = messages[messageIndex];
+      if (message.role !== "tool") break;
+
+      const resultIds = getToolPartIds(message, "tool-result");
+      if (resultIds.length === 0) continue;
+      if (
+        resultIds.some((toolCallId) => !expectedToolCallIds.has(toolCallId))
+      ) {
+        return [];
+      }
+
+      resultIds.forEach((toolCallId) => completedToolCallIds.add(toolCallId));
+      toolMessages.push(message);
+    }
+
+    if (
+      toolMessages.length === 0 ||
+      toolCallIds.some((toolCallId) => !completedToolCallIds.has(toolCallId))
+    ) {
+      return [];
+    }
+
+    return compactModelMessagesForSummarization([
+      assistantMessage,
+      ...toolMessages,
+    ]);
+  }
+
+  return [];
+};
+
 const stringifySummaryMessages = (messages: ModelMessage[]): string => {
   try {
     return JSON.stringify(messages);

--- a/lib/chat/summarization/helpers.ts
+++ b/lib/chat/summarization/helpers.ts
@@ -55,6 +55,8 @@ export interface SummaryPersistenceMetadata {
 }
 
 export interface SummarizationResult {
+  /** True only when summary generation was actually attempted. */
+  summarizationAttempted: boolean;
   needsSummarization: boolean;
   summarizedMessages: UIMessage[];
   cutoffMessageId: string | null;
@@ -65,6 +67,7 @@ export interface SummarizationResult {
 export const NO_SUMMARIZATION = (
   messages: UIMessage[],
 ): SummarizationResult => ({
+  summarizationAttempted: false,
   needsSummarization: false,
   summarizedMessages: messages,
   cutoffMessageId: null,

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -952,6 +952,7 @@ export const checkAndSummarizeIfNeeded = async ({
     await persistSummary(chatId, finalSummaryText, cutoffMessageId, metadata);
 
     return {
+      summarizationAttempted: true,
       needsSummarization: true,
       summarizedMessages: [summaryMessage, ...tailSelection.tailMessages],
       cutoffMessageId,
@@ -976,7 +977,10 @@ export const checkAndSummarizeIfNeeded = async ({
       fallbackResult: "no_summarization",
       error,
     });
-    return NO_SUMMARIZATION(uiMessages);
+    return {
+      ...NO_SUMMARIZATION(uiMessages),
+      summarizationAttempted: true,
+    };
   } finally {
     if (!abortSignal?.aborted) {
       writeSummarizationCompleted(writer, 1);

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -11,6 +11,7 @@ import { v4 as uuidv4 } from "uuid";
 import { SubscriptionTier, ChatMode, Todo, AnySandbox } from "@/types";
 import { countMessagesTokens } from "@/lib/token-utils";
 import {
+  writeSummarizationCleared,
   writeSummarizationStarted,
   writeSummarizationCompleted,
 } from "@/lib/utils/stream-writer-utils";
@@ -50,7 +51,9 @@ export type { SummarizationResult, SummarizationUsage } from "./helpers";
 export type EnsureSandbox = () => Promise<AnySandbox>;
 
 type CompactionLogReason =
-  "provider_pressure" | "provider_input_tokens" | "estimated_token_threshold";
+  | "provider_pressure"
+  | "provider_input_tokens"
+  | "estimated_token_threshold";
 
 type SummarizationAttempt = "primary" | "fallback";
 
@@ -427,6 +430,7 @@ const logContextCompactionStarted = ({
 
 const generateSummaryTextWithRetry = async ({
   messagesToSummarize,
+  modelMessages,
   languageModel,
   mode,
   chatSystemPrompt,
@@ -440,6 +444,7 @@ const generateSummaryTextWithRetry = async ({
   reason,
 }: {
   messagesToSummarize: UIMessage[];
+  modelMessages?: ModelMessage[];
   languageModel: LanguageModel;
   mode: ChatMode;
   chatSystemPrompt: string;
@@ -467,7 +472,7 @@ const generateSummaryTextWithRetry = async ({
       tools,
       providerOptions,
       abortSignal,
-      undefined,
+      modelMessages,
       summaryInputMaxTokens,
     );
 
@@ -505,7 +510,7 @@ const generateSummaryTextWithRetry = async ({
         undefined,
         buildSummarizationRetryProviderOptions(providerOptions),
         abortSignal,
-        undefined,
+        modelMessages,
         summaryInputMaxTokens,
       );
     } catch (retryError) {
@@ -518,6 +523,176 @@ const generateSummaryTextWithRetry = async ({
       languageModel: retryLanguageModel,
       attempt: "fallback",
     };
+  }
+};
+
+export interface CompactModelMessagesInRunOptions {
+  modelMessages: ModelMessage[];
+  /** Raw cumulative SDK history used only for the transcript sidecar. */
+  transcriptModelMessages: ModelMessage[];
+  subscription: SubscriptionTier;
+  languageModel: LanguageModel;
+  mode: ChatMode;
+  writer: UIMessageStreamWriter;
+  chatId: string | null;
+  todos?: Todo[];
+  abortSignal?: AbortSignal;
+  ensureSandbox?: EnsureSandbox;
+  systemPromptTokens?: number;
+  providerInputTokens?: number;
+  chatSystemPrompt?: string;
+  tools?: ToolSet;
+  providerOptions?: Record<string, Record<string, unknown>>;
+  maxTokens: number;
+  providerPromptPressure?: ProviderPromptPressure | null;
+  compactionIndex: number;
+  hasExistingSummary: boolean;
+}
+
+export interface InRunModelCompactionResult {
+  summaryMessage: UIMessage;
+  summaryText: string;
+  summarizationUsage: SummarizationResult["summarizationUsage"];
+}
+
+/**
+ * Compacts the live ModelMessage history without updating latest_summary_id.
+ *
+ * In-flight assistant/tool messages do not have a durable chat message cutoff
+ * yet, so persisting this summary would make reloads duplicate that work. The
+ * caller keeps the result as a run-scoped rolling checkpoint instead.
+ */
+export const compactModelMessagesInRun = async ({
+  modelMessages,
+  transcriptModelMessages,
+  subscription,
+  languageModel,
+  mode,
+  writer,
+  chatId,
+  todos = [],
+  abortSignal,
+  ensureSandbox,
+  systemPromptTokens = 0,
+  providerInputTokens = 0,
+  chatSystemPrompt = "",
+  tools,
+  providerOptions,
+  maxTokens,
+  providerPromptPressure,
+  compactionIndex,
+  hasExistingSummary,
+}: CompactModelMessagesInRunOptions): Promise<InRunModelCompactionResult | null> => {
+  const summarizationThreshold = getSummarizationThresholdTokens(maxTokens);
+  const compactionReason = getCompactionLogReason({
+    providerPromptPressure,
+    providerInputTokens,
+    summarizationThreshold,
+  });
+
+  console.info(
+    JSON.stringify({
+      level: "info",
+      event: "agent_in_run_context_compaction_started",
+      service: "chat-handler",
+      timestamp: new Date().toISOString(),
+      chat_id: chatId ?? undefined,
+      mode,
+      subscription,
+      reason: compactionReason,
+      compaction_index: compactionIndex,
+      persistence: "run_scoped",
+      model_message_count: modelMessages.length,
+      provider_input_tokens: providerInputTokens,
+      max_tokens: maxTokens,
+      threshold_tokens: summarizationThreshold,
+      system_prompt_tokens: systemPromptTokens,
+      provider_pressure_reason: providerPromptPressure?.reason,
+      provider_pressure_serialized_message_bytes:
+        providerPromptPressure?.serializedMessageBytes,
+    }),
+  );
+  writeSummarizationStarted(writer, compactionIndex);
+
+  try {
+    const summaryPromise = generateSummaryTextWithRetry({
+      messagesToSummarize: [],
+      modelMessages,
+      languageModel,
+      mode,
+      chatSystemPrompt,
+      hasExistingSummary,
+      tools,
+      providerOptions,
+      abortSignal,
+      summaryInputMaxTokens: getSummaryInputMaxTokens(maxTokens),
+      chatId,
+      subscription,
+      reason: compactionReason,
+    });
+    const transcriptPromise: Promise<string | null> =
+      ensureSandbox && mode === "agent"
+        ? ensureSandbox()
+            .then((sandbox) =>
+              saveTranscriptToSandbox([], sandbox, transcriptModelMessages),
+            )
+            .catch((error) => {
+              console.error(
+                "[Summarization] Failed to ensure sandbox for in-run transcript:",
+                error,
+              );
+              return null;
+            })
+        : Promise.resolve(null);
+
+    const [summaryResult, savedPath] = await Promise.all([
+      summaryPromise,
+      transcriptPromise,
+    ]);
+    let finalSummaryText = summaryResult.text;
+    if (savedPath) finalSummaryText += buildTranscriptNotice(savedPath);
+
+    console.info(
+      JSON.stringify({
+        level: "info",
+        event: "agent_in_run_context_compaction_generated",
+        service: "chat-handler",
+        timestamp: new Date().toISOString(),
+        chat_id: chatId ?? undefined,
+        mode,
+        subscription,
+        compaction_index: compactionIndex,
+        persistence: "run_scoped",
+        summary_input_tokens: summaryResult.usage.inputTokens,
+        summary_output_tokens: summaryResult.usage.outputTokens,
+        estimated_compacted_input_tokens:
+          summaryResult.usage.estimatedCompactedInputTokens,
+      }),
+    );
+
+    return {
+      summaryMessage: buildSummaryMessage(finalSummaryText, todos),
+      summaryText: finalSummaryText,
+      summarizationUsage: summaryResult.usage,
+    };
+  } catch (error) {
+    if (abortSignal?.aborted) throw error;
+    const failedAttempt = getSummarizationAttemptFromError(error);
+    logContextCompactionFailed({
+      chatId,
+      mode,
+      subscription,
+      reason: compactionReason,
+      attempt: failedAttempt,
+      languageModel:
+        failedAttempt === "fallback"
+          ? myProvider.languageModel(SUMMARIZATION_RETRY_MODEL_BY_MODE[mode])
+          : languageModel,
+      fallbackResult: "no_summarization",
+      error,
+    });
+    writeSummarizationCleared(writer, compactionIndex);
+    return null;
   }
 };
 
@@ -708,7 +883,7 @@ export const checkAndSummarizeIfNeeded = async ({
     retainedTail: tailSelection.retainedTail,
   });
 
-  writeSummarizationStarted(writer);
+  writeSummarizationStarted(writer, 1);
 
   try {
     // Run summary generation and transcript saving in parallel — they are
@@ -804,7 +979,7 @@ export const checkAndSummarizeIfNeeded = async ({
     return NO_SUMMARIZATION(uiMessages);
   } finally {
     if (!abortSignal?.aborted) {
-      writeSummarizationCompleted(writer);
+      writeSummarizationCompleted(writer, 1);
     }
   }
 };

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -94,26 +94,29 @@ export class UsageTracker {
   /** Costs from sandbox sessions and tool usage (always accurate, even on non-clean streams) */
   nonModelCost = 0;
   lastStepInputTokens = 0;
+  /** Input tokens from summarization requests, preserved across model fallback. */
+  summarizationInputTokens = 0;
   /** Output tokens from summarization (not from assistant responses) */
   summarizationOutputTokens = 0;
+  /** Cache tokens from summarization requests, preserved across model fallback. */
+  summarizationCacheReadTokens = 0;
+  summarizationCacheWriteTokens = 0;
 
   /**
    * Discard the model leg's accumulated usage before a fallback retry runs.
-   * Keeps nonModelCost (sandbox/tool spend already incurred) and summarization
-   * output tokens, so the final deduction only bills the fallback model.
+   * Keeps nonModelCost (sandbox/tool spend already incurred) and all
+   * summarization usage, so the final deduction only replaces the streamed
+   * model leg with the fallback model.
    */
   resetModelLeg() {
     this.providerCost -= this.modelProviderCost;
     this.modelProviderCost = 0;
-    this.inputTokens = 0;
-    // Preserve summarization's contribution to outputTokens so the
-    // streamOutputTokens getter (outputTokens - summarizationOutputTokens)
-    // never goes negative.
+    this.inputTokens = this.summarizationInputTokens;
     this.outputTokens = this.summarizationOutputTokens;
-    this.totalTokens = this.outputTokens;
+    this.totalTokens = this.inputTokens + this.outputTokens;
     this.lastStepInputTokens = 0;
-    this.cacheReadTokens = 0;
-    this.cacheWriteTokens = 0;
+    this.cacheReadTokens = this.summarizationCacheReadTokens;
+    this.cacheWriteTokens = this.summarizationCacheWriteTokens;
     this.modelStepCosts = [];
   }
 

--- a/lib/utils/stream-writer-utils.ts
+++ b/lib/utils/stream-writer-utils.ts
@@ -37,10 +37,13 @@ export const writeUploadCompleteStatus = (
 // Summarization notifications
 export const writeSummarizationStarted = (
   writer: UIMessageStreamWriter,
+  compactionIndex?: number,
 ): void => {
   writer.write({
     type: "data-summarization",
-    id: "summarization-status",
+    id: compactionIndex
+      ? `summarization-status-${compactionIndex}`
+      : "summarization-status",
     data: {
       status: "started",
       message: "Automatically compacting context",
@@ -51,14 +54,32 @@ export const writeSummarizationStarted = (
 
 export const writeSummarizationCompleted = (
   writer: UIMessageStreamWriter,
+  compactionIndex?: number,
 ): void => {
   writer.write({
     type: "data-summarization",
-    id: "summarization-status",
+    id: compactionIndex
+      ? `summarization-status-${compactionIndex}`
+      : "summarization-status",
     data: {
       status: "completed",
       message: "Context automatically compacted",
     },
+  });
+};
+
+/** Clear the transient compacting indicator without persisting a success. */
+export const writeSummarizationCleared = (
+  writer: UIMessageStreamWriter,
+  compactionIndex?: number,
+): void => {
+  writer.write({
+    type: "data-summarization",
+    id: compactionIndex
+      ? `summarization-status-${compactionIndex}`
+      : "summarization-status",
+    data: { status: "completed", message: "" },
+    transient: true,
   });
 };
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -142,6 +142,7 @@ import {
 } from "@/lib/chat/agent-long-realtime-sanitizer";
 import {
   BUDGET_EXHAUSTION_FINISH_REASON,
+  getAgentAutoContinueStopSource,
   PREEMPTIVE_TIMEOUT_FINISH_REASON,
 } from "@/lib/chat/stop-conditions";
 import {
@@ -2436,13 +2437,25 @@ export const agentLongTask = task({
                       // Don't auto-continue on elapsed timeout. Runs that hit
                       // their plan cap are large enough that the user should
                       // explicitly decide whether to continue.
-                      if (
-                        (state.stoppedDueToTokenExhaustion ||
-                          state.stoppedDueToPostSummarizationIncomplete ||
-                          state.streamFinishReason === "tool-calls") &&
-                        !temporary
-                      ) {
+                      const autoContinueStopSource =
+                        getAgentAutoContinueStopSource({
+                          finishReason: state.streamFinishReason,
+                          stoppedDueToTokenExhaustion:
+                            state.stoppedDueToTokenExhaustion,
+                          stoppedDueToPostSummarizationIncomplete:
+                            state.stoppedDueToPostSummarizationIncomplete,
+                        });
+                      if (autoContinueStopSource && !temporary) {
                         writeAutoContinue(writer);
+                        phLogger.info("Agent auto-continue signaled", {
+                          event: "agent_auto_continue_signaled",
+                          chat_id: chatId,
+                          assistant_id: assistantMessageId,
+                          finish_reason: state.streamFinishReason,
+                          stop_source: autoContinueStopSource,
+                          last_step_input_tokens: state.lastStepInputTokens,
+                          had_summarization: summarizationTracker.hasSummarized,
+                        });
                       }
                       posthog?.shutdown();
                     } finally {


### PR DESCRIPTION
## Summary
- keep compacted provider context as a rolling backend checkpoint across every AI SDK tool step
- enforce a strict eight-round context-compaction budget, including a failed durable step-zero attempt
- keep later in-flight summaries run-scoped so chat reloads cannot duplicate unsaved assistant/tool work
- preserve the existing client-driven fresh-run fallback for provider `context-limit` finishes while the web client is connected
- preserve every accepted or ineffective summary's token, cache, and cost accounting across model fallback resets
- track every accepted summary at its correct step with distinct UI part IDs

## Root cause
AI SDK `prepareStep.messages` overrides apply to only one provider request. On the following tool step the SDK rebuilds `initialMessages + responseMessages`, so the original oversized history returned immediately. HackerAI also stopped on high input tokens after the first summary before another `prepareStep` could compact again.

## Backend behavior
- The runner now rebases every provider call onto `latest compacted base + raw messages after the checkpoint cursor`.
- Step-zero summaries may persist normally. Summaries that include in-flight assistant/tool work are runtime-only because those messages do not yet have a durable cutoff.
- Failed or ineffective compactions clear transient UI state, do not install a checkpoint, and may retry after the raw cursor advances.
- Same-cursor loops are skipped and the total compaction-round budget is capped at eight, including a failed durable step-zero attempt.
- When the connected client receives a terminal auto-continue marker, it starts the existing fresh backend run. Closing the web client does not create a server-side replacement run.
- Structured logs distinguish generated, accepted, ineffective, and failed in-run compactions without logging prompt content.

## Validation
- `pnpm jest lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts lib/api/__tests__/agent-stream-runner-rolling-context.test.ts lib/api/__tests__/chat-stream-helpers-summarization.test.ts lib/chat/__tests__/stop-conditions.test.ts lib/chat/summarization/__tests__/index.test.ts lib/api/__tests__/agent-long-contracts.test.ts lib/__tests__/usage-tracker.test.ts --runInBand` (191 tests)
- targeted ESLint on all changed implementation and test files
- Prettier check on all changed implementation and test files
- `git diff --check`
- `pnpm typecheck` reaches the existing `packages/local/src/index.ts(17,23): Cannot find module 'ws'` dependency issue in this sparse worktree; GitHub CI runs with a complete install

## Manual verification
- Run an Agent task that crosses the context threshold, continues through multiple large tool-result steps, and crosses the threshold again.
- Confirm the same backend run continues after each accepted compaction and later provider requests do not restore the original history.
- Close the web client during a Trigger Agent task and confirm the current backend execution and same-run compaction continue.
- With the web client connected, exhaust all eight rounds or force a direct provider `context-limit`; confirm the client starts the existing fresh continuation run.
- With the web client closed, confirm the current Trigger run may finish but no client-driven fresh run starts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent runs can now auto-continue based on additional stop causes, including context-limit, elapsed timeout, incomplete post-summarization continuation, and tool-call termination.
  * Improved run-scoped/rolling context compaction with capped repeated attempts to reduce runaway summarize/retry behavior.
* **Bug Fixes**
  * Finish-reason notices in agent mode are no longer suppressed for “auto-continuable” finish reasons; they’re hidden only when the stream is auto-resuming or after the user clicks Continue.
* **Tests**
  * Expanded automated coverage for auto-continue stop-source selection, finish-reason rendering, and context compaction behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->