### PR TITLE
Reuse desktop build artifacts for releases

### DIFF
--- a/.github/scripts/prepare-desktop-release.sh
+++ b/.github/scripts/prepare-desktop-release.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ARTIFACTS_DIR="${1:-}"
+RELEASE_DIR="${2:-}"
+VERSION="${3:-}"
+TAG_NAME="${4:-}"
+GH_REPO="${5:-}"
+
+if [[ -z "$ARTIFACTS_DIR" || -z "$RELEASE_DIR" || -z "$VERSION" || -z "$TAG_NAME" || -z "$GH_REPO" ]]; then
+  echo "Usage: $0 <artifacts-dir> <release-dir> <version> <tag-name> <owner/repo>" >&2
+  exit 1
+fi
+
+if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Invalid desktop version: $VERSION" >&2
+  exit 1
+fi
+
+if [[ "$TAG_NAME" != "desktop-v$VERSION" ]]; then
+  echo "Tag $TAG_NAME does not match embedded version $VERSION" >&2
+  exit 1
+fi
+
+if [[ ! -d "$ARTIFACTS_DIR" ]]; then
+  echo "Artifact directory does not exist: $ARTIFACTS_DIR" >&2
+  exit 1
+fi
+
+if [[ -e "$RELEASE_DIR" ]] && find "$RELEASE_DIR" -mindepth 1 -print -quit | grep -q .; then
+  echo "Release directory must be empty: $RELEASE_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$RELEASE_DIR"
+
+copy_one() {
+  local search_dir="$1"
+  local pattern="$2"
+  local destination_name="${3:-}"
+  local -a matches=()
+
+  if [[ ! -d "$search_dir" ]]; then
+    echo "Expected artifact is missing: $search_dir" >&2
+    exit 1
+  fi
+
+  while IFS= read -r -d '' match; do
+    matches+=("$match")
+  done < <(find "$search_dir" -type f -name "$pattern" -print0)
+
+  if [[ "${#matches[@]}" -ne 1 ]]; then
+    echo "Expected exactly one $pattern in $search_dir, found ${#matches[@]}" >&2
+    exit 1
+  fi
+
+  if [[ -z "$destination_name" ]]; then
+    destination_name="$(basename "${matches[0]}")"
+  fi
+
+  cp "${matches[0]}" "$RELEASE_DIR/$destination_name"
+}
+
+# Copy each versioned installer explicitly so a run with incomplete or mixed
+# artifacts cannot be promoted accidentally.
+copy_one "$ARTIFACTS_DIR/desktop-macOS-arm64" "HackerAI_${VERSION}_aarch64.dmg"
+copy_one "$ARTIFACTS_DIR/desktop-macOS-x64" "HackerAI_${VERSION}_x64.dmg"
+copy_one "$ARTIFACTS_DIR/desktop-macOS-universal" "HackerAI-universal.dmg"
+copy_one "$ARTIFACTS_DIR/desktop-Linux-x64" "HackerAI_${VERSION}_amd64.AppImage"
+copy_one "$ARTIFACTS_DIR/desktop-Linux-x64" "HackerAI_${VERSION}_amd64.AppImage.tar.gz"
+copy_one "$ARTIFACTS_DIR/desktop-Linux-x64" "HackerAI_${VERSION}_amd64.AppImage.tar.gz.sig"
+copy_one "$ARTIFACTS_DIR/desktop-Linux-x64" "HackerAI_${VERSION}_amd64.deb"
+copy_one "$ARTIFACTS_DIR/desktop-Linux-arm64" "HackerAI_${VERSION}_aarch64.AppImage"
+copy_one "$ARTIFACTS_DIR/desktop-Linux-arm64" "HackerAI_${VERSION}_aarch64.AppImage.tar.gz"
+copy_one "$ARTIFACTS_DIR/desktop-Linux-arm64" "HackerAI_${VERSION}_aarch64.AppImage.tar.gz.sig"
+copy_one "$ARTIFACTS_DIR/desktop-Linux-arm64" "HackerAI_${VERSION}_arm64.deb"
+copy_one "$ARTIFACTS_DIR/desktop-Windows-x64" "HackerAI_${VERSION}_x64-setup.exe"
+copy_one "$ARTIFACTS_DIR/desktop-Windows-x64" "HackerAI_${VERSION}_x64-setup.nsis.zip"
+copy_one "$ARTIFACTS_DIR/desktop-Windows-x64" "HackerAI_${VERSION}_x64-setup.nsis.zip.sig"
+
+# Tauri gives both macOS updater archives the same filename. Keep both by
+# assigning architecture-specific release names before generating latest.json.
+copy_one "$ARTIFACTS_DIR/desktop-macOS-arm64" "HackerAI.app.tar.gz" "HackerAI-aarch64.app.tar.gz"
+copy_one "$ARTIFACTS_DIR/desktop-macOS-arm64" "HackerAI.app.tar.gz.sig" "HackerAI-aarch64.app.tar.gz.sig"
+copy_one "$ARTIFACTS_DIR/desktop-macOS-x64" "HackerAI.app.tar.gz" "HackerAI-x86_64.app.tar.gz"
+copy_one "$ARTIFACTS_DIR/desktop-macOS-x64" "HackerAI.app.tar.gz.sig" "HackerAI-x86_64.app.tar.gz.sig"
+
+cp "$RELEASE_DIR/HackerAI_${VERSION}_amd64.AppImage" "$RELEASE_DIR/HackerAI-linux-x64.AppImage"
+cp "$RELEASE_DIR/HackerAI_${VERSION}_aarch64.AppImage" "$RELEASE_DIR/HackerAI-linux-arm64.AppImage"
+cp "$RELEASE_DIR/HackerAI_${VERSION}_amd64.deb" "$RELEASE_DIR/HackerAI-linux-x64.deb"
+cp "$RELEASE_DIR/HackerAI_${VERSION}_arm64.deb" "$RELEASE_DIR/HackerAI-linux-arm64.deb"
+cp "$RELEASE_DIR/HackerAI_${VERSION}_x64-setup.exe" "$RELEASE_DIR/HackerAI-windows-x64.exe"
+
+read_signature() {
+  local signature_file="$1"
+  local signature
+
+  signature="$(<"$signature_file")"
+  if [[ -z "$signature" ]]; then
+    echo "Updater signature is empty: $signature_file" >&2
+    exit 1
+  fi
+  printf '%s' "$signature"
+}
+
+verify_signature() {
+  local archive_file="$1"
+  local signature_file="$2"
+  local decoded_signature
+
+  if [[ -z "${MINISIGN_PUBLIC_KEY:-}" ]]; then
+    echo "MINISIGN_PUBLIC_KEY is required to verify updater artifacts" >&2
+    exit 1
+  fi
+  if ! command -v minisign >/dev/null 2>&1; then
+    echo "minisign is required to verify updater artifacts" >&2
+    exit 1
+  fi
+
+  decoded_signature="$(mktemp)"
+  if ! openssl base64 -d -A -in "$signature_file" -out "$decoded_signature" 2>/dev/null; then
+    rm -f "$decoded_signature"
+    echo "Updater signature is not valid base64: $signature_file" >&2
+    exit 1
+  fi
+
+  if ! minisign -Vm "$archive_file" -x "$decoded_signature" -P "$MINISIGN_PUBLIC_KEY" >/dev/null; then
+    rm -f "$decoded_signature"
+    echo "Updater signature verification failed: $archive_file" >&2
+    exit 1
+  fi
+  rm -f "$decoded_signature"
+}
+
+MACOS_ARM_FILE="HackerAI-aarch64.app.tar.gz"
+MACOS_X64_FILE="HackerAI-x86_64.app.tar.gz"
+LINUX_X64_FILE="HackerAI_${VERSION}_amd64.AppImage.tar.gz"
+LINUX_ARM_FILE="HackerAI_${VERSION}_aarch64.AppImage.tar.gz"
+WINDOWS_FILE="HackerAI_${VERSION}_x64-setup.nsis.zip"
+
+verify_signature "$RELEASE_DIR/$MACOS_ARM_FILE" "$RELEASE_DIR/${MACOS_ARM_FILE}.sig"
+verify_signature "$RELEASE_DIR/$MACOS_X64_FILE" "$RELEASE_DIR/${MACOS_X64_FILE}.sig"
+verify_signature "$RELEASE_DIR/$LINUX_X64_FILE" "$RELEASE_DIR/${LINUX_X64_FILE}.sig"
+verify_signature "$RELEASE_DIR/$LINUX_ARM_FILE" "$RELEASE_DIR/${LINUX_ARM_FILE}.sig"
+verify_signature "$RELEASE_DIR/$WINDOWS_FILE" "$RELEASE_DIR/${WINDOWS_FILE}.sig"
+
+MACOS_ARM_SIG="$(read_signature "$RELEASE_DIR/${MACOS_ARM_FILE}.sig")"
+MACOS_X64_SIG="$(read_signature "$RELEASE_DIR/${MACOS_X64_FILE}.sig")"
+LINUX_X64_SIG="$(read_signature "$RELEASE_DIR/${LINUX_X64_FILE}.sig")"
+LINUX_ARM_SIG="$(read_signature "$RELEASE_DIR/${LINUX_ARM_FILE}.sig")"
+WINDOWS_SIG="$(read_signature "$RELEASE_DIR/${WINDOWS_FILE}.sig")"
+PUBLISH_DATE="${PUBLISH_DATE:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"
+RELEASE_URL="https://github.com/${GH_REPO}/releases/download/${TAG_NAME}"
+
+jq -n \
+  --arg version "$VERSION" \
+  --arg pub_date "$PUBLISH_DATE" \
+  --arg macos_arm_url "$RELEASE_URL/$MACOS_ARM_FILE" \
+  --arg macos_arm_sig "$MACOS_ARM_SIG" \
+  --arg macos_x64_url "$RELEASE_URL/$MACOS_X64_FILE" \
+  --arg macos_x64_sig "$MACOS_X64_SIG" \
+  --arg linux_x64_url "$RELEASE_URL/$LINUX_X64_FILE" \
+  --arg linux_x64_sig "$LINUX_X64_SIG" \
+  --arg linux_arm_url "$RELEASE_URL/$LINUX_ARM_FILE" \
+  --arg linux_arm_sig "$LINUX_ARM_SIG" \
+  --arg windows_url "$RELEASE_URL/$WINDOWS_FILE" \
+  --arg windows_sig "$WINDOWS_SIG" \
+  '{
+    version: $version,
+    notes: "See release notes on GitHub",
+    pub_date: $pub_date,
+    platforms: {
+      "darwin-aarch64": {url: $macos_arm_url, signature: $macos_arm_sig},
+      "darwin-x86_64": {url: $macos_x64_url, signature: $macos_x64_sig},
+      "linux-x86_64": {url: $linux_x64_url, signature: $linux_x64_sig},
+      "linux-aarch64": {url: $linux_arm_url, signature: $linux_arm_sig},
+      "windows-x86_64": {url: $windows_url, signature: $windows_sig}
+    }
+  }' > "$RELEASE_DIR/latest.json"
+
+echo "Prepared desktop release $TAG_NAME from verified $VERSION artifacts:"
+find "$RELEASE_DIR" -maxdepth 1 -type f -print | sort

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "packages/desktop/**"
       - ".github/workflows/desktop-build.yml"
