### PR TITLE
Stage sidebar chat index backfill

### DIFF
--- a/convex/__tests__/chats.getUserChats.test.ts
+++ b/convex/__tests__/chats.getUserChats.test.ts
@@ -174,8 +174,14 @@ describe("getUserChats", () => {
     };
     const paginate = jest.fn<any>().mockResolvedValue(page);
     const regularOrder = jest.fn<any>().mockReturnValue({ paginate });
-    const regularWithIndex = jest.fn<any>().mockReturnValue({
+    const regularFilter = jest.fn<any>().mockReturnValue({
       order: regularOrder,
+    });
+    const regularEq = jest.fn<any>().mockReturnThis();
+    const regularWithIndex = jest.fn<any>((indexName, applyIndex) => {
+      expect(indexName).toBe("by_user_and_updated");
+      applyIndex({ eq: regularEq });
+      return { filter: regularFilter };
     });
     const ctx = {
       auth: {
@@ -201,5 +207,7 @@ describe("getUserChats", () => {
     });
     expect(pinnedEq).toHaveBeenCalledWith("user_id", "user-123");
     expect(gt).toHaveBeenCalledWith("pinned_at", 0);
+    expect(regularEq).toHaveBeenCalledWith("user_id", "user-123");
+    expect(regularFilter).toHaveBeenCalledWith(expect.any(Function));
   });
 });

--- a/convex/__tests__/projects.test.ts
+++ b/convex/__tests__/projects.test.ts
@@ -223,7 +223,7 @@ describe("projects", () => {
     const take = jest.fn<any>().mockResolvedValue(tasks);
     const projectEq = jest.fn<any>().mockReturnThis();
     const withIndex = jest.fn<any>((indexName, applyIndex) => {
-      expect(indexName).toBe("by_user_project_and_updated");
+      expect(indexName).toBe("by_project_and_updated");
       applyIndex({ eq: projectEq });
       return { take };
     });
@@ -256,11 +256,10 @@ describe("projects", () => {
     expect(patch).toHaveBeenCalledWith("task-2", { project_id: undefined });
     expect(deleteDocument).toHaveBeenCalledWith("project-1");
     expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
-    expect(projectEq).toHaveBeenNthCalledWith(1, "user_id", "user-1");
-    expect(projectEq).toHaveBeenNthCalledWith(2, "project_id", "project-1");
+    expect(projectEq).toHaveBeenCalledWith("project_id", "project-1");
   });
 
-  it("paginates project tasks through the user and project index", async () => {
+  it("paginates project tasks through the temporary project index", async () => {
     const page = {
       page: [{ _id: "task-1", user_id: "user-1", project_id: "project-1" }],
       isDone: true,
@@ -270,7 +269,7 @@ describe("projects", () => {
     const order = jest.fn<any>().mockReturnValue({ paginate });
     const projectEq = jest.fn<any>().mockReturnThis();
     const withIndex = jest.fn<any>((indexName, applyIndex) => {
-      expect(indexName).toBe("by_user_project_and_updated");
+      expect(indexName).toBe("by_project_and_updated");
       applyIndex({ eq: projectEq });
       return { order };
     });
@@ -289,8 +288,7 @@ describe("projects", () => {
       }),
     ).resolves.toEqual(page);
 
-    expect(projectEq).toHaveBeenNthCalledWith(1, "user_id", "user-1");
-    expect(projectEq).toHaveBeenNthCalledWith(2, "project_id", "project-1");
+    expect(projectEq).toHaveBeenCalledWith("project_id", "project-1");
     expect(order).toHaveBeenCalledWith("desc");
     expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 5 });
   });

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -907,9 +907,10 @@ export const getUserChats = query({
       // because the cursor advances past all fetched items)
       const result = await ctx.db
         .query("chats")
-        .withIndex("by_user_project_and_updated", (q) =>
-          q.eq("user_id", identity.subject).eq("project_id", undefined),
+        .withIndex("by_user_and_updated", (q) =>
+          q.eq("user_id", identity.subject),
         )
+        .filter((q) => q.eq(q.field("project_id"), undefined))
         .order("desc")
         .paginate(args.paginationOpts);
 

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -90,9 +90,7 @@ const detachNextProjectTasksBatch = async (
 
   const tasks = await ctx.db
     .query("chats")
-    .withIndex("by_user_project_and_updated", (q) =>
-      q.eq("user_id", userId).eq("project_id", projectId),
-    )
+    .withIndex("by_project_and_updated", (q) => q.eq("project_id", projectId))
     .take(PROJECT_TASK_DETACH_BATCH_SIZE + 1);
 
   for (const task of tasks.slice(0, PROJECT_TASK_DETACH_BATCH_SIZE)) {
@@ -330,15 +328,18 @@ export const getProjectThreads = query({
 
     const result = await ctx.db
       .query("chats")
-      .withIndex("by_user_project_and_updated", (q) =>
-        q.eq("user_id", identity.subject).eq("project_id", args.projectId),
+      .withIndex("by_project_and_updated", (q) =>
+        q.eq("project_id", args.projectId),
       )
       .order("desc")
       .paginate(args.paginationOpts);
 
+    const ownedPage = result.page.filter(
+      (chat) => chat.user_id === identity.subject,
+    );
     const branchedIds = [
       ...new Set(
-        result.page
+        ownedPage
           .map((chat) => chat.branched_from_chat_id)
           .filter((id): id is string => id !== undefined),
       ),
@@ -359,7 +360,7 @@ export const getProjectThreads = query({
 
     return {
       ...result,
-      page: result.page.map((chat) => ({
+      page: ownedPage.map((chat) => ({
         ...chat,
         ...(chat.branched_from_chat_id
           ? {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -115,11 +115,11 @@ export default defineSchema({
   })
     .index("by_chat_id", ["id"])
     .index("by_user_and_updated", ["user_id", "update_time"])
-    .index("by_user_project_and_updated", [
-      "user_id",
-      "project_id",
-      "update_time",
-    ])
+    .index("by_user_project_and_updated", {
+      fields: ["user_id", "project_id", "update_time"],
+      staged: true,
+    })
+    .index("by_project_and_updated", ["project_id", "update_time"])
     .index("by_user_and_active_trigger_run", [
       "user_id",
       "active_trigger_run_id",


### PR DESCRIPTION
## Summary

- mark `by_user_project_and_updated` as staged so its four-million-row backfill does not block deployment
- temporarily keep the already-built `by_project_and_updated` index for project pagination and deletion batches
- temporarily read normal Tasks through the existing user/update index while filtering project tasks
- retain the one-time deletion confirmation for the unused pinned-project index

## Why

The synchronous production backfill remained active near Vercel's 45-minute build limit. Convex recommends staged indexes for large tables so the backfill can finish asynchronously without blocking deployment. After the staged index becomes ready, a final follow-up will enable it, switch all sidebar reads back to the composite index, remove the temporary project-only index, and remove the deployment override.

## Validation

- focused Convex tests: 11 passed
- `pnpm typecheck`
- focused ESLint and Prettier checks
- full test suite: 282 suites, 2,784 tests
- `git diff --check`
