### PR TITLE
Redact signed URLs from error telemetry

### DIFF
--- a/lib/__tests__/logger.test.ts
+++ b/lib/__tests__/logger.test.ts
@@ -9,17 +9,27 @@ describe("logger error redaction", () => {
       "https://bucket.s3.amazonaws.com/user-files/user_123/private-image.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=access-key&X-Amz-Signature=signature-secret";
     const error = new Error(`Provider could not fetch ${signedUrl}`);
 
-    logger.error("Provider request failed", error, {
-      event: "provider_request_failed",
-    });
+    try {
+      logger.error("Provider request failed", error, {
+        event: "provider_request_failed",
+        message: signedUrl,
+        error: signedUrl,
+      });
 
-    const serialized = String(consoleError.mock.calls[0]?.[0]);
+      const serialized = String(consoleError.mock.calls[0]?.[0]);
+      const parsed = JSON.parse(serialized) as {
+        message?: string;
+        error?: { message?: string };
+      };
 
-    expect(serialized).toContain("[Redacted signed URL]");
-    expect(serialized).not.toContain("user-files");
-    expect(serialized).not.toContain("access-key");
-    expect(serialized).not.toContain("signature-secret");
-
-    consoleError.mockRestore();
+      expect(serialized).toContain("[Redacted signed URL]");
+      expect(serialized).not.toContain("user-files");
+      expect(serialized).not.toContain("access-key");
+      expect(serialized).not.toContain("signature-secret");
+      expect(parsed.message).toBe("Provider request failed");
+      expect(parsed.error?.message).toContain("[Redacted signed URL]");
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/lib/__tests__/logger.test.ts
+++ b/lib/__tests__/logger.test.ts
@@ -1,0 +1,25 @@
+import { logger } from "../logger";
+
+describe("logger error redaction", () => {
+  it("redacts presigned URLs from runtime error messages and stacks", () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const signedUrl =
+      "https://bucket.s3.amazonaws.com/user-files/user_123/private-image.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=access-key&X-Amz-Signature=signature-secret";
+    const error = new Error(`Provider could not fetch ${signedUrl}`);
+
+    logger.error("Provider request failed", error, {
+      event: "provider_request_failed",
+    });
+
+    const serialized = String(consoleError.mock.calls[0]?.[0]);
+
+    expect(serialized).toContain("[Redacted signed URL]");
+    expect(serialized).not.toContain("user-files");
+    expect(serialized).not.toContain("access-key");
+    expect(serialized).not.toContain("signature-secret");
+
+    consoleError.mockRestore();
+  });
+});

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -9,6 +9,7 @@ import type { ChatMode, ExtraUsageConfig } from "@/types";
 import type { ChatApiEndpoint } from "@/lib/api/agent-endpoints";
 import type { OpenRouterModelMetadata } from "@/lib/api/openrouter-metadata";
 import { getProviderUsageRawModelCost } from "@/lib/provider-usage-cost";
+import { redactSensitiveErrorMessage } from "@/lib/utils/error-redaction";
 
 export interface ProviderRequestDiagnostics {
   model: string;
@@ -729,13 +730,16 @@ export const logger = {
     console.error(
       JSON.stringify({
         level: "error",
-        message,
+        message: redactSensitiveErrorMessage(message),
         timestamp: new Date().toISOString(),
         error: error
           ? {
               name: error.name,
-              message: error.message,
-              stack: error.stack,
+              message: redactSensitiveErrorMessage(error.message),
+              stack:
+                typeof error.stack === "string"
+                  ? redactSensitiveErrorMessage(error.stack)
+                  : error.stack,
             }
           : undefined,
         ...context,

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -729,6 +729,7 @@ export const logger = {
   ): void {
     console.error(
       JSON.stringify({
+        ...context,
         level: "error",
         message: redactSensitiveErrorMessage(message),
         timestamp: new Date().toISOString(),
@@ -742,7 +743,6 @@ export const logger = {
                   : error.stack,
             }
           : undefined,
-        ...context,
       }),
     );
   },

--- a/lib/posthog/__tests__/server.test.ts
+++ b/lib/posthog/__tests__/server.test.ts
@@ -75,10 +75,11 @@ describe("phLogger", () => {
       },
     );
 
-    phLogger.error("provider_failed", {
+    phLogger.error(`provider_failed ${signedUrl}`, {
       userId: "user_123",
       error,
       requestId: "req_123",
+      message: signedUrl,
     });
 
     const capturedError = mockCaptureException.mock.calls[0]?.[0] as Error;
@@ -97,6 +98,37 @@ describe("phLogger", () => {
     expect(serialized).not.toContain("access-key");
     expect(serialized).not.toContain("signature-secret");
     expect("cause" in capturedError).toBe(false);
+    expect(emittedLog?.body).toBe("provider_failed [Redacted signed URL]");
+    expect(capturedProperties?.message).toBe(
+      "provider_failed [Redacted signed URL]",
+    );
+  });
+
+  it("redacts signed URLs from error console fallbacks", () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const signedUrl =
+      "https://bucket.s3.amazonaws.com/user-files/user_123/private-image.png?X-Amz-Credential=access-key&X-Amz-Signature=signature-secret";
+    mockCaptureException.mockImplementationOnce(() => {
+      throw new Error(`Telemetry failed for ${signedUrl}`);
+    });
+
+    try {
+      phLogger.error(`provider_failed ${signedUrl}`, {
+        error: new Error(`Provider failed for ${signedUrl}`),
+        message: signedUrl,
+      });
+
+      const serialized = JSON.stringify(consoleError.mock.calls);
+
+      expect(serialized).toContain("[Redacted signed URL]");
+      expect(serialized).not.toContain("user-files");
+      expect(serialized).not.toContain("access-key");
+      expect(serialized).not.toContain("signature-secret");
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it("passes stable event UUIDs to PostHog without leaking them into properties", () => {

--- a/lib/posthog/__tests__/server.test.ts
+++ b/lib/posthog/__tests__/server.test.ts
@@ -65,6 +65,40 @@ describe("phLogger", () => {
     expect(mockCaptureException).toHaveBeenCalledTimes(1);
   });
 
+  it("redacts signed URLs and raw causes before exception capture", () => {
+    const signedUrl =
+      "https://bucket.s3.amazonaws.com/user-files/user_123/private-image.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=access-key&X-Amz-Signature=signature-secret";
+    const error = Object.assign(
+      new Error(`Provider could not fetch ${signedUrl}`),
+      {
+        cause: new Error(`Upstream rejected ${signedUrl}`),
+      },
+    );
+
+    phLogger.error("provider_failed", {
+      userId: "user_123",
+      error,
+      requestId: "req_123",
+    });
+
+    const capturedError = mockCaptureException.mock.calls[0]?.[0] as Error;
+    const capturedProperties = mockCaptureException.mock.calls[0]?.[2];
+    const emittedLog = mockEmitPostHogLog.mock.calls[0]?.[0];
+    const serialized = JSON.stringify({
+      message: capturedError.message,
+      stack: capturedError.stack,
+      properties: capturedProperties,
+      log: emittedLog,
+    });
+
+    expect(capturedError).toBeInstanceOf(Error);
+    expect(serialized).toContain("[Redacted signed URL]");
+    expect(serialized).not.toContain("user-files");
+    expect(serialized).not.toContain("access-key");
+    expect(serialized).not.toContain("signature-secret");
+    expect("cause" in capturedError).toBe(false);
+  });
+
   it("passes stable event UUIDs to PostHog without leaking them into properties", () => {
     phLogger.event("checkout_started", {
       userId: "user_123",

--- a/lib/posthog/server.ts
+++ b/lib/posthog/server.ts
@@ -1,5 +1,6 @@
 import PostHogClient from "@/app/posthog";
 import { emitPostHogLog, flushPostHogLogs } from "@/lib/posthog/logs";
+import { redactSensitiveErrorMessage } from "@/lib/utils/error-redaction";
 import type { PostHog } from "posthog-node";
 
 let cachedClient: PostHog | null | undefined;
@@ -67,14 +68,24 @@ function serializeError(error: unknown): Record<string, unknown> {
   if (error instanceof Error) {
     return {
       error_name: error.name,
-      error_message: truncate(error.message),
-      ...(error.stack && { error_stack: truncate(error.stack, 4_000) }),
+      error_message: truncate(redactSensitiveErrorMessage(error.message)),
+      ...(error.stack && {
+        error_stack: truncate(redactSensitiveErrorMessage(error.stack), 4_000),
+      }),
       ...("cause" in error &&
         (error as { cause?: unknown }).cause !== undefined && {
           error_cause:
             (error as { cause?: unknown }).cause instanceof Error
-              ? truncate((error as { cause: Error }).cause.message)
-              : truncate(String((error as { cause?: unknown }).cause)),
+              ? truncate(
+                  redactSensitiveErrorMessage(
+                    (error as { cause: Error }).cause.message,
+                  ),
+                )
+              : truncate(
+                  redactSensitiveErrorMessage(
+                    String((error as { cause?: unknown }).cause),
+                  ),
+                ),
         }),
     };
   }
@@ -83,8 +94,29 @@ function serializeError(error: unknown): Record<string, unknown> {
 
   return {
     error_name: "UnknownError",
-    error_message: truncate(stringifyUnknown(error)),
+    error_message: truncate(
+      redactSensitiveErrorMessage(stringifyUnknown(error)),
+    ),
   };
+}
+
+function sanitizeExceptionForCapture(error: Error): Error {
+  const serialized = serializeError(error);
+  const message =
+    typeof serialized.error_message === "string"
+      ? serialized.error_message
+      : "Unknown error";
+  const sanitized = new Error(message);
+  sanitized.name =
+    typeof serialized.error_name === "string"
+      ? serialized.error_name
+      : error.name;
+  if (typeof serialized.error_stack === "string") {
+    sanitized.stack = serialized.error_stack;
+  }
+  // PostHog traverses Error.cause. Keep the diagnostic fields above, but do
+  // not retain a raw cause that could reintroduce a presigned URL or object key.
+  return sanitized;
 }
 
 function commonLogFields({
@@ -146,7 +178,9 @@ export const phLogger = {
     }
     try {
       const { userId, error, ...rest } = fields;
-      const exception = error instanceof Error ? error : new Error(message);
+      const exception = sanitizeExceptionForCapture(
+        error instanceof Error ? error : new Error(message),
+      );
       const event =
         typeof fields.event === "string" && fields.event.length > 0
           ? fields.event

--- a/lib/posthog/server.ts
+++ b/lib/posthog/server.ts
@@ -119,6 +119,34 @@ function sanitizeExceptionForCapture(error: Error): Error {
   return sanitized;
 }
 
+function sanitizeErrorForConsole(error: unknown): unknown {
+  if (error instanceof Error) {
+    const serialized = [
+      error.message,
+      error.stack ?? "",
+      stringifyUnknown(error),
+    ].join("\n");
+    return redactSensitiveErrorMessage(serialized) === serialized
+      ? error
+      : sanitizeExceptionForCapture(error);
+  }
+  if (error === undefined) return undefined;
+  return redactSensitiveErrorMessage(stringifyUnknown(error));
+}
+
+function sanitizeFieldsForConsole(fields: LogFields): LogFields {
+  return Object.fromEntries(
+    Object.entries(fields).map(([key, value]) => [
+      key,
+      key === "error"
+        ? sanitizeErrorForConsole(value)
+        : typeof value === "string"
+          ? redactSensitiveErrorMessage(value)
+          : value,
+    ]),
+  );
+}
+
 function commonLogFields({
   level,
   event,
@@ -158,8 +186,8 @@ function emitStructuredLog(
       event,
       body: message,
       attributes: {
-        ...commonLogFields({ level, event, message, userId }),
         ...rest,
+        ...commonLogFields({ level, event, message, userId }),
         ...serializeError(error),
       },
     });
@@ -170,29 +198,39 @@ function emitStructuredLog(
 
 export const phLogger = {
   error(message: string, fields: LogFields = {}) {
-    const wroteLog = emitStructuredLog("error", message, fields);
+    const redactedMessage = redactSensitiveErrorMessage(message);
+    const wroteLog = emitStructuredLog("error", redactedMessage, fields);
+    const safeFields = sanitizeFieldsForConsole(fields);
     const client = getClient();
     if (!client) {
-      if (!wroteLog) console.error(message, fields);
+      if (!wroteLog) console.error(redactedMessage, safeFields);
       return;
     }
     try {
       const { userId, error, ...rest } = fields;
       const exception = sanitizeExceptionForCapture(
-        error instanceof Error ? error : new Error(message),
+        error instanceof Error ? error : new Error(redactedMessage),
       );
       const event =
         typeof fields.event === "string" && fields.event.length > 0
           ? fields.event
-          : eventNameFor(message);
+          : eventNameFor(redactedMessage);
       client.captureException(exception, distinctIdFor(userId), {
-        ...commonLogFields({ level: "error", event, message, userId }),
-        ...serializeError(exception),
-        message,
         ...rest,
+        ...commonLogFields({
+          level: "error",
+          event,
+          message: redactedMessage,
+          userId,
+        }),
+        ...serializeError(exception),
+        message: redactedMessage,
       });
     } catch (telemetryError) {
-      console.error(message, { ...fields, telemetryError });
+      console.error(redactedMessage, {
+        ...safeFields,
+        telemetryError: sanitizeErrorForConsole(telemetryError),
+      });
     }
   },
 

--- a/lib/utils/__tests__/error-redaction.test.ts
+++ b/lib/utils/__tests__/error-redaction.test.ts
@@ -55,4 +55,26 @@ describe("error redaction", () => {
     expect(redacted).not.toContain(bell);
     expect(redacted).not.toContain("secret-value");
   });
+
+  it("redacts complete presigned URLs including storage object paths", () => {
+    const signedUrl =
+      "https://bucket.s3.amazonaws.com/user-files/user_123/private-image.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=access-key&X-Amz-Signature=signature-secret";
+    const message = `Provider failed to download ${signedUrl} with HTTP 404`;
+
+    const redacted = redactSensitiveErrorMessage(message);
+
+    expect(redacted).toBe(
+      "Provider failed to download [Redacted signed URL] with HTTP 404",
+    );
+    expect(redacted).not.toContain("user-files");
+    expect(redacted).not.toContain("access-key");
+    expect(redacted).not.toContain("signature-secret");
+  });
+
+  it("preserves ordinary non-signed diagnostic URLs", () => {
+    const message =
+      "Provider request failed at https://openrouter.ai/api/v1/chat/completions";
+
+    expect(redactSensitiveErrorMessage(message)).toBe(message);
+  });
 });

--- a/lib/utils/__tests__/error-redaction.test.ts
+++ b/lib/utils/__tests__/error-redaction.test.ts
@@ -77,4 +77,16 @@ describe("error redaction", () => {
 
     expect(redactSensitiveErrorMessage(message)).toBe(message);
   });
+
+  it("redacts signed URLs with apostrophes in object paths", () => {
+    const message =
+      "Provider failed for 'https://bucket.s3.amazonaws.com/user-files/user's-file.png?X-Amz-Credential=access-key&X-Amz-Signature=signature-secret'";
+
+    const redacted = redactSensitiveErrorMessage(message);
+
+    expect(redacted).toBe("Provider failed for '[Redacted signed URL]'");
+    expect(redacted).not.toContain("user's-file");
+    expect(redacted).not.toContain("access-key");
+    expect(redacted).not.toContain("signature-secret");
+  });
 });

--- a/lib/utils/__tests__/error-utils.test.ts
+++ b/lib/utils/__tests__/error-utils.test.ts
@@ -323,6 +323,39 @@ describe("provider error classification", () => {
     );
   });
 
+  it("redacts signed image URLs from every extracted telemetry field", () => {
+    const signedUrl =
+      "https://bucket.s3.amazonaws.com/user-files/user_123/private-image.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=access-key&X-Amz-Signature=signature-secret";
+    const err = Object.assign(
+      new Error(
+        `Failed to download the provided image at ${signedUrl} because the image host returned HTTP status 404.`,
+      ),
+      {
+        statusCode: 400,
+        url: signedUrl,
+        responseBody: JSON.stringify({
+          error: { message: `Image unavailable at ${signedUrl}` },
+        }),
+        cause: new Error(`Upstream rejected ${signedUrl}`),
+      },
+    );
+
+    const details = extractErrorDetails(err);
+    const attempts = extractRetryAttempts({ errors: [err] });
+    const serialized = JSON.stringify({ details, attempts });
+
+    expect(isInvalidImageInputError(err)).toBe(true);
+    expect(attempts).toHaveLength(1);
+    expect(details).toMatchObject({
+      statusCode: 400,
+      providerUrl: "[Redacted signed URL]",
+    });
+    expect(serialized).toContain("[Redacted signed URL]");
+    expect(serialized).not.toContain("user-files");
+    expect(serialized).not.toContain("access-key");
+    expect(serialized).not.toContain("signature-secret");
+  });
+
   it("classifies network-loss messages as provider stream termination", () => {
     const err = new Error("Network connection lost.");
 

--- a/lib/utils/error-redaction.ts
+++ b/lib/utils/error-redaction.ts
@@ -6,7 +6,7 @@ const SENSITIVE_FIELD_PATTERN =
 const ENV_SECRET_PATTERN =
   /(["']?\b(?:CONVEX_SERVICE_ROLE_KEY|POSTHOG_API_KEY|STRIPE_SECRET_KEY)\b["']?)(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,}]+)/gi;
 
-const URL_PATTERN = /https?:\/\/[^\s"'<>\\]+/gi;
+const URL_PATTERN = /https?:\/\/[^\s"<>\\]+/gi;
 const SIGNED_URL_CREDENTIAL_PATTERN =
   /[?&](?:x-amz-(?:algorithm|credential|date|expires|signedheaders|signature|security-token)|awsaccesskeyid|signature)=/i;
 const REDACTED_SIGNED_URL = "[Redacted signed URL]";
@@ -27,9 +27,14 @@ export const stripControlSequencesFromErrorMessage = (
 
 export const redactSensitiveErrorMessage = (message: string): string =>
   stripControlSequencesFromErrorMessage(message)
-    .replace(URL_PATTERN, (url) =>
-      SIGNED_URL_CREDENTIAL_PATTERN.test(url) ? REDACTED_SIGNED_URL : url,
-    )
+    .replace(URL_PATTERN, (url) => {
+      if (!SIGNED_URL_CREDENTIAL_PATTERN.test(url)) return url;
+
+      // Apostrophes are valid inside object paths, but a terminal apostrophe
+      // after the signed query is a surrounding string delimiter.
+      const trailingDelimiter = url.endsWith("'") ? "'" : "";
+      return `${REDACTED_SIGNED_URL}${trailingDelimiter}`;
+    })
     .replace(SENSITIVE_FIELD_PATTERN, (_match, key, separator) => {
       return `${key}${separator}"${REDACTED_VALUE}"`;
     })

--- a/lib/utils/error-redaction.ts
+++ b/lib/utils/error-redaction.ts
@@ -6,6 +6,11 @@ const SENSITIVE_FIELD_PATTERN =
 const ENV_SECRET_PATTERN =
   /(["']?\b(?:CONVEX_SERVICE_ROLE_KEY|POSTHOG_API_KEY|STRIPE_SECRET_KEY)\b["']?)(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,}]+)/gi;
 
+const URL_PATTERN = /https?:\/\/[^\s"'<>\\]+/gi;
+const SIGNED_URL_CREDENTIAL_PATTERN =
+  /[?&](?:x-amz-(?:algorithm|credential|date|expires|signedheaders|signature|security-token)|awsaccesskeyid|signature)=/i;
+const REDACTED_SIGNED_URL = "[Redacted signed URL]";
+
 // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional ANSI/control-sequence cleanup for model/log-facing errors
 const ANSI_ESCAPE_PATTERN =
   /\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1B]*(?:\x07|\x1B\\)|[@-Z\\-_])/g;
@@ -22,6 +27,9 @@ export const stripControlSequencesFromErrorMessage = (
 
 export const redactSensitiveErrorMessage = (message: string): string =>
   stripControlSequencesFromErrorMessage(message)
+    .replace(URL_PATTERN, (url) =>
+      SIGNED_URL_CREDENTIAL_PATTERN.test(url) ? REDACTED_SIGNED_URL : url,
+    )
     .replace(SENSITIVE_FIELD_PATTERN, (_match, key, separator) => {
       return `${key}${separator}"${REDACTED_VALUE}"`;
     })

--- a/lib/utils/error-utils.ts
+++ b/lib/utils/error-utils.ts
@@ -1,3 +1,5 @@
+import { redactSensitiveErrorMessage } from "@/lib/utils/error-redaction";
+
 /**
  * Extracts a readable error message from any error type.
  */
@@ -129,7 +131,7 @@ const getOpenRouterProviderInfo = (
       nested.message.length > 0
     ) {
       details.providerErrorMessage = truncate(
-        nested.message,
+        redactSensitiveErrorMessage(nested.message),
         OPENROUTER_DETAIL_MAX_LENGTH,
       );
     }
@@ -149,7 +151,7 @@ const getOpenRouterProviderInfo = (
       metadata.raw.length > 0
     ) {
       details.providerRawError = truncate(
-        metadata.raw,
+        redactSensitiveErrorMessage(metadata.raw),
         OPENROUTER_DETAIL_MAX_LENGTH,
       );
     }
@@ -243,6 +245,9 @@ const removeSensitiveData = (data: unknown): unknown => {
 
   const recurse = (value: unknown): unknown => {
     if (value === null || value === undefined) return value;
+    if (typeof value === "string") {
+      return redactSensitiveErrorMessage(value);
+    }
     if (typeof value !== "object") return value;
 
     if (seen.has(value)) return "[Circular]";
@@ -259,11 +264,7 @@ const removeSensitiveData = (data: unknown): unknown => {
       if (SENSITIVE_KEYS.has(key)) {
         continue;
       }
-      if (val && typeof val === "object") {
-        cleaned[key] = recurse(val);
-      } else {
-        cleaned[key] = val;
-      }
+      cleaned[key] = recurse(val);
     }
 
     return cleaned;
@@ -292,12 +293,12 @@ export const extractErrorDetails = (
       (typeof primaryRecord?.name === "string"
         ? primaryRecord.name
         : "UnknownError"),
-    errorMessage: getErrorMessage(error),
+    errorMessage: redactSensitiveErrorMessage(getErrorMessage(error)),
   };
 
   // Add stack trace if available
   if (err?.stack) {
-    details.errorStack = err.stack;
+    details.errorStack = redactSensitiveErrorMessage(err.stack);
   }
 
   // Extract provider-specific error details (AI SDK format). Walk common
@@ -307,7 +308,10 @@ export const extractErrorDetails = (
       details.statusCode = source.statusCode;
     }
     if (details.providerUrl === undefined && "url" in source) {
-      details.providerUrl = source.url;
+      details.providerUrl =
+        typeof source.url === "string"
+          ? redactSensitiveErrorMessage(source.url)
+          : source.url;
     }
     if (details.responseBody === undefined && "responseBody" in source) {
       details.responseBody = removeSensitiveData(source.responseBody);
@@ -319,7 +323,9 @@ export const extractErrorDetails = (
       details.providerData = removeSensitiveData(source.data);
     }
     if (details.cause === undefined && "cause" in source && source.cause) {
-      details.cause = getErrorMessage(source.cause);
+      details.cause = redactSensitiveErrorMessage(
+        getErrorMessage(source.cause),
+      );
     }
     if (details.errorCode === undefined && "code" in source) {
       details.errorCode = source.code;
@@ -516,7 +522,7 @@ const toAttempt = (error: unknown): ProviderAttempt => {
         : undefined;
   return {
     status_code: statusCode,
-    message: getErrorMessage(error),
+    message: redactSensitiveErrorMessage(getErrorMessage(error)),
     error_name: errorName,
     request_id: extractRequestId(error),
     provider_name:
@@ -637,13 +643,13 @@ function extractProviderDetails(error: unknown): {
         }
         // metadata.raw has the most specific upstream error
         if (typeof meta.raw === "string" && meta.raw.length > 0) {
-          detail = truncate(meta.raw, 300);
+          detail = truncate(redactSensitiveErrorMessage(meta.raw), 300);
         }
       }
 
       // Fall back to data.error.message
       if (!detail && typeof nested.message === "string") {
-        detail = truncate(nested.message, 300);
+        detail = truncate(redactSensitiveErrorMessage(nested.message), 300);
       }
     }
   }
@@ -694,13 +700,13 @@ function extractMessageFromResponseBody(body: string): string | undefined {
     const parsed = JSON.parse(body);
     const msg = parsed?.error?.message ?? parsed?.message;
     if (typeof msg === "string" && msg.length > 0) {
-      return truncate(msg, 300);
+      return truncate(redactSensitiveErrorMessage(msg), 300);
     }
   } catch {
     // Not JSON — return a trimmed snippet if it's short enough to be useful
     const trimmed = body.trim();
     if (trimmed.length > 0 && trimmed.length <= 300) {
-      return trimmed;
+      return redactSensitiveErrorMessage(trimmed);
     }
   }
   return undefined;

--- a/lib/utils/file-transform-utils.ts
+++ b/lib/utils/file-transform-utils.ts
@@ -17,7 +17,10 @@ import { getMaxFileTokens } from "../token-utils";
 import type { SubscriptionTier } from "@/types";
 import { logger } from "@/lib/logger";
 import { validateDownloadUrl } from "@/lib/ai/tools/utils/path-validation";
-import { stringifyRedactedError } from "@/lib/utils/error-redaction";
+import {
+  redactSensitiveErrorMessage,
+  stringifyRedactedError,
+} from "@/lib/utils/error-redaction";
 import {
   normalizeImageMediaType,
   validateImageBytes,
@@ -51,6 +54,9 @@ type SizeProbeResult = {
 const providerUnsafeImageParts = new WeakSet<object>();
 
 const redactUrlForLog = (url: string): string => {
+  const redacted = redactSensitiveErrorMessage(url);
+  if (redacted !== url) return redacted;
+
   try {
     const parsed = new URL(url);
     return `${parsed.origin}${parsed.pathname}`;
@@ -133,7 +139,9 @@ const convertUrlToBase64DataUrl = async (
   try {
     const response = await fetch(url, { signal: controller.signal });
     if (!response.ok) {
-      console.error(`Failed to fetch file (${response.status}): ${url}`);
+      console.error(
+        `Failed to fetch file (${response.status}): ${redactUrlForLog(url)}`,
+      );
       return url;
     }
 
@@ -141,8 +149,8 @@ const convertUrlToBase64DataUrl = async (
     return `data:${mediaType};base64,${buffer.toString("base64")}`;
   } catch (error) {
     console.error("Failed to convert file to base64:", {
-      url,
-      error: error instanceof Error ? error.message : String(error),
+      url: redactUrlForLog(url),
+      error: stringifyRedactedError(error),
     });
     return url;
   } finally {


### PR DESCRIPTION
## Summary
- redact AWS-signed media URLs from server logs and PostHog exception telemetry
- preserve stable error category, status, fingerprint, stack structure, and opaque user/chat identifiers
- cover chat and Agent provider failures, retry attempts, runtime logger errors, PostHog exceptions, and local file-download logging

## Production evidence
Frozen audit window: `2026-07-28T20:00:38Z` through `2026-07-29T20:00:38Z`.

PostHog Error Tracking contained 3 handled signed-media provider failures affecting 2 users. Representative 403/404 exception values retained the complete presigned S3 URL and object path. One matched a Vercel provider-image 404 on the current production deployment at `2026-07-29T17:52:08Z`.

## Root cause
The existing sanitizer covered structured secret fields, but several error serialization paths retained signed URLs in messages, stacks, causes, retry attempts, and captured exceptions. The local file-download fallback also logged the raw URL.

## Change
- add a narrow signed-URL redactor keyed to AWS signing parameters
- apply it at shared error normalization, runtime logging, PostHog capture, and local file-fetch logging boundaries
- leave ordinary provider endpoint URLs visible
- do not suppress or reclassify any error, change retries, or change user-visible provider behavior

## Validation
- focused regression suite: 6 suites, 96 tests
- full commit-hook suite: 307 suites, 3,035 tests
- `corepack pnpm typecheck`
- changed-file ESLint
- Prettier checks

## Manual verification
1. In production or a representative preview, send an Ask or Agent request with an expired S3-backed image.
2. Confirm the user still receives the reattach/provider-failure message and the error remains visible with status, category, fingerprint, and opaque identifiers.
3. Confirm Vercel and PostHog properties, exception values, stacks, and causes contain `[Redacted signed URL]` and no `X-Amz-*` parameters, object key, file name, or user path.
4. Confirm ordinary provider endpoint URLs remain visible.

No visual verification is required because this changes backend telemetry only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Signed/credential-style URLs are now fully redacted from application error logs, telemetry, and console fallback output, including nested error details and stacks.
  * Sensitive content in extracted provider errors, retry-attempt messages, and file-processing error logs is sanitized before truncation.
  * Non-signed diagnostic URLs remain unchanged.
* **Tests**
  * Added/extended Jest coverage to ensure signed URL redaction is consistently applied across logging, telemetry capture, error extraction, retry details, and URL-handling flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->