### PR TITLE
Restore guarded Convex deploys

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "npx convex deploy --allow-deleting-large-indexes --cmd 'pnpm run build'"
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }


### PR DESCRIPTION
## Summary

- remove the temporary `--allow-deleting-large-indexes` Vercel build override
- restore the guarded Convex deploy command configured in project settings

## Why

The intended redundant index deletion completed successfully in production. Keeping the flag would weaken safety for unrelated future schema changes, so this cleanup removes it immediately after the audited one-time deployment.

## Validation

- production deployment with the intended index deletion reached Ready
- `pnpm exec prettier --check vercel.json`
- `pnpm typecheck`
- `pnpm test` (282 suites, 2,784 tests)
- `git diff --check`
