### PR TITLE
Restrict temporary chats to paid users

### DIFF
--- a/app/components/ChatHeader.tsx
+++ b/app/components/ChatHeader.tsx
@@ -84,6 +84,8 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
     !loading && user && !isCheckingProPlan && subscription === "free",
   );
   const showVisibleUpgradeCta = showEmptyStateHeader && showUpgradeCta;
+  const canUseTemporaryChats =
+    !loading && Boolean(user) && !isCheckingProPlan && subscription !== "free";
 
   React.useEffect(() => {
     if (!showVisibleUpgradeCta) return;
@@ -146,7 +148,7 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
               <div className="flex gap-[40px]"></div>
               <div className="flex gap-2 items-center">
                 {/* Temporary Chat Toggle - Desktop */}
-                {!loading && user && (
+                {canUseTemporaryChats && (
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger asChild>
@@ -226,7 +228,7 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
             </div>
             <div className="flex items-center gap-2">
               {/* Temporary Chat Toggle - Mobile */}
-              {!loading && user && (
+              {canUseTemporaryChats && (
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>

--- a/app/components/__tests__/ChatHeader.temporary-chat.test.tsx
+++ b/app/components/__tests__/ChatHeader.temporary-chat.test.tsx
@@ -1,0 +1,75 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { useAuth } from "@workos-inc/authkit-nextjs/components";
+
+let mockSubscription: "free" | "pro" = "free";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+jest.mock("@/app/contexts/GlobalState", () => ({
+  useGlobalState: () => ({
+    toggleChatSidebar: jest.fn(),
+    subscription: mockSubscription,
+    isCheckingProPlan: false,
+    initializeNewChat: jest.fn(),
+    closeSidebar: jest.fn(),
+    setChatSidebarOpen: jest.fn(),
+    temporaryChatsEnabled: false,
+    setTemporaryChatsEnabled: jest.fn(),
+  }),
+}));
+
+jest.mock("@/app/hooks/usePricingDialog", () => ({
+  redirectToPricing: jest.fn(),
+}));
+
+jest.mock("@/app/hooks/useTauri", () => ({
+  navigateToAuth: jest.fn(),
+}));
+
+jest.mock("@/lib/analytics/client", () => ({
+  captureUpgradeCtaImpression: jest.fn(),
+}));
+
+const ChatHeader = require("../ChatHeader")
+  .default as typeof import("../ChatHeader").default;
+
+describe("ChatHeader temporary chat entitlement", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSubscription = "free";
+    jest.mocked(useAuth).mockReturnValue({
+      user: { id: "user_123" },
+      loading: false,
+    } as ReturnType<typeof useAuth>);
+  });
+
+  it("hides the temporary chat toggle from free users", () => {
+    render(<ChatHeader hasMessages={false} hasActiveChat={false} />);
+
+    expect(
+      screen.queryByRole("button", {
+        name: "Toggle temporary chats for new chats",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the temporary chat toggle available to paid users", () => {
+    mockSubscription = "pro";
+
+    render(<ChatHeader hasMessages={false} hasActiveChat={false} />);
+
+    expect(
+      screen.getAllByRole("button", {
+        name: "Toggle temporary chats for new chats",
+      }),
+    ).toHaveLength(2);
+  });
+});

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -492,12 +492,14 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     subscriptionFromEntitlements !== "free"
       ? subscriptionFromEntitlements
       : subscription;
+  const temporaryChatAccessResolved =
+    subscriptionResolved || (!authLoading && !user);
 
   // Remove stale or manually forged temporary-chat state once the user's
   // subscription has been resolved. The API independently enforces this gate.
   useEffect(() => {
     if (
-      !subscriptionResolved ||
+      !temporaryChatAccessResolved ||
       temporaryChatSubscription !== "free" ||
       !temporaryChatsEnabled
     ) {
@@ -508,7 +510,11 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     const url = new URL(window.location.href);
     url.searchParams.delete("temporary-chat");
     window.history.replaceState({}, "", url.toString());
-  }, [subscriptionResolved, temporaryChatsEnabled, temporaryChatSubscription]);
+  }, [
+    temporaryChatAccessResolved,
+    temporaryChatsEnabled,
+    temporaryChatSubscription,
+  ]);
 
   useEffect(() => {
     if (agentFirstDefaultAppliedRef.current) return;

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -487,6 +487,28 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     const urlParams = new URLSearchParams(window.location.search);
     return urlParams.get("temporary-chat") === "true";
   });
+  const temporaryChatSubscription =
+    subscriptionFromEntitlements !== null &&
+    subscriptionFromEntitlements !== "free"
+      ? subscriptionFromEntitlements
+      : subscription;
+
+  // Remove stale or manually forged temporary-chat state once the user's
+  // subscription has been resolved. The API independently enforces this gate.
+  useEffect(() => {
+    if (
+      !subscriptionResolved ||
+      temporaryChatSubscription !== "free" ||
+      !temporaryChatsEnabled
+    ) {
+      return;
+    }
+
+    setTemporaryChatsEnabled(false);
+    const url = new URL(window.location.href);
+    url.searchParams.delete("temporary-chat");
+    window.history.replaceState({}, "", url.toString());
+  }, [subscriptionResolved, temporaryChatsEnabled, temporaryChatSubscription]);
 
   useEffect(() => {
     if (agentFirstDefaultAppliedRef.current) return;
@@ -964,19 +986,29 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   };
 
   // Custom setter for temporary chats that also updates URL
-  const setTemporaryChatsEnabledWithUrl = useCallback((enabled: boolean) => {
-    setTemporaryChatsEnabled(enabled);
-
-    if (typeof window !== "undefined") {
-      const url = new URL(window.location.href);
-      if (enabled) {
-        url.searchParams.set("temporary-chat", "true");
-      } else {
-        url.searchParams.delete("temporary-chat");
+  const setTemporaryChatsEnabledWithUrl = useCallback(
+    (enabled: boolean) => {
+      if (
+        enabled &&
+        (!subscriptionResolved || temporaryChatSubscription === "free")
+      ) {
+        return;
       }
-      window.history.replaceState({}, "", url.toString());
-    }
-  }, []);
+
+      setTemporaryChatsEnabled(enabled);
+
+      if (typeof window !== "undefined") {
+        const url = new URL(window.location.href);
+        if (enabled) {
+          url.searchParams.set("temporary-chat", "true");
+        } else {
+          url.searchParams.delete("temporary-chat");
+        }
+        window.history.replaceState({}, "", url.toString());
+      }
+    },
+    [subscriptionResolved, temporaryChatSubscription],
+  );
 
   // Custom setter for team welcome dialog that also updates URL
   const setTeamWelcomeDialogOpenWithUrl = useCallback((open: boolean) => {

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -42,6 +42,16 @@ function GlobalStateProbe() {
   );
 }
 
+function TemporaryChatProbe() {
+  const { temporaryChatsEnabled } = useGlobalState();
+
+  return (
+    <div data-testid="temporary-chat-enabled">
+      {String(temporaryChatsEnabled)}
+    </div>
+  );
+}
+
 describe("GlobalStateProvider agent defaults", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -56,6 +66,41 @@ describe("GlobalStateProvider agent defaults", () => {
       Promise.resolve({ ok: false }),
     ) as unknown as typeof fetch;
     mockAuthUser([]);
+  });
+
+  it("clears a temporary chat URL request for free users", async () => {
+    window.history.pushState({}, "", "/?temporary-chat=true");
+
+    render(
+      <GlobalStateProvider>
+        <TemporaryChatProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("temporary-chat-enabled")).toHaveTextContent(
+        "false",
+      );
+    });
+    expect(window.location.search).toBe("");
+  });
+
+  it("preserves a temporary chat URL request for paid users", async () => {
+    mockAuthUser(["pro-plan"]);
+    window.history.pushState({}, "", "/?temporary-chat=true");
+
+    render(
+      <GlobalStateProvider>
+        <TemporaryChatProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("temporary-chat-enabled")).toHaveTextContent(
+        "true",
+      );
+    });
+    expect(window.location.search).toBe("?temporary-chat=true");
   });
 
   it("defaults first-time Ultra users to Agent with the auto model and cloud sandbox", async () => {

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -85,6 +85,29 @@ describe("GlobalStateProvider agent defaults", () => {
     expect(window.location.search).toBe("");
   });
 
+  it("clears a temporary chat URL request after unauthenticated auth resolves", async () => {
+    mockAuthUser([], {
+      user: null,
+      loading: false,
+      isAuthenticated: false,
+      organizationId: undefined,
+    });
+    window.history.pushState({}, "", "/?temporary-chat=true");
+
+    render(
+      <GlobalStateProvider>
+        <TemporaryChatProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("temporary-chat-enabled")).toHaveTextContent(
+        "false",
+      );
+    });
+    expect(window.location.search).toBe("");
+  });
+
   it("preserves a temporary chat URL request for paid users", async () => {
     mockAuthUser(["pro-plan"]);
     window.history.pushState({}, "", "/?temporary-chat=true");

--- a/lib/api/__tests__/chat-handler-request-validation.test.ts
+++ b/lib/api/__tests__/chat-handler-request-validation.test.ts
@@ -1,6 +1,29 @@
-import { requireChatMessagesArray } from "@/lib/api/chat-request-validation";
+import {
+  requireBooleanFlag,
+  requireChatMessagesArray,
+} from "@/lib/api/chat-request-validation";
 
 describe("chat-handler request validation", () => {
+  it("accepts only boolean request flags", () => {
+    expect(requireBooleanFlag("temporary", undefined)).toBe(false);
+    expect(requireBooleanFlag("temporary", false)).toBe(false);
+    expect(requireBooleanFlag("temporary", true)).toBe(true);
+
+    expect(() => requireBooleanFlag("temporary", "false")).toThrow(
+      expect.objectContaining({
+        type: "bad_request",
+        surface: "api",
+        statusCode: 400,
+        cause: "Invalid chat request: temporary must be a boolean.",
+        metadata: expect.objectContaining({
+          invalid_request_field: "temporary",
+          invalid_request_field_type: "string",
+          invalid_request_field_reason: "not_boolean",
+        }),
+      }),
+    );
+  });
+
   it("rejects non-array messages as a bad request", () => {
     expect(() => requireChatMessagesArray({ id: "not-array" })).toThrow(
       expect.objectContaining({

--- a/lib/api/__tests__/chat-stream-helpers-free-gates.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-free-gates.test.ts
@@ -1,5 +1,6 @@
 import {
   assertFreeAgentGates,
+  assertTemporaryChatAccess,
   countFileAttachments,
   stripImageAttachments,
 } from "@/lib/api/chat-stream-helpers";
@@ -33,6 +34,38 @@ describe("assertFreeAgentGates", () => {
       }),
     ).toThrow(ChatSDKError);
   });
+});
+
+describe("assertTemporaryChatAccess", () => {
+  it("rejects temporary chats for free users", () => {
+    expect(() =>
+      assertTemporaryChatAccess({
+        isTemporary: true,
+        subscription: "free",
+      }),
+    ).toThrow(ChatSDKError);
+  });
+
+  it("allows regular chats for free users", () => {
+    expect(() =>
+      assertTemporaryChatAccess({
+        isTemporary: false,
+        subscription: "free",
+      }),
+    ).not.toThrow();
+  });
+
+  it.each(["pro", "pro-plus", "ultra", "team"] as const)(
+    "allows temporary chats for %s users",
+    (subscription) => {
+      expect(() =>
+        assertTemporaryChatAccess({
+          isTemporary: true,
+          subscription,
+        }),
+      ).not.toThrow();
+    },
+  );
 });
 
 describe("free-tier image attachment helpers", () => {

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/db/actions";
 import {
   assertFreeAgentGates,
+  assertTemporaryChatAccess,
   buildExtraUsageConfig,
 } from "@/lib/api/chat-stream-helpers";
 import {
@@ -196,6 +197,10 @@ export const createAgentTriggerPost =
           coerceSelectedModel(rawSelectedModel ?? null),
           subscription,
         );
+      assertTemporaryChatAccess({
+        isTemporary: temporary === true,
+        subscription,
+      });
       await assertUserCanMakeCostIncurringRequest(userId);
       const userLocation = geolocation(req);
       const triggerRegion = getTriggerRegionForVercelRequest(req, userLocation);

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -84,6 +84,7 @@ import {
   appendSystemReminderToLastUserMessage,
   injectNotesIntoMessages,
   assertFreeAgentGates,
+  assertTemporaryChatAccess,
   buildExtraUsageConfig,
   estimatePreflightInputTokens,
   getRetryFallbackModel,
@@ -259,6 +260,10 @@ export const createChatHandler = () => {
         );
       await assertUserCanMakeCostIncurringRequest(userId);
       usageRefundTracker.setUser(userId, subscription, organizationId);
+      assertTemporaryChatAccess({
+        isTemporary: temporary === true,
+        subscription,
+      });
       if (subscription === "free") {
         const lock = await acquireFreeRunConcurrencyLock(
           freeUsageSubject,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -153,7 +153,10 @@ import {
   getProviderStatusCode,
   getUserFriendlyProviderError,
 } from "@/lib/utils/error-utils";
-import { requireChatMessagesArray } from "@/lib/api/chat-request-validation";
+import {
+  requireBooleanFlag,
+  requireChatMessagesArray,
+} from "@/lib/api/chat-request-validation";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import {
   createAgentStream,
@@ -215,7 +218,7 @@ export const createChatHandler = () => {
         todos,
         chatId,
         regenerate,
-        temporary,
+        temporary: rawTemporary,
         sandboxPreference,
         selectedModel: rawSelectedModel,
         isAutoContinue,
@@ -227,13 +230,14 @@ export const createChatHandler = () => {
         chatId: string;
         todos?: Todo[];
         regenerate?: boolean;
-        temporary?: boolean;
+        temporary?: unknown;
         sandboxPreference?: SandboxPreference;
         selectedModel?: string;
         isAutoContinue?: boolean;
         useClientMessagesForRegenerate?: boolean;
         limitRescue?: unknown;
       } = await req.json();
+      const temporary = requireBooleanFlag("temporary", rawTemporary);
       outerChatId = chatId;
 
       const limitRescue: LimitRescueRequest | undefined = isLimitRescueRequest(
@@ -245,7 +249,7 @@ export const createChatHandler = () => {
       chatLogger = createChatLogger({ chatId, endpoint });
       chatLogger.setRequestDetails({
         mode,
-        isTemporary: !!temporary,
+        isTemporary: temporary,
         isRegenerate: !!regenerate,
       });
       const requestMessages = requireChatMessagesArray(messages);
@@ -261,7 +265,7 @@ export const createChatHandler = () => {
       await assertUserCanMakeCostIncurringRequest(userId);
       usageRefundTracker.setUser(userId, subscription, organizationId);
       assertTemporaryChatAccess({
-        isTemporary: temporary === true,
+        isTemporary: temporary,
         subscription,
       });
       if (subscription === "free") {
@@ -318,7 +322,7 @@ export const createChatHandler = () => {
       const baseTodos: Todo[] = getBaseTodosForRequest(
         (chat?.todos as unknown as Todo[]) || [],
         Array.isArray(todos) ? todos : [],
-        { isTemporary: !!temporary, regenerate },
+        { isTemporary: temporary, regenerate },
       );
 
       const extraUsageConfig = await buildExtraUsageConfig({
@@ -384,7 +388,7 @@ export const createChatHandler = () => {
           getEmptyProcessedMessagesMetadata(truncatedMessages, {
             regenerate: !!regenerate,
             isAutoContinue: !!isAutoContinue,
-            isTemporary: !!temporary,
+            isTemporary: temporary,
             sandboxPreference,
           }),
         );
@@ -559,7 +563,7 @@ export const createChatHandler = () => {
       let subscriberStopped = false;
       const cancellationSubscriber = await createCancellationSubscriber({
         chatId,
-        isTemporary: !!temporary,
+        isTemporary: temporary,
         abortController: userStopSignal,
         onStop: () => {
           subscriberStopped = true;

--- a/lib/api/chat-request-validation.ts
+++ b/lib/api/chat-request-validation.ts
@@ -25,6 +25,21 @@ const invalidMessagesError = (
     },
   );
 
+export const requireBooleanFlag = (field: string, value: unknown): boolean => {
+  if (value === undefined) return false;
+  if (typeof value === "boolean") return value;
+
+  throw new ChatSDKError(
+    "bad_request:api",
+    `Invalid chat request: ${field} must be a boolean.`,
+    {
+      invalid_request_field: field,
+      invalid_request_field_type: getValueKind(value),
+      invalid_request_field_reason: "not_boolean",
+    },
+  );
+};
+
 export const requireChatMessagesArray = (messages: unknown): UIMessage[] => {
   if (!Array.isArray(messages)) {
     throw invalidMessagesError("messages", messages, "not_array");

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -1046,6 +1046,22 @@ export function assertFreeAgentGates(args: {
 }
 
 /**
+ * Temporary chats are a paid-plan feature. Enforce this at the API boundary so
+ * free users cannot bypass the client-side entitlement check.
+ */
+export function assertTemporaryChatAccess(args: {
+  isTemporary: boolean;
+  subscription: SubscriptionTier;
+}): void {
+  if (!args.isTemporary || args.subscription !== "free") return;
+
+  throw new ChatSDKError(
+    "forbidden:chat",
+    "Temporary chats are available on paid plans. Upgrade to Pro to use this feature.",
+  );
+}
+
+/**
  * Build the extra-usage config for paid users with `extra_usage_enabled`.
  * Falls back to an optimistic config if the balance lookup fails so a
  * transient Convex error doesn't silently disable extra usage and force


### PR DESCRIPTION
## Summary

- hide the Temporary Chat toggle for free users on desktop and mobile
- clear or ignore unauthorized `temporary-chat` URL state while preserving paid deep links
- enforce the paid-plan entitlement in both standard chat and durable Agent API entry points
- reject non-boolean `temporary` request values before authorization or persistence logic
- add regression coverage for free/paid UI, authenticated and unauthenticated URL state, and server authorization

## Why

Temporary chats were exposed to every authenticated user and the backend trusted the client-provided `temporary` flag. Free users could therefore enable the feature from the UI or by forging URL/request state. A truthy non-boolean value could also skip the new authorization check while later code still treated the request as temporary.

## User impact

Free users no longer see or access Temporary Chat. Pro, Pro Plus, Ultra, and Team users retain the existing behavior.

## Validation

- pre-commit TypeScript check passed
- 216 Jest suites passed (2,192 tests)
- ESLint and Prettier passed for changed files
- GitHub Actions, Trigger preview, Vercel, and CodeRabbit passed
- all CodeRabbit review threads are resolved

## Visual verification

The deployed Vercel preview loaded successfully in a headless browser through Vercel's preview-protection bypass and rendered the HackerAI home screen without a blank page or error overlay. Authenticated free/paid header states are covered by component tests because the browser session has no test-user credentials.

## Manual verification

1. Sign in with a free account and open `/?temporary-chat=true`.
2. Confirm the query parameter is removed and the Temporary Chat toggle is absent.
3. Sign in with a paid account and confirm the toggle remains available and Temporary Chat starts normally.