### PR TITLE
Stop payment retries after subscription cancellation

### DIFF
--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -7,6 +7,10 @@ import {
   afterEach,
 } from "@jest/globals";
 import { HACKERAI_PRO_20_MONTHLY_PRICE_ID } from "@/lib/billing/included-usage";
+import {
+  PAID_FUNNEL_EVENTS,
+  cancellationCompletionInsertId,
+} from "@/lib/analytics/paid-funnel";
 
 const mockConstructEvent = jest.fn();
 const mockRetrieveCustomer = jest.fn();
@@ -650,6 +654,13 @@ describe("POST /api/subscription/webhook", () => {
     mockListMemberships.mockResolvedValue({
       autoPagination: jest.fn().mockResolvedValue([{ userId: "user_paid" }]),
     } as never);
+    mockConvexMutation.mockImplementation((mutation) =>
+      Promise.resolve(
+        mutation === "cancellationReasons.markCancellationCompleted"
+          ? { matchedCount: 1, updatedCount: 1 }
+          : { alreadyProcessed: false },
+      ),
+    );
 
     const { POST } = await import("../route");
 
@@ -685,6 +696,12 @@ describe("POST /api/subscription/webhook", () => {
         tier: "pro-plus",
         org_id: "org_hackerai",
         $set: { subscription_tier: "free" },
+      }),
+    );
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      PAID_FUNNEL_EVENTS.cancellationCompleted,
+      expect.objectContaining({
+        $insert_id: cancellationCompletionInsertId("sub_hackerai_deleted"),
       }),
     );
     expect(console.warn).toHaveBeenCalledWith(

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -21,6 +21,7 @@ import type { SubscriptionTier } from "@/types";
 import { getReferralRewardConfig } from "@/lib/referrals/config";
 import {
   PAID_FUNNEL_EVENTS,
+  cancellationCompletionInsertId,
   paidFunnelProperties,
 } from "@/lib/analytics/paid-funnel";
 import {
@@ -1319,7 +1320,7 @@ async function recordCancellationCompleted(args: {
         stripe_customer_id: args.customerId,
         stripe_subscription_id: args.subscription.id,
         stripe_price_id: args.price?.id,
-        $insert_id: `${PAID_FUNNEL_EVENTS.cancellationCompleted}:${args.subscription.id}`,
+        $insert_id: cancellationCompletionInsertId(args.subscription.id),
       }),
     );
   }

--- a/app/components/AccountTab.tsx
+++ b/app/components/AccountTab.tsx
@@ -147,16 +147,18 @@ const AccountTab = () => {
     setShowCancelDialog(true);
   };
 
