### PR TITLE
Add Trigger agent cost observability

### DIFF
--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -31,6 +31,7 @@ import type {
   SandboxBootInfo,
   ToolFailureLogger,
   AgentToolApprovalRequester,
+  AgentActiveTimeMeasurer,
 } from "@/types";
 import { isAgentMode } from "@/lib/utils/mode-helpers";
 import type { Geo } from "@vercel/functions";
@@ -62,6 +63,7 @@ export const createTools = (
   modelName?: string,
   onToolFailure?: ToolFailureLogger,
   requestToolApproval?: AgentToolApprovalRequester,
+  measureAgentActiveTime?: AgentActiveTimeMeasurer,
 ) => {
   let sandbox: AnySandbox | null = null;
   let sandboxFirstUsedAt: number | null = null;
@@ -129,6 +131,7 @@ export const createTools = (
     onToolCost,
     onToolFailure,
     requestToolApproval,
+    measureAgentActiveTime,
   };
 
   const buildTools = (): ToolSet => {

--- a/lib/ai/tools/interact-terminal-session.ts
+++ b/lib/ai/tools/interact-terminal-session.ts
@@ -34,6 +34,10 @@ const WAIT_QUIET_WINDOW_MS = 500;
 
 export const createInteractTerminalSession = (context: ToolContext) => {
   const { writer, chatId, ptySessionManager } = context;
+  const measureTerminalWait = <T>(operation: () => Promise<T>): Promise<T> =>
+    context.measureAgentActiveTime
+      ? context.measureAgentActiveTime("terminal_wait", operation)
+      : operation();
 
   return tool({
     ...interactTerminalSessionTool,
@@ -221,12 +225,14 @@ export const createInteractTerminalSession = (context: ToolContext) => {
         // Capture the immediate response chunk — prompts that echo a reply
         // ("Hello, X!") show up here. Use action=wait for processes that
         // take longer to respond.
-        const delta = await waitForOutput(
-          session,
-          SEND_IMMEDIATE_OUTPUT_WINDOW_MS,
-          abortSignal,
-          emitTerminal,
-          (s) => ptySessionManager.consumeDelta(s),
+        const delta = await measureTerminalWait(() =>
+          waitForOutput(
+            session,
+            SEND_IMMEDIATE_OUTPUT_WINDOW_MS,
+            abortSignal,
+            emitTerminal,
+            (s) => ptySessionManager.consumeDelta(s),
+          ),
         );
         await drainEmitQueue();
         const snapshots = await getSessionSnapshots(ptySessionManager, session);
@@ -249,13 +255,15 @@ export const createInteractTerminalSession = (context: ToolContext) => {
         emitPriorContext(session);
 
         const alreadyExited = await peekExited(session);
-        const delta = await waitForOutput(
-          session,
-          timeoutMs,
-          abortSignal,
-          emitTerminal,
-          (s) => ptySessionManager.consumeDelta(s),
-          { quietMs: WAIT_QUIET_WINDOW_MS },
+        const delta = await measureTerminalWait(() =>
+          waitForOutput(
+            session,
+            timeoutMs,
+            abortSignal,
+            emitTerminal,
+            (s) => ptySessionManager.consumeDelta(s),
+            { quietMs: WAIT_QUIET_WINDOW_MS },
+          ),
         );
         await drainEmitQueue();
         const snapshots = await getSessionSnapshots(ptySessionManager, session);

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -91,6 +91,16 @@ export const createRunTerminalCmd = (context: ToolContext) => {
     ptySessionManager,
     chatId,
   } = context;
+  const measureTerminalWait = <T>(operation: () => Promise<T>): Promise<T> =>
+    context.measureAgentActiveTime
+      ? context.measureAgentActiveTime("terminal_wait", operation)
+      : operation();
+  const measureSandboxRecovery = <T>(
+    operation: () => Promise<T>,
+  ): Promise<T> =>
+    context.measureAgentActiveTime
+      ? context.measureAgentActiveTime("sandbox_recovery", operation)
+      : operation();
   const runTerminalCmdTool = createRunTerminalCmdToolSchema({
     approvalGated: !!context.requestToolApproval,
     // The conditional schema adds approval-only fields, but both branches
@@ -268,13 +278,15 @@ export const createRunTerminalCmd = (context: ToolContext) => {
           // Stream output chunks as they arrive. Resolve early on a brief
           // quiet window so launching a REPL/shell returns when its prompt
           // finishes drawing rather than blocking the full timeout ceiling.
-          const delta = await waitForOutput(
-            session,
-            effectiveStreamTimeout * 1000,
-            abortSignal,
-            emitTerminal,
-            (s) => ptySessionManager.consumeDelta(s),
-            { quietMs: INTERACTIVE_QUIET_WINDOW_MS },
+          const delta = await measureTerminalWait(() =>
+            waitForOutput(
+              session,
+              effectiveStreamTimeout * 1000,
+              abortSignal,
+              emitTerminal,
+              (s) => ptySessionManager.consumeDelta(s),
+              { quietMs: INTERACTIVE_QUIET_WINDOW_MS },
+            ),
           );
           await drainEmitQueue();
           const snapshots = await getSessionSnapshots(
@@ -355,46 +367,51 @@ export const createRunTerminalCmd = (context: ToolContext) => {
               };
             }
 
-            // Sandbox health check failed - log diagnostics and wait briefly before recreating
-            const diagnostics = await getSandboxDiagnostics(sandbox).catch(
-              () => "diagnostics unavailable",
-            );
-            console.warn(
-              `[Terminal Command] Sandbox health check failed (${diagnostics}), waiting before recreating sandbox`,
-            );
-            await new Promise((resolve) => setTimeout(resolve, 2000));
+            const recovery = await measureSandboxRecovery(async () => {
+              // Sandbox health check failed - log diagnostics and wait briefly before recreating
+              const diagnostics = await getSandboxDiagnostics(sandbox).catch(
+                () => "diagnostics unavailable",
+              );
+              console.warn(
+                `[Terminal Command] Sandbox health check failed (${diagnostics}), waiting before recreating sandbox`,
+              );
+              await new Promise((resolve) => setTimeout(resolve, 2000));
 
-            // Reset cached instance to force ensureSandboxConnection to create a fresh one
-            sandboxManager.setSandbox(null as any);
-            const { sandbox: freshSandbox } = await getSandboxWithFallbackGuard(
-              {
-                sandboxManager,
-              },
-            );
+              // Reset cached instance to force ensureSandboxConnection to create a fresh one
+              sandboxManager.setSandbox(null as any);
+              const { sandbox: freshSandbox } =
+                await getSandboxWithFallbackGuard({ sandboxManager });
 
-            // Verify the fresh sandbox is ready
-            try {
-              await waitForSandboxReady(freshSandbox, 5, abortSignal);
-              sandboxManager.resetHealthFailures();
-            } catch (freshHealthError) {
-              if (
-                freshHealthError instanceof DOMException &&
-                freshHealthError.name === "AbortError"
-              ) {
-                throw freshHealthError;
+              // Verify the fresh sandbox is ready
+              try {
+                await waitForSandboxReady(freshSandbox, 5, abortSignal);
+                sandboxManager.resetHealthFailures();
+              } catch (freshHealthError) {
+                if (
+                  freshHealthError instanceof DOMException &&
+                  freshHealthError.name === "AbortError"
+                ) {
+                  throw freshHealthError;
+                }
+                sandboxManager.recordHealthFailure();
+                return {
+                  ok: false as const,
+                  response: {
+                    result: {
+                      output: "",
+                      exitCode: 1,
+                      error:
+                        "Sandbox recreation failed. The sandbox environment is not responding. Another attempt may be made but the sandbox will be marked unavailable after repeated failures.",
+                    },
+                  },
+                };
               }
-              sandboxManager.recordHealthFailure();
-              return {
-                result: {
-                  output: "",
-                  exitCode: 1,
-                  error:
-                    "Sandbox recreation failed. The sandbox environment is not responding. Another attempt may be made but the sandbox will be marked unavailable after repeated failures.",
-                },
-              };
-            }
 
-            return executeCommand(freshSandbox);
+              return { ok: true as const, sandbox: freshSandbox };
+            });
+
+            if (!recovery.ok) return recovery.response;
+            return executeCommand(recovery.sandbox);
           }
         }
 
@@ -838,14 +855,16 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                 execution = started;
                 processId = started.pid;
                 commandHandle?.setPid(started.pid);
-                const result = await started.wait();
+                const result = await measureTerminalWait(() => started.wait());
                 return { ...result, pid: started.pid };
               }
 
-              return retryWithBackoff(
-                () =>
-                  sandboxInstance.commands.run(effectiveCommand, runOptions),
-                retryOptions,
+              return measureTerminalWait(() =>
+                retryWithBackoff(
+                  () =>
+                    sandboxInstance.commands.run(effectiveCommand, runOptions),
+                  retryOptions,
+                ),
               );
             });
 

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -635,10 +635,34 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
 
   test("runs are triggered with filterable queued metadata and tags", () => {
     expect(routeSrc).toMatch(/tags:\s*triggerTags/);
+    expect(routeSrc).toMatch(
+      /triggerTags\.push\(`permission_\$\{agentPermissionMode\}`\)/,
+    );
     expect(routeSrc).toMatch(/const triggerMetadata\s*=\s*{/);
     expect(routeSrc).toMatch(/metadata:\s*triggerMetadata/);
     expect(routeSrc).toMatch(/status:\s*"queued"/);
     expect(routeSrc).toMatch(/loginRequired:\s*false/);
+  });
+
+  test("captures Trigger usage and active-time attribution on Agent completion", () => {
+    expect(taskSrc).toMatch(/triggerUsage\.getCurrent\(\)/);
+    expect(taskSrc).toMatch(
+      /triggerUsageDurationMs:\s*currentUsage\.compute\.total\.durationMs/,
+    );
+    expect(taskSrc).toMatch(
+      /triggerTotalCostUsd:\s*currentUsage\.totalCostInCents\s*\/\s*100/,
+    );
+    expect(taskSrc).toMatch(
+      /onApprovalWait:\s*runTimingTracker\.recordApprovalWait/,
+    );
+    expect(taskSrc).toMatch(
+      /onModelStreamStart:\s*runTimingTracker\.startModelStream/,
+    );
+    expect(taskSrc).toMatch(
+      /onModelStreamFinish:\s*runTimingTracker\.finishModelStream/,
+    );
+    expect(agentStreamRunnerSrc).toMatch(/experimental_onStepStart/);
+    expect(agentStreamRunnerSrc).toMatch(/experimental_onToolCallStart/);
   });
 
   test("validates agent trigger request bodies before auth and Trigger work", () => {
@@ -859,7 +883,9 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
       /await\s+recordAgentLongHandledToolFailureForDashboard/,
     );
     expect(taskSrc).toMatch(/handled tool failure dashboard update failed/);
-    expect(taskSrc).toMatch(/onToolFailure,\s*requestToolApproval,\s*\)/);
+    expect(taskSrc).toMatch(
+      /onToolFailure,\s*requestToolApproval,\s*runTimingTracker\.measureActiveTime,\s*\)/,
+    );
   });
 
   test("direct runs use small subscription-aware Trigger.dev priority offsets", () => {

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -87,6 +87,14 @@ describe("captureAgentRun", () => {
       agentPermissionMode: "ask_approval",
       responseModel: "deepseek/deepseek-v4-pro",
       fallbackServed: false,
+      triggerRunId: "run_123",
+      triggerUsageDurationMs: 42_000,
+      triggerTotalCostUsd: 0.00714,
+      approvalWaitCount: 1,
+      approvalWaitDurationMs: 90_000,
+      activeModelStreamDurationMs: 30_000,
+      activeTerminalWaitDurationMs: 10_000,
+      activeSandboxRecoveryDurationMs: 2_000,
     });
 
     expect(capture).toHaveBeenCalledWith({
@@ -100,11 +108,55 @@ describe("captureAgentRun", () => {
         selected_model: "agent-model",
         configured_model: "deepseek/deepseek-v4-pro",
         agent_permission_mode: "ask_approval",
+        trigger_run_id: "run_123",
+        trigger_usage_duration_ms: 42_000,
+        trigger_total_cost_usd: 0.00714,
+        approval_wait_count: 1,
+        approval_wait_duration_ms: 90_000,
+        active_model_stream_duration_ms: 30_000,
+        active_terminal_wait_duration_ms: 10_000,
+        active_sandbox_recovery_duration_ms: 2_000,
         response_model: "deepseek/deepseek-v4-pro",
         fallback_served: false,
         sandbox_type: "remote-connection",
       },
     });
+  });
+
+  it("preserves zero-valued Trigger timing fields", () => {
+    const capture = jest.fn();
+
+    captureAgentRun({
+      posthog: { capture } as any,
+      userId: "user_123",
+      mode: "agent",
+      subscription: "pro",
+      sandboxInfo: null,
+      outcome: "success",
+      selectedModel: "agent-model",
+      configuredModelId: "minimax/minimax-m3",
+      triggerRunId: "run_zero",
+      triggerUsageDurationMs: 0,
+      triggerTotalCostUsd: 0,
+      approvalWaitCount: 0,
+      approvalWaitDurationMs: 0,
+      activeModelStreamDurationMs: 0,
+      activeTerminalWaitDurationMs: 0,
+      activeSandboxRecoveryDurationMs: 0,
+    });
+
+    expect(capture.mock.calls[0][0].properties).toEqual(
+      expect.objectContaining({
+        trigger_run_id: "run_zero",
+        trigger_usage_duration_ms: 0,
+        trigger_total_cost_usd: 0,
+        approval_wait_count: 0,
+        approval_wait_duration_ms: 0,
+        active_model_stream_duration_ms: 0,
+        active_terminal_wait_duration_ms: 0,
+        active_sandbox_recovery_duration_ms: 0,
+      }),
+    );
   });
 
   it("attributes a served fallback without inferring it from model names", () => {
@@ -295,6 +347,14 @@ describe("captureAgentCompletionAnalytics", () => {
       configuredModelId: "deepseek/deepseek-v4-pro",
       responseModel: "deepseek/deepseek-v4-pro",
       fallbackServed: false,
+      triggerRunId: "run_completion",
+      triggerUsageDurationMs: 12_345,
+      triggerTotalCostUsd: 0.0021,
+      approvalWaitCount: 0,
+      approvalWaitDurationMs: 0,
+      activeModelStreamDurationMs: 8_000,
+      activeTerminalWaitDurationMs: 4_000,
+      activeSandboxRecoveryDurationMs: 0,
     });
 
     expect(capture).toHaveBeenCalledTimes(1);
@@ -308,6 +368,14 @@ describe("captureAgentCompletionAnalytics", () => {
         outcome: "success",
         selected_model: "agent-model",
         configured_model: "deepseek/deepseek-v4-pro",
+        trigger_run_id: "run_completion",
+        trigger_usage_duration_ms: 12_345,
+        trigger_total_cost_usd: 0.0021,
+        approval_wait_count: 0,
+        approval_wait_duration_ms: 0,
+        active_model_stream_duration_ms: 8_000,
+        active_terminal_wait_duration_ms: 4_000,
+        active_sandbox_recovery_duration_ms: 0,
         response_model: "deepseek/deepseek-v4-pro",
         fallback_served: false,
         sandbox_type: "e2b",

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -466,6 +466,8 @@ export type AgentStreamContext = {
   chatLogger: ChatLogger | undefined;
   usageRefundTracker: UsageRefundTracker;
   onBudgetAbort?: (details: BudgetAbortDetails & { model: string }) => void;
+  onModelStreamStart?: () => void;
+  onModelStreamFinish?: () => void;
   settleUsageAfterStep?: (args: {
     currentCostDollars: number;
     force: boolean;
@@ -753,6 +755,8 @@ export async function createAgentStream(
     activeTools: initialActiveTools,
     abortSignal,
     providerOptions: initialProviderOptions,
+    experimental_onStepStart: () => ctx.onModelStreamStart?.(),
+    experimental_onToolCallStart: () => ctx.onModelStreamFinish?.(),
 
     prepareStep: async ({ steps, messages }) => {
       const rawModelMessages = messages as ModelMessage[];
@@ -1173,6 +1177,7 @@ export async function createAgentStream(
     },
 
     onStepFinish: async ({ usage, response, providerMetadata }) => {
+      ctx.onModelStreamFinish?.();
       let stepUsageCostIndex: number | undefined;
       if (usage) {
         stepUsageCostIndex = ctx.usageTracker.accumulateStep(
@@ -1223,6 +1228,7 @@ export async function createAgentStream(
     },
 
     onFinish: async (finishResult) => {
+      ctx.onModelStreamFinish?.();
       const { finishReason, usage, response } = finishResult;
       const hardReason = ctx.getHardTimeoutReason();
       if (

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -505,6 +505,7 @@ export const createAgentTriggerPost =
 
       const triggerTags = [`user_${userId}`, `chat_${chatId}`];
       if (subscription !== "free") triggerTags.push(`sub_${subscription}`);
+      triggerTags.push(`permission_${agentPermissionMode}`);
 
       // Persisted chats are rehydrated from Convex inside the task after the
       // route saves the latest user message. Avoid sending the same history

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -1166,6 +1166,14 @@ type AgentCompletionAnalyticsArgs = {
   finishReason?: string;
   budgetAbortDetails?: BudgetAbortDetails;
   agentPermissionMode?: AgentPermissionMode;
+  triggerRunId?: string;
+  triggerUsageDurationMs?: number;
+  triggerTotalCostUsd?: number;
+  approvalWaitCount?: number;
+  approvalWaitDurationMs?: number;
+  activeModelStreamDurationMs?: number;
+  activeTerminalWaitDurationMs?: number;
+  activeSandboxRecoveryDurationMs?: number;
 };
 
 export function captureAgentRun({
@@ -1182,6 +1190,14 @@ export function captureAgentRun({
   finishReason,
   budgetAbortDetails,
   agentPermissionMode,
+  triggerRunId,
+  triggerUsageDurationMs,
+  triggerTotalCostUsd,
+  approvalWaitCount,
+  approvalWaitDurationMs,
+  activeModelStreamDurationMs,
+  activeTerminalWaitDurationMs,
+  activeSandboxRecoveryDurationMs,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -1196,6 +1212,14 @@ export function captureAgentRun({
   finishReason?: string;
   budgetAbortDetails?: BudgetAbortDetails;
   agentPermissionMode?: AgentPermissionMode;
+  triggerRunId?: string;
+  triggerUsageDurationMs?: number;
+  triggerTotalCostUsd?: number;
+  approvalWaitCount?: number;
+  approvalWaitDurationMs?: number;
+  activeModelStreamDurationMs?: number;
+  activeTerminalWaitDurationMs?: number;
+  activeSandboxRecoveryDurationMs?: number;
 }) {
   if (!posthog || mode !== "agent") return;
   posthog.capture({
@@ -1210,6 +1234,28 @@ export function captureAgentRun({
       configured_model: configuredModelId,
       ...(agentPermissionMode && {
         agent_permission_mode: agentPermissionMode,
+      }),
+      ...(triggerRunId && { trigger_run_id: triggerRunId }),
+      ...(triggerUsageDurationMs !== undefined && {
+        trigger_usage_duration_ms: triggerUsageDurationMs,
+      }),
+      ...(triggerTotalCostUsd !== undefined && {
+        trigger_total_cost_usd: triggerTotalCostUsd,
+      }),
+      ...(approvalWaitCount !== undefined && {
+        approval_wait_count: approvalWaitCount,
+      }),
+      ...(approvalWaitDurationMs !== undefined && {
+        approval_wait_duration_ms: approvalWaitDurationMs,
+      }),
+      ...(activeModelStreamDurationMs !== undefined && {
+        active_model_stream_duration_ms: activeModelStreamDurationMs,
+      }),
+      ...(activeTerminalWaitDurationMs !== undefined && {
+        active_terminal_wait_duration_ms: activeTerminalWaitDurationMs,
+      }),
+      ...(activeSandboxRecoveryDurationMs !== undefined && {
+        active_sandbox_recovery_duration_ms: activeSandboxRecoveryDurationMs,
       }),
       ...(responseModel && { response_model: responseModel }),
       ...(responseModel &&
@@ -1245,6 +1291,14 @@ export function captureAgentCompletionAnalytics(
     finishReason: args.finishReason,
     budgetAbortDetails: args.budgetAbortDetails,
     agentPermissionMode: args.agentPermissionMode,
+    triggerRunId: args.triggerRunId,
+    triggerUsageDurationMs: args.triggerUsageDurationMs,
+    triggerTotalCostUsd: args.triggerTotalCostUsd,
+    approvalWaitCount: args.approvalWaitCount,
+    approvalWaitDurationMs: args.approvalWaitDurationMs,
+    activeModelStreamDurationMs: args.activeModelStreamDurationMs,
+    activeTerminalWaitDurationMs: args.activeTerminalWaitDurationMs,
+    activeSandboxRecoveryDurationMs: args.activeSandboxRecoveryDurationMs,
   });
 }
 

--- a/lib/chat/__tests__/agent-run-timing.test.ts
+++ b/lib/chat/__tests__/agent-run-timing.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { AgentRunTimingTracker } from "../agent-run-timing";
+
+describe("AgentRunTimingTracker", () => {
+  it("aggregates approval waits and active categories", async () => {
+    let now = 1_000;
+    const tracker = new AgentRunTimingTracker(() => now);
+
+    tracker.recordApprovalWait(8_000, true);
+    tracker.recordApprovalWait(2_000, false);
+    tracker.recordApprovalWait(1_000, true);
+
+    tracker.startModelStream();
+    now += 4_000;
+    tracker.finishModelStream();
+
+    await tracker.measureActiveTime("terminal_wait", async () => {
+      now += 3_000;
+    });
+    await tracker.measureActiveTime("sandbox_recovery", async () => {
+      now += 2_000;
+    });
+
+    expect(tracker.snapshot()).toEqual({
+      approvalWaitCount: 2,
+      approvalWaitDurationMs: 11_000,
+      activeModelStreamDurationMs: 4_000,
+      activeTerminalWaitDurationMs: 3_000,
+      activeSandboxRecoveryDurationMs: 2_000,
+    });
+  });
+
+  it("closes a previous model phase when a new step starts", () => {
+    let now = 0;
+    const tracker = new AgentRunTimingTracker(() => now);
+
+    tracker.startModelStream();
+    now = 500;
+    tracker.startModelStream();
+    now = 1_250;
+
+    expect(tracker.snapshot().activeModelStreamDurationMs).toBe(1_250);
+  });
+
+  it("records active duration when an operation fails", async () => {
+    let now = 0;
+    const tracker = new AgentRunTimingTracker(() => now);
+
+    await expect(
+      tracker.measureActiveTime("terminal_wait", async () => {
+        now = 750;
+        throw new Error("terminal failed");
+      }),
+    ).rejects.toThrow("terminal failed");
+
+    expect(tracker.snapshot().activeTerminalWaitDurationMs).toBe(750);
+  });
+});

--- a/lib/chat/agent-run-timing.ts
+++ b/lib/chat/agent-run-timing.ts
@@ -1,0 +1,78 @@
+import type { AgentActiveTimeCategory } from "@/types";
+
+export type AgentRunTimingSnapshot = {
+  approvalWaitCount: number;
+  approvalWaitDurationMs: number;
+  activeModelStreamDurationMs: number;
+  activeTerminalWaitDurationMs: number;
+  activeSandboxRecoveryDurationMs: number;
+};
+
+/**
+ * Aggregates low-cardinality wall-clock phases for one Agent task run.
+ * Trigger's usage duration remains the source of truth for billed runtime;
+ * these categories explain where that active runtime was spent.
+ */
+export class AgentRunTimingTracker {
+  private approvalWaitCount = 0;
+  private approvalWaitDurationMs = 0;
+  private activeModelStreamDurationMs = 0;
+  private activeTerminalWaitDurationMs = 0;
+  private activeSandboxRecoveryDurationMs = 0;
+  private modelStreamStartedAt: number | undefined;
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  recordApprovalWait = (
+    durationMs: number,
+    incrementCount: boolean = true,
+  ): void => {
+    if (incrementCount) this.approvalWaitCount += 1;
+    this.approvalWaitDurationMs += normalizeDuration(durationMs);
+  };
+
+  startModelStream = (): void => {
+    this.finishModelStream();
+    this.modelStreamStartedAt = this.now();
+  };
+
+  finishModelStream = (): void => {
+    if (this.modelStreamStartedAt === undefined) return;
+    this.activeModelStreamDurationMs += normalizeDuration(
+      this.now() - this.modelStreamStartedAt,
+    );
+    this.modelStreamStartedAt = undefined;
+  };
+
+  measureActiveTime = async <T>(
+    category: AgentActiveTimeCategory,
+    operation: () => Promise<T>,
+  ): Promise<T> => {
+    const startedAt = this.now();
+    try {
+      return await operation();
+    } finally {
+      const durationMs = normalizeDuration(this.now() - startedAt);
+      if (category === "terminal_wait") {
+        this.activeTerminalWaitDurationMs += durationMs;
+      } else {
+        this.activeSandboxRecoveryDurationMs += durationMs;
+      }
+    }
+  };
+
+  snapshot = (): AgentRunTimingSnapshot => ({
+    approvalWaitCount: this.approvalWaitCount,
+    approvalWaitDurationMs: this.approvalWaitDurationMs,
+    activeModelStreamDurationMs:
+      this.activeModelStreamDurationMs +
+      (this.modelStreamStartedAt === undefined
+        ? 0
+        : normalizeDuration(this.now() - this.modelStreamStartedAt)),
+    activeTerminalWaitDurationMs: this.activeTerminalWaitDurationMs,
+    activeSandboxRecoveryDurationMs: this.activeSandboxRecoveryDurationMs,
+  });
+}
+
+const normalizeDuration = (durationMs: number): number =>
+  Number.isFinite(durationMs) ? Math.max(0, Math.round(durationMs)) : 0;

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -3,6 +3,7 @@ import {
   tags,
   metadata,
   logger as triggerLogger,
+  usage as triggerUsage,
 } from "@trigger.dev/sdk";
 import * as triggerSdk from "@trigger.dev/sdk";
 import { agentUiStream } from "./streams";
@@ -207,6 +208,7 @@ import {
 } from "@/lib/chat/multimodal-tool-result-recovery";
 import { FREE_AGENT_LONG_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
 import { isCentrifugoSandbox } from "@/lib/ai/tools/utils/sandbox-types";
+import { AgentRunTimingTracker } from "@/lib/chat/agent-run-timing";
 
 const AGENT_LONG_FREE_MAX_DURATION_SECONDS = 60 * 60;
 const AGENT_LONG_PAID_MAX_DURATION_SECONDS = 2 * 60 * 60;
@@ -402,6 +404,7 @@ const buildAgentToolApprovalRequester = ({
   beforeSuspend,
   revalidateAfterSuspend,
   onPostWaitAuthorizationDenied,
+  onApprovalWait,
 }: {
   agentPermissionMode: AgentPermissionMode;
   approvalSessionId?: string;
@@ -422,6 +425,7 @@ const buildAgentToolApprovalRequester = ({
     input: AgentToolApprovalInputRecord,
   ) => Promise<void>;
   onPostWaitAuthorizationDenied: () => void;
+  onApprovalWait?: (durationMs: number, incrementCount: boolean) => void;
 }): AgentToolApprovalRequester | undefined => {
   if (agentPermissionMode !== "ask_approval") return undefined;
   let approvalQueue: Promise<void> = Promise.resolve();
@@ -581,13 +585,20 @@ const buildAgentToolApprovalRequester = ({
           };
         }
       }
+      let approvalWaitCounted = false;
       while (!signal.aborted) {
+        const approvalWaitStartedAt = Date.now();
         activeRuntimeBudget.pause();
         let waitOutcome: TriggerSessionInputWaitOutcome;
         try {
           waitOutcome = await waitForApprovalInput(session, signal);
         } finally {
           activeRuntimeBudget.resume();
+          onApprovalWait?.(
+            Date.now() - approvalWaitStartedAt,
+            !approvalWaitCounted,
+          );
+          approvalWaitCounted = true;
         }
         if (waitOutcome.status === "aborted") break;
 
@@ -1622,6 +1633,16 @@ export const agentLongTask = task({
     // the soft stop past the plan-specific runtime cap.
     const taskStartTime = Date.now();
     const agentLongMaxDurationMs = getAgentLongMaxDurationMs(subscription);
+    const runTimingTracker = new AgentRunTimingTracker();
+    const getTriggerRunTelemetry = () => {
+      const currentUsage = triggerUsage.getCurrent();
+      return {
+        triggerRunId: ctx.run.id,
+        triggerUsageDurationMs: currentUsage.compute.total.durationMs,
+        triggerTotalCostUsd: currentUsage.totalCostInCents / 100,
+        ...runTimingTracker.snapshot(),
+      };
+    };
 
     // Tag for dashboard filtering; add subscription tier for paid-only queries.
     await tags.add([`user_${userId}`, `chat_${chatId}`]);
@@ -2126,6 +2147,7 @@ export const agentLongTask = task({
                 subscription === "free" ? releaseFreeRunLockOnce : undefined,
               revalidateAfterSuspend: revalidateAfterApprovalSuspend,
               onPostWaitAuthorizationDenied: () => userStopSignal.abort(),
+              onApprovalWait: runTimingTracker.recordApprovalWait,
             });
             const {
               tools,
@@ -2161,6 +2183,7 @@ export const agentLongTask = task({
               selectedModel,
               onToolFailure,
               requestToolApproval,
+              runTimingTracker.measureActiveTime,
             );
             approvalSandboxManager = sandboxManager;
 
@@ -2732,6 +2755,8 @@ export const agentLongTask = task({
               ensureSandbox,
               chatLogger,
               usageRefundTracker,
+              onModelStreamStart: runTimingTracker.startModelStream,
+              onModelStreamFinish: runTimingTracker.finishModelStream,
               settleUsageAfterStep,
               onBudgetAbort: (details) =>
                 captureAgentBudgetAbort({
@@ -3067,6 +3092,7 @@ export const agentLongTask = task({
                                     budgetAbortDetails:
                                       state.budgetAbortDetails,
                                     agentPermissionMode,
+                                    ...getTriggerRunTelemetry(),
                                   });
                                   if (!isTerminalProviderStreamError(state)) {
                                     chatLogger?.emitSuccess({
@@ -3205,6 +3231,7 @@ export const agentLongTask = task({
                         finishReason: state.streamFinishReason,
                         budgetAbortDetails: state.budgetAbortDetails,
                         agentPermissionMode,
+                        ...getTriggerRunTelemetry(),
                       });
                       if (!isTerminalProviderStreamError(state)) {
                         chatLogger?.emitSuccess({

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -289,6 +289,13 @@ export type AgentToolApprovalRequester = (
   request: AgentToolApprovalRequest,
 ) => Promise<AgentToolApprovalResult>;
 
+export type AgentActiveTimeCategory = "terminal_wait" | "sandbox_recovery";
+
+export type AgentActiveTimeMeasurer = <T>(
+  category: AgentActiveTimeCategory,
+  operation: () => Promise<T>,
+) => Promise<T>;
+
 export const AGENT_TOOL_APPROVAL_PROTOCOL_VERSION = 2 as const;
 
 export type AgentToolApprovalAuthorization = {
@@ -351,4 +358,6 @@ export interface ToolContext {
   onToolFailure?: ToolFailureLogger;
   /** Optional approval gate for mutating or command-executing agent tools. */
   requestToolApproval?: AgentToolApprovalRequester;
+  /** Aggregates active wall time for cost attribution in Trigger-hosted Agent runs. */
+  measureAgentActiveTime?: AgentActiveTimeMeasurer;
 }


### PR DESCRIPTION
## Summary

- tag every initial `agent-long` Trigger run with `permission_full_access` or `permission_ask_approval`
- add Trigger run ID, billed usage duration, and total Trigger cost to `hackerai-agent_run`
- aggregate approval wait count/wall time plus active model-stream, terminal-wait, and sandbox-recovery durations
- preserve zero-valued telemetry and cover the wiring with regression tests

## Validation

- `jest --runInBand --no-cache lib/api/__tests__/chat-logger.test.ts lib/chat/__tests__/agent-run-timing.test.ts lib/api/__tests__/agent-long-contracts.test.ts lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/ai/tools/__tests__/interact-terminal-session.test.ts` (144 tests passed)
- `tsc --noEmit --incremental false`
- changed-file ESLint
- full ESLint (0 errors; 6 existing warnings)
- Prettier check and `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed agent-run timing and cost telemetry, including model streaming, terminal waits, sandbox recovery, and approval waits.
  * Agent runs now include permission-mode metadata for improved tracking.
  * Analytics capture expanded trigger usage, cost, timing, and recovery metrics.

* **Bug Fixes**
  * Ensured timing metrics are recorded even when terminal operations or other measured tasks fail.
  * Improved sandbox recovery tracking and readiness verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->