### PR TITLE
Add Agent memory high-water telemetry

### DIFF
--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -281,6 +281,114 @@ describe("createAgentStream repeated compaction", () => {
     mockStreamText.mockImplementation((options) => options);
   });
 
+  it("emits sanitized provider and retained-message diagnostics", async () => {
+    const onProviderRequestDiagnostics = jest.fn();
+    const tracker = {
+      hasSummarized: true,
+      summarizationCount: 2,
+    };
+    const state = initAgentStreamState(
+      [
+        uiMessage("initial-1", "private initial content"),
+        uiMessage("initial-2", "more private content"),
+      ],
+      { usedTokens: 1_000, maxTokens: 128_000 },
+    );
+    state.transcriptSourceMessages = [
+      uiMessage("transcript-1", "private transcript content"),
+    ];
+
+    await createAgentStream(
+      "test-model",
+      createTestStreamContext({
+        summarizationTracker: tracker,
+        usageTracker: {},
+        onProviderRequestDiagnostics,
+      }) as any,
+      state,
+    );
+
+    expect(onProviderRequestDiagnostics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "initial",
+        message_count: 2,
+        role_counts: { user: 2 },
+        serialized_message_bytes: expect.any(Number),
+      }),
+      {
+        raw_message_count: 2,
+        rolling_message_count: 2,
+        final_ui_message_count: 2,
+        transcript_source_message_count: 1,
+        summarization_count: 2,
+        compaction_attempt_count: 0,
+      },
+    );
+    expect(
+      JSON.stringify(onProviderRequestDiagnostics.mock.calls),
+    ).not.toContain("private initial content");
+    expect(
+      JSON.stringify(onProviderRequestDiagnostics.mock.calls),
+    ).not.toContain("private transcript content");
+  });
+
+  it("emits retained-message diagnostics on prepare-step fallback", async () => {
+    const onProviderRequestDiagnostics = jest.fn();
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mockGetProviderPromptPressure.mockImplementationOnce(() => {
+      throw new Error("pressure inspection failed");
+    });
+    const state = initAgentStreamState(
+      [uiMessage("initial", "initial message")],
+      { usedTokens: 1_000, maxTokens: 128_000 },
+    );
+
+    try {
+      const stream = (await createAgentStream(
+        "test-model",
+        createTestStreamContext({
+          summarizationTracker: {
+            hasSummarized: false,
+            summarizationCount: 0,
+          },
+          usageTracker: {},
+          onProviderRequestDiagnostics,
+        }) as any,
+        state,
+      )) as any;
+      const rawMessages: ModelMessage[] = [
+        { role: "user", content: "initial message" },
+        { role: "assistant", content: "partial response" },
+      ];
+
+      await stream.prepareStep({
+        steps: [{ toolResults: [] }],
+        messages: rawMessages,
+      });
+
+      expect(onProviderRequestDiagnostics).toHaveBeenCalledTimes(2);
+      expect(onProviderRequestDiagnostics).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          source: "prepare_step",
+          step_index: 2,
+          message_count: 2,
+        }),
+        {
+          raw_message_count: 2,
+          rolling_message_count: 2,
+          final_ui_message_count: 1,
+          transcript_source_message_count: 0,
+          summarization_count: 0,
+          compaction_attempt_count: 0,
+        },
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("rebases every later prepareStep onto the latest in-run summary", async () => {
     const summary1 = uiMessage("summary-1", "summary 1");
     const summary2 = uiMessage("summary-2", "summary 2");

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -107,7 +107,10 @@ import type {
 import type { ChatLogger } from "@/lib/api/chat-logger";
 import type { ChatApiEndpoint } from "@/lib/api/agent-endpoints";
 import type { createTrackedProvider } from "@/lib/ai/providers";
-import type { ProviderRequestDiagnostics } from "@/lib/logger";
+import type {
+  ProviderRequestDiagnostics,
+  ProviderRequestRetentionDiagnostics,
+} from "@/lib/logger";
 import type { ChatMode, SubscriptionTier } from "@/types";
 
 const AGENT_VISION_MODEL = "model-grok-4.5";
@@ -473,6 +476,10 @@ export type AgentStreamContext = {
   onBudgetAbort?: (details: BudgetAbortDetails & { model: string }) => void;
   onModelStreamStart?: () => void;
   onModelStreamFinish?: () => void;
+  onProviderRequestDiagnostics?: (
+    diagnostics: ProviderRequestDiagnostics,
+    retention: ProviderRequestRetentionDiagnostics,
+  ) => void;
   settleUsageAfterStep?: (args: {
     currentCostDollars: number;
     force: boolean;
@@ -705,6 +712,8 @@ export async function createAgentStream(
     stepIndex: number;
     source: ProviderRequestDiagnostics["source"];
     messages: ModelMessage[];
+    rawMessages?: ModelMessage[];
+    rollingMessages?: ModelMessage[];
     providerOptions: unknown;
     activeTools: Array<keyof typeof ctx.tools> | undefined;
   }) => {
@@ -725,6 +734,16 @@ export async function createAgentStream(
     ctx.chatLogger?.recordProviderRequestDiagnostics(
       latestProviderRequestDiagnostics,
     );
+    ctx.onProviderRequestDiagnostics?.(latestProviderRequestDiagnostics, {
+      raw_message_count: args.rawMessages?.length ?? args.messages.length,
+      rolling_message_count:
+        args.rollingMessages?.length ?? args.messages.length,
+      final_ui_message_count: state.finalMessages.length,
+      transcript_source_message_count:
+        state.transcriptSourceMessages?.length ?? 0,
+      summarization_count: ctx.summarizationTracker.summarizationCount,
+      compaction_attempt_count: compactionAttemptCount,
+    });
     return latestProviderRequestDiagnostics;
   };
   const initialModelInfo = getEffectiveModelInfo();
@@ -744,6 +763,8 @@ export async function createAgentStream(
     stepIndex: 0,
     source: "initial",
     messages: initialModelMessages,
+    rawMessages: initialModelMessages,
+    rollingMessages: initialModelMessages,
     providerOptions: initialProviderOptions,
     activeTools: initialActiveTools,
   });
@@ -879,6 +900,8 @@ export async function createAgentStream(
                 stepIndex: steps.length + 1,
                 source: "summarized_prepare_step",
                 messages: preparedMessages,
+                rawMessages: rawModelMessages,
+                rollingMessages: summarizedModelMessages,
                 providerOptions,
                 activeTools,
               });
@@ -1032,6 +1055,8 @@ export async function createAgentStream(
                   stepIndex: steps.length + 1,
                   source: "summarized_prepare_step",
                   messages: preparedMessages,
+                  rawMessages: rawModelMessages,
+                  rollingMessages: nextBaseMessages,
                   providerOptions,
                   activeTools,
                 });
@@ -1083,6 +1108,8 @@ export async function createAgentStream(
           stepIndex: steps.length + 1,
           source: "prepare_step",
           messages: preparedMessages as ModelMessage[],
+          rawMessages: rawModelMessages,
+          rollingMessages: rollingModelMessages,
           providerOptions,
           activeTools,
         });
@@ -1102,6 +1129,17 @@ export async function createAgentStream(
         const fallbackMessages = prepareProviderMessages(
           rollingModelMessages,
         ) as typeof messages;
+        recordProviderRequestDiagnostics({
+          modelName: getEffectiveModelName(),
+          requestedSlug: lastRequestedSlug,
+          stepIndex: steps.length + 1,
+          source: "prepare_step",
+          messages: fallbackMessages as ModelMessage[],
+          rawMessages: rawModelMessages,
+          rollingMessages: rollingModelMessages,
+          providerOptions,
+          activeTools: undefined,
+        });
         return {
           providerOptions,
           messages: fallbackMessages,

--- a/lib/chat/__tests__/agent-long-memory-telemetry.test.ts
+++ b/lib/chat/__tests__/agent-long-memory-telemetry.test.ts
@@ -186,4 +186,53 @@ describe("AgentLongMemoryTelemetry", () => {
       heap_used_percent: 0,
     });
   });
+
+  it("does not propagate memory collector failures", () => {
+    const emit = jest.fn();
+    const telemetry = new AgentLongMemoryTelemetry({
+      runId: "run_123",
+      chatId: "chat_123",
+      userId: "user_123",
+      emit,
+      readMemory: () => {
+        throw new Error("memory stats unavailable");
+      },
+    });
+
+    expect(telemetry.checkpoint({ phase: "run_failed", force: true })).toBe(
+      false,
+    );
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it("does not mark a failed emission as a completed checkpoint", () => {
+    const emit = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("logger unavailable");
+      })
+      .mockImplementation(() => undefined);
+    const telemetry = new AgentLongMemoryTelemetry({
+      runId: "run_123",
+      chatId: "chat_123",
+      userId: "user_123",
+      emit,
+      now: () => 1_000,
+      readMemory: () => ({
+        rss: 200 * MIB,
+        heapTotal: 180 * MIB,
+        heapUsed: 100 * MIB,
+        external: 0,
+        arrayBuffers: 0,
+      }),
+      readHeapLimit: () => 416 * MIB,
+    });
+
+    expect(telemetry.checkpoint({ phase: "provider_request" })).toBe(false);
+    expect(telemetry.checkpoint({ phase: "provider_request" })).toBe(true);
+    expect(emit).toHaveBeenCalledTimes(2);
+    expect(emit.mock.calls[1]?.[0]).toMatchObject({
+      checkpoint_reason: "initial",
+    });
+  });
 });

--- a/lib/chat/__tests__/agent-long-memory-telemetry.test.ts
+++ b/lib/chat/__tests__/agent-long-memory-telemetry.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import { AgentLongMemoryTelemetry } from "../agent-long-memory-telemetry";
+import type {
+  ProviderRequestDiagnostics,
+  ProviderRequestRetentionDiagnostics,
+} from "@/lib/logger";
+
+const MIB = 1024 * 1024;
+
+const providerRequest: ProviderRequestDiagnostics = {
+  model: "model-grok-4.5",
+  requested_model_slug: "agent-model",
+  step_index: 3,
+  source: "prepare_step",
+  message_count: 207,
+  role_counts: { user: 4, assistant: 203 },
+  content_part_counts: { text: 80, "tool-call": 60, "tool-result": 67 },
+  serialized_message_bytes: 450_000,
+  estimated_serialized_message_tokens: 112_500,
+  context_used_tokens: 75_000,
+  context_max_tokens: 131_072,
+  context_used_percent: 57.2,
+  system_tokens: 9_000,
+  max_output_tokens: 16_384,
+  tool_count: 18,
+  active_tool_count: 18,
+  active_tools_mode: "all",
+  fallback_model_count: 0,
+  has_user_attribution: true,
+  has_multimodal_tool_results: false,
+};
+
+const retention: ProviderRequestRetentionDiagnostics = {
+  raw_message_count: 207,
+  rolling_message_count: 153,
+  final_ui_message_count: 61,
+  transcript_source_message_count: 61,
+  summarization_count: 2,
+  compaction_attempt_count: 3,
+};
+
+describe("AgentLongMemoryTelemetry", () => {
+  it("emits an initial privacy-safe provider checkpoint", () => {
+    const emit = jest.fn();
+    const telemetry = new AgentLongMemoryTelemetry({
+      runId: "run_123",
+      chatId: "chat_123",
+      userId: "user_123",
+      environment: "production",
+      emit,
+      now: () => Date.parse("2026-07-24T12:00:00.000Z"),
+      readMemory: () => ({
+        rss: 300 * MIB,
+        heapTotal: 250 * MIB,
+        heapUsed: 200 * MIB,
+        external: 12 * MIB,
+        arrayBuffers: 4 * MIB,
+      }),
+      readHeapLimit: () => 416 * MIB,
+    });
+
+    expect(
+      telemetry.checkpoint({
+        phase: "provider_request",
+        providerRequest,
+        retention,
+      }),
+    ).toBe(true);
+
+    expect(emit).toHaveBeenCalledWith({
+      level: "info",
+      event: "agent_long_memory_checkpoint",
+      service: "agent-long",
+      environment: "production",
+      timestamp: "2026-07-24T12:00:00.000Z",
+      run_id: "run_123",
+      chat_id: "chat_123",
+      user_id: "user_123",
+      phase: "provider_request",
+      checkpoint_reason: "initial",
+      rss_bytes: 300 * MIB,
+      rss_high_water_bytes: 300 * MIB,
+      heap_total_bytes: 250 * MIB,
+      heap_used_bytes: 200 * MIB,
+      heap_used_high_water_bytes: 200 * MIB,
+      heap_limit_bytes: 416 * MIB,
+      heap_used_percent: 48.1,
+      external_bytes: 12 * MIB,
+      array_buffer_bytes: 4 * MIB,
+      provider_request: providerRequest,
+      retention,
+    });
+    expect(JSON.stringify(emit.mock.calls)).not.toContain("prompt");
+    expect(JSON.stringify(emit.mock.calls)).not.toContain("target");
+  });
+
+  it("emits only after meaningful heap growth", () => {
+    let heapUsed = 100 * MIB;
+    const emit = jest.fn();
+    const telemetry = new AgentLongMemoryTelemetry({
+      runId: "run_123",
+      chatId: "chat_123",
+      userId: "user_123",
+      emit,
+      now: () => 1_000,
+      readMemory: () => ({
+        rss: 200 * MIB,
+        heapTotal: 180 * MIB,
+        heapUsed,
+        external: 0,
+        arrayBuffers: 0,
+      }),
+      readHeapLimit: () => 416 * MIB,
+    });
+
+    expect(telemetry.checkpoint({ phase: "provider_request" })).toBe(true);
+    heapUsed += 31 * MIB;
+    expect(telemetry.checkpoint({ phase: "provider_request" })).toBe(false);
+    heapUsed += 1 * MIB;
+    expect(telemetry.checkpoint({ phase: "provider_request" })).toBe(true);
+    expect(emit.mock.calls[1]?.[0]).toMatchObject({
+      checkpoint_reason: "heap_growth",
+      heap_used_bytes: 132 * MIB,
+      heap_used_high_water_bytes: 132 * MIB,
+    });
+  });
+
+  it("emits an interval checkpoint for long stable streams", () => {
+    let now = 0;
+    const emit = jest.fn();
+    const telemetry = new AgentLongMemoryTelemetry({
+      runId: "run_123",
+      chatId: "chat_123",
+      userId: "user_123",
+      emit,
+      now: () => now,
+      readMemory: () => ({
+        rss: 200 * MIB,
+        heapTotal: 180 * MIB,
+        heapUsed: 100 * MIB,
+        external: 0,
+        arrayBuffers: 0,
+      }),
+      readHeapLimit: () => 416 * MIB,
+    });
+
+    telemetry.checkpoint({ phase: "provider_request" });
+    now = 9 * 60 * 1_000;
+    expect(telemetry.checkpoint({ phase: "provider_request" })).toBe(false);
+    now = 10 * 60 * 1_000;
+    expect(telemetry.checkpoint({ phase: "provider_request" })).toBe(true);
+    expect(emit.mock.calls[1]?.[0]).toMatchObject({
+      checkpoint_reason: "interval",
+    });
+  });
+
+  it("forces a failure checkpoint and keeps prior high-water values", () => {
+    let heapUsed = 200 * MIB;
+    const emit = jest.fn();
+    const telemetry = new AgentLongMemoryTelemetry({
+      runId: "run_123",
+      chatId: "chat_123",
+      userId: "user_123",
+      emit,
+      now: () => 1_000,
+      readMemory: () => ({
+        rss: heapUsed + 50 * MIB,
+        heapTotal: 220 * MIB,
+        heapUsed,
+        external: 0,
+        arrayBuffers: 0,
+      }),
+      readHeapLimit: () => 0,
+    });
+
+    telemetry.checkpoint({ phase: "provider_request" });
+    heapUsed = 150 * MIB;
+    expect(telemetry.checkpoint({ phase: "run_failed", force: true })).toBe(
+      true,
+    );
+    expect(emit.mock.calls[1]?.[0]).toMatchObject({
+      checkpoint_reason: "forced",
+      rss_high_water_bytes: 250 * MIB,
+      heap_used_high_water_bytes: 200 * MIB,
+      heap_used_percent: 0,
+    });
+  });
+});

--- a/lib/chat/agent-long-memory-telemetry.ts
+++ b/lib/chat/agent-long-memory-telemetry.ts
@@ -81,61 +81,66 @@ export class AgentLongMemoryTelemetry {
   }
 
   checkpoint(input: MemoryCheckpointInput): boolean {
-    const now = this.now();
-    const memory = this.readMemory();
-    const rss = finiteNonNegative(memory.rss);
-    const heapTotal = finiteNonNegative(memory.heapTotal);
-    const heapUsed = finiteNonNegative(memory.heapUsed);
-    const external = finiteNonNegative(memory.external);
-    const arrayBuffers = finiteNonNegative(memory.arrayBuffers);
-    const heapLimit = finiteNonNegative(this.readHeapLimit());
+    try {
+      const now = this.now();
+      const memory = this.readMemory();
+      const rss = finiteNonNegative(memory.rss);
+      const heapTotal = finiteNonNegative(memory.heapTotal);
+      const heapUsed = finiteNonNegative(memory.heapUsed);
+      const external = finiteNonNegative(memory.external);
+      const arrayBuffers = finiteNonNegative(memory.arrayBuffers);
+      const heapLimit = finiteNonNegative(this.readHeapLimit());
 
-    this.rssHighWater = Math.max(this.rssHighWater, rss);
-    this.heapUsedHighWater = Math.max(this.heapUsedHighWater, heapUsed);
+      this.rssHighWater = Math.max(this.rssHighWater, rss);
+      this.heapUsedHighWater = Math.max(this.heapUsedHighWater, heapUsed);
 
-    const reason =
-      this.lastEmittedAt === undefined
-        ? "initial"
-        : input.force
-          ? "forced"
-          : heapUsed - this.lastEmittedHeapUsed >= HEAP_GROWTH_CHECKPOINT_BYTES
-            ? "heap_growth"
-            : now - this.lastEmittedAt >= CHECKPOINT_INTERVAL_MS
-              ? "interval"
-              : undefined;
+      const reason =
+        this.lastEmittedAt === undefined
+          ? "initial"
+          : input.force
+            ? "forced"
+            : heapUsed - this.lastEmittedHeapUsed >=
+                HEAP_GROWTH_CHECKPOINT_BYTES
+              ? "heap_growth"
+              : now - this.lastEmittedAt >= CHECKPOINT_INTERVAL_MS
+                ? "interval"
+                : undefined;
 
-    if (!reason) return false;
+      if (!reason) return false;
 
-    this.options.emit({
-      level: "info",
-      event: "agent_long_memory_checkpoint",
-      service: "agent-long",
-      environment:
-        this.options.environment ??
-        process.env.VERCEL_ENV ??
-        process.env.NODE_ENV ??
-        "unknown",
-      timestamp: new Date(now).toISOString(),
-      run_id: this.options.runId,
-      chat_id: this.options.chatId,
-      user_id: this.options.userId,
-      phase: input.phase,
-      checkpoint_reason: reason,
-      rss_bytes: rss,
-      rss_high_water_bytes: this.rssHighWater,
-      heap_total_bytes: heapTotal,
-      heap_used_bytes: heapUsed,
-      heap_used_high_water_bytes: this.heapUsedHighWater,
-      heap_limit_bytes: heapLimit,
-      heap_used_percent:
-        heapLimit > 0 ? Math.round((heapUsed / heapLimit) * 1000) / 10 : 0,
-      external_bytes: external,
-      array_buffer_bytes: arrayBuffers,
-      provider_request: input.providerRequest,
-      retention: input.retention,
-    });
-    this.lastEmittedAt = now;
-    this.lastEmittedHeapUsed = heapUsed;
-    return true;
+      this.options.emit({
+        level: "info",
+        event: "agent_long_memory_checkpoint",
+        service: "agent-long",
+        environment:
+          this.options.environment ??
+          process.env.VERCEL_ENV ??
+          process.env.NODE_ENV ??
+          "unknown",
+        timestamp: new Date(now).toISOString(),
+        run_id: this.options.runId,
+        chat_id: this.options.chatId,
+        user_id: this.options.userId,
+        phase: input.phase,
+        checkpoint_reason: reason,
+        rss_bytes: rss,
+        rss_high_water_bytes: this.rssHighWater,
+        heap_total_bytes: heapTotal,
+        heap_used_bytes: heapUsed,
+        heap_used_high_water_bytes: this.heapUsedHighWater,
+        heap_limit_bytes: heapLimit,
+        heap_used_percent:
+          heapLimit > 0 ? Math.round((heapUsed / heapLimit) * 1000) / 10 : 0,
+        external_bytes: external,
+        array_buffer_bytes: arrayBuffers,
+        provider_request: input.providerRequest,
+        retention: input.retention,
+      });
+      this.lastEmittedAt = now;
+      this.lastEmittedHeapUsed = heapUsed;
+      return true;
+    } catch {
+      return false;
+    }
   }
 }

