### PR TITLE
Clarify local Agent connection requirements

### DIFF
--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -452,7 +452,7 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
       "Do not use host.docker.internal as a shortcut to the user's host from the cloud sandbox",
     );
     expect(prompt).toContain(
-      "use the HackerAI Desktop App, Remote Connection, or a user-provided reachable tunnel URL",
+      "use the HackerAI Desktop App, Remote Control, or a user-provided reachable tunnel URL",
     );
     expect(prompt).toContain(
       "Do not invent host aliases or imply the cloud sandbox can directly reach private/internal assets",
@@ -490,7 +490,7 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).toContain("<current_mode>");
     expect(prompt).toContain("You are in ASK MODE with limited tools.");
     expect(prompt).toContain(
-      "AGENT MODE runs commands in the selected execution environment. Cloud Agent cannot access the user's computer; local execution requires an explicitly connected Desktop App or Remote Connection.",
+      "AGENT MODE runs commands in the selected execution environment. Cloud Agent cannot access the user's computer; local execution requires an explicitly connected Desktop App or Remote Control.",
     );
     expect(prompt).not.toContain("switch to AGENT MODE for full access");
   });
@@ -508,19 +508,43 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).toContain("<current_mode>");
     expect(prompt).toContain("You are in ASK MODE with limited tools.");
     expect(prompt).toContain(
-      "AGENT MODE requires a connected local machine on the free plan, or Pro for isolated cloud Agent access. Switching modes alone does not connect the user's computer.",
+      "AGENT MODE requires a connected local machine on the free plan, or a paid plan for isolated cloud Agent access. Switching modes alone does not connect the user's computer.",
     );
     expect(prompt).not.toContain("switch to AGENT MODE for full access");
   });
 
   it.each([
-    ["free Ask", "ask", "free", null],
-    ["paid Ask", "ask", "pro", null],
-    ["cloud Agent", "agent", "pro", null],
-    ["local Agent", "agent", "pro", "Local sandbox context"],
+    [
+      "free Ask",
+      "ask",
+      "free",
+      null,
+      "requires a connected local machine on the free plan, or a paid plan for isolated cloud Agent access",
+    ],
+    [
+      "paid Ask",
+      "ask",
+      "pro",
+      null,
+      "Cloud Agent cannot access the user's computer; local execution requires an explicitly connected Desktop App or Remote Control.",
+    ],
+    [
+      "cloud Agent",
+      "agent",
+      "pro",
+      null,
+      "For the default cloud sandbox, commands run in an isolated container",
+    ],
+    [
+      "local Agent",
+      "agent",
+      "pro",
+      "Local sandbox context",
+      "Local sandbox context",
+    ],
   ] as const)(
     "adds local-machine connection guidance once for %s",
-    async (_label, mode, subscription, sandboxContext) => {
+    async (_label, mode, subscription, sandboxContext, expectedVariant) => {
       const prompt = await systemPrompt(
         "user_123",
         mode,
@@ -537,12 +561,13 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
         "Switching to Agent Mode or upgrading does not automatically connect HackerAI to the user's computer.",
       );
       expect(prompt).toContain(
-        "connect it through the HackerAI Desktop App or a Remote Connection",
+        "connect it through the HackerAI Desktop App or Remote Control",
       );
       expect(prompt).toContain(
         "Local Agent access is available on every plan, including Free.",
       );
       expect(prompt.split(setupUrl)).toHaveLength(2);
+      expect(prompt).toContain(expectedVariant);
     },
   );
 

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -537,10 +537,10 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
         "Switching to Agent Mode or upgrading does not automatically connect HackerAI to the user's computer.",
       );
       expect(prompt).toContain(
-        "Local-machine Agent access is available on every plan, including Free.",
+        "connect it through the HackerAI Desktop App or a Remote Connection",
       );
       expect(prompt).toContain(
-        "Do not promise that switching modes alone is sufficient",
+        "Local Agent access is available on every plan, including Free.",
       );
       expect(prompt.split(setupUrl)).toHaveLength(2);
     },

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -490,8 +490,9 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).toContain("<current_mode>");
     expect(prompt).toContain("You are in ASK MODE with limited tools.");
     expect(prompt).toContain(
-      "inform them to switch to AGENT MODE for full access including file operations, terminal commands, and code execution.",
+      "AGENT MODE runs commands in the selected execution environment. Cloud Agent cannot access the user's computer; local execution requires an explicitly connected Desktop App or Remote Connection.",
     );
