### PR TITLE
Prevent paid mode selector flicker on reload

### DIFF
--- a/app/components/ChatInput/ChatInputToolbar.tsx
+++ b/app/components/ChatInput/ChatInputToolbar.tsx
@@ -21,8 +21,13 @@ export function ChatInputToolbar({
   chatMode,
   ...submitStopProps
 }: ChatInputToolbarProps) {
-  const { paidAgentOnlyActive, selectedModel, setSelectedModel, subscription } =
-    useGlobalState();
+  const {
+    chatModeAccessResolved,
+    paidAgentOnlyActive,
+    selectedModel,
+    setSelectedModel,
+    subscription,
+  } = useGlobalState();
   const { user } = useAuth();
 
   return (
@@ -30,7 +35,9 @@ export function ChatInputToolbar({
       <div className="shrink-0">
         <AttachmentButton onAttachClick={onAttachClick} />
       </div>
-      {paidAgentOnlyActive ? null : <ChatModeSelector />}
+      {chatModeAccessResolved && !paidAgentOnlyActive ? (
+        <ChatModeSelector />
+      ) : null}
       {isAgentMode(chatMode) ? (
         <div className="hidden md:block">
           <AgentPermissionSelector analyticsSurface="chat_input" />

--- a/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
+++ b/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
@@ -135,6 +135,14 @@ describe("ChatInputToolbar", () => {
     expect(screen.queryByTestId("chat-mode-selector")).not.toBeInTheDocument();
   });
 
+  it("shows the mode selector after access resolves for eligible users", () => {
+    mockAuthUser({ id: "user_123" });
+
+    render(<ChatInputToolbar {...defaultProps} />);
+
+    expect(screen.getByTestId("chat-mode-selector")).toBeInTheDocument();
+  });
+
   it("enables the paid visual treatment only for paid subscriptions", () => {
     const { rerender } = render(<ChatInputToolbar {...defaultProps} />);
 

--- a/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
+++ b/app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import type { SubscriptionTier } from "@/types";
 
 let mockSubscription: SubscriptionTier = "free";
+let mockChatModeAccessResolved = true;
 let mockPaidAgentOnlyActive = false;
 
 jest.mock("@/app/components/AttachmentButton", () => ({
@@ -38,6 +39,7 @@ jest.mock("@/app/contexts/GlobalState", () => ({
     selectedModel: "auto",
     setSelectedModel: jest.fn(),
     subscription: mockSubscription,
+    chatModeAccessResolved: mockChatModeAccessResolved,
     paidAgentOnlyActive: mockPaidAgentOnlyActive,
   }),
 }));
@@ -72,6 +74,7 @@ const mockAuthUser = (user: unknown) => {
 describe("ChatInputToolbar", () => {
   beforeEach(() => {
     mockSubscription = "free";
+    mockChatModeAccessResolved = true;
     mockPaidAgentOnlyActive = false;
     mockAuthUser(null);
   });
@@ -114,6 +117,22 @@ describe("ChatInputToolbar", () => {
 
     expect(screen.queryByTestId("chat-mode-selector")).not.toBeInTheDocument();
     expect(screen.getByTestId("agent-permission-selector")).toBeInTheDocument();
+  });
+
+  it("never flashes the mode selector while paid access resolves", () => {
+    mockAuthUser({ id: "user_123" });
+    mockChatModeAccessResolved = false;
+
+    const { rerender } = render(<ChatInputToolbar {...defaultProps} />);
+
+    expect(screen.queryByTestId("chat-mode-selector")).not.toBeInTheDocument();
+
+    mockSubscription = "pro";
+    mockChatModeAccessResolved = true;
+    mockPaidAgentOnlyActive = true;
+    rerender(<ChatInputToolbar {...defaultProps} chatMode="agent" />);
+
+    expect(screen.queryByTestId("chat-mode-selector")).not.toBeInTheDocument();
   });
 
   it("enables the paid visual treatment only for paid subscriptions", () => {

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -84,6 +84,7 @@ interface GlobalStateType {
   // Chat mode state
   chatMode: ChatMode;
   setChatMode: (mode: ChatMode) => void;
+  chatModeAccessResolved: boolean;
   paidAgentOnlyActive: boolean;
 
   // Computer sidebar state (right side)
@@ -663,6 +664,8 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     user,
   ]);
 
+  const chatModeAccessResolved =
+    !authLoading && (!user || (subscriptionResolved && !isCheckingProPlan));
   const paidAgentOnlyActive =
     Boolean(user) &&
     subscriptionResolved &&
@@ -1137,6 +1140,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     isUploadingFiles,
     chatMode,
     setChatMode,
+    chatModeAccessResolved,
     paidAgentOnlyActive,
     sidebarOpen,
     setSidebarOpen,

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -25,6 +25,7 @@ const mockAuthUser = (
 function GlobalStateProbe() {
   const {
     agentPermissionMode,
+    chatModeAccessResolved,
     chatMode,
     isCheckingProPlan,
     paidAgentOnlyActive,
@@ -37,6 +38,9 @@ function GlobalStateProbe() {
   return (
     <>
       <div data-testid="agent-permission-mode">{agentPermissionMode}</div>
+      <div data-testid="chat-mode-access-resolved">
+        {String(chatModeAccessResolved)}
+      </div>
       <div data-testid="chat-mode">{chatMode}</div>
       <div data-testid="checking-pro-plan">{String(isCheckingProPlan)}</div>
       <div data-testid="paid-agent-only">{String(paidAgentOnlyActive)}</div>
@@ -95,6 +99,20 @@ describe("GlobalStateProvider agent defaults", () => {
       );
     });
     expect(window.location.search).toBe("");
+  });
+
+  it("keeps chat mode access unresolved while authentication is loading", () => {
+    mockAuthUser([], { loading: true });
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    expect(screen.getByTestId("chat-mode-access-resolved")).toHaveTextContent(
+      "false",
+    );
   });
 
   it("clears a temporary chat URL request after unauthenticated auth resolves", async () => {


### PR DESCRIPTION
## What changed

- add a derived `chatModeAccessResolved` state that stays false while authentication or subscription entitlement checks are pending
- render the Ask/Agent selector only after mode access is authoritative
- keep the selector available after resolution for logged-out users, free users, and paid temporary chats
- add regression coverage for the unresolved-to-paid transition

## Root cause

`paidAgentOnlyActive` correctly stayed false until authentication and entitlements resolved. The toolbar treated that temporary false value as permission to render the Ask/Agent selector, so paid users could see it briefly during page hydration before Agent-only access became active.

## User impact

Paid normal chats no longer flash an unavailable Ask/Agent selector during reload. The remaining controls keep their existing layout and behavior.

## Validation

- `pnpm test -- app/components/ChatInput/__tests__/ChatInputToolbar.test.tsx app/contexts/__tests__/GlobalState.agent-default.test.tsx --runInBand`
- `pnpm typecheck`
- targeted ESLint and Prettier checks
- full pre-commit suite: 306 suites / 3025 tests passed
- existing Playwright Pro test: `should default paid users to Agent-only controls`
- five authenticated Pro reloads with a pre-hydration MutationObserver: selector never entered the DOM; zero console errors, page errors, or Next.js overlays

## Manual verification

1. Sign in with a paid account on the new-chat page.
2. Reload the page several times.
3. Confirm the Ask/Agent selector never appears and the Agent controls (`Full access`, model selector, and sandbox selector) remain visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the chat mode selector from rendering until chat-mode access permissions have finished resolving.
  * Ensured the selector remains hidden when paid agent-only mode is active, including during agent-mode transitions.
* **Tests**
  * Added/updated test coverage for chat-mode access resolution states, including scenarios with authentication loading and rerenders into agent mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->