### PR TITLE
Improve cost-neutral agent run reliability

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1392,6 +1392,9 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(
       /USER_CORRECTABLE_AGENT_LONG_ERROR_CATEGORIES[\s\S]*"invalid_image_input"/,
     );
+    expect(taskSrc).toMatch(
+      /isProviderApiError\(error\)\s*&&\s*!isInvalidImageInputError\(error\)/,
+    );
   });
 
   test("recognizes every observed Trigger S2 terminal signature", () => {
@@ -1400,24 +1403,27 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(/Request timeout after \\d\+ms/);
   });
 
-  test("final chat metadata failure cannot discard a saved generation", () => {
-    const finalizationBlockIdx = taskSrc.lastIndexOf(
-      "const generatedTitle = await titlePromise",
-    );
-    const updateIdx = taskSrc.indexOf(
-      "await updateChat({",
-      finalizationBlockIdx,
-    );
-    const finalizationCatchIdx = taskSrc.indexOf(
-      "agent_long_chat_metadata_update_failed",
-      updateIdx,
-    );
-    const saveMessageIdx = taskSrc.indexOf("await saveMessage({", updateIdx);
+  test("chat metadata failure cannot discard main or fallback generations", () => {
+    const finalizationBlockIndexes = [
+      ...taskSrc.matchAll(/const generatedTitle = await titlePromise/g),
+    ].map((match) => match.index);
 
-    expect(finalizationBlockIdx).toBeGreaterThan(-1);
-    expect(updateIdx).toBeGreaterThan(finalizationBlockIdx);
-    expect(finalizationCatchIdx).toBeGreaterThan(updateIdx);
-    expect(saveMessageIdx).toBeGreaterThan(finalizationCatchIdx);
+    expect(finalizationBlockIndexes).toHaveLength(2);
+    for (const finalizationBlockIdx of finalizationBlockIndexes) {
+      const updateIdx = taskSrc.indexOf(
+        "await updateChat({",
+        finalizationBlockIdx,
+      );
+      const guardedFailureIdx = taskSrc.indexOf(
+        "recordAgentLongChatMetadataUpdateFailure(",
+        updateIdx,
+      );
+      const saveMessageIdx = taskSrc.indexOf("await saveMessage({", updateIdx);
+
+      expect(updateIdx).toBeGreaterThan(finalizationBlockIdx);
+      expect(guardedFailureIdx).toBeGreaterThan(updateIdx);
+      expect(saveMessageIdx).toBeGreaterThan(guardedFailureIdx);
+    }
     expect(taskSrc).toMatch(/chatFinalizationStatus/);
   });
 

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -978,6 +978,27 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(readerLoopIdx).toBeGreaterThan(immediateModelHeartbeatIdx);
   });
 
