### PR TITLE
Let sidebar task rows open and drag

### DIFF
--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -57,9 +57,9 @@ import {
   FolderInput,
   FolderMinus,
   FolderPlus,
-  GripVertical,
   ListPlus,
 } from "lucide-react";
+import { useDraggable } from "@dnd-kit/core";
 import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { removeDraft } from "@/lib/utils/client-storage";
@@ -70,7 +70,7 @@ import { MoveChatToProjectDialog } from "./MoveChatToProjectDialog";
 import { ProjectCreateDialog } from "./ProjectCreateDialog";
 import { usePinChat, useUnpinChat } from "../hooks/useChats";
 import { useMoveChatToProjectAction } from "../hooks/useMoveChatToProjectAction";
-import { setSidebarChatDragData } from "./sidebar-chat-drag";
+import type { SidebarChatDragData } from "./sidebar-chat-drag";
 import { formatTaskTitle, formatTaskUiCopy } from "@/app/utils/task-ui-copy";
 import { useSidebarProjectList } from "@/app/contexts/SidebarProjectList";
 
@@ -132,7 +132,6 @@ const ChatItem: React.FC<ChatItemProps> = ({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [editTitle, setEditTitle] = useState(taskTitle);
   const [isRenaming, setIsRenaming] = useState(false);
-  const [isDragging, setIsDragging] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const renameInputId = useId();
 
@@ -170,37 +169,45 @@ const ChatItem: React.FC<ChatItemProps> = ({
   const showActions = Boolean(
     isHovered || isFocusedWithin || isDropdownOpen || isMobile,
   );
-  const showDragHandle = (isHovered || isDragging) && !isMobile;
   const showStreamingIndicator =
     isStreaming && (!isHovered || isMobile) && (!isDropdownOpen || isMobile);
   const visibleActionSlotCount =
-    Number(showStreamingIndicator) +
-    Number(showDragHandle) +
-    Number(showActions);
+    Number(showStreamingIndicator) + Number(showActions);
   const rightPaddingClass =
-    visibleActionSlotCount >= 3
-      ? "pr-[6.5rem]"
-      : visibleActionSlotCount === 2
-        ? "pr-[4.5rem]"
-        : visibleActionSlotCount === 1
-          ? "pr-9"
-          : "";
+    visibleActionSlotCount === 2
+      ? "pr-[4.5rem]"
+      : visibleActionSlotCount === 1
+        ? "pr-9"
+        : "";
   const rowStartPaddingClass = indentContent ? "ps-6" : "ps-2";
+  const dragData: SidebarChatDragData = {
+    type: "sidebar-chat",
+    chatId: id,
+    isPinned,
+    projectId,
+    title: taskTitle,
+  };
+  const {
+    attributes: dragAttributes,
+    isDragging,
+    listeners: dragListeners,
+    setNodeRef: setDraggableNodeRef,
+  } = useDraggable({
+    id: `sidebar-chat:${id}`,
+    data: dragData,
+    disabled: isMobile,
+    attributes: {
+      role: "button",
+      roleDescription: "draggable task",
+      tabIndex: 0,
+    },
+  });
 
   useEffect(() => {
     if (optimisticChatId && optimisticChatId === routeChatId) {
       setOptimisticChatId(null);
     }
   }, [optimisticChatId, routeChatId, setOptimisticChatId]);
-
-  const handleDragStart = (event: React.DragEvent<HTMLSpanElement>) => {
-    setIsDragging(true);
-    setSidebarChatDragData(event.dataTransfer, id, projectId);
-  };
-
-  const handleDragEnd = () => {
-    setIsDragging(false);
-  };
 
   const handleClick = () => {
     // Don't navigate if dialog is open or dropdown is open
@@ -411,6 +418,8 @@ const ChatItem: React.FC<ChatItemProps> = ({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.target !== e.currentTarget) return;
+
     // Don't handle keyboard events if dialog or dropdown is open
     if (
       showRenameDialog ||
@@ -422,19 +431,24 @@ const ChatItem: React.FC<ChatItemProps> = ({
       return;
     }
 
-    if (e.key === "Enter" || e.key === " ") {
+    if (e.key === "Enter") {
       e.preventDefault();
       handleClick();
+    } else if (e.key === " ") {
+      dragListeners?.onKeyDown?.(e);
     }
   };
 
   return (
     <div
+      ref={setDraggableNodeRef}
       className={`group relative flex w-full cursor-pointer select-none items-center rounded-lg py-2 pe-0.5 ${rowStartPaddingClass} hover:bg-sidebar-accent/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
         isCurrentlyActive
           ? "bg-sidebar-accent text-sidebar-accent-foreground"
           : ""
       } ${isDragging ? "opacity-50" : ""}`}
+      {...(!isMobile ? dragAttributes : {})}
+      {...(!isMobile ? dragListeners : {})}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onFocus={() => setIsFocusedWithin(true)}
@@ -491,6 +505,8 @@ const ChatItem: React.FC<ChatItemProps> = ({
             : "pointer-events-none opacity-0"
         }`}
         aria-hidden={!showActions && !showStreamingIndicator}
+        onMouseDown={(event) => event.stopPropagation()}
+        onTouchStart={(event) => event.stopPropagation()}
       >
         {showStreamingIndicator ? (
           <div className="flex size-8 flex-shrink-0 items-center justify-center">
@@ -500,23 +516,6 @@ const ChatItem: React.FC<ChatItemProps> = ({
               aria-hidden="true"
             />
           </div>
-        ) : null}
-        {showDragHandle ? (
-          <span
-            className="flex size-8 flex-shrink-0 cursor-grab items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent active:cursor-grabbing"
-            draggable
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-            }}
-            onDragStart={handleDragStart}
-            onDragEnd={handleDragEnd}
-            title="Drag task"
-            aria-hidden="true"
-            data-testid={`chat-drag-handle-${id}`}
-          >
-            <GripVertical className="size-4" />
-          </span>
         ) : null}
         {showActions ? (
           <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>

--- a/app/components/ChatItem.tsx
+++ b/app/components/ChatItem.tsx
@@ -431,6 +431,8 @@ const ChatItem: React.FC<ChatItemProps> = ({
       return;
     }
 
+    if (isDragging) return;
+
     if (e.key === "Enter") {
       e.preventDefault();
       handleClick();

--- a/app/components/SidebarChatSections.tsx
+++ b/app/components/SidebarChatSections.tsx
@@ -119,7 +119,7 @@ function CollapsibleChatSection({
   );
 }
 
-function SidebarChatSectionsContent({
+export function SidebarChatSections({
   chats,
   projects,
   projectPaginationStatus,
@@ -264,8 +264,4 @@ function SidebarChatSectionsContent({
       </DragOverlay>
     </DndContext>
   );
-}
-
-export function SidebarChatSections(props: SidebarChatSectionsProps) {
-  return <SidebarChatSectionsContent {...props} />;
 }

--- a/app/components/SidebarChatSections.tsx
+++ b/app/components/SidebarChatSections.tsx
@@ -9,10 +9,12 @@ import {
   KeyboardSensor,
   MouseSensor,
   pointerWithin,
+  rectIntersection,
   TouchSensor,
   useDroppable,
   useSensor,
   useSensors,
+  type CollisionDetection,
   type DragCancelEvent,
   type DragEndEvent,
   type DragStartEvent,
@@ -60,6 +62,14 @@ interface CollapsibleChatSectionProps {
   testId: string;
   title: string;
 }
+
+const sidebarChatCollisionDetection: CollisionDetection = (args) => {
+  const pointerCollisions = pointerWithin(args);
+
+  return pointerCollisions.length > 0
+    ? pointerCollisions
+    : rectIntersection(args);
+};
 
 function CollapsibleChatSection({
   children,
@@ -200,7 +210,7 @@ export function SidebarChatSections({
   return (
     <DndContext
       sensors={sensors}
-      collisionDetection={pointerWithin}
+      collisionDetection={sidebarChatCollisionDetection}
       onDragStart={handleDragStart}
       onDragCancel={handleDragCancel}
       onDragEnd={handleDragEnd}

--- a/app/components/SidebarChatSections.tsx
+++ b/app/components/SidebarChatSections.tsx
@@ -1,21 +1,36 @@
 "use client";
 
-import {
-  useId,
-  useState,
-  type DragEvent,
-  type ReactNode,
-  type RefObject,
-} from "react";
+import { useId, useState, type ReactNode, type RefObject } from "react";
 import { ChevronRight } from "lucide-react";
 import { toast } from "sonner";
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  MouseSensor,
+  pointerWithin,
+  TouchSensor,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragCancelEvent,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
 import type { Doc } from "@/convex/_generated/dataModel";
 import { usePinChat, useUnpinChat } from "@/app/hooks/useChats";
 import SidebarHistory, { type SidebarPaginationStatus } from "./SidebarHistory";
 import { SidebarProjects } from "./SidebarProjects";
 import {
-  hasSidebarChatDragData,
-  SIDEBAR_CHAT_DRAG_TYPE,
+  dispatchSidebarChatDrop,
+  getSidebarChatDragData,
+  SIDEBAR_MOUSE_DRAG_DISTANCE,
+  SIDEBAR_PINNED_DROP_ID,
+  SIDEBAR_TASKS_DROP_ID,
+  SIDEBAR_TOUCH_DRAG_DELAY,
+  SIDEBAR_TOUCH_DRAG_TOLERANCE,
+  type SidebarChatDragData,
+  type SidebarChatDropData,
 } from "./sidebar-chat-drag";
 
 interface SidebarChat {
@@ -38,10 +53,8 @@ interface SidebarChatSectionsProps {
 
 interface CollapsibleChatSectionProps {
   children: ReactNode;
-  isDragOver?: boolean;
-  onDragLeave?: (event: DragEvent<HTMLElement>) => void;
-  onDragOver?: (event: DragEvent<HTMLElement>) => void;
-  onDrop?: (event: DragEvent<HTMLElement>) => void;
+  dropId: string;
+  onDrop: SidebarChatDropData["onDrop"];
   open: boolean;
   onOpenChange: (open: boolean) => void;
   testId: string;
@@ -50,9 +63,7 @@ interface CollapsibleChatSectionProps {
 
 function CollapsibleChatSection({
   children,
-  isDragOver = false,
-  onDragLeave,
-  onDragOver,
+  dropId,
   onDrop,
   open,
   onOpenChange,
@@ -60,22 +71,28 @@ function CollapsibleChatSection({
   title,
 }: CollapsibleChatSectionProps) {
   const contentId = useId();
+  const dropData: SidebarChatDropData = {
+    type: "sidebar-chat-drop",
+    onDrop,
+  };
+  const { isOver, setNodeRef } = useDroppable({
+    id: dropId,
+    data: dropData,
+  });
 
   return (
     <section
+      ref={setNodeRef}
       className={`relative flex flex-col gap-px rounded-[10px] bg-sidebar ${
-        isDragOver ? "bg-sidebar-accent/40 ring-1 ring-sidebar-ring" : ""
+        isOver ? "bg-sidebar-accent/40 ring-1 ring-sidebar-ring" : ""
       }`}
       data-testid={testId}
-      data-drop-active={isDragOver ? "true" : undefined}
-      onDragLeave={onDragLeave}
-      onDragOver={onDragOver}
-      onDrop={onDrop}
+      data-drop-active={isOver ? "true" : undefined}
     >
       <button
         type="button"
         className={`group/chat-section sticky top-0 z-[3] flex h-9 w-full items-center gap-0.5 bg-sidebar py-0.5 ps-2.5 pe-0.5 text-left hover:rounded-[10px] hover:bg-sidebar-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring ${
-          isDragOver
+          isOver
             ? "rounded-[10px] bg-sidebar-accent/70 ring-1 ring-sidebar-ring"
             : ""
         }`}
@@ -102,7 +119,7 @@ function CollapsibleChatSection({
   );
 }
 
-export function SidebarChatSections({
+function SidebarChatSectionsContent({
   chats,
   projects,
   projectPaginationStatus,
@@ -113,9 +130,7 @@ export function SidebarChatSections({
 }: SidebarChatSectionsProps) {
   const [isPinnedOpen, setIsPinnedOpen] = useState(true);
   const [isTasksOpen, setIsTasksOpen] = useState(true);
-  const [isTaskDragging, setIsTaskDragging] = useState(false);
-  const [isPinnedDragOver, setIsPinnedDragOver] = useState(false);
-  const [isTasksDragOver, setIsTasksDragOver] = useState(false);
+  const [activeTask, setActiveTask] = useState<SidebarChatDragData>();
   const pinChat = usePinChat();
   const unpinChat = useUnpinChat();
   const pinnedChats = chats.filter((chat) => chat.pinned_at != null);
@@ -129,46 +144,11 @@ export function SidebarChatSections({
   const hasPinnedItems =
     pinnedChats.length > 0 || (pinnedProjects?.length ?? 0) > 0;
 
-  const handleSidebarDragStart = (event: DragEvent<HTMLDivElement>) => {
-    if (hasSidebarChatDragData(event.dataTransfer)) {
-      setIsTaskDragging(true);
-    }
-  };
-
-  const resetDragState = () => {
-    setIsTaskDragging(false);
-    setIsPinnedDragOver(false);
-    setIsTasksDragOver(false);
-  };
-
-  const handlePinnedDragOver = (event: DragEvent<HTMLElement>) => {
-    if (!hasSidebarChatDragData(event.dataTransfer)) return;
-    event.preventDefault();
-    event.dataTransfer.dropEffect = "move";
-    setIsPinnedDragOver(true);
-  };
-
-  const handlePinnedDragLeave = (event: DragEvent<HTMLElement>) => {
-    const nextTarget = event.relatedTarget;
-    if (
-      nextTarget instanceof Node &&
-      event.currentTarget.contains(nextTarget)
-    ) {
-      return;
-    }
-    setIsPinnedDragOver(false);
-  };
-
-  const handlePinnedDrop = async (event: DragEvent<HTMLElement>) => {
-    if (!hasSidebarChatDragData(event.dataTransfer)) return;
-    event.preventDefault();
-    const chatId = event.dataTransfer.getData(SIDEBAR_CHAT_DRAG_TYPE);
-    resetDragState();
-
-    if (!chatId || pinnedChats.some((chat) => chat.id === chatId)) return;
+  const handlePinnedDrop = async (chat: SidebarChatDragData) => {
+    if (chat.isPinned) return;
 
     try {
-      await pinChat({ chatId });
+      await pinChat({ chatId: chat.chatId });
       toast.success("Task pinned");
     } catch (error) {
       console.error("Failed to pin dropped task:", error);
@@ -176,34 +156,11 @@ export function SidebarChatSections({
     }
   };
 
-  const handleTasksDragOver = (event: DragEvent<HTMLElement>) => {
-    if (!hasSidebarChatDragData(event.dataTransfer)) return;
-    event.preventDefault();
-    event.dataTransfer.dropEffect = "move";
-    setIsTasksDragOver(true);
-  };
-
-  const handleTasksDragLeave = (event: DragEvent<HTMLElement>) => {
-    const nextTarget = event.relatedTarget;
-    if (
-      nextTarget instanceof Node &&
-      event.currentTarget.contains(nextTarget)
-    ) {
-      return;
-    }
-    setIsTasksDragOver(false);
-  };
-
-  const handleTasksDrop = async (event: DragEvent<HTMLElement>) => {
-    if (!hasSidebarChatDragData(event.dataTransfer)) return;
-    event.preventDefault();
-    const chatId = event.dataTransfer.getData(SIDEBAR_CHAT_DRAG_TYPE);
-    resetDragState();
-
-    if (!chatId || !pinnedChats.some((chat) => chat.id === chatId)) return;
+  const handleTasksDrop = async (chat: SidebarChatDragData) => {
+    if (!chat.isPinned) return;
 
     try {
-      await unpinChat({ chatId });
+      await unpinChat({ chatId: chat.chatId });
       toast.success("Task unpinned");
     } catch (error) {
       console.error("Failed to unpin dropped task:", error);
@@ -211,62 +168,104 @@ export function SidebarChatSections({
     }
   };
 
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveTask(getSidebarChatDragData(event.active.data.current));
+  };
+
+  const handleDragCancel = (_event: DragCancelEvent) => {
+    setActiveTask(undefined);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveTask(undefined);
+    dispatchSidebarChatDrop(
+      event.active.data.current,
+      event.over?.data.current,
+    );
+  };
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, {
+      activationConstraint: { distance: SIDEBAR_MOUSE_DRAG_DISTANCE },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: SIDEBAR_TOUCH_DRAG_DELAY,
+        tolerance: SIDEBAR_TOUCH_DRAG_TOLERANCE,
+      },
+    }),
+    useSensor(KeyboardSensor),
+  );
+
   return (
-    <div
-      className="flex min-h-full flex-col gap-3 pb-3"
-      data-testid="sidebar-chat-sections"
-      onDragStart={handleSidebarDragStart}
-      onDragEnd={resetDragState}
+    <DndContext
+      sensors={sensors}
+      collisionDetection={pointerWithin}
+      onDragStart={handleDragStart}
+      onDragCancel={handleDragCancel}
+      onDragEnd={handleDragEnd}
     >
-      {hasPinnedItems || isTaskDragging ? (
+      <div
+        className="flex min-h-full flex-col gap-3 pb-3"
+        data-testid="sidebar-chat-sections"
+      >
+        {hasPinnedItems || activeTask ? (
+          <CollapsibleChatSection
+            title="Pinned"
+            dropId={SIDEBAR_PINNED_DROP_ID}
+            onDrop={handlePinnedDrop}
+            open={isPinnedOpen}
+            onOpenChange={setIsPinnedOpen}
+            testId="sidebar-pinned-section"
+          >
+            <SidebarHistory
+              chats={pinnedChats}
+              containerRef={containerRef}
+              showEmptyState={false}
+              testId="sidebar-pinned-chat-list"
+            />
+            <SidebarProjects projects={pinnedProjects} variant="pinned-list" />
+          </CollapsibleChatSection>
+        ) : null}
+
+        <SidebarProjects
+          projects={unpinnedProjects}
+          paginationStatus={projectPaginationStatus}
+          loadMore={loadMoreProjects}
+        />
+
         <CollapsibleChatSection
-          title="Pinned"
-          open={isPinnedOpen}
-          onOpenChange={setIsPinnedOpen}
-          testId="sidebar-pinned-section"
-          isDragOver={isPinnedDragOver}
-          onDragLeave={handlePinnedDragLeave}
-          onDragOver={handlePinnedDragOver}
-          onDrop={handlePinnedDrop}
+          title="Tasks"
+          dropId={SIDEBAR_TASKS_DROP_ID}
+          onDrop={handleTasksDrop}
+          open={isTasksOpen}
+          onOpenChange={setIsTasksOpen}
+          testId="sidebar-tasks-section"
         >
           <SidebarHistory
-            chats={pinnedChats}
+            chats={taskChats}
+            paginationStatus={paginationStatus}
+            loadMore={loadMore}
             containerRef={containerRef}
-            showEmptyState={false}
-            testId="sidebar-pinned-chat-list"
+            showEmptyState={
+              projects !== undefined &&
+              projects.length === 0 &&
+              pinnedChats.length === 0
+            }
           />
-          <SidebarProjects projects={pinnedProjects} variant="pinned-list" />
         </CollapsibleChatSection>
-      ) : null}
-
-      <SidebarProjects
-        projects={unpinnedProjects}
-        paginationStatus={projectPaginationStatus}
-        loadMore={loadMoreProjects}
-      />
-
-      <CollapsibleChatSection
-        title="Tasks"
-        open={isTasksOpen}
-        onOpenChange={setIsTasksOpen}
-        testId="sidebar-tasks-section"
-        isDragOver={isTasksDragOver}
-        onDragLeave={handleTasksDragLeave}
-        onDragOver={handleTasksDragOver}
-        onDrop={handleTasksDrop}
-      >
-        <SidebarHistory
-          chats={taskChats}
-          paginationStatus={paginationStatus}
-          loadMore={loadMore}
-          containerRef={containerRef}
-          showEmptyState={
-            projects !== undefined &&
-            projects.length === 0 &&
-            pinnedChats.length === 0
-          }
-        />
-      </CollapsibleChatSection>
-    </div>
+      </div>
+      <DragOverlay>
+        {activeTask ? (
+          <div className="max-w-64 truncate rounded-lg border border-sidebar-border bg-sidebar-accent px-3 py-2 text-sm font-medium text-sidebar-foreground shadow-lg">
+            {activeTask.title}
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
   );
+}
+
+export function SidebarChatSections(props: SidebarChatSectionsProps) {
+  return <SidebarChatSectionsContent {...props} />;
 }

--- a/app/components/SidebarProjectItem.tsx
+++ b/app/components/SidebarProjectItem.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, type DragEvent } from "react";
+import { useState } from "react";
+import { useDroppable } from "@dnd-kit/core";
 import {
   ChevronRight,
   Ellipsis,
@@ -39,9 +40,8 @@ import { ProjectDeleteDialog } from "./ProjectDeleteDialog";
 import { ProjectEditDialog } from "./ProjectEditDialog";
 import { SidebarProjectThreads } from "./SidebarProjectThreads";
 import {
-  hasSidebarChatDragData,
-  getSidebarChatDragProjectId,
-  SIDEBAR_CHAT_DRAG_TYPE,
+  type SidebarChatDragData,
+  type SidebarChatDropData,
 } from "./sidebar-chat-drag";
 
 interface SidebarProjectItemProps {
@@ -59,42 +59,21 @@ export function SidebarProjectItem({
   onNewThread,
   onDropChat,
 }: SidebarProjectItemProps) {
-  const [isDragOver, setIsDragOver] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [isPinning, setIsPinning] = useState(false);
   const pinProject = usePinProject();
   const unpinProject = useUnpinProject();
-
-  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
-    if (!hasSidebarChatDragData(event.dataTransfer)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    event.dataTransfer.dropEffect = "move";
-    setIsDragOver(true);
+  const dropData: SidebarChatDropData = {
+    type: "sidebar-chat-drop",
+    onDrop: (chat: SidebarChatDragData) =>
+      onDropChat(chat.chatId, chat.projectId),
   };
-
-  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
-    const nextTarget = event.relatedTarget;
-    if (
-      nextTarget instanceof Node &&
-      event.currentTarget.contains(nextTarget)
-    ) {
-      return;
-    }
-    setIsDragOver(false);
-  };
-
-  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
-    if (!hasSidebarChatDragData(event.dataTransfer)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    setIsDragOver(false);
-    const chatId = event.dataTransfer.getData(SIDEBAR_CHAT_DRAG_TYPE);
-    const previousProjectId = getSidebarChatDragProjectId(event.dataTransfer);
-    if (chatId) void onDropChat(chatId, previousProjectId);
-  };
+  const { isOver, setNodeRef } = useDroppable({
+    id: `sidebar-project-drop:${project._id}`,
+    data: dropData,
+  });
 
   const handleTogglePinned = async () => {
     if (isPinning) return;
@@ -151,17 +130,15 @@ export function SidebarProjectItem({
 
   return (
     <Collapsible
+      ref={setNodeRef}
       open={open}
       onOpenChange={onOpenChange}
-      className={`rounded-[10px] ${isDragOver ? "bg-sidebar-accent/40 ring-1 ring-sidebar-ring" : ""}`}
-      onDragEnter={handleDragOver}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
-      onDrop={handleDrop}
+      className={`rounded-[10px] ${isOver ? "bg-sidebar-accent/40 ring-1 ring-sidebar-ring" : ""}`}
       data-testid={`project-${project._id}-drop-target`}
+      data-drop-active={isOver ? "true" : undefined}
     >
       <div
-        className={`group/project sticky top-9 z-[1] flex h-9 items-center gap-3 bg-sidebar ps-2 pe-0.5 hover:rounded-[10px] hover:bg-sidebar-accent/50 ${isDragOver ? "rounded-[10px] bg-sidebar-accent ring-1 ring-sidebar-ring" : ""}`}
+        className={`group/project sticky top-9 z-[1] flex h-9 items-center gap-3 bg-sidebar ps-2 pe-0.5 hover:rounded-[10px] hover:bg-sidebar-accent/50 ${isOver ? "rounded-[10px] bg-sidebar-accent ring-1 ring-sidebar-ring" : ""}`}
       >
         <CollapsibleTrigger asChild>
           <button

--- a/app/components/__tests__/ChatItem.projects.test.tsx
+++ b/app/components/__tests__/ChatItem.projects.test.tsx
@@ -321,48 +321,77 @@ describe("ChatItem project actions", () => {
     expect(screen.getByTestId("chat-item-chat-2")).not.toHaveClass("p-2");
   });
 
-  it("keeps the task row clickable while limiting drag initiation to a handle", () => {
+  it("keeps the entire task row clickable and removes the dedicated drag handle", () => {
     render(<ChatItem id="chat-1" title="Target notes" />);
 
     const row = screen.getByRole("button", { name: /Open task:/ });
     expect(row).not.toHaveAttribute("draggable");
     expect(row).toHaveClass("cursor-pointer");
-
-    fireEvent.mouseEnter(row);
-    const dragHandle = screen.getByTestId("chat-drag-handle-chat-1");
-    expect(dragHandle).toHaveAttribute("draggable", "true");
+    expect(row).toHaveAttribute("aria-roledescription", "draggable task");
+    expect(
+      screen.queryByTestId("chat-drag-handle-chat-1"),
+    ).not.toBeInTheDocument();
 
     fireEvent.click(row);
 
     expect(mockRouterPush).toHaveBeenCalledWith("/c/chat-1");
   });
 
-  it("does not open the task when the dedicated drag handle is used", () => {
+  it("does not start row navigation from the task options control", () => {
     render(<ChatItem id="chat-1" title="Target notes" />);
 
     const row = screen.getByRole("button", { name: /Open task:/ });
     fireEvent.mouseEnter(row);
-    const dragHandle = screen.getByTestId("chat-drag-handle-chat-1");
-    const dataTransfer = {
-      effectAllowed: "none",
-      setData: jest.fn(),
-    };
+    const options = screen.getByRole("button", {
+      name: "Open task options",
+    });
 
-    fireEvent.dragStart(dragHandle, { dataTransfer });
-    fireEvent.mouseLeave(row);
-    expect(dragHandle).toBeInTheDocument();
-    fireEvent.click(dragHandle);
-    fireEvent.dragEnd(dragHandle);
+    fireEvent.mouseDown(options, { button: 0, clientX: 0, clientY: 0 });
+    fireEvent.mouseMove(options, { clientX: 20, clientY: 0 });
+    fireEvent.mouseUp(options, { button: 0, clientX: 20, clientY: 0 });
+    fireEvent.click(options);
 
-    expect(dataTransfer.effectAllowed).toBe("move");
-    expect(dataTransfer.setData).toHaveBeenCalledWith(
-      "application/x-hackerai-chat-id",
-      "chat-1",
-    );
     expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  it("uses Enter to open while reserving Space for keyboard dragging", () => {
+    render(<ChatItem id="chat-1" title="Target notes" />);
+
+    const row = screen.getByRole("button", { name: /Open task:/ });
+    fireEvent.keyDown(row, { key: " " });
+    expect(mockRouterPush).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(row, { key: "Enter" });
+    expect(mockRouterPush).toHaveBeenCalledWith("/c/chat-1");
+  });
+
+  it("does not expose desktop drag semantics on mobile", () => {
+    mockUseIsMobile.mockReturnValue(true);
+    render(<ChatItem id="chat-1" title="Target notes" />);
+
+    const row = screen.getByRole("button", { name: /Open task:/ });
+    expect(row).not.toHaveAttribute("aria-roledescription");
+    expect(row).not.toHaveAttribute("draggable");
+  });
+
+  it("keeps compact action padding after removing the drag icon", () => {
+    render(<ChatItem id="chat-1" title="Target notes" />);
+
+    const row = screen.getByRole("button", { name: /Open task:/ });
+    fireEvent.mouseEnter(row);
+    expect(
+      screen.getByText("Target notes").parentElement?.parentElement,
+    ).toHaveClass("pr-9");
+    expect(
+      screen.getByText("Target notes").parentElement?.parentElement,
+    ).not.toHaveClass("pr-[4.5rem]", "pr-[6.5rem]");
     expect(
       screen.queryByTestId("chat-drag-handle-chat-1"),
     ).not.toBeInTheDocument();
+    expect(row).not.toHaveAttribute("draggable");
+    expect(
+      screen.getByRole("button", { name: "Open task options" }),
+    ).toBeVisible();
   });
 
   it("centers the streaming indicator in the task action slot", () => {

--- a/app/components/__tests__/ChatItem.projects.test.tsx
+++ b/app/components/__tests__/ChatItem.projects.test.tsx
@@ -8,6 +8,13 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  DndContext,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import type { ReactNode } from "react";
 
 const mockMoveChatToProject = jest.fn<any>();
 const mockRouterPush = jest.fn();
@@ -88,6 +95,11 @@ jest.mock("../MoveChatToProjectDialog", () => ({
 
 const ChatItem = require("../ChatItem")
   .default as typeof import("../ChatItem").default;
+
+function KeyboardDragHarness({ children }: { children: ReactNode }) {
+  const sensors = useSensors(useSensor(KeyboardSensor));
+  return <DndContext sensors={sensors}>{children}</DndContext>;
+}
 
 describe("ChatItem project actions", () => {
   beforeEach(() => {
@@ -363,6 +375,22 @@ describe("ChatItem project actions", () => {
 
     fireEvent.keyDown(row, { key: "Enter" });
     expect(mockRouterPush).toHaveBeenCalledWith("/c/chat-1");
+  });
+
+  it("does not open the task when Enter completes a keyboard drag", async () => {
+    render(
+      <KeyboardDragHarness>
+        <ChatItem id="chat-1" title="Target notes" />
+      </KeyboardDragHarness>,
+    );
+
+    const row = screen.getByRole("button", { name: /Open task:/ });
+    fireEvent.keyDown(row, { code: "Space", key: " " });
+    await waitFor(() => expect(row).toHaveClass("opacity-50"));
+
+    fireEvent.keyDown(row, { code: "Enter", key: "Enter" });
+    await waitFor(() => expect(row).not.toHaveClass("opacity-50"));
+    expect(mockRouterPush).not.toHaveBeenCalled();
   });
 
   it("does not expose desktop drag semantics on mobile", () => {

--- a/app/components/__tests__/SidebarChatSections.test.tsx
+++ b/app/components/__tests__/SidebarChatSections.test.tsx
@@ -27,6 +27,8 @@ let mockDndContextProps: {
 };
 let mockOverDropId: string | undefined;
 const mockDroppableData = new Map<string, SidebarChatDropData>();
+const mockPointerWithin = jest.fn();
+const mockRectIntersection = jest.fn();
 
 jest.mock("@dnd-kit/core", () => ({
   DndContext: ({
@@ -46,7 +48,8 @@ jest.mock("@dnd-kit/core", () => ({
   DragOverlay: ({ children }: { children: React.ReactNode }) => children,
   KeyboardSensor: class KeyboardSensor {},
   MouseSensor: class MouseSensor {},
-  pointerWithin: () => [],
+  pointerWithin: mockPointerWithin,
+  rectIntersection: mockRectIntersection,
   TouchSensor: class TouchSensor {},
   useDroppable: ({ data, id }: { data: SidebarChatDropData; id: string }) => {
     mockDroppableData.set(id, data);
@@ -144,6 +147,8 @@ describe("SidebarChatSections", () => {
     jest.clearAllMocks();
     mockDroppableData.clear();
     mockOverDropId = undefined;
+    mockPointerWithin.mockReturnValue([]);
+    mockRectIntersection.mockReturnValue([]);
     mockPinChat.mockResolvedValue(null);
     mockUnpinChat.mockResolvedValue(null);
   });
@@ -381,5 +386,45 @@ describe("SidebarChatSections", () => {
     });
     expect(mockPinChat).not.toHaveBeenCalled();
     expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("falls back to rectangle collisions and completes a keyboard drop", async () => {
+    render(
+      <SidebarChatSections
+        chats={chats}
+        projects={projects}
+        paginationStatus="Exhausted"
+      />,
+    );
+
+    const collisionArgs = { pointerCoordinates: null };
+    const keyboardCollisions = [{ id: SIDEBAR_TASKS_DROP_ID }];
+    mockRectIntersection.mockReturnValue(keyboardCollisions);
+
+    const detectCollisions =
+      mockDndContextProps.collisionDetection as typeof mockPointerWithin;
+    expect(detectCollisions(collisionArgs)).toEqual(keyboardCollisions);
+    expect(mockPointerWithin).toHaveBeenCalledWith(collisionArgs);
+    expect(mockRectIntersection).toHaveBeenCalledWith(collisionArgs);
+
+    const dragData: SidebarChatDragData = {
+      type: "sidebar-chat",
+      chatId: "pinned-chat",
+      isPinned: true,
+      title: "Pinned target",
+    };
+    act(() => {
+      mockDndContextProps.onDragEnd({
+        active: { data: { current: dragData } },
+        over: {
+          data: { current: mockDroppableData.get(keyboardCollisions[0].id) },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockUnpinChat).toHaveBeenCalledWith({ chatId: "pinned-chat" });
+      expect(mockToastSuccess).toHaveBeenCalledWith("Task unpinned");
+    });
   });
 });

--- a/app/components/__tests__/SidebarChatSections.test.tsx
+++ b/app/components/__tests__/SidebarChatSections.test.tsx
@@ -1,11 +1,63 @@
 import "@testing-library/jest-dom";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import {
+  SIDEBAR_PINNED_DROP_ID,
+  SIDEBAR_TASKS_DROP_ID,
+  type SidebarChatDragData,
+  type SidebarChatDropData,
+} from "../sidebar-chat-drag";
 
 const mockPinChat = jest.fn();
 const mockUnpinChat = jest.fn();
 const mockToastSuccess = jest.fn();
 const mockToastError = jest.fn();
+let mockDndContextProps: {
+  collisionDetection: unknown;
+  onDragCancel: (event: unknown) => void;
+  onDragEnd: (event: unknown) => void;
+  onDragStart: (event: unknown) => void;
+  sensors: unknown[];
+};
+let mockOverDropId: string | undefined;
+const mockDroppableData = new Map<string, SidebarChatDropData>();
+
+jest.mock("@dnd-kit/core", () => ({
+  DndContext: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+    collisionDetection: unknown;
+    onDragCancel: (event: unknown) => void;
+    onDragEnd: (event: unknown) => void;
+    onDragStart: (event: unknown) => void;
+    sensors: unknown[];
+  }) => {
+    mockDndContextProps = props;
+    return children;
+  },
+  DragOverlay: ({ children }: { children: React.ReactNode }) => children,
+  KeyboardSensor: class KeyboardSensor {},
+  MouseSensor: class MouseSensor {},
+  pointerWithin: () => [],
+  TouchSensor: class TouchSensor {},
+  useDroppable: ({ data, id }: { data: SidebarChatDropData; id: string }) => {
+    mockDroppableData.set(id, data);
+    return {
+      isOver: mockOverDropId === id,
+      setNodeRef: jest.fn(),
+    };
+  },
+  useSensor: (sensor: unknown, options?: unknown) => ({ sensor, options }),
+  useSensors: (...sensors: unknown[]) => sensors,
+}));
 
 jest.mock("@/app/hooks/useChats", () => ({
   usePinChat: () => mockPinChat,
@@ -90,6 +142,8 @@ const projects = [
 describe("SidebarChatSections", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockDroppableData.clear();
+    mockOverDropId = undefined;
     mockPinChat.mockResolvedValue(null);
     mockUnpinChat.mockResolvedValue(null);
   });
@@ -147,6 +201,10 @@ describe("SidebarChatSections", () => {
     expect(screen.getByTestId("sidebar-chat-list")).not.toHaveTextContent(
       "Pinned target",
     );
+    expect(mockDndContextProps.collisionDetection).toEqual(
+      expect.any(Function),
+    );
+    expect(mockDndContextProps.sensors).toHaveLength(3);
   });
 
   it("collapses pinned chats and tasks independently", () => {
@@ -185,34 +243,42 @@ describe("SidebarChatSections", () => {
   });
 
   it("pins a dropped task and shows the requested toast", async () => {
-    render(
-      <SidebarChatSections
-        chats={[chats[1]]}
-        projects={[]}
-        paginationStatus="Exhausted"
-      />,
-    );
+    const props = {
+      chats: [chats[1]],
+      projects: [],
+      paginationStatus: "Exhausted" as const,
+    };
+    const { rerender } = render(<SidebarChatSections {...props} />);
 
     expect(
       screen.queryByTestId("sidebar-pinned-section"),
     ).not.toBeInTheDocument();
 
-    const values = new Map([["application/x-hackerai-chat-id", "task-chat"]]);
-    const dataTransfer = {
-      types: ["application/x-hackerai-chat-id"],
-      dropEffect: "none",
-      getData: (type: string) => values.get(type) ?? "",
-    } as DataTransfer;
-
-    fireEvent.dragStart(screen.getByTestId("sidebar-chat-sections"), {
-      dataTransfer,
+    const dragData: SidebarChatDragData = {
+      type: "sidebar-chat",
+      chatId: "task-chat",
+      isPinned: false,
+      title: "Regular target",
+    };
+    act(() => {
+      mockDndContextProps.onDragStart({
+        active: { data: { current: dragData } },
+      });
     });
 
     const pinnedDropTarget = screen.getByTestId("sidebar-pinned-section");
-    fireEvent.dragOver(pinnedDropTarget, { dataTransfer });
+    mockOverDropId = SIDEBAR_PINNED_DROP_ID;
+    rerender(<SidebarChatSections {...props} />);
     expect(pinnedDropTarget).toHaveAttribute("data-drop-active", "true");
 
-    fireEvent.drop(pinnedDropTarget, { dataTransfer });
+    act(() => {
+      mockDndContextProps.onDragEnd({
+        active: { data: { current: dragData } },
+        over: {
+          data: { current: mockDroppableData.get(SIDEBAR_PINNED_DROP_ID) },
+        },
+      });
+    });
 
     await waitFor(() => {
       expect(mockPinChat).toHaveBeenCalledWith({ chatId: "task-chat" });
@@ -221,7 +287,7 @@ describe("SidebarChatSections", () => {
     expect(mockToastError).not.toHaveBeenCalled();
   });
 
-  it("accepts a drop on an existing task anywhere inside Pinned", async () => {
+  it("accepts the sensor drop target covering existing Pinned content", async () => {
     render(
       <SidebarChatSections
         chats={chats}
@@ -230,19 +296,24 @@ describe("SidebarChatSections", () => {
       />,
     );
 
-    const values = new Map([["application/x-hackerai-chat-id", "task-chat"]]);
-    const dataTransfer = {
-      types: ["application/x-hackerai-chat-id"],
-      dropEffect: "none",
-      getData: (type: string) => values.get(type) ?? "",
-    } as DataTransfer;
+    const dragData: SidebarChatDragData = {
+      type: "sidebar-chat",
+      chatId: "task-chat",
+      isPinned: false,
+      title: "Regular target",
+    };
     const pinnedSection = screen.getByTestId("sidebar-pinned-section");
     const existingPinnedTask = screen.getByTestId("section-chat-pinned-chat");
+    expect(pinnedSection).toContainElement(existingPinnedTask);
 
-    fireEvent.dragOver(existingPinnedTask, { dataTransfer });
-    expect(pinnedSection).toHaveAttribute("data-drop-active", "true");
-
-    fireEvent.drop(existingPinnedTask, { dataTransfer });
+    act(() => {
+      mockDndContextProps.onDragEnd({
+        active: { data: { current: dragData } },
+        over: {
+          data: { current: mockDroppableData.get(SIDEBAR_PINNED_DROP_ID) },
+        },
+      });
+    });
     await waitFor(() => {
       expect(mockPinChat).toHaveBeenCalledWith({ chatId: "task-chat" });
       expect(mockToastSuccess).toHaveBeenCalledWith("Task pinned");
@@ -258,22 +329,26 @@ describe("SidebarChatSections", () => {
       />,
     );
 
-    const values = new Map([["application/x-hackerai-chat-id", "pinned-chat"]]);
-    const dataTransfer = {
-      types: ["application/x-hackerai-chat-id"],
-      dropEffect: "none",
-      getData: (type: string) => values.get(type) ?? "",
-    } as DataTransfer;
-
-    fireEvent.drop(screen.getByRole("button", { name: "Pinned" }), {
-      dataTransfer,
+    const dragData: SidebarChatDragData = {
+      type: "sidebar-chat",
+      chatId: "pinned-chat",
+      isPinned: true,
+      title: "Pinned target",
+    };
+    act(() => {
+      mockDndContextProps.onDragEnd({
+        active: { data: { current: dragData } },
+        over: {
+          data: { current: mockDroppableData.get(SIDEBAR_PINNED_DROP_ID) },
+        },
+      });
     });
 
     expect(mockPinChat).not.toHaveBeenCalled();
     expect(mockToastSuccess).not.toHaveBeenCalled();
   });
 
-  it("unpins a task dropped anywhere inside Tasks", async () => {
+  it("unpins a task dropped on the Tasks sensor target", async () => {
     render(
       <SidebarChatSections
         chats={chats}
@@ -282,19 +357,24 @@ describe("SidebarChatSections", () => {
       />,
     );
 
-    const values = new Map([["application/x-hackerai-chat-id", "pinned-chat"]]);
-    const dataTransfer = {
-      types: ["application/x-hackerai-chat-id"],
-      dropEffect: "none",
-      getData: (type: string) => values.get(type) ?? "",
-    } as DataTransfer;
+    const dragData: SidebarChatDragData = {
+      type: "sidebar-chat",
+      chatId: "pinned-chat",
+      isPinned: true,
+      title: "Pinned target",
+    };
     const tasksSection = screen.getByTestId("sidebar-tasks-section");
     const existingTask = screen.getByTestId("section-chat-task-chat");
+    expect(tasksSection).toContainElement(existingTask);
 
-    fireEvent.dragOver(existingTask, { dataTransfer });
-    expect(tasksSection).toHaveAttribute("data-drop-active", "true");
-
-    fireEvent.drop(existingTask, { dataTransfer });
+    act(() => {
+      mockDndContextProps.onDragEnd({
+        active: { data: { current: dragData } },
+        over: {
+          data: { current: mockDroppableData.get(SIDEBAR_TASKS_DROP_ID) },
+        },
+      });
+    });
     await waitFor(() => {
       expect(mockUnpinChat).toHaveBeenCalledWith({ chatId: "pinned-chat" });
       expect(mockToastSuccess).toHaveBeenCalledWith("Task unpinned");

--- a/app/components/__tests__/SidebarProjectItem.test.tsx
+++ b/app/components/__tests__/SidebarProjectItem.test.tsx
@@ -1,11 +1,11 @@
 import "@testing-library/jest-dom";
-import { describe, expect, it, jest } from "@jest/globals";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Doc } from "@/convex/_generated/dataModel";
 import {
-  SIDEBAR_CHAT_DRAG_PROJECT_TYPE,
-  SIDEBAR_CHAT_DRAG_TYPE,
+  type SidebarChatDragData,
+  type SidebarChatDropData,
 } from "../sidebar-chat-drag";
 
 const mockProjectThreads = jest.fn(() => (
@@ -17,6 +17,18 @@ const mockProjectThreads = jest.fn(() => (
 ));
 const mockPinProject = jest.fn<any>().mockResolvedValue(null);
 const mockUnpinProject = jest.fn<any>().mockResolvedValue(null);
+let mockProjectDropData: SidebarChatDropData;
+let mockProjectIsOver = false;
+
+jest.mock("@dnd-kit/core", () => ({
+  useDroppable: ({ data }: { data: SidebarChatDropData }) => {
+    mockProjectDropData = data;
+    return {
+      isOver: mockProjectIsOver,
+      setNodeRef: jest.fn(),
+    };
+  },
+}));
 
 jest.mock("@/app/hooks/useProjects", () => ({
   usePinProject: () => mockPinProject,
@@ -50,6 +62,11 @@ const project = {
 } as unknown as Doc<"projects">;
 
 describe("SidebarProjectItem", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockProjectIsOver = false;
+  });
+
   it("unmounts the thread list when collapsed so pagination resets", () => {
     const props = {
       project,
@@ -78,21 +95,19 @@ describe("SidebarProjectItem", () => {
     expect(mockProjectThreads).toHaveBeenCalledTimes(2);
   });
 
-  it("accepts a dragged sidebar chat", () => {
+  it("accepts a sidebar task from the project sensor target", () => {
     const onDropChat = jest
       .fn<() => Promise<void>>()
       .mockResolvedValue(undefined);
-    const values = new Map([
-      [SIDEBAR_CHAT_DRAG_TYPE, "chat-1"],
-      [SIDEBAR_CHAT_DRAG_PROJECT_TYPE, "project-previous"],
-    ]);
-    const dataTransfer = {
-      types: [SIDEBAR_CHAT_DRAG_TYPE, SIDEBAR_CHAT_DRAG_PROJECT_TYPE],
-      dropEffect: "none",
-      getData: (type: string) => values.get(type) ?? "",
-    } as DataTransfer;
+    const dragData: SidebarChatDragData = {
+      type: "sidebar-chat",
+      chatId: "chat-1",
+      isPinned: false,
+      projectId: "project-previous",
+      title: "Target notes",
+    };
 
-    render(
+    const { rerender } = render(
       <SidebarProjectItem
         project={project}
         open={false}
@@ -103,31 +118,40 @@ describe("SidebarProjectItem", () => {
     );
 
     const dropTarget = screen.getByTestId("project-project-1-drop-target");
-    fireEvent.dragEnter(dropTarget, { dataTransfer });
+    expect(dropTarget).not.toHaveClass("ring-1");
+
+    mockProjectIsOver = true;
+    rerender(
+      <SidebarProjectItem
+        project={project}
+        open={false}
+        onOpenChange={jest.fn()}
+        onNewThread={jest.fn()}
+        onDropChat={onDropChat}
+      />,
+    );
     expect(dropTarget).toHaveClass("ring-1");
 
-    fireEvent.drop(dropTarget, { dataTransfer });
+    act(() => {
+      void mockProjectDropData.onDrop(dragData);
+    });
     expect(onDropChat).toHaveBeenCalledWith("chat-1", "project-previous");
-    expect(dropTarget).not.toHaveClass("ring-1");
   });
 
-  it("accepts a drop on an existing task anywhere inside an open project", () => {
+  it("covers existing tasks inside an open project drop target", () => {
     const onDropChat = jest
       .fn<() => Promise<void>>()
       .mockResolvedValue(undefined);
-    const values = new Map([
-      [SIDEBAR_CHAT_DRAG_TYPE, "chat-1"],
-      [SIDEBAR_CHAT_DRAG_PROJECT_TYPE, "project-previous"],
-    ]);
-    const dataTransfer = {
-      types: [SIDEBAR_CHAT_DRAG_TYPE, SIDEBAR_CHAT_DRAG_PROJECT_TYPE],
-      dropEffect: "none",
-      getData: (type: string) => values.get(type) ?? "",
-    } as DataTransfer;
+    const dragData: SidebarChatDragData = {
+      type: "sidebar-chat",
+      chatId: "chat-1",
+      isPinned: false,
+      projectId: "project-previous",
+      title: "Target notes",
+    };
 
-    const outerDrop = jest.fn();
     render(
-      <div onDrop={outerDrop}>
+      <div>
         <SidebarProjectItem
           project={project}
           open
@@ -142,14 +166,12 @@ describe("SidebarProjectItem", () => {
       "project-project-1-drop-target",
     );
     const nestedTask = screen.getByTestId("nested-project-task");
+    expect(projectDropTarget).toContainElement(nestedTask);
 
-    fireEvent.dragOver(nestedTask, { dataTransfer });
-    expect(projectDropTarget).toHaveClass("ring-1");
-
-    fireEvent.drop(nestedTask, { dataTransfer });
+    act(() => {
+      void mockProjectDropData.onDrop(dragData);
+    });
     expect(onDropChat).toHaveBeenCalledWith("chat-1", "project-previous");
-    expect(outerDrop).not.toHaveBeenCalled();
-    expect(projectDropTarget).not.toHaveClass("ring-1");
   });
 
   it("shows the linked Desktop folder in the project menu", async () => {

--- a/app/components/__tests__/sidebar-chat-drag.test.ts
+++ b/app/components/__tests__/sidebar-chat-drag.test.ts
@@ -1,36 +1,55 @@
 import { describe, expect, it, jest } from "@jest/globals";
 import {
-  getSidebarChatDragProjectId,
-  hasSidebarChatDragData,
-  setSidebarChatDragData,
-  SIDEBAR_CHAT_DRAG_PROJECT_TYPE,
-  SIDEBAR_CHAT_DRAG_TYPE,
+  dispatchSidebarChatDrop,
+  getSidebarChatDragData,
+  getSidebarChatDropData,
+  SIDEBAR_MOUSE_DRAG_DISTANCE,
+  SIDEBAR_TOUCH_DRAG_DELAY,
+  SIDEBAR_TOUCH_DRAG_TOLERANCE,
+  type SidebarChatDragData,
+  type SidebarChatDropData,
 } from "../sidebar-chat-drag";
 
+const chat: SidebarChatDragData = {
+  type: "sidebar-chat",
+  chatId: "chat-1",
+  isPinned: false,
+  projectId: "project-1",
+  title: "Target notes",
+};
+
 describe("sidebar chat drag data", () => {
-  it("writes a move payload that project rows recognize", () => {
-    const types: string[] = [];
-    const values = new Map<string, string>();
-    const setData = jest.fn((type: string, value: string) => {
-      if (!types.includes(type)) types.push(type);
-      values.set(type, value);
-    });
-    const dataTransfer = {
-      effectAllowed: "none",
-      getData: (type: string) => values.get(type) ?? "",
-      setData,
-      types,
-    } as unknown as DataTransfer;
+  it("requires intentional mouse or touch activation", () => {
+    expect(SIDEBAR_MOUSE_DRAG_DISTANCE).toBe(8);
+    expect(SIDEBAR_TOUCH_DRAG_DELAY).toBe(250);
+    expect(SIDEBAR_TOUCH_DRAG_TOLERANCE).toBe(5);
+  });
 
-    setSidebarChatDragData(dataTransfer, "chat-1", "project-1");
+  it("recognizes typed sensor drag and drop data", () => {
+    const onDrop = jest.fn();
+    const dropTarget: SidebarChatDropData = {
+      type: "sidebar-chat-drop",
+      onDrop,
+    };
 
-    expect(dataTransfer.effectAllowed).toBe("move");
-    expect(setData).toHaveBeenCalledWith(SIDEBAR_CHAT_DRAG_TYPE, "chat-1");
-    expect(setData).toHaveBeenCalledWith(
-      SIDEBAR_CHAT_DRAG_PROJECT_TYPE,
-      "project-1",
-    );
-    expect(hasSidebarChatDragData(dataTransfer)).toBe(true);
-    expect(getSidebarChatDragProjectId(dataTransfer)).toBe("project-1");
+    expect(getSidebarChatDragData(chat)).toBe(chat);
+    expect(getSidebarChatDropData(dropTarget)).toBe(dropTarget);
+    expect(dispatchSidebarChatDrop(chat, dropTarget)).toBe(true);
+    expect(onDrop).toHaveBeenCalledWith(chat);
+  });
+
+  it("ignores unrelated or incomplete drag data", () => {
+    const onDrop = jest.fn();
+    const dropTarget: SidebarChatDropData = {
+      type: "sidebar-chat-drop",
+      onDrop,
+    };
+
+    expect(getSidebarChatDragData({ type: "sidebar-chat" })).toBeUndefined();
+    expect(
+      getSidebarChatDropData({ type: "sidebar-chat-drop" }),
+    ).toBeUndefined();
+    expect(dispatchSidebarChatDrop({ type: "file" }, dropTarget)).toBe(false);
+    expect(onDrop).not.toHaveBeenCalled();
   });
 });

--- a/app/components/sidebar-chat-drag.ts
+++ b/app/components/sidebar-chat-drag.ts
@@ -1,26 +1,68 @@
-export const SIDEBAR_CHAT_DRAG_TYPE = "application/x-hackerai-chat-id";
-export const SIDEBAR_CHAT_DRAG_PROJECT_TYPE =
-  "application/x-hackerai-project-id";
+export const SIDEBAR_PINNED_DROP_ID = "sidebar-drop:pinned";
+export const SIDEBAR_TASKS_DROP_ID = "sidebar-drop:tasks";
+export const SIDEBAR_MOUSE_DRAG_DISTANCE = 8;
+export const SIDEBAR_TOUCH_DRAG_DELAY = 250;
+export const SIDEBAR_TOUCH_DRAG_TOLERANCE = 5;
 
-export function setSidebarChatDragData(
-  dataTransfer: DataTransfer,
-  chatId: string,
-  projectId?: string,
-): void {
-  dataTransfer.effectAllowed = "move";
-  dataTransfer.setData(SIDEBAR_CHAT_DRAG_TYPE, chatId);
-  if (projectId) {
-    dataTransfer.setData(SIDEBAR_CHAT_DRAG_PROJECT_TYPE, projectId);
+export interface SidebarChatDragData {
+  type: "sidebar-chat";
+  chatId: string;
+  isPinned: boolean;
+  projectId?: string;
+  title: string;
+}
+
+export interface SidebarChatDropData {
+  type: "sidebar-chat-drop";
+  onDrop: (chat: SidebarChatDragData) => Promise<void> | void;
+}
+
+export function getSidebarChatDragData(
+  value: unknown,
+): SidebarChatDragData | undefined {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("type" in value) ||
+    value.type !== "sidebar-chat" ||
+    !("chatId" in value) ||
+    typeof value.chatId !== "string" ||
+    !("isPinned" in value) ||
+    typeof value.isPinned !== "boolean" ||
+    !("title" in value) ||
+    typeof value.title !== "string"
+  ) {
+    return undefined;
   }
+
+  return value as SidebarChatDragData;
 }
 
-export function hasSidebarChatDragData(dataTransfer: DataTransfer): boolean {
-  return Array.from(dataTransfer.types).includes(SIDEBAR_CHAT_DRAG_TYPE);
+export function getSidebarChatDropData(
+  value: unknown,
+): SidebarChatDropData | undefined {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("type" in value) ||
+    value.type !== "sidebar-chat-drop" ||
+    !("onDrop" in value) ||
+    typeof value.onDrop !== "function"
+  ) {
+    return undefined;
+  }
+
+  return value as SidebarChatDropData;
 }
 
-export function getSidebarChatDragProjectId(
-  dataTransfer: DataTransfer,
-): string | undefined {
-  const projectId = dataTransfer.getData(SIDEBAR_CHAT_DRAG_PROJECT_TYPE);
-  return projectId || undefined;
+export function dispatchSidebarChatDrop(
+  activeData: unknown,
+  dropData: unknown,
+): boolean {
+  const chat = getSidebarChatDragData(activeData);
+  const dropTarget = getSidebarChatDropData(dropData);
+  if (!chat || !dropTarget) return false;
+
+  void dropTarget.onDrop(chat);
+  return true;
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@aws-sdk/s3-request-presigner": "3.1096.0",
     "@convex-dev/aggregate": "^0.2.2",
     "@convex-dev/workos": "^0.0.3",
+    "@dnd-kit/core": "6.3.1",
     "@e2b/code-interpreter": "2.7.0",
     "@langchain/community": "^1.1.29",
     "@monaco-editor/react": "^4.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@convex-dev/workos':
         specifier: ^0.0.3
         version: 0.0.3(convex@1.42.3(react@19.2.8))(react@19.2.8)
+      '@dnd-kit/core':
+        specifier: 6.3.1
+        version: 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@e2b/code-interpreter':
         specifier: 2.7.0
         version: 2.7.0
@@ -972,6 +975,22 @@ packages:
     resolution: {integrity: sha512-KvmOiQdpbamFziqnzzgqBm6RjfGhLJimBBYEOVriTxCPtVJuBIFm34xZllM36OQzPZIWpWBP+2/UnOyRG5smUg==}
     engines: {node: '>=14'}
     hasBin: true
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@e2b/code-interpreter@2.7.0':
     resolution: {integrity: sha512-XsYMn1FNzci0niW0Zf8PdYYFzGgyfi79sRJIZBtA4NejnDwgDYUPXdM0zBtrJsPwLS+fv8RPN3RPd5THCHmPow==}
@@ -9169,6 +9188,24 @@ snapshots:
       '@depot/cli-win32-arm64': 0.0.1-cli.2.80.0
       '@depot/cli-win32-ia32': 0.0.1-cli.2.80.0
       '@depot/cli-win32-x64': 0.0.1-cli.2.80.0
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.8)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+      tslib: 2.8.1
 
   '@e2b/code-interpreter@2.7.0':
     dependencies:


### PR DESCRIPTION
## Summary
- replace native whole-row dragging and the hover-only grip workaround with sensor-based dragging from the complete task row
- require intentional pointer movement before dragging, while preserving ordinary click-to-open behavior and excluding nested task controls
- retain Pinned, Tasks, and project drop targets with pointer-based collision detection and keyboard drag support

## Root cause
The sidebar previously used native HTML `draggable` behavior. Small pointer movement could start a native drag and prevent the row click from opening the task. Moving drag initiation to a dedicated grip made opening reliable, but unnecessarily reduced the draggable area.

## User impact
A task row now behaves like one control: click it to open the task, or intentionally drag the same row to Pinned, Tasks, or a project. There is no separate drag icon.

## Validation
- `pnpm test` — 307 suites and 3,039 tests passed
- `pnpm typecheck`
- `pnpm lint` — no errors; five pre-existing warnings remain
- focused sidebar suite — 36 tests passed
- `pnpm audit --prod` — no known vulnerabilities
- Chrome local verification — click opened tasks; 4 px pointer movement stayed a click; intentional drag activated after the threshold; pin and restore drops succeeded; no drag grip, console errors, or framework error overlay

## Manual verification
1. Open HackerAI Desktop and expand the sidebar.
2. Click several existing task rows; each task should open normally.
3. Drag a task from the row body into Pinned, another project, and back to Tasks where applicable.
4. Confirm dragging starts only after intentional movement, the target highlights, the task moves, and no dedicated drag icon appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgraded sidebar chat and project drag-and-drop to the dnd-kit experience, including refined mouse/touch activation, keyboard dragging support, and improved drop overlays for pinned/tasks.
  - You can now drag entire chat rows on desktop without a dedicated drag handle, with more consistent row/keyboard behavior.

- **Bug Fixes**
  - Prevented “Open task options” interactions from triggering row navigation.
  - Improved drop handling and collision behavior across pinned, tasks, open projects, and nested task areas.
  - Added stronger validation for drag/drop payloads to ignore unrelated or incomplete drags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->