### PR TITLE
Honor grandfathered $20 Pro usage allowance

### DIFF
--- a/app/api/migrate-pentestgpt/__tests__/route.test.ts
+++ b/app/api/migrate-pentestgpt/__tests__/route.test.ts
@@ -2,6 +2,11 @@ import { POST } from "../route";
 import { getUserIDAndPro } from "@/lib/auth/get-user-id";
 import { stripe } from "../../stripe";
 import { workos } from "../../workos";
+import {
+  HACKERAI_PRO_20_MONTHLY_PRICE_ID,
+  PENTESTGPT_PRO_20_MONTHLY_PRICE_ID,
+} from "@/lib/billing/included-usage";
+import { capCurrentCycleAllocation } from "@/lib/rate-limit";
 
 jest.mock("next/server", () => ({
   NextResponse: {
@@ -14,6 +19,10 @@ jest.mock("next/server", () => ({
 
 jest.mock("@/lib/auth/get-user-id", () => ({
   getUserIDAndPro: jest.fn(),
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  capCurrentCycleAllocation: jest.fn(),
 }));
 
 jest.mock("../../stripe", () => ({
@@ -100,6 +109,10 @@ const mockCreateSubscription = stripe.subscriptions
   .create as jest.MockedFunction<typeof stripe.subscriptions.create>;
 const mockCancelSubscription = stripe.subscriptions
   .cancel as jest.MockedFunction<typeof stripe.subscriptions.cancel>;
+const mockCapCurrentCycleAllocation =
+  capCurrentCycleAllocation as jest.MockedFunction<
+    typeof capCurrentCycleAllocation
+  >;
 
 const request = () => ({ url: "https://hackerai.test/api/migrate-pentestgpt" });
 
@@ -177,6 +190,7 @@ describe("POST /api/migrate-pentestgpt", () => {
     mockUpdateOrganization.mockResolvedValue({} as never);
     mockCreateSubscription.mockResolvedValue({ id: "sub_new" } as never);
     mockCancelSubscription.mockResolvedValue({ id: "sub_legacy" } as never);
+    mockCapCurrentCycleAllocation.mockResolvedValue({} as never);
   });
 
   it("does not enumerate or delete existing WorkOS organizations", async () => {
@@ -241,6 +255,57 @@ describe("POST /api/migrate-pentestgpt", () => {
       }),
     );
     expect(mockCancelSubscription).toHaveBeenCalledWith("sub_legacy");
+  });
+
+  it("preserves the known legacy $20 Pro price during migration", async () => {
+    mockListSubscriptions.mockResolvedValueOnce({
+      data: [
+        {
+          id: "sub_legacy_20",
+          default_payment_method: "pm_legacy",
+          items: {
+            data: [
+              {
+                quantity: 1,
+                current_period_end: 4_102_444_800,
+                price: {
+                  id: PENTESTGPT_PRO_20_MONTHLY_PRICE_ID,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } as never);
+    mockRetrievePrice.mockResolvedValueOnce({
+      id: PENTESTGPT_PRO_20_MONTHLY_PRICE_ID,
+      metadata: {},
+      product: {
+        id: "prod_legacy",
+        name: "PentestGPT Pro",
+        metadata: {},
+        deleted: false,
+      },
+      recurring: {
+        interval: "month",
+      },
+    } as never);
+
+    const response = await POST(request() as any);
+
+    expect(response.status).toBe(200);
+    expect(mockListPrices).not.toHaveBeenCalled();
+    expect(mockCreateSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [{ price: HACKERAI_PRO_20_MONTHLY_PRICE_ID, quantity: 1 }],
+      }),
+    );
+    expect(mockCapCurrentCycleAllocation).toHaveBeenCalledWith(
+      "user_123",
+      "pro",
+      200_000,
+      4_102_444_800,
+    );
   });
 
   it("does not create or delete WorkOS organizations when destination price is missing", async () => {

--- a/app/api/migrate-pentestgpt/__tests__/route.test.ts
+++ b/app/api/migrate-pentestgpt/__tests__/route.test.ts
@@ -308,6 +308,94 @@ describe("POST /api/migrate-pentestgpt", () => {
     );
   });
 
+  it("stops before migration side effects when the grandfathered usage cap fails", async () => {
+    mockListSubscriptions.mockResolvedValueOnce({
+      data: [
+        {
+          id: "sub_legacy_20",
+          default_payment_method: "pm_legacy",
+          items: {
+            data: [
+              {
+                quantity: 1,
+                current_period_end: 4_102_444_800,
+                price: { id: PENTESTGPT_PRO_20_MONTHLY_PRICE_ID },
+              },
+            ],
+          },
+        },
+      ],
+    } as never);
+    mockRetrievePrice.mockResolvedValueOnce({
+      id: PENTESTGPT_PRO_20_MONTHLY_PRICE_ID,
+      metadata: {},
+      product: {
+        id: "prod_legacy",
+        name: "PentestGPT Pro",
+        metadata: {},
+        deleted: false,
+      },
+      recurring: { interval: "month" },
+    } as never);
+    mockCapCurrentCycleAllocation.mockRejectedValueOnce(
+      new Error("Redis down"),
+    );
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({
+      error: "Failed to prepare grandfathered subscription usage",
+    });
+    expect(mockCreateOrganization).not.toHaveBeenCalled();
+    expect(mockCreateOrganizationMembership).not.toHaveBeenCalled();
+    expect(mockUpdateCustomer).not.toHaveBeenCalled();
+    expect(mockCreateSubscription).not.toHaveBeenCalled();
+    expect(mockCancelSubscription).not.toHaveBeenCalled();
+  });
+
+  it("stops when the legacy $20 billing period cannot be resolved", async () => {
+    mockListSubscriptions.mockResolvedValueOnce({
+      data: [
+        {
+          id: "sub_legacy_20",
+          default_payment_method: "pm_legacy",
+          items: {
+            data: [
+              {
+                quantity: 1,
+                price: { id: PENTESTGPT_PRO_20_MONTHLY_PRICE_ID },
+              },
+            ],
+          },
+        },
+      ],
+    } as never);
+    mockRetrievePrice.mockResolvedValueOnce({
+      id: PENTESTGPT_PRO_20_MONTHLY_PRICE_ID,
+      metadata: {},
+      product: {
+        id: "prod_legacy",
+        name: "PentestGPT Pro",
+        metadata: {},
+        deleted: false,
+      },
+      recurring: { interval: "month" },
+    } as never);
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({
+      error: "Could not determine grandfathered subscription period",
+    });
+    expect(mockCapCurrentCycleAllocation).not.toHaveBeenCalled();
+    expect(mockCreateOrganization).not.toHaveBeenCalled();
+    expect(mockCreateSubscription).not.toHaveBeenCalled();
+  });
+
   it("does not create or delete WorkOS organizations when destination price is missing", async () => {
     mockListPrices.mockResolvedValueOnce({ data: [] } as never);
 

--- a/app/api/migrate-pentestgpt/route.ts
+++ b/app/api/migrate-pentestgpt/route.ts
@@ -2,6 +2,11 @@ import { stripe } from "../stripe";
 import { workos } from "../workos";
 import { getUserIDAndPro } from "@/lib/auth/get-user-id";
 import { buildWorkOSOrganizationName } from "@/lib/auth/workos-organization-name";
+import {
+  pentestgptMigrationPriceOverride,
+  PRO_20_MONTHLY_INCLUDED_USAGE_POINTS,
+} from "@/lib/billing/included-usage";
+import { capCurrentCycleAllocation } from "@/lib/rate-limit";
 import { NextRequest, NextResponse } from "next/server";
 
 export const POST = async (req: NextRequest) => {
@@ -136,21 +141,29 @@ export const POST = async (req: NextRequest) => {
       );
     }
 
-    // Get the destination price by lookup key (must exist in Stripe)
-    const destinationPrices = await stripe.prices.list({
-      lookup_keys: [subscriptionLookupKey],
-      expand: ["data.product"],
-    });
+    // Preserve the known legacy $20 Pro price. All other legacy plans keep
+    // using their current lookup-key mapping.
+    const grandfatheredPriceOverride =
+      pentestgptMigrationPriceOverride(priceId);
+    let destinationPriceId = grandfatheredPriceOverride;
+    if (!destinationPriceId) {
+      const destinationPrices = await stripe.prices.list({
+        lookup_keys: [subscriptionLookupKey],
+        expand: ["data.product"],
+      });
 
-    if (!destinationPrices.data || destinationPrices.data.length === 0) {
-      console.error(`No price found for lookup key: ${subscriptionLookupKey}`);
-      return NextResponse.json(
-        { error: "Destination subscription price not found" },
-        { status: 404 },
-      );
+      if (!destinationPrices.data || destinationPrices.data.length === 0) {
+        console.error(
+          `No price found for lookup key: ${subscriptionLookupKey}`,
+        );
+        return NextResponse.json(
+          { error: "Destination subscription price not found" },
+          { status: 404 },
+        );
+      }
+
+      destinationPriceId = destinationPrices.data[0].id;
     }
-
-    const destinationPriceId = destinationPrices.data[0].id;
 
     const legacySub: any = pentestGPTSubscription;
     let paymentMethodId: string | undefined;
@@ -329,6 +342,25 @@ export const POST = async (req: NextRequest) => {
     } catch (cancelErr) {
       console.error("Failed to cancel old PentestGPT subscription:", cancelErr);
       // Don't fail the whole migration; proceed
+    }
+
+    if (grandfatheredPriceOverride) {
+      try {
+        await capCurrentCycleAllocation(
+          userId,
+          "pro",
+          PRO_20_MONTHLY_INCLUDED_USAGE_POINTS,
+          trialEnd,
+        );
+      } catch (usageError) {
+        // Billing migration has already succeeded. The next paid invoice will
+        // also apply this cap, so do not create duplicate subscriptions by
+        // returning a retryable error here.
+        console.error(
+          "Failed to apply the grandfathered Pro usage cap after migration:",
+          usageError,
+        );
+      }
     }
 
     // Return a minimal response used by the client to decide whether to show team welcome

--- a/app/api/migrate-pentestgpt/route.ts
+++ b/app/api/migrate-pentestgpt/route.ts
@@ -249,6 +249,35 @@ export const POST = async (req: NextRequest) => {
         ? oldCurrentPeriodEnd
         : undefined;
 
+    // Apply the grandfathered allowance before creating any Stripe or WorkOS
+    // resources. If Redis is unavailable, the user can safely retry the
+    // migration without risking duplicate subscriptions.
+    if (grandfatheredPriceOverride) {
+      if (!trialEnd) {
+        return NextResponse.json(
+          { error: "Could not determine grandfathered subscription period" },
+          { status: 500 },
+        );
+      }
+      try {
+        await capCurrentCycleAllocation(
+          userId,
+          "pro",
+          PRO_20_MONTHLY_INCLUDED_USAGE_POINTS,
+          trialEnd,
+        );
+      } catch (usageError) {
+        console.error(
+          "Failed to apply the grandfathered Pro usage cap before migration:",
+          usageError,
+        );
+        return NextResponse.json(
+          { error: "Failed to prepare grandfathered subscription usage" },
+          { status: 500 },
+        );
+      }
+    }
+
     // Create new organization with a WorkOS-safe display name only after all
     // migration prerequisites have been validated.
     const organization = await workos.organizations.createOrganization({
@@ -342,25 +371,6 @@ export const POST = async (req: NextRequest) => {
     } catch (cancelErr) {
       console.error("Failed to cancel old PentestGPT subscription:", cancelErr);
       // Don't fail the whole migration; proceed
-    }
-
-    if (grandfatheredPriceOverride) {
-      try {
-        await capCurrentCycleAllocation(
-          userId,
-          "pro",
-          PRO_20_MONTHLY_INCLUDED_USAGE_POINTS,
-          trialEnd,
-        );
-      } catch (usageError) {
-        // Billing migration has already succeeded. The next paid invoice will
-        // also apply this cap, so do not create duplicate subscriptions by
-        // returning a retryable error here.
-        console.error(
-          "Failed to apply the grandfathered Pro usage cap after migration:",
-          usageError,
-        );
-      }
     }
 
     // Return a minimal response used by the client to decide whether to show team welcome

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -6,6 +6,7 @@ import {
   beforeEach,
   afterEach,
 } from "@jest/globals";
+import { HACKERAI_PRO_20_MONTHLY_PRICE_ID } from "@/lib/billing/included-usage";
 
 const mockConstructEvent = jest.fn();
 const mockRetrieveCustomer = jest.fn();
@@ -517,6 +518,75 @@ describe("POST /api/subscription/webhook", () => {
     );
     expect(console.info).toHaveBeenCalledWith(
       "[Subscription Webhook] invoice.paid: skipping legacy PentestGPT subscription sub_legacy for invoice in_migrated_legacy",
+    );
+  });
+
+  it("resets the grandfathered $20 Pro price to $20 of included usage", async () => {
+    const periodEnd = 1_785_000_000;
+    mockConstructEvent.mockReturnValue({
+      id: "evt_invoice_paid_pro_20",
+      type: "invoice.paid",
+      data: {
+        object: {
+          id: "in_pro_20",
+          customer: "cus_pro_20",
+          amount_paid: 2000,
+          currency: "usd",
+          billing_reason: "subscription_cycle",
+          parent: {
+            subscription_details: {
+              subscription: "sub_pro_20",
+            },
+          },
+          status_transitions: {
+            paid_at: 1_782_000_000,
+          },
+        },
+      },
+    });
+    mockRetrieveCustomer.mockResolvedValue({
+      deleted: false,
+      id: "cus_pro_20",
+      metadata: {
+        workOSOrganizationId: "org_pro_20",
+      },
+    } as never);
+    mockListMemberships.mockResolvedValue({
+      autoPagination: jest.fn().mockResolvedValue([{ userId: "user_pro_20" }]),
+    } as never);
+    mockRetrieveSubscription.mockResolvedValue({
+      id: "sub_pro_20",
+      metadata: {},
+      items: {
+        data: [
+          {
+            quantity: 1,
+            current_period_end: periodEnd,
+            price: {
+              id: HACKERAI_PRO_20_MONTHLY_PRICE_ID,
+              lookup_key: null,
+              recurring: { interval: "month", interval_count: 1 },
+              product: {
+                id: "prod_hackerai_pro",
+                name: "HackerAI Pro",
+                metadata: {},
+              },
+            },
+          },
+        ],
+      },
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(makeWebhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockResetRateLimitBuckets).toHaveBeenCalledWith(
+      "user_pro_20",
+      "pro",
+      periodEnd,
+      200_000,
     );
   });
 

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -35,6 +35,7 @@ import {
   subscriptionPaymentFailureProperties,
   type BillingFailureProperties,
 } from "@/lib/billing/subscription-payment-failure";
+import { includedUsagePointsForStripePrice } from "@/lib/billing/included-usage";
 
 const WEBHOOK_LOG_PREFIX = "[Subscription Webhook]";
 const WEBHOOK_LOG_CONTEXT = {
@@ -112,6 +113,18 @@ const metadataString = (
 function subscriptionCurrentPeriodEndSeconds(
   subscription: Stripe.Subscription,
 ): number | undefined {
+  const itemPeriodEnds = subscription.items?.data
+    ?.map(
+      (item) => (item as { current_period_end?: unknown }).current_period_end,
+    )
+    .filter(
+      (periodEnd): periodEnd is number =>
+        typeof periodEnd === "number" &&
+        Number.isFinite(periodEnd) &&
+        periodEnd > 0,
+    );
+  if (itemPeriodEnds?.length) return Math.max(...itemPeriodEnds);
+
   const periodEnd = (subscription as { current_period_end?: unknown })
     .current_period_end;
   return typeof periodEnd === "number" &&
@@ -656,6 +669,9 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
   }
 
   const { tier, subscription } = resolved;
+  const includedUsagePoints = includedUsagePointsForStripePrice(
+    subscription.items?.data[0]?.price?.id,
+  );
 
   await setReferralCodesPaidEligibility({
     userIds,
@@ -713,8 +729,15 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
         `[Subscription Webhook] invoice.paid (upgrade): prorating ${tier} buckets for ${tierChangeUsers.length} user(s)`,
       );
 
-      const periodStart = (subscription as any).current_period_start as number;
-      const periodEnd = (subscription as any).current_period_end as number;
+      const subscriptionItem = subscription.items?.data[0] as
+        | { current_period_start?: number; current_period_end?: number }
+        | undefined;
+      const periodStart =
+        subscriptionItem?.current_period_start ??
+        ((subscription as any).current_period_start as number);
+      const periodEnd =
+        subscriptionItem?.current_period_end ??
+        ((subscription as any).current_period_end as number);
       const now = Math.floor(Date.now() / 1000);
       const totalDuration = periodEnd - periodStart;
       const remaining = periodEnd - now;
@@ -732,6 +755,7 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
             proratedRatio,
             stash!.consumed,
             periodEnd,
+            includedUsagePoints,
           ),
         ),
       );
@@ -743,7 +767,12 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
           monthlyUsagePeriodEndSeconds(subscription);
         await Promise.all(
           nonTierChangeUsers.map(({ uid }) =>
-            resetRateLimitBuckets(uid, tier, fallbackUsagePeriodEnd),
+            resetRateLimitBuckets(
+              uid,
+              tier,
+              fallbackUsagePeriodEnd,
+              includedUsagePoints,
+            ),
           ),
         );
       }
@@ -763,7 +792,9 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
   );
   const usagePeriodEnd = monthlyUsagePeriodEndSeconds(subscription);
   await Promise.all(
-    userIds.map((uid) => resetRateLimitBuckets(uid, tier, usagePeriodEnd)),
+    userIds.map((uid) =>
+      resetRateLimitBuckets(uid, tier, usagePeriodEnd, includedUsagePoints),
+    ),
   );
 
   if (resetMode.reason === "subscription_create") {

--- a/convex/rateLimitStatus.ts
+++ b/convex/rateLimitStatus.ts
@@ -5,6 +5,7 @@ import { v } from "convex/values";
 import {
   getBudgetLimits,
   getMonthlyBucketKey,
+  POINTS_PER_DOLLAR,
   getSubscriptionPrice,
 } from "../lib/rate-limit/token-bucket";
 import type { SubscriptionTier } from "../types";
@@ -123,7 +124,7 @@ export const getAgentRateLimitStatus = action({
       });
 
       const monthlyKey = `${userId}:${subscription}`;
-      const monthlyResult = await monthlyRatelimit.limit(monthlyKey, {
+      let monthlyResult = await monthlyRatelimit.limit(monthlyKey, {
         rate: 0,
       });
       const monthlyStorageKey = getMonthlyBucketKey(userId, subscription);
@@ -131,18 +132,24 @@ export const getAgentRateLimitStatus = action({
         await redis.hget(monthlyStorageKey, "cycleAllocation"),
       );
 
-      const monthlyRemaining = Math.min(
-        Math.max(0, monthlyResult.remaining),
-        monthlyLimit,
-      );
       const cycleAllocation =
         storedCycleAllocation === null
           ? monthlyLimit
           : Math.min(storedCycleAllocation, monthlyLimit);
-      const effectiveMonthlyLimit = Math.min(
-        monthlyLimit,
-        Math.max(monthlyRemaining, cycleAllocation),
+      if (monthlyResult.remaining > cycleAllocation) {
+        monthlyResult = await monthlyRatelimit.limit(monthlyKey, {
+          rate: monthlyResult.remaining - cycleAllocation,
+        });
+        if (monthlyResult.success === false) {
+          throw new Error("Failed to enforce the current cycle allocation");
+        }
+      }
+
+      const monthlyRemaining = Math.min(
+        Math.max(0, monthlyResult.remaining),
+        cycleAllocation,
       );
+      const effectiveMonthlyLimit = cycleAllocation;
       const monthlyUsed = Math.max(0, effectiveMonthlyLimit - monthlyRemaining);
 
       return {
@@ -156,7 +163,7 @@ export const getAgentRateLimitStatus = action({
               : 0,
           resetTime: new Date(monthlyResult.reset).toISOString(),
         },
-        monthlyBudgetUsd,
+        monthlyBudgetUsd: effectiveMonthlyLimit / POINTS_PER_DOLLAR,
       };
     } catch (error) {
       console.error("Failed to get rate limit status:", error);

--- a/convex/rateLimitStatus.ts
+++ b/convex/rateLimitStatus.ts
@@ -124,7 +124,7 @@ export const getAgentRateLimitStatus = action({
       });
 
       const monthlyKey = `${userId}:${subscription}`;
-      let monthlyResult = await monthlyRatelimit.limit(monthlyKey, {
+      const monthlyResult = await monthlyRatelimit.limit(monthlyKey, {
         rate: 0,
       });
       const monthlyStorageKey = getMonthlyBucketKey(userId, subscription);
@@ -136,15 +136,6 @@ export const getAgentRateLimitStatus = action({
         storedCycleAllocation === null
           ? monthlyLimit
           : Math.min(storedCycleAllocation, monthlyLimit);
-      if (monthlyResult.remaining > cycleAllocation) {
-        monthlyResult = await monthlyRatelimit.limit(monthlyKey, {
-          rate: monthlyResult.remaining - cycleAllocation,
-        });
-        if (monthlyResult.success === false) {
-          throw new Error("Failed to enforce the current cycle allocation");
-        }
-      }
-
       const monthlyRemaining = Math.min(
         Math.max(0, monthlyResult.remaining),
         cycleAllocation,

--- a/lib/billing/__tests__/included-usage.test.ts
+++ b/lib/billing/__tests__/included-usage.test.ts
@@ -1,0 +1,32 @@
+import {
+  HACKERAI_PRO_20_MONTHLY_PRICE_ID,
+  PENTESTGPT_PRO_20_MONTHLY_PRICE_ID,
+  PRO_20_MONTHLY_INCLUDED_USAGE_POINTS,
+  includedUsagePointsForStripePrice,
+  pentestgptMigrationPriceOverride,
+} from "@/lib/billing/included-usage";
+
+describe("price-specific included usage", () => {
+  it.each([
+    HACKERAI_PRO_20_MONTHLY_PRICE_ID,
+    PENTESTGPT_PRO_20_MONTHLY_PRICE_ID,
+  ])("maps %s to the grandfathered $20 allowance", (priceId) => {
+    expect(includedUsagePointsForStripePrice(priceId)).toBe(
+      PRO_20_MONTHLY_INCLUDED_USAGE_POINTS,
+    );
+  });
+
+  it("uses the tier default for every other price", () => {
+    expect(includedUsagePointsForStripePrice("price_pro_25")).toBeUndefined();
+    expect(includedUsagePointsForStripePrice(null)).toBeUndefined();
+  });
+
+  it("preserves the $20 price when a matching PentestGPT user migrates", () => {
+    expect(
+      pentestgptMigrationPriceOverride(PENTESTGPT_PRO_20_MONTHLY_PRICE_ID),
+    ).toBe(HACKERAI_PRO_20_MONTHLY_PRICE_ID);
+    expect(
+      pentestgptMigrationPriceOverride("price_legacy_other"),
+    ).toBeUndefined();
+  });
+});

--- a/lib/billing/included-usage.ts
+++ b/lib/billing/included-usage.ts
@@ -1,0 +1,33 @@
+/** Current HackerAI Pro price retained by grandfathered $20/month customers. */
+export const HACKERAI_PRO_20_MONTHLY_PRICE_ID =
+  "price_1S7i1qFAn4ulhcn1kyxA8jp6";
+
+/** Legacy PentestGPT Pro price used to identify $20/month migrations. */
+export const PENTESTGPT_PRO_20_MONTHLY_PRICE_ID =
+  "price_1OhIo2FAn4ulhcn1JyrRXnwe";
+
+/** Included provider/tool usage for the grandfathered $20/month Pro variant. */
+export const PRO_20_MONTHLY_INCLUDED_USAGE_POINTS = 200_000;
+
+const PRO_20_MONTHLY_PRICE_IDS = new Set([
+  HACKERAI_PRO_20_MONTHLY_PRICE_ID,
+  PENTESTGPT_PRO_20_MONTHLY_PRICE_ID,
+]);
+
+/** Return a price-specific included-usage cap, or undefined for tier defaults. */
+export function includedUsagePointsForStripePrice(
+  priceId: string | null | undefined,
+): number | undefined {
+  return priceId && PRO_20_MONTHLY_PRICE_IDS.has(priceId)
+    ? PRO_20_MONTHLY_INCLUDED_USAGE_POINTS
+    : undefined;
+}
+
+/** Keep grandfathered PentestGPT $20 customers on the HackerAI $20 price. */
+export function pentestgptMigrationPriceOverride(
+  legacyPriceId: string | null | undefined,
+): string | undefined {
+  return legacyPriceId === PENTESTGPT_PRO_20_MONTHLY_PRICE_ID
+    ? HACKERAI_PRO_20_MONTHLY_PRICE_ID
+    : undefined;
+}

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -22,6 +22,7 @@ describe("token-bucket async functions", () => {
   const mockHgetFn = jest.fn();
   const mockHsetFn = jest.fn();
   const mockExistsFn = jest.fn();
+  const mockEvalFn = jest.fn();
   const mockDelFn = jest.fn();
   const mockExpireFn = jest.fn();
   const mockScanFn = jest.fn();
@@ -46,6 +47,7 @@ describe("token-bucket async functions", () => {
     mockHgetFn.mockResolvedValue(null);
     mockHsetFn.mockResolvedValue(1);
     mockExistsFn.mockResolvedValue(1);
+    mockEvalFn.mockResolvedValue([-1, -1, 0]);
     mockDelFn.mockResolvedValue(1);
     mockExpireFn.mockResolvedValue(1);
     mockScanFn.mockResolvedValue(["0", []]);
@@ -74,6 +76,7 @@ describe("token-bucket async functions", () => {
       hget: mockHgetFn,
       hset: mockHsetFn,
       exists: mockExistsFn,
+      eval: mockEvalFn,
       del: mockDelFn,
       expire: mockExpireFn,
       scan: mockScanFn,
@@ -109,6 +112,7 @@ describe("token-bucket async functions", () => {
           hget: mockHgetFn,
           hset: mockHsetFn,
           exists: mockExistsFn,
+          eval: mockEvalFn,
           del: mockDelFn,
           expire: mockExpireFn,
           scan: mockScanFn,
@@ -263,17 +267,11 @@ describe("token-bucket async functions", () => {
 
     it("enforces a stored price-specific cycle allocation", async () => {
       const { checkTokenBucketLimit } = getIsolatedModule();
-      mockHgetFn.mockResolvedValue(200_000);
+      mockEvalFn.mockResolvedValue([200_000, 200_000, 50_000]);
       mockLimitFn
         .mockResolvedValueOnce({
           success: true,
           remaining: 250_000,
-          reset: Date.now() + 3600000,
-          limit: 250_000,
-        })
-        .mockResolvedValueOnce({
-          success: true,
-          remaining: 200_000,
           reset: Date.now() + 3600000,
           limit: 250_000,
         })
@@ -286,9 +284,12 @@ describe("token-bucket async functions", () => {
 
       const result = await checkTokenBucketLimit("user-123", "pro", 1000);
 
-      expect(mockLimitFn).toHaveBeenNthCalledWith(2, expect.any(String), {
-        rate: 50_000,
-      });
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.any(String),
+        ["usage:monthly:user-123:pro"],
+        [],
+      );
+      expect(mockLimitFn).toHaveBeenCalledTimes(2);
       expect(result.limit).toBe(200_000);
       expect(result.monthly?.limit).toBe(200_000);
     });
@@ -991,20 +992,9 @@ describe("token-bucket async functions", () => {
 
     it("lowers the current cycle without restoring consumed usage", async () => {
       const { capCurrentCycleAllocation } = getIsolatedModule();
-      mockHgetFn.mockResolvedValue(250_000);
-      mockLimitFn
-        .mockResolvedValueOnce({
-          success: true,
-          remaining: 150_000,
-          reset: Date.now() + 3600000,
-          limit: 250_000,
-        })
-        .mockResolvedValueOnce({
-          success: true,
-          remaining: 100_000,
-          reset: Date.now() + 3600000,
-          limit: 250_000,
-        });
+      mockEvalFn.mockResolvedValue([
+        250_000, 150_000, 200_000, 100_000, 50_000,
+      ]);
 
       const result = await capCurrentCycleAllocation(
         "user-123",
@@ -1012,9 +1002,7 @@ describe("token-bucket async functions", () => {
         200_000,
       );
 
-      expect(mockLimitFn).toHaveBeenNthCalledWith(2, expect.any(String), {
-        rate: 50_000,
-      });
+      expect(mockLimitFn).toHaveBeenCalledTimes(1);
       expect(result).toEqual({
         created: false,
         previousAllocation: 250_000,
@@ -1023,24 +1011,16 @@ describe("token-bucket async functions", () => {
         targetRemaining: 100_000,
         pointsRemoved: 50_000,
       });
-      expect(mockHsetFn).toHaveBeenCalledWith(
-        "usage:monthly:user-123:pro",
-        expect.objectContaining({
-          cycleAllocation: 200_000,
-          cycleTierMax: 250_000,
-        }),
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.any(String),
+        ["usage:monthly:user-123:pro"],
+        [200_000, 250_000, -1],
       );
     });
 
     it("does not increase an already-lower prorated allocation", async () => {
       const { capCurrentCycleAllocation } = getIsolatedModule();
-      mockHgetFn.mockResolvedValue(150_000);
-      mockLimitFn.mockResolvedValueOnce({
-        success: true,
-        remaining: 100_000,
-        reset: Date.now() + 3600000,
-        limit: 250_000,
-      });
+      mockEvalFn.mockResolvedValue([150_000, 100_000, 150_000, 100_000, 0]);
 
       const result = await capCurrentCycleAllocation(
         "user-123",

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -19,7 +19,9 @@ describe("token-bucket async functions", () => {
   const mockCreateRedisClient = jest.fn();
   const mockLimitFn = jest.fn();
   const mockHincrbyFn = jest.fn();
+  const mockHgetFn = jest.fn();
   const mockHsetFn = jest.fn();
+  const mockExistsFn = jest.fn();
   const mockDelFn = jest.fn();
   const mockExpireFn = jest.fn();
   const mockScanFn = jest.fn();
@@ -41,7 +43,9 @@ describe("token-bucket async functions", () => {
       limit: 10000,
     });
     mockHincrbyFn.mockResolvedValue(5000);
+    mockHgetFn.mockResolvedValue(null);
     mockHsetFn.mockResolvedValue(1);
+    mockExistsFn.mockResolvedValue(1);
     mockDelFn.mockResolvedValue(1);
     mockExpireFn.mockResolvedValue(1);
     mockScanFn.mockResolvedValue(["0", []]);
@@ -67,7 +71,9 @@ describe("token-bucket async functions", () => {
     });
     mockCreateRedisClient.mockReturnValue({
       hincrby: mockHincrbyFn,
+      hget: mockHgetFn,
       hset: mockHsetFn,
+      exists: mockExistsFn,
       del: mockDelFn,
       expire: mockExpireFn,
       scan: mockScanFn,
@@ -100,7 +106,9 @@ describe("token-bucket async functions", () => {
       jest.doMock("@upstash/redis", () => ({
         Redis: jest.fn().mockImplementation(() => ({
           hincrby: mockHincrbyFn,
+          hget: mockHgetFn,
           hset: mockHsetFn,
+          exists: mockExistsFn,
           del: mockDelFn,
           expire: mockExpireFn,
           scan: mockScanFn,
@@ -251,6 +259,38 @@ describe("token-bucket async functions", () => {
       expect(result.monthly!.remaining).toBe(result.remaining);
       expect(result.monthly!.limit).toBe(result.limit);
       expect(result.monthly!.resetTime).toEqual(result.resetTime);
+    });
+
+    it("enforces a stored price-specific cycle allocation", async () => {
+      const { checkTokenBucketLimit } = getIsolatedModule();
+      mockHgetFn.mockResolvedValue(200_000);
+      mockLimitFn
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 250_000,
+          reset: Date.now() + 3600000,
+          limit: 250_000,
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 200_000,
+          reset: Date.now() + 3600000,
+          limit: 250_000,
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 199_993,
+          reset: Date.now() + 3600000,
+          limit: 250_000,
+        });
+
+      const result = await checkTokenBucketLimit("user-123", "pro", 1000);
+
+      expect(mockLimitFn).toHaveBeenNthCalledWith(2, expect.any(String), {
+        rate: 50_000,
+      });
+      expect(result.limit).toBe(200_000);
+      expect(result.monthly?.limit).toBe(200_000);
     });
 
     it("should throw when the final monthly deduction fails after a successful peek", async () => {
@@ -798,6 +838,18 @@ describe("token-bucket async functions", () => {
 
       expect(mockHsetFn).toHaveBeenCalled();
     });
+
+    it("caps refunds at the stored cycle allocation", async () => {
+      const { refundUsage } = getIsolatedModule();
+      mockHgetFn.mockResolvedValue(200_000);
+      mockHincrbyFn.mockResolvedValue(210_000);
+
+      await refundUsage("user-123", "pro", 50_000, 0);
+
+      expect(mockHsetFn).toHaveBeenCalledWith("usage:monthly:user-123:pro", {
+        tokens: 200_000,
+      });
+    });
   });
 
   describe("resetRateLimitBuckets", () => {
@@ -848,6 +900,23 @@ describe("token-bucket async functions", () => {
       }
     });
 
+    it("initializes a price-specific cycle allocation", async () => {
+      const { resetRateLimitBuckets } = getIsolatedModule();
+
+      await resetRateLimitBuckets("user-123", "pro", undefined, 200_000);
+
+      expect(mockLimitFn).toHaveBeenCalledWith(expect.any(String), {
+        rate: 50_000,
+      });
+      expect(mockHsetFn).toHaveBeenCalledWith(
+        "usage:monthly:user-123:pro",
+        expect.objectContaining({
+          cycleAllocation: 200_000,
+          cycleTierMax: 250_000,
+        }),
+      );
+    });
+
     it("does not backdate reset metadata for a stale Stripe period end", async () => {
       const nowSeconds = 1_700_000_000;
       const stalePeriodEndSeconds = nowSeconds - 60;
@@ -891,6 +960,97 @@ describe("token-bucket async functions", () => {
       ).resolves.toBeUndefined();
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe("capCurrentCycleAllocation", () => {
+    it("initializes a missing bucket at the requested allocation", async () => {
+      const { capCurrentCycleAllocation } = getIsolatedModule();
+      mockExistsFn.mockResolvedValue(0);
+      mockHgetFn.mockResolvedValue(200_000);
+
+      const result = await capCurrentCycleAllocation(
+        "user-123",
+        "pro",
+        200_000,
+      );
+
+      expect(result).toEqual({
+        created: true,
+        previousAllocation: 250_000,
+        previousRemaining: 250_000,
+        targetAllocation: 200_000,
+        targetRemaining: 200_000,
+        pointsRemoved: 0,
+      });
+      expect(mockHsetFn).toHaveBeenCalledWith(
+        "usage:monthly:user-123:pro",
+        expect.objectContaining({ cycleAllocation: 200_000 }),
+      );
+    });
+
+    it("lowers the current cycle without restoring consumed usage", async () => {
+      const { capCurrentCycleAllocation } = getIsolatedModule();
+      mockHgetFn.mockResolvedValue(250_000);
+      mockLimitFn
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 150_000,
+          reset: Date.now() + 3600000,
+          limit: 250_000,
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          remaining: 100_000,
+          reset: Date.now() + 3600000,
+          limit: 250_000,
+        });
+
+      const result = await capCurrentCycleAllocation(
+        "user-123",
+        "pro",
+        200_000,
+      );
+
+      expect(mockLimitFn).toHaveBeenNthCalledWith(2, expect.any(String), {
+        rate: 50_000,
+      });
+      expect(result).toEqual({
+        created: false,
+        previousAllocation: 250_000,
+        previousRemaining: 150_000,
+        targetAllocation: 200_000,
+        targetRemaining: 100_000,
+        pointsRemoved: 50_000,
+      });
+      expect(mockHsetFn).toHaveBeenCalledWith(
+        "usage:monthly:user-123:pro",
+        expect.objectContaining({
+          cycleAllocation: 200_000,
+          cycleTierMax: 250_000,
+        }),
+      );
+    });
+
+    it("does not increase an already-lower prorated allocation", async () => {
+      const { capCurrentCycleAllocation } = getIsolatedModule();
+      mockHgetFn.mockResolvedValue(150_000);
+      mockLimitFn.mockResolvedValueOnce({
+        success: true,
+        remaining: 100_000,
+        reset: Date.now() + 3600000,
+        limit: 250_000,
+      });
+
+      const result = await capCurrentCycleAllocation(
+        "user-123",
+        "pro",
+        200_000,
+      );
+
+      expect(result.targetAllocation).toBe(150_000);
+      expect(result.targetRemaining).toBe(100_000);
+      expect(result.pointsRemoved).toBe(0);
     });
   });
 

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -33,6 +33,7 @@ export {
   deductUsageDelta,
   refundUsage,
   resetRateLimitBuckets,
+  capCurrentCycleAllocation,
   stashOldBucketRemaining,
   popOldBucketRemaining,
   initProratedBucket,
@@ -51,6 +52,7 @@ export {
   POINTS_PER_DOLLAR,
   type UsageDeductionFailureReason,
   type UsageDeductionResult,
+  type CycleAllocationCapResult,
 } from "./token-bucket";
 
 // Re-export sliding window functions

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -376,6 +376,85 @@ const getStoredCycleAllocation = async (
   return stored === null ? null : Math.min(tierMax, stored);
 };
 
+const ENFORCE_CYCLE_ALLOCATION_SCRIPT = `
+local key = KEYS[1]
+local tokens = tonumber(redis.call("HGET", key, "tokens"))
+local allocation = tonumber(redis.call("HGET", key, "cycleAllocation"))
+
+if not tokens or not allocation then
+  return {-1, -1, 0}
+end
+
+local remaining = math.max(0, math.min(tokens, allocation))
+if remaining < tokens then
+  redis.call("HSET", key, "tokens", remaining)
+end
+
+return {remaining, allocation, tokens - remaining}
+`;
+
+const CAP_CYCLE_ALLOCATION_SCRIPT = `
+local key = KEYS[1]
+local requestedAllocation = tonumber(ARGV[1])
+local tierMax = tonumber(ARGV[2])
+local targetRefilledAt = tonumber(ARGV[3])
+
+local currentTokens = tonumber(redis.call("HGET", key, "tokens")) or tierMax
+local previousAllocation = tonumber(redis.call("HGET", key, "cycleAllocation")) or tierMax
+local targetAllocation = math.min(previousAllocation, requestedAllocation)
+local previousRemaining = math.max(0, math.min(previousAllocation, currentTokens))
+local consumed = math.max(0, previousAllocation - previousRemaining)
+local targetRemaining = math.max(0, targetAllocation - consumed)
+local pointsRemoved = math.max(0, currentTokens - targetRemaining)
+
+if targetRefilledAt >= 0 then
+  redis.call(
+    "HSET",
+    key,
+    "tokens", targetRemaining,
+    "cycleAllocation", targetAllocation,
+    "cycleTierMax", tierMax,
+    "refilledAt", targetRefilledAt
+  )
+else
+  redis.call(
+    "HSET",
+    key,
+    "tokens", targetRemaining,
+    "cycleAllocation", targetAllocation,
+    "cycleTierMax", tierMax
+  )
+end
+
+return {
+  previousAllocation,
+  math.max(0, currentTokens),
+  targetAllocation,
+  targetRemaining,
+  pointsRemoved
+}
+`;
+
+const enforceStoredCycleAllocation = async (
+  redis: RedisClient,
+  monthlyKey: string,
+  tierMax: number,
+): Promise<{ allocation: number; remaining: number } | null> => {
+  const [remaining, allocation] = await redis.eval<
+    [],
+    [number, number, number]
+  >(ENFORCE_CYCLE_ALLOCATION_SCRIPT, [monthlyKey], []);
+  const normalizedAllocation = finiteNonNegativePoints(allocation);
+  const normalizedRemaining = finiteNonNegativePoints(remaining);
+  if (normalizedAllocation === null || normalizedRemaining === null)
+    return null;
+  const cappedAllocation = Math.min(tierMax, normalizedAllocation);
+  return {
+    allocation: cappedAllocation,
+    remaining: Math.min(cappedAllocation, normalizedRemaining),
+  };
+};
+
 export const getCycleExpireSeconds = (
   periodEndSeconds?: number,
   nowSeconds: number = Math.floor(Date.now() / 1000),
@@ -568,19 +647,17 @@ export const checkTokenBucketLimit = async (
     // in the bucket. Re-apply the cap if Upstash's 30-day refill races ahead
     // of the Stripe renewal webhook.
     const monthlyStorageKey = getMonthlyBucketKey(userId, subscription);
-    const storedCycleAllocation = await getStoredCycleAllocation(
+    const enforcedCycleAllocation = await enforceStoredCycleAllocation(
       redis,
       monthlyStorageKey,
       monthlyLimit,
     );
-    effectiveMonthlyLimit = storedCycleAllocation ?? monthlyLimit;
-    if (monthlyCheck.remaining > effectiveMonthlyLimit) {
-      monthlyCheck = await monthly.limiter.limit(monthly.key, {
-        rate: monthlyCheck.remaining - effectiveMonthlyLimit,
-      });
-      if (monthlyCheck.success === false) {
-        throw monthlyLimitError(monthlyCheck.reset);
-      }
+    if (enforcedCycleAllocation) {
+      effectiveMonthlyLimit = enforcedCycleAllocation.allocation;
+      monthlyCheck = {
+        ...monthlyCheck,
+        remaining: enforcedCycleAllocation.remaining,
+      };
     }
 
     // Step 2: Check if we have enough capacity, or if we need extra usage
@@ -1124,46 +1201,28 @@ export const capCurrentCycleAllocation = async (
   }
 
   const { monthly } = createRateLimiter(redis, userId, subscription);
-  const current = await monthly.limiter.limit(monthly.key, { rate: 0 });
-  const previousAllocation =
-    (await getStoredCycleAllocation(redis, monthlyKey, tierMax)) ?? tierMax;
-  const targetAllocation = Math.min(
-    previousAllocation,
-    requestedTargetAllocation,
-  );
-  const previousRemainingForUsage = Math.min(
-    previousAllocation,
-    Math.max(0, current.remaining),
-  );
-  const consumed = Math.max(0, previousAllocation - previousRemainingForUsage);
-  const targetRemaining = Math.max(0, targetAllocation - consumed);
-  const pointsRemoved = Math.max(
-    0,
-    Math.max(0, current.remaining) - targetRemaining,
-  );
-
-  if (pointsRemoved > 0) {
-    const capped = await monthly.limiter.limit(monthly.key, {
-      rate: pointsRemoved,
-    });
-    if (capped.success === false) {
-      throw new Error(`Failed to cap the current cycle for user ${userId}`);
-    }
-  }
-
-  const metadata: Record<string, number> = {
-    cycleAllocation: targetAllocation,
-    cycleTierMax: tierMax,
-  };
+  await monthly.limiter.limit(monthly.key, { rate: 0 });
   const nowSeconds = Math.floor(Date.now() / 1000);
-  if (
+  const targetRefilledAt =
     periodEndSeconds &&
     Number.isFinite(periodEndSeconds) &&
     periodEndSeconds > nowSeconds
-  ) {
-    metadata.refilledAt = (periodEndSeconds - THIRTY_DAYS_SECONDS) * 1000;
-  }
-  await redis.hset(monthlyKey, metadata);
+      ? (periodEndSeconds - THIRTY_DAYS_SECONDS) * 1000
+      : -1;
+  const [
+    previousAllocation,
+    previousRemaining,
+    targetAllocation,
+    targetRemaining,
+    pointsRemoved,
+  ] = await redis.eval<
+    [number, number, number],
+    [number, number, number, number, number]
+  >(
+    CAP_CYCLE_ALLOCATION_SCRIPT,
+    [monthlyKey],
+    [requestedTargetAllocation, tierMax, targetRefilledAt],
+  );
   await redis.expire(
     monthlyKey,
     getCycleExpireSeconds(periodEndSeconds, nowSeconds),
@@ -1172,7 +1231,7 @@ export const capCurrentCycleAllocation = async (
   return {
     created: false,
     previousAllocation,
-    previousRemaining: Math.max(0, current.remaining),
+    previousRemaining,
     targetAllocation,
     targetRemaining,
     pointsRemoved,

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -123,6 +123,11 @@ const nonNegativePoints = (value: number | undefined): number =>
     ? Math.max(0, Math.round(value))
     : 0;
 
+const finiteNonNegativePoints = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.round(value)
+    : null;
+
 const getDeductionFailureReason = (
   result: DeductBalanceResult,
 ): UsageDeductionFailureReason => {
@@ -352,6 +357,25 @@ export const getSubscriptionPrice = (
 export const getMonthlyBucketKey = (userId: string, tier: SubscriptionTier) =>
   `usage:monthly:${userId}:${tier}`;
 
+const normalizeCycleAllocation = (
+  tierMax: number,
+  requestedAllocation?: number,
+): number => {
+  const normalized = finiteNonNegativePoints(requestedAllocation);
+  return normalized === null ? tierMax : Math.min(tierMax, normalized);
+};
+
+const getStoredCycleAllocation = async (
+  redis: RedisClient,
+  monthlyKey: string,
+  tierMax: number,
+): Promise<number | null> => {
+  const stored = finiteNonNegativePoints(
+    await redis.hget(monthlyKey, "cycleAllocation"),
+  );
+  return stored === null ? null : Math.min(tierMax, stored);
+};
+
 export const getCycleExpireSeconds = (
   periodEndSeconds?: number,
   nowSeconds: number = Math.floor(Date.now() / 1000),
@@ -508,6 +532,8 @@ export const checkTokenBucketLimit = async (
       );
     };
 
+    let effectiveMonthlyLimit = monthlyLimit;
+
     // Helper to build RateLimitInfo from a limiter result
     const buildResult = (
       result: { remaining: number; reset: number },
@@ -516,10 +542,10 @@ export const checkTokenBucketLimit = async (
     ): RateLimitInfo => ({
       remaining: result.remaining,
       resetTime: new Date(result.reset),
-      limit: monthlyLimit,
+      limit: effectiveMonthlyLimit,
       monthly: {
         remaining: result.remaining,
-        limit: monthlyLimit,
+        limit: effectiveMonthlyLimit,
         resetTime: new Date(result.reset),
       },
       pointsDeducted,
@@ -536,6 +562,25 @@ export const checkTokenBucketLimit = async (
       await applyTeamSeatDebt(userId, organizationId!);
       // Re-peek after debt burn to get accurate remaining
       monthlyCheck = await monthly.limiter.limit(monthly.key, { rate: 0 });
+    }
+
+    // Price-specific and prorated cycles store their authoritative allowance
+    // in the bucket. Re-apply the cap if Upstash's 30-day refill races ahead
+    // of the Stripe renewal webhook.
+    const monthlyStorageKey = getMonthlyBucketKey(userId, subscription);
+    const storedCycleAllocation = await getStoredCycleAllocation(
+      redis,
+      monthlyStorageKey,
+      monthlyLimit,
+    );
+    effectiveMonthlyLimit = storedCycleAllocation ?? monthlyLimit;
+    if (monthlyCheck.remaining > effectiveMonthlyLimit) {
+      monthlyCheck = await monthly.limiter.limit(monthly.key, {
+        rate: monthlyCheck.remaining - effectiveMonthlyLimit,
+      });
+      if (monthlyCheck.success === false) {
+        throw monthlyLimitError(monthlyCheck.reset);
+      }
     }
 
     // Step 2: Check if we have enough capacity, or if we need extra usage
@@ -976,9 +1021,17 @@ const refundBucketTokens = async (
       pointsToRefund,
     );
 
-    // Cap at limit if we exceeded it (edge case)
-    if (monthlyTokens > monthlyLimit) {
-      await redis.hset(monthlyKey, { tokens: monthlyLimit });
+    const cycleAllocation = await getStoredCycleAllocation(
+      redis,
+      monthlyKey,
+      monthlyLimit,
+    );
+    const refundCap = cycleAllocation ?? monthlyLimit;
+
+    // Cap refunds at the current cycle allocation, which may be lower than
+    // the broad subscription tier for grandfathered or prorated users.
+    if (monthlyTokens > refundCap) {
+      await redis.hset(monthlyKey, { tokens: refundCap });
     }
   } catch (error) {
     console.error("Failed to refund bucket tokens:", error);
@@ -994,8 +1047,136 @@ export const resetRateLimitBuckets = async (
   userId: string,
   subscription: SubscriptionTier,
   periodEndSeconds?: number,
+  cycleAllocationPoints?: number,
 ): Promise<void> => {
-  await initProratedBucket(userId, subscription, 1.0, 0, periodEndSeconds);
+  await initProratedBucket(
+    userId,
+    subscription,
+    1.0,
+    0,
+    periodEndSeconds,
+    cycleAllocationPoints,
+  );
+};
+
+export type CycleAllocationCapResult = {
+  created: boolean;
+  previousAllocation: number;
+  previousRemaining: number;
+  targetAllocation: number;
+  targetRemaining: number;
+  pointsRemoved: number;
+};
+
+/**
+ * Lower an existing cycle allocation without restoring already-consumed usage.
+ * Used by one-time billing migrations; safe to rerun.
+ */
+export const capCurrentCycleAllocation = async (
+  userId: string,
+  subscription: SubscriptionTier,
+  requestedAllocation: number,
+  periodEndSeconds?: number,
+): Promise<CycleAllocationCapResult> => {
+  const redis = createRedisClient();
+  if (!redis) throw new Error(RATE_LIMIT_SERVICE_NOT_CONFIGURED);
+
+  const { monthly: tierMax } = getBudgetLimits(subscription);
+  if (tierMax <= 0) {
+    throw new Error(`Cannot set a cycle allocation for tier "${subscription}"`);
+  }
+
+  const requestedTargetAllocation = normalizeCycleAllocation(
+    tierMax,
+    requestedAllocation,
+  );
+  const monthlyKey = getMonthlyBucketKey(userId, subscription);
+  const keyExists = Boolean(await redis.exists(monthlyKey));
+
+  if (!keyExists) {
+    await initProratedBucket(
+      userId,
+      subscription,
+      1.0,
+      0,
+      periodEndSeconds,
+      requestedTargetAllocation,
+    );
+    const createdAllocation = await getStoredCycleAllocation(
+      redis,
+      monthlyKey,
+      tierMax,
+    );
+    if (createdAllocation !== requestedTargetAllocation) {
+      throw new Error(
+        `Failed to initialize the current cycle for user ${userId}`,
+      );
+    }
+    await redis.expire(monthlyKey, getCycleExpireSeconds(periodEndSeconds));
+    return {
+      created: true,
+      previousAllocation: tierMax,
+      previousRemaining: tierMax,
+      targetAllocation: requestedTargetAllocation,
+      targetRemaining: requestedTargetAllocation,
+      pointsRemoved: 0,
+    };
+  }
+
+  const { monthly } = createRateLimiter(redis, userId, subscription);
+  const current = await monthly.limiter.limit(monthly.key, { rate: 0 });
+  const previousAllocation =
+    (await getStoredCycleAllocation(redis, monthlyKey, tierMax)) ?? tierMax;
+  const targetAllocation = Math.min(
+    previousAllocation,
+    requestedTargetAllocation,
+  );
+  const previousRemainingForUsage = Math.min(
+    previousAllocation,
+    Math.max(0, current.remaining),
+  );
+  const consumed = Math.max(0, previousAllocation - previousRemainingForUsage);
+  const targetRemaining = Math.max(0, targetAllocation - consumed);
+  const pointsRemoved = Math.max(
+    0,
+    Math.max(0, current.remaining) - targetRemaining,
+  );
+
+  if (pointsRemoved > 0) {
+    const capped = await monthly.limiter.limit(monthly.key, {
+      rate: pointsRemoved,
+    });
+    if (capped.success === false) {
+      throw new Error(`Failed to cap the current cycle for user ${userId}`);
+    }
+  }
+
+  const metadata: Record<string, number> = {
+    cycleAllocation: targetAllocation,
+    cycleTierMax: tierMax,
+  };
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (
+    periodEndSeconds &&
+    Number.isFinite(periodEndSeconds) &&
+    periodEndSeconds > nowSeconds
+  ) {
+    metadata.refilledAt = (periodEndSeconds - THIRTY_DAYS_SECONDS) * 1000;
+  }
+  await redis.hset(monthlyKey, metadata);
+  await redis.expire(
+    monthlyKey,
+    getCycleExpireSeconds(periodEndSeconds, nowSeconds),
+  );
+
+  return {
+    created: false,
+    previousAllocation,
+    previousRemaining: Math.max(0, current.remaining),
+    targetAllocation,
+    targetRemaining,
+    pointsRemoved,
+  };
 };
 
 /**
@@ -1154,6 +1335,7 @@ export const initProratedBucket = async (
   proratedRatio: number,
   consumedCredits: number = 0,
   periodEndSeconds?: number,
+  cycleAllocationPoints?: number,
 ): Promise<void> => {
   const redis = createRedisClient();
   if (!redis) return;
@@ -1161,11 +1343,13 @@ export const initProratedBucket = async (
   const newTierMax = MONTHLY_CREDITS[newTier] ?? 0;
   if (newTierMax === 0) return;
 
-  const { burnAmount, totalCredits } = calculateProratedCredits(
-    newTierMax,
+  const cycleMax = normalizeCycleAllocation(newTierMax, cycleAllocationPoints);
+  const { totalCredits } = calculateProratedCredits(
+    cycleMax,
     proratedRatio,
     consumedCredits,
   );
+  const burnAmount = newTierMax - totalCredits;
   const monthlyKey = getMonthlyBucketKey(userId, newTier);
 
   try {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:e2e:users:reset-passwords": "npx tsx scripts/create-test-users.ts reset-passwords",
     "user:verify-email": "npx tsx scripts/verify-email.ts",
     "rate-limit:reset": "npx tsx scripts/reset-rate-limit.ts",
+    "pro-20-usage:backfill": "npx tsx scripts/backfill-pro-20-usage.ts",
     "paid-allowance:dev": "npx tsx scripts/paid-daily-free-allowance-dev.ts",
     "stripe:attach-failing-card": "npx tsx scripts/attach-failing-card.ts",
     "prepare": "husky",

--- a/scripts/__tests__/backfill-pro-20-usage.test.ts
+++ b/scripts/__tests__/backfill-pro-20-usage.test.ts
@@ -1,0 +1,30 @@
+import { parseBackfillArgs } from "../backfill-pro-20-usage";
+
+describe("backfill-pro-20-usage arguments", () => {
+  it("defaults to dry-run", () => {
+    expect(parseBackfillArgs([])).toEqual({
+      apply: false,
+      envFile: ".env.local",
+    });
+  });
+
+  it("requires an expected subscription count when applying", () => {
+    expect(() => parseBackfillArgs(["--apply"])).toThrow(
+      "--apply requires --expected-subscriptions",
+    );
+  });
+
+  it("accepts an explicit environment file and safety count", () => {
+    expect(
+      parseBackfillArgs([
+        "--env-file=/tmp/production.env",
+        "--apply",
+        "--expected-subscriptions=105",
+      ]),
+    ).toEqual({
+      apply: true,
+      envFile: "/tmp/production.env",
+      expectedSubscriptions: 105,
+    });
+  });
+});

--- a/scripts/__tests__/backfill-pro-20-usage.test.ts
+++ b/scripts/__tests__/backfill-pro-20-usage.test.ts
@@ -1,4 +1,8 @@
-import { parseBackfillArgs } from "../backfill-pro-20-usage";
+import {
+  applyBackfill,
+  parseBackfillArgs,
+  type BackfillTarget,
+} from "../backfill-pro-20-usage";
 
 describe("backfill-pro-20-usage arguments", () => {
   it("defaults to dry-run", () => {
@@ -25,6 +29,121 @@ describe("backfill-pro-20-usage arguments", () => {
       apply: true,
       envFile: "/tmp/production.env",
       expectedSubscriptions: 105,
+    });
+  });
+});
+
+describe("backfill-pro-20-usage preflight", () => {
+  const periodEnd = 1_800_000_000;
+  const capAllocation = jest.fn().mockResolvedValue({
+    created: false,
+    previousAllocation: 250_000,
+    previousRemaining: 150_000,
+    targetAllocation: 200_000,
+    targetRemaining: 100_000,
+    pointsRemoved: 50_000,
+  });
+
+  beforeEach(() => {
+    capAllocation.mockClear();
+  });
+
+  it("performs no writes when a subscription is unmapped", async () => {
+    await expect(
+      applyBackfill(
+        {
+          activeSubscriptionCount: 1,
+          expectedSubscriptions: 1,
+          targets: [],
+          unmapped: 1,
+        },
+        capAllocation as never,
+      ),
+    ).rejects.toThrow("could not be mapped");
+    expect(capAllocation).not.toHaveBeenCalled();
+  });
+
+  it("performs no writes when a period end is missing", async () => {
+    const missingPeriodEnd = {
+      userIds: ["user_1"],
+    } as BackfillTarget;
+
+    await expect(
+      applyBackfill(
+        {
+          activeSubscriptionCount: 1,
+          expectedSubscriptions: 1,
+          targets: [missingPeriodEnd],
+          unmapped: 0,
+        },
+        capAllocation as never,
+      ),
+    ).rejects.toThrow("missing subscription period end");
+    expect(capAllocation).not.toHaveBeenCalled();
+  });
+
+  it("performs no writes when one user has conflicting cycle ends", async () => {
+    await expect(
+      applyBackfill(
+        {
+          activeSubscriptionCount: 2,
+          expectedSubscriptions: 2,
+          targets: [
+            { periodEnd, userIds: ["user_1"] },
+            { periodEnd: periodEnd + 100, userIds: ["user_1"] },
+          ],
+          unmapped: 0,
+        },
+        capAllocation as never,
+      ),
+    ).rejects.toThrow("conflicting subscription period ends");
+    expect(capAllocation).not.toHaveBeenCalled();
+  });
+
+  it("performs no writes when the live count changed after dry-run", async () => {
+    await expect(
+      applyBackfill(
+        {
+          activeSubscriptionCount: 2,
+          expectedSubscriptions: 1,
+          targets: [
+            { periodEnd, userIds: ["user_1"] },
+            { periodEnd, userIds: ["user_2"] },
+          ],
+          unmapped: 0,
+        },
+        capAllocation as never,
+      ),
+    ).rejects.toThrow("expected 1 active subscriptions, found 2");
+    expect(capAllocation).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates the same user with a consistent cycle end", async () => {
+    const result = await applyBackfill(
+      {
+        activeSubscriptionCount: 2,
+        expectedSubscriptions: 2,
+        targets: [
+          { periodEnd, userIds: ["user_1"] },
+          { periodEnd, userIds: ["user_1"] },
+        ],
+        unmapped: 0,
+      },
+      capAllocation as never,
+    );
+
+    expect(capAllocation).toHaveBeenCalledTimes(1);
+    expect(capAllocation).toHaveBeenCalledWith(
+      "user_1",
+      "pro",
+      200_000,
+      periodEnd,
+    );
+    expect(result).toEqual({
+      applied: true,
+      usersProcessed: 1,
+      bucketsCreated: 0,
+      pointsRemoved: 50_000,
     });
   });
 });

--- a/scripts/backfill-pro-20-usage.ts
+++ b/scripts/backfill-pro-20-usage.ts
@@ -17,9 +17,21 @@ type Options = {
   expectedSubscriptions?: number;
 };
 
-type BackfillTarget = {
-  periodEnd?: number;
+export type BackfillTarget = {
+  periodEnd: number;
   userIds: string[];
+};
+
+type UserBackfillTarget = {
+  periodEnd: number;
+  userId: string;
+};
+
+type ApplyBackfillOptions = {
+  activeSubscriptionCount: number;
+  expectedSubscriptions: number;
+  targets: BackfillTarget[];
+  unmapped: number;
 };
 
 function printUsage() {
@@ -103,12 +115,96 @@ function subscriptionPeriodEnd(subscription: Stripe.Subscription) {
         (item as Stripe.SubscriptionItem & { current_period_end?: number })
           .current_period_end,
     )
-    .filter((value): value is number => typeof value === "number");
+    .filter(
+      (value): value is number =>
+        typeof value === "number" && Number.isFinite(value) && value > 0,
+    );
   if (itemEnds.length > 0) return Math.max(...itemEnds);
 
   const topLevelEnd = (subscription as { current_period_end?: unknown })
     .current_period_end;
-  return typeof topLevelEnd === "number" ? topLevelEnd : undefined;
+  return typeof topLevelEnd === "number" &&
+    Number.isFinite(topLevelEnd) &&
+    topLevelEnd > 0
+    ? topLevelEnd
+    : undefined;
+}
+
+/** Build one deterministic target per user and reject ambiguous cycle data. */
+export function groupBackfillTargets(
+  targets: BackfillTarget[],
+): UserBackfillTarget[] {
+  const periodEndByUser = new Map<string, number>();
+
+  for (const target of targets) {
+    if (
+      typeof target.periodEnd !== "number" ||
+      !Number.isFinite(target.periodEnd) ||
+      target.periodEnd <= 0
+    ) {
+      throw new Error("Safety check failed: missing subscription period end");
+    }
+
+    for (const userId of target.userIds) {
+      const existingPeriodEnd = periodEndByUser.get(userId);
+      if (
+        existingPeriodEnd !== undefined &&
+        existingPeriodEnd !== target.periodEnd
+      ) {
+        throw new Error(
+          `Safety check failed: conflicting subscription period ends for user ${userId}`,
+        );
+      }
+      periodEndByUser.set(userId, target.periodEnd);
+    }
+  }
+
+  return [...periodEndByUser.entries()].map(([userId, periodEnd]) => ({
+    userId,
+    periodEnd,
+  }));
+}
+
+/** Validate the full write set before applying any Redis mutations. */
+export async function applyBackfill(
+  options: ApplyBackfillOptions,
+  capAllocation: typeof capCurrentCycleAllocation = capCurrentCycleAllocation,
+) {
+  const userTargets = groupBackfillTargets(options.targets);
+
+  if (options.activeSubscriptionCount !== options.expectedSubscriptions) {
+    throw new Error(
+      `Safety check failed: expected ${options.expectedSubscriptions} active subscriptions, found ${options.activeSubscriptionCount}`,
+    );
+  }
+  if (
+    options.targets.length !== options.activeSubscriptionCount ||
+    options.unmapped > 0
+  ) {
+    throw new Error(
+      `Safety check failed: ${options.unmapped} active subscription(s) could not be mapped to WorkOS users and a Stripe cycle`,
+    );
+  }
+
+  let bucketsCreated = 0;
+  let pointsRemoved = 0;
+  for (const target of userTargets) {
+    const result = await capAllocation(
+      target.userId,
+      "pro",
+      PRO_20_MONTHLY_INCLUDED_USAGE_POINTS,
+      target.periodEnd,
+    );
+    if (result.created) bucketsCreated++;
+    pointsRemoved += result.pointsRemoved;
+  }
+
+  return {
+    applied: true as const,
+    usersProcessed: userTargets.length,
+    bucketsCreated,
+    pointsRemoved,
+  };
 }
 
 async function listSubscriptions(
@@ -142,6 +238,12 @@ async function resolveTargets(
   let unmapped = 0;
 
   for (const subscription of subscriptions) {
+    const periodEnd = subscriptionPeriodEnd(subscription);
+    if (periodEnd === undefined) {
+      unmapped++;
+      continue;
+    }
+
     const customerId =
       typeof subscription.customer === "string"
         ? subscription.customer
@@ -173,7 +275,7 @@ async function resolveTargets(
     }
 
     targets.push({
-      periodEnd: subscriptionPeriodEnd(subscription),
+      periodEnd,
       userIds,
     });
   }
@@ -212,14 +314,14 @@ async function main() {
     listSubscriptions(stripe, PENTESTGPT_PRO_20_MONTHLY_PRICE_ID, "past_due"),
   ]);
   const { targets, unmapped } = await resolveTargets(stripe, workos, active);
-  const uniqueUserIds = new Set(targets.flatMap((target) => target.userIds));
+  const userTargets = groupBackfillTargets(targets);
 
   const summary = {
     mode: options.apply ? "apply" : "dry-run",
     currentPriceActiveSubscriptions: active.length,
     currentPricePastDueSubscriptions: pastDue.length,
     eligibleSubscriptions: targets.length,
-    eligibleUsers: uniqueUserIds.size,
+    eligibleUsers: userTargets.length,
     unmappedActiveSubscriptions: unmapped,
     legacyPriceActiveSubscriptions: legacyActive.length,
     legacyPricePastDueSubscriptions: legacyPastDue.length,
@@ -234,47 +336,13 @@ async function main() {
     return;
   }
 
-  if (active.length !== options.expectedSubscriptions) {
-    throw new Error(
-      `Safety check failed: expected ${options.expectedSubscriptions} active subscriptions, found ${active.length}`,
-    );
-  }
-  if (targets.length !== active.length || unmapped > 0) {
-    throw new Error(
-      `Safety check failed: ${unmapped} active subscription(s) could not be mapped to WorkOS users`,
-    );
-  }
-
-  let bucketsCreated = 0;
-  let pointsRemoved = 0;
-  const processedUsers = new Set<string>();
-  for (const target of targets) {
-    for (const userId of target.userIds) {
-      if (processedUsers.has(userId)) continue;
-      processedUsers.add(userId);
-      const result = await capCurrentCycleAllocation(
-        userId,
-        "pro",
-        PRO_20_MONTHLY_INCLUDED_USAGE_POINTS,
-        target.periodEnd,
-      );
-      if (result.created) bucketsCreated++;
-      pointsRemoved += result.pointsRemoved;
-    }
-  }
-
-  console.log(
-    JSON.stringify(
-      {
-        applied: true,
-        usersProcessed: processedUsers.size,
-        bucketsCreated,
-        pointsRemoved,
-      },
-      null,
-      2,
-    ),
-  );
+  const result = await applyBackfill({
+    activeSubscriptionCount: active.length,
+    expectedSubscriptions: options.expectedSubscriptions!,
+    targets,
+    unmapped,
+  });
+  console.log(JSON.stringify(result, null, 2));
 }
 
 if (process.env.NODE_ENV !== "test") {

--- a/scripts/backfill-pro-20-usage.ts
+++ b/scripts/backfill-pro-20-usage.ts
@@ -1,0 +1,285 @@
+#!/usr/bin/env tsx
+
+import { config } from "dotenv";
+import { resolve } from "path";
+import Stripe from "stripe";
+import { WorkOS } from "@workos-inc/node";
+import {
+  HACKERAI_PRO_20_MONTHLY_PRICE_ID,
+  PENTESTGPT_PRO_20_MONTHLY_PRICE_ID,
+  PRO_20_MONTHLY_INCLUDED_USAGE_POINTS,
+} from "../lib/billing/included-usage";
+import { capCurrentCycleAllocation } from "../lib/rate-limit/token-bucket";
+
+type Options = {
+  apply: boolean;
+  envFile: string;
+  expectedSubscriptions?: number;
+};
+
+type BackfillTarget = {
+  periodEnd?: number;
+  userIds: string[];
+};
+
+function printUsage() {
+  console.log(`
+Backfill the current-cycle included usage for active grandfathered $20 Pro subscriptions.
+
+Dry-run is the default. Apply requires the exact subscription count printed by
+the immediately preceding dry-run.
+
+Usage:
+  pnpm exec tsx scripts/backfill-pro-20-usage.ts --env-file=/tmp/hackerai-production.env
+  pnpm exec tsx scripts/backfill-pro-20-usage.ts --env-file=/tmp/hackerai-production.env --apply --expected-subscriptions=105
+
+Options:
+  --env-file <path>                Environment file. Default: .env.local
+  --apply                          Cap live Redis buckets at $20 of usage.
+  --expected-subscriptions <count> Required with --apply.
+  --help                           Show this message.
+`);
+}
+
+export function parseBackfillArgs(argv: string[]): Options {
+  const options: Options = {
+    apply: false,
+    envFile: ".env.local",
+  };
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    }
+    if (arg === "--apply") {
+      options.apply = true;
+      continue;
+    }
+    if (arg === "--env-file") {
+      const value = argv[++index];
+      if (!value) throw new Error("--env-file requires a value");
+      options.envFile = value;
+      continue;
+    }
+    if (arg.startsWith("--env-file=")) {
+      options.envFile = arg.slice("--env-file=".length);
+      continue;
+    }
+    if (arg === "--expected-subscriptions") {
+      const value = argv[++index];
+      if (!value) throw new Error("--expected-subscriptions requires a value");
+      options.expectedSubscriptions = Number(value);
+      continue;
+    }
+    if (arg.startsWith("--expected-subscriptions=")) {
+      options.expectedSubscriptions = Number(
+        arg.slice("--expected-subscriptions=".length),
+      );
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (
+    options.expectedSubscriptions !== undefined &&
+    (!Number.isInteger(options.expectedSubscriptions) ||
+      options.expectedSubscriptions < 0)
+  ) {
+    throw new Error("--expected-subscriptions must be a non-negative integer");
+  }
+  if (options.apply && options.expectedSubscriptions === undefined) {
+    throw new Error("--apply requires --expected-subscriptions");
+  }
+
+  return options;
+}
+
+function subscriptionPeriodEnd(subscription: Stripe.Subscription) {
+  const itemEnds = subscription.items.data
+    .map(
+      (item) =>
+        (item as Stripe.SubscriptionItem & { current_period_end?: number })
+          .current_period_end,
+    )
+    .filter((value): value is number => typeof value === "number");
+  if (itemEnds.length > 0) return Math.max(...itemEnds);
+
+  const topLevelEnd = (subscription as { current_period_end?: unknown })
+    .current_period_end;
+  return typeof topLevelEnd === "number" ? topLevelEnd : undefined;
+}
+
+async function listSubscriptions(
+  stripe: Stripe,
+  price: string,
+  status: "active" | "past_due",
+): Promise<Stripe.Subscription[]> {
+  const subscriptions: Stripe.Subscription[] = [];
+  let startingAfter: string | undefined;
+
+  do {
+    const page = await stripe.subscriptions.list({
+      price,
+      status,
+      limit: 100,
+      starting_after: startingAfter,
+    });
+    subscriptions.push(...page.data);
+    startingAfter = page.has_more ? page.data.at(-1)?.id : undefined;
+  } while (startingAfter);
+
+  return subscriptions;
+}
+
+async function resolveTargets(
+  stripe: Stripe,
+  workos: WorkOS,
+  subscriptions: Stripe.Subscription[],
+): Promise<{ targets: BackfillTarget[]; unmapped: number }> {
+  const targets: BackfillTarget[] = [];
+  let unmapped = 0;
+
+  for (const subscription of subscriptions) {
+    const customerId =
+      typeof subscription.customer === "string"
+        ? subscription.customer
+        : subscription.customer.id;
+    const customer = await stripe.customers.retrieve(customerId);
+    if (customer.deleted) {
+      unmapped++;
+      continue;
+    }
+
+    const organizationId = customer.metadata.workOSOrganizationId;
+    if (!organizationId) {
+      unmapped++;
+      continue;
+    }
+
+    const memberships = await workos.userManagement.listOrganizationMemberships(
+      {
+        organizationId,
+        statuses: ["active"],
+      },
+    );
+    const userIds = (await memberships.autoPagination()).map(
+      (membership) => membership.userId,
+    );
+    if (userIds.length === 0) {
+      unmapped++;
+      continue;
+    }
+
+    targets.push({
+      periodEnd: subscriptionPeriodEnd(subscription),
+      userIds,
+    });
+  }
+
+  return { targets, unmapped };
+}
+
+async function main() {
+  const options = parseBackfillArgs(process.argv.slice(2));
+  config({ path: resolve(process.cwd(), options.envFile), override: true });
+
+  const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+  const workosApiKey = process.env.WORKOS_API_KEY;
+  const workosClientId = process.env.WORKOS_CLIENT_ID;
+  if (!stripeSecretKey || !workosApiKey || !workosClientId) {
+    throw new Error(
+      "STRIPE_SECRET_KEY, WORKOS_API_KEY, and WORKOS_CLIENT_ID must be set",
+    );
+  }
+  if (
+    options.apply &&
+    (!process.env.UPSTASH_REDIS_REST_URL ||
+      !process.env.UPSTASH_REDIS_REST_TOKEN)
+  ) {
+    throw new Error(
+      "UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN must be set with --apply",
+    );
+  }
+
+  const stripe = new Stripe(stripeSecretKey);
+  const workos = new WorkOS(workosApiKey, { clientId: workosClientId });
+  const [active, pastDue, legacyActive, legacyPastDue] = await Promise.all([
+    listSubscriptions(stripe, HACKERAI_PRO_20_MONTHLY_PRICE_ID, "active"),
+    listSubscriptions(stripe, HACKERAI_PRO_20_MONTHLY_PRICE_ID, "past_due"),
+    listSubscriptions(stripe, PENTESTGPT_PRO_20_MONTHLY_PRICE_ID, "active"),
+    listSubscriptions(stripe, PENTESTGPT_PRO_20_MONTHLY_PRICE_ID, "past_due"),
+  ]);
+  const { targets, unmapped } = await resolveTargets(stripe, workos, active);
+  const uniqueUserIds = new Set(targets.flatMap((target) => target.userIds));
+
+  const summary = {
+    mode: options.apply ? "apply" : "dry-run",
+    currentPriceActiveSubscriptions: active.length,
+    currentPricePastDueSubscriptions: pastDue.length,
+    eligibleSubscriptions: targets.length,
+    eligibleUsers: uniqueUserIds.size,
+    unmappedActiveSubscriptions: unmapped,
+    legacyPriceActiveSubscriptions: legacyActive.length,
+    legacyPricePastDueSubscriptions: legacyPastDue.length,
+    targetIncludedUsagePoints: PRO_20_MONTHLY_INCLUDED_USAGE_POINTS,
+  };
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (!options.apply) {
+    console.log(
+      `Dry-run only. Re-run with --apply --expected-subscriptions=${active.length} after reviewing these counts.`,
+    );
+    return;
+  }
+
+  if (active.length !== options.expectedSubscriptions) {
+    throw new Error(
+      `Safety check failed: expected ${options.expectedSubscriptions} active subscriptions, found ${active.length}`,
+    );
+  }
+  if (targets.length !== active.length || unmapped > 0) {
+    throw new Error(
+      `Safety check failed: ${unmapped} active subscription(s) could not be mapped to WorkOS users`,
+    );
+  }
+
+  let bucketsCreated = 0;
+  let pointsRemoved = 0;
+  const processedUsers = new Set<string>();
+  for (const target of targets) {
+    for (const userId of target.userIds) {
+      if (processedUsers.has(userId)) continue;
+      processedUsers.add(userId);
+      const result = await capCurrentCycleAllocation(
+        userId,
+        "pro",
+        PRO_20_MONTHLY_INCLUDED_USAGE_POINTS,
+        target.periodEnd,
+      );
+      if (result.created) bucketsCreated++;
+      pointsRemoved += result.pointsRemoved;
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        applied: true,
+        usersProcessed: processedUsers.size,
+        bucketsCreated,
+        pointsRemoved,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+if (process.env.NODE_ENV !== "test") {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- map the two known grandfathered $20/month Pro Price IDs to 200,000 included-usage points
- make the stored cycle allocation authoritative in enforcement, refunds, and the usage UI
- reset current HackerAI $20 subscriptions to the $20 allowance on every paid invoice
- preserve the $20 price and apply the matching usage cap when a legacy PentestGPT subscriber migrates
- add a dry-run-first, count-guarded production backfill for current active subscribers

## Live Stripe snapshot before implementation

- current HackerAI $20 Price: 105 active, 1 past_due
- legacy PentestGPT $20 Price: 3 active, 1 past_due
- total active $20 subscriptions: 108

The backfill intentionally handles the 105 current HackerAI subscriptions. The 3 legacy subscriptions remain on the legacy product until those users run the existing in-app migration; this PR makes that migration preserve both their $20 billing price and $20 usage allowance.

## Validation

- `pnpm typecheck`
- `pnpm lint` (0 errors; 6 existing unrelated warnings)
- `pnpm exec jest --runInBand` (256 suites, 2,567 tests passed)

## Post-merge production runbook

Wait for the production deployment containing this PR, then run from an updated `main` checkout:

```bash
git switch main
git pull --ff-only
pnpm install --frozen-lockfile
vercel env pull /tmp/hackerai-production.env --environment=production
pnpm exec tsx scripts/backfill-pro-20-usage.ts --env-file=/tmp/hackerai-production.env
```

Review the dry-run JSON. `unmappedActiveSubscriptions` must be `0`, and `eligibleSubscriptions` must equal `currentPriceActiveSubscriptions`. Use the freshly printed count, not the historical 105 snapshot, for the guarded apply:

```bash
pnpm exec tsx scripts/backfill-pro-20-usage.ts --env-file=/tmp/hackerai-production.env --apply --expected-subscriptions=<currentPriceActiveSubscriptions>
rm /tmp/hackerai-production.env
```

The apply is idempotent and preserves usage already consumed in the current billing cycle. It reads Stripe and WorkOS and writes only the affected Upstash Redis rate-limit buckets. No Stripe Dashboard changes, Stripe writes, manual Convex deployment, or Convex query/migration are required; the configured Vercel build deploys Convex automatically.

## Manual verification

- Confirm the apply result reports `usersProcessed` equal to the dry-run `eligibleUsers` and no error.
- In production, open Settings > Usage for one grandfathered current HackerAI $20 subscriber; the included monthly budget should show $20 rather than $25.
- Do not manually change the three legacy PentestGPT subscriptions in Stripe; their existing in-app migration path now preserves the grandfathered price.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserved grandfathered $20 Pro pricing and included-usage allowances during PentestGPT→current migrations.
  * Added cycle-specific usage caps that persist across renewals and are reflected in rate-limit bucket resets.
  * Introduced a backfill script to apply included-usage caps to eligible existing subscriptions.
* **Bug Fixes**
  * Improved current-period end detection and rate-limit calculations for multi-item subscriptions.
  * Adjusted limit/remaining and refund behavior to respect stored cycle allocations.
* **Tests**
  * Expanded coverage for migration, webhook handling, rate-limit capping, included-usage mapping, and backfill validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->