### PR TITLE
Fix re-sharing and old invoice entitlement flaws

### DIFF
--- a/app/api/subscription/webhook/__tests__/route.test.ts
+++ b/app/api/subscription/webhook/__tests__/route.test.ts
@@ -547,8 +547,15 @@ describe("POST /api/subscription/webhook", () => {
     );
   });
 
-  it.each(["canceled", "incomplete_expired"] as const)(
-    "skips paid invoice side effects for a terminal %s subscription",
+  it.each([
+    "incomplete",
+    "incomplete_expired",
+    "past_due",
+    "canceled",
+    "unpaid",
+    "paused",
+  ] as const)(
+    "skips paid invoice side effects for a non-entitled %s subscription",
     async (subscriptionStatus) => {
       mockGetReferralRewardConfig.mockReturnValue({
         enabled: true,
@@ -590,6 +597,7 @@ describe("POST /api/subscription/webhook", () => {
       mockRetrieveSubscription.mockResolvedValue({
         id: "sub_terminal",
         status: subscriptionStatus,
+        latest_invoice: `in_${subscriptionStatus}`,
         canceled_at: subscriptionStatus === "canceled" ? 1_784_285_151 : null,
         ended_at: 1_784_285_151,
         metadata: {},
@@ -621,16 +629,18 @@ describe("POST /api/subscription/webhook", () => {
       expect(response.status).toBe(200);
       expect(body).toEqual({ received: true });
       expect(mockPostHogWarn).toHaveBeenCalledWith(
-        "billing_invoice_paid_terminal_subscription_skipped",
+        "billing_invoice_paid_ineligible_subscription_skipped",
         expect.objectContaining({
-          event: "billing_invoice_paid_terminal_subscription_skipped",
+          event: "billing_invoice_paid_ineligible_subscription_skipped",
           userId: "user_terminal",
           user_ids: ["user_terminal"],
           org_id: "org_terminal",
           stripe_customer_id: "cus_terminal",
           stripe_subscription_id: "sub_terminal",
           stripe_invoice_id: `in_${subscriptionStatus}`,
+          stripe_latest_invoice_id: `in_${subscriptionStatus}`,
           subscription_status: subscriptionStatus,
+          skip_reason: "subscription_not_entitled",
           billing_reason: "subscription_cycle",
           amount_paid_dollars: 25,
           requires_manual_reconciliation: true,
@@ -656,6 +666,102 @@ describe("POST /api/subscription/webhook", () => {
       );
     },
   );
+
+  it("does not restore benefits when an older invoice is paid", async () => {
+    mockGetReferralRewardConfig.mockReturnValue({
+      enabled: true,
+      referrerRewardDollars: 10,
+    });
+    mockConstructEvent.mockReturnValue({
+      id: "evt_invoice_paid_old",
+      type: "invoice.paid",
+      data: {
+        object: {
+          id: "in_old",
+          customer: "cus_old_invoice",
+          amount_paid: 2500,
+          currency: "usd",
+          billing_reason: "subscription_cycle",
+          parent: {
+            subscription_details: {
+              subscription: "sub_old_invoice",
+            },
+          },
+          status_transitions: {
+            paid_at: 1_784_456_277,
+          },
+        },
+      },
+    });
+    mockRetrieveCustomer.mockResolvedValue({
+      deleted: false,
+      id: "cus_old_invoice",
+      metadata: {
+        workOSOrganizationId: "org_old_invoice",
+      },
+    } as never);
+    mockListMemberships.mockResolvedValue({
+      autoPagination: jest
+        .fn()
+        .mockResolvedValue([{ userId: "user_old_invoice" }]),
+    } as never);
+    mockRetrieveSubscription.mockResolvedValue({
+      id: "sub_old_invoice",
+      status: "active",
+      latest_invoice: "in_current",
+      metadata: {},
+      items: {
+        data: [
+          {
+            quantity: 1,
+            current_period_end: 1_786_900_800,
+            price: {
+              id: "price_pro",
+              lookup_key: "pro-monthly-plan",
+              recurring: { interval: "month", interval_count: 1 },
+              product: {
+                id: "prod_pro",
+                name: "HackerAI Pro",
+                metadata: {},
+              },
+            },
+          },
+        ],
+      },
+    } as never);
+
+    const { POST } = await import("../route");
+
+    const response = await POST(makeWebhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockPostHogWarn).toHaveBeenCalledWith(
+      "billing_invoice_paid_ineligible_subscription_skipped",
+      expect.objectContaining({
+        event: "billing_invoice_paid_ineligible_subscription_skipped",
+        userId: "user_old_invoice",
+        user_ids: ["user_old_invoice"],
+        org_id: "org_old_invoice",
+        stripe_customer_id: "cus_old_invoice",
+        stripe_subscription_id: "sub_old_invoice",
+        stripe_invoice_id: "in_old",
+        stripe_latest_invoice_id: "in_current",
+        subscription_status: "active",
+        skip_reason: "invoice_not_current",
+        requires_manual_reconciliation: true,
+      }),
+    );
+    expect(mockResetRateLimitBucketAfterPayment).not.toHaveBeenCalled();
+    expect(mockApplyProratedTierChangeBucket).not.toHaveBeenCalled();
+    expect(mockConvexMutation).not.toHaveBeenCalledWith(
+      "referrals.setReferralCodesPaidEligibility",
+      expect.anything(),
+    );
+    expect(mockConvexMutation).not.toHaveBeenCalledWith(
+      "unitEconomics.recordRevenueEvent",
+      expect.anything(),
+    );
+  });
 
   it("resets the grandfathered $20 Pro price to $20 of included usage", async () => {
     const periodEnd = 1_785_000_000;
@@ -692,6 +798,8 @@ describe("POST /api/subscription/webhook", () => {
     } as never);
     mockRetrieveSubscription.mockResolvedValue({
       id: "sub_pro_20",
+      status: "active",
+      latest_invoice: "in_pro_20",
       metadata: {},
       items: {
         data: [
@@ -762,6 +870,8 @@ describe("POST /api/subscription/webhook", () => {
     } as never);
     mockRetrieveSubscription.mockResolvedValue({
       id: "sub_upgrade",
+      status: "active",
+      latest_invoice: "in_upgrade",
       metadata: {},
       items: {
         data: [

--- a/app/api/subscription/webhook/route.ts
+++ b/app/api/subscription/webhook/route.ts
@@ -43,9 +43,9 @@ const WEBHOOK_LOG_CONTEXT = {
   webhook: "subscription",
   route: "/api/subscription/webhook",
 };
-const TERMINAL_SUBSCRIPTION_STATUSES = new Set<Stripe.Subscription.Status>([
-  "canceled",
-  "incomplete_expired",
+const ENTITLED_SUBSCRIPTION_STATUSES = new Set<Stripe.Subscription.Status>([
+  "active",
+  "trialing",
 ]);
 
 // Linear ranking used to label tier transitions as upgrade/downgrade. Team is
@@ -782,19 +782,27 @@ async function handleInvoicePaid(
 
   const { tier, subscription } = resolved;
 
-  // Stripe can keep an invoice collectible after its subscription reaches a
-  // terminal state. Paying that invoice does not reactivate the subscription,
-  // so it must not restore paid eligibility, MRR, or usage credits.
-  if (TERMINAL_SUBSCRIPTION_STATUSES.has(subscription.status)) {
-    phLogger.warn("billing_invoice_paid_terminal_subscription_skipped", {
-      event: "billing_invoice_paid_terminal_subscription_skipped",
+  // A paid historical invoice does not reactivate its subscription. Only the
+  // current invoice of an entitled subscription may restore paid benefits.
+  const latestInvoiceId = stripeObjectId(subscription.latest_invoice);
+  const isEntitledSubscription = ENTITLED_SUBSCRIPTION_STATUSES.has(
+    subscription.status,
+  );
+  const isCurrentInvoice = latestInvoiceId === invoice.id;
+  if (!isEntitledSubscription || !isCurrentInvoice) {
+    phLogger.warn("billing_invoice_paid_ineligible_subscription_skipped", {
+      event: "billing_invoice_paid_ineligible_subscription_skipped",
       userId: userIds[0],
       user_ids: userIds,
       org_id: orgId,
       stripe_customer_id: customerId,
       stripe_subscription_id: subscription.id,
       stripe_invoice_id: invoice.id,
+      stripe_latest_invoice_id: latestInvoiceId,
       subscription_status: subscription.status,
+      skip_reason: !isEntitledSubscription
+        ? "subscription_not_entitled"
+        : "invoice_not_current",
       billing_reason: invoice.billing_reason,
       amount_paid_dollars: centsToDollars(invoice.amount_paid),
       canceled_at: subscription.canceled_at,

--- a/convex/lib/__tests__/branchedChatTitle.test.ts
+++ b/convex/lib/__tests__/branchedChatTitle.test.ts
@@ -18,19 +18,19 @@ describe("resolveBranchedFromTitle", () => {
     ).toBe("Current title");
   });
 
-  it("keeps live titles while another user's source remains shared", () => {
+  it("keeps the fork-time title when another user re-shares the source", () => {
     expect(
       resolveBranchedFromTitle(
         fork,
         {
-          title: "Current shared title",
+          title: "Private title after re-sharing",
           user_id: "owner",
-          share_id: "share-1",
-          share_date: 1,
+          share_id: "replacement-share",
+          share_date: 2,
         },
         "viewer",
       ),
-    ).toBe("Current shared title");
+    ).toBe("Title when forked");
   });
 
   it("uses the fork-time title after another user's share is revoked", () => {

--- a/convex/lib/branchedChatTitle.ts
+++ b/convex/lib/branchedChatTitle.ts
@@ -11,20 +11,17 @@ type SourceChatTitleRecord = {
 };
 
 /**
- * Preserve live source titles only while the viewer is authorized to see the
- * source chat. Revoked cross-user shares use the title captured at fork time;
- * legacy forks fall back to their own title instead of exposing later changes.
+ * Preserve live source titles only for forks of the viewer's own chats.
+ * Cross-user forks always use the title captured at fork time so revoking and
+ * later replacing a share cannot expose a private rename through the old fork.
+ * Legacy forks fall back to their own title.
  */
 export const resolveBranchedFromTitle = (
   forkedChat: ForkedChatTitleRecord,
   sourceChat: SourceChatTitleRecord | null | undefined,
   viewerUserId: string,
 ): string => {
-  const canReadLiveSourceTitle =
-    sourceChat?.user_id === viewerUserId ||
-    (sourceChat?.share_id !== undefined && sourceChat.share_date !== undefined);
-
-  if (sourceChat && canReadLiveSourceTitle) {
+  if (sourceChat?.user_id === viewerUserId) {
     return sourceChat.title;
   }
 


### PR DESCRIPTION
## Summary
- freeze cross-user fork titles at the fork-time snapshot so a later replacement share cannot expose a private rename
- restore paid benefits only when an `invoice.paid` event belongs to the subscription's current invoice and the subscription is entitled
- cover all non-entitled Stripe subscription states and preserve valid owner-title and current-invoice behavior

## Why
Two validated Codex Security findings remained actionable:

1. A user with a historical fork could see the source chat's current private title after the owner created a replacement share.
2. Paying an older Stripe invoice could restore referral eligibility, revenue state, and included usage while a newer invoice remained unpaid.

The title resolver treated any current share as authorization for every historical fork. The billing webhook excluded only terminal subscription states and did not bind the paid event to `subscription.latest_invoice`.

## Validation
- `corepack pnpm typecheck`
- `corepack pnpm test` — 310 suites, 3,064 tests passed
- focused security and surrounding regression suites — 5 suites, 49 tests passed
- ESLint, Prettier, and `git diff --check`

## Manual verification
- Fork another user's shared chat, revoke the share, rename the source, and create a replacement share. The historical fork should retain its fork-time source title.
- In Stripe test mode, pay an older invoice while a newer subscription invoice remains unpaid. The webhook should record an ineligible-subscription warning without restoring referral eligibility or usage credits.
- Pay the current invoice so the subscription becomes active. Normal benefit restoration should still succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented subscription benefits and credits from being restored for ineligible subscriptions or when an older invoice is paid.
  * Improved billing event tracking with clearer skip reasons and subscription details.
  * Preserved the original fork-time title when viewing chats branched from another user’s chat.
  * Continued showing live titles for chats branched from the viewer’s own chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->