### PR TITLE
Clean sandbox build caches

### DIFF
--- a/__tests__/dockerfile-cache-cleanup.test.ts
+++ b/__tests__/dockerfile-cache-cleanup.test.ts
@@ -57,27 +57,27 @@ describe("sandbox Dockerfile cache cleanup", () => {
   });
 
   test("disables pip's download cache for every package installation", () => {
-    const pipRuns = runInstructions.filter((run) =>
-      run.includes("pip3 install"),
+    const pipCommands = runInstructions.flatMap((run) =>
+      run.split("&&").filter((command) => command.includes("pip3 install")),
     );
 
-    expect(pipRuns).not.toHaveLength(0);
-    for (const run of pipRuns) {
-      expect(run.match(/pip3 install/g)).toHaveLength(
-        run.match(/--no-cache-dir/g)?.length ?? 0,
-      );
+    expect(pipCommands).not.toHaveLength(0);
+    for (const command of pipCommands) {
+      expect(command).toContain("--no-cache-dir");
     }
   });
 
   test("removes the temporary npm cache before validating agent-browser", () => {
     const npmRun = findRun("agent-browser@0.26.0");
+    const installIndex = npmRun.indexOf("npm install");
     const cleanupIndex = npmRun.indexOf("rm -rf /tmp/npm-cache");
     const doctorIndex = npmRun.indexOf(
       "agent-browser doctor --offline --quick",
     );
 
     expect(npmRun).toContain("--cache /tmp/npm-cache");
-    expect(cleanupIndex).toBeGreaterThan(-1);
+    expect(installIndex).toBeGreaterThan(-1);
+    expect(cleanupIndex).toBeGreaterThan(installIndex);
     expect(doctorIndex).toBeGreaterThan(cleanupIndex);
   });
 
@@ -85,9 +85,13 @@ describe("sandbox Dockerfile cache cleanup", () => {
     const goRun = findRun(
       "github.com/projectdiscovery/interactsh/cmd/interactsh-client",
     );
+    const lastInstallIndex = goRun.lastIndexOf("go install");
+    const cleanIndex = goRun.indexOf("go clean -cache -modcache");
+    const removeIndex = goRun.indexOf('rm -rf "$GOCACHE" "$GOPATH/pkg/mod"');
 
-    expect(goRun).toContain("go clean -cache -modcache");
-    expect(goRun).toContain('rm -rf "$GOCACHE" "$GOPATH/pkg/mod"');
+    expect(lastInstallIndex).toBeGreaterThan(-1);
+    expect(cleanIndex).toBeGreaterThan(lastInstallIndex);
+    expect(removeIndex).toBeGreaterThan(cleanIndex);
   });
 
   test("validates caches and important runtimes after cleanup", () => {
@@ -118,5 +122,6 @@ describe("sandbox Dockerfile cache cleanup", () => {
 
     expect(dockerfile.match(/^FROM\b/gm)).toHaveLength(1);
     expect(template).toContain(".fromDockerfile(");
+    expect(template).toContain('resolve(__dirname, "../docker/Dockerfile")');
   });
 });

--- a/__tests__/dockerfile-cache-cleanup.test.ts
+++ b/__tests__/dockerfile-cache-cleanup.test.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const dockerfilePath = resolve(process.cwd(), "docker/Dockerfile");
+const dockerfile = readFileSync(dockerfilePath, "utf8");
+
+function parseInstructions(source: string): string[] {
+  const instructions: string[] = [];
+  let current = "";
+
+  for (const line of source.split("\n")) {
+    if (/^\s*(?:#.*)?$/.test(line)) {
+      continue;
+    }
+
+    current += `${current ? "\n" : ""}${line}`;
+
+    if (!line.trimEnd().endsWith("\\")) {
+      instructions.push(current);
+      current = "";
+    }
+  }
+
+  return instructions;
+}
+
+const instructions = parseInstructions(dockerfile);
+const runInstructions = instructions.filter((instruction) =>
+  instruction.startsWith("RUN "),
+);
+
+function findRun(fragment: string): string {
+  const instruction = runInstructions.find((run) => run.includes(fragment));
+
+  if (!instruction) {
+    throw new Error(
+      `Missing Dockerfile RUN instruction containing: ${fragment}`,
+    );
+  }
+
+  return instruction;
+}
+
+describe("sandbox Dockerfile cache cleanup", () => {
+  test("removes apt metadata in every apt installation layer", () => {
+    const aptRuns = runInstructions.filter(
+      (run) =>
+        run.includes("apt-get install") || run.includes("apt-get upgrade"),
+    );
+
+    expect(aptRuns).not.toHaveLength(0);
+    for (const run of aptRuns) {
+      expect(run).toContain("apt-get clean");
+      expect(run).toContain("/var/lib/apt/lists/*");
+      expect(run).toContain("/var/cache/apt/archives/*");
+    }
+  });
+
+  test("disables pip's download cache for every package installation", () => {
+    const pipRuns = runInstructions.filter((run) =>
+      run.includes("pip3 install"),
+    );
+
+    expect(pipRuns).not.toHaveLength(0);
+    for (const run of pipRuns) {
+      expect(run.match(/pip3 install/g)).toHaveLength(
+        run.match(/--no-cache-dir/g)?.length ?? 0,
+      );
+    }
+  });
+
+  test("removes the temporary npm cache before validating agent-browser", () => {
+    const npmRun = findRun("agent-browser@0.26.0");
+    const cleanupIndex = npmRun.indexOf("rm -rf /tmp/npm-cache");
+    const doctorIndex = npmRun.indexOf(
+      "agent-browser doctor --offline --quick",
+    );
+
+    expect(npmRun).toContain("--cache /tmp/npm-cache");
+    expect(cleanupIndex).toBeGreaterThan(-1);
+    expect(doctorIndex).toBeGreaterThan(cleanupIndex);
+  });
+
+  test("removes Go module and build caches after installing binaries", () => {
+    const goRun = findRun(
+      "github.com/projectdiscovery/interactsh/cmd/interactsh-client",
+    );
+
+    expect(goRun).toContain("go clean -cache -modcache");
+    expect(goRun).toContain('rm -rf "$GOCACHE" "$GOPATH/pkg/mod"');
+  });
+
+  test("validates caches and important runtimes after cleanup", () => {
+    const validationRun = findRun("=== Starting tool validation ===");
+
+    for (const expected of [
+      "test ! -e /home/user/.cache/pip",
+      "test ! -e /tmp/npm-cache",
+      'test ! -e "$GOCACHE"',
+      'test ! -e "$GOPATH/pkg/mod"',
+      "which interactsh-client",
+      "which katana",
+      "which cvemap",
+      "which agent-browser",
+      "which go",
+      "which python3",
+      "which node",
+    ]) {
+      expect(validationRun).toContain(expected);
+    }
+  });
+
+  test("keeps the E2B Dockerfile build single-stage", () => {
+    const template = readFileSync(
+      resolve(process.cwd(), "e2b/template.ts"),
+      "utf8",
+    );
+
+    expect(dockerfile.match(/^FROM\b/gm)).toHaveLength(1);
+    expect(template).toContain(".fromDockerfile(");
+  });
+});

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,8 @@ ENV PATH=/home/user/.local/bin:/usr/local/go/bin:/home/user/go/bin:/usr/local/sb
 RUN apt-get update && \
     apt-get install -y kali-archive-keyring sudo && \
     apt-get update && \
-    apt-get upgrade -y
+    apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 # ============================================================================
 # Core System Packages
@@ -173,7 +174,7 @@ RUN printf 'export PATH=/home/user/.local/bin:/usr/local/go/bin:/home/user/go/bi
 # ============================================================================
 # Python Packages for Document Generation & Security Tools
 # ============================================================================
-RUN pip3 install --break-system-packages \
+RUN pip3 install --break-system-packages --no-cache-dir \
     reportlab \
     python-docx \
     openpyxl \
@@ -187,8 +188,8 @@ RUN pip3 install --break-system-packages \
 # requirement, and pip cannot uninstall dpkg-owned packages without RECORD
 # metadata. Install a pip-managed compatible rich first so httpx[cli] resolves
 # against /usr/local without touching the distro package.
-RUN pip3 install --break-system-packages --ignore-installed 'rich<14,>=10' && \
-    pip3 install --break-system-packages requests aiohttp jinja2 'httpx[cli]' ratelimit pycryptodomex
+RUN pip3 install --break-system-packages --no-cache-dir --ignore-installed 'rich<14,>=10' && \
+    pip3 install --break-system-packages --no-cache-dir requests aiohttp jinja2 'httpx[cli]' ratelimit pycryptodomex
 
 # ============================================================================
 # Git-based Security Tools
@@ -245,7 +246,8 @@ ENV AGENT_BROWSER_USER_AGENT="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
 ENV AGENT_BROWSER_ARGS="--disable-blink-features=AutomationControlled,--no-first-run,--no-default-browser-check,--disable-dev-shm-usage,--no-sandbox,--lang=en-US"
 ENV AGENT_BROWSER_SCREENSHOT_DIR=/home/user/agent-browser-screenshots
 
-RUN npm install -g agent-browser@0.26.0 && \
+RUN npm install -g --cache /tmp/npm-cache agent-browser@0.26.0 && \
+    rm -rf /tmp/npm-cache && \
     mkdir -p /home/user/agent-browser-screenshots && \
     chown -R user:user /home/user/agent-browser-screenshots && \
     agent-browser doctor --offline --quick
@@ -256,7 +258,9 @@ RUN npm install -g agent-browser@0.26.0 && \
 RUN set -eux; \
     go install github.com/projectdiscovery/interactsh/cmd/interactsh-client@latest && \
     go install github.com/projectdiscovery/katana/cmd/katana@latest && \
-    go install github.com/projectdiscovery/cvemap/cmd/cvemap@latest
+    go install github.com/projectdiscovery/cvemap/cmd/cvemap@latest && \
+    go clean -cache -modcache && \
+    rm -rf "$GOCACHE" "$GOPATH/pkg/mod"
 
 # ============================================================================
 # TestSSL Symlink - Allow access via both 'testssl' and 'testssl.sh'
@@ -276,6 +280,12 @@ RUN nuclei -update-templates
 # ============================================================================
 RUN set -eux; \
     echo "=== Starting tool validation ===" && \
+    test -z "$(find /var/lib/apt/lists -mindepth 1 -print -quit)" && \
+    test -z "$(find /var/cache/apt/archives -mindepth 1 -print -quit)" && \
+    test ! -e /home/user/.cache/pip && \
+    test ! -e /tmp/npm-cache && \
+    test ! -e "$GOCACHE" && \
+    test ! -e "$GOPATH/pkg/mod" && \
     test -d /usr/share/seclists && \
     echo "✓ SecLists installed" && \
     which nmap && echo "✓ nmap" && \


### PR DESCRIPTION
## Summary
- clean apt metadata in the same layer as the initial system upgrade
- disable pip download caching, use and remove a temporary npm cache before `agent-browser doctor`, and delete Go module/build caches after installing the Go binaries
- assert that targeted caches are absent before validating the existing runtime tools
- add focused structural coverage for same-layer cleanup and the single-stage E2B Dockerfile contract

## Why
The sandbox Dockerfile removed some cache paths only in its final layer. Docker preserves files added by earlier layers, and the final recursive ownership pass can copy up retained content under `/home/user`, so those late deletions do not reclaim the earlier layer bytes.

## Measured result
Paired local arm64 builds used `origin/main` and this PR head, the same Kali base digest, and the same package-source window:

| | `origin/main` | PR head |
| --- | ---: | ---: |
| Docker-reported image size | 4,338,949,710 bytes (4.04 GiB) | 2,434,434,019 bytes (2.27 GiB) |
| Go build cache | 766,050,606 bytes | absent |
| Go module cache | 1,101,026,306 bytes | absent |
| npm cache | 32,995,611 bytes | absent |

The image is 1,904,515,691 bytes (1.77 GiB, 43.9%) smaller. Docker history also shows the Go install layer decreasing from approximately 2.15 GB to 151 MB, the final cleanup/ownership layer from approximately 2.18 GB to 151 MB, and the agent-browser install layer from 108 MB to 74.8 MB.

Both builds used a measurement-only direct URL for the current httpx arm64 release asset because the unchanged latest-release API lookup was rate-limited. This temporary adjustment was identical in both build contexts and is not part of the branch.

## Behavior and compatibility
- keeps every runtime tool, programming language, build dependency, locale, document utility, man page, and nuclei template
- keeps `agent-browser` 0.26.0 and its existing offline quick doctor check
- keeps the Dockerfile single-stage for `Template.fromDockerfile` compatibility
- does not change E2B template names, runtime paths, or sandbox behavior

## Validation
- paired local Docker builds for `linux/arm64` from `origin/main` and the PR head
- cleaned-image runtime `agent-browser doctor --offline --quick` (5 pass, 0 warn, 0 fail)
- cleaned-image runtime presence checks for `interactsh-client`, `katana`, `cvemap`, Go, Python, Node, npm, and pip
- cleaned-image Python imports for reportlab, python-docx, openpyxl, python-pptx, pandas, odfpy, and requests
- cleaned-image absence checks for Go build/module caches, pip cache, npm cache, temporary npm cache, and apt metadata/archives
- commit hooks: `pnpm typecheck`
- commit hooks: `pnpm test` (297 suites, 2,928 tests)
- `corepack pnpm jest __tests__/dockerfile-cache-cleanup.test.ts --runInBand` (6 tests)
- `corepack pnpm exec eslint __tests__/dockerfile-cache-cleanup.test.ts`
- `corepack pnpm exec prettier --check __tests__/dockerfile-cache-cleanup.test.ts`
- E2B `Template.fromDockerfile` load through the repository's `tsx` execution path (succeeded with only the existing unsupported `LABEL`/`SHELL` notices)

## Manual verification
1. Build the E2B template from `docker/Dockerfile` and start a sandbox.
2. Run `agent-browser doctor --offline --quick` and confirm it completes without warnings or failures.
3. Confirm `interactsh-client`, `katana`, `cvemap`, `go`, `python3`, and `node` resolve in the sandbox.
4. Confirm `/home/user/go/.cache`, `/home/user/go/pkg/mod`, `/home/user/.cache/pip`, `/home/user/.npm`, and `/tmp/npm-cache` are absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced leftover package and build caches in the sandbox environment.
  * Tightened cleanup for system packages after installation.
  * Updated Python installs to avoid caching and improved post-install cache removal.
  * Improved Node.js and Go tool installation cleanup by removing temporary caches.
  * Added stronger pre-validation to confirm caches are absent before proceeding.
  * Preserved the sandbox’s single-stage container build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
