### PR TITLE
Route free Agent to DeepSeek V4 Flash

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/ai/providers";
 
 describe("provider registry", () => {
-  it("keeps paid Ask image, Agent Standard, and stale Kimi compatibility keys pointed at their active slugs", () => {
+  it("keeps active routes and stale compatibility keys pointed at their provider slugs", () => {
     expect(
       (myProvider.languageModel("ask-model") as { modelId: string }).modelId,
     ).toBe("minimax/minimax-m3");
@@ -16,7 +16,7 @@ describe("provider registry", () => {
     expect(
       (myProvider.languageModel("agent-model-free") as { modelId: string })
         .modelId,
-    ).toBe("minimax/minimax-m3");
+    ).toBe("deepseek/deepseek-v4-flash");
     expect(
       (myProvider.languageModel("model-minimax-m3") as { modelId: string })
         .modelId,
@@ -195,7 +195,6 @@ describe("sanitizeOpenRouterRequestForXai", () => {
 describe("supportsMultimodalToolResults", () => {
   it("allows MiniMax and Kimi registry keys and OpenRouter slugs for image tool result experiments", () => {
     expect(supportsMultimodalToolResults("agent-model")).toBe(true);
-    expect(supportsMultimodalToolResults("agent-model-free")).toBe(true);
     expect(supportsMultimodalToolResults("ask-model")).toBe(true);
     expect(supportsMultimodalToolResults("model-minimax-m3")).toBe(true);
     expect(supportsMultimodalToolResults("minimax/minimax-m3")).toBe(true);
@@ -213,6 +212,7 @@ describe("supportsMultimodalToolResults", () => {
   });
 
   it("still rejects text-only DeepSeek model keys", () => {
+    expect(supportsMultimodalToolResults("agent-model-free")).toBe(false);
     expect(supportsMultimodalToolResults("model-deepseek-v4-flash")).toBe(
       false,
     );

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -181,19 +181,20 @@ export const KIMI_K2_7_CODE_SLUG = "moonshotai/kimi-k2.7-code:exacto";
 export const GLM_5_2_SLUG = "z-ai/glm-5.2";
 export const MINIMAX_M3_SLUG = "minimax/minimax-m3";
 export const GROK_4_3_SLUG = "x-ai/grok-4.3";
+export const DEEPSEEK_V4_FLASH_SLUG = "deepseek/deepseek-v4-flash";
 
 const buildProviderMap = (or: OpenRouterInstance) =>
   ({
     "ask-model": or(MINIMAX_M3_SLUG),
-    "ask-model-free": or("deepseek/deepseek-v4-flash"),
+    "ask-model-free": or(DEEPSEEK_V4_FLASH_SLUG),
     "agent-model": or(MINIMAX_M3_SLUG),
-    "agent-model-free": or(MINIMAX_M3_SLUG),
+    "agent-model-free": or(DEEPSEEK_V4_FLASH_SLUG),
     "model-sonnet-4.6": or("anthropic/claude-sonnet-4-6"),
     "model-grok-4.3": or(GROK_4_3_SLUG),
     // Compatibility alias for stale internal references persisted before the
     // paid Ask PDF route settled on Grok 4.3.
     "model-gemini-3-flash": or(GROK_4_3_SLUG),
-    "model-deepseek-v4-flash": or("deepseek/deepseek-v4-flash"),
+    "model-deepseek-v4-flash": or(DEEPSEEK_V4_FLASH_SLUG),
     "model-deepseek-v4-pro": or("deepseek/deepseek-v4-pro"),
     "model-opus-4.6": or("anthropic/claude-opus-4.6"),
     "model-glm-5.2": or(GLM_5_2_SLUG),
@@ -217,7 +218,7 @@ export const modelCutoffDates: Record<ModelName, string> &
   "ask-model": "May 2026",
   "ask-model-free": "May 2025",
   "agent-model": "May 2026",
-  "agent-model-free": "May 2026",
+  "agent-model-free": "May 2025",
   "model-sonnet-4.6": "May 2025",
   "model-grok-4.3": "April 2026",
   "model-gemini-3-flash": "April 2026",
@@ -271,6 +272,7 @@ export function isAnthropicModel(modelName: string): boolean {
 export function isDeepSeekModel(modelName: string): boolean {
   return (
     modelName === "ask-model-free" ||
+    modelName === "agent-model-free" ||
     modelName === "model-deepseek-v4-flash" ||
     modelName === "model-deepseek-v4-pro"
   );
@@ -290,7 +292,6 @@ export function isMiniMaxModel(modelName: string): boolean {
   const normalized = modelName.toLowerCase();
   return (
     normalized === "agent-model" ||
-    normalized === "agent-model-free" ||
     normalized === "ask-model" ||
     normalized === "model-minimax-m3" ||
     normalized.includes("minimax/minimax-m3")

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -71,6 +71,7 @@ jest.mock("@/lib/chat/multimodal-tool-result-recovery", () => ({
 jest.mock("@/lib/ai/providers", () => ({
   isAnthropicModel: () => false,
   isDeepSeekModel: (modelName: string) =>
+    modelName === "agent-model-free" ||
     modelName === "model-deepseek-v4-pro" ||
     modelName === "model-deepseek-v4-flash",
 }));
@@ -165,6 +166,12 @@ describe("resolveAgentModelForImageToolResults", () => {
         true,
       ),
     ).toBe("model-kimi-k2.7-code");
+  });
+
+  it("switches free DeepSeek Agent steps to MiniMax after image tool results", () => {
+    expect(
+      resolveAgentModelForImageToolResults("agent-model-free", "agent", true),
+    ).toBe("model-minimax-m3");
   });
 
   it("does not change Ask routes or multimodal Agent models", () => {

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -27,6 +27,7 @@ const GROK_SLUG = "x-ai/grok-4.3";
 const MINIMAX_SLUG = "minimax/minimax-m3";
 const KIMI_SLUG = "moonshotai/kimi-k2.7-code:exacto";
 const GLM_SLUG = "z-ai/glm-5.2";
+const DEEPSEEK_FLASH_SLUG = "deepseek/deepseek-v4-flash";
 
 describe("buildProviderOptions fallback chain", () => {
   it("resolves Opus 4.6 ask chain to Grok", () => {
@@ -189,15 +190,16 @@ describe("buildProviderOptions fallback chain", () => {
     },
   );
 
-  it("falls back from free Agent MiniMax to Kimi then Grok", () => {
+  it("runs free Agent on DeepSeek Flash max and falls back through MiniMax, Kimi, then Grok", () => {
     const opts = buildProviderOptions(
-      false,
+      true,
       "user-1",
       "agent-model-free",
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG, GROK_SLUG],
+      reasoning: { enabled: true, effort: "xhigh" },
+      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
@@ -446,9 +448,9 @@ describe("getRetryFallbackModel", () => {
     },
   );
 
-  it("keeps free Agent MiniMax app-side retry on the terminal Grok fallback", () => {
+  it("retries free Agent DeepSeek Flash with MiniMax", () => {
     expect(getRetryFallbackModel("agent-model-free", "agent")).toBe(
-      "fallback-grok-4.3",
+      "model-minimax-m3",
     );
   });
 
@@ -469,6 +471,26 @@ describe("getRetryFallbackModel", () => {
 });
 
 describe("resolveServedModelForCostAccounting", () => {
+  it("maps the primary free Agent DeepSeek slug back to its local cost key", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "agent-model-free",
+        responseModel: DEEPSEEK_FLASH_SLUG,
+        mode: "agent",
+      }),
+    ).toBe("agent-model-free");
+  });
+
+  it("maps a MiniMax slug served from free Agent fallback back to the local cost key", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "agent-model-free",
+        responseModel: MINIMAX_SLUG,
+        mode: "agent",
+      }),
+    ).toBe("model-minimax-m3");
+  });
+
   it("maps a Kimi provider slug served from free Agent fallback back to the local cost key", () => {
     expect(
       resolveServedModelForCostAccounting({

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -106,17 +106,19 @@ import type { ProviderRequestDiagnostics } from "@/lib/logger";
 import type { ChatMode, SubscriptionTier } from "@/types";
 
 const AGENT_VISION_MODEL = "model-kimi-k2.7-code";
+const FREE_AGENT_VISION_MODEL = "model-minimax-m3";
 
 export const resolveAgentModelForImageToolResults = (
   modelName: string,
   mode: ChatMode,
   hasImageToolResults: boolean,
-): string =>
-  mode === "agent" &&
-  hasImageToolResults &&
-  (modelName === "model-glm-5.2" || isDeepSeekModel(modelName))
+): string => {
+  if (mode !== "agent" || !hasImageToolResults) return modelName;
+  if (modelName === "agent-model-free") return FREE_AGENT_VISION_MODEL;
+  return modelName === "model-glm-5.2" || isDeepSeekModel(modelName)
     ? AGENT_VISION_MODEL
     : modelName;
+};
 
 export type RollingModelContextCheckpoint = {
   /** Latest compacted provider context, excluding later raw SDK responses. */

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -549,7 +549,7 @@ const AGENT_TEXT_FALLBACK_CHAIN = [
 
 const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "ask-model-free": AGENT_TEXT_FALLBACK_CHAIN,
-  "agent-model-free": MINIMAX_M3_FALLBACK_CHAIN,
+  "agent-model-free": AGENT_TEXT_FALLBACK_CHAIN,
   "model-deepseek-v4-flash": AGENT_TEXT_FALLBACK_CHAIN,
   "model-deepseek-v4-pro": AGENT_TEXT_FALLBACK_CHAIN,
   "ask-model": MINIMAX_M3_FALLBACK_CHAIN,
@@ -663,6 +663,7 @@ export function getRetryFallbackModel(
 ): ModelName {
   if (
     modelName === "ask-model-free" ||
+    modelName === "agent-model-free" ||
     modelName === "model-deepseek-v4-flash" ||
     modelName === "model-deepseek-v4-pro" ||
     modelName === "model-grok-4.3" ||

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -685,7 +685,7 @@ describe("token-bucket async functions", () => {
         servedModel,
       );
 
-      expect(expectedAdditional).toBe(65_100);
+      expect(expectedAdditional).toBe(68_040);
       expect(mockLimitFn).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ rate: expectedAdditional }),
@@ -744,7 +744,7 @@ describe("token-bucket async functions", () => {
         servedModel,
       );
 
-      expect(expectedAdditional).toBe(1_680);
+      expect(expectedAdditional).toBe(4_620);
       expect(mockLimitFn).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ rate: expectedAdditional }),

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -433,14 +433,21 @@ describe("token-bucket", () => {
       );
     });
 
-    it.each([
-      "ask-model",
-      "agent-model",
-      "agent-model-free",
-      "model-minimax-m3",
-    ])("should use MiniMax M3 pricing for %s ($0.30/$1.20)", (modelName) => {
-      expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(4200);
-      expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(16800);
+    it.each(["ask-model", "agent-model", "model-minimax-m3"])(
+      "should use MiniMax M3 pricing for %s ($0.30/$1.20)",
+      (modelName) => {
+        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(4200);
+        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(16800);
+      },
+    );
+
+    it("should use DeepSeek V4 Flash pricing for free Agent ($0.09/$0.18)", () => {
+      expect(calculateTokenCost(1_000_000, "input", "agent-model-free")).toBe(
+        1260,
+      );
+      expect(calculateTokenCost(1_000_000, "output", "agent-model-free")).toBe(
+        2520,
+      );
     });
 
     it.each(["model-grok-4.3", "model-gemini-3-flash", "fallback-grok-4.3"])(

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -32,6 +32,8 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   "model-sonnet-4.6": { input: 3.0, output: 15.0 },
   "model-grok-4.3": { input: 1.25, output: 2.5 },
   "model-gemini-3-flash": { input: 1.25, output: 2.5 },
+  // Rates from OpenRouter: $0.09 in / $0.18 out per 1M tokens.
+  "agent-model-free": { input: 0.09, output: 0.18 },
   "model-deepseek-v4-pro": { input: 0.435, output: 0.87 },
   "fallback-grok-4.3": { input: 1.25, output: 2.5 },
   "model-opus-4.6": { input: 5.0, output: 25.0 },
@@ -41,7 +43,6 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   // Rates from OpenRouter: $0.30 in / $1.20 out per 1M tokens.
   "ask-model": { input: 0.3, output: 1.2 },
   "agent-model": { input: 0.3, output: 1.2 },
-  "agent-model-free": { input: 0.3, output: 1.2 },
   "model-minimax-m3": { input: 0.3, output: 1.2 },
   // Kimi keys are retained as compatibility aliases for stale persisted routes.
   // Rates from OpenRouter: $0.95 in / $4.00 out per 1M tokens.


### PR DESCRIPTION
## What changed

- route `agent-model-free` to `deepseek/deepseek-v4-flash` instead of MiniMax M3
- enable DeepSeek max reasoning (`xhigh`) for free Agent runs
- classify the free Agent alias as text-only DeepSeek so prompts and tool capabilities stay model-aware
- retain MiniMax, Kimi, and Grok as provider fallbacks; use MiniMax when image tool results enter a free Agent run
- update retry behavior, cutoff metadata, and token pricing for the new primary model

## Why

Free Agent still pointed at MiniMax M3 after paid Auto/Standard text routing moved to DeepSeek. The free Agent alias, capability checks, fallback assumptions, and pricing needed to move together so runtime behavior and accounting do not drift.

## User impact

Free Agent text requests now use DeepSeek V4 Flash at max reasoning. Provider failures continue through the existing fallback chain, and image tool results remain supported through a temporary MiniMax handoff.

## Validation

- commit hooks: Prettier and ESLint passed
- `pnpm typecheck`
- full Jest suite: 229 suites, 2,311 tests passed
- focused routing/provider/pricing suites: 6 suites, 257 tests passed

Automated validation is sufficient because this change is backend model routing with no visual UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Free Agent mode now uses DeepSeek Flash as its primary model.
  * Added improved fallback routing through MiniMax, Kimi, and Grok when needed.
  * Free Agent can switch to a vision-capable model when image results are included.

* **Bug Fixes**
  * Improved retry behavior and model selection for Free Agent requests.
  * Updated usage pricing to reflect DeepSeek Flash rates.
  * Corrected model classification and cost tracking across fallback routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->