### PR TITLE
Persist Trigger run IDs for client-saved crash recovery

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -659,6 +659,10 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const browserStreamFinishedRef = useRef(false);
   const activeChatIdRef = useRef(chatId);
   const agentLongPartialSaveKeysRef = useRef<Set<string>>(new Set());
+  const agentLongRunCorrelationRef = useRef<{
+    runId: string;
+    token: string;
+  } | null>(null);
   activeChatIdRef.current = chatId;
 
   useEffect(() => {
@@ -805,6 +809,25 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
 
     onData: (dataPart) => {
       if (!isChatMountedRef.current || activeChatIdRef.current !== chatId) {
+        return;
+      }
+      if (dataPart.type === "data-agent-run-correlation") {
+        const correlationData = dataPart.data as {
+          chatId?: unknown;
+          runId?: unknown;
+          token?: unknown;
+        };
+        if (
+          typeof correlationData.runId === "string" &&
+          typeof correlationData.token === "string" &&
+          (correlationData.chatId === undefined ||
+            correlationData.chatId === chatId)
+        ) {
+          agentLongRunCorrelationRef.current = {
+            runId: correlationData.runId,
+            token: correlationData.token,
+          };
+        }
         return;
       }
       setDataStream((ds) => [...ds, { ...dataPart, __chatId: chatId }]);
@@ -1071,6 +1094,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
       const saveKey = `${chatId}:${partialMessage.id}`;
       if (agentLongPartialSaveKeysRef.current.has(saveKey)) return;
       agentLongPartialSaveKeysRef.current.add(saveKey);
+      const runCorrelation = agentLongRunCorrelationRef.current;
 
       void fetch(AGENT_PARTIAL_SAVE_ENDPOINT, {
         method: "POST",
@@ -1081,6 +1105,12 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
           generationStartedAt: partialMessage.generationStartedAt,
           generationTimeMs: partialMessage.generationTimeMs,
           clientReason,
+          ...(runCorrelation
+            ? {
+                triggerRunId: runCorrelation.runId,
+                runCorrelationToken: runCorrelation.token,
+              }
+            : {}),
         }),
       })
         .then((response) => {
@@ -1096,6 +1126,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   );
 
   useEffect(() => {
+    if (status === "submitted") {
+      agentLongRunCorrelationRef.current = null;
+    }
     if (
       shouldUseAgentLongForCurrentChat &&
       (status === "streaming" || status === "submitted")
@@ -1155,6 +1188,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   }, []);
 
   useEffect(() => {
+    agentLongRunCorrelationRef.current = null;
     setDataStream([]);
     setIsAutoResuming(false);
     dispatchStreaming({ type: "RESET_ON_CHAT_CHANGE" });

--- a/convex/__tests__/messages.hidden.test.ts
+++ b/convex/__tests__/messages.hidden.test.ts
@@ -162,6 +162,59 @@ describe("saveMessage — is_hidden handling", () => {
     );
   });
 
+  it("stores the Trigger run ID on an inserted assistant message", async () => {
+    setupExistingMessage(null);
+
+    const { saveMessage } = await import("../messages");
+
+    await saveMessage.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      id: "msg-agent",
+      chatId: CHAT_ID,
+      userId: USER_ID,
+      role: "assistant" as const,
+      parts: [{ type: "text", text: "partial output" }],
+      finishReason: "trigger_crashed_client_saved",
+      triggerRunId: "run-1",
+    });
+
+    expect(mockCtx.db.insert).toHaveBeenCalledWith(
+      "messages",
+      expect.objectContaining({
+        finish_reason: "trigger_crashed_client_saved",
+        trigger_run_id: "run-1",
+      }),
+    );
+  });
+
+  it("rejects changing an existing message to a different Trigger run", async () => {
+    const existing = makeMessage({
+      role: "assistant",
+      trigger_run_id: "run-1",
+    });
+    setupExistingMessage(existing);
+
+    const { saveMessage } = await import("../messages");
+
+    await expect(
+      saveMessage.handler(mockCtx, {
+        serviceKey: SERVICE_KEY,
+        id: "msg-1",
+        chatId: CHAT_ID,
+        userId: USER_ID,
+        role: "assistant" as const,
+        parts: [{ type: "text", text: "partial output" }],
+        triggerRunId: "run-2",
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({
+        code: "MESSAGE_SAVE_FAILED",
+        failureStage: "verify_existing_message_trigger_run",
+      }),
+    });
+    expect(mockCtx.db.patch).not.toHaveBeenCalled();
+  });
+
   it("should store is_hidden on update when isHidden is provided", async () => {
     const existing = makeMessage({ _id: "existing-doc" as Id<"messages"> });
     setupExistingMessage(existing);

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -505,6 +505,7 @@ export const saveMessage = mutation({
     generationStartedAt: v.optional(v.number()),
     generationTimeMs: v.optional(v.number()),
     finishReason: v.optional(v.string()),
+    triggerRunId: v.optional(v.string()),
     usage: v.optional(v.any()),
     updateOnly: v.optional(v.boolean()),
     isHidden: v.optional(v.boolean()),
@@ -632,6 +633,20 @@ export const saveMessage = mutation({
         if (args.finishReason && !existingMessage.finish_reason) {
           patch.finish_reason = args.finishReason;
         }
+        if (
+          args.triggerRunId &&
+          existingMessage.trigger_run_id &&
+          existingMessage.trigger_run_id !== args.triggerRunId
+        ) {
+          failureStage = "verify_existing_message_trigger_run";
+          throw new ConvexError({
+            code: "MESSAGE_TRIGGER_RUN_MISMATCH",
+            message: "Message is already associated with another Agent run",
+          });
+        }
+        if (args.triggerRunId && !existingMessage.trigger_run_id) {
+          patch.trigger_run_id = args.triggerRunId;
+        }
         if (args.isHidden !== undefined) {
           patch.is_hidden = args.isHidden;
         }
@@ -682,6 +697,7 @@ export const saveMessage = mutation({
         generation_started_at: args.generationStartedAt,
         generation_time_ms: args.generationTimeMs,
         finish_reason: args.finishReason,
+        trigger_run_id: args.triggerRunId,
         usage: args.usage,
         is_hidden: args.isHidden,
       };
@@ -1825,6 +1841,7 @@ export const branchChat = mutation({
           generation_started_at: msg.generation_started_at,
           generation_time_ms: msg.generation_time_ms,
           finish_reason: msg.finish_reason,
+          trigger_run_id: msg.trigger_run_id,
           usage: msg.usage,
         });
       }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -181,6 +181,7 @@ export default defineSchema({
     generation_started_at: v.optional(v.number()),
     generation_time_ms: v.optional(v.number()),
     finish_reason: v.optional(v.string()),
+    trigger_run_id: v.optional(v.string()),
     usage: v.optional(v.any()),
     is_hidden: v.optional(v.boolean()),
   })
@@ -188,6 +189,7 @@ export default defineSchema({
     .index("by_chat_id", ["chat_id"])
     .index("by_feedback_id", ["feedback_id"])
     .index("by_user_id", ["user_id"])
+    .index("by_trigger_run_id", ["trigger_run_id"])
     .searchIndex("search_content", {
       searchField: "content",
       filterFields: ["user_id"],

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -460,6 +460,15 @@ describe("agent-long chat UI — completion reconciliation", () => {
     expect(agentPartialSaveRouteSrc).toMatch(/hasVisibleAssistantContent/);
     expect(agentPartialSaveRouteSrc).toMatch(/saveMessage\(\{/);
     expect(agentPartialSaveRouteSrc).toMatch(
+      /verifyAgentRunCorrelationToken\(\{/,
+    );
+    expect(agentPartialSaveRouteSrc).toMatch(
+      /triggerRunId:\s*body\.triggerRunId/,
+    );
+    expect(chatComponentSrc).toMatch(/data-agent-run-correlation/);
+    expect(chatComponentSrc).toMatch(/runCorrelationToken/);
+    expect(convexMessagesSrc).toMatch(/trigger_run_id:\s*args\.triggerRunId/);
+    expect(agentPartialSaveRouteSrc).toMatch(
       /finishReason:\s*CLIENT_SAVED_FINISH_REASON/,
     );
     expect(agentPartialSaveRouteSrc).toMatch(/updateChat\(\{/);
@@ -620,7 +629,7 @@ describe("agent-long resume route — 204 on terminal + self-heal on 404", () =>
 
   test("returns chat id with the public run handle", () => {
     expect(resumeSrc).toMatch(
-      /NextResponse\.json\(\{[\s\S]*runId,[\s\S]*publicAccessToken,[\s\S]*chatId,[\s\S]*approvalSessionPublicAccessToken/,
+      /NextResponse\.json\(\{[\s\S]*runId,[\s\S]*runCorrelationToken:[\s\S]*publicAccessToken,[\s\S]*chatId,[\s\S]*approvalSessionPublicAccessToken/,
     );
   });
 });

--- a/lib/api/__tests__/agent-partial-save-route.test.ts
+++ b/lib/api/__tests__/agent-partial-save-route.test.ts
@@ -249,6 +249,29 @@ describe("createAgentPartialSavePost", () => {
     expect(mockSaveMessage).not.toHaveBeenCalled();
   });
 
+  it("rejects missing Agent run correlation before lookup", async () => {
+    const { createAgentPartialSavePost } =
+      await import("@/lib/api/agent-partial-save-route");
+    const {
+      triggerRunId: _runId,
+      runCorrelationToken: _token,
+      ...bodyWithoutCorrelation
+    } = validBody;
+
+    const response = await createAgentPartialSavePost()(
+      request(bodyWithoutCorrelation),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({
+      code: "bad_request:api",
+      cause: "Agent run correlation is incomplete.",
+    });
+    expect(mockGetChatById).not.toHaveBeenCalled();
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+  });
+
   it("rejects non-assistant messages before looking up the chat", async () => {
     const { createAgentPartialSavePost } =
       await import("@/lib/api/agent-partial-save-route");

--- a/lib/api/__tests__/agent-partial-save-route.test.ts
+++ b/lib/api/__tests__/agent-partial-save-route.test.ts
@@ -14,6 +14,7 @@ const mockSaveMessage = jest.fn();
 const mockUpdateChat = jest.fn();
 const mockAssertUserCanAccessChatHistory = jest.fn();
 const mockCreateRedisClient = jest.fn();
+const mockVerifyAgentRunCorrelationToken = jest.fn();
 
 jest.mock("next/server", () => ({
   NextResponse: class MockNextResponse {
@@ -59,6 +60,10 @@ jest.mock("@/lib/rate-limit/redis", () => ({
   createRedisClient: mockCreateRedisClient,
 }));
 
+jest.mock("@/lib/api/agent-run-correlation", () => ({
+  verifyAgentRunCorrelationToken: mockVerifyAgentRunCorrelationToken,
+}));
+
 function installResponseShim() {
   (globalThis as any).Response = {
     json: (body: unknown, init?: ResponseInit) => ({
@@ -80,6 +85,8 @@ const validBody = {
   generationStartedAt: 100,
   generationTimeMs: 250,
   clientReason: "resume_terminal_204",
+  triggerRunId: "run-1",
+  runCorrelationToken: "v1.signed-run-correlation",
 };
 
 const request = (
@@ -125,6 +132,7 @@ describe("createAgentPartialSavePost", () => {
     mockGetUserID.mockResolvedValue("user-1" as never);
     mockAssertUserCanAccessChatHistory.mockResolvedValue(undefined as never);
     mockCreateRedisClient.mockReturnValue(null);
+    mockVerifyAgentRunCorrelationToken.mockReturnValue(true);
     mockGetChatById.mockResolvedValue(chat() as never);
     mockSaveMessage.mockResolvedValue(undefined as never);
     mockUpdateChat.mockResolvedValue(undefined as never);
@@ -157,9 +165,16 @@ describe("createAgentPartialSavePost", () => {
         generationStartedAt: 100,
         generationTimeMs: 250,
         finishReason: "trigger_crashed_client_saved",
+        triggerRunId: "run-1",
         wasAborted: true,
       }),
     );
+    expect(mockVerifyAgentRunCorrelationToken).toHaveBeenCalledWith({
+      token: "v1.signed-run-correlation",
+      userId: "user-1",
+      chatId: "chat-1",
+      runId: "run-1",
+    });
     expect(mockUpdateChat).toHaveBeenCalledWith({
       chatId: "chat-1",
       finishReason: "trigger_crashed_client_saved",
@@ -199,6 +214,39 @@ describe("createAgentPartialSavePost", () => {
     expect(body).toMatchObject({ code: "forbidden:chat" });
     expect(mockSaveMessage).not.toHaveBeenCalled();
     expect(mockUpdateChat).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid Agent run correlation before writing", async () => {
+    const { createAgentPartialSavePost } =
+      await import("@/lib/api/agent-partial-save-route");
+    mockVerifyAgentRunCorrelationToken.mockReturnValue(false);
+
+    const response = await createAgentPartialSavePost()(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toMatchObject({ code: "forbidden:chat" });
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+    expect(mockUpdateChat).not.toHaveBeenCalled();
+  });
+
+  it("rejects incomplete Agent run correlation before lookup", async () => {
+    const { createAgentPartialSavePost } =
+      await import("@/lib/api/agent-partial-save-route");
+    const { runCorrelationToken: _token, ...bodyWithoutToken } = validBody;
+
+    const response = await createAgentPartialSavePost()(
+      request(bodyWithoutToken),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({
+      code: "bad_request:api",
+      cause: "Agent run correlation is incomplete.",
+    });
+    expect(mockGetChatById).not.toHaveBeenCalled();
+    expect(mockSaveMessage).not.toHaveBeenCalled();
   });
 
   it("rejects non-assistant messages before looking up the chat", async () => {

--- a/lib/api/__tests__/agent-resume-route.test.ts
+++ b/lib/api/__tests__/agent-resume-route.test.ts
@@ -9,6 +9,7 @@ const mockGetTemporaryRefreshHandle = jest.fn();
 const mockSetTemporaryRefreshCookie = jest.fn();
 const mockClearTemporaryRefreshCookie = jest.fn();
 const mockCloseAgentApprovalSession = jest.fn();
+const mockCreateAgentRunCorrelationToken = jest.fn();
 
 jest.mock("next/server", () => ({
   NextResponse: class MockNextResponse {
@@ -69,6 +70,10 @@ jest.mock("@/lib/api/agent-route-errors", () => ({
   }),
 }));
 
+jest.mock("@/lib/api/agent-run-correlation", () => ({
+  createAgentRunCorrelationToken: mockCreateAgentRunCorrelationToken,
+}));
+
 const requestFor = (chatId: string) =>
   ({
     headers: { get: () => null },
@@ -90,6 +95,9 @@ describe("agent resume route", () => {
     mockCreatePublicToken
       .mockResolvedValueOnce("fresh-run-token" as never)
       .mockResolvedValueOnce("fresh-approval-token" as never);
+    mockCreateAgentRunCorrelationToken.mockReturnValue(
+      "v1.signed-run-correlation",
+    );
   });
 
   it("refreshes temporary approval tokens from the signed mapping", async () => {
@@ -102,6 +110,7 @@ describe("agent resume route", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       runId: "run-1",
+      runCorrelationToken: "v1.signed-run-correlation",
       publicAccessToken: "fresh-run-token",
       chatId: "temporary-chat-1",
       approvalProtocolVersion: 2,
@@ -111,6 +120,11 @@ describe("agent resume route", () => {
     expect(mockCreatePublicToken).toHaveBeenNthCalledWith(2, {
       scopes: { write: { sessions: "approval-session-1" } },
       expirationTime: "1m",
+    });
+    expect(mockCreateAgentRunCorrelationToken).toHaveBeenCalledWith({
+      userId: "user-1",
+      chatId: "temporary-chat-1",
+      runId: "run-1",
     });
     expect(mockSetTemporaryRefreshCookie).toHaveBeenCalledWith(response, {
       req,

--- a/lib/api/__tests__/agent-run-correlation.test.ts
+++ b/lib/api/__tests__/agent-run-correlation.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+import {
+  createAgentRunCorrelationToken,
+  verifyAgentRunCorrelationToken,
+} from "@/lib/api/agent-run-correlation";
+
+const TEST_SECRET = "test-agent-run-correlation-secret";
+const originalSecret = process.env.AGENT_RUN_CORRELATION_SECRET;
+
+describe("Agent run correlation tokens", () => {
+  beforeEach(() => {
+    process.env.AGENT_RUN_CORRELATION_SECRET = TEST_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.AGENT_RUN_CORRELATION_SECRET;
+    } else {
+      process.env.AGENT_RUN_CORRELATION_SECRET = originalSecret;
+    }
+  });
+
+  it("verifies a token bound to the same user, chat, and Trigger run", () => {
+    const binding = {
+      userId: "user-1",
+      chatId: "chat-1",
+      runId: "run-1",
+    };
+    const token = createAgentRunCorrelationToken(binding);
+
+    expect(verifyAgentRunCorrelationToken({ ...binding, token })).toBe(true);
+  });
+
+  it.each([
+    { userId: "user-2", chatId: "chat-1", runId: "run-1" },
+    { userId: "user-1", chatId: "chat-2", runId: "run-1" },
+    { userId: "user-1", chatId: "chat-1", runId: "run-2" },
+  ])("rejects a token when its binding is changed", (binding) => {
+    const token = createAgentRunCorrelationToken({
+      userId: "user-1",
+      chatId: "chat-1",
+      runId: "run-1",
+    });
+
+    expect(verifyAgentRunCorrelationToken({ ...binding, token })).toBe(false);
+  });
+
+  it("rejects malformed tokens", () => {
+    expect(
+      verifyAgentRunCorrelationToken({
+        userId: "user-1",
+        chatId: "chat-1",
+        runId: "run-1",
+        token: "not-a-signed-token",
+      }),
+    ).toBe(false);
+  });
+});

--- a/lib/api/agent-partial-save-route.ts
+++ b/lib/api/agent-partial-save-route.ts
@@ -40,8 +40,8 @@ type PartialSaveBody = {
   generationStartedAt?: number;
   generationTimeMs?: number;
   clientReason?: string;
-  triggerRunId?: string;
-  runCorrelationToken?: string;
+  triggerRunId: string;
+  runCorrelationToken: string;
 };
 
 const getOptionalFiniteNumber = (value: unknown): number | undefined =>
@@ -169,6 +169,22 @@ const parsePartialSaveBody = async (
     throw new ChatSDKError("bad_request:api", "message.parts required");
   }
 
+  const triggerRunId =
+    typeof body.triggerRunId === "string" && body.triggerRunId.length > 0
+      ? body.triggerRunId
+      : undefined;
+  const runCorrelationToken =
+    typeof body.runCorrelationToken === "string" &&
+    body.runCorrelationToken.length > 0
+      ? body.runCorrelationToken
+      : undefined;
+  if (!triggerRunId || !runCorrelationToken) {
+    throw new ChatSDKError(
+      "bad_request:api",
+      "Agent run correlation is incomplete.",
+    );
+  }
+
   const parsed: PartialSaveBody = {
     chatId,
     message: {
@@ -180,26 +196,9 @@ const parsePartialSaveBody = async (
     generationTimeMs: getOptionalFiniteNumber(body.generationTimeMs),
     clientReason:
       typeof body.clientReason === "string" ? body.clientReason : undefined,
-    triggerRunId:
-      typeof body.triggerRunId === "string" && body.triggerRunId.length > 0
-        ? body.triggerRunId
-        : undefined,
-    runCorrelationToken:
-      typeof body.runCorrelationToken === "string" &&
-      body.runCorrelationToken.length > 0
-        ? body.runCorrelationToken
-        : undefined,
+    triggerRunId,
+    runCorrelationToken,
   };
-
-  if (
-    (parsed.triggerRunId === undefined) !==
-    (parsed.runCorrelationToken === undefined)
-  ) {
-    throw new ChatSDKError(
-      "bad_request:api",
-      "Agent run correlation is incomplete.",
-    );
-  }
 
   if (!hasVisibleAssistantContent([parsed.message])) {
     throw new ChatSDKError(
@@ -225,8 +224,6 @@ export const createAgentPartialSavePost =
         throw new ChatSDKError("forbidden:chat");
       }
       if (
-        body.triggerRunId &&
-        body.runCorrelationToken &&
         !verifyAgentRunCorrelationToken({
           token: body.runCorrelationToken,
           userId,

--- a/lib/api/agent-partial-save-route.ts
+++ b/lib/api/agent-partial-save-route.ts
@@ -7,6 +7,7 @@ import { ChatSDKError } from "@/lib/errors";
 import { hasVisibleAssistantContent } from "@/lib/chat/abort-persistence";
 import { assertUserCanAccessChatHistory } from "@/lib/suspensions";
 import { createRedisClient } from "@/lib/rate-limit/redis";
+import { verifyAgentRunCorrelationToken } from "@/lib/api/agent-run-correlation";
 
 const CLIENT_SAVED_FINISH_REASON = "trigger_crashed_client_saved";
 const MAX_PARTIAL_SAVE_BODY_BYTES = 4 * 1024 * 1024;
@@ -39,6 +40,8 @@ type PartialSaveBody = {
   generationStartedAt?: number;
   generationTimeMs?: number;
   clientReason?: string;
+  triggerRunId?: string;
+  runCorrelationToken?: string;
 };
 
 const getOptionalFiniteNumber = (value: unknown): number | undefined =>
@@ -177,7 +180,26 @@ const parsePartialSaveBody = async (
     generationTimeMs: getOptionalFiniteNumber(body.generationTimeMs),
     clientReason:
       typeof body.clientReason === "string" ? body.clientReason : undefined,
+    triggerRunId:
+      typeof body.triggerRunId === "string" && body.triggerRunId.length > 0
+        ? body.triggerRunId
+        : undefined,
+    runCorrelationToken:
+      typeof body.runCorrelationToken === "string" &&
+      body.runCorrelationToken.length > 0
+        ? body.runCorrelationToken
+        : undefined,
   };
+
+  if (
+    (parsed.triggerRunId === undefined) !==
+    (parsed.runCorrelationToken === undefined)
+  ) {
+    throw new ChatSDKError(
+      "bad_request:api",
+      "Agent run correlation is incomplete.",
+    );
+  }
 
   if (!hasVisibleAssistantContent([parsed.message])) {
     throw new ChatSDKError(
@@ -202,6 +224,18 @@ export const createAgentPartialSavePost =
       if (!chat || chat.user_id !== userId) {
         throw new ChatSDKError("forbidden:chat");
       }
+      if (
+        body.triggerRunId &&
+        body.runCorrelationToken &&
+        !verifyAgentRunCorrelationToken({
+          token: body.runCorrelationToken,
+          userId,
+          chatId: body.chatId,
+          runId: body.triggerRunId,
+        })
+      ) {
+        throw new ChatSDKError("forbidden:chat");
+      }
 
       await saveMessage({
         chatId: body.chatId,
@@ -211,6 +245,7 @@ export const createAgentPartialSavePost =
         generationStartedAt: body.generationStartedAt,
         generationTimeMs: body.generationTimeMs,
         finishReason: CLIENT_SAVED_FINISH_REASON,
+        triggerRunId: body.triggerRunId,
         wasAborted: true,
       });
 

--- a/lib/api/agent-resume-route.ts
+++ b/lib/api/agent-resume-route.ts
@@ -13,6 +13,7 @@ import {
   getTemporaryAgentApprovalRefreshHandle,
   setTemporaryAgentApprovalRefreshCookie,
 } from "@/lib/api/agent-approval-session";
+import { createAgentRunCorrelationToken } from "@/lib/api/agent-run-correlation";
 
 const TERMINAL_STATUSES = new Set([
   "COMPLETED",
@@ -161,6 +162,11 @@ export const createAgentResumeGet =
 
       const response = NextResponse.json({
         runId,
+        runCorrelationToken: createAgentRunCorrelationToken({
+          userId,
+          chatId,
+          runId,
+        }),
         publicAccessToken,
         chatId,
         approvalProtocolVersion: AGENT_APPROVAL_PROTOCOL_VERSION,

--- a/lib/api/agent-run-correlation.ts
+++ b/lib/api/agent-run-correlation.ts
@@ -1,0 +1,79 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const AGENT_RUN_CORRELATION_VERSION = "v1";
+
+type AgentRunCorrelationBinding = {
+  userId: string;
+  chatId: string;
+  runId: string;
+};
+
+type AgentRunCorrelationOptions = {
+  secret?: string;
+};
+
+const getAgentRunCorrelationSecret = (
+  options?: AgentRunCorrelationOptions,
+): string => {
+  const secret =
+    options?.secret?.trim() ||
+    process.env.AGENT_RUN_CORRELATION_SECRET?.trim() ||
+    process.env.AGENT_APPROVAL_REFRESH_SECRET?.trim() ||
+    process.env.CONVEX_SERVICE_ROLE_KEY?.trim();
+
+  if (!secret) {
+    throw new Error("Agent run correlation secret is not configured");
+  }
+
+  return secret;
+};
+
+const serializeAgentRunCorrelationBinding = ({
+  userId,
+  chatId,
+  runId,
+}: AgentRunCorrelationBinding): string =>
+  JSON.stringify([AGENT_RUN_CORRELATION_VERSION, userId, chatId, runId]);
+
+const signAgentRunCorrelationBinding = (
+  binding: AgentRunCorrelationBinding,
+  secret: string,
+): string =>
+  createHmac("sha256", secret)
+    .update(serializeAgentRunCorrelationBinding(binding))
+    .digest("base64url");
+
+export const createAgentRunCorrelationToken = (
+  binding: AgentRunCorrelationBinding,
+  options?: AgentRunCorrelationOptions,
+): string => {
+  const secret = getAgentRunCorrelationSecret(options);
+  const signature = signAgentRunCorrelationBinding(binding, secret);
+  return `${AGENT_RUN_CORRELATION_VERSION}.${signature}`;
+};
+
+export const verifyAgentRunCorrelationToken = ({
+  token,
+  ...binding
+}: AgentRunCorrelationBinding & {
+  token: string;
+}): boolean => {
+  const [version, signature, extra] = token.split(".");
+  if (
+    version !== AGENT_RUN_CORRELATION_VERSION ||
+    !signature ||
+    extra !== undefined
+  ) {
+    return false;
+  }
+
+  const secret = getAgentRunCorrelationSecret();
+  const expectedSignature = signAgentRunCorrelationBinding(binding, secret);
+  const actualBuffer = Buffer.from(signature, "utf8");
+  const expectedBuffer = Buffer.from(expectedSignature, "utf8");
+
+  return (
+    actualBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(actualBuffer, expectedBuffer)
+  );
+};

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -62,6 +62,7 @@ import {
   closeAgentApprovalSession,
   setTemporaryAgentApprovalRefreshCookie,
 } from "@/lib/api/agent-approval-session";
+import { createAgentRunCorrelationToken } from "@/lib/api/agent-run-correlation";
 
 const AGENT_TRIGGER_PRIORITY_BY_SUBSCRIPTION: Record<SubscriptionTier, number> =
   {
@@ -676,6 +677,11 @@ export const createAgentTriggerPost =
 
       const response = NextResponse.json({
         runId,
+        runCorrelationToken: createAgentRunCorrelationToken({
+          userId,
+          chatId,
+          runId,
+        }),
         publicAccessToken,
         chatId,
         approvalProtocolVersion: AGENT_APPROVAL_PROTOCOL_VERSION,

--- a/lib/chat/agent-long-transport.ts
+++ b/lib/chat/agent-long-transport.ts
@@ -34,6 +34,7 @@ import { createContentSequenceGuard } from "./agent-long-content-sequence-guard"
  */
 type RunHandle = {
   runId: string;
+  runCorrelationToken?: string;
   publicAccessToken: string;
   chatId?: string;
   approvalSessionId?: string;
@@ -261,6 +262,26 @@ const buildSSEResponseFromRun = (
         );
       };
 
+      const enqueueAgentRunCorrelationPart = () => {
+        if (!handle.runCorrelationToken || closed) {
+          return;
+        }
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({
+              type: "data-agent-run-correlation",
+              id: `agent-run-correlation-${runId}`,
+              transient: true,
+              data: {
+                chatId,
+                runId,
+                token: handle.runCorrelationToken,
+              },
+            })}\n\n`,
+          ),
+        );
+      };
+
       cancelRealtimeSubscriptions = async () => {
         readAbortController?.abort();
         if (statusMonitorInterval !== undefined) {
@@ -335,6 +356,7 @@ const buildSSEResponseFromRun = (
           return;
         }
 
+        enqueueAgentRunCorrelationPart();
         enqueueAgentApprovalSessionPart();
 
         const completedRunDrainTimeout = Symbol("completed-run-drain-timeout");

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -574,6 +574,30 @@ describe("setActiveTriggerRun", () => {
 });
 
 describe("saveMessage", () => {
+  it("forwards the durable Trigger run ID to Convex", async () => {
+    const { saveMessage, mockMutation } = await loadSaveMessageWithMocks();
+
+    await saveMessage({
+      chatId: "chat-1",
+      userId: "user-1",
+      message: {
+        id: "message-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "partial output" }],
+      },
+      finishReason: "trigger_crashed_client_saved",
+      triggerRunId: "run-1",
+    });
+
+    expect(mockMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        finishReason: "trigger_crashed_client_saved",
+        triggerRunId: "run-1",
+      }),
+    );
+  });
+
   it("sanitizes assistant parts before storage compaction", async () => {
     const { saveMessage, mockCompactMessageForStorage } =
       await loadSaveMessageWithMocks();

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -902,6 +902,7 @@ export async function saveMessage({
   generationStartedAt,
   generationTimeMs,
   finishReason,
+  triggerRunId,
   usage,
   updateOnly,
   isHidden,
@@ -921,6 +922,7 @@ export async function saveMessage({
   generationStartedAt?: number;
   generationTimeMs?: number;
   finishReason?: string;
+  triggerRunId?: string;
   usage?: Record<string, unknown>;
   updateOnly?: boolean;
   isHidden?: boolean;
@@ -1021,6 +1023,7 @@ export async function saveMessage({
       generationStartedAt,
       generationTimeMs,
       finishReason,
+      triggerRunId,
       usage: usageForSave,
       updateOnly,
       isHidden,


### PR DESCRIPTION
## Summary

- attach a server-signed Trigger run correlation token to Agent start and resume handles
- carry the correlation through the existing transient UI stream without adding another Trigger, model, agent, or tool request
- verify the correlation before client partial-save persistence
- store the exact run ID as immutable `messages.trigger_run_id` data and index it for forensic lookup
- reject attempts to replace a message's existing run association

## Root cause

When a Trigger.dev Agent run reached a terminal state, `active_trigger_run_id` was cleared as intended. The client recovery path then persisted `finish_reason = trigger_crashed_client_saved`, but neither the partial-save request nor the message schema retained the originating Trigger run ID. Database evidence could therefore show that recovery occurred without proving which run crashed.

## Impact

New client-saved crash recoveries can be correlated directly with the exact Trigger.dev dashboard run. The temporary active-run lifecycle remains unchanged, and the correlation adds no additional model, Agent, tool, or Trigger API request.

## Deployment order

1. Deploy the Convex schema/functions so `messages.trigger_run_id` and the updated mutation argument are available.
2. Deploy the web application.

## Validation

- `pnpm typecheck`
- `pnpm lint` (0 errors; existing warnings only)
- focused Jest coverage: 6 suites / 147 tests
- Prettier check on all touched files

## Manual verification

1. Start an Agent run and allow it to produce visible partial output.
2. Force the Trigger.dev run into a crashed/terminal state.
3. Confirm the recovered assistant message has `finish_reason = trigger_crashed_client_saved`.
4. Confirm its indexed `trigger_run_id` exactly matches the Trigger.dev dashboard run ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added secure agent run correlation tokens to trigger, resume, and Agent-long streaming (including extra SSE correlation frames).
  - Partial assistant snapshots now persist `triggerRunId`, and branched chats copy it forward.
  - Message persistence supports optional `triggerRunId` and the database schema now stores it (with a dedicated index).
- **Bug Fixes**
  - Prevent saving when correlation is missing, incomplete, or mismatched; also clears stale correlation across chat transitions/submission.
- **Tests**
  - Expanded correlation and message save coverage, including token verification and triggerRunId mismatch/rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->