### PR TITLE
Align sidebar task loading indicator

### DIFF
--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -142,11 +142,11 @@ const ChatItem: React.FC<ChatItemProps> = ({
     isStreaming && (!isHovered || isMobile) && (!isDropdownOpen || isMobile);
   const rightPaddingClass =
     isMobile && showActions && showStreamingIndicator
-      ? "pr-14"
+      ? "pr-[4.5rem]"
       : showActions
         ? "pr-9"
         : showStreamingIndicator
-          ? "pr-7"
+          ? "pr-9"
           : "";
   const rowStartPaddingClass = indentContent ? "ps-6" : "ps-2";
 
@@ -458,11 +458,13 @@ const ChatItem: React.FC<ChatItemProps> = ({
         aria-hidden={!showActions && !showStreamingIndicator}
       >
         {showStreamingIndicator ? (
-          <LoaderCircle
-            className="size-4 flex-shrink-0 animate-spin text-muted-foreground"
-            data-testid="chat-item-streaming-icon"
-            aria-hidden="true"
-          />
+          <div className="flex size-8 flex-shrink-0 items-center justify-center">
+            <LoaderCircle
+              className="size-4 animate-spin text-muted-foreground"
+              data-testid="chat-item-streaming-icon"
+              aria-hidden="true"
+            />
+          </div>
         ) : null}
         {showActions ? (
           <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>

--- a/app/components/__tests__/ChatItem.projects.test.tsx
+++ b/app/components/__tests__/ChatItem.projects.test.tsx
@@ -17,8 +17,9 @@ jest.mock("@/app/contexts/GlobalState", () => ({
     setOptimisticChatId: jest.fn(),
   }),
 }));
+const mockUseIsMobile = jest.fn(() => false);
 jest.mock("@/hooks/use-mobile", () => ({
-  useIsMobile: () => false,
+  useIsMobile: () => mockUseIsMobile(),
 }));
 jest.mock("convex/react", () => ({
   useMutation: () => jest.fn(),
@@ -49,6 +50,7 @@ const ChatItem = require("../ChatItem")
 describe("ChatItem project actions", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseIsMobile.mockReturnValue(false);
   });
 
   it("reveals an accessible move action when the row receives keyboard focus", async () => {
@@ -130,6 +132,19 @@ describe("ChatItem project actions", () => {
     expect(
       screen.getByText("Running task").parentElement?.parentElement,
     ).toHaveClass("pr-9");
+  });
+
+  it("reserves space for streaming and task actions on mobile", () => {
+    mockUseIsMobile.mockReturnValue(true);
+    render(<ChatItem id="chat-1" title="Running task" isStreaming />);
+
+    expect(
+      screen.getByText("Running task").parentElement?.parentElement,
+    ).toHaveClass("pr-[4.5rem]");
+    expect(
+      screen.getByRole("button", { name: "Open task options" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("chat-item-streaming-icon")).toBeInTheDocument();
   });
 
   it("hides the passive pin icon while keeping the unpin action", async () => {

--- a/app/components/__tests__/ChatItem.projects.test.tsx
+++ b/app/components/__tests__/ChatItem.projects.test.tsx
@@ -117,6 +117,21 @@ describe("ChatItem project actions", () => {
     expect(screen.getByTestId("chat-item-chat-2")).not.toHaveClass("p-2");
   });
 
+  it("centers the streaming indicator in the task action slot", () => {
+    render(<ChatItem id="chat-1" title="Running task" isStreaming />);
+
+    const streamingIcon = screen.getByTestId("chat-item-streaming-icon");
+    expect(streamingIcon.parentElement).toHaveClass(
+      "flex",
+      "size-8",
+      "items-center",
+      "justify-center",
+    );
+    expect(
+      screen.getByText("Running task").parentElement?.parentElement,
+    ).toHaveClass("pr-9");
+  });
+
   it("hides the passive pin icon while keeping the unpin action", async () => {
     const user = userEvent.setup();
     render(<ChatItem id="chat-1" title="Pinned target" isPinned />);


### PR DESCRIPTION
## What changed

- centers the streaming loader in the same 32px sidebar action slot as the three-dot task menu
- reserves matching title space so the indicator does not crowd or overlap the task title
- preserves enough room when both loader and actions are visible on mobile
- adds focused regression coverage for the alignment contract

## Root cause

The three-dot action used a 32px button while the passive streaming loader was a bare 16px icon anchored to the same right edge. Their centers therefore differed by 8px, placing the loader too close to the sidebar border.

## Validation

- `pnpm test -- --runInBand app/components/__tests__/ChatItem.projects.test.tsx`
- `pnpm exec eslint app/components/ChatItem.tsx app/components/__tests__/ChatItem.projects.test.tsx`
- `pnpm exec prettier --check app/components/ChatItem.tsx app/components/__tests__/ChatItem.projects.test.tsx`
- `pnpm typecheck`
- full pre-commit test suite: 282 suites, 2,785 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat action-area spacing, including the reserved layout for streaming states.
  * Centered the streaming/loading indicator within the action area for a more consistent appearance across screen sizes.
* **Tests**
  * Updated ChatItem UI tests to better control mobile vs. non-mobile behavior and to assert streaming-state layout and element presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->