### PR TITLE
Optimize sidebar chat indexes

### DIFF
--- a/convex/__tests__/projects.test.ts
+++ b/convex/__tests__/projects.test.ts
@@ -221,6 +221,12 @@ describe("projects", () => {
   it("deletes a project while preserving its tasks", async () => {
     const tasks = [{ _id: "task-1" }, { _id: "task-2" }];
     const take = jest.fn<any>().mockResolvedValue(tasks);
+    const projectEq = jest.fn<any>().mockReturnThis();
+    const withIndex = jest.fn<any>((indexName, applyIndex) => {
+      expect(indexName).toBe("by_user_project_and_updated");
+      applyIndex({ eq: projectEq });
+      return { take };
+    });
     const patch = jest.fn<any>().mockResolvedValue(undefined);
     const deleteDocument = jest.fn<any>().mockResolvedValue(undefined);
     const ctx = {
@@ -233,7 +239,7 @@ describe("projects", () => {
         patch,
         delete: deleteDocument,
         query: jest.fn<any>().mockReturnValue({
-          withIndex: jest.fn<any>().mockReturnValue({ take }),
+          withIndex,
         }),
       },
       scheduler: { runAfter: jest.fn() },
@@ -250,6 +256,43 @@ describe("projects", () => {
     expect(patch).toHaveBeenCalledWith("task-2", { project_id: undefined });
     expect(deleteDocument).toHaveBeenCalledWith("project-1");
     expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+    expect(projectEq).toHaveBeenNthCalledWith(1, "user_id", "user-1");
+    expect(projectEq).toHaveBeenNthCalledWith(2, "project_id", "project-1");
+  });
+
+  it("paginates project tasks through the user and project index", async () => {
+    const page = {
+      page: [{ _id: "task-1", user_id: "user-1", project_id: "project-1" }],
+      isDone: true,
+      continueCursor: "",
+    };
+    const paginate = jest.fn<any>().mockResolvedValue(page);
+    const order = jest.fn<any>().mockReturnValue({ paginate });
+    const projectEq = jest.fn<any>().mockReturnThis();
+    const withIndex = jest.fn<any>((indexName, applyIndex) => {
+      expect(indexName).toBe("by_user_project_and_updated");
+      applyIndex({ eq: projectEq });
+      return { order };
+    });
+    const ctx = {
+      auth: authenticated,
+      db: {
+        get: jest.fn<any>().mockResolvedValue(project),
+        query: jest.fn<any>().mockReturnValue({ withIndex }),
+      },
+    };
+
+    await expect(
+      getProjectThreads.handler(ctx as any, {
+        projectId: "project-1" as any,
+        paginationOpts: { cursor: null, numItems: 5 },
+      }),
+    ).resolves.toEqual(page);
+
+    expect(projectEq).toHaveBeenNthCalledWith(1, "user_id", "user-1");
+    expect(projectEq).toHaveBeenNthCalledWith(2, "project_id", "project-1");
+    expect(order).toHaveBeenCalledWith("desc");
+    expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 5 });
   });
 
   it("returns no tasks when the project is not owned by the user", async () => {

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -90,7 +90,9 @@ const detachNextProjectTasksBatch = async (
 
   const tasks = await ctx.db
     .query("chats")
-    .withIndex("by_project_and_updated", (q) => q.eq("project_id", projectId))
+    .withIndex("by_user_project_and_updated", (q) =>
+      q.eq("user_id", userId).eq("project_id", projectId),
+    )
     .take(PROJECT_TASK_DETACH_BATCH_SIZE + 1);
 
   for (const task of tasks.slice(0, PROJECT_TASK_DETACH_BATCH_SIZE)) {
@@ -328,18 +330,15 @@ export const getProjectThreads = query({
 
     const result = await ctx.db
       .query("chats")
-      .withIndex("by_project_and_updated", (q) =>
-        q.eq("project_id", args.projectId),
+      .withIndex("by_user_project_and_updated", (q) =>
+        q.eq("user_id", identity.subject).eq("project_id", args.projectId),
       )
       .order("desc")
       .paginate(args.paginationOpts);
 
-    const ownedPage = result.page.filter(
-      (chat) => chat.user_id === identity.subject,
-    );
     const branchedIds = [
       ...new Set(
-        ownedPage
+        result.page
           .map((chat) => chat.branched_from_chat_id)
           .filter((id): id is string => id !== undefined),
       ),
@@ -360,7 +359,7 @@ export const getProjectThreads = query({
 
     return {
       ...result,
-      page: ownedPage.map((chat) => ({
+      page: result.page.map((chat) => ({
         ...chat,
         ...(chat.branched_from_chat_id
           ? {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -120,13 +120,11 @@ export default defineSchema({
       "project_id",
       "update_time",
     ])
-    .index("by_project_and_updated", ["project_id", "update_time"])
     .index("by_user_and_active_trigger_run", [
       "user_id",
       "active_trigger_run_id",
     ])
     .index("by_user_and_pinned", ["user_id", "pinned_at"])
-    .index("by_user_project_and_pinned", ["user_id", "project_id", "pinned_at"])
     .index("by_share_id", ["share_id"])
     .searchIndex("search_title", {
       searchField: "title",


### PR DESCRIPTION
## Summary

- keep only the composite `by_user_project_and_updated` index for sidebar task organization
- reuse that index for normal task pagination, project task pagination, and batched project deletion
- remove the unused pinned-project task index and redundant project-only index
- add regression coverage for both project query paths

## Why

The sidebar rollout initially added three indexes over the four-million-row `chats` table. Two were unnecessary and would add avoidable backfill time, storage, and write maintenance. All sidebar project queries already know both the user and project, so one equality-prefixed composite index covers every required access pattern.

## Validation

- `pnpm typecheck`
- `pnpm exec eslint convex/projects.ts convex/schema.ts convex/__tests__/projects.test.ts`
- `pnpm exec prettier --check convex/projects.ts convex/schema.ts convex/__tests__/projects.test.ts`
- `pnpm test` (282 suites, 2,784 tests)
- `git diff --check`
