### PR TITLE
Bound stalled provider model streams

### DIFF
--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -703,6 +703,31 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(agentStreamRunnerSrc).toMatch(/experimental_onToolCallStart/);
   });
 
+  test("shares a provider-only inactivity guard without timing terminal tools", () => {
+    expect(agentStreamRunnerSrc).toMatch(
+      /createProviderStreamTimeoutGuard\(\{/,
+    );
+    expect(agentStreamRunnerSrc).toMatch(
+      /experimental_onStepStart:[\s\S]*startProviderStep\(\)/,
+    );
+    expect(agentStreamRunnerSrc).toMatch(
+      /experimental_onToolCallStart:[\s\S]*pauseForToolExecution\(\)/,
+    );
+    expect(agentStreamRunnerSrc).toMatch(
+      /onChunk:[\s\S]*recordProviderActivity\(\)/,
+    );
+    expect(agentStreamRunnerSrc).toMatch(
+      /onStepFinish:[\s\S]*finishProviderStep\(\)/,
+    );
+
+    for (const source of [taskSrc, chatHandlerSrc]) {
+      expect(source).toMatch(/state\.stoppedDueToProviderStreamTimeout/);
+      expect(source).toMatch(
+        /!isAborted\s*\|\|\s*state\.stoppedDueToProviderStreamTimeout/,
+      );
+    }
+  });
+
   test("validates agent trigger request bodies before auth and Trigger work", () => {
     expect(routeSrc).toMatch(/parseAgentTriggerRequestBody/);
     expect(routeSrc).toMatch(/Invalid JSON body/);

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -1,5 +1,6 @@
 import type { ModelMessage, UIMessage } from "ai";
 import { MAX_CONTEXT_COMPACTION_ATTEMPTS_PER_AGENT_STREAM } from "@/lib/chat/summarization/constants";
+import { PROVIDER_STREAM_INACTIVITY_TIMEOUT_MS } from "@/lib/api/provider-stream-timeout";
 
 const mockStreamText = jest.fn();
 const mockRunSummarizationStep = jest.fn();
@@ -81,7 +82,10 @@ jest.mock("@/lib/ai/providers", () => ({
     modelName === "model-deepseek-v4-flash",
 }));
 jest.mock("@/lib/ai/tools/utils/pty-session-manager", () => ({
-  ptySessionManager: { closeAllSessions: jest.fn() },
+  ptySessionManager: {
+    closeAll: jest.fn(() => Promise.resolve()),
+    closeAllSessions: jest.fn(),
+  },
 }));
 jest.mock("@/lib/ai/tools/prompt-serialization", () => ({
   createPromptSerializationTools: () => ({}),
@@ -279,6 +283,65 @@ describe("createAgentStream repeated compaction", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockStreamText.mockImplementation((options) => options);
+  });
+
+  it("classifies a no-first-chunk guard abort as a provider timeout", async () => {
+    jest.useFakeTimers();
+    try {
+      const usageRefundTracker = { refund: jest.fn(() => Promise.resolve()) };
+      const chatLogger = {
+        recordProviderRequestDiagnostics: jest.fn(),
+        recordProviderError: jest.fn(),
+      };
+      const onModelStreamStart = jest.fn();
+      const onModelStreamFinish = jest.fn();
+      const state = initAgentStreamState([uiMessage("initial", "hello")], {
+        usedTokens: 0,
+        maxTokens: 128_000,
+      });
+      const stream = (await createAgentStream(
+        "test-model",
+        createTestStreamContext({
+          usageTracker: { hasUsage: false },
+          usageRefundTracker,
+          chatLogger,
+          onModelStreamStart,
+          onModelStreamFinish,
+        }) as any,
+        state,
+      )) as any;
+
+      stream.experimental_onStepStart();
+      await jest.advanceTimersByTimeAsync(
+        PROVIDER_STREAM_INACTIVITY_TIMEOUT_MS,
+      );
+
+      expect(stream.abortSignal.aborted).toBe(true);
+      expect(state).toMatchObject({
+        stoppedDueToProviderStreamTimeout: true,
+        streamFinishReason: "error",
+        providerError: expect.objectContaining({
+          name: "ProviderStreamTimeoutError",
+          code: "PROVIDER_STREAM_TIMEOUT",
+          phase: "first_chunk",
+        }),
+      });
+      expect(onModelStreamStart).toHaveBeenCalledTimes(1);
+      expect(onModelStreamFinish).toHaveBeenCalledTimes(1);
+
+      await stream.onAbort({ steps: [] });
+
+      expect(chatLogger.recordProviderError).toHaveBeenCalledWith(
+        state.providerError,
+        expect.objectContaining({
+          mode: "agent",
+          model: "test-model",
+        }),
+      );
+      expect(usageRefundTracker.refund).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it("rebases every later prepareStep onto the latest in-run summary", async () => {

--- a/lib/api/__tests__/provider-stream-timeout.test.ts
+++ b/lib/api/__tests__/provider-stream-timeout.test.ts
@@ -1,0 +1,114 @@
+import {
+  getProviderErrorCategory,
+  extractErrorDetails,
+} from "@/lib/utils/error-utils";
+import {
+  createProviderStreamTimeoutGuard,
+  ProviderStreamTimeoutError,
+} from "@/lib/api/provider-stream-timeout";
+
+describe("provider stream inactivity timeout", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("times out a provider step that never emits a first chunk", async () => {
+    const externalAbortController = new AbortController();
+    const onTimeout = jest.fn();
+    const guard = createProviderStreamTimeoutGuard({
+      externalAbortSignal: externalAbortController.signal,
+      onTimeout,
+      timeoutMs: 100,
+    });
+
+    guard.startProviderStep();
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(guard.signal.aborted).toBe(true);
+    expect(guard.getTimeoutError()).toMatchObject({
+      name: "ProviderStreamTimeoutError",
+      code: "PROVIDER_STREAM_TIMEOUT",
+      phase: "first_chunk",
+      timeoutMs: 100,
+    });
+    expect(guard.signal.reason).toBe(guard.getTimeoutError());
+    expect(onTimeout).toHaveBeenCalledWith(guard.getTimeoutError());
+  });
+
+  it("resets the deadline for activity and classifies a between-chunk stall", async () => {
+    const guard = createProviderStreamTimeoutGuard({
+      externalAbortSignal: new AbortController().signal,
+      onTimeout: jest.fn(),
+      timeoutMs: 100,
+    });
+
+    guard.startProviderStep();
+    await jest.advanceTimersByTimeAsync(90);
+    guard.recordProviderActivity();
+    await jest.advanceTimersByTimeAsync(99);
+    expect(guard.signal.aborted).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(1);
+
+    expect(guard.getTimeoutError()).toMatchObject({
+      phase: "between_chunks",
+    });
+    expect(guard.signal.aborted).toBe(true);
+  });
+
+  it("keeps explicit user abort separate from an internal timeout", async () => {
+    const externalAbortController = new AbortController();
+    const onTimeout = jest.fn();
+    const guard = createProviderStreamTimeoutGuard({
+      externalAbortSignal: externalAbortController.signal,
+      onTimeout,
+      timeoutMs: 100,
+    });
+
+    guard.startProviderStep();
+    externalAbortController.abort(
+      new DOMException("The user stopped the run", "AbortError"),
+    );
+    await jest.advanceTimersByTimeAsync(1_000);
+
+    expect(guard.signal.aborted).toBe(false);
+    expect(guard.getTimeoutError()).toBeUndefined();
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("does not time out a long terminal tool execution", async () => {
+    const guard = createProviderStreamTimeoutGuard({
+      externalAbortSignal: new AbortController().signal,
+      onTimeout: jest.fn(),
+      timeoutMs: 100,
+    });
+
+    guard.startProviderStep();
+    guard.recordProviderActivity();
+    guard.pauseForToolExecution();
+    await jest.advanceTimersByTimeAsync(10_000);
+
+    expect(guard.signal.aborted).toBe(false);
+
+    guard.startProviderStep();
+    await jest.advanceTimersByTimeAsync(100);
+    expect(guard.getTimeoutError()).toMatchObject({
+      phase: "first_chunk",
+    });
+  });
+
+  it("uses the existing provider timeout error category", () => {
+    const error = new ProviderStreamTimeoutError({
+      phase: "between_chunks",
+      timeoutMs: 120_000,
+    });
+
+    expect(getProviderErrorCategory(extractErrorDetails(error))).toBe(
+      "timeout",
+    );
+  });
+});

--- a/lib/api/__tests__/provider-stream-timeout.test.ts
+++ b/lib/api/__tests__/provider-stream-timeout.test.ts
@@ -4,6 +4,7 @@ import {
 } from "@/lib/utils/error-utils";
 import {
   createProviderStreamTimeoutGuard,
+  PROVIDER_STREAM_INACTIVITY_TIMEOUT_MS,
   ProviderStreamTimeoutError,
 } from "@/lib/api/provider-stream-timeout";
 
@@ -14,6 +15,10 @@ describe("provider stream inactivity timeout", () => {
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  it("uses a five-minute provider inactivity window by default", () => {
+    expect(PROVIDER_STREAM_INACTIVITY_TIMEOUT_MS).toBe(5 * 60 * 1000);
   });
 
   it("times out a provider step that never emits a first chunk", async () => {
@@ -104,7 +109,7 @@ describe("provider stream inactivity timeout", () => {
   it("uses the existing provider timeout error category", () => {
     const error = new ProviderStreamTimeoutError({
       phase: "between_chunks",
-      timeoutMs: 120_000,
+      timeoutMs: PROVIDER_STREAM_INACTIVITY_TIMEOUT_MS,
     });
 
     expect(getProviderErrorCategory(extractErrorDetails(error))).toBe(

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -92,6 +92,7 @@ import {
   extractOpenRouterMetadata,
   mergeOpenRouterMetadata,
 } from "@/lib/api/openrouter-metadata";
+import { createProviderStreamTimeoutGuard } from "@/lib/api/provider-stream-timeout";
 import { getOpenRouterUpstreamInferenceCostFromUsageRaw } from "@/lib/provider-usage-cost";
 import { classifyProviderOverflowError } from "@/lib/utils/error-utils";
 import type { UsageTracker } from "@/lib/usage-tracker";
@@ -199,6 +200,8 @@ export type AgentStreamState = {
   stoppedDueToTokenExhaustion: boolean;
   /** Maps to stoppedDueToPreemptiveTimeout in chat-handler, stoppedDueToElapsedTimeout in agent-long. */
   stoppedDueToElapsedTimeout: boolean;
+  /** Internal provider inactivity timeout; distinct from caller/user aborts. */
+  stoppedDueToProviderStreamTimeout: boolean;
   stoppedDueToDoomLoop: boolean;
   stoppedDueToAssistantContentLoop: boolean;
   assistantContentLoopDetection: AssistantContentLoopDetection | undefined;
@@ -227,6 +230,7 @@ export function initAgentStreamState(
     providerRejectedMultimodalToolResults: false,
     stoppedDueToTokenExhaustion: false,
     stoppedDueToElapsedTimeout: false,
+    stoppedDueToProviderStreamTimeout: false,
     stoppedDueToDoomLoop: false,
     stoppedDueToAssistantContentLoop: false,
     assistantContentLoopDetection: undefined,
@@ -302,16 +306,16 @@ const combineAbortSignals = (signals: AbortSignal[]): AbortSignal => {
   }
 
   const controller = new AbortController();
-  const abort = () => {
-    if (!controller.signal.aborted) controller.abort();
+  const abort = (signal: AbortSignal) => {
+    if (!controller.signal.aborted) controller.abort(signal.reason);
   };
 
   for (const signal of signals) {
     if (signal.aborted) {
-      abort();
+      abort(signal);
       break;
     }
-    signal.addEventListener("abort", abort, { once: true });
+    signal.addEventListener("abort", () => abort(signal), { once: true });
   }
 
   return controller.signal;
@@ -536,10 +540,6 @@ export async function createAgentStream(
   let lastRequestedSlug = requestedSlug;
   const assistantContentLoopMonitor = createAssistantContentLoopMonitor();
   const assistantContentLoopAbortController = new AbortController();
-  const abortSignal = combineAbortSignals([
-    ctx.abortController.signal,
-    assistantContentLoopAbortController.signal,
-  ]);
   const summarizationThreshold = getSummarizationThresholdTokens(
     getMaxTokensForSubscription(ctx.subscription, { mode: ctx.mode }),
   );
@@ -727,6 +727,64 @@ export async function createAgentStream(
     );
     return latestProviderRequestDiagnostics;
   };
+  let recordedProviderError: unknown;
+  const recordProviderError = async (error: unknown) => {
+    if (recordedProviderError === error) return;
+    recordedProviderError = error;
+    state.providerError = error;
+    if (
+      streamHasImageViewResults &&
+      isProviderMultimodalToolResultRejectionError(error)
+    ) {
+      state.providerRejectedMultimodalToolResults = true;
+    }
+    const overflowKind = classifyProviderOverflowError(error);
+    if (overflowKind) {
+      state.stoppedDueToTokenExhaustion = true;
+      state.streamFinishReason = TOKEN_EXHAUSTION_FINISH_REASON;
+      console.warn("[agent-stream] provider overflow detected", {
+        overflowKind,
+        chatId: ctx.chatId,
+        model: modelName,
+        hadSummarization: ctx.summarizationTracker.hasSummarized,
+      });
+    }
+    if (!isXaiSafetyError(error)) {
+      const fallbackSlugs = getFallbackSlugs(modelName, ctx.mode, {
+        hasMultimodalToolResults: streamHasImageViewResults,
+      });
+      ctx.chatLogger?.recordProviderError(error, {
+        mode: ctx.mode,
+        model: modelName,
+        requestedModelSlug: requestedSlug,
+        fallbackModelSlugs:
+          fallbackSlugs.length > 0 ? fallbackSlugs : undefined,
+        userId: ctx.userId,
+        subscription: ctx.subscription,
+        isTemporary: ctx.temporary,
+        providerRequest: latestProviderRequestDiagnostics,
+      });
+    }
+    if (!ctx.usageTracker.hasUsage) {
+      await ctx.usageRefundTracker.refund();
+    }
+  };
+  let providerTimeoutCleanupPromise: Promise<void> | undefined;
+  const providerStreamTimeoutGuard = createProviderStreamTimeoutGuard({
+    externalAbortSignal: ctx.abortController.signal,
+    onTimeout: (error) => {
+      state.stoppedDueToProviderStreamTimeout = true;
+      state.streamFinishReason = "error";
+      state.providerError = error;
+      ctx.onModelStreamFinish?.();
+      providerTimeoutCleanupPromise = recordProviderError(error);
+    },
+  });
+  const abortSignal = combineAbortSignals([
+    ctx.abortController.signal,
+    assistantContentLoopAbortController.signal,
+    providerStreamTimeoutGuard.signal,
+  ]);
   const initialModelInfo = getEffectiveModelInfo();
   const initialProviderOptions = getStepProviderOptions(
     initialModelInfo.modelName,
@@ -760,8 +818,14 @@ export async function createAgentStream(
     activeTools: initialActiveTools,
     abortSignal,
     providerOptions: initialProviderOptions,
-    experimental_onStepStart: () => ctx.onModelStreamStart?.(),
-    experimental_onToolCallStart: () => ctx.onModelStreamFinish?.(),
+    experimental_onStepStart: () => {
+      providerStreamTimeoutGuard.startProviderStep();
+      ctx.onModelStreamStart?.();
+    },
+    experimental_onToolCallStart: () => {
+      providerStreamTimeoutGuard.pauseForToolExecution();
+      ctx.onModelStreamFinish?.();
+    },
 
     prepareStep: async ({ steps, messages }) => {
       const rawModelMessages = messages as ModelMessage[];
@@ -1141,6 +1205,7 @@ export async function createAgentStream(
     ],
 
     onChunk: async (chunk) => {
+      providerStreamTimeoutGuard.recordProviderActivity();
       if (chunk.chunk.type === "text-delta") {
         if (state.postSummarizationContinuationActive) {
           state.postSummarizationText += chunk.chunk.text;
@@ -1174,6 +1239,7 @@ export async function createAgentStream(
       }
 
       if (chunk.chunk.type === "tool-call") {
+        providerStreamTimeoutGuard.pauseForToolExecution();
         if (state.postSummarizationContinuationActive) {
           state.postSummarizationToolCallCount++;
         }
@@ -1185,6 +1251,7 @@ export async function createAgentStream(
     },
 
     onStepFinish: async ({ usage, response, providerMetadata, content }) => {
+      providerStreamTimeoutGuard.finishProviderStep();
       ctx.onModelStreamFinish?.();
       recordAgentStepCompletion(ctx.completionSignalTracker, content);
       let stepUsageCostIndex: number | undefined;
@@ -1237,6 +1304,7 @@ export async function createAgentStream(
     },
 
     onFinish: async (finishResult) => {
+      providerStreamTimeoutGuard.dispose();
       ctx.onModelStreamFinish?.();
       const { finishReason, usage, response } = finishResult;
       const hardReason = ctx.getHardTimeoutReason();
@@ -1263,6 +1331,8 @@ export async function createAgentStream(
       }
       if (hardReason !== null) {
         state.streamFinishReason = hardReason;
+      } else if (state.stoppedDueToProviderStreamTimeout) {
+        state.streamFinishReason = "error";
       } else if (state.stoppedDueToElapsedTimeout) {
         state.streamFinishReason = PREEMPTIVE_TIMEOUT_FINISH_REASON;
       } else if (state.stoppedDueToTokenExhaustion) {
@@ -1355,43 +1425,8 @@ export async function createAgentStream(
     },
 
     onError: async ({ error }) => {
-      state.providerError = error;
-      if (
-        streamHasImageViewResults &&
-        isProviderMultimodalToolResultRejectionError(error)
-      ) {
-        state.providerRejectedMultimodalToolResults = true;
-      }
-      const overflowKind = classifyProviderOverflowError(error);
-      if (overflowKind) {
-        state.stoppedDueToTokenExhaustion = true;
-        state.streamFinishReason = TOKEN_EXHAUSTION_FINISH_REASON;
-        console.warn("[agent-stream] provider overflow detected", {
-          overflowKind,
-          chatId: ctx.chatId,
-          model: modelName,
-          hadSummarization: ctx.summarizationTracker.hasSummarized,
-        });
-      }
-      if (!isXaiSafetyError(error)) {
-        const fallbackSlugs = getFallbackSlugs(modelName, ctx.mode, {
-          hasMultimodalToolResults: streamHasImageViewResults,
-        });
-        ctx.chatLogger?.recordProviderError(error, {
-          mode: ctx.mode,
-          model: modelName,
-          requestedModelSlug: requestedSlug,
-          fallbackModelSlugs:
-            fallbackSlugs.length > 0 ? fallbackSlugs : undefined,
-          userId: ctx.userId,
-          subscription: ctx.subscription,
-          isTemporary: ctx.temporary,
-          providerRequest: latestProviderRequestDiagnostics,
-        });
-      }
-      if (!ctx.usageTracker.hasUsage) {
-        await ctx.usageRefundTracker.refund();
-      }
+      providerStreamTimeoutGuard.dispose();
+      await recordProviderError(error);
       await ptySessionManager
         .closeAll(ctx.chatId)
         .catch((err) =>
@@ -1400,7 +1435,13 @@ export async function createAgentStream(
     },
 
     onAbort: async ({ steps }) => {
+      providerStreamTimeoutGuard.dispose();
       recordAssistantContentLoopAbortState(steps);
+      const timeoutError = providerStreamTimeoutGuard.getTimeoutError();
+      if (timeoutError) {
+        await (providerTimeoutCleanupPromise ??
+          recordProviderError(timeoutError));
+      }
       await ptySessionManager
         .closeAll(ctx.chatId)
         .catch((err) =>

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -1332,6 +1332,7 @@ export const createChatHandler = () => {
                 state.lastStepInputTokens = 0;
                 state.stoppedDueToTokenExhaustion = false;
                 state.stoppedDueToElapsedTimeout = false;
+                state.stoppedDueToProviderStreamTimeout = false;
                 state.stoppedDueToDoomLoop = false;
                 state.stoppedDueToAssistantContentLoop = false;
                 state.assistantContentLoopDetection = undefined;
@@ -1432,9 +1433,11 @@ export const createChatHandler = () => {
                           ? "assistant_content_loop"
                           : state.stoppedDueToDoomLoop
                             ? "doom_loop"
-                            : shouldRetryInterruptedToolInput
-                              ? "interrupted_tool_input"
-                              : "incomplete_stream";
+                            : state.stoppedDueToProviderStreamTimeout
+                              ? "provider_timeout"
+                              : shouldRetryInterruptedToolInput
+                                ? "interrupted_tool_input"
+                                : "incomplete_stream";
                       phLogger.warn(
                         shouldRetryWithoutImageToolResults
                           ? "Provider rejected image tool output - retrying without images"
@@ -1442,11 +1445,13 @@ export const createChatHandler = () => {
                             ? "Assistant content loop detected - triggering fallback"
                             : retryReason === "doom_loop"
                               ? "Agent doom loop detected - triggering fallback"
-                              : retryReason === "interrupted_tool_input"
-                                ? "Provider stream errored during tool input - triggering bounded fallback"
-                                : hasTerminalProviderStreamError
-                                  ? "Provider stream errored before useful output - triggering fallback"
-                                  : "Stream finished incomplete - triggering fallback",
+                              : retryReason === "provider_timeout"
+                                ? "Provider stream timed out before useful output - triggering fallback"
+                                : retryReason === "interrupted_tool_input"
+                                  ? "Provider stream errored during tool input - triggering bounded fallback"
+                                  : hasTerminalProviderStreamError
+                                    ? "Provider stream errored before useful output - triggering fallback"
+                                    : "Stream finished incomplete - triggering fallback",
                         {
                           chatId,
                           endpoint,
@@ -1476,7 +1481,9 @@ export const createChatHandler = () => {
                       // text placeholders.
                       if (
                         !isRetryWithFallback &&
-                        (!isAborted || stoppedDueToAssistantContentLoop) &&
+                        (!isAborted ||
+                          state.stoppedDueToProviderStreamTimeout ||
+                          stoppedDueToAssistantContentLoop) &&
                         (isAutoModel ||
                           shouldRetryWithoutImageToolResults ||
                           loopTriggeredRetry ||
@@ -1489,6 +1496,7 @@ export const createChatHandler = () => {
                         state.providerRejectedMultimodalToolResults = false;
                         state.stoppedDueToTokenExhaustion = false;
                         state.stoppedDueToElapsedTimeout = false;
+                        state.stoppedDueToProviderStreamTimeout = false;
                         state.stoppedDueToDoomLoop = false;
                         state.stoppedDueToAssistantContentLoop = false;
                         state.assistantContentLoopDetection = undefined;
@@ -1591,9 +1599,14 @@ export const createChatHandler = () => {
                                 // reason to budget-exhausted; do it before
                                 // analytics and persistence consume state.
                                 await deductAccumulatedUsage();
-                                const outcome = retryAborted
-                                  ? "aborted"
-                                  : "success";
+                                const retryHasTerminalProviderStreamError =
+                                  state.streamFinishReason === "error";
+                                const outcome =
+                                  retryHasTerminalProviderStreamError
+                                    ? "error"
+                                    : retryAborted
+                                      ? "aborted"
+                                      : "success";
                                 captureAgentCompletionAnalytics({
                                   posthog,
                                   userId,
@@ -1623,13 +1636,15 @@ export const createChatHandler = () => {
                                       tracker: completionSignalTracker,
                                     }),
                                 });
-                                chatLogger!.emitSuccess({
-                                  finishReason: state.streamFinishReason,
-                                  wasAborted: retryAborted,
-                                  wasPreemptiveTimeout: false,
-                                  hadSummarization:
-                                    summarizationTracker.hasSummarized,
-                                });
+                                if (!retryHasTerminalProviderStreamError) {
+                                  chatLogger!.emitSuccess({
+                                    finishReason: state.streamFinishReason,
+                                    wasAborted: retryAborted,
+                                    wasPreemptiveTimeout: false,
+                                    hadSummarization:
+                                      summarizationTracker.hasSummarized,
+                                  });
+                                }
 
                                 const generatedTitle = await titlePromise;
 
@@ -1874,7 +1889,8 @@ export const createChatHandler = () => {
                       isAborted &&
                       !isPreemptiveAbort &&
                       !state.stoppedDueToBudgetExhaustion &&
-                      !state.stoppedDueToAgentRunSpendCap
+                      !state.stoppedDueToAgentRunSpendCap &&
+                      !state.stoppedDueToProviderStreamTimeout
                     ) {
                       state.streamFinishReason = undefined;
                     }
@@ -1893,7 +1909,13 @@ export const createChatHandler = () => {
                     // budget-exhausted; do it before analytics and persistence
                     // consume state.
                     await deductAccumulatedUsage();
-                    const outcome = isAborted ? "aborted" : "success";
+                    const terminalProviderStreamError =
+                      state.streamFinishReason === "error";
+                    const outcome = terminalProviderStreamError
+                      ? "error"
+                      : isAborted
+                        ? "aborted"
+                        : "success";
                     captureAgentCompletionAnalytics({
                       posthog,
                       userId,
@@ -1921,12 +1943,14 @@ export const createChatHandler = () => {
                         tracker: completionSignalTracker,
                       }),
                     });
-                    chatLogger!.emitSuccess({
-                      finishReason: state.streamFinishReason,
-                      wasAborted: isAborted,
-                      wasPreemptiveTimeout: isPreemptiveAbort,
-                      hadSummarization: summarizationTracker.hasSummarized,
-                    });
+                    if (!terminalProviderStreamError) {
+                      chatLogger!.emitSuccess({
+                        finishReason: state.streamFinishReason,
+                        wasAborted: isAborted,
+                        wasPreemptiveTimeout: isPreemptiveAbort,
+                        hadSummarization: summarizationTracker.hasSummarized,
+                      });
+                    }
                     logStep("settle_usage_and_emit_success", stepStart);
 
                     // Sandbox cleanup is automatic with auto-pause

--- a/lib/api/provider-stream-timeout.ts
+++ b/lib/api/provider-stream-timeout.ts
@@ -1,0 +1,122 @@
+export const PROVIDER_STREAM_INACTIVITY_TIMEOUT_MS = 2 * 60 * 1000;
+export const PROVIDER_STREAM_TIMEOUT_CODE = "PROVIDER_STREAM_TIMEOUT";
+
+export type ProviderStreamTimeoutPhase = "first_chunk" | "between_chunks";
+
+export class ProviderStreamTimeoutError extends Error {
+  readonly code = PROVIDER_STREAM_TIMEOUT_CODE;
+  readonly phase: ProviderStreamTimeoutPhase;
+  readonly timeoutMs: number;
+
+  constructor(args: { phase: ProviderStreamTimeoutPhase; timeoutMs: number }) {
+    super(
+      `Provider stream timeout after ${args.timeoutMs}ms without activity (${args.phase})`,
+    );
+    this.name = "ProviderStreamTimeoutError";
+    this.phase = args.phase;
+    this.timeoutMs = args.timeoutMs;
+  }
+}
+
+type TimeoutHandle = ReturnType<typeof setTimeout> & {
+  unref?: () => void;
+};
+
+export type ProviderStreamTimeoutGuard = {
+  signal: AbortSignal;
+  startProviderStep: () => void;
+  recordProviderActivity: () => void;
+  pauseForToolExecution: () => void;
+  finishProviderStep: () => void;
+  dispose: () => void;
+  getTimeoutError: () => ProviderStreamTimeoutError | undefined;
+};
+
+/**
+ * AI SDK chunk timeouts begin after the first chunk and remain active while a
+ * tool executes. Track provider callbacks directly so both initial and
+ * between-chunk stalls are bounded without putting terminal work on the clock.
+ */
+export const createProviderStreamTimeoutGuard = (args: {
+  externalAbortSignal: AbortSignal;
+  onTimeout: (error: ProviderStreamTimeoutError) => void;
+  timeoutMs?: number;
+}): ProviderStreamTimeoutGuard => {
+  const timeoutMs = args.timeoutMs ?? PROVIDER_STREAM_INACTIVITY_TIMEOUT_MS;
+  const timeoutController = new AbortController();
+  let timeoutHandle: TimeoutHandle | undefined;
+  let providerStepActive = false;
+  let receivedProviderChunk = false;
+  let disposed = false;
+  let timeoutError: ProviderStreamTimeoutError | undefined;
+
+  const clearTimeoutHandle = () => {
+    if (timeoutHandle === undefined) return;
+    clearTimeout(timeoutHandle);
+    timeoutHandle = undefined;
+  };
+
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    providerStepActive = false;
+    clearTimeoutHandle();
+    args.externalAbortSignal.removeEventListener("abort", dispose);
+  };
+
+  const armTimeout = () => {
+    clearTimeoutHandle();
+    if (disposed || !providerStepActive || args.externalAbortSignal.aborted) {
+      return;
+    }
+
+    timeoutHandle = setTimeout(() => {
+      if (disposed || !providerStepActive || args.externalAbortSignal.aborted) {
+        return;
+      }
+
+      timeoutError = new ProviderStreamTimeoutError({
+        phase: receivedProviderChunk ? "between_chunks" : "first_chunk",
+        timeoutMs,
+      });
+      const error = timeoutError;
+      dispose();
+      try {
+        args.onTimeout(error);
+      } finally {
+        timeoutController.abort(error);
+      }
+    }, timeoutMs) as TimeoutHandle;
+    timeoutHandle.unref?.();
+  };
+
+  args.externalAbortSignal.addEventListener("abort", dispose, { once: true });
+  if (args.externalAbortSignal.aborted) {
+    dispose();
+  }
+
+  return {
+    signal: timeoutController.signal,
+    startProviderStep: () => {
+      if (disposed) return;
+      providerStepActive = true;
+      receivedProviderChunk = false;
+      armTimeout();
+    },
+    recordProviderActivity: () => {
+      if (!providerStepActive || disposed) return;
+      receivedProviderChunk = true;
+      armTimeout();
+    },
+    pauseForToolExecution: () => {
+      providerStepActive = false;
+      clearTimeoutHandle();
+    },
+    finishProviderStep: () => {
+      providerStepActive = false;
+      clearTimeoutHandle();
+    },
+    dispose,
+    getTimeoutError: () => timeoutError,
+  };
+};

--- a/lib/api/provider-stream-timeout.ts
+++ b/lib/api/provider-stream-timeout.ts
@@ -3,6 +3,7 @@ export const PROVIDER_STREAM_TIMEOUT_CODE = "PROVIDER_STREAM_TIMEOUT";
 
 export type ProviderStreamTimeoutPhase = "first_chunk" | "between_chunks";
 
+/** Typed abort reason that distinguishes provider inactivity from caller cancellation. */
 export class ProviderStreamTimeoutError extends Error {
   readonly code = PROVIDER_STREAM_TIMEOUT_CODE;
   readonly phase: ProviderStreamTimeoutPhase;

--- a/lib/api/provider-stream-timeout.ts
+++ b/lib/api/provider-stream-timeout.ts
@@ -1,4 +1,4 @@
-export const PROVIDER_STREAM_INACTIVITY_TIMEOUT_MS = 2 * 60 * 1000;
+export const PROVIDER_STREAM_INACTIVITY_TIMEOUT_MS = 5 * 60 * 1000;
 export const PROVIDER_STREAM_TIMEOUT_CODE = "PROVIDER_STREAM_TIMEOUT";
 
 export type ProviderStreamTimeoutPhase = "first_chunk" | "between_chunks";
@@ -34,9 +34,10 @@ export type ProviderStreamTimeoutGuard = {
 };
 
 /**
- * AI SDK chunk timeouts begin after the first chunk and remain active while a
- * tool executes. Track provider callbacks directly so both initial and
- * between-chunk stalls are bounded without putting terminal work on the clock.
+ * AI SDK chunk timeouts are first armed after the SDK receives a stream event
+ * and can remain active while a tool executes. Track provider callbacks
+ * directly so initial and between-chunk stalls are bounded without putting
+ * terminal work on the clock.
  */
 export const createProviderStreamTimeoutGuard = (args: {
   externalAbortSignal: AbortSignal;

--- a/lib/api/provider-stream-timeout.ts
+++ b/lib/api/provider-stream-timeout.ts
@@ -1,6 +1,10 @@
+/** Maximum provider silence allowed before the active model request is aborted. */
 export const PROVIDER_STREAM_INACTIVITY_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Stable error code used to classify provider inactivity separately from cancellation. */
 export const PROVIDER_STREAM_TIMEOUT_CODE = "PROVIDER_STREAM_TIMEOUT";
 
+/** Identifies whether provider activity stopped before or after its first event. */
 export type ProviderStreamTimeoutPhase = "first_chunk" | "between_chunks";
 
 /** Typed abort reason that distinguishes provider inactivity from caller cancellation. */
@@ -23,6 +27,7 @@ type TimeoutHandle = ReturnType<typeof setTimeout> & {
   unref?: () => void;
 };
 
+/** Lifecycle controls for timing provider activity without timing local tools. */
 export type ProviderStreamTimeoutGuard = {
   signal: AbortSignal;
   startProviderStep: () => void;

--- a/lib/chat/__tests__/agent-long-provider-retry.test.ts
+++ b/lib/chat/__tests__/agent-long-provider-retry.test.ts
@@ -6,6 +6,26 @@ import {
 } from "../agent-long-provider-retry";
 
 describe("shouldRetryAgentLongWithFallback", () => {
+  it("allows an internal timeout fallback before meaningful output", () => {
+    expect(
+      shouldRetryAgentLongWithFallback([{ type: "step-start" }], {
+        hasTerminalProviderStreamError: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not replay after an internal timeout with meaningful partial output", () => {
+    expect(
+      shouldRetryAgentLongWithFallback(
+        [
+          { type: "step-start" },
+          { type: "text", text: "I found the vulnerable endpoint." },
+        ],
+        { hasTerminalProviderStreamError: true },
+      ),
+    ).toBe(false);
+  });
+
   it("preserves the legacy retry for streams that only emitted step-start", () => {
     expect(
       shouldRetryAgentLongWithFallback([{ type: "step-start" }], {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2882,6 +2882,7 @@ export const agentLongTask = task({
                 state.lastStepInputTokens = 0;
                 state.stoppedDueToTokenExhaustion = false;
                 state.stoppedDueToElapsedTimeout = false;
+                state.stoppedDueToProviderStreamTimeout = false;
                 state.stoppedDueToDoomLoop = false;
                 state.stoppedDueToAssistantContentLoop = false;
                 state.assistantContentLoopDetection = undefined;
@@ -2981,7 +2982,9 @@ export const agentLongTask = task({
                         (shouldRetryWithFallback ||
                           shouldRetryWithoutImageToolResults) &&
                         !isRetryWithFallback &&
-                        (!isAborted || stoppedDueToAssistantContentLoop) &&
+                        (!isAborted ||
+                          state.stoppedDueToProviderStreamTimeout ||
+                          stoppedDueToAssistantContentLoop) &&
                         (isAutoModel ||
                           shouldRetryWithoutImageToolResults ||
                           stoppedDueToAssistantContentLoop ||
@@ -2994,9 +2997,11 @@ export const agentLongTask = task({
                             ? "assistant_content_loop"
                             : state.stoppedDueToDoomLoop
                               ? "doom_loop"
-                              : shouldRetryInterruptedToolInput
-                                ? "interrupted_tool_input"
-                                : "incomplete_stream";
+                              : state.stoppedDueToProviderStreamTimeout
+                                ? "provider_timeout"
+                                : shouldRetryInterruptedToolInput
+                                  ? "interrupted_tool_input"
+                                  : "incomplete_stream";
                         phLogger.warn(
                           "[agent-long] Provider output triggered fallback retry",
                           {
@@ -3026,6 +3031,7 @@ export const agentLongTask = task({
                         state.providerRejectedMultimodalToolResults = false;
                         state.stoppedDueToTokenExhaustion = false;
                         state.stoppedDueToElapsedTimeout = false;
+                        state.stoppedDueToProviderStreamTimeout = false;
                         state.stoppedDueToDoomLoop = false;
                         state.stoppedDueToAssistantContentLoop = false;
                         state.assistantContentLoopDetection = undefined;
@@ -3127,10 +3133,12 @@ export const agentLongTask = task({
                                   // reason to budget-exhausted; do it before
                                   // analytics and persistence consume state.
                                   await deductAccumulatedUsage();
-                                  const outcome = retryAborted
-                                    ? "aborted"
-                                    : isTerminalProviderStreamError(state)
-                                      ? "error"
+                                  const outcome = isTerminalProviderStreamError(
+                                    state,
+                                  )
+                                    ? "error"
+                                    : retryAborted
+                                      ? "aborted"
                                       : "success";
                                   captureAgentCompletionAnalytics({
                                     posthog,
@@ -3271,7 +3279,8 @@ export const agentLongTask = task({
                         isAborted &&
                         triggerSignal.aborted &&
                         !state.stoppedDueToBudgetExhaustion &&
-                        !state.stoppedDueToElapsedTimeout
+                        !state.stoppedDueToElapsedTimeout &&
+                        !state.stoppedDueToProviderStreamTimeout
                       ) {
                         state.streamFinishReason = undefined;
                       }
@@ -3288,10 +3297,10 @@ export const agentLongTask = task({
                       // budget-exhausted; do it before analytics and
                       // persistence consume state.
                       await deductAccumulatedUsage();
-                      const outcome = isAborted
-                        ? "aborted"
-                        : isTerminalProviderStreamError(state)
-                          ? "error"
+                      const outcome = isTerminalProviderStreamError(state)
+                        ? "error"
+                        : isAborted
+                          ? "aborted"
                           : "success";
                       captureAgentCompletionAnalytics({
                         posthog,


### PR DESCRIPTION
## Closed without merging

This PR was closed after verifying the current OpenRouter and AI SDK behavior more closely.

All HackerAI model traffic already goes through OpenRouter, which enforces provider read deadlines and enables provider fallback by default. HackerAI also supplies explicit fallback model lists to OpenRouter. OpenRouter can retry before any tokens are delivered and intentionally does not replay after partial output; mid-stream provider timeouts are returned as in-stream errors. This already covers the primary provider-stall and safe-fallback behavior targeted here.

The additional five-minute application timer would duplicate that responsibility and introduce a correctness risk. OpenRouter sends SSE comments such as `: OPENROUTER PROCESSING` while a long-running model request is still alive, but the installed AI SDK parser consumes those comments without surfacing them through `onChunk`. The proposed guard could therefore classify a live request as inactive and abort it after five minutes.

OpenRouter does not publish its exact read-deadline duration, so an outer HackerAI deadline could still be useful if production evidence shows the OpenRouter connection itself can remain stuck. That should be reconsidered with observed failure data and a design that accounts for transport keepalives, rather than shipping a second timer based only on parsed model chunks.

## Summary

- add a shared five-minute provider inactivity guard to Agent `streamText` execution
- cover both a missing first chunk and a stall between provider chunks
- pause the guard before tool execution so long terminal and sandbox work are not timed as model inactivity
- classify internal timeouts separately from explicit user cancellation and reuse the existing provider timeout observability/refund path
- allow the existing bounded fallback only when the current output-safety rules say the failed leg is safe to discard

## Root cause

The existing run-level caps are evaluated around completed model steps, so a provider stream that stops making progress can prevent the Agent loop from reaching those checks. The pinned AI SDK exposes `totalMs`, `stepMs`, and `chunkMs`, but its current `chunkMs` implementation is first armed only after the SDK receives a stream event and can stay armed while tool execution is in progress. Using it directly would miss a never-starting response and could abort a legitimate long tool step.

The new guard follows the shared Agent provider lifecycle instead: it arms immediately before each provider request, resets on provider chunks, pauses before tool execution, and clears on step completion. Both the Next.js and Trigger Agent paths inherit the same behavior from `agent-stream-runner`.

## Behavior and risk

- Timeout aborts carry `ProviderStreamTimeoutError` with `PROVIDER_STREAM_TIMEOUT`, `first_chunk` or `between_chunks`, and the bounded duration.
- Provider timeout errors continue through the existing `timeout` category, usage tracking, refund checks, and terminal Trigger failure handling.
- Explicit user aborts dispose the guard without creating a provider timeout.
- Fallback is still limited to the existing safe-output policy; visible partial text, completed tool calls, and tool output are not replayed.
- Existing run duration, budget, spend-cap, served-model accounting, and settlement behavior remain unchanged.

## Validation

- `corepack pnpm test --runInBand` — 297 suites / 2,931 tests passed
- focused provider, Agent runner, retry, billing/spend-cap, PTY, active-runtime, error-classification, and Trigger contract suites — 11 suites / 185 tests passed
- five-minute policy follow-up — 2 suites / 20 tests passed
- `corepack pnpm typecheck`
- targeted ESLint for all changed files
- `corepack pnpm lint` — 0 errors; 5 existing warnings in unrelated UI files
- Prettier check for all changed files

## Manual Agent-mode verification

1. On the preview deployment, select Agent mode with Auto and use a non-production provider fault injection that withholds the first response chunk for more than five minutes. Confirm the primary leg ends as a provider timeout and fallback starts only if no useful output was emitted.
2. Repeat with one visible text chunk followed by more than five minutes of provider silence. Confirm the partial output is preserved and no fallback replay starts.
3. Run a long terminal or interactive tool operation spanning more than five minutes. Confirm it is not interrupted by the provider inactivity guard and the next provider step resumes normally.
4. Click Stop during a provider response. Confirm the run remains a user cancellation and is not classified or logged as a provider timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added provider stream inactivity detection with separate “first chunk” vs “between chunks” phases and detailed timeout errors.
  - Provider inactivity timeout now defaults to 5 minutes.
- **Bug Fixes**
  - Streaming/fallback now treats provider timeouts as a distinct terminal error, updating stop/finish behavior and suppressing success reporting.
  - Retry logic uses a specific `provider_timeout` reason, and abort handling preserves timeout stop state.
- **Tests**
  - Added/extended Jest coverage for timeout guard behavior, runner lifecycle handling, multi-compaction aborts, and retry decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->