### PR TITLE
Retry transient Stripe checkout locks

### DIFF
--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -750,4 +750,55 @@ describe("POST /api/subscribe", () => {
       }),
     );
   });
+
+  it("retries an idempotent Stripe customer read after a lock timeout", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          role: { slug: "owner" },
+        },
+      ],
+    } as never);
+    mockGetOrganization.mockResolvedValue({
+      id: "org_team",
+      stripeCustomerId: "cus_existing_org",
+    } as never);
+    const lockTimeout = Object.assign(new Error("Stripe object is locked"), {
+      code: "lock_timeout",
+      requestId: "req_lock_timeout",
+    });
+    mockRetrieveCustomer
+      .mockRejectedValueOnce(lockTimeout as never)
+      .mockResolvedValueOnce({
+        id: "cus_existing_org",
+        metadata: { workOSOrganizationId: "org_team" },
+      } as never);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const { POST } = await import("../route");
+
+      const response = await POST(makeRequest({ plan: "pro-monthly-plan" }));
+
+      expect(response.status).toBe(200);
+      expect(mockRetrieveCustomer).toHaveBeenCalledTimes(2);
+      expect(JSON.parse(String(warnSpy.mock.calls[0]?.[0]))).toMatchObject({
+        event: "billing.stripe_customer_retrieve_retry_scheduled",
+        request_id: "unknown",
+        service: "hackerai-web",
+        route: "/api/subscribe",
+        user_id: "user_123",
+        organization_id: "org_team",
+        stripe_customer_id: "cus_existing_org",
+        stripe_error_code: "lock_timeout",
+        stripe_request_id: "req_lock_timeout",
+        attempt: 1,
+        next_attempt: 2,
+        retry_delay_ms: 0,
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -80,6 +80,8 @@ function getEnvironment(): string {
 const CHECKOUT_SESSION_PAGE_SIZE = 100;
 const MAX_CHECKOUT_SESSION_PAGES = 5;
 const WORKOS_UPDATE_RETRY_DELAY_MS = process.env.NODE_ENV === "test" ? 0 : 250;
+const STRIPE_LOCK_TIMEOUT_RETRY_DELAY_MS =
+  process.env.NODE_ENV === "test" ? 0 : 500;
 
 function isWorkOSRequestTimeout(error: unknown): boolean {
   return error instanceof Error && /request timeout/i.test(error.message);
@@ -125,6 +127,48 @@ async function attachStripeCustomerToOrganization({
       );
     }
   }
+}
+
+async function retrieveStripeCustomer({
+  customerId,
+  organizationId,
+  userId,
+  requestId,
+}: {
+  customerId: string;
+  organizationId: string;
+  userId: string;
+  requestId: string;
+}): Promise<Stripe.Customer | Stripe.DeletedCustomer> {
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    try {
+      return await stripe.customers.retrieve(customerId);
+    } catch (error) {
+      const stripeErrorCode = getErrorString(error, "code");
+      if (stripeErrorCode !== "lock_timeout" || attempt === 2) throw error;
+
+      logger.warn("Retrying Stripe customer retrieval after lock timeout", {
+        event: "billing.stripe_customer_retrieve_retry_scheduled",
+        request_id: requestId,
+        service: "hackerai-web",
+        environment: getEnvironment(),
+        route: "/api/subscribe",
+        user_id: userId,
+        organization_id: organizationId,
+        stripe_customer_id: customerId,
+        stripe_error_code: stripeErrorCode,
+        stripe_request_id: getErrorString(error, "requestId"),
+        attempt,
+        next_attempt: attempt + 1,
+        retry_delay_ms: STRIPE_LOCK_TIMEOUT_RETRY_DELAY_MS,
+      });
+      await new Promise((resolve) =>
+        setTimeout(resolve, STRIPE_LOCK_TIMEOUT_RETRY_DELAY_MS),
+      );
+    }
+  }
+
+  throw new Error("Stripe customer retrieval exhausted without a result");
 }
 
 async function findReusableCheckoutSession({
@@ -352,9 +396,12 @@ export const POST = async (req: NextRequest) => {
     let shouldAttachCustomerToOrganization = false;
 
     if (organization.stripeCustomerId) {
-      const existingCustomer = await stripe.customers.retrieve(
-        organization.stripeCustomerId,
-      );
+      const existingCustomer = await retrieveStripeCustomer({
+        customerId: organization.stripeCustomerId,
+        organizationId: organization.id,
+        userId,
+        requestId,
+      });
 
       if ("deleted" in existingCustomer && existingCustomer.deleted) {
         return json(


### PR DESCRIPTION
## Summary
- retry the idempotent Stripe customer retrieval once when checkout encounters `lock_timeout`
- emit a structured `billing.stripe_customer_retrieve_retry_scheduled` warning with request, customer, and Stripe request IDs
- cover the recovery path with a route regression test

## Why
Production `/api/subscribe` logs contained two checkout 500s 22 seconds apart with Stripe `lock_timeout`. Both failed while retrieving an existing customer. A short, bounded retry lets the request recover when Stripe releases the object lock while preserving all other errors.

## Validation
- `corepack pnpm jest app/api/subscribe/__tests__/route.test.ts --runInBand` (12 tests passed)
- `corepack pnpm typecheck`
- `corepack pnpm exec eslint app/api/subscribe/route.ts app/api/subscribe/__tests__/route.test.ts`
- `corepack pnpm exec prettier --check app/api/subscribe/route.ts app/api/subscribe/__tests__/route.test.ts`
- pre-commit full suite: 259 suites / 2,578 tests passed

## Manual verification
- In production or a Stripe test environment, start checkout for an organization with an existing Stripe customer while another operation briefly holds that customer lock.
- Confirm `/api/subscribe` retries once, returns the checkout URL if the lock clears, and emits `billing.stripe_customer_retrieve_retry_scheduled`.
- Confirm persistent lock failures and non-`lock_timeout` errors still return the existing failure response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription checkout reliability by automatically retrying Stripe customer retrieval when temporary lock timeouts occur.
  * Preserved existing handling for deleted Stripe customers and billing flows after retries.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->