--- a/lib/chat/agent-long-memory-telemetry.ts
+++ b/lib/chat/agent-long-memory-telemetry.ts
@@ -1,0 +1,141 @@
+import { getHeapStatistics } from "node:v8";
+
+import type {
+  ProviderRequestDiagnostics,
+  ProviderRequestRetentionDiagnostics,
+} from "@/lib/logger";
+
+const HEAP_GROWTH_CHECKPOINT_BYTES = 32 * 1024 * 1024;
+const CHECKPOINT_INTERVAL_MS = 10 * 60 * 1000;
+
+type MemorySnapshot = {
+  rss: number;
+  heapTotal: number;
+  heapUsed: number;
+  external: number;
+  arrayBuffers: number;
+};
+
+type MemoryCheckpointPhase =
+  "provider_request" | "stream_finished" | "run_failed";
+
+type MemoryCheckpointInput = {
+  phase: MemoryCheckpointPhase;
+  force?: boolean;
+  providerRequest?: ProviderRequestDiagnostics;
+  retention?: ProviderRequestRetentionDiagnostics;
+};
+
+type MemoryCheckpointEvent = {
+  level: "info";
+  event: "agent_long_memory_checkpoint";
+  service: "agent-long";
+  environment: string;
+  timestamp: string;
+  run_id: string;
+  chat_id: string;
+  user_id: string;
+  phase: MemoryCheckpointPhase;
+  checkpoint_reason: "initial" | "forced" | "heap_growth" | "interval";
+  rss_bytes: number;
+  rss_high_water_bytes: number;
+  heap_total_bytes: number;
+  heap_used_bytes: number;
+  heap_used_high_water_bytes: number;
+  heap_limit_bytes: number;
+  heap_used_percent: number;
+  external_bytes: number;
+  array_buffer_bytes: number;
+  provider_request?: ProviderRequestDiagnostics;
+  retention?: ProviderRequestRetentionDiagnostics;
+};
+
+type AgentLongMemoryTelemetryOptions = {
+  runId: string;
+  chatId: string;
+  userId: string;
+  environment?: string;
+  emit: (event: MemoryCheckpointEvent) => void;
+  now?: () => number;
+  readMemory?: () => MemorySnapshot;
+  readHeapLimit?: () => number;
+};
+
+const finiteNonNegative = (value: number): number =>
+  Number.isFinite(value) ? Math.max(0, Math.round(value)) : 0;
+
+export class AgentLongMemoryTelemetry {
+  private readonly now: () => number;
+  private readonly readMemory: () => MemorySnapshot;
+  private readonly readHeapLimit: () => number;
+  private lastEmittedAt: number | undefined;
+  private lastEmittedHeapUsed = 0;
+  private rssHighWater = 0;
+  private heapUsedHighWater = 0;
+
+  constructor(private readonly options: AgentLongMemoryTelemetryOptions) {
+    this.now = options.now ?? Date.now;
+    this.readMemory = options.readMemory ?? process.memoryUsage;
+    this.readHeapLimit =
+      options.readHeapLimit ?? (() => getHeapStatistics().heap_size_limit);
+  }
+
+  checkpoint(input: MemoryCheckpointInput): boolean {
+    const now = this.now();
+    const memory = this.readMemory();
+    const rss = finiteNonNegative(memory.rss);
+    const heapTotal = finiteNonNegative(memory.heapTotal);
+    const heapUsed = finiteNonNegative(memory.heapUsed);
+    const external = finiteNonNegative(memory.external);
+    const arrayBuffers = finiteNonNegative(memory.arrayBuffers);
+    const heapLimit = finiteNonNegative(this.readHeapLimit());
+
+    this.rssHighWater = Math.max(this.rssHighWater, rss);
+    this.heapUsedHighWater = Math.max(this.heapUsedHighWater, heapUsed);
+
+    const reason =
+      this.lastEmittedAt === undefined
+        ? "initial"
+        : input.force
+          ? "forced"
+          : heapUsed - this.lastEmittedHeapUsed >= HEAP_GROWTH_CHECKPOINT_BYTES
+            ? "heap_growth"
+            : now - this.lastEmittedAt >= CHECKPOINT_INTERVAL_MS
+              ? "interval"
+              : undefined;
+
+    if (!reason) return false;
+
+    this.options.emit({
+      level: "info",
+      event: "agent_long_memory_checkpoint",
+      service: "agent-long",
+      environment:
+        this.options.environment ??
+        process.env.VERCEL_ENV ??
+        process.env.NODE_ENV ??
+        "unknown",
+      timestamp: new Date(now).toISOString(),
+      run_id: this.options.runId,
+      chat_id: this.options.chatId,
+      user_id: this.options.userId,
+      phase: input.phase,
+      checkpoint_reason: reason,
+      rss_bytes: rss,
+      rss_high_water_bytes: this.rssHighWater,
+      heap_total_bytes: heapTotal,
+      heap_used_bytes: heapUsed,
+      heap_used_high_water_bytes: this.heapUsedHighWater,
+      heap_limit_bytes: heapLimit,
+      heap_used_percent:
+        heapLimit > 0 ? Math.round((heapUsed / heapLimit) * 1000) / 10 : 0,
+      external_bytes: external,
+      array_buffer_bytes: arrayBuffers,
+      provider_request: input.providerRequest,
+      retention: input.retention,
+    });
+    this.lastEmittedAt = now;
+    this.lastEmittedHeapUsed = heapUsed;
+    return true;
+  }
+}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -39,6 +39,15 @@ export interface ProviderRequestDiagnostics {
   has_multimodal_tool_results: boolean;
 }
 
