### PR TITLE
Fix actionable production errors and telemetry

### DIFF
--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -33,6 +33,7 @@ const mockLoadPostHogClient = loadPostHogClient as jest.Mock;
 
 describe("PostHogProvider", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
     process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://us.i.posthog.com";
 
@@ -50,6 +51,7 @@ describe("PostHogProvider", () => {
     const posthog = {
       __loaded: false,
       init: jest.fn(),
+      set_config: jest.fn(),
       opt_in_capturing: jest.fn(),
       identify: jest.fn(),
       sessionRecordingStarted: jest.fn(() => false),
@@ -78,6 +80,43 @@ describe("PostHogProvider", () => {
         },
         capture_pageview: false,
         autocapture: false,
+      }),
+    );
+    expect(posthog.set_config).not.toHaveBeenCalled();
+  });
+
+  it("applies exception hooks when the shared client is already initialized", async () => {
+    const posthog = {
+      __loaded: true,
+      init: jest.fn(),
+      set_config: jest.fn(),
+      opt_in_capturing: jest.fn(),
+      identify: jest.fn(),
+      sessionRecordingStarted: jest.fn(() => false),
+      startSessionRecording: jest.fn(),
+      stopSessionRecording: jest.fn(),
+      reset: jest.fn(),
+      opt_out_capturing: jest.fn(),
+    };
+    mockLoadPostHogClient.mockResolvedValue(posthog);
+
+    render(
+      <PostHogProvider>
+        <div>child</div>
+      </PostHogProvider>,
+    );
+
+    await waitFor(() => expect(posthog.set_config).toHaveBeenCalledTimes(1));
+
+    expect(posthog.init).not.toHaveBeenCalled();
+    expect(posthog.set_config).toHaveBeenCalledWith(
+      expect.objectContaining({
+        before_send: expect.any(Function),
+        capture_exceptions: {
+          capture_unhandled_errors: true,
+          capture_unhandled_rejections: true,
+          capture_console_errors: false,
+        },
       }),
     );
   });

--- a/app/api/fraud/webhook/route.ts
+++ b/app/api/fraud/webhook/route.ts
@@ -9,6 +9,10 @@ import {
   logStripeWebhookSignatureVerificationFailed,
 } from "@/lib/billing/stripe-webhook-logging";
 import { getRemainingRefundAmountCents } from "@/lib/billing/fraud-refund";
