### PR TITLE
Allow paid daily usage in Agent mode

### DIFF
--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -241,7 +241,7 @@ export const MessageErrorState = ({
             Your paid-plan limit is used up, but you still have
             {allowanceCostRemaining !== undefined
               ? ` up to $${allowanceCostRemaining.toFixed(2)}`
-              : ""}{" "}
+              : " some"}{" "}
             of free usage today. Continue this request in{" "}
             {mode === "agent"
               ? "Agent"

--- a/app/components/MessageErrorState.tsx
+++ b/app/components/MessageErrorState.tsx
@@ -1,7 +1,11 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { MemoizedMarkdown } from "./MemoizedMarkdown";
-import { ChatSDKError, isNetworkStreamError } from "@/lib/errors";
+import {
+  ChatSDKError,
+  deserializeChatSDKErrorFromStream,
+  isNetworkStreamError,
+} from "@/lib/errors";
 import { useGlobalState } from "@/app/contexts/GlobalState";
 import { redirectToPricing } from "@/app/hooks/usePricingDialog";
 import { openSettingsDialog } from "@/lib/utils/settings-dialog";
@@ -12,9 +16,10 @@ import {
   capturePaidDailyFreeAllowanceImpression,
   captureUpgradeCtaImpression,
 } from "@/lib/analytics/client";
+import type { ChatMode } from "@/types";
 import type { LimitCapReason } from "@/lib/limit-pressure";
 import {
-  PAID_DAILY_FREE_ASK_CTA_TEXT,
+  getPaidDailyFreeAllowanceCtaText,
   getExtraUsageLimitCta,
   getLimitTypeForCapReason,
   shouldShowUpgradeCta,
@@ -25,6 +30,7 @@ interface MessageErrorStateProps {
   error: Error;
   onRetry: (options?: RetryOptions) => void;
   onReconnect?: () => void;
+  mode?: ChatMode;
 }
 
 const formatCountdown = (ms: number): string => {
@@ -45,12 +51,19 @@ export const MessageErrorState = ({
   error,
   onRetry,
   onReconnect,
+  mode,
 }: MessageErrorStateProps) => {
   const { subscription, initializeNewChat } = useGlobalState();
+  const structuredStreamError = useMemo(
+    () => deserializeChatSDKErrorFromStream(error),
+    [error],
+  );
+  const displayError = structuredStreamError ?? error;
   const isRateLimitError =
-    error instanceof ChatSDKError && error.type === "rate_limit";
+    displayError instanceof ChatSDKError && displayError.type === "rate_limit";
 
-  const metadata = error instanceof ChatSDKError ? error.metadata : undefined;
+  const metadata =
+    displayError instanceof ChatSDKError ? displayError.metadata : undefined;
   const resetTimestamp = metadata?.resetTimestamp as number | undefined;
   const capReason = metadata?.capReason as LimitCapReason | undefined;
   const upgradeImpressionRef = useRef(false);
@@ -74,10 +87,12 @@ export const MessageErrorState = ({
 
   // Extract error message - check for cause first, then message
   const errorMessage = (() => {
-    if (error instanceof ChatSDKError) {
-      return typeof error.cause === "string" ? error.cause : error.message;
+    if (displayError instanceof ChatSDKError) {
+      return typeof displayError.cause === "string"
+        ? displayError.cause
+        : displayError.message;
     }
-    return error.message || "An error occurred.";
+    return displayError.message || "An error occurred.";
   })();
   const isProviderContentBlocked =
     metadata?.providerErrorCategory === "content_blocked" ||
@@ -85,7 +100,9 @@ export const MessageErrorState = ({
       errorMessage,
     );
   const canReconnect =
-    !isProviderContentBlocked && !!onReconnect && isNetworkStreamError(error);
+    !isProviderContentBlocked &&
+    !!onReconnect &&
+    isNetworkStreamError(displayError);
 
   const isPaidUser = subscription !== "free";
   const canUpgrade = shouldShowUpgradeCta({ subscription, capReason });
@@ -106,6 +123,11 @@ export const MessageErrorState = ({
     isRateLimitError &&
     paidDailyFreeAllowance?.type === "paid_daily_free_allowance" &&
     paidDailyFreeAllowance.available === true;
+  const paidDailyFreeAllowanceCtaText = getPaidDailyFreeAllowanceCtaText(mode);
+  const allowanceCostRemaining =
+    typeof paidDailyFreeAllowance?.costRemainingDollars === "number"
+      ? paidDailyFreeAllowance.costRemainingDollars
+      : undefined;
   const shouldFocusPaidAllowanceActions =
     canUsePaidDailyFreeAllowance &&
     extraUsageCta?.analyticsText === "Add Credits";
@@ -169,7 +191,7 @@ export const MessageErrorState = ({
       source: "rate_limit_error",
       from_tier: subscription,
       cap_reason: capReason,
-      cta_text: PAID_DAILY_FREE_ASK_CTA_TEXT,
+      cta_text: paidDailyFreeAllowanceCtaText,
       allowance_requests_remaining: paidDailyFreeAllowance?.requestsRemaining,
       allowance_cost_remaining_dollars:
         paidDailyFreeAllowance?.costRemainingDollars,
@@ -178,6 +200,7 @@ export const MessageErrorState = ({
     canUsePaidDailyFreeAllowance,
     capReason,
     paidDailyFreeAllowance,
+    paidDailyFreeAllowanceCtaText,
     subscription,
   ]);
 
@@ -211,6 +234,22 @@ export const MessageErrorState = ({
         {isRateLimitError && timeRemaining > 0 && (
           <p className="text-xs text-muted-foreground mt-1">
             Resets in {formatCountdown(timeRemaining)}
+          </p>
+        )}
+        {canUsePaidDailyFreeAllowance && (
+          <p className="text-xs text-muted-foreground mt-2">
+            Your paid-plan limit is used up, but you still have
+            {allowanceCostRemaining !== undefined
+              ? ` up to $${allowanceCostRemaining.toFixed(2)}`
+              : ""}{" "}
+            of free usage today. Continue this request in{" "}
+            {mode === "agent"
+              ? "Agent"
+              : mode === "ask"
+                ? "Ask"
+                : "the current"}{" "}
+            mode with our low-cost model. The daily allowance resets at midnight
+            UTC.
           </p>
         )}
       </div>
@@ -270,7 +309,7 @@ export const MessageErrorState = ({
                     source: "rate_limit_error",
                     from_tier: subscription,
                     cap_reason: capReason,
-                    cta_text: PAID_DAILY_FREE_ASK_CTA_TEXT,
+                    cta_text: paidDailyFreeAllowanceCtaText,
                     allowance_requests_remaining:
                       paidDailyFreeAllowance?.requestsRemaining,
                     allowance_cost_remaining_dollars:
@@ -281,7 +320,7 @@ export const MessageErrorState = ({
                   });
                 }}
               >
-                {PAID_DAILY_FREE_ASK_CTA_TEXT}
+                {paidDailyFreeAllowanceCtaText}
               </Button>
             )}
             {showUpgrade && (

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -45,10 +45,7 @@ interface MessagesProps {
   scrollRef: RefObject<HTMLDivElement | null>;
   contentRef: RefObject<HTMLDivElement | null>;
   paginationStatus?:
-    | "LoadingFirstPage"
-    | "CanLoadMore"
-    | "LoadingMore"
-    | "Exhausted";
+    "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
   loadMore?: (numItems: number) => void;
   isTemporaryChat?: boolean;
   isMobile?: boolean;
@@ -366,6 +363,7 @@ export const Messages = ({
               error={error}
               onRetry={onRetry}
               onReconnect={onReconnect}
+              mode={mode}
             />
           )}
         </div>

--- a/app/components/RateLimitWarning.tsx
+++ b/app/components/RateLimitWarning.tsx
@@ -52,6 +52,13 @@ export type RateLimitWarningData =
       midStream?: boolean;
     }
   | {
+      warningType: "paid-daily-free-allowance";
+      resetTime: Date;
+      subscription: SubscriptionTier;
+      mode: ChatMode;
+      costLimitDollars: number;
+    }
+  | {
       warningType: "agent-run-spend-cap";
       resetTime: Date;
       subscription: "pro";
@@ -116,6 +123,10 @@ const getMessage = (data: RateLimitWarningData, timeString: string): string => {
     return `You're now using extra usage credits. Your monthly limit resets ${timeString}.`;
   }
 
+  if (data.warningType === "paid-daily-free-allowance") {
+    return `Your paid-plan limit is used up, so this ${data.mode === "agent" ? "Agent" : "Ask"} response is using today's free $${data.costLimitDollars.toFixed(2)} allowance with our low-cost model. It resets ${timeString} and the response will stop if the allowance runs out.`;
+  }
+
   if (data.warningType === "agent-run-spend-cap") {
     return `This Pro Agent run paused after using $${data.runCostDollars.toFixed(2)} of the $${data.runCapDollars.toFixed(2)} legacy per-run safety cap. Continue to keep working.`;
   }
@@ -176,7 +187,8 @@ export const RateLimitWarning = ({
   const message = getMessage(data, timeString);
   const capReason =
     data.warningType === "sliding-window" ||
-    data.warningType === "agent-run-spend-cap"
+    data.warningType === "agent-run-spend-cap" ||
+    data.warningType === "paid-daily-free-allowance"
       ? undefined
       : data.capReason;
   const extraUsageCta =
@@ -186,10 +198,13 @@ export const RateLimitWarning = ({
           capReason,
         })
       : null;
-  const showUsageCta = data.warningType === "extra-usage-active";
+  const showUsageCta =
+    data.warningType === "extra-usage-active" ||
+    data.warningType === "paid-daily-free-allowance";
   const showUpgrade =
     data.warningType !== "agent-run-spend-cap" &&
     data.warningType !== "extra-usage-active" &&
+    data.warningType !== "paid-daily-free-allowance" &&
     shouldShowUpgradeCta({
       subscription: data.subscription,
       capReason,
@@ -199,9 +214,11 @@ export const RateLimitWarning = ({
       ? "daily_requests"
       : data.warningType === "agent-run-spend-cap"
         ? "monthly"
-        : data.warningType === "token-bucket"
-          ? getLimitTypeForCapReason(capReason)
-          : getLimitTypeForCapReason(data.capReason ?? "extra_usage_active");
+        : data.warningType === "paid-daily-free-allowance"
+          ? "paid_daily_free_allowance"
+          : data.warningType === "token-bucket"
+            ? getLimitTypeForCapReason(capReason)
+            : getLimitTypeForCapReason(data.capReason ?? "extra_usage_active");
   const limitSeverity =
     data.warningType === "token-bucket" && data.remainingPercent === 0
       ? "hit"

--- a/app/components/__tests__/MessageErrorState.test.tsx
+++ b/app/components/__tests__/MessageErrorState.test.tsx
@@ -179,6 +179,29 @@ describe("MessageErrorState", () => {
     );
   });
 
+  it("keeps the allowance explanation grammatical without cost metadata", () => {
+    const error = new ChatSDKError(
+      "rate_limit:chat",
+      "You've hit your monthly usage limit.",
+      {
+        capReason: "monthly_exhausted",
+        paidDailyFreeAllowance: {
+          type: "paid_daily_free_allowance",
+          available: true,
+          requestsRemaining: 1,
+        },
+      },
+    );
+
+    render(
+      <TestWrapper>
+        <MessageErrorState error={error} onRetry={jest.fn()} mode="agent" />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText(/some of free usage today/i)).toBeVisible();
+  });
+
   it("does not show the free-request CTA when allowance is unavailable", () => {
     const error = new ChatSDKError(
       "rate_limit:chat",

--- a/app/components/__tests__/MessageErrorState.test.tsx
+++ b/app/components/__tests__/MessageErrorState.test.tsx
@@ -3,8 +3,8 @@ import { describe, expect, it, jest, beforeEach } from "@jest/globals";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { ChatSDKError } from "@/lib/errors";
-import { PAID_DAILY_FREE_ASK_CTA_TEXT } from "@/lib/limit-pressure";
+import { ChatSDKError, serializeChatSDKErrorForStream } from "@/lib/errors";
+import { getPaidDailyFreeAllowanceCtaText } from "@/lib/limit-pressure";
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   GlobalStateProvider: ({ children }: { children: ReactNode }) => children,
@@ -107,7 +107,7 @@ describe("MessageErrorState", () => {
 
     render(
       <TestWrapper>
-        <MessageErrorState error={error} onRetry={onRetry} />
+        <MessageErrorState error={error} onRetry={onRetry} mode="ask" />
       </TestWrapper>,
     );
 
@@ -117,13 +117,13 @@ describe("MessageErrorState", () => {
     expect(screen.queryByRole("button", { name: "Upgrade Plan" })).toBeNull();
 
     const freeRequestButton = screen.getByRole("button", {
-      name: PAID_DAILY_FREE_ASK_CTA_TEXT,
+      name: getPaidDailyFreeAllowanceCtaText("ask"),
     });
     expect(freeRequestButton).toBeVisible();
     expect(capturePaidDailyFreeAllowanceImpression).toHaveBeenCalledWith(
       expect.objectContaining({
         surface: "message_error_state",
-        cta_text: PAID_DAILY_FREE_ASK_CTA_TEXT,
+        cta_text: getPaidDailyFreeAllowanceCtaText("ask"),
         allowance_requests_remaining: 1,
         allowance_cost_remaining_dollars: 0.25,
       }),
@@ -134,12 +134,49 @@ describe("MessageErrorState", () => {
     expect(capturePaidDailyFreeAllowanceClick).toHaveBeenCalledWith(
       expect.objectContaining({
         surface: "message_error_state",
-        cta_text: PAID_DAILY_FREE_ASK_CTA_TEXT,
+        cta_text: getPaidDailyFreeAllowanceCtaText("ask"),
       }),
     );
     expect(onRetry).toHaveBeenCalledWith({
       limitRescue: { type: "paid_daily_free_allowance" },
     });
+  });
+
+  it("offers the daily allowance for a structured Agent stream error", () => {
+    const error = new ChatSDKError(
+      "rate_limit:chat",
+      "You've hit your monthly usage limit.",
+      {
+        capReason: "monthly_exhausted",
+        paidDailyFreeAllowance: {
+          type: "paid_daily_free_allowance",
+          available: true,
+          requestsRemaining: 1,
+          costRemainingDollars: 0.25,
+        },
+      },
+    );
+
+    render(
+      <TestWrapper>
+        <MessageErrorState
+          error={new Error(serializeChatSDKErrorForStream(error))}
+          onRetry={jest.fn()}
+          mode="agent"
+        />
+      </TestWrapper>,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: getPaidDailyFreeAllowanceCtaText("agent"),
+      }),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/up to \$0\.25 of free usage today/i),
+    ).toHaveTextContent(
+      "Continue this request in Agent mode with our low-cost model",
+    );
   });
 
   it("does not show the free-request CTA when allowance is unavailable", () => {
@@ -163,7 +200,9 @@ describe("MessageErrorState", () => {
     );
 
     expect(
-      screen.queryByRole("button", { name: PAID_DAILY_FREE_ASK_CTA_TEXT }),
+      screen.queryByRole("button", {
+        name: getPaidDailyFreeAllowanceCtaText("ask"),
+      }),
     ).toBeNull();
   });
 });

--- a/app/components/__tests__/RateLimitWarning.test.tsx
+++ b/app/components/__tests__/RateLimitWarning.test.tsx
@@ -60,6 +60,34 @@ describe("RateLimitWarning", () => {
     expect(screen.getByText(/free Agent requests/i)).toBeInTheDocument();
   });
 
+  it("explains when a paid Agent run uses the daily free allowance", () => {
+    render(
+      <RateLimitWarning
+        data={{
+          warningType: "paid-daily-free-allowance",
+          resetTime: new Date(Date.now() + 60_000),
+          subscription: "pro",
+          mode: "agent",
+          costLimitDollars: 0.25,
+        }}
+        onDismiss={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/this Agent response/i)).toHaveTextContent(
+      "today's free $0.25 allowance",
+    );
+    expect(screen.getByText(/this Agent response/i)).toHaveTextContent(
+      "low-cost model",
+    );
+    expect(
+      screen.getByRole("button", { name: /view usage/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /upgrade plan/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders legacy Pro Agent run cap copy without upgrade or add-credit CTAs", () => {
     render(
       <RateLimitWarning

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -32,7 +32,7 @@ import { useFileUpload } from "../hooks/useFileUpload";
 import { useDocumentDragAndDrop } from "../hooks/useDocumentDragAndDrop";
 import { DragDropOverlay } from "./DragDropOverlay";
 import { normalizeMessages } from "@/lib/utils/message-processor";
-import { ChatSDKError } from "@/lib/errors";
+import { ChatSDKError, deserializeChatSDKErrorFromStream } from "@/lib/errors";
 import {
   fetchWithErrorHandlers,
   convertToUIMessages,
@@ -823,14 +823,18 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       setIsAutoResuming(false);
       setAwaitingServerChat(false);
       dispatchStreaming({ type: "RESET_ON_FINISH" });
-      if (error instanceof ChatSDKError) {
+      const structuredStreamError = deserializeChatSDKErrorFromStream(error);
+      const displayError = structuredStreamError ?? error;
+      if (displayError instanceof ChatSDKError) {
         const errorMessage =
-          typeof error.cause === "string" ? error.cause : error.message;
-        if (error.type !== "rate_limit") {
+          typeof displayError.cause === "string"
+            ? displayError.cause
+            : displayError.message;
+        if (displayError.type !== "rate_limit") {
           toast.error(errorMessage);
         }
-      } else if (isMobile && error.name !== "AbortError") {
-        toast.error(error.message || "An error occurred.");
+      } else if (isMobile && displayError.name !== "AbortError") {
+        toast.error(displayError.message || "An error occurred.");
       }
     },
   });

--- a/lib/__tests__/errors.test.ts
+++ b/lib/__tests__/errors.test.ts
@@ -67,4 +67,26 @@ describe("ChatSDKError stream serialization", () => {
       },
     });
   });
+
+  it.each([
+    "__HACKERAI_CHAT_SDK_ERROR__:{",
+    '__HACKERAI_CHAT_SDK_ERROR__:{"code":"future:surface"}',
+  ])("returns a friendly error for malformed payload %s", (payload) => {
+    const parsed = deserializeChatSDKErrorFromStream(new Error(payload));
+
+    expect(parsed).toBeInstanceOf(ChatSDKError);
+    expect(parsed).toMatchObject({
+      type: "bad_request",
+      surface: "stream",
+      cause:
+        "Something went wrong while receiving the response. Please try again.",
+    });
+    expect(parsed?.cause).not.toContain("__HACKERAI_CHAT_SDK_ERROR__");
+  });
+
+  it("ignores ordinary unstructured errors", () => {
+    expect(
+      deserializeChatSDKErrorFromStream(new Error("ordinary failure")),
+    ).toBeNull();
+  });
 });

--- a/lib/__tests__/errors.test.ts
+++ b/lib/__tests__/errors.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "@jest/globals";
-import { ChatSDKError, isNetworkStreamError } from "../errors";
+import {
+  ChatSDKError,
+  deserializeChatSDKErrorFromStream,
+  isNetworkStreamError,
+  serializeChatSDKErrorForStream,
+} from "../errors";
 
 describe("isNetworkStreamError", () => {
   it("classifies common browser stream transport failures as reconnectable", () => {
@@ -33,5 +38,33 @@ describe("ChatSDKError messages", () => {
     expect(new ChatSDKError("bad_request:sandbox").message).toBe(
       "The computer attachment upload failed.",
     );
+  });
+});
+
+describe("ChatSDKError stream serialization", () => {
+  it("preserves rate-limit metadata across text-only streams", () => {
+    const original = new ChatSDKError(
+      "rate_limit:chat",
+      "Monthly usage is exhausted.",
+      {
+        capReason: "monthly_exhausted",
+        paidDailyFreeAllowance: { available: true },
+      },
+    );
+
+    const parsed = deserializeChatSDKErrorFromStream(
+      new Error(serializeChatSDKErrorForStream(original)),
+    );
+
+    expect(parsed).toBeInstanceOf(ChatSDKError);
+    expect(parsed).toMatchObject({
+      type: "rate_limit",
+      surface: "chat",
+      cause: "Monthly usage is exhausted.",
+      metadata: {
+        capReason: "monthly_exhausted",
+        paidDailyFreeAllowance: { available: true },
+      },
+    });
   });
 });

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -630,6 +630,17 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(triggerIdx).toBeGreaterThan(authIdx);
   });
 
+  test("carries paid daily allowance rescue through the Agent task", () => {
+    expect(routeSrc).toMatch(/isLimitRescueRequest\(body\.limitRescue\)/);
+    expect(routeSrc).toMatch(/limitRescue,\s*isNewChat/);
+    expect(taskSrc).toMatch(/limitRescue\?:\s*LimitRescueRequest/);
+    expect(taskSrc).toMatch(/reservePaidDailyFreeAllowanceRequest/);
+    expect(taskSrc).toMatch(/getPaidDailyFreeAllowanceModel\(mode\)/);
+    expect(taskSrc).toMatch(/createPaidDailyFreeAllowanceBudgetSnapshot/);
+    expect(taskSrc).toMatch(/recordPaidDailyFreeAllowanceCost/);
+    expect(taskSrc).toMatch(/serializeChatSDKErrorForStream/);
+  });
+
   test("uses a turn-scoped Trigger idempotency key for agent runs", () => {
     expect(routeSrc).toMatch(/idempotencyKeys/);
     expect(routeSrc).toMatch(/buildAgentRunIdempotencyKey/);

--- a/lib/api/__tests__/chat-stream-helpers-rate-limit.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-rate-limit.test.ts
@@ -26,6 +26,36 @@ describe("sendRateLimitWarnings", () => {
     },
   };
 
+  it("announces when Agent uses the paid daily free allowance", () => {
+    const writer = makeWriter();
+
+    sendRateLimitWarnings(writer, {
+      subscription: "pro",
+      mode: "agent",
+      rateLimitInfo: {
+        remaining: 0,
+        limit: 0,
+        resetTime,
+      },
+      paidDailyFreeAllowance: {
+        costLimitDollars: 0.25,
+        resetTime,
+      },
+    });
+
+    expect(writer.write).toHaveBeenCalledWith({
+      type: "data-rate-limit-warning",
+      data: {
+        warningType: "paid-daily-free-allowance",
+        resetTime: resetTime.toISOString(),
+        subscription: "pro",
+        mode: "agent",
+        costLimitDollars: 0.25,
+      },
+      transient: true,
+    });
+  });
+
   it("shows extra usage active when the included bucket is empty and credits can cover overflow", () => {
     const writer = makeWriter();
 

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -30,10 +30,12 @@ import {
 import { ChatSDKError } from "@/lib/errors";
 import type {
   Todo,
+  LimitRescueRequest,
   SandboxPreference,
   SelectedModel,
   SubscriptionTier,
 } from "@/types";
+import { isLimitRescueRequest } from "@/types";
 import { resolveAgentRunSpendCapContinuationModel } from "@/lib/chat/agent-run-spend-cap";
 import { HybridSandboxManager } from "@/lib/ai/tools/utils/hybrid-sandbox-manager";
 import {
@@ -70,6 +72,7 @@ type AgentTriggerRequestBody = {
   sandboxPreference?: SandboxPreference;
   selectedModel?: string;
   isAutoContinue?: boolean;
+  limitRescue?: LimitRescueRequest;
 };
 
 type AgentTriggerRequestParseResult =
@@ -125,6 +128,9 @@ const parseAgentTriggerRequestBody = async (
       selectedModel:
         typeof body.selectedModel === "string" ? body.selectedModel : undefined,
       isAutoContinue: body.isAutoContinue === true,
+      limitRescue: isLimitRescueRequest(body.limitRescue)
+        ? body.limitRescue
+        : undefined,
     },
   };
 };
@@ -188,6 +194,7 @@ export const createAgentTriggerPost =
         sandboxPreference,
         selectedModel: rawSelectedModel,
         isAutoContinue,
+        limitRescue,
       } = parsedBody.body;
 
       const { userId, subscription, organizationId, freeQuotaSubject } =
@@ -371,6 +378,7 @@ export const createAgentTriggerPost =
           temporary,
           isAutoContinue,
           regenerate,
+          limitRescue,
           isNewChat,
           endpoint,
           convexUrl: process.env.NEXT_PUBLIC_CONVEX_URL,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -141,11 +141,11 @@ import { getMaxStepsForUser } from "@/lib/chat/chat-processor";
 import { phLogger } from "@/lib/posthog/server";
 import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
 import {
-  PAID_DAILY_FREE_ALLOWANCE_MODEL,
   capturePaidDailyFreeAllowanceServerEvent,
   createPaidDailyFreeAllowanceBudgetSnapshot,
   createPaidDailyFreeAllowanceRateLimitInfo,
   createPaidDailyFreeAllowanceUsageLogContext,
+  getPaidDailyFreeAllowanceModel,
   getRateLimitErrorCapReason,
 } from "@/lib/api/paid-daily-free-allowance-rescue";
 import {
@@ -195,8 +195,7 @@ export const createChatHandler = () => {
   return async (req: NextRequest) => {
     const endpoint = "/api/chat" as const;
     let preemptiveTimeout:
-      | ReturnType<typeof createPreemptiveTimeout>
-      | undefined;
+      ReturnType<typeof createPreemptiveTimeout> | undefined;
 
     // Track usage deductions for refund on error
     const usageRefundTracker = new UsageRefundTracker();
@@ -427,8 +426,7 @@ export const createChatHandler = () => {
       chatLogger.setChat(chatLogContext, selectedModel);
 
       let paidDailyFreeAllowanceReservation:
-        | PaidDailyFreeAllowanceReservation
-        | undefined;
+        PaidDailyFreeAllowanceReservation | undefined;
       let rateLimitInfo: RateLimitInfo;
 
       try {
@@ -517,7 +515,7 @@ export const createChatHandler = () => {
         }
 
         paidDailyFreeAllowanceReservation = allowanceReservation;
-        selectedModel = PAID_DAILY_FREE_ALLOWANCE_MODEL;
+        selectedModel = getPaidDailyFreeAllowanceModel(mode);
         chatLogger.setChat(chatLogContext, selectedModel);
         rateLimitInfo =
           createPaidDailyFreeAllowanceRateLimitInfo(allowanceReservation);
@@ -597,6 +595,13 @@ export const createChatHandler = () => {
               mode,
               rateLimitInfo,
               extraUsageConfig,
+              ...(paidDailyFreeAllowanceReservation && {
+                paidDailyFreeAllowance: {
+                  costLimitDollars:
+                    paidDailyFreeAllowanceReservation.status.costLimitDollars,
+                  resetTime: paidDailyFreeAllowanceReservation.status.resetTime,
+                },
+              }),
             });
 
             const {

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -132,9 +132,30 @@ export function sendRateLimitWarnings(
       rateLimitSkipped?: boolean;
     };
     extraUsageConfig?: ExtraUsageConfig;
+    paidDailyFreeAllowance?: {
+      costLimitDollars: number;
+      resetTime: Date;
+    };
   },
 ): void {
-  const { subscription, mode, rateLimitInfo, extraUsageConfig } = options;
+  const {
+    subscription,
+    mode,
+    rateLimitInfo,
+    extraUsageConfig,
+    paidDailyFreeAllowance,
+  } = options;
+
+  if (paidDailyFreeAllowance) {
+    writeRateLimitWarning(writer, {
+      warningType: "paid-daily-free-allowance",
+      resetTime: paidDailyFreeAllowance.resetTime.toISOString(),
+      subscription,
+      mode,
+      costLimitDollars: paidDailyFreeAllowance.costLimitDollars,
+    });
+    return;
+  }
 
   if (subscription === "free") {
     // Warn when roughly 30% of daily limit remains (minimum threshold of 1)

--- a/lib/api/paid-daily-free-allowance-rescue.ts
+++ b/lib/api/paid-daily-free-allowance-rescue.ts
@@ -10,8 +10,11 @@ import {
 import { phLogger } from "@/lib/posthog/server";
 import type { PaidDailyFreeAllowanceReservation } from "@/lib/rate-limit";
 import type { ChatMode, RateLimitInfo, SubscriptionTier } from "@/types";
+import type { ChatApiEndpoint } from "@/lib/api/agent-endpoints";
 
-export const PAID_DAILY_FREE_ALLOWANCE_MODEL = "ask-model-free";
+export function getPaidDailyFreeAllowanceModel(mode: ChatMode) {
+  return mode === "agent" ? "agent-model-free" : "ask-model-free";
+}
 
 type PaidDailyFreeAllowanceEvent =
   | typeof PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceStarted
@@ -71,7 +74,7 @@ export function capturePaidDailyFreeAllowanceServerEvent({
   subscription: SubscriptionTier;
   mode: ChatMode;
   chatId: string;
-  endpoint: "/api/chat";
+  endpoint: ChatApiEndpoint;
   reservation?: PaidDailyFreeAllowanceReservation;
   extra?: Record<string, unknown>;
 }) {

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,22 +1,26 @@
-export type ErrorType =
-  | "bad_request"
-  | "unauthorized"
-  | "forbidden"
-  | "not_found"
-  | "rate_limit"
-  | "offline";
+export const ERROR_TYPES = [
+  "bad_request",
+  "unauthorized",
+  "forbidden",
+  "not_found",
+  "rate_limit",
+  "offline",
+] as const;
+export type ErrorType = (typeof ERROR_TYPES)[number];
 
-export type Surface =
-  | "chat"
-  | "auth"
-  | "api"
-  | "stream"
-  | "database"
-  | "history"
-  | "vote"
-  | "document"
-  | "sandbox"
-  | "suggestions";
+export const ERROR_SURFACES = [
+  "chat",
+  "auth",
+  "api",
+  "stream",
+  "database",
+  "history",
+  "vote",
+  "document",
+  "sandbox",
+  "suggestions",
+] as const;
+export type Surface = (typeof ERROR_SURFACES)[number];
 
 export type ErrorCode = `${ErrorType}:${Surface}`;
 
@@ -85,6 +89,22 @@ export class ChatSDKError extends Error {
 }
 
 const STREAM_ERROR_PREFIX = "__HACKERAI_CHAT_SDK_ERROR__:";
+const MALFORMED_STREAM_ERROR_MESSAGE =
+  "Something went wrong while receiving the response. Please try again.";
+
+function isErrorCode(value: unknown): value is ErrorCode {
+  if (typeof value !== "string") return false;
+  const [type, surface, extra] = value.split(":");
+  return (
+    extra === undefined &&
+    (ERROR_TYPES as readonly string[]).includes(type) &&
+    (ERROR_SURFACES as readonly string[]).includes(surface)
+  );
+}
+
+function createMalformedStreamError(): ChatSDKError {
+  return new ChatSDKError("bad_request:stream", MALFORMED_STREAM_ERROR_MESSAGE);
+}
 
 /**
  * UI message streams only carry error text. Preserve the structured error
@@ -124,14 +144,7 @@ export function deserializeChatSDKErrorFromStream(
       cause?: unknown;
       metadata?: unknown;
     };
-    if (
-      typeof parsed.code !== "string" ||
-      !/^(bad_request|unauthorized|forbidden|not_found|rate_limit|offline):(chat|auth|api|stream|database|history|vote|document|sandbox|suggestions)$/.test(
-        parsed.code,
-      )
-    ) {
-      return null;
-    }
+    if (!isErrorCode(parsed.code)) return createMalformedStreamError();
 
     return new ChatSDKError(
       parsed.code as ErrorCode,
@@ -141,7 +154,7 @@ export function deserializeChatSDKErrorFromStream(
         : undefined,
     );
   } catch {
-    return null;
+    return createMalformedStreamError();
   }
 }
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -84,6 +84,67 @@ export class ChatSDKError extends Error {
   }
 }
 
+const STREAM_ERROR_PREFIX = "__HACKERAI_CHAT_SDK_ERROR__:";
+
+/**
+ * UI message streams only carry error text. Preserve the structured error
+ * fields needed by the client for rate-limit actions when an error crosses a
+ * durable Agent stream.
+ */
+export function serializeChatSDKErrorForStream(error: ChatSDKError): string {
+  const code: ErrorCode = `${error.type}:${error.surface}`;
+
+  try {
+    return `${STREAM_ERROR_PREFIX}${JSON.stringify({
+      code,
+      cause: typeof error.cause === "string" ? error.cause : undefined,
+      metadata: error.metadata,
+    })}`;
+  } catch {
+    return typeof error.cause === "string" ? error.cause : error.message;
+  }
+}
+
+export function deserializeChatSDKErrorFromStream(
+  error: unknown,
+): ChatSDKError | null {
+  if (error instanceof ChatSDKError) return error;
+  if (
+    !(error instanceof Error) ||
+    !error.message.startsWith(STREAM_ERROR_PREFIX)
+  ) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(
+      error.message.slice(STREAM_ERROR_PREFIX.length),
+    ) as {
+      code?: unknown;
+      cause?: unknown;
+      metadata?: unknown;
+    };
+    if (
+      typeof parsed.code !== "string" ||
+      !/^(bad_request|unauthorized|forbidden|not_found|rate_limit|offline):(chat|auth|api|stream|database|history|vote|document|sandbox|suggestions)$/.test(
+        parsed.code,
+      )
+    ) {
+      return null;
+    }
+
+    return new ChatSDKError(
+      parsed.code as ErrorCode,
+      typeof parsed.cause === "string" ? parsed.cause : undefined,
+      parsed.metadata && typeof parsed.metadata === "object"
+        ? (parsed.metadata as Record<string, unknown>)
+        : undefined,
+    );
+  } catch {
+    return null;
+  }
+}
+
 export function getMessageByErrorCode(errorCode: ErrorCode): string {
   if (errorCode.includes("database")) {
     return "An error occurred while executing a database query.";

--- a/lib/limit-pressure.ts
+++ b/lib/limit-pressure.ts
@@ -1,6 +1,10 @@
-import type { SubscriptionTier } from "@/types";
+import type { ChatMode, SubscriptionTier } from "@/types";
 
-export const PAID_DAILY_FREE_ASK_CTA_TEXT = "Use free Ask today";
+export function getPaidDailyFreeAllowanceCtaText(mode?: ChatMode): string {
+  if (mode === "agent") return "Use free Agent today";
+  if (mode === "ask") return "Use free Ask today";
+  return "Use today's free allowance";
+}
 
 export type LimitCapReason =
   | "daily_requests_exhausted"

--- a/lib/rate-limit/__tests__/paid-daily-free-allowance.test.ts
+++ b/lib/rate-limit/__tests__/paid-daily-free-allowance.test.ts
@@ -108,7 +108,7 @@ describe("paid daily free allowance", () => {
     hasAttachments: false,
   };
 
-  it("reports one available paid Ask rescue by default", async () => {
+  it("reports one available paid rescue by default", async () => {
     const { getPaidDailyFreeAllowanceStatus } = getIsolatedModule();
 
     const status = await getPaidDailyFreeAllowanceStatus(eligibleContext);
@@ -125,7 +125,7 @@ describe("paid daily free allowance", () => {
     });
   });
 
-  it("excludes unsupported tiers, agent mode, attachments, and rollout-disabled users", async () => {
+  it("supports Agent mode while keeping Ask attachments excluded", async () => {
     const { getPaidDailyFreeAllowanceStatus } = getIsolatedModule();
 
     await expect(
@@ -139,10 +139,14 @@ describe("paid daily free allowance", () => {
     });
     await expect(
       getPaidDailyFreeAllowanceStatus({ ...eligibleContext, mode: "agent" }),
-    ).resolves.toMatchObject({
-      available: false,
-      unavailableReason: "unsupported_mode",
-    });
+    ).resolves.toMatchObject({ available: true });
+    await expect(
+      getPaidDailyFreeAllowanceStatus({
+        ...eligibleContext,
+        mode: "agent",
+        hasAttachments: true,
+      }),
+    ).resolves.toMatchObject({ available: true });
     await expect(
       getPaidDailyFreeAllowanceStatus({
         ...eligibleContext,
@@ -153,6 +157,27 @@ describe("paid daily free allowance", () => {
       unavailableReason: "attachments_not_supported",
     });
 
+    mockIsFeatureEnabled.mockReturnValue(false);
+    await expect(
+      getPaidDailyFreeAllowanceStatus(eligibleContext),
+    ).resolves.toMatchObject({
+      available: false,
+      unavailableReason: "rollout_disabled",
+    });
+  });
+
+  it("excludes unsupported tiers and rollout-disabled users", async () => {
+    const { getPaidDailyFreeAllowanceStatus } = getIsolatedModule();
+    await expect(
+      getPaidDailyFreeAllowanceStatus({
+        ...eligibleContext,
+        subscription: "team",
+        mode: "agent",
+      }),
+    ).resolves.toMatchObject({
+      available: false,
+      unavailableReason: "unsupported_subscription",
+    });
     mockIsFeatureEnabled.mockReturnValue(false);
     await expect(
       getPaidDailyFreeAllowanceStatus(eligibleContext),

--- a/lib/rate-limit/paid-daily-free-allowance.ts
+++ b/lib/rate-limit/paid-daily-free-allowance.ts
@@ -268,12 +268,16 @@ function baseStatus(
 function getStaticUnavailableReason(
   ctx: PaidDailyFreeAllowanceContext,
 ): PaidDailyFreeAllowanceUnavailableReason | null {
-  if (ctx.mode !== "ask") return "unsupported_mode";
   if (!PAID_INDIVIDUAL_TIERS.has(ctx.subscription)) {
     return "unsupported_subscription";
   }
   if (ctx.capReason !== "monthly_exhausted") return "not_monthly_exhausted";
-  if (ctx.hasAttachments) return "attachments_not_supported";
+  // Ask attachments may require a more expensive multimodal route. Agent
+  // attachments stay eligible because the allowance uses the cheap Agent
+  // model and records the run's model, tool, and sandbox costs together.
+  if (ctx.mode === "ask" && ctx.hasAttachments) {
+    return "attachments_not_supported";
+  }
   return null;
 }
 

--- a/lib/rate-limit/paid-daily-free-allowance.ts
+++ b/lib/rate-limit/paid-daily-free-allowance.ts
@@ -1,7 +1,11 @@
 import "server-only";
 
 import { isFeatureEnabled } from "@/lib/auth/feature-flags";
-import type { ChatMode, SubscriptionTier } from "@/types";
+import {
+  isPaidIndividualSubscription,
+  type ChatMode,
+  type SubscriptionTier,
+} from "@/types";
 import { POINTS_PER_DOLLAR } from "./token-bucket";
 import { createRedisClient } from "./redis";
 import type { LimitCapReason } from "@/lib/limit-pressure";
@@ -11,12 +15,6 @@ export const PAID_DAILY_FREE_ALLOWANCE_FEATURE_KEY =
 export const PAID_DAILY_FREE_ALLOWANCE_REQUESTS_PER_DAY_DEFAULT = 1;
 export const PAID_DAILY_FREE_ALLOWANCE_COST_LIMIT_USD_DEFAULT = 0.25;
 export const PAID_DAILY_FREE_ALLOWANCE_ROLLOUT_PERCENT_DEFAULT = 10;
-
-const PAID_INDIVIDUAL_TIERS = new Set<SubscriptionTier>([
-  "pro",
-  "pro-plus",
-  "ultra",
-]);
 
 const RESERVE_PAID_DAILY_FREE_ALLOWANCE_SCRIPT = `
 local requestKey = KEYS[1]
@@ -268,7 +266,7 @@ function baseStatus(
 function getStaticUnavailableReason(
   ctx: PaidDailyFreeAllowanceContext,
 ): PaidDailyFreeAllowanceUnavailableReason | null {
-  if (!PAID_INDIVIDUAL_TIERS.has(ctx.subscription)) {
+  if (!isPaidIndividualSubscription(ctx.subscription)) {
     return "unsupported_subscription";
   }
   if (ctx.capReason !== "monthly_exhausted") return "not_monthly_exhausted";

--- a/lib/utils/__tests__/parse-rate-limit-warning.test.ts
+++ b/lib/utils/__tests__/parse-rate-limit-warning.test.ts
@@ -37,6 +37,21 @@ describe("parseRateLimitWarning", () => {
     ).toBeNull();
   });
 
+  it("rejects paid daily allowance notices for team subscriptions", () => {
+    expect(
+      parseRateLimitWarning(
+        {
+          warningType: "paid-daily-free-allowance",
+          subscription: "team",
+          mode: "agent",
+          resetTime: "2026-06-30T00:00:00.000Z",
+          costLimitDollars: 0.25,
+        },
+        { hasUserDismissed: false },
+      ),
+    ).toBeNull();
+  });
+
   it("parses Pro Agent per-run spend-cap warnings", () => {
     const parsed = parseRateLimitWarning(
       {

--- a/lib/utils/__tests__/parse-rate-limit-warning.test.ts
+++ b/lib/utils/__tests__/parse-rate-limit-warning.test.ts
@@ -2,6 +2,41 @@ import { describe, expect, it } from "@jest/globals";
 import { parseRateLimitWarning } from "../parse-rate-limit-warning";
 
 describe("parseRateLimitWarning", () => {
+  it("parses paid daily Agent allowance notices", () => {
+    expect(
+      parseRateLimitWarning(
+        {
+          warningType: "paid-daily-free-allowance",
+          subscription: "pro",
+          mode: "agent",
+          resetTime: "2026-06-30T00:00:00.000Z",
+          costLimitDollars: 0.25,
+        },
+        { hasUserDismissed: false },
+      ),
+    ).toMatchObject({
+      warningType: "paid-daily-free-allowance",
+      subscription: "pro",
+      mode: "agent",
+      costLimitDollars: 0.25,
+    });
+  });
+
+  it("rejects paid daily allowance notices for free users", () => {
+    expect(
+      parseRateLimitWarning(
+        {
+          warningType: "paid-daily-free-allowance",
+          subscription: "free",
+          mode: "agent",
+          resetTime: "2026-06-30T00:00:00.000Z",
+          costLimitDollars: 0.25,
+        },
+        { hasUserDismissed: false },
+      ),
+    ).toBeNull();
+  });
+
   it("parses Pro Agent per-run spend-cap warnings", () => {
     const parsed = parseRateLimitWarning(
       {

--- a/lib/utils/parse-rate-limit-warning.ts
+++ b/lib/utils/parse-rate-limit-warning.ts
@@ -7,6 +7,7 @@ const WARNING_TYPES = [
   "sliding-window",
   "token-bucket",
   "extra-usage-active",
+  "paid-daily-free-allowance",
   "agent-run-spend-cap",
 ] as const;
 type RawWarningType = (typeof WARNING_TYPES)[number];
@@ -82,6 +83,26 @@ export function parseRateLimitWarning(
       resetTime,
       mode: modeRaw,
       subscription,
+    };
+  }
+
+  if (warningType === "paid-daily-free-allowance") {
+    const modeRaw = typeof rawData.mode === "string" ? rawData.mode : null;
+    const costLimitDollars = rawData.costLimitDollars;
+    if (
+      subscription === "free" ||
+      !isChatMode(modeRaw) ||
+      !isNumber(costLimitDollars) ||
+      costLimitDollars <= 0
+    ) {
+      return null;
+    }
+    return {
+      warningType: "paid-daily-free-allowance",
+      resetTime,
+      subscription,
+      mode: modeRaw,
+      costLimitDollars,
     };
   }
 

--- a/lib/utils/parse-rate-limit-warning.ts
+++ b/lib/utils/parse-rate-limit-warning.ts
@@ -1,5 +1,9 @@
 import type { RateLimitWarningData } from "@/app/components/RateLimitWarning";
-import { isChatMode, isSubscriptionTier } from "@/types/chat";
+import {
+  isChatMode,
+  isPaidIndividualSubscription,
+  isSubscriptionTier,
+} from "@/types/chat";
 import type { LimitCapReason } from "@/lib/limit-pressure";
 import { isAgentRunSpendCapBasis } from "@/lib/chat/agent-run-spend-cap";
 
@@ -90,7 +94,7 @@ export function parseRateLimitWarning(
     const modeRaw = typeof rawData.mode === "string" ? rawData.mode : null;
     const costLimitDollars = rawData.costLimitDollars;
     if (
-      subscription === "free" ||
+      !isPaidIndividualSubscription(subscription) ||
       !isChatMode(modeRaw) ||
       !isNumber(costLimitDollars) ||
       costLimitDollars <= 0

--- a/lib/utils/stream-writer-utils.ts
+++ b/lib/utils/stream-writer-utils.ts
@@ -152,6 +152,14 @@ export type RateLimitWarningData =
       midStream?: boolean;
     }
   | {
+      // Paid users continuing on the daily free fallback allowance.
+      warningType: "paid-daily-free-allowance";
+      resetTime: string;
+      subscription: SubscriptionTier;
+      mode: ChatMode;
+      costLimitDollars: number;
+    }
+  | {
       // Legacy Pro Agent per-run spend-cap warning.
       warningType: "agent-run-spend-cap";
       resetTime: string;

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -55,9 +55,14 @@ import {
   createUsageSettlementState,
   getUsageSettlementInitialDeduction,
   getUnsettledUsagePoints,
+  getPaidDailyFreeAllowanceStatus,
+  paidDailyFreeAllowanceStatusToMetadata,
+  recordPaidDailyFreeAllowanceCost,
   recordFreeMonthlyCost,
   replaceUsageSettlementState,
   shouldSettleUsageMidRun,
+  reservePaidDailyFreeAllowanceRequest,
+  type PaidDailyFreeAllowanceReservation,
   UsageRefundTracker,
 } from "@/lib/rate-limit";
 import { assertUserCanMakeCostIncurringRequest } from "@/lib/suspensions";
@@ -104,12 +109,21 @@ import {
   type AgentApiEndpoint,
 } from "@/lib/api/agent-endpoints";
 import { phLogger } from "@/lib/posthog/server";
+import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
+import {
+  capturePaidDailyFreeAllowanceServerEvent,
+  createPaidDailyFreeAllowanceBudgetSnapshot,
+  createPaidDailyFreeAllowanceRateLimitInfo,
+  createPaidDailyFreeAllowanceUsageLogContext,
+  getPaidDailyFreeAllowanceModel,
+  getRateLimitErrorCapReason,
+} from "@/lib/api/paid-daily-free-allowance-rescue";
 import {
   extractErrorDetails,
   getProviderErrorCategory,
   getUserFriendlyProviderError,
 } from "@/lib/utils/error-utils";
-import { ChatSDKError } from "@/lib/errors";
+import { ChatSDKError, serializeChatSDKErrorForStream } from "@/lib/errors";
 import type { Id } from "@/convex/_generated/dataModel";
 import type {
   SubscriptionTier,
@@ -117,6 +131,7 @@ import type {
   SandboxPreference,
   SelectedModel,
   RateLimitInfo,
+  LimitRescueRequest,
   ToolFailureLogEvent,
 } from "@/types";
 import { canUseExtraUsage, normalizeMaxModelForSubscription } from "@/types";
@@ -593,8 +608,7 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
 
 const getTerminalProviderStreamError = (
   state:
-    | Pick<AgentStreamState, "streamFinishReason" | "providerError">
-    | undefined,
+    Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
 ): unknown | undefined => {
   if (!state) return undefined;
   if (state.streamFinishReason !== "error") return undefined;
@@ -611,8 +625,7 @@ const getTerminalProviderStreamError = (
 
 const isTerminalProviderStreamError = (
   state:
-    | Pick<AgentStreamState, "streamFinishReason" | "providerError">
-    | undefined,
+    Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
 ): boolean => state?.streamFinishReason === "error";
 
 type RecordedAgentLongFailure = {
@@ -949,6 +962,7 @@ export type AgentLongPayload = {
   isAutoContinue?: boolean;
   regenerate?: boolean;
   isNewChat?: boolean;
+  limitRescue?: LimitRescueRequest;
   endpoint?: AgentApiEndpoint;
   convexUrl?: string;
   requestTiming?: {
@@ -1011,6 +1025,7 @@ export const agentLongTask = task({
       isAutoContinue,
       regenerate,
       isNewChat,
+      limitRescue,
       endpoint: payloadEndpoint,
     } = payload;
     let selectedModelOverride = rawSelectedModelOverride;
@@ -1171,17 +1186,15 @@ export const agentLongTask = task({
         truncatedMessages: messagesForAccounting,
       });
 
-      chatLogger.setChat(
-        {
-          messageCount: messagesForAccounting.length,
-          estimatedInputTokens,
-          isNewChat: !!isNewChat,
-          fileCount: 0,
-          imageCount: 0,
-          notesEnabled,
-        },
-        selectedModel,
-      );
+      const chatLogContext = {
+        messageCount: messagesForAccounting.length,
+        estimatedInputTokens,
+        isNewChat: !!isNewChat,
+        fileCount: sandboxFiles.length,
+        imageCount: 0,
+        notesEnabled,
+      };
+      chatLogger.setChat(chatLogContext, selectedModel);
 
       const posthog = PostHogClient();
       chatLogger.getBuilder().setAssistantId(assistantMessageId);
@@ -1221,15 +1234,15 @@ export const agentLongTask = task({
       // before agentUiStream.pipe() registered the stream, and the frontend
       // transport would only see a FAILED status with no error message.
       let rateLimitInfo: RateLimitInfo;
+      let paidDailyFreeAllowanceReservation:
+        PaidDailyFreeAllowanceReservation | undefined;
 
       let streamError: unknown;
       const uiStream = createUIMessageStream({
         onError: (error) => {
           streamError ??= error;
           if (error instanceof ChatSDKError) {
-            return typeof error.cause === "string"
-              ? error.cause
-              : error.message;
+            return serializeChatSDKErrorForStream(error);
           }
           return getUserFriendlyProviderError(error);
         },
@@ -1245,16 +1258,100 @@ export const agentLongTask = task({
               releaseFreeRunLock = lock.release;
             }
 
-            rateLimitInfo = await checkRateLimit(
-              userId,
-              mode,
-              subscription,
-              estimatedInputTokens,
-              extraUsageConfig,
-              selectedModel,
-              organizationId,
-              freeQuotaSubject,
-            );
+            try {
+              rateLimitInfo = await checkRateLimit(
+                userId,
+                mode,
+                subscription,
+                estimatedInputTokens,
+                extraUsageConfig,
+                selectedModel,
+                organizationId,
+                freeQuotaSubject,
+              );
+            } catch (error) {
+              if (!(error instanceof ChatSDKError)) throw error;
+
+              const capReason = getRateLimitErrorCapReason(error);
+              if (capReason !== "monthly_exhausted") {
+                if (limitRescue) {
+                  capturePaidDailyFreeAllowanceServerEvent({
+                    event: PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceBlocked,
+                    userId,
+                    subscription,
+                    mode,
+                    chatId,
+                    endpoint,
+                    extra: {
+                      blocked_reason: "not_monthly_exhausted",
+                      cap_reason: capReason,
+                    },
+                  });
+                }
+                throw error;
+              }
+
+              const allowanceContext = {
+                userId,
+                subscription,
+                mode,
+                capReason,
+                hasAttachments: sandboxFiles.length > 0,
+              };
+              const allowanceStatus =
+                await getPaidDailyFreeAllowanceStatus(allowanceContext);
+              error.metadata = {
+                ...error.metadata,
+                paidDailyFreeAllowance:
+                  paidDailyFreeAllowanceStatusToMetadata(allowanceStatus),
+              };
+
+              if (!limitRescue) throw error;
+
+              const allowanceReservation =
+                await reservePaidDailyFreeAllowanceRequest(allowanceContext);
+              error.metadata = {
+                ...error.metadata,
+                paidDailyFreeAllowance: paidDailyFreeAllowanceStatusToMetadata(
+                  allowanceReservation.status,
+                ),
+              };
+
+              if (!allowanceReservation.allowed) {
+                capturePaidDailyFreeAllowanceServerEvent({
+                  event: PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceBlocked,
+                  userId,
+                  subscription,
+                  mode,
+                  chatId,
+                  endpoint,
+                  reservation: allowanceReservation,
+                  extra: {
+                    blocked_reason:
+                      allowanceReservation.blockReason ??
+                      allowanceReservation.status.unavailableReason,
+                    cap_reason: capReason,
+                  },
+                });
+                throw error;
+              }
+
+              paidDailyFreeAllowanceReservation = allowanceReservation;
+              selectedModel = getPaidDailyFreeAllowanceModel(mode);
+              chatLogger?.setChat(chatLogContext, selectedModel);
+              rateLimitInfo =
+                createPaidDailyFreeAllowanceRateLimitInfo(allowanceReservation);
+              capturePaidDailyFreeAllowanceServerEvent({
+                event: PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceStarted,
+                userId,
+                subscription,
+                mode,
+                chatId,
+                endpoint,
+                reservation: allowanceReservation,
+                extra: { selected_model: selectedModel },
+              });
+            }
 
             const freeMonthlyBudgetSnapshot =
               subscription === "free"
@@ -1279,6 +1376,13 @@ export const agentLongTask = task({
               mode,
               rateLimitInfo,
               extraUsageConfig,
+              ...(paidDailyFreeAllowanceReservation && {
+                paidDailyFreeAllowance: {
+                  costLimitDollars:
+                    paidDailyFreeAllowanceReservation.status.costLimitDollars,
+                  resetTime: paidDailyFreeAllowanceReservation.status.resetTime,
+                },
+              }),
             });
 
             let handledToolFailureCount = 0;
@@ -1508,7 +1612,14 @@ export const agentLongTask = task({
               extraUsageConfig,
               subscription,
             });
+            const paidDailyFreeAllowanceBudgetSnapshot =
+              paidDailyFreeAllowanceReservation
+                ? createPaidDailyFreeAllowanceBudgetSnapshot(
+                    paidDailyFreeAllowanceReservation,
+                  )
+                : null;
             const effectiveBudgetSnapshot =
+              paidDailyFreeAllowanceBudgetSnapshot ??
               budgetSnapshot ??
               (freeMonthlyBudgetSnapshot?.rateLimitSkipped
                 ? null
@@ -1547,7 +1658,7 @@ export const agentLongTask = task({
             let preFallbackCacheRead = 0;
             let preFallbackCacheWrite = 0;
             const usageSettlementState =
-              subscription === "free"
+              subscription === "free" || paidDailyFreeAllowanceReservation
                 ? null
                 : createUsageSettlementState(rateLimitInfo);
             let usageSettlementSequence = 0;
@@ -1580,7 +1691,74 @@ export const agentLongTask = task({
                 const providerCost = usageTracker.hasAuthoritativeModelCost
                   ? usageTracker.providerCost
                   : undefined;
-                if (subscription === "free") {
+                if (paidDailyFreeAllowanceReservation) {
+                  const allowanceCostRecord =
+                    await recordPaidDailyFreeAllowanceCost(
+                      userId,
+                      usageCostRecord.costDollars,
+                    );
+                  if (!allowanceCostRecord.recorded) {
+                    phLogger.warn(
+                      "Paid daily free allowance cost recording failed",
+                      {
+                        userId,
+                        chatId,
+                        endpoint,
+                        mode,
+                        subscription,
+                        selected_model: selectedModel,
+                        cost_dollars: usageCostRecord.costDollars,
+                        cost_record_failure_reason:
+                          allowanceCostRecord.unavailableReason,
+                      },
+                    );
+                  }
+                  usageTracker.log({
+                    userId,
+                    organizationId,
+                    chatId,
+                    endpoint,
+                    mode,
+                    subscription,
+                    selectedModel,
+                    selectedModelOverride,
+                    responseModel: state.responseModel,
+                    configuredModelId,
+                    accountingModel: usageRecordArgs.accountingModel,
+                    rateLimitInfo,
+                  });
+                  const cutOff = state.stoppedDueToBudgetExhaustion;
+                  capturePaidDailyFreeAllowanceServerEvent({
+                    event: cutOff
+                      ? PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceCutOff
+                      : PAID_FUNNEL_EVENTS.paidDailyFreeAllowanceSucceeded,
+                    userId,
+                    subscription,
+                    mode,
+                    chatId,
+                    endpoint,
+                    reservation: paidDailyFreeAllowanceReservation,
+                    extra: {
+                      cost_dollars: usageCostRecord.costDollars,
+                      model_cost_dollars: usageCostRecord.modelCostDollars,
+                      non_model_cost_dollars:
+                        usageCostRecord.nonModelCostDollars,
+                      selected_model: selectedModel,
+                      response_model: state.responseModel,
+                      cost_source: usageCostRecord.costSource,
+                      paid_daily_free_allowance_cost_recorded:
+                        allowanceCostRecord.recorded,
+                      paid_daily_free_allowance_cost_record_failure_reason:
+                        allowanceCostRecord.recorded
+                          ? undefined
+                          : allowanceCostRecord.unavailableReason,
+                      paid_daily_free_allowance_cost_record_next_dollars:
+                        allowanceCostRecord.recorded
+                          ? allowanceCostRecord.nextCostDollars
+                          : undefined,
+                    },
+                  });
+                } else if (subscription === "free") {
                   await recordFreeMonthlyCost(
                     freeUsageSubject,
                     usageCostRecord.costDollars,
@@ -1671,6 +1849,13 @@ export const agentLongTask = task({
                   endpoint,
                   mode,
                   usage: usageCostRecord,
+                  ...(paidDailyFreeAllowanceReservation && {
+                    paidDailyFreeAllowance:
+                      createPaidDailyFreeAllowanceUsageLogContext(
+                        paidDailyFreeAllowanceReservation,
+                        state.stoppedDueToBudgetExhaustion,
+                      ),
+                  }),
                 });
               } finally {
                 await releaseFreeRunLockOnce();
@@ -2629,7 +2814,7 @@ export const agentLongTask = task({
           const errorStream = createUIMessageStream({
             onError: (err) => {
               if (err instanceof ChatSDKError) {
-                return typeof err.cause === "string" ? err.cause : err.message;
+                return serializeChatSDKErrorForStream(err);
               }
               return getUserFriendlyProviderError(err);
             },

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -93,10 +93,25 @@ export const SUBSCRIPTION_TIERS: readonly SubscriptionTier[] = [
   "team",
 ];
 
+export const PAID_INDIVIDUAL_SUBSCRIPTION_TIERS = [
+  "pro",
+  "pro-plus",
+  "ultra",
+] as const satisfies readonly SubscriptionTier[];
+
 export function isSubscriptionTier(value: unknown): value is SubscriptionTier {
   return (
     typeof value === "string" &&
     (SUBSCRIPTION_TIERS as readonly string[]).includes(value)
+  );
+}
+
+export function isPaidIndividualSubscription(
+  value: unknown,
+): value is (typeof PAID_INDIVIDUAL_SUBSCRIPTION_TIERS)[number] {
+  return (
+    typeof value === "string" &&
+    (PAID_INDIVIDUAL_SUBSCRIPTION_TIERS as readonly string[]).includes(value)
   );
 }
 


### PR DESCRIPTION
## Summary

- allow paid individual users who exhausted included monthly usage to spend the existing daily free allowance in Agent mode as well as Ask mode
- route rescued Agent runs through `agent-model-free`, enforce the remaining daily cost budget, and record model, tool, and sandbox costs against the shared allowance
- preserve structured rate-limit metadata across durable Agent streams so the recovery action works from Agent errors
- add mode-aware recovery copy and an in-chat notice explaining the $0.25 daily low-cost fallback and midnight UTC reset

## Why

The paid daily free allowance explicitly rejected Agent mode and the durable Agent task had no rescue path. Paid users therefore saw the fallback only in Ask mode even though the current Agent model is inexpensive enough for the same $0.25 allowance.

## User impact

After a paid individual user reaches their included monthly limit, an Agent request can now offer **Use free Agent today**. Retrying reserves the same shared daily allowance, switches to the low-cost Agent model, and stops if the allowance is exhausted. Ask and Agent still share the single daily request/cost pool.

## Validation

- 112 focused Jest tests passed across allowance eligibility, durable Agent contracts, structured stream errors, UI recovery copy, warning parsing, and active-allowance notices
- `tsc --noEmit`
- focused ESLint passed with no errors
- GitHub Actions passed
- Vercel deployment passed
- deployed preview smoke test: HTTP 200, expected HackerAI UI, no Next.js error overlay, and no browser console errors
- CodeRabbit completed; three valid findings were fixed and all review threads are resolved

## Manual verification

The deployed preview loads correctly, but the exhausted paid-account state still requires an authenticated account check:

1. Use a paid individual account with included monthly usage exhausted and submit an Agent request.
2. Confirm **Use free Agent today** and the $0.25 daily allowance explanation appear.
3. Click it and confirm the Agent run starts with the daily allowance notice.
4. Confirm another rescue is unavailable after the daily request is consumed, until midnight UTC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paid subscribers can use a daily free allowance in Agent mode when monthly limits are reached.
  * Added allowance messaging with mode-specific CTAs (“Use free Agent today” / “Use free Ask today”), plus “View Usage” for daily allowance notices.
  * Display daily allowance details such as cost limit and reset time.

* **Bug Fixes**
  * Improved streamed error handling to show consistent, accurate user-facing messaging and avoid incorrect/misleading toast output.

* **Tests**
  * Added coverage for daily allowance warning parsing and streamed error round-tripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->