### PR TITLE
Speed up Vercel preview builds

### DIFF
--- a/__tests__/next-config-build-settings.test.ts
+++ b/__tests__/next-config-build-settings.test.ts
@@ -1,0 +1,65 @@
+const buildEnvironmentKeys = [
+  "POSTHOG_CLI_API_KEY",
+  "POSTHOG_CLI_PROJECT_ID",
+  "VERCEL_ENV",
+] as const;
+
+const originalBuildEnvironment = Object.fromEntries(
+  buildEnvironmentKeys.map((key) => [key, process.env[key]]),
+);
+
+async function loadNextConfig(environment: Record<string, string>) {
+  jest.resetModules();
+
+  for (const key of buildEnvironmentKeys) {
+    delete process.env[key];
+  }
+  Object.assign(process.env, environment);
+
+  return (await import("../next.config")).default;
+}
+
+afterAll(() => {
+  for (const key of buildEnvironmentKeys) {
+    const originalValue = originalBuildEnvironment[key];
+    if (originalValue === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = originalValue;
+    }
+  }
+});
+
+describe("Next.js build settings", () => {
+  test("enables source maps and type checking for Vercel production", async () => {
+    const config = await loadNextConfig({
+      POSTHOG_CLI_API_KEY: "phx_test",
+      POSTHOG_CLI_PROJECT_ID: "project_test",
+      VERCEL_ENV: "production",
+    });
+
+    expect(config.productionBrowserSourceMaps).toBe(true);
+    expect(config.typescript?.ignoreBuildErrors).toBe(false);
+  });
+
+  test("disables source maps and skips duplicate type checking for previews", async () => {
+    const config = await loadNextConfig({
+      POSTHOG_CLI_API_KEY: "phx_test",
+      POSTHOG_CLI_PROJECT_ID: "project_test",
+      VERCEL_ENV: "preview",
+    });
+
+    expect(config.productionBrowserSourceMaps).toBe(false);
+    expect(config.typescript?.ignoreBuildErrors).toBe(true);
+  });
+
+  test("keeps local builds type-safe without uploading source maps", async () => {
+    const config = await loadNextConfig({
+      POSTHOG_CLI_API_KEY: "phx_test",
+      POSTHOG_CLI_PROJECT_ID: "project_test",
+    });
+
+    expect(config.productionBrowserSourceMaps).toBe(false);
+    expect(config.typescript?.ignoreBuildErrors).toBe(false);
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,12 +4,16 @@ const postHogSourceMapApiKey = process.env.POSTHOG_CLI_API_KEY?.trim();
 const postHogSourceMapProjectId = process.env.POSTHOG_CLI_PROJECT_ID?.trim();
 const hasPostHogSourceMapApiKey = Boolean(postHogSourceMapApiKey);
 const hasPostHogSourceMapProjectId = Boolean(postHogSourceMapProjectId);
-const posthogSourceMapsEnabled =
+const hasPostHogSourceMapConfig =
   hasPostHogSourceMapApiKey && hasPostHogSourceMapProjectId;
+const isVercelPreview = process.env.VERCEL_ENV === "preview";
+const isVercelProduction = process.env.VERCEL_ENV === "production";
+const posthogSourceMapsEnabled =
+  isVercelProduction && hasPostHogSourceMapConfig;
 
 if (
   (hasPostHogSourceMapApiKey || hasPostHogSourceMapProjectId) &&
-  !posthogSourceMapsEnabled
+  !hasPostHogSourceMapConfig
 ) {
   console.warn(
     "[PostHog] Source maps are disabled. Set both POSTHOG_CLI_API_KEY and POSTHOG_CLI_PROJECT_ID to enable upload.",
@@ -19,6 +23,10 @@ if (
 const nextConfig: NextConfig = {
   devIndicators: false,
   productionBrowserSourceMaps: posthogSourceMapsEnabled,
+  typescript: {
+    // Pull request CI runs pnpm typecheck while the preview builds in parallel.
+    ignoreBuildErrors: isVercelPreview,
+  },
   async headers() {
     const iconCacheHeaders = [
       {

--- a/scripts/__tests__/upload-posthog-sourcemaps.test.js
+++ b/scripts/__tests__/upload-posthog-sourcemaps.test.js
@@ -35,6 +35,7 @@ function runUpload({ cliExitCode = 0, env = {} } = {}) {
       cwd,
       env: {
         PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        VERCEL_ENV: "production",
         POSTHOG_CLI_API_KEY: "phx_test",
         POSTHOG_CLI_PROJECT_ID: "project_test",
         ...env,
@@ -47,6 +48,22 @@ function runUpload({ cliExitCode = 0, env = {} } = {}) {
 }
 
 describe("upload-posthog-sourcemaps", () => {
+  test("skips source map uploads outside Vercel production builds", () => {
+    const result = runUpload({
+      cliExitCode: 1,
+      env: {
+        VERCEL_ENV: "preview",
+        POSTHOG_SOURCEMAP_UPLOAD_STRICT: "true",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "Skipping source map upload because this is not a Vercel production build",
+    );
+    expect(result.stdout).not.toContain("fake posthog-cli");
+  });
+
   test("continues the build when posthog-cli fails by default", () => {
     const result = runUpload({ cliExitCode: 1 });
 

--- a/scripts/upload-posthog-sourcemaps.mjs
+++ b/scripts/upload-posthog-sourcemaps.mjs
@@ -18,91 +18,97 @@ const hasProjectId = Boolean(projectId);
 const failOnError =
   process.env.POSTHOG_SOURCEMAP_UPLOAD_STRICT?.trim().toLowerCase() === "true";
 
-if (process.env.VERCEL_ENV !== "production") {
-  console.log(
-    "[PostHog] Skipping source map upload because this is not a Vercel production build.",
-  );
-  process.exit(0);
-}
+process.exitCode = uploadSourceMaps();
 
-if (!hasApiKey && !hasProjectId) {
-  console.log(
-    "[PostHog] Skipping source map upload. Set POSTHOG_CLI_API_KEY and POSTHOG_CLI_PROJECT_ID to enable it.",
-  );
-  process.exit(0);
-}
-
-if (!hasApiKey || !hasProjectId) {
-  const message =
-    "[PostHog] Source map upload requires both POSTHOG_CLI_API_KEY and POSTHOG_CLI_PROJECT_ID.";
-  if (failOnError) {
-    console.error(message);
-    process.exit(1);
-  }
-  console.warn(`${message} Skipping upload.`);
-  process.exit(0);
-}
-
-if (!existsSync(buildDirectory)) {
-  console.error(`[PostHog] Build directory not found: ${buildDirectory}`);
-  process.exit(1);
-}
-
-const releaseName =
-  process.env.POSTHOG_SOURCEMAP_RELEASE_NAME?.trim() ||
-  readPackageName() ||
-  "hackerai";
-const releaseVersion =
-  process.env.POSTHOG_SOURCEMAP_RELEASE_VERSION?.trim() ||
-  process.env.VERCEL_GIT_COMMIT_SHA?.trim() ||
-  process.env.GITHUB_SHA?.trim() ||
-  readGitCommit();
-const build =
-  process.env.POSTHOG_SOURCEMAP_BUILD?.trim() ||
-  process.env.VERCEL_DEPLOYMENT_ID?.trim();
-
-const args = [
-  ...(host ? ["--host", host] : []),
-  "sourcemap",
-  "process",
-  "--directory",
-  buildDirectory,
-  "--release-name",
-  releaseName,
-  "--delete-after",
-];
-
-if (releaseVersion) {
-  args.push("--release-version", releaseVersion);
-}
-
-if (build) {
-  args.push("--build", build);
-}
-
-const result = spawnSync("posthog-cli", args, {
-  env: process.env,
-  stdio: "inherit",
-});
-
-if (result.error) {
-  console.error(`[PostHog] Failed to run posthog-cli: ${result.error.message}`);
-  process.exit(failOnError ? 1 : 0);
-}
-
-if (result.status !== 0) {
-  console.error(
-    `[PostHog] Source map upload failed with exit code ${result.status ?? 1}.`,
-  );
-  if (!failOnError) {
-    console.warn(
-      "[PostHog] Continuing build because source map upload is best-effort. Set POSTHOG_SOURCEMAP_UPLOAD_STRICT=true to fail on upload errors.",
+function uploadSourceMaps() {
+  if (process.env.VERCEL_ENV !== "production") {
+    console.log(
+      "[PostHog] Skipping source map upload because this is not a Vercel production build.",
     );
-    process.exit(0);
+    return 0;
   }
-}
 
-process.exit(result.status ?? 1);
+  if (!hasApiKey && !hasProjectId) {
+    console.log(
+      "[PostHog] Skipping source map upload. Set POSTHOG_CLI_API_KEY and POSTHOG_CLI_PROJECT_ID to enable it.",
+    );
+    return 0;
+  }
+
+  if (!hasApiKey || !hasProjectId) {
+    const message =
+      "[PostHog] Source map upload requires both POSTHOG_CLI_API_KEY and POSTHOG_CLI_PROJECT_ID.";
+    if (failOnError) {
+      console.error(message);
+      return 1;
+    }
+    console.warn(`${message} Skipping upload.`);
+    return 0;
+  }
+
+  if (!existsSync(buildDirectory)) {
+    console.error(`[PostHog] Build directory not found: ${buildDirectory}`);
+    return 1;
+  }
+
+  const releaseName =
+    process.env.POSTHOG_SOURCEMAP_RELEASE_NAME?.trim() ||
+    readPackageName() ||
+    "hackerai";
+  const releaseVersion =
+    process.env.POSTHOG_SOURCEMAP_RELEASE_VERSION?.trim() ||
+    process.env.VERCEL_GIT_COMMIT_SHA?.trim() ||
+    process.env.GITHUB_SHA?.trim() ||
+    readGitCommit();
+  const build =
+    process.env.POSTHOG_SOURCEMAP_BUILD?.trim() ||
+    process.env.VERCEL_DEPLOYMENT_ID?.trim();
+
+  const args = [
+    ...(host ? ["--host", host] : []),
+    "sourcemap",
+    "process",
+    "--directory",
+    buildDirectory,
+    "--release-name",
+    releaseName,
+    "--delete-after",
+  ];
+
+  if (releaseVersion) {
+    args.push("--release-version", releaseVersion);
+  }
+
+  if (build) {
+    args.push("--build", build);
+  }
+
+  const result = spawnSync("posthog-cli", args, {
+    env: process.env,
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    console.error(
+      `[PostHog] Failed to run posthog-cli: ${result.error.message}`,
+    );
+    return failOnError ? 1 : 0;
+  }
+
+  if (result.status !== 0) {
+    console.error(
+      `[PostHog] Source map upload failed with exit code ${result.status ?? 1}.`,
+    );
+    if (!failOnError) {
+      console.warn(
+        "[PostHog] Continuing build because source map upload is best-effort. Set POSTHOG_SOURCEMAP_UPLOAD_STRICT=true to fail on upload errors.",
+      );
+      return 0;
+    }
+  }
+
+  return result.status ?? 1;
+}
 
 function readPackageName() {
   try {

--- a/scripts/upload-posthog-sourcemaps.mjs
+++ b/scripts/upload-posthog-sourcemaps.mjs
@@ -18,6 +18,13 @@ const hasProjectId = Boolean(projectId);
 const failOnError =
   process.env.POSTHOG_SOURCEMAP_UPLOAD_STRICT?.trim().toLowerCase() === "true";
 
+if (process.env.VERCEL_ENV !== "production") {
+  console.log(
+    "[PostHog] Skipping source map upload because this is not a Vercel production build.",
+  );
+  process.exit(0);
+}
+
 if (!hasApiKey && !hasProjectId) {
   console.log(
     "[PostHog] Skipping source map upload. Set POSTHOG_CLI_API_KEY and POSTHOG_CLI_PROJECT_ID to enable it.",


### PR DESCRIPTION
## Summary

- generate and upload PostHog source maps only when `VERCEL_ENV=production`
- skip Next.js's duplicate TypeScript validation only for Vercel preview builds
- keep local and production builds type-safe
- add focused coverage for production, preview, and local build configuration

## Why

A representative preview deployment spent about 48–55 seconds processing 1,132 PostHog source-map pairs and about 30 seconds running TypeScript. Pull request CI already runs `pnpm typecheck` in parallel with Vercel, while production builds continue to perform Next.js TypeScript validation and PostHog uploads.

## Verified preview impact

Two preview deployments for this PR reached `READY` in **2m03s** and **2m13s**, compared with the **3m58s** baseline on the same 4-core / 8 GB build configuration: **1m45s–1m55s faster (44–48%)**.

| Phase | Baseline | First run | Final head |
| --- | ---: | ---: | ---: |
| Next.js compilation | 2m07s | 51s | 88s |
| TypeScript | 29.7s | 11ms config validation | 15ms config validation |
| PostHog source maps | 48s | skipped | skipped |
| Convex deployment | 7s | ~60s | 8s |
| Overall deployment to `READY` | 3m58s | 2m13s | 2m03s |

Compilation and Convex timing varied between runs, but both deployments consistently removed the duplicate TypeScript validation and the 1,132-pair / 20-batch PostHog upload from previews.

Final-head deployment: https://vercel.com/hackerai/hackerai/488WbjCYdbXPX9K2xrTWJ3WNUX1V  
First measured deployment: https://vercel.com/hackerai/hackerai/AScFL5AgdB8vXTpSoYvqb8eXAzyy

## Validation

- `pnpm exec jest --runInBand scripts/__tests__/upload-posthog-sourcemaps.test.js __tests__/next-config-build-settings.test.ts`
- `pnpm exec jest --ci --coverage --maxWorkers=2` — 265 suites, 2,685 tests passed
- `pnpm typecheck`
- `pnpm lint` — no errors; six pre-existing warnings outside this diff
- Prettier check for all changed files
- `git diff --check`
- Vercel preview reached `READY` and confirmed type validation and source-map upload are skipped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deployment Improvements**
  - Source maps are now uploaded only for production deployments, preventing unintended uploads from preview builds.
  - Preview deployments can complete even when type-checking reports errors, while production and local builds retain stricter type-safety checks.
  - Clearer warnings and status messages are provided when source-map configuration is incomplete or uploads are skipped.

- **Tests**
  - Added coverage for production, preview, and local build configurations, including source-map upload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->