+import {
+  isTerminalPaymentMethodDetachError,
+  isTerminalStripeResourceError,
+} from "@/lib/billing/stripe-terminal-errors";
 
 const WEBHOOK_LOG_PREFIX = "[Fraud Webhook]";
 const WEBHOOK_LOG_CONTEXT = {
@@ -17,25 +21,11 @@ const WEBHOOK_LOG_CONTEXT = {
 };
 
 type SuspensionCategory =
-  | "early_fraud_warning"
-  | "dispute_fraudulent"
-  | "dispute_billing_hold";
+  "early_fraud_warning" | "dispute_fraudulent" | "dispute_billing_hold";
 
 // =============================================================================
 // Helpers
 // =============================================================================
-
-/**
- * True if a Stripe error means "the resource is already in the desired
- * end-state" — already cancelled, already detached, or no longer exists.
- * These are safe to swallow on retry; anything else (network, rate limit,
- * 5xx) is transient and must bubble so Stripe retries the webhook.
- */
-function isTerminalStripeError(err: unknown): boolean {
-  return (
-    err instanceof Stripe.errors.StripeError && err.code === "resource_missing"
-  );
-}
 
 /**
  * Cancel Stripe subscriptions that existed at the time of the originating
@@ -64,7 +54,7 @@ async function cancelAllSubscriptions(
     try {
       await stripe.subscriptions.cancel(sub.id as string);
     } catch (err) {
-      if (isTerminalStripeError(err)) {
+      if (isTerminalStripeResourceError(err)) {
         console.log(
           `[Fraud Webhook] Cancel skipped for subscription ${sub.id}: resource_missing`,
         );
@@ -103,9 +93,9 @@ async function detachAllPaymentMethods(
     try {
       await stripe.paymentMethods.detach(pm.id);
     } catch (err) {
-      if (isTerminalStripeError(err)) {
+      if (isTerminalPaymentMethodDetachError(err)) {
         console.log(
-          `[Fraud Webhook] Detach skipped for payment method ${pm.id}: resource_missing`,
+          `[Fraud Webhook] Detach skipped for payment method ${pm.id}: already detached or missing`,
         );
         continue;
       }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
+import type { PostHogConfig } from "posthog-js";
 import { useEffect } from "react";
 import { useGlobalState } from "./contexts/GlobalState";
 import {
@@ -35,28 +36,33 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       .then((posthog) => {
         if (cancelled) return;
 
-        // Initialize PostHog if not already initialized
-        if (!posthog.__loaded) {
-          posthog.init(posthogKey, {
-            api_host:
-              process.env.NEXT_PUBLIC_POSTHOG_HOST ??
-              "https://us.i.posthog.com",
-            capture_pageview: false, // Disable automatic pageview capture, as we capture manually
-            autocapture: false, // Disable automatic event capture, as we capture manually
-            capture_exceptions: {
-              capture_unhandled_errors: true,
-              capture_unhandled_rejections: true,
-              capture_console_errors: false,
-            },
-            disable_session_recording: true,
-            before_send: (event) => {
-              if (!event || shouldDropExpectedFrontendException(event)) {
-                return null;
-              }
+        const config = {
+          api_host:
+            process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com",
+          capture_pageview: false, // Disable automatic pageview capture, as we capture manually
+          autocapture: false, // Disable automatic event capture, as we capture manually
+          capture_exceptions: {
+            capture_unhandled_errors: true,
+            capture_unhandled_rejections: true,
+            capture_console_errors: false,
+          },
+          disable_session_recording: true,
+          before_send: (event) => {
+            if (!event || shouldDropExpectedFrontendException(event)) {
+              return null;
+            }
 
-              return enrichFrontendExceptionEvent(event);
-            },
-          });
+            return enrichFrontendExceptionEvent(event);
+          },
+        } satisfies Partial<PostHogConfig>;
+
+        // The singleton can be initialized before this provider mounts. Apply
+        // our exception hooks in both cases so noisy browser errors are still
+        // suppressed and retained errors receive diagnostic fields.
+        if (!posthog.__loaded) {
+          posthog.init(posthogKey, config);
+        } else {
+          posthog.set_config(config);
         }
 
         posthog.opt_in_capturing();

--- a/lib/api/__tests__/chat-handler-request-validation.test.ts
+++ b/lib/api/__tests__/chat-handler-request-validation.test.ts
@@ -71,6 +71,29 @@ describe("chat-handler request validation", () => {
     );
   });
 
+  it("rejects non-string text before token counting", () => {
+    expect(() =>
+      requireChatMessagesArray([
+        {
+          id: "message-1",
+          role: "user",
+          parts: [{ type: "text", text: ["not", "text"] }],
+        },
+      ]),
+    ).toThrow(
+      expect.objectContaining({
+        type: "bad_request",
+        surface: "api",
+        statusCode: 400,
+        metadata: expect.objectContaining({
+          invalid_request_field: "messages[0].parts[0].text",
+          invalid_request_field_type: "array",
+          invalid_request_field_reason: "invalid_text",
+        }),
+      }),
+    );
+  });
+
   it("returns valid UI messages unchanged", () => {
     const messages = [
       {

--- a/lib/api/__tests__/chat-handler-request-validation.test.ts
+++ b/lib/api/__tests__/chat-handler-request-validation.test.ts
@@ -71,28 +71,31 @@ describe("chat-handler request validation", () => {
     );
   });
 
-  it("rejects non-string text before token counting", () => {
-    expect(() =>
-      requireChatMessagesArray([
-        {
-          id: "message-1",
-          role: "user",
-          parts: [{ type: "text", text: ["not", "text"] }],
-        },
-      ]),
-    ).toThrow(
-      expect.objectContaining({
-        type: "bad_request",
-        surface: "api",
-        statusCode: 400,
-        metadata: expect.objectContaining({
-          invalid_request_field: "messages[0].parts[0].text",
-          invalid_request_field_type: "array",
-          invalid_request_field_reason: "invalid_text",
+  it.each(["text", "reasoning"] as const)(
+    "rejects non-string %s before token counting",
+    (partType) => {
+      expect(() =>
+        requireChatMessagesArray([
+          {
+            id: "message-1",
+            role: "user",
+            parts: [{ type: partType, text: ["not", "text"] }],
+          },
+        ]),
+      ).toThrow(
+        expect.objectContaining({
+          type: "bad_request",
+          surface: "api",
+          statusCode: 400,
+          metadata: expect.objectContaining({
+            invalid_request_field: "messages[0].parts[0].text",
+            invalid_request_field_type: "array",
+            invalid_request_field_reason: "invalid_text",
+          }),
         }),
-      }),
-    );
-  });
+      );
+    },
+  );
 
   it("returns valid UI messages unchanged", () => {
     const messages = [

--- a/lib/api/agent-resume-route.ts
+++ b/lib/api/agent-resume-route.ts
@@ -31,6 +31,26 @@ export const createAgentResumeGet =
       req.headers.get("x-request-id") ??
       req.headers.get("x-vercel-id") ??
       undefined;
+    const requestStartedAt = Date.now();
+    const slowRequestInterval = setInterval(() => {
+      console.warn(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          level: "warn",
+          event: "agent_resume_slow_request",
+          service: "hackerai-web",
+          environment:
+            process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+          endpoint,
+          request_id: requestId,
+          user_id: userId,
+          chat_id: chatId,
+          trigger_run_id: runId,
+          stage,
+          elapsed_ms: Date.now() - requestStartedAt,
+        }),
+      );
+    }, 10_000);
 
     try {
       const authContext = await getUserIDAndPro(req);
@@ -100,5 +120,7 @@ export const createAgentResumeGet =
           stage,
         },
       });
+    } finally {
+      clearInterval(slowRequestInterval);
     }
   };

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1705,10 +1705,67 @@ export const createChatHandler = () => {
                       preemptiveTimeout?.isPreemptive() ?? false;
                     const onFinishStartTime = Date.now();
                     const triggerTime = preemptiveTimeout?.getTriggerTime();
+                    const cleanupRequestId =
+                      req.headers.get("x-request-id") ??
+                      req.headers.get("x-vercel-id") ??
+                      undefined;
+
+                    const logCleanupStage = ({
+                      phase,
+                      step,
+                      stepStartTime,
+                    }: {
+                      phase: "started" | "completed";
+                      step: string;
+                      stepStartTime: number;
+                    }) => {
+                      if (!isPreemptiveAbort) return;
+
+                      console.info(
+                        JSON.stringify({
+                          timestamp: new Date().toISOString(),
+                          level: "info",
+                          event: "preemptive_timeout_cleanup_stage",
+                          service: "chat-handler",
+                          environment:
+                            process.env.VERCEL_ENV ??
+                            process.env.NODE_ENV ??
+                            "unknown",
+                          request_id: cleanupRequestId,
+                          user_id: userId,
+                          chat_id: chatId,
+                          endpoint,
+                          phase,
+                          stage: step,
+                          stage_duration_ms:
+                            phase === "completed"
+                              ? Date.now() - stepStartTime
+                              : undefined,
+                          elapsed_since_timeout_ms: triggerTime
+                            ? Date.now() - triggerTime
+                            : null,
+                        }),
+                      );
+                    };
+
+                    const beginStep = (step: string): number => {
+                      const stepStartTime = Date.now();
+                      logCleanupStage({
+                        phase: "started",
+                        step,
+                        stepStartTime,
+                      });
+                      return stepStartTime;
+                    };
 
                     // Helper to log step timing during preemptive timeout
                     const logStep = (step: string, stepStartTime: number) => {
                       if (isPreemptiveAbort) {
+                        logCleanupStage({
+                          phase: "completed",
+                          step,
+                          stepStartTime,
+                        });
                         const stepDuration = Date.now() - stepStartTime;
                         const totalElapsed =
                           Date.now() - (triggerTime || onFinishStartTime);
@@ -1735,12 +1792,12 @@ export const createChatHandler = () => {
                     }
 
                     // Clear pre-emptive timeout
-                    let stepStart = Date.now();
+                    let stepStart = beginStep("clear_timeout");
                     preemptiveTimeout?.clear();
                     logStep("clear_timeout", stepStart);
 
                     // Stop cancellation subscriber
-                    stepStart = Date.now();
+                    stepStart = beginStep("stop_cancellation_subscriber");
                     await cancellationSubscriber.stop();
                     subscriberStopped = true;
                     logStep("stop_cancellation_subscriber", stepStart);
@@ -1757,7 +1814,7 @@ export const createChatHandler = () => {
                     }
 
                     // Emit wide event
-                    stepStart = Date.now();
+                    stepStart = beginStep("settle_usage_and_emit_success");
                     const sandboxInfo = sandboxManager.getSandboxInfo();
                     chatLogger!.setSandbox(sandboxInfo);
                     chatLogger!.setCacheMetrics({
@@ -1790,19 +1847,19 @@ export const createChatHandler = () => {
                       wasPreemptiveTimeout: isPreemptiveAbort,
                       hadSummarization: summarizationTracker.hasSummarized,
                     });
-                    logStep("emit_success_event", stepStart);
+                    logStep("settle_usage_and_emit_success", stepStart);
 
                     // Sandbox cleanup is automatic with auto-pause
                     // The sandbox will auto-pause after inactivity timeout (7 minutes)
                     // No manual pause needed
 
                     // Always wait for title generation to complete
-                    stepStart = Date.now();
+                    stepStart = beginStep("wait_title_generation");
                     const generatedTitle = await titlePromise;
                     logStep("wait_title_generation", stepStart);
 
                     if (!temporary) {
-                      stepStart = Date.now();
+                      stepStart = beginStep("merge_todos");
                       const mergedTodos = getTodoManager().mergeWith(
                         baseTodos,
                         assistantMessageId,
@@ -1819,7 +1876,7 @@ export const createChatHandler = () => {
 
                       if (shouldPersist) {
                         // updateChat automatically clears stream state (active_stream_id and canceled_at)
-                        stepStart = Date.now();
+                        stepStart = beginStep("update_chat");
                         await updateChat({
                           chatId,
                           title: generatedTitle,
@@ -1832,12 +1889,12 @@ export const createChatHandler = () => {
                         logStep("update_chat", stepStart);
                       } else {
                         // If not persisting, still need to clear stream state
-                        stepStart = Date.now();
+                        stepStart = beginStep("prepare_for_new_stream");
                         await prepareForNewStream({ chatId });
                         logStep("prepare_for_new_stream", stepStart);
                       }
 
-                      stepStart = Date.now();
+                      stepStart = beginStep("get_accumulated_files");
                       const accumulatedFiles = getFileAccumulator().getAll();
                       const newFileIds = accumulatedFiles.map((f) => f.fileId);
                       logStep("get_accumulated_files", stepStart);
@@ -1885,6 +1942,7 @@ export const createChatHandler = () => {
                       let resolvedUsage: Record<string, unknown> | undefined =
                         state.streamUsage;
                       if (!resolvedUsage && isAborted) {
+                        stepStart = beginStep("resolve_stream_usage");
                         try {
                           resolvedUsage = (await result.usage) as Record<
                             string,
@@ -1892,6 +1950,8 @@ export const createChatHandler = () => {
                           >;
                         } catch {
                           // Usage unavailable on abort - continue without it
+                        } finally {
+                          logStep("resolve_stream_usage", stepStart);
                         }
                       }
 
@@ -1945,7 +2005,7 @@ export const createChatHandler = () => {
                       }
 
                       // Save messages (either full save or just append extraFileIds)
-                      stepStart = Date.now();
+                      stepStart = beginStep("save_messages");
                       for (const message of messages) {
                         let processedMessage =
                           summarizationTracker.processMessageForSave(message);
@@ -2037,18 +2097,18 @@ export const createChatHandler = () => {
 
                       // Send file metadata via stream for resumable stream clients
                       // Uses accumulated metadata directly - no DB query needed!
-                      stepStart = Date.now();
+                      stepStart = beginStep("send_file_metadata");
                       sendFileMetadataToStream(accumulatedFiles);
                       logStep("send_file_metadata", stepStart);
                     } else {
                       // For temporary chats, send file metadata via stream before cleanup
-                      stepStart = Date.now();
+                      stepStart = beginStep("send_temp_file_metadata");
                       const tempFiles = getFileAccumulator().getAll();
                       sendFileMetadataToStream(tempFiles);
                       logStep("send_temp_file_metadata", stepStart);
 
                       // Ensure temp stream row is removed backend-side
-                      stepStart = Date.now();
+                      stepStart = beginStep("delete_temp_stream");
                       await deleteTempStreamForBackend({ chatId });
                       logStep("delete_temp_stream", stepStart);
                     }
@@ -2063,7 +2123,9 @@ export const createChatHandler = () => {
                           ? Date.now() - triggerTime
                           : null,
                       });
+                      stepStart = beginStep("flush_telemetry");
                       await phLogger.flush();
+                      logStep("flush_telemetry", stepStart);
                     }
 
                     const autoContinueStopSource =

--- a/lib/api/chat-request-validation.ts
+++ b/lib/api/chat-request-validation.ts
@@ -79,6 +79,17 @@ export const requireChatMessagesArray = (messages: unknown): UIMessage[] => {
           "invalid_type",
         );
       }
+
+      if (
+        (part.type === "text" || part.type === "reasoning") &&
+        typeof part.text !== "string"
+      ) {
+        throw invalidMessagesError(
+          `${partField}.text`,
+          part.text,
+          "invalid_text",
+        );
+      }
     }
   }
 

--- a/lib/billing/__tests__/stripe-terminal-errors.test.ts
+++ b/lib/billing/__tests__/stripe-terminal-errors.test.ts
@@ -1,0 +1,41 @@
+import {
+  isTerminalPaymentMethodDetachError,
+  isTerminalStripeResourceError,
+} from "@/lib/billing/stripe-terminal-errors";
+
+describe("Stripe terminal error classification", () => {
+  it("treats missing resources as an idempotent terminal state", () => {
+    const error = {
+      type: "StripeInvalidRequestError",
+      code: "resource_missing",
+      message: "No such payment method",
+    };
+
+    expect(isTerminalStripeResourceError(error)).toBe(true);
+    expect(isTerminalPaymentMethodDetachError(error)).toBe(true);
+  });
+
+  it("treats an already-detached payment method as terminal", () => {
+    const error = {
+      type: "StripeInvalidRequestError",
+      message:
+        "The payment method pm_123 is not attached to a customer so detachment is impossible.",
+    };
+
+    expect(isTerminalPaymentMethodDetachError(error)).toBe(true);
+  });
+
+  it("keeps other Stripe failures retriable", () => {
+    const invalidRequest = {
+      type: "StripeInvalidRequestError",
+      message: "Payment method belongs to another customer",
+    };
+    const apiError = {
+      type: "StripeAPIError",
+      message: "Stripe is unavailable",
+    };
+
+    expect(isTerminalPaymentMethodDetachError(invalidRequest)).toBe(false);
+    expect(isTerminalPaymentMethodDetachError(apiError)).toBe(false);
+  });
+});

--- a/lib/billing/stripe-terminal-errors.ts
+++ b/lib/billing/stripe-terminal-errors.ts
@@ -1,0 +1,27 @@
+const ALREADY_DETACHED_PAYMENT_METHOD_MESSAGE =
+  "is not attached to a customer so detachment is impossible";
+
+const getStripeErrorField = (error: unknown, field: string) =>
+  error && typeof error === "object"
+    ? (error as Record<string, unknown>)[field]
+    : undefined;
+
+const hasStripeErrorType = (error: unknown, expectedType?: string): boolean => {
+  const type = getStripeErrorField(error, "type");
+  return (
+    typeof type === "string" &&
+    (expectedType ? type === expectedType : type.startsWith("Stripe"))
+  );
+};
+
+export const isTerminalStripeResourceError = (error: unknown): boolean =>
+  hasStripeErrorType(error) &&
+  getStripeErrorField(error, "code") === "resource_missing";
+
+export const isTerminalPaymentMethodDetachError = (error: unknown): boolean =>
+  isTerminalStripeResourceError(error) ||
+  (hasStripeErrorType(error, "StripeInvalidRequestError") &&
+    typeof getStripeErrorField(error, "message") === "string" &&
+    (getStripeErrorField(error, "message") as string).includes(
+      ALREADY_DETACHED_PAYMENT_METHOD_MESSAGE,
+    ));

--- a/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
+++ b/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
@@ -168,6 +168,47 @@ describe("shouldDropExpectedFrontendException", () => {
     ).toBe(false);
   });
 
+  it("drops exceptions whose frames come only from injected third-party scripts", () => {
+    for (const source of [
+      "moz-extension://example/userscripts/user.js",
+      "chrome-extension://example/content.js",
+      "iabjs://navigation_performance_logger_android",
+    ]) {
+      expect(
+        shouldDropExpectedFrontendException({
+          event: "$exception",
+          properties: {
+            $exception_values: ["Injected script failure"],
+            $exception_list: [
+              { stacktrace: { frames: [{ source }, { filename: source }] } },
+            ],
+          },
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("keeps exceptions with both injected and application frames", () => {
+    expect(
+      shouldDropExpectedFrontendException({
+        event: "$exception",
+        properties: {
+          $exception_values: ["Application failure"],
+          $exception_list: [
+            {
+              stacktrace: {
+                frames: [
+                  { source: "moz-extension://example/userscripts/user.js" },
+                  { source: "turbopack:///[project]/app/components/chat.tsx" },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
+  });
+
   it("keeps non-stale server action failures", () => {
     expect(
       shouldDropExpectedFrontendException({

--- a/lib/posthog/expected-frontend-exceptions.ts
+++ b/lib/posthog/expected-frontend-exceptions.ts
@@ -67,6 +67,14 @@ const NEXT_GENERATED_CHUNK_SOURCE_PATTERN =
   /^(?:https?:\/\/[^/]+)?\/_next\/static\/chunks\/[^?\s]+\.js(?:\?[^#\s]*)?(?::\d+){0,2}$/i;
 const VERCEL_DEPLOYMENT_ID_PATTERN = /[?&]dpl=(dpl_[A-Za-z0-9]+)/;
 
+const INJECTED_THIRD_PARTY_SOURCE_PREFIXES = [
+  "chrome-extension://",
+  "moz-extension://",
+  "safari-web-extension://",
+  "ms-browser-extension://",
+  "iabjs://",
+];
+
 const STALE_SERVER_ACTION_MESSAGE_FRAGMENTS = [
   "Failed to find Server Action",
   "was not found on the server",
@@ -172,6 +180,14 @@ const hasOnlyNextGeneratedChunkFrames = (frameSources: string[]): boolean =>
     NEXT_GENERATED_CHUNK_SOURCE_PATTERN.test(source),
   );
 
+const hasOnlyInjectedThirdPartyFrames = (frameSources: string[]): boolean =>
+  frameSources.length > 0 &&
+  frameSources.every((source) =>
+    INJECTED_THIRD_PARTY_SOURCE_PREFIXES.some((prefix) =>
+      source.toLowerCase().startsWith(prefix),
+    ),
+  );
+
 const hasOnlyExpectedNextServerActionFrames = (
   frameSources: string[],
 ): boolean =>
@@ -267,6 +283,7 @@ export function shouldDropExpectedFrontendException(event: PostHogEventLike) {
     matchesBareBrowserTransportPattern(strings, frameSources) ||
     matchesNextServerActionTransportPattern(strings, frameSources) ||
     matchesStaleServerActionPattern(strings, frameSources) ||
+    hasOnlyInjectedThirdPartyFrames(frameSources) ||
     hasChunkLoadMessage(strings) ||
     hasExactStringFrom(strings, MANUAL_CHAT_STOP_ABORT_MESSAGES) ||
     hasExactStringFrom(strings, REACT_DOM_MUTATION_MESSAGES) ||


### PR DESCRIPTION
## Summary

- ensure the PostHog exception filter and diagnostic enrichment are applied even when the shared browser client was initialized before the provider mounted
- suppress browser-extension and injected in-app-browser exceptions only when every stack frame is third-party
- return a 400 for malformed non-string chat text before gpt-tokenizer treats it as a chat payload
- treat Stripe's exact already-detached payment-method response as an idempotent fraud-webhook terminal state
- emit immediate structured stage logs for preemptive chat cleanup and slow agent-resume requests so Vercel hard timeouts identify the pending operation

## Production audit classification

### Suppress

- generic browser and Next server-action transport failures already covered by the classifier
- extension-only and iabjs-only injected stacks added here
- existing expected chunk, stale server-action, auth-refresh, ResizeObserver, manual-abort, and stream-close noise

### Fix

- PostHog before_send was absent from live events when the singleton was already loaded
- malformed UI text parts reached gpt-tokenizer and produced a server error instead of a client error
- fraud webhook retries returned 500 when Stripe reported a payment method was already detached

### Keep and diagnose

- React 185, React 327, and stack-overflow exceptions remain captured because they represent application/runtime invariants
- chat preemptive cleanup and agent-resume timeouts now emit stages immediately to Vercel logs before a hard kill
- transient Convex, ETIMEDOUT, stale WorkOS-session, and malformed scanner/server-action events remain unsuppressed in server logs because they are low-volume or operationally meaningful

## Validation

- pnpm typecheck
- pnpm lint (passes with six pre-existing warnings)
- full Jest suite: 230 suites, 2,325 tests passed
- no visual verification required because this is backend validation and telemetry behavior only

## Manual verification

1. In a preview authenticated session, capture a retained frontend exception and confirm the PostHog event contains hackerai_exception_category and route/network diagnostics.
2. Replay a fraud webhook after its payment method is already detached and confirm the handler logs the terminal skip and completes successfully.
3. If a chat reaches its preemptive timeout, filter Vercel logs for preemptive_timeout_cleanup_stage and confirm the last started stage identifies any pending cleanup operation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of already-resolved Stripe billing errors, preventing unnecessary retries during subscription cancellation and payment-method removal.
  - Chat requests now reject malformed text and reasoning message content with clearer validation errors.
  - Reduced noise from expected frontend errors caused solely by browser extensions or injected scripts.
  - Improved PostHog exception tracking behavior for both new and already-initialized sessions.

- **Monitoring**
  - Added detailed diagnostics for slow agent-resume requests and chat cleanup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->