### PR TITLE
Settle Agent usage per step and serialize auto-reload

### DIFF
--- a/convex/__tests__/extraUsageActionsAuth.test.ts
+++ b/convex/__tests__/extraUsageActionsAuth.test.ts
@@ -49,9 +49,12 @@ const mockBillingPortalSessionCreate = jest.fn();
 const mockCustomerRetrieve = jest.fn();
 const mockSubscriptionsList = jest.fn();
 const mockInvoicesCreate = jest.fn();
+const mockInvoicesRetrieve = jest.fn();
 const mockInvoiceItemsCreate = jest.fn();
 const mockInvoicesFinalize = jest.fn();
 const mockInvoicesPay = jest.fn();
+const mockInvoicesVoid = jest.fn();
+const mockInvoicesDelete = jest.fn();
 jest.mock("stripe", () => {
   const Stripe = jest.fn().mockImplementation(() => ({
     checkout: {
@@ -72,8 +75,11 @@ jest.mock("stripe", () => {
     },
     invoices: {
       create: mockInvoicesCreate,
+      retrieve: mockInvoicesRetrieve,
       finalizeInvoice: mockInvoicesFinalize,
       pay: mockInvoicesPay,
+      voidInvoice: mockInvoicesVoid,
+      del: mockInvoicesDelete,
     },
     invoiceItems: {
       create: mockInvoiceItemsCreate,
@@ -147,6 +153,47 @@ async function callDeductWithAutoReload(
   return (deductWithAutoReload as any).handler(ctx, {
     serviceKey: SERVICE_KEY,
     ...args,
+  });
+}
+
+const claimedAutoReload = (amountDollars: number) => ({
+  status: "operation",
+  operationId: "reload_op",
+  executorId: "reload_executor",
+  amountDollars,
+  startedAt: Date.now(),
+  claimed: true,
+  paymentAllowed: true,
+});
+
+function makeAutoReloadMutationMock({
+  amountDollars,
+  initialDeduct,
+  finalDeduct = initialDeduct,
+  creditBalance = amountDollars,
+}: {
+  amountDollars: number;
+  initialDeduct: Record<string, unknown>;
+  finalDeduct?: Record<string, unknown>;
+  creditBalance?: number;
+}) {
+  let deductCalls = 0;
+  return jest.fn(async (_mutation: unknown, mutationArgs: any) => {
+    if ("candidateOperationId" in mutationArgs) {
+      return claimedAutoReload(amountDollars);
+    }
+    if ("stripeInvoiceId" in mutationArgs && "operationId" in mutationArgs) {
+      return true;
+    }
+    if ("outcome" in mutationArgs) return true;
+    if ("amountDollars" in mutationArgs) {
+      return { newBalance: creditBalance, alreadyProcessed: false };
+    }
+    if ("success" in mutationArgs && !("amountPoints" in mutationArgs)) {
+      return null;
+    }
+    deductCalls++;
+    return deductCalls === 1 ? initialDeduct : finalDeduct;
   });
 }
 
@@ -299,7 +346,14 @@ describe("deductWithAutoReload", () => {
     mockSubscriptionsList.mockResolvedValue({
       data: [{ default_payment_method: "pm_card" }],
     } as never);
-    mockInvoicesCreate.mockResolvedValue({ id: "in_auto" } as never);
+    mockInvoicesCreate.mockResolvedValue({
+      id: "in_auto",
+      status: "draft",
+    } as never);
+    mockInvoicesRetrieve.mockResolvedValue({
+      id: "in_auto",
+      status: "open",
+    } as never);
     mockInvoiceItemsCreate.mockResolvedValue({ id: "ii_auto" } as never);
     mockInvoicesFinalize.mockResolvedValue({
       id: "in_auto",
@@ -309,6 +363,14 @@ describe("deductWithAutoReload", () => {
       id: "in_auto",
       status: "paid",
       payment_intent: "pi_auto",
+    } as never);
+    mockInvoicesVoid.mockResolvedValue({
+      id: "in_auto",
+      status: "void",
+    } as never);
+    mockInvoicesDelete.mockResolvedValue({
+      id: "in_auto",
+      deleted: true,
     } as never);
   });
 
@@ -325,13 +387,16 @@ describe("deductWithAutoReload", () => {
         autoReloadAmountDollars: 15,
         monthlyRemainingDollars: 100,
       })),
-      runMutation: jest.fn(async () => ({
-        success: false,
-        newBalancePoints: 200_000,
-        newBalanceDollars: 20,
-        insufficientFunds: true,
-        monthlyCapExceeded: false,
-      })),
+      runMutation: makeAutoReloadMutationMock({
+        amountDollars: 11.5,
+        initialDeduct: {
+          success: false,
+          newBalancePoints: 200_000,
+          newBalanceDollars: 23,
+          insufficientFunds: true,
+          monthlyCapExceeded: false,
+        },
+      }),
     };
 
     const result = await callDeductWithAutoReload(ctx, {
@@ -343,7 +408,7 @@ describe("deductWithAutoReload", () => {
       userId: "user_member",
       statuses: ["active"],
     });
-    expect(ctx.runMutation).toHaveBeenCalledTimes(1);
+    expect(ctx.runMutation).toHaveBeenCalledTimes(3);
     expect(result).toMatchObject({
       success: false,
       insufficientFunds: true,
@@ -411,18 +476,23 @@ describe("deductWithAutoReload", () => {
         autoReloadAmountDollars: 15,
         monthlyRemainingDollars: 100,
       })),
-      runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
-        if ("amountDollars" in mutationArgs) return null;
-        if ("success" in mutationArgs && !("amountPoints" in mutationArgs)) {
-          return null;
-        }
-        return {
+      runMutation: makeAutoReloadMutationMock({
+        amountDollars: 11.5,
+        initialDeduct: {
+          success: false,
+          newBalancePoints: 200_000,
+          newBalanceDollars: 23,
+          insufficientFunds: true,
+          monthlyCapExceeded: false,
+        },
+        finalDeduct: {
           success: true,
           newBalancePoints: 0,
           newBalanceDollars: 0,
           insufficientFunds: false,
           monthlyCapExceeded: false,
-        };
+        },
+        creditBalance: 34.5,
       }),
     };
 
@@ -433,6 +503,30 @@ describe("deductWithAutoReload", () => {
 
     expect(mockInvoiceItemsCreate).toHaveBeenCalledWith(
       expect.objectContaining({ amount: 1150 }),
+      { idempotencyKey: "reload_op:item" },
+    );
+    expect(mockInvoicesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ operationId: "reload_op" }),
+      }),
+      { idempotencyKey: "reload_op:invoice" },
+    );
+    expect(mockInvoicesFinalize).toHaveBeenCalledWith(
+      "in_auto",
+      {},
+      { idempotencyKey: "reload_op:finalize" },
+    );
+    expect(mockInvoicesPay).toHaveBeenCalledWith(
+      "in_auto",
+      { payment_method: "pm_card" },
+      { idempotencyKey: "reload_op:pay" },
+    );
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        idempotencyKey: "personal_auto_reload:reload_op",
+        stripeInvoiceId: "in_auto",
+      }),
     );
     expect(result).toMatchObject({
       success: true,
@@ -465,18 +559,23 @@ describe("deductWithAutoReload", () => {
         autoReloadAmountDollars: 15,
         monthlyRemainingDollars: 100,
       })),
-      runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
-        if ("amountDollars" in mutationArgs) return null;
-        if ("success" in mutationArgs && !("amountPoints" in mutationArgs)) {
-          return null;
-        }
-        return {
+      runMutation: makeAutoReloadMutationMock({
+        amountDollars: 1,
+        initialDeduct: {
+          success: false,
+          newBalancePoints: 295_000,
+          newBalanceDollars: extraUsagePointsToDollars(295_000),
+          insufficientFunds: true,
+          monthlyCapExceeded: false,
+        },
+        finalDeduct: {
           success: true,
-          newBalancePoints: 5_000,
-          newBalanceDollars: 0.5,
+          newBalancePoints: 3_695,
+          newBalanceDollars: extraUsagePointsToDollars(3_695),
           insufficientFunds: false,
           monthlyCapExceeded: false,
-        };
+        },
+        creditBalance: extraUsagePointsToDollars(295_000) + 1,
       }),
     };
 
@@ -487,11 +586,371 @@ describe("deductWithAutoReload", () => {
 
     expect(mockInvoiceItemsCreate).toHaveBeenCalledWith(
       expect.objectContaining({ amount: 100 }),
+      { idempotencyKey: "reload_op:item" },
     );
     expect(result).toMatchObject({
       success: true,
       autoReloadTriggered: true,
       autoReloadResult: { success: true, chargedAmountDollars: 1 },
+    });
+  });
+
+  it("credits and clears a persisted paid invoice without a PaymentIntent", async () => {
+    mockInvoicesRetrieve.mockResolvedValueOnce({
+      id: "in_paid_recovery",
+      status: "paid",
+    } as never);
+    const deductResult = {
+      success: true,
+      newBalancePoints: 200_000,
+      newBalanceDollars: extraUsagePointsToDollars(200_000),
+      insufficientFunds: false,
+      monthlyCapExceeded: false,
+    };
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        balanceDollars: deductResult.newBalanceDollars,
+        balancePoints: deductResult.newBalancePoints,
+        enabled: true,
+        autoReloadEnabled: false,
+        autoReloadThresholdPoints: 10_000,
+        autoReloadOperationPending: true,
+      })),
+      runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
+        if ("amountPoints" in mutationArgs) return deductResult;
+        if ("candidateOperationId" in mutationArgs) {
+          return {
+            status: "operation",
+            operationId: "paid-recovery-op",
+            executorId: "paid-recovery-executor",
+            amountDollars: 15,
+            stripeInvoiceId: "in_paid_recovery",
+            claimed: true,
+            paymentAllowed: false,
+            paymentBlockedReason: "auto_reload_disabled",
+          };
+        }
+        if ("amountDollars" in mutationArgs) {
+          return { newBalance: 38, alreadyProcessed: true };
+        }
+        if ("outcome" in mutationArgs) return true;
+        return null;
+      }),
+    };
+
+    const result = await callDeductWithAutoReload(ctx, {
+      userId: "user_member",
+      amountPoints: 10_000,
+    });
+
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        amountDollars: 15,
+        idempotencyKey: "personal_auto_reload:paid-recovery-op",
+        stripeInvoiceId: "in_paid_recovery",
+      }),
+    );
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        operationId: "paid-recovery-op",
+        outcome: "success",
+      }),
+    );
+    expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
+    expect(mockInvoicesPay).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      success: true,
+      newBalanceDollars: deductResult.newBalanceDollars,
+      autoReloadTriggered: true,
+      autoReloadResult: { success: true, chargedAmountDollars: 15 },
+    });
+  });
+
+  it("does not pay a persisted unpaid invoice when reload is no longer needed", async () => {
+    mockInvoicesRetrieve.mockResolvedValueOnce({
+      id: "in_stale_open",
+      status: "open",
+    } as never);
+    const deductResult = {
+      success: true,
+      newBalancePoints: 200_000,
+      newBalanceDollars: extraUsagePointsToDollars(200_000),
+      insufficientFunds: false,
+      monthlyCapExceeded: false,
+    };
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        balanceDollars: deductResult.newBalanceDollars,
+        balancePoints: deductResult.newBalancePoints,
+        enabled: true,
+        autoReloadEnabled: true,
+        autoReloadThresholdPoints: 10_000,
+        autoReloadOperationPending: true,
+      })),
+      runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
+        if ("amountPoints" in mutationArgs) return deductResult;
+        if ("candidateOperationId" in mutationArgs) {
+          return {
+            status: "operation",
+            operationId: "stale-open-op",
+            executorId: "stale-open-executor",
+            amountDollars: 15,
+            stripeInvoiceId: "in_stale_open",
+            claimed: true,
+            paymentAllowed: false,
+            paymentBlockedReason: "not_needed",
+          };
+        }
+        if ("outcome" in mutationArgs) return true;
+        throw new Error(
+          `Unexpected mutation args: ${JSON.stringify(mutationArgs)}`,
+        );
+      }),
+    };
+
+    const result = await callDeductWithAutoReload(ctx, {
+      userId: "user_member",
+      amountPoints: 10_000,
+    });
+
+    expect(mockInvoicesPay).not.toHaveBeenCalled();
+    expect(mockListOrganizationMemberships).not.toHaveBeenCalled();
+    expect(mockInvoicesVoid).toHaveBeenCalledWith(
+      "in_stale_open",
+      {},
+      { idempotencyKey: "stale-open-op:void-stale" },
+    );
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        operationId: "stale-open-op",
+        outcome: "released",
+      }),
+    );
+    expect(result).toMatchObject({
+      success: true,
+      autoReloadTriggered: true,
+      autoReloadResult: { success: false, reason: "not_needed" },
+    });
+  });
+
+  it("retires an undersized id-less operation and retries once for the current request", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          status: "active",
+          role: { slug: "admin" },
+        },
+      ],
+    } as never);
+    mockGetOrganization.mockResolvedValue({
+      stripeCustomerId: "cus_team",
+    } as never);
+    let deductCalls = 0;
+    let claimCalls = 0;
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        balanceDollars: 0,
+        balancePoints: 0,
+        enabled: true,
+        autoReloadEnabled: true,
+        autoReloadThresholdPoints: 10_000,
+        autoReloadAmountDollars: 15,
+        autoReloadOperationPending: true,
+      })),
+      runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
+        if ("candidateOperationId" in mutationArgs) {
+          claimCalls++;
+          return claimCalls === 1
+            ? {
+                status: "operation",
+                operationId: "undersized-idless-op",
+                executorId: "undersized-idless-executor",
+                amountDollars: 1,
+                claimed: true,
+                paymentAllowed: false,
+                paymentBlockedReason: "reload_amount_insufficient",
+              }
+            : {
+                status: "operation",
+                operationId: "correctly-sized-op",
+                executorId: "correctly-sized-executor",
+                amountDollars: 34.5,
+                claimed: true,
+                paymentAllowed: true,
+              };
+        }
+        if (
+          "stripeInvoiceId" in mutationArgs &&
+          "operationId" in mutationArgs
+        ) {
+          return true;
+        }
+        if ("outcome" in mutationArgs) return true;
+        if ("amountDollars" in mutationArgs) {
+          return { newBalance: 34.5, alreadyProcessed: false };
+        }
+        if ("success" in mutationArgs) return null;
+        if ("amountPoints" in mutationArgs) {
+          deductCalls++;
+          return deductCalls === 1
+            ? {
+                success: false,
+                newBalancePoints: 0,
+                newBalanceDollars: 0,
+                insufficientFunds: true,
+                monthlyCapExceeded: false,
+              }
+            : {
+                success: true,
+                newBalancePoints: 0,
+                newBalanceDollars: 0,
+                insufficientFunds: false,
+                monthlyCapExceeded: false,
+              };
+        }
+        throw new Error(
+          `Unexpected mutation args: ${JSON.stringify(mutationArgs)}`,
+        );
+      }),
+    };
+
+    const result = await callDeductWithAutoReload(ctx, {
+      userId: "user_member",
+      amountPoints: 300_000,
+    });
+
+    expect(claimCalls).toBe(2);
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        operationId: "undersized-idless-op",
+        outcome: "released",
+      }),
+    );
+    expect(mockInvoicesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          operationId: "correctly-sized-op",
+        }),
+      }),
+      { idempotencyKey: "correctly-sized-op:invoice" },
+    );
+    expect(mockInvoiceItemsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 3450 }),
+      { idempotencyKey: "correctly-sized-op:item" },
+    );
+    expect(result).toMatchObject({
+      success: true,
+      autoReloadTriggered: true,
+      autoReloadResult: { success: true, chargedAmountDollars: 34.5 },
+    });
+  });
+
+  it("retries once when a parallel run consumes a successful reload before deduction", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          status: "active",
+          role: { slug: "admin" },
+        },
+      ],
+    } as never);
+    mockGetOrganization.mockResolvedValue({ stripeCustomerId: "cus_team" });
+    mockInvoicesCreate
+      .mockResolvedValueOnce({ id: "in_parallel_1", status: "draft" } as never)
+      .mockResolvedValueOnce({ id: "in_parallel_2", status: "draft" } as never);
+    mockInvoicesFinalize
+      .mockResolvedValueOnce({ id: "in_parallel_1", status: "open" } as never)
+      .mockResolvedValueOnce({ id: "in_parallel_2", status: "open" } as never);
+    mockInvoicesPay
+      .mockResolvedValueOnce({ id: "in_parallel_1", status: "paid" } as never)
+      .mockResolvedValueOnce({ id: "in_parallel_2", status: "paid" } as never);
+    let deductCalls = 0;
+    let claimCalls = 0;
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        balanceDollars: 0,
+        balancePoints: 0,
+        enabled: true,
+        autoReloadEnabled: true,
+        autoReloadThresholdPoints: 10_000,
+        autoReloadAmountDollars: 15,
+        autoReloadOperationPending: false,
+      })),
+      runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
+        if ("candidateOperationId" in mutationArgs) {
+          claimCalls++;
+          return {
+            status: "operation",
+            operationId: `parallel-op-${claimCalls}`,
+            executorId: `parallel-executor-${claimCalls}`,
+            amountDollars: 15,
+            claimed: true,
+            paymentAllowed: true,
+          };
+        }
+        if (
+          "stripeInvoiceId" in mutationArgs &&
+          "operationId" in mutationArgs
+        ) {
+          return true;
+        }
+        if ("outcome" in mutationArgs) return true;
+        if ("amountDollars" in mutationArgs) {
+          return { newBalance: 15, alreadyProcessed: false };
+        }
+        if ("success" in mutationArgs) return null;
+        if ("amountPoints" in mutationArgs) {
+          deductCalls++;
+          return deductCalls < 3
+            ? {
+                success: false,
+                newBalancePoints: 0,
+                newBalanceDollars: 0,
+                insufficientFunds: true,
+                monthlyCapExceeded: false,
+              }
+            : {
+                success: true,
+                newBalancePoints: 30_434,
+                newBalanceDollars: extraUsagePointsToDollars(30_434),
+                insufficientFunds: false,
+                monthlyCapExceeded: false,
+              };
+        }
+        throw new Error(
+          `Unexpected mutation args: ${JSON.stringify(mutationArgs)}`,
+        );
+      }),
+    };
+
+    const result = await callDeductWithAutoReload(ctx, {
+      userId: "user_member",
+      amountPoints: 100_000,
+    });
+
+    expect(claimCalls).toBe(2);
+    expect(deductCalls).toBe(3);
+    expect(mockInvoicesPay).toHaveBeenNthCalledWith(
+      1,
+      "in_parallel_1",
+      { payment_method: "pm_card" },
+      { idempotencyKey: "parallel-op-1:pay" },
+    );
+    expect(mockInvoicesPay).toHaveBeenNthCalledWith(
+      2,
+      "in_parallel_2",
+      { payment_method: "pm_card" },
+      { idempotencyKey: "parallel-op-2:pay" },
+    );
+    expect(result).toMatchObject({
+      success: true,
+      autoReloadResult: { success: true, chargedAmountDollars: 15 },
     });
   });
 });

