### PR TITLE
Fix cache-aware hybrid agent usage settlement

### DIFF
--- a/convex/__tests__/unitEconomicsReportingWindow.test.ts
+++ b/convex/__tests__/unitEconomicsReportingWindow.test.ts
@@ -42,7 +42,7 @@ type UsageLogRow = {
   extra_usage_points_deducted?: number;
   model_cost_dollars?: number;
   non_model_cost_dollars?: number;
-  cost_source?: "provider" | "token_estimate" | "raw_token_estimate";
+  cost_source?: "provider" | "hybrid" | "token_estimate" | "raw_token_estimate";
 };
 
 type RevenueRow = {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -721,6 +721,7 @@ export default defineSchema({
     cost_source: v.optional(
       v.union(
         v.literal("provider"),
+        v.literal("hybrid"),
         v.literal("token_estimate"),
         v.literal("raw_token_estimate"),
       ),

--- a/convex/usageLogs.ts
+++ b/convex/usageLogs.ts
@@ -74,6 +74,7 @@ export const logUsage = mutation({
     cost_source: v.optional(
       v.union(
         v.literal("provider"),
+        v.literal("hybrid"),
         v.literal("token_estimate"),
         v.literal("raw_token_estimate"),
       ),

--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -304,7 +304,7 @@ describe("UsageTracker", () => {
       expect(tracker.computeCostDollars("model-default")).toBeCloseTo(0.00036);
     });
 
-    it("should use token estimates when any model step lacks authoritative cost", () => {
+    it("should estimate only the model step lacking authoritative cost", () => {
       const firstStepCostIndex = tracker.accumulateStep({
         inputTokens: 500_000,
         outputTokens: 0,
@@ -318,7 +318,64 @@ describe("UsageTracker", () => {
 
       tracker.setAuthoritativeModelCostForStep(firstStepCostIndex, 0.00016);
 
-      expect(tracker.computeCostDollars("model-default")).toBe(0.5);
+      expect(tracker.computeCostDollars("model-default")).toBeCloseTo(0.25016);
+      expect(tracker.hasAnyAuthoritativeModelCost).toBe(true);
+      expect(tracker.hasAuthoritativeModelCost).toBe(false);
+    });
+
+    it("uses each step's served model and cache rates for hybrid cost", () => {
+      const firstStepCostIndex = tracker.accumulateStep(
+        {
+          inputTokens: 1_000_000,
+          outputTokens: 0,
+        },
+        "model-deepseek-v4-pro",
+      );
+      tracker.setAuthoritativeModelCostForStep(firstStepCostIndex, 0.1);
+      tracker.accumulateStep(
+        {
+          inputTokens: 1_000_000,
+          outputTokens: 100_000,
+          inputTokenDetails: { cacheReadTokens: 800_000 },
+        },
+        "model-grok-4.5",
+      );
+
+      // Known DeepSeek step: $0.10.
+      // Missing Grok step: 200k uncached input ($0.40),
+      // 800k cache reads ($0.40), and 100k output ($0.60).
+      expect(
+        tracker.computeCostDollars("agent-model", "model-grok-4.5"),
+      ).toBeCloseTo(1.5);
+
+      const usage = tracker.createUsageCostRecord({
+        selectedModel: "agent-model",
+        configuredModelId: "x-ai/grok-4.5",
+        accountingModel: "model-grok-4.5",
+        rateLimitInfo: {
+          remaining: 1000,
+          resetTime: new Date(),
+          limit: 250000,
+          pointsDeducted: 100,
+        },
+      });
+      expect(usage.costSource).toBe("hybrid");
+    });
+
+    it("applies DeepSeek cache-read pricing to raw step estimates", () => {
+      tracker.accumulateStep(
+        {
+          inputTokens: 1_000_000,
+          outputTokens: 100_000,
+          inputTokenDetails: { cacheReadTokens: 900_000 },
+        },
+        "model-deepseek-v4-pro",
+      );
+
+      // 100k uncached input + 900k cache reads + 100k output.
+      expect(
+        tracker.computeCostDollars("model-deepseek-v4-pro", "model-grok-4.5"),
+      ).toBeCloseTo(0.1337625);
     });
 
     it("should prefer authoritative metadata cost over raw provider cost while preserving non-model spend", () => {
@@ -573,8 +630,7 @@ describe("UsageTracker", () => {
           logUsageRecord: localMockLog,
         }));
         jest.doMock("@/lib/rate-limit", () => ({
-          calculateRawTokenCost: jest.fn(),
-          POINTS_PER_DOLLAR: 10_000,
+          calculateRawModelUsageCostDollars: jest.fn(),
         }));
         IsolatedTracker = require("../usage-tracker").UsageTracker;
       });
@@ -764,15 +820,19 @@ describe("UsageTracker", () => {
     });
 
     it("preserves summarization usage across fallback reset", () => {
-      tracker.inputTokens = 1_200;
-      tracker.summarizationInputTokens = 200;
-      tracker.outputTokens = 140;
-      tracker.summarizationOutputTokens = 40;
-      tracker.totalTokens = 1_340;
-      tracker.cacheReadTokens = 90;
-      tracker.summarizationCacheReadTokens = 20;
-      tracker.cacheWriteTokens = 50;
-      tracker.summarizationCacheWriteTokens = 10;
+      tracker.accumulateSummarization({
+        inputTokens: 200,
+        outputTokens: 40,
+        cacheReadTokens: 20,
+        cacheWriteTokens: 10,
+        model: "anthropic/claude-4.6-opus-20260205",
+      });
+      tracker.accumulateStep({
+        inputTokens: 1_000,
+        outputTokens: 100,
+        inputTokenDetails: { cacheReadTokens: 70, cacheWriteTokens: 40 },
+        raw: { cost: 0.25 },
+      });
 
       tracker.resetModelLeg();
 
@@ -782,6 +842,10 @@ describe("UsageTracker", () => {
       expect(tracker.cacheReadTokens).toBe(20);
       expect(tracker.cacheWriteTokens).toBe(10);
       expect(tracker.streamOutputTokens).toBe(0);
+      expect(tracker.providerCost).toBe(0);
+      expect(tracker.computeCostDollars("model-default")).toBeCloseTo(
+        0.0019225,
+      );
     });
 
     it("labels post-run overflow as mixed when final deduction uses extra usage", () => {

--- a/lib/api/__tests__/chat-stream-helpers-summarization.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-summarization.test.ts
@@ -8,18 +8,42 @@ jest.mock("@/lib/logger", () => ({
   logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
 }));
 
-const makeUsageTracker = () => ({
-  inputTokens: 0,
-  summarizationInputTokens: 0,
-  outputTokens: 0,
-  totalTokens: 0,
-  summarizationOutputTokens: 0,
-  cacheReadTokens: 0,
-  summarizationCacheReadTokens: 0,
-  cacheWriteTokens: 0,
-  summarizationCacheWriteTokens: 0,
-  providerCost: 0,
-});
+const makeUsageTracker = () => {
+  const tracker = {
+    inputTokens: 0,
+    summarizationInputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    summarizationOutputTokens: 0,
+    cacheReadTokens: 0,
+    summarizationCacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    summarizationCacheWriteTokens: 0,
+    providerCost: 0,
+  };
+  Object.defineProperty(tracker, "accumulateSummarization", {
+    enumerable: false,
+    value: (usage: {
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadTokens?: number;
+      cacheWriteTokens?: number;
+      cost?: number;
+    }) => {
+      tracker.inputTokens += usage.inputTokens;
+      tracker.summarizationInputTokens += usage.inputTokens;
+      tracker.outputTokens += usage.outputTokens;
+      tracker.summarizationOutputTokens += usage.outputTokens;
+      tracker.totalTokens += usage.inputTokens + usage.outputTokens;
+      tracker.cacheReadTokens += usage.cacheReadTokens ?? 0;
+      tracker.summarizationCacheReadTokens += usage.cacheReadTokens ?? 0;
+      tracker.cacheWriteTokens += usage.cacheWriteTokens ?? 0;
+      tracker.summarizationCacheWriteTokens += usage.cacheWriteTokens ?? 0;
+      tracker.providerCost += usage.cost ?? 0;
+    },
+  });
+  return tracker;
+};
 
 describe("SummarizationTracker", () => {
   it("tracks and bills every summarization round", () => {

--- a/lib/api/agent-stream-runner.ts
+++ b/lib/api/agent-stream-runner.ts
@@ -34,6 +34,7 @@ import {
   runSummarizationStep,
   getFallbackSlugs,
   isXaiSafetyError,
+  resolveServedModelForCostAccounting,
 } from "@/lib/api/chat-stream-helpers";
 import {
   elapsedTimeExceeds,
@@ -1227,8 +1228,17 @@ export async function createAgentStream(
       recordAgentStepCompletion(ctx.completionSignalTracker, content);
       let stepUsageCostIndex: number | undefined;
       if (usage) {
+        const stepAccountingModel = resolveServedModelForCostAccounting({
+          modelName,
+          responseModel: response?.modelId,
+          mode: ctx.mode,
+          options: {
+            hasMultimodalToolResults: streamHasImageViewResults,
+          },
+        });
         stepUsageCostIndex = ctx.usageTracker.accumulateStep(
           usage as Parameters<typeof ctx.usageTracker.accumulateStep>[0],
+          stepAccountingModel,
         );
         state.lastStepInputTokens = usage.inputTokens || 0;
         if (usage.inputTokens) {

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -944,13 +944,10 @@ export const createChatHandler = () => {
                 let usageCostRecord =
                   usageTracker.createUsageCostRecord(usageRecordArgs);
 
-                // Trust accumulated provider cost only when every model step has
-                // an authoritative cost. providerCost also includes tool/sandbox
-                // spend; if any model step is missing cost, keep token fallback
-                // for the model portion and add nonModelCost separately.
-                const providerCost = usageTracker.hasAuthoritativeModelCost
-                  ? usageTracker.providerCost
-                  : undefined;
+                // Use the same resolved provider/hybrid total that powers
+                // mid-run settlement. This preserves authoritative step costs
+                // and estimates only the individual steps missing provider cost.
+                const settledCostDollars = usageCostRecord.costDollars;
 
                 if (paidDailyFreeAllowanceReservation) {
                   const allowanceCostRecord =
@@ -1032,7 +1029,7 @@ export const createChatHandler = () => {
                     usageTracker.inputTokens,
                     usageTracker.outputTokens,
                     extraUsageConfig,
-                    providerCost,
+                    settledCostDollars,
                     selectedModel,
                     usageTracker.nonModelCost,
                     organizationId,

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -475,20 +475,7 @@ export class SummarizationTracker {
     usageTracker: UsageTracker,
   ): void {
     if (usage) {
-      usageTracker.inputTokens += usage.inputTokens;
-      usageTracker.summarizationInputTokens += usage.inputTokens;
-      usageTracker.outputTokens += usage.outputTokens;
-      usageTracker.summarizationOutputTokens += usage.outputTokens;
-      usageTracker.totalTokens += usage.inputTokens + usage.outputTokens;
-      const cacheReadTokens = usage.cacheReadTokens || 0;
-      const cacheWriteTokens = usage.cacheWriteTokens || 0;
-      usageTracker.cacheReadTokens += cacheReadTokens;
-      usageTracker.summarizationCacheReadTokens += cacheReadTokens;
-      usageTracker.cacheWriteTokens += cacheWriteTokens;
-      usageTracker.summarizationCacheWriteTokens += cacheWriteTokens;
-      if (usage.cost) {
-        usageTracker.providerCost += usage.cost;
-      }
+      usageTracker.accumulateSummarization(usage);
     }
   }
 

--- a/lib/chat/summarization/helpers.ts
+++ b/lib/chat/summarization/helpers.ts
@@ -43,6 +43,7 @@ export interface SummarizationUsage {
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
   cost?: number;
+  model?: string;
 }
 
 export interface SummaryPersistenceMetadata {
@@ -724,6 +725,8 @@ export const generateSummaryText = async (
         ? { cacheWriteTokens: details.cacheWriteTokens }
         : undefined),
       ...(providerCost ? { cost: providerCost } : undefined),
+      model:
+        result.response?.modelId ?? getLanguageModelIdentifier(languageModel),
     },
   };
 };

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -2131,7 +2131,7 @@ export async function logUsageRecord({
   costDollars: number;
   modelCostDollars?: number;
   nonModelCostDollars?: number;
-  costSource?: "provider" | "token_estimate" | "raw_token_estimate";
+  costSource?: "provider" | "hybrid" | "token_estimate" | "raw_token_estimate";
 }) {
   try {
     await getConvexClient().mutation(api.usageLogs.logUsage, {

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "@jest/globals";
 
 import {
   billableCostDollarsToPoints,
+  calculateRawModelUsageCostDollars,
   calculateTokenCost,
   calculateRawTokenCost,
   calculateTierChangeCredits,
@@ -89,6 +90,50 @@ describe("token-bucket", () => {
     it("should calculate raw output token cost without the 1.4x multiplier", () => {
       expect(calculateRawTokenCost(1_000_000, "output")).toBe(30000);
       expect(calculateRawTokenCost(1000, "output")).toBe(30);
+    });
+  });
+
+  describe("calculateRawModelUsageCostDollars", () => {
+    it("prices cached and uncached input at the served model's rates", () => {
+      expect(
+        calculateRawModelUsageCostDollars({
+          inputTokens: 1_000_000,
+          outputTokens: 100_000,
+          cacheReadTokens: 800_000,
+          modelName: "x-ai/grok-4.5",
+        }),
+      ).toBeCloseTo(1.4);
+    });
+
+    it("recognizes dated Anthropic response model IDs", () => {
+      expect(
+        calculateRawModelUsageCostDollars({
+          inputTokens: 200,
+          outputTokens: 40,
+          cacheReadTokens: 20,
+          cacheWriteTokens: 10,
+          modelName: "anthropic/claude-4.6-opus-20260205",
+        }),
+      ).toBeCloseTo(0.0019225);
+    });
+
+    it("clamps invalid and overlapping cache token counts", () => {
+      expect(
+        calculateRawModelUsageCostDollars({
+          inputTokens: 100,
+          outputTokens: Number.NaN,
+          cacheReadTokens: 80,
+          cacheWriteTokens: 80,
+          modelName: "model-deepseek-v4-pro",
+        }),
+      ).toBeCloseTo(0.00000899);
+      expect(
+        calculateRawModelUsageCostDollars({
+          inputTokens: Number.POSITIVE_INFINITY,
+          outputTokens: Number.NEGATIVE_INFINITY,
+          cacheReadTokens: Number.NaN,
+        }),
+      ).toBe(0);
     });
   });
 
@@ -413,12 +458,12 @@ describe("token-bucket", () => {
       ).toBe(12180);
     });
 
-    it("should use GLM 5.2 pricing ($0.9086/$2.856)", () => {
+    it("should use GLM 5.2 baseline pricing ($0.76/$2.42)", () => {
       expect(calculateTokenCost(1_000_000, "input", "model-glm-5.2")).toBe(
-        12721,
+        10640,
       );
       expect(calculateTokenCost(1_000_000, "output", "model-glm-5.2")).toBe(
-        39984,
+        33880,
       );
     });
 

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -45,6 +45,7 @@ export {
   clearOrgRemovedUsage,
   applyTeamSeatDebt,
   billableCostDollarsToPoints,
+  calculateRawModelUsageCostDollars,
   calculateTokenCost,
   calculateRawTokenCost,
   getBudgetLimits,

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -26,35 +26,120 @@ export { isUserRateLimitKey } from "./key-cleanup";
 // Configuration
 // =============================================================================
 
-/** Model pricing: $/1M tokens per model. */
-const MODEL_PRICING_MAP: Record<string, { input: number; output: number }> = {
-  default: { input: 0.5, output: 3.0 },
-  "model-sonnet-4.6": { input: 3.0, output: 15.0 },
-  // Grok 4.5 rates from OpenRouter: $2.00 in / $6.00 out per 1M tokens.
-  "model-grok-4.5": { input: 2.0, output: 6.0 },
-  "model-grok-4.5-pro": { input: 2.0, output: 6.0 },
-  "model-gemini-3-flash": { input: 2.0, output: 6.0 },
-  // Auto and compatibility aliases now resolve to Grok 4.5.
-  "ask-model": { input: 2.0, output: 6.0 },
-  "agent-model": { input: 2.0, output: 6.0 },
-  "model-minimax-m3": { input: 2.0, output: 6.0 },
-  "fallback-agent-model": { input: 2.0, output: 6.0 },
-  "fallback-ask-model": { input: 2.0, output: 6.0 },
-  // Rates from OpenRouter: $0.09 in / $0.18 out per 1M tokens.
-  "agent-model-free": { input: 0.09, output: 0.18 },
-  "model-deepseek-v4-pro": { input: 0.435, output: 0.87 },
-  "fallback-grok-4.5": { input: 2.0, output: 6.0 },
-  "model-opus-4.6": { input: 5.0, output: 25.0 },
-  // Rates from OpenRouter: $0.9086 in / $2.856 out per 1M tokens.
-  "model-glm-5.2": { input: 0.9086, output: 2.856 },
-  // Kimi keys are retained as compatibility aliases for stale persisted routes.
-  // Rates from OpenRouter: $0.95 in / $4.00 out per 1M tokens.
-  "model-kimi-k2.7-code": { input: 0.95, output: 4.0 },
-  "model-kimi-k2.6": { input: 0.95, output: 4.0 },
+type ModelPricing = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
 };
 
-const getModelPricing = (modelName?: string) =>
-  (modelName && MODEL_PRICING_MAP[modelName]) || MODEL_PRICING_MAP.default;
+const DEFAULT_PRICING: ModelPricing = {
+  input: 0.5,
+  output: 3.0,
+  cacheRead: 0.5,
+  cacheWrite: 0.5,
+};
+const SONNET_4_6_PRICING: ModelPricing = {
+  input: 3.0,
+  output: 15.0,
+  cacheRead: 0.3,
+  cacheWrite: 3.75,
+};
+const GROK_4_5_PRICING: ModelPricing = {
+  input: 2.0,
+  output: 6.0,
+  cacheRead: 0.5,
+  cacheWrite: 2.0,
+};
+const DEEPSEEK_V4_FLASH_PRICING: ModelPricing = {
+  input: 0.09,
+  output: 0.18,
+  cacheRead: 0.018,
+  cacheWrite: 0.09,
+};
+const DEEPSEEK_V4_PRO_PRICING: ModelPricing = {
+  input: 0.435,
+  output: 0.87,
+  cacheRead: 0.003625,
+  cacheWrite: 0.435,
+};
+const OPUS_4_6_PRICING: ModelPricing = {
+  input: 5.0,
+  output: 25.0,
+  cacheRead: 0.5,
+  cacheWrite: 6.25,
+};
+const GLM_5_2_PRICING: ModelPricing = {
+  input: 0.76,
+  output: 2.42,
+  cacheRead: 0.14,
+  cacheWrite: 0.76,
+};
+const KIMI_K2_7_CODE_PRICING: ModelPricing = {
+  input: 0.95,
+  output: 4.0,
+  cacheRead: 0.19,
+  cacheWrite: 0.95,
+};
+
+/** Model pricing: $/1M tokens per model, including provider cache rates. */
+const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
+  default: DEFAULT_PRICING,
+  "model-sonnet-4.6": SONNET_4_6_PRICING,
+  // Grok 4.5 rates from OpenRouter: $2.00 in / $6.00 out per 1M tokens.
+  "model-grok-4.5": GROK_4_5_PRICING,
+  "model-grok-4.5-pro": GROK_4_5_PRICING,
+  "model-gemini-3-flash": GROK_4_5_PRICING,
+  // Auto and compatibility aliases now resolve to Grok 4.5.
+  "ask-model": GROK_4_5_PRICING,
+  "agent-model": GROK_4_5_PRICING,
+  "model-minimax-m3": GROK_4_5_PRICING,
+  "fallback-agent-model": GROK_4_5_PRICING,
+  "fallback-ask-model": GROK_4_5_PRICING,
+  // Rates from OpenRouter: $0.09 in / $0.18 out per 1M tokens.
+  "ask-model-free": DEEPSEEK_V4_FLASH_PRICING,
+  "agent-model-free": DEEPSEEK_V4_FLASH_PRICING,
+  "model-deepseek-v4-flash": DEEPSEEK_V4_FLASH_PRICING,
+  "model-deepseek-v4-pro": DEEPSEEK_V4_PRO_PRICING,
+  "fallback-grok-4.5": GROK_4_5_PRICING,
+  "model-opus-4.6": OPUS_4_6_PRICING,
+  // Baseline OpenRouter rates: $0.76 in / $2.42 out per 1M tokens.
+  "model-glm-5.2": GLM_5_2_PRICING,
+  // Kimi keys are retained as compatibility aliases for stale persisted routes.
+  // Rates from OpenRouter: $0.95 in / $4.00 out per 1M tokens.
+  "model-kimi-k2.7-code": KIMI_K2_7_CODE_PRICING,
+  "model-kimi-k2.6": KIMI_K2_7_CODE_PRICING,
+  // Provider response ids can reach accounting before local-key normalization.
+  "x-ai/grok-4.5": GROK_4_5_PRICING,
+  "deepseek/deepseek-v4-flash": DEEPSEEK_V4_FLASH_PRICING,
+  "deepseek/deepseek-v4-pro": DEEPSEEK_V4_PRO_PRICING,
+  "anthropic/claude-sonnet-4-6": SONNET_4_6_PRICING,
+  "anthropic/claude-sonnet-4.6": SONNET_4_6_PRICING,
+  "anthropic/claude-opus-4.6": OPUS_4_6_PRICING,
+  "z-ai/glm-5.2": GLM_5_2_PRICING,
+  "z-ai/glm-5.2-20260616": GLM_5_2_PRICING,
+  "moonshotai/kimi-k2.7-code": KIMI_K2_7_CODE_PRICING,
+  "moonshotai/kimi-k2.7-code:exacto": KIMI_K2_7_CODE_PRICING,
+};
+
+const getModelPricing = (modelName?: string): ModelPricing => {
+  if (!modelName) return DEFAULT_PRICING;
+
+  const exactPricing = MODEL_PRICING_MAP[modelName];
+  if (exactPricing) return exactPricing;
+
+  if (/^anthropic\/claude-4\.6-opus-\d{8}$/.test(modelName)) {
+    return OPUS_4_6_PRICING;
+  }
+  if (/^anthropic\/claude-4\.6-sonnet-\d{8}$/.test(modelName)) {
+    return SONNET_4_6_PRICING;
+  }
+
+  return DEFAULT_PRICING;
+};
+
+const normalizeTokenCount = (value: number): number =>
+  Number.isFinite(value) ? Math.max(0, value) : 0;
 
 /** Points per dollar (1 point = $0.0001) */
 export const POINTS_PER_DOLLAR = 10_000;
@@ -336,6 +421,49 @@ export const calculateRawTokenCost = (
   const pricing = getModelPricing(modelName);
   const price = type === "input" ? pricing.input : pricing.output;
   return Math.ceil((tokens / 1_000_000) * price * POINTS_PER_DOLLAR);
+};
+
+/**
+ * Estimate raw model spend without applying HackerAI's billing multiplier.
+ *
+ * Provider usage reports cache reads/writes as subsets of input tokens. Price
+ * each subset at its model-specific rate and leave unknown models at the
+ * conservative full-input default.
+ */
+export const calculateRawModelUsageCostDollars = ({
+  inputTokens,
+  outputTokens,
+  cacheReadTokens = 0,
+  cacheWriteTokens = 0,
+  modelName,
+}: {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  modelName?: string;
+}): number => {
+  const normalizedInput = normalizeTokenCount(inputTokens);
+  const normalizedOutput = normalizeTokenCount(outputTokens);
+  const normalizedCacheRead = Math.min(
+    normalizedInput,
+    normalizeTokenCount(cacheReadTokens),
+  );
+  const normalizedCacheWrite = Math.min(
+    normalizedInput - normalizedCacheRead,
+    normalizeTokenCount(cacheWriteTokens),
+  );
+  const uncachedInput =
+    normalizedInput - normalizedCacheRead - normalizedCacheWrite;
+  const pricing = getModelPricing(modelName);
+
+  return (
+    (uncachedInput * pricing.input +
+      normalizedCacheRead * pricing.cacheRead +
+      normalizedCacheWrite * pricing.cacheWrite +
+      normalizedOutput * pricing.output) /
+    1_000_000
+  );
 };
 
 // =============================================================================
@@ -993,11 +1121,10 @@ export const deductUsageDelta = async (
  * If extra usage was used for input (bucket at 0), also deducts output from extra usage.
  * If we over-estimated input cost, refunds the difference back to the bucket.
  *
- * @param providerCostDollars - If provided (from authoritative provider cost),
- *   uses this instead of token calculation. On clean completions this includes
- *   model + sandbox + tool costs.
- *   On non-clean completions this is undefined; nonModelCostDollars covers sandbox/tool costs.
- * @param nonModelCostDollars - Sandbox session and tool costs (always accurate). When providerCostDollars
+ * @param resolvedCostDollars - If provided, uses the UsageTracker's resolved
+ *   provider or hybrid total instead of recalculating aggregate tokens with one
+ *   model. This includes model + sandbox + tool costs.
+ * @param nonModelCostDollars - Sandbox session and tool costs (always accurate). When resolvedCostDollars
  *   is undefined (non-clean streams), this is added on top of token-based model cost.
  */
 export const deductUsage = async (
@@ -1007,7 +1134,7 @@ export const deductUsage = async (
   actualInputTokens: number,
   actualOutputTokens: number,
   extraUsageConfig?: ExtraUsageConfig,
-  providerCostDollars?: number,
+  resolvedCostDollars?: number,
   modelName?: string,
   nonModelCostDollars: number = 0,
   organizationId?: string,
@@ -1087,12 +1214,11 @@ export const deductUsage = async (
     });
     lastKnownDeductionResult = buildDeductionResult();
 
-    // Calculate actual billable cost - prefer provider cost if available.
-    // Provider cost already includes non-model costs (sandbox/tools) when present.
-    // When absent (non-clean streams), add billable non-model costs on top of
-    // token-based model pricing.
-    if (providerCostDollars !== undefined && providerCostDollars > 0) {
-      actualCostPoints = billableCostDollarsToPoints(providerCostDollars);
+    // Calculate actual billable cost from the UsageTracker's resolved provider
+    // or hybrid total. Legacy callers without a resolved total retain the
+    // aggregate token fallback.
+    if (resolvedCostDollars !== undefined && resolvedCostDollars > 0) {
+      actualCostPoints = billableCostDollarsToPoints(resolvedCostDollars);
     } else {
       const modelForActualCost = actualModelName ?? modelName;
       const actualInputCost = calculateTokenCost(

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -211,8 +211,12 @@ export class UsageTracker {
     this.modelProviderCost += costDollars - previousCost;
   }
 
+  private get allModelSteps(): ModelStepCost[] {
+    return [...this.modelStepCosts, ...this.summarizationStepCosts];
+  }
+
   get hasAuthoritativeModelCost(): boolean {
-    const modelSteps = [...this.modelStepCosts, ...this.summarizationStepCosts];
+    const modelSteps = this.allModelSteps;
     return (
       modelSteps.length > 0 &&
       modelSteps.every((stepCost) =>
@@ -222,9 +226,8 @@ export class UsageTracker {
   }
 
   get hasAnyAuthoritativeModelCost(): boolean {
-    return [...this.modelStepCosts, ...this.summarizationStepCosts].some(
-      (stepCost) =>
-        isPositiveFiniteNumber(stepCost.authoritativeCost ?? stepCost.rawCost),
+    return this.allModelSteps.some((stepCost) =>
+      isPositiveFiniteNumber(stepCost.authoritativeCost ?? stepCost.rawCost),
     );
   }
 
@@ -255,7 +258,7 @@ export class UsageTracker {
     selectedModel: string,
     accountingModel?: string,
   ): number {
-    const modelSteps = [...this.modelStepCosts, ...this.summarizationStepCosts];
+    const modelSteps = this.allModelSteps;
     if (modelSteps.length === 0) {
       return calculateRawModelUsageCostDollars({
         inputTokens: this.inputTokens,

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -3,7 +3,7 @@ import {
   getProviderUsageRawModelCost,
   isPositiveFiniteNumber,
 } from "@/lib/provider-usage-cost";
-import { calculateRawTokenCost, POINTS_PER_DOLLAR } from "@/lib/rate-limit";
+import { calculateRawModelUsageCostDollars } from "@/lib/rate-limit";
 import type { UsageDeductionFailureReason } from "@/lib/rate-limit";
 import type { ChatApiEndpoint } from "@/lib/api/agent-endpoints";
 import type { ChatMode, RateLimitInfo, SubscriptionTier } from "@/types";
@@ -33,9 +33,16 @@ interface StepUsage {
 type ModelStepCost = {
   rawCost: number;
   authoritativeCost?: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  modelName?: string;
 };
 
 export type UsageBillingType = "included" | "extra" | "mixed";
+export type UsageCostSource =
+  "provider" | "hybrid" | "token_estimate" | "raw_token_estimate";
 
 export interface UsageBillingBreakdown {
   includedPointsDeducted: number;
@@ -72,7 +79,7 @@ export interface UsageCostRecord {
   costDollars: number;
   modelCostDollars: number;
   nonModelCostDollars: number;
-  costSource: "provider" | "token_estimate" | "raw_token_estimate";
+  costSource: UsageCostSource;
 }
 
 /**
@@ -88,12 +95,13 @@ export class UsageTracker {
   cacheReadTokens = 0;
   cacheWriteTokens = 0;
   providerCost = 0;
-  /** Model-only cost from usage.raw.cost, OpenRouter upstream cost details, or
-   * authoritative provider metadata (excludes tool/sandbox spend). Used to
-   * decide whether the provider reported an authoritative model cost; if zero,
-   * fall back to token-based model cost calculation. */
+  /**
+   * Provider cost for the streamed model leg only. Summarization is tracked
+   * separately because it survives resetModelLeg() during a fallback retry.
+   */
   modelProviderCost = 0;
   private modelStepCosts: ModelStepCost[] = [];
+  private summarizationStepCosts: ModelStepCost[] = [];
   /** Costs from sandbox sessions and tool usage (always accurate, even on non-clean streams) */
   nonModelCost = 0;
   lastStepInputTokens = 0;
@@ -123,7 +131,7 @@ export class UsageTracker {
     this.modelStepCosts = [];
   }
 
-  accumulateStep(usage: StepUsage): number {
+  accumulateStep(usage: StepUsage, modelName?: string): number {
     this.inputTokens += usage.inputTokens || 0;
     this.outputTokens += usage.outputTokens || 0;
     this.totalTokens += usage.totalTokens || 0;
@@ -132,12 +140,58 @@ export class UsageTracker {
     this.cacheWriteTokens += usage.inputTokenDetails?.cacheWriteTokens || 0;
     const stepCost = getProviderUsageRawModelCost(usage.raw);
     const rawCost = isPositiveFiniteNumber(stepCost) ? stepCost : 0;
-    const stepCostIndex = this.modelStepCosts.push({ rawCost }) - 1;
+    const stepCostIndex =
+      this.modelStepCosts.push({
+        rawCost,
+        inputTokens: usage.inputTokens || 0,
+        outputTokens: usage.outputTokens || 0,
+        cacheReadTokens: usage.inputTokenDetails?.cacheReadTokens || 0,
+        cacheWriteTokens: usage.inputTokenDetails?.cacheWriteTokens || 0,
+        modelName,
+      }) - 1;
     if (isPositiveFiniteNumber(stepCost)) {
       this.providerCost += stepCost;
       this.modelProviderCost += stepCost;
     }
     return stepCostIndex;
+  }
+
+  accumulateSummarization(usage: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+    cost?: number;
+    model?: string;
+  }): void {
+    const inputTokens = usage.inputTokens || 0;
+    const outputTokens = usage.outputTokens || 0;
+    const cacheReadTokens = usage.cacheReadTokens || 0;
+    const cacheWriteTokens = usage.cacheWriteTokens || 0;
+    const rawCost = isPositiveFiniteNumber(usage.cost) ? usage.cost : 0;
+
+    this.inputTokens += inputTokens;
+    this.summarizationInputTokens += inputTokens;
+    this.outputTokens += outputTokens;
+    this.summarizationOutputTokens += outputTokens;
+    this.totalTokens += inputTokens + outputTokens;
+    this.cacheReadTokens += cacheReadTokens;
+    this.summarizationCacheReadTokens += cacheReadTokens;
+    this.cacheWriteTokens += cacheWriteTokens;
+    this.summarizationCacheWriteTokens += cacheWriteTokens;
+    this.summarizationStepCosts.push({
+      rawCost,
+      inputTokens,
+      outputTokens,
+      cacheReadTokens,
+      cacheWriteTokens,
+      modelName: usage.model,
+    });
+    if (rawCost > 0) {
+      // Summarization survives resetModelLeg(), so do not include it in
+      // modelProviderCost (the amount removed for a streamed-model retry).
+      this.providerCost += rawCost;
+    }
   }
 
   setAuthoritativeModelCostForStep(
@@ -158,11 +212,19 @@ export class UsageTracker {
   }
 
   get hasAuthoritativeModelCost(): boolean {
+    const modelSteps = [...this.modelStepCosts, ...this.summarizationStepCosts];
     return (
-      this.modelStepCosts.length > 0 &&
-      this.modelStepCosts.every((stepCost) =>
+      modelSteps.length > 0 &&
+      modelSteps.every((stepCost) =>
         isPositiveFiniteNumber(stepCost.authoritativeCost ?? stepCost.rawCost),
       )
+    );
+  }
+
+  get hasAnyAuthoritativeModelCost(): boolean {
+    return [...this.modelStepCosts, ...this.summarizationStepCosts].some(
+      (stepCost) =>
+        isPositiveFiniteNumber(stepCost.authoritativeCost ?? stepCost.rawCost),
     );
   }
 
@@ -193,29 +255,36 @@ export class UsageTracker {
     selectedModel: string,
     accountingModel?: string,
   ): number {
-    // Use authoritative provider cost only when the model itself reported one
-    // via raw.cost, OpenRouter upstream cost details, or OpenRouter metadata
-    // (tracked in modelProviderCost).
-    // providerCost also includes sandbox/tool spend and summarization cost, so
-    // subtract nonModelCost to isolate the model portion.
-    if (this.hasAuthoritativeModelCost) {
-      return this.providerCost - this.nonModelCost;
+    const modelSteps = [...this.modelStepCosts, ...this.summarizationStepCosts];
+    if (modelSteps.length === 0) {
+      return calculateRawModelUsageCostDollars({
+        inputTokens: this.inputTokens,
+        outputTokens: this.outputTokens,
+        cacheReadTokens: this.cacheReadTokens,
+        cacheWriteTokens: this.cacheWriteTokens,
+        modelName: accountingModel ?? selectedModel,
+      });
     }
-    const modelForEstimate = accountingModel ?? selectedModel;
-    return (
-      (calculateRawTokenCost(this.inputTokens, "input", modelForEstimate) +
-        calculateRawTokenCost(this.outputTokens, "output", modelForEstimate)) /
-      POINTS_PER_DOLLAR
-    );
+
+    return modelSteps.reduce((totalCost, stepCost) => {
+      const authoritativeCost = stepCost.authoritativeCost ?? stepCost.rawCost;
+      if (isPositiveFiniteNumber(authoritativeCost)) {
+        return totalCost + authoritativeCost;
+      }
+      return (
+        totalCost +
+        calculateRawModelUsageCostDollars({
+          inputTokens: stepCost.inputTokens,
+          outputTokens: stepCost.outputTokens,
+          cacheReadTokens: stepCost.cacheReadTokens,
+          cacheWriteTokens: stepCost.cacheWriteTokens,
+          modelName: stepCost.modelName ?? accountingModel ?? selectedModel,
+        })
+      );
+    }, 0);
   }
 
   computeCostDollars(selectedModel: string, accountingModel?: string): number {
-    // Mirror deductUsage's gate: providerCost is only authoritative for the
-    // total when every model step has authoritative cost. After resetModelLeg()
-    // (fallback retry), providerCost can be positive from nonModelCost alone,
-    // which would underreport the fallback's model tokens if we used it
-    // directly.
-    if (this.hasAuthoritativeModelCost) return this.providerCost;
     return (
       this.computeModelCostDollars(selectedModel, accountingModel) +
       this.nonModelCost
@@ -388,7 +457,9 @@ export class UsageTracker {
       nonModelCostDollars: this.nonModelCost,
       costSource: this.hasAuthoritativeModelCost
         ? "provider"
-        : "raw_token_estimate",
+        : this.hasAnyAuthoritativeModelCost
+          ? "hybrid"
+          : "raw_token_estimate",
     };
   }
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2503,9 +2503,10 @@ export const agentLongTask = task({
                 };
                 let usageCostRecord =
                   usageTracker.createUsageCostRecord(usageRecordArgs);
-                const providerCost = usageTracker.hasAuthoritativeModelCost
-                  ? usageTracker.providerCost
-                  : undefined;
+                // Use the same resolved provider/hybrid total that powers
+                // mid-run settlement. This preserves authoritative step costs
+                // and estimates only the individual steps missing provider cost.
+                const settledCostDollars = usageCostRecord.costDollars;
                 if (paidDailyFreeAllowanceReservation) {
                   const allowanceCostRecord =
                     await recordPaidDailyFreeAllowanceCost(
@@ -2586,7 +2587,7 @@ export const agentLongTask = task({
                     usageTracker.inputTokens,
                     usageTracker.outputTokens,
                     extraUsageConfig,
-                    providerCost,
+                    settledCostDollars,
                     selectedModel,
                     usageTracker.nonModelCost,
                     organizationId,


### PR DESCRIPTION
## Summary

- preserve authoritative provider cost for every completed model step and estimate only individual steps whose provider cost is unavailable
- price missing-cost steps with the model that actually served them and their cache-read/cache-write token breakdown, including summarization and fallback legs
- use the same resolved provider/hybrid total for mid-run budget checks and final reconciliation, and emit `cost_source: hybrid` when both sources contribute

## Root cause

When any model step lacked authoritative provider cost (for example, after a budget stop or incomplete provider metadata), accounting discarded all known step costs and repriced the run's aggregate input/output totals with one model. Cache-read tokens were included in input totals but charged at the full uncached input rate. Final settlement also declined the resolved total unless every step had provider cost, so long cached Agent runs could be substantially overstated.

## Accounting invariant

Each completed model or summarization step now contributes exactly one of:

1. its authoritative provider/upstream cost, or
2. a cache-aware estimate using that step's served model.

Non-model sandbox/tool cost is then added once. The final deduction consumes this same resolved total, so it can reconcile both upward and downward against earlier mid-run settlements without repricing the entire run.

This is an accounting correctness fix and is intentionally not feature-flagged. It adds no model, agent, tool, or provider request; the `hybrid` source is written only through the existing final usage telemetry path.

## Validation

- `pnpm test -- --runInBand lib/__tests__/usage-tracker.test.ts lib/rate-limit/__tests__/token-bucket.test.ts lib/api/__tests__/chat-stream-helpers-summarization.test.ts lib/api/__tests__/agent-long-contracts.test.ts convex/__tests__/usageLogs.test.ts` — 207 tests passed
- `pnpm typecheck`
- `pnpm lint`
- Prettier check on all touched files
- `pnpm exec convex dev --once --typecheck disable --codegen disable --env-file /home/hackerai/src/hackerai/.env.local` — functions ready

## Manual verification

1. In staging, run a paid Agent conversation that produces cache reads and switches models through a fallback or multimodal tool result.
2. Simulate one completed step without provider cost while another step has upstream cost metadata.
3. Confirm the final usage event has `cost_source: hybrid`, keeps the known step's provider cost, and estimates only the missing step using its served-model cache rates.
4. Run close to allowance exhaustion and confirm the Agent stops after the completed step, then final reconciliation does not reprice all cached input at the final model's uncached rate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **hybrid** cost source support for usage logging and reporting.
  * Enhanced model cost attribution per streamed step (including served model selection) and improved summarization usage reporting with optional model context.
  * Expanded token pricing to include provider cache read/write rates and added raw model usage cost estimation.
  * Re-exported raw model usage cost utility for wider internal use.

* **Bug Fixes**
  * Improved billing/accounting deductions by consistently using the resolved settled total cost.

* **Tests**
  * Updated and extended usage, chat, and token-bucket test coverage for the new hybrid and cache-aware behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->