### PR TITLE
Harden Agent context and artifact retention

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -6,6 +6,18 @@ set -e
 
 IMAGE_NAME="${1:-hackerai-sandbox}"
 CONTAINER_NAME="${2:-hackerai-agent}"
+LOG_MAX_SIZE="${HACKERAI_DOCKER_LOG_MAX_SIZE:-50m}"
+LOG_MAX_FILE="${HACKERAI_DOCKER_LOG_MAX_FILE:-3}"
+
+if [[ ! "$LOG_MAX_SIZE" =~ ^[1-9][0-9]*([kKmMgG])?$ ]]; then
+    echo "Invalid HACKERAI_DOCKER_LOG_MAX_SIZE: $LOG_MAX_SIZE" >&2
+    exit 1
+fi
+
+if [[ ! "$LOG_MAX_FILE" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Invalid HACKERAI_DOCKER_LOG_MAX_FILE: $LOG_MAX_FILE" >&2
+    exit 1
+fi
 
 echo "🚀 Starting HackerAI Agent Sandbox..."
 echo "   Image: $IMAGE_NAME"
@@ -17,8 +29,9 @@ docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
 # Run with required capabilities for penetration testing
 docker run -it \
     --name "$CONTAINER_NAME" \
-    --log-opt max-size="${HACKERAI_DOCKER_LOG_MAX_SIZE:-50m}" \
-    --log-opt max-file="${HACKERAI_DOCKER_LOG_MAX_FILE:-3}" \
+    --log-driver local \
+    --log-opt max-size="$LOG_MAX_SIZE" \
+    --log-opt max-file="$LOG_MAX_FILE" \
     --cap-add=NET_RAW \
     --cap-add=NET_ADMIN \
     --cap-add=SYS_PTRACE \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -17,6 +17,8 @@ docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
 # Run with required capabilities for penetration testing
 docker run -it \
     --name "$CONTAINER_NAME" \
+    --log-opt max-size="${HACKERAI_DOCKER_LOG_MAX_SIZE:-50m}" \
+    --log-opt max-file="${HACKERAI_DOCKER_LOG_MAX_FILE:-3}" \
     --cap-add=NET_RAW \
     --cap-add=NET_ADMIN \
     --cap-add=SYS_PTRACE \
@@ -28,4 +30,3 @@ docker run -it \
 # - NET_RAW: Required for ping, nmap, masscan, hping3, arp-scan, raw sockets
 # - NET_ADMIN: Required for network interface manipulation, arp-scan, netdiscover
 # - SYS_PTRACE: Required for gdb, strace, ltrace debugging tools
-

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -178,6 +178,9 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
       expect(prompt).toContain(
         "Distill and deduplicate useful evidence before deleting raw output",
       );
+      expect(prompt).toContain(
+        "never delete user, project, or other-agent files unless explicitly requested or confirmed unused",
+      );
       expect(prompt).toContain("poc_<task-id>.py");
       expect(prompt).toContain(
         "clean up this task's disposable files before continuing",

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -150,6 +150,55 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).not.toContain("<finding_quality>");
   });
 
