### PR TITLE
Improve chat titles and new-task navigation

### DIFF
--- a/app/components/__tests__/chat-route.test.ts
+++ b/app/components/__tests__/chat-route.test.ts
@@ -1,0 +1,54 @@
+import { finalizeNewChatRoute } from "../chat-route";
+
+describe("finalizeNewChatRoute", () => {
+  beforeEach(() => {
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("does not redirect a new task when the previous stream aborts", () => {
+    window.history.replaceState({}, "", "/c/previous-chat");
+
+    expect(
+      finalizeNewChatRoute({
+        chatId: "replacement-chat",
+        isAbort: true,
+        isExistingChat: false,
+        isTemporaryChat: false,
+      }),
+    ).toBe(false);
+
+    expect(window.location.pathname).toBe("/c/previous-chat");
+
+    // The pending Next.js New task navigation remains authoritative.
+    window.history.pushState({}, "", "/");
+    expect(window.location.pathname).toBe("/");
+  });
+
+  it("still finalizes a manually stopped chat that owns the current route", () => {
+    window.history.replaceState({}, "", "/c/current-chat");
+
+    expect(
+      finalizeNewChatRoute({
+        chatId: "current-chat",
+        isAbort: true,
+        isExistingChat: false,
+        isTemporaryChat: false,
+      }),
+    ).toBe(true);
+
+    expect(window.location.pathname).toBe("/c/current-chat");
+  });
+
+  it("finalizes a normally completed new chat", () => {
+    expect(
+      finalizeNewChatRoute({
+        chatId: "completed-chat",
+        isAbort: false,
+        isExistingChat: false,
+        isTemporaryChat: false,
+      }),
+    ).toBe(true);
+
+    expect(window.location.pathname).toBe("/c/completed-chat");
+  });
+});

--- a/app/components/__tests__/chat-route.test.ts
+++ b/app/components/__tests__/chat-route.test.ts
@@ -51,4 +51,19 @@ describe("finalizeNewChatRoute", () => {
 
     expect(window.location.pathname).toBe("/c/completed-chat");
   });
+
+  it("does not let a stale normal completion replace another chat route", () => {
+    window.history.replaceState({}, "", "/c/destination-chat");
+
+    expect(
+      finalizeNewChatRoute({
+        chatId: "stale-chat",
+        isAbort: false,
+        isExistingChat: false,
+        isTemporaryChat: false,
+      }),
+    ).toBe(false);
+
+    expect(window.location.pathname).toBe("/c/destination-chat");
+  });
 });

--- a/app/components/chat-route.ts
+++ b/app/components/chat-route.ts
@@ -13,11 +13,15 @@ export const finalizeNewChatRoute = ({
 }: FinalizeNewChatRouteOptions): boolean => {
   if (isExistingChat || isTemporaryChat) return false;
 
+  const chatPathname = `/c/${chatId}`;
+  const currentPathname = window.location.pathname;
+  if (currentPathname !== "/" && currentPathname !== chatPathname) return false;
+
   // useChat invokes the latest onFinish callback even when an older request is
   // aborted. Only let an abort finalize the URL if it still owns that route.
-  if (isAbort && window.location.pathname !== `/c/${chatId}`) return false;
+  if (isAbort && currentPathname !== chatPathname) return false;
 
   // Avoid a full navigation so the mounted Chat can transition back to ready.
-  window.history.replaceState({}, "", `/c/${chatId}`);
+  window.history.replaceState({}, "", chatPathname);
   return true;
 };

