### PR TITLE
Reduce initial chat bundle size

### DIFF
--- a/app/components/ChatInput/ChatInputTextarea.tsx
+++ b/app/components/ChatInput/ChatInputTextarea.tsx
@@ -10,10 +10,11 @@ import {
   upsertDraft,
   removeDraft,
 } from "@/lib/utils/client-storage";
+import { getMaxTokensForSubscription } from "@/lib/token-limits";
 import {
-  countInputTokens,
-  getMaxTokensForSubscription,
-} from "@/lib/token-utils";
+  getInputTokenLimitStatus,
+  inputTokenCountCouldExceedLimit,
+} from "@/lib/utils/client-token-validation";
 import { toast } from "sonner";
 import type { ChatMode } from "@/types/chat";
 
@@ -103,12 +104,24 @@ export function ChatInputTextarea({
         return;
       }
 
-      const tokenCount = countInputTokens(pastedText, []);
       const maxTokens = getMaxTokensForSubscription(subscription, {
         mode: chatMode,
       });
-      if (tokenCount > maxTokens) {
-        e.preventDefault();
+      if (!inputTokenCountCouldExceedLimit(pastedText, [], maxTokens)) {
+        await handlePasteEvent(e);
+        return;
+      }
+
+      // Async tokenization cannot cancel a native paste after dispatch ends.
+      // Intercept only potentially oversized content, then manually insert it
+      // below when exact tokenization shows that it fits.
+      e.preventDefault();
+      const tokenLimitStatus = await getInputTokenLimitStatus(
+        pastedText,
+        [],
+        maxTokens,
+      );
+      if (tokenLimitStatus.exceedsLimit) {
         if (subscription !== "free") {
           await handlePastedTextAttachment(pastedText);
           return;
@@ -116,16 +129,36 @@ export function ChatInputTextarea({
 
         const planText = subscription !== "free" ? "" : " (Free plan limit)";
         toast.error("Content is too long to paste", {
-          description: `The content you're trying to paste is too large (${tokenCount.toLocaleString()} tokens). Please copy a smaller amount${planText}.`,
+          description: `The content you're trying to paste is too large (${tokenLimitStatus.tokenCount.toLocaleString()} tokens). Please copy a smaller amount${planText}.`,
         });
         return;
       }
 
-      await handlePasteEvent(e);
+      const textarea = textareaRef.current;
+      const currentInput = inputRef.current;
+      const selectionStart = textarea?.selectionStart ?? currentInput.length;
+      const selectionEnd = textarea?.selectionEnd ?? selectionStart;
+      const nextInput =
+        currentInput.slice(0, selectionStart) +
+        pastedText +
+        currentInput.slice(selectionEnd);
+      const nextCursorPosition = selectionStart + pastedText.length;
+
+      setInput(nextInput);
+      requestAnimationFrame(() => {
+        textarea?.focus();
+        textarea?.setSelectionRange(nextCursorPosition, nextCursorPosition);
+      });
     };
     document.addEventListener("paste", handlePaste);
     return () => document.removeEventListener("paste", handlePaste);
-  }, [chatMode, handlePasteEvent, handlePastedTextAttachment, subscription]);
+  }, [
+    chatMode,
+    handlePasteEvent,
+    handlePastedTextAttachment,
+    setInput,
+    subscription,
+  ]);
 
   return (
     <div className="overflow-y-auto pl-4 pr-2">

--- a/app/components/ChatLayout.tsx
+++ b/app/components/ChatLayout.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import { useEffect, useRef, useState, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useGlobalState } from "../contexts/GlobalState";
 import { useChats } from "../hooks/useChats";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import MainSidebar from "./Sidebar";
-import { SettingsDialog } from "./SettingsDialog";
 import { onOpenSettingsDialog } from "@/lib/utils/settings-dialog";
+
+const SettingsDialog = dynamic(
+  () => import("./SettingsDialog").then((module) => module.SettingsDialog),
+  { ssr: false },
+);
 
 /**
  * Shared layout for chat routes: Chat Sidebar (left) + main content slot.
@@ -24,11 +29,13 @@ export function ChatLayout({ children }: { children: React.ReactNode }) {
 
   // Settings dialog — local state, opened via custom event from anywhere
   const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
+  const [hasOpenedSettingsDialog, setHasOpenedSettingsDialog] = useState(false);
   const [settingsDialogTab, setSettingsDialogTab] = useState<string | null>(
     null,
   );
 
   const handleOpenSettings = useCallback((tab?: string) => {
+    setHasOpenedSettingsDialog(true);
     setSettingsDialogTab(null);
     // Force a fresh state change even if the same tab is requested again
     queueMicrotask(() => {
@@ -162,12 +169,14 @@ export function ChatLayout({ children }: { children: React.ReactNode }) {
           </div>
         </div>
       )}
-      {/* Settings Dialog - rendered here so it's always mounted (including mobile) */}
-      <SettingsDialog
-        open={settingsDialogOpen}
-        onOpenChange={setSettingsDialogOpen}
-        initialTab={settingsDialogTab}
-      />
+      {/* Load settings on first use, then keep it mounted for close animations. */}
+      {hasOpenedSettingsDialog && (
+        <SettingsDialog
+          open={settingsDialogOpen}
+          onOpenChange={setSettingsDialogOpen}
+          initialTab={settingsDialogTab}
+        />
+      )}
     </div>
   );
 }

