### PR TITLE
Fix production error clusters from daily Vercel triage

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -279,6 +279,42 @@ describe("proxy", () => {
     expect(mockNextResponseRedirect).not.toHaveBeenCalled();
   });
 
+  it("stops root Server Actions when session refresh has ended", async () => {
+    const endedSessionError = Object.assign(
+      new Error("Failed to refresh session: Error: invalid_grant"),
+      {
+        name: "TokenRefreshError",
+        cause: {
+          error: "invalid_grant",
+          errorDescription: "Session has already ended.",
+        },
+      },
+    );
+    mockAuthkit.mockRejectedValue(endedSessionError);
+    const { default: proxy } = await import("../proxy");
+
+    const response = await proxy(
+      createRequest({
+        pathname: "/",
+        method: "POST",
+        hasSession: true,
+        headers: { "next-action": "billing-action" },
+      }),
+    );
+
+    expect(response).toMatchObject({ kind: "json" });
+    expect(response.cookies.delete).toHaveBeenCalledWith("wos-session");
+    expect(mockNextResponseJson).toHaveBeenCalledWith(
+      {
+        code: "unauthorized:auth",
+        message: "You need to sign in before continuing.",
+        cause: "Session expired or invalid",
+      },
+      { status: 401 },
+    );
+    expect(mockNextResponseNext).not.toHaveBeenCalled();
+  });
+
   it("returns 401 when protected APIs hit thrown ended-session refresh errors", async () => {
     const endedSessionError = Object.assign(
       new Error("Failed to refresh session: Error: invalid_grant"),

--- a/app/api/chat/[id]/stream/route.ts
+++ b/app/api/chat/[id]/stream/route.ts
@@ -134,6 +134,8 @@ export async function GET(
           chatId,
           endpoint: "/api/chat/[id]/stream",
           abortController,
+          requestId: req.headers.get("x-vercel-id") ?? undefined,
+          userId,
         });
 
         // Abort on client disconnect (tab close, network error, etc.)

--- a/app/api/fraud/webhook/route.ts
+++ b/app/api/fraud/webhook/route.ts
@@ -8,6 +8,7 @@ import {
   logStripeWebhookMissingSignature,
   logStripeWebhookSignatureVerificationFailed,
 } from "@/lib/billing/stripe-webhook-logging";
+import { getRemainingRefundAmountCents } from "@/lib/billing/fraud-refund";
 
 const WEBHOOK_LOG_PREFIX = "[Fraud Webhook]";
 const WEBHOOK_LOG_CONTEXT = {
@@ -160,16 +161,28 @@ async function reportChargeFraudulent(chargeId: string): Promise<void> {
  * the dispute fee + ratio impact).
  */
 async function refundChargeForEFW(
-  chargeId: string,
+  charge: Stripe.Charge,
   efwId: string,
 ): Promise<void> {
+  const remainingAmount = getRemainingRefundAmountCents(charge);
+  if (remainingAmount === 0) {
+    console.log(
+      `[Fraud Webhook] Refund skipped for ${charge.id} (EFW ${efwId}): charge has no refundable balance`,
+    );
+    return;
+  }
+
   try {
     await stripe.refunds.create(
-      { charge: chargeId, reason: "fraudulent" },
+      {
+        charge: charge.id,
+        reason: "fraudulent",
+        amount: remainingAmount,
+      },
       { idempotencyKey: `efw-refund:${efwId}` },
     );
     console.log(
-      `[Fraud Webhook] Refunded charge ${chargeId} (early fraud warning ${efwId})`,
+      `[Fraud Webhook] Refunded ${remainingAmount} cents from charge ${charge.id} (early fraud warning ${efwId})`,
     );
   } catch (err) {
     if (err instanceof Stripe.errors.StripeError) {
@@ -180,14 +193,14 @@ async function refundChargeForEFW(
         code === "charge_pending"
       ) {
         console.log(
-          `[Fraud Webhook] Refund skipped for ${chargeId} (EFW ${efwId}): ${code}`,
+          `[Fraud Webhook] Refund skipped for ${charge.id} (EFW ${efwId}): ${code}`,
         );
         return;
       }
     }
     // Transient or unexpected — bubble so Stripe retries the webhook.
     console.error(
-      `[Fraud Webhook] Refund failed for ${chargeId} (EFW ${efwId}):`,
+      `[Fraud Webhook] Refund failed for ${charge.id} (EFW ${efwId}):`,
       err,
     );
     throw err;
@@ -313,7 +326,7 @@ async function handleEarlyFraudWarning(
   const customerId = getCustomerIdFromCharge(charge);
 
   // Refund first. Throws on transient errors so Stripe retries the webhook.
-  await refundChargeForEFW(chargeId, warning.id);
+  await refundChargeForEFW(charge, warning.id);
 
   // Block the user
   if (customerId) {

--- a/app/api/mfa/verify/__tests__/route.test.ts
+++ b/app/api/mfa/verify/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockGetUserID = jest.fn();
+const mockVerifyChallenge = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: ResponseInit) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("@/lib/auth/get-user-id", () => ({
+  getUserID: mockGetUserID,
+}));
+
+jest.mock("@/app/api/workos", () => ({
+  workos: {
+    multiFactorAuth: {
+      verifyChallenge: mockVerifyChallenge,
+    },
+  },
+}));
+
+function makeRequest() {
+  return {
+    json: jest.fn().mockResolvedValue({
+      challengeId: "challenge-1",
+      code: "123456",
+    }),
+  } as any;
+}
+
+describe("POST /api/mfa/verify", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUserID.mockResolvedValue("user-1" as never);
+  });
+
+  it("returns a client error without error logging after too many attempts", async () => {
+    mockVerifyChallenge.mockRejectedValue(
+      new Error("One-time code has had too many failed attempts.") as never,
+    );
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const { POST } = await import("../route");
+      const response = await POST(makeRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body).toEqual({
+        error: "Too many failed attempts. Start a new verification challenge.",
+      });
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/app/api/mfa/verify/route.ts
+++ b/app/api/mfa/verify/route.ts
@@ -55,8 +55,6 @@ export async function POST(req: NextRequest) {
       challenge: verification.challenge,
     });
   } catch (error) {
-    console.error("MFA verification error:", error);
-
     // Handle specific WorkOS errors
     if (error instanceof Error) {
       if (error.message.includes("already verified")) {
@@ -71,7 +69,18 @@ export async function POST(req: NextRequest) {
           { status: 400 },
         );
       }
+      if (error.message.includes("too many failed attempts")) {
+        return NextResponse.json(
+          {
+            error:
+              "Too many failed attempts. Start a new verification challenge.",
+          },
+          { status: 400 },
+        );
+      }
     }
+
+    console.error("MFA verification error:", error);
 
     const status = isUnauthorizedError(error) ? 401 : 500;
     return NextResponse.json(

--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -476,6 +476,61 @@ describe("POST /api/subscribe", () => {
     );
   });
 
+  it("retries a timed-out WorkOS organization update once", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          role: { slug: "owner" },
+        },
+      ],
+    } as never);
+    mockGetOrganization.mockResolvedValue({ id: "org_team" } as never);
+    mockListCustomers.mockResolvedValue({
+      data: [
+        {
+          id: "cus_matched",
+          metadata: { workOSOrganizationId: "org_team" },
+        },
+      ],
+    } as never);
+    const timeout = Object.assign(new Error("Error: Request timeout"), {
+      name: "OauthException",
+    });
+    mockUpdateOrganization
+      .mockRejectedValueOnce(timeout as never)
+      .mockResolvedValueOnce(undefined as never);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const { POST } = await import("../route");
+
+      const response = await POST(makeRequest({ plan: "pro-monthly-plan" }));
+
+      expect(response.status).toBe(200);
+      expect(mockUpdateOrganization).toHaveBeenCalledTimes(2);
+      expect(mockUpdateOrganization).toHaveBeenNthCalledWith(1, {
+        organization: "org_team",
+        stripeCustomerId: "cus_matched",
+      });
+      expect(JSON.parse(String(warnSpy.mock.calls[0]?.[0]))).toMatchObject({
+        event: "billing.workos_organization_update_retry_scheduled",
+        request_id: "unknown",
+        service: "hackerai-web",
+        route: "/api/subscribe",
+        user_id: "user_123",
+        organization_id: "org_team",
+        stripe_customer_id: "cus_matched",
+        attempt: 1,
+        next_attempt: 2,
+        retry_delay_ms: 0,
+        workos_error_name: "OauthException",
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("records referral checkout linkage without copying referral data into Stripe metadata", async () => {
     mockListOrganizationMemberships.mockResolvedValue({
       data: [],

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -79,6 +79,53 @@ function getEnvironment(): string {
 
 const CHECKOUT_SESSION_PAGE_SIZE = 100;
 const MAX_CHECKOUT_SESSION_PAGES = 5;
+const WORKOS_UPDATE_RETRY_DELAY_MS = process.env.NODE_ENV === "test" ? 0 : 250;
+
+function isWorkOSRequestTimeout(error: unknown): boolean {
+  return error instanceof Error && /request timeout/i.test(error.message);
+}
+
+async function attachStripeCustomerToOrganization({
+  organizationId,
+  customerId,
+  userId,
+  requestId,
+}: {
+  organizationId: string;
+  customerId: string;
+  userId: string;
+  requestId: string;
+}): Promise<void> {
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    try {
+      await workos.organizations.updateOrganization({
+        organization: organizationId,
+        stripeCustomerId: customerId,
+      });
+      return;
+    } catch (error) {
+      if (!isWorkOSRequestTimeout(error) || attempt === 2) throw error;
+
+      logger.warn("Retrying timed-out WorkOS organization update", {
+        event: "billing.workos_organization_update_retry_scheduled",
+        request_id: requestId,
+        service: "hackerai-web",
+        environment: getEnvironment(),
+        route: "/api/subscribe",
+        user_id: userId,
+        organization_id: organizationId,
+        stripe_customer_id: customerId,
+        attempt,
+        next_attempt: attempt + 1,
+        retry_delay_ms: WORKOS_UPDATE_RETRY_DELAY_MS,
+        workos_error_name: error instanceof Error ? error.name : typeof error,
+      });
+      await new Promise((resolve) =>
+        setTimeout(resolve, WORKOS_UPDATE_RETRY_DELAY_MS),
+      );
+    }
+  }
+}
 
 async function findReusableCheckoutSession({
   customerId,
@@ -119,6 +166,7 @@ async function findReusableCheckoutSession({
 }
 
 export const POST = async (req: NextRequest) => {
+  const requestId = req.headers.get("x-vercel-id") ?? "unknown";
   let shouldClearReferralCookies = false;
   const json = (body: unknown, init?: ResponseInit) => {
     const response = NextResponse.json(body, init);
@@ -370,9 +418,11 @@ export const POST = async (req: NextRequest) => {
     if (shouldAttachCustomerToOrganization) {
       // Update WorkOS organization with Stripe customer ID
       // This will allow WorkOS to automatically add entitlements to the access token
-      await workos.organizations.updateOrganization({
-        organization: organization.id,
-        stripeCustomerId: customer.id,
+      await attachStripeCustomerToOrganization({
+        organizationId: organization.id,
+        customerId: customer.id,
+        userId,
+        requestId,
       });
     }
 
@@ -472,7 +522,7 @@ export const POST = async (req: NextRequest) => {
       });
       logger.warn("Reused an open Stripe Checkout Session", {
         event: "billing.checkout_session_reused",
-        request_id: req.headers.get("x-vercel-id") ?? "unknown",
+        request_id: requestId,
         service: "hackerai-web",
         environment: getEnvironment(),
         route: "/api/subscribe",
@@ -592,7 +642,7 @@ export const POST = async (req: NextRequest) => {
       error instanceof Error ? error : undefined,
       {
         event: "billing.subscribe_request_failed",
-        request_id: req.headers.get("x-vercel-id") ?? "unknown",
+        request_id: requestId,
         service: "hackerai-web",
         environment: getEnvironment(),
         route: "/api/subscribe",

--- a/app/api/workos/webhook/__tests__/route.test.ts
+++ b/app/api/workos/webhook/__tests__/route.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+const mockLoggerWarn = jest.fn();
+
+jest.mock("next/server", () => ({
+  after: jest.fn(),
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: ResponseInit) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    warn: mockLoggerWarn,
+  },
+}));
+
+describe("POST /api/workos/webhook", () => {
+  it("treats a missing signature as a warning-level client rejection", async () => {
+    const { POST } = await import("../route");
+    const request = {
+      headers: {
+        get: jest.fn((name: string) =>
+          name === "x-vercel-id" ? "iad1::request-1" : null,
+        ),
+      },
+    } as any;
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({ error: "Missing workos-signature header" });
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "Rejected WorkOS webhook without a signature",
+      expect.objectContaining({
+        event: "workos.webhook_missing_signature",
+        request_id: "iad1::request-1",
+        service: "hackerai-web",
+        route: "/api/workos/webhook",
+      }),
+    );
+  });
+});

--- a/app/api/workos/webhook/route.ts
+++ b/app/api/workos/webhook/route.ts
@@ -6,6 +6,7 @@ import { workos } from "@/app/api/workos";
 import { captureUserSignedUp } from "@/lib/analytics/user-signup";
 import { phLogger } from "@/lib/posthog/server";
 import { createFreeQuotaSubject } from "@/lib/auth/free-quota-subject";
+import { logger } from "@/lib/logger";
 
 export const runtime = "nodejs";
 
@@ -21,7 +22,13 @@ export async function POST(req: NextRequest) {
   const signature = req.headers.get("workos-signature");
 
   if (!signature) {
-    console.error("[WorkOS Webhook] Missing workos-signature header");
+    logger.warn("Rejected WorkOS webhook without a signature", {
+      event: "workos.webhook_missing_signature",
+      request_id: req.headers.get("x-vercel-id") ?? "unknown",
+      service: "hackerai-web",
+      environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+      route: "/api/workos/webhook",
+    });
     return NextResponse.json(
       { error: "Missing workos-signature header" },
       { status: 400 },

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -288,6 +288,8 @@ export const createChatHandler = () => {
           chatId,
           endpoint,
           abortController: userStopSignal,
+          requestId: req.headers.get("x-vercel-id") ?? undefined,
+          userId,
         });
       }
 

--- a/lib/billing/__tests__/fraud-refund.test.ts
+++ b/lib/billing/__tests__/fraud-refund.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "@jest/globals";
+import { getRemainingRefundAmountCents } from "../fraud-refund";
+
+describe("getRemainingRefundAmountCents", () => {
+  it("returns the full charge amount when nothing has been refunded", () => {
+    expect(
+      getRemainingRefundAmountCents({ amount: 20_000, amount_refunded: 0 }),
+    ).toBe(20_000);
+  });
+
+  it("returns only the remaining amount after a partial refund", () => {
+    expect(
+      getRemainingRefundAmountCents({
+        amount: 20_000,
+        amount_refunded: 19_140,
+      }),
+    ).toBe(860);
+  });
+
+  it("never returns a negative refund amount", () => {
+    expect(
+      getRemainingRefundAmountCents({ amount: 2_000, amount_refunded: 2_000 }),
+    ).toBe(0);
+  });
+});

--- a/lib/billing/fraud-refund.ts
+++ b/lib/billing/fraud-refund.ts
@@ -1,0 +1,7 @@
+import type Stripe from "stripe";
+
+export function getRemainingRefundAmountCents(
+  charge: Pick<Stripe.Charge, "amount" | "amount_refunded">,
+): number {
+  return Math.max(0, charge.amount - charge.amount_refunded);
+}

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -46,6 +46,7 @@ const loadSaveMessageWithMocks = async () => {
     getMessagesByChatId,
     saveChat,
     saveMessage,
+    setActiveTriggerRun,
   } = await import("../actions");
   return {
     deleteChatForBackend,
@@ -57,6 +58,7 @@ const loadSaveMessageWithMocks = async () => {
     mockQuery,
     saveChat,
     saveMessage,
+    setActiveTriggerRun,
   };
 };
 
@@ -332,6 +334,84 @@ describe("getChatById", () => {
       expect(errorSpy).toHaveBeenCalledTimes(1);
     } finally {
       warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("classifies and sanitizes Convex Cloudflare 5xx pages", async () => {
+    const { getChatById, mockPhEvent, mockQuery } =
+      await loadSaveMessageWithMocks();
+    const cloudflareError = new Error(`<!DOCTYPE html>
+      <html><head><title>haiusercontent.com | 520: Web server is returning an unknown error</title></head>
+      <body>Error code 520 Cloudflare Ray ID: <strong>a18f8f8c09cee629</strong> Your IP: 192.0.2.1</body></html>`);
+    mockQuery.mockRejectedValue(cloudflareError as never);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const thrown = await getChatById({ id: "chat-1" }).catch(
+        (error) => error,
+      );
+
+      expect(thrown).toMatchObject({
+        type: "offline",
+        surface: "database",
+        statusCode: 503,
+        metadata: expect.objectContaining({
+          db_operation: "chats.getChatById",
+          db_error_message: "Convex upstream returned HTTP 520",
+          db_error_kind: "convex_upstream_http_error",
+          db_upstream_status_code: 520,
+          db_upstream_ray_id: "a18f8f8c09cee629",
+          db_retry_reason: "convex_upstream_http_5xx",
+        }),
+      });
+      expect(mockQuery).toHaveBeenCalledTimes(3);
+      expect(JSON.stringify(thrown.metadata)).not.toContain("192.0.2.1");
+      expect(mockPhEvent).toHaveBeenCalledWith(
+        "database_operation_failed",
+        expect.objectContaining({
+          db_error_message: "Convex upstream returned HTTP 520",
+          db_upstream_status_code: 520,
+          db_upstream_ray_id: "a18f8f8c09cee629",
+        }),
+      );
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+});
+
+describe("setActiveTriggerRun", () => {
+  it("preserves transient database failures with queryable run metadata", async () => {
+    const { mockMutation, setActiveTriggerRun } =
+      await loadSaveMessageWithMocks();
+    mockMutation.mockRejectedValue(new TypeError("fetch failed") as never);
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(
+        setActiveTriggerRun({
+          chatId: "chat-1",
+          triggerRunId: "run-1",
+          expectedRunId: "run-0",
+        }),
+      ).rejects.toMatchObject({
+        type: "offline",
+        surface: "database",
+        statusCode: 503,
+        metadata: expect.objectContaining({
+          db_operation: "chats.setActiveTriggerRun",
+          db_retry_reason: "network_fetch_failed",
+          chat_id: "chat-1",
+          trigger_run_id: "run-1",
+          expected_run_id: "run-0",
+        }),
+      });
+    } finally {
       errorSpy.mockRestore();
     }
   });

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -369,6 +369,11 @@ describe("getChatById", () => {
       });
       expect(mockQuery).toHaveBeenCalledTimes(3);
       expect(JSON.stringify(thrown.metadata)).not.toContain("192.0.2.1");
+      expect(thrown.message).not.toContain("192.0.2.1");
+      expect(thrown.cause).toBe(
+        "Database temporarily unavailable: chats.getChatById: Convex upstream returned HTTP 520",
+      );
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain("192.0.2.1");
       expect(mockPhEvent).toHaveBeenCalledWith(
         "database_operation_failed",
         expect.objectContaining({

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -196,6 +196,48 @@ const truncateDiagnosticString = (value: string): string =>
     ? `${value.slice(0, MAX_DATABASE_ERROR_MESSAGE_LENGTH)}...`
     : value;
 
+type UpstreamHttpError = {
+  statusCode: number;
+  rayId?: string;
+};
+
+const getUpstreamHttpError = (
+  message: string,
+): UpstreamHttpError | undefined => {
+  if (!/<(?:!DOCTYPE|html)\b/i.test(message)) return undefined;
+  if (!/cloudflare|cf-error-details|haiusercontent\.com/i.test(message)) {
+    return undefined;
+  }
+
+  const statusMatch =
+    message.match(/<title>[^<|]+\|\s*(5\d{2}):/i) ??
+    message.match(/Error code\s+(5\d{2})/i);
+  if (!statusMatch) return undefined;
+
+  return {
+    statusCode: Number(statusMatch[1]),
+    rayId: message.match(
+      /Cloudflare Ray ID:\s*(?:<[^>]+>)*\s*([a-z0-9]+)/i,
+    )?.[1],
+  };
+};
+
+const getDatabaseErrorDiagnostic = (error: unknown) => {
+  const rawMessage = stringifyError(error);
+  const upstreamHttpError = getUpstreamHttpError(rawMessage);
+  if (!upstreamHttpError) {
+    return {
+      message: truncateDiagnosticString(rawMessage),
+      upstreamHttpError: undefined,
+    };
+  }
+
+  return {
+    message: `Convex upstream returned HTTP ${upstreamHttpError.statusCode}`,
+    upstreamHttpError,
+  };
+};
+
 const getConvexRequestIdFromMessage = (message: string): string | undefined => {
   const match = message.match(/\[Request ID:\s*([^\]\s]+)\]/i);
   return match?.[1];
@@ -241,12 +283,17 @@ const getDatabaseFailureStage = (data: unknown): string | undefined =>
 const getRetryableDatabaseErrorReason = (
   error: unknown,
 ): string | undefined => {
+  const rawErrorMessage = stringifyError(error);
+  if (getUpstreamHttpError(rawErrorMessage)) {
+    return "convex_upstream_http_5xx";
+  }
+
   const dbErrorData = getErrorData(error);
   const dbErrorCode = getDatabaseErrorCode(dbErrorData);
   const dbCauseErrorCode = getDatabaseCauseErrorCode(dbErrorData);
   const errorText = [
     error instanceof Error ? error.name : undefined,
-    stringifyError(error),
+    rawErrorMessage,
     dbErrorCode,
     dbCauseErrorCode,
     getObjectString(dbErrorData, "causeName"),
@@ -373,7 +420,8 @@ const databaseError = (
   metadata: Record<string, unknown> = {},
 ) => {
   const dbErrorName = error instanceof Error ? error.name : typeof error;
-  const dbErrorMessage = truncateDiagnosticString(stringifyError(error));
+  const { message: dbErrorMessage, upstreamHttpError } =
+    getDatabaseErrorDiagnostic(error);
   const dbErrorData = getErrorData(error);
   const isChatNotFound = isChatNotFoundMessageSaveError(operation, dbErrorData);
   const isChatCanceled = isChatCanceledMessageSaveError(operation, dbErrorData);
@@ -424,6 +472,9 @@ const databaseError = (
     db_cause_error_code: getDatabaseCauseErrorCode(dbErrorData),
     db_failure_stage: getDatabaseFailureStage(dbErrorData),
     db_retry_reason: retryReason,
+    db_error_kind: upstreamHttpError ? "convex_upstream_http_error" : undefined,
+    db_upstream_status_code: upstreamHttpError?.statusCode,
+    db_upstream_ray_id: upstreamHttpError?.rayId,
     ...metadata,
   };
 
@@ -1372,10 +1423,11 @@ export async function setActiveTriggerRun({
       ...(expectedRunId !== undefined ? { expectedRunId } : {}),
     });
   } catch (error) {
-    throw new ChatSDKError(
-      "bad_request:database",
-      "Failed to set active trigger run",
-    );
+    throw databaseError("chats.setActiveTriggerRun", error, {
+      chat_id: chatId,
+      trigger_run_id: triggerRunId,
+      expected_run_id: expectedRunId,
+    });
   }
 }
 

--- a/lib/utils/__tests__/stream-cancellation.test.ts
+++ b/lib/utils/__tests__/stream-cancellation.test.ts
@@ -1,15 +1,17 @@
 import {
+  afterEach,
+  beforeEach,
   describe,
   expect,
   it,
-  beforeEach,
-  afterEach,
   jest,
 } from "@jest/globals";
 
 const mockCreateRedisSubscriber = jest.fn();
 const mockGetCancellationStatus = jest.fn();
+const mockPhInfo = jest.fn();
 const mockPhLoggerWarn = jest.fn();
+const mockLoggerWarn = jest.fn();
 
 jest.mock("@/lib/utils/redis-pubsub", () => ({
   createRedisSubscriber: mockCreateRedisSubscriber,
@@ -24,8 +26,14 @@ jest.mock("@/lib/db/actions", () => ({
 jest.mock("@/lib/posthog/server", () => ({
   phLogger: {
     warn: mockPhLoggerWarn,
-    info: jest.fn(),
+    info: mockPhInfo,
     error: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    warn: mockLoggerWarn,
   },
 }));
 
@@ -97,5 +105,59 @@ describe("createCancellationSubscriber", () => {
     expect(onStop).toHaveBeenCalledTimes(1);
 
     await subscriber.stop();
+  });
+});
+
+describe("createPreemptiveTimeout", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("aborts with a one-minute cleanup buffer and emits correlated logs", async () => {
+    const { createPreemptiveTimeout } = await import("../stream-cancellation");
+    const abortController = new AbortController();
+    const abortSpy = jest.spyOn(abortController, "abort");
+
+    const timeout = createPreemptiveTimeout({
+      chatId: "chat-1",
+      endpoint: "/api/chat",
+      abortController,
+      requestId: "iad1::request-1",
+      userId: "user-1",
+    });
+
+    jest.advanceTimersByTime(359_999);
+    expect(abortSpy).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(abortSpy).toHaveBeenCalledTimes(1);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "Preemptive timeout triggered",
+      expect.objectContaining({
+        event: "chat.preemptive_timeout_triggered",
+        request_id: "iad1::request-1",
+        user_id: "user-1",
+        chat_id: "chat-1",
+        endpoint: "/api/chat",
+        max_duration_seconds: 420,
+        safety_buffer_seconds: 60,
+        max_stream_time_ms: 360_000,
+      }),
+    );
+    expect(mockPhInfo).toHaveBeenCalledWith(
+      "Preemptive timeout triggered",
+      expect.objectContaining({
+        event: "chat.preemptive_timeout_triggered",
+        request_id: "iad1::request-1",
+        userId: "user-1",
+      }),
+    );
+
+    timeout.clear();
   });
 });

--- a/lib/utils/stream-cancellation.ts
+++ b/lib/utils/stream-cancellation.ts
@@ -7,6 +7,7 @@ import {
   getCancelChannel,
 } from "@/lib/utils/redis-pubsub";
 import { phLogger } from "@/lib/posthog/server";
+import { logger } from "@/lib/logger";
 
 type PollOptions = {
   chatId: string;
@@ -22,6 +23,8 @@ type PreemptiveTimeoutOptions = {
   chatId: string;
   endpoint: ApiEndpoint;
   abortController: AbortController;
+  requestId?: string;
+  userId?: string;
   safetyBuffer?: number;
 };
 
@@ -258,7 +261,9 @@ export const createPreemptiveTimeout = ({
   chatId,
   endpoint,
   abortController,
-  safetyBuffer = 30,
+  requestId,
+  userId,
+  safetyBuffer = 60,
 }: PreemptiveTimeoutOptions) => {
   // Use endpoint-specific max duration based on Vercel function limits
   const maxDuration = endpoint === "/api/chat" ? 420 : 800;
@@ -272,14 +277,24 @@ export const createPreemptiveTimeout = ({
     triggerTime = Date.now();
     isPreemptive = true;
 
-    phLogger.info("Preemptive timeout triggered", {
-      chatId,
+    const fields = {
+      event: "chat.preemptive_timeout_triggered",
+      request_id: requestId ?? "unknown",
+      service: "hackerai-web",
+      environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+      user_id: userId,
+      chat_id: chatId,
       endpoint,
-      maxDuration,
-      safetyBuffer,
-      maxStreamTimeMs: maxStreamTime,
-      elapsedMs: triggerTime - startTime,
-      triggerTime: new Date(triggerTime).toISOString(),
+      max_duration_seconds: maxDuration,
+      safety_buffer_seconds: safetyBuffer,
+      max_stream_time_ms: maxStreamTime,
+      elapsed_ms: triggerTime - startTime,
+    };
+    logger.warn("Preemptive timeout triggered", fields);
+    phLogger.info("Preemptive timeout triggered", {
+      ...fields,
+      userId,
+      trigger_time: new Date(triggerTime).toISOString(),
     });
 
     abortController.abort();

--- a/proxy.ts
+++ b/proxy.ts
@@ -77,9 +77,11 @@ function isUnsupportedRootPageRequest(
   if (!ROOT_PAGE_PATHS.has(pathname)) return false;
   if (request.method === "GET" || request.method === "HEAD") return false;
 
-  return !(
-    request.method === "POST" && request.headers.has(NEXT_ACTION_HEADER)
-  );
+  return !isNextActionRequest(request);
+}
+
+function isNextActionRequest(request: NextRequest): boolean {
+  return request.method === "POST" && request.headers.has(NEXT_ACTION_HEADER);
 }
 
 function isBrowserRequest(request: NextRequest): boolean {
@@ -128,6 +130,23 @@ function buildEndedSessionResponse(
   request: NextRequest,
   pathname: string,
 ): NextResponse {
+  // A Server Action still runs after middleware. Letting an ended session
+  // through on a public page means the action's `withAuth()` call has no
+  // AuthKit middleware context and throws a misleading 500 instead of a clean
+  // authentication response.
+  if (isNextActionRequest(request)) {
+    return withSessionCookieCleared(
+      NextResponse.json(
+        {
+          code: "unauthorized:auth",
+          message: "You need to sign in before continuing.",
+          cause: "Session expired or invalid",
+        },
+        { status: 401 },
+      ),
+    );
+  }
+
   if (isUnauthenticatedPath(pathname)) {
     return withSessionCookieCleared(
       withReferralCookie(request, NextResponse.next()),


### PR DESCRIPTION
## Summary
- refund only the remaining refundable balance for partially refunded early-fraud-warning charges
- retry timed-out WorkOS organization updates once during checkout and reject stale-session Server Actions with a clean 401
- classify Convex/Cloudflare HTML 5xx responses as transient database failures, sanitize their diagnostics, and preserve status/Ray ID metadata
- add correlated preemptive-timeout logging with a larger cleanup buffer
- downgrade expected MFA lockouts and unsigned WorkOS webhook requests from error-level noise
- add focused regression coverage for each changed path

## Why
Today's production Vercel review found 73 unique errors after deduplicating event IDs. The actionable clusters were a partial-refund mismatch, six checkout WorkOS timeouts, eleven stale-session Server Action failures, two expected MFA lockouts, two hard chat timeouts, and one unsigned webhook request. A two-minute Convex/Cloudflare outage accounted for the largest burst; this PR improves retry/status behavior and prevents raw HTML/IP content from polluting diagnostics while retaining useful upstream correlation.

## Validation
- `jest --runTestsByPath __tests__/proxy.test.ts app/api/subscribe/__tests__/route.test.ts app/api/mfa/verify/__tests__/route.test.ts app/api/workos/webhook/__tests__/route.test.ts lib/billing/__tests__/fraud-refund.test.ts lib/db/__tests__/actions-save-message.test.ts app/api/chat/[id]/stream/__tests__/route.test.ts lib/utils/__tests__/stream-cancellation.test.ts --runInBand` (8 suites, 52 tests)
- focused ESLint on all changed TypeScript files
- `git diff --check`
- `tsc --noEmit` reaches only the existing workspace dependency error: `packages/local/src/index.ts(17,23): Cannot find module 'ws'`

## Manual verification
- Replay an early fraud warning for a partially refunded charge and confirm only the remaining balance is refunded before the customer is blocked.
- Expire a WorkOS session, invoke a billing Server Action from `/` or `/download`, and confirm the request returns 401, clears the session cookie, and does not emit a `withAuth` 500.
- Retry checkout while the first WorkOS organization update times out and confirm the second attempt succeeds with `billing.workos_organization_update_retry_scheduled`.
- Run an Ask request past six minutes and confirm `chat.preemptive_timeout_triggered` includes the Vercel request ID and the response shuts down before the 420-second hard timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Server Actions auth handling for ended/invalid sessions: returns a 401 JSON response, clears the session cookie, and avoids redirects.
  * MFA verification now returns a clear 400 message for “too many failed attempts” scenarios.
  * Early fraud warning refunds now only refund the remaining refundable amount and skip already-completed refunds.
* **Reliability**
  * Improved WorkOS subscription attachment by retrying on temporary timeouts with scheduled warnings.
  * Enhanced chat stream timeout behavior with safer abort timing and richer tracking.
  * Upgraded database error diagnostics and retry classification for upstream HTTP 5xx failures.
* **Tests**
  * Added/expanded Jest coverage for the above behaviors and webhook signature handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->