### PR TITLE
Open locked Max access dialog on desktop

### DIFF
--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -33,7 +33,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
-import { useId, useState } from "react";
+import { useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import {
@@ -189,8 +189,6 @@ const ModelOptionButton = ({
   isPending,
   subscription,
   onSelect,
-  actionPanelId,
-  actionPanelOpen,
   mobile = false,
 }: {
   option: ModelOption;
@@ -199,8 +197,6 @@ const ModelOptionButton = ({
   isPending: boolean;
   subscription: SubscriptionTier;
   onSelect: (option: ModelOption) => void;
-  actionPanelId?: string;
-  actionPanelOpen?: boolean;
   mobile?: boolean;
 }) => {
   const button = (
@@ -210,8 +206,6 @@ const ModelOptionButton = ({
       disabled={isPending}
       aria-busy={isPending || undefined}
       aria-pressed={isSelected}
-      aria-expanded={actionPanelId ? actionPanelOpen : undefined}
-      aria-controls={actionPanelId}
       aria-label={
         isPending
           ? `${option.label}. Checking Extra Usage for Max mode.`
@@ -282,96 +276,6 @@ const ModelOptionButton = ({
         )}
       </TooltipContent>
     </Tooltip>
-  );
-};
-
-const LockedMaxAccessOption = ({
-  option,
-  isSelected,
-  subscription,
-  onClose,
-}: {
-  option: ModelOption;
-  isSelected: boolean;
-  subscription: SubscriptionTier;
-  onClose: () => void;
-}) => {
-  const [open, setOpen] = useState(false);
-  const panelId = useId();
-
-  return (
-    <div
-      className={`rounded-lg transition-colors ${open ? "bg-muted/35" : ""}`}
-      onMouseEnter={() => setOpen(true)}
-      onMouseLeave={() => setOpen(false)}
-      onFocusCapture={() => setOpen(true)}
-      onBlurCapture={(event) => {
-        if (!event.currentTarget.contains(event.relatedTarget)) {
-          setOpen(false);
-        }
-      }}
-    >
-      <ModelOptionButton
-        option={option}
-        isSelected={isSelected}
-        isLocked
-        isPending={false}
-        subscription={subscription}
-        onSelect={() => setOpen(true)}
-        actionPanelId={panelId}
-        actionPanelOpen={open}
-      />
-      {open && (
-        <div
-          id={panelId}
-          role="group"
-          aria-label="Choose how to access HackerAI Max"
-          className="mx-2 mb-1.5 mt-0.5 border-t border-border/50 pt-1"
-        >
-          <Button
-            type="button"
-            variant="ghost"
-            className="group/action h-auto w-full justify-start gap-2 px-2 py-1.5 text-left font-normal"
-            onClick={() => {
-              onClose();
-              openSettingsDialog("Extra Usage");
-            }}
-          >
-            <span className="min-w-0 flex-1">
-              <span className="block text-xs font-medium text-foreground">
-                Use Extra Usage
-              </span>
-              <span className="block text-[11px] leading-4 text-muted-foreground">
-                Pay for Max as you use it
-              </span>
-            </span>
-            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-hover/action:translate-x-0.5" />
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            className="group/action h-auto w-full justify-start gap-2 px-2 py-1.5 text-left font-normal"
-            onClick={() => {
-              onClose();
-              openMaxUltraUpgrade({
-                mobile: false,
-                subscription,
-              });
-            }}
-          >
-            <span className="min-w-0 flex-1">
-              <span className="block text-xs font-medium text-foreground">
-                Upgrade to Ultra
-              </span>
-              <span className="block text-[11px] leading-4 text-muted-foreground">
-                Max included
-              </span>
-            </span>
-            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-hover/action:translate-x-0.5" />
-          </Button>
-        </div>
-      )}
-    </div>
   );
 };
 
@@ -463,21 +367,6 @@ const ModelOptionList = ({
               mobile={mobile}
             />
           </div>
-        );
-      }
-
-      if (
-        isMaxModel(option.id) &&
-        canChoosePersonalMaxAccessPath(subscription)
-      ) {
-        return (
-          <LockedMaxAccessOption
-            key={option.id}
-            option={option}
-            isSelected={isSelected}
-            subscription={subscription}
-            onClose={onClose}
-          />
         );
       }
 
@@ -618,7 +507,6 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
     ) {
       setOpen(false);
       if (
-        isMobile &&
         isMaxModel(option.id) &&
         canChoosePersonalMaxAccessPath(subscription)
       ) {
@@ -651,6 +539,44 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
     </Button>
   );
 
+  const maxAccessDialog = (
+    <Dialog open={maxAccessDialogOpen} onOpenChange={setMaxAccessDialogOpen}>
+      <DialogContent className="w-[calc(100%-2rem)] max-w-sm rounded-2xl p-5">
+        <DialogHeader>
+          <DialogTitle>Unlock HackerAI Max</DialogTitle>
+          <DialogDescription className="leading-relaxed">
+            On Pro and Pro+, use Extra Usage to pay for Max as you go, or
+            upgrade to Ultra to have Max included.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-2 pt-2">
+          <Button
+            type="button"
+            onClick={() => {
+              setMaxAccessDialogOpen(false);
+              openSettingsDialog("Extra Usage");
+            }}
+          >
+            Use Extra Usage
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              setMaxAccessDialogOpen(false);
+              openMaxUltraUpgrade({
+                mobile: isMobile,
+                subscription,
+              });
+            }}
+          >
+            Upgrade to Ultra
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+
   if (isMobile) {
     return (
       <>
@@ -681,44 +607,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
             />
           </SheetContent>
         </Sheet>
-        <Dialog
-          open={maxAccessDialogOpen}
-          onOpenChange={setMaxAccessDialogOpen}
-        >
-          <DialogContent className="w-[calc(100%-2rem)] max-w-sm rounded-2xl p-5">
-            <DialogHeader>
-              <DialogTitle>Unlock HackerAI Max</DialogTitle>
-              <DialogDescription className="leading-relaxed">
-                On Pro and Pro+, Max is paid through Extra Usage. Upgrade to
-                Ultra to have Max included.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="flex flex-col gap-2 pt-2">
-              <Button
-                type="button"
-                onClick={() => {
-                  setMaxAccessDialogOpen(false);
-                  openSettingsDialog("Extra Usage");
-                }}
-              >
-                Use Extra Usage
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => {
-                  setMaxAccessDialogOpen(false);
-                  openMaxUltraUpgrade({
-                    mobile: true,
-                    subscription,
-                  });
-                }}
-              >
-                Upgrade to Ultra
-              </Button>
-            </div>
-          </DialogContent>
-        </Dialog>
+        {maxAccessDialog}
       </>
     );
   }
@@ -742,6 +631,7 @@ export function ModelSelector({ value, onChange, mode }: ModelSelectorProps) {
           />
         </PopoverContent>
       </Popover>
+      {maxAccessDialog}
     </>
   );
 }

--- a/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/app/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -161,7 +161,7 @@ describe("ModelSelector", () => {
     expect(onChange).toHaveBeenCalledWith("hackerai-pro");
   });
 
-  it("reveals Max access choices when a Pro Plus user clicks the locked row", () => {
+  it("opens the Max access dialog when a Pro Plus user clicks the locked desktop row", () => {
     mockMaxEntitlement = {
       extraUsageAvailable: false,
       reason: "disabled",
@@ -182,21 +182,20 @@ describe("ModelSelector", () => {
 
     expect(onChange).not.toHaveBeenCalled();
     expect(
-      screen.getByRole("group", {
-        name: "Choose how to access HackerAI Max",
-      }),
+      screen.getByRole("dialog", { name: "Unlock HackerAI Max" }),
     ).toBeVisible();
-    expect(screen.getByText("Pay for Max as you use it")).toBeVisible();
-    expect(screen.getByText("Max included")).toBeVisible();
+    expect(
+      screen.getByText(/pay for Max as you go, or upgrade to Ultra/i),
+    ).toBeVisible();
     expect(mockOpenSettingsDialog).not.toHaveBeenCalled();
     expect(mockRedirectToPricing).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: /^Use Extra Usage/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Use Extra Usage" }));
 
     expect(mockOpenSettingsDialog).toHaveBeenCalledWith("Extra Usage");
   });
 
-  it("offers compact Extra Usage and Ultra actions inside the model menu", async () => {
+  it("does not reveal inline Max access actions on desktop hover", async () => {
     mockMaxEntitlement = {
       extraUsageAvailable: false,
       reason: "disabled",
@@ -210,15 +209,24 @@ describe("ModelSelector", () => {
     await user.hover(screen.getByRole("button", { name: /HackerAI Max/i }));
 
     expect(
-      await screen.findByRole("group", {
+      screen.queryByRole("group", {
         name: "Choose how to access HackerAI Max",
       }),
-    ).toBeVisible();
-    expect(
-      screen.getByRole("button", { name: /HackerAI Max/i }),
-    ).toHaveAttribute("aria-expanded", "true");
+    ).not.toBeInTheDocument();
+  });
 
-    fireEvent.click(screen.getByRole("button", { name: /^Upgrade to Ultra/i }));
+  it("can upgrade to Ultra from the locked Max desktop dialog", () => {
+    mockMaxEntitlement = {
+      extraUsageAvailable: false,
+      reason: "disabled",
+      hasBalance: false,
+      autoReloadEnabled: false,
+    };
+    render(<ModelSelector value="auto" onChange={jest.fn()} mode="agent" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Auto$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /HackerAI Max/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade to Ultra" }));
 
     expect(mockRedirectToPricing).toHaveBeenCalledWith({
       surface: "model_selector",
@@ -246,7 +254,9 @@ describe("ModelSelector", () => {
     expect(
       screen.getByRole("dialog", { name: "Unlock HackerAI Max" }),
     ).toBeVisible();
-    expect(screen.getByText(/Max is paid through Extra Usage/i)).toBeVisible();
+    expect(
+      screen.getByText(/pay for Max as you go, or upgrade to Ultra/i),
+    ).toBeVisible();
     expect(onChange).not.toHaveBeenCalled();
     expect(mockOpenSettingsDialog).not.toHaveBeenCalled();
     expect(mockRedirectToPricing).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- replace the desktop hover-expanded HackerAI Max access actions with the same focused unlock dialog used on mobile
- share the Max access dialog across desktop and mobile while preserving surface-specific upgrade attribution
- clarify that paid personal users can use Extra Usage **or** upgrade to Ultra
- add regression coverage for desktop click, hover, Extra Usage, and Ultra paths

## Why
For Pro and Pro+ users without Max access, desktop exposed two nested actions inside the model menu while mobile opened a dedicated dialog. The desktop interaction was easy to trigger accidentally on hover and behaved differently from mobile.

Now selecting locked Max on desktop closes the model selector and opens the focused `Unlock HackerAI Max` dialog with the two access choices.

## Validation
- `corepack pnpm test -- app/components/ModelSelector/__tests__/ModelSelector.test.tsx --runInBand` (18/18)
- commit hook full Jest suite (310 suites, 3,065 tests)
- `corepack pnpm typecheck`
- `corepack pnpm exec eslint app/components/ModelSelector.tsx app/components/ModelSelector/__tests__/ModelSelector.test.tsx`
- `corepack pnpm exec prettier --check app/components/ModelSelector.tsx app/components/ModelSelector/__tests__/ModelSelector.test.tsx`
- Chrome visual verification with a Pro test account and Extra Usage temporarily disabled; confirmed the desktop dialog layout and that `Use Extra Usage` opens the correct settings tab, then restored the account state

## Manual verification
1. On desktop, use a Pro or Pro+ account without Max access.
2. Open the model selector and hover over HackerAI Max; inline access actions should not expand.
3. Select HackerAI Max; the `Unlock HackerAI Max` dialog should open with `Use Extra Usage` and `Upgrade to Ultra`.
4. Confirm each action opens the corresponding settings or pricing flow.
5. Repeat on mobile and confirm the existing dialog behavior remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the HackerAI Max access experience with a dedicated unlock dialog across desktop and mobile.
  * Added clearer upgrade messaging, including pay-as-you-go and Ultra upgrade options.

* **Bug Fixes**
  * Improved locked Max interactions and simplified the upgrade flow.
  * Prevented inline access controls from appearing when Max is locked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->