### PR TITLE
Deduplicate checkout start telemetry

### DIFF
--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -229,7 +229,7 @@ describe("POST /api/subscribe", () => {
     }
   });
 
-  it("reuses a matching legacy open Checkout Session", async () => {
+  it("creates a separate Checkout Session for a different attempt", async () => {
     mockListOrganizationMemberships.mockResolvedValue({
       data: [
         {
@@ -289,7 +289,7 @@ describe("POST /api/subscribe", () => {
 
       expect(response.status).toBe(200);
       expect(body).toEqual({
-        url: "https://stripe.example/existing-checkout",
+        url: "https://stripe.example/checkout",
         checkoutAttemptId: "ca_retry_123",
       });
       expect(mockListCheckoutSessions).toHaveBeenNthCalledWith(1, {
@@ -303,33 +303,31 @@ describe("POST /api/subscribe", () => {
         limit: 100,
         starting_after: "cs_other_plan",
       });
-      expect(mockUpdateCheckoutSession).toHaveBeenCalledWith("cs_open", {
-        metadata: {
-          workOSOrganizationId: "org_team",
-          requestedPlan: "pro-monthly-plan",
-          checkoutAttemptId: "ca_retry_123",
-          userId: "user_123",
-          checkoutQuantity: "1",
-          checkoutType: "new_subscription",
+      expect(mockUpdateCheckoutSession).not.toHaveBeenCalled();
+      expect(mockCreateCheckoutSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customer: "cus_existing_org",
+          metadata: expect.objectContaining({
+            checkoutAttemptId: "ca_retry_123",
+          }),
+          subscription_data: expect.objectContaining({
+            metadata: expect.objectContaining({
+              checkoutAttemptId: "ca_retry_123",
+            }),
+          }),
+        }),
+        {
+          idempotencyKey:
+            "checkout_session_create:cus_existing_org:ca_retry_123",
         },
-      });
-      expect(mockCreateCheckoutSession).not.toHaveBeenCalled();
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(JSON.parse(String(warnSpy.mock.calls[0]?.[0]))).toMatchObject({
-        event: "billing.checkout_session_reused",
-        service: "hackerai-web",
-        route: "/api/subscribe",
-        stripe_customer_id: "cus_existing_org",
-        stripe_checkout_session_id: "cs_open",
-        checkout_attempt_id: "ca_retry_123",
-        previous_checkout_attempt_id: "ca_original",
-      });
+      );
+      expect(warnSpy).not.toHaveBeenCalled();
       expect(mockPostHogEvent).toHaveBeenCalledWith(
         "checkout_started",
         expect.objectContaining({
           checkout_attempt_id: "ca_retry_123",
-          stripe_checkout_session_id: "cs_open",
-          stripe_checkout_session_reused: true,
+          stripe_checkout_session_id: "cs_123",
+          stripe_checkout_session_reused: false,
         }),
         expect.objectContaining({
           uuid: "event_uuid:ca_retry_123",

--- a/app/api/subscribe/__tests__/route.test.ts
+++ b/app/api/subscribe/__tests__/route.test.ts
@@ -21,6 +21,19 @@ const mockPostHogEvent = jest.fn();
 const mockPostHogWarn = jest.fn();
 const mockPostHogFlush = jest.fn();
 const mockResponseCookieDelete = jest.fn();
+const mockClaimCheckoutStarted = jest.fn(async () => true);
+
+jest.mock("@/lib/analytics/paid-funnel-server", () => ({
+  claimCheckoutStarted: mockClaimCheckoutStarted,
+  paidFunnelEventUuid: jest.fn(
+    ({ checkoutAttemptId }: { checkoutAttemptId: string }) =>
+      `event_uuid:${checkoutAttemptId}`,
+  ),
+  paidFunnelIdempotencyKey: jest.fn(
+    ({ operation, scopeId, checkoutAttemptId }) =>
+      `${operation}:${scopeId}:${checkoutAttemptId}`,
+  ),
+}));
 
 jest.mock("next/server", () => {
   return {
@@ -110,6 +123,7 @@ describe("POST /api/subscribe", () => {
     delete process.env.REFERRAL_PROGRAM_ENABLED;
 
     mockConvexMutation.mockResolvedValue(null);
+    mockClaimCheckoutStarted.mockResolvedValue(true);
 
     mockGetUserIDAndPro.mockResolvedValue({
       userId: "user_123",
@@ -317,6 +331,64 @@ describe("POST /api/subscribe", () => {
           stripe_checkout_session_id: "cs_open",
           stripe_checkout_session_reused: true,
         }),
+        expect.objectContaining({
+          uuid: "event_uuid:ca_retry_123",
+          timestamp: expect.any(Date),
+        }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("does not emit checkout_started again for a reused session with the same attempt", async () => {
+    mockListOrganizationMemberships.mockResolvedValue({
+      data: [
+        {
+          organizationId: "org_team",
+          role: { slug: "admin" },
+        },
+      ],
+    } as never);
+    mockGetOrganization.mockResolvedValue({
+      id: "org_team",
+      stripeCustomerId: "cus_existing_org",
+    } as never);
+    mockRetrieveCustomer.mockResolvedValue({
+      id: "cus_existing_org",
+      metadata: { workOSOrganizationId: "org_team" },
+    } as never);
+    mockListCheckoutSessions.mockResolvedValueOnce({
+      data: [
+        {
+          id: "cs_open",
+          url: "https://stripe.example/existing-checkout",
+          metadata: {
+            workOSOrganizationId: "org_team",
+            requestedPlan: "pro-monthly-plan",
+            checkoutAttemptId: "ca_same_attempt",
+          },
+        },
+      ],
+      has_more: false,
+    } as never);
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const { POST } = await import("../route");
+      const response = await POST(
+        makeRequest({
+          plan: "pro-monthly-plan",
+          checkoutAttemptId: "ca_same_attempt",
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockClaimCheckoutStarted).not.toHaveBeenCalled();
+      expect(mockPostHogEvent).not.toHaveBeenCalledWith(
+        "checkout_started",
+        expect.anything(),
+        expect.anything(),
       );
     } finally {
       warnSpy.mockRestore();
@@ -425,6 +497,7 @@ describe("POST /api/subscribe", () => {
           metadata: expect.objectContaining({ checkoutQuantity: "1" }),
         }),
       }),
+      expect.objectContaining({ idempotencyKey: expect.any(String) }),
     );
   });
 
@@ -473,6 +546,7 @@ describe("POST /api/subscribe", () => {
           checkoutAttemptId: body.checkoutAttemptId,
         }),
       }),
+      expect.objectContaining({ idempotencyKey: expect.any(String) }),
     );
   });
 
@@ -606,6 +680,7 @@ describe("POST /api/subscribe", () => {
           }),
         }),
       }),
+      expect.objectContaining({ idempotencyKey: expect.any(String) }),
     );
     const checkoutArgs = mockCreateCheckoutSession.mock.calls[0]?.[0] as any;
     expect(checkoutArgs.client_reference_id).toBeUndefined();
@@ -703,18 +778,16 @@ describe("POST /api/subscribe", () => {
     } as never);
 
     const { POST } = await import("../route");
-
-    const response = await POST(
-      makeRequest({
-        plan: "pro-plus-monthly-plan",
-        checkoutAttemptId: "ca_limit_pressure_123",
-        source: "limit_pressure",
-        surface: "rate_limit_warning",
-        reason: "monthly_exhausted",
-        limitType: "monthly",
-        fromTier: "free",
-      }),
-    );
+    const requestBody = {
+      plan: "pro-plus-monthly-plan",
+      checkoutAttemptId: "ca_limit_pressure_123",
+      source: "limit_pressure",
+      surface: "rate_limit_warning",
+      reason: "monthly_exhausted",
+      limitType: "monthly",
+      fromTier: "free",
+    };
+    const response = await POST(makeRequest(requestBody));
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -738,6 +811,9 @@ describe("POST /api/subscribe", () => {
           }),
         }),
       }),
+      expect.objectContaining({
+        idempotencyKey: "checkout_session_create:cus_new:ca_limit_pressure_123",
+      }),
     );
     expect(mockPostHogEvent).toHaveBeenCalledWith(
       "checkout_started",
@@ -748,6 +824,21 @@ describe("POST /api/subscribe", () => {
         reason: "monthly_exhausted",
         limit_type: "monthly",
       }),
+      expect.objectContaining({
+        uuid: "event_uuid:ca_limit_pressure_123",
+        timestamp: expect.any(Date),
+      }),
+    );
+
+    mockPostHogEvent.mockClear();
+    mockClaimCheckoutStarted.mockResolvedValueOnce(false);
+    const replayResponse = await POST(makeRequest(requestBody));
+
+    expect(replayResponse.status).toBe(200);
+    expect(mockPostHogEvent).not.toHaveBeenCalledWith(
+      "checkout_started",
+      expect.anything(),
+      expect.anything(),
     );
   });
 

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -19,12 +19,18 @@ import {
 import {
   PAID_FUNNEL_EVENTS,
   createCheckoutAttemptId,
+  normalizeCheckoutAttemptStartedAt,
   normalizePaidFunnelLabel,
   normalizeCheckoutAttemptId,
   paidFunnelTierFromUnknown,
   paidFunnelProperties,
   planLookupKeyToTier,
 } from "@/lib/analytics/paid-funnel";
+import {
+  claimCheckoutStarted,
+  paidFunnelEventUuid,
+  paidFunnelIdempotencyKey,
+} from "@/lib/analytics/paid-funnel-server";
 
 function canManageOrganizationBilling(
   membership: Awaited<
@@ -227,6 +233,9 @@ export const POST = async (req: NextRequest) => {
     const checkoutAttemptId =
       normalizeCheckoutAttemptId(body?.checkoutAttemptId) ??
       createCheckoutAttemptId();
+    const checkoutStartedAt =
+      normalizeCheckoutAttemptStartedAt(body?.checkoutAttemptStartedAt) ??
+      new Date();
     const checkoutSource = normalizePaidFunnelLabel(body?.source);
     const checkoutSurface = normalizePaidFunnelLabel(body?.surface);
     const checkoutReason = normalizePaidFunnelLabel(body?.reason);
@@ -503,33 +512,22 @@ export const POST = async (req: NextRequest) => {
       quantity,
     });
     const reusedCheckoutSession = Boolean(session);
+    const previousCheckoutAttemptId = session?.metadata?.checkoutAttemptId;
 
     if (!session) {
-      session = await stripe.checkout.sessions.create({
-        customer: customer.id,
-        billing_address_collection: "auto",
-        line_items: [
-          {
-            price: price.data[0].id,
-            quantity: quantity,
-          },
-        ],
-        mode: "subscription",
-        success_url: successUrl.toString(),
-        cancel_url: cancelUrl.toString(),
-        metadata: {
-          userId,
-          workOSOrganizationId: organization.id,
-          requestedPlan: subscriptionLevel,
-          checkoutQuantity: String(quantity),
-          checkoutAttemptId,
-          ...(checkoutSource && { checkoutSource }),
-          ...(checkoutSurface && { checkoutSurface }),
-          ...(checkoutReason && { checkoutReason }),
-          ...(checkoutLimitType && { checkoutLimitType }),
-          checkoutType: "new_subscription",
-        },
-        subscription_data: {
+      session = await stripe.checkout.sessions.create(
+        {
+          customer: customer.id,
+          billing_address_collection: "auto",
+          line_items: [
+            {
+              price: price.data[0].id,
+              quantity: quantity,
+            },
+          ],
+          mode: "subscription",
+          success_url: successUrl.toString(),
+          cancel_url: cancelUrl.toString(),
           metadata: {
             userId,
             workOSOrganizationId: organization.id,
@@ -542,16 +540,36 @@ export const POST = async (req: NextRequest) => {
             ...(checkoutLimitType && { checkoutLimitType }),
             checkoutType: "new_subscription",
           },
-        },
-        custom_text: {
-          submit: {
-            message:
-              "Renews monthly until cancelled. Cancel anytime in Settings.",
+          subscription_data: {
+            metadata: {
+              userId,
+              workOSOrganizationId: organization.id,
+              requestedPlan: subscriptionLevel,
+              checkoutQuantity: String(quantity),
+              checkoutAttemptId,
+              ...(checkoutSource && { checkoutSource }),
+              ...(checkoutSurface && { checkoutSurface }),
+              ...(checkoutReason && { checkoutReason }),
+              ...(checkoutLimitType && { checkoutLimitType }),
+              checkoutType: "new_subscription",
+            },
+          },
+          custom_text: {
+            submit: {
+              message:
+                "Renews monthly until cancelled. Cancel anytime in Settings.",
+            },
           },
         },
-      });
+        {
+          idempotencyKey: paidFunnelIdempotencyKey({
+            operation: "checkout_session_create",
+            scopeId: customer.id,
+            checkoutAttemptId,
+          }),
+        },
+      );
     } else {
-      const previousCheckoutAttemptId = session.metadata?.checkoutAttemptId;
       session = await stripe.checkout.sessions.update(session.id, {
         metadata: {
           ...session.metadata,
@@ -633,40 +651,53 @@ export const POST = async (req: NextRequest) => {
     }
 
     const selectedPrice = price.data[0];
-    phLogger.event(
-      PAID_FUNNEL_EVENTS.checkoutStarted,
-      paidFunnelProperties({
-        userId,
-        org_id: organization.id,
-        checkout_attempt_id: checkoutAttemptId,
-        checkout_type: "new_subscription",
-        from_tier: fromTier,
-        to_tier: planLookupKeyToTier(subscriptionLevel),
-        plan: subscriptionLevel,
-        billing_interval: selectedPrice.recurring?.interval,
-        billing_interval_count: selectedPrice.recurring?.interval_count,
-        quantity,
-        surface: checkoutSurface,
-        source: checkoutSource,
-        reason: checkoutReason,
-        limit_type: checkoutLimitType,
-        checkout_amount_dollars:
-          selectedPrice.unit_amount != null
-            ? (selectedPrice.unit_amount * quantity) / 100
-            : undefined,
-        currency: selectedPrice.currency,
-        stripe_customer_id: customer.id,
-        stripe_checkout_session_id: session.id,
-        stripe_checkout_session_reused: reusedCheckoutSession,
-        stripe_price_id: selectedPrice.id,
-        $session_id: posthogSessionId ?? undefined,
-        $insert_id: `${PAID_FUNNEL_EVENTS.checkoutStarted}:${checkoutAttemptId}`,
-        $set: {
-          last_checkout_started_at: new Date().toISOString(),
+    const shouldEmitCheckoutStarted =
+      previousCheckoutAttemptId !== checkoutAttemptId &&
+      (await claimCheckoutStarted({ userId, checkoutAttemptId }));
+    if (shouldEmitCheckoutStarted) {
+      phLogger.event(
+        PAID_FUNNEL_EVENTS.checkoutStarted,
+        paidFunnelProperties({
+          userId,
+          org_id: organization.id,
+          checkout_attempt_id: checkoutAttemptId,
+          checkout_type: "new_subscription",
+          from_tier: fromTier,
+          to_tier: planLookupKeyToTier(subscriptionLevel),
+          plan: subscriptionLevel,
+          billing_interval: selectedPrice.recurring?.interval,
+          billing_interval_count: selectedPrice.recurring?.interval_count,
+          quantity,
+          surface: checkoutSurface,
+          source: checkoutSource,
+          reason: checkoutReason,
+          limit_type: checkoutLimitType,
+          checkout_amount_dollars:
+            selectedPrice.unit_amount != null
+              ? (selectedPrice.unit_amount * quantity) / 100
+              : undefined,
+          currency: selectedPrice.currency,
+          stripe_customer_id: customer.id,
+          stripe_checkout_session_id: session.id,
+          stripe_checkout_session_reused: reusedCheckoutSession,
+          stripe_price_id: selectedPrice.id,
+          $session_id: posthogSessionId ?? undefined,
+          $insert_id: `${PAID_FUNNEL_EVENTS.checkoutStarted}:${checkoutAttemptId}`,
+          $set: {
+            last_checkout_started_at: checkoutStartedAt.toISOString(),
+          },
+        }),
+        {
+          uuid: paidFunnelEventUuid({
+            event: PAID_FUNNEL_EVENTS.checkoutStarted,
+            userId,
+            checkoutAttemptId,
+          }),
+          timestamp: checkoutStartedAt,
         },
-      }),
-    );
-    after(() => phLogger.flush());
+      );
+      after(() => phLogger.flush());
+    }
 
     return json({ url: session.url, checkoutAttemptId });
   } catch (error: unknown) {

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -57,15 +57,18 @@ function isReusableCheckoutSession(
     organizationId,
     requestedPlan,
     quantity,
+    checkoutAttemptId,
   }: {
     organizationId: string;
     requestedPlan: string;
     quantity: number;
+    checkoutAttemptId: string;
   },
 ): boolean {
   if (!session.url) return false;
   if (session.metadata?.workOSOrganizationId !== organizationId) return false;
   if (session.metadata?.requestedPlan !== requestedPlan) return false;
+  if (session.metadata?.checkoutAttemptId !== checkoutAttemptId) return false;
 
   const checkoutQuantity = session.metadata?.checkoutQuantity;
   return checkoutQuantity
@@ -182,11 +185,13 @@ async function findReusableCheckoutSession({
   organizationId,
   requestedPlan,
   quantity,
+  checkoutAttemptId,
 }: {
   customerId: string;
   organizationId: string;
   requestedPlan: string;
   quantity: number;
+  checkoutAttemptId: string;
 }): Promise<Stripe.Checkout.Session | undefined> {
   let startingAfter: string | undefined;
 
@@ -202,6 +207,7 @@ async function findReusableCheckoutSession({
         organizationId,
         requestedPlan,
         quantity,
+        checkoutAttemptId,
       }),
     );
 
@@ -510,6 +516,7 @@ export const POST = async (req: NextRequest) => {
       organizationId: organization.id,
       requestedPlan: subscriptionLevel,
       quantity,
+      checkoutAttemptId,
     });
     const reusedCheckoutSession = Boolean(session);
     const previousCheckoutAttemptId = session?.metadata?.checkoutAttemptId;

--- a/app/api/subscription-details/__tests__/route.test.ts
+++ b/app/api/subscription-details/__tests__/route.test.ts
@@ -303,6 +303,8 @@ describe("POST /api/subscription-details", () => {
     expect(mockUpdateSubscription).toHaveBeenCalledWith(
       "sub_123",
       expect.objectContaining({
+        proration_behavior: "always_invoice",
+        payment_behavior: "pending_if_incomplete",
         metadata: expect.objectContaining({
           existing: "metadata",
           checkoutAttemptId: "ca_paid_limit_123",
@@ -313,6 +315,12 @@ describe("POST /api/subscription-details", () => {
           checkoutType: "subscription_change",
         }),
       }),
+      {
+        idempotencyKey: "subscription_update:sub_123:ca_paid_limit_123",
+      },
+    );
+    expect(mockUpdateSubscription.mock.calls[0]?.[1]).not.toHaveProperty(
+      "proration_date",
     );
     expect(mockPostHogEvent).toHaveBeenCalledWith(
       "checkout_started",
@@ -348,6 +356,9 @@ describe("POST /api/subscription-details", () => {
 
     expect(replayResponse.status).toBe(200);
     expect(mockUpdateSubscription).toHaveBeenCalledTimes(2);
+    expect(mockUpdateSubscription.mock.calls[1]?.[2]).toEqual({
+      idempotencyKey: "subscription_update:sub_123:ca_paid_limit_123",
+    });
     expect(
       mockPostHogEvent.mock.calls.filter(
         ([event]) => event === "checkout_started",

--- a/app/api/subscription-details/__tests__/route.test.ts
+++ b/app/api/subscription-details/__tests__/route.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 
 const mockGetUserID = jest.fn();
 const mockGetUser = jest.fn();
@@ -11,6 +18,19 @@ const mockCreatePreview = jest.fn();
 const mockUpdateSubscription = jest.fn();
 const mockPostHogEvent = jest.fn();
 const mockPostHogFlush = jest.fn();
+const mockClaimCheckoutStarted = jest.fn(async () => true);
+
+jest.mock("@/lib/analytics/paid-funnel-server", () => ({
+  claimCheckoutStarted: mockClaimCheckoutStarted,
+  paidFunnelEventUuid: jest.fn(
+    ({ checkoutAttemptId }: { checkoutAttemptId: string }) =>
+      `event_uuid:${checkoutAttemptId}`,
+  ),
+  paidFunnelIdempotencyKey: jest.fn(
+    ({ operation, scopeId, checkoutAttemptId }) =>
+      `${operation}:${scopeId}:${checkoutAttemptId}`,
+  ),
+}));
 
 jest.mock("next/server", () => ({
   after: jest.fn((callback: () => void) => callback()),
@@ -75,6 +95,7 @@ function makeRequest(body: Record<string, unknown> = {}) {
 describe("POST /api/subscription-details", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockClaimCheckoutStarted.mockResolvedValue(true);
 
     mockGetUserID.mockResolvedValue("user_123" as never);
     mockGetUser.mockResolvedValue({
@@ -107,6 +128,10 @@ describe("POST /api/subscription-details", () => {
       ],
     } as never);
     mockListSubscriptions.mockResolvedValue({ data: [] } as never);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it.each(["pro-plus-monthly-plan", "pro-plus-yearly-plan"])(
@@ -208,7 +233,9 @@ describe("POST /api/subscription-details", () => {
   });
 
   it("persists subscription-change attribution in metadata and analytics", async () => {
-    mockListPrices.mockResolvedValueOnce({
+    const checkoutStartedAt = new Date("2026-07-17T16:30:45.123Z");
+    jest.useFakeTimers().setSystemTime(checkoutStartedAt);
+    mockListPrices.mockResolvedValue({
       data: [
         {
           id: "price_ultra",
@@ -218,7 +245,7 @@ describe("POST /api/subscription-details", () => {
         },
       ],
     } as never);
-    mockListSubscriptions.mockResolvedValueOnce({
+    mockListSubscriptions.mockResolvedValue({
       data: [
         {
           id: "sub_123",
@@ -242,34 +269,37 @@ describe("POST /api/subscription-details", () => {
         },
       ],
     } as never);
-    mockCreatePreview.mockResolvedValueOnce({
+    mockCreatePreview.mockResolvedValue({
       amount_due: 8000,
       lines: {
         data: [{ amount: 10000 }, { amount: -2000 }],
       },
     } as never);
-    mockUpdateSubscription.mockResolvedValueOnce({
+    mockUpdateSubscription.mockResolvedValue({
       id: "sub_123",
       latest_invoice: null,
     } as never);
 
     const { POST } = await import("../route");
-
-    const response = await POST(
-      makeRequest({
-        plan: "ultra-monthly-plan",
-        confirm: true,
-        checkoutAttemptId: "ca_paid_limit_123",
-        source: "limit_pressure",
-        surface: "pricing_dialog",
-        reason: "monthly_exhausted",
-        limitType: "monthly",
-      }),
-    );
+    const requestBody = {
+      plan: "ultra-monthly-plan",
+      confirm: true,
+      checkoutAttemptId: "ca_paid_limit_123",
+      checkoutAttemptStartedAt: checkoutStartedAt.toISOString(),
+      source: "limit_pressure",
+      surface: "pricing_dialog",
+      reason: "monthly_exhausted",
+      limitType: "monthly",
+    };
+    const response = await POST(makeRequest(requestBody));
     const body = await response.json();
 
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
+    expect(mockClaimCheckoutStarted).toHaveBeenCalledWith({
+      userId: "user_123",
+      checkoutAttemptId: "ca_paid_limit_123",
+    });
     expect(mockUpdateSubscription).toHaveBeenCalledWith(
       "sub_123",
       expect.objectContaining({
@@ -294,6 +324,10 @@ describe("POST /api/subscription-details", () => {
         reason: "monthly_exhausted",
         limit_type: "monthly",
       }),
+      expect.objectContaining({
+        uuid: "event_uuid:ca_paid_limit_123",
+        timestamp: expect.any(Date),
+      }),
     );
     expect(mockPostHogEvent).toHaveBeenCalledWith(
       "checkout_succeeded",
@@ -306,5 +340,48 @@ describe("POST /api/subscription-details", () => {
         limit_type: "monthly",
       }),
     );
+
+    jest.advanceTimersByTime(5_000);
+    mockClaimCheckoutStarted.mockResolvedValueOnce(false);
+
+    const replayResponse = await POST(makeRequest(requestBody));
+
+    expect(replayResponse.status).toBe(200);
+    expect(mockUpdateSubscription).toHaveBeenCalledTimes(2);
+    expect(
+      mockPostHogEvent.mock.calls.filter(
+        ([event]) => event === "checkout_started",
+      ),
+    ).toHaveLength(1);
+
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockUpdateSubscription.mockRejectedValueOnce(
+      new Error("card was declined") as never,
+    );
+    const failedAttemptId = "ca_paid_limit_456";
+    const failedResponse = await POST(
+      makeRequest({
+        ...requestBody,
+        checkoutAttemptId: failedAttemptId,
+        checkoutAttemptStartedAt: new Date().toISOString(),
+      }),
+    );
+
+    expect(failedResponse.status).toBe(400);
+    expect(
+      mockPostHogEvent.mock.calls.filter(
+        ([event, properties]) =>
+          event === "checkout_started" &&
+          properties?.checkout_attempt_id === failedAttemptId,
+      ),
+    ).toHaveLength(1);
+    expect(
+      mockPostHogEvent.mock.calls.filter(
+        ([event, properties]) =>
+          event === "checkout_succeeded" &&
+          properties?.checkout_attempt_id === failedAttemptId,
+      ),
+    ).toHaveLength(0);
+    errorSpy.mockRestore();
   });
 });

--- a/app/api/subscription-details/route.ts
+++ b/app/api/subscription-details/route.ts
@@ -9,10 +9,15 @@ import {
   PAID_FUNNEL_EVENTS,
   createCheckoutAttemptId,
   normalizeCheckoutAttemptId,
+  normalizeCheckoutAttemptStartedAt,
   normalizePaidFunnelLabel,
   paidFunnelProperties,
   planLookupKeyToTier,
 } from "@/lib/analytics/paid-funnel";
+import {
+  claimCheckoutStarted,
+  paidFunnelEventUuid,
+} from "@/lib/analytics/paid-funnel-server";
 
 const MAX_TEAM_SEATS = 999;
 
@@ -67,6 +72,9 @@ export const POST = async (req: NextRequest) => {
     const checkoutAttemptId =
       normalizeCheckoutAttemptId(body?.checkoutAttemptId) ??
       createCheckoutAttemptId();
+    const checkoutStartedAt =
+      normalizeCheckoutAttemptStartedAt(body?.checkoutAttemptStartedAt) ??
+      new Date();
     const checkoutSource = normalizePaidFunnelLabel(body?.source);
     const checkoutSurface = normalizePaidFunnelLabel(body?.surface);
     const checkoutReason = normalizePaidFunnelLabel(body?.reason);
@@ -321,36 +329,46 @@ export const POST = async (req: NextRequest) => {
       // If confirm flag is true, actually update the subscription
       if (confirm) {
         try {
-          phLogger.event(
-            PAID_FUNNEL_EVENTS.checkoutStarted,
-            paidFunnelProperties({
-              userId,
-              org_id: organization.id,
-              checkout_attempt_id: checkoutAttemptId,
-              checkout_type: "subscription_change",
-              from_tier: planType,
-              to_tier: planLookupKeyToTier(targetPlan),
-              plan: targetPlan,
-              billing_interval: targetPrice.recurring?.interval,
-              billing_interval_count: targetPrice.recurring?.interval_count,
-              quantity,
-              surface: checkoutSurface,
-              source: checkoutSource,
-              reason: checkoutReason,
-              limit_type: checkoutLimitType,
-              checkout_amount_dollars: totalDue,
-              currency: targetPrice.currency,
-              stripe_customer_id: matchingCustomer.id,
-              stripe_subscription_id: subscription.id,
-              stripe_price_id: targetPrice.id,
-              $session_id: posthogSessionId ?? undefined,
-              $insert_id: `${PAID_FUNNEL_EVENTS.checkoutStarted}:${checkoutAttemptId}`,
-              $set: {
-                last_checkout_started_at: new Date().toISOString(),
+          if (await claimCheckoutStarted({ userId, checkoutAttemptId })) {
+            phLogger.event(
+              PAID_FUNNEL_EVENTS.checkoutStarted,
+              paidFunnelProperties({
+                userId,
+                org_id: organization.id,
+                checkout_attempt_id: checkoutAttemptId,
+                checkout_type: "subscription_change",
+                from_tier: planType,
+                to_tier: planLookupKeyToTier(targetPlan),
+                plan: targetPlan,
+                billing_interval: targetPrice.recurring?.interval,
+                billing_interval_count: targetPrice.recurring?.interval_count,
+                quantity,
+                surface: checkoutSurface,
+                source: checkoutSource,
+                reason: checkoutReason,
+                limit_type: checkoutLimitType,
+                checkout_amount_dollars: totalDue,
+                currency: targetPrice.currency,
+                stripe_customer_id: matchingCustomer.id,
+                stripe_subscription_id: subscription.id,
+                stripe_price_id: targetPrice.id,
+                $session_id: posthogSessionId ?? undefined,
+                $insert_id: `${PAID_FUNNEL_EVENTS.checkoutStarted}:${checkoutAttemptId}`,
+                $set: {
+                  last_checkout_started_at: checkoutStartedAt.toISOString(),
+                },
+              }),
+              {
+                uuid: paidFunnelEventUuid({
+                  event: PAID_FUNNEL_EVENTS.checkoutStarted,
+                  userId,
+                  checkoutAttemptId,
+                }),
+                timestamp: checkoutStartedAt,
               },
-            }),
-          );
-          after(() => phLogger.flush());
+            );
+            after(() => phLogger.flush());
+          }
 
           const updatedSubscription = await stripe.subscriptions.update(
             subscription.id,

--- a/app/api/subscription-details/route.ts
+++ b/app/api/subscription-details/route.ts
@@ -17,6 +17,7 @@ import {
 import {
   claimCheckoutStarted,
   paidFunnelEventUuid,
+  paidFunnelIdempotencyKey,
 } from "@/lib/analytics/paid-funnel-server";
 
 const MAX_TEAM_SEATS = 999;
@@ -381,7 +382,6 @@ export const POST = async (req: NextRequest) => {
                 },
               ],
               proration_behavior: "always_invoice",
-              proration_date: Math.floor(Date.now() / 1000),
               payment_behavior: "pending_if_incomplete",
               metadata: {
                 ...subscription.metadata,
@@ -392,6 +392,13 @@ export const POST = async (req: NextRequest) => {
                 ...(checkoutLimitType && { checkoutLimitType }),
                 checkoutType: "subscription_change",
               },
+            },
+            {
+              idempotencyKey: paidFunnelIdempotencyKey({
+                operation: "subscription_update",
+                scopeId: subscription.id,
+                checkoutAttemptId,
+              }),
             },
           );
 

--- a/app/components/UpgradeConfirmationDialog.tsx
+++ b/app/components/UpgradeConfirmationDialog.tsx
@@ -59,17 +59,23 @@ const UpgradeConfirmationDialog: React.FC<UpgradeConfirmationDialogProps> = ({
   const [loadingDetails, setLoadingDetails] = useState(false);
   const [confirming, setConfirming] = useState(false);
   const [error, setError] = useState<string>("");
-  const [checkoutAttemptId, setCheckoutAttemptId] = useState<string | null>(
-    null,
-  );
+  const [checkoutAttempt, setCheckoutAttempt] = useState<{
+    id: string;
+    startedAt: string;
+  } | null>(null);
+  const checkoutAttemptId = checkoutAttempt?.id;
+  const checkoutAttemptStartedAt = checkoutAttempt?.startedAt;
 
   useEffect(() => {
     if (!isOpen) {
-      setCheckoutAttemptId(null);
+      setCheckoutAttempt(null);
       return;
     }
 
-    setCheckoutAttemptId(newCheckoutAttemptId());
+    setCheckoutAttempt({
+      id: newCheckoutAttemptId(),
+      startedAt: new Date().toISOString(),
+    });
   }, [isOpen, targetPlan]);
 
   useEffect(() => {
@@ -91,6 +97,7 @@ const UpgradeConfirmationDialog: React.FC<UpgradeConfirmationDialogProps> = ({
             confirm: false,
             quantity: quantity,
             checkoutAttemptId,
+            checkoutAttemptStartedAt,
             source,
             surface,
             reason,
@@ -140,6 +147,7 @@ const UpgradeConfirmationDialog: React.FC<UpgradeConfirmationDialogProps> = ({
     price,
     quantity,
     checkoutAttemptId,
+    checkoutAttemptStartedAt,
     source,
     surface,
     reason,
@@ -152,7 +160,7 @@ const UpgradeConfirmationDialog: React.FC<UpgradeConfirmationDialogProps> = ({
   const canConfirm = Boolean(checkoutAttemptId && details);
 
   const handleConfirmPayment = async () => {
-    if (!checkoutAttemptId || !details) {
+    if (!checkoutAttemptId || !checkoutAttemptStartedAt || !details) {
       setError("Still preparing checkout details. Please wait a moment.");
       return;
     }
@@ -171,6 +179,7 @@ const UpgradeConfirmationDialog: React.FC<UpgradeConfirmationDialogProps> = ({
           confirm: true,
           quantity: quantity,
           checkoutAttemptId,
+          checkoutAttemptStartedAt,
           source,
           surface,
           reason,

--- a/app/components/__tests__/UpgradeConfirmationDialog.test.tsx
+++ b/app/components/__tests__/UpgradeConfirmationDialog.test.tsx
@@ -160,6 +160,7 @@ describe("UpgradeConfirmationDialog", () => {
         confirm: false,
         quantity: 5,
         checkoutAttemptId: expect.stringMatching(/^ca_/),
+        checkoutAttemptStartedAt: expect.any(String),
       });
     });
 
@@ -211,8 +212,16 @@ describe("UpgradeConfirmationDialog", () => {
         confirm: true,
         quantity: 2,
         checkoutAttemptId: expect.stringMatching(/^ca_/),
+        checkoutAttemptStartedAt: expect.any(String),
         fromTier: "pro",
       });
+      const previewBody = JSON.parse(
+        (mockFetch.mock.calls[0]?.[1] as RequestInit).body as string,
+      );
+      const confirmBody = JSON.parse(init.body as string);
+      expect(confirmBody.checkoutAttemptStartedAt).toBe(
+        previewBody.checkoutAttemptStartedAt,
+      );
     });
 
     it("should pass attribution context to preview and confirm APIs", async () => {

--- a/app/hooks/__tests__/useUpgrade.test.tsx
+++ b/app/hooks/__tests__/useUpgrade.test.tsx
@@ -1,0 +1,109 @@
+import { act, renderHook } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+const mockCaptureAuthenticatedEvent = jest.fn();
+const mockNewCheckoutAttemptId = jest
+  .fn<() => string>()
+  .mockReturnValueOnce("ca_attempt_1")
+  .mockReturnValueOnce("ca_attempt_2");
+const mockToastError = jest.fn();
+const originalFetch = globalThis.fetch;
+
+jest.mock("@workos-inc/authkit-nextjs/components", () => ({
+  useAuth: () => ({ user: { id: "user_123" } }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: mockToastError },
+}));
+
+jest.mock("@/lib/analytics/client", () => ({
+  captureAuthenticatedEvent: mockCaptureAuthenticatedEvent,
+  getPostHogRequestHeaders: () => ({}),
+  newCheckoutAttemptId: mockNewCheckoutAttemptId,
+}));
+
+const { useUpgrade } =
+  require("../useUpgrade") as typeof import("../useUpgrade");
+
+describe("useUpgrade", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNewCheckoutAttemptId
+      .mockReset()
+      .mockReturnValueOnce("ca_attempt_1")
+      .mockReturnValueOnce("ca_attempt_2");
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+    } else {
+      delete (globalThis as { fetch?: typeof fetch }).fetch;
+    }
+  });
+
+  it("coalesces duplicate clicks and rerenders, then gives a retry a new ID", async () => {
+    let resolveFirstRequest: ((response: Response) => void) | undefined;
+    const firstRequest = new Promise<Response>((resolve) => {
+      resolveFirstRequest = resolve;
+    });
+    const mockFetch = jest
+      .fn<typeof fetch>()
+      .mockReturnValueOnce(firstRequest)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: "retryable" }),
+      } as Response);
+    globalThis.fetch = mockFetch;
+
+    const { result, rerender } = renderHook(() => useUpgrade());
+    let firstUpgrade: Promise<void> | undefined;
+
+    act(() => {
+      firstUpgrade = result.current.handleUpgrade("pro-monthly-plan");
+      void result.current.handleUpgrade("pro-monthly-plan");
+    });
+    rerender();
+    await act(async () => {
+      await result.current.handleUpgrade("pro-monthly-plan");
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    resolveFirstRequest?.({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: "temporary" }),
+    } as Response);
+    await act(async () => {
+      await firstUpgrade;
+    });
+
+    await act(async () => {
+      await result.current.handleUpgrade("pro-monthly-plan");
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const requestBodies = mockFetch.mock.calls.map(([, init]) =>
+      JSON.parse(String(init?.body)),
+    );
+    expect(requestBodies.map((body) => body.checkoutAttemptId)).toEqual([
+      "ca_attempt_1",
+      "ca_attempt_2",
+    ]);
+    expect(
+      requestBodies.every((body) =>
+        Number.isFinite(Date.parse(body.checkoutAttemptStartedAt)),
+      ),
+    ).toBe(true);
+  });
+});

--- a/app/hooks/useUpgrade.ts
+++ b/app/hooks/useUpgrade.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { toast } from "sonner";
 import {
@@ -15,6 +15,7 @@ import {
 export const useUpgrade = () => {
   const { user } = useAuth();
   const [upgradeLoading, setUpgradeLoading] = useState(false);
+  const upgradeInFlightRef = useRef(false);
 
   const handleUpgrade = async (
     planKey?: PaidFunnelPlan,
@@ -31,7 +32,7 @@ export const useUpgrade = () => {
     e?.preventDefault();
 
     // Prevent duplicate submits
-    if (upgradeLoading) {
+    if (upgradeInFlightRef.current) {
       return;
     }
 
@@ -40,17 +41,20 @@ export const useUpgrade = () => {
       return;
     }
 
+    upgradeInFlightRef.current = true;
     setUpgradeLoading(true);
 
     try {
       const selectedPlan = planKey || "pro-monthly-plan";
       const checkoutAttemptId = newCheckoutAttemptId();
+      const checkoutAttemptStartedAt = new Date().toISOString();
       const toTier = planLookupKeyToTier(selectedPlan);
       const billingInterval = planLookupKeyToBillingInterval(selectedPlan);
       const requestBody: {
         plan: string;
         quantity?: number;
         checkoutAttemptId: string;
+        checkoutAttemptStartedAt: string;
         source?: string;
         surface?: string;
         reason?: string;
@@ -59,6 +63,7 @@ export const useUpgrade = () => {
       } = {
         plan: selectedPlan,
         checkoutAttemptId,
+        checkoutAttemptStartedAt,
         source: analyticsContext.source,
         surface: analyticsContext.surface,
         reason: analyticsContext.reason,
@@ -158,6 +163,7 @@ export const useUpgrade = () => {
             confirm: true,
             quantity: quantity,
             checkoutAttemptId,
+            checkoutAttemptStartedAt,
             source: analyticsContext.source,
             surface: analyticsContext.surface,
             reason: analyticsContext.reason,
@@ -198,6 +204,7 @@ export const useUpgrade = () => {
         toast.error("An unexpected error occurred");
       }
     } finally {
+      upgradeInFlightRef.current = false;
       setUpgradeLoading(false);
     }
   };

--- a/lib/analytics/__tests__/paid-funnel.test.ts
+++ b/lib/analytics/__tests__/paid-funnel.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  PAID_FUNNEL_EVENTS,
+  normalizeCheckoutAttemptStartedAt,
+} from "../paid-funnel";
+
+const mockRedisSet = jest.fn();
+const mockCreateRedisClient = jest.fn(() => ({ set: mockRedisSet }));
+
+jest.mock("server-only", () => ({}));
+jest.mock("@/lib/rate-limit/redis", () => ({
+  createRedisClient: mockCreateRedisClient,
+}));
+
+const { claimCheckoutStarted, paidFunnelEventUuid, paidFunnelIdempotencyKey } =
+  require("../paid-funnel-server") as typeof import("../paid-funnel-server");
+
+describe("paid funnel attempt identity", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it("accepts only a bounded logical-attempt timestamp", () => {
+    const startedAt = new Date("2026-07-17T16:30:45.123Z");
+    jest.useFakeTimers().setSystemTime(startedAt);
+
+    expect(normalizeCheckoutAttemptStartedAt(startedAt.toISOString())).toEqual(
+      startedAt,
+    );
+    expect(
+      normalizeCheckoutAttemptStartedAt(
+        startedAt.toISOString(),
+        startedAt.getTime() + 86_400_001,
+      ),
+    ).toBeUndefined();
+    expect(
+      normalizeCheckoutAttemptStartedAt("not-a-timestamp"),
+    ).toBeUndefined();
+  });
+
+  it("derives stable UUIDs and Stripe keys per attempt", () => {
+    const input = {
+      event: PAID_FUNNEL_EVENTS.checkoutStarted,
+      userId: "user_123",
+      checkoutAttemptId: "ca_attempt_123",
+    };
+
+    const eventUuid = paidFunnelEventUuid(input);
+    expect(eventUuid).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-8[0-9a-f]{3}-8[0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    expect(paidFunnelEventUuid(input)).toBe(eventUuid);
+    expect(
+      paidFunnelEventUuid({ ...input, checkoutAttemptId: "ca_attempt_456" }),
+    ).not.toBe(eventUuid);
+
+    const key = paidFunnelIdempotencyKey({
+      operation: "checkout_session_create",
+      scopeId: "cus_123",
+      checkoutAttemptId: input.checkoutAttemptId,
+    });
+    expect(
+      paidFunnelIdempotencyKey({
+        operation: "checkout_session_create",
+        scopeId: "cus_123",
+        checkoutAttemptId: input.checkoutAttemptId,
+      }),
+    ).toBe(key);
+    expect(key).toMatch(/^checkout_session_create:[0-9a-f]{32}$/);
+  });
+
+  it("claims an attempt once and fails open when Redis is unavailable", async () => {
+    mockRedisSet.mockResolvedValueOnce("OK").mockResolvedValueOnce(null);
+
+    await expect(
+      claimCheckoutStarted({
+        userId: "user_123",
+        checkoutAttemptId: "ca_attempt_123",
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      claimCheckoutStarted({
+        userId: "user_123",
+        checkoutAttemptId: "ca_attempt_123",
+      }),
+    ).resolves.toBe(false);
+
+    expect(mockRedisSet).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/^paid_funnel:checkout_started:/),
+      1,
+      { nx: true, ex: 2_592_000 },
+    );
+
+    mockRedisSet.mockRejectedValueOnce(new Error("redis unavailable"));
+    await expect(
+      claimCheckoutStarted({
+        userId: "user_123",
+        checkoutAttemptId: "ca_attempt_456",
+      }),
+    ).resolves.toBe(true);
+
+    mockCreateRedisClient.mockReturnValueOnce(null as never);
+    await expect(
+      claimCheckoutStarted({
+        userId: "user_123",
+        checkoutAttemptId: "ca_attempt_789",
+      }),
+    ).resolves.toBe(true);
+  });
+});

--- a/lib/analytics/paid-funnel-server.ts
+++ b/lib/analytics/paid-funnel-server.ts
@@ -1,0 +1,78 @@
+import "server-only";
+
+import { createRedisClient } from "@/lib/rate-limit/redis";
+import { createHash } from "node:crypto";
+
+const CHECKOUT_STARTED_CLAIM_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+function stableDigest(parts: string[]): string {
+  return createHash("sha256").update(JSON.stringify(parts)).digest("hex");
+}
+
+function stableEventUuid(parts: string[]): string {
+  const hex = stableDigest(parts).slice(0, 32).split("");
+  // UUIDv8 is reserved for application-defined deterministic identifiers.
+  hex[12] = "8";
+  hex[16] = "8";
+  const value = hex.join("");
+  return `${value.slice(0, 8)}-${value.slice(8, 12)}-${value.slice(12, 16)}-${value.slice(16, 20)}-${value.slice(20)}`;
+}
+
+export function paidFunnelEventUuid({
+  event,
+  userId,
+  checkoutAttemptId,
+}: {
+  event: string;
+  userId: string;
+  checkoutAttemptId: string;
+}): string {
+  return stableEventUuid([event, userId, checkoutAttemptId]);
+}
+
+export function paidFunnelIdempotencyKey({
+  operation,
+  scopeId,
+  checkoutAttemptId,
+}: {
+  operation: string;
+  scopeId: string;
+  checkoutAttemptId: string;
+}): string {
+  const key = stableDigest([operation, scopeId, checkoutAttemptId]).slice(
+    0,
+    32,
+  );
+  return `${operation}:${key}`;
+}
+
+export async function claimCheckoutStarted({
+  userId,
+  checkoutAttemptId,
+}: {
+  userId: string;
+  checkoutAttemptId: string;
+}): Promise<boolean> {
+  try {
+    const redis = createRedisClient();
+    if (!redis) return true;
+    const claimId = stableDigest([
+      "checkout_started",
+      userId,
+      checkoutAttemptId,
+    ]).slice(0, 32);
+    const claimed = await redis.set(
+      `paid_funnel:checkout_started:${claimId}`,
+      1,
+      {
+        nx: true,
+        ex: CHECKOUT_STARTED_CLAIM_TTL_SECONDS,
+      },
+    );
+    return claimed === "OK";
+  } catch {
+    // Analytics must never block checkout; deterministic PostHog identity remains
+    // a secondary deduplication path when the Redis claim is unavailable.
+    return true;
+  }
+}

--- a/lib/analytics/paid-funnel.ts
+++ b/lib/analytics/paid-funnel.ts
@@ -98,6 +98,24 @@ export function normalizeCheckoutAttemptId(value: unknown): string | undefined {
   return trimmed;
 }
 
+export function normalizeCheckoutAttemptStartedAt(
+  value: unknown,
+  nowMs = Date.now(),
+): Date | undefined {
+  if (typeof value !== "string" || value.length > 64) return undefined;
+  const timestamp = Date.parse(value);
+  const maximumPastAgeMs = 24 * 60 * 60 * 1_000;
+  const maximumFutureSkewMs = 5 * 60 * 1_000;
+  if (
+    !Number.isFinite(timestamp) ||
+    timestamp < nowMs - maximumPastAgeMs ||
+    timestamp > nowMs + maximumFutureSkewMs
+  ) {
+    return undefined;
+  }
+  return new Date(timestamp);
+}
+
 export function paidFunnelProperties(properties: Record<string, unknown> = {}) {
   return {
     ...properties,

--- a/lib/posthog/__tests__/server.test.ts
+++ b/lib/posthog/__tests__/server.test.ts
@@ -64,4 +64,28 @@ describe("phLogger", () => {
     expect(mockEmitPostHogLog).toHaveBeenCalledTimes(1);
     expect(mockCaptureException).toHaveBeenCalledTimes(1);
   });
+
+  it("forwards event identity fields at the PostHog envelope level", () => {
+    const timestamp = new Date("2026-07-17T16:30:45.123Z");
+
+    phLogger.event(
+      "checkout_started",
+      {
+        userId: "user_123",
+        checkout_attempt_id: "ca_attempt_123",
+      },
+      {
+        uuid: "a0f4f90b-0a46-52d8-87d2-9ef6792e2e56",
+        timestamp,
+      },
+    );
+
+    expect(mockCapture).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      event: "checkout_started",
+      properties: { checkout_attempt_id: "ca_attempt_123" },
+      uuid: "a0f4f90b-0a46-52d8-87d2-9ef6792e2e56",
+      timestamp,
+    });
+  });
 });

--- a/lib/posthog/server.ts
+++ b/lib/posthog/server.ts
@@ -21,6 +21,11 @@ type EventFields = Record<string, unknown> & {
   $set?: Record<string, unknown>;
 };
 
+type EventOptions = {
+  uuid?: string;
+  timestamp?: Date;
+};
+
 const TELEMETRY_STRING_MAX_LENGTH = 2_000;
 
 function distinctIdFor(userId: unknown): string {
@@ -171,7 +176,7 @@ export const phLogger = {
     if (!wroteLog) console.log(message, fields);
   },
 
-  event(name: string, fields: EventFields = {}) {
+  event(name: string, fields: EventFields = {}, options: EventOptions = {}) {
     const client = getClient();
     if (!client) return;
     try {
@@ -180,6 +185,7 @@ export const phLogger = {
         distinctId: distinctIdFor(userId),
         event: name,
         properties: { ...rest, ...($set && { $set }) },
+        ...options,
       });
     } catch {
       // best-effort


### PR DESCRIPTION
## Summary
- atomically claim `checkout_started` by user and `checkout_attempt_id`, suppressing replayed same-attempt emissions while allowing distinct retries
- make Stripe Checkout session creation idempotent per customer/attempt and preserve stable attempt/session identifiers
- forward deterministic PostHog event identity, carry a bounded attempt timestamp, and synchronously guard duplicate UI submits
- cover request replay, reused sessions, Redis failure, failed subscription changes, duplicate clicks/rerenders, and distinct retries

## Why
Live PostHog data for Jul 6-12 showed 6,337 raw `checkout_started` rows but only 2,889 unique attempts. Five attempt IDs explained 99.65% of excess rows. The existing `$insert_id` was only an event property, so each replay received a new PostHog UUID; several attempts also created hundreds of Stripe sessions.

## Validation
- pre-commit suite: 268 suites, 2,708 tests passed
- focused checkout suites: 6 suites, 42 tests passed
- `corepack pnpm typecheck`
- targeted ESLint and Prettier checks
- independent diff review: no remaining actionable findings
- Google Chrome: pricing dialog and Pro+ confirmation preview rendered cleanly; preview API returned 200; no console warnings/errors; no payment submitted

## Manual verification
- Open the pricing dialog from the user menu and select an eligible upgrade; confirm the plan-change preview appears and the final payment button remains the only mutating step.
- After deployment, compare raw `checkout_started` to unique `checkout_attempt_id` by source and verify replayed attempts no longer fan out Stripe session IDs.
- Exercise a failed subscription change and verify one `checkout_started`, no `checkout_succeeded`, and a later distinct retry remains reportable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgrade and subscription checkout attempts now include consistent timestamps for improved tracking.
  * Checkout creation is protected against duplicate submissions and repeated sessions.
  * Upgrade actions prevent accidental duplicate requests while one is already in progress.

* **Bug Fixes**
  * Replayed checkout attempts no longer generate duplicate checkout-started analytics events.
  * Failed payment updates now report the correct outcome without falsely indicating success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->