### PR TITLE
Enable optimized sidebar chat index

### DIFF
--- a/convex/__tests__/chats.getUserChats.test.ts
+++ b/convex/__tests__/chats.getUserChats.test.ts
@@ -174,14 +174,11 @@ describe("getUserChats", () => {
     };
     const paginate = jest.fn<any>().mockResolvedValue(page);
     const regularOrder = jest.fn<any>().mockReturnValue({ paginate });
-    const regularFilter = jest.fn<any>().mockReturnValue({
-      order: regularOrder,
-    });
     const regularEq = jest.fn<any>().mockReturnThis();
     const regularWithIndex = jest.fn<any>((indexName, applyIndex) => {
-      expect(indexName).toBe("by_user_and_updated");
+      expect(indexName).toBe("by_user_project_and_updated");
       applyIndex({ eq: regularEq });
-      return { filter: regularFilter };
+      return { order: regularOrder };
     });
     const ctx = {
       auth: {
@@ -208,6 +205,6 @@ describe("getUserChats", () => {
     expect(pinnedEq).toHaveBeenCalledWith("user_id", "user-123");
     expect(gt).toHaveBeenCalledWith("pinned_at", 0);
     expect(regularEq).toHaveBeenCalledWith("user_id", "user-123");
-    expect(regularFilter).toHaveBeenCalledWith(expect.any(Function));
+    expect(regularEq).toHaveBeenCalledWith("project_id", undefined);
   });
 });

--- a/convex/__tests__/projects.test.ts
+++ b/convex/__tests__/projects.test.ts
@@ -222,11 +222,10 @@ describe("projects", () => {
     const tasks = [{ _id: "task-1" }, { _id: "task-2" }];
     const take = jest.fn<any>().mockResolvedValue(tasks);
     const projectEq = jest.fn<any>().mockReturnThis();
-    const filter = jest.fn<any>().mockReturnValue({ take });
     const withIndex = jest.fn<any>((indexName, applyIndex) => {
-      expect(indexName).toBe("by_user_and_updated");
+      expect(indexName).toBe("by_user_project_and_updated");
       applyIndex({ eq: projectEq });
-      return { filter };
+      return { take };
     });
     const patch = jest.fn<any>().mockResolvedValue(undefined);
     const deleteDocument = jest.fn<any>().mockResolvedValue(undefined);
@@ -257,11 +256,11 @@ describe("projects", () => {
     expect(patch).toHaveBeenCalledWith("task-2", { project_id: undefined });
     expect(deleteDocument).toHaveBeenCalledWith("project-1");
     expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
-    expect(projectEq).toHaveBeenCalledWith("user_id", "user-1");
-    expect(filter).toHaveBeenCalledWith(expect.any(Function));
+    expect(projectEq).toHaveBeenNthCalledWith(1, "user_id", "user-1");
+    expect(projectEq).toHaveBeenNthCalledWith(2, "project_id", "project-1");
   });
 
-  it("paginates project tasks through the existing user index", async () => {
+  it("paginates project tasks through the user and project index", async () => {
     const page = {
       page: [{ _id: "task-1", user_id: "user-1", project_id: "project-1" }],
       isDone: true,
@@ -269,12 +268,11 @@ describe("projects", () => {
     };
     const paginate = jest.fn<any>().mockResolvedValue(page);
     const order = jest.fn<any>().mockReturnValue({ paginate });
-    const filter = jest.fn<any>().mockReturnValue({ order });
     const projectEq = jest.fn<any>().mockReturnThis();
     const withIndex = jest.fn<any>((indexName, applyIndex) => {
-      expect(indexName).toBe("by_user_and_updated");
+      expect(indexName).toBe("by_user_project_and_updated");
       applyIndex({ eq: projectEq });
-      return { filter };
+      return { order };
     });
     const ctx = {
       auth: authenticated,
@@ -291,8 +289,8 @@ describe("projects", () => {
       }),
     ).resolves.toEqual(page);
 
-    expect(projectEq).toHaveBeenCalledWith("user_id", "user-1");
-    expect(filter).toHaveBeenCalledWith(expect.any(Function));
+    expect(projectEq).toHaveBeenNthCalledWith(1, "user_id", "user-1");
+    expect(projectEq).toHaveBeenNthCalledWith(2, "project_id", "project-1");
     expect(order).toHaveBeenCalledWith("desc");
     expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 5 });
   });

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -907,10 +907,9 @@ export const getUserChats = query({
       // because the cursor advances past all fetched items)
       const result = await ctx.db
         .query("chats")
-        .withIndex("by_user_and_updated", (q) =>
-          q.eq("user_id", identity.subject),
+        .withIndex("by_user_project_and_updated", (q) =>
+          q.eq("user_id", identity.subject).eq("project_id", undefined),
         )
-        .filter((q) => q.eq(q.field("project_id"), undefined))
         .order("desc")
         .paginate(args.paginationOpts);
 

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -90,8 +90,9 @@ const detachNextProjectTasksBatch = async (
 
   const tasks = await ctx.db
     .query("chats")
-    .withIndex("by_user_and_updated", (q) => q.eq("user_id", userId))
-    .filter((q) => q.eq(q.field("project_id"), projectId))
+    .withIndex("by_user_project_and_updated", (q) =>
+      q.eq("user_id", userId).eq("project_id", projectId),
+    )
     .take(PROJECT_TASK_DETACH_BATCH_SIZE + 1);
 
   for (const task of tasks.slice(0, PROJECT_TASK_DETACH_BATCH_SIZE)) {
@@ -329,10 +330,9 @@ export const getProjectThreads = query({
 
     const result = await ctx.db
       .query("chats")
-      .withIndex("by_user_and_updated", (q) =>
-        q.eq("user_id", identity.subject),
+      .withIndex("by_user_project_and_updated", (q) =>
+        q.eq("user_id", identity.subject).eq("project_id", args.projectId),
       )
-      .filter((q) => q.eq(q.field("project_id"), args.projectId))
       .order("desc")
       .paginate(args.paginationOpts);
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -115,10 +115,11 @@ export default defineSchema({
   })
     .index("by_chat_id", ["id"])
     .index("by_user_and_updated", ["user_id", "update_time"])
-    .index("by_user_project_and_updated", {
-      fields: ["user_id", "project_id", "update_time"],
-      staged: true,
-    })
+    .index("by_user_project_and_updated", [
+      "user_id",
+      "project_id",
+      "update_time",
+    ])
     .index("by_user_and_active_trigger_run", [
       "user_id",
       "active_trigger_run_id",


### PR DESCRIPTION
## Summary

- enable the staged `by_user_project_and_updated` index
- switch normal Tasks, project Tasks, and batched project deletion to the composite equality-prefixed index
- remove temporary post-filtering through `by_user_and_updated`

## Why

The staged rollout allowed the four-million-row index to backfill without blocking production. This final step enables that index and restores the intended optimal sidebar query paths while keeping only one new `chats` index.

## Validation

- focused Convex tests: 11 passed
- `pnpm typecheck`
- focused ESLint and Prettier checks
- full test suite: 282 suites, 2,784 tests
- `git diff --check`
