### PR TITLE
Show sidebar button when collapsed

### DIFF
--- a/app/components/SidebarHeader.tsx
+++ b/app/components/SidebarHeader.tsx
@@ -9,7 +9,6 @@ import {
   Search,
 } from "lucide-react";
 import { useSidebar } from "@/components/ui/sidebar";
-import { HackerAISVG } from "@/components/icons/hackerai-svg";
 import { useChats } from "../hooks/useChats";
 import { useStartNewChat } from "../hooks/useStartNewChat";
 import { MessageSearchDialog } from "./MessageSearchDialog";
@@ -87,29 +86,16 @@ const SidebarHeaderContentImpl: FC<SidebarHeaderContentImplProps> = ({
     return (
       <>
         <div className="flex flex-col items-center p-2">
-          {/* HackerAI Logo with hover sidebar toggle */}
-          <div
+          <Button
             data-testid="sidebar-toggle"
-            className="relative flex items-center justify-center mb-2 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded"
+            variant="ghost"
+            size="sm"
+            className="mb-2 h-8 w-8 p-0 hover:bg-sidebar-accent/50"
             onClick={toggleSidebar}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                if (e.key === " ") {
-                  e.preventDefault();
-                }
-                toggleSidebar();
-              }
-            }}
-            tabIndex={0}
-            role="button"
             aria-label="Expand sidebar"
           >
-            <HackerAISVG theme="dark" scale={0.12} />
-            {/* Sidebar icon shown on hover over entire collapsed sidebar */}
-            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity bg-sidebar/80 rounded">
-              <SidebarIcon className="w-5 h-5" />
-            </div>
-          </div>
+            <SidebarIcon className="size-5" />
+          </Button>
 
           {/* Sidebar Actions - Collapsed */}
           <div className="flex flex-col items-center">

--- a/app/components/__tests__/SidebarHeader.test.tsx
+++ b/app/components/__tests__/SidebarHeader.test.tsx
@@ -1,0 +1,45 @@
+import "@testing-library/jest-dom";
+import { describe, expect, it, jest } from "@jest/globals";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const mockToggleSidebar = jest.fn();
+
+jest.mock("@/components/ui/sidebar", () => ({
+  useSidebar: () => ({ toggleSidebar: mockToggleSidebar }),
+}));
+jest.mock("@/components/icons/hackerai-svg", () => ({
+  HackerAISVG: () => <div data-testid="hackerai-svg" />,
+}));
+jest.mock("@/app/hooks/useChats", () => ({
+  useChats: jest.fn(),
+}));
+jest.mock("@/app/hooks/useStartNewChat", () => ({
+  useStartNewChat: () => jest.fn(),
+}));
+jest.mock("../MessageSearchDialog", () => ({
+  MessageSearchDialog: () => null,
+}));
+
+const SidebarHeaderContent = require("../SidebarHeader")
+  .default as typeof import("../SidebarHeader").default;
+
+describe("SidebarHeaderContent", () => {
+  it("shows the sidebar button instead of the HackerAI icon when collapsed", () => {
+    render(
+      <SidebarHeaderContent
+        handleCloseSidebar={jest.fn()}
+        isCollapsed={true}
+      />,
+    );
+
+    const expandButton = screen.getByRole("button", {
+      name: "Expand sidebar",
+    });
+
+    expect(screen.queryByTestId("hackerai-svg")).not.toBeInTheDocument();
+    expect(expandButton.querySelector("svg")).toBeInTheDocument();
+
+    fireEvent.click(expandButton);
+    expect(mockToggleSidebar).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/__tests__/SidebarHeader.test.tsx
+++ b/app/components/__tests__/SidebarHeader.test.tsx
@@ -39,6 +39,7 @@ describe("SidebarHeaderContent", () => {
     expect(screen.queryByTestId("hackerai-svg")).not.toBeInTheDocument();
     expect(expandButton.querySelector("svg")).toBeInTheDocument();
 
+    expect(mockToggleSidebar).not.toHaveBeenCalled();
     fireEvent.click(expandButton);
     expect(mockToggleSidebar).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary

- replace the collapsed HackerAI logo and hover-only icon swap with an always-visible sidebar button
- keep the existing ghost-button styling and accessible `Expand sidebar` label
- add a regression test covering the collapsed icon, absence of the HackerAI mark, and expand interaction

## Why

When the desktop sidebar was collapsed, reopening it was represented by the HackerAI mark and the actual sidebar control appeared only on hover. This made the control less discoverable. The collapsed rail now shows the sidebar button directly.

## Validation

- `pnpm test -- --runInBand app/components/__tests__/SidebarHeader.test.tsx app/components/__tests__/Sidebar.test.tsx`
- full pre-commit Jest suite: 311 suites and 3,065 tests passed
- `pnpm typecheck`
- `pnpm exec eslint app/components/SidebarHeader.tsx app/components/__tests__/SidebarHeader.test.tsx`
- `pnpm exec prettier --check app/components/SidebarHeader.tsx app/components/__tests__/SidebarHeader.test.tsx`
- `git diff --check`
- Playwright visual check at 1280×800 confirmed the icon is visible without hover, the HackerAI mark is absent, clicking expands the sidebar, and no application error overlay or console errors appear

## Manual verification

1. Open the chat UI on a desktop-width viewport.
2. Collapse the left sidebar.
3. Confirm the sidebar button is immediately visible instead of the HackerAI icon.
4. Click the button and confirm the sidebar expands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified the collapsed sidebar toggle into a clearer, accessible “Expand sidebar” button.
  * Updated the collapsed toggle icon presentation to match the interface styling.

* **Bug Fixes**
  * Removed the unused logo from the collapsed sidebar toggle area.
  * Improved interaction behavior for expanding the sidebar (click/keyboard consistency).

* **Tests**
  * Added assertions that the sidebar toggle function is not triggered on initial render.
  * Verified the collapsed toggle UI renders correctly and expands the sidebar on click.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->