### PR TITLE
Fix Agent continuation cancellation races

### DIFF
--- a/app/hooks/__tests__/useAutoContinue.test.ts
+++ b/app/hooks/__tests__/useAutoContinue.test.ts
@@ -325,6 +325,28 @@ describe("useAutoContinue", () => {
     expect(result.current.isAutoContinuing).toBe(false);
   });
 
+  it("cancels a scheduled continuation when manual submission resets it", () => {
+    const sendMessage = jest.fn();
+    let params = buildParams({ status: "streaming", sendMessage });
+
+    const { result, rerender } = renderHook(
+      (p: UseAutoContinueParams) => useTestHarness(p),
+      { initialProps: params, wrapper: createWrapper() },
+    );
+
+    pushAutoContinue(result);
+    params = { ...params, status: "ready" };
+    rerender(params);
+
+    act(() => {
+      result.current.resetAutoContinueCount();
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(result.current.isAutoContinuing).toBe(false);
+  });
+
   it("keeps automatic continuation active until the follow-up run settles", () => {
     const sendMessage = jest.fn();
     let params = buildParams({ status: "streaming", sendMessage });

--- a/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
@@ -209,7 +209,10 @@ describe("useChatHandlers regenerate model", () => {
       "/api/agent/cancel",
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({ chatId: "chat-1" }),
+        body: JSON.stringify({
+          chatId: "chat-1",
+          expectedTriggerRunId: "run-1",
+        }),
       }),
     );
     expect(mockRegenerate).toHaveBeenCalledWith(
@@ -257,7 +260,10 @@ describe("useChatHandlers regenerate model", () => {
       "/api/agent/cancel",
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({ chatId: "chat-1" }),
+        body: JSON.stringify({
+          chatId: "chat-1",
+          expectedTriggerRunId: "run-1",
+        }),
       }),
     );
     expect(mockRegenerate).toHaveBeenCalledWith(
@@ -308,7 +314,10 @@ describe("useChatHandlers regenerate model", () => {
       "/api/agent/cancel",
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({ chatId: "chat-1" }),
+        body: JSON.stringify({
+          chatId: "chat-1",
+          expectedTriggerRunId: "run-1",
+        }),
       }),
     );
     expect(stop).toHaveBeenCalledTimes(1);

--- a/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
@@ -8,9 +8,11 @@ const mockSaveAssistantMessage = jest.fn(async () => null);
 const mockDeleteLastAssistantMessage = jest.fn(async () => null);
 const mockRegenerateWithNewContent = jest.fn(async () => null);
 const mockRemoveQueuedMessage = jest.fn();
+const mockQueueMessage = jest.fn();
 const mockSendMessage = jest.fn(async () => undefined);
 const mockStop = jest.fn();
 const mockSetMessages = jest.fn();
+let mockInput = "";
 
 const todos: Todo[] = [
   {
@@ -54,7 +56,7 @@ jest.mock("convex/react", () => ({
 
 jest.mock("@/app/contexts/GlobalState", () => ({
   useGlobalState: () => ({
-    input: "",
+    input: mockInput,
     uploadedFiles: [],
     chatMode: "agent",
     clearInput: jest.fn(),
@@ -64,7 +66,7 @@ jest.mock("@/app/contexts/GlobalState", () => ({
     isUploadingFiles: false,
     subscription: "pro",
     temporaryChatsEnabled: false,
-    queueMessage: jest.fn(),
+    queueMessage: mockQueueMessage,
     messageQueue: [
       {
         id: "queued-1",
@@ -120,6 +122,7 @@ const messages: ChatMessage[] = [
 describe("useChatHandlers steer todo handoff", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockInput = "";
     Object.defineProperty(globalThis, "fetch", {
       configurable: true,
       value: jest.fn(async () => ({ ok: true, status: 200 }) as Response),
@@ -156,7 +159,10 @@ describe("useChatHandlers steer todo handoff", () => {
       "/api/agent/cancel",
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({ chatId: "chat-1" }),
+        body: JSON.stringify({
+          chatId: "chat-1",
+          expectedTriggerRunId: "run-1",
+        }),
       }),
     );
     expect(mockCancelStream.mock.invocationCallOrder[0]).toBeLessThan(
@@ -170,6 +176,35 @@ describe("useChatHandlers steer todo handoff", () => {
       expect.objectContaining({ text: "Change direction" }),
       expect.objectContaining({ body: expect.objectContaining({ todos }) }),
     );
+  });
+
+  it("queues a manual message while an automatic continuation is submitted", async () => {
+    mockInput = "Use the latest result";
+    const { result } = renderHook(() =>
+      useChatHandlers({
+        chatId: "chat-1",
+        messages,
+        sendMessage: mockSendMessage,
+        stop: mockStop,
+        regenerate: jest.fn(),
+        setMessages: mockSetMessages,
+        isExistingChat: true,
+        status: "submitted",
+        isSendingNowRef: { current: false },
+        hasManuallyStoppedRef: { current: false },
+        activeTriggerRunRef: { current: "run-1" },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleSubmit({
+        preventDefault: jest.fn(),
+      } as unknown as React.FormEvent);
+    });
+
+    expect(mockQueueMessage).toHaveBeenCalledWith("Use the latest result", []);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(mockSendMessage).not.toHaveBeenCalled();
   });
 
   it("sends a queued message after the stream has already stopped", async () => {

--- a/app/hooks/useAutoContinue.ts
+++ b/app/hooks/useAutoContinue.ts
@@ -49,6 +49,9 @@ export function useAutoContinue({
   const pendingAutoContinueRef = useRef(false);
   const autoContinueRunScheduledRef = useRef(false);
   const autoContinueRunStartedRef = useRef(false);
+  const autoContinueTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const lastProcessedIndexRef = useRef(0);
 
   const todosRef = useLatestRef(todos);
@@ -60,12 +63,20 @@ export function useAutoContinue({
   const isPartForCurrentChat = (part: ScopedDataUIPart) =>
     part.__chatId === undefined || part.__chatId === chatId;
 
+  const clearScheduledAutoContinue = useCallback(() => {
+    if (autoContinueTimerRef.current !== null) {
+      clearTimeout(autoContinueTimerRef.current);
+      autoContinueTimerRef.current = null;
+    }
+  }, []);
+
   const clearAutoContinueLifecycle = useCallback(() => {
+    clearScheduledAutoContinue();
     pendingAutoContinueRef.current = false;
     autoContinueRunScheduledRef.current = false;
     autoContinueRunStartedRef.current = false;
     setIsAutoContinuing(false);
-  }, [setIsAutoContinuing]);
+  }, [clearScheduledAutoContinue, setIsAutoContinuing]);
 
   useEffect(() => {
     pendingAutoContinueRef.current = false;
@@ -112,7 +123,10 @@ export function useAutoContinue({
     autoContinueCountRef.current += 1;
     setAutoContinueCount(autoContinueCountRef.current);
 
-    const timeout = setTimeout(() => {
+    clearScheduledAutoContinue();
+    autoContinueTimerRef.current = setTimeout(() => {
+      autoContinueTimerRef.current = null;
+      if (!autoContinueRunScheduledRef.current) return;
       sendMessageRef.current(
         {
           text: AUTO_CONTINUE_PROMPT,
@@ -132,7 +146,7 @@ export function useAutoContinue({
       );
     }, 500);
 
-    return () => clearTimeout(timeout);
+    return clearScheduledAutoContinue;
   }, [
     status,
     dataStream,
@@ -148,6 +162,7 @@ export function useAutoContinue({
     sandboxPreferenceRef,
     agentPermissionModeRef,
     selectedModelRef,
+    clearScheduledAutoContinue,
   ]);
 
   useEffect(() => {

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -177,10 +177,14 @@ export const useChatHandlers = ({
 
   const cancelTriggerRun = async (): Promise<void> => {
     if (!shouldCancelTriggerRun()) return;
+    const expectedTriggerRunId = activeTriggerRunRef?.current;
     const response = await fetch(AGENT_CANCEL_ENDPOINT, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ chatId }),
+      body: JSON.stringify({
+        chatId,
+        ...(expectedTriggerRunId ? { expectedTriggerRunId } : {}),
+      }),
     });
     if (!response.ok) {
       throw new Error(
@@ -360,8 +364,8 @@ export const useChatHandlers = ({
       return false;
     }
 
-    // If streaming in Agent mode, check queue behavior
-    if (status === "streaming") {
+    // While an Agent run is starting or streaming, honor the queue behavior.
+    if (status === "streaming" || status === "submitted") {
       const validFiles = uploadedFiles
         .filter(isSendableUploadedFile)
         .map(createFileMessagePartFromUploadedFile)
@@ -829,7 +833,7 @@ export const useChatHandlers = ({
   };
 
   const handleContinue = (selectedModelOverride?: SelectedModel) => {
-    if (status === "streaming") return;
+    if (status === "streaming" || status === "submitted") return;
     hasManuallyStoppedRef.current = false;
     const continuationSelectedModel =
       selectedModelOverride ?? requestSelectedModelRef.current;

--- a/lib/api/__tests__/agent-cancel-route.test.ts
+++ b/lib/api/__tests__/agent-cancel-route.test.ts
@@ -56,9 +56,14 @@ jest.mock("@/lib/logger", () => ({
   logger: { warn: mockLoggerWarn },
 }));
 
-const request = () =>
+const request = (
+  body: {
+    chatId: string;
+    expectedTriggerRunId?: string;
+  } = { chatId: "temporary-chat-1" },
+) =>
   ({
-    json: jest.fn(async () => ({ chatId: "temporary-chat-1" })),
+    json: jest.fn(async () => body),
     headers: {
       get: jest.fn((name: string) =>
         name === "x-vercel-id" ? "req_agent_cancel" : null,
@@ -151,5 +156,56 @@ describe("agent cancel route", () => {
         chat_id: "temporary-chat-1",
       }),
     );
+  });
+
+  it("cancels the expected active run for a persisted chat", async () => {
+    const { createAgentCancelPost } = await import("../agent-cancel-route");
+    mockGetChatById.mockResolvedValue({
+      user_id: "user-1",
+      active_trigger_run_id: "run-1",
+      active_agent_approval_session_id: "approval-session-1",
+    } as never);
+
+    const response = await createAgentCancelPost({ endpoint: "/api/agent" })(
+      request({
+        chatId: "temporary-chat-1",
+        expectedTriggerRunId: "run-1",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockCancelAgentTriggerRun).toHaveBeenCalledWith("run-1");
+    expect(mockSetActiveTriggerRun).toHaveBeenCalledWith({
+      chatId: "temporary-chat-1",
+      triggerRunId: null,
+      approvalSessionId: null,
+      expectedRunId: "run-1",
+      expectedApprovalSessionId: "approval-session-1",
+      clearApprovalPending: true,
+    });
+  });
+
+  it("does not let a stale cancellation stop a replacement run", async () => {
+    const { createAgentCancelPost } = await import("../agent-cancel-route");
+    mockGetChatById.mockResolvedValue({
+      user_id: "user-1",
+      active_trigger_run_id: "run-2",
+    } as never);
+
+    const response = await createAgentCancelPost({ endpoint: "/api/agent" })(
+      request({
+        chatId: "temporary-chat-1",
+        expectedTriggerRunId: "run-1",
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      canceled: false,
+      reason: "stale_run",
+    });
+    expect(mockCloseAgentApprovalSession).not.toHaveBeenCalled();
+    expect(mockCancelAgentTriggerRun).not.toHaveBeenCalled();
+    expect(mockSetActiveTriggerRun).not.toHaveBeenCalled();
   });
 });

--- a/lib/api/agent-cancel-route.ts
+++ b/lib/api/agent-cancel-route.ts
@@ -47,15 +47,24 @@ export const createAgentCancelPost =
   ({ endpoint }: { endpoint: AgentApiEndpoint }) =>
   async (req: NextRequest) => {
     try {
-      let body: { chatId?: string };
+      let body: { chatId?: string; expectedTriggerRunId?: string };
       try {
         body = await req.json();
       } catch {
         return new NextResponse("Invalid JSON body", { status: 400 });
       }
-      const { chatId } = body;
+      const { chatId, expectedTriggerRunId } = body;
       if (!chatId || typeof chatId !== "string") {
         return new NextResponse("chatId required", { status: 400 });
+      }
+      if (
+        expectedTriggerRunId !== undefined &&
+        (typeof expectedTriggerRunId !== "string" ||
+          expectedTriggerRunId.length === 0)
+      ) {
+        return new NextResponse("expectedTriggerRunId must be a string", {
+          status: 400,
+        });
       }
 
       const { userId } = await getUserIDAndPro(req);
@@ -90,6 +99,12 @@ export const createAgentCancelPost =
         ? chat.active_agent_approval_session_id
         : temporaryRefresh?.approvalSessionId;
       const runId = chat ? chat.active_trigger_run_id : temporaryRefresh?.runId;
+      if (expectedTriggerRunId && runId !== expectedTriggerRunId) {
+        return NextResponse.json(
+          { canceled: false, reason: "stale_run" },
+          { status: 409 },
+        );
+      }
       await closeAgentApprovalSession(approvalSessionId, "agent-run-canceled");
       if (!runId) {
         if (approvalSessionId) {

--- a/lib/chat/__tests__/chat-processor.test.ts
+++ b/lib/chat/__tests__/chat-processor.test.ts
@@ -503,6 +503,29 @@ describe("fixIncompleteMessageParts", () => {
     });
   });
 
+  it("should identify output-limited tools without blaming the user", () => {
+    const parts = [
+      { type: "step-start" },
+      {
+        type: "tool-file",
+        toolCallId: "call_1",
+        state: "input-streaming",
+        input: { action: "write", path: "/tmp/result.py" },
+      },
+    ];
+
+    const result = fixIncompleteMessageParts(parts, {
+      logContext: { finishReason: "length" },
+    });
+
+    expect(result[1]).toMatchObject({
+      type: "tool-file",
+      state: "output-error",
+      errorText:
+        "The response reached its output limit before the tool completed.",
+    });
+  });
+
   it("should remove tool parts with input-streaming and no input", () => {
     const parts = [
       { type: "step-start" },

--- a/lib/chat/chat-processor.ts
+++ b/lib/chat/chat-processor.ts
@@ -19,6 +19,7 @@ import {
 } from "@/lib/ai/providers";
 import {
   ABORTED_TOOL_ERROR_TEXT,
+  getIncompleteToolErrorText,
   hasMeaningfulToolInput,
 } from "@/lib/chat/tool-abort-utils";
 import { stripOpenRouterReasoningMetadataFromMessages } from "@/lib/chat/provider-metadata-sanitizer";
@@ -216,7 +217,10 @@ function logIncompleteToolPartHandled({
   );
 }
 
-function createAbortedToolPart(part: any): any | null {
+function createAbortedToolPart(
+  part: any,
+  errorText = ABORTED_TOOL_ERROR_TEXT,
+): any | null {
   if (
     !ABORT_RENDERABLE_TOOL_TYPES.has(part.type) ||
     !part.toolCallId ||
@@ -229,7 +233,7 @@ function createAbortedToolPart(part: any): any | null {
   return {
     ...restPart,
     state: "output-error",
-    errorText: ABORTED_TOOL_ERROR_TEXT,
+    errorText,
   };
 }
 
@@ -268,7 +272,10 @@ export function fixIncompleteMessageParts(
 
     if (isIncomplete || hasWrongFormat) {
       if (isIncomplete && part.output == null && part.result == null) {
-        const abortedPart = createAbortedToolPart(part);
+        const abortedPart = createAbortedToolPart(
+          part,
+          getIncompleteToolErrorText(options?.logContext?.finishReason),
+        );
         if (abortedPart) {
           logIncompleteToolPartHandled({
             action: "converted_to_output_error",

--- a/lib/chat/tool-abort-utils.ts
+++ b/lib/chat/tool-abort-utils.ts
@@ -1,6 +1,16 @@
 export const ABORTED_TOOL_ERROR_TEXT =
   "Stopped by user before the tool completed.";
 
+export const OUTPUT_LIMIT_TOOL_ERROR_TEXT =
+  "The response reached its output limit before the tool completed.";
+
+export const getIncompleteToolErrorText = (
+  finishReason: string | undefined,
+): string =>
+  finishReason === "length"
+    ? OUTPUT_LIMIT_TOOL_ERROR_TEXT
+    : ABORTED_TOOL_ERROR_TEXT;
+
 export const isUserStoppedToolError = (errorText: unknown): boolean =>
   typeof errorText === "string" && /stopped|aborted/i.test(errorText);
 


### PR DESCRIPTION
## Summary
- preserve the real output-limit cause when an Agent file tool is interrupted instead of labeling it as a user stop
- cancel scheduled browser auto-continuations when manual submission resets the continuation lifecycle
- honor queue behavior while a run is still `submitted`, closing the gap where a second run could start
- scope Agent cancellation requests to the expected Trigger run so a stale request cannot cancel its replacement
- add regression coverage for output-limit copy, continuation timers, submitted-state queueing, and stale cancellation

## Root cause
When a long Agent response hit `finishReason: "length"` during a file tool, incomplete-tool normalization replaced the actual cause with `Stopped by user before the tool completed.` The client then scheduled a hidden auto-continuation. A manual send during the `submitted` transition could bypass the streaming-only queue check, while the pending 500 ms continuation timer could survive a lifecycle reset. Cancellation was addressed only by chat ID, so a delayed cancellation could target whichever run was active by the time the endpoint handled it.

This made output-limit recovery look like repeated self-cancellation and could cancel a replacement run.

## Validation
- `corepack pnpm test -- app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx app/hooks/__tests__/useChatHandlers.contracts.test.ts app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx app/hooks/__tests__/useChatHandlers.regenerate-sidebar.test.tsx app/hooks/__tests__/useAutoContinue.test.ts lib/api/__tests__/agent-cancel-route.test.ts lib/chat/__tests__/chat-processor.test.ts --runInBand` (108 tests)
- `corepack pnpm typecheck`
- targeted ESLint and Prettier checks for all changed files
- pre-commit full suite: 307 suites / 3,039 tests

## Manual verification
1. In a preview Agent chat, run a task that reaches the output limit during a file operation.
2. Confirm the incomplete tool says the response reached its output limit and the UI enters automatic continuation.
3. Submit a follow-up while the continuation is still starting; confirm it queues instead of starting a competing run.
4. Exercise Stop & send, retry, and regenerate; confirm cancellation targets the displayed active run and a stale cancellation cannot stop its replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented auto-continue actions from running after they are reset or canceled.
  * Improved cancellation safety by preventing stale agent runs from being canceled accidentally.
  * Added queueing support while a message is being submitted.
  * Improved tool error messages when output limits are reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->