### PR TITLE
Fix billing failure reason classification

### DIFF
--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -12,6 +12,7 @@ const mockRetrieveCustomer = jest.fn();
 const mockRetrieveSubscription = jest.fn();
 const mockUpdateSubscription = jest.fn();
 const mockRetrieveInvoice = jest.fn();
+const mockRetrievePaymentIntent = jest.fn();
 const mockListMemberships = jest.fn();
 const mockConvexMutation = jest.fn();
 const mockResetRateLimitBuckets = jest.fn();
@@ -49,6 +50,9 @@ jest.mock("@/app/api/stripe", () => ({
     },
     invoices: {
       retrieve: mockRetrieveInvoice,
+    },
+    paymentIntents: {
+      retrieve: mockRetrievePaymentIntent,
     },
   },
 }));
@@ -544,31 +548,51 @@ describe("POST /api/subscription/webhook", () => {
           subscription: "sub_payment_failed",
         },
       },
-      payment_intent: {
-        id: "pi_payment_failed",
-        last_payment_error: {
-          code: "card_declined",
-          decline_code: "insufficient_funds",
-          charge: "ch_payment_failed",
-          payment_method: { type: "card" },
-        },
-        latest_charge: {
-          id: "ch_payment_failed",
-          failure_code: "card_declined",
-          outcome: {
-            type: "issuer_declined",
-            reason: "insufficient_funds",
-            network_status: "declined_by_network",
-            network_decline_code: "51",
-            risk_level: "normal",
-          },
-          payment_method_details: {
-            type: "card",
-            card: {
-              brand: "visa",
-              country: "US",
-              funding: "debit",
+      payments: {
+        data: [
+          {
+            is_default: true,
+            payment: {
+              type: "payment_intent",
+              payment_intent: {
+                id: "pi_payment_failed",
+                last_payment_error: {
+                  code: "card_declined",
+                  decline_code: "insufficient_funds",
+                  charge: "ch_payment_failed",
+                  payment_method: { type: "card" },
+                },
+                latest_charge: "ch_payment_failed",
+              },
             },
+          },
+        ],
+      },
+    } as never);
+    mockRetrievePaymentIntent.mockResolvedValue({
+      id: "pi_payment_failed",
+      last_payment_error: {
+        code: "card_declined",
+        decline_code: "insufficient_funds",
+        charge: "ch_payment_failed",
+        payment_method: { type: "card" },
+      },
+      latest_charge: {
+        id: "ch_payment_failed",
+        failure_code: "card_declined",
+        outcome: {
+          type: "issuer_declined",
+          reason: "insufficient_funds",
+          network_status: "declined_by_network",
+          network_decline_code: "51",
+          risk_level: "normal",
+        },
+        payment_method_details: {
+          type: "card",
+          card: {
+            brand: "visa",
+            country: "US",
+            funding: "debit",
           },
         },
       },
@@ -582,8 +606,14 @@ describe("POST /api/subscription/webhook", () => {
     expect(response.status).toBe(200);
     expect(body).toEqual({ received: true });
     expect(mockRetrieveInvoice).toHaveBeenCalledWith("in_payment_failed", {
-      expand: ["payment_intent", "payment_intent.latest_charge"],
+      expand: ["payments.data.payment.payment_intent"],
     });
+    expect(mockRetrievePaymentIntent).toHaveBeenCalledWith(
+      "pi_payment_failed",
+      {
+        expand: ["latest_charge"],
+      },
+    );
     expect(mockPostHogEvent).toHaveBeenCalledWith(
       "billing_payment_failed",
       expect.objectContaining({
@@ -673,31 +703,51 @@ describe("POST /api/subscription/webhook", () => {
           subscription: "sub_deleted_payment_failed",
         },
       },
-      payment_intent: {
-        id: "pi_deleted_payment_failed",
-        last_payment_error: {
-          code: "card_declined",
-          decline_code: "transaction_not_allowed",
-          charge: "ch_deleted_payment_failed",
-          payment_method: { type: "card" },
-        },
-        latest_charge: {
-          id: "ch_deleted_payment_failed",
-          failure_code: "card_declined",
-          outcome: {
-            type: "issuer_declined",
-            reason: "transaction_not_allowed",
-            network_status: "declined_by_network",
-            network_decline_code: "57",
-            risk_level: "normal",
-          },
-          payment_method_details: {
-            type: "card",
-            card: {
-              brand: "mastercard",
-              country: "MA",
-              funding: "debit",
+      payments: {
+        data: [
+          {
+            is_default: true,
+            payment: {
+              type: "payment_intent",
+              payment_intent: {
+                id: "pi_deleted_payment_failed",
+                last_payment_error: {
+                  code: "card_declined",
+                  decline_code: "transaction_not_allowed",
+                  charge: "ch_deleted_payment_failed",
+                  payment_method: { type: "card" },
+                },
+                latest_charge: "ch_deleted_payment_failed",
+              },
             },
+          },
+        ],
+      },
+    } as never);
+    mockRetrievePaymentIntent.mockResolvedValue({
+      id: "pi_deleted_payment_failed",
+      last_payment_error: {
+        code: "card_declined",
+        decline_code: "transaction_not_allowed",
+        charge: "ch_deleted_payment_failed",
+        payment_method: { type: "card" },
+      },
+      latest_charge: {
+        id: "ch_deleted_payment_failed",
+        failure_code: "card_declined",
+        outcome: {
+          type: "issuer_declined",
+          reason: "transaction_not_allowed",
+          network_status: "declined_by_network",
+          network_decline_code: "57",
+          risk_level: "normal",
+        },
+        payment_method_details: {
+          type: "card",
+          card: {
+            brand: "mastercard",
+            country: "MA",
+            funding: "debit",
           },
         },
       },
@@ -712,7 +762,11 @@ describe("POST /api/subscription/webhook", () => {
     expect(body).toEqual({ received: true });
     expect(mockRetrieveInvoice).toHaveBeenCalledWith(
       "in_deleted_payment_failed",
-      { expand: ["payment_intent", "payment_intent.latest_charge"] },
+      { expand: ["payments.data.payment.payment_intent"] },
+    );
+    expect(mockRetrievePaymentIntent).toHaveBeenCalledWith(
+      "pi_deleted_payment_failed",
+      { expand: ["latest_charge"] },
     );
     expect(mockPostHogEvent).toHaveBeenCalledWith(
       "subscription_cancelled",

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -177,7 +177,10 @@ function mockInvoicePaymentFailedAnalytics({
   paymentIntent = hydratedPaymentIntent(),
   paymentIntentError,
 }: {
-  invoicePaymentIntent?: ReturnType<typeof expandedInvoicePaymentIntent> | null;
+  invoicePaymentIntent?:
+    | ReturnType<typeof expandedInvoicePaymentIntent>
+    | ReturnType<typeof hydratedPaymentIntent>
+    | null;
   paymentIntent?: ReturnType<typeof hydratedPaymentIntent>;
   paymentIntentError?: Error;
 } = {}) {
@@ -713,6 +716,26 @@ describe("POST /api/subscription/webhook", () => {
       expect.objectContaining({
         billing_failure_group: "insufficient_funds",
         stripe_payment_intent_id: "pi_payment_failed",
+      }),
+    );
+  });
+
+  it("uses an already-hydrated charge without retrieving the PaymentIntent", async () => {
+    mockInvoicePaymentFailedAnalytics({
+      invoicePaymentIntent: hydratedPaymentIntent(),
+    });
+
+    const { POST } = await import("../route");
+    const response = await POST(makeWebhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockRetrievePaymentIntent).not.toHaveBeenCalled();
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "billing_payment_failed",
+      expect.objectContaining({
+        billing_failure_group: "insufficient_funds",
+        outcome_reason: "insufficient_funds",
+        card_country: "US",
       }),
     );
   });

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -132,6 +132,150 @@ function makeWebhookRequest({
   } as any;
 }
 
+function expandedInvoicePaymentIntent(
+  latestCharge: string | null = "ch_payment_failed",
+) {
+  return {
+    id: "pi_payment_failed",
+    last_payment_error: {
+      code: "card_declined",
+      decline_code: "insufficient_funds",
+      charge: "ch_payment_failed",
+      payment_method: { type: "card" },
+    },
+    latest_charge: latestCharge,
+  };
+}
+
+function hydratedPaymentIntent() {
+  return {
+    ...expandedInvoicePaymentIntent(),
+    latest_charge: {
+      id: "ch_payment_failed",
+      failure_code: "card_declined",
+      outcome: {
+        type: "issuer_declined",
+        reason: "insufficient_funds",
+        network_status: "declined_by_network",
+        network_decline_code: "51",
+        risk_level: "normal",
+      },
+      payment_method_details: {
+        type: "card",
+        card: {
+          brand: "visa",
+          country: "US",
+          funding: "debit",
+        },
+      },
+    },
+  };
+}
+
+function mockInvoicePaymentFailedAnalytics({
+  invoicePaymentIntent = expandedInvoicePaymentIntent(),
+  paymentIntent = hydratedPaymentIntent(),
+  paymentIntentError,
+}: {
+  invoicePaymentIntent?: ReturnType<typeof expandedInvoicePaymentIntent> | null;
+  paymentIntent?: ReturnType<typeof hydratedPaymentIntent>;
+  paymentIntentError?: Error;
+} = {}) {
+  mockConstructEvent.mockReturnValue({
+    id: "evt_invoice_payment_failed",
+    type: "invoice.payment_failed",
+    data: {
+      object: {
+        id: "in_payment_failed",
+        customer: "cus_payment_failed",
+        amount_due: 6000,
+        amount_remaining: 6000,
+        currency: "usd",
+        status: "open",
+        collection_method: "charge_automatically",
+        billing_reason: "subscription_update",
+        attempt_count: 2,
+        next_payment_attempt: 1_782_000_000,
+        parent: {
+          subscription_details: {
+            subscription: "sub_payment_failed",
+          },
+        },
+      },
+    },
+  });
+  mockRetrieveCustomer.mockResolvedValue({
+    deleted: false,
+    id: "cus_payment_failed",
+    metadata: {
+      workOSOrganizationId: "org_payment_failed",
+    },
+  } as never);
+  mockListMemberships.mockResolvedValue({
+    autoPagination: jest
+      .fn()
+      .mockResolvedValue([{ userId: "user_payment_failed" }]),
+  } as never);
+  mockRetrieveSubscription.mockResolvedValue({
+    id: "sub_payment_failed",
+    metadata: {},
+    items: {
+      data: [
+        {
+          quantity: 1,
+          price: {
+            id: "price_pro_plus",
+            lookup_key: "pro-plus-monthly-plan",
+            recurring: { interval: "month", interval_count: 1 },
+            product: {
+              id: "prod_pro_plus",
+              name: "HackerAI Pro Plus",
+              metadata: {},
+            },
+          },
+        },
+      ],
+    },
+  } as never);
+  mockRetrieveInvoice.mockResolvedValue({
+    id: "in_payment_failed",
+    customer: "cus_payment_failed",
+    amount_due: 6000,
+    amount_remaining: 6000,
+    currency: "usd",
+    status: "open",
+    collection_method: "charge_automatically",
+    billing_reason: "subscription_update",
+    attempt_count: 2,
+    next_payment_attempt: 1_782_000_000,
+    parent: {
+      subscription_details: {
+        subscription: "sub_payment_failed",
+      },
+    },
+    payments: {
+      data: invoicePaymentIntent
+        ? [
+            {
+              is_default: true,
+              payment: {
+                type: "payment_intent",
+                payment_intent: invoicePaymentIntent,
+              },
+            },
+          ]
+        : [],
+    },
+  } as never);
+
+  mockRetrievePaymentIntent.mockReset();
+  if (paymentIntentError) {
+    mockRetrievePaymentIntent.mockRejectedValue(paymentIntentError as never);
+  } else {
+    mockRetrievePaymentIntent.mockResolvedValue(paymentIntent as never);
+  }
+}
+
 describe("POST /api/subscription/webhook", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -476,127 +620,7 @@ describe("POST /api/subscription/webhook", () => {
   });
 
   it("captures classified billing failure analytics for subscription invoice failures", async () => {
-    mockConstructEvent.mockReturnValue({
-      id: "evt_invoice_payment_failed",
-      type: "invoice.payment_failed",
-      data: {
-        object: {
-          id: "in_payment_failed",
-          customer: "cus_payment_failed",
-          amount_due: 6000,
-          amount_remaining: 6000,
-          currency: "usd",
-          status: "open",
-          collection_method: "charge_automatically",
-          billing_reason: "subscription_update",
-          attempt_count: 2,
-          next_payment_attempt: 1_782_000_000,
-          parent: {
-            subscription_details: {
-              subscription: "sub_payment_failed",
-            },
-          },
-        },
-      },
-    });
-    mockRetrieveCustomer.mockResolvedValue({
-      deleted: false,
-      id: "cus_payment_failed",
-      metadata: {
-        workOSOrganizationId: "org_payment_failed",
-      },
-    } as never);
-    mockListMemberships.mockResolvedValue({
-      autoPagination: jest
-        .fn()
-        .mockResolvedValue([{ userId: "user_payment_failed" }]),
-    } as never);
-    mockRetrieveSubscription.mockResolvedValue({
-      id: "sub_payment_failed",
-      metadata: {},
-      items: {
-        data: [
-          {
-            quantity: 1,
-            price: {
-              id: "price_pro_plus",
-              lookup_key: "pro-plus-monthly-plan",
-              recurring: { interval: "month", interval_count: 1 },
-              product: {
-                id: "prod_pro_plus",
-                name: "HackerAI Pro Plus",
-                metadata: {},
-              },
-            },
-          },
-        ],
-      },
-    } as never);
-    mockRetrieveInvoice.mockResolvedValue({
-      id: "in_payment_failed",
-      customer: "cus_payment_failed",
-      amount_due: 6000,
-      amount_remaining: 6000,
-      currency: "usd",
-      status: "open",
-      collection_method: "charge_automatically",
-      billing_reason: "subscription_update",
-      attempt_count: 2,
-      next_payment_attempt: 1_782_000_000,
-      parent: {
-        subscription_details: {
-          subscription: "sub_payment_failed",
-        },
-      },
-      payments: {
-        data: [
-          {
-            is_default: true,
-            payment: {
-              type: "payment_intent",
-              payment_intent: {
-                id: "pi_payment_failed",
-                last_payment_error: {
-                  code: "card_declined",
-                  decline_code: "insufficient_funds",
-                  charge: "ch_payment_failed",
-                  payment_method: { type: "card" },
-                },
-                latest_charge: "ch_payment_failed",
-              },
-            },
-          },
-        ],
-      },
-    } as never);
-    mockRetrievePaymentIntent.mockResolvedValue({
-      id: "pi_payment_failed",
-      last_payment_error: {
-        code: "card_declined",
-        decline_code: "insufficient_funds",
-        charge: "ch_payment_failed",
-        payment_method: { type: "card" },
-      },
-      latest_charge: {
-        id: "ch_payment_failed",
-        failure_code: "card_declined",
-        outcome: {
-          type: "issuer_declined",
-          reason: "insufficient_funds",
-          network_status: "declined_by_network",
-          network_decline_code: "51",
-          risk_level: "normal",
-        },
-        payment_method_details: {
-          type: "card",
-          card: {
-            brand: "visa",
-            country: "US",
-            funding: "debit",
-          },
-        },
-      },
-    } as never);
+    mockInvoicePaymentFailedAnalytics();
 
     const { POST } = await import("../route");
 
@@ -644,6 +668,68 @@ describe("POST /api/subscription/webhook", () => {
         card_country: "US",
         card_funding: "debit",
         paid_funnel_event_version: 1,
+      }),
+    );
+  });
+
+  it("falls back to the expanded PaymentIntent when charge hydration fails", async () => {
+    mockInvoicePaymentFailedAnalytics({
+      paymentIntentError: new Error("Stripe request failed"),
+    });
+
+    const { POST } = await import("../route");
+    const response = await POST(makeWebhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockPostHogWarn).toHaveBeenCalledWith(
+      "subscription_payment_failure_payment_intent_retrieve_failed",
+      expect.objectContaining({
+        stripe_invoice_id: "in_payment_failed",
+        stripe_payment_intent_id: "pi_payment_failed",
+      }),
+    );
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "billing_payment_failed",
+      expect.objectContaining({
+        billing_failure_group: "insufficient_funds",
+        stripe_payment_intent_id: "pi_payment_failed",
+        stripe_charge_id: "ch_payment_failed",
+      }),
+    );
+  });
+
+  it("uses an expanded PaymentIntent without retrieving a missing latest charge", async () => {
+    mockInvoicePaymentFailedAnalytics({
+      invoicePaymentIntent: expandedInvoicePaymentIntent(null),
+    });
+
+    const { POST } = await import("../route");
+    const response = await POST(makeWebhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockRetrievePaymentIntent).not.toHaveBeenCalled();
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "billing_payment_failed",
+      expect.objectContaining({
+        billing_failure_group: "insufficient_funds",
+        stripe_payment_intent_id: "pi_payment_failed",
+      }),
+    );
+  });
+
+  it("keeps the unknown fallback when an invoice has no PaymentIntent", async () => {
+    mockInvoicePaymentFailedAnalytics({ invoicePaymentIntent: null });
+
+    const { POST } = await import("../route");
+    const response = await POST(makeWebhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockRetrievePaymentIntent).not.toHaveBeenCalled();
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      "billing_payment_failed",
+      expect.objectContaining({
+        billing_failure_group: "unknown",
+        stripe_payment_intent_id: undefined,
       }),
     );
   });

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -28,6 +28,8 @@ import {
   logStripeWebhookSignatureVerificationFailed,
 } from "@/lib/billing/stripe-webhook-logging";
 import {
+  invoicePaymentIntent,
+  invoicePaymentIntentId,
   invoiceSubscriptionId,
   stripeObjectId,
   subscriptionPaymentFailureProperties,
@@ -128,12 +130,18 @@ function monthlyUsagePeriodEndSeconds(
   return subscriptionCurrentPeriodEndSeconds(subscription);
 }
 
+type BillingFailureAnalyticsContext = {
+  invoice: Stripe.Invoice;
+  paymentIntent?: Stripe.PaymentIntent;
+};
+
 async function retrieveInvoiceForFailureAnalytics(
   invoiceId: string,
-): Promise<Stripe.Invoice | null> {
+): Promise<BillingFailureAnalyticsContext | null> {
+  let invoice: Stripe.Invoice;
   try {
-    return await stripe.invoices.retrieve(invoiceId, {
-      expand: ["payment_intent", "payment_intent.latest_charge"],
+    invoice = await stripe.invoices.retrieve(invoiceId, {
+      expand: ["payments.data.payment.payment_intent"],
     });
   } catch (error) {
     phLogger.warn("subscription_payment_failure_invoice_retrieve_failed", {
@@ -141,6 +149,37 @@ async function retrieveInvoiceForFailureAnalytics(
       error: error instanceof Error ? error.message : String(error),
     });
     return null;
+  }
+
+  const expandedPaymentIntent = invoicePaymentIntent(invoice);
+  const paymentIntentId = invoicePaymentIntentId(invoice);
+  const latestCharge = expandedPaymentIntent?.latest_charge;
+  if (
+    !paymentIntentId ||
+    latestCharge === null ||
+    (latestCharge && typeof latestCharge === "object")
+  ) {
+    return { invoice, paymentIntent: expandedPaymentIntent };
+  }
+
+  try {
+    const paymentIntent = await stripe.paymentIntents.retrieve(
+      paymentIntentId,
+      {
+        expand: ["latest_charge"],
+      },
+    );
+    return { invoice, paymentIntent };
+  } catch (error) {
+    phLogger.warn(
+      "subscription_payment_failure_payment_intent_retrieve_failed",
+      {
+        stripe_invoice_id: invoiceId,
+        stripe_payment_intent_id: paymentIntentId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return { invoice, paymentIntent: expandedPaymentIntent };
   }
 }
 
@@ -510,6 +549,7 @@ async function recordPaidStartMix({
 
 async function emitBillingPaymentFailed(args: {
   invoice: Stripe.Invoice;
+  paymentIntent?: Stripe.PaymentIntent;
   customerId: string;
   userIds: string[];
   orgId?: string;
@@ -522,6 +562,7 @@ async function emitBillingPaymentFailed(args: {
   const failureProperties = subscriptionPaymentFailureProperties({
     invoice: args.invoice,
     lifecycle: args.lifecycle,
+    paymentIntent: args.paymentIntent,
   });
 
   for (const uid of args.userIds) {
@@ -890,16 +931,15 @@ async function handleInvoicePaymentFailed(
     return;
   }
 
-  const expandedInvoice = (invoice as unknown as { payment_intent?: unknown })
-    .payment_intent
-    ? invoice
-    : ((await retrieveInvoiceForFailureAnalytics(invoice.id)) ?? invoice);
+  const failureContext = await retrieveInvoiceForFailureAnalytics(invoice.id);
+  const failureInvoice = failureContext?.invoice ?? invoice;
   const subscription =
     resolved?.kind === "resolved" ? resolved.subscription : undefined;
   const price = subscription?.items?.data[0]?.price;
 
   await emitBillingPaymentFailed({
-    invoice: expandedInvoice,
+    invoice: failureInvoice,
+    paymentIntent: failureContext?.paymentIntent,
     customerId,
     userIds,
     orgId: orgId ?? undefined,
@@ -1310,14 +1350,15 @@ async function handleSubscriptionDeleted(
 
   const cancellationReason = subscription.cancellation_details?.reason ?? null;
   const latestInvoiceId = stripeObjectId(subscription.latest_invoice);
-  const failureInvoice =
+  const failureContext =
     cancellationReason === "payment_failed" && latestInvoiceId
       ? await retrieveInvoiceForFailureAnalytics(latestInvoiceId)
       : null;
-  const failureProperties = failureInvoice
+  const failureProperties = failureContext
     ? subscriptionPaymentFailureProperties({
-        invoice: failureInvoice,
+        invoice: failureContext.invoice,
         lifecycle: "subscription_deleted",
+        paymentIntent: failureContext.paymentIntent,
       })
     : undefined;
 
@@ -1346,9 +1387,10 @@ async function handleSubscriptionDeleted(
     });
   }
 
-  if (failureInvoice) {
+  if (failureContext) {
     await emitBillingPaymentFailed({
-      invoice: failureInvoice,
+      invoice: failureContext.invoice,
+      paymentIntent: failureContext.paymentIntent,
       customerId,
       userIds,
       orgId: orgId ?? undefined,

--- a/lib/billing/subscription-payment-failure.ts
+++ b/lib/billing/subscription-payment-failure.ts
@@ -66,28 +66,35 @@ export function invoiceSubscriptionId(
   );
 }
 
-function expandedPaymentIntent(
+function invoicePaymentIntentReference(
+  invoice: Stripe.Invoice,
+): string | Stripe.PaymentIntent | undefined {
+  const invoicePayments = invoice.payments?.data ?? [];
+  const invoicePayment =
+    invoicePayments.find(
+      (payment) =>
+        payment.is_default && payment.payment.type === "payment_intent",
+    ) ??
+    invoicePayments.find(
+      (payment) => payment.payment.type === "payment_intent",
+    );
+
+  return invoicePayment?.payment.payment_intent;
+}
+
+export function invoicePaymentIntent(
   invoice: Stripe.Invoice,
 ): Stripe.PaymentIntent | undefined {
-  const paymentIntent = (
-    invoice as unknown as {
-      payment_intent?: string | Stripe.PaymentIntent | null;
-    }
-  ).payment_intent;
-
+  const paymentIntent = invoicePaymentIntentReference(invoice);
   return paymentIntent && typeof paymentIntent === "object"
     ? paymentIntent
     : undefined;
 }
 
-function paymentIntentId(invoice: Stripe.Invoice): string | undefined {
-  const paymentIntent = (
-    invoice as unknown as {
-      payment_intent?: string | Stripe.PaymentIntent | null;
-    }
-  ).payment_intent;
-
-  return stripeObjectId(paymentIntent);
+export function invoicePaymentIntentId(
+  invoice: Stripe.Invoice,
+): string | undefined {
+  return stripeObjectId(invoicePaymentIntentReference(invoice));
 }
 
 function latestCharge(
@@ -157,11 +164,13 @@ function failureGroup(args: {
 export function subscriptionPaymentFailureProperties({
   invoice,
   lifecycle,
+  paymentIntent: providedPaymentIntent,
 }: {
   invoice: Stripe.Invoice;
   lifecycle: BillingFailureLifecycle;
+  paymentIntent?: Stripe.PaymentIntent;
 }): BillingFailureProperties {
-  const paymentIntent = expandedPaymentIntent(invoice);
+  const paymentIntent = providedPaymentIntent ?? invoicePaymentIntent(invoice);
   const charge = latestCharge(paymentIntent);
   const lastPaymentError = paymentIntent?.last_payment_error;
   const card = charge?.payment_method_details?.card;
@@ -194,7 +203,7 @@ export function subscriptionPaymentFailureProperties({
     amount_remaining_dollars: centsToDollars(invoice.amount_remaining),
     currency: invoice.currency,
     stripe_invoice_id: invoice.id,
-    stripe_payment_intent_id: paymentIntentId(invoice),
+    stripe_payment_intent_id: stripeObjectId(paymentIntent),
     stripe_charge_id:
       stripeObjectId(charge) ?? stripeObjectId(lastPaymentError?.charge),
     failure_code: failureCode,


### PR DESCRIPTION
## Summary

- read failed invoice PaymentIntents from Stripe's current Invoice Payments API shape
- hydrate `latest_charge` before normalizing decline, outcome, and card details
- preserve safe fallbacks when PaymentIntent retrieval fails or data is unavailable
- cover expanded, separately hydrated, already hydrated, missing, and retrieval-failure paths

## Root cause

The webhook was still reading the removed top-level `Invoice.payment_intent` field. With Stripe API `2026-06-24.dahlia`, the PaymentIntent reference is under `invoice.payments.data[].payment.payment_intent`, so the failure normalizer received no decline data and emitted `billing_failure_group: "unknown"`.

## Validation

- `pnpm exec jest app/api/subscription/webhook/__tests__/route.test.ts --runInBand` — 12 tests passed
- `pnpm typecheck`
- targeted ESLint
- full pre-commit suite — 229 suites / 2322 tests passed

No visual verification was needed because this is a backend webhook analytics change.

## Manual verification

After deployment, trigger a test subscription invoice failure with a Stripe test decline card, then inspect the resulting `billing_payment_failed` event in PostHog. Expect a specific `billing_failure_group`, `stripe_payment_intent_id`, and decline/outcome fields instead of `unknown`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing failure analytics by enriching events with Stripe PaymentIntent details derived from invoice payment data.
  * Improved subscription cancellation reporting after failed payments by forwarding the associated PaymentIntent into analytics properties.
* **Tests**
  * Enhanced webhook tests to cover PaymentIntent hydration/retrieval outcomes: retrieval failure warnings/events, no-retrieve when data is already present, and unknown fallbacks.
  * Updated invoice mocks and assertions to match the new PaymentIntent expansion and usage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->