### PR TITLE
Add core WorkOS health monitor endpoint

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -117,6 +117,11 @@ E2B_TEMPLATE=terminal-agent-sandbox
 # POSTHOG_CLI_PROJECT_ID=
 # POSTHOG_CLI_HOST=https://us.posthog.com
 
+# Protects /api/health/core, which checks the WorkOS dependency for uptime monitoring.
+# Add the same value as the x-hackerai-health-token header in the uptime monitor.
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# CORE_HEALTH_CHECK_TOKEN=
+
 # =============================================================================
 # PAYMENTS (Optional - Stripe)
 # =============================================================================

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -76,22 +76,25 @@ describe("proxy", () => {
     mockNextResponseRedirect.mockClear();
   });
 
-  it("bypasses AuthKit for the Trigger Agent health endpoint", async () => {
-    const { default: proxy } = await import("../proxy");
+  it.each(["/api/health/core", "/api/health/trigger-agent-mode"])(
+    "bypasses AuthKit for the health endpoint %s",
+    async (pathname) => {
+      const { default: proxy } = await import("../proxy");
 
-    const response = await proxy(
-      createRequest({
-        pathname: "/api/health/trigger-agent-mode",
-        hasSession: true,
-      }),
-    );
+      const response = await proxy(
+        createRequest({
+          pathname,
+          hasSession: true,
+        }),
+      );
 
-    expect(response).toMatchObject({ kind: "next" });
-    expect(mockAuthkit).not.toHaveBeenCalled();
-    expect(mockNextResponseNext).toHaveBeenCalledWith();
-    expect(mockNextResponseJson).not.toHaveBeenCalled();
-    expect(mockNextResponseRedirect).not.toHaveBeenCalled();
-  });
+      expect(response).toMatchObject({ kind: "next" });
+      expect(mockAuthkit).not.toHaveBeenCalled();
+      expect(mockNextResponseNext).toHaveBeenCalledWith();
+      expect(mockNextResponseJson).not.toHaveBeenCalled();
+      expect(mockNextResponseRedirect).not.toHaveBeenCalled();
+    },
+  );
 
   it.each(["/robots.txt", "/sitemap.xml"])(
     "bypasses AuthKit for the public SEO route %s",

--- a/app/api/health/core/__tests__/route.test.ts
+++ b/app/api/health/core/__tests__/route.test.ts
@@ -155,6 +155,34 @@ describe("GET /api/health/core", () => {
     );
   });
 
