### PR TITLE
Route paid Auto and Standard text to DeepSeek V4 Pro

### DIFF
--- a/app/components/ModelSelector/__tests__/options-drift.test.ts
+++ b/app/components/ModelSelector/__tests__/options-drift.test.ts
@@ -31,12 +31,12 @@ describe("ModelSelector tier ↔ provider drift", () => {
     expect([...askIds].sort()).toEqual([...agentIds].sort());
   });
 
-  it("HackerAI Standard resolves to different providers per mode", () => {
+  it("HackerAI Standard resolves to DeepSeek in both modes", () => {
     expect(resolveTierToProviderKey("hackerai-standard", "ask")).toBe(
       "model-deepseek-v4-pro",
     );
     expect(resolveTierToProviderKey("hackerai-standard", "agent")).toBe(
-      "model-minimax-m3",
+      "model-deepseek-v4-pro",
     );
   });
 
@@ -70,5 +70,12 @@ describe("ModelSelector tier ↔ provider drift", () => {
       expect(option.description).toBeTruthy();
       expect(option.poweredBy).toBeTruthy();
     }
+  });
+
+  it("discloses the text and media providers for Agent Standard", () => {
+    expect(
+      AGENT_MODEL_OPTIONS.find((option) => option.id === "hackerai-standard")
+        ?.poweredBy,
+    ).toBe("DeepSeek V4 Pro · MiniMax M3 for images and PDFs");
   });
 });

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -37,7 +37,7 @@ export const AGENT_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-standard",
     label: "HackerAI Standard",
     description: "Reliable agent for everyday automation",