--- a/convex/__tests__/extraUsageAutoReloadOperations.test.ts
+++ b/convex/__tests__/extraUsageAutoReloadOperations.test.ts
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  extraUsageDollarsToPoints,
+  extraUsagePointsToDollars,
+} from "../lib/extraUsagePricing";
+
+jest.mock("../_generated/server", () => ({
+  internalMutation: jest.fn((config: any) => config),
+  mutation: jest.fn((config: any) => config),
+  query: jest.fn((config: any) => config),
+}));
+jest.mock("convex/values", () => ({
+  v: {
+    string: jest.fn(() => "string"),
+    number: jest.fn(() => "number"),
+    boolean: jest.fn(() => "boolean"),
+    null: jest.fn(() => "null"),
+    optional: jest.fn(() => "optional"),
+    object: jest.fn(() => "object"),
+    union: jest.fn(() => "union"),
+    literal: jest.fn(() => "literal"),
+  },
+}));
+jest.mock("../lib/utils", () => ({ validateServiceKey: jest.fn() }));
+jest.mock("../lib/logger", () => ({
+  convexLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("../unitEconomicsLib", () => ({
+  recordRevenueEventInternal: jest.fn(),
+}));
+
+type ExtraUsageRow = {
+  _id: string;
+  user_id: string;
+  balance_points: number;
+  auto_reload_enabled?: boolean;
+  auto_reload_threshold_points?: number;
+  auto_reload_amount_dollars?: number;
+  monthly_cap_points?: number;
+  monthly_spent_points?: number;
+  monthly_reset_date?: string;
+  auto_reload_operation_id?: string;
+  auto_reload_operation_executor_id?: string;
+  auto_reload_operation_started_at?: number;
+  auto_reload_operation_lease_expires_at?: number;
+  auto_reload_operation_amount_dollars?: number;
+  auto_reload_operation_stripe_invoice_id?: string;
+  auto_reload_retry_after?: number;
+  auto_reload_last_failure_reason?: string;
+  updated_at: number;
+};
+
+const USER_ID = "user_123";
+
+function makeCtx(row: ExtraUsageRow) {
+  return {
+    db: {
+      query: jest.fn(() => ({
+        withIndex: jest.fn((_index: string, predicate: any) => {
+          const proxy = {
+            eq: (_field: string, _value: string) => proxy,
+          };
+          predicate(proxy);
+          return { first: async () => row };
+        }),
+      })),
+      patch: jest.fn(async (_id: string, patch: Partial<ExtraUsageRow>) => {
+        Object.assign(row, patch);
+      }),
+    },
+  } as any;
+}
+
+const baseRow = (overrides: Partial<ExtraUsageRow> = {}): ExtraUsageRow => ({
+  _id: "extra-1",
+  user_id: USER_ID,
+  balance_points: 200_000,
+  auto_reload_enabled: true,
+  auto_reload_threshold_points: 10_000,
+  auto_reload_amount_dollars: 15,
+  monthly_cap_points: extraUsageDollarsToPoints(100),
+  monthly_spent_points: 0,
+  monthly_reset_date: new Date().toISOString().slice(0, 7),
+  updated_at: 0,
+  ...overrides,
+});
+
+async function claim(
+  ctx: any,
+  args: {
+    candidateOperationId: string;
+    candidateExecutorId: string;
+    requestedAmountPoints: number;
+  },
+) {
+  const { claimAutoReloadOperation } = await import("../extraUsage");
+  return (claimAutoReloadOperation as any).handler(ctx, {
+    userId: USER_ID,
+    ...args,
+  });
+}
+
+describe("personal auto-reload operation claims", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("uses surcharge-aware dollars for an oversized deduction", async () => {
+    const row = baseRow();
+    const result = await claim(makeCtx(row), {
+      candidateOperationId: "op-1",
+      candidateExecutorId: "executor-1",
+      requestedAmountPoints: 300_000,
+    });
+
+    expect(result).toMatchObject({
+      status: "operation",
+      amountDollars: 11.5,
+      operationId: "op-1",
+      claimed: true,
+    });
+    expect(row.auto_reload_operation_amount_dollars).toBe(11.5);
+  });
+
+  it("keeps the one-dollar minimum for a sub-dollar shortfall", async () => {
+    const row = baseRow({ balance_points: 295_000 });
+    const result = await claim(makeCtx(row), {
+      candidateOperationId: "op-minimum",
+      candidateExecutorId: "executor-minimum",
+      requestedAmountPoints: 300_000,
+    });
+
+    expect(result).toMatchObject({
+      status: "operation",
+      amountDollars: 1,
+    });
+    expect(
+      row.balance_points +
+        extraUsageDollarsToPoints(result.amountDollars as number),
+    ).toBeGreaterThanOrEqual(300_000);
+  });
+
+  it("clamps a reload to the remaining monthly headroom", async () => {
+    const remainingPoints = 10_000;
+    const row = baseRow({
+      balance_points: 0,
+      monthly_cap_points: remainingPoints,
+    });
+    const result = await claim(makeCtx(row), {
+      candidateOperationId: "op-cap",
+      candidateExecutorId: "executor-cap",
+      requestedAmountPoints: remainingPoints,
+    });
+
+    expect(result.status).toBe("operation");
+    expect(result.amountDollars).toBe(
+      Number(extraUsagePointsToDollars(remainingPoints).toFixed(2)),
+    );
+    expect(
+      extraUsageDollarsToPoints(result.amountDollars as number),
+    ).toBeGreaterThanOrEqual(remainingPoints);
+  });
+
+  it("allows the one-dollar minimum with exactly one dollar of cap headroom", async () => {
+    const oneDollarPoints = extraUsageDollarsToPoints(1);
+    const row = baseRow({
+      balance_points: 0,
+      monthly_cap_points: oneDollarPoints,
+    });
+    const result = await claim(makeCtx(row), {
+      candidateOperationId: "op-exact-minimum-cap",
+      candidateExecutorId: "executor-exact-minimum-cap",
+      requestedAmountPoints: oneDollarPoints,
+    });
+
+    expect(result).toMatchObject({
+      status: "operation",
+      amountDollars: 1,
+    });
+    expect(extraUsageDollarsToPoints(result.amountDollars as number)).toBe(
+      oneDollarPoints,
+    );
+  });
+
+  it("gives one executor the operation and rejects stale executor writes", async () => {
+    const row = baseRow();
+    const ctx = makeCtx(row);
+    const first = await claim(ctx, {
+      candidateOperationId: "op-first",
+      candidateExecutorId: "executor-first",
+      requestedAmountPoints: 300_000,
+    });
+    const second = await claim(ctx, {
+      candidateOperationId: "op-second",
+      candidateExecutorId: "executor-second",
+      requestedAmountPoints: 300_000,
+    });
+
+    expect(first).toMatchObject({ operationId: "op-first", claimed: true });
+    expect(second).toMatchObject({ operationId: "op-first", claimed: false });
+
+    const { recordAutoReloadInvoice, completeAutoReloadOperation } =
+      await import("../extraUsage");
+    await expect(
+      (recordAutoReloadInvoice as any).handler(ctx, {
+        userId: USER_ID,
+        operationId: "op-first",
+        executorId: "executor-second",
+        stripeInvoiceId: "in_wrong",
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      (completeAutoReloadOperation as any).handler(ctx, {
+        userId: USER_ID,
+        operationId: "op-first",
+        executorId: "executor-second",
+        outcome: "released",
+      }),
+    ).resolves.toBe(false);
+
+    await (completeAutoReloadOperation as any).handler(ctx, {
+      userId: USER_ID,
+      operationId: "op-first",
+      executorId: "executor-first",
+      outcome: "executor_released",
+    });
+    const takeover = await claim(ctx, {
+      candidateOperationId: "op-third",
+      candidateExecutorId: "executor-third",
+      requestedAmountPoints: 300_000,
+    });
+    expect(takeover).toMatchObject({
+      operationId: "op-first",
+      executorId: "executor-third",
+      claimed: true,
+      paymentAllowed: true,
+    });
+  });
+
+  it("revalidates an unpaid operation after a manual credit", async () => {
+    const row = baseRow();
+    const ctx = makeCtx(row);
+    await claim(ctx, {
+      candidateOperationId: "op-before-credit",
+      candidateExecutorId: "executor-before-credit",
+      requestedAmountPoints: 300_000,
+    });
+
+    const { completeAutoReloadOperation } = await import("../extraUsage");
+    await (completeAutoReloadOperation as any).handler(ctx, {
+      userId: USER_ID,
+      operationId: "op-before-credit",
+      executorId: "executor-before-credit",
+      outcome: "executor_released",
+    });
+    row.balance_points = 300_000;
+
+    const resumed = await claim(ctx, {
+      candidateOperationId: "op-after-credit",
+      candidateExecutorId: "executor-after-credit",
+      requestedAmountPoints: 300_000,
+    });
+
+    expect(resumed).toMatchObject({
+      status: "operation",
+      operationId: "op-before-credit",
+      claimed: true,
+      paymentAllowed: false,
+      paymentBlockedReason: "not_needed",
+    });
+  });
+
+  it("does not resume an operation too small for the current request", async () => {
+    const row = baseRow({
+      balance_points: 0,
+      auto_reload_operation_id: "op-small",
+      auto_reload_operation_executor_id: undefined,
+      auto_reload_operation_started_at: Date.now(),
+      auto_reload_operation_lease_expires_at: 0,
+      auto_reload_operation_amount_dollars: 1,
+    });
+
+    const resumed = await claim(makeCtx(row), {
+      candidateOperationId: "op-large-request",
+      candidateExecutorId: "executor-large-request",
+      requestedAmountPoints: 300_000,
+    });
+
+    expect(resumed).toMatchObject({
+      status: "operation",
+      operationId: "op-small",
+      claimed: true,
+      paymentAllowed: false,
+      paymentBlockedReason: "reload_amount_insufficient",
+    });
+  });
+});

--- a/convex/__tests__/teamExtraUsage.test.ts
+++ b/convex/__tests__/teamExtraUsage.test.ts
@@ -31,9 +31,12 @@ jest.mock("@workos-inc/node", () => ({
 const mockCustomerRetrieve = jest.fn();
 const mockSubscriptionsList = jest.fn();
 const mockInvoicesCreate = jest.fn();
+const mockInvoicesRetrieve = jest.fn();
 const mockInvoiceItemsCreate = jest.fn();
 const mockInvoicesFinalize = jest.fn();
 const mockInvoicesPay = jest.fn();
+const mockInvoicesVoid = jest.fn();
+const mockInvoicesDelete = jest.fn();
 jest.mock("stripe", () => {
   const Stripe = jest.fn().mockImplementation(() => ({
     customers: {
@@ -44,8 +47,11 @@ jest.mock("stripe", () => {
     },
     invoices: {
       create: mockInvoicesCreate,
+      retrieve: mockInvoicesRetrieve,
       finalizeInvoice: mockInvoicesFinalize,
       pay: mockInvoicesPay,
+      voidInvoice: mockInvoicesVoid,
+      del: mockInvoicesDelete,
     },
     invoiceItems: {
       create: mockInvoiceItemsCreate,
@@ -126,6 +132,14 @@ type TeamRow = {
   monthly_reset_date?: string;
   auto_reload_consecutive_failures?: number;
   auto_reload_disabled_reason?: string;
+  auto_reload_operation_id?: string;
+  auto_reload_operation_executor_id?: string;
+  auto_reload_operation_started_at?: number;
+  auto_reload_operation_lease_expires_at?: number;
+  auto_reload_operation_amount_dollars?: number;
+  auto_reload_operation_stripe_invoice_id?: string;
+  auto_reload_retry_after?: number;
+  auto_reload_last_failure_reason?: string;
   updated_at: number;
 };
 
@@ -338,6 +352,60 @@ async function callDeductWithAutoReloadForTeam(
   return (deductWithAutoReloadForTeam as any).handler(ctx, {
     serviceKey: SERVICE_KEY,
     ...args,
+  });
+}
+
+async function callClaimTeamAutoReload(
+  ctx: any,
+  args: {
+    organizationId: string;
+    candidateOperationId: string;
+    candidateExecutorId: string;
+    requestedAmountPoints: number;
+  },
+) {
+  const { claimTeamAutoReloadOperation } = await import("../teamExtraUsage");
+  return (claimTeamAutoReloadOperation as any).handler(ctx, args);
+}
+
+const claimedTeamAutoReload = (amountDollars: number) => ({
+  status: "operation",
+  operationId: "team_reload_op",
+  executorId: "team_reload_executor",
+  amountDollars,
+  startedAt: Date.now(),
+  claimed: true,
+  paymentAllowed: true,
+});
+
+function makeTeamAutoReloadMutationMock({
+  amountDollars,
+  initialDeduct,
+  finalDeduct = initialDeduct,
+  creditBalance = amountDollars,
+}: {
+  amountDollars: number;
+  initialDeduct: Record<string, unknown>;
+  finalDeduct?: Record<string, unknown>;
+  creditBalance?: number;
+}) {
+  let deductCalls = 0;
+  return jest.fn(async (_mutation: unknown, mutationArgs: any) => {
+    if ("candidateOperationId" in mutationArgs) {
+      return claimedTeamAutoReload(amountDollars);
+    }
+    if ("stripeInvoiceId" in mutationArgs && "operationId" in mutationArgs) {
+      return true;
+    }
+    if ("outcome" in mutationArgs) return true;
+    if ("amountDollars" in mutationArgs) {
+      return { newBalance: creditBalance, alreadyProcessed: false };
+    }
+    if ("success" in mutationArgs && !("amountPoints" in mutationArgs)) {
+      return null;
+    }
+    deductCalls++;
+    return deductCalls === 1 ? initialDeduct : finalDeduct;
   });
 }
 
@@ -626,6 +694,145 @@ describe("deductTeamPoints", () => {
   });
 });
 
+describe("team auto-reload operation claims", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("allows the one-dollar minimum with exactly one dollar of cap headroom", async () => {
+    const oneDollarPoints = extraUsageDollarsToPoints(1);
+    const { ctx } = makeMockCtx({
+      team: [
+        enabledTeamRow({
+          balance_points: 0,
+          auto_reload_enabled: true,
+          auto_reload_threshold_points: 0,
+          auto_reload_amount_dollars: 15,
+          monthly_cap_points: oneDollarPoints,
+          monthly_spent_points: 0,
+          monthly_reset_date: new Date().toISOString().slice(0, 7),
+        }),
+      ],
+    });
+
+    const result = await callClaimTeamAutoReload(ctx, {
+      organizationId: ORG_ID,
+      candidateOperationId: "team-op-exact-minimum-cap",
+      candidateExecutorId: "team-executor-exact-minimum-cap",
+      requestedAmountPoints: oneDollarPoints,
+    });
+
+    expect(result).toMatchObject({
+      status: "operation",
+      amountDollars: 1,
+    });
+  });
+
+  it("coalesces parallel claims and only allows the executor to complete", async () => {
+    const { ctx, team } = makeMockCtx({
+      team: [
+        enabledTeamRow({
+          balance_points: 200_000,
+          auto_reload_enabled: true,
+          auto_reload_threshold_points: 10_000,
+          auto_reload_amount_dollars: 15,
+          monthly_cap_points: extraUsageDollarsToPoints(100),
+          monthly_spent_points: 0,
+          monthly_reset_date: new Date().toISOString().slice(0, 7),
+        }),
+      ],
+    });
+
+    const first = await callClaimTeamAutoReload(ctx, {
+      organizationId: ORG_ID,
+      candidateOperationId: "team-op-first",
+      candidateExecutorId: "team-executor-first",
+      requestedAmountPoints: 300_000,
+    });
+    const second = await callClaimTeamAutoReload(ctx, {
+      organizationId: ORG_ID,
+      candidateOperationId: "team-op-second",
+      candidateExecutorId: "team-executor-second",
+      requestedAmountPoints: 300_000,
+    });
+
+    expect(first).toMatchObject({
+      operationId: "team-op-first",
+      amountDollars: 11.5,
+      claimed: true,
+    });
+    expect(second).toMatchObject({
+      operationId: "team-op-first",
+      claimed: false,
+    });
+
+    const { completeTeamAutoReloadOperation } =
+      await import("../teamExtraUsage");
+    await expect(
+      (completeTeamAutoReloadOperation as any).handler(ctx, {
+        organizationId: ORG_ID,
+        operationId: "team-op-first",
+        executorId: "team-executor-second",
+        outcome: "released",
+      }),
+    ).resolves.toBe(false);
+    expect(team[0].auto_reload_operation_id).toBe("team-op-first");
+
+    await (completeTeamAutoReloadOperation as any).handler(ctx, {
+      organizationId: ORG_ID,
+      operationId: "team-op-first",
+      executorId: "team-executor-first",
+      outcome: "executor_released",
+    });
+    team[0].balance_points = 300_000;
+    const resumedAfterCredit = await callClaimTeamAutoReload(ctx, {
+      organizationId: ORG_ID,
+      candidateOperationId: "team-op-after-credit",
+      candidateExecutorId: "team-executor-after-credit",
+      requestedAmountPoints: 300_000,
+    });
+    expect(resumedAfterCredit).toMatchObject({
+      operationId: "team-op-first",
+      claimed: true,
+      paymentAllowed: false,
+      paymentBlockedReason: "not_needed",
+    });
+  });
+
+  it("does not resume an operation too small for the current request", async () => {
+    const { ctx } = makeMockCtx({
+      team: [
+        enabledTeamRow({
+          balance_points: 0,
+          auto_reload_enabled: true,
+          auto_reload_threshold_points: 10_000,
+          auto_reload_amount_dollars: 15,
+          monthly_cap_points: extraUsageDollarsToPoints(100),
+          monthly_spent_points: 0,
+          monthly_reset_date: new Date().toISOString().slice(0, 7),
+          auto_reload_operation_id: "team-op-small",
+          auto_reload_operation_started_at: Date.now(),
+          auto_reload_operation_lease_expires_at: 0,
+          auto_reload_operation_amount_dollars: 1,
+        }),
+      ],
+    });
+
+    const resumed = await callClaimTeamAutoReload(ctx, {
+      organizationId: ORG_ID,
+      candidateOperationId: "team-op-large-request",
+      candidateExecutorId: "team-executor-large-request",
+      requestedAmountPoints: 300_000,
+    });
+
+    expect(resumed).toMatchObject({
+      status: "operation",
+      operationId: "team-op-small",
+      claimed: true,
+      paymentAllowed: false,
+      paymentBlockedReason: "reload_amount_insufficient",
+    });
+  });
+});
+
 describe("deductWithAutoReloadForTeam", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -637,7 +844,14 @@ describe("deductWithAutoReloadForTeam", () => {
     mockSubscriptionsList.mockResolvedValue({
       data: [{ default_payment_method: "pm_card" }],
     } as never);
-    mockInvoicesCreate.mockResolvedValue({ id: "in_team_auto" } as never);
+    mockInvoicesCreate.mockResolvedValue({
+      id: "in_team_auto",
+      status: "draft",
+    } as never);
+    mockInvoicesRetrieve.mockResolvedValue({
+      id: "in_team_auto",
+      status: "open",
+    } as never);
     mockInvoiceItemsCreate.mockResolvedValue({ id: "ii_team_auto" } as never);
     mockInvoicesFinalize.mockResolvedValue({
       id: "in_team_auto",
@@ -647,6 +861,14 @@ describe("deductWithAutoReloadForTeam", () => {
       id: "in_team_auto",
       status: "paid",
       payment_intent: "pi_team_auto",
+    } as never);
+    mockInvoicesVoid.mockResolvedValue({
+      id: "in_team_auto",
+      status: "void",
+    } as never);
+    mockInvoicesDelete.mockResolvedValue({
+      id: "in_team_auto",
+      deleted: true,
     } as never);
   });
 
@@ -663,16 +885,19 @@ describe("deductWithAutoReloadForTeam", () => {
         autoReloadAmountDollars: 15,
         memberDisabled: false,
       })),
-      runMutation: jest.fn(async () => ({
-        success: true,
-        newBalancePoints: 70_000,
-        newBalanceDollars: 7,
-        insufficientFunds: false,
-        monthlyCapExceeded: false,
-        memberCapExceeded: false,
-        memberDisabled: false,
-        poolDisabled: false,
-      })),
+      runMutation: makeTeamAutoReloadMutationMock({
+        amountDollars: 6.95,
+        initialDeduct: {
+          success: true,
+          newBalancePoints: 70_000,
+          newBalanceDollars: extraUsagePointsToDollars(70_000),
+          insufficientFunds: false,
+          monthlyCapExceeded: false,
+          memberCapExceeded: false,
+          memberDisabled: false,
+          poolDisabled: false,
+        },
+      }),
     };
 
     const result = await callDeductWithAutoReloadForTeam(ctx, {
@@ -684,7 +909,7 @@ describe("deductWithAutoReloadForTeam", () => {
     expect(mockGetOrganization).toHaveBeenCalledWith(ORG_ID);
     expect(result).toMatchObject({
       success: true,
-      newBalanceDollars: 7,
+      newBalanceDollars: extraUsagePointsToDollars(70_000),
       autoReloadTriggered: true,
       autoReloadResult: { success: false, reason: "no_stripe_customer" },
     });
@@ -743,16 +968,19 @@ describe("deductWithAutoReloadForTeam", () => {
         autoReloadAmountDollars: 15,
         memberDisabled: false,
       })),
-      runMutation: jest.fn(async () => ({
-        success: false,
-        newBalancePoints: 200_000,
-        newBalanceDollars: 20,
-        insufficientFunds: true,
-        monthlyCapExceeded: false,
-        memberCapExceeded: false,
-        memberDisabled: false,
-        poolDisabled: false,
-      })),
+      runMutation: makeTeamAutoReloadMutationMock({
+        amountDollars: 11.5,
+        initialDeduct: {
+          success: false,
+          newBalancePoints: 200_000,
+          newBalanceDollars: extraUsagePointsToDollars(200_000),
+          insufficientFunds: true,
+          monthlyCapExceeded: false,
+          memberCapExceeded: false,
+          memberDisabled: false,
+          poolDisabled: false,
+        },
+      }),
     };
 
     const result = await callDeductWithAutoReloadForTeam(ctx, {
@@ -762,7 +990,7 @@ describe("deductWithAutoReloadForTeam", () => {
     });
 
     expect(mockGetOrganization).toHaveBeenCalledWith(ORG_ID);
-    expect(ctx.runMutation).toHaveBeenCalledTimes(1);
+    expect(ctx.runMutation).toHaveBeenCalledTimes(3);
     expect(result).toMatchObject({
       success: false,
       insufficientFunds: true,
@@ -773,7 +1001,6 @@ describe("deductWithAutoReloadForTeam", () => {
 
   it("charges enough to cover a team deduction when it exceeds the reload target", async () => {
     mockGetOrganization.mockResolvedValue({ stripeCustomerId: "cus_team" });
-    let deductAttempts = 0;
     const ctx: any = {
       runQuery: jest.fn(async () => ({
         enabled: true,
@@ -785,35 +1012,29 @@ describe("deductWithAutoReloadForTeam", () => {
         autoReloadAmountDollars: 15,
         memberDisabled: false,
       })),
-      runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
-        if ("amountDollars" in mutationArgs) {
-          return { newBalance: 34.5 };
-        }
-        if ("success" in mutationArgs && !("amountPoints" in mutationArgs)) {
-          return null;
-        }
-        deductAttempts++;
-        return deductAttempts === 1
-          ? {
-              success: false,
-              newBalancePoints: 200_000,
-              newBalanceDollars: 20,
-              insufficientFunds: true,
-              monthlyCapExceeded: false,
-              memberCapExceeded: false,
-              memberDisabled: false,
-              poolDisabled: false,
-            }
-          : {
-              success: true,
-              newBalancePoints: 0,
-              newBalanceDollars: 0,
-              insufficientFunds: false,
-              monthlyCapExceeded: false,
-              memberCapExceeded: false,
-              memberDisabled: false,
-              poolDisabled: false,
-            };
+      runMutation: makeTeamAutoReloadMutationMock({
+        amountDollars: 11.5,
+        initialDeduct: {
+          success: false,
+          newBalancePoints: 200_000,
+          newBalanceDollars: extraUsagePointsToDollars(200_000),
+          insufficientFunds: true,
+          monthlyCapExceeded: false,
+          memberCapExceeded: false,
+          memberDisabled: false,
+          poolDisabled: false,
+        },
+        finalDeduct: {
+          success: true,
+          newBalancePoints: 0,
+          newBalanceDollars: 0,
+          insufficientFunds: false,
+          monthlyCapExceeded: false,
+          memberCapExceeded: false,
+          memberDisabled: false,
+          poolDisabled: false,
+        },
+        creditBalance: 34.5,
       }),
     };
 
@@ -825,11 +1046,428 @@ describe("deductWithAutoReloadForTeam", () => {
 
     expect(mockInvoiceItemsCreate).toHaveBeenCalledWith(
       expect.objectContaining({ amount: 1150 }),
+      { idempotencyKey: "team_reload_op:item" },
+    );
+    expect(mockInvoicesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ operationId: "team_reload_op" }),
+      }),
+      { idempotencyKey: "team_reload_op:invoice" },
+    );
+    expect(mockInvoicesFinalize).toHaveBeenCalledWith(
+      "in_team_auto",
+      {},
+      { idempotencyKey: "team_reload_op:finalize" },
+    );
+    expect(mockInvoicesPay).toHaveBeenCalledWith(
+      "in_team_auto",
+      { payment_method: "pm_card" },
+      { idempotencyKey: "team_reload_op:pay" },
+    );
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        idempotencyKey: "team_auto_reload:team_reload_op",
+        stripeInvoiceId: "in_team_auto",
+      }),
     );
     expect(result).toMatchObject({
       success: true,
       autoReloadTriggered: true,
       autoReloadResult: { success: true, chargedAmountDollars: 11.5 },
+    });
+  });
+
+  it("credits and clears a persisted paid invoice without a PaymentIntent", async () => {
+    mockInvoicesRetrieve.mockResolvedValueOnce({
+      id: "in_team_paid_recovery",
+      status: "paid",
+    } as never);
+    const deductResult = {
+      success: true,
+      newBalancePoints: 200_000,
+      newBalanceDollars: extraUsagePointsToDollars(200_000),
+      insufficientFunds: false,
+      monthlyCapExceeded: false,
+      memberCapExceeded: false,
+      memberDisabled: false,
+      poolDisabled: false,
+    };
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        enabled: true,
+        balanceDollars: deductResult.newBalanceDollars,
+        balancePoints: deductResult.newBalancePoints,
+        autoReloadEnabled: false,
+        autoReloadThresholdPoints: 10_000,
+        autoReloadOperationPending: true,
+        memberDisabled: false,
+      })),
+      runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
+        if ("amountPoints" in mutationArgs) return deductResult;
+        if ("candidateOperationId" in mutationArgs) {
+          return {
+            status: "operation",
+            operationId: "team-paid-recovery-op",
+            executorId: "team-paid-recovery-executor",
+            amountDollars: 15,
+            stripeInvoiceId: "in_team_paid_recovery",
+            claimed: true,
+            paymentAllowed: false,
+            paymentBlockedReason: "auto_reload_disabled",
+          };
+        }
+        if ("amountDollars" in mutationArgs) {
+          return { newBalance: 38, alreadyProcessed: false };
+        }
+        if ("outcome" in mutationArgs) return true;
+        return null;
+      }),
+    };
+
+    const result = await callDeductWithAutoReloadForTeam(ctx, {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      amountPoints: 10_000,
+    });
+
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        amountDollars: 15,
+        idempotencyKey: "team_auto_reload:team-paid-recovery-op",
+        stripeInvoiceId: "in_team_paid_recovery",
+      }),
+    );
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        operationId: "team-paid-recovery-op",
+        outcome: "success",
+      }),
+    );
+    expect(mockGetOrganization).not.toHaveBeenCalled();
+    expect(mockInvoicesPay).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      success: true,
+      newBalanceDollars: 38,
+      autoReloadTriggered: true,
+      autoReloadResult: { success: true, chargedAmountDollars: 15 },
+    });
+  });
+
+  it("does not pay a persisted unpaid invoice when reload is no longer needed", async () => {
+    mockInvoicesRetrieve.mockResolvedValueOnce({
+      id: "in_team_stale_open",
+      status: "open",
+    } as never);
+    const deductResult = {
+      success: true,
+      newBalancePoints: 200_000,
+      newBalanceDollars: extraUsagePointsToDollars(200_000),
+      insufficientFunds: false,
+      monthlyCapExceeded: false,
+      memberCapExceeded: false,
+      memberDisabled: false,
+      poolDisabled: false,
+    };
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        enabled: true,
+        balanceDollars: deductResult.newBalanceDollars,
+        balancePoints: deductResult.newBalancePoints,
+        autoReloadEnabled: true,
+        autoReloadThresholdPoints: 10_000,
+        autoReloadOperationPending: true,
+        memberDisabled: false,
+      })),
+      runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
+        if ("amountPoints" in mutationArgs) return deductResult;
+        if ("candidateOperationId" in mutationArgs) {
+          return {
+            status: "operation",
+            operationId: "team-stale-open-op",
+            executorId: "team-stale-open-executor",
+            amountDollars: 15,
+            stripeInvoiceId: "in_team_stale_open",
+            claimed: true,
+            paymentAllowed: false,
+            paymentBlockedReason: "not_needed",
+          };
+        }
+        if ("outcome" in mutationArgs) return true;
+        throw new Error(
+          `Unexpected mutation args: ${JSON.stringify(mutationArgs)}`,
+        );
+      }),
+    };
+
+    const result = await callDeductWithAutoReloadForTeam(ctx, {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      amountPoints: 10_000,
+    });
+
+    expect(mockInvoicesPay).not.toHaveBeenCalled();
+    expect(mockGetOrganization).not.toHaveBeenCalled();
+    expect(mockInvoicesVoid).toHaveBeenCalledWith(
+      "in_team_stale_open",
+      {},
+      { idempotencyKey: "team-stale-open-op:void-stale" },
+    );
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        operationId: "team-stale-open-op",
+        outcome: "released",
+      }),
+    );
+    expect(result).toMatchObject({
+      success: true,
+      autoReloadTriggered: true,
+      autoReloadResult: { success: false, reason: "not_needed" },
+    });
+  });
+
+  it("voids an undersized open operation and retries once for the current request", async () => {
+    mockGetOrganization.mockResolvedValue({ stripeCustomerId: "cus_team" });
+    mockInvoicesRetrieve.mockResolvedValueOnce({
+      id: "in_team_undersized",
+      status: "open",
+    } as never);
+    mockInvoicesVoid.mockResolvedValueOnce({
+      id: "in_team_undersized",
+      status: "void",
+    } as never);
+    let deductCalls = 0;
+    let claimCalls = 0;
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        enabled: true,
+        balanceDollars: 0,
+        balancePoints: 0,
+        autoReloadEnabled: true,
+        autoReloadThresholdPoints: 10_000,
+        autoReloadAmountDollars: 15,
+        autoReloadOperationPending: true,
+        memberDisabled: false,
+      })),
+      runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
+        if ("candidateOperationId" in mutationArgs) {
+          claimCalls++;
+          return claimCalls === 1
+            ? {
+                status: "operation",
+                operationId: "team-undersized-op",
+                executorId: "team-undersized-executor",
+                amountDollars: 1,
+                stripeInvoiceId: "in_team_undersized",
+                claimed: true,
+                paymentAllowed: false,
+                paymentBlockedReason: "reload_amount_insufficient",
+              }
+            : {
+                status: "operation",
+                operationId: "team-correctly-sized-op",
+                executorId: "team-correctly-sized-executor",
+                amountDollars: 34.5,
+                claimed: true,
+                paymentAllowed: true,
+              };
+        }
+        if (
+          "stripeInvoiceId" in mutationArgs &&
+          "operationId" in mutationArgs
+        ) {
+          return true;
+        }
+        if ("outcome" in mutationArgs) return true;
+        if ("amountDollars" in mutationArgs) {
+          return { newBalance: 34.5, alreadyProcessed: false };
+        }
+        if ("success" in mutationArgs) return null;
+        if ("amountPoints" in mutationArgs) {
+          deductCalls++;
+          return deductCalls === 1
+            ? {
+                success: false,
+                newBalancePoints: 0,
+                newBalanceDollars: 0,
+                insufficientFunds: true,
+                monthlyCapExceeded: false,
+                memberCapExceeded: false,
+                memberDisabled: false,
+                poolDisabled: false,
+              }
+            : {
+                success: true,
+                newBalancePoints: 0,
+                newBalanceDollars: 0,
+                insufficientFunds: false,
+                monthlyCapExceeded: false,
+                memberCapExceeded: false,
+                memberDisabled: false,
+                poolDisabled: false,
+              };
+        }
+        throw new Error(
+          `Unexpected mutation args: ${JSON.stringify(mutationArgs)}`,
+        );
+      }),
+    };
+
+    const result = await callDeductWithAutoReloadForTeam(ctx, {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      amountPoints: 300_000,
+    });
+
+    expect(claimCalls).toBe(2);
+    expect(mockInvoicesVoid).toHaveBeenCalledWith(
+      "in_team_undersized",
+      {},
+      { idempotencyKey: "team-undersized-op:void-stale" },
+    );
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        operationId: "team-undersized-op",
+        outcome: "released",
+      }),
+    );
+    expect(mockInvoicesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          operationId: "team-correctly-sized-op",
+        }),
+      }),
+      { idempotencyKey: "team-correctly-sized-op:invoice" },
+    );
+    expect(result).toMatchObject({
+      success: true,
+      autoReloadTriggered: true,
+      autoReloadResult: { success: true, chargedAmountDollars: 34.5 },
+    });
+  });
+
+  it("retries once when a parallel team run consumes a successful reload", async () => {
+    mockGetOrganization.mockResolvedValue({ stripeCustomerId: "cus_team" });
+    mockInvoicesCreate
+      .mockResolvedValueOnce({
+        id: "in_team_parallel_1",
+        status: "draft",
+      } as never)
+      .mockResolvedValueOnce({
+        id: "in_team_parallel_2",
+        status: "draft",
+      } as never);
+    mockInvoicesFinalize
+      .mockResolvedValueOnce({
+        id: "in_team_parallel_1",
+        status: "open",
+      } as never)
+      .mockResolvedValueOnce({
+        id: "in_team_parallel_2",
+        status: "open",
+      } as never);
+    mockInvoicesPay
+      .mockResolvedValueOnce({
+        id: "in_team_parallel_1",
+        status: "paid",
+      } as never)
+      .mockResolvedValueOnce({
+        id: "in_team_parallel_2",
+        status: "paid",
+      } as never);
+    let deductCalls = 0;
+    let claimCalls = 0;
+    const ctx: any = {
+      runQuery: jest.fn(async () => ({
+        enabled: true,
+        balanceDollars: 0,
+        balancePoints: 0,
+        autoReloadEnabled: true,
+        autoReloadThresholdPoints: 10_000,
+        autoReloadAmountDollars: 15,
+        autoReloadOperationPending: false,
+        memberDisabled: false,
+      })),
+      runMutation: jest.fn(async (_mutation: unknown, mutationArgs: any) => {
+        if ("candidateOperationId" in mutationArgs) {
+          claimCalls++;
+          return {
+            status: "operation",
+            operationId: `team-parallel-op-${claimCalls}`,
+            executorId: `team-parallel-executor-${claimCalls}`,
+            amountDollars: 15,
+            claimed: true,
+            paymentAllowed: true,
+          };
+        }
+        if (
+          "stripeInvoiceId" in mutationArgs &&
+          "operationId" in mutationArgs
+        ) {
+          return true;
+        }
+        if ("outcome" in mutationArgs) return true;
+        if ("amountDollars" in mutationArgs) {
+          return { newBalance: 15, alreadyProcessed: false };
+        }
+        if ("success" in mutationArgs) return null;
+        if ("amountPoints" in mutationArgs) {
+          deductCalls++;
+          return deductCalls < 3
+            ? {
+                success: false,
+                newBalancePoints: 0,
+                newBalanceDollars: 0,
+                insufficientFunds: true,
+                monthlyCapExceeded: false,
+                memberCapExceeded: false,
+                memberDisabled: false,
+                poolDisabled: false,
+              }
+            : {
+                success: true,
+                newBalancePoints: 30_434,
+                newBalanceDollars: extraUsagePointsToDollars(30_434),
+                insufficientFunds: false,
+                monthlyCapExceeded: false,
+                memberCapExceeded: false,
+                memberDisabled: false,
+                poolDisabled: false,
+              };
+        }
+        throw new Error(
+          `Unexpected mutation args: ${JSON.stringify(mutationArgs)}`,
+        );
+      }),
+    };
+
+    const result = await callDeductWithAutoReloadForTeam(ctx, {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      amountPoints: 100_000,
+    });
+
+    expect(claimCalls).toBe(2);
+    expect(deductCalls).toBe(3);
+    expect(mockInvoicesPay).toHaveBeenNthCalledWith(
+      1,
+      "in_team_parallel_1",
+      { payment_method: "pm_card" },
+      { idempotencyKey: "team-parallel-op-1:pay" },
+    );
+    expect(mockInvoicesPay).toHaveBeenNthCalledWith(
+      2,
+      "in_team_parallel_2",
+      { payment_method: "pm_card" },
+      { idempotencyKey: "team-parallel-op-2:pay" },
+    );
+    expect(result).toMatchObject({
+      success: true,
+      autoReloadResult: { success: true, chargedAmountDollars: 15 },
     });
   });
 });