+  test("sanitizes every model stream chunk before the final Trigger realtime pipe", () => {
+    const wrapperIdx = taskSrc.indexOf("const withAgentLongStreamHeartbeat");
+    const sanitizerIdx = taskSrc.indexOf(
+      "sanitizeAgentLongRealtimeChunk(",
+      wrapperIdx,
+    );
+    const mergeIdx = taskSrc.indexOf(
+      "writer.merge(\n              withAgentLongStreamHeartbeat(",
+      sanitizerIdx,
+    );
+    const finalPipeIdx = taskSrc.indexOf(
+      "agentUiStream.pipe(uiStream)",
+      mergeIdx,
+    );
+
+    expect(wrapperIdx).toBeGreaterThan(-1);
+    expect(sanitizerIdx).toBeGreaterThan(wrapperIdx);
+    expect(mergeIdx).toBeGreaterThan(sanitizerIdx);
+    expect(finalPipeIdx).toBeGreaterThan(mergeIdx);
+  });
+
   test("both Agent backends route provider finishes through the shared auto-continue helper", () => {
     for (const source of [chatHandlerSrc, taskSrc]) {
       expect(source).toMatch(/getAgentAutoContinueStopSource\(\{/);
@@ -1363,6 +1384,41 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(handledReturnGuardIdx).toBeGreaterThan(syntheticFlushIdx);
     expect(returnIdx).toBeGreaterThan(handledReturnGuardIdx);
     expect(throwIdx).toBeGreaterThan(returnIdx);
+  });
+
+  test("invalid provider image URLs are handled as user-correctable input", () => {
+    expect(taskSrc).toMatch(/isInvalidImageInputError/);
+    expect(taskSrc).toMatch(/"invalid_image_input"/);
+    expect(taskSrc).toMatch(
+      /USER_CORRECTABLE_AGENT_LONG_ERROR_CATEGORIES[\s\S]*"invalid_image_input"/,
+    );
+  });
+
+  test("recognizes every observed Trigger S2 terminal signature", () => {
+    expect(taskSrc).toMatch(/Connection timeout after \\d\+ms/);
+    expect(taskSrc).toMatch(/cs:\[a-z0-9\]\+/);
+    expect(taskSrc).toMatch(/Request timeout after \\d\+ms/);
+  });
+
+  test("final chat metadata failure cannot discard a saved generation", () => {
+    const finalizationBlockIdx = taskSrc.lastIndexOf(
+      "const generatedTitle = await titlePromise",
+    );
+    const updateIdx = taskSrc.indexOf(
+      "await updateChat({",
+      finalizationBlockIdx,
+    );
+    const finalizationCatchIdx = taskSrc.indexOf(
+      "agent_long_chat_metadata_update_failed",
+      updateIdx,
+    );
+    const saveMessageIdx = taskSrc.indexOf("await saveMessage({", updateIdx);
+
+    expect(finalizationBlockIdx).toBeGreaterThan(-1);
+    expect(updateIdx).toBeGreaterThan(finalizationBlockIdx);
+    expect(finalizationCatchIdx).toBeGreaterThan(updateIdx);
+    expect(saveMessageIdx).toBeGreaterThan(finalizationCatchIdx);
+    expect(taskSrc).toMatch(/chatFinalizationStatus/);
   });
 
   test("empty rehydrated history is classified separately from oversized input", () => {

--- a/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
+++ b/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
@@ -901,6 +901,25 @@ describe("compactMessageForStorage", () => {
     expect(part.output).toBeUndefined();
   });
 
+  it("drops an oversized tool part instead of storing an invalid type-only part", () => {
+    const message = makeAssistantMessage([
+      {
+        type: "tool-run_terminal_cmd",
+        toolCallId: "call-streaming",
+        state: "input-streaming",
+        input: { command: "x".repeat(5_000) },
+      } as any,
+    ]);
+
+    const result = compactMessageForStorage(message, {
+      softLimitBytes: 10,
+      toolOutputTokenBudget: 0,
+    });
+
+    expect(result.afterSizeBytes).toBeLessThanOrEqual(10);
+    expect(result.message.parts).toEqual([]);
+  });
+
   it("compacts protected list_notes output only when required by the hard byte cap", () => {
     const notes = Array.from({ length: 30 }, (_, index) => ({
       note_id: `note-${index}`,

--- a/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
+++ b/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
@@ -877,7 +877,7 @@ describe("compactMessageForStorage", () => {
     expect(newestSavedCommand).toBe(newestCommand);
   });
 
-  it("does not byte-compact unfinished tool calls", () => {
+  it("compacts oversized unfinished tool inputs without changing their state", () => {
     const command = "python -c \"print('still streaming')\" ".repeat(200);
     const message = makeAssistantMessage([
       {
@@ -889,16 +889,70 @@ describe("compactMessageForStorage", () => {
     ]);
 
     const result = compactMessageForStorage(message, {
-      softLimitBytes: 100,
+      softLimitBytes: 180,
       toolOutputTokenBudget: 0,
     });
     const part = result.message.parts[0] as any;
 
-    expect(result.compacted).toBe(false);
-    expect(result.afterSizeBytes).toBe(result.beforeSizeBytes);
+    expect(result.compacted).toBe(true);
+    expect(result.afterSizeBytes).toBeLessThanOrEqual(180);
     expect(part.state).toBe("input-streaming");
-    expect(part.input.command).toBe(command);
+    expect(part.input).toEqual({ __hackeraiStorageTruncated: true });
     expect(part.output).toBeUndefined();
+  });
+
+  it("compacts protected list_notes output only when required by the hard byte cap", () => {
+    const notes = Array.from({ length: 30 }, (_, index) => ({
+      note_id: `note-${index}`,
+      title: `Finding ${index}`,
+      content: `Detailed finding ${index}: ${"evidence ".repeat(500)}`,
+      category: "findings",
+      tags: ["confirmed", "critical"],
+      _creationTime: index,
+      updated_at: index,
+    }));
+    const message = makeAssistantMessage([
+      makeToolPart(
+        "list_notes",
+        { success: true, notes, total_count: notes.length },
+        { category: "findings" },
+      ),
+      { type: "text", text: "I reviewed the saved findings." },
+    ]);
+
+    const result = compactMessageForStorage(message, {
+      softLimitBytes: 40_000,
+      toolOutputTokenBudget: 0,
+    });
+    const listNotesPart = result.message.parts[0] as any;
+
+    expect(result.compacted).toBe(true);
+    expect(result.afterSizeBytes).toBeLessThanOrEqual(40_000);
+    expect(listNotesPart.output.__hackeraiStorageCompacted).toBe(true);
+    expect(listNotesPart.output.notes[0]).toMatchObject({
+      note_id: "note-0",
+      title: "Finding 0",
+      category: "findings",
+    });
+    expect(listNotesPart.output.notes[0].content).toContain(
+      "[truncated for storage]",
+    );
+  });
+
+  it("enforces the byte cap for a single oversized assistant text part", () => {
+    const message = makeAssistantMessage([
+      { type: "text", text: "analysis ".repeat(50_000) },
+    ]);
+
+    const result = compactMessageForStorage(message, {
+      softLimitBytes: 10_000,
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.afterSizeBytes).toBeLessThanOrEqual(10_000);
+    expect((result.message.parts[0] as any).text).toContain(
+      "[truncated for storage]",
+    );
   });
 
   it("compacts oversized reasoning and storage-only status parts", () => {

--- a/lib/chat/compaction/prune-tool-outputs.ts
+++ b/lib/chat/compaction/prune-tool-outputs.ts
@@ -42,10 +42,7 @@ export interface PruneResult {
   toolOutputCount: number;
   /** Why pruning was skipped (null if pruning occurred) */
   skipReason:
-    | "no-tool-outputs"
-    | "within-budget"
-    | "below-minimum-savings"
-    | null;
+    "no-tool-outputs" | "within-budget" | "below-minimum-savings" | null;
 }
 
 export interface StorageCompactionResult<T extends UIMessage = UIMessage> {
@@ -63,7 +60,11 @@ const STORAGE_REASONING_CHAR_BUDGET = 32_000;
 const STORAGE_REASONING_PART_CHAR_LIMIT = 8_000;
 const STORAGE_TOOL_INPUT_STRING_LIMIT = 512;
 const STORAGE_TOOL_INPUT_ARRAY_LIMIT = 20;
+const STORAGE_TOOL_INPUT_OBJECT_KEY_LIMIT = 20;
 const STORAGE_TOOL_INPUT_DEPTH_LIMIT = 3;
+const STORAGE_NOTE_CONTENT_PREVIEW_LIMIT = 512;
+const STORAGE_NOTE_TITLE_LIMIT = 200;
+const STORAGE_NOTE_TAG_LIMIT = 20;
 const STORAGE_COMPACTED_STRING_SUFFIX = "... [truncated for storage]";
 const STORAGE_COMPACTED_REASONING_PREFIX =
   "[Earlier reasoning compacted for storage]\n\n";
@@ -179,6 +180,11 @@ const isCompletedPrunableToolPart = (part: ToolPart): boolean =>
   (part.state === "output-available" || part.state === "output-error") &&
   part.output != null;
 
+const isCompletedToolPart = (part: ToolPart): boolean =>
+  part.type?.startsWith(TOOL_TYPE_PREFIX) &&
+  (part.state === "output-available" || part.state === "output-error") &&
+  part.output != null;
+
 const truncateStorageString = (
   value: string,
   maxLength = STORAGE_TOOL_INPUT_STRING_LIMIT,
@@ -236,25 +242,99 @@ const compactToolInputForStorage = (value: unknown, depth = 0): unknown => {
     return compacted;
   }
 
+  const entries = Object.entries(value as Record<string, unknown>);
   const compacted: Record<string, unknown> = {};
-  for (const [key, childValue] of Object.entries(
-    value as Record<string, unknown>,
+  for (const [key, childValue] of entries.slice(
+    0,
+    STORAGE_TOOL_INPUT_OBJECT_KEY_LIMIT,
   )) {
     compacted[key] = compactToolInputForStorage(childValue, depth + 1);
+  }
+  if (entries.length > STORAGE_TOOL_INPUT_OBJECT_KEY_LIMIT) {
+    compacted.__hackeraiStorageTruncatedFields =
+      entries.length - STORAGE_TOOL_INPUT_OBJECT_KEY_LIMIT;
   }
 
   return compacted;
 };
 
-const compactToolPartForStorage = (part: ToolPart): ToolPart => {
-  if (!isPrunableToolPart(part)) return part;
+const compactNoteForStorage = (value: unknown): unknown => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return compactToolInputForStorage(value);
+  }
+
+  const note = value as Record<string, unknown>;
+  return {
+    note_id: note.note_id,
+    title:
+      typeof note.title === "string"
+        ? truncateStorageString(note.title, STORAGE_NOTE_TITLE_LIMIT)
+        : note.title,
+    content:
+      typeof note.content === "string"
+        ? truncateStorageString(
+            note.content,
+            STORAGE_NOTE_CONTENT_PREVIEW_LIMIT,
+          )
+        : note.content,
+    category: note.category,
+    tags: Array.isArray(note.tags)
+      ? note.tags
+          .slice(0, STORAGE_NOTE_TAG_LIMIT)
+          .map((tag) =>
+            typeof tag === "string" ? truncateStorageString(tag, 100) : tag,
+          )
+      : note.tags,
+    _creationTime: note._creationTime,
+    updated_at: note.updated_at,
+  };
+};
+
+const compactProtectedToolOutputForStorage = (
+  toolName: string,
+  output: unknown,
+): unknown => {
+  if (
+    toolName !== "list_notes" ||
+    !output ||
+    typeof output !== "object" ||
+    Array.isArray(output)
+  ) {
+    return compactToolInputForStorage(output);
+  }
+
+  const listOutput = output as Record<string, unknown>;
+  return {
+    success: listOutput.success,
+    notes: Array.isArray(listOutput.notes)
+      ? listOutput.notes.map(compactNoteForStorage)
+      : listOutput.notes,
+    total_count: listOutput.total_count,
+    message: listOutput.message,
+    error: listOutput.error,
+    __hackeraiStorageCompacted: true,
+  };
+};
+
+const compactToolPartForStorage = (
+  part: ToolPart,
+  { includeProtectedTools = false }: { includeProtectedTools?: boolean } = {},
+): ToolPart => {
+  const toolName = part.type?.startsWith(TOOL_TYPE_PREFIX)
+    ? part.type.slice(TOOL_TYPE_PREFIX.length)
+    : null;
+  if (!toolName || (!includeProtectedTools && PROTECTED_TOOLS.has(toolName))) {
+    return part;
+  }
 
   return {
     ...part,
     input: compactToolInputForStorage(part.input),
-    output: isCompactPlaceholderOutput(part.output)
-      ? part.output
-      : buildPlaceholder(part),
+    output: PROTECTED_TOOLS.has(toolName)
+      ? compactProtectedToolOutputForStorage(toolName, part.output)
+      : isCompactPlaceholderOutput(part.output)
+        ? part.output
+        : buildPlaceholder(part),
   };
 };
 
@@ -364,6 +444,7 @@ const stripStorageOnlyParts = (parts: UIMessage["parts"]): UIMessage["parts"] =>
 const compactToolPartsToByteLimit = (
   parts: UIMessage["parts"],
   softLimitBytes: number,
+  { includeProtectedTools = false }: { includeProtectedTools?: boolean } = {},
 ): {
   parts: UIMessage["parts"];
   compactedCount: number;
@@ -383,9 +464,17 @@ const compactToolPartsToByteLimit = (
     index++
   ) {
     const part = compactedParts[index] as ToolPart;
-    if (!isCompletedPrunableToolPart(part)) continue;
+    if (
+      !(includeProtectedTools
+        ? isCompletedToolPart(part)
+        : isCompletedPrunableToolPart(part))
+    ) {
+      continue;
+    }
 
-    const compactedPart = compactToolPartForStorage(part);
+    const compactedPart = compactToolPartForStorage(part, {
+      includeProtectedTools,
+    });
     if (
       estimateSerializedSizeBytes(compactedPart) >=
       estimateSerializedSizeBytes(part)
@@ -407,6 +496,135 @@ const compactToolPartsToByteLimit = (
     compactedCount,
     afterSizeBytes,
   };
+};
+
+const compactNonCompletedPartForStorage = (
+  part: UIMessage["parts"][number],
+): UIMessage["parts"][number] => {
+  const toolPart = part as ToolPart;
+  if (toolPart.type?.startsWith(TOOL_TYPE_PREFIX)) {
+    return {
+      ...toolPart,
+      input: compactToolInputForStorage(toolPart.input),
+    } as UIMessage["parts"][number];
+  }
+
+  if ("data" in part) {
+    return {
+      ...part,
+      data: compactToolInputForStorage(part.data),
+    } as UIMessage["parts"][number];
+  }
+
+  return part;
+};
+
+const fitSinglePartToByteLimit = (
+  part: UIMessage["parts"][number],
+  byteLimit: number,
+): UIMessage["parts"][number] | null => {
+  if (
+    (part.type === "text" || part.type === "reasoning") &&
+    typeof part.text === "string"
+  ) {
+    let low = 0;
+    let high = part.text.length;
+    let best: UIMessage["parts"][number] | null = null;
+
+    while (low <= high) {
+      const midpoint = Math.floor((low + high) / 2);
+      const candidate = {
+        ...part,
+        text: truncateStorageString(part.text, midpoint),
+      } as UIMessage["parts"][number];
+      if (estimateSerializedSizeBytes([candidate]) <= byteLimit) {
+        best = candidate;
+        low = midpoint + 1;
+      } else {
+        high = midpoint - 1;
+      }
+    }
+
+    return best;
+  }
+
+  const toolPart = part as ToolPart;
+  if (toolPart.type?.startsWith(TOOL_TYPE_PREFIX)) {
+    const minimalToolPart = {
+      type: toolPart.type,
+      toolCallId: toolPart.toolCallId,
+      state: toolPart.state,
+      input: { __hackeraiStorageTruncated: true },
+      ...(isCompletedToolPart(toolPart)
+        ? {
+            output: compactProtectedToolOutputForStorage(
+              toolPart.type.slice(TOOL_TYPE_PREFIX.length),
+              toolPart.output,
+            ),
+          }
+        : {}),
+    } as UIMessage["parts"][number];
+    if (estimateSerializedSizeBytes([minimalToolPart]) <= byteLimit) {
+      return minimalToolPart;
+    }
+  }
+
+  const minimalPart = { type: part.type } as UIMessage["parts"][number];
+  return estimateSerializedSizeBytes([minimalPart]) <= byteLimit
+    ? minimalPart
+    : null;
+};
+
+const enforceStorageByteLimit = (
+  parts: UIMessage["parts"],
+  byteLimit: number,
+): {
+  parts: UIMessage["parts"];
+  compactedCount: number;
+  afterSizeBytes: number;
+} => {
+  const protectedCompaction = compactToolPartsToByteLimit(parts, byteLimit, {
+    includeProtectedTools: true,
+  });
+  let compactedParts = protectedCompaction.parts;
+  let compactedCount = protectedCompaction.compactedCount;
+  let afterSizeBytes = protectedCompaction.afterSizeBytes;
+
+  for (
+    let index = 0;
+    index < compactedParts.length && afterSizeBytes > byteLimit;
+    index++
+  ) {
+    const currentPart = compactedParts[index];
+    const compactedPart = compactNonCompletedPartForStorage(currentPart);
+    if (
+      estimateSerializedSizeBytes(compactedPart) >=
+      estimateSerializedSizeBytes(currentPart)
+    ) {
+      continue;
+    }
+
+    compactedParts = compactedParts.map((part, partIndex) =>
+      partIndex === index ? compactedPart : part,
+    );
+    compactedCount++;
+    afterSizeBytes = estimateSerializedSizeBytes(compactedParts);
+  }
+
+  while (compactedParts.length > 1 && afterSizeBytes > byteLimit) {
+    compactedParts = compactedParts.slice(1);
+    compactedCount++;
+    afterSizeBytes = estimateSerializedSizeBytes(compactedParts);
+  }
+
+  if (compactedParts.length === 1 && afterSizeBytes > byteLimit) {
+    const fittedPart = fitSinglePartToByteLimit(compactedParts[0], byteLimit);
+    compactedParts = fittedPart ? [fittedPart] : [];
+    compactedCount++;
+    afterSizeBytes = estimateSerializedSizeBytes(compactedParts);
+  }
+
+  return { parts: compactedParts, compactedCount, afterSizeBytes };
 };
 
 /**
@@ -486,6 +704,13 @@ export function compactMessageForStorage<T extends UIMessage>(
     parts = byteCompactionResult.parts;
     prunedCount += byteCompactionResult.compactedCount;
     afterSizeBytes = byteCompactionResult.afterSizeBytes;
+  }
+
+  if (afterSizeBytes > softLimitBytes) {
+    const hardLimitResult = enforceStorageByteLimit(parts, softLimitBytes);
+    parts = hardLimitResult.parts;
+    prunedCount += hardLimitResult.compactedCount;
+    afterSizeBytes = hardLimitResult.afterSizeBytes;
   }
 
   const compacted =
@@ -674,10 +899,7 @@ export interface ModelPruneResult {
   totalToolOutputTokens: number;
   toolOutputCount: number;
   skipReason:
-    | "no-tool-outputs"
-    | "within-budget"
-    | "below-minimum-savings"
-    | null;
+    "no-tool-outputs" | "within-budget" | "below-minimum-savings" | null;
 }
 
 /**
@@ -884,9 +1106,7 @@ export type PromptMessage = Record<string, unknown> & {
 };
 
 export type AnthropicPromptRepairAction =
-  | "none"
-  | "appended_continue"
-  | "trimmed";
+  "none" | "appended_continue" | "trimmed";
 
 export type AnthropicPromptRepairReason =
   | "not_trailing_assistant"
@@ -913,8 +1133,7 @@ export interface NoAnthropicPromptRepair {
 }
 
 export type AnthropicPromptRepairTelemetry =
-  | AppliedAnthropicPromptRepair
-  | NoAnthropicPromptRepair;
+  AppliedAnthropicPromptRepair | NoAnthropicPromptRepair;
 
 const getContentTypes = (content: unknown): string[] | undefined => {
   if (typeof content === "string") return ["text"];

--- a/lib/chat/compaction/prune-tool-outputs.ts
+++ b/lib/chat/compaction/prune-tool-outputs.ts
@@ -567,6 +567,8 @@ const fitSinglePartToByteLimit = (
     if (estimateSerializedSizeBytes([minimalToolPart]) <= byteLimit) {
       return minimalToolPart;
     }
+
+    return null;
   }
 
   const minimalPart = { type: part.type } as UIMessage["parts"][number];

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -49,6 +49,7 @@ const loadSaveMessageWithMocks = async () => {
     saveChat,
     saveMessage,
     setActiveTriggerRun,
+    updateChat,
   } = await import("../actions");
   return {
     deleteAllChatsForBackend,
@@ -63,6 +64,7 @@ const loadSaveMessageWithMocks = async () => {
     saveChat,
     saveMessage,
     setActiveTriggerRun,
+    updateChat,
   };
 };
 
@@ -440,6 +442,60 @@ describe("getChatById", () => {
       expect(errorSpy).toHaveBeenCalledTimes(1);
     } finally {
       warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+});
+
+describe("updateChat", () => {
+  it("retries transient fetch failures before updating final chat metadata", async () => {
+    const { mockMutation, updateChat } = await loadSaveMessageWithMocks();
+    const fetchError = new TypeError("fetch failed");
+    mockMutation
+      .mockRejectedValueOnce(fetchError as never)
+      .mockRejectedValueOnce(fetchError as never)
+      .mockResolvedValueOnce("chat-doc-1" as never);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await expect(
+        updateChat({ chatId: "chat-1", finishReason: "stop" }),
+      ).resolves.toBe("chat-doc-1");
+
+      expect(mockMutation).toHaveBeenCalledTimes(3);
+      const retryEvents = warnSpy.mock.calls
+        .map(([line]) => JSON.parse(String(line)))
+        .filter((payload) => payload.event === "chat_update_retry_scheduled");
+      expect(retryEvents).toHaveLength(2);
+      expect(retryEvents[0]).toMatchObject({
+        db_operation: "chats.updateChat",
+        retry_reason: "network_fetch_failed",
+        attempt: 1,
+        next_attempt: 2,
+        retry_delay_ms: 0,
+        chat_id: "chat-1",
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("does not retry non-transient update failures", async () => {
+    const { mockMutation, updateChat } = await loadSaveMessageWithMocks();
+    mockMutation.mockRejectedValue(new Error("Invalid todos") as never);
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(updateChat({ chatId: "chat-1" })).rejects.toMatchObject({
+        type: "bad_request",
+        surface: "database",
+        metadata: expect.objectContaining({
+          db_operation: "chats.updateChat",
+          chat_id: "chat-1",
+        }),
+      });
+      expect(mockMutation).toHaveBeenCalledTimes(1);
+    } finally {
       errorSpy.mockRestore();
     }
   });

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -53,6 +53,8 @@ const SAVE_MESSAGE_RETRY_DELAYS_MS =
   process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
 const SAVE_CHAT_RETRY_DELAYS_MS =
   process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
+const UPDATE_CHAT_RETRY_DELAYS_MS =
+  process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
 const GET_CHAT_RETRY_DELAYS_MS =
   process.env.NODE_ENV === "test" ? [0, 0] : [250, 1000];
 const GET_MESSAGES_PAGE_RETRY_DELAYS_MS =
@@ -1147,22 +1149,50 @@ export async function updateChat({
   sandboxType?: string;
   selectedModel?: string;
 }) {
-  try {
-    return await getConvexClient().mutation(api.chats.updateChat, {
-      serviceKey,
-      chatId,
-      title,
-      finishReason,
-      todos,
-      defaultModelSlug,
-      sandboxType,
-      selectedModel,
-    });
-  } catch (error) {
-    throw new ChatSDKError(
-      "bad_request:database",
-      `Failed to update chat: ${error}`,
-    );
+  const mutationArgs = {
+    serviceKey,
+    chatId,
+    title,
+    finishReason,
+    todos,
+    defaultModelSlug,
+    sandboxType,
+    selectedModel,
+  };
+
+  for (let attemptIndex = 0; ; attemptIndex++) {
+    try {
+      return await getConvexClient().mutation(
+        api.chats.updateChat,
+        mutationArgs,
+      );
+    } catch (error) {
+      const retryReason = getRetryableDatabaseErrorReason(error);
+      const retryDelayMs = UPDATE_CHAT_RETRY_DELAYS_MS[attemptIndex];
+      if (!retryReason || retryDelayMs === undefined) {
+        throw databaseError("chats.updateChat", error, {
+          chat_id: chatId,
+        });
+      }
+
+      console.warn(
+        JSON.stringify({
+          level: "warn",
+          event: "chat_update_retry_scheduled",
+          service: "chat-handler",
+          environment:
+            process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+          timestamp: new Date().toISOString(),
+          db_operation: "chats.updateChat",
+          retry_reason: retryReason,
+          attempt: attemptIndex + 1,
+          next_attempt: attemptIndex + 2,
+          retry_delay_ms: retryDelayMs,
+          chat_id: chatId,
+        }),
+      );
+      await waitForRetryDelay(retryDelayMs);
+    }
   }
 }
 

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -6,6 +6,7 @@ import {
   getUserFriendlyProviderError,
   getProviderErrorCategory,
   getProviderStatusCode,
+  isInvalidImageInputError,
   isProviderContentBlockedError,
   isProviderStreamTerminatedError,
 } from "../error-utils";
@@ -279,14 +280,47 @@ describe("extractErrorDetails -> wrapped provider errors", () => {
 
 describe("provider error classification", () => {
   it("classifies undici terminated errors as provider stream termination", () => {
+    const cause = Object.assign(new Error("other side closed"), {
+      code: "UND_ERR_SOCKET",
+    });
     const err = Object.assign(new TypeError("terminated"), {
-      cause: "other side closed",
+      cause,
     });
 
     expect(getProviderErrorCategory(extractErrorDetails(err))).toBe(
       "stream_terminated",
     );
+    expect(extractErrorDetails(err)).toMatchObject({
+      cause: "other side closed",
+      errorCode: "UND_ERR_SOCKET",
+    });
     expect(isProviderStreamTerminatedError(err)).toBe(true);
+  });
+
+  it("classifies ECONNRESET provider socket closures as stream termination", () => {
+    const err = Object.assign(new TypeError("terminated"), {
+      cause: Object.assign(new Error("read ECONNRESET"), {
+        code: "ECONNRESET",
+      }),
+    });
+
+    expect(getProviderErrorCategory(extractErrorDetails(err))).toBe(
+      "stream_terminated",
+    );
+    expect(extractErrorDetails(err)).toMatchObject({ errorCode: "ECONNRESET" });
+  });
+
+  it("recognizes expired provider image URLs as user-correctable input", () => {
+    const err = apiCallError({
+      statusCode: 400,
+      message:
+        "Failed to download the provided image because the image host returned HTTP status 404.",
+    });
+
+    expect(isInvalidImageInputError(err)).toBe(true);
+    expect(getUserFriendlyProviderError(err)).toBe(
+      "An attached image is no longer available at its source URL. Reattach the image and try again.",
+    );
   });
 
   it("classifies network-loss messages as provider stream termination", () => {

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -309,6 +309,44 @@ describe("desktop-local sandbox file helpers", () => {
     }
   });
 
+  it("retries only after the Desktop command relay reports not subscribed", async () => {
+    jest.useFakeTimers();
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const run = jest
+      .fn()
+      .mockRejectedValueOnce(
+        new Error(
+          "Local sandbox connection conn-1 is not subscribed to the command relay.",
+        ),
+      )
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
+
+    try {
+      const pendingResult = uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "https://example.com/screenshot.png",
+            localPath: "/home/user/upload/screenshot.png",
+          },
+        ],
+        async () => ({ commands: { run } }),
+      );
+      await jest.advanceTimersByTimeAsync(5_000);
+
+      await expect(pendingResult).resolves.toEqual({
+        failedCount: 0,
+        pathRewrites: [],
+      });
+      expect(run).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
   it("refreshes the sandbox once after exhausted transient upload command failures", async () => {
     jest.useFakeTimers();
     const consoleWarnSpy = jest

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -282,8 +282,7 @@ export const extractErrorDetails = (
 ): Record<string, unknown> => {
   const sources = collectErrorSources(error);
   const err = sources.find((source) => source instanceof Error) as
-    | Error
-    | undefined;
+    Error | undefined;
   const records = sources.filter(isRecord);
   const primaryRecord = records[0];
 
@@ -365,6 +364,14 @@ const getProviderMessageText = (details: Record<string, unknown>): string => {
     .filter((value): value is string => typeof value === "string")
     .join(" ");
 };
+
+const INVALID_IMAGE_INPUT_PATTERN =
+  /failed to download the provided image[\s\S]{0,500}(?:image host returned )?HTTP status (?:404|410)\b/i;
+
+export const isInvalidImageInputError = (error: unknown): boolean =>
+  INVALID_IMAGE_INPUT_PATTERN.test(
+    getProviderMessageText(extractErrorDetails(error)),
+  );
 
 const PROVIDER_CONTENT_BLOCK_PATTERN =
   /\bPROHIBITED_CONTENT\b|\b(?:content[_ -]?(?:filter(?:ing)?|policy)|safety policy|moderation policy|safety system|moderation system)\b.{0,80}\b(?:block(?:ed)?|flag(?:ged)?|reject(?:ed)?|prohibit(?:ed)?|violate(?:s|d|ion)?|unsafe|harmful)\b|\b(?:block(?:ed)?|flag(?:ged)?|reject(?:ed)?|prohibit(?:ed)?|violate(?:s|d|ion)?|unsafe|harmful)\b.{0,80}\b(?:content[_ -]?(?:filter(?:ing)?|policy)|safety policy|moderation policy|safety system|moderation system)\b|\bblocked by (?:the )?(?:provider )?(?:safety|moderation)(?: system| filter)?\b|\b(?:unsafe|harmful) content\b/i;
@@ -552,6 +559,10 @@ export const getUserFriendlyProviderError = (error: unknown): string => {
   const { providerName, detail } = extractProviderDetails(error);
   const overflowKind = classifyProviderOverflowError(error);
 
+  if (isInvalidImageInputError(error)) {
+    return "An attached image is no longer available at its source URL. Reattach the image and try again.";
+  }
+
   if (isProviderContentBlockedError(error)) {
     return "The model provider blocked this request because the conversation content was flagged by its safety system. Edit your last message or remove sensitive or raw tool output, then try again.";
   }
@@ -663,8 +674,7 @@ function extractStatusCode(error: unknown): number | undefined {
     "error" in anyError.data
   ) {
     const nested = (anyError.data as Record<string, unknown>).error as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
     if (nested && typeof nested.code === "number") {
       return nested.code;
     }

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -110,7 +110,7 @@ const commandErrorToResult = (error: unknown): SandboxCommandResult | null => {
 };
 
 const TRANSIENT_SANDBOX_COMMAND_ERROR_PATTERN =
-  /\b(?:request handshake timed out(?: after \d+ms)?|sandbox command(?: request| channel| transport)? timed out|command (?:channel|transport) timed out|deadline_exceeded|operation timed out:.*\btimeoutMs\b|exceeding ['"]?timeoutMs['"]?|Command timeout after \d+ms)\b/i;
+  /\b(?:request handshake timed out(?: after \d+ms)?|sandbox command(?: request| channel| transport)? timed out|command (?:channel|transport) timed out|deadline_exceeded|operation timed out:.*\btimeoutMs\b|exceeding ['"]?timeoutMs['"]?|Command timeout after \d+ms|is not subscribed to the command relay)\b/i;
 const WRAPPED_FILE_TRANSFER_ERROR_PATTERN =
   /\bfailed to (?:download|copy) file:|curl:\s*\(|\bexitCode:\s*\d+\b/i;
 const SANDBOX_COMMAND_MAX_ATTEMPTS = 3;

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -128,6 +128,7 @@ import {
   extractErrorDetails,
   getProviderErrorCategory,
   getUserFriendlyProviderError,
+  isInvalidImageInputError,
 } from "@/lib/utils/error-utils";
 import { ChatSDKError, serializeChatSDKErrorForStream } from "@/lib/errors";
 import type { Id } from "@/convex/_generated/dataModel";
@@ -998,6 +999,7 @@ const USER_CORRECTABLE_AGENT_LONG_ERROR_CATEGORIES = new Set([
   "input_too_large",
   "empty_after_processing",
   "local_sandbox_fallback_blocked",
+  "invalid_image_input",
 ]);
 
 const isUserCorrectableAgentLongErrorCategory = (category: string): boolean =>
@@ -1017,6 +1019,8 @@ const TRIGGER_REALTIME_TRANSPORT_ERROR_PATTERNS = [
   /S2MetadataStream/i,
   /StreamsWriterV2/i,
   /sendBatchNonBlocking/i,
+  /Max attempts \(\d+\) exhausted: Connection timeout after \d+ms/i,
+  /Max attempts \(\d+\) exhausted: cs:[a-z0-9]+/i,
   /Max attempts \(\d+\) exhausted: Request timeout after \d+ms \(\d+ records, \d+ bytes\)/i,
   /Request timeout after \d+ms \(\d+ records, \d+ bytes\)/i,
 ];
@@ -1048,6 +1052,7 @@ const classifyProviderDashboardCategory = (
   error: unknown,
   details: Record<string, unknown>,
 ): string => {
+  if (isInvalidImageInputError(error)) return "invalid_image_input";
   const category = getProviderErrorCategory(details);
   if (category === "stream_terminated") return "provider_stream_terminated";
   if (category === "timeout") return "provider_timeout";
@@ -3259,16 +3264,51 @@ export const agentLongTask = task({
                             );
 
                         if (shouldPersist) {
-                          await updateChat({
-                            chatId,
-                            title: generatedTitle,
-                            finishReason: state.streamFinishReason,
-                            todos: mergedTodos,
-                            defaultModelSlug: "agent",
-                            sandboxType:
-                              sandboxManager.getEffectivePreference(),
-                            selectedModel: selectedModelOverride,
-                          });
+                          try {
+                            await updateChat({
+                              chatId,
+                              title: generatedTitle,
+                              finishReason: state.streamFinishReason,
+                              todos: mergedTodos,
+                              defaultModelSlug: "agent",
+                              sandboxType:
+                                sandboxManager.getEffectivePreference(),
+                              selectedModel: selectedModelOverride,
+                            });
+                          } catch (error) {
+                            const summary = classifyAgentLongError(error);
+                            metadata
+                              .set(
+                                "chatFinalizationStatus",
+                                "metadata_update_failed",
+                              )
+                              .set(
+                                "chatFinalizationErrorCategory",
+                                summary.category,
+                              )
+                              .set(
+                                "chatFinalizationErrorMessage",
+                                summary.message,
+                              );
+                            triggerLogger.warn(
+                              "[agent-long] final chat metadata update failed",
+                              {
+                                event: "agent_long_chat_metadata_update_failed",
+                                service: "agent-long",
+                                environment:
+                                  process.env.VERCEL_ENV ??
+                                  process.env.NODE_ENV ??
+                                  "unknown",
+                                timestamp: new Date().toISOString(),
+                                chat_id: chatId,
+                                user_id: userId,
+                                run_id: ctx.run.id,
+                                error_category: summary.category,
+                                error_name: summary.name,
+                                error_code: summary.code,
+                              },
+                            );
+                          }
                         } else {
                           await prepareForNewStream({ chatId });
                         }

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1185,6 +1185,29 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
   };
 };
 
+const recordAgentLongChatMetadataUpdateFailure = (
+  error: unknown,
+  context: { chatId: string; userId: string; runId: string },
+) => {
+  const summary = classifyAgentLongError(error);
+  metadata
+    .set("chatFinalizationStatus", "metadata_update_failed")
+    .set("chatFinalizationErrorCategory", summary.category)
+    .set("chatFinalizationErrorMessage", summary.message);
+  triggerLogger.warn("[agent-long] final chat metadata update failed", {
+    event: "agent_long_chat_metadata_update_failed",
+    service: "agent-long",
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+    timestamp: new Date().toISOString(),
+    chat_id: context.chatId,
+    user_id: context.userId,
+    run_id: context.runId,
+    error_category: summary.category,
+    error_name: summary.name,
+    error_code: summary.code,
+  });
+};
+
 const getTerminalProviderStreamError = (
   state:
     Pick<AgentStreamState, "streamFinishReason" | "providerError"> | undefined,
@@ -2797,6 +2820,7 @@ export const agentLongTask = task({
             } catch (error) {
               if (
                 isProviderApiError(error) &&
+                !isInvalidImageInputError(error) &&
                 !isRetryWithFallback &&
                 isAutoModel
               ) {
@@ -3121,16 +3145,28 @@ export const agentLongTask = task({
                                       state.streamFinishReason ||
                                       mergedTodos.length > 0
                                     ) {
-                                      await updateChat({
-                                        chatId,
-                                        title: generatedTitle,
-                                        finishReason: state.streamFinishReason,
-                                        todos: mergedTodos,
-                                        defaultModelSlug: "agent",
-                                        sandboxType:
-                                          sandboxManager.getEffectivePreference(),
-                                        selectedModel: selectedModelOverride,
-                                      });
+                                      try {
+                                        await updateChat({
+                                          chatId,
+                                          title: generatedTitle,
+                                          finishReason:
+                                            state.streamFinishReason,
+                                          todos: mergedTodos,
+                                          defaultModelSlug: "agent",
+                                          sandboxType:
+                                            sandboxManager.getEffectivePreference(),
+                                          selectedModel: selectedModelOverride,
+                                        });
+                                      } catch (error) {
+                                        recordAgentLongChatMetadataUpdateFailure(
+                                          error,
+                                          {
+                                            chatId,
+                                            userId,
+                                            runId: ctx.run.id,
+                                          },
+                                        );
+                                      }
                                     } else {
                                       await prepareForNewStream({ chatId });
                                     }
@@ -3276,38 +3312,11 @@ export const agentLongTask = task({
                               selectedModel: selectedModelOverride,
                             });
                           } catch (error) {
-                            const summary = classifyAgentLongError(error);
-                            metadata
-                              .set(
-                                "chatFinalizationStatus",
-                                "metadata_update_failed",
-                              )
-                              .set(
-                                "chatFinalizationErrorCategory",
-                                summary.category,
-                              )
-                              .set(
-                                "chatFinalizationErrorMessage",
-                                summary.message,
-                              );
-                            triggerLogger.warn(
-                              "[agent-long] final chat metadata update failed",
-                              {
-                                event: "agent_long_chat_metadata_update_failed",
-                                service: "agent-long",
-                                environment:
-                                  process.env.VERCEL_ENV ??
-                                  process.env.NODE_ENV ??
-                                  "unknown",
-                                timestamp: new Date().toISOString(),
-                                chat_id: chatId,
-                                user_id: userId,
-                                run_id: ctx.run.id,
-                                error_category: summary.category,
-                                error_name: summary.name,
-                                error_code: summary.code,
-                              },
-                            );
+                            recordAgentLongChatMetadataUpdateFailure(error, {
+                              chatId,
+                              userId,
+                              runId: ctx.run.id,
+                            });
                           }
                         } else {
                           await prepareForNewStream({ chatId });


### PR DESCRIPTION
## Evidence and root cause

Production traces showed a small set of agent-run failures that can be prevented without increasing machine size or adding healthy-run work:

- Protected tool output could bypass storage compaction, allowing assistant messages to remain above the configured storage byte target.
- A transient final chat-metadata update could fail after successful model generation and prevent the generated assistant message from being saved.
- The Desktop transient matcher omitted the relay-not-subscribed readiness error already handled by the existing retry/refresh path.
- Expired image URLs were grouped with provider/application failures rather than handled input errors.
- The realtime sanitizer existed, but the final stream-pipe ordering was not protected by a regression contract.
- Observed provider socket and Trigger realtime signatures needed exact classification coverage.

This intentionally does **not** increase the Trigger machine size, add a service, or retry an entire agent run.

## Changes

- Enforce the stored assistant-message byte target even for protected and unfinished tool parts.
  - Normal messages keep the existing fast path.
  - `list_notes` is compacted only after the target is exceeded, preserving bounded note IDs, titles, metadata, and content previews.
  - Extreme residual payloads are reduced deterministically so compaction cannot return above its target.
- Retry `updateChat` only for recognized transient Convex/network failures after 250 ms and 1,000 ms, with structured diagnostics.
- Keep exhausted final chat-metadata updates non-fatal after successful generation, while retaining queryable metadata and allowing assistant-message persistence to proceed.
- Classify expired provider image URLs as `invalid_image_input`, return reattach guidance, and complete the Trigger run as user-correctable.
- Recognize the observed Trigger realtime connection-timeout and opaque error signatures.
- Treat the exact Desktop relay-not-subscribed error as transient so the existing retry/refresh path runs only after that failure.
- Add provider socket classification coverage and a final-pipe sanitizer contract regression.

## Cost and latency impact

Healthy runs get no new network call, retry delay, machine upgrade, or external service.

- Database backoff occurs only after a recognized transient `updateChat` failure (maximum added delay: 1.25 seconds in that already-failing path).
- Desktop backoff/refresh occurs only after the exact relay readiness failure.
- Protected-output and hard-cap compaction occurs only when an assistant message is already above the storage byte target.
- Provider/realtime/image changes are classification and error-handling only.

## Validation

- Focused regression suite: 225 tests passed across 6 suites.
- Repository commit hook: 260 test suites / 2,606 tests passed.
- Full TypeScript typecheck passed.
- Changed-file ESLint passed.
- Prettier and `git diff --check` passed.

## Manual verification

1. Run an agent chat that repeatedly lists large notes; confirm the response persists under the storage target while note IDs, titles, and previews remain available.
2. Simulate a transient final `updateChat` failure; confirm retries are logged, the assistant message is saved, and the run records non-fatal finalization metadata if retries are exhausted.
3. Submit an expired image URL; confirm the user sees reattach guidance and the run is user-correctable rather than failed.
4. Reproduce a Desktop relay-not-subscribed state; confirm retry/refresh occurs only after that failure and healthy uploads are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expired or invalid image links with clearer guidance to reattach the image.
  * Added recognition for additional streaming timeout and connection failure scenarios.
  * Chat content is now preserved even when final metadata updates fail.
  * Chat updates retry transient failures automatically.
  * Improved sandbox file upload recovery after temporary command relay issues.
  * Reduced stored message size while preserving unfinished tool-call state and important note details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->