### PR TITLE
Fix completed chat response reconciliation

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -47,6 +47,7 @@ import {
   fetchAgentLongStream,
   resumeAgentLongStream,
 } from "@/lib/chat/agent-long-transport";
+import { areMessagesEquivalentForConvexSync } from "@/lib/chat/message-reconciliation";
 import {
   LEGACY_DESKTOP_AGENT_UPDATE_MESSAGE,
   isLegacyDesktopAgentClient,
@@ -1512,19 +1513,16 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   ]);
 
   // Sync Convex real-time data with useChat messages.
-  // Uses statusRef (not status state) so this effect only fires when
-  // paginatedMessages.results actually changes — not on status transitions.
   // Guards against BOTH "streaming" and "submitted" statuses to prevent
-  // Convex real-time updates from overwriting useChat's in-flight state.
+  // Convex real-time updates from overwriting useChat's in-flight state, then
+  // reruns when the status settles so a completion persisted during streaming
+  // is not left unapplied.
   // Without the "submitted" guard, a race condition occurs in production:
   // Convex receives the user message (via handleInitialChatAndUserMessage)
   // and pushes a subscription update before the first streaming chunk arrives,
   // resetting useChat's messages and causing an empty AI response.
   useEffect(() => {
-    if (
-      statusRef.current === "streaming" ||
-      statusRef.current === "submitted"
-    ) {
+    if (status === "streaming" || status === "submitted") {
       return;
     }
     if (!paginatedMessageResults || paginatedMessageResults.length === 0) {
@@ -1535,11 +1533,12 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       [...paginatedMessageResults].reverse(),
     );
 
-    // Skip if useChat already has the same messages (same IDs, same part count).
+    // Skip if useChat already has the same rendered message content.
     // This prevents redundant setMessages calls — e.g. after a local provider
     // save, Convex echoes the same data back via reactive query, which would
     // otherwise cause a visible flicker from new object references.
-    // Comparing parts.length catches content updates where the ID stays the same.
+    // Content comparison is required because a partial and completed text part can
+    // share the same message ID and part count.
     const current = messagesRef.current;
 
     // Don't overwrite with fewer messages — the backend (e.g. agent-long Trigger.dev
@@ -1549,14 +1548,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       return;
     }
 
-    if (
-      current.length === uiMessages.length &&
-      current.every(
-        (m, i) =>
-          m.id === uiMessages[i].id &&
-          (m.parts?.length ?? 0) === (uiMessages[i].parts?.length ?? 0),
-      )
-    ) {
+    if (areMessagesEquivalentForConvexSync(current, uiMessages)) {
       return;
     }
 
@@ -1582,7 +1574,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     if (isExistingChat) {
       setMessages(uiMessages);
     }
-  }, [paginatedMessageResults, setMessages, isExistingChat, chatId]);
+  }, [paginatedMessageResults, setMessages, isExistingChat, chatId, status]);
 
   const { scrollRef, contentRef, scrollToBottom, isAtBottom } =
     useMessageScroll();

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -47,7 +47,10 @@ import {
   fetchAgentLongStream,
   resumeAgentLongStream,
 } from "@/lib/chat/agent-long-transport";
-import { areMessagesEquivalentForConvexSync } from "@/lib/chat/message-reconciliation";
+import {
+  areMessagesEquivalentForConvexSync,
+  arePersistedMessagesAtLeastAsComplete,
+} from "@/lib/chat/message-reconciliation";
 import {
   LEGACY_DESKTOP_AGENT_UPDATE_MESSAGE,
   isLegacyDesktopAgentClient,
@@ -1019,8 +1022,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     setTodos(latestTodoOutput.todos);
   }, [messages, setTodos, shouldFetchMessages, status]);
 
-  // Ref (not state) so the Convex sync effect only fires when paginatedMessages.results
-  // changes, not on status transitions — avoiding the stale-data overwrite on stream stop.
+  // Ref keeps asynchronous completion and cancellation callbacks on the latest status.
   const statusRef = useRef(status);
   statusRef.current = status;
   const stopRef = useRef(stop);
