### PR TITLE
Avoid blocking sidebar index deploys

### DIFF
--- a/convex/__tests__/projects.test.ts
+++ b/convex/__tests__/projects.test.ts
@@ -222,10 +222,11 @@ describe("projects", () => {
     const tasks = [{ _id: "task-1" }, { _id: "task-2" }];
     const take = jest.fn<any>().mockResolvedValue(tasks);
     const projectEq = jest.fn<any>().mockReturnThis();
+    const filter = jest.fn<any>().mockReturnValue({ take });
     const withIndex = jest.fn<any>((indexName, applyIndex) => {
-      expect(indexName).toBe("by_project_and_updated");
+      expect(indexName).toBe("by_user_and_updated");
       applyIndex({ eq: projectEq });
-      return { take };
+      return { filter };
     });
     const patch = jest.fn<any>().mockResolvedValue(undefined);
     const deleteDocument = jest.fn<any>().mockResolvedValue(undefined);
@@ -256,10 +257,11 @@ describe("projects", () => {
     expect(patch).toHaveBeenCalledWith("task-2", { project_id: undefined });
     expect(deleteDocument).toHaveBeenCalledWith("project-1");
     expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
-    expect(projectEq).toHaveBeenCalledWith("project_id", "project-1");
+    expect(projectEq).toHaveBeenCalledWith("user_id", "user-1");
+    expect(filter).toHaveBeenCalledWith(expect.any(Function));
   });
 
-  it("paginates project tasks through the temporary project index", async () => {
+  it("paginates project tasks through the existing user index", async () => {
     const page = {
       page: [{ _id: "task-1", user_id: "user-1", project_id: "project-1" }],
       isDone: true,
@@ -267,11 +269,12 @@ describe("projects", () => {
     };
     const paginate = jest.fn<any>().mockResolvedValue(page);
     const order = jest.fn<any>().mockReturnValue({ paginate });
+    const filter = jest.fn<any>().mockReturnValue({ order });
     const projectEq = jest.fn<any>().mockReturnThis();
     const withIndex = jest.fn<any>((indexName, applyIndex) => {
-      expect(indexName).toBe("by_project_and_updated");
+      expect(indexName).toBe("by_user_and_updated");
       applyIndex({ eq: projectEq });
-      return { order };
+      return { filter };
     });
     const ctx = {
       auth: authenticated,
@@ -288,7 +291,8 @@ describe("projects", () => {
       }),
     ).resolves.toEqual(page);
 
-    expect(projectEq).toHaveBeenCalledWith("project_id", "project-1");
+    expect(projectEq).toHaveBeenCalledWith("user_id", "user-1");
+    expect(filter).toHaveBeenCalledWith(expect.any(Function));
     expect(order).toHaveBeenCalledWith("desc");
     expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 5 });
   });

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -90,7 +90,8 @@ const detachNextProjectTasksBatch = async (
 
   const tasks = await ctx.db
     .query("chats")
-    .withIndex("by_project_and_updated", (q) => q.eq("project_id", projectId))
+    .withIndex("by_user_and_updated", (q) => q.eq("user_id", userId))
+    .filter((q) => q.eq(q.field("project_id"), projectId))
     .take(PROJECT_TASK_DETACH_BATCH_SIZE + 1);
 
   for (const task of tasks.slice(0, PROJECT_TASK_DETACH_BATCH_SIZE)) {
@@ -328,18 +329,16 @@ export const getProjectThreads = query({
 
     const result = await ctx.db
       .query("chats")
-      .withIndex("by_project_and_updated", (q) =>
-        q.eq("project_id", args.projectId),
+      .withIndex("by_user_and_updated", (q) =>
+        q.eq("user_id", identity.subject),
       )
+      .filter((q) => q.eq(q.field("project_id"), args.projectId))
       .order("desc")
       .paginate(args.paginationOpts);
 
-    const ownedPage = result.page.filter(
-      (chat) => chat.user_id === identity.subject,
-    );
     const branchedIds = [
       ...new Set(
-        ownedPage
+        result.page
           .map((chat) => chat.branched_from_chat_id)
           .filter((id): id is string => id !== undefined),
       ),
@@ -360,7 +359,7 @@ export const getProjectThreads = query({
 
     return {
       ...result,
-      page: ownedPage.map((chat) => ({
+      page: result.page.map((chat) => ({
         ...chat,
         ...(chat.branched_from_chat_id
           ? {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -119,7 +119,6 @@ export default defineSchema({
       fields: ["user_id", "project_id", "update_time"],
       staged: true,
     })
-    .index("by_project_and_updated", ["project_id", "update_time"])
     .index("by_user_and_active_trigger_run", [
       "user_id",
       "active_trigger_run_id",


### PR DESCRIPTION
## Summary

- remove the project-only index from the staged migration so no new large index blocks deployment
- temporarily use the existing `by_user_and_updated` index plus project filtering for normal Tasks, project Tasks, and project deletion batches
- keep `by_user_project_and_updated` staged so it continues backfilling asynchronously

## Why

The previous production attempt had already removed `by_project_and_updated`, so reintroducing it caused another synchronous four-million-row backfill. This correction makes every temporary query depend only on an existing production index. Once the staged composite index is ready, the final optimized queries can be enabled without another backfill.

## Validation

- focused Convex tests: 11 passed
- `pnpm typecheck`
- focused ESLint and Prettier checks
- full test suite: 282 suites, 2,784 tests
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project thread pagination and filtering for more accurate results.
  * Fixed task handling when deleting a project so associated tasks are preserved correctly.
  * Improved project update querying to ensure results are scoped correctly and ordered reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->