### PR TITLE
Bound account deletion cleanup reads

### DIFF
--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -706,13 +706,17 @@ describe("userDeletion", () => {
     ).rejects.toThrow("processes one userId per mutation");
   });
 
-  it("reports remaining work and completes on a later batch when an indexed query exceeds the batch size", async () => {
+  it("keeps cleanup reads bounded and preserves chats until a later message batch", async () => {
     const { deleteAllUserData } = await import("../userDeletion");
     const tables = seedTables();
-    tables.notes = Array.from({ length: 501 }, (_, index) => ({
-      _id: `note-user-${index}`,
+    tables.messages = Array.from({ length: 101 }, (_, index) => ({
+      _id: `message-user-${index}`,
+      id: `msg-${index}`,
+      chat_id: "chat-1",
       user_id: "user_123",
-      note_id: `note-${index}`,
+      role: "user",
+      parts: [{ type: "text", text: "large message payload" }],
+      update_time: index,
     }));
     const { ctx } = createMockCtx(tables);
 
@@ -720,16 +724,17 @@ describe("userDeletion", () => {
 
     expect(firstBatch.hasMore).toBe(true);
     expect(
-      tables.notes.filter((candidate) => candidate.user_id === "user_123"),
+      tables.messages.filter((candidate) => candidate.user_id === "user_123"),
     ).toHaveLength(1);
-    expect(row(tables, "chats", "chat-doc")).toBeUndefined();
+    expect(row(tables, "chats", "chat-doc")).toBeTruthy();
 
     const secondBatch = await deleteAllUserData.handler(ctx as any, {});
 
     expect(secondBatch.hasMore).toBe(false);
     expect(
-      tables.notes.filter((candidate) => candidate.user_id === "user_123"),
+      tables.messages.filter((candidate) => candidate.user_id === "user_123"),
     ).toHaveLength(0);
+    expect(row(tables, "chats", "chat-doc")).toBeUndefined();
   });
 
   it("fails user deletion if S3 cleanup scheduling fails", async () => {

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -725,6 +725,20 @@ describe("userDeletion", () => {
     ).rejects.toThrow("processes one userId per mutation");
   });
 
+  it("rejects combined user and orphan-summary residue cleanup", async () => {
+    const { cleanupDeletedUserResidue } = await import("../userDeletion");
+    const tables = seedTables();
+    const { ctx } = createMockCtx(tables);
+
+    await expect(
+      cleanupDeletedUserResidue.handler(ctx as any, {
+        serviceKey: "service_key",
+        userIds: ["user_123"],
+        deleteOrphanChatSummaries: true,
+      }),
+    ).rejects.toThrow("separate mutations");
+  });
+
   it("keeps cleanup reads bounded and preserves chats until a later message batch", async () => {
     const { deleteAllUserData } = await import("../userDeletion");
     const tables = seedTables();

--- a/convex/__tests__/userDeletion.test.ts
+++ b/convex/__tests__/userDeletion.test.ts
@@ -38,18 +38,31 @@ jest.mock("../fileAggregate", () => ({
 
 type Row = { _id: string; [key: string]: any };
 type Tables = Record<string, Row[]>;
+type ReadCounter = { value: number };
 
-function createQueryResult(rows: Row[]) {
+function createQueryResult(rows: Row[], readCounter: ReadCounter) {
   return {
     collect: jest.fn(async () => rows),
-    first: jest.fn(async () => rows[0] ?? null),
+    first: jest.fn(async () => {
+      const result = rows[0] ?? null;
+      if (result) readCounter.value += 1;
+      return result;
+    }),
     unique: jest.fn(async () => rows[0] ?? null),
-    take: jest.fn(async (limit: number) => rows.slice(0, limit)),
-    order: jest.fn(() => createQueryResult(rows)),
+    take: jest.fn(async (limit: number) => {
+      const result = rows.slice(0, limit);
+      readCounter.value += result.length;
+      return result;
+    }),
+    order: jest.fn(() => createQueryResult(rows, readCounter)),
   };
 }
 
-function createQueryBuilder(tables: Tables, table: string) {
+function createQueryBuilder(
+  tables: Tables,
+  table: string,
+  readCounter: ReadCounter,
+) {
   const tableRows = () => tables[table] ?? [];
 
   const filterRows = (filters: Array<{ field: string; value: any }>) =>
@@ -69,7 +82,7 @@ function createQueryBuilder(tables: Tables, table: string) {
         lte: () => q,
       };
       build(q);
-      return createQueryResult(filterRows(filters));
+      return createQueryResult(filterRows(filters), readCounter);
     }),
     collect: jest.fn(async () => tableRows()),
     take: jest.fn(async (limit: number) => tableRows().slice(0, limit)),
@@ -83,6 +96,7 @@ function createQueryBuilder(tables: Tables, table: string) {
       }) => {
         const start = cursor ? Number(cursor) : 0;
         const page = tableRows().slice(start, start + numItems);
+        readCounter.value += page.length;
         const next = start + page.length;
         return {
           page,
@@ -97,13 +111,17 @@ function createQueryBuilder(tables: Tables, table: string) {
 function createMockCtx(tables: Tables, subject = "user_123") {
   const deletedIds: string[] = [];
   const patches: Array<{ id: string; patch: Record<string, any> }> = [];
+  const readCounter: ReadCounter = { value: 0 };
   const scheduler = {
     runAfter: jest.fn().mockResolvedValue(undefined),
   };
 
   const db = {
-    query: jest.fn((table: string) => createQueryBuilder(tables, table)),
+    query: jest.fn((table: string) =>
+      createQueryBuilder(tables, table, readCounter),
+    ),
     get: jest.fn(async (id: string) => {
+      readCounter.value += 1;
       for (const rows of Object.values(tables)) {
         const row = rows.find((candidate) => candidate._id === id);
         if (row) return row;
@@ -147,6 +165,7 @@ function createMockCtx(tables: Tables, subject = "user_123") {
     scheduler,
     deletedIds,
     patches,
+    readCounter,
   };
 }
 
@@ -709,6 +728,10 @@ describe("userDeletion", () => {
   it("keeps cleanup reads bounded and preserves chats until a later message batch", async () => {
     const { deleteAllUserData } = await import("../userDeletion");
     const tables = seedTables();
+    tables.feedback = Array.from({ length: 101 }, (_, index) => ({
+      _id: `feedback-user-${index}`,
+      feedback_type: "positive",
+    }));
     tables.messages = Array.from({ length: 101 }, (_, index) => ({
       _id: `message-user-${index}`,
       id: `msg-${index}`,
@@ -716,24 +739,43 @@ describe("userDeletion", () => {
       user_id: "user_123",
       role: "user",
       parts: [{ type: "text", text: "large message payload" }],
+      feedback_id: `feedback-user-${index}`,
       update_time: index,
     }));
-    const { ctx } = createMockCtx(tables);
+    const { ctx, readCounter } = createMockCtx(tables);
 
     const firstBatch = await deleteAllUserData.handler(ctx as any, {});
+    const firstBatchReads = readCounter.value;
 
     expect(firstBatch.hasMore).toBe(true);
     expect(
       tables.messages.filter((candidate) => candidate.user_id === "user_123"),
-    ).toHaveLength(1);
+    ).toHaveLength(52);
+    expect(tables.feedback).toHaveLength(52);
+    expect(firstBatchReads).toBeLessThanOrEqual(100);
     expect(row(tables, "chats", "chat-doc")).toBeTruthy();
 
     const secondBatch = await deleteAllUserData.handler(ctx as any, {});
+    const secondBatchReads = readCounter.value - firstBatchReads;
 
-    expect(secondBatch.hasMore).toBe(false);
+    expect(secondBatch.hasMore).toBe(true);
+    expect(
+      tables.messages.filter((candidate) => candidate.user_id === "user_123"),
+    ).toHaveLength(3);
+    expect(tables.feedback).toHaveLength(3);
+    expect(secondBatchReads).toBeLessThanOrEqual(100);
+    expect(row(tables, "chats", "chat-doc")).toBeTruthy();
+
+    const thirdBatch = await deleteAllUserData.handler(ctx as any, {});
+    const thirdBatchReads =
+      readCounter.value - firstBatchReads - secondBatchReads;
+
+    expect(thirdBatch.hasMore).toBe(false);
     expect(
       tables.messages.filter((candidate) => candidate.user_id === "user_123"),
     ).toHaveLength(0);
+    expect(tables.feedback).toHaveLength(0);
+    expect(thirdBatchReads).toBeLessThanOrEqual(100);
     expect(row(tables, "chats", "chat-doc")).toBeUndefined();
   });
 

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -46,7 +46,10 @@ export const USER_DELETION_TABLE_POLICY = {
 type AnyDoc = { _id: Id<any>; [key: string]: any };
 type CleanupMode = "execute" | "dryRun";
 
-const MAX_CLEANUP_DOCS_PER_INDEX = 500;
+// Convex counts full document payloads toward a mutation's 16 MiB read limit.
+// Keep each cleanup pass small enough for message-heavy accounts; the account
+// deletion route already repeats the mutation while `hasMore` is true.
+const MAX_CLEANUP_DOCS_PER_INDEX = 100;
 const MAX_RESIDUE_USER_IDS_PER_MUTATION = 1;
 
 type CleanupStats = {

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -808,6 +808,12 @@ export const cleanupDeletedUserResidue = mutation({
       );
     }
 
+    if (userIds.length > 0 && args.deleteOrphanChatSummaries) {
+      throw new Error(
+        "Run user data cleanup and orphan chat summary cleanup in separate mutations to keep Convex transactions bounded",
+      );
+    }
+
     if (userIds.length > MAX_RESIDUE_USER_IDS_PER_MUTATION) {
       throw new Error(
         "cleanupDeletedUserResidue processes one userId per mutation to keep Convex transactions bounded",

--- a/convex/userDeletion.ts
+++ b/convex/userDeletion.ts
@@ -47,10 +47,14 @@ type AnyDoc = { _id: Id<any>; [key: string]: any };
 type CleanupMode = "execute" | "dryRun";
 
 // Convex counts full document payloads toward a mutation's 16 MiB read limit.
-// Keep each cleanup pass small enough for message-heavy accounts; the account
+// Share one document budget across the entire cleanup pass; the account
 // deletion route already repeats the mutation while `hasMore` is true.
-const MAX_CLEANUP_DOCS_PER_INDEX = 100;
+const MAX_CLEANUP_DOCS_PER_MUTATION = 100;
 const MAX_RESIDUE_USER_IDS_PER_MUTATION = 1;
+
+type ReadBudget = {
+  remaining: number;
+};
 
 type CleanupStats = {
   deleted: Record<string, number>;
@@ -132,11 +136,14 @@ function uniqueDocs<T extends AnyDoc>(docs: Array<T | null | undefined>): T[] {
 
 async function collectByIndexBatch<T extends AnyDoc>(
   ctx: MutationCtx,
+  budget: ReadBudget,
   table: string,
   indexName: string,
   build: (q: any) => any,
-  limit = MAX_CLEANUP_DOCS_PER_INDEX,
+  requestedLimit = MAX_CLEANUP_DOCS_PER_MUTATION,
 ): Promise<IndexedBatch<T>> {
+  // Reserve one read for the lookahead row used to determine `hasMore`.
+  const limit = Math.min(requestedLimit, budget.remaining - 1);
   if (limit <= 0) {
     return { docs: [], hasMore: true };
   }
@@ -144,6 +151,7 @@ async function collectByIndexBatch<T extends AnyDoc>(
   const rows = await (ctx.db.query(table as any) as any)
     .withIndex(indexName, build)
     .take(limit + 1);
+  budget.remaining -= rows.length;
 
   const hasMore = rows.length > limit;
   const docs = hasMore ? rows.slice(0, limit) : rows;
@@ -200,15 +208,15 @@ async function anonymizeDocs(
 
 async function collectChatSummariesForChats(
   ctx: MutationCtx,
+  budget: ReadBudget,
   chats: Doc<"chats">[],
   stats: CleanupStats,
 ) {
   const summaries: Doc<"chat_summaries">[] = [];
   const incompleteChatIds = new Set<string>();
-  let remainingSummaryReads = MAX_CLEANUP_DOCS_PER_INDEX;
 
   for (const chat of chats) {
-    if (remainingSummaryReads <= 0) {
+    if (budget.remaining <= 1) {
       stats.hasMore = true;
       incompleteChatIds.add(chat.id);
       continue;
@@ -216,13 +224,12 @@ async function collectChatSummariesForChats(
 
     const batch = await collectByIndexBatch<Doc<"chat_summaries">>(
       ctx,
+      budget,
       "chat_summaries",
       "by_chat_id",
       (q) => q.eq("chat_id", chat.id),
-      remainingSummaryReads,
     );
     summaries.push(...batch.docs);
-    remainingSummaryReads -= batch.docs.length;
 
     if (batch.hasMore) {
       stats.hasMore = true;
@@ -234,14 +241,18 @@ async function collectChatSummariesForChats(
       continue;
     }
 
-    if (remainingSummaryReads <= 0) {
+    if (summaries.some((summary) => summary._id === chat.latest_summary_id)) {
+      continue;
+    }
+
+    if (budget.remaining <= 0) {
       stats.hasMore = true;
       incompleteChatIds.add(chat.id);
       continue;
     }
 
     const latestSummary = await ctx.db.get(chat.latest_summary_id);
-    remainingSummaryReads -= 1;
+    budget.remaining -= 1;
     if (latestSummary) {
       summaries.push(latestSummary);
     }
@@ -293,81 +304,107 @@ async function cleanupUserDataForUser(
 ) {
   const stats = createStats();
   const now = Date.now();
+  const budget: ReadBudget = {
+    remaining: MAX_CLEANUP_DOCS_PER_MUTATION,
+  };
 
-  const [
-    chatsBatch,
-    filesBatch,
-    notesBatch,
-    customizationBatch,
-    messagesBatch,
-    tempStreamsBatch,
-    localSandboxTokensBatch,
-    localSandboxConnectionsBatch,
-    extraUsageBatch,
-    teamMemberUsageBatch,
-    cancellationReasonDetailsBatch,
-  ] = await Promise.all([
-    collectByIndexBatch<Doc<"chats">>(
-      ctx,
-      "chats",
-      "by_user_and_updated",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"files">>(ctx, "files", "by_user_id", (q) =>
-      q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"notes">>(
-      ctx,
-      "notes",
-      "by_user_and_updated",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"user_customization">>(
-      ctx,
-      "user_customization",
-      "by_user_id",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"messages">>(ctx, "messages", "by_user_id", (q) =>
-      q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"temp_streams">>(
-      ctx,
-      "temp_streams",
-      "by_user_id",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"local_sandbox_tokens">>(
-      ctx,
-      "local_sandbox_tokens",
-      "by_user_id",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"local_sandbox_connections">>(
-      ctx,
-      "local_sandbox_connections",
-      "by_user_id",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"extra_usage">>(
-      ctx,
-      "extra_usage",
-      "by_user_id",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"team_member_usage">>(
-      ctx,
-      "team_member_usage",
-      "by_user_id",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"cancellation_reason_details">>(
-      ctx,
-      "cancellation_reason_details",
-      "by_user_id_and_created_at",
-      (q) => q.eq("user_id", userId),
-    ),
-  ]);
+  // A message may point to one feedback document that must be deleted first,
+  // so reserve enough of the shared budget for those direct lookups.
+  const messageLimit = Math.floor((budget.remaining - 1) / 2);
+  const messagesBatch = await collectByIndexBatch<Doc<"messages">>(
+    ctx,
+    budget,
+    "messages",
+    "by_user_id",
+    (q) => q.eq("user_id", userId),
+    messageLimit,
+  );
+  const messages = messagesBatch.docs;
+  const feedbackIds = uniqueDocs(messages)
+    .map((message) => message.feedback_id)
+    .filter((id): id is Id<"feedback"> => !!id);
+  const feedback: Array<Doc<"feedback"> | null> = [];
+  for (const feedbackId of feedbackIds) {
+    if (budget.remaining <= 0) {
+      stats.hasMore = true;
+      break;
+    }
+    feedback.push(await ctx.db.get(feedbackId));
+    budget.remaining -= 1;
+  }
+
+  // Chat cleanup can require both an indexed summary read and a legacy latest
+  // summary lookup for each chat, so leave room for both.
+  const chatLimit = Math.floor((budget.remaining - 1) / 3);
+  const chatsBatch = await collectByIndexBatch<Doc<"chats">>(
+    ctx,
+    budget,
+    "chats",
+    "by_user_and_updated",
+    (q) => q.eq("user_id", userId),
+    chatLimit,
+  );
+  const chats = chatsBatch.docs;
+  const { summaries: chatSummaries, incompleteChatIds } =
+    await collectChatSummariesForChats(ctx, budget, chats, stats);
+
+  const filesBatch = await collectByIndexBatch<Doc<"files">>(
+    ctx,
+    budget,
+    "files",
+    "by_user_id",
+    (q) => q.eq("user_id", userId),
+  );
+  const notesBatch = await collectByIndexBatch<Doc<"notes">>(
+    ctx,
+    budget,
+    "notes",
+    "by_user_and_updated",
+    (q) => q.eq("user_id", userId),
+  );
+  const customizationBatch = await collectByIndexBatch<
+    Doc<"user_customization">
+  >(ctx, budget, "user_customization", "by_user_id", (q) =>
+    q.eq("user_id", userId),
+  );
+  const tempStreamsBatch = await collectByIndexBatch<Doc<"temp_streams">>(
+    ctx,
+    budget,
+    "temp_streams",
+    "by_user_id",
+    (q) => q.eq("user_id", userId),
+  );
+  const localSandboxTokensBatch = await collectByIndexBatch<
+    Doc<"local_sandbox_tokens">
+  >(ctx, budget, "local_sandbox_tokens", "by_user_id", (q) =>
+    q.eq("user_id", userId),
+  );
+  const localSandboxConnectionsBatch = await collectByIndexBatch<
+    Doc<"local_sandbox_connections">
+  >(ctx, budget, "local_sandbox_connections", "by_user_id", (q) =>
+    q.eq("user_id", userId),
+  );
+  const extraUsageBatch = await collectByIndexBatch<Doc<"extra_usage">>(
+    ctx,
+    budget,
+    "extra_usage",
+    "by_user_id",
+    (q) => q.eq("user_id", userId),
+  );
+  const teamMemberUsageBatch = await collectByIndexBatch<
+    Doc<"team_member_usage">
+  >(ctx, budget, "team_member_usage", "by_user_id", (q) =>
+    q.eq("user_id", userId),
+  );
+  const cancellationReasonDetailsBatch = await collectByIndexBatch<
+    Doc<"cancellation_reason_details">
+  >(
+    ctx,
+    budget,
+    "cancellation_reason_details",
+    "by_user_id_and_created_at",
+    (q) => q.eq("user_id", userId),
+  );
 
   const deletionBatches = [
     chatsBatch,
@@ -384,11 +421,9 @@ async function cleanupUserDataForUser(
   ];
   stats.hasMore ||= deletionBatches.some((batch) => batch.hasMore);
 
-  const chats = chatsBatch.docs;
   const files = filesBatch.docs;
   const notes = notesBatch.docs;
   const customization = customizationBatch.docs;
-  const messages = messagesBatch.docs;
   const tempStreams = tempStreamsBatch.docs;
   const localSandboxTokens = localSandboxTokensBatch.docs;
   const localSandboxConnections = localSandboxConnectionsBatch.docs;
@@ -396,12 +431,6 @@ async function cleanupUserDataForUser(
   const teamMemberUsage = teamMemberUsageBatch.docs;
   const cancellationReasonDetails = cancellationReasonDetailsBatch.docs;
 
-  const feedbackIds = uniqueDocs(messages)
-    .map((message) => message.feedback_id)
-    .filter((id): id is Id<"feedback"> => !!id);
-  const feedback = await Promise.all(feedbackIds.map((id) => ctx.db.get(id)));
-  const { summaries: chatSummaries, incompleteChatIds } =
-    await collectChatSummariesForChats(ctx, chats, stats);
   const chatsReadyToDelete = messagesBatch.hasMore
     ? []
     : chats.filter((chat) => !incompleteChatIds.has(chat.id));
@@ -441,118 +470,94 @@ async function cleanupUserDataForUser(
     mode,
   );
 
-  const [
-    cancellationReasonsBatch,
-    usageLogsBatch,
-    referralCodesBatch,
-    referredAttributionsBatch,
-    referrerAttributionsBatch,
-    referralRewardsByUserBatch,
-    referralRewardsByReferrerBatch,
-    referralRewardsByReferredBatch,
-    userSuspensionsBatch,
-    revenueByUserBatch,
-    revenueByEntityBatch,
-    extraUsagePurchasesBatch,
-    paidStartsByUserBatch,
-    paidStartsByEntityBatch,
-    unitEconomicsByUserBatch,
-    unitEconomicsByEntityBatch,
-  ] = await Promise.all([
-    collectByIndexBatch<Doc<"cancellation_reasons">>(
-      ctx,
-      "cancellation_reasons",
-      "by_user_started",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"usage_logs">>(ctx, "usage_logs", "by_user", (q) =>
-      q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"referral_codes">>(
-      ctx,
-      "referral_codes",
-      "by_user_id",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"referral_attributions">>(
-      ctx,
-      "referral_attributions",
-      "by_referred_user_id",
-      (q) => q.eq("referred_user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"referral_attributions">>(
-      ctx,
-      "referral_attributions",
-      "by_referrer_user_id",
-      (q) => q.eq("referrer_user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"referral_rewards">>(
-      ctx,
-      "referral_rewards",
-      "by_user_id",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"referral_rewards">>(
-      ctx,
-      "referral_rewards",
-      "by_referrer_user_id",
-      (q) => q.eq("referrer_user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"referral_rewards">>(
-      ctx,
-      "referral_rewards",
-      "by_referred_user_id",
-      (q) => q.eq("referred_user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"user_suspensions">>(
-      ctx,
-      "user_suspensions",
-      "by_user_id",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"revenue_events">>(
-      ctx,
-      "revenue_events",
-      "by_user_occurred",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"revenue_events">>(
-      ctx,
-      "revenue_events",
-      "by_entity_occurred",
-      (q) => q.eq("entity_type", "user").eq("entity_id", userId),
-    ),
-    collectByIndexBatch<Doc<"extra_usage_purchases">>(
-      ctx,
-      "extra_usage_purchases",
-      "by_user_created_at",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"paid_start_events">>(
-      ctx,
-      "paid_start_events",
-      "by_user_day",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"paid_start_events">>(
-      ctx,
-      "paid_start_events",
-      "by_entity_day",
-      (q) => q.eq("entity_type", "user").eq("entity_id", userId),
-    ),
-    collectByIndexBatch<Doc<"unit_economics_daily">>(
-      ctx,
-      "unit_economics_daily",
-      "by_user_day",
-      (q) => q.eq("user_id", userId),
-    ),
-    collectByIndexBatch<Doc<"unit_economics_daily">>(
-      ctx,
-      "unit_economics_daily",
-      "by_entity_day",
-      (q) => q.eq("entity_type", "user").eq("entity_id", userId),
-    ),
-  ]);
+  const cancellationReasonsBatch = await collectByIndexBatch<
+    Doc<"cancellation_reasons">
+  >(ctx, budget, "cancellation_reasons", "by_user_started", (q) =>
+    q.eq("user_id", userId),
+  );
+  const usageLogsBatch = await collectByIndexBatch<Doc<"usage_logs">>(
+    ctx,
+    budget,
+    "usage_logs",
+    "by_user",
+    (q) => q.eq("user_id", userId),
+  );
+  const referralCodesBatch = await collectByIndexBatch<Doc<"referral_codes">>(
+    ctx,
+    budget,
+    "referral_codes",
+    "by_user_id",
+    (q) => q.eq("user_id", userId),
+  );
+  const referredAttributionsBatch = await collectByIndexBatch<
+    Doc<"referral_attributions">
+  >(ctx, budget, "referral_attributions", "by_referred_user_id", (q) =>
+    q.eq("referred_user_id", userId),
+  );
+  const referrerAttributionsBatch = await collectByIndexBatch<
+    Doc<"referral_attributions">
+  >(ctx, budget, "referral_attributions", "by_referrer_user_id", (q) =>
+    q.eq("referrer_user_id", userId),
+  );
+  const referralRewardsByUserBatch = await collectByIndexBatch<
+    Doc<"referral_rewards">
+  >(ctx, budget, "referral_rewards", "by_user_id", (q) =>
+    q.eq("user_id", userId),
+  );
+  const referralRewardsByReferrerBatch = await collectByIndexBatch<
+    Doc<"referral_rewards">
+  >(ctx, budget, "referral_rewards", "by_referrer_user_id", (q) =>
+    q.eq("referrer_user_id", userId),
+  );
+  const referralRewardsByReferredBatch = await collectByIndexBatch<
+    Doc<"referral_rewards">
+  >(ctx, budget, "referral_rewards", "by_referred_user_id", (q) =>
+    q.eq("referred_user_id", userId),
+  );
+  const userSuspensionsBatch = await collectByIndexBatch<
+    Doc<"user_suspensions">
+  >(ctx, budget, "user_suspensions", "by_user_id", (q) =>
+    q.eq("user_id", userId),
+  );
+  const revenueByUserBatch = await collectByIndexBatch<Doc<"revenue_events">>(
+    ctx,
+    budget,
+    "revenue_events",
+    "by_user_occurred",
+    (q) => q.eq("user_id", userId),
+  );
+  const revenueByEntityBatch = await collectByIndexBatch<Doc<"revenue_events">>(
+    ctx,
+    budget,
+    "revenue_events",
+    "by_entity_occurred",
+    (q) => q.eq("entity_type", "user").eq("entity_id", userId),
+  );
+  const extraUsagePurchasesBatch = await collectByIndexBatch<
+    Doc<"extra_usage_purchases">
+  >(ctx, budget, "extra_usage_purchases", "by_user_created_at", (q) =>
+    q.eq("user_id", userId),
+  );
+  const paidStartsByUserBatch = await collectByIndexBatch<
+    Doc<"paid_start_events">
+  >(ctx, budget, "paid_start_events", "by_user_day", (q) =>
+    q.eq("user_id", userId),
+  );
+  const paidStartsByEntityBatch = await collectByIndexBatch<
+    Doc<"paid_start_events">
+  >(ctx, budget, "paid_start_events", "by_entity_day", (q) =>
+    q.eq("entity_type", "user").eq("entity_id", userId),
+  );
+  const unitEconomicsByUserBatch = await collectByIndexBatch<
+    Doc<"unit_economics_daily">
+  >(ctx, budget, "unit_economics_daily", "by_user_day", (q) =>
+    q.eq("user_id", userId),
+  );
+  const unitEconomicsByEntityBatch = await collectByIndexBatch<
+    Doc<"unit_economics_daily">
+  >(ctx, budget, "unit_economics_daily", "by_entity_day", (q) =>
+    q.eq("entity_type", "user").eq("entity_id", userId),
+  );
 
   const anonymizeBatches = [
     cancellationReasonsBatch,


### PR DESCRIPTION
## Production evidence

Audit window: `2026-07-15T20:01:26Z` to `2026-07-16T20:01:26Z`.

- Vercel recorded two production `POST /api/delete-account` 500s at `2026-07-16T16:09:39.279Z` and `2026-07-16T16:09:46.197Z` on deployment `dpl_8ZGPaReP6Bayg7YTFbMAiozt9dAG`.
- PostHog grouped both attempts under: `Uncaught Error: Too many bytes read in a single function execution (limit: 16777216 bytes). Consider using smaller limits in your queries, paginating your queries, or using indexed queries with a selective index range expressions.`
- Impact was one user; account deletion stopped at `delete_convex_user_data`.

## Root cause

`cleanupUserDataForUser` ran 27 indexed batch reads plus feedback and chat-summary lookups in one Convex mutation. Capping each index independently still allowed the aggregate transaction to exceed Convex's 16 MiB read limit before the route could follow the existing `hasMore` loop.

## Change

- Enforce one 100-document read budget across the entire cleanup mutation, including indexed batches, feedback lookups, and chat-summary lookups.
- Run indexed cleanup reads sequentially so every query consumes the shared budget.
- Preserve feedback-before-message and summary-before-chat deletion ordering while the route advances through repeated `hasMore` batches.
- Add a regression with 101 messages and 101 feedback documents that verifies each mutation stays within the shared budget and completes in three passes.

## Validation

- `corepack pnpm jest convex/__tests__/userDeletion.test.ts app/api/delete-account/__tests__/route.test.ts --runInBand`
- `corepack pnpm exec eslint convex/userDeletion.ts convex/__tests__/userDeletion.test.ts`
- `corepack pnpm exec prettier --check convex/userDeletion.ts convex/__tests__/userDeletion.test.ts`
- `corepack pnpm typecheck`
- Commit hooks after both commits: 262 suites / 2649 tests passed

## Manual verification

1. In a non-production environment, use an account with more than 100 message documents and associated feedback, including large message payloads.
2. Delete the account from account settings.
3. Confirm the request succeeds, Convex cleanup advances through repeated batches, feedback is removed before messages, chats remain until their messages and summaries are gone, and no 16 MiB read-limit exception is emitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user data cleanup to enforce a shared per-cleanup read budget, bounding indexed collection reads and preventing read-limit failures.
  * Updated chat-summary cleanup to stop early when budget is exhausted, avoid duplicate summary handling, and budget direct lookups.
  * Added a safety guard to prevent combining user deletion with orphan-summary residue cleanup in a single request.
* **Tests**
  * Added/updated coverage for multi-batch user deletion across messages, feedback, and chat-related data, including verification of bounded read behavior and proper rejection when requests are combined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->