@@ -1568,6 +1570,13 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       uiSharedOrder.length > 0 &&
       uiSharedOrder.join("\0") !== currentSharedOrder.join("\0")
     ) {
+      return;
+    }
+
+    // A status transition can rerun this effect before Convex has published the
+    // final save. Never replace more complete local text or tool progress with a
+    // stale persisted snapshot; the later Convex update will rerun the effect.
+    if (!arePersistedMessagesAtLeastAsComplete(current, uiMessages)) {
       return;
     }
 

--- a/lib/chat/__tests__/message-reconciliation.test.ts
+++ b/lib/chat/__tests__/message-reconciliation.test.ts
@@ -1,0 +1,86 @@
+import { areMessagesEquivalentForConvexSync } from "../message-reconciliation";
+import type { ChatMessage } from "@/types";
+
+const createAssistantMessage = (
+  text: string,
+  overrides: Partial<ChatMessage> = {},
+): ChatMessage => ({
+  id: "assistant-1",
+  role: "assistant",
+  parts: [{ type: "text", text }],
+  ...overrides,
+});
+
+describe("areMessagesEquivalentForConvexSync", () => {
+  it("detects completed text when the message ID and part count are unchanged", () => {
+    const current = [createAssistantMessage("The latest")];
+    const persisted = [
+      createAssistantMessage(
+        "The latest release includes the complete researched answer.",
+      ),
+    ];
+
+    expect(areMessagesEquivalentForConvexSync(current, persisted)).toBe(false);
+  });
+
+  it("treats structurally identical message parts as equivalent", () => {
+    const current = [
+      createAssistantMessage("", {
+        parts: [
+          {
+            type: "tool-web_search",
+            toolCallId: "tool-1",
+            state: "output-available",
+            input: { query: "latest release", limit: 5 },
+            output: { results: [{ title: "Release notes" }] },
+          } as ChatMessage["parts"][number],
+        ],
+      }),
+    ];
+    const persisted = [
+      createAssistantMessage("", {
+        parts: [
+          {
+            output: { results: [{ title: "Release notes" }] },
+            input: { limit: 5, query: "latest release" },
+            state: "output-available",
+            toolCallId: "tool-1",
+            type: "tool-web_search",
+          } as ChatMessage["parts"][number],
+        ],
+      }),
+    ];
+
+    expect(areMessagesEquivalentForConvexSync(current, persisted)).toBe(true);
+  });
+
+  it("detects tool state changes without a new part", () => {
+    const current = [
+      createAssistantMessage("", {
+        parts: [
+          {
+            type: "tool-web_search",
+            toolCallId: "tool-1",
+            state: "input-available",
+            input: { query: "latest release" },
+          } as ChatMessage["parts"][number],
+        ],
+      }),
+    ];
+    const persisted = [
+      createAssistantMessage("", {
+        parts: [
+          {
+            type: "tool-web_search",
+            toolCallId: "tool-1",
+            state: "output-available",
+            input: { query: "latest release" },
+            output: { results: [] },
+          } as ChatMessage["parts"][number],
+        ],
+      }),
+    ];
+
+    expect(areMessagesEquivalentForConvexSync(current, persisted)).toBe(false);
+  });
+});

