### PR TITLE
Handle Remote Control clipboard failures

### DIFF
--- a/app/components/RemoteControlTab.tsx
+++ b/app/components/RemoteControlTab.tsx
@@ -221,15 +221,23 @@ const RemoteControlTab = () => {
     }
   };
 
-  const handleCopyCommand = (command: string) => {
-    navigator.clipboard.writeText(command);
-    toast.success("Command copied to clipboard");
+  const handleCopyCommand = async (command: string) => {
+    try {
+      await navigator.clipboard.writeText(command);
+      toast.success("Command copied to clipboard");
+    } catch {
+      toast.error("Failed to copy command");
+    }
   };
 
-  const handleCopyToken = () => {
-    if (token) {
-      navigator.clipboard.writeText(token);
+  const handleCopyToken = async () => {
+    if (!token) return;
+
+    try {
+      await navigator.clipboard.writeText(token);
       toast.success("Token copied to clipboard");
+    } catch {
+      toast.error("Failed to copy token");
     }
   };
 

--- a/app/components/RemoteControlTab.tsx
+++ b/app/components/RemoteControlTab.tsx
@@ -74,6 +74,7 @@ const CommandBlock = ({
         size="icon"
         className="shrink-0 h-9 w-9"
         onClick={onCopy}
+        aria-label={`Copy ${label} command`}
       >
         <Copy className="h-4 w-4" />
       </Button>
@@ -221,24 +222,34 @@ const RemoteControlTab = () => {
     }
   };
 
-  const handleCopyCommand = async (command: string) => {
+  const copyToClipboard = async (
+    text: string,
+    successMessage: string,
+    errorMessage: string,
+  ) => {
     try {
-      await navigator.clipboard.writeText(command);
-      toast.success("Command copied to clipboard");
+      await navigator.clipboard.writeText(text);
+      toast.success(successMessage);
     } catch {
-      toast.error("Failed to copy command");
+      toast.error(errorMessage);
     }
   };
 
-  const handleCopyToken = async () => {
+  const handleCopyCommand = (command: string) =>
+    copyToClipboard(
+      command,
+      "Command copied to clipboard",
+      "Failed to copy command",
+    );
+
+  const handleCopyToken = () => {
     if (!token) return;
 
-    try {
-      await navigator.clipboard.writeText(token);
-      toast.success("Token copied to clipboard");
-    } catch {
-      toast.error("Failed to copy token");
-    }
+    return copyToClipboard(
+      token,
+      "Token copied to clipboard",
+      "Failed to copy token",
+    );
   };
 
   return (
@@ -357,6 +368,7 @@ const RemoteControlTab = () => {
                   size="sm"
                   className="h-7 w-7 p-0"
                   onClick={handleCopyToken}
+                  aria-label="Copy auth token"
                 >
                   <Copy className="h-3.5 w-3.5" />
                 </Button>

--- a/app/components/__tests__/RemoteControlTab.test.tsx
+++ b/app/components/__tests__/RemoteControlTab.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 
 type MockConnection = {
@@ -22,6 +22,9 @@ let mockSandboxPreference: string;
 let mockSelectedModel: "auto" | "hackerai-standard" | "hackerai-pro";
 let mockTemporaryChatsEnabled: boolean;
 
+const mockGetToken = jest.fn<() => Promise<{ token: string }>>();
+const mockRegenerateToken = jest.fn<() => Promise<{ token: string }>>();
+const mockWriteText = jest.fn<(text: string) => Promise<void>>();
 const mockSetChatMode = jest.fn((mode: "ask" | "agent") => {
   mockChatMode = mode;
 });
@@ -34,8 +37,19 @@ const mockSetSelectedModel = jest.fn(
   },
 );
 
+jest.mock("@/convex/_generated/api", () => ({
+  api: {
+    localSandbox: {
+      getToken: "getToken",
+      regenerateToken: "regenerateToken",
+    },
+  },
+}));
+
 jest.mock("convex/react", () => ({
-  useMutation: jest.fn(() => jest.fn()),
+  useMutation: jest.fn((mutation: string) =>
+    mutation === "getToken" ? mockGetToken : mockRegenerateToken,
+  ),
 }));
 
 jest.mock("@/app/contexts/GlobalState", () => ({
@@ -87,6 +101,13 @@ describe("RemoteControlTab", () => {
     mockSandboxPreference = "e2b";
     mockSelectedModel = "hackerai-pro";
     mockTemporaryChatsEnabled = false;
+    mockGetToken.mockResolvedValue({ token: "test-token" });
+    mockRegenerateToken.mockResolvedValue({ token: "regenerated-token" });
+    mockWriteText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: mockWriteText },
+    });
   });
 
   it("selects agent mode with the new local connection after an empty baseline", async () => {
@@ -121,6 +142,67 @@ describe("RemoteControlTab", () => {
     expect(mockSetSandboxPreference).not.toHaveBeenCalled();
     expect(mockSetSelectedModel).not.toHaveBeenCalled();
     expect(mockSetChatMode).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("reports command copy success only after the clipboard write succeeds", async () => {
+    render(<RemoteControlTab />);
+
+    const copyButton = document
+      .querySelector(".lucide-copy")
+      ?.closest("button");
+    expect(copyButton).not.toBeNull();
+    fireEvent.click(copyButton!);
+
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith(
+        expect.stringContaining("--token YOUR_TOKEN"),
+      );
+    });
+    expect(toast.success).toHaveBeenCalledWith("Command copied to clipboard");
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("handles a rejected command clipboard write without a false success", async () => {
+    mockWriteText.mockRejectedValue(
+      new DOMException("Document is not focused"),
+    );
+    render(<RemoteControlTab />);
+
+    const copyButton = document
+      .querySelector(".lucide-copy")
+      ?.closest("button");
+    expect(copyButton).not.toBeNull();
+    fireEvent.click(copyButton!);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to copy command");
+    });
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("handles a rejected token clipboard write without a false success", async () => {
+    mockWriteText.mockRejectedValue(
+      new DOMException("Clipboard write requires user activation"),
+    );
+    render(<RemoteControlTab />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Generate Token" }));
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("test-token")).toBeInTheDocument();
+    });
+
+    const copyButtons = Array.from(
+      document.querySelectorAll(".lucide-copy"),
+      (icon) => icon.closest("button"),
+    );
+    expect(copyButtons).toHaveLength(2);
+    fireEvent.click(copyButtons[0]!);
+
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith("test-token");
+      expect(toast.error).toHaveBeenCalledWith("Failed to copy token");
+    });
     expect(toast.success).not.toHaveBeenCalled();
   });
 });

--- a/app/components/__tests__/RemoteControlTab.test.tsx
+++ b/app/components/__tests__/RemoteControlTab.test.tsx
@@ -148,11 +148,9 @@ describe("RemoteControlTab", () => {
   it("reports command copy success only after the clipboard write succeeds", async () => {
     render(<RemoteControlTab />);
 
-    const copyButton = document
-      .querySelector(".lucide-copy")
-      ?.closest("button");
-    expect(copyButton).not.toBeNull();
-    fireEvent.click(copyButton!);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy Connect Machine command" }),
+    );
 
     await waitFor(() => {
       expect(mockWriteText).toHaveBeenCalledWith(
@@ -169,11 +167,9 @@ describe("RemoteControlTab", () => {
     );
     render(<RemoteControlTab />);
 
-    const copyButton = document
-      .querySelector(".lucide-copy")
-      ?.closest("button");
-    expect(copyButton).not.toBeNull();
-    fireEvent.click(copyButton!);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy Connect Machine command" }),
+    );
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("Failed to copy command");
@@ -192,12 +188,7 @@ describe("RemoteControlTab", () => {
       expect(screen.getByDisplayValue("test-token")).toBeInTheDocument();
     });
 
-    const copyButtons = Array.from(
-      document.querySelectorAll(".lucide-copy"),
-      (icon) => icon.closest("button"),
-    );
-    expect(copyButtons).toHaveLength(2);
-    fireEvent.click(copyButtons[0]!);
+    fireEvent.click(screen.getByRole("button", { name: "Copy auth token" }));
 
     await waitFor(() => {
       expect(mockWriteText).toHaveBeenCalledWith("test-token");


### PR DESCRIPTION
## Production evidence

During the frozen `2026-07-25T02:00:01.784Z`–`2026-07-26T02:00:01.784Z` audit window, Error Tracking recorded 10 clipboard failures across 5 sessions/users. Six events were attributed directly to the Remote Control copy handler and included document-focus and user-activation rejections.

## Root cause

The command and token copy handlers started `navigator.clipboard.writeText(...)` without awaiting or catching the promise, then immediately showed a success toast. A rejected clipboard write therefore became an unhandled exception while the UI falsely reported success.

## Change

- await the exact command and token clipboard writes
- show success only after the write fulfills
- show bounded failure feedback when the browser rejects the write
- cover fulfilled command writes and rejected command/token writes

No retry or error suppression was added, and command/token contents are not logged.

## Validation

- `corepack pnpm test --runInBand app/components/__tests__/RemoteControlTab.test.tsx` — 5 passed
- `corepack pnpm typecheck`
- changed-file ESLint and Prettier checks
- commit hook: 297 suites / 2,945 tests passed
- local browser verification: Settings → Remote Control command copy completed and displayed the success toast with unchanged layout

## Manual verification

1. In Settings → Remote Control, click the command copy button with clipboard access available; the command should copy and only the success toast should appear.
2. Remove document focus or deny clipboard access, then click command copy; only `Failed to copy command` should appear and no unhandled exception should be emitted.
3. With a disposable test token, repeat the allowed and rejected cases for token copy; success should appear only after a completed write and rejection should show `Failed to copy token`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard copying for remote-control commands and tokens with clearer success/error toasts.
  * Success notifications now appear only after clipboard write succeeds.
  * Added error notifications when clipboard access fails.
  * Prevented copy actions when no token is available.
  * Improved accessibility by adding descriptive labels to copy buttons.

* **Tests**
  * Added automated coverage for clipboard-copy success and failure scenarios for command and token flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->