+      - ".github/scripts/prepare-desktop-release.sh"
     tags:
       - "desktop-v*"
   workflow_dispatch:
@@ -33,18 +34,41 @@ jobs:
       - name: Determine version
         id: version
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/desktop-v* ]]; then
+          set -euo pipefail
+
+          if [[ "$GITHUB_REF" == refs/tags/desktop-v* ]]; then
             # Triggered by tag push
             TAG_NAME="${GITHUB_REF_NAME}"
             VERSION="${TAG_NAME#desktop-v}"
+            if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+              echo "Invalid desktop release tag: $TAG_NAME" >&2
+              exit 1
+            fi
             echo "Using existing tag: $TAG_NAME"
             echo "version=$VERSION" >> $GITHUB_OUTPUT
             echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
             echo "should_release=true" >> $GITHUB_OUTPUT
           else
-            # Main and manual runs build without publishing a release.
-            echo "version=dev" >> $GITHUB_OUTPUT
-            echo "tag_name=" >> $GITHUB_OUTPUT
+            # Main and manual runs build the next patch as a promotable release
+            # candidate. The separate promotion workflow can publish these
+            # exact signed artifacts later without rebuilding them.
+            LATEST_TAG="$(git tag --list 'desktop-v*' --sort=-version:refname | sed -n '1p')"
+            if [[ -z "$LATEST_TAG" ]]; then
+              VERSION="0.0.1"
+            elif [[ "$LATEST_TAG" =~ ^desktop-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+              MAJOR="${BASH_REMATCH[1]}"
+              MINOR="${BASH_REMATCH[2]}"
+              PATCH="${BASH_REMATCH[3]}"
+              VERSION="${MAJOR}.${MINOR}.$((10#$PATCH + 1))"
+            else
+              echo "Latest desktop tag is not a stable semver tag: $LATEST_TAG" >&2
+              exit 1
+            fi
+
+            TAG_NAME="desktop-v$VERSION"
+            echo "Building promotable candidate: $TAG_NAME"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
             echo "should_release=false" >> $GITHUB_OUTPUT
           fi
 
@@ -182,7 +206,6 @@ jobs:
         working-directory: packages/desktop
 
       - name: Update version
-        if: needs.prepare.outputs.version != 'dev'
         shell: bash
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
@@ -318,7 +341,6 @@ jobs:
   build-macos-universal:
     needs: [prepare, build]
     runs-on: macos-latest
-    if: needs.prepare.outputs.should_release == 'true'
     permissions:
       contents: read
 
@@ -504,6 +526,7 @@ jobs:
           name: desktop-macOS-universal
           path: HackerAI-universal.dmg
           if-no-files-found: error
+          retention-days: 7
 
   create-release:
     needs: [prepare, build, build-macos-universal]

--- a/.github/workflows/desktop-promote.yml
+++ b/.github/workflows/desktop-promote.yml
@@ -1,0 +1,178 @@
+name: Promote Desktop Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: Successful main Build Desktop App run ID to promote
+        required: true
+        type: string
+
+concurrency:
+  group: desktop-release
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+      - name: Checkout release tooling
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Validate source run
+        id: source
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "Source run ID must be numeric: $SOURCE_RUN_ID" >&2
+            exit 1
+          fi
+
+          RUN_JSON="$(gh api "repos/${GH_REPO}/actions/runs/${SOURCE_RUN_ID}")"
+          STATUS="$(jq -r '.status' <<< "$RUN_JSON")"
+          CONCLUSION="$(jq -r '.conclusion' <<< "$RUN_JSON")"
+          EVENT="$(jq -r '.event' <<< "$RUN_JSON")"
+          HEAD_BRANCH="$(jq -r '.head_branch' <<< "$RUN_JSON")"
+          HEAD_SHA="$(jq -r '.head_sha' <<< "$RUN_JSON")"
+          WORKFLOW_PATH="$(jq -r '.path' <<< "$RUN_JSON")"
+
+          if [[ "$STATUS" != "completed" || "$CONCLUSION" != "success" ]]; then
+            echo "Source run must be completed successfully; got $STATUS/$CONCLUSION" >&2
+            exit 1
+          fi
+          if [[ "$WORKFLOW_PATH" != ".github/workflows/desktop-build.yml" ]]; then
+            echo "Source run used unexpected workflow: $WORKFLOW_PATH" >&2
+            exit 1
+          fi
+          if [[ "$HEAD_BRANCH" != "main" ]]; then
+            echo "Only main builds can be promoted; got $HEAD_BRANCH" >&2
+            exit 1
+          fi
+          if [[ "$EVENT" != "push" && "$EVENT" != "workflow_dispatch" ]]; then
+            echo "Unexpected source event: $EVENT" >&2
+            exit 1
+          fi
+
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "Validated source run $SOURCE_RUN_ID at $HEAD_SHA"
+
+      - name: Download immutable build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+          path: artifacts
+
+      - name: Determine embedded version
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          mapfile -d '' INSTALLERS < <(
+            find artifacts/desktop-Windows-x64 -type f \
+              -name 'HackerAI_*_x64-setup.exe' -print0
+          )
+          if [[ "${#INSTALLERS[@]}" -ne 1 ]]; then
+            echo "Expected exactly one Windows installer, found ${#INSTALLERS[@]}" >&2
+            exit 1
+          fi
+
+          INSTALLER_NAME="$(basename "${INSTALLERS[0]}")"
+          if [[ ! "$INSTALLER_NAME" =~ ^HackerAI_((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))_x64-setup\.exe$ ]]; then
+            echo "Installer is not release-versioned: $INSTALLER_NAME" >&2
+            exit 1
+          fi
+
+          VERSION="${BASH_REMATCH[1]}"
+          TAG_NAME="desktop-v$VERSION"
+          LATEST_TAG="$(gh api "repos/${GH_REPO}/releases/latest" --jq '.tag_name')"
+          if [[ ! "$LATEST_TAG" =~ ^desktop-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "Latest release is not a stable desktop release: $LATEST_TAG" >&2
+            exit 1
+          fi
+          EXPECTED_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((10#${BASH_REMATCH[3]} + 1))"
+
+          if [[ "$VERSION" != "$EXPECTED_VERSION" ]]; then
+            echo "Artifact version $VERSION does not match next release $EXPECTED_VERSION" >&2
+            exit 1
+          fi
+          if gh api "repos/${GH_REPO}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag already exists: $TAG_NAME" >&2
+            exit 1
+          fi
+          if gh release view "$TAG_NAME" --repo "$GH_REPO" >/dev/null 2>&1; then
+            echo "Release already exists: $TAG_NAME" >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "Promoting embedded version $VERSION as $TAG_NAME"
+
+      - name: Install updater signature verifier
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes minisign
+
+      - name: Prepare verified release assets
+        env:
+          GH_REPO: ${{ github.repository }}
+          VERSION: ${{ steps.release.outputs.version }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+        run: |
+          UPDATER_PUBLIC_KEY="$(
+            jq -r '.plugins.updater.pubkey' \
+              packages/desktop/src-tauri/tauri.conf.json | \
+              base64 --decode | sed -n '2p'
+          )"
+          if [[ -z "$UPDATER_PUBLIC_KEY" ]]; then
+            echo "Desktop updater public key is missing" >&2
+            exit 1
+          fi
+
+          MINISIGN_PUBLIC_KEY="$UPDATER_PUBLIC_KEY" \
+            bash .github/scripts/prepare-desktop-release.sh \
+            artifacts release-files "$VERSION" "$TAG_NAME" "$GH_REPO"
+
+      - name: Create draft release without rebuilding
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          TARGET_SHA: ${{ steps.source.outputs.head_sha }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+
+          # A tag created with GITHUB_TOKEN does not trigger the tag-build
+          # workflow, so these already-verified artifacts are not rebuilt.
+          gh release create "$TAG_NAME" \
+            --repo "$GH_REPO" \
+            --target "$TARGET_SHA" \
+            --title "HackerAI Desktop $TAG_NAME" \
+            --draft \
+            --generate-notes \
+            release-files/*
+
+          {
+            echo "## Desktop release promoted"
+            echo
+            echo "- Source run: $SOURCE_RUN_ID"
+            echo "- Commit: $TARGET_SHA"
+            echo "- Draft release: $TAG_NAME"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -117,17 +117,29 @@ GitHub Actions workflow (`.github/workflows/desktop-build.yml`) builds for:
 | Windows  | `x86_64-pc-windows-msvc`   | `.msi`, `.exe`      |
 | Linux    | `x86_64-unknown-linux-gnu` | `.AppImage`, `.deb` |
 
-### Triggering builds
+### Building and releasing
 
-**Via tag:**
+Desktop-related merges to `main` build a release candidate using the next
+desktop patch version. After the `Build Desktop App` run succeeds (including
+approval of the `trusted-signing` Windows job), promote those exact artifacts:
+
+1. Copy the numeric run ID from the successful build URL.
+2. Go to Actions → **Promote Desktop Build** → **Run workflow**.
+3. Enter the source run ID and start the workflow within the seven-day artifact
+   retention window.
+4. Review the generated draft release and publish it.
+
+Promotion verifies the source run, embedded version, required platform assets,
+and updater signatures. It creates the release tag with `GITHUB_TOKEN`, so the
+tag does not trigger another set of platform builds.
+
+Pushing a `desktop-v*` tag remains a fallback when no valid candidate artifacts
+are available, but it performs a fresh release build:
 
 ```bash
-git tag desktop-v0.1.0
+git tag desktop-v0.1.0 <commit>
 git push origin desktop-v0.1.0
 ```
-
-**Via workflow dispatch:**
-Go to Actions → "Build Desktop App" → Run workflow
 
 ## Code Signing
 

--- a/scripts/__tests__/prepare-desktop-release.test.js
+++ b/scripts/__tests__/prepare-desktop-release.test.js
@@ -1,0 +1,247 @@
+const {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} = require("node:fs");
+const { createHash } = require("node:crypto");
+const { tmpdir } = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const scriptPath = path.resolve(".github/scripts/prepare-desktop-release.sh");
+
+function writeArtifact(root, artifact, filename, contents = filename) {
+  const directory = path.join(root, artifact, "bundle");
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(path.join(directory, filename), contents);
+}
+
+function signatureFor(contents) {
+  const digest = createHash("sha256").update(contents).digest("hex");
+  return Buffer.from(`sha256:${digest}\n`).toString("base64");
+}
+
+function createArtifacts(root, version) {
+  writeArtifact(root, "desktop-macOS-arm64", `HackerAI_${version}_aarch64.dmg`);
+  writeArtifact(
+    root,
+    "desktop-macOS-arm64",
+    "HackerAI.app.tar.gz",
+    "mac-arm-updater",
+  );
+  writeArtifact(
+    root,
+    "desktop-macOS-arm64",
+    "HackerAI.app.tar.gz.sig",
+    signatureFor("mac-arm-updater"),
+  );
+  writeArtifact(root, "desktop-macOS-x64", `HackerAI_${version}_x64.dmg`);
+  writeArtifact(
+    root,
+    "desktop-macOS-x64",
+    "HackerAI.app.tar.gz",
+    "mac-x64-updater",
+  );
+  writeArtifact(
+    root,
+    "desktop-macOS-x64",
+    "HackerAI.app.tar.gz.sig",
+    signatureFor("mac-x64-updater"),
+  );
+  writeArtifact(root, "desktop-macOS-universal", "HackerAI-universal.dmg");
+
+  for (const filename of [
+    `HackerAI_${version}_amd64.AppImage`,
+    `HackerAI_${version}_amd64.AppImage.tar.gz`,
+    `HackerAI_${version}_amd64.deb`,
+  ]) {
+    writeArtifact(root, "desktop-Linux-x64", filename);
+  }
+  const linuxX64Updater = `HackerAI_${version}_amd64.AppImage.tar.gz`;
+  writeArtifact(
+    root,
+    "desktop-Linux-x64",
+    `${linuxX64Updater}.sig`,
+    signatureFor(linuxX64Updater),
+  );
+
+  for (const filename of [
+    `HackerAI_${version}_aarch64.AppImage`,
+    `HackerAI_${version}_aarch64.AppImage.tar.gz`,
+    `HackerAI_${version}_arm64.deb`,
+  ]) {
+    writeArtifact(root, "desktop-Linux-arm64", filename);
+  }
+  const linuxArmUpdater = `HackerAI_${version}_aarch64.AppImage.tar.gz`;
+  writeArtifact(
+    root,
+    "desktop-Linux-arm64",
+    `${linuxArmUpdater}.sig`,
+    signatureFor(linuxArmUpdater),
+  );
+
+  for (const filename of [
+    `HackerAI_${version}_x64-setup.exe`,
+    `HackerAI_${version}_x64-setup.nsis.zip`,
+  ]) {
+    writeArtifact(root, "desktop-Windows-x64", filename);
+  }
+  const windowsUpdater = `HackerAI_${version}_x64-setup.nsis.zip`;
+  writeArtifact(
+    root,
+    "desktop-Windows-x64",
+    `${windowsUpdater}.sig`,
+    signatureFor(windowsUpdater),
+  );
+}
+
+function runPreparation({
+  artifactVersion = "0.0.57",
+  mutateArtifacts,
+  version = "0.0.57",
+} = {}) {
+  const workspace = mkdtempSync(path.join(tmpdir(), "desktop-release-"));
+  const artifacts = path.join(workspace, "artifacts");
+  const release = path.join(workspace, "release");
+  const binDirectory = path.join(workspace, "bin");
+  createArtifacts(artifacts, artifactVersion);
+  mutateArtifacts?.(artifacts);
+
+  mkdirSync(binDirectory);
+  writeFileSync(
+    path.join(binDirectory, "minisign"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -Vm) archive="$2"; shift 2 ;;
+    -x) signature="$2"; shift 2 ;;
+    -P) public_key="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[[ "$public_key" == "test-public-key" ]]
+expected="$(sed -n 's/^sha256://p' "$signature")"
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$archive" | awk '{print $1}')"
+else
+  actual="$(shasum -a 256 "$archive" | awk '{print $1}')"
+fi
+[[ -n "$expected" && "$expected" == "$actual" ]]
+`,
+    { mode: 0o755 },
+  );
+
+  const result = spawnSync(
+    "bash",
+    [
+      scriptPath,
+      artifacts,
+      release,
+      version,
+      `desktop-v${version}`,
+      "hackerai-tech/hackerai",
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        MINISIGN_PUBLIC_KEY: "test-public-key",
+        PATH: `${binDirectory}${path.delimiter}${process.env.PATH ?? ""}`,
+        PUBLISH_DATE: "2026-07-17T00:00:00Z",
+      },
+    },
+  );
+
+  return { artifacts, release, result, workspace };
+}
+
+describe("prepare-desktop-release", () => {
+  test("prepares fixed aliases and architecture-specific updater entries", () => {
+    const fixture = runPreparation();
+
+    try {
+      expect(fixture.result.status).toBe(0);
+      expect(fixture.result.stderr).toBe("");
+      expect(
+        existsSync(path.join(fixture.release, "HackerAI-linux-x64.AppImage")),
+      ).toBe(true);
+      expect(
+        existsSync(path.join(fixture.release, "HackerAI-windows-x64.exe")),
+      ).toBe(true);
+
+      const latest = JSON.parse(
+        readFileSync(path.join(fixture.release, "latest.json"), "utf8"),
+      );
+      expect(latest.version).toBe("0.0.57");
+      expect(latest.pub_date).toBe("2026-07-17T00:00:00Z");
+      expect(latest.platforms["darwin-aarch64"]).toEqual({
+        url: "https://github.com/hackerai-tech/hackerai/releases/download/desktop-v0.0.57/HackerAI-aarch64.app.tar.gz",
+        signature: signatureFor("mac-arm-updater"),
+      });
+      expect(latest.platforms["darwin-x86_64"]).toEqual({
+        url: "https://github.com/hackerai-tech/hackerai/releases/download/desktop-v0.0.57/HackerAI-x86_64.app.tar.gz",
+        signature: signatureFor("mac-x64-updater"),
+      });
+      expect(latest.platforms["windows-x86_64"].signature).toBe(
+        signatureFor("HackerAI_0.0.57_x64-setup.nsis.zip"),
+      );
+    } finally {
+      rmSync(fixture.workspace, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects artifacts whose embedded filename version does not match", () => {
+    const fixture = runPreparation({ artifactVersion: "0.0.0" });
+
+    try {
+      expect(fixture.result.status).toBe(1);
+      expect(fixture.result.stderr).toContain(
+        "Expected exactly one HackerAI_0.0.57_aarch64.dmg",
+      );
+    } finally {
+      rmSync(fixture.workspace, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects an updater archive that does not match its signature", () => {
+    const fixture = runPreparation({
+      mutateArtifacts(artifacts) {
+        writeArtifact(
+          artifacts,
+          "desktop-macOS-arm64",
+          "HackerAI.app.tar.gz",
+          "tampered-updater",
+        );
+      },
+    });
+
+    try {
+      expect(fixture.result.status).toBe(1);
+      expect(fixture.result.stderr).toContain(
+        "Updater signature verification failed: ",
+      );
+    } finally {
+      rmSync(fixture.workspace, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects versions with leading-zero components", () => {
+    const fixture = runPreparation({
+      artifactVersion: "01.0.57",
+      version: "01.0.57",
+    });
+
+    try {
+      expect(fixture.result.status).toBe(1);
+      expect(fixture.result.stderr).toContain(
+        "Invalid desktop version: 01.0.57",
+      );
+    } finally {
+      rmSync(fixture.workspace, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- build `main` desktop artifacts with the next patch version instead of `0.0.0`
- include the universal macOS artifact in candidate builds
- add a manual promotion workflow that validates a successful `main` run, infers the embedded version, downloads the immutable artifacts, and creates a draft release without rerunning platform builds
- keep both architecture-specific macOS updater archives and cryptographically verify every updater archive before release creation
- document the new release flow and cover artifact, version, signature, and tamper validation with regression tests

## Why

The existing workflow builds `main` artifacts as version `0.0.0`, then requires all five platform jobs to run again after a release tag is pushed. Those already-signed development artifacts cannot be safely relabeled. Building release candidates with the intended next version lets a successful run be promoted directly within its artifact-retention window.

The promotion job creates its tag with `GITHUB_TOKEN`; GitHub suppresses the resulting push-triggered workflow, preventing a duplicate `Build Desktop App` run.

## Validation

- `corepack pnpm test` (266 suites, 2702 tests)
- `corepack pnpm typecheck`
- `corepack pnpm jest scripts/__tests__/prepare-desktop-release.test.js --runInBand`
- `corepack pnpm exec eslint scripts/__tests__/prepare-desktop-release.test.js`
- `corepack pnpm exec prettier --check .github/workflows/desktop-build.yml .github/workflows/desktop-promote.yml .github/scripts/prepare-desktop-release.sh packages/desktop/README.md scripts/__tests__/prepare-desktop-release.test.js`
- `bash -n .github/scripts/prepare-desktop-release.sh`
- `actionlint v1.7.12 .github/workflows/desktop-build.yml .github/workflows/desktop-promote.yml`
- `minisign 0.12 -Vm HackerAI-x86_64.app.tar.gz ...` against the published desktop-v0.0.56 updater artifact and configured public key

## Manual verification

1. Merge the PR and let the resulting `Build Desktop App` run complete, including approval of the `trusted-signing` Windows job.
2. Open **Actions → Promote Desktop Build**, enter that successful run ID, and run the workflow within seven days.
3. Confirm it creates the next `desktop-v*` tag and a draft release without starting another `Build Desktop App` run.
4. Verify the draft has all fixed-name installers, both macOS updater architectures, all five `latest.json` platforms, and valid signatures before publishing it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual workflow to promote successful desktop builds into draft releases without rebuilding.
  * Desktop release preparation now verifies expected artifacts and updater signatures, and generates `latest.json` with platform URLs and signatures.
  * Improved version/tag handling to produce promotable release candidates.

* **Documentation**
  * Updated desktop CI/CD documentation for the new candidate + promote flow, including verification details and fallback tagging behavior.

* **Tests**
  * Expanded test coverage for successful preparation plus additional failure cases (invalid versions and updater signature verification errors).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->