### PR TITLE
Improve HAC-45 economics and request diagnostics

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -64,7 +64,11 @@ import {
 } from "@/lib/chat/agent-long-heartbeat";
 import { hasVisibleAssistantContent } from "@/lib/chat/abort-persistence";
 import { toast } from "sonner";
-import { addAuthenticatedExceptionStep } from "@/lib/analytics/client";
+import {
+  addAuthenticatedExceptionStep,
+  getPostHogRequestHeaders,
+} from "@/lib/analytics/client";
+import { useHac45AgentOnlyTreatment } from "@/app/contexts/Hac45AgentOnlyContext";
 import {
   normalizeSelectedModelForSubscription,
   type Todo,
@@ -474,6 +478,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const routeChatId = params?.id as string | undefined;
   const router = useRouter();
   const isMobile = useIsMobile();
+  const hac45AgentOnlyActive = useHac45AgentOnlyTreatment();
   const { setDataStream, setIsAutoResuming } = useDataStreamDispatch();
   const {
     isLoading: isConvexAuthLoading,
@@ -534,6 +539,7 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
   const isExistingChatRef = useLatestRef(isExistingChat);
   const chatModeRef = useLatestRef(chatMode);
   const subscriptionRef = useLatestRef(subscription);
+  const hac45AgentOnlyActiveRef = useLatestRef(hac45AgentOnlyActive);
 
   // Suppress transient "Chat Not Found" while server creates the chat
   const [awaitingServerChat, setAwaitingServerChat] = useState<boolean>(false);
@@ -773,6 +779,9 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
         const messagesWithoutUrls = stripUrlsFromMessages(messagesToSend);
 
         return {
+          headers: getPostHogRequestHeaders({
+            hac45AgentOnlyActive: hac45AgentOnlyActiveRef.current,
+          }),
           body: {
             chatId: id,
             messages: messagesWithoutUrls,

--- a/lib/analytics/__tests__/client.test.ts
+++ b/lib/analytics/__tests__/client.test.ts
@@ -12,6 +12,7 @@ const mockPostHog = {
   __loaded: true,
   capture: mockCapture,
   get_distinct_id: jest.fn(() => "user_123"),
+  get_session_id: jest.fn(() => "session_123"),
 };
 
 jest.mock("posthog-js", () => ({
@@ -19,8 +20,11 @@ jest.mock("posthog-js", () => ({
   default: mockPostHog,
 }));
 
-const { captureUpgradeCtaImpression, loadPostHogClient } =
-  require("../client") as typeof import("../client");
+const {
+  captureUpgradeCtaImpression,
+  getPostHogRequestHeaders,
+  loadPostHogClient,
+} = require("../client") as typeof import("../client");
 
 describe("client analytics", () => {
   beforeAll(async () => {
@@ -93,5 +97,14 @@ describe("client analytics", () => {
     window.localStorage.clear();
     expect(captureUpgradeCtaImpression(properties)).toBe(true);
     expect(mockCapture.mock.calls[2]?.[2]?.uuid).not.toBe(firstDeviceUuid);
+  });
+
+  it("adds versioned HAC-45 state and PostHog session correlation headers", () => {
+    expect(getPostHogRequestHeaders({ hac45AgentOnlyActive: true })).toEqual({
+      "x-hackerai-analytics-context-version": "1",
+      "x-hackerai-hac45-agent-only": "active",
+      "X-POSTHOG-DISTINCT-ID": "user_123",
+      "x-posthog-session-id": "session_123",
+    });
   });
 });

--- a/lib/analytics/__tests__/request-context.test.ts
+++ b/lib/analytics/__tests__/request-context.test.ts
@@ -1,0 +1,34 @@
+import {
+  ANALYTICS_CONTEXT_VERSION_HEADER,
+  HAC45_AGENT_ONLY_HEADER,
+  POSTHOG_SESSION_ID_HEADER,
+  readAnalyticsRequestContext,
+} from "../request-context";
+
+describe("readAnalyticsRequestContext", () => {
+  it("accepts the versioned experiment state and a safe PostHog session ID", () => {
+    const headers = new Headers({
+      [ANALYTICS_CONTEXT_VERSION_HEADER]: "1",
+      [HAC45_AGENT_ONLY_HEADER]: "active",
+      [POSTHOG_SESSION_ID_HEADER]: "018f3ba2-c6e1-7f30-a6b2-4c4d8b1f90ef",
+    });
+
+    expect(readAnalyticsRequestContext(headers)).toEqual({
+      analyticsContextVersion: 1,
+      hac45AgentOnlyClientActive: true,
+      posthogSessionId: "018f3ba2-c6e1-7f30-a6b2-4c4d8b1f90ef",
+    });
+  });
+
+  it("keeps an explicit inactive state while dropping malformed values", () => {
+    const headers = new Headers({
+      [ANALYTICS_CONTEXT_VERSION_HEADER]: "2",
+      [HAC45_AGENT_ONLY_HEADER]: "inactive",
+      [POSTHOG_SESSION_ID_HEADER]: "not safe/for analytics",
+    });
+
+    expect(readAnalyticsRequestContext(headers)).toEqual({
+      hac45AgentOnlyClientActive: false,
+    });
+  });
+});

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -9,6 +9,12 @@ import {
   paidFunnelProperties,
   upgradeCtaImpressionInsertId,
 } from "@/lib/analytics/paid-funnel";
+import {
+  ANALYTICS_CONTEXT_VERSION,
+  ANALYTICS_CONTEXT_VERSION_HEADER,
+  HAC45_AGENT_ONLY_HEADER,
+  POSTHOG_SESSION_ID_HEADER,
+} from "@/lib/analytics/request-context";
 
 type ClientAnalyticsProperties = Record<string, unknown>;
 
@@ -215,15 +221,29 @@ export function newCheckoutAttemptId() {
   return createCheckoutAttemptId();
 }
 
-export function getPostHogRequestHeaders(): HeadersInit {
+export function getPostHogRequestHeaders({
+  hac45AgentOnlyActive,
+}: {
+  hac45AgentOnlyActive?: boolean;
+} = {}): HeadersInit {
+  const experimentHeaders: Record<string, string> = {};
+  if (hac45AgentOnlyActive !== undefined) {
+    experimentHeaders[ANALYTICS_CONTEXT_VERSION_HEADER] = String(
+      ANALYTICS_CONTEXT_VERSION,
+    );
+    experimentHeaders[HAC45_AGENT_ONLY_HEADER] = hac45AgentOnlyActive
+      ? "active"
+      : "inactive";
+  }
   const posthog = getReadyPostHogClient();
-  if (!posthog) return {};
+  if (!posthog) return experimentHeaders;
 
   const distinctId = posthog.get_distinct_id();
   const sessionId = posthog.get_session_id?.();
 
   return {
+    ...experimentHeaders,
     ...(distinctId && { "X-POSTHOG-DISTINCT-ID": distinctId }),
-    ...(sessionId && { "X-POSTHOG-SESSION-ID": sessionId }),
+    ...(sessionId && { [POSTHOG_SESSION_ID_HEADER]: sessionId }),
   };
 }

--- a/lib/analytics/request-context.ts
+++ b/lib/analytics/request-context.ts
@@ -1,0 +1,38 @@
+export const POSTHOG_SESSION_ID_HEADER = "x-posthog-session-id";
+export const ANALYTICS_CONTEXT_VERSION_HEADER =
+  "x-hackerai-analytics-context-version";
+export const HAC45_AGENT_ONLY_HEADER = "x-hackerai-hac45-agent-only";
+
+export const ANALYTICS_CONTEXT_VERSION = 1;
+
+const SAFE_POSTHOG_SESSION_ID = /^[A-Za-z0-9_-]{1,128}$/;
+
+export type AnalyticsRequestContext = {
+  analyticsContextVersion?: number;
+  hac45AgentOnlyClientActive?: boolean;
+  posthogSessionId?: string;
+};
+
+export function readAnalyticsRequestContext(
+  headers: Pick<Headers, "get">,
+): AnalyticsRequestContext {
+  const rawSessionId = headers.get(POSTHOG_SESSION_ID_HEADER)?.trim();
+  const rawContextVersion = headers.get(ANALYTICS_CONTEXT_VERSION_HEADER);
+  const rawHac45AgentOnly = headers.get(HAC45_AGENT_ONLY_HEADER);
+
+  return {
+    ...(rawSessionId &&
+      SAFE_POSTHOG_SESSION_ID.test(rawSessionId) && {
+        posthogSessionId: rawSessionId,
+      }),
+    ...(rawContextVersion === String(ANALYTICS_CONTEXT_VERSION) && {
+      analyticsContextVersion: ANALYTICS_CONTEXT_VERSION,
+    }),
+    ...(rawHac45AgentOnly === "active" && {
+      hac45AgentOnlyClientActive: true,
+    }),
+    ...(rawHac45AgentOnly === "inactive" && {
+      hac45AgentOnlyClientActive: false,
+    }),
+  };
+}

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -479,6 +479,11 @@ describe("captureUsageCost", () => {
         id: "settlement_123",
         midRunCount: 7,
       },
+      analyticsRequestContext: {
+        analyticsContextVersion: 1,
+        hac45AgentOnlyClientActive: true,
+        posthogSessionId: "session_123",
+      },
     });
 
     expect(capture).toHaveBeenCalledWith({
@@ -501,6 +506,9 @@ describe("captureUsageCost", () => {
         extra_usage_cost_dollars: 0.32,
         included_points_deducted: 1000,
         extra_usage_points_deducted: 3200,
+        usage_economics_version: 1,
+        extra_usage_charge_dollars: 0.368,
+        consumption_contribution_dollars: -0.05199999999999999,
         model_cost_dollars: 0.3,
         non_model_cost_dollars: 0.12,
         input_tokens: 1000,
@@ -509,6 +517,9 @@ describe("captureUsageCost", () => {
         cache_read_tokens: 200,
         cache_write_tokens: 0,
         cost_source: "provider",
+        $session_id: "session_123",
+        client_analytics_context_version: 1,
+        hac45_agent_only_client_active: true,
         usage_settlement_id: "settlement_123",
         mid_run_usage_settlement_count: 7,
         usage_settlement_step_events_sampled:

--- a/lib/api/agent-trigger-route.ts
+++ b/lib/api/agent-trigger-route.ts
@@ -31,6 +31,7 @@ import {
 } from "@/types";
 import { ChatSDKError } from "@/lib/errors";
 import { requireOptionalIdentifier } from "@/lib/api/chat-request-validation";
+import { readAnalyticsRequestContext } from "@/lib/analytics/request-context";
 import { resolveProjectExecutionContext } from "@/lib/chat/project-context";
 import type {
   Todo,
@@ -349,6 +350,7 @@ export const createAgentTriggerPost =
     try {
       const parsedBody = await parseAgentTriggerRequestBody(req);
       if (!parsedBody.ok) return parsedBody.response;
+      const analyticsRequestContext = readAnalyticsRequestContext(req.headers);
 
       const {
         messages,
@@ -591,6 +593,7 @@ export const createAgentTriggerPost =
         limitRescue,
         isNewChat,
         endpoint,
+        analyticsRequestContext,
         convexUrl: process.env.NEXT_PUBLIC_CONVEX_URL,
         requestTiming: {
           routeStartedAt,

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -138,6 +138,7 @@ import {
 import { Id } from "@/convex/_generated/dataModel";
 import { phLogger } from "@/lib/posthog/server";
 import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
+import { readAnalyticsRequestContext } from "@/lib/analytics/request-context";
 import {
   buildAgentCompletionSignals,
   createAgentCompletionSignalTracker,
@@ -247,6 +248,7 @@ export const createChatHandler = () => {
         limitRescue?: unknown;
         projectId?: unknown;
       } = await req.json();
+      const analyticsRequestContext = readAnalyticsRequestContext(req.headers);
       const temporary = requireBooleanFlag("temporary", rawTemporary);
       const requestedProjectId = requireOptionalIdentifier(
         "projectId",
@@ -1109,6 +1111,7 @@ export const createChatHandler = () => {
                   mode,
                   usage: usageCostRecord,
                   responseModel: state.responseModel,
+                  analyticsRequestContext,
                   ...(usageSettlementState && {
                     usageSettlement: {
                       id: usageTracker.usageSettlementId,

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -30,6 +30,8 @@ import {
   paidFunnelProperties,
 } from "@/lib/analytics/paid-funnel";
 import type { AgentCompletionSignals } from "@/lib/analytics/agent-completion-signals";
+import type { AnalyticsRequestContext } from "@/lib/analytics/request-context";
+import { extraUsagePointsToDollars } from "@/convex/lib/extraUsagePricing";
 import type { UsageCostRecord } from "@/lib/usage-tracker";
 import type { UsageDeductionResult } from "@/lib/rate-limit";
 import type { BudgetAbortDetails } from "@/lib/chat/budget-monitor";
@@ -1334,7 +1336,10 @@ export function captureAgentCompletionAnalytics(
 /**
  * Capture one cost event per request with usage. In PostHog, answer
  * "how much does each user cost you?" by summing cost_dollars on
- * hackerai-usage_cost grouped by distinct_id (or user_id).
+ * hackerai-usage_cost grouped by distinct_id (or user_id). Sum
+ * consumption_contribution_dollars for extra-usage value consumed minus
+ * provider/tool cost; subscription revenue is intentionally reported
+ * separately.
  */
 export function captureUsageCost({
   posthog,
@@ -1349,6 +1354,7 @@ export function captureUsageCost({
   responseModel,
   paidDailyFreeAllowance,
   usageSettlement,
+  analyticsRequestContext,
 }: {
   posthog: PostHog | null;
   userId: string;
@@ -1371,8 +1377,12 @@ export function captureUsageCost({
     id: string;
     midRunCount: number;
   };
+  analyticsRequestContext?: AnalyticsRequestContext;
 }) {
   if (!posthog) return;
+  const extraUsageChargeDollars = extraUsagePointsToDollars(
+    usage.extraUsagePointsDeducted,
+  );
   posthog.capture({
     distinctId: userId,
     event: "hackerai-usage_cost",
@@ -1396,6 +1406,10 @@ export function captureUsageCost({
       uncovered_cost_dollars: usage.uncoveredCostDollars,
       included_points_deducted: usage.includedPointsDeducted,
       extra_usage_points_deducted: usage.extraUsagePointsDeducted,
+      usage_economics_version: 1,
+      extra_usage_charge_dollars: extraUsageChargeDollars,
+      consumption_contribution_dollars:
+        extraUsageChargeDollars - usage.costDollars,
       uncovered_points: usage.uncoveredPoints,
       usage_deduction_failed: usage.usageDeductionFailed,
       usage_deduction_failure_reason: usage.usageDeductionFailureReason,
@@ -1407,6 +1421,17 @@ export function captureUsageCost({
       cache_read_tokens: usage.cacheReadTokens ?? 0,
       cache_write_tokens: usage.cacheWriteTokens ?? 0,
       cost_source: usage.costSource,
+      ...(analyticsRequestContext?.posthogSessionId && {
+        $session_id: analyticsRequestContext.posthogSessionId,
+      }),
+      ...(analyticsRequestContext?.analyticsContextVersion !== undefined && {
+        client_analytics_context_version:
+          analyticsRequestContext.analyticsContextVersion,
+      }),
+      ...(analyticsRequestContext?.hac45AgentOnlyClientActive !== undefined && {
+        hac45_agent_only_client_active:
+          analyticsRequestContext.hac45AgentOnlyClientActive,
+      }),
       ...(usageSettlement && {
         usage_settlement_id: usageSettlement.id,
         mid_run_usage_settlement_count: usageSettlement.midRunCount,

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -118,6 +118,7 @@ import {
 } from "@/lib/api/agent-endpoints";
 import { phLogger } from "@/lib/posthog/server";
 import { PAID_FUNNEL_EVENTS } from "@/lib/analytics/paid-funnel";
+import type { AnalyticsRequestContext } from "@/lib/analytics/request-context";
 import {
   buildAgentCompletionSignals,
   createAgentCompletionSignalTracker,
@@ -1587,6 +1588,7 @@ export type AgentLongPayload = {
   isNewChat?: boolean;
   limitRescue?: LimitRescueRequest;
   endpoint?: AgentApiEndpoint;
+  analyticsRequestContext?: AnalyticsRequestContext;
   convexUrl?: string;
   requestTiming?: {
     routeStartedAt: number;
@@ -1653,6 +1655,7 @@ export const agentLongTask = task({
       isNewChat,
       limitRescue,
       endpoint: payloadEndpoint,
+      analyticsRequestContext,
     } = payload;
     let selectedModelOverride = rawSelectedModelOverride;
     const endpoint = payloadEndpoint ?? LEGACY_AGENT_API_ENDPOINT;
@@ -2661,6 +2664,7 @@ export const agentLongTask = task({
                   endpoint,
                   mode,
                   agentPermissionMode,
+                  analyticsRequestContext,
                   usage: usageCostRecord,
                   responseModel: state.responseModel,
                   ...(usageSettlementState && {


### PR DESCRIPTION
## Summary

- attach versioned, privacy-safe client experiment context and PostHog session correlation to Ask and Agent usage-cost events
- propagate the context through both the browser chat route and Trigger-backed Agent runs
- add `extra_usage_charge_dollars` and `consumption_contribution_dollars` to `hackerai-usage_cost`, versioned with `usage_economics_version = 1`
- validate all client-supplied analytics headers before using them

## Why

HAC-45 has strong directional adoption and reliability results, but two exposed users produced post-exposure Ask requests. Current telemetry cannot distinguish a concurrent stale/old tab from a treatment-aware client bug because server-side cost events are not linked to the browser session or its flag evaluation.

The existing cost and extra-usage point fields are sufficient to reconstruct consumption contribution, but doing so requires repeating pricing logic in every readout. Recording the derived retail charge and contribution at ingestion makes profitability comparisons direct and preserves the pricing version used at the time.

This PR does **not** change the HAC-45 flag, cohort, rollout percentage, Agent enforcement, or permission behavior. It captures no prompts, targets, findings, code, payloads, or other user content.

Linear: [HAC-45](https://linear.app/hackerai/issue/HAC-45/run-25percent-agent-only-mode-experiment-after-7-day-baseline)

## Validation

- `pnpm jest app/__tests__/providers.test.tsx app/components/__tests__/chat.integration.test.tsx lib/analytics/__tests__/client.test.ts lib/analytics/__tests__/request-context.test.ts lib/api/__tests__/chat-logger.test.ts lib/api/__tests__/agent-trigger-route.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand` — 142 tests passed
- scoped ESLint — no errors; three existing `chat.tsx` hook warnings remain
- scoped Prettier check — passed
- `git diff --check` — passed
- `pnpm typecheck` — reaches only the existing `packages/local/src/index.ts(17,23): Cannot find module 'ws'` dependency error

## Manual verification

After a deployment containing this change:

1. Send one authenticated paid Ask request and one Agent request.
2. Confirm their `hackerai-usage_cost` events include `$session_id`, `client_analytics_context_version = 1`, and the HAC-45 client-active boolean.
3. Confirm `extra_usage_charge_dollars` matches extra-usage points at the recorded retail rate and `consumption_contribution_dollars` equals that charge minus total provider/tool cost.
4. For the separate HAC-45 QA user, run Agent with v2 enabled and confirm the cost event records `hac45_agent_only_client_active = true` without capturing user content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced chat analytics to preserve experiment and session context across requests.
  - Improved usage reporting with clearer breakdowns for extra usage charges and consumption contributions.
  - Added safer validation for analytics session information and context values.
  - Extended agent-triggered workflows so usage analytics remain consistent across long-running tasks.

- **Tests**
  - Added coverage for analytics context handling, session validation, and enhanced usage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->