--- a/app/components/chat-route.ts
+++ b/app/components/chat-route.ts
@@ -1,0 +1,23 @@
+type FinalizeNewChatRouteOptions = {
+  chatId: string;
+  isAbort: boolean;
+  isExistingChat: boolean;
+  isTemporaryChat: boolean;
+};
+
+export const finalizeNewChatRoute = ({
+  chatId,
+  isAbort,
+  isExistingChat,
+  isTemporaryChat,
+}: FinalizeNewChatRouteOptions): boolean => {
+  if (isExistingChat || isTemporaryChat) return false;
+
+  // useChat invokes the latest onFinish callback even when an older request is
+  // aborted. Only let an abort finalize the URL if it still owns that route.
+  if (isAbort && window.location.pathname !== `/c/${chatId}`) return false;
+
+  // Avoid a full navigation so the mounted Chat can transition back to ready.
+  window.history.replaceState({}, "", `/c/${chatId}`);
+  return true;
+};

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -922,6 +922,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       }
     },
     onFinish: () => {
+      if (!isChatMountedRef.current || activeChatIdRef.current !== chatId) {
+        return;
+      }
       browserStreamFinishedRef.current = true;
       setIsAutoResuming(false);
       setAwaitingServerChat(false);
@@ -938,6 +941,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       }
     },
     onError: (error) => {
+      if (!isChatMountedRef.current || activeChatIdRef.current !== chatId) {
+        return;
+      }
       browserStreamFinishedRef.current = true;
       setIsAutoResuming(false);
       setAwaitingServerChat(false);
@@ -1026,20 +1032,29 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   );
   shouldUseAgentLongForCurrentChatRef.current =
     shouldUseAgentLongForCurrentChat;
