### PR TITLE
Deduplicate upgrade CTA impressions across devices

### DIFF
--- a/lib/__tests__/paid-funnel.test.ts
+++ b/lib/__tests__/paid-funnel.test.ts
@@ -3,6 +3,7 @@ import {
   checkoutStartedInsertId,
   normalizePaidFunnelLabel,
   paidFunnelProperties,
+  upgradeCtaImpressionInsertId,
 } from "@/lib/analytics/paid-funnel";
 
 describe("paid funnel analytics helpers", () => {
@@ -28,5 +29,42 @@ describe("paid funnel analytics helpers", () => {
     expect(checkoutStartedInsertId("ca_attempt_123")).toBe(
       "checkout_started:ca_attempt_123",
     );
+  });
+
+  it("keeps upgrade impression insert IDs stable per identified-user UTC day", () => {
+    const impression = {
+      distinctId: "user_123",
+      surface: "pricing_dialog",
+      source: "plan_cards",
+      utcDay: "2026-07-18",
+    };
+
+    expect(upgradeCtaImpressionInsertId(impression)).toBe(
+      upgradeCtaImpressionInsertId(impression),
+    );
+    expect(
+      upgradeCtaImpressionInsertId({
+        ...impression,
+        utcDay: "2026-07-19",
+      }),
+    ).not.toBe(upgradeCtaImpressionInsertId(impression));
+    expect(
+      upgradeCtaImpressionInsertId({
+        ...impression,
+        distinctId: "user_456",
+      }),
+    ).not.toBe(upgradeCtaImpressionInsertId(impression));
+    expect(
+      upgradeCtaImpressionInsertId({
+        ...impression,
+        surface: "rate_limit_warning",
+      }),
+    ).not.toBe(upgradeCtaImpressionInsertId(impression));
+    expect(
+      upgradeCtaImpressionInsertId({
+        ...impression,
+        source: "limit_pressure",
+      }),
+    ).not.toBe(upgradeCtaImpressionInsertId(impression));
   });
 });