+  it("adds bounded reconnaissance and artifact hygiene in cloud and local agent modes", async () => {
+    const cloudPrompt = await systemPrompt(
+      "user_123",
+      "agent",
+      "pro",
+      "agent-model",
+      null,
+      false,
+      null,
+    );
+    const localPrompt = await systemPrompt(
+      "user_123",
+      "agent",
+      "pro",
+      "agent-model",
+      null,
+      false,
+      "Local sandbox context",
+    );
+
+    for (const prompt of [cloudPrompt, localPrompt]) {
+      expect(prompt).toContain("<agent_artifact_hygiene>");
+      expect(prompt).toContain(
+        "Bound reconnaissance by the target and declared scope, crawl depth, duration, concurrency, and output size",
+      );
+      expect(prompt).toContain(
+        "Distill and deduplicate useful evidence before deleting raw output",
+      );
+      expect(prompt).toContain("poc_<task-id>.py");
+      expect(prompt).toContain(
+        "clean up this task's disposable files before continuing",
+      );
+    }
+  });
+
+  it("does not add agent artifact hygiene guidance to ask mode", async () => {
+    const prompt = await systemPrompt(
+      "user_123",
+      "ask",
+      "pro",
+      "ask-model",
+      null,
+      false,
+      null,
+    );
+
+    expect(prompt).not.toContain("<agent_artifact_hygiene>");
+  });
+
   it("keeps cloud sandbox isolation scoped to the default cloud sandbox", async () => {
     const prompt = await systemPrompt(
       "user_123",

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -942,6 +942,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                       handler,
                       sandbox: sandboxInstance,
                       terminalWriter: createTerminalWriter,
+                      scopeId: chatId,
                     });
                     if (saveMsg) {
                       outputWithSaveInfo = saveMsg + "\n" + outputWithSaveInfo;
@@ -996,6 +997,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                         handler,
                         sandbox: sandboxInstance,
                         terminalWriter: createTerminalWriter,
+                        scopeId: chatId,
                       });
                       if (saveMsg) {
                         outputWithSaveInfo =

--- a/lib/ai/tools/utils/__tests__/terminal-output-saver.test.ts
+++ b/lib/ai/tools/utils/__tests__/terminal-output-saver.test.ts
@@ -1,0 +1,128 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it, jest } from "@jest/globals";
+import {
+  MAX_SAVED_TERMINAL_OUTPUT_FILES,
+  saveFullOutputToFile,
+} from "../terminal-output-saver";
+
+const CHAT_ID = "chat_123";
+const CHAT_KEY = createHash("sha256")
+  .update(CHAT_ID)
+  .digest("hex")
+  .slice(0, 16);
+
+const createSandbox = ({
+  sandboxKind,
+  listedFiles = [],
+}: {
+  sandboxKind?: "centrifugo";
+  listedFiles?: Array<{ name: string }>;
+} = {}) => ({
+  ...(sandboxKind ? { sandboxKind } : {}),
+  commands: {
+    run: jest.fn(async () => ({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    })),
+  },
+  files: {
+    write: jest.fn(async () => undefined),
+    list: jest.fn(async () => listedFiles),
+    remove: jest.fn(async () => undefined),
+  },
+});
+
+describe("saveFullOutputToFile", () => {
+  it("stores cloud output in a chat-scoped directory", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-16T15:30:45.123Z"));
+    const sandbox = createSandbox();
+
+    const savedPath = await saveFullOutputToFile(
+      sandbox as any,
+      "full output",
+      CHAT_ID,
+    );
+
+    expect(savedPath).toBe(
+      `/home/user/terminal_full_output/chat-${CHAT_KEY}/2026-07-16_15-30-45_123Z.txt`,
+    );
+    expect(sandbox.commands.run).toHaveBeenCalledWith(
+      `mkdir -p /home/user/terminal_full_output/chat-${CHAT_KEY}`,
+      { timeoutMs: 5000 },
+    );
+    expect(sandbox.files.write).toHaveBeenCalledWith(savedPath, "full output");
+    jest.useRealTimers();
+  });
+
+  it("uses the local temporary directory for desktop and remote sandboxes", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-16T15:30:45.123Z"));
+    const sandbox = createSandbox({ sandboxKind: "centrifugo" });
+
+    const savedPath = await saveFullOutputToFile(
+      sandbox as any,
+      "full output",
+      CHAT_ID,
+    );
+
+    expect(savedPath).toMatch(
+      new RegExp(`^/tmp/terminal_full_output/chat-${CHAT_KEY}/`),
+    );
+    jest.useRealTimers();
+  });
+
+  it("removes saved outputs beyond the per-chat retention limit", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-16T15:30:45.123Z"));
+    const listedFiles = [
+      ...Array.from(
+        { length: MAX_SAVED_TERMINAL_OUTPUT_FILES + 2 },
+        (_, index) => ({
+          name: `2026-07-${String(index + 1).padStart(2, "0")}_00-00-00_000Z.txt`,
+        }),
+      ),
+      { name: "2026-07-16_15-30-45_123Z.txt" },
+    ];
+    const sandbox = createSandbox({ listedFiles });
+
+    await saveFullOutputToFile(sandbox as any, "full output", CHAT_ID);
+
+    expect(sandbox.files.remove).toHaveBeenCalledTimes(3);
+    expect(sandbox.files.remove).toHaveBeenNthCalledWith(
+      1,
+      `/home/user/terminal_full_output/chat-${CHAT_KEY}/2026-07-03_00-00-00_000Z.txt`,
+    );
+    expect(sandbox.files.remove).toHaveBeenNthCalledWith(
+      2,
+      `/home/user/terminal_full_output/chat-${CHAT_KEY}/2026-07-02_00-00-00_000Z.txt`,
+    );
+    expect(sandbox.files.remove).toHaveBeenNthCalledWith(
+      3,
+      `/home/user/terminal_full_output/chat-${CHAT_KEY}/2026-07-01_00-00-00_000Z.txt`,
+    );
+    jest.useRealTimers();
+  });
+
+  it("still returns the saved path when retention cleanup fails", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-16T15:30:45.123Z"));
+    const sandbox = createSandbox();
+    sandbox.files.list.mockRejectedValueOnce(new Error("relay unavailable"));
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const savedPath = await saveFullOutputToFile(
+      sandbox as any,
+      "full output",
+      CHAT_ID,
+    );
+
+    expect(savedPath).toContain(
+      `/home/user/terminal_full_output/chat-${CHAT_KEY}/`,
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[Terminal Command] Failed to prune old saved terminal output:",
+      expect.any(Error),
+    );
+
+    warnSpy.mockRestore();
+    jest.useRealTimers();
+  });
+});