+  it("authenticates before exposing missing WorkOS configuration", async () => {
+    delete process.env.WORKOS_API_KEY;
+    const { GET } = await import("../route");
+
+    const unauthorizedResponse = await GET(createRequest());
+    const unauthorizedBody = await unauthorizedResponse.json();
+
+    expect(unauthorizedResponse.status).toBe(401);
+    expect(unauthorizedBody).toMatchObject({
+      ok: false,
+      error: "unauthorized",
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    const authorizedResponse = await GET(createRequest("monitor-secret"));
+    const authorizedBody = await authorizedResponse.json();
+
+    expect(authorizedResponse.status).toBe(503);
+    expect(authorizedBody).toMatchObject({
+      ok: false,
+      error: "health_check_not_configured",
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"missing_workos_api_key":true'),
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("returns 503 when WorkOS returns an error status", async () => {
     mockFetch.mockResolvedValueOnce(
       fetchResponse({ ok: false, status: 504 }) as never,
@@ -183,29 +211,52 @@ describe("GET /api/health/core", () => {
     );
   });
 
-  it("returns 503 when the WorkOS request fails", async () => {
-    mockFetch.mockRejectedValueOnce(new Error("request timeout") as never);
-    const { GET } = await import("../route");
+  it("returns 503 when the four-second WorkOS timeout aborts", async () => {
+    const abortController = new AbortController();
+    const timeoutSpy = jest
+      .spyOn(AbortSignal, "timeout")
+      .mockReturnValue(abortController.signal);
+    mockFetch.mockImplementationOnce(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("request timeout", "AbortError")),
+            { once: true },
+          );
+          abortController.abort();
+        }) as never,
+    );
 
-    const response = await GET(createRequest("monitor-secret"));
-    const body = await response.json();
+    try {
+      const { GET } = await import("../route");
 
-    expect(response.status).toBe(503);
-    expect(body).toMatchObject({
-      ok: false,
-      error: "workos_fetch_failed",
-      dependencies: {
-        workos: {
-          ok: false,
-          status: null,
+      const response = await GET(createRequest("monitor-secret"));
+      const body = await response.json();
+
+      expect(timeoutSpy).toHaveBeenCalledWith(4_000);
+      expect(response.status).toBe(503);
+      expect(body).toMatchObject({
+        ok: false,
+        error: "workos_fetch_failed",
+        dependencies: {
+          workos: {
+            ok: false,
+            status: null,
+          },
         },
-      },
-    });
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('"reason":"fetch_failed"'),
-    );
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('"error_message":"request timeout"'),
-    );
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"reason":"fetch_failed"'),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"error_name":"AbortError"'),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"error_message":"request timeout"'),
+      );
+    } finally {
+      timeoutSpy.mockRestore();
+    }
   });
 });

--- a/app/api/health/core/__tests__/route.test.ts
+++ b/app/api/health/core/__tests__/route.test.ts
@@ -1,0 +1,211 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import type { NextRequest } from "next/server";
+
+jest.mock("next/server", () => ({
+  NextResponse: class MockNextResponse {
+    status: number;
+    headers: Headers;
+    private body: unknown;
+
+    constructor(body?: unknown, init?: ResponseInit) {
+      this.body = body;
+      this.status = init?.status ?? 200;
+      this.headers = new Headers(init?.headers);
+    }
+
+    static json(body: unknown, init?: ResponseInit) {
+      return new MockNextResponse(body, init);
+    }
+
+    async json() {
+      return this.body;
+    }
+  },
+}));
+
+const mockFetch = jest.fn();
+const originalHealthCheckToken = process.env.CORE_HEALTH_CHECK_TOKEN;
+const originalWorkosApiKey = process.env.WORKOS_API_KEY;
+
+function createRequest(token?: string): NextRequest {
+  const headers = new Headers({
+    "x-request-id": "request_123",
+  });
+  if (token) {
+    headers.set("x-hackerai-health-token", token);
+  }
+
+  return {
+    headers,
+  } as NextRequest;
+}
+
+function fetchResponse({
+  ok = true,
+  status = 200,
+}: {
+  ok?: boolean;
+  status?: number;
+} = {}) {
+  return {
+    ok,
+    status,
+  };
+}
+
+describe("GET /api/health/core", () => {
+  let warnSpy: jest.SpiedFunction<typeof console.warn>;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env.CORE_HEALTH_CHECK_TOKEN = "monitor-secret";
+    process.env.WORKOS_API_KEY = "sk_test_workos";
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    global.fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockResolvedValue(fetchResponse() as never);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+
+    if (originalHealthCheckToken === undefined) {
+      delete process.env.CORE_HEALTH_CHECK_TOKEN;
+    } else {
+      process.env.CORE_HEALTH_CHECK_TOKEN = originalHealthCheckToken;
+    }
+
+    if (originalWorkosApiKey === undefined) {
+      delete process.env.WORKOS_API_KEY;
+    } else {
+      process.env.WORKOS_API_KEY = originalWorkosApiKey;
+    }
+  });
+
+  it("returns 200 when WorkOS is available", async () => {
+    const { GET } = await import("../route");
+
+    const response = await GET(createRequest("monitor-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.workos.com/user_management/users?limit=1",
+      expect.objectContaining({
+        cache: "no-store",
+        signal: expect.anything(),
+        headers: {
+          accept: "application/json",
+          authorization: "Bearer sk_test_workos",
+        },
+      }),
+    );
+    expect(body).toMatchObject({
+      ok: true,
+      service: "core",
+      dependencies: {
+        workos: {
+          ok: true,
+          status: 200,
+          latencyMs: expect.any(Number),
+        },
+      },
+    });
+    expect(JSON.stringify(body)).not.toContain("monitor-secret");
+    expect(JSON.stringify(body)).not.toContain("sk_test_workos");
+  });
+
+  it("rejects requests without the monitor token", async () => {
+    const { GET } = await import("../route");
+
+    const response = await GET(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toMatchObject({
+      ok: false,
+      error: "unauthorized",
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when required configuration is missing", async () => {
+    delete process.env.CORE_HEALTH_CHECK_TOKEN;
+    const { GET } = await import("../route");
+
+    const response = await GET(createRequest("monitor-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      ok: false,
+      error: "health_check_not_configured",
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"reason":"missing_configuration"'),
+    );
+  });
+
+  it("returns 503 when WorkOS returns an error status", async () => {
+    mockFetch.mockResolvedValueOnce(
+      fetchResponse({ ok: false, status: 504 }) as never,
+    );
+    const { GET } = await import("../route");
+
+    const response = await GET(createRequest("monitor-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      ok: false,
+      error: "workos_unavailable",
+      dependencies: {
+        workos: {
+          ok: false,
+          status: 504,
+        },
+      },
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"reason":"unexpected_status"'),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"dependency_status":504'),
+    );
+  });
+
+  it("returns 503 when the WorkOS request fails", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("request timeout") as never);
+    const { GET } = await import("../route");
+
+    const response = await GET(createRequest("monitor-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      ok: false,
+      error: "workos_fetch_failed",
+      dependencies: {
+        workos: {
+          ok: false,
+          status: null,
+        },
+      },
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"reason":"fetch_failed"'),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"error_message":"request timeout"'),
+    );
+  });
+});

--- a/app/api/health/core/route.ts
+++ b/app/api/health/core/route.ts
@@ -93,14 +93,12 @@ function unhealthyResponse(
 
 export async function GET(request: NextRequest) {
   const healthCheckToken = process.env.CORE_HEALTH_CHECK_TOKEN;
-  const workosApiKey = process.env.WORKOS_API_KEY;
 
-  if (!healthCheckToken || !workosApiKey) {
+  if (!healthCheckToken) {
     const checkedAt = new Date().toISOString();
     logHealthFailure(request, checkedAt, {
       reason: "missing_configuration",
-      missing_health_check_token: !healthCheckToken,
-      missing_workos_api_key: !workosApiKey,
+      missing_health_check_token: true,
     });
 
     return unhealthyResponse(
@@ -128,6 +126,25 @@ export async function GET(request: NextRequest) {
         error: "unauthorized",
       },
       { status: 401 },
+    );
+  }
+
+  const workosApiKey = process.env.WORKOS_API_KEY;
+  if (!workosApiKey) {
+    const checkedAt = new Date().toISOString();
+    logHealthFailure(request, checkedAt, {
+      reason: "missing_configuration",
+      missing_workos_api_key: true,
+    });
+
+    return unhealthyResponse(
+      checkedAt,
+      {
+        ok: false,
+        status: null,
+        latencyMs: 0,
+      },
+      "health_check_not_configured",
     );
   }
 

--- a/app/api/health/core/route.ts
+++ b/app/api/health/core/route.ts
@@ -1,0 +1,195 @@
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse, type NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const maxDuration = 10;
+export const runtime = "nodejs";
+
+const WORKOS_USERS_URL = "https://api.workos.com/user_management/users?limit=1";
+const WORKOS_FETCH_TIMEOUT_MS = 4_000;
+const HEALTH_CHECK_TOKEN_HEADER = "x-hackerai-health-token";
+
+type DependencyHealth = {
+  ok: boolean;
+  status: number | null;
+  latencyMs: number;
+};
+
+function json(
+  body: Record<string, unknown>,
+  init?: ResponseInit,
+): NextResponse<Record<string, unknown>> {
+  const headers = new Headers(init?.headers);
+  headers.set("Cache-Control", "no-store");
+
+  return NextResponse.json(body, {
+    ...init,
+    headers,
+  });
+}
+
+function getWorkOSFetchSignal(): AbortSignal | undefined {
+  if (typeof AbortSignal === "undefined") return undefined;
+  const timeout = (
+    AbortSignal as typeof AbortSignal & {
+      timeout?: (milliseconds: number) => AbortSignal;
+    }
+  ).timeout;
+
+  return timeout?.(WORKOS_FETCH_TIMEOUT_MS);
+}
+
+function tokensMatch(providedToken: string | null, expectedToken: string) {
+  if (!providedToken) return false;
+
+  const providedBuffer = Buffer.from(providedToken);
+  const expectedBuffer = Buffer.from(expectedToken);
+  if (providedBuffer.length !== expectedBuffer.length) return false;
+
+  return timingSafeEqual(providedBuffer, expectedBuffer);
+}
+
+function logHealthFailure(
+  request: NextRequest,
+  checkedAt: string,
+  fields: Record<string, unknown>,
+) {
+  console.warn(
+    JSON.stringify({
+      timestamp: checkedAt,
+      level: "warn",
+      event: "core_health_check_failed",
+      request_id:
+        request.headers.get("x-request-id") ??
+        request.headers.get("x-vercel-id") ??
+        "unknown",
+      service: "hackerai-web",
+      environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+      dependency: "workos",
+      ...fields,
+    }),
+  );
+}
+
+function unhealthyResponse(
+  checkedAt: string,
+  workos: DependencyHealth,
+  error: string,
+) {
+  return json(
+    {
+      ok: false,
+      service: "core",
+      checkedAt,
+      error,
+      dependencies: {
+        workos,
+      },
+    },
+    { status: 503 },
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const healthCheckToken = process.env.CORE_HEALTH_CHECK_TOKEN;
+  const workosApiKey = process.env.WORKOS_API_KEY;
+
+  if (!healthCheckToken || !workosApiKey) {
+    const checkedAt = new Date().toISOString();
+    logHealthFailure(request, checkedAt, {
+      reason: "missing_configuration",
+      missing_health_check_token: !healthCheckToken,
+      missing_workos_api_key: !workosApiKey,
+    });
+
+    return unhealthyResponse(
+      checkedAt,
+      {
+        ok: false,
+        status: null,
+        latencyMs: 0,
+      },
+      "health_check_not_configured",
+    );
+  }
+
+  if (
+    !tokensMatch(
+      request.headers.get(HEALTH_CHECK_TOKEN_HEADER),
+      healthCheckToken,
+    )
+  ) {
+    return json(
+      {
+        ok: false,
+        service: "core",
+        checkedAt: new Date().toISOString(),
+        error: "unauthorized",
+      },
+      { status: 401 },
+    );
+  }
+
+  const startedAt = Date.now();
+
+  try {
+    const response = await fetch(WORKOS_USERS_URL, {
+      cache: "no-store",
+      signal: getWorkOSFetchSignal(),
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${workosApiKey}`,
+      },
+    });
+    const checkedAt = new Date().toISOString();
+    const latencyMs = Date.now() - startedAt;
+    const workos = {
+      ok: response.ok,
+      status: response.status,
+      latencyMs,
+    };
+
+    if (!response.ok) {
+      logHealthFailure(request, checkedAt, {
+        reason: "unexpected_status",
+        dependency_status: response.status,
+        duration_ms: latencyMs,
+      });
+
+      return unhealthyResponse(checkedAt, workos, "workos_unavailable");
+    }
+
+    return json(
+      {
+        ok: true,
+        service: "core",
+        checkedAt,
+        dependencies: {
+          workos,
+        },
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    const checkedAt = new Date().toISOString();
+    const latencyMs = Date.now() - startedAt;
+    logHealthFailure(request, checkedAt, {
+      reason: "fetch_failed",
+      duration_ms: latencyMs,
+      timeout_ms: WORKOS_FETCH_TIMEOUT_MS,
+      error_name: error instanceof Error ? error.name : "UnknownError",
+      error_message: error instanceof Error ? error.message : "Unknown error",
+    });
+
+    return unhealthyResponse(
+      checkedAt,
+      {
+        ok: false,
+        status: null,
+        latencyMs,
+      },
+      "workos_fetch_failed",
+    );
+  }
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/referrals/config";
 
 const AUTHKIT_BYPASS_PATHS = new Set([
+  "/api/health/core",
   "/api/health/trigger-agent-mode",
   "/robots.txt",
   "/sitemap.xml",


### PR DESCRIPTION
## Summary

- add a token-protected `GET /api/health/core` endpoint for the existing Website uptime monitor
- probe the WorkOS User Management API with a 4-second timeout and return `503` when the auth dependency is unavailable
- bypass AuthKit for the health route while preserving independent header authentication
- emit structured, credential-safe failure logs and document the monitor token environment variable
- cover healthy, unauthorized, misconfigured, upstream error, timeout, and proxy-bypass behavior

## Why

The existing homepage-only Website check can stay green while WorkOS-dependent login and session flows fail. This endpoint lets us keep the single existing Website monitor and have it verify both the HackerAI deployment and its critical WorkOS dependency.

## Validation

- `pnpm typecheck`
- `pnpm test` — 262 suites and 2,648 tests passed
- `pnpm lint` — 0 errors; 6 existing unrelated warnings
- Prettier check passed for all changed TypeScript files

## Manual rollout after merge

1. Generate a random token and add it to Vercel Production as `CORE_HEALTH_CHECK_TOKEN`.
2. Redeploy Production so the route receives the new environment variable.
3. Edit the existing Better Stack **Website** monitor; do not create a second monitor.
4. Set its URL to `https://hackerai.co/api/health/core`.
5. Add request header `x-hackerai-health-token` with the same secret value.
6. Expect HTTP `200`, use a 5-second request timeout, a 60-second check interval, 60-second confirmation, and 120-second recovery.
7. Confirm that the existing Website status-page resource remains linked and automatic status-page updates are enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a protected core health-check endpoint that reports WorkOS availability, including dependency status and latency.
  - Expanded health-check response handling (success, unauthorized, misconfiguration, and dependency/timeouts).
- **Bug Fixes**
  - Health-check requests can bypass standard authentication while still requiring the configured health-check token.
- **Documentation**
  - Updated the sample environment configuration with the optional core health-check token and usage guidance.
- **Tests**
  - Added and enhanced coverage for core health-check and auth-bypass behavior across key scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->