### PR TITLE
Keep default title for image-only chats

### DIFF
--- a/lib/actions/__tests__/index.test.ts
+++ b/lib/actions/__tests__/index.test.ts
@@ -33,6 +33,22 @@ const makeMessage = (text: string): UIMessage[] =>
     },
   ] as UIMessage[];
 
+const makeImageOnlyMessage = (): UIMessage[] =>
+  [
+    {
+      id: "message-1",
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          mediaType: "image/png",
+          filename: "screenshot.png",
+          url: "https://example.com/screenshot.png",
+        },
+      ],
+    },
+  ] as UIMessage[];
+
 describe("generateTitleFromUserMessage", () => {
   beforeEach(() => {
     mockGenerateText.mockReset();
@@ -64,6 +80,15 @@ describe("generateTitleFromUserMessage", () => {
         temperature: 0,
       }),
     );
+  });
+
+  it("keeps the default title without calling the title model for an image-only message", async () => {
+    await expect(
+      generateTitleFromUserMessage(makeImageOnlyMessage()),
+    ).resolves.toBe("New chat");
+
+    expect(mockLanguageModel).not.toHaveBeenCalled();
+    expect(mockGenerateText).not.toHaveBeenCalled();
   });
 
   it("constrains generated titles to non-empty strings under the chat title limit", async () => {

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -6,6 +6,7 @@ import { isXaiSafetyError } from "@/lib/api/chat-stream-helpers";
 const MAX_GENERATED_TITLE_LENGTH = 100;
 const TITLE_GENERATION_MAX_OUTPUT_TOKENS = 64;
 const FALLBACK_TITLE_WORD_LIMIT = 5;
+const IMAGE_ONLY_CHAT_TITLE = "New chat";
 
 const truncateMiddle = (text: string, maxLength: number): string => {
   if (text.length <= maxLength) return text;
@@ -59,6 +60,14 @@ export const generateTitleFromUserMessage = async (
     .filter((part: { type: string; text?: string }) => part.type === "text")
     .map((part: { type: string; text?: string }) => part.text || "")
     .join(" ");
+  const hasImage = (firstMessage?.parts ?? []).some(
+    (part) => part.type === "file" && part.mediaType.startsWith("image/"),
+  );
+
+  if (!textContent.trim() && hasImage) {
+    return IMAGE_ONLY_CHAT_TITLE;
+  }
+
   const fallbackTitle = fallbackTitleFromMessage(textContent);
 
   try {


### PR DESCRIPTION
## Summary

- keep the exact `New chat` title when a new chat starts with an image and no text
- bypass the title-generation model entirely for that case
- add regression coverage proving no title model is resolved or called

## Root cause

The shared title helper extracted an empty text string from image-only messages but still invoked the title generator. The request now returns the default title before resolving or calling any title model.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (289 suites, 2,849 tests)
- `pnpm exec prettier --check lib/actions/index.ts lib/actions/__tests__/index.test.ts`
- `git diff --check`

## Manual verification

1. Start a new persistent chat.
2. Attach an image without entering text, then send it.
3. Confirm the chat title remains exactly `New chat`.
4. Start another chat with text and confirm normal generated titles still work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image-only messages now retain the default “New chat” title.
  * Prevented unnecessary title-generation processing when no text is included.
* **Tests**
  * Added coverage confirming image-only chats preserve the default title and avoid language-model generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->