### PR TITLE
Fix actionable PostHog error sources

### DIFF
--- a/app/components/__tests__/chat.integration.test.tsx
+++ b/app/components/__tests__/chat.integration.test.tsx
@@ -226,6 +226,23 @@ describe("Chat Component Integration", () => {
       ).toBeInTheDocument();
     });
 
+    it("keeps the useChat message snapshot stable across unrelated renders", () => {
+      const { rerender } = render(
+        <TestWrapper>
+          <Chat autoResume={false} />
+        </TestWrapper>,
+      );
+      const firstMessages = mockUseChat.mock.calls.at(-1)?.[0]?.messages;
+
+      rerender(
+        <TestWrapper>
+          <Chat autoResume={false} />
+        </TestWrapper>,
+      );
+
+      expect(mockUseChat.mock.calls.at(-1)?.[0]?.messages).toBe(firstMessages);
+    });
+
     it("keeps an existing chat loading while Convex auth is still loading", () => {
       expect(
         getExistingChatLoadState({

--- a/app/components/__tests__/chat.integration.test.tsx
+++ b/app/components/__tests__/chat.integration.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
-import { render, screen } from "@testing-library/react";
+import { render, renderHook, screen } from "@testing-library/react";
 
 // ===== IMPORTANT: Mock all dependencies BEFORE importing Chat =====
 // These mocks are hoisted by Jest
@@ -173,7 +173,7 @@ jest.mock("@/components/ui/sidebar", () => ({
 }));
 
 // ===== NOW import components =====
-import { Chat, getExistingChatLoadState } from "../chat";
+import { Chat, getExistingChatLoadState, useServerMessages } from "../chat";
 import { ChatLayout } from "../ChatLayout";
 import { TestWrapper } from "../testUtils";
 
@@ -227,20 +227,15 @@ describe("Chat Component Integration", () => {
     });
 
     it("keeps the useChat message snapshot stable across unrelated renders", () => {
-      const { rerender } = render(
-        <TestWrapper>
-          <Chat autoResume={false} />
-        </TestWrapper>,
+      const { result, rerender } = renderHook(() =>
+        useServerMessages(undefined),
       );
-      const firstMessages = mockUseChat.mock.calls.at(-1)?.[0]?.messages;
+      const firstMessages = result.current;
+      expect(Array.isArray(firstMessages)).toBe(true);
 
-      rerender(
-        <TestWrapper>
-          <Chat autoResume={false} />
-        </TestWrapper>,
-      );
+      rerender();
 
-      expect(mockUseChat.mock.calls.at(-1)?.[0]?.messages).toBe(firstMessages);
+      expect(result.current).toBe(firstMessages);
     });
 
     it("keeps an existing chat loading while Convex auth is still loading", () => {

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -543,10 +543,13 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
   // Convert paginated Convex messages to UI format for useChat and useAutoResume
   // Messages come from server in descending order (newest first from pagination); reverse for chronological order
-  const serverMessages: ChatMessage[] =
-    paginatedMessageResults && paginatedMessageResults.length > 0
-      ? convertToUIMessages([...paginatedMessageResults].reverse())
-      : [];
+  const serverMessages = useMemo<ChatMessage[]>(
+    () =>
+      paginatedMessageResults && paginatedMessageResults.length > 0
+        ? convertToUIMessages([...paginatedMessageResults].reverse())
+        : [],
+    [paginatedMessageResults],
+  );
 
   // State to prevent double-processing of queue
   const [isProcessingQueue, setIsProcessingQueue] = useState(false);

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -33,7 +33,11 @@ import { useDocumentDragAndDrop } from "../hooks/useDocumentDragAndDrop";
 import { DragDropOverlay } from "./DragDropOverlay";
 import { normalizeMessages } from "@/lib/utils/message-processor";
 import { ChatSDKError } from "@/lib/errors";
-import { fetchWithErrorHandlers, convertToUIMessages } from "@/lib/utils";
+import {
+  fetchWithErrorHandlers,
+  convertToUIMessages,
+  type MessageRecord,
+} from "@/lib/utils";
 import {
   cancelAgentLongRealtimeStreams,
   fetchAgentLongStream,
@@ -133,6 +137,18 @@ export function getExistingChatLoadState({
     !hasPaginatedMessageResults;
 
   return { isInitialExistingChatLoad, isChatNotFound };
+}
+
+export function useServerMessages(
+  paginatedMessageResults: MessageRecord[] | undefined,
+): ChatMessage[] {
+  return useMemo(
+    () =>
+      paginatedMessageResults && paginatedMessageResults.length > 0
+        ? convertToUIMessages([...paginatedMessageResults].reverse())
+        : [],
+    [paginatedMessageResults],
+  );
 }
 
 type AgentLongPartialSaveMessage = {
@@ -543,13 +559,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
   // Convert paginated Convex messages to UI format for useChat and useAutoResume
   // Messages come from server in descending order (newest first from pagination); reverse for chronological order
-  const serverMessages = useMemo<ChatMessage[]>(
-    () =>
-      paginatedMessageResults && paginatedMessageResults.length > 0
-        ? convertToUIMessages([...paginatedMessageResults].reverse())
-        : [],
-    [paginatedMessageResults],
-  );
+  const serverMessages = useServerMessages(paginatedMessageResults);
 
   // State to prevent double-processing of queue
   const [isProcessingQueue, setIsProcessingQueue] = useState(false);

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -558,6 +558,34 @@ describe("forwardChunk", () => {
     );
     warnSpy.mockRestore();
   });
+
+  it("ignores a late stream chunk after the bridge stops", async () => {
+    const config = buildConfig();
+    const bridge = new DesktopSandboxBridge(config);
+    await bridge.start();
+
+    const handler = getPublicationHandler();
+    handler({
+      data: {
+        type: "command",
+        commandId: "cmd-late",
+        command: "test",
+        targetConnectionId: "conn-123",
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(capturedChannel?.onmessage).toBeDefined();
+
+    await bridge.stop();
+    const publishCountAfterStop = mockSubscription.publish.mock.calls.length;
+
+    await capturedChannel!.onmessage!({ type: "exit", exitCode: 0 });
+
+    expect(mockSubscription.publish).toHaveBeenCalledTimes(
+      publishCountAfterStop,
+    );
+  });
 });
 
 // ── pty_data publish ordering ─────────────────────────────────────────

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -129,6 +129,7 @@ export class DesktopSandboxBridge {
   private subscription: Subscription | null = null;
   private connectionId: string | null = null;
   private activeCommands = new Set<string>();
+  private isStoppingOrStopped = true;
   private config: DesktopBridgeConfig;
 
   constructor(config: DesktopBridgeConfig) {
@@ -140,6 +141,7 @@ export class DesktopSandboxBridge {
   }
 
   private terminateClient(): void {
+    this.isStoppingOrStopped = true;
     const client = this.client;
     this.client = null;
     this.connectionId = null;
@@ -151,6 +153,7 @@ export class DesktopSandboxBridge {
   }
 
   async start(): Promise<string> {
+    this.isStoppingOrStopped = false;
     const osInfo = await this.getOsInfo();
 
     const { connectionId, centrifugoToken, centrifugoWsUrl } =
@@ -745,6 +748,7 @@ export class DesktopSandboxBridge {
   }
 
   private async publishResult(message: SandboxMessage): Promise<void> {
+    if (this.isStoppingOrStopped) return;
     if (!this.subscription) {
       throw new Error(
         "[DesktopSandboxBridge] Cannot publish result: subscription is null",
@@ -939,6 +943,7 @@ export class DesktopSandboxBridge {
   }
 
   async stop(): Promise<void> {
+    this.isStoppingOrStopped = true;
     if (this.connectionId) {
       try {
         await this.config.disconnectDesktop({

--- a/convex/__tests__/usageLogs.test.ts
+++ b/convex/__tests__/usageLogs.test.ts
@@ -48,6 +48,7 @@ describe("usageLogs", () => {
 
     await (logUsage as any).handler(ctx, {
       serviceKey: "test-service-key",
+      usage_settlement_id: "settlement-123",
       user_id: "user_1",
       model: "model-sonnet-4.6",
       type: "mixed",
@@ -68,6 +69,7 @@ describe("usageLogs", () => {
 
     const inserted = ctx.db.insert.mock.calls[0][1];
     expect(inserted).toMatchObject({
+      usage_settlement_id: "settlement-123",
       cost_dollars: 12,
       model_cost_dollars: 10,
       non_model_cost_dollars: 2,

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -21,10 +21,7 @@ type ExtraUsagePurchaseRoute =
 type ExtraUsagePurchaseResult =
   "created" | "paid_seen" | "credited" | "already_processed" | "failed";
 type MaxModelExtraUsageReason =
-  | "available"
-  | "disabled"
-  | "empty"
-  | "monthly_cap_exhausted";
+  "available" | "disabled" | "empty" | "monthly_cap_exhausted";
 
 const MAX_PURCHASE_ERROR_LENGTH = 500;
 const PURCHASE_JSON_SECRET_PATTERN =
@@ -626,6 +623,7 @@ export const deductPoints = mutation({
     serviceKey: v.string(),
     userId: v.string(),
     amountPoints: v.number(),
+    usageSettlementId: v.optional(v.string()),
   },
   returns: v.object({
     success: v.boolean(),
@@ -647,6 +645,7 @@ export const deductPoints = mutation({
       convexLogger.warn("deduct_points_failed", {
         user_id: args.userId,
         amount_points: args.amountPoints,
+        usage_settlement_id: args.usageSettlementId,
         reason: "no_settings",
         insufficient_funds: true,
       });
@@ -666,6 +665,7 @@ export const deductPoints = mutation({
       convexLogger.warn("deduct_points_failed", {
         user_id: args.userId,
         amount_points: args.amountPoints,
+        usage_settlement_id: args.usageSettlementId,
         current_balance_points: currentBalancePoints,
         reason: "insufficient_balance",
         insufficient_funds: true,
@@ -698,6 +698,7 @@ export const deductPoints = mutation({
         convexLogger.warn("deduct_points_failed", {
           user_id: args.userId,
           amount_points: args.amountPoints,
+          usage_settlement_id: args.usageSettlementId,
           monthly_spent_points: monthlySpentPoints,
           monthly_cap_points: monthlyCapPoints,
           reason: "monthly_cap_exceeded",
@@ -728,6 +729,7 @@ export const deductPoints = mutation({
     convexLogger.info("points_deducted", {
       user_id: args.userId,
       amount_points: args.amountPoints,
+      usage_settlement_id: args.usageSettlementId,
       previous_balance_points: currentBalancePoints,
       new_balance_points: newBalancePoints,
       monthly_spent_points: monthlySpentPoints,

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -548,6 +548,7 @@ export const deductWithAutoReload = action({
     serviceKey: v.string(),
     userId: v.string(),
     amountPoints: v.number(),
+    usageSettlementId: v.optional(v.string()),
   },
   returns: v.object({
     success: v.boolean(),
@@ -605,6 +606,7 @@ export const deductWithAutoReload = action({
       convexLogger.error("extra_usage_balance_backend_query_failed", {
         user_id: args.userId,
         amount_points: args.amountPoints,
+        usage_settlement_id: args.usageSettlementId,
         operation: "get_extra_usage_balance",
         convex_function: "extraUsage.getExtraUsageBalanceForBackend",
         duration_ms: Date.now() - balanceLookupStartedAt,
@@ -660,6 +662,7 @@ export const deductWithAutoReload = action({
         convexLogger.error("extra_usage_stripe_customer_lookup_failed", {
           user_id: args.userId,
           amount_points: args.amountPoints,
+          usage_settlement_id: args.usageSettlementId,
           operation: "get_stripe_customer",
           duration_ms: Date.now() - stripeLookupStartedAt,
           error: serializeErrorForLog(error),
@@ -755,6 +758,7 @@ export const deductWithAutoReload = action({
           convexLogger.error("extra_usage_auto_reload_lookup_failed", {
             user_id: args.userId,
             amount_points: args.amountPoints,
+            usage_settlement_id: args.usageSettlementId,
             operation: "prepare_auto_reload_payment",
             duration_ms: Date.now() - stripeLookupStartedAt,
             error: serializeErrorForLog(error),
@@ -799,6 +803,7 @@ export const deductWithAutoReload = action({
         convexLogger.error("extra_usage_auto_reload_outcome_record_failed", {
           user_id: args.userId,
           amount_points: args.amountPoints,
+          usage_settlement_id: args.usageSettlementId,
           operation: "record_auto_reload_outcome",
           auto_reload_success: autoReloadResult.success,
           auto_reload_failure_reason: autoReloadResult.reason,
@@ -823,11 +828,13 @@ export const deductWithAutoReload = action({
         serviceKey: args.serviceKey,
         userId: args.userId,
         amountPoints: args.amountPoints,
+        usageSettlementId: args.usageSettlementId,
       });
     } catch (error) {
       convexLogger.error("extra_usage_deduct_points_failed", {
         user_id: args.userId,
         amount_points: args.amountPoints,
+        usage_settlement_id: args.usageSettlementId,
         operation: "deduct_points",
         convex_function: "extraUsage.deductPoints",
         auto_reload_triggered: autoReloadTriggered,
@@ -842,6 +849,7 @@ export const deductWithAutoReload = action({
     convexLogger.info("deduct_with_auto_reload", {
       user_id: args.userId,
       amount_points: args.amountPoints,
+      usage_settlement_id: args.usageSettlementId,
       success: deductResult.success,
       new_balance_dollars: deductResult.newBalanceDollars,
       insufficient_funds: deductResult.insufficientFunds,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -592,6 +592,7 @@ export default defineSchema({
 
   // Per-request usage logs for the usage dashboard
   usage_logs: defineTable({
+    usage_settlement_id: v.optional(v.string()),
     user_id: v.string(),
     organization_id: v.optional(v.string()),
     chat_id: v.optional(v.string()),
@@ -644,6 +645,7 @@ export default defineSchema({
     // rows still pass validation.
     byok: v.optional(v.boolean()),
   })
+    .index("by_usage_settlement_id", ["usage_settlement_id"])
     .index("by_user", ["user_id"])
     .index("by_user_and_model", ["user_id", "model"])
     .index("by_org", ["organization_id"]),

--- a/convex/teamExtraUsage.ts
+++ b/convex/teamExtraUsage.ts
@@ -218,6 +218,7 @@ export const deductTeamPoints = mutation({
     organizationId: v.string(),
     userId: v.string(),
     amountPoints: v.number(),
+    usageSettlementId: v.optional(v.string()),
   },
   returns: v.object({
     success: v.boolean(),
@@ -367,6 +368,7 @@ export const deductTeamPoints = mutation({
       organization_id: args.organizationId,
       user_id: args.userId,
       amount_points: args.amountPoints,
+      usage_settlement_id: args.usageSettlementId,
       new_balance_points: newBalancePoints,
       team_monthly_spent: teamMonthlySpent,
       member_monthly_spent: memberMonthlySpent,

--- a/convex/teamExtraUsageActions.ts
+++ b/convex/teamExtraUsageActions.ts
@@ -272,6 +272,7 @@ export const deductWithAutoReloadForTeam = action({
     organizationId: v.string(),
     userId: v.string(),
     amountPoints: v.number(),
+    usageSettlementId: v.optional(v.string()),
   },
   returns: v.object({
     success: v.boolean(),
@@ -340,6 +341,7 @@ export const deductWithAutoReloadForTeam = action({
       organizationId: args.organizationId,
       userId: args.userId,
       amountPoints: args.amountPoints,
+      usageSettlementId: args.usageSettlementId,
     });
 
     let deductResult = deductWithoutReload;
@@ -521,6 +523,7 @@ export const deductWithAutoReloadForTeam = action({
           organizationId: args.organizationId,
           userId: args.userId,
           amountPoints: args.amountPoints,
+          usageSettlementId: args.usageSettlementId,
         },
       );
     }
@@ -529,6 +532,7 @@ export const deductWithAutoReloadForTeam = action({
       organization_id: args.organizationId,
       user_id: args.userId,
       amount_points: args.amountPoints,
+      usage_settlement_id: args.usageSettlementId,
       success: deductResult.success,
       new_balance_dollars: deductResult.newBalanceDollars,
       insufficient_funds: deductResult.insufficientFunds,

--- a/convex/usageLogs.ts
+++ b/convex/usageLogs.ts
@@ -38,6 +38,7 @@ const cleanModelName = (model: string): string =>
 export const logUsage = mutation({
   args: {
     serviceKey: v.string(),
+    usage_settlement_id: v.optional(v.string()),
     user_id: v.string(),
     organization_id: v.optional(v.string()),
     chat_id: v.optional(v.string()),
@@ -140,6 +141,7 @@ export const logUsage = mutation({
     const now = Date.now();
 
     await ctx.db.insert("usage_logs", {
+      usage_settlement_id: args.usage_settlement_id,
       user_id: args.user_id,
       organization_id: args.organization_id,
       chat_id: args.chat_id,

--- a/lib/__tests__/extra-usage.test.ts
+++ b/lib/__tests__/extra-usage.test.ts
@@ -213,7 +213,11 @@ describe("extra-usage", () => {
           autoReloadTriggered: false,
         });
 
-        const result = await deductFromBalance("user-123", 2000);
+        const result = await deductFromBalance(
+          "user-123",
+          2000,
+          "settlement-123",
+        );
 
         expect(result).toEqual({
           success: true,
@@ -223,7 +227,14 @@ describe("extra-usage", () => {
           autoReloadTriggered: false,
           autoReloadResult: undefined,
         });
-        expect(mockAction).toHaveBeenCalled();
+        expect(mockAction).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            userId: "user-123",
+            amountPoints: 2000,
+            usageSettlementId: "settlement-123",
+          }),
+        );
       });
 
       it("should return auto-reload info when triggered", async () => {

--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -9,6 +9,16 @@ describe("UsageTracker", () => {
     jest.clearAllMocks();
   });
 
+  describe("usage settlement correlation", () => {
+    it("uses one stable identifier for the tracker lifetime", () => {
+      expect(tracker.usageSettlementId).toEqual(expect.any(String));
+      expect(tracker.usageSettlementId).toBe(tracker.usageSettlementId);
+      expect(new UsageTracker().usageSettlementId).not.toBe(
+        tracker.usageSettlementId,
+      );
+    });
+  });
+
   describe("accumulateStep", () => {
     it("should sum tokens across multiple steps", () => {
       tracker.accumulateStep({
@@ -589,6 +599,7 @@ describe("UsageTracker", () => {
       });
 
       expect(localMockLog).toHaveBeenCalledWith({
+        usageSettlementId: expect.any(String),
         userId: "user-123",
         organizationId: undefined,
         chatId: undefined,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -988,6 +988,7 @@ export const createChatHandler = () => {
                       ? getUsageSettlementInitialDeduction(usageSettlementState)
                       : rateLimitInfo,
                     usageRecordArgs.accountingModel,
+                    usageTracker.usageSettlementId,
                   );
                   if (usageSettlementState) {
                     usageRefundTracker.recordDeductions({
@@ -1099,6 +1100,7 @@ export const createChatHandler = () => {
                     additionalCostPoints,
                     extraUsageConfig,
                     organizationId,
+                    usageTracker.usageSettlementId,
                   );
                 } catch (error) {
                   phLogger.warn("Mid-run usage settlement failed", {
@@ -1111,6 +1113,7 @@ export const createChatHandler = () => {
                     subscription,
                     selected_model: selectedModel,
                     additional_cost_points: additionalCostPoints,
+                    usage_settlement_id: usageTracker.usageSettlementId,
                     current_cost_dollars: currentCostDollars,
                     force,
                     error:

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -1853,6 +1853,7 @@ export async function logUsageRecord({
   } catch (error) {
     console.error("Failed to log usage record:", {
       error,
+      usage_settlement_id: usageSettlementId,
       userId,
       organizationId,
       chatId,

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -1766,6 +1766,7 @@ export async function getNotes({
 }
 
 export async function logUsageRecord({
+  usageSettlementId,
   userId,
   organizationId,
   chatId,
@@ -1792,6 +1793,7 @@ export async function logUsageRecord({
   nonModelCostDollars,
   costSource,
 }: {
+  usageSettlementId?: string;
   userId: string;
   organizationId?: string;
   chatId?: string;
@@ -1821,6 +1823,7 @@ export async function logUsageRecord({
   try {
     await getConvexClient().mutation(api.usageLogs.logUsage, {
       serviceKey,
+      usage_settlement_id: usageSettlementId,
       user_id: userId,
       organization_id: organizationId,
       chat_id: chatId,

--- a/lib/extra-usage.ts
+++ b/lib/extra-usage.ts
@@ -18,6 +18,7 @@ const logExtraUsageConvexFailure = ({
   userId,
   organizationId,
   amountPoints,
+  usageSettlementId,
   convexFunction,
   operation,
   startedAt,
@@ -28,6 +29,7 @@ const logExtraUsageConvexFailure = ({
   userId?: string;
   organizationId?: string;
   amountPoints?: number;
+  usageSettlementId?: string;
   convexFunction: string;
   operation: string;
   startedAt: number;
@@ -38,6 +40,7 @@ const logExtraUsageConvexFailure = ({
     userId,
     organization_id: organizationId,
     amount_points: amountPoints,
+    usage_settlement_id: usageSettlementId,
     convex_function: convexFunction,
     operation,
     component: "extra_usage",
@@ -214,6 +217,7 @@ export async function refundToBalance(
 export async function deductFromBalance(
   userId: string,
   pointsUsed: number,
+  usageSettlementId?: string,
 ): Promise<DeductBalanceResult> {
   // No-op: nothing to deduct, balance unchanged (actual balance not fetched to avoid extra call)
   if (pointsUsed <= 0) {
@@ -238,6 +242,7 @@ export async function deductFromBalance(
         serviceKey: process.env.CONVEX_SERVICE_ROLE_KEY!,
         userId,
         amountPoints: pointsUsed,
+        usageSettlementId,
       },
     );
 
@@ -255,6 +260,7 @@ export async function deductFromBalance(
       message: "Extra usage deduction failed",
       userId,
       amountPoints: pointsUsed,
+      usageSettlementId,
       convexFunction: "extraUsageActions.deductWithAutoReload",
       operation: "deduct_extra_usage_balance",
       startedAt,
@@ -346,6 +352,7 @@ export async function deductFromTeamBalance(
   organizationId: string,
   userId: string,
   pointsUsed: number,
+  usageSettlementId?: string,
 ): Promise<DeductBalanceResult> {
   if (pointsUsed <= 0) {
     return {
@@ -367,6 +374,7 @@ export async function deductFromTeamBalance(
         organizationId,
         userId,
         amountPoints: pointsUsed,
+        usageSettlementId,
       },
     );
 
@@ -388,6 +396,7 @@ export async function deductFromTeamBalance(
       userId,
       organizationId,
       amountPoints: pointsUsed,
+      usageSettlementId,
       convexFunction: "teamExtraUsageActions.deductWithAutoReloadForTeam",
       operation: "deduct_team_extra_usage_balance",
       startedAt,

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -400,7 +400,11 @@ describe("token-bucket async functions", () => {
         autoReloadEnabled: false,
       });
 
-      expect(mockDeductFromBalance).toHaveBeenCalledWith("user-123", 42);
+      expect(mockDeductFromBalance).toHaveBeenCalledWith(
+        "user-123",
+        42,
+        undefined,
+      );
     });
 
     it("should skip deduction for free tier", async () => {
@@ -899,7 +903,11 @@ describe("token-bucket async functions", () => {
         expect.objectContaining({ rate: 10 }),
       );
       // Should deduct the overflow (53) from extra usage
-      expect(mockDeductFromBalance).toHaveBeenCalledWith("user-123", 53);
+      expect(mockDeductFromBalance).toHaveBeenCalledWith(
+        "user-123",
+        53,
+        undefined,
+      );
       expect(result).toEqual({
         includedPointsDeducted: 17,
         extraUsagePointsDeducted: 53,
@@ -940,7 +948,11 @@ describe("token-bucket async functions", () => {
         0.005,
       );
 
-      expect(mockDeductFromBalance).toHaveBeenCalledWith("user-123", 53);
+      expect(mockDeductFromBalance).toHaveBeenCalledWith(
+        "user-123",
+        53,
+        undefined,
+      );
       expect(result).toEqual({
         includedPointsDeducted: 17,
         extraUsagePointsDeducted: 0,
@@ -1079,6 +1091,7 @@ describe("token-bucket async functions", () => {
         "org-123",
         "user-123",
         53,
+        undefined,
       );
       expect(result).toEqual({
         includedPointsDeducted: 17,
@@ -1153,7 +1166,11 @@ describe("token-bucket async functions", () => {
         expect.any(String),
         expect.objectContaining({ rate: 10 }),
       );
-      expect(mockDeductFromBalance).toHaveBeenCalledWith("user-123", 33);
+      expect(mockDeductFromBalance).toHaveBeenCalledWith(
+        "user-123",
+        33,
+        undefined,
+      );
       expect(result).toEqual({
         includedPointsDeducted: 10,
         extraUsagePointsDeducted: 33,
@@ -1223,7 +1240,11 @@ describe("token-bucket async functions", () => {
         autoReloadEnabled: false,
       });
 
-      expect(mockDeductFromBalance).toHaveBeenCalledWith("user-123", 43);
+      expect(mockDeductFromBalance).toHaveBeenCalledWith(
+        "user-123",
+        43,
+        undefined,
+      );
       expect(result).toEqual({
         includedPointsDeducted: 0,
         extraUsagePointsDeducted: 43,

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -407,6 +407,39 @@ describe("token-bucket async functions", () => {
       );
     });
 
+    it("forwards a settlement ID to the extra usage deduction", async () => {
+      const { deductUsage } = getIsolatedModule();
+
+      mockLimitFn.mockResolvedValue({
+        success: true,
+        remaining: -30,
+        reset: Date.now() + 3600000,
+        limit: 250000,
+      });
+
+      await deductUsage(
+        "user-123",
+        "pro",
+        1000,
+        1000,
+        1000,
+        { enabled: true, hasBalance: true, autoReloadEnabled: false },
+        undefined,
+        undefined,
+        0,
+        undefined,
+        undefined,
+        undefined,
+        "settlement-123",
+      );
+
+      expect(mockDeductFromBalance).toHaveBeenCalledWith(
+        "user-123",
+        42,
+        "settlement-123",
+      );
+    });
+
     it("should skip deduction for free tier", async () => {
       const { deductUsage } = getIsolatedModule();
 
@@ -1177,6 +1210,39 @@ describe("token-bucket async functions", () => {
         uncoveredPoints: 0,
         usageDeductionFailed: false,
       });
+    });
+
+    it("forwards a settlement ID to the mid-run extra usage deduction", async () => {
+      const { deductUsageDelta } = getIsolatedModule();
+
+      mockLimitFn
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 10,
+          reset: Date.now() + 3600000,
+          limit: 250000,
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 0,
+          reset: Date.now() + 3600000,
+          limit: 250000,
+        });
+
+      await deductUsageDelta(
+        "user-123",
+        "pro",
+        43,
+        { enabled: true, hasBalance: true, autoReloadEnabled: false },
+        undefined,
+        "settlement-123",
+      );
+
+      expect(mockDeductFromBalance).toHaveBeenCalledWith(
+        "user-123",
+        33,
+        "settlement-123",
+      );
     });
 
     it("reports uncovered mid-run delta when extra usage cannot cover overflow", async () => {

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -211,25 +211,17 @@ const deductAdditionalUsagePoints = async ({
       const deductResult = await (async () => {
         try {
           return isTeamPool
-            ? usageSettlementId
-              ? await deductFromTeamBalance(
-                  organizationId!,
-                  userId,
-                  fromExtraUsage,
-                  usageSettlementId,
-                )
-              : await deductFromTeamBalance(
-                  organizationId!,
-                  userId,
-                  fromExtraUsage,
-                )
-            : usageSettlementId
-              ? await deductFromBalance(
-                  userId,
-                  fromExtraUsage,
-                  usageSettlementId,
-                )
-              : await deductFromBalance(userId, fromExtraUsage);
+            ? await deductFromTeamBalance(
+                organizationId!,
+                userId,
+                fromExtraUsage,
+                usageSettlementId,
+              )
+            : await deductFromBalance(
+                userId,
+                fromExtraUsage,
+                usageSettlementId,
+              );
         } catch (error) {
           console.error("Failed to deduct extra usage delta:", error);
           return {

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -150,6 +150,7 @@ const deductAdditionalUsagePoints = async ({
   additionalCostPoints,
   extraUsageConfig,
   organizationId,
+  usageSettlementId,
 }: {
   monthly: MonthlyLimiter;
   userId: string;
@@ -157,6 +158,7 @@ const deductAdditionalUsagePoints = async ({
   additionalCostPoints: number;
   extraUsageConfig?: ExtraUsageConfig;
   organizationId?: string;
+  usageSettlementId?: string;
 }): Promise<UsageDeductionResult> => {
   const normalizedAdditionalCost = nonNegativePoints(additionalCostPoints);
   if (normalizedAdditionalCost <= 0) return emptyUsageDeductionResult();
@@ -209,12 +211,25 @@ const deductAdditionalUsagePoints = async ({
       const deductResult = await (async () => {
         try {
           return isTeamPool
-            ? await deductFromTeamBalance(
-                organizationId!,
-                userId,
-                fromExtraUsage,
-              )
-            : await deductFromBalance(userId, fromExtraUsage);
+            ? usageSettlementId
+              ? await deductFromTeamBalance(
+                  organizationId!,
+                  userId,
+                  fromExtraUsage,
+                  usageSettlementId,
+                )
+              : await deductFromTeamBalance(
+                  organizationId!,
+                  userId,
+                  fromExtraUsage,
+                )
+            : usageSettlementId
+              ? await deductFromBalance(
+                  userId,
+                  fromExtraUsage,
+                  usageSettlementId,
+                )
+              : await deductFromBalance(userId, fromExtraUsage);
         } catch (error) {
           console.error("Failed to deduct extra usage delta:", error);
           return {
@@ -698,6 +713,7 @@ export const deductUsageDelta = async (
   additionalCostPoints: number,
   extraUsageConfig?: ExtraUsageConfig,
   organizationId?: string,
+  usageSettlementId?: string,
 ): Promise<UsageDeductionResult> => {
   const redis = createRedisClient();
   if (!redis) {
@@ -722,6 +738,7 @@ export const deductUsageDelta = async (
       additionalCostPoints,
       extraUsageConfig,
       organizationId,
+      usageSettlementId,
     });
   } catch (error) {
     console.error("Failed to deduct usage delta:", error);
@@ -762,6 +779,7 @@ export const deductUsage = async (
     "pointsDeducted" | "extraUsagePointsDeducted"
   >,
   actualModelName?: string,
+  usageSettlementId?: string,
 ): Promise<UsageDeductionResult> => {
   const redis = createRedisClient();
   if (!redis) {
@@ -924,6 +942,7 @@ export const deductUsage = async (
       additionalCostPoints: costDifference,
       extraUsageConfig,
       organizationId,
+      usageSettlementId,
     });
     lastKnownDeductionResult = buildDeductionResult(
       deltaResult.includedPointsDeducted,

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -80,6 +80,7 @@ export interface UsageCostRecord {
  * Shared between chat-handler.ts and agent-task.ts to avoid duplication.
  */
 export class UsageTracker {
+  /** Correlates this run's usage record with downstream settlement logs. */
   readonly usageSettlementId = uuidv4();
   inputTokens = 0;
   outputTokens = 0;

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -7,6 +7,7 @@ import { calculateRawTokenCost, POINTS_PER_DOLLAR } from "@/lib/rate-limit";
 import type { UsageDeductionFailureReason } from "@/lib/rate-limit";
 import type { ChatApiEndpoint } from "@/lib/api/agent-endpoints";
 import type { ChatMode, RateLimitInfo, SubscriptionTier } from "@/types";
+import { v4 as uuidv4 } from "uuid";
 
 interface StepUsage {
   inputTokens?: number;
@@ -79,6 +80,7 @@ export interface UsageCostRecord {
  * Shared between chat-handler.ts and agent-task.ts to avoid duplication.
  */
 export class UsageTracker {
+  readonly usageSettlementId = uuidv4();
   inputTokens = 0;
   outputTokens = 0;
   totalTokens = 0;
@@ -406,6 +408,7 @@ export class UsageTracker {
   }) {
     const usage = this.createUsageCostRecord(args);
     logUsageRecord({
+      usageSettlementId: this.usageSettlementId,
       userId: args.userId,
       organizationId: args.organizationId,
       chatId: args.chatId,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1597,6 +1597,7 @@ export const agentLongTask = task({
                       ? getUsageSettlementInitialDeduction(usageSettlementState)
                       : rateLimitInfo,
                     usageRecordArgs.accountingModel,
+                    usageTracker.usageSettlementId,
                   );
                   if (usageSettlementState) {
                     usageRefundTracker.recordDeductions({
@@ -1701,6 +1702,7 @@ export const agentLongTask = task({
                     additionalCostPoints,
                     extraUsageConfig,
                     organizationId,
+                    usageTracker.usageSettlementId,
                   );
                 } catch (error) {
                   phLogger.warn("Mid-run usage settlement failed", {
@@ -1713,6 +1715,7 @@ export const agentLongTask = task({
                     subscription,
                     selected_model: selectedModel,
                     additional_cost_points: additionalCostPoints,
+                    usage_settlement_id: usageTracker.usageSettlementId,
                     current_cost_dollars: currentCostDollars,
                     force,
                     error:


### PR DESCRIPTION
## Summary

- stabilize the initial `useChat` message snapshot to prevent the React maximum-update-depth loop seen in new Ask chats
- propagate and persist a stable `usage_settlement_id` across chat/agent usage records and individual/team extra-usage deduction logs, with a lookup index for investigation
- ignore native desktop stream results that arrive after the bridge has begun stopping

This intentionally does not add automatic usage-deduction retries because the current settlement path is not idempotent, and it does not broadly suppress client fetch errors. The exact Next.js Server Action transport issues can be suppressed in PostHog without hiding real application fetch failures.

## Validation

- `pnpm typecheck`
- staged Prettier and ESLint checks
- `pnpm test` — 228 suites, 2,249 tests passed

## Manual verification

- In a new free Ask chat, submit a prompt and confirm the chat transitions to ready without a maximum-update-depth error.
- Stop or disconnect the desktop bridge while a command is finishing and confirm a late exit chunk does not emit `Cannot publish result: subscription is null`.
- In staging, force an extra-usage deduction failure and confirm the same `usage_settlement_id` appears in the usage row and deduction-path logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented “late” sandbox stream results from being published after stop/shutdown.
  - Improved chat message rendering stability to avoid unnecessary recomputation during routine updates.

- **Reliability**
  - Improved usage, billing, and diagnostics by consistently attaching a stable settlement identifier to deductions and usage records.

- **Tests**
  - Added/updated regression tests to verify settlement-tag stability, chat stability across rerenders, and correct shutdown handling for late stream chunks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->