### PR TITLE
Instrument Agent permission mode analytics

### DIFF
--- a/app/components/AgentPermissionSelector.tsx
+++ b/app/components/AgentPermissionSelector.tsx
@@ -9,6 +9,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { useGlobalState } from "@/app/contexts/GlobalState";
+import { captureAuthenticatedEvent } from "@/lib/analytics/client";
 import type { AgentPermissionMode } from "@/types";
 
 type AgentPermissionSelectorProps = {
@@ -92,6 +93,20 @@ export function AgentPermissionSelector({
                 type="button"
                 aria-pressed={selected}
                 onClick={() => {
+                  if (option.id !== agentPermissionMode) {
+                    captureAuthenticatedEvent("agent_permission_mode_changed", {
+                      mode: "agent",
+                      previous_agent_permission_mode: agentPermissionMode,
+                      agent_permission_mode: option.id,
+                      surface: "chat_input",
+                      agent_permission_event_version: 1,
+                      $set: {
+                        agent_permission_mode: option.id,
+                        last_agent_permission_mode_changed_at:
+                          new Date().toISOString(),
+                      },
+                    });
+                  }
                   setAgentPermissionMode(option.id);
                   setOpen(false);
                 }}

--- a/app/components/AgentPermissionSelector.tsx
+++ b/app/components/AgentPermissionSelector.tsx
@@ -14,6 +14,7 @@ import type { AgentPermissionMode } from "@/types";
 
 type AgentPermissionSelectorProps = {
   size?: "sm" | "md";
+  analyticsSurface: "chat_input" | "agents_tab";
 };
 
 type PermissionOption = {
@@ -43,6 +44,7 @@ const options: PermissionOption[] = [
 
 export function AgentPermissionSelector({
   size = "sm",
+  analyticsSurface,
 }: AgentPermissionSelectorProps) {
   const [open, setOpen] = useState(false);
   const { agentPermissionMode, setAgentPermissionMode } = useGlobalState();
@@ -98,7 +100,7 @@ export function AgentPermissionSelector({
                       mode: "agent",
                       previous_agent_permission_mode: agentPermissionMode,
                       agent_permission_mode: option.id,
-                      surface: "chat_input",
+                      surface: analyticsSurface,
                       agent_permission_event_version: 1,
                       $set: {
                         agent_permission_mode: option.id,

--- a/app/components/AgentsTab.tsx
+++ b/app/components/AgentsTab.tsx
@@ -66,7 +66,7 @@ const AgentsTab = () => {
             </div>
           </div>
           <div className="w-full sm:w-auto">
-            <AgentPermissionSelector size="md" />
+            <AgentPermissionSelector size="md" analyticsSurface="agents_tab" />
           </div>
         </div>
       </div>

--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -418,7 +418,7 @@ export const ChatInput = ({
               onChange={setSandboxPreference}
             />
             <div className="min-w-0 md:hidden">
-              <AgentPermissionSelector />
+              <AgentPermissionSelector analyticsSurface="chat_input" />
             </div>
           </div>
         )}

--- a/app/components/ChatInput/ChatInputToolbar.tsx
+++ b/app/components/ChatInput/ChatInputToolbar.tsx
@@ -32,7 +32,7 @@ export function ChatInputToolbar({
       <ChatModeSelector />
       {isAgentMode(chatMode) ? (
         <div className="hidden md:block">
-          <AgentPermissionSelector />
+          <AgentPermissionSelector analyticsSurface="chat_input" />
         </div>
       ) : null}
       <div className="ml-auto shrink-0 flex items-center gap-2.5">

--- a/app/components/__tests__/AgentPermissionSelector.test.tsx
+++ b/app/components/__tests__/AgentPermissionSelector.test.tsx
@@ -1,0 +1,55 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const setAgentPermissionMode = jest.fn();
+const captureAuthenticatedEvent = jest.fn();
+
+jest.mock("@/app/contexts/GlobalState", () => ({
+  useGlobalState: () => ({
+    agentPermissionMode: "full_access",
+    setAgentPermissionMode,
+  }),
+}));
+
+jest.mock("@/lib/analytics/client", () => ({
+  captureAuthenticatedEvent,
+}));
+
+const { AgentPermissionSelector } = jest.requireActual<
+  typeof import("../AgentPermissionSelector")
+>("../AgentPermissionSelector");
+
+describe("AgentPermissionSelector", () => {
+  beforeEach(() => {
+    setAgentPermissionMode.mockClear();
+    captureAuthenticatedEvent.mockClear();
+  });
+
+  it("captures permission mode changes before updating the selection", () => {
+    render(<AgentPermissionSelector />);
+
+    fireEvent.click(screen.getByRole("button", { name: /full access/i }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /ask for approval always ask before/i,
+      }),
+    );
+
+    expect(captureAuthenticatedEvent).toHaveBeenCalledWith(
+      "agent_permission_mode_changed",
+      expect.objectContaining({
+        mode: "agent",
+        previous_agent_permission_mode: "full_access",
+        agent_permission_mode: "ask_approval",
+        surface: "chat_input",
+        agent_permission_event_version: 1,
+        $set: expect.objectContaining({
+          agent_permission_mode: "ask_approval",
+          last_agent_permission_mode_changed_at: expect.any(String),
+        }),
+      }),
+    );
+    expect(setAgentPermissionMode).toHaveBeenCalledWith("ask_approval");
+  });
+});

--- a/app/components/__tests__/AgentPermissionSelector.test.tsx
+++ b/app/components/__tests__/AgentPermissionSelector.test.tsx
@@ -27,7 +27,7 @@ describe("AgentPermissionSelector", () => {
   });
 
   it("captures permission mode changes before updating the selection", () => {
-    render(<AgentPermissionSelector />);
+    render(<AgentPermissionSelector analyticsSurface="chat_input" />);
 
     fireEvent.click(screen.getByRole("button", { name: /full access/i }));
     fireEvent.click(

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -86,6 +86,7 @@ describe("captureAgentRun", () => {
       outcome: "success",
       selectedModel: "agent-model",
       configuredModelId: "deepseek/deepseek-v4-pro",
+      agentPermissionMode: "ask_approval",
       responseModel: "deepseek/deepseek-v4-pro",
       fallbackServed: false,
     });
@@ -100,6 +101,7 @@ describe("captureAgentRun", () => {
         outcome: "success",
         selected_model: "agent-model",
         configured_model: "deepseek/deepseek-v4-pro",
+        agent_permission_mode: "ask_approval",
         response_model: "deepseek/deepseek-v4-pro",
         fallback_served: false,
         sandboxType: "remote-connection",
@@ -421,6 +423,7 @@ describe("captureUsageCost", () => {
       chatId: "chat_123",
       endpoint: "/api/chat",
       mode: "agent",
+      agentPermissionMode: "ask_approval",
       responseModel: "deepseek/deepseek-v4-pro",
       usage: {
         model: "auto",
@@ -462,6 +465,7 @@ describe("captureUsageCost", () => {
         chat_id: "chat_123",
         endpoint: "/api/chat",
         mode: "agent",
+        agent_permission_mode: "ask_approval",
         model: "auto",
         response_model: "deepseek/deepseek-v4-pro",
         usage_type: "extra",
@@ -486,6 +490,7 @@ describe("captureUsageCost", () => {
         paid_daily_free_allowance_reset_timestamp: 1_800_000_000_000,
         $set: expect.objectContaining({
           subscription_tier: "pro",
+          agent_permission_mode: "ask_approval",
           last_usage_cost_at: expect.any(String),
         }),
       }),

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -490,11 +490,13 @@ describe("captureUsageCost", () => {
         paid_daily_free_allowance_reset_timestamp: 1_800_000_000_000,
         $set: expect.objectContaining({
           subscription_tier: "pro",
-          agent_permission_mode: "ask_approval",
           last_usage_cost_at: expect.any(String),
         }),
       }),
     });
+    expect(capture.mock.calls[0][0].properties.$set).not.toHaveProperty(
+      "agent_permission_mode",
+    );
   });
 
   it("omits response_model when served-model metadata is unavailable", () => {

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/logger";
 import type { ChatApiEndpoint } from "@/lib/api/agent-endpoints";
 import type {
+  AgentPermissionMode,
   ChatMode,
   ExtraUsageConfig,
   SandboxInfo,
@@ -1184,6 +1185,7 @@ type AgentCompletionAnalyticsArgs = {
   fallbackServed?: boolean;
   finishReason?: string;
   budgetAbortDetails?: BudgetAbortDetails;
+  agentPermissionMode?: AgentPermissionMode;
 };
 
 export function captureAgentRun({
@@ -1199,6 +1201,7 @@ export function captureAgentRun({
   fallbackServed,
   finishReason,
   budgetAbortDetails,
+  agentPermissionMode,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -1212,6 +1215,7 @@ export function captureAgentRun({
   fallbackServed?: boolean;
   finishReason?: string;
   budgetAbortDetails?: BudgetAbortDetails;
+  agentPermissionMode?: AgentPermissionMode;
 }) {
   if (!posthog || mode !== "agent") return;
   posthog.capture({
@@ -1224,6 +1228,9 @@ export function captureAgentRun({
       outcome,
       selected_model: selectedModel,
       configured_model: configuredModelId,
+      ...(agentPermissionMode && {
+        agent_permission_mode: agentPermissionMode,
+      }),
       ...(responseModel && { response_model: responseModel }),
       ...(responseModel &&
         fallbackServed !== undefined && { fallback_served: fallbackServed }),
@@ -1310,6 +1317,7 @@ export function captureAgentCompletionAnalytics(
     fallbackServed: args.fallbackServed,
     finishReason: args.finishReason,
     budgetAbortDetails: args.budgetAbortDetails,
+    agentPermissionMode: args.agentPermissionMode,
   });
   captureFreeAgentValueReached(args);
 }
@@ -1327,6 +1335,7 @@ export function captureUsageCost({
   chatId,
   endpoint,
   mode,
+  agentPermissionMode,
   usage,
   responseModel,
   paidDailyFreeAllowance,
@@ -1338,6 +1347,7 @@ export function captureUsageCost({
   chatId: string;
   endpoint: ChatApiEndpoint;
   mode: ChatMode;
+  agentPermissionMode?: AgentPermissionMode;
   usage: UsageCostRecord;
   responseModel?: string;
   paidDailyFreeAllowance?: {
@@ -1360,6 +1370,9 @@ export function captureUsageCost({
       chat_id: chatId,
       endpoint,
       mode,
+      ...(agentPermissionMode && {
+        agent_permission_mode: agentPermissionMode,
+      }),
       model: usage.model,
       ...(responseModel && { response_model: responseModel }),
       usage_type: usage.type,
@@ -1394,6 +1407,9 @@ export function captureUsageCost({
       }),
       $set: {
         subscription_tier: subscription,
+        ...(agentPermissionMode && {
+          agent_permission_mode: agentPermissionMode,
+        }),
         last_usage_cost_at: new Date().toISOString(),
       },
     },

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -1407,9 +1407,6 @@ export function captureUsageCost({
       }),
       $set: {
         subscription_tier: subscription,
-        ...(agentPermissionMode && {
-          agent_permission_mode: agentPermissionMode,
-        }),
         last_usage_cost_at: new Date().toISOString(),
       },
     },

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2569,6 +2569,7 @@ export const agentLongTask = task({
                   chatId,
                   endpoint,
                   mode,
+                  agentPermissionMode,
                   usage: usageCostRecord,
                   responseModel: state.responseModel,
                   ...(paidDailyFreeAllowanceReservation && {
@@ -3059,6 +3060,7 @@ export const agentLongTask = task({
                                     finishReason: state.streamFinishReason,
                                     budgetAbortDetails:
                                       state.budgetAbortDetails,
+                                    agentPermissionMode,
                                   });
                                   if (!isTerminalProviderStreamError(state)) {
                                     chatLogger?.emitSuccess({
@@ -3196,6 +3198,7 @@ export const agentLongTask = task({
                             : state.fallbackServed,
                         finishReason: state.streamFinishReason,
                         budgetAbortDetails: state.budgetAbortDetails,
+                        agentPermissionMode,
                       });
                       if (!isTerminalProviderStreamError(state)) {
                         chatLogger?.emitSuccess({


### PR DESCRIPTION
## What changed

- capture `agent_permission_mode_changed` when users switch between Full access and Ask for approval
- add `agent_permission_mode` to `hackerai-agent_run` for outcome analysis
- add `agent_permission_mode` to `hackerai-usage_cost` for token, cost, and extra-usage analysis
- persist the latest permission mode as a PostHog person property for cohorting

## Why

This establishes the minimal 14-day baseline needed before testing a migration from standalone Ask mode to Agent with Ask for approval.

Follow-up experiment: [HAC-45](https://linear.app/hackerai/issue/HAC-45/start-10-user-ask-to-agent-approval-experiment-after-14-day-baseline), due July 28, 2026.

## Validation

- `pnpm test -- --runInBand app/components/__tests__/AgentPermissionSelector.test.tsx lib/api/__tests__/chat-logger.test.ts`
- `pnpm typecheck`
- focused ESLint and Prettier checks on all touched files

Automated validation is sufficient because this changes analytics payloads without changing visible UI behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for agent permission mode changes, including where the change occurred (chat input vs agents tab).
  * Included agent permission mode in analytics for agent runs and usage-cost events.
* **Bug Fixes**
  * Ensured permission mode is correctly propagated across completion, retry, and final usage deduction flows.
* **Tests**
  * Added/updated test coverage to verify permission-mode change tracking and correct analytics payload properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->