### PR TITLE
Remove stale model routing aliases

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/ai/providers";
 
 describe("provider registry", () => {
-  it("keeps active routes and stale compatibility keys pointed at their provider slugs", () => {
+  it("keeps active routes pointed at their provider slugs", () => {
     expect(
       (myProvider.languageModel("ask-model") as { modelId: string }).modelId,
     ).toBe("x-ai/grok-4.5");
@@ -17,10 +17,6 @@ describe("provider registry", () => {
       (myProvider.languageModel("agent-model-free") as { modelId: string })
         .modelId,
     ).toBe("deepseek/deepseek-v4-flash");
-    expect(
-      (myProvider.languageModel("model-minimax-m3") as { modelId: string })
-        .modelId,
-    ).toBe("x-ai/grok-4.5");
     expect(
       (myProvider.languageModel("model-grok-4.5") as { modelId: string })
         .modelId,
@@ -33,20 +29,6 @@ describe("provider registry", () => {
       (myProvider.languageModel("model-glm-5.2") as { modelId: string })
         .modelId,
     ).toBe("z-ai/glm-5.2");
-    expect(
-      (
-        myProvider.languageModel("model-gemini-3-flash") as {
-          modelId: string;
-        }
-      ).modelId,
-    ).toBe("x-ai/grok-4.5");
-    expect(
-      (
-        myProvider.languageModel("model-kimi-k2.6") as {
-          modelId: string;
-        }
-      ).modelId,
-    ).toBe("moonshotai/kimi-k2.7-code:exacto");
     expect(
       (myProvider.languageModel("model-kimi-k3") as { modelId: string })
         .modelId,
@@ -63,26 +45,32 @@ describe("provider registry", () => {
       (myProvider.languageModel("title-generator-model") as { modelId: string })
         .modelId,
     ).toBe("deepseek/deepseek-v4-flash");
-    expect(getModelDisplayName("model-minimax-m3")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-grok-4.5")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-grok-4.5-pro")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("model-glm-5.2")).toBe("Z.ai GLM 5.2");
     expect(getModelDisplayName("model-kimi-k3")).toBe("Moonshot Kimi K3");
-    expect(getModelDisplayName("model-gemini-3-flash")).toBe("xAI Grok 4.5");
     expect(getModelDisplayName("title-generator-model")).toBe(
       "DeepSeek V4 Flash",
     );
   });
 
-  it("does not register the retired Sonnet route", () => {
-    expect(() => myProvider.languageModel("model-sonnet-4.6")).toThrow();
+  it.each([
+    "model-sonnet-4.6",
+    "model-gemini-3-flash",
+    "model-minimax-m3",
+    "model-kimi-k2.6",
+    "model-kimi-k2.7-code",
+    "model-deepseek-v4-flash",
+    "fallback-grok-4.5",
+  ])("does not register retired route %s", (modelName) => {
+    expect(() => myProvider.languageModel(modelName)).toThrow();
   });
 });
 
 describe("sanitizeOpenRouterRequestForXai", () => {
   it("strips encrypted reasoning details when an OpenRouter fallback can route to xAI", () => {
     const body = {
-      model: "moonshotai/kimi-k2.7-code:exacto",
+      model: "moonshotai/kimi-k3",
       models: ["x-ai/grok-4.5"],
       messages: [
         {
@@ -146,7 +134,7 @@ describe("sanitizeOpenRouterRequestForXai", () => {
 
   it("leaves non-xAI routes unchanged", () => {
     const body = {
-      model: "moonshotai/kimi-k2.7-code:exacto",
+      model: "moonshotai/kimi-k3",
       messages: [
         {
           role: "assistant",
@@ -209,32 +197,34 @@ describe("sanitizeOpenRouterRequestForXai", () => {
 });
 
 describe("supportsMultimodalToolResults", () => {
-  it("allows Grok aliases and Kimi routes for image tool result experiments", () => {
+  it("allows active Grok and Kimi routes for image tool results", () => {
     expect(supportsMultimodalToolResults("agent-model")).toBe(true);
     expect(supportsMultimodalToolResults("ask-model")).toBe(true);
-    expect(supportsMultimodalToolResults("model-minimax-m3")).toBe(true);
     expect(supportsMultimodalToolResults("fallback-agent-model")).toBe(true);
     expect(supportsMultimodalToolResults("fallback-ask-model")).toBe(true);
     expect(supportsMultimodalToolResults("model-kimi-k3")).toBe(true);
-    expect(supportsMultimodalToolResults("model-kimi-k2.7-code")).toBe(true);
-    expect(
-      supportsMultimodalToolResults("moonshotai/kimi-k2.7-code:exacto"),
-    ).toBe(true);
+    expect(supportsMultimodalToolResults("moonshotai/kimi-k3")).toBe(true);
   });
 
-  it("allows multimodal fallback keys and slugs used after image tool results", () => {
+  it("allows active multimodal keys and slugs used after image tool results", () => {
     expect(supportsMultimodalToolResults("model-grok-4.5")).toBe(true);
     expect(supportsMultimodalToolResults("model-grok-4.5-pro")).toBe(true);
-    expect(supportsMultimodalToolResults("model-gemini-3-flash")).toBe(true);
-    expect(supportsMultimodalToolResults("fallback-grok-4.5")).toBe(true);
     expect(supportsMultimodalToolResults("x-ai/grok-4.5")).toBe(true);
   });
 
-  it("still rejects text-only DeepSeek model keys", () => {
+  it("rejects text-only DeepSeek model keys", () => {
     expect(supportsMultimodalToolResults("agent-model-free")).toBe(false);
-    expect(supportsMultimodalToolResults("model-deepseek-v4-flash")).toBe(
-      false,
-    );
     expect(supportsMultimodalToolResults("model-deepseek-v4-pro")).toBe(false);
+  });
+
+  it.each([
+    "model-gemini-3-flash",
+    "model-minimax-m3",
+    "model-kimi-k2.6",
+    "model-kimi-k2.7-code",
+    "model-deepseek-v4-flash",
+    "fallback-grok-4.5",
+  ])("does not classify retired route %s as multimodal", (modelName) => {
+    expect(supportsMultimodalToolResults(modelName)).toBe(false);
   });
 });

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -2,9 +2,6 @@ import { customProvider } from "ai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import type { ChatMode, SelectedModel } from "@/types/chat";
 import { openrouterAttributionHeaders } from "@/lib/ai/openrouter-attribution";
-// import { withTracing } from "@posthog/ai";
-// import PostHogClient from "@/app/posthog";
-// import type { SubscriptionTier } from "@/types";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -177,7 +174,6 @@ const openrouter = createOpenRouter({
 
 type OpenRouterInstance = typeof openrouter;
 
-export const KIMI_K2_7_CODE_SLUG = "moonshotai/kimi-k2.7-code:exacto";
 export const KIMI_K3_SLUG = "moonshotai/kimi-k3";
 export const GLM_5_2_SLUG = "z-ai/glm-5.2";
 export const GROK_4_5_SLUG = "x-ai/grok-4.5";
@@ -191,26 +187,14 @@ const buildProviderMap = (or: OpenRouterInstance) =>
     "agent-model-free": or(DEEPSEEK_V4_FLASH_SLUG),
     "model-grok-4.5": or(GROK_4_5_SLUG),
     // Dedicated HackerAI Pro alias so its GLM fallback can evolve without
-    // changing Standard PDF or legacy Grok fallback behavior.
+    // changing Standard media fallback behavior.
     "model-grok-4.5-pro": or(GROK_4_5_SLUG),
-    // Compatibility alias for stale internal references persisted before the
-    // paid Ask PDF route settled on Grok 4.5.
-    "model-gemini-3-flash": or(GROK_4_5_SLUG),
-    "model-deepseek-v4-flash": or(DEEPSEEK_V4_FLASH_SLUG),
     "model-deepseek-v4-pro": or("deepseek/deepseek-v4-pro"),
     "model-opus-4.6": or("anthropic/claude-opus-4.6"),
     "model-glm-5.2": or(GLM_5_2_SLUG),
-    // Compatibility alias for persisted MiniMax selections. All new and stale
-    // callers now resolve to Grok 4.5 so no route continues sending MiniMax.
-    "model-minimax-m3": or(GROK_4_5_SLUG),
     "model-kimi-k3": or(KIMI_K3_SLUG),
-    "model-kimi-k2.7-code": or(KIMI_K2_7_CODE_SLUG),
-    // Compatibility alias for stale internal references persisted before the
-    // Kimi 2.7 Code rollout. New Agent Standard media selections use Grok 4.5.
-    "model-kimi-k2.6": or(KIMI_K2_7_CODE_SLUG),
     "fallback-agent-model": or(GROK_4_5_SLUG),
     "fallback-ask-model": or(GROK_4_5_SLUG),
-    "fallback-grok-4.5": or(GROK_4_5_SLUG),
     // Titles are a short structured-output task and should never use reasoning.
     "title-generator-model": or(DEEPSEEK_V4_FLASH_SLUG),
   }) as Record<string, any>;
@@ -227,17 +211,11 @@ export const modelCutoffDates: Record<ModelName, string> &
   "agent-model-free": "May 2025",
   "model-grok-4.5": "July 2026",
   "model-grok-4.5-pro": "July 2026",
-  "model-gemini-3-flash": "July 2026",
-  "model-deepseek-v4-flash": "May 2025",
   "model-deepseek-v4-pro": "May 2025",
   "model-opus-4.6": "May 2025",
   "model-glm-5.2": "June 2026",
-  "model-minimax-m3": "July 2026",
-  "model-kimi-k2.7-code": "June 2025",
-  "model-kimi-k2.6": "June 2025",
   "fallback-agent-model": "July 2026",
   "fallback-ask-model": "July 2026",
-  "fallback-grok-4.5": "July 2026",
   "title-generator-model": "May 2025",
 };
 
@@ -249,18 +227,12 @@ export const modelDisplayNames: Record<ModelName, string> &
   "agent-model-free": "Auto, an intelligent model router built by HackerAI",
   "model-grok-4.5": "xAI Grok 4.5",
   "model-grok-4.5-pro": "xAI Grok 4.5",
-  "model-gemini-3-flash": "xAI Grok 4.5",
-  "model-deepseek-v4-flash": "DeepSeek V4 Flash",
   "model-deepseek-v4-pro": "DeepSeek V4 Pro",
   "model-opus-4.6": "Anthropic Claude Opus 4.6",
   "model-glm-5.2": "Z.ai GLM 5.2",
-  "model-minimax-m3": "xAI Grok 4.5",
   "model-kimi-k3": "Moonshot Kimi K3",
-  "model-kimi-k2.7-code": "Moonshot Kimi K2.7 Code",
-  "model-kimi-k2.6": "Moonshot Kimi K2.7 Code",
   "fallback-agent-model": "Auto, an intelligent model router built by HackerAI",
   "fallback-ask-model": "Auto, an intelligent model router built by HackerAI",
-  "fallback-grok-4.5": "Auto, an intelligent model router built by HackerAI",
   "title-generator-model": "DeepSeek V4 Flash",
 };
 
@@ -280,7 +252,6 @@ export function isDeepSeekModel(modelName: string): boolean {
   return (
     modelName === "ask-model-free" ||
     modelName === "agent-model-free" ||
-    modelName === "model-deepseek-v4-flash" ||
     modelName === "model-deepseek-v4-pro"
   );
 }
@@ -288,10 +259,7 @@ export function isDeepSeekModel(modelName: string): boolean {
 export function isKimiModel(modelName: string): boolean {
   const normalized = modelName.toLowerCase();
   return (
-    normalized === "model-kimi-k2.7-code" ||
-    normalized === "model-kimi-k2.6" ||
-    normalized.includes("moonshotai/kimi") ||
-    normalized.includes("kimi-")
+    normalized === "model-kimi-k3" || normalized.includes("moonshotai/kimi")
   );
 }
 
@@ -302,10 +270,10 @@ function isGrokModel(modelName: string): boolean {
     normalized === "ask-model" ||
     normalized === "fallback-agent-model" ||
     normalized === "fallback-ask-model" ||
-    normalized === "model-minimax-m3" ||
-    normalized === "model-gemini-3-flash" ||
+    normalized === "model-grok-4.5" ||
+    normalized === "model-grok-4.5-pro" ||
     normalized.includes("x-ai/") ||
-    normalized.includes("grok")
+    normalized === "grok-4.5"
   );
 }
 
@@ -353,34 +321,4 @@ export const myProvider = customProvider({
   languageModels: baseProviders,
 });
 
-export const createTrackedProvider = () =>
-  // userId?: string,
-  // conversationId?: string,
-  // subscription?: SubscriptionTier,
-  // phClient?: ReturnType<typeof PostHogClient> | null,
-  {
-    // PostHog provider tracking disabled
-    // if (!phClient || subscription === "free") {
-    //   return myProvider;
-    // }
-    //
-    // const trackedModels: Record<string, any> = {};
-    //
-    // Object.entries(baseProviders).forEach(([modelName, model]) => {
-    //   trackedModels[modelName] = withTracing(model, phClient, {
-    //     ...(userId && { posthogDistinctId: userId }),
-    //     posthogProperties: {
-    //       modelType: modelName,
-    //       ...(conversationId && { conversationId }),
-    //       subscriptionTier: subscription,
-    //     },
-    //     posthogPrivacyMode: true,
-    //   });
-    // });
-    //
-    // return customProvider({
-    //   languageModels: trackedModels,
-    // });
-
-    return myProvider;
-  };
+export const createTrackedProvider = () => myProvider;

--- a/lib/ai/tools/__tests__/file.test.ts
+++ b/lib/ai/tools/__tests__/file.test.ts
@@ -582,7 +582,7 @@ describe("file tool image view", () => {
       });
     const sandbox = makeSandbox(commandRun);
     const tool = createFile(
-      makeContext(sandbox, { modelName: "model-kimi-k2.7-code" }),
+      makeContext(sandbox, { modelName: "model-kimi-k3" }),
     );
 
     const result = await runTool(tool, {
@@ -888,7 +888,7 @@ describe("file tool image view", () => {
     });
     const sandbox = makeSandbox(commandRun);
     const tool = createFile(
-      makeContext(sandbox, { modelName: "model-kimi-k2.7-code" }),
+      makeContext(sandbox, { modelName: "model-kimi-k3" }),
     );
 
     await expect(
@@ -934,7 +934,7 @@ describe("file tool image view", () => {
     });
     const sandbox = makeSandbox(commandRun);
     const tool = createFile(
-      makeContext(sandbox, { modelName: "model-kimi-k2.7-code" }),
+      makeContext(sandbox, { modelName: "model-kimi-k3" }),
     );
 
     await expect(

--- a/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
+++ b/lib/api/__tests__/agent-stream-runner-multi-compaction.test.ts
@@ -76,9 +76,7 @@ jest.mock("@/lib/chat/multimodal-tool-result-recovery", () => ({
 jest.mock("@/lib/ai/providers", () => ({
   isAnthropicModel: () => false,
   isDeepSeekModel: (modelName: string) =>
-    modelName === "agent-model-free" ||
-    modelName === "model-deepseek-v4-pro" ||
-    modelName === "model-deepseek-v4-flash",
+    modelName === "agent-model-free" || modelName === "model-deepseek-v4-pro",
 }));
 jest.mock("@/lib/ai/tools/utils/pty-session-manager", () => ({
   ptySessionManager: { closeAllSessions: jest.fn() },
@@ -197,8 +195,8 @@ describe("resolveAgentModelForImageToolResults", () => {
       ),
     ).toBe("model-deepseek-v4-pro");
     expect(
-      resolveAgentModelForImageToolResults("model-minimax-m3", "agent", true),
-    ).toBe("model-minimax-m3");
+      resolveAgentModelForImageToolResults("model-kimi-k3", "agent", true),
+    ).toBe("model-kimi-k3");
     expect(
       resolveAgentModelForImageToolResults("model-grok-4.5-pro", "agent", true),
     ).toBe("model-grok-4.5-pro");

--- a/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
+++ b/lib/api/__tests__/chat-stream-helpers-fallback.test.ts
@@ -34,18 +34,12 @@ const GROK_PRIMARY_OR_FALLBACK_MODELS = [
   "agent-model-free",
   "model-grok-4.5",
   "model-grok-4.5-pro",
-  "model-gemini-3-flash",
-  "model-deepseek-v4-flash",
   "model-deepseek-v4-pro",
   "model-opus-4.6",
   "model-glm-5.2",
-  "model-minimax-m3",
   "model-kimi-k3",
-  "model-kimi-k2.7-code",
-  "model-kimi-k2.6",
   "fallback-agent-model",
   "fallback-ask-model",
-  "fallback-grok-4.5",
 ] as const;
 
 describe("buildProviderOptions fallback chain", () => {
@@ -129,36 +123,23 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("falls back from the Grok-backed auto agent route to Kimi K3", () => {
-    const opts = buildProviderOptions(false, "user-1", "agent-model", "agent");
-    expect(opts.openrouter).toMatchObject({
-      models: [KIMI_K3_SLUG],
-      user: "user-1",
-    });
-  });
-
-  it("keeps the stale MiniMax key on Grok's Kimi K3 fallback", () => {
+  it("resolves Kimi K3 fallback through the active Grok route", () => {
     const opts = buildProviderOptions(
       false,
       "user-1",
-      "model-minimax-m3",
-      "agent",
-    );
-    expect(opts.openrouter).toMatchObject({
-      models: [KIMI_K3_SLUG],
-      user: "user-1",
-    });
-  });
-
-  it("falls back from explicit Kimi 2.7 Code to Grok", () => {
-    const opts = buildProviderOptions(
-      false,
-      "user-1",
-      "model-kimi-k2.7-code",
+      "model-kimi-k3",
       "agent",
     );
     expect(opts.openrouter).toMatchObject({
       models: [GROK_SLUG],
+      user: "user-1",
+    });
+  });
+
+  it("falls back from the Grok-backed auto agent route to Kimi K3", () => {
+    const opts = buildProviderOptions(false, "user-1", "agent-model", "agent");
+    expect(opts.openrouter).toMatchObject({
+      models: [KIMI_K3_SLUG],
       user: "user-1",
     });
   });
@@ -180,7 +161,7 @@ describe("buildProviderOptions fallback chain", () => {
     },
   );
 
-  it("keeps the legacy Agent vision Grok route on its direct Kimi K3 fallback", () => {
+  it("keeps the Standard Agent media route on its direct Kimi K3 fallback", () => {
     const opts = buildProviderOptions(
       true,
       "user-1",
@@ -193,19 +174,13 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it.each([
-    ["ask-model-free", "ask"],
-    ["model-deepseek-v4-flash", "ask"],
-  ] as const)(
-    "falls back from free DeepSeek route %s through the paid Agent chain with Kimi K3",
-    (modelName, mode) => {
-      const opts = buildProviderOptions(false, "user-1", modelName, mode);
-      expect(opts.openrouter).toMatchObject({
-        models: [GROK_SLUG, KIMI_K3_SLUG],
-        user: "user-1",
-      });
-    },
-  );
+  it("falls back from free Ask DeepSeek through Grok then Kimi K3", () => {
+    const opts = buildProviderOptions(false, "user-1", "ask-model-free", "ask");
+    expect(opts.openrouter).toMatchObject({
+      models: [GROK_SLUG, KIMI_K3_SLUG],
+      user: "user-1",
+    });
+  });
 
   it("runs free Agent on DeepSeek Flash high and falls back through Grok then Kimi K3", () => {
     const opts = buildProviderOptions(
@@ -251,14 +226,6 @@ describe("buildProviderOptions fallback chain", () => {
     });
   });
 
-  it("keeps the stale media route alias on the active Ask fallback chain", () => {
-    const opts = buildProviderOptions(false, "user-1", "model-gemini-3-flash");
-    expect(opts.openrouter).toMatchObject({
-      models: [KIMI_K3_SLUG],
-      user: "user-1",
-    });
-  });
-
   it("does not throw for an unknown registry key — no chain, no slug", () => {
     expect(() =>
       buildProviderOptions(false, "user-1", "model-does-not-exist"),
@@ -272,16 +239,13 @@ describe("buildProviderOptions fallback chain", () => {
     expect(opts.openrouter).not.toHaveProperty("models");
   });
 
-  it.each(["ask-model-free", "model-deepseek-v4-flash"])(
-    "uses high reasoning when free/flash ask model %s can fall back to Grok",
-    (modelName) => {
-      const opts = buildProviderOptions(false, "user-1", modelName, "ask");
-      expect(opts.openrouter.reasoning).toEqual({
-        enabled: true,
-        effort: "high",
-      });
-    },
-  );
+  it("uses high reasoning when free Ask can fall back to Grok", () => {
+    const opts = buildProviderOptions(false, "user-1", "ask-model-free", "ask");
+    expect(opts.openrouter.reasoning).toEqual({
+      enabled: true,
+      effort: "high",
+    });
+  });
 
   it("keeps Grok fallback reasoning high over a lower scoped override", () => {
     const opts = buildProviderOptions(
@@ -319,40 +283,7 @@ describe("buildProviderOptions fallback chain", () => {
     expect(opts.openrouter).not.toHaveProperty("models");
   });
 
-  it("enables reasoning for the current Kimi 2.7 Code ask route", () => {
-    const opts = buildProviderOptions(
-      false,
-      "user-1",
-      "model-kimi-k2.7-code",
-      "ask",
-    );
-    expect(opts.openrouter.reasoning).toEqual({
-      enabled: true,
-      effort: "high",
-    });
-  });
-
-  it("keeps reasoning enabled for the legacy Kimi 2.6 alias", () => {
-    const opts = buildProviderOptions(
-      false,
-      "user-1",
-      "model-kimi-k2.6",
-      "ask",
-    );
-    expect(opts.openrouter.reasoning).toEqual({
-      enabled: true,
-      effort: "high",
-    });
-  });
-
-  it.each([
-    "model-deepseek-v4-pro",
-    "ask-model",
-    "model-minimax-m3",
-    "model-grok-4.5",
-    "model-gemini-3-flash",
-    "fallback-grok-4.5",
-  ])(
+  it.each(["model-deepseek-v4-pro", "ask-model", "model-grok-4.5"])(
     "enables high reasoning for Grok-backed ask mode model %s",
     (modelName) => {
       const opts = buildProviderOptions(false, "user-1", modelName, "ask");
@@ -479,15 +410,11 @@ describe("isAutoModelSelectionForRetry", () => {
 });
 
 describe("getRetryFallbackModel", () => {
-  it.each([
-    ["ask-model-free", "ask"],
-    ["model-deepseek-v4-flash", "ask"],
-  ] as const)(
-    "uses the paid Agent fallback chain for app-side retry after free DeepSeek route %s fails",
-    (modelName, mode) => {
-      expect(getRetryFallbackModel(modelName, mode)).toBe("model-grok-4.5");
-    },
-  );
+  it("uses Grok for app-side retry after free Ask DeepSeek fails", () => {
+    expect(getRetryFallbackModel("ask-model-free", "ask")).toBe(
+      "model-grok-4.5",
+    );
+  });
 
   it("retries free Agent DeepSeek Flash with Grok", () => {
     expect(getRetryFallbackModel("agent-model-free", "agent")).toBe(
@@ -517,7 +444,7 @@ describe("getRetryFallbackModel", () => {
     );
   });
 
-  it("retries the legacy Agent vision Grok route with Kimi K3", () => {
+  it("retries the Standard Agent media route with Kimi K3", () => {
     expect(getRetryFallbackModel("model-grok-4.5", "agent")).toBe(
       "model-kimi-k3",
     );
@@ -529,15 +456,17 @@ describe("getRetryFallbackModel", () => {
     );
   });
 
-  it.each([
-    ["model-grok-4.5", "ask"],
-    ["model-gemini-3-flash", "ask"],
-  ] as const)(
-    "retries Grok-backed paid Ask route %s with Kimi K3",
-    (modelName, mode) => {
-      expect(getRetryFallbackModel(modelName, mode)).toBe("model-kimi-k3");
-    },
-  );
+  it("retries Kimi K3 with the active Grok route", () => {
+    expect(getRetryFallbackModel("model-kimi-k3", "agent")).toBe(
+      "model-grok-4.5",
+    );
+  });
+
+  it("retries the Grok-backed paid Ask route with Kimi K3", () => {
+    expect(getRetryFallbackModel("model-grok-4.5", "ask")).toBe(
+      "model-kimi-k3",
+    );
+  });
 });
 
 describe("resolveServedModelForCostAccounting", () => {
@@ -581,6 +510,16 @@ describe("resolveServedModelForCostAccounting", () => {
     ).toBe("model-grok-4.5");
   });
 
+  it("maps a Grok slug served from Kimi K3 fallback to the active cost key", () => {
+    expect(
+      resolveServedModelForCostAccounting({
+        modelName: "model-kimi-k3",
+        responseModel: GROK_SLUG,
+        mode: "agent",
+      }),
+    ).toBe("model-grok-4.5");
+  });
+
   it("maps the dated Kimi K3 provider slug back to the Kimi K3 cost key", () => {
     expect(
       resolveServedModelForCostAccounting({
@@ -615,7 +554,7 @@ describe("resolveServedModelForCostAccounting", () => {
     ).toBe("model-kimi-k3");
   });
 
-  it("maps legacy Agent Pro vision Kimi K3 fallback usage back to the Kimi K3 cost key", () => {
+  it("maps Standard Agent media Kimi K3 fallback usage back to its cost key", () => {
     expect(
       resolveServedModelForCostAccounting({
         modelName: "model-grok-4.5",

--- a/lib/api/chat-stream-helpers.ts
+++ b/lib/api/chat-stream-helpers.ts
@@ -528,7 +528,7 @@ export class SummarizationTracker {
  */
 const KIMI_K3_THEN_GROK_FALLBACK_CHAIN = [
   "model-kimi-k3",
-  "fallback-grok-4.5",
+  "model-grok-4.5",
 ] as const satisfies readonly ModelName[];
 
 const GROK_4_5_FALLBACK_CHAIN = [
@@ -551,20 +551,15 @@ const HACKERAI_PRO_FALLBACK_CHAIN = [
 const MODEL_FALLBACK_CHAIN: Partial<Record<ModelName, readonly ModelName[]>> = {
   "ask-model-free": AGENT_TEXT_FALLBACK_CHAIN,
   "agent-model-free": AGENT_TEXT_FALLBACK_CHAIN,
-  "model-deepseek-v4-flash": AGENT_TEXT_FALLBACK_CHAIN,
   "model-deepseek-v4-pro": AGENT_TEXT_FALLBACK_CHAIN,
   "ask-model": GROK_4_5_FALLBACK_CHAIN,
   "agent-model": GROK_4_5_FALLBACK_CHAIN,
   "model-grok-4.5": GROK_4_5_FALLBACK_CHAIN,
   "model-grok-4.5-pro": HACKERAI_PRO_FALLBACK_CHAIN,
-  "model-gemini-3-flash": GROK_4_5_FALLBACK_CHAIN,
   "model-glm-5.2": KIMI_K3_THEN_GROK_FALLBACK_CHAIN,
-  "model-minimax-m3": GROK_4_5_FALLBACK_CHAIN,
   "fallback-agent-model": GROK_4_5_FALLBACK_CHAIN,
   "fallback-ask-model": GROK_4_5_FALLBACK_CHAIN,
-  "model-kimi-k3": ["fallback-grok-4.5"],
-  "model-kimi-k2.7-code": ["fallback-grok-4.5"],
-  "model-kimi-k2.6": ["fallback-grok-4.5"],
+  "model-kimi-k3": ["model-grok-4.5"],
 };
 
 const AUTO_MODEL_KEYS = new Set<string>([
@@ -597,15 +592,6 @@ const HIGH_REASONING_MODELS = [
 const isHighReasoningModel = (modelName?: string): boolean =>
   typeof modelName === "string" &&
   (HIGH_REASONING_MODELS as readonly string[]).includes(modelName);
-
-const ASK_KIMI_REASONING_MODELS = [
-  "model-kimi-k2.7-code",
-  "model-kimi-k2.6",
-] as const satisfies readonly ModelName[];
-
-const isAskKimiReasoningModel = (modelName?: string): boolean =>
-  typeof modelName === "string" &&
-  (ASK_KIMI_REASONING_MODELS as readonly string[]).includes(modelName);
 
 type FallbackOptions = {
   hasMultimodalToolResults?: boolean;
@@ -641,7 +627,6 @@ export function getRetryFallbackModel(
   if (
     modelName === "ask-model-free" ||
     modelName === "agent-model-free" ||
-    modelName === "model-deepseek-v4-flash" ||
     modelName === "model-deepseek-v4-pro"
   ) {
     return "model-grok-4.5";
@@ -650,14 +635,12 @@ export function getRetryFallbackModel(
     modelName === "ask-model" ||
     modelName === "agent-model" ||
     modelName === "model-grok-4.5" ||
-    modelName === "model-gemini-3-flash" ||
-    modelName === "model-minimax-m3" ||
     modelName === "fallback-agent-model" ||
     modelName === "fallback-ask-model"
   ) {
     return "model-kimi-k3";
   }
-  return "fallback-grok-4.5";
+  return "model-grok-4.5";
 }
 
 const resolveSlug = (modelName: string): string | undefined => {
@@ -698,8 +681,6 @@ const OPENROUTER_RESPONSE_MODEL_COST_KEYS: Record<string, ModelName> = {
   "z-ai/glm-5.2-20260616": "model-glm-5.2",
   "moonshotai/kimi-k3": "model-kimi-k3",
   "moonshotai/kimi-k3-20260715": "model-kimi-k3",
-  "moonshotai/kimi-k2.7-code": "model-kimi-k2.7-code",
-  "moonshotai/kimi-k2.7-code:exacto": "model-kimi-k2.7-code",
 };
 
 function resolveOpenRouterResponseModelCostKey(
@@ -778,11 +759,7 @@ export function buildProviderOptions(
               enabled: true,
               ...(isDeepSeekV4 ? { effort: "xhigh" } : {}),
             }
-          : mode === "ask" && isAskKimiReasoningModel(modelName)
-            ? {
-                enabled: true,
-              }
-            : { enabled: false }));
+          : { enabled: false }));
 
   return {
     openrouter: {

--- a/lib/rate-limit/__tests__/token-bucket.test.ts
+++ b/lib/rate-limit/__tests__/token-bucket.test.ts
@@ -490,13 +490,10 @@ describe("token-bucket", () => {
     it.each([
       "model-grok-4.5",
       "model-grok-4.5-pro",
-      "model-gemini-3-flash",
       "ask-model",
       "agent-model",
-      "model-minimax-m3",
       "fallback-agent-model",
       "fallback-ask-model",
-      "fallback-grok-4.5",
     ])("should use Grok 4.5 pricing for %s ($2.00/$6.00)", (modelName) => {
       expect(calculateTokenCost(1_000_000, "input", modelName)).toBe(28000);
       expect(calculateTokenCost(1_000_000, "output", modelName)).toBe(84000);

--- a/lib/rate-limit/token-bucket.ts
+++ b/lib/rate-limit/token-bucket.ts
@@ -69,12 +69,6 @@ const GLM_5_2_PRICING: ModelPricing = {
   cacheRead: 0.14,
   cacheWrite: 0.76,
 };
-const KIMI_K2_7_CODE_PRICING: ModelPricing = {
-  input: 0.95,
-  output: 4.0,
-  cacheRead: 0.19,
-  cacheWrite: 0.95,
-};
 const KIMI_K3_PRICING: ModelPricing = {
   input: 3.0,
   output: 15.0,
@@ -88,28 +82,20 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   // Grok 4.5 rates from OpenRouter: $2.00 in / $6.00 out per 1M tokens.
   "model-grok-4.5": GROK_4_5_PRICING,
   "model-grok-4.5-pro": GROK_4_5_PRICING,
-  "model-gemini-3-flash": GROK_4_5_PRICING,
-  // Auto and compatibility aliases now resolve to Grok 4.5.
+  // Auto and summarization aliases resolve to Grok 4.5.
   "ask-model": GROK_4_5_PRICING,
   "agent-model": GROK_4_5_PRICING,
-  "model-minimax-m3": GROK_4_5_PRICING,
   "fallback-agent-model": GROK_4_5_PRICING,
   "fallback-ask-model": GROK_4_5_PRICING,
   // Rates from OpenRouter: $0.09 in / $0.18 out per 1M tokens.
   "ask-model-free": DEEPSEEK_V4_FLASH_PRICING,
   "agent-model-free": DEEPSEEK_V4_FLASH_PRICING,
-  "model-deepseek-v4-flash": DEEPSEEK_V4_FLASH_PRICING,
   "model-deepseek-v4-pro": DEEPSEEK_V4_PRO_PRICING,
-  "fallback-grok-4.5": GROK_4_5_PRICING,
   "model-opus-4.6": OPUS_4_6_PRICING,
   // Baseline OpenRouter rates: $0.76 in / $2.42 out per 1M tokens.
   "model-glm-5.2": GLM_5_2_PRICING,
   // OpenRouter rates: $3.00 in / $15.00 out / $0.30 cached input per 1M tokens.
   "model-kimi-k3": KIMI_K3_PRICING,
-  // Kimi keys are retained as compatibility aliases for stale persisted routes.
-  // Rates from OpenRouter: $0.95 in / $4.00 out per 1M tokens.
-  "model-kimi-k2.7-code": KIMI_K2_7_CODE_PRICING,
-  "model-kimi-k2.6": KIMI_K2_7_CODE_PRICING,
   // Provider response ids can reach accounting before local-key normalization.
   "x-ai/grok-4.5": GROK_4_5_PRICING,
   "deepseek/deepseek-v4-flash": DEEPSEEK_V4_FLASH_PRICING,
@@ -119,8 +105,6 @@ const MODEL_PRICING_MAP: Record<string, ModelPricing> = {
   "z-ai/glm-5.2-20260616": GLM_5_2_PRICING,
   "moonshotai/kimi-k3": KIMI_K3_PRICING,
   "moonshotai/kimi-k3-20260715": KIMI_K3_PRICING,
-  "moonshotai/kimi-k2.7-code": KIMI_K2_7_CODE_PRICING,
-  "moonshotai/kimi-k2.7-code:exacto": KIMI_K2_7_CODE_PRICING,
 };
 
 const getModelPricing = (modelName?: string): ModelPricing => {

--- a/scripts/check-openrouter-gen-id.ts
+++ b/scripts/check-openrouter-gen-id.ts
@@ -25,7 +25,7 @@ config({ path: resolve(process.cwd(), ".env.local") });
 
 import { extractRetryAttempts } from "../lib/utils/error-utils";
 
-const VALID_SLUG = "moonshotai/kimi-k2.7-code:exacto";
+const VALID_SLUG = "deepseek/deepseek-v4-flash";
 const INVALID_SLUG = "anthropic/this-model-does-not-exist-please-fail";
 
 function classify(id: string | undefined): string {
@@ -124,8 +124,7 @@ async function probeError(openrouter: ReturnType<typeof createOpenRouter>) {
 
   const e = caught as Record<string, unknown>;
   const inner = (e as { errors?: unknown[] }).errors?.[0] as
-    | Record<string, unknown>
-    | undefined;
+    Record<string, unknown> | undefined;
 
   console.log(`\nouter error: ${(caught as Error).name}`);
   console.log(
@@ -136,8 +135,7 @@ async function probeError(openrouter: ReturnType<typeof createOpenRouter>) {
     console.log(`\ninner attempt fields used by extractRequestId:`);
     console.log(`  statusCode: ${inner.statusCode}`);
     const data = inner.data as
-      | { id?: unknown; request_id?: unknown }
-      | undefined;
+      { id?: unknown; request_id?: unknown } | undefined;
     console.log(`  data.id: ${data?.id ?? "(missing)"}`);
     console.log(`  data.request_id: ${data?.request_id ?? "(missing)"}`);
     console.log(


### PR DESCRIPTION
## Summary

- remove unreachable Gemini, MiniMax, Kimi 2.x, and direct DeepSeek Flash provider keys from the registry
- remove their fallback, reasoning, display, cutoff, pricing, and served-model accounting branches
- replace the duplicate `fallback-grok-4.5` alias with the active `model-grok-4.5` key for Kimi fallback and retry routing
- keep durable user-facing legacy selection migrations and active provider response-slug pricing intact
- update the OpenRouter gen-id probe to use the current inexpensive DeepSeek V4 Flash model and remove the disabled provider-tracing implementation

## Why

The retired `model-*` keys were server-internal outputs of routing. They are not restored from persisted chats or browser state: historical user-facing IDs are coerced to current HackerAI tiers before `selectModel` runs. After the recent route migrations, no live selector or fallback emitted these keys, so their compatibility branches only expanded the provider, reasoning, and accounting surface.

## Validation

- focused routing/provider/file-view/pricing tests: 5 suites, 186 tests passed
- `pnpm typecheck`
- scoped ESLint
- scoped Prettier check
- repository suite: 302 suites / 3000 tests passed in the restricted shell; the remaining two child-process suites were blocked there by sandbox `spawnSync EPERM` and passed separately outside the sandbox (2 suites / 6 tests)
- `git diff --check`

## Manual verification

1. In the preview, start Standard, Pro, and Max requests in both Ask and Agent modes.
2. Exercise an Agent image-view result on an active Grok or Kimi K3 route.
3. Confirm active models resolve without `NoSuchModelError` and Kimi K3 still falls back to Grok 4.5.

No visual verification is required; this changes backend model registration and routing only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved AI provider routing and fallback behavior across Grok, Kimi, DeepSeek, Opus, and GLM models.
  * Enhanced compatibility for reasoning-enabled requests and multimodal tool results.
* **Bug Fixes**
  * Improved handling of provider-specific request formats, including encrypted reasoning and Kimi tool calls.
  * Updated model pricing and cost tracking for current routing paths.
* **Maintenance**
  * Removed obsolete model aliases and refreshed provider validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->