### PR TITLE
Use Grok 4.5 instead of MiniMax M3

### DIFF
--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -104,7 +104,7 @@ describe("ModelSelector", () => {
     );
     expect(
       await screen.findAllByText(
-        "Powered by DeepSeek V4 Pro · MiniMax M3 for vision",
+        "Powered by DeepSeek V4 Pro · xAI Grok 4.5 for vision",
       ),
     ).not.toHaveLength(0);
 
@@ -113,9 +113,7 @@ describe("ModelSelector", () => {
     );
     await user.hover(screen.getByRole("button", { name: /HackerAI Pro/i }));
     expect(
-      await screen.findAllByText(
-        "Powered by xAI Grok 4.5 · Z.ai GLM 5.2 fallback",
-      ),
+      await screen.findAllByText("Powered by xAI Grok 4.5"),
     ).not.toHaveLength(0);
   });
 

--- a/app/components/ModelSelector/__tests__/options-drift.test.ts
+++ b/app/components/ModelSelector/__tests__/options-drift.test.ts
@@ -72,21 +72,21 @@ describe("ModelSelector tier ↔ provider drift", () => {
     }
   });
 
-  it("discloses the text and vision providers for Agent Standard", () => {
+  it("discloses the text and Grok vision providers for Agent Standard", () => {
     expect(
       AGENT_MODEL_OPTIONS.find((option) => option.id === "hackerai-standard")
         ?.poweredBy,
-    ).toBe("DeepSeek V4 Pro · MiniMax M3 for vision");
+    ).toBe("DeepSeek V4 Pro · xAI Grok 4.5 for vision");
   });
 
-  it("discloses Grok primary and GLM fallback for HackerAI Pro", () => {
+  it("discloses Grok 4.5 for HackerAI Pro", () => {
     expect(
       ASK_MODEL_OPTIONS.find((option) => option.id === "hackerai-pro")
         ?.poweredBy,
-    ).toBe("xAI Grok 4.5 · Z.ai GLM 5.2 fallback");
+    ).toBe("xAI Grok 4.5");
     expect(
       AGENT_MODEL_OPTIONS.find((option) => option.id === "hackerai-pro")
         ?.poweredBy,
-    ).toBe("xAI Grok 4.5 · Z.ai GLM 5.2 fallback");
+    ).toBe("xAI Grok 4.5");
   });
 });

--- a/app/components/ModelSelector/constants.ts
+++ b/app/components/ModelSelector/constants.ts
@@ -16,13 +16,13 @@ export const ASK_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-standard",
     label: "HackerAI Standard",
     description: "Reliable performance for everyday tasks",
