### PR TITLE
Reduce AuthKit Server Action fetch failures

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { headers } from "next/headers";
+import { withAuth } from "@workos-inc/authkit-nextjs";
 import "./globals.css";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -90,11 +92,28 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+async function getInitialAuth() {
+  const requestHeaders = await headers();
+
+  // Static public pages are prerendered without proxy-injected AuthKit headers.
+  if (!requestHeaders.has("x-workos-middleware")) {
+    return { user: null } as const;
+  }
+
+  // Never serialize the server-only access token into the client provider.
+  const { accessToken, ...initialAuth } = await withAuth();
+  return initialAuth;
+}
+
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Supplying server-resolved auth prevents AuthKitProvider from invoking its
+  // getAuth Server Action on every mount.
+  const initialAuth = await getInitialAuth();
+
   const content = (
     <GlobalStateProvider>
       <PostHogProvider>
@@ -127,7 +146,9 @@ export default function RootLayout({
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
       </head>
       <body className="antialiased h-full">
-        <ConvexClientProvider>{content}</ConvexClientProvider>
+        <ConvexClientProvider initialAuth={initialAuth}>
+          {content}
+        </ConvexClientProvider>
       </body>
     </html>
   );

--- a/components/ConvexClientProvider.tsx
+++ b/components/ConvexClientProvider.tsx
@@ -4,11 +4,21 @@ import { ReactNode, useState } from "react";
 import { ConvexReactClient } from "convex/react";
 import { ConvexProviderWithAuth } from "convex/react";
 import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
+import type { NoUserInfo, UserInfo } from "@workos-inc/authkit-nextjs";
 import { useAuthFromAuthKit } from "@/lib/auth/use-auth-from-authkit";
 
 const PRERENDER_CONVEX_URL = "https://placeholder.convex.cloud";
 
-export function ConvexClientProvider({ children }: { children: ReactNode }) {
+type AuthKitInitialAuth =
+  Omit<UserInfo, "accessToken"> | Omit<NoUserInfo, "accessToken">;
+
+export function ConvexClientProvider({
+  children,
+  initialAuth,
+}: {
+  children: ReactNode;
+  initialAuth: AuthKitInitialAuth;
+}) {
   const [convex] = useState(() => {
     const convexUrl =
       process.env.NEXT_PUBLIC_CONVEX_URL ??
@@ -24,7 +34,7 @@ export function ConvexClientProvider({ children }: { children: ReactNode }) {
   return (
     // Passing a callback still enables AuthKit's focus/visibility session probe.
     // Disable it entirely; Convex token refresh and middleware own auth recovery.
-    <AuthKitProvider onSessionExpired={false}>
+    <AuthKitProvider initialAuth={initialAuth} onSessionExpired={false}>
       <ConvexProviderWithAuth client={convex} useAuth={useAuthFromAuthKit}>
         {children}
       </ConvexProviderWithAuth>

--- a/components/__tests__/ConvexClientProvider.contracts.test.ts
+++ b/components/__tests__/ConvexClientProvider.contracts.test.ts
@@ -5,12 +5,27 @@ const providerSource = fs.readFileSync(
   path.resolve(__dirname, "../ConvexClientProvider.tsx"),
   "utf8",
 );
+const rootLayoutSource = fs.readFileSync(
+  path.resolve(__dirname, "../../app/layout.tsx"),
+  "utf8",
+);
 
 describe("ConvexClientProvider auth recovery contracts", () => {
   it("disables AuthKit focus and visibility session probes", () => {
-    expect(providerSource).toContain(
-      "<AuthKitProvider onSessionExpired={false}>",
-    );
+    expect(providerSource).toContain("onSessionExpired={false}");
     expect(providerSource).not.toContain("onSessionExpired={noop}");
+  });
+
+  it("hydrates AuthKit from server auth without serializing the access token", () => {
+    expect(rootLayoutSource).toContain(
+      "const { accessToken, ...initialAuth } = await withAuth();",
+    );
+    expect(rootLayoutSource).toContain(
+      'if (!requestHeaders.has("x-workos-middleware"))',
+    );
+    expect(rootLayoutSource).toContain(
+      "<ConvexClientProvider initialAuth={initialAuth}>",
+    );
+    expect(providerSource).toContain("initialAuth={initialAuth}");
   });
 });


### PR DESCRIPTION
## Summary

- hydrate the globally mounted AuthKit provider from proxy-derived server auth
- strip the server-only access token before passing auth state to the client
- preserve static public-route prerendering when AuthKit middleware headers are absent
- extend the existing AuthKit integration contract test

## Why

Fresh production sampling showed the dominant PostHog `TypeError: Failed to fetch` events resolving to Next.js `fetchServerAction`, but exact session/timestamp checks did not map them to Vercel's `Failed to find Server Action` 404 rows. Those are distinct client paths: a rejected fetch versus an action-not-found response.

The July 9 `onSessionExpired={false}` fix still disables AuthKit's focus/visibility probe. However, AuthKit still invoked `getAuthAction()` once on every provider mount because HackerAI did not supply `initialAuth`. A failed request could therefore initialize the client as signed out. Passing sanitized server auth removes that redundant mount-time Server Action without broadening PostHog suppression, changing chat transport, or changing the existing exact stale-action reload recovery.

## Validation

- `corepack pnpm jest components/__tests__/ConvexClientProvider.contracts.test.ts lib/auth/__tests__/use-auth-from-authkit.test.ts lib/posthog/__tests__/expected-frontend-exceptions.test.ts app/__tests__/providers.test.tsx --runInBand` — 4 suites / 58 tests passed
- commit hooks — 254 suites / 2,551 tests passed
- `corepack pnpm typecheck`
- ESLint, Prettier, and `git diff --check`
- `corepack pnpm exec next build` — production build passed, including static legal/trust routes

## Manual verification

- In Chrome, open a fresh authenticated `/c/...` route and confirm auth and Convex initialize without the redundant initial AuthKit Server Action.
- Verify signed-out `/`, `/privacy-policy`, `/terms-of-service`, and `/trust` still load.
- After deployment, compare the PostHog issue's occurrences per session from the deployment timestamp. Track Vercel stale-action 404s separately because tabs beyond the configured skew-protection window can still produce them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved authentication startup by preloading session information during page rendering.
  * Authentication state now hydrates securely without exposing access tokens to the client.
  * Public and prerendered pages initialize without requiring authentication data.

* **Bug Fixes**
  * Improved session recovery and consistency between server-rendered and client-side authentication states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->