### PR TITLE
Instrument Agent completion signals

### DIFF
--- a/lib/analytics/__tests__/agent-completion-signals.test.ts
+++ b/lib/analytics/__tests__/agent-completion-signals.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  buildAgentCompletionSignals,
+  createAgentCompletionSignalTracker,
+  recordAgentStepCompletion,
+  recordHandledToolFailure,
+} from "../agent-completion-signals";
+
+describe("agent completion signals", () => {
+  it("tracks steps and failure proximity without retaining tool content", () => {
+    const tracker = createAgentCompletionSignalTracker();
+
+    recordHandledToolFailure(tracker);
+    recordAgentStepCompletion(tracker, [
+      { type: "tool-error", error: "SECRET_TOOL_ERROR" },
+      { type: "text", text: "SECRET_ASSISTANT_TEXT" },
+    ]);
+    recordAgentStepCompletion(tracker, [{ type: "text", text: "done" }]);
+
+    expect(tracker).toEqual({
+      stepCount: 2,
+      handledToolFailureCount: 1,
+      sdkToolErrorCount: 1,
+      handledToolFailurePendingStep: false,
+      stepsSinceLastToolFailure: 1,
+    });
+    expect(JSON.stringify(tracker)).not.toContain("SECRET");
+  });
+
+  it("builds content-free signals for a suspicious natural stop", () => {
+    const tracker = createAgentCompletionSignalTracker();
+    recordHandledToolFailure(tracker);
+    recordAgentStepCompletion(tracker, []);
+    recordAgentStepCompletion(tracker, []);
+
+    const signals = buildAgentCompletionSignals({
+      outcome: "success",
+      finishReason: "stop",
+      todos: [
+        {
+          id: "todo-1",
+          content: "SECRET_PENDING_TODO",
+          status: "pending",
+        },
+        {
+          id: "todo-2",
+          content: "SECRET_ACTIVE_TODO",
+          status: "in_progress",
+        },
+        {
+          id: "todo-3",
+          content: "SECRET_COMPLETED_TODO",
+          status: "completed",
+        },
+      ],
+      tracker,
+    });
+
+    expect(signals).toEqual({
+      version: 1,
+      naturalStop: true,
+      stepCount: 2,
+      todoTotalCount: 3,
+      todoPendingCount: 1,
+      todoInProgressCount: 1,
+      hasUnfinishedTodos: true,
+      handledToolFailureCount: 1,
+      sdkToolErrorCount: 0,
+      hasToolFailure: true,
+      recentToolFailure: true,
+      stepsSinceLastToolFailure: 1,
+    });
+    expect(JSON.stringify(signals)).not.toContain("SECRET");
+  });
+
+  it("does not classify limits or aborts as natural stops", () => {
+    const tracker = createAgentCompletionSignalTracker();
+
+    expect(
+      buildAgentCompletionSignals({
+        outcome: "success",
+        finishReason: "tool-calls",
+        todos: [],
+        tracker,
+      }).naturalStop,
+    ).toBe(false);
+    expect(
+      buildAgentCompletionSignals({
+        outcome: "aborted",
+        finishReason: "stop",
+        todos: [],
+        tracker,
+      }).naturalStop,
+    ).toBe(false);
+  });
+});

