### PR TITLE
Handle current OpenRouter encrypted reasoning

### DIFF
--- a/lib/ai/__tests__/providers.test.ts
+++ b/lib/ai/__tests__/providers.test.ts
@@ -79,9 +79,10 @@ describe("sanitizeOpenRouterRequestForXai", () => {
           reasoning_details: [
             { type: "text", text: "plain reasoning detail" },
             {
-              type: "encrypted",
-              encrypted_content: "provider-private-reasoning-blob",
+              type: "reasoning.encrypted",
+              data: "provider-private-reasoning-blob",
             },
+            { type: "encrypted", encrypted_content: "legacy-provider-blob" },
           ],
         },
       ],
@@ -100,8 +101,12 @@ describe("sanitizeOpenRouterRequestForXai", () => {
         },
       ],
     });
-    expect(JSON.stringify(result.body)).not.toContain("encrypted_content");
-    expect(JSON.stringify(body)).toContain("encrypted_content");
+    expect(JSON.stringify(result.body)).not.toContain(
+      "provider-private-reasoning-blob",
+    );
+    expect(JSON.stringify(result.body)).not.toContain("legacy-provider-blob");
+    expect(JSON.stringify(body)).toContain("provider-private-reasoning-blob");
+    expect(JSON.stringify(body)).toContain("legacy-provider-blob");
   });
 
   it("removes reasoning_details when every detail is encrypted", () => {
@@ -112,7 +117,7 @@ describe("sanitizeOpenRouterRequestForXai", () => {
           role: "assistant",
           content: "Visible text stays.",
           reasoning_details: [
-            { type: "encrypted", encrypted_content: "x-provider-blob" },
+            { type: "reasoning.encrypted", data: "x-provider-blob" },
           ],
         },
       ],
@@ -167,6 +172,10 @@ describe("sanitizeOpenRouterRequestForXai", () => {
               type: "input_json",
               encrypted_content: "user-owned-data",
             },
+            {
+              type: "reasoning.encrypted",
+              data: "user-owned-reasoning-shaped-data",
+            },
           ],
         },
         {
@@ -192,6 +201,9 @@ describe("sanitizeOpenRouterRequestForXai", () => {
     expect(result.changed).toBe(false);
     expect(result.body).toBe(body);
     expect(JSON.stringify(result.body)).toContain("user-owned-data");
+    expect(JSON.stringify(result.body)).toContain(
+      "user-owned-reasoning-shaped-data",
+    );
     expect(JSON.stringify(result.body)).toContain("tool-owned-data");
   });
 });

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -18,6 +18,11 @@ const requestCanRouteToXai = (body: unknown): boolean => {
 const hasOwnEncryptedContent = (value: unknown): boolean =>
   isRecord(value) && Object.hasOwn(value, "encrypted_content");
 
+// OpenRouter 2.10 uses this shape for provider-private reasoning blobs.
+const isEncryptedReasoningDetail = (value: unknown): boolean =>
+  isRecord(value) &&
+  (hasOwnEncryptedContent(value) || value.type === "reasoning.encrypted");
+
 const stripEncryptedContent = (
   value: unknown,
   inReasoningDetails = false,
@@ -27,7 +32,7 @@ const stripEncryptedContent = (
     const cleaned: unknown[] = [];
 
     for (const item of value) {
-      if (inReasoningDetails && hasOwnEncryptedContent(item)) {
+      if (inReasoningDetails && isEncryptedReasoningDetail(item)) {
         changed = true;
         continue;
       }


### PR DESCRIPTION
## Summary

- remove OpenRouter's current `reasoning.encrypted` provider-private entries before requests that can route to xAI
- preserve the legacy encrypted-detail repair and arbitrary user/tool `data` outside `reasoning_details`
- cover direct Grok, xAI fallback, mixed reasoning details, non-xAI routes, and out-of-scope user/tool data

## Production evidence

Frozen audit window: `2026-07-29T20:03:54.961Z` through `2026-07-30T20:03:54.961Z`.

- Trigger.dev recorded 37 terminal failures across 26 opaque users/chats, versus 2 in the prior equivalent window. The exact provider error was: `Could not decrypt the provided encrypted_content. Ensure the value is the unmodified encrypted_content from a previous response.`
- PostHog recorded 38 handled occurrences affecting 29 users, versus 3 previously.
- Representative Trigger traces `run_06fr71u211sif0fuvbcvv8po01`, `run_06fr8grdeifmjntqagadhi7mc1`, and `run_06fr93frmpodnngue9r286c801` failed after retained reasoning history reached Grok, including direct Grok, fallback routing, and post-compaction paths.
- 33 Trigger failures occurred on the current production worker, so this is not pre-deployment evidence for a recently fixed issue.

## Root cause

The request sanitizer handled the legacy `{ encrypted_content }` representation only. The installed `@openrouter/ai-sdk-provider@2.10.0` serializes opaque reasoning as `{ type: "reasoning.encrypted", data: string }` inside assistant `reasoning_details`, so those provider-private blobs reached xAI unchanged and were rejected.

## Change

The shared OpenRouter fetch boundary now removes either encrypted representation only while traversing `reasoning_details` for a request that directly targets or can fall back to xAI. Visible assistant text, non-encrypted reasoning details, non-xAI requests, and arbitrary user/tool data are unchanged.

This boundary is shared by Ask, Agent, summarization, retries, and fallback requests. No provider routing, model behavior, public payload, persistence schema, structured log, or cross-worker contract changes.

## Validation

- `corepack pnpm jest lib/ai/__tests__/providers.test.ts --runInBand` — 21 tests passed
- `corepack pnpm typecheck` — passed
- changed-file ESLint and Prettier — passed
- commit hooks — 310 suites / 3,064 tests passed; typecheck passed
- adversarial review covered direct/fallback routes, all shared provider callers, retry scope, compaction history, non-xAI behavior, user/tool data preservation, and deploy skew

## Manual verification

After deployment, continue an internal Agent chat with retained reasoning history through compaction and an xAI direct/fallback request. Confirm the run continues without the decrypt 400, visible assistant/tool history remains available, and pre-deployment failures are excluded from the post-fix watch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling for encrypted reasoning metadata when routing requests to xAI.
  * Prevented provider-private reasoning details from being forwarded while preserving supported non-provider data.
  * Ensured original request contents remain unchanged during sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->