### PR TITLE
Improve queued message editing and controls

### DIFF
--- a/app/components/ChatInput/ChatInput.tsx
+++ b/app/components/ChatInput/ChatInput.tsx
@@ -142,6 +142,8 @@ export const ChatInput = ({
     setUploadedFiles,
     isUploadingFiles,
     messageQueue,
+    updateQueuedMessage,
+    setEditingQueuedMessageId,
     removeQueuedMessage,
     queueBehavior,
     setQueueBehavior,
@@ -344,6 +346,8 @@ export const ChatInput = ({
             <QueuedMessagesPanel
               messages={messageQueue}
               onSendNow={onSendNow}
+              onEdit={updateQueuedMessage}
+              onEditingMessageChange={setEditingQueuedMessageId}
               onDelete={removeQueuedMessage}
               isStreaming={status === "streaming"}
               queueBehavior={queueBehavior}

--- a/app/components/QueuedMessagesPanel.tsx
+++ b/app/components/QueuedMessagesPanel.tsx
@@ -2,195 +2,276 @@ import { Button } from "@/components/ui/button";
 import {
   Trash,
   CornerDownRight,
-  ChevronDown,
-  ChevronRight,
   MoreHorizontal,
+  Pencil,
+  ListX,
 } from "lucide-react";
 import type { QueuedMessage, QueueBehavior } from "@/types/chat";
-import { useState } from "react";
+import { useEffect, useState, type KeyboardEvent } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
+  DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import TextareaAutosize from "react-textarea-autosize";
 
 interface QueuedMessagesPanelProps {
   messages: QueuedMessage[];
   onSendNow: (messageId: string) => void;
+  onEdit: (messageId: string, text: string) => void;
+  onEditingMessageChange: (messageId: string | null) => void;
   onDelete: (messageId: string) => void;
   isStreaming: boolean;
   queueBehavior?: QueueBehavior;
   onQueueBehaviorChange?: (behavior: QueueBehavior) => void;
 }
 
-const queueBehaviorOptions: Array<{
-  value: QueueBehavior;
-  label: string;
-}> = [
-  { value: "queue", label: "Queue after current message" },
-  { value: "stop-and-send", label: "Stop & send right away" },
-];
-
-interface QueueSettingsMenuProps {
+interface QueuedMessageMenuProps {
+  message: QueuedMessage;
   queueBehavior: QueueBehavior;
+  onEdit: () => void;
   onQueueBehaviorChange?: (behavior: QueueBehavior) => void;
 }
 
-const QueueSettingsMenu = ({
+interface QueuedMessageRowProps {
+  message: QueuedMessage;
+  isEditing: boolean;
+  isStreaming: boolean;
+  queueBehavior: QueueBehavior;
+  onSendNow: (messageId: string) => void;
+  onEdit: (messageId: string, text: string) => void;
+  onStartEditing: (messageId: string) => void;
+  onFinishEditing: () => void;
+  onDelete: (messageId: string) => void;
+  onQueueBehaviorChange?: (behavior: QueueBehavior) => void;
+}
+
+const QueuedMessageMenu = ({
+  message,
   queueBehavior,
+  onEdit,
   onQueueBehaviorChange,
-}: QueueSettingsMenuProps) => (
-  <DropdownMenu>
-    <DropdownMenuTrigger asChild>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="h-7 w-7 p-0"
-        aria-label="Queue settings"
-      >
-        <MoreHorizontal className="w-4 h-4 text-muted-foreground" />
-      </Button>
-    </DropdownMenuTrigger>
-    <DropdownMenuContent align="end" className="w-56">
-      <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
-        When to send follow-ups
+}: QueuedMessageMenuProps) => {
+  const toggleQueueBehavior = () => {
+    const nextBehavior = queueBehavior === "queue" ? "stop-and-send" : "queue";
+    onQueueBehaviorChange?.(nextBehavior);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0"
+          aria-label={`More options for queued message: ${message.text}`}
+        >
+          <MoreHorizontal className="w-4 h-4 text-muted-foreground" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuItem className="cursor-pointer" onSelect={onEdit}>
+          <Pencil />
+          Edit message
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="cursor-pointer"
+          onSelect={toggleQueueBehavior}
+        >
+          <ListX />
+          {queueBehavior === "queue" ? "Turn off queueing" : "Turn on queueing"}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+const QueuedMessageRow = ({
+  message,
+  isEditing,
+  isStreaming,
+  queueBehavior,
+  onSendNow,
+  onEdit,
+  onStartEditing,
+  onFinishEditing,
+  onDelete,
+  onQueueBehaviorChange,
+}: QueuedMessageRowProps) => {
+  const [editText, setEditText] = useState(message.text);
+
+  const startEditing = () => {
+    setEditText(message.text);
+    onStartEditing(message.id);
+  };
+
+  const cancelEditing = () => {
+    setEditText(message.text);
+    onFinishEditing();
+  };
+
+  const saveEditing = () => {
+    const trimmedText = editText.trim();
+    if (!trimmedText && !message.files?.length) return;
+
+    onEdit(message.id, trimmedText);
+    onFinishEditing();
+  };
+
+  const handleEditKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Escape") {
+      cancelEditing();
+    } else if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      saveEditing();
+    }
+  };
+
+  const content = (
+    <>
+      <div className="flex-1 min-w-0">
+        {isEditing ? (
+          <div className="space-y-2">
+            <TextareaAutosize
+              autoFocus
+              value={editText}
+              onChange={(event) => setEditText(event.target.value)}
+              onKeyDown={handleEditKeyDown}
+              minRows={1}
+              maxRows={6}
+              aria-label="Edit queued message"
+              className="w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7"
+                onClick={cancelEditing}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                className="h-7"
+                onClick={saveEditing}
+                disabled={!editText.trim() && !message.files?.length}
+              >
+                Save
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="text-sm truncate text-foreground">
+              {message.text}
+            </div>
+            {message.files && message.files.length > 0 && (
+              <div className="text-xs text-muted-foreground mt-0.5">
+                {message.files.length} file
+                {message.files.length > 1 ? "s" : ""}
+              </div>
+            )}
+          </>
+        )}
       </div>
-      <DropdownMenuRadioGroup
-        value={queueBehavior}
-        onValueChange={(value) =>
-          onQueueBehaviorChange?.(value as QueueBehavior)
-        }
-      >
-        {queueBehaviorOptions.map((option) => (
-          <DropdownMenuRadioItem
-            key={option.value}
-            value={option.value}
-            className="cursor-pointer"
+
+      {!isEditing && (
+        <div className="flex items-center gap-1 flex-shrink-0">
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={() => onSendNow(message.id)}
+            className="h-7 px-2 text-xs"
+            title={
+              isStreaming
+                ? "Stop the current response and steer with this message"
+                : "Send this queued message now"
+            }
           >
-            {option.label}
-          </DropdownMenuRadioItem>
-        ))}
-      </DropdownMenuRadioGroup>
-    </DropdownMenuContent>
-  </DropdownMenu>
-);
+            <CornerDownRight className="w-3 h-3 mr-1" />
+            Steer
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={() => onDelete(message.id)}
+            className="h-7 w-7 p-0"
+            aria-label={`Remove queued message: ${message.text}`}
+            title="Remove from queue"
+          >
+            <Trash className="w-4 h-4" />
+          </Button>
+          <QueuedMessageMenu
+            message={message}
+            queueBehavior={queueBehavior}
+            onEdit={startEditing}
+            onQueueBehaviorChange={onQueueBehaviorChange}
+          />
+        </div>
+      )}
+    </>
+  );
+
+  const rowClassName = "flex items-start gap-2 py-0.5 min-w-0";
+
+  return (
+    <div className={rowClassName} data-testid={`queued-message-${message.id}`}>
+      {content}
+    </div>
+  );
+};
 
 export const QueuedMessagesPanel = ({
   messages,
   onSendNow,
+  onEdit,
+  onEditingMessageChange,
   onDelete,
   isStreaming,
   queueBehavior = "queue",
   onQueueBehaviorChange,
 }: QueuedMessagesPanelProps) => {
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
+
+  useEffect(() => () => onEditingMessageChange(null), [onEditingMessageChange]);
 
   if (messages.length === 0) {
     return null;
   }
 
-  const isSingleMessage = messages.length === 1;
-
-  const handleToggleExpand = () => {
-    setIsExpanded((expanded) => !expanded);
+  const setEditingMessage = (messageId: string | null) => {
+    setEditingMessageId(messageId);
+    onEditingMessageChange(messageId);
   };
 
-  const renderMessage = (message: QueuedMessage, showSettings = false) => (
-    <div
+  const renderMessage = (message: QueuedMessage) => (
+    <QueuedMessageRow
       key={message.id}
-      className="flex items-start gap-2 transition-colors min-w-0"
-    >
-      <div className="flex-1 min-w-0">
-        <div className="text-sm truncate text-foreground">{message.text}</div>
-        {message.files && message.files.length > 0 && (
-          <div className="text-xs text-muted-foreground mt-0.5">
-            {message.files.length} file
-            {message.files.length > 1 ? "s" : ""}
-          </div>
-        )}
-      </div>
-
-      <div className="flex items-center gap-1 flex-shrink-0">
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          onClick={() => onSendNow(message.id)}
-          disabled={!isStreaming}
-          className="h-7 px-2 text-xs"
-          title={
-            isStreaming
-              ? "Stop the current response and steer with this message"
-              : "Waiting for the current response to complete"
-          }
-        >
-          <CornerDownRight className="w-3 h-3 mr-1" />
-          Steer
-        </Button>
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          onClick={() => onDelete(message.id)}
-          className="h-7 w-7 p-0"
-          aria-label="Remove queued message"
-          title="Remove from queue"
-        >
-          <Trash className="w-4 h-4" />
-        </Button>
-        {showSettings && (
-          <QueueSettingsMenu
-            queueBehavior={queueBehavior}
-            onQueueBehaviorChange={onQueueBehaviorChange}
-          />
-        )}
-      </div>
-    </div>
+      message={message}
+      isEditing={editingMessageId === message.id}
+      isStreaming={isStreaming}
+      queueBehavior={queueBehavior}
+      onSendNow={onSendNow}
+      onEdit={onEdit}
+      onStartEditing={setEditingMessage}
+      onFinishEditing={() => setEditingMessage(null)}
+      onDelete={onDelete}
+      onQueueBehaviorChange={onQueueBehaviorChange}
+    />
   );
 
   return (
-    <div className="mx-4 rounded-[22px_22px_0px_0px] shadow-[0px_12px_32px_0px_rgba(0,0,0,0.02)] border border-black/8 dark:border-border border-b-0 bg-input-chat">
-      {isSingleMessage ? (
-        <div className="px-4 py-3">{renderMessage(messages[0], true)}</div>
-      ) : (
-        <>
-          <div className="flex items-center px-4 transition-all duration-300 py-2">
-            <button
-              type="button"
-              onClick={handleToggleExpand}
-              className="flex items-center gap-2 hover:opacity-80 transition-opacity cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-md p-1 -m-1 flex-1"
-              aria-label={
-                isExpanded
-                  ? "Collapse queued messages"
-                  : "Expand queued messages"
-              }
-            >
-              {isExpanded ? (
-                <ChevronDown className="w-4 h-4 text-muted-foreground" />
-              ) : (
-                <ChevronRight className="w-4 h-4 text-muted-foreground" />
-              )}
-              <h3 className="text-muted-foreground text-sm font-medium">
-                {messages.length} Queued
-              </h3>
-            </button>
-
-            <QueueSettingsMenu
-              queueBehavior={queueBehavior}
-              onQueueBehaviorChange={onQueueBehaviorChange}
-            />
-          </div>
-
-          {isExpanded && (
-            <div className="border-t border-border px-4 py-3 space-y-2 max-h-[200px] overflow-y-auto">
-              {messages.map((message) => renderMessage(message))}
-            </div>
-          )}
-        </>
-      )}
+    <div className="mx-4 rounded-[22px_22px_0px_0px] border border-black/8 dark:border-border border-b-0 bg-input-chat">
+      <div className="px-4 pt-3 pb-1 space-y-1 max-h-[240px] overflow-y-auto">
+        {messages.map(renderMessage)}
+      </div>
     </div>
   );
 };

--- a/app/components/__tests__/QueuedMessagesPanel.test.tsx
+++ b/app/components/__tests__/QueuedMessagesPanel.test.tsx
@@ -22,10 +22,12 @@ describe("QueuedMessagesPanel", () => {
     const onDelete = jest.fn();
     const onQueueBehaviorChange = jest.fn();
 
-    render(
+    const { rerender } = render(
       <QueuedMessagesPanel
         messages={[messages[0]]}
         onSendNow={onSendNow}
+        onEdit={jest.fn()}
+        onEditingMessageChange={jest.fn()}
         onDelete={onDelete}
         isStreaming
         onQueueBehaviorChange={onQueueBehaviorChange}
@@ -40,64 +42,144 @@ describe("QueuedMessagesPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Steer" }));
     fireEvent.click(
-      screen.getByRole("button", { name: "Remove queued message" }),
+      screen.getByRole("button", {
+        name: "Remove queued message: do ping now",
+      }),
     );
 
     expect(onSendNow).toHaveBeenCalledWith("message-1");
     expect(onDelete).toHaveBeenCalledWith("message-1");
     expect(
-      screen.getByRole("button", { name: "Queue settings" }),
+      screen.getByRole("button", {
+        name: "More options for queued message: do ping now",
+      }),
     ).toBeInTheDocument();
 
-    fireEvent.keyDown(screen.getByRole("button", { name: "Queue settings" }), {
-      key: "Enter",
-    });
+    fireEvent.keyDown(
+      screen.getByRole("button", {
+        name: "More options for queued message: do ping now",
+      }),
+      { key: "Enter" },
+    );
     fireEvent.click(
-      await screen.findByRole("menuitemradio", {
-        name: "Stop & send right away",
+      await screen.findByRole("menuitem", {
+        name: "Turn off queueing",
       }),
     );
 
     expect(onQueueBehaviorChange).toHaveBeenCalledWith("stop-and-send");
+
+    rerender(
+      <QueuedMessagesPanel
+        messages={[messages[0]]}
+        onSendNow={onSendNow}
+        onEdit={jest.fn()}
+        onEditingMessageChange={jest.fn()}
+        onDelete={onDelete}
+        isStreaming
+        queueBehavior="stop-and-send"
+        onQueueBehaviorChange={onQueueBehaviorChange}
+      />,
+    );
+
+    fireEvent.keyDown(
+      screen.getByRole("button", {
+        name: "More options for queued message: do ping now",
+      }),
+      { key: "Enter" },
+    );
+    expect(
+      await screen.findByRole("menuitem", { name: "Turn on queueing" }),
+    ).toBeInTheDocument();
   });
 
-  it("keeps the collapsible count view for multiple queued messages", async () => {
+  it("shows multiple queued messages as a flat list", () => {
     const onQueueBehaviorChange = jest.fn();
 
     render(
       <QueuedMessagesPanel
         messages={messages}
         onSendNow={jest.fn()}
+        onEdit={jest.fn()}
+        onEditingMessageChange={jest.fn()}
         onDelete={jest.fn()}
         isStreaming
         onQueueBehaviorChange={onQueueBehaviorChange}
       />,
     );
 
-    expect(screen.getByText("2 Queued")).toBeInTheDocument();
+    expect(screen.queryByText("2 Queued")).not.toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "Steer" })).toHaveLength(2);
+    expect(screen.getByText("do ping now")).toBeInTheDocument();
+    expect(screen.getByText("then check the headers")).toBeInTheDocument();
+    expect(
+      screen.queryByText("When to send follow-ups"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Queue settings" }),
+    ).not.toBeInTheDocument();
+  });
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Collapse queued messages" }),
+  it("allows a stopped queued message to be sent immediately", () => {
+    const onSendNow = jest.fn();
+
+    render(
+      <QueuedMessagesPanel
+        messages={[messages[0]]}
+        onSendNow={onSendNow}
+        onEdit={jest.fn()}
+        onEditingMessageChange={jest.fn()}
+        onDelete={jest.fn()}
+        isStreaming={false}
+      />,
     );
 
-    expect(screen.queryByText("do ping now")).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Expand queued messages" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Queue settings" }),
-    ).toBeInTheDocument();
+    const steerButton = screen.getByRole("button", { name: "Steer" });
+    expect(steerButton).toBeEnabled();
+    expect(steerButton).toHaveAttribute(
+      "title",
+      "Send this queued message now",
+    );
 
-    fireEvent.keyDown(screen.getByRole("button", { name: "Queue settings" }), {
-      key: "Enter",
-    });
-    fireEvent.click(
-      await screen.findByRole("menuitemradio", {
-        name: "Stop & send right away",
+    fireEvent.click(steerButton);
+    expect(onSendNow).toHaveBeenCalledWith("message-1");
+  });
+
+  it("edits a specific queued message from its menu", async () => {
+    const onEdit = jest.fn();
+    const onEditingMessageChange = jest.fn();
+
+    render(
+      <QueuedMessagesPanel
+        messages={messages}
+        onSendNow={jest.fn()}
+        onEdit={onEdit}
+        onEditingMessageChange={onEditingMessageChange}
+        onDelete={jest.fn()}
+        isStreaming
+      />,
+    );
+
+    fireEvent.keyDown(
+      screen.getByRole("button", {
+        name: "More options for queued message: do ping now",
       }),
+      { key: "Enter" },
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Edit message" }),
     );
 
-    expect(onQueueBehaviorChange).toHaveBeenCalledWith("stop-and-send");
+    expect(onEditingMessageChange).toHaveBeenCalledWith("message-1");
+
+    const editor = screen.getByRole("textbox", { name: "Edit queued message" });
+    fireEvent.change(editor, { target: { value: "do ping carefully" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onEdit).toHaveBeenCalledWith("message-1", "do ping carefully");
+    expect(onEditingMessageChange).toHaveBeenLastCalledWith(null);
+    expect(
+      screen.queryByRole("button", { name: /Reorder queued message/ }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/app/components/__tests__/chat.integration.test.tsx
+++ b/app/components/__tests__/chat.integration.test.tsx
@@ -1,6 +1,8 @@
 import "@testing-library/jest-dom";
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import { render, renderHook, screen } from "@testing-library/react";
+import { useEffect } from "react";
+import { useGlobalState } from "@/app/contexts/GlobalState";
 
 // ===== IMPORTANT: Mock all dependencies BEFORE importing Chat =====
 // These mocks are hoisted by Jest
@@ -182,6 +184,18 @@ import {
 import { ChatLayout } from "../ChatLayout";
 import { TestWrapper } from "../testUtils";
 
+const QueueEditingHarness = () => {
+  const { messageQueue, queueMessage, setEditingQueuedMessageId } =
+    useGlobalState();
+
+  useEffect(() => {
+    queueMessage("updated queued message");
+    setEditingQueuedMessageId("editing-message");
+  }, [queueMessage, setEditingQueuedMessageId]);
+
+  return <div data-testid="queue-state">Queued: {messageQueue.length}</div>;
+};
+
 describe("Chat Component Integration", () => {
   let mockUseChat: jest.Mock;
 
@@ -349,6 +363,18 @@ describe("Chat Component Integration", () => {
   });
 
   describe("Message Display", () => {
+    it("keeps a ready queued message pending while it is being edited", () => {
+      render(
+        <TestWrapper>
+          <QueueEditingHarness />
+          <Chat autoResume={false} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByTestId("queue-state")).toHaveTextContent("Queued: 1");
+      expect(mockSendMessage).not.toHaveBeenCalled();
+    });
+
     it("should render with existing messages", () => {
       mockUseChat.mockReturnValue({
         messages: [

--- a/app/components/__tests__/chat.integration.test.tsx
+++ b/app/components/__tests__/chat.integration.test.tsx
@@ -1,8 +1,18 @@
 import "@testing-library/jest-dom";
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
-import { render, renderHook, screen } from "@testing-library/react";
-import { useEffect } from "react";
+import {
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useEffect, useRef } from "react";
 import { useGlobalState } from "@/app/contexts/GlobalState";
+
+jest.mock("uuid", () => ({
+  v4: () => "queued-message-id",
+}));
 
 // ===== IMPORTANT: Mock all dependencies BEFORE importing Chat =====
 // These mocks are hoisted by Jest
@@ -185,15 +195,42 @@ import { ChatLayout } from "../ChatLayout";
 import { TestWrapper } from "../testUtils";
 
 const QueueEditingHarness = () => {
-  const { messageQueue, queueMessage, setEditingQueuedMessageId } =
-    useGlobalState();
+  const {
+    messageQueue,
+    queueMessage,
+    updateQueuedMessage,
+    setEditingQueuedMessageId,
+  } = useGlobalState();
+  const hasSetActualEditingId = useRef(false);
 
   useEffect(() => {
-    queueMessage("updated queued message");
-    setEditingQueuedMessageId("editing-message");
+    queueMessage("original queued message");
+    setEditingQueuedMessageId("queued-message-id");
   }, [queueMessage, setEditingQueuedMessageId]);
 
-  return <div data-testid="queue-state">Queued: {messageQueue.length}</div>;
+  useEffect(() => {
+    if (messageQueue[0] && !hasSetActualEditingId.current) {
+      hasSetActualEditingId.current = true;
+      setEditingQueuedMessageId(messageQueue[0].id);
+    }
+  }, [messageQueue, setEditingQueuedMessageId]);
+
+  const saveEdit = () => {
+    const queuedMessage = messageQueue[0];
+    if (!queuedMessage) return;
+
+    updateQueuedMessage(queuedMessage.id, "updated queued message");
+    setEditingQueuedMessageId(null);
+  };
+
+  return (
+    <>
+      <div data-testid="queue-state">Queued: {messageQueue.length}</div>
+      <button type="button" onClick={saveEdit}>
+        Save queued edit
+      </button>
+    </>
+  );
 };
 
 describe("Chat Component Integration", () => {
@@ -363,7 +400,7 @@ describe("Chat Component Integration", () => {
   });
 
   describe("Message Display", () => {
-    it("keeps a ready queued message pending while it is being edited", () => {
+    it("keeps an edited queued message pending, then resumes with updated text", async () => {
       render(
         <TestWrapper>
           <QueueEditingHarness />
@@ -371,8 +408,22 @@ describe("Chat Component Integration", () => {
         </TestWrapper>,
       );
 
-      expect(screen.getByTestId("queue-state")).toHaveTextContent("Queued: 1");
+      await waitFor(() =>
+        expect(screen.getByTestId("queue-state")).toHaveTextContent(
+          "Queued: 1",
+        ),
+      );
+
       expect(mockSendMessage).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByRole("button", { name: "Save queued edit" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("updated queued message")).toBeInTheDocument();
+        expect(screen.getByTestId("queue-state")).toHaveTextContent(
+          "Queued: 0",
+        );
+      });
     });
 
     it("should render with existing messages", () => {

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -497,9 +497,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     hasUserDismissedRateLimitWarning,
     setHasUserDismissedRateLimitWarning,
     messageQueue,
+    editingQueuedMessageId,
     removeQueuedMessage,
     clearQueue,
-    queueBehavior,
     todos,
     sandboxPreference,
     setSandboxPreference,
@@ -1624,10 +1624,10 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     if (
       status === "ready" &&
       messageQueue.length > 0 &&
+      editingQueuedMessageId === null &&
       !isProcessingQueue &&
       !isSendingNowRef.current &&
-      !hasManuallyStoppedRef.current &&
-      queueBehavior === "queue"
+      !hasManuallyStoppedRef.current
     ) {
       setIsProcessingQueue(true);
       const nextMessage = messageQueue[0];
@@ -1665,10 +1665,10 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   }, [
     status,
     messageQueue,
+    editingQueuedMessageId,
     isProcessingQueue,
     removeQueuedMessage,
     sendMessage,
-    queueBehavior,
     chatModeRef,
     todosRef,
     temporaryChatsEnabledRef,

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -115,6 +115,9 @@ interface GlobalStateType {
   // Message queue state (for Agent mode)
   messageQueue: QueuedMessage[];
   queueMessage: (text: string, files?: FileMessagePart[]) => void;
+  updateQueuedMessage: (id: string, text: string) => void;
+  editingQueuedMessageId: string | null;
+  setEditingQueuedMessageId: (messageId: string | null) => void;
   removeQueuedMessage: (id: string) => void;
   clearQueue: () => void;
 
@@ -399,6 +402,9 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
 
   // Message queue state (for Agent mode queueing)
   const [messageQueue, setMessageQueue] = useState<QueuedMessage[]>([]);
+  const [editingQueuedMessageId, setEditingQueuedMessageId] = useState<
+    string | null
+  >(null);
 
   // Queue behavior preference (persisted to localStorage)
   const [queueBehavior, setQueueBehaviorState] = useState<QueueBehavior>(() => {
@@ -948,10 +954,22 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
 
   const removeQueuedMessage = useCallback((id: string) => {
     setMessageQueue((prev) => prev.filter((msg) => msg.id !== id));
+    setEditingQueuedMessageId((currentId) =>
+      currentId === id ? null : currentId,
+    );
+  }, []);
+
+  const updateQueuedMessage = useCallback((id: string, text: string) => {
+    setMessageQueue((prev) =>
+      prev.map((message) =>
+        message.id === id ? { ...message, text } : message,
+      ),
+    );
   }, []);
 
   const clearQueue = useCallback(() => {
     setMessageQueue([]);
+    setEditingQueuedMessageId(null);
   }, []);
 
   const initializeChat = useCallback((chatId: string, _fromRoute?: boolean) => {
@@ -1119,6 +1137,9 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
 
     messageQueue,
     queueMessage,
+    updateQueuedMessage,
+    editingQueuedMessageId,
+    setEditingQueuedMessageId,
     removeQueuedMessage,
     clearQueue,
 

--- a/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
@@ -172,6 +172,36 @@ describe("useChatHandlers steer todo handoff", () => {
     );
   });
 
+  it("sends a queued message after the stream has already stopped", async () => {
+    const { result } = renderHook(() =>
+      useChatHandlers({
+        chatId: "chat-1",
+        messages,
+        sendMessage: mockSendMessage,
+        stop: mockStop,
+        regenerate: jest.fn(),
+        setMessages: mockSetMessages,
+        isExistingChat: true,
+        status: "ready",
+        isSendingNowRef: { current: false },
+        hasManuallyStoppedRef: { current: true },
+        activeTriggerRunRef: { current: undefined },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleSendNow("queued-1");
+    });
+
+    expect(mockCancelStream).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(mockRemoveQueuedMessage).toHaveBeenCalledWith("queued-1");
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Change direction" }),
+      expect.any(Object),
+    );
+  });
+
   it("keeps the queued message when the todo snapshot cannot be persisted", async () => {
     mockCancelStream.mockRejectedValueOnce(new Error("write failed"));
     const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -866,7 +866,9 @@ export const useChatHandlers = ({
 
     try {
       setIsAutoResuming(false);
-      await stopActiveRunForSteer();
+      if (hasActiveRunToReplace()) {
+        await stopActiveRunForSteer();
+      }
 
       // Keep the queued message available if stopping fails.
       removeQueuedMessage(messageId);


### PR DESCRIPTION
## Summary
- replace the follow-up timing picker with per-message actions for editing and toggling queueing
- pause automatic queued-message delivery while a message is being edited, then resume with the updated text after save or cancel
- keep queued messages steerable after a stopped stream and tighten the queued-message panel spacing
- retain the compact, non-draggable queued-message layout

## Testing
- `corepack pnpm jest app/components/__tests__/QueuedMessagesPanel.test.tsx app/components/__tests__/chat.integration.test.tsx app/components/__tests__/ChatInput.integration.test.tsx app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx --runInBand` (42 tests)
- `corepack pnpm typecheck`
- `corepack pnpm exec eslint app/components/ChatInput/ChatInput.tsx app/components/QueuedMessagesPanel.tsx app/components/__tests__/QueuedMessagesPanel.test.tsx app/components/__tests__/chat.integration.test.tsx app/components/chat.tsx app/contexts/GlobalState.tsx app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx app/hooks/useChatHandlers.ts` (passes with 3 existing warnings in `chat.tsx`)
- `corepack pnpm exec prettier --check ...`
- commit hooks: full Jest suite, 262 suites / 2,653 tests

## Visual verification
- iteratively verified the local queued-message UI in Chrome with the user, including the compact spacing and three-dot menu state

## Manual verification
1. Start an Agent response and queue a follow-up.
2. Open the queued message menu, choose **Edit message**, and confirm it does not auto-send while the editor is open.
3. Save the edit and confirm the updated text is used when the queued message sends.
4. Choose **Turn off queueing**, reopen the menu, and confirm it now says **Turn on queueing**.
5. Stop the current stream, click **Steer** on a queued message, and confirm it sends immediately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added inline editing for queued messages with multi-line input.
  - Added keyboard shortcuts to cancel (Escape) or save (Ctrl/Cmd+Enter) edits.
  - Updated queued-message controls to provide per-message “More options” actions (edit and queue behavior toggle).
  - Steer button is now enabled regardless of streaming state.
- **Bug Fixes**
  - Prevented automatic queue sending while a queued message is being edited.
  - Improved “Send Now” behavior when no eligible active run needs to be stopped.
  - Prevented saving empty queued messages unless attachments are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->