### PR TITLE
Accept legacy production WorkOS keys in Pro backfill

### DIFF
--- a/convex/__tests__/pro20UsageBackfill.test.ts
+++ b/convex/__tests__/pro20UsageBackfill.test.ts
@@ -57,7 +57,7 @@ describe("Pro $20 Convex backfill action", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.STRIPE_SECRET_KEY = "sk_live_test_key";
-    process.env.WORKOS_API_KEY = "sk_live_workos";
+    process.env.WORKOS_API_KEY = "sk_legacy_production_workos";
     process.env.WORKOS_CLIENT_ID = "client_test";
     process.env.UPSTASH_REDIS_REST_URL = "https://redis.example";
     process.env.UPSTASH_REDIS_REST_TOKEN = "redis-token";
@@ -80,7 +80,7 @@ describe("Pro $20 Convex backfill action", () => {
     await callRun();
 
     expect(mockStripe).toHaveBeenCalledWith("sk_live_test_key");
-    expect(mockWorkOS).toHaveBeenCalledWith("sk_live_workos", {
+    expect(mockWorkOS).toHaveBeenCalledWith("sk_legacy_production_workos", {
       clientId: "client_test",
     });
     expect(mockRunPro20UsageBackfill).toHaveBeenCalledWith(
@@ -113,7 +113,16 @@ describe("Pro $20 Convex backfill action", () => {
     expect(mockRunPro20UsageBackfill).not.toHaveBeenCalled();
   });
 
-  it("allows a test WorkOS key for dry-run but rejects it for apply", async () => {
+  it("allows a legacy production key but rejects a test key for apply", async () => {
+    await expect(
+      callRun({
+        apply: true,
+        expectedSubscriptions: 1,
+        expectedFingerprint: "fingerprint",
+        confirmation: "APPLY_PRO_20_USAGE_BACKFILL",
+      }),
+    ).resolves.toBeDefined();
+
     process.env.WORKOS_API_KEY = "sk_test_workos";
 
     await expect(callRun()).resolves.toBeDefined();
@@ -124,8 +133,8 @@ describe("Pro $20 Convex backfill action", () => {
         expectedFingerprint: "fingerprint",
         confirmation: "APPLY_PRO_20_USAGE_BACKFILL",
       }),
-    ).rejects.toThrow("without a live WorkOS key");
-    expect(mockRunPro20UsageBackfill).toHaveBeenCalledTimes(1);
+    ).rejects.toThrow("with a WorkOS test key");
+    expect(mockRunPro20UsageBackfill).toHaveBeenCalledTimes(2);
   });
 
   it("rejects apply without the dry-run count", async () => {

--- a/convex/pro20UsageBackfill.ts
+++ b/convex/pro20UsageBackfill.ts
@@ -81,9 +81,9 @@ export const run = internalAction({
     }
 
     const workosApiKey = requireEnvironment("WORKOS_API_KEY");
-    if (apply && !workosApiKey.startsWith("sk_live_")) {
+    if (apply && workosApiKey.startsWith("sk_test_")) {
       throw new Error(
-        "Refusing to apply the Pro $20 backfill without a live WorkOS key",
+        "Refusing to apply the Pro $20 backfill with a WorkOS test key",
       );
     }
     const workosClientId = requireEnvironment("WORKOS_CLIENT_ID");

--- a/lib/billing/__tests__/pro-20-usage-backfill.test.ts
+++ b/lib/billing/__tests__/pro-20-usage-backfill.test.ts
@@ -161,6 +161,21 @@ describe("runPro20UsageBackfill", () => {
     expect(capAllocation).not.toHaveBeenCalled();
   });
 
+  it("requires a reviewed fingerprint for every apply caller", async () => {
+    const { stripe, workos, capAllocation } = makeDependencies();
+
+    await expect(
+      runPro20UsageBackfill({
+        stripe: stripe as never,
+        workos: workos as never,
+        apply: true,
+        expectedSubscriptions: 1,
+        capAllocation: capAllocation as never,
+      }),
+    ).rejects.toThrow("Apply requires expectedFingerprint");
+    expect(capAllocation).not.toHaveBeenCalled();
+  });
+
   it("applies the exact reviewed snapshot", async () => {
     const { stripe, workos, capAllocation } = makeDependencies();
     const dryRun = await runPro20UsageBackfill({

--- a/lib/billing/pro-20-usage-backfill.ts
+++ b/lib/billing/pro-20-usage-backfill.ts
@@ -326,10 +326,10 @@ export async function runPro20UsageBackfill(
   };
 
   if (!apply) return { summary };
-  if (
-    options.expectedFingerprint !== undefined &&
-    options.expectedFingerprint !== fingerprint
-  ) {
+  if (!options.expectedFingerprint) {
+    throw new Error("Apply requires expectedFingerprint");
+  }
+  if (options.expectedFingerprint !== fingerprint) {
     throw new Error(
       `Safety check failed: expected target fingerprint ${options.expectedFingerprint}, found ${fingerprint}`,
     );


### PR DESCRIPTION
## Summary

- accept valid legacy production WorkOS keys beginning with `sk_`
- continue rejecting explicit `sk_test_` keys for apply
- require `expectedFingerprint` inside the shared backfill runner as defense in depth
- cover both behaviors with focused tests

## Why

The production dry-run successfully resolved all 104 live Stripe subscriptions to 104 WorkOS users, proving the configured WorkOS key and tenant are correct. Apply then stopped before any Redis writes because the action incorrectly assumed every production WorkOS key uses the newer `sk_live_` prefix. The configured production key uses the valid legacy `sk_` format.

## Safety

The apply path still requires:

- production Convex environment variables
- a live Stripe key and live Stripe Price objects
- a non-test WorkOS key
- exact confirmation text
- the reviewed active-subscription count
- the reviewed target fingerprint
- zero unmapped active subscriptions

## Validation

- focused Convex/core tests: 19 passed
- `pnpm typecheck`
- targeted ESLint checks
- Convex bundle/codegen dry-run
- full repository suite: 258 suites / 2,590 tests passed

## Manual verification

After production deployment, rerun `pro20UsageBackfill:run` with `{}` in the Convex production dashboard. Confirm 104 active, 104 eligible, 104 users, and zero unmapped, then apply using the freshly returned fingerprint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened usage backfill safety checks by requiring an expected fingerprint before applying changes.
  - Apply operations now stop when the provided fingerprint does not match the calculated value.
  - Improved WorkOS credential validation so test keys are rejected for live apply operations while approved production credentials remain supported.

- **Tests**
  - Expanded coverage for missing and mismatched fingerprints and updated credential-validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->