### PR TITLE
Fix reusable approval, cancellation, and share-title vulnerabilities

### DIFF
--- a/convex/__tests__/chats.getUserChats.test.ts
+++ b/convex/__tests__/chats.getUserChats.test.ts
@@ -57,7 +57,8 @@ const { ConvexError } =
 const { assertUserCanAccessChatHistory } = jest.requireMock<
   typeof import("../lib/suspensionGuards")
 >("../lib/suspensionGuards");
-const { getUserChats } = require("../chats") as typeof import("../chats");
+const { getChatByIdFromClient, getUserChats } =
+  require("../chats") as typeof import("../chats");
 
 const emptyPage = {
   page: [],
@@ -206,5 +207,106 @@ describe("getUserChats", () => {
     expect(gt).toHaveBeenCalledWith("pinned_at", 0);
     expect(regularEq).toHaveBeenCalledWith("user_id", "user-123");
     expect(regularEq).toHaveBeenCalledWith("project_id", undefined);
+  });
+
+  it("uses a safe legacy fork title after another user's share is revoked", async () => {
+    const legacyFork = {
+      _id: "fork-doc",
+      id: "fork-1",
+      title: "My legacy fork",
+      user_id: "user-123",
+      branched_from_chat_id: "source-1",
+      update_time: 1,
+    };
+    const page = {
+      page: [legacyFork],
+      isDone: true,
+      continueCursor: "",
+    };
+    const paginate = jest.fn<any>().mockResolvedValue(page);
+    const regularOrder = jest.fn<any>().mockReturnValue({ paginate });
+    const regularWithIndex = jest.fn<any>().mockReturnValue({
+      order: regularOrder,
+    });
+    const sourceFirst = jest.fn<any>().mockResolvedValue({
+      _id: "source-doc",
+      id: "source-1",
+      title: "Private renamed source",
+      user_id: "source-owner",
+      update_time: 2,
+    });
+    const sourceWithIndex = jest.fn<any>().mockReturnValue({
+      first: sourceFirst,
+    });
+    const ctx = {
+      auth: {
+        getUserIdentity: jest
+          .fn<any>()
+          .mockResolvedValue({ subject: "user-123" }),
+      },
+      db: {
+        query: jest
+          .fn<any>()
+          .mockReturnValueOnce({ withIndex: regularWithIndex })
+          .mockReturnValueOnce({ withIndex: sourceWithIndex }),
+      },
+    };
+
+    await expect(
+      getUserChats.handler(ctx as any, {
+        paginationOpts: { numItems: 20, cursor: "next-page" },
+      }),
+    ).resolves.toEqual({
+      ...page,
+      page: [
+        expect.objectContaining({
+          branched_from_title: "My legacy fork",
+        }),
+      ],
+    });
+  });
+
+  it("uses the fork-time title in the single-chat query after revocation", async () => {
+    const fork = {
+      _id: "fork-doc",
+      _creationTime: 1,
+      id: "fork-1",
+      title: "My fork",
+      user_id: "user-123",
+      branched_from_chat_id: "source-1",
+      branched_from_title: "Title when forked",
+      update_time: 1,
+    };
+    const source = {
+      _id: "source-doc",
+      _creationTime: 1,
+      id: "source-1",
+      title: "Private renamed source",
+      user_id: "source-owner",
+      update_time: 2,
+    };
+    const first = jest
+      .fn<any>()
+      .mockResolvedValueOnce(fork)
+      .mockResolvedValueOnce(source);
+    const withIndex = jest.fn<any>().mockReturnValue({ first });
+    const ctx = {
+      auth: {
+        getUserIdentity: jest
+          .fn<any>()
+          .mockResolvedValue({ subject: "user-123" }),
+      },
+      db: {
+        query: jest.fn<any>().mockReturnValue({ withIndex }),
+      },
+    };
+
+    await expect(
+      getChatByIdFromClient.handler(ctx as any, { id: "fork-1" }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        branched_from_title: "Title when forked",
+      }),
+    );
   });
 });

