### PR TITLE
Show actual usage credit charges in usage history

### DIFF
--- a/app/components/usage/UsageLogsTable.tsx
+++ b/app/components/usage/UsageLogsTable.tsx
@@ -141,6 +141,7 @@ const UsageLogsTable = () => {
     ];
     const rows = results.map((log) => {
       const {
+        componentBreakdownAvailable,
         includedChargeDollars,
         extraUsageChargeDollars,
         totalChargeDollars,
@@ -155,8 +156,8 @@ const UsageLogsTable = () => {
         log.output_tokens.toString(),
         log.total_tokens.toString(),
         formatCost(totalChargeDollars),
-        formatCost(includedChargeDollars),
-        formatCost(extraUsageChargeDollars),
+        componentBreakdownAvailable ? formatCost(includedChargeDollars) : "",
+        componentBreakdownAvailable ? formatCost(extraUsageChargeDollars) : "",
       ];
     });
 
@@ -298,6 +299,7 @@ const UsageLogsTable = () => {
               results.map((log) => {
                 const billingLabel = getUsageBillingLabel(log);
                 const {
+                  componentBreakdownAvailable,
                   includedChargeDollars,
                   extraUsageChargeDollars,
                   totalChargeDollars,
@@ -327,7 +329,8 @@ const UsageLogsTable = () => {
                     </td>
                     <td className="px-3 py-2.5 text-right tabular-nums text-muted-foreground">
                       <div>{formatCost(totalChargeDollars)}</div>
-                      {billingLabel === "Included + Extra" ? (
+                      {billingLabel === "Included + Extra" &&
+                      componentBreakdownAvailable ? (
                         <div className="mt-0.5 text-[11px] leading-4 text-muted-foreground/80">
                           Included {formatCost(includedChargeDollars)} + Extra{" "}
                           {formatCost(extraUsageChargeDollars)}

--- a/app/components/usage/UsageLogsTable.tsx
+++ b/app/components/usage/UsageLogsTable.tsx
@@ -12,6 +12,10 @@ import {
 } from "@/components/ui/popover";
 import { RefreshCw, Download, ChevronDown } from "lucide-react";
 import { TokenBreakdownTooltip } from "@/app/components/usage/TokenBreakdownTooltip";
+import {
+  getUsageChargeBreakdown,
+  type UsageLogBilling,
+} from "@/app/components/usage/usage-charge";
 import type { DateRange } from "react-day-picker";
 
 type Preset = "1d" | "7d" | "30d" | "custom";
@@ -61,24 +65,6 @@ const formatTimestamp = (ms: number): string => {
     minute: "2-digit",
   });
 };
-
-type UsageLogBilling = {
-  type: "included" | "extra" | "mixed";
-  cost_dollars: number;
-  included_cost_dollars?: number;
-  extra_usage_cost_dollars?: number;
-  included_points_deducted?: number;
-  extra_usage_points_deducted?: number;
-};
-
-const getUsageCostBreakdown = (log: UsageLogBilling) => ({
-  includedCost:
-    log.included_cost_dollars ??
-    (log.type === "included" ? log.cost_dollars : 0),
-  extraUsageCost:
-    log.extra_usage_cost_dollars ??
-    (log.type === "extra" ? log.cost_dollars : 0),
-});
 
 const getUsageBillingLabel = (log: UsageLogBilling): string => {
   const hasIncludedPoints = (log.included_points_deducted ?? 0) > 0;
@@ -154,7 +140,11 @@ const UsageLogsTable = () => {
       "Extra Usage Cost",
     ];
     const rows = results.map((log) => {
-      const { includedCost, extraUsageCost } = getUsageCostBreakdown(log);
+      const {
+        includedChargeDollars,
+        extraUsageChargeDollars,
+        totalChargeDollars,
+      } = getUsageChargeBreakdown(log);
       return [
         new Date(log._creationTime).toISOString(),
         getUsageBillingLabel(log),
@@ -164,9 +154,9 @@ const UsageLogsTable = () => {
         log.input_tokens.toString(),
         log.output_tokens.toString(),
         log.total_tokens.toString(),
-        formatCost(log.cost_dollars),
-        formatCost(includedCost),
-        formatCost(extraUsageCost),
+        formatCost(totalChargeDollars),
+        formatCost(includedChargeDollars),
+        formatCost(extraUsageChargeDollars),
       ];
     });
 
@@ -307,8 +297,11 @@ const UsageLogsTable = () => {
             ) : (
               results.map((log) => {
                 const billingLabel = getUsageBillingLabel(log);
-                const { includedCost, extraUsageCost } =
-                  getUsageCostBreakdown(log);
+                const {
+                  includedChargeDollars,
+                  extraUsageChargeDollars,
+                  totalChargeDollars,
+                } = getUsageChargeBreakdown(log);
                 return (
                   <tr
                     key={log._id}
@@ -333,11 +326,11 @@ const UsageLogsTable = () => {
                       />
                     </td>
                     <td className="px-3 py-2.5 text-right tabular-nums text-muted-foreground">
-                      <div>{formatCost(log.cost_dollars)}</div>
+                      <div>{formatCost(totalChargeDollars)}</div>
                       {billingLabel === "Included + Extra" ? (
                         <div className="mt-0.5 text-[11px] leading-4 text-muted-foreground/80">
-                          Included {formatCost(includedCost)} + Extra{" "}
-                          {formatCost(extraUsageCost)}
+                          Included {formatCost(includedChargeDollars)} + Extra{" "}
+                          {formatCost(extraUsageChargeDollars)}
                         </div>
                       ) : null}
                     </td>

--- a/app/components/usage/__tests__/UsageLogsTable.test.tsx
+++ b/app/components/usage/__tests__/UsageLogsTable.test.tsx
@@ -1,0 +1,45 @@
+import "@testing-library/jest-dom";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { UsageLogsTable } from "../UsageLogsTable";
+
+const convexReact = require("convex/react");
+
+describe("UsageLogsTable", () => {
+  beforeEach(() => {
+    convexReact.resetMockConvexQueries?.();
+  });
+
+  it("shows the amount deducted from extra-usage credits in the Cost column", () => {
+    convexReact.setMockPaginatedQueryResult?.({
+      results: [
+        {
+          _id: "usage-1",
+          _creationTime: Date.parse("2026-07-19T15:29:18.000Z"),
+          type: "extra",
+          model: "anthropic/claude-opus-4.6",
+          input_tokens: 100,
+          output_tokens: 50,
+          total_tokens: 150,
+          cost_dollars: 12.037878597222221,
+          extra_usage_cost_dollars: 12.037878597222221,
+          included_points_deducted: 0,
+          extra_usage_points_deducted: 168_531,
+        },
+      ],
+      status: "Exhausted",
+      loadMore: jest.fn(),
+      isLoading: false,
+    });
+
+    render(
+      <TooltipProvider>
+        <UsageLogsTable />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByText("$19.38")).toBeInTheDocument();
+    expect(screen.queryByText("$12.04")).not.toBeInTheDocument();
+  });
+});

--- a/app/components/usage/__tests__/UsageLogsTable.test.tsx
+++ b/app/components/usage/__tests__/UsageLogsTable.test.tsx
@@ -42,4 +42,33 @@ describe("UsageLogsTable", () => {
     expect(screen.getByText("$19.38")).toBeInTheDocument();
     expect(screen.queryByText("$12.04")).not.toBeInTheDocument();
   });
+
+  it("does not show a false component split for legacy mixed rows", () => {
+    convexReact.setMockPaginatedQueryResult?.({
+      results: [
+        {
+          _id: "usage-legacy-mixed",
+          _creationTime: Date.parse("2026-07-19T15:29:18.000Z"),
+          type: "mixed",
+          model: "anthropic/claude-opus-4.6",
+          input_tokens: 100,
+          output_tokens: 50,
+          total_tokens: 150,
+          cost_dollars: 2.5,
+        },
+      ],
+      status: "Exhausted",
+      loadMore: jest.fn(),
+      isLoading: false,
+    });
+
+    render(
+      <TooltipProvider>
+        <UsageLogsTable />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByText("$2.50")).toBeInTheDocument();
+    expect(screen.queryByText(/Included \$0\.00/)).not.toBeInTheDocument();
+  });
 });

--- a/app/components/usage/__tests__/usage-charge.test.ts
+++ b/app/components/usage/__tests__/usage-charge.test.ts
@@ -25,6 +25,7 @@ describe("getUsageChargeBreakdown", () => {
     });
 
     expect(result).toEqual({
+      componentBreakdownAvailable: true,
       includedChargeDollars: 1,
       extraUsageChargeDollars: 1.15,
       totalChargeDollars: 2.15,
@@ -50,8 +51,23 @@ describe("getUsageChargeBreakdown", () => {
     });
 
     expect(result).toEqual({
+      componentBreakdownAvailable: true,
       includedChargeDollars: 0,
       extraUsageChargeDollars: 2.5,
+      totalChargeDollars: 2.5,
+    });
+  });
+
+  it("marks the component breakdown unavailable for legacy mixed rows", () => {
+    const result = getUsageChargeBreakdown({
+      type: "mixed",
+      cost_dollars: 2.5,
+    });
+
+    expect(result).toEqual({
+      componentBreakdownAvailable: false,
+      includedChargeDollars: 0,
+      extraUsageChargeDollars: 0,
       totalChargeDollars: 2.5,
     });
   });

--- a/app/components/usage/__tests__/usage-charge.test.ts
+++ b/app/components/usage/__tests__/usage-charge.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "@jest/globals";
+import { getUsageChargeBreakdown } from "../usage-charge";
+
+describe("getUsageChargeBreakdown", () => {
+  it("shows the extra-usage balance charge encoded by deducted points", () => {
+    const result = getUsageChargeBreakdown({
+      type: "extra",
+      cost_dollars: 12.037878597222221,
+      extra_usage_cost_dollars: 12.037878597222221,
+      included_points_deducted: 0,
+      extra_usage_points_deducted: 168_531,
+    });
+
+    expect(result.includedChargeDollars).toBe(0);
+    expect(result.extraUsageChargeDollars).toBeCloseTo(19.381065);
+    expect(result.totalChargeDollars).toBeCloseTo(19.381065);
+  });
+
+  it("converts included and extra point deductions independently", () => {
+    const result = getUsageChargeBreakdown({
+      type: "mixed",
+      cost_dollars: 1.34,
+      included_points_deducted: 10_000,
+      extra_usage_points_deducted: 10_000,
+    });
+
+    expect(result).toEqual({
+      includedChargeDollars: 1,
+      extraUsageChargeDollars: 1.15,
+      totalChargeDollars: 2.15,
+    });
+  });
+
+  it("shows zero charge when current logs record no deducted points", () => {
+    const result = getUsageChargeBreakdown({
+      type: "included",
+      cost_dollars: 0.25,
+      included_points_deducted: 0,
+      extra_usage_points_deducted: 0,
+    });
+
+    expect(result.totalChargeDollars).toBe(0);
+  });
+
+  it("preserves raw cost for legacy rows without deduction fields", () => {
+    const result = getUsageChargeBreakdown({
+      type: "extra",
+      cost_dollars: 2.5,
+      extra_usage_cost_dollars: 2.5,
+    });
+
+    expect(result).toEqual({
+      includedChargeDollars: 0,
+      extraUsageChargeDollars: 2.5,
+      totalChargeDollars: 2.5,
+    });
+  });
+});

--- a/app/components/usage/usage-charge.ts
+++ b/app/components/usage/usage-charge.ts
@@ -29,11 +29,17 @@ export const getUsageChargeBreakdown = (log: UsageLogBilling) => {
     );
 
     return {
+      componentBreakdownAvailable: true,
       includedChargeDollars,
       extraUsageChargeDollars,
       totalChargeDollars: includedChargeDollars + extraUsageChargeDollars,
     };
   }
+
+  const componentBreakdownAvailable =
+    log.type !== "mixed" ||
+    (typeof log.included_cost_dollars === "number" &&
+      typeof log.extra_usage_cost_dollars === "number");
 
   const includedChargeDollars =
     log.included_cost_dollars ??
@@ -43,6 +49,7 @@ export const getUsageChargeBreakdown = (log: UsageLogBilling) => {
     (log.type === "extra" ? log.cost_dollars : 0);
 
   return {
+    componentBreakdownAvailable,
     includedChargeDollars,
     extraUsageChargeDollars,
     totalChargeDollars: log.cost_dollars,

--- a/app/components/usage/usage-charge.ts
+++ b/app/components/usage/usage-charge.ts
@@ -1,0 +1,50 @@
+import {
+  EXTRA_USAGE_POINTS_PER_DOLLAR,
+  extraUsagePointsToDollars,
+} from "@/convex/lib/extraUsagePricing";
+
+export type UsageLogBilling = {
+  type: "included" | "extra" | "mixed";
+  cost_dollars: number;
+  included_cost_dollars?: number;
+  extra_usage_cost_dollars?: number;
+  included_points_deducted?: number;
+  extra_usage_points_deducted?: number;
+};
+
+const nonNegativePoints = (points: number | undefined): number =>
+  Number.isFinite(points) ? Math.max(0, points ?? 0) : 0;
+
+export const getUsageChargeBreakdown = (log: UsageLogBilling) => {
+  const hasDeductionData =
+    typeof log.included_points_deducted === "number" ||
+    typeof log.extra_usage_points_deducted === "number";
+
+  if (hasDeductionData) {
+    const includedChargeDollars =
+      nonNegativePoints(log.included_points_deducted) /
+      EXTRA_USAGE_POINTS_PER_DOLLAR;
+    const extraUsageChargeDollars = extraUsagePointsToDollars(
+      nonNegativePoints(log.extra_usage_points_deducted),
+    );
+
+    return {
+      includedChargeDollars,
+      extraUsageChargeDollars,
+      totalChargeDollars: includedChargeDollars + extraUsageChargeDollars,
+    };
+  }
+
+  const includedChargeDollars =
+    log.included_cost_dollars ??
+    (log.type === "included" ? log.cost_dollars : 0);
+  const extraUsageChargeDollars =
+    log.extra_usage_cost_dollars ??
+    (log.type === "extra" ? log.cost_dollars : 0);
+
+  return {
+    includedChargeDollars,
+    extraUsageChargeDollars,
+    totalChargeDollars: log.cost_dollars,
+  };
+};


### PR DESCRIPTION
## Summary

- derive Usage History charges from the included and extra usage points actually deducted
- keep the existing Cost column and apply the same calculation to CSV exports
- preserve the raw provider cost fields for internal accounting and legacy rows
- add focused unit and component regression coverage

## Root cause

Usage History rendered `cost_dollars`, which records the underlying provider cost. Extra-usage credits are deducted using the billed point amount, including the configured usage and credit conversion multipliers, so the visible total could be materially lower than the balance reduction.

## User impact

After this change, existing and future Usage History rows show the amount charged against the user's included or extra usage balance. For example, a row whose internal provider cost is $12.04 and whose logged deduction is 168,531 extra-usage points displays $19.38.

## Validation

- `corepack pnpm test -- app/components/usage/__tests__/UsageLogsTable.test.tsx app/components/usage/__tests__/usage-charge.test.ts convex/__tests__/usageLogs.test.ts --runInBand`
- full commit-hook test suite: 289 suites, 2,842 tests
- `corepack pnpm typecheck`
- focused ESLint and Prettier checks
- Chrome visual verification of Settings > Usage and the existing Cost column layout

## Manual verification

1. Open Settings > Usage for an account with extra-usage activity.
2. Compare the Cost value with `extra_usage_points_deducted` converted through the extra-usage credit rate.
3. Confirm the displayed value and CSV export match the amount deducted from the balance while the raw provider cost remains unchanged in the usage log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed usage cost formatting so “Included” vs “Extra” charges (including the “Included + Extra” split) display correctly in the usage logs table.
  * Corrected CSV export billing values to match the table’s included/extra charge breakdown.
  * Improved handling for legacy and mixed billing rows to avoid incorrect split behavior and keep totals accurate.

* **Tests**
  * Added unit and UI coverage for included, extra, mixed/legacy, and zero-charge scenarios, including export and rendering assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->