-  const stopActiveBrowserStream = useCallback(() => {
-    cancelAgentLongRealtimeStreams(activeChatIdRef.current);
-    const streamAlreadyFinished =
-      shouldUseAgentLongForCurrentChatRef.current &&
-      browserStreamFinishedRef.current;
-    if (
-      !streamAlreadyFinished &&
-      (statusRef.current === "streaming" || statusRef.current === "submitted")
-    ) {
-      stopRef.current();
-    }
-    setDataStream([]);
-    setIsAutoResuming(false);
-  }, [setDataStream, setIsAutoResuming]);
+  const stopActiveBrowserStream = useCallback(
+    (nextChatId?: string) => {
+      const activeChatId = activeChatIdRef.current;
+      cancelAgentLongRealtimeStreams(activeChatId);
+      if (nextChatId) {
+        // Invalidate terminal callbacks before aborting. Some transports finish
+        // asynchronously after the user has already started a new task.
+        activeChatIdRef.current = nextChatId;
+      }
+      const streamAlreadyFinished =
+        shouldUseAgentLongForCurrentChatRef.current &&
+        browserStreamFinishedRef.current;
+      if (
+        !streamAlreadyFinished &&
+        (statusRef.current === "streaming" || statusRef.current === "submitted")
+      ) {
+        stopRef.current();
+      }
+      setDataStream([]);
+      setIsAutoResuming(false);
+    },
+    [setDataStream, setIsAutoResuming],
+  );
 
   const saveAgentLongPartialSnapshot = useCallback(
     (clientReason: string) => {
@@ -1179,7 +1194,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     const abortController = new AbortController();
 
     const finishLocally = () => {
-      if (stopped) return;
+      if (stopped || activeChatIdRef.current !== chatId) return;
       stopped = true;
       stop();
       setIsAutoResuming(false);
@@ -1273,9 +1288,10 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   // Register a reset function with global state so initializeNewChat can call it
   useEffect(() => {
     const reset = () => {
-      stopActiveBrowserStream();
+      const nextChatId = uuidv4();
+      stopActiveBrowserStream(nextChatId);
       setMessages([]);
-      setChatId(uuidv4());
+      setChatId(nextChatId);
       setIsExistingChat(false);
       wasNewChatRef.current = true;
       setTodos([]);

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -89,6 +89,7 @@ import { removeDraft } from "@/lib/utils/client-storage";
 import { parseRateLimitWarning } from "@/lib/utils/parse-rate-limit-warning";
 import Loading from "@/components/ui/loading";
 import { formatTaskUiCopy } from "@/app/utils/task-ui-copy";
+import { finalizeNewChatRoute } from "./chat-route";
 
 import { HackingSuggestions } from "./HackingSuggestions";
 
@@ -921,7 +922,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
         }
       }
     },
-    onFinish: () => {
+    onFinish: ({ isAbort }) => {
       if (!isChatMountedRef.current || activeChatIdRef.current !== chatId) {
         return;
       }
@@ -932,10 +933,14 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
       const isTemporaryChat =
         !isExistingChatRef.current && temporaryChatsEnabledRef.current;
-      if (!isExistingChatRef.current && !isTemporaryChat) {
-        // Update URL without full navigation so this Chat stays mounted and
-        // status can transition to "ready" (stop button → send button).
-        window.history.replaceState({}, "", `/c/${chatId}`);
+      if (
+        finalizeNewChatRoute({
+          chatId,
+          isAbort,
+          isExistingChat: isExistingChatRef.current,
+          isTemporaryChat,
+        })
+      ) {
         removeDraft("new");
         setIsExistingChat(true);
       }
@@ -1035,12 +1040,12 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const stopActiveBrowserStream = useCallback(
     (nextChatId?: string) => {
       const activeChatId = activeChatIdRef.current;
-      cancelAgentLongRealtimeStreams(activeChatId);
       if (nextChatId) {
-        // Invalidate terminal callbacks before aborting. Some transports finish
-        // asynchronously after the user has already started a new task.
+        // Invalidate terminal callbacks before either cancellation path can
+        // finish synchronously.
         activeChatIdRef.current = nextChatId;
       }
+      cancelAgentLongRealtimeStreams(activeChatId);
       const streamAlreadyFinished =
         shouldUseAgentLongForCurrentChatRef.current &&
         browserStreamFinishedRef.current;

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1206,8 +1206,14 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       setAwaitingServerChat(false);
       dispatchStreaming({ type: "RESET_ON_FINISH" });
 
-      if (!isExistingChatRef.current) {
-        window.history.replaceState({}, "", `/c/${chatId}`);
+      if (
+        finalizeNewChatRoute({
+          chatId,
+          isAbort: false,
+          isExistingChat: isExistingChatRef.current,
+          isTemporaryChat: temporaryChatsEnabled,
+        })
+      ) {
         removeDraft("new");
         setIsExistingChat(true);
       }

--- a/convex/__tests__/chats.saveChat.test.ts
+++ b/convex/__tests__/chats.saveChat.test.ts
@@ -291,6 +291,52 @@ describe("saveChat", () => {
   });
 });
 
+describe("updateChatTitle", () => {
+  it("updates the sidebar title without clearing active stream state", async () => {
+    const { updateChatTitle } = await import("../chats");
+    const { ctx, patch } = makeCtx({
+      existingChat: {
+        _id: "chat-doc-1",
+        id: "chat-1",
+        user_id: "user-1",
+        active_stream_id: "stream-1",
+        canceled_at: 123,
+      },
+    });
+
+    await expect(
+      updateChatTitle.handler(ctx, {
+        serviceKey: SERVICE_KEY,
+        chatId: "chat-1",
+        title: "  Generated Sidebar Title  ",
+      }),
+    ).resolves.toBeNull();
+
+    expect(patch).toHaveBeenCalledWith("chat-doc-1", {
+      title: "Generated Sidebar Title",
+      update_time: expect.any(Number),
+    });
+    const update = patch.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(update).not.toHaveProperty("active_stream_id");
+    expect(update).not.toHaveProperty("canceled_at");
+  });
+
+  it("does nothing if the chat was deleted while its title generated", async () => {
+    const { updateChatTitle } = await import("../chats");
+    const { ctx, patch } = makeCtx({ existingChat: null });
+
+    await expect(
+      updateChatTitle.handler(ctx, {
+        serviceKey: SERVICE_KEY,
+        chatId: "deleted-chat",
+        title: "Generated Title",
+      }),
+    ).resolves.toBeNull();
+
+    expect(patch).not.toHaveBeenCalled();
+  });
+});
+
 describe("moveChatToProject", () => {
   it("moves an owned chat to an owned project", async () => {
     const { moveChatToProject } = await import("../chats");

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -730,6 +730,49 @@ export const updateChatPreferences = mutation({
 });
 
 /**
+ * Persist a generated title while the response is still streaming.
+ * Intentionally does not touch active stream state.
+ */
+export const updateChatTitle = mutation({
+  args: {
+    serviceKey: v.string(),
+    chatId: v.string(),
+    title: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    validateServiceKey(args.serviceKey);
+
+    const title = args.title.trim();
+    if (!title || title.length > 100) {
+      throw new ConvexError({
+        code: "VALIDATION_ERROR",
+        message: !title
+          ? "Chat title cannot be empty"
+          : "Chat title cannot exceed 100 characters",
+      });
+    }
+
+    const chat = await ctx.db
+      .query("chats")
+      .withIndex("by_chat_id", (q) => q.eq("id", args.chatId))
+      .first();
+
+    if (!chat) {
+      // Benign race: the user deleted the chat while its title was generating.
+      return null;
+    }
+
+    await ctx.db.patch(chat._id, {
+      title,
+      update_time: Date.now(),
+    });
+
+    return null;
+  },
+});
+
+/**
  * Update an existing chat with title and finish reason
  * Automatically clears active_stream_id and canceled_at for stream cleanup
  */

--- a/lib/actions/__tests__/index.test.ts
+++ b/lib/actions/__tests__/index.test.ts
@@ -162,26 +162,28 @@ describe("generateTitleFromUserMessage", () => {
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
 
-    await expect(
-      generateTitleFromUserMessageWithWriter(
-        makeMessage("do not lose this title"),
-        writer,
-        async () => {
-          throw persistenceError;
-        },
-      ),
-    ).resolves.toBe("Resilient Generated Title");
+    try {
+      await expect(
+        generateTitleFromUserMessageWithWriter(
+          makeMessage("do not lose this title"),
+          writer,
+          async () => {
+            throw persistenceError;
+          },
+        ),
+      ).resolves.toBe("Resilient Generated Title");
 
-    expect(writer.write).toHaveBeenCalledWith({
-      type: "data-title",
-      data: { chatTitle: "Resilient Generated Title" },
-      transient: true,
-    });
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Failed to persist generated chat title:",
-      persistenceError,
-    );
-
-    consoleErrorSpy.mockRestore();
+      expect(writer.write).toHaveBeenCalledWith({
+        type: "data-title",
+        data: { chatTitle: "Resilient Generated Title" },
+        transient: true,
+      });
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Failed to persist generated chat title:",
+        persistenceError,
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 });

--- a/lib/actions/__tests__/index.test.ts
+++ b/lib/actions/__tests__/index.test.ts
@@ -39,7 +39,7 @@ describe("generateTitleFromUserMessage", () => {
     mockLanguageModel.mockClear();
   });
 
-  it("uses the title generator model with a small but safe output budget", async () => {
+  it("uses the title generator model without reasoning and with a small output budget", async () => {
     mockGenerateText.mockResolvedValue({
       output: { title: "Web Recon Tips" },
     });
@@ -57,9 +57,8 @@ describe("generateTitleFromUserMessage", () => {
         maxRetries: 1,
         providerOptions: {
           openrouter: {
-            reasoning: { enabled: true, effort: "high" },
+            reasoning: { enabled: false },
           },
-          xai: { store: false },
         },
         temperature: 0,
       }),
@@ -123,6 +122,65 @@ describe("generateTitleFromUserMessage", () => {
       transient: true,
     });
     expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("persists the generated title after streaming it to the header", async () => {
+    mockGenerateText.mockResolvedValue({
+      output: { title: "Sidebar Title Update" },
+    });
+    const callOrder: string[] = [];
+    const writer = {
+      write: jest.fn(() => callOrder.push("stream")),
+    } as unknown as UIMessageStreamWriter;
+    const onTitleGenerated = jest.fn(async () => {
+      callOrder.push("persist");
+    });
+
+    await expect(
+      generateTitleFromUserMessageWithWriter(
+        makeMessage("update this title everywhere"),
+        writer,
+        onTitleGenerated,
+      ),
+    ).resolves.toBe("Sidebar Title Update");
+
+    expect(onTitleGenerated).toHaveBeenCalledWith("Sidebar Title Update");
+    expect(callOrder).toEqual(["stream", "persist"]);
+  });
+
+  it("keeps the generated title when early sidebar persistence fails", async () => {
+    mockGenerateText.mockResolvedValue({
+      output: { title: "Resilient Generated Title" },
+    });
+    const writer = {
+      write: jest.fn(),
+    } as unknown as UIMessageStreamWriter;
+    const persistenceError = new Error("database unavailable");
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    await expect(
+      generateTitleFromUserMessageWithWriter(
+        makeMessage("do not lose this title"),
+        writer,
+        async () => {
+          throw persistenceError;
+        },
+      ),
+    ).resolves.toBe("Resilient Generated Title");
+
+    expect(writer.write).toHaveBeenCalledWith({
+      type: "data-title",
+      data: { chatTitle: "Resilient Generated Title" },
+      transient: true,
+    });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to persist generated chat title:",
+      persistenceError,
+    );
 
     consoleErrorSpy.mockRestore();
   });

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -66,11 +66,7 @@ export const generateTitleFromUserMessage = async (
       model: myProvider.languageModel("title-generator-model"),
       providerOptions: {
         openrouter: {
-          reasoning: { enabled: true, effort: "high" },
-        },
-        xai: {
-          // Disable storing the conversation in XAI's database
-          store: false,
+          reasoning: { enabled: false },
         },
       },
       output: Output.object({
@@ -105,6 +101,7 @@ export const generateTitleFromUserMessage = async (
 export const generateTitleFromUserMessageWithWriter = async (
   truncatedMessages: UIMessage[],
   writer: UIMessageStreamWriter,
+  onTitleGenerated?: (title: string) => Promise<unknown>,
 ): Promise<string | undefined> => {
   try {
     const chatTitle = await generateTitleFromUserMessage(truncatedMessages);
@@ -114,6 +111,14 @@ export const generateTitleFromUserMessageWithWriter = async (
       data: { chatTitle },
       transient: true,
     });
+
+    if (chatTitle && onTitleGenerated) {
+      try {
+        await onTitleGenerated(chatTitle);
+      } catch (error) {
+        console.error("Failed to persist generated chat title:", error);
+      }
+    }
 
     return chatTitle;
   } catch (error) {

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -58,13 +58,15 @@ describe("provider registry", () => {
     expect(
       (myProvider.languageModel("title-generator-model") as { modelId: string })
         .modelId,
-    ).toBe("x-ai/grok-4.5");
+    ).toBe("deepseek/deepseek-v4-flash");
     expect(getModelDisplayName("model-minimax-m3")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-grok-4.5")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-grok-4.5-pro")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-glm-5.2")).toBe("Z.ai GLM 5.2");
     expect(getModelDisplayName("model-gemini-3-flash")).toBe("xAI Grok 4.5");
-    expect(getModelDisplayName("title-generator-model")).toBe("xAI Grok 4.5");
+    expect(getModelDisplayName("title-generator-model")).toBe(
+      "DeepSeek V4 Flash",
+    );
   });
 });
 

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -210,7 +210,8 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "fallback-agent-model": or(GROK_4_5_SLUG),
     "fallback-ask-model": or(GROK_4_5_SLUG),
     "fallback-grok-4.5": or(GROK_4_5_SLUG),
-    "title-generator-model": or(GROK_4_5_SLUG),
+    // Titles are a short structured-output task and should never use reasoning.
+    "title-generator-model": or(DEEPSEEK_V4_FLASH_SLUG),
   }) as Record<string, any>;
 
 const baseProviders = buildProviderMap(openrouter);
@@ -237,7 +238,7 @@ export const modelCutoffDates: Record<ModelName, string> &
   "fallback-agent-model": "July 2026",
   "fallback-ask-model": "July 2026",
   "fallback-grok-4.5": "July 2026",
-  "title-generator-model": "July 2026",
+  "title-generator-model": "May 2025",
 };
 
 export const modelDisplayNames: Record<ModelName, string> &
@@ -260,7 +261,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
   "fallback-ask-model": "Auto, an intelligent model router built by HackerAI",
   "fallback-grok-4.5": "Auto, an intelligent model router built by HackerAI",
-  "title-generator-model": "xAI Grok 4.5",
+  "title-generator-model": "DeepSeek V4 Flash",
 };
 
 export const getModelDisplayName = (modelName: ModelName): string => {

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1490,6 +1490,17 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(/chatFinalizationStatus/);
   });
 
+  test("generated titles update reactive sidebar data before finalization", () => {
+    expect(dbActionsSrc).toMatch(/export async function updateChatTitle/);
+    expect(dbActionsSrc).toMatch(/api\.chats\.updateChatTitle/);
+    expect(chatHandlerSrc).toMatch(
+      /generateTitleFromUserMessageWithWriter\([\s\S]*?\(title\) => updateChatTitle\(\{ chatId, title \}\)/,
+    );
+    expect(taskSrc).toMatch(
+      /generateTitleFromUserMessageWithWriter\([\s\S]*?\(title\) => updateChatTitle\(\{ chatId, title \}\)/,
+    );
+  });
+
   test("empty rehydrated history is classified separately from oversized input", () => {
     const emptyPromptIdx = dbActionsSrc.indexOf("chat_prompt_empty");
     const emptyMessageIdx = dbActionsSrc.indexOf(

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -436,7 +436,9 @@ describe("agent-long chat UI — completion reconciliation", () => {
       /getLatestAgentLongAssistantMessageForPartialSave/,
     );
     expect(chatComponentSrc).toMatch(/stop\(\)/);
-    expect(chatComponentSrc).toMatch(/window\.history\.replaceState/);
+    expect(chatComponentSrc).toMatch(
+      /const finishLocally = \(\) => \{[\s\S]*finalizeNewChatRoute/,
+    );
     expect(chatComponentSrc).toMatch(/setIsExistingChat\(true\)/);
   });
 

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -487,12 +487,9 @@ describe("agent-long chat UI — completion reconciliation", () => {
     );
     const invalidateIdx = chatComponentSrc.indexOf(
       "activeChatIdRef.current = nextChatId",
-      cancelIdx,
+      stopHelperIdx,
     );
-    const abortIdx = chatComponentSrc.indexOf(
-      "stopRef.current()",
-      invalidateIdx,
-    );
+    const abortIdx = chatComponentSrc.indexOf("stopRef.current()", cancelIdx);
     const resetIdx = chatComponentSrc.indexOf("const reset = () => {");
     const nextChatIdIdx = chatComponentSrc.indexOf(
       "const nextChatId = uuidv4()",
@@ -504,9 +501,9 @@ describe("agent-long chat UI — completion reconciliation", () => {
     );
 
     expect(stopHelperIdx).toBeGreaterThan(-1);
-    expect(cancelIdx).toBeGreaterThan(stopHelperIdx);
-    expect(invalidateIdx).toBeGreaterThan(cancelIdx);
-    expect(abortIdx).toBeGreaterThan(invalidateIdx);
+    expect(invalidateIdx).toBeGreaterThan(stopHelperIdx);
+    expect(cancelIdx).toBeGreaterThan(invalidateIdx);
+    expect(abortIdx).toBeGreaterThan(cancelIdx);
     expect(nextChatIdIdx).toBeGreaterThan(resetIdx);
     expect(guardedStopIdx).toBeGreaterThan(nextChatIdIdx);
     expect(

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -467,7 +467,7 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(chatComponentSrc).toMatch(/const stopRef = useRef\(stop\)/);
     expect(chatComponentSrc).toMatch(/stopActiveBrowserStream/);
     expect(chatComponentSrc).toMatch(
-      /cancelAgentLongRealtimeStreams\(activeChatIdRef\.current\)/,
+      /const activeChatId = activeChatIdRef\.current;[\s\S]*cancelAgentLongRealtimeStreams\(activeChatId\)/,
     );
     expect(chatComponentSrc).toMatch(
       /statusRef\.current\s*===\s*"streaming"[\s\S]*statusRef\.current\s*===\s*"submitted"[\s\S]*stopRef\.current\(\)/,
@@ -475,6 +475,45 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(chatComponentSrc).toMatch(
       /return\s*\(\)\s*=>\s*\{\s*stopActiveBrowserStream\(\);[\s\S]*\}/,
     );
+  });
+
+  test("new-task reset invalidates stale terminal callbacks before aborting", () => {
+    const stopHelperIdx = chatComponentSrc.indexOf(
+      "const stopActiveBrowserStream = useCallback(",
+    );
+    const cancelIdx = chatComponentSrc.indexOf(
+      "cancelAgentLongRealtimeStreams(activeChatId)",
+      stopHelperIdx,
+    );
+    const invalidateIdx = chatComponentSrc.indexOf(
+      "activeChatIdRef.current = nextChatId",
+      cancelIdx,
+    );
+    const abortIdx = chatComponentSrc.indexOf(
+      "stopRef.current()",
+      invalidateIdx,
+    );
+    const resetIdx = chatComponentSrc.indexOf("const reset = () => {");
+    const nextChatIdIdx = chatComponentSrc.indexOf(
+      "const nextChatId = uuidv4()",
+      resetIdx,
+    );
+    const guardedStopIdx = chatComponentSrc.indexOf(
+      "stopActiveBrowserStream(nextChatId)",
+      nextChatIdIdx,
+    );
+
+    expect(stopHelperIdx).toBeGreaterThan(-1);
+    expect(cancelIdx).toBeGreaterThan(stopHelperIdx);
+    expect(invalidateIdx).toBeGreaterThan(cancelIdx);
+    expect(abortIdx).toBeGreaterThan(invalidateIdx);
+    expect(nextChatIdIdx).toBeGreaterThan(resetIdx);
+    expect(guardedStopIdx).toBeGreaterThan(nextChatIdIdx);
+    expect(
+      chatComponentSrc.match(
+        /!isChatMountedRef\.current \|\| activeChatIdRef\.current !== chatId/g,
+      ),
+    ).toHaveLength(3);
   });
 
   test("sidebar navigation cancels stale agent-long realtime before route commit", () => {

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -46,10 +46,23 @@ const GROK_PRIMARY_OR_FALLBACK_MODELS = [
   "fallback-agent-model",
   "fallback-ask-model",
   "fallback-grok-4.5",
-  "title-generator-model",
 ] as const;
 
 describe("buildProviderOptions fallback chain", () => {
+  it("keeps title generation on a non-reasoning route", () => {
+    const opts = buildProviderOptions(
+      false,
+      "user-1",
+      "title-generator-model",
+      "ask",
+    );
+
+    expect(opts.openrouter).toEqual({
+      reasoning: { enabled: false },
+      user: "user-1",
+    });
+  });
+
   it.each(GROK_PRIMARY_OR_FALLBACK_MODELS)(
     "uses high reasoning whenever %s can resolve to Grok",
     (modelName) => {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -96,6 +96,7 @@ import {
   handleInitialChatAndUserMessage,
   saveMessage,
   updateChat,
+  updateChatTitle,
   getMessagesByChatId,
   getUserCustomization,
   prepareForNewStream,
@@ -772,6 +773,7 @@ export const createChatHandler = () => {
                 ? generateTitleFromUserMessageWithWriter(
                     processedMessages,
                     writer,
+                    (title) => updateChatTitle({ chatId, title }),
                   )
                 : Promise.resolve(undefined);
 

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -50,6 +50,7 @@ const loadSaveMessageWithMocks = async () => {
     saveMessage,
     setActiveTriggerRun,
     updateChat,
+    updateChatTitle,
   } = await import("../actions");
   return {
     deleteAllChatsForBackend,
@@ -65,6 +66,7 @@ const loadSaveMessageWithMocks = async () => {
     saveMessage,
     setActiveTriggerRun,
     updateChat,
+    updateChatTitle,
   };
 };
 
@@ -498,6 +500,31 @@ describe("updateChat", () => {
     } finally {
       errorSpy.mockRestore();
     }
+  });
+});
+
+describe("updateChatTitle", () => {
+  it("sends only title fields through the title-specific mutation", async () => {
+    const { mockMutation, updateChatTitle } = await loadSaveMessageWithMocks();
+
+    await expect(
+      updateChatTitle({ chatId: "chat-1", title: "Generated Title" }),
+    ).resolves.toEqual({ id: "message-1" });
+
+    expect(mockMutation).toHaveBeenCalledTimes(1);
+    const mutationArgs = mockMutation.mock.calls[0]?.[1] as Record<
+      string,
+      unknown
+    >;
+    expect(mutationArgs).toMatchObject({
+      chatId: "chat-1",
+      title: "Generated Title",
+    });
+    expect(Object.keys(mutationArgs).sort()).toEqual([
+      "chatId",
+      "serviceKey",
+      "title",
+    ]);
   });
 });
 

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -1223,6 +1223,57 @@ export async function updateChat({
   }
 }
 
+export async function updateChatTitle({
+  chatId,
+  title,
+}: {
+  chatId: string;
+  title: string;
+}) {
+  const mutationArgs = {
+    serviceKey,
+    chatId,
+    title,
+  };
+
+  for (let attemptIndex = 0; ; attemptIndex++) {
+    try {
+      return await getConvexClient().mutation(
+        api.chats.updateChatTitle,
+        mutationArgs,
+      );
+    } catch (error) {
+      const retryReason = getRetryableDatabaseErrorReason(error);
+      const retryDelayMs = UPDATE_CHAT_RETRY_DELAYS_MS[attemptIndex];
+      if (!retryReason || retryDelayMs === undefined) {
+        throw databaseError("chats.updateChatTitle", error, {
+          chat_id: chatId,
+          title_length: title.length,
+        });
+      }
+
+      console.warn(
+        JSON.stringify({
+          level: "warn",
+          event: "chat_title_update_retry_scheduled",
+          service: "chat-handler",
+          environment:
+            process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+          timestamp: new Date().toISOString(),
+          db_operation: "chats.updateChatTitle",
+          retry_reason: retryReason,
+          attempt: attemptIndex + 1,
+          next_attempt: attemptIndex + 2,
+          retry_delay_ms: retryDelayMs,
+          chat_id: chatId,
+          title_length: title.length,
+        }),
+      );
+      await waitForRetryDelay(retryDelayMs);
+    }
+  }
+}
+
 export async function getMessagesByChatId({
   chatId,
   userId,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -72,6 +72,7 @@ import { assertUserCanMakeCostIncurringRequest } from "@/lib/suspensions";
 import {
   saveMessage,
   updateChat,
+  updateChatTitle,
   getUserCustomization,
   setActiveTriggerRun,
   setActiveAgentApprovalPending,
@@ -2323,6 +2324,7 @@ export const agentLongTask = task({
                 ? generateTitleFromUserMessageWithWriter(
                     processedMessages,
                     writer,
+                    (title) => updateChatTitle({ chatId, title }),
                   )
                 : Promise.resolve(undefined);
 


### PR DESCRIPTION
## Summary

- route every chat-title request to DeepSeek V4 Flash and explicitly disable reasoning, including free-user chats
- persist a generated title immediately after the transient header title event through a title-only Convex mutation, so normal and project sidebars update before the response finishes
- prevent an old stream terminal callback from claiming the URL after the user starts or opens another task
- cover regular chat and Trigger.dev agent-long execution paths while keeping title-persistence failures non-blocking

## Root cause

Chat titles were using the Grok 4.5 alias with high reasoning even though title generation is a short structured-output task. The header updated immediately from the transient `data-title` stream event, but the sidebar reads reactive Convex chat data and the generated title was only persisted during end-of-stream finalization.

The existing final `updateChat` mutation cannot safely be reused mid-stream because it clears `active_stream_id` and cancellation state. This PR adds a title-only backend mutation that updates only `title` and `update_time`.

For the New task regression, the authenticated browser trace showed the stale URL write came from the Vercel AI SDK `useChat` abort-time `onFinish` callback. The SDK intentionally invokes the latest React callback for an older in-flight request. After reset generated the replacement chat ID, both the callback closure and `activeChatIdRef` contained that replacement ID, so the earlier equality guard passed and `onFinish` called `history.replaceState` with a nonexistent `/c/{replacementId}`.

The fix requires every new-chat terminal path to still own either `/` or its matching `/c/{chatId}` route before finalizing it; aborted completions must own the matching chat route specifically. Normal completion, manual Stop, and agent-long local completion keep their intended behavior, while stale callbacks cannot replace another destination. The active chat ID is also invalidated before agent-long cancellation so synchronous cancellation cannot pass the old-ID guard.

## Validation

- authenticated Chrome reproduction before the fix captured `Chat.useChat onFinish -> history.replaceState` as the stale writer
- authenticated Chrome verification after the fix stayed on `/` at click, 100 ms, 500 ms, 1.5 s, and 3.5 s, with no abort-time `onFinish` URL write
- behavioral route regression tests cover New task abort, manual Stop, normal completion, and stale normal completion
- focused title/routing/sidebar suites: 7 suites and 225 tests passed
- final full repository commit gate: 290 test suites and 2,859 tests passed
- TypeScript typecheck and Prettier passed
- full ESLint passed with five existing warnings and no errors

## Manual verification

1. On the authenticated local development origin, start a non-temporary response long enough to keep streaming.
2. Open the task sidebar while the response shows **Stop generation** / **Working**, then click **New task**.
3. Confirm the empty composer appears at `/` and remains there after the old stream aborts.
4. Manually stop a separate new response and confirm its existing `/c/{chatId}` route remains intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to update a chat title while a response is still streaming.
  - Titles for new conversations are generated (with reasoning disabled) and automatically persisted.

- **Bug Fixes**
  - Title updates only change the chat title and timestamp—streaming/cancellation data remains untouched; updates safely no-op if the chat no longer exists.
  - UI state mutations are blocked for stale/unmounted chat events, and route finalization/stream stopping during resets is more reliable.

- **Tests**
  - Added/extended tests for title updating, route finalization behavior, and reasoning-disabled title generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->