### PR TITLE
Enable automatic vision handoff for Agent image views

### DIFF
--- a/lib/ai/tools/__tests__/file.test.ts
+++ b/lib/ai/tools/__tests__/file.test.ts
@@ -635,6 +635,104 @@ describe("file tool image view", () => {
     expect(mockPhEvent.mock.calls[0][1]).not.toHaveProperty("path");
   });
 
+  test("allows a non-vision Agent model to initiate a vision handoff", async () => {
+    mockUploadSandboxFileToConvex.mockResolvedValue({
+      fileId: "file-1" as never,
+      name: "screenshot.png",
+      mediaType: "image/png",
+    });
+
+    const commandRun = jest
+      .fn<Promise<FakeCommandResult>, [string, any?]>()
+      .mockImplementationOnce(async (_command, opts) => {
+        expect(opts.envVars.HACKERAI_FILE_VIEW_INCLUDE_DATA).toBe("0");
+        return {
+          stdout: JSON.stringify({
+            path: "/tmp/screenshot.png",
+            mediaType: "image/png",
+            sizeBytes: 68,
+            kind: "image",
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      })
+      .mockImplementationOnce(async (_command, opts) => {
+        expect(opts.envVars.HACKERAI_FILE_VIEW_INCLUDE_DATA).toBe("1");
+        return {
+          stdout: JSON.stringify({
+            path: "/tmp/screenshot.png",
+            mediaType: "image/png",
+            sizeBytes: 68,
+            kind: "image",
+            data: VALID_PNG_BASE64,
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      });
+    const sandbox = makeSandbox(commandRun);
+    const tool = createFile(
+      makeContext(sandbox, { modelName: "model-deepseek-v4-pro" }),
+    );
+    const inputSchema = (
+      tool as unknown as {
+        inputSchema: {
+          safeParse: (input: unknown) => { success: boolean };
+        };
+      }
+    ).inputSchema;
+
+    expect(
+      inputSchema.safeParse({
+        action: "view",
+        path: "/tmp/screenshot.png",
+        brief: "Inspect the screenshot",
+      }).success,
+    ).toBe(true);
+
+    const result = await runTool(tool, {
+      action: "view",
+      path: "/tmp/screenshot.png",
+      brief: "Inspect the screenshot",
+    });
+
+    await expect(runToModelOutput(tool, result)).resolves.toEqual({
+      type: "content",
+      value: [
+        {
+          type: "text",
+          text: "Viewing image file: screenshot.png (image/png, 68 bytes).",
+        },
+        {
+          type: "image-data",
+          data: VALID_PNG_BASE64,
+          mediaType: "image/png",
+        },
+      ],
+    });
+  });
+
+  test("redirects raster image reads to the view action", async () => {
+    const commandRun = jest.fn<Promise<FakeCommandResult>, [string, any?]>();
+    const sandbox = makeSandbox(commandRun);
+    const tool = createFile(
+      makeContext(sandbox, { modelName: "model-deepseek-v4-pro" }),
+    );
+
+    await expect(
+      runTool(tool, {
+        action: "read",
+        path: "/tmp/screenshot.png",
+        brief: "Inspect the screenshot",
+      }),
+    ).resolves.toEqual({
+      error:
+        "Raster image files cannot be read as text. Use the view action instead; Agent will automatically route image inspection to a vision-capable model when necessary.",
+    });
+    expect(commandRun).not.toHaveBeenCalled();
+  });
+
   test("logs initial inspection failures with safe path diagnostics", async () => {
     const commandRun = jest.fn(async () => ({
       stdout: JSON.stringify({

--- a/lib/ai/tools/__tests__/file.test.ts
+++ b/lib/ai/tools/__tests__/file.test.ts
@@ -733,6 +733,62 @@ describe("file tool image view", () => {
     expect(commandRun).not.toHaveBeenCalled();
   });
 
+  test.each([
+    ["extensionless PNG", "/tmp/screenshot", "image/png"],
+    ["renamed JPEG", "/tmp/screenshot.data", "image/jpeg"],
+  ])(
+    "redirects %s reads after bounded content inspection",
+    async (_label, path, imageMediaType) => {
+      const commandRun = jest.fn(async () => ({
+        stdout: JSON.stringify({
+          path,
+          sizeBytes: 68,
+          totalLines: 0,
+          imageMediaType,
+        }),
+        stderr: "",
+        exitCode: 0,
+      }));
+      const sandbox = makeSandbox(commandRun);
+      const tool = createFile(
+        makeContext(sandbox, { modelName: "model-deepseek-v4-pro" }),
+      );
+
+      await expect(
+        runTool(tool, {
+          action: "read",
+          path,
+          brief: "Inspect the screenshot",
+        }),
+      ).resolves.toEqual({
+        error:
+          "Raster image files cannot be read as text. Use the view action instead; Agent will automatically route image inspection to a vision-capable model when necessary.",
+      });
+      expect(commandRun).toHaveBeenCalledTimes(1);
+      expect(sandbox.files.read).not.toHaveBeenCalled();
+    },
+  );
+
+  test("redirects JPEG alias extensions without sandbox inspection", async () => {
+    const commandRun = jest.fn<Promise<FakeCommandResult>, [string, any?]>();
+    const sandbox = makeSandbox(commandRun);
+    const tool = createFile(
+      makeContext(sandbox, { modelName: "model-deepseek-v4-pro" }),
+    );
+
+    await expect(
+      runTool(tool, {
+        action: "read",
+        path: "/tmp/screenshot.jfif",
+        brief: "Inspect the screenshot",
+      }),
+    ).resolves.toEqual({
+      error:
+        "Raster image files cannot be read as text. Use the view action instead; Agent will automatically route image inspection to a vision-capable model when necessary.",
+    });
+    expect(commandRun).not.toHaveBeenCalled();
+  });
+
   test("logs initial inspection failures with safe path diagnostics", async () => {
     const commandRun = jest.fn(async () => ({
       stdout: JSON.stringify({

--- a/lib/ai/tools/__tests__/schemas.test.ts
+++ b/lib/ai/tools/__tests__/schemas.test.ts
@@ -1,4 +1,5 @@
 import {
+  createAgentToolSchemaSet,
   createFileToolSchema,
   createRunTerminalCmdToolSchema,
   runTerminalCmdTool,
@@ -72,6 +73,22 @@ describe("agent tool schema descriptions", () => {
     expect(getDescription(fullAccessTool)).not.toContain("approval-gated");
     expect(getDescription(approvalGatedTool)).toContain(
       "Write, append, and edit actions are approval-gated.",
+    );
+    expect(getDescription(fullAccessTool)).toContain(
+      "automatically routes subsequent Agent steps to a vision-capable model",
+    );
+  });
+
+  test("always exposes image view in the Agent schema catalog", () => {
+    const agentTools = createAgentToolSchemaSet();
+    const fileInputShape = getInputShape(agentTools.file);
+    const actionSchema = fileInputShape.action as {
+      safeParse: (input: unknown) => { success: boolean };
+    };
+
+    expect(actionSchema.safeParse("view").success).toBe(true);
+    expect(createAgentToolSchemaSet({ mode: "ask" })).not.toHaveProperty(
+      "file",
     );
   });
 });

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -23,7 +23,17 @@ import { createFileToolSchema } from "./schemas";
 const MAX_VIEW_FILE_BYTES = 10 * 1024 * 1024;
 const MAX_TEXT_FILE_READ_BYTES = 1024 * 1024;
 const MAX_TEXT_READ_RESULT_BYTES = 1024 * 1024;
-const RASTER_IMAGE_EXTENSIONS = new Set(["gif", "jpeg", "jpg", "png", "webp"]);
+const RASTER_IMAGE_EXTENSIONS = new Set([
+  "gif",
+  "jpe",
+  "jfif",
+  "jpeg",
+  "jpg",
+  "png",
+  "webp",
+]);
+const RASTER_READ_REDIRECT_MESSAGE =
+  "Raster image files cannot be read as text. Use the view action instead; Agent will automatically route image inspection to a vision-capable model when necessary.";
 const MULTIMODAL_UPGRADE_MESSAGE =
   "The current model does not support multimodal tool results for sandbox images. Please select a model with image viewing support and retry the view action.";
 
@@ -149,6 +159,7 @@ emit(payload)
 
 const READ_TEXT_FILE_SCRIPT = String.raw`
 import json
+import mimetypes
 import os
 import sys
 
@@ -171,6 +182,32 @@ if not os.path.isfile(path):
     emit({"error": f"File not found or is not a regular file: {path}"}, 3)
 
 size = os.path.getsize(path)
+
+with open(path, "rb") as f:
+    head = f.read(32)
+
+def detect_raster_media_type(head_bytes, file_path):
+    if head_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if head_bytes.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if head_bytes.startswith(b"GIF87a") or head_bytes.startswith(b"GIF89a"):
+        return "image/gif"
+    if head_bytes.startswith(b"RIFF") and head_bytes[8:12] == b"WEBP":
+        return "image/webp"
+    guessed, _ = mimetypes.guess_type(file_path)
+    if guessed in {"image/gif", "image/jpeg", "image/png", "image/webp"}:
+        return guessed
+    return None
+
+image_media_type = detect_raster_media_type(head, path)
+if image_media_type:
+    emit({
+        "path": path,
+        "sizeBytes": size,
+        "totalLines": 0,
+        "imageMediaType": image_media_type,
+    })
 
 def count_lines(file_path, file_size):
     if file_size == 0:
@@ -614,6 +651,7 @@ type SandboxTextReadPayload = {
   path: string;
   sizeBytes: number;
   totalLines: number;
+  imageMediaType?: string;
   content?: string;
   startLine?: number;
   tooLarge?: boolean;
@@ -1362,10 +1400,7 @@ export const createFile = (context: ToolContext) => {
 
           case "read": {
             if (isRasterImagePath(path)) {
-              return {
-                error:
-                  "Raster image files cannot be read as text. Use the view action instead; Agent will automatically route image inspection to a vision-capable model when necessary.",
-              };
+              return { error: RASTER_READ_REDIRECT_MESSAGE };
             }
 
             const filename = path.split("/").pop() || path;
@@ -1374,6 +1409,10 @@ export const createFile = (context: ToolContext) => {
               path,
               range,
             );
+
+            if (readPayload.imageMediaType) {
+              return { error: RASTER_READ_REDIRECT_MESSAGE };
+            }
 
             if (readPayload.tooLarge) {
               const totalLines =

--- a/lib/ai/tools/file.ts
+++ b/lib/ai/tools/file.ts
@@ -23,6 +23,7 @@ import { createFileToolSchema } from "./schemas";
 const MAX_VIEW_FILE_BYTES = 10 * 1024 * 1024;
 const MAX_TEXT_FILE_READ_BYTES = 1024 * 1024;
 const MAX_TEXT_READ_RESULT_BYTES = 1024 * 1024;
+const RASTER_IMAGE_EXTENSIONS = new Set(["gif", "jpeg", "jpg", "png", "webp"]);
 const MULTIMODAL_UPGRADE_MESSAGE =
   "The current model does not support multimodal tool results for sandbox images. Please select a model with image viewing support and retry the view action.";
 
@@ -292,6 +293,11 @@ const getFileExtension = (path: string): string | undefined => {
   const dotIndex = filename.lastIndexOf(".");
   if (dotIndex <= 0 || dotIndex === filename.length - 1) return undefined;
   return filename.slice(dotIndex + 1).toLowerCase();
+};
+
+const isRasterImagePath = (path: string): boolean => {
+  const extension = getFileExtension(path);
+  return extension ? RASTER_IMAGE_EXTENSIONS.has(extension) : false;
 };
 
 function getViewSandboxType(sandbox: any): "centrifugo" | "e2b" {
@@ -1221,7 +1227,10 @@ export const createFile = (context: ToolContext) => {
     });
   const canViewMultimodalFiles = () =>
     supportsMultimodalToolResults(getCurrentModelName?.() ?? modelName);
-  const supportsViewInSchema = canViewMultimodalFiles();
+  const canHandoffMultimodalFiles = context.mode === "agent";
+  const canReturnMultimodalFiles = () =>
+    canHandoffMultimodalFiles || canViewMultimodalFiles();
+  const supportsViewInSchema = canReturnMultimodalFiles();
   const fileToolSchema = createFileToolSchema({
     supportsView: supportsViewInSchema,
     approvalGated: !!context.requestToolApproval,
@@ -1267,7 +1276,7 @@ export const createFile = (context: ToolContext) => {
           case "view": {
             const viewStartedAt = Date.now();
 
-            if (!canViewMultimodalFiles()) {
+            if (!canReturnMultimodalFiles()) {
               captureFileViewImageUsage({
                 context,
                 sandbox,
@@ -1352,6 +1361,13 @@ export const createFile = (context: ToolContext) => {
           }
 
           case "read": {
+            if (isRasterImagePath(path)) {
+              return {
+                error:
+                  "Raster image files cannot be read as text. Use the view action instead; Agent will automatically route image inspection to a vision-capable model when necessary.",
+              };
+            }
+
             const filename = path.split("/").pop() || path;
             const readPayload = await readSandboxTextFileWithFallback(
               sandbox,
@@ -1598,7 +1614,7 @@ export const createFile = (context: ToolContext) => {
         ) {
           const viewOutput = output as ViewMetadata;
 
-          if (!canViewMultimodalFiles()) {
+          if (!canReturnMultimodalFiles()) {
             return {
               type: "text" as const,
               value: `Error: ${MULTIMODAL_UPGRADE_MESSAGE}`,

--- a/lib/ai/tools/schemas.ts
+++ b/lib/ai/tools/schemas.ts
@@ -253,6 +253,7 @@ export const createFileToolSchema = ({
     ...(supportsView
       ? [
           "Use 'view' only for raster image files such as PNG, JPEG, GIF, and WebP.",
+          "When the current Agent model is not vision-capable, calling 'view' automatically routes subsequent Agent steps to a vision-capable model.",
           "Do not use 'view' for PDFs. Use 'read' for extractable text, or use the shell tool to convert PDF pages to images first if visual inspection is required.",
           "Use 'read' for text-based or line-oriented formats.",
         ]
@@ -739,14 +740,12 @@ export const createAgentToolSchemaSet = ({
   isTemporary = false,
   hasPerplexityApiKey = false,
   hasJinaApiKey = false,
-  supportsFileView = false,
 }: {
   mode?: AgentToolSchemaMode;
   notesEnabled?: boolean;
   isTemporary?: boolean;
   hasPerplexityApiKey?: boolean;
   hasJinaApiKey?: boolean;
-  supportsFileView?: boolean;
 } = {}) => {
   const notes =
     !isTemporary && notesEnabled
@@ -773,7 +772,7 @@ export const createAgentToolSchemaSet = ({
     run_terminal_cmd: runTerminalCmdTool,
     interact_terminal_session: interactTerminalSessionTool,
     get_terminal_files: getTerminalFilesTool,
-    file: createFileToolSchema({ supportsView: supportsFileView }),
+    file: createFileToolSchema({ supportsView: true }),
     todo_write: todoWriteTool,
     ...notes,
     ...networkTools,

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -228,7 +228,7 @@ describe("agent tool schemas — Head Start bundle boundary", () => {
       /get_terminal_files:\s*getTerminalFilesTool/,
     );
     expect(toolSchemasSrc).toMatch(
-      /file:\s*createFileToolSchema\(\{\s*supportsView:\s*supportsFileView/,
+      /file:\s*createFileToolSchema\(\{\s*supportsView:\s*true/,
     );
     expect(toolSchemasSrc).toMatch(/todo_write:\s*todoWriteTool/);
     expect(toolSchemasSrc).toMatch(/create_note:\s*createNoteTool/);


### PR DESCRIPTION
## What changed

- expose the file tool's `view` action to every Agent model, including text-only defaults
- allow non-vision Agent models to emit an image tool result so the existing runner can continue with the tier-appropriate vision model
- prevent raster images from being decoded through the text `read` action and direct the Agent to `view`
- align the schema-only Agent catalog and tool guidance with the runtime behavior
- add coverage for non-vision handoff, raster-read rejection, and Agent schema exposure

## Why

The Agent browser can save screenshots while the default model is text-only. Because `view` was removed from that model's file schema, the model could fall back to `read`, which decoded PNG bytes as text and polluted context. The stream runner already knows how to switch to a vision-capable model after an image tool result; the file tool was preventing that result from being created.

## Impact

Agents can stay on the cheaper/default text model until visual inspection is actually requested. Calling `view` then triggers the existing temporary vision-model continuation, while accidental PNG reads fail cleanly instead of dumping binary data.

## Validation

- `pnpm typecheck`
- `pnpm lint` (no errors; six pre-existing warnings outside this change)
- `pnpm exec prettier --check` on all changed files
- focused Jest suites: 115 tests passed
- commit hook: full Jest suite, 2,684 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled image “view” support for file tooling, including automatic routing to a vision-capable model when required.
* **Bug Fixes**
  * Blocked raster image “read” requests and return a dedicated redirect message instructing use of “view” instead (including detection via extension and content).
* **Tests**
  * Expanded coverage for vision handoff, “view” routing acceptance, raster redirect behavior, and updated schema/tool catalog expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->