+export interface ProviderRequestRetentionDiagnostics {
+  raw_message_count: number;
+  rolling_message_count: number;
+  final_ui_message_count: number;
+  transcript_source_message_count: number;
+  summarization_count: number;
+  compaction_attempt_count: number;
+}
+
 /**
  * Wide event structure for chat/agent API requests
  */

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -217,6 +217,7 @@ import {
 import { FREE_AGENT_LONG_RUN_LOCK_TTL_SECONDS } from "@/lib/rate-limit/free-config";
 import { isCentrifugoSandbox } from "@/lib/ai/tools/utils/sandbox-types";
 import { AgentRunTimingTracker } from "@/lib/chat/agent-run-timing";
+import { AgentLongMemoryTelemetry } from "@/lib/chat/agent-long-memory-telemetry";
 
 const AGENT_LONG_FREE_MAX_DURATION_SECONDS = 60 * 60;
 const AGENT_LONG_PAID_MAX_DURATION_SECONDS = 2 * 60 * 60;
@@ -1679,6 +1680,13 @@ export const agentLongTask = task({
     const taskStartTime = Date.now();
     const agentLongMaxDurationMs = getAgentLongMaxDurationMs(subscription);
     const runTimingTracker = new AgentRunTimingTracker();
+    const memoryTelemetry = new AgentLongMemoryTelemetry({
+      runId: ctx.run.id,
+      chatId,
+      userId,
+      emit: (event) =>
+        triggerLogger.info("[agent-long] memory checkpoint", event),
+    });
     const getTriggerRunTelemetry = () => {
       const currentUsage = triggerUsage.getCurrent();
       return {
@@ -2818,6 +2826,13 @@ export const agentLongTask = task({
               completionSignalTracker,
               onModelStreamStart: runTimingTracker.startModelStream,
               onModelStreamFinish: runTimingTracker.finishModelStream,
+              onProviderRequestDiagnostics: (providerRequest, retention) => {
+                memoryTelemetry.checkpoint({
+                  phase: "provider_request",
+                  providerRequest,
+                  retention,
+                });
+              },
               settleUsageAfterStep,
               onBudgetAbort: (details) =>
                 captureAgentBudgetAbort({
@@ -3607,6 +3622,7 @@ export const agentLongTask = task({
           error,
         });
       }
+      memoryTelemetry.checkpoint({ phase: "stream_finished" });
 
       const terminalStreamError =
         streamError ?? getTerminalProviderStreamError(terminalAgentState);
@@ -3638,6 +3654,7 @@ export const agentLongTask = task({
       await phLogger.flush().catch(() => {});
     } catch (error) {
       await releaseFreeRunLockOnce();
+      memoryTelemetry.checkpoint({ phase: "run_failed", force: true });
       const chatMissingAfterStream =
         streamPiped &&
         error instanceof ChatSDKError &&


### PR DESCRIPTION
## Summary
- add sampled memory high-water checkpoints to production `agent-long` runs
- correlate RSS/heap usage with existing sanitized provider-request sizes, message/tool-part counts, compaction counts, and retained-message counts
- cover initial requests, repeated compaction, provider fallback/recovery, stream completion, and caught failures without changing Agent behavior

## Production evidence
The frozen 24-hour audit window showed 23 Trigger task-process OOM crashes versus 5 in the previous equivalent window (+360%), affecting 19 users/chats. One representative task exhausted the V8 heap near 404 MB on `small-1x`; another showed growing raw message history and serialized prompt pressure before crashing. OOMs persisted on the latest promoted production worker.

The evidence confirms process memory exhaustion but does not yet prove which retained object or phase is causal. This PR therefore adds the missing measurements instead of imposing a speculative cap or resizing the worker.

## Change
- emit one baseline checkpoint at the first provider request
- emit another only after at least 32 MiB of heap growth, after 10 minutes, or on a caught failure
- retain per-run RSS and heap high-water values across provider fallback retries
- include only bounded, privacy-safe shape data: opaque run/chat/user IDs; model/step metadata; serialized message bytes; role/tool-part counts; raw/rolling/final/transcript message counts; and compaction/summarization counts
- keep the shared Vercel chat path unchanged through an optional callback
- keep all diagnostic collection and emission best-effort so telemetry cannot fail or mask an Agent run

No prompts, tool arguments, targets, findings, file contents, raw URLs, or attachment paths are logged.

## Validation
- `corepack pnpm test --runInBand lib/chat/__tests__/agent-long-memory-telemetry.test.ts lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts lib/api/__tests__/agent-long-contracts.test.ts` — 103 tests passed
- `corepack pnpm typecheck`
- changed-file ESLint and Prettier checks
- commit hooks — 297 suites / 2,942 tests passed
- GitHub Actions run 3191 passed
- Vercel preview `dpl_GjoX7V1w8fDfc5ejSZcqMcW3nDcJ` is READY
- Trigger.dev preview `d9i5r0gg` / worker `20260724.3` is DEPLOYED

## Manual verification
In a production-like Trigger preview:
1. Start an Agent run that performs several provider/tool steps and at least one compaction.
2. Confirm `agent_long_memory_checkpoint` appears at the initial provider request with RSS/heap, heap limit, sanitized provider-request bytes/counts, and retained-message counts.
3. Confirm ordinary steps below the 32 MiB/10-minute thresholds do not add checkpoint noise.
4. Force a handled task failure and confirm the final forced checkpoint retains the task-run high-water values.
5. Verify no prompt, target, tool argument/output content, file path, or raw URL is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added privacy-safe provider request diagnostics for agent streams, including message retention and compaction/summarization counters without exposing private transcript content.
  * Introduced long-running memory telemetry in the `agent-long` task, emitting memory checkpoint events during request, completion, and failure.
* **Bug Fixes**
  * Improved how diagnostics are sanitized and emitted when inspection fails, including correct fallback behavior.
  * Preserved high-water memory metrics in forced failure checkpoints for more reliable troubleshooting.
* **Tests**
  * Expanded coverage to verify diagnostics sanitization and checkpoint emission gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->