+    expect(prompt).not.toContain("switch to AGENT MODE for full access");
   });
 
   it("adds free ask-mode local sandbox guidance", async () => {
@@ -507,12 +508,43 @@ Commands run directly on the host OS "workstation" without Docker isolation. Be 
     expect(prompt).toContain("<current_mode>");
     expect(prompt).toContain("You are in ASK MODE with limited tools.");
     expect(prompt).toContain(
-      "AGENT MODE requires a connected local sandbox on the free plan, or Pro for cloud Agent access.",
+      "AGENT MODE requires a connected local machine on the free plan, or Pro for isolated cloud Agent access. Switching modes alone does not connect the user's computer.",
     );
-    expect(prompt).not.toContain(
-      "inform them to switch to AGENT MODE for full access",
-    );
+    expect(prompt).not.toContain("switch to AGENT MODE for full access");
   });
+
+  it.each([
+    ["free Ask", "ask", "free", null],
+    ["paid Ask", "ask", "pro", null],
+    ["cloud Agent", "agent", "pro", null],
+    ["local Agent", "agent", "pro", "Local sandbox context"],
+  ] as const)(
+    "adds local-machine connection guidance once for %s",
+    async (_label, mode, subscription, sandboxContext) => {
+      const prompt = await systemPrompt(
+        "user_123",
+        mode,
+        subscription,
+        mode === "ask" ? "ask-model" : "agent-model",
+        null,
+        sandboxContext,
+      );
+      const setupUrl =
+        "https://help.hackerai.co/en/articles/12961920-connecting-a-hackerai-agent-to-your-local-machine";
+
+      expect(prompt).toContain("<local_machine_access>");
+      expect(prompt).toContain(
+        "Switching to Agent Mode or upgrading does not automatically connect HackerAI to the user's computer.",
+      );
+      expect(prompt).toContain(
+        "Local-machine Agent access is available on every plan, including Free.",
+      );
+      expect(prompt).toContain(
+        "Do not promise that switching modes alone is sufficient",
+      );
+      expect(prompt.split(setupUrl)).toHaveLength(2);
+    },
+  );
 
   it("adds agent-mode current-mode guidance", async () => {
     const prompt = await systemPrompt(

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -201,12 +201,9 @@ before coming back to the user.\n"
 
 const LOCAL_MACHINE_ACCESS_SECTION = `<local_machine_access>
 Switching to Agent Mode or upgrading does not automatically connect HackerAI to the user's computer.
-
-To run commands or access files on the user's computer, the user must first connect that computer through the HackerAI Desktop App or a Remote Connection, then select the connected machine as the execution environment. Local-machine Agent access is available on every plan, including Free. Paid plans additionally provide cloud Agent access, which runs in an isolated cloud sandbox and cannot access the user's computer.
-
-When a user asks whether HackerAI can work on their computer, explain these connection requirements before recommending a paid plan. Do not promise that switching modes alone is sufficient or that the user will never need to interact with local permission prompts or setup steps.
-
-Direct them to https://help.hackerai.co/en/articles/12961920-connecting-a-hackerai-agent-to-your-local-machine for setup instructions.
+To run commands or access files there, connect it through the HackerAI Desktop App or a Remote Connection, then select it as the execution environment.
+Local Agent access is available on every plan, including Free. Paid plans also provide isolated cloud Agent access, which cannot access the user's computer.
+Setup instructions: https://help.hackerai.co/en/articles/12961920-connecting-a-hackerai-agent-to-your-local-machine
 </local_machine_access>`;
 
 const getDefaultSandboxEnvironmentSection = (): string => `<sandbox_environment>

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -201,7 +201,7 @@ before coming back to the user.\n"
 
 const LOCAL_MACHINE_ACCESS_SECTION = `<local_machine_access>
 Switching to Agent Mode or upgrading does not automatically connect HackerAI to the user's computer.
-To run commands or access files there, connect it through the HackerAI Desktop App or a Remote Connection, then select it as the execution environment.
+To run commands or access files there, connect it through the HackerAI Desktop App or Remote Control, then select it as the execution environment.
 Local Agent access is available on every plan, including Free. Paid plans also provide isolated cloud Agent access, which cannot access the user's computer.
 Setup instructions: https://help.hackerai.co/en/articles/12961920-connecting-a-hackerai-agent-to-your-local-machine
 </local_machine_access>`;
@@ -212,7 +212,7 @@ IMPORTANT: All tools operate in an isolated sandbox environment that is individu
 Local/internal target access:
 - In the cloud sandbox, localhost and 127.0.0.1 refer to the sandbox/container, not the user's laptop, private LAN, or local development server.
 - Do not use host.docker.internal as a shortcut to the user's host from the cloud sandbox; it may not resolve, and it is not a supported path to the user's machine.
-- For local or internal targets, use the HackerAI Desktop App, Remote Connection, or a user-provided reachable tunnel URL.
+- For local or internal targets, use the HackerAI Desktop App, Remote Control, or a user-provided reachable tunnel URL.
 - Do not invent host aliases or imply the cloud sandbox can directly reach private/internal assets unless the user has provided a reachable route.
 
 System Environment:
@@ -418,8 +418,8 @@ const getAskModeSection = (
   const notesCapability = notesEnabled ? " and manage notes" : "";
   const agentModeCTA =
     subscription === "free"
-      ? "If the user needs these capabilities, explain that AGENT MODE requires a connected local machine on the free plan, or Pro for isolated cloud Agent access. Switching modes alone does not connect the user's computer."
-      : "If the user needs these capabilities, explain that AGENT MODE runs commands in the selected execution environment. Cloud Agent cannot access the user's computer; local execution requires an explicitly connected Desktop App or Remote Connection.";
+      ? "If the user needs these capabilities, explain that AGENT MODE requires a connected local machine on the free plan, or a paid plan for isolated cloud Agent access. Switching modes alone does not connect the user's computer."
+      : "If the user needs these capabilities, explain that AGENT MODE runs commands in the selected execution environment. Cloud Agent cannot access the user's computer; local execution requires an explicitly connected Desktop App or Remote Control.";
   const modeReminder = `<current_mode>
 You are in ASK MODE with limited tools. You can search the web${notesCapability}, but cannot read files, \
 edit code, run terminal commands, or execute code. ${agentModeCTA}

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -199,13 +199,18 @@ before coming back to the user.\n"
     : "";
 };
 
+const LOCAL_MACHINE_ACCESS_SECTION = `<local_machine_access>
+Switching to Agent Mode or upgrading does not automatically connect HackerAI to the user's computer.
+
+To run commands or access files on the user's computer, the user must first connect that computer through the HackerAI Desktop App or a Remote Connection, then select the connected machine as the execution environment. Local-machine Agent access is available on every plan, including Free. Paid plans additionally provide cloud Agent access, which runs in an isolated cloud sandbox and cannot access the user's computer.
+
+When a user asks whether HackerAI can work on their computer, explain these connection requirements before recommending a paid plan. Do not promise that switching modes alone is sufficient or that the user will never need to interact with local permission prompts or setup steps.
+
+Direct them to https://help.hackerai.co/en/articles/12961920-connecting-a-hackerai-agent-to-your-local-machine for setup instructions.
+</local_machine_access>`;
+
 const getDefaultSandboxEnvironmentSection = (): string => `<sandbox_environment>
 IMPORTANT: All tools operate in an isolated sandbox environment that is individual to each user. You CANNOT access the user's actual machine, local filesystem, or local system. Tools can ONLY interact with the sandbox environment described below.
-
-If the user wants to connect HackerAI to their local machine, they have two options:
-1. Install the HackerAI Desktop App — allows running agent commands directly on their device
-2. Set up a Remote Connection — connects the agent to their machine for internal pentesting
-Direct them to: https://help.hackerai.co/en/articles/12961920-connecting-a-hackerai-agent-to-your-local-machine for setup instructions.
 
 Local/internal target access:
 - In the cloud sandbox, localhost and 127.0.0.1 refer to the sandbox/container, not the user's laptop, private LAN, or local development server.
@@ -378,9 +383,10 @@ Agent tool approval mode: Full access. Tool calls can run without per-action app
 </agent_tool_approval>`;
 
 const getProductQuestionsSection = (): string =>
-  `If the person asks HackerAI about how many messages they can send, costs of HackerAI, \
-how to perform actions within the application, or other product questions related to HackerAI, \
-HackerAI should tell them it doesn't know, and point them to 'https://help.hackerai.co'.`;
+  `For local-machine access questions, follow the requirements in <local_machine_access>. \
+For all other product questions, including how many messages they can send, HackerAI costs, \
+or how to perform actions within the application, HackerAI should say that it doesn't know \
+and point them to 'https://help.hackerai.co'.`;
 
 const getDeepSeekToolUsageInstructions = (): string => `<web_tool_usage>
 CRITICAL: The web_search and open_url tools are EXPENSIVE. Invoke them only when answering the user's current question genuinely requires information you do not already have. Default to answering from your own knowledge.
@@ -415,8 +421,8 @@ const getAskModeSection = (
   const notesCapability = notesEnabled ? " and manage notes" : "";
   const agentModeCTA =
     subscription === "free"
-      ? "If the user needs these capabilities, explain that AGENT MODE requires a connected local sandbox on the free plan, or Pro for cloud Agent access."
-      : "If the user needs these capabilities, inform them to switch to AGENT MODE for full access including file operations, terminal commands, and code execution.";
+      ? "If the user needs these capabilities, explain that AGENT MODE requires a connected local machine on the free plan, or Pro for isolated cloud Agent access. Switching modes alone does not connect the user's computer."
+      : "If the user needs these capabilities, explain that AGENT MODE runs commands in the selected execution environment. Cloud Agent cannot access the user's computer; local execution requires an explicitly connected Desktop App or Remote Connection.";
   const modeReminder = `<current_mode>
 You are in ASK MODE with limited tools. You can search the web${notesCapability}, but cannot read files, \
 edit code, run terminal commands, or execute code. ${agentModeCTA}
@@ -460,6 +466,7 @@ The current date is ${currentDateTime}.`;
     basePrompt,
     LANGUAGE_SECTION,
     GENERAL_RESPONSE_SECTION,
+    LOCAL_MACHINE_ACCESS_SECTION,
     RESPONSE_STYLE_SECTION,
     MISTAKE_RECOVERY_SECTION,
     getFreshnessAndWebSearchSection(modelName),


### PR DESCRIPTION
## Summary

- share canonical local-machine setup guidance across Ask and Agent prompts
- clarify that switching modes or upgrading does not connect a user’s computer
- distinguish free local Agent access from isolated paid cloud Agent access
- direct local-access questions to the existing setup article
- cover Free Ask, paid Ask, cloud Agent, and local Agent prompt variants

## Root cause

The detailed Desktop App and Remote Control requirements previously lived only in the default Agent sandbox section. Ask mode relied on compressed upgrade guidance, including an ambiguous paid-tier promise of full access, so it could describe real Agent capabilities without surfacing the local connection prerequisite.

## Validation

- pnpm test -- --runInBand lib/__tests__/system-prompt.test.ts (27 tests)
- pnpm typecheck
- pnpm lint (0 errors; 5 existing warnings outside this change)
- pre-commit full Jest suite (313 suites, 3,105 tests)
- Prettier check and git diff --check

## Manual verification

In a live Ask conversation, ask whether switching to Agent Mode lets HackerAI run everything on a Windows PC without user setup.

Expected:

- it explains that Desktop App or Remote Control setup and machine selection are required
- it states local Agent access is available on Free
- it distinguishes the isolated cloud Agent environment
- it links the local-machine setup article
- it does not claim that switching modes alone connects the computer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer guidance for connecting to a local machine through the Desktop App or Remote Control.
  * Clarified plan availability, setup requirements, execution context, and setup documentation for local-machine access.
  * Updated Ask Mode messaging to explain Agent Mode access limitations and upgrade options.

* **Bug Fixes**
  * Improved consistency of local-connection guidance across Ask and Agent configurations.
  * Prevented duplicate or misleading setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->