### PR TITLE
Track E2B CPU saturation in PostHog

### DIFF
--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -40,6 +40,7 @@ import { BackgroundProcessTracker } from "./utils/background-process-tracker";
 import { ptySessionManager } from "./utils/pty-session-manager";
 import { isE2BSandbox } from "./utils/sandbox-types";
 import { getSandboxWithFallbackGuard } from "./utils/sandbox-fallback";
+import { createE2BCpuSaturationObserver } from "@/lib/analytics/sandbox-resource-pressure";
 
 export { isE2BSandbox };
 
@@ -112,6 +113,12 @@ export const createTools = (
   const todoManager = new TodoManager(initialTodos);
   const fileAccumulator = new FileAccumulator();
   const backgroundProcessTracker = new BackgroundProcessTracker();
+  const onSandboxResourceMetrics = createE2BCpuSaturationObserver({
+    userId: userID,
+    chatId,
+    mode,
+    subscription,
+  });
 
   const context: ToolContext = {
     sandboxManager,
@@ -134,6 +141,7 @@ export const createTools = (
     onToolFailure,
     requestToolApproval,
     measureAgentActiveTime,
+    onSandboxResourceMetrics,
   };
 
   const buildTools = (): ToolSet => {

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -346,7 +346,12 @@ export const createRunTerminalCmd = (context: ToolContext) => {
         // (they relay commands through Convex and have their own connectivity)
         if (isE2BSandbox(sandbox)) {
           try {
-            await waitForSandboxReady(sandbox, 5, abortSignal);
+            await waitForSandboxReady(
+              sandbox,
+              5,
+              abortSignal,
+              context.onSandboxResourceMetrics,
+            );
             sandboxManager.resetHealthFailures();
           } catch (healthError) {
             // If aborted, don't retry - propagate the abort
@@ -389,7 +394,12 @@ export const createRunTerminalCmd = (context: ToolContext) => {
 
               // Verify the fresh sandbox is ready
               try {
-                await waitForSandboxReady(freshSandbox, 5, abortSignal);
+                await waitForSandboxReady(
+                  freshSandbox,
+                  5,
+                  abortSignal,
+                  context.onSandboxResourceMetrics,
+                );
                 sandboxManager.resetHealthFailures();
               } catch (freshHealthError) {
                 if (

--- a/lib/ai/tools/utils/__tests__/sandbox-health.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-health.test.ts
@@ -1,0 +1,67 @@
+jest.mock("@e2b/code-interpreter", () => {
+  class MockE2BError extends Error {}
+  return {
+    AuthenticationError: MockE2BError,
+    CommandExitError: MockE2BError,
+    InvalidArgumentError: MockE2BError,
+    NotEnoughSpaceError: MockE2BError,
+    NotFoundError: MockE2BError,
+    RateLimitError: MockE2BError,
+    SandboxError: MockE2BError,
+    TemplateError: MockE2BError,
+    TimeoutError: MockE2BError,
+  };
+});
+
+jest.mock("@/lib/posthog/worker", () => ({
+  createRetryLogger: () => jest.fn(),
+}));
+
+import type { AnySandbox } from "@/types";
+import { waitForSandboxReady } from "../sandbox-health";
+
+const makeE2BSandbox = () =>
+  ({
+    isRunning: jest.fn(async () => true),
+    getMetrics: jest.fn(async () => [
+      {
+        cpuUsedPct: 100,
+        memUsed: 768,
+        memTotal: 1024,
+        diskUsed: 250,
+        diskTotal: 1000,
+      },
+    ]),
+    commands: {
+      run: jest.fn(async () => ({
+        stdout: "ready\n",
+        stderr: "",
+        exitCode: 0,
+      })),
+    },
+  }) as unknown as AnySandbox;
+
+describe("sandbox health resource observations", () => {
+  test("reports metrics already fetched by the pre-command health check", async () => {
+    const sandbox = makeE2BSandbox();
+    const onResourceMetrics = jest.fn();
+
+    await waitForSandboxReady(sandbox, 1, undefined, onResourceMetrics);
+
+    expect(onResourceMetrics).toHaveBeenCalledWith({
+      cpuPct: 100,
+      memPct: 75,
+      diskPct: 25,
+    });
+  });
+
+  test("does not let an analytics observer break sandbox execution", async () => {
+    const sandbox = makeE2BSandbox();
+
+    await expect(
+      waitForSandboxReady(sandbox, 1, undefined, () => {
+        throw new Error("analytics unavailable");
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/lib/ai/tools/utils/sandbox-health.ts
+++ b/lib/ai/tools/utils/sandbox-health.ts
@@ -1,4 +1,8 @@
-import type { AnySandbox } from "@/types";
+import type {
+  AnySandbox,
+  SandboxResourceMetrics,
+  SandboxResourceMetricsObserver,
+} from "@/types";
 import { createRetryLogger } from "@/lib/posthog/worker";
 import { isE2BSandbox } from "./sandbox-types";
 import { retryWithBackoff } from "./retry-with-backoff";
@@ -17,12 +21,9 @@ const MEM_WARNING_THRESHOLD = 90; // percentage
  * Check sandbox resource metrics and return a diagnostic summary.
  * Returns null if metrics are unavailable (non-E2B sandbox or API error).
  */
-async function checkSandboxMetrics(sandbox: AnySandbox): Promise<{
-  cpuPct: number;
-  memPct: number;
-  diskPct: number;
-  warning: string | null;
-} | null> {
+async function checkSandboxMetrics(
+  sandbox: AnySandbox,
+): Promise<(SandboxResourceMetrics & { warning: string | null }) | null> {
   if (!isE2BSandbox(sandbox)) return null;
 
   try {
@@ -85,6 +86,7 @@ export async function waitForSandboxReady(
   sandbox: AnySandbox,
   maxRetries: number = 5,
   signal?: AbortSignal,
+  onResourceMetrics?: SandboxResourceMetricsObserver,
 ): Promise<void> {
   await retryWithBackoff(
     async () => {
@@ -97,6 +99,17 @@ export async function waitForSandboxReady(
 
         // Check resource metrics for early warning
         const metrics = await checkSandboxMetrics(sandbox);
+        if (metrics && onResourceMetrics) {
+          try {
+            onResourceMetrics({
+              cpuPct: metrics.cpuPct,
+              memPct: metrics.memPct,
+              diskPct: metrics.diskPct,
+            });
+          } catch {
+            // Analytics must never block sandbox health checks
+          }
+        }
         if (metrics?.warning) {
           console.warn(
             `[Sandbox Health] Resource pressure detected: ${metrics.warning}`,

--- a/lib/analytics/__tests__/sandbox-resource-pressure.test.ts
+++ b/lib/analytics/__tests__/sandbox-resource-pressure.test.ts
@@ -1,0 +1,77 @@
+jest.mock("@/lib/posthog/server", () => ({
+  phLogger: {
+    event: jest.fn(),
+  },
+}));
+
+import { phLogger } from "@/lib/posthog/server";
+import {
+  createE2BCpuSaturationObserver,
+  E2B_CPU_SATURATION_THRESHOLD_PCT,
+} from "@/lib/analytics/sandbox-resource-pressure";
+
+const mockPhEvent = phLogger.event as jest.MockedFunction<
+  typeof phLogger.event
+>;
+
+describe("E2B CPU saturation telemetry", () => {
+  beforeEach(() => {
+    mockPhEvent.mockClear();
+  });
+
+  const createObserver = () =>
+    createE2BCpuSaturationObserver({
+      userId: "user-1",
+      chatId: "chat-1",
+      mode: "agent",
+      subscription: "pro-plus",
+    });
+
+  test("emits a privacy-safe event when CPU enters saturation", () => {
+    const observe = createObserver();
+
+    observe({ cpuPct: 99.876, memPct: 72.345, diskPct: 41.234 });
+
+    expect(mockPhEvent).toHaveBeenCalledWith(
+      "e2b_sandbox_cpu_saturation_observed",
+      {
+        userId: "user-1",
+        chat_id: "chat-1",
+        mode: "agent",
+        subscription_tier: "pro-plus",
+        sandbox_type: "e2b",
+        cpu_used_pct: 99.88,
+        memory_used_pct: 72.35,
+        disk_used_pct: 41.23,
+        cpu_saturation_threshold_pct: E2B_CPU_SATURATION_THRESHOLD_PCT,
+        observation_source: "pre_command_health_check",
+        cpu_saturation_event_version: 1,
+      },
+    );
+    expect(mockPhEvent.mock.calls[0]?.[1]).not.toHaveProperty("command");
+    expect(mockPhEvent.mock.calls[0]?.[1]).not.toHaveProperty("error");
+  });
+
+  test("does not emit below the saturation threshold", () => {
+    const observe = createObserver();
+
+    observe({
+      cpuPct: E2B_CPU_SATURATION_THRESHOLD_PCT - 0.01,
+      memPct: 80,
+      diskPct: 50,
+    });
+
+    expect(mockPhEvent).not.toHaveBeenCalled();
+  });
+
+  test("deduplicates one sustained episode and rearms after recovery", () => {
+    const observe = createObserver();
+
+    observe({ cpuPct: 100, memPct: 70, diskPct: 40 });
+    observe({ cpuPct: 100, memPct: 71, diskPct: 40 });
+    observe({ cpuPct: 80, memPct: 71, diskPct: 40 });
+    observe({ cpuPct: 99, memPct: 72, diskPct: 40 });
+
+    expect(mockPhEvent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/lib/analytics/sandbox-resource-pressure.ts
+++ b/lib/analytics/sandbox-resource-pressure.ts
@@ -1,0 +1,53 @@
+import { phLogger } from "@/lib/posthog/server";
+import type {
+  ChatMode,
+  SandboxResourceMetricsObserver,
+  SubscriptionTier,
+} from "@/types";
+
+export const E2B_CPU_SATURATION_THRESHOLD_PCT = 99;
+
+const roundPercentage = (value: number): number =>
+  Math.round(value * 100) / 100;
+
+/**
+ * Tracks rising edges into CPU saturation for one chat request.
+ *
+ * A sustained period at or above the threshold emits once. A later observation
+ * below the threshold rearms the tracker so a new saturation episode can emit.
+ */
+export function createE2BCpuSaturationObserver(args: {
+  userId: string;
+  chatId: string;
+  mode: ChatMode;
+  subscription?: SubscriptionTier;
+}): SandboxResourceMetricsObserver {
+  let cpuWasSaturated = false;
+
+  return ({ cpuPct, memPct, diskPct }) => {
+    const cpuIsSaturated =
+      Number.isFinite(cpuPct) && cpuPct >= E2B_CPU_SATURATION_THRESHOLD_PCT;
+
+    if (!cpuIsSaturated) {
+      cpuWasSaturated = false;
+      return;
+    }
+
+    if (cpuWasSaturated) return;
+    cpuWasSaturated = true;
+
+    phLogger.event("e2b_sandbox_cpu_saturation_observed", {
+      userId: args.userId,
+      chat_id: args.chatId,
+      mode: args.mode,
+      subscription_tier: args.subscription ?? "unknown",
+      sandbox_type: "e2b",
+      cpu_used_pct: roundPercentage(cpuPct),
+      memory_used_pct: roundPercentage(memPct),
+      disk_used_pct: roundPercentage(diskPct),
+      cpu_saturation_threshold_pct: E2B_CPU_SATURATION_THRESHOLD_PCT,
+      observation_source: "pre_command_health_check",
+      cpu_saturation_event_version: 1,
+    });
+  };
+}

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -55,6 +55,16 @@ export interface SandboxBootInfo {
   create_attempts: number;
 }
 
+export interface SandboxResourceMetrics {
+  cpuPct: number;
+  memPct: number;
+  diskPct: number;
+}
+
+export type SandboxResourceMetricsObserver = (
+  metrics: SandboxResourceMetrics,
+) => void;
+
 export interface SandboxContext {
   userID: string;
   setSandbox: (sandbox: Sandbox) => void;
@@ -399,4 +409,6 @@ export interface ToolContext {
   requestToolApproval?: AgentToolApprovalRequester;
   /** Aggregates active wall time for cost attribution in Trigger-hosted Agent runs. */
   measureAgentActiveTime?: AgentActiveTimeMeasurer;
+  /** Observes resource metrics already fetched by E2B health checks. */
+  onSandboxResourceMetrics?: SandboxResourceMetricsObserver;
 }


### PR DESCRIPTION
## Summary

- emit `e2b_sandbox_cpu_saturation_observed` when the existing E2B pre-command health check sees CPU at 99% or higher
- attribute each observation to the PostHog distinct user and include `subscription_tier`, mode, CPU/memory/disk percentages, and chat correlation
- deduplicate sustained saturation within a request, then rearm after CPU recovers so a later saturation episode counts separately
- keep telemetry best-effort so analytics failures cannot interrupt sandbox health checks

## Why

HackerAI currently fetches E2B CPU metrics and prints a warning above 95%, but PostHog has no CPU/resource event, no CPU property on `hackerai-agent_run`, and no saved CPU insight. The warning is not user- or subscription-attributed, so it cannot answer how many users hit saturation or whether Pro, Pro Plus, Ultra, or Team users are disproportionately affected.

## Measurement contract

After deployment, the new event supports:

- affected users: unique users on `e2b_sandbox_cpu_saturation_observed`
- saturation encounters: total event count
- plan distribution: breakdown by `subscription_tier`
- repeat pressure: event count per unique user, broken down by tier

The signal is intentionally conservative: it emits only when the existing pre-command E2B health check observes saturation. It adds no model, Agent, tool, or E2B API request; only one PostHog capture is added per observed saturation episode. It contains no prompt, command, filename, output, error text, or other user content.

## Validation

- `pnpm typecheck`
- `pnpm lint` (0 errors; 5 pre-existing warnings outside this diff)
- `pnpm test` (302 suites, 2,987 tests passed)
- focused telemetry and sandbox health tests (5 tests passed)
- existing terminal command suite (23 tests passed)
- Prettier check on all touched files

## Manual verification

1. In a preview or production Agent chat using the E2B Cloud sandbox, start a CPU-heavy process that drives CPU to at least 99%.
2. Run another non-interactive terminal command so the existing pre-command health check samples E2B metrics.
3. In PostHog, confirm one `e2b_sandbox_cpu_saturation_observed` event appears with the expected `subscription_tier`, `cpu_used_pct`, `memory_used_pct`, `disk_used_pct`, `mode`, and `sandbox_type=e2b`.
4. Run another command while CPU remains saturated and confirm no duplicate event is emitted in the same request; let CPU recover below 99%, saturate it again, and confirm a second event is emitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added sandbox resource monitoring for CPU, memory, and disk usage.
  - Records CPU saturation events with deduplication during sustained high usage.
  - Resource observations are collected during sandbox readiness checks.

- **Bug Fixes**
  - Monitoring or analytics errors no longer interrupt sandbox readiness or command execution.

- **Tests**
  - Added coverage for resource metric reporting, saturation telemetry, deduplication, and observer failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->