-  const handleCancellationScheduled = ({
+  const handleCancellationCompleted = ({
+    cancelAtPeriodEnd,
     currentPeriodEnd,
   }: {
+    cancelAtPeriodEnd: boolean;
     currentPeriodEnd?: number;
   }) => {
     setCancellationStatus({
       subscription,
-      hasActiveSubscription: true,
-      cancelAtPeriodEnd: true,
-      currentPeriodEnd,
+      hasActiveSubscription: cancelAtPeriodEnd,
+      cancelAtPeriodEnd,
+      currentPeriodEnd: cancelAtPeriodEnd ? currentPeriodEnd : undefined,
     });
   };
 
@@ -414,7 +416,7 @@ const AccountTab = () => {
       <CancelSubscriptionDialog
         open={showCancelDialog}
         onOpenChange={setShowCancelDialog}
-        onCancellationScheduled={handleCancellationScheduled}
+        onCancellationCompleted={handleCancellationCompleted}
       />
     </div>
   );

--- a/app/components/CancelSubscriptionDialog.tsx
+++ b/app/components/CancelSubscriptionDialog.tsx
@@ -43,10 +43,11 @@ import { cn } from "@/lib/utils";
 type CancelSubscriptionDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onCancellationScheduled?: (result: CancellationResult) => void;
+  onCancellationCompleted?: (result: CancellationResult) => void;
 };
 
 type CancellationResult = {
+  cancelAtPeriodEnd: boolean;
   currentPeriodEnd?: number;
   alreadyScheduled?: boolean;
 };
@@ -100,7 +101,7 @@ function getPlanDisplayName(tier: SubscriptionTier) {
 export const CancelSubscriptionDialog = ({
   open,
   onOpenChange,
-  onCancellationScheduled,
+  onCancellationCompleted,
 }: CancelSubscriptionDialogProps) => {
   const { subscription } = useGlobalState();
   const [isProcessing, setIsProcessing] = useState(false);
@@ -190,17 +191,21 @@ export const CancelSubscriptionDialog = ({
         return;
       }
       setCancellationResult({
+        cancelAtPeriodEnd: result.cancelAtPeriodEnd,
         currentPeriodEnd: result.currentPeriodEnd,
         alreadyScheduled: result.alreadyScheduled,
       });
-      onCancellationScheduled?.({
+      onCancellationCompleted?.({
+        cancelAtPeriodEnd: result.cancelAtPeriodEnd,
         currentPeriodEnd: result.currentPeriodEnd,
         alreadyScheduled: result.alreadyScheduled,
       });
       toast.success(
         result.alreadyScheduled
           ? "Subscription already scheduled to cancel"
-          : "Subscription scheduled to cancel",
+          : result.cancelAtPeriodEnd
+            ? "Subscription scheduled to cancel"
+            : "Subscription canceled. Payment retries stopped.",
       );
     } catch (error) {
       if (!openRef.current || requestIdRef.current !== requestId) {
@@ -216,7 +221,7 @@ export const CancelSubscriptionDialog = ({
         setIsProcessing(false);
       }
     }
-  }, [onCancellationScheduled, reasonCategory, reasonDetails]);
+  }, [onCancellationCompleted, reasonCategory, reasonDetails]);
 
   const handleReasonCategoryChange = useCallback(
     (value: string) => {
@@ -258,6 +263,7 @@ export const CancelSubscriptionDialog = ({
         year: "numeric",
       }).format(new Date(cancellationResult.currentPeriodEnd))
     : null;
+  const canceledImmediately = cancellationResult?.cancelAtPeriodEnd === false;
   const isConfirmStep = step === "confirm";
   const StepIcon = cancellationResult
     ? CheckCircle2
@@ -265,7 +271,9 @@ export const CancelSubscriptionDialog = ({
       ? LockKeyhole
       : Heart;
   const stepLabel = cancellationResult
-    ? "Cancellation scheduled"
+    ? canceledImmediately
+      ? "Subscription canceled"
+      : "Cancellation scheduled"
     : isConfirmStep
       ? "Final confirmation"
       : "Your feedback";
@@ -305,12 +313,16 @@ export const CancelSubscriptionDialog = ({
             <div className="min-h-0 flex-1 overflow-y-auto px-6 py-7 sm:px-8">
               <DialogHeader className="gap-3 text-left sm:text-left">
                 <DialogTitle className="text-3xl leading-tight font-semibold sm:text-4xl">
-                  Cancellation scheduled
+                  {canceledImmediately
+                    ? "Subscription canceled"
+                    : "Cancellation scheduled"}
                 </DialogTitle>
                 <DialogDescription className="text-base leading-7">
-                  {periodEndDate
-                    ? `You'll keep your ${planName} plan until ${periodEndDate}.`
-                    : `You'll keep your ${planName} plan until the end of your current billing period.`}
+                  {canceledImmediately
+                    ? `Your ${planName} subscription is canceled. We won't retry the failed renewal payment.`
+                    : periodEndDate
+                      ? `You'll keep your ${planName} plan until ${periodEndDate}.`
+                      : `You'll keep your ${planName} plan until the end of your current billing period.`}
                 </DialogDescription>
               </DialogHeader>
             </div>
@@ -331,7 +343,7 @@ export const CancelSubscriptionDialog = ({
                   Are you sure you want to cancel?
                 </DialogTitle>
                 <DialogDescription className="text-base leading-7">
-                  {`You'll keep your ${planName} plan until the end of your current billing period, then lose access to these benefits.`}
+                  {`You'll keep your ${planName} plan through any period you've already paid for. If a renewal payment is overdue, cancellation takes effect immediately and stops further retries.`}
                 </DialogDescription>
               </DialogHeader>
 

--- a/app/components/__tests__/AccountTab.test.tsx
+++ b/app/components/__tests__/AccountTab.test.tsx
@@ -9,8 +9,12 @@ const mockRedirectToBillingPortal = jest.fn();
 const mockSetMigrateFromPentestgptDialogOpen = jest.fn();
 const mockToastSuccess = jest.fn();
 const mockToastError = jest.fn();
-let mockOnCancellationScheduled:
-  ((result: { currentPeriodEnd?: number }) => void) | undefined;
+let mockOnCancellationCompleted:
+  | ((result: {
+      cancelAtPeriodEnd: boolean;
+      currentPeriodEnd?: number;
+    }) => void)
+  | undefined;
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({
@@ -48,9 +52,12 @@ jest.mock("../DeleteAccountDialog", () => ({
 jest.mock("../CancelSubscriptionDialog", () => ({
   __esModule: true,
   default: (props: {
-    onCancellationScheduled?: (result: { currentPeriodEnd?: number }) => void;
+    onCancellationCompleted?: (result: {
+      cancelAtPeriodEnd: boolean;
+      currentPeriodEnd?: number;
+    }) => void;
   }) => {
-    mockOnCancellationScheduled = props.onCancellationScheduled;
+    mockOnCancellationCompleted = props.onCancellationCompleted;
     return null;
   },
 }));
@@ -61,7 +68,7 @@ const AccountTab = require("../AccountTab")
 describe("AccountTab", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockOnCancellationScheduled = undefined;
+    mockOnCancellationCompleted = undefined;
     window.history.replaceState(null, "", "/");
   });
 
@@ -159,7 +166,10 @@ describe("AccountTab", () => {
     });
 
     act(() => {
-      mockOnCancellationScheduled?.({ currentPeriodEnd });
+      mockOnCancellationCompleted?.({
+        cancelAtPeriodEnd: true,
+        currentPeriodEnd,
+      });
     });
 
     expect(await screen.findByText("Cancellation scheduled.")).toBeVisible();
@@ -172,6 +182,30 @@ describe("AccountTab", () => {
 
     expect(screen.getByText("Cancellation scheduled")).toBeVisible();
     expect(screen.getByText("Keep plan")).toBeVisible();
+    expect(screen.queryByText("Cancel subscription")).not.toBeInTheDocument();
+  });
+
+  it("shows no active subscription after an overdue subscription is canceled", async () => {
+    mockGetSubscriptionCancellationStatus.mockResolvedValue({
+      hasActiveSubscription: true,
+      cancelAtPeriodEnd: false,
+    } as never);
+
+    render(<AccountTab />);
+
+    await waitFor(() => {
+      expect(mockGetSubscriptionCancellationStatus).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      mockOnCancellationCompleted?.({ cancelAtPeriodEnd: false });
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getAllByRole("button", { name: /manage/i })[0]);
+
+    expect(screen.getByText("No active subscription")).toBeVisible();
+    expect(screen.queryByText("Keep plan")).not.toBeInTheDocument();
     expect(screen.queryByText("Cancel subscription")).not.toBeInTheDocument();
   });
 

--- a/app/components/__tests__/CancelSubscriptionDialog.test.tsx
+++ b/app/components/__tests__/CancelSubscriptionDialog.test.tsx
@@ -1,6 +1,10 @@
 import "@testing-library/jest-dom";
 import { describe, expect, it, jest } from "@jest/globals";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockCancelSubscription = jest.fn();
+const mockToastSuccess = jest.fn();
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({
@@ -9,7 +13,7 @@ jest.mock("@/app/contexts/GlobalState", () => ({
 }));
 
 jest.mock("@/lib/billing/client", () => ({
-  cancelSubscription: jest.fn(),
+  cancelSubscription: mockCancelSubscription,
 }));
 
 jest.mock("@/lib/analytics/client", () => ({
@@ -19,7 +23,7 @@ jest.mock("@/lib/analytics/client", () => ({
 jest.mock("sonner", () => ({
   toast: {
     error: jest.fn(),
-    success: jest.fn(),
+    success: mockToastSuccess,
   },
 }));
 
@@ -33,5 +37,48 @@ describe("CancelSubscriptionDialog", () => {
     expect(
       screen.getByRole("radio", { name: /hit usage limits too often/i }),
     ).toBeInTheDocument();
+  });
+
+  it("confirms that retries stopped when a past-due subscription is canceled immediately", async () => {
+    const onCancellationCompleted = jest.fn();
+    mockCancelSubscription.mockResolvedValue({
+      canceled: true,
+      cancelAtPeriodEnd: false,
+      alreadyScheduled: false,
+    } as never);
+    const user = userEvent.setup();
+
+    render(
+      <CancelSubscriptionDialog
+        open={true}
+        onOpenChange={jest.fn()}
+        onCancellationCompleted={onCancellationCompleted}
+      />,
+    );
+
+    await user.click(screen.getByRole("radio", { name: /other/i }));
+    await user.type(
+      screen.getByLabelText("Tell us what happened"),
+      "The renewal failed",
+    );
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Confirm & Cancel" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Subscription canceled" }),
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        "Your Pro subscription is canceled. We won't retry the failed renewal payment.",
+      ),
+    ).toBeVisible();
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      "Subscription canceled. Payment retries stopped.",
+    );
+    expect(onCancellationCompleted).toHaveBeenCalledWith({
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: undefined,
+      alreadyScheduled: false,
+    });
   });
 });

--- a/lib/actions/__tests__/cancel-subscription.test.ts
+++ b/lib/actions/__tests__/cancel-subscription.test.ts
@@ -6,7 +6,10 @@ import {
   beforeEach,
   afterEach,
 } from "@jest/globals";
-import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
+import {
+  PAID_FUNNEL_EVENTS,
+  cancellationCompletionInsertId,
+} from "@/lib/analytics/paid-funnel";
 
 const mockListSubscriptions = jest.fn();
 const mockUpdateSubscription = jest.fn();
@@ -179,7 +182,9 @@ describe("cancelSubscriptionAction", () => {
     expect(mockPostHogEvent).toHaveBeenNthCalledWith(
       2,
       PAID_FUNNEL_EVENTS.cancellationCompleted,
-      expect.any(Object),
+      expect.objectContaining({
+        $insert_id: cancellationCompletionInsertId("sub_123"),
+      }),
     );
   });
 
@@ -340,7 +345,9 @@ describe("cancelSubscriptionAction", () => {
     expect(mockPostHogEvent).toHaveBeenNthCalledWith(
       2,
       PAID_FUNNEL_EVENTS.cancellationCompleted,
-      expect.any(Object),
+      expect.objectContaining({
+        $insert_id: cancellationCompletionInsertId("sub_123"),
+      }),
     );
   });
 

--- a/lib/actions/__tests__/cancel-subscription.test.ts
+++ b/lib/actions/__tests__/cancel-subscription.test.ts
@@ -10,6 +10,7 @@ import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
 
 const mockListSubscriptions = jest.fn();
 const mockUpdateSubscription = jest.fn();
+const mockCancelSubscription = jest.fn();
 const mockGetBillingActionContext = jest.fn();
 const mockPostHogEvent = jest.fn();
 const mockPostHogError = jest.fn();
@@ -19,6 +20,7 @@ jest.mock("@/app/api/stripe", () => ({
     subscriptions: {
       list: mockListSubscriptions,
       update: mockUpdateSubscription,
+      cancel: mockCancelSubscription,
     },
   },
 }));
@@ -173,6 +175,69 @@ describe("cancelSubscriptionAction", () => {
       2,
       PAID_FUNNEL_EVENTS.cancellationCompleted,
       expect.any(Object),
+    );
+  });
+
+  it("cancels a past-due subscription immediately to stop payment retries", async () => {
+    mockListSubscriptions.mockResolvedValue({
+      data: [
+        {
+          id: "sub_past_due",
+          status: "past_due",
+          cancel_at_period_end: true,
+          current_period_end: 1_782_444_800,
+          items: {
+            data: [
+              {
+                price: {
+                  id: "price_pro",
+                  lookup_key: "pro-monthly-plan",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } as never);
+    mockCancelSubscription.mockResolvedValue({
+      id: "sub_past_due",
+      status: "canceled",
+      cancel_at_period_end: false,
+      canceled_at: 1_752_537_600,
+      cancellation_details: {},
+    } as never);
+
+    const { default: cancelSubscriptionAction } =
+      await import("../cancel-subscription");
+
+    await expect(
+      cancelSubscriptionAction({
+        cancellationReason: {
+          reasonCategory: "too_expensive",
+          reasonDetails: "The renewal payment failed",
+        },
+      }),
+    ).resolves.toEqual({
+      canceled: true,
+      cancelAtPeriodEnd: false,
+      alreadyScheduled: false,
+    });
+
+    expect(mockCancelSubscription).toHaveBeenCalledWith("sub_past_due", {
+      cancellation_details: {
+        feedback: "too_expensive",
+      },
+      invoice_now: false,
+      prorate: false,
+    });
+    expect(mockUpdateSubscription).not.toHaveBeenCalled();
+    expect(mockPostHogEvent).toHaveBeenNthCalledWith(
+      2,
+      PAID_FUNNEL_EVENTS.cancellationCompleted,
+      expect.objectContaining({
+        cancellation_completion_type: "immediate_in_app",
+        cancel_at_period_end: false,
+      }),
     );
   });
 

--- a/lib/actions/__tests__/cancel-subscription.test.ts
+++ b/lib/actions/__tests__/cancel-subscription.test.ts
@@ -14,6 +14,8 @@ const mockCancelSubscription = jest.fn();
 const mockGetBillingActionContext = jest.fn();
 const mockPostHogEvent = jest.fn();
 const mockPostHogError = jest.fn();
+const mockConvexMutation = jest.fn();
+const mockGetConvexClient = jest.fn();
 
 jest.mock("@/app/api/stripe", () => ({
   stripe: {
@@ -30,7 +32,7 @@ jest.mock("@/lib/actions/billing-context", () => ({
 }));
 
 jest.mock("@/lib/db/convex-client", () => ({
-  getConvexClient: jest.fn(),
+  getConvexClient: mockGetConvexClient,
 }));
 
 jest.mock("@/lib/posthog/server", () => ({
@@ -47,6 +49,9 @@ describe("cancelSubscriptionAction", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.CONVEX_SERVICE_ROLE_KEY;
+    mockGetConvexClient.mockReturnValue({
+      mutation: mockConvexMutation,
+    } as never);
 
     mockGetBillingActionContext.mockResolvedValue({
       organizationId: "org_123",
@@ -238,6 +243,104 @@ describe("cancelSubscriptionAction", () => {
         cancellation_completion_type: "immediate_in_app",
         cancel_at_period_end: false,
       }),
+    );
+  });
+
+  it("does not emit a duplicate completion event when the webhook completes first", async () => {
+    process.env.CONVEX_SERVICE_ROLE_KEY = "service_key";
+    mockListSubscriptions.mockResolvedValue({
+      data: [
+        {
+          id: "sub_123",
+          status: "active",
+          cancel_at_period_end: false,
+          current_period_end: 1_782_444_800,
+          items: {
+            data: [
+              {
+                price: {
+                  id: "price_pro",
+                  lookup_key: "pro-monthly-plan",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } as never);
+    mockUpdateSubscription.mockResolvedValue({
+      id: "sub_123",
+      cancel_at_period_end: true,
+      current_period_end: 1_782_444_800,
+      cancellation_details: {},
+    } as never);
+    mockConvexMutation
+      .mockResolvedValueOnce("reason_123" as never)
+      .mockResolvedValueOnce({ matchedCount: 1, updatedCount: 0 } as never);
+
+    const { default: cancelSubscriptionAction } =
+      await import("../cancel-subscription");
+
+    await cancelSubscriptionAction({
+      cancellationReason: {
+        reasonCategory: "other",
+        reasonDetails: "Done for now",
+      },
+    });
+
+    expect(mockPostHogEvent).toHaveBeenCalledTimes(1);
+    expect(mockPostHogEvent).toHaveBeenCalledWith(
+      PAID_FUNNEL_EVENTS.cancellationReasonSubmitted,
+      expect.any(Object),
+    );
+  });
+
+  it("keeps fallback completion analytics when the completion mutation fails", async () => {
+    process.env.CONVEX_SERVICE_ROLE_KEY = "service_key";
+    mockListSubscriptions.mockResolvedValue({
+      data: [
+        {
+          id: "sub_123",
+          status: "active",
+          cancel_at_period_end: false,
+          current_period_end: 1_782_444_800,
+          items: {
+            data: [
+              {
+                price: {
+                  id: "price_pro",
+                  lookup_key: "pro-monthly-plan",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } as never);
+    mockUpdateSubscription.mockResolvedValue({
+      id: "sub_123",
+      cancel_at_period_end: true,
+      current_period_end: 1_782_444_800,
+      cancellation_details: {},
+    } as never);
+    mockConvexMutation
+      .mockResolvedValueOnce("reason_123" as never)
+      .mockRejectedValueOnce(new Error("Convex unavailable") as never);
+
+    const { default: cancelSubscriptionAction } =
+      await import("../cancel-subscription");
+
+    await cancelSubscriptionAction({
+      cancellationReason: {
+        reasonCategory: "other",
+        reasonDetails: "Done for now",
+      },
+    });
+
+    expect(mockPostHogEvent).toHaveBeenNthCalledWith(
+      2,
+      PAID_FUNNEL_EVENTS.cancellationCompleted,
+      expect.any(Object),
     );
   });
 

--- a/lib/actions/cancel-subscription.ts
+++ b/lib/actions/cancel-subscription.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import type Stripe from "stripe";
 import { stripe } from "../../app/api/stripe";
 import { api } from "@/convex/_generated/api";
 import {
@@ -37,6 +38,7 @@ type ParsedCancellationReasonInput = {
 
 type SubscriptionContext = {
   id: string;
+  status: Stripe.Subscription.Status;
   priceId?: string;
   plan?: string;
   tier?: SubscriptionTier;
@@ -115,12 +117,17 @@ async function getActiveSubscriptionContext(
   const price = currentSubscription.items.data[0]?.price;
   return {
     id: currentSubscription.id,
+    status: currentSubscription.status,
     priceId: price?.id,
     plan: price?.lookup_key ?? undefined,
     tier: subscriptionTierFromLookupKey(price?.lookup_key),
     currentPeriodEnd: currentPeriodEndMs(currentSubscription),
     cancelAtPeriodEnd: currentSubscription.cancel_at_period_end === true,
   };
+}
+
+function shouldCancelImmediately(status: Stripe.Subscription.Status) {
+  return status === "past_due" || status === "unpaid";
 }
 
 function stripeCancellationFeedback(
@@ -178,7 +185,9 @@ export default async function cancelSubscriptionAction(
     throw error;
   }
 
-  if (subscriptionContext.cancelAtPeriodEnd) {
+  const cancelImmediately = shouldCancelImmediately(subscriptionContext.status);
+
+  if (subscriptionContext.cancelAtPeriodEnd && !cancelImmediately) {
     return {
       canceled: true,
       cancelAtPeriodEnd: true,
@@ -234,26 +243,29 @@ export default async function cancelSubscriptionAction(
     });
   }
 
-  let updatedSubscription: Awaited<
-    ReturnType<typeof stripe.subscriptions.update>
-  >;
+  let updatedSubscription: Stripe.Subscription;
   try {
-    updatedSubscription = await stripe.subscriptions.update(
-      subscriptionContext.id,
-      {
-        cancel_at_period_end: true,
-        cancellation_details: {
-          feedback: stripeCancellationFeedback(
-            cancellationReason.reasonCategory,
-          ),
-        },
-      },
-    );
+    const cancellationDetails = {
+      feedback: stripeCancellationFeedback(cancellationReason.reasonCategory),
+    } as const;
+
+    updatedSubscription = cancelImmediately
+      ? await stripe.subscriptions.cancel(subscriptionContext.id, {
+          cancellation_details: cancellationDetails,
+          invoice_now: false,
+          prorate: false,
+        })
+      : await stripe.subscriptions.update(subscriptionContext.id, {
+          cancel_at_period_end: true,
+          cancellation_details: cancellationDetails,
+        });
   } catch (error) {
     phLogger.error("billing_subscription_cancellation_action_failed", {
       event: "billing_subscription_cancellation_action_failed",
       ...billingFields,
-      stage: "stripe_subscription_update",
+      stage: cancelImmediately
+        ? "stripe_subscription_cancel"
+        : "stripe_subscription_update",
       stripe_subscription_id: subscriptionContext.id,
       duration_ms: Date.now() - startedAt,
       error,
@@ -314,7 +326,9 @@ export default async function cancelSubscriptionAction(
       subscription_tier: subscriptionContext.tier,
       plan: subscriptionContext.plan,
       reason_category: cancellationReason.reasonCategory,
-      cancellation_completion_type: "scheduled_in_app",
+      cancellation_completion_type: cancelImmediately
+        ? "immediate_in_app"
+        : "scheduled_in_app",
       cancel_at_period_end: updatedSubscription.cancel_at_period_end,
       stripe_customer_id: stripeCustomerId,
       stripe_subscription_id: subscriptionContext.id,
@@ -326,9 +340,13 @@ export default async function cancelSubscriptionAction(
   return {
     canceled: true,
     cancelAtPeriodEnd: updatedSubscription.cancel_at_period_end,
-    currentPeriodEnd:
-      currentPeriodEndMs(updatedSubscription) ??
-      subscriptionContext.currentPeriodEnd,
+    ...(updatedSubscription.cancel_at_period_end
+      ? {
+          currentPeriodEnd:
+            currentPeriodEndMs(updatedSubscription) ??
+            subscriptionContext.currentPeriodEnd,
+        }
+      : {}),
     alreadyScheduled: false,
   };
 }

--- a/lib/actions/cancel-subscription.ts
+++ b/lib/actions/cancel-subscription.ts
@@ -202,6 +202,8 @@ export default async function cancelSubscriptionAction(
     ? Math.max(0, Math.floor((now - accountCreatedAt) / 86_400_000))
     : undefined;
   const serviceKey = process.env.CONVEX_SERVICE_ROLE_KEY;
+  let cancellationStartRecorded = false;
+  let shouldEmitCancellationCompleted = true;
 
   if (serviceKey) {
     try {
@@ -224,6 +226,7 @@ export default async function cancelSubscriptionAction(
           source: "in_app",
         },
       );
+      cancellationStartRecorded = true;
     } catch (error) {
       phLogger.error("Failed to record cancellation reason", {
         userId: user.id,
@@ -279,7 +282,7 @@ export default async function cancelSubscriptionAction(
 
   if (serviceKey) {
     try {
-      await getConvexClient().mutation(
+      const result = await getConvexClient().mutation(
         api.cancellationReasons.markCancellationCompleted,
         {
           serviceKey,
@@ -294,6 +297,8 @@ export default async function cancelSubscriptionAction(
           completedAt,
         },
       );
+      shouldEmitCancellationCompleted =
+        !cancellationStartRecorded || result.updatedCount > 0;
     } catch (error) {
       phLogger.warn("cancellation_reason_completion_update_failed", {
         userId: user.id,
@@ -318,24 +323,26 @@ export default async function cancelSubscriptionAction(
       stripe_subscription_id: subscriptionContext.id,
     }),
   );
-  phLogger.event(
-    PAID_FUNNEL_EVENTS.cancellationCompleted,
-    paidFunnelProperties({
-      userId: user.id,
-      org_id: organizationId,
-      subscription_tier: subscriptionContext.tier,
-      plan: subscriptionContext.plan,
-      reason_category: cancellationReason.reasonCategory,
-      cancellation_completion_type: cancelImmediately
-        ? "immediate_in_app"
-        : "scheduled_in_app",
-      cancel_at_period_end: updatedSubscription.cancel_at_period_end,
-      stripe_customer_id: stripeCustomerId,
-      stripe_subscription_id: subscriptionContext.id,
-      stripe_price_id: subscriptionContext.priceId,
-      $insert_id: `${PAID_FUNNEL_EVENTS.cancellationCompleted}:${subscriptionContext.id}:in_app`,
-    }),
-  );
+  if (shouldEmitCancellationCompleted) {
+    phLogger.event(
+      PAID_FUNNEL_EVENTS.cancellationCompleted,
+      paidFunnelProperties({
+        userId: user.id,
+        org_id: organizationId,
+        subscription_tier: subscriptionContext.tier,
+        plan: subscriptionContext.plan,
+        reason_category: cancellationReason.reasonCategory,
+        cancellation_completion_type: cancelImmediately
+          ? "immediate_in_app"
+          : "scheduled_in_app",
+        cancel_at_period_end: updatedSubscription.cancel_at_period_end,
+        stripe_customer_id: stripeCustomerId,
+        stripe_subscription_id: subscriptionContext.id,
+        stripe_price_id: subscriptionContext.priceId,
+        $insert_id: `${PAID_FUNNEL_EVENTS.cancellationCompleted}:${subscriptionContext.id}:in_app`,
+      }),
+    );
+  }
 
   return {
     canceled: true,

--- a/lib/actions/cancel-subscription.ts
+++ b/lib/actions/cancel-subscription.ts
@@ -17,6 +17,7 @@ import { getConvexClient } from "@/lib/db/convex-client";
 import { phLogger } from "@/lib/posthog/server";
 import {
   PAID_FUNNEL_EVENTS,
+  cancellationCompletionInsertId,
   paidFunnelProperties,
   planLookupKeyToTier,
 } from "@/lib/analytics/paid-funnel";
@@ -339,7 +340,7 @@ export default async function cancelSubscriptionAction(
         stripe_customer_id: stripeCustomerId,
         stripe_subscription_id: subscriptionContext.id,
         stripe_price_id: subscriptionContext.priceId,
-        $insert_id: `${PAID_FUNNEL_EVENTS.cancellationCompleted}:${subscriptionContext.id}:in_app`,
+        $insert_id: cancellationCompletionInsertId(subscriptionContext.id),
       }),
     );
   }

--- a/lib/analytics/paid-funnel.ts
+++ b/lib/analytics/paid-funnel.ts
@@ -24,6 +24,12 @@ export const PAID_FUNNEL_EVENTS = {
   paidDailyFreeAllowanceCutOff: "paid_daily_free_allowance_cut_off",
 } as const;
 
+export function cancellationCompletionInsertId(
+  stripeSubscriptionId: string,
+): string {
+  return `${PAID_FUNNEL_EVENTS.cancellationCompleted}:${stripeSubscriptionId}`;
+}
+
 export type PaidFunnelPlan =
   | "pro-monthly-plan"
   | "pro-plus-monthly-plan"


### PR DESCRIPTION
## Summary

- immediately cancel Stripe subscriptions that are already `past_due` or `unpaid` when the customer cancels
- preserve end-of-period cancellation for healthy active and trialing subscriptions
- report the immediate-cancellation outcome in the account UI and cancellation analytics
- deduplicate completion analytics across the in-app action and Stripe webhook
- add regression coverage for the server action, webhook, and both affected cancellation components

## Root cause

The in-app cancellation path always set `cancel_at_period_end=true`. When a renewal invoice had already failed, that only scheduled the subscription to end later and left Stripe's open invoice eligible for automatic retry attempts.

## User impact

Customers who cancel after a failed renewal will now have the delinquent subscription canceled immediately with `invoice_now=false` and `prorate=false`. Stripe then stops automatic collection for the outstanding invoice. Customers in good standing retain access through the period they already paid for.

## Validation

- full pre-commit suite: 259 test suites, 2,583 tests
- focused action and webhook suite: 2 suites, 22 tests
- broader cancellation-focused suite: 5 suites, 27 tests
- `pnpm typecheck`
- `pnpm lint` (no errors; six existing unrelated warnings)
- targeted ESLint and Prettier checks

## Manual verification

1. In Stripe test mode, create a paid subscription and advance it to a failed renewal so the subscription becomes `past_due`.
2. Cancel it from Account settings.
3. Confirm Stripe shows the subscription as canceled immediately, the failed invoice has automatic collection disabled, and the UI says payment retries stopped.
4. Repeat with a healthy active subscription and confirm it remains active with `cancel_at_period_end=true` until its paid period ends.

Stripe reference: https://docs.stripe.com/api/subscriptions/cancel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer in-app messaging and confirmations for immediate vs scheduled subscription cancellation outcomes.
  * Updated cancellation flow to report completion details (including whether cancellation is set to take effect immediately or at period end).

* **Bug Fixes**
  * Prevented past-due/unpaid subscriptions from being incorrectly treated as scheduled cancellations.
  * Improved analytics consistency for cancellation-completed events and ensured account UI reflects the correct active-subscription state.

* **Tests**
  * Updated and expanded UI, action, and webhook tests to cover immediate cancellation, scheduled cancellation, and analytics behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->