### PR TITLE
Limit message editing to the latest user turn

### DIFF
--- a/__mocks__/@legendapp/list-react.tsx
+++ b/__mocks__/@legendapp/list-react.tsx
@@ -1,7 +1,7 @@
 import {
-  Fragment,
   forwardRef,
   isValidElement,
+  memo,
   useImperativeHandle,
   useRef,
   type ComponentType,
@@ -20,11 +20,42 @@ const renderOptionalComponent = (component: OptionalComponent) => {
   return isValidElement(component) ? component : null;
 };
 
+type MockLegendListItemProps = {
+  data: readonly unknown[];
+  extraData: unknown;
+  index: number;
+  item: unknown;
+  renderItem: (info: {
+    data: readonly unknown[];
+    extraData: unknown;
+    index: number;
+    item: unknown;
+  }) => ReactNode;
+};
+
+const MockLegendListItem = memo(
+  function MockLegendListItem({
+    data,
+    extraData,
+    index,
+    item,
+    renderItem,
+  }: MockLegendListItemProps) {
+    return renderItem({ data, extraData, index, item });
+  },
+  (previous, next) =>
+    previous.data === next.data &&
+    previous.extraData === next.extraData &&
+    previous.index === next.index &&
+    previous.item === next.item,
+);
+
 export const LegendList = forwardRef(function MockLegendList<
   Item extends unknown,
 >(
   {
     data,
+    extraData,
     renderItem,
     keyExtractor,
     ListHeaderComponent,
@@ -34,7 +65,13 @@ export const LegendList = forwardRef(function MockLegendList<
     "data-testid": dataTestId,
   }: {
     data: Item[];
-    renderItem: (info: { item: Item; index: number }) => ReactNode;
+    extraData?: unknown;
+    renderItem: (info: {
+      data: readonly Item[];
+      extraData: unknown;
+      item: Item;
+      index: number;
+    }) => ReactNode;
     keyExtractor?: (item: Item, index: number) => string;
     ListHeaderComponent?: OptionalComponent;
     ListFooterComponent?: OptionalComponent;
@@ -66,9 +103,14 @@ export const LegendList = forwardRef(function MockLegendList<
       <div className="legend-list-content-container">
         {renderOptionalComponent(ListHeaderComponent)}
         {data.map((item, index) => (
-          <Fragment key={keyExtractor?.(item, index) ?? index}>
-            {renderItem({ item, index })}
-          </Fragment>
+          <MockLegendListItem
+            key={keyExtractor?.(item, index) ?? index}
+            data={data}
+            extraData={extraData}
+            index={index}
+            item={item}
+            renderItem={renderItem as MockLegendListItemProps["renderItem"]}
+          />
         ))}
         {renderOptionalComponent(ListFooterComponent)}
       </div>

--- a/app/components/MessageActions.tsx
+++ b/app/components/MessageActions.tsx
@@ -23,6 +23,7 @@ interface MessageActionsProps {
   canRegenerate: boolean;
   onRegenerate: () => void | Promise<void>;
   onEdit: () => void;
+  canEdit: boolean;
   onBranch?: () => void;
   isHovered: boolean;
   isEditing: boolean;
@@ -129,6 +130,7 @@ export const MessageActions = ({
   canRegenerate,
   onRegenerate,
   onEdit,
+  canEdit,
   onBranch,
   isHovered,
   isEditing,
@@ -249,8 +251,8 @@ export const MessageActions = ({
               delayDuration={300}
             />
 
-            {/* Show edit only for user messages */}
-            {isUser && (
+            {/* Only the latest user-authored message can be edited. */}
+            {isUser && canEdit && (
               <WithTooltip
                 display={"Edit message"}
                 trigger={

--- a/app/components/MessageItem.tsx
+++ b/app/components/MessageItem.tsx
@@ -57,6 +57,7 @@ interface MessageItemProps {
   messagesLength: number;
   lastAssistantMessageIndex: number | undefined;
   status: ChatStatus;
+  canEdit: boolean;
   isEditing: boolean;
   isMobile?: boolean;
   feedbackInputMessageId: string | null;
@@ -99,6 +100,7 @@ function areMessageItemPropsEqual(
 ): boolean {
   // Always re-render if these change
   if (prev.status !== next.status) return false;
+  if (prev.canEdit !== next.canEdit) return false;
   if (prev.isEditing !== next.isEditing) return false;
   if (prev.isMobile !== next.isMobile) return false;
   if (prev.feedbackInputMessageId !== next.feedbackInputMessageId) return false;
@@ -155,6 +157,7 @@ export const MessageItem = memo(function MessageItem({
   messagesLength,
   lastAssistantMessageIndex,
   status,
+  canEdit,
   isEditing,
   isMobile,
   feedbackInputMessageId,
@@ -667,6 +670,7 @@ export const MessageItem = memo(function MessageItem({
           canRegenerate={canRegenerate}
           onRegenerate={onRegenerate}
           onEdit={handleEdit}
+          canEdit={canEdit}
           onBranch={!isUser && onBranchMessage ? handleBranch : undefined}
           isHovered={isHovered}
           isEditing={isEditing}

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -602,6 +602,7 @@ export const Messages = ({
         <LegendList<ChatTimelineRow>
           ref={setTimelineInstance}
           data={timelineRows}
+          extraData={editingMessageId}
           keyExtractor={getTimelineRowKey}
           getItemType={getChatTimelineRowType}
           renderItem={renderTimelineRow}

--- a/app/components/Messages.tsx
+++ b/app/components/Messages.tsx
@@ -22,7 +22,10 @@ import Loading from "@/components/ui/loading";
 import { useFeedback } from "../hooks/useFeedback";
 import { useFileUrlCache } from "../hooks/useFileUrlCache";
 import { FileUrlCacheProvider } from "../contexts/FileUrlCacheContext";
-import { findLastAssistantMessageIndex } from "@/lib/utils/message-utils";
+import {
+  findLastAssistantMessageIndex,
+  findLastUserMessageIndex,
+} from "@/lib/utils/message-utils";
 import type { ChatStatus, ChatMessage } from "@/types";
 import type { FileDetails } from "@/types/file";
 import type { RetryOptions } from "../hooks/useChatHandlers";
@@ -153,6 +156,14 @@ export const Messages = ({
     return findLastAssistantMessageIndex(visibleMessages);
   }, [visibleMessages]);
 
+  const lastUserMessageIndex = useMemo(() => {
+    return findLastUserMessageIndex(visibleMessages);
+  }, [visibleMessages]);
+  const lastUserMessageId =
+    lastUserMessageIndex === undefined
+      ? undefined
+      : visibleMessages[lastUserMessageIndex]?.id;
+
   // Check if last assistant message has any content (text or files)
   const lastAssistantHasContent = useMemo(() => {
     if (lastAssistantMessageIndex === undefined) return false;
@@ -249,13 +260,18 @@ export const Messages = ({
   // Sidebar auto-open removed - sidebar only opens via manual clicks
 
   // Memoized edit handlers to prevent unnecessary re-renders
-  const handleStartEdit = useCallback((messageId: string) => {
-    setEditingMessageId(messageId);
-  }, []);
+  const handleStartEdit = useCallback(
+    (messageId: string) => {
+      if (messageId === lastUserMessageId) {
+        setEditingMessageId(messageId);
+      }
+    },
+    [lastUserMessageId],
+  );
 
   const handleSaveEdit = useCallback(
     async (newContent: string, remainingFileIds: string[]) => {
-      if (editingMessageId) {
+      if (editingMessageId && editingMessageId === lastUserMessageId) {
         try {
           await onEditMessage(editingMessageId, newContent, remainingFileIds);
         } catch (error) {
@@ -266,7 +282,7 @@ export const Messages = ({
         }
       }
     },
-    [editingMessageId, onEditMessage],
+    [editingMessageId, lastUserMessageId, onEditMessage],
   );
 
   const handleCancelEdit = useCallback(() => {
@@ -458,7 +474,11 @@ export const Messages = ({
             messagesLength={visibleMessages.length}
             lastAssistantMessageIndex={lastAssistantMessageIndex}
             status={status}
-            isEditing={editingMessageId === row.message.id}
+            canEdit={row.messageIndex === lastUserMessageIndex}
+            isEditing={
+              editingMessageId === lastUserMessageId &&
+              editingMessageId === row.message.id
+            }
             isMobile={isMobile}
             feedbackInputMessageId={feedbackInputMessageId}
             tempChatFileDetails={tempChatFileDetails}
@@ -518,6 +538,8 @@ export const Messages = ({
       isMobile,
       isTemporaryChat,
       lastAssistantMessageIndex,
+      lastUserMessageId,
+      lastUserMessageIndex,
       mode,
       onBranchMessage,
       onContinue,

--- a/app/components/__tests__/MessageActions.edit.test.tsx
+++ b/app/components/__tests__/MessageActions.edit.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, jest } from "@jest/globals";
+
+jest.mock("@/components/ui/with-tooltip", () => ({
+  WithTooltip: ({ trigger }: { trigger: React.ReactNode }) => trigger,
+}));
+
+const { MessageActions } =
+  require("../MessageActions") as typeof import("../MessageActions");
+
+const renderUserActions = (canEdit: boolean, onEdit = jest.fn()) => {
+  render(
+    <MessageActions
+      messageText="Question"
+      isUser
+      isLastAssistantMessage={false}
+      canRegenerate={false}
+      onRegenerate={jest.fn()}
+      onEdit={onEdit}
+      canEdit={canEdit}
+      isHovered
+      isEditing={false}
+      status="ready"
+    />,
+  );
+
+  return onEdit;
+};
+
+describe("MessageActions editing", () => {
+  it("does not offer editing for an older user message", () => {
+    renderUserActions(false);
+
+    expect(
+      screen.queryByRole("button", { name: "Edit message" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers editing for the latest user message", () => {
+    const onEdit = renderUserActions(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit message" }));
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/__tests__/MessageItem.worked-for.test.tsx
+++ b/app/components/__tests__/MessageItem.worked-for.test.tsx
@@ -100,6 +100,7 @@ const renderMessageItem = ({
       messagesLength={1}
       lastAssistantMessageIndex={0}
       status={status}
+      canEdit={message.role === "user"}
       isHovered={false}
       isEditing={false}
       feedbackInputMessageId={null}
@@ -405,6 +406,7 @@ describe("MessageItem WorkedFor rendering", () => {
         messagesLength={1}
         lastAssistantMessageIndex={0}
         status="ready"
+        canEdit={false}
         isHovered={false}
         isEditing={false}
         feedbackInputMessageId={null}

--- a/app/components/__tests__/Messages.edit.test.tsx
+++ b/app/components/__tests__/Messages.edit.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { DataStreamProvider } from "../DataStreamProvider";
+import { Messages } from "../Messages";
+import type { ChatMessage } from "@/types";
+
+jest.mock("../MessageItem", () => ({
+  MessageItem: ({
+    canEdit,
+    isEditing,
+    message,
+    onStartEdit,
+  }: {
+    canEdit: boolean;
+    isEditing: boolean;
+    message: ChatMessage;
+    onStartEdit: (messageId: string) => void;
+  }) => (
+    <div data-testid={`message-${message.id}`}>
+      {isEditing ? (
+        <div data-testid="message-editor">Editing {message.id}</div>
+      ) : canEdit ? (
+        <button
+          type="button"
+          aria-label="Edit message"
+          onClick={() => onStartEdit(message.id)}
+        >
+          Edit
+        </button>
+      ) : null}
+    </div>
+  ),
+}));
+
+jest.mock("../AgentActivityRow", () => ({
+  AgentActivityRow: () => null,
+}));
+
+jest.mock("../AgentWorkHeader", () => ({
+  AgentWorkHeader: () => null,
+}));
+
+jest.mock("../../hooks/useFileUrlCache", () => ({
+  useFileUrlCache: () => ({
+    getCachedUrl: jest.fn(),
+    setCachedUrl: jest.fn(),
+  }),
+}));
+
+jest.mock("../../hooks/useFeedback", () => ({
+  useFeedback: () => ({
+    feedbackInputMessageId: null,
+    handleFeedback: jest.fn(),
+    handleFeedbackSubmit: jest.fn(),
+    handleFeedbackCancel: jest.fn(),
+  }),
+}));
+
+const messages = [
+  {
+    id: "user-1",
+    role: "user",
+    parts: [{ type: "text", text: "Question" }],
+  },
+  {
+    id: "assistant-1",
+    role: "assistant",
+    parts: [{ type: "text", text: "Answer" }],
+  },
+] as ChatMessage[];
+
+describe("Messages editing", () => {
+  it("invalidates the virtualized row when editing starts", () => {
+    render(
+      <DataStreamProvider>
+        <Messages
+          messages={messages}
+          setMessages={jest.fn()}
+          onRegenerate={jest.fn()}
+          onRetry={jest.fn()}
+          onEditMessage={jest.fn()}
+          status="ready"
+          error={null}
+          scrollRef={createRef<HTMLElement>()}
+          contentRef={createRef<HTMLElement>()}
+          isMobile
+        />
+      </DataStreamProvider>,
+    );
+
+    expect(screen.queryByTestId("message-editor")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit message" }));
+
+    expect(screen.getByTestId("message-editor")).toHaveTextContent(
+      "Editing user-1",
+    );
+  });
+});

--- a/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.regenerate-model.test.tsx
@@ -279,6 +279,54 @@ describe("useChatHandlers regenerate model", () => {
     );
   });
 
+  it("rejects editing an older user message before cancelling or regenerating", async () => {
+    mockTemporaryChatsEnabled = false;
+    const fetchMock = jest.fn(
+      async () => ({ ok: true, status: 200 }) as Response,
+    );
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+    const multiTurnMessages = [
+      messages[0],
+      messages[1],
+      {
+        id: "user-2",
+        role: "user",
+        parts: [{ type: "text", text: "Follow-up question" }],
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        parts: [{ type: "text", text: "Follow-up answer" }],
+      },
+    ] as ChatMessage[];
+    const { result } = renderHook(() =>
+      useChatHandlers({
+        chatId: "chat-1",
+        messages: multiTurnMessages,
+        sendMessage: mockSendMessage,
+        stop: jest.fn(),
+        regenerate: mockRegenerate,
+        setMessages: mockSetMessages,
+        isExistingChat: true,
+        status: "streaming",
+        isSendingNowRef: { current: false },
+        hasManuallyStoppedRef: { current: false },
+        activeTriggerRunRef: { current: "run-1" },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleEditMessage("user-1", "Edited question");
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mockRegenerate).not.toHaveBeenCalled();
+    expect(mockSetMessages).not.toHaveBeenCalled();
+  });
+
   it("cancels a restored Trigger run even when the current mode is ask", async () => {
     mockTemporaryChatsEnabled = false;
     const fetchMock = jest.fn(

--- a/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
@@ -303,4 +303,36 @@ describe("useChatHandlers steer todo handoff", () => {
     expect(mockSetMessages).not.toHaveBeenCalled();
     expect(regenerate).not.toHaveBeenCalled();
   });
+
+  it("does not clean local state or regenerate when the persisted edit fails", async () => {
+    mockRegenerateWithNewContent.mockRejectedValueOnce(
+      new Error("write failed"),
+    );
+    const regenerate = jest.fn();
+    const { result } = renderHook(() =>
+      useChatHandlers({
+        chatId: "chat-1",
+        messages,
+        sendMessage: mockSendMessage,
+        stop: mockStop,
+        regenerate,
+        setMessages: mockSetMessages,
+        isExistingChat: true,
+        status: "ready",
+        isSendingNowRef: { current: false },
+        hasManuallyStoppedRef: { current: false },
+        activeTriggerRunRef: { current: undefined },
+      }),
+    );
+
+    await act(async () => {
+      await expect(
+        result.current.handleEditMessage("user-1", "Edited task"),
+      ).rejects.toThrow("write failed");
+    });
+
+    expect(mockSetTodos).not.toHaveBeenCalled();
+    expect(mockSetMessages).not.toHaveBeenCalled();
+    expect(regenerate).not.toHaveBeenCalled();
+  });
 });

--- a/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
+++ b/app/hooks/__tests__/useChatHandlers.steer-todos.test.tsx
@@ -12,6 +12,7 @@ const mockQueueMessage = jest.fn();
 const mockSendMessage = jest.fn(async () => undefined);
 const mockStop = jest.fn();
 const mockSetMessages = jest.fn();
+const mockSetTodos = jest.fn();
 let mockInput = "";
 
 const todos: Todo[] = [
@@ -62,7 +63,7 @@ jest.mock("@/app/contexts/GlobalState", () => ({
     clearInput: jest.fn(),
     clearUploadedFiles: jest.fn(),
     todos,
-    setTodos: jest.fn(),
+    setTodos: mockSetTodos,
     isUploadingFiles: false,
     subscription: "pro",
     temporaryChatsEnabled: false,
@@ -267,5 +268,39 @@ describe("useChatHandlers steer todo handoff", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
     expect(mockRemoveQueuedMessage).not.toHaveBeenCalled();
     expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not clean local state or regenerate when the server rejects a stale edit", async () => {
+    mockRegenerateWithNewContent.mockRejectedValueOnce({
+      data: {
+        code: "MESSAGE_NOT_EDITABLE",
+        message: "Only the latest user message can be edited",
+      },
+    });
+    const regenerate = jest.fn();
+    const { result } = renderHook(() =>
+      useChatHandlers({
+        chatId: "chat-1",
+        messages,
+        sendMessage: mockSendMessage,
+        stop: mockStop,
+        regenerate,
+        setMessages: mockSetMessages,
+        isExistingChat: true,
+        status: "ready",
+        isSendingNowRef: { current: false },
+        hasManuallyStoppedRef: { current: false },
+        activeTriggerRunRef: { current: undefined },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleEditMessage("user-1", "Edited task");
+    });
+
+    expect(mockRegenerateWithNewContent).toHaveBeenCalledTimes(1);
+    expect(mockSetTodos).not.toHaveBeenCalled();
+    expect(mockSetMessages).not.toHaveBeenCalled();
+    expect(regenerate).not.toHaveBeenCalled();
   });
 });

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -723,8 +723,7 @@ export const useChatHandlers = ({
           return;
         }
 
-        // Swallow benign errors (e.g., racing edits where the message was already removed)
-        // Avoid logging to keep console clean
+        throw error;
       }
     }
 

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -64,6 +64,20 @@ export type RetryOptions = {
   limitRescue?: LimitRescueRequest;
 };
 
+const getConvexErrorCode = (error: unknown): string | undefined => {
+  if (!error || typeof error !== "object" || !("data" in error)) {
+    return undefined;
+  }
+
+  const data = (error as { data?: unknown }).data;
+  if (!data || typeof data !== "object" || !("code" in data)) {
+    return undefined;
+  }
+
+  const code = (data as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+};
+
 export const useChatHandlers = ({
   chatId,
   messages,
@@ -696,6 +710,24 @@ export const useChatHandlers = ({
     // Find the edited message index to identify subsequent messages
     const editedMessageIndex = messages.findIndex((m) => m.id === messageId);
 
+    if (!temporaryChatsEnabled) {
+      try {
+        await regenerateWithNewContent({
+          messageId: messageId as Id<"messages">,
+          newContent,
+          fileIds: remainingFileIds,
+        });
+      } catch (error) {
+        if (getConvexErrorCode(error) === "MESSAGE_NOT_EDITABLE") {
+          toast.error("Only the latest user message can be edited.");
+          return;
+        }
+
+        // Swallow benign errors (e.g., racing edits where the message was already removed)
+        // Avoid logging to keep console clean
+      }
+    }
+
     if (editedMessageIndex !== -1) {
       // Get all subsequent messages (both user and assistant) that will be removed
       const subsequentMessages = messages.slice(editedMessageIndex + 1);
@@ -711,19 +743,6 @@ export const useChatHandlers = ({
       if (idsToClean.length > 0) {
         const updatedTodos = removeTodosBySourceMessages(todos, idsToClean);
         setTodos(updatedTodos);
-      }
-    }
-
-    if (!temporaryChatsEnabled) {
-      try {
-        await regenerateWithNewContent({
-          messageId: messageId as Id<"messages">,
-          newContent,
-          fileIds: remainingFileIds,
-        });
-      } catch (error) {
-        // Swallow benign errors (e.g., racing edits where the message was already removed)
-        // Avoid logging to keep console clean
       }
     }
 

--- a/app/hooks/useChatHandlers.ts
+++ b/app/hooks/useChatHandlers.ts
@@ -28,6 +28,7 @@ import { normalizeMessages } from "@/lib/utils/message-processor";
 import {
   getAutoContinueChainAssistantIds,
   getMessagesUpToLastRealUser,
+  findLastUserMessageIndex,
 } from "@/lib/utils/message-utils";
 import {
   createFileMessagePartFromUploadedFile,
@@ -675,6 +676,15 @@ export const useChatHandlers = ({
     newContent: string,
     remainingFileIds?: string[],
   ) => {
+    const lastUserMessageIndex = findLastUserMessageIndex(messages);
+    if (
+      lastUserMessageIndex === undefined ||
+      messages[lastUserMessageIndex]?.id !== messageId
+    ) {
+      toast.error("Only the latest user message can be edited.");
+      return;
+    }
+
     setIsAutoResuming(false);
 
     // Stop any active stream first to prevent message order issues and wasted tokens

--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -1557,6 +1557,69 @@ describe("regenerateWithNewContent feedback cleanup", () => {
     );
   });
 
+  it("should reject editing a user message when a newer visible user message exists", async () => {
+    const editedUserMessage = {
+      _id: "user-doc-1" as Id<"messages">,
+      id: "user-msg-1",
+      chat_id: CHAT_ID,
+      user_id: USER_ID,
+      role: "user",
+      parts: [{ type: "text", text: "old prompt" }],
+      content: "old prompt",
+      _creationTime: 1000,
+      file_ids: undefined,
+    };
+    const laterUserMessage = {
+      _id: "user-doc-2" as Id<"messages">,
+      id: "user-msg-2",
+      chat_id: CHAT_ID,
+      user_id: USER_ID,
+      role: "user",
+      parts: [{ type: "text", text: "newer prompt" }],
+      content: "newer prompt",
+      _creationTime: 3000,
+      file_ids: undefined,
+      is_hidden: undefined,
+    };
+
+    mockCtx.db.query.mockImplementation((table: string) => {
+      if (table !== "messages") {
+        throw new Error(`Unexpected table ${table}`);
+      }
+
+      return {
+        withIndex: jest.fn((indexName: string) => {
+          if (indexName === "by_message_id") {
+            return {
+              first: jest.fn<any>().mockResolvedValue(editedUserMessage),
+            };
+          }
+          if (indexName === "by_chat_id") {
+            return {
+              collect: jest.fn<any>().mockResolvedValue([laterUserMessage]),
+            };
+          }
+          throw new Error(`Unexpected messages index ${indexName}`);
+        }),
+      };
+    });
+
+    const { regenerateWithNewContent } = await import("../messages");
+
+    await expect(
+      regenerateWithNewContent.handler(mockCtx, {
+        messageId: editedUserMessage.id,
+        newContent: "edited prompt",
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({
+        code: "MESSAGE_NOT_EDITABLE",
+      }),
+    });
+    expect(mockCtx.db.patch).not.toHaveBeenCalled();
+    expect(mockCtx.db.delete).not.toHaveBeenCalled();
+  });
+
   it("should clear stale summaries when the edited message is covered by the latest summary", async () => {
     const editedUserMessage = {
       _id: "user-doc-1" as Id<"messages">,

--- a/convex/__tests__/chatSummaryFallback.test.ts
+++ b/convex/__tests__/chatSummaryFallback.test.ts
@@ -1620,6 +1620,58 @@ describe("regenerateWithNewContent feedback cleanup", () => {
     expect(mockCtx.db.delete).not.toHaveBeenCalled();
   });
 
+  it("should reject editing a hidden auto-continue user message", async () => {
+    const hiddenUserMessage = {
+      _id: "hidden-user-doc" as Id<"messages">,
+      id: "hidden-user-msg",
+      chat_id: CHAT_ID,
+      user_id: USER_ID,
+      role: "user",
+      parts: [{ type: "text", text: "Continue from where you left off." }],
+      content: "Continue from where you left off.",
+      _creationTime: 3000,
+      file_ids: undefined,
+      is_hidden: true,
+    };
+
+    mockCtx.db.query.mockImplementation((table: string) => {
+      if (table !== "messages") {
+        throw new Error(`Unexpected table ${table}`);
+      }
+
+      return {
+        withIndex: jest.fn((indexName: string) => {
+          if (indexName === "by_message_id") {
+            return {
+              first: jest.fn<any>().mockResolvedValue(hiddenUserMessage),
+            };
+          }
+          if (indexName === "by_chat_id") {
+            return {
+              collect: jest.fn<any>().mockResolvedValue([]),
+            };
+          }
+          throw new Error(`Unexpected messages index ${indexName}`);
+        }),
+      };
+    });
+
+    const { regenerateWithNewContent } = await import("../messages");
+
+    await expect(
+      regenerateWithNewContent.handler(mockCtx, {
+        messageId: hiddenUserMessage.id,
+        newContent: "edited hidden prompt",
+      }),
+    ).rejects.toMatchObject({
+      data: expect.objectContaining({
+        code: "MESSAGE_NOT_EDITABLE",
+      }),
+    });
+    expect(mockCtx.db.patch).not.toHaveBeenCalled();
+    expect(mockCtx.db.delete).not.toHaveBeenCalled();
+  });
+
   it("should clear stale summaries when the edited message is covered by the latest summary", async () => {
     const editedUserMessage = {
       _id: "user-doc-1" as Id<"messages">,

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1986,6 +1986,7 @@ export const regenerateWithNewContent = mutation({
 
       if (
         message.role !== "user" ||
+        message.is_hidden ||
         messages.some((laterMessage) => {
           return laterMessage.role === "user" && !laterMessage.is_hidden;
         })

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1975,6 +1975,27 @@ export const regenerateWithNewContent = mutation({
         }
       }
 
+      const messages = await ctx.db
+        .query("messages")
+        .withIndex("by_chat_id", (q) =>
+          q
+            .eq("chat_id", message.chat_id)
+            .gt("_creationTime", message._creationTime),
+        )
+        .collect();
+
+      if (
+        message.role !== "user" ||
+        messages.some((laterMessage) => {
+          return laterMessage.role === "user" && !laterMessage.is_hidden;
+        })
+      ) {
+        throw new ConvexError({
+          code: "MESSAGE_NOT_EDITABLE",
+          message: "Only the latest user message can be edited",
+        });
+      }
+
       // Determine which files to keep
       const currentFileIds = message.file_ids || [];
       let newFileIds: Id<"files">[] | undefined = undefined;
@@ -2040,15 +2061,6 @@ export const regenerateWithNewContent = mutation({
         update_time: Date.now(),
       });
 
-      const messages = await ctx.db
-        .query("messages")
-        .withIndex("by_chat_id", (q) =>
-          q
-            .eq("chat_id", message.chat_id)
-            .gt("_creationTime", message._creationTime),
-        )
-        .collect();
-
       // Check summary invalidation before deleting messages
       await checkAndInvalidateSummary(ctx, message.chat_id, [
         { id: message.id, creationTime: message._creationTime },
@@ -2099,7 +2111,8 @@ export const regenerateWithNewContent = mutation({
         error instanceof Error &&
         (error.message.includes("Message not found") ||
           error.message.includes("CHAT_NOT_FOUND") ||
-          error.message.includes("CHAT_UNAUTHORIZED"))
+          error.message.includes("CHAT_UNAUTHORIZED") ||
+          error.message.includes("Only the latest user message can be edited"))
       )) {
         console.error("Failed to regenerate with new content:", error);
       }

--- a/lib/utils/__tests__/message-utils.test.ts
+++ b/lib/utils/__tests__/message-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "@jest/globals";
 import {
+  findLastUserMessageIndex,
   getAutoContinueChainAssistantIds,
   getMessagesUpToLastRealUser,
 } from "../message-utils";
@@ -18,6 +19,39 @@ const msg = (
 });
 
 describe("message-utils", () => {
+  describe("findLastUserMessageIndex", () => {
+    it("returns the latest user-authored message before an assistant response", () => {
+      expect(
+        findLastUserMessageIndex([
+          msg("u1", "user"),
+          msg("a1", "assistant"),
+          msg("u2", "user"),
+          msg("a2", "assistant"),
+        ]),
+      ).toBe(2);
+    });
+
+    it("ignores auto-continue prompts after the latest user message", () => {
+      expect(
+        findLastUserMessageIndex([
+          msg("u1", "user"),
+          msg("a1", "assistant"),
+          msg("ac1", "user", true),
+          msg("a2", "assistant"),
+        ]),
+      ).toBe(0);
+    });
+
+    it("returns undefined when no user-authored message exists", () => {
+      expect(
+        findLastUserMessageIndex([
+          msg("a1", "assistant"),
+          msg("sys1", "system"),
+        ]),
+      ).toBeUndefined();
+    });
+  });
+
   describe("getAutoContinueChainAssistantIds", () => {
     it.each([
       {

--- a/lib/utils/message-utils.ts
+++ b/lib/utils/message-utils.ts
@@ -42,6 +42,25 @@ export const findLastAssistantMessageIndex = (
 };
 
 /**
+ * Finds the last user-authored message, ignoring hidden auto-continue prompts.
+ */
+export const findLastUserMessageIndex = (
+  messages: Array<{
+    role: "user" | "assistant" | "system";
+    metadata?: { isAutoContinue?: boolean };
+  }>,
+): number | undefined => {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message.role === "user" && !message.metadata?.isAutoContinue) {
+      return index;
+    }
+  }
+
+  return undefined;
+};
+
+/**
  * Represents a citation/source extracted from web tool outputs
  */
 export type WebSource = {


### PR DESCRIPTION
## Summary

- show the Edit action only on the latest user-authored message
- reject stale edit attempts in the client before stopping or regenerating an active run
- enforce the same rule in the persisted Convex mutation while ignoring hidden auto-continue prompts when finding the latest user turn
- reject hidden auto-continue rows as direct edit targets
- stop client-side cleanup and regeneration when persisted edits are stale or fail unexpectedly
- invalidate cached virtualized rows when edit mode changes so clicking Edit immediately opens the editor
- cover action visibility, latest-user selection, editor rendering, client validation, persistence failures, and backend guards

## Why

Editing an older user message truncates every later turn and can unexpectedly break the conversation flow. Matching Codex's latest-user-turn-only behavior keeps edits predictable and avoids destructive history rewrites.

## Validation

- full pre-commit suite — 313 suites and 3,077 tests passed
- focused edit rendering and regeneration suites — 3 suites and 19 tests passed
- `pnpm typecheck`
- full ESLint (no errors; existing unrelated warnings only)
- Prettier on all changed files
- `git diff --check`

## Manual verification

1. Open a chat with at least two user turns.
2. Hover the older user message and confirm Copy is available but Edit is not.
3. Hover the latest user message and confirm Edit is available.
4. Click Edit and confirm the editor appears immediately with the message selected.
5. Save the edit and confirm the response regenerates from that turn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Edit controls now only appear for the latest eligible user message; auto-continue messages are excluded.
  * Attempting to edit older/hidden messages is prevented with a clear “Only the latest user message can be edited” message.
  * Editing and regeneration behavior is tightened to keep UI and server results consistent.

* **Tests**
  * Added/updated Jest coverage for edit-button visibility, editing state transitions, stale edit rejection, and server-side `MESSAGE_NOT_EDITABLE` handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->