### PR TITLE
Make terminal timeouts resumable

### DIFF
--- a/lib/ai/tools/__tests__/interact-terminal-session.test.ts
+++ b/lib/ai/tools/__tests__/interact-terminal-session.test.ts
@@ -302,6 +302,71 @@ describe("interact_terminal_session — PTY action dispatch", () => {
     ptySessionManager.forget("chat-1", session.sessionId);
   });
 
+  test("non-interactive command sessions support view and confirmed kill", async () => {
+    const { context, ptySessionManager } = makeContext({
+      sandbox: makeFakeE2BSandbox(),
+    });
+    const terminate = jest.fn(async () => true);
+    const handle = createCommandSessionHandle({ kill: terminate });
+    const session = await ptySessionManager.create("chat-1", {
+      cols: 120,
+      rows: 30,
+      kind: "command",
+      createHandle: async () => handle,
+    });
+    const tool = createInteractTerminalSession(context);
+
+    handle.emitText("partial WHOIS output\n");
+    const viewed = (await runTool(tool, {
+      action: "view",
+      session: session.sessionId,
+    })) as {
+      result: { output: string };
+    };
+    expect(viewed.result.output).toContain("partial WHOIS output");
+
+    const killed = (await runTool(tool, {
+      action: "kill",
+      session: session.sessionId,
+    })) as {
+      result: { output: string; exitCode: number | null };
+    };
+    expect(terminate).toHaveBeenCalledTimes(1);
+    expect(killed.result).toEqual({
+      output: "Successfully killed non-interactive command session.",
+      exitCode: null,
+    });
+    expect(ptySessionManager.get("chat-1", session.sessionId)).toBeUndefined();
+  });
+
+  test("failed command-session kill is reported and retained for retry", async () => {
+    const { context, ptySessionManager } = makeContext({
+      sandbox: makeFakeE2BSandbox(),
+    });
+    const terminate = jest.fn(async () => false);
+    const handle = createCommandSessionHandle({ kill: terminate });
+    const session = await ptySessionManager.create("chat-1", {
+      cols: 120,
+      rows: 30,
+      kind: "command",
+      createHandle: async () => handle,
+    });
+    const tool = createInteractTerminalSession(context);
+
+    const killed = (await runTool(tool, {
+      action: "kill",
+      session: session.sessionId,
+    })) as {
+      result: { error?: string };
+    };
+    expect(terminate).toHaveBeenCalledTimes(1);
+    expect(killed.result.error).toContain("Failed to kill session");
+    expect(killed.result.error).toContain("retained");
+    expect(ptySessionManager.get("chat-1", session.sessionId)).toBe(session);
+
+    ptySessionManager.forget("chat-1", session.sessionId);
+  });
+
   test("send with oversized input errors without calling sendInput", async () => {
     const e2b = makeFakeE2BSandbox();
     const handle = makeFakeHandle();

--- a/lib/ai/tools/__tests__/interact-terminal-session.test.ts
+++ b/lib/ai/tools/__tests__/interact-terminal-session.test.ts
@@ -27,6 +27,7 @@ jest.mock("@e2b/code-interpreter", () => ({
 
 import { createInteractTerminalSession } from "../interact-terminal-session";
 import { createRunTerminalCmd } from "../run-terminal-cmd";
+import { createCommandSessionHandle } from "../utils/command-session-handle";
 import type { PtyHandle } from "../utils/e2b-pty-adapter";
 import {
   PtySessionManager,
@@ -251,6 +252,54 @@ describe("interact_terminal_session — PTY action dispatch", () => {
       input: "hi\n",
     })) as { result: { error?: string } };
     expect(result.result.error).toMatch(/Session nope not found/);
+    expect(result.result.error).toContain("a PID is not a session ID");
+  });
+
+  test("non-interactive command sessions support wait but reject send", async () => {
+    const { context, ptySessionManager } = makeContext({
+      sandbox: makeFakeE2BSandbox(),
+    });
+    const handle = createCommandSessionHandle({
+      kill: async () => true,
+    });
+    const session = await ptySessionManager.create("chat-1", {
+      cols: 120,
+      rows: 30,
+      kind: "command",
+      createHandle: async () => handle,
+    });
+    const tool = createInteractTerminalSession(context);
+
+    const send = (await runTool(tool, {
+      action: "send",
+      session: session.sessionId,
+      input: "hello\n",
+    })) as { result: { error?: string } };
+    expect(send.result.error).toContain(
+      "non-interactive command and does not accept input",
+    );
+
+    mockWaitForOutput.mockImplementationOnce(realWaitForOutput);
+    const waitPromise = runTool(tool, {
+      action: "wait",
+      session: session.sessionId,
+      timeout: 1,
+    }) as Promise<{
+      result: {
+        output: string;
+        exited?: { exitCode: number | null };
+      };
+    }>;
+    setTimeout(() => {
+      handle.emitText("WHOIS complete\n");
+      handle.resolveExit(0);
+    }, 10);
+
+    const waited = await waitPromise;
+    expect(waited.result.output).toContain("WHOIS complete");
+    expect(waited.result.exited).toEqual({ exitCode: 0 });
+
+    ptySessionManager.forget("chat-1", session.sessionId);
   });
 
   test("send with oversized input errors without calling sendInput", async () => {

--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -410,6 +410,74 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     ptySessionManager.forget("chat-1", result.result.session!);
   });
 
+  test("uses the exact E2B command handle to terminate noisy foreground work", async () => {
+    const noisyOutput = "line with repeated output\n".repeat(20_000);
+    let rejectWait!: (error: Error) => void;
+    const wait = new Promise<never>((_resolve, reject) => {
+      rejectWait = reject;
+    });
+    const started = {
+      pid: 4321,
+      stdout: "",
+      stderr: "",
+      wait: jest.fn(() => wait),
+      kill: jest.fn(async () => {
+        rejectWait(new Error("signal: killed"));
+        return true;
+      }),
+    };
+    const run = jest.fn(
+      async (
+        calledCommand: string,
+        opts?: {
+          background?: boolean;
+          onStdout?: (data: string) => void;
+        },
+      ) => {
+        if (calledCommand === "echo ready") {
+          return { stdout: "ready\n", stderr: "", exitCode: 0 };
+        }
+        if (calledCommand === "ps -p 4321") {
+          return { stdout: "", stderr: "", exitCode: 1 };
+        }
+        expect(opts?.background).toBe(true);
+        opts?.onStdout?.(noisyOutput);
+        return started;
+      },
+    );
+    const e2b = {
+      jupyterUrl: "http://fake",
+      commands: { run },
+      isRunning: jest.fn(async () => true),
+      getMetrics: jest.fn(async () => []),
+    };
+
+    const { context } = makeContext({ sandbox: e2b });
+    const result = (await runTool(createRunTerminalCmd(context), {
+      command: "yes",
+      brief: "run noisy command",
+      is_background: false,
+      timeout: 0.01,
+      interactive: false,
+    })) as {
+      result: {
+        output: string;
+        exitCode: number | null;
+        terminatedOnTimeout?: boolean;
+      };
+    };
+
+    expect(started.kill).toHaveBeenCalledTimes(1);
+    expect(result.result.exitCode).toBe(124);
+    expect(result.result.terminatedOnTimeout).toBe(true);
+    expect(result.result.output).toContain("PID: 4321");
+    expect(
+      run.mock.calls.some(([calledCommand]) =>
+        String(calledCommand).includes("pgrep"),
+      ),
+    ).toBe(false);
+  });
+
   test("marks detached background PIDs as non-resumable", async () => {
     const nonE2B = {
       sandboxKind: "centrifugo" as const,
@@ -476,35 +544,33 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     ).toContain("rm -rf /");
   });
 
-  test("terminates noisy foreground commands on stream timeout", async () => {
+  test("cancels noisy foreground commands through their execution-specific token", async () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     const noisyOutput = "line with repeated output\n".repeat(20_000);
-    const pendingCommand = new Promise<never>(() => {});
+    const cancellationObserved = jest.fn();
     const nonE2B = {
       sandboxKind: "centrifugo" as const,
       isWindows: () => false,
       commands: {
         run: jest.fn(
-          (
-            command: string,
-            opts?: { onStdout?: (s: string) => void },
+          async (
+            _command: string,
+            opts?: {
+              onStdout?: (s: string) => void;
+              signal?: AbortSignal;
+            },
           ): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
-            if (command.startsWith("pgrep -f")) {
-              return Promise.resolve({
-                stdout: "123\n",
-                stderr: "",
-                exitCode: 0,
-              });
-            }
-            if (command === "kill -9 123") {
-              return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
-            }
-            if (command === "ps -p 123") {
-              return Promise.resolve({ stdout: "", stderr: "", exitCode: 1 });
-            }
-
             opts?.onStdout?.(noisyOutput);
-            return pendingCommand;
+            return new Promise((resolve) => {
+              opts?.signal?.addEventListener(
+                "abort",
+                () => {
+                  cancellationObserved();
+                  resolve({ stdout: "", stderr: "", exitCode: 130 });
+                },
+                { once: true },
+              );
+            });
           },
         ),
       },
@@ -532,84 +598,12 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
       expect(result.result.output).toContain(
         "noisy foreground process was terminated",
       );
-      expect(nonE2B.commands.run).toHaveBeenCalledWith("kill -9 123", {});
-
-      const noisyTimeoutLog = warnSpy.mock.calls
-        .map(([line]) => {
-          try {
-            return JSON.parse(String(line));
-          } catch {
-            return null;
-          }
-        })
-        .find((line) => line?.event === "agent_terminal_noisy_timeout");
-
-      expect(noisyTimeoutLog).toMatchObject({
-        event: "agent_terminal_noisy_timeout",
-        chat_id: "chat-1",
-        user_id: "u1",
-        tool_call_id: "call-1",
-        output_truncated: true,
-        pid: 123,
-        termination_attempted: true,
-        termination_succeeded: true,
-      });
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-
-  test("cancels a managed noisy command when PID discovery fails", async () => {
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-    const noisyOutput = "line with repeated output\n".repeat(20_000);
-    const pendingCommand = new Promise<never>(() => {});
-    const nonE2B = {
-      sandboxKind: "centrifugo" as const,
-      isWindows: () => false,
-      commands: {
-        run: jest.fn(
-          (
-            command: string,
-            opts?: { onStdout?: (s: string) => void },
-          ): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
-            if (command.startsWith("pgrep -f")) {
-              return Promise.resolve({
-                stdout: "",
-                stderr: "",
-                exitCode: 1,
-              });
-            }
-
-            opts?.onStdout?.(noisyOutput);
-            return pendingCommand;
-          },
+      expect(cancellationObserved).toHaveBeenCalledTimes(1);
+      expect(
+        nonE2B.commands.run.mock.calls.some(([calledCommand]) =>
+          String(calledCommand).includes("pgrep"),
         ),
-      },
-    };
-
-    try {
-      const { context } = makeContext({ sandbox: nonE2B });
-      const tool = createRunTerminalCmd(context);
-
-      const result = (await runTool(tool, {
-        command: "yes",
-        brief: "run noisy command",
-        is_background: false,
-        timeout: 0.01,
-      })) as {
-        result: {
-          output: string;
-          exitCode: number | null;
-          terminatedOnTimeout?: boolean;
-        };
-      };
-
-      expect(result.result.exitCode).toBe(124);
-      expect(result.result.terminatedOnTimeout).toBe(true);
-      expect(result.result.output).toContain(
-        "noisy foreground process was terminated",
-      );
-      expect(nonE2B.commands.run).not.toHaveBeenCalledWith("kill -9 123", {});
+      ).toBe(false);
 
       const noisyTimeoutLog = warnSpy.mock.calls
         .map(([line]) => {
@@ -634,6 +628,35 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  test("does not retry a foreground command after its tool timeout resolves", async () => {
+    let rejectFirstAttempt!: (error: Error) => void;
+    const firstAttempt = new Promise<never>((_resolve, reject) => {
+      rejectFirstAttempt = reject;
+    });
+    const nonE2B = {
+      sandboxKind: "centrifugo" as const,
+      isWindows: () => false,
+      commands: {
+        run: jest.fn(() => firstAttempt),
+      },
+    };
+
+    const { context } = makeContext({ sandbox: nonE2B });
+    const tool = createRunTerminalCmd(context);
+    const result = (await runTool(tool, {
+      command: "whois hackerai.co",
+      brief: "look up domain registration",
+      is_background: false,
+      timeout: 0.01,
+    })) as { result: { timedOut?: boolean; session?: string } };
+
+    expect(result.result.timedOut).toBe(true);
+    expect(result.result.session).toMatch(/^[a-f0-9]{8}$/);
+    rejectFirstAttempt(new Error("transient relay failure"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(nonE2B.commands.run).toHaveBeenCalledTimes(1);
   });
 
   test("logs sanitized agent-browser terminal usage to PostHog", async () => {

--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -164,7 +164,9 @@ function makeContext(opts: {
     userID: "u1",
     chatId: opts.chatId ?? "chat-1",
     fileAccumulator: {} as never,
-    backgroundProcessTracker: {} as never,
+    backgroundProcessTracker: {
+      addProcess: jest.fn(),
+    } as never,
     ptySessionManager,
     mode: "agent",
     modelName: "configured-model",
@@ -338,6 +340,113 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     ).toContain("echo hi");
   });
 
+  test("returns a real opaque session when a foreground command outlives its wait window", async () => {
+    let finishCommand!: (result: {
+      stdout: string;
+      stderr: string;
+      exitCode: number;
+    }) => void;
+    let streamStdout: ((data: string) => void) | undefined;
+    const pendingCommand = new Promise<{
+      stdout: string;
+      stderr: string;
+      exitCode: number;
+    }>((resolve) => {
+      finishCommand = resolve;
+    });
+    const nonE2B = {
+      sandboxKind: "centrifugo" as const,
+      isWindows: () => false,
+      commands: {
+        run: jest.fn(
+          async (
+            _command: string,
+            opts?: { onStdout?: (data: string) => void },
+          ) => {
+            streamStdout = opts?.onStdout;
+            return pendingCommand;
+          },
+        ),
+      },
+    };
+
+    const { context, ptySessionManager } = makeContext({ sandbox: nonE2B });
+    const result = (await runTool(createRunTerminalCmd(context), {
+      command: "whois hackerai.co",
+      brief: "query WHOIS",
+      is_background: false,
+      timeout: 0.01,
+      interactive: false,
+    })) as {
+      result: {
+        output: string;
+        session?: string;
+        timedOut?: boolean;
+        exitCode: number | null;
+      };
+    };
+
+    expect(result.result.timedOut).toBe(true);
+    expect(result.result.exitCode).toBeNull();
+    expect(result.result.session).toMatch(/^[a-f0-9]{8}$/);
+    expect(result.result.session).not.toBe("cmd-1689");
+    expect(result.result.output).toContain(
+      `terminal session ${result.result.session}`,
+    );
+    expect(result.result.output).toContain(
+      "Use interact_terminal_session with this exact session ID",
+    );
+
+    const session = ptySessionManager.get("chat-1", result.result.session!);
+    expect(session?.kind).toBe("command");
+
+    streamStdout?.("WHOIS complete\n");
+    finishCommand({ stdout: "WHOIS complete\n", stderr: "", exitCode: 0 });
+    await expect(session?.handle.exited).resolves.toEqual({ exitCode: 0 });
+    expect(
+      new TextDecoder().decode(ptySessionManager.snapshot(session!)),
+    ).toContain("WHOIS complete");
+
+    ptySessionManager.forget("chat-1", result.result.session!);
+  });
+
+  test("marks detached background PIDs as non-resumable", async () => {
+    const nonE2B = {
+      sandboxKind: "centrifugo" as const,
+      isWindows: () => false,
+      commands: {
+        run: jest.fn().mockResolvedValue({
+          stdout: "",
+          stderr: "",
+          exitCode: 0,
+          pid: 1689,
+        }),
+      },
+    };
+
+    const { context } = makeContext({ sandbox: nonE2B });
+    const result = (await runTool(createRunTerminalCmd(context), {
+      command: "sleep 30",
+      is_background: true,
+      timeout: 5,
+      interactive: false,
+    })) as {
+      result: {
+        output: string;
+        pid?: number;
+        session?: string;
+        resumable?: boolean;
+      };
+    };
+
+    expect(result.result.pid).toBe(1689);
+    expect(result.result.session).toBeUndefined();
+    expect(result.result.resumable).toBe(false);
+    expect(result.result.output).toContain(
+      "do not pass this PID to interact_terminal_session",
+    );
+  });
+
   test("does not block destructive-looking commands", async () => {
     const nonE2B = {
       sandboxKind: "centrifugo" as const,
@@ -450,7 +559,7 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     }
   });
 
-  test("does not report noisy timeout termination when PID discovery fails", async () => {
+  test("cancels a managed noisy command when PID discovery fails", async () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     const noisyOutput = "line with repeated output\n".repeat(20_000);
     const pendingCommand = new Promise<never>(() => {});
@@ -495,10 +604,9 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
         };
       };
 
-      expect(result.result.exitCode).toBeNull();
-      expect(result.result.terminatedOnTimeout).toBeUndefined();
-      expect(result.result.output).toContain("continues in background");
-      expect(result.result.output).not.toContain(
+      expect(result.result.exitCode).toBe(124);
+      expect(result.result.terminatedOnTimeout).toBe(true);
+      expect(result.result.output).toContain(
         "noisy foreground process was terminated",
       );
       expect(nonE2B.commands.run).not.toHaveBeenCalledWith("kill -9 123", {});
@@ -519,8 +627,8 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
         user_id: "u1",
         tool_call_id: "call-1",
         output_truncated: true,
-        termination_attempted: false,
-        termination_succeeded: false,
+        termination_attempted: true,
+        termination_succeeded: true,
       });
       expect(noisyTimeoutLog?.pid).toBeUndefined();
     } finally {

--- a/lib/ai/tools/interact-terminal-session.ts
+++ b/lib/ai/tools/interact-terminal-session.ts
@@ -314,8 +314,9 @@ export const createInteractTerminalSession = (context: ToolContext) => {
         try {
           await ptySessionManager.close(chatId, session.sessionId);
         } catch (err) {
+          const retained = ptySessionManager.get(chatId, session.sessionId);
           return errorResult(
-            `Failed to kill session ${sessionId}: ${err instanceof Error ? err.message : String(err)}. The session was retained so cleanup can be retried.`,
+            `Failed to kill session ${sessionId}: ${err instanceof Error ? err.message : String(err)}. ${retained ? "The session was retained so cleanup can be retried." : "The bounded cleanup limit was reached, so local session tracking was removed."}`,
           );
         }
         const exit = await exitPromise.catch(() => ({ exitCode: null }));

--- a/lib/ai/tools/interact-terminal-session.ts
+++ b/lib/ai/tools/interact-terminal-session.ts
@@ -311,7 +311,13 @@ export const createInteractTerminalSession = (context: ToolContext) => {
         // prior view/wait/send blocks; a one-line confirmation reads cleaner
         // in both the agent transcript and the sidebar.
         const exitPromise = session.handle.exited;
-        await ptySessionManager.close(chatId, session.sessionId);
+        try {
+          await ptySessionManager.close(chatId, session.sessionId);
+        } catch (err) {
+          return errorResult(
+            `Failed to kill session ${sessionId}: ${err instanceof Error ? err.message : String(err)}. The session was retained so cleanup can be retried.`,
+          );
+        }
         const exit = await exitPromise.catch(() => ({ exitCode: null }));
         return {
           result: {

--- a/lib/ai/tools/interact-terminal-session.ts
+++ b/lib/ai/tools/interact-terminal-session.ts
@@ -107,7 +107,11 @@ export const createInteractTerminalSession = (context: ToolContext) => {
         }
         const found = ptySessionManager.get(chatId, sid);
         if (!found) {
-          return { error: errorResult(`Session ${sid} not found.`) };
+          return {
+            error: errorResult(
+              `Session ${sid} not found. Only use the exact session ID returned by run_terminal_cmd; a PID is not a session ID and must never be converted into one.`,
+            ),
+          };
         }
         return { session: found };
       };
@@ -174,6 +178,11 @@ export const createInteractTerminalSession = (context: ToolContext) => {
         const lookup = getSessionOrError("send", sessionId);
         if ("error" in lookup) return lookup.error;
         const { session } = lookup;
+        if (session.kind === "command") {
+          return errorResult(
+            `Session ${sessionId} belongs to a non-interactive command and does not accept input. Use action=wait, view, or kill.`,
+          );
+        }
 
         // Fast-fail if the PTY already exited — otherwise sendInput on E2B
         // rejects with an opaque `[not_found] process with pid N not found`
@@ -250,13 +259,14 @@ export const createInteractTerminalSession = (context: ToolContext) => {
         );
         await drainEmitQueue();
         const snapshots = await getSessionSnapshots(ptySessionManager, session);
+        const exited = alreadyExited ?? (await peekExited(session));
         const out: Record<string, unknown> = {
           output: capOutput(stripAnsi(new TextDecoder().decode(delta))),
           sessionSnapshot: snapshots.cleaned,
           rawSnapshot: snapshots.raw,
         };
         if (session.bufferTruncated) out.bufferTruncated = true;
-        if (alreadyExited) out.exited = { exitCode: alreadyExited.exitCode };
+        if (exited) out.exited = { exitCode: exited.exitCode };
         return { result: out };
       };
 
@@ -305,7 +315,10 @@ export const createInteractTerminalSession = (context: ToolContext) => {
         const exit = await exitPromise.catch(() => ({ exitCode: null }));
         return {
           result: {
-            output: "Successfully killed interactive shell.",
+            output:
+              session.kind === "pty"
+                ? "Successfully killed interactive shell."
+                : "Successfully killed non-interactive command session.",
             exitCode: exit.exitCode,
           },
         };

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -20,6 +20,10 @@ import {
 } from "./utils/sandbox-command-options";
 import { createE2BPtyHandle } from "./utils/e2b-pty-adapter";
 import {
+  createCommandSessionHandle,
+  type CommandSessionHandle,
+} from "./utils/command-session-handle";
+import {
   DEFAULT_PTY_COLS,
   DEFAULT_PTY_ROWS,
   type PtySession,
@@ -412,6 +416,44 @@ export const createRunTerminalCmd = (context: ToolContext) => {
             let execution: any = null;
             let handler: ReturnType<typeof createTerminalHandler> | null = null;
             let processId: number | null = null; // Store PID for all processes
+            let commandSession: PtySession | null = null;
+            let commandHandle: CommandSessionHandle | null = null;
+            let commandSessionExposed = false;
+            const commandAbortController = new AbortController();
+
+            const forgetUnexposedCommandSession = () => {
+              if (!commandSession || commandSessionExposed) return;
+              ptySessionManager.forget(chatId, commandSession.sessionId);
+            };
+
+            const terminateManagedCommand = async (): Promise<boolean> => {
+              if (isCentrifugoSandbox(sandboxInstance)) {
+                if (processId) {
+                  return terminateProcessReliably(
+                    sandboxInstance,
+                    null,
+                    processId,
+                  );
+                }
+                if (!commandAbortController.signal.aborted) {
+                  commandAbortController.abort();
+                }
+                return true;
+              }
+
+              if (!processId && execution?.pid) {
+                processId = execution.pid;
+              }
+              if (!processId) {
+                processId = await findProcessPid(sandboxInstance, command);
+              }
+              if (processId) commandHandle?.setPid(processId);
+              return terminateProcessReliably(
+                sandboxInstance,
+                execution,
+                processId,
+              );
+            };
 
             const shouldTerminateNoisyTimedOutCommand = () => {
               if (is_background || !handler) return false;
@@ -469,7 +511,23 @@ export const createRunTerminalCmd = (context: ToolContext) => {
               // from the killed process might trigger retries
               resolved = true;
 
-              if (isCentrifugoSandbox(sandboxInstance)) {
+              if (commandHandle) {
+                try {
+                  const terminated = await terminateManagedCommand();
+                  if (!terminated) {
+                    console.warn(
+                      "[Terminal Command] Managed command could not be terminated during abort",
+                    );
+                  }
+                } catch (error) {
+                  console.error(
+                    "[Terminal Command] Error during managed command abort:",
+                    error,
+                  );
+                }
+                commandHandle.resolveExit(130);
+                forgetUnexposedCommandSession();
+              } else if (isCentrifugoSandbox(sandboxInstance)) {
                 const result = handler ? handler.getResult() : { output: "" };
                 if (handler) {
                   handler.cleanup();
@@ -482,36 +540,36 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                   },
                 });
                 return;
-              }
+              } else {
+                // Try to get PID from execution object first (cheap, no shell call)
+                if (!processId && execution && (execution as any)?.pid) {
+                  processId = (execution as any).pid;
+                }
 
-              // Try to get PID from execution object first (cheap, no shell call)
-              if (!processId && execution && (execution as any)?.pid) {
-                processId = (execution as any).pid;
-              }
+                // Fall back to PID discovery via pgrep/ps for any command type
+                if (!processId) {
+                  processId = await findProcessPid(sandboxInstance, command);
+                }
 
-              // Fall back to PID discovery via pgrep/ps for any command type
-              if (!processId) {
-                processId = await findProcessPid(sandboxInstance, command);
-              }
-
-              // Terminate the current process
-              try {
-                if ((execution && execution.kill) || processId) {
-                  await terminateProcessReliably(
-                    sandboxInstance,
-                    execution,
-                    processId,
-                  );
-                } else {
-                  console.warn(
-                    "[Terminal Command] Cannot kill process: no execution handle or PID available",
+                // Terminate the current process
+                try {
+                  if ((execution && execution.kill) || processId) {
+                    await terminateProcessReliably(
+                      sandboxInstance,
+                      execution,
+                      processId,
+                    );
+                  } else {
+                    console.warn(
+                      "[Terminal Command] Cannot kill process: no execution handle or PID available",
+                    );
+                  }
+                } catch (error) {
+                  console.error(
+                    "[Terminal Command] Error during abort termination:",
+                    error,
                   );
                 }
-              } catch (error) {
-                console.error(
-                  "[Terminal Command] Error during abort termination:",
-                  error,
-                );
               }
 
               // Clean up and resolve
@@ -550,6 +608,11 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                   if (resolved) {
                     return;
                   }
+                  // Claim completion before any async PID/termination work so
+                  // a command exiting at the timeout boundary cannot win the
+                  // race and unregister the session we are about to return.
+                  resolved = true;
+                  if (commandSession) commandSessionExposed = true;
 
                   // Try to get PID from execution object first (if available)
                   if (!processId && execution && (execution as any)?.pid) {
@@ -559,28 +622,32 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                   const terminateNoisyCommand =
                     shouldTerminateNoisyTimedOutCommand();
 
-                  // For foreground commands on stream timeout, try to discover
-                  // PID for user reference and, for noisy truncated output,
-                  // terminate the process before the sandbox transport keeps
-                  // buffering output until MAX_COMMAND_EXECUTION_TIME.
-                  if (!processId && !is_background) {
+                  // A real opaque terminal session is sufficient for ordinary
+                  // foreground timeouts. PID discovery is only needed when a
+                  // noisy command must be terminated defensively.
+                  if (!processId && !is_background && terminateNoisyCommand) {
                     processId = await findProcessPid(sandboxInstance, command);
                   }
+                  if (processId) commandHandle?.setPid(processId);
 
                   let terminationAttempted = false;
                   let terminationSucceeded = false;
                   let terminationError: unknown;
                   if (terminateNoisyCommand) {
                     terminationAttempted = Boolean(
-                      (execution && execution.kill) || processId,
+                      commandHandle ||
+                      (execution && execution.kill) ||
+                      processId,
                     );
                     try {
                       if (terminationAttempted) {
-                        terminationSucceeded = await terminateProcessReliably(
-                          sandboxInstance,
-                          execution,
-                          processId,
-                        );
+                        terminationSucceeded = commandHandle
+                          ? await terminateManagedCommand()
+                          : await terminateProcessReliably(
+                              sandboxInstance,
+                              execution,
+                              processId,
+                            );
                       }
                     } catch (error) {
                       terminationError = error;
@@ -595,6 +662,15 @@ export const createRunTerminalCmd = (context: ToolContext) => {
 
                   const commandTerminated =
                     terminateNoisyCommand && terminationSucceeded;
+                  if (commandTerminated) {
+                    commandSessionExposed = false;
+                    commandHandle?.resolveExit(124);
+                    forgetUnexposedCommandSession();
+                  }
+                  const resumableSession = commandTerminated
+                    ? undefined
+                    : commandSession?.sessionId;
+                  if (resumableSession) commandSessionExposed = true;
                   const timeoutMessage = commandTerminated
                     ? TERMINATED_TIMEOUT_MESSAGE(
                         effectiveStreamTimeout,
@@ -603,11 +679,11 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                     : TIMEOUT_MESSAGE(
                         effectiveStreamTimeout,
                         processId ?? undefined,
+                        resumableSession,
                       );
 
                   await createTerminalWriter(timeoutMessage);
 
-                  resolved = true;
                   abortSignal?.removeEventListener("abort", onAbort);
                   const result = handler
                     ? handler.getResult(processId ?? undefined, {
@@ -621,6 +697,11 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                     result: {
                       output: result.output,
                       exitCode: commandTerminated ? 124 : null,
+                      timedOut: true,
+                      ...(resumableSession && {
+                        session: resumableSession,
+                        ...(processId ? { pid: processId } : {}),
+                      }),
                       ...(commandTerminated && {
                         terminatedOnTimeout: true,
                       }),
@@ -633,17 +714,45 @@ export const createRunTerminalCmd = (context: ToolContext) => {
             // Register abort listener
             abortSignal?.addEventListener("abort", onAbort, { once: true });
 
+            const commandSessionReady: Promise<void> = is_background
+              ? Promise.resolve()
+              : (() => {
+                  commandHandle = createCommandSessionHandle({
+                    kill: terminateManagedCommand,
+                  });
+                  return ptySessionManager
+                    .create(chatId, {
+                      cols,
+                      rows,
+                      kind: "command",
+                      createHandle: async () => commandHandle!,
+                    })
+                    .then((session) => {
+                      commandSession = session;
+                    });
+                })();
+
+            const forwardCommandOutput = (output: string) => {
+              void handler?.stdout(output);
+              commandHandle?.emitText(output);
+            };
+
             const commonOptions = buildSandboxCommandOptions(
               sandboxInstance,
               is_background
                 ? undefined
                 : {
-                    onStdout: handler!.stdout,
-                    onStderr: handler!.stderr,
+                    onStdout: forwardCommandOutput,
+                    onStderr: forwardCommandOutput,
                   },
             );
             const runOptions = isCentrifugoSandbox(sandboxInstance)
-              ? { ...commonOptions, signal: abortSignal }
+              ? {
+                  ...commonOptions,
+                  signal: is_background
+                    ? abortSignal
+                    : commandAbortController.signal,
+                }
               : commonOptions;
 
             // Determine if an error is a permanent command failure (don't retry)
@@ -689,60 +798,70 @@ export const createRunTerminalCmd = (context: ToolContext) => {
               stderr: string;
               exitCode: number;
               pid?: number;
-            }> = is_background
-              ? retryWithBackoff(
-                  async () => {
-                    const result = await sandboxInstance.commands.run(
-                      effectiveCommand,
-                      {
-                        ...runOptions,
-                        background: true,
-                      },
-                    );
-                    // Normalize the result to include exitCode
-                    return {
-                      stdout: result.stdout,
-                      stderr: result.stderr,
-                      exitCode: result.exitCode ?? 0,
-                      pid: (result as { pid?: number }).pid,
-                    };
-                  },
-                  {
-                    maxRetries: 6,
-                    baseDelayMs: 500,
-                    jitterMs: 50,
-                    isPermanentError,
-                    // Retry logs are too noisy - they're expected behavior
-                    logger: () => {},
-                  },
-                )
-              : retryWithBackoff(
-                  () =>
-                    sandboxInstance.commands.run(effectiveCommand, runOptions),
-                  {
-                    maxRetries: 6,
-                    baseDelayMs: 500,
-                    jitterMs: 50,
-                    isPermanentError,
-                    // Retry logs are too noisy - they're expected behavior
-                    logger: () => {},
-                  },
-                );
+            }> = commandSessionReady.then(() => {
+              if (resolved || abortSignal?.aborted) {
+                return { stdout: "", stderr: "", exitCode: 130 };
+              }
+              return is_background
+                ? retryWithBackoff(
+                    async () => {
+                      const result = await sandboxInstance.commands.run(
+                        effectiveCommand,
+                        {
+                          ...runOptions,
+                          background: true,
+                        },
+                      );
+                      // Normalize the result to include exitCode
+                      return {
+                        stdout: result.stdout,
+                        stderr: result.stderr,
+                        exitCode: result.exitCode ?? 0,
+                        pid: (result as { pid?: number }).pid,
+                      };
+                    },
+                    {
+                      maxRetries: 6,
+                      baseDelayMs: 500,
+                      jitterMs: 50,
+                      isPermanentError,
+                      // Retry logs are too noisy - they're expected behavior
+                      logger: () => {},
+                    },
+                  )
+                : retryWithBackoff(
+                    () =>
+                      sandboxInstance.commands.run(
+                        effectiveCommand,
+                        runOptions,
+                      ),
+                    {
+                      maxRetries: 6,
+                      baseDelayMs: 500,
+                      jitterMs: 50,
+                      isPermanentError,
+                      // Retry logs are too noisy - they're expected behavior
+                      logger: () => {},
+                    },
+                  );
+            });
 
             runPromise
               .then(async (exec) => {
                 execution = exec;
 
-                // Capture PID for background processes
-                if (is_background && exec?.pid) {
+                if (exec?.pid) {
                   processId = exec.pid;
+                  commandHandle?.setPid(exec.pid);
                 }
+                commandHandle?.resolveExit(exec.exitCode ?? 0);
 
                 if (handler) {
                   handler.cleanup();
                 }
 
                 if (!resolved) {
+                  forgetUnexposedCommandSession();
                   resolved = true;
                   abortSignal?.removeEventListener("abort", onAbort);
                   const finalResult = handler
@@ -754,7 +873,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
 
                   // Track background processes with their output files
                   if (is_background && processId) {
-                    const backgroundOutput = `Background process started with PID: ${processId}\n`;
+                    const backgroundOutput = `Detached background process started with PID: ${processId}. No reusable terminal session was created; do not pass this PID to interact_terminal_session.\n`;
                     await createTerminalWriter(backgroundOutput);
 
                     const outputFiles =
@@ -784,7 +903,8 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                     result: is_background
                       ? {
                           pid: processId,
-                          output: `Background process started with PID: ${processId ?? "unknown"}\n`,
+                          resumable: false,
+                          output: `Detached background process started with PID: ${processId ?? "unknown"}. No reusable terminal session was created; do not pass this PID to interact_terminal_session.\n`,
                         }
                       : {
                           exitCode: exec.exitCode ?? 0,
@@ -795,13 +915,23 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                               : undefined,
                         },
                   });
+                } else {
+                  // Abort/noisy-timeout paths do not expose a resumable
+                  // session, so discard their bookkeeping once execution
+                  // eventually settles. Exposed timeout sessions stay
+                  // available for wait/view until stream cleanup.
+                  forgetUnexposedCommandSession();
                 }
               })
               .catch(async (error) => {
+                commandHandle?.resolveExit(
+                  error instanceof CommandExitError ? error.exitCode : null,
+                );
                 if (handler) {
                   handler.cleanup();
                 }
                 if (!resolved) {
+                  forgetUnexposedCommandSession();
                   resolved = true;
                   abortSignal?.removeEventListener("abort", onAbort);
                   // Handle CommandExitError as a valid result (non-zero exit code)
@@ -834,6 +964,8 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                   } else {
                     reject(error);
                   }
+                } else {
+                  forgetUnexposedCommandSession();
                 }
               });
           });

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -7,7 +7,6 @@ import { TIMEOUT_MESSAGE } from "@/lib/token-utils";
 import { saveTruncatedOutput } from "./utils/terminal-output-saver";
 import { BackgroundProcessTracker } from "./utils/background-process-tracker";
 import { terminateProcessReliably } from "./utils/process-termination";
-import { findProcessPid } from "./utils/pid-discovery";
 import { retryWithBackoff } from "./utils/retry-with-backoff";
 import {
   waitForSandboxReady,
@@ -64,6 +63,19 @@ type RunTerminalCmdInput = {
   is_background: boolean;
   timeout?: number;
   interactive: boolean;
+};
+
+type E2BCommandHandle = {
+  readonly pid: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode?: number;
+  wait(): Promise<{
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+  }>;
+  kill(): Promise<boolean>;
 };
 
 const TERMINATED_TIMEOUT_MESSAGE = (seconds: number, pid?: number) =>
@@ -428,13 +440,6 @@ export const createRunTerminalCmd = (context: ToolContext) => {
 
             const terminateManagedCommand = async (): Promise<boolean> => {
               if (isCentrifugoSandbox(sandboxInstance)) {
-                if (processId) {
-                  return terminateProcessReliably(
-                    sandboxInstance,
-                    null,
-                    processId,
-                  );
-                }
                 if (!commandAbortController.signal.aborted) {
                   commandAbortController.abort();
                 }
@@ -444,9 +449,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
               if (!processId && execution?.pid) {
                 processId = execution.pid;
               }
-              if (!processId) {
-                processId = await findProcessPid(sandboxInstance, command);
-              }
+              if (!processId && !execution?.kill) return false;
               if (processId) commandHandle?.setPid(processId);
               return terminateProcessReliably(
                 sandboxInstance,
@@ -525,8 +528,6 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                     error,
                   );
                 }
-                commandHandle.resolveExit(130);
-                forgetUnexposedCommandSession();
               } else if (isCentrifugoSandbox(sandboxInstance)) {
                 const result = handler ? handler.getResult() : { output: "" };
                 if (handler) {
@@ -544,11 +545,6 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                 // Try to get PID from execution object first (cheap, no shell call)
                 if (!processId && execution && (execution as any)?.pid) {
                   processId = (execution as any).pid;
-                }
-
-                // Fall back to PID discovery via pgrep/ps for any command type
-                if (!processId) {
-                  processId = await findProcessPid(sandboxInstance, command);
                 }
 
                 // Terminate the current process
@@ -622,12 +618,6 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                   const terminateNoisyCommand =
                     shouldTerminateNoisyTimedOutCommand();
 
-                  // A real opaque terminal session is sufficient for ordinary
-                  // foreground timeouts. PID discovery is only needed when a
-                  // noisy command must be terminated defensively.
-                  if (!processId && !is_background && terminateNoisyCommand) {
-                    processId = await findProcessPid(sandboxInstance, command);
-                  }
                   if (processId) commandHandle?.setPid(processId);
 
                   let terminationAttempted = false;
@@ -664,8 +654,6 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                     terminateNoisyCommand && terminationSucceeded;
                   if (commandTerminated) {
                     commandSessionExposed = false;
-                    commandHandle?.resolveExit(124);
-                    forgetUnexposedCommandSession();
                   }
                   const resumableSession = commandTerminated
                     ? undefined
@@ -753,7 +741,9 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                     ? abortSignal
                     : commandAbortController.signal,
                 }
-              : commonOptions;
+              : isE2BSandbox(sandboxInstance)
+                ? { ...commonOptions, signal: abortSignal }
+                : commonOptions;
 
             // Determine if an error is a permanent command failure (don't retry)
             // vs a transient sandbox issue (do retry)
@@ -784,11 +774,21 @@ export const createRunTerminalCmd = (context: ToolContext) => {
 
             // Augment PATH for local sandboxes so user-installed tools
             // (e.g. ~/go/bin/waybackurls) are found without full paths.
-            // Keep the original `command` for PID discovery (findProcessPid).
             const effectiveCommand = augmentCommandPath(
               command,
               sandboxInstance,
             );
+
+            const retryOptions = {
+              maxRetries: 6,
+              baseDelayMs: 500,
+              jitterMs: 50,
+              signal: abortSignal,
+              isPermanentError: (error: unknown) =>
+                resolved || isPermanentError(error),
+              // Retry logs are too noisy - they're expected behavior
+              logger: () => {},
+            };
 
             // Execute command with retry logic for transient failures
             // Sandbox readiness already checked, so these retries handle race conditions
@@ -798,52 +798,55 @@ export const createRunTerminalCmd = (context: ToolContext) => {
               stderr: string;
               exitCode: number;
               pid?: number;
-            }> = commandSessionReady.then(() => {
+            }> = commandSessionReady.then(async () => {
               if (resolved || abortSignal?.aborted) {
                 return { stdout: "", stderr: "", exitCode: 130 };
               }
-              return is_background
-                ? retryWithBackoff(
-                    async () => {
-                      const result = await sandboxInstance.commands.run(
-                        effectiveCommand,
-                        {
-                          ...runOptions,
-                          background: true,
-                        },
-                      );
-                      // Normalize the result to include exitCode
-                      return {
-                        stdout: result.stdout,
-                        stderr: result.stderr,
-                        exitCode: result.exitCode ?? 0,
-                        pid: (result as { pid?: number }).pid,
-                      };
-                    },
+
+              if (is_background) {
+                return retryWithBackoff(async () => {
+                  const result = await sandboxInstance.commands.run(
+                    effectiveCommand,
                     {
-                      maxRetries: 6,
-                      baseDelayMs: 500,
-                      jitterMs: 50,
-                      isPermanentError,
-                      // Retry logs are too noisy - they're expected behavior
-                      logger: () => {},
-                    },
-                  )
-                : retryWithBackoff(
-                    () =>
-                      sandboxInstance.commands.run(
-                        effectiveCommand,
-                        runOptions,
-                      ),
-                    {
-                      maxRetries: 6,
-                      baseDelayMs: 500,
-                      jitterMs: 50,
-                      isPermanentError,
-                      // Retry logs are too noisy - they're expected behavior
-                      logger: () => {},
+                      ...runOptions,
+                      background: true,
                     },
                   );
+                  return {
+                    stdout: result.stdout,
+                    stderr: result.stderr,
+                    exitCode: result.exitCode ?? 0,
+                    pid: (result as { pid?: number }).pid,
+                  };
+                }, retryOptions);
+              }
+
+              if (isE2BSandbox(sandboxInstance)) {
+                // E2B's foreground `run()` only returns after exit, so it
+                // cannot provide identity while a command is still running.
+                // Start it through the SDK's background handle, retain that
+                // exact handle/PID for lifecycle operations, then wait here
+                // to preserve foreground behavior for the caller.
+                const started = (await retryWithBackoff(
+                  () =>
+                    sandboxInstance.commands.run(effectiveCommand, {
+                      ...runOptions,
+                      background: true,
+                    }),
+                  retryOptions,
+                )) as unknown as E2BCommandHandle;
+                execution = started;
+                processId = started.pid;
+                commandHandle?.setPid(started.pid);
+                const result = await started.wait();
+                return { ...result, pid: started.pid };
+              }
+
+              return retryWithBackoff(
+                () =>
+                  sandboxInstance.commands.run(effectiveCommand, runOptions),
+                retryOptions,
+              );
             });
 
             runPromise

--- a/lib/ai/tools/schemas.ts
+++ b/lib/ai/tools/schemas.ts
@@ -85,21 +85,21 @@ ${largeOutputGuidance}
         .optional()
         .default(false)
         .describe(
-          "Run the command in the background. Only meaningful when interactive=false; ignored otherwise. Use FALSE if you need output files immediately afterward via get_terminal_files; TRUE for long-running processes where you don't need immediate file access.",
+          "Run the command as a detached background process. Only meaningful when interactive=false; ignored otherwise. Detached processes return a PID but no reusable terminal session, so never pass that PID to interact_terminal_session. Use FALSE if you need output or a resumable session; TRUE only for long-running processes whose output you do not need to poll.",
         ),
       timeout: z
         .number()
         .optional()
         .default(RUN_TERMINAL_DEFAULT_STREAM_TIMEOUT_SECONDS)
         .describe(
-          `Timeout in seconds to wait for command output before returning. For interactive=false, quiet foreground commands can keep running in background on timeout; noisy foreground commands that already produced truncated output may be terminated to protect the session. Capped at ${RUN_TERMINAL_MAX_TIMEOUT_SECONDS} seconds. Defaults to ${RUN_TERMINAL_DEFAULT_STREAM_TIMEOUT_SECONDS} seconds.`,
+          `Timeout in seconds to wait for command output before returning. A quiet foreground command that is still running returns a reusable opaque session ID for interact_terminal_session; copy that returned session exactly and never derive one from its PID. Noisy foreground commands that already produced truncated output may be terminated to protect the session. Capped at ${RUN_TERMINAL_MAX_TIMEOUT_SECONDS} seconds. Defaults to ${RUN_TERMINAL_DEFAULT_STREAM_TIMEOUT_SECONDS} seconds.`,
         ),
       interactive: z
         .boolean()
         .optional()
         .default(false)
         .describe(
-          "When true, opens a PTY and returns a reusable `session` ID. Use `interact_terminal_session` tool to continue the session with send/wait/view/kill actions. Use for anything that prompts: REPLs (python, node, mysql), SSH, sudo, confirmations, interactive installers. E2B and local (Centrifugo) sandboxes only.",
+          "When true, opens an input-capable PTY and returns a reusable `session` ID. Use `interact_terminal_session` to continue it with send/wait/view/kill actions. Use for anything that prompts: REPLs (python, node, mysql), SSH, sudo, confirmations, interactive installers. Foreground interactive=false commands can also return a wait/view/kill session if they exceed the initial timeout, but those sessions do not accept send. E2B and local (Centrifugo) sandboxes only.",
         ),
     }),
   });
@@ -121,12 +121,14 @@ export const interactTerminalSessionTool = tool({
 </supported_actions>
 
 <instructions>
-- Sessions are created by \`run_terminal_cmd\` with \`interactive=true\`; pass the returned \`session\` id here
+- Only call this tool when the preceding \`run_terminal_cmd\` result contains an explicit \`session\` field; copy that value exactly
+- A PID is not a session ID. Never derive a session from a PID (for example, never turn PID 1689 into \`cmd-1689\`)
+- Input-capable sessions are created with \`interactive=true\`; timed-out foreground commands may return non-interactive sessions that support wait/view/kill but not send
 - When using \`view\` action, ensure command has completed execution before using its output
 - Set a short \`timeout\` (such as 5s) on \`wait\` for processes that don't return promptly to avoid meaningless waiting time
 - Processes are NEVER killed on timeout - they keep running in the session; \`timeout\` only controls how long to wait for output before returning
 - Use \`wait\` action when a process needs additional time to complete and return
-- Only use \`wait\` after \`send\` (or after \`run_terminal_cmd\` returned without finishing); decide whether to wait based on the prior output
+- Only use \`wait\` after \`send\`, or after \`run_terminal_cmd\` returned without finishing and included an explicit \`session\` field; decide whether to wait based on the prior output
 - DO NOT use \`wait\` for long-running daemon processes
 - \`send\` writes input and captures only the immediate response chunk; if the process needs more time before it replies, follow up with \`action=wait\`
 - \`input\` is sent verbatim. Without a trailing \\n (or \`Enter\`), the line is typed but NOT submitted - a follow-up \`send\` will append to the same line. ALWAYS include \\n unless you specifically want to type without pressing Enter (e.g. building up a key sequence)
@@ -158,7 +160,7 @@ export const interactTerminalSessionTool = tool({
     session: z
       .string()
       .describe(
-        "The unique identifier of the target shell session (returned by `run_terminal_cmd` with `interactive=true`)",
+        "The exact opaque session identifier explicitly returned by run_terminal_cmd. Never pass a PID or construct a session identifier yourself.",
       ),
     timeout: z
       .number()

--- a/lib/ai/tools/utils/__tests__/pty-session-manager.test.ts
+++ b/lib/ai/tools/utils/__tests__/pty-session-manager.test.ts
@@ -404,27 +404,30 @@ describe("PtySessionManager", () => {
       const errorSpy = jest
         .spyOn(console, "error")
         .mockImplementation(() => {});
-      const handle = makeFakeHandle();
-      handle.kill.mockRejectedValue(new Error("transport unavailable"));
-      const session = await manager.create("chat-1", {
-        createHandle: makeCreateHandleFactory(handle),
-        cols: 80,
-        rows: 24,
-        kind: "command",
-      });
+      try {
+        const handle = makeFakeHandle();
+        handle.kill.mockRejectedValue(new Error("transport unavailable"));
+        const session = await manager.create("chat-1", {
+          createHandle: makeCreateHandleFactory(handle),
+          cols: 80,
+          rows: 24,
+          kind: "command",
+        });
 
-      // The idle cleanup and five bounded backoff retries all fail. Timer
-      // callers catch those rejections, and the sixth failure releases local
-      // bookkeeping so the per-chat capacity cannot remain exhausted forever.
-      await jest.advanceTimersByTimeAsync(SESSION_IDLE_TIMEOUT_MS);
-      expect(manager.get("chat-1", session.sessionId)).toBe(session);
-      for (const retryDelay of [5_000, 10_000, 20_000, 30_000, 30_000]) {
-        await jest.advanceTimersByTimeAsync(retryDelay);
+        // The idle cleanup and five bounded backoff retries all fail. Timer
+        // callers catch those rejections, and the sixth failure releases local
+        // bookkeeping so the per-chat capacity cannot remain exhausted forever.
+        await jest.advanceTimersByTimeAsync(SESSION_IDLE_TIMEOUT_MS);
+        expect(manager.get("chat-1", session.sessionId)).toBe(session);
+        for (const retryDelay of [5_000, 10_000, 20_000, 30_000, 30_000]) {
+          await jest.advanceTimersByTimeAsync(retryDelay);
+        }
+
+        expect(handle.kill).toHaveBeenCalledTimes(6);
+        expect(manager.get("chat-1", session.sessionId)).toBeUndefined();
+      } finally {
+        errorSpy.mockRestore();
       }
-
-      expect(handle.kill).toHaveBeenCalledTimes(6);
-      expect(manager.get("chat-1", session.sessionId)).toBeUndefined();
-      errorSpy.mockRestore();
     });
   });
 

--- a/lib/ai/tools/utils/__tests__/pty-session-manager.test.ts
+++ b/lib/ai/tools/utils/__tests__/pty-session-manager.test.ts
@@ -399,6 +399,33 @@ describe("PtySessionManager", () => {
     it("close on unknown session is a no-op", async () => {
       await expect(manager.close("chat-1", "missing")).resolves.toBeUndefined();
     });
+
+    it("bounds timer-driven command cleanup retries and releases the session slot", async () => {
+      const errorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const handle = makeFakeHandle();
+      handle.kill.mockRejectedValue(new Error("transport unavailable"));
+      const session = await manager.create("chat-1", {
+        createHandle: makeCreateHandleFactory(handle),
+        cols: 80,
+        rows: 24,
+        kind: "command",
+      });
+
+      // The idle cleanup and five bounded backoff retries all fail. Timer
+      // callers catch those rejections, and the sixth failure releases local
+      // bookkeeping so the per-chat capacity cannot remain exhausted forever.
+      await jest.advanceTimersByTimeAsync(SESSION_IDLE_TIMEOUT_MS);
+      expect(manager.get("chat-1", session.sessionId)).toBe(session);
+      for (const retryDelay of [5_000, 10_000, 20_000, 30_000, 30_000]) {
+        await jest.advanceTimersByTimeAsync(retryDelay);
+      }
+
+      expect(handle.kill).toHaveBeenCalledTimes(6);
+      expect(manager.get("chat-1", session.sessionId)).toBeUndefined();
+      errorSpy.mockRestore();
+    });
   });
 
   describe("closeAll", () => {

--- a/lib/ai/tools/utils/command-session-handle.ts
+++ b/lib/ai/tools/utils/command-session-handle.ts
@@ -1,0 +1,73 @@
+import type { PtyHandle } from "./e2b-pty-adapter";
+import { createResolvableExited } from "./pty-exited-promise";
+
+/**
+ * A lightweight handle that lets one-shot command execution participate in
+ * the same per-chat session lifecycle as PTYs after a foreground timeout.
+ *
+ * The underlying command transport still owns execution and streaming. This
+ * adapter only provides an opaque session handle, bounded output fan-out, and
+ * cleanup hooks; it deliberately does not make a non-interactive command
+ * input-capable.
+ */
+export interface CommandSessionHandle extends PtyHandle {
+  emitText(text: string): void;
+  setPid(pid: number): void;
+  resolveExit(exitCode: number | null): void;
+}
+
+export function createCommandSessionHandle(opts: {
+  kill: () => Promise<boolean>;
+}): CommandSessionHandle {
+  const listeners = new Set<(bytes: Uint8Array) => void>();
+  const encoder = new TextEncoder();
+  const { exited, resolveOnce } = createResolvableExited();
+  let pid = 0;
+  let hasExited = false;
+
+  const resolveExit = (exitCode: number | null) => {
+    if (hasExited) return;
+    hasExited = true;
+    resolveOnce({ exitCode });
+  };
+
+  return {
+    get pid() {
+      return pid;
+    },
+    async sendInput(): Promise<void> {
+      throw new Error(
+        "This is a non-interactive command session and does not accept input.",
+      );
+    },
+    async resize(): Promise<void> {
+      // Non-interactive commands have no terminal geometry.
+    },
+    async kill(): Promise<void> {
+      if (hasExited) return;
+      const terminated = await opts.kill();
+      if (!terminated) {
+        throw new Error("Failed to terminate non-interactive command session.");
+      }
+      resolveExit(null);
+    },
+    onData(cb): () => void {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+    get exited() {
+      return exited;
+    },
+    emitText(text: string): void {
+      if (!text) return;
+      const bytes = encoder.encode(text);
+      for (const listener of Array.from(listeners)) {
+        listener(bytes);
+      }
+    },
+    setPid(nextPid: number): void {
+      if (Number.isInteger(nextPid) && nextPid > 0) pid = nextPid;
+    },
+    resolveExit,
+  };
+}

--- a/lib/ai/tools/utils/pty-session-manager.ts
+++ b/lib/ai/tools/utils/pty-session-manager.ts
@@ -32,6 +32,7 @@ export const DEFAULT_PTY_COLS = 120;
 export const DEFAULT_PTY_ROWS = 30;
 
 const CLOSE_EXIT_FALLBACK_MS = 2_000;
+const FAILED_COMMAND_CLEANUP_RETRY_MS = 10_000;
 
 export interface PtySession {
   readonly sessionId: string;
@@ -363,6 +364,7 @@ export class PtySessionManager {
       session.lifetimeTimer = null;
     }
 
+    let unexpectedKillError: unknown;
     try {
       await session.handle.kill();
     } catch (err) {
@@ -376,7 +378,30 @@ export class PtySessionManager {
           "[pty-session-manager] kill failed pid=" + session.pid + ":",
           err,
         );
+        unexpectedKillError = err;
       }
+    }
+
+    // A command session represents a still-running foreground execution. If
+    // its transport could not confirm termination, keep the handle and output
+    // buffer registered rather than claiming success and losing the only safe
+    // way to retry cleanup. Natural exit or a later cleanup attempt can still
+    // settle and remove it.
+    if (unexpectedKillError && session.kind === "command") {
+      session.closing = false;
+      session.idleTimer = setTimeout(() => {
+        void this.killAndRemove(session, "idle").catch(() => {});
+      }, FAILED_COMMAND_CLEANUP_RETRY_MS);
+      const lifetimeRemaining = Math.max(
+        0,
+        session.createdAt + SESSION_MAX_LIFETIME_MS - Date.now(),
+      );
+      if (lifetimeRemaining > 0) {
+        session.lifetimeTimer = setTimeout(() => {
+          void this.killAndRemove(session, "lifetime").catch(() => {});
+        }, lifetimeRemaining);
+      }
+      throw unexpectedKillError;
     }
 
     await Promise.race([

--- a/lib/ai/tools/utils/pty-session-manager.ts
+++ b/lib/ai/tools/utils/pty-session-manager.ts
@@ -32,7 +32,9 @@ export const DEFAULT_PTY_COLS = 120;
 export const DEFAULT_PTY_ROWS = 30;
 
 const CLOSE_EXIT_FALLBACK_MS = 2_000;
-const FAILED_COMMAND_CLEANUP_RETRY_MS = 10_000;
+const FAILED_COMMAND_CLEANUP_RETRY_BASE_MS = 5_000;
+const FAILED_COMMAND_CLEANUP_RETRY_MAX_MS = 30_000;
+const MAX_FAILED_COMMAND_CLEANUP_ATTEMPTS = 6;
 
 export interface PtySession {
   readonly sessionId: string;
@@ -75,6 +77,10 @@ interface InternalSession extends PtySession {
   idleTimer: ReturnType<typeof setTimeout> | null;
   /** hard cap timer — set at create, never reset. */
   lifetimeTimer: ReturnType<typeof setTimeout> | null;
+  /** bounded retry timer after command transport termination fails. */
+  cleanupRetryTimer: ReturnType<typeof setTimeout> | null;
+  /** consecutive unexpected command cleanup failures. */
+  cleanupFailureCount: number;
   /** onData unsubscribe function. */
   unsubscribe: (() => void) | null;
   /** True once close() has been initiated — prevents re-entry. */
@@ -142,6 +148,8 @@ export class PtySessionManager {
         droppedBytes: 0,
         idleTimer: null,
         lifetimeTimer: null,
+        cleanupRetryTimer: null,
+        cleanupFailureCount: 0,
         unsubscribe: null,
         closing: false,
         exitedNaturally: null,
@@ -155,7 +163,7 @@ export class PtySessionManager {
       // idle + lifetime timers
       this.armIdleTimer(session);
       session.lifetimeTimer = setTimeout(() => {
-        void this.killAndRemove(session, "lifetime");
+        void this.killAndRemove(session, "lifetime").catch(() => {});
       }, SESSION_MAX_LIFETIME_MS);
 
       // Natural exit — mark as exited but keep session around so the model
@@ -284,7 +292,7 @@ export class PtySessionManager {
   private armIdleTimer(session: InternalSession): void {
     if (session.idleTimer) clearTimeout(session.idleTimer);
     session.idleTimer = setTimeout(() => {
-      void this.killAndRemove(session, "idle");
+      void this.killAndRemove(session, "idle").catch(() => {});
     }, SESSION_IDLE_TIMEOUT_MS);
   }
 
@@ -363,6 +371,10 @@ export class PtySessionManager {
       clearTimeout(session.lifetimeTimer);
       session.lifetimeTimer = null;
     }
+    if (session.cleanupRetryTimer) {
+      clearTimeout(session.cleanupRetryTimer);
+      session.cleanupRetryTimer = null;
+    }
 
     let unexpectedKillError: unknown;
     try {
@@ -389,18 +401,32 @@ export class PtySessionManager {
     // settle and remove it.
     if (unexpectedKillError && session.kind === "command") {
       session.closing = false;
-      session.idleTimer = setTimeout(() => {
-        void this.killAndRemove(session, "idle").catch(() => {});
-      }, FAILED_COMMAND_CLEANUP_RETRY_MS);
-      const lifetimeRemaining = Math.max(
-        0,
-        session.createdAt + SESSION_MAX_LIFETIME_MS - Date.now(),
-      );
-      if (lifetimeRemaining > 0) {
-        session.lifetimeTimer = setTimeout(() => {
-          void this.killAndRemove(session, "lifetime").catch(() => {});
-        }, lifetimeRemaining);
+      session.cleanupFailureCount += 1;
+      const lifetimeRemaining =
+        session.createdAt + SESSION_MAX_LIFETIME_MS - Date.now();
+      const cleanupExhausted =
+        session.cleanupFailureCount >= MAX_FAILED_COMMAND_CLEANUP_ATTEMPTS ||
+        lifetimeRemaining <= 0;
+
+      if (cleanupExhausted) {
+        // The transport repeatedly failed to terminate a command. Drop only
+        // the local bookkeeping at the bounded retry/lifetime cap so one
+        // broken handle cannot permanently consume a per-chat session slot.
+        this.removeSession(session);
+        throw unexpectedKillError;
       }
+
+      const retryDelayMs = Math.min(
+        FAILED_COMMAND_CLEANUP_RETRY_BASE_MS *
+          2 ** (session.cleanupFailureCount - 1),
+        FAILED_COMMAND_CLEANUP_RETRY_MAX_MS,
+      );
+      session.cleanupRetryTimer = setTimeout(() => {
+        void this.killAndRemove(session, "idle").catch(() => {});
+      }, retryDelayMs);
+      session.lifetimeTimer = setTimeout(() => {
+        void this.killAndRemove(session, "lifetime").catch(() => {});
+      }, lifetimeRemaining);
       throw unexpectedKillError;
     }
 
@@ -430,6 +456,10 @@ export class PtySessionManager {
     if (session.lifetimeTimer) {
       clearTimeout(session.lifetimeTimer);
       session.lifetimeTimer = null;
+    }
+    if (session.cleanupRetryTimer) {
+      clearTimeout(session.cleanupRetryTimer);
+      session.cleanupRetryTimer = null;
     }
     const chat = this.chats.get(session.chatId);
     if (chat) {

--- a/lib/ai/tools/utils/pty-session-manager.ts
+++ b/lib/ai/tools/utils/pty-session-manager.ts
@@ -1,5 +1,5 @@
 /**
- * Per-chat PTY session store.
+ * Per-chat terminal session store.
  *
  * Lifetime model for M1: sessions live only for the duration of a single
  * assistant streaming response. `chat-handler.onFinish` calls `closeAll(chatId)`
@@ -7,6 +7,11 @@
  * sandbox — the Node-side object here is only a per-chat cache with ring
  * buffer, idle/lifetime timers and bookkeeping to compute deltas for
  * `action=wait` / `action=view`.
+ *
+ * Most sessions are interactive PTYs. A foreground non-interactive command
+ * that outlives its initial wait window is registered as `kind="command"` so
+ * the model receives a real opaque session id instead of trying to derive one
+ * from an OS PID.
  */
 
 import type { PtyHandle } from "./e2b-pty-adapter";
@@ -31,6 +36,7 @@ const CLOSE_EXIT_FALLBACK_MS = 2_000;
 export interface PtySession {
   readonly sessionId: string;
   readonly chatId: string;
+  readonly kind: "pty" | "command";
   readonly pid: number;
   cols: number;
   rows: number;
@@ -58,6 +64,7 @@ export interface CreateSessionOpts {
   createHandle: () => Promise<PtyHandle>;
   cols: number;
   rows: number;
+  kind?: "pty" | "command";
 }
 
 interface InternalSession extends PtySession {
@@ -119,7 +126,10 @@ export class PtySessionManager {
       const session: InternalSession = {
         sessionId,
         chatId,
-        pid: handle.pid,
+        kind: opts.kind ?? "pty",
+        get pid() {
+          return handle.pid;
+        },
         cols: opts.cols,
         rows: opts.rows,
         createdAt: now,
@@ -245,6 +255,17 @@ export class PtySessionManager {
     if (!chat) return;
     const sessions = Array.from(chat.values());
     await Promise.all(sessions.map((s) => this.killAndRemove(s, "closeAll")));
+  }
+
+  /**
+   * Remove a completed, unexposed session without sending a redundant kill.
+   * Used for ordinary non-interactive commands that finish inside the initial
+   * run_terminal_cmd wait window.
+   */
+  forget(chatId: string, sessionId: string): void {
+    const session = this.chats.get(chatId)?.get(sessionId);
+    if (!session) return;
+    this.removeSession(session);
   }
 
   // ─── internals ──────────────────────────────────────────────────────────

--- a/lib/ai/tools/utils/pty-wait-utils.ts
+++ b/lib/ai/tools/utils/pty-wait-utils.ts
@@ -11,7 +11,8 @@ export const ANSI_REGEX =
 export const stripAnsi = (text: string): string => text.replace(ANSI_REGEX, "");
 
 /**
- * Collect output for up to `timeoutMs`, then resolve. Aborts early on `signal`.
+ * Collect output for up to `timeoutMs`, then resolve. Aborts early on `signal`
+ * or when the underlying process exits.
  *
  * Streams every raw chunk through `onChunk` for the UI writer before
  * consuming the session delta and returning.
@@ -69,6 +70,7 @@ export async function waitForOutput(
 
     const onAbort = () => finish();
     signal?.addEventListener("abort", onAbort, { once: true });
+    void session.handle.exited.then(finish, finish);
 
     function finish() {
       if (settled) return;

--- a/lib/token-utils.ts
+++ b/lib/token-utils.ts
@@ -95,10 +95,19 @@ export const TRUNCATION_MESSAGE =
   "\n\n[... OUTPUT TRUNCATED - middle content removed ...]\n\n";
 export const FILE_READ_TRUNCATION_MESSAGE =
   "\n\n[Content truncated due to size limit. Use line ranges to read in chunks]\n\n";
-export const TIMEOUT_MESSAGE = (seconds: number, pid?: number) =>
-  pid
-    ? `\n\nCommand output paused after ${seconds} seconds. Command continues in background with PID: ${pid}`
-    : `\n\nCommand output paused after ${seconds} seconds. Command continues in background.`;
+export const TIMEOUT_MESSAGE = (
+  seconds: number,
+  pid?: number,
+  session?: string,
+) => {
+  if (session) {
+    const pidSuffix = pid ? ` (PID: ${pid})` : "";
+    return `\n\nCommand output paused after ${seconds} seconds. Command continues in terminal session ${session}${pidSuffix}. Use interact_terminal_session with this exact session ID to wait, view, or kill it.`;
+  }
+
+  const pidSuffix = pid ? ` with PID: ${pid}` : "";
+  return `\n\nCommand output paused after ${seconds} seconds. Command continues in the background${pidSuffix}, but no reusable terminal session was created. Do not derive a session ID from the PID or call interact_terminal_session for this command.`;
+};
 
 export const FULL_OUTPUT_SAVED_MESSAGE = (
   filePath: string,


### PR DESCRIPTION
## Summary

- register foreground non-interactive commands in the existing bounded terminal session store
- return an opaque resumable session ID when a quiet command exceeds the tool timeout
- let Agent mode wait for, inspect, or kill that command through `interact_terminal_session`
- make PID-only detached jobs explicitly non-resumable and prevent models from inventing session IDs such as `cmd-1689`

## Root cause

`run_terminal_cmd` could return an operating-system PID after a foreground timeout without creating a managed terminal session. The model then inferred `cmd-<pid>`, but `interact_terminal_session` only accepts IDs explicitly allocated by the session manager, so the lookup correctly failed with `Session cmd-1689 not found`.

## Design

This keeps process identity separate from operating-system PIDs, matching the durable handle pattern used by Codex-style unified execution. It reuses HackerAI's existing per-chat, TTL-bound, capacity-limited session manager rather than adding a second registry or changing public tool names.

Foreground commands are temporarily managed while running. Successful commands are forgotten immediately; only timed-out commands expose their session. Late output remains in the bounded ring buffer. Detached background commands keep their existing PID behavior and now declare that they cannot be resumed through the session tool.

## Validation

- `pnpm test` (pre-commit) — 252 suites, 2,539 tests passed
- `pnpm exec jest lib/ai/tools --runInBand` — 21 suites, 237 tests passed
- `pnpm exec jest lib/ai/tools/utils/__tests__/pty-session-manager.test.ts --runInBand` — 1 suite, 24 tests passed
- `pnpm typecheck`
- `pnpm lint`
- touched-file Prettier checks
- `git diff --check`
- GitHub Actions, Vercel, and CodeRabbit passed on `abcc565b`

## Manual verification

In Agent mode with a cloud sandbox:

1. Run a quiet foreground command that exceeds the tool timeout and later prints output.
2. Confirm the timeout response contains an opaque `session` value.
3. Call `interact_terminal_session` with that exact value and `action: "wait"`; confirm late output and the final exit code are returned.
4. Start a detached background command and confirm its PID response says it is non-resumable and does not suggest a synthetic session ID.

No visual QA is needed because this changes backend terminal orchestration and tool contracts only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Foreground timeouts can now return a reusable *non-interactive* session supporting **view/wait/kill** for later output inspection and completion tracking.
  - Added managed lifecycle support for non-interactive command sessions with controlled termination and exit-code resolution.
- **Bug Fixes**
  - Reduced timeout/abort race issues and improved handling for noisy foreground commands.
  - Clearer errors when sessions are missing; stronger safeguards to prevent treating PIDs as session IDs.
  - **send** is now rejected for non-interactive sessions; **kill** retains the session for retry if termination fails.
- **Documentation**
  - Updated tool and timeout messaging descriptions for resumable vs non-resumable behavior.
- **Tests**
  - Expanded PTY/session action and cleanup/close coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->