### PR TITLE
Add HAC-45 Ask-to-Agent approval experiment

### DIFF
--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -7,11 +7,17 @@ jest.mock("@workos-inc/authkit-nextjs/components", () => ({
 
 jest.mock("../contexts/GlobalState", () => ({
   useGlobalState: jest.fn(() => ({
+    agentPermissionMode: "full_access",
+    chatMode: "ask",
+    setAgentPermissionMode: jest.fn(),
+    setChatMode: jest.fn(),
     subscription: "pro",
+    temporaryChatsEnabled: false,
   })),
 }));
 
 jest.mock("@/lib/analytics/client", () => ({
+  captureAuthenticatedEvent: jest.fn(() => true),
   getPostHogClient: jest.fn(() => null),
   loadPostHogClient: jest.fn(),
 }));
@@ -22,13 +28,18 @@ process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://us.i.posthog.com";
 const { useAuth } = jest.requireMock<
   typeof import("@workos-inc/authkit-nextjs/components")
 >("@workos-inc/authkit-nextjs/components");
-const { loadPostHogClient } = jest.requireMock<
+const { useGlobalState } = jest.requireMock<
+  typeof import("../contexts/GlobalState")
+>("../contexts/GlobalState");
+const { captureAuthenticatedEvent, loadPostHogClient } = jest.requireMock<
   typeof import("@/lib/analytics/client")
 >("@/lib/analytics/client");
 const { PostHogProvider } =
   require("../providers") as typeof import("../providers");
 
 const mockUseAuth = useAuth as jest.Mock;
+const mockUseGlobalState = useGlobalState as jest.Mock;
+const mockCaptureAuthenticatedEvent = captureAuthenticatedEvent as jest.Mock;
 const mockLoadPostHogClient = loadPostHogClient as jest.Mock;
 
 describe("PostHogProvider", () => {
@@ -36,6 +47,17 @@ describe("PostHogProvider", () => {
     jest.clearAllMocks();
     process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
     process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://us.i.posthog.com";
+    window.localStorage.clear();
+
+    mockUseGlobalState.mockReturnValue({
+      agentPermissionMode: "full_access",
+      chatMode: "ask",
+      setAgentPermissionMode: jest.fn(),
+      setChatMode: jest.fn(),
+      subscription: "pro",
+      temporaryChatsEnabled: false,
+    });
+    mockCaptureAuthenticatedEvent.mockReturnValue(true);
 
     mockUseAuth.mockReturnValue({
       user: {
@@ -55,6 +77,8 @@ describe("PostHogProvider", () => {
       opt_in_capturing: jest.fn(),
       has_opted_out_capturing: jest.fn(() => true),
       identify: jest.fn(),
+      isFeatureEnabled: jest.fn(() => false),
+      onFeatureFlags: jest.fn(() => jest.fn()),
       sessionRecordingStarted: jest.fn(() => false),
       startSessionRecording: jest.fn(),
       stopSessionRecording: jest.fn(),
@@ -97,6 +121,8 @@ describe("PostHogProvider", () => {
       opt_in_capturing: jest.fn(),
       has_opted_out_capturing: jest.fn(() => false),
       identify: jest.fn(),
+      isFeatureEnabled: jest.fn(() => false),
+      onFeatureFlags: jest.fn(() => jest.fn()),
       sessionRecordingStarted: jest.fn(() => false),
       startSessionRecording: jest.fn(),
       stopSessionRecording: jest.fn(),
@@ -123,6 +149,61 @@ describe("PostHogProvider", () => {
           capture_console_errors: false,
         },
       }),
+    );
+  });
+
+  it("applies the HAC-45 treatment only after the selected flag evaluates", async () => {
+    const setAgentPermissionMode = jest.fn();
+    const setChatMode = jest.fn();
+    mockUseGlobalState.mockReturnValue({
+      agentPermissionMode: "full_access",
+      chatMode: "ask",
+      setAgentPermissionMode,
+      setChatMode,
+      subscription: "pro",
+      temporaryChatsEnabled: false,
+    });
+
+    const posthog = {
+      __loaded: true,
+      init: jest.fn(),
+      set_config: jest.fn(),
+      opt_in_capturing: jest.fn(),
+      has_opted_out_capturing: jest.fn(() => false),
+      identify: jest.fn(),
+      isFeatureEnabled: jest.fn(() => true),
+      onFeatureFlags: jest.fn((callback: () => void) => {
+        callback();
+        return jest.fn();
+      }),
+      sessionRecordingStarted: jest.fn(() => false),
+      startSessionRecording: jest.fn(),
+      stopSessionRecording: jest.fn(),
+      reset: jest.fn(),
+      opt_out_capturing: jest.fn(),
+    };
+    mockLoadPostHogClient.mockResolvedValue(posthog);
+
+    render(
+      <PostHogProvider>
+        <div>child</div>
+      </PostHogProvider>,
+    );
+
+    await waitFor(() => {
+      expect(setAgentPermissionMode).toHaveBeenCalledWith("ask_approval");
+      expect(setChatMode).toHaveBeenCalledWith("agent");
+    });
+    expect(posthog.isFeatureEnabled).toHaveBeenCalledWith(
+      "hac45-ask-to-agent-approval-v1",
+    );
+    expect(mockCaptureAuthenticatedEvent).toHaveBeenCalledWith(
+      "ask_to_agent_approval_experiment_exposed",
+      expect.objectContaining({
+        previous_chat_mode: "ask",
+        previous_agent_permission_mode: "full_access",
+      }),
+      { uuid: expect.any(String) },
     );
   });
 });

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -8,12 +8,27 @@ import {
   enrichFrontendExceptionEvent,
   shouldDropExpectedFrontendException,
 } from "@/lib/posthog/expected-frontend-exceptions";
-import { getPostHogClient, loadPostHogClient } from "@/lib/analytics/client";
+import {
+  captureAuthenticatedEvent,
+  getPostHogClient,
+  loadPostHogClient,
+} from "@/lib/analytics/client";
+import {
+  applyAskToAgentApprovalExperiment,
+  ASK_TO_AGENT_APPROVAL_FLAG_KEY,
+} from "@/lib/experiments/ask-to-agent-approval";
 
 let lastIdentifiedSignature: string | null = null;
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
-  const { subscription } = useGlobalState();
+  const {
+    agentPermissionMode,
+    chatMode,
+    setAgentPermissionMode,
+    setChatMode,
+    subscription,
+    temporaryChatsEnabled,
+  } = useGlobalState();
   const { user } = useAuth();
   const userId = user?.id;
   const userEmail = user?.email;
@@ -108,6 +123,49 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       cancelled = true;
     };
   }, [subscription, userEmail, userFirstName, userId, userLastName]);
+
+  useEffect(() => {
+    if (!process.env.NEXT_PUBLIC_POSTHOG_KEY || !userId) return;
+
+    let cancelled = false;
+    let unsubscribeFeatureFlags: (() => void) | undefined;
+
+    void loadPostHogClient()
+      .then((posthog) => {
+        if (cancelled || !posthog.__loaded) return;
+
+        unsubscribeFeatureFlags = posthog.onFeatureFlags(() => {
+          if (cancelled) return;
+
+          applyAskToAgentApprovalExperiment({
+            agentPermissionMode,
+            captureExposure: captureAuthenticatedEvent,
+            chatMode,
+            enabled:
+              posthog.isFeatureEnabled(ASK_TO_AGENT_APPROVAL_FLAG_KEY) === true,
+            setAgentPermissionMode,
+            setChatMode,
+            subscription,
+            temporaryChatsEnabled,
+            userId,
+          });
+        });
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+      unsubscribeFeatureFlags?.();
+    };
+  }, [
+    agentPermissionMode,
+    chatMode,
+    setAgentPermissionMode,
+    setChatMode,
+    subscription,
+    temporaryChatsEnabled,
+    userId,
+  ]);
 
   return <>{children}</>;
 }

--- a/lib/experiments/__tests__/ask-to-agent-approval.test.ts
+++ b/lib/experiments/__tests__/ask-to-agent-approval.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  applyAskToAgentApprovalExperiment,
+  ASK_TO_AGENT_APPROVAL_EXPERIMENT_KEY,
+  ASK_TO_AGENT_APPROVAL_EXPOSURE_EVENT,
+  ASK_TO_AGENT_APPROVAL_FLAG_KEY,
+  hasAskToAgentApprovalExposure,
+} from "../ask-to-agent-approval";
+
+describe("applyAskToAgentApprovalExperiment", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("records exposure before moving a paid cohort user to Agent with approval", () => {
+    const captureExposure = jest.fn(() => true);
+    const setAgentPermissionMode = jest.fn();
+    const setChatMode = jest.fn();
+
+    const applied = applyAskToAgentApprovalExperiment({
+      agentPermissionMode: "full_access",
+      captureExposure,
+      chatMode: "ask",
+      enabled: true,
+      now: () => new Date("2026-07-22T14:00:00.000Z"),
+      setAgentPermissionMode,
+      setChatMode,
+      subscription: "pro",
+      temporaryChatsEnabled: false,
+      userId: "user-123",
+    });
+
+    expect(applied).toBe(true);
+    expect(captureExposure).toHaveBeenCalledWith(
+      ASK_TO_AGENT_APPROVAL_EXPOSURE_EVENT,
+      expect.objectContaining({
+        experiment_key: ASK_TO_AGENT_APPROVAL_EXPERIMENT_KEY,
+        feature_flag_key: ASK_TO_AGENT_APPROVAL_FLAG_KEY,
+        variant: "agent_ask_approval",
+        previous_chat_mode: "ask",
+        previous_agent_permission_mode: "full_access",
+        mode: "agent",
+        agent_permission_mode: "ask_approval",
+        eligible_user_denominator: 452,
+        cohort_user_count: 113,
+        rollout_percentage: 25,
+        $set_once: {
+          ask_to_agent_approval_experiment_variant: "agent_ask_approval",
+          ask_to_agent_approval_experiment_exposed_at:
+            "2026-07-22T14:00:00.000Z",
+        },
+      }),
+      { uuid: expect.any(String) },
+    );
+    expect(setAgentPermissionMode).toHaveBeenCalledWith("ask_approval");
+    expect(setChatMode).toHaveBeenCalledWith("agent");
+    expect(hasAskToAgentApprovalExposure("user-123")).toBe(true);
+  });
+
+  it("does not change behavior unless the exposure event can be queued", () => {
+    const setAgentPermissionMode = jest.fn();
+    const setChatMode = jest.fn();
+
+    const applied = applyAskToAgentApprovalExperiment({
+      agentPermissionMode: "full_access",
+      captureExposure: jest.fn(() => false),
+      chatMode: "ask",
+      enabled: true,
+      setAgentPermissionMode,
+      setChatMode,
+      subscription: "ultra",
+      temporaryChatsEnabled: false,
+      userId: "user-123",
+    });
+
+    expect(applied).toBe(false);
+    expect(setAgentPermissionMode).not.toHaveBeenCalled();
+    expect(setChatMode).not.toHaveBeenCalled();
+    expect(hasAskToAgentApprovalExposure("user-123")).toBe(false);
+  });
+
+  it("applies only once so users can return to Ask without being forced back", () => {
+    const captureExposure = jest.fn(() => true);
+    const setAgentPermissionMode = jest.fn();
+    const setChatMode = jest.fn();
+    const base = {
+      captureExposure,
+      enabled: true,
+      setAgentPermissionMode,
+      setChatMode,
+      subscription: "pro-plus" as const,
+      temporaryChatsEnabled: false,
+      userId: "user-123",
+    };
+
+    expect(
+      applyAskToAgentApprovalExperiment({
+        ...base,
+        agentPermissionMode: "full_access",
+        chatMode: "ask",
+      }),
+    ).toBe(true);
+
+    setAgentPermissionMode.mockClear();
+    setChatMode.mockClear();
+
+    expect(
+      applyAskToAgentApprovalExperiment({
+        ...base,
+        agentPermissionMode: "ask_approval",
+        chatMode: "ask",
+      }),
+    ).toBe(false);
+    expect(captureExposure).toHaveBeenCalledTimes(1);
+    expect(setAgentPermissionMode).not.toHaveBeenCalled();
+    expect(setChatMode).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { enabled: false, subscription: "pro" as const, temporary: false },
+    { enabled: true, subscription: "free" as const, temporary: false },
+    { enabled: true, subscription: "ultra" as const, temporary: true },
+  ])(
+    "skips users outside the live paid non-temporary exposure path",
+    ({ enabled, subscription, temporary }) => {
+      const captureExposure = jest.fn(() => true);
+
+      expect(
+        applyAskToAgentApprovalExperiment({
+          agentPermissionMode: "full_access",
+          captureExposure,
+          chatMode: "ask",
+          enabled,
+          setAgentPermissionMode: jest.fn(),
+          setChatMode: jest.fn(),
+          subscription,
+          temporaryChatsEnabled: temporary,
+          userId: "user-123",
+        }),
+      ).toBe(false);
+      expect(captureExposure).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/lib/experiments/ask-to-agent-approval.ts
+++ b/lib/experiments/ask-to-agent-approval.ts
@@ -1,0 +1,131 @@
+import { v5 as uuidv5 } from "uuid";
+import type {
+  AgentPermissionMode,
+  ChatMode,
+  SubscriptionTier,
+} from "@/types/chat";
+
+export const ASK_TO_AGENT_APPROVAL_FLAG_KEY = "hac45-ask-to-agent-approval-v1";
+export const ASK_TO_AGENT_APPROVAL_EXPERIMENT_KEY =
+  "hac45_ask_to_agent_approval_v1";
+export const ASK_TO_AGENT_APPROVAL_EXPOSURE_EVENT =
+  "ask_to_agent_approval_experiment_exposed";
+
+export const ASK_TO_AGENT_APPROVAL_ELIGIBILITY_WINDOW = {
+  start: "2026-07-14T02:08:00.000Z",
+  end: "2026-07-21T02:08:00.000Z",
+  eligibleUsers: 452,
+  cohortUsers: 113,
+  rolloutPercentage: 25,
+} as const;
+
+const EXPOSURE_STORAGE_PREFIX = "hackerai:hac45-ask-agent-exposure:v1";
+
+type CaptureExposure = (
+  event: string,
+  properties: Record<string, unknown>,
+  options: { uuid: string },
+) => boolean;
+
+type ApplyAskToAgentApprovalExperimentArgs = {
+  agentPermissionMode: AgentPermissionMode;
+  captureExposure: CaptureExposure;
+  chatMode: ChatMode;
+  enabled: boolean;
+  now?: () => Date;
+  setAgentPermissionMode: (mode: AgentPermissionMode) => void;
+  setChatMode: (mode: ChatMode) => void;
+  subscription: SubscriptionTier;
+  temporaryChatsEnabled: boolean;
+  userId: string;
+};
+
+const exposureStorageKey = (userId: string) =>
+  `${EXPOSURE_STORAGE_PREFIX}:${uuidv5(userId, uuidv5.URL)}`;
+
+export function hasAskToAgentApprovalExposure(userId: string): boolean {
+  if (typeof window === "undefined") return false;
+
+  try {
+    return window.localStorage.getItem(exposureStorageKey(userId)) !== null;
+  } catch {
+    return false;
+  }
+}
+
+function rememberAskToAgentApprovalExposure(
+  userId: string,
+  exposedAt: string,
+): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(exposureStorageKey(userId), exposedAt);
+  } catch {
+    // The deterministic event UUID still deduplicates repeated exposure
+    // captures when storage is unavailable.
+  }
+}
+
+export function applyAskToAgentApprovalExperiment({
+  agentPermissionMode,
+  captureExposure,
+  chatMode,
+  enabled,
+  now = () => new Date(),
+  setAgentPermissionMode,
+  setChatMode,
+  subscription,
+  temporaryChatsEnabled,
+  userId,
+}: ApplyAskToAgentApprovalExperimentArgs): boolean {
+  if (
+    !enabled ||
+    subscription === "free" ||
+    temporaryChatsEnabled ||
+    hasAskToAgentApprovalExposure(userId)
+  ) {
+    return false;
+  }
+
+  const exposedAt = now().toISOString();
+  const captured = captureExposure(
+    ASK_TO_AGENT_APPROVAL_EXPOSURE_EVENT,
+    {
+      experiment_key: ASK_TO_AGENT_APPROVAL_EXPERIMENT_KEY,
+      feature_flag_key: ASK_TO_AGENT_APPROVAL_FLAG_KEY,
+      variant: "agent_ask_approval",
+      exposure_event_version: 1,
+      exposure_surface: "global_state",
+      previous_chat_mode: chatMode,
+      previous_agent_permission_mode: agentPermissionMode,
+      mode: "agent",
+      agent_permission_mode: "ask_approval",
+      subscription,
+      eligibility_window_start: ASK_TO_AGENT_APPROVAL_ELIGIBILITY_WINDOW.start,
+      eligibility_window_end: ASK_TO_AGENT_APPROVAL_ELIGIBILITY_WINDOW.end,
+      eligible_user_denominator:
+        ASK_TO_AGENT_APPROVAL_ELIGIBILITY_WINDOW.eligibleUsers,
+      cohort_user_count: ASK_TO_AGENT_APPROVAL_ELIGIBILITY_WINDOW.cohortUsers,
+      rollout_percentage:
+        ASK_TO_AGENT_APPROVAL_ELIGIBILITY_WINDOW.rolloutPercentage,
+      $set_once: {
+        ask_to_agent_approval_experiment_variant: "agent_ask_approval",
+        ask_to_agent_approval_experiment_exposed_at: exposedAt,
+      },
+    },
+    {
+      uuid: uuidv5(
+        `${ASK_TO_AGENT_APPROVAL_EXPERIMENT_KEY}:${userId}`,
+        uuidv5.URL,
+      ),
+    },
+  );
+
+  if (!captured) return false;
+
+  rememberAskToAgentApprovalExposure(userId, exposedAt);
+  setAgentPermissionMode("ask_approval");
+  setChatMode("agent");
+  return true;
+}


### PR DESCRIPTION
## Summary

- add the disabled-by-default HAC-45 treatment path behind `hac45-ask-to-agent-approval-v1`
- move eligible flagged paid users from Ask to Agent with Ask for approval
- emit one deterministic `ask_to_agent_approval_experiment_exposed` event before applying the behavior
- preserve Ask mode and the permission selector as escape paths
- encode the frozen 452-user denominator and exact 113-user (25%) cohort metadata

The exact cohort is stored privately in PostHog flag 775675 and is not present in this repository. The flag remains disabled until this PR reaches production and the deployment is verified.

Linear: [HAC-45](https://linear.app/hackerai/issue/HAC-45/start-25percent-ask-to-agent-approval-experiment-after-7-day-baseline)

## Validation

- `pnpm exec jest app/__tests__/providers.test.tsx lib/experiments/__tests__/ask-to-agent-approval.test.ts --runInBand`
- `pnpm typecheck`
- targeted ESLint
- targeted Prettier check
- `git diff --check`

## Manual verification after deployment

1. Confirm PostHog flag 775675 is still disabled before validation.
2. Verify a non-cohort paid user remains in their existing mode.
3. Enable the flag only after the production deployment is ready.
4. Verify one selected paid user is moved to Agent with Ask for approval, never Full access.
5. Confirm the exposure event is captured once and returning to Ask is not immediately overridden.
6. Disable the flag immediately if the exposure path or permission state is incorrect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an experiment that enables “Ask for approval” agent permissions and Agent chat mode for eligible users.
  * Experiment exposure is tracked and applied only once per user.

* **Bug Fixes**
  * Ensured settings are updated only after feature flags are evaluated and exposure is successfully recorded.

* **Tests**
  * Added coverage for eligibility, exposure tracking, repeat prevention, and provider integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->