### PR TITLE
Stop background message search subscriptions

### DIFF
--- a/app/components/MessageSearchDialog.tsx
+++ b/app/components/MessageSearchDialog.tsx
@@ -50,6 +50,11 @@ interface MessageSearchDialogProps {
 type DateCategory =
   "Today" | "Yesterday" | "Previous 7 Days" | "Previous 30 Days" | "Older";
 
+const resolveNextCursor = (result: {
+  isDone: boolean;
+  continueCursor?: string | null;
+}) => (result.isDone || !result.continueCursor ? null : result.continueCursor);
+
 export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
   isOpen,
   onClose,
@@ -72,6 +77,9 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
   const [allResults, setAllResults] = useState<MessageSearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [searchError, setSearchError] = useState<
+    "initial" | "pagination" | null
+  >(null);
   const [continueCursor, setContinueCursor] = useState<string | null>(null);
   const loaderRef = useRef<HTMLDivElement>(null);
   const chatsLoaderRef = useRef<HTMLDivElement>(null);
@@ -124,6 +132,7 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
       setAllResults([]);
       setIsSearching(false);
       setIsLoadingMore(false);
+      setSearchError(null);
       setContinueCursor(null);
       return;
     }
@@ -131,6 +140,7 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
     setAllResults([]);
     setIsSearching(true);
     setIsLoadingMore(false);
