### PR TITLE
Guard late invoice payments for ended subscriptions

### DIFF
--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -525,6 +525,116 @@ describe("POST /api/subscription/webhook", () => {
     );
   });
 
+  it.each(["canceled", "incomplete_expired"] as const)(
+    "skips paid invoice side effects for a terminal %s subscription",
+    async (subscriptionStatus) => {
+      mockGetReferralRewardConfig.mockReturnValue({
+        enabled: true,
+        referrerRewardDollars: 10,
+      });
+      mockConstructEvent.mockReturnValue({
+        id: `evt_invoice_paid_${subscriptionStatus}`,
+        type: "invoice.paid",
+        data: {
+          object: {
+            id: `in_${subscriptionStatus}`,
+            customer: "cus_terminal",
+            amount_paid: 2500,
+            currency: "usd",
+            billing_reason: "subscription_cycle",
+            parent: {
+              subscription_details: {
+                subscription: "sub_terminal",
+              },
+            },
+            status_transitions: {
+              paid_at: 1_784_456_277,
+            },
+          },
+        },
+      });
+      mockRetrieveCustomer.mockResolvedValue({
+        deleted: false,
+        id: "cus_terminal",
+        metadata: {
+          workOSOrganizationId: "org_terminal",
+        },
+      } as never);
+      mockListMemberships.mockResolvedValue({
+        autoPagination: jest
+          .fn()
+          .mockResolvedValue([{ userId: "user_terminal" }]),
+      } as never);
+      mockRetrieveSubscription.mockResolvedValue({
+        id: "sub_terminal",
+        status: subscriptionStatus,
+        canceled_at: subscriptionStatus === "canceled" ? 1_784_285_151 : null,
+        ended_at: 1_784_285_151,
+        metadata: {},
+        items: {
+          data: [
+            {
+              quantity: 1,
+              current_period_end: 1_786_900_800,
+              price: {
+                id: "price_pro",
+                lookup_key: "pro-monthly-plan",
+                recurring: { interval: "month", interval_count: 1 },
+                product: {
+                  id: "prod_pro",
+                  name: "HackerAI Pro",
+                  metadata: {},
+                },
+              },
+            },
+          ],
+        },
+      } as never);
+
+      const { POST } = await import("../route");
+
+      const response = await POST(makeWebhookRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({ received: true });
+      expect(mockPostHogWarn).toHaveBeenCalledWith(
+        "billing_invoice_paid_terminal_subscription_skipped",
+        expect.objectContaining({
+          event: "billing_invoice_paid_terminal_subscription_skipped",
+          userId: "user_terminal",
+          user_ids: ["user_terminal"],
+          org_id: "org_terminal",
+          stripe_customer_id: "cus_terminal",
+          stripe_subscription_id: "sub_terminal",
+          stripe_invoice_id: `in_${subscriptionStatus}`,
+          subscription_status: subscriptionStatus,
+          billing_reason: "subscription_cycle",
+          amount_paid_dollars: 25,
+          requires_manual_reconciliation: true,
+        }),
+      );
+      expect(mockResetRateLimitBuckets).not.toHaveBeenCalled();
+      expect(mockApplyProratedTierChangeBucket).not.toHaveBeenCalled();
+      expect(mockConvexMutation).not.toHaveBeenCalledWith(
+        "referrals.setReferralCodesPaidEligibility",
+        expect.anything(),
+      );
+      expect(mockConvexMutation).not.toHaveBeenCalledWith(
+        "unitEconomics.recordRevenueEvent",
+        expect.anything(),
+      );
+      expect(mockConvexMutation).toHaveBeenNthCalledWith(
+        2,
+        "extraUsage.checkAndMarkWebhook",
+        {
+          serviceKey: "service_key",
+          eventId: `evt_invoice_paid_${subscriptionStatus}`,
+        },
+      );
+    },
+  );
+
   it("resets the grandfathered $20 Pro price to $20 of included usage", async () => {
     const periodEnd = 1_785_000_000;
     mockConstructEvent.mockReturnValue({

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -42,6 +42,10 @@ const WEBHOOK_LOG_CONTEXT = {
   webhook: "subscription",
   route: "/api/subscription/webhook",
 };
+const TERMINAL_SUBSCRIPTION_STATUSES = new Set<Stripe.Subscription.Status>([
+  "canceled",
+  "incomplete_expired",
+]);
 
 // Linear ranking used to label tier transitions as upgrade/downgrade. Team is
 // pinned at the top because moves between team and individual plans are rare
@@ -765,6 +769,29 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
   }
 
   const { tier, subscription } = resolved;
+
+  // Stripe can keep an invoice collectible after its subscription reaches a
+  // terminal state. Paying that invoice does not reactivate the subscription,
+  // so it must not restore paid eligibility, MRR, or usage credits.
+  if (TERMINAL_SUBSCRIPTION_STATUSES.has(subscription.status)) {
+    phLogger.warn("billing_invoice_paid_terminal_subscription_skipped", {
+      event: "billing_invoice_paid_terminal_subscription_skipped",
+      userId: userIds[0],
+      user_ids: userIds,
+      org_id: orgId,
+      stripe_customer_id: customerId,
+      stripe_subscription_id: subscription.id,
+      stripe_invoice_id: invoice.id,
+      subscription_status: subscription.status,
+      billing_reason: invoice.billing_reason,
+      amount_paid_dollars: centsToDollars(invoice.amount_paid),
+      canceled_at: subscription.canceled_at,
+      ended_at: subscription.ended_at,
+      requires_manual_reconciliation: true,
+    });
+    return;
+  }
+
   const includedUsagePoints = includedUsagePointsForStripePrice(
     subscription.items?.data[0]?.price?.id,
   );


### PR DESCRIPTION
## Summary
- skip `invoice.paid` entitlement side effects when Stripe reports a terminal `canceled` or `incomplete_expired` subscription
- emit a structured reconciliation warning with invoice, subscription, customer, user, and organization identifiers
- cover both terminal states and verify the webhook remains acknowledged and idempotently marked without referral, revenue/MRR, proration, or usage-credit mutations

## Why
Stripe can leave a renewal invoice collectible after its subscription has been canceled. Paying that invoice later succeeds financially but does not reactivate the subscription. The existing webhook treated the late payment like an active renewal, which could create split state between Stripe/WorkOS entitlements and HackerAI billing side effects.

## Validation
- `corepack pnpm test --runInBand` — 296 suites, 2,922 tests passed
- `corepack pnpm typecheck`
- `corepack pnpm lint` — passes with 5 existing unrelated warnings
- `corepack pnpm exec eslint app/api/subscription/webhook/route.ts app/api/subscription/webhook/__tests__/route.test.ts`
- `corepack pnpm exec prettier --check app/api/subscription/webhook/route.ts app/api/subscription/webhook/__tests__/route.test.ts`
- `git diff --check`

## Manual verification
- In Stripe Billing recovery settings, change the production subscription cancellation window from 1 day to at least the end of the configured 1/2/3-day authentication reminder sequence; 7 days is recommended to match the current invoice recovery window.
- In Stripe test mode, deliver an `invoice.paid` event whose referenced subscription is `canceled` or `incomplete_expired`. Confirm the webhook returns 200, emits `billing_invoice_paid_terminal_subscription_skipped`, and does not restore paid entitlements or usage credits.
- Deliver a normal paid renewal for an active subscription and confirm its included usage still resets normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of paid invoices tied to canceled or expired subscriptions.
  * Prevented ineligible usage credits, tier updates, referral rewards, and related analytics from being applied in these cases.
  * Added warning reporting for invoices requiring manual reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->