### PR TITLE
Classify and mitigate E2B non-resource failures

### DIFF
--- a/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
+++ b/lib/ai/tools/__tests__/run-terminal-cmd.test.ts
@@ -16,16 +16,27 @@
 // Stub out @e2b/code-interpreter — its ESM `chalk` dependency trips Jest's
 // default transformer. We only need the named exports that appear in
 // `run-terminal-cmd.ts` to be importable.
-jest.mock("@e2b/code-interpreter", () => ({
-  CommandExitError: class CommandExitError extends Error {
-    exitCode: number;
-    constructor(msg = "exit", exitCode = 1) {
-      super(msg);
-      this.exitCode = exitCode;
-    }
-  },
-  Sandbox: class {},
-}));
+jest.mock("@e2b/code-interpreter", () => {
+  class MockE2BError extends Error {}
+  return {
+    AuthenticationError: class AuthenticationError extends MockE2BError {},
+    InvalidArgumentError: class InvalidArgumentError extends MockE2BError {},
+    NotEnoughSpaceError: class NotEnoughSpaceError extends MockE2BError {},
+    NotFoundError: class NotFoundError extends MockE2BError {},
+    RateLimitError: class RateLimitError extends MockE2BError {},
+    SandboxError: class SandboxError extends MockE2BError {},
+    TemplateError: class TemplateError extends MockE2BError {},
+    TimeoutError: class TimeoutError extends MockE2BError {},
+    CommandExitError: class CommandExitError extends MockE2BError {
+      exitCode: number;
+      constructor(msg = "exit", exitCode = 1) {
+        super(msg);
+        this.exitCode = exitCode;
+      }
+    },
+    Sandbox: class {},
+  };
+});
 
 jest.mock("@/lib/posthog/server", () => ({
   phLogger: {
@@ -38,6 +49,7 @@ jest.mock("@/lib/posthog/server", () => ({
 }));
 
 import { phLogger } from "@/lib/posthog/server";
+import { InvalidArgumentError } from "@e2b/code-interpreter";
 import { createRunTerminalCmd } from "../run-terminal-cmd";
 import { detectAgentBrowserUsage } from "../utils/agent-browser-usage";
 import type { PtyHandle } from "../utils/e2b-pty-adapter";
@@ -132,6 +144,7 @@ function makeContext(opts: {
   chatId?: string;
   requestToolApproval?: import("@/types").AgentToolApprovalRequester;
   onSandboxResourceMetrics?: import("@/types").SandboxResourceMetricsObserver;
+  recordHealthFailure?: jest.MockedFunction<() => boolean>;
 }) {
   const writerWrites: unknown[] = [];
   const writer = {
@@ -146,8 +159,10 @@ function makeContext(opts: {
     getSandboxType: jest.fn(),
     getSandboxInfo: jest.fn(() => null),
     getEffectivePreference: jest.fn(() => "e2b"),
-    recordHealthFailure: jest.fn(() => false),
+    recordHealthFailure:
+      opts.recordHealthFailure ?? jest.fn<() => boolean>(() => false),
     resetHealthFailures: jest.fn(),
+    resetSandbox: jest.fn(async () => undefined),
     isSandboxUnavailable: jest.fn(() => false),
     consumeFallbackInfo: jest.fn(() => null),
   };
@@ -165,6 +180,7 @@ function makeContext(opts: {
     todoManager: {} as never,
     userID: "u1",
     chatId: opts.chatId ?? "chat-1",
+    triggerRunId: "run-test",
     fileAccumulator: {} as never,
     backgroundProcessTracker: {
       addProcess: jest.fn(),
@@ -514,6 +530,165 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
     ptySessionManager.forget("chat-1", result.result.session!);
   });
 
+  test("classifies an E2B wait expiry with a returned session as resumable", async () => {
+    let finishCommand!: (result: {
+      stdout: string;
+      stderr: string;
+      exitCode: number;
+    }) => void;
+    const pendingCommand = new Promise<{
+      stdout: string;
+      stderr: string;
+      exitCode: number;
+    }>((resolve) => {
+      finishCommand = resolve;
+    });
+    const started = {
+      pid: 4321,
+      stdout: "",
+      stderr: "",
+      wait: jest.fn(() => pendingCommand),
+      kill: jest.fn(async () => true),
+    };
+    const e2b = {
+      jupyterUrl: "http://fake",
+      sandboxId: "sandbox-1",
+      setTimeout: jest.fn(async () => undefined),
+      isRunning: jest.fn(async () => true),
+      getMetrics: jest.fn(async () => [
+        {
+          cpuUsedPct: 10,
+          memUsed: 512,
+          memTotal: 2048,
+          diskUsed: 200,
+          diskTotal: 1000,
+        },
+      ]),
+      commands: {
+        run: jest.fn(async (command: string) =>
+          command === "echo ready"
+            ? { stdout: "ready\n", stderr: "", exitCode: 0 }
+            : started,
+        ),
+      },
+    };
+    const onSandboxResourceMetrics = jest.fn();
+    const { context, ptySessionManager } = makeContext({
+      sandbox: e2b,
+      onSandboxResourceMetrics,
+    });
+
+    const result = (await runTool(createRunTerminalCmd(context), {
+      command: "sleep 30",
+      brief: "wait for job",
+      is_background: false,
+      timeout: 0.01,
+      interactive: false,
+    })) as { result: { session?: string } };
+
+    expect(result.result.session).toBeDefined();
+    expect(onSandboxResourceMetrics).toHaveBeenLastCalledWith({
+      kind: "failure",
+      source: "terminal_command_timeout",
+      failureType: "terminal_command_timed_out",
+      timeoutSeconds: 0.01,
+      terminalTimeoutOutcome: "session_resumable",
+      terminationAttempted: false,
+      terminationSucceeded: false,
+      sessionReturned: true,
+      isBackground: false,
+      metrics: {
+        cpuPct: 10,
+        memPct: 25,
+        diskPct: 20,
+      },
+    });
+
+    finishCommand({ stdout: "done\n", stderr: "", exitCode: 0 });
+    const session = ptySessionManager.get("chat-1", result.result.session!);
+    await session?.handle.exited;
+    expect(onSandboxResourceMetrics).toHaveBeenLastCalledWith({
+      kind: "timeout_recovery",
+      source: "terminal_command_timeout",
+      outcome: "completed_success",
+    });
+    ptySessionManager.forget("chat-1", result.result.session!);
+  });
+
+  test("stops terminal retries when the initial check and reconnect both fail", async () => {
+    jest.useFakeTimers();
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const readinessError = new InvalidArgumentError(
+        "fork/exec /bin/sh: permission denied",
+      );
+      const e2b = {
+        jupyterUrl: "http://fake",
+        sandboxId: "sandbox-broken",
+        setTimeout: jest.fn(async () => undefined),
+        isRunning: jest.fn(async () => true),
+        getMetrics: jest.fn(async () => [
+          {
+            cpuUsedPct: 10,
+            memUsed: 512,
+            memTotal: 2048,
+            diskUsed: 200,
+            diskTotal: 1000,
+          },
+        ]),
+        commands: { run: jest.fn(async () => Promise.reject(readinessError)) },
+      };
+      const recordHealthFailure = jest
+        .fn<() => boolean>()
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true);
+      const onSandboxResourceMetrics = jest.fn();
+      const { context, sandboxManager } = makeContext({
+        sandbox: e2b,
+        recordHealthFailure,
+        onSandboxResourceMetrics,
+      });
+
+      const resultPromise = runTool(createRunTerminalCmd(context), {
+        command: "echo should-not-run",
+        brief: "verify sandbox",
+        is_background: false,
+        timeout: 5,
+        interactive: false,
+      }) as Promise<{ result: { error?: string } }>;
+      await jest.advanceTimersByTimeAsync(2_000);
+      const result = await resultPromise;
+
+      expect(result.result.error).toContain(
+        "initial health check and reconnect both failed",
+      );
+      expect(recordHealthFailure).toHaveBeenCalledTimes(2);
+      expect(sandboxManager.resetSandbox).toHaveBeenCalledWith(
+        "terminal_health_check_failed",
+      );
+      expect(onSandboxResourceMetrics).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "failure",
+          failureReason: "permission_denied",
+          readinessStage: "initial",
+          lifecycleState: "running_not_ready",
+        }),
+      );
+      expect(onSandboxResourceMetrics).toHaveBeenCalledWith({
+        kind: "recovery",
+        source: "readiness_reconnect",
+        outcome: "failed_unavailable",
+        initialFailureReason: "permission_denied",
+        finalFailureReason: "permission_denied",
+      });
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
   test("uses the exact E2B command handle to terminate noisy foreground work", async () => {
     const noisyOutput = "line with repeated output\n".repeat(20_000);
     let rejectWait!: (error: Error) => void;
@@ -597,6 +772,12 @@ describe("run_terminal_cmd — PTY action dispatch", () => {
       kind: "failure",
       source: "terminal_command_timeout",
       failureType: "terminal_command_timed_out",
+      timeoutSeconds: 0.01,
+      terminalTimeoutOutcome: "command_terminated",
+      terminationAttempted: true,
+      terminationSucceeded: true,
+      sessionReturned: false,
+      isBackground: false,
       metrics: {
         cpuPct: 100,
         memPct: expect.closeTo(94.9707, 3),

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -66,6 +66,7 @@ export const createTools = (
   requestToolApproval?: AgentToolApprovalRequester,
   measureAgentActiveTime?: AgentActiveTimeMeasurer,
   workingDirectory?: string,
+  triggerRunId?: string,
 ) => {
   let sandbox: AnySandbox | null = null;
   let sandboxFirstUsedAt: number | null = null;
@@ -118,6 +119,7 @@ export const createTools = (
     chatId,
     mode,
     subscription,
+    triggerRunId,
   });
 
   const context: ToolContext = {
@@ -128,6 +130,7 @@ export const createTools = (
     userID,
     chatId,
     assistantMessageId,
+    triggerRunId,
     fileAccumulator,
     backgroundProcessTracker,
     ptySessionManager,

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -1,7 +1,7 @@
 import { tool, type Tool } from "ai";
 import { CommandExitError } from "@e2b/code-interpreter";
 import { randomUUID } from "crypto";
-import type { ToolContext } from "@/types";
+import type { SandboxReadinessFailureReason, ToolContext } from "@/types";
 import { createTerminalHandler } from "@/lib/utils/terminal-executor";
 import { TIMEOUT_MESSAGE } from "@/lib/token-utils";
 import { saveTruncatedOutput } from "./utils/terminal-output-saver";
@@ -10,8 +10,10 @@ import { terminateProcessReliably } from "./utils/process-termination";
 import { retryWithBackoff } from "./utils/retry-with-backoff";
 import {
   waitForSandboxReady,
-  getSandboxDiagnostics,
+  classifySandboxReadinessFailureReason,
   observeSandboxResourceFailure,
+  observeSandboxRecovery,
+  observeTerminalTimeoutRecovery,
 } from "./utils/sandbox-health";
 import { isE2BSandbox, isCentrifugoSandbox } from "./utils/sandbox-types";
 import {
@@ -103,6 +105,37 @@ export const createRunTerminalCmd = (context: ToolContext) => {
     context.measureAgentActiveTime
       ? context.measureAgentActiveTime("sandbox_recovery", operation)
       : operation();
+  const logSandboxReadinessRecovery = (args: {
+    level: "info" | "warn" | "error";
+    outcome: "started" | "reconnected" | "failed" | "skipped_unavailable";
+    sandboxId?: string;
+    initialFailureReason: SandboxReadinessFailureReason;
+    finalFailureReason?: SandboxReadinessFailureReason;
+  }): void => {
+    const payload = JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level: args.level,
+      event: "e2b_sandbox_readiness_recovery",
+      service: context.triggerRunId ? "agent-long" : "chat-handler",
+      environment:
+        process.env.TRIGGER_ENV ??
+        process.env.VERCEL_ENV ??
+        process.env.NODE_ENV ??
+        "unknown",
+      request_id: context.triggerRunId ?? process.env.VERCEL_REQUEST_ID ?? null,
+      trigger_run_id: context.triggerRunId ?? null,
+      chat_id: context.chatId,
+      user_id: context.userID,
+      subscription: context.subscription ?? "unknown",
+      sandbox_id: args.sandboxId ?? null,
+      outcome: args.outcome,
+      initial_failure_reason: args.initialFailureReason,
+      final_failure_reason: args.finalFailureReason ?? null,
+    });
+    if (args.level === "error") console.error(payload);
+    else if (args.level === "warn") console.warn(payload);
+    else console.info(payload);
+  };
   const runTerminalCmdTool = createRunTerminalCmdToolSchema({
     approvalGated: !!context.requestToolApproval,
     // The conditional schema adds approval-only fields, but both branches
@@ -357,6 +390,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
               5,
               abortSignal,
               context.onSandboxResourceMetrics,
+              "initial",
             );
             sandboxManager.resetHealthFailures();
           } catch (healthError) {
@@ -368,11 +402,20 @@ export const createRunTerminalCmd = (context: ToolContext) => {
               throw healthError;
             }
 
+            const initialFailureReason =
+              classifySandboxReadinessFailureReason(healthError);
             const exceeded = sandboxManager.recordHealthFailure();
             if (exceeded) {
-              console.error(
-                "[Terminal Command] Sandbox health check failed too many times, marking unavailable",
-              );
+              observeSandboxRecovery(context.onSandboxResourceMetrics, {
+                outcome: "skipped_unavailable",
+                initialFailureReason,
+              });
+              logSandboxReadinessRecovery({
+                level: "error",
+                outcome: "skipped_unavailable",
+                sandboxId: sandbox.sandboxId,
+                initialFailureReason,
+              });
               return {
                 result: {
                   output: "",
@@ -386,12 +429,12 @@ export const createRunTerminalCmd = (context: ToolContext) => {
             const recovery = await measureSandboxRecovery(async () => {
               // Discard this worker's connection and reconnect the shared
               // sandbox. Never kill it: another Agent run may own commands.
-              const diagnostics = await getSandboxDiagnostics(sandbox).catch(
-                () => "diagnostics unavailable",
-              );
-              console.warn(
-                `[Terminal Command] Sandbox health check failed (${diagnostics}), waiting before reconnecting sandbox`,
-              );
+              logSandboxReadinessRecovery({
+                level: "warn",
+                outcome: "started",
+                sandboxId: sandbox.sandboxId,
+                initialFailureReason,
+              });
               await new Promise((resolve) => setTimeout(resolve, 2000));
 
               // Reset only the cached SDK instance.
@@ -408,6 +451,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                   5,
                   abortSignal,
                   context.onSandboxResourceMetrics,
+                  "reconnect",
                 );
                 sandboxManager.resetHealthFailures();
               } catch (reconnectedHealthError) {
@@ -417,20 +461,51 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                 ) {
                   throw reconnectedHealthError;
                 }
-                sandboxManager.recordHealthFailure();
+                const finalFailureReason =
+                  classifySandboxReadinessFailureReason(reconnectedHealthError);
+                const unavailable = sandboxManager.recordHealthFailure();
+                observeSandboxRecovery(context.onSandboxResourceMetrics, {
+                  outcome: unavailable
+                    ? "failed_unavailable"
+                    : "failed_retryable",
+                  initialFailureReason,
+                  finalFailureReason,
+                });
+                logSandboxReadinessRecovery({
+                  level: "error",
+                  outcome: "failed",
+                  sandboxId: isE2BSandbox(reconnectedSandbox)
+                    ? reconnectedSandbox.sandboxId
+                    : undefined,
+                  initialFailureReason,
+                  finalFailureReason,
+                });
                 return {
                   ok: false as const,
                   response: {
                     result: {
                       output: "",
                       exitCode: 1,
-                      error:
-                        "Sandbox reconnection failed. The sandbox environment is not responding. Another attempt may be made but the sandbox will be marked unavailable after repeated failures.",
+                      error: unavailable
+                        ? "Sandbox is unavailable after the initial health check and reconnect both failed. Do NOT retry terminal or sandbox commands in this run. Inform the user that the sandbox could not be reached and suggest they wait a moment and try again, or delete the sandbox in Settings > Data Controls. If the issue persists, contact HackerAI support."
+                        : "Sandbox reconnection failed. The sandbox environment is not responding.",
                     },
                   },
                 };
               }
 
+              observeSandboxRecovery(context.onSandboxResourceMetrics, {
+                outcome: "reconnected",
+                initialFailureReason,
+              });
+              logSandboxReadinessRecovery({
+                level: "info",
+                outcome: "reconnected",
+                sandboxId: isE2BSandbox(reconnectedSandbox)
+                  ? reconnectedSandbox.sandboxId
+                  : undefined,
+                initialFailureReason,
+              });
               return { ok: true as const, sandbox: reconnectedSandbox };
             });
 
@@ -486,6 +561,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
               exitCode: number;
               pid?: number;
             }> | null = null;
+            let resumableTimeoutObserved = false;
 
             const forgetUnexposedCommandSession = () => {
               if (!commandSession || commandSessionExposed) return;
@@ -539,10 +615,20 @@ export const createRunTerminalCmd = (context: ToolContext) => {
             }) => {
               console.warn(
                 JSON.stringify({
+                  timestamp: new Date().toISOString(),
                   level: "warn",
                   event: "agent_terminal_noisy_timeout",
-                  service: "chat-handler",
-                  timestamp: new Date().toISOString(),
+                  service: context.triggerRunId ? "agent-long" : "chat-handler",
+                  environment:
+                    process.env.TRIGGER_ENV ??
+                    process.env.VERCEL_ENV ??
+                    process.env.NODE_ENV ??
+                    "unknown",
+                  request_id:
+                    context.triggerRunId ??
+                    process.env.VERCEL_REQUEST_ID ??
+                    null,
+                  trigger_run_id: context.triggerRunId ?? null,
                   chat_id: chatId,
                   user_id: context.userID,
                   mode: context.mode,
@@ -558,10 +644,10 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                   pid: fields.processId ?? undefined,
                   termination_attempted: fields.terminationAttempted,
                   termination_succeeded: fields.terminationSucceeded,
-                  termination_error:
+                  termination_error_name:
                     fields.terminationError instanceof Error
-                      ? fields.terminationError.message
-                      : undefined,
+                      ? fields.terminationError.name
+                      : null,
                 }),
               );
             };
@@ -682,17 +768,6 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                   resolved = true;
                   if (commandSession) commandSessionExposed = true;
 
-                  const resourceFailureObservation = isE2BSandbox(
-                    sandboxInstance,
-                  )
-                    ? observeSandboxResourceFailure(
-                        sandboxInstance,
-                        context.onSandboxResourceMetrics,
-                        "terminal_command_timeout",
-                        "terminal_command_timed_out",
-                      )
-                    : Promise.resolve();
-
                   // Try to get PID from execution object first (if available)
                   if (!processId && execution && (execution as any)?.pid) {
                     processId = (execution as any).pid;
@@ -742,6 +817,29 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                     ? undefined
                     : commandSession?.sessionId;
                   if (resumableSession) commandSessionExposed = true;
+                  resumableTimeoutObserved = Boolean(resumableSession);
+                  const resourceFailureObservation = isE2BSandbox(
+                    sandboxInstance,
+                  )
+                    ? observeSandboxResourceFailure(
+                        sandboxInstance,
+                        context.onSandboxResourceMetrics,
+                        "terminal_command_timeout",
+                        "terminal_command_timed_out",
+                        {
+                          timeoutSeconds: effectiveStreamTimeout,
+                          terminalTimeoutOutcome: commandTerminated
+                            ? "command_terminated"
+                            : resumableSession
+                              ? "session_resumable"
+                              : "wait_expired_untracked",
+                          terminationAttempted,
+                          terminationSucceeded,
+                          sessionReturned: Boolean(resumableSession),
+                          isBackground: is_background,
+                        },
+                      )
+                    : Promise.resolve();
                   const timeoutMessage = commandTerminated
                     ? TERMINATED_TIMEOUT_MESSAGE(
                         effectiveStreamTimeout,
@@ -944,6 +1042,15 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                   commandHandle?.setPid(exec.pid);
                 }
                 commandHandle?.resolveExit(exec.exitCode ?? 0);
+                if (resumableTimeoutObserved && isE2BSandbox(sandboxInstance)) {
+                  observeTerminalTimeoutRecovery(
+                    context.onSandboxResourceMetrics,
+                    (exec.exitCode ?? 0) === 0
+                      ? "completed_success"
+                      : "completed_nonzero",
+                  );
+                  resumableTimeoutObserved = false;
+                }
 
                 if (handler) {
                   handler.cleanup();
@@ -1014,6 +1121,15 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                 }
               })
               .catch(async (error) => {
+                if (resumableTimeoutObserved && isE2BSandbox(sandboxInstance)) {
+                  observeTerminalTimeoutRecovery(
+                    context.onSandboxResourceMetrics,
+                    error instanceof CommandExitError
+                      ? "completed_nonzero"
+                      : "execution_failed",
+                  );
+                  resumableTimeoutObserved = false;
+                }
                 commandHandle?.resolveExit(
                   error instanceof CommandExitError ? error.exitCode : null,
                 );

--- a/lib/ai/tools/run-terminal-cmd.ts
+++ b/lib/ai/tools/run-terminal-cmd.ts
@@ -105,6 +105,16 @@ export const createRunTerminalCmd = (context: ToolContext) => {
     context.measureAgentActiveTime
       ? context.measureAgentActiveTime("sandbox_recovery", operation)
       : operation();
+  const buildTerminalLogContext = () => ({
+    service: context.triggerRunId ? "agent-long" : "chat-handler",
+    environment:
+      process.env.TRIGGER_ENV ??
+      process.env.VERCEL_ENV ??
+      process.env.NODE_ENV ??
+      "unknown",
+    request_id: context.triggerRunId ?? process.env.VERCEL_REQUEST_ID ?? null,
+    trigger_run_id: context.triggerRunId ?? null,
+  });
   const logSandboxReadinessRecovery = (args: {
     level: "info" | "warn" | "error";
     outcome: "started" | "reconnected" | "failed" | "skipped_unavailable";
@@ -116,14 +126,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
       timestamp: new Date().toISOString(),
       level: args.level,
       event: "e2b_sandbox_readiness_recovery",
-      service: context.triggerRunId ? "agent-long" : "chat-handler",
-      environment:
-        process.env.TRIGGER_ENV ??
-        process.env.VERCEL_ENV ??
-        process.env.NODE_ENV ??
-        "unknown",
-      request_id: context.triggerRunId ?? process.env.VERCEL_REQUEST_ID ?? null,
-      trigger_run_id: context.triggerRunId ?? null,
+      ...buildTerminalLogContext(),
       chat_id: context.chatId,
       user_id: context.userID,
       subscription: context.subscription ?? "unknown",
@@ -618,17 +621,7 @@ export const createRunTerminalCmd = (context: ToolContext) => {
                   timestamp: new Date().toISOString(),
                   level: "warn",
                   event: "agent_terminal_noisy_timeout",
-                  service: context.triggerRunId ? "agent-long" : "chat-handler",
-                  environment:
-                    process.env.TRIGGER_ENV ??
-                    process.env.VERCEL_ENV ??
-                    process.env.NODE_ENV ??
-                    "unknown",
-                  request_id:
-                    context.triggerRunId ??
-                    process.env.VERCEL_REQUEST_ID ??
-                    null,
-                  trigger_run_id: context.triggerRunId ?? null,
+                  ...buildTerminalLogContext(),
                   chat_id: chatId,
                   user_id: context.userID,
                   mode: context.mode,

--- a/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
+++ b/lib/ai/tools/utils/__tests__/hybrid-sandbox-manager.test.ts
@@ -605,6 +605,21 @@ describe("HybridSandboxManager reset cleanup", () => {
     }
   });
 
+  it("marks E2B unavailable after the initial check and reconnect both fail", () => {
+    const manager = new HybridSandboxManager(
+      "user-1",
+      jest.fn(),
+      "e2b",
+      "service-key",
+      null,
+      "pro",
+    );
+
+    expect(manager.recordHealthFailure()).toBe(false);
+    expect(manager.recordHealthFailure()).toBe(true);
+    expect(manager.isSandboxUnavailable()).toBe(true);
+  });
+
   it("forgets an E2B connection without killing the shared user sandbox", async () => {
     const manager = new HybridSandboxManager(
       "user-1",

--- a/lib/ai/tools/utils/__tests__/sandbox-health.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-health.test.ts
@@ -18,7 +18,10 @@ jest.mock("@/lib/posthog/worker", () => ({
 }));
 
 import type { AnySandbox } from "@/types";
-import { waitForSandboxReady } from "../sandbox-health";
+import {
+  classifySandboxReadinessFailureReason,
+  waitForSandboxReady,
+} from "../sandbox-health";
 
 const makeE2BSandbox = () =>
   ({
@@ -74,6 +77,9 @@ describe("sandbox health resource observations", () => {
       kind: "failure",
       source: "readiness_check_failure",
       failureType: "readiness_check_failed",
+      failureReason: "unknown",
+      readinessStage: "initial",
+      lifecycleState: "unknown",
       metrics: {
         cpuPct: 100,
         memPct: 75,
@@ -90,5 +96,54 @@ describe("sandbox health resource observations", () => {
         throw new Error("analytics unavailable");
       }),
     ).resolves.toBeUndefined();
+  });
+
+  test.each([
+    [
+      Object.assign(new Error("fork/exec /bin/sh: permission denied"), {
+        name: "InvalidArgumentError",
+      }),
+      "permission_denied",
+    ],
+    [
+      Object.assign(new Error("Sandbox is probably not running anymore"), {
+        name: "SandboxNotFoundError",
+      }),
+      "sandbox_not_found",
+    ],
+    [new Error("fetch failed: ECONNRESET"), "connection_error"],
+    [new Error("operation timed out"), "operation_timeout"],
+  ])(
+    "classifies readiness failures without exposing raw errors",
+    (error, expected) => {
+      expect(classifySandboxReadinessFailureReason(error)).toBe(expected);
+    },
+  );
+
+  test("labels failures from the reconnect health-check stage", async () => {
+    const sandbox = makeE2BSandbox();
+    (sandbox.commands.run as jest.Mock).mockRejectedValue(
+      new Error("fetch failed: connection reset"),
+    );
+    const onResourceMetrics = jest.fn();
+
+    await expect(
+      waitForSandboxReady(
+        sandbox,
+        1,
+        undefined,
+        onResourceMetrics,
+        "reconnect",
+      ),
+    ).rejects.toThrow();
+
+    expect(onResourceMetrics).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        kind: "failure",
+        failureReason: "connection_error",
+        readinessStage: "reconnect",
+        lifecycleState: "unknown",
+      }),
+    );
   });
 });

--- a/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-lifecycle.test.ts
@@ -330,6 +330,17 @@ describe("E2B sandbox lease lifecycle", () => {
     expect(sandbox.kill).not.toHaveBeenCalled();
   });
 
+  it("marks the sandbox unavailable after the initial check and reconnect both fail", () => {
+    const manager = new DefaultSandboxManager("user-1", jest.fn());
+
+    expect(manager.recordHealthFailure()).toBe(false);
+    expect(manager.recordHealthFailure()).toBe(true);
+    expect(manager.isSandboxUnavailable()).toBe(true);
+
+    manager.resetHealthFailures();
+    expect(manager.isSandboxUnavailable()).toBe(false);
+  });
+
   it("manager returns a cached sandbox after a transient lease refresh failure", async () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     try {

--- a/lib/ai/tools/utils/hybrid-sandbox-manager.ts
+++ b/lib/ai/tools/utils/hybrid-sandbox-manager.ts
@@ -50,7 +50,10 @@ export interface SandboxFallbackInfo {
  * - Automatic fallback to E2B when local unavailable
  * - Dangerous mode (no Docker) with OS context for AI
  */
-const MAX_SANDBOX_HEALTH_FAILURES = 5;
+// Match DefaultSandboxManager: stop retries in this Agent run after the
+// initial readiness check and one reconnect both fail. E2B reset remains
+// connection-only and never kills the shared per-user sandbox.
+const MAX_SANDBOX_HEALTH_FAILURES = 2;
 export const LOCAL_SANDBOX_PRESENCE_GRACE_MS = 30_000;
 const LOCAL_SANDBOX_PRESENCE_TIMEOUT_MS = 2_000;
 

--- a/lib/ai/tools/utils/sandbox-health.ts
+++ b/lib/ai/tools/utils/sandbox-health.ts
@@ -1,16 +1,27 @@
 import type {
   AnySandbox,
+  SandboxLifecycleState,
+  SandboxReadinessFailureReason,
+  SandboxReadinessStage,
+  SandboxRecoveryOutcome,
   SandboxResourceMetrics,
   SandboxResourceMetricsObserver,
   SandboxResourceObservation,
+  TerminalTimeoutOutcome,
+  TerminalTimeoutRecoveryOutcome,
 } from "@/types";
 import { createRetryLogger } from "@/lib/posthog/worker";
 import { isE2BSandbox } from "./sandbox-types";
 import { retryWithBackoff } from "./retry-with-backoff";
 import {
   AuthenticationError,
+  CommandExitError,
   TemplateError,
   InvalidArgumentError,
+  NotEnoughSpaceError,
+  NotFoundError,
+  RateLimitError,
+  TimeoutError,
 } from "./e2b-errors";
 
 const sandboxHealthLogger = createRetryLogger("sandbox-health");
@@ -90,6 +101,17 @@ export async function observeSandboxResourceFailure(
   observer: SandboxResourceMetricsObserver | undefined,
   source: "readiness_check_failure" | "terminal_command_timeout",
   failureType: "readiness_check_failed" | "terminal_command_timed_out",
+  details: {
+    failureReason?: SandboxReadinessFailureReason;
+    readinessStage?: SandboxReadinessStage;
+    lifecycleState?: SandboxLifecycleState;
+    timeoutSeconds?: number;
+    terminalTimeoutOutcome?: TerminalTimeoutOutcome;
+    terminationAttempted?: boolean;
+    terminationSucceeded?: boolean;
+    sessionReturned?: boolean;
+    isBackground?: boolean;
+  } = {},
 ): Promise<void> {
   if (!observer || !isE2BSandbox(sandbox)) return;
 
@@ -107,7 +129,101 @@ export async function observeSandboxResourceFailure(
     source,
     failureType,
     metrics: stripWarning(metrics),
+    ...details,
   });
+}
+
+export function observeSandboxRecovery(
+  observer: SandboxResourceMetricsObserver | undefined,
+  details: {
+    outcome: SandboxRecoveryOutcome;
+    initialFailureReason: SandboxReadinessFailureReason;
+    finalFailureReason?: SandboxReadinessFailureReason;
+  },
+): void {
+  notifyResourceObserver(observer, {
+    kind: "recovery",
+    source: "readiness_reconnect",
+    ...details,
+  });
+}
+
+export function observeTerminalTimeoutRecovery(
+  observer: SandboxResourceMetricsObserver | undefined,
+  outcome: TerminalTimeoutRecoveryOutcome,
+): void {
+  notifyResourceObserver(observer, {
+    kind: "timeout_recovery",
+    source: "terminal_command_timeout",
+    outcome,
+  });
+}
+
+/**
+ * Reduce E2B/OS errors to privacy-safe, low-cardinality readiness categories.
+ * Never include raw messages because command/runtime errors may contain user data.
+ */
+export function classifySandboxReadinessFailureReason(
+  error: unknown,
+): SandboxReadinessFailureReason {
+  if (!(error instanceof Error)) return "unknown";
+
+  const name = error.name.toLowerCase();
+  const message = error.message.toLowerCase();
+
+  // Check message-level OS failures before SDK classes. E2B can wrap a failed
+  // fork/exec in InvalidArgumentError even though the actionable cause is the
+  // sandbox process subsystem rather than caller input.
+  if (message.includes("permission denied")) return "permission_denied";
+  if (
+    name.includes("sandboxnotfound") ||
+    message.includes("not running anymore") ||
+    message.includes("sandbox not found") ||
+    message.includes("sandbox was not found")
+  ) {
+    return "sandbox_not_found";
+  }
+  if (message.includes("sandbox is not running")) return "sandbox_not_running";
+  if (
+    message.includes("econnreset") ||
+    message.includes("econnrefused") ||
+    message.includes("connection reset") ||
+    message.includes("connection refused") ||
+    message.includes("fetch failed") ||
+    message.includes("network connection") ||
+    message.includes("socket hang up")
+  ) {
+    return "connection_error";
+  }
+
+  if (error instanceof AuthenticationError) return "authentication";
+  if (error instanceof TemplateError) return "template";
+  if (error instanceof RateLimitError) return "rate_limit";
+  if (error instanceof NotEnoughSpaceError) return "disk_space";
+  if (error instanceof NotFoundError) return "sandbox_not_found";
+  if (error instanceof TimeoutError) return "operation_timeout";
+  if (error instanceof CommandExitError) return "command_exit";
+  if (error instanceof InvalidArgumentError) return "invalid_argument";
+
+  if (name.includes("timeout") || message.includes("timed out")) {
+    return "operation_timeout";
+  }
+  return "unknown";
+}
+
+export function inferSandboxLifecycleState(
+  failureReason: SandboxReadinessFailureReason,
+): SandboxLifecycleState {
+  if (failureReason === "sandbox_not_running") return "not_running";
+  if (failureReason === "sandbox_not_found") return "missing";
+  if (
+    failureReason === "permission_denied" ||
+    failureReason === "invalid_argument" ||
+    failureReason === "command_exit"
+  ) {
+    return "running_not_ready";
+  }
+  return "unknown";
 }
 
 /**
@@ -138,6 +254,7 @@ export async function waitForSandboxReady(
   maxRetries: number = 5,
   signal?: AbortSignal,
   onResourceMetrics?: SandboxResourceMetricsObserver,
+  readinessStage: SandboxReadinessStage = "initial",
 ): Promise<void> {
   try {
     await retryWithBackoff(
@@ -217,11 +334,17 @@ export async function waitForSandboxReady(
       signal?.aborted ||
       (error instanceof DOMException && error.name === "AbortError");
     if (!wasAborted) {
+      const failureReason = classifySandboxReadinessFailureReason(error);
       await observeSandboxResourceFailure(
         sandbox,
         onResourceMetrics,
         "readiness_check_failure",
         "readiness_check_failed",
+        {
+          failureReason,
+          readinessStage,
+          lifecycleState: inferSandboxLifecycleState(failureReason),
+        },
       ).catch(() => {
         // Analytics must never mask the readiness failure
       });

--- a/lib/ai/tools/utils/sandbox-manager.ts
+++ b/lib/ai/tools/utils/sandbox-manager.ts
@@ -11,7 +11,10 @@ import {
 } from "./sandbox";
 import { SANDBOX_ENVIRONMENT_TOOLS } from "./sandbox-tools";
 
-const MAX_SANDBOX_HEALTH_FAILURES = 5;
+// One failed initial readiness check plus one failed reconnect is enough to
+// stop terminal retries in this Agent run. The manager only forgets its local
+// SDK client; it never kills the shared per-user sandbox or another run's work.
+const MAX_SANDBOX_HEALTH_FAILURES = 2;
 
 export class DefaultSandboxManager implements SandboxManager {
   private sandbox: Sandbox | null = null;

--- a/lib/analytics/__tests__/sandbox-resource-pressure.test.ts
+++ b/lib/analytics/__tests__/sandbox-resource-pressure.test.ts
@@ -27,6 +27,7 @@ describe("E2B resource pressure telemetry", () => {
       chatId: "chat-1",
       mode: "agent",
       subscription: "pro-plus",
+      triggerRunId: "run-123",
     });
 
   const observeHealth = (
@@ -54,6 +55,7 @@ describe("E2B resource pressure telemetry", () => {
         mode: "agent",
         subscription_tier: "pro-plus",
         sandbox_type: "e2b",
+        trigger_run_id: "run-123",
         cpu_used_pct: 99.88,
         memory_used_pct: 72.35,
         disk_used_pct: 41.23,
@@ -140,6 +142,12 @@ describe("E2B resource pressure telemetry", () => {
       source: "terminal_command_timeout",
       failureType: "terminal_command_timed_out",
       metrics: { cpuPct: 100, memPct: 95, diskPct: 40 },
+      timeoutSeconds: 60,
+      terminalTimeoutOutcome: "session_resumable",
+      terminationAttempted: false,
+      terminationSucceeded: false,
+      sessionReturned: true,
+      isBackground: false,
     });
 
     expect(mockPhEvent).toHaveBeenCalledWith(
@@ -151,6 +159,12 @@ describe("E2B resource pressure telemetry", () => {
         metrics_available: true,
         cpu_used_pct: 100,
         memory_used_pct: 95,
+        timeout_seconds: 60,
+        terminal_timeout_outcome: "session_resumable",
+        termination_attempted: false,
+        termination_succeeded: false,
+        session_returned: true,
+        is_background: false,
       }),
     );
   });
@@ -163,6 +177,9 @@ describe("E2B resource pressure telemetry", () => {
       source: "readiness_check_failure",
       failureType: "readiness_check_failed",
       metrics: null,
+      failureReason: "permission_denied",
+      readinessStage: "reconnect",
+      lifecycleState: "running_not_ready",
     });
 
     expect(mockPhEvent).toHaveBeenCalledWith(
@@ -171,11 +188,58 @@ describe("E2B resource pressure telemetry", () => {
         pressure_type: "unknown",
         failure_type: "readiness_check_failed",
         metrics_available: false,
+        failure_reason: "permission_denied",
+        readiness_stage: "reconnect",
+        sandbox_lifecycle_state: "running_not_ready",
       }),
     );
     expect(mockPhEvent.mock.calls[0]?.[1]).not.toHaveProperty("cpu_used_pct");
     expect(mockPhEvent.mock.calls[0]?.[1]).not.toHaveProperty(
       "memory_used_pct",
+    );
+  });
+
+  test("records reconnect outcomes separately from failure observations", () => {
+    const observe = createObserver();
+
+    observe({
+      kind: "recovery",
+      source: "readiness_reconnect",
+      outcome: "failed_unavailable",
+      initialFailureReason: "connection_error",
+      finalFailureReason: "permission_denied",
+    });
+
+    expect(mockPhEvent).toHaveBeenCalledWith(
+      "e2b_sandbox_recovery_observed",
+      expect.objectContaining({
+        trigger_run_id: "run-123",
+        recovery_source: "readiness_reconnect",
+        recovery_outcome: "failed_unavailable",
+        initial_failure_reason: "connection_error",
+        final_failure_reason: "permission_denied",
+        recovery_event_version: 1,
+      }),
+    );
+  });
+
+  test("records the eventual outcome of a resumable timeout", () => {
+    const observe = createObserver();
+
+    observe({
+      kind: "timeout_recovery",
+      source: "terminal_command_timeout",
+      outcome: "completed_success",
+    });
+
+    expect(mockPhEvent).toHaveBeenCalledWith(
+      "e2b_terminal_timeout_recovery_observed",
+      expect.objectContaining({
+        trigger_run_id: "run-123",
+        recovery_source: "terminal_command_timeout",
+        recovery_outcome: "completed_success",
+        recovery_event_version: 1,
+      }),
     );
   });
 });

--- a/lib/analytics/sandbox-resource-pressure.ts
+++ b/lib/analytics/sandbox-resource-pressure.ts
@@ -9,6 +9,7 @@ import type {
 export const E2B_CPU_SATURATION_THRESHOLD_PCT = 99;
 export const E2B_MEMORY_PRESSURE_THRESHOLD_PCT = 90;
 export const E2B_RESOURCE_PRESSURE_EVENT_VERSION = 2;
+const E2B_FAILURE_RECOVERY_EVENT_VERSION = 1;
 
 const roundPercentage = (value: number): number =>
   Math.round(value * 100) / 100;
@@ -59,6 +60,7 @@ export function createE2BResourcePressureObserver(args: {
   chatId: string;
   mode: ChatMode;
   subscription?: SubscriptionTier;
+  triggerRunId?: string;
 }): SandboxResourceMetricsObserver {
   let cpuWasPressured = false;
   let memoryWasPressured = false;
@@ -69,12 +71,37 @@ export function createE2BResourcePressureObserver(args: {
     mode: args.mode,
     subscription_tier: args.subscription ?? "unknown",
     sandbox_type: "e2b",
+    ...(args.triggerRunId && { trigger_run_id: args.triggerRunId }),
     cpu_saturation_threshold_pct: E2B_CPU_SATURATION_THRESHOLD_PCT,
     memory_pressure_threshold_pct: E2B_MEMORY_PRESSURE_THRESHOLD_PCT,
     resource_pressure_event_version: E2B_RESOURCE_PRESSURE_EVENT_VERSION,
   };
 
   return (observation) => {
+    if (observation.kind === "recovery") {
+      phLogger.event("e2b_sandbox_recovery_observed", {
+        ...commonProperties,
+        recovery_source: observation.source,
+        recovery_outcome: observation.outcome,
+        initial_failure_reason: observation.initialFailureReason,
+        recovery_event_version: E2B_FAILURE_RECOVERY_EVENT_VERSION,
+        ...(observation.finalFailureReason && {
+          final_failure_reason: observation.finalFailureReason,
+        }),
+      });
+      return;
+    }
+
+    if (observation.kind === "timeout_recovery") {
+      phLogger.event("e2b_terminal_timeout_recovery_observed", {
+        ...commonProperties,
+        recovery_source: observation.source,
+        recovery_outcome: observation.outcome,
+        recovery_event_version: E2B_FAILURE_RECOVERY_EVENT_VERSION,
+      });
+      return;
+    }
+
     const pressureType = classifyResourcePressure(observation.metrics);
 
     if (observation.kind === "failure") {
@@ -84,6 +111,33 @@ export function createE2BResourcePressureObserver(args: {
         pressure_type: pressureType,
         failure_type: observation.failureType,
         observation_source: observation.source,
+        ...(observation.failureReason && {
+          failure_reason: observation.failureReason,
+        }),
+        ...(observation.readinessStage && {
+          readiness_stage: observation.readinessStage,
+        }),
+        ...(observation.lifecycleState && {
+          sandbox_lifecycle_state: observation.lifecycleState,
+        }),
+        ...(observation.timeoutSeconds !== undefined && {
+          timeout_seconds: observation.timeoutSeconds,
+        }),
+        ...(observation.terminalTimeoutOutcome && {
+          terminal_timeout_outcome: observation.terminalTimeoutOutcome,
+        }),
+        ...(observation.terminationAttempted !== undefined && {
+          termination_attempted: observation.terminationAttempted,
+        }),
+        ...(observation.terminationSucceeded !== undefined && {
+          termination_succeeded: observation.terminationSucceeded,
+        }),
+        ...(observation.sessionReturned !== undefined && {
+          session_returned: observation.sessionReturned,
+        }),
+        ...(observation.isBackground !== undefined && {
+          is_background: observation.isBackground,
+        }),
       });
       return;
     }

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1000,7 +1000,7 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     );
     expect(taskSrc).toMatch(/handled tool failure dashboard update failed/);
     expect(taskSrc).toMatch(
-      /onToolFailure,\s*requestToolApproval,\s*runTimingTracker\.measureActiveTime,\s*projectContext\.workingDirectory,\s*\)/,
+      /onToolFailure,\s*requestToolApproval,\s*runTimingTracker\.measureActiveTime,\s*projectContext\.workingDirectory,\s*ctx\.run\.id,\s*\)/,
     );
   });
 

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -2270,6 +2270,7 @@ export const agentLongTask = task({
               requestToolApproval,
               runTimingTracker.measureActiveTime,
               projectContext.workingDirectory,
+              ctx.run.id,
             );
             approvalSandboxManager = sandboxManager;
 

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -61,6 +61,37 @@ export interface SandboxResourceMetrics {
   diskPct: number;
 }
 
+export type SandboxReadinessFailureReason =
+  | "sandbox_not_running"
+  | "sandbox_not_found"
+  | "permission_denied"
+  | "authentication"
+  | "template"
+  | "invalid_argument"
+  | "rate_limit"
+  | "disk_space"
+  | "command_exit"
+  | "operation_timeout"
+  | "connection_error"
+  | "unknown";
+
+export type SandboxReadinessStage = "initial" | "reconnect";
+
+export type SandboxLifecycleState =
+  "running_not_ready" | "not_running" | "missing" | "unknown";
+
+export type TerminalTimeoutOutcome =
+  "command_terminated" | "session_resumable" | "wait_expired_untracked";
+
+export type TerminalTimeoutRecoveryOutcome =
+  "completed_success" | "completed_nonzero" | "execution_failed";
+
+export type SandboxRecoveryOutcome =
+  | "reconnected"
+  | "failed_retryable"
+  | "failed_unavailable"
+  | "skipped_unavailable";
+
 export type SandboxResourceObservation =
   | {
       kind: "health_sample";
@@ -72,6 +103,27 @@ export type SandboxResourceObservation =
       source: "readiness_check_failure" | "terminal_command_timeout";
       failureType: "readiness_check_failed" | "terminal_command_timed_out";
       metrics: SandboxResourceMetrics | null;
+      failureReason?: SandboxReadinessFailureReason;
+      readinessStage?: SandboxReadinessStage;
+      lifecycleState?: SandboxLifecycleState;
+      timeoutSeconds?: number;
+      terminalTimeoutOutcome?: TerminalTimeoutOutcome;
+      terminationAttempted?: boolean;
+      terminationSucceeded?: boolean;
+      sessionReturned?: boolean;
+      isBackground?: boolean;
+    }
+  | {
+      kind: "recovery";
+      source: "readiness_reconnect";
+      outcome: SandboxRecoveryOutcome;
+      initialFailureReason: SandboxReadinessFailureReason;
+      finalFailureReason?: SandboxReadinessFailureReason;
+    }
+  | {
+      kind: "timeout_recovery";
+      source: "terminal_command_timeout";
+      outcome: TerminalTimeoutRecoveryOutcome;
     };
 
 export type SandboxResourceMetricsObserver = (
@@ -401,6 +453,8 @@ export interface ToolContext {
   userID: string;
   chatId: string;
   assistantMessageId?: string;
+  /** Trigger.dev run ID when tools execute inside a durable Agent task. */
+  triggerRunId?: string;
   fileAccumulator: FileAccumulator;
   backgroundProcessTracker: BackgroundProcessTracker;
   /** Manages interactive PTY sessions for `run_terminal_cmd` interactive actions. */


### PR DESCRIPTION
## Summary

- correlate E2B pressure/failure events with the owning Trigger run
- classify readiness failures by lifecycle/connectivity cause and initial-vs-reconnect stage
- distinguish terminated, resumable, and untracked terminal wait expiries
- emit reconnect and eventual resumable-command outcomes
- stop terminal retries in the current Agent run after the initial readiness check and one reconnect both fail

## Why

The preliminary HAC-54 readout found that PR #979 reduced no-pressure readiness failures by 93.3% per successful E2B Agent run. The remaining no-pressure observations are 84.9% terminal timeouts, but sampled timeouts often completed successfully and therefore are not equivalent to sandbox failures.

A residual readiness sample failed to fork `/bin/sh` with `permission denied` after reconnect despite normal CPU and memory. The old event schema could not separate that OS/process failure from missing sandboxes, connectivity errors, ordinary terminal wait expiry, or successful recovery.

## Implementation

- add privacy-safe `trigger_run_id` to E2B telemetry emitted by Trigger-hosted Agent runs
- add low-cardinality readiness reason, lifecycle-state, and recovery-stage properties
- emit `e2b_sandbox_recovery_observed` for reconnect outcomes
- add timeout duration, session/termination fields, and `terminal_timeout_outcome`
- emit `e2b_terminal_timeout_recovery_observed` when a resumable E2B command later succeeds, exits non-zero, or fails
- keep `resource_pressure_event_version = 2` so the existing HAC-54 trend remains continuous
- lower the per-run readiness failure ceiling from five to two (initial check + reconnect)
- preserve shared-sandbox safety: recovery clears only the local SDK connection and never kills the per-user sandbox

No prompts, commands, tool output, code, targets, or raw error messages are added to PostHog.

## Validation

- `pnpm test --runInBand`: 313 suites, 3,089 tests passing
- post-rebase focused validation: 6 suites, 162 tests passing
- `pnpm typecheck`
- scoped ESLint
- Prettier check
- `git diff --check`

## Manual verification

After production deployment:

1. Run an E2B Agent terminal command that exceeds its foreground wait window.
2. Confirm the failure event includes `trigger_run_id`, `timeout_seconds`, and `terminal_timeout_outcome`.
3. Resume or let the command finish and confirm a recovery event records the eventual outcome.
4. For a forced readiness failure, confirm initial and reconnect stages are distinct and terminal retries stop after the failed reconnect without killing the shared sandbox.

Tracks HAC-54; the scheduled seven-day resource-pressure readout remains due 2026-08-05.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed sandbox recovery and readiness tracking.
  * Enhanced timeout reporting with termination, resumability, and recovery outcomes.
  * Added run-specific context to sandbox resource monitoring.

* **Bug Fixes**
  * Sandbox availability is now detected after 2 consecutive health failures instead of 5, improving recovery from unhealthy environments.

* **Tests**
  * Expanded coverage for timeout recovery, readiness failures, reconnects, health handling, and sandbox lifecycle transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->