### PR TITLE
Fix browser health test prerequisites

### DIFF
--- a/__tests__/auth-preflight.test.ts
+++ b/__tests__/auth-preflight.test.ts
@@ -1,0 +1,79 @@
+import {
+  assertAuthenticatedSession,
+  E2EAuthConfigurationError,
+  getLocalAuthCallbackMismatch,
+} from "../e2e/helpers/auth-preflight";
+import type { Page } from "@playwright/test";
+
+describe("getLocalAuthCallbackMismatch", () => {
+  it("returns null when the local app and callback origins match", () => {
+    const authorizationUrl =
+      "https://api.workos.com/user_management/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A3001%2Fcallback";
+
+    expect(
+      getLocalAuthCallbackMismatch(
+        "http://localhost:3001/login",
+        authorizationUrl,
+      ),
+    ).toBeNull();
+  });
+
+  it("reports a local callback port mismatch", () => {
+    const authorizationUrl =
+      "https://api.workos.com/user_management/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback";
+
+    expect(
+      getLocalAuthCallbackMismatch(
+        "http://localhost:3001/login",
+        authorizationUrl,
+      ),
+    ).toEqual({
+      appOrigin: "http://localhost:3001",
+      redirectUri: "http://localhost:3000/callback",
+      redirectOrigin: "http://localhost:3000",
+    });
+  });
+
+  it("does not impose local callback rules on remote test targets", () => {
+    const authorizationUrl =
+      "https://api.workos.com/user_management/authorize?redirect_uri=https%3A%2F%2Fauth.hackerai.co%2Fcallback";
+
+    expect(
+      getLocalAuthCallbackMismatch(
+        "https://preview.hackerai.co/login",
+        authorizationUrl,
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores malformed authorization responses", () => {
+    expect(
+      getLocalAuthCallbackMismatch("http://localhost:3001/login", "not a url"),
+    ).toBeNull();
+  });
+});
+
+describe("assertAuthenticatedSession", () => {
+  function createPage(isVisible: boolean): Page {
+    const locator = {
+      or: jest.fn().mockReturnThis(),
+      isVisible: jest.fn().mockResolvedValue(isVisible),
+    };
+
+    return {
+      getByTestId: jest.fn().mockReturnValue(locator),
+    } as unknown as Page;
+  }
+
+  it("accepts a visible authenticated shell", async () => {
+    await expect(assertAuthenticatedSession(createPage(true))).resolves.toBe(
+      undefined,
+    );
+  });
+
+  it("fails before live actions when storage state is stale", async () => {
+    await expect(assertAuthenticatedSession(createPage(false))).rejects.toThrow(
+      E2EAuthConfigurationError,
+    );
+  });
+});

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -163,6 +163,14 @@ Three test users are configured for different subscription tiers:
 
    Copy `.env.e2e.example` to `.env.e2e` if it doesn't exist, and ensure all test user credentials are set.
 
+   `PLAYWRIGHT_BASE_URL` controls both the test target and the local Next.js
+   dev-server port. Authenticated tests also require the WorkOS redirect URI to
+   use the same origin. If you change the test port, update
+   `NEXT_PUBLIC_WORKOS_REDIRECT_URI` and the matching WorkOS redirect allowlist.
+   Isolated chat, file, and Agent specs also validate the saved authenticated
+   shell before acting; refresh storage state with the setup project when they
+   report that it is missing or stale.
+
 ### Running Tests
 
 Run all e2e tests:

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -3,6 +3,10 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { TIMEOUTS } from "../constants";
 import {
+  assertLocalAuthCallbackMatchesApp,
+  E2EAuthConfigurationError,
+} from "../helpers/auth-preflight";
+import {
   getTestUsersRecord,
   type TestUser as TestUserFromConfig,
 } from "../../scripts/test-users-config";
@@ -169,6 +173,10 @@ export async function authenticateUser(
       await page.context().storageState({ path: getStorageStatePath(user) });
       return;
     } catch (error) {
+      if (error instanceof E2EAuthConfigurationError) {
+        throw error;
+      }
+
       lastError = error as Error;
       console.warn(
         `Login attempt ${attempt + 1} failed for ${user.email}:`,
@@ -190,6 +198,8 @@ export async function authenticateUser(
 }
 
 async function performLogin(page: Page, user: TestUser): Promise<void> {
+  await assertLocalAuthCallbackMatchesApp(page);
+
   // Navigate to login page
   await page.goto("/login");
 

--- a/e2e/helpers/auth-preflight.ts
+++ b/e2e/helpers/auth-preflight.ts
@@ -1,0 +1,77 @@
+import type { Page } from "@playwright/test";
+
+const LOCAL_APP_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+const AUTH_SHELL_TIMEOUT_MS = 2000;
+
+interface AuthCallbackMismatch {
+  appOrigin: string;
+  redirectUri: string;
+  redirectOrigin: string;
+}
+
+export class E2EAuthConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "E2EAuthConfigurationError";
+  }
+}
+
+export function getLocalAuthCallbackMismatch(
+  appUrl: string,
+  authorizationUrl: string,
+): AuthCallbackMismatch | null {
+  try {
+    const app = new URL(appUrl);
+    if (!LOCAL_APP_HOSTS.has(app.hostname)) return null;
+
+    const redirectUri = new URL(authorizationUrl, app).searchParams.get(
+      "redirect_uri",
+    );
+    if (!redirectUri) return null;
+
+    const redirect = new URL(redirectUri);
+    if (redirect.origin === app.origin) return null;
+
+    return {
+      appOrigin: app.origin,
+      redirectUri: redirect.toString(),
+      redirectOrigin: redirect.origin,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function assertLocalAuthCallbackMatchesApp(
+  page: Page,
+): Promise<void> {
+  const response = await page.request.get("/login", { maxRedirects: 0 });
+  const headers = response.headers();
+  const authorizationUrl =
+    headers["x-workos-authorization-url"] ?? headers.location;
+  if (!authorizationUrl) return;
+
+  const mismatch = getLocalAuthCallbackMismatch(
+    response.url(),
+    authorizationUrl,
+  );
+  if (!mismatch) return;
+
+  throw new E2EAuthConfigurationError(
+    `E2E auth callback mismatch: tests use ${mismatch.appOrigin}, but WorkOS redirects to ${mismatch.redirectUri}. Run the app on ${mismatch.redirectOrigin}, or update NEXT_PUBLIC_WORKOS_REDIRECT_URI and the WorkOS redirect allowlist to match the test origin.`,
+  );
+}
+
+export async function assertAuthenticatedSession(page: Page): Promise<void> {
+  const userMenuButton = page
+    .getByTestId("user-menu-button")
+    .or(page.getByTestId("user-menu-button-collapsed"));
+  const isAuthenticated = await userMenuButton
+    .isVisible({ timeout: AUTH_SHELL_TIMEOUT_MS })
+    .catch(() => false);
+  if (isAuthenticated) return;
+
+  throw new E2EAuthConfigurationError(
+    "E2E auth state is missing or stale. Run `corepack pnpm test:e2e --project=setup --workers=1` before isolated `--no-deps` chat, file, or Agent tests.",
+  );
+}

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -3,6 +3,7 @@ import { ChatComponent } from "../page-objects";
 import { SidebarComponent } from "../page-objects/SidebarComponent";
 import path from "path";
 import { TEST_DATA, TIMEOUTS } from "../constants";
+import { assertAuthenticatedSession } from "./auth-preflight";
 
 /**
  * Common test helper functions to reduce duplication
@@ -71,6 +72,7 @@ export async function setupChat(
   await page.goto(options.refreshEntitlements ? "/?refresh=entitlements" : "/");
   const chat = new ChatComponent(page);
   await chat.waitForHydrated();
+  await assertAuthenticatedSession(page);
   if (options.refreshEntitlements) {
     await page
       .waitForURL((url) => url.searchParams.get("refresh") !== "entitlements", {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,14 @@ import * as path from "path";
 // Load .env.e2e file for test environment variables
 dotenv.config({ path: path.join(__dirname, ".env.e2e") });
 
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
+const parsedBaseURL = new URL(baseURL);
+const isLocalBaseURL = ["localhost", "127.0.0.1", "[::1]"].includes(
+  parsedBaseURL.hostname,
+);
+const localDevServerPort =
+  parsedBaseURL.port || (parsedBaseURL.protocol === "https:" ? "443" : "80");
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -18,7 +26,7 @@ export default defineConfig({
   timeout: 60000,
 
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000",
+    baseURL,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     navigationTimeout: 30000,
@@ -40,10 +48,12 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: {
-    command: "corepack pnpm exec next dev --webpack",
-    url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
-    timeout: 120000,
-  },
+  webServer: isLocalBaseURL
+    ? {
+        command: `corepack pnpm exec next dev --webpack --port ${localDevServerPort}`,
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120000,
+      }
+    : undefined,
 });

--- a/scripts/__tests__/trigger-dev-branch.test.js
+++ b/scripts/__tests__/trigger-dev-branch.test.js
@@ -1,0 +1,61 @@
+const {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} = require("node:fs");
+const { tmpdir } = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const scriptPath = path.resolve("scripts/trigger-dev-branch.mjs");
+
+describe("trigger-dev-branch", () => {
+  it("starts the Trigger 4.5 dev branch with forwarded arguments", () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "trigger-dev-branch-"));
+    const capturePath = path.join(tempDir, "args.json");
+
+    try {
+      writeFileSync(
+        path.join(tempDir, "capture-trigger.mjs"),
+        `import { writeFileSync } from "node:fs";\nwriteFileSync(process.env.TRIGGER_ARGS_CAPTURE, JSON.stringify(process.argv.slice(2)));\n`,
+      );
+      writeFileSync(
+        path.join(tempDir, "trigger"),
+        `#!/bin/sh\nexec "${process.execPath}" "${path.join(tempDir, "capture-trigger.mjs")}" "$@"\n`,
+      );
+      chmodSync(path.join(tempDir, "trigger"), 0o755);
+
+      const result = spawnSync(
+        process.execPath,
+        [scriptPath, "--skip-update-check"],
+        {
+          cwd: tempDir,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            PATH: `${tempDir}:${process.env.PATH}`,
+            TRIGGER_ARGS_CAPTURE: capturePath,
+            TRIGGER_DEV_BRANCH: "feature/codex health",
+          },
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toContain(
+        "[trigger-dev] using Trigger.dev branch: feature-codex-health",
+      );
+      expect(JSON.parse(readFileSync(capturePath, "utf8"))).toEqual([
+        "dev",
+        "start",
+        "--branch",
+        "feature-codex-health",
+        "--skip-update-check",
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/trigger-dev-branch.mjs
+++ b/scripts/trigger-dev-branch.mjs
@@ -36,7 +36,7 @@ console.log(`[trigger-dev] using Trigger.dev branch: ${triggerBranch}`);
 
 const child = spawn(
   "trigger",
-  ["dev", "--branch", triggerBranch, ...process.argv.slice(2)],
+  ["dev", "start", "--branch", triggerBranch, ...process.argv.slice(2)],
   {
     stdio: "inherit",
     shell: process.platform === "win32",


### PR DESCRIPTION
## Summary

- update the Trigger.dev wrapper to use the Trigger 4.5 `dev start --branch` command shape
- make Playwright start the local Next.js server on the `PLAYWRIGHT_BASE_URL` port and skip local startup for remote targets
- fail stale-auth recovery immediately when the local app origin and WorkOS callback origin differ
- validate the authenticated shell before isolated chat, file, and Agent tests spend quota or upload files

## Root cause

The weekly browser health check found two setup blockers. The repository wrapper still called the Trigger 4.4 command shape even though the locked 4.5 CLI moved branch-aware development under `trigger dev start`. Separately, Playwright could target port 3001 while still starting and authenticating through port 3000, which produced connection resets and repeated WorkOS login attempts instead of a clear setup failure.

## Validation

- `corepack pnpm jest scripts/__tests__/trigger-dev-branch.test.js __tests__/auth-preflight.test.ts --runInBand`
- `corepack pnpm exec eslint scripts/trigger-dev-branch.mjs scripts/__tests__/trigger-dev-branch.test.js e2e/helpers/auth-preflight.ts e2e/helpers/test-helpers.ts __tests__/auth-preflight.test.ts e2e/fixtures/auth.ts playwright.config.ts`
- `corepack pnpm typecheck`
- commit hook: 221 Jest suites / 2,214 tests passed
- live Trigger 4.5.1 probe reached `Local worker ready on branch: codex-openrouter-stream-cost-regressions`
- live port-3001 auth setup stopped after one request with the exact `localhost:3000/callback` mismatch and remediation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preflight checks that detect mismatched local authentication callbacks and stale or missing authenticated sessions before end-to-end tests run.
  * End-to-end tests can now target either local development servers or remote environments through configurable base URLs.
* **Documentation**
  * Added guidance for base URL, redirect URI, and authentication storage configuration.
* **Bug Fixes**
  * Updated development-branch triggering to use the current Trigger.dev start command and preserve forwarded options.
* **Tests**
  * Added coverage for authentication checks and branch-trigger command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->