### PR TITLE
Remove orphaned declarations

### DIFF
--- a/app/components/TeamDialogs.tsx
+++ b/app/components/TeamDialogs.tsx
@@ -299,31 +299,6 @@ export const TeamWelcomeDialog = ({
   );
 };
 
-export const InviteAcceptedDialog = ({
-  open,
-  onOpenChange,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}) => {
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Welcome to the team! 🎉</DialogTitle>
-          <DialogDescription>
-            You&apos;ve successfully joined the team. You now have access to all
-            team plan features.
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button onClick={() => onOpenChange(false)}>Got it</Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-};
-
 interface SeatPreview {
   currentQuantity: number;
   newQuantity: number;

--- a/lib/ai/tools/schemas.ts
+++ b/lib/ai/tools/schemas.ts
@@ -474,8 +474,6 @@ When in doubt, use this tool. Systematic task management ensures comprehensive s
   inputSchema: todoWriteToolInputSchema,
 });
 
-export type TodoWriteToolInput = z.infer<typeof todoWriteToolInputSchema>;
-
 export const PERPLEXITY_QUERY_MAX_LENGTH = 8192;
 const webSearchQuerySchema = z
   .string()
@@ -544,7 +542,6 @@ export const NOTE_CATEGORIES = [
   "questions",
   "plan",
 ] as const;
-export type ToolNoteCategory = (typeof NOTE_CATEGORIES)[number];
 const noteCategorySchema = z.enum(NOTE_CATEGORIES);
 
 export const createNoteToolInputSchema = z.object({

--- a/lib/ai/tools/utils/pty-output-formatter.ts
+++ b/lib/ai/tools/utils/pty-output-formatter.ts
@@ -30,8 +30,7 @@ let TerminalCtor:
           getLine: (
             i: number,
           ) =>
-            | { translateToString: (trimRight: boolean) => string }
-            | undefined;
+            { translateToString: (trimRight: boolean) => string } | undefined;
         };
       };
       dispose: () => void;
@@ -104,27 +103,8 @@ export async function cleanPtyForUI(text: string): Promise<string> {
   return fallbackClean(text);
 }
 
-/** Return last N lines of a PTY snapshot as raw bytes (for streaming context). */
-export async function lastNLinesBytes(
-  bytes: Uint8Array,
-  n: number,
-): Promise<Uint8Array> {
-  const text = await cleanPtyForUI(new TextDecoder().decode(bytes));
-  const lines = text.split("\n");
-  if (lines.length <= n) return new TextEncoder().encode(text);
-  return new TextEncoder().encode(lines.slice(-n).join("\n"));
-}
-
 interface SnapshotSource {
   snapshot(session: { sessionId: string; chatId: string }): Uint8Array;
-}
-
-export async function getSessionSnapshot(
-  mgr: SnapshotSource,
-  session: { sessionId: string; chatId: string },
-): Promise<string> {
-  const bytes = mgr.snapshot(session);
-  return cleanPtyForUI(new TextDecoder().decode(bytes));
 }
 
 /** Returns both raw and cleaned snapshots for persistence. */

--- a/lib/auth/get-user-id.ts
+++ b/lib/auth/get-user-id.ts
@@ -93,24 +93,6 @@ export const getUserIDAndPro = async (
   }
 };
 
-/**
- * Get the current user ID only if the user has signed in recently.
- * Enforces a freshness window (default 10 minutes) using session.user.lastSignInAt.
- * Throws ChatSDKError if unauthenticated or if the last sign-in is stale.
- *
- * @param req - NextRequest object (server-side only)
- * @param windowMs - Freshness window in milliseconds (default 10 minutes)
- * @returns Promise<string> - User ID
- * @throws ChatSDKError - When user is not authenticated or login is stale
- */
-export const getUserIDWithFreshLogin = async (
-  req: NextRequest,
-  windowMs: number = 10 * 60 * 1000,
-): Promise<string> => {
-  const { userId } = await getUserIDWithFreshLoginContext(req, windowMs);
-  return userId;
-};
-
 export const getUserIDWithFreshLoginContext = async (
   req: NextRequest,
   windowMs: number = 10 * 60 * 1000,

--- a/lib/utils/client-storage.ts
+++ b/lib/utils/client-storage.ts
@@ -311,17 +311,6 @@ export const removeDraft = (id: string): void => {
   writeDraftStore({ ...store, drafts: nextDrafts });
 };
 
-export const getDrafts = (): Array<ConversationDraft> =>
-  readDraftStore().drafts;
-
-export const getUserIdFromDrafts = (): string | undefined =>
-  readDraftStore().userId;
-
-export const setUserIdInDrafts = (userId: string): void => {
-  const store = readDraftStore();
-  writeDraftStore({ ...store, userId });
-};
-
 export const clearAllDrafts = (): void => {
   if (!isBrowser()) return;
   try {

--- a/types/file.ts
+++ b/types/file.ts
@@ -85,8 +85,6 @@ export type FileProcessingResult = {
   processedCount: number;
 };
 
-export type FileSource = "upload" | "paste" | "drop";
-
 // File processing chunk interface
 export interface FileItemChunk {
   content: string;


### PR DESCRIPTION
## Summary

- remove an unreferenced team dialog and fresh-login convenience wrapper
- drop unused tool/file type aliases, draft-storage accessors, and PTY snapshot helpers
- keep runtime routes and public HTTP/Convex contracts unchanged

## Why

This is the first small modernization pass from the codebase refactor audit. Every removed symbol had no references across source, tests, scripts, or documentation, so retaining it only increased the apparent API surface and maintenance cost.

## Validation

- `corepack pnpm typecheck`
- `corepack pnpm jest lib/ai/tools/__tests__/schemas.test.ts lib/utils/__tests__/client-storage.test.ts lib/utils/__tests__/file-utils.test.ts --runInBand` (3 suites, 26 tests)
- `corepack pnpm test --runInBand` (291 suites, 2,870 tests)
- `corepack pnpm lint` (passes with 5 existing unrelated warnings)
- `corepack pnpm exec prettier --check app/components/TeamDialogs.tsx lib/ai/tools/schemas.ts lib/ai/tools/utils/pty-output-formatter.ts lib/auth/get-user-id.ts lib/utils/client-storage.ts types/file.ts`
- `git diff --check`

## Manual verification

Automated validation is sufficient for this deletion-only pass because none of the removed declarations had runtime consumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a seat management dialog for adjusting team seat counts.
  * Displays prorated charges or credits and invoice details before confirmation.
  * Supports payment-required redirects and clear error states.

* **Bug Fixes**
  * Improved loading and confirmation state handling during seat updates.

* **Refactor**
  * Removed unused internal helpers and type exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->