### PR TITLE
Keep sidebar task rows clickable

### DIFF
--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -57,6 +57,7 @@ import {
   FolderInput,
   FolderMinus,
   FolderPlus,
+  GripVertical,
   ListPlus,
 } from "lucide-react";
 import { useMutation } from "convex/react";
@@ -133,7 +134,6 @@ const ChatItem: React.FC<ChatItemProps> = ({
   const [isRenaming, setIsRenaming] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const suppressClickAfterDragRef = useRef(false);
   const renameInputId = useId();
 
   const {
@@ -170,14 +170,19 @@ const ChatItem: React.FC<ChatItemProps> = ({
   const showActions = Boolean(
     isHovered || isFocusedWithin || isDropdownOpen || isMobile,
   );
+  const showDragHandle = (isHovered || isDragging) && !isMobile;
   const showStreamingIndicator =
     isStreaming && (!isHovered || isMobile) && (!isDropdownOpen || isMobile);
+  const visibleActionSlotCount =
+    Number(showStreamingIndicator) +
+    Number(showDragHandle) +
+    Number(showActions);
   const rightPaddingClass =
-    isMobile && showActions && showStreamingIndicator
-      ? "pr-[4.5rem]"
-      : showActions
-        ? "pr-9"
-        : showStreamingIndicator
+    visibleActionSlotCount >= 3
+      ? "pr-[6.5rem]"
+      : visibleActionSlotCount === 2
+        ? "pr-[4.5rem]"
+        : visibleActionSlotCount === 1
           ? "pr-9"
           : "";
   const rowStartPaddingClass = indentContent ? "ps-6" : "ps-2";
@@ -188,22 +193,16 @@ const ChatItem: React.FC<ChatItemProps> = ({
     }
   }, [optimisticChatId, routeChatId, setOptimisticChatId]);
 
-  const handleDragStart = (event: React.DragEvent<HTMLDivElement>) => {
-    suppressClickAfterDragRef.current = true;
+  const handleDragStart = (event: React.DragEvent<HTMLSpanElement>) => {
     setIsDragging(true);
     setSidebarChatDragData(event.dataTransfer, id, projectId);
   };
 
   const handleDragEnd = () => {
     setIsDragging(false);
-    window.setTimeout(() => {
-      suppressClickAfterDragRef.current = false;
-    }, 0);
   };
 
   const handleClick = () => {
-    if (suppressClickAfterDragRef.current) return;
-
     // Don't navigate if dialog is open or dropdown is open
     if (
       showRenameDialog ||
@@ -431,14 +430,11 @@ const ChatItem: React.FC<ChatItemProps> = ({
 
   return (
     <div
-      className={`group relative flex w-full cursor-grab select-none items-center rounded-lg py-2 pe-0.5 ${rowStartPaddingClass} hover:bg-sidebar-accent/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:cursor-grabbing ${
+      className={`group relative flex w-full cursor-pointer select-none items-center rounded-lg py-2 pe-0.5 ${rowStartPaddingClass} hover:bg-sidebar-accent/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
         isCurrentlyActive
           ? "bg-sidebar-accent text-sidebar-accent-foreground"
           : ""
       } ${isDragging ? "opacity-50" : ""}`}
-      draggable
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onFocus={() => setIsFocusedWithin(true)}
@@ -504,6 +500,23 @@ const ChatItem: React.FC<ChatItemProps> = ({
               aria-hidden="true"
             />
           </div>
+        ) : null}
+        {showDragHandle ? (
+          <span
+            className="flex size-8 flex-shrink-0 cursor-grab items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent active:cursor-grabbing"
+            draggable
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+            }}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            title="Drag task"
+            aria-hidden="true"
+            data-testid={`chat-drag-handle-${id}`}
+          >
+            <GripVertical className="size-4" />
+          </span>
         ) : null}
         {showActions ? (
           <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>

--- a/app/components/__tests__/ChatItem.projects.test.tsx
+++ b/app/components/__tests__/ChatItem.projects.test.tsx
@@ -10,12 +10,13 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 
 const mockMoveChatToProject = jest.fn<any>();
+const mockRouterPush = jest.fn();
 const mockToastSuccess = jest.fn();
 const mockToastInfo = jest.fn();
 let mockProjects: any[] | undefined;
 
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push: jest.fn() }),
+  useRouter: () => ({ push: mockRouterPush }),
   usePathname: () => "/",
 }));
 jest.mock("@/app/contexts/GlobalState", () => ({
@@ -318,6 +319,50 @@ describe("ChatItem project actions", () => {
     );
     expect(screen.getByTestId("chat-item-chat-1")).not.toHaveClass("p-2");
     expect(screen.getByTestId("chat-item-chat-2")).not.toHaveClass("p-2");
+  });
+
+  it("keeps the task row clickable while limiting drag initiation to a handle", () => {
+    render(<ChatItem id="chat-1" title="Target notes" />);
+
+    const row = screen.getByRole("button", { name: /Open task:/ });
+    expect(row).not.toHaveAttribute("draggable");
+    expect(row).toHaveClass("cursor-pointer");
+
+    fireEvent.mouseEnter(row);
+    const dragHandle = screen.getByTestId("chat-drag-handle-chat-1");
+    expect(dragHandle).toHaveAttribute("draggable", "true");
+
+    fireEvent.click(row);
+
+    expect(mockRouterPush).toHaveBeenCalledWith("/c/chat-1");
+  });
+
+  it("does not open the task when the dedicated drag handle is used", () => {
+    render(<ChatItem id="chat-1" title="Target notes" />);
+
+    const row = screen.getByRole("button", { name: /Open task:/ });
+    fireEvent.mouseEnter(row);
+    const dragHandle = screen.getByTestId("chat-drag-handle-chat-1");
+    const dataTransfer = {
+      effectAllowed: "none",
+      setData: jest.fn(),
+    };
+
+    fireEvent.dragStart(dragHandle, { dataTransfer });
+    fireEvent.mouseLeave(row);
+    expect(dragHandle).toBeInTheDocument();
+    fireEvent.click(dragHandle);
+    fireEvent.dragEnd(dragHandle);
+
+    expect(dataTransfer.effectAllowed).toBe("move");
+    expect(dataTransfer.setData).toHaveBeenCalledWith(
+      "application/x-hackerai-chat-id",
+      "chat-1",
+    );
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(
+      screen.queryByTestId("chat-drag-handle-chat-1"),
+    ).not.toBeInTheDocument();
   });
 
   it("centers the streaming indicator in the task action slot", () => {


### PR DESCRIPTION
## Summary
- keep the full sidebar task row as a reliable click target
- move drag-and-drop initiation to a dedicated hover grip on desktop
- preserve the grip while dragging and retain existing project/pin drag payloads
- add regression coverage for row navigation and drag-handle isolation

## Root cause
Every sidebar task row was marked `draggable`. Small mouse or trackpad movement could fire `dragstart`, set the click-suppression guard, and prevent the row click from navigating. In the Desktop webview this made existing tasks feel difficult or impossible to open.

## Validation
- `corepack pnpm test --runInBand app/components/__tests__/ChatItem.projects.test.tsx app/components/__tests__/SidebarChatSections.test.tsx`
- `corepack pnpm typecheck`
- `corepack pnpm exec eslint app/components/ChatItem.tsx app/components/__tests__/ChatItem.projects.test.tsx`
- `corepack pnpm exec prettier --check app/components/ChatItem.tsx app/components/__tests__/ChatItem.projects.test.tsx`
- commit hook: 304 suites / 3,014 tests passed

## Visual verification
- verified in authenticated Chrome against the local app
- confirmed task rows are not draggable and navigate normally
- confirmed the hover grip is the only draggable element
- confirmed the grip and task options align without overlap
- confirmed no browser warnings or errors

## Manual verification
1. Open HackerAI Desktop and restart the app.
2. Click several existing tasks while allowing slight pointer movement.
3. Confirm each task opens normally.
4. Hover a task, drag it using the grip, and confirm pin/project drag-and-drop still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat item drag-and-drop behavior by adding a dedicated drag handle.
  * Prevented accidental chat navigation when dragging an item.
  * Preserved normal row-click behavior when interacting outside the drag handle.
  * Improved layout spacing for visible chat actions on desktop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->