### PR TITLE
Hide agent-only terminal guidance

### DIFF
--- a/app/components/tools/__tests__/shell-tool-utils.test.ts
+++ b/app/components/tools/__tests__/shell-tool-utils.test.ts
@@ -2,6 +2,7 @@ import {
   computeShellTerminalBlock,
   getTerminalFailureAction,
   isToolInputValidationError,
+  stripAgentOnlyTerminalGuidance,
 } from "../shell-tool-utils";
 
 describe("terminal shell tool display helpers", () => {
@@ -62,5 +63,89 @@ describe("terminal shell tool display helpers", () => {
       command: "Command failed",
       output: errorText,
     });
+  });
+
+  it.each([
+    [
+      "Command output paused after 120 seconds. Command continues in terminal session f7f6fc79 (PID: 93771). Use interact_terminal_session with this exact session ID to wait, view, or kill it.",
+      "Command output paused after 120 seconds. Command continues in terminal session f7f6fc79 (PID: 93771).",
+    ],
+    [
+      "Command output paused after 120 seconds. Command continues in the background with PID: 93771, but no reusable terminal session was created. Do not derive a session ID from the PID or call interact_terminal_session for this command.",
+      "Command output paused after 120 seconds. Command continues in the background with PID: 93771, but no reusable terminal session was created.",
+    ],
+    [
+      "Detached background process started with PID: 93771. No reusable terminal session was created; do not pass this PID to interact_terminal_session.\n",
+      "Detached background process started with PID: 93771. No reusable terminal session was created.\n",
+    ],
+    [
+      "Session f7f6fc79 not found. Only use the exact session ID returned by run_terminal_cmd; a PID is not a session ID and must never be converted into one.",
+      "Session f7f6fc79 not found.",
+    ],
+    [
+      "Session f7f6fc79 has exited (exitCode=0). Use action=view to read final output, or start a new session via run_terminal_cmd.",
+      "Session f7f6fc79 has exited (exitCode=0).",
+    ],
+    [
+      "Session f7f6fc79 belongs to a non-interactive command and does not accept input. Use action=wait, view, or kill.",
+      "Session f7f6fc79 belongs to a non-interactive command and does not accept input.",
+    ],
+    [
+      "Interactive terminal sessions are unavailable on this local connection. Use non-interactive terminal commands instead.",
+      "Interactive terminal sessions are unavailable on this local connection.",
+    ],
+    [
+      'action=send requires `input`. To submit just Enter (e.g. to terminate a Python multi-line block or accept a default prompt), pass input="Enter" or input="\\n".',
+      "Terminal input was missing.",
+    ],
+    ["action=wait requires `session`.", "Terminal session was not specified."],
+    [
+      "Input exceeds MAX_INPUT_BYTES_PER_SEND=65536 (got 65537).",
+      "Terminal input is too large.",
+    ],
+    [
+      "Sandbox is unavailable after repeated health check failures. Do NOT retry any terminal or sandbox commands. Inform the user that the sandbox could not be reached and suggest they wait a moment and try again, or delete the sandbox in Settings > Data Controls. If the issue persists, contact HackerAI support.",
+      "Sandbox is unavailable after repeated health check failures. Try again in a moment, or delete the sandbox in Settings > Data Controls. If the issue persists, contact HackerAI support.",
+    ],
+    [
+      "Sandbox recreation failed. The sandbox environment is not responding. Another attempt may be made but the sandbox will be marked unavailable after repeated failures.",
+      "Sandbox recreation failed. The sandbox environment is not responding.",
+    ],
+    [
+      "Failed to kill session f7f6fc79: connection closed. The session was retained so cleanup can be retried.",
+      "Failed to kill session f7f6fc79: connection closed.",
+    ],
+  ])(
+    "removes agent-only terminal guidance from sidebar output",
+    (raw, shown) => {
+      expect(stripAgentOnlyTerminalGuidance(raw)).toBe(shown);
+    },
+  );
+
+  it("keeps agent guidance in the raw tool output while hiding it in the sidebar", () => {
+    const rawOutput =
+      "Command output paused after 120 seconds. Command continues in terminal session f7f6fc79 (PID: 93771). Use interact_terminal_session with this exact session ID to wait, view, or kill it.";
+    const result = computeShellTerminalBlock({
+      isShellTool: false,
+      shellInput: undefined,
+      shellOutput: { result: { output: rawOutput } },
+      streamingOutput: "",
+      isExecuting: false,
+      hasResult: true,
+      toolCallId: "call-timeout",
+      legacyCommand: "npm test",
+    });
+
+    expect(result.finalOutput).toBe(rawOutput);
+    expect(result.sidebarContent?.output).toBe(
+      "Command output paused after 120 seconds. Command continues in terminal session f7f6fc79 (PID: 93771).",
+    );
+  });
+
+  it("does not remove matching prose from the middle of command output", () => {
+    const commandOutput =
+      "Use action=wait, view, or kill.\nThis line came from the command.";
+
+    expect(stripAgentOnlyTerminalGuidance(commandOutput)).toBe(commandOutput);
   });
 });

