### PR TITLE
Use Kimi K3 for all Kimi fallbacks

### DIFF
--- a/lib/__tests__/usage-tracker.test.ts
+++ b/lib/__tests__/usage-tracker.test.ts
@@ -710,7 +710,7 @@ describe("UsageTracker", () => {
 
       const usage = tracker.createUsageCostRecord({
         selectedModel: "agent-model-free",
-        accountingModel: "model-kimi-k2.7-code",
+        accountingModel: "model-kimi-k3",
         configuredModelId: "x-ai/grok-4.5",
         rateLimitInfo: {
           remaining: 1000,
@@ -721,8 +721,8 @@ describe("UsageTracker", () => {
       });
 
       expect(usage.model).toBe("auto");
-      expect(usage.modelCostDollars).toBe(4.95);
-      expect(usage.costDollars).toBe(4.95);
+      expect(usage.modelCostDollars).toBe(18);
+      expect(usage.costDollars).toBe(18);
       expect(usage.costSource).toBe("raw_token_estimate");
     });
 
@@ -735,7 +735,7 @@ describe("UsageTracker", () => {
 
       const usage = tracker.createUsageCostRecord({
         selectedModel: "agent-model-free",
-        accountingModel: "model-kimi-k2.7-code",
+        accountingModel: "model-kimi-k3",
         configuredModelId: "x-ai/grok-4.5",
         rateLimitInfo: {
           remaining: 1000,
@@ -803,7 +803,7 @@ describe("UsageTracker", () => {
 
       const usage = tracker.createUsageCostRecord({
         selectedModel: "agent-model-free",
-        accountingModel: "model-kimi-k2.7-code",
+        accountingModel: "model-kimi-k3",
         configuredModelId: "x-ai/grok-4.5",
         rateLimitInfo: {
           remaining: 1000,

--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -48,6 +48,10 @@ describe("provider registry", () => {
       ).modelId,
     ).toBe("moonshotai/kimi-k2.7-code:exacto");
     expect(
+      (myProvider.languageModel("model-kimi-k3") as { modelId: string })
+        .modelId,
+    ).toBe("moonshotai/kimi-k3");
+    expect(
       (myProvider.languageModel("fallback-agent-model") as { modelId: string })
         .modelId,
     ).toBe("x-ai/grok-4.5");
@@ -63,6 +67,7 @@ describe("provider registry", () => {
     expect(getModelDisplayName("model-grok-4.5")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-grok-4.5-pro")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-glm-5.2")).toBe("Z.ai GLM 5.2");
+    expect(getModelDisplayName("model-kimi-k3")).toBe("Moonshot Kimi K3");
     expect(getModelDisplayName("model-gemini-3-flash")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("title-generator-model")).toBe(
       "DeepSeek V4 Flash",
@@ -206,6 +211,7 @@ describe("supportsMultimodalToolResults", () => {
     expect(supportsMultimodalToolResults("model-minimax-m3")).toBe(true);
     expect(supportsMultimodalToolResults("fallback-agent-model")).toBe(true);
     expect(supportsMultimodalToolResults("fallback-ask-model")).toBe(true);
+    expect(supportsMultimodalToolResults("model-kimi-k3")).toBe(true);
     expect(supportsMultimodalToolResults("model-kimi-k2.7-code")).toBe(true);
     expect(
       supportsMultimodalToolResults("moonshotai/kimi-k2.7-code:exacto"),

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -235,7 +235,6 @@ export const modelCutoffDates: Record<ModelName, string> &
   "model-opus-4.6": "May 2025",
   "model-glm-5.2": "June 2026",
   "model-minimax-m3": "July 2026",
-  "model-kimi-k3": "July 2026",
   "model-kimi-k2.7-code": "June 2025",
   "model-kimi-k2.6": "June 2025",
   "fallback-agent-model": "July 2026",

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -178,6 +178,7 @@ const openrouter = createOpenRouter({
 type OpenRouterInstance = typeof openrouter;
 
 export const KIMI_K2_7_CODE_SLUG = "moonshotai/kimi-k2.7-code:exacto";
+export const KIMI_K3_SLUG = "moonshotai/kimi-k3";
 export const GLM_5_2_SLUG = "z-ai/glm-5.2";
 export const GROK_4_5_SLUG = "x-ai/grok-4.5";
 export const DEEPSEEK_V4_FLASH_SLUG = "deepseek/deepseek-v4-flash";
@@ -203,6 +204,7 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     // Compatibility alias for persisted MiniMax selections. All new and stale
     // callers now resolve to Grok 4.5 so no route continues sending MiniMax.
     "model-minimax-m3": or(GROK_4_5_SLUG),
+    "model-kimi-k3": or(KIMI_K3_SLUG),
     "model-kimi-k2.7-code": or(KIMI_K2_7_CODE_SLUG),
     // Compatibility alias for stale internal references persisted before the
     // Kimi 2.7 Code rollout. New Agent Standard media selections use Grok 4.5.
@@ -233,6 +235,7 @@ export const modelCutoffDates: Record<ModelName, string> &
   "model-opus-4.6": "May 2025",
   "model-glm-5.2": "June 2026",
   "model-minimax-m3": "July 2026",
+  "model-kimi-k3": "July 2026",
   "model-kimi-k2.7-code": "June 2025",
   "model-kimi-k2.6": "June 2025",
   "fallback-agent-model": "July 2026",
@@ -256,6 +259,7 @@ export const modelDisplayNames: Record<ModelName, string> &
   "model-opus-4.6": "Anthropic Claude Opus 4.6",
   "model-glm-5.2": "Z.ai GLM 5.2",
   "model-minimax-m3": "xAI Grok 4.5",
+  "model-kimi-k3": "Moonshot Kimi K3",
   "model-kimi-k2.7-code": "Moonshot Kimi K2.7 Code",
   "model-kimi-k2.6": "Moonshot Kimi K2.7 Code",
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -24,7 +24,7 @@ jest.mock("@/lib/logger", () => ({
 // Slugs the test asserts against. These match the registry in lib/ai/providers.ts.
 // If the registry slug for a model changes, update both places intentionally.
 const GROK_SLUG = "x-ai/grok-4.5";
-const KIMI_SLUG = "moonshotai/kimi-k2.7-code:exacto";
+const KIMI_K3_SLUG = "moonshotai/kimi-k3";
 const GLM_SLUG = "z-ai/glm-5.2";
 const DEEPSEEK_FLASH_SLUG = "deepseek/deepseek-v4-flash";
 const GROK_PRIMARY_OR_FALLBACK_MODELS = [
@@ -41,6 +41,7 @@ const GROK_PRIMARY_OR_FALLBACK_MODELS = [
   "model-opus-4.6",
   "model-glm-5.2",
   "model-minimax-m3",
+  "model-kimi-k3",
   "model-kimi-k2.7-code",
   "model-kimi-k2.6",
   "fallback-agent-model",
@@ -89,7 +90,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("resolves Opus 4.6 text-only agent chain to Grok then Kimi 2.7 Code", () => {
+  it("resolves Opus 4.6 text-only agent chain to Grok then Kimi K3", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -97,12 +98,12 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [GROK_SLUG, KIMI_SLUG],
+      models: [GROK_SLUG, KIMI_K3_SLUG],
       user: "user-1",
     });
   });
 
-  it("resolves Opus 4.6 multimodal agent chain to Kimi 2.7 Code then Grok", () => {
+  it("resolves Opus 4.6 multimodal agent chain to Kimi K3 then Grok", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -111,7 +112,7 @@ describe("buildProviderOptions fallback chain", () => {
       { hasMultimodalToolResults: true },
     );
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG, GROK_SLUG],
+      models: [KIMI_K3_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
@@ -129,7 +130,7 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("resolves Sonnet 4.6 text-only agent chain to Grok then Kimi 2.7 Code", () => {
+  it("resolves Sonnet 4.6 text-only agent chain to Grok then Kimi K3", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -137,12 +138,12 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [GROK_SLUG, KIMI_SLUG],
+      models: [GROK_SLUG, KIMI_K3_SLUG],
       user: "user-1",
     });
   });
 
-  it("resolves Sonnet 4.6 multimodal agent chain to Kimi 2.7 Code then Grok", () => {
+  it("resolves Sonnet 4.6 multimodal agent chain to Kimi K3 then Grok", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -151,12 +152,12 @@ describe("buildProviderOptions fallback chain", () => {
       { hasMultimodalToolResults: true },
     );
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG, GROK_SLUG],
+      models: [KIMI_K3_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
 
-  it("resolves GLM 5.2 to Kimi 2.7 Code then Grok", () => {
+  it("resolves GLM 5.2 to Kimi K3 then Grok", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -164,12 +165,12 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG, GROK_SLUG],
+      models: [KIMI_K3_SLUG, GROK_SLUG],
       user: "user-1",
     });
   });
 
-  it("keeps Anthropic multimodal agent fallback on Kimi then Grok", () => {
+  it("keeps Anthropic multimodal agent fallback on Kimi K3 then Grok", () => {
     const opus = buildProviderOptions(
       false,
       "user-1",
@@ -187,19 +188,19 @@ describe("buildProviderOptions fallback chain", () => {
       { hasMultimodalToolResults: true },
     );
 
-    expect(opus.openrouter.models).toEqual([KIMI_SLUG, GROK_SLUG]);
-    expect(sonnet.openrouter.models).toEqual([KIMI_SLUG, GROK_SLUG]);
+    expect(opus.openrouter.models).toEqual([KIMI_K3_SLUG, GROK_SLUG]);
+    expect(sonnet.openrouter.models).toEqual([KIMI_K3_SLUG, GROK_SLUG]);
   });
 
-  it("falls back from the Grok-backed auto agent route to Kimi 2.7 Code", () => {
+  it("falls back from the Grok-backed auto agent route to Kimi K3", () => {
     const opts = buildProviderOptions(false, "user-1", "agent-model", "agent");
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG],
+      models: [KIMI_K3_SLUG],
       user: "user-1",
     });
   });
 
-  it("keeps the stale MiniMax key on Grok's Kimi fallback", () => {
+  it("keeps the stale MiniMax key on Grok's Kimi K3 fallback", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -207,7 +208,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG],
+      models: [KIMI_K3_SLUG],
       user: "user-1",
     });
   });
@@ -226,7 +227,7 @@ describe("buildProviderOptions fallback chain", () => {
   });
 
   it.each(["ask", "agent"] as const)(
-    "falls back from HackerAI Pro Grok 4.5 to GLM 5.2 then Kimi in %s mode",
+    "falls back from HackerAI Pro Grok 4.5 to GLM 5.2 then Kimi K3 in %s mode",
     (mode) => {
       const opts = buildProviderOptions(
         mode === "agent",
@@ -236,13 +237,13 @@ describe("buildProviderOptions fallback chain", () => {
       );
       expect(opts.openrouter).toMatchObject({
         reasoning: { enabled: true, effort: "high" },
-        models: [GLM_SLUG, KIMI_SLUG],
+        models: [GLM_SLUG, KIMI_K3_SLUG],
         user: "user-1",
       });
     },
   );
 
-  it("keeps the legacy Agent vision Grok route on its direct Kimi fallback", () => {
+  it("keeps the legacy Agent vision Grok route on its direct Kimi K3 fallback", () => {
     const opts = buildProviderOptions(
       true,
       "user-1",
@@ -250,7 +251,7 @@ describe("buildProviderOptions fallback chain", () => {
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG],
+      models: [KIMI_K3_SLUG],
       user: "user-1",
     });
   });
@@ -259,17 +260,17 @@ describe("buildProviderOptions fallback chain", () => {
     ["ask-model-free", "ask"],
     ["model-deepseek-v4-flash", "ask"],
   ] as const)(
-    "falls back from free DeepSeek route %s through the paid Agent chain with Kimi 2.7 Code",
+    "falls back from free DeepSeek route %s through the paid Agent chain with Kimi K3",
     (modelName, mode) => {
       const opts = buildProviderOptions(false, "user-1", modelName, mode);
       expect(opts.openrouter).toMatchObject({
-        models: [GROK_SLUG, KIMI_SLUG],
+        models: [GROK_SLUG, KIMI_K3_SLUG],
         user: "user-1",
       });
     },
   );
 
-  it("runs free Agent on DeepSeek Flash high and falls back through Grok then Kimi", () => {
+  it("runs free Agent on DeepSeek Flash high and falls back through Grok then Kimi K3", () => {
     const opts = buildProviderOptions(
       true,
       "user-1",
@@ -278,12 +279,12 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(opts.openrouter).toMatchObject({
       reasoning: { enabled: true, effort: "high" },
-      models: [GROK_SLUG, KIMI_SLUG],
+      models: [GROK_SLUG, KIMI_K3_SLUG],
       user: "user-1",
     });
   });
 
-  it("falls back from explicit DeepSeek Pro ask model through Grok then Kimi", () => {
+  it("falls back from explicit DeepSeek Pro ask model through Grok then Kimi K3", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
@@ -291,24 +292,24 @@ describe("buildProviderOptions fallback chain", () => {
       "ask",
     );
     expect(opts.openrouter).toMatchObject({
-      models: [GROK_SLUG, KIMI_SLUG],
+      models: [GROK_SLUG, KIMI_K3_SLUG],
       user: "user-1",
     });
   });
 
-  it("falls back from the Grok-backed paid Ask image route to Kimi", () => {
+  it("falls back from the Grok-backed paid Ask image route to Kimi K3", () => {
     const opts = buildProviderOptions(false, "user-1", "ask-model", "ask");
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG],
+      models: [KIMI_K3_SLUG],
       user: "user-1",
     });
   });
 
-  it("falls back from paid Ask PDF Grok route to Kimi", () => {
+  it("falls back from paid Ask PDF Grok route to Kimi K3", () => {
     const opts = buildProviderOptions(false, "user-1", "model-grok-4.5", "ask");
     expect(opts.openrouter).toMatchObject({
       reasoning: { enabled: true, effort: "high" },
-      models: [KIMI_SLUG],
+      models: [KIMI_K3_SLUG],
       user: "user-1",
     });
   });
@@ -316,7 +317,7 @@ describe("buildProviderOptions fallback chain", () => {
   it("keeps the stale media route alias on the active Ask fallback chain", () => {
     const opts = buildProviderOptions(false, "user-1", "model-gemini-3-flash");
     expect(opts.openrouter).toMatchObject({
-      models: [KIMI_SLUG],
+      models: [KIMI_K3_SLUG],
       user: "user-1",
     });
   });
@@ -360,7 +361,7 @@ describe("buildProviderOptions fallback chain", () => {
       enabled: true,
       effort: "high",
     });
-    expect(opts.openrouter.models).toEqual([GROK_SLUG, KIMI_SLUG]);
+    expect(opts.openrouter.models).toEqual([GROK_SLUG, KIMI_K3_SLUG]);
   });
 
   it("allows a scoped reasoning override when Grok is not in the route", () => {
@@ -473,7 +474,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(reasoning.openrouter).toMatchObject({
       reasoning: { enabled: true, effort: "high" },
-      models: [GROK_SLUG, KIMI_SLUG],
+      models: [GROK_SLUG, KIMI_K3_SLUG],
     });
 
     const grokReasoning = buildProviderOptions(
@@ -484,7 +485,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(grokReasoning.openrouter).toMatchObject({
       reasoning: { enabled: true, effort: "high" },
-      models: [KIMI_SLUG],
+      models: [KIMI_K3_SLUG],
     });
 
     const multimodal = buildProviderOptions(
@@ -496,7 +497,7 @@ describe("buildProviderOptions fallback chain", () => {
     );
     expect(multimodal.openrouter).toMatchObject({
       reasoning: { enabled: true, effort: "high" },
-      models: [KIMI_SLUG, GROK_SLUG],
+      models: [KIMI_K3_SLUG, GROK_SLUG],
     });
   });
 });
@@ -561,10 +562,8 @@ describe("getRetryFallbackModel", () => {
     );
   });
 
-  it("retries the Grok-backed paid Ask image route with Kimi", () => {
-    expect(getRetryFallbackModel("ask-model", "ask")).toBe(
-      "model-kimi-k2.7-code",
-    );
+  it("retries the Grok-backed paid Ask image route with Kimi K3", () => {
+    expect(getRetryFallbackModel("ask-model", "ask")).toBe("model-kimi-k3");
   });
 
   it("retries HackerAI Pro Grok with GLM 5.2", () => {
@@ -576,9 +575,9 @@ describe("getRetryFallbackModel", () => {
     );
   });
 
-  it("retries the legacy Agent vision Grok route with Kimi 2.7 Code", () => {
+  it("retries the legacy Agent vision Grok route with Kimi K3", () => {
     expect(getRetryFallbackModel("model-grok-4.5", "agent")).toBe(
-      "model-kimi-k2.7-code",
+      "model-kimi-k3",
     );
   });
 
@@ -592,11 +591,9 @@ describe("getRetryFallbackModel", () => {
     ["model-grok-4.5", "ask"],
     ["model-gemini-3-flash", "ask"],
   ] as const)(
-    "retries Grok-backed paid Ask route %s with Kimi",
+    "retries Grok-backed paid Ask route %s with Kimi K3",
     (modelName, mode) => {
-      expect(getRetryFallbackModel(modelName, mode)).toBe(
-        "model-kimi-k2.7-code",
-      );
+      expect(getRetryFallbackModel(modelName, mode)).toBe("model-kimi-k3");
     },
   );
 });
@@ -622,14 +619,14 @@ describe("resolveServedModelForCostAccounting", () => {
     ).toBe("model-grok-4.5");
   });
 
-  it("maps a Kimi provider slug served from free Agent fallback back to the local cost key", () => {
+  it("maps a Kimi K3 slug served from free Agent fallback back to the local cost key", () => {
     expect(
       resolveServedModelForCostAccounting({
         modelName: "agent-model-free",
-        responseModel: KIMI_SLUG,
+        responseModel: KIMI_K3_SLUG,
         mode: "agent",
       }),
-    ).toBe("model-kimi-k2.7-code");
+    ).toBe("model-kimi-k3");
   });
 
   it("maps a direct Grok provider slug back to the Grok 4.5 cost key", () => {
@@ -640,6 +637,16 @@ describe("resolveServedModelForCostAccounting", () => {
         mode: "ask",
       }),
     ).toBe("model-grok-4.5");
+  });
+
+  it("maps the dated Kimi K3 provider slug back to the Kimi K3 cost key", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "model-does-not-exist",
+        responseModel: "moonshotai/kimi-k3-20260715",
+        mode: "agent",
+      }),
+    ).toBe("model-kimi-k3");
   });
 
   it("maps HackerAI Pro primary and fallback usage to their exact cost keys", () => {
@@ -660,20 +667,20 @@ describe("resolveServedModelForCostAccounting", () => {
     expect(
       resolveServedModelForCostAccounting({
         modelName: "model-grok-4.5-pro",
-        responseModel: KIMI_SLUG,
+        responseModel: KIMI_K3_SLUG,
         mode: "agent",
       }),
-    ).toBe("model-kimi-k2.7-code");
+    ).toBe("model-kimi-k3");
   });
 
-  it("maps legacy Agent Pro vision Kimi fallback usage back to the Kimi cost key", () => {
+  it("maps legacy Agent Pro vision Kimi K3 fallback usage back to the Kimi K3 cost key", () => {
     expect(
       resolveServedModelForCostAccounting({
         modelName: "model-grok-4.5",
-        responseModel: KIMI_SLUG,
+        responseModel: KIMI_K3_SLUG,
         mode: "agent",
       }),
-    ).toBe("model-kimi-k2.7-code");
+    ).toBe("model-kimi-k3");
   });
 
   it("maps dated Opus provider response slugs back to the local cost key", () => {

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -520,7 +520,7 @@ export class SummarizationTracker {
  * model's rate (response.modelId reflects what actually ran).
  *
  * Claude chats are repaired for Anthropic-compatible message shapes before
- * this fallback can fire. Claude agent calls use Grok and Kimi fallbacks while
+ * this fallback can fire. Claude agent calls use Grok and Kimi K3 fallbacks while
  * the run is text-only, then switch to multimodal-capable fallbacks once image
  * tool results enter the context.
  *
@@ -528,26 +528,26 @@ export class SummarizationTracker {
  * OpenRouter slugs are resolved at request-build time so this stays in sync
  * with the registry.
  */
-const KIMI_THEN_GROK_FALLBACK_CHAIN = [
-  "model-kimi-k2.7-code",
+const KIMI_K3_THEN_GROK_FALLBACK_CHAIN = [
+  "model-kimi-k3",
   "fallback-grok-4.5",
 ] as const satisfies readonly ModelName[];
 
 const GROK_4_5_FALLBACK_CHAIN = [
-  "model-kimi-k2.7-code",
+  "model-kimi-k3",
 ] as const satisfies readonly ModelName[];
 
 const AGENT_TEXT_FALLBACK_CHAIN = [
   "model-grok-4.5",
-  "model-kimi-k2.7-code",
+  "model-kimi-k3",
 ] as const satisfies readonly ModelName[];
 
 // HackerAI Pro uses Grok 4.5 for every request. GLM 5.2 remains its first
-// fallback, followed by Kimi so media requests still have a multimodal final
+// fallback, followed by Kimi K3 so media requests still have a multimodal final
 // recovery path if both primary providers are unavailable.
 const HACKERAI_PRO_FALLBACK_CHAIN = [
   "model-glm-5.2",
-  "model-kimi-k2.7-code",
+  "model-kimi-k3",
 ] as const satisfies readonly ModelName[];
 
 const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
@@ -560,10 +560,11 @@ const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "model-grok-4.5": GROK_4_5_FALLBACK_CHAIN,
   "model-grok-4.5-pro": HACKERAI_PRO_FALLBACK_CHAIN,
   "model-gemini-3-flash": GROK_4_5_FALLBACK_CHAIN,
-  "model-glm-5.2": KIMI_THEN_GROK_FALLBACK_CHAIN,
+  "model-glm-5.2": KIMI_K3_THEN_GROK_FALLBACK_CHAIN,
   "model-minimax-m3": GROK_4_5_FALLBACK_CHAIN,
   "fallback-agent-model": GROK_4_5_FALLBACK_CHAIN,
   "fallback-ask-model": GROK_4_5_FALLBACK_CHAIN,
+  "model-kimi-k3": ["fallback-grok-4.5"],
   "model-kimi-k2.7-code": ["fallback-grok-4.5"],
   "model-kimi-k2.6": ["fallback-grok-4.5"],
 };
@@ -595,7 +596,8 @@ const ANTHROPIC_FALLBACK_CHAIN_BY_MODE: Record<ChatMode, readonly ModelName[]> =
     ask: ["model-grok-4.5"],
   };
 
-const ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN = KIMI_THEN_GROK_FALLBACK_CHAIN;
+const ANTHROPIC_MULTIMODAL_AGENT_FALLBACK_CHAIN =
+  KIMI_K3_THEN_GROK_FALLBACK_CHAIN;
 
 const HIGH_REASONING_MODELS = [
   "model-grok-4.5-pro",
@@ -667,7 +669,7 @@ export function getRetryFallbackModel(
     modelName === "fallback-agent-model" ||
     modelName === "fallback-ask-model"
   ) {
-    return "model-kimi-k2.7-code";
+    return "model-kimi-k3";
   }
   return "fallback-grok-4.5";
 }
@@ -710,6 +712,8 @@ const OPENROUTER_RESPONSE_MODEL_COST_KEYS: Record<string, ModelName> = {
   "x-ai/grok-4.5": "model-grok-4.5",
   "z-ai/glm-5.2": "model-glm-5.2",
   "z-ai/glm-5.2-20260616": "model-glm-5.2",
+  "moonshotai/kimi-k3": "model-kimi-k3",
+  "moonshotai/kimi-k3-20260715": "model-kimi-k3",
   "moonshotai/kimi-k2.7-code": "model-kimi-k2.7-code",
   "moonshotai/kimi-k2.7-code:exacto": "model-kimi-k2.7-code",
 };

--- a/lib/chat/summarization/__tests__/index.test.ts
+++ b/lib/chat/summarization/__tests__/index.test.ts
@@ -40,7 +40,7 @@ jest.doMock("@/lib/db/actions", () => ({
 }));
 jest.doMock("@/lib/ai/providers", () => ({
   GROK_4_5_SLUG: "x-ai/grok-4.5",
-  KIMI_K2_7_CODE_SLUG: "moonshotai/kimi-k2.7-code:exacto",
+  KIMI_K3_SLUG: "moonshotai/kimi-k3",
   myProvider: {
     languageModel: mockProviderLanguageModel,
   },
@@ -948,7 +948,7 @@ describe("checkAndSummarizeIfNeeded", () => {
         openrouter: {
           user: "user_123",
           reasoning: { enabled: false },
-          models: ["x-ai/grok-4.5", "moonshotai/kimi-k2.7-code:exacto"],
+          models: ["x-ai/grok-4.5", "moonshotai/kimi-k3"],
         },
       },
     );
@@ -967,7 +967,7 @@ describe("checkAndSummarizeIfNeeded", () => {
       openrouter: {
         user: "user_123",
         reasoning: { enabled: true, effort: "high" },
-        models: ["moonshotai/kimi-k2.7-code:exacto"],
+        models: ["moonshotai/kimi-k3"],
       },
     });
 

--- a/lib/chat/summarization/index.ts
+++ b/lib/chat/summarization/index.ts
@@ -17,7 +17,7 @@ import {
 } from "@/lib/utils/stream-writer-utils";
 import { isE2BSandbox } from "@/lib/ai/tools/utils/sandbox-types";
 import type { Id } from "@/convex/_generated/dataModel";
-import { KIMI_K2_7_CODE_SLUG, myProvider } from "@/lib/ai/providers";
+import { KIMI_K3_SLUG, myProvider } from "@/lib/ai/providers";
 import type { ProviderPromptPressure } from "./provider-pressure";
 
 import {
@@ -55,7 +55,7 @@ const SUMMARIZATION_RETRY_MODEL_BY_MODE: Record<ChatMode, string> = {
   ask: "fallback-ask-model",
   agent: "fallback-agent-model",
 };
-const SUMMARIZATION_RETRY_FALLBACK_MODEL_SLUGS = [KIMI_K2_7_CODE_SLUG] as const;
+const SUMMARIZATION_RETRY_FALLBACK_MODEL_SLUGS = [KIMI_K3_SLUG] as const;
 const SUMMARIZATION_ATTEMPT_ERROR_KEY = "__hackeraiSummarizationAttempt";
 
 const getLanguageModelId = (

--- a/lib/rate-limit/__tests__/token-bucket.integration.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.integration.test.ts
@@ -926,10 +926,10 @@ describe("token-bucket async functions", () => {
       const { deductUsage, calculateTokenCost } = getIsolatedModule();
 
       const estimatedInputTokens = 1_000_000;
-      const actualInputTokens = 1_000_000;
-      const actualOutputTokens = 1_000_000;
+      const actualInputTokens = 300_000;
+      const actualOutputTokens = 300_000;
       const selectedModel = "agent-model-free";
-      const servedModel = "model-kimi-k2.7-code";
+      const servedModel = "model-kimi-k3";
       const initialDeduction = calculateTokenCost(
         estimatedInputTokens,
         "input",
@@ -969,7 +969,7 @@ describe("token-bucket async functions", () => {
         servedModel,
       );
 
-      expect(expectedAdditional).toBe(68_040);
+      expect(expectedAdditional).toBe(74_340);
       expect(mockLimitFn).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ rate: expectedAdditional }),
@@ -988,7 +988,7 @@ describe("token-bucket async functions", () => {
 
       const estimatedInputTokens = 1_000_000;
       const selectedModel = "agent-model-free";
-      const servedModel = "model-kimi-k2.7-code";
+      const servedModel = "model-kimi-k3";
       const providerCostDollars = 0.42;
       const initialDeduction = calculateTokenCost(
         estimatedInputTokens,

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -105,6 +105,17 @@ describe("token-bucket", () => {
       ).toBeCloseTo(1.4);
     });
 
+    it("prices Kimi K3 cached input at OpenRouter's $0.30/M rate", () => {
+      expect(
+        calculateRawModelUsageCostDollars({
+          inputTokens: 1_000_000,
+          outputTokens: 100_000,
+          cacheReadTokens: 800_000,
+          modelName: "moonshotai/kimi-k3-20260715",
+        }),
+      ).toBeCloseTo(2.34);
+    });
+
     it("recognizes dated Anthropic response model IDs", () => {
       expect(
         calculateRawModelUsageCostDollars({
@@ -464,6 +475,15 @@ describe("token-bucket", () => {
       );
       expect(calculateTokenCost(1_000_000, "output", "model-glm-5.2")).toBe(
         33880,
+      );
+    });
+
+    it("should use Kimi K3 pricing ($3.00/$15.00)", () => {
+      expect(calculateTokenCost(1_000_000, "input", "model-kimi-k3")).toBe(
+        42000,
+      );
+      expect(calculateTokenCost(1_000_000, "output", "model-kimi-k3")).toBe(
+        210000,
       );
     });
 

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -81,6 +81,12 @@ const KIMI_K2_7_CODE_PRICING: ModelPricing = {
   cacheRead: 0.19,
   cacheWrite: 0.95,
 };
+const KIMI_K3_PRICING: ModelPricing = {
+  input: 3.0,
+  output: 15.0,
+  cacheRead: 0.3,
+  cacheWrite: 3.0,
+};
 
 /** Model pricing: $/1M tokens per model, including provider cache rates. */
 const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
@@ -105,6 +111,8 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "model-opus-4.6": OPUS_4_6_PRICING,
   // Baseline OpenRouter rates: $0.76 in / $2.42 out per 1M tokens.
   "model-glm-5.2": GLM_5_2_PRICING,
+  // OpenRouter rates: $3.00 in / $15.00 out / $0.30 cached input per 1M tokens.
+  "model-kimi-k3": KIMI_K3_PRICING,
   // Kimi keys are retained as compatibility aliases for stale persisted routes.
   // Rates from OpenRouter: $0.95 in / $4.00 out per 1M tokens.
   "model-kimi-k2.7-code": KIMI_K2_7_CODE_PRICING,
@@ -118,6 +126,8 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "anthropic/claude-opus-4.6": OPUS_4_6_PRICING,
   "z-ai/glm-5.2": GLM_5_2_PRICING,
   "z-ai/glm-5.2-20260616": GLM_5_2_PRICING,
+  "moonshotai/kimi-k3": KIMI_K3_PRICING,
+  "moonshotai/kimi-k3-20260715": KIMI_K3_PRICING,
   "moonshotai/kimi-k2.7-code": KIMI_K2_7_CODE_PRICING,
   "moonshotai/kimi-k2.7-code:exacto": KIMI_K2_7_CODE_PRICING,
 };


### PR DESCRIPTION
## Summary

- add `moonshotai/kimi-k3` to the provider registry and route every active Kimi fallback through it
- update OpenRouter fallback lists, app-level retry selection, and summarization retry from Kimi 2.7 Code to Kimi K3
- preserve Kimi 2.7/2.6 keys only as compatibility aliases for stale or explicit legacy routes
- account for Kimi K3 at OpenRouter's current $3.00/M input, $15.00/M output, and $0.30/M cached-input rates, including its dated response ID

Upstream metadata: https://openrouter.ai/moonshotai/kimi-k3

## Impact

Grok, GLM, DeepSeek, Anthropic multimodal, HackerAI Pro, and summarization recovery paths now use Kimi K3 whenever they reach the Kimi fallback leg. Usage settlement and analytics resolve the served Kimi K3 model to the matching price instead of falling back to default pricing.

## Validation

- `pnpm exec jest --runInBand lib/ai/__tests__/providers.test.ts lib/api/__tests__/chat-stream-helpers-fallback.test.ts lib/chat/summarization/__tests__/index.test.ts lib/rate-limit/__tests__/token-bucket.test.ts lib/rate-limit/__tests__/token-bucket.integration.test.ts lib/__tests__/usage-tracker.test.ts` — 6 suites, 330 tests passed
- commit hook `pnpm test` — 300 suites, 2,986 tests passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed with five pre-existing warnings in unrelated UI files
- targeted Prettier check — passed

## Manual verification

1. In staging, exercise or fault-inject any route whose fallback list previously ended in Kimi 2.7 Code.
2. Confirm the outgoing OpenRouter `models` list contains `moonshotai/kimi-k3` in the same fallback position.
3. If Kimi K3 serves the request, confirm usage accounting records the Kimi K3 model and its $3/$15 token rates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the Moonshot Kimi K3 model, including provider routing, display naming, multimodal tool support, and model metadata.
- **Bug Fixes**
  - Updated chat fallback and automatic retry chains to prefer Kimi K3 over the prior Kimi 2.7 Code.
  - Improved served-fallback cost accounting and model mapping for Kimi K3, including dated provider variants.
  - Added/updated Kimi K3 token pricing for standard, cached-input, and output usage calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->