### PR TITLE
Remove referral card from sidebar

### DIFF
--- a/app/components/SidebarUserNav.tsx
+++ b/app/components/SidebarUserNav.tsx
@@ -19,7 +19,6 @@ import {
   RefreshCw,
   Gift,
   ShieldCheck,
-  X,
   Zap,
 } from "lucide-react";
 import Link from "next/link";
@@ -51,102 +50,6 @@ const NEXT_PUBLIC_HELP_CENTER_URL =
   process.env.NEXT_PUBLIC_HELP_CENTER_URL || "https://help.hackerai.co/en/";
 
 const STATUS_PAGE_URL = "https://status.hackerai.co/";
-
-const REFERRAL_CARD_DISMISSED_COOKIE = "referral_sidebar_dismissed";
-
-const readCookie = (name: string): string | null => {
-  if (typeof document === "undefined") return null;
-  const match = document.cookie.match(
-    new RegExp(
-      `(?:^|; )${name.replace(/([.$?*|{}()[\]\\/+^])/g, "\\$1")}=([^;]*)`,
-    ),
-  );
-  return match ? decodeURIComponent(match[1]) : null;
-};
-
-const writeCookie = (name: string, value: string, days: number) => {
-  if (typeof document === "undefined") return;
-  const expires = new Date(Date.now() + days * 864e5).toUTCString();
-  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/; SameSite=Lax`;
-};
-
-const ReferralSidebarCard = ({
-  isCollapsed,
-  onOpen,
-}: {
-  isCollapsed: boolean;
-  onOpen: () => void;
-}) => {
-  const [dismissed, setDismissed] = useState(
-    () => readCookie(REFERRAL_CARD_DISMISSED_COOKIE) === "1",
-  );
-
-  if (dismissed) return null;
-
-  const handleDismiss = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    writeCookie(REFERRAL_CARD_DISMISSED_COOKIE, "1", 365);
-    setDismissed(true);
-  };
-
-  if (isCollapsed) {
-    return (
-      <div className="mb-1">
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                data-testid="referral-button-collapsed"
-                variant="secondary"
-                size="sm"
-                className="h-8 w-full border-0 px-2"
-                onClick={onOpen}
-                aria-label="Refer a friend"
-              >
-                <Gift className="size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="right">
-              <p>Refer a friend</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </div>
-    );
-  }
-
-  return (
-    <div className="group/referral-card relative mb-2">
-      <button
-        type="button"
-        onClick={onOpen}
-        aria-label="Refer a friend and earn credits per paid referral"
-        className="bg-muted/50 hover:bg-muted/80 border-sidebar-border hover:border-sidebar-ring flex w-full cursor-pointer items-center gap-3 rounded-xl border p-3 text-left transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-      >
-        <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <p className="text-foreground truncate text-sm font-medium leading-none">
-            Refer a friend
-          </p>
-          <p className="text-muted-foreground truncate text-xs">
-            Earn credits per paid referral
-          </p>
-        </div>
-        <div className="bg-background/70 border-sidebar-border flex size-8 shrink-0 items-center justify-center rounded-full border">
-          <Gift className="size-4" />
-        </div>
-      </button>
-      <button
-        type="button"
-        onClick={handleDismiss}
-        aria-label="Dismiss referral card"
-        title="Dismiss"
-        className="bg-background/80 text-muted-foreground hover:bg-background hover:text-foreground border-sidebar-border absolute -top-2 -right-2 z-10 flex size-6 items-center justify-center rounded-full border opacity-100 shadow-sm transition-[opacity,colors] focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover/referral-card:opacity-100"
-      >
-        <X className="size-3.5" />
-      </button>
-    </div>
-  );
-};
 
 const GithubIcon = ({ className, ...props }: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="currentColor" className={className} {...props}>
@@ -231,7 +134,7 @@ const UpgradeBanner = ({ isCollapsed }: { isCollapsed: boolean }) => {
 
 const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
   const { user } = useAuth();
-  const { isCheckingProPlan, subscription } = useGlobalState();
+  const { subscription } = useGlobalState();
   const [rateLimitsExpanded, setRateLimitsExpanded] = useState(false);
   const [referralDialogOpen, setReferralDialogOpen] = useState(false);
   const [tokenUsage, setTokenUsage] = useState<{
@@ -396,14 +299,6 @@ const SidebarUserNav = ({ isCollapsed = false }: { isCollapsed?: boolean }) => {
         open={referralDialogOpen}
         onOpenChange={setReferralDialogOpen}
       />
-
-      {/* Referral card */}
-      {!isCheckingProPlan && isPaidUser && (
-        <ReferralSidebarCard
-          isCollapsed={isCollapsed}
-          onOpen={() => setReferralDialogOpen(true)}
-        />
-      )}
 
       {/* Upgrade banner above user nav */}
       <UpgradeBanner isCollapsed={isCollapsed} />


### PR DESCRIPTION
## What changed

- removed the persistent referral promotion card from expanded and collapsed sidebars
- removed the card-only dismissal cookie and related rendering code
- kept the paid-user **Refer a friend** account-menu item and referral dialog unchanged

## Why

Referral acquisition is currently too small to justify permanent sidebar real estate for every paid user. The menu entry preserves discoverability without making referrals a default navigation surface.

## Validation

- `pnpm typecheck`
- `pnpm lint` (passes with five pre-existing warnings outside this file)
- `pnpm test --runInBand app/components/__tests__/Sidebar.test.tsx`
- full pre-commit suite: 307 suites / 3,030 tests passed
- `pnpm exec prettier --check app/components/SidebarUserNav.tsx`
- `pnpm exec eslint app/components/SidebarUserNav.tsx`

## Manual verification

1. Sign in with a paid account and open the app with the sidebar expanded and collapsed.
2. Confirm the standalone referral card/button is absent in both layouts.
3. Open the user menu and select **Refer a friend**.
4. Confirm the referral dialog still opens and the link can still be copied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar subscription-status handling by removing unnecessary loading-state restrictions.
  * Upgrade prompts now display based on the current subscription status.
  * Removed the referral card from the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->