### PR TITLE
Tighten Agent OOM memory checkpoints

### DIFF
--- a/lib/chat/__tests__/agent-long-memory-telemetry.test.ts
+++ b/lib/chat/__tests__/agent-long-memory-telemetry.test.ts
@@ -176,18 +176,19 @@ describe("AgentLongMemoryTelemetry", () => {
         readHeapLimit: () => 416 * MIB,
       });
 
-      telemetry.startPeriodicCheckpoints();
-      now = 2 * 60 * 1_000;
-      jest.advanceTimersByTime(2 * 60 * 1_000);
-      expect(emit).not.toHaveBeenCalled();
-
+      now = 30 * 1_000;
       telemetry.checkpoint({
         phase: "provider_request",
         providerRequest,
         retention,
       });
-      now = 4 * 60 * 1_000;
-      jest.advanceTimersByTime(2 * 60 * 1_000);
+      telemetry.startPeriodicCheckpoints();
+      now += 2 * 60 * 1_000 - 1;
+      jest.advanceTimersByTime(2 * 60 * 1_000 - 1);
+      expect(emit).toHaveBeenCalledTimes(1);
+
+      now += 1;
+      jest.advanceTimersByTime(1);
 
       expect(emit).toHaveBeenCalledTimes(2);
       expect(emit.mock.calls[1]?.[0]).toMatchObject({
@@ -198,7 +199,7 @@ describe("AgentLongMemoryTelemetry", () => {
       });
 
       telemetry.dispose();
-      now = 6 * 60 * 1_000;
+      now += 2 * 60 * 1_000;
       jest.advanceTimersByTime(2 * 60 * 1_000);
       expect(emit).toHaveBeenCalledTimes(2);
     } finally {

--- a/lib/chat/__tests__/agent-long-memory-telemetry.test.ts
+++ b/lib/chat/__tests__/agent-long-memory-telemetry.test.ts
@@ -155,6 +155,57 @@ describe("AgentLongMemoryTelemetry", () => {
     });
   });
 
