### PR TITLE
Fix refund balance races and redact attachment paths

### DIFF
--- a/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
+++ b/lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts
@@ -1438,12 +1438,13 @@ describe("CentrifugoSandbox", () => {
       );
     });
 
-    it("redacts signed URL queries from direct download failures", async () => {
+    it("redacts source and destination paths from direct download failures", async () => {
       const { sandbox } = createWindowsBashSandbox();
       const signedUrl =
-        "https://storage.example.com/image.png?X-Amz-Credential=" +
+        "https://storage.example.com/opaque-object/private-image.png?X-Amz-Credential=" +
         "a".repeat(160) +
         "&X-Amz-Signature=secret";
+      const localPath = "/tmp/hackerai-upload/private-image.png";
       (sandbox as any).commands.run = jest.fn(async (cmd: string) => {
         if (cmd.includes("target_dir_exists")) {
           return {
@@ -1454,21 +1455,26 @@ describe("CentrifugoSandbox", () => {
         }
         return {
           stdout: "",
-          stderr: `curl: (23) failed to write ${signedUrl}`,
+          stderr: `curl: (23) failed to write /opaque-object/private-image.png to C:\\sandbox\\private-image.png`,
           exitCode: 23,
         };
       });
 
       const failure = sandbox.files
-        .downloadFromUrl(signedUrl, "/tmp/hackerai-upload/image.png")
+        .downloadFromUrl(signedUrl, localPath)
         .catch((error: unknown) => error);
       await jest.advanceTimersByTimeAsync(5_000);
       const error = await failure;
 
       expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("source: [redacted-url]");
       expect((error as Error).message).toContain(
-        "url: https://storage.example.com/image.png\n",
+        "destination: [redacted-destination-path]",
       );
+      expect((error as Error).message).not.toContain("storage.example.com");
+      expect((error as Error).message).not.toContain("opaque-object");
+      expect((error as Error).message).not.toContain("private-image.png");
+      expect((error as Error).message).not.toContain(localPath);
       expect((error as Error).message).not.toContain("X-Amz-Credential");
       expect((error as Error).message).not.toContain("X-Amz-Signature");
     });

--- a/lib/ai/tools/utils/centrifugo-sandbox.ts
+++ b/lib/ai/tools/utils/centrifugo-sandbox.ts
@@ -61,13 +61,47 @@ const TRANSIENT_COMMAND_TIMEOUT_ERROR_PATTERN =
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
-const safeUrlForLog = (url: string): string => {
+const getPathBasename = (path: string): string | undefined => {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1];
+};
+
+const redactTransferDetails = (
+  value: string,
+  url: string,
+  paths: string[],
+): string => {
+  let redacted = value;
+  const urlVariants = [url];
+  let urlPathname: string | undefined;
   try {
     const parsed = new URL(url);
-    return `${parsed.origin}${parsed.pathname}`;
+    urlVariants.push(`${parsed.origin}${parsed.pathname}`);
+    if (parsed.pathname && parsed.pathname !== "/") {
+      urlPathname = parsed.pathname;
+      urlVariants.push(parsed.pathname);
+    }
   } catch {
-    return url.split("?")[0];
+    urlVariants.push(url.split("?")[0]);
   }
+  for (const urlVariant of new Set(
+    urlVariants.sort((left, right) => right.length - left.length),
+  )) {
+    redacted = redacted.split(urlVariant).join("[redacted-url]");
+  }
+  const pathVariants = paths.flatMap((path) => [path, getPathBasename(path)]);
+  for (const path of new Set(
+    pathVariants
+      .filter((value): value is string => Boolean(value))
+      .sort((left, right) => right.length - left.length),
+  )) {
+    redacted = redacted.split(path).join("[redacted-destination-path]");
+  }
+  const sourceBasename = urlPathname ? getPathBasename(urlPathname) : undefined;
+  if (sourceBasename) {
+    redacted = redacted.split(sourceBasename).join("[redacted-url]");
+  }
+  return redacted;
 };
 
 const isTransientCommandTimeoutError = (error: unknown): boolean =>
@@ -1633,7 +1667,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
             throw error;
           }
           console.warn(
-            `[centrifugo-download] command timeout on attempt ${attempt}/${MAX_ATTEMPTS} for ${path}, retrying: ${getErrorMessage(error)}`,
+            `[centrifugo-download] command timeout on attempt ${attempt}/${MAX_ATTEMPTS}, retrying: ${redactTransferDetails(getErrorMessage(error), url, [rawPath, path])}`,
           );
           await new Promise((r) => setTimeout(r, 500 * attempt));
           continue;
@@ -1647,7 +1681,7 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           break;
         }
         console.warn(
-          `[centrifugo-download] ${httpClient} exit ${result.exitCode} on attempt ${attempt}/${MAX_ATTEMPTS} for ${path}, retrying`,
+          `[centrifugo-download] ${httpClient} exit ${result.exitCode} on attempt ${attempt}/${MAX_ATTEMPTS}, retrying`,
         );
         await new Promise((r) => setTimeout(r, 500 * attempt));
         continue;
@@ -1665,12 +1699,14 @@ Browser automation is host-dependent on this connection. Chromium and agent-brow
           ? `test -d ${diagDir} && echo target_dir_exists=true || echo target_dir_exists=false; test -w ${diagDir} && echo target_dir_writable=true || echo target_dir_writable=false; df -h /tmp 2>&1 | sed -n '1,2p'`
           : `if exist ${diagDir} (echo target_dir_exists=true) else (echo target_dir_exists=false) & (pushd ${diagDir} >nul 2>nul && (copy /Y NUL .hackerai_write_probe.tmp >nul 2>nul && del /q .hackerai_write_probe.tmp >nul 2>nul && echo target_dir_writable=true || echo target_dir_writable=false) & popd >nul 2>nul) || echo target_dir_writable=false`;
         const diag = await this.commands.run(diagCmd, { displayName: "" });
-        const safeUrl = safeUrlForLog(url);
-        const safeStderr = result.stderr.split(url).join(safeUrl);
+        const safeStderr = redactTransferDetails(result.stderr, url, [
+          rawPath,
+          path,
+        ]);
         throw new Error(
           `Failed to download file: ${safeStderr}\n` +
-            `  url: ${safeUrl.substring(0, 120)}${safeUrl.length > 120 ? "..." : ""}\n` +
-            `  path: ${path}\n` +
+            `  source: [redacted-url]\n` +
+            `  destination: [redacted-destination-path]\n` +
             `  command: ${httpClient}\n` +
             `  exitCode: ${result.exitCode}\n` +
             `  diagnostics: ${diag.stdout}`,

--- a/lib/billing/__tests__/fraud-refund.test.ts
+++ b/lib/billing/__tests__/fraud-refund.test.ts
@@ -71,6 +71,17 @@ describe("getRemainingRefundAmountCents", () => {
     ).toBe(true);
     expect(
       isRefundAmountRaceError({
+        raw: {
+          statusCode: 400,
+          type: "invalid_request_error",
+          param: "amount",
+          message:
+            "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.21)",
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isRefundAmountRaceError({
         statusCode: 400,
         type: "StripeInvalidRequestError",
         rawType: "invalid_request_error",

--- a/lib/billing/__tests__/fraud-refund.test.ts
+++ b/lib/billing/__tests__/fraud-refund.test.ts
@@ -51,11 +51,65 @@ describe("getRemainingRefundAmountCents", () => {
         code: "resource_missing",
       }),
     ).toBe(false);
+    expect(
+      isRefundAmountRaceError({
+        statusCode: 400,
+        type: "StripeInvalidRequestError",
+        rawType: "invalid_request_error",
+        code: undefined,
+        param: "amount",
+        message:
+          "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.21)",
+        raw: {
+          type: "invalid_request_error",
+          code: undefined,
+          param: "amount",
+          message:
+            "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.21)",
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isRefundAmountRaceError({
+        statusCode: 400,
+        type: "StripeInvalidRequestError",
+        rawType: "invalid_request_error",
+        code: undefined,
+        param: "amount",
+        message: "Amount must be at least 1 cent",
+      }),
+    ).toBe(false);
+    expect(
+      isRefundAmountRaceError({
+        statusCode: 400,
+        type: "StripeInvalidRequestError",
+        rawType: "invalid_request_error",
+        code: "resource_missing",
+        param: "amount",
+        message:
+          "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.21)",
+      }),
+    ).toBe(false);
   });
 
   it("refreshes the charge and bounds one idempotent race retry", async () => {
     jest.spyOn(console, "log").mockImplementation(() => {});
-    const raceError = { statusCode: 400, code: "amount_too_large" };
+    const raceError = {
+      statusCode: 400,
+      type: "StripeInvalidRequestError",
+      rawType: "invalid_request_error",
+      code: undefined,
+      param: "amount",
+      message:
+        "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.03)",
+      raw: {
+        type: "invalid_request_error",
+        code: undefined,
+        param: "amount",
+        message:
+          "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.03)",
+      },
+    };
     const create = jest
       .fn<
         (
@@ -94,9 +148,45 @@ describe("getRemainingRefundAmountCents", () => {
       { amount: 3, charge: "ch_123", reason: "fraudulent" },
       { idempotencyKey: "efw-refund:issfr_123:remaining:3" },
     );
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(retrieve).toHaveBeenCalledTimes(1);
     expect(retrieve.mock.invocationCallOrder[0]).toBeLessThan(
       create.mock.invocationCallOrder[1],
     );
+  });
+
+  it("does not retry again when the bounded race retry also fails", async () => {
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    const raceError = {
+      statusCode: 400,
+      type: "StripeInvalidRequestError",
+      rawType: "invalid_request_error",
+      code: undefined,
+      param: "amount",
+      message:
+        "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.03)",
+    };
+    const create = jest.fn().mockRejectedValue(raceError);
+    const retrieve = jest.fn().mockResolvedValue({
+      id: "ch_123",
+      amount: 2_500,
+      amount_refunded: 2_497,
+    } as Stripe.Charge);
+
+    await expect(
+      refundChargeForEFW(
+        { charges: { retrieve }, refunds: { create } },
+        {
+          id: "ch_123",
+          amount: 2_500,
+          amount_refunded: 0,
+        } as Stripe.Charge,
+        "issfr_123",
+      ),
+    ).rejects.toBe(raceError);
+
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(retrieve).toHaveBeenCalledTimes(1);
   });
 
   it("treats Stripe's non-refundable charge error as terminal", async () => {

--- a/lib/billing/fraud-refund.ts
+++ b/lib/billing/fraud-refund.ts
@@ -31,9 +31,40 @@ export function getRemainingRefundAmountCents(
 export function isRefundAmountRaceError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
 
-  const stripeError = error as { code?: unknown; statusCode?: unknown };
+  const stripeError = error as {
+    code?: unknown;
+    message?: unknown;
+    param?: unknown;
+    raw?: unknown;
+    rawType?: unknown;
+    statusCode?: unknown;
+    type?: unknown;
+  };
+  const rawError =
+    stripeError.raw && typeof stripeError.raw === "object"
+      ? (stripeError.raw as Record<string, unknown>)
+      : undefined;
+  const statusCode = stripeError.statusCode ?? rawError?.statusCode;
+  const code = stripeError.code ?? rawError?.code;
+
+  if (statusCode !== 400) return false;
+  if (code === "amount_too_large") return true;
+  if (code != null) return false;
+
+  const param = stripeError.param ?? rawError?.param;
+  const message = stripeError.message ?? rawError?.message;
+  const isInvalidRequest =
+    stripeError.type === "StripeInvalidRequestError" ||
+    stripeError.rawType === "invalid_request_error" ||
+    rawError?.type === "invalid_request_error";
+
   return (
-    stripeError.statusCode === 400 && stripeError.code === "amount_too_large"
+    isInvalidRequest &&
+    param === "amount" &&
+    typeof message === "string" &&
+    /^Refund amount \(.+\) is greater than unrefunded amount on charge \(.+\)$/.test(
+      message,
+    )
   );
 }
 

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -131,10 +131,10 @@ describe("desktop-local sandbox file helpers", () => {
     }
   });
 
-  it("redacts signed URL queries from staging failure diagnostics", async () => {
+  it("redacts source and destination paths from staging failure diagnostics", async () => {
     const sourceUrl =
-      "https://storage.example.com/report.pdf?X-Amz-Credential=opaque&X-Amz-Signature=secret";
-    const safeUrl = "https://storage.example.com/report.pdf";
+      "https://storage.example.com/object-key/private-report.pdf?X-Amz-Credential=opaque&X-Amz-Signature=secret";
+    const localPath = "/home/user/upload/private-report.pdf";
     const consoleErrorSpy = jest
       .spyOn(console, "error")
       .mockImplementation(() => {});
@@ -145,7 +145,7 @@ describe("desktop-local sandbox file helpers", () => {
           {
             kind: "url",
             url: sourceUrl,
-            localPath: "/home/user/upload/report.pdf",
+            localPath,
           },
         ],
         async () => ({
@@ -153,7 +153,9 @@ describe("desktop-local sandbox file helpers", () => {
             downloadFromUrl: jest
               .fn()
               .mockRejectedValue(
-                new Error(`Failed to download ${sourceUrl}: timed out`),
+                new Error(
+                  `Failed to download ${sourceUrl} to C:\\sandbox\\private-report.pdf: timed out`,
+                ),
               ),
           },
         }),
@@ -172,7 +174,12 @@ describe("desktop-local sandbox file helpers", () => {
       expect(diagnostics).not.toContain("X-Amz-Signature");
       expect(diagnostics).not.toContain("opaque");
       expect(diagnostics).not.toContain("secret");
-      expect(diagnostics).toContain(safeUrl);
+      expect(diagnostics).not.toContain("storage.example.com");
+      expect(diagnostics).not.toContain("object-key");
+      expect(diagnostics).not.toContain("private-report.pdf");
+      expect(diagnostics).not.toContain(localPath);
+      expect(diagnostics).toContain("[redacted-url]");
+      expect(diagnostics).toContain("[redacted-destination-path]");
       expect(getSandboxUploadFailureMetadata(result)).toMatchObject({
         upload_failure_kind: "url",
         upload_failure_protocol: "https",

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -39,10 +39,8 @@ type SandboxCommandResult = {
 
 type SandboxUploadFailureDetail = {
   kind: SandboxFile["kind"];
-  localPath: string;
   error: string;
   transientSandboxCommand: boolean;
-  url?: string;
   urlLength?: number;
   protocol?: string;
 };
@@ -627,7 +625,7 @@ const stageSandboxFile = async (
   }
 };
 
-const safeUrlForLog = (url: string): string => {
+const getUrlWithoutQuery = (url: string): string => {
   try {
     const parsed = new URL(url);
     return `${parsed.origin}${parsed.pathname}`;
@@ -636,20 +634,45 @@ const safeUrlForLog = (url: string): string => {
   }
 };
 
+const getUrlPathname = (url: string): string | undefined => {
+  try {
+    const pathname = new URL(url).pathname;
+    return pathname && pathname !== "/" ? pathname : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const getPathBasename = (path: string): string | undefined => {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1];
+};
+
+const redactSensitiveValues = (
+  message: string,
+  values: Array<string | undefined>,
+  replacement: string,
+): string => {
+  const orderedValues = [...new Set(values.filter(Boolean) as string[])].sort(
+    (left, right) => right.length - left.length,
+  );
+  for (const value of orderedValues) {
+    message = message.split(value).join(replacement);
+  }
+  return message;
+};
+
 const describeSandboxFileForLog = (file: SandboxFile) => {
   if (file.kind === "url") {
     return {
       kind: file.kind,
-      url: safeUrlForLog(file.url),
       urlLength: file.url.length,
       protocol: file.url.split("://")[0],
-      localPath: file.localPath,
     };
   }
   return {
     kind: file.kind,
     sourcePath: "[redacted-local-path]",
-    localPath: file.localPath,
   };
 };
 
@@ -659,13 +682,11 @@ const summarizeSandboxUploadFailure = (
 ): SandboxUploadFailureDetail => {
   const summary: SandboxUploadFailureDetail = {
     kind: file.kind,
-    localPath: file.localPath,
     error: redactSandboxUploadError(file, error),
     transientSandboxCommand: isTransientSandboxCommandError(error),
   };
 
   if (file.kind === "url") {
-    summary.url = safeUrlForLog(file.url);
     summary.urlLength = file.url.length;
     summary.protocol = file.url.split("://")[0];
   }
@@ -767,11 +788,40 @@ const redactSandboxUploadError = (
   file: SandboxFile,
   error: unknown,
 ): string => {
-  const message = error instanceof Error ? error.message : String(error);
+  let message = error instanceof Error ? error.message : String(error);
   if (file.kind === "url") {
-    return message.split(file.url).join(safeUrlForLog(file.url));
+    const urlPathname = getUrlPathname(file.url);
+    message = redactSensitiveValues(
+      message,
+      [file.url, getUrlWithoutQuery(file.url), urlPathname],
+      "[redacted-url]",
+    );
+    message = redactSensitiveValues(
+      message,
+      [file.localPath, getPathBasename(file.localPath)],
+      "[redacted-destination-path]",
+    );
+    return redactSensitiveValues(
+      message,
+      [urlPathname ? getPathBasename(urlPathname) : undefined],
+      "[redacted-url]",
+    );
   }
-  return message.split(file.path).join("[redacted-local-path]");
+  message = redactSensitiveValues(
+    message,
+    [file.path],
+    "[redacted-local-path]",
+  );
+  message = redactSensitiveValues(
+    message,
+    [file.localPath, getPathBasename(file.localPath)],
+    "[redacted-destination-path]",
+  );
+  return redactSensitiveValues(
+    message,
+    [getPathBasename(file.path)],
+    "[redacted-local-path]",
+  );
 };
 
 /**


### PR DESCRIPTION
## Production evidence

Frozen audit window: `2026-07-21T19:31:14.320Z` to `2026-07-22T19:31:14.320Z`.

- Vercel recorded three production Early Fraud Warning refund failures on deployment `dpl_8G7o1Jzf5xZcK3ihgAmuPvqEphf1`. Every sample was a Stripe 400 `invalid_request_error` with `param: amount`, the exact remaining-balance race message, and no `code`. The existing repair only recognized `code: amount_too_large`, so it never refreshed the charge.
- A representative Trigger.dev attachment failure logged the signed-storage origin/object path and destination attachment filename. The signature query was already removed, but the remaining path data was unnecessary for diagnosis.

## Change

- Recognize Stripe's observed no-code refund-balance race only when status, invalid-request type, `amount` parameter, absent code, and the anchored Stripe message shape all agree. Preserve the existing code-based path.
- Keep the repair bounded to one charge refresh and one idempotent retry for the refreshed remaining balance; unrelated Stripe errors continue to propagate.
- Remove source URLs/object paths and destination paths/filenames from sandbox transfer warnings, thrown diagnostics, and structured upload metadata. Retain bounded cause, source kind, protocol, URL length, retry state, client, exit code, and filesystem diagnostics.

## Adversarial review

- Verified the bound at webhook-operation scope: at most two refund calls and one charge refresh, including second-race exhaustion.
- Checked the only production webhook caller and all chat, Agent, trigger, local/Desktop, E2B, and Centrifugo upload entry points.
- Covered transformed Windows paths and overlapping source/destination filenames so redaction order cannot expose the source origin/object path.
- No deploy-skew contract or persisted data shape changes; no broad error suppression.

## Validation

- `corepack pnpm jest lib/billing/__tests__/fraud-refund.test.ts lib/utils/__tests__/sandbox-file-utils.test.ts lib/ai/tools/utils/__tests__/centrifugo-sandbox.test.ts --runInBand` (77 tests)
- `corepack pnpm typecheck`
- changed-file ESLint
- changed-file Prettier check
- commit hook full suite: 294 suites, 2,886 tests

## Manual verification

1. In Stripe test mode, deliver an Early Fraud Warning while another refund changes the charge balance. The handler should refresh once and request no more than the current unrefunded balance.
2. Force a signed attachment transfer failure. Logs should retain kind/protocol/URL length/bounded cause and transfer diagnostics, but contain no storage host/object path, signed query, local destination path, or attachment filename.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sandbox download/upload failure diagnostics by redacting sensitive URL details (including signed-query content) and destination paths/filenames, using consistent `[redacted-url]` and `[redacted-destination-path]` placeholders.
  - Strengthened fraud refund race-condition detection for detailed Stripe error shapes, improving correctness of bounded retry behavior and ensuring the original error is surfaced when retries fail.

- **Tests**
  - Expanded redaction assertions for both source and destination details.
  - Expanded fraud refund retry tests to validate call ordering/counts and the new regression case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->