### PR TITLE
Route Agent Pro vision through Grok 4.5

### DIFF
--- a/app/components/ModelSelector/CostIndicator.tsx
+++ b/app/components/ModelSelector/CostIndicator.tsx
@@ -7,7 +7,7 @@ import {
 type CostTier = "low" | "medium" | "high" | "very-high";
 
 // Cost tier per HackerAI tier id. Standard stays low cost in both modes;
-// Pro reflects the GLM/Kimi route, while Max surfaces the highest-cost choice.
+// Pro reflects the GLM/vision routes, while Max surfaces the highest-cost choice.
 export function getCostTier(modelId: string): CostTier {
   switch (modelId) {
     case "hackerai-standard":

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import type { SubscriptionTier } from "@/types/chat";
 
@@ -10,6 +11,23 @@ const mockUseQuery = jest.fn((_query: unknown, args: unknown) =>
 );
 const mockRedirectToPricing = jest.fn();
 const mockOpenSettingsDialog = jest.fn();
+
+Object.defineProperty(globalThis, "ResizeObserver", {
+  configurable: true,
+  value: class ResizeObserverMock {
+    observe() {
+      return undefined;
+    }
+
+    unobserve() {
+      return undefined;
+    }
+
+    disconnect() {
+      return undefined;
+    }
+  },
+});
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({
@@ -73,6 +91,32 @@ describe("ModelSelector", () => {
     expect(
       screen.getByRole("button", { name: /HackerAI Standard/i }),
     ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("uses consistent vision wording for Agent Standard and Pro", async () => {
+    const user = userEvent.setup();
+    render(<ModelSelector value="auto" onChange={jest.fn()} mode="agent" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
+
+    await user.hover(
+      screen.getByRole("button", { name: /HackerAI Standard/i }),
+    );
+    expect(
+      await screen.findAllByText(
+        "Powered by DeepSeek V4 Pro · MiniMax M3 for vision",
+      ),
+    ).not.toHaveLength(0);
+
+    await user.unhover(
+      screen.getByRole("button", { name: /HackerAI Standard/i }),
+    );
+    await user.hover(screen.getByRole("button", { name: /HackerAI Pro/i }));
+    expect(
+      await screen.findAllByText(
+        "Powered by Z.ai GLM 5.2 · Grok 4.5 for vision",
+      ),
+    ).not.toHaveLength(0);
   });
 
   it("selects Auto as a first-class option", () => {

--- a/app/components/ModelSelector/__tests__/options-drift.test.ts
+++ b/app/components/ModelSelector/__tests__/options-drift.test.ts
@@ -78,4 +78,15 @@ describe("ModelSelector tier ↔ provider drift", () => {
         ?.poweredBy,
     ).toBe("DeepSeek V4 Pro · MiniMax M3 for images and PDFs");
   });
+
+  it("discloses the mode-specific vision provider for HackerAI Pro", () => {
+    expect(
+      ASK_MODEL_OPTIONS.find((option) => option.id === "hackerai-pro")
+        ?.poweredBy,
+    ).toBe("Z.ai GLM 5.2 · Kimi K2.7 for vision");
+    expect(
+      AGENT_MODEL_OPTIONS.find((option) => option.id === "hackerai-pro")
+        ?.poweredBy,
+    ).toBe("Z.ai GLM 5.2 · Grok 4.5 for vision");
+  });
 });

--- a/app/components/ModelSelector/__tests__/options-drift.test.ts
+++ b/app/components/ModelSelector/__tests__/options-drift.test.ts
@@ -72,11 +72,11 @@ describe("ModelSelector tier ↔ provider drift", () => {
     }
   });
 
-  it("discloses the text and media providers for Agent Standard", () => {
+  it("discloses the text and vision providers for Agent Standard", () => {
     expect(
       AGENT_MODEL_OPTIONS.find((option) => option.id === "hackerai-standard")
         ?.poweredBy,
-    ).toBe("DeepSeek V4 Pro · MiniMax M3 for images and PDFs");
+    ).toBe("DeepSeek V4 Pro · MiniMax M3 for vision");
   });
 
   it("discloses the mode-specific vision provider for HackerAI Pro", () => {

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -37,7 +37,7 @@ export const AGENT_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-standard",
     label: "HackerAI Standard",
     description: "Reliable agent for everyday automation",
-    poweredBy: "DeepSeek V4 Pro · MiniMax M3 for images and PDFs",
+    poweredBy: "DeepSeek V4 Pro · MiniMax M3 for vision",
     thinking: true,
   },
   {

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -44,7 +44,7 @@ export const AGENT_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-pro",
     label: "HackerAI Pro",
     description: "Superior performance for most assignments",
-    poweredBy: "Z.ai GLM 5.2 · Kimi K2.7 for vision",
+    poweredBy: "Z.ai GLM 5.2 · Grok 4.5 for vision",
     thinking: true,
   },
   {

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -171,6 +171,12 @@ describe("resolveAgentModelForImageToolResults", () => {
     ).toBe("model-kimi-k2.7-code");
   });
 
+  it("switches Agent Pro GLM steps to Grok 4.5 after image tool results", () => {
+    expect(
+      resolveAgentModelForImageToolResults("model-glm-5.2", "agent", true),
+    ).toBe("model-grok-4.5");
+  });
+
   it("switches free DeepSeek Agent steps to MiniMax after image tool results", () => {
     expect(
       resolveAgentModelForImageToolResults("agent-model-free", "agent", true),

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -176,6 +176,19 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
+  it("falls back from Agent Pro vision Grok 4.5 directly to Kimi 2.7 Code", () => {
+    const opts = buildProviderOptions(
+      true,
+      "user-1",
+      "model-grok-4.5",
+      "agent",
+    );
+    expect(opts.openrouter).toMatchObject({
+      models: [KIMI_SLUG],
+      user: "user-1",
+    });
+  });
+
   it.each([
     ["ask-model-free", "ask"],
     ["model-deepseek-v4-flash", "ask"],
@@ -459,6 +472,12 @@ describe("getRetryFallbackModel", () => {
     expect(getRetryFallbackModel("ask-model", "ask")).toBe("fallback-grok-4.5");
   });
 
+  it("retries Agent Pro vision Grok with Kimi 2.7 Code", () => {
+    expect(getRetryFallbackModel("model-grok-4.5", "agent")).toBe(
+      "model-kimi-k2.7-code",
+    );
+  });
+
   it.each([
     ["model-deepseek-v4-pro", "ask"],
     ["model-grok-4.5", "ask"],
@@ -520,6 +539,16 @@ describe("resolveServedModelForCostAccounting", () => {
         mode: "ask",
       }),
     ).toBe("model-grok-4.5");
+  });
+
+  it("maps Agent Pro vision Kimi fallback usage back to the Kimi cost key", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "model-grok-4.5",
+        responseModel: KIMI_SLUG,
+        mode: "agent",
+      }),
+    ).toBe("model-kimi-k2.7-code");
   });
 
   it("maps dated Opus provider response slugs back to the local cost key", () => {

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -105,7 +105,8 @@ import type { createTrackedProvider } from "@/lib/ai/providers";
 import type { ProviderRequestDiagnostics } from "@/lib/logger";
 import type { ChatMode, SubscriptionTier } from "@/types";
 
-const AGENT_VISION_MODEL = "model-kimi-k2.7-code";
+const AGENT_PRO_VISION_MODEL = "model-grok-4.5";
+const AGENT_STANDARD_VISION_MODEL = "model-kimi-k2.7-code";
 const FREE_AGENT_VISION_MODEL = "model-minimax-m3";
 
 export const resolveAgentModelForImageToolResults = (
@@ -115,9 +116,8 @@ export const resolveAgentModelForImageToolResults = (
 ): string => {
   if (mode !== "agent" || !hasImageToolResults) return modelName;
   if (modelName === "agent-model-free") return FREE_AGENT_VISION_MODEL;
-  return modelName === "model-glm-5.2" || isDeepSeekModel(modelName)
-    ? AGENT_VISION_MODEL
-    : modelName;
+  if (modelName === "model-glm-5.2") return AGENT_PRO_VISION_MODEL;
+  return isDeepSeekModel(modelName) ? AGENT_STANDARD_VISION_MODEL : modelName;
 };
 
 export const resolveFallbackServedTelemetry = ({

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -547,6 +547,12 @@ const AGENT_TEXT_FALLBACK_CHAIN = [
   ...MINIMAX_M3_FALLBACK_CHAIN,
 ] as const satisfies readonly ModelName[];
 
+// Agent Pro promotes vision steps to Grok 4.5. Keep Kimi as its direct
+// multimodal fallback without routing back through the cheaper Agent chain.
+const AGENT_PRO_VISION_FALLBACK_CHAIN = [
+  "model-kimi-k2.7-code",
+] as const satisfies readonly ModelName[];
+
 const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "ask-model-free": AGENT_TEXT_FALLBACK_CHAIN,
   "agent-model-free": AGENT_TEXT_FALLBACK_CHAIN,
@@ -650,6 +656,9 @@ const getFallbackKeys = (
   options: FallbackOptions = {},
 ): readonly ModelName[] | undefined => {
   if (!modelName) return undefined;
+  if (modelName === "model-grok-4.5" && mode === "agent") {
+    return AGENT_PRO_VISION_FALLBACK_CHAIN;
+  }
   if (modelName === "model-opus-4.6" || modelName === "model-sonnet-4.6") {
     if (mode === "agent" && options.hasMultimodalToolResults) {
       return ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN;
@@ -661,8 +670,11 @@ const getFallbackKeys = (
 
 export function getRetryFallbackModel(
   modelName: ModelName,
-  _mode: ChatMode,
+  mode: ChatMode,
 ): ModelName {
+  if (modelName === "model-grok-4.5" && mode === "agent") {
+    return "model-kimi-k2.7-code";
+  }
   if (
     modelName === "ask-model-free" ||
     modelName === "agent-model-free" ||

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -319,15 +319,15 @@ describe("selectModel", () => {
       expect(selectModel("agent", "pro", "hackerai-pro")).toBe("model-glm-5.2");
     });
 
-    it("should route HackerAI Pro to Kimi K2.7 in agent mode when an image is attached", () => {
+    it("should route HackerAI Pro to Grok 4.5 in agent mode when an image is attached", () => {
       expect(selectModel("agent", "pro", "hackerai-pro", true, false)).toBe(
-        "model-kimi-k2.7-code",
+        "model-grok-4.5",
       );
     });
 
-    it("should route HackerAI Pro to Kimi K2.7 in agent mode when a PDF is attached", () => {
+    it("should route HackerAI Pro to Grok 4.5 in agent mode when a PDF is attached", () => {
       expect(selectModel("agent", "pro", "hackerai-pro", false, true)).toBe(
-        "model-kimi-k2.7-code",
+        "model-grok-4.5",
       );
     });
 

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -49,7 +49,8 @@ export const getMaxStepsForUser = (
  *   stay on Grok 4.5 for native document support. Paid Agent Auto/Standard
  *   routes use DeepSeek V4 Pro for text-only prompts and MiniMax M3 when
  *   provider-visible media is attached. HackerAI Pro uses GLM 5.2 for
- *   text-only prompts and Kimi K2.7 Code for media prompts.
+ *   text-only prompts, Grok 4.5 for Agent vision, and Kimi K2.7 Code for Ask
+ *   media prompts.
  * @returns Model name to use
  */
 export function selectModel(
@@ -115,7 +116,8 @@ export function selectModel(
   }
 
   if (allowedSelectedModel === "hackerai-pro") {
-    return hasProviderMedia ? "model-kimi-k2.7-code" : "model-glm-5.2";
+    if (!hasProviderMedia) return "model-glm-5.2";
+    return isAgent ? "model-grok-4.5" : "model-kimi-k2.7-code";
   }
 
   const providerKey = resolveTierToProviderKey(allowedSelectedModel, mode);


### PR DESCRIPTION
## Summary

- route HackerAI Pro image and PDF prompts in Agent mode through Grok 4.5
- promote GLM-based Agent Pro runs to Grok 4.5 when image-view tool results enter the context
- keep Kimi K2.7 Code as the direct Grok fallback, including app-side retry and served-model cost attribution
- update the Agent model-selector disclosure while keeping Ask Pro on Kimi

## Why

Agent Pro vision was still coupled to the older Kimi route in both initial attachment selection and later image-tool steps. This separates the Agent Pro route from Ask Pro and makes the requested Grok-first, Kimi-fallback order explicit.

## Validation

- `pnpm test` — 252 suites / 2,544 tests passed
- `pnpm typecheck`
- `pnpm lint` — 0 errors; 6 pre-existing warnings
- targeted ESLint and Prettier checks for all changed files
- local browser shell check — page loaded with meaningful content and no Next.js error overlay; authenticated Agent selector behavior is covered by the mode-specific drift test and should be confirmed on the preview

## Manual verification

1. Sign in to the Vercel preview with a paid account.
2. Select Agent mode and HackerAI Pro.
3. Open the model selector and confirm it says `Z.ai GLM 5.2 · Grok 4.5 for vision`.
4. Send an image or PDF, or produce an image-view tool result during a text-first run.
5. Confirm the requested/served primary model is `x-ai/grok-4.5`; if Grok is unavailable before output, confirm OpenRouter serves `moonshotai/kimi-k2.7-code:exacto` as the fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Agent Pro vision handling so Agent-mode requests use Grok 4.5, with Kimi 2.7 Code as a targeted fallback.
  * Model selector “Powered by” text now reflects the correct vision provider per mode.

* **Bug Fixes**
  * Improved vision routing for image and PDF inputs in agent mode.
  * Refined OpenRouter fallback and retry behavior for Agent Pro vision, including cost-tracking mapping.

* **Tests**
  * Expanded/updated coverage for provider drift, hover text, and vision-mode fallback expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->