--- a/convex/extraUsage.ts
+++ b/convex/extraUsage.ts
@@ -17,13 +17,25 @@ import { validateMonthlyCapDollars } from "./lib/extraUsageValidation";
 
 type ExtraUsagePurchaseStatus = "created" | "paid_seen" | "credited" | "failed";
 type ExtraUsagePurchaseRoute =
-  "checkout_action" | "confirm" | "webhook" | "repair";
+  | "checkout_action"
+  | "confirm"
+  | "webhook"
+  | "repair";
 type ExtraUsagePurchaseResult =
-  "created" | "paid_seen" | "credited" | "already_processed" | "failed";
+  | "created"
+  | "paid_seen"
+  | "credited"
+  | "already_processed"
+  | "failed";
 type MaxModelExtraUsageReason =
-  "available" | "disabled" | "empty" | "monthly_cap_exhausted";
+  | "available"
+  | "disabled"
+  | "empty"
+  | "monthly_cap_exhausted";
 
 const MAX_PURCHASE_ERROR_LENGTH = 500;
+const AUTO_RELOAD_RETRY_COOLDOWN_MS = 15_000;
+const AUTO_RELOAD_OPERATION_LEASE_MS = 2 * 60_000;
 const PURCHASE_JSON_SECRET_PATTERN =
   /(["'])(serviceKey|service_key|apiKey|api_key|authorization|cookie|password|secret|token)\1\s*:\s*(["'])(?:(?!\3).)*\3/gi;
 const PURCHASE_ASSIGNMENT_SECRET_PATTERN =
@@ -63,6 +75,90 @@ const getMonthlySpentPointsForCurrentMonth = (
     return 0;
   }
   return settings.monthly_spent_points ?? 0;
+};
+
+type AutoReloadChargeEvaluation =
+  | { allowed: true; amountCents: number }
+  | { allowed: false; reason: string };
+
+/**
+ * Evaluate an auto-reload from one transactional wallet snapshot.
+ *
+ * Keeping this calculation shared by new and resumed operations prevents an
+ * old invoice from bypassing a later balance, configuration, or cap change.
+ */
+const evaluateAutoReloadCharge = ({
+  balancePoints,
+  thresholdPoints,
+  reloadAmountDollars,
+  requestedAmountPoints,
+  monthlyRemainingPoints,
+}: {
+  balancePoints: number;
+  thresholdPoints: number;
+  reloadAmountDollars: number;
+  requestedAmountPoints: number;
+  monthlyRemainingPoints?: number;
+}): AutoReloadChargeEvaluation => {
+  if (reloadAmountDollars <= 0) {
+    return { allowed: false, reason: "reload_amount_not_configured" };
+  }
+
+  if (
+    requestedAmountPoints > 0
+      ? balancePoints >= requestedAmountPoints
+      : balancePoints > thresholdPoints
+  ) {
+    return { allowed: false, reason: "not_needed" };
+  }
+
+  if (
+    monthlyRemainingPoints !== undefined &&
+    requestedAmountPoints > monthlyRemainingPoints
+  ) {
+    return { allowed: false, reason: "monthly_cap_exceeded" };
+  }
+
+  const targetBalancePoints = Math.max(
+    dollarsToPoints(reloadAmountDollars),
+    requestedAmountPoints,
+  );
+  const desiredTopUpPoints = Math.max(0, targetBalancePoints - balancePoints);
+  const capHeadroomPoints =
+    monthlyRemainingPoints === undefined
+      ? undefined
+      : Math.max(0, monthlyRemainingPoints - balancePoints);
+  const desiredCents = Math.ceil(
+    Number((pointsToDollars(desiredTopUpPoints) * 100).toFixed(6)),
+  );
+  const desiredChargeCents =
+    requestedAmountPoints > 0 && desiredCents > 0
+      ? Math.max(100, desiredCents)
+      : desiredCents;
+  let maxAllowedCents = desiredChargeCents;
+  if (capHeadroomPoints !== undefined) {
+    maxAllowedCents = Math.ceil(
+      Number((pointsToDollars(capHeadroomPoints) * 100).toFixed(6)),
+    );
+    while (
+      maxAllowedCents > 0 &&
+      dollarsToPoints(maxAllowedCents / 100) > capHeadroomPoints
+    ) {
+      maxAllowedCents--;
+    }
+  }
+
+  const amountCents = Math.min(desiredChargeCents, maxAllowedCents);
+  const creditedPoints = dollarsToPoints(amountCents / 100);
+  if (
+    amountCents < 100 ||
+    (requestedAmountPoints > 0 &&
+      balancePoints + creditedPoints < requestedAmountPoints)
+  ) {
+    return { allowed: false, reason: "amount_to_charge_below_minimum" };
+  }
+
+  return { allowed: true, amountCents };
 };
 
 async function upsertExtraUsagePurchase(
@@ -747,6 +843,259 @@ export const deductPoints = mutation({
 });
 
 /**
+ * Atomically coalesce parallel auto-reload attempts for one user.
+ *
+ * The returned operation id is also the root Stripe idempotency key. A caller
+ * that finds an existing operation must resume that operation rather than
+ * creating a second invoice from another low-balance snapshot.
+ */
+export const claimAutoReloadOperation = internalMutation({
+  args: {
+    userId: v.string(),
+    candidateOperationId: v.string(),
+    candidateExecutorId: v.string(),
+    requestedAmountPoints: v.number(),
+  },
+  returns: v.object({
+    status: v.union(
+      v.literal("operation"),
+      v.literal("not_needed"),
+      v.literal("blocked"),
+      v.literal("cooldown"),
+    ),
+    operationId: v.optional(v.string()),
+    amountDollars: v.optional(v.number()),
+    stripeInvoiceId: v.optional(v.string()),
+    startedAt: v.optional(v.number()),
+    executorId: v.optional(v.string()),
+    claimed: v.optional(v.boolean()),
+    paymentAllowed: v.optional(v.boolean()),
+    paymentBlockedReason: v.optional(v.string()),
+    reason: v.optional(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    const settings = await ctx.db
+      .query("extra_usage")
+      .withIndex("by_user_id", (q) => q.eq("user_id", args.userId))
+      .first();
+
+    const now = Date.now();
+    const requestedAmountPoints = Math.max(
+      0,
+      Math.round(args.requestedAmountPoints),
+    );
+    const monthlySpentPoints = getMonthlySpentPointsForCurrentMonth(settings);
+    const monthlyCapPoints = settings?.monthly_cap_points;
+    const monthlyRemainingPoints =
+      monthlyCapPoints === undefined
+        ? undefined
+        : Math.max(0, monthlyCapPoints - monthlySpentPoints);
+    if (
+      settings?.auto_reload_operation_id &&
+      settings.auto_reload_operation_amount_dollars !== undefined
+    ) {
+      const leaseExpired =
+        (settings.auto_reload_operation_lease_expires_at ?? 0) <= now;
+      if (leaseExpired) {
+        await ctx.db.patch(settings._id, {
+          auto_reload_operation_executor_id: args.candidateExecutorId,
+          auto_reload_operation_lease_expires_at:
+            now + AUTO_RELOAD_OPERATION_LEASE_MS,
+          updated_at: now,
+        });
+      }
+      const evaluation = settings.auto_reload_enabled
+        ? evaluateAutoReloadCharge({
+            balancePoints: settings.balance_points ?? 0,
+            thresholdPoints: settings.auto_reload_threshold_points ?? 0,
+            reloadAmountDollars: settings.auto_reload_amount_dollars ?? 0,
+            requestedAmountPoints,
+            monthlyRemainingPoints,
+          })
+        : ({ allowed: false, reason: "auto_reload_disabled" } as const);
+      const operationAmountCents = Math.round(
+        settings.auto_reload_operation_amount_dollars * 100,
+      );
+      const balancePoints = settings.balance_points ?? 0;
+      const operationBalancePoints =
+        balancePoints +
+        dollarsToPoints(settings.auto_reload_operation_amount_dollars);
+      const operationSatisfiesNeed =
+        requestedAmountPoints > 0
+          ? operationBalancePoints >= requestedAmountPoints
+          : operationBalancePoints >
+            (settings.auto_reload_threshold_points ?? 0);
+      const paymentAllowed =
+        evaluation.allowed &&
+        operationAmountCents <= evaluation.amountCents &&
+        operationSatisfiesNeed;
+      const paymentBlockedReason = !evaluation.allowed
+        ? evaluation.reason
+        : operationAmountCents > evaluation.amountCents
+          ? "reload_amount_changed"
+          : !operationSatisfiesNeed
+            ? "reload_amount_insufficient"
+            : undefined;
+      return {
+        status: "operation" as const,
+        operationId: settings.auto_reload_operation_id,
+        amountDollars: settings.auto_reload_operation_amount_dollars,
+        stripeInvoiceId: settings.auto_reload_operation_stripe_invoice_id,
+        startedAt: settings.auto_reload_operation_started_at,
+        executorId: leaseExpired ? args.candidateExecutorId : undefined,
+        claimed: leaseExpired,
+        paymentAllowed,
+        paymentBlockedReason,
+      };
+    }
+
+    if (!settings || !(settings.auto_reload_enabled ?? false)) {
+      return { status: "blocked" as const, reason: "auto_reload_disabled" };
+    }
+
+    if ((settings.auto_reload_retry_after ?? 0) > now) {
+      return {
+        status: "cooldown" as const,
+        reason: settings.auto_reload_last_failure_reason ?? "payment_failed",
+      };
+    }
+
+    const balancePoints = settings.balance_points ?? 0;
+    const thresholdPoints = settings.auto_reload_threshold_points ?? 0;
+    const reloadAmountDollars = settings.auto_reload_amount_dollars ?? 0;
+    const evaluation = evaluateAutoReloadCharge({
+      balancePoints,
+      thresholdPoints,
+      reloadAmountDollars,
+      requestedAmountPoints,
+      monthlyRemainingPoints,
+    });
+    if (!evaluation.allowed) {
+      return {
+        status:
+          evaluation.reason === "not_needed"
+            ? ("not_needed" as const)
+            : ("blocked" as const),
+        reason: evaluation.reason,
+      };
+    }
+
+    const amountCents = evaluation.amountCents;
+    const amountDollars = amountCents / 100;
+    await ctx.db.patch(settings._id, {
+      auto_reload_operation_id: args.candidateOperationId,
+      auto_reload_operation_executor_id: args.candidateExecutorId,
+      auto_reload_operation_started_at: now,
+      auto_reload_operation_lease_expires_at:
+        now + AUTO_RELOAD_OPERATION_LEASE_MS,
+      auto_reload_operation_amount_dollars: amountDollars,
+      auto_reload_operation_stripe_invoice_id: undefined,
+      updated_at: now,
+    });
+
+    return {
+      status: "operation" as const,
+      operationId: args.candidateOperationId,
+      amountDollars,
+      startedAt: now,
+      executorId: args.candidateExecutorId,
+      claimed: true,
+      paymentAllowed: true,
+    };
+  },
+});
+
+export const recordAutoReloadInvoice = internalMutation({
+  args: {
+    userId: v.string(),
+    operationId: v.string(),
+    executorId: v.string(),
+    stripeInvoiceId: v.string(),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const settings = await ctx.db
+      .query("extra_usage")
+      .withIndex("by_user_id", (q) => q.eq("user_id", args.userId))
+      .first();
+    if (
+      !settings ||
+      settings.auto_reload_operation_id !== args.operationId ||
+      settings.auto_reload_operation_executor_id !== args.executorId
+    ) {
+      return false;
+    }
+    await ctx.db.patch(settings._id, {
+      auto_reload_operation_stripe_invoice_id: args.stripeInvoiceId,
+      updated_at: Date.now(),
+    });
+    return true;
+  },
+});
+
+export const completeAutoReloadOperation = internalMutation({
+  args: {
+    userId: v.string(),
+    operationId: v.string(),
+    executorId: v.string(),
+    outcome: v.union(
+      v.literal("success"),
+      v.literal("released"),
+      v.literal("executor_released"),
+      v.literal("definitive_failure"),
+    ),
+    failureReason: v.optional(v.string()),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const settings = await ctx.db
+      .query("extra_usage")
+      .withIndex("by_user_id", (q) => q.eq("user_id", args.userId))
+      .first();
+    if (
+      !settings ||
+      settings.auto_reload_operation_id !== args.operationId ||
+      settings.auto_reload_operation_executor_id !== args.executorId
+    ) {
+      return false;
+    }
+
+    const now = Date.now();
+    if (args.outcome === "executor_released") {
+      await ctx.db.patch(settings._id, {
+        auto_reload_operation_executor_id: undefined,
+        auto_reload_operation_lease_expires_at: 0,
+        updated_at: now,
+      });
+      return true;
+    }
+
+    await ctx.db.patch(settings._id, {
+      auto_reload_operation_id: undefined,
+      auto_reload_operation_executor_id: undefined,
+      auto_reload_operation_started_at: undefined,
+      auto_reload_operation_lease_expires_at: undefined,
+      auto_reload_operation_amount_dollars: undefined,
+      auto_reload_operation_stripe_invoice_id: undefined,
+      ...(args.outcome === "success"
+        ? {
+            auto_reload_retry_after: undefined,
+            auto_reload_last_failure_reason: undefined,
+          }
+        : args.outcome === "definitive_failure"
+          ? {
+              auto_reload_retry_after: now + AUTO_RELOAD_RETRY_COOLDOWN_MS,
+              auto_reload_last_failure_reason:
+                args.failureReason ?? "payment_failed",
+            }
+          : {}),
+      updated_at: now,
+    });
+    return true;
+  },
+});
+
+/**
  * Refund points to user balance (for failed requests).
  * This is the reverse of deductPoints - adds points back to the balance.
  * Does NOT affect monthly spending tracking (refunds don't reduce spent amount).
@@ -849,6 +1198,7 @@ export const getExtraUsageBalanceForBackend = query({
     autoReloadThresholdDollars: v.optional(v.number()),
     autoReloadThresholdPoints: v.optional(v.number()),
     autoReloadAmountDollars: v.optional(v.number()),
+    autoReloadOperationPending: v.boolean(),
     monthlyCapDollars: v.optional(v.number()),
     monthlySpentDollars: v.number(),
     monthlyRemainingDollars: v.optional(v.number()),
@@ -887,6 +1237,7 @@ export const getExtraUsageBalanceForBackend = query({
         : undefined,
       autoReloadThresholdPoints: thresholdPoints,
       autoReloadAmountDollars: settings?.auto_reload_amount_dollars,
+      autoReloadOperationPending: !!settings?.auto_reload_operation_id,
       monthlyCapDollars:
         monthlyCapPoints === undefined
           ? undefined
@@ -1097,6 +1448,8 @@ export const updateExtraUsageSettings = mutation({
       if (args.autoReloadEnabled) {
         updateData.auto_reload_disabled_reason = undefined;
         updateData.auto_reload_consecutive_failures = 0;
+        updateData.auto_reload_retry_after = undefined;
+        updateData.auto_reload_last_failure_reason = undefined;
       }
     }
     if (args.autoReloadThresholdDollars !== undefined) {

--- a/convex/extraUsageActions.ts
+++ b/convex/extraUsageActions.ts
@@ -6,10 +6,7 @@ import { v } from "convex/values";
 import Stripe from "stripe";
 import { WorkOS } from "@workos-inc/node";
 import { convexLogger } from "./lib/logger";
-import {
-  extraUsageDollarsToPoints,
-  extraUsagePointsToDollars,
-} from "./lib/extraUsagePricing";
+import { extraUsageDollarsToPoints } from "./lib/extraUsagePricing";
 
 // =============================================================================
 // SDK Initialization (lazy, cached)
@@ -210,55 +207,95 @@ async function createAutoReloadPayment(
   paymentMethodId: string,
   amountCents: number,
   userId: string,
-): Promise<{ success: boolean; paymentIntentId?: string; error?: string }> {
+  operationId: string,
+  existingInvoiceId: string | undefined,
+  recordInvoice: (invoiceId: string) => Promise<void>,
+): Promise<{
+  success: boolean;
+  invoiceId?: string;
+  paymentIntentId?: string;
+  error?: string;
+  failureKind?: "definitive" | "indeterminate" | "released";
+}> {
   const stripe = getStripe();
+  let invoice: Stripe.Invoice | undefined;
 
   try {
-    // Create the invoice first (empty), then add item to it
-    // This avoids picking up stale invoice items from failed attempts
-    const invoice = await stripe.invoices.create({
-      customer: customerId,
-      collection_method: "send_invoice",
-      days_until_due: 0,
-      auto_advance: false,
-      pending_invoice_items_behavior: "exclude", // Don't pick up any pending items
-      metadata: {
-        type: "extra_usage_auto_reload",
-        userId,
-        amountDollars: String(amountCents / 100),
-      },
-    });
+    // Every POST in the invoice sequence uses the same persisted operation as
+    // its idempotency root. Retrying after a timeout therefore resumes the
+    // original invoice instead of charging the card again.
+    invoice = existingInvoiceId
+      ? await stripe.invoices.retrieve(existingInvoiceId)
+      : await stripe.invoices.create(
+          {
+            customer: customerId,
+            collection_method: "send_invoice",
+            days_until_due: 0,
+            auto_advance: false,
+            pending_invoice_items_behavior: "exclude",
+            metadata: {
+              type: "extra_usage_auto_reload",
+              userId,
+              amountDollars: String(amountCents / 100),
+              operationId,
+            },
+          },
+          { idempotencyKey: `${operationId}:invoice` },
+        );
 
-    // Add the invoice item directly to this invoice
-    await stripe.invoiceItems.create({
-      customer: customerId,
-      invoice: invoice.id,
-      amount: amountCents,
-      currency: "usd",
-      description: `HackerAI Extra Usage Auto-Reload ($${amountCents / 100})`,
-    });
+    if (!existingInvoiceId) {
+      await recordInvoice(invoice.id);
+    }
 
-    // Finalize the invoice
-    const finalizedInvoice = await stripe.invoices.finalizeInvoice(invoice.id);
+    if (invoice.status === "draft") {
+      await stripe.invoiceItems.create(
+        {
+          customer: customerId,
+          invoice: invoice.id,
+          amount: amountCents,
+          currency: "usd",
+          description: `HackerAI Extra Usage Auto-Reload ($${amountCents / 100})`,
+        },
+        { idempotencyKey: `${operationId}:item` },
+      );
+
+      invoice = await stripe.invoices.finalizeInvoice(
+        invoice.id,
+        {},
+        { idempotencyKey: `${operationId}:finalize` },
+      );
+    }
 
     // Check if already paid (shouldn't happen, but handle it)
-    if (finalizedInvoice.status === "paid") {
+    if (invoice.status === "paid") {
       const paymentIntent = (
-        finalizedInvoice as unknown as {
+        invoice as unknown as {
           payment_intent?: string | { id: string };
         }
       ).payment_intent;
       return {
         success: true,
+        invoiceId: invoice.id,
         paymentIntentId:
           typeof paymentIntent === "string" ? paymentIntent : paymentIntent?.id,
       };
     }
 
     // Pay the invoice with the specified payment method
-    const paidInvoice = await stripe.invoices.pay(finalizedInvoice.id, {
-      payment_method: paymentMethodId,
-    });
+    if (invoice.status !== "open") {
+      return {
+        success: false,
+        invoiceId: invoice.id,
+        error: `Invoice status: ${invoice.status}`,
+        failureKind: "definitive",
+      };
+    }
+
+    const paidInvoice = await stripe.invoices.pay(
+      invoice.id,
+      { payment_method: paymentMethodId },
+      { idempotencyKey: `${operationId}:pay` },
+    );
 
     if (paidInvoice.status === "paid") {
       const paymentIntent = (
@@ -266,6 +303,7 @@ async function createAutoReloadPayment(
       ).payment_intent;
       return {
         success: true,
+        invoiceId: paidInvoice.id,
         paymentIntentId:
           typeof paymentIntent === "string" ? paymentIntent : paymentIntent?.id,
       };
@@ -273,15 +311,125 @@ async function createAutoReloadPayment(
 
     return {
       success: false,
+      invoiceId: paidInvoice.id,
       error: `Invoice status: ${paidInvoice.status}`,
+      failureKind: "definitive",
     };
   } catch (error) {
     const message =
       error instanceof Stripe.errors.StripeError
         ? error.message
         : "Payment failed";
-    return { success: false, error: message };
+    const stripeErrorType =
+      error instanceof Stripe.errors.StripeError
+        ? (error as Stripe.errors.StripeError).type
+        : undefined;
+    const definitive = stripeErrorType === "StripeCardError";
+    const released =
+      stripeErrorType === "StripeAuthenticationError" ||
+      stripeErrorType === "StripePermissionError" ||
+      stripeErrorType === "StripeInvalidRequestError";
+    if (definitive && invoice && invoice.status === "open") {
+      try {
+        await stripe.invoices.voidInvoice(
+          invoice.id,
+          {},
+          { idempotencyKey: `${operationId}:void` },
+        );
+      } catch {
+        // Do not forget an invoice that might still be payable. Retain the
+        // operation for reconciliation if voiding did not complete cleanly.
+        return {
+          success: false,
+          invoiceId: invoice.id,
+          error: message,
+          failureKind: "indeterminate",
+        };
+      }
+    }
+    return {
+      success: false,
+      invoiceId: invoice?.id,
+      error: message,
+      failureKind: definitive
+        ? "definitive"
+        : released && !invoice?.id
+          ? "released"
+          : "indeterminate",
+    };
   }
+}
+
+const isMissingStripeResource = (error: unknown): boolean => {
+  const stripeError = error as {
+    type?: string;
+    code?: string;
+    statusCode?: number;
+  };
+  return (
+    stripeError?.type === "StripeInvalidRequestError" &&
+    (stripeError.code === "resource_missing" || stripeError.statusCode === 404)
+  );
+};
+
+type RetireAutoReloadInvoiceResult =
+  | { status: "released" }
+  | { status: "paid"; invoice: Stripe.Invoice }
+  | { status: "indeterminate" };
+
+/**
+ * Retire a known unpaid invoice before clearing a stale wallet operation.
+ * Draft invoices cannot have charged the customer and can be deleted; open
+ * invoices are voided with a stable idempotency key. Any ambiguous Stripe
+ * result keeps the operation quarantined for the next reconciliation pass.
+ */
+async function retireAutoReloadInvoice(
+  invoice: Stripe.Invoice,
+  operationId: string,
+): Promise<RetireAutoReloadInvoiceResult> {
+  const stripe = getStripe();
+  if (invoice.status === "paid") return { status: "paid", invoice };
+  if (invoice.status === "void" || invoice.status === "uncollectible") {
+    return { status: "released" };
+  }
+
+  try {
+    if (invoice.status === "draft") {
+      await stripe.invoices.del(invoice.id);
+      return { status: "released" };
+    }
+    if (invoice.status === "open") {
+      const voidedInvoice = await stripe.invoices.voidInvoice(
+        invoice.id,
+        {},
+        { idempotencyKey: `${operationId}:void-stale` },
+      );
+      if (voidedInvoice.status === "void") return { status: "released" };
+      if (voidedInvoice.status === "paid") {
+        return { status: "paid", invoice: voidedInvoice };
+      }
+    }
+  } catch (error) {
+    if (isMissingStripeResource(error)) return { status: "released" };
+    try {
+      const latestInvoice = await stripe.invoices.retrieve(invoice.id);
+      if (latestInvoice.status === "paid") {
+        return { status: "paid", invoice: latestInvoice };
+      }
+      if (
+        latestInvoice.status === "void" ||
+        latestInvoice.status === "uncollectible"
+      ) {
+        return { status: "released" };
+      }
+    } catch (reconcileError) {
+      if (isMissingStripeResource(reconcileError)) {
+        return { status: "released" };
+      }
+    }
+  }
+
+  return { status: "indeterminate" };
 }
 
 // =============================================================================
@@ -591,6 +739,7 @@ export const deductWithAutoReload = action({
       autoReloadThresholdDollars?: number;
       autoReloadThresholdPoints?: number;
       autoReloadAmountDollars?: number;
+      autoReloadOperationPending: boolean;
       monthlyRemainingDollars?: number;
     };
     const balanceLookupStartedAt = Date.now();
@@ -615,206 +764,13 @@ export const deductWithAutoReload = action({
       throw error;
     }
 
-    // Use points for threshold comparison (more precise)
-    const thresholdPoints: number = settings.autoReloadThresholdPoints ?? 0;
-    const reloadAmount: number = settings.autoReloadAmountDollars ?? 0;
-    const monthlyRemainingPoints =
-      settings.monthlyRemainingDollars === undefined
-        ? undefined
-        : extraUsageDollarsToPoints(settings.monthlyRemainingDollars);
-    const requestedDeductionDollars = extraUsagePointsToDollars(
-      args.amountPoints,
-    );
-    const requestNeedsReload = settings.balancePoints < args.amountPoints;
+    // Deduct first. The mutation is transactional, so parallel Agent steps
+    // cannot spend the same wallet balance. Auto-reload is only coordinated if
+    // this debit is underfunded or the successful debit crosses the threshold.
     let autoReloadTriggered = false;
     let autoReloadResult:
       | { success: boolean; chargedAmountDollars?: number; reason?: string }
       | undefined;
-
-    // Check auto-reload conditions individually for debugging.
-    const autoReloadConditions = {
-      auto_reload_enabled: settings.autoReloadEnabled,
-      balance_at_or_below_threshold: settings.balancePoints <= thresholdPoints,
-      balance_cannot_cover_request: requestNeedsReload,
-      reload_amount_configured: reloadAmount > 0,
-      monthly_cap_can_cover_request:
-        monthlyRemainingPoints === undefined ||
-        args.amountPoints <= monthlyRemainingPoints,
-    };
-
-    const allConditionsMet =
-      autoReloadConditions.auto_reload_enabled &&
-      (autoReloadConditions.balance_at_or_below_threshold ||
-        autoReloadConditions.balance_cannot_cover_request) &&
-      autoReloadConditions.reload_amount_configured &&
-      autoReloadConditions.monthly_cap_can_cover_request;
-
-    // Check if auto-reload is needed (compare in points for precision)
-    if (allConditionsMet) {
-      autoReloadTriggered = true;
-
-      // Get Stripe customer ID
-      const stripeLookupStartedAt = Date.now();
-      let stripeCustomerId: string | null = null;
-      try {
-        stripeCustomerId = await getStripeCustomerId(args.userId);
-      } catch (error) {
-        convexLogger.error("extra_usage_stripe_customer_lookup_failed", {
-          user_id: args.userId,
-          amount_points: args.amountPoints,
-          usage_settlement_id: args.usageSettlementId,
-          operation: "get_stripe_customer",
-          duration_ms: Date.now() - stripeLookupStartedAt,
-          error: serializeErrorForLog(error),
-        });
-        autoReloadResult = {
-          success: false,
-          reason: "stripe_lookup_failed",
-        };
-      }
-      if (!stripeCustomerId) {
-        autoReloadResult ??= { success: false, reason: "no_stripe_customer" };
-      } else {
-        try {
-          // Check if customer is blocked (fraud flagged) before attempting charge
-          const customerObj =
-            await getStripe().customers.retrieve(stripeCustomerId);
-          const isBlocked =
-            !customerObj.deleted &&
-            (customerObj as Stripe.Customer).metadata?.blocked === "true";
-
-          if (isBlocked) {
-            autoReloadResult = { success: false, reason: "customer_blocked" };
-          } else {
-            // Get default payment method
-            const paymentMethodId =
-              await getDefaultPaymentMethodId(stripeCustomerId);
-            if (!paymentMethodId) {
-              autoReloadResult = {
-                success: false,
-                reason: "no_default_payment_method",
-              };
-            } else {
-              // Charge enough to satisfy this deduction, or restore the
-              // configured target balance, whichever is larger.
-              const currentBalanceDollars = settings.balanceDollars;
-              const targetBalanceDollars = Math.max(
-                reloadAmount,
-                requestedDeductionDollars,
-              );
-              const rawAmountToCharge = Math.max(
-                0,
-                targetBalanceDollars - currentBalanceDollars,
-              );
-
-              // Minimum charge of $1 to avoid tiny transactions
-              const MIN_CHARGE_DOLLARS = 1;
-              const amountToCharge =
-                requestNeedsReload &&
-                rawAmountToCharge > 0 &&
-                rawAmountToCharge < MIN_CHARGE_DOLLARS
-                  ? MIN_CHARGE_DOLLARS
-                  : rawAmountToCharge;
-              if (amountToCharge < MIN_CHARGE_DOLLARS) {
-                autoReloadResult = {
-                  success: false,
-                  reason: "amount_to_charge_below_minimum",
-                };
-              } else {
-                // Create payment (Stripe uses cents)
-                const amountToChargeCents = Math.round(amountToCharge * 100);
-                const paymentResult = await createAutoReloadPayment(
-                  stripeCustomerId,
-                  paymentMethodId,
-                  amountToChargeCents,
-                  args.userId,
-                );
-
-                if (paymentResult.success) {
-                  // Add credits (dollars -> points conversion happens in mutation)
-                  await ctx.runMutation(api.extraUsage.addCredits, {
-                    serviceKey: args.serviceKey,
-                    userId: args.userId,
-                    amountDollars: amountToCharge,
-                    idempotencyKey: paymentResult.paymentIntentId,
-                    revenueSource: "extra_usage_auto_reload",
-                    stripeCustomerId,
-                    stripePaymentIntentId: paymentResult.paymentIntentId,
-                  });
-                  autoReloadResult = {
-                    success: true,
-                    chargedAmountDollars: amountToCharge,
-                  };
-                } else {
-                  autoReloadResult = {
-                    success: false,
-                    reason: paymentResult.error || "payment_failed",
-                  };
-                }
-              }
-            }
-          }
-        } catch (error) {
-          convexLogger.error("extra_usage_auto_reload_lookup_failed", {
-            user_id: args.userId,
-            amount_points: args.amountPoints,
-            usage_settlement_id: args.usageSettlementId,
-            operation: "prepare_auto_reload_payment",
-            duration_ms: Date.now() - stripeLookupStartedAt,
-            error: serializeErrorForLog(error),
-          });
-          autoReloadResult = {
-            success: false,
-            reason: "stripe_lookup_failed",
-          };
-        }
-      }
-    }
-
-    // Record outcome of auto-reload attempt for failure tracking / auto-disable.
-    // Only count *real charge outcomes*: a successful charge, or a charge that
-    // was actually attempted and declined by Stripe. Pre-charge configuration
-    // / lookup problems (no_stripe_customer, customer_blocked,
-    // no_default_payment_method, stripe_lookup_failed,
-    // amount_to_charge_below_minimum) must NOT increment the consecutive
-    // failure counter — they aren't card declines and shouldn't auto-disable
-    // auto-reload.
-    const PRE_CHARGE_REASONS = new Set([
-      "no_stripe_customer",
-      "customer_blocked",
-      "no_default_payment_method",
-      "stripe_lookup_failed",
-      "amount_to_charge_below_minimum",
-    ]);
-    if (
-      autoReloadTriggered &&
-      autoReloadResult &&
-      (autoReloadResult.success ||
-        !PRE_CHARGE_REASONS.has(autoReloadResult.reason ?? ""))
-    ) {
-      const recordOutcomeStartedAt = Date.now();
-      try {
-        await ctx.runMutation(internal.extraUsage.recordAutoReloadOutcome, {
-          userId: args.userId,
-          success: autoReloadResult.success,
-          failureReason: autoReloadResult.reason,
-        });
-      } catch (error) {
-        convexLogger.error("extra_usage_auto_reload_outcome_record_failed", {
-          user_id: args.userId,
-          amount_points: args.amountPoints,
-          usage_settlement_id: args.usageSettlementId,
-          operation: "record_auto_reload_outcome",
-          auto_reload_success: autoReloadResult.success,
-          auto_reload_failure_reason: autoReloadResult.reason,
-          duration_ms: Date.now() - recordOutcomeStartedAt,
-          error: serializeErrorForLog(error),
-        });
-        throw error;
-      }
-    }
-
-    // Now deduct from balance using points directly (no precision loss)
     let deductResult: {
       success: boolean;
       newBalancePoints: number;
@@ -837,13 +793,471 @@ export const deductWithAutoReload = action({
         usage_settlement_id: args.usageSettlementId,
         operation: "deduct_points",
         convex_function: "extraUsage.deductPoints",
-        auto_reload_triggered: autoReloadTriggered,
-        auto_reload_success: autoReloadResult?.success,
-        auto_reload_failure_reason: autoReloadResult?.reason,
         duration_ms: Date.now() - deductPointsStartedAt,
         error: serializeErrorForLog(error),
       });
       throw error;
+    }
+
+    const requestNeedsReload =
+      !deductResult.success &&
+      deductResult.insufficientFunds &&
+      !deductResult.monthlyCapExceeded;
+    const thresholdReached =
+      deductResult.success &&
+      deductResult.newBalancePoints <=
+        (settings.autoReloadThresholdPoints ?? 0);
+
+    if (
+      settings.autoReloadOperationPending ||
+      (settings.autoReloadEnabled && (requestNeedsReload || thresholdReached))
+    ) {
+      for (let reloadAttempt = 0; reloadAttempt < 2; reloadAttempt++) {
+        let retryAutoReload = false;
+        const candidateOperationId = crypto.randomUUID();
+        const candidateExecutorId = crypto.randomUUID();
+        let claim = await ctx.runMutation(
+          internal.extraUsage.claimAutoReloadOperation,
+          {
+            userId: args.userId,
+            candidateOperationId,
+            candidateExecutorId,
+            requestedAmountPoints: requestNeedsReload ? args.amountPoints : 0,
+          },
+        );
+
+        // A threshold top-up is best-effort once this step's debit succeeded.
+        // Underfunded followers briefly wait for the one active Stripe executor;
+        // they never drive the same operation concurrently.
+        if (
+          claim.status === "operation" &&
+          !claim.claimed &&
+          requestNeedsReload
+        ) {
+          for (const delayMs of [250, 500, 1_000, 2_000]) {
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+            claim = await ctx.runMutation(
+              internal.extraUsage.claimAutoReloadOperation,
+              {
+                userId: args.userId,
+                candidateOperationId,
+                candidateExecutorId,
+                requestedAmountPoints: args.amountPoints,
+              },
+            );
+            if (claim.status !== "operation" || claim.claimed) break;
+          }
+        }
+
+        if (claim.status === "not_needed" && requestNeedsReload) {
+          // Another parallel operation may have funded the wallet between the
+          // failed debit and the atomic claim. Re-read by retrying the mutation.
+          deductResult = await ctx.runMutation(api.extraUsage.deductPoints, {
+            serviceKey: args.serviceKey,
+            userId: args.userId,
+            amountPoints: args.amountPoints,
+            usageSettlementId: args.usageSettlementId,
+          });
+        } else if (claim.status === "cooldown") {
+          autoReloadTriggered = true;
+          autoReloadResult = {
+            success: false,
+            reason: claim.reason ?? "payment_failed",
+          };
+        } else if (claim.status === "blocked") {
+          if (
+            claim.reason === "monthly_cap_exceeded" &&
+            !deductResult.success
+          ) {
+            deductResult = {
+              ...deductResult,
+              insufficientFunds: true,
+              monthlyCapExceeded: true,
+            };
+          }
+        } else if (claim.status === "operation" && !claim.claimed) {
+          if (requestNeedsReload) {
+            autoReloadTriggered = true;
+          }
+        } else if (
+          claim.status === "operation" &&
+          claim.claimed &&
+          claim.operationId &&
+          claim.executorId &&
+          claim.amountDollars !== undefined
+        ) {
+          autoReloadTriggered = true;
+          const operationId = claim.operationId;
+          const executorId = claim.executorId;
+          const amountDollars = claim.amountDollars;
+          const releaseOperation = async () =>
+            await ctx.runMutation(
+              internal.extraUsage.completeAutoReloadOperation,
+              {
+                userId: args.userId,
+                operationId,
+                executorId,
+                outcome: "released",
+              },
+            );
+          const releaseExecutor = async () =>
+            await ctx.runMutation(
+              internal.extraUsage.completeAutoReloadOperation,
+              {
+                userId: args.userId,
+                operationId,
+                executorId,
+                outcome: "executor_released",
+              },
+            );
+          const releasePreCharge = async () =>
+            operationId === candidateOperationId && !claim.stripeInvoiceId
+              ? await releaseOperation()
+              : await releaseExecutor();
+
+          const creditOperation = async ({
+            invoiceId,
+            paymentIntentId,
+            stripeCustomerId,
+          }: {
+            invoiceId: string;
+            paymentIntentId?: string;
+            stripeCustomerId?: string;
+          }) => {
+            const creditResult = await ctx.runMutation(
+              api.extraUsage.addCredits,
+              {
+                serviceKey: args.serviceKey,
+                userId: args.userId,
+                amountDollars,
+                idempotencyKey: `personal_auto_reload:${operationId}`,
+                revenueSource: "extra_usage_auto_reload",
+                stripeCustomerId,
+                stripePaymentIntentId: paymentIntentId,
+                stripeInvoiceId: invoiceId,
+              },
+            );
+            const completed = await ctx.runMutation(
+              internal.extraUsage.completeAutoReloadOperation,
+              {
+                userId: args.userId,
+                operationId,
+                executorId,
+                outcome: "success",
+              },
+            );
+            autoReloadResult = {
+              success: true,
+              chargedAmountDollars: amountDollars,
+            };
+            if (deductResult.success && !creditResult.alreadyProcessed) {
+              deductResult = {
+                ...deductResult,
+                newBalancePoints: extraUsageDollarsToPoints(
+                  creditResult.newBalance,
+                ),
+                newBalanceDollars: creditResult.newBalance,
+              };
+            }
+            if (completed) {
+              try {
+                await ctx.runMutation(
+                  internal.extraUsage.recordAutoReloadOutcome,
+                  { userId: args.userId, success: true },
+                );
+              } catch (error) {
+                convexLogger.error(
+                  "extra_usage_auto_reload_outcome_record_failed",
+                  {
+                    user_id: args.userId,
+                    operation_id: operationId,
+                    auto_reload_success: true,
+                    error: serializeErrorForLog(error),
+                  },
+                );
+              }
+            }
+          };
+
+          let shouldPreparePayment = true;
+          if (claim.stripeInvoiceId) {
+            try {
+              const existingInvoice = await getStripe().invoices.retrieve(
+                claim.stripeInvoiceId,
+              );
+              if (existingInvoice.status === "paid") {
+                const paymentIntent = (
+                  existingInvoice as unknown as {
+                    payment_intent?: string | { id: string };
+                  }
+                ).payment_intent;
+                await creditOperation({
+                  invoiceId: existingInvoice.id,
+                  paymentIntentId:
+                    typeof paymentIntent === "string"
+                      ? paymentIntent
+                      : paymentIntent?.id,
+                });
+                shouldPreparePayment = false;
+              } else if (
+                (!requestNeedsReload && !thresholdReached) ||
+                claim.paymentAllowed === false ||
+                existingInvoice.status === "void" ||
+                existingInvoice.status === "uncollectible"
+              ) {
+                const reason =
+                  claim.paymentBlockedReason ??
+                  (existingInvoice.status === "void" ||
+                  existingInvoice.status === "uncollectible"
+                    ? "invoice_not_payable"
+                    : "reload_not_needed");
+                autoReloadResult = {
+                  success: false,
+                  reason,
+                };
+                const retirement = await retireAutoReloadInvoice(
+                  existingInvoice,
+                  operationId,
+                );
+                if (retirement.status === "paid") {
+                  const paymentIntent = (
+                    retirement.invoice as unknown as {
+                      payment_intent?: string | { id: string };
+                    }
+                  ).payment_intent;
+                  await creditOperation({
+                    invoiceId: retirement.invoice.id,
+                    paymentIntentId:
+                      typeof paymentIntent === "string"
+                        ? paymentIntent
+                        : paymentIntent?.id,
+                  });
+                } else if (retirement.status === "released") {
+                  const released = await releaseOperation();
+                  retryAutoReload =
+                    requestNeedsReload && released && reloadAttempt === 0;
+                } else {
+                  await releaseExecutor();
+                }
+                shouldPreparePayment = false;
+              }
+            } catch (error) {
+              convexLogger.error("extra_usage_auto_reload_reconcile_failed", {
+                user_id: args.userId,
+                operation_id: operationId,
+                error: serializeErrorForLog(error),
+              });
+              const invoiceMissing = isMissingStripeResource(error);
+              autoReloadResult = {
+                success: false,
+                reason: invoiceMissing
+                  ? "invoice_missing"
+                  : "payment_state_unknown",
+              };
+              if (invoiceMissing) {
+                const released = await releaseOperation();
+                retryAutoReload =
+                  requestNeedsReload && released && reloadAttempt === 0;
+              } else {
+                await releaseExecutor();
+              }
+              shouldPreparePayment = false;
+            }
+          } else if (
+            (!requestNeedsReload && !thresholdReached) ||
+            claim.paymentAllowed === false
+          ) {
+            autoReloadResult = {
+              success: false,
+              reason: claim.paymentBlockedReason ?? "reload_not_needed",
+            };
+            // Payment cannot start before the Stripe invoice id is persisted.
+            // Clearing an id-less stale operation can at worst leave an inert
+            // draft invoice (auto_advance=false), never a second card charge.
+            const released = await releaseOperation();
+            retryAutoReload =
+              requestNeedsReload && released && reloadAttempt === 0;
+            shouldPreparePayment = false;
+          }
+
+          // Get Stripe customer ID
+          if (shouldPreparePayment) {
+            const stripeLookupStartedAt = Date.now();
+            let stripeCustomerId: string | null = null;
+            try {
+              stripeCustomerId = await getStripeCustomerId(args.userId);
+            } catch (error) {
+              convexLogger.error("extra_usage_stripe_customer_lookup_failed", {
+                user_id: args.userId,
+                amount_points: args.amountPoints,
+                operation: "get_stripe_customer",
+                duration_ms: Date.now() - stripeLookupStartedAt,
+                error: serializeErrorForLog(error),
+              });
+              autoReloadResult = {
+                success: false,
+                reason: "stripe_lookup_failed",
+              };
+            }
+            if (!stripeCustomerId) {
+              autoReloadResult ??= {
+                success: false,
+                reason: "no_stripe_customer",
+              };
+              await releasePreCharge();
+            } else {
+              let paymentStarted = false;
+              try {
+                // Check if customer is blocked (fraud flagged) before attempting charge
+                const customerObj =
+                  await getStripe().customers.retrieve(stripeCustomerId);
+                const isBlocked =
+                  !customerObj.deleted &&
+                  (customerObj as Stripe.Customer).metadata?.blocked === "true";
+
+                if (isBlocked) {
+                  autoReloadResult = {
+                    success: false,
+                    reason: "customer_blocked",
+                  };
+                  await releasePreCharge();
+                } else {
+                  // Get default payment method
+                  const paymentMethodId =
+                    await getDefaultPaymentMethodId(stripeCustomerId);
+                  if (!paymentMethodId) {
+                    autoReloadResult = {
+                      success: false,
+                      reason: "no_default_payment_method",
+                    };
+                    await releasePreCharge();
+                  } else {
+                    paymentStarted = true;
+                    const paymentResult = await createAutoReloadPayment(
+                      stripeCustomerId,
+                      paymentMethodId,
+                      Math.round(amountDollars * 100),
+                      args.userId,
+                      operationId,
+                      claim.stripeInvoiceId,
+                      async (stripeInvoiceId) => {
+                        const recorded = await ctx.runMutation(
+                          internal.extraUsage.recordAutoReloadInvoice,
+                          {
+                            userId: args.userId,
+                            operationId,
+                            executorId,
+                            stripeInvoiceId,
+                          },
+                        );
+                        if (!recorded) {
+                          throw new Error(
+                            "Auto-reload operation executor changed",
+                          );
+                        }
+                      },
+                    );
+
+                    if (paymentResult.success && paymentResult.invoiceId) {
+                      await creditOperation({
+                        invoiceId: paymentResult.invoiceId,
+                        paymentIntentId: paymentResult.paymentIntentId,
+                        stripeCustomerId,
+                      });
+                    } else {
+                      const reason =
+                        paymentResult.error ||
+                        (paymentResult.success
+                          ? "missing_payment_intent"
+                          : "payment_failed");
+                      autoReloadResult = { success: false, reason };
+                      if (paymentResult.failureKind === "definitive") {
+                        const completed = await ctx.runMutation(
+                          internal.extraUsage.completeAutoReloadOperation,
+                          {
+                            userId: args.userId,
+                            operationId,
+                            executorId,
+                            outcome: "definitive_failure",
+                            failureReason: reason,
+                          },
+                        );
+                        if (completed) {
+                          try {
+                            await ctx.runMutation(
+                              internal.extraUsage.recordAutoReloadOutcome,
+                              {
+                                userId: args.userId,
+                                success: false,
+                                failureReason: reason,
+                              },
+                            );
+                          } catch (error) {
+                            convexLogger.error(
+                              "extra_usage_auto_reload_outcome_record_failed",
+                              {
+                                user_id: args.userId,
+                                operation_id: operationId,
+                                auto_reload_success: false,
+                                error: serializeErrorForLog(error),
+                              },
+                            );
+                          }
+                        }
+                      } else if (paymentResult.failureKind === "released") {
+                        await releasePreCharge();
+                      } else {
+                        await releaseExecutor();
+                      }
+                    }
+                  }
+                }
+              } catch (error) {
+                convexLogger.error("extra_usage_auto_reload_lookup_failed", {
+                  user_id: args.userId,
+                  amount_points: args.amountPoints,
+                  operation: "prepare_auto_reload_payment",
+                  duration_ms: Date.now() - stripeLookupStartedAt,
+                  error: serializeErrorForLog(error),
+                });
+                autoReloadResult = {
+                  success: false,
+                  reason: paymentStarted
+                    ? "payment_state_unknown"
+                    : "stripe_lookup_failed",
+                };
+                // Once a Stripe POST may have started, retain the operation and its
+                // idempotency keys. A later call can safely resume it. Releasing here
+                // could mint a new operation and double-charge an indeterminate one.
+                if (paymentStarted) {
+                  await releaseExecutor();
+                } else {
+                  await releasePreCharge();
+                }
+              }
+            }
+          }
+
+          if (requestNeedsReload && autoReloadResult?.success) {
+            deductResult = await ctx.runMutation(api.extraUsage.deductPoints, {
+              serviceKey: args.serviceKey,
+              userId: args.userId,
+              amountPoints: args.amountPoints,
+              usageSettlementId: args.usageSettlementId,
+            });
+            retryAutoReload =
+              reloadAttempt === 0 &&
+              !deductResult.success &&
+              deductResult.insufficientFunds &&
+              !deductResult.monthlyCapExceeded;
+          }
+        }
+        if (retryAutoReload) {
+          autoReloadResult = undefined;
+          continue;
+        }
+        break;
+      }
     }
 
     convexLogger.info("deduct_with_auto_reload", {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -266,6 +266,19 @@ export default defineSchema({
     // broken saved card does not keep retrying.
     auto_reload_consecutive_failures: v.optional(v.number()),
     auto_reload_disabled_reason: v.optional(v.string()),
+    // One durable, entity-scoped auto-reload operation. Parallel billing
+    // actions reuse this operation (and its Stripe idempotency keys) instead
+    // of creating separate invoices from the same low-balance snapshot.
+    auto_reload_operation_id: v.optional(v.string()),
+    auto_reload_operation_executor_id: v.optional(v.string()),
+    auto_reload_operation_started_at: v.optional(v.number()),
+    auto_reload_operation_lease_expires_at: v.optional(v.number()),
+    auto_reload_operation_amount_dollars: v.optional(v.number()),
+    auto_reload_operation_stripe_invoice_id: v.optional(v.string()),
+    // Briefly suppress duplicate card attempts after a definitive decline so
+    // parallel Agent steps all observe the same failure.
+    auto_reload_retry_after: v.optional(v.number()),
+    auto_reload_last_failure_reason: v.optional(v.string()),
     updated_at: v.number(),
   }).index("by_user_id", ["user_id"]),
 
@@ -331,6 +344,14 @@ export default defineSchema({
     override_monthly_cap_dollars: v.optional(v.number()),
     auto_reload_consecutive_failures: v.optional(v.number()),
     auto_reload_disabled_reason: v.optional(v.string()),
+    auto_reload_operation_id: v.optional(v.string()),
+    auto_reload_operation_executor_id: v.optional(v.string()),
+    auto_reload_operation_started_at: v.optional(v.number()),
+    auto_reload_operation_lease_expires_at: v.optional(v.number()),
+    auto_reload_operation_amount_dollars: v.optional(v.number()),
+    auto_reload_operation_stripe_invoice_id: v.optional(v.string()),
+    auto_reload_retry_after: v.optional(v.number()),
+    auto_reload_last_failure_reason: v.optional(v.string()),
     updated_at: v.number(),
   }).index("by_org", ["organization_id"]),
 

--- a/convex/teamExtraUsage.ts
+++ b/convex/teamExtraUsage.ts
@@ -14,6 +14,87 @@ import {
 } from "./lib/extraUsagePricing";
 import { validateMonthlyCapDollars } from "./lib/extraUsageValidation";
 
+const AUTO_RELOAD_RETRY_COOLDOWN_MS = 15_000;
+const AUTO_RELOAD_OPERATION_LEASE_MS = 2 * 60_000;
+
+type AutoReloadChargeEvaluation =
+  | { allowed: true; amountCents: number }
+  | { allowed: false; reason: string };
+
+const evaluateTeamAutoReloadCharge = ({
+  balancePoints,
+  thresholdPoints,
+  reloadAmountDollars,
+  requestedAmountPoints,
+  monthlyRemainingPoints,
+}: {
+  balancePoints: number;
+  thresholdPoints: number;
+  reloadAmountDollars: number;
+  requestedAmountPoints: number;
+  monthlyRemainingPoints?: number;
+}): AutoReloadChargeEvaluation => {
+  if (reloadAmountDollars <= 0) {
+    return { allowed: false, reason: "reload_amount_not_configured" };
+  }
+
+  if (
+    requestedAmountPoints > 0
+      ? balancePoints >= requestedAmountPoints
+      : balancePoints > thresholdPoints
+  ) {
+    return { allowed: false, reason: "not_needed" };
+  }
+
+  if (
+    monthlyRemainingPoints !== undefined &&
+    requestedAmountPoints > monthlyRemainingPoints
+  ) {
+    return { allowed: false, reason: "monthly_cap_exceeded" };
+  }
+
+  const targetBalancePoints = Math.max(
+    dollarsToPoints(reloadAmountDollars),
+    requestedAmountPoints,
+  );
+  const desiredTopUpPoints = Math.max(0, targetBalancePoints - balancePoints);
+  const capHeadroomPoints =
+    monthlyRemainingPoints === undefined
+      ? undefined
+      : Math.max(0, monthlyRemainingPoints - balancePoints);
+  const desiredCents = Math.ceil(
+    Number((pointsToDollars(desiredTopUpPoints) * 100).toFixed(6)),
+  );
+  const desiredChargeCents =
+    requestedAmountPoints > 0 && desiredCents > 0
+      ? Math.max(100, desiredCents)
+      : desiredCents;
+  let maxAllowedCents = desiredChargeCents;
+  if (capHeadroomPoints !== undefined) {
+    maxAllowedCents = Math.ceil(
+      Number((pointsToDollars(capHeadroomPoints) * 100).toFixed(6)),
+    );
+    while (
+      maxAllowedCents > 0 &&
+      dollarsToPoints(maxAllowedCents / 100) > capHeadroomPoints
+    ) {
+      maxAllowedCents--;
+    }
+  }
+
+  const amountCents = Math.min(desiredChargeCents, maxAllowedCents);
+  const creditedPoints = dollarsToPoints(amountCents / 100);
+  if (
+    amountCents < 100 ||
+    (requestedAmountPoints > 0 &&
+      balancePoints + creditedPoints < requestedAmountPoints)
+  ) {
+    return { allowed: false, reason: "amount_to_charge_below_minimum" };
+  }
+
+  return { allowed: true, amountCents };
+};
+
 // =============================================================================
 // Internal helpers
 // =============================================================================
@@ -93,6 +174,7 @@ export const addTeamCredits = mutation({
     stripeCustomerId: v.optional(v.string()),
     stripeCheckoutSessionId: v.optional(v.string()),
     stripePaymentIntentId: v.optional(v.string()),
+    stripeInvoiceId: v.optional(v.string()),
   },
   returns: v.object({
     newBalance: v.number(),
@@ -173,6 +255,7 @@ export const addTeamCredits = mutation({
       sourceEventId:
         args.stripeCheckoutSessionId ??
         args.stripePaymentIntentId ??
+        args.stripeInvoiceId ??
         args.idempotencyKey ??
         `team_extra_usage:${args.organizationId}:${Date.now()}`,
       idempotencyKey:
@@ -185,6 +268,7 @@ export const addTeamCredits = mutation({
       stripeCustomerId: args.stripeCustomerId,
       stripeCheckoutSessionId: args.stripeCheckoutSessionId,
       stripePaymentIntentId: args.stripePaymentIntentId,
+      stripeInvoiceId: args.stripeInvoiceId,
       description: args.revenueSource ?? "team_extra_usage_purchase",
     });
 
@@ -387,6 +471,261 @@ export const deductTeamPoints = mutation({
   },
 });
 
+/** Atomically coalesce parallel Stripe auto-reloads for one organization. */
+export const claimTeamAutoReloadOperation = internalMutation({
+  args: {
+    organizationId: v.string(),
+    candidateOperationId: v.string(),
+    candidateExecutorId: v.string(),
+    requestedAmountPoints: v.number(),
+  },
+  returns: v.object({
+    status: v.union(
+      v.literal("operation"),
+      v.literal("not_needed"),
+      v.literal("blocked"),
+      v.literal("cooldown"),
+    ),
+    operationId: v.optional(v.string()),
+    amountDollars: v.optional(v.number()),
+    stripeInvoiceId: v.optional(v.string()),
+    startedAt: v.optional(v.number()),
+    executorId: v.optional(v.string()),
+    claimed: v.optional(v.boolean()),
+    paymentAllowed: v.optional(v.boolean()),
+    paymentBlockedReason: v.optional(v.string()),
+    reason: v.optional(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    const team = await ctx.db
+      .query("team_extra_usage")
+      .withIndex("by_org", (q) => q.eq("organization_id", args.organizationId))
+      .first();
+
+    const now = Date.now();
+    const requestedAmountPoints = Math.max(
+      0,
+      Math.round(args.requestedAmountPoints),
+    );
+    const currentMonth = currentMonthString();
+    const monthlySpentPoints =
+      team?.monthly_reset_date === currentMonth
+        ? (team.monthly_spent_points ?? 0)
+        : 0;
+    const monthlyCapPoints = team?.monthly_cap_points;
+    const monthlyRemainingPoints =
+      monthlyCapPoints === undefined
+        ? undefined
+        : Math.max(0, monthlyCapPoints - monthlySpentPoints);
+    if (
+      team?.auto_reload_operation_id &&
+      team.auto_reload_operation_amount_dollars !== undefined
+    ) {
+      const leaseExpired =
+        (team.auto_reload_operation_lease_expires_at ?? 0) <= now;
+      if (leaseExpired) {
+        await ctx.db.patch(team._id, {
+          auto_reload_operation_executor_id: args.candidateExecutorId,
+          auto_reload_operation_lease_expires_at:
+            now + AUTO_RELOAD_OPERATION_LEASE_MS,
+          updated_at: now,
+        });
+      }
+      const evaluation =
+        team.enabled && team.auto_reload_enabled
+          ? evaluateTeamAutoReloadCharge({
+              balancePoints: team.balance_points ?? 0,
+              thresholdPoints: team.auto_reload_threshold_points ?? 0,
+              reloadAmountDollars: team.auto_reload_amount_dollars ?? 0,
+              requestedAmountPoints,
+              monthlyRemainingPoints,
+            })
+          : ({ allowed: false, reason: "auto_reload_disabled" } as const);
+      const operationAmountCents = Math.round(
+        team.auto_reload_operation_amount_dollars * 100,
+      );
+      const balancePoints = team.balance_points ?? 0;
+      const operationBalancePoints =
+        balancePoints +
+        dollarsToPoints(team.auto_reload_operation_amount_dollars);
+      const operationSatisfiesNeed =
+        requestedAmountPoints > 0
+          ? operationBalancePoints >= requestedAmountPoints
+          : operationBalancePoints > (team.auto_reload_threshold_points ?? 0);
+      const paymentAllowed =
+        evaluation.allowed &&
+        operationAmountCents <= evaluation.amountCents &&
+        operationSatisfiesNeed;
+      const paymentBlockedReason = !evaluation.allowed
+        ? evaluation.reason
+        : operationAmountCents > evaluation.amountCents
+          ? "reload_amount_changed"
+          : !operationSatisfiesNeed
+            ? "reload_amount_insufficient"
+            : undefined;
+      return {
+        status: "operation" as const,
+        operationId: team.auto_reload_operation_id,
+        amountDollars: team.auto_reload_operation_amount_dollars,
+        stripeInvoiceId: team.auto_reload_operation_stripe_invoice_id,
+        startedAt: team.auto_reload_operation_started_at,
+        executorId: leaseExpired ? args.candidateExecutorId : undefined,
+        claimed: leaseExpired,
+        paymentAllowed,
+        paymentBlockedReason,
+      };
+    }
+
+    if (
+      !team ||
+      !(team.enabled ?? false) ||
+      !(team.auto_reload_enabled ?? false)
+    ) {
+      return { status: "blocked" as const, reason: "auto_reload_disabled" };
+    }
+
+    if ((team.auto_reload_retry_after ?? 0) > now) {
+      return {
+        status: "cooldown" as const,
+        reason: team.auto_reload_last_failure_reason ?? "payment_failed",
+      };
+    }
+
+    const balancePoints = team.balance_points ?? 0;
+    const thresholdPoints = team.auto_reload_threshold_points ?? 0;
+    const reloadAmountDollars = team.auto_reload_amount_dollars ?? 0;
+    const evaluation = evaluateTeamAutoReloadCharge({
+      balancePoints,
+      thresholdPoints,
+      reloadAmountDollars,
+      requestedAmountPoints,
+      monthlyRemainingPoints,
+    });
+    if (!evaluation.allowed) {
+      return {
+        status:
+          evaluation.reason === "not_needed"
+            ? ("not_needed" as const)
+            : ("blocked" as const),
+        reason: evaluation.reason,
+      };
+    }
+
+    const amountCents = evaluation.amountCents;
+    const amountDollars = amountCents / 100;
+    await ctx.db.patch(team._id, {
+      auto_reload_operation_id: args.candidateOperationId,
+      auto_reload_operation_executor_id: args.candidateExecutorId,
+      auto_reload_operation_started_at: now,
+      auto_reload_operation_lease_expires_at:
+        now + AUTO_RELOAD_OPERATION_LEASE_MS,
+      auto_reload_operation_amount_dollars: amountDollars,
+      auto_reload_operation_stripe_invoice_id: undefined,
+      updated_at: now,
+    });
+
+    return {
+      status: "operation" as const,
+      operationId: args.candidateOperationId,
+      amountDollars,
+      startedAt: now,
+      executorId: args.candidateExecutorId,
+      claimed: true,
+      paymentAllowed: true,
+    };
+  },
+});
+
+export const recordTeamAutoReloadInvoice = internalMutation({
+  args: {
+    organizationId: v.string(),
+    operationId: v.string(),
+    executorId: v.string(),
+    stripeInvoiceId: v.string(),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const team = await ctx.db
+      .query("team_extra_usage")
+      .withIndex("by_org", (q) => q.eq("organization_id", args.organizationId))
+      .first();
+    if (
+      !team ||
+      team.auto_reload_operation_id !== args.operationId ||
+      team.auto_reload_operation_executor_id !== args.executorId
+    ) {
+      return false;
+    }
+    await ctx.db.patch(team._id, {
+      auto_reload_operation_stripe_invoice_id: args.stripeInvoiceId,
+      updated_at: Date.now(),
+    });
+    return true;
+  },
+});
+
+export const completeTeamAutoReloadOperation = internalMutation({
+  args: {
+    organizationId: v.string(),
+    operationId: v.string(),
+    executorId: v.string(),
+    outcome: v.union(
+      v.literal("success"),
+      v.literal("released"),
+      v.literal("executor_released"),
+      v.literal("definitive_failure"),
+    ),
+    failureReason: v.optional(v.string()),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const team = await ctx.db
+      .query("team_extra_usage")
+      .withIndex("by_org", (q) => q.eq("organization_id", args.organizationId))
+      .first();
+    if (
+      !team ||
+      team.auto_reload_operation_id !== args.operationId ||
+      team.auto_reload_operation_executor_id !== args.executorId
+    ) {
+      return false;
+    }
+
+    const now = Date.now();
+    if (args.outcome === "executor_released") {
+      await ctx.db.patch(team._id, {
+        auto_reload_operation_executor_id: undefined,
+        auto_reload_operation_lease_expires_at: 0,
+        updated_at: now,
+      });
+      return true;
+    }
+
+    await ctx.db.patch(team._id, {
+      auto_reload_operation_id: undefined,
+      auto_reload_operation_executor_id: undefined,
+      auto_reload_operation_started_at: undefined,
+      auto_reload_operation_lease_expires_at: undefined,
+      auto_reload_operation_amount_dollars: undefined,
+      auto_reload_operation_stripe_invoice_id: undefined,
+      ...(args.outcome === "success"
+        ? {
+            auto_reload_retry_after: undefined,
+            auto_reload_last_failure_reason: undefined,
+          }
+        : args.outcome === "definitive_failure"
+          ? {
+              auto_reload_retry_after: now + AUTO_RELOAD_RETRY_COOLDOWN_MS,
+              auto_reload_last_failure_reason:
+                args.failureReason ?? "payment_failed",
+            }
+          : {}),
+      updated_at: now,
+    });
+    return true;
+  },
+});
+
 /**
  * Refund points to team balance (for failed requests).
  * Also decrements member's monthly_spent so they can spend again later.
@@ -499,6 +838,7 @@ export const getTeamExtraUsageStateForBackend = query({
     autoReloadThresholdDollars: v.optional(v.number()),
     autoReloadThresholdPoints: v.optional(v.number()),
     autoReloadAmountDollars: v.optional(v.number()),
+    autoReloadOperationPending: v.boolean(),
     memberDisabled: v.boolean(),
     monthlyCapDollars: v.optional(v.number()),
     monthlySpentDollars: v.number(),
@@ -559,6 +899,7 @@ export const getTeamExtraUsageStateForBackend = query({
         : undefined,
       autoReloadThresholdPoints: thresholdPoints,
       autoReloadAmountDollars: team?.auto_reload_amount_dollars,
+      autoReloadOperationPending: !!team?.auto_reload_operation_id,
       memberDisabled: member?.disabled ?? false,
       monthlyCapDollars:
         teamCapPoints === undefined
@@ -725,6 +1066,8 @@ export const updateTeamExtraUsageSettings = mutation({
       if (args.autoReloadEnabled) {
         updateData.auto_reload_disabled_reason = undefined;
         updateData.auto_reload_consecutive_failures = 0;
+        updateData.auto_reload_retry_after = undefined;
+        updateData.auto_reload_last_failure_reason = undefined;
       }
     }
     if (args.autoReloadThresholdDollars !== undefined) {

--- a/convex/teamExtraUsageActions.ts
+++ b/convex/teamExtraUsageActions.ts
@@ -6,10 +6,7 @@ import { v } from "convex/values";
 import Stripe from "stripe";
 import { WorkOS } from "@workos-inc/node";
 import { convexLogger } from "./lib/logger";
-import {
-  extraUsageDollarsToPoints,
-  extraUsagePointsToDollars,
-} from "./lib/extraUsagePricing";
+import { extraUsageDollarsToPoints } from "./lib/extraUsagePricing";
 
 // =============================================================================
 // SDK Initialization (lazy, cached)
@@ -80,49 +77,87 @@ async function createAutoReloadInvoice(
   paymentMethodId: string,
   amountCents: number,
   organizationId: string,
-): Promise<{ success: boolean; paymentIntentId?: string; error?: string }> {
+  operationId: string,
+  existingInvoiceId: string | undefined,
+  recordInvoice: (invoiceId: string) => Promise<void>,
+): Promise<{
+  success: boolean;
+  invoiceId?: string;
+  paymentIntentId?: string;
+  error?: string;
+  failureKind?: "definitive" | "indeterminate" | "released";
+}> {
   const stripe = getStripe();
+  let invoice: Stripe.Invoice | undefined;
 
   try {
-    const invoice = await stripe.invoices.create({
-      customer: customerId,
-      collection_method: "send_invoice",
-      days_until_due: 0,
-      auto_advance: false,
-      pending_invoice_items_behavior: "exclude",
-      metadata: {
-        type: "team_extra_usage_auto_reload",
-        organizationId,
-        amountDollars: String(amountCents / 100),
-      },
-    });
+    invoice = existingInvoiceId
+      ? await stripe.invoices.retrieve(existingInvoiceId)
+      : await stripe.invoices.create(
+          {
+            customer: customerId,
+            collection_method: "send_invoice",
+            days_until_due: 0,
+            auto_advance: false,
+            pending_invoice_items_behavior: "exclude",
+            metadata: {
+              type: "team_extra_usage_auto_reload",
+              organizationId,
+              amountDollars: String(amountCents / 100),
+              operationId,
+            },
+          },
+          { idempotencyKey: `${operationId}:invoice` },
+        );
 
-    await stripe.invoiceItems.create({
-      customer: customerId,
-      invoice: invoice.id,
-      amount: amountCents,
-      currency: "usd",
-      description: `HackerAI Team Extra Usage Auto-Reload ($${amountCents / 100})`,
-    });
+    if (!existingInvoiceId) await recordInvoice(invoice.id);
 
-    const finalizedInvoice = await stripe.invoices.finalizeInvoice(invoice.id);
+    if (invoice.status === "draft") {
+      await stripe.invoiceItems.create(
+        {
+          customer: customerId,
+          invoice: invoice.id,
+          amount: amountCents,
+          currency: "usd",
+          description: `HackerAI Team Extra Usage Auto-Reload ($${amountCents / 100})`,
+        },
+        { idempotencyKey: `${operationId}:item` },
+      );
+      invoice = await stripe.invoices.finalizeInvoice(
+        invoice.id,
+        {},
+        { idempotencyKey: `${operationId}:finalize` },
+      );
+    }
 
-    if (finalizedInvoice.status === "paid") {
+    if (invoice.status === "paid") {
       const paymentIntent = (
-        finalizedInvoice as unknown as {
+        invoice as unknown as {
           payment_intent?: string | { id: string };
         }
       ).payment_intent;
       return {
         success: true,
+        invoiceId: invoice.id,
         paymentIntentId:
           typeof paymentIntent === "string" ? paymentIntent : paymentIntent?.id,
       };
     }
 
-    const paidInvoice = await stripe.invoices.pay(finalizedInvoice.id, {
-      payment_method: paymentMethodId,
-    });
+    if (invoice.status !== "open") {
+      return {
+        success: false,
+        invoiceId: invoice.id,
+        error: `Invoice status: ${invoice.status}`,
+        failureKind: "definitive",
+      };
+    }
+
+    const paidInvoice = await stripe.invoices.pay(
+      invoice.id,
+      { payment_method: paymentMethodId },
+      { idempotencyKey: `${operationId}:pay` },
+    );
 
     if (paidInvoice.status === "paid") {
       const paymentIntent = (
@@ -130,19 +165,125 @@ async function createAutoReloadInvoice(
       ).payment_intent;
       return {
         success: true,
+        invoiceId: paidInvoice.id,
         paymentIntentId:
           typeof paymentIntent === "string" ? paymentIntent : paymentIntent?.id,
       };
     }
 
-    return { success: false, error: `Invoice status: ${paidInvoice.status}` };
+    return {
+      success: false,
+      invoiceId: paidInvoice.id,
+      error: `Invoice status: ${paidInvoice.status}`,
+      failureKind: "definitive",
+    };
   } catch (error) {
     const message =
       error instanceof Stripe.errors.StripeError
         ? error.message
         : "Payment failed";
-    return { success: false, error: message };
+    const stripeErrorType =
+      error instanceof Stripe.errors.StripeError
+        ? (error as Stripe.errors.StripeError).type
+        : undefined;
+    const definitive = stripeErrorType === "StripeCardError";
+    const released =
+      stripeErrorType === "StripeAuthenticationError" ||
+      stripeErrorType === "StripePermissionError" ||
+      stripeErrorType === "StripeInvalidRequestError";
+    if (definitive && invoice && invoice.status === "open") {
+      try {
+        await stripe.invoices.voidInvoice(
+          invoice.id,
+          {},
+          { idempotencyKey: `${operationId}:void` },
+        );
+      } catch {
+        return {
+          success: false,
+          invoiceId: invoice.id,
+          error: message,
+          failureKind: "indeterminate",
+        };
+      }
+    }
+    return {
+      success: false,
+      invoiceId: invoice?.id,
+      error: message,
+      failureKind: definitive
+        ? "definitive"
+        : released && !invoice?.id
+          ? "released"
+          : "indeterminate",
+    };
   }
+}
+
+const isMissingStripeResource = (error: unknown): boolean => {
+  const stripeError = error as {
+    type?: string;
+    code?: string;
+    statusCode?: number;
+  };
+  return (
+    stripeError?.type === "StripeInvalidRequestError" &&
+    (stripeError.code === "resource_missing" || stripeError.statusCode === 404)
+  );
+};
+
+type RetireAutoReloadInvoiceResult =
+  | { status: "released" }
+  | { status: "paid"; invoice: Stripe.Invoice }
+  | { status: "indeterminate" };
+
+async function retireAutoReloadInvoice(
+  invoice: Stripe.Invoice,
+  operationId: string,
+): Promise<RetireAutoReloadInvoiceResult> {
+  const stripe = getStripe();
+  if (invoice.status === "paid") return { status: "paid", invoice };
+  if (invoice.status === "void" || invoice.status === "uncollectible") {
+    return { status: "released" };
+  }
+
+  try {
+    if (invoice.status === "draft") {
+      await stripe.invoices.del(invoice.id);
+      return { status: "released" };
+    }
+    if (invoice.status === "open") {
+      const voidedInvoice = await stripe.invoices.voidInvoice(
+        invoice.id,
+        {},
+        { idempotencyKey: `${operationId}:void-stale` },
+      );
+      if (voidedInvoice.status === "void") return { status: "released" };
+      if (voidedInvoice.status === "paid") {
+        return { status: "paid", invoice: voidedInvoice };
+      }
+    }
+  } catch (error) {
+    if (isMissingStripeResource(error)) return { status: "released" };
+    try {
+      const latestInvoice = await stripe.invoices.retrieve(invoice.id);
+      if (latestInvoice.status === "paid") {
+        return { status: "paid", invoice: latestInvoice };
+      }
+      if (
+        latestInvoice.status === "void" ||
+        latestInvoice.status === "uncollectible"
+      ) {
+        return { status: "released" };
+      }
+    } catch (reconcileError) {
+      if (isMissingStripeResource(reconcileError)) {
+        return { status: "released" };
+      }
+    }
+  }
+
+  return { status: "indeterminate" };
 }
 
 // =============================================================================
@@ -317,6 +458,7 @@ export const deductWithAutoReloadForTeam = action({
       autoReloadThresholdDollars?: number;
       autoReloadThresholdPoints?: number;
       autoReloadAmountDollars?: number;
+      autoReloadOperationPending: boolean;
       memberDisabled: boolean;
     } = await ctx.runQuery(
       api.teamExtraUsage.getTeamExtraUsageStateForBackend,
@@ -356,7 +498,7 @@ export const deductWithAutoReloadForTeam = action({
         deductResult.memberDisabled ||
         deductResult.poolDisabled);
 
-    if (blockedForNonBalanceReason) {
+    if (blockedForNonBalanceReason && !state.autoReloadOperationPending) {
       return {
         success: deductResult.success,
         newBalanceDollars: deductResult.newBalanceDollars,
@@ -369,163 +511,408 @@ export const deductWithAutoReloadForTeam = action({
       };
     }
 
-    const thresholdPoints = state.autoReloadThresholdPoints ?? 0;
-    const reloadAmount = state.autoReloadAmountDollars ?? 0;
-    const requestedDeductionDollars = extraUsagePointsToDollars(
-      args.amountPoints,
-    );
-    const requestNeedsReload = state.balancePoints < args.amountPoints;
-    const balanceForReloadPoints = deductResult.success
-      ? deductResult.newBalancePoints
-      : state.balancePoints;
-    const balanceForReloadDollars = deductResult.success
-      ? deductResult.newBalanceDollars
-      : state.balanceDollars;
+    const requestNeedsReload =
+      !deductResult.success &&
+      deductResult.insufficientFunds &&
+      !deductResult.monthlyCapExceeded &&
+      !deductResult.memberCapExceeded &&
+      !deductResult.memberDisabled &&
+      !deductResult.poolDisabled;
+    const thresholdReached =
+      deductResult.success &&
+      deductResult.newBalancePoints <= (state.autoReloadThresholdPoints ?? 0);
     let autoReloadTriggered = false;
     let autoReloadResult:
       | { success: boolean; chargedAmountDollars?: number; reason?: string }
       | undefined;
 
-    const allConditionsMet =
-      state.enabled &&
-      !state.memberDisabled &&
-      state.autoReloadEnabled &&
-      (balanceForReloadPoints <= thresholdPoints || requestNeedsReload) &&
-      reloadAmount > 0;
+    if (
+      state.autoReloadOperationPending ||
+      (state.enabled &&
+        !state.memberDisabled &&
+        state.autoReloadEnabled &&
+        (requestNeedsReload || thresholdReached))
+    ) {
+      for (let reloadAttempt = 0; reloadAttempt < 2; reloadAttempt++) {
+        let retryAutoReload = false;
+        const candidateOperationId = crypto.randomUUID();
+        const candidateExecutorId = crypto.randomUUID();
+        let claim = await ctx.runMutation(
+          internal.teamExtraUsage.claimTeamAutoReloadOperation,
+          {
+            organizationId: args.organizationId,
+            candidateOperationId,
+            candidateExecutorId,
+            requestedAmountPoints: requestNeedsReload ? args.amountPoints : 0,
+          },
+        );
 
-    if (allConditionsMet) {
-      autoReloadTriggered = true;
-      const stripeCustomerId = await getOrgStripeCustomerId(
-        args.organizationId,
-      );
-      if (!stripeCustomerId) {
-        autoReloadResult = { success: false, reason: "no_stripe_customer" };
-      } else {
-        try {
-          const customerObj =
-            await getStripe().customers.retrieve(stripeCustomerId);
-          const isBlocked =
-            !customerObj.deleted &&
-            (customerObj as Stripe.Customer).metadata?.blocked === "true";
+        if (
+          claim.status === "operation" &&
+          !claim.claimed &&
+          requestNeedsReload
+        ) {
+          for (const delayMs of [250, 500, 1_000, 2_000]) {
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+            claim = await ctx.runMutation(
+              internal.teamExtraUsage.claimTeamAutoReloadOperation,
+              {
+                organizationId: args.organizationId,
+                candidateOperationId,
+                candidateExecutorId,
+                requestedAmountPoints: args.amountPoints,
+              },
+            );
+            if (claim.status !== "operation" || claim.claimed) break;
+          }
+        }
 
-          if (isBlocked) {
-            autoReloadResult = { success: false, reason: "customer_blocked" };
-          } else {
-            const paymentMethodId =
-              await getDefaultPaymentMethodId(stripeCustomerId);
-            if (!paymentMethodId) {
-              autoReloadResult = {
-                success: false,
-                reason: "no_default_payment_method",
+        if (claim.status === "not_needed" && requestNeedsReload) {
+          deductResult = await ctx.runMutation(
+            api.teamExtraUsage.deductTeamPoints,
+            {
+              serviceKey: args.serviceKey,
+              organizationId: args.organizationId,
+              userId: args.userId,
+              amountPoints: args.amountPoints,
+              usageSettlementId: args.usageSettlementId,
+            },
+          );
+        } else if (claim.status === "cooldown") {
+          autoReloadTriggered = true;
+          autoReloadResult = {
+            success: false,
+            reason: claim.reason ?? "payment_failed",
+          };
+        } else if (claim.status === "blocked") {
+          if (
+            claim.reason === "monthly_cap_exceeded" &&
+            !deductResult.success
+          ) {
+            deductResult = {
+              ...deductResult,
+              insufficientFunds: true,
+              monthlyCapExceeded: true,
+            };
+          }
+        } else if (claim.status === "operation" && !claim.claimed) {
+          if (requestNeedsReload) {
+            autoReloadTriggered = true;
+          }
+        } else if (
+          claim.status === "operation" &&
+          claim.claimed &&
+          claim.operationId &&
+          claim.executorId &&
+          claim.amountDollars !== undefined
+        ) {
+          autoReloadTriggered = true;
+          const operationId = claim.operationId;
+          const executorId = claim.executorId;
+          const amountDollars = claim.amountDollars;
+          const completeOperation = (
+            outcome:
+              | "success"
+              | "released"
+              | "executor_released"
+              | "definitive_failure",
+            failureReason?: string,
+          ) =>
+            ctx.runMutation(
+              internal.teamExtraUsage.completeTeamAutoReloadOperation,
+              {
+                organizationId: args.organizationId,
+                operationId,
+                executorId,
+                outcome,
+                failureReason,
+              },
+            );
+          const releasePreCharge = () =>
+            completeOperation(
+              operationId === candidateOperationId && !claim.stripeInvoiceId
+                ? "released"
+                : "executor_released",
+            );
+          const creditOperation = async ({
+            invoiceId,
+            paymentIntentId,
+            stripeCustomerId,
+          }: {
+            invoiceId: string;
+            paymentIntentId?: string;
+            stripeCustomerId?: string;
+          }) => {
+            const creditResult = await ctx.runMutation(
+              api.teamExtraUsage.addTeamCredits,
+              {
+                serviceKey: args.serviceKey,
+                organizationId: args.organizationId,
+                amountDollars,
+                idempotencyKey: `team_auto_reload:${operationId}`,
+                revenueSource: "team_extra_usage_auto_reload",
+                stripeCustomerId,
+                stripePaymentIntentId: paymentIntentId,
+                stripeInvoiceId: invoiceId,
+              },
+            );
+            const completed = await completeOperation("success");
+            autoReloadResult = {
+              success: true,
+              chargedAmountDollars: amountDollars,
+            };
+            if (deductResult.success && !creditResult.alreadyProcessed) {
+              deductResult = {
+                ...deductResult,
+                newBalancePoints: extraUsageDollarsToPoints(
+                  creditResult.newBalance,
+                ),
+                newBalanceDollars: creditResult.newBalance,
               };
-            } else {
-              const currentBalanceDollars = balanceForReloadDollars;
-              const targetBalanceDollars = Math.max(
-                reloadAmount,
-                requestNeedsReload ? requestedDeductionDollars : 0,
-              );
-              const rawAmountToCharge = Math.max(
-                0,
-                targetBalanceDollars - currentBalanceDollars,
-              );
+            }
+            if (completed) {
+              try {
+                await ctx.runMutation(
+                  internal.teamExtraUsage.recordTeamAutoReloadOutcome,
+                  { organizationId: args.organizationId, success: true },
+                );
+              } catch {
+                // The charge, credit, and operation completion already succeeded.
+                // Health telemetry is best-effort and must not change that result.
+              }
+            }
+          };
 
-              const MIN_CHARGE_DOLLARS = 1;
-              const amountToCharge =
-                requestNeedsReload &&
-                rawAmountToCharge > 0 &&
-                rawAmountToCharge < MIN_CHARGE_DOLLARS
-                  ? MIN_CHARGE_DOLLARS
-                  : rawAmountToCharge;
-              if (amountToCharge < MIN_CHARGE_DOLLARS) {
+          let shouldPreparePayment = true;
+          if (claim.stripeInvoiceId) {
+            try {
+              const existingInvoice = await getStripe().invoices.retrieve(
+                claim.stripeInvoiceId,
+              );
+              if (existingInvoice.status === "paid") {
+                const paymentIntent = (
+                  existingInvoice as unknown as {
+                    payment_intent?: string | { id: string };
+                  }
+                ).payment_intent;
+                await creditOperation({
+                  invoiceId: existingInvoice.id,
+                  paymentIntentId:
+                    typeof paymentIntent === "string"
+                      ? paymentIntent
+                      : paymentIntent?.id,
+                });
+                shouldPreparePayment = false;
+              } else if (
+                (!requestNeedsReload && !thresholdReached) ||
+                claim.paymentAllowed === false ||
+                existingInvoice.status === "void" ||
+                existingInvoice.status === "uncollectible"
+              ) {
+                const reason =
+                  claim.paymentBlockedReason ??
+                  (existingInvoice.status === "void" ||
+                  existingInvoice.status === "uncollectible"
+                    ? "invoice_not_payable"
+                    : "reload_not_needed");
                 autoReloadResult = {
                   success: false,
-                  reason: "amount_to_charge_below_minimum",
+                  reason,
                 };
-              } else {
-                const amountToChargeCents = Math.round(amountToCharge * 100);
-                const paymentResult = await createAutoReloadInvoice(
-                  stripeCustomerId,
-                  paymentMethodId,
-                  amountToChargeCents,
-                  args.organizationId,
+                const retirement = await retireAutoReloadInvoice(
+                  existingInvoice,
+                  operationId,
                 );
-
-                if (paymentResult.success) {
-                  const creditResult: {
-                    newBalance: number;
-                  } = await ctx.runMutation(api.teamExtraUsage.addTeamCredits, {
-                    serviceKey: args.serviceKey,
-                    organizationId: args.organizationId,
-                    amountDollars: amountToCharge,
-                    idempotencyKey: paymentResult.paymentIntentId,
-                    revenueSource: "team_extra_usage_auto_reload",
-                    stripeCustomerId,
-                    stripePaymentIntentId: paymentResult.paymentIntentId,
+                if (retirement.status === "paid") {
+                  const paymentIntent = (
+                    retirement.invoice as unknown as {
+                      payment_intent?: string | { id: string };
+                    }
+                  ).payment_intent;
+                  await creditOperation({
+                    invoiceId: retirement.invoice.id,
+                    paymentIntentId:
+                      typeof paymentIntent === "string"
+                        ? paymentIntent
+                        : paymentIntent?.id,
                   });
-                  if (deductResult.success) {
-                    deductResult = {
-                      ...deductResult,
-                      newBalancePoints: extraUsageDollarsToPoints(
-                        creditResult.newBalance,
-                      ),
-                      newBalanceDollars: creditResult.newBalance,
-                    };
-                  }
-                  autoReloadResult = {
-                    success: true,
-                    chargedAmountDollars: amountToCharge,
-                  };
+                } else if (retirement.status === "released") {
+                  const released = await completeOperation("released");
+                  retryAutoReload =
+                    requestNeedsReload && released && reloadAttempt === 0;
                 } else {
+                  await completeOperation("executor_released");
+                }
+                shouldPreparePayment = false;
+              }
+            } catch (error) {
+              const invoiceMissing = isMissingStripeResource(error);
+              autoReloadResult = {
+                success: false,
+                reason: invoiceMissing
+                  ? "invoice_missing"
+                  : "payment_state_unknown",
+              };
+              if (invoiceMissing) {
+                const released = await completeOperation("released");
+                retryAutoReload =
+                  requestNeedsReload && released && reloadAttempt === 0;
+              } else {
+                await completeOperation("executor_released");
+              }
+              shouldPreparePayment = false;
+            }
+          } else if (
+            (!requestNeedsReload && !thresholdReached) ||
+            claim.paymentAllowed === false
+          ) {
+            autoReloadResult = {
+              success: false,
+              reason: claim.paymentBlockedReason ?? "reload_not_needed",
+            };
+            const released = await completeOperation("released");
+            retryAutoReload =
+              requestNeedsReload && released && reloadAttempt === 0;
+            shouldPreparePayment = false;
+          }
+
+          if (shouldPreparePayment) {
+            let paymentStarted = false;
+            try {
+              const stripeCustomerId = await getOrgStripeCustomerId(
+                args.organizationId,
+              );
+              if (!stripeCustomerId) {
+                autoReloadResult = {
+                  success: false,
+                  reason: "no_stripe_customer",
+                };
+                await releasePreCharge();
+              } else {
+                const customerObj =
+                  await getStripe().customers.retrieve(stripeCustomerId);
+                const isBlocked =
+                  !customerObj.deleted &&
+                  (customerObj as Stripe.Customer).metadata?.blocked === "true";
+                const paymentMethodId = isBlocked
+                  ? null
+                  : await getDefaultPaymentMethodId(stripeCustomerId);
+                if (isBlocked || !paymentMethodId) {
                   autoReloadResult = {
                     success: false,
-                    reason: paymentResult.error || "payment_failed",
+                    reason: isBlocked
+                      ? "customer_blocked"
+                      : "no_default_payment_method",
                   };
+                  await releasePreCharge();
+                } else {
+                  paymentStarted = true;
+                  const paymentResult = await createAutoReloadInvoice(
+                    stripeCustomerId,
+                    paymentMethodId,
+                    Math.round(amountDollars * 100),
+                    args.organizationId,
+                    operationId,
+                    claim.stripeInvoiceId,
+                    async (stripeInvoiceId) => {
+                      const recorded = await ctx.runMutation(
+                        internal.teamExtraUsage.recordTeamAutoReloadInvoice,
+                        {
+                          organizationId: args.organizationId,
+                          operationId,
+                          executorId,
+                          stripeInvoiceId,
+                        },
+                      );
+                      if (!recorded) {
+                        throw new Error(
+                          "Auto-reload operation executor changed",
+                        );
+                      }
+                    },
+                  );
+                  if (paymentResult.success && paymentResult.invoiceId) {
+                    await creditOperation({
+                      invoiceId: paymentResult.invoiceId,
+                      paymentIntentId: paymentResult.paymentIntentId,
+                      stripeCustomerId,
+                    });
+                  } else {
+                    const reason =
+                      paymentResult.error ||
+                      (paymentResult.success
+                        ? "missing_invoice"
+                        : "payment_failed");
+                    autoReloadResult = { success: false, reason };
+                    if (paymentResult.failureKind === "definitive") {
+                      const completed = await completeOperation(
+                        "definitive_failure",
+                        reason,
+                      );
+                      if (completed) {
+                        try {
+                          await ctx.runMutation(
+                            internal.teamExtraUsage.recordTeamAutoReloadOutcome,
+                            {
+                              organizationId: args.organizationId,
+                              success: false,
+                              failureReason: reason,
+                            },
+                          );
+                        } catch {
+                          // Best-effort health telemetry after a completed op.
+                        }
+                      }
+                    } else if (paymentResult.failureKind === "released") {
+                      await releasePreCharge();
+                    } else {
+                      await completeOperation("executor_released");
+                    }
+                  }
                 }
+              }
+            } catch {
+              autoReloadResult = {
+                success: false,
+                reason: paymentStarted
+                  ? "payment_state_unknown"
+                  : "stripe_lookup_failed",
+              };
+              if (paymentStarted) {
+                await completeOperation("executor_released");
+              } else {
+                await releasePreCharge();
               }
             }
           }
-        } catch {
-          autoReloadResult = { success: false, reason: "stripe_lookup_failed" };
+
+          if (requestNeedsReload && autoReloadResult?.success) {
+            deductResult = await ctx.runMutation(
+              api.teamExtraUsage.deductTeamPoints,
+              {
+                serviceKey: args.serviceKey,
+                organizationId: args.organizationId,
+                userId: args.userId,
+                amountPoints: args.amountPoints,
+                usageSettlementId: args.usageSettlementId,
+              },
+            );
+            retryAutoReload =
+              reloadAttempt === 0 &&
+              !deductResult.success &&
+              deductResult.insufficientFunds &&
+              !deductResult.monthlyCapExceeded &&
+              !deductResult.memberCapExceeded &&
+              !deductResult.memberDisabled &&
+              !deductResult.poolDisabled;
+          }
         }
+        if (retryAutoReload) {
+          autoReloadResult = undefined;
+          continue;
+        }
+        break;
       }
-    }
-
-    // Record auto-reload outcome (only real charge outcomes count toward
-    // failure tracking — pre-charge config problems must not auto-disable).
-    const PRE_CHARGE_REASONS = new Set([
-      "no_stripe_customer",
-      "customer_blocked",
-      "no_default_payment_method",
-      "stripe_lookup_failed",
-      "amount_to_charge_below_minimum",
-    ]);
-    if (
-      autoReloadTriggered &&
-      autoReloadResult &&
-      (autoReloadResult.success ||
-        !PRE_CHARGE_REASONS.has(autoReloadResult.reason ?? ""))
-    ) {
-      await ctx.runMutation(
-        internal.teamExtraUsage.recordTeamAutoReloadOutcome,
-        {
-          organizationId: args.organizationId,
-          success: autoReloadResult.success,
-          failureReason: autoReloadResult.reason,
-        },
-      );
-    }
-
-    if (autoReloadResult?.success && deductWithoutReload.insufficientFunds) {
-      deductResult = await ctx.runMutation(
-        api.teamExtraUsage.deductTeamPoints,
-        {
-          serviceKey: args.serviceKey,
-          organizationId: args.organizationId,
-          userId: args.userId,
-          amountPoints: args.amountPoints,
-          usageSettlementId: args.usageSettlementId,
-        },
-      );
     }
 
     convexLogger.info("team_deduct_with_auto_reload", {

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -12,6 +12,7 @@ const {
   captureFreeAgentValueReached,
   captureToolCalls,
   captureUsageCost,
+  captureUsageSettlement,
 } = require("../chat-logger");
 const { ChatSDKError } = require("../../errors");
 const { phLogger } = require("../../posthog/server");
@@ -410,6 +411,88 @@ describe("captureUsageCost", () => {
   });
 });
 
+describe("captureUsageSettlement", () => {
+  it("captures one queryable event for an actual provider-step settlement", () => {
+    const capture = jest.fn();
+
+    captureUsageSettlement({
+      posthog: { capture } as any,
+      userId: "user_123",
+      subscription: "team",
+      organizationId: "org_123",
+      chatId: "chat_123",
+      endpoint: "/api/agent-long",
+      mode: "agent",
+      model: "anthropic/claude-opus",
+      requestId: "run_123",
+      usageSettlementId: "settlement_123",
+      settlementSequence: 2,
+      currentCostDollars: 1.75,
+      requestedDeltaPoints: 12_500,
+      deduction: {
+        includedPointsDeducted: 2_500,
+        extraUsagePointsDeducted: 8_000,
+        uncoveredPoints: 2_000,
+        usageDeductionFailed: true,
+        usageDeductionFailureReason: "monthly_cap_exceeded",
+      },
+      forced: false,
+    });
+
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      event: "hackerai-usage_settlement",
+      properties: {
+        user_id: "user_123",
+        subscription: "team",
+        subscription_tier: "team",
+        organization_id: "org_123",
+        chat_id: "chat_123",
+        request_id: "run_123",
+        usage_settlement_id: "settlement_123",
+        endpoint: "/api/agent-long",
+        mode: "agent",
+        model: "anthropic/claude-opus",
+        settlement_sequence: 2,
+        current_cost_dollars: 1.75,
+        requested_delta_points: 12_500,
+        included_points_deducted: 2_500,
+        extra_usage_points_deducted: 8_000,
+        uncovered_points: 2_000,
+        usage_deduction_failed: true,
+        usage_deduction_failure_reason: "monthly_cap_exceeded",
+        forced: false,
+        settlement_event_version: 1,
+      },
+    });
+  });
+
+  it("does nothing without a PostHog client", () => {
+    expect(() =>
+      captureUsageSettlement({
+        posthog: null,
+        userId: "user_123",
+        subscription: "pro",
+        chatId: "chat_123",
+        endpoint: "/api/chat",
+        mode: "agent",
+        model: "agent-model",
+        usageSettlementId: "settlement_123",
+        settlementSequence: 1,
+        currentCostDollars: 0.1,
+        requestedDeltaPoints: 1_400,
+        deduction: {
+          includedPointsDeducted: 1_400,
+          extraUsagePointsDeducted: 0,
+          uncoveredPoints: 0,
+          usageDeductionFailed: false,
+        },
+        forced: false,
+      }),
+    ).not.toThrow();
+  });
+});
+
 describe("createChatLogger provider stream termination", () => {
   it("logs provider safety blocks as errors with provider and model context", () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
@@ -721,7 +804,8 @@ describe("createChatLogger provider stream termination", () => {
       );
       const fields = posthogErrorCall?.[1] as { error?: unknown } | undefined;
       const capturedError = fields?.error as
-        (Error & { cause?: unknown }) | undefined;
+        | (Error & { cause?: unknown })
+        | undefined;
 
       expect(capturedError).toBeInstanceOf(Error);
       expect(capturedError?.name).toBe("AI_APICallError");

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -332,7 +332,8 @@ const buildProviderRequestDiagnostics = (args: {
   }
 
   const lastMessage = args.messages.at(-1) as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
   const serializedBytes = getSerializedBytes(args.messages);
   const contextUsedPercent =
     args.contextUsage.maxTokens > 0
@@ -426,6 +427,7 @@ export type AgentStreamContext = {
   settleUsageAfterStep?: (args: {
     currentCostDollars: number;
     force: boolean;
+    model: string;
   }) => Promise<void>;
 
   /**
@@ -880,7 +882,8 @@ export async function createAgentStream(
               const lastStepResponseMessages =
                 (
                   lastStep as
-                    { response?: { messages?: ModelMessage[] } } | undefined
+                    | { response?: { messages?: ModelMessage[] } }
+                    | undefined
                 )?.response?.messages ?? [];
               const retainedToolTransaction = getLatestCompletedToolTransaction(
                 lastStepResponseMessages,
@@ -1152,6 +1155,7 @@ export async function createAgentStream(
         force:
           budgetDecision?.type === "abort" ||
           budgetDecision?.type === "abort-agent-run-spend-cap",
+        model: response?.modelId ?? modelName,
       });
       if (budgetDecision?.type === "abort-agent-run-spend-cap") {
         state.stoppedDueToAgentRunSpendCap = true;

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -69,6 +69,7 @@ import {
   captureAgentCompletionAnalytics,
   captureToolCalls,
   captureUsageCost,
+  captureUsageSettlement,
   createChatLogger,
   shutdownPostHog,
   type ChatLogger,
@@ -194,7 +195,8 @@ export const createChatHandler = () => {
   return async (req: NextRequest) => {
     const endpoint = "/api/chat" as const;
     let preemptiveTimeout:
-      ReturnType<typeof createPreemptiveTimeout> | undefined;
+      | ReturnType<typeof createPreemptiveTimeout>
+      | undefined;
 
     // Track usage deductions for refund on error
     const usageRefundTracker = new UsageRefundTracker();
@@ -425,7 +427,8 @@ export const createChatHandler = () => {
       chatLogger.setChat(chatLogContext, selectedModel);
 
       let paidDailyFreeAllowanceReservation:
-        PaidDailyFreeAllowanceReservation | undefined;
+        | PaidDailyFreeAllowanceReservation
+        | undefined;
       let rateLimitInfo: RateLimitInfo;
 
       try {
@@ -868,7 +871,8 @@ export const createChatHandler = () => {
             const usageSettlementState =
               subscription === "free" || paidDailyFreeAllowanceReservation
                 ? null
-                : createUsageSettlementState(rateLimitInfo, extraUsageConfig);
+                : createUsageSettlementState(rateLimitInfo);
+            let usageSettlementSequence = 0;
 
             const deductAccumulatedUsage = async () => {
               try {
@@ -1081,7 +1085,7 @@ export const createChatHandler = () => {
             };
 
             const settleUsageAfterStep: AgentStreamContext["settleUsageAfterStep"] =
-              async ({ currentCostDollars, force }) => {
+              async ({ currentCostDollars, force, model }) => {
                 if (!usageSettlementState || hasRecordedUsage) return;
                 if (
                   !shouldSettleUsageMidRun({
@@ -1098,6 +1102,7 @@ export const createChatHandler = () => {
                   currentCostDollars,
                 );
                 if (additionalCostPoints <= 0) return;
+                usageSettlementSequence += 1;
 
                 let deductionResult: Awaited<
                   ReturnType<typeof deductUsageDelta>
@@ -1125,8 +1130,8 @@ export const createChatHandler = () => {
                     usage_settlement_id: usageTracker.usageSettlementId,
                     current_cost_dollars: currentCostDollars,
                     force,
-                    error:
-                      error instanceof Error ? error.message : String(error),
+                    error_name:
+                      error instanceof Error ? error.name : "UnknownError",
                   });
                   deductionResult = {
                     includedPointsDeducted: 0,
@@ -1136,6 +1141,24 @@ export const createChatHandler = () => {
                     usageDeductionFailureReason: "deduction_failed",
                   };
                 }
+
+                captureUsageSettlement({
+                  posthog,
+                  userId,
+                  subscription,
+                  organizationId,
+                  chatId,
+                  endpoint,
+                  mode,
+                  model,
+                  requestId: req.headers.get("x-vercel-id") ?? undefined,
+                  usageSettlementId: usageTracker.usageSettlementId,
+                  settlementSequence: usageSettlementSequence,
+                  currentCostDollars,
+                  requestedDeltaPoints: additionalCostPoints,
+                  deduction: deductionResult,
+                  forced: force,
+                });
 
                 usageRefundTracker.addDeductions(deductionResult);
                 const cumulativeDeduction = addUsageDeductionDelta(

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -29,6 +29,7 @@ import {
   paidFunnelProperties,
 } from "@/lib/analytics/paid-funnel";
 import type { UsageCostRecord } from "@/lib/usage-tracker";
+import type { UsageDeductionResult } from "@/lib/rate-limit";
 import type { BudgetAbortDetails } from "@/lib/chat/budget-monitor";
 import type { OpenRouterModelMetadata } from "@/lib/api/openrouter-metadata";
 import {
@@ -601,7 +602,9 @@ export function createChatLogger(config: ChatLoggerConfig) {
     recordAnthropicPromptRepair(repair: {
       action: "appended_continue" | "trimmed";
       reason:
-        "useful_assistant_tail" | "no_useful_content" | "dangling_tool_call";
+        | "useful_assistant_tail"
+        | "no_useful_content"
+        | "dangling_tool_call";
       trailingAssistantContentTypes?: string[];
       model: string;
     }) {
@@ -837,7 +840,8 @@ export function createChatLogger(config: ChatLoggerConfig) {
           (error.metadata?.capReason as LimitCapReason | undefined) ??
           "unknown";
         const resetTimestamp = error.metadata?.resetTimestamp as
-          number | undefined;
+          | number
+          | undefined;
         const subscriptionTier = isSubscriptionTier(subscription)
           ? subscription
           : undefined;
@@ -1371,6 +1375,73 @@ export function captureUsageCost({
         subscription_tier: subscription,
         last_usage_cost_at: new Date().toISOString(),
       },
+    },
+  });
+}
+
+/**
+ * Capture one event for each positive provider-step settlement attempt. This
+ * complements the request-level hackerai-usage_cost aggregate with the exact
+ * wallet outcome that determined whether the next provider step could start.
+ */
+export function captureUsageSettlement({
+  posthog,
+  userId,
+  subscription,
+  organizationId,
+  chatId,
+  endpoint,
+  mode,
+  model,
+  requestId,
+  usageSettlementId,
+  settlementSequence,
+  currentCostDollars,
+  requestedDeltaPoints,
+  deduction,
+  forced,
+}: {
+  posthog: PostHog | null;
+  userId: string;
+  subscription: string;
+  organizationId?: string;
+  chatId: string;
+  endpoint: ChatApiEndpoint;
+  mode: ChatMode;
+  model: string;
+  requestId?: string;
+  usageSettlementId: string;
+  settlementSequence: number;
+  currentCostDollars: number;
+  requestedDeltaPoints: number;
+  deduction: UsageDeductionResult;
+  forced: boolean;
+}) {
+  if (!posthog) return;
+  posthog.capture({
+    distinctId: userId,
+    event: "hackerai-usage_settlement",
+    properties: {
+      user_id: userId,
+      subscription,
+      subscription_tier: subscription,
+      ...(organizationId && { organization_id: organizationId }),
+      chat_id: chatId,
+      ...(requestId && { request_id: requestId }),
+      usage_settlement_id: usageSettlementId,
+      endpoint,
+      mode,
+      model,
+      settlement_sequence: settlementSequence,
+      current_cost_dollars: currentCostDollars,
+      requested_delta_points: requestedDeltaPoints,
+      included_points_deducted: deduction.includedPointsDeducted,
+      extra_usage_points_deducted: deduction.extraUsagePointsDeducted,
+      uncovered_points: deduction.uncoveredPoints,
+      usage_deduction_failed: deduction.usageDeductionFailed,
+      usage_deduction_failure_reason: deduction.usageDeductionFailureReason,
+      forced,
+      settlement_event_version: 1,
     },
   });
 }

--- a/lib/rate-limit/__tests__/usage-settlement.test.ts
+++ b/lib/rate-limit/__tests__/usage-settlement.test.ts
@@ -14,69 +14,43 @@ describe("usage-settlement", () => {
     pointsDeducted: 1_000,
   };
 
-  it("does not settle small deltas while known balance can cover the run", () => {
-    const state = createUsageSettlementState(baseRateLimitInfo, {
-      enabled: true,
-      hasBalance: true,
-      balanceDollars: 10,
-    });
+  it("does not settle cost already covered by the upfront deduction", () => {
+    const state = createUsageSettlementState(baseRateLimitInfo);
 
     expect(
       shouldSettleUsageMidRun({
         state,
-        currentCostDollars: 0.25,
+        currentCostDollars: 0.05,
       }),
     ).toBe(false);
   });
 
-  it("does not settle larger deltas while included monthly cushion can cover them", () => {
-    const state = createUsageSettlementState(baseRateLimitInfo, {
-      enabled: true,
-      hasBalance: false,
-      balanceDollars: 0,
-    });
+  it("settles a positive delta below the former minimum threshold", () => {
+    const state = createUsageSettlementState(baseRateLimitInfo);
+
+    expect(
+      shouldSettleUsageMidRun({
+        state,
+        currentCostDollars: 0.08,
+      }),
+    ).toBe(true);
+    expect(getUnsettledUsagePoints(state, 0.08)).toBe(120);
+  });
+
+  it("settles without trusting the remaining balance captured at run start", () => {
+    const state = createUsageSettlementState(baseRateLimitInfo);
 
     expect(
       shouldSettleUsageMidRun({
         state,
         currentCostDollars: 5,
       }),
-    ).toBe(false);
-  });
-
-  it("settles when accumulated cost exceeds known included and extra balance cushion", () => {
-    const state = createUsageSettlementState(
-      {
-        ...baseRateLimitInfo,
-        remaining: 0,
-        monthly: {
-          remaining: 0,
-          limit: 250_000,
-          resetTime: new Date(),
-        },
-      },
-      {
-        enabled: true,
-        hasBalance: true,
-        balanceDollars: 0.57,
-      },
-    );
-
-    expect(
-      shouldSettleUsageMidRun({
-        state,
-        currentCostDollars: 8.71,
-      }),
     ).toBe(true);
-    expect(getUnsettledUsagePoints(state, 8.71)).toBe(120_940);
+    expect(getUnsettledUsagePoints(state, 5)).toBe(69_000);
   });
 
   it("updates cumulative settled totals after a mid-run deduction", () => {
-    const state = createUsageSettlementState(baseRateLimitInfo, {
-      enabled: true,
-      hasBalance: true,
-      balanceDollars: 1,
-    });
+    const state = createUsageSettlementState(baseRateLimitInfo);
 
     const cumulative = addUsageDeductionDelta(state, {
       includedPointsDeducted: 2_000,
@@ -95,29 +69,12 @@ describe("usage-settlement", () => {
     });
   });
 
-  it("subtracts initial and mid-run extra usage from known monthly cap cushion", () => {
-    const state = createUsageSettlementState(
-      {
-        ...baseRateLimitInfo,
-        remaining: 0,
-        monthly: {
-          remaining: 0,
-          limit: 250_000,
-          resetTime: new Date(),
-        },
-        extraUsagePointsDeducted: 2_000,
-      },
-      {
-        enabled: true,
-        hasBalance: true,
-        balanceDollars: 2,
-        monthlyRemainingDollars: 0.9,
-      },
-    );
+  it("settles only the new delta after an earlier step was deducted", () => {
+    const state = createUsageSettlementState(baseRateLimitInfo);
 
     addUsageDeductionDelta(state, {
-      includedPointsDeducted: 0,
-      extraUsagePointsDeducted: 3_000,
+      includedPointsDeducted: 2_500,
+      extraUsagePointsDeducted: 0,
       uncoveredPoints: 0,
       usageDeductionFailed: false,
     });
@@ -125,8 +82,17 @@ describe("usage-settlement", () => {
     expect(
       shouldSettleUsageMidRun({
         state,
-        currentCostDollars: 1.2,
+        currentCostDollars: 0.25,
+      }),
+    ).toBe(false);
+    expect(getUnsettledUsagePoints(state, 0.25)).toBe(0);
+
+    expect(
+      shouldSettleUsageMidRun({
+        state,
+        currentCostDollars: 0.3,
       }),
     ).toBe(true);
+    expect(getUnsettledUsagePoints(state, 0.3)).toBe(700);
   });
 });

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -63,7 +63,6 @@ export { createRedisClient, formatTimeRemaining } from "./redis";
 export { UsageRefundTracker } from "./refund";
 export {
   addUsageDeductionDelta,
-  costDollarsToPoints,
   createUsageSettlementState,
   getUsageSettlementInitialDeduction,
   getUnsettledUsagePoints,

--- a/lib/rate-limit/usage-settlement.ts
+++ b/lib/rate-limit/usage-settlement.ts
@@ -1,28 +1,16 @@
-import type { ExtraUsageConfig, RateLimitInfo } from "@/types";
-import { extraUsageDollarsToPoints } from "@/convex/lib/extraUsagePricing";
+import type { RateLimitInfo } from "@/types";
 import {
   billableCostDollarsToPoints,
-  POINTS_PER_DOLLAR,
   type UsageDeductionFailureReason,
   type UsageDeductionResult,
 } from "./token-bucket";
 
-export const MID_RUN_SETTLEMENT_MIN_DELTA_DOLLARS = 0.5;
-export const MID_RUN_SETTLEMENT_MIN_DELTA_POINTS = billableCostDollarsToPoints(
-  MID_RUN_SETTLEMENT_MIN_DELTA_DOLLARS,
-);
-
 export type UsageSettlementState = {
-  initialIncludedPointsDeducted: number;
-  initialExtraUsagePointsDeducted: number;
   includedPointsDeducted: number;
   extraUsagePointsDeducted: number;
   uncoveredPoints: number;
   usageDeductionFailed: boolean;
   usageDeductionFailureReason?: UsageDeductionFailureReason;
-  monthlyRemainingAtStartPoints: number;
-  extraUsageBalanceAtStartPoints: number;
-  extraUsageMonthlyRemainingAtStartPoints?: number;
 };
 
 const nonNegativePoints = (value: number | undefined): number =>
@@ -30,49 +18,16 @@ const nonNegativePoints = (value: number | undefined): number =>
     ? Math.max(0, Math.round(value))
     : 0;
 
-export const costDollarsToPoints = (costDollars: number): number =>
-  Number.isFinite(costDollars)
-    ? Math.max(
-        0,
-        Math.ceil(Number((costDollars * POINTS_PER_DOLLAR).toFixed(6))),
-      )
-    : 0;
-
 export const createUsageSettlementState = (
   rateLimitInfo: RateLimitInfo,
-  extraUsageConfig?: ExtraUsageConfig,
 ): UsageSettlementState => {
-  const initialIncludedPointsDeducted = nonNegativePoints(
-    rateLimitInfo.pointsDeducted,
-  );
-  const initialExtraUsagePointsDeducted = nonNegativePoints(
-    rateLimitInfo.extraUsagePointsDeducted,
-  );
-
   return {
-    initialIncludedPointsDeducted,
-    initialExtraUsagePointsDeducted,
-    includedPointsDeducted: initialIncludedPointsDeducted,
-    extraUsagePointsDeducted: initialExtraUsagePointsDeducted,
+    includedPointsDeducted: nonNegativePoints(rateLimitInfo.pointsDeducted),
+    extraUsagePointsDeducted: nonNegativePoints(
+      rateLimitInfo.extraUsagePointsDeducted,
+    ),
     uncoveredPoints: 0,
     usageDeductionFailed: false,
-    monthlyRemainingAtStartPoints: nonNegativePoints(
-      rateLimitInfo.monthly?.remaining ?? rateLimitInfo.remaining,
-    ),
-    extraUsageBalanceAtStartPoints: Math.max(
-      0,
-      extraUsageDollarsToPoints(extraUsageConfig?.balanceDollars ?? 0) -
-        initialExtraUsagePointsDeducted,
-    ),
-    extraUsageMonthlyRemainingAtStartPoints:
-      extraUsageConfig?.monthlyRemainingDollars === undefined
-        ? undefined
-        : Math.max(
-            0,
-            extraUsageDollarsToPoints(
-              extraUsageConfig.monthlyRemainingDollars,
-            ) - initialExtraUsagePointsDeducted,
-          ),
   };
 };
 
@@ -86,39 +41,6 @@ export const getUsageSettlementInitialDeduction = (
 export const getSettledUsagePoints = (state: UsageSettlementState): number =>
   state.includedPointsDeducted + state.extraUsagePointsDeducted;
 
-const getKnownUnsettledCushionPoints = (
-  state: UsageSettlementState,
-): number => {
-  const includedDeductedAfterStart = Math.max(
-    0,
-    state.includedPointsDeducted - state.initialIncludedPointsDeducted,
-  );
-  const includedCushion = Math.max(
-    0,
-    state.monthlyRemainingAtStartPoints - includedDeductedAfterStart,
-  );
-
-  const extraDeductedAfterStart = Math.max(
-    0,
-    state.extraUsagePointsDeducted - state.initialExtraUsagePointsDeducted,
-  );
-  const balanceCushion = Math.max(
-    0,
-    state.extraUsageBalanceAtStartPoints - extraDeductedAfterStart,
-  );
-  const extraMonthlyCapCushion =
-    state.extraUsageMonthlyRemainingAtStartPoints === undefined
-      ? balanceCushion
-      : Math.max(
-          0,
-          state.extraUsageMonthlyRemainingAtStartPoints -
-            extraDeductedAfterStart,
-        );
-  const extraCushion = Math.min(balanceCushion, extraMonthlyCapCushion);
-
-  return includedCushion + extraCushion;
-};
-
 export const getUnsettledUsagePoints = (
   state: UsageSettlementState,
   currentCostDollars: number,
@@ -129,21 +51,16 @@ export const getUnsettledUsagePoints = (
       getSettledUsagePoints(state),
   );
 
+// Settle every newly accrued model-step delta. A balance captured when the run
+// started is not a safe cushion because another parallel run can spend it.
 export const shouldSettleUsageMidRun = ({
   state,
   currentCostDollars,
-  force = false,
 }: {
   state: UsageSettlementState;
   currentCostDollars: number;
   force?: boolean;
-}): boolean => {
-  const unsettledPoints = getUnsettledUsagePoints(state, currentCostDollars);
-  if (unsettledPoints <= 0) return false;
-  if (force) return true;
-  if (unsettledPoints < MID_RUN_SETTLEMENT_MIN_DELTA_POINTS) return false;
-  return unsettledPoints > getKnownUnsettledCushionPoints(state);
-};
+}): boolean => getUnsettledUsagePoints(state, currentCostDollars) > 0;
 
 export const addUsageDeductionDelta = (
   state: UsageSettlementState,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -95,6 +95,7 @@ import {
   captureAgentCompletionAnalytics,
   captureToolCalls,
   captureUsageCost,
+  captureUsageSettlement,
   createChatLogger,
   type ChatLogger,
 } from "@/lib/api/chat-logger";
@@ -592,7 +593,8 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
 
 const getTerminalProviderStreamError = (
   state:
-    Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
+    | Pick<AgentStreamState, "streamFinishReason" | "providerError">
+    | undefined,
 ): unknown | undefined => {
   if (!state) return undefined;
   if (state.streamFinishReason !== "error") return undefined;
@@ -609,7 +611,8 @@ const getTerminalProviderStreamError = (
 
 const isTerminalProviderStreamError = (
   state:
-    Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
+    | Pick<AgentStreamState, "streamFinishReason" | "providerError">
+    | undefined,
 ): boolean => state?.streamFinishReason === "error";
 
 type RecordedAgentLongFailure = {
@@ -1546,7 +1549,8 @@ export const agentLongTask = task({
             const usageSettlementState =
               subscription === "free"
                 ? null
-                : createUsageSettlementState(rateLimitInfo, extraUsageConfig);
+                : createUsageSettlementState(rateLimitInfo);
+            let usageSettlementSequence = 0;
 
             const deductAccumulatedUsage = async () => {
               try {
@@ -1674,7 +1678,7 @@ export const agentLongTask = task({
             };
 
             const settleUsageAfterStep: AgentStreamContext["settleUsageAfterStep"] =
-              async ({ currentCostDollars, force }) => {
+              async ({ currentCostDollars, force, model }) => {
                 if (!usageSettlementState || hasRecordedUsage) return;
                 if (
                   !shouldSettleUsageMidRun({
@@ -1691,6 +1695,7 @@ export const agentLongTask = task({
                   currentCostDollars,
                 );
                 if (additionalCostPoints <= 0) return;
+                usageSettlementSequence += 1;
 
                 let deductionResult: Awaited<
                   ReturnType<typeof deductUsageDelta>
@@ -1718,8 +1723,8 @@ export const agentLongTask = task({
                     usage_settlement_id: usageTracker.usageSettlementId,
                     current_cost_dollars: currentCostDollars,
                     force,
-                    error:
-                      error instanceof Error ? error.message : String(error),
+                    error_name:
+                      error instanceof Error ? error.name : "UnknownError",
                   });
                   deductionResult = {
                     includedPointsDeducted: 0,
@@ -1729,6 +1734,24 @@ export const agentLongTask = task({
                     usageDeductionFailureReason: "deduction_failed",
                   };
                 }
+
+                captureUsageSettlement({
+                  posthog,
+                  userId,
+                  subscription,
+                  organizationId,
+                  chatId,
+                  endpoint,
+                  mode,
+                  model,
+                  requestId: ctx.run.id,
+                  usageSettlementId: usageTracker.usageSettlementId,
+                  settlementSequence: usageSettlementSequence,
+                  currentCostDollars,
+                  requestedDeltaPoints: additionalCostPoints,
+                  deduction: deductionResult,
+                  forced: force,
+                });
 
                 usageRefundTracker.addDeductions(deductionResult);
                 const cumulativeDeduction = addUsageDeductionDelta(


### PR DESCRIPTION
## Summary

- settle every positive newly accrued Agent provider-step cost before starting the next provider request
- serialize personal and team auto-reload through one durable wallet-scoped operation with executor leases and Stripe idempotency
- emit a structured `hackerai-usage_settlement` PostHog event for every live settlement attempt while retaining the existing request-level `hackerai-usage_cost` aggregate
- preserve final reconciliation and `UsageRefundTracker` semantics so mid-run deductions are neither charged twice nor lost on refunds

## Root cause

The stream runner already awaits `onStepFinish` before starting the next provider step, but mid-run billing previously waited for both a $0.50 delta and spend beyond a balance snapshot captured at request start. Parallel runs could spend that same apparent cushion, allowing one long Agent run to continue through many expensive provider calls before final reconciliation exposed a large `uncovered_cost_dollars` value.

Personal and team auto-reload also used query/charge/credit/deduct flows. Parallel actions could both observe a low balance and independently charge Stripe.

## Design

### Per-step settlement

After each completed provider request:

1. compute the newly accrued cumulative cost delta
2. settle every positive delta against the current included/extra-usage balance
3. stop before the next provider request if any points remain uncovered
4. run the existing final reconciliation for authoritative totals and refunds

This adds an internal billing round trip per positive Agent model step. It does not add another model call, and Stripe is contacted only when the current wallet state requires auto-reload.

### Auto-reload concurrency and recovery

Personal and team paths now:

- deduct transactionally before coordinating reload
- atomically claim one durable operation per wallet or organization
- lease exactly one Stripe executor while followers wait/re-read
- use stable operation-scoped idempotency keys for invoice creation, invoice item creation, finalize, pay, void, and credit
- revalidate balance, config, requested need, and cap headroom before resuming an existing operation
- credit paid invoices before any retirement path, including paid invoices without a PaymentIntent
- retire stale drafts, void open invoices, and safely release missing/void/uncollectible operations
- retain ambiguous payment state for takeover while clearing confirmed declines with a short cooldown
- retry once after retiring an undersized/stale operation so a replacement reload can cover the current deduction

The canonical extra-usage surcharge conversion remains 1.15. Exact-$1 Stripe minimum and cap-boundary cases are handled without exceeding configured monthly headroom.

## Settlement telemetry

Each actual mid-run attempt emits `hackerai-usage_settlement` with stable snake_case fields:

- user, organization, chat, endpoint, mode, subscription, served model
- request/run ID and `usage_settlement_id`
- settlement sequence and cumulative `current_cost_dollars`
- requested delta points
- included, extra-usage, and uncovered points
- deduction failure boolean/reason and forced-budget state

The event contains no prompts, secrets, card data, invoice contents, or raw exception messages. The existing one-per-request `hackerai-usage_cost` event remains unchanged for aggregate cost reporting.

## Validation

- `corepack pnpm jest convex/__tests__/extraUsageActionsAuth.test.ts convex/__tests__/extraUsageAutoReloadOperations.test.ts convex/__tests__/teamExtraUsage.test.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts lib/rate-limit/__tests__/refund.test.ts lib/rate-limit/__tests__/usage-settlement.test.ts lib/api/__tests__/chat-logger.test.ts --runInBand` — 7 suites / 147 tests
- `corepack pnpm test --runInBand` — 229 suites / 2,278 tests
- `corepack pnpm typecheck`
- focused ESLint over all changed production and test files
- focused Prettier over all changed files
- `corepack pnpm lint` — 0 errors; 6 pre-existing unrelated warnings
- `git diff origin/main...HEAD --check`

## Rationale and limitation

This follows prepaid/metered billing practice: settle actual measured usage at the provider-request boundary and prevent further work when funds or caps cannot cover it. See [Anthropic spend limits](https://platform.claude.com/docs/en/build-with-claude/spend-limits), [OpenAI prepaid billing](https://help.openai.com/en/articles/8264778-what-is-prepaid-billin), [Stripe idempotent requests](https://docs.stripe.com/api/idempotent_requests), [Cursor pricing](https://cursor.com/docs/account/pricing), [Cursor spend limits](https://cursor.com/docs/account/teams/spend-limits), [GitHub metered billing](https://docs.github.com/en/billing/concepts/product-billing/github-actions), and [GitHub budgets](https://docs.github.com/en/billing/concepts/product-billing/usage-and-spending-limits).

One provider request that is already in flight can still overshoot the available balance. This PR bounds exposure to that single request; it prevents a multi-step Agent run from continuing unpaid after the step settles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordinated auto-reload handling for personal and team usage.
  * Improved invoice recovery, retry, and duplicate-charge prevention during parallel usage requests.
  * Balance status now indicates when an auto-reload is pending.
  * Re-enabling auto-reload clears previous retry and failure states.

* **Bug Fixes**
  * Improved mid-run usage settlement to charge only newly accumulated usage.
  * Added more reliable handling for failed, incomplete, or already-paid reload invoices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->