### PR TITLE
Handle Snap sandbox transfers and action diagnostics

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -9,6 +9,66 @@ export function register() {
   }
 }
 
+const getHeaderValue = (
+  headers: NodeJS.Dict<string | string[]>,
+  name: string,
+): string | undefined => {
+  const value = Object.entries(headers).find(
+    ([key]) => key.toLowerCase() === name,
+  )?.[1];
+  return Array.isArray(value) ? value[0] : value;
+};
+
+const getErrorDigest = (error: unknown): string | undefined => {
+  try {
+    if (typeof error !== "object" || error === null || !("digest" in error)) {
+      return undefined;
+    }
+    return typeof error.digest === "string" || typeof error.digest === "number"
+      ? String(error.digest)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const getServerActionErrorMetadata = (
+  error: unknown,
+  request: Parameters<Instrumentation.onRequestError>[1],
+  context: Parameters<Instrumentation.onRequestError>[2],
+): Record<string, string | number> => {
+  if (context.routeType !== "action") return {};
+
+  const actionId = getHeaderValue(request.headers, "next-action");
+  const rawContentType = getHeaderValue(request.headers, "content-type");
+  const contentType = rawContentType?.split(";", 1)[0].trim().toLowerCase();
+  const rawContentLength = getHeaderValue(request.headers, "content-length");
+  const contentLength =
+    rawContentLength && /^\d{1,15}$/.test(rawContentLength)
+      ? Number(rawContentLength)
+      : undefined;
+  const vercelRequestId = getHeaderValue(request.headers, "x-vercel-id");
+  const digest = getErrorDigest(error);
+
+  return {
+    ...(actionId && /^[a-f0-9]{40}$/i.test(actionId)
+      ? { action_id: actionId }
+      : {}),
+    ...(contentType && contentType.length <= 128
+      ? { content_type: contentType }
+      : {}),
+    ...(contentLength !== undefined && Number.isSafeInteger(contentLength)
+      ? { content_length: contentLength }
+      : {}),
+    ...(vercelRequestId && /^[a-z0-9:._-]{1,256}$/i.test(vercelRequestId)
+      ? { vercel_request_id: vercelRequestId }
+      : {}),
+    ...(digest && /^[a-z0-9_-]{1,128}$/i.test(digest)
+      ? { error_digest: digest }
+      : {}),
+  };
+};
+
 export const onRequestError: Instrumentation.onRequestError = (
   error,
   request,
@@ -34,5 +94,6 @@ export const onRequestError: Instrumentation.onRequestError = (
     routePath: context.routePath,
     routeType: context.routeType,
     routerKind: context.routerKind,
+    ...getServerActionErrorMetadata(error, request, context),
   });
 };

--- a/lib/__tests__/instrumentation.test.ts
+++ b/lib/__tests__/instrumentation.test.ts
@@ -1,0 +1,128 @@
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/posthog/logs", () => ({
+  registerPostHogLogProvider: jest.fn(),
+}));
+
+jest.mock("@/lib/auth/expected-auth-errors", () => ({
+  isEndedSessionRefreshError: jest.fn(() => false),
+}));
+
+import { phLogger } from "@/lib/posthog/server";
+import { onRequestError } from "@/instrumentation";
+
+describe("onRequestError", () => {
+  const mockPhLoggerError = phLogger.error as jest.MockedFunction<
+    typeof phLogger.error
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("adds bounded Server Action request metadata without sensitive headers", () => {
+    const error = Object.assign(
+      new SyntaxError("Unexpected end of JSON input"),
+      {
+        digest: "2147368089",
+      },
+    );
+
+    onRequestError(
+      error,
+      {
+        path: "/c/opaque-chat-id",
+        method: "POST",
+        headers: {
+          "next-action": "a".repeat(40),
+          "content-type": "text/plain; charset=utf-8",
+          "content-length": "0",
+          "x-vercel-id": "iad1::opaque-request",
+          authorization: "Bearer secret",
+          cookie: "session=secret",
+        },
+      },
+      {
+        routePath: "/c/[id]",
+        routeType: "action",
+        routerKind: "App Router",
+        revalidateReason: undefined,
+      },
+    );
+
+    expect(mockPhLoggerError).toHaveBeenCalledWith(
+      "Next.js request error",
+      expect.objectContaining({
+        error,
+        routeType: "action",
+        action_id: "a".repeat(40),
+        content_type: "text/plain",
+        content_length: 0,
+        vercel_request_id: "iad1::opaque-request",
+        error_digest: "2147368089",
+      }),
+    );
+    const logged = JSON.stringify(mockPhLoggerError.mock.calls[0][1]);
+    expect(logged).not.toContain("Bearer secret");
+    expect(logged).not.toContain("session=secret");
+  });
+
+  it("omits malformed Server Action metadata", () => {
+    onRequestError(
+      new Error("boom"),
+      {
+        path: "/api/chat",
+        method: "POST",
+        headers: {
+          "next-action": "not-an-action-id",
+          "content-length": "NaN",
+          "x-vercel-id": "not valid whitespace",
+        },
+      },
+      {
+        routePath: "/c/[id]",
+        routeType: "action",
+        routerKind: "App Router",
+        revalidateReason: undefined,
+      },
+    );
+
+    const payload = mockPhLoggerError.mock.calls[0][1];
+    expect(payload).not.toHaveProperty("action_id");
+    expect(payload).not.toHaveProperty("content_length");
+    expect(payload).not.toHaveProperty("vercel_request_id");
+    expect(payload).not.toHaveProperty("error_digest");
+  });
+
+  it("leaves non-action request logging unchanged", () => {
+    onRequestError(
+      new Error("boom"),
+      {
+        path: "/api/chat",
+        method: "POST",
+        headers: {
+          "next-action": "a".repeat(40),
+          "content-length": "123",
+          "x-vercel-id": "iad1::opaque-request",
+        },
+      },
+      {
+        routePath: "/api/chat",
+        routeType: "route",
+        routerKind: "App Router",
+        revalidateReason: undefined,
+      },
+    );
+
+    const payload = mockPhLoggerError.mock.calls[0][1];
+    expect(payload).not.toHaveProperty("action_id");
+    expect(payload).not.toHaveProperty("content_length");
+    expect(payload).not.toHaveProperty("vercel_request_id");
+    expect(payload).not.toHaveProperty("error_digest");
+  });
+});

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -1144,6 +1144,279 @@ describe("CentrifugoSandbox", () => {
       expect(runs[0]).not.toContain("--ssl-no-revoke");
     });
 
