### PR TITLE
Track E2B CPU and memory pressure

### DIFF
--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -130,6 +130,7 @@ function makeContext(opts: {
   ptySessionManager?: PtySessionManager;
   chatId?: string;
   requestToolApproval?: import("@/types").AgentToolApprovalRequester;
+  onSandboxResourceMetrics?: import("@/types").SandboxResourceMetricsObserver;
 }) {
   const writerWrites: unknown[] = [];
   const writer = {
@@ -173,6 +174,7 @@ function makeContext(opts: {
     getCurrentModelName: () => "active-model",
     subscription: "pro",
     requestToolApproval: opts.requestToolApproval,
+    onSandboxResourceMetrics: opts.onSandboxResourceMetrics,
     isE2BSandbox: (s: unknown) => {
       if (!s || typeof s !== "object") return false;
       if ((s as { sandboxKind?: unknown }).sandboxKind === "centrifugo")
@@ -527,10 +529,22 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
       jupyterUrl: "http://fake",
       commands: { run },
       isRunning: jest.fn(async () => true),
-      getMetrics: jest.fn(async () => []),
+      getMetrics: jest.fn(async () => [
+        {
+          cpuUsedPct: 100,
+          memUsed: 1945,
+          memTotal: 2048,
+          diskUsed: 400,
+          diskTotal: 1000,
+        },
+      ]),
     };
+    const onSandboxResourceMetrics = jest.fn();
 
-    const { context } = makeContext({ sandbox: e2b });
+    const { context } = makeContext({
+      sandbox: e2b,
+      onSandboxResourceMetrics,
+    });
     const result = (await runTool(createRunTerminalCmd(context), {
       command: "yes",
       brief: "run noisy command",
@@ -554,6 +568,16 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
         String(calledCommand).includes("pgrep"),
       ),
     ).toBe(false);
+    expect(onSandboxResourceMetrics).toHaveBeenCalledWith({
+      kind: "failure",
+      source: "terminal_command_timeout",
+      failureType: "terminal_command_timed_out",
+      metrics: {
+        cpuPct: 100,
+        memPct: expect.closeTo(94.9707, 3),
+        diskPct: 40,
+      },
+    });
   });
 
   test("marks detached background PIDs as non-resumable", async () => {

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -40,7 +40,7 @@ import { BackgroundProcessTracker } from "./utils/background-process-tracker";
 import { ptySessionManager } from "./utils/pty-session-manager";
 import { isE2BSandbox } from "./utils/sandbox-types";
 import { getSandboxWithFallbackGuard } from "./utils/sandbox-fallback";
-import { createE2BCpuSaturationObserver } from "@/lib/analytics/sandbox-resource-pressure";
+import { createE2BResourcePressureObserver } from "@/lib/analytics/sandbox-resource-pressure";
 
 export { isE2BSandbox };
 
@@ -113,7 +113,7 @@ export const createTools = (
   const todoManager = new TodoManager(initialTodos);
   const fileAccumulator = new FileAccumulator();
   const backgroundProcessTracker = new BackgroundProcessTracker();
-  const onSandboxResourceMetrics = createE2BCpuSaturationObserver({
+  const onSandboxResourceMetrics = createE2BResourcePressureObserver({
     userId: userID,
     chatId,
     mode,

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -11,6 +11,7 @@ import { retryWithBackoff } from "./utils/retry-with-backoff";
 import {
   waitForSandboxReady,
   getSandboxDiagnostics,
+  observeSandboxResourceFailure,
 } from "./utils/sandbox-health";
 import { isE2BSandbox, isCentrifugoSandbox } from "./utils/sandbox-types";
 import {
@@ -667,6 +668,17 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                   resolved = true;
                   if (commandSession) commandSessionExposed = true;
 
+                  const resourceFailureObservation = isE2BSandbox(
+                    sandboxInstance,
+                  )
+                    ? observeSandboxResourceFailure(
+                        sandboxInstance,
+                        context.onSandboxResourceMetrics,
+                        "terminal_command_timeout",
+                        "terminal_command_timed_out",
+                      )
+                    : Promise.resolve();
+
                   // Try to get PID from execution object first (if available)
                   if (!processId && execution && (execution as any)?.pid) {
                     processId = (execution as any).pid;
@@ -727,6 +739,9 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                         resumableSession,
                       );
 
+                  await resourceFailureObservation.catch(() => {
+                    // Analytics must never delay or mask terminal timeout handling
+                  });
                   await createTerminalWriter(timeoutMessage);
 
                   abortSignal?.removeEventListener("abort", onAbort);

--- a/lib/ai/tools/utils/__tests__/sandbox-health.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-health.test.ts
@@ -49,9 +49,36 @@ describe("sandbox health resource observations", () => {
     await waitForSandboxReady(sandbox, 1, undefined, onResourceMetrics);
 
     expect(onResourceMetrics).toHaveBeenCalledWith({
-      cpuPct: 100,
-      memPct: 75,
-      diskPct: 25,
+      kind: "health_sample",
+      source: "pre_command_health_check",
+      metrics: {
+        cpuPct: 100,
+        memPct: 75,
+        diskPct: 25,
+      },
+    });
+  });
+
+  test("reports final readiness failures with the latest resource metrics", async () => {
+    const sandbox = makeE2BSandbox();
+    (sandbox.commands.run as jest.Mock).mockRejectedValue(
+      new Error("envd unresponsive"),
+    );
+    const onResourceMetrics = jest.fn();
+
+    await expect(
+      waitForSandboxReady(sandbox, 1, undefined, onResourceMetrics),
+    ).rejects.toThrow("Sandbox running but not ready");
+
+    expect(onResourceMetrics).toHaveBeenLastCalledWith({
+      kind: "failure",
+      source: "readiness_check_failure",
+      failureType: "readiness_check_failed",
+      metrics: {
+        cpuPct: 100,
+        memPct: 75,
+        diskPct: 25,
+      },
     });
   });
 

--- a/lib/ai/tools/utils/sandbox-health.ts
+++ b/lib/ai/tools/utils/sandbox-health.ts
@@ -2,6 +2,7 @@ import type {
   AnySandbox,
   SandboxResourceMetrics,
   SandboxResourceMetricsObserver,
+  SandboxResourceObservation,
 } from "@/types";
 import { createRetryLogger } from "@/lib/posthog/worker";
 import { isE2BSandbox } from "./sandbox-types";
@@ -16,6 +17,7 @@ const sandboxHealthLogger = createRetryLogger("sandbox-health");
 
 const CPU_WARNING_THRESHOLD = 95; // percentage
 const MEM_WARNING_THRESHOLD = 90; // percentage
+const FAILURE_METRICS_TIMEOUT_MS = 1000;
 
 /**
  * Check sandbox resource metrics and return a diagnostic summary.
@@ -59,6 +61,55 @@ async function checkSandboxMetrics(
   }
 }
 
+function notifyResourceObserver(
+  observer: SandboxResourceMetricsObserver | undefined,
+  observation: SandboxResourceObservation,
+): void {
+  if (!observer) return;
+
+  try {
+    observer(observation);
+  } catch {
+    // Analytics must never block sandbox health checks or command handling
+  }
+}
+
+function stripWarning(
+  metrics: (SandboxResourceMetrics & { warning: string | null }) | null,
+): SandboxResourceMetrics | null {
+  if (!metrics) return null;
+  return {
+    cpuPct: metrics.cpuPct,
+    memPct: metrics.memPct,
+    diskPct: metrics.diskPct,
+  };
+}
+
+export async function observeSandboxResourceFailure(
+  sandbox: AnySandbox,
+  observer: SandboxResourceMetricsObserver | undefined,
+  source: "readiness_check_failure" | "terminal_command_timeout",
+  failureType: "readiness_check_failed" | "terminal_command_timed_out",
+): Promise<void> {
+  if (!observer || !isE2BSandbox(sandbox)) return;
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const metrics = await Promise.race([
+    checkSandboxMetrics(sandbox),
+    new Promise<null>((resolve) => {
+      timeout = setTimeout(() => resolve(null), FAILURE_METRICS_TIMEOUT_MS);
+    }),
+  ]).finally(() => {
+    if (timeout) clearTimeout(timeout);
+  });
+  notifyResourceObserver(observer, {
+    kind: "failure",
+    source,
+    failureType,
+    metrics: stripWarning(metrics),
+  });
+}
+
 /**
  * Build a diagnostic message from metrics for error context.
  */
@@ -88,80 +139,93 @@ export async function waitForSandboxReady(
   signal?: AbortSignal,
   onResourceMetrics?: SandboxResourceMetricsObserver,
 ): Promise<void> {
-  await retryWithBackoff(
-    async () => {
-      // For E2B Sandbox, check if it's running first
-      if (isE2BSandbox(sandbox)) {
-        const running = await sandbox.isRunning();
-        if (!running) {
-          throw new Error("Sandbox is not running");
-        }
+  try {
+    await retryWithBackoff(
+      async () => {
+        // For E2B Sandbox, check if it's running first
+        if (isE2BSandbox(sandbox)) {
+          const running = await sandbox.isRunning();
+          if (!running) {
+            throw new Error("Sandbox is not running");
+          }
 
-        // Check resource metrics for early warning
-        const metrics = await checkSandboxMetrics(sandbox);
-        if (metrics && onResourceMetrics) {
-          try {
-            onResourceMetrics({
-              cpuPct: metrics.cpuPct,
-              memPct: metrics.memPct,
-              diskPct: metrics.diskPct,
+          // Check resource metrics for early warning
+          const metrics = await checkSandboxMetrics(sandbox);
+          if (metrics) {
+            notifyResourceObserver(onResourceMetrics, {
+              kind: "health_sample",
+              source: "pre_command_health_check",
+              metrics: stripWarning(metrics)!,
             });
-          } catch {
-            // Analytics must never block sandbox health checks
+          }
+          if (metrics?.warning) {
+            console.warn(
+              `[Sandbox Health] Resource pressure detected: ${metrics.warning}`,
+            );
           }
         }
-        if (metrics?.warning) {
-          console.warn(
-            `[Sandbox Health] Resource pressure detected: ${metrics.warning}`,
+
+        // Verify it can actually execute commands with a simple test
+        try {
+          await sandbox.commands.run("echo ready", {
+            timeoutMs: 5000, // 5 second timeout for health check (envd can be slow under CPU pressure)
+            // Hide from local CLI output (empty string = hide)
+            displayName: "",
+          } as { timeoutMs: number; displayName?: string });
+        } catch (error) {
+          // Enrich error with metrics context for debugging
+          let metricsContext = "";
+          try {
+            metricsContext = ` [${await getSandboxDiagnostics(sandbox)}]`;
+          } catch {
+            // Don't let metrics failure mask the real error
+          }
+
+          // Re-throw original error to preserve instanceof checks for
+          // isPermanentError (AuthenticationError, TemplateError, etc.)
+          if (error instanceof Error) {
+            error.message = `Sandbox running but not ready to execute commands${metricsContext}: ${error.message}`;
+            throw error;
+          }
+          throw new Error(
+            `Sandbox running but not ready to execute commands${metricsContext}: ${error}`,
           );
         }
-      }
-
-      // Verify it can actually execute commands with a simple test
-      try {
-        await sandbox.commands.run("echo ready", {
-          timeoutMs: 5000, // 5 second timeout for health check (envd can be slow under CPU pressure)
-          // Hide from local CLI output (empty string = hide)
-          displayName: "",
-        } as { timeoutMs: number; displayName?: string });
-      } catch (error) {
-        // Enrich error with metrics context for debugging
-        let metricsContext = "";
-        try {
-          metricsContext = ` [${await getSandboxDiagnostics(sandbox)}]`;
-        } catch {
-          // Don't let metrics failure mask the real error
-        }
-
-        // Re-throw original error to preserve instanceof checks for
-        // isPermanentError (AuthenticationError, TemplateError, etc.)
-        if (error instanceof Error) {
-          error.message = `Sandbox running but not ready to execute commands${metricsContext}: ${error.message}`;
-          throw error;
-        }
-        throw new Error(
-          `Sandbox running but not ready to execute commands${metricsContext}: ${error}`,
-        );
-      }
-    },
-    {
-      maxRetries,
-      baseDelayMs: 1000, // 1s, 2s, 4s, 8s, 16s (~31s total for 5 retries)
-      jitterMs: 100,
-      isPermanentError: (error: unknown) => {
-        // Auth and template errors will never recover by retrying health checks
-        if (error instanceof AuthenticationError) return true;
-        if (error instanceof TemplateError) return true;
-        if (error instanceof InvalidArgumentError) return true;
-        return false; // All other errors: keep retrying - sandbox might be starting
       },
-      logger: (message, error) => {
-        // Only log final failure (when it gives up)
-        if (message.includes("failed after")) {
-          sandboxHealthLogger(message, error);
-        }
+      {
+        maxRetries,
+        baseDelayMs: 1000, // 1s, 2s, 4s, 8s, 16s (~31s total for 5 retries)
+        jitterMs: 100,
+        isPermanentError: (error: unknown) => {
+          // Auth and template errors will never recover by retrying health checks
+          if (error instanceof AuthenticationError) return true;
+          if (error instanceof TemplateError) return true;
+          if (error instanceof InvalidArgumentError) return true;
+          return false; // All other errors: keep retrying - sandbox might be starting
+        },
+        logger: (message, error) => {
+          // Only log final failure (when it gives up)
+          if (message.includes("failed after")) {
+            sandboxHealthLogger(message, error);
+          }
+        },
+        signal,
       },
-      signal,
-    },
-  );
+    );
+  } catch (error) {
+    const wasAborted =
+      signal?.aborted ||
+      (error instanceof DOMException && error.name === "AbortError");
+    if (!wasAborted) {
+      await observeSandboxResourceFailure(
+        sandbox,
+        onResourceMetrics,
+        "readiness_check_failure",
+        "readiness_check_failed",
+      ).catch(() => {
+        // Analytics must never mask the readiness failure
+      });
+    }
+    throw error;
+  }
 }

--- a/lib/analytics/__tests__/sandbox-resource-pressure.test.ts
+++ b/lib/analytics/__tests__/sandbox-resource-pressure.test.ts
@@ -6,34 +6,48 @@ jest.mock("@/lib/posthog/server", () => ({
 
 import { phLogger } from "@/lib/posthog/server";
 import {
-  createE2BCpuSaturationObserver,
+  createE2BResourcePressureObserver,
   E2B_CPU_SATURATION_THRESHOLD_PCT,
+  E2B_MEMORY_PRESSURE_THRESHOLD_PCT,
+  E2B_RESOURCE_PRESSURE_EVENT_VERSION,
 } from "@/lib/analytics/sandbox-resource-pressure";
 
 const mockPhEvent = phLogger.event as jest.MockedFunction<
   typeof phLogger.event
 >;
 
-describe("E2B CPU saturation telemetry", () => {
+describe("E2B resource pressure telemetry", () => {
   beforeEach(() => {
     mockPhEvent.mockClear();
   });
 
   const createObserver = () =>
-    createE2BCpuSaturationObserver({
+    createE2BResourcePressureObserver({
       userId: "user-1",
       chatId: "chat-1",
       mode: "agent",
       subscription: "pro-plus",
     });
 
-  test("emits a privacy-safe event when CPU enters saturation", () => {
+  const observeHealth = (
+    observer: ReturnType<typeof createObserver>,
+    cpuPct: number,
+    memPct: number,
+    diskPct = 41.234,
+  ) =>
+    observer({
+      kind: "health_sample",
+      source: "pre_command_health_check",
+      metrics: { cpuPct, memPct, diskPct },
+    });
+
+  test("emits a privacy-safe CPU-only pressure event", () => {
     const observe = createObserver();
 
-    observe({ cpuPct: 99.876, memPct: 72.345, diskPct: 41.234 });
+    observeHealth(observe, 99.876, 72.345);
 
     expect(mockPhEvent).toHaveBeenCalledWith(
-      "e2b_sandbox_cpu_saturation_observed",
+      "e2b_sandbox_resource_pressure_observed",
       {
         userId: "user-1",
         chat_id: "chat-1",
@@ -43,35 +57,125 @@ describe("E2B CPU saturation telemetry", () => {
         cpu_used_pct: 99.88,
         memory_used_pct: 72.35,
         disk_used_pct: 41.23,
+        metrics_available: true,
+        pressure_type: "cpu",
+        newly_pressured_resource: "cpu",
         cpu_saturation_threshold_pct: E2B_CPU_SATURATION_THRESHOLD_PCT,
+        memory_pressure_threshold_pct: E2B_MEMORY_PRESSURE_THRESHOLD_PCT,
         observation_source: "pre_command_health_check",
-        cpu_saturation_event_version: 1,
+        resource_pressure_event_version: E2B_RESOURCE_PRESSURE_EVENT_VERSION,
       },
     );
     expect(mockPhEvent.mock.calls[0]?.[1]).not.toHaveProperty("command");
     expect(mockPhEvent.mock.calls[0]?.[1]).not.toHaveProperty("error");
   });
 
-  test("does not emit below the saturation threshold", () => {
+  test("emits memory-only and simultaneous pressure classifications", () => {
+    const memoryOnly = createObserver();
+    observeHealth(memoryOnly, 70, 90);
+
+    expect(mockPhEvent).toHaveBeenLastCalledWith(
+      "e2b_sandbox_resource_pressure_observed",
+      expect.objectContaining({
+        pressure_type: "memory",
+        newly_pressured_resource: "memory",
+      }),
+    );
+
+    mockPhEvent.mockClear();
+    const both = createObserver();
+    observeHealth(both, 99, 95);
+
+    expect(mockPhEvent).toHaveBeenLastCalledWith(
+      "e2b_sandbox_resource_pressure_observed",
+      expect.objectContaining({
+        pressure_type: "both",
+        newly_pressured_resource: "both",
+      }),
+    );
+  });
+
+  test("does not emit while both resources remain below their thresholds", () => {
     const observe = createObserver();
 
-    observe({
-      cpuPct: E2B_CPU_SATURATION_THRESHOLD_PCT - 0.01,
-      memPct: 80,
-      diskPct: 50,
-    });
+    observeHealth(
+      observe,
+      E2B_CPU_SATURATION_THRESHOLD_PCT - 0.01,
+      E2B_MEMORY_PRESSURE_THRESHOLD_PCT - 0.01,
+    );
 
     expect(mockPhEvent).not.toHaveBeenCalled();
   });
 
-  test("deduplicates one sustained episode and rearms after recovery", () => {
+  test("deduplicates and rearms CPU and memory pressure independently", () => {
     const observe = createObserver();
 
-    observe({ cpuPct: 100, memPct: 70, diskPct: 40 });
-    observe({ cpuPct: 100, memPct: 71, diskPct: 40 });
-    observe({ cpuPct: 80, memPct: 71, diskPct: 40 });
-    observe({ cpuPct: 99, memPct: 72, diskPct: 40 });
+    observeHealth(observe, 100, 70);
+    observeHealth(observe, 100, 71);
+    observeHealth(observe, 100, 92);
+    observeHealth(observe, 80, 92);
+    observeHealth(observe, 99, 92);
+    observeHealth(observe, 80, 80);
+    observeHealth(observe, 80, 90);
 
-    expect(mockPhEvent).toHaveBeenCalledTimes(2);
+    expect(mockPhEvent).toHaveBeenCalledTimes(4);
+    expect(
+      mockPhEvent.mock.calls.map(([, properties]) => ({
+        pressureType: properties.pressure_type,
+        newlyPressuredResource: properties.newly_pressured_resource,
+      })),
+    ).toEqual([
+      { pressureType: "cpu", newlyPressuredResource: "cpu" },
+      { pressureType: "both", newlyPressuredResource: "memory" },
+      { pressureType: "both", newlyPressuredResource: "cpu" },
+      { pressureType: "memory", newlyPressuredResource: "memory" },
+    ]);
+  });
+
+  test("records readiness or command failures with resource context", () => {
+    const observe = createObserver();
+
+    observe({
+      kind: "failure",
+      source: "terminal_command_timeout",
+      failureType: "terminal_command_timed_out",
+      metrics: { cpuPct: 100, memPct: 95, diskPct: 40 },
+    });
+
+    expect(mockPhEvent).toHaveBeenCalledWith(
+      "e2b_sandbox_resource_failure_observed",
+      expect.objectContaining({
+        pressure_type: "both",
+        failure_type: "terminal_command_timed_out",
+        observation_source: "terminal_command_timeout",
+        metrics_available: true,
+        cpu_used_pct: 100,
+        memory_used_pct: 95,
+      }),
+    );
+  });
+
+  test("records failures even when E2B metrics are unavailable", () => {
+    const observe = createObserver();
+
+    observe({
+      kind: "failure",
+      source: "readiness_check_failure",
+      failureType: "readiness_check_failed",
+      metrics: null,
+    });
+
+    expect(mockPhEvent).toHaveBeenCalledWith(
+      "e2b_sandbox_resource_failure_observed",
+      expect.objectContaining({
+        pressure_type: "unknown",
+        failure_type: "readiness_check_failed",
+        metrics_available: false,
+      }),
+    );
+    expect(mockPhEvent.mock.calls[0]?.[1]).not.toHaveProperty("cpu_used_pct");
+    expect(mockPhEvent.mock.calls[0]?.[1]).not.toHaveProperty(
+      "memory_used_pct",
+    );
   });
 });

--- a/lib/analytics/sandbox-resource-pressure.ts
+++ b/lib/analytics/sandbox-resource-pressure.ts
@@ -1,53 +1,121 @@
 import { phLogger } from "@/lib/posthog/server";
 import type {
   ChatMode,
+  SandboxResourceMetrics,
   SandboxResourceMetricsObserver,
   SubscriptionTier,
 } from "@/types";
 
 export const E2B_CPU_SATURATION_THRESHOLD_PCT = 99;
+export const E2B_MEMORY_PRESSURE_THRESHOLD_PCT = 90;
+export const E2B_RESOURCE_PRESSURE_EVENT_VERSION = 2;
 
 const roundPercentage = (value: number): number =>
   Math.round(value * 100) / 100;
 
+type ResourcePressureType = "none" | "cpu" | "memory" | "both" | "unknown";
+
+function classifyResourcePressure(
+  metrics: SandboxResourceMetrics | null,
+): ResourcePressureType {
+  if (!metrics) return "unknown";
+
+  const cpuIsPressured =
+    Number.isFinite(metrics.cpuPct) &&
+    metrics.cpuPct >= E2B_CPU_SATURATION_THRESHOLD_PCT;
+  const memoryIsPressured =
+    Number.isFinite(metrics.memPct) &&
+    metrics.memPct >= E2B_MEMORY_PRESSURE_THRESHOLD_PCT;
+
+  if (cpuIsPressured && memoryIsPressured) return "both";
+  if (cpuIsPressured) return "cpu";
+  if (memoryIsPressured) return "memory";
+  return "none";
+}
+
+function metricProperties(metrics: SandboxResourceMetrics | null) {
+  if (!metrics) {
+    return {
+      metrics_available: false,
+    };
+  }
+
+  return {
+    metrics_available: true,
+    cpu_used_pct: roundPercentage(metrics.cpuPct),
+    memory_used_pct: roundPercentage(metrics.memPct),
+    disk_used_pct: roundPercentage(metrics.diskPct),
+  };
+}
+
 /**
- * Tracks rising edges into CPU saturation for one chat request.
+ * Tracks independent rising edges into CPU and memory pressure for one request.
  *
- * A sustained period at or above the threshold emits once. A later observation
- * below the threshold rearms the tracker so a new saturation episode can emit.
+ * Sustained pressure for either resource emits once. Each resource rearms
+ * independently after recovering below its threshold.
  */
-export function createE2BCpuSaturationObserver(args: {
+export function createE2BResourcePressureObserver(args: {
   userId: string;
   chatId: string;
   mode: ChatMode;
   subscription?: SubscriptionTier;
 }): SandboxResourceMetricsObserver {
-  let cpuWasSaturated = false;
+  let cpuWasPressured = false;
+  let memoryWasPressured = false;
 
-  return ({ cpuPct, memPct, diskPct }) => {
-    const cpuIsSaturated =
-      Number.isFinite(cpuPct) && cpuPct >= E2B_CPU_SATURATION_THRESHOLD_PCT;
+  const commonProperties = {
+    userId: args.userId,
+    chat_id: args.chatId,
+    mode: args.mode,
+    subscription_tier: args.subscription ?? "unknown",
+    sandbox_type: "e2b",
+    cpu_saturation_threshold_pct: E2B_CPU_SATURATION_THRESHOLD_PCT,
+    memory_pressure_threshold_pct: E2B_MEMORY_PRESSURE_THRESHOLD_PCT,
+    resource_pressure_event_version: E2B_RESOURCE_PRESSURE_EVENT_VERSION,
+  };
 
-    if (!cpuIsSaturated) {
-      cpuWasSaturated = false;
+  return (observation) => {
+    const pressureType = classifyResourcePressure(observation.metrics);
+
+    if (observation.kind === "failure") {
+      phLogger.event("e2b_sandbox_resource_failure_observed", {
+        ...commonProperties,
+        ...metricProperties(observation.metrics),
+        pressure_type: pressureType,
+        failure_type: observation.failureType,
+        observation_source: observation.source,
+      });
       return;
     }
 
-    if (cpuWasSaturated) return;
-    cpuWasSaturated = true;
+    const { metrics } = observation;
+    const cpuIsPressured =
+      Number.isFinite(metrics.cpuPct) &&
+      metrics.cpuPct >= E2B_CPU_SATURATION_THRESHOLD_PCT;
+    const memoryIsPressured =
+      Number.isFinite(metrics.memPct) &&
+      metrics.memPct >= E2B_MEMORY_PRESSURE_THRESHOLD_PCT;
+    const cpuEnteredPressure = cpuIsPressured && !cpuWasPressured;
+    const memoryEnteredPressure = memoryIsPressured && !memoryWasPressured;
 
-    phLogger.event("e2b_sandbox_cpu_saturation_observed", {
-      userId: args.userId,
-      chat_id: args.chatId,
-      mode: args.mode,
-      subscription_tier: args.subscription ?? "unknown",
-      sandbox_type: "e2b",
-      cpu_used_pct: roundPercentage(cpuPct),
-      memory_used_pct: roundPercentage(memPct),
-      disk_used_pct: roundPercentage(diskPct),
-      cpu_saturation_threshold_pct: E2B_CPU_SATURATION_THRESHOLD_PCT,
-      observation_source: "pre_command_health_check",
-      cpu_saturation_event_version: 1,
+    cpuWasPressured = cpuIsPressured;
+    memoryWasPressured = memoryIsPressured;
+
+    if (!cpuEnteredPressure && !memoryEnteredPressure) return;
+
+    const newlyPressuredResource =
+      cpuEnteredPressure && memoryEnteredPressure
+        ? "both"
+        : cpuEnteredPressure
+          ? "cpu"
+          : "memory";
+
+    phLogger.event("e2b_sandbox_resource_pressure_observed", {
+      ...commonProperties,
+      ...metricProperties(metrics),
+      pressure_type: pressureType,
+      newly_pressured_resource: newlyPressuredResource,
+      observation_source: observation.source,
     });
   };
 }

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -61,8 +61,21 @@ export interface SandboxResourceMetrics {
   diskPct: number;
 }
 
+export type SandboxResourceObservation =
+  | {
+      kind: "health_sample";
+      source: "pre_command_health_check";
+      metrics: SandboxResourceMetrics;
+    }
+  | {
+      kind: "failure";
+      source: "readiness_check_failure" | "terminal_command_timeout";
+      failureType: "readiness_check_failed" | "terminal_command_timed_out";
+      metrics: SandboxResourceMetrics | null;
+    };
+
 export type SandboxResourceMetricsObserver = (
-  metrics: SandboxResourceMetrics,
+  observation: SandboxResourceObservation,
 ) => void;
 
 export interface SandboxContext {


### PR DESCRIPTION
## Summary

- replace the CPU-only saturation event from #976 with `e2b_sandbox_resource_pressure_observed`
- emit on independent rising edges for CPU at 99% or higher and memory at 90% or higher
- classify each observation as `cpu`, `memory`, or `both`, while recording which resource newly crossed its threshold
- emit `e2b_sandbox_resource_failure_observed` after a final readiness-check failure or terminal command timeout, including the sampled resource state or `metrics_available=false`
- preserve subscription tier, mode, chat correlation, and CPU/memory/disk percentages without capturing commands, output, prompts, filenames, or error text

## Why

The event added in #976 only fired when CPU reached 99%. Although it included memory percentage, it could not observe memory-only pressure and therefore could not answer whether E2B failures are primarily CPU- or RAM-related.

This change gives [HAC-54](https://linear.app/hackerai/issue/HAC-54/review-e2b-cpu-saturation-telemetry-and-choose-mitigation) the data needed to compare:

- CPU-only, memory-only, and simultaneous pressure
- affected users and repeat episodes by subscription tier
- resource pressure correlated with readiness failures and command timeouts
- failures where E2B metrics are already unavailable

## Measurement contract

### `e2b_sandbox_resource_pressure_observed`

Emits once when either resource crosses its threshold:

- CPU: `cpu_used_pct >= 99`
- memory: `memory_used_pct >= 90`

CPU and memory rearm independently after recovery, preventing sustained pressure from flooding PostHog. Key properties include `pressure_type`, `newly_pressured_resource`, `subscription_tier`, all three resource percentages, both thresholds, and `resource_pressure_event_version=2`.

### `e2b_sandbox_resource_failure_observed`

Emits for:

- `readiness_check_failed`
- `terminal_command_timed_out`

It records `pressure_type=cpu|memory|both|none|unknown`, the resource percentages when available, and `metrics_available`.

Normal health observations reuse metrics E2B already fetched. Failure correlation adds one best-effort E2B metrics sample only on terminal timeout or final readiness failure, bounded to one second. Analytics failures never interrupt command or recovery handling.

## Validation

- `pnpm typecheck`
- `pnpm lint` (0 errors; 5 pre-existing warnings outside this diff)
- focused telemetry, sandbox health, and terminal tests: 3 suites / 32 tests passed
- full Jest suite: 303 suites / 3,010 tests passed
- repository pre-commit formatting and ESLint fixes passed

## Manual verification

1. In a preview Agent chat using E2B Cloud, drive CPU to at least 99%, run another non-interactive command, and confirm a pressure event with `pressure_type=cpu`.
2. In a fresh preview sandbox, allocate memory above 90% while keeping CPU below 99%, run another command, and confirm `pressure_type=memory`.
3. Drive both above threshold and confirm `pressure_type=both`.
4. Let a terminal command exceed its timeout and confirm a failure event with `failure_type=terminal_command_timed_out` and the sampled resource state.
5. Confirm sustained pressure does not repeatedly emit until the affected resource recovers and crosses its threshold again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Monitoring**
  * Improved sandbox health and resource monitoring for CPU, memory, and disk usage.
  * Added clearer reporting for command timeouts and sandbox readiness failures.
  * Resource pressure events now distinguish CPU, memory, or combined pressure.

* **Reliability**
  * Monitoring and analytics errors no longer interrupt command execution or sandbox health handling.

* **Privacy**
  * Resource-pressure telemetry uses structured, privacy-safe data without command contents or error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->