### PR TITLE
Harden Agent approval and cancellation boundaries

### DIFF
--- a/app/components/ChatInput/AgentApprovalPrompt.tsx
+++ b/app/components/ChatInput/AgentApprovalPrompt.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import { AlertTriangle, ChevronDown, Hand, LoaderCircle } from "lucide-react";
 import { toast } from "sonner";
 
@@ -23,66 +23,6 @@ type AgentApprovalPromptProps = {
   onRetryConnection?: () => void;
   onStop: () => void;
 };
-
-const isPlainEnterKey = (event: {
-  key: string;
-  altKey: boolean;
-  ctrlKey: boolean;
-  metaKey: boolean;
-  shiftKey: boolean;
-}) =>
-  event.key === "Enter" &&
-  !event.altKey &&
-  !event.ctrlKey &&
-  !event.metaKey &&
-  !event.shiftKey;
-
-const INTERACTIVE_KEY_TARGET_SELECTOR = [
-  "a",
-  "area[href]",
-  "button",
-  "input",
-  "textarea",
-  "select",
-  "details",
-  "summary",
-  '[contenteditable=""]',
-  '[contenteditable="true"]',
-  '[contenteditable="plaintext-only"]',
-  '[role~="button"]',
-  '[role~="checkbox"]',
-  '[role~="combobox"]',
-  '[role~="grid"]',
-  '[role~="gridcell"]',
-  '[role~="link"]',
-  '[role~="listbox"]',
-  '[role~="menu"]',
-  '[role~="menubar"]',
-  '[role~="menuitem"]',
-  '[role~="menuitemcheckbox"]',
-  '[role~="menuitemradio"]',
-  '[role~="option"]',
-  '[role~="radio"]',
-  '[role~="radiogroup"]',
-  '[role~="scrollbar"]',
-  '[role~="searchbox"]',
-  '[role~="slider"]',
-  '[role~="spinbutton"]',
-  '[role~="switch"]',
-  '[role~="tab"]',
-  '[role~="tablist"]',
-  '[role~="textbox"]',
-  '[role~="tree"]',
-  '[role~="treegrid"]',
-  '[role~="treeitem"]',
-  '[tabindex]:not([tabindex="-1"])',
-].join(",");
-
-const isInteractiveKeyTarget = (target: EventTarget | null) =>
-  target instanceof Element &&
-  (target instanceof HTMLElement && target.isContentEditable
-    ? true
-    : target.closest(INTERACTIVE_KEY_TARGET_SELECTOR) !== null);
 
 const getApprovalCategory = (request: ActiveAgentToolApprovalRequest) => {
   if (request.operation === "terminal_execute") return "Terminal command";
@@ -181,26 +121,6 @@ export function AgentApprovalPrompt({
       );
     }
   }, [canSubmit, request.approvalId, request.toolCallId, sendToolApproval]);
-
-  useEffect(() => {
-    const handleDocumentKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (!canSubmit || event.defaultPrevented || !isPlainEnterKey(event)) {
-        return;
-      }
-      if (
-        isInteractiveKeyTarget(event.target) ||
-        isInteractiveKeyTarget(document.activeElement)
-      ) {
-        return;
-      }
-
-      event.preventDefault();
-      void submitApproval(false);
-    };
-
-    document.addEventListener("keydown", handleDocumentKeyDown);
-    return () => document.removeEventListener("keydown", handleDocumentKeyDown);
-  }, [canSubmit, submitApproval]);
 
   const allowLabel = isApproved
     ? "Approved"

--- a/app/components/ChatInput/__tests__/AgentApprovalPrompt.test.tsx
+++ b/app/components/ChatInput/__tests__/AgentApprovalPrompt.test.tsx
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 const mockSendToolApproval = jest.fn(() => Promise.resolve());
 const mockOnRetryConnection = jest.fn();
