### PR TITLE
Harden agent runtime and build workflows

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -27,9 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Determine version
         id: version
@@ -102,17 +103,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 
@@ -122,7 +123,7 @@ jobs:
         id: pnpm-cache
 
       - name: Setup pnpm cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('packages/desktop/pnpm-lock.yaml') }}
@@ -131,7 +132,7 @@ jobs:
 
       - name: Install Rust stable (Linux, Windows)
         if: matrix.platform != 'macos-latest'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: stable
           target: ${{ matrix.target }}
@@ -186,7 +187,7 @@ jobs:
           "$HOME/.cargo/bin/rustc" --version
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: packages/desktop/src-tauri -> target
 
@@ -244,7 +245,7 @@ jobs:
           rm $CERTIFICATE_PATH
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
@@ -309,7 +310,7 @@ jobs:
 
       - name: Sign Windows executables with Azure Trusted Signing
         if: matrix.platform == 'windows-latest'
-        uses: azure/trusted-signing-action@v2
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -330,7 +331,7 @@ jobs:
           find packages/desktop/src-tauri/target/${{ matrix.target }}/release/bundle -type f 2>/dev/null || true
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: desktop-${{ matrix.name }}
           path: |
@@ -346,18 +347,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Download macOS arm64 artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: desktop-macOS-arm64
           path: arm64
 
       - name: Download macOS x64 artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: desktop-macOS-x64
           path: x64
@@ -521,7 +522,7 @@ jobs:
           spctl --assess --type open --context context:primary-signature -v HackerAI-universal.dmg || true
 
       - name: Upload universal artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: desktop-macOS-universal
           path: HackerAI-universal.dmg
@@ -537,13 +538,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 

--- a/.github/workflows/desktop-promote.yml
+++ b/.github/workflows/desktop-promote.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout release tooling
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -68,7 +68,7 @@ jobs:
           echo "Validated source run $SOURCE_RUN_ID at $HEAD_SHA"
 
       - name: Download immutable build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}

--- a/.github/workflows/docker-sandbox.yml
+++ b/.github/workflows/docker-sandbox.yml
@@ -26,13 +26,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -40,7 +42,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -48,7 +50,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./docker
           file: ./docker/Dockerfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
-      checks: write
 
     strategy:
       matrix:
@@ -22,13 +20,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -440,6 +440,23 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).toContain("Browser screenshot flow: use agent-browser");
   });
 
+  it("advertises only the installed CVE mapper and SecLists path", async () => {
+    const prompt = await systemPrompt(
+      "user_123",
+      "agent",
+      "pro",
+      "agent-model",
+      null,
+      false,
+      null,
+    );
+
+    expect(prompt).toContain("cvemap (CVE vulnerability mapping)");
+    expect(prompt).not.toContain("vulnx");
+    expect(prompt).toContain("SecLists (/usr/share/seclists)");
+    expect(prompt).not.toContain("/home/user/SecLists");
+  });
+
   it("clarifies cloud sandbox cannot directly reach local host aliases", async () => {
     const prompt = await systemPrompt(
       "user_123",

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -74,10 +74,10 @@ export const PREINSTALLED_PENTESTING_TOOLS = `Pre-installed Pentesting Tools:
 - Web Recon: gospider (web spider/crawler), katana (advanced web crawler)
 - Git/Repository Analysis: gitdumper, gitextractor (dump/extract git repos)
 - Secret Scanning: trufflehog (find credentials in git/filesystems)
-- Vulnerability Assessment: nuclei (vulnerability scanner with templates), trivy (container/dependency scanner), zaproxy (OWASP ZAP), vulnx/cvemap (CVE vulnerability mapping)
+- Vulnerability Assessment: nuclei (vulnerability scanner with templates), trivy (container/dependency scanner), zaproxy (OWASP ZAP), cvemap (CVE vulnerability mapping)
 - Forensics: binwalk, foremost (file carving)
 - Utilities: gobuster, socat, proxychains4, hashid, libimage-exiftool-perl (exiftool), cewl
-- Specialized: jwt-tool (wrapper for jwt_tool; JWT manipulation), interactsh-client (OOB interaction testing), SecLists (/home/user/SecLists or /usr/share/seclists)
+- Specialized: jwt-tool (wrapper for jwt_tool; JWT manipulation), interactsh-client (OOB interaction testing), SecLists (/usr/share/seclists)
 - Browser Automation: Chromium and agent-browser (headless browser CLI with accessibility snapshots, element refs, form interaction, screenshots, tabs, and network inspection)
 - Documents: reportlab, python-docx, openpyxl, python-pptx, pandas, pypandoc, pandoc, odfpy`;
 


### PR DESCRIPTION
## Summary
- align the cloud Agent tool inventory with the commands and paths actually provided by the sandbox, with a focused regression test
- pin every GitHub Action to a verified full commit SHA while retaining version comments for Dependabot updates
- disable checkout credential persistence where Git never writes and reduce the test job token to read-only repository contents

## Why
The cloud Agent prompt advertised `vulnx` and `/home/user/SecLists`, while the sandbox image installs and validates only `cvemap` and `/usr/share/seclists`. That mismatch can cause avoidable failed tool calls and recovery work.

The desktop release, artifact promotion, sandbox image, and test workflows also executed most actions through mutable major-version tags. Full commit pins keep the reviewed action implementation stable across trusted build and publishing jobs without changing their intended versions.

## Impact
Agent mode receives an accurate preinstalled-tool contract. Workflow behavior and Dependabot maintenance remain the same, while build inputs, published artifacts, registry writes, and signing steps have a narrower supply-chain trust boundary.

## Validation
- `corepack pnpm typecheck`
- `corepack pnpm test` — 310 suites and 3,065 tests passed
- `corepack pnpm jest lib/__tests__/system-prompt.test.ts --runInBand` — 23 tests passed
- `corepack pnpm exec eslint lib/system-prompt.ts lib/__tests__/system-prompt.test.ts`
- `corepack pnpm exec prettier --check lib/system-prompt.ts lib/__tests__/system-prompt.test.ts .github/workflows/desktop-build.yml .github/workflows/desktop-promote.yml .github/workflows/docker-sandbox.yml .github/workflows/test.yml`
- parsed all workflow YAML files and verified every external `uses:` reference is a full 40-character SHA

## Manual verification
- In a cloud Agent session, ask it to identify the installed CVE mapper and SecLists path. It should use `cvemap` and `/usr/share/seclists`, without suggesting `vulnx` or `/home/user/SecLists`.
- On the next desktop or sandbox-image build, confirm pinned setup, signing, artifact, and Docker actions initialize normally and Dependabot continues recognizing their version comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the advertised preinstalled security tools and SecLists location to reflect the current environment.
  * Prevented outdated tool names and paths from appearing in system guidance.

* **Tests**
  * Added coverage to verify that system guidance lists only the supported tools and location.

* **Chores**
  * Improved build, test, desktop release, and Docker workflows by pinning automation actions to specific versions for more consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->