--- a/lib/ai/tools/utils/__tests__/terminal-output-saver.test.ts
+++ b/lib/ai/tools/utils/__tests__/terminal-output-saver.test.ts
@@ -71,6 +71,22 @@ describe("saveFullOutputToFile", () => {
     jest.useRealTimers();
   });
 
+  it("uses an unscoped directory when no chat identifier is available", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-16T15:30:45.123Z"));
+    const sandbox = createSandbox();
+
+    const savedPath = await saveFullOutputToFile(sandbox as any, "full output");
+
+    expect(savedPath).toBe(
+      "/home/user/terminal_full_output/chat-unscoped/2026-07-16_15-30-45_123Z.txt",
+    );
+    expect(sandbox.commands.run).toHaveBeenCalledWith(
+      "mkdir -p /home/user/terminal_full_output/chat-unscoped",
+      { timeoutMs: 5000 },
+    );
+    jest.useRealTimers();
+  });
+
   it("removes saved outputs beyond the per-chat retention limit", async () => {
     jest.useFakeTimers().setSystemTime(new Date("2026-07-16T15:30:45.123Z"));
     const listedFiles = [

--- a/lib/ai/tools/utils/terminal-output-saver.ts
+++ b/lib/ai/tools/utils/terminal-output-saver.ts
@@ -1,16 +1,51 @@
+import { createHash } from "node:crypto";
 import type { AnySandbox } from "@/types";
 import type { createTerminalHandler } from "@/lib/utils/terminal-executor";
 import { FULL_OUTPUT_SAVED_MESSAGE } from "@/lib/token-utils";
-import { isE2BSandbox } from "./sandbox-types";
+import { asCommonSandbox, isE2BSandbox } from "./sandbox-types";
+
+export const MAX_SAVED_TERMINAL_OUTPUT_FILES = 10;
+
+const getOutputDirectory = (sandbox: AnySandbox, scopeId?: string): string => {
+  const baseDirectory = isE2BSandbox(sandbox)
+    ? "/home/user/terminal_full_output"
+    : "/tmp/terminal_full_output";
+  const scopeKey = scopeId
+    ? createHash("sha256").update(scopeId).digest("hex").slice(0, 16)
+    : "unscoped";
+
+  return `${baseDirectory}/chat-${scopeKey}`;
+};
+
+const pruneOldSavedOutputs = async (
+  sandbox: AnySandbox,
+  directory: string,
+): Promise<void> => {
+  const files = asCommonSandbox(sandbox).files;
+  const savedOutputs = (await files.list(directory))
+    .map((entry) => entry.name)
+    .filter((name) => name.endsWith(".txt"))
+    .sort()
+    .reverse();
+
+  for (const staleName of savedOutputs.slice(MAX_SAVED_TERMINAL_OUTPUT_FILES)) {
+    const stalePath = staleName.startsWith("/")
+      ? staleName
+      : `${directory}/${staleName}`;
+    await files.remove(stalePath);
+  }
+};
 
 /**
  * Save full terminal output to a file in the sandbox when it exceeds token limits.
- * E2B (cloud) saves to ~/terminal_full_output/, local Docker saves to /tmp/terminal_full_output/.
+ * E2B (cloud) saves under ~/terminal_full_output/, local Docker saves under
+ * /tmp/terminal_full_output/. Each chat gets an isolated retained directory.
  * Returns the file path if saved, or null if saving failed.
  */
 export async function saveFullOutputToFile(
   sandbox: AnySandbox,
   fullOutput: string,
+  scopeId?: string,
 ): Promise<string | null> {
   try {
     const now = new Date();
@@ -21,15 +56,22 @@ export async function saveFullOutputToFile(
       .replace(/\./, "_");
     // e.g. 2026-02-17_16-54-34_442Z
 
-    const dir = isE2BSandbox(sandbox)
-      ? "/home/user/terminal_full_output"
-      : "/tmp/terminal_full_output";
+    const dir = getOutputDirectory(sandbox, scopeId);
     const filePath = `${dir}/${timestamp}.txt`;
 
     await sandbox.commands.run(`mkdir -p ${dir}`, {
       timeoutMs: 5000,
     });
     await sandbox.files.write(filePath, fullOutput);
+
+    try {
+      await pruneOldSavedOutputs(sandbox, dir);
+    } catch (err) {
+      console.warn(
+        "[Terminal Command] Failed to prune old saved terminal output:",
+        err,
+      );
+    }
 
     return filePath;
   } catch (err) {
@@ -50,15 +92,16 @@ export async function saveTruncatedOutput(opts: {
   handler: ReturnType<typeof createTerminalHandler>;
   sandbox: AnySandbox;
   terminalWriter: (output: string) => Promise<void>;
+  scopeId?: string;
 }): Promise<string> {
-  const { handler, sandbox, terminalWriter } = opts;
+  const { handler, sandbox, terminalWriter, scopeId } = opts;
 
   if (!handler.wasTruncated()) {
     return "";
   }
 
   const fullOutput = handler.getFullOutput();
-  const savedPath = await saveFullOutputToFile(sandbox, fullOutput);
+  const savedPath = await saveFullOutputToFile(sandbox, fullOutput, scopeId);
 
   if (!savedPath) {
     return "";

--- a/lib/ai/tools/utils/terminal-output-saver.ts
+++ b/lib/ai/tools/utils/terminal-output-saver.ts
@@ -6,6 +6,7 @@ import { asCommonSandbox, isE2BSandbox } from "./sandbox-types";
 
 export const MAX_SAVED_TERMINAL_OUTPUT_FILES = 10;
 
+/** Builds a stable, non-identifying output directory for one chat scope. */
 const getOutputDirectory = (sandbox: AnySandbox, scopeId?: string): string => {
   const baseDirectory = isE2BSandbox(sandbox)
     ? "/home/user/terminal_full_output"
@@ -17,6 +18,7 @@ const getOutputDirectory = (sandbox: AnySandbox, scopeId?: string): string => {
   return `${baseDirectory}/chat-${scopeKey}`;
 };
 
+/** Deletes the oldest timestamped output files beyond the per-chat limit. */
 const pruneOldSavedOutputs = async (
   sandbox: AnySandbox,
   directory: string,

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -62,6 +62,11 @@ jest.mock("@/lib/chat/compaction/prune-tool-outputs", () => ({
     messages,
     prunedCount: 0,
   }),
+  limitModelImageToolResults: (messages: ModelMessage[]) => ({
+    messages,
+    totalImageCount: 0,
+    elidedImageCount: 0,
+  }),
 }));
 jest.mock("@/lib/chat/multimodal-tool-result-recovery", () => ({
   isProviderMultimodalToolResultRejectionError: () => false,

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -55,6 +55,7 @@ import {
   repairAnthropicModelMessagesWithTelemetry,
   pruneToolOutputs,
   pruneModelMessages,
+  limitModelImageToolResults,
 } from "@/lib/chat/compaction/prune-tool-outputs";
 import {
   isProviderMultimodalToolResultRejectionError,
@@ -764,6 +765,9 @@ export async function createAgentStream(
         rawModelMessages,
         rollingContextCheckpoint,
       );
+      rollingModelMessages = limitModelImageToolResults(
+        rollingModelMessages as Array<Record<string, unknown>>,
+      ).messages as ModelMessage[];
       try {
         const pruneResult = pruneToolOutputs(state.finalMessages);
         if (pruneResult.prunedCount > 0) {

--- a/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
+++ b/lib/chat/compaction/__tests__/prune-tool-outputs.test.ts
@@ -7,6 +7,9 @@ import {
   repairAnthropicModelMessages,
   compactMessageForStorage,
   estimateSerializedSizeBytes,
+  ELIDED_IMAGE_TOOL_RESULT_MESSAGE,
+  limitModelImageToolResults,
+  MODEL_IMAGE_TOOL_RESULT_LIMIT,
 } from "../prune-tool-outputs";
 
 // Helper to create a UIMessage with tool parts
@@ -1049,6 +1052,100 @@ function makeToolModelMsg(
     })),
   };
 }
+
+describe("limitModelImageToolResults", () => {
+  const makeImageOutput = (label: string) => ({
+    type: "content",
+    value: [
+      { type: "text", text: `Viewed ${label}` },
+      {
+        type: "image-data",
+        data: Buffer.from(label).toString("base64"),
+        mediaType: "image/png",
+      },
+    ],
+  });
+
+  it("keeps the newest image tool results and elides older image blocks", () => {
+    const messages = Array.from(
+      { length: MODEL_IMAGE_TOOL_RESULT_LIMIT + 1 },
+      (_, index) =>
+        makeToolModelMsg([
+          {
+            toolCallId: `view-${index}`,
+            toolName: "file",
+            output: makeImageOutput(`image-${index}`),
+          },
+        ]),
+    );
+
+    const result = limitModelImageToolResults(messages);
+
+    expect(result.totalImageCount).toBe(MODEL_IMAGE_TOOL_RESULT_LIMIT + 1);
+    expect(result.elidedImageCount).toBe(1);
+    expect((messages[0] as any).content[0].output.value[1].type).toBe(
+      "image-data",
+    );
+    expect((result.messages[0] as any).content[0].output).toEqual({
+      type: "content",
+      value: [
+        { type: "text", text: "Viewed image-0" },
+        { type: "text", text: ELIDED_IMAGE_TOOL_RESULT_MESSAGE },
+      ],
+    });
+    expect(
+      (result.messages.at(-1) as any).content[0].output.value[1].type,
+    ).toBe("image-data");
+  });
+
+  it("preserves sibling text and image ordering within one tool result", () => {
+    const messages = [
+      makeToolModelMsg([
+        {
+          toolCallId: "multi-view",
+          toolName: "file",
+          output: {
+            type: "content",
+            value: [
+              { type: "text", text: "before" },
+              { type: "image-data", data: "old", mediaType: "image/png" },
+              { type: "text", text: "between" },
+              { type: "image-data", data: "new", mediaType: "image/png" },
+            ],
+          },
+        },
+      ]),
+    ];
+
+    const result = limitModelImageToolResults(messages, 1);
+    const value = (result.messages[0] as any).content[0].output.value;
+
+    expect(value).toEqual([
+      { type: "text", text: "before" },
+      { type: "text", text: ELIDED_IMAGE_TOOL_RESULT_MESSAGE },
+      { type: "text", text: "between" },
+      { type: "image-data", data: "new", mediaType: "image/png" },
+    ]);
+  });
+
+  it("returns the original messages when the image count is within the limit", () => {
+    const messages = [
+      makeToolModelMsg([
+        {
+          toolCallId: "view-1",
+          toolName: "file",
+          output: makeImageOutput("image-1"),
+        },
+      ]),
+    ];
+
+    const result = limitModelImageToolResults(messages);
+
+    expect(result.messages).toBe(messages);
+    expect(result.totalImageCount).toBe(1);
+    expect(result.elidedImageCount).toBe(0);
+  });
+});
 
 describe("pruneModelMessages", () => {
   it("returns messages unchanged when within budget", () => {

--- a/lib/chat/compaction/prune-tool-outputs.ts
+++ b/lib/chat/compaction/prune-tool-outputs.ts
@@ -894,6 +894,117 @@ const toTextModelToolOutput = (value: string) => ({
   value,
 });
 
+export const MODEL_IMAGE_TOOL_RESULT_LIMIT = 3;
+export const ELIDED_IMAGE_TOOL_RESULT_MESSAGE =
+  "[Older image tool result omitted to bound Agent context. Re-run the view action if visual inspection is still needed.]";
+
+export interface ModelImageToolResultLimit {
+  messages: Array<Record<string, unknown>>;
+  totalImageCount: number;
+  elidedImageCount: number;
+}
+
+const isModelImageOutputPart = (part: unknown): boolean =>
+  typeof part === "object" &&
+  part !== null &&
+  ((part as { type?: unknown }).type === "image-data" ||
+    (part as { type?: unknown }).type === "image" ||
+    (part as { type?: unknown }).type === "image-url");
+
+const replaceModelToolOutputValue = (
+  output: unknown,
+  value: unknown,
+): unknown =>
+  isModelToolOutput(output) && Object.hasOwn(output, "value")
+    ? { ...output, value }
+    : value;
+
+/**
+ * Keeps only the newest image blocks returned by tools during an agentic loop.
+ *
+ * Image payloads are much heavier than their token estimate suggests and can
+ * otherwise accumulate across consecutive file view calls. Text blocks in the
+ * same result are preserved so paths, dimensions, and other evidence remain
+ * available to the model.
+ */
+export function limitModelImageToolResults(
+  messages: Array<Record<string, unknown>>,
+  maxImages: number = MODEL_IMAGE_TOOL_RESULT_LIMIT,
+): ModelImageToolResultLimit {
+  const normalizedMaxImages = Math.max(0, Math.floor(maxImages));
+  let totalImageCount = 0;
+  const imagePartsToElide = new Set<string>();
+
+  for (let mi = messages.length - 1; mi >= 0; mi--) {
+    const message = messages[mi];
+    if (message.role !== "tool" || !Array.isArray(message.content)) continue;
+
+    for (let pi = message.content.length - 1; pi >= 0; pi--) {
+      const part = message.content[pi] as ToolResultPart;
+      if (part.type !== "tool-result") continue;
+
+      const outputValue = unwrapModelToolOutput(part.output);
+      if (!Array.isArray(outputValue)) continue;
+
+      for (let oi = outputValue.length - 1; oi >= 0; oi--) {
+        if (!isModelImageOutputPart(outputValue[oi])) continue;
+        totalImageCount++;
+        if (totalImageCount > normalizedMaxImages) {
+          imagePartsToElide.add(`${mi}:${pi}:${oi}`);
+        }
+      }
+    }
+  }
+
+  if (imagePartsToElide.size === 0) {
+    return {
+      messages,
+      totalImageCount,
+      elidedImageCount: 0,
+    };
+  }
+
+  const limitedMessages = messages.map((message, mi) => {
+    if (message.role !== "tool" || !Array.isArray(message.content)) {
+      return message;
+    }
+
+    let messageChanged = false;
+    const content = message.content.map((rawPart, pi) => {
+      const part = rawPart as ToolResultPart;
+      if (part.type !== "tool-result") return rawPart;
+
+      const outputValue = unwrapModelToolOutput(part.output);
+      if (!Array.isArray(outputValue)) return rawPart;
+
+      let outputChanged = false;
+      const limitedOutput = outputValue.map((outputPart, oi) => {
+        if (!imagePartsToElide.has(`${mi}:${pi}:${oi}`)) return outputPart;
+        outputChanged = true;
+        return {
+          type: "text" as const,
+          text: ELIDED_IMAGE_TOOL_RESULT_MESSAGE,
+        };
+      });
+
+      if (!outputChanged) return rawPart;
+      messageChanged = true;
+      return {
+        ...part,
+        output: replaceModelToolOutputValue(part.output, limitedOutput),
+      };
+    });
+
+    return messageChanged ? { ...message, content } : message;
+  });
+
+  return {
+    messages: limitedMessages,
+    totalImageCount,
+    elidedImageCount: imagePartsToElide.size,
+  };
+}
+
 export interface ModelPruneResult {
   messages: Array<Record<string, unknown>>;
   prunedCount: number;

--- a/lib/chat/compaction/prune-tool-outputs.ts
+++ b/lib/chat/compaction/prune-tool-outputs.ts
@@ -904,6 +904,7 @@ export interface ModelImageToolResultLimit {
   elidedImageCount: number;
 }
 
+/** Identifies image blocks supported by AI SDK model tool-result content. */
 const isModelImageOutputPart = (part: unknown): boolean =>
   typeof part === "object" &&
   part !== null &&
@@ -911,6 +912,7 @@ const isModelImageOutputPart = (part: unknown): boolean =>
     (part as { type?: unknown }).type === "image" ||
     (part as { type?: unknown }).type === "image-url");
 
+/** Preserves an AI SDK output wrapper while replacing its underlying value. */
 const replaceModelToolOutputValue = (
   output: unknown,
   value: unknown,

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -89,6 +89,14 @@ Screenshots:
 - For pages with responsive layouts, run \`agent-browser set viewport 1920 1080\` once before navigating.
 </agent_browser>`;
 
+const AGENT_ARTIFACT_HYGIENE_SECTION = `<agent_artifact_hygiene>
+- Bound reconnaissance by the target and declared scope, crawl depth, duration, concurrency, and output size. Start narrow and expand only when the evidence justifies it.
+- For Katana, prefer bounded crawl duration and depth, scoped URL filtering, and URL-only output when raw request or response bodies are not needed. Reserve JavaScript-heavy and deep-crawl modes for narrowed targets.
+- Distill and deduplicate useful evidence before deleting raw output. Remove only artifacts created for the current task; never delete user, project, or other-agent files unless explicitly requested or confirmed unused.
+- Use task-unique proof-of-concept filenames such as \`poc_<task-id>.py\` instead of generic names such as \`exploit.py\` or \`poc.py\`, especially on local or remote hosts.
+- If a command fails because the sandbox is out of disk space or cannot write, inspect artifact sizes and clean up this task's disposable files before continuing.
+</agent_artifact_hygiene>`;
+
 type SecurityExecutionEnvironment = "ask" | "cloud" | "local-host";
 
 const getExecutionEnvironmentSecurityText = (
@@ -223,6 +231,8 @@ You have tools at your disposal to solve the penetration testing task. Follow th
 </tool_calling>
 
 ${getAgentToolApprovalSection(agentPermissionMode)}
+
+${AGENT_ARTIFACT_HYGIENE_SECTION}
 
 <maximize_parallel_tool_calls>
 Security assessments often require sequential workflows due to dependencies (e.g., discover targets → scan ports → enumerate services → test vulnerabilities). However, when operations are truly independent, execute them concurrently for efficiency.


### PR DESCRIPTION
## Summary

- keep only the newest three image blocks from Agent tool results while preserving sibling text and replacing older images with a re-view marker
- add Agent guidance for bounded reconnaissance, evidence distillation, task-owned cleanup, and unique PoC filenames
- store truncated terminal output in chat-scoped directories and retain only the newest ten files per chat
- cap local Docker sandbox logs at 50 MB across three rotated files by default using the compatible `local` driver

## Why

Several reliability gaps were present in HackerAI's solo Agent workflows. Consecutive screenshot views can accumulate heavyweight model context, truncated terminal files can grow without retention boundaries, broad recon can leave oversized artifacts, and the local Docker helper had no log rotation.

These changes add narrow limits at the existing Agent/runtime boundaries without changing orchestration, sandbox providers, or the user-visible workflow.

## Impact

- Agent keeps the newest visual evidence available while avoiding unbounded image-result context
- cloud, desktop, and remote terminal truncation artifacts are separated by chat and bounded to ten files
- prompts encourage narrower scans and safer cleanup without deleting user or project files
- local Docker users get bounded container logs with validated overrides through `HACKERAI_DOCKER_LOG_MAX_SIZE` and `HACKERAI_DOCKER_LOG_MAX_FILE`

## Validation

- `pnpm test --runInBand` — 263 suites, 2,659 tests
- `pnpm typecheck`
- `pnpm lint` — passes with six existing warnings
- `pnpm exec prettier --check ...`
- `bash -n docker/run.sh`
- commit hooks reran formatting, lint fixes, typecheck, and the full test suite

## Manual verification

- In Agent mode, view more than three screenshots in one run and confirm later steps retain the newest three images while older results remain as text with a re-view instruction.
- Run a command whose output is truncated and confirm the saved path is under a chat-scoped `terminal_full_output/chat-*` directory; after more than ten saved outputs in that chat, confirm only the newest ten remain.
- Start the local sandbox with `docker/run.sh`, then inspect the container log configuration and confirm the `local` driver with `max-size=50m` and `max-file=3` (or supplied environment overrides).
