### PR TITLE
Clarify automatic Agent continuation status

### DIFF
--- a/app/components/DataStreamProvider.tsx
+++ b/app/components/DataStreamProvider.tsx
@@ -17,6 +17,7 @@ export type ScopedDataUIPart = DataUIPart<any> & {
 interface DataStreamStateValue {
   dataStream: ScopedDataUIPart[];
   isAutoResuming: boolean;
+  isAutoContinuing: boolean;
   autoContinueCount: number;
 }
 
@@ -24,6 +25,7 @@ interface DataStreamStateValue {
 interface DataStreamDispatchValue {
   setDataStream: React.Dispatch<React.SetStateAction<ScopedDataUIPart[]>>;
   setIsAutoResuming: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsAutoContinuing: React.Dispatch<React.SetStateAction<boolean>>;
   setAutoContinueCount: React.Dispatch<React.SetStateAction<number>>;
 }
 
@@ -39,17 +41,33 @@ export function DataStreamProvider({
 }) {
   const [dataStream, setDataStream] = useState<ScopedDataUIPart[]>([]);
   const [isAutoResuming, setIsAutoResuming] = useState<boolean>(false);
+  const [isAutoContinuing, setIsAutoContinuing] = useState<boolean>(false);
   const [autoContinueCount, setAutoContinueCount] = useState<number>(0);
 
   const stateValue = useMemo(
-    () => ({ dataStream, isAutoResuming, autoContinueCount }),
-    [dataStream, isAutoResuming, autoContinueCount],
+    () => ({
+      dataStream,
+      isAutoResuming,
+      isAutoContinuing,
+      autoContinueCount,
+    }),
+    [dataStream, isAutoResuming, isAutoContinuing, autoContinueCount],
   );
 
   const dispatchValue = useMemo(
-    () => ({ setDataStream, setIsAutoResuming, setAutoContinueCount }),
+    () => ({
+      setDataStream,
+      setIsAutoResuming,
+      setIsAutoContinuing,
+      setAutoContinueCount,
+    }),
     // setState functions from useState are stable — this memo runs once
-    [setDataStream, setIsAutoResuming, setAutoContinueCount],
+    [
+      setDataStream,
+      setIsAutoResuming,
+      setIsAutoContinuing,
+      setAutoContinueCount,
+    ],
   );
 
   return (
@@ -61,7 +79,7 @@ export function DataStreamProvider({
   );
 }
 
-/** Subscribe to stream state (dataStream, isAutoResuming, autoContinueCount).
+/** Subscribe to stream state (dataStream, resume state, autoContinueCount).
  *  Components using this will re-render on every state change. */
 export function useDataStreamState() {
   const context = useContext(DataStreamStateContext);

--- a/app/components/FinishReasonNotice.tsx
+++ b/app/components/FinishReasonNotice.tsx
@@ -27,13 +27,23 @@ export const FinishReasonNotice = ({
   agentRunSpendCapPremiumContinuationAllowed,
   onContinue,
 }: FinishReasonNoticeProps) => {
-  const { isAutoResuming } = useDataStreamState();
+  const { isAutoResuming, isAutoContinuing } = useDataStreamState();
   const [hasContinued, setHasContinued] = useState(false);
+
+  if (!finishReason) return null;
+
+  if (isAutoContinuing) {
+    return (
+      <div className="mt-2 w-full" role="status" aria-live="polite">
+        <div className="bg-muted text-muted-foreground rounded-lg px-3 py-2 border border-border">
+          Continuing automatically…
+        </div>
+      </div>
+    );
+  }
 
   if (isAutoResuming) return null;
   if (hasContinued) return null;
-
-  if (!finishReason) return null;
 
   const getNoticeContent = () => {
     if (finishReason === "tool-calls") {

--- a/app/components/__mocks__/DataStreamProvider.tsx
+++ b/app/components/__mocks__/DataStreamProvider.tsx
@@ -3,26 +3,31 @@ import { ReactNode } from "react";
 // Create stable mock references
 const mockSetDataStream = jest.fn();
 const mockSetIsAutoResuming = jest.fn();
+const mockSetIsAutoContinuing = jest.fn();
 const mockSetAutoContinueCount = jest.fn();
 
 export const useDataStream = () => ({
   dataStream: [],
   isAutoResuming: false,
+  isAutoContinuing: false,
   autoContinueCount: 0,
   setDataStream: mockSetDataStream,
   setIsAutoResuming: mockSetIsAutoResuming,
+  setIsAutoContinuing: mockSetIsAutoContinuing,
   setAutoContinueCount: mockSetAutoContinueCount,
 });
 
 export const useDataStreamState = () => ({
   dataStream: [],
   isAutoResuming: false,
+  isAutoContinuing: false,
   autoContinueCount: 0,
 });
 
 export const useDataStreamDispatch = () => ({
   setDataStream: mockSetDataStream,
   setIsAutoResuming: mockSetIsAutoResuming,
+  setIsAutoContinuing: mockSetIsAutoContinuing,
   setAutoContinueCount: mockSetAutoContinueCount,
 });
 

--- a/app/components/__tests__/FinishReasonNotice.test.tsx
+++ b/app/components/__tests__/FinishReasonNotice.test.tsx
@@ -11,23 +11,29 @@ import type { ChatMode, SelectedModel } from "@/types/chat";
 
 function DataStreamSetter({
   isAutoResuming,
+  isAutoContinuing,
   autoContinueCount,
   children,
 }: {
   isAutoResuming?: boolean;
+  isAutoContinuing?: boolean;
   autoContinueCount?: number;
   children: React.ReactNode;
 }) {
-  const { setIsAutoResuming, setAutoContinueCount } = useDataStream();
+  const { setIsAutoResuming, setIsAutoContinuing, setAutoContinueCount } =
+    useDataStream();
 
   React.useEffect(() => {
     if (isAutoResuming !== undefined) setIsAutoResuming(isAutoResuming);
+    if (isAutoContinuing !== undefined) setIsAutoContinuing(isAutoContinuing);
     if (autoContinueCount !== undefined)
       setAutoContinueCount(autoContinueCount);
   }, [
     isAutoResuming,
+    isAutoContinuing,
     autoContinueCount,
     setIsAutoResuming,
+    setIsAutoContinuing,
     setAutoContinueCount,
   ]);
 
@@ -43,7 +49,11 @@ interface RenderNoticeProps {
 
 function renderNotice(
   props: RenderNoticeProps,
-  contextOverrides?: { isAutoResuming?: boolean; autoContinueCount?: number },
+  contextOverrides?: {
+    isAutoResuming?: boolean;
+    isAutoContinuing?: boolean;
+    autoContinueCount?: number;
+  },
 ) {
   return render(
     <DataStreamProvider>
@@ -55,6 +65,21 @@ function renderNotice(
 }
 
 describe("FinishReasonNotice", () => {
+  it("shows automatic continuation status without a manual Continue button", () => {
+    const onContinue = jest.fn();
+    renderNotice(
+      { finishReason: "length", mode: "agent", onContinue },
+      { isAutoResuming: false, isAutoContinuing: true },
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Continuing automatically…",
+    );
+    expect(
+      screen.queryByRole("button", { name: /continue/i }),
+    ).not.toBeInTheDocument();
+  });
+
   describe("suppression cases (should render nothing)", () => {
     it.each([
       { finishReason: "length", mode: "agent" as ChatMode },

--- a/app/hooks/__tests__/useAutoContinue.test.ts
+++ b/app/hooks/__tests__/useAutoContinue.test.ts
@@ -361,6 +361,33 @@ describe("useAutoContinue", () => {
     expect(result.current.isAutoContinuing).toBe(false);
   });
 
+  it("clears automatic continuation and its pending signal on error", () => {
+    const sendMessage = jest.fn();
+    let params = buildParams({ status: "streaming", sendMessage });
+
+    const { result, rerender } = renderHook(
+      (p: UseAutoContinueParams) => useTestHarness(p),
+      { initialProps: params, wrapper: createWrapper() },
+    );
+
+    pushAutoContinue(result);
+    expect(result.current.isAutoContinuing).toBe(true);
+
+    params = { ...params, status: "error" };
+    rerender(params);
+
+    expect(result.current.isAutoContinuing).toBe(false);
+    expect(result.current.isAutoResuming).toBe(false);
+
+    params = { ...params, status: "ready" };
+    rerender(params);
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("resets isAutoResuming to false when status transitions to streaming", () => {
     let params = buildParams({ status: "streaming" });
 

--- a/app/hooks/__tests__/useAutoContinue.test.ts
+++ b/app/hooks/__tests__/useAutoContinue.test.ts
@@ -16,8 +16,15 @@ type DataStreamEntry = { type: string; data?: unknown; __chatId?: string };
 
 function useTestHarness(params: UseAutoContinueParams) {
   const autoContinue = useAutoContinue(params);
-  const { setDataStream, isAutoResuming, autoContinueCount } = useDataStream();
-  return { ...autoContinue, setDataStream, isAutoResuming, autoContinueCount };
+  const { setDataStream, isAutoResuming, isAutoContinuing, autoContinueCount } =
+    useDataStream();
+  return {
+    ...autoContinue,
+    setDataStream,
+    isAutoResuming,
+    isAutoContinuing,
+    autoContinueCount,
+  };
 }
 
 function createWrapper() {
@@ -74,6 +81,7 @@ describe("useAutoContinue", () => {
     pushAutoContinue(result);
 
     expect(result.current.isAutoResuming).toBe(true);
+    expect(result.current.isAutoContinuing).toBe(true);
   });
 
   it("ignores data-auto-continue from another chat", () => {
@@ -99,6 +107,7 @@ describe("useAutoContinue", () => {
     });
 
     expect(sendMessage).not.toHaveBeenCalled();
+    expect(result.current.isAutoContinuing).toBe(false);
   });
 
   it("sends message with full body when signal arrives during streaming then status becomes ready", () => {
@@ -253,6 +262,7 @@ describe("useAutoContinue", () => {
 
     expect(sendMessage).toHaveBeenCalledTimes(MAX_AUTO_CONTINUES);
     expect(result.current.isAutoResuming).toBe(false);
+    expect(result.current.isAutoContinuing).toBe(false);
   });
 
   it("increments autoContinueCount in context after each auto-continue", () => {
@@ -303,12 +313,52 @@ describe("useAutoContinue", () => {
     });
 
     expect(result.current.autoContinueCount).toBe(1);
+    expect(result.current.isAutoContinuing).toBe(true);
 
     act(() => {
       result.current.resetAutoContinueCount();
     });
 
     expect(result.current.autoContinueCount).toBe(0);
+    expect(result.current.isAutoContinuing).toBe(false);
+  });
+
+  it("keeps automatic continuation active until the follow-up run settles", () => {
+    const sendMessage = jest.fn();
+    let params = buildParams({ status: "streaming", sendMessage });
+
+    const { result, rerender } = renderHook(
+      (p: UseAutoContinueParams) => useTestHarness(p),
+      { initialProps: params, wrapper: createWrapper() },
+    );
+
+    pushAutoContinue(result);
+
+    params = { ...params, status: "ready" };
+    rerender(params);
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    params = { ...params, status: "submitted" };
+    rerender(params);
+    expect(result.current.isAutoContinuing).toBe(true);
+
+    params = { ...params, status: "streaming" };
+    rerender(params);
+    expect(result.current.isAutoContinuing).toBe(true);
+
+    params = { ...params, status: "ready" };
+    rerender(params);
+    act(() => {
+      jest.advanceTimersByTime(249);
+    });
+    expect(result.current.isAutoContinuing).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current.isAutoContinuing).toBe(false);
   });
 
   it("resets isAutoResuming to false when status transitions to streaming", () => {

--- a/app/hooks/useAutoContinue.ts
+++ b/app/hooks/useAutoContinue.ts
@@ -12,6 +12,7 @@ import { useLatestRef } from "./useLatestRef";
 export const MAX_AUTO_CONTINUES = 5;
 export const AUTO_CONTINUE_PROMPT =
   "Continue from the latest saved progress. Do not restart the original task or repeat completed work.";
+const AUTO_CONTINUE_SETTLE_DELAY_MS = 250;
 
 export interface UseAutoContinueParams {
   chatId: string;
@@ -40,9 +41,12 @@ export function useAutoContinue({
   selectedModel,
 }: UseAutoContinueParams) {
   const { dataStream } = useDataStreamState();
-  const { setIsAutoResuming, setAutoContinueCount } = useDataStreamDispatch();
+  const { setIsAutoResuming, setIsAutoContinuing, setAutoContinueCount } =
+    useDataStreamDispatch();
   const autoContinueCountRef = useRef(0);
   const pendingAutoContinueRef = useRef(false);
+  const autoContinueRunScheduledRef = useRef(false);
+  const autoContinueRunStartedRef = useRef(false);
   const lastProcessedIndexRef = useRef(0);
 
   const todosRef = useLatestRef(todos);
@@ -53,10 +57,17 @@ export function useAutoContinue({
   const isPartForCurrentChat = (part: ScopedDataUIPart) =>
     part.__chatId === undefined || part.__chatId === chatId;
 
+  const clearAutoContinueLifecycle = useCallback(() => {
+    autoContinueRunScheduledRef.current = false;
+    autoContinueRunStartedRef.current = false;
+    setIsAutoContinuing(false);
+  }, [setIsAutoContinuing]);
+
   useEffect(() => {
     pendingAutoContinueRef.current = false;
     lastProcessedIndexRef.current = 0;
-  }, [chatId]);
+    clearAutoContinueLifecycle();
+  }, [chatId, clearAutoContinueLifecycle]);
 
   // Detect data-auto-continue signal and immediately mark pending
   useEffect(() => {
@@ -66,24 +77,34 @@ export function useAutoContinue({
     if (newParts.some((part) => part.type === "data-auto-continue")) {
       pendingAutoContinueRef.current = true;
       setIsAutoResuming(true);
+      setIsAutoContinuing(true);
     }
     lastProcessedIndexRef.current = currentChatDataStream.length;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataStream, setIsAutoResuming]);
+  }, [dataStream, setIsAutoContinuing, setIsAutoResuming]);
 
   // Fire auto-continue when status is ready and signal was detected.
   // Depends on both `status` and `dataStream` so it re-evaluates when
   // the signal arrives after the stream has already ended (status already "ready").
   useEffect(() => {
     if (status !== "ready" || !pendingAutoContinueRef.current) return;
-    if (hasManuallyStoppedRef.current) return;
-    if (chatMode !== "agent") return;
+    if (hasManuallyStoppedRef.current || chatMode !== "agent") {
+      pendingAutoContinueRef.current = false;
+      clearAutoContinueLifecycle();
+      setIsAutoResuming(false);
+      return;
+    }
     if (autoContinueCountRef.current >= MAX_AUTO_CONTINUES) {
+      pendingAutoContinueRef.current = false;
+      clearAutoContinueLifecycle();
       setIsAutoResuming(false);
       return;
     }
 
     pendingAutoContinueRef.current = false;
+    autoContinueRunScheduledRef.current = true;
+    autoContinueRunStartedRef.current = false;
+    setIsAutoContinuing(true);
     autoContinueCountRef.current += 1;
     setAutoContinueCount(autoContinueCountRef.current);
 
@@ -112,7 +133,9 @@ export function useAutoContinue({
     dataStream,
     chatMode,
     hasManuallyStoppedRef,
+    clearAutoContinueLifecycle,
     setAutoContinueCount,
+    setIsAutoContinuing,
     setIsAutoResuming,
     sendMessageRef,
     todosRef,
@@ -122,17 +145,43 @@ export function useAutoContinue({
   ]);
 
   useEffect(() => {
+    if (status === "submitted" || status === "streaming") {
+      if (autoContinueRunScheduledRef.current) {
+        autoContinueRunStartedRef.current = true;
+      }
+    }
     if (status === "streaming") {
       setIsAutoResuming(false);
     }
   }, [status, setIsAutoResuming]);
 
+  useEffect(() => {
+    if (
+      status !== "ready" ||
+      pendingAutoContinueRef.current ||
+      !autoContinueRunScheduledRef.current ||
+      !autoContinueRunStartedRef.current
+    ) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      if (!pendingAutoContinueRef.current) {
+        clearAutoContinueLifecycle();
+      }
+    }, AUTO_CONTINUE_SETTLE_DELAY_MS);
+
+    return () => clearTimeout(timeout);
+  }, [status, dataStream, clearAutoContinueLifecycle]);
+
   const resetAutoContinueCount = useCallback(() => {
     autoContinueCountRef.current = 0;
     pendingAutoContinueRef.current = false;
     lastProcessedIndexRef.current = 0;
+    clearAutoContinueLifecycle();
+    setIsAutoResuming(false);
     setAutoContinueCount(0);
-  }, [setAutoContinueCount]);
+  }, [clearAutoContinueLifecycle, setAutoContinueCount, setIsAutoResuming]);
 
   return { resetAutoContinueCount };
 }

--- a/app/hooks/useAutoContinue.ts
+++ b/app/hooks/useAutoContinue.ts
@@ -58,6 +58,7 @@ export function useAutoContinue({
     part.__chatId === undefined || part.__chatId === chatId;
 
   const clearAutoContinueLifecycle = useCallback(() => {
+    pendingAutoContinueRef.current = false;
     autoContinueRunScheduledRef.current = false;
     autoContinueRunStartedRef.current = false;
     setIsAutoContinuing(false);
@@ -145,6 +146,12 @@ export function useAutoContinue({
   ]);
 
   useEffect(() => {
+    if (status === "error") {
+      clearAutoContinueLifecycle();
+      setIsAutoResuming(false);
+      return;
+    }
+
     if (status === "submitted" || status === "streaming") {
       if (autoContinueRunScheduledRef.current) {
         autoContinueRunStartedRef.current = true;
@@ -153,7 +160,7 @@ export function useAutoContinue({
     if (status === "streaming") {
       setIsAutoResuming(false);
     }
-  }, [status, setIsAutoResuming]);
+  }, [status, clearAutoContinueLifecycle, setIsAutoResuming]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
## Summary
- track automatic Agent continuation separately from generic stream resume state
- show `Continuing automatically…` without a manual Continue button while the follow-up is pending
- clear the automatic-continuation state after the follow-up chain settles, is stopped, or reaches its retry cap
- add lifecycle and rendering regression coverage

## Root cause
`isAutoResuming` was cleared by normal stream transitions. During the gap before the next Agent request began streaming, the last `length` response could therefore render its manual fallback notice and Continue button even though an automatic continuation had already been scheduled.

## Validation
- `pnpm typecheck`
- `pnpm lint` (passes with six pre-existing warnings)
- `pnpm jest app/hooks/__tests__/useAutoContinue.test.ts app/components/__tests__/FinishReasonNotice.test.tsx --runInBand`
- commit hooks: full Jest suite, 228 suites / 2,245 tests
- focused ESLint and Prettier checks

## Chrome verification
Using the signed-in local app, Trigger.dev 4.5.1 on an isolated dev branch, and a temporary 512-token output cap:
- two real Agent generations ended with `finish_reason: length`
- both handoffs displayed `Continuing automatically…`
- neither handoff displayed the manual fallback or Continue button
- the third generation completed normally with `finish_reason: stop` and the status cleared
- the requested 80-item response reached `AUTO_CONTINUE_UI_COMPLETE`

The temporary output cap was restored to 32,000 before commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer automatic continuation state tracking and messaging.
  * When auto-continuation is active, the UI shows “Continuing automatically…” (aria-live) and hides the manual Continue option.
  * Automatic continuation now persists across intermediate response phases and settles after completion.

* **Bug Fixes**
  * Improved stopping/reset behavior for automatic continuation, including max-attempt limits and manual-stop scenarios.
  * Prevented continuation state from persisting across unrelated chats and ensured errors properly disable further continuation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->