### PR TITLE
Unblock production by removing unused Trigger run index

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -192,7 +192,6 @@ export default defineSchema({
     .index("by_chat_id", ["chat_id"])
     .index("by_feedback_id", ["feedback_id"])
     .index("by_user_id", ["user_id"])
-    .index("by_trigger_run_id", ["trigger_run_id"])
     .searchIndex("search_content", {
       searchField: "content",
       filterFields: ["user_id"],


### PR DESCRIPTION
## Summary

- remove the unused `messages.by_trigger_run_id` Convex index
- keep the optional `messages.trigger_run_id` field and all crash-correlation persistence behavior unchanged
- allow the production Convex deployment to complete without backfilling the entire historical messages table

## Root cause

PR #965 added a synchronous index to the large production `messages` table. Convex waited for that index to backfill before registering the new schema and functions. The Vercel production deployment remained at `103/104 ready` and eventually failed while the index was still backfilling.

No application query uses `by_trigger_run_id`, so the index imposed deployment and write-maintenance cost without serving a read path.

## Impact

The durable Trigger run ID remains stored on newly recovered Agent messages. This change removes only the unnecessary lookup index, allowing the original crash-correlation fix to deploy.

If a run-ID-first query is introduced later, the index should be added as a staged Convex index in a separate deployment, enabled only after its asynchronous backfill completes.

## Validation

- `pnpm typecheck`
- ESLint on `convex/schema.ts`
- Prettier check on `convex/schema.ts`
- focused Jest coverage: 6 suites / 148 tests
- `git diff --check`
- confirmed there are no `by_trigger_run_id` query references

## Production verification

After merge, verify the production Convex deployment completes, the Vercel deployment becomes Ready, and a forced Agent crash persists `finish_reason = trigger_crashed_client_saved` with the matching `trigger_run_id`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full-text search for message content.
  * Search results can be filtered by user for more relevant matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->