### PR TITLE
Use high reasoning for DeepSeek V4 Agent routes

### DIFF
--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -203,7 +203,7 @@ describe("buildProviderOptions fallback chain", () => {
     },
   );
 
-  it("runs free Agent on DeepSeek Flash max and falls back through MiniMax, Kimi, then Grok", () => {
+  it("runs free Agent on DeepSeek Flash high and falls back through MiniMax, Kimi, then Grok", () => {
     const opts = buildProviderOptions(
       true,
       "user-1",
@@ -211,7 +211,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      reasoning: { enabled: true, effort: "xhigh" },
+      reasoning: { enabled: true, effort: "high" },
       models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
       user: "user-1",
     });

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -358,7 +358,7 @@ describe("buildProviderOptions fallback chain", () => {
     },
   );
 
-  it("uses max reasoning for DeepSeek V4 Pro in agent mode", () => {
+  it("uses high reasoning for DeepSeek V4 Pro in agent mode", () => {
     const opts = buildProviderOptions(
       true,
       "user-1",
@@ -367,7 +367,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(opts.openrouter.reasoning).toEqual({
       enabled: true,
-      effort: "xhigh",
+      effort: "high",
     });
   });
 

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -626,12 +626,9 @@ const HIGH_REASONING_MODELS = [
   "model-opus-4.6",
 ] as const satisfies readonly ModelName[];
 
-const isHighReasoningModel = (modelName?: string, mode?: ChatMode): boolean =>
+const isHighReasoningModel = (modelName?: string): boolean =>
   typeof modelName === "string" &&
-  ((HIGH_REASONING_MODELS as readonly string[]).includes(modelName) ||
-    // Paid Agent Auto/Standard text routes resolve to DeepSeek V4 Pro. Keep
-    // this mode-scoped so the paid Ask route remains at medium reasoning.
-    (mode === "agent" && modelName === "model-deepseek-v4-pro"));
+  (HIGH_REASONING_MODELS as readonly string[]).includes(modelName);
 
 const ASK_KIMI_REASONING_MODELS = [
   "model-kimi-k2.7-code",
@@ -789,10 +786,13 @@ export function buildProviderOptions(
 ) {
   const modelId = modelName ? resolveSlug(modelName) : undefined;
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
+  // Agent routes use high for both DeepSeek V4 Flash and Pro. Keep this
+  // mode-scoped so the corresponding Ask routes retain their existing effort.
+  const isAgentDeepSeekV4 = mode === "agent" && isDeepSeekV4;
   const fallbackSlugs = getFallbackSlugs(modelName, mode, options);
   const reasoning =
     options.reasoningOverride ??
-    (isHighReasoningModel(modelName, mode)
+    (isHighReasoningModel(modelName) || isAgentDeepSeekV4
       ? {
           enabled: true,
           effort: "high",

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -626,9 +626,12 @@ const HIGH_REASONING_MODELS = [
   "model-opus-4.6",
 ] as const satisfies readonly ModelName[];
 
-const isHighReasoningModel = (modelName?: string): boolean =>
+const isHighReasoningModel = (modelName?: string, mode?: ChatMode): boolean =>
   typeof modelName === "string" &&
-  (HIGH_REASONING_MODELS as readonly string[]).includes(modelName);
+  ((HIGH_REASONING_MODELS as readonly string[]).includes(modelName) ||
+    // Paid Agent Auto/Standard text routes resolve to DeepSeek V4 Pro. Keep
+    // this mode-scoped so the paid Ask route remains at medium reasoning.
+    (mode === "agent" && modelName === "model-deepseek-v4-pro"));
 
 const ASK_KIMI_REASONING_MODELS = [
   "model-kimi-k2.7-code",
@@ -789,7 +792,7 @@ export function buildProviderOptions(
   const fallbackSlugs = getFallbackSlugs(modelName, mode, options);
   const reasoning =
     options.reasoningOverride ??
-    (isHighReasoningModel(modelName)
+    (isHighReasoningModel(modelName, mode)
       ? {
           enabled: true,
           effort: "high",


### PR DESCRIPTION
## Summary

- use high reasoning for free Agent requests routed to DeepSeek V4 Flash
- use high reasoning for paid Agent Auto/Standard text requests routed to DeepSeek V4 Pro
- detect Agent DeepSeek V4 routes from the resolved model family so registry aliases receive the same setting
- keep the existing Ask behavior unchanged: Flash disabled and Pro medium

## Why

DeepSeek V4 Agent requests previously inherited the generic max (`xhigh`) reasoning option. Both Flash and Pro should instead use `high` in Agent mode. The setting remains mode-scoped so Ask requests keep their existing reasoning levels.

## Validation

- `pnpm test -- --runInBand lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/chat/__tests__/chat-processor.test.ts` (137 tests passed)
- `pnpm typecheck`
- `pnpm lint` (passes with 6 pre-existing warnings in unrelated files)
- pre-commit full suite (265 suites, 2,685 tests passed)

Manual verification is not required; this backend provider-options change is covered by routing and provider regression tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reasoning configuration for DeepSeek V4 Pro in agent mode by consistently using the “high” reasoning effort setting.
  - Agent-mode requests now apply the appropriate high reasoning effort for DeepSeek V4 models for more consistent behavior.

- **Tests**
  - Updated expectations for OpenRouter `reasoning.effort` to reflect the new “high” setting for DeepSeek agent-mode scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->