@@ -75,10 +76,13 @@ describe("AgentApprovalPrompt", () => {
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 
-  it("approves once when Enter is pressed", async () => {
+  it("approves once when Enter activates the focused primary action", async () => {
+    const user = userEvent.setup();
     renderPrompt();
+    const allowButton = screen.getByRole("button", { name: "Allow once" });
+    allowButton.focus();
 
-    fireEvent.keyDown(document.body, { key: "Enter", code: "Enter" });
+    await user.keyboard("{Enter}");
 
     await waitFor(() =>
       expect(mockSendToolApproval).toHaveBeenCalledWith({
@@ -87,6 +91,15 @@ describe("AgentApprovalPrompt", () => {
         decision: "approve",
       }),
     );
+    expect(allowButton).toHaveFocus();
+  });
+
+  it("does not approve when Enter is pressed on the page body", () => {
+    renderPrompt();
+
+    fireEvent.keyDown(document.body, { key: "Enter", code: "Enter" });
+
+    expect(mockSendToolApproval).not.toHaveBeenCalled();
   });
 
   it("approves once from the primary action", async () => {
@@ -237,7 +250,7 @@ describe("AgentApprovalPrompt", () => {
     expect(mockSendToolApproval).not.toHaveBeenCalled();
   });
 
-  it("still approves from a safe noninteractive page target", async () => {
+  it("does not approve from an unrelated noninteractive page target", () => {
     render(
       <>
         <div data-testid="outside-copy">Outside copy</div>
@@ -254,7 +267,35 @@ describe("AgentApprovalPrompt", () => {
       code: "Enter",
     });
 
-    await waitFor(() => expect(mockSendToolApproval).toHaveBeenCalledTimes(1));
+    expect(mockSendToolApproval).not.toHaveBeenCalled();
+  });
+
+  it("requires one-time approval for file changes", async () => {
+    render(
+      <AgentApprovalPrompt
+        request={{
+          ...request,
+          kind: "file",
+          operation: "file_write",
+          target: "/workspace/report.txt",
+        }}
+        onRetryConnection={mockOnRetryConnection}
+        onStop={mockOnStop}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "More approval options" }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Allow once" }));
+
+    await waitFor(() =>
+      expect(mockSendToolApproval).toHaveBeenCalledWith({
+        approvalId: "approval-1",
+        toolCallId: "tool-1",
+        decision: "approve",
+      }),
+    );
   });
 
   it("shows reconnecting and stop controls without session credentials", () => {

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -248,6 +248,69 @@ describe("targetConnectionId filtering", () => {
   });
 });
 
+describe("command cancellation acknowledgement", () => {
+  it.each([true, false])(
+    "publishes the native cancellation result when invoke returns %s",
+    async (nativeResult) => {
+      const bridge = new DesktopSandboxBridge(buildConfig());
+      await bridge.start();
+      const handler = getPublicationHandler();
+      (bridge as unknown as { activeCommands: Set<string> }).activeCommands.add(
+        "cmd-cancel",
+      );
+      mockInvokeHandler = async (cmd: string) => {
+        if (cmd === "cancel_stream_command") return nativeResult;
+        return undefined;
+      };
+
+      handler({
+        data: {
+          type: "command_cancel",
+          commandId: "cmd-cancel",
+          targetConnectionId: "conn-123",
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockSubscription.publish).toHaveBeenCalledWith({
+        type: "command_cancel_result",
+        commandId: "cmd-cancel",
+        canceled: nativeResult,
+      });
+    },
+  );
+
+  it("publishes false when native cancellation throws", async () => {
+    const bridge = new DesktopSandboxBridge(buildConfig());
+    await bridge.start();
+    const handler = getPublicationHandler();
+    (bridge as unknown as { activeCommands: Set<string> }).activeCommands.add(
+      "cmd-cancel",
+    );
+    mockInvokeHandler = async (cmd: string) => {
+      if (cmd === "cancel_stream_command") {
+        throw new Error("native transport failed");
+      }
+      return undefined;
+    };
+
+    handler({
+      data: {
+        type: "command_cancel",
+        commandId: "cmd-cancel",
+        targetConnectionId: "conn-123",
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockSubscription.publish).toHaveBeenCalledWith({
+      type: "command_cancel_result",
+      commandId: "cmd-cancel",
+      canceled: false,
+    });
+  });
+});
+
 // ── native desktop file relay ─────────────────────────────────────────
 
 describe("native desktop file relay", () => {

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -681,10 +681,30 @@ export class DesktopSandboxBridge {
   private async handleCommandCancel(
     command: CommandCancelMessage,
   ): Promise<void> {
-    if (!this.activeCommands.has(command.commandId)) return;
-    const { invoke } = await import("@tauri-apps/api/core");
-    await invoke("cancel_stream_command", {
+    let canceled = false;
+    if (this.activeCommands.has(command.commandId)) {
+      try {
+        const { invoke } = await import("@tauri-apps/api/core");
+        canceled = await invoke<boolean>("cancel_stream_command", {
+          commandId: command.commandId,
+        });
+      } catch (error) {
+        console.error(
+          "[desktop-bridge]",
+          JSON.stringify({
+            event: "desktop_stream_command_cancel_failed",
+            service: "desktop_bridge",
+            command_id: command.commandId,
+            error_name: error instanceof Error ? error.name : "UnknownError",
+          }),
+        );
+      }
+    }
+
+    await this.publishResult({
+      type: "command_cancel_result",
       commandId: command.commandId,
+      canceled,
     });
   }
 

--- a/lib/__tests__/errors.test.ts
+++ b/lib/__tests__/errors.test.ts
@@ -68,6 +68,47 @@ describe("ChatSDKError stream serialization", () => {
     });
   });
 
+  it("keeps log-only diagnostics and metadata out of client streams", () => {
+    const original = new ChatSDKError(
+      "offline:database",
+      "SECRET database diagnostic",
+      {
+        operation: "saveMessage",
+        requestId: "request-secret",
+        failureStage: "database-write",
+        chatId: "chat-secret",
+        userId: "user-secret",
+      },
+    );
+
+    const serialized = serializeChatSDKErrorForStream(original);
+    const parsed = deserializeChatSDKErrorFromStream(new Error(serialized));
+
+    expect(serialized).not.toContain("SECRET database diagnostic");
+    expect(serialized).not.toContain("request-secret");
+    expect(serialized).not.toContain("chat-secret");
+    expect(serialized).not.toContain("user-secret");
+    expect(parsed).toMatchObject({
+      type: "bad_request",
+      surface: "stream",
+      cause: "Something went wrong. Please try again later.",
+      metadata: undefined,
+    });
+
+    // Serialization is client-only; the original remains available to bounded
+    // server logging with its diagnostic context intact.
+    expect(original).toMatchObject({
+      cause: "SECRET database diagnostic",
+      metadata: {
+        operation: "saveMessage",
+        requestId: "request-secret",
+        failureStage: "database-write",
+        chatId: "chat-secret",
+        userId: "user-secret",
+      },
+    });
+  });
+
   it.each([
     "__HACKERAI_CHAT_SDK_ERROR__:{",
     '__HACKERAI_CHAT_SDK_ERROR__:{"code":"future:surface"}',

--- a/lib/ai/tools/__tests__/file.test.ts
+++ b/lib/ai/tools/__tests__/file.test.ts
@@ -114,11 +114,12 @@ function makeSandbox(
   };
 }
 
-function makeNativeDesktopSandbox() {
+function makeNativeDesktopSandbox(connectionId = "desktop-a") {
   const commandRun = jest.fn<Promise<FakeCommandResult>, [string, any?]>();
   return {
     sandbox: {
       sandboxKind: "centrifugo" as const,
+      getConnectionId: () => connectionId,
       isWindows: () => true,
       supportsNativeFileRelay: () => true,
       commands: { run: commandRun },
@@ -148,6 +149,50 @@ function makeNativeDesktopSandbox() {
 }
 
 describe("file tool large text safety", () => {
+  test("does not write on a replacement Desktop connection after approval", async () => {
+    const { sandbox } = makeNativeDesktopSandbox("desktop-b");
+    const requestToolApproval = jest.fn(async () => ({
+      approved: true as const,
+      approvalId: "approval-1",
+      sandboxIdentity: "connection:desktop-a" as const,
+    }));
+    const tool = createFile(makeContext(sandbox, { requestToolApproval }));
+
+    const result = (await runTool(tool, {
+      action: "write",
+      path: "C:\\repo\\approved-on-a.txt",
+      brief: "test connection binding",
+      text: "must not reach desktop B",
+    })) as { error: string };
+
+    expect(result.error).toContain("selected sandbox changed after approval");
+    expect(sandbox.files.write).not.toHaveBeenCalled();
+  });
+
+  test("preserves an approved write on the same Desktop connection", async () => {
+    const { sandbox } = makeNativeDesktopSandbox("desktop-a");
+    const requestToolApproval = jest.fn(async () => ({
+      approved: true as const,
+      approvalId: "approval-1",
+      sandboxIdentity: "connection:desktop-a" as const,
+    }));
+    const tool = createFile(makeContext(sandbox, { requestToolApproval }));
+
+    await expect(
+      runTool(tool, {
+        action: "write",
+        path: "C:\\repo\\approved-on-a.txt",
+        brief: "test connection binding",
+        text: "allowed on desktop A",
+      }),
+    ).resolves.toBe("File written: C:\\repo\\approved-on-a.txt");
+    expect(sandbox.files.write).toHaveBeenCalledWith(
+      "C:\\repo\\approved-on-a.txt",
+      "allowed on desktop A",
+      { user: "user" },
+    );
+  });
+
   test("blocks file operations when a selected local sandbox falls back", async () => {
     const commandRun = jest.fn(async () => ({
       stdout: "",

--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -193,6 +193,7 @@ const mockPhEvent = phLogger.event as jest.MockedFunction<
 async function runTool(
   tool: ReturnType<typeof createRunTerminalCmd>,
   input: Record<string, unknown>,
+  abortSignal?: AbortSignal,
 ) {
   const execute = (
     tool as unknown as {
@@ -201,7 +202,7 @@ async function runTool(
   ).execute;
   return execute(input, {
     toolCallId: "call-1",
-    abortSignal: undefined,
+    abortSignal,
     messages: [],
   });
 }
@@ -628,6 +629,63 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  test("retains local command tracking when cancellation is not confirmed", async () => {
+    const abortController = new AbortController();
+    let commandStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      commandStarted = resolve;
+    });
+    const nonE2B = {
+      sandboxKind: "centrifugo" as const,
+      isWindows: () => false,
+      commands: {
+        run: jest.fn(
+          async (
+            _command: string,
+            opts?: {
+              signal?: AbortSignal;
+              onCancelReady?: (cancel: () => Promise<boolean>) => void;
+            },
+          ): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
+            commandStarted();
+            opts?.onCancelReady?.(async () => false);
+            return new Promise(() => {});
+          },
+        ),
+      },
+    };
+    const { context, ptySessionManager } = makeContext({ sandbox: nonE2B });
+    const resultPromise = runTool(
+      createRunTerminalCmd(context),
+      {
+        action: "exec",
+        command: "sleep 999",
+        brief: "wait",
+        is_background: false,
+        interactive: false,
+        timeout: 30,
+      },
+      abortController.signal,
+    ) as Promise<{
+      result: { error?: string; exitCode?: number | null; session?: string };
+    }>;
+
+    await started;
+    abortController.abort();
+    const result = await resultPromise;
+
+    expect(result.result.exitCode).toBeNull();
+    expect(result.result.error).toContain(
+      "Command cancellation could not be confirmed",
+    );
+    expect(result.result.session).toBeDefined();
+    expect(
+      ptySessionManager.get("chat-1", result.result.session!),
+    ).toBeDefined();
+
+    ptySessionManager.forget("chat-1", result.result.session!);
   });
 
   test("does not retry a foreground command after its tool timeout resolves", async () => {

--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -217,6 +217,7 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
   test("forwards the user-facing justification and reusable argv prefix", async () => {
     const nonE2B = {
       sandboxKind: "centrifugo" as const,
+      getConnectionId: () => "desktop-a",
       isWindows: () => false,
       commands: {
         run: jest.fn(
@@ -230,6 +231,7 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     const requestToolApproval = jest.fn(async () => ({
       approved: true as const,
       approvalId: "approval-1",
+      sandboxIdentity: "connection:desktop-a" as const,
     }));
     const { context } = makeContext({
       sandbox: nonE2B,
@@ -255,6 +257,81 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
       justification: "Check whether the target host is reachable.",
       prefixRule: ["ping", "-c", "4"],
     });
+  });
+
+  test("does not execute a command on a replacement Desktop connection", async () => {
+    const run = jest.fn(async () => ({
+      stdout: "wrong host\n",
+      stderr: "",
+      exitCode: 0,
+    }));
+    const replacementDesktop = {
+      sandboxKind: "centrifugo" as const,
+      getConnectionId: () => "desktop-b",
+      isWindows: () => false,
+      commands: { run },
+    };
+    const requestToolApproval = jest.fn(async () => ({
+      approved: true as const,
+      approvalId: "approval-1",
+      sandboxIdentity: "connection:desktop-a" as const,
+    }));
+    const { context } = makeContext({
+      sandbox: replacementDesktop,
+      requestToolApproval,
+    });
+
+    const result = (await runTool(createRunTerminalCmd(context), {
+      command: "echo approved-on-a",
+      brief: "test connection binding",
+      is_background: false,
+      timeout: 5,
+      interactive: false,
+    })) as { result: { error?: string; exitCode: number | null } };
+
+    expect(result.result.error).toContain(
+      "selected sandbox changed after approval",
+    );
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  test("does not create an interactive PTY on a replacement Desktop connection", async () => {
+    const fakeHandle = makeFakeHandle();
+    mockCreateCentrifugoPtyHandle.mockResolvedValue(fakeHandle);
+    const replacementDesktop = {
+      sandboxKind: "centrifugo" as const,
+      getConnectionId: () => "desktop-b",
+      getUserId: () => "user-1",
+      getConfig: () => ({ wsUrl: "ws://fake", tokenSecret: "secret" }),
+      isWindows: () => false,
+      commands: { run: jest.fn() },
+    };
+    const requestToolApproval = jest.fn(async () => ({
+      approved: true as const,
+      approvalId: "approval-1",
+      sandboxIdentity: "connection:desktop-a" as const,
+    }));
+    const { context } = makeContext({
+      sandbox: replacementDesktop,
+      requestToolApproval,
+    });
+
+    setTimeout(() => {
+      fakeHandle.emit(new TextEncoder().encode("wrong host\n"));
+      fakeHandle.resolveExit(0);
+    }, 10);
+    const result = (await runTool(createRunTerminalCmd(context), {
+      command: "sh",
+      brief: "test connection binding",
+      is_background: false,
+      timeout: 0.1,
+      interactive: true,
+    })) as { result: { error?: string; exitCode: number | null } };
+
+    expect(result.result.error).toContain(
+      "selected sandbox changed after approval",
+    );
+    expect(mockCreateCentrifugoPtyHandle).not.toHaveBeenCalled();
   });
 
   test("detectAgentBrowserUsage extracts sanitized actions", () => {

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -1,6 +1,10 @@
 import { tool } from "ai";
 import { createHash } from "crypto";
-import type { AnySandbox, ToolContext } from "@/types";
+import type {
+  AgentApprovalSandboxIdentity,
+  AnySandbox,
+  ToolContext,
+} from "@/types";
 import { truncateOutput } from "@/lib/token-utils";
 import { supportsMultimodalToolResults } from "@/lib/ai/providers";
 import { buildSandboxCommandOptions } from "./utils/sandbox-command-options";
@@ -1208,9 +1212,12 @@ async function uploadViewPreviewFiles(args: {
 
 export const createFile = (context: ToolContext) => {
   const { sandboxManager, modelName, getCurrentModelName } = context;
-  const getSandboxForFileTool = () =>
+  const getSandboxForFileTool = (
+    expectedSandboxIdentity?: AgentApprovalSandboxIdentity,
+  ) =>
     getSandboxWithFallbackGuard({
       sandboxManager,
+      expectedSandboxIdentity,
     });
   const canViewMultimodalFiles = () =>
     supportsMultimodalToolResults(getCurrentModelName?.() ?? modelName);
@@ -1227,6 +1234,7 @@ export const createFile = (context: ToolContext) => {
       { toolCallId },
     ) => {
       try {
+        let approvedSandboxIdentity: AgentApprovalSandboxIdentity | undefined;
         if (action === "write" || action === "append" || action === "edit") {
           const approval = await context.requestToolApproval?.({
             toolCallId,
@@ -1246,9 +1254,14 @@ export const createFile = (context: ToolContext) => {
               approvalDenied: true,
             };
           }
+          approvedSandboxIdentity = approval?.approved
+            ? approval.sandboxIdentity
+            : undefined;
         }
 
-        const { sandbox } = await getSandboxForFileTool();
+        const { sandbox } = await getSandboxForFileTool(
+          approvedSandboxIdentity,
+        );
 
         switch (action) {
           case "view": {

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -449,6 +449,13 @@ export const createRunTerminalCmd = (context: ToolContext) => {
             let commandHandle: CommandSessionHandle | null = null;
             let commandSessionExposed = false;
             const commandAbortController = new AbortController();
+            let cancelCentrifugoCommand: (() => Promise<boolean>) | null = null;
+            let runPromise: Promise<{
+              stdout: string;
+              stderr: string;
+              exitCode: number;
+              pid?: number;
+            }> | null = null;
 
             const forgetUnexposedCommandSession = () => {
               if (!commandSession || commandSessionExposed) return;
@@ -457,10 +464,19 @@ export const createRunTerminalCmd = (context: ToolContext) => {
 
             const terminateManagedCommand = async (): Promise<boolean> => {
               if (isCentrifugoSandbox(sandboxInstance)) {
+                if (cancelCentrifugoCommand) {
+                  return cancelCentrifugoCommand();
+                }
                 if (!commandAbortController.signal.aborted) {
                   commandAbortController.abort();
                 }
-                return true;
+                if (!runPromise) return false;
+                try {
+                  const result = await runPromise;
+                  return result.exitCode === 130;
+                } catch {
+                  return false;
+                }
               }
 
               if (!processId && execution?.pid) {
@@ -530,10 +546,15 @@ export const createRunTerminalCmd = (context: ToolContext) => {
               // This must happen before we kill the process, otherwise the error
               // from the killed process might trigger retries
               resolved = true;
+              // Keep the session addressable until termination is confirmed.
+              // runPromise may settle before this async handler resumes.
+              commandSessionExposed = true;
+
+              let terminated = false;
 
               if (commandHandle) {
                 try {
-                  const terminated = await terminateManagedCommand();
+                  terminated = await terminateManagedCommand();
                   if (!terminated) {
                     console.warn(
                       "[Terminal Command] Managed command could not be terminated during abort",
@@ -545,19 +566,13 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                     error,
                   );
                 }
-              } else if (isCentrifugoSandbox(sandboxInstance)) {
-                const result = handler ? handler.getResult() : { output: "" };
-                if (handler) {
-                  handler.cleanup();
+              } else if (isCentrifugoSandbox(sandboxInstance) && runPromise) {
+                try {
+                  const executionResult = await runPromise;
+                  terminated = executionResult.exitCode === 130;
+                } catch {
+                  terminated = false;
                 }
-                resolve({
-                  result: {
-                    output: result.output,
-                    exitCode: 130,
-                    error: "Command execution aborted by user",
-                  },
-                });
-                return;
               } else {
                 // Try to get PID from execution object first (cheap, no shell call)
                 if (!processId && execution && (execution as any)?.pid) {
@@ -567,7 +582,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                 // Terminate the current process
                 try {
                   if ((execution && execution.kill) || processId) {
-                    await terminateProcessReliably(
+                    terminated = await terminateProcessReliably(
                       sandboxInstance,
                       execution,
                       processId,
@@ -593,11 +608,21 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                 handler.cleanup();
               }
 
+              if (terminated) {
+                commandSessionExposed = false;
+                forgetUnexposedCommandSession();
+              }
+
               resolve({
                 result: {
                   output: result.output,
-                  exitCode: 130, // Standard SIGINT exit code
-                  error: "Command execution aborted by user",
+                  exitCode: terminated ? 130 : null,
+                  error: terminated
+                    ? "Command execution aborted by user"
+                    : "Command cancellation could not be confirmed. The local session was retained so termination can be retried.",
+                  ...(!terminated && commandSession
+                    ? { session: commandSession.sessionId }
+                    : {}),
                 },
               });
             };
@@ -757,6 +782,9 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                   signal: is_background
                     ? abortSignal
                     : commandAbortController.signal,
+                  onCancelReady: (cancel: () => Promise<boolean>) => {
+                    cancelCentrifugoCommand = cancel;
+                  },
                 }
               : isE2BSandbox(sandboxInstance)
                 ? { ...commonOptions, signal: abortSignal }
@@ -810,12 +838,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
             // Execute command with retry logic for transient failures
             // Sandbox readiness already checked, so these retries handle race conditions
             // Retries: 6 attempts with exponential backoff (500ms, 1s, 2s, 4s, 8s, 16s) + jitter (±50ms)
-            const runPromise: Promise<{
-              stdout: string;
-              stderr: string;
-              exitCode: number;
-              pid?: number;
-            }> = commandSessionReady.then(async () => {
+            runPromise = commandSessionReady.then(async () => {
               if (resolved || abortSignal?.aborted) {
                 return { stdout: "", stderr: "", exitCode: 130 };
               }

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -193,13 +193,19 @@ export const createRunTerminalCmd = (context: ToolContext) => {
           },
         };
       }
+      const approvedSandboxIdentity = approval?.approved
+        ? approval.sandboxIdentity
+        : undefined;
+      const getApprovedExecutionSandbox = () =>
+        getSandboxWithFallbackGuard({
+          sandboxManager,
+          expectedSandboxIdentity: approvedSandboxIdentity,
+        });
 
       // ─── Interactive PTY exec branch ─────────────────────────────────
       if (interactive) {
         try {
-          const { sandbox } = await getSandboxWithFallbackGuard({
-            sandboxManager,
-          });
+          const { sandbox } = await getApprovedExecutionSandbox();
           const isCentrifugo = isCentrifugoSandbox(sandbox);
           const isE2B = isE2BSandbox(sandbox);
 
@@ -321,9 +327,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
 
       try {
         // Get fresh sandbox and verify it's ready
-        const { sandbox } = await getSandboxWithFallbackGuard({
-          sandboxManager,
-        });
+        const { sandbox } = await getApprovedExecutionSandbox();
 
         // Bail early if sandbox was already marked unavailable by any tool
         if (sandboxManager.isSandboxUnavailable()) {
@@ -380,7 +384,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
               // Reset cached instance to force ensureSandboxConnection to create a fresh one
               sandboxManager.setSandbox(null as any);
               const { sandbox: freshSandbox } =
-                await getSandboxWithFallbackGuard({ sandboxManager });
+                await getApprovedExecutionSandbox();
 
               // Verify the fresh sandbox is ready
               try {

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -478,6 +478,55 @@ describe("CentrifugoSandbox", () => {
       );
     });
 
+    it("times out a stalled cancellation publish and ignores its late rejection", async () => {
+      const sandbox = createSandbox();
+      let cancel!: () => Promise<boolean>;
+      const { promise } = startCommand(sandbox, "sleep 999", {
+        timeoutMs: 10000,
+        onCancelReady: (readyCancel) => {
+          cancel = readyCancel;
+        },
+      });
+
+      await jest.advanceTimersByTimeAsync(0);
+      const sub = mockSubscriptions[0];
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      let rejectFirstPublish!: (error: Error) => void;
+      let cancellationPublishes = 0;
+      sub.publish = jest.fn((message: { type: string }) => {
+        if (message.type !== "command_cancel") return Promise.resolve();
+        cancellationPublishes += 1;
+        if (cancellationPublishes === 1) {
+          return new Promise<void>((_resolve, reject) => {
+            rejectFirstPublish = reject;
+          });
+        }
+        return Promise.resolve();
+      });
+
+      const firstAttempt = cancel();
+      await jest.advanceTimersByTimeAsync(5001);
+      await expect(firstAttempt).resolves.toBe(false);
+
+      const secondAttempt = cancel();
+      await jest.advanceTimersByTimeAsync(0);
+      rejectFirstPublish(new Error("late relay failure"));
+      await jest.advanceTimersByTimeAsync(0);
+
+      sub.emit("publication", {
+        data: {
+          type: "command_cancel_result",
+          commandId: FIXED_UUID,
+          canceled: true,
+        },
+      });
+
+      await expect(secondAttempt).resolves.toBe(true);
+      await expect(promise).resolves.toMatchObject({ exitCode: 130 });
+    });
+
     it("keeps the command live after an uncertain callback cancellation so it can be retried", async () => {
       const sandbox = createSandbox();
       let cancel!: () => Promise<boolean>;

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -347,7 +347,7 @@ describe("CentrifugoSandbox", () => {
   });
 
   describe("commands.run cancellation", () => {
-    it("publishes command_cancel and resolves with exitCode 130 when aborted", async () => {
+    it("resolves with exitCode 130 only after a positive cancellation acknowledgement", async () => {
       const sandbox = createSandbox();
       const abortController = new AbortController();
 
@@ -374,6 +374,21 @@ describe("CentrifugoSandbox", () => {
       abortController.abort();
       await jest.advanceTimersByTimeAsync(0);
 
+      let settled = false;
+      void promise.finally(() => {
+        settled = true;
+      });
+      await jest.advanceTimersByTimeAsync(0);
+      expect(settled).toBe(false);
+
+      sub.emit("publication", {
+        data: {
+          type: "command_cancel_result",
+          commandId: FIXED_UUID,
+          canceled: true,
+        },
+      });
+
       await expect(promise).resolves.toMatchObject({
         exitCode: 130,
       });
@@ -384,6 +399,136 @@ describe("CentrifugoSandbox", () => {
       });
       expect(sub.unsubscribe).toHaveBeenCalled();
       expect(client.disconnect).toHaveBeenCalled();
+    });
+
+    it("rejects and keeps cancellation distinct when the native runner reports false", async () => {
+      const sandbox = createSandbox();
+      const abortController = new AbortController();
+      const { promise } = startCommand(sandbox, "sleep 999", {
+        timeoutMs: 5000,
+        signal: abortController.signal,
+      });
+
+      await jest.advanceTimersByTimeAsync(0);
+      const sub = mockSubscriptions[0];
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      abortController.abort();
+      await jest.advanceTimersByTimeAsync(0);
+      sub.emit("publication", {
+        data: {
+          type: "command_cancel_result",
+          commandId: FIXED_UUID,
+          canceled: false,
+        },
+      });
+
+      await expect(promise).rejects.toThrow(
+        "Local command cancellation was not confirmed",
+      );
+    });
+
+    it("rejects when publishing the cancellation fails", async () => {
+      const sandbox = createSandbox();
+      const abortController = new AbortController();
+      const { promise } = startCommand(sandbox, "sleep 999", {
+        timeoutMs: 5000,
+        signal: abortController.signal,
+      });
+
+      await jest.advanceTimersByTimeAsync(0);
+      const sub = mockSubscriptions[0];
+      sub.publish = jest.fn((msg: { type: string }) =>
+        msg.type === "command_cancel"
+          ? Promise.reject(new Error("relay unavailable"))
+          : Promise.resolve(),
+      );
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      const rejection = expect(promise).rejects.toThrow(
+        "Failed to publish local command cancellation",
+      );
+      abortController.abort();
+      await jest.advanceTimersByTimeAsync(0);
+
+      await rejection;
+    });
+
+    it("rejects when no cancellation acknowledgement arrives", async () => {
+      const sandbox = createSandbox();
+      const abortController = new AbortController();
+      const { promise } = startCommand(sandbox, "sleep 999", {
+        timeoutMs: 10000,
+        signal: abortController.signal,
+      });
+
+      await jest.advanceTimersByTimeAsync(0);
+      const sub = mockSubscriptions[0];
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      abortController.abort();
+      await jest.advanceTimersByTimeAsync(0);
+      jest.advanceTimersByTime(5001);
+
+      await expect(promise).rejects.toThrow(
+        "Local command cancellation was not acknowledged",
+      );
+    });
+
+    it("keeps the command live after an uncertain callback cancellation so it can be retried", async () => {
+      const sandbox = createSandbox();
+      let cancel!: () => Promise<boolean>;
+      const { promise } = startCommand(sandbox, "sleep 999", {
+        timeoutMs: 10000,
+        onCancelReady: (readyCancel) => {
+          cancel = readyCancel;
+        },
+      });
+
+      await jest.advanceTimersByTimeAsync(0);
+      const sub = mockSubscriptions[0];
+      sub.emit("subscribed");
+      await jest.advanceTimersByTimeAsync(0);
+
+      const firstAttempt = cancel();
+      await jest.advanceTimersByTimeAsync(0);
+      sub.emit("publication", {
+        data: {
+          type: "command_cancel_result",
+          commandId: FIXED_UUID,
+          canceled: false,
+        },
+      });
+      await expect(firstAttempt).resolves.toBe(false);
+      expect(sub.unsubscribe).not.toHaveBeenCalled();
+
+      let commandSettled = false;
+      void promise.then(() => {
+        commandSettled = true;
+      });
+      await jest.advanceTimersByTimeAsync(0);
+      expect(commandSettled).toBe(false);
+
+      const secondAttempt = cancel();
+      await jest.advanceTimersByTimeAsync(0);
+      expect(
+        sub.publish.mock.calls.filter(
+          ([message]) => message.type === "command_cancel",
+        ),
+      ).toHaveLength(2);
+      sub.emit("publication", {
+        data: {
+          type: "command_cancel_result",
+          commandId: FIXED_UUID,
+          canceled: true,
+        },
+      });
+
+      await expect(secondAttempt).resolves.toBe(true);
+      await expect(promise).resolves.toMatchObject({ exitCode: 130 });
     });
 
     it("publishes command_cancel when aborted while command publish is in flight", async () => {
@@ -427,6 +572,14 @@ describe("CentrifugoSandbox", () => {
 
       resolveCommandPublish();
       await jest.advanceTimersByTimeAsync(0);
+
+      sub.emit("publication", {
+        data: {
+          type: "command_cancel_result",
+          commandId: FIXED_UUID,
+          canceled: true,
+        },
+      });
 
       await expect(promise).resolves.toMatchObject({
         exitCode: 130,

--- a/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
+++ b/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
@@ -18,6 +18,7 @@ import {
   LOCAL_SANDBOX_PRESENCE_GRACE_MS,
 } from "../hybrid-sandbox-manager";
 import {
+  assertAgentApprovalSandboxIdentity,
   assertLocalSandboxFallbackAllowed,
   getSandboxFallbackErrorMessage,
   getSandboxFallbackPromptReminder,
@@ -355,6 +356,30 @@ describe("HybridSandboxManager prompt-time fallback", () => {
     expect((error as Error & { cause?: unknown }).cause).toContain(
       "commands would run on the wrong host",
     );
+  });
+
+  it("binds an approved operation to the exact local connection", () => {
+    const desktopA = {
+      sandboxKind: "centrifugo" as const,
+      getConnectionId: () => "desktop-a",
+    } as never;
+    const desktopB = {
+      sandboxKind: "centrifugo" as const,
+      getConnectionId: () => "desktop-b",
+    } as never;
+
+    expect(() =>
+      assertAgentApprovalSandboxIdentity({
+        sandbox: desktopA,
+        expectedSandboxIdentity: "connection:desktop-a",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertAgentApprovalSandboxIdentity({
+        sandbox: desktopB,
+        expectedSandboxIdentity: "connection:desktop-a",
+      }),
+    ).toThrow("selected sandbox changed after approval");
   });
 
   it("blocks Desktop-local attachment preparation when Desktop falls back", () => {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -570,6 +570,14 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           }
           if (cancelPublishStarted) return;
           cancelPublishStarted = true;
+          const attempt = cancelAttemptPromise;
+          cancelAckTimeoutId = setTimeout(() => {
+            if (cancelAttemptPromise === attempt) {
+              failCancellation(
+                "Local command cancellation was not acknowledged.",
+              );
+            }
+          }, COMMAND_CANCEL_ACK_TIMEOUT_MS);
 
           subscription
             .publish({
@@ -577,16 +585,12 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
               commandId,
               targetConnectionId: this.connectionInfo.connectionId,
             })
-            .then(() => {
-              if (settled) return;
-              cancelAckTimeoutId = setTimeout(() => {
-                failCancellation(
-                  "Local command cancellation was not acknowledged.",
-                );
-              }, COMMAND_CANCEL_ACK_TIMEOUT_MS);
-            })
             .catch(() => {
-              failCancellation("Failed to publish local command cancellation.");
+              if (cancelAttemptPromise === attempt) {
+                failCancellation(
+                  "Failed to publish local command cancellation.",
+                );
+              }
             });
         };
 

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -21,6 +21,7 @@ import { validateDownloadUrl } from "./path-validation";
 const VALID_MESSAGE_TYPES = new Set([
   "command",
   "command_cancel",
+  "command_cancel_result",
   "stdout",
   "stderr",
   "exit",
@@ -53,6 +54,7 @@ const FILE_DOWNLOAD_TIMEOUT_MS = 120000;
 const SETUP_COMMAND_TIMEOUT_MS = 30000;
 const SETUP_COMMAND_MAX_ATTEMPTS = 2;
 const SETUP_COMMAND_RETRY_DELAY_MS = 500;
+const COMMAND_CANCEL_ACK_TIMEOUT_MS = 5000;
 const TRANSIENT_COMMAND_TIMEOUT_ERROR_PATTERN =
   /\b(?:deadline_exceeded|operation timed out:.*\btimeoutMs\b|exceeding ['"]?timeoutMs['"]?|Command timeout after \d+ms)\b/i;
 
@@ -116,6 +118,15 @@ export function parseSandboxMessage(
       }
       break;
     case "command_cancel":
+      break;
+    case "command_cancel_result":
+      if (typeof msg.canceled !== "boolean") {
+        console.warn(
+          "Invalid command_cancel_result message: missing canceled",
+          msg,
+        );
+        return null;
+      }
       break;
   }
 
@@ -439,6 +450,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
         onStderr?: (data: string) => void;
         displayName?: string;
         signal?: AbortSignal;
+        onCancelReady?: (cancel: () => Promise<boolean>) => void;
       },
     ): Promise<{
       stdout: string;
@@ -468,11 +480,15 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
         let stderr = "";
         let settled = false;
         let timeoutId: NodeJS.Timeout | undefined;
+        let cancelAckTimeoutId: NodeJS.Timeout | undefined;
         let subscription: Subscription | undefined;
         let publishedCommand = false;
         let commandPublishInFlight = false;
         let cancelRequested = false;
         let cancelPublishStarted = false;
+        let cancelTriggeredBySignal = false;
+        let cancelAttemptPromise: Promise<boolean> | null = null;
+        let resolveCancelAttempt: ((confirmed: boolean) => void) | null = null;
 
         const maxWaitTime = timeout + 5000; // Add 5s buffer for network
 
@@ -487,6 +503,10 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           if (timeoutId) {
             clearTimeout(timeoutId);
             timeoutId = undefined;
+          }
+          if (cancelAckTimeoutId) {
+            clearTimeout(cancelAckTimeoutId);
+            cancelAckTimeoutId = undefined;
           }
           if (subscription) {
             try {
@@ -510,6 +530,9 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
 
         const resolveCanceled = () => {
           if (settled) return;
+          resolveCancelAttempt?.(true);
+          resolveCancelAttempt = null;
+          cancelAttemptPromise = null;
           settled = true;
           cleanup();
           resolve({
@@ -517,6 +540,24 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
             stderr,
             exitCode: 130,
           });
+        };
+
+        const failCancellation = (message: string) => {
+          if (cancelAckTimeoutId) {
+            clearTimeout(cancelAckTimeoutId);
+            cancelAckTimeoutId = undefined;
+          }
+          resolveCancelAttempt?.(false);
+          resolveCancelAttempt = null;
+          cancelAttemptPromise = null;
+          cancelRequested = false;
+          cancelPublishStarted = false;
+
+          if (cancelTriggeredBySignal && !settled) {
+            settled = true;
+            cleanup();
+            reject(new Error(message));
+          }
         };
 
         const publishCancel = () => {
@@ -536,16 +577,38 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
               commandId,
               targetConnectionId: this.connectionInfo.connectionId,
             })
-            .catch(() => {
-              // The run is being aborted already; resolve locally even if the
-              // remote relay disappeared before it accepted the cancel message.
+            .then(() => {
+              if (settled) return;
+              cancelAckTimeoutId = setTimeout(() => {
+                failCancellation(
+                  "Local command cancellation was not acknowledged.",
+                );
+              }, COMMAND_CANCEL_ACK_TIMEOUT_MS);
             })
-            .finally(resolveCanceled);
+            .catch(() => {
+              failCancellation("Failed to publish local command cancellation.");
+            });
+        };
+
+        const requestCancellation = (
+          triggeredBySignal = false,
+        ): Promise<boolean> => {
+          cancelTriggeredBySignal ||= triggeredBySignal;
+          if (settled) return Promise.resolve(true);
+          if (cancelAttemptPromise) return cancelAttemptPromise;
+
+          cancelAttemptPromise = new Promise<boolean>((resolveAttempt) => {
+            resolveCancelAttempt = resolveAttempt;
+          });
+          publishCancel();
+          return cancelAttemptPromise;
         };
 
         const handleAbort = () => {
-          publishCancel();
+          void requestCancellation(true);
         };
+
+        opts?.onCancelReady?.(() => requestCancellation(false));
 
         if (opts?.signal?.aborted) {
           resolveCanceled();
@@ -597,6 +660,10 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
               opts?.onStderr?.(message.data);
               break;
             case "exit":
+              if (cancelRequested) {
+                resolveCanceled();
+                break;
+              }
               settled = true;
               cleanup();
               resolve({
@@ -606,7 +673,21 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
                 pid: message.pid,
               });
               break;
+            case "command_cancel_result":
+              if (!cancelRequested) break;
+              if (message.canceled) {
+                resolveCanceled();
+              } else {
+                failCancellation(
+                  "Local command cancellation was not confirmed.",
+                );
+              }
+              break;
             case "error":
+              if (cancelRequested) {
+                resolveCanceled();
+                break;
+              }
               console.warn(
                 "[local-command]",
                 JSON.stringify({
@@ -711,8 +792,9 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
               .catch((err: unknown) => {
                 commandPublishInFlight = false;
                 if (cancelRequested || opts?.signal?.aborted) {
-                  resolveCanceled();
-                  return;
+                  failCancellation(
+                    "Command publication failed while cancellation was pending.",
+                  );
                 }
                 if (!settled) {
                   settled = true;

--- a/lib/ai/tools/utils/sandbox-fallback.ts
+++ b/lib/ai/tools/utils/sandbox-fallback.ts
@@ -1,6 +1,12 @@
 import type { UIMessageStreamWriter } from "ai";
+import {
+  getAgentApprovalConnectionSandboxIdentity,
+  type AgentApprovalSandboxIdentity,
+  type AnySandbox,
+} from "@/types";
 import { ChatSDKError } from "@/lib/errors";
 import type { SandboxFallbackInfo } from "./hybrid-sandbox-manager";
+import { isCentrifugoSandbox } from "./sandbox-types";
 
 type SandboxContextForPromptManager = {
   getSandboxInfo?: () => unknown;
@@ -34,6 +40,25 @@ const LOCAL_ATTACHMENT_BLOCK_MESSAGE =
   "Desktop-local attachments require the Desktop sandbox. Reconnect Desktop, then resend the message with the attachment.";
 
 const CLOUD_SANDBOX_TYPE = "e2b";
+const APPROVED_SANDBOX_CHANGED_MESSAGE =
+  "The selected sandbox changed after approval. The operation was not run. Retry it to approve in the current sandbox.";
+
+export function assertAgentApprovalSandboxIdentity({
+  sandbox,
+  expectedSandboxIdentity,
+}: {
+  sandbox: AnySandbox;
+  expectedSandboxIdentity?: AgentApprovalSandboxIdentity;
+}): void {
+  if (!expectedSandboxIdentity) return;
+
+  const actualSandboxIdentity = isCentrifugoSandbox(sandbox)
+    ? getAgentApprovalConnectionSandboxIdentity(sandbox.getConnectionId())
+    : "e2b";
+  if (actualSandboxIdentity !== expectedSandboxIdentity) {
+    throw new Error(APPROVED_SANDBOX_CHANGED_MESSAGE);
+  }
+}
 
 export function assertLocalSandboxFallbackAllowed({
   fallbackInfo,
@@ -83,9 +108,11 @@ export function writeSandboxFallbackEvent(
 export async function getSandboxWithFallbackGuard<TSandbox>({
   sandboxManager,
   requireLocalSandbox = false,
+  expectedSandboxIdentity,
 }: {
   sandboxManager: SandboxAcquisitionManager<TSandbox>;
   requireLocalSandbox?: boolean;
+  expectedSandboxIdentity?: AgentApprovalSandboxIdentity;
 }): Promise<{ sandbox: TSandbox }> {
   const result = await sandboxManager.getSandbox();
   const fallbackInfo =
@@ -112,6 +139,11 @@ export async function getSandboxWithFallbackGuard<TSandbox>({
       throw error;
     }
   }
+
+  assertAgentApprovalSandboxIdentity({
+    sandbox: result.sandbox as AnySandbox,
+    expectedSandboxIdentity,
+  });
 
   return result;
 }

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -724,7 +724,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
   test("agent approval denial resolves as rejected without aborting the run", () => {
     expect(taskSrc).toMatch(/next\.output\.decision\s*===\s*"approve"/);
     expect(taskSrc).toMatch(
-      /next\.output\.decision\s*===\s*"approve"[\s\S]*return\s*\{\s*approved:\s*true,\s*approvalId\s*\}/,
+      /next\.output\.decision\s*===\s*"approve"[\s\S]*return\s*\{\s*approved:\s*true,\s*approvalId,\s*sandboxIdentity\s*\}/,
     );
     expect(taskSrc).toMatch(
       /tool approval denied[\s\S]*return\s*\{\s*approved:\s*false,[\s\S]*reason:\s*buildDeniedApprovalReason\(next\.output\.message\)/,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -850,6 +850,21 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     );
   });
 
+  test("approval telemetry keeps correlation context without raw targets", () => {
+    expect(taskSrc).toContain('event: "agent_tool_approval_waiting"');
+    expect(taskSrc).toContain('event: "agent_tool_approval_reused"');
+    expect(taskSrc).toContain('event: "agent_tool_approval_granted"');
+    expect(taskSrc).toContain('event: "agent_tool_approval_denied"');
+    expect(taskSrc).toContain("tool_call_id: request.toolCallId");
+    expect(taskSrc).toContain("operation: request.operation");
+    expect(taskSrc).not.toContain("target: request.target.slice");
+    expect(taskSrc).not.toContain("target_prefix: existingGrant.targetPrefix");
+    expect(taskSrc).not.toContain(
+      "target_prefix: approvedTargetGrant?.targetPrefix",
+    );
+    expect(taskSrc).not.toContain('.set("approvalTargetPrefix"');
+  });
+
   test("terminal approval cleanup compare-clears stale composer state", () => {
     expect(taskSrc).toMatch(
       /expectedRunId:\s*ctx\.run\.id,[\s\S]*clearApprovalPending:\s*true/,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -851,17 +851,65 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
   });
 
   test("approval telemetry keeps correlation context without raw targets", () => {
-    expect(taskSrc).toContain('event: "agent_tool_approval_waiting"');
-    expect(taskSrc).toContain('event: "agent_tool_approval_reused"');
-    expect(taskSrc).toContain('event: "agent_tool_approval_granted"');
-    expect(taskSrc).toContain('event: "agent_tool_approval_denied"');
-    expect(taskSrc).toContain("tool_call_id: request.toolCallId");
-    expect(taskSrc).toContain("operation: request.operation");
-    expect(taskSrc).not.toContain("target: request.target.slice");
-    expect(taskSrc).not.toContain("target_prefix: existingGrant.targetPrefix");
-    expect(taskSrc).not.toContain(
-      "target_prefix: approvedTargetGrant?.targetPrefix",
-    );
+    const expectedKeysByMessage = {
+      "[agent-long] tool approval reused": [
+        "event",
+        "service",
+        "runId",
+        "approvalId",
+        "tool_call_id",
+        "tool_name",
+        "operation",
+        "target_kind",
+      ],
+      "[agent-long] waiting for tool approval": [
+        "event",
+        "service",
+        "runId",
+        "approvalId",
+        "tool_call_id",
+        "tool_name",
+        "operation",
+      ],
+      "[agent-long] tool approval granted": [
+        "event",
+        "service",
+        "runId",
+        "approvalId",
+        "tool_call_id",
+        "tool_name",
+        "operation",
+        "requested_grant",
+        "grant",
+        "target_kind",
+      ],
+      "[agent-long] tool approval denied": [
+        "event",
+        "service",
+        "runId",
+        "approvalId",
+        "tool_call_id",
+        "tool_name",
+        "operation",
+      ],
+    } as const;
+
+    for (const [message, expectedKeys] of Object.entries(
+      expectedKeysByMessage,
+    )) {
+      const escapedMessage = message.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const payload = new RegExp(
+        `triggerLogger\\.info\\("${escapedMessage}",\\s*\\{([\\s\\S]*?)\\n\\s*\\}\\);`,
+      ).exec(taskSrc)?.[1];
+      expect(payload).toBeDefined();
+      const keys = Array.from(
+        payload?.matchAll(/^\s*([A-Za-z_][A-Za-z0-9_]*)(?:\s*:|\s*,\s*$)/gm) ??
+          [],
+        (match) => match[1],
+      );
+      expect(keys.sort()).toEqual([...expectedKeys].sort());
+    }
+
     expect(taskSrc).not.toContain('.set("approvalTargetPrefix"');
   });
 

--- a/lib/centrifugo/types.ts
+++ b/lib/centrifugo/types.ts
@@ -16,6 +16,12 @@ export interface CommandCancelMessage {
   targetConnectionId: string;
 }
 
+export interface CommandCancelResultMessage {
+  type: "command_cancel_result";
+  commandId: string;
+  canceled: boolean;
+}
+
 export interface StdoutMessage {
   type: "stdout";
   commandId: string;
@@ -195,6 +201,7 @@ export interface PtyErrorMessage {
 export type CommandResponseMessage =
   | CommandMessage
   | CommandCancelMessage
+  | CommandCancelResultMessage
   | StdoutMessage
   | StderrMessage
   | ExitMessage

--- a/lib/chat/__tests__/agent-approval-grants.test.ts
+++ b/lib/chat/__tests__/agent-approval-grants.test.ts
@@ -17,6 +17,28 @@ const request = (
   ...(prefixRule ? { prefixRule } : {}),
 });
 
+const expectFileOperationRequiresFreshApproval = (
+  operation: "file_write" | "file_append" | "file_edit",
+) => {
+  const approvedPath = "/workspace/project/victim.txt";
+  const legacyGrant = {
+    kind: "file_change" as const,
+    targetPrefix: approvedPath,
+    path: approvedPath,
+    pathFlavor: "posix" as const,
+  };
+
+  expect(
+    deriveAgentApprovalTargetGrant(request(operation, approvedPath)),
+  ).toBeNull();
+  expect(
+    matchesAgentApprovalTargetGrant(
+      request(operation, "/workspace/project/link/../victim.txt"),
+      legacyGrant,
+    ),
+  ).toBe(false);
+};
+
 describe("agent approval grants", () => {
   it("matches an exact static argv, not another command or executable", () => {
     const grant = deriveAgentApprovalTargetGrant(
@@ -160,10 +182,34 @@ describe("agent approval grants", () => {
     ["shell", "bash -c 'npm test && npm publish'"],
     ["absolute shell", "/bin/bash -lc 'npm test'"],
     ["Windows shell", String.raw`"C:\Windows\System32\cmd.exe" /c dir`],
+    ["unquoted Windows shell", String.raw`C:\Windows\System32\cmd.exe /c dir`],
+    ["Windows command.com", "command.com /c dir"],
+    ["Windows call builtin", "call script.cmd"],
+    ["Windows start builtin", "start cmd.exe /c dir"],
+    ["Windows subsystem wrapper", "wsl.exe sh -c 'id'"],
     ["evaluator", "eval 'npm test'"],
     ["environment dispatcher", "env npm test"],
     ["privilege dispatcher", "sudo npm test"],
   ])("rejects a reusable %s wrapper", (_description, target) => {
+    expect(
+      deriveAgentApprovalTargetGrant(request("terminal_execute", target)),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["COMSPEC", "%COMSPEC% /c echo harmless"],
+    ["lowercase COMSPEC", "%comspec% /c echo harmless"],
+    ["mixed-case COMSPEC", "%ComSpec% /c echo harmless"],
+    [
+      "SystemRoot cmd path",
+      String.raw`%SystemRoot%\System32\cmd.exe /c echo harmless`,
+    ],
+    [
+      "windir PowerShell path",
+      String.raw`%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -Command Get-ChildItem`,
+    ],
+    ["caret-obfuscated cmd", "c^m^d /c echo harmless"],
+  ])("rejects a reusable Windows %s expansion", (_description, target) => {
     expect(
       deriveAgentApprovalTargetGrant(request("terminal_execute", target)),
     ).toBeNull();
@@ -190,94 +236,16 @@ describe("agent approval grants", () => {
     },
   );
 
-  it("normalizes POSIX paths while keeping sibling and traversal targets separate", () => {
-    const grant = deriveAgentApprovalTargetGrant(
-      request("file_write", "/workspace/reports/report.txt"),
-    );
-
-    expect(grant).toMatchObject({
-      kind: "file_change",
-      path: "/workspace/reports/report.txt",
-      pathFlavor: "posix",
-    });
-    expect(
-      grant &&
-        matchesAgentApprovalTargetGrant(
-          request("file_edit", "/workspace/reports/drafts/.././report.txt"),
-          grant,
-        ),
-    ).toBe(true);
-    expect(
-      grant &&
-        matchesAgentApprovalTargetGrant(
-          request("file_append", "/workspace/reports/report.txt.bak"),
-          grant,
-        ),
-    ).toBe(false);
-    expect(
-      grant &&
-        matchesAgentApprovalTargetGrant(
-          request("file_edit", "/workspace/reports/../report.txt"),
-          grant,
-        ),
-    ).toBe(false);
+  it("requires fresh file_write approval and invalidates old grants", () => {
+    expectFileOperationRequiresFreshApproval("file_write");
   });
 
-  it("rejects surrounding path whitespace while preserving internal spaces", () => {
-    expect(
-      deriveAgentApprovalTargetGrant(
-        request("file_write", " /workspace/report.txt"),
-      ),
-    ).toBeNull();
-    expect(
-      deriveAgentApprovalTargetGrant(
-        request("file_write", "/workspace/report.txt "),
-      ),
-    ).toBeNull();
-    expect(
-      deriveAgentApprovalTargetGrant(
-        request("file_write", "/workspace/project files/report.txt"),
-      ),
-    ).toMatchObject({
-      kind: "file_change",
-      path: "/workspace/project files/report.txt",
-    });
+  it("requires fresh file_append approval and invalidates old grants", () => {
+    expectFileOperationRequiresFreshApproval("file_append");
   });
 
-  it("normalizes Windows paths while keeping sibling and traversal targets separate", () => {
-    const grant = deriveAgentApprovalTargetGrant(
-      request("file_write", String.raw`C:\workspace\reports\report.txt`),
-    );
-
-    expect(grant).toMatchObject({
-      kind: "file_change",
-      path: "C:/workspace/reports/report.txt",
-      pathFlavor: "windows",
-    });
-    expect(
-      grant &&
-        matchesAgentApprovalTargetGrant(
-          request(
-            "file_edit",
-            String.raw`c:\workspace\reports\drafts\..\report.txt`,
-          ),
-          grant,
-        ),
-    ).toBe(true);
-    expect(
-      grant &&
-        matchesAgentApprovalTargetGrant(
-          request("file_append", "C:/workspace/reports/report.txt.bak"),
-          grant,
-        ),
-    ).toBe(false);
-    expect(
-      grant &&
-        matchesAgentApprovalTargetGrant(
-          request("file_edit", String.raw`C:\workspace\reports\..\report.txt`),
-          grant,
-        ),
-    ).toBe(false);
+  it("requires fresh file_edit approval and invalidates old grants", () => {
+    expectFileOperationRequiresFreshApproval("file_edit");
   });
 
   it("keeps terminal interaction grants within one PTY session and action", () => {

--- a/lib/chat/agent-approval-grants.ts
+++ b/lib/chat/agent-approval-grants.ts
@@ -58,6 +58,8 @@ const SHELL_CONTROL_CHARACTERS = new Set([
 
 const SHELL_DYNAMIC_CHARACTERS = new Set([
   "$",
+  "%",
+  "^",
   "*",
   "?",
   "[",
@@ -98,6 +100,8 @@ const NON_REUSABLE_COMMAND_WRAPPERS = new Set([
   "busybox.exe",
   "cmd",
   "cmd.exe",
+  "command.com",
+  "call",
   "command",
   "csh",
   "csh.exe",
@@ -119,15 +123,27 @@ const NON_REUSABLE_COMMAND_WRAPPERS = new Set([
   "sh",
   "sh.exe",
   "sudo",
+  "start",
   "tcsh",
   "tcsh.exe",
   "xargs",
+  "wsl",
+  "wsl.exe",
   "zsh",
   "zsh.exe",
 ]);
 
 const isShellWhitespace = (character: string): boolean =>
   character === " " || character === "\t";
+
+const getRawExecutableBasename = (command: string): string | null => {
+  const match = /^\s*(?:"([^"]+)"|'([^']+)'|(\S+))/.exec(command);
+  const rawExecutable = match?.[1] ?? match?.[2] ?? match?.[3];
+  if (!rawExecutable) return null;
+  return (
+    rawExecutable.replace(/\\/g, "/").split("/").pop()?.toLowerCase() ?? null
+  );
+};
 
 /**
  * Parses a static shell command into argv. Any syntax that could introduce
@@ -157,6 +173,10 @@ export const parseStaticCommandArgv = (command: string): string[] | null => {
     if (quote === "single") {
       if (character === "'") {
         quote = null;
+      } else if (character === "%" || character === "!" || character === "^") {
+        // Single quotes are not quoting characters for cmd.exe. Reject
+        // syntax that can still expand or escape on the Windows fallback.
+        return null;
       } else {
         token += character;
       }
@@ -168,7 +188,14 @@ export const parseStaticCommandArgv = (command: string): string[] | null => {
         quote = null;
         continue;
       }
-      if (character === "$") return null;
+      if (
+        character === "$" ||
+        character === "%" ||
+        character === "!" ||
+        character === "^"
+      ) {
+        return null;
+      }
       if (character === "\\") {
         const nextCharacter = command[index + 1];
         if (
@@ -231,103 +258,23 @@ export const parseStaticCommandArgv = (command: string): string[] | null => {
   const executable = argv[0];
   if (!executable) return null;
   if (/^[A-Za-z_][A-Za-z0-9_]*\+?=/.test(executable)) return null;
-  if (NON_EXECUTABLE_SHELL_TOKENS.has(executable)) return null;
+  if (NON_EXECUTABLE_SHELL_TOKENS.has(executable.toLowerCase())) return null;
   const executableBasename = executable
     .replace(/\\/g, "/")
     .split("/")
     .pop()
     ?.toLowerCase();
+  const rawExecutableBasename = getRawExecutableBasename(command);
   if (
-    executableBasename &&
-    NON_REUSABLE_COMMAND_WRAPPERS.has(executableBasename)
+    (executableBasename &&
+      NON_REUSABLE_COMMAND_WRAPPERS.has(executableBasename)) ||
+    (rawExecutableBasename &&
+      NON_REUSABLE_COMMAND_WRAPPERS.has(rawExecutableBasename))
   ) {
     return null;
   }
 
   return argv;
-};
-
-const normalizePathSegments = (
-  segments: string[],
-  absolute: boolean,
-): string[] => {
-  const normalized: string[] = [];
-
-  for (const segment of segments) {
-    if (!segment || segment === ".") continue;
-    if (segment === "..") {
-      const previous = normalized[normalized.length - 1];
-      if (previous && previous !== "..") {
-        normalized.pop();
-      } else if (!absolute) {
-        normalized.push(segment);
-      }
-      continue;
-    }
-    normalized.push(segment);
-  }
-
-  return normalized;
-};
-
-const normalizeWindowsPath = (
-  rawPath: string,
-): { path: string; pathFlavor: "windows" } | null => {
-  const slashPath = rawPath.replace(/\\/g, "/");
-  if (/^\/\/[?.]\//.test(slashPath)) return null;
-
-  if (/^\/\//.test(slashPath)) {
-    const segments = slashPath.slice(2).split("/").filter(Boolean);
-    if (segments.length < 2) return null;
-    const [server, share, ...rest] = segments;
-    const normalized = normalizePathSegments(rest, true);
-    return {
-      path: `//${server}/${share}${normalized.length ? `/${normalized.join("/")}` : ""}`,
-      pathFlavor: "windows",
-    };
-  }
-
-  const driveMatch = /^([A-Za-z]):(.*)$/.exec(slashPath);
-  if (driveMatch) {
-    const drive = driveMatch[1].toUpperCase();
-    const suffix = driveMatch[2];
-    const absolute = suffix.charAt(0) === "/";
-    const normalized = normalizePathSegments(suffix.split("/"), absolute);
-    const tail = normalized.join("/");
-    return {
-      path: absolute
-        ? `${drive}:/${tail}`.replace(/\/$/, tail ? "" : "/")
-        : `${drive}:${tail || "."}`,
-      pathFlavor: "windows",
-    };
-  }
-
-  const absolute = slashPath.charAt(0) === "/";
-  const normalized = normalizePathSegments(slashPath.split("/"), absolute);
-  return {
-    path: absolute
-      ? `/${normalized.join("/")}` || "/"
-      : normalized.join("/") || ".",
-    pathFlavor: "windows",
-  };
-};
-
-export const normalizeAgentApprovalFilePath = (
-  path: string,
-): { path: string; pathFlavor: "posix" | "windows" } | null => {
-  if (!path || path !== path.trim() || path.includes("\0")) return null;
-
-  const isWindowsPath = /^[A-Za-z]:/.test(path) || path.includes("\\");
-  if (isWindowsPath) return normalizeWindowsPath(path);
-
-  const absolute = path.charAt(0) === "/";
-  const normalized = normalizePathSegments(path.split("/"), absolute);
-  return {
-    path: absolute
-      ? `/${normalized.join("/")}` || "/"
-      : normalized.join("/") || ".",
-    pathFlavor: "posix",
-  };
 };
 
 const parseTerminalInteraction = (
@@ -401,14 +348,10 @@ export const deriveAgentApprovalTargetGrant = (
     request.operation === "file_append" ||
     request.operation === "file_edit"
   ) {
-    const normalized = normalizeAgentApprovalFilePath(request.target);
-    return normalized
-      ? {
-          kind: "file_change",
-          targetPrefix: normalized.path,
-          ...normalized,
-        }
-      : null;
+    // Reusable file grants cannot be bound to a canonical filesystem object
+    // across E2B, Local, and Desktop backends. Require a fresh approval for
+    // every mutation instead of treating lexical path equality as authority.
+    return null;
   }
 
   // Older persisted prompts may not include operation. This inference is only
@@ -419,14 +362,7 @@ export const deriveAgentApprovalTargetGrant = (
     return deriveTerminalCommandGrant(request.target, request.prefixRule);
   }
   if (request.kind === "file") {
-    const normalized = normalizeAgentApprovalFilePath(request.target);
-    return normalized
-      ? {
-          kind: "file_change",
-          targetPrefix: normalized.path,
-          ...normalized,
-        }
-      : null;
+    return null;
   }
 
   return null;
@@ -447,6 +383,10 @@ export const matchesAgentApprovalTargetGrant = (
   request: AgentApprovalGrantSource,
   grant: AgentApprovalTargetGrant,
 ): boolean => {
+  // Invalidate file grants persisted by older workers. Lexical paths are not
+  // stable identities across symlinks, junctions, or backend operations.
+  if (grant.kind === "file_change") return false;
+
   if (
     request.operation === "terminal_execute" &&
     grant.kind === "terminal_command"
@@ -481,11 +421,5 @@ export const matchesAgentApprovalTargetGrant = (
       candidate.sessionId === grant.sessionId
     );
   }
-  if (candidate.kind === "file_change" && grant.kind === "file_change") {
-    return (
-      candidate.pathFlavor === grant.pathFlavor && candidate.path === grant.path
-    );
-  }
-
   return false;
 };

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -89,6 +89,8 @@ export class ChatSDKError extends Error {
 }
 
 const STREAM_ERROR_PREFIX = "__HACKERAI_CHAT_SDK_ERROR__:";
+const GENERIC_STREAM_ERROR_MESSAGE =
+  "Something went wrong. Please try again later.";
 const MALFORMED_STREAM_ERROR_MESSAGE =
   "Something went wrong while receiving the response. Please try again.";
 
@@ -113,8 +115,15 @@ function createMalformedStreamError(): ChatSDKError {
  */
 export function serializeChatSDKErrorForStream(error: ChatSDKError): string {
   const code: ErrorCode = `${error.type}:${error.surface}`;
+  const visibility = visibilityBySurface[error.surface];
 
   try {
+    if (visibility !== "response") {
+      return `${STREAM_ERROR_PREFIX}${JSON.stringify({
+        code: "bad_request:stream" satisfies ErrorCode,
+        cause: GENERIC_STREAM_ERROR_MESSAGE,
+      })}`;
+    }
     return `${STREAM_ERROR_PREFIX}${JSON.stringify({
       code,
       cause: typeof error.cause === "string" ? error.cause : undefined,

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -286,7 +286,7 @@ async fn wait_with_output_or_kill_on_timeout(
         Ok(output) => output,
         Err(_) => {
             if let Some(pid) = child_pid {
-                platform::cancel_process_tree(pid).await;
+                let _ = platform::cancel_process_tree(pid).await;
             }
             stdout_abort.abort();
             stderr_abort.abort();
@@ -1155,8 +1155,7 @@ async fn cancel_stream_command(
         .copied();
 
     if let Some(pid) = pid {
-        platform::cancel_process_tree(pid).await;
-        Ok(true)
+        Ok(platform::cancel_process_tree(pid).await)
     } else {
         Ok(false)
     }

--- a/packages/desktop/src-tauri/src/platform.rs
+++ b/packages/desktop/src-tauri/src/platform.rs
@@ -224,20 +224,50 @@ fn terminate_process_group(pid: u32, signal: libc::c_int) {
     }
 }
 
-/// Best-effort external cancellation for a streaming command by process id.
-pub async fn cancel_process_tree(pid: u32) {
+/// Cancel a streaming command and report success only after the OS confirms
+/// that the process tree is no longer running.
+pub async fn cancel_process_tree(pid: u32) -> bool {
     #[cfg(unix)]
     {
         terminate_process_group(pid, libc::SIGTERM);
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        for _ in 0..10 {
+            if !process_group_is_running(pid) {
+                return true;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
         terminate_process_group(pid, libc::SIGKILL);
+        for _ in 0..20 {
+            if !process_group_is_running(pid) {
+                return true;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        return !process_group_is_running(pid);
     }
 
     #[cfg(windows)]
     {
-        let _ = tokio::process::Command::new("taskkill")
+        return tokio::process::Command::new("taskkill")
             .args(["/PID", &pid.to_string(), "/T", "/F"])
             .output()
-            .await;
+            .await
+            .map(|output| output.status.success())
+            .unwrap_or(false);
     }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        false
+    }
+}
+
+#[cfg(unix)]
+fn process_group_is_running(pid: u32) -> bool {
+    let pid = pid as libc::pid_t;
+    let result = unsafe { libc::kill(-pid, 0) };
+    if result == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
 }

--- a/packages/local/src/__tests__/command-cancellation.test.ts
+++ b/packages/local/src/__tests__/command-cancellation.test.ts
@@ -49,6 +49,15 @@ describe("confirmProcessTermination", () => {
     ).resolves.toBe(false);
   });
 
+  it("reports false when the child emits an error", async () => {
+    const proc = new FakeProcess();
+    const confirmation = confirmProcessTermination(proc, jest.fn());
+
+    proc.emit("error", new Error("signal delivery failed"));
+
+    await expect(confirmation).resolves.toBe(false);
+  });
+
   it("preserves already-confirmed terminal state", async () => {
     const proc = new FakeProcess();
     proc.exitCode = 0;

--- a/packages/local/src/__tests__/command-cancellation.test.ts
+++ b/packages/local/src/__tests__/command-cancellation.test.ts
@@ -1,0 +1,62 @@
+import { EventEmitter } from "events";
+import {
+  confirmProcessTermination,
+  LOCAL_CANCEL_CONFIRMATION_TIMEOUT_MS,
+} from "../command-cancellation";
+
+class FakeProcess extends EventEmitter {
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+}
+
+describe("confirmProcessTermination", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it("does not confirm until the child reaches a terminal state", async () => {
+    const proc = new FakeProcess();
+    const requestTermination = jest.fn();
+    const confirmation = confirmProcessTermination(proc, requestTermination);
+    let settled = false;
+    void confirmation.then(() => {
+      settled = true;
+    });
+
+    await jest.advanceTimersByTimeAsync(0);
+    expect(requestTermination).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+
+    proc.emit("close", null, "SIGTERM");
+    await expect(confirmation).resolves.toBe(true);
+  });
+
+  it("reports false when no terminal acknowledgement arrives", async () => {
+    const proc = new FakeProcess();
+    const confirmation = confirmProcessTermination(proc, jest.fn());
+
+    jest.advanceTimersByTime(LOCAL_CANCEL_CONFIRMATION_TIMEOUT_MS + 1);
+
+    await expect(confirmation).resolves.toBe(false);
+  });
+
+  it("reports false when requesting termination throws", async () => {
+    const proc = new FakeProcess();
+
+    await expect(
+      confirmProcessTermination(proc, () => {
+        throw new Error("signal failed");
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("preserves already-confirmed terminal state", async () => {
+    const proc = new FakeProcess();
+    proc.exitCode = 0;
+    const requestTermination = jest.fn();
+
+    await expect(
+      confirmProcessTermination(proc, requestTermination),
+    ).resolves.toBe(true);
+    expect(requestTermination).not.toHaveBeenCalled();
+  });
+});

--- a/packages/local/src/command-cancellation.ts
+++ b/packages/local/src/command-cancellation.ts
@@ -26,16 +26,17 @@ export function confirmProcessTermination(
       if (settled) return;
       settled = true;
       clearTimeout(timeoutId);
-      proc.off("close", handleTerminal);
-      proc.off("error", handleTerminal);
+      proc.off("close", handleClose);
+      proc.off("error", handleError);
       resolve(confirmed);
     };
-    const handleTerminal = () => finish(true);
+    const handleClose = () => finish(true);
+    const handleError = () => finish(false);
     const timeoutId = setTimeout(() => finish(false), timeoutMs);
     timeoutId.unref?.();
 
-    proc.once("close", handleTerminal);
-    proc.once("error", handleTerminal);
+    proc.once("close", handleClose);
+    proc.once("error", handleError);
     try {
       requestTermination();
     } catch {

--- a/packages/local/src/command-cancellation.ts
+++ b/packages/local/src/command-cancellation.ts
@@ -1,0 +1,45 @@
+import type { ChildProcess } from "child_process";
+
+export const LOCAL_CANCEL_CONFIRMATION_TIMEOUT_MS = 4000;
+
+type TerminationObservable = Pick<
+  ChildProcess,
+  "exitCode" | "signalCode" | "once" | "off"
+>;
+
+/**
+ * A signal request is not a termination acknowledgement. Wait for Node to
+ * observe the child reaching a terminal state before reporting success.
+ */
+export function confirmProcessTermination(
+  proc: TerminationObservable,
+  requestTermination: () => void,
+  timeoutMs = LOCAL_CANCEL_CONFIRMATION_TIMEOUT_MS,
+): Promise<boolean> {
+  if (proc.exitCode !== null || proc.signalCode !== null) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (confirmed: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      proc.off("close", handleTerminal);
+      proc.off("error", handleTerminal);
+      resolve(confirmed);
+    };
+    const handleTerminal = () => finish(true);
+    const timeoutId = setTimeout(() => finish(false), timeoutMs);
+    timeoutId.unref?.();
+
+    proc.once("close", handleTerminal);
+    proc.once("error", handleTerminal);
+    try {
+      requestTermination();
+    } catch {
+      finish(false);
+    }
+  });
+}

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -29,6 +29,7 @@ import {
   ProcessRunResult,
   isPtyAvailable,
 } from "./process-runner";
+import { confirmProcessTermination } from "./command-cancellation";
 
 const DEFAULT_SHELL = getDefaultShell(os.platform());
 
@@ -120,6 +121,12 @@ interface CentrifugoErrorMessage {
   type: "error";
   commandId: string;
   message: string;
+}
+
+interface CentrifugoCommandCancelResultMessage {
+  type: "command_cancel_result";
+  commandId: string;
+  canceled: boolean;
 }
 
 // --- PTY incoming message types ---
@@ -217,6 +224,7 @@ type CentrifugoOutgoingMessage =
   | CentrifugoStderrMessage
   | CentrifugoExitMessage
   | CentrifugoErrorMessage
+  | CentrifugoCommandCancelResultMessage
   | CentrifugoPtyReadyMessage
   | CentrifugoPtyDataMessage
   | CentrifugoPtyExitMessage
@@ -508,7 +516,15 @@ class LocalSandboxClient {
           break;
 
         case "command_cancel":
-          this.handleCommandCancel(message as CentrifugoCommandCancelMessage);
+          this.handleCommandCancel(
+            message as CentrifugoCommandCancelMessage,
+          ).catch((error: unknown) => {
+            console.error(
+              chalk.red(
+                `[CMD] Failed to handle cancellation: ${error instanceof Error ? error.message : String(error)}`,
+              ),
+            );
+          });
           break;
 
         case "pty_create":
@@ -672,12 +688,20 @@ class LocalSandboxClient {
     }
   }
 
-  private handleCommandCancel(msg: CentrifugoCommandCancelMessage): void {
+  private async handleCommandCancel(
+    msg: CentrifugoCommandCancelMessage,
+  ): Promise<void> {
     const proc = this.activeStreamCommands.get(msg.commandId);
-    if (!proc) {
-      return;
-    }
-    this.terminateProcessTree(proc);
+    const canceled = proc
+      ? await confirmProcessTermination(proc, () =>
+          this.terminateProcessTree(proc),
+        )
+      : false;
+    await this.publishToChannel({
+      type: "command_cancel_result",
+      commandId: msg.commandId,
+      canceled,
+    });
   }
 
   private terminateProcessTree(proc: ChildProcess): void {

--- a/trigger/__tests__/agent-long-post-wait-authorization.test.ts
+++ b/trigger/__tests__/agent-long-post-wait-authorization.test.ts
@@ -26,7 +26,7 @@ describe("agent-long post-wait authorization contract", () => {
       approvedBranch,
     );
     const approvedReturn = taskSource.indexOf(
-      "return { approved: true, approvalId }",
+      "return { approved: true, approvalId, sandboxIdentity }",
       deriveGrant,
     );
 
@@ -34,6 +34,14 @@ describe("agent-long post-wait authorization contract", () => {
     expect(revalidate).toBeGreaterThan(approvedBranch);
     expect(deriveGrant).toBeGreaterThan(revalidate);
     expect(approvedReturn).toBeGreaterThan(deriveGrant);
+  });
+
+  it("carries the checked sandbox identity in every approval success", () => {
+    expect(
+      taskSource.match(
+        /return \{ approved: true, approvalId, sandboxIdentity \};/g,
+      ),
+    ).toHaveLength(2);
   });
 
   it("excludes suspension time and reacquires free concurrency after checks", () => {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -490,14 +490,14 @@ const buildAgentToolApprovalRequester = ({
           .set("approvalToolName", request.toolName)
           .set("approvalOperation", request.operation);
         triggerLogger.info("[agent-long] tool approval reused", {
-          chatId,
-          userId,
+          event: "agent_tool_approval_reused",
+          service: "agent-long",
           runId,
           approvalId,
+          tool_call_id: request.toolCallId,
           tool_name: request.toolName,
           operation: request.operation,
           target_kind: existingGrant.kind,
-          target_prefix: existingGrant.targetPrefix,
         });
         return { approved: true, approvalId };
       }
@@ -551,13 +551,13 @@ const buildAgentToolApprovalRequester = ({
       } as AgentLongUiStreamPart);
 
       triggerLogger.info("[agent-long] waiting for tool approval", {
-        chatId,
-        userId,
+        event: "agent_tool_approval_waiting",
+        service: "agent-long",
         runId,
         approvalId,
+        tool_call_id: request.toolCallId,
         tool_name: request.toolName,
         operation: request.operation,
-        target: request.target.slice(0, 200),
       });
 
       const session = triggerSessions.open(approvalSessionId);
@@ -733,29 +733,29 @@ const buildAgentToolApprovalRequester = ({
             }
             metadata
               .set("approvalGrant", "target_prefix")
-              .set("approvalTargetKind", approvedTargetGrant.kind)
-              .set("approvalTargetPrefix", approvedTargetGrant.targetPrefix);
+              .set("approvalTargetKind", approvedTargetGrant.kind);
           }
           triggerLogger.info("[agent-long] tool approval granted", {
-            chatId,
-            userId,
+            event: "agent_tool_approval_granted",
+            service: "agent-long",
             runId,
             approvalId,
+            tool_call_id: request.toolCallId,
             tool_name: request.toolName,
             operation: request.operation,
             requested_grant: next.output.grant,
             grant: approvedTargetGrant ? "target_prefix" : "full_access",
             target_kind: approvedTargetGrant?.kind,
-            target_prefix: approvedTargetGrant?.targetPrefix,
           });
           return { approved: true, approvalId };
         }
 
         triggerLogger.info("[agent-long] tool approval denied", {
-          chatId,
-          userId,
+          event: "agent_tool_approval_denied",
+          service: "agent-long",
           runId,
           approvalId,
+          tool_call_id: request.toolCallId,
           tool_name: request.toolName,
           operation: request.operation,
         });

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -499,7 +499,7 @@ const buildAgentToolApprovalRequester = ({
           operation: request.operation,
           target_kind: existingGrant.kind,
         });
-        return { approved: true, approvalId };
+        return { approved: true, approvalId, sandboxIdentity };
       }
 
       if (!approvalSessionId) {
@@ -747,7 +747,7 @@ const buildAgentToolApprovalRequester = ({
             grant: approvedTargetGrant ? "target_prefix" : "full_access",
             target_kind: approvedTargetGrant?.kind,
           });
-          return { approved: true, approvalId };
+          return { approved: true, approvalId, sandboxIdentity };
         }
 
         triggerLogger.info("[agent-long] tool approval denied", {

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -278,6 +278,7 @@ export type AgentToolApprovalResult =
   | {
       approved: true;
       approvalId: string;
+      sandboxIdentity: AgentApprovalSandboxIdentity;
     }
   | {
       approved: false;


### PR DESCRIPTION
## Summary
- harden reusable Agent approval grants by rejecting dynamic Windows shell syntax/wrappers and requiring one-time approval for file write, append, and edit operations
- bind each successful Agent approval to the exact Desktop connection or E2B environment checked by the worker, rejecting a replacement connection before terminal or file execution
- bind local/Desktop cancellation success to an explicit native termination acknowledgement while retaining uncertain sessions for retry
- limit Enter approval to the focused Allow control, remove raw approval targets from Trigger telemetry, and serialize log-only Durable Agent errors generically to clients

## Root causes and user impact
- reusable command grants classified the scanned command text without conservatively rejecting Windows environment expansion and shell-wrapper equivalents
- reusable file grants compared lexical paths even though E2B, Local, and Desktop backends cannot bind that string to the same canonical filesystem object across the later sink operation
- the worker rechecked Desktop A after approval but returned no sandbox identity; terminal and file tools independently reacquired the current sandbox, so a precisely timed same-account replacement with Desktop B could receive the approved operation
- approval logs and run metadata persisted raw target or prefix material
- local cancellation treated publish/request success as process termination and could discard command tracking after a false or missing acknowledgement
- a document-wide Enter listener approved from body or unrelated focus
- log-only ChatSDKError diagnostics were serialized into the client stream

The Desktop replacement race is calibrated as Medium at most, not High: it is same-account and requires a narrow reconnect/replacement interval. It is still a real boundary violation because the repository explicitly scopes reusable approvals to `connection:<connectionId>`. The file compatibility tradeoff is intentional: file write, append, and edit now require fresh approval because the current cross-backend contract cannot prove canonical object identity through symlinks, junctions, and TOCTOU windows.

## Validation
- `corepack pnpm jest app/components/ChatInput/__tests__/AgentApprovalPrompt.test.tsx app/services/__tests__/desktop-sandbox-bridge.test.ts lib/__tests__/errors.test.ts lib/ai/tools/__tests__/run-terminal-cmd.test.ts lib/ai/tools/__tests__/interact-terminal-session.test.ts lib/ai/tools/__tests__/file.test.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts lib/api/__tests__/agent-long-contracts.test.ts lib/chat/__tests__/agent-approval-grants.test.ts packages/local/src/__tests__/command-cancellation.test.ts trigger/__tests__/agent-long-post-wait-authorization.test.ts --runInBand --silent` — 12 suites, 306 tests
- `corepack pnpm jest app/components/ChatInput/__tests__ app/services/__tests__ lib/__tests__ lib/ai/tools/__tests__ lib/ai/tools/utils/__tests__ lib/api/__tests__ lib/chat/__tests__ packages/local/src/__tests__ trigger/__tests__ --runInBand --silent` — 86 suites, 1,085 tests
- `corepack pnpm typecheck`
- `corepack pnpm lint` — 0 errors; 6 pre-existing warnings
- `corepack pnpm --dir packages/local build`
- changed TypeScript Prettier check and `git diff --check`

Exploit reruns cover COMSPEC case variants, SystemRoot/windir wrappers, caret-obfuscated cmd, cmd/cmd.exe, command.com, call, start, WSL, and quoted/unquoted Windows paths; direct `ping` prefix reuse remains valid. Separate file write/append/edit tests reject both new and legacy reusable grants. Cancellation tests cover publish rejection, native false, missing acknowledgement, retained tracking/retry, and confirmed success. Error tests prove generic client text with intact server diagnostics. Desktop binding tests prove terminal execution, interactive PTY creation, and file write approved on A cannot reach B, while same-connection execution remains valid.

## Remaining validation gaps
- Windows runtime classification and Desktop process-tree behavior need a Windows Local/Desktop smoke test. All platform-independent parser/grant tests pass.
- The connection-race regression uses in-memory sandbox-manager doubles at the real tool acquisition boundary; no live authenticated two-Desktop reconnect timing test touched Convex or Centrifugo resources.
- Rust tooling is unavailable in this worktree, so the Tauri Rust changes were reviewed but not compiled locally.
- Chrome loaded the local app without console errors, but an authenticated live Agent approval card was unavailable without touching live Trigger resources. The component interaction tests cover focused Allow Enter and body/unrelated-focus rejection.

## Manual verification
1. **Windows Local/Desktop:** approve a direct reusable command such as `ping`, confirm another matching direct command reuses it, then confirm `%COMSPEC%`, case variants, environment-root cmd paths, cmd/cmd.exe, PowerShell, WSL, and wrapper variants require fresh approval.
2. **Desktop replacement:** begin approval on Desktop A, approve it, then replace/reconnect as Desktop B before execution. Confirm the operation is rejected with retry guidance and does not execute on B; retry and approve for B, then confirm it executes there.
3. **File grants:** approve write, append, and edit once each; confirm the UI offers no reusable scope and the next operation asks again. Exercise a symlink/junction plus `..\\` destination and confirm it cannot reuse an older file grant.
4. **Cancellation:** start a long-lived child tree in Local and Desktop, cancel it, and confirm success appears only after the child tree exits. Simulate native/transport failure and confirm an uncertain failure plus retained resumable session, then retry termination.
5. **Agent approval keyboard:** in Google Chrome, open an authenticated approval card. Press Enter with body/unrelated focus (no approval), then focus **Allow once** and press Enter (one approval); verify click and keyboard accessibility.
6. **Durable error display:** trigger a safe test error with log-only diagnostics; confirm the client shows generic text while bounded server logs retain the internal diagnostic and the client payload contains no operation/request/failure/chat/user metadata.

No production service, live Trigger resource, billing provider, real user data, or public target was used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added acknowledgement-based command cancellation results across local, desktop, and sandbox flows.
  * Introduced a sandbox cancellation “readiness” hook for coordinated abort/confirmation.
  * Added sandbox identity to successful tool approvals to keep subsequent tool execution consistent.

* **Bug Fixes**
  * Prevented approval submission when Enter is pressed outside the focused approval control.
  * Tightened terminal/file approval validation (including Windows shell variants and file-operation freshness).
  * Fixed cancellation result publication so the desktop side always responds.

* **Security**
  * Reduced streamed error detail and reshaped approval telemetry to avoid exposing sensitive diagnostics/targets.

* **Tests**
  * Expanded cancellation, keyboard/approval, and serialization regression coverage with new edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->