### PR TITLE
Keep large Agent task histories responsive

### DIFF
--- a/__mocks__/@legendapp/list-react.tsx
+++ b/__mocks__/@legendapp/list-react.tsx
@@ -1,0 +1,77 @@
+import {
+  Fragment,
+  forwardRef,
+  isValidElement,
+  useImperativeHandle,
+  useRef,
+  type ComponentType,
+  type ForwardedRef,
+  type ReactNode,
+} from "react";
+
+type OptionalComponent = ReactNode | ComponentType;
+
+const renderOptionalComponent = (component: OptionalComponent) => {
+  if (typeof component === "function") {
+    const Component = component;
+    return <Component />;
+  }
+
+  return isValidElement(component) ? component : null;
+};
+
+export const LegendList = forwardRef(function MockLegendList<
+  Item extends unknown,
+>(
+  {
+    data,
+    renderItem,
+    keyExtractor,
+    ListHeaderComponent,
+    ListFooterComponent,
+    className,
+    style,
+    "data-testid": dataTestId,
+  }: {
+    data: Item[];
+    renderItem: (info: { item: Item; index: number }) => ReactNode;
+    keyExtractor?: (item: Item, index: number) => string;
+    ListHeaderComponent?: OptionalComponent;
+    ListFooterComponent?: OptionalComponent;
+    className?: string;
+    style?: React.CSSProperties;
+    "data-testid"?: string;
+  },
+  forwardedRef: ForwardedRef<{
+    getScrollableNode: () => HTMLDivElement | null;
+  }>,
+) {
+  const scrollElementRef = useRef<HTMLDivElement>(null);
+
+  useImperativeHandle(
+    forwardedRef,
+    () => ({
+      getScrollableNode: () => scrollElementRef.current,
+    }),
+    [],
+  );
+
+  return (
+    <div
+      ref={scrollElementRef}
+      className={className}
+      style={style}
+      data-testid={dataTestId}
+    >
+      <div className="legend-list-content-container">
+        {renderOptionalComponent(ListHeaderComponent)}
+        {data.map((item, index) => (
+          <Fragment key={keyExtractor?.(item, index) ?? index}>
+            {renderItem({ item, index })}
+          </Fragment>
+        ))}
+        {renderOptionalComponent(ListFooterComponent)}
+      </div>
+    </div>
+  );
+});

--- a/app/components/AgentActivityRow.tsx
+++ b/app/components/AgentActivityRow.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { memo, useMemo } from "react";
+import { MessagePartHandler } from "./MessagePartHandler";
+import type { ChatMessage, ChatStatus } from "@/types";
+import type { FileDetails } from "@/types/file";
+
+type AgentActivityRowProps = {
+  deferReasoningCollapseUntilParent: boolean;
+  isLastMessage: boolean;
+  keepLatestReasoningOpenDuringStreaming: boolean;
+  message: ChatMessage;
+  part: ChatMessage["parts"][number];
+  partIndex: number;
+  sharedFileDetails?: FileDetails[];
+  status: ChatStatus;
+  terminalChunksByToolCallId: Map<string, readonly string[]>;
+};
+
+export const AgentActivityRow = memo(function AgentActivityRow({
+  deferReasoningCollapseUntilParent,
+  isLastMessage,
+  keepLatestReasoningOpenDuringStreaming,
+  message,
+  part,
+  partIndex,
+  sharedFileDetails,
+  status,
+  terminalChunksByToolCallId,
+}: AgentActivityRowProps) {
+  const terminalOutputByToolCallId = useMemo(() => {
+    const toolCallId =
+      (part as { data?: { toolCallId?: unknown } }).data?.toolCallId ??
+      (part as { toolCallId?: unknown }).toolCallId;
+    if (typeof toolCallId !== "string") return new Map<string, string>();
+
+    return new Map([
+      [toolCallId, (terminalChunksByToolCallId.get(toolCallId) ?? []).join("")],
+    ]);
+  }, [part, terminalChunksByToolCallId]);
+
+  return (
+    <div
+      className="message-row w-full min-w-0 overflow-hidden text-foreground"
+      data-testid="agent-activity-row"
+    >
+      <div className="prose max-w-none min-w-0 overflow-hidden dark:prose-invert">
+        <MessagePartHandler
+          message={message}
+          part={part}
+          partIndex={partIndex}
+          status={status}
+          isLastMessage={isLastMessage}
+          keepLatestReasoningOpenDuringStreaming={
+            keepLatestReasoningOpenDuringStreaming
+          }
+          deferReasoningCollapseUntilParent={deferReasoningCollapseUntilParent}
+          terminalOutputByToolCallId={terminalOutputByToolCallId}
+          sharedFileDetails={sharedFileDetails}
+        />
+      </div>
+    </div>
+  );
+});

--- a/app/components/AgentWorkHeader.tsx
+++ b/app/components/AgentWorkHeader.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { memo, useEffect, useState } from "react";
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+import { formatDuration } from "@/components/ai-elements/worked-for";
+
+type AgentWorkHeaderProps = {
+  activityCount: number;
+  canToggle: boolean;
+  durationMs?: number;
+  expanded: boolean;
+  isTiming: boolean;
+  messageId: string;
+  onToggle: (messageId: string) => void;
+  startedAt?: number;
+};
+
+export const AgentWorkHeader = memo(function AgentWorkHeader({
+  activityCount,
+  canToggle,
+  durationMs,
+  expanded,
+  isTiming,
+  messageId,
+  onToggle,
+  startedAt,
+}: AgentWorkHeaderProps) {
+  const [elapsedMs, setElapsedMs] = useState(() =>
+    typeof startedAt === "number" ? Math.max(0, Date.now() - startedAt) : 0,
+  );
+
+  useEffect(() => {
+    if (!isTiming) return;
+
+    const effectiveStartedAt =
+      typeof startedAt === "number" && Number.isFinite(startedAt)
+        ? startedAt
+        : Date.now();
+    const updateElapsed = () => {
+      setElapsedMs(Math.max(0, Date.now() - effectiveStartedAt));
+    };
+
+    updateElapsed();
+    const intervalId = window.setInterval(updateElapsed, 1_000);
+    return () => window.clearInterval(intervalId);
+  }, [isTiming, startedAt]);
+
+  const label = isTiming
+    ? `Working for ${formatDuration(elapsedMs)}`
+    : typeof durationMs === "number" && durationMs > 0
+      ? `Worked for ${formatDuration(durationMs)}`
+      : "Worked";
+  const activityLabel = `${activityCount} ${
+    activityCount === 1 ? "activity" : "activities"
+  }`;
+
+  return (
+    <button
+      type="button"
+      disabled={!canToggle}
+      aria-expanded={canToggle ? expanded : undefined}
+      onClick={() => onToggle(messageId)}
+      className={`flex w-full items-center gap-2 border-b border-border pb-3 text-left text-sm text-muted-foreground transition-colors ${
+        canToggle ? "hover:text-foreground" : "cursor-default"
+      }`}
+    >
+      <span>{label}</span>
+      <span className="text-xs text-muted-foreground/70">{activityLabel}</span>
+      {canToggle &&
+        (expanded ? (
+          <ChevronDownIcon className="size-4" />
+        ) : (
+          <ChevronRightIcon className="size-4" />
+        ))}
+    </button>
+  );
+});

