### PR TITLE
Reduce PostHog event volume

### DIFF
--- a/app/__tests__/providers.test.tsx
+++ b/app/__tests__/providers.test.tsx
@@ -1,5 +1,9 @@
 import { describe, expect, it, jest, beforeEach } from "@jest/globals";
 import { render, waitFor } from "@testing-library/react";
+import {
+  createPostHogIdentitySignature,
+  POSTHOG_IDENTITY_SIGNATURE_STORAGE_KEY,
+} from "@/lib/analytics/identity";
 
 jest.mock("@workos-inc/authkit-nextjs/components", () => ({
   useAuth: jest.fn(),
@@ -90,11 +94,17 @@ describe("PostHogProvider", () => {
         },
         capture_pageview: false,
         autocapture: false,
+        advanced_disable_feature_flags: true,
       }),
     );
     expect(posthog.set_config).not.toHaveBeenCalled();
     expect(posthog.opt_in_capturing).toHaveBeenCalledWith({
       captureEventName: false,
+    });
+    expect(posthog.identify).toHaveBeenCalledWith("user-123", {
+      email: "user@example.com",
+      name: "Test User",
+      subscription: "pro",
     });
 
     const [, config] = posthog.init.mock.calls[0] as unknown as [
@@ -122,6 +132,50 @@ describe("PostHogProvider", () => {
       $current_url: "https://hackerai.co/auth-error",
       $referrer: "https://idp.example/callback",
     });
+  });
+
+  it("does not resend unchanged person properties across app loads", async () => {
+    const posthog = {
+      __loaded: false,
+      init: jest.fn(),
+      set_config: jest.fn(),
+      opt_in_capturing: jest.fn(),
+      has_opted_out_capturing: jest.fn(() => false),
+      identify: jest.fn(),
+      sessionRecordingStarted: jest.fn(() => false),
+      startSessionRecording: jest.fn(),
+      stopSessionRecording: jest.fn(),
+      reset: jest.fn(),
+      opt_out_capturing: jest.fn(),
+    };
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: "user-deduped",
+        email: "deduped@example.com",
+        firstName: "Deduped",
+        lastName: "User",
+      },
+    });
+    const signature = createPostHogIdentitySignature({
+      userId: "user-deduped",
+      email: "deduped@example.com",
+      name: "Deduped User",
+      subscription: "pro",
+    });
+    window.localStorage.setItem(
+      POSTHOG_IDENTITY_SIGNATURE_STORAGE_KEY,
+      signature,
+    );
+    mockLoadPostHogClient.mockResolvedValue(posthog);
+
+    render(
+      <PostHogProvider>
+        <div>child</div>
+      </PostHogProvider>,
+    );
+
+    await waitFor(() => expect(posthog.identify).toHaveBeenCalledTimes(1));
+    expect(posthog.identify).toHaveBeenCalledWith("user-deduped", undefined);
   });
 
   it("applies exception hooks when the shared client is already initialized", async () => {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -10,6 +10,10 @@ import {
   shouldDropExpectedFrontendException,
 } from "@/lib/posthog/expected-frontend-exceptions";
 import { getPostHogClient, loadPostHogClient } from "@/lib/analytics/client";
+import {
+  createPostHogIdentitySignature,
+  POSTHOG_IDENTITY_SIGNATURE_STORAGE_KEY,
+} from "@/lib/analytics/identity";
 
 let lastIdentifiedSignature: string | null = null;
 
@@ -49,6 +53,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
             process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com",
           capture_pageview: false,
           autocapture: false,
+          advanced_disable_feature_flags: true,
           capture_exceptions: {
             capture_unhandled_errors: true,
             capture_unhandled_rejections: true,
@@ -85,19 +90,46 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 
         const name =
           [userFirstName, userLastName].filter(Boolean).join(" ") || userEmail;
-        const identitySignature = JSON.stringify([
-          userId,
-          userEmail,
+        const identitySignature = createPostHogIdentitySignature({
+          userId: userId!,
+          email: userEmail,
           name,
           subscription,
-        ]);
+        });
         if (lastIdentifiedSignature !== identitySignature) {
-          posthog.identify(userId!, {
-            email: userEmail,
-            name,
-            subscription,
-          });
+          let persistedIdentitySignature: string | null = null;
+          try {
+            persistedIdentitySignature = window.localStorage.getItem(
+              POSTHOG_IDENTITY_SIGNATURE_STORAGE_KEY,
+            );
+          } catch {
+            // Storage can be unavailable in privacy-restricted browsers.
+          }
+
+          const shouldUpdatePersonProperties =
+            persistedIdentitySignature !== identitySignature;
+          posthog.identify(
+            userId!,
+            shouldUpdatePersonProperties
+              ? {
+                  email: userEmail,
+                  name,
+                  subscription,
+                }
+              : undefined,
+          );
           lastIdentifiedSignature = identitySignature;
+
+          if (shouldUpdatePersonProperties) {
+            try {
+              window.localStorage.setItem(
+                POSTHOG_IDENTITY_SIGNATURE_STORAGE_KEY,
+                identitySignature,
+              );
+            } catch {
+              // Best-effort cross-load deduplication only.
+            }
+          }
         }
 
         if (subscription !== "free") {

--- a/lib/analytics/__tests__/identity.test.ts
+++ b/lib/analytics/__tests__/identity.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "@jest/globals";
+import { createPostHogIdentitySignature } from "../identity";
+
+describe("createPostHogIdentitySignature", () => {
+  const identity = {
+    userId: "user_123",
+    email: "user@example.com",
+    name: "Test User",
+    subscription: "pro",
+  };
+
+  it("is stable for unchanged analytics identity properties", () => {
+    expect(createPostHogIdentitySignature(identity)).toBe(
+      createPostHogIdentitySignature(identity),
+    );
+  });
+
+  it("changes when a person property changes", () => {
+    expect(
+      createPostHogIdentitySignature({
+        ...identity,
+        subscription: "ultra",
+      }),
+    ).not.toBe(createPostHogIdentitySignature(identity));
+  });
+});

--- a/lib/analytics/identity.ts
+++ b/lib/analytics/identity.ts
@@ -1,0 +1,21 @@
+import { v5 as uuidv5 } from "uuid";
+
+export const POSTHOG_IDENTITY_SIGNATURE_STORAGE_KEY =
+  "hackerai:analytics:identity-signature:v1";
+
+export function createPostHogIdentitySignature({
+  userId,
+  email,
+  name,
+  subscription,
+}: {
+  userId: string;
+  email?: string | null;
+  name?: string | null;
+  subscription: string;
+}) {
+  return uuidv5(
+    JSON.stringify([userId, email ?? null, name ?? null, subscription]),
+    uuidv5.URL,
+  );
+}

--- a/lib/api/__tests__/chat-logger.test.ts
+++ b/lib/api/__tests__/chat-logger.test.ts
@@ -17,7 +17,7 @@ const {
 const { ChatSDKError } = require("../../errors");
 const { phLogger } = require("../../posthog/server");
 describe("captureToolCalls", () => {
-  it("aggregates repeated tool calls by tool before sending PostHog events", () => {
+  it("aggregates all tool calls into one anonymous PostHog event", () => {
     const capture = jest.fn();
     const posthog = { capture };
     const chatLogger = {
@@ -36,23 +36,17 @@ describe("captureToolCalls", () => {
       mode: "agent",
     });
 
-    expect(capture).toHaveBeenCalledTimes(2);
+    expect(capture).toHaveBeenCalledTimes(1);
     expect(capture).toHaveBeenCalledWith({
       distinctId: "user_123",
       event: "hackerai-tool_usage",
       properties: {
         mode: "agent",
-        toolName: "run_terminal_cmd",
-        count: 3,
-      },
-    });
-    expect(capture).toHaveBeenCalledWith({
-      distinctId: "user_123",
-      event: "hackerai-tool_usage",
-      properties: {
-        mode: "agent",
-        toolName: "open_url",
-        count: 1,
+        toolCountsByName: JSON.stringify({ run_terminal_cmd: 3, open_url: 1 }),
+        totalCount: 4,
+        distinctToolCount: 2,
+        tool_usage_event_version: 2,
+        $process_person_profile: false,
       },
     });
   });

--- a/lib/api/chat-logger.ts
+++ b/lib/api/chat-logger.ts
@@ -1105,8 +1105,8 @@ export function captureAgentBudgetAbort({
 
 /**
  * Capture aggregated tool usage to PostHog at end of request.
- * One event is emitted per tool to keep analytics useful while
- * avoiding the cost of one PostHog event per individual tool call.
+ * One event is emitted per request with a JSON tool-count map so exact tool
+ * totals remain queryable without one billable event per tool.
  */
 export function captureToolCalls({
   posthog,
@@ -1137,17 +1137,21 @@ export function captureToolCalls({
     aggregatedToolCalls.set(tool.name, { name: tool.name, count: 1 });
   }
 
-  for (const tool of aggregatedToolCalls.values()) {
-    posthog.capture({
-      distinctId: userId,
-      event: "hackerai-tool_usage",
-      properties: {
-        mode,
-        toolName: tool.name,
-        count: tool.count,
-      },
-    });
-  }
+  const tools = Array.from(aggregatedToolCalls.values());
+  posthog.capture({
+    distinctId: userId,
+    event: "hackerai-tool_usage",
+    properties: {
+      mode,
+      toolCountsByName: JSON.stringify(
+        Object.fromEntries(tools.map((tool) => [tool.name, tool.count])),
+      ),
+      totalCount: toolCalls.length,
+      distinctToolCount: tools.length,
+      tool_usage_event_version: 2,
+      $process_person_profile: false,
+    },
+  });
 }
 
 export type AgentRunOutcome = "success" | "aborted" | "error";


### PR DESCRIPTION
## Summary

- bundle all tool calls from one chat request into a single versioned `hackerai-tool_usage` event while preserving exact per-tool counts
- stop sending unchanged email, name, and subscription person properties on every app load
- disable automatic browser feature-flag polling while the project has no active flags
- mark tool summaries with `$process_person_profile: false` to avoid unnecessary person-profile processing

## Expected impact

The latest complete-week sample showed about 55,724 `hackerai-tool_usage` events/day. Bundling by request is estimated to remove about 24,902/day (44.7% of that stream), before the additional reduction from repeated `$set` events.

The existing PostHog insight [Tool calls per Agent run (top 8 + Other, 30d)](https://us.posthog.com/project/144137/insights/Cvn5emdy) has already been updated and verified to read both legacy events and the new bundled format. No dashboard setup is required.

If browser-side PostHog feature flags are introduced later, remove `advanced_disable_feature_flags: true` as part of that rollout.

## Validation

- `pnpm typecheck`
- focused ESLint on all changed files
- 312 Jest suites passed (3,069 tests)
- saved PostHog insight executed successfully after its backward-compatible query update

## Post-deploy verification

- confirm each instrumented chat request emits at most one version-2 `hackerai-tool_usage` event
- confirm `toolCountsByName` totals match the request's actual tool calls
- reload an unchanged signed-in session and verify repeated `$set` volume drops
- confirm the saved tool-usage insight continues populating across the deployment boundary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics identity handling to avoid resending unchanged profile information.
  * Added safeguards for environments where browser storage is unavailable.
  * Improved consistency when tracking tool activity.

* **Refactor**
  * Consolidated tool activity tracking into a single event with summarized usage details.
  * Standardized identity signatures for more reliable analytics across sessions.

* **Tests**
  * Added coverage for stable identity tracking, changed profile data, and aggregated tool activity events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->