### PR TITLE
Avoid stale sandbox attachment targets

### DIFF
--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -183,7 +183,7 @@ describe("desktop-local sandbox file helpers", () => {
     }
   });
 
-  it("retries url uploads in a writable directory when /tmp is not writable", async () => {
+  it("retries url uploads at a unique writable path when /tmp is not writable", async () => {
     const consoleWarnSpy = jest
       .spyOn(console, "warn")
       .mockImplementation(() => {});
@@ -197,7 +197,7 @@ describe("desktop-local sandbox file helpers", () => {
       .mockResolvedValueOnce(undefined);
     const run = jest.fn().mockResolvedValue({
       exitCode: 0,
-      stdout: "/home/alice/hackerai-upload/report.pdf",
+      stdout: "/home/alice/hackerai-upload/fallback.a1b2c3/report.pdf",
       stderr: "",
     });
 
@@ -221,7 +221,7 @@ describe("desktop-local sandbox file helpers", () => {
         pathRewrites: [
           {
             from: "/tmp/hackerai-upload/report.pdf",
-            to: "/home/alice/hackerai-upload/report.pdf",
+            to: "/home/alice/hackerai-upload/fallback.a1b2c3/report.pdf",
           },
         ],
       });
@@ -231,7 +231,15 @@ describe("desktop-local sandbox file helpers", () => {
       );
       expect(downloadFromUrl).toHaveBeenCalledWith(
         "https://example.com/report.pdf",
-        "/home/alice/hackerai-upload/report.pdf",
+        "/home/alice/hackerai-upload/fallback.a1b2c3/report.pdf",
+      );
+      expect(run).toHaveBeenCalledWith(
+        expect.stringContaining('dir="$root/fallback-'),
+        { displayName: "" },
+      );
+      expect(run).toHaveBeenCalledWith(
+        expect.stringContaining('mkdir "$dir" 2>/dev/null || continue'),
+        { displayName: "" },
       );
     } finally {
       consoleWarnSpy.mockRestore();
@@ -259,7 +267,7 @@ describe("desktop-local sandbox file helpers", () => {
       if (command.includes("for base in")) {
         return {
           exitCode: 0,
-          stdout: "/tmp/hackerai-upload/report.pdf",
+          stdout: "/tmp/hackerai-upload/fallback.d4e5f6/report.pdf",
           stderr: "",
         };
       }
@@ -303,7 +311,7 @@ describe("desktop-local sandbox file helpers", () => {
         pathRewrites: [
           {
             from: "/home/user/upload/report.pdf",
-            to: "/tmp/hackerai-upload/report.pdf",
+            to: "/tmp/hackerai-upload/fallback.d4e5f6/report.pdf",
           },
         ],
       });
@@ -312,10 +320,17 @@ describe("desktop-local sandbox file helpers", () => {
         String(command).includes("-o '/home/user/upload/report.pdf'"),
       );
       const fallbackCurlAttempts = run.mock.calls.filter(([command]) =>
-        String(command).includes("-o '/tmp/hackerai-upload/report.pdf'"),
+        String(command).includes(
+          "-o '/tmp/hackerai-upload/fallback.d4e5f6/report.pdf'",
+        ),
       );
       expect(homeCurlAttempts).toHaveLength(3);
       expect(fallbackCurlAttempts).toHaveLength(1);
+      expect(
+        run.mock.calls.some(([command]) =>
+          String(command).includes('dir="$root/fallback-'),
+        ),
+      ).toBe(true);
     } finally {
       jest.useRealTimers();
       consoleWarnSpy.mockRestore();

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { UIMessage } from "ai";
 import type { SandboxPreference } from "@/types";
 import { validateDownloadUrl } from "@/lib/ai/tools/utils/path-validation";
@@ -540,16 +540,22 @@ const resolveWritableUploadFallbackPath = async (
 ): Promise<string | null> => {
   const fileName = originalLocalPath.split(/[/\\]/).pop();
   if (!fileName || !sandbox.commands?.run) return null;
+  const fallbackDirectory = `fallback-${randomUUID()}`;
 
   const script = [
     `filename=${shellQuote(fileName)}`,
     `for base in "\${TMPDIR:-/tmp}" /var/tmp "\${HOME:-}" "\${PWD:-.}"; do`,
     `  [ -n "$base" ] || continue`,
-    `  dir="$base/hackerai-upload"`,
-    `  if mkdir -p "$dir" 2>/dev/null && [ -w "$dir" ]; then`,
-    `    cd "$dir" 2>/dev/null && printf '%s/%s' "$(pwd -P)" "$filename"`,
-    `    exit 0`,
-    `  fi`,
+    `  root="$base/hackerai-upload"`,
+    `  mkdir -p "$root" 2>/dev/null && [ -w "$root" ] || continue`,
+    `  root="$(cd "$root" 2>/dev/null && pwd -P)" || continue`,
+    // A reused sandbox can contain a stale root-owned file with the same
+    // basename. Reserve a fresh directory so the fallback destination cannot
+    // collide with an existing file that the sandbox user cannot overwrite.
+    `  dir="$root/${fallbackDirectory}"`,
+    `  mkdir "$dir" 2>/dev/null || continue`,
+    `  printf '%s/%s' "$dir" "$filename"`,
+    `  exit 0`,
     `done`,
     `exit 1`,
   ].join("\n");


### PR DESCRIPTION
## Summary

- reserve a unique fallback directory when attachment staging cannot write the requested sandbox path
- keep existing curl retry, fresh-sandbox retry, partial-progress, and path-rewrite behavior unchanged
- cover both URL-download fallback paths, including the production curl exit 23 shape

## Production evidence

Frozen audit window: `2026-07-19T19:32:14Z` to `2026-07-20T19:32:14Z`.

Production Trigger.dev had 5 `The computer attachment upload failed.` terminal runs with curl exit 23, up from 1 in the preceding exact window. They affected 1 user across 4 chats on worker `20260720.1` / deployment `yj5jpfzs`. A representative reused sandbox retried the primary path, selected `/tmp/hackerai-upload/<same basename>`, and exhausted the fallback too despite 9.8 GB free. The primary listing showed a likely root-owned file at the destination sort position; the fallback helper checked only directory writability and reused the same basename.

Vercel and PostHog showed no post-#939 auth, Stripe refund, or signed-URL regression. Other observed provider, Convex, S2, OOM, React, and transport groups remain visible and are not suppressed by this change.

## Root cause and change

Reused sandboxes can retain an existing destination that the sandbox user cannot overwrite. The fallback previously chose another shared directory with the same basename, so it could collide again. The helper now creates a UUID-named directory beneath the first writable fallback root and returns the new destination for the existing message-path rewrite.

## Validation

- `corepack pnpm jest lib/utils/__tests__/sandbox-file-utils.test.ts --runInBand` — 16 tests passed
- `corepack pnpm jest lib/api/__tests__/agent-long-contracts.test.ts --runInBand` — 80 tests passed
- `corepack pnpm typecheck`
- `corepack pnpm exec eslint lib/utils/sandbox-file-utils.ts lib/utils/__tests__/sandbox-file-utils.test.ts`
- `corepack pnpm exec prettier --check lib/utils/sandbox-file-utils.ts lib/utils/__tests__/sandbox-file-utils.test.ts`
- commit hooks — 287 suites / 2,837 tests passed

## Manual verification

1. In an E2B Agent sandbox, leave a non-writable file at the normal upload destination and stage another attachment with the same basename.
2. Confirm staging selects a UUID fallback directory, succeeds, and rewrites the attachment tag to the new path.
3. Confirm failure diagnostics still omit signed URL query parameters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file uploads when the default temporary directory is not writable.
  * Upload retries now use unique fallback locations, preventing conflicts with stale files or directories.
  * Enhanced reliability for URL downloads and transient upload failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->