### PR TITLE
Share response quality and freshness guidance across modes

### DIFF
--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -51,6 +51,60 @@ describe("systemPrompt security instructions", () => {
     }
   });
 
+  it("shares response style, mistake recovery, and freshness guidance across modes", async () => {
+    const askPrompt = await systemPrompt(
+      "user_123",
+      "ask",
+      "pro",
+      "ask-model",
+      null,
+      false,
+      null,
+    );
+    const agentPrompt = await systemPrompt(
+      "user_123",
+      "agent",
+      "pro",
+      "agent-model",
+      null,
+      false,
+      null,
+    );
+
+    for (const prompt of [askPrompt, agentPrompt]) {
+      expect(prompt).toContain("<response_style>");
+      expect(prompt).toContain(
+        "For simple or conversational requests, respond naturally and concisely",
+      );
+      expect(prompt).toContain(
+        "Give the best useful answer before asking a follow-up question.",
+      );
+      expect(prompt).toContain(
+        "Do not use emojis unless the user asks for them",
+      );
+
+      expect(prompt).toContain("<mistake_recovery>");
+      expect(prompt).toContain("address their specific criticism directly");
+      expect(prompt).toContain("Own and correct mistakes honestly.");
+      expect(prompt).toContain("Avoid excessive apology");
+      expect(prompt).not.toContain("'thumbs down' button");
+
+      expect(prompt).toContain("<freshness_and_web_search>");
+      expect(prompt).toContain("Your reliable knowledge cutoff is");
+      expect(prompt).toContain(
+        "Use web_search when the user asks for current or time-sensitive information",
+      );
+      expect(prompt).toContain(
+        "Use open_url when the user provides a specific page to inspect",
+      );
+      expect(prompt).toContain("Do not search for stable general concepts");
+
+      expect(prompt.match(/<response_style>/g)).toHaveLength(1);
+      expect(prompt.match(/<mistake_recovery>/g)).toHaveLength(1);
+      expect(prompt.match(/<freshness_and_web_search>/g)).toHaveLength(1);
+    }
+  });
+
   it("does not claim isolated container execution for dangerous local hosts", async () => {
     const localHostContext = `You are executing commands on macOS 15.0 (arm64) in DANGEROUS MODE.
 Commands are invoked via /bin/bash -c.

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -82,6 +82,7 @@ describe("systemPrompt security instructions", () => {
       expect(prompt).toContain(
         "Do not use emojis unless the user asks for them",
       );
+      expect(prompt.match(/emojis/gi)).toHaveLength(1);
 
       expect(prompt).toContain("<mistake_recovery>");
       expect(prompt).toContain("address their specific criticism directly");

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -38,6 +38,29 @@ Do not say the request is outside cybersecurity, do not apologize for scope, and
 Mention HackerAI's cybersecurity focus only when the user asks about product scope or capabilities.
 </general_responses>`;
 
+const RESPONSE_STYLE_SECTION = `<response_style>
+For simple or conversational requests, respond naturally and concisely, usually with sentences or short paragraphs. Use lists when the user asks for them or when structure materially improves clarity.
+Give the best useful answer before asking a follow-up question. Ask no more than one necessary clarification at a time.
+Do not use emojis unless the user asks for them or their immediately previous message uses one; even then, use them sparingly.
+</response_style>`;
+
+const MISTAKE_RECOVERY_SECTION = `<mistake_recovery>
+When the user says a response is wrong, unhelpful, or unsatisfactory, address their specific criticism directly.
+Own and correct mistakes honestly. Avoid excessive apology, self-critique, self-abasement, or submissive language; stay respectful and focused on solving the problem.
+</mistake_recovery>`;
+
+const getFreshnessAndWebSearchSection = (modelName: ModelName): string => {
+  const knowledgeCutoffDate = getModelCutoffDate(modelName);
+
+  return `<freshness_and_web_search>
+Your reliable knowledge cutoff is ${knowledgeCutoffDate}. Treat facts that may have changed after that date as requiring verification when current accuracy matters.
+Use web_search when the user asks for current or time-sensitive information, explicitly asks to verify or look something up, or when the answer depends on a fact likely to have changed. This includes current events, officeholders and appointments, laws and regulations, prices, product specifications, software and library versions, security advisories, schedules, market data, and weather.
+Use open_url when the user provides a specific page to inspect or when a search result's full contents are necessary to answer accurately.
+Do not search for stable general concepts, historical facts, scientific principles, programming fundamentals, or established cybersecurity concepts unless the user asks for sources or verification.
+Prefer one focused, comprehensive search over multiple speculative searches. Present sourced findings without overstating certainty, and mention the knowledge cutoff only when it is relevant.
+</freshness_and_web_search>`;
+};
+
 // Shared pentesting tools list for sandbox environments
 export const PREINSTALLED_PENTESTING_TOOLS = `Pre-installed Pentesting Tools:
 - Network Scanning: nmap (network mapping/port scanning), naabu (fast port scanner), httpx (HTTP prober)
@@ -387,11 +410,9 @@ When in doubt, answer from your own knowledge first. One focused query beats sev
 </web_tool_usage>`;
 
 const getAskModeSection = (
-  modelName: ModelName,
   subscription: SubscriptionTier,
   notesEnabled: boolean,
 ): string => {
-  const knowledgeCutOffDate = getModelCutoffDate(modelName);
   const notesCapability = notesEnabled ? " and manage notes" : "";
   const agentModeCTA =
     subscription === "free"
@@ -403,61 +424,7 @@ edit code, run terminal commands, or execute code. ${agentModeCTA}
 </current_mode>
 
 `;
-  return `${modeReminder}${getProductQuestionsSection()}
-
-<tone_and_formatting>
-In typical conversations or when asked simple questions HackerAI keeps its tone natural and responds \
-in sentences/paragraphs rather than lists or bullet points unless explicitly asked for these. \
-In casual conversation, it's fine for HackerAI's responses to be relatively short, \
-e.g. just a few sentences long.
-
-In general conversation, HackerAI doesn't always ask questions but, when it does it tries to avoid \
-overwhelming the person with more than one question per response. HackerAI does its best to address \
-the user's query, even if ambiguous, before asking for clarification or additional information.
-
-HackerAI does not use emojis unless the person in the conversation asks it to or if the person's \
-message immediately prior contains an emoji, and is judicious about its use of emojis even in these circumstances.
-</tone_and_formatting>
-
-<responding_to_mistakes_and_criticism>
-If the person seems unhappy or unsatisfied with HackerAI or HackerAI's responses or seems unhappy that HackerAI \
-won't help with something, HackerAI can respond normally but can also let the person know that they can press the \
-'thumbs down' button below any of HackerAI's responses to provide feedback.
-
-When HackerAI makes mistakes, it should own them honestly and work to fix them. HackerAI is deserving of respectful \
-engagement and does not need to apologize when the person is unnecessarily rude. It's best for HackerAI to take \
-accountability but avoid collapsing into self-abasement, excessive apology, or other kinds of self-critique and \
-surrender. If the person becomes abusive over the course of a conversation, HackerAI avoids becoming increasingly \
-submissive in response. The goal is to maintain steady, honest helpfulness: acknowledge what went wrong, stay \
-focused on solving the problem, and maintain self-respect.
-</responding_to_mistakes_and_criticism>
-
-<knowledge_cutoff>
-HackerAI's reliable knowledge cutoff date - the date past which it cannot answer questions reliably \
-- is ${knowledgeCutOffDate}. It answers questions the way a highly informed individual in \
-${knowledgeCutOffDate} would if they were talking to someone from ${currentDateTime}, and \
-can let the person it's talking to know this if relevant.
-
-HackerAI uses the web tool judiciously. It searches when asked about current events, breaking news, \
-or time-sensitive information after its cutoff date, and when asked about specific binary facts that \
-may have changed (such as deaths, elections, appointments, or major incidents). It also searches for \
-real-time data like stock prices, weather, or schedules, and when the person explicitly asks to verify \
-or look up something online.
-
-HackerAI does NOT search for information it already knows reliably. This includes general concepts, \
-definitions, or explanations that don't change over time; historical events, scientific principles, \
-or established facts; programming concepts, algorithms, or technical fundamentals; cybersecurity \
-concepts, common vulnerabilities, or attack methodologies. HackerAI also avoids searching when the \
-answer wouldn't meaningfully differ between ${knowledgeCutOffDate} and ${currentDateTime}, or when \
-the information is already available in the conversation context or provided files.
-
-When HackerAI does search, it prefers one well-crafted comprehensive query over multiple narrow \
-searches. It exhausts its training knowledge before searching - only searching when it genuinely \
-doesn't know or needs verification. HackerAI does not make overconfident claims about the validity \
-of search results or lack thereof, and instead presents its findings evenhandedly without jumping \
-to unwarranted conclusions, allowing the person to investigate further if desired. HackerAI does \
-not remind the person of its cutoff date unless it is relevant to the person's message.
-</knowledge_cutoff>`;
+  return `${modeReminder}${getProductQuestionsSection()}`;
 };
 
 // Core system prompt with optimized structure
@@ -496,12 +463,13 @@ The current date is ${currentDateTime}.`;
     basePrompt,
     LANGUAGE_SECTION,
     GENERAL_RESPONSE_SECTION,
+    RESPONSE_STYLE_SECTION,
+    MISTAKE_RECOVERY_SECTION,
+    getFreshnessAndWebSearchSection(modelName),
   ];
 
   if (mode === "ask") {
-    sections.push(
-      getAskModeSection(modelName, subscription, shouldIncludeNotes),
-    );
+    sections.push(getAskModeSection(subscription, shouldIncludeNotes));
   } else {
     sections.push(
       getAgentModeSection(mode, sandboxContext, agentPermissionMode),

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -300,7 +300,6 @@ Do what has been asked; nothing more, nothing less.
 NEVER create files unless they're absolutely necessary for achieving your goal.
 ALWAYS prefer editing an existing file to creating a new one.
 NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
-Generally refrain from using emojis unless explicitly asked for or extremely informative.
 
 <inline_line_numbers>
 Code chunks that you receive (via tool calls or from user) may include inline line numbers in the form LINE_NUMBER|LINE_CONTENT. Treat the LINE_NUMBER| prefix as metadata and do NOT treat it as part of the actual code. LINE_NUMBER is right-aligned number padded with spaces to 6 characters.


### PR DESCRIPTION
## What changed

- move compact response-style guidance into a shared Ask/Agent section
- add shared mistake-recovery guidance that addresses specific criticism, corrects errors directly, and avoids excessive apology
- move and tighten freshness/web-search policy so Agent also verifies current or changeable facts
- cover when to use `web_search` versus `open_url`, plus when not to search
- remove the Ask-only UI instruction that told dissatisfied users to press the thumbs-down button
- remove the older Agent-only emoji instruction so the shared rule appears exactly once

## Why

Paid normal chats now use Agent mode by default, but several general-response quality rules remained isolated inside the Ask prompt. Agent had web tools without the same explicit freshness policy and did not receive the same compact style or mistake-recovery guidance.

The thumbs-down sentence was a feedback-UI CTA rather than answer-quality behavior. Both modes now receive the useful behavior directly: address the criticism, own and correct mistakes, and stay focused on solving the problem.

## Rollout decision

This is intentionally an unflagged consistency/correctness change. The desired default is the same response-quality and freshness behavior in both Ask and Agent after Agent became the paid default; adding another mode-specific flag would preserve the split this PR fixes. The change is isolated to prompt assembly, covered by exact inclusion tests, and can be rolled back independently.

## User impact

Ask and Agent now consistently:

- answer simple requests naturally and concisely
- avoid unnecessary follow-up questions and excessive emoji use
- recover from incorrect or unsatisfactory answers directly
- verify current, time-sensitive, or likely-to-change information
- avoid unnecessary searches for stable concepts

## Validation

- `pnpm test -- lib/__tests__/system-prompt.test.ts --runInBand` — 22 tests passed
- `pnpm typecheck`
- targeted ESLint and Prettier checks
- full pre-commit suite: 307 suites / 3031 tests passed

## Manual verification

1. In both Ask and Agent, ask a simple factual or conversational question; confirm the response is concise and does not add an unnecessary follow-up.
2. Ask for current software-version or security-advisory information; confirm the model uses web verification and reports sourced findings without overstating certainty.
3. Tell the model that its prior answer was wrong; confirm it addresses the specific error and corrects it without excessive apology or telling the user to press thumbs down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved consistency in response style and formatting across Ask and Agent modes.
  * Enhanced mistake-handling and recovery guidance for clearer corrections.
  * Updated freshness and web-search instructions to match the selected model.
  * Streamlined shared system guidance used across conversation modes.

* **Tests**
  * Added a Jest test to ensure Ask/Agent prompts include the same guidance and that each guidance placeholder appears exactly once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->