### PR TITLE
Add served-model telemetry to Agent analytics

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -639,6 +639,12 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(/createPaidDailyFreeAllowanceBudgetSnapshot/);
     expect(taskSrc).toMatch(/recordPaidDailyFreeAllowanceCost/);
     expect(taskSrc).toMatch(/serializeChatSDKErrorForStream/);
+    expect(taskSrc).toMatch(
+      /selected_model:\s*selectedModel,\s*response_model:\s*state\.responseModel,/,
+    );
+    expect(chatHandlerSrc).toMatch(
+      /selected_model:\s*selectedModel,\s*response_model:\s*state\.responseModel,/,
+    );
   });
 
   test("uses a turn-scoped Trigger idempotency key for agent runs", () => {

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -878,6 +878,52 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(fallbackIdx).toBeGreaterThan(retryModelIdx);
   });
 
+  test("retry streams reset served-model telemetry and distinguish same-model recovery", () => {
+    for (const source of [taskSrc, chatHandlerSrc]) {
+      expect(
+        source.match(/resetServedModelTelemetryForRetry\(state\)/g),
+      ).toHaveLength(2);
+
+      const retryModelIdx = source.indexOf(
+        "const retryModel = shouldRetryWithoutImageToolResults",
+      );
+      const modelSwitchIdx = source.indexOf(
+        "retryUsedFallbackModel = retryUsesDifferentModel(",
+        retryModelIdx,
+      );
+      const resetIdx = source.indexOf(
+        "resetServedModelTelemetryForRetry(state)",
+        modelSwitchIdx,
+      );
+      const retryStreamIdx = source.indexOf(
+        "createStream(retryModel)",
+        resetIdx,
+      );
+
+      expect(modelSwitchIdx).toBeGreaterThan(retryModelIdx);
+      expect(resetIdx).toBeGreaterThan(modelSwitchIdx);
+      expect(retryStreamIdx).toBeGreaterThan(resetIdx);
+    }
+  });
+
+  test("assistant-loop abort telemetry uses the multimodal fallback chain", () => {
+    const abortStateIdx = agentStreamRunnerSrc.indexOf(
+      "const recordAssistantContentLoopAbortState",
+    );
+    const fallbackTelemetryIdx = agentStreamRunnerSrc.indexOf(
+      "state.fallbackServed = resolveFallbackServedTelemetry",
+      abortStateIdx,
+    );
+    const multimodalFallbackIdx = agentStreamRunnerSrc.indexOf(
+      "hasMultimodalToolResults: streamHasImageViewResults",
+      fallbackTelemetryIdx,
+    );
+
+    expect(abortStateIdx).toBeGreaterThan(-1);
+    expect(fallbackTelemetryIdx).toBeGreaterThan(abortStateIdx);
+    expect(multimodalFallbackIdx).toBeGreaterThan(fallbackTelemetryIdx);
+  });
+
   test("agent stream applies per-step OpenRouter metadata cost before budget checks", () => {
     const onStepFinishIdx = agentStreamRunnerSrc.indexOf(
       "onStepFinish: async ({ usage, response, providerMetadata }) => {",

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -884,6 +884,22 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
         source.match(/resetServedModelTelemetryForRetry\(state\)/g),
       ).toHaveLength(2);
 
+      const catchModelSwitchIdx = source.indexOf(
+        "retryUsedFallbackModel = retryUsesDifferentModel(",
+      );
+      const catchResetIdx = source.indexOf(
+        "resetServedModelTelemetryForRetry(state)",
+        catchModelSwitchIdx,
+      );
+      const catchRetryStreamIdx = source.indexOf(
+        "createStream(fallbackModel)",
+        catchResetIdx,
+      );
+
+      expect(catchModelSwitchIdx).toBeGreaterThan(-1);
+      expect(catchResetIdx).toBeGreaterThan(catchModelSwitchIdx);
+      expect(catchRetryStreamIdx).toBeGreaterThan(catchResetIdx);
+
       const retryModelIdx = source.indexOf(
         "const retryModel = shouldRetryWithoutImageToolResults",
       );

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -95,8 +95,10 @@ jest.mock("@/lib/utils/error-utils", () => ({
 const {
   createAgentStream,
   initAgentStreamState,
+  resetServedModelTelemetryForRetry,
   resolveAgentModelForImageToolResults,
   resolveFallbackServedTelemetry,
+  retryUsesDifferentModel,
 }: typeof import("@/lib/api/agent-stream-runner") = require("@/lib/api/agent-stream-runner");
 
 const uiMessage = (id: string, text: string): UIMessage => ({
@@ -231,6 +233,31 @@ describe("resolveFallbackServedTelemetry", () => {
         fallbackModels: ["x-ai/grok-4.5"],
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("retry served-model telemetry", () => {
+  it("does not label a same-model image recovery as a fallback model retry", () => {
+    expect(
+      retryUsesDifferentModel("agent-model-free", "agent-model-free"),
+    ).toBe(false);
+    expect(
+      retryUsesDifferentModel("agent-model-free", "model-minimax-m3"),
+    ).toBe(true);
+  });
+
+  it("clears prior served-model state before a retry can abort without metadata", () => {
+    const state = {
+      responseModel: "deepseek/deepseek-v4-flash",
+      fallbackServed: false,
+    };
+
+    resetServedModelTelemetryForRetry(state);
+
+    expect(state).toEqual({
+      responseModel: undefined,
+      fallbackServed: undefined,
+    });
   });
 });
 

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -96,6 +96,7 @@ const {
   createAgentStream,
   initAgentStreamState,
   resolveAgentModelForImageToolResults,
+  resolveFallbackServedTelemetry,
 }: typeof import("@/lib/api/agent-stream-runner") = require("@/lib/api/agent-stream-runner");
 
 const uiMessage = (id: string, text: string): UIMessage => ({
@@ -185,6 +186,51 @@ describe("resolveAgentModelForImageToolResults", () => {
     expect(
       resolveAgentModelForImageToolResults("model-minimax-m3", "agent", true),
     ).toBe("model-minimax-m3");
+  });
+});
+
+describe("resolveFallbackServedTelemetry", () => {
+  it("returns false for the requested primary model", () => {
+    expect(
+      resolveFallbackServedTelemetry({
+        requestedModel: "deepseek/deepseek-v4-pro",
+        responseModel: "deepseek/deepseek-v4-pro",
+        fallbackModels: ["minimax/minimax-m3"],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true only for a configured fallback model", () => {
+    expect(
+      resolveFallbackServedTelemetry({
+        requestedModel: "deepseek/deepseek-v4-pro",
+        responseModel: "minimax/minimax-m3",
+        fallbackModels: ["minimax/minimax-m3"],
+      }),
+    ).toBe(true);
+    expect(
+      resolveFallbackServedTelemetry({
+        requestedModel: "minimax/minimax-m3",
+        responseModel: "minimax/minimax-m3",
+        fallbackModels: ["minimax/minimax-m3"],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns undefined without a response model or an exact route match", () => {
+    expect(
+      resolveFallbackServedTelemetry({
+        requestedModel: "anthropic/claude-opus-4.6",
+        fallbackModels: ["x-ai/grok-4.5"],
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveFallbackServedTelemetry({
+        requestedModel: "anthropic/claude-opus-4.6",
+        responseModel: "anthropic/claude-4.6-opus-20260205",
+        fallbackModels: ["x-ai/grok-4.5"],
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -84,6 +84,10 @@ describe("captureAgentRun", () => {
       subscription: "pro",
       sandboxInfo: { type: "remote-connection", name: "Work laptop" },
       outcome: "success",
+      selectedModel: "agent-model",
+      configuredModelId: "deepseek/deepseek-v4-pro",
+      responseModel: "deepseek/deepseek-v4-pro",
+      fallbackServed: false,
     });
 
     expect(capture).toHaveBeenCalledWith({
@@ -94,10 +98,66 @@ describe("captureAgentRun", () => {
         subscription: "pro",
         subscription_tier: "pro",
         outcome: "success",
+        selected_model: "agent-model",
+        configured_model: "deepseek/deepseek-v4-pro",
+        response_model: "deepseek/deepseek-v4-pro",
+        fallback_served: false,
         sandboxType: "remote-connection",
         sandbox_type: "remote-connection",
       },
     });
+  });
+
+  it("attributes a served fallback without inferring it from model names", () => {
+    const capture = jest.fn();
+
+    captureAgentRun({
+      posthog: { capture } as any,
+      userId: "user_123",
+      mode: "agent",
+      subscription: "free",
+      sandboxInfo: { type: "e2b" },
+      outcome: "success",
+      selectedModel: "agent-model-free",
+      configuredModelId: "deepseek/deepseek-v4-flash",
+      responseModel: "minimax/minimax-m3",
+      fallbackServed: true,
+    });
+
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      event: "hackerai-agent_run",
+      properties: expect.objectContaining({
+        selected_model: "agent-model-free",
+        configured_model: "deepseek/deepseek-v4-flash",
+        response_model: "minimax/minimax-m3",
+        fallback_served: true,
+      }),
+    });
+  });
+
+  it("omits served-model attribution when the provider reports no response model", () => {
+    const capture = jest.fn();
+
+    captureAgentRun({
+      posthog: { capture } as any,
+      userId: "user_123",
+      mode: "agent",
+      subscription: "pro",
+      sandboxInfo: null,
+      outcome: "error",
+      selectedModel: "agent-model",
+      configuredModelId: "deepseek/deepseek-v4-pro",
+      fallbackServed: false,
+    });
+
+    const properties = capture.mock.calls[0][0].properties;
+    expect(properties).toMatchObject({
+      selected_model: "agent-model",
+      configured_model: "deepseek/deepseek-v4-pro",
+    });
+    expect(properties).not.toHaveProperty("response_model");
+    expect(properties).not.toHaveProperty("fallback_served");
   });
 
   it("does not capture agent run events for ask mode", () => {
@@ -110,6 +170,10 @@ describe("captureAgentRun", () => {
       subscription: "pro",
       sandboxInfo: { type: "e2b" },
       outcome: "success",
+      selectedModel: "agent-model",
+      configuredModelId: "deepseek/deepseek-v4-pro",
+      responseModel: "deepseek/deepseek-v4-pro",
+      fallbackServed: false,
     });
 
     expect(capture).not.toHaveBeenCalled();
@@ -269,6 +333,10 @@ describe("captureAgentCompletionAnalytics", () => {
       sandboxInfo: { type: "e2b" },
       outcome: "success",
       chatLogger: { getToolCalls: () => [{ name: "web_search" }] } as any,
+      selectedModel: "agent-model-free",
+      configuredModelId: "deepseek/deepseek-v4-flash",
+      responseModel: "deepseek/deepseek-v4-flash",
+      fallbackServed: false,
     });
 
     expect(capture).toHaveBeenCalledTimes(2);
@@ -280,6 +348,10 @@ describe("captureAgentCompletionAnalytics", () => {
         subscription: "free",
         subscription_tier: "free",
         outcome: "success",
+        selected_model: "agent-model-free",
+        configured_model: "deepseek/deepseek-v4-flash",
+        response_model: "deepseek/deepseek-v4-flash",
+        fallback_served: false,
         sandboxType: "e2b",
         sandbox_type: "e2b",
       },
@@ -311,6 +383,10 @@ describe("captureAgentCompletionAnalytics", () => {
       sandboxInfo: { type: "e2b" },
       outcome: "success",
       chatLogger: { getToolCalls: () => [{ name: "web_search" }] } as any,
+      selectedModel: "agent-model",
+      configuredModelId: "deepseek/deepseek-v4-pro",
+      responseModel: "deepseek/deepseek-v4-pro",
+      fallbackServed: false,
     });
 
     expect(capture).toHaveBeenCalledTimes(1);
@@ -322,6 +398,10 @@ describe("captureAgentCompletionAnalytics", () => {
         subscription: "pro",
         subscription_tier: "pro",
         outcome: "success",
+        selected_model: "agent-model",
+        configured_model: "deepseek/deepseek-v4-pro",
+        response_model: "deepseek/deepseek-v4-pro",
+        fallback_served: false,
         sandboxType: "e2b",
         sandbox_type: "e2b",
       },
@@ -330,7 +410,7 @@ describe("captureAgentCompletionAnalytics", () => {
 });
 
 describe("captureUsageCost", () => {
-  it("captures a user-scoped cost event with queryable dollar fields", () => {
+  it("keeps model=auto while adding the actual served model and allowance fields", () => {
     const capture = jest.fn();
 
     captureUsageCost({
@@ -341,8 +421,9 @@ describe("captureUsageCost", () => {
       chatId: "chat_123",
       endpoint: "/api/chat",
       mode: "agent",
+      responseModel: "deepseek/deepseek-v4-pro",
       usage: {
-        model: "claude-sonnet",
+        model: "auto",
         type: "extra",
         inputTokens: 1000,
         outputTokens: 500,
@@ -381,7 +462,8 @@ describe("captureUsageCost", () => {
         chat_id: "chat_123",
         endpoint: "/api/chat",
         mode: "agent",
-        model: "claude-sonnet",
+        model: "auto",
+        response_model: "deepseek/deepseek-v4-pro",
         usage_type: "extra",
         cost_dollars: 0.42,
         included_cost_dollars: 0.1,
@@ -408,6 +490,41 @@ describe("captureUsageCost", () => {
         }),
       }),
     });
+  });
+
+  it("omits response_model when served-model metadata is unavailable", () => {
+    const capture = jest.fn();
+
+    captureUsageCost({
+      posthog: { capture } as any,
+      userId: "user_123",
+      subscription: "pro",
+      chatId: "chat_123",
+      endpoint: "/api/chat",
+      mode: "agent",
+      usage: {
+        model: "auto",
+        type: "included",
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+        costDollars: 0.01,
+        includedCostDollars: 0.01,
+        extraUsageCostDollars: 0,
+        uncoveredCostDollars: 0,
+        includedPointsDeducted: 100,
+        extraUsagePointsDeducted: 0,
+        uncoveredPoints: 0,
+        usageDeductionFailed: false,
+        modelCostDollars: 0.01,
+        nonModelCostDollars: 0,
+        costSource: "provider",
+      },
+    });
+
+    expect(capture.mock.calls[0][0].properties).not.toHaveProperty(
+      "response_model",
+    );
   });
 });
 
@@ -804,8 +921,7 @@ describe("createChatLogger provider stream termination", () => {
       );
       const fields = posthogErrorCall?.[1] as { error?: unknown } | undefined;
       const capturedError = fields?.error as
-        | (Error & { cause?: unknown })
-        | undefined;
+        (Error & { cause?: unknown }) | undefined;
 
       expect(capturedError).toBeInstanceOf(Error);
       expect(capturedError?.name).toBe("AI_APICallError");

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -134,6 +134,11 @@ export const resolveFallbackServedTelemetry = ({
   return fallbackModels.includes(responseModel) ? true : undefined;
 };
 
+export const retryUsesDifferentModel = (
+  selectedModel: string,
+  retryModel: string,
+): boolean => retryModel !== selectedModel;
+
 export type RollingModelContextCheckpoint = {
   /** Latest compacted provider context, excluding later raw SDK responses. */
   baseMessages: ModelMessage[];
@@ -230,6 +235,13 @@ export function initAgentStreamState(
     budgetAbortDetails: undefined,
   };
 }
+
+export const resetServedModelTelemetryForRetry = (
+  state: Pick<AgentStreamState, "responseModel" | "fallbackServed">,
+): void => {
+  state.responseModel = undefined;
+  state.fallbackServed = undefined;
+};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -551,7 +563,9 @@ export async function createAgentStream(
     state.fallbackServed = resolveFallbackServedTelemetry({
       requestedModel: lastRequestedSlug,
       responseModel: state.responseModel,
-      fallbackModels: getFallbackSlugs(modelName, ctx.mode),
+      fallbackModels: getFallbackSlugs(modelName, ctx.mode, {
+        hasMultimodalToolResults: streamHasImageViewResults,
+      }),
     });
 
     const openRouterMetadata = lastStep

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -120,6 +120,20 @@ export const resolveAgentModelForImageToolResults = (
     : modelName;
 };
 
+export const resolveFallbackServedTelemetry = ({
+  requestedModel,
+  responseModel,
+  fallbackModels,
+}: {
+  requestedModel: string;
+  responseModel?: string;
+  fallbackModels: string[];
+}): boolean | undefined => {
+  if (!responseModel) return undefined;
+  if (responseModel === requestedModel) return false;
+  return fallbackModels.includes(responseModel) ? true : undefined;
+};
+
 export type RollingModelContextCheckpoint = {
   /** Latest compacted provider context, excluding later raw SDK responses. */
   baseMessages: ModelMessage[];
@@ -166,6 +180,8 @@ export type AgentStreamState = {
   streamFinishReason: string | undefined;
   streamUsage: Record<string, unknown> | undefined;
   responseModel: string | undefined;
+  /** Set only when provider/retry state can identify fallback serving. */
+  fallbackServed: boolean | undefined;
   /** Original provider/AI SDK error captured from streamText.onError. */
   providerError: unknown;
   /** True when a provider rejected an image-bearing tool result. */
@@ -197,6 +213,7 @@ export function initAgentStreamState(
     streamFinishReason: undefined,
     streamUsage: undefined,
     responseModel: undefined,
+    fallbackServed: undefined,
     providerError: undefined,
     providerRejectedMultimodalToolResults: false,
     stoppedDueToTokenExhaustion: false,
@@ -531,6 +548,11 @@ export async function createAgentStream(
     }
     state.responseModel = lastStep?.response?.modelId ?? state.responseModel;
     state.responseModel ??= lastRequestedSlug;
+    state.fallbackServed = resolveFallbackServedTelemetry({
+      requestedModel: lastRequestedSlug,
+      responseModel: state.responseModel,
+      fallbackModels: getFallbackSlugs(modelName, ctx.mode),
+    });
 
     const openRouterMetadata = lastStep
       ? extractOpenRouterMetadata({
@@ -1274,7 +1296,12 @@ export async function createAgentStream(
       const fallbackSlugs = getFallbackSlugs(modelName, ctx.mode, {
         hasMultimodalToolResults: streamHasImageViewResults,
       });
-      if (state.responseModel && fallbackSlugs.includes(state.responseModel)) {
+      state.fallbackServed = resolveFallbackServedTelemetry({
+        requestedModel: lastRequestedSlug,
+        responseModel: state.responseModel,
+        fallbackModels: fallbackSlugs,
+      });
+      if (state.fallbackServed && state.responseModel) {
         ctx.chatLogger?.recordModelFallback({
           requested: requestedSlug,
           served: state.responseModel,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -162,6 +162,8 @@ import { isAgentMode } from "@/lib/utils/mode-helpers";
 import {
   createAgentStream,
   initAgentStreamState,
+  resetServedModelTelemetryForRetry,
+  retryUsesDifferentModel,
   type AgentStreamContext,
 } from "@/lib/api/agent-stream-runner";
 import {
@@ -859,6 +861,7 @@ export const createChatHandler = () => {
               : null;
 
             let isRetryWithFallback = false;
+            let retryUsedFallbackModel = false;
             const isAutoModel = isAutoModelSelectionForRetry({
               selectedModel,
               selectedModelOverride,
@@ -1285,6 +1288,11 @@ export const createChatHandler = () => {
                 });
 
                 isRetryWithFallback = true;
+                retryUsedFallbackModel = retryUsesDifferentModel(
+                  selectedModel,
+                  fallbackModel,
+                );
+                resetServedModelTelemetryForRetry(state);
                 state.lastStepInputTokens = 0;
                 state.stoppedDueToTokenExhaustion = false;
                 state.stoppedDueToElapsedTimeout = false;
@@ -1462,6 +1470,11 @@ export const createChatHandler = () => {
                         const retryModel = shouldRetryWithoutImageToolResults
                           ? selectedModel
                           : fallbackModel;
+                        retryUsedFallbackModel = retryUsesDifferentModel(
+                          selectedModel,
+                          retryModel,
+                        );
+                        resetServedModelTelemetryForRetry(state);
                         if (shouldRetryWithoutImageToolResults) {
                           state.finalMessages =
                             omitTrailingStepStartAssistantMessage(
@@ -1559,7 +1572,8 @@ export const createChatHandler = () => {
                                   configuredModelId,
                                   responseModel: state.responseModel,
                                   fallbackServed:
-                                    state.responseModel && isRetryWithFallback
+                                    state.responseModel &&
+                                    retryUsedFallbackModel
                                       ? true
                                       : state.fallbackServed,
                                   finishReason: state.streamFinishReason,
@@ -1793,7 +1807,7 @@ export const createChatHandler = () => {
                       configuredModelId,
                       responseModel: state.responseModel,
                       fallbackServed:
-                        state.responseModel && isRetryWithFallback
+                        state.responseModel && retryUsedFallbackModel
                           ? true
                           : state.fallbackServed,
                       finishReason: state.streamFinishReason,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1076,6 +1076,7 @@ export const createChatHandler = () => {
                   endpoint,
                   mode,
                   usage: usageCostRecord,
+                  responseModel: state.responseModel,
                   ...(paidDailyFreeAllowanceReservation && {
                     paidDailyFreeAllowance:
                       createPaidDailyFreeAllowanceUsageLogContext(
@@ -1554,6 +1555,13 @@ export const createChatHandler = () => {
                                   sandboxInfo,
                                   outcome,
                                   chatLogger,
+                                  selectedModel,
+                                  configuredModelId,
+                                  responseModel: state.responseModel,
+                                  fallbackServed:
+                                    state.responseModel && isRetryWithFallback
+                                      ? true
+                                      : state.fallbackServed,
                                   finishReason: state.streamFinishReason,
                                   budgetAbortDetails: state.budgetAbortDetails,
                                 });
@@ -1781,6 +1789,13 @@ export const createChatHandler = () => {
                       sandboxInfo,
                       outcome,
                       chatLogger,
+                      selectedModel,
+                      configuredModelId,
+                      responseModel: state.responseModel,
+                      fallbackServed:
+                        state.responseModel && isRetryWithFallback
+                          ? true
+                          : state.fallbackServed,
                       finishReason: state.streamFinishReason,
                       budgetAbortDetails: state.budgetAbortDetails,
                     });

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -602,9 +602,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
     recordAnthropicPromptRepair(repair: {
       action: "appended_continue" | "trimmed";
       reason:
-        | "useful_assistant_tail"
-        | "no_useful_content"
-        | "dangling_tool_call";
+        "useful_assistant_tail" | "no_useful_content" | "dangling_tool_call";
       trailingAssistantContentTypes?: string[];
       model: string;
     }) {
@@ -840,8 +838,7 @@ export function createChatLogger(config: ChatLoggerConfig) {
           (error.metadata?.capReason as LimitCapReason | undefined) ??
           "unknown";
         const resetTimestamp = error.metadata?.resetTimestamp as
-          | number
-          | undefined;
+          number | undefined;
         const subscriptionTier = isSubscriptionTier(subscription)
           ? subscription
           : undefined;
@@ -1181,6 +1178,10 @@ type AgentCompletionAnalyticsArgs = {
   sandboxInfo: SandboxInfo | null;
   outcome: AgentRunOutcome;
   chatLogger: ChatLogger | undefined;
+  selectedModel: string;
+  configuredModelId: string;
+  responseModel?: string;
+  fallbackServed?: boolean;
   finishReason?: string;
   budgetAbortDetails?: BudgetAbortDetails;
 };
@@ -1192,6 +1193,10 @@ export function captureAgentRun({
   subscription,
   sandboxInfo,
   outcome,
+  selectedModel,
+  configuredModelId,
+  responseModel,
+  fallbackServed,
   finishReason,
   budgetAbortDetails,
 }: {
@@ -1201,6 +1206,10 @@ export function captureAgentRun({
   subscription: string;
   sandboxInfo: SandboxInfo | null;
   outcome: AgentRunOutcome;
+  selectedModel: string;
+  configuredModelId: string;
+  responseModel?: string;
+  fallbackServed?: boolean;
   finishReason?: string;
   budgetAbortDetails?: BudgetAbortDetails;
 }) {
@@ -1213,6 +1222,11 @@ export function captureAgentRun({
       subscription,
       subscription_tier: subscription,
       outcome,
+      selected_model: selectedModel,
+      configured_model: configuredModelId,
+      ...(responseModel && { response_model: responseModel }),
+      ...(responseModel &&
+        fallbackServed !== undefined && { fallback_served: fallbackServed }),
       ...(sandboxInfo?.type && {
         sandboxType: sandboxInfo.type,
         sandbox_type: sandboxInfo.type,
@@ -1290,6 +1304,10 @@ export function captureAgentCompletionAnalytics(
     subscription,
     sandboxInfo,
     outcome,
+    selectedModel: args.selectedModel,
+    configuredModelId: args.configuredModelId,
+    responseModel: args.responseModel,
+    fallbackServed: args.fallbackServed,
     finishReason: args.finishReason,
     budgetAbortDetails: args.budgetAbortDetails,
   });
@@ -1310,6 +1328,7 @@ export function captureUsageCost({
   endpoint,
   mode,
   usage,
+  responseModel,
   paidDailyFreeAllowance,
 }: {
   posthog: PostHog | null;
@@ -1320,6 +1339,7 @@ export function captureUsageCost({
   endpoint: ChatApiEndpoint;
   mode: ChatMode;
   usage: UsageCostRecord;
+  responseModel?: string;
   paidDailyFreeAllowance?: {
     active: boolean;
     cutOff?: boolean;
@@ -1341,6 +1361,7 @@ export function captureUsageCost({
       endpoint,
       mode,
       model: usage.model,
+      ...(responseModel && { response_model: responseModel }),
       usage_type: usage.type,
       cost_dollars: usage.costDollars,
       included_cost_dollars: usage.includedCostDollars,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -138,6 +138,8 @@ import { canUseExtraUsage, normalizeMaxModelForSubscription } from "@/types";
 import {
   createAgentStream,
   initAgentStreamState,
+  resetServedModelTelemetryForRetry,
+  retryUsesDifferentModel,
   type AgentStreamContext,
   type AgentStreamState,
 } from "@/lib/api/agent-stream-runner";
@@ -1641,6 +1643,7 @@ export const agentLongTask = task({
               : null;
 
             let isRetryWithFallback = false;
+            let retryUsedFallbackModel = false;
             const isAutoModel = [
               "ask-model",
               "ask-model-free",
@@ -2058,6 +2061,11 @@ export const agentLongTask = task({
                   },
                 );
                 isRetryWithFallback = true;
+                retryUsedFallbackModel = retryUsesDifferentModel(
+                  selectedModel,
+                  fallbackModel,
+                );
+                resetServedModelTelemetryForRetry(state);
                 state.lastStepInputTokens = 0;
                 state.stoppedDueToTokenExhaustion = false;
                 state.stoppedDueToElapsedTimeout = false;
@@ -2221,6 +2229,11 @@ export const agentLongTask = task({
                         const retryModel = shouldRetryWithoutImageToolResults
                           ? selectedModel
                           : fallbackModel;
+                        retryUsedFallbackModel = retryUsesDifferentModel(
+                          selectedModel,
+                          retryModel,
+                        );
+                        resetServedModelTelemetryForRetry(state);
                         if (shouldRetryWithoutImageToolResults) {
                           const normalizedRetryMessages = imageRecovery.messages
                             .map((message) =>
@@ -2320,7 +2333,8 @@ export const agentLongTask = task({
                                     configuredModelId,
                                     responseModel: state.responseModel,
                                     fallbackServed:
-                                      state.responseModel && isRetryWithFallback
+                                      state.responseModel &&
+                                      retryUsedFallbackModel
                                         ? true
                                         : state.fallbackServed,
                                     finishReason: state.streamFinishReason,
@@ -2458,7 +2472,7 @@ export const agentLongTask = task({
                         configuredModelId,
                         responseModel: state.responseModel,
                         fallbackServed:
-                          state.responseModel && isRetryWithFallback
+                          state.responseModel && retryUsedFallbackModel
                             ? true
                             : state.fallbackServed,
                         finishReason: state.streamFinishReason,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1849,6 +1849,7 @@ export const agentLongTask = task({
                   endpoint,
                   mode,
                   usage: usageCostRecord,
+                  responseModel: state.responseModel,
                   ...(paidDailyFreeAllowanceReservation && {
                     paidDailyFreeAllowance:
                       createPaidDailyFreeAllowanceUsageLogContext(
@@ -2315,6 +2316,13 @@ export const agentLongTask = task({
                                     sandboxInfo,
                                     outcome,
                                     chatLogger,
+                                    selectedModel,
+                                    configuredModelId,
+                                    responseModel: state.responseModel,
+                                    fallbackServed:
+                                      state.responseModel && isRetryWithFallback
+                                        ? true
+                                        : state.fallbackServed,
                                     finishReason: state.streamFinishReason,
                                     budgetAbortDetails:
                                       state.budgetAbortDetails,
@@ -2446,6 +2454,13 @@ export const agentLongTask = task({
                         sandboxInfo,
                         outcome,
                         chatLogger,
+                        selectedModel,
+                        configuredModelId,
+                        responseModel: state.responseModel,
+                        fallbackServed:
+                          state.responseModel && isRetryWithFallback
+                            ? true
+                            : state.fallbackServed,
                         finishReason: state.streamFinishReason,
                         budgetAbortDetails: state.budgetAbortDetails,
                       });


### PR DESCRIPTION
## Summary

- add selected route, configured provider, actual response model, and explicit fallback attribution to hackerai-agent_run
- add the actual response model to hackerai-usage_cost so cost can be segmented without changing its logical model field
- keep fallback attribution conservative and preserve the paid daily free allowance event contracts

## Telemetry schema

- hackerai-agent_run adds selected_model, configured_model, response_model, and fallback_served
- hackerai-usage_cost adds response_model
- response_model is omitted when provider response metadata is unavailable
- fallback_served is false only for an exact requested-model response, true only for a configured fallback or explicit fallback retry, and omitted when the relationship is unknown
- same-model image recovery clears prior response metadata without being labeled as a model fallback

## Compatibility

- hackerai-usage_cost.model keeps its existing logical semantics, including model=auto
- no prompts, messages, tool contents, URLs, or other request payloads are added
- no model selection, fallback chain, allowance, billing, settlement, pricing, rate-limit, or stream behavior changes
- this closes a pre-existing general attribution gap; it is not a regression from #877, #878, or #879

## Validation

- corepack pnpm jest lib/api/__tests__/chat-logger.test.ts lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts lib/api/__tests__/agent-long-contracts.test.ts lib/rate-limit/__tests__/paid-daily-free-allowance.test.ts --runInBand
- corepack pnpm exec prettier --check on all touched files
- corepack pnpm exec eslint on all touched files
- corepack pnpm lint (passes with 6 existing warnings)
- corepack pnpm typecheck
- commit hook full suite after review fixes: 229 suites, 2328 tests

Automated validation is sufficient for this backend-only telemetry change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Analytics**
  * Improved model attribution across agent, chat streaming, and usage cost events, including selected, configured, response, and fallback-served context.
  * Retry and fallback flows now more reliably report whether a different model was used.
* **Bug Fixes**
  * Corrected served-model telemetry handling during retries and assistant-loop abort/recovery, ensuring fallback-serving is gated and reset appropriately.
  * Prevented missing response-model metadata from appearing in emitted analytics events.
* **Tests**
  * Expanded coverage for fallback-serving and served-model telemetry reset/retry ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->