--- a/lib/analytics/__tests__/client.test.ts
+++ b/lib/analytics/__tests__/client.test.ts
@@ -31,6 +31,7 @@ describe("client analytics", () => {
   beforeEach(() => {
     window.localStorage.clear();
     mockCapture.mockClear();
+    mockPostHog.get_distinct_id.mockReturnValue("user_123");
     jest.useFakeTimers().setSystemTime(new Date("2026-07-14T12:00:00Z"));
   });
 
@@ -44,6 +45,16 @@ describe("client analytics", () => {
     expect(captureUpgradeCtaImpression(properties)).toBe(true);
     expect(captureUpgradeCtaImpression(properties)).toBe(false);
     expect(mockCapture).toHaveBeenCalledTimes(1);
+    const firstUuid = mockCapture.mock.calls[0]?.[2]?.uuid;
+    expect(mockCapture).toHaveBeenLastCalledWith(
+      "upgrade_cta_impressed",
+      expect.objectContaining({
+        impression_dedupe_scope: "identified_user_surface_source_utc_day",
+        impression_dedupe_version: 1,
+        impression_utc_day: "2026-07-14",
+      }),
+      { uuid: expect.stringMatching(/^[0-9a-f-]{36}$/i) },
+    );
 
     expect(
       captureUpgradeCtaImpression({
@@ -52,9 +63,35 @@ describe("client analytics", () => {
       }),
     ).toBe(true);
     expect(mockCapture).toHaveBeenCalledTimes(2);
+    expect(mockCapture.mock.calls[1]?.[2]?.uuid).not.toBe(firstUuid);
 
     jest.setSystemTime(new Date("2026-07-15T00:00:01Z"));
     expect(captureUpgradeCtaImpression(properties)).toBe(true);
     expect(mockCapture).toHaveBeenCalledTimes(3);
+    expect(mockCapture.mock.calls[2]?.[2]?.uuid).not.toBe(firstUuid);
+  });
+
+  it("uses one ingestion UUID across devices for the same identified user key", () => {
+    const properties = {
+      surface: "pricing_dialog",
+      source: "plan_cards",
+      from_tier: "free",
+    };
+
+    expect(captureUpgradeCtaImpression(properties)).toBe(true);
+    const firstDeviceUuid = mockCapture.mock.calls[0]?.[2]?.uuid;
+
+    // A different device has no access to the first device's local storage.
+    window.localStorage.clear();
+
+    expect(captureUpgradeCtaImpression(properties)).toBe(true);
+    const secondDeviceUuid = mockCapture.mock.calls[1]?.[2]?.uuid;
+
+    expect(secondDeviceUuid).toBe(firstDeviceUuid);
+
+    mockPostHog.get_distinct_id.mockReturnValue("user_456");
+    window.localStorage.clear();
+    expect(captureUpgradeCtaImpression(properties)).toBe(true);
+    expect(mockCapture.mock.calls[2]?.[2]?.uuid).not.toBe(firstDeviceUuid);
   });
 });

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -1,10 +1,13 @@
 "use client";
 
 import type posthogJs from "posthog-js";
+import { v5 as uuidv5 } from "uuid";
 import {
   PAID_FUNNEL_EVENTS,
+  UPGRADE_CTA_IMPRESSION_DEDUPE,
   createCheckoutAttemptId,
   paidFunnelProperties,
+  upgradeCtaImpressionInsertId,
 } from "@/lib/analytics/paid-funnel";
 
 type ClientAnalyticsProperties = Record<string, unknown>;
@@ -12,6 +15,7 @@ type ClientAnalyticsProperties = Record<string, unknown>;
 type PostHogClient = typeof posthogJs & {
   get_session_id?: () => string;
 };
+type PostHogCaptureOptions = Parameters<PostHogClient["capture"]>[2];
 
 let posthogClient: PostHogClient | null = null;
 let posthogImportPromise: Promise<PostHogClient> | null = null;
@@ -50,6 +54,7 @@ function getReadyPostHogClient() {
 export function captureAuthenticatedEvent(
   event: string,
   properties: ClientAnalyticsProperties = {},
+  options?: PostHogCaptureOptions,
 ) {
   if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return false;
 
@@ -60,7 +65,11 @@ export function captureAuthenticatedEvent(
   }
 
   try {
-    posthog.capture(event, properties);
+    if (options) {
+      posthog.capture(event, properties, options);
+    } else {
+      posthog.capture(event, properties);
+    }
     return true;
   } catch {
     return false;
@@ -102,8 +111,9 @@ export function captureUpgradeCtaImpression(
   }
 
   const day = new Date().toISOString().slice(0, 10);
+  const distinctId = posthog.get_distinct_id();
   const dedupeKey = [
-    posthog.get_distinct_id(),
+    distinctId,
     properties.surface,
     properties.source ?? "",
   ].join(":");
@@ -129,7 +139,23 @@ export function captureUpgradeCtaImpression(
 
   const captured = captureAuthenticatedEvent(
     PAID_FUNNEL_EVENTS.upgradeCtaImpressed,
-    paidFunnelProperties(properties),
+    paidFunnelProperties({
+      ...properties,
+      impression_dedupe_scope: UPGRADE_CTA_IMPRESSION_DEDUPE.scope,
+      impression_dedupe_version: UPGRADE_CTA_IMPRESSION_DEDUPE.version,
+      impression_utc_day: day,
+    }),
+    {
+      uuid: uuidv5(
+        upgradeCtaImpressionInsertId({
+          distinctId,
+          surface: properties.surface,
+          source: properties.source,
+          utcDay: day,
+        }),
+        uuidv5.URL,
+      ),
+    },
   );
   if (!captured) return false;
 

--- a/lib/analytics/paid-funnel.ts
+++ b/lib/analytics/paid-funnel.ts
@@ -1,5 +1,10 @@
 export const PAID_FUNNEL_EVENT_VERSION = 1;
 
+export const UPGRADE_CTA_IMPRESSION_DEDUPE = {
+  scope: "identified_user_surface_source_utc_day",
+  version: 1,
+} as const;
+
 export const PAID_FUNNEL_EVENTS = {
   upgradeCtaImpressed: "upgrade_cta_impressed",
   upgradeCtaClicked: "upgrade_cta_clicked",
@@ -32,6 +37,27 @@ export function cancellationCompletionInsertId(
 
 export function checkoutStartedInsertId(checkoutAttemptId: string): string {
   return `${PAID_FUNNEL_EVENTS.checkoutStarted}:${checkoutAttemptId}`;
+}
+
+export function upgradeCtaImpressionInsertId({
+  distinctId,
+  surface,
+  source,
+  utcDay,
+}: {
+  distinctId: string;
+  surface: string;
+  source?: string;
+  utcDay: string;
+}): string {
+  return JSON.stringify([
+    PAID_FUNNEL_EVENTS.upgradeCtaImpressed,
+    UPGRADE_CTA_IMPRESSION_DEDUPE.version,
+    distinctId,
+    surface,
+    source ?? null,
+    utcDay,
+  ]);
 }
 
 export type PaidFunnelPlan =


### PR DESCRIPTION
## Summary

- assign `upgrade_cta_impressed` a deterministic PostHog event UUID for each identified user, surface, source, and UTC day
- retain browser-local suppression to avoid unnecessary capture requests while making ingestion dedupe authoritative across devices and storage failures
- add a versioned, queryable dedupe scope/day without adding prompts, content, emails, or other user data
- cover same-device suppression, cross-device UUID stability, and key changes in regression tests

## Why

PR #895 reduced duplicate impressions with browser-local storage, but separate devices cannot share that state. HAC-48 measured 723 duplicate impressions across the two steady-state UTC days after rollout, with 91.8% of those duplicates spanning multiple device IDs.

PostHog supports a caller-provided event UUID for ingestion idempotency. Deriving that UUID from the existing authenticated distinct ID plus surface, source, and UTC day enforces the intended once-per-user contract regardless of device.

## Validation

- `corepack pnpm jest lib/analytics/__tests__/client.test.ts lib/__tests__/paid-funnel.test.ts --runInBand`
- `corepack pnpm exec eslint lib/analytics/paid-funnel.ts lib/analytics/client.ts lib/analytics/__tests__/client.test.ts lib/__tests__/paid-funnel.test.ts`
- `corepack pnpm typecheck`
- commit hook: 282 test suites / 2,786 tests passed

## Production verification after deploy

1. For one authenticated test user on one UTC day, expose the same upgrade CTA surface/source repeatedly in one browser. PostHog should retain one `upgrade_cta_impressed` row for that user/surface/source/day.
2. Sign into a second device or browser as the same user and expose the same surface/source. The retained count and event UUID should remain one.
3. Change the surface or source, then repeat after the next UTC day. Each changed key should produce its own event.
4. Query only `impression_dedupe_scope = identified_user_surface_source_utc_day` and `impression_dedupe_version = 1` when validating the new contract.

Closes [HAC-48](https://linear.app/hackerai/issue/HAC-48/close-remaining-cross-device-upgrade-cta-impression-duplicates).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved upgrade CTA impression tracking to prevent duplicate counts within the same UTC day.
  - Impression records now remain consistent across devices for the same identified user, while changes in user, surface, source, or day are tracked separately.
  - Enhanced analytics event handling for more reliable ingestion and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->