### PR TITLE
Refine sidebar header and mobile spacing

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -133,7 +133,10 @@ const MainSidebar: FC<{
           />
 
           {/* Chat List */}
-          <div className="flex-1 overflow-hidden">
+          <div
+            className="flex-1 overflow-hidden px-2"
+            data-testid="mobile-sidebar-chat-content"
+          >
             <ChatListContent chatListData={chatListData} />
           </div>
 

--- a/app/components/SidebarHeader.tsx
+++ b/app/components/SidebarHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, useMemo, FC } from "react";
+import Link from "next/link";
+import { useEffect, useMemo, useState, type FC } from "react";
 import { Button } from "@/components/ui/button";
 import {
   PanelLeft,
@@ -9,9 +10,50 @@ import {
   Search,
 } from "lucide-react";
 import { useSidebar } from "@/components/ui/sidebar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { HackerAISVG } from "@/components/icons/hackerai-svg";
+import { useGlobalState } from "../contexts/GlobalState";
 import { useChats } from "../hooks/useChats";
 import { useStartNewChat } from "../hooks/useStartNewChat";
 import { MessageSearchDialog } from "./MessageSearchDialog";
+import type { SubscriptionTier } from "@/types";
+
+const SIDEBAR_PLAN_LABELS: Record<SubscriptionTier, string | null> = {
+  free: null,
+  pro: "Pro",
+  "pro-plus": "Pro+",
+  ultra: "Ultra",
+  team: "Team",
+};
+
+interface SidebarActionTooltipProps {
+  label: string;
+  shortcut?: string;
+  side?: "bottom" | "right";
+}
+
+const SidebarActionTooltip: FC<SidebarActionTooltipProps> = ({
+  label,
+  shortcut,
+  side = "bottom",
+}) => (
+  <TooltipContent
+    side={side}
+    sideOffset={6}
+    className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm"
+  >
+    <span>{label}</span>
+    {shortcut ? (
+      <kbd className="text-primary-foreground/70 font-sans text-xs">
+        {shortcut}
+      </kbd>
+    ) : null}
+  </TooltipContent>
+);
 
 interface SidebarHeaderContentProps {
   /** Function to handle closing the sidebar */
@@ -26,21 +68,21 @@ interface SidebarHeaderContentProps {
 interface SidebarHeaderContentImplProps {
   handleCloseSidebar: () => void;
   isCollapsed: boolean;
+  isMobileOverlay: boolean;
   toggleSidebar: () => void;
 }
 
 const SidebarHeaderContentImpl: FC<SidebarHeaderContentImplProps> = ({
   handleCloseSidebar,
   isCollapsed,
+  isMobileOverlay,
   toggleSidebar,
 }) => {
   const startNewChat = useStartNewChat();
+  const { subscription, isCheckingProPlan } = useGlobalState();
 
   // Search dialog state
   const [isSearchOpen, setIsSearchOpen] = useState(false);
-
-  // Hover state for search button
-  const [isSearchHovered, setIsSearchHovered] = useState(false);
 
   // Fetch chats when search dialog is opened to ensure data is available
   // This handles the case where user opens search without opening sidebar first
@@ -52,8 +94,11 @@ const SidebarHeaderContentImpl: FC<SidebarHeaderContentImplProps> = ({
     [],
   );
 
-  // Platform-specific modifier key
-  const modifierKey = isMac ? "⌘" : "Ctrl+";
+  const searchShortcutLabel = isMac ? "⌘K" : "Ctrl+K";
+  const planLabel = isCheckingProPlan
+    ? null
+    : SIDEBAR_PLAN_LABELS[subscription];
+  const showPlanWordmark = planLabel !== null && !isMobileOverlay;
 
   // Add keyboard shortcut for search (Cmd/Ctrl + K)
   useEffect(() => {
@@ -86,45 +131,62 @@ const SidebarHeaderContentImpl: FC<SidebarHeaderContentImplProps> = ({
     return (
       <>
         <div className="flex flex-col items-center p-2">
-          <Button
-            data-testid="sidebar-toggle"
-            variant="ghost"
-            size="sm"
-            className="mb-2 h-8 w-8 p-0 hover:bg-sidebar-accent/50"
-            onClick={toggleSidebar}
-            aria-label="Expand sidebar"
-          >
-            <SidebarIcon className="size-5" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                data-testid="sidebar-toggle"
+                variant="ghost"
+                size="sm"
+                className="mb-2 h-8 w-8 p-0 hover:bg-sidebar-accent/50"
+                onClick={toggleSidebar}
+                aria-label="Open sidebar"
+              >
+                <SidebarIcon className="size-5" />
+              </Button>
+            </TooltipTrigger>
+            <SidebarActionTooltip label="Toggle sidebar" side="right" />
+          </Tooltip>
 
           {/* Sidebar Actions - Collapsed */}
           <div className="flex flex-col items-center">
             {/* New Chat Button - Collapsed */}
             <div className="p-1">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-8 w-8 p-0 hover:bg-sidebar-accent/50"
-                onClick={handleNewChat}
-                aria-label="Start new task"
-              >
-                <SquarePen className="w-4 h-4" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 w-8 p-0 hover:bg-sidebar-accent/50"
+                    onClick={handleNewChat}
+                    aria-label="Start new task"
+                  >
+                    <SquarePen className="size-4" />
+                  </Button>
+                </TooltipTrigger>
+                <SidebarActionTooltip label="New task" side="right" />
+              </Tooltip>
             </div>
 
             {/* Search Button - Collapsed */}
             <div className="p-1">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-8 w-8 p-0 hover:bg-sidebar-accent/50"
-                onClick={handleSearchOpen}
-                aria-label="Search tasks"
-                onMouseEnter={() => setIsSearchHovered(true)}
-                onMouseLeave={() => setIsSearchHovered(false)}
-              >
-                <Search className="w-4 h-4" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 w-8 p-0 hover:bg-sidebar-accent/50"
+                    onClick={handleSearchOpen}
+                    aria-label="Search"
+                  >
+                    <Search className="size-4" />
+                  </Button>
+                </TooltipTrigger>
+                <SidebarActionTooltip
+                  label="Search"
+                  shortcut={searchShortcutLabel}
+                  side="right"
+                />
+              </Tooltip>
             </div>
           </div>
         </div>
@@ -140,23 +202,74 @@ const SidebarHeaderContentImpl: FC<SidebarHeaderContentImplProps> = ({
 
   return (
     <>
-      <div className="flex items-center justify-between p-2">
-        <div className="flex items-center gap-2">
-          {/* Show close button on mobile or desktop when expanded */}
-          <Button
-            data-testid="sidebar-toggle"
-            variant="ghost"
-            size="sm"
-            className="-ms-1 h-8 w-8 p-0"
-            onClick={handleCloseSidebar}
-          >
-            <PanelLeft className="size-5" />
-          </Button>
+      <div
+        data-testid="sidebar-top-header"
+        className={`sticky top-0 z-30 flex items-center justify-between bg-sidebar ${
+          isMobileOverlay ? "h-14 ps-3 pe-2.5" : "h-10"
+        }`}
+      >
+        <Link
+          href="/"
+          data-testid="sidebar-home"
+          onClick={isMobileOverlay ? handleCloseSidebar : undefined}
+          aria-label={
+            planLabel ? `HackerAI ${planLabel} home` : "HackerAI home"
+          }
+          className={`flex h-9 items-center rounded-lg text-sidebar-foreground no-underline outline-none hover:bg-transparent hover:no-underline focus-visible:underline focus-visible:underline-offset-4 ${
+            showPlanWordmark ? "px-2.5" : "w-9 justify-center"
+          }`}
+        >
+          {showPlanWordmark ? (
+            <span className="flex min-w-0 items-baseline gap-1 whitespace-nowrap text-[18px] leading-6 font-semibold">
+              <span>HackerAI</span>
+              <span className="font-medium text-sidebar-foreground/55">
+                {planLabel}
+              </span>
+            </span>
+          ) : (
+            <HackerAISVG theme="dark" scale={isMobileOverlay ? 0.11 : 0.1} />
+          )}
+        </Link>
+
+        <div className="flex items-center gap-0">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="size-9 text-sidebar-foreground/65 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+                onClick={handleSearchOpen}
+                aria-label="Search"
+              >
+                <Search className="size-[18px]" />
+              </Button>
+            </TooltipTrigger>
+            <SidebarActionTooltip
+              label="Search"
+              shortcut={searchShortcutLabel}
+            />
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                data-testid="sidebar-toggle"
+                variant="ghost"
+                size="icon-sm"
+                className="size-9 cursor-w-resize text-sidebar-foreground/65 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+                onClick={handleCloseSidebar}
+                aria-label="Close sidebar"
+              >
+                <PanelLeft className="size-[18px]" />
+              </Button>
+            </TooltipTrigger>
+            <SidebarActionTooltip label="Toggle sidebar" />
+          </Tooltip>
         </div>
       </div>
 
       {/* Sidebar Actions - Expanded */}
-      <div className="flex flex-col">
+      <div className={`flex flex-col ${isMobileOverlay ? "px-2" : ""}`}>
         {/* New Chat Button styled like a chat item */}
         <div className="py-1">
           <Button
@@ -165,34 +278,9 @@ const SidebarHeaderContentImpl: FC<SidebarHeaderContentImplProps> = ({
             onClick={handleNewChat}
             aria-label="Start new task"
           >
-            <SquarePen className="w-4 h-4" />
+            <SquarePen className="size-4" />
             <div className="mr-2 flex-1 overflow-hidden text-clip whitespace-nowrap text-sm font-medium text-left">
               New task
-            </div>
-          </Button>
-        </div>
-
-        {/* Search Button styled like a chat item */}
-        <div className="py-1">
-          <Button
-            variant="ghost"
-            className="relative flex w-full justify-start items-center rounded-lg p-2 h-auto hover:bg-sidebar-accent/50 text-left"
-            onClick={handleSearchOpen}
-            aria-label="Search tasks"
-            onMouseEnter={() => setIsSearchHovered(true)}
-            onMouseLeave={() => setIsSearchHovered(false)}
-          >
-            <Search className="w-4 h-4" />
-            <div className="mr-2 flex-1 overflow-hidden text-clip whitespace-nowrap text-sm font-medium text-left">
-              Search tasks
-            </div>
-            {/* Only show shortcut when hovering directly on the search button */}
-            <div
-              className={`text-xs transition-opacity ${
-                isSearchHovered ? "opacity-100" : "opacity-0"
-              }`}
-            >
-              {modifierKey}K
             </div>
           </Button>
         </div>
@@ -213,6 +301,7 @@ const DesktopSidebarHeaderContent: FC<
     <SidebarHeaderContentImpl
       handleCloseSidebar={handleCloseSidebar}
       isCollapsed={isCollapsed}
+      isMobileOverlay={false}
       toggleSidebar={toggleSidebar}
     />
   );
@@ -227,6 +316,7 @@ const MobileSidebarHeaderContent: FC<
     <SidebarHeaderContentImpl
       handleCloseSidebar={handleCloseSidebar}
       isCollapsed={isCollapsed}
+      isMobileOverlay={true}
       toggleSidebar={toggleSidebar}
     />
   );

--- a/app/components/SidebarHeader.tsx
+++ b/app/components/SidebarHeader.tsx
@@ -98,7 +98,7 @@ const SidebarHeaderContentImpl: FC<SidebarHeaderContentImplProps> = ({
   const planLabel = isCheckingProPlan
     ? null
     : SIDEBAR_PLAN_LABELS[subscription];
-  const showPlanWordmark = planLabel !== null && !isMobileOverlay;
+  const showPlanWordmark = Boolean(planLabel) && !isMobileOverlay;
 
   // Add keyboard shortcut for search (Cmd/Ctrl + K)
   useEffect(() => {

--- a/app/components/SidebarHeader.tsx
+++ b/app/components/SidebarHeader.tsx
@@ -256,7 +256,7 @@ const SidebarHeaderContentImpl: FC<SidebarHeaderContentImplProps> = ({
                 data-testid="sidebar-toggle"
                 variant="ghost"
                 size="icon-sm"
-                className="size-9 cursor-w-resize text-sidebar-foreground/65 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+                className="size-9 text-sidebar-foreground/65 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
                 onClick={handleCloseSidebar}
                 aria-label="Close sidebar"
               >

--- a/app/components/SidebarHeader.tsx
+++ b/app/components/SidebarHeader.tsx
@@ -137,30 +137,30 @@ const SidebarHeaderContentImpl: FC<SidebarHeaderContentImplProps> = ({
                 data-testid="sidebar-toggle"
                 variant="ghost"
                 size="sm"
-                className="mb-2 h-8 w-8 p-0 hover:bg-sidebar-accent/50"
+                className="mb-2 size-9 p-0 hover:bg-sidebar-accent/50"
                 onClick={toggleSidebar}
                 aria-label="Open sidebar"
               >
-                <SidebarIcon className="size-5" />
+                <SidebarIcon className="size-[18px]" />
               </Button>
             </TooltipTrigger>
             <SidebarActionTooltip label="Toggle sidebar" side="right" />
           </Tooltip>
 
           {/* Sidebar Actions - Collapsed */}
-          <div className="flex flex-col items-center">
+          <div className="flex flex-col items-center gap-px">
             {/* New Chat Button - Collapsed */}
-            <div className="p-1">
+            <div>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="h-8 w-8 p-0 hover:bg-sidebar-accent/50"
+                    className="size-9 p-0 hover:bg-sidebar-accent/50"
                     onClick={handleNewChat}
                     aria-label="Start new task"
                   >
-                    <SquarePen className="size-4" />
+                    <SquarePen className="size-[18px]" />
                   </Button>
                 </TooltipTrigger>
                 <SidebarActionTooltip label="New task" side="right" />
@@ -168,17 +168,17 @@ const SidebarHeaderContentImpl: FC<SidebarHeaderContentImplProps> = ({
             </div>
 
             {/* Search Button - Collapsed */}
-            <div className="p-1">
+            <div>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="h-8 w-8 p-0 hover:bg-sidebar-accent/50"
+                    className="size-9 p-0 hover:bg-sidebar-accent/50"
                     onClick={handleSearchOpen}
                     aria-label="Search"
                   >
-                    <Search className="size-4" />
+                    <Search className="size-[18px]" />
                   </Button>
                 </TooltipTrigger>
                 <SidebarActionTooltip

--- a/app/components/__tests__/Sidebar.test.tsx
+++ b/app/components/__tests__/Sidebar.test.tsx
@@ -42,7 +42,11 @@ jest.mock("@/app/hooks/useProjects", () => ({
 }));
 jest.mock("../SidebarHeader", () => ({
   __esModule: true,
-  default: () => <div>Header</div>,
+  default: ({ isMobileOverlay }: { isMobileOverlay?: boolean }) => (
+    <div data-testid="sidebar-header" data-mobile={isMobileOverlay}>
+      Header
+    </div>
+  ),
 }));
 jest.mock("../SidebarUserNav", () => ({
   __esModule: true,
@@ -85,5 +89,17 @@ describe("MainSidebar", () => {
     expect(collapsedContent).toHaveAttribute("aria-hidden", "true");
     expect(collapsedContent).toHaveAttribute("inert");
     expect(screen.getByTestId("sidebar-chat-sections")).toBeInTheDocument();
+  });
+
+  it("adds consistent side gutters to the mobile sidebar", () => {
+    render(<MainSidebar isMobileOverlay={true} chatListData={chatListData} />);
+
+    expect(screen.getByTestId("sidebar-header")).toHaveAttribute(
+      "data-mobile",
+      "true",
+    );
+    expect(screen.getByTestId("mobile-sidebar-chat-content")).toHaveClass(
+      "px-2",
+    );
   });
 });

--- a/app/components/__tests__/SidebarHeader.test.tsx
+++ b/app/components/__tests__/SidebarHeader.test.tsx
@@ -1,29 +1,57 @@
 import "@testing-library/jest-dom";
-import { describe, expect, it, jest } from "@jest/globals";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { fireEvent, render, screen } from "@testing-library/react";
+import type { SubscriptionTier } from "@/types";
 
 const mockToggleSidebar = jest.fn();
+const mockStartNewChat = jest.fn();
+let mockSubscription: SubscriptionTier = "free";
+let mockIsCheckingProPlan = false;
 
 jest.mock("@/components/ui/sidebar", () => ({
   useSidebar: () => ({ toggleSidebar: mockToggleSidebar }),
 }));
+jest.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
 jest.mock("@/components/icons/hackerai-svg", () => ({
-  HackerAISVG: () => <div data-testid="hackerai-svg" />,
+  HackerAISVG: ({ scale }: { scale?: number }) => (
+    <div data-testid="hackerai-svg" data-scale={scale} />
+  ),
+}));
+jest.mock("@/app/contexts/GlobalState", () => ({
+  useGlobalState: () => ({
+    subscription: mockSubscription,
+    isCheckingProPlan: mockIsCheckingProPlan,
+  }),
 }));
 jest.mock("@/app/hooks/useChats", () => ({
   useChats: jest.fn(),
 }));
 jest.mock("@/app/hooks/useStartNewChat", () => ({
-  useStartNewChat: () => jest.fn(),
+  useStartNewChat: () => mockStartNewChat,
 }));
 jest.mock("../MessageSearchDialog", () => ({
-  MessageSearchDialog: () => null,
+  MessageSearchDialog: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div role="dialog">Task search</div> : null,
 }));
 
 const SidebarHeaderContent = require("../SidebarHeader")
   .default as typeof import("../SidebarHeader").default;
 
 describe("SidebarHeaderContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSubscription = "free";
+    mockIsCheckingProPlan = false;
+  });
+
   it("shows the sidebar button instead of the HackerAI icon when collapsed", () => {
     render(
       <SidebarHeaderContent
@@ -33,7 +61,7 @@ describe("SidebarHeaderContent", () => {
     );
 
     const expandButton = screen.getByRole("button", {
-      name: "Expand sidebar",
+      name: "Open sidebar",
     });
 
     expect(screen.queryByTestId("hackerai-svg")).not.toBeInTheDocument();
@@ -42,5 +70,99 @@ describe("SidebarHeaderContent", () => {
     expect(mockToggleSidebar).not.toHaveBeenCalled();
     fireEvent.click(expandButton);
     expect(mockToggleSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows only the HackerAI mark for free users", () => {
+    render(
+      <SidebarHeaderContent
+        handleCloseSidebar={jest.fn()}
+        isCollapsed={false}
+      />,
+    );
+
+    const homeLink = screen.getByRole("link", { name: "HackerAI home" });
+
+    expect(homeLink).toContainElement(screen.getByTestId("hackerai-svg"));
+    expect(screen.queryByText("HackerAI")).not.toBeInTheDocument();
+    expect(screen.queryByText("Free")).not.toBeInTheDocument();
+  });
+
+  it.each<[SubscriptionTier, string]>([
+    ["pro", "Pro"],
+    ["pro-plus", "Pro+"],
+    ["ultra", "Ultra"],
+    ["team", "Team"],
+  ])("shows the %s subscription in the header", (subscription, label) => {
+    mockSubscription = subscription;
+
+    render(
+      <SidebarHeaderContent
+        handleCloseSidebar={jest.fn()}
+        isCollapsed={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: `HackerAI ${label} home` }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("hackerai-svg")).not.toBeInTheDocument();
+    expect(screen.getByText("HackerAI")).toBeInTheDocument();
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it("uses icon-only branding and roomier spacing in the mobile overlay", () => {
+    mockSubscription = "pro";
+    const handleCloseSidebar = jest.fn();
+
+    render(
+      <SidebarHeaderContent
+        handleCloseSidebar={handleCloseSidebar}
+        isCollapsed={false}
+        isMobileOverlay={true}
+      />,
+    );
+
+    const homeLink = screen.getByRole("link", {
+      name: "HackerAI Pro home",
+    });
+    const logo = screen.getByTestId("hackerai-svg");
+
+    expect(homeLink).toContainElement(logo);
+    expect(logo).toHaveAttribute("data-scale", "0.11");
+    expect(screen.queryByText("HackerAI")).not.toBeInTheDocument();
+    expect(screen.queryByText("Pro")).not.toBeInTheDocument();
+    expect(screen.getByTestId("sidebar-top-header")).toHaveClass(
+      "h-14",
+      "ps-3",
+      "pe-2.5",
+    );
+    expect(
+      screen.getByRole("button", { name: "Start new task" }).parentElement
+        ?.parentElement,
+    ).toHaveClass("px-2");
+
+    fireEvent.click(homeLink);
+    expect(handleCloseSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves search into the header and closes the sidebar from its icon", () => {
+    const handleCloseSidebar = jest.fn();
+
+    render(
+      <SidebarHeaderContent
+        handleCloseSidebar={handleCloseSidebar}
+        isCollapsed={false}
+      />,
+    );
+
+    expect(screen.queryByText("Search tasks")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    expect(screen.getByRole("dialog", { name: "" })).toHaveTextContent(
+      "Task search",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close sidebar" }));
+    expect(handleCloseSidebar).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/__tests__/SidebarHeader.test.tsx
+++ b/app/components/__tests__/SidebarHeader.test.tsx
@@ -66,6 +66,18 @@ describe("SidebarHeaderContent", () => {
 
     expect(screen.queryByTestId("hackerai-svg")).not.toBeInTheDocument();
     expect(expandButton.querySelector("svg")).toBeInTheDocument();
+    expect(expandButton).toHaveClass("size-9");
+    expect(expandButton.querySelector("svg")).toHaveClass("size-[18px]");
+
+    const newTaskButton = screen.getByRole("button", {
+      name: "Start new task",
+    });
+    const searchButton = screen.getByRole("button", { name: "Search" });
+
+    expect(newTaskButton).toHaveClass("size-9");
+    expect(newTaskButton.querySelector("svg")).toHaveClass("size-[18px]");
+    expect(searchButton).toHaveClass("size-9");
+    expect(searchButton.querySelector("svg")).toHaveClass("size-[18px]");
 
     expect(mockToggleSidebar).not.toHaveBeenCalled();
     fireEvent.click(expandButton);

--- a/app/components/__tests__/SidebarHeader.test.tsx
+++ b/app/components/__tests__/SidebarHeader.test.tsx
@@ -162,7 +162,12 @@ describe("SidebarHeaderContent", () => {
       "Task search",
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Close sidebar" }));
+    const closeButton = screen.getByRole("button", { name: "Close sidebar" });
+
+    expect(closeButton).not.toHaveClass("cursor-pointer");
+    expect(closeButton).not.toHaveClass("cursor-w-resize");
+
+    fireEvent.click(closeButton);
     expect(handleCloseSidebar).toHaveBeenCalledTimes(1);
   });
 });

--- a/components/ui/__tests__/sidebar.test.tsx
+++ b/components/ui/__tests__/sidebar.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import React from "react";
-import { act, render } from "@testing-library/react";
+import { act, fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, jest } from "@jest/globals";
 import { SidebarProvider } from "../sidebar";
 
@@ -33,6 +33,35 @@ describe("SidebarProvider", () => {
         window.dispatchEvent(new Event("keydown"));
       });
     }).not.toThrow();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps the existing Cmd/Ctrl+Shift+S shortcut", () => {
+    const onOpenChange = jest.fn();
+
+    render(
+      <SidebarProvider open={true} onOpenChange={onOpenChange}>
+        <div>content</div>
+      </SidebarProvider>,
+    );
+
+    fireEvent.keyDown(window, { key: "s", metaKey: true, shiftKey: true });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does not replace the sidebar shortcut with Cmd/Ctrl+B", () => {
+    const onOpenChange = jest.fn();
+
+    render(
+      <SidebarProvider open={true} onOpenChange={onOpenChange}>
+        <div>content</div>
+      </SidebarProvider>,
+    );
+
+    fireEvent.keyDown(window, { key: "b", metaKey: true });
+    fireEvent.keyDown(window, { key: "b", ctrlKey: true });
+
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 });

--- a/components/ui/__tests__/sidebar.test.tsx
+++ b/components/ui/__tests__/sidebar.test.tsx
@@ -83,14 +83,18 @@ describe("SidebarProvider", () => {
     const rail = container.querySelector('[data-sidebar="rail"]');
 
     expect(rail).toHaveClass("cursor-default");
-    expect(rail?.className).not.toContain("cursor-w-resize");
-    expect(rail?.className).not.toContain("cursor-e-resize");
+    expect(rail?.className).toContain(
+      "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize",
+    );
+    expect(rail?.className).toContain(
+      "[[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+    );
 
     fireEvent.click(rail!);
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it("uses the default cursor on the collapsed expand area", () => {
+  it("shows the expand cursor on the collapsed expand area", () => {
     const { container } = render(
       <SidebarProvider open={false} onOpenChange={jest.fn()}>
         <Sidebar>
@@ -101,7 +105,6 @@ describe("SidebarProvider", () => {
 
     const expandArea = container.querySelector('[data-sidebar="expand-area"]');
 
-    expect(expandArea).toHaveClass("cursor-default");
-    expect(expandArea?.className).not.toContain("cursor-e-resize");
+    expect(expandArea).toHaveClass("cursor-e-resize");
   });
 });

--- a/components/ui/__tests__/sidebar.test.tsx
+++ b/components/ui/__tests__/sidebar.test.tsx
@@ -26,14 +26,32 @@ jest.mock("@/lib/utils/sidebar-storage", () => ({
 describe("SidebarProvider", () => {
   it("uses a 52px collapsed sidebar width", () => {
     const { container } = render(
-      <SidebarProvider>
-        <div>content</div>
+      <SidebarProvider open={false} onOpenChange={jest.fn()}>
+        <Sidebar collapsible="icon">
+          <SidebarContent />
+        </Sidebar>
       </SidebarProvider>,
     );
 
-    expect(container.firstElementChild).toHaveStyle({
+    const wrapper = container.querySelector('[data-slot="sidebar-wrapper"]');
+    const sidebar = container.querySelector(
+      '[data-slot="sidebar"][data-state="collapsed"]',
+    );
+    const sidebarGap = sidebar?.querySelector('[data-slot="sidebar-gap"]');
+    const sidebarContainer = sidebar?.querySelector(
+      '[data-slot="sidebar-container"]',
+    );
+
+    expect(sidebar).toHaveAttribute("data-collapsible", "icon");
+    expect(wrapper).toHaveStyle({
       "--sidebar-width-icon": "3.25rem",
     });
+    expect(sidebarGap).toHaveClass(
+      "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
+    );
+    expect(sidebarContainer).toHaveClass(
+      "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
+    );
   });
 
   it("ignores keydown events without a string key", () => {

--- a/components/ui/__tests__/sidebar.test.tsx
+++ b/components/ui/__tests__/sidebar.test.tsx
@@ -24,6 +24,18 @@ jest.mock("@/lib/utils/sidebar-storage", () => ({
 }));
 
 describe("SidebarProvider", () => {
+  it("uses a 52px collapsed sidebar width", () => {
+    const { container } = render(
+      <SidebarProvider>
+        <div>content</div>
+      </SidebarProvider>,
+    );
+
+    expect(container.firstElementChild).toHaveStyle({
+      "--sidebar-width-icon": "3.25rem",
+    });
+  });
+
   it("ignores keydown events without a string key", () => {
     const onOpenChange = jest.fn();
 

--- a/components/ui/__tests__/sidebar.test.tsx
+++ b/components/ui/__tests__/sidebar.test.tsx
@@ -2,7 +2,12 @@ import "@testing-library/jest-dom";
 import React from "react";
 import { act, fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, jest } from "@jest/globals";
-import { SidebarProvider } from "../sidebar";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarProvider,
+  SidebarRail,
+} from "../sidebar";
 
 jest.mock("@/hooks/use-mobile", () => ({
   useIsMobile: () => false,
@@ -63,5 +68,40 @@ describe("SidebarProvider", () => {
     fireEvent.keyDown(window, { key: "b", ctrlKey: true });
 
     expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("uses the default cursor instead of a resize cursor on the sidebar rail", () => {
+    const onOpenChange = jest.fn();
+    const { container } = render(
+      <SidebarProvider open={true} onOpenChange={onOpenChange}>
+        <Sidebar>
+          <SidebarRail />
+        </Sidebar>
+      </SidebarProvider>,
+    );
+
+    const rail = container.querySelector('[data-sidebar="rail"]');
+
+    expect(rail).toHaveClass("cursor-default");
+    expect(rail?.className).not.toContain("cursor-w-resize");
+    expect(rail?.className).not.toContain("cursor-e-resize");
+
+    fireEvent.click(rail!);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("uses the default cursor on the collapsed expand area", () => {
+    const { container } = render(
+      <SidebarProvider open={false} onOpenChange={jest.fn()}>
+        <Sidebar>
+          <SidebarContent />
+        </Sidebar>
+      </SidebarProvider>,
+    );
+
+    const expandArea = container.querySelector('[data-sidebar="expand-area"]');
+
+    expect(expandArea).toHaveClass("cursor-default");
+    expect(expandArea?.className).not.toContain("cursor-e-resize");
   });
 });

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -29,7 +29,7 @@ import {
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "300px";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
-const SIDEBAR_WIDTH_ICON = "3rem";
+const SIDEBAR_WIDTH_ICON = "3.25rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "s";
 
 type SidebarContextProps = {

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -305,9 +305,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
-        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 cursor-default transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
         "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0",
         "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
         "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
@@ -334,7 +332,7 @@ function SidebarExpandArea({
       data-sidebar="expand-area"
       data-slot="sidebar-expand-area"
       className={cn(
-        "absolute inset-0 z-10 cursor-e-resize hover:bg-sidebar-accent/5 transition-colors",
+        "absolute inset-0 z-10 cursor-default hover:bg-sidebar-accent/5 transition-colors",
         className,
       )}
       onClick={toggleSidebar}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -306,6 +306,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
       title="Toggle Sidebar"
       className={cn(
         "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 cursor-default transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
         "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0",
         "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
         "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
@@ -332,7 +333,7 @@ function SidebarExpandArea({
       data-sidebar="expand-area"
       data-slot="sidebar-expand-area"
       className={cn(
-        "absolute inset-0 z-10 cursor-default hover:bg-sidebar-accent/5 transition-colors",
+        "absolute inset-0 z-10 cursor-e-resize hover:bg-sidebar-accent/5 transition-colors",
         className,
       )}
       onClick={toggleSidebar}


### PR DESCRIPTION
## Summary
- consolidate sidebar search into the top header and show subscription-aware desktop branding
- preserve the existing sidebar toggle behavior and shortcut while using smaller, aligned header icons
- use icon-only branding, a 56px header, and consistent side gutters in the mobile overlay
- close the mobile sidebar when the HackerAI home icon is tapped
- keep the open sidebar boundary on the normal arrow while retaining a directional expand cursor when collapsed
- match the collapsed reference with a 52px rail, centered 36px controls, and 18px icons
- add regression coverage for subscription labels, mobile spacing, search, cursor affordances, sizing, and sidebar shortcuts

## Why
The sidebar actions used separate padding and header treatments, which left key icons and task text visually misaligned. The desktop header also lacked a compact plan-aware hierarchy, while the mobile overlay reused spacing and branding that felt oversized and cramped. The expanded sidebar boundary also advertised drag-resizing even though it only toggles the fixed-width sidebar.

## Validation
- `corepack pnpm typecheck`
- `corepack pnpm test` — 313 suites and 3,091 tests passed
- focused Sidebar, SidebarHeader, and sidebar-provider tests
- targeted Prettier and ESLint checks
- Chrome verification at 390×844: open sidebar, open search, tap HackerAI home icon, and close sidebar
- Chrome verification of the desktop sidebar rail location and click-to-collapse behavior

## Manual verification
1. On desktop, open the sidebar and confirm paid users see `HackerAI <plan>` while free users see the HackerAI icon.
2. Confirm Search opens from the header and the sidebar toggle tooltip says `Toggle sidebar`.
3. With the desktop sidebar open, hover its boundary and confirm the cursor remains the normal arrow.
4. Collapse the sidebar and confirm the rail is 52px wide with centered 36px controls and 18px icons.
5. Hover the collapsed expand edge and confirm the directional resize cursor appears and clicking reopens the sidebar.
6. On mobile, open the task sidebar and confirm the icon-only header, side gutters, and 36px header controls.
7. Tap the HackerAI icon and confirm the home/new-task view opens while the sidebar closes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subscription-specific sidebar branding, improved search and new-task controls, and tooltips for sidebar actions.
  * Improved mobile sidebar overlays with consistent spacing, layout, and closing behavior.
  * Updated sidebar accessibility labels and interaction cues.

* **Bug Fixes**
  * Improved supported sidebar keyboard shortcuts and rail interactions.
  * Corrected sidebar rail and expand-area cursor styling.

* **Tests**
  * Expanded coverage for branding, mobile layouts, search, accessibility, and keyboard shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->