+    setSearchError(null);
     setContinueCursor(null);
 
     const loadFirstPage = async () => {
@@ -142,15 +152,12 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
         if (cancelled || searchGenerationRef.current !== generation) return;
 
         setAllResults(result.page);
-        setContinueCursor(
-          result.isDone || !result.continueCursor
-            ? null
-            : result.continueCursor,
-        );
+        setContinueCursor(resolveNextCursor(result));
       } catch (error) {
         if (cancelled || searchGenerationRef.current !== generation) return;
         console.error("Failed to search messages:", error);
         setAllResults([]);
+        setSearchError("initial");
         setContinueCursor(null);
       } finally {
         if (!cancelled && searchGenerationRef.current === generation) {
@@ -171,6 +178,7 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
 
     const generation = searchGenerationRef.current;
     setIsLoadingMore(true);
+    setSearchError(null);
 
     try {
       const result = await convex.query(api.messages.searchMessages, {
@@ -180,12 +188,11 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
       if (searchGenerationRef.current !== generation) return;
 
       setAllResults((current) => [...current, ...result.page]);
-      setContinueCursor(
-        result.isDone || !result.continueCursor ? null : result.continueCursor,
-      );
+      setContinueCursor(resolveNextCursor(result));
     } catch (error) {
       if (searchGenerationRef.current !== generation) return;
       console.error("Failed to load more message search results:", error);
+      setSearchError("pagination");
       setContinueCursor(null);
     } finally {
       if (searchGenerationRef.current === generation) {
@@ -494,6 +501,16 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
                 <Loader2 className="animate-spin mr-2" size={20} />
                 <span className="text-sm">Searching...</span>
               </div>
+            ) : searchError === "initial" ? (
+              <div className="flex items-center justify-center py-12 text-muted-foreground">
+                <div className="text-center">
+                  <Search size={48} className="mx-auto mb-4 opacity-50" />
+                  <p className="text-sm">Search failed</p>
+                  <p className="text-xs mt-2">
+                    Try again or use different keywords
+                  </p>
+                </div>
+              </div>
             ) : allResults.length === 0 ? (
               <div className="flex items-center justify-center py-12 text-muted-foreground">
                 <div className="text-center">
@@ -566,6 +583,14 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
                   <div className="flex justify-center py-4">
                     <Loader2 className="animate-spin mr-2" size={16} />
                     <span className="text-sm">Loading more...</span>
+                  </div>
+                )}
+
+                {searchError === "pagination" && (
+                  <div className="flex justify-center py-4 text-muted-foreground">
+                    <span className="text-sm">
+                      Couldn&apos;t load more results. Try searching again.
+                    </span>
                   </div>
                 )}
               </div>

--- a/app/components/MessageSearchDialog.tsx
+++ b/app/components/MessageSearchDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from "react";
-import { usePaginatedQuery } from "convex/react";
+import React, { useCallback, useState, useEffect, useRef } from "react";
+import { useConvex } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { useRouter } from "next/navigation";
@@ -56,6 +56,7 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
 }) => {
   const { user } = useAuth();
   const router = useRouter();
+  const convex = useConvex();
   const { setChatSidebarOpen, closeSidebar } = useGlobalState();
   const isMobile = useIsMobile();
   const [searchQuery, setSearchQuery] = useState("");
@@ -70,17 +71,14 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
     trimmedDebouncedQuery.length <= MAX_MESSAGE_SEARCH_QUERY_LENGTH;
   const [allResults, setAllResults] = useState<MessageSearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [continueCursor, setContinueCursor] = useState<string | null>(null);
   const loaderRef = useRef<HTMLDivElement>(null);
   const chatsLoaderRef = useRef<HTMLDivElement>(null);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const chatsObserverRef = useRef<IntersectionObserver | null>(null);
-
-  // Use Convex usePaginatedQuery for search
-  const searchResults = usePaginatedQuery(
-    api.messages.searchMessages,
-    isSearchReady && user ? { searchQuery: trimmedDebouncedQuery } : "skip",
-    { initialNumItems: 20 },
-  );
+  const searchGenerationRef = useRef(0);
+  const canSearch = isOpen && isSearchReady && Boolean(user);
 
   // Date categorization functions
   const getChatDateCategory = (chat: Doc<"chats">): DateCategory => {
@@ -106,40 +104,95 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
-  // Handle search results updates
+  // Clear the query when the dialog closes so a previous search cannot restart
+  // when the always-mounted sidebar header renders again.
   useEffect(() => {
-    if (!isSearchReady) {
-      setIsSearching(false);
+    if (isOpen) return;
+    setSearchQuery("");
+    setDebouncedQuery("");
+  }, [isOpen]);
+
+  // Message history search does not need realtime updates. A one-shot query
+  // prevents Convex from keeping a costly full-text subscription alive while
+  // messages are written in the background.
+  useEffect(() => {
+    const generation = searchGenerationRef.current + 1;
+    searchGenerationRef.current = generation;
+    let cancelled = false;
+
+    if (!canSearch) {
       setAllResults([]);
+      setIsSearching(false);
+      setIsLoadingMore(false);
+      setContinueCursor(null);
       return;
     }
 
-    if (searchResults.status === "LoadingFirstPage") {
-      setIsSearching(true);
+    setAllResults([]);
+    setIsSearching(true);
+    setIsLoadingMore(false);
+    setContinueCursor(null);
 
-      setAllResults([]);
-    } else if (
-      searchResults.status === "CanLoadMore" ||
-      searchResults.status === "Exhausted"
-    ) {
-      setIsSearching(false);
+    const loadFirstPage = async () => {
+      try {
+        const result = await convex.query(api.messages.searchMessages, {
+          searchQuery: trimmedDebouncedQuery,
+          paginationOpts: { numItems: 20, cursor: null },
+        });
+        if (cancelled || searchGenerationRef.current !== generation) return;
 
-      if (searchResults.results) {
-        // Use all accumulated results from the paginated query
+        setAllResults(result.page);
+        setContinueCursor(
+          result.isDone || !result.continueCursor
+            ? null
+            : result.continueCursor,
+        );
+      } catch (error) {
+        if (cancelled || searchGenerationRef.current !== generation) return;
+        console.error("Failed to search messages:", error);
+        setAllResults([]);
+        setContinueCursor(null);
+      } finally {
+        if (!cancelled && searchGenerationRef.current === generation) {
+          setIsSearching(false);
+        }
+      }
+    };
 
-        setAllResults(searchResults.results);
+    void loadFirstPage();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [canSearch, convex, trimmedDebouncedQuery]);
+
+  const loadMoreSearchResults = useCallback(async () => {
+    if (!canSearch || !continueCursor || isLoadingMore) return;
+
+    const generation = searchGenerationRef.current;
+    setIsLoadingMore(true);
+
+    try {
+      const result = await convex.query(api.messages.searchMessages, {
+        searchQuery: trimmedDebouncedQuery,
+        paginationOpts: { numItems: 10, cursor: continueCursor },
+      });
+      if (searchGenerationRef.current !== generation) return;
+
+      setAllResults((current) => [...current, ...result.page]);
+      setContinueCursor(
+        result.isDone || !result.continueCursor ? null : result.continueCursor,
+      );
+    } catch (error) {
+      if (searchGenerationRef.current !== generation) return;
+      console.error("Failed to load more message search results:", error);
+      setContinueCursor(null);
+    } finally {
+      if (searchGenerationRef.current === generation) {
+        setIsLoadingMore(false);
       }
     }
-  }, [isSearchReady, searchResults.status, searchResults.results]);
-
-  // Reset results when query changes
-  useEffect(() => {
-    if (!isSearchReady) {
-      setAllResults([]);
-
-      setIsSearching(false);
-    }
-  }, [isSearchReady]);
+  }, [canSearch, continueCursor, convex, isLoadingMore, trimmedDebouncedQuery]);
 
   // Set up Intersection Observer for infinite scrolling of search results
   useEffect(() => {
@@ -149,11 +202,7 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
     }
 
     // Only set up observer if we have results and can load more
-    if (
-      searchResults.status === "CanLoadMore" &&
-      isSearchReady &&
-      allResults.length > 0
-    ) {
+    if (continueCursor && canSearch && allResults.length > 0) {
       const options = {
         root: null,
         rootMargin: "50px",
@@ -164,11 +213,11 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
         const [entry] = entries;
         if (
           entry.isIntersecting &&
-          searchResults.status === "CanLoadMore" &&
-          isSearchReady &&
-          !searchResults.isLoading
+          continueCursor &&
+          canSearch &&
+          !isLoadingMore
         ) {
-          searchResults.loadMore(10);
+          void loadMoreSearchResults();
         }
       }, options);
 
@@ -183,12 +232,11 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
         observerRef.current.disconnect();
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    searchResults.status,
-    isSearchReady,
-    searchResults.loadMore,
-    searchResults.isLoading,
+    continueCursor,
+    canSearch,
+    loadMoreSearchResults,
+    isLoadingMore,
     allResults.length,
   ]);
 
@@ -501,10 +549,10 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
                 ))}
 
                 {/* Loader element for intersection observer - only show if we have results and can load more */}
-                {searchResults.status === "CanLoadMore" &&
-                  isSearchReady &&
+                {continueCursor &&
+                  canSearch &&
                   allResults.length > 0 &&
-                  !searchResults.isLoading && (
+                  !isLoadingMore && (
                     <div
                       ref={loaderRef}
                       className="flex justify-center py-4 text-muted-foreground"
@@ -514,7 +562,7 @@ export const MessageSearchDialog: React.FC<MessageSearchDialogProps> = ({
                   )}
 
                 {/* Show loading state when actively loading more */}
-                {searchResults.isLoading && allResults.length > 0 && (
+                {isLoadingMore && allResults.length > 0 && (
                   <div className="flex justify-center py-4">
                     <Loader2 className="animate-spin mr-2" size={16} />
                     <span className="text-sm">Loading more...</span>

--- a/app/components/__tests__/MessageSearchDialog.test.tsx
+++ b/app/components/__tests__/MessageSearchDialog.test.tsx
@@ -1,0 +1,87 @@
+import "@testing-library/jest-dom";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useConvex } from "convex/react";
+import { MessageSearchDialog } from "../MessageSearchDialog";
+
+jest.mock("@/convex/_generated/api", () => ({
+  api: {
+    messages: { searchMessages: "messages.searchMessages" },
+  },
+}));
+
+jest.mock("@workos-inc/authkit-nextjs/components", () => ({
+  useAuth: () => ({ user: { id: "user-1" } }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/app/contexts/GlobalState", () => ({
+  useGlobalState: () => ({
+    setChatSidebarOpen: jest.fn(),
+    closeSidebar: jest.fn(),
+  }),
+}));
+
+jest.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+jest.mock("@/app/hooks/useChats", () => ({
+  useChats: () => ({
+    results: [],
+    status: "Exhausted",
+    loadMore: jest.fn(),
+    isLoading: false,
+  }),
+}));
+
+describe("MessageSearchDialog", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("uses one-shot search and clears it when the dialog closes", async () => {
+    const query = useConvex().query as jest.Mock;
+    query.mockResolvedValue({ page: [], isDone: true, continueCursor: "" });
+
+    const { rerender } = render(
+      <MessageSearchDialog isOpen={true} onClose={jest.fn()} />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Search messages..."), {
+      target: { value: "billing" },
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => {
+      expect(query).toHaveBeenCalledTimes(1);
+    });
+    expect(query).toHaveBeenCalledWith("messages.searchMessages", {
+      searchQuery: "billing",
+      paginationOpts: { numItems: 20, cursor: null },
+    });
+
+    rerender(<MessageSearchDialog isOpen={false} onClose={jest.fn()} />);
+    rerender(<MessageSearchDialog isOpen={true} onClose={jest.fn()} />);
+
+    expect(screen.getByPlaceholderText("Search messages...")).toHaveValue("");
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/__tests__/MessageSearchDialog.test.tsx
+++ b/app/components/__tests__/MessageSearchDialog.test.tsx
@@ -43,12 +43,30 @@ jest.mock("@/app/hooks/useChats", () => ({
   }),
 }));
 
+const originalIntersectionObserver = global.IntersectionObserver;
+
+const makeSearchResult = (id: string, content: string) => ({
+  id,
+  chat_id: `chat-${id}`,
+  content,
+  created_at: Date.now(),
+  match_type: "message" as const,
+});
+
+const runDebounce = async () => {
+  await act(async () => {
+    jest.advanceTimersByTime(300);
+  });
+};
+
 describe("MessageSearchDialog", () => {
   beforeEach(() => {
     jest.useFakeTimers();
+    (useConvex().query as jest.Mock).mockReset();
   });
 
   afterEach(() => {
+    global.IntersectionObserver = originalIntersectionObserver;
     jest.useRealTimers();
   });
 
@@ -63,9 +81,7 @@ describe("MessageSearchDialog", () => {
     fireEvent.change(screen.getByPlaceholderText("Search messages..."), {
       target: { value: "billing" },
     });
-    await act(async () => {
-      jest.advanceTimersByTime(300);
-    });
+    await runDebounce();
 
     await waitFor(() => {
       expect(query).toHaveBeenCalledTimes(1);
@@ -79,9 +95,126 @@ describe("MessageSearchDialog", () => {
     rerender(<MessageSearchDialog isOpen={true} onClose={jest.fn()} />);
 
     expect(screen.getByPlaceholderText("Search messages...")).toHaveValue("");
-    await act(async () => {
-      jest.advanceTimersByTime(300);
-    });
+    await runDebounce();
     expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores stale results when the query changes", async () => {
+    const query = useConvex().query as jest.Mock;
+    let resolveFirstSearch!: (value: {
+      page: ReturnType<typeof makeSearchResult>[];
+      isDone: boolean;
+      continueCursor: string;
+    }) => void;
+    const firstSearch = new Promise<{
+      page: ReturnType<typeof makeSearchResult>[];
+      isDone: boolean;
+      continueCursor: string;
+    }>((resolve) => {
+      resolveFirstSearch = resolve;
+    });
+
+    query
+      .mockImplementationOnce(() => firstSearch)
+      .mockResolvedValueOnce({
+        page: [makeSearchResult("new", "new result")],
+        isDone: true,
+        continueCursor: "",
+      });
+
+    render(<MessageSearchDialog isOpen={true} onClose={jest.fn()} />);
+    const input = screen.getByPlaceholderText("Search messages...");
+
+    fireEvent.change(input, { target: { value: "first" } });
+    await runDebounce();
+    await waitFor(() => expect(query).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(input, { target: { value: "second" } });
+    await runDebounce();
+    await waitFor(() => expect(screen.getByText("new result")).toBeVisible());
+
+    await act(async () => {
+      resolveFirstSearch({
+        page: [makeSearchResult("stale", "stale result")],
+        isDone: true,
+        continueCursor: "",
+      });
+    });
+
+    expect(screen.queryByText("stale result")).not.toBeInTheDocument();
+    expect(screen.getByText("new result")).toBeVisible();
+  });
+
+  it("shows a search error instead of an empty-results state", async () => {
+    const query = useConvex().query as jest.Mock;
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    query.mockRejectedValueOnce(new Error("search unavailable"));
+
+    render(<MessageSearchDialog isOpen={true} onClose={jest.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText("Search messages..."), {
+      target: { value: "billing" },
+    });
+    await runDebounce();
+
+    await waitFor(() =>
+      expect(screen.getByText("Search failed")).toBeVisible(),
+    );
+    expect(screen.queryByText("No messages found")).not.toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  it("reports pagination failures without discarding existing results", async () => {
+    let intersectionCallback: IntersectionObserverCallback | undefined;
+    global.IntersectionObserver = jest.fn(
+      (callback: IntersectionObserverCallback) => {
+        intersectionCallback = callback;
+        return {
+          disconnect: jest.fn(),
+          observe: jest.fn(),
+          unobserve: jest.fn(),
+        } as unknown as IntersectionObserver;
+      },
+    ) as unknown as typeof IntersectionObserver;
+
+    const query = useConvex().query as jest.Mock;
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    query
+      .mockResolvedValueOnce({
+        page: [makeSearchResult("first", "first result")],
+        isDone: false,
+        continueCursor: "next-page",
+      })
+      .mockRejectedValueOnce(new Error("pagination unavailable"));
+
+    render(<MessageSearchDialog isOpen={true} onClose={jest.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText("Search messages..."), {
+      target: { value: "billing" },
+    });
+    await runDebounce();
+    await waitFor(() => expect(screen.getByText("first result")).toBeVisible());
+    expect(intersectionCallback).toBeDefined();
+
+    await act(async () => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    await waitFor(() => {
+      expect(query).toHaveBeenLastCalledWith("messages.searchMessages", {
+        searchQuery: "billing",
+        paginationOpts: { numItems: 10, cursor: "next-page" },
+      });
+      expect(
+        screen.getByText("Couldn't load more results. Try searching again."),
+      ).toBeVisible();
+    });
+    expect(screen.getByText("first result")).toBeVisible();
+    consoleError.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- replace the reactive message-history search subscription with one-shot Convex queries
- stop and clear message search when the dialog closes
- preserve cursor pagination and add regression coverage for the closed-dialog lifecycle

## Root cause

`MessageSearchDialog` is always mounted. Its previous `usePaginatedQuery` retained the last search and stayed reactively subscribed after the dialog closed. Message writes could therefore re-run the global full-text query in inactive tabs. In production, each uncached execution scanned about 31 query-GB.

## Validation

- `pnpm exec jest app/components/__tests__/MessageSearchDialog.test.tsx --runInBand`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint app/components/MessageSearchDialog.tsx app/components/__tests__/MessageSearchDialog.test.tsx`
- `pnpm exec prettier --check app/components/MessageSearchDialog.tsx app/components/__tests__/MessageSearchDialog.test.tsx`
- full pre-commit Jest suite: 292 suites / 2,874 tests passed
- authenticated browser smoke test: search results rendered; close/reopen cleared the input; no framework overlay or console errors

## Manual verification

1. Open **Search tasks** from the authenticated sidebar.
2. Enter at least three characters and confirm matching messages appear.
3. Close and reopen the dialog.

Expected: the previous query is cleared, and the closed dialog does not retain a reactive search subscription.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message search loading and infinite scrolling pagination for more consistent results.
  * Prevented stale results from showing after a newer search is started.
  * Added clearer error states for initial search failures and pagination failures.
  * Reset the search input when closing the dialog to avoid unintended restarts.
* **Tests**
  * Added comprehensive test coverage for debounced search, pagination requests, error handling, and search reset behavior (including infinite-scroll behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->