### PR TITLE
Fix production auth probes, Grok fallback, and chat deletion

### DIFF
--- a/components/ConvexClientProvider.tsx
+++ b/components/ConvexClientProvider.tsx
@@ -6,7 +6,6 @@ import { ConvexProviderWithAuth } from "convex/react";
 import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
 import { useAuthFromAuthKit } from "@/lib/auth/use-auth-from-authkit";
 
-const noop = () => {};
 const PRERENDER_CONVEX_URL = "https://placeholder.convex.cloud";
 
 export function ConvexClientProvider({ children }: { children: ReactNode }) {
@@ -23,9 +22,9 @@ export function ConvexClientProvider({ children }: { children: ReactNode }) {
   });
 
   return (
-    // Prevent AuthKit's default window.location.reload() on session expiration.
-    // We handle auth state gracefully via Convex token refresh and middleware checks.
-    <AuthKitProvider onSessionExpired={noop}>
+    // Passing a callback still enables AuthKit's focus/visibility session probe.
+    // Disable it entirely; Convex token refresh and middleware own auth recovery.
+    <AuthKitProvider onSessionExpired={false}>
       <ConvexProviderWithAuth client={convex} useAuth={useAuthFromAuthKit}>
         {children}
       </ConvexProviderWithAuth>

--- a/components/__tests__/ConvexClientProvider.contracts.test.ts
+++ b/components/__tests__/ConvexClientProvider.contracts.test.ts
@@ -1,0 +1,16 @@
+import fs from "fs";
+import path from "path";
+
+const providerSource = fs.readFileSync(
+  path.resolve(__dirname, "../ConvexClientProvider.tsx"),
+  "utf8",
+);
+
+describe("ConvexClientProvider auth recovery contracts", () => {
+  it("disables AuthKit focus and visibility session probes", () => {
+    expect(providerSource).toContain(
+      "<AuthKitProvider onSessionExpired={false}>",
+    );
+    expect(providerSource).not.toContain("onSessionExpired={noop}");
+  });
+});

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -314,6 +314,7 @@ describe("buildProviderOptions fallback chain", () => {
     "model-minimax-m3",
     "model-grok-4.5",
     "model-gemini-3-flash",
+    "fallback-grok-4.5",
   ])("enables medium reasoning for ask mode model %s", (modelName) => {
     const opts = buildProviderOptions(false, "user-1", modelName, "ask");
     expect(opts.openrouter.reasoning).toEqual({

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -595,13 +595,15 @@ const ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN = MINIMAX_M3_FALLBACK_CHAIN;
 
 // Standard Ask can route text-only prompts to DeepSeek, image prompts to
 // MiniMax, and PDF prompts to Grok. Keep those route keys and their persisted
-// Grok alias on one effort level so they do not drift.
+// Grok aliases, including the app-side retry key, on one effort level so they
+// do not drift. Grok 4.5 rejects requests that explicitly disable reasoning.
 const ASK_STANDARD_REASONING_MODELS = [
   "model-deepseek-v4-pro",
   "ask-model",
   "model-minimax-m3",
   "model-grok-4.5",
   "model-gemini-3-flash",
+  "fallback-grok-4.5",
 ] as const satisfies readonly ModelName[];
 
 const ASK_MEDIUM_REASONING_MODELS = [

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -1169,7 +1169,9 @@ describe("deleteChatForBackend", () => {
         const payload = JSON.parse(String(line));
         return payload.event;
       });
+      expect(mockMutation).toHaveBeenCalledTimes(1);
       expect(warnEvents).toContain("chat_access_denied");
+      expect(warnEvents).not.toContain("chat_deletion_retry_scheduled");
       expect(errorSpy).not.toHaveBeenCalled();
     } finally {
       warnSpy.mockRestore();
@@ -1215,6 +1217,48 @@ describe("deleteAllChatsForBackend", () => {
       ]);
     } finally {
       warnSpy.mockRestore();
+    }
+  });
+
+  it("classifies an exhausted optimistic concurrency retry as transient", async () => {
+    const { deleteAllChatsForBackend, mockMutation } =
+      await loadSaveMessageWithMocks();
+    const convexError = new Error(
+      JSON.stringify({
+        code: "OptimisticConcurrencyControlFailure",
+        message: "Documents changed while this mutation was being run",
+      }),
+    );
+    mockMutation.mockRejectedValue(convexError as never);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(
+        deleteAllChatsForBackend({ userId: "user-1" }),
+      ).rejects.toMatchObject({
+        type: "offline",
+        surface: "database",
+        statusCode: 503,
+        metadata: expect.objectContaining({
+          db_operation: "chats.deleteAllChatsForBackend",
+          db_retry_reason: "optimistic_concurrency_conflict",
+        }),
+      });
+
+      expect(mockMutation).toHaveBeenCalledTimes(3);
+      const retryEvents = warnSpy.mock.calls
+        .map(([line]) => JSON.parse(String(line)))
+        .filter((payload) => payload.event === "chat_deletion_retry_scheduled");
+      expect(retryEvents).toEqual([
+        expect.objectContaining({ attempt: 1, next_attempt: 2 }),
+        expect.objectContaining({ attempt: 2, next_attempt: 3 }),
+      ]);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
     }
   });
 });

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -41,6 +41,7 @@ const loadSaveMessageWithMocks = async () => {
   }));
 
   const {
+    deleteAllChatsForBackend,
     deleteChatForBackend,
     fenceAndGetActiveAgentResourcesForUser,
     getChatById,
@@ -50,6 +51,7 @@ const loadSaveMessageWithMocks = async () => {
     setActiveTriggerRun,
   } = await import("../actions");
   return {
+    deleteAllChatsForBackend,
     deleteChatForBackend,
     fenceAndGetActiveAgentResourcesForUser,
     getChatById,
@@ -1089,6 +1091,46 @@ describe("getMessagesByChatId", () => {
 });
 
 describe("deleteChatForBackend", () => {
+  it("retries generic Convex server errors before deleting a chat", async () => {
+    const { deleteChatForBackend, mockMutation } =
+      await loadSaveMessageWithMocks();
+    const convexError = new Error("[Request ID: abc] Server Error");
+    mockMutation
+      .mockRejectedValueOnce(convexError as never)
+      .mockResolvedValueOnce({ deleted: true } as never);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await expect(
+        deleteChatForBackend({
+          chatId: "chat-1",
+          userId: "user-1",
+          expectedTriggerRunId: null,
+          expectedApprovalSessionId: null,
+        }),
+      ).resolves.toEqual({ deleted: true });
+
+      expect(mockMutation).toHaveBeenCalledTimes(2);
+      const retryEvents = warnSpy.mock.calls
+        .map(([line]) => JSON.parse(String(line)))
+        .filter((payload) => payload.event === "chat_deletion_retry_scheduled");
+      expect(retryEvents).toEqual([
+        expect.objectContaining({
+          db_operation: "chats.deleteChatForBackend",
+          retry_reason: "convex_server_error",
+          attempt: 1,
+          next_attempt: 2,
+          retry_delay_ms: 0,
+          chat_id: "chat-1",
+          user_id: "user-1",
+        }),
+      ]);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("classifies Convex access denials as warnings and forbidden chat errors", async () => {
     const { deleteChatForBackend, mockMutation } =
       await loadSaveMessageWithMocks();
@@ -1132,6 +1174,47 @@ describe("deleteChatForBackend", () => {
     } finally {
       warnSpy.mockRestore();
       errorSpy.mockRestore();
+    }
+  });
+});
+
+describe("deleteAllChatsForBackend", () => {
+  it("retries Convex optimistic concurrency conflicts", async () => {
+    const { deleteAllChatsForBackend, mockMutation } =
+      await loadSaveMessageWithMocks();
+    const convexError = new Error(
+      JSON.stringify({
+        code: "OptimisticConcurrencyControlFailure",
+        message: "Documents changed while this mutation was being run",
+      }),
+    );
+    mockMutation
+      .mockRejectedValueOnce(convexError as never)
+      .mockResolvedValueOnce(undefined as never);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await expect(
+        deleteAllChatsForBackend({ userId: "user-1" }),
+      ).resolves.toBeUndefined();
+
+      expect(mockMutation).toHaveBeenCalledTimes(2);
+      const retryEvents = warnSpy.mock.calls
+        .map(([line]) => JSON.parse(String(line)))
+        .filter((payload) => payload.event === "chat_deletion_retry_scheduled");
+      expect(retryEvents).toEqual([
+        expect.objectContaining({
+          db_operation: "chats.deleteAllChatsForBackend",
+          retry_reason: "optimistic_concurrency_conflict",
+          attempt: 1,
+          next_attempt: 2,
+          retry_delay_ms: 0,
+          user_id: "user-1",
+        }),
+      ]);
+    } finally {
+      warnSpy.mockRestore();
     }
   });
 });

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -57,6 +57,8 @@ const GET_CHAT_RETRY_DELAYS_MS =
   process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
 const GET_MESSAGES_PAGE_RETRY_DELAYS_MS =
   process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
+const CHAT_DELETION_RETRY_DELAYS_MS =
+  process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
 const MAX_CHAT_DELETION_FENCE_BATCHES = 50;
 const MAX_ACTIVE_AGENT_RESOURCES_TO_RETURN = 100;
 const REDACTED_ERROR_DATA_VALUE = "[Redacted]";
@@ -352,6 +354,19 @@ const getRetryableDatabaseErrorReason = (
 const getRetryableSaveMessageErrorReason = getRetryableDatabaseErrorReason;
 const getRetryableGetChatErrorReason = getRetryableDatabaseErrorReason;
 
+const getRetryableChatDeletionErrorReason = (
+  error: unknown,
+): string | undefined => {
+  const retryReason = getRetryableDatabaseErrorReason(error);
+  if (retryReason) return retryReason;
+
+  if (/OptimisticConcurrencyControlFailure/i.test(stringifyError(error))) {
+    return "optimistic_concurrency_conflict";
+  }
+
+  return undefined;
+};
+
 const getRetryableSaveChatErrorReason = (
   error: unknown,
 ): string | undefined => {
@@ -374,11 +389,55 @@ const getRetryableReasonForDatabaseOperation = (
   if (operation === "chats.saveChat") {
     return getRetryableSaveChatErrorReason(error);
   }
+  if (
+    operation === "chats.deleteChatForBackend" ||
+    operation === "chats.deleteAllChatsForBackend"
+  ) {
+    return getRetryableChatDeletionErrorReason(error);
+  }
   return getRetryableDatabaseErrorReason(error);
 };
 
 const waitForRetryDelay = (delayMs: number) =>
   new Promise((resolve) => setTimeout(resolve, delayMs));
+
+const runRetryableChatDeletion = async <T>({
+  operation,
+  metadata,
+  mutation,
+}: {
+  operation: "chats.deleteChatForBackend" | "chats.deleteAllChatsForBackend";
+  metadata: Record<string, unknown>;
+  mutation: () => Promise<T>;
+}): Promise<T> => {
+  for (let attemptIndex = 0; ; attemptIndex++) {
+    try {
+      return await mutation();
+    } catch (error) {
+      const retryReason = getRetryableChatDeletionErrorReason(error);
+      const retryDelayMs = CHAT_DELETION_RETRY_DELAYS_MS[attemptIndex];
+      if (!retryReason || retryDelayMs === undefined) {
+        throw error;
+      }
+
+      console.warn(
+        JSON.stringify({
+          level: "warn",
+          event: "chat_deletion_retry_scheduled",
+          service: "chat-handler",
+          timestamp: new Date().toISOString(),
+          db_operation: operation,
+          retry_reason: retryReason,
+          attempt: attemptIndex + 1,
+          next_attempt: attemptIndex + 2,
+          retry_delay_ms: retryDelayMs,
+          ...metadata,
+        }),
+      );
+      await waitForRetryDelay(retryDelayMs);
+    }
+  }
+};
 
 const ACCESS_DENIED_ERROR_CODE = "ACCESS_DENIED";
 const CHAT_CANCELED_ERROR_CODE = "CHAT_CANCELED";
@@ -642,13 +701,23 @@ export async function deleteChatForBackend({
   expectedTriggerRunId: string | null;
   expectedApprovalSessionId: string | null;
 }) {
+  const mutationArgs = {
+    serviceKey,
+    chatId,
+    userId,
+    expectedTriggerRunId,
+    expectedApprovalSessionId,
+  };
+
   try {
-    return await getConvexClient().mutation(api.chats.deleteChatForBackend, {
-      serviceKey,
-      chatId,
-      userId,
-      expectedTriggerRunId,
-      expectedApprovalSessionId,
+    return await runRetryableChatDeletion({
+      operation: "chats.deleteChatForBackend",
+      metadata: { chat_id: chatId, user_id: userId },
+      mutation: () =>
+        getConvexClient().mutation(
+          api.chats.deleteChatForBackend,
+          mutationArgs,
+        ),
     });
   } catch (error) {
     throw databaseError("chats.deleteChatForBackend", error, {
@@ -724,9 +793,14 @@ export async function fenceAndGetActiveAgentResourcesForUser({
 
 export async function deleteAllChatsForBackend({ userId }: { userId: string }) {
   try {
-    await getConvexClient().mutation(api.chats.deleteAllChatsForBackend, {
-      serviceKey,
-      userId,
+    await runRetryableChatDeletion({
+      operation: "chats.deleteAllChatsForBackend",
+      metadata: { user_id: userId },
+      mutation: () =>
+        getConvexClient().mutation(api.chats.deleteAllChatsForBackend, {
+          serviceKey,
+          userId,
+        }),
     });
   } catch (error) {
     throw databaseError("chats.deleteAllChatsForBackend", error, {


### PR DESCRIPTION
## Summary

- disable AuthKit's focus and visibility session probe instead of supplying a no-op expiration callback
- keep mandatory medium reasoning enabled when Ask mode retries on Grok 4.5
- retry bounded transient Convex failures for single-chat and delete-all mutations, with structured retry telemetry

## Production evidence (previous 24 hours)

- PostHog's largest active issue was `Failed to fetch`: 1,100 occurrences affecting 1,005 users, with current samples resolving through Next's Server Action transport. The AuthKit provider still enabled its refocus session probe because a callback, even a no-op callback, does not disable it.
- Vercel recorded an Ask-mode app-side retry to `fallback-grok-4.5` with `reasoning_enabled: false`; the provider returned 400 because reasoning is mandatory.
- Six single-chat deletion requests returned retryable Convex server errors, and the current production deployment returned a 400 for `OptimisticConcurrencyControlFailure` during delete-all.

No broad PostHog suppression was added. Unknown stack overflows, React invariants, persistence/provider failures, and unattributed browser exceptions remain visible.

## Root cause

- AuthKit only disables focus/visibility probes when `onSessionExpired` is the literal `false`; the existing no-op callback still ran the Server Action probe.
- The primary Grok model aliases were in the Ask reasoning allowlist, but the app-side retry key was missing.
- Chat save/read paths had bounded transient retries; the corresponding delete paths did not, and optimistic concurrency conflicts were misclassified as non-retryable 400s.

## Validation

- `corepack pnpm jest components/__tests__/ConvexClientProvider.contracts.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/db/__tests__/actions-save-message.test.ts --runInBand` (84 tests)
- full pre-commit Jest suite after review follow-up (252 suites, 2,532 tests)
- `corepack pnpm typecheck`
- `corepack pnpm lint` (passes with 6 existing warnings)
- focused ESLint and Prettier checks on all changed files
- CodeRabbit follow-up: retry exhaustion and non-retryable boundary coverage added; final review has no actionable comments

## Manual verification

- Refocus or re-show an authenticated chat tab and confirm no AuthKit `checkSessionAction` request is emitted.
- Trigger an Ask-mode app-side fallback to Grok 4.5 and confirm provider request telemetry reports reasoning enabled and the fallback streams successfully.
- Delete one chat and delete all chats while Convex has concurrent scheduled message activity; confirm transient conflicts emit `chat_deletion_retry_scheduled` and the request succeeds without a user-visible 400/503.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication recovery when sessions expire by disabling AuthKit’s default session-expired probing and relying on token refresh/middleware recovery.
  - Improved chat deletion reliability with deletion-specific retry scheduling for temporary and synchronization/optimistic concurrency failures.
  - Added clearer retry behavior for deleting individual chats and for deleting all chats.

- **AI Improvements**
  - Updated ask-mode fallback Grok models so “standard reasoning” effort levels are applied consistently (including the new grok fallback alias).

- **Tests**
  - Added/updated contract and coverage tests to validate auth recovery and chat deletion retry outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->