### PR TITLE
Refine single queued message steering UI

### DIFF
--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -337,18 +337,20 @@ export const ChatInput = ({
           />
         )}
 
-        <TodoPanel status={status} />
+        <div className="flex flex-col [&>*+*]:rounded-t-none">
+          <TodoPanel status={status} />
 
-        {messageQueue.length > 0 && (
-          <QueuedMessagesPanel
-            messages={messageQueue}
-            onSendNow={onSendNow}
-            onDelete={removeQueuedMessage}
-            isStreaming={status === "streaming"}
-            queueBehavior={queueBehavior}
-            onQueueBehaviorChange={setQueueBehavior}
-          />
-        )}
+          {messageQueue.length > 0 && (
+            <QueuedMessagesPanel
+              messages={messageQueue}
+              onSendNow={onSendNow}
+              onDelete={removeQueuedMessage}
+              isStreaming={status === "streaming"}
+              queueBehavior={queueBehavior}
+              onQueueBehaviorChange={setQueueBehavior}
+            />
+          )}
+        </div>
 
         {uploadedFiles && uploadedFiles.length > 0 && (
           <FileUploadPreview

--- a/app/components/QueuedMessagesPanel.tsx
+++ b/app/components/QueuedMessagesPanel.tsx
@@ -5,14 +5,14 @@ import {
   ChevronDown,
   ChevronRight,
   MoreHorizontal,
-  Check,
 } from "lucide-react";
 import type { QueuedMessage, QueueBehavior } from "@/types/chat";
 import { useState } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
@@ -58,16 +58,22 @@ const QueueSettingsMenu = ({
       <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
         When to send follow-ups
       </div>
-      {queueBehaviorOptions.map((option) => (
-        <DropdownMenuItem
-          key={option.value}
-          onClick={() => onQueueBehaviorChange?.(option.value)}
-          className="flex items-center justify-between cursor-pointer"
-        >
-          <span>{option.label}</span>
-          {queueBehavior === option.value && <Check className="w-4 h-4" />}
-        </DropdownMenuItem>
-      ))}
+      <DropdownMenuRadioGroup
+        value={queueBehavior}
+        onValueChange={(value) =>
+          onQueueBehaviorChange?.(value as QueueBehavior)
+        }
+      >
+        {queueBehaviorOptions.map((option) => (
+          <DropdownMenuRadioItem
+            key={option.value}
+            value={option.value}
+            className="cursor-pointer"
+          >
+            {option.label}
+          </DropdownMenuRadioItem>
+        ))}
+      </DropdownMenuRadioGroup>
     </DropdownMenuContent>
   </DropdownMenu>
 );
@@ -155,7 +161,7 @@ export const QueuedMessagesPanel = ({
             <button
               type="button"
               onClick={handleToggleExpand}
-              className="flex items-center gap-2 hover:opacity-80 transition-opacity cursor-pointer focus:outline-none rounded-md p-1 -m-1 flex-1"
+              className="flex items-center gap-2 hover:opacity-80 transition-opacity cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-md p-1 -m-1 flex-1"
               aria-label={
                 isExpanded
                   ? "Collapse queued messages"

--- a/app/components/QueuedMessagesPanel.tsx
+++ b/app/components/QueuedMessagesPanel.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import {
   Trash,
-  ArrowUp,
+  CornerDownRight,
   ChevronDown,
   ChevronRight,
   MoreHorizontal,
@@ -25,6 +25,53 @@ interface QueuedMessagesPanelProps {
   onQueueBehaviorChange?: (behavior: QueueBehavior) => void;
 }
 
+const queueBehaviorOptions: Array<{
+  value: QueueBehavior;
+  label: string;
+}> = [
+  { value: "queue", label: "Queue after current message" },
+  { value: "stop-and-send", label: "Stop & send right away" },
+];
+
+interface QueueSettingsMenuProps {
+  queueBehavior: QueueBehavior;
+  onQueueBehaviorChange?: (behavior: QueueBehavior) => void;
+}
+
+const QueueSettingsMenu = ({
+  queueBehavior,
+  onQueueBehaviorChange,
+}: QueueSettingsMenuProps) => (
+  <DropdownMenu>
+    <DropdownMenuTrigger asChild>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-7 w-7 p-0"
+        aria-label="Queue settings"
+      >
+        <MoreHorizontal className="w-4 h-4 text-muted-foreground" />
+      </Button>
+    </DropdownMenuTrigger>
+    <DropdownMenuContent align="end" className="w-56">
+      <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+        When to send follow-ups
+      </div>
+      {queueBehaviorOptions.map((option) => (
+        <DropdownMenuItem
+          key={option.value}
+          onClick={() => onQueueBehaviorChange?.(option.value)}
+          className="flex items-center justify-between cursor-pointer"
+        >
+          <span>{option.label}</span>
+          {queueBehavior === option.value && <Check className="w-4 h-4" />}
+        </DropdownMenuItem>
+      ))}
+    </DropdownMenuContent>
+  </DropdownMenu>
+);
+
 export const QueuedMessagesPanel = ({
   messages,
   onSendNow,
@@ -39,133 +86,104 @@ export const QueuedMessagesPanel = ({
     return null;
   }
 
+  const isSingleMessage = messages.length === 1;
+
   const handleToggleExpand = () => {
-    setIsExpanded(!isExpanded);
+    setIsExpanded((expanded) => !expanded);
   };
 
-  const queueBehaviorOptions: Array<{
-    value: QueueBehavior;
-    label: string;
-  }> = [
-    { value: "queue", label: "Queue after current message" },
-    { value: "stop-and-send", label: "Stop & send right away" },
-  ];
+  const renderMessage = (message: QueuedMessage, showSettings = false) => (
+    <div
+      key={message.id}
+      className="flex items-start gap-2 transition-colors min-w-0"
+    >
+      <div className="flex-1 min-w-0">
+        <div className="text-sm truncate text-foreground">{message.text}</div>
+        {message.files && message.files.length > 0 && (
+          <div className="text-xs text-muted-foreground mt-0.5">
+            {message.files.length} file
+            {message.files.length > 1 ? "s" : ""}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1 flex-shrink-0">
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={() => onSendNow(message.id)}
+          disabled={!isStreaming}
+          className="h-7 px-2 text-xs"
+          title={
+            isStreaming
+              ? "Stop the current response and steer with this message"
+              : "Waiting for the current response to complete"
+          }
+        >
+          <CornerDownRight className="w-3 h-3 mr-1" />
+          Steer
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={() => onDelete(message.id)}
+          className="h-7 w-7 p-0"
+          aria-label="Remove queued message"
+          title="Remove from queue"
+        >
+          <Trash className="w-4 h-4" />
+        </Button>
+        {showSettings && (
+          <QueueSettingsMenu
+            queueBehavior={queueBehavior}
+            onQueueBehaviorChange={onQueueBehaviorChange}
+          />
+        )}
+      </div>
+    </div>
+  );
 
   return (
     <div className="mx-4 rounded-[22px_22px_0px_0px] shadow-[0px_12px_32px_0px_rgba(0,0,0,0.02)] border border-black/8 dark:border-border border-b-0 bg-input-chat">
-      {/* Header */}
-      <div className="flex items-center px-4 transition-all duration-300 py-2">
-        <button
-          onClick={handleToggleExpand}
-          className="flex items-center gap-2 hover:opacity-80 transition-opacity cursor-pointer focus:outline-none rounded-md p-1 -m-1 flex-1"
-          aria-label={
-            isExpanded ? "Collapse queued messages" : "Expand queued messages"
-          }
-          tabIndex={0}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              handleToggleExpand();
-            }
-          }}
-        >
-          {isExpanded ? (
-            <ChevronDown className="w-4 h-4 text-muted-foreground" />
-          ) : (
-            <ChevronRight className="w-4 h-4 text-muted-foreground" />
-          )}
-          <div className="flex items-center gap-2">
-            <h3 className="text-muted-foreground text-sm font-medium">
-              {messages.length} Queued
-            </h3>
+      {isSingleMessage ? (
+        <div className="px-4 py-3">{renderMessage(messages[0], true)}</div>
+      ) : (
+        <>
+          <div className="flex items-center px-4 transition-all duration-300 py-2">
+            <button
+              type="button"
+              onClick={handleToggleExpand}
+              className="flex items-center gap-2 hover:opacity-80 transition-opacity cursor-pointer focus:outline-none rounded-md p-1 -m-1 flex-1"
+              aria-label={
+                isExpanded
+                  ? "Collapse queued messages"
+                  : "Expand queued messages"
+              }
+            >
+              {isExpanded ? (
+                <ChevronDown className="w-4 h-4 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="w-4 h-4 text-muted-foreground" />
+              )}
+              <h3 className="text-muted-foreground text-sm font-medium">
+                {messages.length} Queued
+              </h3>
+            </button>
+
+            <QueueSettingsMenu
+              queueBehavior={queueBehavior}
+              onQueueBehaviorChange={onQueueBehaviorChange}
+            />
           </div>
-        </button>
 
-        {/* Settings Dropdown */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 w-7 p-0"
-              aria-label="Queue settings"
-            >
-              <MoreHorizontal className="w-4 h-4 text-muted-foreground" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
-              When to send follow-ups
+          {isExpanded && (
+            <div className="border-t border-border px-4 py-3 space-y-2 max-h-[200px] overflow-y-auto">
+              {messages.map((message) => renderMessage(message))}
             </div>
-            {queueBehaviorOptions.map((option) => (
-              <DropdownMenuItem
-                key={option.value}
-                onClick={() => onQueueBehaviorChange?.(option.value)}
-                className="flex items-center justify-between cursor-pointer"
-              >
-                <span>{option.label}</span>
-                {queueBehavior === option.value && (
-                  <Check className="w-4 h-4" />
-                )}
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-
-      {/* Message List - Collapsible */}
-      {isExpanded && (
-        <div className="border-t border-border px-4 py-3 space-y-2 max-h-[200px] overflow-y-auto">
-          {messages.map((message) => (
-            <div
-              key={message.id}
-              className="flex items-start gap-2 transition-colors"
-            >
-              {/* Message preview */}
-              <div className="flex-1 min-w-0">
-                <div className="text-sm truncate text-foreground">
-                  {message.text}
-                </div>
-                {message.files && message.files.length > 0 && (
-                  <div className="text-xs text-muted-foreground mt-0.5">
-                    {message.files.length} file
-                    {message.files.length > 1 ? "s" : ""}
-                  </div>
-                )}
-              </div>
-
-              {/* Actions */}
-              <div className="flex items-center gap-1 flex-shrink-0">
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => onSendNow(message.id)}
-                  disabled={!isStreaming}
-                  className="h-7 px-2 text-xs"
-                  title={
-                    isStreaming
-                      ? "Cancel current response and send this now"
-                      : "Waiting for current response to complete"
-                  }
-                >
-                  <ArrowUp className="w-3 h-3 mr-1" />
-                  Send Now
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => onDelete(message.id)}
-                  className="h-7 w-7 p-0"
-                  title="Remove from queue"
-                >
-                  <Trash className="w-4 h-4" />
-                </Button>
-              </div>
-            </div>
-          ))}
-        </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/app/components/__tests__/QueuedMessagesPanel.test.tsx
+++ b/app/components/__tests__/QueuedMessagesPanel.test.tsx
@@ -1,0 +1,73 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueuedMessagesPanel } from "../QueuedMessagesPanel";
+import type { QueuedMessage } from "@/types/chat";
+
+const messages: QueuedMessage[] = [
+  {
+    id: "message-1",
+    text: "do ping now",
+    timestamp: 1,
+  },
+  {
+    id: "message-2",
+    text: "then check the headers",
+    timestamp: 2,
+  },
+];
+
+describe("QueuedMessagesPanel", () => {
+  it("shows a single queued message directly with compact steer actions", () => {
+    const onSendNow = jest.fn();
+    const onDelete = jest.fn();
+
+    render(
+      <QueuedMessagesPanel
+        messages={[messages[0]]}
+        onSendNow={onSendNow}
+        onDelete={onDelete}
+        isStreaming
+      />,
+    );
+
+    expect(screen.getByText("do ping now")).toBeInTheDocument();
+    expect(screen.queryByText("1 Queued")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Collapse queued messages" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Steer" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove queued message" }),
+    );
+
+    expect(onSendNow).toHaveBeenCalledWith("message-1");
+    expect(onDelete).toHaveBeenCalledWith("message-1");
+    expect(
+      screen.getByRole("button", { name: "Queue settings" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the collapsible count view for multiple queued messages", () => {
+    render(
+      <QueuedMessagesPanel
+        messages={messages}
+        onSendNow={jest.fn()}
+        onDelete={jest.fn()}
+        isStreaming
+      />,
+    );
+
+    expect(screen.getByText("2 Queued")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Steer" })).toHaveLength(2);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Collapse queued messages" }),
+    );
+
+    expect(screen.queryByText("do ping now")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Expand queued messages" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/components/__tests__/QueuedMessagesPanel.test.tsx
+++ b/app/components/__tests__/QueuedMessagesPanel.test.tsx
@@ -17,9 +17,10 @@ const messages: QueuedMessage[] = [
 ];
 
 describe("QueuedMessagesPanel", () => {
-  it("shows a single queued message directly with compact steer actions", () => {
+  it("shows a single queued message directly with compact steer actions", async () => {
     const onSendNow = jest.fn();
     const onDelete = jest.fn();
+    const onQueueBehaviorChange = jest.fn();
 
     render(
       <QueuedMessagesPanel
@@ -27,6 +28,7 @@ describe("QueuedMessagesPanel", () => {
         onSendNow={onSendNow}
         onDelete={onDelete}
         isStreaming
+        onQueueBehaviorChange={onQueueBehaviorChange}
       />,
     );
 
@@ -46,15 +48,29 @@ describe("QueuedMessagesPanel", () => {
     expect(
       screen.getByRole("button", { name: "Queue settings" }),
     ).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByRole("button", { name: "Queue settings" }), {
+      key: "Enter",
+    });
+    fireEvent.click(
+      await screen.findByRole("menuitemradio", {
+        name: "Stop & send right away",
+      }),
+    );
+
+    expect(onQueueBehaviorChange).toHaveBeenCalledWith("stop-and-send");
   });
 
-  it("keeps the collapsible count view for multiple queued messages", () => {
+  it("keeps the collapsible count view for multiple queued messages", async () => {
+    const onQueueBehaviorChange = jest.fn();
+
     render(
       <QueuedMessagesPanel
         messages={messages}
         onSendNow={jest.fn()}
         onDelete={jest.fn()}
         isStreaming
+        onQueueBehaviorChange={onQueueBehaviorChange}
       />,
     );
 
@@ -69,5 +85,19 @@ describe("QueuedMessagesPanel", () => {
     expect(
       screen.getByRole("button", { name: "Expand queued messages" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Queue settings" }),
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByRole("button", { name: "Queue settings" }), {
+      key: "Enter",
+    });
+    fireEvent.click(
+      await screen.findByRole("menuitemradio", {
+        name: "Stop & send right away",
+      }),
+    );
+
+    expect(onQueueBehaviorChange).toHaveBeenCalledWith("stop-and-send");
   });
 });

--- a/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
@@ -1,0 +1,206 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { ChatMessage, Todo } from "@/types";
+
+const mockCancelStream = jest.fn(async () => null);
+const mockCancelTempStream = jest.fn(async () => null);
+const mockSaveAssistantMessage = jest.fn(async () => null);
+const mockDeleteLastAssistantMessage = jest.fn(async () => null);
+const mockRegenerateWithNewContent = jest.fn(async () => null);
+const mockRemoveQueuedMessage = jest.fn();
+const mockSendMessage = jest.fn(async () => undefined);
+const mockStop = jest.fn();
+const mockSetMessages = jest.fn();
+
+const todos: Todo[] = [
+  {
+    id: "todo-1",
+    content: "Keep this task",
+    status: "in_progress",
+    sourceMessageId: "assistant-1",
+  },
+];
+
+jest.mock("@/convex/_generated/api", () => ({
+  api: {
+    chatStreams: { cancelStreamFromClient: "cancelStreamFromClient" },
+    messages: {
+      deleteLastAssistantMessage: "deleteLastAssistantMessage",
+      regenerateWithNewContent: "regenerateWithNewContent",
+      saveAssistantMessage: "saveAssistantMessage",
+    },
+    tempStreams: { cancelTempStreamFromClient: "cancelTempStreamFromClient" },
+  },
+}));
+
+jest.mock("convex/react", () => ({
+  useMutation: (mutation: string) => {
+    switch (mutation) {
+      case "cancelStreamFromClient":
+        return mockCancelStream;
+      case "cancelTempStreamFromClient":
+        return mockCancelTempStream;
+      case "saveAssistantMessage":
+        return mockSaveAssistantMessage;
+      case "deleteLastAssistantMessage":
+        return mockDeleteLastAssistantMessage;
+      case "regenerateWithNewContent":
+        return mockRegenerateWithNewContent;
+      default:
+        throw new Error(`Unexpected mutation: ${mutation}`);
+    }
+  },
+}));
+
+jest.mock("@/app/contexts/GlobalState", () => ({
+  useGlobalState: () => ({
+    input: "",
+    uploadedFiles: [],
+    chatMode: "agent",
+    clearInput: jest.fn(),
+    clearUploadedFiles: jest.fn(),
+    todos,
+    setTodos: jest.fn(),
+    isUploadingFiles: false,
+    subscription: "pro",
+    temporaryChatsEnabled: false,
+    queueMessage: jest.fn(),
+    messageQueue: [
+      {
+        id: "queued-1",
+        text: "Change direction",
+        files: [],
+        timestamp: 123,
+      },
+    ],
+    removeQueuedMessage: mockRemoveQueuedMessage,
+    queueBehavior: "queue",
+    sandboxPreference: "e2b",
+    agentPermissionMode: "full_access",
+    selectedModel: "hackerai-standard",
+    sidebarOpen: false,
+    sidebarContent: null,
+    openSidebar: jest.fn(),
+    closeSidebar: jest.fn(),
+  }),
+}));
+
+jest.mock("@/app/components/DataStreamProvider", () => ({
+  useDataStreamDispatch: () => ({ setIsAutoResuming: jest.fn() }),
+}));
+
+jest.mock("@/app/hooks/useTauri", () => ({
+  isTauriEnvironment: () => false,
+}));
+
+const { useChatHandlers } =
+  require("../useChatHandlers") as typeof import("../useChatHandlers");
+
+const messages: ChatMessage[] = [
+  {
+    id: "user-1",
+    role: "user",
+    parts: [{ type: "text", text: "Start the task" }],
+  },
+  {
+    id: "assistant-1",
+    role: "assistant",
+    parts: [
+      {
+        type: "tool-todo_write",
+        toolCallId: "todo-call-1",
+        state: "output-available",
+        input: { todos },
+        output: { currentTodos: todos },
+      },
+    ],
+  },
+];
+
+describe("useChatHandlers steer todo handoff", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: jest.fn(async () => ({ ok: true, status: 200 }) as Response),
+    });
+  });
+
+  it("persists todos and cancels the active run before sending the queued message", async () => {
+    const { result } = renderHook(() =>
+      useChatHandlers({
+        chatId: "chat-1",
+        messages,
+        sendMessage: mockSendMessage,
+        stop: mockStop,
+        regenerate: jest.fn(),
+        setMessages: mockSetMessages,
+        isExistingChat: true,
+        status: "streaming",
+        isSendingNowRef: { current: false },
+        hasManuallyStoppedRef: { current: false },
+        activeTriggerRunRef: { current: "run-1" },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleSendNow("queued-1");
+    });
+
+    expect(mockCancelStream).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      skipSave: undefined,
+      todos,
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/agent/cancel",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ chatId: "chat-1" }),
+      }),
+    );
+    expect(mockCancelStream.mock.invocationCallOrder[0]).toBeLessThan(
+      (globalThis.fetch as jest.Mock).mock.invocationCallOrder[0],
+    );
+    expect(
+      (globalThis.fetch as jest.Mock).mock.invocationCallOrder[0],
+    ).toBeLessThan(mockSendMessage.mock.invocationCallOrder[0]);
+    expect(mockRemoveQueuedMessage).toHaveBeenCalledWith("queued-1");
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Change direction" }),
+      expect.objectContaining({ body: expect.objectContaining({ todos }) }),
+    );
+  });
+
+  it("keeps the queued message when the todo snapshot cannot be persisted", async () => {
+    mockCancelStream.mockRejectedValueOnce(new Error("write failed"));
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() =>
+      useChatHandlers({
+        chatId: "chat-1",
+        messages,
+        sendMessage: mockSendMessage,
+        stop: mockStop,
+        regenerate: jest.fn(),
+        setMessages: mockSetMessages,
+        isExistingChat: true,
+        status: "streaming",
+        isSendingNowRef: { current: false },
+        hasManuallyStoppedRef: { current: false },
+        activeTriggerRunRef: { current: "run-1" },
+      }),
+    );
+
+    try {
+      await act(async () => {
+        await result.current.handleSendNow("queued-1");
+      });
+    } finally {
+      errorSpy.mockRestore();
+    }
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(mockRemoveQueuedMessage).not.toHaveBeenCalled();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -196,6 +196,7 @@ export const useChatHandlers = ({
    */
   const stopActiveStream = async (options?: {
     skipSave?: boolean;
+    requireCancelSuccess?: boolean;
   }): Promise<ChatMessage[]> => {
     // Stop the stream immediately (client-side abort)
     stop();
@@ -259,18 +260,27 @@ export const useChatHandlers = ({
             })
           : Promise.resolve();
 
+      const cancelPromise = cancelStreamMutation({
+        chatId,
+        skipSave: options?.skipSave || undefined,
+        todos,
+      });
       await Promise.all([
-        cancelStreamMutation({
-          chatId,
-          skipSave: options?.skipSave || undefined,
-        }).catch((error) => {
-          console.error("Failed to cancel stream:", error);
-        }),
+        options?.requireCancelSuccess
+          ? cancelPromise
+          : cancelPromise.catch((error) => {
+              console.error("Failed to cancel stream:", error);
+            }),
         savePromise,
       ]);
     } else {
       // Temporary chats: signal cancel via temp stream coordination
-      await cancelTempStreamMutation({ chatId }).catch(() => {});
+      const cancelPromise = cancelTempStreamMutation({ chatId });
+      if (options?.requireCancelSuccess) {
+        await cancelPromise;
+      } else {
+        await cancelPromise.catch(() => {});
+      }
     }
 
     return normalizedMessages;
@@ -293,6 +303,13 @@ export const useChatHandlers = ({
     if (streamStopResult.status === "rejected") {
       throw streamStopResult.reason;
     }
+  };
+
+  const stopActiveRunForSteer = async (): Promise<void> => {
+    // Persist the latest message and todo snapshot before canceling the Trigger
+    // run. The next run reads persisted todos for non-temporary chats.
+    await stopActiveStream({ requireCancelSuccess: true });
+    await cancelTriggerRun();
   };
 
   const hasActiveRunToReplace = () =>
@@ -357,13 +374,16 @@ export const useChatHandlers = ({
         clearUploadedFiles();
         return true;
       } else if (queueBehavior === "stop-and-send") {
-        // Cancel the trigger.dev run for Agent streams so the prior
-        // run stops burning compute instead of finishing in the background.
-        void cancelTriggerRun().catch((error) => {
-          console.error("Failed to cancel trigger.dev run:", error);
-        });
-
-        await stopActiveStream();
+        try {
+          await stopActiveRunForSteer();
+        } catch (error) {
+          console.error(
+            "Failed to stop the active run before steering:",
+            error,
+          );
+          toast.error("Could not steer the Agent run. Please try again.");
+          return false;
+        }
         // Continue to send the new message immediately below (don't return)
       }
     }
@@ -845,12 +865,11 @@ export const useChatHandlers = ({
     hasManuallyStoppedRef.current = false;
 
     try {
-      // Remove the message from queue FIRST (before stopping)
-      removeQueuedMessage(messageId);
-
-      // Stop the stream using the shared helper
       setIsAutoResuming(false);
-      await stopActiveStream();
+      await stopActiveRunForSteer();
+
+      // Keep the queued message available if stopping fails.
+      removeQueuedMessage(messageId);
 
       // Send the queued message immediately
       const validFiles = message.files || [];
@@ -883,6 +902,7 @@ export const useChatHandlers = ({
       );
     } catch (error) {
       console.error("Failed to send queued message:", error);
+      toast.error("Could not steer the Agent run. Please try again.");
     } finally {
       // Clear flag after a brief delay to allow status to change
       setTimeout(() => {

--- a/convex/__tests__/chatStreams.cancel.test.ts
+++ b/convex/__tests__/chatStreams.cancel.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+jest.mock("../_generated/server", () => ({
+  mutation: jest.fn((config: any) => config),
+  query: jest.fn((config: any) => config),
+}));
+
+jest.mock("convex/values", () => ({
+  v: {
+    array: jest.fn(() => "array"),
+    boolean: jest.fn(() => "boolean"),
+    literal: jest.fn(() => "literal"),
+    null: jest.fn(() => "null"),
+    number: jest.fn(() => "number"),
+    object: jest.fn(() => "object"),
+    optional: jest.fn(() => "optional"),
+    string: jest.fn(() => "string"),
+    union: jest.fn(() => "union"),
+  },
+  ConvexError: class ConvexError extends Error {
+    data: unknown;
+
+    constructor(data: any) {
+      super(typeof data === "string" ? data : data.message);
+      this.data = data;
+    }
+  },
+}));
+
+jest.mock("../_generated/api", () => ({
+  internal: {
+    redisPubsub: {
+      publishCancellation: "internal.redisPubsub.publishCancellation",
+    },
+  },
+}));
+
+jest.mock("../lib/utils", () => ({
+  validateServiceKey: jest.fn(),
+}));
+
+jest.mock("../lib/logger", () => ({
+  convexLogger: { warn: jest.fn() },
+}));
+
+const todos = [
+  {
+    id: "todo-1",
+    content: "Keep this task",
+    status: "in_progress" as const,
+    sourceMessageId: "assistant-1",
+  },
+];
+
+const makeCtx = (chat: Record<string, unknown>) => {
+  const patch = jest.fn(async () => undefined);
+  const runAfter = jest.fn(async () => undefined);
+  const first = jest.fn(async () => chat);
+  const withIndex = jest.fn((_name: string, build: (q: any) => unknown) => {
+    const q = { eq: jest.fn(() => q) };
+    build(q);
+    return { first };
+  });
+
+  return {
+    ctx: {
+      auth: {
+        getUserIdentity: jest.fn(async () => ({ subject: "user-1" })),
+      },
+      db: {
+        patch,
+        query: jest.fn(() => ({ withIndex })),
+      },
+      scheduler: { runAfter },
+    } as any,
+    patch,
+    runAfter,
+  };
+};
+
+describe("cancelStreamFromClient", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("persists the current todos atomically with stream cancellation", async () => {
+    const { cancelStreamFromClient } = await import("../chatStreams");
+    const { ctx, patch, runAfter } = makeCtx({
+      _id: "chat-doc-1",
+      id: "chat-1",
+      user_id: "user-1",
+      active_stream_id: "stream-1",
+    });
+
+    await cancelStreamFromClient.handler(ctx, {
+      chatId: "chat-1",
+      todos,
+    });
+
+    expect(patch).toHaveBeenCalledWith(
+      "chat-doc-1",
+      expect.objectContaining({
+        active_stream_id: undefined,
+        canceled_at: expect.any(Number),
+        finish_reason: undefined,
+        todos,
+      }),
+    );
+    expect(runAfter).toHaveBeenCalledWith(
+      0,
+      "internal.redisPubsub.publishCancellation",
+      { chatId: "chat-1", skipSave: undefined },
+    );
+  });
+
+  it("still persists todos when the stream was already marked canceled", async () => {
+    const { cancelStreamFromClient } = await import("../chatStreams");
+    const { ctx, patch } = makeCtx({
+      _id: "chat-doc-1",
+      id: "chat-1",
+      user_id: "user-1",
+      active_stream_id: undefined,
+      canceled_at: 123,
+    });
+
+    await cancelStreamFromClient.handler(ctx, {
+      chatId: "chat-1",
+      todos,
+    });
+
+    expect(patch).toHaveBeenCalledWith("chat-doc-1", { todos });
+  });
+});

--- a/convex/chatStreams.ts
+++ b/convex/chatStreams.ts
@@ -89,6 +89,21 @@ export const cancelStreamFromClient = mutation({
   args: {
     chatId: v.string(),
     skipSave: v.optional(v.boolean()),
+    todos: v.optional(
+      v.array(
+        v.object({
+          id: v.string(),
+          content: v.string(),
+          status: v.union(
+            v.literal("pending"),
+            v.literal("in_progress"),
+            v.literal("completed"),
+            v.literal("cancelled"),
+          ),
+          sourceMessageId: v.optional(v.string()),
+        }),
+      ),
+    ),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -119,13 +134,23 @@ export const cancelStreamFromClient = mutation({
       });
     }
 
-    // Only patch if needed
-    if (chat.active_stream_id !== undefined || chat.canceled_at === undefined) {
+    const shouldMarkCanceled =
+      chat.active_stream_id !== undefined || chat.canceled_at === undefined;
+
+    // Persist the client todo snapshot with the cancellation so an immediate
+    // steer cannot reload the older stored list before the interrupted run
+    // finishes its normal todo persistence path.
+    if (shouldMarkCanceled || args.todos !== undefined) {
       await ctx.db.patch(chat._id, {
-        active_stream_id: undefined,
-        canceled_at: Date.now(),
-        finish_reason: undefined,
-        update_time: Date.now(),
+        ...(shouldMarkCanceled
+          ? {
+              active_stream_id: undefined,
+              canceled_at: Date.now(),
+              finish_reason: undefined,
+              update_time: Date.now(),
+            }
+          : {}),
+        ...(args.todos !== undefined ? { todos: args.todos } : {}),
       });
     }
 


### PR DESCRIPTION
## Summary
- render a single queued message directly without a redundant count or collapse control
- rename the immediate follow-up action from `Send Now` to `Steer` and keep delete/settings actions alongside it
- visually join task progress and queued-message panels into one clean composer accessory stack
- preserve the collapsible count view for multiple queued messages
- persist the latest todo snapshot before steering and cancel the active Trigger run before sending the queued message
- add regression coverage for queue rendering, steering order, and atomic todo persistence

## Why
A single queued message used the same expandable `1 Queued` panel as a larger queue, adding unnecessary hierarchy and creating an awkward rounded seam when task progress was also visible. The compact state now follows the Codex steering pattern and keeps the stacked composer surfaces visually connected.

Steering could also stop a run before its latest todo snapshot reached persisted chat state. The cancellation update then reloaded an older empty todo list and hid Task progress. Cancellation now stores the current todos atomically, and the queued message is kept if that handoff fails.

## Validation
- `corepack pnpm jest app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx app/hooks/__tests__/useChatHandlers.contracts.test.ts app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx app/hooks/__tests__/useChatHandlers.regenerate-sidebar.test.tsx app/components/__tests__/ChatInput.integration.test.tsx app/components/__tests__/QueuedMessagesPanel.test.tsx convex/__tests__/chatStreams.cancel.test.ts --runInBand` (39 tests passed)
- `corepack pnpm exec eslint app/hooks/useChatHandlers.ts convex/chatStreams.ts app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx convex/__tests__/chatStreams.cancel.test.ts`
- `corepack pnpm exec prettier --check app/hooks/useChatHandlers.ts convex/chatStreams.ts app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx convex/__tests__/chatStreams.cancel.test.ts`
- `git diff --check`
- `corepack pnpm typecheck` (blocked by unrelated workspace dependency errors: `@trigger.dev/sdk` does not export `sessions`, and `packages/local/src/index.ts` cannot resolve `ws`)

## Manual verification
- Open an Agent chat while it is streaming and queue one follow-up.
- Confirm the message is always visible without a `1 Queued` header or collapse control, and that `Steer`, delete, and queue settings remain available.
- Have the Agent create an active Task progress list, click `Steer`, and confirm the existing task list remains visible while the steered run begins.
- Expand and collapse Task progress while the queued message is present; confirm both panels form a clean continuous stack above the composer.
- Queue a second follow-up and confirm the multi-message count and collapse behavior still appear.

Verified the layout locally in Google Chrome in both expanded and collapsed Task progress states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated queued-message UI: clearer “Steer” actions (icon/label/tooltips) plus streamlined single vs. multi-message layouts.
  * Integrated queue behavior settings directly into the queued-message rows and header.
* **Bug Fixes**
  * Improved steer/stop flow: coordinated stopping before removing queued messages, added better failure handling with user feedback.
  * Enhanced stream cancellation to optionally persist todo updates alongside cancellation.
* **Tests**
  * Added/expanded test coverage for queued-message rendering/action flows and steer handoff behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->