### PR TITLE
Fix production auth, refund, and upload diagnostics

### DIFF
--- a/app/api/fraud/webhook/route.ts
+++ b/app/api/fraud/webhook/route.ts
@@ -8,10 +8,7 @@ import {
   logStripeWebhookMissingSignature,
   logStripeWebhookSignatureVerificationFailed,
 } from "@/lib/billing/stripe-webhook-logging";
-import {
-  getRemainingRefundAmountCents,
-  isRefundAmountRaceError,
-} from "@/lib/billing/fraud-refund";
+import { refundChargeForEFW } from "@/lib/billing/fraud-refund";
 import {
   isTerminalPaymentMethodDetachError,
   isTerminalStripeResourceError,
@@ -139,108 +136,6 @@ async function reportChargeFraudulent(chargeId: string): Promise<void> {
   }
 }
 
-/**
- * Refund a charge for an early fraud warning.
- *
- * Uses an idempotency key derived from the EFW ID so that webhook retries
- * (or TOCTOU duplicate deliveries) collapse onto a single refund instead
- * of erroring with `charge_already_refunded`.
- *
- * Terminal failures (`charge_already_refunded`, `charge_disputed`,
- * `charge_pending`) are logged and treated as success: there is nothing
- * to retry. All other errors bubble so the webhook returns 500 and Stripe
- * retries the delivery — silently swallowing transient errors here would
- * defeat the entire point of the EFW path (refund proactively to avoid
- * the dispute fee + ratio impact).
- */
-async function refundChargeForEFW(
-  charge: Stripe.Charge,
-  efwId: string,
-): Promise<void> {
-  const remainingAmount = getRemainingRefundAmountCents(charge);
-  if (remainingAmount === 0) {
-    console.log(
-      `[Fraud Webhook] Refund skipped for ${charge.id} (EFW ${efwId}): charge has no refundable balance`,
-    );
-    return;
-  }
-
-  let refundError: unknown;
-
-  try {
-    await stripe.refunds.create(
-      {
-        charge: charge.id,
-        reason: "fraudulent",
-        amount: remainingAmount,
-      },
-      { idempotencyKey: `efw-refund:${efwId}` },
-    );
-    console.log(
-      `[Fraud Webhook] Refunded ${remainingAmount} cents from charge ${charge.id} (early fraud warning ${efwId})`,
-    );
-    return;
-  } catch (err) {
-    refundError = err;
-  }
-
-  // Another refund can land after the charge retrieval above. Refresh once
-  // and bound one retry to Stripe's current remaining balance. A distinct,
-  // event-derived idempotency key keeps concurrent race retries idempotent.
-  if (isRefundAmountRaceError(refundError)) {
-    try {
-      const refreshedCharge = await stripe.charges.retrieve(charge.id);
-      const refreshedRemainingAmount =
-        getRemainingRefundAmountCents(refreshedCharge);
-
-      if (refreshedRemainingAmount === 0) {
-        console.log(
-          `[Fraud Webhook] Refund skipped for ${charge.id} (EFW ${efwId}): charge has no refundable balance after refresh`,
-        );
-        return;
-      }
-
-      if (refreshedRemainingAmount < remainingAmount) {
-        await stripe.refunds.create(
-          {
-            charge: charge.id,
-            reason: "fraudulent",
-            amount: refreshedRemainingAmount,
-          },
-          { idempotencyKey: `efw-refund:${efwId}:remaining` },
-        );
-        console.log(
-          `[Fraud Webhook] Refunded refreshed remaining balance of ${refreshedRemainingAmount} cents from charge ${charge.id} (early fraud warning ${efwId})`,
-        );
-        return;
-      }
-    } catch (err) {
-      refundError = err;
-    }
-  }
-
-  if (refundError instanceof Stripe.errors.StripeError) {
-    const code = refundError.code;
-    if (
-      code === "charge_already_refunded" ||
-      code === "charge_disputed" ||
-      code === "charge_pending"
-    ) {
-      console.log(
-        `[Fraud Webhook] Refund skipped for ${charge.id} (EFW ${efwId}): ${code}`,
-      );
-      return;
-    }
-  }
-
-  // Transient or unexpected — bubble so Stripe retries the webhook.
-  console.error(
-    `[Fraud Webhook] Refund failed for ${charge.id} (EFW ${efwId}):`,
-    refundError,
-  );
-  throw refundError;
-}
-
 /** Resolve Stripe customer ID from a charge. */
 function getCustomerIdFromCharge(charge: Stripe.Charge): string | null {
   return typeof charge.customer === "string"
@@ -360,7 +255,7 @@ async function handleEarlyFraudWarning(
   const customerId = getCustomerIdFromCharge(charge);
 
   // Refund first. Throws on transient errors so Stripe retries the webhook.
-  await refundChargeForEFW(charge, warning.id);
+  await refundChargeForEFW(stripe, charge, warning.id);
 
   // Block the user
   if (customerId) {

--- a/app/api/fraud/webhook/route.ts
+++ b/app/api/fraud/webhook/route.ts
@@ -8,7 +8,10 @@ import {
   logStripeWebhookMissingSignature,
   logStripeWebhookSignatureVerificationFailed,
 } from "@/lib/billing/stripe-webhook-logging";
-import { getRemainingRefundAmountCents } from "@/lib/billing/fraud-refund";
+import {
+  getRemainingRefundAmountCents,
+  isRefundAmountRaceError,
+} from "@/lib/billing/fraud-refund";
 import {
   isTerminalPaymentMethodDetachError,
   isTerminalStripeResourceError,
@@ -162,6 +165,8 @@ async function refundChargeForEFW(
     return;
   }
 
+  let refundError: unknown;
+
   try {
     await stripe.refunds.create(
       {
@@ -174,27 +179,66 @@ async function refundChargeForEFW(
     console.log(
       `[Fraud Webhook] Refunded ${remainingAmount} cents from charge ${charge.id} (early fraud warning ${efwId})`,
     );
+    return;
   } catch (err) {
-    if (err instanceof Stripe.errors.StripeError) {
-      const code = err.code;
-      if (
-        code === "charge_already_refunded" ||
-        code === "charge_disputed" ||
-        code === "charge_pending"
-      ) {
+    refundError = err;
+  }
+
+  // Another refund can land after the charge retrieval above. Refresh once
+  // and bound one retry to Stripe's current remaining balance. A distinct,
+  // event-derived idempotency key keeps concurrent race retries idempotent.
+  if (isRefundAmountRaceError(refundError)) {
+    try {
+      const refreshedCharge = await stripe.charges.retrieve(charge.id);
+      const refreshedRemainingAmount =
+        getRemainingRefundAmountCents(refreshedCharge);
+
+      if (refreshedRemainingAmount === 0) {
         console.log(
-          `[Fraud Webhook] Refund skipped for ${charge.id} (EFW ${efwId}): ${code}`,
+          `[Fraud Webhook] Refund skipped for ${charge.id} (EFW ${efwId}): charge has no refundable balance after refresh`,
         );
         return;
       }
+
+      if (refreshedRemainingAmount < remainingAmount) {
+        await stripe.refunds.create(
+          {
+            charge: charge.id,
+            reason: "fraudulent",
+            amount: refreshedRemainingAmount,
+          },
+          { idempotencyKey: `efw-refund:${efwId}:remaining` },
+        );
+        console.log(
+          `[Fraud Webhook] Refunded refreshed remaining balance of ${refreshedRemainingAmount} cents from charge ${charge.id} (early fraud warning ${efwId})`,
+        );
+        return;
+      }
+    } catch (err) {
+      refundError = err;
     }
-    // Transient or unexpected — bubble so Stripe retries the webhook.
-    console.error(
-      `[Fraud Webhook] Refund failed for ${charge.id} (EFW ${efwId}):`,
-      err,
-    );
-    throw err;
   }
+
+  if (refundError instanceof Stripe.errors.StripeError) {
+    const code = refundError.code;
+    if (
+      code === "charge_already_refunded" ||
+      code === "charge_disputed" ||
+      code === "charge_pending"
+    ) {
+      console.log(
+        `[Fraud Webhook] Refund skipped for ${charge.id} (EFW ${efwId}): ${code}`,
+      );
+      return;
+    }
+  }
+
+  // Transient or unexpected — bubble so Stripe retries the webhook.
+  console.error(
+    `[Fraud Webhook] Refund failed for ${charge.id} (EFW ${efwId}):`,
+    refundError,
+  );
+  throw refundError;
 }
 
 /** Resolve Stripe customer ID from a charge. */

--- a/components/__tests__/ConvexClientProvider.contracts.test.ts
+++ b/components/__tests__/ConvexClientProvider.contracts.test.ts
@@ -16,6 +16,10 @@ const authkitPatchSource = fs.readFileSync(
   ),
   "utf8",
 );
+const expectedAuthErrorSource = fs.readFileSync(
+  path.resolve(__dirname, "../../lib/auth/expected-auth-errors.ts"),
+  "utf8",
+);
 
 describe("ConvexClientProvider auth recovery contracts", () => {
   it("disables AuthKit focus and visibility session probes", () => {
@@ -40,7 +44,14 @@ describe("ConvexClientProvider auth recovery contracts", () => {
     expect(authkitPatchSource).toContain(
       "const isEndedSessionRefreshError = (value",
     );
-    expect(authkitPatchSource).toContain("errorText.includes('invalid_grant')");
+    for (const contractText of [
+      "invalid_grant",
+      "session has already ended",
+      "session ended due to inactivity",
+    ]) {
+      expect(authkitPatchSource).toContain(contractText);
+      expect(expectedAuthErrorSource).toContain(contractText);
+    }
     expect(authkitPatchSource).toContain("throw error;");
     expect(authkitPatchSource).toContain(
       "recoverEndedSession(() => refreshSession({ organizationId })",
@@ -48,8 +59,14 @@ describe("ConvexClientProvider auth recovery contracts", () => {
     expect(authkitPatchSource).toContain(
       "recoverEndedSession(() => switchToOrganization(organizationId, options)",
     );
-    expect(authkitPatchSource).toContain(
-      "recoverEndedSession(() => withAuth(), { user: null })",
+    expect(authkitPatchSource).toMatch(
+      /const \{ user, organizationId: sessionOrganizationId \} = await recoverEndedSession[\s\S]{0,160}\(\) => withAuth\(\)/,
+    );
+    expect(authkitPatchSource).toMatch(
+      /export const getAuthAction[\s\S]{0,700}const auth = await recoverEndedSession\(\(\) => withAuth\(\), \{ user: null \}/,
+    );
+    expect(authkitPatchSource).toMatch(
+      /export async function getAccessTokenAction[\s\S]{0,350}recoverEndedSession\(\(\) => withAuth\(\), \{ user: null \}[\s\S]{0,100}return auth\.accessToken/,
     );
     expect(authkitPatchSource).toContain(
       "if (isEndedSessionRefreshError(error))",

--- a/components/__tests__/ConvexClientProvider.contracts.test.ts
+++ b/components/__tests__/ConvexClientProvider.contracts.test.ts
@@ -9,6 +9,13 @@ const rootLayoutSource = fs.readFileSync(
   path.resolve(__dirname, "../../app/layout.tsx"),
   "utf8",
 );
+const authkitPatchSource = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    "../../patches/@workos-inc__authkit-nextjs@4.2.0.patch",
+  ),
+  "utf8",
+);
 
 describe("ConvexClientProvider auth recovery contracts", () => {
   it("disables AuthKit focus and visibility session probes", () => {
@@ -27,5 +34,26 @@ describe("ConvexClientProvider auth recovery contracts", () => {
       "<ConvexClientProvider initialAuth={initialAuth}>",
     );
     expect(providerSource).toContain("initialAuth={initialAuth}");
+  });
+
+  it("recovers exact ended sessions at automatic AuthKit action boundaries", () => {
+    expect(authkitPatchSource).toContain(
+      "const isEndedSessionRefreshError = (value",
+    );
+    expect(authkitPatchSource).toContain("errorText.includes('invalid_grant')");
+    expect(authkitPatchSource).toContain("throw error;");
+    expect(authkitPatchSource).toContain(
+      "recoverEndedSession(() => refreshSession({ organizationId })",
+    );
+    expect(authkitPatchSource).toContain(
+      "recoverEndedSession(() => switchToOrganization(organizationId, options)",
+    );
+    expect(authkitPatchSource).toContain(
+      "recoverEndedSession(() => withAuth(), { user: null })",
+    );
+    expect(authkitPatchSource).toContain(
+      "if (isEndedSessionRefreshError(error))",
+    );
+    expect(authkitPatchSource).toContain("return { accessToken: undefined };");
   });
 });

--- a/lib/billing/__tests__/fraud-refund.test.ts
+++ b/lib/billing/__tests__/fraud-refund.test.ts
@@ -98,4 +98,35 @@ describe("getRemainingRefundAmountCents", () => {
       create.mock.invocationCallOrder[1],
     );
   });
+
+  it("treats Stripe's non-refundable charge error as terminal", async () => {
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    const create = jest
+      .fn<
+        (
+          params: { amount: number; charge: string; reason: "fraudulent" },
+          options: { idempotencyKey: string },
+        ) => Promise<unknown>
+      >()
+      .mockRejectedValue({
+        statusCode: 400,
+        code: "charge_not_refundable",
+      });
+    const retrieve = jest.fn<(chargeId: string) => Promise<Stripe.Charge>>();
+
+    await expect(
+      refundChargeForEFW(
+        { charges: { retrieve }, refunds: { create } },
+        {
+          id: "ch_123",
+          amount: 2_500,
+          amount_refunded: 0,
+        } as Stripe.Charge,
+        "issfr_123",
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalledTimes(1);
+  });
 });

--- a/lib/billing/__tests__/fraud-refund.test.ts
+++ b/lib/billing/__tests__/fraud-refund.test.ts
@@ -1,15 +1,14 @@
-import fs from "fs";
-import path from "path";
-import { describe, expect, it } from "@jest/globals";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import type Stripe from "stripe";
 import {
   getRemainingRefundAmountCents,
   isRefundAmountRaceError,
+  refundChargeForEFW,
 } from "../fraud-refund";
 
-const fraudWebhookSource = fs.readFileSync(
-  path.resolve(__dirname, "../../../app/api/fraud/webhook/route.ts"),
-  "utf8",
-);
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 describe("getRemainingRefundAmountCents", () => {
   it("returns the full charge amount when nothing has been refunded", () => {
@@ -37,35 +36,66 @@ describe("getRemainingRefundAmountCents", () => {
     expect(
       isRefundAmountRaceError({
         statusCode: 400,
-        message:
-          "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.03)",
+        code: "amount_too_large",
       }),
     ).toBe(true);
     expect(
       isRefundAmountRaceError({
         statusCode: 500,
-        message:
-          "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.03)",
+        code: "amount_too_large",
       }),
     ).toBe(false);
     expect(
       isRefundAmountRaceError({
         statusCode: 400,
-        message: "No such charge",
+        code: "resource_missing",
       }),
     ).toBe(false);
   });
 
-  it("refreshes the charge and bounds one idempotent race retry", () => {
-    const refreshIndex = fraudWebhookSource.indexOf(
-      "stripe.charges.retrieve(charge.id)",
-    );
-    const boundedRetryIndex = fraudWebhookSource.indexOf(
-      "amount: refreshedRemainingAmount",
+  it("refreshes the charge and bounds one idempotent race retry", async () => {
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    const raceError = { statusCode: 400, code: "amount_too_large" };
+    const create = jest
+      .fn<
+        (
+          params: { amount: number; charge: string; reason: "fraudulent" },
+          options: { idempotencyKey: string },
+        ) => Promise<unknown>
+      >()
+      .mockRejectedValueOnce(raceError)
+      .mockResolvedValueOnce({ id: "re_123" });
+    const retrieve = jest
+      .fn<(chargeId: string) => Promise<Stripe.Charge>>()
+      .mockResolvedValue({
+        id: "ch_123",
+        amount: 2_500,
+        amount_refunded: 2_497,
+      } as Stripe.Charge);
+
+    await refundChargeForEFW(
+      { charges: { retrieve }, refunds: { create } },
+      {
+        id: "ch_123",
+        amount: 2_500,
+        amount_refunded: 0,
+      } as Stripe.Charge,
+      "issfr_123",
     );
 
-    expect(refreshIndex).toBeGreaterThan(-1);
-    expect(boundedRetryIndex).toBeGreaterThan(refreshIndex);
-    expect(fraudWebhookSource).toContain("`efw-refund:${efwId}:remaining`");
+    expect(create).toHaveBeenNthCalledWith(
+      1,
+      { amount: 2_500, charge: "ch_123", reason: "fraudulent" },
+      { idempotencyKey: "efw-refund:issfr_123:2500" },
+    );
+    expect(retrieve).toHaveBeenCalledWith("ch_123");
+    expect(create).toHaveBeenNthCalledWith(
+      2,
+      { amount: 3, charge: "ch_123", reason: "fraudulent" },
+      { idempotencyKey: "efw-refund:issfr_123:remaining:3" },
+    );
+    expect(retrieve.mock.invocationCallOrder[0]).toBeLessThan(
+      create.mock.invocationCallOrder[1],
+    );
   });
 });

--- a/lib/billing/__tests__/fraud-refund.test.ts
+++ b/lib/billing/__tests__/fraud-refund.test.ts
@@ -1,5 +1,15 @@
+import fs from "fs";
+import path from "path";
 import { describe, expect, it } from "@jest/globals";
-import { getRemainingRefundAmountCents } from "../fraud-refund";
+import {
+  getRemainingRefundAmountCents,
+  isRefundAmountRaceError,
+} from "../fraud-refund";
+
+const fraudWebhookSource = fs.readFileSync(
+  path.resolve(__dirname, "../../../app/api/fraud/webhook/route.ts"),
+  "utf8",
+);
 
 describe("getRemainingRefundAmountCents", () => {
   it("returns the full charge amount when nothing has been refunded", () => {
@@ -21,5 +31,41 @@ describe("getRemainingRefundAmountCents", () => {
     expect(
       getRemainingRefundAmountCents({ amount: 2_000, amount_refunded: 2_000 }),
     ).toBe(0);
+  });
+
+  it("matches only Stripe's refund-balance race response", () => {
+    expect(
+      isRefundAmountRaceError({
+        statusCode: 400,
+        message:
+          "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.03)",
+      }),
+    ).toBe(true);
+    expect(
+      isRefundAmountRaceError({
+        statusCode: 500,
+        message:
+          "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.03)",
+      }),
+    ).toBe(false);
+    expect(
+      isRefundAmountRaceError({
+        statusCode: 400,
+        message: "No such charge",
+      }),
+    ).toBe(false);
+  });
+
+  it("refreshes the charge and bounds one idempotent race retry", () => {
+    const refreshIndex = fraudWebhookSource.indexOf(
+      "stripe.charges.retrieve(charge.id)",
+    );
+    const boundedRetryIndex = fraudWebhookSource.indexOf(
+      "amount: refreshedRemainingAmount",
+    );
+
+    expect(refreshIndex).toBeGreaterThan(-1);
+    expect(boundedRetryIndex).toBeGreaterThan(refreshIndex);
+    expect(fraudWebhookSource).toContain("`efw-refund:${efwId}:remaining`");
   });
 });

--- a/lib/billing/fraud-refund.ts
+++ b/lib/billing/fraud-refund.ts
@@ -5,3 +5,15 @@ export function getRemainingRefundAmountCents(
 ): number {
   return Math.max(0, charge.amount - charge.amount_refunded);
 }
+
+export function isRefundAmountRaceError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  const stripeError = error as { message?: unknown; statusCode?: unknown };
+  return (
+    stripeError.statusCode === 400 &&
+    typeof stripeError.message === "string" &&
+    stripeError.message.includes("Refund amount (") &&
+    stripeError.message.includes("is greater than unrefunded amount on charge")
+  );
+}

--- a/lib/billing/fraud-refund.ts
+++ b/lib/billing/fraud-refund.ts
@@ -1,5 +1,27 @@
 import type Stripe from "stripe";
 
+type FraudRefundStripeClient = {
+  charges: {
+    retrieve: (chargeId: string) => Promise<Stripe.Charge>;
+  };
+  refunds: {
+    create: (
+      params: {
+        amount: number;
+        charge: string;
+        reason: "fraudulent";
+      },
+      options: { idempotencyKey: string },
+    ) => Promise<unknown>;
+  };
+};
+
+const TERMINAL_REFUND_ERROR_CODES = new Set([
+  "charge_already_refunded",
+  "charge_disputed",
+  "charge_pending",
+]);
+
 export function getRemainingRefundAmountCents(
   charge: Pick<Stripe.Charge, "amount" | "amount_refunded">,
 ): number {
@@ -9,11 +31,107 @@ export function getRemainingRefundAmountCents(
 export function isRefundAmountRaceError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
 
-  const stripeError = error as { message?: unknown; statusCode?: unknown };
+  const stripeError = error as { code?: unknown; statusCode?: unknown };
   return (
-    stripeError.statusCode === 400 &&
-    typeof stripeError.message === "string" &&
-    stripeError.message.includes("Refund amount (") &&
-    stripeError.message.includes("is greater than unrefunded amount on charge")
+    stripeError.statusCode === 400 && stripeError.code === "amount_too_large"
   );
+}
+
+/**
+ * Refund a charge for an early fraud warning.
+ *
+ * Idempotency keys include the observed refundable balance, so webhook retries
+ * for the same balance collapse while a later delivery with a fresher balance
+ * can make progress. If another refund wins the race after retrieval, refresh
+ * the charge once and retry no more than its current remaining balance.
+ *
+ * Terminal failures are treated as success because there is nothing to retry.
+ * All other failures propagate so Stripe can retry the webhook delivery.
+ */
+export async function refundChargeForEFW(
+  stripeClient: FraudRefundStripeClient,
+  charge: Stripe.Charge,
+  efwId: string,
+): Promise<void> {
+  const remainingAmount = getRemainingRefundAmountCents(charge);
+  if (remainingAmount === 0) {
+    console.log(
+      `[Fraud Webhook] Refund skipped for ${charge.id} (EFW ${efwId}): charge has no refundable balance`,
+    );
+    return;
+  }
+
+  let refundError: unknown;
+
+  try {
+    await stripeClient.refunds.create(
+      {
+        charge: charge.id,
+        reason: "fraudulent",
+        amount: remainingAmount,
+      },
+      { idempotencyKey: `efw-refund:${efwId}:${remainingAmount}` },
+    );
+    console.log(
+      `[Fraud Webhook] Refunded ${remainingAmount} cents from charge ${charge.id} (early fraud warning ${efwId})`,
+    );
+    return;
+  } catch (error) {
+    refundError = error;
+  }
+
+  if (isRefundAmountRaceError(refundError)) {
+    try {
+      const refreshedCharge = await stripeClient.charges.retrieve(charge.id);
+      const refreshedRemainingAmount =
+        getRemainingRefundAmountCents(refreshedCharge);
+
+      if (refreshedRemainingAmount === 0) {
+        console.log(
+          `[Fraud Webhook] Refund skipped for ${charge.id} (EFW ${efwId}): charge has no refundable balance after refresh`,
+        );
+        return;
+      }
+
+      if (refreshedRemainingAmount < remainingAmount) {
+        await stripeClient.refunds.create(
+          {
+            charge: charge.id,
+            reason: "fraudulent",
+            amount: refreshedRemainingAmount,
+          },
+          {
+            idempotencyKey: `efw-refund:${efwId}:remaining:${refreshedRemainingAmount}`,
+          },
+        );
+        console.log(
+          `[Fraud Webhook] Refunded refreshed remaining balance of ${refreshedRemainingAmount} cents from charge ${charge.id} (early fraud warning ${efwId})`,
+        );
+        return;
+      }
+    } catch (error) {
+      refundError = error;
+    }
+  }
+
+  const terminalError =
+    refundError && typeof refundError === "object"
+      ? (refundError as { code?: unknown; statusCode?: unknown })
+      : null;
+  if (
+    terminalError?.statusCode === 400 &&
+    typeof terminalError.code === "string" &&
+    TERMINAL_REFUND_ERROR_CODES.has(terminalError.code)
+  ) {
+    console.log(
+      `[Fraud Webhook] Refund skipped for ${charge.id} (EFW ${efwId}): ${terminalError.code}`,
+    );
+    return;
+  }
+
+  console.error(
+    `[Fraud Webhook] Refund failed for ${charge.id} (EFW ${efwId}):`,
+    refundError,
+  );
+  throw refundError;
 }

--- a/lib/billing/fraud-refund.ts
+++ b/lib/billing/fraud-refund.ts
@@ -19,7 +19,7 @@ type FraudRefundStripeClient = {
 const TERMINAL_REFUND_ERROR_CODES = new Set([
   "charge_already_refunded",
   "charge_disputed",
-  "charge_pending",
+  "charge_not_refundable",
 ]);
 
 export function getRemainingRefundAmountCents(

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -131,6 +131,52 @@ describe("desktop-local sandbox file helpers", () => {
     }
   });
 
+  it("redacts signed URL queries from staging failure diagnostics", async () => {
+    const sourceUrl =
+      "https://storage.example.com/report.pdf?X-Amz-Credential=opaque&X-Amz-Signature=secret";
+    const safeUrl = "https://storage.example.com/report.pdf";
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      const result = await uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: sourceUrl,
+            localPath: "/home/user/upload/report.pdf",
+          },
+        ],
+        async () => ({
+          files: {
+            downloadFromUrl: jest
+              .fn()
+              .mockRejectedValue(
+                new Error(`Failed to download ${sourceUrl}: timed out`),
+              ),
+          },
+        }),
+      );
+
+      const diagnostics = JSON.stringify({
+        logged: consoleErrorSpy.mock.calls,
+        metadata: getSandboxUploadFailureMetadata(result),
+      });
+      expect(diagnostics).not.toContain("X-Amz-Credential");
+      expect(diagnostics).not.toContain("X-Amz-Signature");
+      expect(diagnostics).not.toContain("secret");
+      expect(diagnostics).toContain(safeUrl);
+      expect(getSandboxUploadFailureMetadata(result)).toMatchObject({
+        upload_failure_kind: "url",
+        upload_failure_protocol: "https",
+        upload_failure_url_length: sourceUrl.length,
+      });
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it("retries url uploads in a writable directory when /tmp is not writable", async () => {
     const consoleWarnSpy = jest
       .spyOn(console, "warn")

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -159,12 +159,18 @@ describe("desktop-local sandbox file helpers", () => {
         }),
       );
 
+      const normalizedLogCalls = consoleErrorSpy.mock.calls.map((call) =>
+        call.map((value) =>
+          value instanceof Error ? { message: value.message } : value,
+        ),
+      );
       const diagnostics = JSON.stringify({
-        logged: consoleErrorSpy.mock.calls,
+        logged: normalizedLogCalls,
         metadata: getSandboxUploadFailureMetadata(result),
       });
       expect(diagnostics).not.toContain("X-Amz-Credential");
       expect(diagnostics).not.toContain("X-Amz-Signature");
+      expect(diagnostics).not.toContain("opaque");
       expect(diagnostics).not.toContain("secret");
       expect(diagnostics).toContain(safeUrl);
       expect(getSandboxUploadFailureMetadata(result)).toMatchObject({

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -762,7 +762,9 @@ const redactSandboxUploadError = (
   error: unknown,
 ): string => {
   const message = error instanceof Error ? error.message : String(error);
-  if (file.kind !== "localPath") return message;
+  if (file.kind === "url") {
+    return message.split(file.url).join(safeUrlForLog(file.url));
+  }
   return message.split(file.path).join("[redacted-local-path]");
 };
 

--- a/package.json
+++ b/package.json
@@ -230,7 +230,8 @@
       "undici@>=7.0.0 <7.28.0": "7.28.0"
     },
     "patchedDependencies": {
-      "ai@6.0.200": "patches/ai@6.0.200.patch"
+      "ai@6.0.200": "patches/ai@6.0.200.patch",
+      "@workos-inc/authkit-nextjs@4.2.0": "patches/@workos-inc__authkit-nextjs@4.2.0.patch"
     }
   }
 }

--- a/patches/@workos-inc__authkit-nextjs@4.2.0.patch
+++ b/patches/@workos-inc__authkit-nextjs@4.2.0.patch
@@ -1,0 +1,248 @@
+diff --git a/dist/esm/actions.js b/dist/esm/actions.js
+index 48babd8e1868c58577252b8a27660fcb73e7ef98..bb6fefe1447ffed2e06833f3882ab6471aec4a05 100644
+--- a/dist/esm/actions.js
++++ b/dist/esm/actions.js
+@@ -13,6 +13,56 @@ function sanitize(value) {
+     const { accessToken, ...sanitized } = value;
+     return sanitized;
+ }
++const getStringValue = (value, key) => {
++    const fieldValue = value[key];
++    return typeof fieldValue === 'string' ? fieldValue : null;
++};
++const collectAuthErrorText = (value, seen = new Set(), depth = 0) => {
++    if (typeof value === 'string') {
++        return value;
++    }
++    if (!value || typeof value !== 'object' || depth > 4 || seen.has(value)) {
++        return '';
++    }
++    seen.add(value);
++    const record = value;
++    const rawData = record.rawData && typeof record.rawData === 'object'
++        ? record.rawData
++        : {};
++    return [
++        getStringValue(record, 'name'),
++        getStringValue(record, 'message'),
++        getStringValue(record, 'error'),
++        getStringValue(record, 'errorDescription'),
++        getStringValue(record, 'error_description'),
++        getStringValue(rawData, 'error'),
++        getStringValue(rawData, 'errorDescription'),
++        getStringValue(rawData, 'error_description'),
++        collectAuthErrorText(record.cause, seen, depth + 1),
++    ].filter((text) => Boolean(text)).join('\n');
++};
++const isEndedSessionRefreshError = (value) => {
++    const errorText = collectAuthErrorText(value).toLowerCase();
++    return errorText.includes('invalid_grant') && (errorText.includes('session has already ended') ||
++        errorText.includes('session ended due to inactivity'));
++};
++/**
++ * Client-triggered server actions run after middleware, so a session can end
++ * between the middleware check and the action's refresh. Treat only WorkOS's
++ * exact ended-session response as signed out; all other auth errors still fail
++ * visibly so configuration, provider, and authorization defects are not hidden.
++ */
++async function recoverEndedSession(loadAuth, fallback) {
++    try {
++        return await loadAuth();
++    }
++    catch (error) {
++        if (!isEndedSessionRefreshError(error)) {
++            throw error;
++        }
++        return fallback;
++    }
++}
+ /**
+  * This action is only accessible to authenticated users,
+  * there is no need to check the session here as the middleware will
+@@ -29,7 +79,7 @@ export const getOrganizationAction = async (organizationId) => {
+     // authenticated within. The WorkOS client uses the app's API key, which can
+     // read any organization in the environment, so without this check any caller
+     // could fetch arbitrary organizations by ID (authorization bypass / IDOR).
+-    const { user, organizationId: sessionOrganizationId } = await withAuth();
++    const { user, organizationId: sessionOrganizationId } = await recoverEndedSession(() => withAuth(), { user: null });
+     if (!user || sessionOrganizationId !== organizationId) {
+         return null;
+     }
+@@ -43,7 +93,7 @@ export const getAuthAction = async (options) => {
+     // would call redirect() to an external URL, which causes CORS errors when
+     // invoked via a client-side fetch. Instead, return the sign-in URL so the
+     // client can redirect via window.location.href.
+-    const auth = await withAuth();
++    const auth = await recoverEndedSession(() => withAuth(), { user: null });
+     const sanitized = sanitize(auth);
+     if (options?.ensureSignedIn && !auth.user) {
+         const signInUrl = await getSignInUrl();
+@@ -54,7 +104,7 @@ export const getAuthAction = async (options) => {
+ export const refreshAuthAction = async ({ ensureSignedIn, organizationId, }) => {
+     // Never pass ensureSignedIn to refreshSession from a server action for the
+     // same CORS reason as getAuthAction above.
+-    const auth = await refreshSession({ organizationId });
++    const auth = await recoverEndedSession(() => refreshSession({ organizationId }), { user: null });
+     const sanitized = sanitize(auth);
+     if (ensureSignedIn && !auth.user) {
+         const signInUrl = await getSignInUrl();
+@@ -63,14 +113,14 @@ export const refreshAuthAction = async ({ ensureSignedIn, organizationId, }) =>
+     return sanitized;
+ };
+ export const switchToOrganizationAction = async (organizationId, options) => {
+-    return sanitize(await switchToOrganization(organizationId, options));
++    return sanitize(await recoverEndedSession(() => switchToOrganization(organizationId, options), { user: null }));
+ };
+ /**
+  * This action is used to get the access token from the auth object.
+  * It is used to fetch the access token from the server.
+  */
+ export async function getAccessTokenAction() {
+-    const auth = await withAuth();
++    const auth = await recoverEndedSession(() => withAuth(), { user: null });
+     return auth.accessToken;
+ }
+ /**
+@@ -86,6 +136,9 @@ export async function refreshAccessTokenAction() {
+         return { accessToken: auth.accessToken };
+     }
+     catch (error) {
++        if (isEndedSessionRefreshError(error)) {
++            return { accessToken: undefined };
++        }
+         console.warn('Failed to refresh access token:', error instanceof Error ? error.message : String(error));
+         return {
+             accessToken: undefined,
+diff --git a/src/actions.ts b/src/actions.ts
+index dbc84f49ce8960ac2c88d31e6f98d60af4deab90..f1d7a65274daffcfa5716f253460e4b9affc0e1c 100644
+--- a/src/actions.ts
++++ b/src/actions.ts
+@@ -22,6 +22,64 @@ function sanitize<T extends UserInfo | NoUserInfo>(value: T) {
+   return sanitized;
+ }
+ 
++const getStringValue = (value: Record<string, unknown>, key: string): string | null => {
++  const fieldValue = value[key];
++  return typeof fieldValue === 'string' ? fieldValue : null;
++};
++
++const collectAuthErrorText = (value: unknown, seen = new Set<unknown>(), depth = 0): string => {
++  if (typeof value === 'string') {
++    return value;
++  }
++
++  if (!value || typeof value !== 'object' || depth > 4 || seen.has(value)) {
++    return '';
++  }
++  seen.add(value);
++
++  const record = value as Record<string, unknown>;
++  const rawData = record.rawData && typeof record.rawData === 'object'
++    ? record.rawData as Record<string, unknown>
++    : {};
++
++  return [
++    getStringValue(record, 'name'),
++    getStringValue(record, 'message'),
++    getStringValue(record, 'error'),
++    getStringValue(record, 'errorDescription'),
++    getStringValue(record, 'error_description'),
++    getStringValue(rawData, 'error'),
++    getStringValue(rawData, 'errorDescription'),
++    getStringValue(rawData, 'error_description'),
++    collectAuthErrorText(record.cause, seen, depth + 1),
++  ].filter((text): text is string => Boolean(text)).join('\n');
++};
++
++const isEndedSessionRefreshError = (value: unknown): boolean => {
++  const errorText = collectAuthErrorText(value).toLowerCase();
++  return errorText.includes('invalid_grant') && (
++    errorText.includes('session has already ended') ||
++    errorText.includes('session ended due to inactivity')
++  );
++};
++
++/**
++ * Client-triggered server actions run after middleware, so a session can end
++ * between the middleware check and the action's refresh. Treat only WorkOS's
++ * exact ended-session response as signed out; all other auth errors still fail
++ * visibly so configuration, provider, and authorization defects are not hidden.
++ */
++async function recoverEndedSession<T>(loadAuth: () => Promise<T>, fallback: T): Promise<T> {
++  try {
++    return await loadAuth();
++  } catch (error) {
++    if (!isEndedSessionRefreshError(error)) {
++      throw error;
++    }
++    return fallback;
++  }
++}
++
+ /**
+  * This action is only accessible to authenticated users,
+  * there is no need to check the session here as the middleware will
+@@ -40,7 +98,10 @@ export const getOrganizationAction = async (organizationId: string) => {
+   // authenticated within. The WorkOS client uses the app's API key, which can
+   // read any organization in the environment, so without this check any caller
+   // could fetch arbitrary organizations by ID (authorization bypass / IDOR).
+-  const { user, organizationId: sessionOrganizationId } = await withAuth();
++  const { user, organizationId: sessionOrganizationId } = await recoverEndedSession(
++    () => withAuth(),
++    { user: null } as NoUserInfo,
++  );
+   if (!user || sessionOrganizationId !== organizationId) {
+     return null;
+   }
+@@ -56,7 +117,7 @@ export const getAuthAction = async (options?: { ensureSignedIn?: boolean }) => {
+   // would call redirect() to an external URL, which causes CORS errors when
+   // invoked via a client-side fetch. Instead, return the sign-in URL so the
+   // client can redirect via window.location.href.
+-  const auth = await withAuth();
++  const auth = await recoverEndedSession(() => withAuth(), { user: null } as NoUserInfo);
+   const sanitized = sanitize(auth);
+ 
+   if (options?.ensureSignedIn && !auth.user) {
+@@ -76,7 +137,10 @@ export const refreshAuthAction = async ({
+ }) => {
+   // Never pass ensureSignedIn to refreshSession from a server action for the
+   // same CORS reason as getAuthAction above.
+-  const auth = await refreshSession({ organizationId });
++  const auth = await recoverEndedSession(
++    () => refreshSession({ organizationId }),
++    { user: null } as NoUserInfo,
++  );
+   const sanitized = sanitize(auth);
+ 
+   if (ensureSignedIn && !auth.user) {
+@@ -88,7 +152,10 @@ export const refreshAuthAction = async ({
+ };
+ 
+ export const switchToOrganizationAction = async (organizationId: string, options?: SwitchToOrganizationOptions) => {
+-  return sanitize(await switchToOrganization(organizationId, options));
++  return sanitize(await recoverEndedSession(
++    () => switchToOrganization(organizationId, options),
++    { user: null } as NoUserInfo,
++  ));
+ };
+ 
+ /**
+@@ -96,7 +163,7 @@ export const switchToOrganizationAction = async (organizationId: string, options
+  * It is used to fetch the access token from the server.
+  */
+ export async function getAccessTokenAction() {
+-  const auth = await withAuth();
++  const auth = await recoverEndedSession(() => withAuth(), { user: null } as NoUserInfo);
+   return auth.accessToken;
+ }
+ 
+@@ -112,6 +179,9 @@ export async function refreshAccessTokenAction(): Promise<RefreshAccessTokenActi
+     const auth = await refreshSession();
+     return { accessToken: auth.accessToken };
+   } catch (error) {
++    if (isEndedSessionRefreshError(error)) {
++      return { accessToken: undefined };
++    }
+     console.warn('Failed to refresh access token:', error instanceof Error ? error.message : String(error));
+     return {
+       accessToken: undefined,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ overrides:
   undici@>=7.0.0 <7.28.0: 7.28.0
 
 patchedDependencies:
+  '@workos-inc/authkit-nextjs@4.2.0':
+    hash: d280094ebf5ae4aec314c2a50eac6a004ce97078f318e4c47741c7b3953e9649
+    path: patches/@workos-inc__authkit-nextjs@4.2.0.patch
   ai@6.0.200:
     hash: 1079dc939735763e1ec40ea672cd70da577a253b731d47f34d1506acb47febf9
     path: patches/ai@6.0.200.patch
@@ -161,7 +164,7 @@ importers:
         version: 3.7.5(@aws-sdk/credential-provider-web-identity@3.972.63)(ws@8.21.0)
       '@workos-inc/authkit-nextjs':
         specifier: 4.2.0
-        version: 4.2.0(@workos-inc/node@10.7.0)(next@16.2.10(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+        version: 4.2.0(patch_hash=d280094ebf5ae4aec314c2a50eac6a004ce97078f318e4c47741c7b3953e9649)(@workos-inc/node@10.7.0)(next@16.2.10(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@workos-inc/node':
         specifier: ^10.7.0
         version: 10.7.0
@@ -12022,7 +12025,7 @@ snapshots:
 
   '@workos-inc/authkit-js@0.20.0': {}
 
-  '@workos-inc/authkit-nextjs@4.2.0(@workos-inc/node@10.7.0)(next@16.2.10(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
+  '@workos-inc/authkit-nextjs@4.2.0(patch_hash=d280094ebf5ae4aec314c2a50eac6a004ce97078f318e4c47741c7b3953e9649)(@workos-inc/node@10.7.0)(next@16.2.10(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@sindresorhus/fnv1a': 3.1.0
       '@workos-inc/node': 10.7.0


### PR DESCRIPTION
## Summary

- recover exact WorkOS ended-session `invalid_grant` responses at automatic AuthKit server-action read and refresh boundaries while preserving unrelated auth failures
- re-read Stripe's current refundable balance and perform one bounded, event-idempotent retry when an early-fraud-warning refund races another refund
- strip signed URL query parameters from sandbox attachment failure logs and diagnostic metadata

## Why

A production audit identified three current failure classes: ended sessions could still escape from client-invoked AuthKit server actions after root-layout hydration, an early-fraud-warning refund could race a concurrent partial refund, and attachment transfer errors could echo signed source URLs into internal diagnostics.

The detailed production identifiers and incident timeline remain in the internal audit rather than this public repository.

## Root cause and change

The existing root-layout recovery did not cover AuthKit's later client-invoked server actions. A pnpm patch applies the same narrow ended-session classifier to automatic reads, refreshes, access-token refresh, and organization actions. Other auth failures still throw or retain their existing error result.

The fraud handler bounded its first refund from a retrieved charge, but another refund could land before `refunds.create`. The handler now refreshes the charge once and retries only the smaller current balance under a separate event-derived idempotency key.

Sandbox upload error text now replaces the exact signed source URL with its origin and path before any log or failure metadata is emitted.

## Validation

- focused auth, refund, and sandbox regression tests (30 tests)
- commit hook: full test suite (287 suites, 2,836 tests) and typecheck
- changed-file ESLint and Prettier checks
- production Next.js build
- patched AuthKit action syntax check

Visual QA is not applicable; this is server-action, payment webhook, and diagnostic redaction behavior.

## Manual verification

1. With an expired WorkOS session, load the home route and trigger organization/access-token refresh. The client should resolve signed out or redirect to sign-in without a root server-action 500; unrelated auth failures must remain visible.
2. In Stripe test mode, deliver an early fraud warning while a partial refund races the handler. The webhook should refund no more than the freshly retrieved remaining balance and finalize successfully.
3. Force a sandbox attachment download failure using a signed URL. Diagnostics should retain protocol, URL length, and safe path, with no query signature or credential.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fraud-refund robustness for concurrent refund attempts by detecting “amount too large” race conditions and safely retrying when appropriate; also treats “charge not refundable” cases as terminal.
  * Authentication actions now recover from “ended session” (`invalid_grant`) refresh errors by returning signed-out style fallbacks instead of failing.
  * Sandbox upload diagnostics now redact signed URL query/signature details for URL-based uploads.
* **Tests**
  * Added/extended unit and contract tests covering refund race handling, ended-session recovery behavior, and signed URL redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->