### PR TITLE
Fix local Agent dispatch and resume races

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ To use the agent locally:
    pnpm dev:trigger
    ```
 
-   This runs `trigger dev start --branch <name>` so parallel Codex worktrees
-   and local dev sessions do not collide in Trigger.dev. The branch name
-   defaults to the current Git branch, sanitized for Trigger.dev. Override it
-   with `TRIGGER_DEV_BRANCH=my-local-agent pnpm dev:trigger` when you need a
-   stable custom branch name.
+   This starts the default Trigger.dev worker used by local Agent requests.
+   To start an explicitly routed Trigger.dev branch instead, set a stable
+   branch name with
+   `TRIGGER_DEV_BRANCH=my-local-agent pnpm dev:trigger`. Only use that override
+   when the request path is configured to target the same Trigger.dev branch.

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -442,6 +442,7 @@ function StreamEffects({
     initialMessages: serverMessages,
     resumeStream,
     setMessages,
+    status,
     hasActiveStream,
   });
 

--- a/app/hooks/__tests__/useAutoResume.test.ts
+++ b/app/hooks/__tests__/useAutoResume.test.ts
@@ -1,4 +1,14 @@
-import { mergeResumedMessage } from "../useAutoResume";
+import React from "react";
+import { renderHook } from "@testing-library/react";
+import {
+  DataStreamProvider,
+  useDataStream,
+} from "@/app/components/DataStreamProvider";
+import {
+  mergeResumedMessage,
+  useAutoResume,
+  type UseAutoResumeParams,
+} from "../useAutoResume";
 import type { ChatMessage } from "@/types/chat";
 
 function message(id: string, role: "user" | "assistant"): ChatMessage {
@@ -7,6 +17,32 @@ function message(id: string, role: "user" | "assistant"): ChatMessage {
     role,
     parts: [{ type: "text", text: id }],
   } as ChatMessage;
+}
+
+function createWrapper() {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(DataStreamProvider, null, children);
+  };
+}
+
+function buildParams(
+  overrides: Partial<UseAutoResumeParams> = {},
+): UseAutoResumeParams {
+  return {
+    chatId: "chat-1",
+    autoResume: true,
+    initialMessages: [message("user-1", "user")],
+    resumeStream: jest.fn(),
+    setMessages: jest.fn(),
+    status: "ready",
+    hasActiveStream: true,
+    ...overrides,
+  };
+}
+
+function useTestHarness(params: UseAutoResumeParams) {
+  useAutoResume(params);
+  return useDataStream();
 }
 
 describe("mergeResumedMessage", () => {
@@ -61,5 +97,111 @@ describe("mergeResumedMessage", () => {
     );
 
     expect(result.map((item) => item.id)).toEqual(["user-1", "a-1"]);
+  });
+});
+
+describe("useAutoResume", () => {
+  it("resumes a stream that was active when the chat loaded", () => {
+    const resumeStream = jest.fn();
+    const params = buildParams({ resumeStream });
+
+    const { result } = renderHook(() => useTestHarness(params), {
+      wrapper: createWrapper(),
+    });
+
+    expect(resumeStream).toHaveBeenCalledTimes(1);
+    expect(result.current.isAutoResuming).toBe(true);
+  });
+
+  it("does not resume a stream that becomes active after initial load", () => {
+    const resumeStream = jest.fn();
+    let params = buildParams({
+      resumeStream,
+      hasActiveStream: false,
+    });
+
+    const { rerender } = renderHook(
+      (nextParams: UseAutoResumeParams) => useTestHarness(nextParams),
+      {
+        initialProps: params,
+        wrapper: createWrapper(),
+      },
+    );
+
+    params = { ...params, hasActiveStream: true };
+    rerender(params);
+
+    expect(resumeStream).not.toHaveBeenCalled();
+  });
+
+  it("does not reconsider a completed initial chat after a new user message", () => {
+    const resumeStream = jest.fn();
+    let params = buildParams({
+      resumeStream,
+      initialMessages: [message("assistant-1", "assistant")],
+    });
+
+    const { rerender } = renderHook(
+      (nextParams: UseAutoResumeParams) => useTestHarness(nextParams),
+      {
+        initialProps: params,
+        wrapper: createWrapper(),
+      },
+    );
+
+    params = {
+      ...params,
+      initialMessages: [
+        message("assistant-1", "assistant"),
+        message("user-2", "user"),
+      ],
+    };
+    rerender(params);
+
+    expect(resumeStream).not.toHaveBeenCalled();
+  });
+
+  it.each(["submitted", "streaming"] as const)(
+    "does not resume while a local request is %s",
+    (status) => {
+      const resumeStream = jest.fn();
+      let params = buildParams({ resumeStream, status });
+
+      const { rerender } = renderHook(
+        (nextParams: UseAutoResumeParams) => useTestHarness(nextParams),
+        {
+          initialProps: params,
+          wrapper: createWrapper(),
+        },
+      );
+
+      params = { ...params, status: "ready" };
+      rerender(params);
+
+      expect(resumeStream).not.toHaveBeenCalled();
+    },
+  );
+
+  it("waits for the initial server stream state before resuming", () => {
+    const resumeStream = jest.fn();
+    let params = buildParams({
+      resumeStream,
+      hasActiveStream: undefined,
+    });
+
+    const { rerender } = renderHook(
+      (nextParams: UseAutoResumeParams) => useTestHarness(nextParams),
+      {
+        initialProps: params,
+        wrapper: createWrapper(),
+      },
+    );
+
+    expect(resumeStream).not.toHaveBeenCalled();
+
+    params = { ...params, hasActiveStream: true };
+    rerender(params);
+
+    expect(resumeStream).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/hooks/useAutoResume.ts
+++ b/app/hooks/useAutoResume.ts
@@ -15,6 +15,7 @@ export interface UseAutoResumeParams {
   initialMessages: ChatMessage[];
   resumeStream: UseChatHelpers<ChatMessage>["resumeStream"];
   setMessages: UseChatHelpers<ChatMessage>["setMessages"];
+  status: UseChatHelpers<ChatMessage>["status"];
   // Tri-state: undefined = chat data still loading (wait), true = server is
   // actively producing (resume), false = no active stream (don't resume —
   // the user message went unanswered, but resuming would just GET an empty
@@ -43,26 +44,46 @@ export function useAutoResume({
   initialMessages,
   resumeStream,
   setMessages,
+  status,
   hasActiveStream,
 }: UseAutoResumeParams) {
   const { dataStream } = useDataStreamState();
   const { setIsAutoResuming } = useDataStreamDispatch();
   const hasAutoResumedRef = useRef(false);
+  const hasEvaluatedInitialResumeRef = useRef(false);
+  const hasLocalRequestStartedRef = useRef(false);
 
   const isPartForCurrentChat = (part: ScopedDataUIPart) =>
     part.__chatId === undefined || part.__chatId === chatId;
 
   useEffect(() => {
     hasAutoResumedRef.current = false;
+    hasEvaluatedInitialResumeRef.current = false;
+    hasLocalRequestStartedRef.current = false;
   }, [chatId]);
 
   useEffect(() => {
-    if (!autoResume || hasAutoResumedRef.current) return;
-    if (initialMessages.length === 0) return;
-    // Wait for chat data to load, then only resume when the server says
-    // it's actively producing a response.
+    if (status !== "ready") {
+      hasLocalRequestStartedRef.current = true;
+    }
+  }, [status]);
+
+  useEffect(() => {
+    if (!autoResume || hasEvaluatedInitialResumeRef.current) return;
     if (hasActiveStream === undefined) return;
-    if (!hasActiveStream) return;
+
+    // Auto-resume is a one-time hydration decision. Once the initial server
+    // state says there is no active stream, a later local request must not
+    // become eligible when it publishes its own active run id.
+    if (!hasActiveStream) {
+      hasEvaluatedInitialResumeRef.current = true;
+      return;
+    }
+
+    if (initialMessages.length === 0) return;
+
+    hasEvaluatedInitialResumeRef.current = true;
+    if (status !== "ready" || hasLocalRequestStartedRef.current) return;
 
     const mostRecentMessage = initialMessages.at(-1);
 
@@ -72,7 +93,7 @@ export function useAutoResume({
       resumeStream();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoResume, initialMessages.length > 0, hasActiveStream]);
+  }, [autoResume, initialMessages.length > 0, hasActiveStream, status]);
 
   useEffect(() => {
     if (!autoResume || !hasAutoResumedRef.current) return;

--- a/scripts/__tests__/trigger-dev-branch.test.js
+++ b/scripts/__tests__/trigger-dev-branch.test.js
@@ -12,7 +12,7 @@ const { spawnSync } = require("node:child_process");
 const scriptPath = path.resolve("scripts/trigger-dev-branch.mjs");
 
 describe("trigger-dev-branch", () => {
-  it("starts the Trigger 4.5 dev branch with forwarded arguments", () => {
+  function runScript(environment = {}) {
     const tempDir = mkdtempSync(path.join(tmpdir(), "trigger-dev-branch-"));
     const capturePath = path.join(tempDir, "args.json");
 
@@ -37,25 +37,48 @@ describe("trigger-dev-branch", () => {
             ...process.env,
             PATH: `${tempDir}:${process.env.PATH}`,
             TRIGGER_ARGS_CAPTURE: capturePath,
-            TRIGGER_DEV_BRANCH: "feature/codex health",
+            TRIGGER_DEV_BRANCH: undefined,
+            ...environment,
           },
         },
       );
 
-      expect(result.status).toBe(0);
-      expect(result.stderr).toBe("");
-      expect(result.stdout).toContain(
-        "[trigger-dev] using Trigger.dev branch: feature-codex-health",
-      );
-      expect(JSON.parse(readFileSync(capturePath, "utf8"))).toEqual([
-        "dev",
-        "start",
-        "--branch",
-        "feature-codex-health",
-        "--skip-update-check",
-      ]);
+      return {
+        result,
+        args: JSON.parse(readFileSync(capturePath, "utf8")),
+      };
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  }
+
+  it("starts the default Trigger.dev worker with forwarded arguments", () => {
+    const { result, args } = runScript();
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(
+      "[trigger-dev] using default Trigger.dev branch",
+    );
+    expect(args).toEqual(["dev", "start", "--skip-update-check"]);
+  });
+
+  it("uses a sanitized branch only when explicitly configured", () => {
+    const { result, args } = runScript({
+      TRIGGER_DEV_BRANCH: "feature/codex health",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(
+      "[trigger-dev] using explicit Trigger.dev branch: feature-codex-health",
+    );
+    expect(args).toEqual([
+      "dev",
+      "start",
+      "--branch",
+      "feature-codex-health",
+      "--skip-update-check",
+    ]);
   });
 });

--- a/scripts/trigger-dev-branch.mjs
+++ b/scripts/trigger-dev-branch.mjs
@@ -1,16 +1,6 @@
 #!/usr/bin/env node
 
-import { spawn, spawnSync } from "node:child_process";
-import path from "node:path";
-
-const readGit = (args) => {
-  const result = spawnSync("git", args, {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-  });
-
-  return result.status === 0 ? result.stdout.trim() : "";
-};
+import { spawn } from "node:child_process";
 
 const sanitizeBranchName = (value) => {
   const normalized = value
@@ -22,26 +12,23 @@ const sanitizeBranchName = (value) => {
   return normalized || "local";
 };
 
-const branchFromGit =
-  readGit(["branch", "--show-current"]) ||
-  [path.basename(process.cwd()), readGit(["rev-parse", "--short", "HEAD"])]
-    .filter(Boolean)
-    .join("-");
+const configuredBranch = process.env.TRIGGER_DEV_BRANCH?.trim();
+const triggerArgs = ["dev", "start"];
 
-const triggerBranch = sanitizeBranchName(
-  process.env.TRIGGER_DEV_BRANCH || branchFromGit || "local",
-);
+if (configuredBranch) {
+  const triggerBranch = sanitizeBranchName(configuredBranch);
+  triggerArgs.push("--branch", triggerBranch);
+  console.log(
+    `[trigger-dev] using explicit Trigger.dev branch: ${triggerBranch}`,
+  );
+} else {
+  console.log("[trigger-dev] using default Trigger.dev branch");
+}
 
-console.log(`[trigger-dev] using Trigger.dev branch: ${triggerBranch}`);
-
-const child = spawn(
-  "trigger",
-  ["dev", "start", "--branch", triggerBranch, ...process.argv.slice(2)],
-  {
-    stdio: "inherit",
-    shell: process.platform === "win32",
-  },
-);
+const child = spawn("trigger", [...triggerArgs, ...process.argv.slice(2)], {
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
 
 child.on("exit", (code, signal) => {
   if (signal) {


### PR DESCRIPTION
## Summary

- start the default Trigger.dev worker for normal local Agent requests while keeping branch routing explicitly opt-in
- make auto-resume a one-time hydration decision so a newly submitted Agent run cannot trigger a concurrent `resumeStream()`
- document the local worker contract and add behavioral regression coverage

## Root cause

`pnpm dev:trigger` automatically derived a Trigger.dev branch from Git, but the local Agent request path submitted runs to the default development branch. Runs therefore remained queued even though the branch-scoped worker reported ready.

Separately, `useAutoResume` watched live server state indefinitely. After reloading a completed chat, a new local continuation could publish an active run and user message, making the hook call `resumeStream()` concurrently with the already active request.

## Validation

- pre-commit full suite: 259 suites, 2,590 tests passed
- `corepack pnpm jest scripts/__tests__/trigger-dev-branch.test.js app/hooks/__tests__/useAutoResume.test.ts app/components/__tests__/chat.integration.test.tsx lib/api/__tests__/agent-long-contracts.test.ts --runInBand`
- `corepack pnpm typecheck`
- `corepack pnpm lint` (passes with six existing warnings)
- Prettier check and `git diff --check`

## Manual verification

Verified through the actual Google Chrome application against `http://localhost:3000`:

1. Started `corepack pnpm dev:trigger` and confirmed `Local worker ready on branch: default`.
2. Created a fresh Cloud Agent chat and received `QA-FIX-INITIAL-PASS`; Trigger run `run_cmrmm740zugra0iol34fftp9q` succeeded.
3. Reloaded the completed chat and sent a continuation.
4. Received `QA-FIX-RESUME-PASS`; Trigger run `run_cmrmm8anzuwc00poivg97pb7g` succeeded.
5. Confirmed the continuation did not call `/api/agent/resume` and Chrome console contained no `Cannot read properties of undefined (reading 'state')` error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat auto-resume behavior to prevent resuming during active local requests and wait for the server stream state.
  - Ensured auto-resume decisions reset correctly when switching chats.

- **Chores**
  - Trigger.dev workers now use the default branch unless `TRIGGER_DEV_BRANCH` is explicitly configured.
  - Explicit branch names are sanitized before use.
  - Updated setup documentation to reflect the new branch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->