-    poweredBy: "DeepSeek V4 Pro · MiniMax M3 for images · Grok 4.5 for PDFs",
+    poweredBy: "DeepSeek V4 Pro · xAI Grok 4.5 for vision",
   },
   {
     id: "hackerai-pro",
     label: "HackerAI Pro",
     description: "Superior performance for most assignments",
-    poweredBy: "xAI Grok 4.5 · Z.ai GLM 5.2 fallback",
+    poweredBy: "xAI Grok 4.5",
   },
   {
     id: "hackerai-max",
@@ -37,14 +37,14 @@ export const AGENT_MODEL_OPTIONS: ModelOption[] = [
     id: "hackerai-standard",
     label: "HackerAI Standard",
     description: "Reliable agent for everyday automation",
-    poweredBy: "DeepSeek V4 Pro · MiniMax M3 for vision",
+    poweredBy: "DeepSeek V4 Pro · xAI Grok 4.5 for vision",
     thinking: true,
   },
   {
     id: "hackerai-pro",
     label: "HackerAI Pro",
     description: "Superior performance for most assignments",
-    poweredBy: "xAI Grok 4.5 · Z.ai GLM 5.2 fallback",
+    poweredBy: "xAI Grok 4.5",
     thinking: true,
   },
   {

--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -655,7 +655,7 @@ describe("UsageTracker", () => {
       const usage = tracker.createUsageCostRecord({
         selectedModel: "agent-model-free",
         accountingModel: "model-kimi-k2.7-code",
-        configuredModelId: "minimax/minimax-m3",
+        configuredModelId: "x-ai/grok-4.5",
         rateLimitInfo: {
           remaining: 1000,
           resetTime: new Date(),
@@ -680,7 +680,7 @@ describe("UsageTracker", () => {
       const usage = tracker.createUsageCostRecord({
         selectedModel: "agent-model-free",
         accountingModel: "model-kimi-k2.7-code",
-        configuredModelId: "minimax/minimax-m3",
+        configuredModelId: "x-ai/grok-4.5",
         rateLimitInfo: {
           remaining: 1000,
           resetTime: new Date(),
@@ -748,7 +748,7 @@ describe("UsageTracker", () => {
       const usage = tracker.createUsageCostRecord({
         selectedModel: "agent-model-free",
         accountingModel: "model-kimi-k2.7-code",
-        configuredModelId: "minimax/minimax-m3",
+        configuredModelId: "x-ai/grok-4.5",
         rateLimitInfo: {
           remaining: 1000,
           resetTime: new Date(),

--- a/lib/actions/__tests__/index.test.ts
+++ b/lib/actions/__tests__/index.test.ts
@@ -55,6 +55,12 @@ describe("generateTitleFromUserMessage", () => {
       expect.objectContaining({
         maxOutputTokens: 64,
         maxRetries: 1,
+        providerOptions: {
+          openrouter: {
+            reasoning: { enabled: true, effort: "high" },
+          },
+          xai: { store: false },
+        },
         temperature: 0,
       }),
     );

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -65,6 +65,9 @@ export const generateTitleFromUserMessage = async (
     const { output } = await generateText({
       model: myProvider.languageModel("title-generator-model"),
       providerOptions: {
+        openrouter: {
+          reasoning: { enabled: true, effort: "high" },
+        },
         xai: {
           // Disable storing the conversation in XAI's database
           store: false,

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -9,10 +9,10 @@ describe("provider registry", () => {
   it("keeps active routes and stale compatibility keys pointed at their provider slugs", () => {
     expect(
       (myProvider.languageModel("ask-model") as { modelId: string }).modelId,
-    ).toBe("minimax/minimax-m3");
+    ).toBe("x-ai/grok-4.5");
     expect(
       (myProvider.languageModel("agent-model") as { modelId: string }).modelId,
-    ).toBe("minimax/minimax-m3");
+    ).toBe("x-ai/grok-4.5");
     expect(
       (myProvider.languageModel("agent-model-free") as { modelId: string })
         .modelId,
@@ -20,7 +20,7 @@ describe("provider registry", () => {
     expect(
       (myProvider.languageModel("model-minimax-m3") as { modelId: string })
         .modelId,
-    ).toBe("minimax/minimax-m3");
+    ).toBe("x-ai/grok-4.5");
     expect(
       (myProvider.languageModel("model-grok-4.5") as { modelId: string })
         .modelId,
@@ -50,16 +50,16 @@ describe("provider registry", () => {
     expect(
       (myProvider.languageModel("fallback-agent-model") as { modelId: string })
         .modelId,
-    ).toBe("minimax/minimax-m3");
+    ).toBe("x-ai/grok-4.5");
     expect(
       (myProvider.languageModel("fallback-ask-model") as { modelId: string })
         .modelId,
-    ).toBe("minimax/minimax-m3");
+    ).toBe("x-ai/grok-4.5");
     expect(
       (myProvider.languageModel("title-generator-model") as { modelId: string })
         .modelId,
     ).toBe("x-ai/grok-4.5");
-    expect(getModelDisplayName("model-minimax-m3")).toBe("MiniMax M3");
+    expect(getModelDisplayName("model-minimax-m3")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-grok-4.5")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-grok-4.5-pro")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-glm-5.2")).toBe("Z.ai GLM 5.2");
@@ -71,7 +71,7 @@ describe("provider registry", () => {
 describe("sanitizeOpenRouterRequestForXai", () => {
   it("strips encrypted reasoning details when an OpenRouter fallback can route to xAI", () => {
     const body = {
-      model: "minimax/minimax-m3",
+      model: "moonshotai/kimi-k2.7-code:exacto",
       models: ["x-ai/grok-4.5"],
       messages: [
         {
@@ -135,7 +135,7 @@ describe("sanitizeOpenRouterRequestForXai", () => {
 
   it("leaves non-xAI routes unchanged", () => {
     const body = {
-      model: "minimax/minimax-m3",
+      model: "moonshotai/kimi-k2.7-code:exacto",
       messages: [
         {
           role: "assistant",
@@ -198,11 +198,12 @@ describe("sanitizeOpenRouterRequestForXai", () => {
 });
 
 describe("supportsMultimodalToolResults", () => {
-  it("allows MiniMax and Kimi registry keys and OpenRouter slugs for image tool result experiments", () => {
+  it("allows Grok aliases and Kimi routes for image tool result experiments", () => {
     expect(supportsMultimodalToolResults("agent-model")).toBe(true);
     expect(supportsMultimodalToolResults("ask-model")).toBe(true);
     expect(supportsMultimodalToolResults("model-minimax-m3")).toBe(true);
-    expect(supportsMultimodalToolResults("minimax/minimax-m3")).toBe(true);
+    expect(supportsMultimodalToolResults("fallback-agent-model")).toBe(true);
+    expect(supportsMultimodalToolResults("fallback-ask-model")).toBe(true);
     expect(supportsMultimodalToolResults("model-kimi-k2.7-code")).toBe(true);
     expect(
       supportsMultimodalToolResults("moonshotai/kimi-k2.7-code:exacto"),

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -179,15 +179,14 @@ type OpenRouterInstance = typeof openrouter;
 
 export const KIMI_K2_7_CODE_SLUG = "moonshotai/kimi-k2.7-code:exacto";
 export const GLM_5_2_SLUG = "z-ai/glm-5.2";
-export const MINIMAX_M3_SLUG = "minimax/minimax-m3";
 export const GROK_4_5_SLUG = "x-ai/grok-4.5";
 export const DEEPSEEK_V4_FLASH_SLUG = "deepseek/deepseek-v4-flash";
 
 const buildProviderMap = (or: OpenRouterInstance) =>
   ({
-    "ask-model": or(MINIMAX_M3_SLUG),
+    "ask-model": or(GROK_4_5_SLUG),
     "ask-model-free": or(DEEPSEEK_V4_FLASH_SLUG),
-    "agent-model": or(MINIMAX_M3_SLUG),
+    "agent-model": or(GROK_4_5_SLUG),
     "agent-model-free": or(DEEPSEEK_V4_FLASH_SLUG),
     "model-sonnet-4.6": or("anthropic/claude-sonnet-4-6"),
     "model-grok-4.5": or(GROK_4_5_SLUG),
@@ -201,13 +200,15 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "model-deepseek-v4-pro": or("deepseek/deepseek-v4-pro"),
     "model-opus-4.6": or("anthropic/claude-opus-4.6"),
     "model-glm-5.2": or(GLM_5_2_SLUG),
-    "model-minimax-m3": or(MINIMAX_M3_SLUG),
+    // Compatibility alias for persisted MiniMax selections. All new and stale
+    // callers now resolve to Grok 4.5 so no route continues sending MiniMax.
+    "model-minimax-m3": or(GROK_4_5_SLUG),
     "model-kimi-k2.7-code": or(KIMI_K2_7_CODE_SLUG),
     // Compatibility alias for stale internal references persisted before the
-    // Kimi 2.7 Code rollout. New Agent Standard selections use model-minimax-m3.
+    // Kimi 2.7 Code rollout. New Agent Standard media selections use Grok 4.5.
     "model-kimi-k2.6": or(KIMI_K2_7_CODE_SLUG),
-    "fallback-agent-model": or(MINIMAX_M3_SLUG),
-    "fallback-ask-model": or(MINIMAX_M3_SLUG),
+    "fallback-agent-model": or(GROK_4_5_SLUG),
+    "fallback-ask-model": or(GROK_4_5_SLUG),
     "fallback-grok-4.5": or(GROK_4_5_SLUG),
     "title-generator-model": or(GROK_4_5_SLUG),
   }) as Record<string, any>;
@@ -218,9 +219,9 @@ export type ModelName = keyof typeof baseProviders;
 
 export const modelCutoffDates: Record<ModelName, string> &
   Record<string, string> = {
-  "ask-model": "May 2026",
+  "ask-model": "July 2026",
   "ask-model-free": "May 2025",
-  "agent-model": "May 2026",
+  "agent-model": "July 2026",
   "agent-model-free": "May 2025",
   "model-sonnet-4.6": "May 2025",
   "model-grok-4.5": "July 2026",
@@ -230,11 +231,11 @@ export const modelCutoffDates: Record<ModelName, string> &
   "model-deepseek-v4-pro": "May 2025",
   "model-opus-4.6": "May 2025",
   "model-glm-5.2": "June 2026",
-  "model-minimax-m3": "May 2026",
+  "model-minimax-m3": "July 2026",
   "model-kimi-k2.7-code": "June 2025",
   "model-kimi-k2.6": "June 2025",
-  "fallback-agent-model": "May 2026",
-  "fallback-ask-model": "May 2026",
+  "fallback-agent-model": "July 2026",
+  "fallback-ask-model": "July 2026",
   "fallback-grok-4.5": "July 2026",
   "title-generator-model": "July 2026",
 };
@@ -253,7 +254,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-deepseek-v4-pro": "DeepSeek V4 Pro",
   "model-opus-4.6": "Anthropic Claude Opus 4.6",
   "model-glm-5.2": "Z.ai GLM 5.2",
-  "model-minimax-m3": "MiniMax M3",
+  "model-minimax-m3": "xAI Grok 4.5",
   "model-kimi-k2.7-code": "Moonshot Kimi K2.7 Code",
   "model-kimi-k2.6": "Moonshot Kimi K2.7 Code",
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
@@ -293,13 +294,17 @@ export function isKimiModel(modelName: string): boolean {
   );
 }
 
-export function isMiniMaxModel(modelName: string): boolean {
+function isGrokModel(modelName: string): boolean {
   const normalized = modelName.toLowerCase();
   return (
     normalized === "agent-model" ||
     normalized === "ask-model" ||
+    normalized === "fallback-agent-model" ||
+    normalized === "fallback-ask-model" ||
     normalized === "model-minimax-m3" ||
-    normalized.includes("minimax/minimax-m3")
+    normalized === "model-gemini-3-flash" ||
+    normalized.includes("x-ai/") ||
+    normalized.includes("grok")
   );
 }
 
@@ -309,9 +314,8 @@ export function supportsMultimodalToolResults(modelName?: string): boolean {
   const normalized = modelName.toLowerCase();
 
   return (
-    normalized === "model-gemini-3-flash" ||
     isKimiModel(normalized) ||
-    isMiniMaxModel(normalized) ||
+    isGrokModel(normalized) ||
     isAnthropicModel(normalized) ||
     normalized.includes("anthropic/") ||
     normalized.includes("claude") ||
@@ -319,9 +323,7 @@ export function supportsMultimodalToolResults(modelName?: string): boolean {
     normalized.includes("gpt-") ||
     normalized.includes("o1") ||
     normalized.includes("o3") ||
-    normalized.includes("o4") ||
-    normalized.includes("x-ai/") ||
-    normalized.includes("grok")
+    normalized.includes("o4")
   );
 }
 

--- a/lib/ai/tools/__tests__/get-terminal-files.test.ts
+++ b/lib/ai/tools/__tests__/get-terminal-files.test.ts
@@ -42,7 +42,7 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
     assistantMessageId: "assistant-1",
     ptySessionManager: {} as never,
     mode: "agent",
-    modelName: "model-minimax-m3",
+    modelName: "model-grok-4.5",
     subscription: "pro",
     isE2BSandbox: (() => true) as never,
     ...overrides,

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -166,14 +166,14 @@ describe("resolveAgentModelForImageToolResults", () => {
     ).toBe("model-deepseek-v4-pro");
   });
 
-  it("switches DeepSeek Agent steps to Kimi after image tool results", () => {
+  it("switches DeepSeek Agent steps to Grok after image tool results", () => {
     expect(
       resolveAgentModelForImageToolResults(
         "model-deepseek-v4-pro",
         "agent",
         true,
       ),
-    ).toBe("model-kimi-k2.7-code");
+    ).toBe("model-grok-4.5");
   });
 
   it("keeps the HackerAI Pro GLM fallback active after image tool results", () => {
@@ -182,10 +182,10 @@ describe("resolveAgentModelForImageToolResults", () => {
     ).toBe("model-glm-5.2");
   });
 
-  it("switches free DeepSeek Agent steps to MiniMax after image tool results", () => {
+  it("switches free DeepSeek Agent steps to Grok after image tool results", () => {
     expect(
       resolveAgentModelForImageToolResults("agent-model-free", "agent", true),
-    ).toBe("model-minimax-m3");
+    ).toBe("model-grok-4.5");
   });
 
   it("does not change Ask routes or multimodal Agent models", () => {
@@ -211,7 +211,7 @@ describe("resolveFallbackServedTelemetry", () => {
       resolveFallbackServedTelemetry({
         requestedModel: "deepseek/deepseek-v4-pro",
         responseModel: "deepseek/deepseek-v4-pro",
-        fallbackModels: ["minimax/minimax-m3"],
+        fallbackModels: ["x-ai/grok-4.5"],
       }),
     ).toBe(false);
   });
@@ -220,15 +220,15 @@ describe("resolveFallbackServedTelemetry", () => {
     expect(
       resolveFallbackServedTelemetry({
         requestedModel: "deepseek/deepseek-v4-pro",
-        responseModel: "minimax/minimax-m3",
-        fallbackModels: ["minimax/minimax-m3"],
+        responseModel: "x-ai/grok-4.5",
+        fallbackModels: ["x-ai/grok-4.5"],
       }),
     ).toBe(true);
     expect(
       resolveFallbackServedTelemetry({
-        requestedModel: "minimax/minimax-m3",
-        responseModel: "minimax/minimax-m3",
-        fallbackModels: ["minimax/minimax-m3"],
+        requestedModel: "x-ai/grok-4.5",
+        responseModel: "x-ai/grok-4.5",
+        fallbackModels: ["x-ai/grok-4.5"],
       }),
     ).toBe(false);
   });
@@ -255,9 +255,9 @@ describe("retry served-model telemetry", () => {
     expect(
       retryUsesDifferentModel("agent-model-free", "agent-model-free"),
     ).toBe(false);
-    expect(
-      retryUsesDifferentModel("agent-model-free", "model-minimax-m3"),
-    ).toBe(true);
+    expect(retryUsesDifferentModel("agent-model-free", "model-grok-4.5")).toBe(
+      true,
+    );
   });
 
   it("clears prior served-model state before a retry can abort without metadata", () => {

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -134,7 +134,7 @@ describe("captureAgentRun", () => {
       sandboxInfo: null,
       outcome: "success",
       selectedModel: "agent-model",
-      configuredModelId: "minimax/minimax-m3",
+      configuredModelId: "x-ai/grok-4.5",
       triggerRunId: "run_zero",
       triggerUsageDurationMs: 0,
       triggerTotalCostUsd: 0,
@@ -171,7 +171,7 @@ describe("captureAgentRun", () => {
       outcome: "success",
       selectedModel: "agent-model-free",
       configuredModelId: "deepseek/deepseek-v4-flash",
-      responseModel: "minimax/minimax-m3",
+      responseModel: "x-ai/grok-4.5",
       fallbackServed: true,
     });
 
@@ -181,7 +181,7 @@ describe("captureAgentRun", () => {
       properties: expect.objectContaining({
         selected_model: "agent-model-free",
         configured_model: "deepseek/deepseek-v4-flash",
-        response_model: "minimax/minimax-m3",
+        response_model: "x-ai/grok-4.5",
         fallback_served: true,
       }),
     });
@@ -759,7 +759,7 @@ describe("createChatLogger provider stream termination", () => {
       chatLogger.recordProviderError(err, {
         mode: "agent",
         model: "agent-model",
-        requestedModelSlug: "minimax/minimax-m3",
+        requestedModelSlug: "x-ai/grok-4.5",
       });
       chatLogger.emitUnexpectedError(err);
 
@@ -1541,7 +1541,7 @@ describe("createChatLogger provider stream timeout", () => {
       chatLogger.recordProviderError(err, {
         mode: "agent",
         model: "agent-model",
-        requestedModelSlug: "minimax/minimax-m3",
+        requestedModelSlug: "x-ai/grok-4.5",
       });
       chatLogger.emitUnexpectedError(err);
 

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -27,8 +27,47 @@ const GROK_SLUG = "x-ai/grok-4.5";
 const KIMI_SLUG = "moonshotai/kimi-k2.7-code:exacto";
 const GLM_SLUG = "z-ai/glm-5.2";
 const DEEPSEEK_FLASH_SLUG = "deepseek/deepseek-v4-flash";
+const GROK_PRIMARY_OR_FALLBACK_MODELS = [
+  "ask-model",
+  "ask-model-free",
+  "agent-model",
+  "agent-model-free",
+  "model-sonnet-4.6",
+  "model-grok-4.5",
+  "model-grok-4.5-pro",
+  "model-gemini-3-flash",
+  "model-deepseek-v4-flash",
+  "model-deepseek-v4-pro",
+  "model-opus-4.6",
+  "model-glm-5.2",
+  "model-minimax-m3",
+  "model-kimi-k2.7-code",
+  "model-kimi-k2.6",
+  "fallback-agent-model",
+  "fallback-ask-model",
+  "fallback-grok-4.5",
+  "title-generator-model",
+] as const;
 
 describe("buildProviderOptions fallback chain", () => {
+  it.each(GROK_PRIMARY_OR_FALLBACK_MODELS)(
+    "uses high reasoning whenever %s can resolve to Grok",
+    (modelName) => {
+      for (const mode of ["ask", "agent"] as const) {
+        const opts = buildProviderOptions(
+          mode === "agent",
+          "user-1",
+          modelName,
+          mode,
+        );
+        expect(opts.openrouter.reasoning).toEqual({
+          enabled: true,
+          effort: "high",
+        });
+      }
+    },
+  );
+
   it("resolves Opus 4.6 ask chain to Grok", () => {
     const opts = buildProviderOptions(false, "user-1", "model-opus-4.6", "ask");
     expect(opts.openrouter).toMatchObject({
@@ -255,7 +294,7 @@ describe("buildProviderOptions fallback chain", () => {
   it("falls back from paid Ask PDF Grok route to Kimi", () => {
     const opts = buildProviderOptions(false, "user-1", "model-grok-4.5", "ask");
     expect(opts.openrouter).toMatchObject({
-      reasoning: { enabled: true, effort: "medium" },
+      reasoning: { enabled: true, effort: "high" },
       models: [KIMI_SLUG],
       user: "user-1",
     });
@@ -283,14 +322,17 @@ describe("buildProviderOptions fallback chain", () => {
   });
 
   it.each(["ask-model-free", "model-deepseek-v4-flash"])(
-    "keeps reasoning disabled for free/flash ask mode model %s",
+    "uses high reasoning when free/flash ask model %s can fall back to Grok",
     (modelName) => {
       const opts = buildProviderOptions(false, "user-1", modelName, "ask");
-      expect(opts.openrouter.reasoning).toEqual({ enabled: false });
+      expect(opts.openrouter.reasoning).toEqual({
+        enabled: true,
+        effort: "high",
+      });
     },
   );
 
-  it("allows a scoped reasoning override", () => {
+  it("keeps Grok fallback reasoning high over a lower scoped override", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -303,9 +345,27 @@ describe("buildProviderOptions fallback chain", () => {
 
     expect(opts.openrouter.reasoning).toEqual({
       enabled: true,
-      effort: "medium",
+      effort: "high",
     });
     expect(opts.openrouter.models).toEqual([GROK_SLUG, KIMI_SLUG]);
+  });
+
+  it("allows a scoped reasoning override when Grok is not in the route", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "model-does-not-exist",
+      "ask",
+      {
+        reasoningOverride: { enabled: true, effort: "medium" },
+      },
+    );
+
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+      effort: "medium",
+    });
+    expect(opts.openrouter).not.toHaveProperty("models");
   });
 
   it("enables reasoning for the current Kimi 2.7 Code ask route", () => {
@@ -317,6 +377,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(opts.openrouter.reasoning).toEqual({
       enabled: true,
+      effort: "high",
     });
   });
 
@@ -329,6 +390,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(opts.openrouter.reasoning).toEqual({
       enabled: true,
+      effort: "high",
     });
   });
 
@@ -339,13 +401,16 @@ describe("buildProviderOptions fallback chain", () => {
     "model-grok-4.5",
     "model-gemini-3-flash",
     "fallback-grok-4.5",
-  ])("enables medium reasoning for ask mode model %s", (modelName) => {
-    const opts = buildProviderOptions(false, "user-1", modelName, "ask");
-    expect(opts.openrouter.reasoning).toEqual({
-      enabled: true,
-      effort: "medium",
-    });
-  });
+  ])(
+    "enables high reasoning for Grok-backed ask mode model %s",
+    (modelName) => {
+      const opts = buildProviderOptions(false, "user-1", modelName, "ask");
+      expect(opts.openrouter.reasoning).toEqual({
+        enabled: true,
+        effort: "high",
+      });
+    },
+  );
 
   it.each([
     "model-grok-4.5-pro",
@@ -405,7 +470,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(grokReasoning.openrouter).toMatchObject({
-      reasoning: { enabled: true },
+      reasoning: { enabled: true, effort: "high" },
       models: [KIMI_SLUG],
     });
 

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -255,6 +255,7 @@ describe("buildProviderOptions fallback chain", () => {
   it("falls back from paid Ask PDF Grok route to Kimi", () => {
     const opts = buildProviderOptions(false, "user-1", "model-grok-4.5", "ask");
     expect(opts.openrouter).toMatchObject({
+      reasoning: { enabled: true, effort: "medium" },
       models: [KIMI_SLUG],
       user: "user-1",
     });

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -24,7 +24,6 @@ jest.mock("@/lib/logger", () => ({
 // Slugs the test asserts against. These match the registry in lib/ai/providers.ts.
 // If the registry slug for a model changes, update both places intentionally.
 const GROK_SLUG = "x-ai/grok-4.5";
-const MINIMAX_SLUG = "minimax/minimax-m3";
 const KIMI_SLUG = "moonshotai/kimi-k2.7-code:exacto";
 const GLM_SLUG = "z-ai/glm-5.2";
 const DEEPSEEK_FLASH_SLUG = "deepseek/deepseek-v4-flash";
@@ -38,7 +37,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("resolves Opus 4.6 text-only agent chain to MiniMax, Kimi 2.7 Code, then Grok slugs", () => {
+  it("resolves Opus 4.6 text-only agent chain to Grok then Kimi 2.7 Code", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -46,7 +45,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
+      models: [GROK_SLUG, KIMI_SLUG],
       user: "user-1",
     });
   });
@@ -78,7 +77,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("resolves Sonnet 4.6 text-only agent chain to MiniMax, Kimi 2.7 Code, then Grok slugs", () => {
+  it("resolves Sonnet 4.6 text-only agent chain to Grok then Kimi 2.7 Code", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -86,7 +85,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
+      models: [GROK_SLUG, KIMI_SLUG],
       user: "user-1",
     });
   });
@@ -118,7 +117,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("keeps Anthropic multimodal agent fallback off MiniMax once image tool results exist", () => {
+  it("keeps Anthropic multimodal agent fallback on Kimi then Grok", () => {
     const opus = buildProviderOptions(
       false,
       "user-1",
@@ -138,19 +137,17 @@ describe("buildProviderOptions fallback chain", () => {
 
     expect(opus.openrouter.models).toEqual([KIMI_SLUG, GROK_SLUG]);
     expect(sonnet.openrouter.models).toEqual([KIMI_SLUG, GROK_SLUG]);
-    expect(opus.openrouter.models).not.toContain(MINIMAX_SLUG);
-    expect(sonnet.openrouter.models).not.toContain(MINIMAX_SLUG);
   });
 
-  it("falls back from auto agent MiniMax to Kimi 2.7 Code then Grok", () => {
+  it("falls back from the Grok-backed auto agent route to Kimi 2.7 Code", () => {
     const opts = buildProviderOptions(false, "user-1", "agent-model", "agent");
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG, GROK_SLUG],
+      models: [KIMI_SLUG],
       user: "user-1",
     });
   });
 
-  it("falls back from explicit MiniMax to Kimi 2.7 Code then Grok", () => {
+  it("keeps the stale MiniMax key on Grok's Kimi fallback", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -158,7 +155,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG, GROK_SLUG],
+      models: [KIMI_SLUG],
       user: "user-1",
     });
   });
@@ -214,13 +211,13 @@ describe("buildProviderOptions fallback chain", () => {
     (modelName, mode) => {
       const opts = buildProviderOptions(false, "user-1", modelName, mode);
       expect(opts.openrouter).toMatchObject({
-        models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
+        models: [GROK_SLUG, KIMI_SLUG],
         user: "user-1",
       });
     },
   );
 
-  it("runs free Agent on DeepSeek Flash high and falls back through MiniMax, Kimi, then Grok", () => {
+  it("runs free Agent on DeepSeek Flash high and falls back through Grok then Kimi", () => {
     const opts = buildProviderOptions(
       true,
       "user-1",
@@ -229,12 +226,12 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(opts.openrouter).toMatchObject({
       reasoning: { enabled: true, effort: "high" },
-      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
+      models: [GROK_SLUG, KIMI_SLUG],
       user: "user-1",
     });
   });
 
-  it("falls back from explicit DeepSeek Pro ask model through MiniMax, Kimi, then Grok", () => {
+  it("falls back from explicit DeepSeek Pro ask model through Grok then Kimi", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -242,23 +239,23 @@ describe("buildProviderOptions fallback chain", () => {
       "ask",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
+      models: [GROK_SLUG, KIMI_SLUG],
       user: "user-1",
     });
   });
 
-  it("falls back from paid Ask image auto route through Kimi then Grok", () => {
+  it("falls back from the Grok-backed paid Ask image route to Kimi", () => {
     const opts = buildProviderOptions(false, "user-1", "ask-model", "ask");
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG, GROK_SLUG],
+      models: [KIMI_SLUG],
       user: "user-1",
     });
   });
 
-  it("falls back from paid Ask PDF Grok route through MiniMax, Kimi, then Grok", () => {
+  it("falls back from paid Ask PDF Grok route to Kimi", () => {
     const opts = buildProviderOptions(false, "user-1", "model-grok-4.5", "ask");
     expect(opts.openrouter).toMatchObject({
-      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
+      models: [KIMI_SLUG],
       user: "user-1",
     });
   });
@@ -266,7 +263,7 @@ describe("buildProviderOptions fallback chain", () => {
   it("keeps the stale media route alias on the active Ask fallback chain", () => {
     const opts = buildProviderOptions(false, "user-1", "model-gemini-3-flash");
     expect(opts.openrouter).toMatchObject({
-      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
+      models: [KIMI_SLUG],
       user: "user-1",
     });
   });
@@ -307,11 +304,7 @@ describe("buildProviderOptions fallback chain", () => {
       enabled: true,
       effort: "medium",
     });
-    expect(opts.openrouter.models).toEqual([
-      MINIMAX_SLUG,
-      KIMI_SLUG,
-      GROK_SLUG,
-    ]);
+    expect(opts.openrouter.models).toEqual([GROK_SLUG, KIMI_SLUG]);
   });
 
   it("enables reasoning for the current Kimi 2.7 Code ask route", () => {
@@ -401,18 +394,18 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(reasoning.openrouter).toMatchObject({
       reasoning: { enabled: true, effort: "high" },
-      models: [MINIMAX_SLUG, KIMI_SLUG, GROK_SLUG],
+      models: [GROK_SLUG, KIMI_SLUG],
     });
 
-    const noReasoning = buildProviderOptions(
+    const grokReasoning = buildProviderOptions(
       false,
       "user-1",
       "agent-model",
       "agent",
     );
-    expect(noReasoning.openrouter).toMatchObject({
-      reasoning: { enabled: false },
-      models: [KIMI_SLUG, GROK_SLUG],
+    expect(grokReasoning.openrouter).toMatchObject({
+      reasoning: { enabled: true },
+      models: [KIMI_SLUG],
     });
 
     const multimodal = buildProviderOptions(
@@ -479,18 +472,20 @@ describe("getRetryFallbackModel", () => {
   ] as const)(
     "uses the paid Agent fallback chain for app-side retry after free DeepSeek route %s fails",
     (modelName, mode) => {
-      expect(getRetryFallbackModel(modelName, mode)).toBe("model-minimax-m3");
+      expect(getRetryFallbackModel(modelName, mode)).toBe("model-grok-4.5");
     },
   );
 
-  it("retries free Agent DeepSeek Flash with MiniMax", () => {
+  it("retries free Agent DeepSeek Flash with Grok", () => {
     expect(getRetryFallbackModel("agent-model-free", "agent")).toBe(
-      "model-minimax-m3",
+      "model-grok-4.5",
     );
   });
 
-  it("keeps paid Ask image MiniMax app-side retry on the terminal Grok fallback", () => {
-    expect(getRetryFallbackModel("ask-model", "ask")).toBe("fallback-grok-4.5");
+  it("retries the Grok-backed paid Ask image route with Kimi", () => {
+    expect(getRetryFallbackModel("ask-model", "ask")).toBe(
+      "model-kimi-k2.7-code",
+    );
   });
 
   it("retries HackerAI Pro Grok with GLM 5.2", () => {
@@ -508,14 +503,21 @@ describe("getRetryFallbackModel", () => {
     );
   });
 
+  it("retries paid DeepSeek Pro with Grok", () => {
+    expect(getRetryFallbackModel("model-deepseek-v4-pro", "ask")).toBe(
+      "model-grok-4.5",
+    );
+  });
+
   it.each([
-    ["model-deepseek-v4-pro", "ask"],
     ["model-grok-4.5", "ask"],
     ["model-gemini-3-flash", "ask"],
   ] as const)(
-    "uses the paid Agent fallback chain for app-side retry after paid Ask route %s fails",
+    "retries Grok-backed paid Ask route %s with Kimi",
     (modelName, mode) => {
-      expect(getRetryFallbackModel(modelName, mode)).toBe("model-minimax-m3");
+      expect(getRetryFallbackModel(modelName, mode)).toBe(
+        "model-kimi-k2.7-code",
+      );
     },
   );
 });
@@ -531,14 +533,14 @@ describe("resolveServedModelForCostAccounting", () => {
     ).toBe("agent-model-free");
   });
 
-  it("maps a MiniMax slug served from free Agent fallback back to the local cost key", () => {
+  it("maps a Grok slug served from free Agent fallback back to the local cost key", () => {
     expect(
       resolveServedModelForCostAccounting({
         modelName: "agent-model-free",
-        responseModel: MINIMAX_SLUG,
+        responseModel: GROK_SLUG,
         mode: "agent",
       }),
-    ).toBe("model-minimax-m3");
+    ).toBe("model-grok-4.5");
   });
 
   it("maps a Kimi provider slug served from free Agent fallback back to the local cost key", () => {
@@ -549,16 +551,6 @@ describe("resolveServedModelForCostAccounting", () => {
         mode: "agent",
       }),
     ).toBe("model-kimi-k2.7-code");
-  });
-
-  it("maps a terminal Grok provider slug served from free Agent fallback back to the fallback cost key", () => {
-    expect(
-      resolveServedModelForCostAccounting({
-        modelName: "agent-model-free",
-        responseModel: GROK_SLUG,
-        mode: "agent",
-      }),
-    ).toBe("fallback-grok-4.5");
   });
 
   it("maps a direct Grok provider slug back to the Grok 4.5 cost key", () => {

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -106,8 +106,7 @@ import type { createTrackedProvider } from "@/lib/ai/providers";
 import type { ProviderRequestDiagnostics } from "@/lib/logger";
 import type { ChatMode, SubscriptionTier } from "@/types";
 
-const AGENT_STANDARD_VISION_MODEL = "model-kimi-k2.7-code";
-const FREE_AGENT_VISION_MODEL = "model-minimax-m3";
+const AGENT_VISION_MODEL = "model-grok-4.5";
 
 export const resolveAgentModelForImageToolResults = (
   modelName: string,
@@ -115,8 +114,10 @@ export const resolveAgentModelForImageToolResults = (
   hasImageToolResults: boolean,
 ): string => {
   if (mode !== "agent" || !hasImageToolResults) return modelName;
-  if (modelName === "agent-model-free") return FREE_AGENT_VISION_MODEL;
-  return isDeepSeekModel(modelName) ? AGENT_STANDARD_VISION_MODEL : modelName;
+  if (modelName === "agent-model-free" || isDeepSeekModel(modelName)) {
+    return AGENT_VISION_MODEL;
+  }
+  return modelName;
 };
 
 export const resolveFallbackServedTelemetry = ({

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -610,26 +610,6 @@ const ANTHROPIC_FALLBACK_CHAIN_BY_MODE: Record<ChatMode, readonly ModelName[]> =
 
 const ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN = KIMI_THEN_GROK_FALLBACK_CHAIN;
 
-// Standard Ask routes text-only prompts to DeepSeek and media prompts to Grok.
-// Keep those route keys and persisted Grok aliases on one effort level so they
-// do not drift. Grok 4.5 rejects requests that explicitly disable reasoning.
-const ASK_STANDARD_REASONING_MODELS = [
-  "model-deepseek-v4-pro",
-  "ask-model",
-  "model-minimax-m3",
-  "model-grok-4.5",
-  "model-gemini-3-flash",
-  "fallback-grok-4.5",
-] as const satisfies readonly ModelName[];
-
-const ASK_MEDIUM_REASONING_MODELS = [
-  ...ASK_STANDARD_REASONING_MODELS,
-] as const satisfies readonly ModelName[];
-
-const isAskMediumReasoningModel = (modelName?: string): boolean =>
-  typeof modelName === "string" &&
-  (ASK_MEDIUM_REASONING_MODELS as readonly string[]).includes(modelName);
-
 const HIGH_REASONING_MODELS = [
   "model-grok-4.5-pro",
   "model-glm-5.2",
@@ -805,36 +785,34 @@ export function buildProviderOptions(
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
   const isGrok45 = modelId === GROK_4_5_SLUG;
   // Agent routes use high for both DeepSeek V4 Flash and Pro. Keep this
-  // mode-scoped so the corresponding Ask routes retain their existing effort.
+  // mode-scoped for any future route that does not also include Grok.
   const isAgentDeepSeekV4 = mode === "agent" && isDeepSeekV4;
   const fallbackSlugs = getFallbackSlugs(modelName, mode, options);
-  const reasoning =
-    options.reasoningOverride ??
-    (isHighReasoningModel(modelName) || isAgentDeepSeekV4
-      ? {
-          enabled: true,
-          effort: "high",
-        }
-      : isReasoningModel
+  // OpenRouter applies one reasoning configuration to both the primary model
+  // and every provider fallback. Force high whenever this request can resolve
+  // to Grok 4.5 so fallback execution cannot inherit a lower effort.
+  const routesThroughGrok45 = isGrok45 || fallbackSlugs.includes(GROK_4_5_SLUG);
+  const reasoning = routesThroughGrok45
+    ? {
+        enabled: true,
+        effort: "high",
+      }
+    : (options.reasoningOverride ??
+      (isHighReasoningModel(modelName) || isAgentDeepSeekV4
         ? {
             enabled: true,
-            ...(isDeepSeekV4 ? { effort: "xhigh" } : {}),
+            effort: "high",
           }
-        : isGrok45
+        : isReasoningModel
           ? {
               enabled: true,
-              ...(mode === "ask" ? { effort: "medium" } : {}),
+              ...(isDeepSeekV4 ? { effort: "xhigh" } : {}),
             }
           : mode === "ask" && isAskKimiReasoningModel(modelName)
             ? {
                 enabled: true,
               }
-            : mode === "ask" && isAskMediumReasoningModel(modelName)
-              ? {
-                  enabled: true,
-                  effort: "medium",
-                }
-              : { enabled: false });
+            : { enabled: false }));
 
   return {
     openrouter: {

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -22,7 +22,11 @@ import type {
   Todo,
   UserCustomization,
 } from "@/types";
-import { isAnthropicModel, myProvider } from "@/lib/ai/providers";
+import {
+  GROK_4_5_SLUG,
+  isAnthropicModel,
+  myProvider,
+} from "@/lib/ai/providers";
 import type { ModelName } from "@/lib/ai/providers";
 import type { Id } from "@/convex/_generated/dataModel";
 import type { UIMessagePart } from "ai";
@@ -529,22 +533,26 @@ export class SummarizationTracker {
  * model's rate (response.modelId reflects what actually ran).
  *
  * Claude chats are repaired for Anthropic-compatible message shapes before
- * this fallback can fire. Claude agent calls use the cheaper MiniMax and Kimi
- * fallback chain while the run is text-only, then switch to multimodal-capable
- * fallbacks once image tool results enter the context.
+ * this fallback can fire. Claude agent calls use Grok and Kimi fallbacks while
+ * the run is text-only, then switch to multimodal-capable fallbacks once image
+ * tool results enter the context.
  *
  * Keys and values are registry names (see lib/ai/providers.ts) — the actual
  * OpenRouter slugs are resolved at request-build time so this stays in sync
  * with the registry.
  */
-const MINIMAX_M3_FALLBACK_CHAIN = [
+const KIMI_THEN_GROK_FALLBACK_CHAIN = [
   "model-kimi-k2.7-code",
   "fallback-grok-4.5",
 ] as const satisfies readonly ModelName[];
 
+const GROK_4_5_FALLBACK_CHAIN = [
+  "model-kimi-k2.7-code",
+] as const satisfies readonly ModelName[];
+
 const AGENT_TEXT_FALLBACK_CHAIN = [
-  "model-minimax-m3",
-  ...MINIMAX_M3_FALLBACK_CHAIN,
+  "model-grok-4.5",
+  "model-kimi-k2.7-code",
 ] as const satisfies readonly ModelName[];
 
 // HackerAI Pro uses Grok 4.5 for every request. GLM 5.2 remains its first
@@ -555,27 +563,20 @@ const HACKERAI_PRO_FALLBACK_CHAIN = [
   "model-kimi-k2.7-code",
 ] as const satisfies readonly ModelName[];
 
-// Agent Pro promotes vision steps to Grok 4.5. Keep Kimi as its direct
-// multimodal fallback for legacy in-flight routes that still use the generic
-// Grok key rather than the dedicated HackerAI Pro alias.
-const AGENT_PRO_VISION_FALLBACK_CHAIN = [
-  "model-kimi-k2.7-code",
-] as const satisfies readonly ModelName[];
-
 const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "ask-model-free": AGENT_TEXT_FALLBACK_CHAIN,
   "agent-model-free": AGENT_TEXT_FALLBACK_CHAIN,
   "model-deepseek-v4-flash": AGENT_TEXT_FALLBACK_CHAIN,
   "model-deepseek-v4-pro": AGENT_TEXT_FALLBACK_CHAIN,
-  "ask-model": MINIMAX_M3_FALLBACK_CHAIN,
-  "agent-model": MINIMAX_M3_FALLBACK_CHAIN,
-  "model-grok-4.5": AGENT_TEXT_FALLBACK_CHAIN,
+  "ask-model": GROK_4_5_FALLBACK_CHAIN,
+  "agent-model": GROK_4_5_FALLBACK_CHAIN,
+  "model-grok-4.5": GROK_4_5_FALLBACK_CHAIN,
   "model-grok-4.5-pro": HACKERAI_PRO_FALLBACK_CHAIN,
-  "model-gemini-3-flash": AGENT_TEXT_FALLBACK_CHAIN,
-  "model-glm-5.2": MINIMAX_M3_FALLBACK_CHAIN,
-  "model-minimax-m3": MINIMAX_M3_FALLBACK_CHAIN,
-  "fallback-agent-model": MINIMAX_M3_FALLBACK_CHAIN,
-  "fallback-ask-model": MINIMAX_M3_FALLBACK_CHAIN,
+  "model-gemini-3-flash": GROK_4_5_FALLBACK_CHAIN,
+  "model-glm-5.2": KIMI_THEN_GROK_FALLBACK_CHAIN,
+  "model-minimax-m3": GROK_4_5_FALLBACK_CHAIN,
+  "fallback-agent-model": GROK_4_5_FALLBACK_CHAIN,
+  "fallback-ask-model": GROK_4_5_FALLBACK_CHAIN,
   "model-kimi-k2.7-code": ["fallback-grok-4.5"],
   "model-kimi-k2.6": ["fallback-grok-4.5"],
 };
@@ -607,11 +608,10 @@ const ANTHROPIC_FALLBACK_CHAIN_BY_MODE: Record<ChatMode, readonly ModelName[]> =
     ask: ["model-grok-4.5"],
   };
 
-const ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN = MINIMAX_M3_FALLBACK_CHAIN;
+const ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN = KIMI_THEN_GROK_FALLBACK_CHAIN;
 
-// Standard Ask can route text-only prompts to DeepSeek, image prompts to
-// MiniMax, and PDF prompts to Grok. Keep those route keys and their persisted
-// Grok aliases, including the app-side retry key, on one effort level so they
+// Standard Ask routes text-only prompts to DeepSeek and media prompts to Grok.
+// Keep those route keys and persisted Grok aliases on one effort level so they
 // do not drift. Grok 4.5 rejects requests that explicitly disable reasoning.
 const ASK_STANDARD_REASONING_MODELS = [
   "model-deepseek-v4-pro",
@@ -667,9 +667,6 @@ const getFallbackKeys = (
   options: FallbackOptions = {},
 ): readonly ModelName[] | undefined => {
   if (!modelName) return undefined;
-  if (modelName === "model-grok-4.5" && mode === "agent") {
-    return AGENT_PRO_VISION_FALLBACK_CHAIN;
-  }
   if (modelName === "model-opus-4.6" || modelName === "model-sonnet-4.6") {
     if (mode === "agent" && options.hasMultimodalToolResults) {
       return ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN;
@@ -681,23 +678,29 @@ const getFallbackKeys = (
 
 export function getRetryFallbackModel(
   modelName: ModelName,
-  mode: ChatMode,
+  _mode: ChatMode,
 ): ModelName {
   if (modelName === "model-grok-4.5-pro") {
     return "model-glm-5.2";
-  }
-  if (modelName === "model-grok-4.5" && mode === "agent") {
-    return "model-kimi-k2.7-code";
   }
   if (
     modelName === "ask-model-free" ||
     modelName === "agent-model-free" ||
     modelName === "model-deepseek-v4-flash" ||
-    modelName === "model-deepseek-v4-pro" ||
-    modelName === "model-grok-4.5" ||
-    modelName === "model-gemini-3-flash"
+    modelName === "model-deepseek-v4-pro"
   ) {
-    return "model-minimax-m3";
+    return "model-grok-4.5";
+  }
+  if (
+    modelName === "ask-model" ||
+    modelName === "agent-model" ||
+    modelName === "model-grok-4.5" ||
+    modelName === "model-gemini-3-flash" ||
+    modelName === "model-minimax-m3" ||
+    modelName === "fallback-agent-model" ||
+    modelName === "fallback-ask-model"
+  ) {
+    return "model-kimi-k2.7-code";
   }
   return "fallback-grok-4.5";
 }
@@ -800,6 +803,7 @@ export function buildProviderOptions(
 ) {
   const modelId = modelName ? resolveSlug(modelName) : undefined;
   const isDeepSeekV4 = modelId?.startsWith("deepseek/deepseek-v4") ?? false;
+  const isGrok45 = modelId === GROK_4_5_SLUG;
   // Agent routes use high for both DeepSeek V4 Flash and Pro. Keep this
   // mode-scoped so the corresponding Ask routes retain their existing effort.
   const isAgentDeepSeekV4 = mode === "agent" && isDeepSeekV4;
@@ -816,16 +820,21 @@ export function buildProviderOptions(
             enabled: true,
             ...(isDeepSeekV4 ? { effort: "xhigh" } : {}),
           }
-        : mode === "ask" && isAskKimiReasoningModel(modelName)
+        : isGrok45
           ? {
               enabled: true,
+              ...(mode === "ask" ? { effort: "medium" } : {}),
             }
-          : mode === "ask" && isAskMediumReasoningModel(modelName)
+          : mode === "ask" && isAskKimiReasoningModel(modelName)
             ? {
                 enabled: true,
-                effort: "medium",
               }
-            : { enabled: false });
+            : mode === "ask" && isAskMediumReasoningModel(modelName)
+              ? {
+                  enabled: true,
+                  effort: "medium",
+                }
+              : { enabled: false });
 
   return {
     openrouter: {

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -179,13 +179,13 @@ describe("selectModel", () => {
       },
     );
 
-    it("should return agent-model (MiniMax) for paid agent with an image", () => {
+    it("should return the Grok-backed agent model for paid agent with an image", () => {
       expect(selectModel("agent", "pro", undefined, true, false)).toBe(
         "agent-model",
       );
     });
 
-    it("should return agent-model (MiniMax) for paid agent with a PDF", () => {
+    it("should return the Grok-backed agent model for paid agent with a PDF", () => {
       expect(selectModel("agent", "pro", undefined, false, true)).toBe(
         "agent-model",
       );
@@ -195,7 +195,7 @@ describe("selectModel", () => {
       expect(selectModel("ask", "pro")).toBe("model-deepseek-v4-pro");
     });
 
-    it("should return ask-model (MiniMax) for paid ask when an image is attached", () => {
+    it("should return the Grok-backed ask model when an image is attached", () => {
       expect(selectModel("ask", "pro", undefined, true, false)).toBe(
         "ask-model",
       );
@@ -258,9 +258,9 @@ describe("selectModel", () => {
       );
     });
 
-    it("should promote HackerAI Standard to MiniMax M3 when an image is attached", () => {
+    it("should promote HackerAI Standard to Grok 4.5 when an image is attached", () => {
       expect(selectModel("ask", "pro", "hackerai-standard", true, false)).toBe(
-        "model-minimax-m3",
+        "model-grok-4.5",
       );
     });
 
@@ -311,16 +311,16 @@ describe("selectModel", () => {
       );
     });
 
-    it("should route HackerAI Standard to MiniMax M3 when an image is attached", () => {
+    it("should route HackerAI Standard to Grok 4.5 when an image is attached", () => {
       expect(
         selectModel("agent", "pro", "hackerai-standard", true, false),
-      ).toBe("model-minimax-m3");
+      ).toBe("model-grok-4.5");
     });
 
-    it("should route HackerAI Standard to MiniMax M3 when a PDF is attached", () => {
+    it("should route HackerAI Standard to Grok 4.5 when a PDF is attached", () => {
       expect(
         selectModel("agent", "pro", "hackerai-standard", false, true),
-      ).toBe("model-minimax-m3");
+      ).toBe("model-grok-4.5");
     });
 
     it("should map HackerAI Pro to Grok 4.5 in text-only agent mode", () => {
@@ -398,7 +398,7 @@ describe("selectModel", () => {
       expect(selectModel("agent", "pro", "auto")).toBe("model-deepseek-v4-pro");
     });
 
-    it("should route paid agent Auto media to agent-model (MiniMax)", () => {
+    it("should route paid agent Auto media to the Grok-backed agent model", () => {
       expect(selectModel("agent", "pro", "auto", true, false)).toBe(
         "agent-model",
       );
@@ -411,7 +411,7 @@ describe("selectModel", () => {
       expect(selectModel("ask", "pro", "auto")).toBe("model-deepseek-v4-pro");
     });
 
-    it("should treat 'auto' as no override in ask mode with image -> MiniMax", () => {
+    it("should treat 'auto' as no override in ask mode with image -> Grok", () => {
       expect(selectModel("ask", "pro", "auto", true, false)).toBe("ask-model");
     });
 

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -45,11 +45,10 @@ export const getMaxStepsForUser = (
  * @param hasImageAttachment - Whether any message has an image attachment.
  * @param hasPdfAttachment - Whether any message has a PDF attachment.
  *   Paid ASK on the Standard/auto route normally uses DeepSeek V4 Pro
- *   (text-only); image-only prompts promote to MiniMax M3, while PDF prompts
- *   stay on Grok 4.5 for native document support. Paid Agent Auto/Standard
- *   routes use DeepSeek V4 Pro for text-only prompts and MiniMax M3 when
- *   provider-visible media is attached. HackerAI Pro uses Grok 4.5 for both
- *   text and vision; its GLM 5.2 fallback is configured downstream.
+ *   (text-only); image and PDF prompts promote to Grok 4.5. Paid Agent
+ *   Auto/Standard routes use DeepSeek V4 Pro for text-only prompts and Grok
+ *   4.5 when provider-visible media is attached. HackerAI Pro uses Grok 4.5
+ *   for both text and vision; its GLM 5.2 fallback is configured downstream.
  * @returns Model name to use
  */
 export function selectModel(
@@ -68,8 +67,7 @@ export function selectModel(
   );
   // DeepSeek routes are text-only, so image/PDF prompts promote to a
   // media-capable route unless the selected tier intentionally uses a
-  // multimodal/file-capable model such as Kimi or Opus. PDFs take precedence
-  // when mixed with images because the MiniMax ask route is image-scoped.
+  // multimodal/file-capable model such as Grok, Kimi, or Opus.
   const isFreeAsk = !isAgent && subscription === "free";
   const hasAskImage = !isAgent && !!hasImageAttachment;
   const hasAskPdf = !isAgent && !!hasPdfAttachment;
@@ -105,13 +103,11 @@ export function selectModel(
   // the auto-router label.
   if (allowedSelectedModel === "hackerai-standard") {
     if (isAgent) {
-      return hasProviderMedia ? "model-minimax-m3" : "model-deepseek-v4-pro";
+      return hasProviderMedia ? "model-grok-4.5" : "model-deepseek-v4-pro";
     }
-    return hasAskPdf
+    return hasAskImage || hasAskPdf
       ? "model-grok-4.5"
-      : hasAskImage
-        ? "model-minimax-m3"
-        : "model-deepseek-v4-pro";
+      : "model-deepseek-v4-pro";
   }
 
   if (allowedSelectedModel === "hackerai-pro") {

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -948,7 +948,7 @@ describe("checkAndSummarizeIfNeeded", () => {
         openrouter: {
           user: "user_123",
           reasoning: { enabled: false },
-          models: ["minimax/minimax-m3"],
+          models: ["x-ai/grok-4.5", "moonshotai/kimi-k2.7-code:exacto"],
         },
       },
     );
@@ -966,8 +966,8 @@ describe("checkAndSummarizeIfNeeded", () => {
     expect(retryCall.providerOptions).toEqual({
       openrouter: {
         user: "user_123",
-        reasoning: { enabled: false },
-        models: ["moonshotai/kimi-k2.7-code:exacto", "x-ai/grok-4.5"],
+        reasoning: { enabled: true },
+        models: ["moonshotai/kimi-k2.7-code:exacto"],
       },
     });
 

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -966,7 +966,7 @@ describe("checkAndSummarizeIfNeeded", () => {
     expect(retryCall.providerOptions).toEqual({
       openrouter: {
         user: "user_123",
-        reasoning: { enabled: true },
+        reasoning: { enabled: true, effort: "high" },
         models: ["moonshotai/kimi-k2.7-code:exacto"],
       },
     });

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -195,7 +195,7 @@ const buildSummarizationRetryProviderOptions = (
 
   retryProviderOptions.openrouter = {
     ...(retryProviderOptions.openrouter ?? {}),
-    reasoning: { enabled: true },
+    reasoning: { enabled: true, effort: "high" },
     models: [...SUMMARIZATION_RETRY_FALLBACK_MODEL_SLUGS],
   };
 

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -17,11 +17,7 @@ import {
 } from "@/lib/utils/stream-writer-utils";
 import { isE2BSandbox } from "@/lib/ai/tools/utils/sandbox-types";
 import type { Id } from "@/convex/_generated/dataModel";
-import {
-  GROK_4_5_SLUG,
-  KIMI_K2_7_CODE_SLUG,
-  myProvider,
-} from "@/lib/ai/providers";
+import { KIMI_K2_7_CODE_SLUG, myProvider } from "@/lib/ai/providers";
 import type { ProviderPromptPressure } from "./provider-pressure";
 
 import {
@@ -59,10 +55,7 @@ const SUMMARIZATION_RETRY_MODEL_BY_MODE: Record<ChatMode, string> = {
   ask: "fallback-ask-model",
   agent: "fallback-agent-model",
 };
-const SUMMARIZATION_RETRY_FALLBACK_MODEL_SLUGS = [
-  KIMI_K2_7_CODE_SLUG,
-  GROK_4_5_SLUG,
-] as const;
+const SUMMARIZATION_RETRY_FALLBACK_MODEL_SLUGS = [KIMI_K2_7_CODE_SLUG] as const;
 const SUMMARIZATION_ATTEMPT_ERROR_KEY = "__hackeraiSummarizationAttempt";
 
 const getLanguageModelId = (
@@ -202,6 +195,7 @@ const buildSummarizationRetryProviderOptions = (
 
   retryProviderOptions.openrouter = {
     ...(retryProviderOptions.openrouter ?? {}),
+    reasoning: { enabled: true },
     models: [...SUMMARIZATION_RETRY_FALLBACK_MODEL_SLUGS],
   };
 

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -422,14 +422,6 @@ describe("token-bucket", () => {
       );
     });
 
-    it.each(["ask-model", "agent-model", "model-minimax-m3"])(
-      "should use MiniMax M3 pricing for %s ($0.30/$1.20)",
-      (modelName) => {
-        expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(4200);
-        expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(16800);
-      },
-    );
-
     it("should use DeepSeek V4 Flash pricing for free Agent ($0.09/$0.18)", () => {
       expect(calculateTokenCost(1_000_000, "input", "agent-model-free")).toBe(
         1260,
@@ -443,6 +435,11 @@ describe("token-bucket", () => {
       "model-grok-4.5",
       "model-grok-4.5-pro",
       "model-gemini-3-flash",
+      "ask-model",
+      "agent-model",
+      "model-minimax-m3",
+      "fallback-agent-model",
+      "fallback-ask-model",
       "fallback-grok-4.5",
     ])("should use Grok 4.5 pricing for %s ($2.00/$6.00)", (modelName) => {
       expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(28000);

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -34,6 +34,12 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   "model-grok-4.5": { input: 2.0, output: 6.0 },
   "model-grok-4.5-pro": { input: 2.0, output: 6.0 },
   "model-gemini-3-flash": { input: 2.0, output: 6.0 },
+  // Auto and compatibility aliases now resolve to Grok 4.5.
+  "ask-model": { input: 2.0, output: 6.0 },
+  "agent-model": { input: 2.0, output: 6.0 },
+  "model-minimax-m3": { input: 2.0, output: 6.0 },
+  "fallback-agent-model": { input: 2.0, output: 6.0 },
+  "fallback-ask-model": { input: 2.0, output: 6.0 },
   // Rates from OpenRouter: $0.09 in / $0.18 out per 1M tokens.
   "agent-model-free": { input: 0.09, output: 0.18 },
   "model-deepseek-v4-pro": { input: 0.435, output: 0.87 },
@@ -41,11 +47,6 @@ const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
   "model-opus-4.6": { input: 5.0, output: 25.0 },
   // Rates from OpenRouter: $0.9086 in / $2.856 out per 1M tokens.
   "model-glm-5.2": { input: 0.9086, output: 2.856 },
-  // These keys route to minimax/minimax-m3 via lib/ai/providers.ts.
-  // Rates from OpenRouter: $0.30 in / $1.20 out per 1M tokens.
-  "ask-model": { input: 0.3, output: 1.2 },
-  "agent-model": { input: 0.3, output: 1.2 },
-  "model-minimax-m3": { input: 0.3, output: 1.2 },
   // Kimi keys are retained as compatibility aliases for stale persisted routes.
   // Rates from OpenRouter: $0.95 in / $4.00 out per 1M tokens.
   "model-kimi-k2.7-code": { input: 0.95, output: 4.0 },


### PR DESCRIPTION
## Summary

- route all active Auto/Standard media paths and legacy MiniMax aliases through `x-ai/grok-4.5`
- replace MiniMax in DeepSeek fallback/retry, Agent image-tool promotion, and summarization retry paths while keeping Kimi as the non-duplicate recovery model
- force explicit `reasoning: { enabled: true, effort: "high" }` whenever Grok 4.5 is the primary or any OpenRouter fallback, including title generation and summarization retries
- update Grok pricing/cost accounting, cutoff/display metadata, and selector disclosures
- show only `Powered by xAI Grok 4.5` for HackerAI Pro while preserving its GLM/Kimi backend failover

## Why

MiniMax M3 was not removed because it was proven bad at PDFs. The earlier PDF route was historical rather than backed by a current repository benchmark. This change applies the product decision to use Grok 4.5 consistently everywhere MiniMax M3 was active, including PDFs and images.

The legacy `model-minimax-m3` key remains compatibility-only so older clients do not break, but it resolves to Grok 4.5 and never calls MiniMax.

OpenRouter's reasoning configuration is request-level while its fallback list contains model IDs. Any request that can resolve to Grok therefore starts with high reasoning so Grok cannot inherit medium, disabled, or provider-default reasoning during failover.

## Validation

- focused high-reasoning coverage: 3 suites, 131 tests passed
- `pnpm typecheck`
- `pnpm lint` (0 errors; 5 pre-existing warnings)
- full Jest suite: 287 suites, 2,832 tests passed
- Prettier and `git diff --check`
- regression table covers all 19 Grok-primary or Grok-fallback registry keys in Ask and Agent modes

## Manual verification

1. Sign in on the preview and open the model selector.
2. Hover Standard in Ask and Agent: it should show `Powered by DeepSeek V4 Pro · xAI Grok 4.5 for vision`.
3. Hover HackerAI Pro: it should show only `Powered by xAI Grok 4.5`.
4. Send an image and a PDF with paid Auto/Standard in both Ask and Agent; provider metadata should resolve to `x-ai/grok-4.5`.
5. Trigger an Agent image-tool result from a DeepSeek route; the effective model should become `x-ai/grok-4.5`.
6. Confirm text-only Auto/Standard requests remain on DeepSeek V4 Pro.
7. Inspect the OpenRouter request options for direct and fallback Grok routes; reasoning should be enabled with `effort: "high"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated HackerAI model routing and model-selector disclosures so supported ask/agent workflows for images and PDFs now use **xAI Grok 4.5** (including updated provider wording and labels).
  * Improved multimodal tool image handling to align with Grok 4.5 selection where applicable.
* **Bug Fixes**
  * Refined provider routing, fallback-chain ordering, and retry targets across Grok/Kimi paths (including served-model and cost/pricing tracking alignment).
  * Enabled higher-effort reasoning for OpenRouter fallback/retry and title-generation flows; narrowed summarization retry models to **Kimi**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->