### PR TITLE
Fix idempotent account deletion and log Agent cancel rejections

### DIFF
--- a/app/api/delete-account/__tests__/route.test.ts
+++ b/app/api/delete-account/__tests__/route.test.ts
@@ -299,6 +299,36 @@ describe("POST /api/delete-account", () => {
     );
   });
 
+  it("treats an already-missing WorkOS user as a completed deletion", async () => {
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [],
+    } as never);
+    const missingUserError = new Error("User not found: 'user_123'.");
+    missingUserError.name = "NotFoundException";
+    mockDeleteUser.mockRejectedValueOnce(missingUserError as never);
+
+    const response = await POST(request() as any);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(mockDeleteUser).toHaveBeenCalledWith("user_123");
+  });
+
+  it("keeps unexpected WorkOS user deletion failures visible", async () => {
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [],
+    } as never);
+    mockDeleteUser.mockRejectedValueOnce(
+      new Error("WorkOS temporarily unavailable") as never,
+    );
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("WorkOS temporarily unavailable");
+  });
+
   it("does not delete WorkOS or billing resources if Convex cleanup fails", async () => {
     mockListOrganizationMemberships.mockResolvedValueOnce({
       data: [],

--- a/app/api/delete-account/__tests__/route.test.ts
+++ b/app/api/delete-account/__tests__/route.test.ts
@@ -329,6 +329,23 @@ describe("POST /api/delete-account", () => {
     expect(body.error).toBe("WorkOS temporarily unavailable");
   });
 
+  it("keeps other WorkOS NotFoundExceptions visible", async () => {
+    mockListOrganizationMemberships.mockResolvedValueOnce({
+      data: [],
+    } as never);
+    const unrelatedNotFoundError = new Error(
+      "Organization not found: 'org_123'.",
+    );
+    unrelatedNotFoundError.name = "NotFoundException";
+    mockDeleteUser.mockRejectedValueOnce(unrelatedNotFoundError as never);
+
+    const response = await POST(request() as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("Organization not found: 'org_123'.");
+  });
+
   it("does not delete WorkOS or billing resources if Convex cleanup fails", async () => {
     mockListOrganizationMemberships.mockResolvedValueOnce({
       data: [],

--- a/app/api/delete-account/route.ts
+++ b/app/api/delete-account/route.ts
@@ -22,6 +22,14 @@ type MembershipDeletionPlan = {
 
 const MAX_CONVEX_ACCOUNT_CLEANUP_BATCHES = 50;
 
+function isMissingWorkosUserError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === "NotFoundException" &&
+    error.message.startsWith("User not found:")
+  );
+}
+
 function parseConvexCleanupResult(result: unknown): { hasMore: boolean } {
   if (
     result &&
@@ -284,7 +292,14 @@ export const POST = async (req: NextRequest) => {
 
     // Finally, delete the WorkOS user
     stage = "delete_workos_user";
-    await workos.userManagement.deleteUser(userId);
+    try {
+      await workos.userManagement.deleteUser(userId);
+    } catch (error) {
+      // Account deletion is idempotent once all owned app data is gone.
+      // WorkOS can report this exact state when a previous attempt already
+      // removed the external identity but the client retried the request.
+      if (!isMissingWorkosUserError(error)) throw error;
+    }
 
     return NextResponse.json({ ok: true });
   } catch (error) {

--- a/lib/api/__tests__/agent-cancel-route.test.ts
+++ b/lib/api/__tests__/agent-cancel-route.test.ts
@@ -7,6 +7,7 @@ const mockGetTemporaryRefreshHandle = jest.fn();
 const mockCloseAgentApprovalSession = jest.fn();
 const mockCancelAgentTriggerRun = jest.fn();
 const mockClearTemporaryRefreshCookie = jest.fn();
+const mockLoggerWarn = jest.fn();
 
 jest.mock("next/server", () => ({
   NextResponse: class MockNextResponse {
@@ -51,8 +52,19 @@ jest.mock("@/lib/api/agent-route-errors", () => ({
   }),
 }));
 
+jest.mock("@/lib/logger", () => ({
+  logger: { warn: mockLoggerWarn },
+}));
+
 const request = () =>
-  ({ json: jest.fn(async () => ({ chatId: "temporary-chat-1" })) }) as any;
+  ({
+    json: jest.fn(async () => ({ chatId: "temporary-chat-1" })),
+    headers: {
+      get: jest.fn((name: string) =>
+        name === "x-vercel-id" ? "req_agent_cancel" : null,
+      ),
+    },
+  }) as any;
 
 describe("agent cancel route", () => {
   beforeEach(() => {
@@ -103,5 +115,41 @@ describe("agent cancel route", () => {
     expect(response.status).toBe(403);
     expect(mockCancelAgentTriggerRun).not.toHaveBeenCalled();
     expect(mockClearTemporaryRefreshCookie).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "Rejected Agent cancellation request",
+      expect.objectContaining({
+        event: "agent_cancel_rejected",
+        request_id: "req_agent_cancel",
+        endpoint: "/api/agent",
+        route: "/api/agent/cancel",
+        reason: "temporary_refresh_missing",
+        status_code: 403,
+        user_id: "user-1",
+        chat_id: "temporary-chat-1",
+      }),
+    );
+  });
+
+  it("logs a distinct reason when a persisted chat belongs to another user", async () => {
+    const { createAgentCancelPost } = await import("../agent-cancel-route");
+    mockGetChatById.mockResolvedValue({ user_id: "user-2" } as never);
+
+    const response = await createAgentCancelPost({ endpoint: "/api/agent" })(
+      request(),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockGetTemporaryRefreshHandle).not.toHaveBeenCalled();
+    expect(mockCancelAgentTriggerRun).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "Rejected Agent cancellation request",
+      expect.objectContaining({
+        event: "agent_cancel_rejected",
+        reason: "chat_owner_mismatch",
+        status_code: 403,
+        user_id: "user-1",
+        chat_id: "temporary-chat-1",
+      }),
+    );
   });
 });

--- a/lib/api/agent-cancel-route.ts
+++ b/lib/api/agent-cancel-route.ts
@@ -10,6 +10,38 @@ import {
   closeAgentApprovalSession,
   getTemporaryAgentApprovalRefreshHandle,
 } from "@/lib/api/agent-approval-session";
+import { logger } from "@/lib/logger";
+
+type AgentCancelRejectionReason =
+  "chat_owner_mismatch" | "temporary_refresh_missing";
+
+function logAgentCancelRejection({
+  req,
+  endpoint,
+  userId,
+  chatId,
+  reason,
+}: {
+  req: NextRequest;
+  endpoint: AgentApiEndpoint;
+  userId: string;
+  chatId: string;
+  reason: AgentCancelRejectionReason;
+}) {
+  logger.warn("Rejected Agent cancellation request", {
+    event: "agent_cancel_rejected",
+    request_id: req.headers.get("x-vercel-id") ?? "unknown",
+    service: "hackerai-web",
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+    route: `${endpoint}/cancel`,
+    endpoint,
+    action: "cancel",
+    reason,
+    status_code: 403,
+    user_id: userId,
+    chat_id: chatId,
+  });
+}
 
 export const createAgentCancelPost =
   ({ endpoint }: { endpoint: AgentApiEndpoint }) =>
@@ -30,6 +62,13 @@ export const createAgentCancelPost =
 
       const chat = await getChatById({ id: chatId });
       if (chat && chat.user_id !== userId) {
+        logAgentCancelRejection({
+          req,
+          endpoint,
+          userId,
+          chatId,
+          reason: "chat_owner_mismatch",
+        });
         return new NextResponse("Forbidden", { status: 403 });
       }
 
@@ -37,6 +76,13 @@ export const createAgentCancelPost =
         ? null
         : getTemporaryAgentApprovalRefreshHandle({ req, userId, chatId });
       if (!chat && !temporaryRefresh) {
+        logAgentCancelRejection({
+          req,
+          endpoint,
+          userId,
+          chatId,
+          reason: "temporary_refresh_missing",
+        });
         return new NextResponse("Forbidden", { status: 403 });
       }
 


### PR DESCRIPTION
## Summary
- treat the exact WorkOS `NotFoundException` for an already-missing user as a completed final account-deletion step
- keep all other WorkOS deletion failures visible and returning 500
- emit a structured `agent_cancel_rejected` warning that distinguishes `chat_owner_mismatch` from `temporary_refresh_missing`
- cover the deletion and cancellation branches with focused regression tests

## Production evidence
- the previous 24 hours contained three `/api/delete-account` 500s for one user, all at `stage=delete_workos_user` with `NotFoundException: User not found`
- PostHog captured one user-visible `Agent cancellation failed with status 403`, while the server returned two indistinguishable forbidden branches without structured reason logging
- the remaining Vercel and PostHog clusters were retained as operational errors or already-narrowly-filtered transport noise; no broader suppression was added

## Validation
- `corepack pnpm jest app/api/delete-account/__tests__/route.test.ts lib/api/__tests__/agent-cancel-route.test.ts --runInBand` (15 tests)
- `corepack pnpm typecheck`
- changed-file ESLint and Prettier checks
- commit hook: full Jest suite (255 suites, 2,556 tests), typecheck, ESLint, and Prettier

## Manual verification
- In staging with a disposable account whose WorkOS user is already absent, call Delete account and confirm the request returns 200 after app-data cleanup rather than surfacing the WorkOS 404.
- Trigger Agent cancellation once with a missing temporary refresh mapping and once for a chat owned by another test user; confirm both remain 403 and emit `agent_cancel_rejected` with the corresponding bounded `reason` value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Account deletion now succeeds when the WorkOS user is already missing, returning `{ ok: true }` with HTTP 200.
  - Unexpected account deletion failures now return HTTP 500 with the error message in the response.
  - Agent cancellation requests now deny unauthorized chat access with HTTP 403.

- **Monitoring**
  - Added structured warning logs for rejected agent cancellation requests, capturing the rejection reason and key request details.

- **Tests**
  - Expanded coverage for account deletion and agent cancellation rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->