### PR TITLE
Improve Agent browser recovery and finding severity calibration

### DIFF
--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -110,8 +110,8 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     );
   });
 
-  it("adds a compact finding quality contract for agent security work", async () => {
-    const prompt = await systemPrompt(
+  it("adds a compact finding quality contract in cloud and local agent modes", async () => {
+    const cloudPrompt = await systemPrompt(
       "user_123",
       "agent",
       "pro",
@@ -120,20 +120,46 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
       false,
       null,
     );
+    const localPrompt = await systemPrompt(
+      "user_123",
+      "agent",
+      "pro",
+      "agent-model",
+      null,
+      false,
+      "Local sandbox context",
+    );
 
-    expect(prompt).toContain("<finding_quality>");
-    expect(prompt).toContain(
-      "Treat scanner output, tool hits, and suspicious behavior as leads until validated with evidence",
-    );
-    expect(prompt).toContain(
-      "affected asset, concrete evidence, reliable reproduction steps, demonstrated impact, remediation guidance, and confidence level",
-    );
-    expect(prompt).toContain(
-      "Deduplicate equivalent findings and consolidate repeated evidence",
-    );
-    expect(prompt).toContain(
-      "label it as a hypothesis or needs-validation item rather than a confirmed vulnerability",
-    );
+    for (const prompt of [cloudPrompt, localPrompt]) {
+      expect(prompt).toContain("<finding_quality>");
+      expect(prompt).toContain(
+        "Treat scanner output, tool hits, and suspicious behavior as leads until validated with evidence",
+      );
+      expect(prompt).toContain(
+        "affected asset, concrete evidence, reliable reproduction steps, demonstrated impact, remediation guidance, and confidence level",
+      );
+      expect(prompt).toContain(
+        "Calibrate severity to only the weakness and impact actually demonstrated",
+      );
+      expect(prompt).toContain(
+        "demo or sandbox context, intentionally public data, real exploit prerequisites, required victim interaction or attacker position",
+      );
+      expect(prompt).toContain(
+        "demonstrated confidentiality, integrity, and availability blast radius",
+      );
+      expect(prompt).toContain(
+        "Reserve high-impact ratings for demonstrated broad or systemic impact",
+      );
+      expect(prompt).toContain(
+        "preserving severe ratings when a complete attack chain proves them",
+      );
+      expect(prompt).toContain(
+        "Deduplicate equivalent findings and consolidate repeated evidence",
+      );
+      expect(prompt).toContain(
+        "label it as a hypothesis or needs-validation item rather than a confirmed vulnerability",
+      );
+    }
   });
 
   it("does not add agent finding quality guidance to ask mode", async () => {
@@ -240,6 +266,65 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).toContain("file tool's view action");
     expect(prompt).toContain("Inline image attachments are already visible");
     expect(prompt).toContain("do not call the file view action");
+  });
+
+  it("adds browser recovery guidance only to cloud agent mode", async () => {
+    const cloudPrompt = await systemPrompt(
+      "user_123",
+      "agent",
+      "pro",
+      "agent-model",
+      null,
+      false,
+      null,
+    );
+    const localPrompt = await systemPrompt(
+      "user_123",
+      "agent",
+      "pro",
+      "agent-model",
+      null,
+      false,
+      "Local sandbox context",
+    );
+    const askPrompt = await systemPrompt(
+      "user_123",
+      "ask",
+      "pro",
+      "ask-model",
+      null,
+      false,
+      null,
+    );
+
+    expect(cloudPrompt).toContain("<agent_browser>");
+    expect(cloudPrompt).toContain(
+      "For daemon, socket, connection, or browser-not-running failures, run `agent-browser doctor`",
+    );
+    expect(cloudPrompt).toContain(
+      "use `agent-browser doctor --fix` only when the diagnosis identifies a repairable problem",
+    );
+    expect(cloudPrompt).toContain("then reopen the page and retry");
+    expect(cloudPrompt).toContain(
+      "For malformed command syntax, correct the command",
+    );
+    expect(cloudPrompt).toContain(
+      "For stale or invalid element refs, run a fresh `agent-browser snapshot -i`",
+    );
+    expect(cloudPrompt).toContain(
+      "do not blindly retry the same failing action",
+    );
+    expect(cloudPrompt).toContain(
+      "Invoke `agent-browser` directly through the terminal command tool",
+    );
+
+    for (const prompt of [localPrompt, askPrompt]) {
+      expect(prompt).not.toContain("<agent_browser>");
+      expect(prompt).not.toContain("agent-browser doctor --fix");
+      expect(prompt).not.toContain(
+        "Invoke `agent-browser` directly through the terminal command tool",
+      );
+    }
   });
 
   it("adds compact cloud sandbox tool recipes for solo security workflows", async () => {

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -83,6 +83,11 @@ Useful reading commands:
 - \`agent-browser get text @e1\`, \`agent-browser get attr @e1 href\`, \`agent-browser get url\`, and \`agent-browser get title\` for targeted extraction.
 - Use semantic locators such as \`agent-browser find role button click --name "Submit"\` when a snapshot ref is unavailable.
 
+Recovery:
+- For daemon, socket, connection, or browser-not-running failures, run \`agent-browser doctor\`; use \`agent-browser doctor --fix\` only when the diagnosis identifies a repairable problem, then reopen the page and retry.
+- For malformed command syntax, correct the command. For stale or invalid element refs, run a fresh \`agent-browser snapshot -i\`; do not blindly retry the same failing action.
+- Invoke \`agent-browser\` directly through the terminal command tool; use a shell wrapper only when the command requires shell composition.
+
 Screenshots:
 - \`agent-browser screenshot\` writes an image under /home/user/agent-browser-screenshots by default and prints the path.
 - Use the file tool's view action on the printed screenshot path when visual inspection is needed.
@@ -319,6 +324,8 @@ When running security scans:
 Treat scanner output, tool hits, and suspicious behavior as leads until validated with evidence.
 A vulnerability is report-ready only when it includes the affected asset, concrete evidence, reliable reproduction steps, demonstrated impact, remediation guidance, and confidence level.
 Document relevant exploit chains, prerequisites, account roles, payloads, requests/responses, screenshots, logs, or code references needed for the user to reproduce the issue.
+Calibrate severity to only the weakness and impact actually demonstrated. Account honestly for demo or sandbox context, intentionally public data, real exploit prerequisites, required victim interaction or attacker position, and the demonstrated confidentiality, integrity, and availability blast radius.
+Reserve high-impact ratings for demonstrated broad or systemic impact, while preserving severe ratings when a complete attack chain proves them.
 Deduplicate equivalent findings and consolidate repeated evidence instead of reporting the same issue multiple times.
 If impact cannot be reproduced, label it as a hypothesis or needs-validation item rather than a confirmed vulnerability.
 </finding_quality>


### PR DESCRIPTION
## Summary
- guide cloud Agent mode to diagnose daemon, socket, connection, and browser-not-running failures before repairing and retrying
- correct malformed browser commands or resnapshot stale element references instead of blindly looping, while preferring direct invocations
- calibrate finding severity to the demonstrated weakness, prerequisites, context, and confidentiality/integrity/availability blast radius
- add prompt contract coverage for the intended Agent and sandbox boundaries

## Why
The cloud browser prompt covered the normal interaction workflow but did not distinguish infrastructure recovery from command or element-reference errors. The finding-quality contract also needed an explicit calibration rule so ratings track the impact actually proven without discounting complete severe attack chains.

## Scope
Prompt and contract-test changes only. The cloud image and structured finding/report behavior are unchanged.

## Validation
- `corepack pnpm test -- lib/__tests__/system-prompt.test.ts --runInBand` (20 tests)
- `corepack pnpm typecheck`
- `corepack pnpm lint` (passes with five existing warnings)
- `corepack pnpm exec prettier --check lib/system-prompt.ts lib/__tests__/system-prompt.test.ts`
- pre-commit full Jest suite (296 suites, 2,923 tests)

## Manual verification
- In a cloud Agent chat, run a browser workflow against a test page. For a daemon/socket/browser-not-running error, confirm the Agent diagnoses first, repairs only when indicated, reopens, and retries; for syntax or stale-ref errors, confirm it corrects or resnapshots instead of repeating the same action.
- Ask Agent mode to assess both a demo/public-data weakness and a complete high-impact attack chain. Confirm each rating follows the demonstrated prerequisites and confidentiality/integrity/availability blast radius.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer browser recovery guidance for diagnosing failures, correcting commands, and refreshing stale references.
  * Added stricter guidance for calibrating vulnerability severity based on demonstrated impact, sandbox limitations, and required conditions.

* **Bug Fixes**
  * Improved prompt behavior by limiting browser recovery instructions to cloud agent mode and ensuring finding-quality guidance applies consistently across agent contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->