### PR TITLE
Fix prorated usage on subscription upgrades

### DIFF
--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -658,6 +658,11 @@ describe("POST /api/subscription/webhook", () => {
       "user_upgrade",
       "pro-plus",
       expect.objectContaining({
+        identity: {
+          subscriptionId: "sub_upgrade",
+          targetTier: "pro-plus",
+          transitionId: "in_upgrade",
+        },
         periodEndSeconds: periodEnd,
       }),
     );
@@ -721,6 +726,7 @@ describe("POST /api/subscription/webhook", () => {
       status: "paid",
       amount_paid: 1459,
       billing_reason: "subscription_update",
+      status_transitions: { paid_at: nowSeconds - 24 * 60 * 60 },
     } as never);
     mockApplyProratedTierChangeBucket.mockResolvedValue({
       remainingCredits: 140_000,
@@ -733,19 +739,31 @@ describe("POST /api/subscription/webhook", () => {
     expect(mockStashTierChangeBucketState).toHaveBeenCalledWith(
       "user_upgrade",
       "pro",
-      undefined,
+      {
+        identity: {
+          subscriptionId: "sub_upgrade",
+          targetTier: "pro-plus",
+          transitionId: "in_upgrade",
+        },
+        oldCycleAllocationPoints: undefined,
+      },
     );
     expect(mockRetrieveInvoice).toHaveBeenCalledWith("in_upgrade");
     expect(mockApplyProratedTierChangeBucket).toHaveBeenCalledWith(
       "user_upgrade",
       "pro-plus",
       expect.objectContaining({
+        identity: {
+          subscriptionId: "sub_upgrade",
+          targetTier: "pro-plus",
+          transitionId: "in_upgrade",
+        },
         periodEndSeconds: periodEnd,
       }),
     );
     expect(
       mockApplyProratedTierChangeBucket.mock.calls[0][2].proratedRatio,
-    ).toBeCloseTo(0.4, 4);
+    ).toBeCloseTo(13 / 30, 4);
     expect(mockResetRateLimitBuckets).not.toHaveBeenCalled();
   });
 

--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -21,9 +21,8 @@ const mockRetrievePaymentIntent = jest.fn();
 const mockListMemberships = jest.fn();
 const mockConvexMutation = jest.fn();
 const mockResetRateLimitBuckets = jest.fn();
-const mockStashOldBucketRemaining = jest.fn();
-const mockPopOldBucketRemaining = jest.fn();
-const mockInitProratedBucket = jest.fn();
+const mockStashTierChangeBucketState = jest.fn();
+const mockApplyProratedTierChangeBucket = jest.fn();
 const mockClearOrgRemovedUsage = jest.fn();
 const mockPostHogEvent = jest.fn();
 const mockPostHogWarn = jest.fn();
@@ -104,9 +103,8 @@ jest.mock("@/convex/_generated/api", () => ({
 
 jest.mock("@/lib/rate-limit", () => ({
   resetRateLimitBuckets: mockResetRateLimitBuckets,
-  stashOldBucketRemaining: mockStashOldBucketRemaining,
-  popOldBucketRemaining: mockPopOldBucketRemaining,
-  initProratedBucket: mockInitProratedBucket,
+  stashTierChangeBucketState: mockStashTierChangeBucketState,
+  applyProratedTierChangeBucket: mockApplyProratedTierChangeBucket,
   clearOrgRemovedUsage: mockClearOrgRemovedUsage,
 }));
 
@@ -295,6 +293,8 @@ describe("POST /api/subscription/webhook", () => {
     jest.spyOn(console, "error").mockImplementation(() => {});
 
     mockConvexMutation.mockResolvedValue({ alreadyProcessed: false } as never);
+    mockStashTierChangeBucketState.mockResolvedValue({} as never);
+    mockApplyProratedTierChangeBucket.mockResolvedValue(null as never);
     mockGetReferralRewardConfig.mockReturnValue({
       enabled: false,
       referrerRewardDollars: 0,
@@ -592,6 +592,161 @@ describe("POST /api/subscription/webhook", () => {
       periodEnd,
       200_000,
     );
+  });
+
+  it("applies stashed tier-change state for a paid upgrade invoice", async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const periodStart = nowSeconds - 18 * 24 * 60 * 60;
+    const periodEnd = nowSeconds + 12 * 24 * 60 * 60;
+    mockConstructEvent.mockReturnValue({
+      id: "evt_invoice_paid_upgrade",
+      type: "invoice.paid",
+      data: {
+        object: {
+          id: "in_upgrade",
+          customer: "cus_upgrade",
+          amount_paid: 1459,
+          currency: "usd",
+          billing_reason: "subscription_update",
+          parent: {
+            subscription_details: { subscription: "sub_upgrade" },
+          },
+          status_transitions: { paid_at: nowSeconds },
+        },
+      },
+    });
+    mockRetrieveCustomer.mockResolvedValue({
+      deleted: false,
+      id: "cus_upgrade",
+      metadata: { workOSOrganizationId: "org_upgrade" },
+    } as never);
+    mockListMemberships.mockResolvedValue({
+      autoPagination: jest.fn().mockResolvedValue([{ userId: "user_upgrade" }]),
+    } as never);
+    mockRetrieveSubscription.mockResolvedValue({
+      id: "sub_upgrade",
+      metadata: {},
+      items: {
+        data: [
+          {
+            quantity: 1,
+            current_period_start: periodStart,
+            current_period_end: periodEnd,
+            price: {
+              id: "price_pro_plus",
+              lookup_key: "pro-plus-monthly-plan",
+              recurring: { interval: "month", interval_count: 1 },
+              product: {
+                id: "prod_pro_plus",
+                name: "HackerAI Pro Plus",
+                metadata: {},
+              },
+            },
+          },
+        ],
+      },
+    } as never);
+    mockApplyProratedTierChangeBucket.mockResolvedValue({
+      remainingCredits: 140_000,
+    } as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(makeWebhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockApplyProratedTierChangeBucket).toHaveBeenCalledWith(
+      "user_upgrade",
+      "pro-plus",
+      expect.objectContaining({
+        periodEndSeconds: periodEnd,
+      }),
+    );
+    expect(
+      mockApplyProratedTierChangeBucket.mock.calls[0][2].proratedRatio,
+    ).toBeCloseTo(0.4, 4);
+    expect(mockResetRateLimitBuckets).not.toHaveBeenCalled();
+  });
+
+  it("finishes a tier migration when invoice.paid arrived before subscription.updated", async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const periodStart = nowSeconds - 18 * 24 * 60 * 60;
+    const periodEnd = nowSeconds + 12 * 24 * 60 * 60;
+    mockConstructEvent.mockReturnValue({
+      id: "evt_subscription_updated_upgrade",
+      type: "customer.subscription.updated",
+      data: {
+        object: {
+          id: "sub_upgrade",
+          customer: "cus_upgrade",
+          latest_invoice: "in_upgrade",
+          metadata: {},
+          items: {
+            data: [
+              {
+                current_period_start: periodStart,
+                current_period_end: periodEnd,
+                price: {
+                  id: "price_pro_plus",
+                  lookup_key: "pro-plus-monthly-plan",
+                  recurring: { interval: "month", interval_count: 1 },
+                },
+              },
+            ],
+          },
+        },
+        previous_attributes: {
+          items: {
+            data: [
+              {
+                price: {
+                  id: "price_pro",
+                  lookup_key: "pro-monthly-plan",
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+    mockRetrieveCustomer.mockResolvedValue({
+      deleted: false,
+      id: "cus_upgrade",
+      metadata: { workOSOrganizationId: "org_upgrade" },
+    } as never);
+    mockListMemberships.mockResolvedValue({
+      autoPagination: jest.fn().mockResolvedValue([{ userId: "user_upgrade" }]),
+    } as never);
+    mockRetrieveInvoice.mockResolvedValue({
+      id: "in_upgrade",
+      status: "paid",
+      amount_paid: 1459,
+      billing_reason: "subscription_update",
+    } as never);
+    mockApplyProratedTierChangeBucket.mockResolvedValue({
+      remainingCredits: 140_000,
+    } as never);
+
+    const { POST } = await import("../route");
+    const response = await POST(makeWebhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockStashTierChangeBucketState).toHaveBeenCalledWith(
+      "user_upgrade",
+      "pro",
+      undefined,
+    );
+    expect(mockRetrieveInvoice).toHaveBeenCalledWith("in_upgrade");
+    expect(mockApplyProratedTierChangeBucket).toHaveBeenCalledWith(
+      "user_upgrade",
+      "pro-plus",
+      expect.objectContaining({
+        periodEndSeconds: periodEnd,
+      }),
+    );
+    expect(
+      mockApplyProratedTierChangeBucket.mock.calls[0][2].proratedRatio,
+    ).toBeCloseTo(0.4, 4);
+    expect(mockResetRateLimitBuckets).not.toHaveBeenCalled();
   });
 
   it("deactivates referral paid eligibility for deleted HackerAI subscriptions resolved from product fallback", async () => {

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -143,7 +143,10 @@ function monthlyUsagePeriodEndSeconds(
   return subscriptionCurrentPeriodEndSeconds(subscription);
 }
 
-function monthlyTierChangeProration(subscription: Stripe.Subscription): {
+function monthlyTierChangeProration(
+  subscription: Stripe.Subscription,
+  effectiveChangeAtMs: number,
+): {
   proratedRatio?: number;
   periodEndSeconds?: number;
 } {
@@ -155,11 +158,11 @@ function monthlyTierChangeProration(subscription: Stripe.Subscription): {
   const periodStartSeconds =
     subscriptionItem?.current_period_start ??
     (subscription as { current_period_start?: number }).current_period_start;
-  const nowSeconds = Math.floor(Date.now() / 1000);
+  const effectiveChangeAtSeconds = Math.floor(effectiveChangeAtMs / 1000);
   const totalDuration = periodStartSeconds
     ? periodEndSeconds - periodStartSeconds
     : 0;
-  const remainingDuration = periodEndSeconds - nowSeconds;
+  const remainingDuration = periodEndSeconds - effectiveChangeAtSeconds;
 
   return {
     periodEndSeconds,
@@ -177,18 +180,28 @@ async function applyTierChangeBuckets({
   tier,
   subscription,
   includedUsagePoints,
+  subscriptionId,
+  transitionId,
+  effectiveChangeAtMs,
   source,
 }: {
   userIds: string[];
   tier: SubscriptionTier;
   subscription: Stripe.Subscription;
   includedUsagePoints?: number;
+  subscriptionId: string;
+  transitionId: string;
+  effectiveChangeAtMs: number;
   source: "invoice.paid" | "subscription.updated";
 }): Promise<number> {
-  const proration = monthlyTierChangeProration(subscription);
+  const proration = monthlyTierChangeProration(
+    subscription,
+    effectiveChangeAtMs,
+  );
   const results = await Promise.all(
     userIds.map((userId) =>
       applyProratedTierChangeBucket(userId, tier, {
+        identity: { subscriptionId, targetTier: tier, transitionId },
         ...proration,
         cycleAllocationPoints: includedUsagePoints,
       }),
@@ -801,6 +814,9 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
       tier,
       subscription,
       includedUsagePoints,
+      subscriptionId,
+      transitionId: invoice.id,
+      effectiveChangeAtMs: invoicePaidAtMs(invoice),
       source: "invoice.paid",
     });
     return;
@@ -1270,16 +1286,23 @@ async function handleSubscriptionUpdated(
   // following invoice.paid event applies the new bucket. If Stripe delivered
   // invoice.paid first, apply it here from the already-paid latest invoice.
   if (previousTier && currentTier) {
+    const latestInvoiceId = stripeObjectId(subscription.latest_invoice);
+    const transitionId =
+      latestInvoiceId ??
+      `subscription:${subscription.id}:${currentTier}:${subscriptionCurrentPeriodEndSeconds(subscription) ?? "unknown"}`;
     const previousIncludedUsagePoints = includedUsagePointsForStripePrice(
       typeof previousPriceId === "string" ? previousPriceId : undefined,
     );
     await Promise.all(
       userIds.map((uid) =>
-        stashTierChangeBucketState(
-          uid,
-          previousTier,
-          previousIncludedUsagePoints,
-        ),
+        stashTierChangeBucketState(uid, previousTier, {
+          identity: {
+            subscriptionId: subscription.id,
+            targetTier: currentTier,
+            transitionId,
+          },
+          oldCycleAllocationPoints: previousIncludedUsagePoints,
+        }),
       ),
     );
 
@@ -1292,6 +1315,9 @@ async function handleSubscriptionUpdated(
         includedUsagePoints: includedUsagePointsForStripePrice(
           currentPrice?.id,
         ),
+        subscriptionId: subscription.id,
+        transitionId: paidTierChangeInvoice.id,
+        effectiveChangeAtMs: invoicePaidAtMs(paidTierChangeInvoice),
         source: "subscription.updated",
       });
     }

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -5,9 +5,8 @@ import { api } from "@/convex/_generated/api";
 import Stripe from "stripe";
 import {
   resetRateLimitBuckets,
-  stashOldBucketRemaining,
-  popOldBucketRemaining,
-  initProratedBucket,
+  stashTierChangeBucketState,
+  applyProratedTierChangeBucket,
   clearOrgRemovedUsage,
 } from "@/lib/rate-limit";
 import { phLogger } from "@/lib/posthog/server";
@@ -142,6 +141,89 @@ function monthlyUsagePeriodEndSeconds(
   if (priceBillingInterval(price) !== "month") return undefined;
   if ((price?.recurring?.interval_count ?? 1) !== 1) return undefined;
   return subscriptionCurrentPeriodEndSeconds(subscription);
+}
+
+function monthlyTierChangeProration(subscription: Stripe.Subscription): {
+  proratedRatio?: number;
+  periodEndSeconds?: number;
+} {
+  const periodEndSeconds = monthlyUsagePeriodEndSeconds(subscription);
+  if (!periodEndSeconds) return {};
+
+  const subscriptionItem = subscription.items?.data[0] as
+    { current_period_start?: number } | undefined;
+  const periodStartSeconds =
+    subscriptionItem?.current_period_start ??
+    (subscription as { current_period_start?: number }).current_period_start;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const totalDuration = periodStartSeconds
+    ? periodEndSeconds - periodStartSeconds
+    : 0;
+  const remainingDuration = periodEndSeconds - nowSeconds;
+
+  return {
+    periodEndSeconds,
+    ...(totalDuration > 0 && {
+      proratedRatio: Math.max(
+        0,
+        Math.min(1, remainingDuration / totalDuration),
+      ),
+    }),
+  };
+}
+
+async function applyTierChangeBuckets({
+  userIds,
+  tier,
+  subscription,
+  includedUsagePoints,
+  source,
+}: {
+  userIds: string[];
+  tier: SubscriptionTier;
+  subscription: Stripe.Subscription;
+  includedUsagePoints?: number;
+  source: "invoice.paid" | "subscription.updated";
+}): Promise<number> {
+  const proration = monthlyTierChangeProration(subscription);
+  const results = await Promise.all(
+    userIds.map((userId) =>
+      applyProratedTierChangeBucket(userId, tier, {
+        ...proration,
+        cycleAllocationPoints: includedUsagePoints,
+      }),
+    ),
+  );
+  const appliedResults = results.filter((result) => result !== null);
+  const appliedCount = appliedResults.length;
+  const incrementalPoints = appliedResults.reduce(
+    (total, result) => total + result.incrementalCredits,
+    0,
+  );
+
+  console.log(
+    appliedCount > 0
+      ? `[Subscription Webhook] ${source}: applied ${tier} tier-change proration for ${appliedCount} user(s), ${incrementalPoints} incremental point(s)`
+      : `[Subscription Webhook] ${source}: no tier-change state found; skipping bucket reset`,
+  );
+  return appliedCount;
+}
+
+async function getPaidTierChangeInvoice(
+  subscription: Stripe.Subscription,
+): Promise<Stripe.Invoice | null> {
+  const latestInvoice = subscription.latest_invoice;
+  if (!latestInvoice) return null;
+
+  const invoice =
+    typeof latestInvoice === "string"
+      ? await stripe.invoices.retrieve(latestInvoice)
+      : latestInvoice;
+  if (invoice.status !== "paid") return null;
+  return getInvoicePaidBucketResetMode(invoice).mode ===
+    "subscription_update_proration"
+    ? invoice
+    : null;
 }
 
 type BillingFailureAnalyticsContext = {
@@ -710,80 +792,17 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
     return;
   }
 
-  // Mid-cycle tier change: prorate credits based on remaining time in the cycle.
-  // Only prorate if handleSubscriptionUpdated stashed old-tier data (confirms
-  // a real tier change). Other subscription_update reasons (quantity changes,
-  // billing anchor changes) are ignored so they cannot mint fresh credits.
+  // Mid-cycle tier change: apply only a previously stashed bucket migration.
+  // Missing state is intentionally a no-op so quantity/anchor changes cannot
+  // mint a fresh monthly allocation.
   if (resetMode.mode === "subscription_update_proration") {
-    // Check each user for a tier-change stash; collect those that have one
-    const stashResults = await Promise.all(
-      userIds.map(async (uid) => ({
-        uid,
-        stash: await popOldBucketRemaining(uid),
-      })),
-    );
-
-    const tierChangeUsers = stashResults.filter((r) => r.stash !== null);
-
-    if (tierChangeUsers.length > 0) {
-      console.log(
-        `[Subscription Webhook] invoice.paid (upgrade): prorating ${tier} buckets for ${tierChangeUsers.length} user(s)`,
-      );
-
-      const subscriptionItem = subscription.items?.data[0] as
-        | { current_period_start?: number; current_period_end?: number }
-        | undefined;
-      const periodStart =
-        subscriptionItem?.current_period_start ??
-        ((subscription as any).current_period_start as number);
-      const periodEnd =
-        subscriptionItem?.current_period_end ??
-        ((subscription as any).current_period_end as number);
-      const now = Math.floor(Date.now() / 1000);
-      const totalDuration = periodEnd - periodStart;
-      const remaining = periodEnd - now;
-
-      const proratedRatio = Math.max(
-        0,
-        Math.min(1, totalDuration > 0 ? remaining / totalDuration : 1),
-      );
-
-      await Promise.all(
-        tierChangeUsers.map(({ uid, stash }) =>
-          initProratedBucket(
-            uid,
-            tier,
-            proratedRatio,
-            stash!.consumed,
-            periodEnd,
-            includedUsagePoints,
-          ),
-        ),
-      );
-
-      // Any users without a stash (shouldn't happen, but safe fallback)
-      const nonTierChangeUsers = stashResults.filter((r) => r.stash === null);
-      if (nonTierChangeUsers.length > 0) {
-        const fallbackUsagePeriodEnd =
-          monthlyUsagePeriodEndSeconds(subscription);
-        await Promise.all(
-          nonTierChangeUsers.map(({ uid }) =>
-            resetRateLimitBuckets(
-              uid,
-              tier,
-              fallbackUsagePeriodEnd,
-              includedUsagePoints,
-            ),
-          ),
-        );
-      }
-
-      return;
-    }
-
-    console.log(
-      `[Subscription Webhook] invoice.paid (subscription_update): no tier-change stash for invoice ${invoice.id}; skipping bucket reset`,
-    );
+    await applyTierChangeBuckets({
+      userIds,
+      tier,
+      subscription,
+      includedUsagePoints,
+      source: "invoice.paid",
+    });
     return;
   }
 
@@ -1187,6 +1206,7 @@ async function handleSubscriptionUpdated(
   }
 
   const prevLookupKey = previousItems?.data?.[0]?.price?.lookup_key ?? null;
+  const previousPriceId = previousItems?.data?.[0]?.price?.id;
   const previousTier = prevLookupKey
     ? planLookupKeyToTier(prevLookupKey)
     : null;
@@ -1246,14 +1266,35 @@ async function handleSubscriptionUpdated(
     });
   }
 
-  // Stash remaining credits from old tier before deleting, then reset old buckets
-  if (previousTier) {
-    await Promise.all(
-      userIds.map((uid) => stashOldBucketRemaining(uid, previousTier)),
+  // Preserve the old cycle before removing its tier-specific key. Usually the
+  // following invoice.paid event applies the new bucket. If Stripe delivered
+  // invoice.paid first, apply it here from the already-paid latest invoice.
+  if (previousTier && currentTier) {
+    const previousIncludedUsagePoints = includedUsagePointsForStripePrice(
+      typeof previousPriceId === "string" ? previousPriceId : undefined,
     );
     await Promise.all(
-      userIds.map((uid) => resetRateLimitBuckets(uid, previousTier)),
+      userIds.map((uid) =>
+        stashTierChangeBucketState(
+          uid,
+          previousTier,
+          previousIncludedUsagePoints,
+        ),
+      ),
     );
+
+    const paidTierChangeInvoice = await getPaidTierChangeInvoice(subscription);
+    if (paidTierChangeInvoice) {
+      await applyTierChangeBuckets({
+        userIds,
+        tier: currentTier,
+        subscription,
+        includedUsagePoints: includedUsagePointsForStripePrice(
+          currentPrice?.id,
+        ),
+        source: "subscription.updated",
+      });
+    }
   }
 }
 

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -24,6 +24,7 @@ describe("token-bucket async functions", () => {
   const mockExistsFn = jest.fn();
   const mockEvalFn = jest.fn();
   const mockDelFn = jest.fn();
+  const mockSetFn = jest.fn();
   const mockExpireFn = jest.fn();
   const mockScanFn = jest.fn();
   const mockDeductFromBalance = jest.fn();
@@ -49,6 +50,7 @@ describe("token-bucket async functions", () => {
     mockExistsFn.mockResolvedValue(1);
     mockEvalFn.mockResolvedValue([-1, -1, 0]);
     mockDelFn.mockResolvedValue(1);
+    mockSetFn.mockResolvedValue("OK");
     mockExpireFn.mockResolvedValue(1);
     mockScanFn.mockResolvedValue(["0", []]);
     mockDeductFromBalance.mockResolvedValue({
@@ -78,6 +80,7 @@ describe("token-bucket async functions", () => {
       exists: mockExistsFn,
       eval: mockEvalFn,
       del: mockDelFn,
+      set: mockSetFn,
       expire: mockExpireFn,
       scan: mockScanFn,
     });
@@ -114,6 +117,7 @@ describe("token-bucket async functions", () => {
           exists: mockExistsFn,
           eval: mockEvalFn,
           del: mockDelFn,
+          set: mockSetFn,
           expire: mockExpireFn,
           scan: mockScanFn,
         })),
@@ -156,6 +160,172 @@ describe("token-bucket async functions", () => {
       await expect(deleteUserRateLimitKeys("user-123")).resolves.toBe(1);
 
       expect(mockDelFn).toHaveBeenCalledWith("usage:monthly:user-123:pro");
+    });
+  });
+
+  describe("tier-change bucket migration", () => {
+    it("atomically stashes the real cycle state and deletes the old bucket", async () => {
+      const resetAtMs = Date.now() + 12 * 24 * 60 * 60 * 1000;
+      const state = JSON.stringify({
+        version: 2,
+        oldTier: "pro",
+        remaining: 0,
+        cycleAllocation: 250_000,
+        resetAtMs,
+      });
+      mockLimitFn.mockResolvedValueOnce({
+        success: true,
+        remaining: 0,
+        reset: resetAtMs,
+        limit: 250_000,
+      });
+      mockEvalFn.mockResolvedValueOnce(state);
+      const { stashTierChangeBucketState } = getIsolatedModule();
+
+      await expect(
+        stashTierChangeBucketState("user-123", "pro"),
+      ).resolves.toEqual(JSON.parse(state));
+
+      expect(mockLimitFn).toHaveBeenCalledWith("user-123:pro", { rate: 0 });
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.stringContaining('redis.call("SET", stashKey'),
+        ["usage:monthly:user-123:pro", "upgrade:carryover:user-123"],
+        [250_000, resetAtMs, "pro", 86_400],
+      );
+    });
+
+    it("uses a price-specific old-cycle allocation when metadata is absent", async () => {
+      const resetAtMs = Date.now() + 12 * 24 * 60 * 60 * 1000;
+      mockLimitFn.mockResolvedValueOnce({
+        success: true,
+        remaining: 50_000,
+        reset: resetAtMs,
+        limit: 250_000,
+      });
+      mockEvalFn.mockResolvedValueOnce(
+        JSON.stringify({
+          version: 2,
+          oldTier: "pro",
+          remaining: 50_000,
+          cycleAllocation: 200_000,
+          resetAtMs,
+        }),
+      );
+      const { stashTierChangeBucketState } = getIsolatedModule();
+
+      await stashTierChangeBucketState("user-123", "pro", 200_000);
+
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        [200_000, resetAtMs, "pro", 86_400],
+      );
+    });
+
+    it("applies only the prorated Pro→Pro+ difference and preserves reset", async () => {
+      const resetAtMs = Date.now() + 12 * 24 * 60 * 60 * 1000;
+      const periodEndSeconds = Math.ceil(resetAtMs / 1000);
+      mockEvalFn.mockResolvedValueOnce(
+        JSON.stringify({
+          version: 2,
+          oldTier: "pro",
+          remaining: 0,
+          cycleAllocation: 250_000,
+          resetAtMs,
+        }),
+      );
+      const { applyProratedTierChangeBucket } = getIsolatedModule();
+
+      const result = await applyProratedTierChangeBucket(
+        "user-123",
+        "pro-plus",
+        {
+          proratedRatio: 0.41581478,
+          periodEndSeconds,
+        },
+      );
+
+      expect(result).toMatchObject({
+        consumedCredits: 250_000,
+        incrementalCredits: 145_535,
+        cycleAllocation: 395_535,
+        remainingCredits: 145_535,
+        proratedRatio: 0.41581478,
+      });
+      expect(mockLimitFn).toHaveBeenNthCalledWith(1, "user-123:pro-plus", {
+        rate: 0,
+      });
+      expect(mockLimitFn).toHaveBeenNthCalledWith(2, "user-123:pro-plus", {
+        rate: 454_465,
+      });
+      expect(mockHsetFn).toHaveBeenCalledWith(
+        "usage:monthly:user-123:pro-plus",
+        expect.objectContaining({
+          tokens: 145_535,
+          cycleAllocation: 395_535,
+          cycleTierMax: 600_000,
+          refilledAt: (periodEndSeconds - 30 * 24 * 60 * 60) * 1000,
+        }),
+      );
+    });
+
+    it("does not create credits when no tier-change state exists", async () => {
+      mockEvalFn.mockResolvedValueOnce(null);
+      const { applyProratedTierChangeBucket } = getIsolatedModule();
+
+      await expect(
+        applyProratedTierChangeBucket("user-123", "pro-plus", {
+          proratedRatio: 0.5,
+        }),
+      ).resolves.toBeNull();
+
+      expect(mockDelFn).not.toHaveBeenCalled();
+      expect(mockLimitFn).not.toHaveBeenCalled();
+    });
+
+    it("does not let a delayed proration overwrite a newer cycle", async () => {
+      mockEvalFn.mockResolvedValueOnce(
+        JSON.stringify({
+          version: 2,
+          oldTier: "pro",
+          remaining: 0,
+          cycleAllocation: 250_000,
+          resetAtMs: Date.now() - 1_000,
+        }),
+      );
+      const { applyProratedTierChangeBucket } = getIsolatedModule();
+
+      await expect(
+        applyProratedTierChangeBucket("user-123", "pro-plus"),
+      ).resolves.toBeNull();
+
+      expect(mockDelFn).not.toHaveBeenCalled();
+      expect(mockLimitFn).not.toHaveBeenCalled();
+    });
+
+    it("restores claimed state when writing the new bucket fails", async () => {
+      const state = JSON.stringify({
+        version: 2,
+        oldTier: "pro",
+        remaining: 80_000,
+        cycleAllocation: 250_000,
+        resetAtMs: Date.now() + 12 * 24 * 60 * 60 * 1000,
+      });
+      mockEvalFn.mockResolvedValueOnce(state);
+      mockHsetFn.mockRejectedValueOnce(new Error("redis write failed"));
+      const { applyProratedTierChangeBucket } = getIsolatedModule();
+
+      await expect(
+        applyProratedTierChangeBucket("user-123", "pro-plus", {
+          proratedRatio: 1 / 3,
+        }),
+      ).rejects.toThrow("redis write failed");
+
+      expect(mockSetFn).toHaveBeenCalledWith(
+        "upgrade:carryover:user-123",
+        state,
+        { ex: 86_400 },
+      );
     });
   });
 

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -164,15 +164,28 @@ describe("token-bucket async functions", () => {
   });
 
   describe("tier-change bucket migration", () => {
-    it("atomically stashes the real cycle state and deletes the old bucket", async () => {
-      const resetAtMs = Date.now() + 12 * 24 * 60 * 60 * 1000;
-      const state = JSON.stringify({
-        version: 2,
+    const identity = {
+      subscriptionId: "sub_upgrade",
+      targetTier: "pro-plus" as const,
+      transitionId: "in_upgrade",
+    };
+
+    const tierChangeState = (overrides: Record<string, unknown> = {}) =>
+      JSON.stringify({
+        version: 3,
         oldTier: "pro",
+        targetTier: "pro-plus",
+        subscriptionId: "sub_upgrade",
+        transitionId: "in_upgrade",
         remaining: 0,
         cycleAllocation: 250_000,
-        resetAtMs,
+        resetAtMs: Date.now() + 12 * 24 * 60 * 60 * 1000,
+        ...overrides,
       });
+
+    it("atomically stashes the real cycle state and deletes the old bucket", async () => {
+      const resetAtMs = Date.now() + 12 * 24 * 60 * 60 * 1000;
+      const state = tierChangeState({ resetAtMs });
       mockLimitFn.mockResolvedValueOnce({
         success: true,
         remaining: 0,
@@ -183,14 +196,26 @@ describe("token-bucket async functions", () => {
       const { stashTierChangeBucketState } = getIsolatedModule();
 
       await expect(
-        stashTierChangeBucketState("user-123", "pro"),
+        stashTierChangeBucketState("user-123", "pro", { identity }),
       ).resolves.toEqual(JSON.parse(state));
 
       expect(mockLimitFn).toHaveBeenCalledWith("user-123:pro", { rate: 0 });
       expect(mockEvalFn).toHaveBeenCalledWith(
         expect.stringContaining('redis.call("SET", stashKey'),
-        ["usage:monthly:user-123:pro", "upgrade:carryover:user-123"],
-        [250_000, resetAtMs, "pro", 86_400],
+        [
+          "usage:monthly:user-123:pro",
+          "upgrade:carryover:user-123:in_upgrade",
+          "upgrade:carryover:user-123:in_upgrade:completed",
+        ],
+        [
+          250_000,
+          resetAtMs,
+          "pro",
+          86_400,
+          "sub_upgrade",
+          "pro-plus",
+          "in_upgrade",
+        ],
       );
     });
 
@@ -203,9 +228,7 @@ describe("token-bucket async functions", () => {
         limit: 250_000,
       });
       mockEvalFn.mockResolvedValueOnce(
-        JSON.stringify({
-          version: 2,
-          oldTier: "pro",
+        tierChangeState({
           remaining: 50_000,
           cycleAllocation: 200_000,
           resetAtMs,
@@ -213,33 +236,39 @@ describe("token-bucket async functions", () => {
       );
       const { stashTierChangeBucketState } = getIsolatedModule();
 
-      await stashTierChangeBucketState("user-123", "pro", 200_000);
+      await stashTierChangeBucketState("user-123", "pro", {
+        identity,
+        oldCycleAllocationPoints: 200_000,
+      });
 
       expect(mockEvalFn).toHaveBeenCalledWith(
         expect.any(String),
         expect.any(Array),
-        [200_000, resetAtMs, "pro", 86_400],
+        [
+          200_000,
+          resetAtMs,
+          "pro",
+          86_400,
+          "sub_upgrade",
+          "pro-plus",
+          "in_upgrade",
+        ],
       );
     });
 
     it("applies only the prorated Pro→Pro+ difference and preserves reset", async () => {
       const resetAtMs = Date.now() + 12 * 24 * 60 * 60 * 1000;
       const periodEndSeconds = Math.ceil(resetAtMs / 1000);
-      mockEvalFn.mockResolvedValueOnce(
-        JSON.stringify({
-          version: 2,
-          oldTier: "pro",
-          remaining: 0,
-          cycleAllocation: 250_000,
-          resetAtMs,
-        }),
-      );
+      mockEvalFn
+        .mockResolvedValueOnce(tierChangeState({ resetAtMs }))
+        .mockResolvedValueOnce([1, 145_535]);
       const { applyProratedTierChangeBucket } = getIsolatedModule();
 
       const result = await applyProratedTierChangeBucket(
         "user-123",
         "pro-plus",
         {
+          identity,
           proratedRatio: 0.41581478,
           periodEndSeconds,
         },
@@ -252,21 +281,24 @@ describe("token-bucket async functions", () => {
         remainingCredits: 145_535,
         proratedRatio: 0.41581478,
       });
-      expect(mockLimitFn).toHaveBeenNthCalledWith(1, "user-123:pro-plus", {
-        rate: 0,
-      });
-      expect(mockLimitFn).toHaveBeenNthCalledWith(2, "user-123:pro-plus", {
-        rate: 454_465,
-      });
-      expect(mockHsetFn).toHaveBeenCalledWith(
-        "usage:monthly:user-123:pro-plus",
-        expect.objectContaining({
-          tokens: 145_535,
-          cycleAllocation: 395_535,
-          cycleTierMax: 600_000,
-          refilledAt: (periodEndSeconds - 30 * 24 * 60 * 60) * 1000,
-        }),
+      expect(mockEvalFn).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('redis.call("DEL", stashKey, claimKey)'),
+        [
+          "usage:monthly:user-123:pro-plus",
+          "upgrade:carryover:user-123:in_upgrade",
+          "upgrade:carryover:user-123:in_upgrade:claim",
+          "upgrade:carryover:user-123:in_upgrade:completed",
+        ],
+        expect.arrayContaining([
+          tierChangeState({ resetAtMs }),
+          145_535,
+          395_535,
+          600_000,
+        ]),
       );
+      expect(mockLimitFn).not.toHaveBeenCalled();
+      expect(mockHsetFn).not.toHaveBeenCalled();
     });
 
     it("does not create credits when no tier-change state exists", async () => {
@@ -275,6 +307,7 @@ describe("token-bucket async functions", () => {
 
       await expect(
         applyProratedTierChangeBucket("user-123", "pro-plus", {
+          identity,
           proratedRatio: 0.5,
         }),
       ).resolves.toBeNull();
@@ -285,47 +318,56 @@ describe("token-bucket async functions", () => {
 
     it("does not let a delayed proration overwrite a newer cycle", async () => {
       mockEvalFn.mockResolvedValueOnce(
-        JSON.stringify({
-          version: 2,
-          oldTier: "pro",
-          remaining: 0,
-          cycleAllocation: 250_000,
+        tierChangeState({
           resetAtMs: Date.now() - 1_000,
         }),
       );
       const { applyProratedTierChangeBucket } = getIsolatedModule();
 
       await expect(
-        applyProratedTierChangeBucket("user-123", "pro-plus"),
+        applyProratedTierChangeBucket("user-123", "pro-plus", {
+          identity,
+          periodEndSeconds: Math.floor(Date.now() / 1000) + 12 * 24 * 60 * 60,
+        }),
       ).resolves.toBeNull();
 
       expect(mockDelFn).not.toHaveBeenCalled();
       expect(mockLimitFn).not.toHaveBeenCalled();
     });
 
-    it("restores claimed state when writing the new bucket fails", async () => {
-      const state = JSON.stringify({
-        version: 2,
-        oldTier: "pro",
+    it("retains the stash and claim when the atomic replacement fails", async () => {
+      const state = tierChangeState({
         remaining: 80_000,
-        cycleAllocation: 250_000,
-        resetAtMs: Date.now() + 12 * 24 * 60 * 60 * 1000,
       });
-      mockEvalFn.mockResolvedValueOnce(state);
-      mockHsetFn.mockRejectedValueOnce(new Error("redis write failed"));
+      mockEvalFn
+        .mockResolvedValueOnce(state)
+        .mockRejectedValueOnce(new Error("redis write failed"));
       const { applyProratedTierChangeBucket } = getIsolatedModule();
 
       await expect(
         applyProratedTierChangeBucket("user-123", "pro-plus", {
+          identity,
           proratedRatio: 1 / 3,
         }),
       ).rejects.toThrow("redis write failed");
 
-      expect(mockSetFn).toHaveBeenCalledWith(
-        "upgrade:carryover:user-123",
-        state,
-        { ex: 86_400 },
-      );
+      expect(mockSetFn).not.toHaveBeenCalled();
+      expect(mockDelFn).not.toHaveBeenCalled();
+    });
+
+    it("does not let a different Stripe transition consume the stash", async () => {
+      mockEvalFn.mockResolvedValueOnce(tierChangeState());
+      const { applyProratedTierChangeBucket } = getIsolatedModule();
+
+      await expect(
+        applyProratedTierChangeBucket("user-123", "pro-plus", {
+          identity: { ...identity, subscriptionId: "sub_other" },
+          proratedRatio: 0.5,
+        }),
+      ).resolves.toBeNull();
+
+      expect(mockEvalFn).toHaveBeenCalledTimes(1);
+      expect(mockLimitFn).not.toHaveBeenCalled();
     });
   });
 
@@ -1024,24 +1066,22 @@ describe("token-bucket async functions", () => {
   });
 
   describe("resetRateLimitBuckets", () => {
-    it("should delete the monthly Redis key and set explicit TTL", async () => {
+    it("atomically replaces the monthly bucket with an explicit TTL", async () => {
       const { resetRateLimitBuckets } = getIsolatedModule();
 
       await resetRateLimitBuckets("user-123", "pro");
 
-      expect(mockDelFn).toHaveBeenCalledWith("usage:monthly:user-123:pro");
-      expect(mockHsetFn).toHaveBeenCalledWith(
-        "usage:monthly:user-123:pro",
-        expect.objectContaining({
-          cycleAllocation: 250_000,
-          cycleTierMax: 250_000,
-          cycleStartedAt: expect.any(Number),
-        }),
-      );
-      // Verify explicit 30-day TTL is set
-      expect(mockExpireFn).toHaveBeenCalledWith(
-        "usage:monthly:user-123:pro",
-        30 * 24 * 60 * 60,
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.stringContaining('redis.call("EXPIRE", bucketKey'),
+        ["usage:monthly:user-123:pro"],
+        [
+          250_000,
+          250_000,
+          250_000,
+          expect.any(Number),
+          expect.any(Number),
+          30 * 24 * 60 * 60,
+        ],
       );
     });
 
@@ -1055,16 +1095,17 @@ describe("token-bucket async functions", () => {
 
         await resetRateLimitBuckets("user-123", "pro", periodEndSeconds);
 
-        expect(mockHsetFn).toHaveBeenCalledWith(
-          "usage:monthly:user-123:pro",
-          expect.objectContaining({
-            refilledAt: (periodEndSeconds - 30 * 24 * 60 * 60) * 1000,
-            cycleAllocation: 250_000,
-          }),
-        );
-        expect(mockExpireFn).toHaveBeenCalledWith(
-          "usage:monthly:user-123:pro",
-          32 * 24 * 60 * 60,
+        expect(mockEvalFn).toHaveBeenCalledWith(
+          expect.any(String),
+          ["usage:monthly:user-123:pro"],
+          [
+            250_000,
+            250_000,
+            250_000,
+            nowSeconds * 1000,
+            (periodEndSeconds - 30 * 24 * 60 * 60) * 1000,
+            32 * 24 * 60 * 60,
+          ],
         );
       } finally {
         nowSpy.mockRestore();
@@ -1076,15 +1117,17 @@ describe("token-bucket async functions", () => {
 
       await resetRateLimitBuckets("user-123", "pro", undefined, 200_000);
 
-      expect(mockLimitFn).toHaveBeenCalledWith(expect.any(String), {
-        rate: 50_000,
-      });
-      expect(mockHsetFn).toHaveBeenCalledWith(
-        "usage:monthly:user-123:pro",
-        expect.objectContaining({
-          cycleAllocation: 200_000,
-          cycleTierMax: 250_000,
-        }),
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.any(String),
+        ["usage:monthly:user-123:pro"],
+        [
+          200_000,
+          200_000,
+          250_000,
+          expect.any(Number),
+          expect.any(Number),
+          30 * 24 * 60 * 60,
+        ],
       );
     });
 
@@ -1098,30 +1141,27 @@ describe("token-bucket async functions", () => {
 
         await resetRateLimitBuckets("user-123", "pro", stalePeriodEndSeconds);
 
-        const metadata = mockHsetFn.mock.calls.find(
-          ([key]) => key === "usage:monthly:user-123:pro",
-        )?.[1] as Record<string, number> | undefined;
-
-        expect(metadata).toEqual(
-          expect.objectContaining({
-            cycleAllocation: 250_000,
-            cycleTierMax: 250_000,
-          }),
-        );
-        expect(metadata).not.toHaveProperty("refilledAt");
-        expect(mockExpireFn).toHaveBeenCalledWith(
-          "usage:monthly:user-123:pro",
-          30 * 24 * 60 * 60,
+        expect(mockEvalFn).toHaveBeenCalledWith(
+          expect.any(String),
+          ["usage:monthly:user-123:pro"],
+          [
+            250_000,
+            250_000,
+            250_000,
+            nowSeconds * 1000,
+            nowSeconds * 1000,
+            30 * 24 * 60 * 60,
+          ],
         );
       } finally {
         nowSpy.mockRestore();
       }
     });
 
-    it("should not throw when Redis delete fails", async () => {
+    it("should not throw when the atomic Redis write fails", async () => {
       const { resetRateLimitBuckets } = getIsolatedModule();
 
-      mockDelFn.mockRejectedValue(new Error("Redis down"));
+      mockEvalFn.mockRejectedValue(new Error("Redis down"));
       const consoleSpy = jest
         .spyOn(console, "error")
         .mockImplementation(() => {});
@@ -1154,9 +1194,10 @@ describe("token-bucket async functions", () => {
         targetRemaining: 200_000,
         pointsRemoved: 0,
       });
-      expect(mockHsetFn).toHaveBeenCalledWith(
-        "usage:monthly:user-123:pro",
-        expect.objectContaining({ cycleAllocation: 200_000 }),
+      expect(mockEvalFn).toHaveBeenCalledWith(
+        expect.stringContaining('"HSET"'),
+        ["usage:monthly:user-123:pro"],
+        expect.arrayContaining([200_000, 200_000, 250_000]),
       );
     });
 

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -229,6 +229,12 @@ describe("token-bucket", () => {
       expect(isUserRateLimitKey(`upgrade:carryover:${userId}`, userId)).toBe(
         true,
       );
+      expect(
+        isUserRateLimitKey(
+          `upgrade:carryover:${userId}:in_upgrade:claim`,
+          userId,
+        ),
+      ).toBe(true);
       expect(isUserRateLimitKey(`free_limit:${userId}:free:ask`, userId)).toBe(
         true,
       );

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -4,7 +4,7 @@ import {
   billableCostDollarsToPoints,
   calculateTokenCost,
   calculateRawTokenCost,
-  calculateProratedCredits,
+  calculateTierChangeCredits,
   getBudgetLimits,
   getCycleExpireSeconds,
   getSubscriptionPrice,
@@ -305,85 +305,68 @@ describe("token-bucket", () => {
   // ==========================================================================
   // Proration calculation logic
   // ==========================================================================
-  describe("calculateProratedCredits", () => {
-    // Tier maxes for reference: pro=250k, pro-plus=600k, ultra=2M, team=400k
-    // Third param is consumedCredits (deducted from prorated allocation)
+  describe("calculateTierChangeCredits", () => {
+    it("adds the prorated plan difference for an exhausted Pro→Pro+ upgrade", () => {
+      const result = calculateTierChangeCredits(
+        600_000,
+        250_000,
+        0,
+        0.41581478,
+      );
 
-    it("should give 50% credits at 50% ratio with no consumption", () => {
-      const result = calculateProratedCredits(2_000_000, 0.5, 0);
-      expect(result.proratedCredits).toBe(1_000_000);
-      expect(result.totalCredits).toBe(1_000_000);
-      expect(result.burnAmount).toBe(1_000_000);
+      expect(result).toEqual({
+        consumedCredits: 250_000,
+        incrementalCredits: 145_535,
+        cycleAllocation: 395_535,
+        remainingCredits: 145_535,
+      });
     });
 
-    it("should deduct consumed credits from prorated amount", () => {
-      // Pro → Ultra at day 15/30, user consumed 100k of Pro credits
-      const result = calculateProratedCredits(2_000_000, 0.5, 100_000);
-      expect(result.proratedCredits).toBe(1_000_000);
-      // total = 1M - 100k consumed = 900k
-      expect(result.totalCredits).toBe(900_000);
-      expect(result.burnAmount).toBe(1_100_000);
+    it("preserves unused old credits and adds only the prorated difference", () => {
+      const result = calculateTierChangeCredits(
+        600_000,
+        250_000,
+        80_000,
+        1 / 3,
+      );
+
+      expect(result).toEqual({
+        consumedCredits: 170_000,
+        incrementalCredits: 116_666,
+        cycleAllocation: 366_666,
+        remainingCredits: 196_666,
+      });
     });
 
-    it("should not go below 0 when consumed exceeds prorated", () => {
-      // User burned all 250k Pro credits, upgrades to Ultra at day 25/30
-      // prorated = floor(2M * 5/30) = 333_333
-      // consumed = 250_000 → 333_333 - 250_000 = 83_333
-      const result = calculateProratedCredits(2_000_000, 5 / 30, 250_000);
-      expect(result.totalCredits).toBe(83_333);
+    it("uses the stored cycle allocation for grandfathered plans", () => {
+      const result = calculateTierChangeCredits(600_000, 200_000, 50_000, 0.5);
 
-      // Edge: consumed > prorated → floor to 0
-      const result2 = calculateProratedCredits(2_000_000, 0.1, 250_000);
-      // prorated = 200k, consumed = 250k → 0
-      expect(result2.totalCredits).toBe(0);
+      expect(result).toEqual({
+        consumedCredits: 150_000,
+        incrementalCredits: 200_000,
+        cycleAllocation: 400_000,
+        remainingCredits: 250_000,
+      });
     });
 
-    it("should cap total credits at tier max", () => {
-      const result = calculateProratedCredits(250_000, 0.95, 0);
-      expect(result.totalCredits).toBeLessThanOrEqual(250_000);
+    it("caps a downgrade without restoring consumed usage", () => {
+      const result = calculateTierChangeCredits(250_000, 600_000, 400_000, 0.5);
+
+      expect(result).toEqual({
+        consumedCredits: 200_000,
+        incrementalCredits: 0,
+        cycleAllocation: 250_000,
+        remainingCredits: 50_000,
+      });
     });
 
-    it("should give full credits at ratio 1.0 with no consumption", () => {
-      const result = calculateProratedCredits(2_000_000, 1.0, 0);
-      expect(result.totalCredits).toBe(2_000_000);
-      expect(result.burnAmount).toBe(0);
-    });
-
-    it("should give 0 at ratio 0.0 with no consumption", () => {
-      const result = calculateProratedCredits(2_000_000, 0.0, 0);
-      expect(result.totalCredits).toBe(0);
-      expect(result.burnAmount).toBe(2_000_000);
-    });
-
-    it("should handle negative consumed as 0", () => {
-      const result = calculateProratedCredits(250_000, 0.5, -100);
-      expect(result.totalCredits).toBe(125_000); // just prorated, no deduction
-    });
-
-    it("should return 0 for zero tier max", () => {
-      const result = calculateProratedCredits(0, 0.5, 100_000);
-      expect(result.totalCredits).toBe(0);
-    });
-
-    it("user burns all Pro credits day 1, upgrades to Ultra", () => {
-      // Day 1 of 30 → ratio ≈ 29/30 = 0.967
-      // Consumed all 250k Pro credits
-      const result = calculateProratedCredits(2_000_000, 29 / 30, 250_000);
-      // prorated = floor(2M * 29/30) = 1_933_333
-      expect(result.proratedCredits).toBe(1_933_333);
-      // total = 1_933_333 - 250_000 = 1_683_333
-      expect(result.totalCredits).toBe(1_683_333);
-    });
-
-    it("Pro→Pro+ at 1/3 remaining, 170k consumed", () => {
-      // Day 20 of 30 → 10 days remaining → ratio = 1/3
-      // User consumed 170k of 250k Pro credits
-      const result = calculateProratedCredits(600_000, 1 / 3, 170_000);
-      // prorated = floor(600k * 0.333) = 200_000
-      expect(result.proratedCredits).toBe(200_000);
-      // total = 200k - 170k = 30k
-      expect(result.totalCredits).toBe(30_000);
-      expect(result.burnAmount).toBe(570_000);
+    it("clamps invalid remaining credits and proration ratios", () => {
+      expect(calculateTierChangeCredits(600_000, 250_000, 999_999, 2)).toEqual({
+        consumedCredits: 0,
+        incrementalCredits: 350_000,
+        cycleAllocation: 600_000,
+        remainingCredits: 600_000,
+      });
     });
   });
 

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -34,10 +34,10 @@ export {
   refundUsage,
   resetRateLimitBuckets,
   capCurrentCycleAllocation,
-  stashOldBucketRemaining,
-  popOldBucketRemaining,
+  stashTierChangeBucketState,
+  applyProratedTierChangeBucket,
+  calculateTierChangeCredits,
   initProratedBucket,
-  calculateProratedCredits,
   getTeamMemberConsumed,
   addOrgRemovedUsage,
   clearOrgRemovedUsage,
@@ -53,6 +53,9 @@ export {
   type UsageDeductionFailureReason,
   type UsageDeductionResult,
   type CycleAllocationCapResult,
+  type TierChangeBucketState,
+  type TierChangeCredits,
+  type AppliedTierChangeBucket,
 } from "./token-bucket";
 
 // Re-export sliding window functions

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -56,6 +56,7 @@ export {
   type TierChangeBucketState,
   type TierChangeCredits,
   type AppliedTierChangeBucket,
+  type TierChangeIdentity,
 } from "./token-bucket";
 
 // Re-export sliding window functions

--- a/lib/rate-limit/key-cleanup.ts
+++ b/lib/rate-limit/key-cleanup.ts
@@ -17,6 +17,7 @@ export const isUserRateLimitKey = (key: string, userId: string): boolean => {
   return (
     key.startsWith(`usage:monthly:${userId}:`) ||
     key === `upgrade:carryover:${userId}` ||
+    key.startsWith(`upgrade:carryover:${userId}:`) ||
     isFreeQuotaSubjectRateLimitKey(key, userId) ||
     (key.startsWith("team:debt_applied:") && key.endsWith(`:${userId}`))
   );

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -1248,7 +1248,7 @@ export const capCurrentCycleAllocation = async (
  *
  * Namespaces (keep in sync with key builders in this file and sliding-window.ts):
  *   - usage:monthly:<userId>:*       — monthly token bucket (any tier)
- *   - upgrade:carryover:<userId>     — upgrade proration stash
+ *   - upgrade:carryover:<userId>:*   — tier-change stash, claim, and completion keys
  *   - free_limit:<userId>:*          — free-tier shared ask/agent sliding window
  *   - free_referral_bonus:<userId>   — one-time free request units from referral signup
  *   - free_referral_bonus_grant:*:<userId> — referral bonus grant idempotency marker
@@ -1291,13 +1291,26 @@ export const deleteUserRateLimitKeys = async (
 // =============================================================================
 
 const TIER_CHANGE_STASH_TTL_SECONDS = 24 * 60 * 60;
+const TIER_CHANGE_COMPLETED_TTL_SECONDS = 35 * 24 * 60 * 60;
 const THIRTY_DAYS_MS = THIRTY_DAYS_SECONDS * 1000;
 
-const tierChangeStashKey = (userId: string) => `upgrade:carryover:${userId}`;
+export type TierChangeIdentity = {
+  subscriptionId: string;
+  targetTier: SubscriptionTier;
+  transitionId: string;
+};
+
+const tierChangeStashKey = (userId: string, transitionId: string) =>
+  `upgrade:carryover:${userId}:${transitionId}`;
+const tierChangeClaimKey = (stashKey: string) => `${stashKey}:claim`;
+const tierChangeCompletedKey = (stashKey: string) => `${stashKey}:completed`;
 
 export type TierChangeBucketState = {
-  version: 2;
+  version: 3;
   oldTier: SubscriptionTier | null;
+  targetTier: SubscriptionTier | null;
+  subscriptionId: string | null;
+  transitionId: string | null;
   remaining: number;
   cycleAllocation: number;
   resetAtMs: number;
@@ -1332,10 +1345,26 @@ const parseTierChangeBucketState = (
     typeof parsed.oldTier === "string" && parsed.oldTier in MONTHLY_CREDITS
       ? (parsed.oldTier as SubscriptionTier)
       : null;
+  const targetTier =
+    typeof parsed.targetTier === "string" &&
+    parsed.targetTier in MONTHLY_CREDITS
+      ? (parsed.targetTier as SubscriptionTier)
+      : null;
+  const subscriptionId =
+    typeof parsed.subscriptionId === "string" && parsed.subscriptionId
+      ? parsed.subscriptionId
+      : null;
+  const transitionId =
+    typeof parsed.transitionId === "string" && parsed.transitionId
+      ? parsed.transitionId
+      : null;
 
   return {
-    version: 2,
+    version: 3,
     oldTier,
+    targetTier,
+    subscriptionId,
+    transitionId,
     remaining: Math.min(remaining, cycleAllocation),
     cycleAllocation,
     resetAtMs,
@@ -1345,10 +1374,19 @@ const parseTierChangeBucketState = (
 const STASH_TIER_CHANGE_BUCKET_SCRIPT = `
 local bucketKey = KEYS[1]
 local stashKey = KEYS[2]
+local completedKey = KEYS[3]
 local oldCycleMax = tonumber(ARGV[1])
 local resetAtMs = tonumber(ARGV[2])
 local oldTier = ARGV[3]
 local ttlSeconds = tonumber(ARGV[4])
+local subscriptionId = ARGV[5]
+local targetTier = ARGV[6]
+local transitionId = ARGV[7]
+
+if redis.call("EXISTS", completedKey) == 1 then
+  redis.call("DEL", bucketKey)
+  return nil
+end
 
 local existing = redis.call("GET", stashKey)
 if existing then
@@ -1361,8 +1399,11 @@ local allocation = tonumber(redis.call("HGET", bucketKey, "cycleAllocation")) or
 allocation = math.max(0, math.min(oldCycleMax, allocation))
 local remaining = math.max(0, math.min(allocation, tokens))
 local state = cjson.encode({
-  version = 2,
+  version = 3,
   oldTier = oldTier,
+  targetTier = targetTier,
+  subscriptionId = subscriptionId,
+  transitionId = transitionId,
   remaining = remaining,
   cycleAllocation = allocation,
   resetAtMs = resetAtMs
@@ -1373,12 +1414,94 @@ redis.call("DEL", bucketKey)
 return state
 `;
 
-const POP_TIER_CHANGE_BUCKET_SCRIPT = `
-local raw = redis.call("GET", KEYS[1])
-if raw then
-  redis.call("DEL", KEYS[1])
+const CLAIM_TIER_CHANGE_BUCKET_SCRIPT = `
+local stashKey = KEYS[1]
+local claimKey = KEYS[2]
+local completedKey = KEYS[3]
+local ttlSeconds = tonumber(ARGV[1])
+
+if redis.call("EXISTS", completedKey) == 1 then
+  return nil
 end
+
+local raw = redis.call("GET", claimKey)
+if raw then return raw end
+
+raw = redis.call("GET", stashKey)
+if not raw then return nil end
+
+redis.call("SET", claimKey, raw, "EX", ttlSeconds)
 return raw
+`;
+
+const SET_MONTHLY_BUCKET_STATE_SCRIPT = `
+local bucketKey = KEYS[1]
+local remaining = tonumber(ARGV[1])
+local allocation = tonumber(ARGV[2])
+local tierMax = tonumber(ARGV[3])
+local cycleStartedAt = tonumber(ARGV[4])
+local refilledAt = tonumber(ARGV[5])
+local expireSeconds = tonumber(ARGV[6])
+
+redis.call("DEL", bucketKey)
+redis.call(
+  "HSET",
+  bucketKey,
+  "tokens", remaining,
+  "cycleAllocation", allocation,
+  "cycleTierMax", tierMax,
+  "cycleStartedAt", cycleStartedAt,
+  "refilledAt", refilledAt
+)
+redis.call("EXPIRE", bucketKey, expireSeconds)
+return remaining
+`;
+
+const APPLY_TIER_CHANGE_BUCKET_SCRIPT = `
+local bucketKey = KEYS[1]
+local stashKey = KEYS[2]
+local claimKey = KEYS[3]
+local completedKey = KEYS[4]
+local expectedClaim = ARGV[1]
+local desiredRemaining = tonumber(ARGV[2])
+local allocation = tonumber(ARGV[3])
+local tierMax = tonumber(ARGV[4])
+local cycleStartedAt = tonumber(ARGV[5])
+local refilledAt = tonumber(ARGV[6])
+local expireSeconds = tonumber(ARGV[7])
+local completedTtlSeconds = tonumber(ARGV[8])
+
+if redis.call("GET", claimKey) ~= expectedClaim then
+  return {0, 0}
+end
+if redis.call("GET", stashKey) ~= expectedClaim then
+  return {0, 0}
+end
+
+-- A request can create the target-tier bucket in the short interval between
+-- Stripe changing the entitlement and this migration. Preserve that usage.
+local existingTokens = tonumber(redis.call("HGET", bucketKey, "tokens"))
+local existingAllocation = redis.call("HGET", bucketKey, "cycleAllocation")
+local remaining = desiredRemaining
+if existingTokens and not existingAllocation then
+  local provisionalConsumed = math.max(0, tierMax - existingTokens)
+  remaining = math.max(0, desiredRemaining - provisionalConsumed)
+end
+
+redis.call("DEL", bucketKey)
+redis.call(
+  "HSET",
+  bucketKey,
+  "tokens", remaining,
+  "cycleAllocation", allocation,
+  "cycleTierMax", tierMax,
+  "cycleStartedAt", cycleStartedAt,
+  "refilledAt", refilledAt
+)
+redis.call("EXPIRE", bucketKey, expireSeconds)
+redis.call("SET", completedKey, "1", "EX", completedTtlSeconds)
+redis.call("DEL", stashKey, claimKey)
+return {1, remaining}
 `;
 
 /**
@@ -1389,8 +1512,11 @@ return raw
 export const stashTierChangeBucketState = async (
   userId: string,
   oldTier: SubscriptionTier,
-  oldCycleAllocationPoints?: number,
-): Promise<TierChangeBucketState> => {
+  options: {
+    identity: TierChangeIdentity;
+    oldCycleAllocationPoints?: number;
+  },
+): Promise<TierChangeBucketState | null> => {
   const redis = createRedisClient();
   if (!redis) throw new Error(RATE_LIMIT_SERVICE_NOT_CONFIGURED);
 
@@ -1400,7 +1526,7 @@ export const stashTierChangeBucketState = async (
   }
   const oldCycleMax = normalizeCycleAllocation(
     oldTierMax,
-    oldCycleAllocationPoints,
+    options.oldCycleAllocationPoints,
   );
 
   const { monthly } = createRateLimiter(redis, userId, oldTier);
@@ -1409,13 +1535,29 @@ export const stashTierChangeBucketState = async (
     Number.isFinite(snapshot.reset) && snapshot.reset > Date.now()
       ? snapshot.reset
       : Date.now() + THIRTY_DAYS_MS;
-  const raw = await redis.eval<[number, number, string, number], string>(
+  const stashKey = tierChangeStashKey(userId, options.identity.transitionId);
+  const raw = await redis.eval<
+    [number, number, string, number, string, string, string],
+    string | null
+  >(
     STASH_TIER_CHANGE_BUCKET_SCRIPT,
-    [getMonthlyBucketKey(userId, oldTier), tierChangeStashKey(userId)],
-    [oldCycleMax, resetAtMs, oldTier, TIER_CHANGE_STASH_TTL_SECONDS],
+    [
+      getMonthlyBucketKey(userId, oldTier),
+      stashKey,
+      tierChangeCompletedKey(stashKey),
+    ],
+    [
+      oldCycleMax,
+      resetAtMs,
+      oldTier,
+      TIER_CHANGE_STASH_TTL_SECONDS,
+      options.identity.subscriptionId,
+      options.identity.targetTier,
+      options.identity.transitionId,
+    ],
   );
 
-  return parseTierChangeBucketState(raw);
+  return raw ? parseTierChangeBucketState(raw) : null;
 };
 
 /**
@@ -1479,37 +1621,25 @@ const writeMonthlyBucketState = async (
     normalizedAllocation,
     Math.max(0, Math.round(remainingCredits)),
   );
-  const monthlyKey = getMonthlyBucketKey(userId, tier);
-
-  await redis.del(monthlyKey);
-  const { monthly } = createRateLimiter(redis, userId, tier);
-  await monthly.limiter.limit(monthly.key, { rate: 0 });
-
-  const burnAmount = tierMax - normalizedRemaining;
-  if (burnAmount > 0) {
-    await monthly.limiter.limit(monthly.key, { rate: burnAmount });
-  }
-
   const nowMs = Date.now();
   const nowSeconds = Math.floor(nowMs / 1000);
-  const bucketMetadata: Record<string, number> = {
-    tokens: normalizedRemaining,
-    cycleAllocation: normalizedAllocation,
-    cycleTierMax: tierMax,
-    cycleStartedAt: nowMs,
-  };
-  if (
+  const refilledAt =
     periodEndSeconds &&
     Number.isFinite(periodEndSeconds) &&
     periodEndSeconds > nowSeconds
-  ) {
-    bucketMetadata.refilledAt = (periodEndSeconds - THIRTY_DAYS_SECONDS) * 1000;
-  }
-
-  await redis.hset(monthlyKey, bucketMetadata);
-  await redis.expire(
-    monthlyKey,
-    getCycleExpireSeconds(periodEndSeconds, nowSeconds),
+      ? (periodEndSeconds - THIRTY_DAYS_SECONDS) * 1000
+      : nowMs;
+  await redis.eval<[number, number, number, number, number, number], number>(
+    SET_MONTHLY_BUCKET_STATE_SCRIPT,
+    [getMonthlyBucketKey(userId, tier)],
+    [
+      normalizedRemaining,
+      normalizedAllocation,
+      tierMax,
+      nowMs,
+      refilledAt,
+      getCycleExpireSeconds(periodEndSeconds, nowSeconds),
+    ],
   );
 };
 
@@ -1521,30 +1651,41 @@ export const applyProratedTierChangeBucket = async (
   userId: string,
   newTier: SubscriptionTier,
   options: {
+    identity: TierChangeIdentity;
     proratedRatio?: number;
     periodEndSeconds?: number;
     cycleAllocationPoints?: number;
-  } = {},
+  },
 ): Promise<AppliedTierChangeBucket | null> => {
   const redis = createRedisClient();
   if (!redis) throw new Error(RATE_LIMIT_SERVICE_NOT_CONFIGURED);
 
-  const stashKey = tierChangeStashKey(userId);
-  const raw = await redis.eval<[], string | null>(
-    POP_TIER_CHANGE_BUCKET_SCRIPT,
-    [stashKey],
-    [],
+  const stashKey = tierChangeStashKey(userId, options.identity.transitionId);
+  const claimKey = tierChangeClaimKey(stashKey);
+  const completedKey = tierChangeCompletedKey(stashKey);
+  const raw = await redis.eval<[number], string | null>(
+    CLAIM_TIER_CHANGE_BUCKET_SCRIPT,
+    [stashKey, claimKey, completedKey],
+    [TIER_CHANGE_STASH_TTL_SECONDS],
   );
   if (!raw) return null;
 
   const state = parseTierChangeBucketState(raw);
+  if (
+    state.subscriptionId !== options.identity.subscriptionId ||
+    state.targetTier !== newTier ||
+    state.transitionId !== options.identity.transitionId
+  ) {
+    return null;
+  }
   const nowMs = Date.now();
-  const requestedResetAtMs =
+  const fallbackResetAtMs =
     options.periodEndSeconds && Number.isFinite(options.periodEndSeconds)
       ? options.periodEndSeconds * 1000
-      : state.resetAtMs;
+      : 0;
+  const storedResetAtMs = state.resetAtMs || fallbackResetAtMs;
   // Never let a delayed proration webhook overwrite a newer renewal bucket.
-  if (requestedResetAtMs > 0 && requestedResetAtMs <= nowMs) return null;
+  if (state.resetAtMs > 0 && state.resetAtMs <= nowMs) return null;
 
   const tierMax = MONTHLY_CREDITS[newTier] ?? 0;
   const newCycleMax = normalizeCycleAllocation(
@@ -1565,27 +1706,33 @@ export const applyProratedTierChangeBucket = async (
     state.remaining,
     proratedRatio,
   );
-  const storedResetAtMs = requestedResetAtMs;
   const periodEndSeconds =
     storedResetAtMs > nowMs ? Math.ceil(storedResetAtMs / 1000) : undefined;
-
-  try {
-    await writeMonthlyBucketState(
-      redis,
-      userId,
-      newTier,
-      credits.cycleAllocation,
+  const refilledAt = periodEndSeconds
+    ? (periodEndSeconds - THIRTY_DAYS_SECONDS) * 1000
+    : nowMs;
+  const [applied, appliedRemaining] = await redis.eval<
+    [string, number, number, number, number, number, number, number],
+    [number, number]
+  >(
+    APPLY_TIER_CHANGE_BUCKET_SCRIPT,
+    [getMonthlyBucketKey(userId, newTier), stashKey, claimKey, completedKey],
+    [
+      raw,
       credits.remainingCredits,
-      periodEndSeconds,
-    );
-  } catch (error) {
-    // Restore the claim so a Stripe retry can safely finish the migration.
-    await redis.set(stashKey, raw, { ex: TIER_CHANGE_STASH_TTL_SECONDS });
-    throw error;
-  }
+      credits.cycleAllocation,
+      tierMax,
+      nowMs,
+      refilledAt,
+      getCycleExpireSeconds(periodEndSeconds, Math.floor(nowMs / 1000)),
+      TIER_CHANGE_COMPLETED_TTL_SECONDS,
+    ],
+  );
+  if (applied !== 1) return null;
 
   return {
     ...credits,
+    remainingCredits: appliedRemaining,
     proratedRatio,
     resetAtMs: storedResetAtMs,
   };

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -1287,93 +1287,307 @@ export const deleteUserRateLimitKeys = async (
 };
 
 // =============================================================================
-// Upgrade Proration
+// Tier-change proration
 // =============================================================================
 
+const TIER_CHANGE_STASH_TTL_SECONDS = 24 * 60 * 60;
+const THIRTY_DAYS_MS = THIRTY_DAYS_SECONDS * 1000;
+
+const tierChangeStashKey = (userId: string) => `upgrade:carryover:${userId}`;
+
+export type TierChangeBucketState = {
+  version: 2;
+  oldTier: SubscriptionTier | null;
+  remaining: number;
+  cycleAllocation: number;
+  resetAtMs: number;
+};
+
+export type TierChangeCredits = {
+  consumedCredits: number;
+  incrementalCredits: number;
+  cycleAllocation: number;
+  remainingCredits: number;
+};
+
+export type AppliedTierChangeBucket = TierChangeCredits & {
+  proratedRatio: number;
+  resetAtMs: number;
+};
+
+const parseTierChangeBucketState = (
+  raw: string | Record<string, unknown>,
+): TierChangeBucketState => {
+  const parsed =
+    typeof raw === "string"
+      ? (JSON.parse(raw) as Record<string, unknown>)
+      : raw;
+  const remaining = finiteNonNegativePoints(parsed.remaining) ?? 0;
+  const legacyConsumed = finiteNonNegativePoints(parsed.consumed) ?? 0;
+  const cycleAllocation =
+    finiteNonNegativePoints(parsed.cycleAllocation) ??
+    remaining + legacyConsumed;
+  const resetAtMs = finiteNonNegativePoints(parsed.resetAtMs) ?? 0;
+  const oldTier =
+    typeof parsed.oldTier === "string" && parsed.oldTier in MONTHLY_CREDITS
+      ? (parsed.oldTier as SubscriptionTier)
+      : null;
+
+  return {
+    version: 2,
+    oldTier,
+    remaining: Math.min(remaining, cycleAllocation),
+    cycleAllocation,
+    resetAtMs,
+  };
+};
+
+const STASH_TIER_CHANGE_BUCKET_SCRIPT = `
+local bucketKey = KEYS[1]
+local stashKey = KEYS[2]
+local oldCycleMax = tonumber(ARGV[1])
+local resetAtMs = tonumber(ARGV[2])
+local oldTier = ARGV[3]
+local ttlSeconds = tonumber(ARGV[4])
+
+local existing = redis.call("GET", stashKey)
+if existing then
+  redis.call("DEL", bucketKey)
+  return existing
+end
+
+local tokens = tonumber(redis.call("HGET", bucketKey, "tokens")) or oldCycleMax
+local allocation = tonumber(redis.call("HGET", bucketKey, "cycleAllocation")) or oldCycleMax
+allocation = math.max(0, math.min(oldCycleMax, allocation))
+local remaining = math.max(0, math.min(allocation, tokens))
+local state = cjson.encode({
+  version = 2,
+  oldTier = oldTier,
+  remaining = remaining,
+  cycleAllocation = allocation,
+  resetAtMs = resetAtMs
+})
+
+redis.call("SET", stashKey, state, "EX", ttlSeconds)
+redis.call("DEL", bucketKey)
+return state
+`;
+
+const POP_TIER_CHANGE_BUCKET_SCRIPT = `
+local raw = redis.call("GET", KEYS[1])
+if raw then
+  redis.call("DEL", KEYS[1])
+end
+return raw
+`;
+
 /**
- * Stash the old bucket's remaining tokens in a temporary Redis key before
- * deleting the bucket on tier change. The `invoice.paid` handler picks this
- * up to carry over unused credits into the prorated new-tier bucket.
+ * Atomically preserve the authoritative old-cycle allocation and remaining
+ * credits, then remove the old-tier bucket. Throws on storage failures so
+ * Stripe retries the event instead of accepting a partially applied change.
  */
-export const stashOldBucketRemaining = async (
+export const stashTierChangeBucketState = async (
   userId: string,
   oldTier: SubscriptionTier,
-): Promise<void> => {
+  oldCycleAllocationPoints?: number,
+): Promise<TierChangeBucketState> => {
   const redis = createRedisClient();
-  if (!redis) return;
+  if (!redis) throw new Error(RATE_LIMIT_SERVICE_NOT_CONFIGURED);
 
-  const monthlyKey = getMonthlyBucketKey(userId, oldTier);
-  const stashKey = `upgrade:carryover:${userId}`;
   const oldTierMax = MONTHLY_CREDITS[oldTier] ?? 0;
-
-  try {
-    const tokens = await redis.hget<number>(monthlyKey, "tokens");
-    const remaining = Math.max(0, tokens ?? 0);
-    const consumed = Math.max(0, oldTierMax - remaining);
-    // Stash both remaining and consumed so proration can deduct old-tier usage
-    await redis.set(stashKey, JSON.stringify({ remaining, consumed }), {
-      ex: 300,
-    }); // 5-minute TTL
-  } catch (error) {
-    console.error(
-      `[stashOldBucketRemaining] Failed for user ${userId}:`,
-      error,
-    );
+  if (oldTierMax <= 0) {
+    throw new Error(`Cannot migrate a bucket from tier "${oldTier}"`);
   }
+  const oldCycleMax = normalizeCycleAllocation(
+    oldTierMax,
+    oldCycleAllocationPoints,
+  );
+
+  const { monthly } = createRateLimiter(redis, userId, oldTier);
+  const snapshot = await monthly.limiter.limit(monthly.key, { rate: 0 });
+  const resetAtMs =
+    Number.isFinite(snapshot.reset) && snapshot.reset > Date.now()
+      ? snapshot.reset
+      : Date.now() + THIRTY_DAYS_MS;
+  const raw = await redis.eval<[number, number, string, number], string>(
+    STASH_TIER_CHANGE_BUCKET_SCRIPT,
+    [getMonthlyBucketKey(userId, oldTier), tierChangeStashKey(userId)],
+    [oldCycleMax, resetAtMs, oldTier, TIER_CHANGE_STASH_TTL_SECONDS],
+  );
+
+  return parseTierChangeBucketState(raw);
 };
 
 /**
- * Pop the stashed carry-over data for a user. Returns remaining and consumed
- * credits from the old tier, or null if no stash exists (no tier change
- * happened). The null case is used by the webhook to distinguish real tier
- * changes from other subscription updates (e.g. quantity changes).
+ * Compute the new cycle from the old cycle, not from the whole new plan.
+ * Upgrades add only the prorated difference between allocations. Downgrades
+ * cap the cycle immediately without restoring already-consumed credits.
  */
-export const popOldBucketRemaining = async (
-  userId: string,
-): Promise<{ remaining: number; consumed: number } | null> => {
-  const redis = createRedisClient();
-  if (!redis) return null;
-
-  const stashKey = `upgrade:carryover:${userId}`;
-
-  try {
-    const raw = await redis.get<string>(stashKey);
-    if (raw !== null) {
-      await redis.del(stashKey);
-    }
-    if (!raw) return null;
-    const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
-    return {
-      remaining: Math.max(0, parsed.remaining ?? 0),
-      consumed: Math.max(0, parsed.consumed ?? 0),
-    };
-  } catch (error) {
-    console.error(`[popOldBucketRemaining] Failed for user ${userId}:`, error);
-    return null;
-  }
-};
-
-/**
- * Calculate prorated credits for a mid-cycle upgrade (pure function).
- *
- *   proratedCredits = floor(tierMax * proratedRatio) - consumed
- *   totalCredits    = max(0, proratedCredits)
- *
- * Subtracting consumed ensures a user who burns all old-tier credits
- * then upgrades doesn't get a near-full new-tier bucket for the same cycle.
- */
-export const calculateProratedCredits = (
-  tierMax: number,
+export const calculateTierChangeCredits = (
+  newCycleMax: number,
+  oldCycleAllocation: number,
+  oldRemaining: number,
   proratedRatio: number,
-  consumedCredits: number = 0,
-): { proratedCredits: number; totalCredits: number; burnAmount: number } => {
-  const rawProrated = Math.floor(tierMax * proratedRatio);
-  const consumed = Math.max(0, consumedCredits);
-  const totalCredits = Math.max(0, Math.min(rawProrated - consumed, tierMax));
+): TierChangeCredits => {
+  const normalizedNewMax = Math.max(0, Math.round(newCycleMax));
+  const normalizedOldAllocation = Math.max(0, Math.round(oldCycleAllocation));
+  const normalizedOldRemaining = Math.min(
+    normalizedOldAllocation,
+    Math.max(0, Math.round(oldRemaining)),
+  );
+  const normalizedRatio = Number.isFinite(proratedRatio)
+    ? Math.max(0, Math.min(1, proratedRatio))
+    : 0;
+  const consumedCredits = Math.max(
+    0,
+    normalizedOldAllocation - normalizedOldRemaining,
+  );
+  const isUpgrade = normalizedNewMax >= normalizedOldAllocation;
+  const incrementalCredits = isUpgrade
+    ? Math.floor((normalizedNewMax - normalizedOldAllocation) * normalizedRatio)
+    : 0;
+  const cycleAllocation = isUpgrade
+    ? normalizedOldAllocation + incrementalCredits
+    : normalizedNewMax;
+
   return {
-    proratedCredits: rawProrated,
-    totalCredits,
-    burnAmount: tierMax - totalCredits,
+    consumedCredits,
+    incrementalCredits,
+    cycleAllocation,
+    remainingCredits: Math.max(0, cycleAllocation - consumedCredits),
+  };
+};
+
+const writeMonthlyBucketState = async (
+  redis: RedisClient,
+  userId: string,
+  tier: SubscriptionTier,
+  cycleAllocation: number,
+  remainingCredits: number,
+  periodEndSeconds?: number,
+): Promise<void> => {
+  const tierMax = MONTHLY_CREDITS[tier] ?? 0;
+  if (tierMax <= 0) {
+    throw new Error(`Cannot initialize a bucket for tier "${tier}"`);
+  }
+
+  const normalizedAllocation = normalizeCycleAllocation(
+    tierMax,
+    cycleAllocation,
+  );
+  const normalizedRemaining = Math.min(
+    normalizedAllocation,
+    Math.max(0, Math.round(remainingCredits)),
+  );
+  const monthlyKey = getMonthlyBucketKey(userId, tier);
+
+  await redis.del(monthlyKey);
+  const { monthly } = createRateLimiter(redis, userId, tier);
+  await monthly.limiter.limit(monthly.key, { rate: 0 });
+
+  const burnAmount = tierMax - normalizedRemaining;
+  if (burnAmount > 0) {
+    await monthly.limiter.limit(monthly.key, { rate: burnAmount });
+  }
+
+  const nowMs = Date.now();
+  const nowSeconds = Math.floor(nowMs / 1000);
+  const bucketMetadata: Record<string, number> = {
+    tokens: normalizedRemaining,
+    cycleAllocation: normalizedAllocation,
+    cycleTierMax: tierMax,
+    cycleStartedAt: nowMs,
+  };
+  if (
+    periodEndSeconds &&
+    Number.isFinite(periodEndSeconds) &&
+    periodEndSeconds > nowSeconds
+  ) {
+    bucketMetadata.refilledAt = (periodEndSeconds - THIRTY_DAYS_SECONDS) * 1000;
+  }
+
+  await redis.hset(monthlyKey, bucketMetadata);
+  await redis.expire(
+    monthlyKey,
+    getCycleExpireSeconds(periodEndSeconds, nowSeconds),
+  );
+};
+
+/**
+ * Claim and apply one stashed tier change. Missing state is a safe no-op: an
+ * unrelated subscription-update invoice must never mint a fresh bucket.
+ */
+export const applyProratedTierChangeBucket = async (
+  userId: string,
+  newTier: SubscriptionTier,
+  options: {
+    proratedRatio?: number;
+    periodEndSeconds?: number;
+    cycleAllocationPoints?: number;
+  } = {},
+): Promise<AppliedTierChangeBucket | null> => {
+  const redis = createRedisClient();
+  if (!redis) throw new Error(RATE_LIMIT_SERVICE_NOT_CONFIGURED);
+
+  const stashKey = tierChangeStashKey(userId);
+  const raw = await redis.eval<[], string | null>(
+    POP_TIER_CHANGE_BUCKET_SCRIPT,
+    [stashKey],
+    [],
+  );
+  if (!raw) return null;
+
+  const state = parseTierChangeBucketState(raw);
+  const nowMs = Date.now();
+  const requestedResetAtMs =
+    options.periodEndSeconds && Number.isFinite(options.periodEndSeconds)
+      ? options.periodEndSeconds * 1000
+      : state.resetAtMs;
+  // Never let a delayed proration webhook overwrite a newer renewal bucket.
+  if (requestedResetAtMs > 0 && requestedResetAtMs <= nowMs) return null;
+
+  const tierMax = MONTHLY_CREDITS[newTier] ?? 0;
+  const newCycleMax = normalizeCycleAllocation(
+    tierMax,
+    options.cycleAllocationPoints,
+  );
+  const derivedRatio = Math.max(
+    0,
+    Math.min(1, (state.resetAtMs - nowMs) / THIRTY_DAYS_MS),
+  );
+  const proratedRatio =
+    options.proratedRatio !== undefined
+      ? Math.max(0, Math.min(1, options.proratedRatio))
+      : derivedRatio;
+  const credits = calculateTierChangeCredits(
+    newCycleMax,
+    state.cycleAllocation,
+    state.remaining,
+    proratedRatio,
+  );
+  const storedResetAtMs = requestedResetAtMs;
+  const periodEndSeconds =
+    storedResetAtMs > nowMs ? Math.ceil(storedResetAtMs / 1000) : undefined;
+
+  try {
+    await writeMonthlyBucketState(
+      redis,
+      userId,
+      newTier,
+      credits.cycleAllocation,
+      credits.remainingCredits,
+      periodEndSeconds,
+    );
+  } catch (error) {
+    // Restore the claim so a Stripe retry can safely finish the migration.
+    await redis.set(stashKey, raw, { ex: TIER_CHANGE_STASH_TTL_SECONDS });
+    throw error;
+  }
+
+  return {
+    ...credits,
+    proratedRatio,
+    resetAtMs: storedResetAtMs,
   };
 };
 
@@ -1404,53 +1618,23 @@ export const initProratedBucket = async (
   if (newTierMax === 0) return;
 
   const cycleMax = normalizeCycleAllocation(newTierMax, cycleAllocationPoints);
-  const { totalCredits } = calculateProratedCredits(
-    cycleMax,
-    proratedRatio,
-    consumedCredits,
+  const normalizedRatio = Number.isFinite(proratedRatio)
+    ? Math.max(0, Math.min(1, proratedRatio))
+    : 0;
+  const cycleAllocation = Math.floor(cycleMax * normalizedRatio);
+  const totalCredits = Math.max(
+    0,
+    cycleAllocation - Math.max(0, Math.round(consumedCredits)),
   );
-  const burnAmount = newTierMax - totalCredits;
-  const monthlyKey = getMonthlyBucketKey(userId, newTier);
 
   try {
-    // Delete any existing bucket for the new tier
-    await redis.del(monthlyKey);
-
-    // Create fresh bucket at full capacity
-    const { monthly } = createRateLimiter(redis, userId, newTier);
-    await monthly.limiter.limit(monthly.key, { rate: 0 });
-
-    // Burn excess to bring bucket down to prorated level
-    if (burnAmount > 0) {
-      await monthly.limiter.limit(monthly.key, { rate: burnAmount });
-    }
-
-    // Align the UI-facing reset time with Stripe's billing cycle. Upstash's
-    // token bucket computes reset as `refilledAt + interval`; our interval is
-    // hardcoded to 30 d, so setting `refilledAt = periodEnd - 30 d` makes the
-    // reported reset land exactly on the next invoice date. `refilledAt` is
-    // an internal field of @upstash/ratelimit — re-verify on SDK upgrades.
-    const bucketMetadata: Record<string, number> = {
-      cycleAllocation: totalCredits,
-      cycleTierMax: newTierMax,
-      cycleStartedAt: Date.now(),
-    };
-    const nowSeconds = Math.floor(bucketMetadata.cycleStartedAt / 1000);
-
-    if (
-      periodEndSeconds &&
-      Number.isFinite(periodEndSeconds) &&
-      periodEndSeconds > nowSeconds
-    ) {
-      const targetRefilledAtMs =
-        (periodEndSeconds - THIRTY_DAYS_SECONDS) * 1000;
-      bucketMetadata.refilledAt = targetRefilledAtMs;
-    }
-
-    await redis.hset(monthlyKey, bucketMetadata);
-    await redis.expire(
-      monthlyKey,
-      getCycleExpireSeconds(periodEndSeconds, nowSeconds),
+    await writeMonthlyBucketState(
+      redis,
+      userId,
+      newTier,
+      cycleAllocation,
+      totalCredits,
+      periodEndSeconds,
     );
   } catch (error) {
     console.error(`[initProratedBucket] Failed for user ${userId}:`, error);


### PR DESCRIPTION
## Summary

- migrate tier-change usage from the authoritative old Upstash bucket instead of recalculating from the new plan maximum
- add only the prorated difference between the old and new cycle allocations while preserving consumed usage and the reset date
- bind migration state to the Stripe subscription, target tier, and invoice transition, then atomically apply it in Redis
- make Stripe webhook handling safe for out-of-order delivery, delayed retries, concurrent deductions, missing migration state, custom allocations, downgrades, and stale events
- add unit, Redis integration, and webhook regression coverage

## Root cause

Mid-cycle upgrades used `floor(newTierMax * remainingRatio) - consumedCredits`. For an exhausted Pro account upgrading to Pro+, this subtracted the full 250,000 previously consumed points from a prorated slice of the entire 600,000-point plan, producing zero additional usage.

The correct model is to preserve the old cycle and add only the prorated plan difference:

`oldAllocation + floor((newAllocation - oldAllocation) * remainingRatio)`

The old implementation also refilled the old-tier bucket after stashing it and could miss the migration when `invoice.paid` arrived before `customer.subscription.updated`.

## Impact

Customers upgrading mid-cycle now receive the paid prorated increase without receiving a full fresh monthly allowance or losing their already-earned remaining usage. Unrelated or delayed Stripe events cannot consume another transition's state or overwrite a newer usage cycle.

## Validation

- focused token-bucket and webhook regression suites — 134 tests passed
- full suite — 282 suites / 2,792 tests passed
- `corepack pnpm typecheck`
- targeted ESLint
- targeted Prettier check
- `git diff --check`

## Manual verification

1. In Stripe test mode, exhaust a Pro monthly bucket and upgrade it to Pro+ mid-cycle.
2. Confirm the webhook logs report a non-zero incremental point grant calculated from the invoice paid time.
3. Confirm the Pro+ Upstash hash preserves the original Stripe reset date and has a cycle allocation equal to the old allocation plus the prorated tier difference.
4. Confirm the user can immediately make a request and that Convex records successful included usage.
5. Deliver `invoice.paid` before `customer.subscription.updated` and confirm the subscription update completes the same invoice-bound migration exactly once.
6. Send a delayed duplicate event and confirm it does not alter the current bucket.
