### PR TITLE
Fix Desktop Agent connection gate

### DIFF
--- a/app/components/ChatInput/AgentUpgradeDialog.tsx
+++ b/app/components/ChatInput/AgentUpgradeDialog.tsx
@@ -8,19 +8,35 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog";
-import { Download, Laptop, Cloud } from "lucide-react";
+import {
+  Check,
+  Cloud,
+  Download,
+  Laptop,
+  LoaderCircle,
+  RefreshCw,
+} from "lucide-react";
 import { openSettingsDialog } from "@/lib/utils/settings-dialog";
 import { redirectToPricing } from "@/app/hooks/usePricingDialog";
 import { captureUpgradeCtaImpression } from "@/lib/analytics/client";
+import type { DesktopBridgeStatus } from "@/app/hooks/useSandboxPreference";
 
 export interface AgentUpgradeDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  isDesktopEnvironment: boolean;
+  desktopBridgeStatus: DesktopBridgeStatus;
+  onRetryDesktopBridge: () => void;
+  onUseConnectedDesktop: () => void;
 }
 
 export function AgentUpgradeDialog({
   open,
   onOpenChange,
+  isDesktopEnvironment,
+  desktopBridgeStatus,
+  onRetryDesktopBridge,
+  onUseConnectedDesktop,
 }: AgentUpgradeDialogProps) {
   const capturedImpressionRef = useRef(false);
 
@@ -45,32 +61,93 @@ export function AgentUpgradeDialog({
         <DialogHeader>
           <DialogTitle>Use Agent mode</DialogTitle>
           <DialogDescription>
-            Connect a local sandbox for free, or upgrade for cloud Agent mode
-            with higher limits.
+            {isDesktopEnvironment
+              ? desktopBridgeStatus === "failed"
+                ? "HackerAI Desktop is open, but its local sandbox could not connect."
+                : desktopBridgeStatus === "connected"
+                  ? "HackerAI Desktop is connected and ready for local Agent mode."
+                  : "HackerAI Desktop is connecting its local sandbox."
+              : "Connect a local sandbox for free, or upgrade for cloud Agent mode with higher limits."}
           </DialogDescription>
         </DialogHeader>
 
         <div className="flex flex-col gap-3 pt-1">
           {/* Local sandbox options */}
           <div className="rounded-lg border p-1 space-y-1">
-            <button
-              onClick={() => {
-                onOpenChange(false);
-                window.open("/download", "_blank");
-              }}
-              className="w-full flex items-center gap-3 p-3 rounded-md text-left hover:bg-muted/50 transition-colors"
-              data-testid="agent-install-desktop-button"
-            >
-              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-background">
-                <Download className="h-4 w-4" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="text-sm font-medium">Desktop App</div>
-                <div className="text-xs text-muted-foreground">
-                  Free local Agent runs
+            {isDesktopEnvironment ? (
+              desktopBridgeStatus === "failed" ? (
+                <button
+                  onClick={onRetryDesktopBridge}
+                  className="w-full flex items-center gap-3 p-3 rounded-md text-left hover:bg-muted/50 transition-colors"
+                  data-testid="agent-retry-desktop-button"
+                >
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-background">
+                    <RefreshCw className="h-4 w-4" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium">
+                      Retry Desktop connection
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      Reconnect the local sandbox
+                    </div>
+                  </div>
+                </button>
+              ) : desktopBridgeStatus === "connected" ? (
+                <button
+                  onClick={onUseConnectedDesktop}
+                  className="w-full flex items-center gap-3 p-3 rounded-md text-left hover:bg-muted/50 transition-colors"
+                  data-testid="agent-use-desktop-button"
+                >
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-background">
+                    <Check className="h-4 w-4" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium">Use Agent mode</div>
+                    <div className="text-xs text-muted-foreground">
+                      Run with the Desktop sandbox
+                    </div>
+                  </div>
+                </button>
+              ) : (
+                <div
+                  className="w-full flex items-center gap-3 p-3 rounded-md text-left"
+                  role="status"
+                  data-testid="agent-desktop-connecting"
+                >
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-background">
+                    <LoaderCircle className="h-4 w-4 animate-spin" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium">
+                      Connecting Desktop sandbox
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      This usually takes a few seconds
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </button>
+              )
+            ) : (
+              <button
+                onClick={() => {
+                  onOpenChange(false);
+                  window.open("/download", "_blank");
+                }}
+                className="w-full flex items-center gap-3 p-3 rounded-md text-left hover:bg-muted/50 transition-colors"
+                data-testid="agent-install-desktop-button"
+              >
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-background">
+                  <Download className="h-4 w-4" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium">Desktop App</div>
+                  <div className="text-xs text-muted-foreground">
+                    Free local Agent runs
+                  </div>
+                </div>
+              </button>
+            )}
             <button
               onClick={() => {
                 onOpenChange(false);

--- a/app/components/ChatInput/ChatModeSelector.tsx
+++ b/app/components/ChatInput/ChatModeSelector.tsx
@@ -7,7 +7,7 @@ import { useGlobalState } from "@/app/contexts/GlobalState";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { toast } from "sonner";
 import { AgentUpgradeDialog } from "./AgentUpgradeDialog";
-import { navigateToAuth } from "@/app/hooks/useTauri";
+import { navigateToAuth, useTauri } from "@/app/hooks/useTauri";
 
 export interface ChatModeSelectorProps {
   className?: string;
@@ -20,6 +20,8 @@ export function ChatModeSelector({ className }: ChatModeSelectorProps) {
     subscription,
     temporaryChatsEnabled,
     hasLocalSandbox,
+    desktopBridgeStatus,
+    retryDesktopBridge,
     defaultLocalSandboxPreference,
     sandboxPreference,
     setSandboxPreference,
@@ -27,7 +29,22 @@ export function ChatModeSelector({ className }: ChatModeSelectorProps) {
     setSelectedModel,
   } = useGlobalState();
   const { user } = useAuth();
+  const { isTauri } = useTauri();
   const [agentUpgradeDialogOpen, setAgentUpgradeDialogOpen] = useState(false);
+
+  const enableLocalAgentMode = () => {
+    setChatMode("agent");
+    if (
+      (sandboxPreference === "e2b" || !sandboxPreference) &&
+      defaultLocalSandboxPreference
+    ) {
+      setSandboxPreference(defaultLocalSandboxPreference);
+    }
+    if (selectedModel !== "auto") {
+      setSelectedModel("auto");
+    }
+    setAgentUpgradeDialogOpen(false);
+  };
 
   const handleAgentModeClick = () => {
     if (!user) {
@@ -43,15 +60,7 @@ export function ChatModeSelector({ className }: ChatModeSelectorProps) {
     if (subscription !== "free") {
       setChatMode("agent");
     } else if (hasLocalSandbox) {
-      setChatMode("agent");
-      if (sandboxPreference === "e2b" || !sandboxPreference) {
-        if (defaultLocalSandboxPreference) {
-          setSandboxPreference(defaultLocalSandboxPreference);
-        }
-      }
-      if (selectedModel !== "auto") {
-        setSelectedModel("auto");
-      }
+      enableLocalAgentMode();
     } else {
       setAgentUpgradeDialogOpen(true);
     }
@@ -75,6 +84,10 @@ export function ChatModeSelector({ className }: ChatModeSelectorProps) {
       <AgentUpgradeDialog
         open={agentUpgradeDialogOpen}
         onOpenChange={setAgentUpgradeDialogOpen}
+        isDesktopEnvironment={isTauri}
+        desktopBridgeStatus={desktopBridgeStatus}
+        onRetryDesktopBridge={retryDesktopBridge}
+        onUseConnectedDesktop={enableLocalAgentMode}
       />
     </>
   );

--- a/app/components/ChatInput/__tests__/AgentUpgradeDialog.test.tsx
+++ b/app/components/ChatInput/__tests__/AgentUpgradeDialog.test.tsx
@@ -1,0 +1,111 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockCaptureUpgradeCtaImpression = jest.fn();
+
+jest.mock("@/lib/analytics/client", () => ({
+  captureUpgradeCtaImpression: (...args: unknown[]) =>
+    mockCaptureUpgradeCtaImpression(...args),
+}));
+
+jest.mock("@/app/hooks/usePricingDialog", () => ({
+  redirectToPricing: jest.fn(),
+}));
+
+jest.mock("@/lib/utils/settings-dialog", () => ({
+  openSettingsDialog: jest.fn(),
+}));
+
+const { AgentUpgradeDialog } =
+  require("../AgentUpgradeDialog") as typeof import("../AgentUpgradeDialog");
+
+describe("AgentUpgradeDialog", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows Desktop connection progress instead of a download prompt", () => {
+    render(
+      <AgentUpgradeDialog
+        open
+        onOpenChange={jest.fn()}
+        isDesktopEnvironment
+        desktopBridgeStatus="connecting"
+        onRetryDesktopBridge={jest.fn()}
+        onUseConnectedDesktop={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Connecting Desktop sandbox")).toBeInTheDocument();
+    expect(
+      screen.getByText("HackerAI Desktop is connecting its local sandbox."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("agent-install-desktop-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("retries a failed Desktop sandbox connection", async () => {
+    const user = userEvent.setup();
+    const onRetryDesktopBridge = jest.fn();
+
+    render(
+      <AgentUpgradeDialog
+        open
+        onOpenChange={jest.fn()}
+        isDesktopEnvironment
+        desktopBridgeStatus="failed"
+        onRetryDesktopBridge={onRetryDesktopBridge}
+        onUseConnectedDesktop={jest.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Retry Desktop connection/ }),
+    );
+
+    expect(onRetryDesktopBridge).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByTestId("agent-install-desktop-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("enters Agent mode after the Desktop sandbox connects", async () => {
+    const user = userEvent.setup();
+    const onUseConnectedDesktop = jest.fn();
+
+    render(
+      <AgentUpgradeDialog
+        open
+        onOpenChange={jest.fn()}
+        isDesktopEnvironment
+        desktopBridgeStatus="connected"
+        onRetryDesktopBridge={jest.fn()}
+        onUseConnectedDesktop={onUseConnectedDesktop}
+      />,
+    );
+
+    await user.click(screen.getByTestId("agent-use-desktop-button"));
+
+    expect(onUseConnectedDesktop).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the Desktop download option on the web", () => {
+    render(
+      <AgentUpgradeDialog
+        open
+        onOpenChange={jest.fn()}
+        isDesktopEnvironment={false}
+        desktopBridgeStatus="idle"
+        onRetryDesktopBridge={jest.fn()}
+        onUseConnectedDesktop={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("agent-install-desktop-button"),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -31,7 +31,10 @@ import {
 import type { UploadedFileState } from "@/types/file";
 import type { FileMessagePart } from "@/types/file";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { useSandboxPreference } from "@/app/hooks/useSandboxPreference";
+import {
+  useSandboxPreference,
+  type DesktopBridgeStatus,
+} from "@/app/hooks/useSandboxPreference";
 import { isTauriEnvironment } from "@/app/hooks/useTauri";
 import { resolveSubscriptionTier } from "@/lib/auth/entitlements";
 import { clearSharedToken, setSharedToken } from "@/lib/auth/shared-token";
@@ -137,6 +140,8 @@ interface GlobalStateType {
 
   // Desktop bridge active (Centrifugo-based desktop sandbox)
   desktopBridgeActive: boolean;
+  desktopBridgeStatus: DesktopBridgeStatus;
+  retryDesktopBridge: () => void;
 
   // Whether a local sandbox (desktop or remote) is available
   hasLocalSandbox: boolean;
@@ -436,8 +441,13 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   });
 
   // Tauri detection + sandbox preference (co-located in a custom hook)
-  const { sandboxPreference, setSandboxPreference, desktopBridgeActive } =
-    useSandboxPreference(!!user);
+  const {
+    sandboxPreference,
+    setSandboxPreference,
+    desktopBridgeActive,
+    desktopBridgeStatus,
+    retryDesktopBridge,
+  } = useSandboxPreference(!!user);
 
   const [agentPermissionMode, setAgentPermissionMode] =
     useState<AgentPermissionMode>(() => readAgentPermissionMode());
@@ -1174,6 +1184,8 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     agentPermissionMode,
     setAgentPermissionMode,
     desktopBridgeActive,
+    desktopBridgeStatus,
+    retryDesktopBridge,
     hasLocalSandbox,
     localConnections,
     defaultLocalSandboxPreference,

--- a/app/hooks/__tests__/useSandboxPreference.test.tsx
+++ b/app/hooks/__tests__/useSandboxPreference.test.tsx
@@ -1,0 +1,130 @@
+import { StrictMode, type ReactNode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+jest.mock("convex/react", () => ({
+  useMutation: () => jest.fn(),
+}));
+
+jest.mock("@/app/hooks/useTauri", () => ({
+  isTauriEnvironment: () => true,
+}));
+
+jest.mock("@/app/services/desktop-sandbox-bridge", () => ({
+  DesktopSandboxBridge: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn() },
+}));
+
+const { DesktopSandboxBridge } =
+  require("@/app/services/desktop-sandbox-bridge") as typeof import("@/app/services/desktop-sandbox-bridge");
+const { useSandboxPreference } =
+  require("../useSandboxPreference") as typeof import("../useSandboxPreference");
+
+type BridgeConfig = {
+  onTerminated?: (
+    reason:
+      | "unauthenticated"
+      | "connection_not_found"
+      | "ownership_mismatch"
+      | "connection_inactive",
+  ) => void;
+};
+
+describe("useSandboxPreference", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("invalidates bridge startup and connected state when authentication is lost", async () => {
+    let resolveFirstStart: ((connectionId: string) => void) | undefined;
+    const firstStart = new Promise<string>((resolve) => {
+      resolveFirstStart = resolve;
+    });
+    const bridgeConfigs: BridgeConfig[] = [];
+    const bridgeInstances: Array<{
+      start: jest.Mock;
+      stop: jest.Mock;
+      getConnectionId: jest.Mock;
+    }> = [];
+
+    (DesktopSandboxBridge as jest.Mock).mockImplementation(
+      (config: BridgeConfig) => {
+        const index = bridgeInstances.length;
+        const instance = {
+          start: jest
+            .fn()
+            .mockImplementation(() =>
+              index === 0
+                ? firstStart
+                : Promise.resolve(`connection-${index + 1}`),
+            ),
+          stop: jest.fn().mockResolvedValue(undefined),
+          getConnectionId: jest.fn().mockReturnValue(`connection-${index + 1}`),
+        };
+        bridgeConfigs.push(config);
+        bridgeInstances.push(instance);
+        return instance;
+      },
+    );
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <StrictMode>{children}</StrictMode>
+    );
+    const { result, rerender } = renderHook(
+      ({ isAuthenticated }) => useSandboxPreference(isAuthenticated),
+      { initialProps: { isAuthenticated: true }, wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.desktopBridgeStatus).toBe("connecting");
+    });
+
+    rerender({ isAuthenticated: false });
+    await waitFor(() => {
+      expect(result.current.desktopBridgeStatus).toBe("idle");
+      expect(result.current.desktopBridgeActive).toBe(false);
+    });
+
+    await act(async () => {
+      resolveFirstStart?.("connection-1");
+      await firstStart;
+    });
+    await waitFor(() => {
+      expect(bridgeInstances[0].stop).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.desktopBridgeStatus).toBe("idle");
+
+    rerender({ isAuthenticated: true });
+    await waitFor(() => {
+      expect(result.current.desktopBridgeStatus).toBe("connected");
+      expect(result.current.desktopBridgeActive).toBe(true);
+    });
+
+    act(() => {
+      bridgeConfigs[1].onTerminated?.("connection_inactive");
+    });
+    await waitFor(() => {
+      expect(result.current.desktopBridgeStatus).toBe("failed");
+      expect(result.current.desktopBridgeActive).toBe(false);
+    });
+
+    act(() => {
+      result.current.retryDesktopBridge();
+    });
+    await waitFor(() => {
+      expect(result.current.desktopBridgeStatus).toBe("connected");
+      expect(result.current.desktopBridgeActive).toBe(true);
+    });
+
+    rerender({ isAuthenticated: false });
+    await waitFor(() => {
+      expect(result.current.desktopBridgeStatus).toBe("idle");
+      expect(result.current.desktopBridgeActive).toBe(false);
+      expect(bridgeInstances[2].stop).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/hooks/useSandboxPreference.ts
+++ b/app/hooks/useSandboxPreference.ts
@@ -6,21 +6,31 @@ import { api } from "@/convex/_generated/api";
 import type { SandboxPreference } from "@/types/chat";
 import { toast } from "sonner";
 import { DesktopSandboxBridge } from "@/app/services/desktop-sandbox-bridge";
+import { isTauriEnvironment } from "@/app/hooks/useTauri";
+
+export type DesktopBridgeStatus =
+  "idle" | "connecting" | "connected" | "failed";
 
 interface SandboxPreferenceState {
   sandboxPreference: SandboxPreference;
   setSandboxPreference: (preference: SandboxPreference) => void;
   desktopBridgeActive: boolean;
+  desktopBridgeStatus: DesktopBridgeStatus;
+  retryDesktopBridge: () => void;
 }
 
 // Module-level singleton to survive React strict mode double-mount
 let activeBridge: DesktopSandboxBridge | null = null;
-let bridgeStarting = false;
+let bridgeStartPromise: Promise<DesktopSandboxBridge> | null = null;
+const PERSISTABLE_SANDBOX_PREFERENCES = new Set(["e2b", "desktop"]);
 
 export function useSandboxPreference(
   isAuthenticated: boolean,
 ): SandboxPreferenceState {
   const [desktopBridgeActive, setDesktopBridgeActive] = useState(false);
+  const [desktopBridgeStatus, setDesktopBridgeStatus] =
+    useState<DesktopBridgeStatus>("idle");
+  const [desktopBridgeRetryAttempt, setDesktopBridgeRetryAttempt] = useState(0);
 
   const [sandboxPreference, setSandboxPreferenceState] =
     useState<SandboxPreference>(() => {
@@ -49,53 +59,73 @@ export function useSandboxPreference(
   }, [connectDesktopMutation, refreshTokenMutation, disconnectMutation]);
 
   useEffect(() => {
-    if (!isAuthenticated) return;
+    let cancelled = false;
+    const syncBridgeState = (active: boolean, status: DesktopBridgeStatus) => {
+      queueMicrotask(() => {
+        if (cancelled) return;
+        setDesktopBridgeActive(active);
+        setDesktopBridgeStatus(status);
+      });
+    };
+
+    if (!isAuthenticated || !isTauriEnvironment()) {
+      syncBridgeState(false, "idle");
+      return () => {
+        cancelled = true;
+      };
+    }
 
     // Already running — just sync bridge active state (keep Cloud as default)
     if (activeBridge?.getConnectionId()) {
-      setDesktopBridgeActive(true);
+      syncBridgeState(true, "connected");
       // setSandboxPreferenceState(activeBridge.getConnectionId()!);
-      return;
+      return () => {
+        cancelled = true;
+      };
     }
 
-    // Another call is already starting the bridge
-    if (bridgeStarting) return;
-
-    let cancelled = false;
-
     async function startBridge() {
-      bridgeStarting = true;
+      setDesktopBridgeActive(false);
+      setDesktopBridgeStatus("connecting");
       try {
-        const { isTauriEnvironment } = await import("@/app/hooks/useTauri");
-        if (!isTauriEnvironment()) return;
+        if (!bridgeStartPromise) {
+          const bridge = new DesktopSandboxBridge({
+            connectDesktop: (args) => connectDesktopRef.current(args),
+            refreshCentrifugoTokenDesktop: (args) =>
+              refreshTokenRef.current(args),
+            disconnectDesktop: (args) => disconnectRef.current(args),
+          });
 
-        if (cancelled) return;
-
-        // Double-check after async gap
-        if (activeBridge?.getConnectionId()) return;
-
-        const bridge = new DesktopSandboxBridge({
-          connectDesktop: (args) => connectDesktopRef.current(args),
-          refreshCentrifugoTokenDesktop: (args) =>
-            refreshTokenRef.current(args),
-          disconnectDesktop: (args) => disconnectRef.current(args),
-        });
-
-        await bridge.start();
-        if (cancelled) {
-          bridge.stop();
-          return;
+          bridgeStartPromise = bridge
+            .start()
+            .then(() => {
+              activeBridge = bridge;
+              return bridge;
+            })
+            .catch(async (error) => {
+              await bridge.stop();
+              throw error;
+            })
+            .finally(() => {
+              bridgeStartPromise = null;
+            });
         }
 
-        activeBridge = bridge;
+        await bridgeStartPromise;
+        if (cancelled) return;
+
         setDesktopBridgeActive(true);
+        setDesktopBridgeStatus("connected");
         // Keep Cloud selected by default; user can switch to Local if desired
         // setSandboxPreferenceState(connectionId);
       } catch (error) {
+        if (cancelled) return;
         console.error("[DesktopSandboxBridge] Failed to start:", error);
-        toast.error("Desktop sandbox failed to connect. Using cloud.");
-      } finally {
-        bridgeStarting = false;
+        setDesktopBridgeActive(false);
+        setDesktopBridgeStatus("failed");
+        toast.error("Desktop sandbox failed to connect.", {
+          description: "Retry the local connection to use Agent mode.",
+        });
       }
     }
 
@@ -118,9 +148,7 @@ export function useSandboxPreference(
       // Don't tear down the bridge on React strict mode unmount —
       // it's a module-level singleton that persists across remounts.
     };
-  }, [isAuthenticated]);
-
-  const PERSISTABLE_PREFERENCES = new Set(["e2b", "desktop"]);
+  }, [desktopBridgeRetryAttempt, isAuthenticated]);
 
   const isFirstRender = useRef(true);
   useEffect(() => {
@@ -130,7 +158,7 @@ export function useSandboxPreference(
     }
     if (
       typeof window !== "undefined" &&
-      PERSISTABLE_PREFERENCES.has(sandboxPreference)
+      PERSISTABLE_SANDBOX_PREFERENCES.has(sandboxPreference)
     ) {
       localStorage.setItem("sandbox-preference", sandboxPreference);
     }
@@ -140,5 +168,18 @@ export function useSandboxPreference(
     setSandboxPreferenceState(preference);
   }, []);
 
-  return { sandboxPreference, setSandboxPreference, desktopBridgeActive };
+  const retryDesktopBridge = useCallback(() => {
+    if (!isAuthenticated || !isTauriEnvironment()) return;
+    setDesktopBridgeActive(false);
+    setDesktopBridgeStatus("connecting");
+    setDesktopBridgeRetryAttempt((attempt) => attempt + 1);
+  }, [isAuthenticated]);
+
+  return {
+    sandboxPreference,
+    setSandboxPreference,
+    desktopBridgeActive,
+    desktopBridgeStatus,
+    retryDesktopBridge,
+  };
 }

--- a/app/hooks/useSandboxPreference.ts
+++ b/app/hooks/useSandboxPreference.ts
@@ -21,7 +21,10 @@ interface SandboxPreferenceState {
 
 // Module-level singleton to survive React strict mode double-mount
 let activeBridge: DesktopSandboxBridge | null = null;
-let bridgeStartPromise: Promise<DesktopSandboxBridge> | null = null;
+let bridgeStartPromise: Promise<DesktopSandboxBridge | null> | null = null;
+let bridgeGeneration = 0;
+let bridgeStateListener:
+  ((active: boolean, status: DesktopBridgeStatus) => void) | null = null;
 const PERSISTABLE_SANDBOX_PREFERENCES = new Set(["e2b", "desktop"]);
 
 export function useSandboxPreference(
@@ -60,20 +63,34 @@ export function useSandboxPreference(
 
   useEffect(() => {
     let cancelled = false;
+    const updateBridgeState = (
+      active: boolean,
+      status: DesktopBridgeStatus,
+    ) => {
+      if (cancelled) return;
+      setDesktopBridgeActive(active);
+      setDesktopBridgeStatus(status);
+    };
     const syncBridgeState = (active: boolean, status: DesktopBridgeStatus) => {
       queueMicrotask(() => {
-        if (cancelled) return;
-        setDesktopBridgeActive(active);
-        setDesktopBridgeStatus(status);
+        updateBridgeState(active, status);
       });
     };
 
     if (!isAuthenticated || !isTauriEnvironment()) {
+      bridgeStateListener = null;
+      bridgeGeneration += 1;
+      bridgeStartPromise = null;
+      const bridgeToStop = activeBridge;
+      activeBridge = null;
+      void bridgeToStop?.stop();
       syncBridgeState(false, "idle");
       return () => {
         cancelled = true;
       };
     }
+
+    bridgeStateListener = updateBridgeState;
 
     // Already running — just sync bridge active state (keep Cloud as default)
     if (activeBridge?.getConnectionId()) {
@@ -81,6 +98,9 @@ export function useSandboxPreference(
       // setSandboxPreferenceState(activeBridge.getConnectionId()!);
       return () => {
         cancelled = true;
+        if (bridgeStateListener === updateBridgeState) {
+          bridgeStateListener = null;
+        }
       };
     }
 
@@ -89,16 +109,28 @@ export function useSandboxPreference(
       setDesktopBridgeStatus("connecting");
       try {
         if (!bridgeStartPromise) {
-          const bridge = new DesktopSandboxBridge({
+          const generation = bridgeGeneration;
+          let bridge: DesktopSandboxBridge;
+          bridge = new DesktopSandboxBridge({
             connectDesktop: (args) => connectDesktopRef.current(args),
             refreshCentrifugoTokenDesktop: (args) =>
               refreshTokenRef.current(args),
             disconnectDesktop: (args) => disconnectRef.current(args),
+            onTerminated: (reason) => {
+              if (generation !== bridgeGeneration) return;
+              if (activeBridge === bridge) activeBridge = null;
+              bridgeStateListener?.(false, "failed");
+            },
           });
 
-          bridgeStartPromise = bridge
+          let startPromise: Promise<DesktopSandboxBridge | null>;
+          startPromise = bridge
             .start()
-            .then(() => {
+            .then(async () => {
+              if (generation !== bridgeGeneration) {
+                await bridge.stop();
+                return null;
+              }
               activeBridge = bridge;
               return bridge;
             })
@@ -107,12 +139,15 @@ export function useSandboxPreference(
               throw error;
             })
             .finally(() => {
-              bridgeStartPromise = null;
+              if (bridgeStartPromise === startPromise) {
+                bridgeStartPromise = null;
+              }
             });
+          bridgeStartPromise = startPromise;
         }
 
-        await bridgeStartPromise;
-        if (cancelled) return;
+        const bridge = await bridgeStartPromise;
+        if (cancelled || !bridge) return;
 
         setDesktopBridgeActive(true);
         setDesktopBridgeStatus("connected");
@@ -133,6 +168,9 @@ export function useSandboxPreference(
 
     // Cleanup on beforeunload (page close/refresh)
     const handleBeforeUnload = () => {
+      bridgeGeneration += 1;
+      bridgeStartPromise = null;
+      bridgeStateListener = null;
       try {
         activeBridge?.stop();
       } catch {
@@ -144,6 +182,9 @@ export function useSandboxPreference(
 
     return () => {
       cancelled = true;
+      if (bridgeStateListener === updateBridgeState) {
+        bridgeStateListener = null;
+      }
       window.removeEventListener("beforeunload", handleBeforeUnload);
       // Don't tear down the bridge on React strict mode unmount —
       // it's a module-level singleton that persists across remounts.
@@ -170,6 +211,8 @@ export function useSandboxPreference(
 
   const retryDesktopBridge = useCallback(() => {
     if (!isAuthenticated || !isTauriEnvironment()) return;
+    bridgeGeneration += 1;
+    bridgeStartPromise = null;
     setDesktopBridgeActive(false);
     setDesktopBridgeStatus("connecting");
     setDesktopBridgeRetryAttempt((attempt) => attempt + 1);

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -16,9 +16,13 @@ const mockClient = {
   disconnect: jest.fn(),
   on: jest.fn(),
 };
+let mockClientOptions: { getToken?: () => Promise<string> } | null = null;
 
 jest.mock("centrifuge", () => ({
-  Centrifuge: jest.fn().mockImplementation(() => mockClient),
+  Centrifuge: jest.fn().mockImplementation((_, options) => {
+    mockClientOptions = options;
+    return mockClient;
+  }),
 }));
 
 // Mock Tauri IPC
@@ -81,6 +85,7 @@ function getPublicationHandler(): (ctx: { data: unknown }) => void {
 beforeEach(() => {
   jest.clearAllMocks();
   capturedChannel = null;
+  mockClientOptions = null;
   global.fetch = originalFetch;
 
   mockInvokeHandler = async (cmd: string) => {
@@ -115,6 +120,54 @@ describe("desktop capability registration", () => {
         capabilities: { commands: true, pty: true, files: true },
       }),
     );
+  });
+});
+
+describe("terminal connection state", () => {
+  it("notifies the owner when the server terminates the connection", async () => {
+    const onTerminated = jest.fn();
+    const config = buildConfig({
+      onTerminated,
+      refreshCentrifugoTokenDesktop: jest.fn().mockResolvedValue({
+        ok: false,
+        terminated: true,
+        reason: "connection_inactive",
+        connectionId: "conn-123",
+        clientVersion: "desktop",
+        status: "disconnected",
+        disconnectReason: "presence_sweep",
+        msSinceDisconnected: 100,
+        msSinceLastHeartbeat: 200,
+        msSinceCreated: 300,
+      }),
+    });
+    const bridge = new DesktopSandboxBridge(config);
+    await bridge.start();
+
+    await expect(mockClientOptions?.getToken?.()).rejects.toThrow(
+      "Centrifugo refresh aborted: connection_inactive",
+    );
+
+    expect(onTerminated).toHaveBeenCalledWith("connection_inactive");
+    expect(bridge.getConnectionId()).toBeNull();
+    expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(mockClient.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports unauthenticated token refresh termination", async () => {
+    const onTerminated = jest.fn();
+    const error = { data: { code: "UNAUTHORIZED" } };
+    const config = buildConfig({
+      onTerminated,
+      refreshCentrifugoTokenDesktop: jest.fn().mockRejectedValue(error),
+    });
+    const bridge = new DesktopSandboxBridge(config);
+    await bridge.start();
+
+    await expect(mockClientOptions?.getToken?.()).rejects.toBe(error);
+
+    expect(onTerminated).toHaveBeenCalledWith("unauthenticated");
+    expect(bridge.getConnectionId()).toBeNull();
   });
 });
 

--- a/app/services/__tests__/desktop-sandbox-bridge.test.ts
+++ b/app/services/__tests__/desktop-sandbox-bridge.test.ts
@@ -126,6 +126,9 @@ describe("desktop capability registration", () => {
 describe("terminal connection state", () => {
   it("notifies the owner when the server terminates the connection", async () => {
     const onTerminated = jest.fn();
+    mockSubscription.unsubscribe.mockImplementationOnce(() => {
+      throw new Error("already unsubscribed");
+    });
     const config = buildConfig({
       onTerminated,
       refreshCentrifugoTokenDesktop: jest.fn().mockResolvedValue({
@@ -151,6 +154,7 @@ describe("terminal connection state", () => {
     expect(onTerminated).toHaveBeenCalledWith("connection_inactive");
     expect(bridge.getConnectionId()).toBeNull();
     expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(mockSubscription.removeAllListeners).toHaveBeenCalledTimes(1);
     expect(mockClient.disconnect).toHaveBeenCalledTimes(1);
   });
 

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -157,6 +157,10 @@ export class DesktopSandboxBridge {
     this.connectionId = null;
     try {
       subscription?.unsubscribe();
+    } catch {
+      // already in a terminal state
+    }
+    try {
       subscription?.removeAllListeners();
     } catch {
       // already in a terminal state

--- a/app/services/desktop-sandbox-bridge.ts
+++ b/app/services/desktop-sandbox-bridge.ts
@@ -44,6 +44,12 @@ type RefreshTokenResult =
       msSinceCreated: number | null;
     };
 
+type DesktopBridgeTerminationReason =
+  | "unauthenticated"
+  | "connection_not_found"
+  | "ownership_mismatch"
+  | "connection_inactive";
+
 interface StreamChunk {
   type: "stdout" | "stderr" | "exit" | "error";
   data?: string;
@@ -122,6 +128,7 @@ interface DesktopBridgeConfig {
   disconnectDesktop: (args: {
     connectionId: string;
   }) => Promise<{ success: boolean }>;
+  onTerminated?: (reason: DesktopBridgeTerminationReason) => void;
 }
 
 export class DesktopSandboxBridge {
@@ -140,16 +147,26 @@ export class DesktopSandboxBridge {
     return this.connectionId;
   }
 
-  private terminateClient(): void {
+  private terminateClient(reason: DesktopBridgeTerminationReason): void {
+    if (this.isStoppingOrStopped) return;
     this.isStoppingOrStopped = true;
     const client = this.client;
+    const subscription = this.subscription;
     this.client = null;
+    this.subscription = null;
     this.connectionId = null;
+    try {
+      subscription?.unsubscribe();
+      subscription?.removeAllListeners();
+    } catch {
+      // already in a terminal state
+    }
     try {
       client?.disconnect();
     } catch {
       // already in a terminal state
     }
+    this.config.onTerminated?.(reason);
   }
 
   async start(): Promise<string> {
@@ -193,7 +210,7 @@ export class DesktopSandboxBridge {
               "sandbox_connection_terminated",
               eventProps,
             );
-            this.terminateClient();
+            this.terminateClient("unauthenticated");
           } else {
             console.error(
               "[DesktopSandboxBridge] Failed to refresh Centrifugo token:",
@@ -221,7 +238,7 @@ export class DesktopSandboxBridge {
           eventProps,
         );
         captureAuthenticatedEvent("sandbox_connection_terminated", eventProps);
-        this.terminateClient();
+        this.terminateClient(result.reason);
         throw new Error(`Centrifugo refresh aborted: ${result.reason}`);
       },
     });


### PR DESCRIPTION
## Summary

- track Desktop sandbox startup as idle, connecting, connected, or failed and expose an in-app retry
- keep concurrent React mounts on the same bridge startup promise so the visible connection state stays accurate
- invalidate and stop shared bridge state on logout, and propagate terminal refresh events back into the UI
- replace the misleading Desktop download CTA with connecting, retry, and ready states when the app is already running inside Desktop
- preserve the existing download option for web users and add lifecycle/dialog regression coverage

## Root cause

For free users, selecting Agent checks `hasLocalSandbox`. Desktop bridge startup is asynchronous, so that value can still be false even though HackerAI is already running inside the desktop shell. The fallback dialog did not distinguish Desktop from web and always offered another Desktop download.

The shared bridge also needed explicit lifecycle invalidation so logout or a terminal token-refresh event could not leave `hasLocalSandbox` reporting a stale connection.

## Validation

- `pnpm typecheck`
- `pnpm test` — 284 suites, 2,795 tests passed
- focused ESLint on the changed files
- Prettier check on the changed files
- Chrome visual verification of connecting, failed/retry, and connected states; temporary preview scaffolding was removed from the diff

## Manual verification

1. Open the latest HackerAI Desktop app with a free account and select Agent while the local sandbox is still starting.
2. Confirm the dialog says Desktop is connecting and does not offer to download Desktop.
3. If startup fails, choose **Retry Desktop connection** and confirm the state returns to connecting.
4. After the bridge connects, choose **Use Agent mode** and confirm Agent opens with the Desktop sandbox selected.
5. Sign out while Desktop is connecting or connected, then sign back in and confirm the previous bridge is not reused.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Agent Upgrade dialog to reflect desktop bridge states (connecting/failed/connected) with state-specific actions (retry, use connected desktop).
  * Improved local agent mode setup to better align model/sandbox defaults and desktop behavior.
* **Bug Fixes**
  * Strengthened desktop bridge lifecycle handling to prevent stale status updates and ensure correct transitions on authentication and connection termination.
  * Improved teardown/cleanup on desktop bridge termination (including “connection_inactive” and unauthorized cases).
* **Tests**
  * Added/expanded automated tests for dialog behavior, sandbox preference/bridge state transitions, and desktop bridge termination scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->