+  it("emits bounded periodic checkpoints during long provider work", () => {
+    jest.useFakeTimers();
+    try {
+      let now = 0;
+      const emit = jest.fn();
+      const telemetry = new AgentLongMemoryTelemetry({
+        runId: "run_123",
+        chatId: "chat_123",
+        userId: "user_123",
+        emit,
+        now: () => now,
+        readMemory: () => ({
+          rss: 220 * MIB,
+          heapTotal: 180 * MIB,
+          heapUsed: 110 * MIB,
+          external: 0,
+          arrayBuffers: 0,
+        }),
+        readHeapLimit: () => 416 * MIB,
+      });
+
+      telemetry.startPeriodicCheckpoints();
+      now = 2 * 60 * 1_000;
+      jest.advanceTimersByTime(2 * 60 * 1_000);
+      expect(emit).not.toHaveBeenCalled();
+
+      telemetry.checkpoint({
+        phase: "provider_request",
+        providerRequest,
+        retention,
+      });
+      now = 4 * 60 * 1_000;
+      jest.advanceTimersByTime(2 * 60 * 1_000);
+
+      expect(emit).toHaveBeenCalledTimes(2);
+      expect(emit.mock.calls[1]?.[0]).toMatchObject({
+        checkpoint_reason: "periodic",
+        phase: "provider_request",
+        provider_request: providerRequest,
+        retention,
+      });
+
+      telemetry.dispose();
+      now = 6 * 60 * 1_000;
+      jest.advanceTimersByTime(2 * 60 * 1_000);
+      expect(emit).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it("forces a failure checkpoint and keeps prior high-water values", () => {
     let heapUsed = 200 * MIB;
     const emit = jest.fn();

--- a/lib/chat/agent-long-memory-telemetry.ts
+++ b/lib/chat/agent-long-memory-telemetry.ts
@@ -7,6 +7,7 @@ import type {
 
 const HEAP_GROWTH_CHECKPOINT_BYTES = 32 * 1024 * 1024;
 const CHECKPOINT_INTERVAL_MS = 10 * 60 * 1000;
+const PERIODIC_CHECKPOINT_INTERVAL_MS = 2 * 60 * 1000;
 
 type MemorySnapshot = {
   rss: number;
@@ -36,7 +37,8 @@ type MemoryCheckpointEvent = {
   chat_id: string;
   user_id: string;
   phase: MemoryCheckpointPhase;
-  checkpoint_reason: "initial" | "forced" | "heap_growth" | "interval";
+  checkpoint_reason:
+    "initial" | "forced" | "heap_growth" | "interval" | "periodic";
   rss_bytes: number;
   rss_high_water_bytes: number;
   heap_total_bytes: number;
@@ -72,6 +74,8 @@ export class AgentLongMemoryTelemetry {
   private lastEmittedHeapUsed = 0;
   private rssHighWater = 0;
   private heapUsedHighWater = 0;
+  private latestInput: MemoryCheckpointInput | undefined;
+  private periodicTimer: ReturnType<typeof setInterval> | undefined;
 
   constructor(private readonly options: AgentLongMemoryTelemetryOptions) {
     this.now = options.now ?? Date.now;
@@ -80,7 +84,35 @@ export class AgentLongMemoryTelemetry {
       options.readHeapLimit ?? (() => getHeapStatistics().heap_size_limit);
   }
 
+  startPeriodicCheckpoints(): void {
+    if (this.periodicTimer) return;
+
+    this.periodicTimer = setInterval(() => {
+      if (!this.latestInput) return;
+      this.captureCheckpoint(this.latestInput, "periodic");
+    }, PERIODIC_CHECKPOINT_INTERVAL_MS);
+    this.periodicTimer.unref?.();
+  }
+
+  dispose(): void {
+    if (!this.periodicTimer) return;
+    clearInterval(this.periodicTimer);
+    this.periodicTimer = undefined;
+  }
+
   checkpoint(input: MemoryCheckpointInput): boolean {
+    this.latestInput = {
+      phase: input.phase,
+      providerRequest: input.providerRequest,
+      retention: input.retention,
+    };
+    return this.captureCheckpoint(input);
+  }
+
+  private captureCheckpoint(
+    input: MemoryCheckpointInput,
+    reasonOverride?: MemoryCheckpointEvent["checkpoint_reason"],
+  ): boolean {
     try {
       const now = this.now();
       const memory = this.readMemory();
@@ -95,7 +127,8 @@ export class AgentLongMemoryTelemetry {
       this.heapUsedHighWater = Math.max(this.heapUsedHighWater, heapUsed);
 
       const reason =
-        this.lastEmittedAt === undefined
+        reasonOverride ??
+        (this.lastEmittedAt === undefined
           ? "initial"
           : input.force
             ? "forced"
@@ -104,7 +137,7 @@ export class AgentLongMemoryTelemetry {
               ? "heap_growth"
               : now - this.lastEmittedAt >= CHECKPOINT_INTERVAL_MS
                 ? "interval"
-                : undefined;
+                : undefined);
 
       if (!reason) return false;
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1769,6 +1769,7 @@ export const agentLongTask = task({
     let activeRuntimeBudget: ActiveRuntimeBudget | undefined;
 
     try {
+      memoryTelemetry.startPeriodicCheckpoints();
       // Re-fetch from DB so we have fileTokens for summarization.
       // The route already saved the user message; newMessages:[] avoids duplicates.
       const [userCustomization, fetched] = await Promise.all([
@@ -3761,6 +3762,7 @@ export const agentLongTask = task({
 
       throw error;
     } finally {
+      memoryTelemetry.dispose();
       activeRuntimeBudget?.dispose();
       runCleanupMap.delete(ctx.run.id);
       if (payload.approvalSessionId && triggerSessions) {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -1769,7 +1769,6 @@ export const agentLongTask = task({
     let activeRuntimeBudget: ActiveRuntimeBudget | undefined;
 
     try {
-      memoryTelemetry.startPeriodicCheckpoints();
       // Re-fetch from DB so we have fileTokens for summarization.
       // The route already saved the user message; newMessages:[] avoids duplicates.
       const [userCustomization, fetched] = await Promise.all([
@@ -2847,11 +2846,15 @@ export const agentLongTask = task({
               onModelStreamStart: runTimingTracker.startModelStream,
               onModelStreamFinish: runTimingTracker.finishModelStream,
               onProviderRequestDiagnostics: (providerRequest, retention) => {
-                memoryTelemetry.checkpoint({
-                  phase: "provider_request",
-                  providerRequest,
-                  retention,
-                });
+                if (
+                  memoryTelemetry.checkpoint({
+                    phase: "provider_request",
+                    providerRequest,
+                    retention,
+                  })
+                ) {
+                  memoryTelemetry.startPeriodicCheckpoints();
+                }
               },
               settleUsageAfterStep,
               onBudgetAbort: (details) =>


### PR DESCRIPTION
## Production evidence

Frozen audit window: `2026-07-27T20:27:28.747Z` through `2026-07-28T20:27:28.747Z`.

Trigger.dev recorded 24 `TASK_PROCESS_OOM_KILLED` crashes affecting 20 users and 22 chats. The current production worker `20260728.4` produced 11 OOMs after deployment, or 0.3281% of completed-plus-failed exposure. Three representative current-worker crashes had their final memory checkpoint 374–469 seconds before termination, leaving the final allocation unknown. Their sampled heap usage ranged from 45.3% to 80.9%, while a comparable two-hour run completed at 57.9%, so the evidence does not support a safe message guard or blanket machine-size increase yet.

Vercel had 12 unique production error rows and PostHog had 44 issues / 2,399 occurrences (+1.14% window over window). Neither source supported a new error suppression or a separate application fix.

## Change

- add an unref'd, task-run-scoped memory checkpoint every two minutes after the first provider checkpoint
- reuse the existing privacy-safe provider and retention diagnostics so long provider work no longer leaves a 6–8 minute observability gap
- dispose the timer on every protected Agent task exit
- preserve the existing initial, heap-growth, ten-minute, and forced-failure checkpoints

This does not change Agent behavior, retries, payloads, model routing, machine size, or Vercel/Trigger deploy contracts.

## Validation

- `corepack pnpm jest lib/chat/__tests__/agent-long-memory-telemetry.test.ts lib/api/__tests__/agent-long-contracts.test.ts --runInBand` — 90 tests passed
- `corepack pnpm typecheck`
- changed-file ESLint
- changed-file Prettier
- commit hooks — 304 suites / 3,013 tests passed

## Manual verification

After deploying the Trigger preview:

1. Run an internal multi-step Agent task for more than two minutes.
2. Confirm `agent_long_memory_checkpoint` emits `initial` and then bounded `periodic` checkpoints at no more than one per two minutes.
3. Confirm the events contain only opaque run/chat/user IDs, memory values, and bounded request/retention counts—no prompt, target, tool content, file path, attachment name, or raw URL.
4. End the run and confirm no checkpoint appears after task cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added periodic memory checkpointing for long-running agent operations, including phase, provider request diagnostics, and retention details.
  * Periodic checkpoints can be conditionally enabled based on provider-request diagnostics, and emissions are labeled as periodic.
  * Periodic checkpointing is automatically stopped when the operation ends or telemetry is disposed.

* **Tests**
  * Added coverage validating periodic checkpoint timing/metadata and confirming no further periodic emissions after disposal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->