### PR TITLE
Make Convex WorkOS issuer configurable

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -7,6 +7,10 @@ WORKOS_API_KEY=sk_example_123456789
 # ⚠️ IMPORTANT: Also add this to Convex Dashboard → Environment Variables
 WORKOS_CLIENT_ID=client_123456789
 
+# ⚠️ IMPORTANT: Also add this to Convex Dashboard → Environment Variables
+# Use api.workos.com unless WorkOS has configured a custom Authentication API domain.
+WORKOS_AUTH_DOMAIN=api.workos.com
+
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 WORKOS_COOKIE_PASSWORD=
 NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/callback

--- a/convex/__tests__/auth.config.test.ts
+++ b/convex/__tests__/auth.config.test.ts
@@ -35,15 +35,33 @@ afterEach(() => {
 
 describe("Convex WorkOS auth configuration", () => {
   it("leaves providers empty when WORKOS_CLIENT_ID is unavailable", async () => {
-    const authConfig = await loadAuthConfig({});
+    const authConfig = await loadAuthConfig({
+      authDomain: "not a valid domain",
+    });
 
     expect(authConfig.providers).toEqual([]);
   });
 
-  it("always uses HackerAI's custom auth domain", async () => {
+  it("uses WorkOS's standard domain when configured", async () => {
     const authConfig = await loadAuthConfig({
       clientId: "client_test",
       authDomain: "api.workos.com",
+    });
+
+    expect(authConfig.providers).toEqual([
+      {
+        type: "customJwt",
+        issuer: "https://api.workos.com/user_management/client_test",
+        algorithm: "RS256",
+        jwks: "https://api.workos.com/sso/jwks/client_test",
+      },
+    ]);
+  });
+
+  it("uses a configured custom auth domain", async () => {
+    const authConfig = await loadAuthConfig({
+      clientId: "client_test",
+      authDomain: "auth.hackerai.co",
     });
 
     expect(authConfig.providers).toEqual([
@@ -55,4 +73,34 @@ describe("Convex WorkOS auth configuration", () => {
       },
     ]);
   });
+
+  it("normalizes an HTTPS origin with trailing slashes", async () => {
+    const authConfig = await loadAuthConfig({
+      clientId: "client_test",
+      authDomain: " https://auth.hackerai.co/// ",
+    });
+
+    expect(authConfig.providers).toEqual([
+      {
+        type: "customJwt",
+        issuer: "https://auth.hackerai.co/user_management/client_test",
+        algorithm: "RS256",
+        jwks: "https://auth.hackerai.co/sso/jwks/client_test",
+      },
+    ]);
+  });
+
+  it.each([undefined, "", "http://auth.hackerai.co", "auth.hackerai.co/path"])(
+    "rejects a missing or invalid auth domain: %s",
+    async (authDomain) => {
+      await expect(
+        loadAuthConfig({
+          clientId: "client_test",
+          authDomain,
+        }),
+      ).rejects.toThrow(
+        "WORKOS_AUTH_DOMAIN must be a hostname or HTTPS origin without a path",
+      );
+    },
+  );
 });

--- a/convex/__tests__/auth.config.test.ts
+++ b/convex/__tests__/auth.config.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+const originalClientId = process.env.WORKOS_CLIENT_ID;
+const originalAuthDomain = process.env.WORKOS_AUTH_DOMAIN;
+
+function restoreEnvironmentVariable(
+  name: "WORKOS_CLIENT_ID" | "WORKOS_AUTH_DOMAIN",
+  value: string | undefined,
+) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+async function loadAuthConfig({
+  clientId,
+  authDomain,
+}: {
+  clientId?: string;
+  authDomain?: string;
+}) {
+  jest.resetModules();
+  restoreEnvironmentVariable("WORKOS_CLIENT_ID", clientId);
+  restoreEnvironmentVariable("WORKOS_AUTH_DOMAIN", authDomain);
+  return (await import("../auth.config")).default;
+}
+
+afterEach(() => {
+  restoreEnvironmentVariable("WORKOS_CLIENT_ID", originalClientId);
+  restoreEnvironmentVariable("WORKOS_AUTH_DOMAIN", originalAuthDomain);
+  jest.resetModules();
+});
+
+describe("Convex WorkOS auth configuration", () => {
+  it("leaves providers empty when WORKOS_CLIENT_ID is unavailable", async () => {
+    const authConfig = await loadAuthConfig({});
+
+    expect(authConfig.providers).toEqual([]);
+  });
+
+  it("always uses HackerAI's custom auth domain", async () => {
+    const authConfig = await loadAuthConfig({
+      clientId: "client_test",
+      authDomain: "api.workos.com",
+    });
+
+    expect(authConfig.providers).toEqual([
+      {
+        type: "customJwt",
+        issuer: "https://auth.hackerai.co/user_management/client_test",
+        algorithm: "RS256",
+        jwks: "https://auth.hackerai.co/sso/jwks/client_test",
+      },
+    ]);
+  });
+});

--- a/convex/auth.config.ts
+++ b/convex/auth.config.ts
@@ -1,24 +1,19 @@
+import type { AuthConfig } from "convex/server";
+
 const clientId = process.env.WORKOS_CLIENT_ID ?? "";
+const authOrigin = "https://auth.hackerai.co";
 
 const authConfig = {
   providers: clientId
     ? [
         {
           type: "customJwt" as const,
-          issuer: `https://auth.hackerai.co/`,
+          issuer: `${authOrigin}/user_management/${clientId}`,
           algorithm: "RS256" as const,
-          applicationID: clientId,
-          jwks: `https://auth.hackerai.co/sso/jwks/${clientId}`,
-        },
-        {
-          type: "customJwt" as const,
-          issuer: `https://auth.hackerai.co/user_management/${clientId}`,
-          algorithm: "RS256" as const,
-          jwks: `https://auth.hackerai.co/sso/jwks/${clientId}`,
-          applicationID: clientId,
+          jwks: `${authOrigin}/sso/jwks/${clientId}`,
         },
       ]
     : [],
-};
+} satisfies AuthConfig;
 
 export default authConfig;

--- a/convex/auth.config.ts
+++ b/convex/auth.config.ts
@@ -1,18 +1,59 @@
 import type { AuthConfig } from "convex/server";
 
 const clientId = process.env.WORKOS_CLIENT_ID ?? "";
-const authOrigin = "https://auth.hackerai.co";
+
+function resolveAuthOrigin(authDomain: string | undefined): string {
+  const configuredDomain = authDomain?.trim();
+  const errorMessage =
+    "WORKOS_AUTH_DOMAIN must be a hostname or HTTPS origin without a path";
+
+  if (!configuredDomain) {
+    throw new Error(errorMessage);
+  }
+
+  let authOrigin: URL;
+  try {
+    authOrigin = new URL(
+      configuredDomain.includes("://")
+        ? configuredDomain
+        : `https://${configuredDomain}`,
+    );
+  } catch {
+    throw new Error(errorMessage);
+  }
+
+  if (
+    authOrigin.protocol !== "https:" ||
+    authOrigin.username ||
+    authOrigin.password ||
+    authOrigin.port ||
+    !authOrigin.hostname ||
+    !/^\/+$/.test(authOrigin.pathname) ||
+    authOrigin.search ||
+    authOrigin.hash
+  ) {
+    throw new Error(errorMessage);
+  }
+
+  return authOrigin.origin;
+}
+
+function createWorkOSProvider(
+  clientId: string,
+  authDomain: string | undefined,
+) {
+  const authOrigin = resolveAuthOrigin(authDomain);
+  return {
+    type: "customJwt" as const,
+    issuer: `${authOrigin}/user_management/${clientId}`,
+    algorithm: "RS256" as const,
+    jwks: `${authOrigin}/sso/jwks/${clientId}`,
+  };
+}
 
 const authConfig = {
   providers: clientId
-    ? [
-        {
-          type: "customJwt" as const,
-          issuer: `${authOrigin}/user_management/${clientId}`,
-          algorithm: "RS256" as const,
-          jwks: `${authOrigin}/sso/jwks/${clientId}`,
-        },
-      ]
+    ? [createWorkOSProvider(clientId, process.env.WORKOS_AUTH_DOMAIN)]
     : [],
 } satisfies AuthConfig;
 

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -115,6 +115,48 @@ async function getWorkOSClientId(): Promise<string> {
   return await question("Enter your WorkOS Client ID: ");
 }
 
+async function getWorkOSAuthDomain(): Promise<string> {
+  console.log(`\n${chalk.bold("Getting WorkOS Authentication API Domain")}`);
+  console.log(
+    "Press enter to use api.workos.com, or enter the custom domain configured in WorkOS.",
+  );
+
+  const input = (
+    await question("Enter your WorkOS auth domain [api.workos.com]: ")
+  ).trim();
+  const configuredDomain = input || "api.workos.com";
+
+  try {
+    const authOrigin = new URL(
+      configuredDomain.includes("://")
+        ? configuredDomain
+        : `https://${configuredDomain}`,
+    );
+
+    if (
+      authOrigin.protocol === "https:" &&
+      !authOrigin.username &&
+      !authOrigin.password &&
+      !authOrigin.port &&
+      /^[a-z0-9.-]+$/i.test(authOrigin.hostname) &&
+      /^\/+$/.test(authOrigin.pathname) &&
+      !authOrigin.search &&
+      !authOrigin.hash
+    ) {
+      return authOrigin.hostname;
+    }
+  } catch {
+    // Show the validation message below.
+  }
+
+  console.log(
+    chalk.red(
+      "Invalid WorkOS auth domain. Enter a hostname or HTTPS origin without a path.",
+    ),
+  );
+  return await getWorkOSAuthDomain();
+}
+
 function generateWorkOSCookiePassword(): string {
   console.log(`\n${chalk.bold("Generating WORKOS_COOKIE_PASSWORD")}`);
   console.log(
@@ -150,6 +192,7 @@ async function configureWorkOSDashboard() {
 
 async function configureConvexDashboard(
   workOSClientId: string,
+  workOSAuthDomain: string,
   convexServiceRoleKey: string,
 ) {
   console.log(`\n${chalk.bold("Configure Convex Dashboard")}`);
@@ -161,6 +204,7 @@ async function configureConvexDashboard(
   console.log("3. Go to Settings → Environment Variables");
   console.log("4. Add the following required variables:\n");
   console.log(chalk.bold(`   WORKOS_CLIENT_ID=${workOSClientId}`));
+  console.log(chalk.bold(`   WORKOS_AUTH_DOMAIN=${workOSAuthDomain}`));
   console.log(chalk.bold(`   CONVEX_SERVICE_ROLE_KEY=${convexServiceRoleKey}`));
   console.log("\nOptional variables (add later if using these features):");
   console.log("   - AWS_S3_* variables (if using S3 storage)");
@@ -182,6 +226,10 @@ WORKOS_API_KEY=${envVars.WORKOS_API_KEY}
 
 # ⚠️ IMPORTANT: Also add this to Convex Dashboard → Environment Variables
 WORKOS_CLIENT_ID=${envVars.WORKOS_CLIENT_ID}
+
+# Use api.workos.com unless WorkOS has configured a custom Authentication API domain.
+# ⚠️ IMPORTANT: Also add this to Convex Dashboard → Environment Variables
+WORKOS_AUTH_DOMAIN=${envVars.WORKOS_AUTH_DOMAIN}
 
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 WORKOS_COOKIE_PASSWORD=${envVars.WORKOS_COOKIE_PASSWORD}
@@ -428,6 +476,7 @@ async function main() {
   // Get WorkOS configuration
   const WORKOS_API_KEY = await getWorkOSApiKey();
   const WORKOS_CLIENT_ID = await getWorkOSClientId();
+  const WORKOS_AUTH_DOMAIN = await getWorkOSAuthDomain();
   const NEXT_PUBLIC_BASE_URL = "http://localhost:3000";
   const NEXT_PUBLIC_WORKOS_REDIRECT_URI = `${NEXT_PUBLIC_BASE_URL}/callback`;
   const WORKOS_COOKIE_PASSWORD = generateWorkOSCookiePassword();
@@ -449,6 +498,7 @@ async function main() {
     E2B_API_KEY,
     WORKOS_API_KEY,
     WORKOS_CLIENT_ID,
+    WORKOS_AUTH_DOMAIN,
     NEXT_PUBLIC_WORKOS_REDIRECT_URI,
     WORKOS_COOKIE_PASSWORD,
     ACCOUNT_IDENTITY_HMAC_SECRET,
@@ -468,6 +518,9 @@ async function main() {
         `npx convex env set WORKOS_CLIENT_ID ${WORKOS_CLIENT_ID} --local`,
       );
       await execAsync(
+        `npx convex env set WORKOS_AUTH_DOMAIN ${WORKOS_AUTH_DOMAIN} --local`,
+      );
+      await execAsync(
         `npx convex env set CONVEX_SERVICE_ROLE_KEY ${CONVEX_SERVICE_ROLE_KEY} --local`,
       );
       console.log(
@@ -483,12 +536,19 @@ async function main() {
         `   npx convex env set WORKOS_CLIENT_ID ${WORKOS_CLIENT_ID} --local`,
       );
       console.log(
+        `   npx convex env set WORKOS_AUTH_DOMAIN ${WORKOS_AUTH_DOMAIN} --local`,
+      );
+      console.log(
         `   npx convex env set CONVEX_SERVICE_ROLE_KEY ${CONVEX_SERVICE_ROLE_KEY} --local`,
       );
     }
   } else {
     // Configure Convex Dashboard for cloud deployments
-    await configureConvexDashboard(WORKOS_CLIENT_ID, CONVEX_SERVICE_ROLE_KEY);
+    await configureConvexDashboard(
+      WORKOS_CLIENT_ID,
+      WORKOS_AUTH_DOMAIN,
+      CONVEX_SERVICE_ROLE_KEY,
+    );
   }
 
   const devCommand = useLocal ? "pnpm run dev:local" : "pnpm run dev";


### PR DESCRIPTION
## Summary

- Configure the WorkOS Authentication API domain with `WORKOS_AUTH_DOMAIN` instead of hardcoding HackerAI's domain.
- Default the open-source setup flow and `.env.local.example` to `api.workos.com`, while allowing custom domains such as `auth.hackerai.co`.
- Build the client-scoped WorkOS issuer/JWKS URLs without `applicationID`, matching tokens that do not include an `aud` claim.
- Validate and normalize the configured hostname or HTTPS origin, with focused auth-config tests.

## Why

#980 correctly identified that HackerAI's custom WorkOS auth domain must be used for HackerAI deployments, but hardcoding it would break open-source/self-hosted deployments. Convex also treats environment variables referenced by auth config as deployment requirements even when JavaScript supplies a fallback, so the setup flow writes an explicit standard default instead.

## Validation

- `pnpm exec jest convex/__tests__/auth.config.test.ts --runInBand`
- `pnpm exec eslint scripts/setup.ts convex/auth.config.ts convex/__tests__/auth.config.test.ts`
- `pnpm prettier --check scripts/setup.ts convex/auth.config.ts convex/__tests__/auth.config.test.ts`
- `pnpm typecheck`
- `git diff --check`

## Manual verification

1. In a standard WorkOS/self-hosted deployment, set `WORKOS_AUTH_DOMAIN=api.workos.com` in Convex and sign in.
2. In HackerAI's deployment, set `WORKOS_AUTH_DOMAIN=auth.hackerai.co` in Convex and sign in.
3. Confirm Convex accepts the WorkOS JWT and authenticated queries succeed in both cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable WorkOS authentication domains, supporting both the standard WorkOS domain and custom domains.
  * Added setup prompts and environment configuration for the WorkOS authentication domain.
  * Added validation and normalization for HTTPS authentication domain values.

* **Bug Fixes**
  * Improved authentication provider URL generation based on the configured domain.
  * Invalid domain configurations now produce clear validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->