### PR TITLE
Add project move submenu

### DIFF
--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -579,6 +579,7 @@ const ChatItem: React.FC<ChatItemProps> = ({
                   >
                     <DropdownMenuItem
                       className={CHAT_OPTION_ITEM_CLASS}
+                      disabled={movingProjectId !== null}
                       onSelect={handleCreateProject}
                     >
                       <FolderPlus

--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -14,6 +14,10 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -49,7 +53,11 @@ import {
   Pin,
   PinOff,
   LoaderCircle,
+  Folder,
   FolderInput,
+  FolderMinus,
+  FolderPlus,
+  ListPlus,
 } from "lucide-react";
 import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
@@ -58,9 +66,12 @@ import { openSettingsDialog } from "@/lib/utils/settings-dialog";
 import { cancelAgentLongRealtimeStreams } from "@/lib/chat/agent-long-transport";
 import { ShareDialog } from "./ShareDialog";
 import { MoveChatToProjectDialog } from "./MoveChatToProjectDialog";
+import { ProjectCreateDialog } from "./ProjectCreateDialog";
 import { usePinChat, useUnpinChat } from "../hooks/useChats";
+import { useMoveChatToProjectAction } from "../hooks/useMoveChatToProjectAction";
 import { setSidebarChatDragData } from "./sidebar-chat-drag";
 import { formatTaskTitle, formatTaskUiCopy } from "@/app/utils/task-ui-copy";
+import { useSidebarProjectList } from "@/app/contexts/SidebarProjectList";
 
 interface ChatItemProps {
   id: string;
@@ -74,6 +85,15 @@ interface ChatItemProps {
   isStreaming?: boolean;
   isAwaitingApproval?: boolean;
 }
+
+const CHAT_OPTIONS_CONTENT_CLASS =
+  "z-50 min-w-52 rounded-xl border-border/80 p-1.5 shadow-xl";
+const CHAT_OPTION_ITEM_CLASS =
+  "h-9 gap-2.5 rounded-md px-2.5 py-1.5 text-sm font-normal text-foreground focus:bg-accent focus:text-foreground data-[highlighted]:bg-accent data-[highlighted]:text-foreground";
+const CHAT_OPTION_DESTRUCTIVE_ITEM_CLASS =
+  "h-9 gap-2.5 rounded-md px-2.5 py-1.5 text-sm font-normal text-destructive focus:bg-destructive/10 focus:text-destructive data-[highlighted]:bg-destructive/10 data-[highlighted]:text-destructive";
+const CHAT_OPTIONS_SEPARATOR_CLASS = "mx-1 my-1 bg-border/80";
+const CHAT_OPTION_ICON_CLASS = "size-4 shrink-0 text-foreground/75";
 
 const getRouteChatIdFromPathname = (pathname: string | null): string | null => {
   const match = pathname?.match(/^\/c\/([^/?#]+)/);
@@ -107,6 +127,7 @@ const ChatItem: React.FC<ChatItemProps> = ({
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [showShareDialog, setShowShareDialog] = useState(false);
   const [showMoveProjectDialog, setShowMoveProjectDialog] = useState(false);
+  const [showCreateProjectDialog, setShowCreateProjectDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [editTitle, setEditTitle] = useState(taskTitle);
   const [isRenaming, setIsRenaming] = useState(false);
@@ -127,6 +148,17 @@ const ChatItem: React.FC<ChatItemProps> = ({
   const renameChat = useMutation(api.chats.renameChat);
   const pinChat = usePinChat();
   const unpinChat = useUnpinChat();
+  const {
+    movingDestination: movingProjectId,
+    moveToProject: handleProjectMove,
+  } = useMoveChatToProjectAction({ chatId: id, currentProjectId: projectId });
+  const {
+    projects,
+    paginationStatus: projectPaginationStatus,
+    loadMoreProjects,
+  } = useSidebarProjectList();
+  const destinationProjects =
+    projects?.filter((project) => project._id !== projectId) ?? [];
 
   const routeChatId = getRouteChatIdFromPathname(pathname);
   const selectedChatId = optimisticChatId ?? routeChatId;
@@ -177,6 +209,7 @@ const ChatItem: React.FC<ChatItemProps> = ({
       showRenameDialog ||
       showShareDialog ||
       showMoveProjectDialog ||
+      showCreateProjectDialog ||
       showDeleteDialog ||
       isDropdownOpen
     ) {
@@ -303,6 +336,11 @@ const ChatItem: React.FC<ChatItemProps> = ({
     }, 50);
   };
 
+  const handleCreateProject = () => {
+    setIsDropdownOpen(false);
+    window.setTimeout(() => setShowCreateProjectDialog(true), 50);
+  };
+
   const handlePin = async (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -378,6 +416,7 @@ const ChatItem: React.FC<ChatItemProps> = ({
     if (
       showRenameDialog ||
       showMoveProjectDialog ||
+      showCreateProjectDialog ||
       isDropdownOpen ||
       showDeleteDialog
     ) {
@@ -480,44 +519,165 @@ const ChatItem: React.FC<ChatItemProps> = ({
                 }}
                 aria-label="Open task options"
               >
-                <Ellipsis className="size-[18px]" />
+                <Ellipsis className="size-[18px]" aria-hidden="true" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent
               align="start"
               side="bottom"
               sideOffset={5}
-              className="z-50 py-2"
+              className={CHAT_OPTIONS_CONTENT_CLASS}
               onClick={(e) => e.stopPropagation()}
             >
-              <DropdownMenuItem onClick={handleRename}>
-                <Edit2 className="mr-2 h-4 w-4" />
+              <DropdownMenuItem
+                className={CHAT_OPTION_ITEM_CLASS}
+                onClick={handleShare}
+              >
+                <Share className={CHAT_OPTION_ICON_CLASS} aria-hidden="true" />
+                Share
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className={CHAT_OPTION_ITEM_CLASS}
+                onClick={handleRename}
+              >
+                <Edit2 className={CHAT_OPTION_ICON_CLASS} aria-hidden="true" />
                 Rename
               </DropdownMenuItem>
+              <DropdownMenuSeparator className={CHAT_OPTIONS_SEPARATOR_CLASS} />
               {isPinned ? (
-                <DropdownMenuItem onClick={handleUnpin}>
-                  <PinOff className="mr-2 h-4 w-4" />
+                <DropdownMenuItem
+                  className={CHAT_OPTION_ITEM_CLASS}
+                  onClick={handleUnpin}
+                >
+                  <PinOff
+                    className={CHAT_OPTION_ICON_CLASS}
+                    aria-hidden="true"
+                  />
                   Unpin
                 </DropdownMenuItem>
               ) : (
-                <DropdownMenuItem onClick={handlePin}>
-                  <Pin className="mr-2 h-4 w-4" />
+                <DropdownMenuItem
+                  className={CHAT_OPTION_ITEM_CLASS}
+                  onClick={handlePin}
+                >
+                  <Pin className={CHAT_OPTION_ICON_CLASS} aria-hidden="true" />
                   Pin
                 </DropdownMenuItem>
               )}
-              <DropdownMenuItem onClick={handleShare}>
-                <Share className="mr-2 h-4 w-4" />
-                Share
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={handleMoveToProject}>
-                <FolderInput className="mr-2 h-4 w-4" />
-                Move to project…
-              </DropdownMenuItem>
+              {projects && projects.length > 0 ? (
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger className={CHAT_OPTION_ITEM_CLASS}>
+                    <FolderInput
+                      className={CHAT_OPTION_ICON_CLASS}
+                      aria-hidden="true"
+                    />
+                    Move to project
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent
+                    className={CHAT_OPTIONS_CONTENT_CLASS}
+                    onClick={(event) => event.stopPropagation()}
+                  >
+                    <DropdownMenuItem
+                      className={CHAT_OPTION_ITEM_CLASS}
+                      onSelect={handleCreateProject}
+                    >
+                      <FolderPlus
+                        className={CHAT_OPTION_ICON_CLASS}
+                        aria-hidden="true"
+                      />
+                      New project
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator
+                      className={CHAT_OPTIONS_SEPARATOR_CLASS}
+                    />
+                    {projectId ? (
+                      <>
+                        <DropdownMenuItem
+                          className={CHAT_OPTION_ITEM_CLASS}
+                          disabled={movingProjectId !== null}
+                          onSelect={() => void handleProjectMove(null)}
+                        >
+                          <FolderMinus
+                            className={CHAT_OPTION_ICON_CLASS}
+                            aria-hidden="true"
+                          />
+                          Remove from project
+                        </DropdownMenuItem>
+                        {destinationProjects.length > 0 ? (
+                          <DropdownMenuSeparator
+                            className={CHAT_OPTIONS_SEPARATOR_CLASS}
+                          />
+                        ) : null}
+                      </>
+                    ) : null}
+                    {destinationProjects.map((project) => (
+                      <DropdownMenuItem
+                        key={project._id}
+                        className={CHAT_OPTION_ITEM_CLASS}
+                        disabled={movingProjectId !== null}
+                        onSelect={() =>
+                          void handleProjectMove(project._id, project.name)
+                        }
+                      >
+                        <Folder
+                          className={CHAT_OPTION_ICON_CLASS}
+                          aria-hidden="true"
+                        />
+                        <span className="min-w-0 truncate">{project.name}</span>
+                      </DropdownMenuItem>
+                    ))}
+                    {projectPaginationStatus === "LoadingMore" ? (
+                      <DropdownMenuItem
+                        className={CHAT_OPTION_ITEM_CLASS}
+                        disabled
+                      >
+                        <LoaderCircle
+                          className={`${CHAT_OPTION_ICON_CLASS} animate-spin`}
+                          aria-hidden="true"
+                        />
+                        Loading more projects…
+                      </DropdownMenuItem>
+                    ) : null}
+                    {projectPaginationStatus === "CanLoadMore" &&
+                    loadMoreProjects ? (
+                      <DropdownMenuItem
+                        className={CHAT_OPTION_ITEM_CLASS}
+                        onSelect={(event) => {
+                          event.preventDefault();
+                          loadMoreProjects(10);
+                        }}
+                      >
+                        <ListPlus
+                          className={CHAT_OPTION_ICON_CLASS}
+                          aria-hidden="true"
+                        />
+                        Show more projects
+                      </DropdownMenuItem>
+                    ) : null}
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+              ) : (
+                <DropdownMenuItem
+                  className={CHAT_OPTION_ITEM_CLASS}
+                  onClick={handleMoveToProject}
+                >
+                  <FolderInput
+                    className={CHAT_OPTION_ICON_CLASS}
+                    aria-hidden="true"
+                  />
+                  Move to project…
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator className={CHAT_OPTIONS_SEPARATOR_CLASS} />
               <DropdownMenuItem
+                variant="destructive"
                 onClick={handleDeleteClick}
-                className="text-destructive focus:text-destructive"
+                className={CHAT_OPTION_DESTRUCTIVE_ITEM_CLASS}
               >
-                <Trash2 className="mr-2 h-4 w-4" />
+                <Trash2
+                  className="size-4 shrink-0 text-destructive"
+                  aria-hidden="true"
+                />
                 Delete
               </DropdownMenuItem>
             </DropdownMenuContent>
@@ -586,6 +746,17 @@ const ChatItem: React.FC<ChatItemProps> = ({
           currentProjectId={projectId}
           open={showMoveProjectDialog}
           onOpenChange={setShowMoveProjectDialog}
+        />
+      ) : null}
+
+      {showCreateProjectDialog ? (
+        <ProjectCreateDialog
+          open
+          onOpenChange={setShowCreateProjectDialog}
+          onCreated={(newProjectId, projectName) => {
+            void handleProjectMove(newProjectId, projectName);
+          }}
+          showSuccessToast={false}
         />
       ) : null}
 

--- a/app/components/MoveChatToProjectDialog.tsx
+++ b/app/components/MoveChatToProjectDialog.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useState } from "react";
 import { Folder, FolderMinus, LoaderCircle } from "lucide-react";
-import { toast } from "sonner";
 import type { Id } from "@/convex/_generated/dataModel";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,8 +11,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { useMoveChatToProject, useProjects } from "@/app/hooks/useProjects";
-import { formatTaskUiCopy } from "@/app/utils/task-ui-copy";
+import { useProjects } from "@/app/hooks/useProjects";
+import {
+  TASKS_DESTINATION,
+  useMoveChatToProjectAction,
+} from "@/app/hooks/useMoveChatToProjectAction";
 
 interface MoveChatToProjectDialogProps {
   chatId: string;
@@ -22,8 +23,6 @@ interface MoveChatToProjectDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
-
-const TASKS_DESTINATION = "tasks" as const;
 
 export function MoveChatToProjectDialog({
   chatId,
@@ -33,63 +32,18 @@ export function MoveChatToProjectDialog({
 }: MoveChatToProjectDialogProps) {
   const projectListData = useProjects();
   const projects = projectListData.results;
-  const moveChatToProject = useMoveChatToProject();
-  const [movingDestination, setMovingDestination] = useState<
-    Id<"projects"> | typeof TASKS_DESTINATION | null
-  >(null);
-
-  const undoMove = async (projectId: Id<"projects"> | null) => {
-    try {
-      await moveChatToProject({ chatId, projectId });
-      toast.success("Move undone");
-    } catch (error) {
-      console.error("Failed to undo task move:", error);
-      toast.error("Failed to undo move", {
-        description:
-          error instanceof Error
-            ? formatTaskUiCopy(error.message)
-            : "Please try again.",
-      });
-    }
-  };
+  const { movingDestination, moveToProject } = useMoveChatToProjectAction({
+    chatId,
+    currentProjectId,
+  });
 
   const handleMove = async (
     projectId: Id<"projects"> | null,
     projectName?: string,
   ) => {
-    if (movingDestination !== null) return;
-
-    setMovingDestination(projectId ?? TASKS_DESTINATION);
-    try {
-      const moved = await moveChatToProject({ chatId, projectId });
+    const moveFinished = await moveToProject(projectId, projectName);
+    if (moveFinished) {
       onOpenChange(false);
-      if (moved) {
-        toast.success(
-          projectId === null
-            ? "Removed from project"
-            : `Moved to ${projectName}`,
-          {
-            action: {
-              label: "Undo",
-              onClick: () => void undoMove(currentProjectId ?? null),
-            },
-          },
-        );
-      } else {
-        toast.info(
-          projectId === null ? "Already in Tasks" : `Already in ${projectName}`,
-        );
-      }
-    } catch (error) {
-      console.error("Failed to move chat to project:", error);
-      toast.error("Failed to move task", {
-        description:
-          error instanceof Error
-            ? formatTaskUiCopy(error.message)
-            : "Please try again.",
-      });
-    } finally {
-      setMovingDestination(null);
     }
   };
 

--- a/app/components/ProjectCreateDialog.tsx
+++ b/app/components/ProjectCreateDialog.tsx
@@ -23,7 +23,8 @@ import { isTauriEnvironment, pickLocalFolder } from "@/app/hooks/useTauri";
 interface ProjectCreateDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onCreated: (projectId: Id<"projects">) => void;
+  onCreated: (projectId: Id<"projects">, projectName: string) => void;
+  showSuccessToast?: boolean;
 }
 
 const getFolderName = (path: string): string => {
@@ -35,6 +36,7 @@ export function ProjectCreateDialog({
   open,
   onOpenChange,
   onCreated,
+  showSuccessToast = true,
 }: ProjectCreateDialogProps) {
   const createProject = useCreateProject();
   const isMobile = useIsMobile();
@@ -87,9 +89,9 @@ export function ProjectCreateDialog({
         name: trimmedName,
         ...(folderPath ? { folderPath } : {}),
       });
-      onCreated(projectId);
+      onCreated(projectId, trimmedName);
       onOpenChange(false);
-      toast.success("Project created");
+      if (showSuccessToast) toast.success("Project created");
     } catch (error) {
       console.error("Failed to create project:", error);
       toast.error("Failed to create project", {

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -18,6 +18,7 @@ import SidebarUserNav from "./SidebarUserNav";
 import SidebarHeaderContent from "./SidebarHeader";
 import { SidebarChatSections } from "./SidebarChatSections";
 import { useProjects } from "../hooks/useProjects";
+import { SidebarProjectListProvider } from "../contexts/SidebarProjectList";
 
 /** Chat list data lifted from parent so the subscription stays active when sidebar closes. */
 export type ChatListData = ReturnType<typeof useChats>;
@@ -35,15 +36,21 @@ const ChatListContent: FC<{ chatListData: ChatListData }> = ({
       ref={scrollContainerRef}
       data-testid="sidebar-chat-list-scroll-container"
     >
-      <SidebarChatSections
-        chats={chatListData.results || []}
+      <SidebarProjectListProvider
         projects={projectListData.results}
-        projectPaginationStatus={projectListData.status}
+        paginationStatus={projectListData.status}
         loadMoreProjects={projectListData.loadMore}
-        paginationStatus={chatListData.status}
-        loadMore={chatListData.loadMore}
-        containerRef={scrollContainerRef}
-      />
+      >
+        <SidebarChatSections
+          chats={chatListData.results || []}
+          projects={projectListData.results}
+          projectPaginationStatus={projectListData.status}
+          loadMoreProjects={projectListData.loadMore}
+          paginationStatus={chatListData.status}
+          loadMore={chatListData.loadMore}
+          containerRef={scrollContainerRef}
+        />
+      </SidebarProjectListProvider>
     </div>
   );
 };

--- a/app/components/__tests__/ChatItem.projects.test.tsx
+++ b/app/components/__tests__/ChatItem.projects.test.tsx
@@ -1,7 +1,18 @@
 import "@testing-library/jest-dom";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockMoveChatToProject = jest.fn<any>();
+const mockToastSuccess = jest.fn();
+const mockToastInfo = jest.fn();
+let mockProjects: any[] | undefined;
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: jest.fn() }),
@@ -28,8 +39,38 @@ jest.mock("@/app/hooks/useChats", () => ({
   usePinChat: () => jest.fn(),
   useUnpinChat: () => jest.fn(),
 }));
+jest.mock("@/app/hooks/useProjects", () => ({
+  useMoveChatToProject: () => mockMoveChatToProject,
+}));
+jest.mock("@/app/contexts/SidebarProjectList", () => ({
+  useSidebarProjectList: () => ({ projects: mockProjects }),
+}));
+jest.mock("sonner", () => ({
+  toast: {
+    success: mockToastSuccess,
+    info: mockToastInfo,
+    error: jest.fn(),
+  },
+}));
 jest.mock("../ShareDialog", () => ({
   ShareDialog: () => null,
+}));
+jest.mock("../ProjectCreateDialog", () => ({
+  ProjectCreateDialog: ({
+    open,
+    onCreated,
+  }: {
+    open: boolean;
+    onCreated: (projectId: string, projectName: string) => void;
+  }) =>
+    open ? (
+      <button
+        type="button"
+        onClick={() => onCreated("project-new", "New target")}
+      >
+        Complete project creation
+      </button>
+    ) : null,
 }));
 jest.mock("../MoveChatToProjectDialog", () => ({
   MoveChatToProjectDialog: ({
@@ -51,6 +92,8 @@ describe("ChatItem project actions", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseIsMobile.mockReturnValue(false);
+    mockMoveChatToProject.mockResolvedValue(true);
+    mockProjects = undefined;
   });
 
   it("reveals an accessible move action when the row receives keyboard focus", async () => {
@@ -80,6 +123,119 @@ describe("ChatItem project actions", () => {
         "data-project-id",
         "project-1",
       );
+    });
+  });
+
+  it("shows existing projects in a submenu instead of the move dialog", async () => {
+    const user = userEvent.setup();
+    mockProjects = [
+      {
+        _id: "project-1",
+        _creationTime: 1,
+        user_id: "user-1",
+        name: "Acme target",
+        created_at: 1,
+        updated_at: 1,
+      },
+    ];
+    render(<ChatItem id="chat-1" title="Target notes" />);
+
+    fireEvent.focus(screen.getByRole("button", { name: /Open task:/ }));
+    await user.click(screen.getByRole("button", { name: "Open task options" }));
+
+    const moveTrigger = await screen.findByRole("menuitem", {
+      name: "Move to project",
+    });
+    const taskOptionsMenu = moveTrigger.closest('[role="menu"]');
+    expect(taskOptionsMenu).toHaveClass(
+      "min-w-52",
+      "rounded-xl",
+      "border-border/80",
+      "p-1.5",
+    );
+    expect(
+      taskOptionsMenu?.querySelectorAll('[role="separator"]'),
+    ).toHaveLength(2);
+    for (const itemName of ["Share", "Rename", "Pin", "Move to project"]) {
+      expect(screen.getByRole("menuitem", { name: itemName })).toHaveClass(
+        "h-9",
+        "gap-2.5",
+        "rounded-md",
+        "px-2.5",
+        "text-foreground",
+      );
+    }
+    const deleteItem = screen.getByRole("menuitem", { name: "Delete" });
+    expect(deleteItem).toHaveAttribute("data-variant", "destructive");
+    expect(deleteItem).toHaveClass("h-9", "px-2.5", "text-destructive");
+
+    act(() => moveTrigger.focus());
+    fireEvent.keyDown(moveTrigger, { key: "ArrowRight" });
+
+    const destinationItem = await screen.findByRole("menuitem", {
+      name: "Acme target",
+    });
+    expect(destinationItem).toHaveClass(
+      "h-9",
+      "gap-2.5",
+      "rounded-md",
+      "px-2.5",
+      "text-foreground",
+    );
+    await user.click(destinationItem);
+
+    await waitFor(() => {
+      expect(mockMoveChatToProject).toHaveBeenCalledWith({
+        chatId: "chat-1",
+        projectId: "project-1",
+      });
+    });
+    expect(
+      screen.queryByTestId("move-chat-to-project-dialog"),
+    ).not.toBeInTheDocument();
+    expect(mockToastSuccess).toHaveBeenCalledWith("Moved to Acme target", {
+      action: expect.objectContaining({ label: "Undo" }),
+    });
+  });
+
+  it("creates a project from the submenu and moves the task into it", async () => {
+    const user = userEvent.setup();
+    mockProjects = [
+      {
+        _id: "project-1",
+        _creationTime: 1,
+        user_id: "user-1",
+        name: "Acme target",
+        created_at: 1,
+        updated_at: 1,
+      },
+    ];
+    render(<ChatItem id="chat-1" title="Target notes" />);
+
+    fireEvent.focus(screen.getByRole("button", { name: /Open task:/ }));
+    await user.click(screen.getByRole("button", { name: "Open task options" }));
+    const moveTrigger = await screen.findByRole("menuitem", {
+      name: "Move to project",
+    });
+    act(() => moveTrigger.focus());
+    fireEvent.keyDown(moveTrigger, { key: "ArrowRight" });
+    await user.click(
+      await screen.findByRole("menuitem", { name: "New project" }),
+    );
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Complete project creation",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockMoveChatToProject).toHaveBeenCalledWith({
+        chatId: "chat-1",
+        projectId: "project-new",
+      });
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith("Moved to New target", {
+      action: expect.objectContaining({ label: "Undo" }),
     });
   });
 

--- a/app/components/__tests__/ChatItem.projects.test.tsx
+++ b/app/components/__tests__/ChatItem.projects.test.tsx
@@ -239,6 +239,51 @@ describe("ChatItem project actions", () => {
     });
   });
 
+  it("disables project creation while a move is in progress", async () => {
+    const user = userEvent.setup();
+    let finishMove: ((moved: boolean) => void) | undefined;
+    mockMoveChatToProject.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishMove = resolve;
+        }),
+    );
+    mockProjects = [
+      {
+        _id: "project-1",
+        _creationTime: 1,
+        user_id: "user-1",
+        name: "Acme target",
+        created_at: 1,
+        updated_at: 1,
+      },
+    ];
+    render(<ChatItem id="chat-1" title="Target notes" />);
+
+    fireEvent.focus(screen.getByRole("button", { name: /Open task:/ }));
+    await user.click(screen.getByRole("button", { name: "Open task options" }));
+    let moveTrigger = await screen.findByRole("menuitem", {
+      name: "Move to project",
+    });
+    act(() => moveTrigger.focus());
+    fireEvent.keyDown(moveTrigger, { key: "ArrowRight" });
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Acme target" }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open task options" }));
+    moveTrigger = await screen.findByRole("menuitem", {
+      name: "Move to project",
+    });
+    act(() => moveTrigger.focus());
+    fireEvent.keyDown(moveTrigger, { key: "ArrowRight" });
+    expect(
+      await screen.findByRole("menuitem", { name: "New project" }),
+    ).toHaveAttribute("data-disabled");
+
+    await act(async () => finishMove?.(true));
+  });
+
   it("labels the Rename Task field for keyboard and screen-reader users", async () => {
     const user = userEvent.setup();
     render(<ChatItem id="chat-1" title="Target notes" />);

--- a/app/components/__tests__/MoveChatToProjectDialog.test.tsx
+++ b/app/components/__tests__/MoveChatToProjectDialog.test.tsx
@@ -1,5 +1,11 @@
 import "@testing-library/jest-dom";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import type { Doc } from "@/convex/_generated/dataModel";
 
@@ -101,7 +107,7 @@ describe("MoveChatToProjectDialog", () => {
     const successOptions = mockToast.success.mock.calls.find(
       ([message]) => message === "Removed from project",
     )?.[1] as { action?: { onClick?: () => void } } | undefined;
-    successOptions?.action?.onClick?.();
+    act(() => successOptions?.action?.onClick?.());
 
     await waitFor(() => {
       expect(moveChatToProject).toHaveBeenCalledWith({
@@ -133,6 +139,7 @@ describe("MoveChatToProjectDialog", () => {
     const undo = mockToast.success.mock.calls.find(
       ([message]) => message === "Moved to Acme target",
     )?.[1]?.action?.onClick as (() => void) | undefined;
+    expect(undo).toBeDefined();
 
     moveChatToProject.mockImplementationOnce(
       () =>

--- a/app/components/__tests__/MoveChatToProjectDialog.test.tsx
+++ b/app/components/__tests__/MoveChatToProjectDialog.test.tsx
@@ -112,6 +112,50 @@ describe("MoveChatToProjectDialog", () => {
     });
   });
 
+  it("does not race an undo with another move", async () => {
+    let finishMove: ((moved: boolean) => void) | undefined;
+    const onOpenChange = jest.fn();
+
+    render(
+      <MoveChatToProjectDialog
+        chatId="chat-1"
+        open
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Acme target" }));
+    await waitFor(() => {
+      expect(mockToast.success).toHaveBeenCalledWith("Moved to Acme target", {
+        action: expect.objectContaining({ label: "Undo" }),
+      });
+    });
+    const undo = mockToast.success.mock.calls.find(
+      ([message]) => message === "Moved to Acme target",
+    )?.[1]?.action?.onClick as (() => void) | undefined;
+
+    moveChatToProject.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishMove = resolve;
+        }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Acme target" }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Acme target" }),
+      ).toBeDisabled();
+    });
+
+    undo?.();
+    expect(moveChatToProject).toHaveBeenCalledTimes(2);
+
+    finishMove?.(true);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Acme target" })).toBeEnabled();
+    });
+  });
+
   it("shows an info toast when the chat is already in the project", async () => {
     moveChatToProject.mockResolvedValueOnce(false);
     const onOpenChange = jest.fn();

--- a/app/components/__tests__/ProjectCreateDialog.test.tsx
+++ b/app/components/__tests__/ProjectCreateDialog.test.tsx
@@ -102,7 +102,7 @@ describe("ProjectCreateDialog", () => {
         name: "acme-security",
         folderPath: "/Users/hackerai/targets/acme-security",
       });
-      expect(onCreated).toHaveBeenCalledWith("project-1");
+      expect(onCreated).toHaveBeenCalledWith("project-1", "acme-security");
     });
   });
 
@@ -170,7 +170,7 @@ describe("ProjectCreateDialog", () => {
 
     finishCreate?.("project-1");
     await waitFor(() => {
-      expect(onCreated).toHaveBeenCalledWith("project-1");
+      expect(onCreated).toHaveBeenCalledWith("project-1", "Acme");
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });

--- a/app/contexts/SidebarProjectList.tsx
+++ b/app/contexts/SidebarProjectList.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import type { Doc } from "@/convex/_generated/dataModel";
+
+export type ProjectPaginationStatus =
+  "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
+
+interface SidebarProjectListValue {
+  projects: Doc<"projects">[] | undefined;
+  paginationStatus?: ProjectPaginationStatus;
+  loadMoreProjects?: (numItems: number) => void;
+}
+
+interface SidebarProjectListProviderProps extends SidebarProjectListValue {
+  children: ReactNode;
+}
+
+const SidebarProjectListContext = createContext<SidebarProjectListValue>({
+  projects: undefined,
+});
+
+export function SidebarProjectListProvider({
+  children,
+  projects,
+  paginationStatus,
+  loadMoreProjects,
+}: SidebarProjectListProviderProps) {
+  const value = useMemo(
+    () => ({ projects, paginationStatus, loadMoreProjects }),
+    [projects, paginationStatus, loadMoreProjects],
+  );
+
+  return (
+    <SidebarProjectListContext.Provider value={value}>
+      {children}
+    </SidebarProjectListContext.Provider>
+  );
+}
+
+export const useSidebarProjectList = () =>
+  useContext(SidebarProjectListContext);

--- a/app/contexts/SidebarProjectList.tsx
+++ b/app/contexts/SidebarProjectList.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import { createContext, useContext, useMemo, type ReactNode } from "react";
+import type { PaginationStatus } from "convex/react";
 import type { Doc } from "@/convex/_generated/dataModel";
-
-export type ProjectPaginationStatus =
-  "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
 
 interface SidebarProjectListValue {
   projects: Doc<"projects">[] | undefined;
-  paginationStatus?: ProjectPaginationStatus;
+  paginationStatus?: PaginationStatus;
   loadMoreProjects?: (numItems: number) => void;
 }
 

--- a/app/hooks/useMoveChatToProjectAction.ts
+++ b/app/hooks/useMoveChatToProjectAction.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import type { Id } from "@/convex/_generated/dataModel";
+import { useMoveChatToProject } from "@/app/hooks/useProjects";
+import { formatTaskUiCopy } from "@/app/utils/task-ui-copy";
+
+export const TASKS_DESTINATION = "tasks" as const;
+
+interface UseMoveChatToProjectActionOptions {
+  chatId: string;
+  currentProjectId?: Id<"projects">;
+}
+
+export function useMoveChatToProjectAction({
+  chatId,
+  currentProjectId,
+}: UseMoveChatToProjectActionOptions) {
+  const moveChatToProject = useMoveChatToProject();
+  const [movingDestination, setMovingDestination] = useState<
+    Id<"projects"> | typeof TASKS_DESTINATION | null
+  >(null);
+
+  const undoMove = async (projectId: Id<"projects"> | null) => {
+    try {
+      await moveChatToProject({ chatId, projectId });
+      toast.success("Move undone");
+    } catch (error) {
+      console.error("Failed to undo task move:", error);
+      toast.error("Failed to undo move", {
+        description:
+          error instanceof Error
+            ? formatTaskUiCopy(error.message)
+            : "Please try again.",
+      });
+    }
+  };
+
+  const moveToProject = async (
+    projectId: Id<"projects"> | null,
+    projectName?: string,
+  ): Promise<boolean> => {
+    if (movingDestination !== null) return false;
+
+    setMovingDestination(projectId ?? TASKS_DESTINATION);
+    try {
+      const moved = await moveChatToProject({ chatId, projectId });
+      if (moved) {
+        toast.success(
+          projectId === null
+            ? "Removed from project"
+            : `Moved to ${projectName}`,
+          {
+            action: {
+              label: "Undo",
+              onClick: () => void undoMove(currentProjectId ?? null),
+            },
+          },
+        );
+      } else {
+        toast.info(
+          projectId === null ? "Already in Tasks" : `Already in ${projectName}`,
+        );
+      }
+      return true;
+    } catch (error) {
+      console.error("Failed to move chat to project:", error);
+      toast.error("Failed to move task", {
+        description:
+          error instanceof Error
+            ? formatTaskUiCopy(error.message)
+            : "Please try again.",
+      });
+      return false;
+    } finally {
+      setMovingDestination(null);
+    }
+  };
+
+  return { movingDestination, moveToProject };
+}

--- a/app/hooks/useMoveChatToProjectAction.ts
+++ b/app/hooks/useMoveChatToProjectAction.ts
@@ -1,12 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import type { Id } from "@/convex/_generated/dataModel";
 import { useMoveChatToProject } from "@/app/hooks/useProjects";
 import { formatTaskUiCopy } from "@/app/utils/task-ui-copy";
 
 export const TASKS_DESTINATION = "tasks" as const;
+
+type MoveDestination = Id<"projects"> | typeof TASKS_DESTINATION;
 
 interface UseMoveChatToProjectActionOptions {
   chatId: string;
@@ -18,11 +20,26 @@ export function useMoveChatToProjectAction({
   currentProjectId,
 }: UseMoveChatToProjectActionOptions) {
   const moveChatToProject = useMoveChatToProject();
-  const [movingDestination, setMovingDestination] = useState<
-    Id<"projects"> | typeof TASKS_DESTINATION | null
-  >(null);
+  const movingDestinationRef = useRef<MoveDestination | null>(null);
+  const [movingDestination, setMovingDestination] =
+    useState<MoveDestination | null>(null);
+
+  const startMove = (destination: MoveDestination) => {
+    if (movingDestinationRef.current !== null) return false;
+
+    movingDestinationRef.current = destination;
+    setMovingDestination(destination);
+    return true;
+  };
+
+  const finishMove = () => {
+    movingDestinationRef.current = null;
+    setMovingDestination(null);
+  };
 
   const undoMove = async (projectId: Id<"projects"> | null) => {
+    if (!startMove(projectId ?? TASKS_DESTINATION)) return;
+
     try {
       await moveChatToProject({ chatId, projectId });
       toast.success("Move undone");
@@ -34,6 +51,8 @@ export function useMoveChatToProjectAction({
             ? formatTaskUiCopy(error.message)
             : "Please try again.",
       });
+    } finally {
+      finishMove();
     }
   };
 
@@ -41,9 +60,8 @@ export function useMoveChatToProjectAction({
     projectId: Id<"projects"> | null,
     projectName?: string,
   ): Promise<boolean> => {
-    if (movingDestination !== null) return false;
+    if (!startMove(projectId ?? TASKS_DESTINATION)) return false;
 
-    setMovingDestination(projectId ?? TASKS_DESTINATION);
     try {
       const moved = await moveChatToProject({ chatId, projectId });
       if (moved) {
@@ -74,7 +92,7 @@ export function useMoveChatToProjectAction({
       });
       return false;
     } finally {
-      setMovingDestination(null);
+      finishMove();
     }
   };
 


### PR DESCRIPTION
## Summary
- show existing project destinations in a nested task-options submenu instead of opening a modal
- create a project directly from the submenu and move the task into it
- share sidebar project data and move/undo behavior without duplicate subscriptions
- make task-option rows compact and consistent, with separators and destructive styling reserved for Delete

## Validation
- `corepack pnpm test -- app/components/__tests__/ChatItem.projects.test.tsx app/components/__tests__/MoveChatToProjectDialog.test.tsx app/components/__tests__/ProjectCreateDialog.test.tsx app/components/__tests__/SidebarHistory.test.tsx app/components/__tests__/SidebarChatSections.test.tsx app/components/__tests__/SidebarProjectThreads.test.tsx app/components/__tests__/SidebarProjects.test.tsx --runInBand` (42 tests passed)
- commit hook: Prettier, ESLint, TypeScript, and full Jest suite (287 suites / 2,839 tests passed)
- `git diff --check`
- Chrome: opened the task options and project submenu by keyboard; verified compact spacing, colors, separators, and no console warnings or errors

## Manual verification
- Open a sidebar task menu for an account with existing projects.
- Confirm **Move to project** opens a nested submenu containing **New project** and existing projects.
- Move a task or create a project and confirm the task changes destination and the Undo toast is available.
- Confirm Share, Rename, Pin, and Move use the same compact neutral styling while Delete remains red.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added creating a new project directly from a chat’s “Move to project” menu, then moving the chat into it.
  * Enhanced the project destination picker with submenus, richer icons, pagination, and conditional “Remove from project”.
  * Improved chat move flow with shared move progress indicators and Undo from toast actions.
  * Centralized sidebar/project list loading so project availability stays consistent across menus.
* **Bug Fixes**
  * Prevented chat movement/selection while the project creation dialog is open.
  * Prevented overlapping move/Undo flows to keep UI state consistent.
* **Tests**
  * Expanded coverage for submenu interactions, new-project flows, and race-condition prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->