### PR TITLE
Use Grok 4.5 as the HackerAI Pro default

### DIFF
--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -93,7 +93,7 @@ describe("ModelSelector", () => {
     ).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("uses consistent vision wording for Agent Standard and Pro", async () => {
+  it("discloses the Agent Standard and Pro providers", async () => {
     const user = userEvent.setup();
     render(<ModelSelector value="auto" onChange={jest.fn()} mode="agent" />);
 
@@ -114,7 +114,7 @@ describe("ModelSelector", () => {
     await user.hover(screen.getByRole("button", { name: /HackerAI Pro/i }));
     expect(
       await screen.findAllByText(
-        "Powered by Z.ai GLM 5.2 · Grok 4.5 for vision",
+        "Powered by xAI Grok 4.5 · Z.ai GLM 5.2 fallback",
       ),
     ).not.toHaveLength(0);
   });

--- a/app/components/ModelSelector/__tests__/options-drift.test.ts
+++ b/app/components/ModelSelector/__tests__/options-drift.test.ts
@@ -40,12 +40,12 @@ describe("ModelSelector tier ↔ provider drift", () => {
     );
   });
 
-  it("HackerAI Pro resolves to GLM in both modes", () => {
+  it("HackerAI Pro resolves to its dedicated Grok route in both modes", () => {
     expect(resolveTierToProviderKey("hackerai-pro", "ask")).toBe(
-      "model-glm-5.2",
+      "model-grok-4.5-pro",
     );
     expect(resolveTierToProviderKey("hackerai-pro", "agent")).toBe(
-      "model-glm-5.2",
+      "model-grok-4.5-pro",
     );
   });
 
@@ -79,14 +79,14 @@ describe("ModelSelector tier ↔ provider drift", () => {
     ).toBe("DeepSeek V4 Pro · MiniMax M3 for vision");
   });
 
-  it("discloses the mode-specific vision provider for HackerAI Pro", () => {
+  it("discloses Grok primary and GLM fallback for HackerAI Pro", () => {
     expect(
       ASK_MODEL_OPTIONS.find((option) => option.id === "hackerai-pro")
         ?.poweredBy,
-    ).toBe("Z.ai GLM 5.2 · Kimi K2.7 for vision");
+    ).toBe("xAI Grok 4.5 · Z.ai GLM 5.2 fallback");
     expect(
       AGENT_MODEL_OPTIONS.find((option) => option.id === "hackerai-pro")
         ?.poweredBy,
-    ).toBe("Z.ai GLM 5.2 · Grok 4.5 for vision");
+    ).toBe("xAI Grok 4.5 · Z.ai GLM 5.2 fallback");
   });
 });

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -22,7 +22,7 @@ export const ASK_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-pro",
     label: "HackerAI Pro",
     description: "Superior performance for most assignments",
-    poweredBy: "Z.ai GLM 5.2 · Kimi K2.7 for vision",
+    poweredBy: "xAI Grok 4.5 · Z.ai GLM 5.2 fallback",
   },
   {
     id: "hackerai-max",
@@ -44,7 +44,7 @@ export const AGENT_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-pro",
     label: "HackerAI Pro",
     description: "Superior performance for most assignments",
-    poweredBy: "Z.ai GLM 5.2 · Grok 4.5 for vision",
+    poweredBy: "xAI Grok 4.5 · Z.ai GLM 5.2 fallback",
     thinking: true,
   },
   {

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -26,6 +26,10 @@ describe("provider registry", () => {
         .modelId,
     ).toBe("x-ai/grok-4.5");
     expect(
+      (myProvider.languageModel("model-grok-4.5-pro") as { modelId: string })
+        .modelId,
+    ).toBe("x-ai/grok-4.5");
+    expect(
       (myProvider.languageModel("model-glm-5.2") as { modelId: string })
         .modelId,
     ).toBe("z-ai/glm-5.2");
@@ -57,6 +61,7 @@ describe("provider registry", () => {
     ).toBe("x-ai/grok-4.5");
     expect(getModelDisplayName("model-minimax-m3")).toBe("MiniMax M3");
     expect(getModelDisplayName("model-grok-4.5")).toBe("xAI Grok 4.5");
+    expect(getModelDisplayName("model-grok-4.5-pro")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-glm-5.2")).toBe("Z.ai GLM 5.2");
     expect(getModelDisplayName("model-gemini-3-flash")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("title-generator-model")).toBe("xAI Grok 4.5");
@@ -206,6 +211,7 @@ describe("supportsMultimodalToolResults", () => {
 
   it("allows multimodal fallback keys and slugs used after image tool results", () => {
     expect(supportsMultimodalToolResults("model-grok-4.5")).toBe(true);
+    expect(supportsMultimodalToolResults("model-grok-4.5-pro")).toBe(true);
     expect(supportsMultimodalToolResults("model-gemini-3-flash")).toBe(true);
     expect(supportsMultimodalToolResults("fallback-grok-4.5")).toBe(true);
     expect(supportsMultimodalToolResults("x-ai/grok-4.5")).toBe(true);

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -191,6 +191,9 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "agent-model-free": or(DEEPSEEK_V4_FLASH_SLUG),
     "model-sonnet-4.6": or("anthropic/claude-sonnet-4-6"),
     "model-grok-4.5": or(GROK_4_5_SLUG),
+    // Dedicated HackerAI Pro alias so its GLM fallback can evolve without
+    // changing Standard PDF or legacy Grok fallback behavior.
+    "model-grok-4.5-pro": or(GROK_4_5_SLUG),
     // Compatibility alias for stale internal references persisted before the
     // paid Ask PDF route settled on Grok 4.5.
     "model-gemini-3-flash": or(GROK_4_5_SLUG),
@@ -221,6 +224,7 @@ export const modelCutoffDates: Record<ModelName, string> &
   "agent-model-free": "May 2025",
   "model-sonnet-4.6": "May 2025",
   "model-grok-4.5": "July 2026",
+  "model-grok-4.5-pro": "July 2026",
   "model-gemini-3-flash": "July 2026",
   "model-deepseek-v4-flash": "May 2025",
   "model-deepseek-v4-pro": "May 2025",
@@ -243,6 +247,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "agent-model-free": "Auto, an intelligent model router built by HackerAI",
   "model-sonnet-4.6": "Anthropic Claude Sonnet 4.6",
   "model-grok-4.5": "xAI Grok 4.5",
+  "model-grok-4.5-pro": "xAI Grok 4.5",
   "model-gemini-3-flash": "xAI Grok 4.5",
   "model-deepseek-v4-flash": "DeepSeek V4 Flash",
   "model-deepseek-v4-pro": "DeepSeek V4 Pro",
@@ -323,7 +328,7 @@ export function supportsMultimodalToolResults(modelName?: string): boolean {
 /**
  * Map a HackerAI tier id to the underlying provider key for a given mode.
  * Returns `null` for `"auto"` (the caller routes to the auto-router model
- * key instead). Standard maps to DeepSeek, Pro to GLM, and Max to Opus in
+ * key instead). Standard maps to DeepSeek, Pro to Grok, and Max to Opus in
  * both modes; media-aware promotion happens in `selectModel`.
  */
 export function resolveTierToProviderKey(
@@ -335,7 +340,7 @@ export function resolveTierToProviderKey(
     case "hackerai-standard":
       return "model-deepseek-v4-pro";
     case "hackerai-pro":
-      return "model-glm-5.2";
+      return "model-grok-4.5-pro";
     case "hackerai-max":
       return "model-opus-4.6";
   }

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -176,10 +176,10 @@ describe("resolveAgentModelForImageToolResults", () => {
     ).toBe("model-kimi-k2.7-code");
   });
 
-  it("switches Agent Pro GLM steps to Grok 4.5 after image tool results", () => {
+  it("keeps the HackerAI Pro GLM fallback active after image tool results", () => {
     expect(
       resolveAgentModelForImageToolResults("model-glm-5.2", "agent", true),
-    ).toBe("model-grok-4.5");
+    ).toBe("model-glm-5.2");
   });
 
   it("switches free DeepSeek Agent steps to MiniMax after image tool results", () => {
@@ -199,6 +199,9 @@ describe("resolveAgentModelForImageToolResults", () => {
     expect(
       resolveAgentModelForImageToolResults("model-minimax-m3", "agent", true),
     ).toBe("model-minimax-m3");
+    expect(
+      resolveAgentModelForImageToolResults("model-grok-4.5-pro", "agent", true),
+    ).toBe("model-grok-4.5-pro");
   });
 });
 

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -176,7 +176,24 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("falls back from Agent Pro vision Grok 4.5 directly to Kimi 2.7 Code", () => {
+  it.each(["ask", "agent"] as const)(
+    "falls back from HackerAI Pro Grok 4.5 to GLM 5.2 then Kimi in %s mode",
+    (mode) => {
+      const opts = buildProviderOptions(
+        mode === "agent",
+        "user-1",
+        "model-grok-4.5-pro",
+        mode,
+      );
+      expect(opts.openrouter).toMatchObject({
+        reasoning: { enabled: true, effort: "high" },
+        models: [GLM_SLUG, KIMI_SLUG],
+        user: "user-1",
+      });
+    },
+  );
+
+  it("keeps the legacy Agent vision Grok route on its direct Kimi fallback", () => {
     const opts = buildProviderOptions(
       true,
       "user-1",
@@ -336,27 +353,31 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it.each(["model-glm-5.2", "model-sonnet-4.6", "model-opus-4.6"])(
-    "enables high reasoning for ask mode model %s",
-    (modelName) => {
-      const opts = buildProviderOptions(false, "user-1", modelName, "ask");
-      expect(opts.openrouter.reasoning).toEqual({
-        enabled: true,
-        effort: "high",
-      });
-    },
-  );
+  it.each([
+    "model-grok-4.5-pro",
+    "model-glm-5.2",
+    "model-sonnet-4.6",
+    "model-opus-4.6",
+  ])("enables high reasoning for ask mode model %s", (modelName) => {
+    const opts = buildProviderOptions(false, "user-1", modelName, "ask");
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+      effort: "high",
+    });
+  });
 
-  it.each(["model-glm-5.2", "model-sonnet-4.6", "model-opus-4.6"])(
-    "enables high reasoning for agent mode model %s",
-    (modelName) => {
-      const opts = buildProviderOptions(true, "user-1", modelName, "agent");
-      expect(opts.openrouter.reasoning).toEqual({
-        enabled: true,
-        effort: "high",
-      });
-    },
-  );
+  it.each([
+    "model-grok-4.5-pro",
+    "model-glm-5.2",
+    "model-sonnet-4.6",
+    "model-opus-4.6",
+  ])("enables high reasoning for agent mode model %s", (modelName) => {
+    const opts = buildProviderOptions(true, "user-1", modelName, "agent");
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+      effort: "high",
+    });
+  });
 
   it("uses max reasoning for DeepSeek V4 Pro in agent mode", () => {
     const opts = buildProviderOptions(
@@ -435,7 +456,7 @@ describe("isAutoModelSelectionForRetry", () => {
     ).toBe(false);
     expect(
       isAutoModelSelectionForRetry({
-        selectedModel: "model-glm-5.2",
+        selectedModel: "model-grok-4.5-pro",
         selectedModelOverride: "hackerai-pro",
       }),
     ).toBe(false);
@@ -472,7 +493,16 @@ describe("getRetryFallbackModel", () => {
     expect(getRetryFallbackModel("ask-model", "ask")).toBe("fallback-grok-4.5");
   });
 
-  it("retries Agent Pro vision Grok with Kimi 2.7 Code", () => {
+  it("retries HackerAI Pro Grok with GLM 5.2", () => {
+    expect(getRetryFallbackModel("model-grok-4.5-pro", "agent")).toBe(
+      "model-glm-5.2",
+    );
+    expect(getRetryFallbackModel("model-grok-4.5-pro", "ask")).toBe(
+      "model-glm-5.2",
+    );
+  });
+
+  it("retries the legacy Agent vision Grok route with Kimi 2.7 Code", () => {
     expect(getRetryFallbackModel("model-grok-4.5", "agent")).toBe(
       "model-kimi-k2.7-code",
     );
@@ -541,7 +571,31 @@ describe("resolveServedModelForCostAccounting", () => {
     ).toBe("model-grok-4.5");
   });
 
-  it("maps Agent Pro vision Kimi fallback usage back to the Kimi cost key", () => {
+  it("maps HackerAI Pro primary and fallback usage to their exact cost keys", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "model-grok-4.5-pro",
+        responseModel: GROK_SLUG,
+        mode: "agent",
+      }),
+    ).toBe("model-grok-4.5-pro");
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "model-grok-4.5-pro",
+        responseModel: GLM_SLUG,
+        mode: "ask",
+      }),
+    ).toBe("model-glm-5.2");
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "model-grok-4.5-pro",
+        responseModel: KIMI_SLUG,
+        mode: "agent",
+      }),
+    ).toBe("model-kimi-k2.7-code");
+  });
+
+  it("maps legacy Agent Pro vision Kimi fallback usage back to the Kimi cost key", () => {
     expect(
       resolveServedModelForCostAccounting({
         modelName: "model-grok-4.5",

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -106,7 +106,6 @@ import type { createTrackedProvider } from "@/lib/ai/providers";
 import type { ProviderRequestDiagnostics } from "@/lib/logger";
 import type { ChatMode, SubscriptionTier } from "@/types";
 
-const AGENT_PRO_VISION_MODEL = "model-grok-4.5";
 const AGENT_STANDARD_VISION_MODEL = "model-kimi-k2.7-code";
 const FREE_AGENT_VISION_MODEL = "model-minimax-m3";
 
@@ -117,7 +116,6 @@ export const resolveAgentModelForImageToolResults = (
 ): string => {
   if (mode !== "agent" || !hasImageToolResults) return modelName;
   if (modelName === "agent-model-free") return FREE_AGENT_VISION_MODEL;
-  if (modelName === "model-glm-5.2") return AGENT_PRO_VISION_MODEL;
   return isDeepSeekModel(modelName) ? AGENT_STANDARD_VISION_MODEL : modelName;
 };
 

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -547,8 +547,17 @@ const AGENT_TEXT_FALLBACK_CHAIN = [
   ...MINIMAX_M3_FALLBACK_CHAIN,
 ] as const satisfies readonly ModelName[];
 
+// HackerAI Pro uses Grok 4.5 for every request. GLM 5.2 remains its first
+// fallback, followed by Kimi so media requests still have a multimodal final
+// recovery path if both primary providers are unavailable.
+const HACKERAI_PRO_FALLBACK_CHAIN = [
+  "model-glm-5.2",
+  "model-kimi-k2.7-code",
+] as const satisfies readonly ModelName[];
+
 // Agent Pro promotes vision steps to Grok 4.5. Keep Kimi as its direct
-// multimodal fallback without routing back through the cheaper Agent chain.
+// multimodal fallback for legacy in-flight routes that still use the generic
+// Grok key rather than the dedicated HackerAI Pro alias.
 const AGENT_PRO_VISION_FALLBACK_CHAIN = [
   "model-kimi-k2.7-code",
 ] as const satisfies readonly ModelName[];
@@ -561,6 +570,7 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "ask-model": MINIMAX_M3_FALLBACK_CHAIN,
   "agent-model": MINIMAX_M3_FALLBACK_CHAIN,
   "model-grok-4.5": AGENT_TEXT_FALLBACK_CHAIN,
+  "model-grok-4.5-pro": HACKERAI_PRO_FALLBACK_CHAIN,
   "model-gemini-3-flash": AGENT_TEXT_FALLBACK_CHAIN,
   "model-glm-5.2": MINIMAX_M3_FALLBACK_CHAIN,
   "model-minimax-m3": MINIMAX_M3_FALLBACK_CHAIN,
@@ -621,6 +631,7 @@ const isAskMediumReasoningModel = (modelName?: string): boolean =>
   (ASK_MEDIUM_REASONING_MODELS as readonly string[]).includes(modelName);
 
 const HIGH_REASONING_MODELS = [
+  "model-grok-4.5-pro",
   "model-glm-5.2",
   "model-sonnet-4.6",
   "model-opus-4.6",
@@ -672,6 +683,9 @@ export function getRetryFallbackModel(
   modelName: ModelName,
   mode: ChatMode,
 ): ModelName {
+  if (modelName === "model-grok-4.5-pro") {
+    return "model-glm-5.2";
+  }
   if (modelName === "model-grok-4.5" && mode === "agent") {
     return "model-kimi-k2.7-code";
   }

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -228,23 +228,27 @@ describe("selectModel", () => {
 
   // Tier override — Standard is content-aware in ask mode; Max maps to Opus in both modes
   describe("tier override for ask mode (paid users)", () => {
-    it("should map HackerAI Pro to GLM 5.2 for text-only ask mode", () => {
-      expect(selectModel("ask", "ultra", "hackerai-pro")).toBe("model-glm-5.2");
-    });
-
-    it("should map HackerAI Pro to GLM 5.2 for team users", () => {
-      expect(selectModel("ask", "team", "hackerai-pro")).toBe("model-glm-5.2");
-    });
-
-    it("should route HackerAI Pro to Kimi K2.7 when an image is attached", () => {
-      expect(selectModel("ask", "pro", "hackerai-pro", true, false)).toBe(
-        "model-kimi-k2.7-code",
+    it("should map HackerAI Pro to Grok 4.5 for text-only ask mode", () => {
+      expect(selectModel("ask", "ultra", "hackerai-pro")).toBe(
+        "model-grok-4.5-pro",
       );
     });
 
-    it("should route HackerAI Pro to Kimi K2.7 when a PDF is attached", () => {
+    it("should map HackerAI Pro to Grok 4.5 for team users", () => {
+      expect(selectModel("ask", "team", "hackerai-pro")).toBe(
+        "model-grok-4.5-pro",
+      );
+    });
+
+    it("should keep HackerAI Pro on Grok 4.5 when an image is attached", () => {
+      expect(selectModel("ask", "pro", "hackerai-pro", true, false)).toBe(
+        "model-grok-4.5-pro",
+      );
+    });
+
+    it("should keep HackerAI Pro on Grok 4.5 when a PDF is attached", () => {
       expect(selectModel("ask", "pro", "hackerai-pro", false, true)).toBe(
-        "model-kimi-k2.7-code",
+        "model-grok-4.5-pro",
       );
     });
 
@@ -279,11 +283,15 @@ describe("selectModel", () => {
     });
 
     it("should downgrade HackerAI Max to Pro outside Ultra", () => {
-      expect(selectModel("ask", "pro", "hackerai-max")).toBe("model-glm-5.2");
-      expect(selectModel("ask", "pro-plus", "hackerai-max")).toBe(
-        "model-glm-5.2",
+      expect(selectModel("ask", "pro", "hackerai-max")).toBe(
+        "model-grok-4.5-pro",
       );
-      expect(selectModel("ask", "team", "hackerai-max")).toBe("model-glm-5.2");
+      expect(selectModel("ask", "pro-plus", "hackerai-max")).toBe(
+        "model-grok-4.5-pro",
+      );
+      expect(selectModel("ask", "team", "hackerai-max")).toBe(
+        "model-grok-4.5-pro",
+      );
     });
 
     it("should map HackerAI Max to Opus 4.6 for paid users with extra usage", () => {
@@ -315,19 +323,21 @@ describe("selectModel", () => {
       ).toBe("model-minimax-m3");
     });
 
-    it("should keep HackerAI Pro on GLM 5.2 in text-only agent mode", () => {
-      expect(selectModel("agent", "pro", "hackerai-pro")).toBe("model-glm-5.2");
+    it("should map HackerAI Pro to Grok 4.5 in text-only agent mode", () => {
+      expect(selectModel("agent", "pro", "hackerai-pro")).toBe(
+        "model-grok-4.5-pro",
+      );
     });
 
     it("should route HackerAI Pro to Grok 4.5 in agent mode when an image is attached", () => {
       expect(selectModel("agent", "pro", "hackerai-pro", true, false)).toBe(
-        "model-grok-4.5",
+        "model-grok-4.5-pro",
       );
     });
 
     it("should route HackerAI Pro to Grok 4.5 in agent mode when a PDF is attached", () => {
       expect(selectModel("agent", "pro", "hackerai-pro", false, true)).toBe(
-        "model-grok-4.5",
+        "model-grok-4.5-pro",
       );
     });
 
@@ -338,12 +348,14 @@ describe("selectModel", () => {
     });
 
     it("should downgrade HackerAI Max to Pro in agent mode outside Ultra", () => {
-      expect(selectModel("agent", "pro", "hackerai-max")).toBe("model-glm-5.2");
+      expect(selectModel("agent", "pro", "hackerai-max")).toBe(
+        "model-grok-4.5-pro",
+      );
       expect(selectModel("agent", "pro-plus", "hackerai-max")).toBe(
-        "model-glm-5.2",
+        "model-grok-4.5-pro",
       );
       expect(selectModel("agent", "team", "hackerai-max")).toBe(
-        "model-glm-5.2",
+        "model-grok-4.5-pro",
       );
     });
 

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -48,9 +48,8 @@ export const getMaxStepsForUser = (
  *   (text-only); image-only prompts promote to MiniMax M3, while PDF prompts
  *   stay on Grok 4.5 for native document support. Paid Agent Auto/Standard
  *   routes use DeepSeek V4 Pro for text-only prompts and MiniMax M3 when
- *   provider-visible media is attached. HackerAI Pro uses GLM 5.2 for
- *   text-only prompts, Grok 4.5 for Agent vision, and Kimi K2.7 Code for Ask
- *   media prompts.
+ *   provider-visible media is attached. HackerAI Pro uses Grok 4.5 for both
+ *   text and vision; its GLM 5.2 fallback is configured downstream.
  * @returns Model name to use
  */
 export function selectModel(
@@ -116,8 +115,7 @@ export function selectModel(
   }
 
   if (allowedSelectedModel === "hackerai-pro") {
-    if (!hasProviderMedia) return "model-glm-5.2";
-    return isAgent ? "model-grok-4.5" : "model-kimi-k2.7-code";
+    return "model-grok-4.5-pro";
   }
 
   const providerKey = resolveTierToProviderKey(allowedSelectedModel, mode);

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -450,13 +450,15 @@ describe("token-bucket", () => {
       );
     });
 
-    it.each(["model-grok-4.5", "model-gemini-3-flash", "fallback-grok-4.5"])(
-      "should use Grok 4.5 pricing for %s ($2.00/$6.00)",
-      (modelName) => {
-        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(28000);
-        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(84000);
-      },
-    );
+    it.each([
+      "model-grok-4.5",
+      "model-grok-4.5-pro",
+      "model-gemini-3-flash",
+      "fallback-grok-4.5",
+    ])("should use Grok 4.5 pricing for %s ($2.00/$6.00)", (modelName) => {
+      expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(28000);
+      expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(84000);
+    });
 
     it("expensive models should deplete budget faster", () => {
       const monthlyBudget = getBudgetLimits("pro").monthly;

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -32,6 +32,7 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   "model-sonnet-4.6": { input: 3.0, output: 15.0 },
   // Grok 4.5 rates from OpenRouter: $2.00 in / $6.00 out per 1M tokens.
   "model-grok-4.5": { input: 2.0, output: 6.0 },
+  "model-grok-4.5-pro": { input: 2.0, output: 6.0 },
   "model-gemini-3-flash": { input: 2.0, output: 6.0 },
   // Rates from OpenRouter: $0.09 in / $0.18 out per 1M tokens.
   "agent-model-free": { input: 0.09, output: 0.18 },


### PR DESCRIPTION
## Summary

- route HackerAI Pro to `x-ai/grok-4.5` for Ask and Agent, including text, images, and PDFs
- keep `z-ai/glm-5.2` as the first fallback, followed by Kimi as the terminal multimodal recovery path
- isolate the Pro fallback chain behind a dedicated provider alias so Standard PDF and legacy Grok routes do not change
- keep retry routing, high reasoning, served-model cost accounting, token pricing, and image-tool continuation aligned
- update the model selector disclosure to `xAI Grok 4.5 · Z.ai GLM 5.2 fallback`

## Validation

- `pnpm typecheck`
- `pnpm lint` (0 errors; 6 existing warnings outside this change)
- Prettier check on all touched files
- focused routing/provider/fallback/UI/cost tests: 7 suites, 249 tests passed
- full pre-commit suite: 265 suites, 2,692 tests passed
- GitHub Actions passed
- Vercel preview is ready and its landing page loads without a Next.js error overlay
- CodeRabbit completed with no actionable comments or review threads

## Manual verification

The model picker requires signed-in account state, which was not available in the browser session used for preview QA.

1. Open the Vercel preview and sign in with an account that can select HackerAI Pro.
2. In both Ask and Agent mode, open the model selector and hover HackerAI Pro.
3. Confirm the disclosure reads `Powered by xAI Grok 4.5 · Z.ai GLM 5.2 fallback`.