### PR TITLE
Reduce Convex message history I/O

### DIFF
--- a/convex/__tests__/messages.hidden.test.ts
+++ b/convex/__tests__/messages.hidden.test.ts
@@ -532,7 +532,7 @@ describe("getMessagesByChatId — is_hidden filtering", () => {
     };
   });
 
-  function setupPaginatedMessages(messages: Record<string, any>[]): void {
+  function setupPaginatedMessages(messages: Record<string, any>[]) {
     const paginateMock = jest.fn<any>().mockResolvedValue({
       page: messages,
       isDone: true,
@@ -545,6 +545,7 @@ describe("getMessagesByChatId — is_hidden filtering", () => {
         }),
       }),
     });
+    return paginateMock;
   }
 
   it("should exclude messages where is_hidden is true", async () => {
@@ -560,7 +561,7 @@ describe("getMessagesByChatId — is_hidden filtering", () => {
       is_hidden: true,
     });
 
-    setupPaginatedMessages([visibleMsg, hiddenMsg]);
+    const paginateMock = setupPaginatedMessages([visibleMsg, hiddenMsg]);
 
     const { getMessagesByChatId } = await import("../messages");
 
@@ -571,6 +572,11 @@ describe("getMessagesByChatId — is_hidden filtering", () => {
 
     expect(result.page).toHaveLength(1);
     expect(result.page[0].id).toBe("msg-visible");
+    expect(paginateMock).toHaveBeenCalledWith({
+      numItems: 10,
+      cursor: null,
+      maximumBytesRead: 4 * 1024 * 1024,
+    });
   });
 
   it("should include messages where is_hidden is undefined or false", async () => {
@@ -608,6 +614,85 @@ describe("getMessagesByChatId — is_hidden filtering", () => {
     expect(ids).toContain("msg-2");
     expect(ids).not.toContain("msg-3");
   });
+
+  it("does not read user attachment rows but preserves assistant file details", async () => {
+    const userFileId = "file-user" as Id<"files">;
+    const assistantFileId = "file-assistant" as Id<"files">;
+    const feedbackId = "feedback-1" as Id<"feedback">;
+    const userMessage = makeMessage({
+      id: "msg-user-file",
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          fileId: userFileId,
+          name: "request.txt",
+          mediaType: "text/plain",
+          size: 128,
+        },
+      ],
+      file_ids: [userFileId],
+    });
+    const assistantMessage = makeMessage({
+      id: "msg-assistant-file",
+      role: "assistant",
+      file_ids: [assistantFileId],
+      feedback_id: feedbackId,
+    });
+
+    setupPaginatedMessages([assistantMessage, userMessage]);
+    mockCtx.db.get.mockImplementation(async (id: string) => {
+      if (id === userFileId) {
+        throw new Error("user attachment row should not be read");
+      }
+      if (id === assistantFileId) {
+        return {
+          _id: assistantFileId,
+          user_id: USER_ID,
+          name: "artifact.zip",
+          media_type: "application/zip",
+          s3_key: "generated/artifact.zip",
+          size: 2048,
+          file_token_size: 0,
+          is_attached: true,
+        };
+      }
+      if (id === feedbackId) {
+        return {
+          _id: feedbackId,
+          feedback_type: "positive",
+        };
+      }
+      return null;
+    });
+
+    const { getMessagesByChatId } = await import("../messages");
+    const result = await getMessagesByChatId.handler(mockCtx, {
+      chatId: CHAT_ID,
+      paginationOpts: { numItems: 10, cursor: null },
+    });
+
+    const assistantResult = result.page.find(
+      (message: any) => message.id === "msg-assistant-file",
+    );
+    const userResult = result.page.find(
+      (message: any) => message.id === "msg-user-file",
+    );
+    expect(mockCtx.db.get).not.toHaveBeenCalledWith(userFileId);
+    expect(assistantResult?.fileDetails).toEqual([
+      {
+        fileId: assistantFileId,
+        name: "artifact.zip",
+        mediaType: "application/zip",
+        s3Key: "generated/artifact.zip",
+        sizeBytes: 2048,
+      },
+    ]);
+    expect(assistantResult?.feedback).toEqual({
+      feedbackType: "positive",
+    });
+    expect(userResult?.fileDetails).toBeUndefined();
+  });
 });
 
 describe("getMessagesPageForBackend — is_hidden filtering", () => {
@@ -626,7 +711,7 @@ describe("getMessagesPageForBackend — is_hidden filtering", () => {
     };
   });
 
-  function setupPaginatedMessages(messages: Record<string, any>[]): void {
+  function setupPaginatedMessages(messages: Record<string, any>[]) {
     const paginateMock = jest.fn<any>().mockResolvedValue({
       page: messages,
       isDone: true,
@@ -639,6 +724,7 @@ describe("getMessagesPageForBackend — is_hidden filtering", () => {
         }),
       }),
     });
+    return paginateMock;
   }
 
   it("should filter out hidden messages", async () => {
@@ -654,7 +740,7 @@ describe("getMessagesPageForBackend — is_hidden filtering", () => {
       is_hidden: true,
     });
 
-    setupPaginatedMessages([visibleMsg, hiddenMsg]);
+    const paginateMock = setupPaginatedMessages([visibleMsg, hiddenMsg]);
 
     const { getMessagesPageForBackend } = await import("../messages");
 
@@ -667,6 +753,12 @@ describe("getMessagesPageForBackend — is_hidden filtering", () => {
 
     expect(result.page).toHaveLength(1);
     expect(result.page[0].id).toBe("msg-visible");
+    expect(result.fileTokens).toEqual([]);
+    expect(paginateMock).toHaveBeenCalledWith({
+      numItems: 10,
+      cursor: null,
+      maximumBytesRead: 4 * 1024 * 1024,
+    });
   });
 
   it("should keep messages where is_hidden is false or undefined", async () => {
@@ -705,5 +797,32 @@ describe("getMessagesPageForBackend — is_hidden filtering", () => {
     expect(ids).toContain("msg-a");
     expect(ids).toContain("msg-b");
     expect(ids).not.toContain("msg-c");
+  });
+
+  it("reuses ownership reads as verified file token metadata", async () => {
+    const fileId = "file-owned" as Id<"files">;
+    const message = makeMessage({
+      id: "msg-with-file",
+      role: "user",
+      parts: [{ type: "file", fileId }],
+    });
+    setupPaginatedMessages([message]);
+    mockCtx.db.get = jest.fn<any>().mockResolvedValue({
+      _id: fileId,
+      user_id: USER_ID,
+      file_token_size: 321,
+    });
+
+    const { getMessagesPageForBackend } = await import("../messages");
+    const result = await getMessagesPageForBackend.handler(mockCtx, {
+      serviceKey: SERVICE_KEY,
+      chatId: CHAT_ID,
+      userId: USER_ID,
+      paginationOpts: { numItems: 10, cursor: null },
+    });
+
+    expect(result.page[0].parts).toEqual([{ type: "file", fileId }]);
+    expect(result.fileTokens).toEqual([{ fileId, tokenSize: 321 }]);
+    expect(mockCtx.db.get).toHaveBeenCalledTimes(1);
   });
 });

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -6,6 +6,7 @@ import type { DataModel, Doc, Id } from "./_generated/dataModel";
 import {
   paginationOptsValidator,
   type GenericDatabaseReader,
+  type PaginationOptions,
 } from "convex/server";
 import { validateServiceKey, copyChatSummary } from "./lib/utils";
 import { fileCountAggregate } from "./fileAggregate";
@@ -43,13 +44,30 @@ const extractFileIdsFromParts = (parts: any[]): Id<"files">[] =>
     )
     .map((part) => part.fileId as Id<"files">);
 
-const getOwnedFileIdSet = async (
+const MESSAGE_PAGE_MAX_BYTES = 4 * 1024 * 1024;
+
+const withMessagePageReadLimit = (
+  paginationOpts: PaginationOptions,
+): PaginationOptions => ({
+  ...paginationOpts,
+  maximumBytesRead: Math.min(
+    paginationOpts.maximumBytesRead ?? MESSAGE_PAGE_MAX_BYTES,
+    MESSAGE_PAGE_MAX_BYTES,
+  ),
+});
+
+const getOwnedFileInfo = async (
   ctx: { db: GenericDatabaseReader<DataModel> },
   fileIds: Id<"files">[],
   userId: string,
-): Promise<Set<string>> => {
+): Promise<{
+  ownedFileIds: Set<string>;
+  fileTokens: Array<{ fileId: Id<"files">; tokenSize: number }>;
+}> => {
   const uniqueFileIds = Array.from(new Set(fileIds));
-  if (uniqueFileIds.length === 0) return new Set();
+  if (uniqueFileIds.length === 0) {
+    return { ownedFileIds: new Set(), fileTokens: [] };
+  }
 
   const files = await Promise.all(
     uniqueFileIds.map((fileId) =>
@@ -64,11 +82,19 @@ const getOwnedFileIdSet = async (
     ),
   );
 
-  return new Set(
-    files
-      .filter((file) => file && file.user_id === userId)
-      .map((file) => file!._id),
+  const ownedFiles = files.flatMap((file, index) =>
+    file && file.user_id === userId
+      ? [{ file, fileId: uniqueFileIds[index] }]
+      : [],
   );
+
+  return {
+    ownedFileIds: new Set(ownedFiles.map(({ fileId }) => fileId)),
+    fileTokens: ownedFiles.map(({ file, fileId }) => ({
+      fileId,
+      tokenSize: file.file_token_size,
+    })),
+  };
 };
 
 const stripUnownedFileParts = (
@@ -961,7 +987,7 @@ export const getMessagesByChatId = query({
         .query("messages")
         .withIndex("by_chat_id", (q) => q.eq("chat_id", args.chatId))
         .order("desc")
-        .paginate(args.paginationOpts);
+        .paginate(withMessagePageReadLimit(args.paginationOpts));
 
       // Filter hidden messages (e.g. auto-continue rows) from the page.
       // This is applied post-pagination; hidden messages are rare so page
@@ -973,16 +999,34 @@ export const getMessagesByChatId = query({
       // Step 1: Collect all unique file IDs from all messages
       const allFileIds = new Set<Id<"files">>();
       for (const message of visiblePage) {
-        if (message.file_ids && message.file_ids.length > 0) {
+        if (
+          message.role !== "user" &&
+          message.file_ids &&
+          message.file_ids.length > 0
+        ) {
           message.file_ids.forEach((id) => allFileIds.add(id));
         }
       }
 
-      // Step 2: Batch fetch all files in parallel
+      const allFeedbackIds = new Set<Id<"feedback">>();
+      for (const message of visiblePage) {
+        if (message.role === "assistant" && message.feedback_id) {
+          allFeedbackIds.add(message.feedback_id);
+        }
+      }
+
+      // Step 2: Batch fetch assistant-generated file metadata and feedback in
+      // parallel. User attachment metadata already lives in the persisted
+      // file part and the UI intentionally ignores message.fileDetails for
+      // user messages, so reading those potentially large file rows is waste.
       const fileIdArray = Array.from(allFileIds);
-      const files = await Promise.all(
-        fileIdArray.map((fileId) => ctx.db.get(fileId)),
-      );
+      const feedbackIdArray = Array.from(allFeedbackIds);
+      const [files, feedbackDocs] = await Promise.all([
+        Promise.all(fileIdArray.map((fileId) => ctx.db.get(fileId))),
+        Promise.all(
+          feedbackIdArray.map((feedbackId) => ctx.db.get(feedbackId)),
+        ),
+      ]);
 
       // Step 3: Build file details lookup map for O(1) access
       // DON'T generate URLs here - they expire and get cached with the query!
@@ -1002,25 +1046,32 @@ export const getMessagesByChatId = query({
           });
         }
       });
+      const feedbackDetailsMap = new Map<
+        Id<"feedback">,
+        { feedbackType: "positive" | "negative" }
+      >();
+      feedbackDocs.forEach((feedbackDoc, index) => {
+        if (feedbackDoc) {
+          feedbackDetailsMap.set(feedbackIdArray[index], {
+            feedbackType: feedbackDoc.feedback_type,
+          });
+        }
+      });
 
       // Step 5: Build enhanced messages using the lookup map
       const enhancedMessages = [];
       for (const message of visiblePage) {
-        // Get feedback if exists
-        let feedback = null;
-        if (message.role === "assistant" && message.feedback_id) {
-          const feedbackDoc = await ctx.db.get(message.feedback_id);
-          if (feedbackDoc) {
-            feedback = {
-              feedbackType: feedbackDoc.feedback_type as
-                "positive" | "negative",
-            };
-          }
-        }
+        const feedback = message.feedback_id
+          ? (feedbackDetailsMap.get(message.feedback_id) ?? null)
+          : null;
 
         // Get file details using O(1) lookup
         let fileDetails = undefined;
-        if (message.file_ids && message.file_ids.length > 0) {
+        if (
+          message.role !== "user" &&
+          message.file_ids &&
+          message.file_ids.length > 0
+        ) {
           fileDetails = message.file_ids
             .map((fileId) => fileDetailsMap.get(fileId))
             .filter((detail) => detail !== undefined);
@@ -1395,6 +1446,12 @@ export const getMessagesPageForBackend = query({
         parts: v.array(v.any()),
       }),
     ),
+    fileTokens: v.array(
+      v.object({
+        fileId: v.id("files"),
+        tokenSize: v.number(),
+      }),
+    ),
     isDone: v.boolean(),
     continueCursor: v.union(v.string(), v.null()),
   }),
@@ -1411,14 +1468,14 @@ export const getMessagesPageForBackend = query({
     );
 
     if (!chatExists) {
-      return { page: [], isDone: true, continueCursor: "" };
+      return { page: [], fileTokens: [], isDone: true, continueCursor: "" };
     }
 
     const result = await ctx.db
       .query("messages")
       .withIndex("by_chat_id", (q) => q.eq("chat_id", args.chatId))
       .order("desc")
-      .paginate(args.paginationOpts);
+      .paginate(withMessagePageReadLimit(args.paginationOpts));
 
     const visiblePage = result.page.filter(
       (message) => message.is_hidden !== true,
@@ -1429,7 +1486,7 @@ export const getMessagesPageForBackend = query({
         fileIds.add(fileId),
       );
     }
-    const ownedFileIds = await getOwnedFileIdSet(
+    const { ownedFileIds, fileTokens } = await getOwnedFileInfo(
       ctx,
       Array.from(fileIds),
       args.userId,
@@ -1441,6 +1498,7 @@ export const getMessagesPageForBackend = query({
         role: message.role,
         parts: stripUnownedFileParts(message.parts, ownedFileIds),
       })),
+      fileTokens,
       isDone: result.isDone,
       continueCursor: result.continueCursor,
     };

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -1191,6 +1191,38 @@ describe("getMessagesByChatId", () => {
     expect(mockQuery).toHaveBeenCalledTimes(2);
   });
 
+  it("ignores returned file token metadata in agent mode", async () => {
+    const { getMessagesByChatId, mockQuery } = await loadSaveMessageWithMocks();
+    const fileId = "file-from-ask-mode";
+    const existingMessage = {
+      id: "existing-message-with-file",
+      role: "user" as const,
+      parts: [{ type: "file" as const, fileId }],
+    };
+
+    mockQuery
+      .mockResolvedValueOnce({ id: "chat-1", user_id: "user-1" })
+      .mockResolvedValueOnce({
+        page: [existingMessage],
+        fileTokens: [{ fileId, tokenSize: 200_001 }],
+        isDone: true,
+        continueCursor: null,
+      });
+
+    const result = await getMessagesByChatId({
+      chatId: "chat-1",
+      userId: "user-1",
+      subscription: "pro",
+      newMessages: [],
+      isTemporary: false,
+      mode: "agent",
+    });
+
+    expect(result.truncatedMessages).toEqual([existingMessage]);
+    expect(result.fileTokens).toEqual({});
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
   it("does not inject a stored summary while regenerating", async () => {
     const { getMessagesByChatId, mockQuery } = await loadSaveMessageWithMocks();
     const lastUserMessage = {

--- a/lib/db/__tests__/actions-save-message.test.ts
+++ b/lib/db/__tests__/actions-save-message.test.ts
@@ -1159,6 +1159,38 @@ describe("getMessagesByChatId", () => {
     }
   });
 
+  it("reuses file token metadata returned with existing history pages", async () => {
+    const { getMessagesByChatId, mockQuery } = await loadSaveMessageWithMocks();
+    const fileId = "file-existing";
+    const existingMessage = {
+      id: "existing-message-with-file",
+      role: "user" as const,
+      parts: [{ type: "file" as const, fileId }],
+    };
+
+    mockQuery
+      .mockResolvedValueOnce({ id: "chat-1", user_id: "user-1" })
+      .mockResolvedValueOnce({
+        page: [existingMessage],
+        fileTokens: [{ fileId, tokenSize: 321 }],
+        isDone: true,
+        continueCursor: null,
+      });
+
+    const result = await getMessagesByChatId({
+      chatId: "chat-1",
+      userId: "user-1",
+      subscription: "pro",
+      newMessages: [],
+      isTemporary: false,
+      mode: "ask",
+    });
+
+    expect(result.truncatedMessages).toEqual([existingMessage]);
+    expect(result.fileTokens).toEqual({ [fileId]: 321 });
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
   it("does not inject a stored summary while regenerating", async () => {
     const { getMessagesByChatId, mockQuery } = await loadSaveMessageWithMocks();
     const lastUserMessage = {

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -1369,8 +1369,10 @@ export async function getMessagesByChatId({
           fetchedDesc = fetchedDesc.concat(page);
           pagesFetched++;
 
-          for (const { fileId, tokenSize } of pageFileTokens) {
-            fileTokensFromLoop[fileId] = tokenSize;
+          if (!skipFileTokens) {
+            for (const { fileId, tokenSize } of pageFileTokens) {
+              fileTokensFromLoop[fileId] = tokenSize;
+            }
           }
 
           const existingChrono = [...fetchedDesc].reverse();

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -586,6 +586,7 @@ const databaseError = (
 
 type MessagesPageForBackendResult = {
   page: UIMessage[];
+  fileTokens?: Array<{ fileId: Id<"files">; tokenSize: number }>;
   isDone: boolean;
   continueCursor: string | null;
 };
@@ -1343,6 +1344,10 @@ export async function getMessagesByChatId({
         while (pagesFetched < MAX_PAGES) {
           const pageResult: {
             page: UIMessage[];
+            fileTokens?: Array<{
+              fileId: Id<"files">;
+              tokenSize: number;
+            }>;
             isDone: boolean;
             continueCursor: string | null;
           } = await getMessagesPageForBackendWithRetry({
@@ -1354,10 +1359,19 @@ export async function getMessagesByChatId({
             regenerate: !!regenerate,
             newMessagesCount: newMessages.length,
           });
-          const { page, isDone, continueCursor: nextCursor } = pageResult;
+          const {
+            page,
+            fileTokens: pageFileTokens = [],
+            isDone,
+            continueCursor: nextCursor,
+          } = pageResult;
 
           fetchedDesc = fetchedDesc.concat(page);
           pagesFetched++;
+
+          for (const { fileId, tokenSize } of pageFileTokens) {
+            fileTokensFromLoop[fileId] = tokenSize;
+          }
 
           const existingChrono = [...fetchedDesc].reverse();
           const candidate =


### PR DESCRIPTION
## Summary

- cap both message-history queries at 4 MiB per paginated database read while preserving cursors and pagination behavior
- stop reading large user attachment rows that the UI does not consume, while batching assistant-file and feedback enrichment
- return verified attachment token sizes from the backend history query and reuse them during Ask-mode prompt assembly instead of issuing a second Convex read
- preserve Agent-mode history behavior by ignoring returned file token sizes there

## Why

`messages.getMessagesByChatId` and `messages.getMessagesPageForBackend` account for the large majority of current Convex database I/O. This reduces redundant reads on both paths without changing stored data, message ordering, auth/ownership checks, or user-visible attachment behavior.

## Validation

- `pnpm typecheck`
- `pnpm lint` (passes with 5 pre-existing warnings)
- `pnpm exec eslint convex/messages.ts convex/__tests__/messages.hidden.test.ts lib/db/actions.ts lib/db/__tests__/actions-save-message.test.ts`
- `pnpm exec jest --runInBand convex/__tests__/messages.hidden.test.ts lib/db/__tests__/actions-save-message.test.ts` (50 tests)
- pre-commit full suite: 300 suites / 2,971 tests
- anonymous local `convex dev --once --typecheck=disable` function push

## Manual verification

1. Open an existing chat containing a user-uploaded attachment and an assistant-generated file.
2. Confirm the user attachment renders from its message part and the assistant file still renders/downloads.
3. Send a follow-up in Ask mode and Agent mode; confirm prior history and attachment context are retained.
4. Scroll backward through a long chat and confirm older pages continue loading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved message history pagination with per-page read limits for more predictable loading.
  - Reduced redundant reads when assembling paginated message history, including file and feedback enrichment.

- **Bug Fixes**
  - Hidden and unowned file attachments are filtered more reliably from message results.
  - File token metadata is now preserved across paginated message history.
  - In agent mode, any returned file token metadata is safely ignored while truncated messages remain intact.

- **Tests**
  - Expanded coverage for pagination behavior, hidden message filtering, and file/ownership metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->