### PR TITLE
Fix stale refund retries and redact exception URLs

### DIFF
--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -118,6 +118,32 @@ describe("PostHogProvider", () => {
     expect(posthog.opt_in_capturing).toHaveBeenCalledWith({
       captureEventName: false,
     });
+
+    const [, config] = posthog.init.mock.calls[0] as unknown as [
+      string,
+      {
+        before_send: (event: {
+          event: string;
+          properties: Record<string, unknown>;
+        }) => {
+          event?: string;
+          properties?: Record<string, unknown>;
+        } | null;
+      },
+    ];
+    const retainedException = config.before_send({
+      event: "$exception",
+      properties: {
+        $current_url: "https://hackerai.co/auth-error?state=secret",
+        $referrer: "https://idp.example/callback?code=secret",
+        $exception_values: ["Unexpected application error"],
+      },
+    });
+
+    expect(retainedException?.properties).toMatchObject({
+      $current_url: "https://hackerai.co/auth-error",
+      $referrer: "https://idp.example/callback",
+    });
   });
 
   it("applies exception hooks when the shared client is already initialized", async () => {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -7,6 +7,7 @@ import { useGlobalState } from "./contexts/GlobalState";
 import { Hac45AgentOnlyContext } from "./contexts/Hac45AgentOnlyContext";
 import {
   enrichFrontendExceptionEvent,
+  sanitizeFrontendExceptionUrlProperties,
   shouldDropExpectedFrontendException,
 } from "@/lib/posthog/expected-frontend-exceptions";
 import {
@@ -84,11 +85,17 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
           },
           disable_session_recording: true,
           before_send: (event) => {
-            if (!event || shouldDropExpectedFrontendException(event)) {
+            if (!event) {
               return null;
             }
 
-            return enrichFrontendExceptionEvent(event);
+            const sanitizedEvent =
+              sanitizeFrontendExceptionUrlProperties(event);
+            if (shouldDropExpectedFrontendException(sanitizedEvent)) {
+              return null;
+            }
+
+            return enrichFrontendExceptionEvent(sanitizedEvent);
           },
         } satisfies Partial<PostHogConfig>;
 

--- a/lib/billing/__tests__/fraud-refund.test.ts
+++ b/lib/billing/__tests__/fraud-refund.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, jest } from "@jest/globals";
 import type Stripe from "stripe";
 import {
+  getReportedRemainingRefundAmountCents,
   getRemainingRefundAmountCents,
   isRefundAmountRaceError,
   refundChargeForEFW,
@@ -30,6 +31,34 @@ describe("getRemainingRefundAmountCents", () => {
     expect(
       getRemainingRefundAmountCents({ amount: 2_000, amount_refunded: 2_000 }),
     ).toBe(0);
+  });
+
+  it("parses only the provider-reported USD remaining balance", () => {
+    expect(
+      getReportedRemainingRefundAmountCents({
+        message:
+          "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.03)",
+      }),
+    ).toBe(3);
+    expect(
+      getReportedRemainingRefundAmountCents({
+        raw: {
+          message:
+            "Refund amount ($1,250.00) is greater than unrefunded amount on charge ($1,000.05)",
+        },
+      }),
+    ).toBe(100_005);
+    expect(
+      getReportedRemainingRefundAmountCents({
+        message:
+          "Refund amount (€25.00) is greater than unrefunded amount on charge (€0.03)",
+      }),
+    ).toBeUndefined();
+    expect(
+      getReportedRemainingRefundAmountCents({
+        message: "Amount must be at least 1 cent",
+      }),
+    ).toBeUndefined();
   });
 
   it("matches only Stripe's refund-balance race response", () => {
@@ -164,6 +193,132 @@ describe("getRemainingRefundAmountCents", () => {
     expect(retrieve.mock.invocationCallOrder[0]).toBeLessThan(
       create.mock.invocationCallOrder[1],
     );
+  });
+
+  it("uses Stripe's reported balance when an immediate charge refresh is stale", async () => {
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    const raceError = {
+      statusCode: 400,
+      type: "StripeInvalidRequestError",
+      rawType: "invalid_request_error",
+      code: undefined,
+      param: "amount",
+      message:
+        "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.03)",
+    };
+    const create = jest
+      .fn<
+        (
+          params: { amount: number; charge: string; reason: "fraudulent" },
+          options: { idempotencyKey: string },
+        ) => Promise<unknown>
+      >()
+      .mockRejectedValueOnce(raceError)
+      .mockResolvedValueOnce({ id: "re_123" });
+    const retrieve = jest
+      .fn<(chargeId: string) => Promise<Stripe.Charge>>()
+      .mockResolvedValue({
+        id: "ch_123",
+        amount: 2_500,
+        amount_refunded: 0,
+      } as Stripe.Charge);
+
+    await refundChargeForEFW(
+      { charges: { retrieve }, refunds: { create } },
+      {
+        id: "ch_123",
+        amount: 2_500,
+        amount_refunded: 0,
+      } as Stripe.Charge,
+      "issfr_123",
+    );
+
+    expect(create).toHaveBeenNthCalledWith(
+      2,
+      { amount: 3, charge: "ch_123", reason: "fraudulent" },
+      { idempotencyKey: "efw-refund:issfr_123:remaining:3" },
+    );
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(retrieve).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the lower refreshed balance when it is below Stripe's reported balance", async () => {
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    const create = jest
+      .fn<
+        (
+          params: { amount: number; charge: string; reason: "fraudulent" },
+          options: { idempotencyKey: string },
+        ) => Promise<unknown>
+      >()
+      .mockRejectedValueOnce({
+        statusCode: 400,
+        type: "StripeInvalidRequestError",
+        rawType: "invalid_request_error",
+        code: undefined,
+        param: "amount",
+        message:
+          "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.03)",
+      })
+      .mockResolvedValueOnce({ id: "re_123" });
+    const retrieve = jest
+      .fn<(chargeId: string) => Promise<Stripe.Charge>>()
+      .mockResolvedValue({
+        id: "ch_123",
+        amount: 2_500,
+        amount_refunded: 2_498,
+      } as Stripe.Charge);
+
+    await refundChargeForEFW(
+      { charges: { retrieve }, refunds: { create } },
+      {
+        id: "ch_123",
+        amount: 2_500,
+        amount_refunded: 0,
+      } as Stripe.Charge,
+      "issfr_123",
+    );
+
+    expect(create).toHaveBeenNthCalledWith(
+      2,
+      { amount: 2, charge: "ch_123", reason: "fraudulent" },
+      { idempotencyKey: "efw-refund:issfr_123:remaining:2" },
+    );
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(retrieve).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry when the refreshed charge has no balance", async () => {
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    const create = jest.fn().mockRejectedValueOnce({
+      statusCode: 400,
+      type: "StripeInvalidRequestError",
+      rawType: "invalid_request_error",
+      code: undefined,
+      param: "amount",
+      message:
+        "Refund amount ($25.00) is greater than unrefunded amount on charge ($0.03)",
+    });
+    const retrieve = jest.fn().mockResolvedValue({
+      id: "ch_123",
+      amount: 2_500,
+      amount_refunded: 2_500,
+    } as Stripe.Charge);
+
+    await expect(
+      refundChargeForEFW(
+        { charges: { retrieve }, refunds: { create } },
+        {
+          id: "ch_123",
+          amount: 2_500,
+          amount_refunded: 0,
+        } as Stripe.Charge,
+        "issfr_123",
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(retrieve).toHaveBeenCalledTimes(1);
   });
 
   it("does not retry again when the bounded race retry also fails", async () => {

--- a/lib/billing/fraud-refund.ts
+++ b/lib/billing/fraud-refund.ts
@@ -22,10 +22,45 @@ const TERMINAL_REFUND_ERROR_CODES = new Set([
   "charge_not_refundable",
 ]);
 
+const getRefundAmountRaceMessage = (error: unknown): string | undefined => {
+  if (!error || typeof error !== "object") return undefined;
+
+  const stripeError = error as { message?: unknown; raw?: unknown };
+  const rawError =
+    stripeError.raw && typeof stripeError.raw === "object"
+      ? (stripeError.raw as Record<string, unknown>)
+      : undefined;
+  const message = stripeError.message ?? rawError?.message;
+
+  return typeof message === "string" ? message : undefined;
+};
+
 export function getRemainingRefundAmountCents(
   charge: Pick<Stripe.Charge, "amount" | "amount_refunded">,
 ): number {
   return Math.max(0, charge.amount - charge.amount_refunded);
+}
+
+export function getReportedRemainingRefundAmountCents(
+  error: unknown,
+): number | undefined {
+  const message = getRefundAmountRaceMessage(error);
+  if (!message) return undefined;
+
+  const match =
+    /^Refund amount \(\$[\d,]+\.\d{2}\) is greater than unrefunded amount on charge \(\$([\d,]+)\.(\d{2})\)$/.exec(
+      message,
+    );
+  if (!match?.[1] || !match[2]) return undefined;
+
+  const dollars = Number(match[1].replaceAll(",", ""));
+  const cents = Number(match[2]);
+  if (!Number.isSafeInteger(dollars) || !Number.isSafeInteger(cents)) {
+    return undefined;
+  }
+
+  const amount = dollars * 100 + cents;
+  return Number.isSafeInteger(amount) ? amount : undefined;
 }
 
 export function isRefundAmountRaceError(error: unknown): boolean {
@@ -52,7 +87,7 @@ export function isRefundAmountRaceError(error: unknown): boolean {
   if (code != null) return false;
 
   const param = stripeError.param ?? rawError?.param;
-  const message = stripeError.message ?? rawError?.message;
+  const message = getRefundAmountRaceMessage(error);
   const isInvalidRequest =
     stripeError.type === "StripeInvalidRequestError" ||
     stripeError.rawType === "invalid_request_error" ||
@@ -74,7 +109,8 @@ export function isRefundAmountRaceError(error: unknown): boolean {
  * Idempotency keys include the observed refundable balance, so webhook retries
  * for the same balance collapse while a later delivery with a fresher balance
  * can make progress. If another refund wins the race after retrieval, refresh
- * the charge once and retry no more than its current remaining balance.
+ * the charge once and retry no more than the lower of its refreshed balance and
+ * the balance Stripe reported in the exact refund-race response.
  *
  * Terminal failures are treated as success because there is nothing to retry.
  * All other failures propagate so Stripe can retry the webhook delivery.
@@ -113,30 +149,36 @@ export async function refundChargeForEFW(
 
   if (isRefundAmountRaceError(refundError)) {
     try {
+      const reportedRemainingAmount =
+        getReportedRemainingRefundAmountCents(refundError);
       const refreshedCharge = await stripeClient.charges.retrieve(charge.id);
       const refreshedRemainingAmount =
         getRemainingRefundAmountCents(refreshedCharge);
+      const retryAmount =
+        reportedRemainingAmount === undefined
+          ? refreshedRemainingAmount
+          : Math.min(refreshedRemainingAmount, reportedRemainingAmount);
 
-      if (refreshedRemainingAmount === 0) {
+      if (retryAmount === 0) {
         console.log(
           `[Fraud Webhook] Refund skipped for ${charge.id} (EFW ${efwId}): charge has no refundable balance after refresh`,
         );
         return;
       }
 
-      if (refreshedRemainingAmount < remainingAmount) {
+      if (retryAmount < remainingAmount) {
         await stripeClient.refunds.create(
           {
             charge: charge.id,
             reason: "fraudulent",
-            amount: refreshedRemainingAmount,
+            amount: retryAmount,
           },
           {
-            idempotencyKey: `efw-refund:${efwId}:remaining:${refreshedRemainingAmount}`,
+            idempotencyKey: `efw-refund:${efwId}:remaining:${retryAmount}`,
           },
         );
         console.log(
-          `[Fraud Webhook] Refunded refreshed remaining balance of ${refreshedRemainingAmount} cents from charge ${charge.id} (early fraud warning ${efwId})`,
+          `[Fraud Webhook] Refunded refreshed remaining balance of ${retryAmount} cents from charge ${charge.id} (early fraud warning ${efwId})`,
         );
         return;
       }

--- a/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
+++ b/lib/posthog/__tests__/expected-frontend-exceptions.test.ts
@@ -1,5 +1,6 @@
 import {
   enrichFrontendExceptionEvent,
+  sanitizeFrontendExceptionUrlProperties,
   shouldDropExpectedFrontendException,
 } from "../expected-frontend-exceptions";
 
@@ -573,5 +574,41 @@ describe("shouldDropExpectedFrontendException", () => {
         hackerai_exception_category: "stack_overflow",
       });
     }
+  });
+
+  it("removes query strings and fragments from retained exception URLs", () => {
+    const event = sanitizeFrontendExceptionUrlProperties({
+      event: "$exception",
+      properties: {
+        $current_url:
+          "https://hackerai.co/auth-error?state=secret#client_redirect_key=secret",
+        $referrer: "https://idp.example/callback?code=secret&state=secret",
+        $exception_values: [
+          "Request failed for https://api.example/resource?diagnostic=keep",
+        ],
+      },
+    });
+
+    expect(event.properties).toEqual({
+      $current_url: "https://hackerai.co/auth-error",
+      $referrer: "https://idp.example/callback",
+      $exception_values: [
+        "Request failed for https://api.example/resource?diagnostic=keep",
+      ],
+    });
+  });
+
+  it("does not change URL properties on non-exception events", () => {
+    const event = {
+      event: "custom_event",
+      properties: {
+        $current_url: "https://hackerai.co/c/chat-123?tab=files",
+        $referrer: "https://hackerai.co/?source=home",
+      },
+    };
+
+    expect(sanitizeFrontendExceptionUrlProperties(event)).toBe(event);
+    expect(event.properties.$current_url).toContain("?tab=files");
+    expect(event.properties.$referrer).toContain("?source=home");
   });
 });

--- a/lib/posthog/expected-frontend-exceptions.ts
+++ b/lib/posthog/expected-frontend-exceptions.ts
@@ -309,6 +309,41 @@ const getRouteKind = (currentUrl: unknown): string | undefined => {
   }
 };
 
+const stripUrlQueryAndFragment = (value: string): string => {
+  const queryIndex = value.indexOf("?");
+  const fragmentIndex = value.indexOf("#");
+  const firstSensitiveIndex =
+    queryIndex === -1
+      ? fragmentIndex
+      : fragmentIndex === -1
+        ? queryIndex
+        : Math.min(queryIndex, fragmentIndex);
+
+  return firstSensitiveIndex === -1
+    ? value
+    : value.slice(0, firstSensitiveIndex);
+};
+
+export function sanitizeFrontendExceptionUrlProperties<
+  T extends PostHogEventLike,
+>(event: T): T {
+  if (event.event !== "$exception" || !event.properties) return event;
+
+  const currentUrl = event.properties.$current_url;
+  const referrer = event.properties.$referrer;
+  event.properties = {
+    ...event.properties,
+    ...(typeof currentUrl === "string"
+      ? { $current_url: stripUrlQueryAndFragment(currentUrl) }
+      : {}),
+    ...(typeof referrer === "string"
+      ? { $referrer: stripUrlQueryAndFragment(referrer) }
+      : {}),
+  };
+
+  return event;
+}
+
 const getDeploymentIdFromFrameSources = (
   frameSources: string[],
 ): string | undefined => {


### PR DESCRIPTION
## Production evidence

The frozen production audit confirmed two actionable conditions:

- Early Fraud Warning webhook retries continued to return HTTP 500 after the prior refund-race fix. The refund response reported a smaller current balance, while the immediate charge retrieval could still return the stale original balance, so the smaller retry was skipped.
- Retained frontend exception analytics included query and fragment data in current-URL and referrer properties.

Exact deployment/event identifiers and raw URL values are intentionally omitted from this public PR and retained only in the private audit artifacts.

## Change

- Parse only Stripe's exact USD refund-race response and bound the retry amount to the lower of the refreshed charge balance and Stripe's error-reported balance.
- Preserve the existing webhook-operation bound: at most two refund calls, one charge retrieval, and balance-scoped idempotency keys. A second race or unrelated error still propagates.
- Strip query strings and fragments from `$current_url` and `$referrer` before retained frontend `$exception` events are classified and sent. Error messages, stack frames, and deployment-ID attribution remain unchanged.
- No broad PostHog suppression, persisted-data contract, or deploy-skew-sensitive API change.

## Adversarial review

- Checked the only production refund caller and the webhook claim/retry lifecycle.
- Covered stale, lower, zero, unsupported-currency, raw-only, terminal, and second-race exhaustion cases.
- Verified the payment bound at the full webhook operation rather than per helper call.
- Verified both fresh and already-loaded PostHog client configuration paths.
- Confirmed URL redaction is limited to retained exception URL/referrer properties and does not rewrite error strings or frame sources.

## Validation

- `corepack pnpm jest lib/billing/__tests__/fraud-refund.test.ts lib/posthog/__tests__/expected-frontend-exceptions.test.ts app/__tests__/providers.test.tsx --runInBand` (38 tests)
- `corepack pnpm typecheck`
- changed-file ESLint
- changed-file Prettier check
- commit hook full suite: 296 suites / 2,920 tests

## Manual verification

1. In Stripe test mode, reproduce an EFW refund race where the refund response reports a smaller balance while the immediate charge retrieval is stale. Confirm one lower-balance retry uses the balance-scoped idempotency key and the webhook succeeds.
2. Capture a retained frontend exception from a URL/referrer containing query and fragment values. Confirm PostHog receives origin/path only in `$current_url` and `$referrer`, while error details and deployment attribution remain available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized URLs in captured frontend exception events by removing query parameters and fragments from page and referrer URLs while preserving exception details.
  * Improved refund retry handling to prevent over-refunding when payment provider balances are stale or change during a retry.
  * Skipped refund retries when no refundable balance remains.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->