### PR TITLE
Restore free desktop Agent selector

### DIFF
--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -694,8 +694,14 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   // desktop sessions may be unscoped, so refresh once to pull WorkOS
   // entitlements from the user's organization before showing them as free.
   useEffect(() => {
+    let cancelled = false;
+    let requestSettled = false;
+    let controller: AbortController | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     const refreshDesktopEntitlements = async () => {
       if (!user || typeof window === "undefined" || !isTauriEnvironment()) {
+        setIsCheckingProPlan(false);
         return;
       }
 
@@ -703,6 +709,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
         ? entitlements
         : [];
       if (resolveSubscriptionTier(currentEntitlements) !== "free") {
+        setIsCheckingProPlan(false);
         return;
       }
 
@@ -717,9 +724,9 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
       desktopEntitlementRefreshUserRef.current = user.id;
 
       setIsCheckingProPlan(true);
-      const controller = new AbortController();
-      const timeoutId = setTimeout(
-        () => controller.abort(),
+      controller = new AbortController();
+      timeoutId = setTimeout(
+        () => controller?.abort(),
         DESKTOP_ENTITLEMENT_REFRESH_TIMEOUT_MS,
       );
       try {
@@ -730,6 +737,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
         if (!response.ok) return;
 
         const data = await response.json();
+        if (cancelled) return;
         setSubscriptionWithNormalize(
           resolveSubscriptionTier(
             Array.isArray(data.entitlements) ? data.entitlements : [],
@@ -742,12 +750,26 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
       } catch {
         // Keep the token-derived tier; this is only a best-effort desktop heal.
       } finally {
-        clearTimeout(timeoutId);
-        setIsCheckingProPlan(false);
+        requestSettled = true;
+        if (timeoutId !== null) clearTimeout(timeoutId);
+        if (!cancelled) setIsCheckingProPlan(false);
       }
     };
 
     refreshDesktopEntitlements();
+
+    return () => {
+      cancelled = true;
+      if (
+        controller !== null &&
+        !requestSettled &&
+        desktopEntitlementRefreshUserRef.current === user?.id
+      ) {
+        desktopEntitlementRefreshUserRef.current = null;
+      }
+      controller?.abort();
+      if (timeoutId !== null) clearTimeout(timeoutId);
+    };
   }, [
     user,
     entitlements,

--- a/app/contexts/GlobalState.tsx
+++ b/app/contexts/GlobalState.tsx
@@ -60,6 +60,8 @@ import {
   normalizeAgentFirstSandboxType,
 } from "@/lib/activation/agent-first-default";
 
+const DESKTOP_ENTITLEMENT_REFRESH_TIMEOUT_MS = 5_000;
+
 interface GlobalStateType {
   // Input state
   input: string;
@@ -715,22 +717,32 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
       desktopEntitlementRefreshUserRef.current = user.id;
 
       setIsCheckingProPlan(true);
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        DESKTOP_ENTITLEMENT_REFRESH_TIMEOUT_MS,
+      );
       try {
         const response = await fetch("/api/entitlements", {
           credentials: "include",
+          signal: controller.signal,
         });
         if (!response.ok) return;
 
         const data = await response.json();
-        await refreshAuthTokenAfterEntitlementRefresh();
         setSubscriptionWithNormalize(
           resolveSubscriptionTier(
             Array.isArray(data.entitlements) ? data.entitlements : [],
           ),
         );
+        // The API response is authoritative for the UI. Refresh AuthKit and the
+        // shared access token in the background so a slow token refresh cannot
+        // keep the free Ask/Agent selector hidden.
+        void refreshAuthTokenAfterEntitlementRefresh();
       } catch {
         // Keep the token-derived tier; this is only a best-effort desktop heal.
       } finally {
+        clearTimeout(timeoutId);
         setIsCheckingProPlan(false);
       }
     };

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -195,6 +195,49 @@ describe("GlobalStateProvider agent defaults", () => {
     expect(screen.getByTestId("checking-pro-plan")).toHaveTextContent("false");
   });
 
+  it("aborts a stale desktop entitlement refresh when the account changes", async () => {
+    window.__TAURI_INTERNALS__ = {};
+    let requestSignal: AbortSignal | undefined;
+    global.fetch = jest.fn((input, init) => {
+      if (String(input) === "/api/entitlements") {
+        requestSignal = init?.signal ?? undefined;
+        return new Promise((_, reject) => {
+          requestSignal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        });
+      }
+
+      return Promise.resolve({ ok: false });
+    }) as unknown as typeof fetch;
+
+    const { rerender } = render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(requestSignal).toBeDefined();
+    });
+
+    mockAuthUser(["pro-plan"], { user: { id: "user_paid" } });
+    rerender(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    expect(requestSignal?.aborted).toBe(true);
+    await waitFor(() => {
+      expect(screen.getByTestId("subscription")).toHaveTextContent("pro");
+      expect(screen.getByTestId("checking-pro-plan")).toHaveTextContent(
+        "false",
+      );
+      expect(screen.getByTestId("paid-agent-only")).toHaveTextContent("true");
+    });
+  });
+
   it("keeps chat mode access unresolved while authentication is loading", () => {
     mockAuthUser([], { loading: true });
 

--- a/app/contexts/__tests__/GlobalState.agent-default.test.tsx
+++ b/app/contexts/__tests__/GlobalState.agent-default.test.tsx
@@ -2,8 +2,25 @@ import "@testing-library/jest-dom";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { useAccessToken, useAuth } from "@workos-inc/authkit-nextjs/components";
-import { GlobalStateProvider, useGlobalState } from "../GlobalState";
 import { SHARED_TOKEN_KEY } from "@/lib/auth/shared-token";
+
+jest.mock("@/app/hooks/useSandboxPreference", () => {
+  const setSandboxPreference = jest.fn();
+  const retryDesktopBridge = jest.fn();
+
+  return {
+    useSandboxPreference: () => ({
+      sandboxPreference: "e2b",
+      setSandboxPreference,
+      desktopBridgeActive: false,
+      desktopBridgeStatus: "idle",
+      retryDesktopBridge,
+    }),
+  };
+});
+
+const { GlobalStateProvider, useGlobalState } =
+  jest.requireActual<typeof import("../GlobalState")>("../GlobalState");
 
 const mockAuthUser = (
   entitlements: string[],
@@ -59,6 +76,8 @@ function ActiveProjectProbe() {
 describe("GlobalStateProvider agent defaults", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useRealTimers();
+    delete window.__TAURI_INTERNALS__;
     window.history.pushState({}, "", "/");
     window.localStorage.clear();
     jest.mocked(useAccessToken).mockReturnValue({
@@ -70,6 +89,110 @@ describe("GlobalStateProvider agent defaults", () => {
       Promise.resolve({ ok: false }),
     ) as unknown as typeof fetch;
     mockAuthUser([]);
+  });
+
+  it("reveals free desktop mode access before token refresh finishes", async () => {
+    window.__TAURI_INTERNALS__ = {};
+    const refreshAuth = jest.fn(() => new Promise<void>(() => {}));
+    mockAuthUser([], { refreshAuth });
+    global.fetch = jest.fn((input) => {
+      if (String(input) === "/api/entitlements") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ entitlements: [] }),
+        });
+      }
+
+      return Promise.resolve({ ok: false });
+    }) as unknown as typeof fetch;
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(refreshAuth).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("chat-mode-access-resolved")).toHaveTextContent(
+        "true",
+      );
+      expect(screen.getByTestId("checking-pro-plan")).toHaveTextContent(
+        "false",
+      );
+    });
+    expect(screen.getByTestId("subscription")).toHaveTextContent("free");
+    expect(screen.getByTestId("paid-agent-only")).toHaveTextContent("false");
+  });
+
+  it("resolves paid desktop users to Agent-only before token refresh finishes", async () => {
+    window.__TAURI_INTERNALS__ = {};
+    const refreshAuth = jest.fn(() => new Promise<void>(() => {}));
+    mockAuthUser([], { refreshAuth });
+    global.fetch = jest.fn((input) => {
+      if (String(input) === "/api/entitlements") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ entitlements: ["pro-plan"] }),
+        });
+      }
+
+      return Promise.resolve({ ok: false });
+    }) as unknown as typeof fetch;
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(refreshAuth).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("subscription")).toHaveTextContent("pro");
+      expect(screen.getByTestId("chat-mode-access-resolved")).toHaveTextContent(
+        "true",
+      );
+      expect(screen.getByTestId("paid-agent-only")).toHaveTextContent("true");
+      expect(screen.getByTestId("chat-mode")).toHaveTextContent("agent");
+    });
+  });
+
+  it("releases free desktop mode access when entitlement refresh times out", async () => {
+    jest.useFakeTimers();
+    window.__TAURI_INTERNALS__ = {};
+    let requestAborted = false;
+    global.fetch = jest.fn((input, init) => {
+      if (String(input) === "/api/entitlements") {
+        return new Promise((_, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            requestAborted = true;
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        });
+      }
+
+      return Promise.resolve({ ok: false });
+    }) as unknown as typeof fetch;
+
+    render(
+      <GlobalStateProvider>
+        <GlobalStateProbe />
+      </GlobalStateProvider>,
+    );
+
+    expect(screen.getByTestId("chat-mode-access-resolved")).toHaveTextContent(
+      "false",
+    );
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(requestAborted).toBe(true);
+    expect(screen.getByTestId("chat-mode-access-resolved")).toHaveTextContent(
+      "true",
+    );
+    expect(screen.getByTestId("checking-pro-plan")).toHaveTextContent("false");
   });
 
   it("keeps chat mode access unresolved while authentication is loading", () => {


### PR DESCRIPTION
## Summary

- bound the automatic desktop entitlement refresh to five seconds
- apply the authoritative entitlement response before refreshing AuthKit and the shared token in the background
- abort and ignore stale entitlement requests when the component unmounts or the active account changes
- add regression coverage for free desktop users, paid Agent-only users, timeout fallback, and account switching

## Root cause

PR #990 correctly prevented the Ask/Agent selector from flashing for paid users while access resolved, but the desktop healing path kept isCheckingProPlan active until both the entitlement request and sequential token refreshes finished. Those token refreshes had no UI timeout, so free desktop users could remain in Ask mode with no mode selector.

## Impact

Free desktop users regain the Ask/Agent selector as soon as the entitlement endpoint confirms their tier, or after a five-second fallback if that request stalls. Paid users still resolve directly to Agent-only mode without an Ask selector flash. Cleanup prevents an old account response from overwriting a newly active account.

## Validation

- Focused GlobalState suite: 10 tests passed
- Pre-commit full suite: 313 suites / 3,105 tests passed
- corepack pnpm typecheck
- corepack pnpm lint — passes with 5 existing unrelated warnings
- targeted Prettier check
- GitHub Tests, Vercel, Trigger.dev, and CodeRabbit all pass

## Manual verification

1. Open HackerAI Desktop with a free account whose token has no paid entitlement. Confirm the Ask/Agent selector appears after entitlement resolution and Agent can be selected.
2. Delay AuthKit/access-token refresh after /api/entitlements returns. Confirm the free selector remains available.
3. Delay /api/entitlements beyond five seconds. Confirm the selector returns using the token-derived free state.
4. Open an older or unscoped paid desktop session. Confirm it resolves directly to Agent mode without showing the Ask/Agent selector.
5. Switch accounts while entitlement refresh is pending. Confirm the previous request is cancelled and cannot overwrite the new account tier.