--- a/convex/__tests__/chats.saveChat.test.ts
+++ b/convex/__tests__/chats.saveChat.test.ts
@@ -359,6 +359,7 @@ describe("moveChatToProject", () => {
     expect(get).toHaveBeenCalledWith("project-1");
     expect(patch).toHaveBeenCalledWith("chat-doc-1", {
       project_id: "project-1",
+      agent_approval_grants: undefined,
       update_time: expect.any(Number),
     });
     expect(patch).toHaveBeenCalledWith("project-1", {
@@ -410,7 +411,39 @@ describe("moveChatToProject", () => {
     expect(get).not.toHaveBeenCalled();
     expect(patch).toHaveBeenCalledWith("chat-doc-1", {
       project_id: undefined,
+      agent_approval_grants: undefined,
       update_time: expect.any(Number),
     });
+  });
+
+  it("preserves approvals when the project assignment does not change", async () => {
+    const { moveChatToProject } = await import("../chats");
+    const existingGrants = [
+      {
+        kind: "terminal_command",
+        targetPrefix: '["npm","test"]',
+        executable: "npm",
+        argv: ["npm", "test"],
+      },
+    ];
+    const { ctx, patch } = makeCtx({
+      existingChat: {
+        _id: "chat-doc-1",
+        id: "chat-1",
+        user_id: "user-1",
+        project_id: "project-1",
+        agent_approval_grants: existingGrants,
+      },
+      project: { _id: "project-1", user_id: "user-1" },
+    });
+
+    await expect(
+      moveChatToProject.handler(ctx, {
+        chatId: "chat-1",
+        projectId: "project-1" as any,
+      }),
+    ).resolves.toBe(false);
+
+    expect(patch).not.toHaveBeenCalled();
   });
 });

--- a/convex/__tests__/projects.test.ts
+++ b/convex/__tests__/projects.test.ts
@@ -252,8 +252,14 @@ describe("projects", () => {
     expect(patch).toHaveBeenCalledWith("project-1", {
       deletion_started_at: expect.any(Number),
     });
-    expect(patch).toHaveBeenCalledWith("task-1", { project_id: undefined });
-    expect(patch).toHaveBeenCalledWith("task-2", { project_id: undefined });
+    expect(patch).toHaveBeenCalledWith("task-1", {
+      project_id: undefined,
+      agent_approval_grants: undefined,
+    });
+    expect(patch).toHaveBeenCalledWith("task-2", {
+      project_id: undefined,
+      agent_approval_grants: undefined,
+    });
     expect(deleteDocument).toHaveBeenCalledWith("project-1");
     expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
     expect(projectEq).toHaveBeenNthCalledWith(1, "user_id", "user-1");
@@ -293,6 +299,62 @@ describe("projects", () => {
     expect(projectEq).toHaveBeenNthCalledWith(2, "project_id", "project-1");
     expect(order).toHaveBeenCalledWith("desc");
     expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 5 });
+  });
+
+  it("does not expose a renamed source title after sharing is revoked", async () => {
+    const page = {
+      page: [
+        {
+          _id: "fork-1",
+          id: "fork-1",
+          user_id: "user-1",
+          title: "My fork",
+          branched_from_chat_id: "source-1",
+          branched_from_title: "Title when forked",
+          project_id: "project-1",
+          update_time: 1,
+        },
+      ],
+      isDone: true,
+      continueCursor: "",
+    };
+    const paginate = jest.fn<any>().mockResolvedValue(page);
+    const order = jest.fn<any>().mockReturnValue({ paginate });
+    const projectWithIndex = jest.fn<any>().mockReturnValue({ order });
+    const sourceFirst = jest.fn<any>().mockResolvedValue({
+      _id: "source-1",
+      id: "source-1",
+      user_id: "source-owner",
+      title: "Private title after revocation",
+      update_time: 2,
+    });
+    const sourceWithIndex = jest.fn<any>().mockReturnValue({
+      first: sourceFirst,
+    });
+    const ctx = {
+      auth: authenticated,
+      db: {
+        get: jest.fn<any>().mockResolvedValue(project),
+        query: jest
+          .fn<any>()
+          .mockReturnValueOnce({ withIndex: projectWithIndex })
+          .mockReturnValueOnce({ withIndex: sourceWithIndex }),
+      },
+    };
+
+    await expect(
+      getProjectThreads.handler(ctx as any, {
+        projectId: "project-1" as any,
+        paginationOpts: { cursor: null, numItems: 5 },
+      }),
+    ).resolves.toEqual({
+      ...page,
+      page: [
+        expect.objectContaining({
+          branched_from_title: "Title when forked",
+        }),
+      ],
+    });
   });
 
   it("returns no tasks when the project is not owned by the user", async () => {

--- a/convex/__tests__/sharedChats.fork.test.ts
+++ b/convex/__tests__/sharedChats.fork.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+jest.mock("../_generated/server", () => ({
+  mutation: jest.fn((config: unknown) => config),
+  query: jest.fn((config: unknown) => config),
+}));
+jest.mock("convex/values", () => ({
+  v: {
+    array: jest.fn(() => "array"),
+    id: jest.fn(() => "id"),
+    null: jest.fn(() => "null"),
+    number: jest.fn(() => "number"),
+    object: jest.fn(() => "object"),
+    string: jest.fn(() => "string"),
+    union: jest.fn(() => "union"),
+  },
+}));
+jest.mock("../lib/logger", () => ({
+  convexLogger: {
+    warn: jest.fn(),
+  },
+}));
+jest.mock("../lib/suspensionGuards", () => ({
+  assertUserCanAccessChatHistory: jest.fn<any>().mockResolvedValue(undefined),
+  isUserBlockedByActiveFraudDispute: jest.fn<any>().mockResolvedValue(false),
+}));
+
+const { forkSharedChat } =
+  require("../sharedChats") as typeof import("../sharedChats");
+
+describe("forkSharedChat", () => {
+  it("stores the source title snapshot on the new owned fork", async () => {
+    const sourceChat = {
+      _id: "source-doc",
+      id: "source-1",
+      title: "Shared title",
+      user_id: "source-owner",
+      share_id: "11111111-1111-4111-8111-111111111111",
+      share_date: 100,
+      update_time: 100,
+    };
+    const sourceFirst = jest.fn<any>().mockResolvedValue(sourceChat);
+    const messagesCollect = jest.fn<any>().mockResolvedValue([]);
+    const insert = jest.fn<any>().mockResolvedValue("fork-doc");
+    const ctx = {
+      auth: {
+        getUserIdentity: jest
+          .fn<any>()
+          .mockResolvedValue({ subject: "fork-owner" }),
+      },
+      db: {
+        query: jest.fn<any>((table: string) => ({
+          withIndex: jest.fn<any>().mockReturnValue(
+            table === "chats"
+              ? { first: sourceFirst }
+              : {
+                  order: jest.fn<any>().mockReturnValue({
+                    collect: messagesCollect,
+                  }),
+                },
+          ),
+        })),
+        insert,
+      },
+    };
+
+    await expect(
+      forkSharedChat.handler(ctx as any, {
+        shareId: sourceChat.share_id,
+      }),
+    ).resolves.toEqual(expect.any(String));
+
+    expect(insert).toHaveBeenCalledWith(
+      "chats",
+      expect.objectContaining({
+        title: "Shared title",
+        user_id: "fork-owner",
+        branched_from_chat_id: "source-1",
+        branched_from_title: "Shared title",
+      }),
+    );
+  });
+});

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -25,6 +25,7 @@ import {
   CHAT_ACCESS_SUSPENDED_CODE,
   assertUserCanAccessChatHistory,
 } from "./lib/suspensionGuards";
+import { resolveBranchedFromTitle } from "./lib/branchedChatTitle";
 
 const DELETE_ALL_CHATS_MESSAGE_BATCH_SIZE = 10;
 const DELETE_ALL_CHATS_SUMMARY_BATCH_SIZE = 25;
@@ -452,7 +453,11 @@ export const getChatByIdFromClient = query({
 
         return {
           ...chatPublic,
-          branched_from_title: branchedFromChat?.title,
+          branched_from_title: resolveBranchedFromTitle(
+            chatPublic,
+            branchedFromChat,
+            identity.subject,
+          ),
         };
       }
 
@@ -500,6 +505,7 @@ export const getChatById = query({
         ),
       ),
       branched_from_chat_id: v.optional(v.string()),
+      branched_from_title: v.optional(v.string()),
       latest_summary_id: v.optional(v.id("chat_summaries")),
       share_id: v.optional(v.string()),
       share_date: v.optional(v.number()),
@@ -996,7 +1002,11 @@ export const getUserChats = query({
           );
           return {
             ...chat,
-            branched_from_title: branchedFromChat?.title,
+            branched_from_title: resolveBranchedFromTitle(
+              chat,
+              branchedFromChat,
+              identity.subject,
+            ),
           };
         }
         return chat;
@@ -1281,6 +1291,7 @@ export const moveChatToProject = mutation({
       if (chat.project_id === undefined) return false;
       await ctx.db.patch(chat._id, {
         project_id: undefined,
+        agent_approval_grants: undefined,
         update_time: Date.now(),
       });
       return true;
@@ -1303,6 +1314,7 @@ export const moveChatToProject = mutation({
     await Promise.all([
       ctx.db.patch(chat._id, {
         project_id: args.projectId,
+        agent_approval_grants: undefined,
         update_time: now,
       }),
       ctx.db.patch(args.projectId, { updated_at: now }),

--- a/convex/lib/__tests__/branchedChatTitle.test.ts
+++ b/convex/lib/__tests__/branchedChatTitle.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { resolveBranchedFromTitle } from "../branchedChatTitle";
+
+describe("resolveBranchedFromTitle", () => {
+  const fork = {
+    title: "Fork title",
+    branched_from_title: "Title when forked",
+  };
+
+  it("keeps live titles for a source owned by the viewer", () => {
+    expect(
+      resolveBranchedFromTitle(
+        fork,
+        { title: "Current title", user_id: "viewer" },
+        "viewer",
+      ),
+    ).toBe("Current title");
+  });
+
+  it("keeps live titles while another user's source remains shared", () => {
+    expect(
+      resolveBranchedFromTitle(
+        fork,
+        {
+          title: "Current shared title",
+          user_id: "owner",
+          share_id: "share-1",
+          share_date: 1,
+        },
+        "viewer",
+      ),
+    ).toBe("Current shared title");
+  });
+
+  it("uses the fork-time title after another user's share is revoked", () => {
+    expect(
+      resolveBranchedFromTitle(
+        fork,
+        { title: "Private renamed title", user_id: "owner" },
+        "viewer",
+      ),
+    ).toBe("Title when forked");
+  });
+
+  it("uses the owned fork title for legacy rows without a title snapshot", () => {
+    expect(
+      resolveBranchedFromTitle(
+        { title: "Legacy fork title" },
+        { title: "Private renamed title", user_id: "owner" },
+        "viewer",
+      ),
+    ).toBe("Legacy fork title");
+  });
+});

--- a/convex/lib/branchedChatTitle.ts
+++ b/convex/lib/branchedChatTitle.ts
@@ -1,0 +1,32 @@
+type ForkedChatTitleRecord = {
+  title: string;
+  branched_from_title?: string;
+};
+
+type SourceChatTitleRecord = {
+  title: string;
+  user_id: string;
+  share_id?: string;
+  share_date?: number;
+};
+
+/**
+ * Preserve live source titles only while the viewer is authorized to see the
+ * source chat. Revoked cross-user shares use the title captured at fork time;
+ * legacy forks fall back to their own title instead of exposing later changes.
+ */
+export const resolveBranchedFromTitle = (
+  forkedChat: ForkedChatTitleRecord,
+  sourceChat: SourceChatTitleRecord | null | undefined,
+  viewerUserId: string,
+): string => {
+  const canReadLiveSourceTitle =
+    sourceChat?.user_id === viewerUserId ||
+    (sourceChat?.share_id !== undefined && sourceChat.share_date !== undefined);
+
+  if (sourceChat && canReadLiveSourceTitle) {
+    return sourceChat.title;
+  }
+
+  return forkedChat.branched_from_title ?? forkedChat.title;
+};

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -10,6 +10,7 @@ import {
 import type { Id } from "./_generated/dataModel";
 import { validateServiceKey } from "./lib/utils";
 import { assertUserCanAccessChatHistory } from "./lib/suspensionGuards";
+import { resolveBranchedFromTitle } from "./lib/branchedChatTitle";
 
 const MAX_PROJECT_NAME_LENGTH = 80;
 const MAX_FOLDER_PATH_LENGTH = 4096;
@@ -96,7 +97,10 @@ const detachNextProjectTasksBatch = async (
     .take(PROJECT_TASK_DETACH_BATCH_SIZE + 1);
 
   for (const task of tasks.slice(0, PROJECT_TASK_DETACH_BATCH_SIZE)) {
-    await ctx.db.patch(task._id, { project_id: undefined });
+    await ctx.db.patch(task._id, {
+      project_id: undefined,
+      agent_approval_grants: undefined,
+    });
   }
 
   if (tasks.length > PROJECT_TASK_DETACH_BATCH_SIZE) {
@@ -351,10 +355,10 @@ export const getProjectThreads = query({
           .first(),
       ),
     );
-    const branchedTitles = new Map(
+    const branchedChatMap = new Map(
       branchedChats
         .filter((chat): chat is NonNullable<typeof chat> => chat !== null)
-        .map((chat) => [chat.id, chat.title]),
+        .map((chat) => [chat.id, chat]),
     );
 
     return {
@@ -363,8 +367,10 @@ export const getProjectThreads = query({
         ...chat,
         ...(chat.branched_from_chat_id
           ? {
-              branched_from_title: branchedTitles.get(
-                chat.branched_from_chat_id,
+              branched_from_title: resolveBranchedFromTitle(
+                chat,
+                branchedChatMap.get(chat.branched_from_chat_id),
+                identity.subject,
               ),
             }
           : {}),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -99,6 +99,9 @@ export default defineSchema({
       ),
     ),
     branched_from_chat_id: v.optional(v.string()),
+    // Snapshot the source title when another user's shared chat is forked.
+    // This avoids reading later source-title changes after sharing is revoked.
+    branched_from_title: v.optional(v.string()),
     latest_summary_id: v.optional(v.id("chat_summaries")),
     update_time: v.number(),
     // Sharing fields

--- a/convex/sharedChats.ts
+++ b/convex/sharedChats.ts
@@ -357,6 +357,7 @@ export const forkSharedChat = mutation({
       title: chat.title,
       user_id: identity.subject,
       branched_from_chat_id: chat.id,
+      branched_from_title: chat.title,
       update_time: Date.now(),
     });
 

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -791,6 +791,12 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(taskSrc).toMatch(/persistAgentApprovalGrant/);
     expect(taskSrc).toMatch(/agent_approval_grants/);
     expect(taskSrc).toMatch(
+      /scopedGrant\.workingDirectory === workingDirectory/,
+    );
+    expect(taskSrc).toMatch(
+      /workingDirectory:\s*projectContext\.workingDirectory/,
+    );
+    expect(taskSrc).toMatch(
       /approvedTargetGrant\.kind !== "terminal_interaction"/,
     );
     expect(taskSrc).toMatch(/matchesApprovalTargetGrant/);

--- a/lib/chat/__tests__/agent-approval-grants.test.ts
+++ b/lib/chat/__tests__/agent-approval-grants.test.ts
@@ -215,6 +215,49 @@ describe("agent approval grants", () => {
     ).toBeNull();
   });
 
+  it.each([
+    ["and operator", "&"],
+    ["pipe operator", "|"],
+    ["input redirection", "<"],
+    ["output redirection", ">"],
+    ["group opening", "("],
+    ["group closing", ")"],
+    ["newline", "\n"],
+    ["carriage return", "\r"],
+    ["NUL byte", "\0"],
+  ])(
+    "requires fresh approval for a Windows single-quoted %s",
+    (_description, operator) => {
+      const safeGrant = deriveAgentApprovalTargetGrant(
+        request("terminal_execute", "echo harmless"),
+      );
+      const target = `echo 'harmless ${operator} whoami'`;
+
+      expect(
+        deriveAgentApprovalTargetGrant(request("terminal_execute", target)),
+      ).toBeNull();
+      expect(
+        safeGrant &&
+          matchesAgentApprovalTargetGrant(
+            request("terminal_execute", target),
+            safeGrant,
+          ),
+      ).toBe(false);
+    },
+  );
+
+  it("keeps harmless single-quoted arguments eligible for approval reuse", () => {
+    expect(
+      deriveAgentApprovalTargetGrant(
+        request("terminal_execute", "echo 'hello world'"),
+      ),
+    ).toMatchObject({
+      kind: "terminal_command",
+      executable: "echo",
+      argv: ["echo", "hello world"],
+    });
+  });
+
   it("does not confuse a wrapper name with a sibling executable", () => {
     expect(
       deriveAgentApprovalTargetGrant(

--- a/lib/chat/agent-approval-grants.ts
+++ b/lib/chat/agent-approval-grants.ts
@@ -69,6 +69,18 @@ const SHELL_DYNAMIC_CHARACTERS = new Set([
   "!",
 ]);
 
+const CMD_SINGLE_QUOTE_CONTROL_CHARACTERS = new Set([
+  "&",
+  "|",
+  "<",
+  ">",
+  "(",
+  ")",
+  "\n",
+  "\r",
+  "\0",
+]);
+
 const NON_EXECUTABLE_SHELL_TOKENS = new Set([
   ".",
   "case",
@@ -173,9 +185,16 @@ export const parseStaticCommandArgv = (command: string): string[] | null => {
     if (quote === "single") {
       if (character === "'") {
         quote = null;
-      } else if (character === "%" || character === "!" || character === "^") {
+      } else if (
+        character === "%" ||
+        character === "!" ||
+        character === "^" ||
+        CMD_SINGLE_QUOTE_CONTROL_CHARACTERS.has(character)
+      ) {
         // Single quotes are not quoting characters for cmd.exe. Reject
-        // syntax that can still expand or escape on the Windows fallback.
+        // syntax that can still expand, escape, chain, or redirect on the
+        // Windows fallback. The command remains executable after a fresh
+        // approval; only automatic approval reuse is disabled.
         return null;
       } else {
         token += character;

--- a/packages/local/src/__tests__/command-cancellation.test.ts
+++ b/packages/local/src/__tests__/command-cancellation.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events";
 import {
   confirmProcessTermination,
+  isProcessTreeTerminationConfirmed,
   LOCAL_CANCEL_CONFIRMATION_TIMEOUT_MS,
 } from "../command-cancellation";
 
@@ -26,7 +27,32 @@ describe("confirmProcessTermination", () => {
     expect(requestTermination).toHaveBeenCalledTimes(1);
     expect(settled).toBe(false);
 
-    proc.emit("close", null, "SIGTERM");
+    proc.exitCode = 0;
+    proc.emit("close", 0, null);
+    await expect(confirmation).resolves.toBe(true);
+  });
+
+  it("waits for the process tree after the root process exits", async () => {
+    const proc = new FakeProcess();
+    let processTreeAlive = true;
+    const confirmation = confirmProcessTermination(
+      proc,
+      jest.fn(),
+      LOCAL_CANCEL_CONFIRMATION_TIMEOUT_MS,
+      () => !processTreeAlive,
+    );
+    let settled = false;
+    void confirmation.then(() => {
+      settled = true;
+    });
+
+    proc.exitCode = 0;
+    proc.emit("close", 0, null);
+    await jest.advanceTimersByTimeAsync(0);
+    expect(settled).toBe(false);
+
+    processTreeAlive = false;
+    await jest.advanceTimersByTimeAsync(50);
     await expect(confirmation).resolves.toBe(true);
   });
 
@@ -67,5 +93,49 @@ describe("confirmProcessTermination", () => {
       confirmProcessTermination(proc, requestTermination),
     ).resolves.toBe(true);
     expect(requestTermination).not.toHaveBeenCalled();
+  });
+});
+
+describe("isProcessTreeTerminationConfirmed", () => {
+  it("does not treat a terminated Unix root as a terminated process group", () => {
+    const proc = new FakeProcess();
+    proc.exitCode = 0;
+    Object.assign(proc, { pid: 123 });
+    const signalProcessGroup = jest.fn();
+
+    expect(
+      isProcessTreeTerminationConfirmed(
+        proc as FakeProcess & { pid: number },
+        "darwin",
+        signalProcessGroup,
+      ),
+    ).toBe(false);
+    expect(signalProcessGroup).toHaveBeenCalledWith(-123, 0);
+  });
+
+  it("confirms Unix process-group termination only after ESRCH", () => {
+    const proc = Object.assign(new FakeProcess(), { pid: 123 });
+    const missingProcessGroup = jest.fn(() => {
+      const error = new Error("No such process") as NodeJS.ErrnoException;
+      error.code = "ESRCH";
+      throw error;
+    });
+
+    expect(
+      isProcessTreeTerminationConfirmed(proc, "linux", missingProcessGroup),
+    ).toBe(true);
+  });
+
+  it("does not confirm Unix process-group termination on probe errors", () => {
+    const proc = Object.assign(new FakeProcess(), { pid: 123 });
+    const deniedProbe = jest.fn(() => {
+      const error = new Error("Not permitted") as NodeJS.ErrnoException;
+      error.code = "EPERM";
+      throw error;
+    });
+
+    expect(isProcessTreeTerminationConfirmed(proc, "linux", deniedProbe)).toBe(
+      false,
+    );
   });
 });

--- a/packages/local/src/command-cancellation.ts
+++ b/packages/local/src/command-cancellation.ts
@@ -1,44 +1,100 @@
 import type { ChildProcess } from "child_process";
+import os from "os";
 
 export const LOCAL_CANCEL_CONFIRMATION_TIMEOUT_MS = 4000;
+const LOCAL_CANCEL_CONFIRMATION_POLL_MS = 50;
 
 type TerminationObservable = Pick<
   ChildProcess,
   "exitCode" | "signalCode" | "once" | "off"
 >;
 
+type ProcessTreeObservable = TerminationObservable & Pick<ChildProcess, "pid">;
+
+const isRootProcessTerminated = (proc: TerminationObservable): boolean =>
+  proc.exitCode !== null || proc.signalCode !== null;
+
+/**
+ * On Unix, streamed commands run in their own process group. A shell exiting
+ * does not prove its descendants exited, so probe the group before confirming
+ * cancellation. Windows taskkill /T completion is observed through the root
+ * process because Windows does not expose the same process-group probe.
+ */
+export function isProcessTreeTerminationConfirmed(
+  proc: ProcessTreeObservable,
+  platform: NodeJS.Platform = os.platform(),
+  signalProcessGroup: (pid: number, signal: 0) => unknown = (pid, signal) =>
+    process.kill(pid, signal),
+): boolean {
+  if (platform === "win32" || !proc.pid) {
+    return isRootProcessTerminated(proc);
+  }
+
+  try {
+    signalProcessGroup(-proc.pid, 0);
+    return false;
+  } catch (error) {
+    return (
+      error instanceof Error &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ESRCH"
+    );
+  }
+}
+
 /**
  * A signal request is not a termination acknowledgement. Wait for Node to
- * observe the child reaching a terminal state before reporting success.
+ * observe the requested termination scope reaching a terminal state before
+ * reporting success.
  */
 export function confirmProcessTermination(
   proc: TerminationObservable,
   requestTermination: () => void,
   timeoutMs = LOCAL_CANCEL_CONFIRMATION_TIMEOUT_MS,
+  isTerminationComplete: () => boolean = () => isRootProcessTerminated(proc),
 ): Promise<boolean> {
-  if (proc.exitCode !== null || proc.signalCode !== null) {
-    return Promise.resolve(true);
+  try {
+    if (isTerminationComplete()) {
+      return Promise.resolve(true);
+    }
+  } catch {
+    return Promise.resolve(false);
   }
 
   return new Promise((resolve) => {
     let settled = false;
+    let timeoutId: NodeJS.Timeout | undefined;
+    let pollId: NodeJS.Timeout | undefined;
     const finish = (confirmed: boolean) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timeoutId);
+      if (timeoutId) clearTimeout(timeoutId);
+      if (pollId) clearInterval(pollId);
       proc.off("close", handleClose);
       proc.off("error", handleError);
       resolve(confirmed);
     };
-    const handleClose = () => finish(true);
+    const checkCompletion = () => {
+      try {
+        if (isTerminationComplete()) {
+          finish(true);
+        }
+      } catch {
+        finish(false);
+      }
+    };
+    const handleClose = () => checkCompletion();
     const handleError = () => finish(false);
-    const timeoutId = setTimeout(() => finish(false), timeoutMs);
+    timeoutId = setTimeout(() => finish(false), timeoutMs);
     timeoutId.unref?.();
+    pollId = setInterval(checkCompletion, LOCAL_CANCEL_CONFIRMATION_POLL_MS);
+    pollId.unref?.();
 
     proc.once("close", handleClose);
     proc.once("error", handleError);
     try {
       requestTermination();
+      checkCompletion();
     } catch {
       finish(false);
     }

--- a/packages/local/src/index.ts
+++ b/packages/local/src/index.ts
@@ -29,7 +29,10 @@ import {
   ProcessRunResult,
   isPtyAvailable,
 } from "./process-runner";
-import { confirmProcessTermination } from "./command-cancellation";
+import {
+  confirmProcessTermination,
+  isProcessTreeTerminationConfirmed,
+} from "./command-cancellation";
 
 const DEFAULT_SHELL = getDefaultShell(os.platform());
 
@@ -693,8 +696,11 @@ class LocalSandboxClient {
   ): Promise<void> {
     const proc = this.activeStreamCommands.get(msg.commandId);
     const canceled = proc
-      ? await confirmProcessTermination(proc, () =>
-          this.terminateProcessTree(proc),
+      ? await confirmProcessTermination(
+          proc,
+          () => this.terminateProcessTree(proc),
+          undefined,
+          () => isProcessTreeTerminationConfirmed(proc),
         )
       : false;
     await this.publishToChannel({
@@ -726,7 +732,7 @@ class LocalSandboxClient {
     }
 
     setTimeout(() => {
-      if (proc.exitCode !== null || proc.signalCode !== null) {
+      if (isProcessTreeTerminationConfirmed(proc)) {
         return;
       }
       try {

--- a/trigger/__tests__/agent-approval-sandbox-grants.test.ts
+++ b/trigger/__tests__/agent-approval-sandbox-grants.test.ts
@@ -25,6 +25,36 @@ describe("sandbox-scoped reusable Agent approval grants", () => {
     ).toBe(targetPrefix);
   });
 
+  it("reuses a persisted grant only within the same working directory", () => {
+    const persistedTargetPrefix =
+      serializeSandboxScopedAgentApprovalTargetPrefix({
+        sandboxIdentity: desktopA,
+        workingDirectory: "/targets/acme",
+        targetPrefix,
+      });
+
+    expect(
+      getAgentApprovalTargetPrefixForSandbox({
+        persistedTargetPrefix,
+        sandboxIdentity: desktopA,
+        workingDirectory: "/targets/acme",
+      }),
+    ).toBe(targetPrefix);
+    expect(
+      getAgentApprovalTargetPrefixForSandbox({
+        persistedTargetPrefix,
+        sandboxIdentity: desktopA,
+        workingDirectory: "/targets/other",
+      }),
+    ).toBeNull();
+    expect(
+      getAgentApprovalTargetPrefixForSandbox({
+        persistedTargetPrefix,
+        sandboxIdentity: desktopA,
+      }),
+    ).toBeNull();
+  });
+
   it("does not reuse E2B grants on desktop or desktop grants on E2B", () => {
     const e2bGrant = serializeSandboxScopedAgentApprovalTargetPrefix({
       sandboxIdentity: "e2b",
@@ -72,6 +102,28 @@ describe("sandbox-scoped reusable Agent approval grants", () => {
       parseSandboxScopedAgentApprovalTargetPrefix(
         '["agent-approval-sandbox-scope-v1","connection:","prefix"]',
       ),
+    ).toBeNull();
+  });
+
+  it("allows version 1 grants only without a project working directory", () => {
+    const versionOneGrant = JSON.stringify([
+      "agent-approval-sandbox-scope-v1",
+      desktopA,
+      targetPrefix,
+    ]);
+
+    expect(
+      getAgentApprovalTargetPrefixForSandbox({
+        persistedTargetPrefix: versionOneGrant,
+        sandboxIdentity: desktopA,
+      }),
+    ).toBe(targetPrefix);
+    expect(
+      getAgentApprovalTargetPrefixForSandbox({
+        persistedTargetPrefix: versionOneGrant,
+        sandboxIdentity: desktopA,
+        workingDirectory: "/targets/acme",
+      }),
     ).toBeNull();
   });
 });

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -372,16 +372,19 @@ const waitForApprovalInput = async (
 
 type SandboxScopedAgentApprovalTargetGrant = {
   sandboxIdentity: AgentApprovalSandboxIdentity;
+  workingDirectory?: string;
   grant: AgentApprovalTargetGrant;
 };
 
 const restoreSandboxScopedAgentApprovalTargetGrant = (
   grant: PersistedAgentApprovalTargetGrant,
   sandboxIdentity: AgentApprovalSandboxIdentity,
+  workingDirectory?: string,
 ): AgentApprovalTargetGrant | null => {
   const targetPrefix = getAgentApprovalTargetPrefixForSandbox({
     persistedTargetPrefix: grant.targetPrefix,
     sandboxIdentity,
+    workingDirectory,
   });
   return targetPrefix === null ? null : { ...grant, targetPrefix };
 };
@@ -389,10 +392,12 @@ const restoreSandboxScopedAgentApprovalTargetGrant = (
 const scopePersistedAgentApprovalTargetGrant = (
   grant: PersistedAgentApprovalTargetGrant,
   sandboxIdentity: AgentApprovalSandboxIdentity,
+  workingDirectory?: string,
 ): PersistedAgentApprovalTargetGrant => ({
   ...grant,
   targetPrefix: serializeSandboxScopedAgentApprovalTargetPrefix({
     sandboxIdentity,
+    workingDirectory,
     targetPrefix: grant.targetPrefix,
   }),
 });
@@ -409,6 +414,7 @@ const buildAgentToolApprovalRequester = ({
   initialTargetGrants = [],
   persistTargetGrant,
   resolveSandboxIdentity,
+  workingDirectory,
   beforeSuspend,
   revalidateAfterSuspend,
   onPostWaitAuthorizationDenied,
@@ -428,6 +434,7 @@ const buildAgentToolApprovalRequester = ({
     sandboxIdentity: AgentApprovalSandboxIdentity,
   ) => Promise<void>;
   resolveSandboxIdentity: () => Promise<AgentApprovalSandboxIdentity>;
+  workingDirectory?: string;
   beforeSuspend?: () => Promise<void>;
   revalidateAfterSuspend: (
     input: AgentToolApprovalInputRecord,
@@ -479,6 +486,7 @@ const buildAgentToolApprovalRequester = ({
         approvedTargetGrants.find(
           (scopedGrant) =>
             scopedGrant.sandboxIdentity === sandboxIdentity &&
+            scopedGrant.workingDirectory === workingDirectory &&
             matchesApprovalTargetGrant(request, scopedGrant.grant),
         )?.grant ??
         initialTargetGrants
@@ -486,6 +494,7 @@ const buildAgentToolApprovalRequester = ({
             restoreSandboxScopedAgentApprovalTargetGrant(
               grant,
               sandboxIdentity,
+              workingDirectory,
             ),
           )
           .find(
@@ -716,6 +725,7 @@ const buildAgentToolApprovalRequester = ({
           if (approvedTargetGrant) {
             approvedTargetGrants.push({
               sandboxIdentity,
+              workingDirectory,
               grant: approvedTargetGrant,
             });
             if (
@@ -2186,9 +2196,11 @@ export const agentLongTask = task({
                       grant: scopePersistedAgentApprovalTargetGrant(
                         grant,
                         sandboxIdentity,
+                        projectContext.workingDirectory,
                       ),
                     }),
               resolveSandboxIdentity: resolveApprovalSandboxIdentity,
+              workingDirectory: projectContext.workingDirectory,
               beforeSuspend:
                 subscription === "free" ? releaseFreeRunLockOnce : undefined,
               revalidateAfterSuspend: revalidateAfterApprovalSuspend,

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -97,6 +97,8 @@ export type AgentApprovalSandboxIdentity = "e2b" | `connection:${string}`;
 
 const AGENT_APPROVAL_SANDBOX_SCOPE_VERSION =
   "agent-approval-sandbox-scope-v1" as const;
+const AGENT_APPROVAL_EXECUTION_SCOPE_VERSION =
+  "agent-approval-execution-scope-v2" as const;
 
 export const getAgentApprovalConnectionSandboxIdentity = (
   connectionId: string,
@@ -118,14 +120,17 @@ const isAgentApprovalSandboxIdentity = (
 
 export const serializeSandboxScopedAgentApprovalTargetPrefix = ({
   sandboxIdentity,
+  workingDirectory,
   targetPrefix,
 }: {
   sandboxIdentity: AgentApprovalSandboxIdentity;
+  workingDirectory?: string;
   targetPrefix: string;
 }): string =>
   JSON.stringify([
-    AGENT_APPROVAL_SANDBOX_SCOPE_VERSION,
+    AGENT_APPROVAL_EXECUTION_SCOPE_VERSION,
     sandboxIdentity,
+    workingDirectory ?? null,
     targetPrefix,
   ]);
 
@@ -133,22 +138,45 @@ export const parseSandboxScopedAgentApprovalTargetPrefix = (
   value: string,
 ): {
   sandboxIdentity: AgentApprovalSandboxIdentity;
+  workingDirectory?: string;
   targetPrefix: string;
+  version: 1 | 2;
 } | null => {
   try {
     const parsed: unknown = JSON.parse(value);
     if (
+      Array.isArray(parsed) &&
+      parsed.length === 3 &&
+      parsed[0] === AGENT_APPROVAL_SANDBOX_SCOPE_VERSION &&
+      isAgentApprovalSandboxIdentity(parsed[1]) &&
+      typeof parsed[2] === "string"
+    ) {
+      return {
+        sandboxIdentity: parsed[1],
+        targetPrefix: parsed[2],
+        version: 1,
+      };
+    }
+    if (
       !Array.isArray(parsed) ||
-      parsed.length !== 3 ||
-      parsed[0] !== AGENT_APPROVAL_SANDBOX_SCOPE_VERSION ||
+      parsed.length !== 4 ||
+      parsed[0] !== AGENT_APPROVAL_EXECUTION_SCOPE_VERSION ||
       !isAgentApprovalSandboxIdentity(parsed[1]) ||
-      typeof parsed[2] !== "string"
+      !(
+        parsed[2] === null ||
+        (typeof parsed[2] === "string" &&
+          parsed[2].length > 0 &&
+          !/[\u0000-\u001f]/.test(parsed[2]))
+      ) ||
+      typeof parsed[3] !== "string"
     ) {
       return null;
     }
     return {
       sandboxIdentity: parsed[1],
-      targetPrefix: parsed[2],
+      ...(parsed[2] === null ? {} : { workingDirectory: parsed[2] }),
+      targetPrefix: parsed[3],
+      version: 2,
     };
   } catch {
     return null;
@@ -158,14 +186,24 @@ export const parseSandboxScopedAgentApprovalTargetPrefix = (
 export const getAgentApprovalTargetPrefixForSandbox = ({
   persistedTargetPrefix,
   sandboxIdentity,
+  workingDirectory,
 }: {
   persistedTargetPrefix: string;
   sandboxIdentity: AgentApprovalSandboxIdentity;
+  workingDirectory?: string;
 }): string | null => {
   const scoped = parseSandboxScopedAgentApprovalTargetPrefix(
     persistedTargetPrefix,
   );
-  return scoped?.sandboxIdentity === sandboxIdentity
+  if (!scoped || scoped.sandboxIdentity !== sandboxIdentity) return null;
+
+  // Version 1 grants predate working-directory scoping. They remain safe for
+  // contexts without an active project folder, but must not cross into one.
+  if (scoped.version === 1) {
+    return workingDirectory === undefined ? scoped.targetPrefix : null;
+  }
+
+  return scoped.workingDirectory === workingDirectory
     ? scoped.targetPrefix
     : null;
 };


### PR DESCRIPTION
## Summary
- bind reusable Agent terminal approvals to both sandbox identity and working directory, and clear stale grants when a task moves or its project is deleted
- require a fresh approval for cmd.exe control syntax hidden inside POSIX single quotes; this shared boundary covers Local, Desktop execute, and Desktop PTY paths
- confirm Local cancellation only after the Unix process group is gone, while still escalating resistant descendants to SIGKILL
- snapshot shared-chat titles at fork time and expose live source titles only while the viewer remains authorized

## Compatibility
- commands are never blocked by the new Windows rule; unsafe edge cases simply prompt for fresh approval
- ordinary reusable approvals continue working in the same sandbox and working directory, including legacy grants outside project-folder contexts
- project moves keep working; only prior terminal authority is reset when the execution context changes
- fork labels remain populated, and live source-title updates continue while the source is owned by the viewer or actively shared
- no Desktop/Rust executor code changed

## Validation
- corepack pnpm test --runInBand (296 suites, 2914 tests)
- corepack pnpm typecheck
- changed-file ESLint and Prettier checks
- corepack pnpm --dir packages/local build
- corepack pnpm exec next build
- cargo test was unavailable locally because the Rust toolchain is not installed; CI should validate the unchanged Desktop crate

## Manual verification
- approve a harmless terminal prefix in Agent mode, repeat it in the same project folder, then move the task to another folder-backed project; the moved task should ask again
- on Windows Local or Desktop, approve a harmless command and then submit a command containing an ampersand or pipe inside single quotes; it should ask again and still run after approval
- cancel a Local command with a child process that ignores SIGTERM; cancellation should wait for the process group and leave no descendant running
- fork a shared task, revoke the original share, rename the original, and confirm the fork keeps its fork-time source label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the original source title when shared-chat access is revoked, including for older forked chats.
  * Prevented stale approval permissions from carrying over when chats or tasks are removed from projects.
  * Improved command cancellation confirmation, including process-tree handling on Unix systems.
  * Strengthened safeguards around shell commands and reusable approval grants.
* **Improvements**
  * Approval grants now respect the active project working directory, reducing unintended reuse across projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->