--- a/app/components/ChatLayout.tsx
+++ b/app/components/ChatLayout.tsx
@@ -6,12 +6,26 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useGlobalState } from "../contexts/GlobalState";
 import { useChats } from "../hooks/useChats";
 import { SidebarProvider } from "@/components/ui/sidebar";
+import Loading from "@/components/ui/loading";
 import MainSidebar from "./Sidebar";
 import { onOpenSettingsDialog } from "@/lib/utils/settings-dialog";
 
 const SettingsDialog = dynamic(
   () => import("./SettingsDialog").then((module) => module.SettingsDialog),
-  { ssr: false },
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        role="status"
+        aria-label="Loading settings"
+      >
+        <div className="rounded-xl border bg-background p-6 shadow-lg">
+          <Loading size={6} />
+        </div>
+      </div>
+    ),
+  },
 );
 
 /**

--- a/app/components/MessageEditor.tsx
+++ b/app/components/MessageEditor.tsx
@@ -47,7 +47,7 @@ export const MessageEditor = ({
     setFiles((prev) => prev.filter((f) => f.fileId !== fileId));
   }, []);
 
-  const handleSave = async () => {
+  const saveMessage = async () => {
     const trimmedContent = content.trim();
 
     // Must have either content or files
@@ -73,12 +73,21 @@ export const MessageEditor = ({
     onSave(trimmedContent, remainingFileIds);
   };
 
+  const handleSave = () => {
+    void saveMessage().catch((error) => {
+      console.error("Failed to validate edited message:", error);
+      toast.error("Could not validate message", {
+        description: "Please try again.",
+      });
+    });
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Escape") {
       onCancel();
     } else if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
-      void handleSave();
+      handleSave();
     }
   };
 

--- a/app/components/MessageEditor.tsx
+++ b/app/components/MessageEditor.tsx
@@ -4,10 +4,8 @@ import TextareaAutosize from "react-textarea-autosize";
 import Image from "next/image";
 import { X, File } from "lucide-react";
 import { useGlobalState } from "../contexts/GlobalState";
-import {
-  countInputTokens,
-  getMaxTokensForSubscription,
-} from "@/lib/token-utils";
+import { getMaxTokensForSubscription } from "@/lib/token-limits";
+import { getInputTokenLimitStatus } from "@/lib/utils/client-token-validation";
 import { toast } from "sonner";
 
 export interface EditableFile {
@@ -49,20 +47,24 @@ export const MessageEditor = ({
     setFiles((prev) => prev.filter((f) => f.fileId !== fileId));
   }, []);
 
-  const handleSave = () => {
+  const handleSave = async () => {
     const trimmedContent = content.trim();
 
     // Must have either content or files
     if (!trimmedContent && files.length === 0) return;
 
     // Check token limit for edited content based on user plan
-    const tokenCount = countInputTokens(trimmedContent, []);
     const maxTokens = getMaxTokensForSubscription(subscription);
+    const tokenLimitStatus = await getInputTokenLimitStatus(
+      trimmedContent,
+      [],
+      maxTokens,
+    );
 
-    if (tokenCount > maxTokens) {
+    if (tokenLimitStatus.exceedsLimit) {
       const planText = subscription !== "free" ? "" : " (Free plan limit)";
       toast.error("Message is too long", {
-        description: `Your edited message is too large (${tokenCount.toLocaleString()} tokens). Maximum is ${maxTokens.toLocaleString()} tokens${planText}.`,
+        description: `Your edited message is too large (${tokenLimitStatus.tokenCount.toLocaleString()} tokens). Maximum is ${maxTokens.toLocaleString()} tokens${planText}.`,
       });
       return;
     }
@@ -76,7 +78,7 @@ export const MessageEditor = ({
       onCancel();
     } else if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
-      handleSave();
+      void handleSave();
     }
   };
 

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -7,11 +7,11 @@ import {
   Dispatch,
   SetStateAction,
 } from "react";
+import dynamic from "next/dynamic";
 import { MessageItem } from "./MessageItem";
 import { MessageErrorState } from "./MessageErrorState";
 import { SummarizationStatusDivider } from "./SummarizationStatusDivider";
 import { Shimmer } from "@/components/ai-elements/shimmer";
-import { AllFilesDialog } from "./AllFilesDialog";
 import Loading from "@/components/ui/loading";
 import { useFeedback } from "../hooks/useFeedback";
 import { useFileUrlCache } from "../hooks/useFileUrlCache";
@@ -26,6 +26,11 @@ import { hasTextContent } from "@/lib/utils/message-utils";
 import { useDataStreamState } from "./DataStreamProvider";
 import type { RateLimitWarningData } from "./RateLimitWarning";
 import type { SelectedModel } from "@/types";
+
+const AllFilesDialog = dynamic(
+  () => import("./AllFilesDialog").then((module) => module.AllFilesDialog),
+  { ssr: false },
+);
 
 interface MessagesProps {
   messages: ChatMessage[];
@@ -166,6 +171,7 @@ export const Messages = ({
 
   // Track all files dialog state
   const [showAllFilesDialog, setShowAllFilesDialog] = useState(false);
+  const [hasOpenedAllFilesDialog, setHasOpenedAllFilesDialog] = useState(false);
   const [dialogFiles, setDialogFiles] = useState<
     Array<{
       part: any;
@@ -232,6 +238,7 @@ export const Messages = ({
         }));
 
       setDialogFiles(files);
+      setHasOpenedAllFilesDialog(true);
       setShowAllFilesDialog(true);
     },
     [],
@@ -369,12 +376,14 @@ export const Messages = ({
         </div>
 
         {/* All Files Dialog */}