--- a/lib/chat/__tests__/message-reconciliation.test.ts
+++ b/lib/chat/__tests__/message-reconciliation.test.ts
@@ -1,4 +1,7 @@
-import { areMessagesEquivalentForConvexSync } from "../message-reconciliation";
+import {
+  areMessagesEquivalentForConvexSync,
+  arePersistedMessagesAtLeastAsComplete,
+} from "../message-reconciliation";
 import type { ChatMessage } from "@/types";
 
 const createAssistantMessage = (
@@ -82,5 +85,65 @@ describe("areMessagesEquivalentForConvexSync", () => {
     ];
 
     expect(areMessagesEquivalentForConvexSync(current, persisted)).toBe(false);
+  });
+});
+
+describe("arePersistedMessagesAtLeastAsComplete", () => {
+  it("accepts completed persisted text that extends the local partial text", () => {
+    const current = [createAssistantMessage("The latest")];
+    const persisted = [
+      createAssistantMessage(
+        "The latest release includes the complete researched answer.",
+      ),
+    ];
+
+    expect(arePersistedMessagesAtLeastAsComplete(current, persisted)).toBe(
+      true,
+    );
+  });
+
+  it("rejects stale persisted text that would truncate the local answer", () => {
+    const current = [
+      createAssistantMessage(
+        "The latest release includes the complete researched answer.",
+      ),
+    ];
+    const persisted = [createAssistantMessage("The latest")];
+
+    expect(arePersistedMessagesAtLeastAsComplete(current, persisted)).toBe(
+      false,
+    );
+  });
+
+  it("rejects persisted tool state that regresses local progress", () => {
+    const current = [
+      createAssistantMessage("", {
+        parts: [
+          {
+            type: "tool-web_search",
+            toolCallId: "tool-1",
+            state: "output-available",
+            input: { query: "latest release" },
+            output: { results: [] },
+          } as ChatMessage["parts"][number],
+        ],
+      }),
+    ];
+    const persisted = [
+      createAssistantMessage("", {
+        parts: [
+          {
+            type: "tool-web_search",
+            toolCallId: "tool-1",
+            state: "input-available",
+            input: { query: "latest release" },
+          } as ChatMessage["parts"][number],
+        ],
+      }),
+    ];
+
+    expect(arePersistedMessagesAtLeastAsComplete(current, persisted)).toBe(
+      false,
+    );
   });
 });

