### PR TITLE
Restore expanded project folders after reload

### DIFF
--- a/app/components/SidebarChatSections.tsx
+++ b/app/components/SidebarChatSections.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useId, useState, type ReactNode, type RefObject } from "react";
+import {
+  useId,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+  type RefObject,
+} from "react";
 import { ChevronRight } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -21,6 +28,13 @@ import {
 } from "@dnd-kit/core";
 import type { Doc } from "@/convex/_generated/dataModel";
 import { usePinChat, useUnpinChat } from "@/app/hooks/useChats";
+import {
+  getOpenSidebarProjectIdsSnapshot,
+  getServerOpenSidebarProjectIdsSnapshot,
+  parseOpenSidebarProjectIdsSnapshot,
+  subscribeOpenSidebarProjectIds,
+  writeOpenSidebarProjectIds,
+} from "@/lib/utils/client-storage";
 import SidebarHistory, { type SidebarPaginationStatus } from "./SidebarHistory";
 import { SidebarProjects } from "./SidebarProjects";
 import {
@@ -140,6 +154,15 @@ export function SidebarChatSections({
 }: SidebarChatSectionsProps) {
   const [isPinnedOpen, setIsPinnedOpen] = useState(true);
   const [isTasksOpen, setIsTasksOpen] = useState(true);
+  const openProjectIdsSnapshot = useSyncExternalStore(
+    subscribeOpenSidebarProjectIds,
+    getOpenSidebarProjectIdsSnapshot,
+    getServerOpenSidebarProjectIdsSnapshot,
+  );
+  const openProjectIds = useMemo(
+    () => new Set(parseOpenSidebarProjectIdsSnapshot(openProjectIdsSnapshot)),
+    [openProjectIdsSnapshot],
+  );
   const [activeTask, setActiveTask] = useState<SidebarChatDragData>();
   const pinChat = usePinChat();
   const unpinChat = useUnpinChat();
@@ -153,6 +176,19 @@ export function SidebarChatSections({
   );
   const hasPinnedItems =
     pinnedChats.length > 0 || (pinnedProjects?.length ?? 0) > 0;
+
+  const handleProjectOpenChange = (projectId: string, open: boolean) => {
+    const next = new Set(openProjectIds);
+    if (open) next.add(projectId);
+    else next.delete(projectId);
+    writeOpenSidebarProjectIds(next);
+  };
+
+  const handleCollapseProjects = (projectIds: readonly string[]) => {
+    const next = new Set(openProjectIds);
+    projectIds.forEach((projectId) => next.delete(projectId));
+    writeOpenSidebarProjectIds(next);
+  };
 
   const handlePinnedDrop = async (chat: SidebarChatDragData) => {
     if (chat.isPinned) return;
@@ -234,12 +270,21 @@ export function SidebarChatSections({
               showEmptyState={false}
               testId="sidebar-pinned-chat-list"
             />
-            <SidebarProjects projects={pinnedProjects} variant="pinned-list" />
+            <SidebarProjects
+              projects={pinnedProjects}
+              openProjectIds={openProjectIds}
+              onProjectOpenChange={handleProjectOpenChange}
+              onCollapseProjects={handleCollapseProjects}
+              variant="pinned-list"
+            />
           </CollapsibleChatSection>
         ) : null}
 
         <SidebarProjects
           projects={unpinnedProjects}
+          openProjectIds={openProjectIds}
+          onProjectOpenChange={handleProjectOpenChange}
+          onCollapseProjects={handleCollapseProjects}
           paginationStatus={projectPaginationStatus}
           loadMore={loadMoreProjects}
         />

--- a/app/components/SidebarProjects.tsx
+++ b/app/components/SidebarProjects.tsx
@@ -25,6 +25,9 @@ import { SidebarProjectItem } from "./SidebarProjectItem";
 
 interface SidebarProjectsProps {
   projects: Doc<"projects">[] | undefined;
+  openProjectIds: ReadonlySet<string>;
+  onProjectOpenChange: (projectId: string, open: boolean) => void;
+  onCollapseProjects: (projectIds: readonly string[]) => void;
   variant?: "section" | "pinned-list";
   paginationStatus?:
     "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
@@ -33,6 +36,9 @@ interface SidebarProjectsProps {
 
 export function SidebarProjects({
   projects,
+  openProjectIds,
+  onProjectOpenChange,
+  onCollapseProjects,
   variant = "section",
   paginationStatus,
   loadMore,
@@ -42,9 +48,6 @@ export function SidebarProjects({
   const startNewChat = useStartNewChat();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isSectionOpen, setIsSectionOpen] = useState(true);
-  const [openProjectIds, setOpenProjectIds] = useState<Set<string>>(
-    () => new Set(),
-  );
 
   const projectIds = projects?.map((project) => project._id) ?? [];
   const hasOpenProjects = projectIds.some((projectId) =>
@@ -52,12 +55,7 @@ export function SidebarProjects({
   );
 
   const setProjectOpen = (projectId: string, open: boolean) => {
-    setOpenProjectIds((current) => {
-      const next = new Set(current);
-      if (open) next.add(projectId);
-      else next.delete(projectId);
-      return next;
-    });
+    onProjectOpenChange(projectId, open);
   };
 
   const handleCreated = (projectId: Id<"projects">) => {
@@ -66,7 +64,7 @@ export function SidebarProjects({
   };
 
   const collapseAllProjects = () => {
-    setOpenProjectIds(new Set());
+    onCollapseProjects(projectIds);
   };
 
   const isPinnedList = variant === "pinned-list";

--- a/app/components/__tests__/SidebarChatSections.test.tsx
+++ b/app/components/__tests__/SidebarChatSections.test.tsx
@@ -13,6 +13,7 @@ import {
   type SidebarChatDragData,
   type SidebarChatDropData,
 } from "../sidebar-chat-drag";
+import { SIDEBAR_OPEN_PROJECT_IDS_STORAGE_KEY } from "@/lib/utils/client-storage";
 
 const mockPinChat = jest.fn();
 const mockUnpinChat = jest.fn();
@@ -75,9 +76,13 @@ jest.mock("sonner", () => ({
 
 jest.mock("../SidebarProjects", () => ({
   SidebarProjects: ({
+    openProjectIds,
+    onProjectOpenChange,
     projects,
     variant = "section",
   }: {
+    openProjectIds: ReadonlySet<string>;
+    onProjectOpenChange: (projectId: string, open: boolean) => void;
     projects: Array<{ _id: string; name: string }>;
     variant?: "section" | "pinned-list";
   }) => (
@@ -89,7 +94,17 @@ jest.mock("../SidebarProjects", () => ({
       }
     >
       {projects.map((project) => (
-        <span key={project._id}>{project.name}</span>
+        <button
+          key={project._id}
+          type="button"
+          data-open={String(openProjectIds.has(project._id))}
+          onClick={() =>
+            onProjectOpenChange(project._id, !openProjectIds.has(project._id))
+          }
+          aria-label={`Toggle ${project.name}`}
+        >
+          {project.name}
+        </button>
       ))}
     </section>
   ),
@@ -151,6 +166,7 @@ describe("SidebarChatSections", () => {
     mockRectIntersection.mockReturnValue([]);
     mockPinChat.mockResolvedValue(null);
     mockUnpinChat.mockResolvedValue(null);
+    window.localStorage.clear();
   });
 
   it("moves pinned projects under Pinned and keeps unpinned projects in Projects", () => {
@@ -210,6 +226,57 @@ describe("SidebarChatSections", () => {
       expect.any(Function),
     );
     expect(mockDndContextProps.sensors).toHaveLength(3);
+  });
+
+  it("restores expanded projects across pinned and regular lists", async () => {
+    const props = {
+      chats,
+      projects,
+      paginationStatus: "Exhausted" as const,
+    };
+    const firstRender = render(<SidebarChatSections {...props} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Toggle Pinned project" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Toggle Regular project" }),
+    );
+    await waitFor(() => {
+      expect(
+        window.localStorage.getItem(SIDEBAR_OPEN_PROJECT_IDS_STORAGE_KEY),
+      ).toBe(JSON.stringify(["pinned-project", "regular-project"]));
+    });
+
+    firstRender.unmount();
+    render(<SidebarChatSections {...props} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Toggle Pinned project" }),
+      ).toHaveAttribute("data-open", "true");
+      expect(
+        screen.getByRole("button", { name: "Toggle Regular project" }),
+      ).toHaveAttribute("data-open", "true");
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Toggle Regular project" }),
+    );
+    await waitFor(() => {
+      expect(
+        window.localStorage.getItem(SIDEBAR_OPEN_PROJECT_IDS_STORAGE_KEY),
+      ).toBe(JSON.stringify(["pinned-project"]));
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Toggle Pinned project" }),
+    );
+    await waitFor(() => {
+      expect(
+        window.localStorage.getItem(SIDEBAR_OPEN_PROJECT_IDS_STORAGE_KEY),
+      ).toBeNull();
+    });
   });
 
   it("collapses pinned chats and tasks independently", () => {

--- a/app/components/__tests__/SidebarProjects.test.tsx
+++ b/app/components/__tests__/SidebarProjects.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { useState, type ComponentProps } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Doc } from "@/convex/_generated/dataModel";
@@ -76,6 +77,39 @@ const { toast: mockToast } = jest.requireMock<{
 const { SidebarProjects } =
   require("../SidebarProjects") as typeof import("../SidebarProjects");
 
+type SidebarProjectsHarnessProps = Omit<
+  ComponentProps<typeof SidebarProjects>,
+  "openProjectIds" | "onProjectOpenChange" | "onCollapseProjects"
+>;
+
+function SidebarProjectsHarness(props: SidebarProjectsHarnessProps) {
+  const [openProjectIds, setOpenProjectIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  return (
+    <SidebarProjects
+      {...props}
+      openProjectIds={openProjectIds}
+      onProjectOpenChange={(projectId, open) => {
+        setOpenProjectIds((current) => {
+          const next = new Set(current);
+          if (open) next.add(projectId);
+          else next.delete(projectId);
+          return next;
+        });
+      }}
+      onCollapseProjects={(projectIds) => {
+        setOpenProjectIds((current) => {
+          const next = new Set(current);
+          projectIds.forEach((projectId) => next.delete(projectId));
+          return next;
+        });
+      }}
+    />
+  );
+}
+
 const projects = ["Acme", "Example"].map(
   (name, index) =>
     ({
@@ -97,7 +131,7 @@ describe("SidebarProjects", () => {
   });
 
   it("only shows collapse-all while an individual project is open", () => {
-    render(<SidebarProjects projects={projects} />);
+    render(<SidebarProjectsHarness projects={projects} />);
 
     expect(
       screen.queryByRole("button", { name: "Collapse all projects" }),
@@ -130,7 +164,7 @@ describe("SidebarProjects", () => {
 
   it("shows the create-project label on hover", async () => {
     const user = userEvent.setup();
-    render(<SidebarProjects projects={projects} />);
+    render(<SidebarProjectsHarness projects={projects} />);
 
     const createButton = screen.getByRole("button", {
       name: "Create project",
@@ -143,7 +177,7 @@ describe("SidebarProjects", () => {
 
   it("shows the collapse-all label on hover", async () => {
     const user = userEvent.setup();
-    render(<SidebarProjects projects={projects} />);
+    render(<SidebarProjectsHarness projects={projects} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Toggle Acme" }));
     await user.hover(
@@ -155,7 +189,7 @@ describe("SidebarProjects", () => {
   });
 
   it("shows a new-project row when there are no projects", () => {
-    render(<SidebarProjects projects={[]} />);
+    render(<SidebarProjectsHarness projects={[]} />);
 
     expect(
       screen.getByRole("button", { name: "New project" }),
@@ -174,7 +208,7 @@ describe("SidebarProjects", () => {
   });
 
   it("does not show the new-project row when projects exist", () => {
-    render(<SidebarProjects projects={projects} />);
+    render(<SidebarProjectsHarness projects={projects} />);
 
     expect(
       screen.queryByRole("button", { name: "New project" }),
@@ -184,7 +218,7 @@ describe("SidebarProjects", () => {
   it("loads ten more projects", () => {
     const loadMore = jest.fn();
     render(
-      <SidebarProjects
+      <SidebarProjectsHarness
         projects={projects}
         paginationStatus="CanLoadMore"
         loadMore={loadMore}
@@ -198,7 +232,7 @@ describe("SidebarProjects", () => {
   it("renders pinned projects without a nested Projects heading or pagination", () => {
     const loadMore = jest.fn();
     render(
-      <SidebarProjects
+      <SidebarProjectsHarness
         projects={projects}
         variant="pinned-list"
         paginationStatus="CanLoadMore"
@@ -221,7 +255,7 @@ describe("SidebarProjects", () => {
   });
 
   it("collapses the entire projects section from its heading", () => {
-    render(<SidebarProjects projects={projects} />);
+    render(<SidebarProjectsHarness projects={projects} />);
 
     expect(screen.getByTestId("projects-section-chevron")).toHaveClass(
       "rotate-90",
@@ -245,7 +279,7 @@ describe("SidebarProjects", () => {
   });
 
   it("moves a dropped chat and opens the target project", async () => {
-    render(<SidebarProjects projects={projects} />);
+    render(<SidebarProjectsHarness projects={projects} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Drop chat in Acme" }));
 

--- a/lib/utils/__tests__/client-storage.test.ts
+++ b/lib/utils/__tests__/client-storage.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "@jest/globals";
 import {
   getDraftAttachmentsById,
+  readOpenSidebarProjectIds,
   readSelectedModel,
   removeDraftAttachments,
   writeSelectedModel,
@@ -10,6 +11,8 @@ import {
   markHasAuthenticatedBefore,
   upsertDraft,
   upsertDraftAttachments,
+  writeOpenSidebarProjectIds,
+  SIDEBAR_OPEN_PROJECT_IDS_STORAGE_KEY,
 } from "../client-storage";
 
 const STORAGE_KEY = "selected_model";
@@ -155,6 +158,42 @@ describe("client-storage auth marker", () => {
   it("persists that this browser has authenticated before", () => {
     markHasAuthenticatedBefore();
     expect(hasAuthenticatedBefore()).toBe(true);
+  });
+});
+
+describe("client-storage sidebar open projects", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("stores only unique, non-empty project ids", () => {
+    writeOpenSidebarProjectIds(["project-1", "", "project-2", "project-1"]);
+
+    expect(readOpenSidebarProjectIds()).toEqual(["project-1", "project-2"]);
+  });
+
+  it("ignores malformed saved values", () => {
+    window.localStorage.setItem(
+      SIDEBAR_OPEN_PROJECT_IDS_STORAGE_KEY,
+      JSON.stringify(["project-1", null, 2, {}, "project-1"]),
+    );
+
+    expect(readOpenSidebarProjectIds()).toEqual(["project-1"]);
+
+    window.localStorage.setItem(
+      SIDEBAR_OPEN_PROJECT_IDS_STORAGE_KEY,
+      "not-json",
+    );
+    expect(readOpenSidebarProjectIds()).toEqual([]);
+  });
+
+  it("removes storage when every project is closed", () => {
+    writeOpenSidebarProjectIds(["project-1"]);
+    writeOpenSidebarProjectIds([]);
+
+    expect(
+      window.localStorage.getItem(SIDEBAR_OPEN_PROJECT_IDS_STORAGE_KEY),
+    ).toBeNull();
   });
 });
 

--- a/lib/utils/client-storage.ts
+++ b/lib/utils/client-storage.ts
@@ -33,12 +33,99 @@ export type ConversationDraftStore = {
 export const CONVERSATION_DRAFTS_STORAGE_KEY = "conversation_drafts";
 export const NULL_THREAD_DRAFT_ID = "null_thread";
 export const CHAT_MODE_STORAGE_KEY = "chat_mode";
+export const SIDEBAR_OPEN_PROJECT_IDS_STORAGE_KEY =
+  "hackerai:sidebar:open-projects:v1";
 const DRAFT_ATTACHMENT_RESTORE_TTL_MS = 24 * 60 * 60 * 1000;
 const HAS_AUTHENTICATED_BEFORE_STORAGE_KEY = "hackerai_has_authed_before";
 const SELECTED_MODEL_STORAGE_KEY = "selected_model";
 const AGENT_PERMISSION_MODE_STORAGE_KEY = "agent_permission_mode";
+const EMPTY_SIDEBAR_OPEN_PROJECT_IDS_SNAPSHOT = "[]";
+const openSidebarProjectIdsListeners = new Set<() => void>();
+let openSidebarProjectIdsMemorySnapshot =
+  EMPTY_SIDEBAR_OPEN_PROJECT_IDS_SNAPSHOT;
 
 const isBrowser = (): boolean => typeof window !== "undefined";
+
+export const parseOpenSidebarProjectIdsSnapshot = (raw: string): string[] => {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    return Array.from(
+      new Set(
+        parsed.filter(
+          (projectId): projectId is string =>
+            typeof projectId === "string" && projectId.length > 0,
+        ),
+      ),
+    );
+  } catch {
+    return [];
+  }
+};
+
+export const getOpenSidebarProjectIdsSnapshot = (): string => {
+  if (!isBrowser()) return EMPTY_SIDEBAR_OPEN_PROJECT_IDS_SNAPSHOT;
+  try {
+    return (
+      window.localStorage.getItem(SIDEBAR_OPEN_PROJECT_IDS_STORAGE_KEY) ??
+      EMPTY_SIDEBAR_OPEN_PROJECT_IDS_SNAPSHOT
+    );
+  } catch {
+    return openSidebarProjectIdsMemorySnapshot;
+  }
+};
+
+export const getServerOpenSidebarProjectIdsSnapshot = (): string =>
+  EMPTY_SIDEBAR_OPEN_PROJECT_IDS_SNAPSHOT;
+
+export const subscribeOpenSidebarProjectIds = (
+  onStoreChange: () => void,
+): (() => void) => {
+  if (!isBrowser()) return () => undefined;
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === SIDEBAR_OPEN_PROJECT_IDS_STORAGE_KEY) onStoreChange();
+  };
+
+  openSidebarProjectIdsListeners.add(onStoreChange);
+  window.addEventListener("storage", handleStorage);
+
+  return () => {
+    openSidebarProjectIdsListeners.delete(onStoreChange);
+    window.removeEventListener("storage", handleStorage);
+  };
+};
+
+export const readOpenSidebarProjectIds = (): string[] =>
+  parseOpenSidebarProjectIdsSnapshot(getOpenSidebarProjectIdsSnapshot());
+
+export const writeOpenSidebarProjectIds = (
+  projectIds: Iterable<string>,
+): void => {
+  if (!isBrowser()) return;
+  try {
+    const uniqueProjectIds = Array.from(
+      new Set(
+        Array.from(projectIds).filter((projectId) => projectId.length > 0),
+      ),
+    );
+    openSidebarProjectIdsMemorySnapshot = JSON.stringify(uniqueProjectIds);
+
+    if (uniqueProjectIds.length === 0) {
+      window.localStorage.removeItem(SIDEBAR_OPEN_PROJECT_IDS_STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(
+        SIDEBAR_OPEN_PROJECT_IDS_STORAGE_KEY,
+        openSidebarProjectIdsMemorySnapshot,
+      );
+    }
+  } catch {
+    // Browser storage can be disabled or unavailable.
+  }
+
+  openSidebarProjectIdsListeners.forEach((listener) => listener());
+};
 
 export const readDraftStore = (): ConversationDraftStore => {
   if (!isBrowser()) return { drafts: [] };


### PR DESCRIPTION
## Summary

- persist expanded project IDs in versioned browser storage
- share open-folder state across pinned and regular project lists
- keep folder toggles functional when browser storage is unavailable
- cover persistence, remount restoration, malformed storage, and collapse behavior

## Why

Expanded project IDs were held only in an in-memory `Set` inside `SidebarProjects`. Reloading the app created a new empty set, so every project folder closed regardless of the user's previous state.

## Validation

- commit hook: 314 test suites / 3,109 tests passed
- `corepack pnpm typecheck`
- targeted ESLint and Prettier checks
- 7 sidebar suites: 41 tests passed
- client storage suite: 24 tests passed
- Chrome: created a temporary development project, confirmed it remained visibly expanded after a full reload, then deleted the temporary project

## Manual verification

1. Open one or more project folders in the sidebar.
2. Reload the app.
3. Confirm each previously open folder is still expanded and closed folders remain closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar project expansion states now persist across page reloads and component remounts.
  * Project expansion stays synchronized across pinned and unpinned project sections.
  * Collapsing projects updates the saved sidebar state automatically.
  * Invalid or duplicate saved project entries are handled safely.

* **Bug Fixes**
  * Improved resilience when browser storage is unavailable or contains malformed data.

* **Tests**
  * Added coverage for persistence, synchronization, cleanup, and storage validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->