### PR TITLE
Fix checkout started event idempotency

### DIFF
--- a/__mocks__/uuid.ts
+++ b/__mocks__/uuid.ts
@@ -5,8 +5,42 @@ export const v4 = () => {
   return `test-uuid-${counter}`;
 };
 
+function stableHex(value: string): string {
+  let hash = 2166136261;
+  let result = "";
+  for (let chunk = 0; chunk < 4; chunk += 1) {
+    for (let index = 0; index < value.length; index += 1) {
+      hash ^= value.charCodeAt(index) + chunk;
+      hash = Math.imul(hash, 16777619);
+    }
+    result += (hash >>> 0).toString(16).padStart(8, "0");
+  }
+  return result;
+}
+
+export const v5 = Object.assign(
+  (value: string, namespace: string) => {
+    const hex = stableHex(`${namespace}:${value}`);
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-5${hex.slice(
+      13,
+      16,
+    )}-8${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
+  },
+  {
+    DNS: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+    URL: "6ba7b811-9dad-11d1-80b4-00c04fd430c8",
+  },
+);
+
+export const validate = (value: string) =>
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+
 const mockUuid = {
   v4,
+  v5,
+  validate,
 };
 
 export default mockUuid;

--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -313,9 +313,11 @@ describe("POST /api/subscribe", () => {
       expect(mockPostHogEvent).toHaveBeenCalledWith(
         "checkout_started",
         expect.objectContaining({
+          eventUuid: expect.stringMatching(/^[0-9a-f-]{36}$/i),
           checkout_attempt_id: "ca_retry_123",
           stripe_checkout_session_id: "cs_open",
           stripe_checkout_session_reused: true,
+          $insert_id: "checkout_started:ca_retry_123",
         }),
       );
     } finally {
@@ -742,11 +744,13 @@ describe("POST /api/subscribe", () => {
     expect(mockPostHogEvent).toHaveBeenCalledWith(
       "checkout_started",
       expect.objectContaining({
+        eventUuid: expect.stringMatching(/^[0-9a-f-]{36}$/i),
         checkout_attempt_id: "ca_limit_pressure_123",
         source: "limit_pressure",
         surface: "rate_limit_warning",
         reason: "monthly_exhausted",
         limit_type: "monthly",
+        $insert_id: "checkout_started:ca_limit_pressure_123",
       }),
     );
   });

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/referrals/config";
 import {
   PAID_FUNNEL_EVENTS,
+  checkoutStartedInsertId,
   createCheckoutAttemptId,
   normalizePaidFunnelLabel,
   normalizeCheckoutAttemptId,
@@ -25,6 +26,7 @@ import {
   paidFunnelProperties,
   planLookupKeyToTier,
 } from "@/lib/analytics/paid-funnel";
+import { checkoutStartedEventUuid } from "@/lib/analytics/paid-funnel-server";
 
 function canManageOrganizationBilling(
   membership: Awaited<
@@ -637,6 +639,7 @@ export const POST = async (req: NextRequest) => {
       PAID_FUNNEL_EVENTS.checkoutStarted,
       paidFunnelProperties({
         userId,
+        eventUuid: checkoutStartedEventUuid(checkoutAttemptId),
         org_id: organization.id,
         checkout_attempt_id: checkoutAttemptId,
         checkout_type: "new_subscription",
@@ -660,7 +663,7 @@ export const POST = async (req: NextRequest) => {
         stripe_checkout_session_reused: reusedCheckoutSession,
         stripe_price_id: selectedPrice.id,
         $session_id: posthogSessionId ?? undefined,
-        $insert_id: `${PAID_FUNNEL_EVENTS.checkoutStarted}:${checkoutAttemptId}`,
+        $insert_id: checkoutStartedInsertId(checkoutAttemptId),
         $set: {
           last_checkout_started_at: new Date().toISOString(),
         },

--- a/app/api/subscription-details/__tests__/route.test.ts
+++ b/app/api/subscription-details/__tests__/route.test.ts
@@ -287,12 +287,14 @@ describe("POST /api/subscription-details", () => {
     expect(mockPostHogEvent).toHaveBeenCalledWith(
       "checkout_started",
       expect.objectContaining({
+        eventUuid: expect.stringMatching(/^[0-9a-f-]{36}$/i),
         checkout_attempt_id: "ca_paid_limit_123",
         checkout_type: "subscription_change",
         source: "limit_pressure",
         surface: "pricing_dialog",
         reason: "monthly_exhausted",
         limit_type: "monthly",
+        $insert_id: "checkout_started:ca_paid_limit_123",
       }),
     );
     expect(mockPostHogEvent).toHaveBeenCalledWith(

--- a/app/api/subscription-details/route.ts
+++ b/app/api/subscription-details/route.ts
@@ -7,12 +7,14 @@ import { getSuspensionMessage } from "@/lib/suspensionMessage";
 import { phLogger } from "@/lib/posthog/server";
 import {
   PAID_FUNNEL_EVENTS,
+  checkoutStartedInsertId,
   createCheckoutAttemptId,
   normalizeCheckoutAttemptId,
   normalizePaidFunnelLabel,
   paidFunnelProperties,
   planLookupKeyToTier,
 } from "@/lib/analytics/paid-funnel";
+import { checkoutStartedEventUuid } from "@/lib/analytics/paid-funnel-server";
 
 const MAX_TEAM_SEATS = 999;
 
@@ -325,6 +327,7 @@ export const POST = async (req: NextRequest) => {
             PAID_FUNNEL_EVENTS.checkoutStarted,
             paidFunnelProperties({
               userId,
+              eventUuid: checkoutStartedEventUuid(checkoutAttemptId),
               org_id: organization.id,
               checkout_attempt_id: checkoutAttemptId,
               checkout_type: "subscription_change",
@@ -344,7 +347,7 @@ export const POST = async (req: NextRequest) => {
               stripe_subscription_id: subscription.id,
               stripe_price_id: targetPrice.id,
               $session_id: posthogSessionId ?? undefined,
-              $insert_id: `${PAID_FUNNEL_EVENTS.checkoutStarted}:${checkoutAttemptId}`,
+              $insert_id: checkoutStartedInsertId(checkoutAttemptId),
               $set: {
                 last_checkout_started_at: new Date().toISOString(),
               },

--- a/app/hooks/__tests__/useUpgrade.test.ts
+++ b/app/hooks/__tests__/useUpgrade.test.ts
@@ -1,0 +1,170 @@
+import { act, renderHook } from "@testing-library/react";
+import { useAuth } from "@workos-inc/authkit-nextjs/components";
+import { toast } from "sonner";
+import { useUpgrade } from "../useUpgrade";
+import {
+  captureAuthenticatedEvent,
+  getPostHogRequestHeaders,
+  newCheckoutAttemptId,
+} from "@/lib/analytics/client";
+
+jest.mock("@workos-inc/authkit-nextjs/components", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/analytics/client", () => ({
+  captureAuthenticatedEvent: jest.fn(),
+  getPostHogRequestHeaders: jest.fn(() => ({})),
+  newCheckoutAttemptId: jest.fn(),
+}));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockNewCheckoutAttemptId = newCheckoutAttemptId as jest.MockedFunction<
+  typeof newCheckoutAttemptId
+>;
+const mockCaptureAuthenticatedEvent =
+  captureAuthenticatedEvent as jest.MockedFunction<
+    typeof captureAuthenticatedEvent
+  >;
+const mockGetPostHogRequestHeaders =
+  getPostHogRequestHeaders as jest.MockedFunction<
+    typeof getPostHogRequestHeaders
+  >;
+const mockToastError = toast.error as jest.MockedFunction<typeof toast.error>;
+
+function response({
+  ok,
+  status,
+  body,
+}: {
+  ok: boolean;
+  status: number;
+  body: Record<string, unknown>;
+}) {
+  return {
+    ok,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe("useUpgrade checkout attempts", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      user: { id: "user_123" },
+    } as ReturnType<typeof useAuth>);
+    mockGetPostHogRequestHeaders.mockReturnValue({});
+    mockCaptureAuthenticatedEvent.mockReturnValue(true);
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("coalesces duplicate clicks before React commits the loading state", async () => {
+    let resolveFetch: ((value: Response) => void) | undefined;
+    global.fetch = jest.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    mockNewCheckoutAttemptId.mockReturnValue("ca_click_123");
+    const { result } = renderHook(() => useUpgrade());
+
+    let firstRequest!: Promise<void>;
+    let duplicateRequest!: Promise<void>;
+    act(() => {
+      firstRequest = result.current.handleUpgrade("pro-monthly-plan");
+      duplicateRequest = result.current.handleUpgrade("pro-monthly-plan");
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockNewCheckoutAttemptId).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFetch?.(
+        response({ ok: true, status: 200, body: { error: "cancelled" } }),
+      );
+      await Promise.all([firstRequest, duplicateRequest]);
+    });
+  });
+
+  it("keeps the synchronous submit lock across re-renders", async () => {
+    let resolveFetch: ((value: Response) => void) | undefined;
+    global.fetch = jest.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    mockNewCheckoutAttemptId.mockReturnValue("ca_render_123");
+    const { result, rerender } = renderHook(() => useUpgrade());
+
+    let firstRequest!: Promise<void>;
+    act(() => {
+      firstRequest = result.current.handleUpgrade("pro-monthly-plan");
+    });
+    rerender();
+
+    await act(async () => {
+      await result.current.handleUpgrade("pro-monthly-plan");
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockNewCheckoutAttemptId).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFetch?.(
+        response({ ok: true, status: 200, body: { error: "cancelled" } }),
+      );
+      await firstRequest;
+    });
+  });
+
+  it("creates a distinct attempt ID for a valid retry after failure", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          ok: false,
+          status: 503,
+          body: { error: "Checkout temporarily unavailable" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        response({ ok: true, status: 200, body: { error: "cancelled" } }),
+      );
+    mockNewCheckoutAttemptId
+      .mockReturnValueOnce("ca_first_123")
+      .mockReturnValueOnce("ca_retry_456");
+    const { result } = renderHook(() => useUpgrade());
+
+    await act(async () => {
+      await result.current.handleUpgrade("pro-monthly-plan");
+    });
+    await act(async () => {
+      await result.current.handleUpgrade("pro-monthly-plan");
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    const requestBodies = (global.fetch as jest.Mock).mock.calls.map(
+      ([, init]) => JSON.parse(String(init?.body)),
+    );
+    expect(requestBodies.map((body) => body.checkoutAttemptId)).toEqual([
+      "ca_first_123",
+      "ca_retry_456",
+    ]);
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Checkout temporarily unavailable",
+    );
+  });
+});

--- a/app/hooks/__tests__/useUpgrade.test.ts
+++ b/app/hooks/__tests__/useUpgrade.test.ts
@@ -70,6 +70,10 @@ describe("useUpgrade checkout attempts", () => {
     global.fetch = originalFetch;
   });
 
+  afterEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
   it("coalesces duplicate clicks before React commits the loading state", async () => {
     let resolveFetch: ((value: Response) => void) | undefined;
     global.fetch = jest.fn(
@@ -166,5 +170,29 @@ describe("useUpgrade checkout attempts", () => {
     expect(mockToastError).toHaveBeenCalledWith(
       "Checkout temporarily unavailable",
     );
+  });
+
+  it("keeps the submit lock held once checkout navigation starts", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      response({
+        ok: true,
+        status: 200,
+        body: { url: `${window.location.origin}/#checkout` },
+      }),
+    );
+    mockNewCheckoutAttemptId.mockReturnValue("ca_redirect_123");
+    const { result } = renderHook(() => useUpgrade());
+
+    await act(async () => {
+      await result.current.handleUpgrade("pro-monthly-plan");
+    });
+    await act(async () => {
+      await result.current.handleUpgrade("pro-monthly-plan");
+    });
+
+    expect(window.location.hash).toBe("#checkout");
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockNewCheckoutAttemptId).toHaveBeenCalledTimes(1);
+    expect(result.current.upgradeLoading).toBe(true);
   });
 });

--- a/app/hooks/useUpgrade.ts
+++ b/app/hooks/useUpgrade.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { toast } from "sonner";
 import {
@@ -15,6 +15,7 @@ import {
 export const useUpgrade = () => {
   const { user } = useAuth();
   const [upgradeLoading, setUpgradeLoading] = useState(false);
+  const upgradeInFlightRef = useRef(false);
 
   const handleUpgrade = async (
     planKey?: PaidFunnelPlan,
@@ -31,7 +32,7 @@ export const useUpgrade = () => {
     e?.preventDefault();
 
     // Prevent duplicate submits
-    if (upgradeLoading) {
+    if (upgradeInFlightRef.current) {
       return;
     }
 
@@ -40,6 +41,7 @@ export const useUpgrade = () => {
       return;
     }
 
+    upgradeInFlightRef.current = true;
     setUpgradeLoading(true);
 
     try {
@@ -198,6 +200,7 @@ export const useUpgrade = () => {
         toast.error("An unexpected error occurred");
       }
     } finally {
+      upgradeInFlightRef.current = false;
       setUpgradeLoading(false);
     }
   };

--- a/app/hooks/useUpgrade.ts
+++ b/app/hooks/useUpgrade.ts
@@ -44,6 +44,8 @@ export const useUpgrade = () => {
     upgradeInFlightRef.current = true;
     setUpgradeLoading(true);
 
+    let navigationStarted = false;
+
     try {
       const selectedPlan = planKey || "pro-monthly-plan";
       const checkoutAttemptId = newCheckoutAttemptId();
@@ -124,6 +126,7 @@ export const useUpgrade = () => {
             checkout_type: "new_subscription",
           });
           window.location.href = url;
+          navigationStarted = true;
           return;
         }
 
@@ -183,9 +186,11 @@ export const useUpgrade = () => {
           url.searchParams.set("refresh", "entitlements");
           url.hash = ""; // Remove #pricing hash if present
           window.location.href = url.toString();
+          navigationStarted = true;
         } else if (result.invoiceUrl) {
           // Payment failed, redirect to invoice payment page
           window.location.href = result.invoiceUrl;
+          navigationStarted = true;
         } else if (result.error) {
           toast.error(`Error: ${result.error}`);
         } else {
@@ -200,8 +205,10 @@ export const useUpgrade = () => {
         toast.error("An unexpected error occurred");
       }
     } finally {
-      upgradeInFlightRef.current = false;
-      setUpgradeLoading(false);
+      if (!navigationStarted) {
+        upgradeInFlightRef.current = false;
+        setUpgradeLoading(false);
+      }
     }
   };
 

--- a/lib/__tests__/paid-funnel-server.test.ts
+++ b/lib/__tests__/paid-funnel-server.test.ts
@@ -1,0 +1,12 @@
+import { validate as isUuid } from "uuid";
+import { checkoutStartedEventUuid } from "@/lib/analytics/paid-funnel-server";
+
+describe("paid funnel server analytics helpers", () => {
+  it("creates one stable PostHog UUID per checkout attempt", () => {
+    const first = checkoutStartedEventUuid("ca_attempt_123");
+
+    expect(isUuid(first)).toBe(true);
+    expect(checkoutStartedEventUuid("ca_attempt_123")).toBe(first);
+    expect(checkoutStartedEventUuid("ca_retry_456")).not.toBe(first);
+  });
+});

--- a/lib/__tests__/paid-funnel.test.ts
+++ b/lib/__tests__/paid-funnel.test.ts
@@ -1,5 +1,6 @@
 import {
   PAID_FUNNEL_EVENT_VERSION,
+  checkoutStartedInsertId,
   normalizePaidFunnelLabel,
   paidFunnelProperties,
 } from "@/lib/analytics/paid-funnel";
@@ -21,5 +22,11 @@ describe("paid funnel analytics helpers", () => {
     expect(normalizePaidFunnelLabel("pricing_dialog")).toBe("pricing_dialog");
     expect(normalizePaidFunnelLabel(" user@example.com ")).toBeUndefined();
     expect(normalizePaidFunnelLabel("free form label")).toBeUndefined();
+  });
+
+  it("keeps checkout insert IDs stable per logical attempt", () => {
+    expect(checkoutStartedInsertId("ca_attempt_123")).toBe(
+      "checkout_started:ca_attempt_123",
+    );
   });
 });

--- a/lib/analytics/paid-funnel-server.ts
+++ b/lib/analytics/paid-funnel-server.ts
@@ -1,0 +1,6 @@
+import { v5 as uuidv5 } from "uuid";
+import { checkoutStartedInsertId } from "./paid-funnel";
+
+export function checkoutStartedEventUuid(checkoutAttemptId: string): string {
+  return uuidv5(checkoutStartedInsertId(checkoutAttemptId), uuidv5.URL);
+}

--- a/lib/analytics/paid-funnel.ts
+++ b/lib/analytics/paid-funnel.ts
@@ -30,6 +30,10 @@ export function cancellationCompletionInsertId(
   return `${PAID_FUNNEL_EVENTS.cancellationCompleted}:${stripeSubscriptionId}`;
 }
 
+export function checkoutStartedInsertId(checkoutAttemptId: string): string {
+  return `${PAID_FUNNEL_EVENTS.checkoutStarted}:${checkoutAttemptId}`;
+}
+
 export type PaidFunnelPlan =
   | "pro-monthly-plan"
   | "pro-plus-monthly-plan"

--- a/lib/posthog/__tests__/server.test.ts
+++ b/lib/posthog/__tests__/server.test.ts
@@ -64,4 +64,21 @@ describe("phLogger", () => {
     expect(mockEmitPostHogLog).toHaveBeenCalledTimes(1);
     expect(mockCaptureException).toHaveBeenCalledTimes(1);
   });
+
+  it("passes stable event UUIDs to PostHog without leaking them into properties", () => {
+    phLogger.event("checkout_started", {
+      userId: "user_123",
+      eventUuid: "b01882bb-b996-52d2-aaca-b2f4edc0fa3d",
+      checkout_attempt_id: "ca_12345678",
+    });
+
+    expect(mockCapture).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      event: "checkout_started",
+      uuid: "b01882bb-b996-52d2-aaca-b2f4edc0fa3d",
+      properties: {
+        checkout_attempt_id: "ca_12345678",
+      },
+    });
+  });
 });

--- a/lib/posthog/server.ts
+++ b/lib/posthog/server.ts
@@ -18,6 +18,7 @@ type LogFields = Record<string, unknown> & {
 
 type EventFields = Record<string, unknown> & {
   userId?: string;
+  eventUuid?: string;
   $set?: Record<string, unknown>;
 };
 
@@ -175,10 +176,11 @@ export const phLogger = {
     const client = getClient();
     if (!client) return;
     try {
-      const { userId, $set, ...rest } = fields;
+      const { userId, eventUuid, $set, ...rest } = fields;
       client.capture({
         distinctId: distinctIdFor(userId),
         event: name,
+        ...(eventUuid && { uuid: eventUuid }),
         properties: { ...rest, ...($set && { $set }) },
       });
     } catch {


### PR DESCRIPTION
## Summary

- add a synchronous in-flight guard to the shared upgrade hook so duplicate clicks cannot race React state updates
- assign a deterministic PostHog message UUID to `checkout_started` from the existing `checkout_attempt_id`
- keep `checkout_attempt_id`, `$insert_id`, and Stripe checkout/subscription identifiers unchanged across both new-subscription and subscription-change routes
- cover duplicate clicks, re-renders, failed retries, server event UUID forwarding, and both checkout route contracts

## Evidence

During July 6-12, `checkout_started` recorded 6,337 rows but only 2,889 unique attempts. Duplication was concentrated in `sidebar` and `empty_chat_header`; a handful of attempt IDs produced hundreds or thousands of rows with the same Stripe session and `$insert_id`, but distinct PostHog event UUIDs.

The shared client hook only guarded with React state, leaving a same-tick duplicate-click race. On the server, `$insert_id` was sent as an ordinary event property; PostHog's ingestion idempotency uses the top-level event UUID. This change closes both demonstrated gaps while preserving valid retry semantics.

## Validation

- `pnpm typecheck`
- focused ESLint and Prettier checks for all changed files
- focused checkout and settlement suite: 8 suites, 94 tests
- commit hooks: full Jest suite, 268 suites / 2,708 tests
- Google Chrome on the isolated worktree: sidebar and empty-chat-header pricing contexts both opened the upgrade dialog with no console warnings/errors

## Manual verification

1. From a free account's empty-chat header, double-click **Upgrade plan**. Confirm only one checkout request and one logical `checkout_started` attempt are recorded.
2. Repeat from the sidebar account menu.
3. Force the first checkout request to fail, retry, and confirm the retry receives a new `checkout_attempt_id`.
4. Confirm each attempt retains its Stripe checkout session/subscription identifier and appears once after PostHog deduplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate checkout upgrade submissions during rapid clicks and rerenders.
  * Failed upgrade attempts now retry with a new checkout attempt identifier.
* **Analytics**
  * Improved `checkout_started` event deduplication using deterministic, stable event UUIDs and insert IDs.
  * Analytics tracking now forwards `eventUuid` consistently to PostHog.
* **Tests**
  * Expanded coverage for duplicate-submission prevention, retry behavior, deterministic identifiers, and updated analytics payload shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->