--- a/app/components/tools/shell-tool-utils.ts
+++ b/app/components/tools/shell-tool-utils.ts
@@ -301,6 +301,10 @@ const AGENT_ONLY_TERMINAL_MESSAGE_REPLACEMENTS = new Map([
   ],
 ]);
 
+/**
+ * Removes platform-authored recovery guidance before terminal output is shown
+ * in the Computer sidebar. The persisted/model-facing tool result is unchanged.
+ */
 export function stripAgentOnlyTerminalGuidance(output: string): string {
   const trimmedOutput = output.trimEnd();
   const trailingWhitespace = output.slice(trimmedOutput.length);

--- a/app/components/tools/shell-tool-utils.ts
+++ b/app/components/tools/shell-tool-utils.ts
@@ -273,6 +273,63 @@ export function getShellOutput(
   );
 }
 
+// Terminal tool results sometimes append recovery instructions for the model.
+// Keep those instructions in the persisted/model-facing result, but remove them
+// from the user-facing Computer sidebar. These patterns intentionally match only
+// platform-authored suffixes so command output containing similar prose is left
+// untouched.
+const AGENT_ONLY_TERMINAL_GUIDANCE_SUFFIXES = [
+  /\s+Use interact_terminal_session with this exact session ID to wait, view, or kill it\.(?=\s*$)/,
+  /\s+Do not derive a session ID from the PID or call interact_terminal_session for this command\.(?=\s*$)/,
+  /\s+Only use the exact session ID returned by run_terminal_cmd; a PID is not a session ID and must never be converted into one\.(?=\s*$)/,
+  /\s+Use action=view to read final output, or start a new session via run_terminal_cmd\.(?=\s*$)/,
+  /\s+Use action=wait, view, or kill\.(?=\s*$)/,
+  /\s+Use non-interactive terminal commands instead\.(?=\s*$)/,
+  /\s+The session was retained so cleanup can be retried\.(?=\s*$)/,
+  /\s+The bounded cleanup limit was reached, so local session tracking was removed\.(?=\s*$)/,
+  /\s+Another attempt may be made but the sandbox will be marked unavailable after repeated failures\.(?=\s*$)/,
+] as const;
+
+const AGENT_ONLY_TERMINAL_MESSAGE_REPLACEMENTS = new Map([
+  [
+    'action=send requires `input`. To submit just Enter (e.g. to terminate a Python multi-line block or accept a default prompt), pass input="Enter" or input="\\n".',
+    "Terminal input was missing.",
+  ],
+  [
+    "Sandbox is unavailable after repeated health check failures. Do NOT retry any terminal or sandbox commands. Inform the user that the sandbox could not be reached and suggest they wait a moment and try again, or delete the sandbox in Settings > Data Controls. If the issue persists, contact HackerAI support.",
+    "Sandbox is unavailable after repeated health check failures. Try again in a moment, or delete the sandbox in Settings > Data Controls. If the issue persists, contact HackerAI support.",
+  ],
+]);
+
+export function stripAgentOnlyTerminalGuidance(output: string): string {
+  const trimmedOutput = output.trimEnd();
+  const trailingWhitespace = output.slice(trimmedOutput.length);
+  const replacement =
+    AGENT_ONLY_TERMINAL_MESSAGE_REPLACEMENTS.get(trimmedOutput);
+  let userFacingOutput = replacement
+    ? replacement + trailingWhitespace
+    : output
+        .replace(
+          /^action=(?:send|wait|view|kill) requires `session`\.(?=\s*$)/,
+          "Terminal session was not specified.",
+        )
+        .replace(
+          /^Input exceeds MAX_INPUT_BYTES_PER_SEND=\d+ \(got \d+\)\.(?=\s*$)/,
+          "Terminal input is too large.",
+        );
+
+  userFacingOutput = userFacingOutput.replace(
+    /; do not pass this PID to interact_terminal_session\.(?=\s*$)/,
+    ".",
+  );
+
+  for (const suffix of AGENT_ONLY_TERMINAL_GUIDANCE_SUFFIXES) {
+    userFacingOutput = userFacingOutput.replace(suffix, "");
+  }
+
+  return userFacingOutput;
+}
+
 // ---------------------------------------------------------------------------
 // Unified ToolBlock + sidebar computation
 //