--- a/lib/chat/__tests__/message-reconciliation.test.ts
+++ b/lib/chat/__tests__/message-reconciliation.test.ts
@@ -132,7 +132,7 @@ describe("arePersistedMessagesAtLeastAsComplete", () => {
         parts: [
           {
             type: "text",
-            text: "The latest release includes the complete researched answer.",
+            text: "The latest",
             state: "done",
           } as ChatMessage["parts"][number],
         ],

--- a/lib/chat/__tests__/message-reconciliation.test.ts
+++ b/lib/chat/__tests__/message-reconciliation.test.ts
@@ -115,6 +115,35 @@ describe("arePersistedMessagesAtLeastAsComplete", () => {
     );
   });
 
+  it("accepts a persisted text part transitioning from streaming to done", () => {
+    const current = [
+      createAssistantMessage("", {
+        parts: [
+          {
+            type: "text",
+            text: "The latest",
+            state: "streaming",
+          } as ChatMessage["parts"][number],
+        ],
+      }),
+    ];
+    const persisted = [
+      createAssistantMessage("", {
+        parts: [
+          {
+            type: "text",
+            text: "The latest release includes the complete researched answer.",
+            state: "done",
+          } as ChatMessage["parts"][number],
+        ],
+      }),
+    ];
+
+    expect(arePersistedMessagesAtLeastAsComplete(current, persisted)).toBe(
+      true,
+    );
+  });
+
   it("rejects persisted tool state that regresses local progress", () => {
     const current = [
       createAssistantMessage("", {
@@ -137,6 +166,38 @@ describe("arePersistedMessagesAtLeastAsComplete", () => {
             toolCallId: "tool-1",
             state: "input-available",
             input: { query: "latest release" },
+          } as ChatMessage["parts"][number],
+        ],
+      }),
+    ];
+
+    expect(arePersistedMessagesAtLeastAsComplete(current, persisted)).toBe(
+      false,
+    );
+  });
+
+  it("rejects a persisted tool part from a different tool call", () => {
+    const current = [
+      createAssistantMessage("", {
+        parts: [
+          {
+            type: "tool-web_search",
+            toolCallId: "tool-1",
+            state: "input-available",
+            input: { query: "latest release" },
+          } as ChatMessage["parts"][number],
+        ],
+      }),
+    ];
+    const persisted = [
+      createAssistantMessage("", {
+        parts: [
+          {
+            type: "tool-web_search",
+            toolCallId: "tool-2",
+            state: "output-available",
+            input: { query: "different release" },
+            output: { results: [] },
           } as ChatMessage["parts"][number],
         ],
       }),

--- a/lib/chat/message-reconciliation.ts
+++ b/lib/chat/message-reconciliation.ts
@@ -1,0 +1,55 @@
+import type { ChatMessage } from "@/types";
+
+type ReconciledMessage = Pick<ChatMessage, "id" | "role" | "parts">;
+
+const haveSameJsonValue = (current: unknown, next: unknown): boolean => {
+  if (Object.is(current, next)) return true;
+  if (
+    current === null ||
+    next === null ||
+    typeof current !== "object" ||
+    typeof next !== "object"
+  ) {
+    return false;
+  }
+
+  const currentIsArray = Array.isArray(current);
+  const nextIsArray = Array.isArray(next);
+  if (currentIsArray !== nextIsArray) return false;
+
+  if (currentIsArray && nextIsArray) {
+    if (current.length !== next.length) return false;
+    return current.every((value, index) =>
+      haveSameJsonValue(value, next[index]),
+    );
+  }
+
+  const currentRecord = current as Record<string, unknown>;
+  const nextRecord = next as Record<string, unknown>;
+  const currentKeys = Object.keys(currentRecord).filter(
+    (key) => currentRecord[key] !== undefined,
+  );
+  const nextKeys = Object.keys(nextRecord).filter(
+    (key) => nextRecord[key] !== undefined,
+  );
+
+  if (currentKeys.length !== nextKeys.length) return false;
+
+  return currentKeys.every(
+    (key) =>
+      Object.prototype.hasOwnProperty.call(nextRecord, key) &&
+      haveSameJsonValue(currentRecord[key], nextRecord[key]),
+  );
+};
+
+export const areMessagesEquivalentForConvexSync = (
+  current: readonly ReconciledMessage[],
+  next: readonly ReconciledMessage[],
+): boolean =>
+  current.length === next.length &&
+  current.every(
+    (message, index) =>
+      message.id === next[index].id &&
+      message.role === next[index].role &&
+      haveSameJsonValue(message.parts, next[index].parts),
+  );

--- a/lib/chat/message-reconciliation.ts
+++ b/lib/chat/message-reconciliation.ts
@@ -42,6 +42,63 @@ const haveSameJsonValue = (current: unknown, next: unknown): boolean => {
   );
 };
 
+const partStateProgress: Record<string, number> = {
+  "input-streaming": 0,
+  "input-available": 1,
+  "approval-requested": 2,
+  "approval-responded": 3,
+  "output-available": 4,
+  "output-error": 4,
+  "output-denied": 4,
+};
+
+const isPersistedPartAtLeastAsComplete = (
+  current: ChatMessage["parts"][number],
+  persisted: ChatMessage["parts"][number],
+): boolean => {
+  const currentPart = current as Record<string, unknown>;
+  const persistedPart = persisted as Record<string, unknown>;
+
+  if (currentPart.type !== persistedPart.type) return false;
+
+  for (const field of ["text", "delta"] as const) {
+    const currentText = currentPart[field];
+    if (typeof currentText !== "string") continue;
+    const persistedText = persistedPart[field];
+    if (
+      typeof persistedText !== "string" ||
+      !persistedText.startsWith(currentText)
+    ) {
+      return false;
+    }
+  }
+
+  const currentState = currentPart.state;
+  if (typeof currentState === "string") {
+    const persistedState = persistedPart.state;
+    if (typeof persistedState !== "string") return false;
+
+    const currentProgress = partStateProgress[currentState];
+    const persistedProgress = partStateProgress[persistedState];
+    if (
+      currentProgress === undefined || persistedProgress === undefined
+        ? currentState !== persistedState
+        : persistedProgress < currentProgress
+    ) {
+      return false;
+    }
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(currentPart, "output") &&
+    !Object.prototype.hasOwnProperty.call(persistedPart, "output")
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
 export const areMessagesEquivalentForConvexSync = (
   current: readonly ReconciledMessage[],
   next: readonly ReconciledMessage[],
@@ -53,3 +110,24 @@ export const areMessagesEquivalentForConvexSync = (
       message.role === next[index].role &&
       haveSameJsonValue(message.parts, next[index].parts),
   );
+
+export const arePersistedMessagesAtLeastAsComplete = (
+  current: readonly ReconciledMessage[],
+  persisted: readonly ReconciledMessage[],
+): boolean => {
+  const persistedById = new Map(
+    persisted.map((message) => [message.id, message]),
+  );
+
+  return current.every((message) => {
+    const persistedMessage = persistedById.get(message.id);
+    if (!persistedMessage || persistedMessage.role !== message.role) {
+      return false;
+    }
+    if (persistedMessage.parts.length < message.parts.length) return false;
+
+    return message.parts.every((part, index) =>
+      isPersistedPartAtLeastAsComplete(part, persistedMessage.parts[index]),
+    );
+  });
+};

--- a/lib/chat/message-reconciliation.ts
+++ b/lib/chat/message-reconciliation.ts
@@ -43,6 +43,8 @@ const haveSameJsonValue = (current: unknown, next: unknown): boolean => {
 };
 
 const partStateProgress: Record<string, number> = {
+  streaming: 0,
+  done: 1,
   "input-streaming": 0,
   "input-available": 1,
   "approval-requested": 2,
@@ -60,6 +62,12 @@ const isPersistedPartAtLeastAsComplete = (
   const persistedPart = persisted as Record<string, unknown>;
 
   if (currentPart.type !== persistedPart.type) return false;
+  if (
+    typeof currentPart.toolCallId === "string" &&
+    currentPart.toolCallId !== persistedPart.toolCallId
+  ) {
+    return false;
+  }
 
   for (const field of ["text", "delta"] as const) {
     const currentText = currentPart[field];


### PR DESCRIPTION
## Summary
- reconcile persisted chat messages again when streaming settles
- compare message part content instead of only IDs and part counts
- add regression coverage for completed text and tool-state updates that retain the same message shape

## Root cause
Convex can persist and publish a completed assistant message while the client still reports `streaming`. The synchronization effect skipped that update and did not rerun when the client became ready. When the update arrived later, the equality shortcut compared only message IDs and part counts, so a partial text part and its completed text part could be treated as identical.

This left the current task showing a truncated response even though the full answer was persisted; reopening the task loaded the persisted version.

## Validation
- `corepack pnpm test --runInBand lib/chat/__tests__/message-reconciliation.test.ts app/components/__tests__/chat.integration.test.tsx`
- `corepack pnpm typecheck`
- `corepack pnpm exec prettier --check app/components/chat.tsx lib/chat/message-reconciliation.ts lib/chat/__tests__/message-reconciliation.test.ts`
- targeted ESLint: no errors; three pre-existing hook warnings in `app/components/chat.tsx`
- commit hook: 298 suites and 2,945 tests passed

## Visual verification
In authenticated Google Chrome against the local branch:
- loaded the complete long web-research response with reasoning, tool calls, table, and sources
- switched to another task and back
- confirmed the full response remained visible with completion controls
- confirmed no browser warnings or errors

## Manual verification
1. In Ask mode, request a long answer that performs several web searches and opens multiple pages.
2. Let generation finish and confirm the complete answer appears without switching tasks or reloading.
3. Switch to another task and back; confirm the same complete answer remains visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message synchronization to apply completed responses reliably after streaming.
  * Prevented stale persisted message snapshots from overwriting more advanced local progress.
  * Enhanced message equivalence to detect redundant updates using rendered content rather than IDs/length alone, including tool-part detail differences.
* **Tests**
  * Added/updated reconciliation tests covering equivalence and “at least as complete” acceptance/rejection for both text and tool states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->