--- a/app/components/AgentWorkHeader.tsx
+++ b/app/components/AgentWorkHeader.tsx
@@ -5,7 +5,6 @@ import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
 import { formatDuration } from "@/components/ai-elements/worked-for";
 
 type AgentWorkHeaderProps = {
-  activityCount: number;
   canToggle: boolean;
   durationMs?: number;
   expanded: boolean;
@@ -16,7 +15,6 @@ type AgentWorkHeaderProps = {
 };
 
 export const AgentWorkHeader = memo(function AgentWorkHeader({
-  activityCount,
   canToggle,
   durationMs,
   expanded,
@@ -50,9 +48,6 @@ export const AgentWorkHeader = memo(function AgentWorkHeader({
     : typeof durationMs === "number" && durationMs > 0
       ? `Worked for ${formatDuration(durationMs)}`
       : "Worked";
-  const activityLabel = `${activityCount} ${
-    activityCount === 1 ? "activity" : "activities"
-  }`;
 
   return (
     <button
@@ -65,7 +60,6 @@ export const AgentWorkHeader = memo(function AgentWorkHeader({
       }`}
     >
       <span>{label}</span>
-      <span className="text-xs text-muted-foreground/70">{activityLabel}</span>
       {canToggle &&
         (expanded ? (
           <ChevronDownIcon className="size-4" />

--- a/app/components/AgentWorkHeader.tsx
+++ b/app/components/AgentWorkHeader.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import { memo, useEffect, useState } from "react";
+import type {
+  KeyboardEventHandler,
+  MouseEventHandler,
+  PointerEventHandler,
+  TouchEventHandler,
+} from "react";
 import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
 import { formatDuration } from "@/components/ai-elements/worked-for";
 
@@ -10,7 +16,8 @@ type AgentWorkHeaderProps = {
   expanded: boolean;
   isTiming: boolean;
   messageId: string;
-  onToggle: (messageId: string) => void;
+  onCaptureScroll: (target: EventTarget | null) => void;
+  onToggle: (messageId: string, nextExpanded: boolean) => void;
   startedAt?: number;
 };
 
@@ -20,6 +27,7 @@ export const AgentWorkHeader = memo(function AgentWorkHeader({
   expanded,
   isTiming,
   messageId,
+  onCaptureScroll,
   onToggle,
   startedAt,
 }: AgentWorkHeaderProps) {
@@ -48,13 +56,41 @@ export const AgentWorkHeader = memo(function AgentWorkHeader({
     : typeof durationMs === "number" && durationMs > 0
       ? `Worked for ${formatDuration(durationMs)}`
       : "Worked";
+  const handlePointerDown: PointerEventHandler<HTMLButtonElement> = (event) => {
+    if (canToggle && !event.defaultPrevented) {
+      onCaptureScroll(event.currentTarget);
+    }
+  };
+  const handleTouchStart: TouchEventHandler<HTMLButtonElement> = (event) => {
+    if (canToggle && !event.defaultPrevented) {
+      onCaptureScroll(event.currentTarget);
+    }
+  };
+  const handleKeyDown: KeyboardEventHandler<HTMLButtonElement> = (event) => {
+    if (
+      canToggle &&
+      !event.defaultPrevented &&
+      (event.key === "Enter" || event.key === " ")
+    ) {
+      onCaptureScroll(event.currentTarget);
+    }
+  };
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    if (!canToggle || event.defaultPrevented) return;
+
+    onCaptureScroll(event.currentTarget);
+    onToggle(messageId, !expanded);
+  };
 
   return (
     <button
       type="button"
       disabled={!canToggle}
       aria-expanded={canToggle ? expanded : undefined}
-      onClick={() => onToggle(messageId)}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      onPointerDown={handlePointerDown}
+      onTouchStart={handleTouchStart}
       className={`flex w-full items-center gap-2 border-b border-border pb-3 text-left text-sm text-muted-foreground transition-colors ${
         canToggle ? "hover:text-foreground" : "cursor-default"
       }`}

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -1,11 +1,4 @@
-import {
-  memo,
-  useMemo,
-  useCallback,
-  Fragment,
-  startTransition,
-  useState,
-} from "react";
+import { memo, useMemo, useCallback, Fragment, useState } from "react";
 import { MessageActions } from "./MessageActions";
 import { MessagePartHandler } from "./MessagePartHandler";
 import { FilePartRenderer } from "./FilePartRenderer";
@@ -14,8 +7,9 @@ import { FeedbackInput } from "./FeedbackInput";
 import { BranchIndicator } from "./BranchIndicator";
 import { FinishReasonNotice } from "./FinishReasonNotice";
 import {
-  isExpandableWorkedForPart,
+  projectAgentWorkParts,
   splitWorkedForParts,
+  type AgentWorkProjection,
 } from "./worked-for-parts";
 import { SummarizationStatusDivider } from "./SummarizationStatusDivider";
 import {
@@ -35,7 +29,11 @@ import type { FileDetails } from "@/types/file";
 
 const USER_MESSAGE_PREVIEW_LINE_LIMIT = 20;
 const USER_MESSAGE_PREVIEW_CHAR_LIMIT = 1_200;
-const WORK_ACTIVITY_RENDER_BATCH_SIZE = 80;
+const EMPTY_AGENT_WORK_PROJECTION: AgentWorkProjection = {
+  activities: [],
+  hasExpandableWork: false,
+  terminalChunksByToolCallId: new Map(),
+};
 
 const splitMessageLines = (text: string) => text.split(/\r\n|\r|\n/);
 
@@ -51,16 +49,6 @@ const getUserMessagePreview = (text: string) => {
   }
 
   return text.slice(0, USER_MESSAGE_PREVIEW_CHAR_LIMIT).trimEnd();
-};
-
-const shouldRenderWorkPart = (part: ChatMessage["parts"][number]): boolean => {
-  const type = (part as { type?: string }).type;
-  return (
-    type === "text" ||
-    type === "reasoning" ||
-    type === "data-summarization" ||
-    Boolean(type?.startsWith("tool-"))
-  );
 };
 
 interface MessageItemProps {
@@ -80,6 +68,7 @@ interface MessageItemProps {
   branchedFromChatTitle?: string;
   branchBoundaryIndex: number | undefined;
   showingLoadingIndicator?: boolean;
+  workPresentation?: "inline" | "timeline-shell";
   // Inline status for mid-conversation summarization (when message already has content)
   summarizationStatus?: {
     status: "started" | "completed";
@@ -123,6 +112,7 @@ function areMessageItemPropsEqual(
     return false;
   if (prev.showingLoadingIndicator !== next.showingLoadingIndicator)
     return false;
+  if (prev.workPresentation !== next.workPresentation) return false;
   if (prev.summarizationStatus?.status !== next.summarizationStatus?.status)
     return false;
   if (prev.tempChatFileDetails !== next.tempChatFileDetails) return false;
@@ -187,6 +177,7 @@ export const MessageItem = memo(function MessageItem({
   onShowAllFiles,
   getCachedUrl,
   showingLoadingIndicator,
+  workPresentation = "inline",
   summarizationStatus,
   agentRunSpendCapWarning,
 }: MessageItemProps) {
@@ -219,39 +210,24 @@ export const MessageItem = memo(function MessageItem({
   );
 
   // Memoize part filtering - only recompute when parts change
-  const { fileParts, nonFileParts, workParts, trailingTextParts } = useMemo(
-    () => splitWorkedForParts(message.parts),
-    [message.parts],
-  );
-  const indexedWorkParts = useMemo(
+  const {
+    fileParts,
+    nonFileParts,
+    workParts,
+    workPartIndexes,
+    trailingTextParts,
+  } = useMemo(() => splitWorkedForParts(message.parts), [message.parts]);
+  const workProjection = useMemo(
     () =>
-      workParts.flatMap((part, partIndex) =>
-        shouldRenderWorkPart(part) ? [{ part, partIndex }] : [],
-      ),
-    [workParts],
+      workPresentation === "timeline-shell"
+        ? EMPTY_AGENT_WORK_PROJECTION
+        : projectAgentWorkParts(message.parts, workPartIndexes),
+    [message.parts, workPartIndexes, workPresentation],
   );
-  const [visibleWorkPartCount, setVisibleWorkPartCount] = useState(
-    WORK_ACTIVITY_RENDER_BATCH_SIZE,
-  );
-  const hiddenWorkPartCount = Math.max(
-    0,
-    indexedWorkParts.length - visibleWorkPartCount,
-  );
-  const visibleWorkParts = useMemo(
-    () => indexedWorkParts.slice(hiddenWorkPartCount),
-    [hiddenWorkPartCount, indexedWorkParts],
-  );
-  const hasExpandableWork = useMemo(
-    () => indexedWorkParts.some(({ part }) => isExpandableWorkedForPart(part)),
-    [indexedWorkParts],
-  );
-  const handleShowEarlierWork = useCallback(() => {
-    startTransition(() => {
-      setVisibleWorkPartCount(
-        (current) => current + WORK_ACTIVITY_RENDER_BATCH_SIZE,
-      );
-    });
-  }, []);
+  const renderedNonFileParts =
+    workPresentation === "timeline-shell" ? trailingTextParts : nonFileParts;
+  const shouldRenderWorkedFor =
+    message.metadata?.mode === "agent" && workPresentation === "inline";
 
   const shouldCollapseUserMessage =
     isUser &&
@@ -288,20 +264,19 @@ export const MessageItem = memo(function MessageItem({
   const shouldShowWorkingTimer = isStreamingThisMessage;
   const shouldUseWorkedFor = message.metadata?.mode === "agent";
   const deferReasoningCollapseUntilWorkedFor =
-    shouldUseWorkedFor && workParts.length > 0 && trailingTextParts.length > 0;
-
-  // Pre-compute terminal output by toolCallId so TerminalToolHandler doesn't filter all parts per instance
+    shouldRenderWorkedFor &&
+    workParts.length > 0 &&
+    trailingTextParts.length > 0;
   const terminalOutputByToolCallId = useMemo(() => {
-    const map = new Map<string, string>();
-    message.parts.forEach((p) => {
-      if (p.type === "data-terminal" && (p as any).data?.toolCallId) {
-        const id = (p as any).data.toolCallId;
-        const terminal = (p as any).data?.terminal || "";
-        map.set(id, (map.get(id) || "") + terminal);
-      }
-    });
-    return map;
-  }, [message.parts]);
+    const outputByToolCallId = new Map<string, string>();
+    for (const [
+      toolCallId,
+      chunks,
+    ] of workProjection.terminalChunksByToolCallId) {
+      outputByToolCallId.set(toolCallId, chunks.join(""));
+    }
+    return outputByToolCallId;
+  }, [workProjection.terminalChunksByToolCallId]);
 
   const hasFileContent = fileParts.length > 0;
   const hasAnyContent = messageHasTextContent || hasFileContent;
@@ -337,18 +312,9 @@ export const MessageItem = memo(function MessageItem({
     />
   );
 
-  const renderVisibleWorkParts = () => (
+  const renderWorkParts = () => (
     <>
-      {hiddenWorkPartCount > 0 && (
-        <button
-          type="button"
-          onClick={handleShowEarlierWork}
-          className="not-prose w-full rounded-lg border border-border px-3 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-        >
-          Show earlier activity ({hiddenWorkPartCount} hidden)
-        </button>
-      )}
-      {visibleWorkParts.map(({ part, partIndex }) =>
+      {workProjection.activities.map(({ part, partIndex }) =>
         renderAssistantPart(part, partIndex),
       )}
     </>
@@ -454,7 +420,7 @@ export const MessageItem = memo(function MessageItem({
             )}
 
             {/* Render text and other parts */}
-            {nonFileParts.length > 0 && (
+            {renderedNonFileParts.length > 0 && (
               <div
                 data-testid="message-content"
                 className={`${
@@ -481,7 +447,7 @@ export const MessageItem = memo(function MessageItem({
                       </>
                     ) : (
                       <>
-                        {nonFileParts.map((part, partIndex) => (
+                        {renderedNonFileParts.map((part, partIndex) => (
                           <MessagePartHandler
                             key={`${message.id}-${partIndex}`}
                             message={message}
@@ -507,8 +473,8 @@ export const MessageItem = memo(function MessageItem({
                       </>
                     )}
                   </div>
-                ) : !shouldUseWorkedFor ? (
-                  nonFileParts.map((part, partIndex) => (
+                ) : !shouldRenderWorkedFor ? (
+                  renderedNonFileParts.map((part, partIndex) => (
                     <MessagePartHandler
                       key={`${message.id}-${partIndex}`}
                       message={message}
@@ -525,7 +491,7 @@ export const MessageItem = memo(function MessageItem({
                     {workParts.length > 0 && (
                       <WorkedFor
                         key="work"
-                        hasWork={hasExpandableWork}
+                        hasWork={workProjection.hasExpandableWork}
                         defaultOpen
                         isTiming={shouldShowWorkingTimer}
                       >
@@ -533,9 +499,7 @@ export const MessageItem = memo(function MessageItem({
                           isTiming
                           startedAt={generationStartedAt}
                         />
-                        <WorkedForContent>
-                          {renderVisibleWorkParts()}
-                        </WorkedForContent>
+                        <WorkedForContent>{renderWorkParts()}</WorkedForContent>
                       </WorkedFor>
                     )}
                     {trailingTextParts.length > 0 && (
@@ -556,18 +520,18 @@ export const MessageItem = memo(function MessageItem({
                 ) : trailingTextParts.length === 0 ? (
                   // If a run stops before producing final text, keep the work
                   // visible inline instead of leaving only a collapsed header.
-                  renderVisibleWorkParts()
+                  renderWorkParts()
                 ) : (
                   <>
                     {workParts.length > 0 && (
                       <WorkedFor
                         key="work"
-                        hasWork={hasExpandableWork}
+                        hasWork={workProjection.hasExpandableWork}
                         isTiming={shouldShowWorkingTimer}
                       >
                         <WorkedForTrigger durationMs={generationTimeMs} />
                         <WorkedForContent lazy>
-                          {renderVisibleWorkParts}
+                          {renderWorkParts}
                         </WorkedForContent>
                       </WorkedFor>
                     )}
@@ -591,21 +555,23 @@ export const MessageItem = memo(function MessageItem({
             )}
 
             {/* For assistant messages without the user-specific styling, render files mixed with content */}
-            {!isUser && fileParts.length > 0 && nonFileParts.length === 0 && (
-              <div className="prose space-y-3 max-w-none dark:prose-invert min-w-0 overflow-hidden">
-                {message.parts.map((part, partIndex) => (
-                  <MessagePartHandler
-                    key={`${message.id}-${partIndex}`}
-                    message={message}
-                    part={part}
-                    partIndex={partIndex}
-                    status={effectiveStatus}
-                    terminalOutputByToolCallId={terminalOutputByToolCallId}
-                    sharedFileDetails={effectiveFileDetails}
-                  />
-                ))}
-              </div>
-            )}
+            {!isUser &&
+              fileParts.length > 0 &&
+              renderedNonFileParts.length === 0 && (
+                <div className="prose space-y-3 max-w-none dark:prose-invert min-w-0 overflow-hidden">
+                  {message.parts.map((part, partIndex) => (
+                    <MessagePartHandler
+                      key={`${message.id}-${partIndex}`}
+                      message={message}
+                      part={part}
+                      partIndex={partIndex}
+                      status={effectiveStatus}
+                      terminalOutputByToolCallId={terminalOutputByToolCallId}
+                      sharedFileDetails={effectiveFileDetails}
+                    />
+                  ))}
+                </div>
+              )}
           </div>
         )}
 

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -1,4 +1,11 @@
-import { memo, useMemo, useCallback, Fragment, useState } from "react";
+import {
+  memo,
+  useMemo,
+  useCallback,
+  Fragment,
+  startTransition,
+  useState,
+} from "react";
 import { MessageActions } from "./MessageActions";
 import { MessagePartHandler } from "./MessagePartHandler";
 import { FilePartRenderer } from "./FilePartRenderer";
@@ -28,6 +35,7 @@ import type { FileDetails } from "@/types/file";
 
 const USER_MESSAGE_PREVIEW_LINE_LIMIT = 20;
 const USER_MESSAGE_PREVIEW_CHAR_LIMIT = 1_200;
+const WORK_ACTIVITY_RENDER_BATCH_SIZE = 80;
 
 const splitMessageLines = (text: string) => text.split(/\r\n|\r|\n/);
 
@@ -43,6 +51,16 @@ const getUserMessagePreview = (text: string) => {
   }
 
   return text.slice(0, USER_MESSAGE_PREVIEW_CHAR_LIMIT).trimEnd();
+};
+
+const shouldRenderWorkPart = (part: ChatMessage["parts"][number]): boolean => {
+  const type = (part as { type?: string }).type;
+  return (
+    type === "text" ||
+    type === "reasoning" ||
+    type === "data-summarization" ||
+    Boolean(type?.startsWith("tool-"))
+  );
 };
 
 interface MessageItemProps {
@@ -205,10 +223,35 @@ export const MessageItem = memo(function MessageItem({
     () => splitWorkedForParts(message.parts),
     [message.parts],
   );
-  const hasExpandableWork = useMemo(
-    () => workParts.some(isExpandableWorkedForPart),
+  const indexedWorkParts = useMemo(
+    () =>
+      workParts.flatMap((part, partIndex) =>
+        shouldRenderWorkPart(part) ? [{ part, partIndex }] : [],
+      ),
     [workParts],
   );
+  const [visibleWorkPartCount, setVisibleWorkPartCount] = useState(
+    WORK_ACTIVITY_RENDER_BATCH_SIZE,
+  );
+  const hiddenWorkPartCount = Math.max(
+    0,
+    indexedWorkParts.length - visibleWorkPartCount,
+  );
+  const visibleWorkParts = useMemo(
+    () => indexedWorkParts.slice(hiddenWorkPartCount),
+    [hiddenWorkPartCount, indexedWorkParts],
+  );
+  const hasExpandableWork = useMemo(
+    () => indexedWorkParts.some(({ part }) => isExpandableWorkedForPart(part)),
+    [indexedWorkParts],
+  );
+  const handleShowEarlierWork = useCallback(() => {
+    startTransition(() => {
+      setVisibleWorkPartCount(
+        (current) => current + WORK_ACTIVITY_RENDER_BATCH_SIZE,
+      );
+    });
+  }, []);
 
   const shouldCollapseUserMessage =
     isUser &&
@@ -292,6 +335,23 @@ export const MessageItem = memo(function MessageItem({
       terminalOutputByToolCallId={terminalOutputByToolCallId}
       sharedFileDetails={effectiveFileDetails}
     />
+  );
+
+  const renderVisibleWorkParts = () => (
+    <>
+      {hiddenWorkPartCount > 0 && (
+        <button
+          type="button"
+          onClick={handleShowEarlierWork}
+          className="not-prose w-full rounded-lg border border-border px-3 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+        >
+          Show earlier activity ({hiddenWorkPartCount} hidden)
+        </button>
+      )}
+      {visibleWorkParts.map(({ part, partIndex }) =>
+        renderAssistantPart(part, partIndex),
+      )}
+    </>
   );
 
   const shouldShowBranchIndicator = Boolean(
@@ -474,7 +534,7 @@ export const MessageItem = memo(function MessageItem({
                           startedAt={generationStartedAt}
                         />
                         <WorkedForContent>
-                          {workParts.map(renderAssistantPart)}
+                          {renderVisibleWorkParts()}
                         </WorkedForContent>
                       </WorkedFor>
                     )}
@@ -496,18 +556,7 @@ export const MessageItem = memo(function MessageItem({
                 ) : trailingTextParts.length === 0 ? (
                   // If a run stops before producing final text, keep the work
                   // visible inline instead of leaving only a collapsed header.
-                  nonFileParts.map((part, partIndex) => (
-                    <MessagePartHandler
-                      key={`${message.id}-${partIndex}`}
-                      message={message}
-                      part={part}
-                      partIndex={partIndex}
-                      status={effectiveStatus}
-                      isLastMessage={isLastMessage}
-                      terminalOutputByToolCallId={terminalOutputByToolCallId}
-                      sharedFileDetails={effectiveFileDetails}
-                    />
-                  ))
+                  renderVisibleWorkParts()
                 ) : (
                   <>
                     {workParts.length > 0 && (
@@ -517,8 +566,8 @@ export const MessageItem = memo(function MessageItem({
                         isTiming={shouldShowWorkingTimer}
                       >
                         <WorkedForTrigger durationMs={generationTimeMs} />
-                        <WorkedForContent>
-                          {() => workParts.map(renderAssistantPart)}
+                        <WorkedForContent lazy>
+                          {renderVisibleWorkParts}
                         </WorkedForContent>
                       </WorkedFor>
                     )}

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -555,23 +555,21 @@ export const MessageItem = memo(function MessageItem({
             )}
 
             {/* For assistant messages without the user-specific styling, render files mixed with content */}
-            {!isUser &&
-              fileParts.length > 0 &&
-              renderedNonFileParts.length === 0 && (
-                <div className="prose space-y-3 max-w-none dark:prose-invert min-w-0 overflow-hidden">
-                  {message.parts.map((part, partIndex) => (
-                    <MessagePartHandler
-                      key={`${message.id}-${partIndex}`}
-                      message={message}
-                      part={part}
-                      partIndex={partIndex}
-                      status={effectiveStatus}
-                      terminalOutputByToolCallId={terminalOutputByToolCallId}
-                      sharedFileDetails={effectiveFileDetails}
-                    />
-                  ))}
-                </div>
-              )}
+            {!isUser && fileParts.length > 0 && nonFileParts.length === 0 && (
+              <div className="prose space-y-3 max-w-none dark:prose-invert min-w-0 overflow-hidden">
+                {message.parts.map((part, partIndex) => (
+                  <MessagePartHandler
+                    key={`${message.id}-${partIndex}`}
+                    message={message}
+                    part={part}
+                    partIndex={partIndex}
+                    status={effectiveStatus}
+                    terminalOutputByToolCallId={terminalOutputByToolCallId}
+                    sharedFileDetails={effectiveFileDetails}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         )}
 

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -4,7 +4,6 @@ import {
   useLayoutEffect,
   useMemo,
   useCallback,
-  startTransition,
   Dispatch,
   MutableRefObject,
   RefCallback,
@@ -18,6 +17,7 @@ import { AgentWorkHeader } from "./AgentWorkHeader";
 import { MessageErrorState } from "./MessageErrorState";
 import { SummarizationStatusDivider } from "./SummarizationStatusDivider";
 import { Shimmer } from "@/components/ai-elements/shimmer";
+import { useScrollPreservation } from "@/components/ai-elements/worked-for";
 import Loading from "@/components/ui/loading";
 import { useFeedback } from "../hooks/useFeedback";
 import { useFileUrlCache } from "../hooks/useFileUrlCache";
@@ -224,20 +224,6 @@ export const Messages = ({
       visibleMessages,
     ],
   );
-  const handleToggleAgentWork = useCallback((messageId: string) => {
-    startTransition(() => {
-      setExpandedAgentMessageIds((current) => {
-        const next = new Set(current);
-        if (next.has(messageId)) {
-          next.delete(messageId);
-        } else {
-          next.add(messageId);
-        }
-        return next;
-      });
-    });
-  }, []);
-
   // Track edit state for messages
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
 
@@ -337,6 +323,24 @@ export const Messages = ({
     content: HTMLElement | null;
     scroll: HTMLElement | null;
   }>({ content: null, scroll: null });
+  const { captureScrollPosition, preserveScrollPosition } =
+    useScrollPreservation();
+  const handleToggleAgentWork = useCallback(
+    (messageId: string, nextExpanded: boolean) => {
+      preserveScrollPosition(() => {
+        setExpandedAgentMessageIds((current) => {
+          const next = new Set(current);
+          if (nextExpanded) {
+            next.add(messageId);
+          } else {
+            next.delete(messageId);
+          }
+          return next;
+        });
+      }, nextExpanded);
+    },
+    [preserveScrollPosition],
+  );
 
   // Keep the established bottom-follow hook connected to LegendList's actual
   // scroll and content elements. LegendList owns row virtualization and
@@ -413,6 +417,7 @@ export const Messages = ({
             expanded={row.expanded}
             isTiming={row.isTiming}
             messageId={row.message.id}
+            onCaptureScroll={captureScrollPosition}
             onToggle={handleToggleAgentWork}
             startedAt={row.startedAt}
           />
@@ -499,6 +504,7 @@ export const Messages = ({
       editingMessageId,
       feedbackInputMessageId,
       finishReason,
+      captureScrollPosition,
       getCachedUrl,
       handleBranchMessage,
       handleCancelEdit,

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -408,7 +408,6 @@ export const Messages = ({
       if (row.kind === "agent-work-header") {
         content = (
           <AgentWorkHeader
-            activityCount={row.activityCount}
             canToggle={row.canToggle}
             durationMs={row.durationMs}
             expanded={row.expanded}

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -1,14 +1,21 @@
 import {
   useState,
-  RefObject,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useCallback,
+  useRef,
+  startTransition,
   Dispatch,
+  MutableRefObject,
+  RefCallback,
   SetStateAction,
 } from "react";
 import dynamic from "next/dynamic";
+import { LegendList, type LegendListRef } from "@legendapp/list/react";
 import { MessageItem } from "./MessageItem";
+import { AgentActivityRow } from "./AgentActivityRow";
+import { AgentWorkHeader } from "./AgentWorkHeader";
 import { MessageErrorState } from "./MessageErrorState";
 import { SummarizationStatusDivider } from "./SummarizationStatusDivider";
 import { Shimmer } from "@/components/ai-elements/shimmer";
@@ -26,6 +33,11 @@ import { hasTextContent } from "@/lib/utils/message-utils";
 import { useDataStreamState } from "./DataStreamProvider";
 import type { RateLimitWarningData } from "./RateLimitWarning";
 import type { SelectedModel } from "@/types";
+import {
+  deriveChatTimelineRows,
+  getChatTimelineRowType,
+  type ChatTimelineRow,
+} from "./message-timeline-rows";
 
 const AllFilesDialog = dynamic(
   () => import("./AllFilesDialog").then((module) => module.AllFilesDialog),
@@ -45,6 +57,25 @@ const AllFilesDialog = dynamic(
   },
 );
 
+type StickyElementRef =
+  | MutableRefObject<HTMLElement | null>
+  | (RefCallback<HTMLElement> & {
+      current?: HTMLElement | null;
+    });
+
+const getTimelineRowKey = (row: ChatTimelineRow) => row.id;
+
+const setElementRef = (ref: StickyElementRef, element: HTMLElement | null) => {
+  if (typeof ref === "function") {
+    ref(element);
+  } else {
+    ref.current = element;
+  }
+};
+
+const getElementRefValue = (ref: StickyElementRef) =>
+  typeof ref === "function" ? (ref.current ?? null) : ref.current;
+
 interface MessagesProps {
   messages: ChatMessage[];
   setMessages: Dispatch<SetStateAction<ChatMessage[]>>;
@@ -60,8 +91,8 @@ interface MessagesProps {
   onBranchMessage?: (messageId: string) => Promise<void>;
   status: ChatStatus;
   error: Error | null;
-  scrollRef: RefObject<HTMLDivElement | null>;
-  contentRef: RefObject<HTMLDivElement | null>;
+  scrollRef: StickyElementRef;
+  contentRef: StickyElementRef;
   paginationStatus?:
     "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
   loadMore?: (numItems: number) => void;
@@ -179,6 +210,38 @@ export const Messages = ({
     return -1;
   }, [messages]);
 
+  const [expandedAgentMessageIds, setExpandedAgentMessageIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const timelineRows = useMemo(
+    () =>
+      deriveChatTimelineRows({
+        messages: visibleMessages,
+        status,
+        lastAssistantMessageIndex,
+        expandedAgentMessageIds,
+      }),
+    [
+      expandedAgentMessageIds,
+      lastAssistantMessageIndex,
+      status,
+      visibleMessages,
+    ],
+  );
+  const handleToggleAgentWork = useCallback((messageId: string) => {
+    startTransition(() => {
+      setExpandedAgentMessageIds((current) => {
+        const next = new Set(current);
+        if (next.has(messageId)) {
+          next.delete(messageId);
+        } else {
+          next.add(messageId);
+        }
+        return next;
+      });
+    });
+  }, []);
+
   // Track edit state for messages
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
 
@@ -272,13 +335,36 @@ export const Messages = ({
     [onBranchMessage],
   );
 
+  const timelineRef = useRef<LegendListRef>(null);
+
+  // Keep the established bottom-follow hook connected to LegendList's actual
+  // scroll and content elements. LegendList owns row virtualization and
+  // measurement; use-stick-to-bottom continues to own the existing composer
+  // follow/escape behavior.
+  useLayoutEffect(() => {
+    const scrollElement = timelineRef.current?.getScrollableNode() ?? null;
+    const contentElement =
+      scrollElement?.querySelector<HTMLElement>(
+        ":scope > .legend-list-content-container",
+      ) ?? null;
+
+    setElementRef(scrollRef, scrollElement);
+    setElementRef(contentRef, contentElement);
+
+    return () => {
+      setElementRef(contentRef, null);
+      setElementRef(scrollRef, null);
+    };
+  }, [contentRef, scrollRef]);
+
   // Handle scroll to load more messages when scrolling to top
   const handleScroll = useCallback(() => {
-    if (!scrollRef.current || !loadMore || paginationStatus !== "CanLoadMore") {
+    const scrollElement = getElementRefValue(scrollRef);
+    if (!scrollElement || !loadMore || paginationStatus !== "CanLoadMore") {
       return;
     }
 
-    const { scrollTop } = scrollRef.current;
+    const { scrollTop } = scrollElement;
 
     // Check if we're near the top (within 100px)
     if (scrollTop < 100) {
@@ -288,7 +374,7 @@ export const Messages = ({
 
   // Add scroll event listener
   useEffect(() => {
-    const scrollElement = scrollRef.current;
+    const scrollElement = getElementRefValue(scrollRef);
     if (!scrollElement) return;
 
     scrollElement.addEventListener("scroll", handleScroll, { passive: true });
@@ -296,97 +382,210 @@ export const Messages = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [handleScroll]);
 
+  const showingLoadingIndicator =
+    summarizationStatus?.status === "started" ||
+    uploadStatus?.isUploading ||
+    shouldShowLoadingDots;
+
+  const renderTimelineRow = useCallback(
+    ({ item: row }: { item: ChatTimelineRow }) => {
+      const rowClassName =
+        row.kind === "agent-work-header"
+          ? "pb-2"
+          : row.kind === "agent-activity"
+            ? "pb-3"
+            : "pb-4";
+
+      let content;
+      if (row.kind === "agent-work-header") {
+        content = (
+          <AgentWorkHeader
+            activityCount={row.activityCount}
+            canToggle={row.canToggle}
+            durationMs={row.durationMs}
+            expanded={row.expanded}
+            isTiming={row.isTiming}
+            messageId={row.message.id}
+            onToggle={handleToggleAgentWork}
+            startedAt={row.startedAt}
+          />
+        );
+      } else if (row.kind === "agent-activity") {
+        const effectiveStatus: ChatStatus =
+          status === "streaming" &&
+          row.messageIndex !== lastAssistantMessageIndex
+            ? "ready"
+            : status;
+        const sharedFileDetails =
+          row.message.fileDetails ||
+          tempChatFileDetails?.get(row.message.id) ||
+          undefined;
+
+        content = (
+          <AgentActivityRow
+            deferReasoningCollapseUntilParent={
+              row.deferReasoningCollapseUntilParent
+            }
+            isLastMessage={row.isLastMessage}
+            keepLatestReasoningOpenDuringStreaming={
+              row.keepLatestReasoningOpenDuringStreaming
+            }
+            message={row.message}
+            part={row.part}
+            partIndex={row.partIndex}
+            sharedFileDetails={sharedFileDetails}
+            status={effectiveStatus}
+            terminalChunksByToolCallId={row.terminalChunksByToolCallId}
+          />
+        );
+      } else {
+        content = (
+          <MessageItem
+            message={row.message}
+            index={row.messageIndex}
+            messagesLength={visibleMessages.length}
+            lastAssistantMessageIndex={lastAssistantMessageIndex}
+            status={status}
+            isEditing={editingMessageId === row.message.id}
+            isMobile={isMobile}
+            feedbackInputMessageId={feedbackInputMessageId}
+            tempChatFileDetails={tempChatFileDetails}
+            finishReason={finishReason}
+            mode={mode}
+            agentRunSpendCapWarning={agentRunSpendCapWarning}
+            isTemporaryChat={isTemporaryChat}
+            branchedFromChatId={branchedFromChatId}
+            branchedFromChatTitle={branchedFromChatTitle}
+            branchBoundaryIndex={branchBoundaryIndex}
+            onStartEdit={handleStartEdit}
+            onSaveEdit={handleSaveEdit}
+            onCancelEdit={handleCancelEdit}
+            onRegenerate={onRegenerate}
+            onContinue={onContinue}
+            onBranchMessage={onBranchMessage ? handleBranchMessage : undefined}
+            onFeedback={handleFeedback}
+            onFeedbackSubmit={handleFeedbackSubmit}
+            onFeedbackCancel={handleFeedbackCancel}
+            onShowAllFiles={handleShowAllFiles}
+            getCachedUrl={getCachedUrl}
+            showingLoadingIndicator={showingLoadingIndicator}
+            summarizationStatus={summarizationStatus}
+            workPresentation={row.workPresentation}
+          />
+        );
+      }
+
+      return (
+        <div
+          className={`mx-auto w-full max-w-full sm:max-w-[768px] sm:min-w-[390px] ${rowClassName}`}
+          data-timeline-row-kind={row.kind}
+        >
+          {content}
+        </div>
+      );
+    },
+    [
+      agentRunSpendCapWarning,
+      branchBoundaryIndex,
+      branchedFromChatId,
+      branchedFromChatTitle,
+      editingMessageId,
+      feedbackInputMessageId,
+      finishReason,
+      getCachedUrl,
+      handleBranchMessage,
+      handleCancelEdit,
+      handleFeedback,
+      handleFeedbackCancel,
+      handleFeedbackSubmit,
+      handleSaveEdit,
+      handleShowAllFiles,
+      handleStartEdit,
+      handleToggleAgentWork,
+      isMobile,
+      isTemporaryChat,
+      lastAssistantMessageIndex,
+      mode,
+      onBranchMessage,
+      onContinue,
+      onRegenerate,
+      showingLoadingIndicator,
+      status,
+      summarizationStatus,
+      tempChatFileDetails,
+      visibleMessages.length,
+    ],
+  );
+
+  const timelineHeader =
+    paginationStatus === "LoadingMore" ? (
+      <div className="mx-auto flex w-full max-w-[768px] justify-center pb-4">
+        <Loading size={6} />
+      </div>
+    ) : null;
+
+  const timelineFooter =
+    showSummarizationSeparately ||
+    uploadStatus?.isUploading ||
+    shouldShowLoadingDots ||
+    (error && finishReason !== "timeout") ? (
+      <div className="mx-auto flex w-full max-w-full flex-col items-start pb-20 sm:max-w-[768px] sm:min-w-[390px]">
+        {showSummarizationSeparately && (
+          <SummarizationStatusDivider
+            status={summarizationStatus?.status}
+            message={summarizationStatus?.message}
+            className="mb-1 mt-0"
+          />
+        )}
+        {uploadStatus?.isUploading && (
+          <Shimmer className="text-sm">{`${uploadStatus.message}...`}</Shimmer>
+        )}
+        {shouldShowLoadingDots && (
+          <div className="inline-flex items-center rounded-lg bg-muted px-3 py-2 text-muted-foreground">
+            <DotsSpinner size="sm" variant="primary" />
+          </div>
+        )}
+        {error && finishReason !== "timeout" && (
+          <MessageErrorState
+            error={error}
+            onRetry={onRetry}
+            onReconnect={onReconnect}
+            mode={mode}
+          />
+        )}
+      </div>
+    ) : (
+      <div className="h-20" />
+    );
+
   return (
     <FileUrlCacheProvider
       getCachedUrl={getCachedUrl}
       setCachedUrl={setCachedUrl}
     >
-      <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-4">
-        <div
-          ref={contentRef}
-          className="mx-auto w-full max-w-full sm:max-w-[768px] sm:min-w-[390px] flex flex-col space-y-4 pb-20"
+      <div className="relative flex-1 min-h-0">
+        <LegendList<ChatTimelineRow>
+          ref={timelineRef}
+          data={timelineRows}
+          keyExtractor={getTimelineRowKey}
+          getItemType={getChatTimelineRowType}
+          renderItem={renderTimelineRow}
+          estimatedItemSize={64}
+          recycleItems={false}
+          initialScrollAtEnd
+          maintainVisibleContentPosition={{ data: true, size: true }}
+          style={{ height: "100%", minHeight: 0 }}
+          className="h-full min-h-0 overflow-x-hidden"
+          contentContainerStyle={{
+            paddingTop: 16,
+            paddingRight: 16,
+            paddingBottom: 0,
+            paddingLeft: 16,
+          }}
+          ListHeaderComponent={timelineHeader}
+          ListFooterComponent={timelineFooter}
           data-testid="messages-container"
-        >
-          {/* Loading indicator at top when loading more messages */}
-          {paginationStatus === "LoadingMore" && (
-            <div className="flex justify-center py-2">
-              <Loading size={6} />
-            </div>
-          )}
-          {visibleMessages.map((message, index) => (
-            <MessageItem
-              key={message.id}
-              message={message}
-              index={index}
-              messagesLength={visibleMessages.length}
-              lastAssistantMessageIndex={lastAssistantMessageIndex}
-              status={status}
-              isEditing={editingMessageId === message.id}
-              isMobile={isMobile}
-              feedbackInputMessageId={feedbackInputMessageId}
-              tempChatFileDetails={tempChatFileDetails}
-              finishReason={finishReason}
-              mode={mode}
-              agentRunSpendCapWarning={agentRunSpendCapWarning}
-              isTemporaryChat={isTemporaryChat}
-              branchedFromChatId={branchedFromChatId}
-              branchedFromChatTitle={branchedFromChatTitle}
-              branchBoundaryIndex={branchBoundaryIndex}
-              onStartEdit={handleStartEdit}
-              onSaveEdit={handleSaveEdit}
-              onCancelEdit={handleCancelEdit}
-              onRegenerate={onRegenerate}
-              onContinue={onContinue}
-              onBranchMessage={
-                onBranchMessage ? handleBranchMessage : undefined
-              }
-              onFeedback={handleFeedback}
-              onFeedbackSubmit={handleFeedbackSubmit}
-              onFeedbackCancel={handleFeedbackCancel}
-              onShowAllFiles={handleShowAllFiles}
-              getCachedUrl={getCachedUrl}
-              showingLoadingIndicator={
-                summarizationStatus?.status === "started" ||
-                uploadStatus?.isUploading ||
-                shouldShowLoadingDots
-              }
-              summarizationStatus={summarizationStatus}
-            />
-          ))}
-
-          {/* Processing status - upload/loading dots always separate, summarization only when no content */}
-          {(showSummarizationSeparately ||
-            uploadStatus?.isUploading ||
-            shouldShowLoadingDots) && (
-            <div className="flex flex-col items-start">
-              {showSummarizationSeparately && (
-                <SummarizationStatusDivider
-                  status={summarizationStatus?.status}
-                  message={summarizationStatus?.message}
-                  className="mb-1 mt-0"
-                />
-              )}
-              {uploadStatus?.isUploading && (
-                <Shimmer className="text-sm">{`${uploadStatus.message}...`}</Shimmer>
-              )}
-              {shouldShowLoadingDots && (
-                <div className="bg-muted text-muted-foreground rounded-lg px-3 py-2 inline-flex items-center">
-                  <DotsSpinner size="sm" variant="primary" />
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Error state - hide if it was a graceful preemptive timeout */}
-          {error && finishReason !== "timeout" && (
-            <MessageErrorState
-              error={error}
-              onRetry={onRetry}
-              onReconnect={onReconnect}
-              mode={mode}
-            />
-          )}
-        </div>
+        />
 
         {/* All Files Dialog */}
         {hasOpenedAllFilesDialog && (

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -4,7 +4,6 @@ import {
   useLayoutEffect,
   useMemo,
   useCallback,
-  useRef,
   startTransition,
   Dispatch,
   MutableRefObject,
@@ -72,9 +71,6 @@ const setElementRef = (ref: StickyElementRef, element: HTMLElement | null) => {
     ref.current = element;
   }
 };
-
-const getElementRefValue = (ref: StickyElementRef) =>
-  typeof ref === "function" ? (ref.current ?? null) : ref.current;
 
 interface MessagesProps {
   messages: ChatMessage[];
@@ -335,31 +331,44 @@ export const Messages = ({
     [onBranchMessage],
   );
 
-  const timelineRef = useRef<LegendListRef>(null);
+  const [timelineInstance, setTimelineInstance] =
+    useState<LegendListRef | null>(null);
+  const [timelineElements, setTimelineElements] = useState<{
+    content: HTMLElement | null;
+    scroll: HTMLElement | null;
+  }>({ content: null, scroll: null });
 
   // Keep the established bottom-follow hook connected to LegendList's actual
   // scroll and content elements. LegendList owns row virtualization and
   // measurement; use-stick-to-bottom continues to own the existing composer
   // follow/escape behavior.
   useLayoutEffect(() => {
-    const scrollElement = timelineRef.current?.getScrollableNode() ?? null;
+    const scrollElement = timelineInstance?.getScrollableNode() ?? null;
     const contentElement =
       scrollElement?.querySelector<HTMLElement>(
         ":scope > .legend-list-content-container",
       ) ?? null;
 
-    setElementRef(scrollRef, scrollElement);
-    setElementRef(contentRef, contentElement);
+    setTimelineElements((current) =>
+      current.scroll === scrollElement && current.content === contentElement
+        ? current
+        : { content: contentElement, scroll: scrollElement },
+    );
+  }, [timelineInstance]);
+
+  useLayoutEffect(() => {
+    setElementRef(scrollRef, timelineElements.scroll);
+    setElementRef(contentRef, timelineElements.content);
 
     return () => {
       setElementRef(contentRef, null);
       setElementRef(scrollRef, null);
     };
-  }, [contentRef, scrollRef]);
+  }, [contentRef, scrollRef, timelineElements]);
 
   // Handle scroll to load more messages when scrolling to top
   const handleScroll = useCallback(() => {
-    const scrollElement = getElementRefValue(scrollRef);
+    const scrollElement = timelineElements.scroll;
     if (!scrollElement || !loadMore || paginationStatus !== "CanLoadMore") {
       return;
     }
@@ -370,17 +379,16 @@ export const Messages = ({
     if (scrollTop < 100) {
       loadMore(28); // Load 28 more messages
     }
-  }, [scrollRef, loadMore, paginationStatus]);
+  }, [loadMore, paginationStatus, timelineElements.scroll]);
 
   // Add scroll event listener
   useEffect(() => {
-    const scrollElement = getElementRefValue(scrollRef);
+    const scrollElement = timelineElements.scroll;
     if (!scrollElement) return;
 
     scrollElement.addEventListener("scroll", handleScroll, { passive: true });
     return () => scrollElement.removeEventListener("scroll", handleScroll);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [handleScroll]);
+  }, [handleScroll, timelineElements.scroll]);
 
   const showingLoadingIndicator =
     summarizationStatus?.status === "started" ||
@@ -565,12 +573,12 @@ export const Messages = ({
     >
       <div className="relative flex-1 min-h-0">
         <LegendList<ChatTimelineRow>
-          ref={timelineRef}
+          ref={setTimelineInstance}
           data={timelineRows}
           keyExtractor={getTimelineRowKey}
           getItemType={getChatTimelineRowType}
           renderItem={renderTimelineRow}
-          estimatedItemSize={64}
+          estimatedItemSize={48}
           recycleItems={false}
           initialScrollAtEnd
           maintainVisibleContentPosition={{ data: true, size: true }}

--- a/app/components/__tests__/AgentWorkHeader.test.tsx
+++ b/app/components/__tests__/AgentWorkHeader.test.tsx
@@ -1,0 +1,37 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { AgentWorkHeader } from "../AgentWorkHeader";
+
+describe("AgentWorkHeader", () => {
+  it("captures scroll before asking the timeline to expand", () => {
+    const onCaptureScroll = jest.fn();
+    const onToggle = jest.fn();
+
+    render(
+      <AgentWorkHeader
+        canToggle
+        durationMs={34_000}
+        expanded={false}
+        isTiming={false}
+        messageId="assistant-1"
+        onCaptureScroll={onCaptureScroll}
+        onToggle={onToggle}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /worked for 34s/i });
+
+    fireEvent.pointerDown(trigger);
+
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    expect(onCaptureScroll).toHaveBeenCalledTimes(2);
+    expect(onCaptureScroll).toHaveBeenNthCalledWith(1, trigger);
+    expect(onCaptureScroll).toHaveBeenNthCalledWith(2, trigger);
+    expect(onToggle).toHaveBeenCalledWith("assistant-1", true);
+    expect(onCaptureScroll.mock.invocationCallOrder[1]).toBeLessThan(
+      onToggle.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/app/components/__tests__/MessageItem.worked-for.test.tsx
+++ b/app/components/__tests__/MessageItem.worked-for.test.tsx
@@ -238,6 +238,72 @@ describe("MessageItem WorkedFor rendering", () => {
     expect(screen.getByText("regenerated final answer")).toBeInTheDocument();
   });
 
+  it("bounds live Agent activity and progressively reveals earlier tools", () => {
+    const toolParts = Array.from({ length: 100 }, (_, index) => ({
+      type: "tool-shell",
+      input: `command ${index + 1}`,
+      state: "output-available",
+    }));
+
+    renderMessageItem({
+      mode: "agent",
+      status: "streaming",
+      message: {
+        ...assistantMessage,
+        parts: [...toolParts, { type: "text", text: "final answer" }],
+        metadata: {
+          mode: "agent",
+          generationStartedAt: Date.now(),
+        },
+      } as unknown as ChatMessage,
+    });
+
+    expect(screen.getAllByTestId("part-tool-shell")).toHaveLength(80);
+    expect(screen.queryByText("command 20")).not.toBeInTheDocument();
+    expect(screen.getByText("command 21")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /show earlier activity \(20 hidden\)/i,
+      }),
+    );
+
+    expect(screen.getAllByTestId("part-tool-shell")).toHaveLength(100);
+    expect(screen.getByText("command 1")).toBeInTheDocument();
+  });
+
+  it("does not count terminal stream chunks as separate visible activity", () => {
+    const terminalChunks = Array.from({ length: 100 }, (_, index) => ({
+      type: "data-terminal",
+      data: { toolCallId: "tool-1", terminal: `chunk ${index}` },
+    }));
+
+    renderMessageItem({
+      mode: "agent",
+      status: "streaming",
+      message: {
+        ...assistantMessage,
+        parts: [
+          {
+            type: "tool-shell",
+            input: "ran command",
+            state: "input-available",
+          },
+          ...terminalChunks,
+        ],
+        metadata: {
+          mode: "agent",
+          generationStartedAt: Date.now(),
+        },
+      } as unknown as ChatMessage,
+    });
+
+    expect(screen.getAllByTestId("part-tool-shell")).toHaveLength(1);
+    expect(
+      screen.queryByRole("button", { name: /show earlier activity/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not show an expand icon when there are no expandable work parts", () => {
     renderMessageItem({
       mode: "agent",

--- a/app/components/__tests__/MessageItem.worked-for.test.tsx
+++ b/app/components/__tests__/MessageItem.worked-for.test.tsx
@@ -266,6 +266,35 @@ describe("MessageItem WorkedFor rendering", () => {
     expect(screen.getByText("final answer")).toBeInTheDocument();
   });
 
+  it("does not duplicate Agent work for a file-bearing answer shell without final text", () => {
+    renderMessageItem({
+      mode: "agent",
+      message: {
+        ...assistantMessage,
+        parts: [
+          {
+            type: "tool-shell",
+            input: "ran command",
+            state: "output-available",
+          },
+          {
+            type: "file",
+            mediaType: "text/plain",
+            name: "result.txt",
+            url: "https://example.com/result.txt",
+          },
+        ],
+        metadata: {
+          mode: "agent",
+          generationTimeMs: 1_500,
+        },
+      } as unknown as ChatMessage,
+      workPresentation: "timeline-shell",
+    });
+
+    expect(screen.queryByTestId("part-tool-shell")).not.toBeInTheDocument();
+  });
+
   it("does not count terminal stream chunks as separate visible activity", () => {
     const terminalChunks = Array.from({ length: 100 }, (_, index) => ({
       type: "data-terminal",

--- a/app/components/__tests__/MessageItem.worked-for.test.tsx
+++ b/app/components/__tests__/MessageItem.worked-for.test.tsx
@@ -86,10 +86,12 @@ const renderMessageItem = ({
   mode,
   message = assistantMessage,
   status = "ready",
+  workPresentation = "inline",
 }: {
   mode: ChatMode;
   message?: ChatMessage;
   status?: ChatStatus;
+  workPresentation?: "inline" | "timeline-shell";
 }) =>
   render(
     <MessageItem
@@ -102,6 +104,7 @@ const renderMessageItem = ({
       isEditing={false}
       feedbackInputMessageId={null}
       mode={mode}
+      workPresentation={workPresentation}
       branchBoundaryIndex={undefined}
       onMouseEnter={jest.fn()}
       onMouseLeave={jest.fn()}
@@ -238,7 +241,7 @@ describe("MessageItem WorkedFor rendering", () => {
     expect(screen.getByText("regenerated final answer")).toBeInTheDocument();
   });
 
-  it("bounds live Agent activity and progressively reveals earlier tools", () => {
+  it("leaves Agent work to the virtual timeline when rendering its answer shell", () => {
     const toolParts = Array.from({ length: 100 }, (_, index) => ({
       type: "tool-shell",
       input: `command ${index + 1}`,
@@ -256,20 +259,11 @@ describe("MessageItem WorkedFor rendering", () => {
           generationStartedAt: Date.now(),
         },
       } as unknown as ChatMessage,
+      workPresentation: "timeline-shell",
     });
 
-    expect(screen.getAllByTestId("part-tool-shell")).toHaveLength(80);
-    expect(screen.queryByText("command 20")).not.toBeInTheDocument();
-    expect(screen.getByText("command 21")).toBeInTheDocument();
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: /show earlier activity \(20 hidden\)/i,
-      }),
-    );
-
-    expect(screen.getAllByTestId("part-tool-shell")).toHaveLength(100);
-    expect(screen.getByText("command 1")).toBeInTheDocument();
+    expect(screen.queryByTestId("part-tool-shell")).not.toBeInTheDocument();
+    expect(screen.getByText("final answer")).toBeInTheDocument();
   });
 
   it("does not count terminal stream chunks as separate visible activity", () => {

--- a/app/components/__tests__/message-timeline-rows.test.ts
+++ b/app/components/__tests__/message-timeline-rows.test.ts
@@ -45,7 +45,6 @@ describe("deriveChatTimelineRows", () => {
     expect(rows).toHaveLength(102);
     expect(rows[0]).toMatchObject({
       kind: "agent-work-header",
-      activityCount: 100,
       expanded: true,
       isTiming: true,
     });

--- a/app/components/__tests__/message-timeline-rows.test.ts
+++ b/app/components/__tests__/message-timeline-rows.test.ts
@@ -1,0 +1,164 @@
+import {
+  deriveChatTimelineRows,
+  type AgentActivityTimelineRow,
+} from "../message-timeline-rows";
+import type { ChatMessage } from "@/types";
+
+const agentMessage = (
+  parts: ChatMessage["parts"],
+  metadata: Record<string, unknown> = {},
+) =>
+  ({
+    id: "assistant-1",
+    role: "assistant",
+    parts,
+    metadata: {
+      mode: "agent",
+      generationTimeMs: 10_000,
+      ...metadata,
+    },
+  }) as unknown as ChatMessage;
+
+describe("deriveChatTimelineRows", () => {
+  it("creates independently virtualizable rows for every live activity", () => {
+    const tools = Array.from({ length: 100 }, (_, index) => ({
+      type: "tool-shell",
+      toolCallId: `tool-${index}`,
+      input: { command: `command ${index}` },
+      state: "output-available",
+    }));
+    const message = agentMessage(
+      [
+        ...tools,
+        { type: "text", text: "final answer" },
+      ] as ChatMessage["parts"],
+      { generationStartedAt: Date.now() },
+    );
+
+    const rows = deriveChatTimelineRows({
+      messages: [message],
+      status: "streaming",
+      lastAssistantMessageIndex: 0,
+      expandedAgentMessageIds: new Set(),
+    });
+
+    expect(rows).toHaveLength(102);
+    expect(rows[0]).toMatchObject({
+      kind: "agent-work-header",
+      activityCount: 100,
+      expanded: true,
+      isTiming: true,
+    });
+    expect(rows.filter((row) => row.kind === "agent-activity")).toHaveLength(
+      100,
+    );
+    expect(rows.at(-1)).toMatchObject({
+      kind: "message",
+      workPresentation: "timeline-shell",
+    });
+  });
+
+  it("keeps settled activity collapsed until the user expands it", () => {
+    const message = agentMessage([
+      {
+        type: "tool-shell",
+        toolCallId: "tool-1",
+        input: { command: "pwd" },
+        state: "output-available",
+      },
+      { type: "text", text: "final answer" },
+    ] as ChatMessage["parts"]);
+
+    const collapsedRows = deriveChatTimelineRows({
+      messages: [message],
+      status: "ready",
+      lastAssistantMessageIndex: 0,
+      expandedAgentMessageIds: new Set(),
+    });
+    const expandedRows = deriveChatTimelineRows({
+      messages: [message],
+      status: "ready",
+      lastAssistantMessageIndex: 0,
+      expandedAgentMessageIds: new Set([message.id]),
+    });
+
+    expect(collapsedRows.map((row) => row.kind)).toEqual([
+      "agent-work-header",
+      "message",
+    ]);
+    expect(expandedRows.map((row) => row.kind)).toEqual([
+      "agent-work-header",
+      "agent-activity",
+      "message",
+    ]);
+  });
+
+  it("merges tool lifecycle snapshots and terminal chunks into their logical row", () => {
+    const message = agentMessage([
+      {
+        type: "tool-shell",
+        toolCallId: "tool-1",
+        input: { command: "long command" },
+        state: "input-available",
+      },
+      {
+        type: "data-terminal",
+        data: { toolCallId: "tool-1", terminal: "first " },
+      },
+      {
+        type: "data-terminal",
+        data: { toolCallId: "tool-1", terminal: "second" },
+      },
+      {
+        type: "tool-shell",
+        toolCallId: "tool-1",
+        input: { command: "long command" },
+        output: "done",
+        state: "output-available",
+      },
+    ] as ChatMessage["parts"]);
+
+    const rows = deriveChatTimelineRows({
+      messages: [message],
+      status: "ready",
+      lastAssistantMessageIndex: 0,
+      expandedAgentMessageIds: new Set(),
+    });
+    const activityRows = rows.filter(
+      (row): row is AgentActivityTimelineRow => row.kind === "agent-activity",
+    );
+
+    expect(activityRows).toHaveLength(1);
+    expect(activityRows[0].part).toMatchObject({
+      toolCallId: "tool-1",
+      output: "done",
+      state: "output-available",
+    });
+    expect(activityRows[0].terminalChunksByToolCallId.get("tool-1")).toEqual([
+      "first ",
+      "second",
+    ]);
+  });
+
+  it("projects a contiguous reasoning stream as one logical activity", () => {
+    const message = agentMessage([
+      { type: "reasoning", text: "first" },
+      { type: "reasoning", text: "second" },
+      {
+        type: "tool-shell",
+        toolCallId: "tool-1",
+        input: { command: "pwd" },
+        state: "output-available",
+      },
+    ] as ChatMessage["parts"]);
+
+    const rows = deriveChatTimelineRows({
+      messages: [message],
+      status: "ready",
+      lastAssistantMessageIndex: 0,
+      expandedAgentMessageIds: new Set(),
+    });
+
+    expect(rows.filter((row) => row.kind === "agent-activity")).toHaveLength(2);
+  });
+});

--- a/app/components/__tests__/message-timeline-rows.test.ts
+++ b/app/components/__tests__/message-timeline-rows.test.ts
@@ -93,6 +93,37 @@ describe("deriveChatTimelineRows", () => {
     ]);
   });
 
+  it("keeps reasoning-only activity reachable from the settled header", () => {
+    const message = agentMessage([
+      { type: "reasoning", text: "analysis" },
+      { type: "text", text: "final answer" },
+    ] as ChatMessage["parts"]);
+
+    const collapsedRows = deriveChatTimelineRows({
+      messages: [message],
+      status: "ready",
+      lastAssistantMessageIndex: 0,
+      expandedAgentMessageIds: new Set(),
+    });
+    const expandedRows = deriveChatTimelineRows({
+      messages: [message],
+      status: "ready",
+      lastAssistantMessageIndex: 0,
+      expandedAgentMessageIds: new Set([message.id]),
+    });
+
+    expect(collapsedRows[0]).toMatchObject({
+      kind: "agent-work-header",
+      canToggle: true,
+      expanded: false,
+    });
+    expect(expandedRows.map((row) => row.kind)).toEqual([
+      "agent-work-header",
+      "agent-activity",
+      "message",
+    ]);
+  });
+
   it("merges tool lifecycle snapshots and terminal chunks into their logical row", () => {
     const message = agentMessage([
       {

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -66,6 +66,7 @@ import {
   stripAgentLongHeartbeatParts,
   stripAgentLongHeartbeatPartsFromMessages,
 } from "@/lib/chat/agent-long-heartbeat";
+import { getAgentLongMessageProgressFingerprint } from "@/lib/chat/agent-long-message-progress";
 import { hasVisibleAssistantContent } from "@/lib/chat/abort-persistence";
 import { toast } from "sonner";
 import {
@@ -263,40 +264,6 @@ const getLatestAgentLongAssistantMessageForPartialSave = (
         : undefined,
   };
 };
-
-const getAgentLongPartFingerprint = (part: unknown): string => {
-  if (typeof part !== "object" || part === null) return String(part);
-  const typedPart = part as {
-    type?: unknown;
-    text?: unknown;
-    delta?: unknown;
-    state?: unknown;
-  };
-  const type = typeof typedPart.type === "string" ? typedPart.type : "unknown";
-  const textLength =
-    typeof typedPart.text === "string" ? typedPart.text.length : undefined;
-  const deltaLength =
-    typeof typedPart.delta === "string" ? typedPart.delta.length : undefined;
-  if (textLength !== undefined || deltaLength !== undefined) {
-    return `${type}:${textLength ?? 0}:${deltaLength ?? 0}:${typedPart.state ?? ""}`;
-  }
-
-  try {
-    return `${type}:${JSON.stringify(part).length}`;
-  } catch {
-    return type;
-  }
-};
-
-const getAgentLongMessageFingerprint = (messages: ChatMessage[]): string =>
-  messages
-    .map(
-      (message) =>
-        `${message.id}:${message.role}:${(message.parts ?? [])
-          .map(getAgentLongPartFingerprint)
-          .join(",")}`,
-    )
-    .join("|");
 
 const ComputerSidebar = dynamic(
   () => import("./ComputerSidebar").then((m) => m.ComputerSidebar),
@@ -1207,7 +1174,8 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
     };
   }, [stopActiveBrowserStream]);
 
-  const agentLongMessageFingerprint = getAgentLongMessageFingerprint(messages);
+  const agentLongMessageFingerprint =
+    getAgentLongMessageProgressFingerprint(messages);
   const agentLongMessageFingerprintRef = useRef(agentLongMessageFingerprint);
   const agentLongLastMessageChangeAtRef = useRef(Date.now());
 

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1891,8 +1891,8 @@ export const Chat = ({ autoResume }: { autoResume: boolean }) => {
                 </div>
               ) : showChatLayout ? (
                 <Messages
-                  scrollRef={scrollRef as RefObject<HTMLDivElement | null>}
-                  contentRef={contentRef as RefObject<HTMLDivElement | null>}
+                  scrollRef={scrollRef}
+                  contentRef={contentRef}
                   messages={messages}
                   setMessages={setMessages}
                   onRegenerate={handleRegenerate}

--- a/app/components/message-timeline-rows.ts
+++ b/app/components/message-timeline-rows.ts
@@ -90,8 +90,7 @@ export function deriveChatTimelineRows({
       messageIndex === lastAssistantMessageIndex;
     const isTiming = status === "streaming" && isLastAssistantMessage;
     const hasFinalAnswer = trailingTextParts.length > 0;
-    const canToggle =
-      !isTiming && hasFinalAnswer && projection.hasExpandableWork;
+    const canToggle = !isTiming && hasFinalAnswer;
     const expanded =
       isTiming || !hasFinalAnswer || expandedAgentMessageIds.has(message.id);
 

--- a/app/components/message-timeline-rows.ts
+++ b/app/components/message-timeline-rows.ts
@@ -1,0 +1,150 @@
+import type { ChatMessage, ChatStatus } from "@/types";
+import {
+  projectAgentWorkParts,
+  splitWorkedForParts,
+  type AgentWorkActivity,
+} from "./worked-for-parts";
+
+type BaseTimelineRow = {
+  id: string;
+  message: ChatMessage;
+  messageIndex: number;
+};
+
+export type MessageTimelineRow = BaseTimelineRow & {
+  kind: "message";
+  workPresentation: "inline" | "timeline-shell";
+};
+
+export type AgentWorkHeaderTimelineRow = BaseTimelineRow & {
+  kind: "agent-work-header";
+  activityCount: number;
+  canToggle: boolean;
+  durationMs?: number;
+  expanded: boolean;
+  isTiming: boolean;
+  startedAt?: number;
+};
+
+export type AgentActivityTimelineRow = BaseTimelineRow &
+  AgentWorkActivity & {
+    kind: "agent-activity";
+    isLastMessage: boolean;
+    keepLatestReasoningOpenDuringStreaming: boolean;
+    deferReasoningCollapseUntilParent: boolean;
+    terminalChunksByToolCallId: Map<string, readonly string[]>;
+  };
+
+export type ChatTimelineRow =
+  MessageTimelineRow | AgentWorkHeaderTimelineRow | AgentActivityTimelineRow;
+
+export type DeriveChatTimelineRowsOptions = {
+  messages: readonly ChatMessage[];
+  status: ChatStatus;
+  lastAssistantMessageIndex: number | undefined;
+  expandedAgentMessageIds: ReadonlySet<string>;
+};
+
+export function deriveChatTimelineRows({
+  messages,
+  status,
+  lastAssistantMessageIndex,
+  expandedAgentMessageIds,
+}: DeriveChatTimelineRowsOptions): ChatTimelineRow[] {
+  const rows: ChatTimelineRow[] = [];
+
+  for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
+    const message = messages[messageIndex];
+    const isAgentAssistant =
+      message.role === "assistant" && message.metadata?.mode === "agent";
+
+    if (!isAgentAssistant) {
+      rows.push({
+        kind: "message",
+        id: `message:${message.id}`,
+        message,
+        messageIndex,
+        workPresentation: "inline",
+      });
+      continue;
+    }
+
+    const { trailingTextParts, workPartIndexes } = splitWorkedForParts(
+      message.parts,
+    );
+    const projection = projectAgentWorkParts(message.parts, workPartIndexes);
+
+    if (projection.activities.length === 0) {
+      rows.push({
+        kind: "message",
+        id: `message:${message.id}`,
+        message,
+        messageIndex,
+        workPresentation: "inline",
+      });
+      continue;
+    }
+
+    const isLastAssistantMessage =
+      lastAssistantMessageIndex !== undefined &&
+      messageIndex === lastAssistantMessageIndex;
+    const isTiming = status === "streaming" && isLastAssistantMessage;
+    const hasFinalAnswer = trailingTextParts.length > 0;
+    const canToggle =
+      !isTiming && hasFinalAnswer && projection.hasExpandableWork;
+    const expanded =
+      isTiming || !hasFinalAnswer || expandedAgentMessageIds.has(message.id);
+
+    rows.push({
+      kind: "agent-work-header",
+      id: `work-header:${message.id}`,
+      message,
+      messageIndex,
+      activityCount: projection.activities.length,
+      canToggle,
+      durationMs:
+        typeof message.metadata?.generationTimeMs === "number"
+          ? message.metadata.generationTimeMs
+          : undefined,
+      expanded,
+      isTiming,
+      startedAt:
+        typeof message.metadata?.generationStartedAt === "number"
+          ? message.metadata.generationStartedAt
+          : undefined,
+    });
+
+    if (expanded) {
+      for (const activity of projection.activities) {
+        rows.push({
+          kind: "agent-activity",
+          message,
+          messageIndex,
+          ...activity,
+          id: `work:${message.id}:${activity.id}`,
+          isLastMessage: messageIndex === messages.length - 1,
+          keepLatestReasoningOpenDuringStreaming: true,
+          deferReasoningCollapseUntilParent: hasFinalAnswer,
+          terminalChunksByToolCallId: projection.terminalChunksByToolCallId,
+        });
+      }
+    }
+
+    rows.push({
+      kind: "message",
+      id: `message:${message.id}`,
+      message,
+      messageIndex,
+      workPresentation: "timeline-shell",
+    });
+  }
+
+  return rows;
+}
+
+export function getChatTimelineRowType(row: ChatTimelineRow) {
+  if (row.kind === "message") {
+    return `message:${row.message.role}`;
+  }
+  return row.kind;
+}

--- a/app/components/message-timeline-rows.ts
+++ b/app/components/message-timeline-rows.ts
@@ -18,7 +18,6 @@ export type MessageTimelineRow = BaseTimelineRow & {
 
 export type AgentWorkHeaderTimelineRow = BaseTimelineRow & {
   kind: "agent-work-header";
-  activityCount: number;
   canToggle: boolean;
   durationMs?: number;
   expanded: boolean;
@@ -99,7 +98,6 @@ export function deriveChatTimelineRows({
       id: `work-header:${message.id}`,
       message,
       messageIndex,
-      activityCount: projection.activities.length,
       canToggle,
       durationMs:
         typeof message.metadata?.generationTimeMs === "number"

--- a/app/components/worked-for-parts.ts
+++ b/app/components/worked-for-parts.ts
@@ -24,7 +24,20 @@ export type WorkedForParts = {
   fileParts: FilePart[];
   nonFileParts: MessagePart[];
   workParts: MessagePart[];
+  workPartIndexes: number[];
   trailingTextParts: MessagePart[];
+};
+
+export type AgentWorkActivity = {
+  id: string;
+  part: MessagePart;
+  partIndex: number;
+};
+
+export type AgentWorkProjection = {
+  activities: AgentWorkActivity[];
+  hasExpandableWork: boolean;
+  terminalChunksByToolCallId: Map<string, readonly string[]>;
 };
 
 const isTrailingMetadataPart = (part: MessagePart) => {
@@ -39,11 +52,121 @@ export const isExpandableWorkedForPart = (part: MessagePart) => {
   );
 };
 
+const shouldProjectWorkPart = (part: MessagePart) => {
+  const type = (part as { type?: string }).type;
+  return (
+    type === "text" ||
+    type === "reasoning" ||
+    type === "data-summarization" ||
+    Boolean(type?.startsWith("tool-"))
+  );
+};
+
+const getToolCallId = (part: MessagePart) => {
+  const toolCallId = (part as { toolCallId?: unknown }).toolCallId;
+  return typeof toolCallId === "string" && toolCallId.length > 0
+    ? toolCallId
+    : null;
+};
+
+/**
+ * Builds the lightweight rows used by the Agent activity timeline.
+ *
+ * Terminal stream chunks remain available to their owning tool row without
+ * becoming hundreds of independent UI rows. Repeated lifecycle snapshots for
+ * the same tool call also keep one stable row and use the newest snapshot.
+ */
+export function projectAgentWorkParts(
+  parts: ChatMessage["parts"],
+  workPartIndexes: readonly number[],
+): AgentWorkProjection {
+  const activities: AgentWorkActivity[] = [];
+  const activityIndexByToolCallId = new Map<string, number>();
+  const terminalChunksByToolCallId = new Map<string, string[]>();
+  let previousProjectedType: string | undefined;
+
+  for (const partIndex of workPartIndexes) {
+    const part = parts[partIndex];
+    if (!part) continue;
+
+    const type = (part as { type?: string }).type;
+    if (type === "data-terminal") {
+      const data = (
+        part as {
+          data?: { terminal?: unknown; toolCallId?: unknown };
+        }
+      ).data;
+      if (
+        typeof data?.toolCallId === "string" &&
+        typeof data.terminal === "string"
+      ) {
+        const existing = terminalChunksByToolCallId.get(data.toolCallId);
+        if (existing) {
+          existing.push(data.terminal);
+        } else {
+          terminalChunksByToolCallId.set(data.toolCallId, [data.terminal]);
+        }
+      }
+      continue;
+    }
+
+    if (!shouldProjectWorkPart(part)) continue;
+
+    // A contiguous reasoning block is rendered as one logical activity. The
+    // ReasoningHandler reads the remaining fragments from the source message.
+    if (type === "reasoning" && previousProjectedType === "reasoning") {
+      continue;
+    }
+
+    const toolCallId = getToolCallId(part);
+    if (toolCallId) {
+      const existingIndex = activityIndexByToolCallId.get(toolCallId);
+      if (existingIndex !== undefined) {
+        activities[existingIndex] = {
+          id: `tool:${toolCallId}`,
+          part,
+          partIndex,
+        };
+        previousProjectedType = type;
+        continue;
+      }
+      activityIndexByToolCallId.set(toolCallId, activities.length);
+    }
+
+    activities.push({
+      id: toolCallId ? `tool:${toolCallId}` : `part:${partIndex}`,
+      part,
+      partIndex,
+    });
+    previousProjectedType = type;
+  }
+
+  return {
+    activities,
+    hasExpandableWork: activities.some(({ part }) =>
+      isExpandableWorkedForPart(part),
+    ),
+    terminalChunksByToolCallId,
+  };
+}
+
 export function splitWorkedForParts(
   parts: ChatMessage["parts"],
 ): WorkedForParts {
-  const fileParts = parts.filter((part) => part.type === "file") as FilePart[];
-  const nonFileParts = parts.filter((part) => part.type !== "file");
+  const fileParts: FilePart[] = [];
+  const indexedNonFileParts: Array<{ part: MessagePart; partIndex: number }> =
+    [];
+
+  for (let partIndex = 0; partIndex < parts.length; partIndex++) {
+    const part = parts[partIndex];
+    if (part.type === "file") {
+      fileParts.push(part as FilePart);
+    } else {
+      indexedNonFileParts.push({ part, partIndex });
+    }
+  }
+
+  const nonFileParts = indexedNonFileParts.map(({ part }) => part);
 
   let trailingEnd = nonFileParts.length;
   while (
@@ -66,6 +189,9 @@ export function splitWorkedForParts(
     fileParts,
     nonFileParts,
     workParts: nonFileParts.slice(0, trailingStart),
+    workPartIndexes: indexedNonFileParts
+      .slice(0, trailingStart)
+      .map(({ partIndex }) => partIndex),
     trailingTextParts: nonFileParts.slice(trailingStart, trailingEnd),
   };
 }

--- a/components/ai-elements/worked-for.tsx
+++ b/components/ai-elements/worked-for.tsx
@@ -98,32 +98,9 @@ const escapeStickyBottom = (snapshot: ScrollSnapshot) => {
   );
 };
 
-export function WorkedFor({
-  className,
-  hasWork,
-  isTiming = false,
-  open,
-  defaultOpen = false,
-  onOpenChange,
-  children,
-  ...props
-}: WorkedForProps) {
-  const [isOpen, setIsOpen] = useControllableState({
-    prop: open,
-    defaultProp: defaultOpen,
-    onChange: onOpenChange,
-  });
+export const useScrollPreservation = () => {
   const scrollSnapshotRef = useRef<ScrollSnapshot | null>(null);
   const restoreTokenRef = useRef(0);
-  const wasTimingRef = useRef(isTiming);
-  const autoCollapseTimeoutRef = useRef<number | null>(null);
-
-  const clearAutoCollapseTimeout = useCallback(() => {
-    if (autoCollapseTimeoutRef.current === null) return;
-
-    window.clearTimeout(autoCollapseTimeoutRef.current);
-    autoCollapseTimeoutRef.current = null;
-  }, []);
 
   const captureScrollPosition = useCallback((target: EventTarget | null) => {
     if (!(target instanceof HTMLElement)) return;
@@ -188,17 +165,57 @@ export function WorkedFor({
     requestAnimationFrame(restore);
   }, []);
 
-  const handleOpenChange = useCallback(
-    (nextOpen: boolean) => {
+  const preserveScrollPosition = useCallback(
+    (change: () => void, isOpening: boolean) => {
       const snapshot = scrollSnapshotRef.current;
-      clearAutoCollapseTimeout();
-      if (nextOpen && snapshot) {
+      if (isOpening && snapshot) {
         escapeStickyBottom(snapshot);
       }
-      setIsOpen(nextOpen);
+      change();
       restoreCapturedScrollPosition();
     },
-    [clearAutoCollapseTimeout, restoreCapturedScrollPosition, setIsOpen],
+    [restoreCapturedScrollPosition],
+  );
+
+  return {
+    captureScrollPosition,
+    preserveScrollPosition,
+  };
+};
+
+export function WorkedFor({
+  className,
+  hasWork,
+  isTiming = false,
+  open,
+  defaultOpen = false,
+  onOpenChange,
+  children,
+  ...props
+}: WorkedForProps) {
+  const [isOpen, setIsOpen] = useControllableState({
+    prop: open,
+    defaultProp: defaultOpen,
+    onChange: onOpenChange,
+  });
+  const { captureScrollPosition, preserveScrollPosition } =
+    useScrollPreservation();
+  const wasTimingRef = useRef(isTiming);
+  const autoCollapseTimeoutRef = useRef<number | null>(null);
+
+  const clearAutoCollapseTimeout = useCallback(() => {
+    if (autoCollapseTimeoutRef.current === null) return;
+
+    window.clearTimeout(autoCollapseTimeoutRef.current);
+    autoCollapseTimeoutRef.current = null;
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      clearAutoCollapseTimeout();
+      preserveScrollPosition(() => setIsOpen(nextOpen), nextOpen);
+    },
+    [clearAutoCollapseTimeout, preserveScrollPosition, setIsOpen],
   );
 
   useEffect(() => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,6 +25,7 @@ const customJestConfig = {
     "^shiki/langs$": "<rootDir>/__mocks__/shiki.ts",
     "^shiki$": "<rootDir>/__mocks__/shiki.ts",
     "^use-stick-to-bottom$": "<rootDir>/__mocks__/use-stick-to-bottom.ts",
+    "^@legendapp/list/react$": "<rootDir>/__mocks__/@legendapp/list-react.tsx",
     "^@aws-sdk/client-s3$": "<rootDir>/__mocks__/@aws-sdk/client-s3.ts",
     "^@aws-sdk/s3-request-presigner$":
       "<rootDir>/__mocks__/@aws-sdk/s3-request-presigner.ts",

--- a/lib/chat/__tests__/agent-long-message-progress.test.ts
+++ b/lib/chat/__tests__/agent-long-message-progress.test.ts
@@ -1,0 +1,91 @@
+import { getAgentLongMessageProgressFingerprint } from "../agent-long-message-progress";
+import type { ChatMessage } from "@/types";
+
+const message = (id: string, parts: ChatMessage["parts"]): ChatMessage =>
+  ({
+    id,
+    role: "assistant",
+    parts,
+  }) as ChatMessage;
+
+describe("getAgentLongMessageProgressFingerprint", () => {
+  it("changes when the latest streamed text grows", () => {
+    const before = getAgentLongMessageProgressFingerprint([
+      message("assistant-1", [{ type: "text", text: "working" }]),
+    ]);
+    const after = getAgentLongMessageProgressFingerprint([
+      message("assistant-1", [{ type: "text", text: "working longer" }]),
+    ]);
+
+    expect(after).not.toBe(before);
+  });
+
+  it("changes when a new streamed part is appended", () => {
+    const toolPart = {
+      type: "tool-shell",
+      state: "input-available",
+      input: { command: "pwd" },
+    } as ChatMessage["parts"][number];
+    const before = getAgentLongMessageProgressFingerprint([
+      message("assistant-1", [toolPart]),
+    ]);
+    const after = getAgentLongMessageProgressFingerprint([
+      message("assistant-1", [
+        toolPart,
+        {
+          type: "data-terminal",
+          data: { toolCallId: "tool-1", terminal: "output" },
+        } as ChatMessage["parts"][number],
+      ]),
+    ]);
+
+    expect(after).not.toBe(before);
+  });
+
+  it("does not serialize transcript parts", () => {
+    const earlierPart = {
+      type: "tool-shell",
+      toJSON: () => {
+        throw new Error("earlier part should not be serialized");
+      },
+    } as unknown as ChatMessage["parts"][number];
+    const latestPart = {
+      type: "tool-shell",
+      state: "output-available",
+      toolCallId: "tool-1",
+      toJSON: () => {
+        throw new Error("latest part should not be serialized");
+      },
+    } as unknown as ChatMessage["parts"][number];
+
+    expect(() =>
+      getAgentLongMessageProgressFingerprint([
+        message("assistant-1", [earlierPart]),
+        message("assistant-2", [latestPart]),
+      ]),
+    ).not.toThrow();
+  });
+
+  it("changes when the latest tool state changes", () => {
+    const before = getAgentLongMessageProgressFingerprint([
+      message("assistant-1", [
+        {
+          type: "tool-shell",
+          state: "input-available",
+          toolCallId: "tool-1",
+        } as ChatMessage["parts"][number],
+      ]),
+    ]);
+    const after = getAgentLongMessageProgressFingerprint([
+      message("assistant-1", [
+        {
+          type: "tool-shell",
+          state: "output-available",
+          toolCallId: "tool-1",
+        } as ChatMessage["parts"][number],
+      ]),
+    ]);
+
+    expect(after).not.toBe(before);
+  });
+});

--- a/lib/chat/agent-long-message-progress.ts
+++ b/lib/chat/agent-long-message-progress.ts
@@ -1,0 +1,59 @@
+import type { ChatMessage } from "@/types";
+
+const getAgentLongPartProgressFingerprint = (part: unknown): string => {
+  if (typeof part !== "object" || part === null) return String(part);
+
+  const typedPart = part as {
+    type?: unknown;
+    text?: unknown;
+    delta?: unknown;
+    state?: unknown;
+    toolCallId?: unknown;
+    data?: {
+      terminal?: unknown;
+      toolCallId?: unknown;
+    };
+  };
+  const type = typeof typedPart.type === "string" ? typedPart.type : "unknown";
+  const textLength =
+    typeof typedPart.text === "string" ? typedPart.text.length : undefined;
+  const deltaLength =
+    typeof typedPart.delta === "string" ? typedPart.delta.length : undefined;
+  const terminalLength =
+    typeof typedPart.data?.terminal === "string"
+      ? typedPart.data.terminal.length
+      : undefined;
+  const toolCallId =
+    typeof typedPart.toolCallId === "string"
+      ? typedPart.toolCallId
+      : typeof typedPart.data?.toolCallId === "string"
+        ? typedPart.data.toolCallId
+        : "";
+
+  return `${type}:${typedPart.state ?? ""}:${toolCallId}:${textLength ?? 0}:${
+    deltaLength ?? 0
+  }:${terminalLength ?? 0}`;
+};
+
+/**
+ * Tracks progress for the active Agent response without serializing the full
+ * transcript or a potentially large tool result on every streamed part. Agent
+ * progress is append-oriented, so the latest message id, part count, and a
+ * shallow latest-part signature are sufficient to reset the completion
+ * poller's quiet timer.
+ */
+export const getAgentLongMessageProgressFingerprint = (
+  messages: ChatMessage[],
+): string => {
+  const latestMessage = messages.at(-1);
+  if (!latestMessage) return "";
+
+  const parts = latestMessage.parts ?? [];
+  const latestPart = parts.at(-1);
+
+  return `${latestMessage.id}:${latestMessage.role}:${parts.length}:${
+    latestPart === undefined
+      ? "empty"
+      : getAgentLongPartProgressFingerprint(latestPart)
+  }`;
+};

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@convex-dev/workos": "^0.0.3",
     "@e2b/code-interpreter": "2.7.0",
     "@langchain/community": "^1.1.29",
+    "@legendapp/list": "3.2.0",
     "@monaco-editor/react": "^4.7.0",
     "@openrouter/ai-sdk-provider": "^2.10.0",
     "@posthog/ai": "8.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@langchain/community':
         specifier: ^1.1.29
         version: 1.1.29(ec0fa2fbdcf06ea0405634861d9596f2)
+      '@legendapp/list':
+        specifier: 3.2.0
+        version: 3.2.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2152,6 +2155,18 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       '@langchain/core': ^1.0.0
+
+  '@legendapp/list@3.2.0':
+    resolution: {integrity: sha512-bN+g/oQYjFz+UAyuBN4cmYJAwdJS1TdNcZZOVlh3+VwCQUWrsg0PH46Mvm76gdZSCYMfoFanPY4dKnILcYEzeg==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
 
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
@@ -9974,6 +9989,13 @@ snapshots:
     dependencies:
       '@langchain/core': 1.1.46(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.73)(@smithy/signature-v4@5.6.11)(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       js-tiktoken: 1.0.21
+
+  '@legendapp/list@3.2.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+      use-sync-external-store: 1.5.0(react@19.2.8)
+    optionalDependencies:
+      react-dom: 19.2.8(react@19.2.8)
 
   '@mermaid-js/parser@1.1.1':
     dependencies:


### PR DESCRIPTION
## Summary
- render Agent work as independently virtualized timeline rows instead of mounting an entire run inside one message
- consolidate repeated tool lifecycle updates and attach terminal stream chunks to their owning tool row
- keep settled activity lazy while preserving full expand-and-scroll access, and avoid rebuilding raw output for collapsed history
- preserve the reader's exact viewport position when Agent work is expanded or collapsed
- replace full-transcript progress serialization with a shallow latest-message fingerprint

## Root cause
Long Agent runs can accumulate hundreds of tool and terminal-output parts inside one assistant message. The browser mounted and repeatedly fingerprinted the whole live payload on every stream update, so sufficiently large runs could stall or blank the chat surface.

## Validation
- corepack pnpm test (310 suites, 3,047 tests)
- corepack pnpm typecheck
- corepack pnpm lint (passes with five existing warnings)
- corepack pnpm exec next build
- Chrome: opened a real 31-minute Agent task with 153 activities; expansion mounted 15 rows at once, scrolling kept the final answer reachable, and the composer stayed responsive
- Chrome: expanding and collapsing from the bottom preserved both scrollTop (246 px) and the Worked for header position (74 px)
- Chrome responsive check at 390 x 844

## Manual verification
1. Open a completed Agent task with a large activity history.
2. Scroll until its Worked for header is visible, note its position, and expand the section.
3. Confirm the header stays in the same viewport position while activity rows load as you scroll.
4. Collapse the section and confirm the same viewport position is preserved and the compact view returns.
5. Confirm the final answer, composer, and scroll-to-bottom control remain responsive.
6. Repeat during an active long Agent run and confirm new tool activity follows at the bottom without blanking the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a virtualized, sticky timeline-based chat feed with scroll-to-load-more.
  * Introduced agent work headers and agent activity rows for expandable/collapsible work tracking.
  * Added “worked for” rendering modes (inline and timeline-shell), including duration-based “Working for/Worked for”.
* **Bug Fixes**
  * Prevented duplicate terminal/tool activity and improved grouping/deduping across snapshots and reasoning streams.
  * Corrected toggleability and expansion behavior for streaming vs settled timelines.
* **Tests**
  * Expanded unit test coverage for timeline row projection, timeline-shell rendering, agent header interactions, and streaming progress fingerprinting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->