@@ -397,7 +454,7 @@ export function computeShellTerminalBlock(
       ? null
       : {
           command: isInteractiveAction ? displayTarget : displayCommand,
-          output: finalOutput,
+          output: stripAgentOnlyTerminalGuidance(finalOutput),
           isExecuting,
           isBackground: !isShellTool ? legacyIsBackground : undefined,
           isInteractive: !isShellTool ? legacyInteractive : undefined,

--- a/lib/utils/__tests__/sidebar-utils.test.ts
+++ b/lib/utils/__tests__/sidebar-utils.test.ts
@@ -1,0 +1,53 @@
+import { extractSidebarContentFromMessage } from "../sidebar-utils";
+
+describe("terminal sidebar output", () => {
+  it("hides agent-only timeout guidance in fallback sidebar extraction", () => {
+    const [terminal] = extractSidebarContentFromMessage({
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-run_terminal_cmd",
+          toolCallId: "call-timeout",
+          state: "output-available",
+          input: { command: "npm test", interactive: false },
+          output: {
+            result: {
+              output:
+                "Tests started.\n\nCommand output paused after 120 seconds. Command continues in terminal session f7f6fc79 (PID: 93771). Use interact_terminal_session with this exact session ID to wait, view, or kill it.",
+            },
+          },
+        },
+      ],
+    });
+
+    expect(terminal).toMatchObject({
+      command: "npm test",
+      output:
+        "Tests started.\n\nCommand output paused after 120 seconds. Command continues in terminal session f7f6fc79 (PID: 93771).",
+    });
+  });
+
+  it("hides agent-only guidance for unified shell output too", () => {
+    const [terminal] = extractSidebarContentFromMessage({
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-shell",
+          toolCallId: "call-shell",
+          state: "output-available",
+          input: { action: "exec", command: "npm test" },
+          output: {
+            output:
+              "Interactive terminal sessions are unavailable on this local connection. Use non-interactive terminal commands instead.",
+          },
+        },
+      ],
+    });
+
+    expect(terminal).toMatchObject({
+      command: "npm test",
+      output:
+        "Interactive terminal sessions are unavailable on this local connection.",
+    });
+  });
+});

--- a/lib/utils/sidebar-utils.ts
+++ b/lib/utils/sidebar-utils.ts
@@ -8,6 +8,7 @@ import {
 import {
   formatSendInput,
   isInteractiveShellAction,
+  stripAgentOnlyTerminalGuidance,
 } from "@/app/components/tools/shell-tool-utils";
 
 interface MessagePart {
@@ -157,7 +158,7 @@ export function extractSidebarContentFromMessage(
 
       contentList.push({
         command,
-        output: finalOutput,
+        output: stripAgentOnlyTerminalGuidance(finalOutput),
         isExecuting:
           part.state === "input-available" || part.state === "running",
         isBackground: part.input.is_background,
@@ -205,7 +206,7 @@ export function extractSidebarContentFromMessage(
 
       contentList.push({
         command,
-        output: finalOutput,
+        output: stripAgentOnlyTerminalGuidance(finalOutput),
         isExecuting:
           part.state === "input-available" || part.state === "running",
         isBackground: false,


### PR DESCRIPTION
## Summary

- keep terminal recovery instructions in model-facing tool results
- remove internal tool/action guidance from the user-facing Computer sidebar
- apply the cleanup consistently to live, shared, and fallback sidebar extraction paths
- replace internal validation and sandbox-control wording with concise user-facing status text

## Root cause

Terminal tool results combine command status with recovery instructions intended for the agent. The Computer sidebar rendered the same raw result verbatim, exposing internal tool names such as `interact_terminal_session` to users.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- 264 Jest suites / 2,677 tests (commit hook)
- focused terminal/sidebar tests: 21 passing
- Prettier and `git diff --check`
- Playwright visual verification of the Computer sidebar using the reported 120-second timeout text; useful session/PID status remained visible, internal guidance was absent, and no console/framework errors were detected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal output shown in the sidebar by removing internal recovery instructions and agent-only guidance.
  * Preserved relevant command output, including similar text appearing within normal command results.
  * Applied cleaner handling for session errors, oversized input messages, timeouts, and process-related instructions.
* **Tests**
  * Added coverage to verify guidance is removed while raw terminal output remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->