### PR TITLE
Recover ended sessions in root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,7 @@ import { AgentApprovalProvider } from "./contexts/AgentApprovalContext";
 import { PostHogProvider } from "./providers";
 import { DataStreamProvider } from "./components/DataStreamProvider";
 import { ChunkLoadRecovery } from "./components/ChunkLoadRecovery";
+import { resolveClientInitialAuth } from "@/lib/auth/initial-auth";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -101,8 +102,9 @@ async function getInitialAuth() {
   }
 
   // Never serialize the server-only access token into the client provider.
-  const { accessToken, ...initialAuth } = await withAuth();
-  return initialAuth;
+  // An ended refresh session is equivalent to being signed out; hydrating that
+  // state keeps the root layout available so the user can sign in again.
+  return resolveClientInitialAuth(withAuth);
 }
 
 export default async function RootLayout({

--- a/components/__tests__/ConvexClientProvider.contracts.test.ts
+++ b/components/__tests__/ConvexClientProvider.contracts.test.ts
@@ -18,7 +18,7 @@ describe("ConvexClientProvider auth recovery contracts", () => {
 
   it("hydrates AuthKit from server auth without serializing the access token", () => {
     expect(rootLayoutSource).toContain(
-      "const { accessToken, ...initialAuth } = await withAuth();",
+      "return resolveClientInitialAuth(withAuth);",
     );
     expect(rootLayoutSource).toContain(
       'if (!requestHeaders.has("x-workos-middleware"))',

--- a/lib/auth/__tests__/initial-auth.test.ts
+++ b/lib/auth/__tests__/initial-auth.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import { resolveClientInitialAuth } from "../initial-auth";
+
+describe("resolveClientInitialAuth", () => {
+  it("preserves the ordinary signed-out state", async () => {
+    await expect(
+      resolveClientInitialAuth(
+        jest.fn<any>().mockResolvedValue({ user: null }),
+      ),
+    ).resolves.toEqual({ user: null });
+  });
+
+  it("hydrates an ended refresh session as signed out", async () => {
+    const error = Object.assign(
+      new Error("Failed to refresh session: Error: invalid_grant"),
+      {
+        name: "TokenRefreshError",
+        cause: {
+          error: "invalid_grant",
+          errorDescription: "Session has already ended.",
+        },
+      },
+    );
+
+    await expect(
+      resolveClientInitialAuth(
+        jest.fn<() => Promise<never>>().mockRejectedValue(error),
+      ),
+    ).resolves.toEqual({ user: null });
+  });
+
+  it("removes the server-only access token from authenticated state", async () => {
+    await expect(
+      resolveClientInitialAuth(
+        jest.fn<any>().mockResolvedValue({
+          user: { id: "user-1" },
+          sessionId: "session-1",
+          accessToken: "server-secret",
+        }),
+      ),
+    ).resolves.toEqual({
+      user: { id: "user-1" },
+      sessionId: "session-1",
+    });
+  });
+
+  it("keeps unrelated authentication failures visible", async () => {
+    const error = new Error("JWKS request timed out");
+
+    await expect(
+      resolveClientInitialAuth(
+        jest.fn<() => Promise<never>>().mockRejectedValue(error),
+      ),
+    ).rejects.toBe(error);
+  });
+
+  it("does not treat other invalid_grant failures as ended sessions", async () => {
+    const error = Object.assign(new Error("Error: invalid_grant"), {
+      error: "invalid_grant",
+      errorDescription: "Invalid code verifier.",
+    });
+
+    await expect(
+      resolveClientInitialAuth(
+        jest.fn<() => Promise<never>>().mockRejectedValue(error),
+      ),
+    ).rejects.toBe(error);
+  });
+});

--- a/lib/auth/initial-auth.ts
+++ b/lib/auth/initial-auth.ts
@@ -1,0 +1,22 @@
+import type { NoUserInfo, UserInfo } from "@workos-inc/authkit-nextjs";
+import { isEndedSessionRefreshError } from "./expected-auth-errors";
+
+type ServerAuth = UserInfo | NoUserInfo;
+
+export type ClientInitialAuth =
+  Omit<UserInfo, "accessToken"> | Omit<NoUserInfo, "accessToken">;
+
+export async function resolveClientInitialAuth(
+  loadAuth: () => Promise<ServerAuth>,
+): Promise<ClientInitialAuth> {
+  try {
+    const { accessToken: _serverOnlyAccessToken, ...initialAuth } =
+      await loadAuth();
+    return initialAuth;
+  } catch (error) {
+    if (isEndedSessionRefreshError(error)) {
+      return { user: null };
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- hydrate AuthKit as signed out when the root layout encounters the exact terminal ended-session refresh error
- continue surfacing unrelated authentication failures, including other `invalid_grant` causes
- keep server-only access tokens out of the client provider and cover signed-in, signed-out, terminal-session, and near-miss paths

## Production evidence
The frozen production audit window was `2026-07-17T20:02:03Z` through `2026-07-18T20:02:03Z`.

Vercel recorded 9 root-route HTTP 500 responses across 7 sessions and 6 users with:

`TokenRefreshError: Failed to refresh session: invalid_grant; Session has already ended`

The signature appeared across multiple production deployments and has recurred in prior daily audits, so it is not tied to the current sidebar release. API auth helpers already translate this exact terminal state to unauthenticated, but `app/layout.tsx` called `withAuth()` without the same boundary and let the error fail the entire root layout.

## Change
`resolveClientInitialAuth` removes the server-only access token from normal authenticated results. Only `isEndedSessionRefreshError` maps to `{ user: null }`, allowing the existing signed-out UI and sign-in flow to render. Invalid code-verifier errors, JWKS failures, and all other auth exceptions still throw.

## Validation
- `corepack pnpm jest lib/auth/__tests__/initial-auth.test.ts lib/auth/__tests__/expected-auth-errors.test.ts components/__tests__/ConvexClientProvider.contracts.test.ts --runInBand` — 3 suites / 13 tests passed
- `corepack pnpm typecheck` — passed
- changed-file ESLint — passed
- changed-file Prettier check — passed
- `corepack pnpm test --runInBand` — 283 suites / 2,793 tests passed
- commit hooks — typecheck plus 283 suites / 2,793 tests passed

The first commit-hook attempt had one unrelated `robots.txt` Jest worker exit with `SIGSEGV`; that suite passed in isolation, the full serial suite passed, and the successful hook rerun passed the complete suite.

## Manual verification
After deployment:
1. Open `/` with a WorkOS session whose refresh token now returns `invalid_grant` with `Session has already ended`.
2. Confirm the page renders the existing signed-out experience instead of HTTP 500.
3. Click **Sign in** and confirm the normal login flow succeeds.
4. Confirm an unrelated auth failure still surfaces rather than being converted to signed out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication initialization when a refresh session has ended, allowing the app to recognize the signed-out state gracefully.
  * Prevented stale server-only authentication credentials from being exposed to the client.
  * Preserved proper error reporting for unrelated authentication failures.
* **Tests**
  * Added coverage for signed-out, authenticated, expired-session, and authentication-error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->