--- a/lib/analytics/agent-completion-signals.ts
+++ b/lib/analytics/agent-completion-signals.ts
@@ -1,0 +1,106 @@
+import type { Todo } from "@/types";
+
+export const AGENT_COMPLETION_SIGNAL_VERSION = 1;
+
+export type AgentCompletionSignalTracker = {
+  stepCount: number;
+  handledToolFailureCount: number;
+  sdkToolErrorCount: number;
+  handledToolFailurePendingStep: boolean;
+  stepsSinceLastToolFailure?: number;
+};
+
+export type AgentCompletionSignals = {
+  version: typeof AGENT_COMPLETION_SIGNAL_VERSION;
+  naturalStop: boolean;
+  stepCount: number;
+  todoTotalCount: number;
+  todoPendingCount: number;
+  todoInProgressCount: number;
+  hasUnfinishedTodos: boolean;
+  handledToolFailureCount: number;
+  sdkToolErrorCount: number;
+  hasToolFailure: boolean;
+  recentToolFailure: boolean;
+  stepsSinceLastToolFailure?: number;
+};
+
+export const createAgentCompletionSignalTracker =
+  (): AgentCompletionSignalTracker => ({
+    stepCount: 0,
+    handledToolFailureCount: 0,
+    sdkToolErrorCount: 0,
+    handledToolFailurePendingStep: false,
+    stepsSinceLastToolFailure: undefined,
+  });
+
+/** Record a handled tool failure without retaining the tool name or payload. */
+export const recordHandledToolFailure = (
+  tracker: AgentCompletionSignalTracker,
+): void => {
+  tracker.handledToolFailureCount += 1;
+  tracker.handledToolFailurePendingStep = true;
+};
+
+/** Record one model step and count only AI SDK tool-error part types. */
+export const recordAgentStepCompletion = (
+  tracker: AgentCompletionSignalTracker,
+  content: unknown,
+): void => {
+  tracker.stepCount += 1;
+
+  const sdkToolErrors = Array.isArray(content)
+    ? content.filter(
+        (part) =>
+          typeof part === "object" &&
+          part !== null &&
+          (part as { type?: unknown }).type === "tool-error",
+      ).length
+    : 0;
+  tracker.sdkToolErrorCount += sdkToolErrors;
+
+  if (tracker.handledToolFailurePendingStep || sdkToolErrors > 0) {
+    tracker.stepsSinceLastToolFailure = 0;
+  } else if (tracker.stepsSinceLastToolFailure !== undefined) {
+    tracker.stepsSinceLastToolFailure += 1;
+  }
+  tracker.handledToolFailurePendingStep = false;
+};
+
+export const buildAgentCompletionSignals = ({
+  outcome,
+  finishReason,
+  todos,
+  tracker,
+}: {
+  outcome: "success" | "aborted" | "error";
+  finishReason?: string;
+  todos: Todo[];
+  tracker: AgentCompletionSignalTracker;
+}): AgentCompletionSignals => {
+  const todoPendingCount = todos.filter(
+    (todo) => todo.status === "pending",
+  ).length;
+  const todoInProgressCount = todos.filter(
+    (todo) => todo.status === "in_progress",
+  ).length;
+  const hasToolFailure =
+    tracker.handledToolFailureCount + tracker.sdkToolErrorCount > 0;
+
+  return {
+    version: AGENT_COMPLETION_SIGNAL_VERSION,
+    naturalStop: outcome === "success" && finishReason === "stop",
+    stepCount: tracker.stepCount,
+    todoTotalCount: todos.length,
+    todoPendingCount,
+    todoInProgressCount,
+    hasUnfinishedTodos: todoPendingCount + todoInProgressCount > 0,
+    handledToolFailureCount: tracker.handledToolFailureCount,
+    sdkToolErrorCount: tracker.sdkToolErrorCount,
+    hasToolFailure,
+    recentToolFailure:
+      tracker.stepsSinceLastToolFailure !== undefined &&
+      tracker.stepsSinceLastToolFailure <= 1,
+    stepsSinceLastToolFailure: tracker.stepsSinceLastToolFailure,
+  };
+};

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1292,7 +1292,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
 
   test("agent stream applies per-step OpenRouter metadata cost before budget checks", () => {
     const onStepFinishIdx = agentStreamRunnerSrc.indexOf(
-      "onStepFinish: async ({ usage, response, providerMetadata }) => {",
+      "onStepFinish: async ({ usage, response, providerMetadata, content }) => {",
     );
     const accumulateIdx = agentStreamRunnerSrc.indexOf(
       "stepUsageCostIndex = ctx.usageTracker.accumulateStep",

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -159,6 +159,56 @@ describe("captureAgentRun", () => {
     );
   });
 
+  it("adds content-free completion signals to the existing run event", () => {
+    const capture = jest.fn();
+
+    captureAgentRun({
+      posthog: { capture } as any,
+      userId: "user_123",
+      mode: "agent",
+      subscription: "pro",
+      sandboxInfo: null,
+      outcome: "success",
+      selectedModel: "agent-model",
+      configuredModelId: "x-ai/grok-4.5",
+      finishReason: "stop",
+      isAutoContinue: false,
+      completionSignals: {
+        version: 1,
+        naturalStop: true,
+        stepCount: 12,
+        todoTotalCount: 3,
+        todoPendingCount: 1,
+        todoInProgressCount: 1,
+        hasUnfinishedTodos: true,
+        handledToolFailureCount: 1,
+        sdkToolErrorCount: 0,
+        hasToolFailure: true,
+        recentToolFailure: true,
+        stepsSinceLastToolFailure: 1,
+      },
+    });
+
+    expect(capture.mock.calls[0][0].properties).toEqual(
+      expect.objectContaining({
+        finish_reason: "stop",
+        is_auto_continue: false,
+        completion_signal_version: 1,
+        natural_stop: true,
+        agent_step_count: 12,
+        todo_total_count: 3,
+        todo_pending_count: 1,
+        todo_in_progress_count: 1,
+        has_unfinished_todos: true,
+        handled_tool_failure_count: 1,
+        sdk_tool_error_count: 0,
+        has_tool_failure: true,
+        recent_tool_failure: true,
+        steps_since_last_tool_failure: 1,
+      }),
+    );
+  });
+
   it("attributes a served fallback without inferring it from model names", () => {
     const capture = jest.fn();
 

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -23,6 +23,10 @@ import {
   type ToolSet,
 } from "ai";
 import {
+  recordAgentStepCompletion,
+  type AgentCompletionSignalTracker,
+} from "@/lib/analytics/agent-completion-signals";
+import {
   buildProviderOptions,
   buildSystemPrompt,
   addCacheBreakpointToLastUserMessage,
@@ -465,6 +469,7 @@ export type AgentStreamContext = {
   ensureSandbox: import("@/lib/chat/summarization").EnsureSandbox;
   chatLogger: ChatLogger | undefined;
   usageRefundTracker: UsageRefundTracker;
+  completionSignalTracker: AgentCompletionSignalTracker;
   onBudgetAbort?: (details: BudgetAbortDetails & { model: string }) => void;
   onModelStreamStart?: () => void;
   onModelStreamFinish?: () => void;
@@ -1179,8 +1184,9 @@ export async function createAgentStream(
       }
     },
 
-    onStepFinish: async ({ usage, response, providerMetadata }) => {
+    onStepFinish: async ({ usage, response, providerMetadata, content }) => {
       ctx.onModelStreamFinish?.();
+      recordAgentStepCompletion(ctx.completionSignalTracker, content);
       let stepUsageCostIndex: number | undefined;
       if (usage) {
         stepUsageCostIndex = ctx.usageTracker.accumulateStep(

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -139,6 +139,11 @@ import { Id } from "@/convex/_generated/dataModel";
 import { phLogger } from "@/lib/posthog/server";
 import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
 import {
+  buildAgentCompletionSignals,
+  createAgentCompletionSignalTracker,
+  recordHandledToolFailure,
+} from "@/lib/analytics/agent-completion-signals";
+import {
   capturePaidDailyFreeAllowanceServerEvent,
   createPaidDailyFreeAllowanceBudgetSnapshot,
   createPaidDailyFreeAllowanceRateLimitInfo,
@@ -622,6 +627,10 @@ export const createChatHandler = () => {
               }),
             });
 
+            const completionSignalTracker =
+              createAgentCompletionSignalTracker();
+            const onToolFailure = () =>
+              recordHandledToolFailure(completionSignalTracker);
             const {
               tools,
               ensureSandbox,
@@ -654,7 +663,7 @@ export const createChatHandler = () => {
                 chatLogger?.setSandboxBoot(info);
               },
               selectedModel,
-              undefined,
+              onToolFailure,
               undefined,
               undefined,
               projectContext.workingDirectory,
@@ -1259,6 +1268,7 @@ export const createChatHandler = () => {
               ensureSandbox,
               chatLogger,
               usageRefundTracker,
+              completionSignalTracker,
               settleUsageAfterStep,
               onBudgetAbort: (details) =>
                 captureAgentBudgetAbort({
@@ -1604,6 +1614,14 @@ export const createChatHandler = () => {
                                       : state.fallbackServed,
                                   finishReason: state.streamFinishReason,
                                   budgetAbortDetails: state.budgetAbortDetails,
+                                  isAutoContinue,
+                                  completionSignals:
+                                    buildAgentCompletionSignals({
+                                      outcome,
+                                      finishReason: state.streamFinishReason,
+                                      todos: getTodoManager().getAllTodos(),
+                                      tracker: completionSignalTracker,
+                                    }),
                                 });
                                 chatLogger!.emitSuccess({
                                   finishReason: state.streamFinishReason,
@@ -1895,6 +1913,13 @@ export const createChatHandler = () => {
                           : state.fallbackServed,
                       finishReason: state.streamFinishReason,
                       budgetAbortDetails: state.budgetAbortDetails,
+                      isAutoContinue,
+                      completionSignals: buildAgentCompletionSignals({
+                        outcome,
+                        finishReason: state.streamFinishReason,
+                        todos: getTodoManager().getAllTodos(),
+                        tracker: completionSignalTracker,
+                      }),
                     });
                     chatLogger!.emitSuccess({
                       finishReason: state.streamFinishReason,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -29,6 +29,7 @@ import {
   PAID_FUNNEL_EVENTS,
   paidFunnelProperties,
 } from "@/lib/analytics/paid-funnel";
+import type { AgentCompletionSignals } from "@/lib/analytics/agent-completion-signals";
 import type { UsageCostRecord } from "@/lib/usage-tracker";
 import type { UsageDeductionResult } from "@/lib/rate-limit";
 import type { BudgetAbortDetails } from "@/lib/chat/budget-monitor";
@@ -1174,6 +1175,8 @@ type AgentCompletionAnalyticsArgs = {
   activeModelStreamDurationMs?: number;
   activeTerminalWaitDurationMs?: number;
   activeSandboxRecoveryDurationMs?: number;
+  isAutoContinue?: boolean;
+  completionSignals?: AgentCompletionSignals;
 };
 
 export function captureAgentRun({
@@ -1198,6 +1201,8 @@ export function captureAgentRun({
   activeModelStreamDurationMs,
   activeTerminalWaitDurationMs,
   activeSandboxRecoveryDurationMs,
+  isAutoContinue,
+  completionSignals,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -1220,6 +1225,8 @@ export function captureAgentRun({
   activeModelStreamDurationMs?: number;
   activeTerminalWaitDurationMs?: number;
   activeSandboxRecoveryDurationMs?: number;
+  isAutoContinue?: boolean;
+  completionSignals?: AgentCompletionSignals;
 }) {
   if (!posthog || mode !== "agent") return;
   posthog.capture({
@@ -1257,6 +1264,9 @@ export function captureAgentRun({
       ...(activeSandboxRecoveryDurationMs !== undefined && {
         active_sandbox_recovery_duration_ms: activeSandboxRecoveryDurationMs,
       }),
+      ...(isAutoContinue !== undefined && {
+        is_auto_continue: isAutoContinue,
+      }),
       ...(responseModel && { response_model: responseModel }),
       ...(responseModel &&
         fallbackServed !== undefined && { fallback_served: fallbackServed }),
@@ -1264,6 +1274,23 @@ export function captureAgentRun({
         sandbox_type: sandboxInfo.type,
       }),
       ...(finishReason && { finish_reason: finishReason }),
+      ...(completionSignals && {
+        completion_signal_version: completionSignals.version,
+        natural_stop: completionSignals.naturalStop,
+        agent_step_count: completionSignals.stepCount,
+        todo_total_count: completionSignals.todoTotalCount,
+        todo_pending_count: completionSignals.todoPendingCount,
+        todo_in_progress_count: completionSignals.todoInProgressCount,
+        has_unfinished_todos: completionSignals.hasUnfinishedTodos,
+        handled_tool_failure_count: completionSignals.handledToolFailureCount,
+        sdk_tool_error_count: completionSignals.sdkToolErrorCount,
+        has_tool_failure: completionSignals.hasToolFailure,
+        recent_tool_failure: completionSignals.recentToolFailure,
+        ...(completionSignals.stepsSinceLastToolFailure !== undefined && {
+          steps_since_last_tool_failure:
+            completionSignals.stepsSinceLastToolFailure,
+        }),
+      }),
       ...(budgetAbortDetails && {
         budget_abort_cap_reason: budgetAbortDetails.capReason,
         budget_abort_billing_stop_reason: budgetAbortDetails.billingStopReason,
@@ -1299,6 +1326,8 @@ export function captureAgentCompletionAnalytics(
     activeModelStreamDurationMs: args.activeModelStreamDurationMs,
     activeTerminalWaitDurationMs: args.activeTerminalWaitDurationMs,
     activeSandboxRecoveryDurationMs: args.activeSandboxRecoveryDurationMs,
+    isAutoContinue: args.isAutoContinue,
+    completionSignals: args.completionSignals,
   });
 }
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -119,6 +119,11 @@ import {
 import { phLogger } from "@/lib/posthog/server";
 import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
 import {
+  buildAgentCompletionSignals,
+  createAgentCompletionSignalTracker,
+  recordHandledToolFailure,
+} from "@/lib/analytics/agent-completion-signals";
+import {
   capturePaidDailyFreeAllowanceServerEvent,
   createPaidDailyFreeAllowanceBudgetSnapshot,
   createPaidDailyFreeAllowanceRateLimitInfo,
@@ -2030,8 +2035,11 @@ export const agentLongTask = task({
               }),
             });
 
+            const completionSignalTracker =
+              createAgentCompletionSignalTracker();
             let handledToolFailureCount = 0;
             const onToolFailure = (failure: ToolFailureLogEvent) => {
+              recordHandledToolFailure(completionSignalTracker);
               handledToolFailureCount += 1;
               void recordAgentLongHandledToolFailureForDashboard(failure, {
                 chatId,
@@ -2795,6 +2803,7 @@ export const agentLongTask = task({
               ensureSandbox,
               chatLogger,
               usageRefundTracker,
+              completionSignalTracker,
               onModelStreamStart: runTimingTracker.startModelStream,
               onModelStreamFinish: runTimingTracker.finishModelStream,
               settleUsageAfterStep,
@@ -3133,6 +3142,14 @@ export const agentLongTask = task({
                                     budgetAbortDetails:
                                       state.budgetAbortDetails,
                                     agentPermissionMode,
+                                    isAutoContinue,
+                                    completionSignals:
+                                      buildAgentCompletionSignals({
+                                        outcome,
+                                        finishReason: state.streamFinishReason,
+                                        todos: getTodoManager().getAllTodos(),
+                                        tracker: completionSignalTracker,
+                                      }),
                                     ...getTriggerRunTelemetry(),
                                   });
                                   if (!isTerminalProviderStreamError(state)) {
@@ -3284,6 +3301,13 @@ export const agentLongTask = task({
                         finishReason: state.streamFinishReason,
                         budgetAbortDetails: state.budgetAbortDetails,
                         agentPermissionMode,
+                        isAutoContinue,
+                        completionSignals: buildAgentCompletionSignals({
+                          outcome,
+                          finishReason: state.streamFinishReason,
+                          todos: getTodoManager().getAllTodos(),
+                          tracker: completionSignalTracker,
+                        }),
                         ...getTriggerRunTelemetry(),
                       });
                       if (!isTerminalProviderStreamError(state)) {


### PR DESCRIPTION
## Summary

- extend the existing `hackerai-agent_run` event with versioned, content-free Agent completion signals
- track per-request model step count, todo status counts, handled/SDK tool-failure counts, and distance from the latest tool failure
- distinguish a natural successful `stop` from limits, errors, and aborts
- record whether the request itself was an automatic continuation
- cover both the Next.js Agent path and the Trigger.dev long-running Agent path through the shared stream runner

## Privacy

The new properties contain counts and booleans only. They do not include prompts, todo text, tool names, tool inputs, tool outputs, errors, code, targets, findings, or evidence.

## Why

This gives us a baseline for deciding whether premature natural stops justify a narrowly scoped one-shot stop veto. It does not change Agent behavior.

## Validation

- full pre-commit suite: 292 suites / 2,874 tests passed
- `pnpm typecheck`
- targeted ESLint and Prettier checks
- focused completion-signal, analytics, shared-runner, and Trigger contract tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added completion analytics for agent runs, including step counts, todo progress, stop reasons, and tool-failure indicators.
  * Completion data is captured consistently for primary and retry runs.
  * Added support for identifying natural stops and recent tool failures.

* **Privacy**
  * Sensitive tool-content values are excluded from serialized completion data.

* **Tests**
  * Added coverage for completion signals, failure tracking, stop conditions, and analytics event recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->