### PR TITLE
Recover transient attachment sandbox acquisition

### DIFF
--- a/lib/ai/tools/utils/__tests__/sandbox-health.test.ts
+++ b/lib/ai/tools/utils/__tests__/sandbox-health.test.ts
@@ -113,6 +113,7 @@ describe("sandbox health resource observations", () => {
     ],
     [new Error("fetch failed: ECONNRESET"), "connection_error"],
     [new Error("operation timed out"), "operation_timeout"],
+    [new Error("500: Failed to place sandbox"), "placement_failure"],
   ])(
     "classifies readiness failures without exposing raw errors",
     (error, expected) => {

--- a/lib/ai/tools/utils/sandbox-health.ts
+++ b/lib/ai/tools/utils/sandbox-health.ts
@@ -23,6 +23,7 @@ import {
   RateLimitError,
   TimeoutError,
 } from "./e2b-errors";
+import { classifySandboxReadinessFailureSignal } from "./sandbox-readiness-failure";
 
 const sandboxHealthLogger = createRetryLogger("sandbox-health");
 
@@ -168,33 +169,10 @@ export function classifySandboxReadinessFailureReason(
 ): SandboxReadinessFailureReason {
   if (!(error instanceof Error)) return "unknown";
 
-  const name = error.name.toLowerCase();
-  const message = error.message.toLowerCase();
-
-  // Check message-level OS failures before SDK classes. E2B can wrap a failed
-  // fork/exec in InvalidArgumentError even though the actionable cause is the
-  // sandbox process subsystem rather than caller input.
-  if (message.includes("permission denied")) return "permission_denied";
-  if (
-    name.includes("sandboxnotfound") ||
-    message.includes("not running anymore") ||
-    message.includes("sandbox not found") ||
-    message.includes("sandbox was not found")
-  ) {
-    return "sandbox_not_found";
-  }
-  if (message.includes("sandbox is not running")) return "sandbox_not_running";
-  if (
-    message.includes("econnreset") ||
-    message.includes("econnrefused") ||
-    message.includes("connection reset") ||
-    message.includes("connection refused") ||
-    message.includes("fetch failed") ||
-    message.includes("network connection") ||
-    message.includes("socket hang up")
-  ) {
-    return "connection_error";
-  }
+  // Check wrapped message/name signals before SDK classes. E2B can wrap a
+  // failed fork/exec in InvalidArgumentError even when caller input is valid.
+  const signal = classifySandboxReadinessFailureSignal(error);
+  if (signal) return signal;
 
   if (error instanceof AuthenticationError) return "authentication";
   if (error instanceof TemplateError) return "template";
@@ -205,9 +183,6 @@ export function classifySandboxReadinessFailureReason(
   if (error instanceof CommandExitError) return "command_exit";
   if (error instanceof InvalidArgumentError) return "invalid_argument";
 
-  if (name.includes("timeout") || message.includes("timed out")) {
-    return "operation_timeout";
-  }
   return "unknown";
 }
 

--- a/lib/ai/tools/utils/sandbox-readiness-failure.ts
+++ b/lib/ai/tools/utils/sandbox-readiness-failure.ts
@@ -1,0 +1,42 @@
+import type { SandboxReadinessFailureReason } from "@/types";
+
+/**
+ * Classify privacy-safe readiness signals that survive SDK error wrapping.
+ * Returns undefined when the error needs SDK-class-specific classification.
+ */
+export function classifySandboxReadinessFailureSignal(
+  error: unknown,
+): SandboxReadinessFailureReason | undefined {
+  if (!(error instanceof Error)) return undefined;
+
+  const name = error.name.toLowerCase();
+  const message = error.message.toLowerCase();
+
+  if (message.includes("permission denied")) return "permission_denied";
+  if (
+    name.includes("sandboxnotfound") ||
+    message.includes("not running anymore") ||
+    message.includes("sandbox not found") ||
+    message.includes("sandbox was not found")
+  ) {
+    return "sandbox_not_found";
+  }
+  if (message.includes("sandbox is not running")) return "sandbox_not_running";
+  if (message.includes("failed to place sandbox")) return "placement_failure";
+  if (
+    message.includes("econnreset") ||
+    message.includes("econnrefused") ||
+    message.includes("connection reset") ||
+    message.includes("connection refused") ||
+    message.includes("fetch failed") ||
+    message.includes("network connection") ||
+    message.includes("socket hang up")
+  ) {
+    return "connection_error";
+  }
+  if (name.includes("timeout") || message.includes("timed out")) {
+    return "operation_timeout";
+  }
+
+  return undefined;
+}

--- a/lib/api/__tests__/agent-long-contracts.test.ts
+++ b/lib/api/__tests__/agent-long-contracts.test.ts
@@ -1643,10 +1643,13 @@ describe("agent-long task — Trigger.dev dashboard error visibility", () => {
     expect(chatHandlerSrc).toMatch(
       /retryWithFreshSandboxOnTransientFailure:\s*true/,
     );
+    expect(taskSrc).toMatch(/service:\s*"agent-long"/);
+    expect(chatHandlerSrc).toMatch(/service:\s*"chat-handler"/);
     expect(taskSrc).toMatch(/"bad_request:sandbox"/);
     expect(chatHandlerSrc).toMatch(/"bad_request:sandbox"/);
     expect(taskSrc).toMatch(/"sandbox_upload_failure"/);
     expect(taskSrc).toMatch(/upload_failure_kind/);
+    expect(taskSrc).toMatch(/upload_failure_sandbox_readiness_reason/);
     expect(taskSrc).toMatch(/isSandboxUploadError/);
     expect(taskSrc).toMatch(/alreadyEmittedFromStream/);
   });

--- a/lib/api/chat-handler.ts
+++ b/lib/api/chat-handler.ts
@@ -733,7 +733,15 @@ export const createChatHandler = () => {
                 uploadResult = await uploadSandboxFiles(
                   sandboxFiles,
                   ensureSandbox,
-                  { retryWithFreshSandboxOnTransientFailure: true },
+                  {
+                    retryWithFreshSandboxOnTransientFailure: true,
+                    logContext: {
+                      service: "chat-handler",
+                      requestId: req.headers.get("x-vercel-id") ?? undefined,
+                      userId,
+                      chatId,
+                    },
+                  },
                 );
               } finally {
                 writeUploadCompleteStatus(writer);

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -523,6 +523,253 @@ describe("desktop-local sandbox file helpers", () => {
     }
   });
 
+  it.each([
+    [
+      "Sandbox operation timed out. The sandbox may be overloaded. Please try again.",
+      "operation_timeout",
+    ],
+    [
+      "Failed creating persistent sandbox: 500: Failed to place sandbox",
+      "placement_failure",
+    ],
+  ])(
+    "refreshes once after retryable sandbox acquisition failure %s",
+    async (errorMessage, failureReason) => {
+      const consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      const consoleInfoSpy = jest
+        .spyOn(console, "info")
+        .mockImplementation(() => {});
+      const downloadFromUrl = jest.fn().mockResolvedValue(undefined);
+      const ensureSandbox = jest
+        .fn()
+        .mockRejectedValueOnce(new Error(errorMessage))
+        .mockResolvedValueOnce({ files: { downloadFromUrl } });
+
+      try {
+        const result = await uploadSandboxFiles(
+          [
+            {
+              kind: "url",
+              url: "https://example.com/screenshot.png",
+              localPath: "/home/user/upload/screenshot.png",
+            },
+          ],
+          ensureSandbox,
+          {
+            retryWithFreshSandboxOnTransientFailure: true,
+            logContext: {
+              service: "agent-long",
+              requestId: "run-123",
+              userId: "user-123",
+              chatId: "chat-123",
+            },
+          },
+        );
+
+        expect(result).toEqual({
+          failedCount: 0,
+          pathRewrites: [],
+          retriedWithFreshSandbox: true,
+        });
+        expect(ensureSandbox).toHaveBeenCalledTimes(2);
+        expect(ensureSandbox.mock.calls[1][0]).toEqual({
+          refresh: true,
+          reason: "attachment_staging_sandbox_acquisition_failure",
+        });
+        expect(downloadFromUrl).toHaveBeenCalledTimes(1);
+
+        const scheduledLog = JSON.parse(
+          String(
+            consoleWarnSpy.mock.calls.find(([value]) =>
+              String(value).includes(
+                "sandbox_attachment_acquisition_retry_scheduled",
+              ),
+            )?.[0],
+          ),
+        );
+        expect(scheduledLog).toMatchObject({
+          level: "warn",
+          event: "sandbox_attachment_acquisition_retry_scheduled",
+          service: "agent-long",
+          request_id: "run-123",
+          user_id: "user-123",
+          chat_id: "chat-123",
+          initial_failure_reason: failureReason,
+          final_failure_reason: null,
+        });
+        expect(
+          consoleInfoSpy.mock.calls.some(([value]) =>
+            String(value).includes("sandbox_attachment_acquisition_recovered"),
+          ),
+        ).toBe(true);
+        expect(JSON.stringify(scheduledLog)).not.toContain(errorMessage);
+      } finally {
+        consoleWarnSpy.mockRestore();
+        consoleInfoSpy.mockRestore();
+      }
+    },
+  );
+
+  it("does not refresh non-retryable sandbox acquisition failures", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const ensureSandbox = jest
+      .fn()
+      .mockRejectedValue(new Error("Sandbox authentication failed"));
+
+    try {
+      const result = await uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "https://example.com/screenshot.png",
+            localPath: "/home/user/upload/screenshot.png",
+          },
+        ],
+        ensureSandbox,
+        { retryWithFreshSandboxOnTransientFailure: true },
+      );
+
+      expect(result.failedCount).toBe(1);
+      expect(result.retriedWithFreshSandbox).toBeUndefined();
+      expect(ensureSandbox).toHaveBeenCalledTimes(1);
+      expect(getSandboxUploadFailureMetadata(result)).toMatchObject({
+        upload_failure_sandbox_readiness_reason: "unknown",
+      });
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("keeps sandbox acquisition recovery opt-in for alternate callers", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const ensureSandbox = jest
+      .fn()
+      .mockRejectedValue(new Error("Sandbox operation timed out"));
+
+    try {
+      const result = await uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "https://example.com/screenshot.png",
+            localPath: "/home/user/upload/screenshot.png",
+          },
+        ],
+        ensureSandbox,
+      );
+
+      expect(result.failedCount).toBe(1);
+      expect(result.retriedWithFreshSandbox).toBeUndefined();
+      expect(ensureSandbox).toHaveBeenCalledTimes(1);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("records the bounded final reason when sandbox acquisition retry fails", async () => {
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const ensureSandbox = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("Sandbox operation timed out"))
+      .mockRejectedValueOnce(new Error("500: Failed to place sandbox"));
+
+    try {
+      const result = await uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "https://example.com/screenshot.png",
+            localPath: "/home/user/upload/screenshot.png",
+          },
+        ],
+        ensureSandbox,
+        { retryWithFreshSandboxOnTransientFailure: true },
+      );
+
+      expect(result.failedCount).toBe(1);
+      expect(ensureSandbox).toHaveBeenCalledTimes(2);
+      expect(getSandboxUploadFailureMetadata(result)).toMatchObject({
+        upload_failure_sandbox_readiness_reason: "placement_failure",
+        upload_retried_with_fresh_sandbox: true,
+      });
+      const retryFailedLog = JSON.parse(
+        String(
+          consoleErrorSpy.mock.calls.find(([value]) =>
+            String(value).includes(
+              "sandbox_attachment_acquisition_retry_failed",
+            ),
+          )?.[0],
+        ),
+      );
+      expect(retryFailedLog).toMatchObject({
+        initial_failure_reason: "operation_timeout",
+        final_failure_reason: "placement_failure",
+      });
+    } finally {
+      consoleWarnSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("uses one operation-wide refresh across acquisition and staging", async () => {
+    jest.useFakeTimers();
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const run = jest
+      .fn()
+      .mockRejectedValue(
+        new Error("2: [unknown] Request handshake timed out after 60000ms"),
+      );
+    const ensureSandbox = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("Sandbox operation timed out"))
+      .mockResolvedValue({ commands: { run } });
+
+    try {
+      const pendingResult = uploadSandboxFiles(
+        [
+          {
+            kind: "url",
+            url: "https://example.com/screenshot.png",
+            localPath: "/home/user/upload/screenshot.png",
+          },
+        ],
+        ensureSandbox,
+        { retryWithFreshSandboxOnTransientFailure: true },
+      );
+      await jest.advanceTimersByTimeAsync(5_000);
+      const result = await pendingResult;
+
+      expect(result.failedCount).toBe(1);
+      expect(result.retriedWithFreshSandbox).toBe(true);
+      expect(ensureSandbox).toHaveBeenCalledTimes(2);
+      expect(run).toHaveBeenCalledTimes(3);
+      expect(getSandboxUploadFailureMetadata(result)).toMatchObject({
+        upload_failure_transient_sandbox_command: true,
+        upload_retried_with_fresh_sandbox: true,
+      });
+    } finally {
+      jest.useRealTimers();
+      consoleWarnSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it("returns redacted metadata for transient upload command failures", async () => {
     jest.useFakeTimers();
     const consoleWarnSpy = jest
@@ -613,48 +860,54 @@ describe("desktop-local sandbox file helpers", () => {
     }
   });
 
-  it("does not refresh the sandbox for wrapped curl download timeouts", async () => {
-    const consoleErrorSpy = jest
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-    const run = jest.fn(async (command: string) => {
-      if (command.includes("df -h /home/user")) {
-        return {
-          exitCode: 0,
-          stdout: "Filesystem Size Used Avail Use% Mounted on\n",
-          stderr: "",
-        };
-      }
+  it.each([
+    [28, "curl: (28) ETIMEDOUT"],
+    [35, "curl: (35) SSL connect error: Connection reset by peer"],
+  ])(
+    "does not refresh the sandbox for wrapped curl exit %i",
+    async (exitCode, stderr) => {
+      const consoleErrorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const run = jest.fn(async (command: string) => {
+        if (command.includes("df -h /home/user")) {
+          return {
+            exitCode: 0,
+            stdout: "Filesystem Size Used Avail Use% Mounted on\n",
+            stderr: "",
+          };
+        }
 
-      return { exitCode: 28, stdout: "", stderr: "curl: (28) ETIMEDOUT" };
-    });
-    const ensureSandbox = jest.fn(async () => ({
-      commands: { run },
-    }));
-
-    try {
-      const result = await uploadSandboxFiles(
-        [
-          {
-            kind: "url",
-            url: "https://example.com/screenshot.png",
-            localPath: "/home/user/upload/screenshot.png",
-          },
-        ],
-        ensureSandbox,
-        { retryWithFreshSandboxOnTransientFailure: true },
-      );
-
-      expect(result.failedCount).toBe(1);
-      expect(ensureSandbox).toHaveBeenCalledTimes(1);
-      expect(getSandboxUploadFailureMetadata(result)).toMatchObject({
-        upload_failure_kind: "url",
-        upload_failure_transient_sandbox_command: false,
+        return { exitCode, stdout: "", stderr };
       });
-    } finally {
-      consoleErrorSpy.mockRestore();
-    }
-  });
+      const ensureSandbox = jest.fn(async () => ({
+        commands: { run },
+      }));
+
+      try {
+        const result = await uploadSandboxFiles(
+          [
+            {
+              kind: "url",
+              url: "https://example.com/screenshot.png",
+              localPath: "/home/user/upload/screenshot.png",
+            },
+          ],
+          ensureSandbox,
+          { retryWithFreshSandboxOnTransientFailure: true },
+        );
+
+        expect(result.failedCount).toBe(1);
+        expect(ensureSandbox).toHaveBeenCalledTimes(1);
+        expect(getSandboxUploadFailureMetadata(result)).toMatchObject({
+          upload_failure_kind: "url",
+          upload_failure_transient_sandbox_command: false,
+        });
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
+    },
+  );
 
   it("blocks internal URL downloads before invoking the sandbox", async () => {
     const consoleErrorSpy = jest

--- a/lib/utils/__tests__/sandbox-file-utils.test.ts
+++ b/lib/utils/__tests__/sandbox-file-utils.test.ts
@@ -902,6 +902,7 @@ describe("desktop-local sandbox file helpers", () => {
         expect(getSandboxUploadFailureMetadata(result)).toMatchObject({
           upload_failure_kind: "url",
           upload_failure_transient_sandbox_command: false,
+          upload_failure_sandbox_readiness_reason: "unknown",
         });
       } finally {
         consoleErrorSpy.mockRestore();

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -2,8 +2,9 @@ import "server-only";
 
 import { createHash, randomUUID } from "node:crypto";
 import { UIMessage } from "ai";
-import type { SandboxPreference } from "@/types";
+import type { SandboxPreference, SandboxReadinessFailureReason } from "@/types";
 import { validateDownloadUrl } from "@/lib/ai/tools/utils/path-validation";
+import { classifySandboxReadinessFailureSignal } from "@/lib/ai/tools/utils/sandbox-readiness-failure";
 
 export type SandboxFile = {
   localPath: string;
@@ -41,6 +42,7 @@ type SandboxUploadFailureDetail = {
   kind: SandboxFile["kind"];
   error: string;
   transientSandboxCommand: boolean;
+  sandboxReadinessReason: SandboxReadinessFailureReason;
   urlLength?: number;
   protocol?: string;
 };
@@ -54,6 +56,12 @@ type EnsureSandboxForUpload = (options?: SandboxRefreshOptions) => Promise<any>;
 
 type UploadSandboxFilesOptions = {
   retryWithFreshSandboxOnTransientFailure?: boolean | (() => boolean);
+  logContext?: {
+    service: "agent-long" | "chat-handler";
+    requestId?: string;
+    userId: string;
+    chatId: string;
+  };
 };
 
 type SandboxAttachmentTagKind = "attachment" | "inline-image";
@@ -113,6 +121,11 @@ const WRAPPED_FILE_TRANSFER_ERROR_PATTERN =
   /\bfailed to (?:download|copy) file:|curl:\s*\(|\bexitCode:\s*\d+\b/i;
 const SANDBOX_COMMAND_MAX_ATTEMPTS = 3;
 const SANDBOX_COMMAND_RETRY_BASE_DELAY_MS = 750;
+const RETRYABLE_SANDBOX_ACQUISITION_FAILURES =
+  new Set<SandboxReadinessFailureReason>([
+    "operation_timeout",
+    "placement_failure",
+  ]);
 
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
@@ -121,6 +134,44 @@ const isTransientSandboxCommandError = (error: unknown): boolean => {
   const message = errorMessage(error);
   if (WRAPPED_FILE_TRANSFER_ERROR_PATTERN.test(message)) return false;
   return TRANSIENT_SANDBOX_COMMAND_ERROR_PATTERN.test(message);
+};
+
+const classifySandboxUploadReadinessFailure = (
+  error: unknown,
+): SandboxReadinessFailureReason =>
+  classifySandboxReadinessFailureSignal(error) ?? "unknown";
+
+const logSandboxAcquisitionRecovery = (
+  options: UploadSandboxFilesOptions | undefined,
+  event:
+    | "sandbox_attachment_acquisition_retry_scheduled"
+    | "sandbox_attachment_acquisition_recovered"
+    | "sandbox_attachment_acquisition_retry_failed",
+  level: "info" | "warn" | "error",
+  initialFailureReason: SandboxReadinessFailureReason,
+  finalFailureReason?: SandboxReadinessFailureReason,
+): void => {
+  const payload = JSON.stringify({
+    timestamp: new Date().toISOString(),
+    level,
+    event,
+    service: options?.logContext?.service ?? "chat-handler",
+    environment:
+      process.env.TRIGGER_ENV ??
+      process.env.VERCEL_ENV ??
+      process.env.NODE_ENV ??
+      "unknown",
+    request_id:
+      options?.logContext?.requestId ?? process.env.VERCEL_REQUEST_ID ?? null,
+    user_id: options?.logContext?.userId ?? null,
+    chat_id: options?.logContext?.chatId ?? null,
+    initial_failure_reason: initialFailureReason,
+    final_failure_reason: finalFailureReason ?? null,
+  });
+
+  if (level === "error") console.error(payload);
+  else if (level === "warn") console.warn(payload);
+  else console.info(payload);
 };
 
 const delay = (ms: number): Promise<void> =>
@@ -684,6 +735,7 @@ const summarizeSandboxUploadFailure = (
     kind: file.kind,
     error: redactSandboxUploadError(file, error),
     transientSandboxCommand: isTransientSandboxCommandError(error),
+    sandboxReadinessReason: classifySandboxUploadReadinessFailure(error),
   };
 
   if (file.kind === "url") {
@@ -772,6 +824,12 @@ export const getSandboxUploadFailureMetadata = (
             failure.transientSandboxCommand,
         }
       : {}),
+    ...(failure?.sandboxReadinessReason
+      ? {
+          upload_failure_sandbox_readiness_reason:
+            failure.sandboxReadinessReason,
+        }
+      : {}),
     ...(failure?.protocol ? { upload_failure_protocol: failure.protocol } : {}),
     ...(typeof failure?.urlLength === "number"
       ? { upload_failure_url_length: failure.urlLength }
@@ -846,17 +904,63 @@ export const uploadSandboxFiles = async (
   });
 
   let sandbox: any;
+  let retriedWithFreshSandbox = false;
   try {
     sandbox = await ensureSandbox();
-  } catch (e) {
-    console.error("Failed to acquire sandbox for upload:", e);
-    return {
-      failedCount: sandboxFiles.length,
-      pathRewrites: [],
-      failureDetails: sandboxFiles.map((file) =>
-        summarizeSandboxUploadFailure(file, e),
-      ),
-    };
+  } catch (error) {
+    const initialFailureReason = classifySandboxUploadReadinessFailure(error);
+    const shouldRetryAcquisition =
+      RETRYABLE_SANDBOX_ACQUISITION_FAILURES.has(initialFailureReason) &&
+      shouldRetryWithFreshSandbox(options);
+
+    if (!shouldRetryAcquisition) {
+      console.error("Failed to acquire sandbox for upload:", error);
+      return {
+        failedCount: sandboxFiles.length,
+        pathRewrites: [],
+        failureDetails: sandboxFiles.map((file) =>
+          summarizeSandboxUploadFailure(file, error),
+        ),
+      };
+    }
+
+    retriedWithFreshSandbox = true;
+    logSandboxAcquisitionRecovery(
+      options,
+      "sandbox_attachment_acquisition_retry_scheduled",
+      "warn",
+      initialFailureReason,
+    );
+    try {
+      sandbox = await ensureSandbox({
+        refresh: true,
+        reason: "attachment_staging_sandbox_acquisition_failure",
+      });
+      logSandboxAcquisitionRecovery(
+        options,
+        "sandbox_attachment_acquisition_recovered",
+        "info",
+        initialFailureReason,
+      );
+    } catch (retryError) {
+      const finalFailureReason =
+        classifySandboxUploadReadinessFailure(retryError);
+      logSandboxAcquisitionRecovery(
+        options,
+        "sandbox_attachment_acquisition_retry_failed",
+        "error",
+        initialFailureReason,
+        finalFailureReason,
+      );
+      return {
+        failedCount: sandboxFiles.length,
+        pathRewrites: [],
+        failureDetails: sandboxFiles.map((file) =>
+          summarizeSandboxUploadFailure(file, retryError),
+        ),
+        retriedWithFreshSandbox: true,
+      };
+    }
   }
 
   const firstResult = await uploadSandboxFilesOnce(sandboxFiles, sandbox);
@@ -864,6 +968,7 @@ export const uploadSandboxFiles = async (
   if (
     firstResult.failedCount > 0 &&
     hasTransientSandboxCommandFailure(firstResult) &&
+    !retriedWithFreshSandbox &&
     shouldRetryWithFreshSandbox(options)
   ) {
     console.warn(
@@ -892,5 +997,7 @@ export const uploadSandboxFiles = async (
     }
   }
 
-  return firstResult;
+  return retriedWithFreshSandbox
+    ? { ...firstResult, retriedWithFreshSandbox: true }
+    : firstResult;
 };

--- a/lib/utils/sandbox-file-utils.ts
+++ b/lib/utils/sandbox-file-utils.ts
@@ -731,11 +731,16 @@ const summarizeSandboxUploadFailure = (
   file: SandboxFile,
   error: unknown,
 ): SandboxUploadFailureDetail => {
+  const message = error instanceof Error ? error.message : String(error);
+  const wrappedFileTransferFailure =
+    file.kind === "url" && message.includes("Failed to download file:");
   const summary: SandboxUploadFailureDetail = {
     kind: file.kind,
     error: redactSandboxUploadError(file, error),
     transientSandboxCommand: isTransientSandboxCommandError(error),
-    sandboxReadinessReason: classifySandboxUploadReadinessFailure(error),
+    sandboxReadinessReason: wrappedFileTransferFailure
+      ? "unknown"
+      : classifySandboxUploadReadinessFailure(error),
   };
 
   if (file.kind === "url") {

--- a/trigger/agent-long.ts
+++ b/trigger/agent-long.ts
@@ -984,6 +984,7 @@ type AgentLongErrorSummary = {
   uploadFailureKind?: string;
   uploadFailureCause?: string;
   uploadFailureTransientSandboxCommand?: boolean;
+  uploadFailureSandboxReadinessReason?: string;
   uploadFailureProtocol?: string;
   uploadFailureUrlLength?: number;
   uploadRetriedWithFreshSandbox?: boolean;
@@ -1175,6 +1176,10 @@ const classifyAgentLongError = (error: unknown): AgentLongErrorSummary => {
         errorMetadata,
         "upload_failure_transient_sandbox_command",
       ),
+      uploadFailureSandboxReadinessReason: getStringMetadata(
+        errorMetadata,
+        "upload_failure_sandbox_readiness_reason",
+      ),
       uploadFailureProtocol: getStringMetadata(
         errorMetadata,
         "upload_failure_protocol",
@@ -1343,6 +1348,12 @@ const recordAgentLongFailureForDashboard = async (
     metadata.set(
       "uploadFailureTransientSandboxCommand",
       summary.uploadFailureTransientSandboxCommand,
+    );
+  }
+  if (summary.uploadFailureSandboxReadinessReason) {
+    metadata.set(
+      "uploadFailureSandboxReadinessReason",
+      summary.uploadFailureSandboxReadinessReason,
     );
   }
   if (summary.uploadFailureProtocol)
@@ -2328,7 +2339,15 @@ export const agentLongTask = task({
                 uploadResult = await uploadSandboxFiles(
                   sandboxFiles,
                   ensureSandbox,
-                  { retryWithFreshSandboxOnTransientFailure: true },
+                  {
+                    retryWithFreshSandboxOnTransientFailure: true,
+                    logContext: {
+                      service: "agent-long",
+                      requestId: ctx.run.id,
+                      userId,
+                      chatId,
+                    },
+                  },
                 );
               } finally {
                 writeUploadCompleteStatus(writer);

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -73,6 +73,7 @@ export type SandboxReadinessFailureReason =
   | "command_exit"
   | "operation_timeout"
   | "connection_error"
+  | "placement_failure"
   | "unknown";
 
 export type SandboxReadinessStage = "initial" | "reconnect";


### PR DESCRIPTION
## Summary
- retry attachment sandbox acquisition once for the observed E2B timeout and placement-failure classes
- share the bounded readiness taxonomy with sandbox health checks
- emit correlated structured recovery events and preserve the bounded reason in Trigger failure metadata
- enforce one fresh-sandbox retry across the entire attachment operation

## Production evidence
Frozen audit window: `2026-07-30T20:02:18.694Z`–`2026-07-31T20:02:18.694Z`.

Trigger.dev recorded 16 `The computer attachment upload failed.` runs across 5 users / 9 chats. Thirteen occurred on the current worker after the code from #1004 deployed. Representative traces showed E2B resume/create timeouts and `500: Failed to place sandbox`, but attachment acquisition returned `bad_request:sandbox` without using the existing fresh-sandbox recovery option.

The same group also contained S3 curl/TLS failures. Those remain visible and do not trigger a sandbox refresh because they are transfer/provider failures, not sandbox-acquisition failures.

## Root cause
`uploadSandboxFiles` applied the opt-in fresh-sandbox retry only after a sandbox had been acquired and a command-channel failure occurred. Errors thrown by the initial `ensureSandbox()` call were immediately converted into failed uploads, so the durable Agent path never reached recovery.

## Change
- recognize the observed wrapped E2B placement failure as `placement_failure`
- reconnect/retry once for `operation_timeout` or `placement_failure`
- keep the retry operation-wide, so a later staging failure cannot cause a second sandbox refresh
- preserve existing retry exhaustion, partial-result, path-rewrite, local-desktop opt-in, and user error behavior
- log only bounded reasons plus opaque request/user/chat identifiers; no target, prompt, path, filename, URL, or attachment content

## Validation
- 6 focused suites / 133 tests passed
- `corepack pnpm typecheck`
- changed-file ESLint and Prettier checks
- commit hook: 313 suites / 3,101 tests passed
- adversarial review covered both opted-in callers, the local-desktop alternate path, operation-wide retry exhaustion, mixed acquisition/staging failures, curl 28/35 behavior, deploy skew, and structured-log privacy

Jest emitted its existing worker teardown warning after the full suite; all tests and the hook completed successfully.

## Manual verification
1. In the Trigger preview, start an Agent run with a URL-backed attachment while forcing the first E2B acquisition to time out or fail placement.
2. Confirm exactly one reconnect occurs, attachment staging succeeds, and the Agent run continues.
3. Force the reconnect to fail and confirm the existing attachment error remains user-visible with bounded initial/final recovery reasons.
4. Force curl exit 35 and confirm it remains a visible transfer failure without a fresh-sandbox reconnect.

Visual QA is not applicable to this backend recovery and telemetry change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox file upload recovery for placement, timeout, connection, permission, and availability failures.
  * Uploads can retry with a refreshed sandbox when recovery is enabled.
  * Failure details now include clearer readiness reasons and retry outcomes.
* **Reliability**
  * Preserved request and session context across retries.
  * Improved handling of wrapped file-transfer errors to avoid unnecessary sandbox refreshes.
  * Added coverage for bounded retries and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->