### PR TITLE
Reduce shared task loading round trips

### DIFF
--- a/app/share/[shareId]/SharedChatView.tsx
+++ b/app/share/[shareId]/SharedChatView.tsx
@@ -125,26 +125,22 @@ export function SharedChatView({ shareId }: SharedChatViewProps) {
 
     const loadSharedSnapshot = async () => {
       try {
-        const nextChat = await convex.query(api.sharedChats.getSharedChat, {
-          shareId,
-        });
+        const nextSnapshot = await convex.query(
+          api.sharedChats.getSharedSnapshot,
+          { shareId },
+        );
         if (cancelled || loadGenerationRef.current !== generation) return;
 
-        if (!nextChat) {
+        if (!nextSnapshot) {
           setSnapshot({ shareId, chat: null, messages: [] });
           return;
         }
 
-        setSnapshot({ shareId, chat: nextChat, messages: undefined });
-
-        const nextMessages = await convex.query(
-          api.messages.getSharedMessages,
-          {
-            chatId: nextChat.id,
-          },
-        );
-        if (cancelled || loadGenerationRef.current !== generation) return;
-        setSnapshot({ shareId, chat: nextChat, messages: nextMessages });
+        setSnapshot({
+          shareId,
+          chat: nextSnapshot.chat,
+          messages: nextSnapshot.messages,
+        });
       } catch (error) {
         console.error("Failed to load shared chat:", error);
         if (cancelled || loadGenerationRef.current !== generation) return;

--- a/convex/__tests__/sharedChats.fork.test.ts
+++ b/convex/__tests__/sharedChats.fork.test.ts
@@ -30,6 +30,8 @@ jest.mock("../lib/suspensionGuards", () => ({
 
 const { forkSharedChat, getSharedSnapshot } =
   require("../sharedChats") as typeof import("../sharedChats");
+const { getVisibleSharedChatByChatId } =
+  require("../lib/sharedChatSnapshot") as typeof import("../lib/sharedChatSnapshot");
 
 describe("getSharedSnapshot", () => {
   it("returns frozen, anonymous chat data with one shared-chat lookup", async () => {
@@ -162,6 +164,43 @@ describe("getSharedSnapshot", () => {
     expect(query).toHaveBeenCalledWith("chats");
   });
 
+  it("returns null without reading messages when the chat owner is blocked", async () => {
+    const { isUserBlockedByActiveFraudDispute } = jest.requireMock(
+      "../lib/suspensionGuards",
+    ) as { isUserBlockedByActiveFraudDispute: jest.Mock };
+    isUserBlockedByActiveFraudDispute.mockResolvedValueOnce(true);
+
+    const sharedChat = {
+      _id: "source-doc",
+      _creationTime: 1,
+      id: "source-1",
+      title: "Shared title",
+      user_id: "blocked-owner",
+      share_id: "11111111-1111-4111-8111-111111111111",
+      share_date: 200,
+      update_time: 200,
+    };
+    const query = jest.fn<any>(() => ({
+      withIndex: jest.fn<any>().mockReturnValue({
+        first: jest.fn<any>().mockResolvedValue(sharedChat),
+      }),
+    }));
+    const ctx = { db: { query } };
+
+    await expect(
+      getSharedSnapshot.handler(ctx as any, {
+        shareId: sharedChat.share_id,
+      }),
+    ).resolves.toBeNull();
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledWith("chats");
+    expect(isUserBlockedByActiveFraudDispute).toHaveBeenCalledWith(
+      ctx,
+      sharedChat.user_id,
+    );
+  });
+
   it("preserves chat metadata when the message read fails", async () => {
     const consoleError = jest
       .spyOn(console, "error")
@@ -211,6 +250,18 @@ describe("getSharedSnapshot", () => {
       expect.any(Error),
     );
     consoleError.mockRestore();
+  });
+});
+
+describe("shared chat visibility helpers", () => {
+  it("rejects an invalid legacy chat ID without reading the database", async () => {
+    const query = jest.fn<any>();
+
+    await expect(
+      getVisibleSharedChatByChatId({ db: { query } } as any, "not-a-uuid"),
+    ).resolves.toBeNull();
+
+    expect(query).not.toHaveBeenCalled();
   });
 });
 

--- a/convex/__tests__/sharedChats.fork.test.ts
+++ b/convex/__tests__/sharedChats.fork.test.ts
@@ -7,10 +7,13 @@ jest.mock("../_generated/server", () => ({
 jest.mock("convex/values", () => ({
   v: {
     array: jest.fn(() => "array"),
+    any: jest.fn(() => "any"),
     id: jest.fn(() => "id"),
+    literal: jest.fn(() => "literal"),
     null: jest.fn(() => "null"),
     number: jest.fn(() => "number"),
     object: jest.fn(() => "object"),
+    optional: jest.fn(() => "optional"),
     string: jest.fn(() => "string"),
     union: jest.fn(() => "union"),
   },
@@ -25,8 +28,191 @@ jest.mock("../lib/suspensionGuards", () => ({
   isUserBlockedByActiveFraudDispute: jest.fn<any>().mockResolvedValue(false),
 }));
 
-const { forkSharedChat } =
+const { forkSharedChat, getSharedSnapshot } =
   require("../sharedChats") as typeof import("../sharedChats");
+
+describe("getSharedSnapshot", () => {
+  it("returns frozen, anonymous chat data with one shared-chat lookup", async () => {
+    const sharedChat = {
+      _id: "source-doc",
+      _creationTime: 1,
+      id: "source-1",
+      title: "Shared title",
+      user_id: "source-owner",
+      share_id: "11111111-1111-4111-8111-111111111111",
+      share_date: 200,
+      update_time: 200,
+    };
+    const chatFirst = jest.fn<any>().mockResolvedValue(sharedChat);
+    const messagesCollect = jest.fn<any>().mockResolvedValue([
+      {
+        _id: "message-2",
+        _creationTime: 20,
+        id: "visible-file",
+        chat_id: sharedChat.id,
+        user_id: sharedChat.user_id,
+        role: "assistant",
+        content: "download",
+        parts: [
+          {
+            type: "file",
+            name: "private.txt",
+            mediaType: "text/plain",
+            url: "https://secret.example/private.txt",
+          },
+        ],
+        update_time: 150,
+      },
+      {
+        _id: "message-1",
+        _creationTime: 10,
+        id: "visible-text",
+        chat_id: sharedChat.id,
+        user_id: sharedChat.user_id,
+        role: "user",
+        content: "hello",
+        parts: [{ type: "text", text: "hello" }],
+        update_time: 100,
+      },
+      {
+        _id: "message-3",
+        _creationTime: 30,
+        id: "hidden",
+        chat_id: sharedChat.id,
+        user_id: sharedChat.user_id,
+        role: "assistant",
+        parts: [{ type: "text", text: "hidden" }],
+        is_hidden: true,
+        update_time: 175,
+      },
+      {
+        _id: "message-4",
+        _creationTime: 40,
+        id: "after-share",
+        chat_id: sharedChat.id,
+        user_id: sharedChat.user_id,
+        role: "assistant",
+        parts: [{ type: "text", text: "new" }],
+        update_time: 250,
+      },
+    ]);
+    const query = jest.fn<any>((table: string) => ({
+      withIndex: jest.fn<any>().mockReturnValue(
+        table === "chats"
+          ? { first: chatFirst }
+          : {
+              order: jest.fn<any>().mockReturnValue({
+                collect: messagesCollect,
+              }),
+            },
+      ),
+    }));
+
+    await expect(
+      getSharedSnapshot.handler({ db: { query } } as any, {
+        shareId: sharedChat.share_id,
+      }),
+    ).resolves.toEqual({
+      chat: {
+        _id: sharedChat._id,
+        id: sharedChat.id,
+        title: sharedChat.title,
+        share_id: sharedChat.share_id,
+        share_date: sharedChat.share_date,
+        update_time: sharedChat.update_time,
+      },
+      messages: [
+        {
+          id: "visible-text",
+          role: "user",
+          content: "hello",
+          parts: [{ type: "text", text: "hello" }],
+          update_time: 100,
+        },
+        {
+          id: "visible-file",
+          role: "assistant",
+          content: "download",
+          parts: [{ type: "file", placeholder: true }],
+          update_time: 150,
+        },
+      ],
+    });
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query).toHaveBeenNthCalledWith(1, "chats");
+    expect(query).toHaveBeenNthCalledWith(2, "messages");
+    expect(chatFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null without reading messages when the share is unavailable", async () => {
+    const query = jest.fn<any>(() => ({
+      withIndex: jest.fn<any>().mockReturnValue({
+        first: jest.fn<any>().mockResolvedValue(null),
+      }),
+    }));
+
+    await expect(
+      getSharedSnapshot.handler({ db: { query } } as any, {
+        shareId: "11111111-1111-4111-8111-111111111111",
+      }),
+    ).resolves.toBeNull();
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledWith("chats");
+  });
+
+  it("preserves chat metadata when the message read fails", async () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const sharedChat = {
+      _id: "source-doc",
+      _creationTime: 1,
+      id: "source-1",
+      title: "Shared title",
+      user_id: "source-owner",
+      share_id: "11111111-1111-4111-8111-111111111111",
+      share_date: 200,
+      update_time: 200,
+    };
+    const query = jest.fn<any>((table: string) => ({
+      withIndex: jest.fn<any>().mockReturnValue(
+        table === "chats"
+          ? { first: jest.fn<any>().mockResolvedValue(sharedChat) }
+          : {
+              order: jest.fn<any>().mockReturnValue({
+                collect: jest
+                  .fn<any>()
+                  .mockRejectedValue(new Error("messages unavailable")),
+              }),
+            },
+      ),
+    }));
+
+    await expect(
+      getSharedSnapshot.handler({ db: { query } } as any, {
+        shareId: sharedChat.share_id,
+      }),
+    ).resolves.toEqual({
+      chat: {
+        _id: sharedChat._id,
+        id: sharedChat.id,
+        title: sharedChat.title,
+        share_id: sharedChat.share_id,
+        share_date: sharedChat.share_date,
+        update_time: sharedChat.update_time,
+      },
+      messages: [],
+    });
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to get shared messages:",
+      expect.any(Error),
+    );
+    consoleError.mockRestore();
+  });
+});
 
 describe("forkSharedChat", () => {
   it("stores the source title snapshot on the new owned fork", async () => {

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -24,6 +24,7 @@ import type * as lib_extraUsagePricing from "../lib/extraUsagePricing.js";
 import type * as lib_extraUsageValidation from "../lib/extraUsageValidation.js";
 import type * as lib_logger from "../lib/logger.js";
 import type * as lib_retainedTail from "../lib/retainedTail.js";
+import type * as lib_sharedChatSnapshot from "../lib/sharedChatSnapshot.js";
 import type * as lib_suspensionGuards from "../lib/suspensionGuards.js";
 import type * as lib_utils from "../lib/utils.js";
 import type * as localSandbox from "../localSandbox.js";
@@ -70,6 +71,7 @@ declare const fullApi: ApiFromModules<{
   "lib/extraUsageValidation": typeof lib_extraUsageValidation;
   "lib/logger": typeof lib_logger;
   "lib/retainedTail": typeof lib_retainedTail;
+  "lib/sharedChatSnapshot": typeof lib_sharedChatSnapshot;
   "lib/suspensionGuards": typeof lib_suspensionGuards;
   "lib/utils": typeof lib_utils;
   localSandbox: typeof localSandbox;

--- a/convex/lib/sharedChatSnapshot.ts
+++ b/convex/lib/sharedChatSnapshot.ts
@@ -1,0 +1,128 @@
+import type { GenericDatabaseReader } from "convex/server";
+import { v } from "convex/values";
+
+import type { DataModel, Doc } from "../_generated/dataModel";
+import { stripOpenRouterReasoningMetadataFromParts } from "../../lib/chat/provider-metadata-sanitizer";
+import { isUserBlockedByActiveFraudDispute } from "./suspensionGuards";
+
+type SharedChatReaderCtx = {
+  db: GenericDatabaseReader<DataModel>;
+};
+
+export type VisibleSharedChat = Doc<"chats"> & {
+  share_id: string;
+  share_date: number;
+};
+
+export const sharedChatValidator = v.object({
+  _id: v.id("chats"),
+  id: v.string(),
+  title: v.string(),
+  share_id: v.string(),
+  share_date: v.number(),
+  update_time: v.number(),
+});
+
+export const sharedMessageValidator = v.object({
+  id: v.string(),
+  role: v.union(v.literal("user"), v.literal("assistant"), v.literal("system")),
+  parts: v.array(v.any()),
+  content: v.optional(v.string()),
+  update_time: v.number(),
+});
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const resolveVisibleSharedChat = async (
+  ctx: SharedChatReaderCtx,
+  chat: Doc<"chats"> | null,
+): Promise<VisibleSharedChat | null> => {
+  if (!chat?.share_id || !chat.share_date) {
+    return null;
+  }
+
+  if (await isUserBlockedByActiveFraudDispute(ctx, chat.user_id)) {
+    return null;
+  }
+
+  return chat as VisibleSharedChat;
+};
+
+export const getVisibleSharedChatByShareId = async (
+  ctx: SharedChatReaderCtx,
+  shareId: string,
+): Promise<VisibleSharedChat | null> => {
+  const chat = await ctx.db
+    .query("chats")
+    .withIndex("by_share_id", (q) => q.eq("share_id", shareId))
+    .first();
+
+  return resolveVisibleSharedChat(ctx, chat);
+};
+
+export const getVisibleSharedChatByChatId = async (
+  ctx: SharedChatReaderCtx,
+  chatId: string,
+): Promise<VisibleSharedChat | null> => {
+  if (!UUID_REGEX.test(chatId)) {
+    return null;
+  }
+
+  const chat = await ctx.db
+    .query("chats")
+    .withIndex("by_chat_id", (q) => q.eq("id", chatId))
+    .first();
+
+  return resolveVisibleSharedChat(ctx, chat);
+};
+
+export const serializeSharedChat = (chat: VisibleSharedChat) => ({
+  _id: chat._id,
+  id: chat.id,
+  title: chat.title,
+  share_id: chat.share_id,
+  share_date: chat.share_date,
+  update_time: chat.update_time,
+});
+
+export const listVisibleSharedMessages = async (
+  ctx: SharedChatReaderCtx,
+  chat: VisibleSharedChat,
+) => {
+  // Preserve the existing full shared-task response contract. The query is
+  // indexed by chat ID; pagination would be a separate user-visible change.
+  const messages = await ctx.db
+    .query("messages")
+    .withIndex("by_chat_id", (q) => q.eq("chat_id", chat.id))
+    .order("asc")
+    .collect();
+
+  return messages
+    .filter(
+      (message) =>
+        message.update_time <= chat.share_date && message.is_hidden !== true,
+    )
+    .sort(
+      (a, b) =>
+        a.update_time - b.update_time || a._creationTime - b._creationTime,
+    )
+    .map((message) => ({
+      id: message.id,
+      role: message.role,
+      content: message.content,
+      update_time: message.update_time,
+      parts: stripOpenRouterReasoningMetadataFromParts(message.parts).map(
+        (part: any) => {
+          if (part.type === "file") {
+            return {
+              type: part.mediaType?.startsWith("image/") ? "image" : "file",
+              placeholder: true,
+            };
+          }
+
+          return part;
+        },
+      ),
+    }));
+};

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -15,6 +15,11 @@ import {
   assertUserCanAccessChatHistory,
   isUserBlockedByActiveFraudDispute,
 } from "./lib/suspensionGuards";
+import {
+  getVisibleSharedChatByChatId,
+  listVisibleSharedMessages,
+  sharedMessageValidator,
+} from "./lib/sharedChatSnapshot";
 import { stripOpenRouterReasoningMetadataFromParts } from "../lib/chat/provider-metadata-sanitizer";
 import {
   MAX_MESSAGE_SEARCH_QUERY_LENGTH,
@@ -2071,86 +2076,11 @@ export const regenerateWithNewContent = mutation({
  */
 export const getSharedMessages = query({
   args: { chatId: v.string() },
-  returns: v.array(
-    v.object({
-      id: v.string(),
-      role: v.union(
-        v.literal("user"),
-        v.literal("assistant"),
-        v.literal("system"),
-      ),
-      parts: v.array(v.any()),
-      content: v.optional(v.string()),
-      update_time: v.number(),
-    }),
-  ),
+  returns: v.array(sharedMessageValidator),
   handler: async (ctx, args) => {
     try {
-      // Validate UUID format
-      const UUID_REGEX =
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-      if (!UUID_REGEX.test(args.chatId)) {
-        return [];
-      }
-
-      // CRITICAL SECURITY CHECK: Verify the chat is actually shared
-      const chat = await ctx.db
-        .query("chats")
-        .withIndex("by_chat_id", (q) => q.eq("id", args.chatId))
-        .first();
-
-      // Return empty array if chat doesn't exist or isn't shared
-      if (!chat || !chat.share_id || !chat.share_date) {
-        return [];
-      }
-      if (await isUserBlockedByActiveFraudDispute(ctx, chat.user_id)) {
-        return [];
-      }
-
-      // Read the chat's messages via the existing per-chat index, then apply
-      // the frozen-share cutoff locally to avoid a production-wide backfill.
-      const messages = await ctx.db
-        .query("messages")
-        .withIndex("by_chat_id", (q) => q.eq("chat_id", args.chatId))
-        .order("asc")
-        .collect();
-
-      // FROZEN CONTENT: Exclude hidden messages (e.g. auto-continue rows).
-      const frozenMessages = messages
-        .filter(
-          (msg) =>
-            msg.update_time <= chat.share_date! && msg.is_hidden !== true,
-        )
-        .sort(
-          (a, b) =>
-            a.update_time - b.update_time || a._creationTime - b._creationTime,
-        );
-
-      // Strip sensitive data and replace files with placeholders
-      return frozenMessages.map((msg) => ({
-        id: msg.id,
-        role: msg.role,
-        content: msg.content,
-        update_time: msg.update_time,
-        // Process parts to replace files/images with placeholders
-        parts: stripOpenRouterReasoningMetadataFromParts(msg.parts).map(
-          (part: any) => {
-            // Replace file references with placeholder
-            if (part.type === "file") {
-              // Determine if it's an image based on mediaType
-              const isImage = part.mediaType?.startsWith("image/");
-              return {
-                type: isImage ? "image" : "file",
-                placeholder: true,
-                // SECURITY: Do NOT include url, file_id, name, or mediaType
-              };
-            }
-            // Keep text parts as-is
-            return part;
-          },
-        ),
-        // SECURITY: user_id is NOT included in response (anonymity)
-      }));
+      const chat = await getVisibleSharedChatByChatId(ctx, args.chatId);
+      return chat ? await listVisibleSharedMessages(ctx, chat) : [];
     } catch (error) {
       console.error("Failed to get shared messages:", error);
       // Return empty array on error (fail secure)

--- a/convex/sharedChats.ts
+++ b/convex/sharedChats.ts
@@ -6,6 +6,14 @@ import {
   isUserBlockedByActiveFraudDispute,
 } from "./lib/suspensionGuards";
 import { stripOpenRouterReasoningMetadataFromParts } from "../lib/chat/provider-metadata-sanitizer";
+import {
+  getVisibleSharedChatByShareId,
+  listVisibleSharedMessages,
+  serializeSharedChat,
+  sharedChatValidator,
+  sharedMessageValidator,
+  type VisibleSharedChat,
+} from "./lib/sharedChatSnapshot";
 
 /**
  * Share a chat by creating a public share link.
@@ -212,38 +220,51 @@ export const unshareChat = mutation({
  */
 export const getSharedChat = query({
   args: { shareId: v.string() },
+  returns: v.union(sharedChatValidator, v.null()),
+  handler: async (ctx, args) => {
+    const chat = await getVisibleSharedChatByShareId(ctx, args.shareId);
+    return chat ? serializeSharedChat(chat) : null;
+  },
+});
+
+/**
+ * Get a complete public shared-chat snapshot in one client round trip.
+ * Returns the same anonymous chat metadata and frozen messages as the legacy
+ * getSharedChat + getSharedMessages sequence.
+ */
+export const getSharedSnapshot = query({
+  args: { shareId: v.string() },
   returns: v.union(
     v.object({
-      _id: v.id("chats"),
-      id: v.string(),
-      title: v.string(),
-      share_id: v.string(),
-      share_date: v.number(),
-      update_time: v.number(),
+      chat: sharedChatValidator,
+      messages: v.array(sharedMessageValidator),
     }),
     v.null(),
   ),
   handler: async (ctx, args) => {
-    const chat = await ctx.db
-      .query("chats")
-      .withIndex("by_share_id", (q) => q.eq("share_id", args.shareId))
-      .first();
-
-    if (!chat || !chat.share_id || !chat.share_date) {
-      return null;
-    }
-    if (await isUserBlockedByActiveFraudDispute(ctx, chat.user_id)) {
+    let chat: VisibleSharedChat | null;
+    try {
+      chat = await getVisibleSharedChatByShareId(ctx, args.shareId);
+    } catch (error) {
+      console.error("Failed to get shared snapshot:", error);
       return null;
     }
 
-    // Return chat without user_id for anonymity
+    if (!chat) {
+      return null;
+    }
+
+    let messages: Awaited<ReturnType<typeof listVisibleSharedMessages>>;
+    try {
+      messages = await listVisibleSharedMessages(ctx, chat);
+    } catch (error) {
+      console.error("Failed to get shared messages:", error);
+      messages = [];
+    }
+
     return {
-      _id: chat._id,
-      id: chat.id,
-      title: chat.title,
-      share_id: chat.share_id,
-      share_date: chat.share_date,
-      update_time: chat.update_time,
+      chat: serializeSharedChat(chat),
+      messages,
     };
   },
 });


### PR DESCRIPTION
## Summary

- load public shared-task metadata and frozen messages through one Convex snapshot query instead of two dependent browser requests
- centralize the existing share visibility, suspension, freeze-cutoff, ordering, and file-sanitization behavior
- keep the legacy public queries for deployment skew and add regression coverage for privacy and failure behavior

## Measured impact

- client data requests for `/share/[shareId]`: **2 sequential queries → 1 query**
- shared-chat document lookups for the successful snapshot path: **2 → 1**
- Next analyzer `All Route Modules` for `/share/[shareId]`: **5.82 MB compressed estimated / 19.94 MB uncompressed / 1,370 modules before and after** (expected: this change removes a request waterfall rather than bundle code)

## Audit context

No dead files or tests were removed. TypeScript unused diagnostics and Knip surfaced only cosmetic callback parameters/imports or framework/manual operational entrypoints; source-reading tests inspected still protect unique auth, agent, PTY, release, or security contracts. This avoids repeating the cleanup already landed in #859, #888, and #889.

## Validation

- `corepack pnpm exec jest --runTestsByPath convex/__tests__/sharedChats.fork.test.ts 'app/share/[shareId]/__tests__/SharedMessages.test.tsx' --runInBand` — 2 suites, 20 tests passed
- post-merge focused integration run — 4 suites, 70 tests passed
- `corepack pnpm test --runInBand` — 300 suites, 2,989 tests passed on latest `origin/main`
- `corepack pnpm typecheck` — passed
- `corepack pnpm lint` — passed with 5 pre-existing warnings
- targeted ESLint for all changed source/test files — passed
- targeted Prettier check for all changed files — passed
- `corepack pnpm format:check` — blocked by 18 pre-existing formatting failures outside this diff
- `corepack pnpm next experimental-analyze --output` — completed before and after; inspected in Google Chrome

## Manual verification

Live affected-flow verification is pending because `CONVEX_AGENT_MODE=anonymous corepack pnpm exec convex dev --once` is blocked by an existing development `usage_logs` document containing legacy `total_tokens` and `usage_deduction_failed` fields that current schema rejects.

Once that development data/schema mismatch is resolved:

1. Deploy the Convex functions before the preview frontend.
2. Open an existing public shared-task URL and confirm the loading state resolves to the same frozen message history.
3. Confirm file/image parts remain anonymous placeholders with no URL, file ID, name, or media type.
4. Open an unavailable share ID and confirm the existing not-found state remains visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared chat views now load chat details and messages together in a single snapshot for faster, more consistent display.
* **Bug Fixes**
  * Improved fail-secure behavior: if shared chat data isn’t available (or message retrieval fails), the view safely shows an empty message list while preserving safe chat metadata when possible.
  * Shared conversations now consistently exclude hidden and post-share messages, and represent file attachments with safe image/file placeholders while removing sensitive reasoning details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->