-    poweredBy: "MiniMax M3",
+    poweredBy: "DeepSeek V4 Pro · MiniMax M3 for images and PDFs",
     thinking: true,
   },
   {

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1,7 +1,6 @@
 import { customProvider } from "ai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import type { ChatMode, SelectedModel } from "@/types/chat";
-import { isAgentMode } from "@/lib/utils/mode-helpers";
 import { openrouterAttributionHeaders } from "@/lib/ai/openrouter-attribution";
 // import { withTracing } from "@posthog/ai";
 // import PostHogClient from "@/app/posthog";
@@ -323,12 +322,12 @@ export function supportsMultimodalToolResults(modelName?: string): boolean {
 /**
  * Map a HackerAI tier id to the underlying provider key for a given mode.
  * Returns `null` for `"auto"` (the caller routes to the auto-router model
- * key instead). Standard and Pro are mode-aware; Max maps to Opus in both
- * modes.
+ * key instead). Standard maps to DeepSeek, Pro to GLM, and Max to Opus in
+ * both modes; media-aware promotion happens in `selectModel`.
  */
 export function resolveTierToProviderKey(
   tier: SelectedModel,
-  mode: ChatMode,
+  _mode: ChatMode,
 ): ModelName | null {
   if (tier === "auto") return null;
   switch (tier) {

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -333,7 +333,7 @@ export function resolveTierToProviderKey(
   if (tier === "auto") return null;
   switch (tier) {
     case "hackerai-standard":
-      return isAgentMode(mode) ? "model-minimax-m3" : "model-deepseek-v4-pro";
+      return "model-deepseek-v4-pro";
     case "hackerai-pro":
       return "model-glm-5.2";
     case "hackerai-max":

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -70,6 +70,9 @@ jest.mock("@/lib/chat/multimodal-tool-result-recovery", () => ({
 }));
 jest.mock("@/lib/ai/providers", () => ({
   isAnthropicModel: () => false,
+  isDeepSeekModel: (modelName: string) =>
+    modelName === "model-deepseek-v4-pro" ||
+    modelName === "model-deepseek-v4-flash",
 }));
 jest.mock("@/lib/ai/tools/utils/pty-session-manager", () => ({
   ptySessionManager: { closeAllSessions: jest.fn() },
@@ -91,6 +94,7 @@ jest.mock("@/lib/utils/error-utils", () => ({
 const {
   createAgentStream,
   initAgentStreamState,
+  resolveAgentModelForImageToolResults,
 }: typeof import("@/lib/api/agent-stream-runner") = require("@/lib/api/agent-stream-runner");
 
 const uiMessage = (id: string, text: string): UIMessage => ({
@@ -140,6 +144,41 @@ const createTestStreamContext = (
   usageRefundTracker: {},
   getHardTimeoutReason: () => null,
   ...overrides,
+});
+
+describe("resolveAgentModelForImageToolResults", () => {
+  it("keeps DeepSeek for text-only Agent steps", () => {
+    expect(
+      resolveAgentModelForImageToolResults(
+        "model-deepseek-v4-pro",
+        "agent",
+        false,
+      ),
+    ).toBe("model-deepseek-v4-pro");
+  });
+
+  it("switches DeepSeek Agent steps to Kimi after image tool results", () => {
+    expect(
+      resolveAgentModelForImageToolResults(
+        "model-deepseek-v4-pro",
+        "agent",
+        true,
+      ),
+    ).toBe("model-kimi-k2.7-code");
+  });
+
+  it("does not change Ask routes or multimodal Agent models", () => {
+    expect(
+      resolveAgentModelForImageToolResults(
+        "model-deepseek-v4-pro",
+        "ask",
+        true,
+      ),
+    ).toBe("model-deepseek-v4-pro");
+    expect(
+      resolveAgentModelForImageToolResults("model-minimax-m3", "agent", true),
+    ).toBe("model-minimax-m3");
+  });
 });
 
 describe("createAgentStream repeated compaction", () => {

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -342,6 +342,19 @@ describe("buildProviderOptions fallback chain", () => {
     },
   );
 
+  it("uses max reasoning for DeepSeek V4 Pro in agent mode", () => {
+    const opts = buildProviderOptions(
+      true,
+      "user-1",
+      "model-deepseek-v4-pro",
+      "agent",
+    );
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+      effort: "xhigh",
+    });
+  });
+
   it("includes reasoning settings independent of fallback chain", () => {
     const reasoning = buildProviderOptions(
       true,

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -61,7 +61,7 @@ import {
   toolResultsContainImageViewResult,
   uiMessagesContainImageViewResult,
 } from "@/lib/chat/multimodal-tool-result-recovery";
-import { isAnthropicModel } from "@/lib/ai/providers";
+import { isAnthropicModel, isDeepSeekModel } from "@/lib/ai/providers";
 import { MAX_OUTPUT_TOKENS } from "@/lib/ai/output-limits";
 import { ptySessionManager } from "@/lib/ai/tools/utils/pty-session-manager";
 import { getMaxTokensForSubscription } from "@/lib/token-utils";
@@ -105,7 +105,18 @@ import type { createTrackedProvider } from "@/lib/ai/providers";
 import type { ProviderRequestDiagnostics } from "@/lib/logger";
 import type { ChatMode, SubscriptionTier } from "@/types";
 
-const GLM_AGENT_VISION_MODEL = "model-kimi-k2.7-code";
+const AGENT_VISION_MODEL = "model-kimi-k2.7-code";
+
+export const resolveAgentModelForImageToolResults = (
+  modelName: string,
+  mode: ChatMode,
+  hasImageToolResults: boolean,
+): string =>
+  mode === "agent" &&
+  hasImageToolResults &&
+  (modelName === "model-glm-5.2" || isDeepSeekModel(modelName))
+    ? AGENT_VISION_MODEL
+    : modelName;
 
 export type RollingModelContextCheckpoint = {
   /** Latest compacted provider context, excluding later raw SDK responses. */
@@ -332,8 +343,7 @@ const buildProviderRequestDiagnostics = (args: {
   }
 
   const lastMessage = args.messages.at(-1) as
-    | Record<string, unknown>
-    | undefined;
+    Record<string, unknown> | undefined;
   const serializedBytes = getSerializedBytes(args.messages);
   const contextUsedPercent =
     args.contextUsage.maxTokens > 0
@@ -594,11 +604,11 @@ export async function createAgentStream(
     state.finalMessages,
   );
   const getEffectiveModelName = () =>
-    modelName === "model-glm-5.2" &&
-    ctx.mode === "agent" &&
-    streamHasImageViewResults
-      ? GLM_AGENT_VISION_MODEL
-      : modelName;
+    resolveAgentModelForImageToolResults(
+      modelName,
+      ctx.mode,
+      streamHasImageViewResults,
+    );
   const getEffectiveModelInfo = () => {
     const effectiveModelName = getEffectiveModelName();
     const languageModel = ctx.trackedProvider.languageModel(effectiveModelName);
@@ -882,8 +892,7 @@ export async function createAgentStream(
               const lastStepResponseMessages =
                 (
                   lastStep as
-                    | { response?: { messages?: ModelMessage[] } }
-                    | undefined
+                    { response?: { messages?: ModelMessage[] } } | undefined
                 )?.response?.messages ?? [];
               const retainedToolTransaction = getLatestCompletedToolTransaction(
                 lastStepResponseMessages,

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -155,10 +155,40 @@ describe("limitImageParts", () => {
 // selectModel - Model selection logic
 // ==========================================================================
 describe("selectModel", () => {
+  it.each(["pro", "pro-plus", "ultra", "team"] as const)(
+    "routes paid %s Auto/Standard text to DeepSeek V4 Pro in both modes",
+    (subscription) => {
+      for (const mode of ["ask", "agent"] as const) {
+        for (const selectedModel of ["auto", "hackerai-standard"] as const) {
+          expect(selectModel(mode, subscription, selectedModel)).toBe(
+            "model-deepseek-v4-pro",
+          );
+        }
+      }
+    },
+  );
+
   // Default model selection by mode
   describe("default models (no override)", () => {
-    it("should return agent-model for agent mode", () => {
-      expect(selectModel("agent", "pro")).toBe("agent-model");
+    it.each(["pro", "pro-plus", "ultra", "team"] as const)(
+      "should return DeepSeek V4 Pro for paid agent text on %s",
+      (subscription) => {
+        expect(selectModel("agent", subscription)).toBe(
+          "model-deepseek-v4-pro",
+        );
+      },
+    );
+
+    it("should return agent-model (MiniMax) for paid agent with an image", () => {
+      expect(selectModel("agent", "pro", undefined, true, false)).toBe(
+        "agent-model",
+      );
+    });
+
+    it("should return agent-model (MiniMax) for paid agent with a PDF", () => {
+      expect(selectModel("agent", "pro", undefined, false, true)).toBe(
+        "agent-model",
+      );
     });
 
     it("should return DeepSeek V4 Pro for paid ask with no image/PDF", () => {
@@ -265,15 +295,27 @@ describe("selectModel", () => {
     });
   });
 
-  // Agent mode — Standard resolves to MiniMax.
+  // Agent mode — Auto/Standard use DeepSeek for text and media-capable routes otherwise.
   describe("tier override in agent mode", () => {
-    it("should map HackerAI Standard to MiniMax M3 in agent mode", () => {
+    it("should map HackerAI Standard to DeepSeek V4 Pro for text-only agent mode", () => {
       expect(selectModel("agent", "pro", "hackerai-standard")).toBe(
-        "model-minimax-m3",
+        "model-deepseek-v4-pro",
       );
     });
 
-    it("should map HackerAI Pro to GLM 5.2 in text-only agent mode", () => {
+    it("should route HackerAI Standard to MiniMax M3 when an image is attached", () => {
+      expect(
+        selectModel("agent", "pro", "hackerai-standard", true, false),
+      ).toBe("model-minimax-m3");
+    });
+
+    it("should route HackerAI Standard to MiniMax M3 when a PDF is attached", () => {
+      expect(
+        selectModel("agent", "pro", "hackerai-standard", false, true),
+      ).toBe("model-minimax-m3");
+    });
+
+    it("should keep HackerAI Pro on GLM 5.2 in text-only agent mode", () => {
       expect(selectModel("agent", "pro", "hackerai-pro")).toBe("model-glm-5.2");
     });
 
@@ -313,9 +355,9 @@ describe("selectModel", () => {
       ).toBe("model-opus-4.6");
     });
 
-    it("should default to agent-model when no model selected", () => {
-      expect(selectModel("agent", "pro")).toBe("agent-model");
-      expect(selectModel("agent", "pro", "auto")).toBe("agent-model");
+    it("should default to DeepSeek V4 Pro when no model is selected", () => {
+      expect(selectModel("agent", "pro")).toBe("model-deepseek-v4-pro");
+      expect(selectModel("agent", "pro", "auto")).toBe("model-deepseek-v4-pro");
     });
   });
 
@@ -340,8 +382,17 @@ describe("selectModel", () => {
 
   // "auto" override
   describe("auto override", () => {
-    it("should treat 'auto' as no override in agent mode", () => {
-      expect(selectModel("agent", "pro", "auto")).toBe("agent-model");
+    it("should route paid agent Auto text to DeepSeek V4 Pro", () => {
+      expect(selectModel("agent", "pro", "auto")).toBe("model-deepseek-v4-pro");
+    });
+
+    it("should route paid agent Auto media to agent-model (MiniMax)", () => {
+      expect(selectModel("agent", "pro", "auto", true, false)).toBe(
+        "agent-model",
+      );
+      expect(selectModel("agent", "pro", "auto", false, true)).toBe(
+        "agent-model",
+      );
     });
 
     it("should treat 'auto' as no override in paid ask mode (text-only → DeepSeek Pro)", () => {
@@ -362,7 +413,9 @@ describe("selectModel", () => {
   // Undefined override
   describe("undefined override", () => {
     it("should use default when override is undefined", () => {
-      expect(selectModel("agent", "pro", undefined)).toBe("agent-model");
+      expect(selectModel("agent", "pro", undefined)).toBe(
+        "model-deepseek-v4-pro",
+      );
       expect(selectModel("ask", "pro", undefined)).toBe(
         "model-deepseek-v4-pro",
       );

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -46,9 +46,10 @@ export const getMaxStepsForUser = (
  * @param hasPdfAttachment - Whether any message has a PDF attachment.
  *   Paid ASK on the Standard/auto route normally uses DeepSeek V4 Pro
  *   (text-only); image-only prompts promote to MiniMax M3, while PDF prompts
- *   stay on Grok 4.3 for native document support. HackerAI Pro uses GLM 5.2
- *   for text-only prompts and Kimi K2.7 Code when provider-visible media is
- *   attached.
+ *   stay on Grok 4.3 for native document support. Paid Agent Auto/Standard
+ *   routes use DeepSeek V4 Pro for text-only prompts and MiniMax M3 when
+ *   provider-visible media is attached. HackerAI Pro uses GLM 5.2 for
+ *   text-only prompts and Kimi K2.7 Code for media prompts.
  * @returns Model name to use
  */
 export function selectModel(
@@ -65,14 +66,14 @@ export function selectModel(
     subscription,
     options,
   );
-  // DeepSeek ask routes are text-only, so image/PDF prompts promote to a
+  // DeepSeek routes are text-only, so image/PDF prompts promote to a
   // media-capable route unless the selected tier intentionally uses a
   // multimodal/file-capable model such as Kimi or Opus. PDFs take precedence
   // when mixed with images because the MiniMax ask route is image-scoped.
   const isFreeAsk = !isAgent && subscription === "free";
   const hasAskImage = !isAgent && !!hasImageAttachment;
   const hasAskPdf = !isAgent && !!hasPdfAttachment;
-  const hasProProviderMedia = !!hasImageAttachment || !!hasPdfAttachment;
+  const hasProviderMedia = !!hasImageAttachment || !!hasPdfAttachment;
   const paidAskMediaModel: ModelName = hasAskPdf
     ? "model-grok-4.3"
     : hasAskImage
@@ -82,7 +83,9 @@ export function selectModel(
   const autoModel: ModelName = isAgent
     ? subscription === "free"
       ? "agent-model-free"
-      : "agent-model"
+      : hasProviderMedia
+        ? "agent-model"
+        : "model-deepseek-v4-pro"
     : isFreeAsk
       ? "ask-model-free"
       : paidAskMediaModel;
@@ -97,10 +100,13 @@ export function selectModel(
     return autoModel;
   }
 
-  // Paid ASK Standard mirrors the auto-route split, but uses explicit keys so
+  // Paid Standard mirrors each mode's Auto split, but uses explicit keys so
   // any UI that reads `getModelDisplayName` shows the picked model rather than
   // the auto-router label.
-  if (allowedSelectedModel === "hackerai-standard" && !isAgent) {
+  if (allowedSelectedModel === "hackerai-standard") {
+    if (isAgent) {
+      return hasProviderMedia ? "model-minimax-m3" : "model-deepseek-v4-pro";
+    }
     return hasAskPdf
       ? "model-grok-4.3"
       : hasAskImage
@@ -109,7 +115,7 @@ export function selectModel(
   }
 
   if (allowedSelectedModel === "hackerai-pro") {
-    return hasProProviderMedia ? "model-kimi-k2.7-code" : "model-glm-5.2";
+    return hasProviderMedia ? "model-kimi-k2.7-code" : "model-glm-5.2";
   }
 
   const providerKey = resolveTierToProviderKey(allowedSelectedModel, mode);


### PR DESCRIPTION
## What changed

- route text-only requests from all paid tiers to `deepseek/deepseek-v4-pro` when Auto or HackerAI Standard is selected in Ask or Agent mode
- keep Ask image requests on MiniMax M3 and Ask PDF requests on Grok 4.3
- keep Agent image/PDF requests on MiniMax M3
- run DeepSeek Agent requests with `xhigh` reasoning (OpenRouter max reasoning)
- switch DeepSeek Agent runs to Kimi K2.7 if image tool results enter the context mid-run
- update the Agent Standard provider disclosure in the model selector

## Why

Paid Auto/Standard text requests should consistently use DeepSeek V4 Pro across both chat modes while preserving media-capable routes for images and PDFs.

## User impact

Paid users selecting Auto or Standard get DeepSeek V4 Pro for text-only Ask and Agent requests. Media behavior remains supported through the existing MiniMax/Grok routes, and Agent image tool results are handed off to Kimi rather than sent to the text-only DeepSeek route.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- full Jest suite: 229 suites, 2,295 tests passed
- focused routing/provider suites: 151 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Agent mode now defaults to DeepSeek V4 Pro for text-only requests.
  - Requests with images or PDFs now route to a media-capable model.
  - Standard-tier “powered by” messaging now includes PDFs alongside images.

- **Bug Fixes**
  - “hackerai-standard” tier routing is now consistent across Ask and Agent modes.
  - Agent handling of image tool results is improved (uses a vision-capable model when images are present).
  - Provider option behavior for DeepSeek in agent mode now sets reasoning effort to **xhigh**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->