-        <AllFilesDialog
-          open={showAllFilesDialog}
-          onOpenChange={setShowAllFilesDialog}
-          files={dialogFiles}
-          chatTitle={chatTitle}
-        />
+        {hasOpenedAllFilesDialog && (
+          <AllFilesDialog
+            open={showAllFilesDialog}
+            onOpenChange={setShowAllFilesDialog}
+            files={dialogFiles}
+            chatTitle={chatTitle}
+          />
+        )}
       </div>
     </FileUrlCacheProvider>
   );

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -29,7 +29,20 @@ import type { SelectedModel } from "@/types";
 
 const AllFilesDialog = dynamic(
   () => import("./AllFilesDialog").then((module) => module.AllFilesDialog),
-  { ssr: false },
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        role="status"
+        aria-label="Loading files"
+      >
+        <div className="rounded-xl border bg-background p-6 shadow-lg">
+          <Loading size={6} />
+        </div>
+      </div>
+    ),
+  },
 );
 
 interface MessagesProps {

--- a/app/components/SettingsDialog.tsx
+++ b/app/components/SettingsDialog.tsx
@@ -52,12 +52,22 @@ const SettingsDialog = ({
     // Only consulted when subscription === "team"; tabs() condition gates
     // any other read, so a stale value after switching tier is harmless and
     // will be overwritten the next time the user becomes a team member.
-    if (subscription !== "team") return;
-    fetch("/api/team/members")
+    if (!open || subscription !== "team") return;
+    const controller = new AbortController();
+
+    fetch("/api/team/members", { signal: controller.signal })
       .then((res) => res.json())
-      .then((data) => setIsTeamAdmin(data.isAdmin ?? false))
-      .catch(() => setIsTeamAdmin(false));
-  }, [subscription]);
+      .then((data) => {
+        if (!controller.signal.aborted) {
+          setIsTeamAdmin(data.isAdmin ?? false);
+        }
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setIsTeamAdmin(false);
+      });
+
+    return () => controller.abort();
+  }, [open, subscription]);
 
   // Base tabs visible to all users
   const baseTabs = [

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -90,7 +90,7 @@ const MainSidebar: FC<{
   const isMobile = useIsMobile();
   const { setChatSidebarOpen } = useGlobalState();
   // Use lifted data when provided; otherwise subscribe here (e.g. SharedChatView)
-  const chatListDataFromHook = useChats();
+  const chatListDataFromHook = useChats(chatListDataProp === undefined);
   const chatListData = chatListDataProp ?? chatListDataFromHook;
 
   const handleCloseSidebar = () => {

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -16,10 +16,10 @@ import {
 } from "@/types";
 import { Id } from "@/convex/_generated/dataModel";
 import {
-  countInputTokens,
-  getMaxTokensForSubscription,
   getMaxFileTokens,
-} from "@/lib/token-utils";
+  getMaxTokensForSubscription,
+} from "@/lib/token-limits";
+import { getInputTokenLimitStatus } from "@/lib/utils/client-token-validation";
 import { toast } from "sonner";
 import { removeTodosBySourceMessages } from "@/lib/utils/todo-utils";
 import { useDataStreamDispatch } from "@/app/components/DataStreamProvider";
@@ -368,7 +368,6 @@ export const useChatHandlers = ({
       }
     }
     // Check token limit before sending based on user plan
-    const tokenCount = countInputTokens(input, uploadedFiles);
     const maxTokens = getMaxTokensForSubscription(subscription, {
       mode: currentChatMode,
     });
@@ -389,11 +388,16 @@ export const useChatHandlers = ({
       }
     }
 
-    if (tokenCount > maxTokens) {
+    const tokenLimitStatus = await getInputTokenLimitStatus(
+      input,
+      uploadedFiles,
+      maxTokens,
+    );
+    if (tokenLimitStatus.exceedsLimit) {
       const hasFiles = uploadedFiles.length > 0;
       const planText = subscription !== "free" ? "" : " (Free plan limit)";
       toast.error("Message is too long", {
-        description: `Your message is too large (${tokenCount.toLocaleString()} tokens). Please make it shorter${hasFiles ? " or remove some files" : ""}${planText}.`,
+        description: `Your message is too large (${tokenLimitStatus.tokenCount.toLocaleString()} tokens). Please make it shorter${hasFiles ? " or remove some files" : ""}${planText}.`,
       });
       return false;
     }

--- a/app/hooks/useFileUpload.ts
+++ b/app/hooks/useFileUpload.ts
@@ -12,7 +12,7 @@ import {
   isImageFile,
   RateLimitInfo,
 } from "@/lib/utils/file-utils";
-import { getMaxFileTokens } from "@/lib/token-utils";
+import { getMaxFileTokens } from "@/lib/token-limits";
 import {
   FileProcessingResult,
   FileSource,

--- a/lib/token-limits.ts
+++ b/lib/token-limits.ts
@@ -1,0 +1,32 @@
+import { FREE_MAX_CONTEXT_TOKENS } from "@/lib/rate-limit/free-config";
+import type { ChatMode, SubscriptionTier } from "@/types";
+
+export const MAX_TOKENS_FREE = FREE_MAX_CONTEXT_TOKENS;
+export const MAX_TOKENS_PAID = 200000;
+
+/**
+ * Percentage of context window budget allocated to file uploads in Ask mode.
+ * Leaves remaining budget for conversation history, system prompt, and model output.
+ */
+export const FILE_TOKEN_PERCENT = 0.5;
+
+export const getMaxTokensForSubscription = (
+  subscription?: SubscriptionTier,
+  _opts?: { mode?: ChatMode },
+): number => {
+  if (subscription === "free") return MAX_TOKENS_FREE;
+  return MAX_TOKENS_PAID;
+};
+
+/**
+ * Maximum total tokens allowed across all uploaded files in Ask mode.
+ * Scales with the subscription's context window budget.
+ */
+export const getMaxFileTokens = (
+  subscription: SubscriptionTier,
+  opts?: { mode?: ChatMode },
+): number => {
+  return Math.floor(
+    getMaxTokensForSubscription(subscription, opts) * FILE_TOKEN_PERCENT,
+  );
+};

--- a/lib/token-utils.ts
+++ b/lib/token-utils.ts
@@ -4,9 +4,15 @@ import {
   encode as encodeGptTokens,
   decode,
 } from "gpt-tokenizer";
-import type { SubscriptionTier } from "@/types";
 import type { Id } from "@/convex/_generated/dataModel";
-import { FREE_MAX_CONTEXT_TOKENS } from "@/lib/rate-limit/free-config";
+import { MAX_TOKENS_PAID } from "@/lib/token-limits";
+export {
+  FILE_TOKEN_PERCENT,
+  getMaxFileTokens,
+  getMaxTokensForSubscription,
+  MAX_TOKENS_FREE,
+  MAX_TOKENS_PAID,
+} from "@/lib/token-limits";
 
 const DISALLOWED_SPECIAL_TOKEN_MESSAGE = "Disallowed special token";
 const TOKENIZE_SPECIAL_TOKENS_AS_TEXT: NonNullable<
@@ -55,35 +61,6 @@ export const safeEncode = (
 
     throw error;
   }
-};
-
-export const MAX_TOKENS_FREE = FREE_MAX_CONTEXT_TOKENS;
-export const MAX_TOKENS_PAID = 200000;
-/**
- * Percentage of context window budget allocated to file uploads in Ask mode.
- * Leaves remaining budget for conversation history, system prompt, and model output.
- */
-export const FILE_TOKEN_PERCENT = 0.5;
-
-export const getMaxTokensForSubscription = (
-  subscription?: SubscriptionTier,
-  _opts?: { mode?: import("@/types").ChatMode },
-): number => {
-  if (subscription === "free") return MAX_TOKENS_FREE;
-  return MAX_TOKENS_PAID;
-};
-
-/**
- * Maximum total tokens allowed across all uploaded files in Ask mode.
- * Scales with the subscription's context window budget.
- */
-export const getMaxFileTokens = (
-  subscription: SubscriptionTier,
-  opts?: { mode?: import("@/types").ChatMode },
-): number => {
-  return Math.floor(
-    getMaxTokensForSubscription(subscription, opts) * FILE_TOKEN_PERCENT,
-  );
 };
 
 // Token limits for different contexts

--- a/lib/utils/__tests__/client-token-validation.test.ts
+++ b/lib/utils/__tests__/client-token-validation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  getInputTokenLimitStatus,
+  inputTokenCountCouldExceedLimit,
+} from "@/lib/utils/client-token-validation";
+
+describe("getInputTokenLimitStatus", () => {
+  it("accepts inputs whose UTF-8 byte upper bound fits the token budget", async () => {
+    expect(
+      inputTokenCountCouldExceedLimit("ordinary chat message", [], 128000),
+    ).toBe(false);
+    await expect(
+      getInputTokenLimitStatus("ordinary chat message", [], 128000),
+    ).resolves.toEqual({ exceedsLimit: false });
+  });
+
+  it("uses the exact tokenizer instead of rejecting multibyte text early", async () => {
+    expect(inputTokenCountCouldExceedLimit("é", [], 1)).toBe(true);
+    await expect(getInputTokenLimitStatus("é", [], 1)).resolves.toEqual({
+      exceedsLimit: false,
+    });
+  });
+
+  it("reports the exact token count when text exceeds the limit", async () => {
+    const result = await getInputTokenLimitStatus("hello world", [], 1);
+
+    expect(result.exceedsLimit).toBe(true);
+    if (result.exceedsLimit) {
+      expect(result.tokenCount).toBeGreaterThan(1);
+    }
+  });
+
+  it("includes uploaded file tokens in the limit", async () => {
+    await expect(
+      getInputTokenLimitStatus("", [{ tokens: 2 }], 1),
+    ).resolves.toEqual({ exceedsLimit: true, tokenCount: 2 });
+  });
+});

--- a/lib/utils/client-token-validation.ts
+++ b/lib/utils/client-token-validation.ts
@@ -1,0 +1,41 @@
+type TokenizedFile = { tokens?: number };
+
+export type InputTokenLimitStatus =
+  { exceedsLimit: false } | { exceedsLimit: true; tokenCount: number };
+
+export const inputTokenCountCouldExceedLimit = (
+  input: string,
+  uploadedFiles: TokenizedFile[],
+  maxTokens: number,
+): boolean => {
+  const fileTokens = uploadedFiles.reduce(
+    (total, file) => total + (file.tokens || 0),
+    0,
+  );
+  const textByteUpperBound = new TextEncoder().encode(input).byteLength;
+
+  return fileTokens + textByteUpperBound > maxTokens;
+};
+
+/**
+ * Checks common inputs without loading the browser tokenizer. A BPE token
+ * represents at least one UTF-8 byte, so an input whose total UTF-8 byte count
+ * fits the token budget cannot exceed that budget. Inputs near the limit still
+ * use the exact tokenizer to preserve existing validation behavior.
+ */
+export const getInputTokenLimitStatus = async (
+  input: string,
+  uploadedFiles: TokenizedFile[],
+  maxTokens: number,
+): Promise<InputTokenLimitStatus> => {
+  if (!inputTokenCountCouldExceedLimit(input, uploadedFiles, maxTokens)) {
+    return { exceedsLimit: false };
+  }
+
+  const { countInputTokens } = await import("@/lib/token-utils");
+  const tokenCount = countInputTokens(input, uploadedFiles);
+
+  return tokenCount > maxTokens
+    ? { exceedsLimit: true, tokenCount }
+    : { exceedsLimit: false };
+};


### PR DESCRIPTION
## Summary

- keep the 1 MB compressed GPT tokenizer rank table out of the initial browser bundle by using a safe UTF-8 byte upper bound for ordinary messages and dynamically loading exact tokenization only near the limit
- lazy-load Settings and All Files dialogs on first use, with cold-load feedback, while keeping them mounted afterward so close animations and dialog state remain intact
- skip the redundant sidebar chat query when `ChatLayout` already supplies its lifted chat-list subscription
- avoid fetching team membership data until Settings is actually open

## Measured impact

Using the Next.js 16 Turbopack module graph (`pnpm exec next experimental-analyze`) on current `main` and this branch:

| Client JavaScript | Before | After | Change |
| --- | ---: | ---: | ---: |
| Estimated compressed initial graph | 2,111,811 B | 966,641 B | -1,145,170 B (-54.2%) |

The tokenizer rank table is 1,024,464 compressed bytes and moves from initial depth 8 to async depth 1009. `SettingsDialog` and `AllFilesDialog` also move behind async boundaries.

References: [Next.js lazy loading](https://nextjs.org/docs/app/guides/lazy-loading), [Next.js package bundling](https://nextjs.org/docs/pages/guides/package-bundling).

## Validation

- `pnpm typecheck`
- `pnpm lint` (passes with six pre-existing warnings in untouched files)
- 45 focused Jest tests across token validation, token utilities, ChatInput integration, chat integration, and All Files dialog
- before/after `pnpm exec next experimental-analyze`
- authenticated Chromium verification: normal paste, near-limit multibyte paste, over-limit rejection, lazy Settings open/close, no console errors or framework overlay

## Manual verification

1. Sign in and open Settings from the sidebar. Switch tabs and close with Escape; the dialog should load on demand and behave normally.
2. Paste ordinary text into the chat input; it should insert immediately. Paste content above the plan limit; it should keep the existing attachment/rejection behavior.
3. Open a message's All Files view; the dialog should load on first use and retain its existing download/preview behavior.
4. Expand and collapse the chat sidebar; the chat list should stay populated without a second query subscription.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved token-limit validation for chat messages, pasted text, files, and message edits with async checking and more precise limits.
  * Free-tier users now see token-count details when content is too long, including paste attempts.
  * Oversized pasted text can be uploaded for eligible users.
  * Settings and “All files” dialogs now load only after first open to improve initial performance.
* **Bug Fixes**
  * Prevented unnecessary chat-list refreshes when preloaded data is provided.
  * Enhanced cancellation when fetching team admin status.
* **Tests**
  * Added coverage for token-limit validation, including multilingual and file token counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->