+    it("prefers wget when Linux curl is installed as a strict Snap", async () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      const sandbox = createSandbox({
+        osInfo: {
+          platform: "linux",
+          arch: "x64",
+          release: "6.1",
+          hostname: "devbox",
+        },
+      });
+      const run = jest
+        .fn()
+        .mockResolvedValueOnce({
+          stdout: "/snap/bin/curl\n",
+          stderr: "",
+          exitCode: 0,
+        })
+        .mockResolvedValueOnce({
+          stdout: "/usr/bin/wget\n",
+          stderr: "",
+          exitCode: 0,
+        })
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+      (sandbox as any).commands.run = run;
+
+      try {
+        await sandbox.files.downloadFromUrl(
+          "https://example.com/image.png",
+          "/tmp/hackerai-upload/image.png",
+        );
+
+        expect(run).toHaveBeenNthCalledWith(1, "command -v curl || true", {
+          displayName: "",
+          timeoutMs: 30000,
+        });
+        expect(run).toHaveBeenNthCalledWith(2, "command -v wget || true", {
+          displayName: "",
+          timeoutMs: 30000,
+        });
+        expect(run).toHaveBeenNthCalledWith(
+          3,
+          expect.stringContaining("wget -q --tries=3 --waitretry=1"),
+          expect.objectContaining({
+            displayName: "Downloading: image.png",
+            timeoutMs: 120000,
+          }),
+        );
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          "[centrifugo-http]",
+          expect.stringContaining('"reason":"snap_filesystem_confinement"'),
+        );
+        const warning = JSON.parse(consoleWarnSpy.mock.calls[0][1] as string);
+        expect(warning).toMatchObject({
+          level: "warn",
+          event: "centrifugo_http_client_fallback_selected",
+          service: "web",
+          environment: "test",
+          trace_id: "conn-1",
+          user_id: "user-1",
+          connection_id: "conn-1",
+          from_client: "curl",
+          from_package: "snap",
+          to_client: "wget",
+          reason: "snap_filesystem_confinement",
+        });
+        expect(warning).not.toHaveProperty("url");
+        expect(warning).not.toHaveProperty("path");
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
+    });
+
+    it("uses the Snap-safe wget selection for URL uploads", async () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      const sandbox = createSandbox({
+        osInfo: {
+          platform: "linux",
+          arch: "x64",
+          release: "6.1",
+          hostname: "devbox",
+        },
+      });
+      const run = jest
+        .fn()
+        .mockResolvedValueOnce({
+          stdout: "/snap/bin/curl\n",
+          stderr: "",
+          exitCode: 0,
+        })
+        .mockResolvedValueOnce({
+          stdout: "/usr/bin/wget\n",
+          stderr: "",
+          exitCode: 0,
+        })
+        .mockResolvedValueOnce({
+          stdout: "GNU Wget 1.21.4\n",
+          stderr: "",
+          exitCode: 0,
+        })
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+      (sandbox as any).commands.run = run;
+
+      try {
+        await sandbox.files.uploadToUrl(
+          "/tmp/hackerai-upload/report.txt",
+          "https://example.com/upload",
+          "text/plain",
+        );
+
+        expect(run).toHaveBeenNthCalledWith(
+          4,
+          expect.stringContaining("wget -q --method=PUT"),
+          {
+            displayName: "Uploading: report.txt",
+            timeoutMs: 120000,
+          },
+        );
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
+    });
+
+    it("retries wget network failures", async () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      const sandbox = createSandbox({
+        osInfo: {
+          platform: "linux",
+          arch: "x64",
+          release: "6.1",
+          hostname: "devbox",
+        },
+      });
+      (sandbox as any).httpClient = "wget";
+      const run = jest
+        .fn()
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 4 })
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+      (sandbox as any).commands.run = run;
+
+      try {
+        const promise = sandbox.files.downloadFromUrl(
+          "https://example.com/image.png",
+          "/tmp/hackerai-upload/image.png",
+        );
+        await jest.advanceTimersByTimeAsync(500);
+        await promise;
+
+        expect(run).toHaveBeenCalledTimes(2);
+        expect(run).toHaveBeenNthCalledWith(
+          2,
+          expect.stringContaining("wget -q --tries=3 --waitretry=1"),
+          expect.objectContaining({
+            displayName: "Downloading: image.png (retry 1)",
+          }),
+        );
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
+    });
+
+    it("does not retry wget protocol failures", async () => {
+      const sandbox = createSandbox({
+        osInfo: {
+          platform: "linux",
+          arch: "x64",
+          release: "6.1",
+          hostname: "devbox",
+        },
+      });
+      (sandbox as any).httpClient = "wget";
+      const run = jest.fn(async (cmd: string) => {
+        if (cmd.includes("target_dir_exists")) {
+          return {
+            stdout: "target_dir_exists=true\ntarget_dir_writable=true\n",
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return { stdout: "", stderr: "protocol error", exitCode: 7 };
+      });
+      (sandbox as any).commands.run = run;
+
+      await expect(
+        sandbox.files.downloadFromUrl(
+          "https://example.com/image.png",
+          "/tmp/hackerai-upload/image.png",
+        ),
+      ).rejects.toThrow("Failed to download file");
+
+      expect(
+        run.mock.calls.filter(([command]) =>
+          String(command).includes("wget -q --tries=3 --waitretry=1"),
+        ),
+      ).toHaveLength(1);
+    });
+
+    it("keeps Snap curl when wget is unavailable", async () => {
+      const sandbox = createSandbox({
+        osInfo: {
+          platform: "linux",
+          arch: "x64",
+          release: "6.1",
+          hostname: "devbox",
+        },
+      });
+      const run = jest
+        .fn()
+        .mockResolvedValueOnce({
+          stdout: "/snap/bin/curl\n",
+          stderr: "",
+          exitCode: 0,
+        })
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 })
+        .mockResolvedValueOnce({
+          stdout: "--retry-all-errors --retry-connrefused\n",
+          stderr: "",
+          exitCode: 0,
+        })
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+      (sandbox as any).commands.run = run;
+
+      await sandbox.files.downloadFromUrl(
+        "https://example.com/image.png",
+        "/tmp/hackerai-upload/image.png",
+      );
+
+      expect(run).toHaveBeenNthCalledWith(
+        4,
+        expect.stringContaining("curl -fsSL"),
+        expect.objectContaining({
+          displayName: "Downloading: image.png",
+          timeoutMs: 120000,
+        }),
+      );
+    });
+
+    it("redacts signed URL queries from direct download failures", async () => {
+      const { sandbox } = createWindowsBashSandbox();
+      (sandbox as any).commands.run = jest.fn(async (cmd: string) => {
+        if (cmd.includes("target_dir_exists")) {
+          return {
+            stdout: "target_dir_exists=true\ntarget_dir_writable=true\n",
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return {
+          stdout: "",
+          stderr: "curl: (23) client returned ERROR on write",
+          exitCode: 23,
+        };
+      });
+      const signedUrl =
+        "https://storage.example.com/image.png?X-Amz-Credential=" +
+        "a".repeat(160) +
+        "&X-Amz-Signature=secret";
+
+      const assertion = expect(
+        sandbox.files.downloadFromUrl(
+          signedUrl,
+          "/tmp/hackerai-upload/image.png",
+        ),
+      ).rejects.toThrow("url: https://storage.example.com/image.png\n");
+      await jest.advanceTimersByTimeAsync(5_000);
+      await assertion;
+    });
+
     it("uploadToUrl emits Windows curl with --ssl-no-revoke when supported", async () => {
       const { sandbox, runs, runOptions } = createWindowsBashSandbox();
 

--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -1270,6 +1270,58 @@ describe("CentrifugoSandbox", () => {
       }
     });
 
+    it("rejects Snap-safe URL uploads when only BusyBox wget is available", async () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      const sandbox = createSandbox({
+        osInfo: {
+          platform: "linux",
+          arch: "x64",
+          release: "6.1",
+          hostname: "devbox",
+        },
+      });
+      const run = jest
+        .fn()
+        .mockResolvedValueOnce({
+          stdout: "/snap/bin/curl\n",
+          stderr: "",
+          exitCode: 0,
+        })
+        .mockResolvedValueOnce({
+          stdout: "/usr/bin/wget\n",
+          stderr: "",
+          exitCode: 0,
+        })
+        .mockResolvedValueOnce({
+          stdout: "BusyBox v1.36.1 multi-call binary.\n",
+          stderr: "",
+          exitCode: 0,
+        });
+      (sandbox as any).commands.run = run;
+
+      try {
+        await expect(
+          sandbox.files.uploadToUrl(
+            "/tmp/hackerai-upload/report.txt",
+            "https://example.com/upload",
+            "text/plain",
+          ),
+        ).rejects.toThrow(
+          "Snap curl cannot safely access sandbox file paths, and BusyBox wget does not support PUT requests",
+        );
+
+        expect(
+          run.mock.calls.some(([command]) =>
+            String(command).includes("--method=PUT"),
+          ),
+        ).toBe(false);
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
+    });
+
     it("retries wget network failures", async () => {
       const consoleWarnSpy = jest
         .spyOn(console, "warn")
@@ -1388,6 +1440,10 @@ describe("CentrifugoSandbox", () => {
 
     it("redacts signed URL queries from direct download failures", async () => {
       const { sandbox } = createWindowsBashSandbox();
+      const signedUrl =
+        "https://storage.example.com/image.png?X-Amz-Credential=" +
+        "a".repeat(160) +
+        "&X-Amz-Signature=secret";
       (sandbox as any).commands.run = jest.fn(async (cmd: string) => {
         if (cmd.includes("target_dir_exists")) {
           return {
@@ -1398,23 +1454,23 @@ describe("CentrifugoSandbox", () => {
         }
         return {
           stdout: "",
-          stderr: "curl: (23) client returned ERROR on write",
+          stderr: `curl: (23) failed to write ${signedUrl}`,
           exitCode: 23,
         };
       });
-      const signedUrl =
-        "https://storage.example.com/image.png?X-Amz-Credential=" +
-        "a".repeat(160) +
-        "&X-Amz-Signature=secret";
 
-      const assertion = expect(
-        sandbox.files.downloadFromUrl(
-          signedUrl,
-          "/tmp/hackerai-upload/image.png",
-        ),
-      ).rejects.toThrow("url: https://storage.example.com/image.png\n");
+      const failure = sandbox.files
+        .downloadFromUrl(signedUrl, "/tmp/hackerai-upload/image.png")
+        .catch((error: unknown) => error);
       await jest.advanceTimersByTimeAsync(5_000);
-      await assertion;
+      const error = await failure;
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain(
+        "url: https://storage.example.com/image.png\n",
+      );
+      expect((error as Error).message).not.toContain("X-Amz-Credential");
+      expect((error as Error).message).not.toContain("X-Amz-Signature");
     });
 
     it("uploadToUrl emits Windows curl with --ssl-no-revoke when supported", async () => {

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -61,6 +61,15 @@ const TRANSIENT_COMMAND_TIMEOUT_ERROR_PATTERN =
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
+const safeUrlForLog = (url: string): string => {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return url.split("?")[0];
+  }
+};
+
 const isTransientCommandTimeoutError = (error: unknown): boolean =>
   TRANSIENT_COMMAND_TIMEOUT_ERROR_PATTERN.test(getErrorMessage(error));
 
@@ -1055,6 +1064,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
 
   // Cache for detected HTTP client (curl or wget)
   private httpClient: "curl" | "wget" | null = null;
+  private snapCurlFallbackSelected = false;
 
   // Cache for detected curl capabilities (probed once per sandbox).
   // --retry-all-errors requires curl >= 7.71.0
@@ -1111,7 +1121,11 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
     const curlCheck = await this.runSetupCommand("command -v curl || true", {
       displayName: "",
     });
-    if (curlCheck.stdout.includes("curl")) {
+    const curlPath = curlCheck.stdout.trim().split(/\s+/)[0] ?? "";
+    // Strict Snap packages use a private /tmp mount namespace. A shell probe
+    // can report the destination writable while Snap curl still cannot open
+    // that same host path, so prefer the already-supported wget when present.
+    if (curlPath && !curlPath.endsWith("/snap/bin/curl")) {
       this.httpClient = "curl";
       return "curl";
     }
@@ -1120,8 +1134,34 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       displayName: "",
     });
     if (wgetCheck.stdout.includes("wget")) {
+      if (curlPath.endsWith("/snap/bin/curl")) {
+        this.snapCurlFallbackSelected = true;
+        console.warn(
+          "[centrifugo-http]",
+          JSON.stringify({
+            level: "warn",
+            event: "centrifugo_http_client_fallback_selected",
+            service: "web",
+            environment:
+              process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown",
+            timestamp: new Date().toISOString(),
+            trace_id: this.connectionInfo.connectionId,
+            user_id: this.userId,
+            connection_id: this.connectionInfo.connectionId,
+            from_client: "curl",
+            from_package: "snap",
+            to_client: "wget",
+            reason: "snap_filesystem_confinement",
+          }),
+        );
+      }
       this.httpClient = "wget";
       return "wget";
+    }
+
+    if (curlPath) {
+      this.httpClient = "curl";
+      return "curl";
     }
 
     this.httpClient = "curl";
@@ -1569,7 +1609,10 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
       //   56 = failure receiving network data
       //   92 = HTTP/2 stream error
       //   124 = local command wrapper timeout
-      const TRANSIENT_EXIT_CODES = new Set([7, 18, 23, 28, 35, 56, 92, 124]);
+      const transientExitCodes =
+        httpClient === "curl"
+          ? new Set([7, 18, 23, 28, 35, 56, 92, 124])
+          : new Set([4, 124]);
       const MAX_ATTEMPTS = 3;
 
       let result: Awaited<ReturnType<typeof this.commands.run>> | null = null;
@@ -1599,7 +1642,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
         if (result.exitCode === 0) break;
         if (
           attempt === MAX_ATTEMPTS ||
-          !TRANSIENT_EXIT_CODES.has(result.exitCode)
+          !transientExitCodes.has(result.exitCode)
         ) {
           break;
         }
@@ -1622,9 +1665,11 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           ? `test -d ${diagDir} && echo target_dir_exists=true || echo target_dir_exists=false; test -w ${diagDir} && echo target_dir_writable=true || echo target_dir_writable=false; df -h /tmp 2>&1 | sed -n '1,2p'`
           : `if exist ${diagDir} (echo target_dir_exists=true) else (echo target_dir_exists=false) & (pushd ${diagDir} >nul 2>nul && (copy /Y NUL .hackerai_write_probe.tmp >nul 2>nul && del /q .hackerai_write_probe.tmp >nul 2>nul && echo target_dir_writable=true || echo target_dir_writable=false) & popd >nul 2>nul) || echo target_dir_writable=false`;
         const diag = await this.commands.run(diagCmd, { displayName: "" });
+        const safeUrl = safeUrlForLog(url);
+        const safeStderr = result.stderr.split(url).join(safeUrl);
         throw new Error(
-          `Failed to download file: ${result.stderr}\n` +
-            `  url: ${url.substring(0, 120)}${url.length > 120 ? "..." : ""}\n` +
+          `Failed to download file: ${safeStderr}\n` +
+            `  url: ${safeUrl.substring(0, 120)}${safeUrl.length > 120 ? "..." : ""}\n` +
             `  path: ${path}\n` +
             `  command: ${httpClient}\n` +
             `  exitCode: ${result.exitCode}\n` +
@@ -1647,6 +1692,11 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           displayName: "",
         });
         if (versionCheck.stdout.toLowerCase().includes("busybox")) {
+          if (this.snapCurlFallbackSelected) {
+            throw new Error(
+              "File upload failed: Snap curl cannot safely access sandbox file paths, and BusyBox wget does not support PUT requests. Install GNU wget or a native curl package to enable file uploads.",
+            );
+          }
           throw new Error(
             "File upload failed: curl is not available and BusyBox wget does not support PUT requests. " +
               "Install curl to enable file uploads (e.g., 'apk add curl' on Alpine or 'apt install curl' on Debian).",


### PR DESCRIPTION
## Summary
- prefer `wget` for sandbox HTTP transfers when the installed `curl` comes from strict-confined Snap
- keep transfer retries client-specific and redact signed URL query strings from failure logs
- add bounded Server Action request metadata to instrumentation errors without logging request bodies, cookies, authorization, or action arguments

## Production evidence
Frozen audit window: `2026-07-20T19:32:58.595Z` through `2026-07-21T19:32:58.595Z`.

- Trigger.dev had 5 `The computer attachment upload failed.` terminal failures affecting 3 users / 3 chats, all after the prior unique-fallback-directory fix deployed. Representative run: `run_06foc45k3igckqfog9a6vbfi01`.
- The representative trace showed both the primary and UUID fallback directories existed, were writable, and had about 59 GB free, while every attempted transfer used `/snap/bin/curl`, emitted Snap's strict-confinement filesystem warning, and failed with exit 23.
- Vercel had 4 repeated `SyntaxError: Unexpected end of JSON input` Server Action POSTs for one chat (digest `2147368089`) with no frame or request-shape attribution. This PR adds narrowly scoped diagnostics rather than guessing at a parser fix.
- No error suppression is added.

## Root cause
Strict-confined Snap curl uses a private `/tmp` namespace, so files written to the host sandbox's `/tmp/hackerai-upload` tree are not reliably visible to that curl process. Retrying curl against a second host `/tmp` directory cannot cross the namespace boundary.

The repeated Server Action JSON parse error still lacks enough production context for a safe behavioral fix. Its error signature is retained, with bounded request metadata added for the next occurrence.

## Change
- detect Snap curl by resolved executable path and prefer available `wget` for shared URL downloads and uploads
- preserve Windows, native curl, unique fallback-directory, and partial-progress behavior
- apply curl and wget retry codes separately, so wget protocol errors are not retried
- sanitize direct-transfer URLs to origin and pathname before structured failure logging
- enrich only failed Server Action request logs with validated action ID, normalized content type, content length, Vercel request ID, and error digest

## Validation
- `corepack pnpm jest lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts lib/utils/__tests__/sandbox-file-utils.test.ts lib/__tests__/instrumentation.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand` — 154 tests passed
- `corepack pnpm typecheck` — passed
- changed-file ESLint — passed
- changed-file Prettier check — passed
- `git diff --check` — passed
- configured pre-commit hooks — full Jest suite passed (291 suites / 2,869 tests), plus typecheck, formatting, and lint

## Manual verification
1. In a Linux local/Desktop sandbox that resolves curl to `/snap/bin/curl` and has GNU wget, attach a URL-backed file to Agent mode. The fallback-selection warning should appear and staging should complete without curl exit 23.
2. Force a direct transfer failure with a signed URL. Diagnostics should contain only the URL origin/path and must not include its query string.
3. In non-production, send an empty or truncated Server Action POST. The error log should include only bounded action/request metadata and must not include body, cookies, authorization, or action arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file transfers in Snap-constrained environments by detecting Snap-provided tools and selecting compatible download/upload commands.
  * Added robust retry behavior for transient download failures while avoiding retries for protocol errors.
  * Improved upload/download diagnostics, including clearer Snap limitation messages.
  * Redacted signed URL query parameters from download error output.
  * Enhanced request error logging for server action failures with validated, structured metadata while excluding sensitive headers.
* **Tests**
  * Added coverage for server action error logging behavior and Snap confinement download/upload command selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->