### PR TITLE
Clarify HackerAI Max access choices

### DIFF
--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -342,7 +342,7 @@ const LockedMaxAccessOption = ({
                 Use Extra Usage
               </span>
               <span className="block text-[11px] leading-4 text-muted-foreground">
-                Keep your current plan
+                Pay for Max as you use it
               </span>
             </span>
             <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-hover/action:translate-x-0.5" />
@@ -364,7 +364,7 @@ const LockedMaxAccessOption = ({
                 Upgrade to Ultra
               </span>
               <span className="block text-[11px] leading-4 text-muted-foreground">
-                Max included with your plan
+                Max included
               </span>
             </span>
             <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-hover/action:translate-x-0.5" />
@@ -689,8 +689,8 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
             <DialogHeader>
               <DialogTitle>Unlock HackerAI Max</DialogTitle>
               <DialogDescription className="leading-relaxed">
-                Use Max with Extra Usage after your included credits, or upgrade
-                to Ultra to have Max included.
+                On Pro and Pro+, Max is paid through Extra Usage. Upgrade to
+                Ultra to have Max included.
               </DialogDescription>
             </DialogHeader>
             <div className="flex flex-col gap-2 pt-2">

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -10,7 +10,6 @@ import {
 } from "lucide-react";
 import {
   Popover,
-  PopoverAnchor,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
@@ -34,7 +33,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
-import { useEffect, useId, useRef, useState } from "react";
+import { useId, useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import {
@@ -211,7 +210,6 @@ const ModelOptionButton = ({
       disabled={isPending}
       aria-busy={isPending || undefined}
       aria-pressed={isSelected}
-      aria-haspopup={actionPanelId ? "dialog" : undefined}
       aria-expanded={actionPanelId ? actionPanelOpen : undefined}
       aria-controls={actionPanelId}
       aria-label={
@@ -287,105 +285,73 @@ const ModelOptionButton = ({
   );
 };
 
-const LockedMaxAccessPopover = ({
+const LockedMaxAccessOption = ({
   option,
   isSelected,
   subscription,
-  onSelect,
   onClose,
 }: {
   option: ModelOption;
   isSelected: boolean;
   subscription: SubscriptionTier;
-  onSelect: (option: ModelOption) => void;
   onClose: () => void;
 }) => {
   const [open, setOpen] = useState(false);
   const panelId = useId();
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const clearScheduledClose = () => {
-    if (closeTimerRef.current !== null) {
-      clearTimeout(closeTimerRef.current);
-      closeTimerRef.current = null;
-    }
-  };
-
-  const showPanel = () => {
-    clearScheduledClose();
-    setOpen(true);
-  };
-
-  const schedulePanelClose = () => {
-    clearScheduledClose();
-    closeTimerRef.current = setTimeout(() => setOpen(false), 150);
-  };
-
-  useEffect(() => clearScheduledClose, []);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverAnchor asChild>
+    <div
+      className={`rounded-lg transition-colors ${open ? "bg-muted/35" : ""}`}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onFocusCapture={() => setOpen(true)}
+      onBlurCapture={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setOpen(false);
+        }
+      }}
+    >
+      <ModelOptionButton
+        option={option}
+        isSelected={isSelected}
+        isLocked
+        isPending={false}
+        subscription={subscription}
+        onSelect={() => setOpen(true)}
+        actionPanelId={panelId}
+        actionPanelOpen={open}
+      />
+      {open && (
         <div
-          onMouseEnter={showPanel}
-          onMouseLeave={schedulePanelClose}
-          onFocusCapture={showPanel}
+          id={panelId}
+          role="group"
+          aria-label="Choose how to access HackerAI Max"
+          className="mx-2 mb-1.5 mt-0.5 border-t border-border/50 pt-1"
         >
-          <ModelOptionButton
-            option={option}
-            isSelected={isSelected}
-            isLocked
-            isPending={false}
-            subscription={subscription}
-            onSelect={onSelect}
-            actionPanelId={panelId}
-            actionPanelOpen={open}
-          />
-        </div>
-      </PopoverAnchor>
-      <PopoverContent
-        id={panelId}
-        side="right"
-        sideOffset={12}
-        align="start"
-        aria-label="HackerAI Max access options"
-        className="w-[240px] rounded-xl px-4 py-3 space-y-1.5"
-        onMouseEnter={showPanel}
-        onMouseLeave={schedulePanelClose}
-        onOpenAutoFocus={(event) => event.preventDefault()}
-      >
-        <p className="text-sm font-semibold text-foreground leading-snug">
-          {option.description || option.label}
-        </p>
-        {option.poweredBy && (
-          <p className="text-xs text-muted-foreground">
-            Powered by {option.poweredBy}
-          </p>
-        )}
-        <p className="text-xs text-muted-foreground leading-relaxed pt-1">
-          Set up Extra Usage to use Max on your current plan, or upgrade to
-          Ultra to have Max included.
-        </p>
-        <div className="flex gap-2 pt-1">
           <Button
             type="button"
-            size="sm"
-            className="h-8 flex-1 px-2 text-xs"
+            variant="ghost"
+            className="group/action h-auto w-full justify-start gap-2 px-2 py-1.5 text-left font-normal"
             onClick={() => {
-              setOpen(false);
               onClose();
               openSettingsDialog("Extra Usage");
             }}
           >
-            Use Extra Usage
+            <span className="min-w-0 flex-1">
+              <span className="block text-xs font-medium text-foreground">
+                Use Extra Usage
+              </span>
+              <span className="block text-[11px] leading-4 text-muted-foreground">
+                Keep your current plan
+              </span>
+            </span>
+            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-hover/action:translate-x-0.5" />
           </Button>
           <Button
             type="button"
-            size="sm"
-            variant="outline"
-            className="h-8 flex-1 px-2 text-xs"
+            variant="ghost"
+            className="group/action h-auto w-full justify-start gap-2 px-2 py-1.5 text-left font-normal"
             onClick={() => {
-              setOpen(false);
               onClose();
               openMaxUltraUpgrade({
                 mobile: false,
@@ -393,11 +359,19 @@ const LockedMaxAccessPopover = ({
               });
             }}
           >
-            Upgrade to Ultra
+            <span className="min-w-0 flex-1">
+              <span className="block text-xs font-medium text-foreground">
+                Upgrade to Ultra
+              </span>
+              <span className="block text-[11px] leading-4 text-muted-foreground">
+                Max included with your plan
+              </span>
+            </span>
+            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-hover/action:translate-x-0.5" />
           </Button>
         </div>
-      </PopoverContent>
-    </Popover>
+      )}
+    </div>
   );
 };
 
@@ -497,12 +471,11 @@ const ModelOptionList = ({
         canChoosePersonalMaxAccessPath(subscription)
       ) {
         return (
-          <LockedMaxAccessPopover
+          <LockedMaxAccessOption
             key={option.id}
             option={option}
             isSelected={isSelected}
             subscription={subscription}
-            onSelect={onSelect}
             onClose={onClose}
           />
         );
@@ -716,9 +689,8 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
             <DialogHeader>
               <DialogTitle>Unlock HackerAI Max</DialogTitle>
               <DialogDescription className="leading-relaxed">
-                Set up Extra Usage to use Max on your current plan, or upgrade
-                to Ultra to have Max included. Your included credits are used
-                first; Extra Usage covers any overflow.
+                Use Max with Extra Usage after your included credits, or upgrade
+                to Ultra to have Max included.
               </DialogDescription>
             </DialogHeader>
             <div className="flex flex-col gap-2 pt-2">

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -14,6 +14,13 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   Sheet,
   SheetContent,
   SheetDescription,
@@ -67,6 +74,10 @@ const isMaxModel = (model: SelectedModel): boolean => model === "hackerai-max";
 const canUnlockMaxWithExtraUsage = (subscription: SubscriptionTier): boolean =>
   subscription !== "free" && subscription !== "ultra";
 
+const canChoosePersonalMaxAccessPath = (
+  subscription: SubscriptionTier,
+): boolean => subscription === "pro" || subscription === "pro-plus";
+
 const isModelLockedForSubscription = (
   subscription: SubscriptionTier,
   model: SelectedModel,
@@ -88,10 +99,30 @@ const getLockedModelCta = (
 const getLockedModelAnnouncement = (
   model: SelectedModel,
   subscription: SubscriptionTier,
-): string =>
-  `${getLockedModelCta(model, subscription)}${
+): string => {
+  if (isMaxModel(model) && canChoosePersonalMaxAccessPath(subscription)) {
+    return "Use Extra Usage or upgrade to Ultra for Max mode";
+  }
+
+  return `${getLockedModelCta(model, subscription)}${
     isMaxModel(model) ? " for Max mode" : " to unlock"
   }`;
+};
+
+const openMaxUltraUpgrade = ({
+  mobile,
+  subscription,
+}: {
+  mobile: boolean;
+  subscription: SubscriptionTier;
+}) => {
+  redirectToPricing({
+    surface: mobile ? "model_selector_mobile" : "model_selector",
+    source: "max_model_gate",
+    from_tier: subscription,
+    cta_text: "Upgrade to Ultra",
+  });
+};
 
 const handleLockedModelCta = ({
   mobile,
@@ -374,30 +405,68 @@ const ModelOptionList = ({
                 Powered by {option.poweredBy}
               </p>
             )}
-            <p className="text-xs text-muted-foreground leading-relaxed pt-1">
-              <a
-                href={
-                  isMaxModel(option.id) &&
-                  canUnlockMaxWithExtraUsage(subscription)
-                    ? "#extra-usage"
-                    : "#pricing"
-                }
-                onClick={(event) => {
-                  event.preventDefault();
-                  onClose();
-                  handleLockedModelCta({
-                    mobile,
-                    option,
-                    subscription,
-                  });
-                }}
-                className="text-foreground underline underline-offset-2 hover:text-foreground/80"
-                tabIndex={0}
-              >
-                {getLockedModelCta(option.id, subscription)}
-              </a>
-              {isMaxModel(option.id) ? " for Max mode." : " to unlock."}
-            </p>
+            {isMaxModel(option.id) &&
+            canChoosePersonalMaxAccessPath(subscription) ? (
+              <>
+                <p className="text-xs text-muted-foreground leading-relaxed pt-1">
+                  Set up Extra Usage to use Max on your current plan, or upgrade
+                  to Ultra to have Max included.
+                </p>
+                <div className="flex gap-2 pt-1">
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="h-8 flex-1 px-2 text-xs"
+                    onClick={() => {
+                      onClose();
+                      openSettingsDialog("Extra Usage");
+                    }}
+                  >
+                    Use Extra Usage
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="h-8 flex-1 px-2 text-xs"
+                    onClick={() => {
+                      onClose();
+                      openMaxUltraUpgrade({
+                        mobile,
+                        subscription,
+                      });
+                    }}
+                  >
+                    Upgrade to Ultra
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <p className="text-xs text-muted-foreground leading-relaxed pt-1">
+                <a
+                  href={
+                    isMaxModel(option.id) &&
+                    canUnlockMaxWithExtraUsage(subscription)
+                      ? "#extra-usage"
+                      : "#pricing"
+                  }
+                  onClick={(event) => {
+                    event.preventDefault();
+                    onClose();
+                    handleLockedModelCta({
+                      mobile,
+                      option,
+                      subscription,
+                    });
+                  }}
+                  className="text-foreground underline underline-offset-2 hover:text-foreground/80"
+                  tabIndex={0}
+                >
+                  {getLockedModelCta(option.id, subscription)}
+                </a>
+                {isMaxModel(option.id) ? " for Max mode." : " to unlock."}
+              </p>
+            )}
           </TooltipContent>
         </Tooltip>
       );
@@ -409,6 +478,7 @@ const ModelOptionList = ({
 
 export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
+  const [maxAccessDialogOpen, setMaxAccessDialogOpen] = useState(false);
   const { subscription } = useGlobalState();
   const isMobile = Boolean(useIsMobile());
 
@@ -474,6 +544,15 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
       )
     ) {
       setOpen(false);
+      if (
+        isMobile &&
+        isMaxModel(option.id) &&
+        canChoosePersonalMaxAccessPath(subscription)
+      ) {
+        setMaxAccessDialogOpen(true);
+        return;
+      }
+
       handleLockedModelCta({
         mobile: isMobile,
         option,
@@ -529,6 +608,45 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
             />
           </SheetContent>
         </Sheet>
+        <Dialog
+          open={maxAccessDialogOpen}
+          onOpenChange={setMaxAccessDialogOpen}
+        >
+          <DialogContent className="w-[calc(100%-2rem)] max-w-sm rounded-2xl p-5">
+            <DialogHeader>
+              <DialogTitle>Unlock HackerAI Max</DialogTitle>
+              <DialogDescription className="leading-relaxed">
+                Set up Extra Usage to use Max on your current plan, or upgrade
+                to Ultra to have Max included. Your included credits are used
+                first; Extra Usage covers any overflow.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex flex-col gap-2 pt-2">
+              <Button
+                type="button"
+                onClick={() => {
+                  setMaxAccessDialogOpen(false);
+                  openSettingsDialog("Extra Usage");
+                }}
+              >
+                Use Extra Usage
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setMaxAccessDialogOpen(false);
+                  openMaxUltraUpgrade({
+                    mobile: true,
+                    subscription,
+                  });
+                }}
+              >
+                Upgrade to Ultra
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
       </>
     );
   }

--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import {
   Popover,
+  PopoverAnchor,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
@@ -33,7 +34,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
-import { useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import {
@@ -189,6 +190,8 @@ const ModelOptionButton = ({
   isPending,
   subscription,
   onSelect,
+  actionPanelId,
+  actionPanelOpen,
   mobile = false,
 }: {
   option: ModelOption;
@@ -197,6 +200,8 @@ const ModelOptionButton = ({
   isPending: boolean;
   subscription: SubscriptionTier;
   onSelect: (option: ModelOption) => void;
+  actionPanelId?: string;
+  actionPanelOpen?: boolean;
   mobile?: boolean;
 }) => {
   const button = (
@@ -206,6 +211,9 @@ const ModelOptionButton = ({
       disabled={isPending}
       aria-busy={isPending || undefined}
       aria-pressed={isSelected}
+      aria-haspopup={actionPanelId ? "dialog" : undefined}
+      aria-expanded={actionPanelId ? actionPanelOpen : undefined}
+      aria-controls={actionPanelId}
       aria-label={
         isPending
           ? `${option.label}. Checking Extra Usage for Max mode.`
@@ -276,6 +284,120 @@ const ModelOptionButton = ({
         )}
       </TooltipContent>
     </Tooltip>
+  );
+};
+
+const LockedMaxAccessPopover = ({
+  option,
+  isSelected,
+  subscription,
+  onSelect,
+  onClose,
+}: {
+  option: ModelOption;
+  isSelected: boolean;
+  subscription: SubscriptionTier;
+  onSelect: (option: ModelOption) => void;
+  onClose: () => void;
+}) => {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearScheduledClose = () => {
+    if (closeTimerRef.current !== null) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  };
+
+  const showPanel = () => {
+    clearScheduledClose();
+    setOpen(true);
+  };
+
+  const schedulePanelClose = () => {
+    clearScheduledClose();
+    closeTimerRef.current = setTimeout(() => setOpen(false), 150);
+  };
+
+  useEffect(() => clearScheduledClose, []);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div
+          onMouseEnter={showPanel}
+          onMouseLeave={schedulePanelClose}
+          onFocusCapture={showPanel}
+        >
+          <ModelOptionButton
+            option={option}
+            isSelected={isSelected}
+            isLocked
+            isPending={false}
+            subscription={subscription}
+            onSelect={onSelect}
+            actionPanelId={panelId}
+            actionPanelOpen={open}
+          />
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        id={panelId}
+        side="right"
+        sideOffset={12}
+        align="start"
+        aria-label="HackerAI Max access options"
+        className="w-[240px] rounded-xl px-4 py-3 space-y-1.5"
+        onMouseEnter={showPanel}
+        onMouseLeave={schedulePanelClose}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <p className="text-sm font-semibold text-foreground leading-snug">
+          {option.description || option.label}
+        </p>
+        {option.poweredBy && (
+          <p className="text-xs text-muted-foreground">
+            Powered by {option.poweredBy}
+          </p>
+        )}
+        <p className="text-xs text-muted-foreground leading-relaxed pt-1">
+          Set up Extra Usage to use Max on your current plan, or upgrade to
+          Ultra to have Max included.
+        </p>
+        <div className="flex gap-2 pt-1">
+          <Button
+            type="button"
+            size="sm"
+            className="h-8 flex-1 px-2 text-xs"
+            onClick={() => {
+              setOpen(false);
+              onClose();
+              openSettingsDialog("Extra Usage");
+            }}
+          >
+            Use Extra Usage
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-8 flex-1 px-2 text-xs"
+            onClick={() => {
+              setOpen(false);
+              onClose();
+              openMaxUltraUpgrade({
+                mobile: false,
+                subscription,
+              });
+            }}
+          >
+            Upgrade to Ultra
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 };
 
@@ -370,6 +492,22 @@ const ModelOptionList = ({
         );
       }
 
+      if (
+        isMaxModel(option.id) &&
+        canChoosePersonalMaxAccessPath(subscription)
+      ) {
+        return (
+          <LockedMaxAccessPopover
+            key={option.id}
+            option={option}
+            isSelected={isSelected}
+            subscription={subscription}
+            onSelect={onSelect}
+            onClose={onClose}
+          />
+        );
+      }
+
       return (
         <Tooltip key={option.id}>
           <TooltipTrigger asChild>
@@ -405,68 +543,30 @@ const ModelOptionList = ({
                 Powered by {option.poweredBy}
               </p>
             )}
-            {isMaxModel(option.id) &&
-            canChoosePersonalMaxAccessPath(subscription) ? (
-              <>
-                <p className="text-xs text-muted-foreground leading-relaxed pt-1">
-                  Set up Extra Usage to use Max on your current plan, or upgrade
-                  to Ultra to have Max included.
-                </p>
-                <div className="flex gap-2 pt-1">
-                  <Button
-                    type="button"
-                    size="sm"
-                    className="h-8 flex-1 px-2 text-xs"
-                    onClick={() => {
-                      onClose();
-                      openSettingsDialog("Extra Usage");
-                    }}
-                  >
-                    Use Extra Usage
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    className="h-8 flex-1 px-2 text-xs"
-                    onClick={() => {
-                      onClose();
-                      openMaxUltraUpgrade({
-                        mobile,
-                        subscription,
-                      });
-                    }}
-                  >
-                    Upgrade to Ultra
-                  </Button>
-                </div>
-              </>
-            ) : (
-              <p className="text-xs text-muted-foreground leading-relaxed pt-1">
-                <a
-                  href={
-                    isMaxModel(option.id) &&
-                    canUnlockMaxWithExtraUsage(subscription)
-                      ? "#extra-usage"
-                      : "#pricing"
-                  }
-                  onClick={(event) => {
-                    event.preventDefault();
-                    onClose();
-                    handleLockedModelCta({
-                      mobile,
-                      option,
-                      subscription,
-                    });
-                  }}
-                  className="text-foreground underline underline-offset-2 hover:text-foreground/80"
-                  tabIndex={0}
-                >
-                  {getLockedModelCta(option.id, subscription)}
-                </a>
-                {isMaxModel(option.id) ? " for Max mode." : " to unlock."}
-              </p>
-            )}
+            <p className="text-xs text-muted-foreground leading-relaxed pt-1">
+              <a
+                href={
+                  isMaxModel(option.id) &&
+                  canUnlockMaxWithExtraUsage(subscription)
+                    ? "#extra-usage"
+                    : "#pricing"
+                }
+                onClick={(event) => {
+                  event.preventDefault();
+                  onClose();
+                  handleLockedModelCta({
+                    mobile,
+                    option,
+                    subscription,
+                  });
+                }}
+                className="text-foreground underline underline-offset-2 hover:text-foreground/80"
+                tabIndex={0}
+              >
+                {getLockedModelCta(option.id, subscription)}
+              </a>
+              {isMaxModel(option.id) ? " for Max mode." : " to unlock."}
+            </p>
           </TooltipContent>
         </Tooltip>
       );

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -185,7 +185,7 @@ describe("ModelSelector", () => {
     expect(mockRedirectToPricing).not.toHaveBeenCalled();
   });
 
-  it("offers Extra Usage or Ultra from the locked Max hover tooltip", async () => {
+  it("offers Extra Usage or Ultra from the locked Max hover panel", async () => {
     mockMaxEntitlement = {
       extraUsageAvailable: false,
       reason: "disabled",
@@ -206,6 +206,9 @@ describe("ModelSelector", () => {
     expect(
       screen.getByRole("button", { name: "Use Extra Usage" }),
     ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /HackerAI Max/i }),
+    ).toHaveAttribute("aria-haspopup", "dialog");
 
     await user.click(screen.getByRole("button", { name: "Upgrade to Ultra" }));
 

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -161,7 +161,7 @@ describe("ModelSelector", () => {
     expect(onChange).toHaveBeenCalledWith("hackerai-pro");
   });
 
-  it("locks HackerAI Max on Pro Plus and opens Extra Usage settings", () => {
+  it("reveals Max access choices when a Pro Plus user clicks the locked row", () => {
     mockMaxEntitlement = {
       extraUsageAvailable: false,
       reason: "disabled",
@@ -181,11 +181,22 @@ describe("ModelSelector", () => {
     fireEvent.click(maxButton);
 
     expect(onChange).not.toHaveBeenCalled();
-    expect(mockOpenSettingsDialog).toHaveBeenCalledWith("Extra Usage");
+    expect(
+      screen.getByRole("group", {
+        name: "Choose how to access HackerAI Max",
+      }),
+    ).toBeVisible();
+    expect(screen.getByText("Keep your current plan")).toBeVisible();
+    expect(screen.getByText("Max included with your plan")).toBeVisible();
+    expect(mockOpenSettingsDialog).not.toHaveBeenCalled();
     expect(mockRedirectToPricing).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Use Extra Usage/i }));
+
+    expect(mockOpenSettingsDialog).toHaveBeenCalledWith("Extra Usage");
   });
 
-  it("offers Extra Usage or Ultra from the locked Max hover panel", async () => {
+  it("offers compact Extra Usage and Ultra actions inside the model menu", async () => {
     mockMaxEntitlement = {
       extraUsageAvailable: false,
       reason: "disabled",
@@ -199,18 +210,15 @@ describe("ModelSelector", () => {
     await user.hover(screen.getByRole("button", { name: /HackerAI Max/i }));
 
     expect(
-      await screen.findByText(
-        "Set up Extra Usage to use Max on your current plan, or upgrade to Ultra to have Max included.",
-      ),
-    ).toBeVisible();
-    expect(
-      screen.getByRole("button", { name: "Use Extra Usage" }),
+      await screen.findByRole("group", {
+        name: "Choose how to access HackerAI Max",
+      }),
     ).toBeVisible();
     expect(
       screen.getByRole("button", { name: /HackerAI Max/i }),
-    ).toHaveAttribute("aria-haspopup", "dialog");
+    ).toHaveAttribute("aria-expanded", "true");
 
-    await user.click(screen.getByRole("button", { name: "Upgrade to Ultra" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Upgrade to Ultra/i }));
 
     expect(mockRedirectToPricing).toHaveBeenCalledWith({
       surface: "model_selector",
@@ -239,7 +247,7 @@ describe("ModelSelector", () => {
       screen.getByRole("dialog", { name: "Unlock HackerAI Max" }),
     ).toBeVisible();
     expect(
-      screen.getByText(/Your included credits are used first/i),
+      screen.getByText(/Extra Usage after your included credits/i),
     ).toBeVisible();
     expect(onChange).not.toHaveBeenCalled();
     expect(mockOpenSettingsDialog).not.toHaveBeenCalled();

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -6,6 +6,7 @@ import type { SubscriptionTier } from "@/types/chat";
 
 let mockSubscription: SubscriptionTier;
 let mockMaxEntitlement: unknown;
+let mockIsMobile: boolean;
 const mockUseQuery = jest.fn((_query: unknown, args: unknown) =>
   args === "skip" ? undefined : mockMaxEntitlement,
 );
@@ -36,7 +37,7 @@ jest.mock("@/app/contexts/GlobalState", () => ({
 }));
 
 jest.mock("@/hooks/use-mobile", () => ({
-  useIsMobile: () => false,
+  useIsMobile: () => mockIsMobile,
 }));
 
 jest.mock("@/app/hooks/usePricingDialog", () => ({
@@ -59,6 +60,7 @@ describe("ModelSelector", () => {
   beforeEach(() => {
     mockSubscription = "pro-plus";
     mockMaxEntitlement = undefined;
+    mockIsMobile = false;
     mockUseQuery.mockClear();
     mockRedirectToPricing.mockClear();
     mockOpenSettingsDialog.mockClear();
@@ -173,7 +175,7 @@ describe("ModelSelector", () => {
     const maxButton = screen.getByRole("button", { name: /HackerAI Max/i });
 
     expect(maxButton).toHaveAccessibleName(
-      "HackerAI Max. Set up Extra Usage for Max mode.",
+      "HackerAI Max. Use Extra Usage or upgrade to Ultra for Max mode.",
     );
 
     fireEvent.click(maxButton);
@@ -181,6 +183,92 @@ describe("ModelSelector", () => {
     expect(onChange).not.toHaveBeenCalled();
     expect(mockOpenSettingsDialog).toHaveBeenCalledWith("Extra Usage");
     expect(mockRedirectToPricing).not.toHaveBeenCalled();
+  });
+
+  it("offers Extra Usage or Ultra from the locked Max hover tooltip", async () => {
+    mockMaxEntitlement = {
+      extraUsageAvailable: false,
+      reason: "disabled",
+      hasBalance: false,
+      autoReloadEnabled: false,
+    };
+    const user = userEvent.setup();
+    render(<ModelSelector value="auto" onChange={jest.fn()} mode="agent" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
+    await user.hover(screen.getByRole("button", { name: /HackerAI Max/i }));
+
+    expect(
+      await screen.findByText(
+        "Set up Extra Usage to use Max on your current plan, or upgrade to Ultra to have Max included.",
+      ),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Use Extra Usage" }),
+    ).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Upgrade to Ultra" }));
+
+    expect(mockRedirectToPricing).toHaveBeenCalledWith({
+      surface: "model_selector",
+      source: "max_model_gate",
+      from_tier: "pro-plus",
+      cta_text: "Upgrade to Ultra",
+    });
+    expect(mockOpenSettingsDialog).not.toHaveBeenCalled();
+  });
+
+  it("shows both Max access choices after a locked mobile selection", () => {
+    mockIsMobile = true;
+    mockMaxEntitlement = {
+      extraUsageAvailable: false,
+      reason: "disabled",
+      hasBalance: false,
+      autoReloadEnabled: false,
+    };
+    const onChange = jest.fn();
+    render(<ModelSelector value="auto" onChange={onChange} mode="agent" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /HackerAI Max/i }));
+
+    expect(
+      screen.getByRole("dialog", { name: "Unlock HackerAI Max" }),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/Your included credits are used first/i),
+    ).toBeVisible();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(mockOpenSettingsDialog).not.toHaveBeenCalled();
+    expect(mockRedirectToPricing).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Use Extra Usage" }));
+
+    expect(mockOpenSettingsDialog).toHaveBeenCalledWith("Extra Usage");
+    expect(mockRedirectToPricing).not.toHaveBeenCalled();
+  });
+
+  it("can upgrade to Ultra from the locked Max mobile dialog", () => {
+    mockIsMobile = true;
+    mockMaxEntitlement = {
+      extraUsageAvailable: false,
+      reason: "empty",
+      hasBalance: false,
+      autoReloadEnabled: false,
+    };
+    render(<ModelSelector value="auto" onChange={jest.fn()} mode="agent" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /HackerAI Max/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade to Ultra" }));
+
+    expect(mockRedirectToPricing).toHaveBeenCalledWith({
+      surface: "model_selector_mobile",
+      source: "max_model_gate",
+      from_tier: "pro-plus",
+      cta_text: "Upgrade to Ultra",
+    });
+    expect(mockOpenSettingsDialog).not.toHaveBeenCalled();
   });
 
   it("shows a checking state while lazy Max entitlement is loading", () => {

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -186,8 +186,8 @@ describe("ModelSelector", () => {
         name: "Choose how to access HackerAI Max",
       }),
     ).toBeVisible();
-    expect(screen.getByText("Keep your current plan")).toBeVisible();
-    expect(screen.getByText("Max included with your plan")).toBeVisible();
+    expect(screen.getByText("Pay for Max as you use it")).toBeVisible();
+    expect(screen.getByText("Max included")).toBeVisible();
     expect(mockOpenSettingsDialog).not.toHaveBeenCalled();
     expect(mockRedirectToPricing).not.toHaveBeenCalled();
 
@@ -246,9 +246,7 @@ describe("ModelSelector", () => {
     expect(
       screen.getByRole("dialog", { name: "Unlock HackerAI Max" }),
     ).toBeVisible();
-    expect(
-      screen.getByText(/Extra Usage after your included credits/i),
-    ).toBeVisible();
+    expect(screen.getByText(/Max is paid through Extra Usage/i)).toBeVisible();
     expect(onChange).not.toHaveBeenCalled();
     expect(mockOpenSettingsDialog).not.toHaveBeenCalled();
     expect(mockRedirectToPricing).not.toHaveBeenCalled();

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -29,6 +29,7 @@ import {
   isLimitRescueRequest,
   normalizeMaxModelForSubscription,
   normalizeSelectedModelOverrideForSubscription,
+  withExtraUsageBillingForModel,
 } from "@/types";
 import { getBaseTodosForRequest } from "@/lib/utils/todo-utils";
 import {
@@ -350,17 +351,22 @@ export const createChatHandler = () => {
         { isTemporary: temporary, regenerate },
       );
 
-      const extraUsageConfig = await buildExtraUsageConfig({
+      const baseExtraUsageConfig = await buildExtraUsageConfig({
         userId,
         subscription,
         userCustomization,
         organizationId,
       });
-      const extraUsageAvailable = canUseExtraUsage(extraUsageConfig);
+      const extraUsageAvailable = canUseExtraUsage(baseExtraUsageConfig);
       selectedModelOverride =
         normalizeMaxModelForSubscription(selectedModelOverride, subscription, {
           extraUsageAvailable,
         }) ?? undefined;
+      const extraUsageConfig = withExtraUsageBillingForModel(
+        baseExtraUsageConfig,
+        selectedModelOverride,
+        subscription,
+      );
 
       if (!temporary) {
         await handleInitialChatAndUserMessage({

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -466,6 +466,37 @@ describe("token-bucket async functions", () => {
       expect(result.extraUsagePointsDeducted).toBeGreaterThan(0);
     });
 
+    it("charges the full request to extra usage without consuming included credits", async () => {
+      const { checkTokenBucketLimit } = getIsolatedModule();
+
+      mockLimitFn.mockResolvedValue({
+        success: true,
+        remaining: 10000,
+        reset: Date.now() + 3600000,
+        limit: 250000,
+      });
+
+      const result = await checkTokenBucketLimit("user-123", "pro", 1000, {
+        enabled: true,
+        hasBalance: true,
+        autoReloadEnabled: false,
+        chargeAllUsage: true,
+      });
+
+      expect(mockDeductFromBalance).toHaveBeenCalledWith(
+        "user-123",
+        expect.any(Number),
+      );
+      expect(result.pointsDeducted).toBe(0);
+      expect(result.extraUsagePointsDeducted).toBeGreaterThan(0);
+      expect(result.remaining).toBe(10000);
+      expect(mockLimitFn).toHaveBeenCalledTimes(1);
+      expect(mockLimitFn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ rate: 0 }),
+      );
+    });
+
     it("should return monthly nested field matching top-level fields", async () => {
       const { checkTokenBucketLimit } = getIsolatedModule();
 
@@ -1407,6 +1438,45 @@ describe("token-bucket async functions", () => {
   });
 
   describe("deductUsage - split deduction (peek-then-deduct)", () => {
+    it("keeps final reconciliation entirely on extra usage when required", async () => {
+      const { deductUsage } = getIsolatedModule();
+
+      const result = await deductUsage(
+        "user-123",
+        "pro",
+        1000,
+        5000,
+        1000,
+        {
+          enabled: true,
+          hasBalance: true,
+          autoReloadEnabled: false,
+          chargeAllUsage: true,
+        },
+        0.005,
+        undefined,
+        0,
+        undefined,
+        {
+          pointsDeducted: 0,
+          extraUsagePointsDeducted: 7,
+        },
+      );
+
+      expect(mockLimitFn).not.toHaveBeenCalled();
+      expect(mockDeductFromBalance).toHaveBeenCalledWith(
+        "user-123",
+        63,
+        undefined,
+      );
+      expect(result).toEqual({
+        includedPointsDeducted: 0,
+        extraUsagePointsDeducted: 70,
+        uncoveredPoints: 0,
+        usageDeductionFailed: false,
+      });
+    });
+
     it("should deduct overflow from extra usage when bucket has insufficient balance", async () => {
       const { deductUsage } = getIsolatedModule();
 
@@ -1719,6 +1789,30 @@ describe("token-bucket async functions", () => {
       expect(result).toEqual({
         includedPointsDeducted: 10,
         extraUsagePointsDeducted: 33,
+        uncoveredPoints: 0,
+        usageDeductionFailed: false,
+      });
+    });
+
+    it("charges a full mid-run delta to extra usage when required", async () => {
+      const { deductUsageDelta } = getIsolatedModule();
+
+      const result = await deductUsageDelta("user-123", "pro", 43, {
+        enabled: true,
+        hasBalance: true,
+        autoReloadEnabled: false,
+        chargeAllUsage: true,
+      });
+
+      expect(mockLimitFn).not.toHaveBeenCalled();
+      expect(mockDeductFromBalance).toHaveBeenCalledWith(
+        "user-123",
+        43,
+        undefined,
+      );
+      expect(result).toEqual({
+        includedPointsDeducted: 0,
+        extraUsagePointsDeducted: 43,
         uncoveredPoints: 0,
         usageDeductionFailed: false,
       });

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -210,8 +210,12 @@ const deductAdditionalUsagePoints = async ({
     };
   };
 
-  const peekResult = await monthly.limiter.limit(monthly.key, { rate: 0 });
-  const available = Math.max(0, peekResult.remaining);
+  const available = extraUsageConfig?.chargeAllUsage
+    ? 0
+    : Math.max(
+        0,
+        (await monthly.limiter.limit(monthly.key, { rate: 0 })).remaining,
+      );
   const fromBucket = Math.min(normalizedAdditionalCost, available);
   let includedDeducted = 0;
 
@@ -781,8 +785,11 @@ export const checkTokenBucketLimit = async (
       };
     }
 
-    // Step 2: Check if we have enough capacity, or if we need extra usage
-    const shortfall = Math.max(0, estimatedCost - monthlyCheck.remaining);
+    // Step 2: Check if we have enough capacity, or if we need extra usage.
+    // Models excluded from the plan allowance charge the full request to Extra Usage.
+    const shortfall = extraUsageConfig?.chargeAllUsage
+      ? estimatedCost
+      : Math.max(0, estimatedCost - monthlyCheck.remaining);
 
     // If we're over limit, try extra usage (prepaid balance)
     if (shortfall > 0) {
@@ -801,9 +808,12 @@ export const checkTokenBucketLimit = async (
           // Extra usage covered the shortfall. Deduct only what subscription contributed.
           const bucketDeduct = estimatedCost - shortfall;
 
-          const monthlyResult = await monthly.limiter.limit(monthly.key, {
-            rate: bucketDeduct,
-          });
+          const monthlyResult =
+            bucketDeduct > 0
+              ? await monthly.limiter.limit(monthly.key, {
+                  rate: bucketDeduct,
+                })
+              : monthlyCheck;
 
           if (!monthlyResult.success) {
             try {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -162,6 +162,7 @@ import {
   getAgentApprovalTargetPrefixForSandbox,
   normalizeMaxModelForSubscription,
   serializeSandboxScopedAgentApprovalTargetPrefix,
+  withExtraUsageBillingForModel,
 } from "@/types";
 import {
   createAgentStream,
@@ -1789,17 +1790,22 @@ export const agentLongTask = task({
             sandboxPreference,
           });
       const truncatedMessages = fetched.truncatedMessages;
-      const extraUsageConfig = await buildExtraUsageConfig({
+      const baseExtraUsageConfig = await buildExtraUsageConfig({
         userId,
         subscription,
         userCustomization,
         organizationId,
       });
-      const extraUsageAvailable = canUseExtraUsage(extraUsageConfig);
+      const extraUsageAvailable = canUseExtraUsage(baseExtraUsageConfig);
       selectedModelOverride =
         normalizeMaxModelForSubscription(selectedModelOverride, subscription, {
           extraUsageAvailable,
         }) ?? undefined;
+      const extraUsageConfig = withExtraUsageBillingForModel(
+        baseExtraUsageConfig,
+        selectedModelOverride,
+        subscription,
+      );
 
       const baseTodos: Todo[] = getBaseTodosForRequest(
         (chat?.todos as unknown as Todo[]) || [],
@@ -2149,12 +2155,18 @@ export const agentLongTask = task({
                   "The selected model is no longer authorized.",
                 );
               }
+              const currentModelExtraUsageConfig =
+                withExtraUsageBillingForModel(
+                  currentExtraUsageConfig,
+                  currentlyAllowedModel,
+                  authorization.subscription,
+                );
 
               await checkRateLimitCapacity(
                 userId,
                 mode,
                 authorization.subscription,
-                currentExtraUsageConfig,
+                currentModelExtraUsageConfig,
                 selectedModel,
                 authorization.organizationId,
                 freeQuotaSubject,

--- a/types/__tests__/chat.test.ts
+++ b/types/__tests__/chat.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeMaxModelForSubscription,
   normalizeSelectedModelForSubscription,
   normalizeSelectedModelOverrideForSubscription,
+  withExtraUsageBillingForModel,
 } from "../chat";
 
 describe("normalizeSelectedModelForSubscription", () => {
@@ -112,5 +113,34 @@ describe("Max model entitlement helpers", () => {
         },
       }),
     ).toBe("hackerai-pro");
+  });
+
+  it("bills Max entirely through Extra Usage outside Ultra", () => {
+    const extraUsageConfig = {
+      enabled: true,
+      hasBalance: true,
+      autoReloadEnabled: false,
+    };
+
+    expect(
+      withExtraUsageBillingForModel(
+        extraUsageConfig,
+        "hackerai-max",
+        "pro-plus",
+      ),
+    ).toEqual({
+      ...extraUsageConfig,
+      chargeAllUsage: true,
+    });
+    expect(
+      withExtraUsageBillingForModel(extraUsageConfig, "hackerai-max", "ultra"),
+    ).toBe(extraUsageConfig);
+    expect(
+      withExtraUsageBillingForModel(
+        extraUsageConfig,
+        "hackerai-pro",
+        "pro-plus",
+      ),
+    ).toBe(extraUsageConfig);
   });
 });

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -180,6 +180,25 @@ export function canUseMaxModel(
   );
 }
 
+export function withExtraUsageBillingForModel(
+  extraUsageConfig: ExtraUsageConfig | undefined,
+  model: SelectedModel | null | undefined,
+  subscription: SubscriptionTier,
+): ExtraUsageConfig | undefined {
+  if (
+    !extraUsageConfig ||
+    model !== "hackerai-max" ||
+    subscription === "ultra"
+  ) {
+    return extraUsageConfig;
+  }
+
+  return {
+    ...extraUsageConfig,
+    chargeAllUsage: true,
+  };
+}
+
 export const normalizeMaxModelForSubscription = (
   model: SelectedModel | null | undefined,
   subscription: SubscriptionTier,
@@ -479,6 +498,8 @@ export interface ExtraUsageConfig {
   monthlyRemainingDollars?: number;
   /** Whether auto-reload is enabled (can use extra usage even with $0 balance) */
   autoReloadEnabled?: boolean;
+  /** Bypass included plan credits and bill the full request as Extra Usage */
+  chargeAllUsage?: boolean;
 }
 
 export interface QueuedMessage {


### PR DESCRIPTION
## Summary
- explain in the locked Max model tooltip that Pro and Pro+ can use Extra Usage or upgrade to Ultra
- show the same two choices in a mobile-friendly dialog
- preserve the existing Team Extra Usage flow and Ultra access behavior
- add focused coverage for desktop, mobile, Team, and accessible-state behavior

## Why
Pro and Pro+ users could reasonably mistake higher included usage for Max being included. This makes the entitlement boundary and both available paths explicit at the point of selection.

## Validation
- `pnpm typecheck`
- `pnpm test` — 299 suites, 2,967 tests passed
- targeted ESLint and Prettier checks
- `git diff --check`
- authenticated visual QA on desktop and at 390×844 mobile
- verified **Use Extra Usage** opens Settings → Extra Usage
- verified **Upgrade to Ultra** opens the pricing dialog
- verified no browser errors or stuck overlays

## Manual verification
1. As a Pro or Pro+ user on desktop, open the model selector and hover the locked Max option. Confirm the tooltip explains both choices and both buttons work.
2. At mobile width, tap the locked Max option. Confirm the dialog appears and each button opens the correct destination.
3. As a Team user, confirm the existing Extra Usage-only behavior remains unchanged.
4. As an Ultra user, confirm Max remains directly selectable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an eligibility-gated mobile “Unlock HackerAI Max” dialog for Pro/Pro Plus when selecting HackerAI Max.
  * Updated locked Max UX to offer two explicit actions: **“Use Extra Usage”** or **“Upgrade to Ultra”**, including improved desktop inline access choices.
* **Bug Fixes**
  * Fixed locked Max flows to prevent unintended model selection and ensure the correct settings/upgrade dialogs appear.
  * Improved extra-usage billing behavior so full requests are correctly charged to Extra Usage when applicable, avoiding incorrect included-credit handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->