### PR TITLE
Avoid large chat index backfills

### DIFF
--- a/convex/__tests__/chats.agentApprovalLifecycle.test.ts
+++ b/convex/__tests__/chats.agentApprovalLifecycle.test.ts
@@ -56,7 +56,6 @@ jest.mock("../lib/suspensionGuards", () => ({
 const {
   deleteChatForBackend,
   fenceChatsForDeletion,
-  getActiveAgentResourcesForUser,
   getActiveTriggerRunsForUser,
   setActiveTriggerRun,
 } = require("../chats") as typeof import("../chats");
@@ -120,14 +119,14 @@ describe("Agent approval lifecycle guards", () => {
       id: "chat-1",
       user_id: "user-1",
     };
-    const take = jest
-      .fn<any>()
-      .mockImplementation(async () =>
-        chat.deletion_started_at === undefined ? [chat] : [],
-      );
+    const paginate = jest.fn<any>().mockResolvedValue({
+      page: [chat],
+      isDone: true,
+      continueCursor: "",
+    });
     const first = jest.fn<any>().mockImplementation(async () => chat);
     const withIndex = jest.fn((indexName: string) =>
-      indexName === "by_user_and_deletion_started" ? { take } : { first },
+      indexName === "by_user_and_updated" ? { paginate } : { first },
     );
     const patch = jest.fn<any>().mockImplementation(async (_id, update) => {
       Object.assign(chat, update);
@@ -140,8 +139,14 @@ describe("Agent approval lifecycle guards", () => {
       fenceChatsForDeletion.handler(ctx, {
         serviceKey: "service-key",
         userId: "user-1",
+        cursor: null,
       }),
-    ).resolves.toEqual({ fencedChats: 1, hasMore: false });
+    ).resolves.toEqual({
+      fencedChats: 1,
+      isDone: true,
+      continueCursor: "",
+      resources: [],
+    });
     await expect(
       setActiveTriggerRun.handler(ctx, {
         serviceKey: "service-key",
@@ -153,6 +158,7 @@ describe("Agent approval lifecycle guards", () => {
     expect(chat.deletion_started_at).toEqual(expect.any(Number));
     expect(chat.active_trigger_run_id).toBeUndefined();
     expect(patch).toHaveBeenCalledTimes(1);
+    expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 100 });
   });
 
   it("reports when a started run has no chat row to associate with", async () => {
@@ -254,33 +260,43 @@ describe("Agent approval lifecycle guards", () => {
     });
   });
 
-  it("enumerates approval Sessions even when no Trigger run is stored", async () => {
-    const runTake = jest.fn<any>().mockResolvedValue([]);
-    const sessionTake = jest.fn<any>().mockResolvedValue([
-      {
-        id: "chat-1",
-        active_agent_approval_session_id: "approval-session-1",
-      },
-    ]);
-    const withIndex = jest.fn((indexName: string) => ({
-      take:
-        indexName === "by_user_and_active_trigger_run" ? runTake : sessionTake,
-    }));
-    const ctx = { db: { query: jest.fn(() => ({ withIndex })) } } as any;
+  it("returns approval Sessions even when no Trigger run is stored", async () => {
+    const chat = {
+      _id: "chat-doc-1",
+      id: "chat-1",
+      user_id: "user-1",
+      active_agent_approval_session_id: "approval-session-1",
+    };
+    const paginate = jest.fn<any>().mockResolvedValue({
+      page: [chat],
+      isDone: true,
+      continueCursor: "",
+    });
+    const withIndex = jest.fn(() => ({ paginate }));
+    const patch = jest.fn<any>().mockResolvedValue(undefined);
+    const ctx = {
+      db: { query: jest.fn(() => ({ withIndex })), patch },
+    } as any;
 
     await expect(
-      getActiveAgentResourcesForUser.handler(ctx, {
+      fenceChatsForDeletion.handler(ctx, {
         serviceKey: "service-key",
         userId: "user-1",
+        cursor: null,
       }),
     ).resolves.toEqual({
+      fencedChats: 1,
+      isDone: true,
+      continueCursor: "",
       resources: [
         {
           chatId: "chat-1",
           approvalSessionId: "approval-session-1",
         },
       ],
-      hasMore: false,
+    });
+    expect(patch).toHaveBeenCalledWith("chat-doc-1", {
+      deletion_started_at: expect.any(Number),
     });
   });
 });

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -77,6 +77,12 @@ const agentApprovalTargetGrantValidator = v.union(
   }),
 );
 
+const activeAgentResourceValidator = v.object({
+  chatId: v.string(),
+  triggerRunId: v.optional(v.string()),
+  approvalSessionId: v.optional(v.string()),
+});
+
 const MAX_AGENT_APPROVAL_GRANTS_PER_CHAT = 100;
 
 const getErrorName = (error: unknown): string =>
@@ -1280,30 +1286,55 @@ export const fenceChatsForDeletion = mutation({
   args: {
     serviceKey: v.string(),
     userId: v.string(),
+    cursor: v.union(v.string(), v.null()),
   },
   returns: v.object({
     fencedChats: v.number(),
-    hasMore: v.boolean(),
+    isDone: v.boolean(),
+    continueCursor: v.string(),
+    resources: v.array(activeAgentResourceValidator),
   }),
   handler: async (ctx, args) => {
     validateServiceKey(args.serviceKey);
 
-    const chats = await ctx.db
+    const page = await ctx.db
       .query("chats")
-      .withIndex("by_user_and_deletion_started", (q) =>
-        q.eq("user_id", args.userId).eq("deletion_started_at", undefined),
-      )
-      .take(CHAT_DELETION_FENCE_BATCH_SIZE + 1);
-    const batch = chats.slice(0, CHAT_DELETION_FENCE_BATCH_SIZE);
+      .withIndex("by_user_and_updated", (q) => q.eq("user_id", args.userId))
+      .paginate({
+        cursor: args.cursor,
+        numItems: CHAT_DELETION_FENCE_BATCH_SIZE,
+      });
     const now = Date.now();
+    let fencedChats = 0;
 
-    for (const chat of batch) {
-      await ctx.db.patch(chat._id, { deletion_started_at: now });
+    for (const chat of page.page) {
+      if (chat.deletion_started_at === undefined) {
+        await ctx.db.patch(chat._id, { deletion_started_at: now });
+        fencedChats++;
+      }
     }
 
     return {
-      fencedChats: batch.length,
-      hasMore: chats.length > CHAT_DELETION_FENCE_BATCH_SIZE,
+      fencedChats,
+      isDone: page.isDone,
+      continueCursor: page.continueCursor,
+      resources: page.page.flatMap((chat) =>
+        chat.active_trigger_run_id || chat.active_agent_approval_session_id
+          ? [
+              {
+                chatId: chat.id,
+                ...(chat.active_trigger_run_id
+                  ? { triggerRunId: chat.active_trigger_run_id }
+                  : {}),
+                ...(chat.active_agent_approval_session_id
+                  ? {
+                      approvalSessionId: chat.active_agent_approval_session_id,
+                    }
+                  : {}),
+              },
+            ]
+          : [],
+      ),
     };
   },
 });
@@ -1518,80 +1549,6 @@ export const getActiveTriggerRunsForUser = query({
           : [],
       ),
       hasMore: chats.length > limit,
-    };
-  },
-});
-
-export const getActiveAgentResourcesForUser = query({
-  args: {
-    serviceKey: v.string(),
-    userId: v.string(),
-    limit: v.optional(v.number()),
-  },
-  returns: v.object({
-    resources: v.array(
-      v.object({
-        chatId: v.string(),
-        triggerRunId: v.optional(v.string()),
-        approvalSessionId: v.optional(v.string()),
-      }),
-    ),
-    hasMore: v.boolean(),
-  }),
-  handler: async (ctx, args) => {
-    validateServiceKey(args.serviceKey);
-    const requestedLimit = Math.floor(
-      args.limit ?? MAX_ACTIVE_TRIGGER_RUNS_TO_RETURN,
-    );
-    const limit = Math.min(
-      Math.max(Number.isFinite(requestedLimit) ? requestedLimit : 1, 1),
-      MAX_ACTIVE_TRIGGER_RUNS_TO_RETURN,
-    );
-
-    const [runChats, sessionChats] = await Promise.all([
-      ctx.db
-        .query("chats")
-        .withIndex("by_user_and_active_trigger_run", (q) =>
-          q.eq("user_id", args.userId).gt("active_trigger_run_id", ""),
-        )
-        .take(limit + 1),
-      ctx.db
-        .query("chats")
-        .withIndex("by_user_and_active_approval_session", (q) =>
-          q
-            .eq("user_id", args.userId)
-            .gt("active_agent_approval_session_id", ""),
-        )
-        .take(limit + 1),
-    ]);
-
-    const resourcesByChatId = new Map<
-      string,
-      {
-        chatId: string;
-        triggerRunId?: string;
-        approvalSessionId?: string;
-      }
-    >();
-    for (const chat of [
-      ...runChats.slice(0, limit),
-      ...sessionChats.slice(0, limit),
-    ]) {
-      const current = resourcesByChatId.get(chat.id) ?? { chatId: chat.id };
-      resourcesByChatId.set(chat.id, {
-        ...current,
-        ...(chat.active_trigger_run_id
-          ? { triggerRunId: chat.active_trigger_run_id }
-          : {}),
-        ...(chat.active_agent_approval_session_id
-          ? { approvalSessionId: chat.active_agent_approval_session_id }
-          : {}),
-      });
-    }
-
-    return {
-      resources: [...resourcesByChatId.values()],
-      hasMore: runChats.length > limit || sessionChats.length > limit,
     };
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -105,11 +105,6 @@ export default defineSchema({
       "user_id",
       "active_trigger_run_id",
     ])
-    .index("by_user_and_active_approval_session", [
-      "user_id",
-      "active_agent_approval_session_id",
-    ])
-    .index("by_user_and_deletion_started", ["user_id", "deletion_started_at"])
     .index("by_user_and_pinned", ["user_id", "pinned_at"])
     .index("by_share_id", ["share_id"])
     .searchIndex("search_title", {

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -65,34 +65,53 @@ const loadSaveMessageWithMocks = async () => {
 };
 
 describe("fenceAndGetActiveAgentResourcesForUser", () => {
-  it("finishes every fence batch before enumerating active resources", async () => {
+  it("collects active resources while advancing through fence cursors", async () => {
     const { fenceAndGetActiveAgentResourcesForUser, mockMutation, mockQuery } =
       await loadSaveMessageWithMocks();
     const calls: string[] = [];
     mockMutation
       .mockImplementationOnce(async () => {
         calls.push("fence-1");
-        return { fencedChats: 100, hasMore: true };
+        return {
+          fencedChats: 100,
+          isDone: false,
+          continueCursor: "cursor-1",
+          resources: [{ chatId: "chat-1", triggerRunId: "run-1" }],
+        };
       })
       .mockImplementationOnce(async () => {
         calls.push("fence-2");
-        return { fencedChats: 1, hasMore: false };
+        return {
+          fencedChats: 1,
+          isDone: true,
+          continueCursor: "",
+          resources: [
+            { chatId: "chat-2", approvalSessionId: "approval-session-2" },
+          ],
+        };
       });
-    mockQuery.mockImplementationOnce(async () => {
-      calls.push("snapshot");
-      return {
-        resources: [{ chatId: "chat-1", triggerRunId: "run-1" }],
-        hasMore: false,
-      };
-    });
 
     await expect(
       fenceAndGetActiveAgentResourcesForUser({ userId: "user-1" }),
     ).resolves.toEqual({
-      resources: [{ chatId: "chat-1", triggerRunId: "run-1" }],
+      resources: [
+        { chatId: "chat-1", triggerRunId: "run-1" },
+        { chatId: "chat-2", approvalSessionId: "approval-session-2" },
+      ],
       hasMore: false,
     });
-    expect(calls).toEqual(["fence-1", "fence-2", "snapshot"]);
+    expect(calls).toEqual(["fence-1", "fence-2"]);
+    expect(mockMutation).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({ cursor: null }),
+    );
+    expect(mockMutation).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.objectContaining({ cursor: "cursor-1" }),
+    );
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 });
 

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -58,7 +58,19 @@ const GET_CHAT_RETRY_DELAYS_MS =
 const GET_MESSAGES_PAGE_RETRY_DELAYS_MS =
   process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
 const MAX_CHAT_DELETION_FENCE_BATCHES = 50;
+const MAX_ACTIVE_AGENT_RESOURCES_TO_RETURN = 100;
 const REDACTED_ERROR_DATA_VALUE = "[Redacted]";
+type ActiveAgentResource = {
+  chatId: string;
+  triggerRunId?: string;
+  approvalSessionId?: string;
+};
+type ChatDeletionFencePage = {
+  fencedChats: number;
+  isDone: boolean;
+  continueCursor: string;
+  resources: ActiveAgentResource[];
+};
 type SummaryReason =
   "token_threshold" | "provider_input_threshold" | "provider_pressure";
 
@@ -672,24 +684,32 @@ export async function fenceAndGetActiveAgentResourcesForUser({
   userId: string;
 }) {
   try {
+    const resourcesByChatId = new Map<string, ActiveAgentResource>();
+    let cursor: string | null = null;
+
     for (let batch = 0; batch < MAX_CHAT_DELETION_FENCE_BATCHES; batch++) {
-      const result = await getConvexClient().mutation(
+      const result: ChatDeletionFencePage = await getConvexClient().mutation(
         api.chats.fenceChatsForDeletion,
         {
           serviceKey,
           userId,
+          cursor,
         },
       );
 
-      if (!result.hasMore) {
-        return await getConvexClient().query(
-          api.chats.getActiveAgentResourcesForUser,
-          {
-            serviceKey,
-            userId,
-          },
-        );
+      for (const resource of result.resources) {
+        resourcesByChatId.set(resource.chatId, resource);
       }
+
+      if (result.isDone) {
+        const resources = [...resourcesByChatId.values()];
+        return {
+          resources: resources.slice(0, MAX_ACTIVE_AGENT_RESOURCES_TO_RETURN),
+          hasMore: resources.length > MAX_ACTIVE_AGENT_RESOURCES_TO_RETURN,
+        };
+      }
+
+      cursor = result.continueCursor;
     }
 
     throw new Error(


### PR DESCRIPTION
## Summary
- remove two approval-cleanup indexes that would backfill roughly 4 million chat documents
- paginate the existing per-user chat index during the rare account-deletion cleanup path
- collect active Trigger and approval Session resources while fencing each page
- add regression coverage for pagination, late-run fencing, and resource aggregation

## Why
The new chat indexes block Convex deployment while every existing chat document is indexed. They are only needed during account deletion, where paginating the existing `by_user_and_updated` index is cheaper and avoids production-wide schema migration work.

## Validation
- `pnpm jest convex/__tests__/chats.agentApprovalLifecycle.test.ts lib/db/__tests__/actions-save-message.test.ts app/api/delete-account/__tests__/route.test.ts app/api/chats/__tests__/route.test.ts --runInBand`
- `pnpm typecheck`
- targeted ESLint and Prettier checks
- `pnpm exec convex codegen --dry-run --typecheck enable`
- full commit hook: 250 suites and 2,478 tests passed

## Deployment
Stop the currently running old Convex deployment, merge this PR, then deploy Convex from the updated `main`. The removed indexes will no longer trigger the 4M-document backfills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat deletion handling to prevent late agent activity from being associated with inactive chats.
  * Active agent resources are now collected consistently during paginated deletion processing.
  * Approval sessions remain available for cleanup even when no trigger run is stored.

* **Improvements**
  * Added cursor-based pagination for large chat deletion operations.
  * Added safeguards and limits for incomplete or oversized deletion processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->